### PR TITLE
Also delete GitHub environment when PR is closed

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -200,6 +200,14 @@ jobs:
             }
 
             console.log(`Deleted ${deployments.length} deployments for ${environment}`);
+
+            // Delete the environment itself
+            await github.rest.repos.deleteAnEnvironment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              environment_name: environment,
+            });
+            console.log(`Deleted environment ${environment}`);
       - name: Delete RIG Deployment
         run: |
           PR_NUM="${{ github.event.pull_request.number }}"


### PR DESCRIPTION
## Summary

- Delete the GitHub environment (e.g., `pr75`) when a PR is closed
- Prevents accumulation of stale `prN` environments in repo settings

## Changes

After deleting all deployments for the environment, now also deletes the environment itself.