### PR TITLE
fix(grafana): harden config and CI based on review feedback

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,7 @@ env:
   IMAGE_NAME: minbzk/regelrecht-mvp
   IMAGE_NAME_ADMIN: minbzk/regelrecht-admin
   IMAGE_NAME_HARVESTER_WORKER: minbzk/regelrecht-harvester-worker
+  IMAGE_NAME_GRAFANA: minbzk/regelrecht-grafana
   ZAD_PROJECT: regel-k4c
   ZAD_COMPONENT: editor
 
@@ -26,6 +27,7 @@ jobs:
     outputs:
       admin: ${{ steps.filter.outputs.admin }}
       harvester-worker: ${{ steps.filter.outputs.harvester-worker }}
+      grafana: ${{ steps.filter.outputs.grafana }}
       backend: ${{ steps.backend.outputs.result }}
     steps:
       - uses: actions/checkout@v6
@@ -42,6 +44,8 @@ jobs:
               - 'packages/pipeline/**'
               - 'packages/harvester/**'
               - 'packages/corpus/**'
+            grafana:
+              - 'packages/grafana/**'
 
       - name: Determine backend changes
         id: backend
@@ -193,6 +197,50 @@ jobs:
           cache-from: type=gha,scope=harvester-worker
           cache-to: type=gha,mode=max,scope=harvester-worker
 
+  build-grafana:
+    runs-on: ubuntu-latest
+    needs: changes
+    if: >-
+      github.ref == 'refs/heads/main' && github.event_name == 'push' &&
+      needs.changes.outputs.grafana == 'true'
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_GRAFANA }}
+          tags: |
+            type=ref,event=pr,prefix=pr-
+            type=sha,prefix=sha-,format=short
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./packages/grafana
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=grafana
+          cache-to: type=gha,mode=max,scope=grafana
+
   deploy-preview:
     runs-on: ubuntu-latest
     needs: [build, build-admin, build-harvester-worker, changes]
@@ -254,16 +302,16 @@ jobs:
           force-clone: false
           comment-on-pr: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          comment-header: '## Preview Deployment'
+          comment-header: '## Preview Deployment — editor'
 
   deploy-production:
     runs-on: ubuntu-latest
-    needs: [build, build-admin, build-harvester-worker]
+    needs: [build, build-admin, build-harvester-worker, build-grafana]
     if: >-
       always() &&
       github.ref == 'refs/heads/main' && github.event_name == 'push' &&
       !cancelled() &&
-      (needs.build.result == 'success' || needs.build-admin.result == 'success' || needs.build-harvester-worker.result == 'success')
+      needs.build.result == 'success'
     permissions: {}
     environment:
       name: production
@@ -304,6 +352,16 @@ jobs:
           deployment-name: regelrecht
           component: harvester-worker
           image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_HARVESTER_WORKER }}:sha-${{ steps.sha.outputs.short }}
+
+      - name: Deploy grafana to ZAD (Production)
+        if: needs.build-grafana.result == 'success'
+        uses: RijksICTGilde/zad-actions/deploy@v2.4.0
+        with:
+          api-key: ${{ secrets.RIG_API_KEY }}
+          project-id: ${{ env.ZAD_PROJECT }}
+          deployment-name: regelrecht
+          component: grafana
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_GRAFANA }}:sha-${{ steps.sha.outputs.short }}
 
   cleanup-preview:
     runs-on: ubuntu-latest
@@ -362,7 +420,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.ADMIN_TOKEN }}
         run: |
-          for PACKAGE in ${{ github.event.repository.name }} regelrecht-admin regelrecht-harvester-worker; do
+          for PACKAGE in ${{ github.event.repository.name }} regelrecht-admin regelrecht-harvester-worker regelrecht-grafana; do
             echo "Pruning sha-only images for $PACKAGE..."
             gh api --paginate \
               "/orgs/${{ github.repository_owner }}/packages/container/${PACKAGE}/versions" \

