### PR TITLE
feat: add scheduled cleanup for stale PR environments

### DIFF
--- a/.github/workflows/scheduled-cleanup.yml
+++ b/.github/workflows/scheduled-cleanup.yml
@@ -21,7 +21,7 @@ jobs:
       contents: read
       deployments: write
       packages: write
-      environments: write
+      actions: write
 
     steps:
       - name: Cleanup stale PR preview environments


### PR DESCRIPTION
## Summary

- Add nightly scheduled workflow (`scheduled-cleanup.yml`) using `RijksICTGilde/zad-actions/scheduled-cleanup@v2` to automatically find and remove ZAD deployments for closed/merged PRs
- Bump `docker/build-push-action` v5 → v6 for db-migrate build
- Bump `RijksICTGilde/zad-actions/deploy` v1 → v2 for db-migrate deploy

## Details

The scheduled cleanup runs daily at 3:00 UTC and also supports manual trigger via `workflow_dispatch` (with dry-run option). It:
- Scans GitHub environments matching `^pr[0-9]+$`
- Checks if the corresponding PR is still open
- Cleans up stale environments: ZAD deployment, GitHub environment, GitHub deployments, and container images

## Test plan

- [ ] Verify workflow syntax is valid (CI will check)
- [ ] Trigger manually via `workflow_dispatch` after merge to verify it runs correctly
- [ ] Run with `dry-run: true` first to see what it would clean up