### PR TITLE
fix(security): override lodash-es to 4.18.1

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -3577,9 +3577,9 @@
       }
     },
     "node_modules/lodash-es": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "dev": true,
       "license": "MIT"
     },

--- a/docs/package.json
+++ b/docs/package.json
@@ -12,7 +12,8 @@
     "@minbzk/storybook": "^0.8.12"
   },
   "overrides": {
-    "esbuild": "^0.25.0"
+    "esbuild": "^0.25.0",
+    "lodash-es": "^4.18.1"
   },
   "devDependencies": {
     "mermaid": "^11.4.1",


### PR DESCRIPTION
## Summary

- Override `lodash-es` to `^4.18.1` in `docs/package.json` to fix prototype pollution and code injection vulnerabilities
- Resolves Dependabot alerts #31 and #32
- Transitive dependency via `mermaid` → `chevrotain`/`dagre-d3-es`

## Test plan

- [x] `npm audit` reports 0 vulnerabilities
- [x] `npm ls lodash-es` confirms 4.18.1 across all paths
- [ ] Docs build succeeds in CI