### PR TITLE
feat(editor): make ActionSheet save results with two-way binding

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,3 +1,5 @@
 dist/
 node_modules/
 public/data/
+test-results/
+playwright-report/

--- a/frontend/e2e/action-crud.spec.js
+++ b/frontend/e2e/action-crud.spec.js
@@ -1,0 +1,116 @@
+import { test, expect } from '@playwright/test';
+import { interceptLaw, gotoEditor, selectArticle, readYamlPane } from './helpers.js';
+
+test.describe('Action CRUD', () => {
+  test.beforeEach(async ({ page }) => {
+    await interceptLaw(page, 'zorgtoeslagwet', 'zorgtoeslag-stripped.yaml');
+    await gotoEditor(page);
+  });
+
+  test('add a simple literal-value action', async ({ page }) => {
+    await selectArticle(page, '5');
+
+    // Init machine_readable
+    await page.locator('[data-testid="init-mr-btn"]').click();
+    await page.waitForTimeout(300);
+
+    // Click "Voeg actie toe"
+    await page.locator('[data-testid="add-action-btn"]').click();
+    await page.waitForTimeout(300);
+
+    // ActionSheet should be open
+    const panel = page.locator('ndd-sheet');
+    await expect(panel).toBeVisible();
+
+    // Set output name
+    const outputField = panel.locator('[data-testid="action-output-field"] input');
+    await outputField.evaluate((el, val) => {
+      el.value = val;
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    }, 'bevoegd_gezag');
+    await page.waitForTimeout(100);
+
+    // The operation tree should be empty for a new action with value=''
+    // The OperationSettings won't show since there's no operation
+    // Let's save and check the YAML
+    await panel.locator('ndd-button:has-text("Opslaan")').click();
+    await page.waitForTimeout(300);
+
+    // Verify YAML
+    const yaml = await readYamlPane(page);
+    expect(yaml.execution.actions).toHaveLength(1);
+    expect(yaml.execution.actions[0].output).toBe('bevoegd_gezag');
+  });
+
+  test('add action with output name and literal value via YAML editing', async ({ page }) => {
+    await selectArticle(page, '8');
+
+    // Init machine_readable
+    await page.locator('[data-testid="init-mr-btn"]').click();
+    await page.waitForTimeout(300);
+
+    // Add an action
+    await page.locator('[data-testid="add-action-btn"]').click();
+    await page.waitForTimeout(300);
+
+    const panel = page.locator('ndd-sheet');
+
+    // Set output name
+    const outputField = panel.locator('[data-testid="action-output-field"] input');
+    await outputField.evaluate((el, val) => {
+      el.value = val;
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    }, 'wet_naam');
+    await page.waitForTimeout(100);
+
+    // Save actionsheet
+    await panel.locator('ndd-button:has-text("Opslaan")').click();
+    await page.waitForTimeout(300);
+
+    // Now manually edit the YAML to set the value (simpler than building UI for literal string values)
+    const textarea = page.locator('.editor-yaml-textarea');
+    const currentYaml = await textarea.inputValue();
+    const updatedYaml = currentYaml.replace("value: ''", "value: Wet op de zorgtoeslag");
+    await textarea.evaluate((el, val) => {
+      el.value = val;
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    }, updatedYaml);
+    await page.waitForTimeout(200);
+
+    // Read back YAML
+    const yaml = await readYamlPane(page);
+    expect(yaml.execution.actions[0].output).toBe('wet_naam');
+    expect(yaml.execution.actions[0].value).toBe('Wet op de zorgtoeslag');
+  });
+
+  test('add action with operation type and values', async ({ page }) => {
+    await selectArticle(page, '2');
+
+    // Init and add outputs first (needed for action output binding)
+    await page.locator('[data-testid="init-mr-btn"]').click();
+    await page.waitForTimeout(300);
+
+    // Add an action
+    await page.locator('[data-testid="add-action-btn"]').click();
+    await page.waitForTimeout(300);
+
+    const panel = page.locator('ndd-sheet');
+
+    // Set output name
+    const outputField = panel.locator('[data-testid="action-output-field"] input');
+    await outputField.evaluate((el, val) => {
+      el.value = val;
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    }, 'hoogte_zorgtoeslag');
+    await page.waitForTimeout(100);
+
+    // No OperationSettings visible yet because action.value is '' (not an operation)
+    // Save and verify
+    await panel.locator('ndd-button:has-text("Opslaan")').click();
+    await page.waitForTimeout(300);
+
+    const yaml = await readYamlPane(page);
+    expect(yaml.execution.actions).toHaveLength(1);
+    expect(yaml.execution.actions[0].output).toBe('hoogte_zorgtoeslag');
+  });
+});

--- a/frontend/e2e/complex-actions.spec.js
+++ b/frontend/e2e/complex-actions.spec.js
@@ -1,0 +1,189 @@
+import { test, expect } from '@playwright/test';
+import { interceptLaw, gotoEditor, selectArticle, readYamlPane } from './helpers.js';
+import yaml from 'js-yaml';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Create a fixture with article 2 having definitions, params, inputs, outputs
+ * but no actions yet — so we can test building complex actions from scratch.
+ */
+function createFixtureWithMetadata() {
+  const base = readFileSync(resolve(import.meta.dirname, 'fixtures/zorgtoeslag-stripped.yaml'), 'utf-8');
+  const law = yaml.load(base);
+
+  law.articles[2].machine_readable = {
+    definitions: {
+      drempelinkomen_alleenstaande: { value: 3971900 },
+      percentage_drempelinkomen_alleenstaande: { value: 0.01896 },
+    },
+    execution: {
+      parameters: [{ name: 'bsn', type: 'string', required: true }],
+      input: [
+        { name: 'leeftijd', type: 'number', source: { regulation: 'wet_basisregistratie_personen', output: 'leeftijd', parameters: { bsn: '$bsn' } } },
+        { name: 'is_verzekerde', type: 'boolean', source: { regulation: 'zorgverzekeringswet', output: 'is_verzekerd', parameters: { bsn: '$bsn' } } },
+      ],
+      output: [
+        { name: 'heeft_recht_op_zorgtoeslag', type: 'boolean' },
+        { name: 'hoogte_zorgtoeslag', type: 'amount', type_spec: { unit: 'eurocent' } },
+      ],
+      actions: [],
+    },
+  };
+
+  return yaml.dump(law, { lineWidth: 80, noRefs: true });
+}
+
+test.describe('Complex actions', () => {
+  test('add action with AND operation containing comparison conditions', async ({ page }) => {
+    const fixtureYaml = createFixtureWithMetadata();
+
+    await page.route('**/api/corpus/laws/zorgtoeslagwet', route =>
+      route.fulfill({ status: 200, contentType: 'text/yaml', body: fixtureYaml })
+    );
+    await page.goto('/editor.html?law=zorgtoeslagwet');
+    await page.waitForSelector('ndd-document-tab-bar-item', { timeout: 10_000 });
+
+    await selectArticle(page, '2');
+    await page.waitForTimeout(300);
+
+    // Add an action
+    await page.locator('[data-testid="add-action-btn"]').click();
+    await page.waitForTimeout(300);
+
+    const panel = page.locator('ndd-sheet');
+
+    // Set output
+    const outputField = panel.locator('[data-testid="action-output-field"] input');
+    await outputField.evaluate((el, val) => {
+      el.value = val;
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    }, 'heeft_recht_op_zorgtoeslag');
+    await page.waitForTimeout(100);
+
+    // New actions have value='' — no OperationSettings shown
+    // We need to close and use YAML editing to set up the initial operation structure
+    await panel.locator('ndd-button:has-text("Opslaan")').click();
+    await page.waitForTimeout(300);
+
+    // Edit YAML directly to set up the AND operation with conditions
+    const textarea = page.locator('.editor-yaml-textarea');
+    const currentYaml = await textarea.inputValue();
+
+    // Replace the action's value with an AND operation
+    const updatedYaml = currentYaml.replace(
+      "value: ''",
+      `value:
+            operation: AND
+            conditions:
+              - operation: GREATER_THAN_OR_EQUAL
+                subject: $leeftijd
+                value: 18
+              - operation: EQUALS
+                subject: $is_verzekerde
+                value: true`
+    );
+
+    await textarea.evaluate((el, val) => {
+      el.value = val;
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    }, updatedYaml);
+    await page.waitForTimeout(300);
+
+    // Verify YAML round-trips correctly
+    const parsedYaml = await readYamlPane(page);
+    const action = parsedYaml.execution.actions[0];
+    expect(action.output).toBe('heeft_recht_op_zorgtoeslag');
+    expect(action.value.operation).toBe('AND');
+    expect(action.value.conditions).toHaveLength(2);
+    expect(action.value.conditions[0].operation).toBe('GREATER_THAN_OR_EQUAL');
+    expect(action.value.conditions[0].subject).toBe('$leeftijd');
+    expect(action.value.conditions[0].value).toBe(18);
+    expect(action.value.conditions[1].operation).toBe('EQUALS');
+    expect(action.value.conditions[1].subject).toBe('$is_verzekerde');
+    expect(action.value.conditions[1].value).toBe(true);
+
+    // Now open the ActionSheet and verify the operation tree renders
+    const actionItem = page.locator('ndd-list-item:has(ndd-text-cell:has-text("heeft_recht_op_zorgtoeslag"))').last();
+    await actionItem.locator('ndd-button:has-text("Bewerk")').click();
+    await page.waitForTimeout(300);
+
+    // ActionSheet should show the AND operation
+    const panel2 = page.locator('ndd-sheet');
+    await expect(panel2).toBeVisible();
+
+    // The ActionSheet initially selects the deepest operation in the tree.
+    // Verify the operation settings panel rendered (has a type dropdown)
+    const typeSelect = panel2.locator('[data-testid="operation-type-dropdown"] select');
+    const currentType = await typeSelect.evaluate(el => el.value);
+    // Should be one of the comparison ops (the leaves of the AND tree)
+    expect(['EQUALS', 'GREATER_THAN_OR_EQUAL']).toContain(currentType);
+
+    // Verify the "Bovenliggende operaties" section is shown (since we're viewing a child)
+    await expect(panel2.locator('text=Bovenliggende operaties')).toBeVisible();
+
+    // Close
+    await panel2.locator('ndd-button:has-text("Opslaan")').click();
+    await page.waitForTimeout(200);
+  });
+
+  test('add nested operation via button and verify in YAML', async ({ page }) => {
+    const fixtureYaml = createFixtureWithMetadata();
+
+    await page.route('**/api/corpus/laws/zorgtoeslagwet', route =>
+      route.fulfill({ status: 200, contentType: 'text/yaml', body: fixtureYaml })
+    );
+    await page.goto('/editor.html?law=zorgtoeslagwet');
+    await page.waitForSelector('ndd-document-tab-bar-item', { timeout: 10_000 });
+
+    await selectArticle(page, '2');
+    await page.waitForTimeout(300);
+
+    // Set up an action with a MAX operation via YAML editing
+    const textarea = page.locator('.editor-yaml-textarea');
+    const currentYaml = await textarea.inputValue();
+
+    // Replace "actions: []" with a real action
+    const updatedYaml = currentYaml.replace(
+      'actions: []',
+      `actions:
+    - output: hoogte_zorgtoeslag
+      value:
+        operation: MAX
+        values:
+          - 0`
+    );
+
+    await textarea.evaluate((el, val) => {
+      el.value = val;
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    }, updatedYaml);
+    await page.waitForTimeout(300);
+
+    // Open the action sheet
+    const actionItem = page.locator('ndd-list-item:has(ndd-text-cell:has-text("hoogte_zorgtoeslag"))').last();
+    await actionItem.locator('ndd-button:has-text("Bewerk")').click();
+    await page.waitForTimeout(300);
+
+    const panel = page.locator('ndd-sheet');
+
+    // Click "Voeg operatie toe" to add a nested operation (use evaluate for ndd-button)
+    await panel.locator('[data-testid="add-nested-op-btn"]').evaluate(el => el.click());
+    await page.waitForTimeout(200);
+
+    // Save
+    await panel.locator('ndd-button:has-text("Opslaan")').click();
+    await page.waitForTimeout(300);
+
+    // Verify YAML has the nested operation
+    const parsedYaml = await readYamlPane(page);
+    const action = parsedYaml.execution.actions[0];
+    expect(action.output).toBe('hoogte_zorgtoeslag');
+    expect(action.value.operation).toBe('MAX');
+    expect(action.value.values).toHaveLength(2);
+    expect(action.value.values[0]).toBe(0);
+    // The nested op should be an ADD with empty values
+    expect(action.value.values[1].operation).toBe('ADD');
+    expect(action.value.values[1].values).toEqual([]);
+  });
+});

--- a/frontend/e2e/complex-actions.spec.js
+++ b/frontend/e2e/complex-actions.spec.js
@@ -167,23 +167,21 @@ test.describe('Complex actions', () => {
 
     const panel = page.locator('ndd-sheet');
 
-    // Click "Voeg operatie toe" to add a nested operation (use evaluate for ndd-button)
+    // Click "Voeg operatie toe" to add a nested ADD (empty values[])
     await panel.locator('[data-testid="add-nested-op-btn"]').evaluate(el => el.click());
     await page.waitForTimeout(200);
 
-    // Save
+    // Save should be rejected because the nested ADD has no values yet —
+    // saving a structurally-incomplete operation would produce YAML the
+    // engine cannot execute.
     await panel.locator('ndd-button:has-text("Opslaan")').click();
     await page.waitForTimeout(300);
 
-    // Verify YAML has the nested operation
-    const parsedYaml = await readYamlPane(page);
-    const action = parsedYaml.execution.actions[0];
-    expect(action.output).toBe('hoogte_zorgtoeslag');
-    expect(action.value.operation).toBe('MAX');
-    expect(action.value.values).toHaveLength(2);
-    expect(action.value.values[0]).toBe(0);
-    // The nested op should be an ADD with empty values
-    expect(action.value.values[1].operation).toBe('ADD');
-    expect(action.value.values[1].values).toEqual([]);
+    // The action sheet should still be open (save was blocked)
+    await expect(panel).toBeVisible();
+
+    // The middle pane should display the parse error from handleActionSave
+    const error = page.locator('.editor-parse-error-detail');
+    await expect(error).toContainText("Operatie 'ADD' is nog niet ingevuld");
   });
 });

--- a/frontend/e2e/definitions.spec.js
+++ b/frontend/e2e/definitions.spec.js
@@ -1,0 +1,64 @@
+import { test, expect } from '@playwright/test';
+import { interceptLaw, gotoEditor, selectArticle, readYamlPane, waitForSheet, fillSheetTextField, fillSheetNumberField, saveSheet } from './helpers.js';
+
+test.describe('Definitions', () => {
+  test.beforeEach(async ({ page }) => {
+    await interceptLaw(page, 'zorgtoeslagwet', 'zorgtoeslag-stripped.yaml');
+    await gotoEditor(page);
+  });
+
+  test('add a numeric definition to article 1a', async ({ page }) => {
+    await selectArticle(page, '1a');
+
+    // Init machine_readable
+    await page.locator('[data-testid="init-mr-btn"]').click();
+    await page.waitForTimeout(300);
+
+    // Click "Nieuwe definitie" button
+    await page.locator('ndd-button:has-text("Nieuwe definitie")').click();
+    await waitForSheet(page);
+
+    // Set name
+    await fillSheetTextField(page, 'Naam', 'verantwoordelijke_autoriteit');
+
+    // Set value (new definitions default to number)
+    await fillSheetNumberField(page, 'Waarde', 42);
+
+    // Save
+    await saveSheet(page);
+
+    // Verify the definition appears in the machine readable view
+    const mrPane = page.locator('[data-testid="machine-readable"]');
+    await expect(mrPane).toContainText('verantwoordelijke_autoriteit');
+
+    // Verify YAML
+    const yaml = await readYamlPane(page);
+    expect(yaml.definitions).toHaveProperty('verantwoordelijke_autoriteit');
+    // New definitions from EditSheet always store as {value: N} format
+    expect(yaml.definitions.verantwoordelijke_autoriteit).toEqual({ value: 42 });
+  });
+
+  test('add numeric definitions to article 2', async ({ page }) => {
+    await selectArticle(page, '2');
+
+    // Init machine_readable
+    await page.locator('[data-testid="init-mr-btn"]').click();
+    await page.waitForTimeout(300);
+
+    // Add definition: drempelinkomen_alleenstaande = 3971900
+    await page.locator('ndd-button:has-text("Nieuwe definitie")').click();
+    await waitForSheet(page);
+
+    await fillSheetTextField(page, 'Naam', 'drempelinkomen_alleenstaande');
+    await fillSheetNumberField(page, 'Waarde', 3971900);
+    await saveSheet(page);
+
+    // Verify definition appears
+    const mrPane = page.locator('[data-testid="machine-readable"]');
+    await expect(mrPane).toContainText('drempelinkomen_alleenstaande');
+
+    // Verify YAML
+    const yaml = await readYamlPane(page);
+    expect(yaml.definitions.drempelinkomen_alleenstaande).toEqual({ value: 3971900 });
+  });
+});

--- a/frontend/e2e/fixtures/zorgtoeslag-full.yaml
+++ b/frontend/e2e/fixtures/zorgtoeslag-full.yaml
@@ -1,5 +1,5 @@
 ---
-$schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/heads/main/schema/v0.5.0/schema.json
+$schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/tags/schema-v0.5.1/schema/v0.5.1/schema.json
 $id: zorgtoeslagwet
 regulatory_layer: WET
 publication_date: '2024-12-20'

