### PR TITLE
fix: update schema $id URLs from poc-machine-law to regelrecht-mvp

### DIFF
--- a/schema/v0.2.0/schema.json
+++ b/schema/v0.2.0/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.2.0/schema.json",
+  "$id": "https://raw.githubusercontent.com/MinBZK/regelrecht-mvp/refs/heads/main/schema/v0.2.0/schema.json",
   "title": "Machine-Readable Dutch Law Schema v0.2.0",
   "description": "Article-based schema for machine-readable representation of Dutch laws and regulations",
   "type": "object",

--- a/schema/v0.3.0/schema.json
+++ b/schema/v0.3.0/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/MinBZK/poc-machine-law/refs/heads/main/schema/v0.3.0/schema.json",
+  "$id": "https://raw.githubusercontent.com/MinBZK/regelrecht-mvp/refs/heads/main/schema/v0.3.0/schema.json",
   "title": "Machine-Readable Dutch Law Schema v0.3.0",
   "description": "Article-based schema for machine-readable representation of Dutch laws and regulations",
   "type": "object",


### PR DESCRIPTION
## Summary

- Update `$id` URLs in `schema/v0.2.0/schema.json` and `schema/v0.3.0/schema.json` from `poc-machine-law` to `regelrecht-mvp` to reflect the repository rename.

## Note

This will fail the "Protect schema versions" CI check since it modifies released schema versions. This is intentional — the `$id` URLs need to match the current repository name. Force merge required.

Once merged, the `feature/rust-harvester` branch (PR #104) will no longer trigger the schema protection failure.