### PR TITLE
feat(editor): request harvest for missing law dependencies

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,7 +3,7 @@
 FROM rust:1.94-alpine@sha256:7f752ee8ea5deb9f4863d8c3f228a216a6466619882f09a44b9eda9617dc7770 AS wasm-builder
 RUN apk add --no-cache musl-dev
 RUN rustup target add wasm32-unknown-unknown
-RUN cargo install wasm-bindgen-cli@0.2.114 --locked
+RUN cargo install wasm-bindgen-cli@0.2.117 --locked
 WORKDIR /build
 COPY packages/Cargo.lock ./
 RUN printf '[workspace]\nresolver = "2"\nmembers = [\n    "packages/engine",\n    "packages/shared",\n]\n' > Cargo.toml

--- a/frontend/src/LibraryApp.vue
+++ b/frontend/src/LibraryApp.vue
@@ -124,8 +124,17 @@ async function pollHarvestStatus() {
     bwbHarvestSlugs.value = updatedSlugs;
 
     if (needsReload) {
-      // Trigger corpus reload and refresh law index
-      await fetch('/api/corpus/reload', { method: 'POST' }).catch(() => {});
+      // Trigger corpus reload with the newly harvested law slugs so the
+      // editor pulls them from the GitHub corpus repo.
+      const newSlugs = Object.entries(updatedSlugs)
+        .filter(([bwbId]) => AVAILABLE_STATUSES.has(updatedStatus[bwbId]))
+        .map(([, slug]) => slug)
+        .filter(Boolean);
+      await fetch('/api/corpus/reload', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ law_ids: newSlugs }),
+      }).catch(() => {});
       await loadIndex();
     }
 

--- a/frontend/src/LibraryApp.vue
+++ b/frontend/src/LibraryApp.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed, shallowRef, watch } from 'vue';
+import { ref, computed, shallowRef, watch, onUnmounted } from 'vue';
 import { useRoute, useRouter, onBeforeRouteUpdate } from 'vue-router';
 import yaml from 'js-yaml';
 import ArticleText from './components/ArticleText.vue';
@@ -49,13 +49,100 @@ const filteredLaws = computed(() => {
 // --- BWB external search (fallback when local search has no results) ---
 const bwbResults = ref([]);
 const bwbLoading = ref(false);
-const bwbHarvestStatus = ref({}); // { [bwb_id]: 'queued' | 'error' | ... }
+const bwbHarvestStatus = ref({}); // { [bwb_id]: 'queued' | 'harvesting' | ... }
+const bwbHarvestSlugs = ref({}); // { [bwb_id]: 'slug_name' } — resolved after harvest
+
+const TERMINAL_STATUSES = new Set([
+  'harvest_failed', 'harvest_exhausted', 'enrich_failed', 'enrich_exhausted', 'error', 'timeout',
+]);
+const AVAILABLE_STATUSES = new Set(['harvested', 'enriched']);
+const POLLING_STATUSES = new Set(['queued', 'already_queued', 'harvesting', 'enriching']);
 
 let bwbSearchTimeout = null;
+let harvestPollInterval = null;
+let harvestPollStart = null;
+const POLL_INTERVAL_MS = 5000;
+const POLL_MAX_MS = 10 * 60 * 1000; // 10 minutes
+
+function startHarvestPoll() {
+  if (harvestPollInterval) return;
+  harvestPollStart = Date.now();
+  harvestPollInterval = setInterval(pollHarvestStatus, POLL_INTERVAL_MS);
+}
+
+function stopHarvestPoll() {
+  if (harvestPollInterval) {
+    clearInterval(harvestPollInterval);
+    harvestPollInterval = null;
+    harvestPollStart = null;
+  }
+}
+
+const hasActiveHarvests = computed(() => {
+  return Object.values(bwbHarvestStatus.value).some(
+    s => POLLING_STATUSES.has(s) || AVAILABLE_STATUSES.has(s)
+  );
+});
+
+async function pollHarvestStatus() {
+  // Timeout check
+  if (harvestPollStart && Date.now() - harvestPollStart > POLL_MAX_MS) {
+    const updated = { ...bwbHarvestStatus.value };
+    for (const [id, status] of Object.entries(updated)) {
+      if (POLLING_STATUSES.has(status)) updated[id] = 'timeout';
+    }
+    bwbHarvestStatus.value = updated;
+    stopHarvestPoll();
+    return;
+  }
+
+  const activeIds = Object.entries(bwbHarvestStatus.value)
+    .filter(([, status]) => POLLING_STATUSES.has(status))
+    .map(([id]) => id);
+
+  if (activeIds.length === 0) {
+    stopHarvestPoll();
+    return;
+  }
+
+  try {
+    const res = await fetch(`/api/harvest-status?bwb_ids=${activeIds.join(',')}`);
+    if (!res.ok) return;
+    const data = await res.json();
+
+    const updatedStatus = { ...bwbHarvestStatus.value };
+    const updatedSlugs = { ...bwbHarvestSlugs.value };
+    let needsReload = false;
+
+    for (const entry of data.results) {
+      updatedStatus[entry.bwb_id] = entry.status;
+      if (entry.slug) updatedSlugs[entry.bwb_id] = entry.slug;
+      if (AVAILABLE_STATUSES.has(entry.status) && entry.slug) needsReload = true;
+    }
+
+    bwbHarvestStatus.value = updatedStatus;
+    bwbHarvestSlugs.value = updatedSlugs;
+
+    if (needsReload) {
+      // Trigger corpus reload and refresh law index
+      await fetch('/api/corpus/reload', { method: 'POST' }).catch(() => {});
+      await loadIndex();
+    }
+
+    // Stop polling if no active IDs remain
+    const stillActive = Object.values(updatedStatus).some(s => POLLING_STATUSES.has(s));
+    if (!stillActive) stopHarvestPoll();
+  } catch {
+    // Poll is best-effort
+  }
+}
+
+onUnmounted(stopHarvestPoll);
 
 watch([search, filteredLaws], ([q, filtered]) => {
   clearTimeout(bwbSearchTimeout);
-  bwbResults.value = [];
+  // Only clear results when there's no active/completed harvest to show
+  if (!hasActiveHarvests.value) bwbResults.value = [];
 
   if (!q || q.length < 3 || filtered.length > 0) return;
 
@@ -74,6 +161,16 @@ watch([search, filteredLaws], ([q, filtered]) => {
   }, 400);
 });
 
+function bwbItemClick(result) {
+  const status = bwbHarvestStatus.value[result.bwb_id];
+  const slug = bwbHarvestSlugs.value[result.bwb_id];
+  if (AVAILABLE_STATUSES.has(status) && slug) {
+    selectLaw(slug);
+  } else if (!status || status === 'error' || TERMINAL_STATUSES.has(status)) {
+    requestBwbHarvest(result.bwb_id);
+  }
+}
+
 async function requestBwbHarvest(bwbId) {
   bwbHarvestStatus.value = { ...bwbHarvestStatus.value, [bwbId]: 'loading' };
   try {
@@ -85,12 +182,45 @@ async function requestBwbHarvest(bwbId) {
     if (res.ok) {
       const data = await res.json();
       bwbHarvestStatus.value = { ...bwbHarvestStatus.value, [bwbId]: data.status };
+      if (data.status === 'queued' || data.status === 'already_queued') {
+        startHarvestPoll();
+      }
     } else {
       bwbHarvestStatus.value = { ...bwbHarvestStatus.value, [bwbId]: 'error' };
     }
   } catch {
     bwbHarvestStatus.value = { ...bwbHarvestStatus.value, [bwbId]: 'error' };
   }
+}
+
+function bwbStatusText(result) {
+  const s = bwbHarvestStatus.value[result.bwb_id];
+  if (!s) return `${result.type} \u2014 ${result.bwb_id}`;
+  switch (s) {
+    case 'loading': return 'Aanvragen...';
+    case 'queued':
+    case 'already_queued': return 'Harvest aangevraagd';
+    case 'harvesting': return 'Wordt opgehaald...';
+    case 'enriching': return 'Wordt verwerkt...';
+    case 'harvested':
+    case 'enriched': return 'Beschikbaar \u2014 klik om te openen';
+    case 'harvest_failed':
+    case 'harvest_exhausted':
+    case 'enrich_failed':
+    case 'enrich_exhausted': return 'Ophalen mislukt';
+    case 'timeout': return 'Timeout \u2014 probeer later opnieuw';
+    case 'error': return 'Fout bij aanvragen';
+    default: return `${result.type} \u2014 ${result.bwb_id}`;
+  }
+}
+
+function bwbStatusIcon(result) {
+  const s = bwbHarvestStatus.value[result.bwb_id];
+  if (!s) return 'arrow-down-to-line';
+  if (AVAILABLE_STATUSES.has(s)) return 'arrow-right';
+  if (POLLING_STATUSES.has(s)) return 'arrow-clockwise';
+  if (TERMINAL_STATUSES.has(s)) return 'x-circle';
+  return 'arrow-down-to-line';
 }
 
 const articles = computed(() => selectedLaw.value?.articles ?? []);
@@ -346,8 +476,8 @@ loadIndex();
                     </ndd-list-item>
                   </ndd-list>
 
-                  <!-- BWB search results when local search has no matches -->
-                  <template v-if="search && filteredLaws.length === 0">
+                  <!-- BWB search results / harvest tracker -->
+                  <template v-if="(search && filteredLaws.length === 0) || (bwbResults.length > 0 && hasActiveHarvests)">
                     <ndd-inline-dialog v-if="bwbLoading" text="Zoeken op wetten.overheid.nl..."></ndd-inline-dialog>
                     <template v-else-if="bwbResults.length > 0">
                       <ndd-spacer size="8"></ndd-spacer>
@@ -359,25 +489,24 @@ loadIndex();
                           :key="result.bwb_id"
                           size="md"
                           type="button"
-                          :disabled="bwbHarvestStatus[result.bwb_id] === 'queued' || bwbHarvestStatus[result.bwb_id] === 'already_queued' || bwbHarvestStatus[result.bwb_id] === 'loading' || undefined"
-                          @click="requestBwbHarvest(result.bwb_id)"
+                          :disabled="bwbHarvestStatus[result.bwb_id] === 'loading'
+                            || (POLLING_STATUSES.has(bwbHarvestStatus[result.bwb_id])
+                                && !AVAILABLE_STATUSES.has(bwbHarvestStatus[result.bwb_id]))
+                            || undefined"
+                          @click="bwbItemClick(result)"
                         >
                           <ndd-text-cell
                             :text="result.title"
-                            :supporting-text="bwbHarvestStatus[result.bwb_id] === 'queued' ? 'Harvest aangevraagd'
-                              : bwbHarvestStatus[result.bwb_id] === 'already_queued' ? 'Harvest al aangevraagd'
-                              : bwbHarvestStatus[result.bwb_id] === 'error' ? 'Fout bij aanvragen'
-                              : bwbHarvestStatus[result.bwb_id] === 'loading' ? 'Aanvragen...'
-                              : `${result.type} \u2014 ${result.bwb_id}`"
+                            :supporting-text="bwbStatusText(result)"
                           >
                           </ndd-text-cell>
                           <ndd-icon-cell slot="end" size="20">
-                            <ndd-icon :name="bwbHarvestStatus[result.bwb_id] === 'queued' || bwbHarvestStatus[result.bwb_id] === 'already_queued' ? 'checkmark' : 'arrow-down-to-line'"></ndd-icon>
+                            <ndd-icon :name="bwbStatusIcon(result)"></ndd-icon>
                           </ndd-icon-cell>
                         </ndd-list-item>
                       </ndd-list>
                     </template>
-                    <ndd-inline-dialog v-else-if="search.length >= 3 && !bwbLoading" text="Geen resultaten gevonden"></ndd-inline-dialog>
+                    <ndd-inline-dialog v-else-if="search && search.length >= 3 && !bwbLoading" text="Geen resultaten gevonden"></ndd-inline-dialog>
                   </template>
                 </template>
               </ndd-simple-section>

--- a/frontend/src/LibraryApp.vue
+++ b/frontend/src/LibraryApp.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed, shallowRef } from 'vue';
+import { ref, computed, shallowRef, watch } from 'vue';
 import { useRoute, useRouter, onBeforeRouteUpdate } from 'vue-router';
 import yaml from 'js-yaml';
 import ArticleText from './components/ArticleText.vue';
@@ -45,6 +45,53 @@ const filteredLaws = computed(() => {
     displayName(law).toLowerCase().includes(q)
   );
 });
+
+// --- BWB external search (fallback when local search has no results) ---
+const bwbResults = ref([]);
+const bwbLoading = ref(false);
+const bwbHarvestStatus = ref({}); // { [bwb_id]: 'queued' | 'error' | ... }
+
+let bwbSearchTimeout = null;
+
+watch([search, filteredLaws], ([q, filtered]) => {
+  clearTimeout(bwbSearchTimeout);
+  bwbResults.value = [];
+
+  if (!q || q.length < 3 || filtered.length > 0) return;
+
+  bwbSearchTimeout = setTimeout(async () => {
+    bwbLoading.value = true;
+    try {
+      const res = await fetch(`/api/bwb/search?q=${encodeURIComponent(q)}`);
+      if (res.ok) {
+        bwbResults.value = await res.json();
+      }
+    } catch {
+      // BWB search is best-effort
+    } finally {
+      bwbLoading.value = false;
+    }
+  }, 400);
+});
+
+async function requestBwbHarvest(bwbId) {
+  bwbHarvestStatus.value = { ...bwbHarvestStatus.value, [bwbId]: 'loading' };
+  try {
+    const res = await fetch('/api/bwb/harvest', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ bwb_id: bwbId }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      bwbHarvestStatus.value = { ...bwbHarvestStatus.value, [bwbId]: data.status };
+    } else {
+      bwbHarvestStatus.value = { ...bwbHarvestStatus.value, [bwbId]: 'error' };
+    }
+  } catch {
+    bwbHarvestStatus.value = { ...bwbHarvestStatus.value, [bwbId]: 'error' };
+  }
+}
 
 const articles = computed(() => selectedLaw.value?.articles ?? []);
 
