### PR TITLE
fix(grafana): add reduce expressions to prevent duplicate label error

### DIFF
--- a/packages/grafana/provisioning/alerting/alerts.yaml
+++ b/packages/grafana/provisioning/alerting/alerts.yaml
@@ -45,7 +45,7 @@ groups:
   - orgId: 1
     name: regelrecht
     folder: Regelrecht
-    interval: 1h
+    interval: 10m
     rules:
       - uid: daily-summary
         title: Dagelijkse Regelrecht Update


### PR DESCRIPTION
## Summary

- Fixes "frame cannot uniquely be identified by its labels: has duplicate results with labels {}" on the daily summary alert
- The previous `instant: true` approach (#261) didn't work — Grafana's alerting engine may ignore `instant` in provisioned models and always evaluate as range queries
- Adds explicit `reduce` expressions (RA, RB) between the PromQL queries and the threshold condition, guaranteeing a single value regardless of how many frames the data source returns
- Updates Mattermost template and annotations to reference RA/RB instead of A/B

## Test plan

- [ ] After deploy, verify alert evaluates without errors in Grafana UI
- [ ] Confirm Mattermost daily summary fires with correct values