### PR TITLE
perf(ci): switch to Swatinem/rust-cache for faster CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,8 +153,8 @@ jobs:
         if: needs.changes.outputs.ci != 'true'
         run: echo "No relevant changes, skipping pre-commit"
 
-  test-engine:
-    name: Test Engine
+  test:
+    name: Test
     needs: changes
     runs-on: ubuntu-latest
     steps:
@@ -169,22 +169,15 @@ jobs:
         if: needs.changes.outputs.ci == 'true'
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7  # stable
 
-      - name: Cache cargo registry
+      - name: Cache Rust dependencies
         if: needs.changes.outputs.ci == 'true'
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            packages/target
-          key: ${{ runner.os }}-cargo-engine-${{ hashFiles('packages/**/Cargo.toml', 'packages/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-engine-
-            ${{ runner.os }}-cargo-
+          workspaces: packages
 
-      - name: Run engine unit tests
+      - name: Run all tests
         if: needs.changes.outputs.ci == 'true'
-        run: just test
+        run: just test-all
 
       - name: Run BDD tests
         if: needs.changes.outputs.ci == 'true'
@@ -192,85 +185,7 @@ jobs:
 
       - name: Skip (no relevant changes)
         if: needs.changes.outputs.ci != 'true'
-        run: echo "No relevant changes, skipping engine tests"
-
-  test-harvester-pipeline:
-    name: Test Harvester & Pipeline
-    needs: changes
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
-        if: needs.changes.outputs.ci == 'true'
-
-      - name: Install just
-        if: needs.changes.outputs.ci == 'true'
-        uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b  # v3
-
-      - name: Install Rust toolchain
-        if: needs.changes.outputs.ci == 'true'
-        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7  # stable
-
-      - name: Cache cargo registry
-        if: needs.changes.outputs.ci == 'true'
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            packages/target
-          key: ${{ runner.os }}-cargo-harvester-${{ hashFiles('packages/**/Cargo.toml', 'packages/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-harvester-
-            ${{ runner.os }}-cargo-
-
-      - name: Run harvester tests
-        if: needs.changes.outputs.ci == 'true'
-        run: just harvester-test
-
-      - name: Run pipeline unit tests
-        if: needs.changes.outputs.ci == 'true'
-        run: just pipeline-test
-
-      - name: Skip (no relevant changes)
-        if: needs.changes.outputs.ci != 'true'
-        run: echo "No relevant changes, skipping harvester & pipeline tests"
-
-  test-pipeline-integration:
-    name: Test Pipeline Integration
-    needs: changes
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
-        if: needs.changes.outputs.ci == 'true'
-
-      - name: Install just
-        if: needs.changes.outputs.ci == 'true'
-        uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b  # v3
-
-      - name: Install Rust toolchain
-        if: needs.changes.outputs.ci == 'true'
-        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7  # stable
-
-      - name: Cache cargo registry
-        if: needs.changes.outputs.ci == 'true'
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            packages/target
-          key: ${{ runner.os }}-cargo-pipeline-${{ hashFiles('packages/**/Cargo.toml', 'packages/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-pipeline-
-            ${{ runner.os }}-cargo-
-
-      - name: Run pipeline integration tests
-        if: needs.changes.outputs.ci == 'true'
-        run: just pipeline-integration-test
-
-      - name: Skip (no relevant changes)
-        if: needs.changes.outputs.ci != 'true'
-        run: echo "No relevant changes, skipping pipeline integration tests"
+        run: echo "No relevant changes, skipping tests"
 
   wasm:
     name: WASM Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,9 +141,9 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             packages/target
-          key: ${{ runner.os }}-cargo-precommit-${{ hashFiles('packages/**/Cargo.toml') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('packages/**/Cargo.toml', 'packages/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-precommit-
+            ${{ runner.os }}-cargo-
 
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # v3.0.1
         if: needs.changes.outputs.ci == 'true'
@@ -152,8 +152,8 @@ jobs:
         if: needs.changes.outputs.ci != 'true'
         run: echo "No relevant changes, skipping pre-commit"
 
-  test:
-    name: Test
+  test-engine:
+    name: Test Engine
     needs: changes
     runs-on: ubuntu-latest
     steps:
@@ -176,17 +176,97 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             packages/target
-          key: ${{ runner.os }}-cargo-test-${{ hashFiles('packages/**/Cargo.toml') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('packages/**/Cargo.toml', 'packages/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-test-
+            ${{ runner.os }}-cargo-
 
-      - name: Run all tests
+      - name: Run engine unit tests
         if: needs.changes.outputs.ci == 'true'
-        run: just test-all
+        run: just test
+
+      - name: Run BDD tests
+        if: needs.changes.outputs.ci == 'true'
+        run: just bdd
 
       - name: Skip (no relevant changes)
         if: needs.changes.outputs.ci != 'true'
-        run: echo "No relevant changes, skipping tests"
+        run: echo "No relevant changes, skipping engine tests"
+
+  test-harvester-pipeline:
+    name: Test Harvester & Pipeline
+    needs: changes
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        if: needs.changes.outputs.ci == 'true'
+
+      - name: Install just
+        if: needs.changes.outputs.ci == 'true'
+        uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b  # v3
+
+      - name: Install Rust toolchain
+        if: needs.changes.outputs.ci == 'true'
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7  # stable
+
+      - name: Cache cargo registry
+        if: needs.changes.outputs.ci == 'true'
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            packages/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('packages/**/Cargo.toml', 'packages/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Run harvester tests
+        if: needs.changes.outputs.ci == 'true'
+        run: just harvester-test
+
+      - name: Run pipeline unit tests
+        if: needs.changes.outputs.ci == 'true'
+        run: just pipeline-test
+
+      - name: Skip (no relevant changes)
+        if: needs.changes.outputs.ci != 'true'
+        run: echo "No relevant changes, skipping harvester & pipeline tests"
+
+  test-pipeline-integration:
+    name: Test Pipeline Integration
+    needs: changes
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        if: needs.changes.outputs.ci == 'true'
+
+      - name: Install just
+        if: needs.changes.outputs.ci == 'true'
+        uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b  # v3
+
+      - name: Install Rust toolchain
+        if: needs.changes.outputs.ci == 'true'
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7  # stable
+
+      - name: Cache cargo registry
+        if: needs.changes.outputs.ci == 'true'
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            packages/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('packages/**/Cargo.toml', 'packages/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Run pipeline integration tests
+        if: needs.changes.outputs.ci == 'true'
+        run: just pipeline-integration-test
+
+      - name: Skip (no relevant changes)
+        if: needs.changes.outputs.ci != 'true'
+        run: echo "No relevant changes, skipping pipeline integration tests"
 
   wasm:
     name: WASM Build
@@ -210,9 +290,9 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             packages/target
-          key: ${{ runner.os }}-cargo-wasm-${{ hashFiles('packages/**/Cargo.toml') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('packages/**/Cargo.toml', 'packages/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-wasm-
+            ${{ runner.os }}-cargo-
 
       - name: Build for WASM
         if: needs.changes.outputs.ci == 'true'
@@ -287,9 +367,9 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             packages/target
-          key: ${{ runner.os }}-cargo-admin-${{ hashFiles('packages/admin/Cargo.toml', 'packages/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('packages/**/Cargo.toml', 'packages/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-admin-
+            ${{ runner.os }}-cargo-
 
       - name: Install just
         if: needs.changes.outputs.admin == 'true'
@@ -356,9 +436,9 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             packages/target
-          key: ${{ runner.os }}-cargo-editor-api-${{ hashFiles('packages/editor-api/Cargo.toml', 'packages/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('packages/**/Cargo.toml', 'packages/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-editor-api-
+            ${{ runner.os }}-cargo-
 
       - name: Install just
         if: needs.changes.outputs.editor-api == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,8 +141,9 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             packages/target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('packages/**/Cargo.toml', 'packages/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-precommit-${{ hashFiles('packages/**/Cargo.toml', 'packages/Cargo.lock') }}
           restore-keys: |
+            ${{ runner.os }}-cargo-precommit-
             ${{ runner.os }}-cargo-
 
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # v3.0.1
@@ -176,8 +177,9 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             packages/target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('packages/**/Cargo.toml', 'packages/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-engine-${{ hashFiles('packages/**/Cargo.toml', 'packages/Cargo.lock') }}
           restore-keys: |
+            ${{ runner.os }}-cargo-engine-
             ${{ runner.os }}-cargo-
 
       - name: Run engine unit tests
@@ -216,8 +218,9 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             packages/target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('packages/**/Cargo.toml', 'packages/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-harvester-${{ hashFiles('packages/**/Cargo.toml', 'packages/Cargo.lock') }}
           restore-keys: |
+            ${{ runner.os }}-cargo-harvester-
             ${{ runner.os }}-cargo-
 
       - name: Run harvester tests
@@ -256,8 +259,9 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             packages/target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('packages/**/Cargo.toml', 'packages/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-pipeline-${{ hashFiles('packages/**/Cargo.toml', 'packages/Cargo.lock') }}
           restore-keys: |
+            ${{ runner.os }}-cargo-pipeline-
             ${{ runner.os }}-cargo-
 
       - name: Run pipeline integration tests
@@ -290,8 +294,9 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             packages/target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('packages/**/Cargo.toml', 'packages/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-wasm-${{ hashFiles('packages/**/Cargo.toml', 'packages/Cargo.lock') }}
           restore-keys: |
+            ${{ runner.os }}-cargo-wasm-
             ${{ runner.os }}-cargo-
 
       - name: Build for WASM
@@ -367,8 +372,9 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             packages/target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('packages/**/Cargo.toml', 'packages/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-admin-${{ hashFiles('packages/**/Cargo.toml', 'packages/Cargo.lock') }}
           restore-keys: |
+            ${{ runner.os }}-cargo-admin-
             ${{ runner.os }}-cargo-
 
       - name: Install just
@@ -436,8 +442,9 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             packages/target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('packages/**/Cargo.toml', 'packages/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-editor-api-${{ hashFiles('packages/**/Cargo.toml', 'packages/Cargo.lock') }}
           restore-keys: |
+            ${{ runner.os }}-cargo-editor-api-
             ${{ runner.os }}-cargo-
 
       - name: Install just


### PR DESCRIPTION
## Summary

- **Switch from `actions/cache` to `Swatinem/rust-cache`** in the test job. The old approach cached the entire `packages/target` directory (including workspace crates recompiled every run). `rust-cache` only caches dependency artifacts, resulting in a much smaller cache that's faster to restore and save.
- **Recombine test jobs** back into a single `Test` job. The parallel split from #411 added ~40-50s setup overhead per extra job, which exceeded the time saved from parallelism (tests are fast, setup is not).
- **BDD tests** remain in CI (`just bdd`), added in #411.

## Expected improvement

The old `Test` job took ~1m43s. With smaller cache restores we expect to get under that, especially on warm cache runs.

## Test plan

- [ ] Verify `Test` job passes with `Swatinem/rust-cache`
- [ ] Compare timing vs previous runs