### PR TITLE
refactor(engine): rename PathNodeType::UriCall to CrossLawReference

### DIFF
--- a/docs/rfcs/rfc-009.md
+++ b/docs/rfcs/rfc-009.md
@@ -408,11 +408,11 @@ This principle aligns with the [Logboek Dataverwerkingen](https://logius-standaa
 
 #### How cross-org boundaries appear in traces
 
-The existing trace uses `PathNodeType` to identify what each trace node represents. Cross-law calls use `UriCall`, IoC resolution uses `OpenTermResolution`. For cross-org boundaries, a new node type is introduced:
+The existing trace uses `PathNodeType` to identify what each trace node represents. Cross-law calls use `CrossLawReference`, IoC resolution uses `OpenTermResolution`. For cross-org boundaries, a new node type is introduced:
 
 - **`AuthorityCall`** — the engine needs a value that is another organisation's competence (*bevoegdheid*)
 
-This follows the same parent-child pattern as `UriCall` and `OpenTermResolution`: the parent node explains what is happening, the child node holds the result.
+This follows the same parent-child pattern as `CrossLawReference` and `OpenTermResolution`: the parent node explains what is happening, the child node holds the result.
 
 **Example: healthcare allowance (*zorgtoeslag*) trace in federated authoritative mode**
 

--- a/packages/engine/src/service.rs
+++ b/packages/engine/src/service.rs
@@ -960,8 +960,10 @@ impl LawExecutionService {
                 depth = res_ctx.depth,
                 "Cross-law resolution depth exceeded"
             );
-            let _guard =
-                res_ctx.trace_guard(format!("{}#{}", law_id, output_name), PathNodeType::UriCall);
+            let _guard = res_ctx.trace_guard(
+                format!("{}#{}", law_id, output_name),
+                PathNodeType::CrossLawReference,
+            );
             res_ctx.trace_set_message(format!(
                 "Cross-law resolution depth exceeded {} levels ({}:{})",
                 config::MAX_CROSS_LAW_DEPTH,
@@ -1914,8 +1916,10 @@ impl LawExecutionService {
         }
 
         // Trace cross-law call (guard auto-pops on all exit paths)
-        let _guard =
-            res_ctx.trace_guard(format!("{}#{}", regulation, output), PathNodeType::UriCall);
+        let _guard = res_ctx.trace_guard(
+            format!("{}#{}", regulation, output),
+            PathNodeType::CrossLawReference,
+        );
 
         // Build parameters for the target article
         let target_params = match self.build_target_parameters(source_parameters, context) {

--- a/packages/engine/src/trace.rs
+++ b/packages/engine/src/trace.rs
@@ -162,7 +162,7 @@ impl PathNode {
             PathNodeType::Operation => "operation",
             PathNodeType::Action => "action",
             PathNodeType::Requirement => "requirement",
-            PathNodeType::UriCall => "uri_call",
+            PathNodeType::CrossLawReference => "cross_law_reference",
             PathNodeType::Article => "article",
             PathNodeType::Cached => "cached",
             PathNodeType::OpenTermResolution => "open_term",
@@ -523,15 +523,15 @@ impl PathNode {
                 }
             }
 
-            PathNodeType::UriCall => {
+            PathNodeType::CrossLawReference => {
                 if let Some(ref msg) = self.message {
                     lines.push(format!("{}{}{}", prefix, connector, msg));
                 } else {
                     lines.push(format!("{}{}Reference: {}", prefix, connector, self.name));
                 }
 
-                // UriCall children use double connectors; scope continuation
-                // matches whether this UriCall is itself in a double or single parent.
+                // CrossLawReference children use double connectors; scope continuation
+                // matches whether this CrossLawReference is itself in a double or single parent.
                 self.render_double_children(
                     lines,
                     child_base,
@@ -636,7 +636,7 @@ impl PathNode {
             PathNodeType::Operation => "op",
             PathNodeType::Action => "act",
             PathNodeType::Requirement => "req",
-            PathNodeType::UriCall => "uri",
+            PathNodeType::CrossLawReference => "xlaw",
             PathNodeType::Article => "art",
             PathNodeType::Cached => "cache",
             PathNodeType::OpenTermResolution => "ot",
@@ -1300,17 +1300,17 @@ mod tests {
     }
 
     #[test]
-    fn test_box_drawing_uri_call_double_lines() {
+    fn test_box_drawing_cross_law_reference_double_lines() {
         let child = PathNode::new(PathNodeType::Resolve, "param").with_result(Value::Int(1));
-        let uri_node = PathNode::new(PathNodeType::UriCall, "other_law#output")
+        let uri_node = PathNode::new(PathNodeType::CrossLawReference, "other_law#output")
             .with_message("Reference: other_law#output")
             .with_child(child);
 
         let rendered = uri_node.render_box_drawing();
-        // UriCall children should use double-line connectors
+        // CrossLawReference children should use double-line connectors
         assert!(
             rendered.contains("╙──") || rendered.contains("╟──"),
-            "UriCall children should use double-line connectors in:\n{}",
+            "CrossLawReference children should use double-line connectors in:\n{}",
             rendered
         );
     }
@@ -1342,11 +1342,11 @@ mod tests {
 
     #[test]
     fn test_box_drawing_continuation_not_interrupted() {
-        // Two children under a UriCall inside an Article: the continuation
+        // Two children under a CrossLawReference inside an Article: the continuation
         // between children should use ║ (double-scope parent).
         let child1 = PathNode::new(PathNodeType::Resolve, "first").with_result(Value::Int(1));
         let child2 = PathNode::new(PathNodeType::Resolve, "second").with_result(Value::Int(2));
-        let uri_node = PathNode::new(PathNodeType::UriCall, "law#out")
+        let uri_node = PathNode::new(PathNodeType::CrossLawReference, "law#out")
             .with_message("Reference: law#out")
             .with_child(child1)
             .with_child(child2);
@@ -1358,11 +1358,11 @@ mod tests {
         let rendered = article.render_box_drawing();
         let lines: Vec<&str> = rendered.lines().collect();
         // Between the two children, the ║ continuation should be present
-        // (UriCall is inside Article's double-scope)
+        // (CrossLawReference is inside Article's double-scope)
         let has_double_continuation = lines.iter().any(|l| l.contains("║   ║"));
         assert!(
             has_double_continuation,
-            "UriCall inside Article should show ║ continuation in:\n{}",
+            "CrossLawReference inside Article should show ║ continuation in:\n{}",
             rendered
         );
     }

--- a/packages/engine/src/types.rs
+++ b/packages/engine/src/types.rs
@@ -766,8 +766,8 @@ pub enum PathNodeType {
     Action,
     /// Requirement check
     Requirement,
-    /// Cross-law URI call
-    UriCall,
+    /// Cross-law reference resolution (source.regulation lookup)
+    CrossLawReference,
     /// Article-level execution
     Article,
     /// Cached cross-law result (memoized)

--- a/packages/tui/src/views/trace.rs
+++ b/packages/tui/src/views/trace.rs
@@ -301,7 +301,7 @@ fn type_label(t: &PathNodeType) -> &'static str {
         PathNodeType::Operation => "op",
         PathNodeType::Action => "action",
         PathNodeType::Requirement => "req",
-        PathNodeType::UriCall => "uri",
+        PathNodeType::CrossLawReference => "xlaw",
         PathNodeType::Article => "article",
         PathNodeType::Cached => "cached",
         PathNodeType::OpenTermResolution => "open_term",


### PR DESCRIPTION
## Summary
- Renames `PathNodeType::UriCall` to `CrossLawReference` across the engine, TUI, and RFC docs
- Updates serialized string representations (`uri_call` → `cross_law_reference`, short form `uri` → `xlaw`)
- Updates all match arms, constructors, comments, and test names

The old name was an implementation detail (it resolves a `regelrecht://` URI). The new name describes the semantic purpose: resolving a cross-law reference via `source.regulation`.

Closes #318

## Test plan
- [x] `just check` passes (format, lint, build, validate, tests)