### PR TITLE
fix: skip preview deploy for dependabot PRs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,7 +65,10 @@ jobs:
   deploy-preview:
     runs-on: ubuntu-latest
     needs: build
-    if: github.event_name == 'pull_request' && github.event.action != 'closed'
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.action != 'closed' &&
+      github.actor != 'dependabot[bot]'
     permissions:
       pull-requests: write
     environment:
@@ -114,7 +117,10 @@ jobs:
 
   cleanup-preview:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.action == 'closed' &&
+      github.actor != 'dependabot[bot]'
     permissions:
       packages: write
       deployments: write


### PR DESCRIPTION
## Summary

- Skip `deploy-preview` and `cleanup-preview` jobs when the PR author is `dependabot[bot]`

## Problem

All 11 open Dependabot PRs (#134, #135, #136, #137, #139, #140, #141, #142, #143, #144, #145) fail on the `deploy-preview` check with:

```
Deployment failed: Authentication failed (HTTP 401)
Please verify your ZAD_API_KEY secret is correct and not expired
```

**Root cause:** GitHub Actions [does not expose repository secrets](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#responding-to-events) to workflows triggered by Dependabot PRs. This is a security measure to prevent untrusted code from exfiltrating secrets. Since `RIG_API_KEY` is unavailable, the ZAD deploy call returns HTTP 401.

## Fix

Add `github.actor != 'dependabot[bot]'` to the `if` conditions of both:
- **`deploy-preview`** — Dependabot PRs are dependency bumps; preview deployments are not useful
- **`cleanup-preview`** — no preview was created, so nothing to clean up

The `build` job is left unchanged — it still runs for Dependabot PRs to verify the Docker image builds successfully, which is a valid CI check for dependency bumps.

## Test plan

- [ ] Verify this PR's own CI passes (deploy-preview should still run since the author is not dependabot)
- [ ] After merge, re-run CI on an existing Dependabot PR to confirm deploy-preview is skipped