### PR TITLE
fix(frontend): editor/library UI fixes

### DIFF
--- a/frontend/src/LibraryApp.vue
+++ b/frontend/src/LibraryApp.vue
@@ -224,11 +224,10 @@ loadIndex();
                 </rr-toolbar-start-area>
                 <rr-toolbar-end-area>
                   <rr-toolbar-item>
-                    <rr-button
-                      variant="accent-filled"
-                      size="md"
-                      :href="selectedLawId ? `editor.html?law=${selectedLawId}` : undefined"
-                    >Bewerk</rr-button>
+                    <a v-if="selectedLawId" :href="`editor.html?law=${selectedLawId}`">
+                      <rr-button variant="accent-filled" size="md">Bewerk</rr-button>
+                    </a>
+                    <rr-button v-else variant="accent-filled" size="md" disabled>Bewerk</rr-button>
                   </rr-toolbar-item>
                 </rr-toolbar-end-area>
               </rr-toolbar>
@@ -270,28 +269,25 @@ loadIndex();
             container="sm"
             toolbar="custom"
           >
-            <div slot="toolbar-start">
-              <rr-toolbar size="md">
-                <rr-toolbar-start-area>
-                  <rr-toolbar-item>
-                    <rr-segmented-control size="md" :value="detailView" @change="detailView = $event.detail.value">
-                      <rr-segmented-control-item value="tekst">Tekst</rr-segmented-control-item>
-                      <rr-segmented-control-item value="machine">Machine</rr-segmented-control-item>
-                      <rr-segmented-control-item value="yaml">YAML</rr-segmented-control-item>
-                    </rr-segmented-control>
-                  </rr-toolbar-item>
-                </rr-toolbar-start-area>
-                <rr-toolbar-end-area>
-                  <rr-toolbar-item>
-                    <rr-button
-                      variant="accent-filled"
-                      size="md"
-                      :href="selectedLawId ? `editor.html?law=${selectedLawId}` : undefined"
-                    >Bewerk</rr-button>
-                  </rr-toolbar-item>
-                </rr-toolbar-end-area>
-              </rr-toolbar>
-            </div>
+            <rr-toolbar slot="toolbar-start" size="md">
+              <rr-toolbar-start-area>
+                <rr-toolbar-item>
+                  <rr-segmented-control size="md" :value="detailView" @change="detailView = $event.detail.value">
+                    <rr-segmented-control-item value="tekst">Tekst</rr-segmented-control-item>
+                    <rr-segmented-control-item value="machine">Machine</rr-segmented-control-item>
+                    <rr-segmented-control-item value="yaml">YAML</rr-segmented-control-item>
+                  </rr-segmented-control>
+                </rr-toolbar-item>
+              </rr-toolbar-start-area>
+              <rr-toolbar-end-area>
+                <rr-toolbar-item>
+                  <a v-if="selectedLawId" :href="`editor.html?law=${selectedLawId}`">
+                    <rr-button variant="accent-filled" size="md">Bewerk</rr-button>
+                  </a>
+                  <rr-button v-else variant="accent-filled" size="md" disabled>Bewerk</rr-button>
+                </rr-toolbar-item>
+              </rr-toolbar-end-area>
+            </rr-toolbar>
           </rr-top-title-bar>
 
           <rr-simple-section container="sm">

--- a/frontend/src/components/MachineReadable.vue
+++ b/frontend/src/components/MachineReadable.vue
@@ -205,7 +205,7 @@ function addOutput() {
         <rr-list-item v-for="(action, index) in actions" :key="index" size="md">
           <rr-text-cell>{{ action.output }}</rr-text-cell>
           <rr-button-cell slot="end">
-            <rr-button variant="neutral-tinted" size="sm" @click="emit('open-action', action)">Bewerk</rr-button>
+            <rr-button variant="neutral-tinted" size="sm" @click="emit('open-action', action)">{{ editable ? 'Bewerk' : 'Bekijk' }}</rr-button>
           </rr-button-cell>
         </rr-list-item>
       </rr-list>
@@ -229,9 +229,6 @@ function addOutput() {
   justify-content: space-between;
   padding: 6px 12px;
   min-height: 36px;
-}
-.machine-readable rr-list[variant="box"] rr-list-item + rr-list-item {
-  border-top: 1px solid var(--semantics-dividers-color, #E0E3E8);
 }
 .add-button {
   display: inline-flex;

--- a/frontend/src/composables/useLaw.js
+++ b/frontend/src/composables/useLaw.js
@@ -4,7 +4,7 @@ import yaml from 'js-yaml';
 export function useLaw(lawParam) {
   if (!lawParam) {
     const params = new URLSearchParams(window.location.search);
-    lawParam = params.get('law') || 'wet_op_de_zorgtoeslag';
+    lawParam = params.get('law') || 'zorgtoeslagwet';
   }
   // If the parameter looks like a URL, fetch directly; otherwise use the API.
   const yamlUrl = (lawParam.startsWith('/') || lawParam.startsWith('http'))

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -36,8 +36,8 @@ export default defineConfig({
       interval: 1000,
     },
     proxy: {
-      '/api': 'http://localhost:8001',
-      '/health': 'http://localhost:8001',
+      '/api': 'http://localhost:8000',
+      '/health': 'http://localhost:8000',
     },
   },
 });


### PR DESCRIPTION
## Summary
- Fix vite dev proxy target (8001→8000) to match editor-api port
- Fix default law ID to `zorgtoeslagwet` (was `wet_op_de_zorgtoeslag` which doesn't exist)
- Remove duplicate divider on `rr-list variant="box"` items (manual CSS + automatic component divider)
- Fix Bewerk button alignment in library pane-3 (toolbar was wrapped in div)
- Make Bewerk buttons navigate using native `<a>` tags instead of non-functional `rr-button` href
- Show "Bekijk" instead of "Bewerk" for actions in library read-only view

## Test plan
- [ ] Open library (index.html) — no double dividers in machine readable lists
- [ ] Bewerk button in library right panel is right-aligned
- [ ] Click Bewerk → navigates to editor with correct law loaded
- [ ] Editor default loads zorgtoeslagwet without 404
- [ ] Actions show "Bekijk" in library, "Bewerk" in editor