### PR TITLE
fix(monitoring): daily summary at midnight, disable failed-jobs alert

### DIFF
--- a/packages/grafana/provisioning/alerting/alerts.yaml
+++ b/packages/grafana/provisioning/alerting/alerts.yaml
@@ -55,9 +55,17 @@ policies:
       - alertname
     group_wait: 30s
     group_interval: 5m
-    repeat_interval: 24h
-    mute_time_intervals:
-      - niet-middernacht
+    repeat_interval: 1h
+    routes:
+      # Daily summary: once per day, only at midnight Amsterdam time.
+      # The mute is scoped to this route so future real-time alerts
+      # on the root policy are unaffected.
+      - receiver: mattermost
+        matchers:
+          - alertname = "Dagelijkse Regelrecht Update"
+        repeat_interval: 24h
+        mute_time_intervals:
+          - niet-middernacht
 
 groups:
   - orgId: 1


### PR DESCRIPTION
## Summary

- Add a Grafana mute time interval (`niet-middernacht`) that silences notifications outside 00:00-01:00 Europe/Amsterdam, so the daily summary is delivered once at midnight Dutch time (handles CET/CEST automatically)
- Remove the `failed-jobs` alert rule — too noisy while the failed-job counts are being investigated
- Simplify the Mattermost contact point template (no more alert branching needed)

## Test plan

- [ ] Deploy to a PR preview and verify Grafana starts without provisioning errors
- [ ] Check Grafana UI: Alerting > Notification policies shows the mute time interval
- [ ] Check Grafana UI: Alerting > Alert rules shows only the daily summary, no failed-jobs rule
- [ ] Verify the daily summary fires during the 00:00-01:00 Amsterdam window