### PR TITLE
fix(grafana): set root URL for alert links

### DIFF
--- a/packages/grafana/Dockerfile
+++ b/packages/grafana/Dockerfile
@@ -1,4 +1,4 @@
-FROM grafana/grafana-oss:11.6.0
+FROM grafana/grafana-oss:12.4.0
 
 # ZAD requires port 8000 for liveprobe
 ENV GF_SERVER_HTTP_PORT=8000


### PR DESCRIPTION
## Summary

Alert notifications in Mattermost contain links like `http://localhost:8000/alerting/grafana/failed-jobs/view` because `GF_SERVER_ROOT_URL` was not set. 

Sets it to `https://grafana.regelrecht.rijks.app` so links are clickable.

## Test plan

- [ ] Verify alert links in Mattermost point to `https://grafana.regelrecht.rijks.app/...`