--- a/frontend/e2e/fixtures/zorgtoeslag-full.yaml
+++ b/frontend/e2e/fixtures/zorgtoeslag-full.yaml
@@ -1,0 +1,324 @@
+---
+$schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/heads/main/schema/v0.5.0/schema.json
+$id: zorgtoeslagwet
+regulatory_layer: WET
+publication_date: '2024-12-20'
+valid_from: '2025-01-01'
+bwb_id: BWBR0018451
+url: https://wetten.overheid.nl/BWBR0018451/2025-01-01
+name: '#wet_naam'
+competent_authority: '#bevoegd_gezag'
+articles:
+  - number: '1'
+    text: |-
+      In deze wet en de daarop berustende bepalingen wordt verstaan onder:
+
+      a. verzekerde: degene die ingevolge de Zorgverzekeringswet verzekerd is; b. toetsingsinkomen: het verzamelinkomen,
+      bedoeld in artikel 2.18 van de Wet inkomstenbelasting 2001; c. drempelinkomen: het bedrag, bedoeld in artikel 2,
+      tweede lid; d. normpremie: de premie, berekend overeenkomstig artikel 2; e. standaardpremie: de premie, bedoeld in
+      artikel 4.
+    url: https://wetten.overheid.nl/BWBR0018451/2025-01-01#Artikel1
+  - number: 1a
+    text: |-
+      In deze wet en de daarop berustende bepalingen wordt verstaan onder Onze Minister: Onze Minister van
+      Volksgezondheid, Welzijn en Sport.
+    url: https://wetten.overheid.nl/BWBR0018451/2025-01-01#Artikel1a
+    machine_readable:
+      definitions:
+        verantwoordelijke_autoriteit: Minister van Volksgezondheid, Welzijn en Sport
+  - number: '2'
+    text: |-
+      1. Indien de normpremie voor een verzekerde in het berekeningsjaar minder bedraagt dan de standaardpremie in dat
+      jaar, heeft de verzekerde aanspraak op een zorgtoeslag ter grootte van dat verschil. Voor een verzekerde met een
+      toeslagpartner geldt het dubbele van de standaardpremie en worden de verzekerde en de toeslagpartner geacht
+      gezamenlijk aanspraak te maken op zorgtoeslag.
+
+      2. De normpremie bedraagt een percentage van het drempelinkomen in het berekeningsjaar, vermeerderd met een
+      percentage van het toetsingsinkomen van de verzekerde. Ingeval de verzekerde een toeslagpartner heeft, wordt het
+      gezamenlijk toetsingsinkomen van de verzekerde en de toeslagpartner in aanmerking genomen.
+
+      3. De percentages, bedoeld in het tweede lid, bedragen voor een verzekerde met een toeslagpartner 4,273 procent van
+      het drempelinkomen, vermeerderd met 13,700 procent van het toetsingsinkomen, en voor een verzekerde zonder
+      toeslagpartner 1,896 procent van het drempelinkomen, vermeerderd met 13,700 procent van het toetsingsinkomen. Bij
+      ministeriële regeling kunnen deze percentages worden gewijzigd.
+
+      4. In afwijking van het eerste lid bedraagt de aanspraak op een zorgtoeslag voor een verzekerde met een partner die
+      geen verzekerde is, vijftig procent van het op grond van het eerste lid berekende bedrag.
+
+      5. De aanspraak op een zorgtoeslag wordt voor iedere kalendermaand afzonderlijk bepaald.
+
+      6. Bij ministeriële regeling kunnen nadere regels worden gesteld.
+
+      7. Onze Minister zendt een voornemen tot wijziging van de percentages, bedoeld in het derde lid, ten minste twee
+      weken voor de vaststelling aan beide kamers der Staten-Generaal.
+    url: https://wetten.overheid.nl/BWBR0018451/2025-01-01#Artikel2
+    machine_readable:
+      definitions:
+        drempelinkomen_alleenstaande:
+          value: 3971900
+        drempelinkomen_aanvrager_met_toeslagpartner:
+          value: 5587500
+        percentage_drempelinkomen_alleenstaande:
+          value: 0.01896
+        percentage_drempelinkomen_partner:
+          value: 0.04273
+        percentage_toetsingsinkomen:
+          value: 0.137
+      execution:
+        produces:
+          legal_character: BESCHIKKING
+          decision_type: TOEKENNING
+        parameters:
+          - name: bsn
+            type: string
+            required: true
+        input:
+          - name: is_verzekerde
+            type: boolean
+            source:
+              regulation: zorgverzekeringswet
+              output: is_verzekerd
+              parameters:
+                bsn: $bsn
+          - name: heeft_toeslagpartner
+            type: boolean
+            source:
+              regulation: algemene_wet_inkomensafhankelijke_regelingen
+              output: heeft_toeslagpartner
+              parameters:
+                bsn: $bsn
+          # Art. 2 lid 2: "wordt het gezamenlijk toetsingsinkomen van de verzekerde en
+          # de toeslagpartner in aanmerking genomen."
+          # TODO #377: Bij partners moet het gezamenlijke toetsingsinkomen worden gebruikt.
+          # Geblokkeerd: engine ondersteunt geen conditionele input-resolutie — ophalen
+          # partner-toetsingsinkomen via AWIR art. 8 met partner_bsn faalt bij null BSN.
+          - name: toetsingsinkomen
+            type: amount
+            source:
+              regulation: algemene_wet_inkomensafhankelijke_regelingen
+              output: toetsingsinkomen
+              parameters:
+                bsn: $bsn
+            type_spec:
+              unit: eurocent
+          - name: standaardpremie
+            type: amount
+            source:
+              output: standaardpremie
+            type_spec:
+              unit: eurocent
+          - name: vermogen_onder_grens
+            type: boolean
+            source:
+              output: vermogen_onder_grens
+        output:
+          - name: heeft_recht_op_zorgtoeslag
+            type: boolean
+          - name: hoogte_zorgtoeslag
+            type: amount
+            type_spec:
+              unit: eurocent
+        actions:
+          - output: hoogte_zorgtoeslag
+            value:
+              operation: MAX
+              values:
+                - 0
+                - operation: SUBTRACT
+                  values:
+                    - operation: IF
+                      cases:
+                        - when:
+                            operation: EQUALS
+                            subject: $heeft_toeslagpartner
+                            value: true
+                          then:
+                            operation: MULTIPLY
+                            values:
+                              - 2
+                              - $standaardpremie
+                      default: $standaardpremie
+                    - operation: ADD
+                      values:
+                        - operation: MULTIPLY
+                          values:
+                            - operation: IF
+                              cases:
+                                - when:
+                                    operation: EQUALS
+                                    subject: $heeft_toeslagpartner
+                                    value: true
+                                  then: $percentage_drempelinkomen_partner
+                              default: $percentage_drempelinkomen_alleenstaande
+                            - operation: MIN
+                              values:
+                                - $toetsingsinkomen
+                                - operation: IF
+                                  cases:
+                                    - when:
+                                        operation: EQUALS
+                                        subject: $heeft_toeslagpartner
+                                        value: true
+                                      then: $drempelinkomen_aanvrager_met_toeslagpartner
+                                  default: $drempelinkomen_alleenstaande
+                        - operation: IF
+                          cases:
+                            - when:
+                                operation: GREATER_THAN
+                                subject: $toetsingsinkomen
+                                value:
+                                  operation: IF
+                                  cases:
+                                    - when:
+                                        operation: EQUALS
+                                        subject: $heeft_toeslagpartner
+                                        value: true
+                                      then: $drempelinkomen_aanvrager_met_toeslagpartner
+                                  default: $drempelinkomen_alleenstaande
+                              then:
+                                operation: MULTIPLY
+                                values:
+                                  - operation: SUBTRACT
+                                    values:
+                                      - $toetsingsinkomen
+                                      - operation: IF
+                                        cases:
+                                          - when:
+                                              operation: EQUALS
+                                              subject: $heeft_toeslagpartner
+                                              value: true
+                                            then: $drempelinkomen_aanvrager_met_toeslagpartner
+                                        default: $drempelinkomen_alleenstaande
+                                  - $percentage_toetsingsinkomen
+                          default: 0
+          - output: heeft_recht_op_zorgtoeslag
+            value:
+              operation: AND
+              conditions:
+                - operation: EQUALS
+                  subject: $is_verzekerde
+                  value: true
+                - operation: EQUALS
+                  subject: $vermogen_onder_grens
+                  value: true
+                - operation: GREATER_THAN
+                  subject: $hoogte_zorgtoeslag
+                  value: 0
+  - number: '3'
+    text: |-
+      Een verzekerde heeft geen aanspraak op zorgtoeslag indien de rendementsgrondslag, bedoeld in artikel 5.2 van de Wet
+      inkomstenbelasting 2001, van de verzekerde of, ingeval de verzekerde een toeslagpartner heeft, de gezamenlijke
+      rendementsgrondslag van de verzekerde en de toeslagpartner op de peildatum meer bedraagt dan € 141.896 voor een
+      verzekerde zonder toeslagpartner, onderscheidenlijk € 179.429 voor een verzekerde met een toeslagpartner.
+    url: https://wetten.overheid.nl/BWBR0018451/2025-01-01#Artikel3
+    machine_readable:
+      definitions:
+        vermogensgrens_alleenstaand:
+          value: 14189600
+        vermogensgrens_aanvrager_met_toeslagpartner:
+          value: 17942900
+      execution:
+        produces:
+          legal_character: TOETS
+          decision_type: GOEDKEURING
+        parameters:
+          - name: bsn
+            type: string
+            required: true
+        input:
+          # Art. 3: "de gezamenlijke rendementsgrondslag van de verzekerde en de
+          # toeslagpartner op de peildatum"
+          # TODO #377: Bij partners moet de gezamenlijke rendementsgrondslag worden
+          # gebruikt. Geblokkeerd: zelfde engine-beperking als bij toetsingsinkomen.
+          - name: vermogen
+            type: amount
+            source:
+              regulation: wet_inkomstenbelasting_2001
+              output: rendementsgrondslag
+              parameters:
+                bsn: $bsn
+            type_spec:
+              unit: eurocent
+          - name: heeft_toeslagpartner
+            type: boolean
+            source:
+              regulation: algemene_wet_inkomensafhankelijke_regelingen
+              output: heeft_toeslagpartner
+              parameters:
+                bsn: $bsn
+        output:
+          - name: vermogen_onder_grens
+            type: boolean
+        actions:
+          - output: vermogen_onder_grens
+            value:
+              operation: LESS_THAN_OR_EQUAL
+              subject: $vermogen
+              value:
+                operation: IF
+                cases:
+                  - when:
+                      operation: EQUALS
+                      subject: $heeft_toeslagpartner
+                      value: true
+                    then: $vermogensgrens_aanvrager_met_toeslagpartner
+                default: $vermogensgrens_alleenstaand
+  - number: '4'
+    text: |-
+      Onze Minister stelt uiterlijk 22 dagen voorafgaande aan het berekeningsjaar bij regeling de standaardpremie voor
+      het berekeningsjaar vast.
+    url: https://wetten.overheid.nl/BWBR0018451/2025-01-01#Artikel4
+    machine_readable:
+      open_terms:
+        - id: standaardpremie
+          type: amount
+          required: true
+          delegated_to: minister
+          delegation_type: MINISTERIELE_REGELING
+          legal_basis: artikel 4 Wet op de zorgtoeslag
+      execution:
+        output:
+          - name: standaardpremie
+            type: amount
+            type_spec:
+              unit: eurocent
+        actions:
+          - output: standaardpremie
+            value: $standaardpremie
+  - number: 4a
+    text: |-
+      Voor de persoon, bedoeld in artikel 69 van de Zorgverzekeringswet, wordt de standaardpremie aangepast aan de hand
+      van de verhouding tussen de zorguitgaven per verzekerde in het land waar de persoon woont en de zorguitgaven per
+      verzekerde in Nederland.
+    url: https://wetten.overheid.nl/BWBR0018451/2025-01-01#Artikel4a
+  - number: '5'
+    text: |-
+      1. De Dienst Toeslagen is belast met de uitvoering van deze wet.
+
+      2. Tot en met 4. [Procedurele bepalingen over aanvraag en betaling]
+
+      5. De zorgtoeslag komt ten laste van het Rijk.
+    url: https://wetten.overheid.nl/BWBR0018451/2025-01-01#Artikel5
+    machine_readable:
+      execution:
+        actions:
+          - output: bevoegd_gezag
+            value: Dienst Toeslagen
+  - number: '6'
+    text: |-
+      Onze Minister zendt binnen vier jaar na de inwerkingtreding van deze wet, en vervolgens telkens na vier jaar, aan
+      de Staten-Generaal een verslag over de doeltreffendheid en de effecten van deze wet in de praktijk.
+    url: https://wetten.overheid.nl/BWBR0018451/2025-01-01#Artikel6
+  - number: '7'
+    text: |-
+      Deze wet treedt in werking op een bij koninklijk besluit te bepalen tijdstip.
+    url: https://wetten.overheid.nl/BWBR0018451/2025-01-01#Artikel7
+  - number: '8'
+    text: |-
+      Deze wet wordt aangehaald als: Wet op de zorgtoeslag.
+    url: https://wetten.overheid.nl/BWBR0018451/2025-01-01#Artikel8
+    machine_readable:
+      execution:
+        actions:
+          - output: wet_naam
+            value: Wet op de zorgtoeslag

--- a/frontend/e2e/fixtures/zorgtoeslag-stripped.yaml
+++ b/frontend/e2e/fixtures/zorgtoeslag-stripped.yaml
@@ -1,0 +1,90 @@
+---
+$schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/heads/main/schema/v0.4.0/schema.json
+$id: zorgtoeslagwet
+regulatory_layer: WET
+publication_date: '2024-12-20'
+valid_from: '2025-01-01'
+bwb_id: BWBR0018451
+url: https://wetten.overheid.nl/BWBR0018451/2025-01-01
+name: '#wet_naam'
+competent_authority: '#bevoegd_gezag'
+articles:
+  - number: '1'
+    text: |-
+      In deze wet en de daarop berustende bepalingen wordt verstaan onder:
+
+      a. verzekerde: degene die ingevolge de Zorgverzekeringswet verzekerd is; b. toetsingsinkomen: het verzamelinkomen,
+      bedoeld in artikel 2.18 van de Wet inkomstenbelasting 2001; c. drempelinkomen: het bedrag, bedoeld in artikel 2,
+      tweede lid; d. normpremie: de premie, berekend overeenkomstig artikel 2; e. standaardpremie: de premie, bedoeld in
+      artikel 4.
+    url: https://wetten.overheid.nl/BWBR0018451/2025-01-01#Artikel1
+  - number: 1a
+    text: |-
+      In deze wet en de daarop berustende bepalingen wordt verstaan onder Onze Minister: Onze Minister van
+      Volksgezondheid, Welzijn en Sport.
+    url: https://wetten.overheid.nl/BWBR0018451/2025-01-01#Artikel1a
+  - number: '2'
+    text: |-
+      1. Indien de normpremie voor een verzekerde in het berekeningsjaar minder bedraagt dan de standaardpremie in dat
+      jaar, heeft de verzekerde aanspraak op een zorgtoeslag ter grootte van dat verschil. Voor een verzekerde met een
+      toeslagpartner geldt het dubbele van de standaardpremie en worden de verzekerde en de toeslagpartner geacht
+      gezamenlijk aanspraak te maken op zorgtoeslag.
+
+      2. De normpremie bedraagt een percentage van het drempelinkomen in het berekeningsjaar, vermeerderd met een
+      percentage van het toetsingsinkomen van de verzekerde. Ingeval de verzekerde een toeslagpartner heeft, wordt het
+      gezamenlijk toetsingsinkomen van de verzekerde en de toeslagpartner in aanmerking genomen.
+
+      3. De percentages, bedoeld in het tweede lid, bedragen voor een verzekerde met een toeslagpartner 4,273 procent van
+      het drempelinkomen, vermeerderd met 13,700 procent van het toetsingsinkomen, en voor een verzekerde zonder
+      toeslagpartner 1,896 procent van het drempelinkomen, vermeerderd met 13,700 procent van het toetsingsinkomen. Bij
+      ministeriële regeling kunnen deze percentages worden gewijzigd.
+
+      4. In afwijking van het eerste lid bedraagt de aanspraak op een zorgtoeslag voor een verzekerde met een partner die
+      geen verzekerde is, vijftig procent van het op grond van het eerste lid berekende bedrag.
+
+      5. De aanspraak op een zorgtoeslag wordt voor iedere kalendermaand afzonderlijk bepaald.
+
+      6. Bij ministeriële regeling kunnen nadere regels worden gesteld.
+
+      7. Onze Minister zendt een voornemen tot wijziging van de percentages, bedoeld in het derde lid, ten minste twee
+      weken voor de vaststelling aan beide kamers der Staten-Generaal.
+    url: https://wetten.overheid.nl/BWBR0018451/2025-01-01#Artikel2
+  - number: '3'
+    text: |-
+      Een verzekerde heeft geen aanspraak op zorgtoeslag indien de rendementsgrondslag, bedoeld in artikel 5.2 van de Wet
+      inkomstenbelasting 2001, van de verzekerde of, ingeval de verzekerde een toeslagpartner heeft, de gezamenlijke
+      rendementsgrondslag van de verzekerde en de toeslagpartner op de peildatum meer bedraagt dan € 141.896 voor een
+      verzekerde zonder toeslagpartner, onderscheidenlijk € 179.429 voor een verzekerde met een toeslagpartner.
+    url: https://wetten.overheid.nl/BWBR0018451/2025-01-01#Artikel3
+  - number: '4'
+    text: |-
+      Onze Minister stelt uiterlijk 22 dagen voorafgaande aan het berekeningsjaar bij regeling de standaardpremie voor
+      het berekeningsjaar vast.
+    url: https://wetten.overheid.nl/BWBR0018451/2025-01-01#Artikel4
+  - number: 4a
+    text: |-
+      Voor de persoon, bedoeld in artikel 69 van de Zorgverzekeringswet, wordt de standaardpremie aangepast aan de hand
+      van de verhouding tussen de zorguitgaven per verzekerde in het land waar de persoon woont en de zorguitgaven per
+      verzekerde in Nederland.
+    url: https://wetten.overheid.nl/BWBR0018451/2025-01-01#Artikel4a
+  - number: '5'
+    text: |-
+      1. De Dienst Toeslagen is belast met de uitvoering van deze wet.
+
+      2. Tot en met 4. [Procedurele bepalingen over aanvraag en betaling]
+
+      5. De zorgtoeslag komt ten laste van het Rijk.
+    url: https://wetten.overheid.nl/BWBR0018451/2025-01-01#Artikel5
+  - number: '6'
+    text: |-
+      Onze Minister zendt binnen vier jaar na de inwerkingtreding van deze wet, en vervolgens telkens na vier jaar, aan
+      de Staten-Generaal een verslag over de doeltreffendheid en de effecten van deze wet in de praktijk.
+    url: https://wetten.overheid.nl/BWBR0018451/2025-01-01#Artikel6
+  - number: '7'
+    text: |-
+      Deze wet treedt in werking op een bij koninklijk besluit te bepalen tijdstip.
+    url: https://wetten.overheid.nl/BWBR0018451/2025-01-01#Artikel7
+  - number: '8'
+    text: |-
+      Deze wet wordt aangehaald als: Wet op de zorgtoeslag.
+    url: https://wetten.overheid.nl/BWBR0018451/2025-01-01#Artikel8

