### PR TITLE
fix: use macos-latest for x86_64 cross-compilation in release workflow

### DIFF
--- a/.github/workflows/release-engine.yml
+++ b/.github/workflows/release-engine.yml
@@ -26,7 +26,7 @@ jobs:
             asset: evaluate-linux-amd64
 
           - target: x86_64-apple-darwin
-            os: macos-13
+            os: macos-latest
             binary: evaluate
             asset: evaluate-macos-amd64
 


### PR DESCRIPTION
## Summary

- `macos-13` runners have been retired by GitHub, causing the `engine-v0.1.0` release to fail
- Switch to `macos-latest` (ARM) which cross-compiles to `x86_64-apple-darwin` via the `--target` flag (already set in the workflow)

## Test plan
- [ ] Merge, delete the failed `engine-v0.1.0` release/tag, re-tag and push