### PR TITLE
fix(pipeline): fix absolute yaml_path in enrich job payloads

### DIFF
--- a/packages/pipeline/migrations/0005_fix_absolute_enrich_payload_paths.sql
+++ b/packages/pipeline/migrations/0005_fix_absolute_enrich_payload_paths.sql
@@ -1,0 +1,11 @@
+-- Fix enrich job payloads that have absolute yaml_path values.
+-- The enrich worker reads yaml_path from its payload, and rejects
+-- absolute paths. Strip the '/tmp/corpus-repo/' prefix.
+UPDATE jobs
+SET payload = jsonb_set(
+    payload,
+    '{yaml_path}',
+    to_jsonb(regexp_replace(payload->>'yaml_path', '^/tmp/corpus-repo/', ''))
+)
+WHERE job_type = 'enrich'
+  AND payload->>'yaml_path' LIKE '/tmp/%';


### PR DESCRIPTION
## Summary

Migration 0004 fixte `file_path` in harvest job **results**, maar de enrich worker leest `yaml_path` uit zijn eigen **payload** - die was ook absoluut. Deze migration (0005) stript het `/tmp/corpus-repo/` prefix uit enrich job payloads, zodat bestaande failed/pending enrich jobs bij retry succesvol zijn.

## Context

Na merge van #267 bleef de enrich worker falen met "yaml_path must be relative, not absolute" omdat de enrich job payloads niet door migration 0004 geraakt werden.

## Test plan

- [ ] Na deploy: bestaande enrich jobs retrien succesvol
- [ ] Geen nieuwe "yaml_path must be relative" errors in logs