### PR TITLE
docs: remove unimplemented features from RFC-007

### DIFF
--- a/docs/rfcs/rfc-007.md
+++ b/docs/rfcs/rfc-007.md
@@ -112,15 +112,12 @@ Available filter fields:
 |---|---|---|
 | `legal_character` | Decision | `execution.produces.legal_character` |
 | `decision_type` | Decision | `execution.produces.decision_type` |
-| `output_semantic` | Output | `output` declaration (see §3 Temporal) |
 
 Decision-level filters (`legal_character`, `decision_type`) are AND-combined. An article with `produces: { legal_character: BESCHIKKING, decision_type: TOEKENNING }` matches a hook with `applies_to: { legal_character: BESCHIKKING }`.
 
 #### Hook ordering
 
-Within a hook point, **decision-level hooks** (`legal_character`, `decision_type` filters) fire before **output-level hooks** (`output_semantic` filters). This is a structural requirement: output-level hooks operate on the article's outputs, which must exist before they can be matched and transformed.
-
-Among hooks at the same level, execution is independent — no inter-hook dependencies. If hook A's output is needed by hook B, they must use cross-law references (`regelrecht://`), not output chaining.
+Among hooks at the same hook point, execution is independent — no inter-hook dependencies. If hook A's output is needed by hook B, they must use cross-law references (`regelrecht://`), not output chaining.
 
 #### Resolution model
 
@@ -232,44 +229,6 @@ All operations are pure functions. No domain knowledge. These operations extend 
 | `DAY_OF_WEEK` | date | number (0=mon..6=sun) | `DAY_OF_WEEK(2026-04-27) → 0` | Implemented |
 | `AGE` | date_of_birth + reference_date | number (complete years) | `AGE(1990-01-01, 2026-03-30) → 36` | Implemented |
 | `LIST` | items | array | `LIST(a, b, c) → [a, b, c]` | Implemented |
