### PR TITLE
fix(engine): complete trace coverage and improve rendering

### DIFF
--- a/packages/engine/src/error.rs
+++ b/packages/engine/src/error.rs
@@ -12,6 +12,7 @@
 //! errors to external callers (API responses, WASM, etc.) to prevent
 //! information disclosure.
 
+use crate::trace::PathNode;
 use thiserror::Error;
 
 /// Main error type for engine operations
@@ -103,6 +104,16 @@ pub enum EngineError {
         input_name: String,
         regulation: String,
         output: String,
+    },
+
+    /// Wraps an error that occurred during traced execution, carrying the partial trace.
+    ///
+    /// This variant is returned by `evaluate_law_output_with_trace` when execution
+    /// fails, so callers can inspect the trace up to the point of failure.
+    #[error("{source}")]
+    TracedError {
+        source: Box<EngineError>,
+        trace: Option<Box<PathNode>>,
     },
 }
 
@@ -231,6 +242,7 @@ impl From<EngineError> for ExternalError {
             }
             EngineError::DataSourceError(_) => ExternalError::DataSourceError,
             EngineError::InvalidDate(_) => ExternalError::InvalidDate,
+            EngineError::TracedError { source, .. } => ExternalError::from(*source),
         }
     }
 }

--- a/packages/engine/src/service.rs
+++ b/packages/engine/src/service.rs
@@ -457,23 +457,56 @@ impl LawExecutionService {
 
         let mut res_ctx = ResolutionContext::with_trace(calculation_date, Rc::clone(&trace));
         res_ctx.contextual_law_id = Some(law_id.to_string());
-        let mut result =
-            self.evaluate_law_output_internal(law_id, output_name, parameters, &mut res_ctx)?;
+        let result =
+            self.evaluate_law_output_internal(law_id, output_name, parameters, &mut res_ctx);
 
         // Drop res_ctx so it releases its Rc clone
         drop(res_ctx);
 
-        // Set the result on the top-level article node and pop it
-        {
-            let mut tb = trace.borrow_mut();
-            if let Some(value) = result.outputs.get(output_name) {
-                tb.set_result(value.clone());
+        match result {
+            Ok(mut result) => {
+                // Set the result on the top-level article node and pop it
+                let mut tb = trace.borrow_mut();
+                if let Some(value) = result.outputs.get(output_name) {
+                    tb.set_result(value.clone());
+                }
+                // Pop returns the completed top-level node
+                result.trace = tb.pop();
+                Ok(result)
             }
-            // Pop returns the completed top-level node
-            result.trace = tb.pop();
-        }
+            Err(e) => {
+                // Pop the top-level node so the partial trace is not lost
+                let mut tb = trace.borrow_mut();
+                tb.set_message(format!("Execution failed: {}", e));
+                let partial_trace = tb.pop();
 
-        Ok(result)
+                // Return an error result that still carries the partial trace.
+                // Since Result<ArticleResult> can't carry both, we embed the
+                // trace in the error via EngineError::TracedError.
+                Err(EngineError::TracedError {
+                    source: Box::new(e),
+                    trace: partial_trace.map(Box::new),
+                })
+            }
+        }
+    }
+
+    /// Execute a law output using an existing shared trace builder.
+    ///
+    /// Unlike `evaluate_law_output_with_trace` which creates its own root trace node,
+    /// this method appends to an existing trace tree. Used by `execute_stage_internal`
+    /// when falling through to non-procedure execution.
+    fn evaluate_law_output_with_shared_trace(
+        &self,
+        law_id: &str,
+        output_name: &str,
+        parameters: HashMap<String, Value>,
+        calculation_date: &str,
+        trace: Rc<RefCell<TraceBuilder>>,
+    ) -> Result<ArticleResult> {
+        let mut res_ctx = ResolutionContext::with_trace(calculation_date, trace);
+        res_ctx.contextual_law_id = Some(law_id.to_string());
+        self.evaluate_law_output_internal(law_id, output_name, parameters, &mut res_ctx)
     }
 
     /// Execute a single lifecycle stage of a procedure-aware law (RFC-008).
@@ -500,6 +533,49 @@ impl LawExecutionService {
         parameters: HashMap<String, Value>,
         calculation_date: &str,
     ) -> Result<ExecutionOutcome> {
+        self.execute_stage_internal(
+            law_id,
+            output_name,
+            state,
+            parameters,
+            calculation_date,
+            None,
+        )
+    }
+
+    /// Execute a single lifecycle stage with tracing enabled.
+    ///
+    /// Same as `execute_stage` but accepts a shared trace builder so the
+    /// staged execution is recorded in the trace tree.
+    pub fn execute_stage_with_trace(
+        &self,
+        law_id: &str,
+        output_name: &str,
+        state: Option<StageState>,
+        parameters: HashMap<String, Value>,
+        calculation_date: &str,
+        trace: Rc<RefCell<TraceBuilder>>,
+    ) -> Result<ExecutionOutcome> {
+        self.execute_stage_internal(
+            law_id,
+            output_name,
+            state,
+            parameters,
+            calculation_date,
+            Some(trace),
+        )
+    }
+
+    /// Internal stage execution with optional tracing.
+    fn execute_stage_internal(
+        &self,
+        law_id: &str,
+        output_name: &str,
+        state: Option<StageState>,
+        parameters: HashMap<String, Value>,
+        calculation_date: &str,
+        trace: Option<Rc<RefCell<TraceBuilder>>>,
+    ) -> Result<ExecutionOutcome> {
         // Look up the law and article
         let ref_date = NaiveDate::parse_from_str(calculation_date, "%Y-%m-%d").ok();
         let law = self
@@ -525,8 +601,17 @@ impl LawExecutionService {
 
         // If no procedure, fall through to normal single-stage execution
         let Some(procedure) = procedure else {
-            let result =
-                self.evaluate_law_output(law_id, output_name, parameters, calculation_date)?;
+            let result = if let Some(tb) = trace {
+                self.evaluate_law_output_with_shared_trace(
+                    law_id,
+                    output_name,
+                    parameters,
+                    calculation_date,
+                    tb,
+                )?
+            } else {
+                self.evaluate_law_output(law_id, output_name, parameters, calculation_date)?
+            };
             return Ok(ExecutionOutcome::Complete(result));
         };
 
@@ -593,7 +678,11 @@ impl LawExecutionService {
         }
 
         // Execute the article with stage-aware hook firing
-        let mut res_ctx = ResolutionContext::new(calculation_date);
+        let mut res_ctx = if let Some(ref tb) = trace {
+            ResolutionContext::with_trace(calculation_date, Rc::clone(tb))
+        } else {
+            ResolutionContext::new(calculation_date)
+        };
         res_ctx.contextual_law_id = Some(stage_state.contextual_law.clone());
 
         // Execute the article with stage-aware hook firing.
@@ -638,12 +727,13 @@ impl LawExecutionService {
             }
 
             // Next stage has all inputs — continue executing (recursive)
-            return self.execute_stage(
+            return self.execute_stage_internal(
                 law_id,
                 output_name,
                 Some(stage_state),
                 parameters,
                 calculation_date,
+                trace,
             );
         }
 
@@ -713,6 +803,14 @@ impl LawExecutionService {
                 depth = res_ctx.depth,
                 "Cross-law resolution depth exceeded"
             );
+            res_ctx.trace_push(format!("{}#{}", law_id, output_name), PathNodeType::UriCall);
+            res_ctx.trace_set_message(format!(
+                "Cross-law resolution depth exceeded {} levels ({}:{})",
+                config::MAX_CROSS_LAW_DEPTH,
+                law_id,
+                output_name
+            ));
+            res_ctx.trace_pop();
             return Err(EngineError::CircularReference(format!(
                 "Cross-law resolution depth exceeded {} levels. \
                  Possible circular reference involving {}:{}",
@@ -1284,7 +1382,7 @@ impl LawExecutionService {
                     // Trace success
                     res_ctx.trace_set_result(value.clone());
                     res_ctx.trace_set_message(format!(
-                        "Open term '{}' resolved from {} article {}",
+                        "Open term '{}' implemented by {} article {}",
                         term.id, impl_law.id, impl_article.number
                     ));
                     res_ctx.trace_pop();
@@ -1370,20 +1468,16 @@ impl LawExecutionService {
                         .unwrap_or(Value::Null);
 
                     res_ctx.trace_set_result(default_value.clone());
-                    res_ctx.trace_set_message(format!(
-                        "Open term '{}' resolved from default",
-                        term.id
-                    ));
+                    res_ctx
+                        .trace_set_message(format!("Open term '{}' using default value", term.id));
                     res_ctx.trace_pop();
 
                     resolved.insert(term.id.clone(), default_value);
                 } else {
                     // Default exists but has no actions — treat as null
                     res_ctx.trace_set_result(Value::Null);
-                    res_ctx.trace_set_message(format!(
-                        "Open term '{}' resolved from empty default",
-                        term.id
-                    ));
+                    res_ctx
+                        .trace_set_message(format!("Open term '{}' using empty default", term.id));
                     res_ctx.trace_pop();
                     resolved.insert(term.id.clone(), Value::Null);
                 }
@@ -1484,30 +1578,63 @@ impl LawExecutionService {
                 // Internal reference (same-law) with output specified.
                 // Resolve through the service layer so cross-law inputs of the
                 // referenced article are properly handled.
-                let ref_article = law.find_article_by_output(output_name).ok_or_else(|| {
-                    EngineError::OutputNotFound {
-                        law_id: law.id.clone(),
-                        output: output_name.to_string(),
+                res_ctx.trace_push(format!("{}#{}", law.id, output_name), PathNodeType::Resolve);
+                res_ctx.trace_set_resolve_type(ResolveType::ResolvedInput);
+                res_ctx
+                    .trace_set_message(format!("Internal reference: {}#{}", law.id, output_name));
+
+                let ref_article = match law.find_article_by_output(output_name) {
+                    Some(a) => a,
+                    None => {
+                        res_ctx.trace_set_message(format!(
+                            "Internal reference failed: output '{}' not found in {}",
+                            output_name, law.id
+                        ));
+                        res_ctx.trace_pop();
+                        return Err(EngineError::OutputNotFound {
+                            law_id: law.id.clone(),
+                            output: output_name.to_string(),
+                        });
                     }
-                })?;
+                };
 
                 let ref_params = parameters.clone();
-                let result = self.evaluate_article_with_service(
+                let result = match self.evaluate_article_with_service(
                     ref_article,
                     law,
                     ref_params,
                     Some(output_name),
                     "BESLUIT",
                     res_ctx,
-                )?;
+                ) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        res_ctx.trace_set_message(format!("Internal reference failed: {}", e));
+                        res_ctx.trace_pop();
+                        return Err(e);
+                    }
+                };
 
                 if let Some(value) = result.outputs.get(output_name) {
+                    res_ctx.trace_set_result(value.clone());
+                    res_ctx.trace_pop();
                     context.set_resolved_input(&input.name, value.clone());
+                } else {
+                    res_ctx.trace_set_message(format!(
+                        "Internal reference: output '{}' not in result from article {}",
+                        output_name, ref_article.number
+                    ));
+                    res_ctx.trace_pop();
                 }
             } else {
                 // Empty source (source: {}) — resolved from DataSourceRegistry only.
-                // If DataSourceRegistry didn't match above, leave unresolved
-                // (engine will use null/default).
+                // If DataSourceRegistry didn't match above, leave unresolved.
+                res_ctx.trace_push(&input.name, PathNodeType::Resolve);
+                res_ctx.trace_set_message(format!(
+                    "Input '{}' has empty source and no data source match, left unresolved",
+                    input.name
+                ));
+                res_ctx.trace_pop();
             }
         }
 

--- a/packages/engine/src/trace.rs
+++ b/packages/engine/src/trace.rs
@@ -242,7 +242,7 @@ impl PathNode {
     /// ```text
     /// zorgtoeslagwet (2025-01-01 {bsn: 999993653} hoogte_zorgtoeslag)
     /// ╟──Evaluating rules for zorgtoeslagwet (hoogte_zorgtoeslag)
-    /// ║   ╟──URI call: wet_basisregistratie_personen#leeftijd
+    /// ║   ╟──Reference: wet_basisregistratie_personen#leeftijd
     /// ║   ║   ╟──Resolving from PARAMETERS: $BSN = '999993653'
     /// ║   ║   ╙──Computing leeftijd
     /// ║   ║       └──Result: leeftijd = 20
@@ -252,35 +252,49 @@ impl PathNode {
     /// ```
     pub fn render_box_drawing(&self) -> String {
         let mut lines = Vec::new();
-        self.render_box_node(&mut lines, "", true, false, None);
+        self.render_box_node(&mut lines, "", true, false, false, None);
         lines.join("\n")
     }
 
-    /// Render children that live inside a double-line (cross-document) scope.
+    /// Render children that live inside a cross-law scope.
     ///
-    /// `node_continuation` is the continuation string for the node that owns
-    /// this scope (e.g., `"║   "` if it has more siblings, `"    "` if last).
-    /// This ensures the parent's continuation line remains visible through
-    /// the last child's subtree.
+    /// Children use double-line connectors (`╟──`/`╙──`) to indicate they are
+    /// executing in a different law. The scope continuation column matches the
+    /// parent's scope: `║` when the parent is also double-scope, `│` when the
+    /// parent is single-scope (e.g., an OpenTerm inside a Resolve).
+    ///
+    /// `parent_is_double` controls the scope continuation character.
+    /// `node_continuation` is this node's continuation in its parent (used
+    /// for the last child's subtree to preserve the parent's line).
     fn render_double_children(
         &self,
         lines: &mut Vec<String>,
         prefix: &str,
         scope_continues: bool,
         node_continuation: &str,
+        parent_is_double: bool,
     ) {
         let child_count = self.children.len();
-        let double_prefix = format!("{}║   ", prefix);
+        // Scope continuation character matches the parent's context:
+        // ║ when parent is double-scope (cross-law), │ when single-scope (same-law).
+        let scope_char = if parent_is_double { "║" } else { "│" };
+        let scope_prefix = format!("{}{}   ", prefix, scope_char);
         let ended_prefix = format!("{}{}", prefix, node_continuation);
         for (i, child) in self.children.iter().enumerate() {
             let is_last = i == child_count - 1;
+            // double_connector=true: children use ╟──/╙── (cross-law boundary)
+            // double_continuation=parent_is_double: continuation matches outer scope
             if is_last && !scope_continues {
-                // Last child, scope ends: header at ║ column, subtree uses
-                // the node's own continuation (preserving parent's ║ if needed).
-                child.render_box_node(lines, &double_prefix, is_last, true, Some(&ended_prefix));
+                child.render_box_node(
+                    lines,
+                    &scope_prefix,
+                    is_last,
+                    true,
+                    parent_is_double,
+                    Some(&ended_prefix),
+                );
             } else {
-                // Non-last, or last with continuing scope: header and subtree at ║ column.
-                child.render_box_node(lines, &double_prefix, is_last, true, None);
+                child.render_box_node(lines, &scope_prefix, is_last, true, parent_is_double, None);
             }
         }
     }
@@ -289,21 +303,24 @@ impl PathNode {
     ///
     /// `prefix` is the leading string for this node's header line.
     /// `is_last` indicates whether this node is the last child of its parent.
-    /// `parent_is_double` controls connector characters: single context uses
-    /// `├──` / `└──`, double context (cross-document scope) uses `╟──` / `╙──`.
+    /// `double_connector` controls connector characters: double uses `╟──`/`╙──`,
+    ///   single uses `├──`/`└──`.
+    /// `double_continuation` controls continuation lines: double uses `║`,
+    ///   single uses `│`. These can differ from the connector when a cross-law
+    ///   scope is nested inside a same-law context.
     /// `child_base_override` when `Some(base)` uses that base instead of `prefix`
     /// for computing children's prefix, handling the case where the header renders
-    /// at a `║` column (for `╙──`) but the subtree should use spaces because the
-    /// double-line scope has ended.
+    /// at a scope column but the subtree should use spaces because the scope ended.
     fn render_box_node(
         &self,
         lines: &mut Vec<String>,
         prefix: &str,
         is_last: bool,
-        parent_is_double: bool,
+        double_connector: bool,
+        double_continuation: bool,
         child_base_override: Option<&str>,
     ) {
-        let connector = match (parent_is_double, is_last) {
+        let connector = match (double_connector, is_last) {
             (true, true) => "╙──",
             (true, false) => "╟──",
             (false, true) => "└──",
@@ -312,8 +329,7 @@ impl PathNode {
         // Base for computing children's prefix: use override if provided
         let child_base = child_base_override.unwrap_or(prefix);
         // Continuation prefix for this node's children.
-        // Double-line context uses ║ instead of │ for visual consistency.
-        let continuation = match (parent_is_double, is_last) {
+        let continuation = match (double_continuation, is_last) {
             (_, true) => "    ",
             (true, false) => "║   ",
             (false, false) => "│   ",
@@ -335,7 +351,7 @@ impl PathNode {
                 ));
 
                 // Article children are in double-line scope; scope continues for Result line
-                self.render_double_children(lines, child_base, true, continuation);
+                self.render_double_children(lines, child_base, true, continuation, true);
 
                 // Result line (last branch of the article scope)
                 if let Some(ref result) = self.result {
@@ -366,7 +382,7 @@ impl PathNode {
 
                 for (i, child) in self.children.iter().enumerate() {
                     let child_is_last = i == child_count - 1 && !has_result;
-                    child.render_box_node(lines, &child_prefix, child_is_last, false, None);
+                    child.render_box_node(lines, &child_prefix, child_is_last, false, false, None);
                 }
 
                 if let Some(ref result) = self.result {
@@ -445,6 +461,7 @@ impl PathNode {
                             &child_prefix,
                             i == child_count - 1,
                             false,
+                            false,
                             None,
                         );
                     }
@@ -469,7 +486,14 @@ impl PathNode {
                 let child_prefix = format!("{}{}", child_base, continuation);
                 let child_count = self.children.len();
                 for (i, child) in self.children.iter().enumerate() {
-                    child.render_box_node(lines, &child_prefix, i == child_count - 1, false, None);
+                    child.render_box_node(
+                        lines,
+                        &child_prefix,
+                        i == child_count - 1,
+                        false,
+                        false,
+                        None,
+                    );
                 }
             }
 
@@ -486,7 +510,7 @@ impl PathNode {
 
                 for (i, child) in self.children.iter().enumerate() {
                     let child_is_last = i == child_count - 1 && !has_result;
-                    child.render_box_node(lines, &child_prefix, child_is_last, false, None);
+                    child.render_box_node(lines, &child_prefix, child_is_last, false, false, None);
                 }
 
                 if let Some(ref result) = self.result {
@@ -503,11 +527,18 @@ impl PathNode {
                 if let Some(ref msg) = self.message {
                     lines.push(format!("{}{}{}", prefix, connector, msg));
                 } else {
-                    lines.push(format!("{}{}URI call: {}", prefix, connector, self.name));
+                    lines.push(format!("{}{}Reference: {}", prefix, connector, self.name));
                 }
 
-                // UriCall children are in double-line scope (cross-document)
-                self.render_double_children(lines, child_base, false, continuation);
+                // UriCall children use double connectors; scope continuation
+                // matches whether this UriCall is itself in a double or single parent.
+                self.render_double_children(
+                    lines,
+                    child_base,
+                    false,
+                    continuation,
+                    double_continuation,
+                );
             }
 
             PathNodeType::Cached => {
@@ -517,7 +548,7 @@ impl PathNode {
                     .map(|v| format!(": {}", format_value_display(v)))
                     .unwrap_or_default();
                 lines.push(format!(
-                    "{}{}CACHED: {}{}",
+                    "{}{}Cached: {}{}",
                     prefix, connector, self.name, result_str
                 ));
             }
@@ -530,12 +561,19 @@ impl PathNode {
                     .unwrap_or_default();
                 let msg = self.message.as_deref().unwrap_or(&self.name);
                 lines.push(format!(
-                    "{}{}OPEN_TERM: {}{}",
+                    "{}{}Delegation: {}{}",
                     prefix, connector, msg, result_str
                 ));
 
-                // OpenTerm children are in double-line scope (cross-document)
-                self.render_double_children(lines, child_base, false, continuation);
+                // OpenTerm children use double connectors; scope continuation
+                // matches whether this OpenTerm is in a double or single parent.
+                self.render_double_children(
+                    lines,
+                    child_base,
+                    false,
+                    continuation,
+                    double_continuation,
+                );
             }
 
             PathNodeType::HookResolution => {
@@ -550,8 +588,15 @@ impl PathNode {
                     prefix, connector, msg, result_str
                 ));
 
-                // Hook children are in double-line scope (cross-document)
-                self.render_double_children(lines, child_base, false, continuation);
+                // Hook children use double connectors; scope continuation
+                // matches whether this Hook is in a double or single parent.
+                self.render_double_children(
+                    lines,
+                    child_base,
+                    false,
+                    continuation,
+                    double_continuation,
+                );
             }
 
             PathNodeType::OverrideResolution => {
@@ -562,12 +607,24 @@ impl PathNode {
                     .unwrap_or_default();
                 let msg = self.message.as_deref().unwrap_or(&self.name);
                 lines.push(format!(
-                    "{}{}OVERRIDE: {}{}",
+                    "{}{}Lex specialis: {}{}",
                     prefix, connector, msg, result_str
                 ));
 
-                // Override children are in double-line scope (cross-document)
-                self.render_double_children(lines, child_base, false, continuation);
+                // Override is declared in the current (contextual) law, so
+                // children use single-line scope (same-law convention).
+                let child_prefix = format!("{}{}", child_base, continuation);
+                let child_count = self.children.len();
+                for (i, child) in self.children.iter().enumerate() {
+                    child.render_box_node(
+                        lines,
+                        &child_prefix,
+                        i == child_count - 1,
+                        false,
+                        false,
+                        None,
+                    );
+                }
             }
         }
     }
@@ -1240,7 +1297,7 @@ mod tests {
     fn test_box_drawing_uri_call_double_lines() {
         let child = PathNode::new(PathNodeType::Resolve, "param").with_result(Value::Int(1));
         let uri_node = PathNode::new(PathNodeType::UriCall, "other_law#output")
-            .with_message("URI call: other_law#output")
+            .with_message("Reference: other_law#output")
             .with_child(child);
 
         let rendered = uri_node.render_box_drawing();
@@ -1279,22 +1336,27 @@ mod tests {
 
     #[test]
     fn test_box_drawing_continuation_not_interrupted() {
-        // Two children under a UriCall: the first child's subtree should show ║
-        // continuation for the second child
+        // Two children under a UriCall inside an Article: the continuation
+        // between children should use ║ (double-scope parent).
         let child1 = PathNode::new(PathNodeType::Resolve, "first").with_result(Value::Int(1));
         let child2 = PathNode::new(PathNodeType::Resolve, "second").with_result(Value::Int(2));
         let uri_node = PathNode::new(PathNodeType::UriCall, "law#out")
-            .with_message("URI call: law#out")
+            .with_message("Reference: law#out")
             .with_child(child1)
             .with_child(child2);
+        let article = PathNode::new(PathNodeType::Article, "test (out)")
+            .with_message("test (2025-01-01 {} out)")
+            .with_child(uri_node)
+            .with_result(Value::Int(42));
 
-        let rendered = uri_node.render_box_drawing();
+        let rendered = article.render_box_drawing();
         let lines: Vec<&str> = rendered.lines().collect();
         // Between the two children, the ║ continuation should be present
-        let has_double_continuation = lines.iter().any(|l| l.contains("║"));
+        // (UriCall is inside Article's double-scope)
+        let has_double_continuation = lines.iter().any(|l| l.contains("║   ║"));
         assert!(
             has_double_continuation,
-            "UriCall with multiple children should show ║ continuation in:\n{}",
+            "UriCall inside Article should show ║ continuation in:\n{}",
             rendered
         );
     }
@@ -1306,8 +1368,8 @@ mod tests {
 
         let rendered = cached.render_box_drawing();
         assert!(
-            rendered.contains("CACHED:"),
-            "Cached node should show CACHED label in:\n{}",
+            rendered.contains("Cached:"),
+            "Cached node should show Cached label in:\n{}",
             rendered
         );
     }

--- a/packages/engine/tests/expected_zorgtoeslag_trace.txt
+++ b/packages/engine/tests/expected_zorgtoeslag_trace.txt
@@ -1,6 +1,6 @@
 zorgtoeslagwet (2025-01-01 {bsn: 999993653} hoogte_zorgtoeslag)
 ╟──Evaluating rules for zorgtoeslagwet (hoogte_zorgtoeslag)
-║   ╟──URI call: wet_basisregistratie_personen#leeftijd
+║   ╟──Reference: wet_basisregistratie_personen#leeftijd
 ║   ║   ╟──Resolving from PARAMETERS: $BSN = '999993653'
 ║   ║   ╟──Resolving from CONTEXT: $REFERENCEDATE = {'day': 1, 'iso': '2025-01-01', 'month': 1, 'year': 2025}
 ║   ║   ╟──Resolving from DATA_SOURCE: $GEBOORTEDATUM = '2005-01-01'
@@ -9,11 +9,11 @@ zorgtoeslagwet (2025-01-01 {bsn: 999993653} hoogte_zorgtoeslag)
 ║   ║       │   ├──Resolving from PARAMETERS: $GEBOORTEDATUM = '2005-01-01'
 ║   ║       │   └──Resolving from PARAMETERS: $PEILDATUM = {'day': 1, 'iso': '2025-01-01', 'month': 1, 'year': 2025}
 ║   ║       └──Result: leeftijd = 20
-║   ╟──URI call: zorgverzekeringswet#is_verzekerd
+║   ╟──Reference: zorgverzekeringswet#is_verzekerd
 ║   ║   ╟──Resolving from PARAMETERS: $BSN = '999993653'
 ║   ║   ╟──Resolving from DATA_SOURCE: $POLIS_STATUS = 'ACTIEF'
 ║   ║   ╟──Resolving from DATA_SOURCE: $VERDRAGSINSCHRIJVING = False
-║   ║   ╟──URI call: penitentiaire_beginselenwet#is_gedetineerd
+║   ║   ╟──Reference: penitentiaire_beginselenwet#is_gedetineerd
 ║   ║   ║   ╟──Resolving from PARAMETERS: $BSN = '999993653'
 ║   ║   ║   ╟──Resolving from DATA_SOURCE: $DETENTIESTATUS = None
 ║   ║   ║   ╟──Resolving from DATA_SOURCE: $INRICHTING_TYPE = None
@@ -33,7 +33,7 @@ zorgtoeslagwet (2025-01-01 {bsn: 999993653} hoogte_zorgtoeslag)
 ║   ║       │       └──Compute EQUALS(...) = False
 ║   ║       │           └──Resolving from PARAMETERS: $IS_GEDETINEERD = False
 ║   ║       └──Result: is_verzekerd = True
-║   ╟──URI call: wet_forensische_zorg#is_forensisch
+║   ╟──Reference: wet_forensische_zorg#is_forensisch
 ║   ║   ╟──Resolving from PARAMETERS: $BSN = '999993653'
 ║   ║   ╟──Resolving from DATA_SOURCE: $ZORGTYPE = None
 ║   ║   ╟──Resolving from DATA_SOURCE: $JURIDISCHE_GRONDSLAG = None
@@ -43,7 +43,7 @@ zorgtoeslagwet (2025-01-01 {bsn: 999993653} hoogte_zorgtoeslag)
 ║   ║       │       ├──Resolving from PARAMETERS: $ZORGTYPE = None
 ║   ║       │       └──Resolving from DEFINITION: $FORENSISCHE_ZORGTYPEN = ['GGZ', 'VERSLAVINGSZORG', 'VG_ZORG']
 ║   ║       └──Result: is_forensisch = False
-║   ╟──URI call: algemene_wet_inkomensafhankelijke_regelingen#heeft_toeslagpartner
+║   ╟──Reference: algemene_wet_inkomensafhankelijke_regelingen#heeft_toeslagpartner
 ║   ║   ╟──Resolving from PARAMETERS: $BSN = '999993653'
 ║   ║   ╟──Resolving from DATA_SOURCE: $PARTNERSCHAP_TYPE = 'GEEN'
 ║   ║   ╙──Computing heeft_toeslagpartner
@@ -51,11 +51,11 @@ zorgtoeslagwet (2025-01-01 {bsn: 999993653} hoogte_zorgtoeslag)
 ║   ║       │   ├──Resolving from PARAMETERS: $PARTNERSCHAP_TYPE = 'GEEN'
 ║   ║       │   └──Resolving from DEFINITION: $GELDIGE_PARTNERTYPEN = ['HUWELIJK', 'GEREGISTREERD_PARTNERSCHAP']
 ║   ║       └──Result: heeft_toeslagpartner = False
-║   ╟──URI call: algemene_wet_inkomensafhankelijke_regelingen#toetsingsinkomen
+║   ╟──Reference: algemene_wet_inkomensafhankelijke_regelingen#toetsingsinkomen
 ║   ║   ╟──Resolving from PARAMETERS: $BSN = '999993653'
-║   ║   ╟──URI call: wet_inkomstenbelasting_2001#toetsingsinkomen
+║   ║   ╟──Reference: wet_inkomstenbelasting_2001#toetsingsinkomen
 ║   ║   ║   ╟──Resolving from PARAMETERS: $BSN = '999993653'
-║   ║   ║   ╟──URI call: wet_inkomstenbelasting_2001#box1_inkomen
+║   ║   ║   ╟──Reference: wet_inkomstenbelasting_2001#box1_inkomen
 ║   ║   ║   ║   ╟──Resolving from PARAMETERS: $BSN = '999993653'
 ║   ║   ║   ║   ╟──Resolving from DATA_SOURCE: $LOON_UIT_DIENSTBETREKKING = 79547
 ║   ║   ║   ║   ╟──Resolving from DATA_SOURCE: $UITKERINGEN_EN_PENSIOENEN = 0
@@ -70,7 +70,7 @@ zorgtoeslagwet (2025-01-01 {bsn: 999993653} hoogte_zorgtoeslag)
 ║   ║   ║   ║       │   ├──Resolving from PARAMETERS: $RESULTAAT_OVERIGE_WERKZAAMHEDEN = 0
 ║   ║   ║   ║       │   └──Resolving from PARAMETERS: $EIGEN_WONING = 0
 ║   ║   ║   ║       └──Result: box1_inkomen = 79547
-║   ║   ║   ╟──URI call: wet_inkomstenbelasting_2001#box2_inkomen
+║   ║   ║   ╟──Reference: wet_inkomstenbelasting_2001#box2_inkomen
 ║   ║   ║   ║   ╟──Resolving from PARAMETERS: $BSN = '999993653'
 ║   ║   ║   ║   ╟──Resolving from DATA_SOURCE: $REGULIERE_VOORDELEN = 0
 ║   ║   ║   ║   ╟──Resolving from DATA_SOURCE: $VERVREEMDINGSVOORDELEN = 0
@@ -79,15 +79,15 @@ zorgtoeslagwet (2025-01-01 {bsn: 999993653} hoogte_zorgtoeslag)
 ║   ║   ║   ║       │   ├──Resolving from PARAMETERS: $REGULIERE_VOORDELEN = 0
 ║   ║   ║   ║       │   └──Resolving from PARAMETERS: $VERVREEMDINGSVOORDELEN = 0
 ║   ║   ║   ║       └──Result: box2_inkomen = 0
-║   ║   ║   ╟──URI call: wet_inkomstenbelasting_2001#box3_inkomen
+║   ║   ║   ╟──Reference: wet_inkomstenbelasting_2001#box3_inkomen
 ║   ║   ║   ║   ╟──Resolving from PARAMETERS: $BSN = '999993653'
 ║   ║   ║   ║   ╟──Resolving from DATA_SOURCE: $SPAARGELD = 0
 ║   ║   ║   ║   ╟──Resolving from DATA_SOURCE: $BELEGGINGEN = 0
 ║   ║   ║   ║   ╟──Resolving from DATA_SOURCE: $ONROEREND_GOED = 0
 ║   ║   ║   ║   ╟──Resolving from DATA_SOURCE: $SCHULDEN = 0
-║   ║   ║   ║   ╟──URI call: algemene_wet_inkomensafhankelijke_regelingen#heeft_toeslagpartner
+║   ║   ║   ║   ╟──Reference: algemene_wet_inkomensafhankelijke_regelingen#heeft_toeslagpartner
 ║   ║   ║   ║   ║   ╟──Resolving from PARAMETERS: $BSN = '999993653'
-║   ║   ║   ║   ║   ╙──CACHED: algemene_wet_inkomensafhankelijke_regelingen#heeft_toeslagpartner: False
+║   ║   ║   ║   ║   ╙──Cached: algemene_wet_inkomensafhankelijke_regelingen#heeft_toeslagpartner: False
 ║   ║   ║   ║   ╟──Computing rendementsgrondslag
 ║   ║   ║   ║   ║   ├──Compute SUBTRACT(...) = 0
 ║   ║   ║   ║   ║   │   ├──Compute ADD(...) = 0
@@ -130,66 +130,70 @@ zorgtoeslagwet (2025-01-01 {bsn: 999993653} hoogte_zorgtoeslag)
 ║   ║       │   ├──Resolving from PARAMETERS: $VERZAMELINKOMEN = 79547
 ║   ║       │   └──Resolving from PARAMETERS: $BUITENLANDS_INKOMEN = 0
 ║   ║       └──Result: toetsingsinkomen = 79547
-║   ╟──OPEN_TERM: Open term 'standaardpremie' resolved from regeling_standaardpremie article 1: 211200
-║   ║   ╟──Computing standaardpremie
-║   ║   ║   └──Result: standaardpremie = 211200
-║   ║   ╙──Computing berekeningsjaar
-║   ║       └──Result: berekeningsjaar = 2025
-║   ╟──Computing standaardpremie
-║   ║   ├──Resolving from PARAMETERS: $STANDAARDPREMIE = 211200
-║   ║   └──Result: standaardpremie = 211200
-║   ╟──URI call: wet_inkomstenbelasting_2001#rendementsgrondslag
-║   ║   ╟──Resolving from PARAMETERS: $BSN = '999993653'
-║   ║   ╟──Resolving from DATA_SOURCE: $SPAARGELD = 0
-║   ║   ╟──Resolving from DATA_SOURCE: $BELEGGINGEN = 0
-║   ║   ╟──Resolving from DATA_SOURCE: $ONROEREND_GOED = 0
-║   ║   ╟──Resolving from DATA_SOURCE: $SCHULDEN = 0
-║   ║   ╟──URI call: algemene_wet_inkomensafhankelijke_regelingen#heeft_toeslagpartner
-║   ║   ║   ╟──Resolving from PARAMETERS: $BSN = '999993653'
-║   ║   ║   ╙──CACHED: algemene_wet_inkomensafhankelijke_regelingen#heeft_toeslagpartner: False
-║   ║   ╟──Computing rendementsgrondslag
-║   ║   ║   ├──Compute SUBTRACT(...) = 0
-║   ║   ║   │   ├──Compute ADD(...) = 0
-║   ║   ║   │   │   ├──Resolving from PARAMETERS: $SPAARGELD = 0
-║   ║   ║   │   │   ├──Resolving from PARAMETERS: $BELEGGINGEN = 0
-║   ║   ║   │   │   └──Resolving from PARAMETERS: $ONROEREND_GOED = 0
-║   ║   ║   │   └──Resolving from PARAMETERS: $SCHULDEN = 0
-║   ║   ║   └──Result: rendementsgrondslag = 0
-║   ║   ╟──Computing box3_bezittingen
-║   ║   ║   ├──Compute MAX(...) = 0
-║   ║   ║   │   └──Compute SUBTRACT(...) = -5768400
-║   ║   ║   │       ├──Compute ADD(...) = 0
-║   ║   ║   │       │   ├──Resolving from PARAMETERS: $SPAARGELD = 0
-║   ║   ║   │       │   ├──Resolving from PARAMETERS: $BELEGGINGEN = 0
-║   ║   ║   │       │   └──Resolving from PARAMETERS: $ONROEREND_GOED = 0
-║   ║   ║   │       ├──Resolving from PARAMETERS: $SCHULDEN = 0
-║   ║   ║   │       └──IF(took default) = 5768400
-║   ║   ║   │           ├──CASE 0: False
-║   ║   ║   │           │   └──Compute EQUALS(...) = False
-║   ║   ║   │           │       └──Resolving from PARAMETERS: $HEEFT_TOESLAGPARTNER = False
-║   ║   ║   │           └──DEFAULT: 5768400
-║   ║   ║   │               └──Resolving from DEFINITION: $HEFFINGSVRIJE_VOET_ALLEENSTAAND = 5768400
-║   ║   ║   └──Result: box3_bezittingen = 0
-║   ║   ╙──Computing box3_inkomen
-║   ║       ├──IF(took default) = 0
-║   ║       │   ├──CASE 0: False
-║   ║       │   │   └──Compute GREATER_THAN(...) = False
-║   ║       │   │       └──Resolving from OUTPUT: $RENDEMENTSGRONDSLAG = 0
-║   ║       │   └──DEFAULT: 0
-║   ║       └──Result: box3_inkomen = 0
-║   ╟──URI call: algemene_wet_inkomensafhankelijke_regelingen#heeft_toeslagpartner
-║   ║   ╟──Resolving from PARAMETERS: $BSN = '999993653'
-║   ║   ╙──CACHED: algemene_wet_inkomensafhankelijke_regelingen#heeft_toeslagpartner: False
-║   ╟──Computing vermogen_onder_grens
-║   ║   ├──Compute LESS_THAN_OR_EQUAL(...) = True
-║   ║   │   ├──Resolving from PARAMETERS: $VERMOGEN = 0
-║   ║   │   └──IF(took default) = 14189600
-║   ║   │       ├──CASE 0: False
-║   ║   │       │   └──Compute EQUALS(...) = False
-║   ║   │       │       └──Resolving from PARAMETERS: $HEEFT_TOESLAGPARTNER = False
-║   ║   │       └──DEFAULT: 14189600
-║   ║   │           └──Resolving from DEFINITION: $VERMOGENSGRENS_ALLEENSTAAND = 14189600
-║   ║   └──Result: vermogen_onder_grens = True
+║   ╟──Resolving $ZORGTOESLAGWET#STANDAARDPREMIE
+║   ║   ├──Resolving from RESOLVED_INPUT: 211200
+║   ║   ├──Delegation: Open term 'standaardpremie' implemented by regeling_standaardpremie article 1: 211200
+║   ║   │   ╟──Computing standaardpremie
+║   ║   │   │   └──Result: standaardpremie = 211200
+║   ║   │   ╙──Computing berekeningsjaar
+║   ║   │       └──Result: berekeningsjaar = 2025
+║   ║   └──Computing standaardpremie
+║   ║       ├──Resolving from PARAMETERS: $STANDAARDPREMIE = 211200
+║   ║       └──Result: standaardpremie = 211200
+║   ╟──Resolving $ZORGTOESLAGWET#VERMOGEN_ONDER_GRENS
+║   ║   ├──Resolving from RESOLVED_INPUT: True
+║   ║   ├──Reference: wet_inkomstenbelasting_2001#rendementsgrondslag
+║   ║   │   ╟──Resolving from PARAMETERS: $BSN = '999993653'
+║   ║   │   ╟──Resolving from DATA_SOURCE: $SPAARGELD = 0
+║   ║   │   ╟──Resolving from DATA_SOURCE: $BELEGGINGEN = 0
+║   ║   │   ╟──Resolving from DATA_SOURCE: $ONROEREND_GOED = 0
+║   ║   │   ╟──Resolving from DATA_SOURCE: $SCHULDEN = 0
+║   ║   │   ╟──Reference: algemene_wet_inkomensafhankelijke_regelingen#heeft_toeslagpartner
+║   ║   │   │   ╟──Resolving from PARAMETERS: $BSN = '999993653'
+║   ║   │   │   ╙──Cached: algemene_wet_inkomensafhankelijke_regelingen#heeft_toeslagpartner: False
+║   ║   │   ╟──Computing rendementsgrondslag
+║   ║   │   │   ├──Compute SUBTRACT(...) = 0
+║   ║   │   │   │   ├──Compute ADD(...) = 0
+║   ║   │   │   │   │   ├──Resolving from PARAMETERS: $SPAARGELD = 0
+║   ║   │   │   │   │   ├──Resolving from PARAMETERS: $BELEGGINGEN = 0
+║   ║   │   │   │   │   └──Resolving from PARAMETERS: $ONROEREND_GOED = 0
+║   ║   │   │   │   └──Resolving from PARAMETERS: $SCHULDEN = 0
+║   ║   │   │   └──Result: rendementsgrondslag = 0
+║   ║   │   ╟──Computing box3_bezittingen
+║   ║   │   │   ├──Compute MAX(...) = 0
+║   ║   │   │   │   └──Compute SUBTRACT(...) = -5768400
+║   ║   │   │   │       ├──Compute ADD(...) = 0
+║   ║   │   │   │       │   ├──Resolving from PARAMETERS: $SPAARGELD = 0
+║   ║   │   │   │       │   ├──Resolving from PARAMETERS: $BELEGGINGEN = 0
+║   ║   │   │   │       │   └──Resolving from PARAMETERS: $ONROEREND_GOED = 0
+║   ║   │   │   │       ├──Resolving from PARAMETERS: $SCHULDEN = 0
+║   ║   │   │   │       └──IF(took default) = 5768400
+║   ║   │   │   │           ├──CASE 0: False
+║   ║   │   │   │           │   └──Compute EQUALS(...) = False
+║   ║   │   │   │           │       └──Resolving from PARAMETERS: $HEEFT_TOESLAGPARTNER = False
+║   ║   │   │   │           └──DEFAULT: 5768400
+║   ║   │   │   │               └──Resolving from DEFINITION: $HEFFINGSVRIJE_VOET_ALLEENSTAAND = 5768400
+║   ║   │   │   └──Result: box3_bezittingen = 0
+║   ║   │   ╙──Computing box3_inkomen
+║   ║   │       ├──IF(took default) = 0
+║   ║   │       │   ├──CASE 0: False
+║   ║   │       │   │   └──Compute GREATER_THAN(...) = False
+║   ║   │       │   │       └──Resolving from OUTPUT: $RENDEMENTSGRONDSLAG = 0
+║   ║   │       │   └──DEFAULT: 0
+║   ║   │       └──Result: box3_inkomen = 0
+║   ║   ├──Reference: algemene_wet_inkomensafhankelijke_regelingen#heeft_toeslagpartner
+║   ║   │   ╟──Resolving from PARAMETERS: $BSN = '999993653'
+║   ║   │   ╙──Cached: algemene_wet_inkomensafhankelijke_regelingen#heeft_toeslagpartner: False
+║   ║   └──Computing vermogen_onder_grens
+║   ║       ├──Compute LESS_THAN_OR_EQUAL(...) = True
+║   ║       │   ├──Resolving from PARAMETERS: $VERMOGEN = 0
+║   ║       │   └──IF(took default) = 14189600
+║   ║       │       ├──CASE 0: False
+║   ║       │       │   └──Compute EQUALS(...) = False
+║   ║       │       │       └──Resolving from PARAMETERS: $HEEFT_TOESLAGPARTNER = False
+║   ║       │       └──DEFAULT: 14189600
+║   ║       │           └──Resolving from DEFINITION: $VERMOGENSGRENS_ALLEENSTAAND = 14189600
+║   ║       └──Result: vermogen_onder_grens = True
 ║   ╟──HOOK: Hook PreActions on BESCHIKKING stage BESLUIT → algemene_wet_bestuursrecht:3:46
 ║   ║   ╙──Computing motivering_vereist
 ║   ║       └──Result: motivering_vereist = True


### PR DESCRIPTION
## Summary

- Close all trace gaps so every engine action (success + error) is visible in the execution trace
- Fix box-drawing rendering: double-line connectors (`╟──`/`╙──`) mark cross-law boundaries, single-line continuation (`│`) when staying in the same law
- Replace engine jargon with legal concepts: "URI call" → "Reference", "OPEN_TERM" → "Delegation", "OVERRIDE" → "Lex specialis", "resolved from" → "implemented by"

## Changes

**Trace completeness** (`service.rs`, `error.rs`):
- Internal same-law references now emit trace nodes
- `evaluate_law_output_with_trace` returns partial trace on error via new `TracedError` variant
- `execute_stage` supports tracing via `execute_stage_with_trace`
- Depth-exceeded, article-not-found, and empty-source-unresolved errors traced

**Rendering consistency** (`trace.rs`):
- Split `parent_is_double` into `double_connector` + `double_continuation` in `render_box_node`
- `render_double_children` passes parent scope for continuation, always uses double connectors
- `OverrideResolution` renders with single-line scope (lex specialis is declared in current law)

## Test plan
- [x] `just format` — passes
- [x] `just lint` — passes
- [x] `just test` — 319 unit tests, 12 golden tests, 4 trace integration tests pass
- [x] `just bdd` — 28 scenarios, 197 steps pass
- [x] Trace snapshot updated and verified identical content (only box chars differ from previous)