### PR TITLE
chore: strict scope rule for code reviewer

### DIFF
--- a/.claude/skills/code-reviewer/SKILL.md
+++ b/.claude/skills/code-reviewer/SKILL.md
@@ -45,14 +45,26 @@ git diff --cached
 
 ## Step 3: Review the Changes
 
-For each changed file:
+**CRITICAL RULE: Only review lines that were actually changed in the diff.**
 
-1. **Read the entire file** — not just the diff
+Do NOT comment on:
+- Pre-existing code that was not modified in this PR/commit
+- Surrounding context lines that appear in the diff for readability but were not changed
+- Issues in files that were not touched by this PR/commit
+- Pre-existing patterns, style, or naming choices in unchanged code
+
+You may read the full file to *understand* context, but every finding you report
+MUST point to a line that was added or modified in the diff. If a line was not
+changed, it is out of scope — no matter how wrong it looks.
+
+For each changed line/block:
+
+1. **Understand the surrounding code** — read enough context to judge the change
 2. **Trace the data flow** — where does data come from, where does it go?
 3. **Check the boundaries** — what happens at edges and limits?
 4. **Apply REVIEW.md dimensions** — check each applicable dimension from the guidelines
 
-**Questions to ask:**
+**Questions to ask (about changed code only):**
 - What could go wrong here?
 - What happens if this input is null/empty/huge/negative?
 - What happens if this external call fails?

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -66,7 +66,23 @@ jobs:
             Read `REVIEW.md` for the project context, review dimensions, severity scale, and
             skip rules. Follow those guidelines strictly.
 
-            Review the PR diff. Only comment on changed lines.
+            ## CRITICAL SCOPE RULE
+
+            **ONLY review lines that were actually added or modified in this PR's diff.**
+
+            You MUST NOT comment on:
+            - Pre-existing code that was not changed in this PR
+            - Context lines shown in the diff that were not added/modified (lines without + prefix)
+            - Issues in unchanged files or unchanged sections of changed files
+            - Pre-existing patterns, naming, style, or technical debt in surrounding code
+
+            You may read full files for context to understand the changes, but every single
+            finding you report MUST point to a line that was added or modified in the diff.
+            If a line was not changed by this PR, it is OUT OF SCOPE, no matter how wrong it looks.
+
+            Before submitting each finding, verify: "Was this line actually changed in the PR diff?"
+            If the answer is no, drop the finding.
+
             Skip dimensions that have no findings. Be precise and actionable — no "consider"
             or "you might want to" comments.
 


### PR DESCRIPTION
## Summary

- De automated reviewer commenteerde op pre-existing code buiten de PR diff (zie bijv. #339 waar een schema versie in een ongewijzigd bestand werd geflagd)
- Zowel de skill prompt (SKILL.md) als de CI workflow (claude-code-review.yml) hebben nu een expliciet "CRITICAL SCOPE RULE" blok dat findings op ongewijzigde regels verbiedt
- De reviewer mag wel volledige bestanden lezen voor context, maar elke finding moet naar een daadwerkelijk gewijzigde regel wijzen

## Changes

- **`.claude/skills/code-reviewer/SKILL.md`** — "Read the entire file — not just the diff" vervangen door strikte scope-regel met expliciete do-not lijst
- **`.github/workflows/claude-code-review.yml`** — "Only comment on changed lines" vervangen door uitgebreid CRITICAL SCOPE RULE blok met self-check instructie