### PR TITLE
fix(ci): match CI RUSTFLAGS locally via Justfile

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -3,6 +3,10 @@
 
 set dotenv-load := true
 
+# CI uses RUSTFLAGS=-Dwarnings; ci_flags mirrors that for quality/test recipes
+# but not for dev (hot-reload), where in-flight warnings would kill cargo watch.
+ci_flags := "RUSTFLAGS=-Dwarnings"
+
 # Default task - toon beschikbare tasks
 default:
     @just --list
@@ -15,11 +19,11 @@ format:
 
 # Run clippy lints
 lint:
-    cd packages && cargo clippy --all-features -- -D warnings
+    cd packages && {{ci_flags}} cargo clippy --all-features
 
 # Run cargo check
 build-check:
-    cd packages && cargo check --all-features
+    cd packages && {{ci_flags}} cargo check --all-features
 
 # Validate regulation YAML files
 validate *FILES:
@@ -33,23 +37,23 @@ check: format lint build-check validate test harvester-test pipeline-test admin-
 
 # Run Rust unit and integration tests
 test:
-    cd packages/engine && cargo test --all-features
+    cd packages/engine && {{ci_flags}} cargo test --all-features
 
 # Run Rust BDD tests
 bdd:
-    cd packages/engine && cargo test --test bdd -- --nocapture
+    cd packages/engine && {{ci_flags}} cargo test --test bdd -- --nocapture
 
 # Run harvester tests
 harvester-test:
-    cd packages/harvester && cargo test
+    cd packages/harvester && {{ci_flags}} cargo test
 
 # Run pipeline unit tests (no Docker/DB required)
 pipeline-test:
-    cd packages/pipeline && cargo test --lib
+    cd packages/pipeline && {{ci_flags}} cargo test --lib
 
 # Run pipeline integration tests (requires Docker for testcontainers)
 pipeline-integration-test:
-    cd packages/pipeline && cargo test --test '*'
+    cd packages/pipeline && {{ci_flags}} cargo test --test '*'
 
 # Run all tests (engine + harvester + pipeline unit + pipeline integration)
 test-all: test harvester-test pipeline-test pipeline-integration-test
@@ -97,11 +101,11 @@ admin-frontend:
 
 # Check admin Rust code
 admin-check:
-    cd packages && cargo check --package regelrecht-admin
+    cd packages && {{ci_flags}} cargo check --package regelrecht-admin
 
 # Lint admin Rust code
 admin-lint:
-    cd packages && cargo clippy --package regelrecht-admin -- -D warnings
+    cd packages && {{ci_flags}} cargo clippy --package regelrecht-admin
 
 # Format check admin Rust code
 admin-fmt:
@@ -109,7 +113,7 @@ admin-fmt:
 
 # Run admin tests
 admin-test:
-    cd packages && cargo test --package regelrecht-admin
+    cd packages && {{ci_flags}} cargo test --package regelrecht-admin
 
 # --- Development (native with hot reload) ---
 


### PR DESCRIPTION
## Summary

- Adds a `ci_flags` variable (`RUSTFLAGS=-Dwarnings`) to the Justfile, applied to quality and test recipes (`lint`, `build-check`, `test`, `bdd`, `harvester-test`, `pipeline-test`, `admin-lint`, `admin-check`, `admin-test`) so they treat warnings as errors — matching CI behavior.
- Removes the now-redundant `-- -D warnings` from clippy recipes (covered by `RUSTFLAGS`).
- Leaves `just dev` (cargo watch hot-reload) unaffected, so in-flight warnings don't kill the dev loop.

## Why

CI sets `RUSTFLAGS: -Dwarnings` globally in `.github/workflows/ci.yml:15`. Locally this flag was absent, so warnings (e.g. `dead_code`) passed silently during development but failed in CI. This caused a CI-only failure on the `feature/operations-v0.5.0` branch that wasn't caught locally.

## Test plan

- [x] `just test` on main passes with the new flag
- [x] `just lint` works without redundant `-- -D warnings`
- [ ] Verify pre-commit hooks still work (they call `just format` and `just lint`)
- [ ] Confirm CI passes on this PR