### PR TITLE
ci: add PR title linting for conventional commits

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,7 +1,7 @@
 name: PR Title Lint
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, edited, synchronize]
 
 permissions:
@@ -43,7 +43,7 @@ jobs:
             schema
             deps
           requireScope: false
-          subjectPattern: ^[a-z].+$
+          subjectPattern: ^[a-z].*$
           subjectPatternError: |
             The subject "{subject}" found in the pull request title "{title}"
             must start with a lowercase letter.


### PR DESCRIPTION
## Summary

- Adds `pr-title.yml` workflow using `amannn/action-semantic-pull-request` (v5.5.3, pinned to commit SHA)
- Enforces Conventional Commits format on PR titles with allowed types and scopes matching the monorepo structure
- Subject must start lowercase

## Test plan

- [ ] Open a PR with a non-conventional title → should fail
- [ ] Open a PR with a valid title like `feat(engine): add feature` → should pass
- [ ] Open a PR without a scope → should pass (`requireScope: false`)