### PR TITLE
feat(engine): cross-law resolution memoization cache

### DIFF
--- a/packages/engine/src/trace.rs
+++ b/packages/engine/src/trace.rs
@@ -165,6 +165,7 @@ impl PathNode {
             PathNodeType::UriCall => "uri_call",
             PathNodeType::Article => "article",
             PathNodeType::Delegation => "delegation",
+            PathNodeType::Cached => "cached",
         };
 
         // Build the main line
@@ -424,6 +425,15 @@ impl PathNode {
                     child.render_box_node(lines, &child_prefix);
                 }
             }
+
+            PathNodeType::Cached => {
+                let result_str = self
+                    .result
+                    .as_ref()
+                    .map(|v| format!(": {}", format_value_display(v)))
+                    .unwrap_or_default();
+                lines.push(format!("{}├──CACHED: {}{}", prefix, self.name, result_str));
+            }
         }
     }
 
@@ -437,6 +447,7 @@ impl PathNode {
             PathNodeType::UriCall => "uri",
             PathNodeType::Article => "art",
             PathNodeType::Delegation => "del",
+            PathNodeType::Cached => "cache",
         };
 
         let result_str = self

--- a/packages/engine/src/types.rs
+++ b/packages/engine/src/types.rs
@@ -353,6 +353,8 @@ pub enum PathNodeType {
     Article,
     /// Delegation to another regulation
     Delegation,
+    /// Cached cross-law result (memoized)
+    Cached,
 }
 
 /// Resolve type for variable resolution

--- a/packages/engine/tests/expected_zorgtoeslag_trace.txt
+++ b/packages/engine/tests/expected_zorgtoeslag_trace.txt
@@ -144,15 +144,7 @@ zorgtoeslagwet (2025-01-01 {bsn: 999993653} hoogte_zorgtoeslag)
 ║   ├──URI call: algemene_wet_inkomensafhankelijke_regelingen#heeft_toeslagpartner
 ║   ║   ├──Resolving $BSN
 ║   ║   │   ├──Resolving from PARAMETERS: '999993653'
-║   ║   ├──Resolving $PARTNERSCHAP_TYPE
-║   ║   │   ├──Resolving from DATA_SOURCE: 'GEEN'
-║   ║   ├──Computing heeft_toeslagpartner
-║   ║   │   ├──Compute IN(...) = False
-║   ║   │   │   ├──Resolving $PARTNERSCHAP_TYPE
-║   ║   │   │   │   ├──Resolving from PARAMETERS: 'GEEN'
-║   ║   │   │   ├──Resolving $GELDIGE_PARTNERTYPEN
-║   ║   │   │   │   ├──Resolving from DEFINITION: ['HUWELIJK', 'GEREGISTREERD_PARTNERSCHAP']
-║   ║   ├──Result of heeft_toeslagpartner: False
+║   ║   ├──CACHED: algemene_wet_inkomensafhankelijke_regelingen#heeft_toeslagpartner: False
 ║   ├──Computing vermogen_onder_grens
 ║   │   ├──Compute LESSTHANOREQUAL(...) = True
 ║   │   │   ├──Resolving $VERMOGEN


### PR DESCRIPTION
## Summary

- Add per-execution memoization cache to `ResolutionContext` that stores `(law_id, output_name, parameters) → outputs` for cross-law calls
- Repeated calls with identical inputs (e.g., AWIR's `heeft_toeslagpartner` called from both Art. 2 and Art. 3 of zorgtoeslagwet) return instantly from cache
- Cache lives at `evaluate_law_output_internal` — the single choke-point for all cross-law calls
- Add `Cached` variant to `PathNodeType` for trace visibility in all render modes

Stacked on #123 ← #107

## Test plan

- [x] 303 unit tests pass
- [x] 4 trace integration tests pass (snapshot updated for CACHED output)
- [x] 17 BDD scenarios pass
- [x] Zorgtoeslag result value (209691.78888) unchanged