### PR TITLE
feat(editor): add feature flags for panel visibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,8 @@ jobs:
             editor-api:
               - packages/editor-api/**
               - packages/corpus/**
+              - packages/pipeline/**
+              - packages/harvester/**
               - Justfile
               - .github/workflows/ci.yml
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -99,6 +99,7 @@ jobs:
     with:
       image-name: minbzk/regelrecht-editor
       dockerfile: frontend/Dockerfile
+      cache-scope: editor
     # Only GITHUB_TOKEN is needed; it is automatically available to called workflows
 
   build-admin:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Development Setup
 
 ### Prerequisites
-- [Rust](https://rustup.rs/) (version pinned in `rust-toolchain.toml`)
+- [Rust](https://rustup.rs/) (stable toolchain)
 - [just](https://github.com/casey/just) command runner
 
 ### Just Commands
@@ -74,7 +74,7 @@ git worktree add .worktrees/feature-branch feature-branch
 ### Law Format
 
 Laws are stored as article-based YAML files conforming to the official JSON schema:
-- Schema: `https://raw.githubusercontent.com/MinBZK/regelrecht/refs/tags/schema-v0.5.1/schema/v0.5.1/schema.json`
+- Schema: `https://raw.githubusercontent.com/MinBZK/regelrecht/refs/heads/main/schema/v0.4.0/schema.json`
 
 ### Cross-Law References
 
@@ -144,6 +144,15 @@ CI runs via `.github/workflows/ci.yml`.
 1. **PR opened/updated**: Builds changed Docker images, pushes to GHCR, deploys `prN` to ZAD
 2. **PR closed**: Deletes ZAD deployment and GHCR images
 3. **Push to main**: Deploys `regelrecht` (production) to ZAD
+
+### Debugging deploy-preview failures
+
+ZAD deploy timeouts ("Task did not complete within 300s") almost always indicate an **application error**, not a platform issue. When `deploy-preview` fails:
+
+1. Check container logs: `zad logs <deployment>` (e.g. `zad logs pr429`)
+2. Look for ERROR lines — common causes: migration conflicts, missing env vars, startup panics
+3. If the DB is in a bad state (e.g. migration checksum mismatch after renumbering), delete the preview deployment (`zad deployment delete <deployment>`) and re-trigger CI to get a fresh DB
+4. Do **not** blindly retry — diagnose the root cause first
 
 ### Required Secrets
 

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -5,6 +5,3 @@ dist
 *.md
 .vscode
 .idea
-# Ensure Rust packages are available in the Docker build context
-# (BuildKit uses this file when the Dockerfile is in frontend/)
-!packages

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,7 +1,0 @@
-node_modules
-dist
-.git
-.gitignore
-*.md
-.vscode
-.idea

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -5,3 +5,6 @@ dist
 *.md
 .vscode
 .idea
+# Ensure Rust packages are available in the Docker build context
+# (BuildKit uses this file when the Dockerfile is in frontend/)
+!packages

--- a/frontend/Dockerfile.dockerignore
+++ b/frontend/Dockerfile.dockerignore
@@ -1,18 +1,20 @@
-.git
-.worktrees
-target
-node_modules
-features
-doc
-*.md
-*.png
-.vscode
-.idea
-.claude
-.pytest_cache
-__pycache__
+# Dockerfile-specific .dockerignore for the editor build.
+# BuildKit resolves this by naming convention (Dockerfile.dockerignore).
+# This replaces the root .dockerignore so the full repo context is
+# available, while still excluding unnecessary files.
+**/.git
+**/.vscode
+**/.idea
+**/.worktrees
+**/node_modules
+**/dist
+**/target
+**/*.md
+**/__pycache__
+**/.pytest_cache
 .github
+.claude
 # Exclude packages not needed for editor-api build
 packages/admin
 packages/tui
-# Keep: packages/editor-api, packages/corpus, packages/engine, packages/harvester, packages/pipeline, packages/shared, packages/Cargo.*
+# Keep: packages/auth, packages/editor-api, packages/corpus, packages/engine, packages/harvester, packages/pipeline, packages/shared, packages/Cargo.*

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -22,13 +22,16 @@ const settingsOpen = ref(false);
 const showMiddlePane = computed(() => isEnabled('panel.scenario_form') || isEnabled('panel.yaml_editor'));
 const showFormOption = computed(() => isEnabled('panel.scenario_form'));
 const showYamlOption = computed(() => isEnabled('panel.yaml_editor'));
