### PR TITLE
Deactivate GitHub deployments when PR is closed

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -164,8 +164,36 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
     permissions:
       packages: write
+      deployments: write
 
     steps:
+      - name: Deactivate GitHub Deployment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const environment = `pr${prNumber}`;
+
+            // List all deployments for this environment
+            const { data: deployments } = await github.rest.repos.listDeployments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              environment: environment,
+            });
+
+            // Mark each deployment as inactive
+            for (const deployment of deployments) {
+              await github.rest.repos.createDeploymentStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                deployment_id: deployment.id,
+                state: 'inactive',
+                description: 'PR closed, deployment deactivated',
+              });
+              console.log(`Deactivated deployment ${deployment.id}`);
+            }
+
+            console.log(`Deactivated ${deployments.length} deployments for ${environment}`);
       - name: Delete RIG Deployment
         run: |
           PR_NUM="${{ github.event.pull_request.number }}"


### PR DESCRIPTION
## Summary

- Add step to mark GitHub deployments as inactive when a PR is closed
- This removes stale deployment entries from the PR UI after the deployment is deleted

## Changes

When a PR is closed, the `cleanup-preview` job now:
1. **Deactivates GitHub deployments** - Marks all deployments in the `prN` environment as inactive
2. Deletes the RIG deployment (existing behavior)
3. Deletes the container image (existing behavior)

This addresses the issue where closed PRs still showed stale deployment entries (like `pr73`, `pr-73`) in the GitHub UI.

## Test Plan

- [ ] Close a PR with a preview deployment
- [ ] Verify deployment entries are marked as inactive in the PR UI