### PR TITLE
fix(skills): add scope enforcement rules to law-generate and law-reverse-validate

### DIFF
--- a/.claude/skills/law-generate/SKILL.md
+++ b/.claude/skills/law-generate/SKILL.md
@@ -35,6 +35,43 @@ working examples in the corpus.
    `features/bijstand.feature`
 6. Count articles; if >20 articles, process in batches of ~15
 
+## FUNDAMENTAL RULE: Stay Within Scope
+
+Each `machine_readable` section must faithfully interpret ONLY the legal provision it
+belongs to — nothing more, nothing less. The scope is defined by the text field of the
+article, lid, or provision that the machine_readable is attached to.
+
+**Why this matters:** The purpose of machine-readable law is to execute what the law says,
+not what an engineer thinks is efficient. It is very tempting for the engineering mind to
+optimize: to combine conditions from multiple articles into one check, to pull in eligibility
+rules from elsewhere "because they're needed anyway", or to hardcode values that technically
+come from another provision. Resist this temptation. The whole point is to follow the law
+very strictly, even when the law is illogical, redundant, or inefficient.
+
+**Scope violations to avoid:**
+- Do NOT add conditions from other articles. If article 2 says "de verzekerde heeft
+  aanspraak op zorgtoeslag" and the age requirement comes from article 11 of another law,
+  do NOT put `leeftijd >= 18` in article 2's machine_readable. Instead, use a cross-law
+  reference (`source.regulation`) to let the other article determine eligibility.
+- Do NOT hardcode values that come from other provisions. If article 2 uses "drempelinkomen"
+  but the amount is set by a ministerial regulation, declare it as an `open_term` or
+  `input` with `source`, not as a `definition`.
+- Do NOT combine multiple leden into one action unless the law text explicitly combines them.
+  If lid 1 sets a base rule and lid 4 adds an exception, model them as separate outputs
+  or use the structure the text prescribes.
+- Do NOT add "obvious" conditions that aren't in the text. If the article doesn't mention
+  an age check, don't add one — even if you know it's required by another article.
+
+**What to do instead:**
+- Use `input` with `source.regulation` to reference other laws
+- Use `input` with `source.output` to reference other articles in the same law
+- Use `open_terms` for values delegated to lower regulations
+- If an article is a pure orchestration point (like "het college stelt het recht vast"),
+  model it as cross-law references to the articles that define the substantive rules,
+  not as a reimplementation of those rules
+
+**The law may be inefficient. That's fine. Model it as written.**
+
 ## Phase 1: Generate `machine_readable` Sections
 
 For each article with computable logic, generate the `machine_readable` section.

--- a/.claude/skills/law-reverse-validate/SKILL.md
+++ b/.claude/skills/law-reverse-validate/SKILL.md
@@ -18,11 +18,40 @@ Verifies that every element in `machine_readable` sections traces back to the
 original legal text. This catches invented logic, phantom conditions, and
 hallucinated operations that aren't grounded in the law.
 
+## CRITICAL: Scope Audit
+
+The most important check is **scope**: does the machine_readable section stay within the
+boundaries of the legal provision it belongs to?
+
+Each machine_readable must interpret ONLY the text of the article, lid, or provision it is
+attached to. It must not pull in logic, conditions, thresholds, or values from other
+provisions — even when doing so seems "obvious" or "efficient."
+
+This is the most common failure mode. The engineering instinct is to optimize by combining
+logic from multiple articles into one execution block, but this fundamentally breaks the
+contract between the law and its machine-readable interpretation. The law may be redundant,
+circular, or inefficient. That is intentional — model it as the law writes it.
+
+**Scope violations to flag:**
+- Conditions not in this provision's text (e.g., an age check in an article that doesn't
+  mention age — even if age is required by another article)
+- Hardcoded values from other provisions (e.g., drempelinkomen amounts in an article that
+  only references the concept, not the value)
+- Logic from other articles reimplemented instead of referenced via `source`
+- Eligibility conditions from one article stuffed into an orchestration article
+- `legal_character` that doesn't match what this provision does (e.g., BESCHIKKING on a
+  norm article that merely sets amounts)
+
+**When cross-article dependencies are needed, the correct mechanism is:**
+- `input` with `source.regulation` / `source.output` for values from other provisions
+- `open_terms` for delegated values
+- `hooks` / `overrides` for reactive cross-law interactions
+
 ## Instructions
 
 1. Read the target law YAML file
 2. For each article that has a `machine_readable` section:
-   a. Read the article's `text` field carefully
+   a. Read the article's `text` field carefully — this defines the SCOPE
    b. Check every element in the `machine_readable` section:
       - Every `input` field — is it referenced in the legal text?
       - Every `parameter` — is it needed by the legal text?
@@ -39,12 +68,17 @@ hallucinated operations that aren't grounded in the law.
 
 3. Classify each element:
 
-| Traceable in text? | Needed for logic? | Action |
-|-------------------|-------------------|--------|
+| Traceable in THIS provision's text? | Needed for logic? | Action |
+|-------------------------------------|-------------------|--------|
 | YES | YES | Keep |
 | YES | NO | Keep (informational) |
+| NO, but in another provision | YES | **Scope violation** — must be refactored to use `source` reference |
 | NO | YES | Report as assumption |
 | NO | NO | **Remove** |
+
+**Scope violations are the highest priority finding.** They mean logic from one provision
+has leaked into another. This is worse than a missing element, because it produces results
+that look correct but cannot be traced back to the provision that claims to produce them.
 
 4. For elements classified as "Remove": delete them from the YAML using Edit
 5. For elements classified as "Report as assumption": collect them for the report


### PR DESCRIPTION
## Summary
- Add "FUNDAMENTAL RULE: Stay Within Scope" to law-generate skill
- Add "CRITICAL: Scope Audit" to law-reverse-validate skill
- New scope violation classification in the traceability table

## Why

Expert review of all corpus YAML files found scope violations as the #1 systemic issue: articles pulling in logic from other articles instead of using cross-law references. This happened because the skills had no explicit rule about staying within scope.

The engineering instinct is to optimize by combining conditions from multiple articles into one execution block. These rules explain why that's wrong and what to do instead.

## Test plan
- [ ] Run `/law-reverse-validate` on an existing corpus file — verify it flags known scope violations
- [ ] Run `/law-generate` on a new article — verify it stays within scope