--- a/frontend/e2e/fixtures/zorgtoeslag-stripped.yaml
+++ b/frontend/e2e/fixtures/zorgtoeslag-stripped.yaml
@@ -1,5 +1,5 @@
 ---
-$schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/heads/main/schema/v0.4.0/schema.json
+$schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/tags/schema-v0.5.1/schema/v0.5.1/schema.json
 $id: zorgtoeslagwet
 regulatory_layer: WET
 publication_date: '2024-12-20'

--- a/frontend/e2e/full-roundtrip.spec.js
+++ b/frontend/e2e/full-roundtrip.spec.js
@@ -1,0 +1,162 @@
+import { test, expect } from '@playwright/test';
+import { interceptLaw, gotoEditor, selectArticle, readYamlPane } from './helpers.js';
+import yaml from 'js-yaml';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Load the original (with machine_readable) zorgtoeslag YAML.
+ */
+function loadOriginal() {
+  const path = resolve(import.meta.dirname, '../../corpus/regulation/nl/wet/wet_op_de_zorgtoeslag/2025-01-01.yaml');
+  return yaml.load(readFileSync(path, 'utf-8'));
+}
+
+test.describe('Full round-trip', () => {
+  test('YAML textarea round-trips without data loss', async ({ page }) => {
+    // Load the FULL zorgtoeslag (with machine_readable) instead of stripped
+    const original = loadOriginal();
+    const fullYaml = readFileSync(
+      resolve(import.meta.dirname, '../../corpus/regulation/nl/wet/wet_op_de_zorgtoeslag/2025-01-01.yaml'),
+      'utf-8'
+    );
+
+    await page.route('**/api/corpus/laws/zorgtoeslagwet', route =>
+      route.fulfill({ status: 200, contentType: 'text/yaml', body: fullYaml })
+    );
+    await page.goto('/editor.html?law=zorgtoeslagwet');
+    await page.waitForSelector('ndd-document-tab-bar-item', { timeout: 10_000 });
+
+    // Article 1a: simple definition
+    await selectArticle(page, '1a');
+    await page.waitForTimeout(300);
+    const yaml1a = await readYamlPane(page);
+    expect(yaml1a.definitions.verantwoordelijke_autoriteit).toBe(
+      original.articles[1].machine_readable.definitions.verantwoordelijke_autoriteit
+    );
+
+    // Article 2: complex structure with definitions, execution, actions
+    await selectArticle(page, '2');
+    await page.waitForTimeout(300);
+    const yaml2 = await readYamlPane(page);
+
+    // Verify definitions
+    const origDefs = original.articles[2].machine_readable.definitions;
+    expect(yaml2.definitions.drempelinkomen_alleenstaande).toEqual(origDefs.drempelinkomen_alleenstaande);
+    expect(yaml2.definitions.percentage_toetsingsinkomen).toEqual(origDefs.percentage_toetsingsinkomen);
+
+    // Verify execution structure
+    expect(yaml2.execution.produces.legal_character).toBe('BESCHIKKING');
+    expect(yaml2.execution.produces.decision_type).toBe('TOEKENNING');
+    expect(yaml2.execution.parameters[0].name).toBe('bsn');
+    const origExec = original.articles[2].machine_readable.execution;
+    expect(yaml2.execution.input).toHaveLength(origExec.input.length);
+    expect(yaml2.execution.output).toHaveLength(origExec.output.length);
+    expect(yaml2.execution.actions).toHaveLength(origExec.actions.length);
+
+    // Verify action structure (hoogte_zorgtoeslag - MAX operation)
+    const hoogte = yaml2.execution.actions[0];
+    expect(hoogte.output).toBe('hoogte_zorgtoeslag');
+    expect(hoogte.value.operation).toBe('MAX');
+    expect(hoogte.value.values).toHaveLength(2);
+    expect(hoogte.value.values[0]).toBe(0);
+    expect(hoogte.value.values[1].operation).toBe('SUBTRACT');
+
+    // Verify action structure (heeft_recht - AND operation)
+    const heeftRecht = yaml2.execution.actions[1];
+    expect(heeftRecht.output).toBe('heeft_recht_op_zorgtoeslag');
+    expect(heeftRecht.value.operation).toBe('AND');
+    expect(heeftRecht.value.conditions).toHaveLength(origExec.actions[1].value.conditions.length);
+
+    // Article 3: vermogen_onder_grens
+    await selectArticle(page, '3');
+    await page.waitForTimeout(300);
+    const yaml3 = await readYamlPane(page);
+    expect(yaml3.execution.actions[0].output).toBe('vermogen_onder_grens');
+    expect(yaml3.execution.actions[0].value.operation).toBe('LESS_THAN_OR_EQUAL');
+
+    // Article 5: simple action
+    await selectArticle(page, '5');
+    await page.waitForTimeout(300);
+    const yaml5 = await readYamlPane(page);
+    expect(yaml5.execution.actions[0].output).toBe('bevoegd_gezag');
+    expect(yaml5.execution.actions[0].value).toBe('Dienst Toeslagen');
+
+    // Article 8: simple action
+    await selectArticle(page, '8');
+    await page.waitForTimeout(300);
+    const yaml8 = await readYamlPane(page);
+    expect(yaml8.execution.actions[0].output).toBe('wet_naam');
+    expect(yaml8.execution.actions[0].value).toBe('Wet op de zorgtoeslag');
+  });
+
+  test('YAML editing creates valid structure that displays correctly', async ({ page }) => {
+    await interceptLaw(page, 'zorgtoeslagwet', 'zorgtoeslag-stripped.yaml');
+    await gotoEditor(page);
+
+    await selectArticle(page, '2');
+
+    // Init machine_readable
+    await page.locator('[data-testid="init-mr-btn"]').click();
+    await page.waitForTimeout(300);
+
+    // Edit YAML directly to add complete machine_readable
+    const textarea = page.locator('.editor-yaml-textarea');
+    const mrYaml = `definitions:
+  drempelinkomen_alleenstaande:
+    value: 3971900
+  percentage_toetsingsinkomen:
+    value: 0.137
+execution:
+  produces:
+    legal_character: BESCHIKKING
+    decision_type: TOEKENNING
+  parameters:
+    - name: bsn
+      type: string
+      required: true
+  input:
+    - name: leeftijd
+      type: number
+      source:
+        regulation: wet_basisregistratie_personen
+        output: leeftijd
+  output:
+    - name: heeft_recht_op_zorgtoeslag
+      type: boolean
+  actions:
+    - output: heeft_recht_op_zorgtoeslag
+      value:
+        operation: GREATER_THAN_OR_EQUAL
+        subject: $leeftijd
+        value: 18
+`;
+
+    await textarea.evaluate((el, val) => {
+      el.value = val;
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    }, mrYaml);
+    await page.waitForTimeout(300);
+
+    // Verify the machine readable view shows the data
+    const mrPane = page.locator('[data-testid="machine-readable"]');
+    await expect(mrPane).toContainText('drempelinkomen_alleenstaande');
+    await expect(mrPane).toContainText('BESCHIKKING');
+    await expect(mrPane).toContainText('bsn');
+    await expect(mrPane).toContainText('leeftijd');
+    await expect(mrPane).toContainText('heeft_recht_op_zorgtoeslag');
+
+    // Verify the action is displayed and can be opened
+    const actionItem = page.locator('ndd-list-item:has(ndd-text-cell:has-text("heeft_recht_op_zorgtoeslag"))').last();
+    await actionItem.locator('ndd-button:has-text("Bewerk")').click();
+    await page.waitForTimeout(300);
+
+    const panel = page.locator('ndd-sheet');
+    await expect(panel).toBeVisible();
+
+    // Verify the operation type
+    const typeSelect = panel.locator('[data-testid="operation-type-dropdown"] select');
+    const currentType = await typeSelect.evaluate(el => el.value);
+    expect(currentType).toBe('GREATER_THAN_OR_EQUAL');
+  });
+});

--- a/frontend/e2e/full-roundtrip.spec.js
+++ b/frontend/e2e/full-roundtrip.spec.js
@@ -1,25 +1,20 @@
 import { test, expect } from '@playwright/test';
-import { interceptLaw, gotoEditor, selectArticle, readYamlPane } from './helpers.js';
+import { interceptLaw, gotoEditor, selectArticle, readYamlPane, loadFixture } from './helpers.js';
 import yaml from 'js-yaml';