-| `NEXT_WORKING_DAY` | date + list of dates | date | advances past weekends + listed dates | Deferred |
-
-> **Implementation note (v0.5.0):** `NEXT_WORKING_DAY` is deferred — it requires a feestdagen list which is itself law-dependent (Algemene Termijnenwet art 3). `CONCAT` from the original proposal was dropped; `ADD` with string operands provides the same functionality. `semantic` output annotations and `output_semantic` hook filters are also deferred to a future schema version.
-
-#### Array type and operations
-
-Add `type: array` for outputs that are collections (consistent with the existing schema's type enum).
-
-| Operation | Input | Output |
-|-----------|-------|--------|
-| `LIST` | items | array |
-| `CONCAT` | multiple arrays | merged array |
-
-Needed for the public holidays (*feestdagen*) calendar.
-
-#### Semantic output annotations
-
-Outputs get an optional `semantic` annotation alongside their data `type`:
-
-```yaml
-output:
-  - name: bezwaartermijn_einddatum
-    type: date
-    semantic: termijn
-```
-
-Hooks can match on `output_semantic` — a new filter dimension. This is how the Termijnenwet hooks into any law that produces a deadline (*termijn*), regardless of decision type.
-
-#### Trigger-parameterized hooks
-
-For generic hooks that operate on any matching output:
-
-| Variable | Meaning |
-|----------|---------|
-| `$trigger_output` | The value of the output that matched the hook filter |
-| `$trigger_output_name` | The name of that output (so the hook can replace it) |
-
-When an article produces multiple outputs with `semantic: termijn`, the hook fires once per matching output.
 
 #### Feestdagen as harvested regulation
 
@@ -287,7 +246,7 @@ graph LR
     Caller["Caller provides\njaar + pasen_datum"] -->|parameters| L2
     Harvester["Staatscourant\nHarvester"] -->|"pipeline → corpus"| KB
 
-    L1 --> M["CONCAT → feestdagen list"]
+    L1 --> M["feestdagen list"]
     L2 --> M
     L3 --> M
 
@@ -311,10 +270,6 @@ graph TB
         H3["AWB 6:8\nstartdatum, einddatum\n(post_actions)"]
     end
 
-    subgraph "Output-level hooks · output_semantic: termijn"
-        H4["Termijnenwet art 1\nweekend/feestdag extension\n(post_actions)"]
-    end
-
     subgraph "Override · lex specialis"
         O1["Vw art 69\nbezwaartermijn_weken = 4"]
     end
@@ -325,21 +280,17 @@ graph TB
 
     H3 -->|"regelrecht:// ref"| H2
     O1 -.->|"overrides AWB 6:7"| H2
-    H4 -->|"regelrecht:// ref"| T3["Termijnenwet art 3\nfeestdagen list"]
-    D1 -->|"implements art 3 lid 3"| T3
+    D1 -->|"implements art 3 lid 3"| T3["Termijnenwet art 3\nfeestdagen list"]
 
     style O1 fill:#f9f,stroke:#333
     style D1 fill:#ff9,stroke:#333
-    style H4 fill:#9ff,stroke:#333
 ```
 
 ### Full YAML examples
 
 #### AWB 6:7 — Duration (hook)
 
-See Section 1 above for the full YAML. Key point:
-
-> `bezwaartermijn_weken` is a duration (number), not a deadline (date). The `semantic: termijn` annotation belongs on `bezwaartermijn_einddatum` in AWB 6:8, where the Termijnenwet can meaningfully extend the date.
+See Section 1 above for the full YAML. Key point: `bezwaartermijn_weken` is a duration (number), not a deadline (date). AWB 6:8 computes the actual date.
 
 #### AWB 3:46 — Motiveringsplicht (hook)
 
@@ -387,7 +338,6 @@ See Section 1 above for the full YAML. Key point:
           type: date
         - name: bezwaartermijn_einddatum
           type: date
-          semantic: termijn
       actions:
         - output: bezwaartermijn_startdatum
           value:
@@ -497,11 +447,11 @@ See Section 1 above for the full YAML. Key point:
               - { operation: DATE_ADD, date: $pasen_datum, days: 39 }   # Hemelvaartsdag
               - { operation: DATE_ADD, date: $pasen_datum, days: 50 }   # Tweede Pinksterdag
 
-        # Merge all layers
+        # Merge all layers (requires a list-merge operation — not yet implemented)
         - output: feestdagen
           value:
-            operation: CONCAT
-            lists:
+            operation: LIST
+            items:
               - $vaste_feestdagen
               - $paas_feestdagen
               - $gelijkgestelde_dagen
@@ -537,35 +487,6 @@ See Section 1 above for the full YAML. Key point:
               - '2028-05-26'
 ```
 
-#### Termijnenwet art 1 — Weekend/feestdag extension (semantic hook)
-
-```yaml
-- number: '1'    # algemene_termijnenwet
-  text: |-
-    Een in een wet gestelde termijn die op een zaterdag, zondag
-    of algemeen erkende feestdag eindigt, wordt verlengd tot en
-    met de eerstvolgende dag die niet een zaterdag, zondag of
-    algemeen erkende feestdag is.
-  machine_readable:
-    hooks:
-      - hook_point: post_actions
-        applies_to:
-          output_semantic: termijn
-    execution:
-      input:
-        - name: feestdagen
-          source: regelrecht://algemene_termijnenwet/feestdagen#value
-      output:
-        - name: $trigger_output_name
-          type: date
-      actions:
-        - output: $trigger_output_name
-          value:
-            operation: NEXT_WORKING_DAY
-            date: $trigger_output
-            non_working_days: $feestdagen
-```
-
 ### Walk-through
 
 **Scenario 1: Vreemdelingenwet with override and public holidays (*feestdagen*)**
@@ -579,14 +500,10 @@ sequenceDiagram
     participant AWB_67 as AWB 6:7
     participant Vw69 as Vw art 69
     participant AWB_68 as AWB 6:8
-    participant TW1 as Termijnenwet art 1
-    participant TW3 as Termijnenwet art 3
-    participant KB as KB 2026-2028
-
-    Caller->>Engine: execute(vreemdelingenwet art 25,<br/>bekendmaking=2026-03-12,<br/>pasen=2026-04-05)
+    Caller->>Engine: execute(vreemdelingenwet art 25,<br/>bekendmaking=2026-03-12)
     Engine->>Engine: produces BESCHIKKING
 
-    Note over Engine: Phase 1: decision-level hooks
+    Note over Engine: decision-level hooks
 
     Engine->>AWB_67: post_actions hook
     AWB_67->>Engine: bezwaartermijn_weken = 6
@@ -599,15 +516,6 @@ sequenceDiagram
     AWB_67->>AWB_68: bezwaartermijn_weken = 4
     AWB_68->>Engine: startdatum = 2026-03-13<br/>einddatum = 2026-04-09
 
-    Note over Engine: Phase 2: output-level hooks
-
-    Engine->>TW1: post_actions hook<br/>(semantic: termijn on einddatum)
-    TW1->>TW3: regelrecht:// ref (feestdagen)
-    TW3->>KB: IoC resolve gelijkgestelde_dagen
-    KB->>TW3: [2026-01-02, 2026-05-15, ...]
-    TW3->>TW1: feestdagen = [1 jan, 2 jan, 3 apr, 6 apr, ...]
-    TW1->>Engine: bezwaartermijn_einddatum = 2026-04-09<br/>(Thursday, no extension needed)
-
     Engine->>Caller: Result
 ```
 
@@ -619,18 +527,7 @@ Final result:
 
 *"U kunt tot en met 9 april 2026 bezwaar maken (artikel 69 Vreemdelingenwet, in afwijking van artikel 6:7 Awb)"*
 
-**Scenario 2: Deadline falls on an equivalent day (*gelijkgestelde dag*)**
-
-- `bekendmaking_datum: 2026-04-03` (Friday)
-- Contextual law: Participatiewet (no override, 6 weeks)
-- `einddatum = 2026-04-03 + 6 weeks = 2026-05-15` (Friday)
-- 15 mei 2026 is an equivalent day (*gelijkgestelde dag*) (KB Stcrt. 2025, 24713)
-- `NEXT_WORKING_DAY(2026-05-15, feestdagen)` → 15 mei in list → try 16 mei (Saturday) → weekend → try 17 mei (Sunday) → weekend → try 18 mei (Monday) → clear
-- `bezwaartermijn_einddatum: 2026-05-18`
-
-The harvested KB changes the legal outcome. Without it, the deadline would be Friday 15 May. With the KB, it extends to Monday 18 May.
-
-**Scenario 3: Simple hooks without override**
+**Scenario 2: Simple hooks without override**
 
 Zorgtoeslag produces a BESCHIKKING (individual decision (*beschikking*)). No override, no date computation needed for the basic determination:
 
@@ -673,11 +570,7 @@ The Zorgtoeslag YAML declares nothing about AWB. AWB declares nothing about Zorg
 
 **Contextual law threading.** The engine needs to know which law initiated the execution chain to determine which overrides apply. This requires threading `contextual_law_id` through `ResolutionContext`.
 
-**New types and operations.** `date`, `array`, plus `DATE_ADD`, `DATE`, `DAY_OF_WEEK`, `NEXT_WORKING_DAY`, `LIST`, `CONCAT`. This is a large expansion of the operation set.
-
-**Semantic annotations.** `semantic` on outputs introduces a new schema dimension. The set of valid values needs definition (initially just deadline (*termijn*)).
-
-**Trigger-parameterized hooks.** `$trigger_output` and `$trigger_output_name` make hooks more powerful but more complex to reason about.
+**New types and operations.** `date`, `array`, plus `DATE_ADD`, `DATE`, `DAY_OF_WEEK`, `AGE`, `LIST`. This is a significant expansion of the operation set.
 
 **Public holidays (*feestdagen*) require Government Gazette (*Staatscourant*) harvesting.** The equivalent days (*gelijkgestelde dagen*) from KB's are not algorithmically predictable. New source type for the pipeline.
 
@@ -697,12 +590,10 @@ The Zorgtoeslag YAML declares nothing about AWB. AWB declares nothing about Zorg
 
 **Public holidays (*feestdagen*) as engine configuration.** Rejected: public holidays (*feestdagen*) are defined in law. Treating them as configuration hides the legal source.
 
-**Termijnenwet hooks on legal_character.** Rejected: legally imprecise. The Termijnenwet applies to any statutory deadline (*termijn*), not just individual decisions (*beschikkingen*).
-
 ### Implementation Notes
 
 **Hooks:**
-- New structs: `HookDeclaration { hook_point, applies_to }`, `HookPoint { PreActions, PostActions }`, `HookFilter { legal_character, decision_type, output_semantic }`.
+- New structs: `HookDeclaration { hook_point, applies_to }`, `HookPoint { PreActions, PostActions }`, `HookFilter { legal_character, decision_type }`.
 - `hooks_index` in `RuleResolver`, keyed by `(HookPoint, String)`.
 - The `hooks_index` key should include `stage: Option<String>` from the start. RFC-008 (Bestuursrecht) will add stage-aware filtering; designing the index with this field avoids reworking the data structure later. Hooks without `stage` default to matching any stage.
 - Hook firing in `LawExecutionService::evaluate_article_with_service()`.
@@ -720,16 +611,7 @@ The Zorgtoeslag YAML declares nothing about AWB. AWB declares nothing about Zorg
 **Temporal:**
 - `type: date` → `chrono::NaiveDate`. Already available via `chrono` crate.
 - `type: array` → `Vec<Value>`. New `Value::Array` variant.
-- `NEXT_WORKING_DAY`: loop advancing past weekends + listed dates. Bounded (max 9 consecutive non-working days).
-- `semantic` on outputs indexed by `RuleResolver` for hook matching.
-- Trigger-parameterized hooks bind `$trigger_output` and `$trigger_output_name` per matching output.
 - Government Gazette (*Staatscourant*) KB's: new source type in harvester.
-
-**Trigger variable resolution:**
-- `$trigger_output` and `$trigger_output_name` are meta-variables injected by the engine when a semantic hook fires. They differ from regular parameters (which are declared in `parameters`).
-- Resolution requires either a new scope in `RuleContext` (checked between parameters and other scopes) or injection as synthetic parameters before hook execution. The former is cleaner; the latter requires less structural change.
-- Dynamic output names (`name: $trigger_output_name`) require resolving the variable before article execution begins. This is a change to the current static output name model: the engine must substitute trigger variables in the output declarations before evaluating actions.
-- Per-output firing loop: for each output on the target article with a matching `semantic` annotation, the engine fires the hook once, binding `$trigger_output` to that output's value and `$trigger_output_name` to that output's name. The hook's result replaces the original output value.
 
 ## References
 


### PR DESCRIPTION
## Summary

- Remove references to five features never implemented in schema v0.5.1 or the engine: `semantic` output annotations, `output_semantic` hook filter, `NEXT_WORKING_DAY` operation, `CONCAT` operation, and `$trigger_output`/`$trigger_output_name` meta-variables
- Verified via grep against `packages/engine/src/` that none exist in the codebase
- Removes the Termijnenwet art 1 semantic hook example, walk-through scenario 2 (gelijkgestelde dag/NEXT_WORKING_DAY), and related prose, diagrams, and implementation notes
- Docs build passes clean

## Test plan

- [x] Grepped engine source for all five features — zero matches
- [x] `cd docs && npx vitepress build` succeeds with no errors

Closes #439