### PR TITLE
Disable automatic fix commits from pre-commit.ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+ci:
+  autofix_prs: false
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0


### PR DESCRIPTION
## Summary

- Disable automatic fix commits by pre-commit.ci on pull requests
- Adds `ci: autofix_prs: false` configuration to `.pre-commit-config.yaml`

## Problem

Currently, pre-commit.ci automatically creates fix commits on PRs when pre-commit hooks detect issues that can be auto-fixed (like formatting issues). This creates extra commits that clutter the git history and can interfere with the development workflow.

## Solution

Added a CI configuration section to `.pre-commit-config.yaml` that disables automatic fixes:

```yaml
ci:
  autofix_prs: false
```

## Behavior After This Change

- Pre-commit.ci will still run checks on PRs and report issues
- It will NOT automatically commit fixes
- Developers can still trigger fixes manually by commenting "pre-commit.ci autofix" on a PR if needed
- Local pre-commit hooks will continue to work as before

## Test Plan

- Merge this PR
- Create a test PR with pre-commit violations
- Verify that pre-commit.ci reports issues but doesn't create fix commits