### PR TITLE
docs(rfcs): add RFC-012 to navigation sidebar

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -143,6 +143,7 @@ export default withMermaid(
               { text: 'RFC-008: Bestuursrecht/AWB', link: '/rfcs/rfc-008' },
               { text: 'RFC-009: Multi-Org Execution', link: '/rfcs/rfc-009' },
               { text: 'RFC-010: Federated Corpus', link: '/rfcs/rfc-010' },
+              { text: 'RFC-012: Untranslatables', link: '/rfcs/rfc-012' },
             ],
           },
         ],


### PR DESCRIPTION
## Summary
- Adds RFC-012 (Untranslatables) to the docs sidebar navigation

## Test plan
- [ ] Verify docs site builds and RFC-012 link appears in sidebar