### PR TITLE
feat(docs): overhaul README with current project state

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,27 +6,73 @@
 [![Mutation Testing](https://github.com/MinBZK/regelrecht/actions/workflows/mutation-testing.yml/badge.svg)](https://github.com/MinBZK/regelrecht/actions/workflows/mutation-testing.yml)
 [![Docs](https://img.shields.io/badge/docs-regelrecht-green.svg)](https://docs.regelrecht.rijks.app)
 
-RegelRecht MVP - Machine-readable Dutch law execution engine with a web-based editor.
+Machine-readable Dutch law execution. regelrecht takes legal texts, encodes them as structured YAML, and runs them as deterministic decision logic.
+
+## What does it do
+
+- The engine takes a regulation and a set of inputs, evaluates the decision logic, and returns a result with a full explanation trail
+- Laws are tested against real-world scenarios using BDD (Gherkin) tests, many derived from legislative explanatory memoranda
+- A harvester downloads and tracks Dutch legislation from the official BWB repository
+- Regulations can be edited through a web UI with live execution preview
 
 ## Components
 
-- **[packages/engine/](packages/engine/)** - Rust law execution engine
-- **[packages/harvester/](packages/harvester/)** - Rust harvester for downloading Dutch legislation from BWB
-- **[packages/pipeline/](packages/pipeline/)** - PostgreSQL-backed job queue and law status tracking for the processing pipeline
-- **corpus/regulation/** - Dutch legal regulations in machine-readable YAML format
-- **frontend/** - Static HTML/CSS law editor prototype
+### Rust packages
 
-## Deployment
+| Package | Description |
+|---------|-------------|
+| [packages/engine/](packages/engine/) | Law execution engine (also compiles to WASM) |
+| [packages/harvester/](packages/harvester/) | Downloads Dutch legislation from BWB |
+| [packages/pipeline/](packages/pipeline/) | PostgreSQL job queue for law processing |
+| [packages/admin/](packages/admin/) | Admin dashboard API (Axum) |
+| [packages/editor-api/](packages/editor-api/) | Backend API for the law editor |
+| [packages/corpus/](packages/corpus/) | Git integration for the regulation corpus |
+| [packages/shared/](packages/shared/) | Shared domain types across crates |
+| [packages/tui/](packages/tui/) | Terminal dashboard (Ratatui) |
 
-The frontend is automatically deployed to RIG (Quattro/rijksapps):
+### Frontends and sites
 
-| Environment | URL | Trigger |
-|-------------|-----|---------|
-| Production | https://editor-regelrecht-regel-k4c.rig.prd1.gn2.quattro.rijksapps.nl | Push to `main` |
-| PR Preview | https://editor-prN-regel-k4c.rig.prd1.gn2.quattro.rijksapps.nl | PR opened/updated |
+| Directory | Description |
+|-----------|-------------|
+| [frontend/](frontend/) | Law editor UI (Vue 3 + Vite) |
+| [frontend-lawmaking/](frontend-lawmaking/) | Law-making process visualization (Vue 3 + Vite) |
+| [landing/](landing/) | Landing page |
+| [docs/](docs/) | Documentation site (VitePress) |
 
-PR preview environments are automatically cleaned up when the PR is closed.
+### Data and testing
 
-## Development
+| Directory | Description |
+|-----------|-------------|
+| [corpus/regulation/](corpus/regulation/) | Dutch regulations in machine-readable YAML |
+| [schema/](schema/) | Versioned JSON schema for the law format (current: v0.5.1) |
+| [features/](features/) | Gherkin BDD scenarios for law execution |
+| [packages/grafana/](packages/grafana/) | Grafana monitoring dashboards |
 
-See the [docs site](https://docs.regelrecht.rijks.app) for detailed development instructions
+## Deployed services
+
+| Service | URL |
+|---------|-----|
+| Editor | https://editor.regelrecht.rijks.app |
+| Landing page | https://regelrecht.rijks.app |
+| Documentation | https://docs.regelrecht.rijks.app |
+| Law-making | https://lawmaking.regelrecht.rijks.app |
+| Harvester admin | https://harvester-admin.regelrecht.rijks.app |
+| Grafana | https://grafana.regelrecht.rijks.app |
+
+PR preview environments are deployed automatically and cleaned up when the PR is closed.
+
+## Getting started
+
+Prerequisites: [Rust](https://rustup.rs/) (stable) and [just](https://github.com/casey/just).
+
+```bash
+just check    # run all quality checks (format, lint, build, validate, tests)
+just test     # unit tests only
+just bdd      # BDD tests only
+```
+
+See the [docs site](https://docs.regelrecht.rijks.app) for full development instructions.
+
+## License
+
+[EUPL-1.2](LICENSE)


### PR DESCRIPTION
## Summary
- Replace stale component list (3 packages) with all 16 components across Rust packages, frontends, data, and testing
- Fix broken deployment URLs (old quattro domain -> current rijks.app domains)
- Add "What does it do" section, getting started, and license footer
- Drop "MVP" framing

## Test plan
- [ ] Verify all component links resolve to existing directories
- [ ] Verify deployed service URLs are reachable
- [ ] Check rendering on GitHub