--- a/packages/grafana/Dockerfile
+++ b/packages/grafana/Dockerfile
@@ -1,0 +1,34 @@
+FROM grafana/grafana-oss:11.6.0
+
+# ZAD requires port 8000 for liveprobe
+ENV GF_SERVER_HTTP_PORT=8000
+
+# Disable anonymous access
+ENV GF_AUTH_ANONYMOUS_ENABLED=false
+
+# Disable local admin account — OIDC is the sole auth path.
+ENV GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION=true
+# NOTE: GF_SECURITY_SECRET_KEY must be injected at deploy time via ZAD env_vars
+# to keep sessions stable across pod restarts.
+
+# Enable OIDC via Keycloak using ZAD-provided env vars.
+# ZAD injects OIDC_CLIENT_ID, OIDC_CLIENT_SECRET, OIDC_URL, and OIDC_REALM
+# into all components automatically.
+ENV GF_AUTH_GENERIC_OAUTH_ENABLED=true
+ENV GF_AUTH_GENERIC_OAUTH_NAME=Keycloak
+ENV GF_AUTH_GENERIC_OAUTH_ALLOW_SIGN_UP=true
+ENV GF_AUTH_GENERIC_OAUTH_SCOPES="openid email profile"
+# Map Keycloak roles to Grafana roles — users in 'grafana-admin' group get Admin
+ENV GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_PATH="contains(groups[*], 'grafana-admin') && 'Admin' || 'Viewer'"
+
+# Enable unified alerting
+ENV GF_UNIFIED_ALERTING_ENABLED=true
+ENV GF_ALERTING_ENABLED=false
+
+# Copy provisioning files and entrypoint
+COPY provisioning/ /etc/grafana/provisioning/
+COPY entrypoint.sh /entrypoint.sh
+
+EXPOSE 8000
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/packages/grafana/entrypoint.sh
+++ b/packages/grafana/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -eu
+
+# Map ZAD-provided OIDC env vars to Grafana's generic OAuth config.
+# ZAD injects: OIDC_CLIENT_ID, OIDC_CLIENT_SECRET, OIDC_URL, OIDC_REALM
+# Note: OIDC_DISCOVERY_URL is also provided but Grafana doesn't support a
+# single discovery URL — we construct the individual endpoints manually.
+
+export GF_AUTH_GENERIC_OAUTH_CLIENT_ID="${OIDC_CLIENT_ID}"
+export GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET="${OIDC_CLIENT_SECRET}"
+export GF_AUTH_GENERIC_OAUTH_AUTH_URL="${OIDC_URL}/realms/${OIDC_REALM}/protocol/openid-connect/auth"
+export GF_AUTH_GENERIC_OAUTH_TOKEN_URL="${OIDC_URL}/realms/${OIDC_REALM}/protocol/openid-connect/token"
+export GF_AUTH_GENERIC_OAUTH_API_URL="${OIDC_URL}/realms/${OIDC_REALM}/protocol/openid-connect/userinfo"
+
+exec /run.sh "$@"

--- a/packages/grafana/provisioning/alerting/alerts.yaml
+++ b/packages/grafana/provisioning/alerting/alerts.yaml
@@ -1,0 +1,89 @@
+---
+apiVersion: 1
+
+# Contact points and notification policies are configured via the Grafana UI
+# once external webhook URLs (e.g. Mattermost) are available.
+
+groups:
+  - orgId: 1
+    name: regelrecht
+    folder: Regelrecht
+    interval: 1m
+    rules:
+      - uid: failed-jobs
+        title: New failed jobs detected
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: PBFA97CFB590B2093
+            model:
+              expr: regelrecht_jobs{status="failed"}
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    type: gt
+                    params:
+                      - 0
+                  operator:
+                    type: and
+                  reducer:
+                    type: last
+              refId: C
+        noDataState: NoData
+        execErrState: Error
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: >-
+            {{ $value }} failed jobs detected
+
+      - uid: slow-jobs
+        title: Jobs running slow
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: PBFA97CFB590B2093
+            model:
+              expr: regelrecht_job_duration_avg_seconds
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    type: gt
+                    params:
+                      - 300
+                  operator:
+                    type: and
+                  reducer:
+                    type: last
+              refId: C
+        noDataState: NoData
+        execErrState: Error
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: >-
+            Average job duration is {{ $value }}s (threshold: 300s)

