### PR TITLE
fix(ci): grant write permissions to Claude review workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,8 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:


### PR DESCRIPTION
## Summary

- `claude-code-review.yml`: `pull-requests: read` → `write` — allows posting review comments on PRs
- `claude.yml`: `pull-requests: read` → `write`, `issues: read` → `write` — allows responding to @claude mentions

The `claude-dependabot.yml` already had write permissions. This explains why PR #209's review ran for 11 minutes ($4.30) but produced no visible output — 27 permission denials trying to post comments.

## Test plan

- [ ] Merge this PR, then re-trigger Claude review on #209 to verify comments appear