### PR TITLE
docs(rfc): RFC-008 execution lifecycle hooks and RFC-009 lex specialis overrides

### DIFF
--- a/doc/rfcs/RFC-008-reactive-execution.md
+++ b/doc/rfcs/RFC-008-reactive-execution.md
@@ -4,7 +4,7 @@
 **Date:** 2026-03-16
 **Authors:** Eelco Hotting
 
-> **Note:** This RFC is under active research and may change significantly. The interaction between hooks, overrides (RFC-009), and temporal computation (RFC-011) is being explored. See the [bezwaartermijn chain analysis](../analysis/bezwaartermijn-chain-analysis.md) for the current design exploration.
+> **Note:** This RFC is under active research and may change significantly. The interaction between hooks, overrides (RFC-009), and temporal computation (RFC-011) is being explored. See RFC-011 (Temporal Computation) for the current design exploration.
 
 ## Context
 

--- a/doc/rfcs/RFC-009-lex-specialis-overrides.md
+++ b/doc/rfcs/RFC-009-lex-specialis-overrides.md
@@ -4,7 +4,7 @@
 **Date:** 2026-03-16
 **Authors:** Eelco Hotting
 
-> **Note:** This RFC is under active research and may change significantly. The interaction between overrides, hooks (RFC-008), and temporal computation (RFC-011) is being explored. See the [bezwaartermijn chain analysis](../analysis/bezwaartermijn-chain-analysis.md) for the current design exploration.
+> **Note:** This RFC is under active research and may change significantly. The interaction between overrides, hooks (RFC-008), and temporal computation (RFC-011) is being explored. See RFC-011 (Temporal Computation) for the current design exploration.
 
 ## Context
 


### PR DESCRIPTION
## Summary

Two new RFCs extending the law execution model:

### RFC-008: Execution Lifecycle Hooks
- Introduces `hooks` on article-level `machine_readable`
- Laws inject themselves at defined engine lifecycle points (`pre_input`, `post_input`, `pre_actions`, `post_actions`)
- Hook articles declare `applies_to` filters matching the target article's `produces` annotation (e.g., `legal_character: BESCHIKKING`)
- Engine builds `hooks_index` at load time, queries it at each lifecycle stage during execution
- Unilateral: the target law declares nothing about hooks, matching the legal reality where AWB applies to all besluiten
- Example: AWB 3:46 (motiveringsplicht) hooks at `pre_actions`, AWB 6:7 (bezwaartermijn) hooks at `post_actions` on any BESCHIKKING

### RFC-009: Lex Specialis Overrides
- Introduces `overrides` on article-level `machine_readable`
- Declares lex specialis relationships ("in afwijking van") where a specific law unilaterally replaces a value set by a general law
- Works for both active execution (e.g., AWB 4:13 beslistermijn) and hook-augmented execution (e.g., AWB 6:7 bezwaartermijn)
- Parallels `implements` (RFC-007) in structure but differs in nature: replacing vs filling in
- Example: Vreemdelingenwet art 69 overrides AWB 6:7 bezwaartermijn from 6 to 4 weeks

## Context

These RFCs were split from an initial combined draft to keep the concerns separate:
- `hooks` (RFC-008) is about **when** a law fires, triggered by output properties of another law's execution
- `overrides` (RFC-009) is about **what value** applies when lex specialis replaces a general value

Both are independent mechanisms that interact: overrides affect a hook article's result, not its triggering condition.

## Test plan

- [ ] Review RFC-008 for clarity on lifecycle hooks model and walk-through
- [ ] Review RFC-009 for correctness of lex specialis representation
- [ ] Verify examples match actual Dutch legal text
- [ ] Check that `applies_to` filters align with schema v0.4.0 `produces` block