### PR TITLE
fix(frontend): force light mode for demo

### DIFF
--- a/frontend/editor.html
+++ b/frontend/editor.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="nl" style="color-scheme: light dark;">
+<html lang="nl" data-scheme="light" style="color-scheme: light;">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="nl" style="color-scheme: light dark;">
+<html lang="nl" data-scheme="light" style="color-scheme: light;">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
## Summary
- Force light mode on editor and library pages by adding `data-scheme="light"` and changing `color-scheme` to `light` only
- The design system `tokens.css` sets `color-scheme: light dark` on `:root`, which was overriding any inline style preference

## Test plan
- [ ] Verify editor page renders in light mode at the preview URL
- [ ] Verify library page renders in light mode