### PR TITLE
ci: add conventional commit message linting to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,23 @@ repos:
       - id: check-merge-conflict
       - id: check-case-conflict
 
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v4.4.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]
+        args:
+          - feat
+          - fix
+          - docs
+          - style
+          - refactor
+          - perf
+          - test
+          - chore
+          - build
+          - ci
+
   - repo: https://github.com/adrienverge/yamllint
     rev: v1.38.0
     hooks:


### PR DESCRIPTION
## Summary

- Adds `conventional-pre-commit` (v4.4.0) as a `commit-msg` stage hook
- Enforces the same Conventional Commits types locally that the PR title workflow checks remotely
- Complements the PR title lint (#423) — catches bad commit messages before push

## Test plan

- [ ] `git commit -m "bad message"` → should be rejected
- [ ] `git commit -m "feat: valid message"` → should pass
- [ ] `git commit -m "fix(engine): scoped message"` → should pass