### PR TITLE
chore: ignore non-LTS Node versions in Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,6 +37,14 @@ updates:
     labels:
       - dependencies
       - docker
+    ignore:
+      - dependency-name: node
+        versions:
+          - "23"
+          - "25"
+          - "27"
+          - "29"
+          - "31"
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
## Summary

- Ignore odd (non-LTS) Node versions (23, 25, 27, 29, 31) in the Docker Dependabot config
- Even/LTS versions (24, 26, 28, 30) will still be proposed
- Closed #134 (Node 25 bump) since Node 25 is not LTS and its deploy-preview was failing