### PR TITLE
feat(grafana): replace alerts with daily summary

### DIFF
--- a/packages/grafana/provisioning/alerting/alerts.yaml
+++ b/packages/grafana/provisioning/alerting/alerts.yaml
@@ -23,8 +23,8 @@ contactPoints:
             {{ if eq .Labels.alertname "Dagelijkse Regelrecht Update" -}}
             | | |
             |:---|:---|
-            | :seedling: **Geharvest** | {{ index $values "A" }} wetten |
-            | :sparkles: **Verrijkt** | {{ index $values "B" }} wetten |
+            | :seedling: **Geharvest** | {{ index .Values "A" }} wetten |
+            | :sparkles: **Verrijkt** | {{ index .Values "B" }} wetten |
             {{ else if eq .Labels.alertname "Nieuwe mislukte jobs" -}}
             :warning: **{{ .Annotations.summary }}**
             {{ end -}}


### PR DESCRIPTION
## Summary

- Remove `failed-jobs` and `slow-jobs` threshold alerts that fired continuously every hour
- Add a single `daily-summary` alert that reports harvested and enriched law counts
- Set `repeat_interval: 24h` so the notification sends once per day
- Use positive messaging format instead of fire-alarm style `[FIRING]` alerts
- Disable resolve messages to avoid `[RESOLVED]` noise

## Test plan

- [ ] Verify YAML syntax passes yamllint (done locally)
- [ ] Build Grafana Docker image in CI
- [ ] Deploy to PR preview and verify alert rule in Grafana UI
- [ ] After 24h, verify Mattermost receives the daily summary