### PR TITLE
feat(admin): show error message in jobs table

### DIFF
--- a/packages/admin/frontend-src/app.js
+++ b/packages/admin/frontend-src/app.js
@@ -46,6 +46,7 @@ const TAB_CONFIG = {
       { key: 'job_type', label: 'Type', sortable: true },
       { key: 'law_id', label: 'Law ID', sortable: true },
       { key: 'status', label: 'Status', sortable: true },
+      { key: '_error', label: 'Error', sortable: false },
       { key: 'priority', label: 'Priority', sortable: true },
       { key: 'attempts', label: 'Attempts', sortable: true },
       { key: 'created_at', label: 'Created', sortable: true },
@@ -340,7 +341,18 @@ function renderTableBody() {
 
     for (const col of config.columns) {
       const td = document.createElement('td');
-      if (col.key === '_actions' && state.activeTab === 'law_entries') {
+      if (col.key === '_error' && state.activeTab === 'jobs') {
+        const error = row.result && row.result.error;
+        if (error) {
+          const span = document.createElement('span');
+          span.className = 'cell-error';
+          span.title = error;
+          span.textContent = error.length > 80 ? error.substring(0, 80) + '\u2026' : error;
+          td.appendChild(span);
+        } else {
+          td.innerHTML = '<span class="cell-null">\u2014</span>';
+        }
+      } else if (col.key === '_actions' && state.activeTab === 'law_entries') {
         td.appendChild(renderRowActions(row));
       } else if (col.key === 'law_id' && state.activeTab === 'law_entries') {
         // Clickable law_id to view jobs for this law

--- a/packages/admin/frontend-src/css/admin.css
+++ b/packages/admin/frontend-src/css/admin.css
@@ -126,6 +126,17 @@
   opacity: 0.6;
 }
 
+.cell-error {
+  font-size: 12px;
+  color: var(--primitives-color-danger-700);
+  max-width: 300px;
+  display: inline-block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  vertical-align: middle;
+}
+
 .table-message {
   text-align: center;
   padding: var(--primitives-space-24) var(--primitives-space-16);


### PR DESCRIPTION
## Summary

- Add an "Error" column to the jobs table that shows the `result.error` message inline, so you can see why a job failed without opening the detail panel
- Error text is truncated at 80 chars with full message in the tooltip

## Test plan

- [ ] After deploy: verify failed jobs show their error message in the table
- [ ] Verify non-failed jobs show a dash in the Error column
- [ ] Verify clicking a row still opens the detail panel with the full error