### PR TITLE
chore: use built-in PR commenting from zad-actions v1.1.0

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -84,50 +84,9 @@ jobs:
           image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}
           clone-from: regelrecht
           force-clone: false
-
-      - name: Comment on PR
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const prNumber = context.payload.pull_request.number;
-            const deploymentUrl = '${{ steps.deploy.outputs.url }}';
-            const body = `## Preview Deployment
-
-            Your changes have been deployed to a preview environment:
-
-            **URL:** ${deploymentUrl}
-
-            This deployment will be automatically deleted when the PR is closed.`;
-
-            // Check if there's already a comment from this workflow
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-            });
-
-            const botComment = comments.find(comment =>
-              comment.user.type === 'Bot' &&
-              comment.body.includes('Preview Deployment')
-            );
-
-            if (botComment) {
-              // Update existing comment
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: botComment.id,
-                body: body,
-              });
-            } else {
-              // Create new comment
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: prNumber,
-                body: body,
-              });
-            }
+          comment-on-pr: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          comment-header: '## Preview Deployment'
 
   deploy-production:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Replace separate `actions/github-script` step with the built-in `comment-on-pr` feature from [zad-actions v1.1.0](https://github.com/RijksICTGilde/zad-actions/releases/tag/v1.1.0).

## Changes

**Before** (44 lines):
```yaml
- name: Deploy to ZAD (Preview)
  uses: RijksICTGilde/zad-actions/deploy@v1
  with:
    # deploy inputs...

- name: Comment on PR
  uses: actions/github-script@v7
  with:
    script: |
      // 30+ lines of JavaScript...
```

**After** (3 additional lines):
```yaml
- name: Deploy to ZAD (Preview)
  uses: RijksICTGilde/zad-actions/deploy@v1
  with:
    # deploy inputs...
    comment-on-pr: true
    github-token: ${{ secrets.GITHUB_TOKEN }}
    comment-header: '## Preview Deployment'
```

## Benefits

- Simpler workflow: Removes 44 lines of code
- Less duplication: PR commenting logic is now in the shared action
- Same functionality: Upsert behavior, custom header, same comment format

## Test plan

- [ ] Create a test PR to verify commenting works
- [ ] Verify existing comment is updated (not duplicated) on push