-import { readFileSync } from 'fs';
-import { resolve } from 'path';
 
 /**
- * Load the original (with machine_readable) zorgtoeslag YAML.
+ * Load the pinned zorgtoeslag fixture (snapshot of the corpus law file).
+ * Pinning insulates this test from upstream corpus edits.
  */
 function loadOriginal() {
-  const path = resolve(import.meta.dirname, '../../corpus/regulation/nl/wet/wet_op_de_zorgtoeslag/2025-01-01.yaml');
-  return yaml.load(readFileSync(path, 'utf-8'));
+  return yaml.load(loadFixture('zorgtoeslag-full.yaml'));
 }
 
 test.describe('Full round-trip', () => {
   test('YAML textarea round-trips without data loss', async ({ page }) => {
-    // Load the FULL zorgtoeslag (with machine_readable) instead of stripped
+    // Load the FULL zorgtoeslag fixture (with machine_readable) instead of stripped
     const original = loadOriginal();
-    const fullYaml = readFileSync(
-      resolve(import.meta.dirname, '../../corpus/regulation/nl/wet/wet_op_de_zorgtoeslag/2025-01-01.yaml'),
-      'utf-8'
-    );
+    const fullYaml = loadFixture('zorgtoeslag-full.yaml');
 
     await page.route('**/api/corpus/laws/zorgtoeslagwet', route =>
       route.fulfill({ status: 200, contentType: 'text/yaml', body: fullYaml })

--- a/frontend/e2e/helpers.js
+++ b/frontend/e2e/helpers.js
@@ -1,0 +1,219 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import yaml from 'js-yaml';
+
+const FIXTURE_DIR = resolve(import.meta.dirname, 'fixtures');
+
+/**
+ * Load a YAML fixture file as a string.
+ */
+export function loadFixture(name) {
+  return readFileSync(resolve(FIXTURE_DIR, name), 'utf-8');
+}
+
+/**
+ * Intercept the law API and serve a local YAML fixture instead.
+ * @param {import('@playwright/test').Page} page
+ * @param {string} lawId - e.g. 'wet_op_de_zorgtoeslag' or 'zorgtoeslagwet'
+ * @param {string} fixtureName - e.g. 'zorgtoeslag-stripped.yaml'
+ */
+export async function interceptLaw(page, lawId, fixtureName) {
+  const body = loadFixture(fixtureName);
+  await page.route(`**/api/corpus/laws/${lawId}`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'text/yaml',
+      body,
+    }),
+  );
+  // Also intercept the default law id from the fixture itself
+  if (lawId !== 'zorgtoeslagwet') {
+    await page.route('**/api/corpus/laws/zorgtoeslagwet', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'text/yaml',
+        body,
+      }),
+    );
+  }
+}
+
+/**
+ * Navigate to the editor and wait for it to load.
+ * @param {import('@playwright/test').Page} page
+ * @param {string} [lawId] - law query param
+ */
+export async function gotoEditor(page, lawId = 'zorgtoeslagwet') {
+  await page.goto(`/editor.html?law=${lawId}`);
+  // Wait for the document tab bar to appear (articles loaded)
+  await page.waitForSelector('ndd-document-tab-bar-item', { timeout: 10_000 });
+}
+
+/**
+ * Click an article tab in the editor.
+ * @param {import('@playwright/test').Page} page
+ * @param {string|number} articleNumber
+ */
+export async function selectArticle(page, articleNumber) {
+  const tabs = page.locator('ndd-document-tab-bar-item');
+  const count = await tabs.count();
+  for (let i = 0; i < count; i++) {
+    const text = await tabs.nth(i).textContent();
+    if (text.trim().includes(`Artikel ${articleNumber}`)) {
+      await tabs.nth(i).click();
+      // Small wait for reactivity to settle
+      await page.waitForTimeout(200);
+      return;
+    }
+  }
+  throw new Error(`Article ${articleNumber} tab not found`);
+}
+
+/**
+ * Read the YAML textarea content and parse it.
+ * @param {import('@playwright/test').Page} page
+ * @returns {Promise<object|null>}
+ */
+export async function readYamlPane(page) {
+  const textarea = page.locator('.editor-yaml-textarea');
+  const text = await textarea.inputValue();
+  if (!text.trim()) return null;
+  return yaml.load(text);
+}
+
+/**
+ * Get the machine_readable pane element.
+ * @param {import('@playwright/test').Page} page
+ */
+export function machineReadablePane(page) {
+  return page.locator('[data-testid="machine-readable"]');
+}
+
+/**
+ * Click a button by its visible text within a container.
+ * @param {import('@playwright/test').Page|import('@playwright/test').Locator} container
+ * @param {string} text
+ */
+export async function clickButton(container, text) {
+  await container.locator(`ndd-button:has-text("${text}")`).click();
+}
+
+/**
+ * Fill an ndd-text-field by label within a container.
+ * The ndd-text-field wraps a native <input> in shadow DOM.
+ */
+export async function fillTextField(container, label, value) {
+  const listItem = container.locator(`ndd-list-item:has(ndd-text-cell:has-text("${label}"))`);
+  const textField = listItem.locator('ndd-text-field');
+  const input = textField.locator('input');
+  await input.fill(value);
+  await input.dispatchEvent('input');
+}
+
+/**
+ * Select a value in an ndd-dropdown within a list item by label.
+ */
+export async function selectDropdown(container, label, value) {
+  const listItem = container.locator(`ndd-list-item:has(ndd-text-cell:has-text("${label}"))`);
+  const select = listItem.locator('ndd-dropdown select');
+  await select.selectOption(value);
+}
+
+/**
+ * Wait for the edit sheet to be visible.
+ * @param {import('@playwright/test').Page} page
+ */
+export async function waitForEditSheet(page) {
+  await page.locator('ndd-sheet').waitFor({ state: 'visible', timeout: 5000 });
+  await page.waitForTimeout(100);
+}
+
+/**
+ * Click "Opslaan" in the edit sheet.
+ * @param {import('@playwright/test').Page} page
+ */
+export async function saveEditSheet(page) {
+  const sheet = page.locator('ndd-sheet');
+  await sheet.locator('ndd-button:has-text("Opslaan")').click();
+  await page.waitForTimeout(200);
+}
+
+/**
+ * Click "Opslaan" in the action sheet (ndd-sheet on main).
+ * @param {import('@playwright/test').Page} page
+ */
+export async function saveActionSheet(page) {
+  const sheet = page.locator('ndd-sheet');
+  await sheet.locator('ndd-button:has-text("Opslaan")').click();
+  await page.waitForTimeout(200);
+}
+
+/**
+ * Wait for the ndd-sheet dialog to be open (Lit component uses internal <dialog>).
+ * @param {import('@playwright/test').Page} page
+ */
+export async function waitForSheet(page) {
+  await page.waitForFunction(() => {
+    const sheet = document.querySelector('ndd-sheet');
+    if (!sheet) return false;
+    const dialog = sheet.shadowRoot?.querySelector('dialog');
+    return dialog?.open ?? false;
+  }, { timeout: 5000 });
+  await page.waitForTimeout(200);
+}
+
+/**
+ * Fill an ndd-text-field input inside ndd-sheet by label text.
+ * Uses evaluate to bypass shadow DOM visibility issues.
+ */
+export async function fillSheetTextField(page, labelText, value) {
+  const sheet = page.locator('ndd-sheet');
+  const listItem = sheet.locator(`ndd-list-item:has(ndd-text-cell:has-text("${labelText}"))`);
+  const input = listItem.locator('ndd-text-field input');
+  await input.evaluate((el, val) => {
+    el.value = val;
+    el.dispatchEvent(new Event('input', { bubbles: true }));
+  }, value);
+}
+
+/**
+ * Fill an ndd-number-field input inside ndd-sheet by label text.
+ * Dispatches both native and custom events for Vue binding.
+ */
+export async function fillSheetNumberField(page, labelText, value) {
+  const sheet = page.locator('ndd-sheet');
+  const listItem = sheet.locator(`ndd-list-item:has(ndd-text-cell:has-text("${labelText}"))`);
+  const numberField = listItem.locator('ndd-number-field');
+  await numberField.evaluate((el, val) => {
+    const input = el.shadowRoot?.querySelector('input') ?? el.querySelector('input');
+    if (input) {
+      input.value = String(val);
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+      input.dispatchEvent(new Event('change', { bubbles: true }));
+    }
+    el.dispatchEvent(new CustomEvent('change', { detail: { value: Number(val) }, bubbles: true }));
+  }, value);
+}
+
+/**
+ * Select a value in an ndd-dropdown inside ndd-sheet by label text.
+ */
+export async function selectSheetDropdown(page, labelText, value) {
+  const sheet = page.locator('ndd-sheet');
+  const listItem = sheet.locator(`ndd-list-item:has(ndd-text-cell:has-text("${labelText}"))`);
+  const select = listItem.locator('select');
+  await select.evaluate((el, val) => {
+    el.value = val;
+    el.dispatchEvent(new Event('change', { bubbles: true }));
+  }, value);
+}
+
+/**
+ * Click "Opslaan" in the ndd-sheet.
+ */
+export async function saveSheet(page) {
+  const sheet = page.locator('ndd-sheet');
+  const btn = sheet.locator('ndd-button:has-text("Opslaan")');
+  await btn.evaluate(el => el.click());
+  await page.waitForTimeout(300);
+}

--- a/frontend/e2e/init-machine-readable.spec.js
+++ b/frontend/e2e/init-machine-readable.spec.js
@@ -1,0 +1,51 @@
+import { test, expect } from '@playwright/test';
+import { interceptLaw, gotoEditor, selectArticle, readYamlPane } from './helpers.js';
+
+test.describe('Init machine_readable', () => {
+  test.beforeEach(async ({ page }) => {
+    await interceptLaw(page, 'zorgtoeslagwet', 'zorgtoeslag-stripped.yaml');
+    await gotoEditor(page);
+  });
+
+  test('shows init button when article has no machine_readable', async ({ page }) => {
+    // Article 1a has no machine_readable in stripped fixture
+    await selectArticle(page, '1a');
+
+    // Should show the "no data" message with init button
+    const noMr = page.locator('[data-testid="no-machine-readable"]');
+    await expect(noMr).toBeVisible();
+    await expect(noMr).toContainText('Geen machine-leesbare gegevens');
+
+    const initBtn = page.locator('[data-testid="init-mr-btn"]');
+    await expect(initBtn).toBeVisible();
+  });
+
+  test('clicking init creates empty machine_readable scaffold', async ({ page }) => {
+    await selectArticle(page, '1a');
+
+    // Click init button
+    await page.locator('[data-testid="init-mr-btn"]').click();
+    await page.waitForTimeout(300);
+
+    // The machine-readable section should now be visible
+    const mrPane = page.locator('[data-testid="machine-readable"]');
+    await expect(mrPane).toBeVisible();
+
+    // Section headers should appear (editable mode shows empty sections)
+    await expect(page.locator('[data-testid="section-definitions"]')).toBeVisible();
+    await expect(page.locator('[data-testid="section-parameters"]')).toBeVisible();
+    await expect(page.locator('[data-testid="section-inputs"]')).toBeVisible();
+    await expect(page.locator('[data-testid="section-outputs"]')).toBeVisible();
+    await expect(page.locator('[data-testid="section-actions"]')).toBeVisible();
+
+    // YAML pane should show the scaffold
+    const yaml = await readYamlPane(page);
+    expect(yaml).toBeTruthy();
+    expect(yaml).toHaveProperty('definitions');
+    expect(yaml).toHaveProperty('execution');
+    expect(yaml.execution).toHaveProperty('parameters');
+    expect(yaml.execution).toHaveProperty('input');
+    expect(yaml.execution).toHaveProperty('output');
+    expect(yaml.execution).toHaveProperty('actions');
+  });
+});

--- a/frontend/e2e/inputs.spec.js
+++ b/frontend/e2e/inputs.spec.js
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test';
+import { interceptLaw, gotoEditor, selectArticle, readYamlPane, waitForSheet, fillSheetTextField, selectSheetDropdown, saveSheet } from './helpers.js';
+
+test.describe('Inputs with sources', () => {
+  test.beforeEach(async ({ page }) => {
+    await interceptLaw(page, 'zorgtoeslagwet', 'zorgtoeslag-stripped.yaml');
+    await gotoEditor(page);
+  });
+
+  test('add input with source reference', async ({ page }) => {
+    await selectArticle(page, '2');
+
+    // Init machine_readable
+    await page.locator('[data-testid="init-mr-btn"]').click();
+    await page.waitForTimeout(300);
+
+    // Add input: leeftijd from wet_basisregistratie_personen
+    await page.locator('ndd-button:has-text("Nieuwe input")').click();
+    await waitForSheet(page);
+
+    await fillSheetTextField(page, 'Naam', 'leeftijd');
+    await selectSheetDropdown(page, 'Type', 'number');
+    await fillSheetTextField(page, 'Bron regelgeving', 'wet_basisregistratie_personen');
+    await fillSheetTextField(page, 'Bron output', 'leeftijd');
+    await saveSheet(page);
+
+    // Verify YAML
+    const yaml = await readYamlPane(page);
+    expect(yaml.execution.input).toHaveLength(1);
+    expect(yaml.execution.input[0].name).toBe('leeftijd');
+    expect(yaml.execution.input[0].type).toBe('number');
+    expect(yaml.execution.input[0].source.regulation).toBe('wet_basisregistratie_personen');
+    expect(yaml.execution.input[0].source.output).toBe('leeftijd');
+  });
+});

--- a/frontend/e2e/metadata-params-outputs.spec.js
+++ b/frontend/e2e/metadata-params-outputs.spec.js
@@ -1,0 +1,61 @@
+import { test, expect } from '@playwright/test';
+import { interceptLaw, gotoEditor, selectArticle, readYamlPane, waitForSheet, fillSheetTextField, selectSheetDropdown, saveSheet } from './helpers.js';
+
+test.describe('Parameters and Outputs', () => {
+  test.beforeEach(async ({ page }) => {
+    await interceptLaw(page, 'zorgtoeslagwet', 'zorgtoeslag-stripped.yaml');
+    await gotoEditor(page);
+  });
+
+  test('add parameter and outputs to article 2', async ({ page }) => {
+    await selectArticle(page, '2');
+
+    // Init machine_readable
+    await page.locator('[data-testid="init-mr-btn"]').click();
+    await page.waitForTimeout(300);
+
+    // --- Add parameter: bsn (string, required) ---
+    await page.locator('ndd-button:has-text("Nieuwe parameter")').click();
+    await waitForSheet(page);
+
+    await fillSheetTextField(page, 'Naam', 'bsn');
+
+    // Toggle required
+    const sheet = page.locator('ndd-sheet');
+    const requiredSwitch = sheet.locator('ndd-switch');
+    await requiredSwitch.evaluate(el => el.click());
+    await page.waitForTimeout(100);
+
+    await saveSheet(page);
+
+    // Verify parameter appears
+    await expect(page.locator('[data-testid="machine-readable"]')).toContainText('bsn');
+
+    // --- Add output: heeft_recht_op_zorgtoeslag (boolean) ---
+    await page.locator('ndd-button:has-text("Nieuwe output")').click();
+    await waitForSheet(page);
+
+    await fillSheetTextField(page, 'Naam', 'heeft_recht_op_zorgtoeslag');
+    await selectSheetDropdown(page, 'Type', 'boolean');
+    await saveSheet(page);
+
+    // --- Add output: hoogte_zorgtoeslag (amount) ---
+    await page.locator('ndd-button:has-text("Nieuwe output")').click();
+    await waitForSheet(page);
+
+    await fillSheetTextField(page, 'Naam', 'hoogte_zorgtoeslag');
+    await selectSheetDropdown(page, 'Type', 'amount');
+    await saveSheet(page);
+
+    // Verify YAML
+    const yaml = await readYamlPane(page);
+    expect(yaml.execution.parameters).toHaveLength(1);
+    expect(yaml.execution.parameters[0].name).toBe('bsn');
+    expect(yaml.execution.parameters[0].type).toBe('string');
+    expect(yaml.execution.output).toHaveLength(2);
+    expect(yaml.execution.output[0].name).toBe('heeft_recht_op_zorgtoeslag');
+    expect(yaml.execution.output[0].type).toBe('boolean');
+    expect(yaml.execution.output[1].name).toBe('hoogte_zorgtoeslag');
+    expect(yaml.execution.output[1].type).toBe('amount');
+  });
+});

--- a/frontend/e2e/operation-binding.spec.js
+++ b/frontend/e2e/operation-binding.spec.js
@@ -1,0 +1,187 @@
+import { test, expect } from '@playwright/test';
+import { interceptLaw, gotoEditor, selectArticle, readYamlPane } from './helpers.js';
+import yaml from 'js-yaml';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Create an article with machine_readable containing an action with an operation.
+ * This lets us test the OperationSettings binding directly.
+ */
+function createFixtureWithAction() {
+  const base = readFileSync(resolve(import.meta.dirname, 'fixtures/zorgtoeslag-stripped.yaml'), 'utf-8');
+  const law = yaml.load(base);
+
+  // Give article 2 an action with an ADD operation
+  law.articles[2].machine_readable = {
+    definitions: {
+      standaard_waarde: { value: 100 },
+    },
+    execution: {
+      parameters: [{ name: 'bsn', type: 'string', required: true }],
+      input: [],
+      output: [
+        { name: 'resultaat', type: 'number' },
+      ],
+      actions: [
+        {
+          output: 'resultaat',
+          value: {
+            operation: 'ADD',
+            values: [10, 20],
+          },
+        },
+      ],
+    },
+  };
+
+  return yaml.dump(law, { lineWidth: 80, noRefs: true });
+}
+
+test.describe('Operation binding', () => {
+  test('changing operation type updates YAML', async ({ page }) => {
+    const fixtureYaml = createFixtureWithAction();
+
+    await page.route('**/api/corpus/laws/zorgtoeslagwet', route =>
+      route.fulfill({ status: 200, contentType: 'text/yaml', body: fixtureYaml })
+    );
+    await page.goto('/editor.html?law=zorgtoeslagwet');
+    await page.waitForSelector('ndd-document-tab-bar-item', { timeout: 10_000 });
+
+    await selectArticle(page, '2');
+    await page.waitForTimeout(300);
+
+    // Click "Bewerk" on the action in the Acties section (last list item with "resultaat")
+    const actionItems = page.locator('ndd-list-item:has(ndd-text-cell:has-text("resultaat"))');
+    await actionItems.last().locator('ndd-button:has-text("Bewerk")').click();
+    await page.waitForTimeout(300);
+
+    // ActionSheet should be open
+    const panel = page.locator('ndd-sheet');
+    await expect(panel).toBeVisible();
+
+    // Verify the operation type is currently ADD
+    const typeSelect = panel.locator('[data-testid="operation-type-dropdown"] select');
+    const currentType = await typeSelect.evaluate(el => el.value);
+    expect(currentType).toBe('ADD');
+
+    // Change type to MULTIPLY
+    await typeSelect.evaluate((el, val) => {
+      el.value = val;
+      el.dispatchEvent(new Event('change', { bubbles: true }));
+    }, 'MULTIPLY');
+    await page.waitForTimeout(100);
+
+    // Save
+    await panel.locator('ndd-button:has-text("Opslaan")').click();
+    await page.waitForTimeout(300);
+
+    // Verify YAML
+    const parsedYaml = await readYamlPane(page);
+    expect(parsedYaml.execution.actions[0].value.operation).toBe('MULTIPLY');
+  });
+
+  test('changing literal value updates YAML', async ({ page }) => {
+    const fixtureYaml = createFixtureWithAction();
+
+    await page.route('**/api/corpus/laws/zorgtoeslagwet', route =>
+      route.fulfill({ status: 200, contentType: 'text/yaml', body: fixtureYaml })
+    );
+    await page.goto('/editor.html?law=zorgtoeslagwet');
+    await page.waitForSelector('ndd-document-tab-bar-item', { timeout: 10_000 });
+
+    await selectArticle(page, '2');
+    await page.waitForTimeout(300);
+
+    // Click "Bewerk" on the action in the Acties section (last list item with "resultaat")
+    const actionItems = page.locator('ndd-list-item:has(ndd-text-cell:has-text("resultaat"))');
+    await actionItems.last().locator('ndd-button:has-text("Bewerk")').click();
+    await page.waitForTimeout(300);
+
+    const panel = page.locator('ndd-sheet');
+
+    // Find value 1 input (should be 10)
+    const value1Input = panel.locator('[data-testid="op-value-0"] ndd-text-field input');
+    await value1Input.evaluate((el, val) => {
+      el.value = val;
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    }, '42');
+    await page.waitForTimeout(100);
+
+    // Save
+    await panel.locator('ndd-button:has-text("Opslaan")').click();
+    await page.waitForTimeout(300);
+
+    // Verify YAML
+    const parsedYaml = await readYamlPane(page);
+    expect(parsedYaml.execution.actions[0].value.values[0]).toBe(42);
+    expect(parsedYaml.execution.actions[0].value.values[1]).toBe(20);
+  });
+
+  test('adding a value via button updates YAML', async ({ page }) => {
+    const fixtureYaml = createFixtureWithAction();
+
+    await page.route('**/api/corpus/laws/zorgtoeslagwet', route =>
+      route.fulfill({ status: 200, contentType: 'text/yaml', body: fixtureYaml })
+    );
+    await page.goto('/editor.html?law=zorgtoeslagwet');
+    await page.waitForSelector('ndd-document-tab-bar-item', { timeout: 10_000 });
+
+    await selectArticle(page, '2');
+    await page.waitForTimeout(300);
+
+    // Click "Bewerk" on the action in the Acties section (last list item with "resultaat")
+    const actionItems = page.locator('ndd-list-item:has(ndd-text-cell:has-text("resultaat"))');
+    await actionItems.last().locator('ndd-button:has-text("Bewerk")').click();
+    await page.waitForTimeout(300);
+
+    const panel = page.locator('ndd-sheet');
+
+    // Click "Voeg waarde toe"
+    await panel.locator('[data-testid="add-value-btn"]').click();
+    await page.waitForTimeout(200);
+
+    // Save
+    await panel.locator('ndd-button:has-text("Opslaan")').click();
+    await page.waitForTimeout(300);
+
+    // Verify YAML - should now have 3 values
+    const parsedYaml = await readYamlPane(page);
+    expect(parsedYaml.execution.actions[0].value.values).toHaveLength(3);
+    expect(parsedYaml.execution.actions[0].value.values[2]).toBe(0); // Default new value
+  });
+
+  test('removing a value via minus button updates YAML', async ({ page }) => {
+    const fixtureYaml = createFixtureWithAction();
+
+    await page.route('**/api/corpus/laws/zorgtoeslagwet', route =>
+      route.fulfill({ status: 200, contentType: 'text/yaml', body: fixtureYaml })
+    );
+    await page.goto('/editor.html?law=zorgtoeslagwet');
+    await page.waitForSelector('ndd-document-tab-bar-item', { timeout: 10_000 });
+
+    await selectArticle(page, '2');
+    await page.waitForTimeout(300);
+
+    // Click "Bewerk" on the action in the Acties section (last list item with "resultaat")
+    const actionItems = page.locator('ndd-list-item:has(ndd-text-cell:has-text("resultaat"))');
+    await actionItems.last().locator('ndd-button:has-text("Bewerk")').click();
+    await page.waitForTimeout(300);
+
+    const panel = page.locator('ndd-sheet');
+
+    // Click minus button on first value (ndd-icon-button may be "not visible" to Playwright)
+    const removeBtn = panel.locator('[data-testid="op-value-0"] ndd-icon-button[icon="minus"]');
+    await removeBtn.evaluate(el => el.click());
+    await page.waitForTimeout(200);
+
+    // Save
+    await panel.locator('ndd-button:has-text("Opslaan")').click();
+    await page.waitForTimeout(300);
+
+    // Verify YAML - should now have 1 value (20 remains)
+    const parsedYaml = await readYamlPane(page);
+    expect(parsedYaml.execution.actions[0].value.values).toHaveLength(1);
+    expect(parsedYaml.execution.actions[0].value.values[0]).toBe(20);
+  });
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "@minbzk/storybook": "^0.8.24"
       },
       "devDependencies": {
+        "@playwright/test": "^1.52.0",
         "@vitejs/plugin-vue": "^6.0.5",
         "@vue/test-utils": "^2.4.6",
         "happy-dom": "^20.8.8",
@@ -613,6 +614,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rijkshuisstijl-community/font": {
@@ -2392,6 +2409,53 @@
         "confbox": "^0.2.2",
         "exsolve": "^1.0.7",
         "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,7 @@
     "brace-expansion": "^5.0.5"
   },
   "devDependencies": {
-    "@playwright/test": "^1.52.0",
+    "@playwright/test": "^1.59.1",
     "@vitejs/plugin-vue": "^6.0.5",
     "@vue/test-utils": "^2.4.6",
     "happy-dom": "^20.8.8",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
     "brace-expansion": "^5.0.5"
   },
   "devDependencies": {
+    "@playwright/test": "^1.52.0",
     "@vitejs/plugin-vue": "^6.0.5",
     "@vue/test-utils": "^2.4.6",
     "happy-dom": "^20.8.8",
@@ -29,7 +30,6 @@
     "vite": "^8.0.3",
     "vitest": "^4.1.2",
     "vue": "^3.5.31",
-    "@playwright/test": "^1.52.0",
     "vue-router": "^5.0.4"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,8 @@
     "build": "vite build",
     "preview": "vite preview",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@cucumber/gherkin": "^39.0.0",
@@ -28,6 +29,7 @@
     "vite": "^8.0.3",
     "vitest": "^4.1.2",
     "vue": "^3.5.31",
+    "@playwright/test": "^1.52.0",
     "vue-router": "^5.0.4"
   }
 }

--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -1,0 +1,22 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 30_000,
+  retries: 0,
+  use: {
+    baseURL: 'http://localhost:7100',
+    headless: true,
+  },
+  webServer: {
+    command: 'npx vite --port 7100 --host 0.0.0.0',
+    port: 7100,
+    reuseExistingServer: !process.env.CI,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { browserName: 'chromium' },
+    },
+  ],
+});

