### PR TITLE
fix(deps): bump aws-lc-sys to fix CRL validation vulnerability

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -10,9 +10,6 @@ ignore = [
     # Transitive dep via openidconnect -> rsa; no patched version available.
     # We don't use RSA directly; the OIDC flow uses HTTPS transport security.
     "RUSTSEC-2023-0071",
-    # RUSTSEC-2025-0111: tokio-tar PAX header parsing vulnerability.
-    # Dev-only dep via testcontainers; not used in production.
-    "RUSTSEC-2025-0111",
 ]
 
 [licenses]

--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -193,9 +193,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -203,9 +203,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
 dependencies = [
  "cc",
  "cmake",


### PR DESCRIPTION
## Summary
- Update aws-lc-rs 1.16.1 → 1.16.2 (aws-lc-sys 0.38.0 → 0.39.0) to resolve RUSTSEC advisory for CRL distribution point matching logic error
- Remove stale RUSTSEC-2025-0111 ignore (tokio-tar) which no longer matches any crate in the dependency tree

## Test plan
- [ ] Security Audit CI check passes