### PR TITLE
refactor(engine): replace HashMap with BTreeMap for deterministic execution

### DIFF
--- a/packages/corpus/tests/federation.rs
+++ b/packages/corpus/tests/federation.rs
@@ -255,7 +255,7 @@ fn execute_law(
         .evaluate_law_output(
             law_id,
             output,
-            std::collections::HashMap::new(),
+            std::collections::BTreeMap::new(),
             "2025-01-01",
         )
         .ok()
@@ -398,7 +398,7 @@ fn test_multi_repo_reversed_priority() {
 #[test]
 fn test_source_map_to_engine() {
     use regelrecht_engine::LawExecutionService;
-    use std::collections::HashMap;
+    use std::collections::BTreeMap;
 
     let central_dir = fixtures_dir().join("central");
     let gemeente_a_dir = fixtures_dir().join("gemeente-a");
@@ -430,7 +430,7 @@ fn test_source_map_to_engine() {
 
     // Execute a law from the central source
     let result = service
-        .evaluate_law_output("test_wet", "test_value", HashMap::new(), "2025-01-01")
+        .evaluate_law_output("test_wet", "test_value", BTreeMap::new(), "2025-01-01")
         .unwrap();
 
     assert_eq!(
@@ -443,7 +443,7 @@ fn test_source_map_to_engine() {
         .evaluate_law_output(
             "test_verordening_a",
             "local_rate",
-            HashMap::new(),
+            BTreeMap::new(),
             "2025-01-01",
         )
         .unwrap();
@@ -459,7 +459,7 @@ fn test_source_map_to_engine() {
 #[test]
 fn test_priority_conflict_correct_law_executes() {
     use regelrecht_engine::LawExecutionService;
-    use std::collections::HashMap;
+    use std::collections::BTreeMap;
 
     let central_dir = fixtures_dir().join("central");
     let overlap_dir = fixtures_dir().join("overlap");
@@ -481,7 +481,7 @@ fn test_priority_conflict_correct_law_executes() {
     // Central outputs 200, overlap outputs 999
     // Central should win (priority 1 < 10)
     let result = service
-        .evaluate_law_output("test_wet", "test_value", HashMap::new(), "2025-01-01")
+        .evaluate_law_output("test_wet", "test_value", BTreeMap::new(), "2025-01-01")
         .unwrap();
 
     // Should be 200 (from central), not 999 (from overlap)

--- a/packages/engine/benches/article_evaluation.rs
+++ b/packages/engine/benches/article_evaluation.rs
@@ -1,6 +1,6 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use regelrecht_engine::{ArticleBasedLaw, ArticleEngine, Value};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 const SIMPLE_LAW_YAML: &str = r#"
 $id: bench_simple
@@ -110,7 +110,7 @@ fn bench_article_evaluate(c: &mut Criterion) {
     group.bench_function("simple_conditional", |b| {
         let article = &simple_law.articles[0];
         let engine = ArticleEngine::new(article, &simple_law);
-        let mut params = HashMap::new();
+        let mut params = BTreeMap::new();
         params.insert("inkomen".to_string(), Value::Int(35000));
         params.insert("drempel".to_string(), Value::Int(25000));
         b.iter(|| engine.evaluate(black_box(params.clone()), "2025-01-01"))
@@ -120,7 +120,7 @@ fn bench_article_evaluate(c: &mut Criterion) {
     group.bench_function("nested_arithmetic", |b| {
         let article = &arithmetic_law.articles[0];
         let engine = ArticleEngine::new(article, &arithmetic_law);
-        let mut params = HashMap::new();
+        let mut params = BTreeMap::new();
         params.insert("a".to_string(), Value::Int(100));
         params.insert("b".to_string(), Value::Int(200));
         params.insert("c".to_string(), Value::Int(300));
@@ -131,7 +131,7 @@ fn bench_article_evaluate(c: &mut Criterion) {
     group.bench_function("simple_with_trace", |b| {
         let article = &simple_law.articles[0];
         let engine = ArticleEngine::new(article, &simple_law);
-        let mut params = HashMap::new();
+        let mut params = BTreeMap::new();
         params.insert("inkomen".to_string(), Value::Int(35000));
         params.insert("drempel".to_string(), Value::Int(25000));
         b.iter(|| {

--- a/packages/engine/benches/service_e2e.rs
+++ b/packages/engine/benches/service_e2e.rs
@@ -1,6 +1,6 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use regelrecht_engine::{LawExecutionService, Value};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 fn corpus_path() -> PathBuf {
@@ -34,7 +34,7 @@ fn load_all_laws(service: &mut LawExecutionService) {
     }
 }
 
-fn make_record(pairs: &[(&str, Value)]) -> HashMap<String, Value> {
+fn make_record(pairs: &[(&str, Value)]) -> BTreeMap<String, Value> {
     pairs
         .iter()
         .map(|(k, v)| (k.to_string(), v.clone()))
@@ -161,7 +161,7 @@ fn bench_simple_law(c: &mut Criterion) {
             service.evaluate_law_output(
                 black_box("regeling_standaardpremie"),
                 black_box("standaardpremie"),
-                HashMap::new(),
+                BTreeMap::new(),
                 "2025-01-01",
             )
         })
@@ -172,7 +172,7 @@ fn bench_simple_law(c: &mut Criterion) {
             service.evaluate_law_output_with_trace(
                 black_box("regeling_standaardpremie"),
                 black_box("standaardpremie"),
-                HashMap::new(),
+                BTreeMap::new(),
                 "2025-01-01",
             )
         })
@@ -186,7 +186,7 @@ fn bench_complex_law(c: &mut Criterion) {
     load_all_laws(&mut service);
     register_zorgtoeslag_data(&mut service);
 
-    let mut params = HashMap::new();
+    let mut params = BTreeMap::new();
     params.insert("bsn".to_string(), Value::String("999993653".to_string()));
 
     let mut group = c.benchmark_group("service_e2e_complex");

--- a/packages/engine/benches/variable_resolution.rs
+++ b/packages/engine/benches/variable_resolution.rs
@@ -1,16 +1,16 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use regelrecht_engine::{RuleContext, Value, ValueResolver};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 fn make_context() -> RuleContext {
-    let mut parameters = HashMap::new();
+    let mut parameters = BTreeMap::new();
     parameters.insert("bsn".to_string(), Value::String("999993653".to_string()));
     parameters.insert("inkomen".to_string(), Value::Int(35000));
     parameters.insert("leeftijd".to_string(), Value::Int(30));
 
     let mut ctx = RuleContext::new(parameters, "2025-01-01").unwrap();
 
-    let mut definitions = HashMap::new();
+    let mut definitions = BTreeMap::new();
     definitions.insert("drempelinkomen".to_string(), Value::Int(25000));
     definitions.insert("maximale_toeslag".to_string(), Value::Int(2112));
     ctx.set_definitions_raw(definitions);

--- a/packages/engine/examples/trace.rs
+++ b/packages/engine/examples/trace.rs
@@ -7,7 +7,7 @@
 //!   cargo run --example trace -- zorgtoeslagwet hoogte_zorgtoeslag 2025-01-01 bsn=999993653
 
 use regelrecht_engine::{LawExecutionService, Value};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::path::Path;
 use walkdir::WalkDir;
 
@@ -23,7 +23,7 @@ fn main() {
     let output_name = &args[1];
     let date = &args[2];
 
-    let mut params: HashMap<String, Value> = HashMap::new();
+    let mut params: BTreeMap<String, Value> = BTreeMap::new();
     for arg in &args[3..] {
         if let Some((key, val)) = arg.split_once('=') {
             let value = parse_value(val);

--- a/packages/engine/src/article.rs
+++ b/packages/engine/src/article.rs
@@ -15,7 +15,7 @@ use crate::config;
 use crate::error::{EngineError, Result};
 use crate::types::{Operation, ParameterType, RegulatoryLayer, Value};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::path::Path;
 
@@ -65,7 +65,7 @@ pub struct Source {
     pub output: Option<String>,
     /// Parameters to pass to the source execution
     #[serde(default)]
-    pub parameters: Option<HashMap<String, String>>,
+    pub parameters: Option<BTreeMap<String, String>>,
 }
 
 /// Parameter definition in execution spec

--- a/packages/engine/src/bin/evaluate.rs
+++ b/packages/engine/src/bin/evaluate.rs
@@ -20,14 +20,14 @@
 //!   - error: Optional<String> — error message if evaluation failed
 
 use regelrecht_engine::{LawExecutionService, Value};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::io::Read;
 
 #[derive(serde::Deserialize)]
 struct EvaluateRequest {
     law_yaml: String,
     output_name: String,
-    params: HashMap<String, serde_json::Value>,
+    params: BTreeMap<String, serde_json::Value>,
     date: String,
     #[serde(default)]
     extra_laws: Vec<String>,
@@ -36,9 +36,9 @@ struct EvaluateRequest {
 #[derive(serde::Serialize)]
 struct EvaluateResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
-    outputs: Option<HashMap<String, serde_json::Value>>,
+    outputs: Option<BTreeMap<String, serde_json::Value>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    resolved_inputs: Option<HashMap<String, serde_json::Value>>,
+    resolved_inputs: Option<BTreeMap<String, serde_json::Value>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     article_number: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -123,7 +123,7 @@ fn main() {
     }
 
     // Convert params
-    let params: HashMap<String, Value> = request
+    let params: BTreeMap<String, Value> = request
         .params
         .iter()
         .map(|(k, v)| (k.clone(), Value::from(v)))
@@ -132,12 +132,12 @@ fn main() {
     // Evaluate
     match service.evaluate_law_output(&law_id, &request.output_name, params, &request.date) {
         Ok(result) => {
-            let outputs: HashMap<String, serde_json::Value> = result
+            let outputs: BTreeMap<String, serde_json::Value> = result
                 .outputs
                 .iter()
                 .map(|(k, v)| (k.clone(), serde_json::Value::from(v)))
                 .collect();
-            let resolved_inputs: HashMap<String, serde_json::Value> = result
+            let resolved_inputs: BTreeMap<String, serde_json::Value> = result
                 .resolved_inputs
                 .iter()
                 .map(|(k, v)| (k.clone(), serde_json::Value::from(v)))

--- a/packages/engine/src/context.rs
+++ b/packages/engine/src/context.rs
@@ -38,7 +38,7 @@ use crate::trace::TraceBuilder;
 use crate::types::{PathNodeType, ResolveType, Value};
 use chrono::{Datelike, NaiveDate};
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::rc::Rc;
 
 /// Execution context for article evaluation.
@@ -54,19 +54,19 @@ use std::rc::Rc;
 #[derive(Debug, Clone)]
 pub struct RuleContext {
     /// Article-level definitions (constants)
-    definitions: Rc<HashMap<String, Value>>,
+    definitions: Rc<BTreeMap<String, Value>>,
 
     /// Input parameters (e.g., BSN, income)
-    parameters: Rc<HashMap<String, Value>>,
+    parameters: Rc<BTreeMap<String, Value>>,
 
     /// Calculated output values
-    outputs: Rc<HashMap<String, Value>>,
+    outputs: Rc<BTreeMap<String, Value>>,
 
     /// Local scope variables (for FOREACH loops)
-    local: HashMap<String, Value>,
+    local: BTreeMap<String, Value>,
 
     /// Cached resolved inputs from cross-law references
-    resolved_inputs: Rc<HashMap<String, Value>>,
+    resolved_inputs: Rc<BTreeMap<String, Value>>,
 
     /// Reference date for calculations
     reference_date: NaiveDate,
@@ -84,18 +84,18 @@ impl RuleContext {
     /// # Arguments
     /// * `parameters` - Input parameters for the execution
     /// * `calculation_date` - Reference date for calculations (YYYY-MM-DD format)
-    pub fn new(parameters: HashMap<String, Value>, calculation_date: &str) -> Result<Self> {
+    pub fn new(parameters: BTreeMap<String, Value>, calculation_date: &str) -> Result<Self> {
         let reference_date = NaiveDate::parse_from_str(calculation_date, "%Y-%m-%d")
             .map_err(|e| EngineError::InvalidDate(format!("{}: {}", calculation_date, e)))?;
 
         let reference_date_value = date_to_value(reference_date);
 
         Ok(Self {
-            definitions: Rc::new(HashMap::new()),
+            definitions: Rc::new(BTreeMap::new()),
             parameters: Rc::new(parameters),
-            outputs: Rc::new(HashMap::with_capacity(8)),
-            local: HashMap::new(),
-            resolved_inputs: Rc::new(HashMap::with_capacity(8)),
+            outputs: Rc::new(BTreeMap::new()),
+            local: BTreeMap::new(),
+            resolved_inputs: Rc::new(BTreeMap::new()),
             reference_date,
             reference_date_value,
             trace: None,
@@ -106,7 +106,7 @@ impl RuleContext {
     ///
     /// Useful for testing.
     #[allow(clippy::expect_used)]
-    pub fn with_defaults(parameters: HashMap<String, Value>) -> Self {
+    pub fn with_defaults(parameters: BTreeMap<String, Value>) -> Self {
         let today = chrono::Local::now().format("%Y-%m-%d").to_string();
         Self::new(parameters, &today).expect("today's date should always be valid")
     }
@@ -124,7 +124,7 @@ impl RuleContext {
     }
 
     /// Set definitions directly from a Value HashMap.
-    pub fn set_definitions_raw(&mut self, definitions: HashMap<String, Value>) {
+    pub fn set_definitions_raw(&mut self, definitions: BTreeMap<String, Value>) {
         self.definitions = Rc::new(definitions);
     }
 
@@ -139,7 +139,7 @@ impl RuleContext {
     }
 
     /// Get all outputs.
-    pub fn outputs(&self) -> &HashMap<String, Value> {
+    pub fn outputs(&self) -> &BTreeMap<String, Value> {
         &self.outputs
     }
 
@@ -159,12 +159,12 @@ impl RuleContext {
     }
 
     /// Get all resolved inputs (cached cross-law results).
-    pub fn resolved_inputs(&self) -> &HashMap<String, Value> {
+    pub fn resolved_inputs(&self) -> &BTreeMap<String, Value> {
         &self.resolved_inputs
     }
 
     /// Get all input parameters.
-    pub fn parameters(&self) -> &HashMap<String, Value> {
+    pub fn parameters(&self) -> &BTreeMap<String, Value> {
         &self.parameters
     }
 
@@ -211,7 +211,7 @@ impl RuleContext {
             definitions: Rc::clone(&self.definitions),
             parameters: Rc::clone(&self.parameters),
             outputs: Rc::clone(&self.outputs),
-            local: HashMap::new(), // Child starts with empty local scope
+            local: BTreeMap::new(), // Child starts with empty local scope
             resolved_inputs: Rc::clone(&self.resolved_inputs),
             reference_date: self.reference_date,
             reference_date_value: self.reference_date_value.clone(),
@@ -425,7 +425,7 @@ impl ValueResolver for RuleContext {
 
 /// Convert a NaiveDate to a Value object with year, month, day properties.
 fn date_to_value(date: NaiveDate) -> Value {
-    let mut obj = HashMap::new();
+    let mut obj = BTreeMap::new();
     obj.insert("year".to_string(), Value::Int(date.year() as i64));
     obj.insert("month".to_string(), Value::Int(date.month() as i64));
     obj.insert("day".to_string(), Value::Int(date.day() as i64));
@@ -494,7 +494,7 @@ mod tests {
     use crate::config;
 
     fn make_context() -> RuleContext {
-        let mut params = HashMap::new();
+        let mut params = BTreeMap::new();
         params.insert("BSN".to_string(), Value::String("123456789".to_string()));
         params.insert("income".to_string(), Value::Int(30000));
 
@@ -519,7 +519,7 @@ mod tests {
     #[test]
     fn test_resolve_definition() {
         let mut ctx = make_context();
-        let mut defs = HashMap::new();
+        let mut defs = BTreeMap::new();
         defs.insert("MAX_INCOME".to_string(), Value::Int(50000));
         defs.insert("TAX_RATE".to_string(), Value::Float(0.21));
         ctx.set_definitions_raw(defs);
@@ -587,7 +587,7 @@ mod tests {
     #[test]
     fn test_priority_output_over_definition() {
         let mut ctx = make_context();
-        let mut defs = HashMap::new();
+        let mut defs = BTreeMap::new();
         defs.insert("x".to_string(), Value::Int(100));
         ctx.set_definitions_raw(defs);
         ctx.set_output("x", Value::Int(200));
@@ -601,7 +601,7 @@ mod tests {
     fn test_priority_definition_over_parameter() {
         let mut ctx = make_context();
         // "income" exists as parameter (30000)
-        let mut defs = HashMap::new();
+        let mut defs = BTreeMap::new();
         defs.insert("income".to_string(), Value::Int(50000));
         ctx.set_definitions_raw(defs);
 
@@ -652,7 +652,7 @@ mod tests {
     fn test_dot_notation_object() {
         let mut ctx = make_context();
 
-        let mut person = HashMap::new();
+        let mut person = BTreeMap::new();
         person.insert("name".to_string(), Value::String("Jan".to_string()));
         person.insert("age".to_string(), Value::Int(35));
         ctx.set_output("person", Value::Object(person));
@@ -668,11 +668,11 @@ mod tests {
     fn test_dot_notation_nested() {
         let mut ctx = make_context();
 
-        let mut address = HashMap::new();
+        let mut address = BTreeMap::new();
         address.insert("city".to_string(), Value::String("Amsterdam".to_string()));
         address.insert("zip".to_string(), Value::String("1012AB".to_string()));
 
-        let mut person = HashMap::new();
+        let mut person = BTreeMap::new();
         person.insert("name".to_string(), Value::String("Jan".to_string()));
         person.insert("address".to_string(), Value::Object(address));
         ctx.set_output("person", Value::Object(person));
@@ -703,7 +703,7 @@ mod tests {
     fn test_dot_notation_not_found() {
         let mut ctx = make_context();
 
-        let mut person = HashMap::new();
+        let mut person = BTreeMap::new();
         person.insert("name".to_string(), Value::String("Jan".to_string()));
         ctx.set_output("person", Value::Object(person));
 
@@ -729,7 +729,7 @@ mod tests {
     fn test_child_context_inherits() {
         let mut ctx = make_context();
         ctx.set_output("parent_output", Value::Int(100));
-        let mut defs = HashMap::new();
+        let mut defs = BTreeMap::new();
         defs.insert("CONSTANT".to_string(), Value::Int(42));
         ctx.set_definitions_raw(defs);
 
@@ -786,14 +786,14 @@ mod tests {
 
     #[test]
     fn test_invalid_date() {
-        let params = HashMap::new();
+        let params = BTreeMap::new();
         let result = RuleContext::new(params, "not-a-date");
         assert!(matches!(result, Err(EngineError::InvalidDate(_))));
     }
 
     #[test]
     fn test_empty_context() {
-        let ctx = RuleContext::with_defaults(HashMap::new());
+        let ctx = RuleContext::with_defaults(BTreeMap::new());
         let result = ctx.resolve("anything");
         assert!(matches!(result, Err(EngineError::VariableNotFound(_))));
     }
@@ -810,7 +810,7 @@ mod tests {
     #[test]
     fn test_priority_resolved_input_over_definition() {
         let mut ctx = make_context();
-        let mut defs = HashMap::new();
+        let mut defs = BTreeMap::new();
         defs.insert("x".to_string(), Value::Int(100));
         ctx.set_definitions_raw(defs);
         ctx.set_resolved_input("x", Value::Int(200));
@@ -826,11 +826,11 @@ mod tests {
 
         // Create a deeply nested object (but not exceeding limit)
         // 5 levels of nesting: {n: {n: {n: {n: {n: {value: 42}}}}}}
-        let mut deep = HashMap::new();
+        let mut deep = BTreeMap::new();
         deep.insert("value".to_string(), Value::Int(42));
 
         for _ in 0..5 {
-            let mut wrapper = HashMap::new();
+            let mut wrapper = BTreeMap::new();
             wrapper.insert("n".to_string(), Value::Object(deep));
             deep = wrapper;
         }
@@ -845,11 +845,11 @@ mod tests {
         // Create a structure that's deeper than MAX_PROPERTY_DEPTH (32)
         // We need (MAX_PROPERTY_DEPTH + 3) levels to trigger the depth limit
         let depth = config::MAX_PROPERTY_DEPTH + 3;
-        let mut very_deep = HashMap::new();
+        let mut very_deep = BTreeMap::new();
         very_deep.insert("end".to_string(), Value::Int(999));
 
         for _ in 0..depth {
-            let mut wrapper = HashMap::new();
+            let mut wrapper = BTreeMap::new();
             wrapper.insert("n".to_string(), Value::Object(very_deep));
             very_deep = wrapper;
         }

--- a/packages/engine/src/data_source.rs
+++ b/packages/engine/src/data_source.rs
@@ -12,9 +12,9 @@
 //!
 //! // Create a registry and add a data source
 //! let mut registry = DataSourceRegistry::new();
-//! let mut data = HashMap::new();
+//! let mut data = BTreeMap::new();
 //! data.insert("person_123".to_string(), {
-//!     let mut record = HashMap::new();
+//!     let mut record = BTreeMap::new();
 //!     record.insert("income".to_string(), Value::Int(50000));
 //!     record.insert("age".to_string(), Value::Int(35));
 //!     record
@@ -24,7 +24,7 @@
 //! registry.add_source(Box::new(source));
 //!
 //! // Query the registry
-//! let mut criteria = HashMap::new();
+//! let mut criteria = BTreeMap::new();
 //! criteria.insert("BSN".to_string(), Value::String("123".to_string()));
 //!
 //! if let Some(match_result) = registry.resolve("income", &criteria) {
@@ -33,7 +33,7 @@
 //! ```
 
 use crate::types::Value;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashSet};
 
 /// Result of a successful data source query.
 #[derive(Debug, Clone)]
@@ -74,7 +74,7 @@ pub trait DataSource: Send + Sync {
     ///
     /// # Returns
     /// The value if found, or None if no matching record exists.
-    fn get(&self, field: &str, criteria: &HashMap<String, Value>) -> Option<Value>;
+    fn get(&self, field: &str, criteria: &BTreeMap<String, Value>) -> Option<Value>;
 
     /// Get all available fields in this data source.
     fn fields(&self) -> Vec<&str>;
@@ -100,7 +100,7 @@ pub struct DictDataSource {
     name: String,
     priority: i32,
     /// Data: record_key -> field_name (lowercase) -> value
-    data: HashMap<String, HashMap<String, Value>>,
+    data: BTreeMap<String, BTreeMap<String, Value>>,
     /// Index of all available field names (lowercase)
     field_index: HashSet<String>,
     /// When set, `get()` filters criteria to only these fields before building the
@@ -119,7 +119,7 @@ impl DictDataSource {
     pub fn new(
         name: impl Into<String>,
         priority: i32,
-        data: HashMap<String, HashMap<String, Value>>,
+        data: BTreeMap<String, BTreeMap<String, Value>>,
     ) -> Self {
         // Build field index with lowercase field names
         let field_index = data
@@ -163,11 +163,11 @@ impl DictDataSource {
         name: impl Into<String>,
         priority: i32,
         key_field: &str,
-        records: Vec<HashMap<String, Value>>,
+        records: Vec<BTreeMap<String, Value>>,
     ) -> Option<Self> {
         let key_field_lower = key_field.to_lowercase();
         let has_records = !records.is_empty();
-        let mut data = HashMap::new();
+        let mut data = BTreeMap::new();
 
         for record in records {
             // Find the key field (case-insensitive)
@@ -198,7 +198,7 @@ impl DictDataSource {
     /// # Arguments
     /// * `key` - The record key
     /// * `fields` - Field values for this record
-    pub fn store(&mut self, key: impl Into<String>, fields: HashMap<String, Value>) {
+    pub fn store(&mut self, key: impl Into<String>, fields: BTreeMap<String, Value>) {
         let key = key.into();
 
         // Update field index
@@ -238,13 +238,13 @@ impl DataSource for DictDataSource {
         self.field_index.contains(&field.to_lowercase())
     }
 
-    fn get(&self, field: &str, criteria: &HashMap<String, Value>) -> Option<Value> {
+    fn get(&self, field: &str, criteria: &BTreeMap<String, Value>) -> Option<Value> {
         // When key_fields is set (e.g. from_records), filter criteria to only
         // the key fields before building the lookup key. Otherwise a caller
         // passing extra criteria would produce a key that doesn't match any record.
         let key = match &self.key_fields {
             Some(fields) => {
-                let filtered: HashMap<String, Value> = criteria
+                let filtered: BTreeMap<String, Value> = criteria
                     .iter()
                     .filter(|(k, _)| fields.contains(&k.to_lowercase()))
                     .map(|(k, v)| (k.clone(), v.clone()))
@@ -328,7 +328,7 @@ impl DataSourceRegistry {
     pub fn resolve(
         &self,
         field: &str,
-        criteria: &HashMap<String, Value>,
+        criteria: &BTreeMap<String, Value>,
     ) -> Option<DataSourceMatch> {
         for source in &self.sources {
             if !source.has_field(field) {
@@ -386,7 +386,7 @@ impl std::fmt::Debug for DataSourceRegistry {
 /// Build a lookup key from criteria values.
 ///
 /// Sorts criteria by key name and joins values with underscore.
-fn build_lookup_key(criteria: &HashMap<String, Value>) -> String {
+fn build_lookup_key(criteria: &BTreeMap<String, Value>) -> String {
     let mut pairs: Vec<_> = criteria
         .iter()
         .map(|(k, v)| (k.to_lowercase(), v))
@@ -416,16 +416,16 @@ fn value_to_key(value: &Value) -> String {
 mod tests {
     use super::*;
 
-    fn make_person_data() -> HashMap<String, HashMap<String, Value>> {
-        let mut data = HashMap::new();
+    fn make_person_data() -> BTreeMap<String, BTreeMap<String, Value>> {
+        let mut data = BTreeMap::new();
 
-        let mut person1 = HashMap::new();
+        let mut person1 = BTreeMap::new();
         person1.insert("income".to_string(), Value::Int(50000));
         person1.insert("age".to_string(), Value::Int(35));
         person1.insert("name".to_string(), Value::String("Jan".to_string()));
         data.insert("123".to_string(), person1);
 
-        let mut person2 = HashMap::new();
+        let mut person2 = BTreeMap::new();
         person2.insert("income".to_string(), Value::Int(40000));
         person2.insert("age".to_string(), Value::Int(28));
         person2.insert("name".to_string(), Value::String("Piet".to_string()));
@@ -463,7 +463,7 @@ mod tests {
     fn test_dict_source_get() {
         let source = DictDataSource::new("persons", 10, make_person_data());
 
-        let mut criteria = HashMap::new();
+        let mut criteria = BTreeMap::new();
         criteria.insert("BSN".to_string(), Value::String("123".to_string()));
 
         let income = source.get("income", &criteria);
@@ -477,7 +477,7 @@ mod tests {
     fn test_dict_source_get_case_insensitive() {
         let source = DictDataSource::new("persons", 10, make_person_data());
 
-        let mut criteria = HashMap::new();
+        let mut criteria = BTreeMap::new();
         criteria.insert("BSN".to_string(), Value::String("123".to_string()));
 
         // Field name should be case-insensitive
@@ -490,7 +490,7 @@ mod tests {
     fn test_dict_source_get_not_found() {
         let source = DictDataSource::new("persons", 10, make_person_data());
 
-        let mut criteria = HashMap::new();
+        let mut criteria = BTreeMap::new();
         criteria.insert("BSN".to_string(), Value::String("999".to_string()));
 
         let result = source.get("income", &criteria);
@@ -499,9 +499,9 @@ mod tests {
 
     #[test]
     fn test_dict_source_store() {
-        let mut source = DictDataSource::new("persons", 10, HashMap::new());
+        let mut source = DictDataSource::new("persons", 10, BTreeMap::new());
 
-        let mut fields = HashMap::new();
+        let mut fields = BTreeMap::new();
         fields.insert("income".to_string(), Value::Int(60000));
         fields.insert("age".to_string(), Value::Int(42));
         source.store("789", fields);
@@ -509,7 +509,7 @@ mod tests {
         assert_eq!(source.record_count(), 1);
         assert!(source.has_field("income"));
 
-        let mut criteria = HashMap::new();
+        let mut criteria = BTreeMap::new();
         criteria.insert("key".to_string(), Value::String("789".to_string()));
         assert_eq!(source.get("income", &criteria), Some(Value::Int(60000)));
     }
@@ -519,13 +519,13 @@ mod tests {
         // Records exist but none contain the key field → should return None
         let records = vec![
             {
-                let mut r = HashMap::new();
+                let mut r = BTreeMap::new();
                 r.insert("name".to_string(), Value::String("Jan".to_string()));
                 r.insert("income".to_string(), Value::Int(50000));
                 r
             },
             {
-                let mut r = HashMap::new();
+                let mut r = BTreeMap::new();
                 r.insert("name".to_string(), Value::String("Piet".to_string()));
                 r.insert("income".to_string(), Value::Int(40000));
                 r
@@ -554,13 +554,13 @@ mod tests {
     fn test_dict_source_from_records() {
         let records = vec![
             {
-                let mut r = HashMap::new();
+                let mut r = BTreeMap::new();
                 r.insert("BSN".to_string(), Value::String("123".to_string()));
                 r.insert("income".to_string(), Value::Int(50000));
                 r
             },
             {
-                let mut r = HashMap::new();
+                let mut r = BTreeMap::new();
                 r.insert("BSN".to_string(), Value::String("456".to_string()));
                 r.insert("income".to_string(), Value::Int(40000));
                 r
@@ -571,7 +571,7 @@ mod tests {
         assert_eq!(source.record_count(), 2);
 
         // Criteria must use the key_field name ("BSN"), not an arbitrary name
-        let mut criteria = HashMap::new();
+        let mut criteria = BTreeMap::new();
         criteria.insert("BSN".to_string(), Value::String("123".to_string()));
         assert_eq!(source.get("income", &criteria), Some(Value::Int(50000)));
     }
@@ -602,7 +602,7 @@ mod tests {
             make_person_data(),
         )));
 
-        let mut criteria = HashMap::new();
+        let mut criteria = BTreeMap::new();
         criteria.insert("BSN".to_string(), Value::String("123".to_string()));
 
         let result = registry.resolve("income", &criteria).unwrap();
@@ -616,20 +616,20 @@ mod tests {
         let mut registry = DataSourceRegistry::new();
 
         // Add low priority source first
-        let mut low_data = HashMap::new();
-        let mut low_record = HashMap::new();
+        let mut low_data = BTreeMap::new();
+        let mut low_record = BTreeMap::new();
         low_record.insert("value".to_string(), Value::Int(100));
         low_data.insert("key".to_string(), low_record);
         registry.add_source(Box::new(DictDataSource::new("low", 1, low_data)));
 
         // Add high priority source second
-        let mut high_data = HashMap::new();
-        let mut high_record = HashMap::new();
+        let mut high_data = BTreeMap::new();
+        let mut high_record = BTreeMap::new();
         high_record.insert("value".to_string(), Value::Int(200));
         high_data.insert("key".to_string(), high_record);
         registry.add_source(Box::new(DictDataSource::new("high", 10, high_data)));
 
-        let mut criteria = HashMap::new();
+        let mut criteria = BTreeMap::new();
         criteria.insert("k".to_string(), Value::String("key".to_string()));
 
         // High priority source should win
@@ -643,20 +643,20 @@ mod tests {
         let mut registry = DataSourceRegistry::new();
 
         // High priority source without the field
-        let mut high_data = HashMap::new();
-        let mut high_record = HashMap::new();
+        let mut high_data = BTreeMap::new();
+        let mut high_record = BTreeMap::new();
         high_record.insert("other".to_string(), Value::Int(999));
         high_data.insert("key".to_string(), high_record);
         registry.add_source(Box::new(DictDataSource::new("high", 10, high_data)));
 
         // Low priority source with the field
-        let mut low_data = HashMap::new();
-        let mut low_record = HashMap::new();
+        let mut low_data = BTreeMap::new();
+        let mut low_record = BTreeMap::new();
         low_record.insert("value".to_string(), Value::Int(100));
         low_data.insert("key".to_string(), low_record);
         registry.add_source(Box::new(DictDataSource::new("low", 1, low_data)));
 
-        let mut criteria = HashMap::new();
+        let mut criteria = BTreeMap::new();
         criteria.insert("k".to_string(), Value::String("key".to_string()));
 
         // Should fall back to low priority source
@@ -682,8 +682,8 @@ mod tests {
     #[test]
     fn test_registry_clear() {
         let mut registry = DataSourceRegistry::new();
-        registry.add_source(Box::new(DictDataSource::new("a", 1, HashMap::new())));
-        registry.add_source(Box::new(DictDataSource::new("b", 2, HashMap::new())));
+        registry.add_source(Box::new(DictDataSource::new("a", 1, BTreeMap::new())));
+        registry.add_source(Box::new(DictDataSource::new("b", 2, BTreeMap::new())));
 
         registry.clear();
         assert_eq!(registry.source_count(), 0);
@@ -706,9 +706,9 @@ mod tests {
     #[test]
     fn test_registry_list_sources() {
         let mut registry = DataSourceRegistry::new();
-        registry.add_source(Box::new(DictDataSource::new("a", 5, HashMap::new())));
-        registry.add_source(Box::new(DictDataSource::new("b", 10, HashMap::new())));
-        registry.add_source(Box::new(DictDataSource::new("c", 1, HashMap::new())));
+        registry.add_source(Box::new(DictDataSource::new("a", 5, BTreeMap::new())));
+        registry.add_source(Box::new(DictDataSource::new("b", 10, BTreeMap::new())));
+        registry.add_source(Box::new(DictDataSource::new("c", 1, BTreeMap::new())));
 
         let sources = registry.list_sources();
         // Should be sorted by priority (highest first)
@@ -736,7 +736,7 @@ mod tests {
 
     #[test]
     fn test_build_lookup_key_single() {
-        let mut criteria = HashMap::new();
+        let mut criteria = BTreeMap::new();
         criteria.insert("BSN".to_string(), Value::String("123".to_string()));
 
         let key = build_lookup_key(&criteria);
@@ -745,7 +745,7 @@ mod tests {
 
     #[test]
     fn test_build_lookup_key_multiple() {
-        let mut criteria = HashMap::new();
+        let mut criteria = BTreeMap::new();
         criteria.insert("BSN".to_string(), Value::String("123".to_string()));
         criteria.insert("year".to_string(), Value::Int(2025));
 
@@ -757,11 +757,11 @@ mod tests {
     #[test]
     fn test_build_lookup_key_case_insensitive_sort() {
         // Mixed-case keys should produce the same lookup key regardless of casing
-        let mut criteria_upper = HashMap::new();
+        let mut criteria_upper = BTreeMap::new();
         criteria_upper.insert("BSN".to_string(), Value::String("123".to_string()));
         criteria_upper.insert("Year".to_string(), Value::Int(2025));
 
-        let mut criteria_lower = HashMap::new();
+        let mut criteria_lower = BTreeMap::new();
         criteria_lower.insert("bsn".to_string(), Value::String("123".to_string()));
         criteria_lower.insert("year".to_string(), Value::Int(2025));
 
@@ -788,13 +788,13 @@ mod tests {
         // would cause a key mismatch and the lookup would silently fail.
         let records = vec![
             {
-                let mut r = HashMap::new();
+                let mut r = BTreeMap::new();
                 r.insert("BSN".to_string(), Value::String("123".to_string()));
                 r.insert("income".to_string(), Value::Int(50000));
                 r
             },
             {
-                let mut r = HashMap::new();
+                let mut r = BTreeMap::new();
                 r.insert("BSN".to_string(), Value::String("456".to_string()));
                 r.insert("income".to_string(), Value::Int(40000));
                 r
@@ -805,14 +805,14 @@ mod tests {
 
         // Lookup with multiple criteria — the extra "year" criterion should be
         // ignored because the source was created with key_field="BSN"
-        let mut criteria = HashMap::new();
+        let mut criteria = BTreeMap::new();
         criteria.insert("BSN".to_string(), Value::String("123".to_string()));
         criteria.insert("year".to_string(), Value::Int(2025));
 
         assert_eq!(source.get("income", &criteria), Some(Value::Int(50000)));
 
         // Single criterion should still work
-        let mut criteria_single = HashMap::new();
+        let mut criteria_single = BTreeMap::new();
         criteria_single.insert("BSN".to_string(), Value::String("456".to_string()));
         assert_eq!(
             source.get("income", &criteria_single),

--- a/packages/engine/src/engine.rs
+++ b/packages/engine/src/engine.rs
@@ -6,13 +6,13 @@
 //!
 //! ```ignore
 //! use regelrecht_engine::{ArticleEngine, ArticleBasedLaw, Value};
-//! use std::collections::HashMap;
+//! use std::collections::BTreeMap;
 //!
 //! let law = ArticleBasedLaw::from_yaml_file("path/to/law.yaml")?;
 //! let article = law.find_article_by_output("some_output").unwrap();
 //!
 //! let engine = ArticleEngine::new(article, &law);
-//! let mut params = HashMap::new();
+//! let mut params = BTreeMap::new();
 //! params.insert("BSN".to_string(), Value::String("123456789".to_string()));
 //!
 //! let result = engine.evaluate(params, "2025-01-01")?;
@@ -27,16 +27,16 @@ use crate::operations::{evaluate_value, execute_operation};
 use crate::trace::{PathNode, TraceBuilder};
 use crate::types::{PathNodeType, Value};
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::rc::Rc;
 
 /// Result of article execution
 #[derive(Debug, Clone)]
 pub struct ArticleResult {
     /// Calculated output values
-    pub outputs: HashMap<String, Value>,
+    pub outputs: BTreeMap<String, Value>,
     /// Resolved input values (from cross-law references)
-    pub resolved_inputs: HashMap<String, Value>,
+    pub resolved_inputs: BTreeMap<String, Value>,
     /// Article number that was executed
     pub article_number: String,
     /// Law ID containing the article
@@ -80,7 +80,7 @@ impl<'a> ArticleEngine<'a> {
     #[cfg_attr(feature = "otel", tracing::instrument(skip(self, parameters), fields(law_id = %self.law.id, article = %self.article.number)))]
     pub fn evaluate(
         &self,
-        parameters: HashMap<String, Value>,
+        parameters: BTreeMap<String, Value>,
         calculation_date: &str,
     ) -> Result<ArticleResult> {
         self.evaluate_with_output(parameters, calculation_date, None)
@@ -98,7 +98,7 @@ impl<'a> ArticleEngine<'a> {
     /// * `Err(EngineError)` - If execution fails
     pub fn evaluate_with_output(
         &self,
-        parameters: HashMap<String, Value>,
+        parameters: BTreeMap<String, Value>,
         calculation_date: &str,
         requested_output: Option<&str>,
     ) -> Result<ArticleResult> {
@@ -113,7 +113,7 @@ impl<'a> ArticleEngine<'a> {
     /// Same as `evaluate_with_output` but accepts a shared trace builder.
     pub fn evaluate_with_trace(
         &self,
-        parameters: HashMap<String, Value>,
+        parameters: BTreeMap<String, Value>,
         calculation_date: &str,
         requested_output: Option<&str>,
         trace: Rc<RefCell<TraceBuilder>>,
@@ -140,7 +140,7 @@ impl<'a> ArticleEngine<'a> {
     /// * `depth` - Current resolution depth
     fn evaluate_internal(
         &self,
-        parameters: HashMap<String, Value>,
+        parameters: BTreeMap<String, Value>,
         calculation_date: &str,
         requested_output: Option<&str>,
         visited: Vec<String>,
@@ -159,7 +159,7 @@ impl<'a> ArticleEngine<'a> {
     /// Internal evaluation with optional tracing.
     fn evaluate_internal_traced(
         &self,
-        parameters: HashMap<String, Value>,
+        parameters: BTreeMap<String, Value>,
         calculation_date: &str,
         requested_output: Option<&str>,
         visited: Vec<String>,
@@ -242,7 +242,7 @@ impl<'a> ArticleEngine<'a> {
     fn resolve_input_sources(
         &self,
         context: &mut RuleContext,
-        parameters: &HashMap<String, Value>,
+        parameters: &BTreeMap<String, Value>,
         calculation_date: &str,
         visited: &[String],
         depth: usize,
@@ -313,7 +313,7 @@ impl<'a> ArticleEngine<'a> {
     fn resolve_internal_reference(
         &self,
         output_name: &str,
-        parameters: &HashMap<String, Value>,
+        parameters: &BTreeMap<String, Value>,
         calculation_date: &str,
         visited: &[String],
         depth: usize,
@@ -706,7 +706,7 @@ articles:
         let article = law.find_article_by_number("1").unwrap();
         let engine = ArticleEngine::new(article, &law);
 
-        let mut params = HashMap::new();
+        let mut params = BTreeMap::new();
         params.insert("age".to_string(), Value::Int(25));
 
         let result = engine.evaluate(params, "2025-01-01").unwrap();
@@ -723,7 +723,7 @@ articles:
         let engine = ArticleEngine::new(article, &law);
 
         // Age 15 is less than MIN_AGE (18)
-        let mut params = HashMap::new();
+        let mut params = BTreeMap::new();
         params.insert("age".to_string(), Value::Int(15));
 
         let result = engine.evaluate(params, "2025-01-01").unwrap();
@@ -738,7 +738,7 @@ articles:
         let engine = ArticleEngine::new(article, &law);
 
         // Adult case
-        let mut params = HashMap::new();
+        let mut params = BTreeMap::new();
         params.insert("age".to_string(), Value::Int(25));
         let result = engine.evaluate(params, "2025-01-01").unwrap();
         assert_eq!(
@@ -747,7 +747,7 @@ articles:
         );
 
         // Minor case
-        let mut params = HashMap::new();
+        let mut params = BTreeMap::new();
         params.insert("age".to_string(), Value::Int(15));
         let result = engine.evaluate(params, "2025-01-01").unwrap();
         assert_eq!(
@@ -766,7 +766,7 @@ articles:
         let article = law.find_article_by_number("1").unwrap();
         let engine = ArticleEngine::new(article, &law);
 
-        let mut params = HashMap::new();
+        let mut params = BTreeMap::new();
         params.insert("income".to_string(), Value::Int(5000));
 
         let result = engine.evaluate(params, "2025-01-01").unwrap();
@@ -788,7 +788,7 @@ articles:
         let engine = ArticleEngine::new(article, &law);
 
         // Income below deduction
-        let mut params = HashMap::new();
+        let mut params = BTreeMap::new();
         params.insert("income".to_string(), Value::Int(500));
 
         let result = engine.evaluate(params, "2025-01-01").unwrap();
@@ -810,7 +810,7 @@ articles:
         let article = law.find_article_by_number("1").unwrap();
         let engine = ArticleEngine::new(article, &law);
 
-        let mut params = HashMap::new();
+        let mut params = BTreeMap::new();
         params.insert("age".to_string(), Value::Int(25));
 
         // Request specific output (used for article lookup)
@@ -835,7 +835,7 @@ articles:
         let engine = ArticleEngine::new(article, &law);
 
         // No parameters - age is missing
-        let params = HashMap::new();
+        let params = BTreeMap::new();
         let result = engine.evaluate(params, "2025-01-01");
 
         assert!(matches!(result, Err(EngineError::VariableNotFound(_))));
@@ -847,7 +847,7 @@ articles:
         let article = law.find_article_by_number("1").unwrap();
         let engine = ArticleEngine::new(article, &law);
 
-        let mut params = HashMap::new();
+        let mut params = BTreeMap::new();
         params.insert("age".to_string(), Value::Int(25));
 
         let result = engine.evaluate(params, "not-a-date");
@@ -880,7 +880,7 @@ articles:
         let article = law.find_article_by_number("1").unwrap();
         let engine = ArticleEngine::new(article, &law);
 
-        let result = engine.evaluate(HashMap::new(), "2025-06-15").unwrap();
+        let result = engine.evaluate(BTreeMap::new(), "2025-06-15").unwrap();
 
         assert_eq!(result.outputs.get("current_year"), Some(&Value::Int(2025)));
     }
@@ -933,7 +933,7 @@ articles:
         let article = law.find_article_by_number("2").unwrap();
         let engine = ArticleEngine::new(article, &law);
 
-        let result = engine.evaluate(HashMap::new(), "2025-01-01").unwrap();
+        let result = engine.evaluate(BTreeMap::new(), "2025-01-01").unwrap();
 
         // doubled_amount should be 100 * 2 = 200
         assert_eq!(result.outputs.get("doubled_amount"), Some(&Value::Int(200)));
@@ -1003,7 +1003,7 @@ articles:
         let article = law.find_article_by_number("3").unwrap();
         let engine = ArticleEngine::new(article, &law);
 
-        let result = engine.evaluate(HashMap::new(), "2025-01-01").unwrap();
+        let result = engine.evaluate(BTreeMap::new(), "2025-01-01").unwrap();
 
         // Chain: first_value = 10, second_value = 10 + 5 = 15, third_value = 15 * 2 = 30
         assert_eq!(result.outputs.get("third_value"), Some(&Value::Int(30)));
@@ -1061,7 +1061,7 @@ articles:
         let article = law.find_article_by_number("2").unwrap();
         let engine = ArticleEngine::new(article, &law);
 
-        let mut params = HashMap::new();
+        let mut params = BTreeMap::new();
         params.insert("multiplier".to_string(), Value::Int(3));
 
         let result = engine.evaluate(params, "2025-01-01").unwrap();
@@ -1098,7 +1098,7 @@ articles:
         let article = law.find_article_by_number("1").unwrap();
         let engine = ArticleEngine::new(article, &law);
 
-        let result = engine.evaluate(HashMap::new(), "2025-01-01");
+        let result = engine.evaluate(BTreeMap::new(), "2025-01-01");
 
         assert!(matches!(result, Err(EngineError::CircularReference(_))));
     }
@@ -1154,7 +1154,7 @@ articles:
         let article = law.find_article_by_number("1").unwrap();
         let engine = ArticleEngine::new(article, &law);
 
-        let result = engine.evaluate(HashMap::new(), "2025-01-01");
+        let result = engine.evaluate(BTreeMap::new(), "2025-01-01");
 
         assert!(
             matches!(result, Err(EngineError::CircularReference(_))),
@@ -1223,7 +1223,7 @@ articles:
         let article = law.find_article_by_number("1").unwrap();
         let engine = ArticleEngine::new(article, &law);
 
-        let result = engine.evaluate(HashMap::new(), "2025-01-01");
+        let result = engine.evaluate(BTreeMap::new(), "2025-01-01");
 
         assert!(
             matches!(result, Err(EngineError::CircularReference(_))),
@@ -1261,7 +1261,7 @@ articles:
         let article = law.find_article_by_number("1").unwrap();
         let engine = ArticleEngine::new(article, &law);
 
-        let result = engine.evaluate(HashMap::new(), "2025-01-01");
+        let result = engine.evaluate(BTreeMap::new(), "2025-01-01");
 
         assert!(
             matches!(
@@ -1356,7 +1356,7 @@ articles:
             // Test with vermogen under threshold for single person
             // The article requires: vermogen, heeft_toeslagpartner
             // Thresholds: €161.329 single, €203.643 with partner
-            let mut params = HashMap::new();
+            let mut params = BTreeMap::new();
             params.insert("vermogen".to_string(), Value::Int(100000)); // €1000 in cents, well under €161.329
             params.insert("heeft_toeslagpartner".to_string(), Value::Bool(false));
 
@@ -1384,7 +1384,7 @@ articles:
             let engine = ArticleEngine::new(article, &law);
 
             // Execute with minimal params
-            let result = engine.evaluate(HashMap::new(), "2025-01-01").unwrap();
+            let result = engine.evaluate(BTreeMap::new(), "2025-01-01").unwrap();
 
             // Should have standaardpremie output (211200 eurocent = €2112 for 2025)
             assert_eq!(

--- a/packages/engine/src/operations.rs
+++ b/packages/engine/src/operations.rs
@@ -1222,7 +1222,7 @@ fn type_error(expected: &str, actual: &Value) -> EngineError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashMap;
+    use std::collections::{BTreeMap, HashMap};
 
     /// Simple resolver for testing that uses a HashMap
     struct TestResolver {
@@ -2253,7 +2253,7 @@ mod tests {
 
         #[test]
         fn test_age_with_object_date() {
-            let mut date_obj = HashMap::new();
+            let mut date_obj = BTreeMap::new();
             date_obj.insert("iso".to_string(), Value::String("2025-01-01".to_string()));
             date_obj.insert("year".to_string(), Value::Int(2025));
             date_obj.insert("month".to_string(), Value::Int(1));
@@ -2534,7 +2534,7 @@ mod tests {
 
     #[test]
     fn test_parse_date_with_object() {
-        let mut date_obj = HashMap::new();
+        let mut date_obj = BTreeMap::new();
         date_obj.insert("iso".to_string(), Value::String("2025-01-01".to_string()));
         date_obj.insert("year".to_string(), Value::Int(2025));
 
@@ -2544,7 +2544,7 @@ mod tests {
 
     #[test]
     fn test_parse_date_object_without_iso_field() {
-        let mut date_obj = HashMap::new();
+        let mut date_obj = BTreeMap::new();
         date_obj.insert("year".to_string(), Value::Int(2025));
 
         let result = parse_date(&Value::Object(date_obj));

--- a/packages/engine/src/service.rs
+++ b/packages/engine/src/service.rs
@@ -7,13 +7,13 @@
 //!
 //! ```ignore
 //! use regelrecht_engine::{LawExecutionService, Value};
-//! use std::collections::HashMap;
+//! use std::collections::BTreeMap;
 //!
 //! let mut service = LawExecutionService::new();
 //! service.load_law(zorgtoeslagwet_yaml)?;
 //! service.load_law(regeling_standaardpremie_yaml)?;
 //!
-//! let mut params = HashMap::new();
+//! let mut params = BTreeMap::new();
 //! params.insert("BSN".to_string(), Value::String("123456789".to_string()));
 //!
 //! // This will automatically resolve cross-law references
@@ -40,7 +40,7 @@ use crate::uri::RegelrechtUri;
 use chrono::NaiveDate;
 use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::hash::{Hash, Hasher};
 use std::rc::Rc;
 
@@ -59,8 +59,8 @@ use std::rc::Rc;
 type CacheEntry = (
     String,
     String,
-    HashMap<String, Value>,
-    HashMap<String, Value>,
+    BTreeMap<String, Value>,
+    BTreeMap<String, Value>,
 );
 
 /// Uses a scoped push/pop pattern for the visited set to avoid
@@ -170,7 +170,7 @@ impl<'a> ResolutionContext<'a> {
 /// Parameters are sorted by key for consistent hashing within a process.
 /// Note: `DefaultHasher` is randomly seeded per process, so keys are only
 /// valid for per-execution memoization (not persisted across runs).
-fn cache_key(law_id: &str, output_name: &str, params: &HashMap<String, Value>) -> u64 {
+fn cache_key(law_id: &str, output_name: &str, params: &BTreeMap<String, Value>) -> u64 {
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     law_id.hash(&mut hasher);
     output_name.hash(&mut hasher);
@@ -236,7 +236,7 @@ pub trait ServiceProvider {
     fn evaluate_uri(
         &self,
         uri: &str,
-        parameters: &HashMap<String, Value>,
+        parameters: &BTreeMap<String, Value>,
         calculation_date: &str,
     ) -> Result<ArticleResult>;
 
@@ -257,7 +257,7 @@ pub trait ServiceProvider {
         &self,
         regulation: &str,
         output: &str,
-        source_parameters: Option<&HashMap<String, String>>,
+        source_parameters: Option<&BTreeMap<String, String>>,
         context: &RuleContext,
         calculation_date: &str,
     ) -> Result<Value>;
@@ -297,9 +297,9 @@ pub struct StageState {
     /// Current lifecycle stage (e.g., "BESLUIT", "BEKENDMAKING")
     pub current_stage: String,
     /// Outputs accumulated from all completed stages
-    pub accumulated_outputs: HashMap<String, Value>,
+    pub accumulated_outputs: BTreeMap<String, Value>,
     /// Original parameters from the initial execution
-    pub parameters: HashMap<String, Value>,
+    pub parameters: BTreeMap<String, Value>,
 }
 
 /// Outcome of a stage-aware execution step.
@@ -312,7 +312,7 @@ pub enum ExecutionOutcome {
         /// Updated decision state
         state: StageState,
         /// Outputs computed so far (including this stage)
-        outputs: HashMap<String, Value>,
+        outputs: BTreeMap<String, Value>,
         /// Inputs required to advance to the next stage
         pending_inputs: Vec<String>,
     },
@@ -413,7 +413,7 @@ impl LawExecutionService {
         &self,
         law_id: &str,
         output_name: &str,
-        parameters: HashMap<String, Value>,
+        parameters: BTreeMap<String, Value>,
         calculation_date: &str,
     ) -> Result<ArticleResult> {
         let mut res_ctx = ResolutionContext::new(calculation_date);
@@ -429,7 +429,7 @@ impl LawExecutionService {
         &self,
         law_id: &str,
         output_name: &str,
-        parameters: HashMap<String, Value>,
+        parameters: BTreeMap<String, Value>,
         calculation_date: &str,
     ) -> Result<ArticleResult> {
         let trace = Rc::new(RefCell::new(TraceBuilder::new()));
@@ -506,7 +506,12 @@ impl LawExecutionService {
     ) -> Result<ArticleResult> {
         let mut res_ctx = ResolutionContext::with_trace(calculation_date, trace);
         res_ctx.contextual_law_id = Some(law_id.to_string());
-        self.evaluate_law_output_internal(law_id, output_name, parameters, &mut res_ctx)
+        self.evaluate_law_output_internal(
+            law_id,
+            output_name,
+            parameters.into_iter().collect(),
+            &mut res_ctx,
+        )
     }
 
     /// Execute a single lifecycle stage of a procedure-aware law (RFC-008).
@@ -530,7 +535,7 @@ impl LawExecutionService {
         law_id: &str,
         output_name: &str,
         state: Option<StageState>,
-        parameters: HashMap<String, Value>,
+        parameters: BTreeMap<String, Value>,
         calculation_date: &str,
     ) -> Result<ExecutionOutcome> {
         self.execute_stage_internal(
@@ -560,7 +565,7 @@ impl LawExecutionService {
             law_id,
             output_name,
             state,
-            parameters,
+            parameters.into_iter().collect(),
             calculation_date,
             Some(trace),
         )
@@ -572,7 +577,7 @@ impl LawExecutionService {
         law_id: &str,
         output_name: &str,
         state: Option<StageState>,
-        parameters: HashMap<String, Value>,
+        parameters: BTreeMap<String, Value>,
         calculation_date: &str,
         trace: Option<Rc<RefCell<TraceBuilder>>>,
     ) -> Result<ExecutionOutcome> {
@@ -605,12 +610,17 @@ impl LawExecutionService {
                 self.evaluate_law_output_with_shared_trace(
                     law_id,
                     output_name,
-                    parameters,
+                    parameters.into_iter().collect(),
                     calculation_date,
                     tb,
                 )?
             } else {
-                self.evaluate_law_output(law_id, output_name, parameters, calculation_date)?
+                self.evaluate_law_output(
+                    law_id,
+                    output_name,
+                    parameters.into_iter().collect(),
+                    calculation_date,
+                )?
             };
             return Ok(ExecutionOutcome::Complete(result));
         };
@@ -628,7 +638,7 @@ impl LawExecutionService {
                     procedure_id: procedure.id.clone(),
                     contextual_law: law_id.to_string(),
                     current_stage: first_stage.name.clone(),
-                    accumulated_outputs: HashMap::new(),
+                    accumulated_outputs: BTreeMap::new(),
                     parameters: parameters.clone(),
                 }
             }
@@ -749,7 +759,7 @@ impl LawExecutionService {
         &self,
         law_id: &str,
         output_name: &str,
-        parameters: HashMap<String, Value>,
+        parameters: BTreeMap<String, Value>,
         res_ctx: &mut ResolutionContext<'_>,
     ) -> Result<ArticleResult> {
         // --- Cache check (before depth check: cached results don't increase depth) ---
@@ -779,7 +789,7 @@ impl LawExecutionService {
                 res_ctx.trace_pop();
                 return Ok(ArticleResult {
                     outputs: cached_outputs.clone(),
-                    resolved_inputs: HashMap::new(),
+                    resolved_inputs: BTreeMap::new(),
                     article_number: String::new(),
                     law_id: law_id.to_string(),
                     law_uuid: None,
@@ -886,12 +896,12 @@ impl LawExecutionService {
         article: &Article,
         _law: &ArticleBasedLaw,
         stage: &str,
-        parameters: &HashMap<String, Value>,
+        parameters: &BTreeMap<String, Value>,
         res_ctx: &mut ResolutionContext<'_>,
-    ) -> Result<HashMap<String, Value>> {
-        let mut hook_outputs: HashMap<String, Value> = HashMap::new();
+    ) -> Result<BTreeMap<String, Value>> {
+        let mut hook_outputs: BTreeMap<String, Value> = BTreeMap::new();
         // Track which law produced each output for priority resolution
-        let mut output_sources: HashMap<String, &ArticleBasedLaw> = HashMap::new();
+        let mut output_sources: BTreeMap<String, &ArticleBasedLaw> = BTreeMap::new();
 
         // Only fire hooks if the article declares what it produces
         let produces = match article.get_produces() {
@@ -1019,7 +1029,7 @@ impl LawExecutionService {
         result: &mut ArticleResult,
         article: &Article,
         law: &ArticleBasedLaw,
-        parameters: &HashMap<String, Value>,
+        parameters: &BTreeMap<String, Value>,
         res_ctx: &mut ResolutionContext<'_>,
     ) -> Result<()> {
         let contextual_law_id = match &res_ctx.contextual_law_id {
@@ -1130,7 +1140,7 @@ impl LawExecutionService {
         &self,
         article: &Article,
         law: &ArticleBasedLaw,
-        parameters: HashMap<String, Value>,
+        parameters: BTreeMap<String, Value>,
         requested_output: Option<&str>,
         stage: &str,
         res_ctx: &mut ResolutionContext<'_>,
@@ -1264,8 +1274,8 @@ impl LawExecutionService {
         law: &ArticleBasedLaw,
         context: &RuleContext,
         res_ctx: &mut ResolutionContext<'_>,
-    ) -> Result<HashMap<String, Value>> {
-        let mut resolved = HashMap::new();
+    ) -> Result<BTreeMap<String, Value>> {
+        let mut resolved = BTreeMap::new();
 
         let open_terms = match article.get_open_terms() {
             Some(terms) => terms,
@@ -1308,12 +1318,18 @@ impl LawExecutionService {
             res_ctx.trace_set_resolve_type(ResolveType::OpenTerm);
 
             // Look up implementations (filtered by execution scope)
+            // Convert BTreeMap to HashMap at the resolver boundary
+            let scope: HashMap<String, Value> = context
+                .parameters()
+                .iter()
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect();
             let implementations = match self.resolver.find_implementations(
                 &law.id,
                 &article.number,
                 &term.id,
                 res_ctx.reference_date(),
-                context.parameters(),
+                &scope,
             ) {
                 Ok(impls) => impls,
                 Err(e) => {
@@ -1520,7 +1536,7 @@ impl LawExecutionService {
         article: &Article,
         law: &ArticleBasedLaw,
         context: &mut RuleContext,
-        parameters: &HashMap<String, Value>,
+        parameters: &BTreeMap<String, Value>,
         res_ctx: &mut ResolutionContext<'_>,
     ) -> Result<()> {
         let inputs = article.get_inputs();
@@ -1646,7 +1662,7 @@ impl LawExecutionService {
         &self,
         regulation: &str,
         output: &str,
-        source_parameters: Option<&HashMap<String, String>>,
+        source_parameters: Option<&BTreeMap<String, String>>,
         context: &RuleContext,
         res_ctx: &mut ResolutionContext<'_>,
     ) -> Result<Value> {
@@ -1718,16 +1734,16 @@ impl LawExecutionService {
     /// execution.parameters section.
     fn filter_parameters_for_article(
         article: &Article,
-        all_params: &HashMap<String, Value>,
-    ) -> HashMap<String, Value> {
+        all_params: &BTreeMap<String, Value>,
+    ) -> BTreeMap<String, Value> {
         let Some(exec) = article.get_execution_spec() else {
-            return HashMap::new();
+            return BTreeMap::new();
         };
         let Some(declared_params) = &exec.parameters else {
-            return HashMap::new();
+            return BTreeMap::new();
         };
 
-        let mut filtered = HashMap::new();
+        let mut filtered = BTreeMap::new();
         for param in declared_params {
             if let Some(value) = all_params.get(&param.name) {
                 filtered.insert(param.name.clone(), value.clone());
@@ -1739,10 +1755,10 @@ impl LawExecutionService {
     /// Build parameters for a target article from source parameter mapping.
     fn build_target_parameters(
         &self,
-        source_parameters: Option<&HashMap<String, String>>,
+        source_parameters: Option<&BTreeMap<String, String>>,
         context: &RuleContext,
-    ) -> Result<HashMap<String, Value>> {
-        let mut params = HashMap::new();
+    ) -> Result<BTreeMap<String, Value>> {
+        let mut params = BTreeMap::new();
 
         if let Some(param_map) = source_parameters {
             for (target_name, source_ref) in param_map {
@@ -1852,7 +1868,7 @@ impl LawExecutionService {
         &mut self,
         name: impl Into<String>,
         priority: i32,
-        data: HashMap<String, HashMap<String, Value>>,
+        data: BTreeMap<String, BTreeMap<String, Value>>,
     ) {
         self.data_registry
             .add_source(Box::new(DictDataSource::new(name, priority, data)));
@@ -1878,7 +1894,7 @@ impl LawExecutionService {
         &mut self,
         name: &str,
         key_field: &str,
-        records: Vec<HashMap<String, Value>>,
+        records: Vec<BTreeMap<String, Value>>,
     ) -> Result<()> {
         match DictDataSource::from_records(name, 10, key_field, records) {
             Some(source) => {
@@ -1912,7 +1928,7 @@ impl ServiceProvider for LawExecutionService {
     fn evaluate_uri(
         &self,
         uri: &str,
-        parameters: &HashMap<String, Value>,
+        parameters: &BTreeMap<String, Value>,
         calculation_date: &str,
     ) -> Result<ArticleResult> {
         let parsed = RegelrechtUri::parse(uri)?;
@@ -1933,7 +1949,7 @@ impl ServiceProvider for LawExecutionService {
         &self,
         regulation: &str,
         output: &str,
-        source_parameters: Option<&HashMap<String, String>>,
+        source_parameters: Option<&BTreeMap<String, String>>,
         context: &RuleContext,
         calculation_date: &str,
     ) -> Result<Value> {
@@ -2024,7 +2040,7 @@ articles:
         service.load_law(make_base_law()).unwrap();
 
         let result = service
-            .evaluate_law_output("base_law", "base_value", HashMap::new(), "2025-01-01")
+            .evaluate_law_output("base_law", "base_value", BTreeMap::new(), "2025-01-01")
             .unwrap();
 
         assert_eq!(result.outputs.get("base_value"), Some(&Value::Int(100)));
@@ -2045,7 +2061,7 @@ articles:
             .evaluate_law_output(
                 "dependent_law",
                 "doubled_value",
-                HashMap::new(),
+                BTreeMap::new(),
                 "2025-01-01",
             )
             .unwrap();
@@ -2063,7 +2079,7 @@ articles:
         let result = service.evaluate_law_output(
             "dependent_law",
             "doubled_value",
-            HashMap::new(),
+            BTreeMap::new(),
             "2025-01-01",
         );
 
@@ -2086,7 +2102,7 @@ articles:
         let result = service
             .evaluate_uri(
                 "regelrecht://base_law/base_value",
-                &HashMap::new(),
+                &BTreeMap::new(),
                 "2025-01-01",
             )
             .unwrap();
@@ -2151,7 +2167,8 @@ articles:
         service.load_law(law_a).unwrap();
         service.load_law(law_b).unwrap();
 
-        let result = service.evaluate_law_output("law_a", "output_a", HashMap::new(), "2025-01-01");
+        let result =
+            service.evaluate_law_output("law_a", "output_a", BTreeMap::new(), "2025-01-01");
 
         assert!(
             matches!(result, Err(EngineError::CircularReference(_))),
@@ -2201,7 +2218,7 @@ articles:
         service.load_law(law).unwrap();
 
         // Provide the value directly - should skip external resolution
-        let mut params = HashMap::new();
+        let mut params = BTreeMap::new();
         params.insert("external_value".to_string(), Value::Int(50));
 
         let result = service
@@ -2302,7 +2319,7 @@ articles:
                 .evaluate_law_output(
                     "zorgtoeslagwet",
                     "standaardpremie",
-                    HashMap::new(),
+                    BTreeMap::new(),
                     "2025-01-01",
                 )
                 .unwrap();
@@ -2433,7 +2450,12 @@ articles:
 
         // Reference date 2024-06-15 should use v1 (BASE_VALUE=100)
         let result = service
-            .evaluate_law_output("cross_law_consumer", "result", HashMap::new(), "2024-06-15")
+            .evaluate_law_output(
+                "cross_law_consumer",
+                "result",
+                BTreeMap::new(),
+                "2024-06-15",
+            )
             .unwrap();
         assert_eq!(
             result.outputs.get("result"),
@@ -2443,7 +2465,12 @@ articles:
 
         // Reference date 2025-06-15 should use v2 (BASE_VALUE=200)
         let result = service
-            .evaluate_law_output("cross_law_consumer", "result", HashMap::new(), "2025-06-15")
+            .evaluate_law_output(
+                "cross_law_consumer",
+                "result",
+                BTreeMap::new(),
+                "2025-06-15",
+            )
             .unwrap();
         assert_eq!(
             result.outputs.get("result"),
@@ -2496,7 +2523,7 @@ articles:
         service.load_law(law).unwrap();
 
         // Register data source with the input field
-        let mut record = HashMap::new();
+        let mut record = BTreeMap::new();
         record.insert("BSN".to_string(), Value::String("123".to_string()));
         record.insert("external_value".to_string(), Value::Int(42));
 
@@ -2504,7 +2531,7 @@ articles:
             .register_dict_source("test_data", "BSN", vec![record])
             .unwrap();
 
-        let mut params = HashMap::new();
+        let mut params = BTreeMap::new();
         params.insert("BSN".to_string(), Value::String("123".to_string()));
 
         let result = service
@@ -2523,7 +2550,7 @@ articles:
         service.load_law(make_dependent_law()).unwrap();
 
         // Register a data source with an unrelated field
-        let mut record = HashMap::new();
+        let mut record = BTreeMap::new();
         record.insert("key".to_string(), Value::String("x".to_string()));
         record.insert("unrelated_field".to_string(), Value::Int(999));
 
@@ -2536,7 +2563,7 @@ articles:
             .evaluate_law_output(
                 "dependent_law",
                 "doubled_value",
-                HashMap::new(),
+                BTreeMap::new(),
                 "2025-01-01",
             )
             .unwrap();
@@ -2582,7 +2609,7 @@ articles:
         service.load_law(law).unwrap();
 
         // Register data source with external_value = 100
-        let mut record = HashMap::new();
+        let mut record = BTreeMap::new();
         record.insert("BSN".to_string(), Value::String("123".to_string()));
         record.insert("external_value".to_string(), Value::Int(100));
 
@@ -2591,7 +2618,7 @@ articles:
             .unwrap();
 
         // Pass external_value = 50 as parameter (should win)
-        let mut params = HashMap::new();
+        let mut params = BTreeMap::new();
         params.insert("BSN".to_string(), Value::String("123".to_string()));
         params.insert("external_value".to_string(), Value::Int(50));
 
@@ -2667,7 +2694,7 @@ articles:
             .evaluate_law_output(
                 "zorgtoeslag_ioc",
                 "standaardpremie",
-                HashMap::new(),
+                BTreeMap::new(),
                 "2025-01-01",
             )
             .unwrap();
@@ -2687,7 +2714,7 @@ articles:
         let result = service.evaluate_law_output(
             "zorgtoeslag_ioc",
             "standaardpremie",
-            HashMap::new(),
+            BTreeMap::new(),
             "2025-01-01",
         );
 
@@ -2725,7 +2752,7 @@ articles:
 
         // Should succeed — optional term not implemented is fine
         let result = service
-            .evaluate_law_output("optional_term_law", "result", HashMap::new(), "2025-01-01")
+            .evaluate_law_output("optional_term_law", "result", BTreeMap::new(), "2025-01-01")
             .unwrap();
 
         assert_eq!(result.outputs.get("result"), Some(&Value::Int(42)));
@@ -2765,7 +2792,7 @@ articles:
             .evaluate_law_output(
                 "default_term_law",
                 "redelijk_percentage",
-                HashMap::new(),
+                BTreeMap::new(),
                 "2025-01-01",
             )
             .unwrap();
@@ -2834,7 +2861,7 @@ articles:
             .evaluate_law_output(
                 "default_override_law",
                 "percentage",
-                HashMap::new(),
+                BTreeMap::new(),
                 "2025-07-01",
             )
             .unwrap();
@@ -2919,7 +2946,7 @@ articles:
 
         // Calculate for 2025: should use the 2025 version
         let result = service
-            .evaluate_law_output("test_higher_law", "result", HashMap::new(), "2025-06-01")
+            .evaluate_law_output("test_higher_law", "result", BTreeMap::new(), "2025-06-01")
             .unwrap();
         assert_eq!(
             result.outputs.get("result"),
@@ -2929,7 +2956,7 @@ articles:
 
         // Calculate for 2026: should use the 2026 version
         let result = service
-            .evaluate_law_output("test_higher_law", "result", HashMap::new(), "2026-06-01")
+            .evaluate_law_output("test_higher_law", "result", BTreeMap::new(), "2026-06-01")
             .unwrap();
         assert_eq!(
             result.outputs.get("result"),

--- a/packages/engine/src/types.rs
+++ b/packages/engine/src/types.rs
@@ -1,7 +1,7 @@
 //! Core types for the RegelRecht engine
 
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::fmt;
 
 /// Represents any value in the engine (similar to Python's Any)
@@ -27,7 +27,7 @@ pub enum Value {
     /// Array of values
     Array(Vec<Value>),
     /// Object/Map of values
-    Object(HashMap<String, Value>),
+    Object(BTreeMap<String, Value>),
 }
 
 impl PartialEq for Value {
@@ -103,7 +103,7 @@ impl Value {
     }
 
     /// Try to get value as object reference
-    pub fn as_object(&self) -> Option<&HashMap<String, Value>> {
+    pub fn as_object(&self) -> Option<&BTreeMap<String, Value>> {
         match self {
             Value::Object(o) => Some(o),
             _ => None,
@@ -215,7 +215,7 @@ impl From<serde_json::Value> for Value {
                 Value::Array(arr.into_iter().map(Value::from).collect())
             }
             serde_json::Value::Object(obj) => {
-                let map: HashMap<String, Value> =
+                let map: BTreeMap<String, Value> =
                     obj.into_iter().map(|(k, v)| (k, Value::from(v))).collect();
                 Value::Object(map)
             }
@@ -244,7 +244,7 @@ impl From<&serde_json::Value> for Value {
             serde_json::Value::String(s) => Value::String(s.clone()),
             serde_json::Value::Array(arr) => Value::Array(arr.iter().map(Value::from).collect()),
             serde_json::Value::Object(obj) => {
-                let map: HashMap<String, Value> = obj
+                let map: BTreeMap<String, Value> = obj
                     .iter()
                     .map(|(k, v)| (k.clone(), Value::from(v)))
                     .collect();

--- a/packages/engine/src/wasm.rs
+++ b/packages/engine/src/wasm.rs
@@ -55,7 +55,7 @@
 
 use serde::Serialize;
 use serde_wasm_bindgen::Serializer;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use wasm_bindgen::prelude::*;
 
 use crate::config;
@@ -87,8 +87,8 @@ fn engine_error_to_wasm(err: EngineError) -> JsValue {
 /// Serializable result for execute()
 #[derive(Serialize)]
 struct WasmExecuteResult {
-    outputs: HashMap<String, Value>,
-    resolved_inputs: HashMap<String, Value>,
+    outputs: BTreeMap<String, Value>,
+    resolved_inputs: BTreeMap<String, Value>,
     article_number: String,
     law_id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -174,7 +174,7 @@ impl WasmEngine {
         parameters: JsValue,
         calculation_date: &str,
     ) -> Result<JsValue, JsValue> {
-        let params: HashMap<String, Value> = serde_wasm_bindgen::from_value(parameters)
+        let params: BTreeMap<String, Value> = serde_wasm_bindgen::from_value(parameters)
             .map_err(|e| wasm_error(&format!("Failed to parse parameters: {}", e)))?;
 
         let result = self
@@ -278,7 +278,7 @@ impl WasmEngine {
         key_field: &str,
         records: JsValue,
     ) -> Result<(), JsValue> {
-        let parsed: Vec<HashMap<String, Value>> = serde_wasm_bindgen::from_value(records)
+        let parsed: Vec<BTreeMap<String, Value>> = serde_wasm_bindgen::from_value(records)
             .map_err(|e| wasm_error(&format!("Failed to parse records: {}", e)))?;
 
         self.service
@@ -476,7 +476,7 @@ articles:
         load_law(&mut engine, law_b);
 
         // Execute via the service directly (can't use JsValue in native tests)
-        let params = HashMap::new();
+        let params = BTreeMap::new();
         let result = engine
             .service
             .evaluate_law_output("law_b", "doubled", params, "2025-01-01")
@@ -521,7 +521,7 @@ articles:
 
         // Register data source
         let records = vec![{
-            let mut r = HashMap::new();
+            let mut r = BTreeMap::new();
             r.insert("bsn".to_string(), Value::String("123".to_string()));
             r.insert("age".to_string(), Value::Int(25));
             r
@@ -531,7 +531,7 @@ articles:
             .register_dict_source("people", "bsn", records)
             .unwrap();
 
-        let mut params = HashMap::new();
+        let mut params = BTreeMap::new();
         params.insert("bsn".to_string(), Value::String("123".to_string()));
 
         let result = engine

--- a/packages/engine/tests/bdd/helpers/value_conversion.rs
+++ b/packages/engine/tests/bdd/helpers/value_conversion.rs
@@ -51,8 +51,8 @@ pub fn convert_gherkin_value(val: &str) -> Value {
 /// ```
 pub fn parse_table_to_params(
     table: &cucumber::gherkin::Table,
-) -> std::collections::HashMap<String, Value> {
-    let mut params = std::collections::HashMap::new();
+) -> std::collections::BTreeMap<String, Value> {
+    let mut params = std::collections::BTreeMap::new();
 
     for row in &table.rows {
         if row.len() >= 2 {

--- a/packages/engine/tests/bdd/steps/given.rs
+++ b/packages/engine/tests/bdd/steps/given.rs
@@ -141,7 +141,7 @@ fn parse_external_data_table(
     table: &cucumber::gherkin::Table,
     storage: &mut std::collections::HashMap<
         String,
-        std::collections::HashMap<String, regelrecht_engine::Value>,
+        std::collections::BTreeMap<String, regelrecht_engine::Value>,
     >,
 ) {
     if table.rows.len() < 2 {
@@ -153,7 +153,7 @@ fn parse_external_data_table(
 
     // Remaining rows are data
     for row in table.rows.iter().skip(1) {
-        let mut record = std::collections::HashMap::new();
+        let mut record = std::collections::BTreeMap::new();
         let mut bsn = String::new();
 
         for (i, cell) in row.iter().enumerate() {

--- a/packages/engine/tests/bdd/steps/when.rs
+++ b/packages/engine/tests/bdd/steps/when.rs
@@ -96,7 +96,7 @@ fn execute_healthcare_allowance(world: &mut RegelrechtWorld) {
 fn register_if_present(
     service: &mut regelrecht_engine::LawExecutionService,
     name: &str,
-    data: &std::collections::HashMap<String, std::collections::HashMap<String, Value>>,
+    data: &std::collections::HashMap<String, std::collections::BTreeMap<String, Value>>,
 ) {
     if !data.is_empty() {
         let records: Vec<_> = data.values().cloned().collect();

--- a/packages/engine/tests/bdd/world.rs
+++ b/packages/engine/tests/bdd/world.rs
@@ -6,7 +6,7 @@
 
 use cucumber::World;
 use regelrecht_engine::{ArticleResult, EngineError, LawExecutionService, Value};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 
 use crate::helpers::regulation_loader::load_all_regulations;
@@ -20,7 +20,7 @@ pub struct RegelrechtWorld {
     /// Calculation date for the current scenario
     pub calculation_date: String,
     /// Parameters for law execution
-    pub parameters: HashMap<String, Value>,
+    pub parameters: BTreeMap<String, Value>,
     /// Last execution result (if successful)
     pub result: Option<ArticleResult>,
     /// Last error (if execution failed)
@@ -49,23 +49,23 @@ impl fmt::Debug for RegelrechtWorld {
 #[derive(Debug, Default, Clone)]
 pub struct ExternalData {
     /// RVIG personal_data
-    pub rvig_personal: HashMap<String, HashMap<String, Value>>,
+    pub rvig_personal: HashMap<String, BTreeMap<String, Value>>,
     /// RVIG relationship_data
-    pub rvig_relationship: HashMap<String, HashMap<String, Value>>,
+    pub rvig_relationship: HashMap<String, BTreeMap<String, Value>>,
     /// RVZ insurance data
-    pub rvz_insurance: HashMap<String, HashMap<String, Value>>,
+    pub rvz_insurance: HashMap<String, BTreeMap<String, Value>>,
     /// Belastingdienst box1 data
-    pub bd_box1: HashMap<String, HashMap<String, Value>>,
+    pub bd_box1: HashMap<String, BTreeMap<String, Value>>,
     /// Belastingdienst box2 data
-    pub bd_box2: HashMap<String, HashMap<String, Value>>,
+    pub bd_box2: HashMap<String, BTreeMap<String, Value>>,
     /// Belastingdienst box3 data
-    pub bd_box3: HashMap<String, HashMap<String, Value>>,
+    pub bd_box3: HashMap<String, BTreeMap<String, Value>>,
     /// DJI detenties data
-    pub dji_detenties: HashMap<String, HashMap<String, Value>>,
+    pub dji_detenties: HashMap<String, BTreeMap<String, Value>>,
     /// DUO inschrijvingen data
-    pub duo_inschrijvingen: HashMap<String, HashMap<String, Value>>,
+    pub duo_inschrijvingen: HashMap<String, BTreeMap<String, Value>>,
     /// DUO studiefinanciering data
-    pub duo_studiefinanciering: HashMap<String, HashMap<String, Value>>,
+    pub duo_studiefinanciering: HashMap<String, BTreeMap<String, Value>>,
 }
 
 impl Default for RegelrechtWorld {
@@ -87,7 +87,7 @@ impl RegelrechtWorld {
         Self {
             service,
             calculation_date: "2024-01-01".to_string(),
-            parameters: HashMap::new(),
+            parameters: BTreeMap::new(),
             result: None,
             error: None,
             external_data: ExternalData::default(),

--- a/packages/engine/tests/golden_tests.rs
+++ b/packages/engine/tests/golden_tests.rs
@@ -5,7 +5,7 @@
 
 use regelrecht_engine::{LawExecutionService, Value};
 use serde::Deserialize;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::path::Path;
 
@@ -145,7 +145,7 @@ fn run_test_case(test: &TestCase) -> Result<(), String> {
     }
 
     // Convert parameters
-    let params: HashMap<String, Value> = test
+    let params: BTreeMap<String, Value> = test
         .parameters
         .iter()
         .map(|(k, v)| (k.clone(), json_to_value(v)))

--- a/packages/engine/tests/trace_integration.rs
+++ b/packages/engine/tests/trace_integration.rs
@@ -6,7 +6,7 @@
 mod common;
 
 use regelrecht_engine::{LawExecutionService, Value};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use walkdir::WalkDir;
 
 /// Load all regulation YAML files into the service.
@@ -40,7 +40,7 @@ fn load_all_regulations(service: &mut LawExecutionService) -> Result<usize, Stri
 }
 
 /// Helper to create a record HashMap from key-value pairs.
-fn record(entries: Vec<(&str, Value)>) -> HashMap<String, Value> {
+fn record(entries: Vec<(&str, Value)>) -> BTreeMap<String, Value> {
     entries
         .into_iter()
         .map(|(k, v)| (k.to_string(), v))
@@ -124,7 +124,7 @@ fn setup_zorgtoeslag_service() -> LawExecutionService {
 fn test_zorgtoeslag_trace_output_format() {
     let service = setup_zorgtoeslag_service();
 
-    let mut params = HashMap::new();
+    let mut params = BTreeMap::new();
     params.insert("bsn".to_string(), Value::String("999993653".to_string()));
 
     let result = service
@@ -151,36 +151,12 @@ fn test_zorgtoeslag_trace_output_format() {
     let rendered = trace.render_box_drawing();
 
     // Snapshot comparison against expected trace output.
-    // Sort lines within each "Resolving from" block to handle HashMap iteration
-    // order differences between platforms (macOS vs Linux).
-    let normalize = |s: &str| -> Vec<String> {
-        let lines: Vec<&str> = s.trim().lines().collect();
-        let mut result = Vec::new();
-        let mut i = 0;
-        while i < lines.len() {
-            // Collect consecutive "Resolving from" lines and sort them
-            if lines[i].contains("Resolving from") {
-                let start = i;
-                while i < lines.len() && lines[i].contains("Resolving from") {
-                    i += 1;
-                }
-                let mut group: Vec<&str> = lines[start..i].to_vec();
-                group.sort();
-                result.extend(group.iter().map(|s| s.to_string()));
-            } else {
-                result.push(lines[i].to_string());
-                i += 1;
-            }
-        }
-        result
-    };
-
+    // BTreeMap ensures deterministic iteration order, so trace output is
+    // identical across platforms without any normalization.
     let expected = include_str!("expected_zorgtoeslag_trace.txt");
-    let actual_norm = normalize(&rendered);
-    let expected_norm = normalize(expected);
     assert_eq!(
-        actual_norm,
-        expected_norm,
+        rendered.trim(),
+        expected.trim(),
         "Trace output does not match expected snapshot.\n\n--- ACTUAL ---\n{}\n--- EXPECTED ---\n{}",
         rendered,
         expected
@@ -191,7 +167,7 @@ fn test_zorgtoeslag_trace_output_format() {
 fn test_zorgtoeslag_trace_result_matches_non_trace() {
     let service = setup_zorgtoeslag_service();
 
-    let mut params = HashMap::new();
+    let mut params = BTreeMap::new();
     params.insert("bsn".to_string(), Value::String("999993653".to_string()));
 
     // Execute with trace
@@ -220,7 +196,7 @@ fn test_zorgtoeslag_trace_result_matches_non_trace() {
 fn test_trace_disabled_by_default() {
     let service = setup_zorgtoeslag_service();
 
-    let mut params = HashMap::new();
+    let mut params = BTreeMap::new();
     params.insert("bsn".to_string(), Value::String("999993653".to_string()));
 
     // Normal evaluation should not have a trace
@@ -244,7 +220,7 @@ fn test_simple_law_trace() {
         .evaluate_law_output_with_trace(
             "regeling_standaardpremie",
             "standaardpremie",
-            HashMap::new(),
+            BTreeMap::new(),
             "2025-01-01",
         )
         .expect("Standard premium evaluation should succeed");

--- a/packages/tui/src/backend/engine_backend.rs
+++ b/packages/tui/src/backend/engine_backend.rs
@@ -1,5 +1,5 @@
 use regelrecht_engine::{ArticleResult, LawExecutionService, LawInfo, PathNode, Value};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::path::Path;
 use tokio::sync::mpsc;
 use walkdir::WalkDir;
@@ -10,7 +10,7 @@ pub enum EngineCommand {
     Evaluate {
         law_id: String,
         output: String,
-        params: HashMap<String, Value>,
+        params: BTreeMap<String, Value>,
         date: String,
     },
 }

--- a/packages/tui/src/views/engine.rs
+++ b/packages/tui/src/views/engine.rs
@@ -3,7 +3,7 @@ use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wrap};
 use regelrecht_engine::{ArticleResult, LawInfo, PathNode, Value};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum Focus {
@@ -339,7 +339,7 @@ impl EngineView {
             None => return,
         };
 
-        let mut params = HashMap::new();
+        let mut params = BTreeMap::new();
         for p in &self.params {
             if !p.name.is_empty() && !p.value.is_empty() {
                 params.insert(p.name.clone(), parse_value(&p.value));


### PR DESCRIPTION
## Summary

Replace `HashMap` with `BTreeMap` throughout the engine for deterministic execution and trace output.

## Problem

HashMap iteration order is nondeterministic (random seed per process). This causes trace output to differ between macOS and Linux, making snapshot tests flaky. More importantly, the execution itself is not reproducible — the same law with the same inputs can resolve parameters in different orders on different platforms.

## Solution

BTreeMap iterates in sorted key order by default. This makes both execution and trace output deterministic without any display-layer hacks. The trace faithfully shows what actually happened.

## Performance

BTreeMap is actually ~6-10% **faster** for the small maps used in law execution (better cache locality for <20 keys):

| Benchmark | HashMap | BTreeMap | Change |
|-----------|---------|----------|--------|
| standaardpremie | 2.60 µs | 2.41 µs | -7% |
| zorgtoeslag full | 90.5 µs | 85.3 µs | -6% |
| zorgtoeslag+trace | 123.1 µs | 111.3 µs | -10% |

## Scope

22 files changed across engine, corpus tests, TUI, and benchmarks. The resolver (`resolver.rs`) was deliberately excluded — its internal indexes are lookup-only and don't affect execution order.

Closes #370.

## Test plan
- [x] 309 unit tests pass
- [x] 28 BDD scenarios pass
- [x] 4 trace integration tests pass (without normalize workaround)
- [x] Golden tests pass
- [x] Benchmarks show no regression

@tdjager — Would appreciate your review on this. The motivation: we had a trace snapshot test that was flaky across platforms because HashMap iteration order differed between macOS and Linux. Rather than sorting the display, we made the execution itself deterministic by switching to BTreeMap. This means the trace faithfully shows the actual execution order, and that order is now reproducible. The performance impact is positive (BTreeMap is faster for our small maps due to cache locality).