### PR TITLE
ci: fix dependabot config for root cargo workspace

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,10 +2,10 @@
 version: 2
 updates:
   - package-ecosystem: cargo
-    directory: /packages
+    directory: /
     schedule:
       interval: weekly
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
     labels:
       - dependencies
       - rust
@@ -20,7 +20,7 @@ updates:
     directory: /frontend
     schedule:
       interval: weekly
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
     labels:
       - dependencies
       - javascript
@@ -34,7 +34,7 @@ updates:
     directory: /frontend
     schedule:
       interval: weekly
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
     labels:
       - dependencies
       - docker
@@ -52,7 +52,7 @@ updates:
     directory: /packages/admin
     schedule:
       interval: weekly
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
     labels:
       - dependencies
       - rust
@@ -66,7 +66,7 @@ updates:
     directory: /packages/admin/frontend-src
     schedule:
       interval: weekly
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
     labels:
       - dependencies
       - javascript
@@ -80,7 +80,7 @@ updates:
     directory: /packages/admin
     schedule:
       interval: weekly
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
     labels:
       - dependencies
       - docker
@@ -97,7 +97,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
     labels:
       - dependencies
       - github-actions


### PR DESCRIPTION
## Summary
- Change cargo ecosystem directory from `/packages` to `/` so Dependabot monitors the root `Cargo.lock` (which covers engine, harvester, pipeline, corpus). This was the reason 6 of the 10 open security alerts had no Dependabot coverage.
- Raise `open-pull-requests-limit` from 5 to 10 on all entries to reduce the chance of security updates being blocked by the PR limit.

## Context
GitHub reports 10 high vulnerabilities on the default branch. The root cause was that Dependabot was configured for `/packages` but the root workspace (`/Cargo.toml`) has its own `Cargo.lock` that wasn't being monitored.

## Test plan
- [ ] Verify Dependabot creates PRs for `aws-lc-sys` and `tokio-tar` vulnerabilities after merge
- [ ] Verify existing Dependabot updates for `/packages/admin` still work