### PR TITLE
fix(ci): pin review workflow actions to commit SHAs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           fetch-depth: 1
 
@@ -51,7 +51,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@1eddb334cfa79fdb21ecbe2180ca1a016e8e7d47  # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           use_sticky_comment: true


### PR DESCRIPTION
## Summary

- Pin `actions/checkout` and `anthropics/code-action` to full commit SHAs in `claude-code-review.yml`
- Prevents supply-chain attacks on a workflow with `pull-requests: write` and `id-token: write`

Split out from #479 so that the review workflow on `main` matches the PR branch, unblocking the OAuth token exchange for future PRs.

## Test plan
- [ ] Verify this PR's own review workflow passes (it will fail with the same chicken-and-egg issue, but once merged, subsequent PRs will work)