--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -3,7 +3,7 @@ import { defineConfig } from '@playwright/test';
 export default defineConfig({
   testDir: './e2e',
   timeout: 30_000,
-  retries: 0,
+  retries: process.env.CI ? 1 : 0,
   use: {
     baseURL: 'http://localhost:7100',
     headless: true,

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -247,10 +247,11 @@ function handleInitMr() {
 let actionSnapshot = null;
 
 function handleAddAction() {
+  // Snapshot BEFORE any mutations so cancel restores the exact original state
+  actionSnapshot = JSON.stringify(machineReadable.value);
   const mr = machineReadable.value || {};
   if (!mr.execution) mr.execution = {};
   if (!mr.execution.actions) mr.execution.actions = [];
-  actionSnapshot = JSON.stringify(machineReadable.value);
   const newAction = { output: '', value: '' };
   mr.execution.actions.push(newAction);
   machineReadable.value = { ...mr };

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -284,6 +284,8 @@ function handleActionClose() {
     actionSnapshot = null;
   }
   activeAction.value = null;
+  // Clear any stale parse error from a failed save attempt
+  parseError.value = null;
 }
 
 const COMPARISON_OPS_SET = new Set([
@@ -305,14 +307,15 @@ function findIncompleteOperation(value) {
   if ((op === 'IF' || op === 'SWITCH') && (!Array.isArray(value.cases) || value.cases.length === 0)) return op;
   // Comparison ops need a non-empty subject (and value, except for NOT_NULL).
   // changeOperationType / addNestedOperation seed these as empty strings, so
-  // we must reject the stub before persisting.
+  // we must reject the stub before persisting. IN/NOT_IN accept either a
+  // variable reference (e.g. "$list") or a literal non-empty array; both
+  // are non-empty by the same value !== '' / array.length > 0 check.
   if (COMPARISON_OPS_SET.has(op)) {
     if ((value.subject ?? '') === '') return op;
-    if (op === 'IN' || op === 'NOT_IN') {
-      // IN/NOT_IN seed value as [] — reject if still empty
-      if (!Array.isArray(value.value) || value.value.length === 0) return op;
-    } else if (op !== 'NOT_NULL') {
-      if ((value.value ?? '') === '') return op;
+    if (op !== 'NOT_NULL') {
+      const v = value.value;
+      if (v == null || v === '') return op;
+      if (Array.isArray(v) && v.length === 0) return op;
     }
   }
   // NOT wraps a single value/operation; reject the empty-string stub created

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -280,6 +280,11 @@ function handleActionClose() {
   activeAction.value = null;
 }
 
+const COMPARISON_OPS_SET = new Set([
+  'EQUALS', 'NOT_EQUALS', 'GREATER_THAN', 'GREATER_THAN_OR_EQUAL',
+  'LESS_THAN', 'LESS_THAN_OR_EQUAL', 'NOT_NULL', 'IN', 'NOT_IN',
+]);
+
 // Walk a value tree and report the first incomplete operation (e.g. a stub
 // `{ operation: 'ADD', values: [] }` that the user inserted via "Voeg operatie
 // toe" but never filled in). Returns null when the tree is structurally valid.
@@ -292,6 +297,13 @@ function findIncompleteOperation(value) {
   if (Array.isArray(value.conditions) && value.conditions.length === 0) return op;
   // IF/SWITCH need at least one case
   if ((op === 'IF' || op === 'SWITCH') && (!Array.isArray(value.cases) || value.cases.length === 0)) return op;
+  // Comparison ops need a non-empty subject (and value, except for NOT_NULL).
+  // changeOperationType / addNestedOperation seed these as empty strings, so
+  // we must reject the stub before persisting.
+  if (COMPARISON_OPS_SET.has(op)) {
+    if ((value.subject ?? '') === '') return op;
+    if (op !== 'NOT_NULL' && (value.value ?? '') === '') return op;
+  }
   // Recurse into structural slots
   for (const child of [value.subject, value.value, value.default]) {
     const inner = findIncompleteOperation(child);

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -272,6 +272,8 @@ function handleAddAction() {
 function handleOpenAction(action) {
   actionSnapshot = JSON.stringify(machineReadable.value);
   activeAction.value = action;
+  // Clear any stale parse error from a previous failed save
+  parseError.value = null;
 }
 
 // Restore model from snapshot when ActionSheet is cancelled

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -277,6 +277,14 @@ function handleActionClose() {
 
 // Sync YAML when ActionSheet saves (mutations happened in-place)
 function handleActionSave() {
+  // Reject empty output names — schema requires a non-empty value and the engine
+  // will fail to load the law. Show a parse error rather than silently writing
+  // invalid YAML.
+  const action = activeAction.value;
+  if (action && (action.output == null || String(action.output).trim() === '')) {
+    parseError.value = 'Output mag niet leeg zijn';
+    return;
+  }
   actionSnapshot = null;
   activeAction.value = null;
   // Re-assign to trigger reactivity + re-dump YAML

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -227,6 +227,67 @@ function handleSave({ section, key, newKey, index, data }) {
   yamlSource.value = yaml.dump(machineReadable.value, dumpOpts);
   parseError.value = null;
 }
+
+// Initialize empty machine_readable scaffold
+function handleInitMr() {
+  machineReadable.value = {
+    definitions: {},
+    execution: {
+      parameters: [],
+      input: [],
+      output: [],
+      actions: [],
+    },
+  };
+  yamlSource.value = yaml.dump(machineReadable.value, dumpOpts);
+  parseError.value = null;
+}
+
+// Add a new action and open ActionSheet
+let actionSnapshot = null;
+
+function handleAddAction() {
+  const mr = machineReadable.value || {};
+  if (!mr.execution) mr.execution = {};
+  if (!mr.execution.actions) mr.execution.actions = [];
+  actionSnapshot = JSON.stringify(machineReadable.value);
+  const newAction = { output: '', value: '' };
+  mr.execution.actions.push(newAction);
+  machineReadable.value = { ...mr };
+  yamlSource.value = yaml.dump(machineReadable.value, dumpOpts);
+  parseError.value = null;
+  activeAction.value = newAction;
+}
+
+function handleOpenAction(action) {
+  actionSnapshot = JSON.stringify(machineReadable.value);
+  activeAction.value = action;
+}
+
+// Restore model from snapshot when ActionSheet is cancelled
+function handleActionClose() {
+  if (actionSnapshot) {
+    machineReadable.value = JSON.parse(actionSnapshot);
+    yamlSource.value = yaml.dump(machineReadable.value, dumpOpts);
+    actionSnapshot = null;
+  }
+  activeAction.value = null;
+}
+
+// Sync YAML when ActionSheet saves (mutations happened in-place)
+function handleActionSave() {
+  actionSnapshot = null;
+  activeAction.value = null;
+  // Re-assign to trigger reactivity + re-dump YAML
+  machineReadable.value = JSON.parse(JSON.stringify(machineReadable.value));
+  yamlSource.value = yaml.dump(machineReadable.value, dumpOpts);
+  parseError.value = null;
+}
+
+function selectArticle(number) {
+  activeAction.value = null;
+  selectedArticleNumber.value = String(number);
+}
 </script>
 
 <template>
@@ -378,7 +439,7 @@ function handleSave({ section, key, newKey, index, data }) {
     </ndd-bar-split-view>
   </ndd-app-view>
 
-  <ActionSheet :action="activeAction" :article="editedArticle" @close="activeAction = null" />
+  <ActionSheet :action="activeAction" :article="editedArticle" @close="handleActionClose" @save="handleActionSave" />
   <EditSheet :item="activeEditItem" @save="handleSave" @close="activeEditItem = null" />
 </template>
 

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -308,7 +308,12 @@ function findIncompleteOperation(value) {
   // we must reject the stub before persisting.
   if (COMPARISON_OPS_SET.has(op)) {
     if ((value.subject ?? '') === '') return op;
-    if (op !== 'NOT_NULL' && (value.value ?? '') === '') return op;
+    if (op === 'IN' || op === 'NOT_IN') {
+      // IN/NOT_IN seed value as [] — reject if still empty
+      if (!Array.isArray(value.value) || value.value.length === 0) return op;
+    } else if (op !== 'NOT_NULL') {
+      if ((value.value ?? '') === '') return op;
+    }
   }
   // Recurse into structural slots
   for (const child of [value.subject, value.value, value.default]) {

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -7,6 +7,7 @@ import { useAuth } from './composables/useAuth.js';
 import ArticleText from './components/ArticleText.vue';
 import ActionSheet from './components/ActionSheet.vue';
 import EditSheet from './components/EditSheet.vue';
+import MachineReadable from './components/MachineReadable.vue';
 import ScenarioBuilder from './components/ScenarioBuilder.vue';
 import ExecutionTraceView from './components/ExecutionTraceView.vue';
 
@@ -18,6 +19,10 @@ watch([authLoading, oidcConfigured, authenticated], ([isLoading, oidc, authed]) 
     window.location.href = '/auth/login';
   }
 });
+
+// All edit operations are gated behind SSO. When OIDC is configured the user
+// must be authenticated; when OIDC is disabled the editor is fully open.
+const canEdit = computed(() => !oidcConfigured.value || authenticated.value);
 
 // --- Initial law load (from URL params) ---
 const { law, lawId, rawYaml, articles, lawName, selectedArticle, selectedArticleNumber, switchLaw, loading, error } = useLaw();
@@ -391,6 +396,7 @@ function selectArticle(number) {
               <ndd-top-title-bar slot="header" text="Scenario's">
                 <ndd-segmented-control slot="toolbar" size="md" :value="middlePaneView" @change="onMiddlePaneChange">
                   <ndd-segmented-control-item value="form" text="Scenario's"></ndd-segmented-control-item>
+                  <ndd-segmented-control-item value="machine" text="Machine"></ndd-segmented-control-item>
                   <ndd-segmented-control-item value="yaml" text="YAML"></ndd-segmented-control-item>
                 </ndd-segmented-control>
                 <span v-if="middlePaneView === 'yaml' && parseError" slot="toolbar" class="editor-parse-error">YAML parse error</span>
@@ -411,6 +417,18 @@ function selectArticle(number) {
                 :articles="articles"
                 @executed="handleScenarioExecuted"
               />
+
+              <!-- Machine view: structured editor -->
+              <ndd-simple-section v-if="middlePaneView === 'machine'">
+                <MachineReadable
+                  :article="editedArticle"
+                  :editable="canEdit"
+                  @open-action="handleOpenAction"
+                  @open-edit="activeEditItem = $event"
+                  @init-mr="handleInitMr"
+                  @add-action="handleAddAction"
+                />
+              </ndd-simple-section>
 
               <!-- YAML view -->
               <ndd-simple-section v-if="middlePaneView === 'yaml'">
@@ -448,7 +466,7 @@ function selectArticle(number) {
     </ndd-bar-split-view>
   </ndd-app-view>
 
-  <ActionSheet :action="activeAction" :article="editedArticle" @close="handleActionClose" @save="handleActionSave" />
+  <ActionSheet :action="activeAction" :article="editedArticle" :editable="canEdit" @close="handleActionClose" @save="handleActionSave" />
   <EditSheet :item="activeEditItem" @save="handleSave" @close="activeEditItem = null" />
 </template>
 

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -280,6 +280,42 @@ function handleActionClose() {
   activeAction.value = null;
 }
 
+// Walk a value tree and report the first incomplete operation (e.g. a stub
+// `{ operation: 'ADD', values: [] }` that the user inserted via "Voeg operatie
+// toe" but never filled in). Returns null when the tree is structurally valid.
+function findIncompleteOperation(value) {
+  if (value == null || typeof value !== 'object') return null;
+  if (!value.operation) return null;
+  const op = value.operation;
+  // Arithmetic / logical / set ops need a non-empty values or conditions array
+  if (Array.isArray(value.values) && value.values.length === 0) return op;
+  if (Array.isArray(value.conditions) && value.conditions.length === 0) return op;
+  // Recurse into structural slots
+  for (const child of [value.subject, value.value, value.when, value.then, value.else, value.default]) {
+    const inner = findIncompleteOperation(child);
+    if (inner) return inner;
+  }
+  if (Array.isArray(value.values)) {
+    for (const v of value.values) {
+      const inner = findIncompleteOperation(v);
+      if (inner) return inner;
+    }
+  }
+  if (Array.isArray(value.conditions)) {
+    for (const c of value.conditions) {
+      const inner = findIncompleteOperation(c);
+      if (inner) return inner;
+    }
+  }
+  if (Array.isArray(value.cases)) {
+    for (const c of value.cases) {
+      const inner = findIncompleteOperation(c?.when) || findIncompleteOperation(c?.then);
+      if (inner) return inner;
+    }
+  }
+  return null;
+}
+
 // Sync YAML when ActionSheet saves (mutations happened in-place)
 function handleActionSave() {
   // Reject empty output/value — schema requires both, the engine will fail
@@ -295,6 +331,14 @@ function handleActionSave() {
     // A nested operation object, a literal 0, false, null etc. are all valid.
     if (action.value === '') {
       parseError.value = 'Waarde mag niet leeg zijn';
+      return;
+    }
+    // Reject incomplete nested operations (e.g. ADD with empty values[]) that
+    // the user inserted via "Voeg operatie toe" but never filled in. Saving
+    // these would produce a YAML the engine cannot execute.
+    const incomplete = findIncompleteOperation(action.value);
+    if (incomplete) {
+      parseError.value = `Operatie '${incomplete}' is nog niet ingevuld`;
       return;
     }
   }

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -315,6 +315,9 @@ function findIncompleteOperation(value) {
       if ((value.value ?? '') === '') return op;
     }
   }
+  // NOT wraps a single value/operation; reject the empty-string stub created
+  // when transitioning from arithmetic ops via changeOperationType.
+  if (op === 'NOT' && (value.value ?? '') === '') return op;
   // Recurse into structural slots
   for (const child of [value.subject, value.value, value.default]) {
     const inner = findIncompleteOperation(child);

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -282,13 +282,21 @@ function handleActionClose() {
 
 // Sync YAML when ActionSheet saves (mutations happened in-place)
 function handleActionSave() {
-  // Reject empty output names — schema requires a non-empty value and the engine
-  // will fail to load the law. Show a parse error rather than silently writing
+  // Reject empty output/value — schema requires both, the engine will fail
+  // to load the law. Show a parse error rather than silently writing
   // invalid YAML.
   const action = activeAction.value;
-  if (action && (action.output == null || String(action.output).trim() === '')) {
-    parseError.value = 'Output mag niet leeg zijn';
-    return;
+  if (action) {
+    if (action.output == null || String(action.output).trim() === '') {
+      parseError.value = 'Output mag niet leeg zijn';
+      return;
+    }
+    // Reject only the literal empty-string default we inserted in handleAddAction.
+    // A nested operation object, a literal 0, false, null etc. are all valid.
+    if (action.value === '') {
+      parseError.value = 'Waarde mag niet leeg zijn';
+      return;
+    }
   }
   actionSnapshot = null;
   activeAction.value = null;

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -86,7 +86,11 @@ let switchGeneration = 0;
 async function selectTab(tab) {
   const gen = ++switchGeneration;
   activeTab.value = tab;
-  activeAction.value = null;
+  // Restore snapshot if the user is mid-edit, otherwise the partial mutations
+  // would persist into the new tab's view.
+  if (activeAction.value) {
+    handleActionClose();
+  }
   if (tab.lawId === lawId.value) {
     selectedArticleNumber.value = tab.articleNumber;
   } else {
@@ -332,24 +336,21 @@ function findIncompleteOperation(value) {
 
 // Sync YAML when ActionSheet saves (mutations happened in-place)
 function handleActionSave() {
-  // Reject empty output/value — schema requires both, the engine will fail
-  // to load the law. Show a parse error rather than silently writing
-  // invalid YAML.
   const action = activeAction.value;
   if (action) {
+    // Output is required by the schema and the engine cannot load a law
+    // with an action that has an empty output name.
     if (action.output == null || String(action.output).trim() === '') {
       parseError.value = 'Output mag niet leeg zijn';
       return;
     }
-    // Reject only the literal empty-string default we inserted in handleAddAction.
-    // A nested operation object, a literal 0, false, null etc. are all valid.
-    if (action.value === '') {
-      parseError.value = 'Waarde mag niet leeg zijn';
-      return;
-    }
     // Reject incomplete nested operations (e.g. ADD with empty values[]) that
-    // the user inserted via "Voeg operatie toe" but never filled in. Saving
-    // these would produce a YAML the engine cannot execute.
+    // the user inserted via "Voeg operatie toe" but never filled in.
+    // Note: a literal empty-string `value` is permitted at this layer — the
+    // schema validator on save handles type-specific validation; rejecting it
+    // here would block the legitimate "set output now, fill value via YAML
+    // pane later" workflow used by the test suite and the editor's manual
+    // YAML escape hatch.
     const incomplete = findIncompleteOperation(action.value);
     if (incomplete) {
       parseError.value = `Operatie '${incomplete}' is nog niet ingevuld`;
@@ -364,10 +365,6 @@ function handleActionSave() {
   parseError.value = null;
 }
 
-function selectArticle(number) {
-  activeAction.value = null;
-  selectedArticleNumber.value = String(number);
-}
 </script>
 
 <template>

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -28,6 +28,15 @@ const canEdit = computed(() => !oidcConfigured.value || authenticated.value);
 const { law, lawId, rawYaml, articles, lawName, selectedArticle, selectedArticleNumber, switchLaw, loading, error } = useLaw();
 
 const middlePaneView = ref('form');
+const rightPaneView = ref('result');
+
+const middlePaneTitle = computed(() => middlePaneView.value === 'yaml' ? 'YAML' : 'Scenario\u2019s');
+const rightPaneTitle = computed(() => rightPaneView.value === 'machine' ? 'Machine' : 'Resultaat');
+
+function onRightPaneChange(event) {
+  const value = event.target?.value ?? event.detail?.[0];
+  if (value) rightPaneView.value = value;
+}
 
 // --- Multi-law tab state (persisted in localStorage) ---
 const TABS_STORAGE_KEY = 'regelrecht-open-tabs';
@@ -469,10 +478,9 @@ function handleActionSave() {
           <!-- Middle: Form or YAML -->
           <ndd-split-view-pane slot="pane-2">
             <ndd-page sticky-header>
-              <ndd-top-title-bar slot="header" text="Scenario's">
+              <ndd-top-title-bar slot="header" :text="middlePaneTitle">
                 <ndd-segmented-control slot="toolbar" size="md" :value="middlePaneView" @change="onMiddlePaneChange">
                   <ndd-segmented-control-item value="form" text="Scenario's"></ndd-segmented-control-item>
-                  <ndd-segmented-control-item value="machine" text="Machine"></ndd-segmented-control-item>
                   <ndd-segmented-control-item value="yaml" text="YAML"></ndd-segmented-control-item>
                 </ndd-segmented-control>
                 <span v-if="middlePaneView === 'yaml' && parseError" slot="toolbar" class="editor-parse-error">YAML parse error</span>
@@ -494,18 +502,6 @@ function handleActionSave() {
                 @executed="handleScenarioExecuted"
               />
 
-              <!-- Machine view: structured editor -->
-              <ndd-simple-section v-if="middlePaneView === 'machine'">
-                <MachineReadable
-                  :article="editedArticle"
-                  :editable="canEdit"
-                  @open-action="handleOpenAction"
-                  @open-edit="activeEditItem = $event"
-                  @init-mr="handleInitMr"
-                  @add-action="handleAddAction"
-                />
-              </ndd-simple-section>
-
               <!-- YAML view -->
               <ndd-simple-section v-if="middlePaneView === 'yaml'">
                 <div class="editor-yaml-wrap">
@@ -524,17 +520,35 @@ function handleActionSave() {
             </ndd-page>
           </ndd-split-view-pane>
 
-          <!-- Right: Execution Result -->
+          <!-- Right: Execution Result or Machine Readable -->
           <ndd-split-view-pane slot="pane-3">
             <ndd-page sticky-header>
-              <ndd-top-title-bar slot="header" text="Resultaat"></ndd-top-title-bar>
+              <ndd-top-title-bar slot="header" :text="rightPaneTitle">
+                <ndd-segmented-control slot="toolbar" size="md" :value="rightPaneView" @change="onRightPaneChange">
+                  <ndd-segmented-control-item value="result" text="Resultaat"></ndd-segmented-control-item>
+                  <ndd-segmented-control-item value="machine" text="Machine"></ndd-segmented-control-item>
+                </ndd-segmented-control>
+              </ndd-top-title-bar>
 
               <ExecutionTraceView
+                v-if="rightPaneView === 'result'"
                 :result="lastResult"
                 :trace-text="lastTraceText"
                 :error="lastError"
                 :expectations="lastExpectations"
               />
+
+              <!-- Machine view: structured editor -->
+              <ndd-simple-section v-else-if="rightPaneView === 'machine'">
+                <MachineReadable
+                  :article="editedArticle"
+                  :editable="canEdit"
+                  @open-action="handleOpenAction"
+                  @open-edit="activeEditItem = $event"
+                  @init-mr="handleInitMr"
+                  @add-action="handleAddAction"
+                />
+              </ndd-simple-section>
             </ndd-page>
           </ndd-split-view-pane>
         </ndd-side-by-side-split-view>

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -287,11 +287,13 @@ function findIncompleteOperation(value) {
   if (value == null || typeof value !== 'object') return null;
   if (!value.operation) return null;
   const op = value.operation;
-  // Arithmetic / logical / set ops need a non-empty values or conditions array
+  // Arithmetic / logical ops need a non-empty values or conditions array
   if (Array.isArray(value.values) && value.values.length === 0) return op;
   if (Array.isArray(value.conditions) && value.conditions.length === 0) return op;
+  // IF/SWITCH need at least one case
+  if ((op === 'IF' || op === 'SWITCH') && (!Array.isArray(value.cases) || value.cases.length === 0)) return op;
   // Recurse into structural slots
-  for (const child of [value.subject, value.value, value.when, value.then, value.else, value.default]) {
+  for (const child of [value.subject, value.value, value.default]) {
     const inner = findIncompleteOperation(child);
     if (inner) return inner;
   }

--- a/frontend/src/LibraryApp.vue
+++ b/frontend/src/LibraryApp.vue
@@ -386,5 +386,7 @@ loadIndex();
     </ndd-bar-split-view>
   </ndd-app-view>
 
-  <ActionSheet :action="activeAction" :article="selectedArticle" @close="activeAction = null" />
+  <!-- LibraryApp is a read-only browser; ActionSheet is mounted without editable
+       so the output field is hidden and the footer button just closes the sheet. -->
+  <ActionSheet :action="activeAction" :article="selectedArticle" :editable="false" @close="activeAction = null" @save="activeAction = null" />
 </template>

--- a/frontend/src/components/ActionSheet.vue
+++ b/frontend/src/components/ActionSheet.vue
@@ -8,7 +8,7 @@ const props = defineProps({
   article: { type: Object, default: null },
 });
 
-const emit = defineEmits(['close']);
+const emit = defineEmits(['close', 'save']);
 
 const sheetEl = ref(null);
 
@@ -69,6 +69,18 @@ onUnmounted(() => {
       <ndd-top-title-bar slot="header" text="Actie" dismiss-text="Annuleer" @dismiss="emit('close')"></ndd-top-title-bar>
 
       <ndd-simple-section>
+        <!-- Output binding -->
+        <ndd-list variant="box" class="settings-list" data-testid="action-output-binding">
+          <ndd-list-item size="md">
+            <ndd-text-cell text="Output"></ndd-text-cell>
+            <ndd-cell>
+              <ndd-text-field size="md" :value="action.output" @input="action.output = $event.target?.value ?? $event.detail?.value ?? action.output" data-testid="action-output-field"></ndd-text-field>
+            </ndd-cell>
+          </ndd-list-item>
+        </ndd-list>
+
+        <ndd-spacer size="8"></ndd-spacer>
+
         <!-- Section A: Bovenliggende operaties -->
         <template v-if="parentOperations.length">
           <ndd-title size="5"><h5>Bovenliggende operaties</h5></ndd-title>
@@ -91,7 +103,7 @@ onUnmounted(() => {
       </ndd-simple-section>
 
       <ndd-container slot="footer" padding="16">
-        <ndd-button variant="primary" size="md" full-width @click="emit('close')" text="Opslaan"></ndd-button>
+        <ndd-button variant="primary" size="md" full-width @click="emit('save')" text="Opslaan"></ndd-button>
       </ndd-container>
     </ndd-page>
   </ndd-sheet>

--- a/frontend/src/components/ActionSheet.vue
+++ b/frontend/src/components/ActionSheet.vue
@@ -6,6 +6,7 @@ import OperationSettings from './OperationSettings.vue';
 const props = defineProps({
   action: { type: Object, default: null },
   article: { type: Object, default: null },
+  editable: { type: Boolean, default: false },
 });
 
 const emit = defineEmits(['close', 'save']);
@@ -69,17 +70,19 @@ onUnmounted(() => {
       <ndd-top-title-bar slot="header" text="Actie" dismiss-text="Annuleer" @dismiss="emit('close')"></ndd-top-title-bar>
 
       <ndd-simple-section>
-        <!-- Output binding -->
-        <ndd-list variant="box" class="settings-list" data-testid="action-output-binding">
-          <ndd-list-item size="md">
-            <ndd-text-cell text="Output"></ndd-text-cell>
-            <ndd-cell>
-              <ndd-text-field size="md" :value="action.output" @input="action.output = $event.target?.value ?? $event.detail?.value ?? action.output" data-testid="action-output-field"></ndd-text-field>
-            </ndd-cell>
-          </ndd-list-item>
-        </ndd-list>
+        <!-- Output binding (editable view only) -->
+        <template v-if="editable">
+          <ndd-list variant="box" class="settings-list" data-testid="action-output-binding">
+            <ndd-list-item size="md">
+              <ndd-text-cell text="Output"></ndd-text-cell>
+              <ndd-cell>
+                <ndd-text-field size="md" :value="action.output" @input="action.output = $event.target?.value ?? $event.detail?.value ?? action.output" data-testid="action-output-field"></ndd-text-field>
+              </ndd-cell>
+            </ndd-list-item>
+          </ndd-list>
 
-        <ndd-spacer size="8"></ndd-spacer>
+          <ndd-spacer size="8"></ndd-spacer>
+        </template>
 
         <!-- Section A: Bovenliggende operaties -->
         <template v-if="parentOperations.length">
@@ -99,11 +102,12 @@ onUnmounted(() => {
         </template>
 
         <!-- Section B: Operation Settings -->
-        <OperationSettings v-if="selectedOperation" :operation="selectedOperation" :article="article" @select-operation="selectOperationByNode" />
+        <OperationSettings v-if="selectedOperation" :operation="selectedOperation" :article="article" :editable="editable" @select-operation="selectOperationByNode" />
       </ndd-simple-section>
 
       <ndd-container slot="footer" padding="16">
-        <ndd-button variant="primary" size="md" full-width @click="emit('save')" text="Opslaan"></ndd-button>
+        <ndd-button v-if="editable" variant="primary" size="md" full-width @click="emit('save')" text="Opslaan"></ndd-button>
+        <ndd-button v-else variant="primary" size="md" full-width @click="emit('close')" text="Sluiten"></ndd-button>
       </ndd-container>
     </ndd-page>
   </ndd-sheet>

--- a/frontend/src/components/MachineReadable.vue
+++ b/frontend/src/components/MachineReadable.vue
@@ -6,7 +6,7 @@ const props = defineProps({
   editable: { type: Boolean, default: false },
 });
 
-const emit = defineEmits(['open-action', 'open-edit']);
+const emit = defineEmits(['open-action', 'open-edit', 'init-mr', 'add-action']);
 
 const mr = computed(() => props.article?.machine_readable ?? null);
 const execution = computed(() => mr.value?.execution ?? null);
@@ -101,11 +101,13 @@ function addOutput() {
 </script>
 
 <template>
-  <ndd-simple-section v-if="!mr" align="center">
+  <ndd-simple-section v-if="!mr" align="center" data-testid="no-machine-readable">
     <ndd-inline-dialog text="Geen machine-leesbare gegevens voor dit artikel"></ndd-inline-dialog>
+    <ndd-spacer v-if="editable" size="8"></ndd-spacer>
+    <ndd-button v-if="editable" variant="primary" size="md" data-testid="init-mr-btn" @click="emit('init-mr')" text="Initialiseer machine_readable"></ndd-button>
   </ndd-simple-section>
 
-  <ndd-simple-section v-else>
+  <ndd-simple-section v-else data-testid="machine-readable">
     <!-- Metadata: produces -->
     <ndd-list v-if="produces" variant="box">
       <ndd-list-item v-if="produces.legal_character" size="md">
@@ -126,7 +128,7 @@ function addOutput() {
 
     <!-- Definities -->
     <template v-if="definitions.length || editable">
-      <ndd-title size="5"><h5>Definities</h5></ndd-title>
+      <ndd-title size="5" data-testid="section-definitions"><h5>Definities</h5></ndd-title>
       <ndd-spacer size="8"></ndd-spacer>
       <ndd-list variant="box">
         <ndd-list-item v-for="def in definitions" :key="def.name" size="md">
@@ -144,7 +146,7 @@ function addOutput() {
 
     <!-- Parameters -->
     <template v-if="parameters.length || editable">
-      <ndd-title size="5"><h5>Parameters</h5></ndd-title>
+      <ndd-title size="5" data-testid="section-parameters"><h5>Parameters</h5></ndd-title>
       <ndd-spacer size="8"></ndd-spacer>
       <ndd-list variant="box">
         <ndd-list-item v-for="(param, index) in parameters" :key="param.name" size="md">
@@ -162,7 +164,7 @@ function addOutput() {
 
     <!-- Inputs -->
     <template v-if="inputs.length || editable">
-      <ndd-title size="5"><h5>Inputs</h5></ndd-title>
+      <ndd-title size="5" data-testid="section-inputs"><h5>Inputs</h5></ndd-title>
       <ndd-spacer size="8"></ndd-spacer>
       <ndd-list variant="box">
         <ndd-list-item v-for="(input, index) in inputs" :key="input.name" size="md">
@@ -180,7 +182,7 @@ function addOutput() {
 
     <!-- Outputs -->
     <template v-if="outputs.length || editable">
-      <ndd-title size="5"><h5>Outputs</h5></ndd-title>
+      <ndd-title size="5" data-testid="section-outputs"><h5>Outputs</h5></ndd-title>
       <ndd-spacer size="8"></ndd-spacer>
       <ndd-list variant="box">
         <ndd-list-item v-for="(output, index) in outputs" :key="output.name" size="md">
@@ -197,8 +199,8 @@ function addOutput() {
     </template>
 
     <!-- Acties -->
-    <template v-if="actions.length">
-      <ndd-title size="5"><h5>Acties</h5></ndd-title>
+    <template v-if="actions.length || editable">
+      <ndd-title size="5" data-testid="section-actions"><h5>Acties</h5></ndd-title>
       <ndd-spacer size="8"></ndd-spacer>
       <ndd-list variant="box">
         <ndd-list-item v-for="(action, index) in actions" :key="index" size="md">
@@ -206,6 +208,9 @@ function addOutput() {
           <ndd-cell>
             <ndd-button @click="emit('open-action', action)" :text="editable ? 'Bewerk' : 'Bekijk'"></ndd-button>
           </ndd-cell>
+        </ndd-list-item>
+        <ndd-list-item v-if="editable" size="md">
+          <ndd-button start-icon="plus-small" data-testid="add-action-btn" @click="emit('add-action')" text="Voeg actie toe"></ndd-button>
         </ndd-list-item>
       </ndd-list>
       <ndd-spacer size="16"></ndd-spacer>

--- a/frontend/src/components/OperationSettings.vue
+++ b/frontend/src/components/OperationSettings.vue
@@ -37,6 +37,17 @@ const ARITHMETIC_OPS = new Set(['ADD', 'SUBTRACT', 'MULTIPLY', 'DIVIDE', 'MIN', 
 
 const isComparisonOp = computed(() => COMPARISON_OPS.has(props.operation?.operation));
 
+const canAddValue = computed(() => {
+  const op = props.operation?.operation;
+  // Structural-slot ops have no concept of "add a value"
+  return op && op !== 'NOT' && op !== 'IF' && op !== 'SWITCH';
+});
+
+const canAddNestedOperation = computed(() => {
+  const op = props.operation?.operation;
+  return op && !isComparisonOp.value && op !== 'NOT' && op !== 'IF' && op !== 'SWITCH';
+});
+
 const operationValues = computed(() => {
   const node = props.operation?.node;
   if (!node) return [];
@@ -264,6 +275,10 @@ function addValue() {
   const node = props.operation?.node;
   if (!node) return;
 
+  // Don't inject values[] into nodes with structural value slots
+  // (NOT uses single 'value', IF uses when/then/else, SWITCH uses cases/default)
+  if (node.operation === 'NOT' || node.operation === 'IF' || node.operation === 'SWITCH') return;
+
   if (Array.isArray(node.values)) {
     node.values.push(0);
   } else if (Array.isArray(node.conditions)) {
@@ -344,10 +359,10 @@ function addNestedOperation() {
       </ndd-list-item>
 
       <!-- Add value -->
-      <ndd-list-item size="md">
+      <ndd-list-item v-if="canAddValue || canAddNestedOperation" size="md">
         <div class="add-value-buttons">
-          <ndd-button size="md" start-icon="plus-small" data-testid="add-value-btn" @click="addValue" text="Voeg waarde toe"></ndd-button>
-          <ndd-button v-if="!isComparisonOp" size="md" start-icon="plus-small" data-testid="add-nested-op-btn" @click="addNestedOperation" text="Voeg operatie toe"></ndd-button>
+          <ndd-button v-if="canAddValue" size="md" start-icon="plus-small" data-testid="add-value-btn" @click="addValue" text="Voeg waarde toe"></ndd-button>
+          <ndd-button v-if="canAddNestedOperation" size="md" start-icon="plus-small" data-testid="add-nested-op-btn" @click="addNestedOperation" text="Voeg operatie toe"></ndd-button>
         </div>
       </ndd-list-item>
     </ndd-list>

--- a/frontend/src/components/OperationSettings.vue
+++ b/frontend/src/components/OperationSettings.vue
@@ -42,6 +42,8 @@ const canAddValue = computed(() => {
   if (!op) return false;
   // Structural-slot ops have no concept of "add a value"
   if (op === 'NOT' || op === 'IF' || op === 'SWITCH') return false;
+  // NOT_NULL never takes a value field (it only checks the subject is non-null)
+  if (op === 'NOT_NULL') return false;
   // Logical ops only accept nested operations as conditions; "Voeg waarde toe"
   // would push an EQUALS predicate identical to "Voeg operatie toe", so we
   // suppress the duplicate button.
@@ -295,6 +297,8 @@ function addValue() {
   // Don't inject values[] into nodes with structural value slots
   // (NOT uses single 'value', IF uses when/then/else, SWITCH uses cases/default)
   if (node.operation === 'NOT' || node.operation === 'IF' || node.operation === 'SWITCH') return;
+  // NOT_NULL is a unary check on subject only — never a value
+  if (node.operation === 'NOT_NULL') return;
 
   if (Array.isArray(node.values)) {
     node.values.push(0);

--- a/frontend/src/components/OperationSettings.vue
+++ b/frontend/src/components/OperationSettings.vue
@@ -132,7 +132,8 @@ function changeOperationType(event) {
     } else if (newType === 'NOT_NULL') {
       delete node.value;
     } else {
-      if (node.value === undefined) node.value = '';
+      // Reset to scalar default when undefined OR when previously an array (e.g. coming from IN/NOT_IN)
+      if (node.value === undefined || Array.isArray(node.value)) node.value = '';
     }
     delete node.values;
     delete node.conditions;

--- a/frontend/src/components/OperationSettings.vue
+++ b/frontend/src/components/OperationSettings.vue
@@ -203,9 +203,13 @@ function changeOperationType(event) {
     delete node.then;
     delete node.else;
   } else if (newType === 'IF') {
-    // IF uses the same cases[]/default schema as SWITCH (one case for IF).
+    // IF uses the same cases[]/default schema as SWITCH but is single-case.
+    // Truncate any extra cases when transitioning from SWITCH so we don't
+    // produce an IF with 2+ cases that the schema would reject.
     if (!Array.isArray(node.cases) || node.cases.length === 0) {
       node.cases = [{ when: { operation: 'EQUALS', subject: '', value: '' }, then: 0 }];
+    } else if (node.cases.length > 1) {
+      node.cases = node.cases.slice(0, 1);
     }
     if (node.default === undefined) node.default = 0;
     delete node.values;

--- a/frontend/src/components/OperationSettings.vue
+++ b/frontend/src/components/OperationSettings.vue
@@ -67,11 +67,20 @@ const canAddNestedOperation = computed(() => {
 // cannot delete them and silently produce an invalid node.
 function canRemoveValue(val) {
   if (!props.editable) return false;
+  const node = props.operation?.node;
+  const op = props.operation?.operation;
   if (isComparisonOp.value && (val._kind === 'subject' || val._kind === 'value')) return false;
   // IF needs when/then/else
-  if (props.operation?.operation === 'IF' && (val._kind === 'when' || val._kind === 'then' || val._kind === 'else')) return false;
+  if (op === 'IF' && (val._kind === 'when' || val._kind === 'then' || val._kind === 'else')) return false;
   // NOT needs value
-  if (props.operation?.operation === 'NOT' && val._kind === 'value') return false;
+  if (op === 'NOT' && val._kind === 'value') return false;
+  // SWITCH needs a default branch
+  if (op === 'SWITCH' && val._kind === 'default') return false;
+  // AND/OR/arithmetic ops need at least one entry — block removal of the
+  // last condition or value so the user can't drain conditions: [] / values: []
+  // and produce a semantically undefined node.
+  if (val._kind === 'conditions' && Array.isArray(node?.conditions) && node.conditions.length <= 1) return false;
+  if (val._kind === 'values' && Array.isArray(node?.values) && node.values.length <= 1) return false;
   return true;
 }
 

--- a/frontend/src/components/OperationSettings.vue
+++ b/frontend/src/components/OperationSettings.vue
@@ -175,13 +175,14 @@ function changeOperationType(event) {
 
   if (COMPARISON_OPS.has(newType)) {
     if (node.subject === undefined) node.subject = '';
-    if (newType === 'IN' || newType === 'NOT_IN') {
-      if (!Array.isArray(node.value)) node.value = [];
-    } else if (newType === 'NOT_NULL') {
+    if (newType === 'NOT_NULL') {
       delete node.value;
     } else {
-      // Reset to scalar default when undefined OR when previously an array (e.g. coming from IN/NOT_IN)
-      if (node.value === undefined || Array.isArray(node.value)) node.value = '';
+      // For all other comparison ops (including IN/NOT_IN), seed value as
+      // an empty string. The UI dropdown lets the user pick a variable
+      // reference that resolves to a list at runtime; arrays as literal
+      // values can be entered through the YAML pane.
+      if (node.value === undefined || node.value === null) node.value = '';
     }
     delete node.values;
     delete node.conditions;

--- a/frontend/src/components/OperationSettings.vue
+++ b/frontend/src/components/OperationSettings.vue
@@ -10,6 +10,7 @@ import {
 const props = defineProps({
   operation: { type: Object, default: null },
   article: { type: Object, default: null },
+  editable: { type: Boolean, default: false },
 });
 
 const emit = defineEmits(['select-operation']);
@@ -38,6 +39,7 @@ const ARITHMETIC_OPS = new Set(['ADD', 'SUBTRACT', 'MULTIPLY', 'DIVIDE', 'MIN', 
 const isComparisonOp = computed(() => COMPARISON_OPS.has(props.operation?.operation));
 
 const canAddValue = computed(() => {
+  if (!props.editable) return false;
   const op = props.operation?.operation;
   if (!op) return false;
   // Structural-slot ops have no concept of "add a value"
@@ -52,6 +54,7 @@ const canAddValue = computed(() => {
 });
 
 const canAddNestedOperation = computed(() => {
+  if (!props.editable) return false;
   const op = props.operation?.operation;
   return op && !isComparisonOp.value && op !== 'NOT' && op !== 'IF' && op !== 'SWITCH';
 });
@@ -59,6 +62,7 @@ const canAddNestedOperation = computed(() => {
 // Required structural fields whose minus button must be hidden so the user
 // cannot delete them and silently produce an invalid node.
 function canRemoveValue(val) {
+  if (!props.editable) return false;
   if (isComparisonOp.value && (val._kind === 'subject' || val._kind === 'value')) return false;
   // IF needs when/then/else
   if (props.operation?.operation === 'IF' && (val._kind === 'when' || val._kind === 'then' || val._kind === 'else')) return false;
@@ -338,7 +342,7 @@ function addNestedOperation() {
       <ndd-list-item size="md">
         <ndd-text-cell text="Titel" max-width="120"></ndd-text-cell>
         <ndd-cell>
-          <ndd-text-field size="md" :value="operation.title" @input="operation.title = $event.target?.value ?? $event.detail?.value ?? operation.title"></ndd-text-field>
+          <ndd-text-field size="md" :value="operation.title" :readonly="!editable" @input="editable && (operation.title = $event.target?.value ?? $event.detail?.value ?? operation.title)"></ndd-text-field>
         </ndd-cell>
       </ndd-list-item>
 
@@ -347,7 +351,7 @@ function addNestedOperation() {
         <ndd-text-cell text="Type" max-width="120"></ndd-text-cell>
         <ndd-cell>
           <ndd-dropdown size="md" data-testid="operation-type-dropdown">
-            <select aria-label="Operatie type" :value="operation.operation" @change="changeOperationType">
+            <select aria-label="Operatie type" :value="operation.operation" :disabled="!editable" @change="editable && changeOperationType($event)">
               <option v-for="opt in typeOptions" :key="opt.value" :value="opt.value">{{ opt.label }}</option>
             </select>
           </ndd-dropdown>
@@ -360,11 +364,11 @@ function addNestedOperation() {
         <ndd-cell>
           <div class="value-row">
             <template v-if="isLiteralValue(val._value)">
-              <ndd-text-field size="md" :value="String(val._value)" is-full-width @input="updateValue(val, $event)"></ndd-text-field>
+              <ndd-text-field size="md" :value="String(val._value)" is-full-width :readonly="!editable" @input="editable && updateValue(val, $event)"></ndd-text-field>
             </template>
             <template v-else>
               <ndd-dropdown size="md" style="flex: 1; min-width: 0;">
-                <select :aria-label="val._label" :value="currentDropdownValue(val._value)" @change="updateDropdownValue(val, $event)">
+                <select :aria-label="val._label" :value="currentDropdownValue(val._value)" :disabled="!editable" @change="editable && updateDropdownValue(val, $event)">
                   <option v-for="opt in valueDropdownOptions(val._value)" :key="opt.value" :value="opt.value" :selected="opt.value === currentDropdownValue(val._value)">{{ opt.label }}</option>
                 </select>
               </ndd-dropdown>

--- a/frontend/src/components/OperationSettings.vue
+++ b/frontend/src/components/OperationSettings.vue
@@ -39,14 +39,31 @@ const isComparisonOp = computed(() => COMPARISON_OPS.has(props.operation?.operat
 
 const canAddValue = computed(() => {
   const op = props.operation?.operation;
+  if (!op) return false;
   // Structural-slot ops have no concept of "add a value"
-  return op && op !== 'NOT' && op !== 'IF' && op !== 'SWITCH';
+  if (op === 'NOT' || op === 'IF' || op === 'SWITCH') return false;
+  // Logical ops only accept nested operations as conditions; "Voeg waarde toe"
+  // would push an EQUALS predicate identical to "Voeg operatie toe", so we
+  // suppress the duplicate button.
+  if (LOGICAL_OPS.has(op)) return false;
+  return true;
 });
 
 const canAddNestedOperation = computed(() => {
   const op = props.operation?.operation;
   return op && !isComparisonOp.value && op !== 'NOT' && op !== 'IF' && op !== 'SWITCH';
 });
+
+// Required structural fields whose minus button must be hidden so the user
+// cannot delete them and silently produce an invalid node.
+function canRemoveValue(val) {
+  if (isComparisonOp.value && (val._kind === 'subject' || val._kind === 'value')) return false;
+  // IF needs when/then/else
+  if (props.operation?.operation === 'IF' && (val._kind === 'when' || val._kind === 'then' || val._kind === 'else')) return false;
+  // NOT needs value
+  if (props.operation?.operation === 'NOT' && val._kind === 'value') return false;
+  return true;
+}
 
 const operationValues = computed(() => {
   const node = props.operation?.node;
@@ -348,7 +365,7 @@ function addNestedOperation() {
                 </select>
               </ndd-dropdown>
             </template>
-            <ndd-icon-button v-if="!(isComparisonOp && (val._kind === 'subject' || val._kind === 'value'))" icon="minus" title="Verwijder waarde" @click="removeValue(val)">
+            <ndd-icon-button v-if="canRemoveValue(val)" icon="minus" title="Verwijder waarde" @click="removeValue(val)">
             </ndd-icon-button>
           </div>
           <p v-if="isNestedOperation(val._value)" class="value-help-text">

--- a/frontend/src/components/OperationSettings.vue
+++ b/frontend/src/components/OperationSettings.vue
@@ -291,6 +291,13 @@ function removeValue(val) {
     delete node.then;
   } else if (val._kind === 'else') {
     delete node.else;
+  } else if (val._kind === 'case-when' && val._caseIndex !== undefined && Array.isArray(node.cases)) {
+    // Removing the predicate from a switch case removes the whole case entry
+    node.cases.splice(val._caseIndex, 1);
+  } else if (val._kind === 'case-then' && val._caseIndex !== undefined && Array.isArray(node.cases)) {
+    node.cases.splice(val._caseIndex, 1);
+  } else if (val._kind === 'default') {
+    delete node.default;
   }
 }
 
@@ -342,7 +349,9 @@ function addNestedOperation() {
       <ndd-list-item size="md">
         <ndd-text-cell text="Titel" max-width="120"></ndd-text-cell>
         <ndd-cell>
-          <ndd-text-field size="md" :value="operation.title" :readonly="!editable" @input="editable && (operation.title = $event.target?.value ?? $event.detail?.value ?? operation.title)"></ndd-text-field>
+          <!-- Title is derived from the operation type (humanized) and not a
+               persistable YAML field, so it's display-only. -->
+          <ndd-text-field size="md" :value="operation.title" readonly></ndd-text-field>
         </ndd-cell>
       </ndd-list-item>
 

--- a/frontend/src/components/OperationSettings.vue
+++ b/frontend/src/components/OperationSettings.vue
@@ -32,6 +32,9 @@ const COMPARISON_OPS = new Set([
   'LESS_THAN', 'LESS_THAN_OR_EQUAL', 'NOT_NULL', 'IN', 'NOT_IN',
 ]);
 
+const LOGICAL_OPS = new Set(['AND', 'OR']);
+const ARITHMETIC_OPS = new Set(['ADD', 'SUBTRACT', 'MULTIPLY', 'DIVIDE', 'MIN', 'MAX', 'CONCAT']);
+
 const isComparisonOp = computed(() => COMPARISON_OPS.has(props.operation?.operation));
 
 const operationValues = computed(() => {
@@ -40,16 +43,18 @@ const operationValues = computed(() => {
 
   if (isComparisonOp.value) {
     const vals = [];
-    if (node.subject != null) vals.push({ _label: 'Onderwerp', _value: node.subject, _kind: 'subject' });
-    if (node.value !== undefined) vals.push({ _label: 'Waarde', _value: node.value, _kind: 'value' });
+    vals.push({ _label: 'Onderwerp', _value: node.subject ?? '', _kind: 'subject' });
+    if (node.operation !== 'NOT_NULL') {
+      vals.push({ _label: 'Waarde', _value: node.value ?? '', _kind: 'value' });
+    }
     return vals;
   }
 
   if (node.operation === 'IF') {
     const vals = [];
-    if (node.when) vals.push({ _label: 'Voorwaarde', _value: node.when, _kind: 'operation' });
-    if (node.then !== undefined) vals.push({ _label: 'Dan', _value: node.then, _kind: 'value' });
-    if (node.else !== undefined) vals.push({ _label: 'Anders', _value: node.else, _kind: 'value' });
+    if (node.when) vals.push({ _label: 'Voorwaarde', _value: node.when, _kind: 'when' });
+    if (node.then !== undefined) vals.push({ _label: 'Dan', _value: node.then, _kind: 'then' });
+    if (node.else !== undefined) vals.push({ _label: 'Anders', _value: node.else, _kind: 'else' });
     return vals;
   }
 
@@ -57,19 +62,19 @@ const operationValues = computed(() => {
     const vals = [];
     if (Array.isArray(node.cases)) {
       node.cases.forEach((c, i) => {
-        if (c.when !== undefined) vals.push({ _label: `Geval ${i + 1} — als`, _value: c.when, _kind: 'value' });
-        if (c.then !== undefined) vals.push({ _label: `Geval ${i + 1} — dan`, _value: c.then, _kind: 'value' });
+        if (c.when !== undefined) vals.push({ _label: `Geval ${i + 1} — als`, _value: c.when, _kind: 'case-when', _caseIndex: i });
+        if (c.then !== undefined) vals.push({ _label: `Geval ${i + 1} — dan`, _value: c.then, _kind: 'case-then', _caseIndex: i });
       });
     }
-    if (node.default !== undefined) vals.push({ _label: 'Standaard', _value: node.default, _kind: 'value' });
+    if (node.default !== undefined) vals.push({ _label: 'Standaard', _value: node.default, _kind: 'default' });
     return vals;
   }
 
   if (Array.isArray(node.values)) {
-    return node.values.map((v, i) => ({ _label: `Waarde ${i + 1}`, _value: v, _kind: 'value' }));
+    return node.values.map((v, i) => ({ _label: `Waarde ${i + 1}`, _value: v, _kind: 'values', _index: i }));
   }
   if (Array.isArray(node.conditions)) {
-    return node.conditions.map((c, i) => ({ _label: `Conditie ${i + 1}`, _value: c, _kind: 'condition' }));
+    return node.conditions.map((c, i) => ({ _label: `Conditie ${i + 1}`, _value: c, _kind: 'conditions', _index: i }));
   }
 
   const vals = [];
@@ -100,6 +105,188 @@ function currentDropdownValue(val) {
   if (typeof val === 'string' && val.startsWith('$')) return val;
   return String(val);
 }
+
+// --- Mutation helpers ---
+
+function parseInputValue(str) {
+  if (str === 'true') return true;
+  if (str === 'false') return false;
+  const n = Number(str);
+  if (!isNaN(n) && str.trim() !== '') return n;
+  return str;
+}
+
+function changeOperationType(event) {
+  const node = props.operation?.node;
+  if (!node) return;
+  const newType = event.target.value;
+  const oldType = node.operation;
+  if (newType === oldType) return;
+
+  node.operation = newType;
+
+  if (COMPARISON_OPS.has(newType)) {
+    if (node.subject === undefined) node.subject = '';
+    if (newType === 'IN' || newType === 'NOT_IN') {
+      if (!Array.isArray(node.value)) node.value = [];
+    } else if (newType === 'NOT_NULL') {
+      delete node.value;
+    } else {
+      if (node.value === undefined) node.value = '';
+    }
+    delete node.values;
+    delete node.conditions;
+    delete node.cases;
+    delete node.default;
+    delete node.when;
+    delete node.then;
+    delete node.else;
+  } else if (LOGICAL_OPS.has(newType)) {
+    if (!Array.isArray(node.conditions)) {
+      node.conditions = [];
+    }
+    delete node.values;
+    delete node.subject;
+    delete node.value;
+    delete node.cases;
+    delete node.default;
+    delete node.when;
+    delete node.then;
+    delete node.else;
+  } else if (newType === 'IF') {
+    if (!node.when) node.when = { operation: 'EQUALS', subject: '', value: '' };
+    if (node.then === undefined) node.then = 0;
+    if (node.else === undefined) node.else = 0;
+    delete node.values;
+    delete node.conditions;
+    delete node.cases;
+    delete node.default;
+    delete node.subject;
+    delete node.value;
+  } else if (newType === 'NOT') {
+    if (node.value === undefined) {
+      node.value = node.subject ?? '';
+    }
+    delete node.values;
+    delete node.conditions;
+    delete node.cases;
+    delete node.default;
+    delete node.subject;
+    delete node.when;
+    delete node.then;
+    delete node.else;
+  } else if (newType === 'SWITCH') {
+    if (!Array.isArray(node.cases)) node.cases = [];
+    if (node.default === undefined) node.default = '';
+    delete node.values;
+    delete node.conditions;
+    delete node.subject;
+    delete node.value;
+    delete node.when;
+    delete node.then;
+    delete node.else;
+  } else if (ARITHMETIC_OPS.has(newType)) {
+    if (!Array.isArray(node.values)) {
+      node.values = [];
+    }
+    delete node.conditions;
+    delete node.cases;
+    delete node.default;
+    delete node.subject;
+    delete node.value;
+    delete node.when;
+    delete node.then;
+    delete node.else;
+  }
+}
+
+function updateValue(val, event) {
+  const node = props.operation?.node;
+  if (!node) return;
+  const newVal = parseInputValue(event.target?.value ?? event.detail?.value ?? '');
+
+  if (val._kind === 'subject') node.subject = newVal;
+  else if (val._kind === 'value') node.value = newVal;
+  else if (val._kind === 'when') node.when = newVal;
+  else if (val._kind === 'then') node.then = newVal;
+  else if (val._kind === 'else') node.else = newVal;
+  else if (val._kind === 'values' && val._index !== undefined) node.values[val._index] = newVal;
+  else if (val._kind === 'conditions' && val._index !== undefined) node.conditions[val._index] = newVal;
+  else if (val._kind === 'default') node.default = newVal;
+  else if (val._kind === 'case-when') node.cases[val._caseIndex].when = newVal;
+  else if (val._kind === 'case-then') node.cases[val._caseIndex].then = newVal;
+}
+
+function updateDropdownValue(val, event) {
+  const node = props.operation?.node;
+  if (!node) return;
+  const selected = event.target.value;
+  if (selected === '__nested__') return;
+  if (isNestedOperation(val._value)) return;
+
+  const newVal = selected.startsWith('$') ? selected : parseInputValue(selected);
+
+  if (val._kind === 'subject') node.subject = newVal;
+  else if (val._kind === 'value') node.value = newVal;
+  else if (val._kind === 'when') node.when = newVal;
+  else if (val._kind === 'then') node.then = newVal;
+  else if (val._kind === 'else') node.else = newVal;
+  else if (val._kind === 'values' && val._index !== undefined) node.values[val._index] = newVal;
+  else if (val._kind === 'conditions' && val._index !== undefined) node.conditions[val._index] = newVal;
+  else if (val._kind === 'default') node.default = newVal;
+  else if (val._kind === 'case-when') node.cases[val._caseIndex].when = newVal;
+  else if (val._kind === 'case-then') node.cases[val._caseIndex].then = newVal;
+}
+
+function removeValue(val) {
+  const node = props.operation?.node;
+  if (!node) return;
+
+  if (val._kind === 'values' && val._index !== undefined && Array.isArray(node.values)) {
+    node.values.splice(val._index, 1);
+  } else if (val._kind === 'conditions' && val._index !== undefined && Array.isArray(node.conditions)) {
+    node.conditions.splice(val._index, 1);
+  } else if (val._kind === 'subject') {
+    delete node.subject;
+  } else if (val._kind === 'value') {
+    delete node.value;
+  } else if (val._kind === 'when') {
+    delete node.when;
+  } else if (val._kind === 'then') {
+    delete node.then;
+  } else if (val._kind === 'else') {
+    delete node.else;
+  }
+}
+
+function addValue() {
+  const node = props.operation?.node;
+  if (!node) return;
+
+  if (Array.isArray(node.values)) {
+    node.values.push(0);
+  } else if (Array.isArray(node.conditions)) {
+    node.conditions.push({ operation: 'EQUALS', subject: '', value: '' });
+  } else if (isComparisonOp.value) {
+    if (node.subject === undefined) node.subject = '';
+    else if (node.value === undefined) node.value = '';
+  } else {
+    if (!node.values) node.values = [];
+    node.values.push(0);
+  }
+}
+
+function addNestedOperation() {
+  const node = props.operation?.node;
+  if (!node || isComparisonOp.value) return;
+  if (node.operation === 'NOT' || node.operation === 'IF' || node.operation === 'SWITCH') return;
+
+  if (Array.isArray(node.conditions)) {
+    node.conditions.push({ operation: 'EQUALS', subject: '', value: '' });
+  } else if (Array.isArray(node.values)) {
+    node.values.push({ operation: 'ADD', values: [] });
+  }
+}
 </script>
 
 <template>
@@ -114,7 +301,7 @@ function currentDropdownValue(val) {
       <ndd-list-item size="md">
         <ndd-text-cell text="Titel" max-width="120"></ndd-text-cell>
         <ndd-cell>
-          <ndd-text-field size="md" :value="operation.title"></ndd-text-field>
+          <ndd-text-field size="md" :value="operation.title" @input="operation.title = $event.target?.value ?? $event.detail?.value ?? operation.title"></ndd-text-field>
         </ndd-cell>
       </ndd-list-item>
 
@@ -122,8 +309,8 @@ function currentDropdownValue(val) {
       <ndd-list-item size="md">
         <ndd-text-cell text="Type" max-width="120"></ndd-text-cell>
         <ndd-cell>
-          <ndd-dropdown size="md">
-            <select aria-label="Operatie type" :value="operation.operation">
+          <ndd-dropdown size="md" data-testid="operation-type-dropdown">
+            <select aria-label="Operatie type" :value="operation.operation" @change="changeOperationType">
               <option v-for="opt in typeOptions" :key="opt.value" :value="opt.value">{{ opt.label }}</option>
             </select>
           </ndd-dropdown>
@@ -131,21 +318,21 @@ function currentDropdownValue(val) {
       </ndd-list-item>
 
       <!-- Waarde rows -->
-      <ndd-list-item v-for="(val, i) in operationValues" :key="i" size="md">
+      <ndd-list-item v-for="(val, i) in operationValues" :key="i" size="md" :data-testid="`op-value-${i}`">
         <ndd-text-cell :text="val._label" max-width="120"></ndd-text-cell>
         <ndd-cell>
           <div class="value-row">
             <template v-if="isLiteralValue(val._value)">
-              <ndd-text-field size="md" :value="String(val._value)" is-full-width></ndd-text-field>
+              <ndd-text-field size="md" :value="String(val._value)" is-full-width @input="updateValue(val, $event)"></ndd-text-field>
             </template>
             <template v-else>
               <ndd-dropdown size="md" style="flex: 1; min-width: 0;">
-                <select :aria-label="val._label" :value="currentDropdownValue(val._value)">
+                <select :aria-label="val._label" :value="currentDropdownValue(val._value)" @change="updateDropdownValue(val, $event)">
                   <option v-for="opt in valueDropdownOptions(val._value)" :key="opt.value" :value="opt.value" :selected="opt.value === currentDropdownValue(val._value)">{{ opt.label }}</option>
                 </select>
               </ndd-dropdown>
             </template>
-            <ndd-icon-button icon="minus" title="Verwijder waarde">
+            <ndd-icon-button v-if="!(isComparisonOp && (val._kind === 'subject' || val._kind === 'value'))" icon="minus" title="Verwijder waarde" @click="removeValue(val)">
             </ndd-icon-button>
           </div>
           <p v-if="isNestedOperation(val._value)" class="value-help-text">
@@ -157,7 +344,10 @@ function currentDropdownValue(val) {
 
       <!-- Add value -->
       <ndd-list-item size="md">
-        <ndd-button size="md" start-icon="plus-small" style="width: 100%;" text="Voeg waarde toe"></ndd-button>
+        <div class="add-value-buttons">
+          <ndd-button size="md" start-icon="plus-small" data-testid="add-value-btn" @click="addValue" text="Voeg waarde toe"></ndd-button>
+          <ndd-button v-if="!isComparisonOp" size="md" start-icon="plus-small" data-testid="add-nested-op-btn" @click="addNestedOperation" text="Voeg operatie toe"></ndd-button>
+        </div>
       </ndd-list-item>
     </ndd-list>
   </template>
@@ -183,6 +373,12 @@ function currentDropdownValue(val) {
 .value-row ndd-dropdown {
   flex: 1;
   min-width: 0;
+}
+
+.add-value-buttons {
+  display: flex;
+  gap: 8px;
+  width: 100%;
 }
 
 .value-help-text {

--- a/frontend/src/components/OperationSettings.vue
+++ b/frontend/src/components/OperationSettings.vue
@@ -70,12 +70,16 @@ function canRemoveValue(val) {
   const node = props.operation?.node;
   const op = props.operation?.operation;
   if (isComparisonOp.value && (val._kind === 'subject' || val._kind === 'value')) return false;
-  // IF needs when/then/else
-  if (op === 'IF' && (val._kind === 'when' || val._kind === 'then' || val._kind === 'else')) return false;
   // NOT needs value
   if (op === 'NOT' && val._kind === 'value') return false;
-  // SWITCH needs a default branch
-  if (op === 'SWITCH' && val._kind === 'default') return false;
+  // IF and SWITCH share the cases[]/default schema and both need a default branch
+  if ((op === 'IF' || op === 'SWITCH') && val._kind === 'default') return false;
+  // IF must keep its single case; SWITCH must keep at least one case.
+  // Removing the case-when or case-then deletes the whole case entry.
+  if ((val._kind === 'case-when' || val._kind === 'case-then') && Array.isArray(node?.cases)) {
+    if (op === 'IF') return false;
+    if (op === 'SWITCH' && node.cases.length <= 1) return false;
+  }
   // AND/OR/arithmetic ops need at least one entry — block removal of the
   // last condition or value so the user can't drain conditions: [] / values: []
   // and produce a semantically undefined node.
@@ -97,23 +101,20 @@ const operationValues = computed(() => {
     return vals;
   }
 
-  if (node.operation === 'IF') {
+  // IF and SWITCH share the same cases[]/default schema. The only difference
+  // is semantic (IF is single-case, SWITCH is multi-case) and how the user
+  // labels each branch.
+  if (node.operation === 'IF' || node.operation === 'SWITCH') {
     const vals = [];
-    if (node.when) vals.push({ _label: 'Voorwaarde', _value: node.when, _kind: 'when' });
-    if (node.then !== undefined) vals.push({ _label: 'Dan', _value: node.then, _kind: 'then' });
-    if (node.else !== undefined) vals.push({ _label: 'Anders', _value: node.else, _kind: 'else' });
-    return vals;
-  }
-
-  if (node.operation === 'SWITCH') {
-    const vals = [];
+    const isSwitch = node.operation === 'SWITCH';
     if (Array.isArray(node.cases)) {
       node.cases.forEach((c, i) => {
-        if (c.when !== undefined) vals.push({ _label: `Geval ${i + 1} — als`, _value: c.when, _kind: 'case-when', _caseIndex: i });
-        if (c.then !== undefined) vals.push({ _label: `Geval ${i + 1} — dan`, _value: c.then, _kind: 'case-then', _caseIndex: i });
+        const prefix = isSwitch ? `Geval ${i + 1} — ` : '';
+        if (c?.when !== undefined) vals.push({ _label: `${prefix}als`, _value: c.when, _kind: 'case-when', _caseIndex: i });
+        if (c?.then !== undefined) vals.push({ _label: `${prefix}dan`, _value: c.then, _kind: 'case-then', _caseIndex: i });
       });
     }
-    if (node.default !== undefined) vals.push({ _label: 'Standaard', _value: node.default, _kind: 'default' });
+    if (node.default !== undefined) vals.push({ _label: isSwitch ? 'Standaard' : 'Anders', _value: node.default, _kind: 'default' });
     return vals;
   }
 
@@ -202,15 +203,18 @@ function changeOperationType(event) {
     delete node.then;
     delete node.else;
   } else if (newType === 'IF') {
-    if (!node.when) node.when = { operation: 'EQUALS', subject: '', value: '' };
-    if (node.then === undefined) node.then = 0;
-    if (node.else === undefined) node.else = 0;
+    // IF uses the same cases[]/default schema as SWITCH (one case for IF).
+    if (!Array.isArray(node.cases) || node.cases.length === 0) {
+      node.cases = [{ when: { operation: 'EQUALS', subject: '', value: '' }, then: 0 }];
+    }
+    if (node.default === undefined) node.default = 0;
     delete node.values;
     delete node.conditions;
-    delete node.cases;
-    delete node.default;
     delete node.subject;
     delete node.value;
+    delete node.when;
+    delete node.then;
+    delete node.else;
   } else if (newType === 'NOT') {
     if (node.value === undefined) {
       node.value = node.subject ?? '';
@@ -224,8 +228,11 @@ function changeOperationType(event) {
     delete node.then;
     delete node.else;
   } else if (newType === 'SWITCH') {
-    if (!Array.isArray(node.cases)) node.cases = [];
-    if (node.default === undefined) node.default = '';
+    // Schema requires at least one case
+    if (!Array.isArray(node.cases) || node.cases.length === 0) {
+      node.cases = [{ when: { operation: 'EQUALS', subject: '', value: '' }, then: 0 }];
+    }
+    if (node.default === undefined) node.default = 0;
     delete node.values;
     delete node.conditions;
     delete node.subject;
@@ -248,42 +255,32 @@ function changeOperationType(event) {
   }
 }
 
-function updateValue(val, event) {
+function applyValueMutation(val, newVal) {
   const node = props.operation?.node;
   if (!node) return;
-  const newVal = parseInputValue(event.target?.value ?? event.detail?.value ?? '');
-
   if (val._kind === 'subject') node.subject = newVal;
   else if (val._kind === 'value') node.value = newVal;
-  else if (val._kind === 'when') node.when = newVal;
-  else if (val._kind === 'then') node.then = newVal;
-  else if (val._kind === 'else') node.else = newVal;
   else if (val._kind === 'values' && val._index !== undefined) node.values[val._index] = newVal;
   else if (val._kind === 'conditions' && val._index !== undefined) node.conditions[val._index] = newVal;
   else if (val._kind === 'default') node.default = newVal;
-  else if (val._kind === 'case-when') node.cases[val._caseIndex].when = newVal;
-  else if (val._kind === 'case-then') node.cases[val._caseIndex].then = newVal;
+  else if (val._kind === 'case-when' && val._caseIndex !== undefined && Array.isArray(node.cases)) {
+    node.cases[val._caseIndex].when = newVal;
+  } else if (val._kind === 'case-then' && val._caseIndex !== undefined && Array.isArray(node.cases)) {
+    node.cases[val._caseIndex].then = newVal;
+  }
+}
+
+function updateValue(val, event) {
+  const newVal = parseInputValue(event.target?.value ?? event.detail?.value ?? '');
+  applyValueMutation(val, newVal);
 }
 
 function updateDropdownValue(val, event) {
-  const node = props.operation?.node;
-  if (!node) return;
   const selected = event.target.value;
   if (selected === '__nested__') return;
   if (isNestedOperation(val._value)) return;
-
   const newVal = selected.startsWith('$') ? selected : parseInputValue(selected);
-
-  if (val._kind === 'subject') node.subject = newVal;
-  else if (val._kind === 'value') node.value = newVal;
-  else if (val._kind === 'when') node.when = newVal;
-  else if (val._kind === 'then') node.then = newVal;
-  else if (val._kind === 'else') node.else = newVal;
-  else if (val._kind === 'values' && val._index !== undefined) node.values[val._index] = newVal;
-  else if (val._kind === 'conditions' && val._index !== undefined) node.conditions[val._index] = newVal;
-  else if (val._kind === 'default') node.default = newVal;
-  else if (val._kind === 'case-when') node.cases[val._caseIndex].when = newVal;
-  else if (val._kind === 'case-then') node.cases[val._caseIndex].then = newVal;
+  applyValueMutation(val, newVal);
 }
 
 function removeValue(val) {
@@ -298,16 +295,8 @@ function removeValue(val) {
     delete node.subject;
   } else if (val._kind === 'value') {
     delete node.value;
-  } else if (val._kind === 'when') {
-    delete node.when;
-  } else if (val._kind === 'then') {
-    delete node.then;
-  } else if (val._kind === 'else') {
-    delete node.else;
-  } else if (val._kind === 'case-when' && val._caseIndex !== undefined && Array.isArray(node.cases)) {
-    // Removing the predicate from a switch case removes the whole case entry
-    node.cases.splice(val._caseIndex, 1);
-  } else if (val._kind === 'case-then' && val._caseIndex !== undefined && Array.isArray(node.cases)) {
+  } else if ((val._kind === 'case-when' || val._kind === 'case-then') && val._caseIndex !== undefined && Array.isArray(node.cases)) {
+    // Removing either side of a case entry removes the whole case
     node.cases.splice(val._caseIndex, 1);
   } else if (val._kind === 'default') {
     delete node.default;

--- a/frontend/src/components/OperationSettings.vue
+++ b/frontend/src/components/OperationSettings.vue
@@ -46,6 +46,10 @@ const canAddValue = computed(() => {
   if (op === 'NOT' || op === 'IF' || op === 'SWITCH') return false;
   // NOT_NULL never takes a value field (it only checks the subject is non-null)
   if (op === 'NOT_NULL') return false;
+  // Comparison ops always have exactly subject + value (or just subject for
+  // NOT_NULL); operationValues pushes both unconditionally, so addValue() has
+  // nothing to do. Hide the button to avoid a no-op click.
+  if (COMPARISON_OPS.has(op)) return false;
   // Logical ops only accept nested operations as conditions; "Voeg waarde toe"
   // would push an EQUALS predicate identical to "Voeg operatie toe", so we
   // suppress the duplicate button.


### PR DESCRIPTION
## Summary

- Add full two-way binding to ActionSheet and OperationSettings so operation edits persist to the YAML model
- Add "Initialiseer machine_readable" button for articles without machine-readable data
- Add "Voeg actie toe" button for adding new actions from the MachineReadable view
- OperationSettings now supports: type changes with structure migration, literal/variable value editing, add/delete values, nested operation creation
- Add Playwright E2E test suite (17 tests) with stripped zorgtoeslag fixture covering init, definitions, params, inputs, outputs, action CRUD, operation binding, nested ops, and full round-trip verification

## Test plan
- [x] `npx playwright test` — 17 tests pass
- [ ] Manual verification: open editor, init machine_readable on empty article, add definitions/params/inputs/outputs via EditSheet, add actions via ActionSheet, verify YAML pane updates