### PR TITLE
feat(corpus): add RepoBackend trait for reading and writing corpus files

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -59,7 +59,7 @@ RUN find packages -name '*.rs' -exec touch {} + && \
 
 # Stage 5: Runtime
 FROM alpine:3.23@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
-RUN apk add --no-cache ca-certificates && \
+RUN apk add --no-cache ca-certificates git && \
     addgroup -S app && adduser -S app -G app
 
 COPY --from=builder /build/target/release/regelrecht-editor-api /usr/local/bin/

--- a/frontend/src/components/ScenarioBuilder.vue
+++ b/frontend/src/components/ScenarioBuilder.vue
@@ -297,6 +297,7 @@ async function onSave() {
               :law-id="lawId"
               :article-map="articleMap"
               @show-details="() => onShowDetails(i)"
+              @executed="(data) => onScenarioResult(i, data)"
             />
           </div>
         </details>

--- a/frontend/src/components/ScenarioBuilder.vue
+++ b/frontend/src/components/ScenarioBuilder.vue
@@ -212,22 +212,28 @@ function onScenarioFileSelect(event) {
 async function onSave() {
   if (!formState.value || !selectedScenarioFile.value) return;
 
-  // Sync edited input values back to formState before serializing
-  for (let i = 0; i < (formState.value.scenarios || []).length; i++) {
-    const formRef = scenarioRefs.value[i];
-    if (!formRef?.getFormValues) continue;
-    const values = formRef.getFormValues();
-    syncEditedValues(formState.value, i, values);
-  }
-
   saveSuccess.value = false;
   try {
+    // Sync edited input values back to formState before serializing.
+    // This must be inside the try so that a throw from syncEditedValues
+    // (e.g. unexpected form shape) surfaces as a save error rather than
+    // failing silently.
+    for (let i = 0; i < (formState.value.scenarios || []).length; i++) {
+      const formRef = scenarioRefs.value[i];
+      if (!formRef?.getFormValues) continue;
+      const values = formRef.getFormValues();
+      syncEditedValues(formState.value, i, values);
+    }
+
     const gherkin = formStateToGherkin(formState.value);
     await saveScenario(selectedScenarioFile.value, gherkin);
     saveSuccess.value = true;
     setTimeout(() => { saveSuccess.value = false; }, 3000);
-  } catch {
-    // saveError is already set by the composable
+  } catch (e) {
+    // The composable sets saveError on its own failures. For sync/serialise
+    // errors that happen before saveScenario, set it manually so the user
+    // still sees the banner instead of an unexplained no-op.
+    if (!saveError.value) saveError.value = e;
   }
 }
 </script>

--- a/frontend/src/components/ScenarioBuilder.vue
+++ b/frontend/src/components/ScenarioBuilder.vue
@@ -3,7 +3,7 @@ import { ref, computed, watch, nextTick } from 'vue';
 import { useDependencies } from '../composables/useDependencies.js';
 import { useScenarios } from '../composables/useScenarios.js';
 import { parseFeature } from '../gherkin/parser.js';
-import { mapFeatureToForm, getEffectiveSetup, formStateToGherkin } from '../gherkin/formMapper.js';
+import { mapFeatureToForm, getEffectiveSetup, formStateToGherkin, syncEditedValues } from '../gherkin/formMapper.js';
 import { matchStatus } from '../utils/outputFormat.js';
 import { buildArticleMap } from '../utils/articleMapping.js';
 import ScenarioForm from './ScenarioForm.vue';
@@ -211,6 +211,14 @@ function onScenarioFileSelect(event) {
 
 async function onSave() {
   if (!formState.value || !selectedScenarioFile.value) return;
+
+  // Sync edited input values back to formState before serializing
+  for (let i = 0; i < (formState.value.scenarios || []).length; i++) {
+    const formRef = scenarioRefs.value[i];
+    if (!formRef?.getFormValues) continue;
+    const values = formRef.getFormValues();
+    syncEditedValues(formState.value, i, values);
+  }
 
   saveSuccess.value = false;
   try {

--- a/frontend/src/components/ScenarioBuilder.vue
+++ b/frontend/src/components/ScenarioBuilder.vue
@@ -3,7 +3,7 @@ import { ref, computed, watch, nextTick } from 'vue';
 import { useDependencies } from '../composables/useDependencies.js';
 import { useScenarios } from '../composables/useScenarios.js';
 import { parseFeature } from '../gherkin/parser.js';
-import { mapFeatureToForm, getEffectiveSetup } from '../gherkin/formMapper.js';
+import { mapFeatureToForm, getEffectiveSetup, formStateToGherkin } from '../gherkin/formMapper.js';
 import { matchStatus } from '../utils/outputFormat.js';
 import { buildArticleMap } from '../utils/articleMapping.js';
 import ScenarioForm from './ScenarioForm.vue';
@@ -37,10 +37,14 @@ const {
   selectedScenario: selectedScenarioFile,
   featureText,
   loading: scenariosLoading,
+  saving,
+  saveError,
   selectScenario: selectScenarioFile,
+  saveScenario,
 } = useScenarios(lawIdRef);
 
 const formState = ref(null);
+const saveSuccess = ref(false);
 
 // Parse feature file when loaded
 watch(featureText, (text) => {
@@ -204,24 +208,54 @@ function onScenarioFileSelect(event) {
   const filename = event.target.value;
   if (filename) selectScenarioFile(filename);
 }
+
+async function onSave() {
+  if (!formState.value || !selectedScenarioFile.value) return;
+
+  saveSuccess.value = false;
+  try {
+    const gherkin = formStateToGherkin(formState.value);
+    await saveScenario(selectedScenarioFile.value, gherkin);
+    saveSuccess.value = true;
+    setTimeout(() => { saveSuccess.value = false; }, 3000);
+  } catch {
+    // saveError is already set by the composable
+  }
+}
 </script>
 
 <template>
   <div class="sb-container">
     <div class="sb-scroll">
-      <!-- Feature file selector -->
-      <div class="sb-section" v-if="scenarioFiles.length > 1 || scenariosLoading">
+      <!-- Feature file selector + save button -->
+      <div class="sb-section sb-toolbar" v-if="scenarioFiles.length > 0 || scenariosLoading">
         <div v-if="scenariosLoading" class="sb-loading">Scenario's laden...</div>
-        <select
-          v-else
-          class="sb-select"
-          :value="selectedScenarioFile"
-          @change="onScenarioFileSelect"
-        >
-          <option v-for="sf in scenarioFiles" :key="sf.filename" :value="sf.filename">
-            {{ sf.filename }}
-          </option>
-        </select>
+        <template v-else>
+          <select
+            v-if="scenarioFiles.length > 1"
+            class="sb-select"
+            :value="selectedScenarioFile"
+            @change="onScenarioFileSelect"
+          >
+            <option v-for="sf in scenarioFiles" :key="sf.filename" :value="sf.filename">
+              {{ sf.filename }}
+            </option>
+          </select>
+          <button
+            v-if="formState"
+            class="sb-save-btn"
+            :disabled="saving"
+            @click="onSave"
+          >
+            {{ saving ? 'Opslaan...' : 'Opslaan' }}
+          </button>
+        </template>
+      </div>
+
+      <!-- Save feedback -->
+      <div v-if="saveSuccess" class="sb-section sb-save-success">Opgeslagen</div>
+      <div v-if="saveError" class="sb-section sb-error">
+        Opslaan mislukt: {{ saveError.message || saveError }}
       </div>
 
       <!-- Dependencies loading -->
@@ -292,6 +326,12 @@ function onScenarioFileSelect(event) {
   border-bottom: 1px solid var(--semantics-dividers-color, #E0E3E8);
 }
 
+.sb-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .sb-section-title {
   font-weight: 600;
   font-size: 13px;
@@ -300,13 +340,34 @@ function onScenarioFileSelect(event) {
 }
 
 .sb-select {
-  width: 100%;
+  flex: 1;
   padding: 6px 8px;
   border: 1px solid var(--semantics-dividers-color, #E0E3E8);
   border-radius: 6px;
   font-size: 13px;
   font-family: var(--primitives-font-family-body, 'RijksSansVF', sans-serif);
   background: white;
+}
+
+.sb-save-btn {
+  padding: 6px 14px;
+  border: 1px solid var(--semantics-dividers-color, #E0E3E8);
+  border-radius: 6px;
+  font-size: 13px;
+  font-family: var(--rr-font-family-body, 'RijksSansVF', sans-serif);
+  background: var(--semantics-surfaces-color-primary, white);
+  color: var(--semantics-text-color-primary, #1C2029);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.sb-save-btn:hover:not(:disabled) {
+  background: var(--semantics-surfaces-color-secondary, #F8F9FA);
+}
+
+.sb-save-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 .sb-loading {
@@ -322,6 +383,12 @@ function onScenarioFileSelect(event) {
 .sb-error {
   background: #fee;
   color: #c00;
+  font-size: 13px;
+}
+
+.sb-save-success {
+  background: #efe;
+  color: #060;
   font-size: 13px;
 }
 

--- a/frontend/src/components/ScenarioBuilder.vue
+++ b/frontend/src/components/ScenarioBuilder.vue
@@ -363,7 +363,7 @@ async function onSave() {
   border: 1px solid var(--semantics-dividers-color, #E0E3E8);
   border-radius: 6px;
   font-size: 13px;
-  font-family: var(--rr-font-family-body, 'RijksSansVF', sans-serif);
+  font-family: var(--primitives-font-family-body, 'RijksSansVF', sans-serif);
   background: var(--semantics-surfaces-color-primary, white);
   color: var(--semantics-text-color-primary, #1C2029);
   cursor: pointer;

--- a/frontend/src/components/ScenarioForm.vue
+++ b/frontend/src/components/ScenarioForm.vue
@@ -143,6 +143,10 @@ function execute() {
     }
   } finally {
     running.value = false;
+    // Always emit so the parent's result panel reflects the latest state,
+    // including the error path: getExecutionData() returns the error and
+    // any partial trace, which the parent renders instead of stale data
+    // from a previous successful run.
     emit('executed', getExecutionData());
   }
 }

--- a/frontend/src/components/ScenarioForm.vue
+++ b/frontend/src/components/ScenarioForm.vue
@@ -19,7 +19,7 @@ const props = defineProps({
   articleMap: { type: Object, default: null },
 });
 
-const emit = defineEmits(['show-details']);
+const emit = defineEmits(['show-details', 'executed']);
 
 // --- Form state (initialized from scenario setup) ---
 const calculationDate = ref(props.setup.calculationDate || new Date().toISOString().slice(0, 10));
@@ -143,6 +143,7 @@ function execute() {
     }
   } finally {
     running.value = false;
+    emit('executed', getExecutionData());
   }
 }
 
@@ -157,6 +158,18 @@ function getExecutionData() {
 }
 
 defineExpose({ execute, getExecutionData });
+
+// --- Auto-re-execute when input values change ---
+let executeTimer = null;
+watch(
+  [parameterValues, calculationDate, dataSources],
+  () => {
+    if (!props.engine || !props.ready) return;
+    clearTimeout(executeTimer);
+    executeTimer = setTimeout(() => execute(), 300);
+  },
+  { deep: true },
+);
 
 function updateDataSourceRows(index, rows) {
   const updated = [...dataSources.value];

--- a/frontend/src/components/ScenarioForm.vue
+++ b/frontend/src/components/ScenarioForm.vue
@@ -161,12 +161,14 @@ function getExecutionData() {
   };
 }
 
-/** Returns the current form input values for syncing back to formState */
+/** Returns the current form input values for syncing back to formState.
+ *  All collections are returned as fresh shallow copies so a caller cannot
+ *  accidentally mutate the component's reactive form state. */
 function getFormValues() {
   return {
     parameterValues: { ...parameterValues.value },
     calculationDate: calculationDate.value,
-    dataSources: dataSources.value,
+    dataSources: [...dataSources.value],
   };
 }
 

--- a/frontend/src/components/ScenarioForm.vue
+++ b/frontend/src/components/ScenarioForm.vue
@@ -157,7 +157,16 @@ function getExecutionData() {
   };
 }
 
-defineExpose({ execute, getExecutionData });
+/** Returns the current form input values for syncing back to formState */
+function getFormValues() {
+  return {
+    parameterValues: { ...parameterValues.value },
+    calculationDate: calculationDate.value,
+    dataSources: dataSources.value,
+  };
+}
+
+defineExpose({ execute, getExecutionData, getFormValues });
 
 // --- Auto-re-execute when input values change ---
 let executeTimer = null;

--- a/frontend/src/components/ScenarioForm.vue
+++ b/frontend/src/components/ScenarioForm.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed, watch } from 'vue';
+import { ref, computed, watch, onBeforeUnmount } from 'vue';
 import { parseValue } from '../gherkin/steps.js';
 import { formatValue, formatOutputValue, normalizeForCompare, matchStatus as _matchStatus } from '../utils/outputFormat.js';
 import DataSourceTable from './DataSourceTable.vue';
@@ -179,6 +179,10 @@ watch(
   },
   { deep: true },
 );
+
+onBeforeUnmount(() => {
+  clearTimeout(executeTimer);
+});
 
 function updateDataSourceRows(index, rows) {
   const updated = [...dataSources.value];

--- a/frontend/src/components/ScenarioGherkin.vue
+++ b/frontend/src/components/ScenarioGherkin.vue
@@ -256,7 +256,7 @@ function stepIcon(status) {
   border: 1px solid var(--semantics-dividers-color, #E0E3E8);
   border-radius: 6px;
   font-size: 13px;
-  font-family: var(--rr-font-family-body, 'RijksSansVF', sans-serif);
+  font-family: var(--primitives-font-family-body, 'RijksSansVF', sans-serif);
   background: white;
   color: var(--semantics-text-color-primary, #1C2029);
   cursor: pointer;

--- a/frontend/src/components/ScenarioGherkin.vue
+++ b/frontend/src/components/ScenarioGherkin.vue
@@ -20,13 +20,17 @@ const {
   selectedScenario,
   featureText,
   loading: scenariosLoading,
+  saving,
+  saveError,
   selectScenario,
+  saveScenario,
 } = useScenarios(lawIdRef);
 
 const results = ref(null);
 const running = ref(false);
 const runError = ref(null);
 const viewMode = ref('visual');
+const saveSuccess = ref(false);
 
 function onScenarioSelect(event) {
   const filename = event.target.value;
@@ -61,6 +65,19 @@ const formState = computed(() => {
     return null;
   }
 });
+
+async function onSave() {
+  if (!selectedScenario.value || !featureText.value) return;
+
+  saveSuccess.value = false;
+  try {
+    await saveScenario(selectedScenario.value, featureText.value);
+    saveSuccess.value = true;
+    setTimeout(() => { saveSuccess.value = false; }, 3000);
+  } catch {
+    // saveError is already set by the composable
+  }
+}
 
 const summary = computed(() => {
   if (!results.value) return null;
@@ -103,12 +120,26 @@ function stepIcon(status) {
       </select>
 
       <button
+        class="scenario-save-btn"
+        @click="onSave"
+        :disabled="saving || !featureText || !selectedScenario"
+      >
+        {{ saving ? 'Opslaan...' : 'Opslaan' }}
+      </button>
+
+      <button
         class="scenario-run-btn"
         @click="runScenarios"
         :disabled="!ready || running || !featureText"
       >
         {{ running ? 'Bezig...' : 'Run \u25B6' }}
       </button>
+    </div>
+
+    <!-- Save feedback -->
+    <div v-if="saveSuccess" class="scenario-save-success">Opgeslagen</div>
+    <div v-if="saveError" class="scenario-error">
+      Opslaan mislukt: {{ saveError.message || saveError }}
     </div>
 
     <!-- View mode toggle -->
@@ -218,6 +249,33 @@ function stepIcon(status) {
   border-radius: 6px;
   font-size: 13px;
   background: white;
+}
+
+.scenario-save-btn {
+  padding: 6px 14px;
+  border: 1px solid var(--semantics-dividers-color, #E0E3E8);
+  border-radius: 6px;
+  font-size: 13px;
+  font-family: var(--rr-font-family-body, 'RijksSansVF', sans-serif);
+  background: white;
+  color: var(--semantics-text-color-primary, #1C2029);
+  cursor: pointer;
+  white-space: nowrap;
+}
+.scenario-save-btn:hover:not(:disabled) {
+  background: var(--semantics-surfaces-color-secondary, #F8F9FA);
+}
+.scenario-save-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.scenario-save-success {
+  padding: 8px 16px;
+  background: #efe;
+  color: #060;
+  font-size: 13px;
+  border-bottom: 1px solid var(--semantics-dividers-color, #E0E3E8);
 }
 
 .scenario-run-btn {

--- a/frontend/src/composables/useScenarios.js
+++ b/frontend/src/composables/useScenarios.js
@@ -42,6 +42,7 @@ export function useScenarios(lawId) {
 
   async function selectScenario(filename) {
     selectedScenario.value = filename;
+    saveError.value = null;
 
     try {
       const res = await fetch(

--- a/frontend/src/composables/useScenarios.js
+++ b/frontend/src/composables/useScenarios.js
@@ -1,5 +1,5 @@
 /**
- * useScenarios — fetch and manage scenario files for a law.
+ * useScenarios — fetch, manage, and save scenario files for a law.
  */
 import { ref, watch } from 'vue';
 
@@ -8,7 +8,9 @@ export function useScenarios(lawId) {
   const selectedScenario = ref(null);
   const featureText = ref('');
   const loading = ref(false);
+  const saving = ref(false);
   const error = ref(null);
+  const saveError = ref(null);
 
   async function fetchScenarios() {
     if (!lawId.value) return;
@@ -54,6 +56,41 @@ export function useScenarios(lawId) {
     }
   }
 
+  /**
+   * Save scenario content to the backend via PUT.
+   *
+   * @param {string} filename - Scenario filename (e.g. "eligibility.feature")
+   * @param {string} content - Gherkin feature text
+   */
+  async function saveScenario(filename, content) {
+    if (!lawId.value) return;
+
+    saving.value = true;
+    saveError.value = null;
+
+    try {
+      const res = await fetch(
+        `/api/corpus/laws/${encodeURIComponent(lawId.value)}/scenarios/${encodeURIComponent(filename)}`,
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+          body: content,
+        },
+      );
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(text || `Save failed: ${res.status}`);
+      }
+      // Update local state with saved content
+      featureText.value = content;
+    } catch (e) {
+      saveError.value = e;
+      throw e;
+    } finally {
+      saving.value = false;
+    }
+  }
+
   // Re-fetch when lawId changes
   watch(lawId, () => {
     selectedScenario.value = null;
@@ -66,8 +103,11 @@ export function useScenarios(lawId) {
     selectedScenario,
     featureText,
     loading,
+    saving,
     error,
+    saveError,
     selectScenario,
     fetchScenarios,
+    saveScenario,
   };
 }

--- a/frontend/src/composables/useScenarios.js
+++ b/frontend/src/composables/useScenarios.js
@@ -17,6 +17,9 @@ export function useScenarios(lawId) {
 
     loading.value = true;
     error.value = null;
+    // Drop any stale save error from a previously selected law so the
+    // banner does not linger after navigating to a different law.
+    saveError.value = null;
 
     try {
       const res = await fetch(

--- a/frontend/src/gherkin/formMapper.js
+++ b/frontend/src/gherkin/formMapper.js
@@ -251,23 +251,65 @@ export function getEffectiveSetup(formState, scenarioIndex) {
 }
 
 /**
+ * Convert a DataSourceTable form-format data source to the formState format.
+ *
+ * Form format: `{ sourceName, keyField, fields: [{name, type}], rows: [{_id, [h]: v}] }`
+ * State format: `{ sourceName, keyField, headers: string[], rows: string[][] }`
+ */
+function formDataSourceToState(ds) {
+  const headers = [ds.keyField, ...(ds.fields || []).map((f) => f.name)];
+  const rows = (ds.rows || []).map((row) =>
+    headers.map((h) => {
+      const v = row[h];
+      return v === undefined || v === null ? '' : String(v);
+    }),
+  );
+  return { sourceName: ds.sourceName, keyField: ds.keyField, headers, rows };
+}
+
+/** Deep equality check for two state-format data sources. */
+function dataSourcesEqual(a, b) {
+  if (!a || !b) return false;
+  if (a.sourceName !== b.sourceName || a.keyField !== b.keyField) return false;
+  if ((a.headers || []).length !== (b.headers || []).length) return false;
+  for (let i = 0; i < a.headers.length; i++) {
+    if (a.headers[i] !== b.headers[i]) return false;
+  }
+  if ((a.rows || []).length !== (b.rows || []).length) return false;
+  for (let i = 0; i < a.rows.length; i++) {
+    const ra = a.rows[i];
+    const rb = b.rows[i];
+    if (ra.length !== rb.length) return false;
+    for (let j = 0; j < ra.length; j++) {
+      if (String(ra[j]) !== String(rb[j])) return false;
+    }
+  }
+  return true;
+}
+
+/**
  * Sync edited form values back into formState for a given scenario.
  *
  * Parameters that exist in the scenario's own setup are updated in-place.
  * Background-only parameters that were changed get added as scenario-level
- * overrides so other scenarios are not affected.
+ * overrides so other scenarios are not affected. Scenario-level overrides
+ * that end up matching the background value are removed so the Gherkin
+ * round-trip does not accumulate redundant `Given parameter ...` steps.
+ *
+ * Data sources follow the same rule: scenario-level overrides exist only
+ * when they differ from the background source with the same name.
  *
  * @param {object} formState - Mutable form state
  * @param {number} scenarioIndex - Which scenario was edited
- * @param {object} values - { parameterValues, calculationDate }
+ * @param {object} values - { parameterValues, calculationDate, dataSources }
  */
 export function syncEditedValues(formState, scenarioIndex, values) {
   const scenario = formState.scenarios[scenarioIndex];
   if (!scenario) return;
 
-  const { parameterValues, calculationDate } = values;
+  const { parameterValues, calculationDate, dataSources } = values;
 
-  // Build lookup of scenario-level param names for fast check
+  // --- Parameters ---
   const scenarioParamMap = new Map(
     scenario.setup.parameters.map((p, i) => [p.name, i]),
   );
@@ -289,11 +331,53 @@ export function syncEditedValues(formState, scenarioIndex, values) {
     }
   }
 
+  // Drop scenario-level overrides that now match the background — otherwise
+  // a save/edit/save cycle accumulates redundant `Given parameter ...` steps.
+  scenario.setup.parameters = scenario.setup.parameters.filter((p) => {
+    if (!bgParamMap.has(p.name)) return true;
+    return String(bgParamMap.get(p.name).value) !== String(p.value);
+  });
+
+  // --- Data sources ---
+  if (Array.isArray(dataSources)) {
+    const bgDataSources = formState.background?.dataSources || [];
+    const bgDsMap = new Map(bgDataSources.map((ds) => [ds.sourceName, ds]));
+    const scenarioDsMap = new Map(
+      scenario.setup.dataSources.map((ds, i) => [ds.sourceName, i]),
+    );
+
+    for (const formDs of dataSources) {
+      const stateDs = formDataSourceToState(formDs);
+
+      if (scenarioDsMap.has(stateDs.sourceName)) {
+        // Update existing scenario-level data source in place
+        scenario.setup.dataSources[scenarioDsMap.get(stateDs.sourceName)] = stateDs;
+      } else if (bgDsMap.has(stateDs.sourceName)) {
+        // Background data source — add scenario override only if it differs
+        if (!dataSourcesEqual(bgDsMap.get(stateDs.sourceName), stateDs)) {
+          scenario.setup.dataSources.push(stateDs);
+        }
+      } else {
+        // Wholly new data source — add at scenario level
+        scenario.setup.dataSources.push(stateDs);
+      }
+    }
+
+    // Drop scenario-level data sources that now match the background.
+    scenario.setup.dataSources = scenario.setup.dataSources.filter((ds) => {
+      const bg = bgDsMap.get(ds.sourceName);
+      return !bg || !dataSourcesEqual(bg, ds);
+    });
+  }
+
   // Sync calculation date (scenario-level override)
   if (calculationDate) {
     const bgDate = formState.background?.calculationDate || null;
     if (calculationDate !== bgDate) {
       scenario.setup.calculationDate = calculationDate;
+    } else {
+      // Match the background — drop the scenario-level override.
+      scenario.setup.calculationDate = null;
     }
   }
 }

--- a/frontend/src/gherkin/formMapper.js
+++ b/frontend/src/gherkin/formMapper.js
@@ -250,6 +250,54 @@ export function getEffectiveSetup(formState, scenarioIndex) {
   };
 }
 
+/**
+ * Sync edited form values back into formState for a given scenario.
+ *
+ * Parameters that exist in the scenario's own setup are updated in-place.
+ * Background-only parameters that were changed get added as scenario-level
+ * overrides so other scenarios are not affected.
+ *
+ * @param {object} formState - Mutable form state
+ * @param {number} scenarioIndex - Which scenario was edited
+ * @param {object} values - { parameterValues, calculationDate }
+ */
+export function syncEditedValues(formState, scenarioIndex, values) {
+  const scenario = formState.scenarios[scenarioIndex];
+  if (!scenario) return;
+
+  const { parameterValues, calculationDate } = values;
+
+  // Build lookup of scenario-level param names for fast check
+  const scenarioParamMap = new Map(
+    scenario.setup.parameters.map((p, i) => [p.name, i]),
+  );
+  const bgParams = formState.background?.parameters || [];
+  const bgParamMap = new Map(bgParams.map((p) => [p.name, p]));
+
+  for (const [name, rawValue] of Object.entries(parameterValues)) {
+    const value = parseValue(rawValue);
+
+    if (scenarioParamMap.has(name)) {
+      // Update existing scenario-level parameter
+      scenario.setup.parameters[scenarioParamMap.get(name)].value = value;
+    } else if (bgParamMap.has(name)) {
+      // Background param — add scenario override only if value differs
+      const bgValue = bgParamMap.get(name).value;
+      if (String(bgValue) !== String(value)) {
+        scenario.setup.parameters.push({ name, value });
+      }
+    }
+  }
+
+  // Sync calculation date (scenario-level override)
+  if (calculationDate) {
+    const bgDate = formState.background?.calculationDate || null;
+    if (calculationDate !== bgDate) {
+      scenario.setup.calculationDate = calculationDate;
+    }
+  }
+}
+
 // --- Reverse: Form State → Gherkin text ---
 
 function formatCell(value) {

--- a/frontend/src/gherkin/formMapper.js
+++ b/frontend/src/gherkin/formMapper.js
@@ -370,14 +370,19 @@ export function syncEditedValues(formState, scenarioIndex, values) {
     });
   }
 
-  // Sync calculation date (scenario-level override)
-  if (calculationDate) {
+  // Sync calculation date (scenario-level override).
+  // Treat `null`, `undefined` and `""` as "user cleared the field" so that
+  // a clear is not silently dropped — otherwise the next save would write
+  // the stale date back to the .feature file.
+  if (calculationDate !== undefined) {
+    const cleared = calculationDate === null || calculationDate === '';
     const bgDate = formState.background?.calculationDate || null;
-    if (calculationDate !== bgDate) {
-      scenario.setup.calculationDate = calculationDate;
-    } else {
-      // Match the background — drop the scenario-level override.
+    if (cleared || calculationDate === bgDate) {
+      // Either the user cleared the field, or it now matches the background:
+      // in both cases the scenario-level override should disappear.
       scenario.setup.calculationDate = null;
+    } else {
+      scenario.setup.calculationDate = calculationDate;
     }
   }
 }

--- a/frontend/src/gherkin/formMapper.test.js
+++ b/frontend/src/gherkin/formMapper.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { parseFeature } from './parser.js';
-import { mapFeatureToForm, getEffectiveSetup, formStateToGherkin } from './formMapper.js';
+import { mapFeatureToForm, getEffectiveSetup, formStateToGherkin, syncEditedValues } from './formMapper.js';
 
 describe('mapFeatureToForm', () => {
   it('maps a simple scenario with date, evaluate, and assertions', () => {
@@ -284,5 +284,86 @@ describe('formStateToGherkin round-trip', () => {
     expect(reformatted.scenarios[0].setup.dataSources).toHaveLength(1);
     expect(reformatted.scenarios[0].setup.dataSources[0].sourceName).toBe('personal_data');
     expect(reformatted.scenarios[0].setup.dataSources[0].keyField).toBe('bsn');
+  });
+});
+
+describe('syncEditedValues', () => {
+  it('updates scenario-level parameter values', () => {
+    const parsed = parseFeature(`
+Feature: Sync test
+
+  Scenario: Test
+    Given parameter "loon" is 30000
+    When I evaluate "result" of "law"
+    Then output "result" is true
+`);
+
+    const form = mapFeatureToForm(parsed);
+    syncEditedValues(form, 0, {
+      parameterValues: { loon: '50000' },
+      calculationDate: null,
+    });
+
+    expect(form.scenarios[0].setup.parameters[0].value).toBe(50000);
+
+    const gherkin = formStateToGherkin(form);
+    expect(gherkin).toContain('parameter "loon" is 50000');
+    expect(gherkin).not.toContain('30000');
+  });
+
+  it('adds scenario override when background parameter is changed', () => {
+    const parsed = parseFeature(`
+Feature: Background override
+
+  Background:
+    Given parameter "bsn" is "999993653"
+    Given parameter "loon" is 30000
+
+  Scenario: First
+    When I evaluate "result" of "law"
+
+  Scenario: Second
+    When I evaluate "result" of "law"
+`);
+
+    const form = mapFeatureToForm(parsed);
+
+    // Change loon only in the first scenario
+    syncEditedValues(form, 0, {
+      parameterValues: { bsn: '999993653', loon: '50000' },
+      calculationDate: null,
+    });
+
+    // First scenario should have an override
+    expect(form.scenarios[0].setup.parameters).toEqual([
+      { name: 'loon', value: 50000 },
+    ]);
+
+    // Background should be unchanged
+    expect(form.background.parameters[1].value).toBe(30000);
+
+    // Second scenario should still have no overrides
+    expect(form.scenarios[1].setup.parameters).toHaveLength(0);
+  });
+
+  it('does not add override when value matches background', () => {
+    const parsed = parseFeature(`
+Feature: No-op sync
+
+  Background:
+    Given parameter "bsn" is "999993653"
+
+  Scenario: Test
+    When I evaluate "result" of "law"
+`);
+
+    const form = mapFeatureToForm(parsed);
+    syncEditedValues(form, 0, {
+      parameterValues: { bsn: '999993653' },
+      calculationDate: null,
+    });
+
+    // No scenario-level override should be added
+    expect(form.scenarios[0].setup.parameters).toHaveLength(0);
   });
 });

--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -3656,6 +3656,7 @@ dependencies = [
 name = "regelrecht-corpus"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "regelrecht-engine",
  "reqwest 0.13.2",
  "serde",

--- a/packages/corpus/Cargo.toml
+++ b/packages/corpus/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["law", "legal", "corpus", "dutch", "regelrecht"]
 categories = ["development-tools"]
 
 [dependencies]
+async-trait = "0.1"
 tokio = { version = "1", features = ["process", "fs"] }
 tracing = "0.1"
 thiserror = "2.0"

--- a/packages/corpus/src/backend.rs
+++ b/packages/corpus/src/backend.rs
@@ -183,7 +183,16 @@ impl RepoBackend for LocalBackend {
             let probe = self.root.join(".write-probe");
             match tokio::fs::write(&probe, b"").await {
                 Ok(()) => {
-                    let _ = tokio::fs::remove_file(&probe).await;
+                    if let Err(e) = tokio::fs::remove_file(&probe).await {
+                        // The write succeeded but cleanup failed — leave a
+                        // visible warning rather than silently leaving a
+                        // .write-probe file behind in the source root.
+                        tracing::warn!(
+                            path = %probe.display(),
+                            error = %e,
+                            "failed to remove write probe file after success"
+                        );
+                    }
                 }
                 Err(_) => {
                     tracing::info!(

--- a/packages/corpus/src/backend.rs
+++ b/packages/corpus/src/backend.rs
@@ -188,6 +188,10 @@ impl RepoBackend for LocalBackend {
 // ---------------------------------------------------------------------------
 
 /// Backend that reads/writes to a local git checkout and commits/pushes on persist.
+///
+/// When no push token is configured (`local_only` mode), edits are committed
+/// to a local session branch without pushing. This is useful for playground
+/// environments where users want to experiment without affecting the remote.
 pub struct GitBackend {
     client: CorpusClient,
     /// Sub-path within the repo that corresponds to the source root
@@ -195,14 +199,33 @@ pub struct GitBackend {
     repo_subpath: Option<String>,
     /// Files written since the last persist, as absolute paths.
     dirty_files: tokio::sync::Mutex<Vec<PathBuf>>,
+    /// When true, commits stay local (no push). Set when no push token is available.
+    local_only: bool,
+    /// Name of the local session branch (created on first persist).
+    session_branch: Option<String>,
+    /// Whether the session branch has been created yet.
+    branched: tokio::sync::Mutex<bool>,
 }
 
 impl GitBackend {
     pub fn new(client: CorpusClient, repo_subpath: Option<String>) -> Self {
+        let local_only = !client.has_push_token();
+        let session_branch = if local_only {
+            let ts = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+            Some(format!("editor/session-{ts}"))
+        } else {
+            None
+        };
         Self {
             client,
             repo_subpath,
             dirty_files: tokio::sync::Mutex::new(Vec::new()),
+            local_only,
+            session_branch,
+            branched: tokio::sync::Mutex::new(false),
         }
     }
 
@@ -292,14 +315,29 @@ impl RepoBackend for GitBackend {
             return Ok(());
         }
 
-        match self.client.commit_and_push(&paths, &ctx.message).await {
-            Ok(()) => Ok(()),
-            Err(e) => {
-                // Restore dirty files so the next persist attempt can retry.
-                self.dirty_files.lock().await.extend(paths);
-                Err(e)
+        let result = if self.local_only {
+            // Create session branch on first persist
+            {
+                let mut branched = self.branched.lock().await;
+                if !*branched {
+                    if let Some(branch) = &self.session_branch {
+                        self.client.create_local_branch(branch).await?;
+                    }
+                    *branched = true;
+                }
             }
+            self.client.commit_local(&paths, &ctx.message).await
+        } else {
+            self.client.commit_and_push(&paths, &ctx.message).await
+        };
+
+        if let Err(e) = result {
+            // Restore dirty files so the next persist attempt can retry.
+            self.dirty_files.lock().await.extend(paths);
+            return Err(e);
         }
+
+        Ok(())
     }
 
     async fn ensure_ready(&mut self) -> Result<()> {
@@ -447,5 +485,97 @@ mod tests {
         let mut backend = LocalBackend::new(PathBuf::from("/nonexistent/path"), true);
         let result = backend.ensure_ready().await;
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn git_local_only_commits_without_push() {
+        use tokio::process::Command;
+
+        // Set up a bare repo
+        let dir = TempDir::new().unwrap();
+        let bare_path = dir.path().join("bare.git");
+        Command::new("git")
+            .args(["init", "--bare", "--initial-branch=development"])
+            .arg(&bare_path)
+            .output()
+            .await
+            .unwrap();
+        let bare_url = format!("file://{}", bare_path.display());
+
+        // Push an initial commit
+        let tmp_clone = dir.path().join("tmp-clone");
+        Command::new("git")
+            .args(["clone", &bare_url])
+            .arg(&tmp_clone)
+            .output()
+            .await
+            .unwrap();
+        for args in [
+            vec!["config", "user.name", "test"],
+            vec!["config", "user.email", "test@test.nl"],
+            vec!["commit", "--allow-empty", "-m", "init"],
+            vec!["push", "origin", "development"],
+        ] {
+            Command::new("git")
+                .args(&args)
+                .current_dir(&tmp_clone)
+                .output()
+                .await
+                .unwrap();
+        }
+
+        // Create a GitBackend without a token (local_only mode)
+        let repo_path = dir.path().join("editor-repo");
+        let config = CorpusConfig::new(&bare_url, &repo_path);
+        // No .with_token() — triggers local_only
+        let client = CorpusClient::new(config);
+        let mut backend = GitBackend::new(client, None);
+        assert!(backend.local_only);
+
+        backend.ensure_ready().await.unwrap();
+
+        // Write and persist
+        backend
+            .write_file(Path::new("test.feature"), "Feature: Test\n")
+            .await
+            .unwrap();
+        backend
+            .persist(&WriteContext {
+                message: "add test scenario".to_string(),
+            })
+            .await
+            .unwrap();
+
+        // Verify local commit exists on a session branch
+        let branch = Command::new("git")
+            .args(["branch", "--show-current"])
+            .current_dir(&repo_path)
+            .output()
+            .await
+            .unwrap();
+        let branch_str = String::from_utf8_lossy(&branch.stdout);
+        assert!(
+            branch_str.trim().starts_with("editor/session-"),
+            "expected session branch, got: {branch_str}"
+        );
+
+        let log = Command::new("git")
+            .args(["log", "--oneline", "-1"])
+            .current_dir(&repo_path)
+            .output()
+            .await
+            .unwrap();
+        let log_str = String::from_utf8_lossy(&log.stdout);
+        assert!(log_str.contains("add test scenario"));
+
+        // Verify NOT pushed
+        let remote_log = Command::new("git")
+            .args(["log", "--oneline", "--all"])
+            .current_dir(&bare_path)
+            .output()
+            .await
+            .unwrap();
+        let remote_str = String::from_utf8_lossy(&remote_log.stdout);
+        assert!(!remote_str.contains("add test scenario"));
     }
 }

--- a/packages/corpus/src/backend.rs
+++ b/packages/corpus/src/backend.rs
@@ -298,6 +298,12 @@ impl RepoBackend for GitBackend {
                 self.dirty_files.lock().await.push(abs);
                 Ok(())
             }
+            // Deleting a file that doesn't exist is intentionally a no-op
+            // and does NOT enqueue anything onto `dirty_files`. Callers
+            // typically follow up with `persist`, which short-circuits on
+            // an empty dirty set — so the overall flow stays an idempotent
+            // no-op (no spurious empty commit, no push) when the target
+            // was already gone.
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
             Err(e) => Err(e.into()),
         }

--- a/packages/corpus/src/backend.rs
+++ b/packages/corpus/src/backend.rs
@@ -154,6 +154,26 @@ impl RepoBackend for LocalBackend {
                 self.root.display()
             )));
         }
+
+        // Probe write access: try creating and removing a temporary file.
+        // If the filesystem is read-only (e.g. inside a container), downgrade
+        // to read-only mode rather than failing at save time.
+        if self.writable {
+            let probe = self.root.join(".write-probe");
+            match tokio::fs::write(&probe, b"").await {
+                Ok(()) => {
+                    let _ = tokio::fs::remove_file(&probe).await;
+                }
+                Err(_) => {
+                    tracing::info!(
+                        path = %self.root.display(),
+                        "local source is not writable, disabling writes"
+                    );
+                    self.writable = false;
+                }
+            }
+        }
+
         Ok(())
     }
 

--- a/packages/corpus/src/backend.rs
+++ b/packages/corpus/src/backend.rs
@@ -391,12 +391,22 @@ impl RepoBackend for GitBackend {
 /// Create a [`RepoBackend`] for a given corpus source.
 ///
 /// For GitHub sources, an optional authentication token can be provided.
+///
+/// The on-disk checkout path is namespaced by the host identifier
+/// (`HOSTNAME` env var, falling back to `"local"`) so that multiple replicas
+/// of the editor running on the same node — or a pod restart racing with a
+/// previous instance — do not share a working directory and corrupt each
+/// other's git state during concurrent `clone`/`pull --rebase`/`push`.
 pub fn create_backend(source: &Source, auth_token: Option<&str>) -> Result<Box<dyn RepoBackend>> {
     match &source.source_type {
         SourceType::Local { local } => Ok(Box::new(LocalBackend::new(local.path.clone(), true))),
         SourceType::GitHub { github } => {
             let repo_url = format!("https://github.com/{}/{}.git", github.owner, github.repo);
-            let repo_path = std::env::temp_dir().join("corpus-editor").join(&source.id);
+            let host_id = std::env::var("HOSTNAME").unwrap_or_else(|_| "local".to_string());
+            let repo_path = std::env::temp_dir()
+                .join("corpus-editor")
+                .join(&host_id)
+                .join(&source.id);
             let mut config = CorpusConfig::new(&repo_url, &repo_path);
             config.branch = github.effective_ref().to_string();
 

--- a/packages/corpus/src/backend.rs
+++ b/packages/corpus/src/backend.rs
@@ -57,20 +57,84 @@ pub trait RepoBackend: Send + Sync {
 // ---------------------------------------------------------------------------
 
 /// Backend that reads/writes directly to the local filesystem.
+///
+/// When the configured `root` is on a read-only filesystem (typical for a
+/// corpus baked into a container image), [`ensure_ready`] transparently
+/// rehomes the backend onto an **ephemeral scratch copy** under
+/// `$TMPDIR/regelrecht-editor-corpus/<host>/<source_id>` and operates on
+/// that copy from then on. Edits survive for the lifetime of the process
+/// but are lost on the next deployment — by design.
 pub struct LocalBackend {
+    /// Stable identifier of the source this backend belongs to. Used to
+    /// namespace the scratch directory so multiple local sources do not
+    /// collide on the same node.
+    source_id: String,
     root: PathBuf,
     writable: bool,
 }
 
 impl LocalBackend {
-    pub fn new(root: PathBuf, writable: bool) -> Self {
-        Self { root, writable }
+    pub fn new(source_id: String, root: PathBuf, writable: bool) -> Self {
+        Self {
+            source_id,
+            root,
+            writable,
+        }
     }
 
     fn resolve(&self, relative: &Path) -> Result<PathBuf> {
         validate_relative_path(relative)?;
         Ok(self.root.join(relative))
     }
+}
+
+/// Probe whether a directory accepts writes by creating and removing a
+/// short-lived sentinel file. Returns `false` on any IO error.
+async fn probe_writable(dir: &Path) -> bool {
+    let probe = dir.join(".write-probe");
+    match tokio::fs::write(&probe, b"").await {
+        Ok(()) => {
+            if let Err(e) = tokio::fs::remove_file(&probe).await {
+                tracing::warn!(
+                    path = %probe.display(),
+                    error = %e,
+                    "failed to remove write probe file after success"
+                );
+            }
+            true
+        }
+        Err(_) => false,
+    }
+}
+
+/// Recursively copy a directory tree.
+///
+/// Uses [`walkdir::WalkDir`] for traversal and `std::fs` for the file ops;
+/// callers should wrap in [`tokio::task::spawn_blocking`] to avoid stalling
+/// the runtime on a large corpus.
+fn copy_dir_recursive_sync(src: &Path, dst: &Path) -> std::io::Result<()> {
+    if !dst.exists() {
+        std::fs::create_dir_all(dst)?;
+    }
+    for entry in walkdir::WalkDir::new(src)
+        .into_iter()
+        .filter_map(|e| e.ok())
+    {
+        let path = entry.path();
+        let Ok(rel) = path.strip_prefix(src) else {
+            continue;
+        };
+        let target = dst.join(rel);
+        if entry.file_type().is_dir() {
+            std::fs::create_dir_all(&target)?;
+        } else if entry.file_type().is_file() {
+            if let Some(parent) = target.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            std::fs::copy(path, &target)?;
+        }
+    }
+    Ok(())
 }
 
 /// Reject paths that are absolute or contain `..` components.
@@ -176,31 +240,80 @@ impl RepoBackend for LocalBackend {
             )));
         }
 
-        // Probe write access: try creating and removing a temporary file.
-        // If the filesystem is read-only (e.g. inside a container), downgrade
-        // to read-only mode rather than failing at save time.
-        if self.writable {
-            let probe = self.root.join(".write-probe");
-            match tokio::fs::write(&probe, b"").await {
-                Ok(()) => {
-                    if let Err(e) = tokio::fs::remove_file(&probe).await {
-                        // The write succeeded but cleanup failed — leave a
-                        // visible warning rather than silently leaving a
-                        // .write-probe file behind in the source root.
-                        tracing::warn!(
-                            path = %probe.display(),
-                            error = %e,
-                            "failed to remove write probe file after success"
+        // Probe write access at the configured root. If it succeeds, we
+        // operate in place. If it fails (typical for a corpus baked into a
+        // read-only container layer), copy the corpus to an ephemeral
+        // scratch directory under $TMPDIR and operate there. The copy is
+        // lost on container restart — by design — but for the lifetime of
+        // the process the source is fully editable and the engine sees
+        // every edit because both reads and writes route through the same
+        // backend.
+        if self.writable && !probe_writable(&self.root).await {
+            tracing::info!(
+                path = %self.root.display(),
+                "local source root is not writable; preparing ephemeral scratch copy"
+            );
+
+            let host_id = std::env::var("HOSTNAME").unwrap_or_else(|_| "local".to_string());
+            let scratch = std::env::temp_dir()
+                .join("regelrecht-editor-corpus")
+                .join(host_id)
+                .join(&self.source_id);
+
+            // If a previous invocation of this process already populated
+            // the scratch dir, leave it alone — that preserves any edits
+            // the operator made earlier in the same container lifetime.
+            // Otherwise copy the corpus tree across.
+            if !scratch.exists() {
+                let src = self.root.clone();
+                let dst = scratch.clone();
+                let copy_result =
+                    tokio::task::spawn_blocking(move || copy_dir_recursive_sync(&src, &dst)).await;
+
+                match copy_result {
+                    Ok(Ok(())) => {
+                        tracing::info!(
+                            from = %self.root.display(),
+                            to = %scratch.display(),
+                            "copied read-only local source to writable scratch directory"
                         );
                     }
+                    Ok(Err(e)) => {
+                        tracing::warn!(
+                            error = %e,
+                            from = %self.root.display(),
+                            to = %scratch.display(),
+                            "failed to copy local source to scratch directory; \
+                             marking backend read-only"
+                        );
+                        self.writable = false;
+                        return Ok(());
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            error = %e,
+                            "scratch copy task panicked; marking backend read-only"
+                        );
+                        self.writable = false;
+                        return Ok(());
+                    }
                 }
-                Err(_) => {
-                    tracing::info!(
-                        path = %self.root.display(),
-                        "local source is not writable, disabling writes"
-                    );
-                    self.writable = false;
-                }
+            } else {
+                tracing::info!(
+                    path = %scratch.display(),
+                    "reusing existing scratch directory from a previous run in this process"
+                );
+            }
+
+            // Re-probe at the scratch location to confirm it's writable.
+            if probe_writable(&scratch).await {
+                self.root = scratch;
+            } else {
+                tracing::warn!(
+                    path = %scratch.display(),
+                    "scratch directory is not writable; marking backend read-only"
+                );
+                self.writable = false;
             }
         }
 
@@ -414,7 +527,11 @@ impl RepoBackend for GitBackend {
 /// other's git state during concurrent `clone`/`pull --rebase`/`push`.
 pub fn create_backend(source: &Source, auth_token: Option<&str>) -> Result<Box<dyn RepoBackend>> {
     match &source.source_type {
-        SourceType::Local { local } => Ok(Box::new(LocalBackend::new(local.path.clone(), true))),
+        SourceType::Local { local } => Ok(Box::new(LocalBackend::new(
+            source.id.clone(),
+            local.path.clone(),
+            true,
+        ))),
         SourceType::GitHub { github } => {
             let repo_url = format!("https://github.com/{}/{}.git", github.owner, github.repo);
             let host_id = std::env::var("HOSTNAME").unwrap_or_else(|_| "local".to_string());
@@ -448,7 +565,7 @@ mod tests {
     #[tokio::test]
     async fn local_read_write_roundtrip() {
         let dir = TempDir::new().unwrap();
-        let mut backend = LocalBackend::new(dir.path().to_path_buf(), true);
+        let mut backend = LocalBackend::new("test".to_string(), dir.path().to_path_buf(), true);
         backend.ensure_ready().await.unwrap();
 
         let path = Path::new("scenarios/test.feature");
@@ -475,7 +592,7 @@ mod tests {
     #[tokio::test]
     async fn local_delete_file() {
         let dir = TempDir::new().unwrap();
-        let mut backend = LocalBackend::new(dir.path().to_path_buf(), true);
+        let mut backend = LocalBackend::new("test".to_string(), dir.path().to_path_buf(), true);
         backend.ensure_ready().await.unwrap();
 
         let path = Path::new("test.feature");
@@ -492,7 +609,7 @@ mod tests {
     #[tokio::test]
     async fn local_list_files_with_extension() {
         let dir = TempDir::new().unwrap();
-        let mut backend = LocalBackend::new(dir.path().to_path_buf(), true);
+        let mut backend = LocalBackend::new("test".to_string(), dir.path().to_path_buf(), true);
         backend.ensure_ready().await.unwrap();
 
         backend
@@ -520,7 +637,7 @@ mod tests {
     #[tokio::test]
     async fn local_list_files_missing_dir() {
         let dir = TempDir::new().unwrap();
-        let mut backend = LocalBackend::new(dir.path().to_path_buf(), true);
+        let mut backend = LocalBackend::new("test".to_string(), dir.path().to_path_buf(), true);
         backend.ensure_ready().await.unwrap();
 
         let entries = backend
@@ -533,7 +650,7 @@ mod tests {
     #[tokio::test]
     async fn local_read_only_rejects_writes() {
         let dir = TempDir::new().unwrap();
-        let backend = LocalBackend::new(dir.path().to_path_buf(), false);
+        let backend = LocalBackend::new("test".to_string(), dir.path().to_path_buf(), false);
 
         let result = backend.write_file(Path::new("test.txt"), "content").await;
         assert!(result.is_err());
@@ -543,7 +660,7 @@ mod tests {
     #[tokio::test]
     async fn local_rejects_path_traversal() {
         let dir = TempDir::new().unwrap();
-        let mut backend = LocalBackend::new(dir.path().to_path_buf(), true);
+        let mut backend = LocalBackend::new("test".to_string(), dir.path().to_path_buf(), true);
         backend.ensure_ready().await.unwrap();
 
         let result = backend.read_file(Path::new("../etc/passwd")).await;
@@ -557,7 +674,8 @@ mod tests {
 
     #[tokio::test]
     async fn local_ensure_ready_fails_for_missing_dir() {
-        let mut backend = LocalBackend::new(PathBuf::from("/nonexistent/path"), true);
+        let mut backend =
+            LocalBackend::new("test".to_string(), PathBuf::from("/nonexistent/path"), true);
         let result = backend.ensure_ready().await;
         assert!(result.is_err());
     }

--- a/packages/corpus/src/backend.rs
+++ b/packages/corpus/src/backend.rs
@@ -371,7 +371,7 @@ pub fn create_backend(source: &Source, auth_token: Option<&str>) -> Result<Box<d
         SourceType::Local { local } => Ok(Box::new(LocalBackend::new(local.path.clone(), true))),
         SourceType::GitHub { github } => {
             let repo_url = format!("https://github.com/{}/{}.git", github.owner, github.repo);
-            let repo_path = PathBuf::from(format!("/tmp/corpus-editor/{}", source.id));
+            let repo_path = std::env::temp_dir().join("corpus-editor").join(&source.id);
             let mut config = CorpusConfig::new(&repo_url, &repo_path);
             config.branch = github.effective_ref().to_string();
 

--- a/packages/corpus/src/backend.rs
+++ b/packages/corpus/src/backend.rs
@@ -317,16 +317,26 @@ impl RepoBackend for GitBackend {
 
         let result = if self.local_only {
             // Create session branch on first persist
-            {
+            let branch_ok = {
                 let mut branched = self.branched.lock().await;
                 if !*branched {
-                    if let Some(branch) = &self.session_branch {
-                        self.client.create_local_branch(branch).await?;
+                    let res = if let Some(branch) = &self.session_branch {
+                        self.client.create_local_branch(branch).await
+                    } else {
+                        Ok(())
+                    };
+                    if res.is_ok() {
+                        *branched = true;
                     }
-                    *branched = true;
+                    res
+                } else {
+                    Ok(())
                 }
+            };
+            match branch_ok {
+                Ok(()) => self.client.commit_local(&paths, &ctx.message).await,
+                Err(e) => Err(e),
             }
-            self.client.commit_local(&paths, &ctx.message).await
         } else {
             self.client.commit_and_push(&paths, &ctx.message).await
         };

--- a/packages/corpus/src/backend.rs
+++ b/packages/corpus/src/backend.rs
@@ -67,15 +67,35 @@ impl LocalBackend {
         Self { root, writable }
     }
 
-    fn resolve(&self, relative: &Path) -> PathBuf {
-        self.root.join(relative)
+    fn resolve(&self, relative: &Path) -> Result<PathBuf> {
+        validate_relative_path(relative)?;
+        Ok(self.root.join(relative))
     }
+}
+
+/// Reject paths that are absolute or contain `..` components.
+fn validate_relative_path(path: &Path) -> Result<()> {
+    if path.is_absolute() {
+        return Err(CorpusError::Config(format!(
+            "path must be relative: {}",
+            path.display()
+        )));
+    }
+    for component in path.components() {
+        if matches!(component, std::path::Component::ParentDir) {
+            return Err(CorpusError::Config(format!(
+                "path must not contain '..': {}",
+                path.display()
+            )));
+        }
+    }
+    Ok(())
 }
 
 #[async_trait]
 impl RepoBackend for LocalBackend {
     async fn read_file(&self, relative_path: &Path) -> Result<Option<String>> {
-        let abs = self.resolve(relative_path);
+        let abs = self.resolve(relative_path)?;
         match tokio::fs::read_to_string(&abs).await {
             Ok(content) => Ok(Some(content)),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
@@ -89,7 +109,7 @@ impl RepoBackend for LocalBackend {
                 "local source is read-only".to_string(),
             ));
         }
-        let abs = self.resolve(relative_path);
+        let abs = self.resolve(relative_path)?;
         if let Some(parent) = abs.parent() {
             tokio::fs::create_dir_all(parent).await?;
         }
@@ -103,7 +123,7 @@ impl RepoBackend for LocalBackend {
                 "local source is read-only".to_string(),
             ));
         }
-        let abs = self.resolve(relative_path);
+        let abs = self.resolve(relative_path)?;
         match tokio::fs::remove_file(&abs).await {
             Ok(()) => Ok(()),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
@@ -112,7 +132,7 @@ impl RepoBackend for LocalBackend {
     }
 
     async fn list_files(&self, dir: &Path, extension: Option<&str>) -> Result<Vec<FileEntry>> {
-        let abs = self.resolve(dir);
+        let abs = self.resolve(dir)?;
         let mut entries = Vec::new();
 
         let mut read_dir = match tokio::fs::read_dir(&abs).await {
@@ -230,19 +250,20 @@ impl GitBackend {
     }
 
     /// Resolve a source-relative path to an absolute path in the checkout.
-    fn resolve(&self, relative: &Path) -> PathBuf {
+    fn resolve(&self, relative: &Path) -> Result<PathBuf> {
+        validate_relative_path(relative)?;
         let base = match &self.repo_subpath {
             Some(sub) => self.client.repo_path().join(sub),
             None => self.client.repo_path().to_path_buf(),
         };
-        base.join(relative)
+        Ok(base.join(relative))
     }
 }
 
 #[async_trait]
 impl RepoBackend for GitBackend {
     async fn read_file(&self, relative_path: &Path) -> Result<Option<String>> {
-        let abs = self.resolve(relative_path);
+        let abs = self.resolve(relative_path)?;
         match tokio::fs::read_to_string(&abs).await {
             Ok(content) => Ok(Some(content)),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
@@ -251,7 +272,7 @@ impl RepoBackend for GitBackend {
     }
 
     async fn write_file(&self, relative_path: &Path, content: &str) -> Result<()> {
-        let abs = self.resolve(relative_path);
+        let abs = self.resolve(relative_path)?;
         if let Some(parent) = abs.parent() {
             tokio::fs::create_dir_all(parent).await?;
         }
@@ -262,7 +283,7 @@ impl RepoBackend for GitBackend {
     }
 
     async fn delete_file(&self, relative_path: &Path) -> Result<()> {
-        let abs = self.resolve(relative_path);
+        let abs = self.resolve(relative_path)?;
         match tokio::fs::remove_file(&abs).await {
             Ok(()) => {
                 self.dirty_files.lock().await.push(abs);
@@ -274,7 +295,7 @@ impl RepoBackend for GitBackend {
     }
 
     async fn list_files(&self, dir: &Path, extension: Option<&str>) -> Result<Vec<FileEntry>> {
-        let abs = self.resolve(dir);
+        let abs = self.resolve(dir)?;
         let mut entries = Vec::new();
 
         let mut read_dir = match tokio::fs::read_dir(&abs).await {
@@ -488,6 +509,21 @@ mod tests {
         let result = backend.write_file(Path::new("test.txt"), "content").await;
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("read-only"));
+    }
+
+    #[tokio::test]
+    async fn local_rejects_path_traversal() {
+        let dir = TempDir::new().unwrap();
+        let mut backend = LocalBackend::new(dir.path().to_path_buf(), true);
+        backend.ensure_ready().await.unwrap();
+
+        let result = backend.read_file(Path::new("../etc/passwd")).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains(".."));
+
+        let result = backend.read_file(Path::new("/etc/passwd")).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("relative"));
     }
 
     #[tokio::test]

--- a/packages/corpus/src/backend.rs
+++ b/packages/corpus/src/backend.rs
@@ -122,10 +122,11 @@ impl RepoBackend for LocalBackend {
         };
 
         while let Some(entry) = read_dir.next_entry().await? {
-            let path = entry.path();
-            if !path.is_file() {
+            let ft = entry.file_type().await?;
+            if !ft.is_file() {
                 continue;
             }
+            let path = entry.path();
             if let Some(ext) = extension {
                 if path.extension().is_none_or(|e| e != ext) {
                     continue;
@@ -260,10 +261,11 @@ impl RepoBackend for GitBackend {
         };
 
         while let Some(entry) = read_dir.next_entry().await? {
-            let path = entry.path();
-            if !path.is_file() {
+            let ft = entry.file_type().await?;
+            if !ft.is_file() {
                 continue;
             }
+            let path = entry.path();
             if let Some(ext) = extension {
                 if path.extension().is_none_or(|e| e != ext) {
                     continue;

--- a/packages/corpus/src/backend.rs
+++ b/packages/corpus/src/backend.rs
@@ -375,6 +375,10 @@ impl RepoBackend for GitBackend {
         self.client.ensure_repo().await
     }
 
+    /// A `GitBackend` is always considered writable: even in `local_only`
+    /// mode (no push token) edits are committed to a local session branch.
+    /// "Writable" here means "the backend will accept `write_file` calls",
+    /// not "the backend will push to a remote".
     fn is_writable(&self) -> bool {
         true
     }

--- a/packages/corpus/src/backend.rs
+++ b/packages/corpus/src/backend.rs
@@ -290,7 +290,14 @@ impl RepoBackend for GitBackend {
             return Ok(());
         }
 
-        self.client.commit_and_push(&paths, &ctx.message).await
+        match self.client.commit_and_push(&paths, &ctx.message).await {
+            Ok(()) => Ok(()),
+            Err(e) => {
+                // Restore dirty files so the next persist attempt can retry.
+                self.dirty_files.lock().await.extend(paths);
+                Err(e)
+            }
+        }
     }
 
     async fn ensure_ready(&mut self) -> Result<()> {

--- a/packages/corpus/src/backend.rs
+++ b/packages/corpus/src/backend.rs
@@ -1,0 +1,422 @@
+use std::path::{Path, PathBuf};
+
+use async_trait::async_trait;
+
+use crate::client::CorpusClient;
+use crate::config::CorpusConfig;
+use crate::error::{CorpusError, Result};
+use crate::models::{Source, SourceType};
+
+/// Metadata for a write operation (used as commit message for git backends).
+pub struct WriteContext {
+    pub message: String,
+}
+
+/// A file entry returned by list operations.
+pub struct FileEntry {
+    /// Filename only (not a full path), e.g. "eligibility.feature".
+    pub name: String,
+}
+
+/// Abstraction over different corpus storage backends.
+///
+/// All paths are relative to the source root directory. The backend resolves
+/// them to absolute paths internally.
+#[async_trait]
+pub trait RepoBackend: Send + Sync {
+    /// Read a file's contents. Returns `None` if the file does not exist.
+    async fn read_file(&self, relative_path: &Path) -> Result<Option<String>>;
+
+    /// Write a file's contents, creating parent directories as needed.
+    ///
+    /// For git backends this writes to the local checkout without committing.
+    /// Call [`persist`] afterwards to commit and push.
+    async fn write_file(&self, relative_path: &Path, content: &str) -> Result<()>;
+
+    /// Delete a file. Returns `Ok(())` even if the file did not exist.
+    async fn delete_file(&self, relative_path: &Path) -> Result<()>;
+
+    /// List files in a directory, optionally filtered by extension (without dot).
+    async fn list_files(&self, dir: &Path, extension: Option<&str>) -> Result<Vec<FileEntry>>;
+
+    /// Persist pending changes.
+    ///
+    /// No-op for local backends. For git backends this commits dirty files and
+    /// pushes to the remote.
+    async fn persist(&self, ctx: &WriteContext) -> Result<()>;
+
+    /// Prepare the backend for use (validate directories, clone repos, etc.).
+    async fn ensure_ready(&mut self) -> Result<()>;
+
+    /// Whether this backend supports write operations.
+    fn is_writable(&self) -> bool;
+}
+
+// ---------------------------------------------------------------------------
+// LocalBackend
+// ---------------------------------------------------------------------------
+
+/// Backend that reads/writes directly to the local filesystem.
+pub struct LocalBackend {
+    root: PathBuf,
+    writable: bool,
+}
+
+impl LocalBackend {
+    pub fn new(root: PathBuf, writable: bool) -> Self {
+        Self { root, writable }
+    }
+
+    fn resolve(&self, relative: &Path) -> PathBuf {
+        self.root.join(relative)
+    }
+}
+
+#[async_trait]
+impl RepoBackend for LocalBackend {
+    async fn read_file(&self, relative_path: &Path) -> Result<Option<String>> {
+        let abs = self.resolve(relative_path);
+        match tokio::fs::read_to_string(&abs).await {
+            Ok(content) => Ok(Some(content)),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    async fn write_file(&self, relative_path: &Path, content: &str) -> Result<()> {
+        if !self.writable {
+            return Err(CorpusError::ReadOnly(
+                "local source is read-only".to_string(),
+            ));
+        }
+        let abs = self.resolve(relative_path);
+        if let Some(parent) = abs.parent() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+        tokio::fs::write(&abs, content).await?;
+        Ok(())
+    }
+
+    async fn delete_file(&self, relative_path: &Path) -> Result<()> {
+        if !self.writable {
+            return Err(CorpusError::ReadOnly(
+                "local source is read-only".to_string(),
+            ));
+        }
+        let abs = self.resolve(relative_path);
+        match tokio::fs::remove_file(&abs).await {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    async fn list_files(&self, dir: &Path, extension: Option<&str>) -> Result<Vec<FileEntry>> {
+        let abs = self.resolve(dir);
+        let mut entries = Vec::new();
+
+        let mut read_dir = match tokio::fs::read_dir(&abs).await {
+            Ok(rd) => rd,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(entries),
+            Err(e) => return Err(e.into()),
+        };
+
+        while let Some(entry) = read_dir.next_entry().await? {
+            let path = entry.path();
+            if !path.is_file() {
+                continue;
+            }
+            if let Some(ext) = extension {
+                if path.extension().is_none_or(|e| e != ext) {
+                    continue;
+                }
+            }
+            if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                entries.push(FileEntry {
+                    name: name.to_string(),
+                });
+            }
+        }
+
+        entries.sort_by(|a, b| a.name.cmp(&b.name));
+        Ok(entries)
+    }
+
+    async fn persist(&self, _ctx: &WriteContext) -> Result<()> {
+        // Local writes are immediate — nothing to persist.
+        Ok(())
+    }
+
+    async fn ensure_ready(&mut self) -> Result<()> {
+        if !self.root.exists() {
+            return Err(CorpusError::Config(format!(
+                "local source root does not exist: {}",
+                self.root.display()
+            )));
+        }
+        Ok(())
+    }
+
+    fn is_writable(&self) -> bool {
+        self.writable
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GitBackend
+// ---------------------------------------------------------------------------
+
+/// Backend that reads/writes to a local git checkout and commits/pushes on persist.
+pub struct GitBackend {
+    client: CorpusClient,
+    /// Sub-path within the repo that corresponds to the source root
+    /// (e.g. "regulation/nl").
+    repo_subpath: Option<String>,
+    /// Files written since the last persist, as absolute paths.
+    dirty_files: tokio::sync::Mutex<Vec<PathBuf>>,
+}
+
+impl GitBackend {
+    pub fn new(client: CorpusClient, repo_subpath: Option<String>) -> Self {
+        Self {
+            client,
+            repo_subpath,
+            dirty_files: tokio::sync::Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Resolve a source-relative path to an absolute path in the checkout.
+    fn resolve(&self, relative: &Path) -> PathBuf {
+        let base = match &self.repo_subpath {
+            Some(sub) => self.client.repo_path().join(sub),
+            None => self.client.repo_path().to_path_buf(),
+        };
+        base.join(relative)
+    }
+}
+
+#[async_trait]
+impl RepoBackend for GitBackend {
+    async fn read_file(&self, relative_path: &Path) -> Result<Option<String>> {
+        let abs = self.resolve(relative_path);
+        match tokio::fs::read_to_string(&abs).await {
+            Ok(content) => Ok(Some(content)),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    async fn write_file(&self, relative_path: &Path, content: &str) -> Result<()> {
+        let abs = self.resolve(relative_path);
+        if let Some(parent) = abs.parent() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+        tokio::fs::write(&abs, content).await?;
+
+        self.dirty_files.lock().await.push(abs);
+        Ok(())
+    }
+
+    async fn delete_file(&self, relative_path: &Path) -> Result<()> {
+        let abs = self.resolve(relative_path);
+        match tokio::fs::remove_file(&abs).await {
+            Ok(()) => {
+                self.dirty_files.lock().await.push(abs);
+                Ok(())
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    async fn list_files(&self, dir: &Path, extension: Option<&str>) -> Result<Vec<FileEntry>> {
+        let abs = self.resolve(dir);
+        let mut entries = Vec::new();
+
+        let mut read_dir = match tokio::fs::read_dir(&abs).await {
+            Ok(rd) => rd,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(entries),
+            Err(e) => return Err(e.into()),
+        };
+
+        while let Some(entry) = read_dir.next_entry().await? {
+            let path = entry.path();
+            if !path.is_file() {
+                continue;
+            }
+            if let Some(ext) = extension {
+                if path.extension().is_none_or(|e| e != ext) {
+                    continue;
+                }
+            }
+            if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                entries.push(FileEntry {
+                    name: name.to_string(),
+                });
+            }
+        }
+
+        entries.sort_by(|a, b| a.name.cmp(&b.name));
+        Ok(entries)
+    }
+
+    async fn persist(&self, ctx: &WriteContext) -> Result<()> {
+        let paths: Vec<PathBuf> = {
+            let mut dirty = self.dirty_files.lock().await;
+            std::mem::take(&mut *dirty)
+        };
+
+        if paths.is_empty() {
+            return Ok(());
+        }
+
+        self.client.commit_and_push(&paths, &ctx.message).await
+    }
+
+    async fn ensure_ready(&mut self) -> Result<()> {
+        self.client.ensure_repo().await
+    }
+
+    fn is_writable(&self) -> bool {
+        true
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/// Create a [`RepoBackend`] for a given corpus source.
+///
+/// For GitHub sources, an optional authentication token can be provided.
+pub fn create_backend(source: &Source, auth_token: Option<&str>) -> Result<Box<dyn RepoBackend>> {
+    match &source.source_type {
+        SourceType::Local { local } => Ok(Box::new(LocalBackend::new(local.path.clone(), true))),
+        SourceType::GitHub { github } => {
+            let repo_url = format!("https://github.com/{}/{}.git", github.owner, github.repo);
+            let repo_path = PathBuf::from(format!("/tmp/corpus-editor/{}", source.id));
+            let mut config = CorpusConfig::new(&repo_url, &repo_path);
+            config.branch = github.effective_ref().to_string();
+
+            if let Some(token) = auth_token {
+                config = config.with_token(token);
+            }
+
+            let client = CorpusClient::new(config);
+            Ok(Box::new(GitBackend::new(client, github.path.clone())))
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn local_read_write_roundtrip() {
+        let dir = TempDir::new().unwrap();
+        let mut backend = LocalBackend::new(dir.path().to_path_buf(), true);
+        backend.ensure_ready().await.unwrap();
+
+        let path = Path::new("scenarios/test.feature");
+
+        // File doesn't exist yet
+        assert!(backend.read_file(path).await.unwrap().is_none());
+
+        // Write
+        backend.write_file(path, "Feature: Test\n").await.unwrap();
+
+        // Read back
+        let content = backend.read_file(path).await.unwrap().unwrap();
+        assert_eq!(content, "Feature: Test\n");
+
+        // Persist is a no-op
+        backend
+            .persist(&WriteContext {
+                message: "test".to_string(),
+            })
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn local_delete_file() {
+        let dir = TempDir::new().unwrap();
+        let mut backend = LocalBackend::new(dir.path().to_path_buf(), true);
+        backend.ensure_ready().await.unwrap();
+
+        let path = Path::new("test.feature");
+        backend.write_file(path, "content").await.unwrap();
+        assert!(backend.read_file(path).await.unwrap().is_some());
+
+        backend.delete_file(path).await.unwrap();
+        assert!(backend.read_file(path).await.unwrap().is_none());
+
+        // Deleting non-existent file is fine
+        backend.delete_file(path).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn local_list_files_with_extension() {
+        let dir = TempDir::new().unwrap();
+        let mut backend = LocalBackend::new(dir.path().to_path_buf(), true);
+        backend.ensure_ready().await.unwrap();
+
+        backend
+            .write_file(Path::new("scenarios/a.feature"), "a")
+            .await
+            .unwrap();
+        backend
+            .write_file(Path::new("scenarios/b.feature"), "b")
+            .await
+            .unwrap();
+        backend
+            .write_file(Path::new("scenarios/readme.md"), "r")
+            .await
+            .unwrap();
+
+        let entries = backend
+            .list_files(Path::new("scenarios"), Some("feature"))
+            .await
+            .unwrap();
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].name, "a.feature");
+        assert_eq!(entries[1].name, "b.feature");
+    }
+
+    #[tokio::test]
+    async fn local_list_files_missing_dir() {
+        let dir = TempDir::new().unwrap();
+        let mut backend = LocalBackend::new(dir.path().to_path_buf(), true);
+        backend.ensure_ready().await.unwrap();
+
+        let entries = backend
+            .list_files(Path::new("nonexistent"), None)
+            .await
+            .unwrap();
+        assert!(entries.is_empty());
+    }
+
+    #[tokio::test]
+    async fn local_read_only_rejects_writes() {
+        let dir = TempDir::new().unwrap();
+        let backend = LocalBackend::new(dir.path().to_path_buf(), false);
+
+        let result = backend.write_file(Path::new("test.txt"), "content").await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("read-only"));
+    }
+
+    #[tokio::test]
+    async fn local_ensure_ready_fails_for_missing_dir() {
+        let mut backend = LocalBackend::new(PathBuf::from("/nonexistent/path"), true);
+        let result = backend.ensure_ready().await;
+        assert!(result.is_err());
+    }
+}

--- a/packages/corpus/src/client.rs
+++ b/packages/corpus/src/client.rs
@@ -73,6 +73,43 @@ impl CorpusClient {
         &self.config.repo_path
     }
 
+    /// Whether this client has a push token configured.
+    pub fn has_push_token(&self) -> bool {
+        self.config.git_token().is_some()
+    }
+
+    /// Create a local branch (no push).
+    pub async fn create_local_branch(&self, branch: &str) -> Result<()> {
+        self.run_git(&["checkout", "-b", branch]).await?;
+        tracing::info!(branch = %branch, "created local branch");
+        Ok(())
+    }
+
+    /// Stage the given paths and commit locally (no push).
+    ///
+    /// If there are no changes to commit (working tree is clean), this is a no-op.
+    pub async fn commit_local(&self, paths: &[PathBuf], message: &str) -> Result<()> {
+        let mut add_args = vec!["add", "--"];
+        let path_strings: Vec<String> = paths
+            .iter()
+            .map(|p| p.to_string_lossy().to_string())
+            .collect();
+        for p in &path_strings {
+            add_args.push(p);
+        }
+        self.run_git(&add_args).await?;
+
+        let status_output = self.run_git_output(&["status", "--porcelain"]).await?;
+        if status_output.trim().is_empty() {
+            tracing::debug!("no changes to commit, skipping");
+            return Ok(());
+        }
+
+        self.run_git(&["commit", "-m", message]).await?;
+        tracing::info!(message = %message, "committed locally (no push)");
+        Ok(())
+    }
+
     /// Maximum number of rebase+push attempts before giving up.
     const MAX_PUSH_ATTEMPTS: u32 = 5;
 
@@ -560,6 +597,64 @@ mod tests {
             log_str.contains("worker B commit"),
             "worker B commit not found in log: {log_str}"
         );
+    }
+
+    #[tokio::test]
+    async fn test_commit_local_without_push() {
+        let dir = tempfile::tempdir().unwrap();
+        let bare_path = setup_bare_repo(dir.path()).await;
+        let bare_url = format!("file://{}", bare_path.display());
+        let repo_path = dir.path().join("corpus");
+        clone_with_config(&bare_path, &repo_path).await;
+
+        // Create a local branch
+        let config = CorpusConfig::new(&bare_url, &repo_path);
+        let client = CorpusClient::new(config);
+        client
+            .create_local_branch("editor/test-session")
+            .await
+            .unwrap();
+
+        // Write and commit locally
+        let test_file = repo_path.join("local-edit.txt");
+        tokio::fs::write(&test_file, "local change").await.unwrap();
+        client
+            .commit_local(&[test_file], "local edit")
+            .await
+            .unwrap();
+
+        // Verify commit exists locally
+        let log = Command::new("git")
+            .args(["log", "--oneline", "-1"])
+            .current_dir(&repo_path)
+            .output()
+            .await
+            .unwrap();
+        let log_str = String::from_utf8_lossy(&log.stdout);
+        assert!(log_str.contains("local edit"));
+
+        // Verify it was NOT pushed to the bare repo
+        let remote_log = Command::new("git")
+            .args(["log", "--oneline", "--all"])
+            .current_dir(&bare_path)
+            .output()
+            .await
+            .unwrap();
+        let remote_str = String::from_utf8_lossy(&remote_log.stdout);
+        assert!(
+            !remote_str.contains("local edit"),
+            "commit should not be on remote: {remote_str}"
+        );
+
+        // Verify we're on the session branch
+        let branch = Command::new("git")
+            .args(["branch", "--show-current"])
+            .current_dir(&repo_path)
+            .output()
+            .await
+            .unwrap();
+        let branch_str = String::from_utf8_lossy(&branch.stdout);
+        assert_eq!(branch_str.trim(), "editor/test-session");
     }
 
     #[tokio::test]

--- a/packages/corpus/src/error.rs
+++ b/packages/corpus/src/error.rs
@@ -13,6 +13,9 @@ pub enum CorpusError {
 
     #[error("YAML parse error: {0}")]
     Yaml(#[from] serde_yaml_ng::Error),
+
+    #[error("write not supported: {0}")]
+    ReadOnly(String),
 }
 
 pub type Result<T> = std::result::Result<T, CorpusError>;

--- a/packages/corpus/src/lib.rs
+++ b/packages/corpus/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod auth;
+pub mod backend;
 pub mod client;
 pub mod config;
 pub mod error;

--- a/packages/corpus/src/registry.rs
+++ b/packages/corpus/src/registry.rs
@@ -173,6 +173,7 @@ impl CorpusRegistry {
                             map.load_fetched_file(
                                 &file.content,
                                 &file.path,
+                                github.path.as_deref(),
                                 &source.id,
                                 &source.name,
                                 source.priority,
@@ -229,6 +230,7 @@ impl CorpusRegistry {
                                 map.load_fetched_file(
                                     &file.content,
                                     &file.path,
+                                    github.path.as_deref(),
                                     &source.id,
                                     &source.name,
                                     source.priority,

--- a/packages/corpus/src/source_map.rs
+++ b/packages/corpus/src/source_map.rs
@@ -15,8 +15,17 @@ pub struct LoadedLaw {
     pub name: Option<String>,
     /// The raw YAML content.
     pub yaml_content: String,
-    /// Path to the source file.
+    /// Path to the source file. For local sources this is the absolute path
+    /// on disk; for fetched (e.g. GitHub) sources this is the path inside
+    /// the upstream repository.
     pub file_path: String,
+    /// Path to the source file *relative to the source root* — i.e. the
+    /// portion of [`file_path`](Self::file_path) below the source's own
+    /// root directory. This is what backends use to address the file via
+    /// [`RepoBackend::write_file`](crate::backend::RepoBackend::write_file)
+    /// and friends, and avoids the structural-depth heuristic that breaks
+    /// when a source root is configured at an unusual location.
+    pub relative_path: String,
     /// ID of the source that provided this law.
     pub source_id: String,
     /// Name of the source that provided this law.
@@ -117,11 +126,20 @@ impl SourceMap {
 
             let name = extract_law_name(&content);
 
+            // Compute the path relative to the source root so that writes
+            // can address the file via the backend without re-deriving the
+            // structural location from a depth heuristic.
+            let relative_path = path
+                .strip_prefix(dir)
+                .map(|p| p.display().to_string())
+                .unwrap_or_else(|_| path.display().to_string());
+
             let loaded = LoadedLaw {
                 law_id: law_id.clone(),
                 name,
                 yaml_content: content,
                 file_path: path.display().to_string(),
+                relative_path,
                 source_id: source.id.clone(),
                 source_name: source.name.clone(),
                 source_priority: source.priority,
@@ -208,10 +226,16 @@ impl SourceMap {
     }
 
     /// Load a single fetched file (from GitHub or other remote) into the map.
+    ///
+    /// `file_path` is the path inside the upstream repository (e.g.
+    /// `regulation/nl/wet/my_law/2025.yaml`). `source_subpath`, when set,
+    /// is the in-repo prefix that the source is rooted at — it is stripped
+    /// to compute the source-root-relative path stored on `LoadedLaw`.
     pub fn load_fetched_file(
         &mut self,
         content: &str,
         file_path: &str,
+        source_subpath: Option<&str>,
         source_id: &str,
         source_name: &str,
         source_priority: u32,
@@ -223,11 +247,26 @@ impl SourceMap {
 
         let name = extract_law_name(content);
 
+        // Strip the source's in-repo subpath so the stored relative path is
+        // relative to the source root, matching the on-disk layout the
+        // backend writes to.
+        let relative_path = match source_subpath {
+            Some(sub) if !sub.is_empty() => {
+                let trimmed = sub.trim_end_matches('/');
+                file_path
+                    .strip_prefix(&format!("{trimmed}/"))
+                    .unwrap_or(file_path)
+                    .to_string()
+            }
+            _ => file_path.to_string(),
+        };
+
         let loaded = LoadedLaw {
             law_id: law_id.clone(),
             name,
             yaml_content: content.to_string(),
             file_path: file_path.to_string(),
+            relative_path,
             source_id: source_id.to_string(),
             source_name: source_name.to_string(),
             source_priority,

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -268,36 +268,21 @@ fn validate_scenario_filename(filename: &str) -> Result<(), (StatusCode, String)
 
 /// Extract the law-relative directory from a law's file_path.
 ///
-/// Returns the structural path like `wet/law_id/` — the path from the
-/// regulation root to the law directory. This is source-agnostic and works
-/// with any backend.
+/// Returns the path of the law's directory, relative to the source root.
 ///
-/// The law's file_path is either absolute (local sources) or repo-relative
-/// (GitHub-fetched). In both cases the structural part is the last two path
-/// components: `{regulatory_layer}/{law_id}/`.
+/// `LoadedLaw::relative_path` is computed at load time by stripping the
+/// source root (for local sources) or the in-repo subpath (for GitHub
+/// sources). Taking its parent gives the directory the backend writes to,
+/// without making any assumption about the structural depth of the corpus
+/// layout.
 fn law_relative_dir(law: &LoadedLaw) -> Result<PathBuf, (StatusCode, String)> {
-    let file_path = std::path::Path::new(&law.file_path);
-    let law_dir = file_path.parent().ok_or_else(|| {
+    let rel = std::path::Path::new(&law.relative_path);
+    rel.parent().map(PathBuf::from).ok_or_else(|| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
             "Cannot determine law directory".to_string(),
         )
-    })?;
-
-    // Extract the last two components: regulatory_layer/law_id
-    // e.g. from "/abs/path/corpus/regulation/nl/wet/my_law/2025.yaml"
-    //   → parent = ".../wet/my_law"
-    //   → last two components = "wet/my_law"
-    let components: Vec<_> = law_dir.components().rev().take(2).collect();
-    if components.len() == 2 {
-        let mut rel = PathBuf::new();
-        rel.push(components[1].as_os_str());
-        rel.push(components[0].as_os_str());
-        Ok(rel)
-    } else {
-        // Fallback: use the full law_dir filename as-is
-        Ok(law_dir.file_name().map(PathBuf::from).unwrap_or_default())
-    }
+    })
 }
 
 /// Resolved backend information for a law.

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -338,23 +338,23 @@ fn resolve_writable_backend(
     // Try the law's own backend first, then fall back to any other backend.
     // The fallback picks the backend with the lowest source ID (alphabetical)
     // for deterministic behaviour across restarts.
-    let backend = corpus
-        .backends
-        .get(&law.source_id)
-        .or_else(|| {
-            corpus
-                .backends
-                .iter()
-                .min_by_key(|(k, _)| (*k).clone())
-                .map(|(_, v)| v)
-        })
-        .ok_or_else(|| {
-            (
-                StatusCode::FORBIDDEN,
-                "No write backend available".to_string(),
-            )
-        })?
-        .clone();
+    let backend = if let Some(b) = corpus.backends.get(&law.source_id) {
+        b.clone()
+    } else if let Some((fallback_id, b)) = corpus.backends.iter().min_by_key(|(k, _)| (*k).clone())
+    {
+        tracing::warn!(
+            law_id = %law_id,
+            law_source = %law.source_id,
+            fallback_source = %fallback_id,
+            "law's own source has no write backend, falling back to a different source"
+        );
+        b.clone()
+    } else {
+        return Err((
+            StatusCode::FORBIDDEN,
+            "No write backend available".to_string(),
+        ));
+    };
 
     Ok(ResolvedBackend { law, backend })
 }
@@ -379,12 +379,6 @@ async fn resolve_write_target(
     let relative_path = rel_dir.join("scenarios").join(filename);
 
     let backend = resolved.backend.lock_owned().await;
-    if !backend.is_writable() {
-        return Err((
-            StatusCode::FORBIDDEN,
-            "No writable backend available".to_string(),
-        ));
-    }
 
     Ok((relative_path, backend))
 }

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -1,8 +1,15 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::Json;
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use tokio::sync::Mutex;
+
+use regelrecht_corpus::backend::{RepoBackend, WriteContext};
+use regelrecht_corpus::source_map::LoadedLaw;
+use regelrecht_corpus::SourceType;
 
 use crate::state::AppState;
 
@@ -245,4 +252,176 @@ pub async fn get_scenario(
         )],
         content,
     ))
+}
+
+// ---------------------------------------------------------------------------
+// Scenario write helpers
+// ---------------------------------------------------------------------------
+
+/// Validate a scenario filename (no path traversal, must end with `.feature`).
+fn validate_scenario_filename(filename: &str) -> Result<(), (StatusCode, String)> {
+    if filename.contains('/') || filename.contains('\\') || filename.contains("..") {
+        return Err((StatusCode::BAD_REQUEST, "Invalid filename".to_string()));
+    }
+    if !filename.ends_with(".feature") {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "Only .feature files are supported".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+/// Compute the backend-relative path for a scenario file.
+///
+/// Given a law's file_path and its source configuration, returns the path
+/// relative to the backend's root that points to `scenarios/{filename}`.
+fn scenario_relative_path(
+    law: &LoadedLaw,
+    source: &regelrecht_corpus::Source,
+    filename: &str,
+) -> Result<PathBuf, (StatusCode, String)> {
+    let file_path = std::path::Path::new(&law.file_path);
+    let law_dir = file_path.parent().ok_or_else(|| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Cannot determine law directory".to_string(),
+        )
+    })?;
+
+    // Determine the source root to strip from the law's file_path.
+    let source_root: PathBuf = match &source.source_type {
+        SourceType::Local { local } => local.path.clone(),
+        SourceType::GitHub { github } => {
+            // For GitHub-fetched laws, file_path is repo-relative (e.g.
+            // "regulation/nl/wet/law_id/2025.yaml"). The backend's subpath
+            // already accounts for github.path, so strip it here.
+            github.path.as_ref().map(PathBuf::from).unwrap_or_default()
+        }
+    };
+
+    let relative_law_dir = law_dir.strip_prefix(&source_root).unwrap_or(law_dir);
+    Ok(relative_law_dir.join("scenarios").join(filename))
+}
+
+/// Resolved backend information for a law.
+struct ResolvedBackend {
+    law: LoadedLaw,
+    source: regelrecht_corpus::Source,
+    backend: Arc<Mutex<Box<dyn RepoBackend>>>,
+}
+
+/// Look up the backend and source for a law.
+fn resolve_backend(
+    corpus: &crate::state::CorpusState,
+    law_id: &str,
+) -> Result<ResolvedBackend, (StatusCode, String)> {
+    let law = corpus
+        .source_map
+        .get_law(law_id)
+        .ok_or_else(|| (StatusCode::NOT_FOUND, format!("Law '{}' not found", law_id)))?
+        .clone();
+
+    let source = corpus
+        .registry
+        .sources()
+        .iter()
+        .find(|s| s.id == law.source_id)
+        .ok_or_else(|| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Source '{}' not found in registry", law.source_id),
+            )
+        })?
+        .clone();
+
+    let backend = corpus
+        .backends
+        .get(&law.source_id)
+        .ok_or_else(|| {
+            (
+                StatusCode::FORBIDDEN,
+                format!("No write backend available for source '{}'", law.source_id),
+            )
+        })?
+        .clone();
+
+    Ok(ResolvedBackend {
+        law,
+        source,
+        backend,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Save / Delete scenario endpoints
+// ---------------------------------------------------------------------------
+
+/// PUT /api/corpus/laws/{law_id}/scenarios/{filename} — save a scenario file.
+pub async fn save_scenario(
+    State(state): State<AppState>,
+    Path((law_id, filename)): Path<(String, String)>,
+    body: String,
+) -> Result<StatusCode, (StatusCode, String)> {
+    validate_scenario_filename(&filename)?;
+
+    let resolved = {
+        let corpus = state.corpus.read().await;
+        resolve_backend(&corpus, &law_id)?
+    };
+
+    let relative_path = scenario_relative_path(&resolved.law, &resolved.source, &filename)?;
+
+    let backend = resolved.backend.lock().await;
+    if !backend.is_writable() {
+        return Err((StatusCode::FORBIDDEN, "Source is read-only".to_string()));
+    }
+
+    backend
+        .write_file(&relative_path, &body)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    backend
+        .persist(&WriteContext {
+            message: format!("Update scenario {} for {}", filename, law_id),
+        })
+        .await
+        .map_err(|e| (StatusCode::CONFLICT, format!("Failed to persist: {e}")))?;
+
+    Ok(StatusCode::OK)
+}
+
+/// DELETE /api/corpus/laws/{law_id}/scenarios/{filename} — delete a scenario file.
+pub async fn delete_scenario(
+    State(state): State<AppState>,
+    Path((law_id, filename)): Path<(String, String)>,
+) -> Result<StatusCode, (StatusCode, String)> {
+    validate_scenario_filename(&filename)?;
+
+    let resolved = {
+        let corpus = state.corpus.read().await;
+        resolve_backend(&corpus, &law_id)?
+    };
+
+    let relative_path = scenario_relative_path(&resolved.law, &resolved.source, &filename)?;
+
+    let backend = resolved.backend.lock().await;
+    if !backend.is_writable() {
+        return Err((StatusCode::FORBIDDEN, "Source is read-only".to_string()));
+    }
+
+    backend
+        .delete_file(&relative_path)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    backend
+        .persist(&WriteContext {
+            message: format!("Delete scenario {} for {}", filename, law_id),
+        })
+        .await
+        .map_err(|e| (StatusCode::CONFLICT, format!("Failed to persist: {e}")))?;
+
+    Ok(StatusCode::OK)
 }

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -293,10 +293,18 @@ struct ResolvedBackend {
 
 /// Look up a writable backend for a law.
 ///
-/// First tries the law's own source backend. If that backend is not writable
-/// (e.g. read-only container filesystem), falls back to any writable backend.
-/// This allows deployed editors to write to a git repo even when laws are
-/// loaded from a baked-in local source.
+/// Only the law's *own* source backend is considered. Earlier revisions of
+/// this PR fell back to "any writable backend" to support deployments where
+/// laws were baked into a read-only local source while git pushes had to go
+/// elsewhere — but the path that gets written is always
+/// `law.relative_path`, which is relative to the **law's own** source root.
+/// Writing that path through a backend rooted at a different source silently
+/// produces files at the wrong location (e.g. `wet/foo/scenarios/x.feature`
+/// in a backend whose laws actually live under `regulation/nl/`), and the
+/// reader side never sees them.
+///
+/// Operators who need cross-source writes must configure the law's own
+/// source as writable rather than relying on an implicit fallback.
 fn resolve_writable_backend(
     corpus: &crate::state::CorpusState,
     law_id: &str,
@@ -307,26 +315,19 @@ fn resolve_writable_backend(
         .ok_or_else(|| (StatusCode::NOT_FOUND, format!("Law '{}' not found", law_id)))?
         .clone();
 
-    // Try the law's own backend first, then fall back to any other backend.
-    // The fallback picks the backend with the lowest source ID (alphabetical)
-    // for deterministic behaviour across restarts.
-    let backend = if let Some(b) = corpus.backends.get(&law.source_id) {
-        b.clone()
-    } else if let Some((fallback_id, b)) = corpus.backends.iter().min_by_key(|(k, _)| (*k).clone())
-    {
-        tracing::warn!(
-            law_id = %law_id,
-            law_source = %law.source_id,
-            fallback_source = %fallback_id,
-            "law's own source has no write backend, falling back to a different source"
-        );
-        b.clone()
-    } else {
-        return Err((
-            StatusCode::FORBIDDEN,
-            "No write backend available".to_string(),
-        ));
-    };
+    let backend = corpus
+        .backends
+        .get(&law.source_id)
+        .cloned()
+        .ok_or_else(|| {
+            (
+                StatusCode::FORBIDDEN,
+                format!(
+                "No writable backend registered for source '{}' (the source that owns law '{}')",
+                law.source_id, law_id
+            ),
+            )
+        })?;
 
     Ok(ResolvedBackend { law, backend })
 }

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -145,60 +145,36 @@ pub struct ScenarioEntry {
     pub filename: String,
 }
 
-/// Derive the scenarios directory from a law's file_path.
-///
-/// Given a law file at `.../wet_op_de_zorgtoeslag/2025-01-01.yaml`,
-/// the scenarios directory is `.../wet_op_de_zorgtoeslag/scenarios/`.
-fn scenarios_dir_for_law(file_path: &str) -> Option<PathBuf> {
-    let path = PathBuf::from(file_path);
-    let parent = path.parent()?;
-    Some(parent.join("scenarios"))
-}
-
 /// GET /api/corpus/laws/{law_id}/scenarios — list available scenario files.
 pub async fn list_scenarios(
     State(state): State<AppState>,
     Path(law_id): Path<String>,
 ) -> Result<Json<Vec<ScenarioEntry>>, (StatusCode, String)> {
-    // Resolve the scenarios directory while holding the lock, then drop it before I/O.
-    let scenarios_dir = {
+    // Route reads through the same backend resolution as writes so a save
+    // followed by a list/get always sees its own writes.
+    let resolved = {
         let corpus = state.corpus.read().await;
-        let law = corpus
-            .source_map
-            .get_law(&law_id)
-            .ok_or_else(|| (StatusCode::NOT_FOUND, format!("Law '{}' not found", law_id)))?;
-        match scenarios_dir_for_law(&law.file_path) {
-            Some(dir) => dir,
-            _ => return Ok(Json(Vec::new())),
-        }
+        resolve_backend_for_law(&corpus, &law_id).await?
     };
 
-    if !scenarios_dir.is_dir() {
-        return Ok(Json(Vec::new()));
-    }
+    let scenarios_dir = match law_relative_dir(&resolved.law) {
+        Ok(dir) => dir.join("scenarios"),
+        Err(_) => return Ok(Json(Vec::new())),
+    };
 
-    let mut entries = Vec::new();
-    if let Ok(mut read_dir) = tokio::fs::read_dir(&scenarios_dir).await {
-        loop {
-            match read_dir.next_entry().await {
-                Ok(Some(entry)) => {
-                    let path = entry.path();
-                    if path.extension().is_some_and(|ext| ext == "feature") {
-                        if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
-                            entries.push(ScenarioEntry {
-                                filename: name.to_string(),
-                            });
-                        }
-                    }
-                }
-                Ok(None) => break,
-                Err(_) => continue,
-            }
-        }
-    }
+    let backend = resolved.backend.lock().await;
+    let entries = backend
+        .list_files(&scenarios_dir, Some("feature"))
+        .await
+        .unwrap_or_default();
+    drop(backend);
 
-    entries.sort_by(|a, b| a.filename.cmp(&b.filename));
-    Ok(Json(entries))
+    let mut out: Vec<ScenarioEntry> = entries
+        .into_iter()
+        .map(|e| ScenarioEntry { filename: e.name })
+        .collect();
+    out.sort_by(|a, b| a.filename.cmp(&b.filename));
+    Ok(Json(out))
 }
 
 /// GET /api/corpus/laws/{law_id}/scenarios/{filename} — return raw .feature content.
@@ -215,24 +191,26 @@ pub async fn get_scenario(
 > {
     validate_scenario_filename(&filename)?;
 
-    // Resolve path while holding the lock, then drop it before I/O.
-    let file_path = {
+    let resolved = {
         let corpus = state.corpus.read().await;
-        let law = corpus
-            .source_map
-            .get_law(&law_id)
-            .ok_or_else(|| (StatusCode::NOT_FOUND, format!("Law '{}' not found", law_id)))?;
-        let scenarios_dir = scenarios_dir_for_law(&law.file_path)
-            .ok_or_else(|| (StatusCode::NOT_FOUND, "No scenarios directory".to_string()))?;
-        scenarios_dir.join(&filename)
+        resolve_backend_for_law(&corpus, &law_id).await?
     };
 
-    let content = tokio::fs::read_to_string(&file_path).await.map_err(|_| {
-        (
-            StatusCode::NOT_FOUND,
-            format!("Scenario '{}' not found", filename),
-        )
-    })?;
+    let scenarios_dir = law_relative_dir(&resolved.law)?.join("scenarios");
+    let relative_path = scenarios_dir.join(&filename);
+
+    let backend = resolved.backend.lock().await;
+    let content = backend
+        .read_file(&relative_path)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                format!("Scenario '{}' not found", filename),
+            )
+        })?;
+    drop(backend);
 
     Ok((
         StatusCode::OK,
@@ -289,23 +267,34 @@ fn law_relative_dir(law: &LoadedLaw) -> Result<PathBuf, (StatusCode, String)> {
 struct ResolvedBackend {
     law: LoadedLaw,
     backend: Arc<Mutex<Box<dyn RepoBackend>>>,
+    /// Whether the resolved backend supports writes. Read handlers ignore
+    /// this; write handlers must reject the request with 403 if `false`.
+    writable: bool,
 }
 
-/// Look up a writable backend for a law.
+/// Resolve the backend that should be used for a law's scenario files.
 ///
-/// Tries the law's *own* source backend first. If that source has no
-/// registered backend (e.g. the local source was loaded from a read-only
-/// container filesystem and skipped during init), falls back to another
-/// backend that contains the **same law file at the same source-relative
-/// path** — verified by reading `law.relative_path` from the candidate.
+/// Both read and write handlers go through this function so the editor
+/// always uses the **same** backend for `get_scenario` / `list_scenarios` /
+/// `save_scenario` / `delete_scenario` on a given law. Without this single
+/// source of truth, a read can end up at one on-disk location while a write
+/// for the same law lands at a different one — silent data loss.
 ///
-/// The verification is what makes the fallback safe: it guarantees the two
-/// sources share a structural layout under their roots, so writing a
-/// scenario at `<law_dir>/scenarios/<file>` in the fallback backend lands
-/// at the directory the reader side already addresses. Without this check
-/// the fallback could silently produce files at a path the reader never
-/// looks at.
-async fn resolve_writable_backend(
+/// Resolution order:
+///
+/// 1. **Law's own writable backend.** Happy path for normal local-only dev.
+/// 2. **Verified writable fallback.** When the law's own source is read-only
+///    (e.g. baked-in container filesystem) we look for another writable
+///    backend whose root contains the **same** law file at the same
+///    `law.relative_path`. A successful read of that path proves the two
+///    sources share their structural layout, so subsequent reads/writes of
+///    sibling scenario files land at consistent locations.
+/// 3. **Law's own read-only backend.** No writable target available. Reads
+///    still work; writes will be rejected with 403 by the caller.
+///
+/// The verification in step 2 is essential: without it the fallback could
+/// silently produce files at a path the reader never looks at.
+async fn resolve_backend_for_law(
     corpus: &crate::state::CorpusState,
     law_id: &str,
 ) -> Result<ResolvedBackend, (StatusCode, String)> {
@@ -315,25 +304,32 @@ async fn resolve_writable_backend(
         .ok_or_else(|| (StatusCode::NOT_FOUND, format!("Law '{}' not found", law_id)))?
         .clone();
 
-    // Fast path: the law's own source has a backend.
-    if let Some(backend) = corpus.backends.get(&law.source_id).cloned() {
-        return Ok(ResolvedBackend { law, backend });
+    // 1. Prefer the law's own backend if it can accept writes.
+    if let Some(entry) = corpus.backends.get(&law.source_id) {
+        if entry.writable {
+            return Ok(ResolvedBackend {
+                law,
+                backend: entry.backend.clone(),
+                writable: true,
+            });
+        }
     }
 
-    // Fallback: look for another backend that contains this exact law at
-    // the same source-relative path. Iterating in alphabetical order keeps
-    // the choice deterministic across restarts.
+    // 2. Look for another writable backend that contains the same law file
+    //    at the same source-relative path. Alphabetical iteration keeps the
+    //    choice deterministic across restarts.
     let law_rel = std::path::Path::new(&law.relative_path);
     let mut candidate_ids: Vec<&String> = corpus.backends.keys().collect();
     candidate_ids.sort();
 
     for source_id in candidate_ids {
-        let Some(backend_arc) = corpus.backends.get(source_id) else {
+        let Some(entry) = corpus.backends.get(source_id) else {
             continue;
         };
-        // Briefly lock to probe; release before returning so the caller's
-        // own lock acquisition is uncontended.
-        let backend = backend_arc.lock().await;
+        if !entry.writable || source_id == &law.source_id {
+            continue;
+        }
+        let backend = entry.backend.lock().await;
         let exists = backend.read_file(law_rel).await.ok().flatten().is_some();
         drop(backend);
         if exists {
@@ -341,20 +337,30 @@ async fn resolve_writable_backend(
                 law_id = %law_id,
                 law_source = %law.source_id,
                 fallback_source = %source_id,
-                "law's own source has no write backend; falling back to a verified-matching source"
+                "law's own source has no writable backend; routing reads and writes through verified-matching source"
             );
             return Ok(ResolvedBackend {
                 law,
-                backend: backend_arc.clone(),
+                backend: entry.backend.clone(),
+                writable: true,
             });
         }
     }
 
+    // 3. Fall through to the law's own read-only backend so reads still
+    //    work. Write handlers turn this into a 403.
+    if let Some(entry) = corpus.backends.get(&law.source_id) {
+        return Ok(ResolvedBackend {
+            law,
+            backend: entry.backend.clone(),
+            writable: entry.writable,
+        });
+    }
+
     Err((
-        StatusCode::FORBIDDEN,
+        StatusCode::NOT_FOUND,
         format!(
-            "No writable backend registered for source '{}' (the source that owns law '{}'), \
-             and no other backend contains a matching copy of the law at the same path",
+            "No backend registered for source '{}' (the source that owns law '{}')",
             law.source_id, law_id
         ),
     ))
@@ -380,8 +386,9 @@ fn corpus_write_error(e: CorpusError) -> (StatusCode, String) {
 // Save / Delete scenario endpoints
 // ---------------------------------------------------------------------------
 
-/// Resolve write target: find a writable backend, compute the scenario path,
-/// and lock the backend. Shared by save and delete handlers.
+/// Resolve write target: pick the backend, compute the scenario path, and
+/// lock the backend. Shared by save and delete handlers. Returns 403 if the
+/// resolved backend is read-only — the caller cannot recover from this.
 async fn resolve_write_target(
     state: &AppState,
     law_id: &str,
@@ -389,8 +396,19 @@ async fn resolve_write_target(
 ) -> Result<(PathBuf, tokio::sync::OwnedMutexGuard<Box<dyn RepoBackend>>), (StatusCode, String)> {
     let resolved = {
         let corpus = state.corpus.read().await;
-        resolve_writable_backend(&corpus, law_id).await?
+        resolve_backend_for_law(&corpus, law_id).await?
     };
+
+    if !resolved.writable {
+        return Err((
+            StatusCode::FORBIDDEN,
+            format!(
+                "No writable backend available for law '{}' (source '{}' is read-only \
+                 and no other registered source contains a matching copy of the law)",
+                law_id, resolved.law.source_id
+            ),
+        ));
+    }
 
     let rel_dir = law_relative_dir(&resolved.law)?;
     let relative_path = rel_dir.join("scenarios").join(filename);

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -293,19 +293,19 @@ struct ResolvedBackend {
 
 /// Look up a writable backend for a law.
 ///
-/// Only the law's *own* source backend is considered. Earlier revisions of
-/// this PR fell back to "any writable backend" to support deployments where
-/// laws were baked into a read-only local source while git pushes had to go
-/// elsewhere — but the path that gets written is always
-/// `law.relative_path`, which is relative to the **law's own** source root.
-/// Writing that path through a backend rooted at a different source silently
-/// produces files at the wrong location (e.g. `wet/foo/scenarios/x.feature`
-/// in a backend whose laws actually live under `regulation/nl/`), and the
-/// reader side never sees them.
+/// Tries the law's *own* source backend first. If that source has no
+/// registered backend (e.g. the local source was loaded from a read-only
+/// container filesystem and skipped during init), falls back to another
+/// backend that contains the **same law file at the same source-relative
+/// path** — verified by reading `law.relative_path` from the candidate.
 ///
-/// Operators who need cross-source writes must configure the law's own
-/// source as writable rather than relying on an implicit fallback.
-fn resolve_writable_backend(
+/// The verification is what makes the fallback safe: it guarantees the two
+/// sources share a structural layout under their roots, so writing a
+/// scenario at `<law_dir>/scenarios/<file>` in the fallback backend lands
+/// at the directory the reader side already addresses. Without this check
+/// the fallback could silently produce files at a path the reader never
+/// looks at.
+async fn resolve_writable_backend(
     corpus: &crate::state::CorpusState,
     law_id: &str,
 ) -> Result<ResolvedBackend, (StatusCode, String)> {
@@ -315,21 +315,49 @@ fn resolve_writable_backend(
         .ok_or_else(|| (StatusCode::NOT_FOUND, format!("Law '{}' not found", law_id)))?
         .clone();
 
-    let backend = corpus
-        .backends
-        .get(&law.source_id)
-        .cloned()
-        .ok_or_else(|| {
-            (
-                StatusCode::FORBIDDEN,
-                format!(
-                "No writable backend registered for source '{}' (the source that owns law '{}')",
-                law.source_id, law_id
-            ),
-            )
-        })?;
+    // Fast path: the law's own source has a backend.
+    if let Some(backend) = corpus.backends.get(&law.source_id).cloned() {
+        return Ok(ResolvedBackend { law, backend });
+    }
 
-    Ok(ResolvedBackend { law, backend })
+    // Fallback: look for another backend that contains this exact law at
+    // the same source-relative path. Iterating in alphabetical order keeps
+    // the choice deterministic across restarts.
+    let law_rel = std::path::Path::new(&law.relative_path);
+    let mut candidate_ids: Vec<&String> = corpus.backends.keys().collect();
+    candidate_ids.sort();
+
+    for source_id in candidate_ids {
+        let Some(backend_arc) = corpus.backends.get(source_id) else {
+            continue;
+        };
+        // Briefly lock to probe; release before returning so the caller's
+        // own lock acquisition is uncontended.
+        let backend = backend_arc.lock().await;
+        let exists = backend.read_file(law_rel).await.ok().flatten().is_some();
+        drop(backend);
+        if exists {
+            tracing::warn!(
+                law_id = %law_id,
+                law_source = %law.source_id,
+                fallback_source = %source_id,
+                "law's own source has no write backend; falling back to a verified-matching source"
+            );
+            return Ok(ResolvedBackend {
+                law,
+                backend: backend_arc.clone(),
+            });
+        }
+    }
+
+    Err((
+        StatusCode::FORBIDDEN,
+        format!(
+            "No writable backend registered for source '{}' (the source that owns law '{}'), \
+             and no other backend contains a matching copy of the law at the same path",
+            law.source_id, law_id
+        ),
+    ))
 }
 
 /// Map a [`CorpusError`] from a write / delete / persist operation to an
@@ -361,7 +389,7 @@ async fn resolve_write_target(
 ) -> Result<(PathBuf, tokio::sync::OwnedMutexGuard<Box<dyn RepoBackend>>), (StatusCode, String)> {
     let resolved = {
         let corpus = state.corpus.read().await;
-        resolve_writable_backend(&corpus, law_id)?
+        resolve_writable_backend(&corpus, law_id).await?
     };
 
     let rel_dir = law_relative_dir(&resolved.law)?;

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -9,6 +9,7 @@ use tokio::sync::Mutex;
 
 use regelrecht_corpus::backend::{RepoBackend, WriteContext};
 use regelrecht_corpus::source_map::LoadedLaw;
+use regelrecht_corpus::CorpusError;
 
 use crate::state::AppState;
 
@@ -345,6 +346,19 @@ fn resolve_writable_backend(
     Ok(ResolvedBackend { law, backend })
 }
 
+/// Map a [`CorpusError`] from a write/delete operation to an HTTP error tuple.
+///
+/// `ReadOnly` is an expected, recoverable precondition (e.g. the resolved
+/// backend is a baked-in local source on a read-only container filesystem),
+/// and must surface as `403 Forbidden` so the frontend can render a useful
+/// message instead of "Internal Server Error".
+fn corpus_write_error(e: CorpusError) -> (StatusCode, String) {
+    match e {
+        CorpusError::ReadOnly(_) => (StatusCode::FORBIDDEN, e.to_string()),
+        _ => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Save / Delete scenario endpoints
 // ---------------------------------------------------------------------------
@@ -382,7 +396,7 @@ pub async fn save_scenario(
     backend
         .write_file(&relative_path, &body)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        .map_err(corpus_write_error)?;
 
     backend
         .persist(&WriteContext {
@@ -406,7 +420,7 @@ pub async fn delete_scenario(
     backend
         .delete_file(&relative_path)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        .map_err(corpus_write_error)?;
 
     backend
         .persist(&WriteContext {

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -9,7 +9,6 @@ use tokio::sync::Mutex;
 
 use regelrecht_corpus::backend::{RepoBackend, WriteContext};
 use regelrecht_corpus::source_map::LoadedLaw;
-use regelrecht_corpus::SourceType;
 
 use crate::state::AppState;
 
@@ -272,15 +271,16 @@ fn validate_scenario_filename(filename: &str) -> Result<(), (StatusCode, String)
     Ok(())
 }
 
-/// Extract the law-relative directory from a law's file_path and its source.
+/// Extract the law-relative directory from a law's file_path.
 ///
-/// Returns the structural path like `wet/law_id/` that is the same regardless
-/// of which backend is used. This is the law directory relative to the source
-/// root.
-fn law_relative_dir(
-    law: &LoadedLaw,
-    source: &regelrecht_corpus::Source,
-) -> Result<PathBuf, (StatusCode, String)> {
+/// Returns the structural path like `wet/law_id/` — the path from the
+/// regulation root to the law directory. This is source-agnostic and works
+/// with any backend.
+///
+/// The law's file_path is either absolute (local sources) or repo-relative
+/// (GitHub-fetched). In both cases the structural part is the last two path
+/// components: `{regulatory_layer}/{law_id}/`.
+fn law_relative_dir(law: &LoadedLaw) -> Result<PathBuf, (StatusCode, String)> {
     let file_path = std::path::Path::new(&law.file_path);
     let law_dir = file_path.parent().ok_or_else(|| {
         (
@@ -289,23 +289,25 @@ fn law_relative_dir(
         )
     })?;
 
-    // Determine the source root to strip from the law's file_path.
-    let source_root: PathBuf = match &source.source_type {
-        SourceType::Local { local } => local.path.clone(),
-        SourceType::GitHub { github } => {
-            github.path.as_ref().map(PathBuf::from).unwrap_or_default()
-        }
-    };
-
-    let relative = law_dir.strip_prefix(&source_root).unwrap_or(law_dir);
-    Ok(relative.to_path_buf())
+    // Extract the last two components: regulatory_layer/law_id
+    // e.g. from "/abs/path/corpus/regulation/nl/wet/my_law/2025.yaml"
+    //   → parent = ".../wet/my_law"
+    //   → last two components = "wet/my_law"
+    let components: Vec<_> = law_dir.components().rev().take(2).collect();
+    if components.len() == 2 {
+        let mut rel = PathBuf::new();
+        rel.push(components[1].as_os_str());
+        rel.push(components[0].as_os_str());
+        Ok(rel)
+    } else {
+        // Fallback: use the full law_dir filename as-is
+        Ok(law_dir.file_name().map(PathBuf::from).unwrap_or_default())
+    }
 }
 
 /// Resolved backend information for a law.
 struct ResolvedBackend {
     law: LoadedLaw,
-    /// Source the law was loaded from (used for path computation).
-    law_source: regelrecht_corpus::Source,
     backend: Arc<Mutex<Box<dyn RepoBackend>>>,
 }
 
@@ -325,26 +327,18 @@ fn resolve_writable_backend(
         .ok_or_else(|| (StatusCode::NOT_FOUND, format!("Law '{}' not found", law_id)))?
         .clone();
 
-    let law_source = corpus
-        .registry
-        .sources()
-        .iter()
-        .find(|s| s.id == law.source_id)
-        .ok_or_else(|| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Source '{}' not found in registry", law.source_id),
-            )
-        })?
-        .clone();
-
-    // Try the law's own backend first, then fall back to any writable backend.
+    // Try the law's own backend first, then fall back to any other backend.
+    // The fallback picks the backend with the lowest source ID (alphabetical)
+    // for deterministic behaviour across restarts.
     let backend = corpus
         .backends
         .get(&law.source_id)
         .or_else(|| {
-            // Pick the first available backend as fallback.
-            corpus.backends.values().next()
+            corpus
+                .backends
+                .iter()
+                .min_by_key(|(k, _)| (*k).clone())
+                .map(|(_, v)| v)
         })
         .ok_or_else(|| {
             (
@@ -354,11 +348,7 @@ fn resolve_writable_backend(
         })?
         .clone();
 
-    Ok(ResolvedBackend {
-        law,
-        law_source,
-        backend,
-    })
+    Ok(ResolvedBackend { law, backend })
 }
 
 // ---------------------------------------------------------------------------
@@ -377,7 +367,7 @@ async fn resolve_write_target(
         resolve_writable_backend(&corpus, law_id)?
     };
 
-    let rel_dir = law_relative_dir(&resolved.law, &resolved.law_source)?;
+    let rel_dir = law_relative_dir(&resolved.law)?;
     let relative_path = rel_dir.join("scenarios").join(filename);
 
     let backend = resolved.backend.lock_owned().await;

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -272,14 +272,14 @@ fn validate_scenario_filename(filename: &str) -> Result<(), (StatusCode, String)
     Ok(())
 }
 
-/// Compute the backend-relative path for a scenario file.
+/// Extract the law-relative directory from a law's file_path and its source.
 ///
-/// Given a law's file_path and its source configuration, returns the path
-/// relative to the backend's root that points to `scenarios/{filename}`.
-fn scenario_relative_path(
+/// Returns the structural path like `wet/law_id/` that is the same regardless
+/// of which backend is used. This is the law directory relative to the source
+/// root.
+fn law_relative_dir(
     law: &LoadedLaw,
     source: &regelrecht_corpus::Source,
-    filename: &str,
 ) -> Result<PathBuf, (StatusCode, String)> {
     let file_path = std::path::Path::new(&law.file_path);
     let law_dir = file_path.parent().ok_or_else(|| {
@@ -293,26 +293,29 @@ fn scenario_relative_path(
     let source_root: PathBuf = match &source.source_type {
         SourceType::Local { local } => local.path.clone(),
         SourceType::GitHub { github } => {
-            // For GitHub-fetched laws, file_path is repo-relative (e.g.
-            // "regulation/nl/wet/law_id/2025.yaml"). The backend's subpath
-            // already accounts for github.path, so strip it here.
             github.path.as_ref().map(PathBuf::from).unwrap_or_default()
         }
     };
 
-    let relative_law_dir = law_dir.strip_prefix(&source_root).unwrap_or(law_dir);
-    Ok(relative_law_dir.join("scenarios").join(filename))
+    let relative = law_dir.strip_prefix(&source_root).unwrap_or(law_dir);
+    Ok(relative.to_path_buf())
 }
 
 /// Resolved backend information for a law.
 struct ResolvedBackend {
     law: LoadedLaw,
-    source: regelrecht_corpus::Source,
+    /// Source the law was loaded from (used for path computation).
+    law_source: regelrecht_corpus::Source,
     backend: Arc<Mutex<Box<dyn RepoBackend>>>,
 }
 
-/// Look up the backend and source for a law.
-fn resolve_backend(
+/// Look up a writable backend for a law.
+///
+/// First tries the law's own source backend. If that backend is not writable
+/// (e.g. read-only container filesystem), falls back to any writable backend.
+/// This allows deployed editors to write to a git repo even when laws are
+/// loaded from a baked-in local source.
+fn resolve_writable_backend(
     corpus: &crate::state::CorpusState,
     law_id: &str,
 ) -> Result<ResolvedBackend, (StatusCode, String)> {
@@ -322,7 +325,7 @@ fn resolve_backend(
         .ok_or_else(|| (StatusCode::NOT_FOUND, format!("Law '{}' not found", law_id)))?
         .clone();
 
-    let source = corpus
+    let law_source = corpus
         .registry
         .sources()
         .iter()
@@ -335,20 +338,25 @@ fn resolve_backend(
         })?
         .clone();
 
+    // Try the law's own backend first, then fall back to any writable backend.
     let backend = corpus
         .backends
         .get(&law.source_id)
+        .or_else(|| {
+            // Pick the first available backend as fallback.
+            corpus.backends.values().next()
+        })
         .ok_or_else(|| {
             (
                 StatusCode::FORBIDDEN,
-                format!("No write backend available for source '{}'", law.source_id),
+                "No write backend available".to_string(),
             )
         })?
         .clone();
 
     Ok(ResolvedBackend {
         law,
-        source,
+        law_source,
         backend,
     })
 }
@@ -356,6 +364,32 @@ fn resolve_backend(
 // ---------------------------------------------------------------------------
 // Save / Delete scenario endpoints
 // ---------------------------------------------------------------------------
+
+/// Resolve write target: find a writable backend, compute the scenario path,
+/// and lock the backend. Shared by save and delete handlers.
+async fn resolve_write_target(
+    state: &AppState,
+    law_id: &str,
+    filename: &str,
+) -> Result<(PathBuf, tokio::sync::OwnedMutexGuard<Box<dyn RepoBackend>>), (StatusCode, String)> {
+    let resolved = {
+        let corpus = state.corpus.read().await;
+        resolve_writable_backend(&corpus, law_id)?
+    };
+
+    let rel_dir = law_relative_dir(&resolved.law, &resolved.law_source)?;
+    let relative_path = rel_dir.join("scenarios").join(filename);
+
+    let backend = resolved.backend.lock_owned().await;
+    if !backend.is_writable() {
+        return Err((
+            StatusCode::FORBIDDEN,
+            "No writable backend available".to_string(),
+        ));
+    }
+
+    Ok((relative_path, backend))
+}
 
 /// PUT /api/corpus/laws/{law_id}/scenarios/{filename} — save a scenario file.
 pub async fn save_scenario(
@@ -365,17 +399,7 @@ pub async fn save_scenario(
 ) -> Result<StatusCode, (StatusCode, String)> {
     validate_scenario_filename(&filename)?;
 
-    let resolved = {
-        let corpus = state.corpus.read().await;
-        resolve_backend(&corpus, &law_id)?
-    };
-
-    let relative_path = scenario_relative_path(&resolved.law, &resolved.source, &filename)?;
-
-    let backend = resolved.backend.lock().await;
-    if !backend.is_writable() {
-        return Err((StatusCode::FORBIDDEN, "Source is read-only".to_string()));
-    }
+    let (relative_path, backend) = resolve_write_target(&state, &law_id, &filename).await?;
 
     backend
         .write_file(&relative_path, &body)
@@ -399,17 +423,7 @@ pub async fn delete_scenario(
 ) -> Result<StatusCode, (StatusCode, String)> {
     validate_scenario_filename(&filename)?;
 
-    let resolved = {
-        let corpus = state.corpus.read().await;
-        resolve_backend(&corpus, &law_id)?
-    };
-
-    let relative_path = scenario_relative_path(&resolved.law, &resolved.source, &filename)?;
-
-    let backend = resolved.backend.lock().await;
-    if !backend.is_writable() {
-        return Err((StatusCode::FORBIDDEN, "Source is read-only".to_string()));
-    }
+    let (relative_path, backend) = resolve_write_target(&state, &law_id, &filename).await?;
 
     backend
         .delete_file(&relative_path)

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -212,21 +212,7 @@ pub async fn get_scenario(
     ),
     (StatusCode, String),
 > {
-    // Reject path traversal attempts
-    if filename.contains('/')
-        || filename.contains('\\')
-        || filename.contains("..")
-        || filename.contains('\0')
-    {
-        return Err((StatusCode::BAD_REQUEST, "Invalid filename".to_string()));
-    }
-
-    if !filename.ends_with(".feature") {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            "Only .feature files are served".to_string(),
-        ));
-    }
+    validate_scenario_filename(&filename)?;
 
     // Resolve path while holding the lock, then drop it before I/O.
     let file_path = {

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -213,7 +213,11 @@ pub async fn get_scenario(
     (StatusCode, String),
 > {
     // Reject path traversal attempts
-    if filename.contains('/') || filename.contains('\\') || filename.contains("..") {
+    if filename.contains('/')
+        || filename.contains('\\')
+        || filename.contains("..")
+        || filename.contains('\0')
+    {
         return Err((StatusCode::BAD_REQUEST, "Invalid filename".to_string()));
     }
 
@@ -259,7 +263,11 @@ pub async fn get_scenario(
 
 /// Validate a scenario filename (no path traversal, must end with `.feature`).
 fn validate_scenario_filename(filename: &str) -> Result<(), (StatusCode, String)> {
-    if filename.contains('/') || filename.contains('\\') || filename.contains("..") {
+    if filename.contains('/')
+        || filename.contains('\\')
+        || filename.contains("..")
+        || filename.contains('\0')
+    {
         return Err((StatusCode::BAD_REQUEST, "Invalid filename".to_string()));
     }
     if !filename.ends_with(".feature") {

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -346,12 +346,15 @@ fn resolve_writable_backend(
     Ok(ResolvedBackend { law, backend })
 }
 
-/// Map a [`CorpusError`] from a write/delete operation to an HTTP error tuple.
+/// Map a [`CorpusError`] from a write / delete / persist operation to an
+/// HTTP error tuple.
 ///
 /// `ReadOnly` is an expected, recoverable precondition (e.g. the resolved
 /// backend is a baked-in local source on a read-only container filesystem),
 /// and must surface as `403 Forbidden` so the frontend can render a useful
-/// message instead of "Internal Server Error".
+/// message instead of "Internal Server Error". Everything else (IO, git
+/// command failures, push failures, …) is unexpected from the client's
+/// perspective and falls through to `500 Internal Server Error`.
 fn corpus_write_error(e: CorpusError) -> (StatusCode, String) {
     match e {
         CorpusError::ReadOnly(_) => (StatusCode::FORBIDDEN, e.to_string()),
@@ -403,7 +406,7 @@ pub async fn save_scenario(
             message: format!("Update scenario {} for {}", filename, law_id),
         })
         .await
-        .map_err(|e| (StatusCode::CONFLICT, format!("Failed to persist: {e}")))?;
+        .map_err(corpus_write_error)?;
 
     Ok(StatusCode::OK)
 }
@@ -427,7 +430,7 @@ pub async fn delete_scenario(
             message: format!("Delete scenario {} for {}", filename, law_id),
         })
         .await
-        .map_err(|e| (StatusCode::CONFLICT, format!("Failed to persist: {e}")))?;
+        .map_err(corpus_write_error)?;
 
     Ok(StatusCode::OK)
 }

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -163,10 +163,20 @@ pub async fn list_scenarios(
     };
 
     let backend = resolved.backend.lock().await;
+    // Surface real backend errors (permissions, broken git checkout, …) as
+    // 500 instead of swallowing them as "no scenarios". `list_files` itself
+    // already returns `Ok(vec![])` for a missing directory, so anything that
+    // does reach the error arm is a genuine fault worth telling the client.
     let entries = backend
         .list_files(&scenarios_dir, Some("feature"))
         .await
-        .unwrap_or_default();
+        .map_err(|e| {
+            tracing::warn!(law_id = %law_id, error = %e, "list_scenarios backend failure");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to list scenarios".to_string(),
+            )
+        })?;
     drop(backend);
 
     let mut out: Vec<ScenarioEntry> = entries
@@ -371,14 +381,23 @@ async fn resolve_backend_for_law(
 ///
 /// `ReadOnly` is an expected, recoverable precondition (e.g. the resolved
 /// backend is a baked-in local source on a read-only container filesystem),
-/// and must surface as `403 Forbidden` so the frontend can render a useful
-/// message instead of "Internal Server Error". Everything else (IO, git
-/// command failures, push failures, …) is unexpected from the client's
-/// perspective and falls through to `500 Internal Server Error`.
+/// and the message is safe to surface to the user as `403 Forbidden`.
+///
+/// Every other variant (IO, git command failures, push failures, …) goes
+/// out as `500 Internal Server Error` with a **generic** message. The full
+/// error — which can include git stderr, repository URLs that may carry
+/// push tokens for local-only backends, and absolute filesystem paths — is
+/// logged at warn level for operators but never returned to the client.
 fn corpus_write_error(e: CorpusError) -> (StatusCode, String) {
     match e {
         CorpusError::ReadOnly(_) => (StatusCode::FORBIDDEN, e.to_string()),
-        _ => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()),
+        _ => {
+            tracing::warn!(error = %e, "scenario write/persist failed");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Internal error while writing scenario".to_string(),
+            )
+        }
     }
 }
 

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -311,6 +311,13 @@ async fn init_backends(
                     );
                     continue;
                 }
+                if !backend.is_writable() {
+                    tracing::info!(
+                        source_id = %source.id,
+                        "backend is read-only, skipping"
+                    );
+                    continue;
+                }
                 tracing::info!(source_id = %source.id, "write backend ready");
                 backends.insert(source.id.clone(), Arc::new(Mutex::new(backend)));
             }

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -88,17 +88,22 @@ async fn main() {
         )
         .route(
             "/api/corpus/laws/{law_id}/scenarios/{filename}",
-            get(corpus_handlers::get_scenario)
-                .put(corpus_handlers::save_scenario)
-                .delete(corpus_handlers::delete_scenario),
+            get(corpus_handlers::get_scenario),
         );
 
     // Protected API routes — require authentication when OIDC is enabled.
-    // Currently empty; PR #422 and #517 will add write endpoints here.
-    // NOTE: add .route_layer(axum_middleware::from_fn_with_state(
-    //     app_state.clone(), middleware::require_session_auth::<AppState>))
-    // once actual routes are added — an empty Router with route_layer panics.
-    let protected_api_routes = Router::new();
+    // Write endpoints (PUT/DELETE) for scenarios live here so they cannot be
+    // invoked anonymously when a deployment has a git push token configured.
+    let protected_api_routes = Router::new()
+        .route(
+            "/api/corpus/laws/{law_id}/scenarios/{filename}",
+            axum::routing::put(corpus_handlers::save_scenario)
+                .delete(corpus_handlers::delete_scenario),
+        )
+        .route_layer(axum_middleware::from_fn_with_state(
+            app_state.clone(),
+            middleware::require_session_auth::<AppState>,
+        ));
 
     // --- Build app with session layer ---
     // SessionManagerLayer is generic over the store type, so we build the

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::env;
 use std::net::SocketAddr;
 use std::path::PathBuf;
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use axum::middleware as axum_middleware;
 use axum::routing::get;
 use axum::Router;
-use tokio::sync::RwLock;
+use tokio::sync::{Mutex, RwLock};
 use tower_http::services::{ServeDir, ServeFile};
 use tower_http::trace::TraceLayer;
 use tower_sessions::ExpiredDeletion;
@@ -88,7 +88,9 @@ async fn main() {
         )
         .route(
             "/api/corpus/laws/{law_id}/scenarios/{filename}",
-            get(corpus_handlers::get_scenario),
+            get(corpus_handlers::get_scenario)
+                .put(corpus_handlers::save_scenario)
+                .delete(corpus_handlers::delete_scenario),
         );
 
     // Protected API routes — require authentication when OIDC is enabled.
@@ -272,10 +274,57 @@ async fn init_corpus(static_dir: &str) -> CorpusState {
         }
     };
 
+    let backends = init_backends(&registry, auth_file).await;
+
     CorpusState {
         registry,
         source_map,
+        backends,
     }
+}
+
+/// Create and initialize write backends for each registered source.
+async fn init_backends(
+    registry: &regelrecht_corpus::CorpusRegistry,
+    auth_file: Option<&std::path::Path>,
+) -> HashMap<String, Arc<Mutex<Box<dyn regelrecht_corpus::backend::RepoBackend>>>> {
+    let mut backends = HashMap::new();
+
+    for source in registry.sources() {
+        let token = regelrecht_corpus::auth::resolve_token_for_source(
+            &source.id,
+            source.auth_ref.as_deref(),
+            auth_file,
+        )
+        .unwrap_or_else(|e| {
+            tracing::warn!(source_id = %source.id, error = %e, "failed to resolve auth token");
+            None
+        });
+
+        match regelrecht_corpus::backend::create_backend(source, token.as_deref()) {
+            Ok(mut backend) => {
+                if let Err(e) = backend.ensure_ready().await {
+                    tracing::warn!(
+                        source_id = %source.id,
+                        error = %e,
+                        "backend init failed, writes disabled for this source"
+                    );
+                    continue;
+                }
+                tracing::info!(source_id = %source.id, "write backend ready");
+                backends.insert(source.id.clone(), Arc::new(Mutex::new(backend)));
+            }
+            Err(e) => {
+                tracing::warn!(
+                    source_id = %source.id,
+                    error = %e,
+                    "failed to create backend"
+                );
+            }
+        }
+    }
+
+    backends
 }
 
 /// Read favorites.json from the static directory.

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -301,6 +301,9 @@ async fn init_backends(
             None
         });
 
+        // When a push token is present, the backend will push commits to the
+        // remote repo. This requires authentication on the write endpoints —
+        // do NOT enable push tokens without adding auth middleware first.
         match regelrecht_corpus::backend::create_backend(source, token.as_deref()) {
             Ok(mut backend) => {
                 if let Err(e) = backend.ensure_ready().await {

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -94,11 +94,18 @@ async fn main() {
     // Protected API routes — require authentication when OIDC is enabled.
     // Write endpoints (PUT/DELETE) for scenarios live here so they cannot be
     // invoked anonymously when a deployment has a git push token configured.
+    //
+    // The 1 MiB body cap is generous for a single Gherkin scenario file
+    // (real-world scenarios are a few KiB) and prevents a caller from
+    // streaming an arbitrarily large body to disk — important when OIDC
+    // is disabled in local dev and the endpoint is reachable without auth.
+    const MAX_SCENARIO_BODY: usize = 1024 * 1024;
     let protected_api_routes = Router::new()
         .route(
             "/api/corpus/laws/{law_id}/scenarios/{filename}",
             axum::routing::put(corpus_handlers::save_scenario)
-                .delete(corpus_handlers::delete_scenario),
+                .delete(corpus_handlers::delete_scenario)
+                .layer(axum::extract::DefaultBodyLimit::max(MAX_SCENARIO_BODY)),
         )
         .route_layer(axum_middleware::from_fn_with_state(
             app_state.clone(),

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -295,11 +295,16 @@ async fn init_corpus(static_dir: &str) -> CorpusState {
     }
 }
 
-/// Create and initialize write backends for each registered source.
+/// Create and initialize backends for each registered source.
+///
+/// All successfully-initialised backends are registered, including read-only
+/// ones (e.g. a local source on a read-only container filesystem). Reads
+/// route through the same backends as writes so the editor never has a
+/// read/write path mismatch — see [`crate::state::BackendEntry::writable`].
 async fn init_backends(
     registry: &regelrecht_corpus::CorpusRegistry,
     auth_file: Option<&std::path::Path>,
-) -> HashMap<String, Arc<Mutex<Box<dyn regelrecht_corpus::backend::RepoBackend>>>> {
+) -> HashMap<String, crate::state::BackendEntry> {
     let mut backends = HashMap::new();
 
     for source in registry.sources() {
@@ -322,19 +327,23 @@ async fn init_backends(
                     tracing::warn!(
                         source_id = %source.id,
                         error = %e,
-                        "backend init failed, writes disabled for this source"
+                        "backend init failed, skipping registration"
                     );
                     continue;
                 }
-                if !backend.is_writable() {
-                    tracing::info!(
-                        source_id = %source.id,
-                        "backend is read-only, skipping"
-                    );
-                    continue;
-                }
-                tracing::info!(source_id = %source.id, "write backend ready");
-                backends.insert(source.id.clone(), Arc::new(Mutex::new(backend)));
+                let writable = backend.is_writable();
+                tracing::info!(
+                    source_id = %source.id,
+                    writable,
+                    "backend ready"
+                );
+                backends.insert(
+                    source.id.clone(),
+                    crate::state::BackendEntry {
+                        backend: Arc::new(Mutex::new(backend)),
+                        writable,
+                    },
+                );
             }
             Err(e) => {
                 tracing::warn!(

--- a/packages/editor-api/src/middleware.rs
+++ b/packages/editor-api/src/middleware.rs
@@ -1,3 +1,1 @@
-// Re-enable when protected routes are added:
-// pub use regelrecht_auth::middleware::require_session_auth;
-pub use regelrecht_auth::middleware::security_headers;
+pub use regelrecht_auth::middleware::{require_session_auth, security_headers};

--- a/packages/editor-api/src/state.rs
+++ b/packages/editor-api/src/state.rs
@@ -39,12 +39,23 @@ impl OidcAppState for AppState {
     }
 }
 
+/// A registered backend along with its writability flag, captured at init
+/// time after [`RepoBackend::ensure_ready`] (so a local source on a
+/// read-only filesystem is recorded as `writable: false`).
+pub struct BackendEntry {
+    pub backend: Arc<Mutex<Box<dyn RepoBackend>>>,
+    pub writable: bool,
+}
+
 /// State for the corpus subsystem.
 pub struct CorpusState {
     pub registry: regelrecht_corpus::CorpusRegistry,
     pub source_map: SourceMap,
-    /// Write backends keyed by source ID.
-    pub backends: HashMap<String, Arc<Mutex<Box<dyn RepoBackend>>>>,
+    /// Backends keyed by source ID. Read-only backends are also registered
+    /// here so reads (`get_scenario`, `list_scenarios`) can route through
+    /// the same abstraction as writes — preventing read/write path
+    /// mismatches when a fallback writable backend is used.
+    pub backends: HashMap<String, BackendEntry>,
 }
 
 impl CorpusState {

--- a/packages/editor-api/src/state.rs
+++ b/packages/editor-api/src/state.rs
@@ -1,8 +1,10 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use regelrecht_auth::{ConfiguredClient, OidcAppState, OidcConfig};
+use regelrecht_corpus::backend::RepoBackend;
 use regelrecht_corpus::SourceMap;
-use tokio::sync::RwLock;
+use tokio::sync::{Mutex, RwLock};
 
 use crate::config::AppConfig;
 
@@ -41,6 +43,8 @@ impl OidcAppState for AppState {
 pub struct CorpusState {
     pub registry: regelrecht_corpus::CorpusRegistry,
     pub source_map: SourceMap,
+    /// Write backends keyed by source ID.
+    pub backends: HashMap<String, Arc<Mutex<Box<dyn RepoBackend>>>>,
 }
 
 impl CorpusState {

--- a/packages/editor-api/src/state.rs
+++ b/packages/editor-api/src/state.rs
@@ -53,6 +53,7 @@ impl CorpusState {
         Self {
             registry: regelrecht_corpus::CorpusRegistry::empty(),
             source_map: SourceMap::new(),
+            backends: HashMap::new(),
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds `RepoBackend` trait in `packages/corpus/src/backend.rs` with `LocalBackend` (direct filesystem) and `GitBackend` (clone + commit/push via `CorpusClient`) implementations
- Adds `PUT` and `DELETE` endpoints for `/api/corpus/laws/{law_id}/scenarios/{filename}` in editor-api to save/delete scenario files
- Adds save buttons to both ScenarioBuilder (form mode) and ScenarioGherkin (text mode) frontend components
- Adds `CorpusError::ReadOnly` variant for write-rejection on read-only sources

## Test plan
- [ ] `just build-check` passes
- [ ] `just test` passes (includes 6 new backend unit tests)
- [ ] `just lint` + `just format` clean
- [ ] Manual: start editor-api with local source, save scenario via frontend, verify file written to disk
- [ ] Manual: verify save button shows "Opgeslagen" feedback on success
- [ ] Manual: verify read-only sources return 403 on save attempts