### PR TITLE
chore: use cleanup PR comment update from zad-actions v1.2.0

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -118,6 +118,7 @@ jobs:
     permissions:
       packages: write
       deployments: write
+      pull-requests: write
 
     steps:
       - name: Cleanup ZAD Deployment
@@ -134,3 +135,5 @@ jobs:
           container-tag: pr-${{ github.event.pull_request.number }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           github-admin-token: ${{ secrets.ADMIN_TOKEN }}
+          update-pr-comment: true
+          comment-header: '## Preview Deployment'


### PR DESCRIPTION
## Summary

Update the cleanup step to use the new `update-pr-comment` feature from [zad-actions v1.2.0](https://github.com/RijksICTGilde/zad-actions/releases/tag/v1.2.0).

## What this does

When a PR is closed, the cleanup action will now update the deploy comment to show the deployment was removed:

**Before (on deploy):**
> ## Preview Deployment
>
> Your changes have been deployed to a preview environment:
>
> **URL:** https://editor-pr123-regel-k4c.rig...
>
> This deployment will be automatically cleaned up when the PR is closed.

**After (on cleanup):**
> ## 🧹 Preview Deployment (Cleaned Up)
>
> ~~https://editor-pr123-regel-k4c.rig...~~
>
> This deployment was automatically cleaned up when the PR was closed.

## Changes

- Add `pull-requests: write` permission to cleanup-preview job
- Add `update-pr-comment: true` to cleanup step
- Add `comment-header: '## Preview Deployment'` to match deploy step

## Test plan

- [ ] Create a test PR to verify the full lifecycle:
  1. Open PR → deploy comment appears
  2. Push to PR → comment is updated (not duplicated)
  3. Close PR → comment shows "Cleaned Up" status