### PR TITLE
fix(ci): resolve medium and low severity security findings

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -29,6 +29,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
   changes:
     name: Detect changes
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       ci: ${{ steps.filter.outputs.ci }}
       admin: ${{ steps.filter.outputs.admin }}
@@ -56,6 +57,7 @@ jobs:
     name: Protect schema versions
     needs: changes
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
@@ -114,6 +116,7 @@ jobs:
     name: Provenance checks (RFC-013)
     needs: changes
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: needs.changes.outputs.ci == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
@@ -222,29 +225,24 @@ jobs:
 
   pre-commit:
     name: Pre-commit
-    needs: changes
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
-        if: needs.changes.outputs.ci == 'true'
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
-        if: needs.changes.outputs.ci == 'true'
         with:
           python-version: '3.12'
 
       - name: Install just
-        if: needs.changes.outputs.ci == 'true'
         uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b  # v3
 
       - name: Install Rust toolchain
-        if: needs.changes.outputs.ci == 'true'
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7  # stable
         with:
           components: rustfmt, clippy
 
       - name: Cache cargo registry
-        if: needs.changes.outputs.ci == 'true'
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5
         with:
           path: |
@@ -257,16 +255,12 @@ jobs:
             ${{ runner.os }}-cargo-
 
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # v3.0.1
-        if: needs.changes.outputs.ci == 'true'
-
-      - name: Skip (no relevant changes)
-        if: needs.changes.outputs.ci != 'true'
-        run: echo "No relevant changes, skipping pre-commit"
 
   test:
     name: Test
     needs: changes
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         if: needs.changes.outputs.ci == 'true'
@@ -304,6 +298,7 @@ jobs:
     name: WASM Build
     needs: changes
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         if: needs.changes.outputs.ci == 'true'
@@ -339,6 +334,7 @@ jobs:
   audit:
     name: Security Audit
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: read
@@ -348,8 +344,19 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7  # stable
 
