### PR TITLE
chore: add full workspace build check to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,13 @@ repos:
         pass_filenames: false
         types: [rust]
 
+      - id: rust-build-check
+        name: Rust workspace build check
+        entry: just build-check
+        language: system
+        pass_filenames: false
+        types: [rust]
+
       - id: validate-law-yaml
         name: Validate law YAML schema
         entry: just validate


### PR DESCRIPTION
## Summary

Adds `just build-check` (`cargo check --all`) as a pre-commit hook for Rust files.

## Why

In #386 (HashMap→BTreeMap refactor), the engine's public API changed from `HashMap<String, Value>` to `BTreeMap<String, Value>`. Local tests passed because they only compiled the engine crate. CI failed because the Docker build compiles the full workspace, where `editor-api`, `admin`, and `tui` still called the engine API with `HashMap`.

The existing pre-commit hooks run `just format` (formatting) and `just lint` (clippy) — both only check the engine crate. Adding `just build-check` catches cross-package type mismatches before push.

## Trade-off

`cargo check --all` takes ~5-10 seconds on a warm cache, ~60 seconds cold. This adds to every commit touching `.rs` files. The question is whether catching workspace-level errors locally is worth the extra time.

For reference, the current hooks already run `just format` + `just lint` + `just validate` which together take ~10-15 seconds. Adding `build-check` roughly doubles that on warm cache.

@tdjager — Would appreciate your thoughts on whether the extra build time is acceptable. An alternative would be to only run this in CI (which already does), but that means slower feedback when making public API changes.