### PR TITLE
feat(editor): VLAM-powered AI operation titles in action sheet

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,9 +15,10 @@ WORKER_MAX_POLL_INTERVAL_SECS=60
 # LLM_PROVIDER=opencode
 # OPENCODE_MODEL=vlam/ubiops-deployment/bzk-dig-mistralmedium-flexibel//chat-model
 
-# === Enrich Worker: VLAM API Key (for opencode provider) ===
+# === VLAM API (shared by enrich-worker and editor for AI features) ===
 # VLAM_API_KEY=
 # VLAM_BASE_URL=
+# VLAM_MODEL=
 
 # === Enrich Worker: Anthropic API Key (for claude provider) ===
 # ANTHROPIC_API_KEY=

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -75,6 +75,10 @@ services:
       dockerfile: frontend/Dockerfile
       secrets:
         - GITHUB_TOKEN
+    environment:
+      VLAM_API_KEY: ${VLAM_API_KEY:-}
+      VLAM_BASE_URL: ${VLAM_BASE_URL:-}
+      VLAM_MODEL: ${VLAM_MODEL:-}
     ports:
       - ${FRONTEND_PORT:-3000}:8000
 

--- a/frontend/src/components/ActionSheet.vue
+++ b/frontend/src/components/ActionSheet.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { computed, ref, watch, onMounted, onUnmounted } from 'vue';
 import { buildOperationTree } from '../utils/operationTree.js';
