### PR TITLE
fix(grafana): trigger rebuild to pick up entrypoint crash fix

### DIFF
--- a/packages/grafana/Dockerfile
+++ b/packages/grafana/Dockerfile
@@ -40,7 +40,7 @@ ENV GF_ALERTING_ENABLED=false
 # Enable Git Sync (experimental) for dashboard version control
 ENV GF_FEATURE_TOGGLES_ENABLE=provisioning,kubernetesDashboards
 
-# Copy provisioning files and entrypoint
+# Copy provisioning files and entrypoint (includes GF_SECURITY_ADMIN_PASSWORD default fix)
 COPY provisioning/ /etc/grafana/provisioning/
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
## Summary

- Triggers a Grafana image rebuild to deploy the existing entrypoint.sh fix for the `GF_SECURITY_ADMIN_PASSWORD` crash

## Root cause

The deployed Grafana image (`sha-f7a4d81` from Apr 5) has an old `entrypoint.sh` that uses `${GF_SECURITY_ADMIN_PASSWORD}` without a default on line 92. With `set -eu`, this crashes when the env var is unset. The fix (`:-admin` default) was already on main but never deployed because no Grafana files were modified since.

The Grafana crash-loop prevents ArgoCD from reaching "Synced + Healthy", which blocks **all** production deploys — including the harvester-worker and pipeline fixes from PRs #490 and #501.

## Test plan

- [ ] Grafana pod starts without crash-loop
- [ ] ArgoCD sync completes successfully
- [ ] Full production deploy succeeds (all components)