### PR TITLE
Use ADMIN_TOKEN for GitHub environment deletion

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -201,13 +201,21 @@ jobs:
 
             console.log(`Deleted ${deployments.length} deployments for ${environment}`);
 
-            // Delete the environment itself
+      - name: Delete GitHub Environment
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.ADMIN_TOKEN }}
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const environment = `pr${prNumber}`;
+
             await github.rest.repos.deleteAnEnvironment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               environment_name: environment,
             });
             console.log(`Deleted environment ${environment}`);
+
       - name: Delete RIG Deployment
         run: |
           PR_NUM="${{ github.event.pull_request.number }}"


### PR DESCRIPTION
## Summary

- Split environment deletion into separate step using `ADMIN_TOKEN`
- Fixes 403 error: environment deletion requires admin permissions not available to `GITHUB_TOKEN`

## Changes

The cleanup now has two steps:
1. **Delete GitHub Deployment** - uses default `GITHUB_TOKEN`
2. **Delete GitHub Environment** - uses `ADMIN_TOKEN` (classic PAT with `repo` scope)