### PR TITLE
fix(grafana): daily summary alert shows 1 instead of actual count

### DIFF
--- a/packages/grafana/provisioning/alerting/alerts.yaml
+++ b/packages/grafana/provisioning/alerting/alerts.yaml
@@ -71,23 +71,17 @@ groups:
               expr: max(regelrecht_laws{status="enriched"})
               instant: true
               refId: B
+          # Always-fire: math expression that's always >= 0.
+          # Avoids the threshold reducer which returns 1 (boolean result)
+          # instead of the actual metric value in .Values.
           - refId: C
             relativeTimeRange:
               from: 600
               to: 0
             datasourceUid: __expr__
             model:
-              type: threshold
-              expression: A
-              conditions:
-                - evaluator:
-                    type: gt
-                    params:
-                      - -1
-                  operator:
-                    type: and
-                  reducer:
-                    type: last
+              type: math
+              expression: $A + $B + 1
               refId: C
         noDataState: OK
         execErrState: Alerting


### PR DESCRIPTION
## Summary

The daily Mattermost alert always shows "1 wetten geharvest" regardless of the actual number of harvested laws.

## Cause

The `threshold` condition expression with `reducer: type: last` returns `1` (the boolean result of the threshold check: true=1) instead of the actual metric value. This value ends up in `.Values["A"]` in the notification template.

## Fix

Replace the `threshold` expression with a `math` expression (`$A + $B + 1`) that:
- Always evaluates to > 0 so the alert keeps firing
- Preserves the raw query values of A and B in `.Values`

## Test plan

- [ ] After deploy, verify the next daily summary shows the correct harvested/enriched counts