### PR TITLE
feat(corpus): gebruik DEPLOYMENT_NAME als corpus branch in previews

### DIFF
--- a/packages/corpus/src/config.rs
+++ b/packages/corpus/src/config.rs
@@ -201,6 +201,11 @@ mod tests {
     }
 
     #[test]
+    fn resolve_branch_uses_corpus_branch_without_deployment() {
+        assert_eq!(resolve_branch(Some("custom".into()), None), "custom");
+    }
+
+    #[test]
     fn resolve_branch_uses_deployment_name_for_preview() {
         assert_eq!(resolve_branch(None, Some("pr42".into())), "pr42");
     }


### PR DESCRIPTION
## Summary

- Preview deployments gebruiken automatisch `DEPLOYMENT_NAME` als corpus branch (bijv. `pr42`)
- Branch wordt aangemaakt vanuit `development` als deze nog niet bestaat (bestaande logica in `CorpusClient`)
- Productie (`regelrecht`) valt door naar de default `development` branch
- `CORPUS_BRANCH` env var heeft altijd voorrang als die expliciet gezet is

## Prioriteit

```
CORPUS_BRANCH > DEPLOYMENT_NAME (als preview) > "development"
```

## Test plan

- [ ] Verificeer dat preview deployment een eigen corpus branch aanmaakt
- [ ] Verificeer dat productie deployment `development` branch blijft gebruiken
- [ ] Unit tests: `cargo test -p regelrecht-corpus -- config`