### PR TITLE
fix(grafana): use instant queries for alert rules

### DIFF
--- a/packages/grafana/provisioning/alerting/alerts.yaml
+++ b/packages/grafana/provisioning/alerting/alerts.yaml
@@ -60,6 +60,7 @@ groups:
             datasourceUid: PBFA97CFB590B2093
             model:
               expr: max(regelrecht_laws{status="harvested"})
+              instant: true
               refId: A
           - refId: B
             relativeTimeRange:
@@ -68,6 +69,7 @@ groups:
             datasourceUid: PBFA97CFB590B2093
             model:
               expr: max(regelrecht_laws{status="enriched"})
+              instant: true
               refId: B
           - refId: C
             relativeTimeRange:
@@ -109,6 +111,7 @@ groups:
             model:
               # Detect NEW failures in the last hour, not cumulative total.
               expr: sum(increase(regelrecht_jobs{status="failed"}[1h]))
+              instant: true
               refId: A
           - refId: C
             relativeTimeRange:


### PR DESCRIPTION
## Summary

- Fixes "frame cannot uniquely be identified by its labels: has duplicate results with labels {}" error on the Dagelijkse Regelrecht Update alert
- Root cause: range queries over 24h can produce multiple data frames with identical empty labels when there are gaps (pod restarts, scrape failures). Even `max()` aggregation doesn't prevent this because Grafana splits the range result into multiple frames before evaluation
- Fix: add `instant: true` to all PromQL alert queries so each returns exactly one value. For gauges (`regelrecht_laws`) this gives the current count; for `increase(...[1h])` it gives the increase at evaluation time

## Test plan

- [ ] After deploy, verify the alert evaluates without errors in Grafana UI
- [ ] Confirm the Mattermost daily summary fires correctly