+      - name: Cache cargo registry
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ~/.cargo/bin/cargo-deny
+          key: ${{ runner.os }}-cargo-audit-${{ hashFiles('packages/**/Cargo.toml', 'packages/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-audit-
+
       - name: Install cargo-deny
-        run: cargo install cargo-deny --locked
+        run: command -v cargo-deny || cargo install cargo-deny --locked
 
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6
@@ -379,6 +386,7 @@ jobs:
     name: Admin
     needs: changes
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
       packages: read
@@ -452,6 +460,7 @@ jobs:
     name: Editor API
     needs: changes
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         if: needs.changes.outputs.editor-api == 'true'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,12 +19,12 @@ jobs:
         (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
         (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
       ) && (
-        github.event.sender.type == 'Bot' ||
         contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) ||
         contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association) ||
         (github.event_name == 'issues' && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
       )
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,12 +16,14 @@ env:
 jobs:
   changes:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: >-
       github.event.action != 'closed' &&
       (github.event.action != 'labeled' || startsWith(github.event.label.name, 'deploy:'))
     permissions:
       contents: read
     outputs:
+      editor: ${{ steps.filter.outputs.editor }}
       admin: ${{ steps.filter.outputs.admin }}
       harvester-worker: ${{ steps.filter.outputs.harvester-worker }}
       enrich-worker: ${{ steps.filter.outputs.enrich-worker }}
@@ -36,6 +38,11 @@ jobs:
         id: filter
         with:
           filters: |
+            editor:
+              - 'frontend/**'
+              - 'packages/engine/**'
+              - 'packages/corpus/**'
+              - 'packages/editor-api/**'
             admin:
               - 'packages/admin/**'
               - 'packages/pipeline/migrations/**'
@@ -58,11 +65,14 @@ jobs:
               - 'docs/**'
 
   # -- Build jobs --
-  # Editor always builds (not conditional on changes)
   build:
+    needs: changes
     if: >-
       github.event.action != 'closed' &&
-      (github.event.action != 'labeled' || startsWith(github.event.label.name, 'deploy:'))
+      (
+        (github.ref == 'refs/heads/main' && github.event_name == 'push') ||
+        needs.changes.outputs.editor == 'true'
+      )
     permissions:
       contents: read
       packages: write
@@ -195,11 +205,12 @@ jobs:
   # -- Deploy preview --
   deploy-preview:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: [build, build-admin, build-harvester-worker, build-enrich-worker, build-lawmaking, build-landing, build-docs, changes]
     if: >-
       always() &&
       github.event_name == 'pull_request' && github.event.action != 'closed' &&
-      needs.build.result == 'success'
+      (needs.build.result == 'success' || needs.build.result == 'skipped')
     permissions:
       pull-requests: write
     environment:
@@ -261,7 +272,9 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           comment-header: '## Preview Deployment'
 
+      # Falls back to :latest when editor build is skipped (requires a prior production push)
       - name: Deploy editor to ZAD (Preview)
+        if: needs.build.result != 'failure'
         id: deploy
         uses: RijksICTGilde/zad-actions/deploy@02fea0a223d3b18db796454b110f2afc16a09cf9  # v3
         with:
@@ -269,7 +282,7 @@ jobs:
           project-id: ${{ env.ZAD_PROJECT }}
           deployment-name: pr${{ github.event.pull_request.number }}
           component: editor
-          image: ${{ env.REGISTRY }}/minbzk/regelrecht-editor:sha-${{ steps.sha.outputs.short }}
+          image: ${{ env.REGISTRY }}/minbzk/regelrecht-editor:${{ needs.build.result == 'success' && format('sha-{0}', steps.sha.outputs.short) || 'latest' }}
           domain-format: component-deployment-project
           clone-from: regelrecht
           force-clone: false
@@ -328,6 +341,7 @@ jobs:
   # -- Deploy production --
   deploy-production:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: [build, build-admin, build-harvester-worker, build-enrich-worker, build-grafana, build-lawmaking, build-landing, build-docs]
     if: >-
       always() &&
@@ -428,6 +442,7 @@ jobs:
   # -- Cleanup preview --
   cleanup-preview:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
     permissions:
       packages: write

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -8,7 +8,7 @@ COPY docs/ .
 RUN npm run build
 
 # Stage 2: Production (unprivileged nginx for Kubernetes/OpenShift)
-FROM nginxinc/nginx-unprivileged:alpine
+FROM nginxinc/nginx-unprivileged:1.27-alpine
 COPY docs/nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=builder /app/.vitepress/dist /usr/share/nginx/html
 EXPOSE 8000

--- a/frontend-lawmaking/Dockerfile
+++ b/frontend-lawmaking/Dockerfile
@@ -8,7 +8,7 @@ COPY frontend-lawmaking/ .
 RUN npm run build
 
 # Stage 2: Production (unprivileged nginx for Kubernetes/OpenShift)
-FROM nginxinc/nginx-unprivileged:alpine
+FROM nginxinc/nginx-unprivileged:1.27-alpine
 COPY frontend-lawmaking/nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=builder /app/dist /usr/share/nginx/html
 EXPOSE 8000

--- a/landing/Dockerfile
+++ b/landing/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginxinc/nginx-unprivileged:alpine
+FROM nginxinc/nginx-unprivileged:1.27-alpine
 COPY landing/nginx.conf /etc/nginx/conf.d/default.conf
 COPY landing/index.html landing/styles.css landing/script.js /usr/share/nginx/html/
 COPY landing/src/ /usr/share/nginx/html/src/

--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -3617,6 +3617,7 @@ dependencies = [
  "tower-sessions-sqlx-store",
  "tracing",
  "tracing-subscriber",
+ "url",
  "urlencoding",
  "uuid",
  "wiremock",

--- a/packages/admin/Cargo.toml
+++ b/packages/admin/Cargo.toml
@@ -33,6 +33,7 @@ openidconnect = "4.0"
 tower-sessions = "0.14"
 tower-sessions-sqlx-store = { version = "0.15", features = ["postgres"] }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
+url = "2"
 urlencoding = "2"
 base64 = "0.22"
 time = "0.3"

--- a/packages/admin/src/config.rs
+++ b/packages/admin/src/config.rs
@@ -79,9 +79,12 @@ impl AppConfig {
             .filter(|s| !s.is_empty())
             .map(|s| {
                 let trimmed = s.trim_end_matches('/').to_string();
+                url::Url::parse(&trimmed)
+                    .map_err(|e| format!("BASE_URL is not a valid URL: {e}"))?;
                 tracing::info!("BASE_URL configured: {trimmed}");
-                trimmed
-            });
+                Ok::<String, String>(trimmed)
+            })
+            .transpose()?;
         if base_url.is_none() && oidc.is_some() {
             tracing::warn!(
                 "BASE_URL is not set — OIDC redirect URLs will be derived from request headers. \

--- a/packages/admin/src/corpus_handlers.rs
+++ b/packages/admin/src/corpus_handlers.rs
@@ -90,7 +90,13 @@ pub async fn list_corpus_laws(
             law_id: law.law_id.clone(),
             source_id: law.source_id.clone(),
             source_name: law.source_name.clone(),
-            file_path: law.file_path.clone(),
+            file_path: std::path::Path::new(&law.file_path)
+                .file_name()
+                .map(|f| f.to_string_lossy().into_owned())
+                .unwrap_or_else(|| {
+                    tracing::warn!(path = %law.file_path, "unexpected file_path with no filename");
+                    String::new()
+                }),
         })
         .collect();
 

--- a/packages/admin/src/handlers.rs
+++ b/packages/admin/src/handlers.rs
@@ -461,17 +461,19 @@ pub async fn create_harvest_job(
     }
 
     if !BWB_ID_PATTERN.is_match(&bwb_id) {
+        tracing::debug!(bwb_id, "rejected invalid BWB ID");
         return Err((
             StatusCode::BAD_REQUEST,
-            format!("invalid BWB ID format: expected BWBR followed by 7 digits, got '{bwb_id}'"),
+            "invalid BWB ID format: expected BWBR followed by 7 digits".to_string(),
         ));
     }
 
     if let Some(ref date) = body.date {
         if chrono::NaiveDate::parse_from_str(date, "%Y-%m-%d").is_err() {
+            tracing::debug!(date, "rejected invalid date");
             return Err((
                 StatusCode::BAD_REQUEST,
-                format!("invalid date format: expected YYYY-MM-DD, got '{date}'"),
+                "invalid date format: expected YYYY-MM-DD".to_string(),
             ));
         }
     }
@@ -913,7 +915,7 @@ pub async fn reset_exhausted(
         _ => {
             return Err((
                 StatusCode::BAD_REQUEST,
-                format!("{law_id} is not exhausted (status: {:?})", law.status),
+                format!("law is not exhausted (status: {})", law.status),
             ))
         }
     };

--- a/packages/admin/src/main.rs
+++ b/packages/admin/src/main.rs
@@ -171,11 +171,11 @@ async fn main() {
             "/api/sources/{source_id}/sync",
             post(corpus_handlers::sync_source),
         )
+        .route("/api/info", get(handlers::platform_info))
         .route_layer(axum_middleware::from_fn_with_state(
             app_state.clone(),
             middleware::require_auth,
-        ))
-        .route("/api/info", get(handlers::platform_info));
+        ));
 
     let auth_routes = Router::new()
         .route("/auth/login", get(auth::login))

--- a/packages/grafana/Dockerfile
+++ b/packages/grafana/Dockerfile
@@ -28,7 +28,7 @@ ENV GF_AUTH_ANONYMOUS_ENABLED=false
 # ZAD injects OIDC_CLIENT_ID, OIDC_CLIENT_SECRET, OIDC_URL, OIDC_REALM.
 # These static OIDC settings apply when OIDC is enabled:
 ENV GF_AUTH_GENERIC_OAUTH_NAME=Keycloak
-ENV GF_AUTH_GENERIC_OAUTH_ALLOW_SIGN_UP=true
+ENV GF_AUTH_GENERIC_OAUTH_ALLOW_SIGN_UP=false
 ENV GF_AUTH_GENERIC_OAUTH_SCOPES="openid email profile"
 # Map Keycloak roles to Grafana roles — users in 'grafana-admin' group get Admin
 ENV GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_PATH="contains(groups[*], 'grafana-admin') && 'Admin' || 'Viewer'"

--- a/packages/pipeline/Dockerfile.enrich-worker
+++ b/packages/pipeline/Dockerfile.enrich-worker
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Stage 1: Chef base
-FROM rust:1.93-alpine AS chef
+FROM rust:1.94-alpine AS chef
 RUN apk add --no-cache musl-dev
 RUN cargo install cargo-chef --locked
 WORKDIR /build
@@ -33,7 +33,7 @@ RUN find packages -name '*.rs' -exec touch {} + && \
     cargo build --release --bin regelrecht-enrich-worker
 
 # Stage 4: Runtime
-FROM alpine:3.21
+FROM alpine:3.23
 RUN apk add --no-cache ca-certificates git nodejs npm && \
     addgroup -S app && adduser -S app -G app
 

--- a/packages/pipeline/Dockerfile.harvester-worker
+++ b/packages/pipeline/Dockerfile.harvester-worker
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Stage 1: Chef base
-FROM rust:1.93-alpine AS chef
+FROM rust:1.94-alpine AS chef
 RUN apk add --no-cache musl-dev
 RUN cargo install cargo-chef --locked
 WORKDIR /build


### PR DESCRIPTION
## Summary

Addresses medium and low severity findings from #476 and follow-up items from #483.

### Workflow hardening
- Remove `sender.type == 'Bot'` exception from interactive action allowlist — any bot could trigger writes
- Add `timeout-minutes` to all CI/CD jobs (15min standard, 30min for builds/audit)
- Run pre-commit on **all** PRs — previously admin/editor-api changes bypassed it via path filter
- Add cargo registry cache to security audit job
- Gate editor image build on `frontend/**` path changes (saves ~10-15min on unrelated PRs)

### Admin auth hardening
- Move `/api/info` above `route_layer` so it's protected by `require_auth`
- Use `SameSite::Strict` for session cookies when OIDC is enabled
- Validate `BASE_URL` as a proper URL at startup (fail-fast on misconfiguration)

### Docker standardization
- Pin `nginxinc/nginx-unprivileged:alpine` → `1.27-alpine` in landing, docs, lawmaking
- Standardize Rust `1.93` → `1.94` in pipeline worker Dockerfiles
- Standardize Alpine `3.21` → `3.23` in enrich-worker

### Other
- Grafana: disable OAuth auto-provisioning (`allow_sign_up=false`)
- Remove user input echo from error messages (defense-in-depth against XSS)
- Use `Display` instead of `Debug` for status enum in error responses
- Strip absolute file paths to filename only in corpus API responses

Closes #483. Partially addresses #476 (medium/low severity items).

## Test plan
- [x] `just build-check` passes
- [x] `just format` + `just lint` pass
- [x] All 86 admin tests pass
- [ ] Verify CI workflows trigger correctly with new timeouts and path filters
- [ ] Verify OIDC login flow with `SameSite::Strict`
- [ ] Verify Grafana access for users in `grafana-admin` group after sign-up disable