### PR TITLE
feat(graph): law dependency graph visualization

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,3 +1,5 @@
 dist/
 node_modules/
 public/data/
+data/
+wasm/

--- a/frontend/css/components/graph.css
+++ b/frontend/css/components/graph.css
@@ -8,14 +8,183 @@
 
 /* Sidebar */
 .graph-sidebar {
-  width: 280px;
-  min-width: 280px;
+  width: 300px;
+  min-width: 300px;
   flex-shrink: 0;
   background-color: var(--color-surface);
   border-right: var(--divider-width) solid var(--color-border);
   display: flex;
   flex-direction: column;
+  overflow: hidden;
+}
+
+/* Tabs */
+.graph-tabs {
+  display: flex;
+  border-bottom: var(--divider-width) solid var(--color-border);
+  flex-shrink: 0;
+}
+
+.graph-tabs__tab {
+  flex: 1;
+  padding: var(--spacing-2) var(--spacing-3);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-normal);
+  color: var(--color-text-secondary);
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.graph-tabs__tab:hover {
+  color: var(--color-text-primary);
+}
+
+.graph-tabs__tab--active {
+  color: var(--color-primary);
+  border-bottom-color: var(--color-primary);
+  font-weight: var(--font-weight-medium);
+}
+
+.graph-tab-content {
+  flex: 1;
   overflow-y: auto;
+}
+
+/* Test Panel */
+.test-panel__actions {
+  padding: var(--spacing-3) var(--spacing-4);
+  border-bottom: var(--divider-width) solid var(--color-border);
+}
+
+.test-panel__run-all {
+  display: block;
+  width: 100%;
+  padding: var(--spacing-2) var(--spacing-3);
+  background-color: var(--color-primary);
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+}
+
+.test-panel__run-all:hover {
+  opacity: 0.9;
+}
+
+.test-panel__run-all:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.test-panel__summary {
+  margin-top: var(--spacing-2);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+}
+
+.test-panel__list {
+  padding: var(--spacing-2) var(--spacing-4);
+}
+
+.test-panel__feature {
+  margin-bottom: var(--spacing-3);
+}
+
+.test-panel__feature-name {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: var(--spacing-1);
+}
+
+.test-panel__scenario {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  padding: 3px var(--spacing-2);
+  border-radius: 3px;
+  cursor: pointer;
+  font-size: var(--font-size-xs);
+}
+
+.test-panel__scenario:hover {
+  background-color: #f1f5f9;
+}
+
+.test-panel__scenario--active {
+  background-color: var(--color-primary);
+  color: #fff;
+}
+
+.test-panel__scenario-status {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 9px;
+  font-weight: bold;
+}
+
+.test-panel__scenario-status--pending {
+  background: #f1f5f9;
+  border: 1px solid #cbd5e1;
+  color: #94a3b8;
+}
+
+.test-panel__scenario-status--pass {
+  background: #dcfce7;
+  border: 1px solid #22c55e;
+  color: #166534;
+}
+
+.test-panel__scenario-status--fail {
+  background: #fee2e2;
+  border: 1px solid #ef4444;
+  color: #991b1b;
+}
+
+.test-panel__scenario-status--running {
+  background: #dbeafe;
+  border: 1px solid #3b82f6;
+  color: #1e40af;
+}
+
+.test-panel__scenario-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+}
+
+.test-panel__scenario-run {
+  padding: 1px 6px;
+  font-size: 10px;
+  background: none;
+  border: 1px solid var(--color-border);
+  border-radius: 3px;
+  cursor: pointer;
+  flex-shrink: 0;
+  color: var(--color-text-secondary);
+}
+
+.test-panel__scenario-run:hover {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+}
+
+.test-panel__upload {
+  padding: var(--spacing-3) var(--spacing-4);
+  border-top: var(--divider-width) solid var(--color-border);
+  margin-top: auto;
 }
 
 .graph-sidebar__header {

--- a/frontend/css/components/graph.css
+++ b/frontend/css/components/graph.css
@@ -1,0 +1,375 @@
+/* Graph View */
+
+.graph-page {
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+}
+
+/* Sidebar */
+.graph-sidebar {
+  width: 280px;
+  min-width: 280px;
+  flex-shrink: 0;
+  background-color: var(--color-surface);
+  border-right: var(--divider-width) solid var(--color-border);
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+}
+
+.graph-sidebar__header {
+  padding: var(--spacing-3) var(--spacing-4);
+  border-bottom: var(--divider-width) solid var(--color-border);
+}
+
+.graph-sidebar__title {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-medium);
+  line-height: var(--line-height-snug);
+}
+
+/* Scenario picker */
+.graph-sidebar__scenarios {
+  padding: var(--spacing-3) var(--spacing-4);
+  border-bottom: var(--divider-width) solid var(--color-border);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.graph-scenario__feature-header {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  width: 100%;
+  padding: var(--spacing-1) 0;
+  background: none;
+  border: none;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  cursor: pointer;
+  color: var(--color-text);
+  text-align: left;
+}
+
+.graph-scenario__feature-header::before {
+  content: '\25B8';
+  font-size: 10px;
+}
+
+.graph-scenario__feature--expanded > .graph-scenario__feature-header::before {
+  content: '\25BE';
+}
+
+.graph-scenario__feature-body {
+  display: none;
+  padding-left: var(--spacing-2);
+}
+
+.graph-scenario__feature--expanded > .graph-scenario__feature-body {
+  display: block;
+}
+
+.graph-scenario__article-header {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  width: 100%;
+  padding: var(--spacing-1) 0;
+  background: none;
+  border: none;
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  text-align: left;
+}
+
+.graph-scenario__article-header::before {
+  content: '\25B8';
+  font-size: 9px;
+}
+
+.graph-scenario__article-group--expanded > .graph-scenario__article-header::before {
+  content: '\25BE';
+}
+
+.graph-scenario__article-body {
+  display: none;
+  padding-left: var(--spacing-3);
+}
+
+.graph-scenario__article-group--expanded > .graph-scenario__article-body {
+  display: block;
+}
+
+.graph-scenario__item {
+  display: block;
+  width: 100%;
+  padding: 2px var(--spacing-2);
+  background: none;
+  border: none;
+  font-size: var(--font-size-xs);
+  cursor: pointer;
+  text-align: left;
+  color: var(--color-text);
+  border-radius: 3px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.graph-scenario__item:hover {
+  background-color: #f1f5f9;
+}
+
+.graph-scenario__item--active {
+  background-color: var(--color-primary, #154273);
+  color: #fff;
+}
+
+.graph-sidebar__filters {
+  padding: var(--spacing-3) var(--spacing-4);
+  flex: 1;
+}
+
+.graph-sidebar__section {
+  margin-bottom: var(--spacing-4);
+}
+
+.graph-sidebar__section-title {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: var(--spacing-2);
+}
+
+.graph-sidebar__checkbox {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  padding: var(--spacing-1) 0;
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+}
+
+.graph-sidebar__checkbox input[type="checkbox"] {
+  accent-color: var(--color-primary);
+}
+
+.graph-sidebar__checkbox span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Legend */
+.graph-sidebar__legend {
+  padding: var(--spacing-3) var(--spacing-4);
+  border-top: var(--divider-width) solid var(--color-border);
+}
+
+.graph-sidebar__subtitle {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  margin-bottom: var(--spacing-2);
+}
+
+.graph-legend {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.graph-legend__item {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  font-size: var(--font-size-sm);
+}
+
+.graph-legend__color {
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
+  border: 2px solid;
+  flex-shrink: 0;
+}
+
+.graph-legend__color--wet {
+  background-color: #dbeafe;
+  border-color: #3b82f6;
+}
+
+.graph-legend__color--amvb {
+  background-color: #dcfce7;
+  border-color: #22c55e;
+}
+
+.graph-legend__color--mr {
+  background-color: #fce7f3;
+  border-color: #ec4899;
+}
+
+.graph-legend__color--verordening {
+  background-color: #fef3c7;
+  border-color: #f59e0b;
+}
+
+.graph-legend__line {
+  width: 24px;
+  height: 0;
+  border-top: 2px solid;
+  flex-shrink: 0;
+}
+
+.graph-legend__line--data {
+  border-color: #94a3b8;
+}
+
+.graph-legend__line--grondslag {
+  border-color: #3b82f6;
+  border-top-style: dashed;
+}
+
+.graph-legend__color--user-input {
+  background-color: #f8fafc;
+  border-color: #94a3b8;
+  border-style: dashed;
+  border-radius: 50%;
+}
+
+.graph-legend__line--user-input {
+  border-color: #cbd5e1;
+  border-top-style: dotted;
+}
+
+/* YAML Upload */
+.graph-sidebar__upload {
+  padding: var(--spacing-3) var(--spacing-4);
+  border-top: var(--divider-width) solid var(--color-border);
+}
+
+.graph-upload__input {
+  display: none;
+}
+
+.graph-upload__label {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+  cursor: pointer;
+}
+
+.graph-upload__button {
+  display: inline-block;
+  padding: var(--spacing-1) var(--spacing-3);
+  background-color: var(--color-primary, #154273);
+  color: #fff;
+  border-radius: 4px;
+  font-size: var(--font-size-sm);
+  text-align: center;
+}
+
+.graph-upload__button:hover {
+  opacity: 0.9;
+}
+
+.graph-upload__button--folder {
+  background-color: #475569;
+}
+
+.graph-upload__hint {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+}
+
+.graph-upload__status {
+  font-size: var(--font-size-xs);
+  color: var(--color-primary, #154273);
+  margin-top: var(--spacing-1);
+  min-height: 1.2em;
+}
+
+/* Canvas */
+.graph-canvas {
+  flex: 1;
+  background-color: var(--color-slate-50);
+  position: relative;
+  overflow: hidden;
+}
+
+.graph-canvas--dragover {
+  outline: 3px dashed var(--color-primary, #154273);
+  outline-offset: -3px;
+  background-color: rgba(21, 66, 115, 0.04);
+}
+
+/* Tooltip */
+.graph-tooltip {
+  background: #fff;
+  border: 1px solid var(--color-border, #e2e8f0);
+  border-radius: 6px;
+  padding: 12px;
+  min-width: 200px;
+  max-width: 320px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+  font-family: system-ui, sans-serif;
+  font-size: 12px;
+  pointer-events: none;
+}
+
+.graph-tooltip__header {
+  font-weight: 600;
+  font-size: 13px;
+  margin-bottom: 2px;
+  color: #1e293b;
+}
+
+.graph-tooltip__article {
+  font-size: 11px;
+  color: #64748b;
+  margin-bottom: 8px;
+}
+
+.graph-tooltip__section {
+  margin-bottom: 6px;
+}
+
+.graph-tooltip__section-title {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #94a3b8;
+  margin-bottom: 4px;
+}
+
+.graph-tooltip__field {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+  padding: 1px 0;
+}
+
+.graph-tooltip__field-name {
+  font-family: "SF Mono", "Fira Code", "Consolas", monospace;
+  font-size: 11px;
+  color: #1e293b;
+}
+
+.graph-tooltip__field-type {
+  font-size: 10px;
+  color: #94a3b8;
+  background: #f1f5f9;
+  padding: 0 4px;
+  border-radius: 3px;
+}
+
+.graph-tooltip__field-source {
+  font-size: 10px;
+  color: #64748b;
+  margin-left: auto;
+}

--- a/frontend/graph.html
+++ b/frontend/graph.html
@@ -16,82 +16,125 @@
     </header>
 
     <main class="graph-page">
-      <aside class="graph-sidebar scrollable">
-        <div class="graph-sidebar__header">
-          <h2 class="graph-sidebar__title">Wetten</h2>
+      <aside class="graph-sidebar">
+        <div class="graph-tabs">
+          <button class="graph-tabs__tab graph-tabs__tab--active" data-tab="graaf">Graaf</button>
+          <button class="graph-tabs__tab" data-tab="tests">Tests</button>
         </div>
-        <div class="graph-sidebar__scenarios" id="scenario-filters">
-          <!-- Dynamically populated -->
-        </div>
-        <div class="graph-sidebar__filters" id="law-filters">
-          <!-- Dynamically populated -->
-        </div>
-        <div class="graph-sidebar__upload">
-          <h3 class="graph-sidebar__subtitle">YAML laden</h3>
-          <label class="graph-upload__label" for="yaml-upload">
-            <span class="graph-upload__button">Bestanden kiezen</span>
-            <span class="graph-upload__hint">of sleep YAML naar de graaf</span>
-          </label>
-          <input type="file" id="yaml-upload" accept=".yaml,.yml" multiple class="graph-upload__input">
-          <label class="graph-upload__label" for="yaml-folder-upload" style="margin-top:8px;">
-            <span class="graph-upload__button graph-upload__button--folder">Map laden</span>
-            <span class="graph-upload__hint">selecteer een map met YAML bestanden</span>
-          </label>
-          <input type="file" id="yaml-folder-upload" webkitdirectory class="graph-upload__input">
-          <div id="upload-status" class="graph-upload__status"></div>
-        </div>
-        <div class="graph-sidebar__legend">
-          <h3 class="graph-sidebar__subtitle">Legenda</h3>
-          <div class="graph-legend">
-            <div class="graph-legend__item">
-              <span class="graph-legend__color graph-legend__color--wet"></span>
-              <span>Wet</span>
-            </div>
-            <div class="graph-legend__item">
-              <span class="graph-legend__color graph-legend__color--amvb"></span>
-              <span>AMvB</span>
-            </div>
-            <div class="graph-legend__item">
-              <span class="graph-legend__color graph-legend__color--mr"></span>
-              <span>Ministeri&euml;le regeling</span>
-            </div>
-            <div class="graph-legend__item">
-              <span class="graph-legend__color graph-legend__color--verordening"></span>
-              <span>Verordening</span>
-            </div>
-            <div class="graph-legend__item">
-              <span class="graph-legend__color graph-legend__color--user-input"></span>
-              <span>Gebruikersinvoer</span>
-            </div>
-            <div class="graph-legend__item graph-legend__item--edge">
-              <span class="graph-legend__line graph-legend__line--data"></span>
-              <span>Datastroom</span>
-            </div>
-            <div class="graph-legend__item graph-legend__item--edge">
-              <span class="graph-legend__line graph-legend__line--grondslag"></span>
-              <span>Grondslag</span>
-            </div>
-            <div class="graph-legend__item graph-legend__item--edge">
-              <span class="graph-legend__line graph-legend__line--user-input"></span>
-              <span>Invoer</span>
-            </div>
+
+        <!-- Graaf tab -->
+        <div class="graph-tab-content scrollable" id="tab-graaf">
+          <div class="graph-sidebar__header">
+            <h2 class="graph-sidebar__title">Wetten</h2>
           </div>
-          <h3 class="graph-sidebar__subtitle" style="margin-top:12px;">Validatiestatus</h3>
-          <div class="graph-legend">
-            <div class="graph-legend__item">
-              <span class="graph-legend__color" style="background:#fff7ed;border-color:#ea580c;"></span>
-              <span>Te controleren</span>
-            </div>
-            <div class="graph-legend__item">
-              <span class="graph-legend__color" style="background:#fefce8;border-color:#ca8a04;"></span>
-              <span>Bezig</span>
-            </div>
-            <div class="graph-legend__item">
-              <span class="graph-legend__color" style="background:#f0fdf4;border-color:#16a34a;"></span>
-              <span>Gevalideerd</span>
-            </div>
+          <div class="graph-sidebar__scenarios" id="scenario-filters">
+            <!-- Dynamically populated -->
           </div>
-          <p style="font-size:11px;color:#94a3b8;margin-top:6px;">Rechtsklik op node om status te wisselen</p>
+          <div class="graph-sidebar__filters" id="law-filters">
+            <!-- Dynamically populated -->
+          </div>
+          <div class="graph-sidebar__upload">
+            <h3 class="graph-sidebar__subtitle">YAML laden</h3>
+            <label class="graph-upload__label" for="yaml-upload">
+              <span class="graph-upload__button">Bestanden kiezen</span>
+              <span class="graph-upload__hint">of sleep YAML naar de graaf</span>
+            </label>
+            <input type="file" id="yaml-upload" accept=".yaml,.yml" multiple class="graph-upload__input">
+            <label class="graph-upload__label" for="yaml-folder-upload" style="margin-top:8px;">
+              <span class="graph-upload__button graph-upload__button--folder">Map laden</span>
+              <span class="graph-upload__hint">selecteer een map met YAML bestanden</span>
+            </label>
+            <input type="file" id="yaml-folder-upload" webkitdirectory class="graph-upload__input">
+            <div id="upload-status" class="graph-upload__status"></div>
+          </div>
+          <div class="graph-sidebar__legend">
+            <h3 class="graph-sidebar__subtitle">Legenda</h3>
+            <div class="graph-legend">
+              <div class="graph-legend__item">
+                <span class="graph-legend__color graph-legend__color--wet"></span>
+                <span>Wet</span>
+              </div>
+              <div class="graph-legend__item">
+                <span class="graph-legend__color graph-legend__color--amvb"></span>
+                <span>AMvB</span>
+              </div>
+              <div class="graph-legend__item">
+                <span class="graph-legend__color graph-legend__color--mr"></span>
+                <span>Ministeri&euml;le regeling</span>
+              </div>
+              <div class="graph-legend__item">
+                <span class="graph-legend__color graph-legend__color--verordening"></span>
+                <span>Verordening</span>
+              </div>
+              <div class="graph-legend__item">
+                <span class="graph-legend__color graph-legend__color--user-input"></span>
+                <span>Gebruikersinvoer</span>
+              </div>
+              <div class="graph-legend__item graph-legend__item--edge">
+                <span class="graph-legend__line graph-legend__line--data"></span>
+                <span>Datastroom</span>
+              </div>
+              <div class="graph-legend__item graph-legend__item--edge">
+                <span class="graph-legend__line graph-legend__line--grondslag"></span>
+                <span>Grondslag</span>
+              </div>
+              <div class="graph-legend__item graph-legend__item--edge">
+                <span class="graph-legend__line graph-legend__line--user-input"></span>
+                <span>Invoer</span>
+              </div>
+            </div>
+            <h3 class="graph-sidebar__subtitle" style="margin-top:12px;">Validatiestatus</h3>
+            <div class="graph-legend">
+              <div class="graph-legend__item">
+                <span class="graph-legend__color" style="background:#fff7ed;border-color:#ea580c;"></span>
+                <span>Te controleren</span>
+              </div>
+              <div class="graph-legend__item">
+                <span class="graph-legend__color" style="background:#fefce8;border-color:#ca8a04;"></span>
+                <span>Bezig</span>
+              </div>
+              <div class="graph-legend__item">
+                <span class="graph-legend__color" style="background:#f0fdf4;border-color:#16a34a;"></span>
+                <span>Gevalideerd</span>
+              </div>
+            </div>
+            <p style="font-size:11px;color:#94a3b8;margin-top:6px;">Rechtsklik op node om status te wisselen</p>
+          </div>
+        </div>
+
+        <!-- Tests tab -->
+        <div class="graph-tab-content scrollable" id="tab-tests" style="display:none;">
+          <div class="graph-sidebar__header">
+            <h2 class="graph-sidebar__title">BDD Tests</h2>
+          </div>
+          <div class="test-panel__actions">
+            <button class="test-panel__run-all" id="run-all-tests">Alle tests uitvoeren</button>
+            <div class="test-panel__summary" id="test-summary"></div>
+          </div>
+          <div class="test-panel__list" id="test-list">
+            <!-- Dynamically populated -->
+          </div>
+          <div class="test-panel__upload">
+            <h3 class="graph-sidebar__subtitle">Feature bestanden laden</h3>
+            <label class="graph-upload__label" for="feature-upload">
+              <span class="graph-upload__button">Feature bestanden kiezen</span>
+              <span class="graph-upload__hint">.feature bestanden (Gherkin)</span>
+            </label>
+            <input type="file" id="feature-upload" accept=".feature" multiple class="graph-upload__input">
+            <label class="graph-upload__label" for="feature-folder-upload" style="margin-top:8px;">
+              <span class="graph-upload__button graph-upload__button--folder">Features map laden</span>
+            </label>
+            <input type="file" id="feature-folder-upload" webkitdirectory class="graph-upload__input">
+            <div id="feature-upload-status" class="graph-upload__status"></div>
+          </div>
+          <div class="test-panel__upload">
+            <h3 class="graph-sidebar__subtitle">Resultaten importeren</h3>
+            <label class="graph-upload__label" for="test-results-upload">
+              <span class="graph-upload__button">Resultaten laden</span>
+              <span class="graph-upload__hint">importeer test-results.json</span>
+            </label>
+            <input type="file" id="test-results-upload" accept=".json" class="graph-upload__input">
+          </div>
         </div>
       </aside>
 
@@ -105,6 +148,6 @@
   <script src="https://unpkg.com/elkjs@0.9.3/lib/elk.bundled.js"></script>
   <script src="https://unpkg.com/cytoscape-elk@2.2.0/dist/cytoscape-elk.js"></script>
   <script src="https://unpkg.com/js-yaml@4.1.0/dist/js-yaml.min.js"></script>
-  <script src="/js/graph.js"></script>
+  <script type="module" src="/js/graph.js"></script>
 </body>
 </html>

--- a/frontend/graph.html
+++ b/frontend/graph.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>RegelRecht - Graaf</title>
+  <link rel="stylesheet" href="css/reset.css">
+  <link rel="stylesheet" href="css/variables.css">
+  <link rel="stylesheet" href="css/layout.css">
+  <link rel="stylesheet" href="css/components/graph.css">
+</head>
+<body>
+  <div class="app">
+    <header style="padding:12px 16px;border-bottom:1px solid #e2e8f0;background:#fff;font-size:18px;font-weight:700;">
+      RegelRecht graaf
+    </header>
+
+    <main class="graph-page">
+      <aside class="graph-sidebar scrollable">
+        <div class="graph-sidebar__header">
+          <h2 class="graph-sidebar__title">Wetten</h2>
+        </div>
+        <div class="graph-sidebar__scenarios" id="scenario-filters">
+          <!-- Dynamically populated -->
+        </div>
+        <div class="graph-sidebar__filters" id="law-filters">
+          <!-- Dynamically populated -->
+        </div>
+        <div class="graph-sidebar__upload">
+          <h3 class="graph-sidebar__subtitle">YAML laden</h3>
+          <label class="graph-upload__label" for="yaml-upload">
+            <span class="graph-upload__button">Bestanden kiezen</span>
+            <span class="graph-upload__hint">of sleep YAML naar de graaf</span>
+          </label>
+          <input type="file" id="yaml-upload" accept=".yaml,.yml" multiple class="graph-upload__input">
+          <label class="graph-upload__label" for="yaml-folder-upload" style="margin-top:8px;">
+            <span class="graph-upload__button graph-upload__button--folder">Map laden</span>
+            <span class="graph-upload__hint">selecteer een map met YAML bestanden</span>
+          </label>
+          <input type="file" id="yaml-folder-upload" webkitdirectory class="graph-upload__input">
+          <div id="upload-status" class="graph-upload__status"></div>
+        </div>
+        <div class="graph-sidebar__legend">
+          <h3 class="graph-sidebar__subtitle">Legenda</h3>
+          <div class="graph-legend">
+            <div class="graph-legend__item">
+              <span class="graph-legend__color graph-legend__color--wet"></span>
+              <span>Wet</span>
+            </div>
+            <div class="graph-legend__item">
+              <span class="graph-legend__color graph-legend__color--amvb"></span>
+              <span>AMvB</span>
+            </div>
+            <div class="graph-legend__item">
+              <span class="graph-legend__color graph-legend__color--mr"></span>
+              <span>Ministeri&euml;le regeling</span>
+            </div>
+            <div class="graph-legend__item">
+              <span class="graph-legend__color graph-legend__color--verordening"></span>
+              <span>Verordening</span>
+            </div>
+            <div class="graph-legend__item">
+              <span class="graph-legend__color graph-legend__color--user-input"></span>
+              <span>Gebruikersinvoer</span>
+            </div>
+            <div class="graph-legend__item graph-legend__item--edge">
+              <span class="graph-legend__line graph-legend__line--data"></span>
+              <span>Datastroom</span>
+            </div>
+            <div class="graph-legend__item graph-legend__item--edge">
+              <span class="graph-legend__line graph-legend__line--grondslag"></span>
+              <span>Grondslag</span>
+            </div>
+            <div class="graph-legend__item graph-legend__item--edge">
+              <span class="graph-legend__line graph-legend__line--user-input"></span>
+              <span>Invoer</span>
+            </div>
+          </div>
+          <h3 class="graph-sidebar__subtitle" style="margin-top:12px;">Validatiestatus</h3>
+          <div class="graph-legend">
+            <div class="graph-legend__item">
+              <span class="graph-legend__color" style="background:#fff7ed;border-color:#ea580c;"></span>
+              <span>Te controleren</span>
+            </div>
+            <div class="graph-legend__item">
+              <span class="graph-legend__color" style="background:#fefce8;border-color:#ca8a04;"></span>
+              <span>Bezig</span>
+            </div>
+            <div class="graph-legend__item">
+              <span class="graph-legend__color" style="background:#f0fdf4;border-color:#16a34a;"></span>
+              <span>Gevalideerd</span>
+            </div>
+          </div>
+          <p style="font-size:11px;color:#94a3b8;margin-top:6px;">Rechtsklik op node om status te wisselen</p>
+        </div>
+      </aside>
+
+      <div class="graph-canvas" id="graph-canvas">
+        <!-- Cytoscape renders here -->
+      </div>
+    </main>
+  </div>
+
+  <script src="https://unpkg.com/cytoscape@3.31.0/dist/cytoscape.min.js"></script>
+  <script src="https://unpkg.com/elkjs@0.9.3/lib/elk.bundled.js"></script>
+  <script src="https://unpkg.com/cytoscape-elk@2.2.0/dist/cytoscape-elk.js"></script>
+  <script src="https://unpkg.com/js-yaml@4.1.0/dist/js-yaml.min.js"></script>
+  <script src="/js/graph.js"></script>
+</body>
+</html>

--- a/frontend/js/graph.js
+++ b/frontend/js/graph.js
@@ -1,0 +1,1478 @@
+const LAYER_COLORS = {
+  WET: { bg: '#dbeafe', border: '#3b82f6', text: '#1e40af' },
+  AMVB: { bg: '#dcfce7', border: '#22c55e', text: '#166534' },
+  MINISTERIELE_REGELING: { bg: '#fce7f3', border: '#ec4899', text: '#9d174d' },
+  GEMEENTELIJKE_VERORDENING: { bg: '#fef3c7', border: '#f59e0b', text: '#92400e' },
+  ONBEKEND: { bg: '#f1f5f9', border: '#94a3b8', text: '#475569' },
+};
+
+const VALIDATION_STATUS = {
+  none:        { border: null, bg: null, label: 'Geen status' },
+  pending:     { border: '#ea580c', bg: '#fff7ed', label: 'Te controleren' },
+  in_progress: { border: '#ca8a04', bg: '#fefce8', label: 'Bezig' },
+  validated:   { border: '#16a34a', bg: '#f0fdf4', label: 'Gevalideerd' },
+};
+const STATUS_CYCLE = ['none', 'pending', 'in_progress', 'validated'];
+const nodeStatusMap = new Map();
+
+function getLayerColor(layer) {
+  return LAYER_COLORS[layer] || LAYER_COLORS.ONBEKEND;
+}
+
+function formatLawName(name) {
+  if (name.startsWith('#')) return name.substring(1).replace(/_/g, ' ');
+  return name.replace(/_/g, ' ');
+}
+
+function formatLayerLabel(layer) {
+  const labels = {
+    WET: 'Wet',
+    AMVB: 'AMvB',
+    MINISTERIELE_REGELING: 'Min. regeling',
+    GEMEENTELIJKE_VERORDENING: 'Verordening',
+  };
+  return labels[layer] || layer;
+}
+
+let cy = null;
+let graphData = null;
+let selectedNode = null;
+let parsedScenarios = [];
+let activeScenarioIdx = null;
+
+async function init() {
+  try {
+    const resp = await fetch('/data/graph-data.json');
+    if (resp.ok) {
+      graphData = await resp.json();
+    }
+  } catch (e) {
+    // No pre-generated data — that's fine, user can upload YAML
+  }
+
+  if (!graphData) {
+    document.getElementById('graph-canvas').innerHTML =
+      '<p style="padding:2rem;color:#64748b;">Geen graaf-data gevonden. Upload YAML-bestanden of een map via de sidebar.</p>';
+  }
+
+  try {
+    const featResp = await fetch('/data/features-data.json');
+    if (featResp.ok) {
+      const featuresData = await featResp.json();
+      parsedScenarios = parseAllScenarios(featuresData);
+    }
+  } catch (e) {
+    console.warn('Features data not available');
+  }
+
+  if (graphData) {
+    buildScenarioFilters();
+    buildFilters();
+    renderGraph(graphData);
+  }
+}
+
+// Compute connected component from seed law IDs
+function getConnectedLaws(data, seedIds) {
+  const connected = new Set(seedIds);
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const edge of data.edges) {
+      if (connected.has(edge.source) && !connected.has(edge.target)) {
+        connected.add(edge.target);
+        changed = true;
+      }
+      if (connected.has(edge.target) && !connected.has(edge.source)) {
+        connected.add(edge.source);
+        changed = true;
+      }
+    }
+  }
+  return connected;
+}
+
+function setAllCheckboxes(checked) {
+  document.querySelectorAll('#law-filters input[type="checkbox"]').forEach(cb => {
+    cb.checked = checked;
+  });
+}
+
+function buildFilters() {
+  const container = document.getElementById('law-filters');
+  if (!container || !graphData) return;
+
+  container.innerHTML = '';
+
+  // Only show laws that are visible in the graph
+  const connectedIds = new Set();
+  for (const edge of graphData.edges) {
+    connectedIds.add(edge.source);
+    connectedIds.add(edge.target);
+  }
+  const visibleLaws = graphData.laws.filter(law =>
+    (law.articles && law.articles.length > 0) || connectedIds.has(law.id)
+  );
+
+  const groups = {};
+  for (const law of visibleLaws) {
+    const layer = law.regulatory_layer || 'ONBEKEND';
+    if (!groups[layer]) groups[layer] = [];
+    groups[layer].push(law);
+  }
+
+  const layerOrder = ['WET', 'AMVB', 'MINISTERIELE_REGELING', 'GEMEENTELIJKE_VERORDENING', 'ONBEKEND'];
+
+  for (const layer of layerOrder) {
+    const laws = groups[layer];
+    if (!laws || laws.length === 0) continue;
+
+    const section = document.createElement('div');
+    section.className = 'graph-sidebar__section';
+
+    const sectionTitle = document.createElement('div');
+    sectionTitle.className = 'graph-sidebar__section-title';
+    sectionTitle.textContent = formatLayerLabel(layer);
+    section.appendChild(sectionTitle);
+
+    for (const law of laws) {
+      const label = document.createElement('label');
+      label.className = 'graph-sidebar__checkbox';
+
+      const checkbox = document.createElement('input');
+      checkbox.type = 'checkbox';
+      checkbox.checked = true;
+      checkbox.value = law.id;
+      checkbox.addEventListener('change', () => updateVisibility());
+
+      const span = document.createElement('span');
+      span.textContent = formatLawName(law.name);
+      span.title = law.id;
+
+      label.appendChild(checkbox);
+      label.appendChild(span);
+      section.appendChild(label);
+    }
+
+    container.appendChild(section);
+  }
+}
+
+function buildArticleLabel(art) {
+  const lines = [`Art. ${art.number}`];
+  if (art.inputs.length > 0 || art.outputs.length > 0) {
+    lines.push('\u2500'.repeat(16));
+  }
+  for (const inp of art.inputs) {
+    lines.push(`\u2192 ${inp.name}`);
+  }
+  if (art.inputs.length > 0 && art.outputs.length > 0) {
+    lines.push('\u2500'.repeat(16));
+  }
+  for (const out of art.outputs) {
+    lines.push(`\u2190 ${out.name}`);
+  }
+  return lines.join('\n');
+}
+
+function calcArticleSize(art) {
+  const lineCount = 1 + art.inputs.length + art.outputs.length +
+    (art.inputs.length > 0 || art.outputs.length > 0 ? 1 : 0) +
+    (art.inputs.length > 0 && art.outputs.length > 0 ? 1 : 0);
+  const height = Math.max(40, lineCount * 16 + 16);
+
+  let maxLen = `Art. ${art.number}`.length;
+  for (const inp of art.inputs) {
+    maxLen = Math.max(maxLen, inp.name.length + 2);
+  }
+  for (const out of art.outputs) {
+    maxLen = Math.max(maxLen, out.name.length + 2);
+  }
+  const width = Math.max(120, maxLen * 7.5 + 24);
+
+  return { width, height };
+}
+
+function renderGraph(data) {
+  if (!data) return;
+
+  const elements = [];
+
+  // Determine which laws are connected by edges
+  const connectedLawIds = new Set();
+  for (const edge of data.edges) {
+    connectedLawIds.add(edge.source);
+    connectedLawIds.add(edge.target);
+  }
+
+  // Filter: only show laws that have articles OR are connected by edges
+  const visibleLaws = data.laws.filter(law =>
+    (law.articles && law.articles.length > 0) || connectedLawIds.has(law.id)
+  );
+
+  // Assign partition indices by regulatory layer for ELK grouping
+  const LAYER_ORDER = ['WET', 'AMVB', 'MINISTERIELE_REGELING', 'GEMEENTELIJKE_VERORDENING', 'ONBEKEND'];
+  const layerPartition = {};
+  LAYER_ORDER.forEach((l, i) => { layerPartition[l] = i; });
+
+  // Law parent nodes (compound containers)
+  for (const law of visibleLaws) {
+    const color = getLayerColor(law.regulatory_layer);
+    const partition = layerPartition[law.regulatory_layer] ?? LAYER_ORDER.length;
+    elements.push({
+      group: 'nodes',
+      data: {
+        id: law.id,
+        label: formatLawName(law.name),
+        nodeType: 'law',
+        layer: law.regulatory_layer,
+        layerLabel: formatLayerLabel(law.regulatory_layer),
+        bgColor: color.bg,
+        borderColor: color.border,
+        textColor: color.text,
+        url: law.url,
+        elkPartition: partition,
+      },
+    });
+
+    // Article child nodes
+    if (law.articles) {
+      for (const art of law.articles) {
+        const size = calcArticleSize(art);
+        const artId = `${law.id}:${art.number}`;
+        elements.push({
+          group: 'nodes',
+          data: {
+            id: artId,
+            parent: law.id,
+            label: buildArticleLabel(art),
+            nodeType: 'article',
+            layer: law.regulatory_layer,
+            lawId: law.id,
+            articleNumber: art.number,
+            bgColor: color.bg,
+            borderColor: color.border,
+            textColor: color.text,
+            inputs: art.inputs,
+            outputs: art.outputs,
+            nodeWidth: size.width,
+            nodeHeight: size.height,
+          },
+        });
+      }
+    }
+  }
+
+  // Edges — article-level (with fallback to law-level)
+  const elementIds = new Set(elements.map(el => el.data.id));
+  for (const edge of data.edges) {
+    let sourceId = edge.source_article ? `${edge.source}:${edge.source_article}` : edge.source;
+    let targetId = edge.target_article ? `${edge.target}:${edge.target_article}` : edge.target;
+
+    // Fallback to law node if article node doesn't exist
+    if (!elementIds.has(sourceId)) sourceId = edge.source;
+    if (!elementIds.has(targetId)) targetId = edge.target;
+
+    if (!elementIds.has(sourceId) || !elementIds.has(targetId)) continue;
+
+    const isLegalBasis = edge.edge_type === 'legal_basis';
+    const edgeId = `${sourceId}->${targetId}:${edge.source_output}`;
+    elements.push({
+      group: 'edges',
+      data: {
+        id: edgeId,
+        source: sourceId,
+        target: targetId,
+        label: isLegalBasis ? 'grondslag' : (edge.source_output || ''),
+        sourceOutput: edge.source_output || '',
+        sourceLaw: edge.source,
+        targetLaw: edge.target,
+        isIntraLaw: edge.source === edge.target,
+        isLegalBasis,
+      },
+    });
+  }
+
+  // User input nodes — leaf inputs without incoming edges
+  const coveredInputs = new Set();
+  for (const edge of data.edges) {
+    if (edge.target_input && edge.target) {
+      const artKey = edge.target_article
+        ? `${edge.target}:${edge.target_article}:${edge.target_input}`
+        : `${edge.target}::${edge.target_input}`;
+      coveredInputs.add(artKey);
+    }
+  }
+
+  for (const law of visibleLaws) {
+    if (!law.articles) continue;
+    for (const art of law.articles) {
+      for (const inp of art.inputs) {
+        const key = `${law.id}:${art.number}:${inp.name}`;
+        if (coveredInputs.has(key)) continue;
+
+        const artNodeId = `${law.id}:${art.number}`;
+        if (!elementIds.has(artNodeId)) continue;
+
+        const labelText = inp.name.replace(/_/g, ' ');
+        const nodeWidth = Math.max(80, labelText.length * 6.5 + 20);
+        const nodeId = `user:${law.id}:${art.number}:${inp.name}`;
+
+        elements.push({
+          group: 'nodes',
+          data: {
+            id: nodeId,
+            label: labelText,
+            nodeType: 'user_input',
+            lawId: law.id,
+            fieldName: inp.name,
+            nodeWidth: nodeWidth,
+            nodeHeight: 26,
+          },
+        });
+
+        elements.push({
+          group: 'edges',
+          data: {
+            id: `${nodeId}->${artNodeId}`,
+            source: nodeId,
+            target: artNodeId,
+            label: '',
+            sourceOutput: inp.name,
+            sourceLaw: law.id,
+            targetLaw: law.id,
+            isUserInput: true,
+          },
+        });
+      }
+    }
+  }
+
+  if (cy) cy.destroy();
+
+  cy = cytoscape({
+    container: document.getElementById('graph-canvas'),
+    elements,
+    style: [
+      // Law compound parent
+      {
+        selector: 'node[nodeType="law"]',
+        style: {
+          label: 'data(label)',
+          'text-wrap': 'wrap',
+          'text-max-width': '200px',
+          'text-valign': 'top',
+          'text-halign': 'center',
+          'text-margin-y': '8px',
+          'font-size': '13px',
+          'font-weight': 'bold',
+          'font-family': 'RijksoverheidSans, system-ui, sans-serif',
+          'background-color': 'data(bgColor)',
+          'background-opacity': 0.4,
+          'border-width': 2,
+          'border-color': 'data(borderColor)',
+          color: 'data(textColor)',
+          shape: 'round-rectangle',
+          'padding': '40px 12px 12px 12px',
+          'compound-sizing-wrt-labels': 'include',
+        },
+      },
+      // Article child node
+      {
+        selector: 'node[nodeType="article"]',
+        style: {
+          label: 'data(label)',
+          'text-wrap': 'wrap',
+          'text-max-width': '300px',
+          'text-valign': 'center',
+          'text-halign': 'center',
+          'font-size': '10px',
+          'font-family': '"SF Mono", "Fira Code", "Consolas", monospace',
+          'background-color': '#ffffff',
+          'background-opacity': 0.95,
+          'border-width': 1.5,
+          'border-color': 'data(borderColor)',
+          color: '#1e293b',
+          shape: 'round-rectangle',
+          width: 'data(nodeWidth)',
+          height: 'data(nodeHeight)',
+        },
+      },
+      // Edges
+      {
+        selector: 'edge',
+        style: {
+          width: 1.5,
+          'line-color': '#94a3b8',
+          'target-arrow-color': '#94a3b8',
+          'target-arrow-shape': 'triangle',
+          'curve-style': 'taxi',
+          'taxi-direction': 'rightward',
+          'taxi-turn': '60px',
+          'arrow-scale': 1,
+          'font-size': '9px',
+          'text-opacity': 0,
+          color: '#64748b',
+          'source-endpoint': 'outside-to-node',
+          'target-endpoint': 'outside-to-node',
+        },
+      },
+      // Intra-law edges
+      {
+        selector: 'edge[?isIntraLaw]',
+        style: {
+          'line-style': 'dashed',
+          'line-dash-pattern': [6, 3],
+        },
+      },
+      // Legal basis edges (hierarchy)
+      {
+        selector: 'edge[?isLegalBasis]',
+        style: {
+          'line-color': '#3b82f6',
+          'target-arrow-color': '#3b82f6',
+          'line-style': 'dashed',
+          'line-dash-pattern': [8, 4],
+          width: 1.5,
+          'target-arrow-shape': 'triangle',
+        },
+      },
+      // Highlighted states
+      {
+        selector: 'node.highlighted',
+        style: {
+          'border-width': 3,
+          'border-color': '#154273',
+          'z-index': 10,
+        },
+      },
+      {
+        selector: 'edge.inbound',
+        style: {
+          'line-color': '#ef4444',
+          'target-arrow-color': '#ef4444',
+          width: 2.5,
+          'z-index': 10,
+          label: 'data(label)',
+          'text-opacity': 1,
+          'text-background-color': '#ffffff',
+          'text-background-opacity': 0.9,
+          'text-background-padding': '2px',
+        },
+      },
+      {
+        selector: 'edge.outbound',
+        style: {
+          'line-color': '#22c55e',
+          'target-arrow-color': '#22c55e',
+          width: 2.5,
+          'z-index': 10,
+          label: 'data(label)',
+          'text-opacity': 1,
+          'text-background-color': '#ffffff',
+          'text-background-opacity': 0.9,
+          'text-background-padding': '2px',
+        },
+      },
+      {
+        selector: 'node.dimmed',
+        style: { opacity: 0.2 },
+      },
+      {
+        selector: 'edge.dimmed',
+        style: { opacity: 0.08 },
+      },
+      // Scenario overlay styles
+      {
+        selector: 'edge.scenario-true',
+        style: {
+          'line-color': '#22c55e',
+          'target-arrow-color': '#22c55e',
+          width: 2.5,
+          'z-index': 10,
+          label: 'data(label)',
+          'text-opacity': 1,
+          'text-background-color': '#f0fdf4',
+          'text-background-opacity': 0.95,
+          'text-background-padding': '3px',
+          color: '#166534',
+          'font-size': '9px',
+        },
+      },
+      {
+        selector: 'edge.scenario-false',
+        style: {
+          'line-color': '#f87171',
+          'target-arrow-color': '#f87171',
+          width: 1.5,
+          'z-index': 5,
+          label: 'data(label)',
+          'text-opacity': 1,
+          'text-background-color': '#fef2f2',
+          'text-background-opacity': 0.95,
+          'text-background-padding': '3px',
+          color: '#991b1b',
+          'font-size': '9px',
+        },
+      },
+      {
+        selector: 'edge.scenario-value',
+        style: {
+          'line-color': '#3b82f6',
+          'target-arrow-color': '#3b82f6',
+          width: 2,
+          'z-index': 10,
+          label: 'data(label)',
+          'text-opacity': 1,
+          'text-background-color': '#eff6ff',
+          'text-background-opacity': 0.95,
+          'text-background-padding': '3px',
+          color: '#1e40af',
+          'font-size': '9px',
+        },
+      },
+      {
+        selector: 'edge.scenario-dimmed',
+        style: { opacity: 0.1 },
+      },
+      {
+        selector: 'node.scenario-active',
+        style: {
+          'border-width': 2.5,
+          'border-color': '#154273',
+        },
+      },
+      // User input nodes
+      {
+        selector: 'node[nodeType="user_input"]',
+        style: {
+          label: 'data(label)',
+          'text-wrap': 'wrap',
+          'text-valign': 'center',
+          'text-halign': 'center',
+          'font-size': '8px',
+          'font-family': '"SF Mono", "Fira Code", "Consolas", monospace',
+          'background-color': '#f8fafc',
+          'background-opacity': 0.9,
+          'border-width': 1,
+          'border-color': '#94a3b8',
+          'border-style': 'dashed',
+          shape: 'ellipse',
+          width: 'data(nodeWidth)',
+          height: 'data(nodeHeight)',
+          color: '#475569',
+        },
+      },
+      {
+        selector: 'edge[?isUserInput]',
+        style: {
+          'line-style': 'dotted',
+          'line-dash-pattern': [3, 3],
+          'line-color': '#cbd5e1',
+          'target-arrow-color': '#cbd5e1',
+          'target-arrow-shape': 'triangle',
+          width: 1,
+          'arrow-scale': 0.7,
+        },
+      },
+      {
+        selector: 'node.hidden',
+        style: { display: 'none' },
+      },
+      {
+        selector: 'edge.hidden-edge',
+        style: { display: 'none' },
+      },
+    ],
+    layout: {
+      name: 'elk',
+      elk: {
+        algorithm: 'layered',
+        'elk.direction': 'RIGHT',
+        'elk.hierarchyHandling': 'INCLUDE_CHILDREN',
+        'elk.padding': '[top=40,left=16,bottom=16,right=16]',
+        'elk.spacing.nodeNode': '50',
+        'elk.layered.spacing.nodeNodeBetweenLayers': '140',
+        'elk.layered.spacing.edgeEdgeBetweenLayers': '20',
+        'elk.layered.spacing.edgeNodeBetweenLayers': '30',
+        'elk.layered.considerModelOrder.strategy': 'NODES_AND_EDGES',
+        'elk.layered.crossingMinimization.strategy': 'LAYER_SWEEP',
+        'elk.layered.nodePlacement.strategy': 'NETWORK_SIMPLEX',
+        'elk.layered.nodePlacement.favorStraightEdges': 'true',
+        'elk.partitioning.activate': 'true',
+      },
+      elkLayoutOptions: (node) => {
+        const partition = node.data('elkPartition');
+        if (partition !== undefined) {
+          return { 'elk.partitioning.partition': String(partition) };
+        }
+        return {};
+      },
+      ready: () => {
+        cy.fit(undefined, 40);
+        restoreAllValidationStatus();
+      },
+    },
+    minZoom: 0.05,
+    maxZoom: 4,
+    wheelSensitivity: 0.3,
+  });
+
+  // Click: highlight article and its connections
+  cy.on('tap', 'node[nodeType="article"]', (evt) => {
+    const node = evt.target;
+    if (selectedNode === node.id()) {
+      clearHighlight();
+      selectedNode = null;
+      hideTooltip();
+    } else {
+      highlightNode(node.id());
+      selectedNode = node.id();
+      showTooltip(node, evt.originalEvent);
+    }
+  });
+
+  // Click law parent: expand/collapse info
+  cy.on('tap', 'node[nodeType="law"]', (evt) => {
+    if (evt.target.isParent()) {
+      const lawId = evt.target.id();
+      // Highlight all articles + connections of this law
+      if (selectedNode === lawId) {
+        clearHighlight();
+        selectedNode = null;
+        hideTooltip();
+      } else {
+        highlightLaw(lawId);
+        selectedNode = lawId;
+      }
+    }
+  });
+
+  // Double-click article: open in editor
+  cy.on('dbltap', 'node[nodeType="article"]', (evt) => {
+    const node = evt.target;
+    const lawId = node.data('lawId');
+    const artNum = node.data('articleNumber');
+    window.open(`editor.html?law=${encodeURIComponent(lawId)}&article=${artNum}`, '_blank');
+  });
+
+  // Right-click: cycle validation status on law, article, or user_input nodes
+  cy.on('cxttap', 'node', (evt) => {
+    const node = evt.target;
+    const nodeType = node.data('nodeType');
+    if (nodeType !== 'law' && nodeType !== 'article' && nodeType !== 'user_input') return;
+
+    const id = node.id();
+    const current = nodeStatusMap.get(id) || 'none';
+    const nextIdx = (STATUS_CYCLE.indexOf(current) + 1) % STATUS_CYCLE.length;
+    const next = STATUS_CYCLE[nextIdx];
+
+    if (next === 'none') {
+      nodeStatusMap.delete(id);
+    } else {
+      nodeStatusMap.set(id, next);
+    }
+    applyValidationStatus(node, next);
+  });
+
+  cy.on('tap', (evt) => {
+    if (evt.target === cy) {
+      clearHighlight();
+      selectedNode = null;
+      hideTooltip();
+    }
+  });
+
+  // Hover tooltip for edges
+  cy.on('mouseover', 'edge', (evt) => {
+    const edge = evt.target;
+    edge.style('text-opacity', 1);
+    edge.style('label', edge.data('label'));
+  });
+  cy.on('mouseout', 'edge', (evt) => {
+    const edge = evt.target;
+    if (!edge.hasClass('inbound') && !edge.hasClass('outbound') &&
+        !edge.hasClass('scenario-true') && !edge.hasClass('scenario-false') &&
+        !edge.hasClass('scenario-value')) {
+      edge.style('text-opacity', 0);
+    }
+  });
+}
+
+function applyValidationStatus(node, status) {
+  const s = VALIDATION_STATUS[status];
+  if (status === 'none') {
+    // Restore original colors
+    const origBg = node.data('bgColor');
+    const origBorder = node.data('borderColor');
+    if (origBg) node.style('background-color', origBg);
+    if (origBorder) node.style('border-color', origBorder);
+    if (node.data('nodeType') === 'article') {
+      node.style('background-color', '#ffffff');
+      node.style('border-color', origBorder);
+    }
+    if (node.data('nodeType') === 'user_input') {
+      node.style('background-color', '#f8fafc');
+      node.style('border-color', '#94a3b8');
+    }
+    node.style('border-width', node.data('nodeType') === 'law' ? 2 : 1.5);
+  } else {
+    node.style('border-color', s.border);
+    node.style('border-width', 3);
+    if (node.data('nodeType') === 'law') {
+      node.style('background-color', s.bg);
+    } else {
+      node.style('background-color', s.bg);
+    }
+  }
+}
+
+function restoreAllValidationStatus() {
+  if (!cy) return;
+  for (const [id, status] of nodeStatusMap) {
+    const node = cy.getElementById(id);
+    if (node.length) applyValidationStatus(node, status);
+  }
+}
+
+function highlightNode(nodeId) {
+  clearHighlight();
+  hideTooltip();
+
+  const node = cy.getElementById(nodeId);
+  node.addClass('highlighted');
+
+  const connectedNodeIds = new Set([nodeId]);
+  // Also keep parent law visible
+  const parentId = node.data('parent');
+  if (parentId) connectedNodeIds.add(parentId);
+
+  // Inbound edges
+  const inboundEdges = cy.edges(`[target = "${nodeId}"]`);
+  inboundEdges.addClass('inbound');
+  inboundEdges.forEach(e => {
+    connectedNodeIds.add(e.data('source'));
+    const srcNode = cy.getElementById(e.data('source'));
+    if (srcNode.data('parent')) connectedNodeIds.add(srcNode.data('parent'));
+  });
+
+  // Outbound edges
+  const outboundEdges = cy.edges(`[source = "${nodeId}"]`);
+  outboundEdges.addClass('outbound');
+  outboundEdges.forEach(e => {
+    connectedNodeIds.add(e.data('target'));
+    const tgtNode = cy.getElementById(e.data('target'));
+    if (tgtNode.data('parent')) connectedNodeIds.add(tgtNode.data('parent'));
+  });
+
+  // Dim unconnected
+  cy.nodes().forEach(n => {
+    if (!connectedNodeIds.has(n.id())) n.addClass('dimmed');
+  });
+  cy.edges().forEach(e => {
+    if (!e.hasClass('inbound') && !e.hasClass('outbound')) e.addClass('dimmed');
+  });
+}
+
+function highlightLaw(lawId) {
+  clearHighlight();
+  hideTooltip();
+
+  const lawNode = cy.getElementById(lawId);
+  lawNode.addClass('highlighted');
+
+  const children = lawNode.children();
+  const connectedNodeIds = new Set([lawId]);
+  children.forEach(c => connectedNodeIds.add(c.id()));
+
+  children.forEach(child => {
+    const childId = child.id();
+    const inbound = cy.edges(`[target = "${childId}"]`);
+    inbound.addClass('inbound');
+    inbound.forEach(e => {
+      connectedNodeIds.add(e.data('source'));
+      const srcNode = cy.getElementById(e.data('source'));
+      if (srcNode.data('parent')) connectedNodeIds.add(srcNode.data('parent'));
+    });
+
+    const outbound = cy.edges(`[source = "${childId}"]`);
+    outbound.addClass('outbound');
+    outbound.forEach(e => {
+      connectedNodeIds.add(e.data('target'));
+      const tgtNode = cy.getElementById(e.data('target'));
+      if (tgtNode.data('parent')) connectedNodeIds.add(tgtNode.data('parent'));
+    });
+  });
+
+  cy.nodes().forEach(n => {
+    if (!connectedNodeIds.has(n.id())) n.addClass('dimmed');
+  });
+  cy.edges().forEach(e => {
+    if (!e.hasClass('inbound') && !e.hasClass('outbound')) e.addClass('dimmed');
+  });
+}
+
+function clearHighlight() {
+  if (!cy) return;
+  cy.elements().removeClass('highlighted inbound outbound dimmed');
+  // Reset edge labels (preserve scenario overlay labels)
+  cy.edges().forEach(e => {
+    if (!e.hasClass('inbound') && !e.hasClass('outbound') &&
+        !e.hasClass('scenario-true') && !e.hasClass('scenario-false') &&
+        !e.hasClass('scenario-value')) {
+      e.style('text-opacity', 0);
+    }
+  });
+}
+
+function showTooltip(node, mouseEvent) {
+  hideTooltip();
+  const inputs = node.data('inputs') || [];
+  const outputs = node.data('outputs') || [];
+  const artNum = node.data('articleNumber');
+  const lawId = node.data('lawId');
+
+  let html = `<div class="graph-tooltip">`;
+  html += `<div class="graph-tooltip__header">${formatLawName(lawId)}</div>`;
+  html += `<div class="graph-tooltip__article">Artikel ${artNum}</div>`;
+
+  if (inputs.length > 0) {
+    html += `<div class="graph-tooltip__section">`;
+    html += `<div class="graph-tooltip__section-title">Inputs</div>`;
+    for (const inp of inputs) {
+      const src = inp.source_regulation
+        ? `\u2190 ${formatLawName(inp.source_regulation)}`
+        : '(parameter)';
+      html += `<div class="graph-tooltip__field">`;
+      html += `<span class="graph-tooltip__field-name">${inp.name}</span>`;
+      html += `<span class="graph-tooltip__field-type">${inp.type}</span>`;
+      html += `<span class="graph-tooltip__field-source">${src}</span>`;
+      html += `</div>`;
+    }
+    html += `</div>`;
+  }
+
+  if (outputs.length > 0) {
+    html += `<div class="graph-tooltip__section">`;
+    html += `<div class="graph-tooltip__section-title">Outputs</div>`;
+    for (const out of outputs) {
+      html += `<div class="graph-tooltip__field">`;
+      html += `<span class="graph-tooltip__field-name">${out.name}</span>`;
+      html += `<span class="graph-tooltip__field-type">${out.type}</span>`;
+      html += `</div>`;
+    }
+    html += `</div>`;
+  }
+
+  html += `<div style="margin-top:8px;font-size:10px;color:#94a3b8;border-top:1px solid #e2e8f0;padding-top:6px;">Dubbelklik \u2192 editor</div>`;
+  html += `</div>`;
+
+  const container = document.getElementById('graph-canvas');
+  const tooltipEl = document.createElement('div');
+  tooltipEl.id = 'graph-tooltip-overlay';
+  tooltipEl.innerHTML = html;
+
+  // Position near the mouse click
+  const containerRect = container.getBoundingClientRect();
+  const x = mouseEvent ? mouseEvent.clientX - containerRect.left + 15 : 20;
+  const y = mouseEvent ? mouseEvent.clientY - containerRect.top - 10 : 20;
+  tooltipEl.style.position = 'absolute';
+  tooltipEl.style.left = `${x}px`;
+  tooltipEl.style.top = `${y}px`;
+  tooltipEl.style.zIndex = '1000';
+
+  container.appendChild(tooltipEl);
+}
+
+function hideTooltip() {
+  const existing = document.getElementById('graph-tooltip-overlay');
+  if (existing) existing.remove();
+}
+
+// ─── Scenario Overlay ───
+
+function parseAllScenarios(features) {
+  const scenarios = [];
+  for (const feature of features) {
+    if (!feature.scenarios) continue;
+    for (const s of feature.scenarios) {
+      if (s.type !== 'scenario') continue;
+      const whenStep = s.steps.find(step => step.keyword === 'When');
+      if (!whenStep) continue;
+
+      let match = whenStep.text.match(/the (\S+) is executed for article (.+)/);
+      if (!match) {
+        match = whenStep.text.match(/the \S+ is executed for (\S+) article (.+)/);
+      }
+      if (!match) continue;
+
+      const lawId = match[1];
+      const article = match[2].trim();
+
+      const inputs = {};
+      for (const step of s.steps) {
+        if (step.keyword === 'Given' && step.table) {
+          for (const [key, value] of step.table) {
+            inputs[key] = value;
+          }
+        }
+      }
+
+      const outputs = {};
+      for (const step of s.steps) {
+        if (step.keyword === 'Then' || step.keyword === 'And') {
+          const outMatch = step.text.match(/the output (\S+) is "([^"]+)"/);
+          if (outMatch) {
+            outputs[outMatch[1]] = outMatch[2];
+          }
+        }
+      }
+
+      scenarios.push({
+        name: s.name,
+        featureName: feature.name,
+        featureFilename: feature.filename,
+        lawId,
+        article,
+        inputs,
+        outputs,
+        _idx: scenarios.length,
+      });
+    }
+  }
+  return scenarios;
+}
+
+function buildScenarioFilters() {
+  const container = document.getElementById('scenario-filters');
+  if (!container || parsedScenarios.length === 0) return;
+
+  container.innerHTML = '';
+
+  const title = document.createElement('div');
+  title.className = 'graph-sidebar__section-title';
+  title.textContent = "Scenario's";
+  container.appendChild(title);
+
+  // Group by feature, then by lawId:article
+  const byFeature = {};
+  for (const s of parsedScenarios) {
+    if (!byFeature[s.featureName]) byFeature[s.featureName] = {};
+    const artKey = `${s.lawId}:${s.article}`;
+    if (!byFeature[s.featureName][artKey]) byFeature[s.featureName][artKey] = [];
+    byFeature[s.featureName][artKey].push(s);
+  }
+
+  for (const [featureName, articles] of Object.entries(byFeature)) {
+    const featureGroup = document.createElement('div');
+    featureGroup.className = 'graph-scenario__feature';
+
+    const featureHeader = document.createElement('button');
+    featureHeader.className = 'graph-scenario__feature-header';
+    featureHeader.textContent = featureName;
+    featureHeader.addEventListener('click', () => {
+      featureGroup.classList.toggle('graph-scenario__feature--expanded');
+    });
+    featureGroup.appendChild(featureHeader);
+
+    const featureBody = document.createElement('div');
+    featureBody.className = 'graph-scenario__feature-body';
+
+    for (const [artKey, scenarios] of Object.entries(articles)) {
+      const parts = artKey.split(':');
+      const lawId = parts[0];
+      const artNum = parts.slice(1).join(':');
+
+      const artGroup = document.createElement('div');
+      artGroup.className = 'graph-scenario__article-group';
+
+      const artHeader = document.createElement('button');
+      artHeader.className = 'graph-scenario__article-header';
+      const lawName = formatLawName(lawId);
+      const shortName = lawName.length > 25 ? lawName.substring(0, 22) + '...' : lawName;
+      artHeader.textContent = `${shortName} art. ${artNum}`;
+      artHeader.addEventListener('click', (e) => {
+        e.stopPropagation();
+        artGroup.classList.toggle('graph-scenario__article-group--expanded');
+      });
+      artGroup.appendChild(artHeader);
+
+      const artBody = document.createElement('div');
+      artBody.className = 'graph-scenario__article-body';
+
+      for (const scenario of scenarios) {
+        const btn = document.createElement('button');
+        btn.className = 'graph-scenario__item';
+        btn.textContent = scenario.name;
+        btn.title = scenario.name;
+        btn.dataset.scenarioIdx = scenario._idx;
+        btn.addEventListener('click', (e) => {
+          e.stopPropagation();
+          if (activeScenarioIdx === scenario._idx) {
+            clearScenarioOverlay();
+          } else {
+            activateScenarioOverlay(scenario._idx);
+          }
+        });
+        artBody.appendChild(btn);
+      }
+
+      artGroup.appendChild(artBody);
+      featureBody.appendChild(artGroup);
+    }
+
+    featureGroup.appendChild(featureBody);
+    container.appendChild(featureGroup);
+  }
+}
+
+function buildArticleLabelOverlay(art, valueMap) {
+  const inputLines = [];
+  const outputLines = [];
+
+  for (const inp of art.inputs) {
+    const val = valueMap[inp.name];
+    inputLines.push(val !== undefined ? `\u2192 ${inp.name} = ${val}` : `\u2192 ${inp.name}`);
+  }
+  for (const out of art.outputs) {
+    const val = valueMap[out.name];
+    outputLines.push(val !== undefined ? `\u2190 ${out.name} = ${val}` : `\u2190 ${out.name}`);
+  }
+
+  const allLines = [...inputLines, ...outputLines, `Art. ${art.number}`];
+  const maxLen = Math.max(...allLines.map(l => l.length));
+  const sep = '\u2500'.repeat(Math.max(16, maxLen));
+
+  const lines = [`Art. ${art.number}`];
+  if (inputLines.length > 0 || outputLines.length > 0) {
+    lines.push(sep);
+  }
+  lines.push(...inputLines);
+  if (inputLines.length > 0 && outputLines.length > 0) {
+    lines.push(sep);
+  }
+  lines.push(...outputLines);
+  return lines.join('\n');
+}
+
+function calcLabelSize(label) {
+  const lines = label.split('\n');
+  const height = Math.max(40, lines.length * 16 + 16);
+  const maxLen = Math.max(...lines.map(l => l.length));
+  const width = Math.max(120, maxLen * 7.5 + 24);
+  return { width, height };
+}
+
+function activateScenarioOverlay(idx) {
+  clearScenarioOverlay();
+  if (!cy || idx == null) return;
+
+  activeScenarioIdx = idx;
+  const scenario = parsedScenarios[idx];
+  if (!scenario) return;
+
+  // Update active button styling
+  document.querySelectorAll('.graph-scenario__item').forEach(btn => {
+    btn.classList.toggle(
+      'graph-scenario__item--active',
+      parseInt(btn.dataset.scenarioIdx) === idx
+    );
+  });
+
+  // Build per-article value maps from feature scenarios
+  const featureScenarios = parsedScenarios.filter(
+    s => s.featureFilename === scenario.featureFilename
+  );
+
+  const articleValueMaps = {};
+  for (const s of featureScenarios) {
+    const key = `${s.lawId}:${s.article}`;
+    if (s._idx === idx) {
+      // Selected scenario takes priority for its article
+      articleValueMaps[key] = { ...s.inputs, ...s.outputs };
+    } else if (!articleValueMaps[key]) {
+      articleValueMaps[key] = { ...s.inputs, ...s.outputs };
+    }
+  }
+
+  // Global value map for edge lookups
+  const globalValueMap = {};
+  for (const s of featureScenarios) {
+    Object.assign(globalValueMap, s.inputs);
+    Object.assign(globalValueMap, s.outputs);
+  }
+  Object.assign(globalValueMap, scenario.inputs);
+  Object.assign(globalValueMap, scenario.outputs);
+
+  // Propagate values between input names and their source_output names,
+  // so a value set under one name also applies to the other.
+  cy.nodes('[nodeType="article"]').forEach(node => {
+    const inputs = node.data('inputs') || [];
+    for (const inp of inputs) {
+      if (inp.source_output) {
+        if (globalValueMap[inp.name] !== undefined && globalValueMap[inp.source_output] === undefined) {
+          globalValueMap[inp.source_output] = globalValueMap[inp.name];
+        }
+        if (globalValueMap[inp.source_output] !== undefined && globalValueMap[inp.name] === undefined) {
+          globalValueMap[inp.name] = globalValueMap[inp.source_output];
+        }
+      }
+    }
+  });
+
+  // Update article node labels
+  cy.nodes('[nodeType="article"]').forEach(node => {
+    const lawId = node.data('lawId');
+    const artNum = node.data('articleNumber');
+    const key = `${lawId}:${artNum}`;
+    const valueMap = articleValueMaps[key] || globalValueMap;
+
+    const inputs = node.data('inputs') || [];
+    const outputs = node.data('outputs') || [];
+
+    const hasValues = inputs.some(i => valueMap[i.name] !== undefined) ||
+                      outputs.some(o => valueMap[o.name] !== undefined);
+
+    if (hasValues) {
+      node.data('_origLabel', node.data('label'));
+      node.data('_origWidth', node.data('nodeWidth'));
+      node.data('_origHeight', node.data('nodeHeight'));
+
+      const newLabel = buildArticleLabelOverlay(
+        { number: artNum, inputs, outputs }, valueMap
+      );
+      const newSize = calcLabelSize(newLabel);
+
+      node.data('label', newLabel);
+      node.data('nodeWidth', newSize.width);
+      node.data('nodeHeight', newSize.height);
+      node.addClass('scenario-active');
+    }
+  });
+
+  // Update user input node labels
+  cy.nodes('[nodeType="user_input"]').forEach(node => {
+    const fieldName = node.data('fieldName');
+    const value = globalValueMap[fieldName];
+    if (value !== undefined) {
+      node.data('_origLabel', node.data('label'));
+      node.data('_origWidth', node.data('nodeWidth'));
+      const valLabel = `${node.data('label')}\n= ${value}`;
+      const valWidth = Math.max(node.data('nodeWidth'), valLabel.length * 4 + 20);
+      node.data('label', valLabel);
+      node.data('nodeWidth', valWidth);
+      node.data('nodeHeight', 38);
+      node.addClass('scenario-active');
+    }
+  });
+
+  // Update edge labels and colors
+  cy.edges().forEach(edge => {
+    if (edge.data('isLegalBasis')) {
+      edge.addClass('scenario-dimmed');
+      return;
+    }
+
+    const fieldName = edge.data('sourceOutput');
+    if (!fieldName) {
+      edge.addClass('scenario-dimmed');
+      return;
+    }
+
+    const value = globalValueMap[fieldName];
+
+    if (value !== undefined) {
+      edge.data('_origLabel', edge.data('label'));
+      edge.data('label', `${fieldName} = ${value}`);
+
+      if (value === 'true') {
+        edge.addClass('scenario-true');
+      } else if (value === 'false') {
+        edge.addClass('scenario-false');
+      } else {
+        edge.addClass('scenario-value');
+      }
+    } else {
+      edge.addClass('scenario-dimmed');
+    }
+  });
+}
+
+function clearScenarioOverlay() {
+  activeScenarioIdx = null;
+
+  document.querySelectorAll('.graph-scenario__item--active').forEach(btn => {
+    btn.classList.remove('graph-scenario__item--active');
+  });
+
+  if (!cy) return;
+
+  cy.nodes('[nodeType="article"], [nodeType="user_input"]').forEach(node => {
+    if (node.data('_origLabel') !== undefined) {
+      node.data('label', node.data('_origLabel'));
+      node.data('nodeWidth', node.data('_origWidth'));
+      node.removeData('_origLabel');
+      node.removeData('_origWidth');
+      if (node.data('_origHeight') !== undefined) {
+        node.data('nodeHeight', node.data('_origHeight'));
+        node.removeData('_origHeight');
+      }
+    }
+    node.removeClass('scenario-active');
+  });
+
+  cy.edges().forEach(edge => {
+    if (edge.data('_origLabel') !== undefined) {
+      edge.data('label', edge.data('_origLabel'));
+      edge.removeData('_origLabel');
+    }
+    edge.removeClass('scenario-true scenario-false scenario-value scenario-dimmed');
+  });
+}
+
+function updateVisibility() {
+  const checkboxes = document.querySelectorAll('#law-filters input[type="checkbox"]');
+  const visibleLawIds = new Set();
+  checkboxes.forEach(cb => {
+    if (cb.checked) visibleLawIds.add(cb.value);
+  });
+
+  cy.nodes().forEach(n => {
+    const lawId = n.data('nodeType') === 'law' ? n.id() : n.data('lawId');
+    if (visibleLawIds.has(lawId)) {
+      n.removeClass('hidden');
+    } else {
+      n.addClass('hidden');
+    }
+  });
+
+  cy.edges().forEach(e => {
+    const sourceLaw = e.data('sourceLaw') || e.data('source');
+    const targetLaw = e.data('targetLaw') || e.data('target');
+    if (visibleLawIds.has(sourceLaw) && visibleLawIds.has(targetLaw)) {
+      e.removeClass('hidden-edge');
+    } else {
+      e.addClass('hidden-edge');
+    }
+  });
+}
+
+// ─── YAML Upload ───
+
+function parseYamlToGraphData(docs) {
+  const laws = [];
+  const edges = [];
+
+  for (const doc of docs) {
+    if (!doc || !doc.$id) continue;
+
+    const rawName = doc.name && !doc.name.startsWith('#') ? doc.name : doc.$id;
+    const law = {
+      id: doc.$id,
+      name: rawName,
+      regulatory_layer: doc.regulatory_layer || 'ONBEKEND',
+      legal_basis: doc.legal_basis || null,
+      bwb_id: doc.bwb_id || null,
+      url: doc.url || null,
+      valid_from: doc.valid_from || null,
+      articles: [],
+    };
+
+    if (doc.articles) {
+      for (const article of doc.articles) {
+        const artInfo = { number: article.number, outputs: [], inputs: [] };
+        const mr = article.machine_readable;
+        if (mr && mr.execution) {
+          if (mr.execution.output) {
+            for (const out of mr.execution.output) {
+              artInfo.outputs.push({ name: out.name, type: out.type });
+            }
+          }
+          if (mr.execution.input) {
+            for (const inp of mr.execution.input) {
+              artInfo.inputs.push({
+                name: inp.name,
+                type: inp.type,
+                source_regulation: inp.source?.regulation || null,
+                source_output: inp.source?.output || null,
+              });
+
+              if (inp.source?.regulation && inp.source.regulation !== doc.$id) {
+                edges.push({
+                  source: inp.source.regulation,
+                  target: doc.$id,
+                  source_output: inp.source.output || inp.name,
+                  target_input: inp.name,
+                  target_article: article.number,
+                  source_article: null,
+                });
+              }
+            }
+          }
+        }
+        if (artInfo.outputs.length > 0 || artInfo.inputs.length > 0) {
+          law.articles.push(artInfo);
+        }
+      }
+    }
+
+    laws.push(law);
+  }
+
+  // Build output lookup
+  const outputLookup = {};
+  for (const law of laws) {
+    outputLookup[law.id] = {};
+    for (const art of law.articles) {
+      for (const out of art.outputs) {
+        outputLookup[law.id][out.name] = art.number;
+      }
+    }
+  }
+
+  // Resolve source_article
+  for (const edge of edges) {
+    if (edge.source_article === null && outputLookup[edge.source]) {
+      edge.source_article = outputLookup[edge.source][edge.source_output] || null;
+    }
+  }
+
+  // Add intra-law edges
+  for (const law of laws) {
+    for (const art of law.articles) {
+      for (const inp of art.inputs) {
+        if (inp.source_output && !inp.source_regulation) {
+          const sourceArt = outputLookup[law.id]?.[inp.source_output];
+          if (sourceArt && sourceArt !== art.number) {
+            edges.push({
+              source: law.id,
+              target: law.id,
+              source_article: sourceArt,
+              target_article: art.number,
+              source_output: inp.source_output,
+              target_input: inp.name,
+            });
+          }
+        }
+      }
+    }
+  }
+
+  // Add legal_basis edges
+  for (const law of laws) {
+    if (law.legal_basis) {
+      const seen = new Set();
+      for (const lb of law.legal_basis) {
+        if (!lb.law_id || seen.has(lb.law_id)) continue;
+        seen.add(lb.law_id);
+        edges.push({
+          source: lb.law_id,
+          target: law.id,
+          source_article: lb.article || null,
+          target_article: null,
+          source_output: 'legal_basis',
+          target_input: 'legal_basis',
+          edge_type: 'legal_basis',
+        });
+      }
+    }
+  }
+
+  // Deduplicate
+  const edgeSet = new Set();
+  const uniqueEdges = edges.filter(e => {
+    const key = `${e.source}:${e.source_article}->${e.target}:${e.target_article}:${e.source_output}`;
+    if (edgeSet.has(key)) return false;
+    edgeSet.add(key);
+    return true;
+  });
+
+  return { laws, edges: uniqueEdges };
+}
+
+function mergeAndRender(uploadedData, fileCount) {
+  if (graphData) {
+    const existingIds = new Set(graphData.laws.map(l => l.id));
+    for (const law of uploadedData.laws) {
+      if (existingIds.has(law.id)) {
+        const idx = graphData.laws.findIndex(l => l.id === law.id);
+        graphData.laws[idx] = law;
+      } else {
+        graphData.laws.push(law);
+      }
+    }
+    graphData.edges = graphData.edges.concat(uploadedData.edges);
+    const edgeSet = new Set();
+    graphData.edges = graphData.edges.filter(e => {
+      const key = `${e.source}:${e.source_article}->${e.target}:${e.target_article}:${e.source_output}`;
+      if (edgeSet.has(key)) return false;
+      edgeSet.add(key);
+      return true;
+    });
+  } else {
+    graphData = uploadedData;
+  }
+
+  buildScenarioFilters();
+  buildFilters();
+  renderGraph(graphData);
+
+  const status = document.getElementById('upload-status');
+  if (status) {
+    status.textContent = `${fileCount} bestand${fileCount !== 1 ? 'en' : ''} geladen`;
+    setTimeout(() => { status.textContent = ''; }, 3000);
+  }
+}
+
+async function loadYamlFiles(files) {
+  const docs = [];
+  for (const file of files) {
+    if (!file.name.endsWith('.yaml') && !file.name.endsWith('.yml')) continue;
+    try {
+      const text = await file.text();
+      const doc = jsyaml.load(text);
+      if (doc) docs.push(doc);
+    } catch (e) {
+      console.warn(`Could not parse ${file.name}: ${e.message}`);
+    }
+  }
+  if (docs.length === 0) return;
+  mergeAndRender(parseYamlToGraphData(docs), docs.length);
+}
+
+function setupYamlUpload() {
+  const input = document.getElementById('yaml-upload');
+  if (input) {
+    input.addEventListener('change', (evt) => loadYamlFiles(evt.target.files));
+  }
+
+  const folderInput = document.getElementById('yaml-folder-upload');
+  if (folderInput) {
+    folderInput.addEventListener('change', (evt) => loadYamlFiles(evt.target.files));
+  }
+
+  // Drag & drop on the canvas
+  const canvas = document.getElementById('graph-canvas');
+  if (canvas) {
+    canvas.addEventListener('dragover', (e) => {
+      e.preventDefault();
+      canvas.classList.add('graph-canvas--dragover');
+    });
+    canvas.addEventListener('dragleave', () => {
+      canvas.classList.remove('graph-canvas--dragover');
+    });
+    canvas.addEventListener('drop', (e) => {
+      e.preventDefault();
+      canvas.classList.remove('graph-canvas--dragover');
+      const files = e.dataTransfer.files;
+      if (files.length > 0) loadYamlFiles(files);
+    });
+  }
+}
+
+// Disable browser context menu on graph canvas so right-click cycles status
+document.getElementById('graph-canvas')?.addEventListener('contextmenu', (e) => e.preventDefault());
+
+// Init
+init();
+setupYamlUpload();

--- a/frontend/js/graph.js
+++ b/frontend/js/graph.js
@@ -1,3 +1,31 @@
+// ─── WASM Engine ───
+import initWasm, { WasmEngine } from '../wasm/regelrecht_engine.js';
+
+let wasmEngine = null;
+
+async function initEngine() {
+  try {
+    await initWasm();
+    wasmEngine = new WasmEngine();
+    console.log('WASM engine initialized');
+  } catch (e) {
+    console.warn('Could not initialize WASM engine:', e.message);
+  }
+}
+
+function loadLawIntoEngine(yamlText) {
+  if (!wasmEngine) return;
+  try {
+    const doc = jsyaml.load(yamlText);
+    if (doc?.$id && wasmEngine.hasLaw(doc.$id)) {
+      wasmEngine.unloadLaw(doc.$id);
+    }
+    wasmEngine.loadLaw(yamlText);
+  } catch (e) {
+    // Silently skip laws that can't be loaded (e.g. missing machine_readable)
+  }
+}
+
 const LAYER_COLORS = {
   WET: { bg: '#dbeafe', border: '#3b82f6', text: '#1e40af' },
   AMVB: { bg: '#dcfce7', border: '#22c55e', text: '#166534' },
@@ -39,6 +67,8 @@ let graphData = null;
 let selectedNode = null;
 let parsedScenarios = [];
 let activeScenarioIdx = null;
+// Map law $id → raw YAML text, for passing to the editor via localStorage
+const rawYamlByLawId = new Map();
 
 async function init() {
   try {
@@ -47,7 +77,41 @@ async function init() {
       graphData = await resp.json();
     }
   } catch (e) {
-    // No pre-generated data — that's fine, user can upload YAML
+    // No pre-generated data — try index.json fallback
+  }
+
+  // Fallback: load all laws from index.json (static YAML files from predev script)
+  if (!graphData) {
+    try {
+      const indexResp = await fetch('/data/index.json');
+      if (indexResp.ok) {
+        const index = await indexResp.json();
+        const docs = [];
+        for (const entry of index) {
+          try {
+            const yamlResp = await fetch(entry.path);
+            if (yamlResp.ok) {
+              const text = await yamlResp.text();
+              const doc = jsyaml.load(text);
+              if (doc) {
+                docs.push(doc);
+                if (doc.$id) {
+                  rawYamlByLawId.set(doc.$id, text);
+                  loadLawIntoEngine(text);
+                }
+              }
+            }
+          } catch (e) {
+            console.warn(`Could not load ${entry.path}: ${e.message}`);
+          }
+        }
+        if (docs.length > 0) {
+          graphData = parseYamlToGraphData(docs);
+        }
+      }
+    } catch (e) {
+      console.warn('Could not load index.json:', e.message);
+    }
   }
 
   if (!graphData) {
@@ -64,6 +128,8 @@ async function init() {
   } catch (e) {
     console.warn('Features data not available');
   }
+
+  buildTestList();
 
   if (graphData) {
     buildScenarioFilters();
@@ -653,7 +719,14 @@ function renderGraph(data) {
     const node = evt.target;
     const lawId = node.data('lawId');
     const artNum = node.data('articleNumber');
-    window.open(`editor.html?law=${encodeURIComponent(lawId)}&article=${artNum}`, '_blank');
+    const rawYaml = rawYamlByLawId.get(lawId);
+    if (rawYaml) {
+      localStorage.setItem('regelrecht_yaml', rawYaml);
+      localStorage.setItem('regelrecht_law_id', lawId);
+      window.open(`editor.html?law=local&article=${artNum}`, '_blank');
+    } else {
+      window.open(`editor.html?law=${encodeURIComponent(lawId)}&article=${artNum}`, '_blank');
+    }
   });
 
   // Right-click: cycle validation status on law, article, or user_input nodes
@@ -1431,7 +1504,13 @@ async function loadYamlFiles(files) {
     try {
       const text = await file.text();
       const doc = jsyaml.load(text);
-      if (doc) docs.push(doc);
+      if (doc) {
+        docs.push(doc);
+        if (doc.$id) {
+          rawYamlByLawId.set(doc.$id, text);
+          loadLawIntoEngine(text);
+        }
+      }
     } catch (e) {
       console.warn(`Could not parse ${file.name}: ${e.message}`);
     }
@@ -1473,6 +1552,313 @@ function setupYamlUpload() {
 // Disable browser context menu on graph canvas so right-click cycles status
 document.getElementById('graph-canvas')?.addEventListener('contextmenu', (e) => e.preventDefault());
 
-// Init
-init();
+// ─── Tab switching ───
+
+function setupTabs() {
+  const tabs = document.querySelectorAll('.graph-tabs__tab');
+  tabs.forEach(tab => {
+    tab.addEventListener('click', () => {
+      tabs.forEach(t => t.classList.remove('graph-tabs__tab--active'));
+      tab.classList.add('graph-tabs__tab--active');
+      document.querySelectorAll('.graph-tab-content').forEach(c => c.style.display = 'none');
+      const target = document.getElementById(`tab-${tab.dataset.tab}`);
+      if (target) target.style.display = '';
+    });
+  });
+}
+
+// ─── Test Panel ───
+
+const testResults = new Map(); // scenarioIdx → {status: 'pass'|'fail'|'pending', outputs: {}, error: ''}
+
+function buildTestList() {
+  const container = document.getElementById('test-list');
+  if (!container || parsedScenarios.length === 0) {
+    if (container) container.innerHTML = '<p style="font-size:12px;color:#94a3b8;padding:8px 0;">Geen scenario\'s gevonden. Genereer features-data.json.</p>';
+    return;
+  }
+
+  container.innerHTML = '';
+
+  // Group by feature
+  const byFeature = {};
+  for (const s of parsedScenarios) {
+    const key = s.featureName || s.featureFilename;
+    if (!byFeature[key]) byFeature[key] = [];
+    byFeature[key].push(s);
+  }
+
+  for (const [featureName, scenarios] of Object.entries(byFeature)) {
+    const featureDiv = document.createElement('div');
+    featureDiv.className = 'test-panel__feature';
+
+    const header = document.createElement('div');
+    header.className = 'test-panel__feature-name';
+    header.textContent = featureName;
+    featureDiv.appendChild(header);
+
+    for (const s of scenarios) {
+      const row = document.createElement('div');
+      row.className = 'test-panel__scenario';
+      row.dataset.scenarioIdx = s._idx;
+
+      const result = testResults.get(s._idx);
+      const statusClass = result ? result.status : 'pending';
+      const statusText = statusClass === 'pass' ? '\u2713' : statusClass === 'fail' ? '\u2717' : statusClass === 'running' ? '\u2026' : '\u00b7';
+
+      row.innerHTML = `
+        <span class="test-panel__scenario-status test-panel__scenario-status--${statusClass}">${statusText}</span>
+        <span class="test-panel__scenario-name" title="${s.name}">${s.name}</span>
+        <button class="test-panel__scenario-run" data-idx="${s._idx}">\u25B6</button>
+      `;
+
+      // Click scenario name → show overlay on graph
+      row.querySelector('.test-panel__scenario-name').addEventListener('click', () => {
+        document.querySelectorAll('.test-panel__scenario').forEach(r => r.classList.remove('test-panel__scenario--active'));
+        row.classList.add('test-panel__scenario--active');
+        activateScenarioOverlay(s._idx);
+      });
+
+      // Click run button → execute test
+      row.querySelector('.test-panel__scenario-run').addEventListener('click', (e) => {
+        e.stopPropagation();
+        executeTest(s._idx);
+      });
+
+      featureDiv.appendChild(row);
+    }
+
+    container.appendChild(featureDiv);
+  }
+}
+
+function parseInputValue(val) {
+  if (val === 'true') return true;
+  if (val === 'false') return false;
+  const num = Number(val);
+  if (!isNaN(num) && val.trim() !== '') return num;
+  return val;
+}
+
+async function executeTest(idx) {
+  const scenario = parsedScenarios[idx];
+  if (!scenario) return;
+
+  testResults.set(idx, { status: 'running', outputs: {}, error: null });
+  buildTestList();
+
+  try {
+    if (!wasmEngine) throw new Error('WASM engine niet geladen');
+    if (!wasmEngine.hasLaw(scenario.lawId)) throw new Error(`Wet '${scenario.lawId}' niet geladen in engine`);
+
+    const calcDate = scenario.inputs.calculation_date || '2025-01-01';
+    const params = {};
+    for (const [key, val] of Object.entries(scenario.inputs)) {
+      if (key === 'calculation_date') continue;
+      params[key] = parseInputValue(val);
+    }
+
+    // Execute for each expected output and collect results
+    const allOutputs = {};
+    let pass = true;
+    const mismatches = [];
+
+    for (const [outputName, expected] of Object.entries(scenario.outputs)) {
+      const result = wasmEngine.execute(scenario.lawId, outputName, params, calcDate);
+      Object.assign(allOutputs, result.outputs || {});
+    }
+
+    // Compare
+    for (const [key, expected] of Object.entries(scenario.outputs)) {
+      const actual = String(allOutputs[key] ?? '');
+      if (actual !== expected) {
+        pass = false;
+        mismatches.push(`${key}: verwacht "${expected}", kreeg "${actual}"`);
+      }
+    }
+
+    testResults.set(idx, {
+      status: pass ? 'pass' : 'fail',
+      outputs: allOutputs,
+      error: pass ? null : mismatches.join('; '),
+    });
+  } catch (e) {
+    testResults.set(idx, { status: 'fail', outputs: {}, error: e.message });
+  }
+
+  buildTestList();
+  updateTestSummary();
+  activateScenarioOverlay(idx);
+}
+
+async function executeAllTests() {
+  const btn = document.getElementById('run-all-tests');
+  if (btn) btn.disabled = true;
+
+  for (const s of parsedScenarios) {
+    await executeTest(s._idx);
+  }
+
+  if (btn) btn.disabled = false;
+}
+
+function updateTestSummary() {
+  const el = document.getElementById('test-summary');
+  if (!el) return;
+
+  const total = parsedScenarios.length;
+  let pass = 0, fail = 0;
+  for (const r of testResults.values()) {
+    if (r.status === 'pass') pass++;
+    if (r.status === 'fail') fail++;
+  }
+  const pending = total - pass - fail;
+  el.textContent = `${pass} geslaagd, ${fail} gefaald, ${pending} resterend`;
+}
+
+function setupTestResultsImport() {
+  const input = document.getElementById('test-results-upload');
+  if (!input) return;
+
+  input.addEventListener('change', async (evt) => {
+    const file = evt.target.files[0];
+    if (!file) return;
+
+    try {
+      const text = await file.text();
+      const results = JSON.parse(text);
+      // Expected format: [{scenarioName, lawId, article, status, outputs}]
+      for (const r of results) {
+        const scenario = parsedScenarios.find(s =>
+          s.name === r.scenarioName || (s.lawId === r.lawId && s.article === r.article && s.name === r.scenarioName)
+        );
+        if (scenario) {
+          testResults.set(scenario._idx, {
+            status: r.status || (r.success ? 'pass' : 'fail'),
+            outputs: r.outputs || {},
+            error: r.error || null,
+          });
+        }
+      }
+      buildTestList();
+      updateTestSummary();
+    } catch (e) {
+      console.warn('Could not parse test results:', e.message);
+    }
+  });
+}
+
+// ─── Feature file upload (browser-side Gherkin parser) ───
+
+function parseFeatureText(text, filename) {
+  const lines = text.split('\n');
+  const feature = { name: '', filename, scenarios: [] };
+  let currentScenario = null;
+  let backgroundSteps = [];
+  let inBackground = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (!line || line.startsWith('#')) continue;
+
+    if (line.startsWith('Feature:')) {
+      feature.name = line.slice('Feature:'.length).trim();
+      continue;
+    }
+    if (line.startsWith('Background:')) {
+      inBackground = true;
+      continue;
+    }
+    if (line.startsWith('Scenario:') || line.startsWith('Scenario Outline:')) {
+      inBackground = false;
+      if (currentScenario) feature.scenarios.push(currentScenario);
+      const isOutline = line.startsWith('Scenario Outline:');
+      currentScenario = {
+        type: isOutline ? 'scenario_outline' : 'scenario',
+        name: line.slice(isOutline ? 'Scenario Outline:'.length : 'Scenario:'.length).trim(),
+        steps: [...backgroundSteps],
+      };
+      continue;
+    }
+    const stepMatch = line.match(/^(Given|When|Then|And|But)\s+(.+)/);
+    if (stepMatch) {
+      const step = { keyword: stepMatch[1], text: stepMatch[2] };
+      if (i + 1 < lines.length && lines[i + 1].trim().startsWith('|')) {
+        const rows = [];
+        let j = i + 1;
+        while (j < lines.length && lines[j].trim().startsWith('|')) {
+          rows.push(lines[j].trim().split('|').filter(c => c !== '').map(c => c.trim()));
+          j++;
+        }
+        if (rows.length >= 2) {
+          const headers = rows[0];
+          if (rows.length === 2) {
+            step.table = headers.map((h, idx) => [h, rows[1][idx] || '']);
+          } else {
+            step.table = rows;
+          }
+        } else if (rows.length === 1) {
+          step.table = rows[0].map(c => [c]);
+        }
+        i = j - 1;
+      }
+      if (inBackground) backgroundSteps.push(step);
+      else if (currentScenario) currentScenario.steps.push(step);
+    }
+  }
+  if (currentScenario) feature.scenarios.push(currentScenario);
+  return feature;
+}
+
+async function loadFeatureFiles(files) {
+  const features = [];
+  for (const file of files) {
+    if (!file.name.endsWith('.feature')) continue;
+    try {
+      const text = await file.text();
+      features.push(parseFeatureText(text, file.name));
+    } catch (e) {
+      console.warn(`Could not parse ${file.name}: ${e.message}`);
+    }
+  }
+  if (features.length === 0) return;
+
+  const newScenarios = parseAllScenarios(features);
+  // Re-index and merge
+  const startIdx = parsedScenarios.length;
+  for (const s of newScenarios) {
+    s._idx = parsedScenarios.length;
+    parsedScenarios.push(s);
+  }
+
+  buildScenarioFilters();
+  buildTestList();
+
+  const status = document.getElementById('feature-upload-status');
+  if (status) {
+    const count = newScenarios.length;
+    status.textContent = `${count} scenario${count !== 1 ? "'s" : ''} geladen uit ${features.length} bestand${features.length !== 1 ? 'en' : ''}`;
+    setTimeout(() => { status.textContent = ''; }, 4000);
+  }
+}
+
+function setupFeatureUpload() {
+  const input = document.getElementById('feature-upload');
+  if (input) {
+    input.addEventListener('change', (evt) => loadFeatureFiles(evt.target.files));
+  }
+  const folderInput = document.getElementById('feature-folder-upload');
+  if (folderInput) {
+    folderInput.addEventListener('change', (evt) => loadFeatureFiles(evt.target.files));
+  }
+}
+
+// ─── Init ───
+
+setupTabs();
+initEngine().then(() => init());
 setupYamlUpload();
+setupFeatureUpload();
+setupTestResultsImport();
+
+document.getElementById('run-all-tests')?.addEventListener('click', executeAllTests);

--- a/frontend/js/graph.js
+++ b/frontend/js/graph.js
@@ -1606,11 +1606,21 @@ function buildTestList() {
       const statusClass = result ? result.status : 'pending';
       const statusText = statusClass === 'pass' ? '\u2713' : statusClass === 'fail' ? '\u2717' : statusClass === 'running' ? '\u2026' : '\u00b7';
 
-      row.innerHTML = `
-        <span class="test-panel__scenario-status test-panel__scenario-status--${statusClass}">${statusText}</span>
-        <span class="test-panel__scenario-name" title="${s.name}">${s.name}</span>
-        <button class="test-panel__scenario-run" data-idx="${s._idx}">\u25B6</button>
-      `;
+      const statusSpan = document.createElement('span');
+      statusSpan.className = `test-panel__scenario-status test-panel__scenario-status--${statusClass}`;
+      statusSpan.textContent = statusText;
+
+      const nameSpan = document.createElement('span');
+      nameSpan.className = 'test-panel__scenario-name';
+      nameSpan.title = s.name;
+      nameSpan.textContent = s.name;
+
+      const runBtn = document.createElement('button');
+      runBtn.className = 'test-panel__scenario-run';
+      runBtn.dataset.idx = s._idx;
+      runBtn.textContent = '\u25B6';
+
+      row.append(statusSpan, nameSpan, runBtn);
 
       // Click scenario name → show overlay on graph
       row.querySelector('.test-panel__scenario-name').addEventListener('click', () => {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -172,26 +172,28 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
-      "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.2.tgz",
+      "integrity": "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1",
         "@tybys/wasm-util": "^0.10.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.120.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.120.0.tgz",
-      "integrity": "sha512-k1YNu55DuvAip/MGE1FTsIuU3FUCn6v/ujG9V7Nq5Df/kX2CWb13hhwD0lmJGMGqE+bE1MXvv9SZVnMzEXlWcg==",
+      "version": "0.123.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.123.0.tgz",
+      "integrity": "sha512-YtECP/y8Mj1lSHiUWGSRzy/C6teUKlS87dEfuVKT09LgQbUsBW1rNg+MiJ4buGu3yuADV60gbIvo9/HplA56Ew==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -505,9 +507,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.10.tgz",
-      "integrity": "sha512-jOHxwXhxmFKuXztiu1ORieJeTbx5vrTkcOkkkn2d35726+iwhrY1w/+nYY/AGgF12thg33qC3R1LMBF5tHTZHg==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.13.tgz",
+      "integrity": "sha512-5ZiiecKH2DXAVJTNN13gNMUcCDg4Jy8ZjbXEsPnqa248wgOVeYRX0iqXXD5Jz4bI9BFHgKsI2qmyJynstbmr+g==",
       "cpu": [
         "arm64"
       ],
@@ -522,9 +524,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.10.tgz",
-      "integrity": "sha512-gED05Teg/vtTZbIJBc4VNMAxAFDUPkuO/rAIyyxZjTj1a1/s6z5TII/5yMGZ0uLRCifEtwUQn8OlYzuYc0m70w==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.13.tgz",
+      "integrity": "sha512-tz/v/8G77seu8zAB3A5sK3UFoOl06zcshEzhUO62sAEtrEuW/H1CcyoupOrD+NbQJytYgA4CppXPzlrmp4JZKA==",
       "cpu": [
         "arm64"
       ],
@@ -539,9 +541,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.10.tgz",
-      "integrity": "sha512-rI15NcM1mA48lqrIxVkHfAqcyFLcQwyXWThy+BQ5+mkKKPvSO26ir+ZDp36AgYoYVkqvMcdS8zOE6SeBsR9e8A==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.13.tgz",
+      "integrity": "sha512-8DakphqOz8JrMYWTJmWA+vDJxut6LijZ8Xcdc4flOlAhU7PNVwo2MaWBF9iXjJAPo5rC/IxEFZDhJ3GC7NHvug==",
       "cpu": [
         "x64"
       ],
@@ -556,9 +558,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.10.tgz",
-      "integrity": "sha512-XZRXHdTa+4ME1MuDVp021+doQ+z6Ei4CCFmNc5/sKbqb8YmkiJdj8QKlV3rCI0AJtAeSB5n0WGPuJWNL9p/L2w==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.13.tgz",
+      "integrity": "sha512-4wBQFfjDuXYN/SVI8inBF3Aa+isq40rc6VMFbk5jcpolUBTe5cYnMsHZ51nFWsx3PVyyNN3vgoESki0Hmr/4BA==",
       "cpu": [
         "x64"
       ],
@@ -573,9 +575,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.10.tgz",
-      "integrity": "sha512-R0SQMRluISSLzFE20sPWYHVmJdDQnRyc/FzSCN72BqQmh2SOZUFG+N3/vBZpR4C6WpEUVYJLrYUXaj43sJsNLA==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.13.tgz",
+      "integrity": "sha512-JW/e4yPIXLms+jmnbwwy5LA/LxVwZUWLN8xug+V200wzaVi5TEGIWQlh8o91gWYFxW609euI98OCCemmWGuPrw==",
       "cpu": [
         "arm"
       ],
@@ -590,13 +592,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.10.tgz",
-      "integrity": "sha512-Y1reMrV/o+cwpduYhJuOE3OMKx32RMYCidf14y+HssARRmhDuWXJ4yVguDg2R/8SyyGNo+auzz64LnPK9Hq6jg==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.13.tgz",
+      "integrity": "sha512-ZfKWpXiUymDnavepCaM6KG/uGydJ4l2nBmMxg60Ci4CbeefpqjPWpfaZM7PThOhk2dssqBAcwLc6rAyr0uTdXg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -607,13 +612,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.10.tgz",
-      "integrity": "sha512-vELN+HNb2IzuzSBUOD4NHmP9yrGwl1DVM29wlQvx1OLSclL0NgVWnVDKl/8tEks79EFek/kebQKnNJkIAA4W2g==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.13.tgz",
+      "integrity": "sha512-bmRg3O6Z0gq9yodKKWCIpnlH051sEfdVwt+6m5UDffAQMUUqU0xjnQqqAUm+Gu7ofAAly9DqiQDtKu2nPDEABA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -624,13 +632,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.10.tgz",
-      "integrity": "sha512-ZqrufYTgzxbHwpqOjzSsb0UV/aV2TFIY5rP8HdsiPTv/CuAgCRjM6s9cYFwQ4CNH+hf9Y4erHW1GjZuZ7WoI7w==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.13.tgz",
+      "integrity": "sha512-8Wtnbw4k7pMYN9B/mOEAsQ8HOiq7AZ31Ig4M9BKn2So4xRaFEhtCSa4ZJaOutOWq50zpgR4N5+L/opnlaCx8wQ==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -641,13 +652,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.10.tgz",
-      "integrity": "sha512-gSlmVS1FZJSRicA6IyjoRoKAFK7IIHBs7xJuHRSmjImqk3mPPWbR7RhbnfH2G6bcmMEllCt2vQ/7u9e6bBnByg==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.13.tgz",
+      "integrity": "sha512-D/0Nlo8mQuxSMohNJUF2lDXWRsFDsHldfRRgD9bRgktj+EndGPj4DOV37LqDKPYS+osdyhZEH7fTakTAEcW7qg==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -658,13 +672,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.10.tgz",
-      "integrity": "sha512-eOCKUpluKgfObT2pHjztnaWEIbUabWzk3qPZ5PuacuPmr4+JtQG4k2vGTY0H15edaTnicgU428XW/IH6AimcQw==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.13.tgz",
+      "integrity": "sha512-eRrPvat2YaVQcwwKi/JzOP6MKf1WRnOCr+VaI3cTWz3ZoLcP/654z90lVCJ4dAuMEpPdke0n+qyAqXDZdIC4rA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -675,13 +692,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.10.tgz",
-      "integrity": "sha512-Xdf2jQbfQowJnLcgYfD/m0Uu0Qj5OdxKallD78/IPPfzaiaI4KRAwZzHcKQ4ig1gtg1SuzC7jovNiM2TzQsBXA==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.13.tgz",
+      "integrity": "sha512-PsdONiFRp8hR8KgVjTWjZ9s7uA3uueWL0t74/cKHfM4dR5zXYv4AjB8BvA+QDToqxAFg4ZkcVEqeu5F7inoz5w==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -692,9 +712,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.10.tgz",
-      "integrity": "sha512-o1hYe8hLi1EY6jgPFyxQgQ1wcycX+qz8eEbVmot2hFkgUzPxy9+kF0u0NIQBeDq+Mko47AkaFFaChcvZa9UX9Q==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.13.tgz",
+      "integrity": "sha512-hCNXgC5dI3TVOLrPT++PKFNZ+1EtS0mLQwfXXXSUD/+rGlB65gZDwN/IDuxLpQP4x8RYYHqGomlUXzpO8aVI2w==",
       "cpu": [
         "arm64"
       ],
@@ -709,9 +729,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.10.tgz",
-      "integrity": "sha512-Ugv9o7qYJudqQO5Y5y2N2SOo6S4WiqiNOpuQyoPInnhVzCY+wi/GHltcLHypG9DEUYMB0iTB/huJrpadiAcNcA==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.13.tgz",
+      "integrity": "sha512-viLS5C5et8NFtLWw9Sw3M/w4vvnVkbWkO7wSNh3C+7G1+uCkGpr6PcjNDSFcNtmXY/4trjPBqUfcOL+P3sWy/g==",
       "cpu": [
         "wasm32"
       ],
@@ -719,16 +739,18 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^1.1.1"
+        "@emnapi/core": "1.9.1",
+        "@emnapi/runtime": "1.9.1",
+        "@napi-rs/wasm-runtime": "^1.1.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.10.tgz",
-      "integrity": "sha512-7UODQb4fQUNT/vmgDZBl3XOBAIOutP5R3O/rkxg0aLfEGQ4opbCgU5vOw/scPe4xOqBwL9fw7/RP1vAMZ6QlAQ==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.13.tgz",
+      "integrity": "sha512-Fqa3Tlt1xL4wzmAYxGNFV36Hb+VfPc9PYU+E25DAnswXv3ODDu/yyWjQDbXMo5AGWkQVjLgQExuVu8I/UaZhPQ==",
       "cpu": [
         "arm64"
       ],
@@ -743,9 +765,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.10.tgz",
-      "integrity": "sha512-PYxKHMVHOb5NJuDL53vBUl1VwUjymDcYI6rzpIni0C9+9mTiJedvUxSk7/RPp7OOAm3v+EjgMu9bIy3N6b408w==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.13.tgz",
+      "integrity": "sha512-/pLI5kPkGEi44TDlnbio3St/5gUFeN51YWNAk/Gnv6mEQBOahRBh52qVFVBpmrnU01n2yysvBML9Ynu7K4kGAQ==",
       "cpu": [
         "x64"
       ],
@@ -1379,9 +1401,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "devOptional": true,
       "license": "MIT",
       "engines": {
@@ -1434,14 +1456,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.10.tgz",
-      "integrity": "sha512-q7j6vvarRFmKpgJUT8HCAUljkgzEp4LAhPlJUvQhA5LA1SUL36s5QCysMutErzL3EbNOZOkoziSx9iZC4FddKA==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.13.tgz",
+      "integrity": "sha512-bvVj8YJmf0rq4pSFmH7laLa6pYrhghv3PRzrCdRAr23g66zOKVJ4wkvFtgohtPLWmthgg8/rkaqRHrpUEh0Zbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.120.0",
-        "@rolldown/pluginutils": "1.0.0-rc.10"
+        "@oxc-project/types": "=0.123.0",
+        "@rolldown/pluginutils": "1.0.0-rc.13"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -1450,27 +1472,27 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.10",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.10",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.10",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.10",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.10",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.10",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.10",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.10",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.10",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.10",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.10",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.10",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.10",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.10",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.10"
+        "@rolldown/binding-android-arm64": "1.0.0-rc.13",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.13",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.13",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.13",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.13",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.13",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.13",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.13",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.13",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.13",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.13",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.13",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.13",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.13",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.13"
       }
     },
     "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.10.tgz",
-      "integrity": "sha512-UkVDEFk1w3mveXeKgaTuYfKWtPbvgck1dT8TUG3bnccrH0XtLTuAyfCoks4Q/M5ZGToSVJTIQYCzy2g/atAOeg==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.13.tgz",
+      "integrity": "sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1529,16 +1551,16 @@
       "optional": true
     },
     "node_modules/vite": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.1.tgz",
-      "integrity": "sha512-wt+Z2qIhfFt85uiyRt5LPU4oVEJBXj8hZNWKeqFG4gRG/0RaRGJ7njQCwzFVjO+v4+Ipmf5CY7VdmZRAYYBPHw==",
+      "version": "8.0.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.6.tgz",
+      "integrity": "sha512-jeOXoY6N8rOfit/mZADMd0misLqjRdWBB3/S23ZQNuPcbVsfMBJutWD8b4ftdczMOsNyMBnKro0Z1Kt0HIqq5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
-        "picomatch": "^4.0.3",
+        "picomatch": "^4.0.4",
         "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.10",
+        "rolldown": "1.0.0-rc.13",
         "tinyglobby": "^0.2.15"
       },
       "bin": {
@@ -1556,7 +1578,7 @@
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
         "@vitejs/devtools": "^0.1.0",
-        "esbuild": "^0.27.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
         "sass": "^1.70.0",

--- a/frontend/public/corpus-registry.yaml
+++ b/frontend/public/corpus-registry.yaml
@@ -1,0 +1,21 @@
+---
+schema_version: '1.0'
+sources:
+  - id: local
+    name: Local Test Corpus
+    type: local
+    local:
+      path: corpus/regulation/nl
+    scopes: []
+    priority: 1  # 1 = highest priority
+
+  - id: central
+    name: Centrale Regelrecht Corpus
+    type: github
+    github:
+      owner: MinBZK
+      repo: regelrecht-corpus
+      branch: development
+      path: regulation/nl
+    scopes: []
+    priority: 2

--- a/frontend/scripts/generate-features-data.js
+++ b/frontend/scripts/generate-features-data.js
@@ -1,0 +1,131 @@
+/**
+ * Parse Gherkin .feature files into JSON for the graph visualization.
+ *
+ * Usage: node scripts/generate-features-data.js [features-dir]
+ * Default features dir: ../../features/
+ * Output: public/data/features-data.json
+ */
+import { readdirSync, readFileSync, mkdirSync, writeFileSync } from 'fs';
+import { resolve, dirname, basename } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const featuresDir = resolve(__dirname, process.argv[2] || '../../features');
+// Write to both public/data (for Vite) and data/ (for static server)
+const outDirPublic = resolve(__dirname, '..', 'public', 'data');
+const outDir = resolve(__dirname, '..', 'data');
+
+function parseTable(lines, startIdx) {
+  const rows = [];
+  let i = startIdx;
+  while (i < lines.length && lines[i].trim().startsWith('|')) {
+    const cells = lines[i].trim().split('|').filter(c => c !== '').map(c => c.trim());
+    rows.push(cells);
+    i++;
+  }
+  if (rows.length < 2) return { table: rows.length === 1 ? rows[0].map(c => [c]) : [], endIdx: i };
+
+  // First row is header, rest are data rows → convert to [key, value] pairs
+  const headers = rows[0];
+  if (rows.length === 2) {
+    // Single data row: zip headers with values
+    const values = rows[1];
+    const table = headers.map((h, idx) => [h, values[idx] || '']);
+    return { table, endIdx: i };
+  }
+  // Multiple data rows: return as-is (header + rows)
+  return { table: rows, endIdx: i };
+}
+
+function parseFeatureFile(filePath) {
+  const content = readFileSync(filePath, 'utf-8');
+  const lines = content.split('\n');
+  const filename = basename(filePath);
+
+  const feature = {
+    name: '',
+    filename,
+    scenarios: [],
+  };
+
+  let currentScenario = null;
+  let backgroundSteps = [];
+  let inBackground = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim();
+
+    // Skip empty lines and comments
+    if (!line || line.startsWith('#')) continue;
+
+    if (line.startsWith('Feature:')) {
+      feature.name = line.slice('Feature:'.length).trim();
+      continue;
+    }
+
+    if (line.startsWith('Background:')) {
+      inBackground = true;
+      continue;
+    }
+
+    if (line.startsWith('Scenario:') || line.startsWith('Scenario Outline:')) {
+      inBackground = false;
+      if (currentScenario) {
+        feature.scenarios.push(currentScenario);
+      }
+      const isOutline = line.startsWith('Scenario Outline:');
+      const name = line.slice(isOutline ? 'Scenario Outline:'.length : 'Scenario:'.length).trim();
+      currentScenario = {
+        type: isOutline ? 'scenario_outline' : 'scenario',
+        name,
+        steps: [...backgroundSteps],
+      };
+      continue;
+    }
+
+    // Step keywords
+    const stepMatch = line.match(/^(Given|When|Then|And|But)\s+(.+)/);
+    if (stepMatch) {
+      const keyword = stepMatch[1];
+      const text = stepMatch[2];
+      // Normalize "And"/"But" to inherit the previous keyword's semantic
+      const step = { keyword, text };
+
+      // Check if next line starts a table
+      if (i + 1 < lines.length && lines[i + 1].trim().startsWith('|')) {
+        const { table, endIdx } = parseTable(lines, i + 1);
+        step.table = table;
+        i = endIdx - 1;
+      }
+
+      if (inBackground) {
+        backgroundSteps.push(step);
+      } else if (currentScenario) {
+        currentScenario.steps.push(step);
+      }
+    }
+  }
+
+  if (currentScenario) {
+    feature.scenarios.push(currentScenario);
+  }
+
+  return feature;
+}
+
+// Main
+const featureFiles = readdirSync(featuresDir).filter(f => f.endsWith('.feature'));
+console.log(`Parsing ${featureFiles.length} feature files from ${featuresDir}`);
+
+const features = featureFiles.map(f => parseFeatureFile(resolve(featuresDir, f)));
+
+const totalScenarios = features.reduce((sum, f) => sum + f.scenarios.length, 0);
+console.log(`Parsed ${totalScenarios} scenarios across ${features.length} features`);
+
+const jsonContent = JSON.stringify(features, null, 2);
+for (const dir of [outDir, outDirPublic]) {
+  mkdirSync(dir, { recursive: true });
+  const outPath = resolve(dir, 'features-data.json');
+  writeFileSync(outPath, jsonContent);
+  console.log(`Written to ${outPath}`);
+}

--- a/frontend/src/composables/useLaw.js
+++ b/frontend/src/composables/useLaw.js
@@ -7,7 +7,7 @@ export function useLaw(lawParam) {
     lawParam = params.get('law') || 'wet_op_de_zorgtoeslag';
   }
   // If the parameter looks like a URL, fetch directly; otherwise use the API.
-  const yamlUrl = (lawParam.startsWith('/') || lawParam.startsWith('http'))
+  const yamlUrl = (lawParam.startsWith('/') || lawParam.startsWith('http') || lawParam.startsWith('blob:'))
     ? lawParam
     : `/api/corpus/laws/${encodeURIComponent(lawParam)}`;
   const law = shallowRef(null);
@@ -45,9 +45,15 @@ export function useLaw(lawParam) {
   async function load() {
     try {
       loading.value = true;
-      const res = await fetch(yamlUrl);
-      if (!res.ok) throw new Error(`Failed to fetch: ${res.status}`);
-      const text = await res.text();
+      let text;
+      if (lawParam === 'local') {
+        text = localStorage.getItem('regelrecht_yaml');
+        if (!text) throw new Error('Geen YAML data gevonden in localStorage');
+      } else {
+        const res = await fetch(yamlUrl);
+        if (!res.ok) throw new Error(`Failed to fetch: ${res.status}`);
+        text = await res.text();
+      }
       law.value = yaml.load(text);
       const articleParam = new URLSearchParams(window.location.search).get('article');
       if (articleParam && articles.value.some(a => String(a.number) === articleParam)) {

--- a/frontend/src/composables/useLaw.js
+++ b/frontend/src/composables/useLaw.js
@@ -49,7 +49,10 @@ export function useLaw(lawParam) {
       if (!res.ok) throw new Error(`Failed to fetch: ${res.status}`);
       const text = await res.text();
       law.value = yaml.load(text);
-      if (articles.value.length > 0 && !selectedArticleNumber.value) {
+      const articleParam = new URLSearchParams(window.location.search).get('article');
+      if (articleParam && articles.value.some(a => String(a.number) === articleParam)) {
+        selectedArticleNumber.value = articleParam;
+      } else if (articles.value.length > 0 && !selectedArticleNumber.value) {
         selectedArticleNumber.value = String(articles.value[0].number);
       }
     } catch (e) {

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -20,6 +20,7 @@ export default defineConfig({
       input: {
         main: resolve(__dirname, 'index.html'),
         editor: resolve(__dirname, 'editor.html'),
+        graph: resolve(__dirname, 'graph.html'),
       },
     },
   },


### PR DESCRIPTION
## Summary

Adds a new graph view (`frontend/graph.html`) that visualizes laws, articles
and their cross-references using cytoscape + ELK. Renders both inside the
existing Vite app and as a fully standalone static page so it can be opened
without `npm run dev`.

## What it does

- Renders laws as nodes and inter-law `source:` references as edges, with
  ELK layered layout (taxi edges, network-simplex placement, partitioned by
  regulatory layer).
- Sidebar with two tabs:
  - **Wetten**: load YAML via folder upload (`webkitdirectory`) or
    individual files; toggle visibility per law; right-click an article to
    cycle validation status (pending / in progress / validated).
  - **Tests**: load `.feature` files, run scenarios against the graph
    state, and see pass/fail per scenario propagated as values along the
    edges.
- Double-click an article node opens the editor at that article
  (`editor.html?law=…&article=…`); `useLaw` now also accepts `blob:` URLs
  and a `local` keyword for `localStorage`-backed YAML.
- Standalone mode: `graph.html` can be served as a static file (no Vite) by
  reading YAML from a user-uploaded folder.

## Files

- `frontend/graph.html`, `frontend/js/graph.js`,
  `frontend/css/components/graph.css` — the graph view itself
- `frontend/scripts/generate-features-data.js` — parses Gherkin
  `features/*.feature` into JSON for the test panel
- `frontend/public/corpus-registry.yaml` — corpus sources for standalone mode
- `frontend/src/composables/useLaw.js` — `blob:` + `localStorage` support,
  `?article=` deep-link
- `frontend/vite.config.js` — registers `graph.html` as a build entry
- `frontend/.gitignore` — ignores generated `data/` and `wasm/`

## Test plan

- [ ] `cd frontend && npm run build` succeeds and emits `graph.html`
- [ ] `npm run dev` → open `/graph.html`, upload a folder of YAML laws,
      verify nodes/edges render
- [ ] Right-click an article cycles validation status visually
- [ ] Double-click an article opens the editor at that article
- [ ] Tests tab: upload a `.feature` file, run a scenario, verify pass/fail
      and edge value propagation
- [ ] Open `frontend/graph.html` directly (e.g. `python3 -m http.server`
      from `frontend/`) — confirm it works without Vite