### PR TITLE
fix(ci): drop duplicate BDD test step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,10 +186,6 @@ jobs:
         if: needs.changes.outputs.ci == 'true'
         run: just test-all
 
-      - name: Run BDD tests
-        if: needs.changes.outputs.ci == 'true'
-        run: just bdd
-
       - name: Skip (no relevant changes)
         if: needs.changes.outputs.ci != 'true'
         run: echo "No relevant changes, skipping tests"


### PR DESCRIPTION
## Summary

`just bdd` was running BDD tests a second time — `just test-all` already includes `just test` which runs `cargo test --all-features` on the engine, compiling and executing the BDD binary. The duplicate step added ~2min to CI.

## Test plan

- [ ] Verify Test job timing drops from ~3m39s back toward ~1m43s