--- a/packages/grafana/provisioning/dashboards/dashboards.yaml
+++ b/packages/grafana/provisioning/dashboards/dashboards.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: 1
+providers:
+  - name: regelrecht
+    orgId: 1
+    folder: Regelrecht
+    type: file
+    disableDeletion: true
+    updateIntervalSeconds: 0
+    options:
+      path: /etc/grafana/provisioning/dashboards/json
+      foldersFromFilesStructure: false

--- a/packages/grafana/provisioning/dashboards/json/regelrecht-overview.json
+++ b/packages/grafana/provisioning/dashboards/json/regelrecht-overview.json
@@ -1,0 +1,282 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": false,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "panels": [
+    {
+      "title": "Jobs per status",
+      "type": "bargauge",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "failed" },
+            "properties": [
+              { "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "displayMode": "gradient",
+        "orientation": "horizontal",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+      },
+      "targets": [
+        {
+          "expr": "regelrecht_jobs",
+          "legendFormat": "{{status}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Laws per status",
+      "type": "bargauge",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "displayMode": "gradient",
+        "orientation": "horizontal",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+      },
+      "targets": [
+        {
+          "expr": "regelrecht_laws",
+          "legendFormat": "{{status}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Failed jobs",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 5 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+      },
+      "targets": [
+        {
+          "expr": "regelrecht_jobs{status=\"failed\"}",
+          "legendFormat": "Failed",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Pending jobs",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 10 },
+              { "color": "orange", "value": 50 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+      },
+      "targets": [
+        {
+          "expr": "regelrecht_jobs{status=\"pending\"}",
+          "legendFormat": "Pending",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Avg job duration (24h)",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 60 },
+              { "color": "red", "value": 300 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+      },
+      "targets": [
+        {
+          "expr": "regelrecht_job_duration_avg_seconds",
+          "legendFormat": "Avg duration",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Completed jobs",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+      },
+      "targets": [
+        {
+          "expr": "regelrecht_jobs{status=\"completed\"}",
+          "legendFormat": "Completed",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Jobs over time",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 12 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10,
+            "pointSize": 5,
+            "showPoints": "auto"
+          }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "failed" },
+            "properties": [
+              { "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      },
+      "targets": [
+        {
+          "expr": "regelrecht_jobs",
+          "legendFormat": "{{status}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Avg job duration over time",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 20 },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": { "fixedColor": "blue", "mode": "fixed" },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 20,
+            "pointSize": 5,
+            "showPoints": "auto"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "single" }
+      },
+      "targets": [
+        {
+          "expr": "regelrecht_job_duration_avg_seconds",
+          "legendFormat": "Avg duration",
+          "refId": "A"
+        }
+      ]
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": ["regelrecht"],
+  "templating": { "list": [] },
+  "time": { "from": "now-24h", "to": "now" },
+  "timepicker": {},
+  "timezone": "Europe/Amsterdam",
+  "title": "Regelrecht Overview",
+  "uid": "regelrecht-overview",
+  "version": 1
+}

--- a/packages/grafana/provisioning/datasources/prometheus.yaml
+++ b/packages/grafana/provisioning/datasources/prometheus.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    uid: PBFA97CFB590B2093
+    access: proxy
+    url: http://prometheus.rig-prd-operations.svc.cluster.local:9090
+    isDefault: true
+    editable: false


### PR DESCRIPTION
## Summary

Fixes for the Grafana component that were committed after PR #217 was already merged.

- Add `set -eu` to `entrypoint.sh` — fail fast on missing OIDC vars instead of constructing malformed URLs
- Restore `GF_SECURITY_SECRET_KEY` documentation removed in #217
- Remove unused `OIDC_DISCOVERY_URL` from comments (Grafana doesn't support it)
- Gate `build-grafana` on path filter — only build when `packages/grafana/**` changes
- Tighten production deploy condition — require editor build success (not any-component-OR)
- Set Prometheus URL to `http://prometheus.rig-prd-operations.svc.cluster.local:9090`
- Disable dashboard provisioning re-scan (`updateIntervalSeconds: 0`) since dashboards are baked into the image

## Test plan

- [ ] Verify CI only builds Grafana when `packages/grafana/**` changes
- [ ] Verify Grafana pod starts and connects to Prometheus
- [ ] Verify OIDC login works after merge