@@ -281,22 +328,58 @@ loadIndex();
                 <ndd-spacer size="16"></ndd-spacer>
                 <ndd-inline-dialog v-if="loading" text="Laden..."></ndd-inline-dialog>
                 <ndd-inline-dialog v-else-if="indexError" variant="alert" text="Fout bij laden" :supporting-text="indexError.message"></ndd-inline-dialog>
-                <ndd-list v-else variant="simple">
-                  <ndd-list-item
-                    v-for="law in filteredLaws"
-                    :key="law.law_id"
-                    size="md"
-                    type="button"
-                    :selected="law.law_id === selectedLawId || undefined"
-                    @click="selectLaw(law.law_id)"
-                  >
-                    <ndd-text-cell :text="displayName(law)" :supporting-text="law.source_name">
-                    </ndd-text-cell>
-                    <ndd-icon-cell slot="end" size="20">
-                      <ndd-icon name="chevron-right"></ndd-icon>
-                    </ndd-icon-cell>
-                  </ndd-list-item>
-                </ndd-list>
+                <template v-else>
+                  <ndd-list v-if="filteredLaws.length > 0" variant="simple">
+                    <ndd-list-item
+                      v-for="law in filteredLaws"
+                      :key="law.law_id"
+                      size="md"
+                      type="button"
+                      :selected="law.law_id === selectedLawId || undefined"
+                      @click="selectLaw(law.law_id)"
+                    >
+                      <ndd-text-cell :text="displayName(law)" :supporting-text="law.source_name">
+                      </ndd-text-cell>
+                      <ndd-icon-cell slot="end" size="20">
+                        <ndd-icon name="chevron-right"></ndd-icon>
+                      </ndd-icon-cell>
+                    </ndd-list-item>
+                  </ndd-list>
+
+                  <!-- BWB search results when local search has no matches -->
+                  <template v-if="search && filteredLaws.length === 0">
+                    <ndd-inline-dialog v-if="bwbLoading" text="Zoeken op wetten.overheid.nl..."></ndd-inline-dialog>
+                    <template v-else-if="bwbResults.length > 0">
+                      <ndd-spacer size="8"></ndd-spacer>
+                      <ndd-title size="5"><h5>Resultaten van wetten.overheid.nl</h5></ndd-title>
+                      <ndd-spacer size="8"></ndd-spacer>
+                      <ndd-list variant="simple">
+                        <ndd-list-item
+                          v-for="result in bwbResults"
+                          :key="result.bwb_id"
+                          size="md"
+                          type="button"
+                          :disabled="bwbHarvestStatus[result.bwb_id] === 'queued' || bwbHarvestStatus[result.bwb_id] === 'already_queued' || bwbHarvestStatus[result.bwb_id] === 'loading' || undefined"
+                          @click="requestBwbHarvest(result.bwb_id)"
+                        >
+                          <ndd-text-cell
+                            :text="result.title"
+                            :supporting-text="bwbHarvestStatus[result.bwb_id] === 'queued' ? 'Harvest aangevraagd'
+                              : bwbHarvestStatus[result.bwb_id] === 'already_queued' ? 'Harvest al aangevraagd'
+                              : bwbHarvestStatus[result.bwb_id] === 'error' ? 'Fout bij aanvragen'
+                              : bwbHarvestStatus[result.bwb_id] === 'loading' ? 'Aanvragen...'
+                              : `${result.type} \u2014 ${result.bwb_id}`"
+                          >
+                          </ndd-text-cell>
+                          <ndd-icon-cell slot="end" size="20">
+                            <ndd-icon :name="bwbHarvestStatus[result.bwb_id] === 'queued' || bwbHarvestStatus[result.bwb_id] === 'already_queued' ? 'checkmark' : 'arrow-down-to-line'"></ndd-icon>
+                          </ndd-icon-cell>
+                        </ndd-list-item>
+                      </ndd-list>
+                    </template>
+                    <ndd-inline-dialog v-else-if="search.length >= 3 && !bwbLoading" text="Geen resultaten gevonden"></ndd-inline-dialog>
+                  </template>
+                </template>
               </ndd-simple-section>
             </ndd-page>
           </ndd-split-view-pane>

