### PR TITLE
feat(frontend): migrate to design system v0.8.14 layout components

### DIFF
--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -178,41 +178,27 @@ function selectArticle(number) {
         </div>
 
         <!-- 3-column equal layout: Text | Form | Result -->
-        <div v-else class="editor-layout">
+        <rr-side-by-side-split-view v-else panes="3">
           <!-- Left: Article Text -->
-          <div class="editor-pane">
-            <rr-page header-sticky>
-              <rr-toolbar slot="header" size="md">
-                <rr-toolbar-start-area>
-                  <rr-toolbar-item>
-                    <rr-title-bar size="5">Tekst</rr-title-bar>
-                  </rr-toolbar-item>
-                </rr-toolbar-start-area>
-              </rr-toolbar>
+          <rr-split-view-pane slot="pane-1" background="tinted">
+            <rr-page sticky-header>
+              <rr-top-title-bar slot="header" title="Tekst"></rr-top-title-bar>
               <rr-simple-section>
                 <ArticleText :article="selectedArticle" />
               </rr-simple-section>
             </rr-page>
-          </div>
+          </rr-split-view-pane>
 
           <!-- Middle: Form or YAML -->
-          <div class="editor-pane">
-            <rr-page header-sticky>
-              <rr-toolbar slot="header" size="md">
-                <rr-toolbar-start-area>
-                  <rr-toolbar-item>
-                    <rr-segmented-control size="md" :value="middlePaneView" @change="onMiddlePaneChange">
-                      <rr-segmented-control-item value="form">Formulier</rr-segmented-control-item>
-                      <rr-segmented-control-item value="yaml">YAML</rr-segmented-control-item>
-                    </rr-segmented-control>
-                  </rr-toolbar-item>
-                </rr-toolbar-start-area>
-                <rr-toolbar-end-area>
-                  <rr-toolbar-item v-if="middlePaneView === 'yaml' && parseError">
-                    <span class="editor-parse-error">YAML parse error</span>
-                  </rr-toolbar-item>
-                </rr-toolbar-end-area>
-              </rr-toolbar>
+          <rr-split-view-pane slot="pane-2">
+            <rr-page sticky-header>
+              <rr-top-title-bar slot="header" title="Formulier">
+                <rr-segmented-control slot="toolbar" size="md" :value="middlePaneView" @change="onMiddlePaneChange">
+                  <rr-segmented-control-item value="form">Formulier</rr-segmented-control-item>
+                  <rr-segmented-control-item value="yaml">YAML</rr-segmented-control-item>
+                </rr-segmented-control>
+                <span v-if="middlePaneView === 'yaml' && parseError" slot="toolbar" class="editor-parse-error">YAML parse error</span>
+              </rr-top-title-bar>
 
               <!-- Form view -->
               <div v-if="middlePaneView === 'form'">
@@ -246,18 +232,12 @@ function selectArticle(number) {
                 <div v-if="parseError" class="editor-parse-error-detail">{{ parseError }}</div>
               </div>
             </rr-page>
-          </div>
+          </rr-split-view-pane>
 
           <!-- Right: Execution Result -->
-          <div class="editor-pane">
-            <rr-page header-sticky>
-              <rr-toolbar slot="header" size="md">
-                <rr-toolbar-start-area>
-                  <rr-toolbar-item>
-                    <rr-title-bar size="5">Resultaat</rr-title-bar>
-                  </rr-toolbar-item>
-                </rr-toolbar-start-area>
-              </rr-toolbar>
+          <rr-split-view-pane slot="pane-3">
+            <rr-page sticky-header>
+              <rr-top-title-bar slot="header" title="Resultaat"></rr-top-title-bar>
 
               <ExecutionTraceView
                 :result="lastResult"
@@ -265,8 +245,8 @@ function selectArticle(number) {
                 :error="lastError"
               />
             </rr-page>
-          </div>
-        </div>
+          </rr-split-view-pane>
+        </rr-side-by-side-split-view>
       </rr-split-view-pane>
     </rr-bar-split-view>
   </rr-app-view>
@@ -276,24 +256,6 @@ function selectArticle(number) {
 </template>
 
 <style>
-.editor-layout {
-  display: flex;
-  flex: 1;
-  min-height: 0;
-  height: 100%;
-}
-
-.editor-pane {
-  flex: 1 1 0;
-  min-width: 0;
-  overflow: hidden;
-  border-right: 1px solid var(--semantics-dividers-color, #E0E3E8);
-}
-
-.editor-pane:last-child {
-  border-right: none;
-}
-
 .editor-engine-error {
   padding: 12px 16px;
   background: #fee;

--- a/frontend/src/LibraryApp.vue
+++ b/frontend/src/LibraryApp.vue
@@ -255,7 +255,7 @@ loadIndex();
           <!-- Sidebar: Wetten Browser -->
           <rr-split-view-pane slot="sidebar" has-content>
             <rr-page sticky-header>
-              <rr-top-title-bar slot="header" toolbar="none" title="Wetten en regels" container="sm"></rr-top-title-bar>
+              <rr-top-title-bar slot="header" title="Wetten en regels"></rr-top-title-bar>
 
               <rr-simple-section container="sm">
                 <div v-if="loading" style="padding: 32px; text-align: center;">Laden...</div>
@@ -288,30 +288,15 @@ loadIndex();
               <rr-top-title-bar
                 slot="header"
                 :title="lawName || 'Selecteer een wet'"
-                container="sm"
-                toolbar="custom"
+                back-label="Wetten"
               >
-                <div slot="toolbar-start">
-                  <rr-toolbar size="md">
-                    <rr-toolbar-start-area>
-                      <rr-toolbar-item>
-                        <rr-icon-button variant="neutral-tinted" size="s" icon="heart" title="Favoriet">
-                        </rr-icon-button>
-                      </rr-toolbar-item>
-                      <rr-toolbar-item>
-                        <rr-button variant="neutral-tinted" size="md">Filter</rr-button>
-                      </rr-toolbar-item>
-                    </rr-toolbar-start-area>
-                    <rr-toolbar-end-area>
-                      <rr-toolbar-item>
-                        <a v-if="selectedLawId" :href="`/editor.html?law=${encodeURIComponent(selectedLawId)}`">
-                          <rr-button variant="accent-filled" size="md">Bewerk</rr-button>
-                        </a>
-                        <rr-button v-else variant="accent-filled" size="md" disabled>Bewerk</rr-button>
-                      </rr-toolbar-item>
-                    </rr-toolbar-end-area>
-                  </rr-toolbar>
-                </div>
+                <rr-icon-button slot="toolbar" variant="neutral-tinted" size="s" icon="heart" title="Favoriet">
+                </rr-icon-button>
+                <rr-button slot="toolbar" variant="neutral-tinted" size="md">Filter</rr-button>
+                <a v-if="selectedLawId" slot="toolbar" :href="`/editor.html?law=${encodeURIComponent(selectedLawId)}`">
+                  <rr-button variant="accent-filled" size="md">Bewerk</rr-button>
+                </a>
+                <rr-button v-else slot="toolbar" variant="accent-filled" size="md" disabled>Bewerk</rr-button>
               </rr-top-title-bar>
 
               <rr-simple-section container="sm">
@@ -346,28 +331,17 @@ loadIndex();
               <rr-top-title-bar
                 slot="header"
                 :title="selectedArticle ? `Artikel ${selectedArticle.number}` : 'Selecteer een artikel'"
-                container="sm"
-                toolbar="custom"
+                :back-label="lawName || 'Terug'"
               >
-                <rr-toolbar slot="toolbar-start" size="md">
-                  <rr-toolbar-start-area>
-                    <rr-toolbar-item>
-                      <rr-segmented-control size="md" :value="detailView" @change="detailView = $event.detail.value">
-                        <rr-segmented-control-item value="tekst">Tekst</rr-segmented-control-item>
-                        <rr-segmented-control-item value="machine">Machine</rr-segmented-control-item>
-                        <rr-segmented-control-item value="yaml">YAML</rr-segmented-control-item>
-                      </rr-segmented-control>
-                    </rr-toolbar-item>
-                  </rr-toolbar-start-area>
-                  <rr-toolbar-end-area>
-                    <rr-toolbar-item>
-                      <a v-if="selectedLawId" :href="`/editor.html?law=${encodeURIComponent(selectedLawId)}`">
-                        <rr-button variant="accent-filled" size="md">Bewerk</rr-button>
-                      </a>
-                      <rr-button v-else variant="accent-filled" size="md" disabled>Bewerk</rr-button>
-                    </rr-toolbar-item>
-                  </rr-toolbar-end-area>
-                </rr-toolbar>
+                <rr-segmented-control slot="toolbar" size="md" :value="detailView" @change="detailView = $event.detail.value">
+                  <rr-segmented-control-item value="tekst">Tekst</rr-segmented-control-item>
+                  <rr-segmented-control-item value="machine">Machine</rr-segmented-control-item>
+                  <rr-segmented-control-item value="yaml">YAML</rr-segmented-control-item>
+                </rr-segmented-control>
+                <a v-if="selectedLawId" slot="toolbar" :href="`/editor.html?law=${encodeURIComponent(selectedLawId)}`">
+                  <rr-button variant="accent-filled" size="md">Bewerk</rr-button>
+                </a>
+                <rr-button v-else slot="toolbar" variant="accent-filled" size="md" disabled>Bewerk</rr-button>
               </rr-top-title-bar>
 
               <rr-simple-section container="sm">


### PR DESCRIPTION
**Summary**

- **Editor**: Replace .editor-layout/.editor-pane divs with rr-side-by-side-split-view + rr-split-view-pane, replace rr-toolbar+rr-title-bar headers with rr-top-title-bar, use background=tinted on text pane, fix header-sticky to sticky-header
- **Library**: Migrate rr-top-title-bar from v0.8.12 API (toolbar=custom, slot=toolbar-start, container=sm) to v0.8.14 API (single slot=toolbar), add back-label for responsive back-navigation
- Template-only changes — no script modifications

**Test plan**

- [x] npm run build passes
- [x] All 49 frontend tests pass
- [x] Library: 3-pane navigation layout renders correctly (desktop)
- [x] Library: responsive collapse works on narrow viewport (back button visible)
- [x] Editor: layout structure renders (toolbar, error state)
- [ ] Deploy preview: verify editor with backend API available