### PR TITLE
fix(deploy): predictable preview URLs and always deploy all components

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -305,6 +305,7 @@ jobs:
         run: echo "short=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
 
       - name: Deploy admin to ZAD (Preview)
+        if: needs.build-admin.result != 'failure'
         uses: RijksICTGilde/zad-actions/deploy@v3
         with:
           api-key: ${{ secrets.RIG_API_KEY }}
@@ -320,6 +321,7 @@ jobs:
           comment-header: '## Preview Deployment'
 
       - name: Deploy harvester-worker to ZAD (Preview)
+        if: needs.build-harvester-worker.result != 'failure'
         uses: RijksICTGilde/zad-actions/deploy@v3
         with:
           api-key: ${{ secrets.RIG_API_KEY }}
@@ -335,6 +337,7 @@ jobs:
           comment-header: '## Preview Deployment'
 
       - name: Deploy enrich-worker to ZAD (Preview)
+        if: needs.build-enrich-worker.result != 'failure'
         uses: RijksICTGilde/zad-actions/deploy@v3
         with:
           api-key: ${{ secrets.RIG_API_KEY }}


### PR DESCRIPTION
## Summary
- Add `domain-format: component-deployment-project` to all deploy steps (preview + production) for predictable URLs
- Remove `if`-conditions from backend preview deploy steps so all components are always deployed
- Fall back to `latest` (production) image tag when a component was not rebuilt in the PR

## Test plan
- [ ] Verify PR comment shows URLs in `component-deployment-project` format
- [ ] Verify all components are deployed even when only editor files changed
- [ ] Verify production deployment still works correctly