+import { useOperationTitles } from '../composables/useOperationTitles.js';
 import OperationSettings from './OperationSettings.vue';
 
 const props = defineProps({
@@ -11,6 +12,12 @@ const props = defineProps({
 const emit = defineEmits(['close']);
 
 const operationTree = computed(() => props.action ? buildOperationTree(props.action) : []);
+
+const { aiTitles, loading: titlesLoading } = useOperationTitles(operationTree);
+
+function resolveTitle(op) {
+  return aiTitles.value[op.number] || op.title;
+}
 
 const selectedOpIndex = ref(0);
 
@@ -82,7 +89,7 @@ onUnmounted(() => {
             <rr-list variant="box">
               <rr-list-item v-for="op in parentOperations" :key="op.number" size="md">
                 <rr-text-cell>
-                  <span slot="text">{{ op.number }}. {{ op.title }}</span>
+                  <span slot="text">{{ op.number }}. {{ resolveTitle(op) }}</span>
                   <span slot="supporting-text">{{ op.subtitle }}</span>
                 </rr-text-cell>
                 <rr-cell>
@@ -95,7 +102,7 @@ onUnmounted(() => {
           </template>
 
           <!-- Section B: Operation Settings -->
-          <OperationSettings v-if="selectedOperation" :operation="selectedOperation" :article="article" @select-operation="selectOperationByNode" />
+          <OperationSettings v-if="selectedOperation" :operation="selectedOperation" :article="article" :resolved-title="resolveTitle(selectedOperation)" @select-operation="selectOperationByNode" />
         </rr-simple-section>
       </div>
 

--- a/frontend/src/components/OperationSettings.vue
+++ b/frontend/src/components/OperationSettings.vue
@@ -10,6 +10,7 @@ import {
 const props = defineProps({
   operation: { type: Object, default: null },
   article: { type: Object, default: null },
+  resolvedTitle: { type: String, default: null },
 });
 
 const emit = defineEmits(['select-operation']);
@@ -115,7 +116,7 @@ function currentDropdownValue(val) {
       <rr-list-item size="md">
         <rr-text-cell>Titel</rr-text-cell>
         <rr-cell>
-          <rr-text-field size="md" :value="operation.title"></rr-text-field>
+          <rr-text-field size="md" :value="resolvedTitle || operation.title"></rr-text-field>
         </rr-cell>
       </rr-list-item>
 

--- a/frontend/src/composables/useOperationTitles.js
+++ b/frontend/src/composables/useOperationTitles.js
@@ -1,0 +1,38 @@
+import { ref, watch } from 'vue';
+
+export function useOperationTitles(operationTree) {
+  const aiTitles = ref({});
+  const loading = ref(false);
+
+  async function fetchTitles(tree) {
+    if (!tree || tree.length === 0) {
+      aiTitles.value = {};
+      return;
+    }
+
+    loading.value = true;
+
+    try {
+      const res = await fetch('/api/ai/operation-titles', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ operations: tree }),
+      });
+
+      if (!res.ok) return;
+
+      const data = await res.json();
+      aiTitles.value = data.titles || {};
+    } catch {
+      // Silently degrade — fallback titles remain
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  watch(operationTree, (newTree) => {
+    fetchTitles(newTree);
+  }, { immediate: true });
+
+  return { aiTitles, loading };
+}

--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -3643,6 +3643,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "regelrecht-corpus",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "tokio",

--- a/packages/editor-api/Cargo.toml
+++ b/packages/editor-api/Cargo.toml
@@ -20,6 +20,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
 
 [lints.clippy]
 unwrap_used = "warn"

--- a/packages/editor-api/src/ai_handlers.rs
+++ b/packages/editor-api/src/ai_handlers.rs
@@ -1,0 +1,51 @@
+use std::collections::HashMap;
+
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::Json;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::state::AppState;
+use crate::vlam_client::VlamError;
+
+#[derive(Deserialize)]
+pub struct GenerateTitlesRequest {
+    pub operations: Value,
+}
+
+#[derive(Serialize)]
+pub struct GenerateTitlesResponse {
+    pub titles: HashMap<String, String>,
+}
+
+#[derive(Serialize)]
+pub struct ErrorResponse {
+    pub error: String,
+}
+
+pub async fn generate_operation_titles(
+    State(state): State<AppState>,
+    Json(req): Json<GenerateTitlesRequest>,
+) -> Result<Json<GenerateTitlesResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let vlam = state.vlam.as_ref().ok_or_else(|| {
+        (
+            StatusCode::NOT_IMPLEMENTED,
+            Json(ErrorResponse {
+                error: VlamError::NotConfigured.to_string(),
+            }),
+        )
+    })?;
+
+    let titles = vlam.generate_titles(&req.operations).await.map_err(|e| {
+        tracing::warn!(error = %e, "VLAM title generation failed");
+        (
+            StatusCode::BAD_GATEWAY,
+            Json(ErrorResponse {
+                error: e.to_string(),
+            }),
+        )
+    })?;
+
+    Ok(Json(GenerateTitlesResponse { titles }))
+}

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -5,16 +5,18 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use axum::middleware as axum_middleware;
-use axum::routing::get;
+use axum::routing::{get, post};
 use axum::Router;
 use tokio::sync::RwLock;
 use tower_http::services::{ServeDir, ServeFile};
 use tower_http::trace::TraceLayer;
 use tracing_subscriber::EnvFilter;
 
+mod ai_handlers;
 mod corpus_handlers;
 mod middleware;
 mod state;
+mod vlam_client;
 
 use state::{AppState, CorpusState};
 
@@ -29,8 +31,26 @@ async fn main() {
     let static_dir = env::var("STATIC_DIR").unwrap_or_else(|_| "static".to_string());
     let corpus_state = init_corpus(&static_dir).await;
 
+    let vlam = match vlam_client::VlamConfig::from_env() {
+        Some(config) => match vlam_client::VlamClient::new(config) {
+            Ok(client) => {
+                tracing::info!("VLAM AI title generation enabled");
+                Some(client)
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "failed to initialize VLAM client");
+                None
+            }
+        },
+        None => {
+            tracing::info!("VLAM_API_KEY not set, AI title generation disabled");
+            None
+        }
+    };
+
     let app_state = AppState {
         corpus: Arc::new(RwLock::new(corpus_state)),
+        vlam,
     };
 
     let index_file = PathBuf::from(&static_dir).join("index.html");
@@ -49,6 +69,10 @@ async fn main() {
         .route(
             "/api/corpus/laws/{law_id}/scenarios/{filename}",
             get(corpus_handlers::get_scenario),
+        )
+        .route(
+            "/api/ai/operation-titles",
+            post(ai_handlers::generate_operation_titles),
         );
 
     let app = Router::new()

--- a/packages/editor-api/src/state.rs
+++ b/packages/editor-api/src/state.rs
@@ -3,10 +3,14 @@ use std::sync::Arc;
 use regelrecht_corpus::SourceMap;
 use tokio::sync::RwLock;
 
+use crate::vlam_client::VlamClient;
+
 #[derive(Clone)]
 pub struct AppState {
     /// Loaded corpus sources with provenance metadata.
     pub corpus: Arc<RwLock<CorpusState>>,
+    /// Optional VLAM LLM client for AI-generated operation titles.
+    pub vlam: Option<VlamClient>,
 }
 
 /// State for the corpus subsystem.

--- a/packages/editor-api/src/vlam_client.rs
+++ b/packages/editor-api/src/vlam_client.rs
@@ -1,0 +1,160 @@
+use std::collections::HashMap;
+use std::env;
+use std::time::Duration;
+
+use serde_json::{json, Value};
+
+const DEFAULT_BASE_URL: &str = "https://api.demo.vlam.ai/v2.1/projects/poc/openai-compatible/v1";
+const DEFAULT_MODEL: &str = "vlam/ubiops-deployment/bzk-dig-mistralmedium-flexibel//chat-model";
+
+const SYSTEM_PROMPT: &str = "\
+Je bent een assistent die operatiebomen van Nederlandse wetgeving beschrijft.\n\
+\n\
+Je ontvangt een boom van operaties die een berekening of beslissing uit een wet \
+implementeren. Elke operatie heeft een nummer (bijv. \"1\", \"1.1\", \"1.1.1\") \
+en een type (ADD, SUBTRACT, IF, EQUALS, AND, etc.).\n\
+\n\
+Genereer voor elke operatie een korte, beschrijvende titel in het Nederlands die \
+uitlegt wat de operatie doet in de context van de berekening. De titel moet:\n\
+- Maximaal 8 woorden zijn\n\
+- In het Nederlands geschreven zijn\n\
+- De juridische/rekenkundige betekenis beschrijven, niet de technische operatie\n\
+- Begrijpelijk zijn voor een jurist zonder technische achtergrond\n\
+\n\
+Antwoord uitsluitend met een JSON-object waarbij de sleutels de operatienummers \
+zijn en de waarden de titels. Geen extra tekst.\n\
+\n\
+Voorbeeld:\n\
+{\"1\": \"Bereken hoogte zorgtoeslag\", \"1.1\": \"Bepaal standaardpremie\", \
+\"1.2\": \"Trek normpremie af\"}";
+
+pub struct VlamConfig {
+    api_key: String,
+    base_url: String,
+    model: String,
+}
+
+impl VlamConfig {
+    pub fn from_env() -> Option<Self> {
+        let api_key = env::var("VLAM_API_KEY").ok().filter(|k| !k.is_empty())?;
+        let base_url = env::var("VLAM_BASE_URL")
+            .ok()
+            .filter(|u| !u.is_empty())
+            .unwrap_or_else(|| DEFAULT_BASE_URL.to_string());
+        let model = env::var("VLAM_MODEL")
+            .ok()
+            .filter(|m| !m.is_empty())
+            .unwrap_or_else(|| DEFAULT_MODEL.to_string());
+        Some(Self {
+            api_key,
+            base_url,
+            model,
+        })
+    }
+}
+
+#[derive(Clone)]
+pub struct VlamClient {
+    http: reqwest::Client,
+    endpoint: String,
+    model: String,
+}
+
+impl VlamClient {
+    pub fn new(config: VlamConfig) -> Result<Self, VlamError> {
+        let mut headers = reqwest::header::HeaderMap::new();
+        let auth_value = format!("Bearer {}", config.api_key);
+        headers.insert(
+            reqwest::header::AUTHORIZATION,
+            auth_value
+                .parse()
+                .map_err(|_| VlamError::RequestFailed("invalid API key characters".to_string()))?,
+        );
+
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(30))
+            .default_headers(headers)
+            .build()
+            .map_err(|e| VlamError::RequestFailed(e.to_string()))?;
+
+        let endpoint = format!("{}/chat/completions", config.base_url.trim_end_matches('/'));
+
+        Ok(Self {
+            http,
+            endpoint,
+            model: config.model,
+        })
+    }
+
+    pub async fn generate_titles(
+        &self,
+        operations: &Value,
+    ) -> Result<HashMap<String, String>, VlamError> {
+        let body = json!({
+            "model": self.model,
+            "messages": [
+                { "role": "system", "content": SYSTEM_PROMPT },
+                { "role": "user", "content": operations.to_string() },
+            ],
+            "temperature": 0.3,
+        });
+
+        let resp = self
+            .http
+            .post(&self.endpoint)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| VlamError::RequestFailed(e.to_string()))?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            return Err(VlamError::RequestFailed(format!(
+                "VLAM returned {status}: {text}"
+            )));
+        }
+
+        let resp_json: Value = resp
+            .json()
+            .await
+            .map_err(|e| VlamError::ParseFailed(e.to_string()))?;
+
+        let content = resp_json
+            .pointer("/choices/0/message/content")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| {
+                VlamError::ParseFailed("missing choices[0].message.content".to_string())
+            })?;
+
+        // The LLM may wrap the JSON in markdown code fences; strip them.
+        let cleaned = content
+            .trim()
+            .strip_prefix("```json")
+            .or_else(|| content.trim().strip_prefix("```"))
+            .unwrap_or(content.trim());
+        let cleaned = cleaned.strip_suffix("```").unwrap_or(cleaned).trim();
+
+        let titles: HashMap<String, String> = serde_json::from_str(cleaned)
+            .map_err(|e| VlamError::ParseFailed(format!("invalid JSON from LLM: {e}")))?;
+
+        Ok(titles)
+    }
+}
+
+#[derive(Debug)]
+pub enum VlamError {
+    NotConfigured,
+    RequestFailed(String),
+    ParseFailed(String),
+}
+
+impl std::fmt::Display for VlamError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotConfigured => write!(f, "AI title generation not configured"),
+            Self::RequestFailed(msg) => write!(f, "VLAM request failed: {msg}"),
+            Self::ParseFailed(msg) => write!(f, "VLAM response parse error: {msg}"),
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `POST /api/ai/operation-titles` backend endpoint that proxies to the VLAM LLM API to generate descriptive Dutch titles for operation trees
- Frontend fetches titles async when the action sheet opens, falling back to existing `humanizeTitle()` output
- Gracefully disabled when `VLAM_API_KEY` is not configured (501, no UI error)

## Test plan

- [ ] Set `VLAM_API_KEY` and open action sheet — verify LLM titles replace fallbacks
- [ ] Without `VLAM_API_KEY` — verify fallback titles shown, no errors
- [ ] `curl -X POST /api/ai/operation-titles` with sample payload — verify JSON response
- [ ] `just check` passes