### PR TITLE
chore(grafana): set alert interval to hourly

### DIFF
--- a/packages/grafana/provisioning/alerting/alerts.yaml
+++ b/packages/grafana/provisioning/alerting/alerts.yaml
@@ -38,8 +38,8 @@ policies:
       - grafana_folder
       - alertname
     group_wait: 30s
-    group_interval: 24h
-    repeat_interval: 24h
+    group_interval: 1h
+    repeat_interval: 1h
 
 groups:
   - orgId: 1


### PR DESCRIPTION
## Summary
- Temporarily sets Grafana alert `group_interval` and `repeat_interval` from 24h to 1h

## Test plan
- [ ] Verify Grafana alerts fire hourly after deploy