### PR TITLE
ci: enable PR comments for admin preview deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -147,7 +147,7 @@ jobs:
 
       - name: Deploy admin to ZAD (Preview)
         if: needs.build-admin.result == 'success'
-        uses: RijksICTGilde/zad-actions/deploy@v2
+        uses: RijksICTGilde/zad-actions/deploy@v2.4.0
         with:
           api-key: ${{ secrets.RIG_API_KEY }}
           project-id: ${{ env.ZAD_PROJECT }}
@@ -162,7 +162,7 @@ jobs:
 
       - name: Deploy editor to ZAD (Preview)
         id: deploy
-        uses: RijksICTGilde/zad-actions/deploy@v2
+        uses: RijksICTGilde/zad-actions/deploy@v2.4.0
         with:
           api-key: ${{ secrets.RIG_API_KEY }}
           project-id: ${{ env.ZAD_PROJECT }}
@@ -194,7 +194,7 @@ jobs:
 
       - name: Deploy admin to ZAD (Production)
         if: needs.build-admin.result == 'success'
-        uses: RijksICTGilde/zad-actions/deploy@v2
+        uses: RijksICTGilde/zad-actions/deploy@v2.4.0
         with:
           api-key: ${{ secrets.RIG_API_KEY }}
           project-id: ${{ env.ZAD_PROJECT }}
@@ -204,7 +204,7 @@ jobs:
 
       - name: Deploy editor to ZAD (Production)
         id: deploy
-        uses: RijksICTGilde/zad-actions/deploy@v2
+        uses: RijksICTGilde/zad-actions/deploy@v2.4.0
         with:
           api-key: ${{ secrets.RIG_API_KEY }}
           project-id: ${{ env.ZAD_PROJECT }}
@@ -222,7 +222,7 @@ jobs:
 
     steps:
       - name: Cleanup ZAD Deployment
-        uses: RijksICTGilde/zad-actions/cleanup@v2
+        uses: RijksICTGilde/zad-actions/cleanup@v2.4.0
         with:
           api-key: ${{ secrets.RIG_API_KEY }}
           project-id: ${{ env.ZAD_PROJECT }}
@@ -239,7 +239,7 @@ jobs:
           comment-header: '## Preview Deployment'
 
       - name: Cleanup admin container image
-        uses: RijksICTGilde/zad-actions/cleanup@v2
+        uses: RijksICTGilde/zad-actions/cleanup@v2.4.0
         with:
           api-key: ${{ secrets.RIG_API_KEY }}
           project-id: ${{ env.ZAD_PROJECT }}

--- a/.github/workflows/scheduled-cleanup.yml
+++ b/.github/workflows/scheduled-cleanup.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Cleanup stale PR preview environments
-        uses: RijksICTGilde/zad-actions/scheduled-cleanup@v2
+        uses: RijksICTGilde/zad-actions/scheduled-cleanup@v2.4.0
         with:
           api-key: ${{ secrets.RIG_API_KEY }}
           project-id: ${{ env.ZAD_PROJECT }}


### PR DESCRIPTION
## Summary

- Enable `comment-on-pr` for the admin component in PR preview deployments
- zad-actions v2.4.0 now supports multi-component PR comments — each component gets its own comment identified by `{header} — {component}`
- Previously this wasn't possible because both components would overwrite each other's single comment, so only the editor had commenting enabled