### PR TITLE
fix(ci): clean up stale claude review comments before new review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -20,6 +20,35 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Clean up stale review comments
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR=${{ github.event.pull_request.number }}
+          REPO=${{ github.repository }}
+
+          # Dismiss all previous claude[bot] reviews
+          gh api "repos/${REPO}/pulls/${PR}/reviews" \
+            --paginate --jq '.[] | select(.user.login == "claude[bot]" and (.state == "CHANGES_REQUESTED" or .state == "COMMENTED")) | .id' \
+          | while read -r review_id; do
+              gh api -X PUT "repos/${REPO}/pulls/${PR}/reviews/${review_id}/dismissals" \
+                -f message="Superseded by new review" -f event="DISMISS" 2>/dev/null || true
+            done
+
+          # Delete all previous claude[bot] inline review comments
+          gh api "repos/${REPO}/pulls/${PR}/comments" \
+            --paginate --jq '.[] | select(.user.login == "claude[bot]") | .id' \
+          | while read -r comment_id; do
+              gh api -X DELETE "repos/${REPO}/pulls/comments/${comment_id}" 2>/dev/null || true
+            done
+
+          # Delete all previous claude[bot] issue comments (sticky comment is managed by the action)
+          gh api "repos/${REPO}/issues/${PR}/comments" \
+            --paginate --jq '.[] | select(.user.login == "claude[bot]") | .id' \
+          | while read -r comment_id; do
+              gh api -X DELETE "repos/${REPO}/issues/comments/${comment_id}" 2>/dev/null || true
+            done
+
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@v1
@@ -28,39 +57,6 @@ jobs:
           use_sticky_comment: true
           claude_args: "--allowedTools Bash,Read,Glob,Grep"
           prompt: |
-            ## Step 0: Clean up previous reviews
-
-            BEFORE doing anything else, clean up your own previous review comments and
-            reviews on this PR so they don't pile up. Run these commands:
-
-            ```bash
-            # Dismiss all previous claude[bot] reviews (changes CHANGES_REQUESTED to comments)
-            gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews" \
-              --paginate --jq '.[] | select(.user.login == "claude[bot]" and (.state == "CHANGES_REQUESTED" or .state == "COMMENTED")) | .id' \
-            | while read -r review_id; do
-                gh api -X PUT "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews/${review_id}/dismissals" \
-                  -f message="Superseded by new review" -f event="DISMISS" 2>/dev/null || true
-              done
-
-            # Delete all previous claude[bot] inline review comments
-            gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments" \
-              --paginate --jq '.[] | select(.user.login == "claude[bot]") | .id' \
-            | while read -r comment_id; do
-                gh api -X DELETE "repos/${{ github.repository }}/pulls/comments/${comment_id}" 2>/dev/null || true
-              done
-
-            # Delete all previous claude[bot] issue comments (except sticky which is managed automatically)
-            gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
-              --paginate --jq '.[] | select(.user.login == "claude[bot]") | .id' \
-            | while read -r comment_id; do
-                gh api -X DELETE "repos/${{ github.repository }}/issues/comments/${comment_id}" 2>/dev/null || true
-              done
-            ```
-
-            After cleanup, proceed with the review below.
-
-            ---
-
             Review PR #${{ github.event.pull_request.number }} in ${{ github.repository }}.
 
             Read `REVIEW.md` for the project context, review dimensions, severity scale, and

--- a/.github/workflows/claude-dependabot.yml
+++ b/.github/workflows/claude-dependabot.yml
@@ -20,6 +20,35 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Clean up stale review comments
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR=${{ github.event.pull_request.number }}
+          REPO=${{ github.repository }}
+
+          # Dismiss all previous claude[bot] reviews
+          gh api "repos/${REPO}/pulls/${PR}/reviews" \
+            --paginate --jq '.[] | select(.user.login == "claude[bot]" and (.state == "CHANGES_REQUESTED" or .state == "COMMENTED")) | .id' \
+          | while read -r review_id; do
+              gh api -X PUT "repos/${REPO}/pulls/${PR}/reviews/${review_id}/dismissals" \
+                -f message="Superseded by new review" -f event="DISMISS" 2>/dev/null || true
+            done
+
+          # Delete all previous claude[bot] inline review comments
+          gh api "repos/${REPO}/pulls/${PR}/comments" \
+            --paginate --jq '.[] | select(.user.login == "claude[bot]") | .id' \
+          | while read -r comment_id; do
+              gh api -X DELETE "repos/${REPO}/pulls/comments/${comment_id}" 2>/dev/null || true
+            done
+
+          # Delete all previous claude[bot] issue comments (sticky comment is managed by the action)
+          gh api "repos/${REPO}/issues/${PR}/comments" \
+            --paginate --jq '.[] | select(.user.login == "claude[bot]") | .id' \
+          | while read -r comment_id; do
+              gh api -X DELETE "repos/${REPO}/issues/comments/${comment_id}" 2>/dev/null || true
+            done
+
       - name: Run Claude Dependabot Review
         id: claude-dependabot
         uses: anthropics/claude-code-action@v1


### PR DESCRIPTION
## Summary
- Moves stale review cleanup from Claude's prompt into a dedicated workflow step that runs **before** Claude starts, guaranteeing cleanup actually happens
- Adds the same cleanup step to the dependabot review workflow
- On each new review run: dismisses old reviews, deletes inline review comments, and deletes issue comments from `claude[bot]`

## Test plan
- [ ] Push a second commit to a PR and verify old claude review comments are deleted before the new review appears
- [ ] Verify dependabot PRs also clean up stale comments on re-runs