### PR TITLE
fix(deps): bump rustls-webpki to 0.103.10 (RUSTSEC-2026-0049)

### DIFF
--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -3335,9 +3335,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## Summary

- Bumps `rustls-webpki` from 0.103.9 to 0.103.10 to fix RUSTSEC-2026-0049
- CRL distribution point matching logic was faulty, potentially skipping revocation checks
- Transitive dependency update (lockfile only)

## Test plan

- [ ] CI Security Audit passes
- [ ] All existing tests pass (no code changes)