### PR TITLE
fix(ci): clean up old Claude review comments before each review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -28,6 +28,39 @@ jobs:
           use_sticky_comment: true
           claude_args: "--allowedTools Bash,Read,Glob,Grep"
           prompt: |
+            ## Step 0: Clean up previous reviews
+
+            BEFORE doing anything else, clean up your own previous review comments and
+            reviews on this PR so they don't pile up. Run these commands:
+
+            ```bash
+            # Dismiss all previous claude[bot] reviews (changes CHANGES_REQUESTED to comments)
+            gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews" \
+              --paginate --jq '.[] | select(.user.login == "claude[bot]" and (.state == "CHANGES_REQUESTED" or .state == "COMMENTED")) | .id' \
+            | while read -r review_id; do
+                gh api -X PUT "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews/${review_id}/dismissals" \
+                  -f message="Superseded by new review" -f event="DISMISS" 2>/dev/null || true
+              done
+
+            # Delete all previous claude[bot] inline review comments
+            gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments" \
+              --paginate --jq '.[] | select(.user.login == "claude[bot]") | .id' \
+            | while read -r comment_id; do
+                gh api -X DELETE "repos/${{ github.repository }}/pulls/comments/${comment_id}" 2>/dev/null || true
+              done
+
+            # Delete all previous claude[bot] issue comments (except sticky which is managed automatically)
+            gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+              --paginate --jq '.[] | select(.user.login == "claude[bot]") | .id' \
+            | while read -r comment_id; do
+                gh api -X DELETE "repos/${{ github.repository }}/issues/comments/${comment_id}" 2>/dev/null || true
+              done
+            ```
+
+            After cleanup, proceed with the review below.
+
+            ---
+
             Review PR #${{ github.event.pull_request.number }} in ${{ github.repository }}.
 
             ## Project context


### PR DESCRIPTION
## Summary

- Adds a cleanup step to the Claude Code Review prompt that removes old reviews and comments before starting a new review
- On every `synchronize` (push), Claude was creating new inline comments and PR reviews that piled up — `use_sticky_comment` only works for issue comments, not for PR reviews or inline review comments
- The cleanup runs as `claude[bot]` (via the OAuth token), so it has permission to dismiss/delete its own previous reviews and comments

## How it works

Before reviewing, Claude now:
1. **Dismisses** all its previous `CHANGES_REQUESTED` and `COMMENTED` reviews
2. **Deletes** all its previous inline review comments
3. **Deletes** all its previous issue comments (the sticky comment is managed separately by `use_sticky_comment`)

## Test plan

- [ ] Push a commit to a PR and verify that old Claude reviews/comments are cleaned up before the new review appears
- [ ] Verify the new review still creates inline comments and a sticky summary as expected
- [ ] Verify that non-Claude comments (human reviews, deploy previews) are not affected