+const showResultOption = computed(() => isEnabled('panel.execution_trace'));
+const showMachineOption = computed(() => isEnabled('panel.machine_readable'));
+const showRightPane = computed(() => showResultOption.value || showMachineOption.value);
 
 // Compute visible pane count and slot assignments for split view
 const visiblePanes = computed(() => {
   const panes = [];
   if (isEnabled('panel.article_text')) panes.push('text');
   if (showMiddlePane.value) panes.push('middle');
-  if (isEnabled('panel.execution_trace')) panes.push('trace');
+  if (showRightPane.value) panes.push('trace');
   return panes.length > 0 ? panes : ['text', 'middle', 'trace'];
 });
 const paneSlot = (name) => {
@@ -183,6 +186,12 @@ watch([showFormOption, showYamlOption], ([form, yaml]) => {
   if (!yaml && middlePaneView.value === 'yaml' && form) middlePaneView.value = 'form';
 }, { immediate: true });
 
+// Keep rightPaneView in sync with enabled options
+watch([showResultOption, showMachineOption], ([result, machine]) => {
+  if (!result && rightPaneView.value === 'result' && machine) rightPaneView.value = 'machine';
+  if (!machine && rightPaneView.value === 'machine' && result) rightPaneView.value = 'result';
+}, { immediate: true });
+
 function onMiddlePaneChange(event) {
   const value = event.target?.value ?? event.detail?.[0];
   if (value) middlePaneView.value = value;
@@ -208,7 +217,7 @@ function handleScenarioExecuted({ result, traceText, error, expectations, scenar
   lastError.value = error || null;
   lastExpectations.value = expectations || {};
   lastScenarioName.value = scenarioName || '';
-  rightPaneView.value = 'result';
+  if (showResultOption.value) rightPaneView.value = 'result';
 }
 
 // --- Editor state ---
@@ -745,17 +754,17 @@ function handleActionSave() {
           </ndd-split-view-pane>
 
           <!-- Right: Execution Result or Machine Readable -->
-          <ndd-split-view-pane v-if="isEnabled('panel.execution_trace')" :slot="paneSlot('trace')">
+          <ndd-split-view-pane v-if="showRightPane" :slot="paneSlot('trace')">
             <ndd-page sticky-header>
               <ndd-top-title-bar slot="header" :text="rightPaneTitle">
-                <ndd-segmented-control slot="toolbar" size="md" data-testid="right-pane-toggle" :value="rightPaneView" @change="onRightPaneChange">
+                <ndd-segmented-control v-if="showResultOption && showMachineOption" slot="toolbar" size="md" data-testid="right-pane-toggle" :value="rightPaneView" @change="onRightPaneChange">
                   <ndd-segmented-control-item value="result" text="Resultaat"></ndd-segmented-control-item>
                   <ndd-segmented-control-item value="machine" text="Machine"></ndd-segmented-control-item>
                 </ndd-segmented-control>
               </ndd-top-title-bar>
 
               <ExecutionTraceView
-                v-if="rightPaneView === 'result'"
+                v-if="showResultOption && rightPaneView === 'result'"
                 :result="lastResult"
                 :trace-text="lastTraceText"
                 :error="lastError"
@@ -764,7 +773,7 @@ function handleActionSave() {
               />
 
               <!-- Machine view: structured editor -->
-              <ndd-simple-section v-else-if="rightPaneView === 'machine'">
+              <ndd-simple-section v-else-if="showMachineOption && rightPaneView === 'machine'">
                 <MachineReadable
                   :article="editedArticle"
                   :editable="canEdit"

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -5,14 +5,36 @@ import yaml from 'js-yaml';
 import { useLaw, fetchLaw } from './composables/useLaw.js';
 import { useEngine } from './composables/useEngine.js';
 import { useAuth } from './composables/useAuth.js';
+import { useFeatureFlags } from './composables/useFeatureFlags.js';
 import ArticleText from './components/ArticleText.vue';
 import ActionSheet from './components/ActionSheet.vue';
 import EditSheet from './components/EditSheet.vue';
+import FeatureFlagSettings from './components/FeatureFlagSettings.vue';
 import MachineReadable from './components/MachineReadable.vue';
 import ScenarioBuilder from './components/ScenarioBuilder.vue';
 import ExecutionTraceView from './components/ExecutionTraceView.vue';
 
 const { authenticated, loading: authLoading, oidcConfigured, person, login, logout } = useAuth();
+const { isEnabled } = useFeatureFlags();
+
+const settingsOpen = ref(false);
+
+const showMiddlePane = computed(() => isEnabled('panel.scenario_form') || isEnabled('panel.yaml_editor'));
+const showFormOption = computed(() => isEnabled('panel.scenario_form'));
+const showYamlOption = computed(() => isEnabled('panel.yaml_editor'));
+
+// Compute visible pane count and slot assignments for split view
+const visiblePanes = computed(() => {
+  const panes = [];
+  if (isEnabled('panel.article_text')) panes.push('text');
+  if (showMiddlePane.value) panes.push('middle');
+  if (isEnabled('panel.execution_trace')) panes.push('trace');
+  return panes.length > 0 ? panes : ['text', 'middle', 'trace'];
+});
+const paneSlot = (name) => {
+  const idx = visiblePanes.value.indexOf(name);
+  return idx >= 0 ? `pane-${idx + 1}` : undefined;
+};
 
 // Redirect to login when OIDC is configured but user is not authenticated.
 // { immediate: true } is needed because in SPA navigation the auth state may
@@ -154,6 +176,12 @@ Promise.all(uniqueLawIds.map(async (id) => {
     lawNames.value = { ...lawNames.value, [id]: entry.lawName };
   } catch { /* ignore */ }
 }));
+
+// Keep middlePaneView in sync with enabled options
+watch([showFormOption, showYamlOption], ([form, yaml]) => {
+  if (!form && middlePaneView.value === 'form' && yaml) middlePaneView.value = 'yaml';
+  if (!yaml && middlePaneView.value === 'yaml' && form) middlePaneView.value = 'form';
+}, { immediate: true });
 
 function onMiddlePaneChange(event) {
   const value = event.target?.value ?? event.detail?.[0];
@@ -607,6 +635,8 @@ function handleActionSave() {
                   <ndd-menu-divider></ndd-menu-divider>
                   <ndd-menu-item text="Nieuw project"></ndd-menu-item>
                 </ndd-menu>
+                <ndd-icon-button size="md" icon="gear" title="Instellingen" @click="settingsOpen = true">
+                </ndd-icon-button>
                 <ndd-button-bar-divider></ndd-button-bar-divider>
                 <ndd-icon-button id="account-menu-btn" size="md" icon="person-circle" expandable :title="person?.name || 'Account'" popovertarget="account-menu">
                 </ndd-icon-button>
@@ -661,10 +691,10 @@ function handleActionSave() {
           </ndd-simple-section>
         </ndd-page>
 
-        <!-- 3-column equal layout: Text | Form | Result -->
-        <ndd-side-by-side-split-view v-else panes="3">
+        <!-- Dynamic column layout based on feature flags -->
+        <ndd-side-by-side-split-view v-else :panes="String(visiblePanes.length)">
           <!-- Left: Article Text -->
-          <ndd-split-view-pane slot="pane-1" background="tinted">
+          <ndd-split-view-pane v-if="isEnabled('panel.article_text')" :slot="paneSlot('text')" background="tinted">
             <ndd-page sticky-header>
               <ndd-top-title-bar slot="header" text="Tekst"></ndd-top-title-bar>
               <ArticleText :article="selectedArticle" />
@@ -672,10 +702,10 @@ function handleActionSave() {
           </ndd-split-view-pane>
 
           <!-- Middle: Form or YAML -->
-          <ndd-split-view-pane slot="pane-2">
+          <ndd-split-view-pane v-if="showMiddlePane" :slot="paneSlot('middle')">
             <ndd-page sticky-header>
-              <ndd-top-title-bar slot="header" :text="middlePaneTitle">
-                <ndd-segmented-control slot="toolbar" size="md" data-testid="middle-pane-toggle" :value="middlePaneView" @change="onMiddlePaneChange">
+              <ndd-top-title-bar slot="header" :text="showFormOption ? middlePaneTitle : 'YAML'">
+                <ndd-segmented-control v-if="showFormOption && showYamlOption" slot="toolbar" size="md" data-testid="middle-pane-toggle" :value="middlePaneView" @change="onMiddlePaneChange">
                   <ndd-segmented-control-item value="form" text="Scenario's"></ndd-segmented-control-item>
                   <ndd-segmented-control-item value="yaml" text="YAML"></ndd-segmented-control-item>
                 </ndd-segmented-control>
@@ -683,13 +713,13 @@ function handleActionSave() {
               </ndd-top-title-bar>
 
               <!-- Form view: engine error -->
-              <ndd-simple-section v-if="middlePaneView === 'form' && engineInitError" align="center">
+              <ndd-simple-section v-if="showFormOption && middlePaneView === 'form' && engineInitError" align="center">
                 <ndd-inline-dialog variant="alert" text="WASM engine niet geladen" :supporting-text="`${engineInitError.message} — voer 'just wasm-build' uit om de WASM module te bouwen.`"></ndd-inline-dialog>
               </ndd-simple-section>
 
               <!-- Form view: scenario builder -->
               <ScenarioBuilder
-                v-else-if="middlePaneView === 'form'"
+                v-else-if="showFormOption && middlePaneView === 'form'"
                 :law-id="lawId"
                 :law-yaml="currentLawYaml"
                 :engine="getEngine()"
@@ -698,10 +728,8 @@ function handleActionSave() {
                 @executed="handleScenarioExecuted"
               />
 
-              <!-- YAML view: bypass ndd-simple-section so the textarea can
-                   stretch to fill the pane body. The wrap is a flex column
-                   that anchors the parse-error footer at the bottom. -->
-              <div v-if="middlePaneView === 'yaml'" class="editor-yaml-wrap">
+              <!-- YAML view -->
+              <div v-if="showYamlOption && middlePaneView === 'yaml'" class="editor-yaml-wrap">
                 <textarea
                   :value="yamlSource"
                   @input="onYamlInput"
@@ -717,7 +745,7 @@ function handleActionSave() {
           </ndd-split-view-pane>
 
           <!-- Right: Execution Result or Machine Readable -->
-          <ndd-split-view-pane slot="pane-3">
+          <ndd-split-view-pane v-if="isEnabled('panel.execution_trace')" :slot="paneSlot('trace')">
             <ndd-page sticky-header>
               <ndd-top-title-bar slot="header" :text="rightPaneTitle">
                 <ndd-segmented-control slot="toolbar" size="md" data-testid="right-pane-toggle" :value="rightPaneView" @change="onRightPaneChange">
@@ -760,6 +788,7 @@ function handleActionSave() {
 
   <ActionSheet :action="activeAction" :article="editedArticle" :editable="canEdit" @close="handleActionClose" @save="handleActionSave" />
   <EditSheet :item="activeEditItem" :article="editedArticle" @save="handleSave" @close="activeEditItem = null" />
+  <FeatureFlagSettings :open="settingsOpen" @close="settingsOpen = false" />
 </template>
 
 <style>

--- a/frontend/src/components/FeatureFlagSettings.vue
+++ b/frontend/src/components/FeatureFlagSettings.vue
@@ -9,6 +9,14 @@ const emit = defineEmits(['close']);
 
 const { flags, toggle } = useFeatureFlags();
 
+const panelFlags = [
+  ['panel.article_text', 'Wettekst'],
+  ['panel.scenario_form', 'Scenario formulier'],
+  ['panel.yaml_editor', 'YAML editor'],
+  ['panel.execution_trace', 'Resultaat'],
+  ['panel.machine_readable', 'Machine readable'],
+];
+
 const sheetEl = ref(null);
 
 watch(() => props.open, (val) => {
@@ -54,16 +62,6 @@ watch(() => props.open, (val) => {
     </div>
   </rr-sheet>
 </template>
-
-<script>
-const panelFlags = [
-  ['panel.article_text', 'Wettekst'],
-  ['panel.scenario_form', 'Scenario formulier'],
-  ['panel.yaml_editor', 'YAML editor'],
-  ['panel.execution_trace', 'Resultaat'],
-  ['panel.machine_readable', 'Machine readable'],
-];
-</script>
 
 <style scoped>
 .settings-content {

--- a/frontend/src/components/FeatureFlagSettings.vue
+++ b/frontend/src/components/FeatureFlagSettings.vue
@@ -22,7 +22,7 @@ const sheetEl = ref(null);
 watch(() => props.open, (val) => {
   if (!sheetEl.value) return;
   if (val) {
-    sheetEl.value.showSheet();
+    sheetEl.value.show();
   } else {
     sheetEl.value.close();
   }

--- a/frontend/src/components/FeatureFlagSettings.vue
+++ b/frontend/src/components/FeatureFlagSettings.vue
@@ -14,7 +14,6 @@ const panelFlags = [
   ['panel.scenario_form', 'Scenario formulier'],
   ['panel.yaml_editor', 'YAML editor'],
   ['panel.execution_trace', 'Resultaat'],
-  ['panel.machine_readable', 'Machine readable'],
 ];
 
 const sheetEl = ref(null);

--- a/frontend/src/components/FeatureFlagSettings.vue
+++ b/frontend/src/components/FeatureFlagSettings.vue
@@ -40,7 +40,7 @@ watch(() => props.open, (val) => {
         </rr-toolbar-start-area>
         <rr-toolbar-end-area>
           <rr-toolbar-item>
-            <rr-icon-button variant="neutral-plain" size="m" icon="xmark" @click="emit('close')"></rr-icon-button>
+            <rr-icon-button variant="neutral-plain" size="m" icon="dismiss" @click="emit('close')"></rr-icon-button>
           </rr-toolbar-item>
         </rr-toolbar-end-area>
       </rr-toolbar>

--- a/frontend/src/components/FeatureFlagSettings.vue
+++ b/frontend/src/components/FeatureFlagSettings.vue
@@ -30,37 +30,33 @@ watch(() => props.open, (val) => {
 </script>
 
 <template>
-  <rr-sheet ref="sheetEl" placement="right" @close="emit('close')">
+  <ndd-sheet ref="sheetEl" placement="right" @close="emit('close')">
     <div class="settings-content">
-      <rr-toolbar size="md">
-        <rr-toolbar-start-area>
-          <rr-toolbar-item>
-            <rr-title-bar size="4">Instellingen</rr-title-bar>
-          </rr-toolbar-item>
-        </rr-toolbar-start-area>
-        <rr-toolbar-end-area>
-          <rr-toolbar-item>
-            <rr-icon-button variant="neutral-plain" size="m" icon="dismiss" @click="emit('close')"></rr-icon-button>
-          </rr-toolbar-item>
-        </rr-toolbar-end-area>
-      </rr-toolbar>
+      <ndd-toolbar size="md">
+        <ndd-toolbar-item slot="start">
+          <ndd-title-bar size="4" text="Instellingen"></ndd-title-bar>
+        </ndd-toolbar-item>
+        <ndd-toolbar-item slot="end">
+          <ndd-icon-button variant="neutral-plain" size="md" icon="dismiss" @click="emit('close')"></ndd-icon-button>
+        </ndd-toolbar-item>
+      </ndd-toolbar>
 
-      <rr-simple-section>
-        <rr-title-bar size="5" style="margin-bottom: 8px;">Panelen</rr-title-bar>
-        <rr-list variant="box">
-          <rr-list-item v-for="[key, label] in panelFlags" :key="key" size="md">
-            <rr-text-cell>{{ label }}</rr-text-cell>
-            <rr-cell>
-              <rr-switch
+      <ndd-simple-section>
+        <ndd-title-bar size="5" text="Panelen" style="margin-bottom: 8px;"></ndd-title-bar>
+        <ndd-list variant="box">
+          <ndd-list-item v-for="[key, label] in panelFlags" :key="key" size="md">
+            <ndd-text-cell :text="label"></ndd-text-cell>
+            <ndd-cell>
+              <ndd-switch
                 :checked="flags[key] ? true : undefined"
                 @change="toggle(key)"
-              ></rr-switch>
-            </rr-cell>
-          </rr-list-item>
-        </rr-list>
-      </rr-simple-section>
+              ></ndd-switch>
+            </ndd-cell>
+          </ndd-list-item>
+        </ndd-list>
+      </ndd-simple-section>
     </div>
-  </rr-sheet>
+  </ndd-sheet>
 </template>
 
 <style scoped>

--- a/frontend/src/components/FeatureFlagSettings.vue
+++ b/frontend/src/components/FeatureFlagSettings.vue
@@ -1,0 +1,73 @@
+<script setup>
+import { ref, watch } from 'vue';
+import { useFeatureFlags } from '../composables/useFeatureFlags.js';
+
+const props = defineProps({
+  open: { type: Boolean, default: false },
+});
+const emit = defineEmits(['close']);
+
+const { flags, toggle } = useFeatureFlags();
+
+const sheetEl = ref(null);
+
+watch(() => props.open, (val) => {
+  if (!sheetEl.value) return;
+  if (val) {
+    sheetEl.value.showSheet();
+  } else {
+    sheetEl.value.close();
+  }
+});
+</script>
+
+<template>
+  <rr-sheet ref="sheetEl" placement="right" @close="emit('close')">
+    <div class="settings-content">
+      <rr-toolbar size="md">
+        <rr-toolbar-start-area>
+          <rr-toolbar-item>
+            <rr-title-bar size="4">Instellingen</rr-title-bar>
+          </rr-toolbar-item>
+        </rr-toolbar-start-area>
+        <rr-toolbar-end-area>
+          <rr-toolbar-item>
+            <rr-icon-button variant="neutral-plain" size="m" icon="xmark" @click="emit('close')"></rr-icon-button>
+          </rr-toolbar-item>
+        </rr-toolbar-end-area>
+      </rr-toolbar>
+
+      <rr-simple-section>
+        <rr-title-bar size="5" style="margin-bottom: 8px;">Panelen</rr-title-bar>
+        <rr-list variant="box">
+          <rr-list-item v-for="[key, label] in panelFlags" :key="key" size="md">
+            <rr-text-cell>{{ label }}</rr-text-cell>
+            <rr-cell>
+              <rr-switch
+                :checked="flags[key] ? true : undefined"
+                @change="toggle(key)"
+              ></rr-switch>
+            </rr-cell>
+          </rr-list-item>
+        </rr-list>
+      </rr-simple-section>
+    </div>
+  </rr-sheet>
+</template>
+
+<script>
+const panelFlags = [
+  ['panel.article_text', 'Wettekst'],
+  ['panel.scenario_form', 'Scenario formulier'],
+  ['panel.yaml_editor', 'YAML editor'],
+  ['panel.execution_trace', 'Resultaat'],
+  ['panel.machine_readable', 'Machine readable'],
+];
+</script>
+
+<style scoped>
+.settings-content {
+  width: 320px;
+  min-height: 100%;
+}
+</style>

--- a/frontend/src/components/FeatureFlagSettings.vue
+++ b/frontend/src/components/FeatureFlagSettings.vue
@@ -14,6 +14,7 @@ const panelFlags = [
   ['panel.scenario_form', 'Scenario formulier'],
   ['panel.yaml_editor', 'YAML editor'],
   ['panel.execution_trace', 'Resultaat'],
+  ['panel.machine_readable', 'Machine readable'],
 ];
 
 const sheetEl = ref(null);

--- a/frontend/src/composables/useFeatureFlags.js
+++ b/frontend/src/composables/useFeatureFlags.js
@@ -1,0 +1,71 @@
+/**
+ * useFeatureFlags — singleton feature flag store with API sync.
+ *
+ * Fetches flags from /api/feature-flags on first use, falls back to
+ * hardcoded defaults when the API is unavailable (e.g. no database).
+ */
+import { ref, readonly } from 'vue';
+
+const DEFAULTS = {
+  'panel.article_text': true,
+  'panel.scenario_form': true,
+  'panel.yaml_editor': true,
+  'panel.execution_trace': true,
+  'panel.machine_readable': false,
+};
+
+const flags = ref({ ...DEFAULTS });
+const loaded = ref(false);
+
+let fetchPromise = null;
+
+async function loadFlags() {
+  if (fetchPromise) return fetchPromise;
+  fetchPromise = (async () => {
+    try {
+      const res = await fetch('/api/feature-flags');
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      flags.value = { ...DEFAULTS, ...(await res.json()) };
+    } catch (e) {
+      console.warn('Failed to load feature flags, using defaults:', e.message);
+      flags.value = { ...DEFAULTS };
+    } finally {
+      loaded.value = true;
+    }
+  })();
+  return fetchPromise;
+}
+
+async function toggle(key) {
+  const current = flags.value[key] ?? DEFAULTS[key] ?? true;
+  const newValue = !current;
+
+  // Optimistic update
+  flags.value = { ...flags.value, [key]: newValue };
+
+  try {
+    const res = await fetch(`/api/feature-flags/${encodeURIComponent(key)}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ enabled: newValue }),
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const updated = await res.json();
+    flags.value = { ...DEFAULTS, ...updated };
+  } catch (e) {
+    console.warn('Failed to update feature flag, reverting:', e.message);
+    flags.value = { ...flags.value, [key]: current };
+  }
+}
+
+export function useFeatureFlags() {
+  if (!loaded.value && !fetchPromise) {
+    loadFlags();
+  }
+  return {
+    flags: readonly(flags),
+    loaded: readonly(loaded),
+    isEnabled: (key) => flags.value[key] ?? DEFAULTS[key] ?? true,
+    toggle,
+  };
+}

--- a/packages/editor-api/src/feature_flags.rs
+++ b/packages/editor-api/src/feature_flags.rs
@@ -1,0 +1,86 @@
+use std::collections::HashMap;
+
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::Json;
+use serde::Deserialize;
+
+use crate::state::AppState;
+
+fn defaults() -> HashMap<String, bool> {
+    HashMap::from([
+        ("panel.article_text".into(), true),
+        ("panel.scenario_form".into(), true),
+        ("panel.yaml_editor".into(), true),
+        ("panel.execution_trace".into(), true),
+        ("panel.machine_readable".into(), false),
+    ])
+}
+
+pub async fn list_feature_flags(State(state): State<AppState>) -> Json<HashMap<String, bool>> {
+    let Some(pool) = &state.pool else {
+        return Json(defaults());
+    };
+
+    match regelrecht_pipeline::feature_flags::list_flags(pool).await {
+        Ok(rows) => {
+            let mut flags = defaults();
+            for flag in rows {
+                flags.insert(flag.key, flag.enabled);
+            }
+            Json(flags)
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to fetch feature flags, using defaults");
+            Json(defaults())
+        }
+    }
+}
+
+#[derive(Deserialize)]
+pub struct UpdateFlag {
+    pub enabled: bool,
+}
+
+pub async fn update_feature_flag(
+    State(state): State<AppState>,
+    Path(key): Path<String>,
+    Json(body): Json<UpdateFlag>,
+) -> impl IntoResponse {
+    let Some(pool) = &state.pool else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({"error": "no database configured"})),
+        )
+            .into_response();
+    };
+
+    match regelrecht_pipeline::feature_flags::set_flag(pool, &key, body.enabled).await {
+        Ok(Some(_)) => {
+            // Return the full flag map after update
+            match regelrecht_pipeline::feature_flags::list_flags(pool).await {
+                Ok(rows) => {
+                    let mut flags = defaults();
+                    for flag in rows {
+                        flags.insert(flag.key, flag.enabled);
+                    }
+                    Json(flags).into_response()
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "failed to list flags after update");
+                    StatusCode::INTERNAL_SERVER_ERROR.into_response()
+                }
+            }
+        }
+        Ok(None) => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({"error": format!("flag '{}' not found", key)})),
+        )
+            .into_response(),
+        Err(e) => {
+            tracing::error!(error = %e, "failed to update feature flag");
+            StatusCode::INTERNAL_SERVER_ERROR.into_response()
+        }
+    }
+}

--- a/packages/editor-api/src/feature_flags.rs
+++ b/packages/editor-api/src/feature_flags.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::LazyLock;
 
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
@@ -8,7 +9,7 @@ use serde::Deserialize;
 
 use crate::state::AppState;
 
-fn defaults() -> HashMap<String, bool> {
+static DEFAULTS: LazyLock<HashMap<String, bool>> = LazyLock::new(|| {
     HashMap::from([
         ("panel.article_text".into(), true),
         ("panel.scenario_form".into(), true),
@@ -16,6 +17,10 @@ fn defaults() -> HashMap<String, bool> {
         ("panel.execution_trace".into(), true),
         ("panel.machine_readable".into(), false),
     ])
+});
+
+fn defaults() -> HashMap<String, bool> {
+    DEFAULTS.clone()
 }
 
 pub async fn list_feature_flags(State(state): State<AppState>) -> Json<HashMap<String, bool>> {
@@ -48,7 +53,7 @@ pub async fn update_feature_flag(
     Path(key): Path<String>,
     Json(body): Json<UpdateFlag>,
 ) -> impl IntoResponse {
-    if !defaults().contains_key(&key) {
+    if !DEFAULTS.contains_key(&key) {
         return (
             StatusCode::BAD_REQUEST,
             Json(serde_json::json!({"error": format!("unknown flag key '{}'", key)})),
@@ -64,8 +69,8 @@ pub async fn update_feature_flag(
             .into_response();
     };
 
-    match regelrecht_pipeline::feature_flags::set_flag(pool, &key, body.enabled).await {
-        Ok(Some(_)) => {
+    match regelrecht_pipeline::feature_flags::upsert_flag(pool, &key, body.enabled, None).await {
+        Ok(_) => {
             // Return the full flag map after update
             match regelrecht_pipeline::feature_flags::list_flags(pool).await {
                 Ok(rows) => {
@@ -81,11 +86,6 @@ pub async fn update_feature_flag(
                 }
             }
         }
-        Ok(None) => (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({"error": format!("flag '{}' not found", key)})),
-        )
-            .into_response(),
         Err(e) => {
             tracing::error!(error = %e, "failed to update feature flag");
             StatusCode::INTERNAL_SERVER_ERROR.into_response()

--- a/packages/editor-api/src/feature_flags.rs
+++ b/packages/editor-api/src/feature_flags.rs
@@ -48,6 +48,14 @@ pub async fn update_feature_flag(
     Path(key): Path<String>,
     Json(body): Json<UpdateFlag>,
 ) -> impl IntoResponse {
+    if !defaults().contains_key(&key) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": format!("unknown flag key '{}'", key)})),
+        )
+            .into_response();
+    }
+
     let Some(pool) = &state.pool else {
         return (
             StatusCode::SERVICE_UNAVAILABLE,

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use axum::middleware as axum_middleware;
-use axum::routing::get;
+use axum::routing::{get, put};
 use axum::Router;
 use tokio::sync::{Mutex, RwLock};
 use tower_http::services::{ServeDir, ServeFile};
@@ -20,6 +20,7 @@ use tracing_subscriber::EnvFilter;
 mod config;
 mod corpus_handlers;
 mod favorites;
+mod feature_flags;
 mod harvest_proxy;
 mod middleware;
 mod state;
@@ -106,6 +107,11 @@ async fn main() {
         .route(
             "/api/corpus/laws/{law_id}/scenarios/{filename}",
             get(corpus_handlers::get_scenario),
+        )
+        .route("/api/feature-flags", get(feature_flags::list_feature_flags))
+        .route(
+            "/api/feature-flags/{key}",
+            put(feature_flags::update_feature_flag),
         )
         // Harvest status — forwarded to pipeline-api. Read-only DB lookup,
         // safe to expose unauthenticated. (The search endpoint lives behind

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use axum::middleware as axum_middleware;
-use axum::routing::{get, put};
+use axum::routing::get;
 use axum::Router;
 use tokio::sync::{Mutex, RwLock};
 use tower_http::services::{ServeDir, ServeFile};
@@ -109,10 +109,6 @@ async fn main() {
             get(corpus_handlers::get_scenario),
         )
         .route("/api/feature-flags", get(feature_flags::list_feature_flags))
-        .route(
-            "/api/feature-flags/{key}",
-            put(feature_flags::update_feature_flag),
-        )
         // Harvest status — forwarded to pipeline-api. Read-only DB lookup,
         // safe to expose unauthenticated. (The search endpoint lives behind
         // auth because it triggers outbound requests to zoekservice.overheid.nl
@@ -163,6 +159,10 @@ async fn main() {
         .route(
             "/api/corpus/reload",
             axum::routing::post(corpus_handlers::reload_corpus),
+        )
+        .route(
+            "/api/feature-flags/{key}",
+            axum::routing::put(feature_flags::update_feature_flag),
         )
         .route_layer(axum_middleware::from_fn_with_state(
             app_state.clone(),

--- a/packages/pipeline/migrations/0012_add_feature_flags.sql
+++ b/packages/pipeline/migrations/0012_add_feature_flags.sql
@@ -18,4 +18,5 @@ INSERT INTO feature_flags (key, enabled, description) VALUES
     ('panel.scenario_form', true, 'Scenario formulier (midden paneel)'),
     ('panel.yaml_editor', true, 'YAML editor (midden paneel)'),
     ('panel.execution_trace', true, 'Resultaat (rechter paneel)'),
-    ('panel.machine_readable', false, 'Machine readable weergave');
+    ('panel.machine_readable', false, 'Machine readable weergave')
+ON CONFLICT (key) DO NOTHING;

--- a/packages/pipeline/migrations/0012_add_feature_flags.sql
+++ b/packages/pipeline/migrations/0012_add_feature_flags.sql
@@ -1,0 +1,21 @@
+-- Feature flags for controlling UI panel visibility and other runtime settings.
+-- Centralized table: any application can read/write flags via the pipeline crate.
+CREATE TABLE feature_flags (
+    key         TEXT PRIMARY KEY,
+    enabled     BOOLEAN NOT NULL DEFAULT true,
+    description TEXT,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TRIGGER trg_feature_flags_updated_at
+    BEFORE UPDATE ON feature_flags
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+-- Seed editor panel flags
+INSERT INTO feature_flags (key, enabled, description) VALUES
+    ('panel.article_text', true, 'Wettekst (linker paneel)'),
+    ('panel.scenario_form', true, 'Scenario formulier (midden paneel)'),
+    ('panel.yaml_editor', true, 'YAML editor (midden paneel)'),
+    ('panel.execution_trace', true, 'Resultaat (rechter paneel)'),
+    ('panel.machine_readable', false, 'Machine readable weergave');

--- a/packages/pipeline/src/feature_flags.rs
+++ b/packages/pipeline/src/feature_flags.rs
@@ -1,0 +1,66 @@
+use crate::error::Result;
+use crate::models::FeatureFlag;
+
+/// List all feature flags.
+pub async fn list_flags<'e, E>(executor: E) -> Result<Vec<FeatureFlag>>
+where
+    E: sqlx::PgExecutor<'e>,
+{
+    let flags = sqlx::query_as::<_, FeatureFlag>("SELECT * FROM feature_flags ORDER BY key")
+        .fetch_all(executor)
+        .await?;
+    Ok(flags)
+}
+
+/// Get a single feature flag by key.
+pub async fn get_flag<'e, E>(executor: E, key: &str) -> Result<Option<FeatureFlag>>
+where
+    E: sqlx::PgExecutor<'e>,
+{
+    let flag = sqlx::query_as::<_, FeatureFlag>("SELECT * FROM feature_flags WHERE key = $1")
+        .bind(key)
+        .fetch_optional(executor)
+        .await?;
+    Ok(flag)
+}
+
+/// Update the enabled status of a feature flag. Returns the updated flag.
+pub async fn set_flag<'e, E>(executor: E, key: &str, enabled: bool) -> Result<Option<FeatureFlag>>
+where
+    E: sqlx::PgExecutor<'e>,
+{
+    let flag = sqlx::query_as::<_, FeatureFlag>(
+        "UPDATE feature_flags SET enabled = $2 WHERE key = $1 RETURNING *",
+    )
+    .bind(key)
+    .bind(enabled)
+    .fetch_optional(executor)
+    .await?;
+    Ok(flag)
+}
+
+/// Create or update a feature flag.
+pub async fn upsert_flag<'e, E>(
+    executor: E,
+    key: &str,
+    enabled: bool,
+    description: Option<&str>,
+) -> Result<FeatureFlag>
+where
+    E: sqlx::PgExecutor<'e>,
+{
+    let flag = sqlx::query_as::<_, FeatureFlag>(
+        r#"
+        INSERT INTO feature_flags (key, enabled, description)
+        VALUES ($1, $2, $3)
+        ON CONFLICT (key) DO UPDATE SET enabled = $2, description = COALESCE($3, feature_flags.description)
+        RETURNING *
+        "#,
+    )
+    .bind(key)
+    .bind(enabled)
+    .bind(description)
+    .fetch_one(executor)
+    .await?;
+    Ok(flag)
+}

--- a/packages/pipeline/src/lib.rs
+++ b/packages/pipeline/src/lib.rs
@@ -4,6 +4,7 @@ pub mod config;
 pub mod db;
 pub mod enrich;
 pub mod error;
+pub mod feature_flags;
 pub mod harvest;
 pub mod job_queue;
 pub mod law_status;
@@ -20,4 +21,4 @@ pub use enrich::{
 };
 pub use error::PipelineError;
 pub use harvest::{HarvestPayload, HarvestResult, MAX_HARVEST_DEPTH};
-pub use models::{Job, JobStatus, JobType, LawEntry, LawStatusValue, Priority};
+pub use models::{FeatureFlag, Job, JobStatus, JobType, LawEntry, LawStatusValue, Priority};

--- a/packages/pipeline/src/models.rs
+++ b/packages/pipeline/src/models.rs
@@ -119,3 +119,12 @@ pub struct LawEntry {
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct FeatureFlag {
+    pub key: String,
+    pub enabled: bool,
+    pub description: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}


### PR DESCRIPTION
## Summary
- Add centralized feature flag system in the pipeline crate (shared DB table + CRUD module) so any application can manage flags
- Add optional PostgreSQL connection to editor-api with `GET/PUT /api/feature-flags` endpoints (falls back to defaults when no DB)
- Add settings panel in the editor frontend (gear icon in toolbar) with toggle switches per panel
- Editor panes are conditionally rendered based on flags, with dynamic split view slot assignment

## New files
- `packages/pipeline/migrations/0007_add_feature_flags.sql` — DB table + seed data
- `packages/pipeline/src/feature_flags.rs` — `list_flags`, `get_flag`, `set_flag`, `upsert_flag`
- `packages/editor-api/src/feature_flags.rs` — Axum handlers wrapping pipeline functions
- `frontend/src/composables/useFeatureFlags.js` — Singleton composable with optimistic toggle
- `frontend/src/components/FeatureFlagSettings.vue` — Settings sheet with toggle switches

## Seeded flags
| Key | Default | Description |
|-----|---------|-------------|
| `panel.article_text` | enabled | Wettekst (left pane) |
| `panel.scenario_form` | enabled | Scenario form (middle pane) |
| `panel.yaml_editor` | enabled | YAML editor (middle pane) |
| `panel.execution_trace` | enabled | Results (right pane) |
| `panel.machine_readable` | disabled | Machine readable view |

## Test plan
- [ ] `just build-check` passes
- [ ] `just lint` passes
- [ ] Frontend builds successfully
- [ ] Editor loads with all panels when no DATABASE_URL is set (defaults)
- [ ] With DATABASE_URL: toggling flags via settings hides/shows panels
- [ ] PUT endpoint returns 404 for unknown flag keys