### PR TITLE
chore: ignore non-LTS Node versions in admin Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -84,6 +84,14 @@ updates:
     labels:
       - dependencies
       - docker
+    ignore:
+      - dependency-name: node
+        versions:
+          - '23'
+          - '25'
+          - '27'
+          - '29'
+          - '31'
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
Adds ignore rules for odd (non-LTS) Node.js versions (23, 25, 27, 29, 31) to the /packages/admin Docker ecosystem in dependabot.yml.

This matches the existing configuration for /frontend and ensures Dependabot only proposes LTS Node.js versions (24, 26, 28, 30).

Context: PR #166 proposed upgrading from Node 22 LTS to Node 25 (non-LTS), which is not desirable for production use.