### PR TITLE
fix(frontend): align font-family with Storybook design tokens

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1,6 +1,6 @@
-/* Rijksoverheid Fonts */
+/* Rijksoverheid Fonts - registered as RijksSansVF to align with design tokens */
 @font-face {
-  font-family: 'RijksoverheidSans';
+  font-family: 'RijksSansVF';
   src: url('/fonts/ROsanswebtextregular.woff') format('woff');
   font-weight: 400;
   font-style: normal;
@@ -8,7 +8,7 @@
 }
 
 @font-face {
-  font-family: 'RijksoverheidSans';
+  font-family: 'RijksSansVF';
   src: url('/fonts/ROsanswebtextbold.woff') format('woff');
   font-weight: 700;
   font-style: normal;
@@ -16,7 +16,7 @@
 }
 
 @font-face {
-  font-family: 'RijksoverheidSans';
+  font-family: 'RijksSansVF';
   src: url('/fonts/ROsanswebtextitalic.woff') format('woff');
   font-weight: 400;
   font-style: italic;
@@ -48,8 +48,8 @@
 }
 
 :root {
-  /* Font family override */
-  --rr-font-family-sans: 'RijksoverheidSans', system-ui, -apple-system, sans-serif;
+  /* Font family - aligned with @minbzk/storybook design tokens */
+  --rr-font-family-sans: 'RijksSansVF', system-ui, sans-serif;
   --rr-font-family-serif: 'RijksoverheidSerif', Georgia, serif;
 
   /* Map RegelRecht design tokens to VitePress CSS variables */
@@ -61,7 +61,7 @@
   --vp-c-brand-soft: rgba(21, 66, 115, 0.14);
 
   /* Typography */
-  --vp-font-family-base: 'RijksoverheidSans', system-ui, -apple-system, sans-serif;
+  --vp-font-family-base: 'RijksSansVF', system-ui, sans-serif;
   --vp-font-family-mono: 'SF Mono', 'Fira Code', 'Fira Mono', Menlo, Consolas, monospace;
 
   /* Neutral palette → VitePress surfaces */

--- a/frontend-lawmaking/css/variables.css
+++ b/frontend-lawmaking/css/variables.css
@@ -29,8 +29,8 @@
   --color-text-secondary: var(--color-slate-500);
   --color-text-muted: var(--color-slate-400);
 
-  /* Typography - Using Rijksoverheid fonts from design system */
-  --font-family: var(--rr-font-family-sans, 'RijksoverheidSans', system-ui, -apple-system, sans-serif);
+  /* Typography - aligned with @minbzk/storybook design tokens */
+  --font-family: var(--primitives-font-family-body, var(--rr-font-family-sans, 'RijksSansVF', system-ui, sans-serif));
 
   --font-size-xs: 12px;
   --font-size-sm: 14px;
@@ -41,9 +41,8 @@
   --font-size-3xl: 26px;
   --font-size-4xl: 29px;
 
-  /* Note: Rijksoverheid fonts only have 400 (regular) and 700 (bold) */
   --font-weight-normal: 400;
-  --font-weight-medium: 700;
+  --font-weight-medium: 550;
   --font-weight-semibold: 700;
 
   --line-height-tight: 1;

--- a/frontend-lawmaking/fonts/fonts.css
+++ b/frontend-lawmaking/fonts/fonts.css
@@ -2,11 +2,13 @@
  * Rijksoverheid Webfonts
  * Official fonts for Dutch Government (Rijksoverheid) websites
  * Source: rijkshuisstijl.nl
+ *
+ * Registered as 'RijksSansVF' to align with @minbzk/storybook design tokens.
  */
 
 /* Rijksoverheid Sans - Text variant (for body text) */
 @font-face {
-  font-family: 'RijksoverheidSans';
+  font-family: 'RijksSansVF';
   src: url('./ROsanswebtextregular.woff') format('woff');
   font-weight: 400;
   font-style: normal;
@@ -14,7 +16,7 @@
 }
 
 @font-face {
-  font-family: 'RijksoverheidSans';
+  font-family: 'RijksSansVF';
   src: url('./ROsanswebtextbold.woff') format('woff');
   font-weight: 700;
   font-style: normal;
@@ -22,7 +24,7 @@
 }
 
 @font-face {
-  font-family: 'RijksoverheidSans';
+  font-family: 'RijksSansVF';
   src: url('./ROsanswebtextitalic.woff') format('woff');
   font-weight: 400;
   font-style: italic;
@@ -54,8 +56,8 @@
   font-display: swap;
 }
 
-/* CSS Custom Property for easy usage */
+/* CSS Custom Properties - aligned with @minbzk/storybook design tokens */
 :root {
-  --rr-font-family-sans: 'RijksoverheidSans', system-ui, -apple-system, sans-serif;
+  --rr-font-family-sans: 'RijksSansVF', system-ui, sans-serif;
   --rr-font-family-serif: 'RijksoverheidSerif', Georgia, serif;
 }

--- a/frontend/css/variables.css
+++ b/frontend/css/variables.css
@@ -29,8 +29,8 @@
   --color-text-secondary: var(--color-slate-500);
   --color-text-muted: var(--color-slate-400);
 
-  /* Typography - Using Rijksoverheid fonts from design system */
-  --font-family: var(--rr-font-family-sans, 'RijksoverheidSans', system-ui, -apple-system, sans-serif);
+  /* Typography - aligned with @minbzk/storybook design tokens */
+  --font-family: var(--primitives-font-family-body, var(--rr-font-family-sans, 'RijksSansVF', system-ui, sans-serif));
 
   --font-size-xs: 12px;
   --font-size-sm: 14px;
@@ -41,9 +41,8 @@
   --font-size-3xl: 26px;
   --font-size-4xl: 29px;
 
-  /* Note: Rijksoverheid fonts only have 400 (regular) and 700 (bold) */
   --font-weight-normal: 400;
-  --font-weight-medium: 700;
+  --font-weight-medium: 550;
   --font-weight-semibold: 700;
 
   --line-height-tight: 1;

--- a/frontend/fonts/fonts.css
+++ b/frontend/fonts/fonts.css
@@ -2,11 +2,13 @@
  * Rijksoverheid Webfonts
  * Official fonts for Dutch Government (Rijksoverheid) websites
  * Source: rijkshuisstijl.nl
+ *
+ * Registered as 'RijksSansVF' to align with @minbzk/storybook design tokens.
  */
 
 /* Rijksoverheid Sans - Text variant (for body text) */
 @font-face {
-  font-family: 'RijksoverheidSans';
+  font-family: 'RijksSansVF';
   src: url('./ROsanswebtextregular.woff') format('woff');
   font-weight: 400;
   font-style: normal;
@@ -14,7 +16,7 @@
 }
 
 @font-face {
-  font-family: 'RijksoverheidSans';
+  font-family: 'RijksSansVF';
   src: url('./ROsanswebtextbold.woff') format('woff');
   font-weight: 700;
   font-style: normal;
@@ -22,7 +24,7 @@
 }
 
 @font-face {
-  font-family: 'RijksoverheidSans';
+  font-family: 'RijksSansVF';
   src: url('./ROsanswebtextitalic.woff') format('woff');
   font-weight: 400;
   font-style: italic;
@@ -54,8 +56,8 @@
   font-display: swap;
 }
 
-/* CSS Custom Property for easy usage */
+/* CSS Custom Properties - aligned with @minbzk/storybook design tokens */
 :root {
-  --rr-font-family-sans: 'RijksoverheidSans', system-ui, -apple-system, sans-serif;
+  --rr-font-family-sans: 'RijksSansVF', system-ui, sans-serif;
   --rr-font-family-serif: 'RijksoverheidSerif', Georgia, serif;
 }


### PR DESCRIPTION
## Summary
- Renamed `@font-face` declarations from `RijksoverheidSans` to `RijksSansVF` to match the font-family expected by `@minbzk/storybook` design tokens
- Updated `--font-family` CSS variable to prefer `--primitives-font-family-body` from the Storybook design system, with `--rr-font-family-sans` as fallback
- Corrected `--font-weight-medium` from `700` to `550` to align with the design system's medium weight token
- Applied changes across `frontend/`, `frontend-lawmaking/`, and `docs/`

## Context
The Storybook design system components use `RijksSansVF` as font-family (via `--primitives-font-family-body` and inline fallbacks in web components). The editor was loading old `RijksoverheidSans` .woff fonts under a different name, causing a font mismatch between the editor and what Storybook shows.

## Test plan
- [ ] Verify editor renders with the correct font (matching Storybook components)
- [ ] Verify font-weight: 550 (medium) renders correctly in headings/titles
- [ ] Check frontend-lawmaking and docs site fonts match