### PR TITLE
fix(pipeline): propagate None date to follow-up harvest jobs

### DIFF
--- a/packages/pipeline/src/worker.rs
+++ b/packages/pipeline/src/worker.rs
@@ -296,16 +296,13 @@ async fn process_next_job(
                         _ => {}
                     }
 
-                    // Propagate the original requested date (not the parent's resolved
-                    // consolidation date) so the entire reference chain harvests each
-                    // law at its own correct consolidation for the same point in time.
-                    let follow_up_date = payload
-                        .date
-                        .clone()
-                        .or_else(|| Some(result.harvest_date.clone()));
+                    // Propagate the original requested date through the chain.
+                    // When None (no date specified), each law independently resolves
+                    // its own latest consolidation from BWB — this ensures we always
+                    // harvest the version that is valid today.
                     let follow_up_payload = HarvestPayload {
                         bwb_id: bwb_id.clone(),
-                        date: follow_up_date,
+                        date: payload.date.clone(),
                         max_size_mb: payload.max_size_mb,
                         depth: Some(next_depth),
                     };


### PR DESCRIPTION
## Summary

- When no date is specified on a root harvest job, follow-up jobs for referenced laws now receive `date: None` instead of the parent's resolved consolidation date
- Each referenced law independently resolves its own latest consolidation from BWB, ensuring we harvest the version valid today

## Root cause

The `.or_else(|| Some(result.harvest_date.clone()))` fallback in follow-up job creation converted `None` (meaning "latest/today") into a specific historical date (e.g. `2024-01-01`). Referenced laws then got harvested at that fixed date instead of their own current version.

## Test plan

- [x] All 23 pipeline unit tests pass
- [ ] Deploy and verify follow-up jobs have `date: null` when root job has no date
- [ ] Verify each referenced law resolves its own latest consolidation independently