### PR TITLE
fix: use single quotes in dependabot.yml for yamllint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,11 +40,11 @@ updates:
     ignore:
       - dependency-name: node
         versions:
-          - "23"
-          - "25"
-          - "27"
-          - "29"
-          - "31"
+          - '23'
+          - '25'
+          - '27'
+          - '29'
+          - '31'
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
## Summary

- Fix yamllint `quoted-strings` violation in dependabot.yml introduced by #156
- Changes double quotes to single quotes on the Node version ignore list