### PR TITLE
fix(deploy): conditional enrich-worker preview deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,9 @@ env:
 jobs:
   changes:
     runs-on: ubuntu-latest
-    if: github.event.action != 'closed'
+    if: >-
+      github.event.action != 'closed' &&
+      (github.event.action != 'labeled' || startsWith(github.event.label.name, 'deploy:'))
     permissions:
       contents: read
     outputs:
@@ -58,7 +60,9 @@ jobs:
   # -- Build jobs --
   # Editor always builds (not conditional on changes)
   build:
-    if: github.event.action != 'closed'
+    if: >-
+      github.event.action != 'closed' &&
+      (github.event.action != 'labeled' || startsWith(github.event.label.name, 'deploy:'))
     permissions:
       contents: read
       packages: write
@@ -105,7 +109,8 @@ jobs:
       github.event.action != 'closed' &&
       (
         (github.ref == 'refs/heads/main' && github.event_name == 'push') ||
-        needs.changes.outputs.enrich-worker == 'true'
+        needs.changes.outputs.enrich-worker == 'true' ||
+        contains(github.event.pull_request.labels.*.name, 'deploy:enrich-worker')
       )
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- Skip enrich-worker ZAD deploy for PRs that don't touch its source paths (`packages/pipeline`, `packages/corpus`, `.claude/skills/law-*`)
- Add `deploy:enrich-worker` PR label as manual override to force deploy from any PR
- Add `labeled` event trigger so adding the label kicks off the workflow

Reduces unnecessary ArgoCD syncs and resource pressure on preview deployments — currently all 8 open PRs deploy enrich-worker even when unrelated, contributing to OOM and degraded ArgoCD apps.

## How to manually deploy enrich-worker

Add the label `deploy:enrich-worker` to the PR.

## Test plan

- [ ] Verify PRs without enrich-worker changes skip the deploy step
- [ ] Verify adding `deploy:enrich-worker` label triggers deploy
- [ ] Verify production deploys are unaffected