### PR TITLE
feat: add check-deployment skill for RIG diagnostics

### DIFF
--- a/.claude/skills/check-deployment/SKILL.md
+++ b/.claude/skills/check-deployment/SKILL.md
@@ -24,11 +24,7 @@ Accept a PR number (e.g., `204`) or deployment name (e.g., `pr204`, `pr204b`). I
 
 ### 2. Load RIG API key
 
-You need the `RIG_API_KEY` to access the RIG Operations Manager API. Load it from the workspace environment file:
-
-```bash
-RIG_API_KEY=$(grep '^RIG_API_KEY=' /workspace/.env | cut -d= -f2-)
-```
+You need the `RIG_API_KEY` environment variable set to access the RIG Operations Manager API.
 
 ### 3. Check CI/Deploy status
 


### PR DESCRIPTION
## Summary

- Adds a /check-deployment skill that diagnoses RIG preview deployment issues
- Systematically checks: CI triggers, image availability (Harbor mirror), pod status via logs
- Reports clear status table and suggests fixes
- Manual deploys only as last resort, with user confirmation required

Born from a debugging session where multiple deployment attempts silently failed due to wrong image tags, quota limits, and misleading API responses.

## Test plan

- [ ] Run /check-deployment 204 on an active PR and verify output
- [ ] Run on a PR with no deployment to verify error reporting