--- a/frontend/src/composables/useDependencies.js
+++ b/frontend/src/composables/useDependencies.js
@@ -114,8 +114,6 @@ export function useDependencies() {
   const loadedDeps = ref([]);
   const progress = ref('');
   const error = ref(null);
-  const harvestRequested = ref([]);
-
   /**
    * Load all dependencies for a law, recursively.
    *
@@ -127,7 +125,6 @@ export function useDependencies() {
     loading.value = true;
     error.value = null;
     loadedDeps.value = [];
-    harvestRequested.value = [];
     progress.value = 'Afhankelijkheden analyseren...';
 
     try {
@@ -198,29 +195,20 @@ export function useDependencies() {
       }
 
       // Phase 4: Request harvest for missing dependencies
+      const defaultProgress = total > 0
+        ? `${loadedDeps.value.length}/${total} wetten geladen`
+        : 'Geen afhankelijkheden';
+
       if (missingDeps.length > 0) {
         const harvestResult = await requestHarvest(missingDeps);
-        if (harvestResult?.results) {
-          const queued = harvestResult.results.filter(
-            (r) => r.status === 'queued',
-          );
-          harvestRequested.value = queued.map((r) => r.law_id);
-
-          if (queued.length > 0) {
-            progress.value =
-              `${loadedDeps.value.length}/${total} wetten geladen \u2014 ${queued.length} ontbrekende wet(ten) aangevraagd`;
-          } else {
-            progress.value = `${loadedDeps.value.length}/${total} wetten geladen`;
-          }
-        } else {
-          progress.value = total > 0
-            ? `${loadedDeps.value.length}/${total} wetten geladen`
-            : 'Geen afhankelijkheden';
-        }
+        const queued = harvestResult?.results?.filter(
+          (r) => r.status === 'queued',
+        ) ?? [];
+        progress.value = queued.length > 0
+          ? `${defaultProgress} \u2014 ${queued.length} ontbrekende wet(ten) aangevraagd`
+          : defaultProgress;
       } else {
-        progress.value = total > 0
-          ? `${loadedDeps.value.length}/${total} wetten geladen`
-          : 'Geen afhankelijkheden';
+        progress.value = defaultProgress;
       }
     } catch (e) {
       error.value = e.message || String(e);
@@ -229,7 +217,7 @@ export function useDependencies() {
     }
   }
 
-  return { loading, loadedDeps, progress, error, harvestRequested, loadAllDependencies };
+  return { loading, loadedDeps, progress, error, loadAllDependencies };
 }
 
 /**

--- a/frontend/src/composables/useDependencies.js
+++ b/frontend/src/composables/useDependencies.js
@@ -201,11 +201,11 @@ export function useDependencies() {
 
       if (missingDeps.length > 0) {
         const harvestResult = await requestHarvest(missingDeps);
-        const queued = harvestResult?.results?.filter(
-          (r) => r.status === 'queued',
+        const requested = harvestResult?.results?.filter(
+          (r) => r.status === 'queued' || r.status === 'already_queued',
         ) ?? [];
-        progress.value = queued.length > 0
-          ? `${defaultProgress} \u2014 ${queued.length} ontbrekende wet(ten) aangevraagd`
+        progress.value = requested.length > 0
+          ? `${defaultProgress} \u2014 ${requested.length} ontbrekende wet(ten) aangevraagd`
           : defaultProgress;
       } else {
         progress.value = defaultProgress;

--- a/frontend/src/composables/useDependencies.js
+++ b/frontend/src/composables/useDependencies.js
@@ -4,6 +4,9 @@
  * Parses a law's YAML structure to find all `source.regulation` references,
  * fetches each dependency via the API, loads it into the engine, and recurses.
  * Also discovers implementing regulations via corpus scan.
+ *
+ * When dependencies cannot be loaded, automatically requests their harvesting
+ * via the editor-api so they become available in a future session.
  */
 import { ref } from 'vue';
 import yaml from 'js-yaml';
@@ -81,6 +84,29 @@ async function discoverImplementors(lawId, allLaws, fetchLawYaml) {
 }
 
 /**
+ * Request harvesting for missing dependencies so they become available
+ * in a future session. Best-effort — errors are silently ignored.
+ *
+ * @param {string[]} missingIds - Law slugs that could not be loaded
+ * @returns {Promise<object|null>} Harvest response or null on failure
+ */
+async function requestHarvest(missingIds) {
+  try {
+    const res = await fetch('/api/corpus/request-harvest', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ law_ids: missingIds }),
+    });
+    if (res.ok) {
+      return await res.json();
+    }
+  } catch {
+    // Harvest request is best-effort
+  }
+  return null;
+}
+
+/**
  * Composable for loading all dependencies of a law recursively.
  */
 export function useDependencies() {
@@ -88,6 +114,7 @@ export function useDependencies() {
   const loadedDeps = ref([]);
   const progress = ref('');
   const error = ref(null);
+  const harvestRequested = ref([]);
 
   /**
    * Load all dependencies for a law, recursively.
@@ -100,6 +127,7 @@ export function useDependencies() {
     loading.value = true;
     error.value = null;
     loadedDeps.value = [];
+    harvestRequested.value = [];
     progress.value = 'Afhankelijkheden analyseren...';
 
     try {
@@ -136,6 +164,7 @@ export function useDependencies() {
       // Phase 3: Load all collected dependencies
       let total = toLoad.length;
       let loaded = 0;
+      const missingDeps = [];
 
       for (const lawId of toLoad) {
         if (engine.hasLaw(lawId)) {
@@ -162,14 +191,37 @@ export function useDependencies() {
           }
         } catch (e) {
           console.warn(`Failed to load dependency '${lawId}':`, e);
+          missingDeps.push(lawId);
           loaded++;
           progress.value = `${loaded}/${total} wetten geladen (${lawId} mislukt)`;
         }
       }
 
-      progress.value = total > 0
-        ? `${loadedDeps.value.length}/${total} wetten geladen`
-        : 'Geen afhankelijkheden';
+      // Phase 4: Request harvest for missing dependencies
+      if (missingDeps.length > 0) {
+        const harvestResult = await requestHarvest(missingDeps);
+        if (harvestResult?.results) {
+          const queued = harvestResult.results.filter(
+            (r) => r.status === 'queued',
+          );
+          harvestRequested.value = queued.map((r) => r.law_id);
+
+          if (queued.length > 0) {
+            progress.value =
+              `${loadedDeps.value.length}/${total} wetten geladen \u2014 ${queued.length} ontbrekende wet(ten) aangevraagd`;
+          } else {
+            progress.value = `${loadedDeps.value.length}/${total} wetten geladen`;
+          }
+        } else {
+          progress.value = total > 0
+            ? `${loadedDeps.value.length}/${total} wetten geladen`
+            : 'Geen afhankelijkheden';
+        }
+      } else {
+        progress.value = total > 0
+          ? `${loadedDeps.value.length}/${total} wetten geladen`
+          : 'Geen afhankelijkheden';
+      }
     } catch (e) {
       error.value = e.message || String(e);
     } finally {
@@ -177,7 +229,7 @@ export function useDependencies() {
     }
   }
 
-  return { loading, loadedDeps, progress, error, loadAllDependencies };
+  return { loading, loadedDeps, progress, error, harvestRequested, loadAllDependencies };
 }
 
 /**

--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -212,9 +212,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
 dependencies = [
  "cc",
  "cmake",
@@ -489,9 +489,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -601,9 +601,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
@@ -1307,9 +1307,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ferroid"
@@ -1657,7 +1657,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -1816,9 +1816,9 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1831,7 +1831,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1948,12 +1947,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1961,9 +1961,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1974,9 +1974,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1988,15 +1988,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -2008,15 +2008,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -2089,9 +2089,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
@@ -2142,9 +2142,9 @@ dependencies = [
 
 [[package]]
 name = "inventory"
-version = "0.3.22"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "009ae045c87e7082cb72dab0ccd01ae075dd00141ddc108f43a0ea150a9e7227"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
 dependencies = [
  "rustversion",
 ]
@@ -2157,9 +2157,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.10"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -2213,7 +2213,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.1",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -2222,9 +2222,31 @@ dependencies = [
 
 [[package]]
 name = "jni-sys"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "jobserver"
@@ -2238,10 +2260,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -2309,9 +2333,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libm"
@@ -2321,9 +2345,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
@@ -2343,9 +2367,9 @@ dependencies = [
 
 [[package]]
 name = "line-clipping"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4de44e98ddbf09375cbf4d17714d18f39195f4f4894e8524501726fd9a8a4a"
+checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -2364,9 +2388,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
@@ -2604,9 +2628,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-derive"
@@ -3102,12 +3126,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3176,9 +3194,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -3673,6 +3691,7 @@ name = "regelrecht-editor-api"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "chrono",
  "regelrecht-auth",
  "regelrecht-corpus",
  "reqwest 0.12.28",
@@ -3688,6 +3707,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "uuid",
 ]
 
 [[package]]
@@ -3974,9 +3994,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -4187,9 +4207,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -4308,7 +4328,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -4335,7 +4355,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "itoa",
  "ryu",
  "serde",
@@ -4519,7 +4539,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.15.5",
  "hashlink",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "log",
  "memchr",
  "once_cell",
@@ -4900,12 +4920,12 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5105,9 +5125,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -5247,7 +5267,7 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -5542,9 +5562,9 @@ checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-truncate"
@@ -5758,9 +5778,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5771,23 +5791,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5795,9 +5811,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5808,9 +5824,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -5832,7 +5848,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -5845,15 +5861,15 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.0",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "semver",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6418,7 +6434,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -6449,7 +6465,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "log",
  "serde",
  "serde_derive",
@@ -6468,7 +6484,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "log",
  "semver",
  "serde",
@@ -6480,9 +6496,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xattr"
@@ -6502,9 +6518,9 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -6513,9 +6529,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6525,18 +6541,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6545,18 +6561,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6572,9 +6588,9 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -6583,9 +6599,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -6594,9 +6610,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -3695,6 +3695,7 @@ dependencies = [
  "regelrecht-auth",
  "regelrecht-corpus",
  "reqwest 0.12.28",
+ "roxmltree",
  "serde",
  "serde_json",
  "sqlx",

--- a/packages/admin/src/handlers.rs
+++ b/packages/admin/src/handlers.rs
@@ -125,7 +125,7 @@ pub async fn list_law_entries(
     // interpolating it into the query string is safe.
     let query_str = if params.status.is_some() {
         format!(
-            "SELECT law_id, law_name, status, coverage_score, \
+            "SELECT law_id, law_name, slug, status, coverage_score, \
              harvest_job_id, enrich_job_id, harvest_fail_count, enrich_fail_count, \
              created_at, updated_at \
              FROM law_entries WHERE status::text = $1 \
@@ -133,7 +133,7 @@ pub async fn list_law_entries(
         )
     } else {
         format!(
-            "SELECT law_id, law_name, status, coverage_score, \
+            "SELECT law_id, law_name, slug, status, coverage_score, \
              harvest_job_id, enrich_job_id, harvest_fail_count, enrich_fail_count, \
              created_at, updated_at \
              FROM law_entries \

--- a/packages/admin/src/models.rs
+++ b/packages/admin/src/models.rs
@@ -15,6 +15,7 @@ pub struct PaginatedResponse<T: Serialize> {
 pub struct LawEntry {
     pub law_id: String,
     pub law_name: Option<String>,
+    pub slug: Option<String>,
     pub status: LawStatusValue,
     pub coverage_score: Option<f64>,
     pub harvest_job_id: Option<sqlx::types::Uuid>,

--- a/packages/editor-api/Cargo.toml
+++ b/packages/editor-api/Cargo.toml
@@ -15,19 +15,25 @@ path = "src/main.rs"
 axum = "0.8"
 regelrecht-auth = { path = "../auth" }
 regelrecht-corpus = { path = "../corpus", features = ["github"] }
+sqlx = { version = "0.8", features = ["runtime-tokio", "tls-rustls", "postgres", "uuid", "chrono", "json"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tower-http = { version = "0.6", features = ["fs", "trace"] }
 tower-sessions = "0.14"
 tower-sessions-sqlx-store = { version = "0.15", features = ["postgres"] }
 tower-sessions-memory-store = "0.14"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
-sqlx = { version = "0.8", features = ["runtime-tokio", "tls-rustls", "postgres"] }
+chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+uuid = { version = "1", features = ["serde"] }
 time = "0.3"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 url = "2"
+
+[features]
+default = ["pipeline"]
+pipeline = []
 
 [lints.clippy]
 unwrap_used = "warn"

--- a/packages/editor-api/Cargo.toml
+++ b/packages/editor-api/Cargo.toml
@@ -29,6 +29,7 @@ uuid = { version = "1", features = ["serde"] }
 time = "0.3"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+roxmltree = "0.21"
 url = "2"
 
 [features]

--- a/packages/editor-api/src/bwb_search.rs
+++ b/packages/editor-api/src/bwb_search.rs
@@ -1,0 +1,121 @@
+use axum::extract::{Query, State};
+use axum::http::StatusCode;
+use axum::Json;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+use crate::state::AppState;
+
+const SRU_BASE: &str = "https://zoekservice.overheid.nl/sru/Search";
+const MAX_RESULTS: u32 = 20;
+
+#[derive(Deserialize)]
+pub struct SearchParams {
+    pub q: String,
+}
+
+#[derive(Serialize, Clone)]
+pub struct BwbSearchResult {
+    pub bwb_id: String,
+    pub title: String,
+    #[serde(rename = "type")]
+    pub law_type: String,
+}
+
+pub async fn search_bwb(
+    State(state): State<AppState>,
+    Query(params): Query<SearchParams>,
+) -> Result<Json<Vec<BwbSearchResult>>, (StatusCode, String)> {
+    let q = params.q.trim();
+    if q.is_empty() || q.len() < 2 {
+        return Ok(Json(vec![]));
+    }
+
+    // Build CQL query: search by title, optionally filter to active laws
+    let cql = format!("overheidbwb.titel any \"{}\"", q.replace('"', ""));
+
+    let url = url::Url::parse_with_params(
+        SRU_BASE,
+        &[
+            ("operation", "searchRetrieve"),
+            ("version", "1.2"),
+            ("x-connection", "BWB"),
+            ("query", &cql),
+            ("maximumRecords", &MAX_RESULTS.to_string()),
+        ],
+    )
+    .map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("URL build error: {e}"),
+        )
+    })?;
+
+    let response = state
+        .http_client
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| (StatusCode::BAD_GATEWAY, format!("BWB search failed: {e}")))?;
+
+    let xml_text = response.text().await.map_err(|e| {
+        (
+            StatusCode::BAD_GATEWAY,
+            format!("BWB response read failed: {e}"),
+        )
+    })?;
+
+    let results = parse_sru_response(&xml_text).map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("XML parse error: {e}"),
+        )
+    })?;
+
+    Ok(Json(results))
+}
+
+/// Parse SRU XML response and extract unique laws (deduplicated by BWBR ID).
+fn parse_sru_response(xml: &str) -> Result<Vec<BwbSearchResult>, String> {
+    let doc = roxmltree::Document::parse(xml).map_err(|e| e.to_string())?;
+
+    let mut seen: HashMap<String, BwbSearchResult> = HashMap::new();
+
+    for node in doc.descendants() {
+        if !node.is_element() {
+            continue;
+        }
+        let tag = node.tag_name().name();
+        if tag != "owmskern" {
+            continue;
+        }
+
+        let mut identifier = None;
+        let mut title = None;
+        let mut law_type = None;
+
+        for child in node.children().filter(|n| n.is_element()) {
+            match child.tag_name().name() {
+                "identifier" => identifier = child.text().map(|s| s.trim().to_string()),
+                "title" => title = child.text().map(|s| s.trim().to_string()),
+                "type" => law_type = child.text().map(|s| s.trim().to_string()),
+                _ => {}
+            }
+        }
+
+        if let (Some(bwb_id), Some(title)) = (identifier, title) {
+            if !bwb_id.starts_with("BWBR") {
+                continue;
+            }
+            seen.entry(bwb_id.clone()).or_insert(BwbSearchResult {
+                bwb_id,
+                title,
+                law_type: law_type.unwrap_or_default(),
+            });
+        }
+    }
+
+    let mut results: Vec<BwbSearchResult> = seen.into_values().collect();
+    results.sort_by(|a, b| a.title.cmp(&b.title));
+    Ok(results)
+}

--- a/packages/editor-api/src/bwb_search.rs
+++ b/packages/editor-api/src/bwb_search.rs
@@ -27,7 +27,7 @@ pub async fn search_bwb(
     Query(params): Query<SearchParams>,
 ) -> Result<Json<Vec<BwbSearchResult>>, (StatusCode, String)> {
     let q = params.q.trim();
-    if q.is_empty() || q.len() < 2 {
+    if q.is_empty() || q.len() < 3 {
         return Ok(Json(vec![]));
     }
 

--- a/packages/editor-api/src/bwb_search.rs
+++ b/packages/editor-api/src/bwb_search.rs
@@ -32,7 +32,8 @@ pub async fn search_bwb(
     }
 
     // Build CQL query: search by title, optionally filter to active laws
-    let cql = format!("overheidbwb.titel any \"{}\"", q.replace('"', ""));
+    let sanitized = q.replace(['\\', '"'], "");
+    let cql = format!("overheidbwb.titel any \"{sanitized}\"");
 
     let url = url::Url::parse_with_params(
         SRU_BASE,

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -652,25 +652,53 @@ pub async fn save_law(
     Ok(StatusCode::OK)
 }
 
-/// POST /api/corpus/reload — re-scan local corpus sources.
+/// POST /api/corpus/reload — reload corpus including GitHub sources.
 ///
-/// Picks up newly harvested YAML files without restarting the server. Only
-/// reloads local sources (fast, ~ms) — GitHub-backed sources are unchanged.
+/// Picks up newly harvested YAML files by refetching from all configured
+/// sources (local + GitHub). An optional JSON body can specify additional
+/// `law_ids` to pull from GitHub (e.g. after a harvest completes).
+///
+/// All law IDs currently in the SourceMap are preserved plus any extras.
 pub async fn reload_corpus(
     State(state): State<AppState>,
+    body: Option<Json<ReloadRequest>>,
 ) -> Result<Json<ReloadResponse>, (StatusCode, String)> {
     let mut corpus = state.corpus.write().await;
-    let new_map = corpus.registry.load_local_sources().map_err(|e| {
-        tracing::error!(error = %e, "corpus reload failed");
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "Failed to reload corpus".to_string(),
-        )
-    })?;
+
+    // Collect law IDs to fetch from GitHub: everything already loaded + any
+    // extras the caller explicitly requests (e.g. a freshly harvested law).
+    let mut law_ids: std::collections::HashSet<String> =
+        corpus.source_map.laws().map(|l| l.law_id.clone()).collect();
+
+    if let Some(Json(req)) = &body {
+        for id in &req.law_ids {
+            law_ids.insert(id.clone());
+        }
+    }
+
+    let auth_file = corpus.auth_file.as_deref();
+    let new_map = corpus
+        .registry
+        .load_favorites_async(&law_ids, auth_file)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, "corpus reload failed");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to reload corpus".to_string(),
+            )
+        })?;
+
     let law_count = new_map.len();
     corpus.source_map = new_map;
-    tracing::info!(law_count, "corpus reloaded from local sources");
+    tracing::info!(law_count, "corpus reloaded (local + GitHub)");
     Ok(Json(ReloadResponse { law_count }))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ReloadRequest {
+    #[serde(default)]
+    pub law_ids: Vec<String>,
 }
 
 #[derive(Debug, Serialize)]

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -652,6 +652,32 @@ pub async fn save_law(
     Ok(StatusCode::OK)
 }
 
+/// POST /api/corpus/reload — re-scan local corpus sources.
+///
+/// Picks up newly harvested YAML files without restarting the server. Only
+/// reloads local sources (fast, ~ms) — GitHub-backed sources are unchanged.
+pub async fn reload_corpus(
+    State(state): State<AppState>,
+) -> Result<Json<ReloadResponse>, (StatusCode, String)> {
+    let mut corpus = state.corpus.write().await;
+    let new_map = corpus.registry.load_local_sources().map_err(|e| {
+        tracing::error!(error = %e, "corpus reload failed");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Failed to reload corpus".to_string(),
+        )
+    })?;
+    let law_count = new_map.len();
+    corpus.source_map = new_map;
+    tracing::info!(law_count, "corpus reloaded from local sources");
+    Ok(Json(ReloadResponse { law_count }))
+}
+
+#[derive(Debug, Serialize)]
+pub struct ReloadResponse {
+    pub law_count: usize,
+}
+
 /// DELETE /api/corpus/laws/{law_id}/scenarios/{filename} — delete a scenario file.
 pub async fn delete_scenario(
     State(state): State<AppState>,

--- a/packages/editor-api/src/harvest_handlers.rs
+++ b/packages/editor-api/src/harvest_handlers.rs
@@ -1,4 +1,4 @@
-use axum::extract::State;
+use axum::extract::{Query, State};
 use axum::http::StatusCode;
 use axum::Json;
 use serde::{Deserialize, Serialize};
@@ -12,6 +12,9 @@ const EDITOR_HARVEST_PRIORITY: i32 = 80;
 
 /// Maximum number of law IDs per harvest request.
 const MAX_LAW_IDS: usize = 100;
+
+/// Maximum number of BWB IDs per status query.
+const MAX_STATUS_IDS: usize = 20;
 
 #[derive(Deserialize)]
 pub struct HarvestRequest {
@@ -263,4 +266,86 @@ async fn create_harvest_job(pool: &PgPool, slug: &str, bwb_id: &str) -> HarvestS
             }
         }
     }
+}
+
+// --- Harvest status polling (used by BWB search UI after requesting harvest) ---
+
+#[derive(Deserialize)]
+pub struct HarvestStatusQuery {
+    pub bwb_ids: String,
+}
+
+#[derive(Serialize)]
+pub struct HarvestStatusResponse {
+    pub results: Vec<HarvestStatusEntry>,
+}
+
+#[derive(Serialize)]
+pub struct HarvestStatusEntry {
+    pub bwb_id: String,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub slug: Option<String>,
+}
+
+/// GET /api/harvest-status?bwb_ids=BWBR0001234,BWBR0005678
+///
+/// Returns the current pipeline status and slug (if known) for each BWB ID.
+/// The frontend polls this endpoint after requesting a harvest to track progress.
+pub async fn harvest_status(
+    State(state): State<AppState>,
+    Query(query): Query<HarvestStatusQuery>,
+) -> Result<Json<HarvestStatusResponse>, (StatusCode, String)> {
+    let pool = match &state.pipeline_pool {
+        Some(pool) => pool,
+        None => {
+            return Err((
+                StatusCode::SERVICE_UNAVAILABLE,
+                "Pipeline database not configured".to_string(),
+            ));
+        }
+    };
+
+    let bwb_ids: Vec<String> = query
+        .bwb_ids
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect();
+
+    if bwb_ids.is_empty() {
+        return Ok(Json(HarvestStatusResponse {
+            results: Vec::new(),
+        }));
+    }
+    if bwb_ids.len() > MAX_STATUS_IDS {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!("too many bwb_ids: maximum is {MAX_STATUS_IDS}"),
+        ));
+    }
+
+    let rows: Vec<(String, String, Option<String>)> =
+        sqlx::query_as("SELECT law_id, status::text, slug FROM law_entries WHERE law_id = ANY($1)")
+            .bind(&bwb_ids)
+            .fetch_all(pool)
+            .await
+            .map_err(|e| {
+                tracing::error!(error = %e, "failed to query harvest status");
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Failed to query harvest status".to_string(),
+                )
+            })?;
+
+    let results = rows
+        .into_iter()
+        .map(|(law_id, status, slug)| HarvestStatusEntry {
+            bwb_id: law_id,
+            status,
+            slug,
+        })
+        .collect();
+
+    Ok(Json(HarvestStatusResponse { results }))
 }

--- a/packages/editor-api/src/harvest_handlers.rs
+++ b/packages/editor-api/src/harvest_handlers.rs
@@ -58,8 +58,9 @@ pub async fn request_harvest(
             format!("too many law_ids: maximum is {MAX_LAW_IDS}"),
         ));
     }
-    for law_id in &body.law_ids {
-        if law_id.trim().is_empty() || law_id.len() > 256 {
+    let law_ids: Vec<String> = body.law_ids.iter().map(|s| s.trim().to_string()).collect();
+    for law_id in &law_ids {
+        if law_id.is_empty() || law_id.len() > 256 {
             return Err((
                 StatusCode::BAD_REQUEST,
                 "law_ids must be non-empty and at most 256 characters".to_string(),
@@ -70,8 +71,7 @@ pub async fn request_harvest(
     let pool = match &state.pipeline_pool {
         Some(pool) => pool,
         None => {
-            let results = body
-                .law_ids
+            let results = law_ids
                 .into_iter()
                 .map(|law_id| HarvestSlugResult {
                     law_id,
@@ -87,17 +87,17 @@ pub async fn request_harvest(
     // the read lock before doing any DB work.
     let already_available: std::collections::HashSet<String> = {
         let corpus = state.corpus.read().await;
-        body.law_ids
+        law_ids
             .iter()
             .filter(|slug| corpus.source_map.get_law(slug).is_some())
             .cloned()
             .collect()
     };
 
-    let mut results = Vec::with_capacity(body.law_ids.len());
+    let mut results = Vec::with_capacity(law_ids.len());
     let mut seen = std::collections::HashSet::new();
 
-    for slug in &body.law_ids {
+    for slug in &law_ids {
         if !seen.insert(slug) {
             continue; // skip duplicate slugs
         }

--- a/packages/editor-api/src/harvest_handlers.rs
+++ b/packages/editor-api/src/harvest_handlers.rs
@@ -58,6 +58,14 @@ pub async fn request_harvest(
             format!("too many law_ids: maximum is {MAX_LAW_IDS}"),
         ));
     }
+    for law_id in &body.law_ids {
+        if law_id.trim().is_empty() || law_id.len() > 256 {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                "law_ids must be non-empty and at most 256 characters".to_string(),
+            ));
+        }
+    }
 
     let pool = match &state.pipeline_pool {
         Some(pool) => pool,
@@ -131,6 +139,47 @@ async fn find_bwb_id_by_slug(pool: &PgPool, slug: &str) -> Result<Option<String>
             .await?;
 
     Ok(row.map(|(law_id,)| law_id))
+}
+
+// --- BWB-ID-based harvest (used by the BWB search UI) ---
+
+#[derive(Deserialize)]
+pub struct BwbHarvestRequest {
+    pub bwb_id: String,
+}
+
+#[derive(Serialize)]
+pub struct BwbHarvestResponse {
+    pub bwb_id: String,
+    pub status: HarvestStatus,
+}
+
+pub async fn harvest_by_bwb_id(
+    State(state): State<AppState>,
+    Json(body): Json<BwbHarvestRequest>,
+) -> Result<Json<BwbHarvestResponse>, (StatusCode, String)> {
+    if !body.bwb_id.starts_with("BWBR") || body.bwb_id.len() > 20 {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "bwb_id must start with BWBR and be at most 20 characters".to_string(),
+        ));
+    }
+
+    let pool = match &state.pipeline_pool {
+        Some(pool) => pool,
+        None => {
+            return Ok(Json(BwbHarvestResponse {
+                bwb_id: body.bwb_id,
+                status: HarvestStatus::HarvestDisabled,
+            }));
+        }
+    };
+
+    let result = create_harvest_job(pool, &body.bwb_id, &body.bwb_id).await;
+    Ok(Json(BwbHarvestResponse {
+        bwb_id: result.bwb_id.unwrap_or(body.bwb_id),
+        status: result.status,
+    }))
 }
 
 /// Create a high-priority harvest job for a law, with deduplication.

--- a/packages/editor-api/src/harvest_handlers.rs
+++ b/packages/editor-api/src/harvest_handlers.rs
@@ -1,0 +1,204 @@
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::Json;
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+
+use crate::state::AppState;
+
+/// Priority for editor-requested harvest jobs (higher = processed first).
+/// Default pipeline priority is 50, follow-up jobs use 30.
+const EDITOR_HARVEST_PRIORITY: i32 = 80;
+
+#[derive(Deserialize)]
+pub struct HarvestRequest {
+    pub law_ids: Vec<String>,
+}
+
+#[derive(Serialize)]
+pub struct HarvestResponse {
+    pub results: Vec<HarvestSlugResult>,
+}
+
+#[derive(Serialize)]
+pub struct HarvestSlugResult {
+    pub law_id: String,
+    pub status: HarvestStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bwb_id: Option<String>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HarvestStatus {
+    /// Law is already available in the editor corpus.
+    AlreadyAvailable,
+    /// Harvest job created with high priority.
+    Queued,
+    /// A pending or processing harvest job already exists.
+    AlreadyQueued,
+    /// No BWB ID mapping found for this slug.
+    NotFound,
+    /// Pipeline database not configured.
+    HarvestDisabled,
+}
+
+pub async fn request_harvest(
+    State(state): State<AppState>,
+    Json(body): Json<HarvestRequest>,
+) -> Result<Json<HarvestResponse>, (StatusCode, String)> {
+    let corpus = state.corpus.read().await;
+    let pool = match &state.pipeline_pool {
+        Some(pool) => pool,
+        None => {
+            let results = body
+                .law_ids
+                .into_iter()
+                .map(|law_id| HarvestSlugResult {
+                    law_id,
+                    status: HarvestStatus::HarvestDisabled,
+                    bwb_id: None,
+                })
+                .collect();
+            return Ok(Json(HarvestResponse { results }));
+        }
+    };
+
+    let mut results = Vec::with_capacity(body.law_ids.len());
+
+    for slug in &body.law_ids {
+        // Check if law is already in corpus
+        if corpus.source_map.get_law(slug).is_some() {
+            results.push(HarvestSlugResult {
+                law_id: slug.clone(),
+                status: HarvestStatus::AlreadyAvailable,
+                bwb_id: None,
+            });
+            continue;
+        }
+
+        // Look up BWB ID by slug in the pipeline database
+        let result = match find_bwb_id_by_slug(pool, slug).await {
+            Ok(Some(bwb_id)) => create_harvest_job(pool, slug, &bwb_id).await,
+            Ok(None) => HarvestSlugResult {
+                law_id: slug.clone(),
+                status: HarvestStatus::NotFound,
+                bwb_id: None,
+            },
+            Err(e) => {
+                tracing::warn!(error = %e, slug = %slug, "failed to look up slug");
+                HarvestSlugResult {
+                    law_id: slug.clone(),
+                    status: HarvestStatus::NotFound,
+                    bwb_id: None,
+                }
+            }
+        };
+
+        results.push(result);
+    }
+
+    Ok(Json(HarvestResponse { results }))
+}
+
+/// Find a law's BWB ID by its slug in the law_entries table.
+async fn find_bwb_id_by_slug(pool: &PgPool, slug: &str) -> Result<Option<String>, sqlx::Error> {
+    let row: Option<(String,)> =
+        sqlx::query_as("SELECT law_id FROM law_entries WHERE slug = $1 LIMIT 1")
+            .bind(slug)
+            .fetch_optional(pool)
+            .await?;
+
+    Ok(row.map(|(law_id,)| law_id))
+}
+
+/// Create a high-priority harvest job for a law, with deduplication.
+async fn create_harvest_job(pool: &PgPool, slug: &str, bwb_id: &str) -> HarvestSlugResult {
+    // Check for existing pending/processing harvest job
+    let existing: Option<(uuid::Uuid,)> = match sqlx::query_as(
+        "SELECT id FROM jobs \
+         WHERE law_id = $1 AND job_type = 'harvest' AND status IN ('pending', 'processing') \
+         LIMIT 1",
+    )
+    .bind(bwb_id)
+    .fetch_optional(pool)
+    .await
+    {
+        Ok(row) => row,
+        Err(e) => {
+            tracing::warn!(error = %e, bwb_id = %bwb_id, "failed to check existing jobs");
+            return HarvestSlugResult {
+                law_id: slug.to_string(),
+                status: HarvestStatus::NotFound,
+                bwb_id: Some(bwb_id.to_string()),
+            };
+        }
+    };
+
+    if existing.is_some() {
+        return HarvestSlugResult {
+            law_id: slug.to_string(),
+            status: HarvestStatus::AlreadyQueued,
+            bwb_id: Some(bwb_id.to_string()),
+        };
+    }
+
+    // Create the harvest job with high priority
+    let payload = serde_json::json!({
+        "bwb_id": bwb_id,
+    });
+
+    let result = sqlx::query_scalar::<_, uuid::Uuid>(
+        "INSERT INTO jobs (id, job_type, law_id, status, priority, payload) \
+         VALUES (gen_random_uuid(), 'harvest', $1, 'pending', $2, $3) \
+         RETURNING id",
+    )
+    .bind(bwb_id)
+    .bind(EDITOR_HARVEST_PRIORITY)
+    .bind(&payload)
+    .fetch_one(pool)
+    .await;
+
+    match result {
+        Ok(job_id) => {
+            tracing::info!(
+                job_id = %job_id,
+                slug = %slug,
+                bwb_id = %bwb_id,
+                priority = EDITOR_HARVEST_PRIORITY,
+                "created editor-requested harvest job"
+            );
+
+            // Best-effort: upsert law_entry to 'queued' and link job
+            let _ = sqlx::query(
+                "INSERT INTO law_entries (law_id, status) \
+                 VALUES ($1, 'queued') \
+                 ON CONFLICT (law_id) DO UPDATE SET status = 'queued', updated_at = NOW() \
+                 WHERE law_entries.status NOT IN ('harvesting', 'enriching')",
+            )
+            .bind(bwb_id)
+            .execute(pool)
+            .await;
+
+            let _ = sqlx::query("UPDATE law_entries SET harvest_job_id = $2 WHERE law_id = $1")
+                .bind(bwb_id)
+                .bind(job_id)
+                .execute(pool)
+                .await;
+
+            HarvestSlugResult {
+                law_id: slug.to_string(),
+                status: HarvestStatus::Queued,
+                bwb_id: Some(bwb_id.to_string()),
+            }
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, bwb_id = %bwb_id, "failed to create harvest job");
+            HarvestSlugResult {
+                law_id: slug.to_string(),
+                status: HarvestStatus::NotFound,
+                bwb_id: Some(bwb_id.to_string()),
+            }
+        }
+    }
+}

--- a/packages/editor-api/src/harvest_handlers.rs
+++ b/packages/editor-api/src/harvest_handlers.rs
@@ -10,6 +10,9 @@ use crate::state::AppState;
 /// Default pipeline priority is 50, follow-up jobs use 30.
 const EDITOR_HARVEST_PRIORITY: i32 = 80;
 
+/// Maximum number of law IDs per harvest request.
+const MAX_LAW_IDS: usize = 100;
+
 #[derive(Deserialize)]
 pub struct HarvestRequest {
     pub law_ids: Vec<String>,
@@ -39,6 +42,8 @@ pub enum HarvestStatus {
     AlreadyQueued,
     /// No BWB ID mapping found for this slug.
     NotFound,
+    /// An internal error occurred while processing the request.
+    Error,
     /// Pipeline database not configured.
     HarvestDisabled,
 }
@@ -47,7 +52,13 @@ pub async fn request_harvest(
     State(state): State<AppState>,
     Json(body): Json<HarvestRequest>,
 ) -> Result<Json<HarvestResponse>, (StatusCode, String)> {
-    let corpus = state.corpus.read().await;
+    if body.law_ids.len() > MAX_LAW_IDS {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!("too many law_ids: maximum is {MAX_LAW_IDS}"),
+        ));
+    }
+
     let pool = match &state.pipeline_pool {
         Some(pool) => pool,
         None => {
@@ -64,11 +75,21 @@ pub async fn request_harvest(
         }
     };
 
+    // Check which slugs are already available in the corpus, then release
+    // the read lock before doing any DB work.
+    let already_available: std::collections::HashSet<String> = {
+        let corpus = state.corpus.read().await;
+        body.law_ids
+            .iter()
+            .filter(|slug| corpus.source_map.get_law(slug).is_some())
+            .cloned()
+            .collect()
+    };
+
     let mut results = Vec::with_capacity(body.law_ids.len());
 
     for slug in &body.law_ids {
-        // Check if law is already in corpus
-        if corpus.source_map.get_law(slug).is_some() {
+        if already_available.contains(slug) {
             results.push(HarvestSlugResult {
                 law_id: slug.clone(),
                 status: HarvestStatus::AlreadyAvailable,
@@ -113,54 +134,32 @@ async fn find_bwb_id_by_slug(pool: &PgPool, slug: &str) -> Result<Option<String>
 }
 
 /// Create a high-priority harvest job for a law, with deduplication.
+///
+/// Uses `INSERT ... ON CONFLICT DO NOTHING` against the partial unique index
+/// `idx_unique_active_harvest_job` to atomically deduplicate. If the insert
+/// returns no rows, a pending/processing job already exists.
 async fn create_harvest_job(pool: &PgPool, slug: &str, bwb_id: &str) -> HarvestSlugResult {
-    // Check for existing pending/processing harvest job
-    let existing: Option<(uuid::Uuid,)> = match sqlx::query_as(
-        "SELECT id FROM jobs \
-         WHERE law_id = $1 AND job_type = 'harvest' AND status IN ('pending', 'processing') \
-         LIMIT 1",
-    )
-    .bind(bwb_id)
-    .fetch_optional(pool)
-    .await
-    {
-        Ok(row) => row,
-        Err(e) => {
-            tracing::warn!(error = %e, bwb_id = %bwb_id, "failed to check existing jobs");
-            return HarvestSlugResult {
-                law_id: slug.to_string(),
-                status: HarvestStatus::NotFound,
-                bwb_id: Some(bwb_id.to_string()),
-            };
-        }
-    };
-
-    if existing.is_some() {
-        return HarvestSlugResult {
-            law_id: slug.to_string(),
-            status: HarvestStatus::AlreadyQueued,
-            bwb_id: Some(bwb_id.to_string()),
-        };
-    }
-
-    // Create the harvest job with high priority
     let payload = serde_json::json!({
         "bwb_id": bwb_id,
     });
 
+    // Atomic insert-or-skip: the partial unique index on (law_id, job_type)
+    // WHERE job_type = 'harvest' AND status IN ('pending', 'processing')
+    // prevents duplicates without a separate SELECT.
     let result = sqlx::query_scalar::<_, uuid::Uuid>(
         "INSERT INTO jobs (id, job_type, law_id, status, priority, payload) \
          VALUES (gen_random_uuid(), 'harvest', $1, 'pending', $2, $3) \
+         ON CONFLICT DO NOTHING \
          RETURNING id",
     )
     .bind(bwb_id)
     .bind(EDITOR_HARVEST_PRIORITY)
     .bind(&payload)
-    .fetch_one(pool)
+    .fetch_optional(pool)
     .await;
 
     match result {
-        Ok(job_id) => {
+        Ok(Some(job_id)) => {
             tracing::info!(
                 job_id = %job_id,
                 slug = %slug,
@@ -192,11 +191,19 @@ async fn create_harvest_job(pool: &PgPool, slug: &str, bwb_id: &str) -> HarvestS
                 bwb_id: Some(bwb_id.to_string()),
             }
         }
-        Err(e) => {
-            tracing::warn!(error = %e, bwb_id = %bwb_id, "failed to create harvest job");
+        Ok(None) => {
+            // ON CONFLICT DO NOTHING returned no rows — an active job exists.
             HarvestSlugResult {
                 law_id: slug.to_string(),
-                status: HarvestStatus::NotFound,
+                status: HarvestStatus::AlreadyQueued,
+                bwb_id: Some(bwb_id.to_string()),
+            }
+        }
+        Err(e) => {
+            tracing::error!(error = %e, bwb_id = %bwb_id, "failed to create harvest job");
+            HarvestSlugResult {
+                law_id: slug.to_string(),
+                status: HarvestStatus::Error,
                 bwb_id: Some(bwb_id.to_string()),
             }
         }

--- a/packages/editor-api/src/harvest_handlers.rs
+++ b/packages/editor-api/src/harvest_handlers.rs
@@ -173,7 +173,7 @@ async fn create_harvest_job(pool: &PgPool, slug: &str, bwb_id: &str) -> HarvestS
                 "INSERT INTO law_entries (law_id, status) \
                  VALUES ($1, 'queued') \
                  ON CONFLICT (law_id) DO UPDATE SET status = 'queued', updated_at = NOW() \
-                 WHERE law_entries.status NOT IN ('harvesting', 'enriching')",
+                 WHERE law_entries.status NOT IN ('harvesting', 'enriching', 'harvested', 'enriched')",
             )
             .bind(bwb_id)
             .execute(pool)

--- a/packages/editor-api/src/harvest_handlers.rs
+++ b/packages/editor-api/src/harvest_handlers.rs
@@ -149,7 +149,9 @@ async fn create_harvest_job(pool: &PgPool, slug: &str, bwb_id: &str) -> HarvestS
     let result = sqlx::query_scalar::<_, uuid::Uuid>(
         "INSERT INTO jobs (id, job_type, law_id, status, priority, payload) \
          VALUES (gen_random_uuid(), 'harvest', $1, 'pending', $2, $3) \
-         ON CONFLICT DO NOTHING \
+         ON CONFLICT (law_id, job_type) \
+             WHERE job_type = 'harvest' AND status IN ('pending', 'processing') \
+             DO NOTHING \
          RETURNING id",
     )
     .bind(bwb_id)

--- a/packages/editor-api/src/harvest_handlers.rs
+++ b/packages/editor-api/src/harvest_handlers.rs
@@ -107,10 +107,10 @@ pub async fn request_harvest(
                 bwb_id: None,
             },
             Err(e) => {
-                tracing::warn!(error = %e, slug = %slug, "failed to look up slug");
+                tracing::error!(error = %e, slug = %slug, "failed to look up slug");
                 HarvestSlugResult {
                     law_id: slug.clone(),
-                    status: HarvestStatus::NotFound,
+                    status: HarvestStatus::Error,
                     bwb_id: None,
                 }
             }

--- a/packages/editor-api/src/harvest_handlers.rs
+++ b/packages/editor-api/src/harvest_handlers.rs
@@ -95,8 +95,12 @@ pub async fn request_harvest(
     };
 
     let mut results = Vec::with_capacity(body.law_ids.len());
+    let mut seen = std::collections::HashSet::new();
 
     for slug in &body.law_ids {
+        if !seen.insert(slug) {
+            continue; // skip duplicate slugs
+        }
         if already_available.contains(slug) {
             results.push(HarvestSlugResult {
                 law_id: slug.clone(),

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -142,7 +142,9 @@ async fn main() {
             .route(
                 "/api/bwb/harvest",
                 post(harvest_handlers::harvest_by_bwb_id),
-            );
+            )
+            .route("/api/harvest-status", get(harvest_handlers::harvest_status))
+            .route("/api/corpus/reload", post(corpus_handlers::reload_corpus));
     }
 
     let protected_api_routes =

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -6,6 +6,8 @@ use std::sync::Arc;
 
 use axum::middleware as axum_middleware;
 use axum::routing::get;
+#[cfg(feature = "pipeline")]
+use axum::routing::post;
 use axum::Router;
 use tokio::sync::{Mutex, RwLock};
 use tower_http::services::{ServeDir, ServeFile};
@@ -19,6 +21,8 @@ use tracing_subscriber::EnvFilter;
 
 mod config;
 mod corpus_handlers;
+#[cfg(feature = "pipeline")]
+mod harvest_handlers;
 mod middleware;
 mod state;
 
@@ -61,12 +65,17 @@ async fn main() {
     let static_dir = env::var("STATIC_DIR").unwrap_or_else(|_| "static".to_string());
     let corpus_state = init_corpus(&static_dir).await;
 
+    #[cfg(feature = "pipeline")]
+    let pipeline_pool = init_pipeline_pool().await;
+
     let app_state = AppState {
         corpus: Arc::new(RwLock::new(corpus_state)),
         oidc_client,
         end_session_url,
         config: Arc::new(app_config),
         http_client,
+        #[cfg(feature = "pipeline")]
+        pipeline_pool,
     };
 
     let index_file = PathBuf::from(&static_dir).join("index.html");
@@ -108,7 +117,7 @@ async fn main() {
     // but federated regulations can reach a few hundred KiB. A 5 MiB cap
     // gives ample headroom while still rejecting pathological bodies.
     const MAX_LAW_BODY: usize = 5 * 1024 * 1024;
-    let protected_api_routes = Router::new()
+    let mut protected_api_routes = Router::new()
         .route(
             "/api/corpus/laws/{law_id}/scenarios/{filename}",
             axum::routing::put(corpus_handlers::save_scenario)
@@ -119,11 +128,20 @@ async fn main() {
             "/api/corpus/laws/{law_id}",
             axum::routing::put(corpus_handlers::save_law)
                 .layer(axum::extract::DefaultBodyLimit::max(MAX_LAW_BODY)),
-        )
-        .route_layer(axum_middleware::from_fn_with_state(
-            app_state.clone(),
-            middleware::require_session_auth::<AppState>,
-        ));
+        );
+
+    #[cfg(feature = "pipeline")]
+    {
+        protected_api_routes = protected_api_routes.route(
+            "/api/corpus/request-harvest",
+            post(harvest_handlers::request_harvest),
+        );
+    }
+
+    let protected_api_routes = protected_api_routes.route_layer(axum_middleware::from_fn_with_state(
+        app_state.clone(),
+        middleware::require_session_auth::<AppState>,
+    ));
 
     // --- Build app with session layer ---
     // SessionManagerLayer is generic over the store type, so we build the
@@ -241,6 +259,35 @@ async fn serve(
     } else if let Err(e) = axum::serve(listener, app).await {
         tracing::error!(error = %e, "server error");
         std::process::exit(1);
+    }
+}
+
+/// Optionally connect to the pipeline database for harvest request support.
+/// Returns `None` if `DATABASE_URL` is not set.
+#[cfg(feature = "pipeline")]
+async fn init_pipeline_pool() -> Option<sqlx::PgPool> {
+    let database_url = match env::var("DATABASE_URL") {
+        Ok(url) => url,
+        Err(_) => {
+            tracing::info!("DATABASE_URL not set — harvest request endpoint disabled");
+            return None;
+        }
+    };
+
+    match sqlx::postgres::PgPoolOptions::new()
+        .max_connections(3)
+        .acquire_timeout(std::time::Duration::from_secs(10))
+        .connect(&database_url)
+        .await
+    {
+        Ok(pool) => {
+            tracing::info!("connected to pipeline database — harvest requests enabled");
+            Some(pool)
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to connect to pipeline database — harvest requests disabled");
+            None
+        }
     }
 }
 

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -138,32 +138,45 @@ async fn main() {
         );
     }
 
-    let protected_api_routes = protected_api_routes.route_layer(axum_middleware::from_fn_with_state(
-        app_state.clone(),
-        middleware::require_session_auth::<AppState>,
-    ));
+    let protected_api_routes =
+        protected_api_routes.route_layer(axum_middleware::from_fn_with_state(
+            app_state.clone(),
+            middleware::require_session_auth::<AppState>,
+        ));
 
     // --- Build app with session layer ---
     // SessionManagerLayer is generic over the store type, so we build the
     // router in two branches depending on whether auth is enabled.
     if app_state.config.is_auth_enabled() {
-        let database_url = env::var("DATABASE_URL")
-            .or_else(|_| env::var("DATABASE_SERVER_FULL"))
-            .unwrap_or_else(|_| {
-                tracing::error!(
-                    "DATABASE_URL is required when OIDC is enabled (for session storage)"
-                );
-                std::process::exit(1);
-            });
+        // Reuse the pipeline pool for session storage when available,
+        // avoiding a duplicate connection pool to the same database.
+        #[cfg(feature = "pipeline")]
+        let session_pool = app_state.pipeline_pool.clone();
+        #[cfg(not(feature = "pipeline"))]
+        let session_pool: Option<sqlx::PgPool> = None;
 
-        let pool = sqlx::postgres::PgPoolOptions::new()
-            .max_connections(5)
-            .connect(&database_url)
-            .await
-            .unwrap_or_else(|e| {
-                tracing::error!(error = %e, "failed to connect to database");
-                std::process::exit(1);
-            });
+        let pool = match session_pool {
+            Some(pool) => pool,
+            None => {
+                let database_url = env::var("DATABASE_URL")
+                    .or_else(|_| env::var("DATABASE_SERVER_FULL"))
+                    .unwrap_or_else(|_| {
+                        tracing::error!(
+                            "DATABASE_URL is required when OIDC is enabled (for session storage)"
+                        );
+                        std::process::exit(1);
+                    });
+
+                sqlx::postgres::PgPoolOptions::new()
+                    .max_connections(5)
+                    .connect(&database_url)
+                    .await
+                    .unwrap_or_else(|e| {
+                        tracing::error!(error = %e, "failed to connect to database");
+                        std::process::exit(1);
+                    })
+            }
+        };
 
         let session_store = PostgresStore::new(pool);
         if let Err(e) = session_store.migrate().await {

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -19,6 +19,7 @@ use tower_sessions_memory_store::MemoryStore;
 use tower_sessions_sqlx_store::PostgresStore;
 use tracing_subscriber::EnvFilter;
 
+mod bwb_search;
 mod config;
 mod corpus_handlers;
 #[cfg(feature = "pipeline")]
@@ -102,7 +103,8 @@ async fn main() {
         .route(
             "/api/corpus/laws/{law_id}/scenarios/{filename}",
             get(corpus_handlers::get_scenario),
-        );
+        )
+        .route("/api/bwb/search", get(bwb_search::search_bwb));
 
     // Protected API routes — require authentication when OIDC is enabled.
     // Write endpoints (PUT/DELETE) for scenarios live here so they cannot be
@@ -132,10 +134,15 @@ async fn main() {
 
     #[cfg(feature = "pipeline")]
     {
-        protected_api_routes = protected_api_routes.route(
-            "/api/corpus/request-harvest",
-            post(harvest_handlers::request_harvest),
-        );
+        protected_api_routes = protected_api_routes
+            .route(
+                "/api/corpus/request-harvest",
+                post(harvest_handlers::request_harvest),
+            )
+            .route(
+                "/api/bwb/harvest",
+                post(harvest_handlers::harvest_by_bwb_id),
+            );
     }
 
     let protected_api_routes =
@@ -279,7 +286,8 @@ async fn serve(
 /// Returns `None` if `DATABASE_URL` is not set.
 #[cfg(feature = "pipeline")]
 async fn init_pipeline_pool() -> Option<sqlx::PgPool> {
-    let database_url = match env::var("DATABASE_URL") {
+    let database_url = match env::var("DATABASE_URL").or_else(|_| env::var("DATABASE_SERVER_FULL"))
+    {
         Ok(url) => url,
         Err(_) => {
             tracing::info!("DATABASE_URL not set — harvest request endpoint disabled");

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -103,8 +103,7 @@ async fn main() {
         .route(
             "/api/corpus/laws/{law_id}/scenarios/{filename}",
             get(corpus_handlers::get_scenario),
-        )
-        .route("/api/bwb/search", get(bwb_search::search_bwb));
+        );
 
     // Protected API routes — require authentication when OIDC is enabled.
     // Write endpoints (PUT/DELETE) for scenarios live here so they cannot be
@@ -130,7 +129,8 @@ async fn main() {
             "/api/corpus/laws/{law_id}",
             axum::routing::put(corpus_handlers::save_law)
                 .layer(axum::extract::DefaultBodyLimit::max(MAX_LAW_BODY)),
-        );
+        )
+        .route("/api/bwb/search", get(bwb_search::search_bwb));
 
     #[cfg(feature = "pipeline")]
     {
@@ -296,7 +296,7 @@ async fn init_pipeline_pool() -> Option<sqlx::PgPool> {
     };
 
     match sqlx::postgres::PgPoolOptions::new()
-        .max_connections(3)
+        .max_connections(5)
         .acquire_timeout(std::time::Duration::from_secs(10))
         .connect(&database_url)
         .await

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -375,6 +375,7 @@ async fn init_corpus(static_dir: &str) -> CorpusState {
         registry,
         source_map,
         backends,
+        auth_file: auth_file.map(|p| p.to_path_buf()),
     }
 }
 

--- a/packages/editor-api/src/state.rs
+++ b/packages/editor-api/src/state.rs
@@ -16,6 +16,9 @@ pub struct AppState {
     pub end_session_url: Option<String>,
     pub config: Arc<AppConfig>,
     pub http_client: reqwest::Client,
+    /// Optional connection to the pipeline database for harvest requests.
+    #[cfg(feature = "pipeline")]
+    pub pipeline_pool: Option<sqlx::PgPool>,
 }
 
 impl OidcAppState for AppState {

--- a/packages/editor-api/src/state.rs
+++ b/packages/editor-api/src/state.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use regelrecht_auth::{ConfiguredClient, OidcAppState, OidcConfig};
@@ -59,6 +60,10 @@ pub struct CorpusState {
     /// the same abstraction as writes — preventing read/write path
     /// mismatches when a fallback writable backend is used.
     pub backends: HashMap<String, BackendEntry>,
+    /// Path to the corpus-auth.yaml file for GitHub source authentication.
+    /// Stored here so that `reload_corpus` can refetch from GitHub sources
+    /// without restarting the server.
+    pub auth_file: Option<PathBuf>,
 }
 
 impl CorpusState {
@@ -68,6 +73,7 @@ impl CorpusState {
             registry: regelrecht_corpus::CorpusRegistry::empty(),
             source_map: SourceMap::new(),
             backends: HashMap::new(),
+            auth_file: None,
         }
     }
 }

--- a/packages/pipeline/migrations/0008_add_law_slug.sql
+++ b/packages/pipeline/migrations/0008_add_law_slug.sql
@@ -1,0 +1,5 @@
+-- Add slug column to law_entries for reverse lookup (slug → bwb_id).
+-- The editor knows laws by their slug ($id like "participatiewet") but the
+-- harvester needs the BWB ID. This column bridges that gap.
+ALTER TABLE law_entries ADD COLUMN slug TEXT;
+CREATE INDEX idx_law_entries_slug ON law_entries (slug) WHERE slug IS NOT NULL;

--- a/packages/pipeline/migrations/0009_unique_active_harvest_jobs.sql
+++ b/packages/pipeline/migrations/0009_unique_active_harvest_jobs.sql
@@ -2,6 +2,6 @@
 -- This closes the TOCTOU race where concurrent harvest requests
 -- could both create a harvest job for the same law.
 -- Mirrors 0003_unique_active_enrich_jobs.sql for harvest jobs.
-CREATE UNIQUE INDEX IF NOT EXISTS idx_unique_active_harvest_job
+CREATE UNIQUE INDEX idx_unique_active_harvest_job
     ON jobs (law_id, job_type)
     WHERE job_type = 'harvest' AND status IN ('pending', 'processing');

--- a/packages/pipeline/migrations/0009_unique_active_harvest_jobs.sql
+++ b/packages/pipeline/migrations/0009_unique_active_harvest_jobs.sql
@@ -2,6 +2,6 @@
 -- This closes the TOCTOU race where concurrent harvest requests
 -- could both create a harvest job for the same law.
 -- Mirrors 0003_unique_active_enrich_jobs.sql for harvest jobs.
-CREATE UNIQUE INDEX idx_unique_active_harvest_job
+CREATE UNIQUE INDEX IF NOT EXISTS idx_unique_active_harvest_job
     ON jobs (law_id, job_type)
     WHERE job_type = 'harvest' AND status IN ('pending', 'processing');

--- a/packages/pipeline/migrations/0009_unique_active_harvest_jobs.sql
+++ b/packages/pipeline/migrations/0009_unique_active_harvest_jobs.sql
@@ -1,0 +1,7 @@
+-- Prevent duplicate active harvest jobs per law.
+-- This closes the TOCTOU race where concurrent harvest requests
+-- could both create a harvest job for the same law.
+-- Mirrors 0003_unique_active_enrich_jobs.sql for harvest jobs.
+CREATE UNIQUE INDEX idx_unique_active_harvest_job
+    ON jobs (law_id, job_type)
+    WHERE job_type = 'harvest' AND status IN ('pending', 'processing');

--- a/packages/pipeline/src/law_status.rs
+++ b/packages/pipeline/src/law_status.rs
@@ -222,19 +222,6 @@ where
     Ok(entry)
 }
 
-/// Find a law entry by its slug ($id). Returns `None` if no law with that slug exists.
-pub async fn find_law_by_slug<'e, E>(executor: E, slug: &str) -> Result<Option<LawEntry>>
-where
-    E: sqlx::PgExecutor<'e>,
-{
-    let entry = sqlx::query_as::<_, LawEntry>(r#"SELECT * FROM law_entries WHERE slug = $1"#)
-        .bind(slug)
-        .fetch_optional(executor)
-        .await?;
-
-    Ok(entry)
-}
-
 /// List all law entries, optionally filtered by status.
 pub async fn list_laws<'e, E>(executor: E, status: Option<LawStatusValue>) -> Result<Vec<LawEntry>>
 where

--- a/packages/pipeline/src/law_status.rs
+++ b/packages/pipeline/src/law_status.rs
@@ -3,26 +3,30 @@ use uuid::Uuid;
 use crate::error::{PipelineError, Result};
 use crate::models::{LawEntry, LawStatusValue};
 
-/// Upsert a law entry. Creates it if it doesn't exist, updates name if it does.
+/// Upsert a law entry. Creates it if it doesn't exist, updates name/slug if it does.
 #[tracing::instrument(skip(executor))]
 pub async fn upsert_law<'e, E>(
     executor: E,
     law_id: &str,
     law_name: Option<&str>,
+    slug: Option<&str>,
 ) -> Result<LawEntry>
 where
     E: sqlx::PgExecutor<'e>,
 {
     let entry = sqlx::query_as::<_, LawEntry>(
         r#"
-        INSERT INTO law_entries (law_id, law_name)
-        VALUES ($1, $2)
-        ON CONFLICT (law_id) DO UPDATE SET law_name = COALESCE($2, law_entries.law_name)
+        INSERT INTO law_entries (law_id, law_name, slug)
+        VALUES ($1, $2, $3)
+        ON CONFLICT (law_id) DO UPDATE SET
+            law_name = COALESCE($2, law_entries.law_name),
+            slug = COALESCE($3, law_entries.slug)
         RETURNING *
         "#,
     )
     .bind(law_id)
     .bind(law_name)
+    .bind(slug)
     .fetch_one(executor)
     .await?;
 
@@ -214,6 +218,19 @@ where
         .fetch_optional(executor)
         .await?
         .ok_or_else(|| PipelineError::LawNotFound(law_id.to_string()))?;
+
+    Ok(entry)
+}
+
+/// Find a law entry by its slug ($id). Returns `None` if no law with that slug exists.
+pub async fn find_law_by_slug<'e, E>(executor: E, slug: &str) -> Result<Option<LawEntry>>
+where
+    E: sqlx::PgExecutor<'e>,
+{
+    let entry = sqlx::query_as::<_, LawEntry>(r#"SELECT * FROM law_entries WHERE slug = $1"#)
+        .bind(slug)
+        .fetch_optional(executor)
+        .await?;
 
     Ok(entry)
 }

--- a/packages/pipeline/src/models.rs
+++ b/packages/pipeline/src/models.rs
@@ -109,6 +109,7 @@ pub struct Job {
 pub struct LawEntry {
     pub law_id: String,
     pub law_name: Option<String>,
+    pub slug: Option<String>,
     pub status: LawStatusValue,
     pub harvest_job_id: Option<Uuid>,
     pub enrich_job_id: Option<Uuid>,

--- a/packages/pipeline/src/worker.rs
+++ b/packages/pipeline/src/worker.rs
@@ -191,7 +191,7 @@ async fn process_next_job(
                 tracing::warn!(error = %e, law_id = %job.law_id, "failed to reset harvest fail count after success");
             }
 
-            // Always store slug; update law_name if not yet set.
+            // Always store slug and refresh law_name from latest harvest.
             if let Err(e) = law_status::upsert_law(
                 pool,
                 &job.law_id,

--- a/packages/pipeline/src/worker.rs
+++ b/packages/pipeline/src/worker.rs
@@ -152,7 +152,7 @@ async fn process_next_job(
         },
     };
 
-    if let Err(e) = law_status::upsert_law(pool, &job.law_id, None).await {
+    if let Err(e) = law_status::upsert_law(pool, &job.law_id, None, None).await {
         tracing::warn!(error = %e, law_id = %job.law_id, "failed to upsert law entry before harvest");
     }
     if let Err(e) = law_status::update_status(pool, &job.law_id, LawStatusValue::Harvesting).await {
@@ -191,14 +191,16 @@ async fn process_next_job(
                 tracing::warn!(error = %e, law_id = %job.law_id, "failed to reset harvest fail count after success");
             }
 
-            if let Ok(entry) = law_status::get_law(pool, &job.law_id).await {
-                if entry.law_name.is_none() {
-                    if let Err(e) =
-                        law_status::upsert_law(pool, &job.law_id, Some(&result.law_name)).await
-                    {
-                        tracing::warn!(error = %e, law_id = %job.law_id, "failed to upsert law name");
-                    }
-                }
+            // Always store slug; update law_name if not yet set.
+            if let Err(e) = law_status::upsert_law(
+                pool,
+                &job.law_id,
+                Some(&result.law_name),
+                Some(&result.slug),
+            )
+            .await
+            {
+                tracing::warn!(error = %e, law_id = %job.law_id, "failed to upsert law name/slug");
             }
 
             // Auto-create enrich jobs after successful harvest — one per provider.

--- a/packages/pipeline/tests/law_status_tests.rs
+++ b/packages/pipeline/tests/law_status_tests.rs
@@ -41,6 +41,28 @@ async fn test_upsert_law_without_name() {
 }
 
 #[tokio::test]
+async fn test_upsert_law_slug_preserved() {
+    let db = common::TestDb::new().await;
+
+    let entry = law_status::upsert_law(&db.pool, "slug_law", Some("Slug Law"), Some("slug_law"))
+        .await
+        .unwrap();
+    assert_eq!(entry.slug, Some("slug_law".to_string()));
+
+    // Upserting with None slug should preserve the original
+    let entry = law_status::upsert_law(&db.pool, "slug_law", None, None)
+        .await
+        .unwrap();
+    assert_eq!(entry.slug, Some("slug_law".to_string()));
+
+    // Upserting with a new slug should update it
+    let entry = law_status::upsert_law(&db.pool, "slug_law", None, Some("new_slug"))
+        .await
+        .unwrap();
+    assert_eq!(entry.slug, Some("new_slug".to_string()));
+}
+
+#[tokio::test]
 async fn test_update_status() {
     let db = common::TestDb::new().await;
 

--- a/packages/pipeline/tests/law_status_tests.rs
+++ b/packages/pipeline/tests/law_status_tests.rs
@@ -10,7 +10,7 @@ use regelrecht_pipeline::models::{JobType, LawStatusValue};
 async fn test_upsert_law() {
     let db = common::TestDb::new().await;
 
-    let entry = law_status::upsert_law(&db.pool, "zorgtoeslagwet", Some("Zorgtoeslagwet"))
+    let entry = law_status::upsert_law(&db.pool, "zorgtoeslagwet", Some("Zorgtoeslagwet"), None)
         .await
         .unwrap();
 
@@ -19,9 +19,10 @@ async fn test_upsert_law() {
     assert_eq!(entry.status, LawStatusValue::Unknown);
     assert!(entry.coverage_score.is_none());
 
-    let updated = law_status::upsert_law(&db.pool, "zorgtoeslagwet", Some("Zorgtoeslagwet v2"))
-        .await
-        .unwrap();
+    let updated =
+        law_status::upsert_law(&db.pool, "zorgtoeslagwet", Some("Zorgtoeslagwet v2"), None)
+            .await
+            .unwrap();
     assert_eq!(updated.law_name, Some("Zorgtoeslagwet v2".to_string()));
 }
 
@@ -29,11 +30,11 @@ async fn test_upsert_law() {
 async fn test_upsert_law_without_name() {
     let db = common::TestDb::new().await;
 
-    law_status::upsert_law(&db.pool, "test_law", Some("Test Law"))
+    law_status::upsert_law(&db.pool, "test_law", Some("Test Law"), None)
         .await
         .unwrap();
 
-    let entry = law_status::upsert_law(&db.pool, "test_law", None)
+    let entry = law_status::upsert_law(&db.pool, "test_law", None, None)
         .await
         .unwrap();
     assert_eq!(entry.law_name, Some("Test Law".to_string()));
@@ -43,7 +44,7 @@ async fn test_upsert_law_without_name() {
 async fn test_update_status() {
     let db = common::TestDb::new().await;
 
-    law_status::upsert_law(&db.pool, "test_law", None)
+    law_status::upsert_law(&db.pool, "test_law", None, None)
         .await
         .unwrap();
 
@@ -70,7 +71,7 @@ async fn test_update_status_not_found() {
 async fn test_set_job_links() {
     let db = common::TestDb::new().await;
 
-    law_status::upsert_law(&db.pool, "test_law", None)
+    law_status::upsert_law(&db.pool, "test_law", None, None)
         .await
         .unwrap();
 
@@ -101,7 +102,7 @@ async fn test_set_job_links() {
 async fn test_set_coverage_score() {
     let db = common::TestDb::new().await;
 
-    law_status::upsert_law(&db.pool, "test_law", None)
+    law_status::upsert_law(&db.pool, "test_law", None, None)
         .await
         .unwrap();
 
@@ -115,7 +116,7 @@ async fn test_set_coverage_score() {
 async fn test_set_coverage_score_validation() {
     let db = common::TestDb::new().await;
 
-    law_status::upsert_law(&db.pool, "test_law", None)
+    law_status::upsert_law(&db.pool, "test_law", None, None)
         .await
         .unwrap();
 
@@ -149,7 +150,7 @@ async fn test_set_coverage_score_validation() {
 async fn test_get_law() {
     let db = common::TestDb::new().await;
 
-    law_status::upsert_law(&db.pool, "zorgtoeslagwet", Some("Zorgtoeslagwet"))
+    law_status::upsert_law(&db.pool, "zorgtoeslagwet", Some("Zorgtoeslagwet"), None)
         .await
         .unwrap();
 
@@ -171,10 +172,10 @@ async fn test_get_law_not_found() {
 async fn test_list_laws() {
     let db = common::TestDb::new().await;
 
-    law_status::upsert_law(&db.pool, "law_a", Some("Law A"))
+    law_status::upsert_law(&db.pool, "law_a", Some("Law A"), None)
         .await
         .unwrap();
-    law_status::upsert_law(&db.pool, "law_b", Some("Law B"))
+    law_status::upsert_law(&db.pool, "law_b", Some("Law B"), None)
         .await
         .unwrap();
 
@@ -208,7 +209,7 @@ async fn test_transaction_atomicity() {
         .await
         .unwrap();
 
-    law_status::upsert_law(&mut *tx, "tx_law", Some("Transaction Law"))
+    law_status::upsert_law(&mut *tx, "tx_law", Some("Transaction Law"), None)
         .await
         .unwrap();
 
@@ -241,7 +242,7 @@ async fn test_transaction_rollback() {
         .await
         .unwrap();
 
-        law_status::upsert_law(&mut *tx, "rollback_law", Some("Should Not Exist"))
+        law_status::upsert_law(&mut *tx, "rollback_law", Some("Should Not Exist"), None)
             .await
             .unwrap();
 


### PR DESCRIPTION
## Summary

- When the editor loads a law and discovers cross-law references not in the corpus, it automatically requests harvesting with high priority (80)
- Adds `slug` column to `law_entries` table for reverse lookup (slug → BWB ID)
- New `POST /api/corpus/request-harvest` endpoint on editor-api (requires optional `DATABASE_URL`)
- Frontend `useDependencies.js` now reports missing deps and shows harvest feedback in progress message

## How it works

1. Editor loads law → `useDependencies` discovers referenced laws
2. Missing deps are collected after loading phase
3. Frontend calls `POST /api/corpus/request-harvest` with missing slugs
4. Editor-api looks up BWB ID by slug in `law_entries`, creates high-priority harvest job
5. User sees progress: "5/7 wetten geladen — 2 ontbrekende wetten aangevraagd"

## Configuration

- `DATABASE_URL` on editor-api enables harvest requests (optional, graceful degradation when not set)
- Pipeline feature flag on editor-api (`pipeline` feature, enabled by default)

## Test plan

- [x] `cargo check --workspace` passes
- [x] `just format` passes
- [x] `just lint` passes
- [x] `just test` passes
- [x] `just pipeline-test` passes
- [ ] Manual test: open editor with law that has missing deps, verify harvest request is sent
- [ ] Verify pipeline integration test with slug column migration