### PR TITLE
feat(editor): edit → re-execute loop for machine_readable

### DIFF
--- a/frontend/e2e/edit-test-loop.spec.js
+++ b/frontend/e2e/edit-test-loop.spec.js
@@ -275,10 +275,18 @@ test.describe('Edit → re-execute loop', () => {
     });
 
     // Append the age condition to the heeft_recht_op_zorgtoeslag AND.
+    // Assert the action is shaped the way we expect before mutating so a
+    // future refactor (e.g. top-level op change) produces a legible error
+    // instead of a bare `Cannot read properties of undefined` on .push.
     const heeftRecht = mr.execution.actions.find(
       (a) => a.output === 'heeft_recht_op_zorgtoeslag',
     );
     expect(heeftRecht, 'heeft_recht_op_zorgtoeslag action must exist').toBeTruthy();
+    expect(
+      heeftRecht.value?.operation,
+      'heeft_recht action must be an AND at the top level',
+    ).toBe('AND');
+    expect(Array.isArray(heeftRecht.value?.conditions)).toBe(true);
     heeftRecht.value.conditions.push({
       operation: 'GREATER_THAN_OR_EQUAL',
       subject: '$leeftijd',

--- a/frontend/e2e/edit-test-loop.spec.js
+++ b/frontend/e2e/edit-test-loop.spec.js
@@ -1,0 +1,306 @@
+/**
+ * Edit → re-execute loop end-to-end.
+ *
+ * Verifies the demo flow the editor was built for:
+ *   1. Open zorgtoeslagwet in the editor.
+ *   2. Observe the *Minderjarige heeft geen recht op zorgtoeslag* scenario is
+ *      red (badge = ✗) — age check isn't in the law's machine_readable.
+ *   3. Edit article 2's machine_readable via the middle-pane YAML editor to
+ *      add a leeftijd input + an AGE-based condition to the existing AND.
+ *   4. ScenarioBuilder auto-reexecutes against the edited YAML.
+ *   5. Observe the scenario badge is now green (badge = ✓).
+ *
+ * This is the smoke-test for the propagation chain we just wired up:
+ *   machineReadable edit → currentLawYaml computed → engine reload →
+ *   ScenarioBuilder lawYaml prop → dependency reload → auto-execute.
+ *
+ * All corpus laws, the scenarios list, the scenario feature file, and the
+ * PUT save endpoint are mocked from the on-disk corpus directory so the
+ * spec doesn't need a running editor-api. This keeps it CI-friendly and
+ * reproduces the real dependency graph.
+ */
+import { test, expect } from '@playwright/test';
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import yaml from 'js-yaml';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CORPUS_ROOT = resolve(__dirname, '../../corpus/regulation/nl');
+
+/**
+ * Recursively walk a corpus directory and pick one YAML per `$id`,
+ * preferring the latest publication date. Returns a map from law id →
+ * { content: string, path: string }.
+ */
+function loadCorpus(rootDir) {
+  const byId = new Map();
+
+  function visit(dir) {
+    for (const entry of readdirSync(dir)) {
+      const full = resolve(dir, entry);
+      if (statSync(full).isDirectory()) {
+        visit(full);
+      } else if (entry.endsWith('.yaml')) {
+        const content = readFileSync(full, 'utf-8');
+        const idMatch = content.match(/^\$id:\s*['"]?([^'"\n]+)['"]?$/m);
+        if (!idMatch) continue;
+        const lawId = idMatch[1].trim();
+        const pubMatch = content.match(/^publication_date:\s*['"]?([^'"\n]+)['"]?$/m);
+        const pubDate = pubMatch ? pubMatch[1].trim() : '';
+        const existing = byId.get(lawId);
+        if (!existing || pubDate > existing.pubDate) {
+          byId.set(lawId, { content, path: full, pubDate });
+        }
+      }
+    }
+  }
+
+  visit(rootDir);
+  return byId;
+}
+
+/**
+ * Find the scenario file for a law. Returns the raw `.feature` text or null.
+ */
+function loadScenario(lawPath, filename) {
+  const scenariosDir = resolve(dirname(lawPath), 'scenarios');
+  try {
+    return readFileSync(resolve(scenariosDir, filename), 'utf-8');
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Set up route intercepts so the editor can fetch any law in the corpus
+ * without a running editor-api. Also stubs the scenarios list/get and the
+ * PUT save endpoint.
+ */
+async function mockCorpusApi(page, corpus, scenarioLaw, scenarioFile) {
+  // GET /api/corpus/laws — list for dependency discovery
+  await page.route('**/api/corpus/laws*', (route, request) => {
+    const url = new URL(request.url());
+    // /api/corpus/laws/{id}... handled below
+    if (url.pathname !== '/api/corpus/laws') {
+      return route.fallback();
+    }
+    const entries = [...corpus.entries()].map(([law_id]) => ({
+      law_id,
+      name: null,
+      source_id: 'local',
+      source_name: 'Local Test Corpus',
+    }));
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(entries),
+    });
+  });
+
+  // PUT /api/corpus/laws/{law_id} — save endpoint. We no-op because the
+  // frontend's useLaw.saveLaw() already updates rawYaml locally on success.
+  // GET /api/corpus/laws/{law_id} — serve from corpus map
+  await page.route('**/api/corpus/laws/*', (route, request) => {
+    const url = new URL(request.url());
+    const pathname = url.pathname;
+    // Skip scenario sub-paths — separate handler below.
+    if (pathname.includes('/scenarios')) {
+      return route.fallback();
+    }
+    const lawId = decodeURIComponent(pathname.split('/').pop());
+    if (request.method() === 'PUT') {
+      return route.fulfill({ status: 200, body: '' });
+    }
+    const entry = corpus.get(lawId);
+    if (!entry) {
+      return route.fulfill({ status: 404, body: `Law '${lawId}' not found` });
+    }
+    return route.fulfill({
+      status: 200,
+      contentType: 'text/yaml; charset=utf-8',
+      body: entry.content,
+    });
+  });
+
+  // GET /api/corpus/laws/{law_id}/scenarios — list (only for the target law)
+  await page.route('**/api/corpus/laws/*/scenarios', (route, request) => {
+    const url = new URL(request.url());
+    const match = url.pathname.match(/\/api\/corpus\/laws\/([^/]+)\/scenarios$/);
+    if (!match) return route.fallback();
+    const lawId = decodeURIComponent(match[1]);
+    if (lawId === scenarioLaw.id) {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([{ filename: scenarioLaw.scenarioFilename }]),
+      });
+    }
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: '[]',
+    });
+  });
+
+  // GET /api/corpus/laws/{law_id}/scenarios/{filename}
+  await page.route('**/api/corpus/laws/*/scenarios/*', (route, request) => {
+    const url = new URL(request.url());
+    const match = url.pathname.match(/\/api\/corpus\/laws\/([^/]+)\/scenarios\/([^/]+)$/);
+    if (!match) return route.fallback();
+    return route.fulfill({
+      status: 200,
+      contentType: 'text/plain; charset=utf-8',
+      body: scenarioFile,
+    });
+  });
+
+  // /api/sources — corpus source list (used by library page)
+  await page.route('**/api/sources', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        { id: 'local', name: 'Local Test Corpus', source_type: 'local', priority: 1, law_count: corpus.size },
+      ]),
+    }),
+  );
+
+  // /auth/* — OIDC is disabled in tests, return the disabled-state response
+  // the frontend's useAuth expects.
+  await page.route('**/auth/status', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ authenticated: false, oidc_configured: false }),
+    }),
+  );
+}
+
+test.describe('Edit → re-execute loop', () => {
+  test.beforeEach(async ({ page }) => {
+    // Clear localStorage tabs to avoid bleed-over between test runs.
+    await page.addInitScript(() => {
+      try {
+        window.localStorage.removeItem('regelrecht-open-tabs');
+      } catch { /* ignore */ }
+    });
+  });
+
+  test('Minderjarige scenario goes red → green after adding age check', async ({ page }) => {
+    const corpus = loadCorpus(CORPUS_ROOT);
+    const zorgtoeslag = corpus.get('zorgtoeslagwet');
+    expect(zorgtoeslag, 'zorgtoeslagwet must exist in the test corpus').toBeTruthy();
+
+    const scenarioFilename = 'eligibility.feature';
+    const scenarioText = loadScenario(zorgtoeslag.path, scenarioFilename);
+    expect(scenarioText, 'eligibility.feature must exist').toBeTruthy();
+
+    await mockCorpusApi(
+      page,
+      corpus,
+      { id: 'zorgtoeslagwet', scenarioFilename },
+      scenarioText,
+    );
+
+    // Navigate directly to article 2 via the query param — that's where
+    // heeft_recht_op_zorgtoeslag lives and where we need to edit.
+    await page.goto('/editor.html?law=zorgtoeslagwet&article=2');
+
+    // Wait for the document tab bar to render — articles loaded.
+    await page.waitForSelector('ndd-document-tab-bar-item', { timeout: 15_000 });
+
+    const minorHeader = page
+      .locator('.sb-accordion-header')
+      .filter({ hasText: 'Minderjarige' });
+    await expect(minorHeader).toBeVisible({ timeout: 30_000 });
+
+    // Wait until the badge appears (either ✓ or ✗) — meaning execution
+    // completed. The badge span has class sb-badge--pass or sb-badge--fail.
+    await minorHeader
+      .locator('.sb-badge--pass, .sb-badge--fail')
+      .first()
+      .waitFor({ timeout: 30_000 });
+
+    // Initial state: scenario is failed (age check not in the law).
+    await expect(minorHeader).toHaveClass(/sb-header--fail/);
+
+    // Toggle the middle pane to YAML view. ndd-segmented-control-item is
+    // a custom element whose click target lives in shadow DOM, so instead
+    // of clicking we synthesize the change event the way EditorApp's
+    // `onMiddlePaneChange` handler expects: it reads `event.target.value`
+    // first, then falls back to `event.detail[0]`. The first
+    // ndd-segmented-control in the page is the middle pane's form/yaml
+    // toggle (the right pane's result/machine toggle comes after it).
+    await page.locator('ndd-segmented-control').first().evaluate((el) => {
+      el.value = 'yaml';
+      el.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    // Wait for Vue to re-render the YAML pane.
+    await page.waitForSelector('.editor-yaml-textarea', { timeout: 5000 });
+
+    // Grab the current YAML (article 2's machine_readable), parse it,
+    // surgically add the leeftijd input and the AND condition, and write
+    // it back into the textarea.
+    const textarea = page.locator('.editor-yaml-textarea');
+    await expect(textarea).toBeVisible();
+
+    const originalYaml = await textarea.inputValue();
+    expect(originalYaml).toContain('heeft_recht_op_zorgtoeslag');
+    const mr = yaml.load(originalYaml);
+
+    // Inject leeftijd input (sourced from BRP with a literal peildatum).
+    // BRP art 1.2 requires both bsn and peildatum; we use 2025-01-01 so
+    // the scenario's calculation date matches.
+    mr.execution.input.push({
+      name: 'leeftijd',
+      type: 'number',
+      source: {
+        regulation: 'wet_basisregistratie_personen',
+        output: 'leeftijd',
+        parameters: {
+          bsn: '$bsn',
+          peildatum: '2025-01-01',
+        },
+      },
+    });
+
+    // Append the age condition to the heeft_recht_op_zorgtoeslag AND.
+    const heeftRecht = mr.execution.actions.find(
+      (a) => a.output === 'heeft_recht_op_zorgtoeslag',
+    );
+    expect(heeftRecht, 'heeft_recht_op_zorgtoeslag action must exist').toBeTruthy();
+    heeftRecht.value.conditions.push({
+      operation: 'GREATER_THAN_OR_EQUAL',
+      subject: '$leeftijd',
+      value: 18,
+    });
+
+    const editedYaml = yaml.dump(mr, { lineWidth: 80, noRefs: true });
+
+    // Fill the textarea by dispatching an input event; the editor's
+    // onYamlInput handler parses the text and updates machineReadable.
+    await textarea.evaluate((el, val) => {
+      el.value = val;
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    }, editedYaml);
+
+    // Toggle back to the form view so the scenarios accordion mounts
+    // again. The middle pane only shows one of the two views at a time;
+    // remounting ScenarioBuilder kicks off its immediate `lawYaml` watch,
+    // which reloads dependencies against the edited law and re-executes.
+    await page.locator('ndd-segmented-control').first().evaluate((el) => {
+      el.value = 'form';
+      el.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+
+    // Re-execution fires via the currentLawYaml → ScenarioBuilder lawYaml
+    // prop chain. Allow the engine + dependency reload + scenario run to
+    // complete.
+    const minorHeaderAfter = page
+      .locator('.sb-accordion-header')
+      .filter({ hasText: 'Minderjarige' })
+      .first();
+    await expect(minorHeaderAfter).toHaveClass(/sb-header--pass/, { timeout: 60_000 });
+  });
+});

--- a/frontend/e2e/edit-test-loop.spec.js
+++ b/frontend/e2e/edit-test-loop.spec.js
@@ -78,10 +78,13 @@ function loadScenario(lawPath, filename) {
  * PUT save endpoint.
  */
 async function mockCorpusApi(page, corpus, scenarioLaw, scenarioFile) {
-  // GET /api/corpus/laws — list for dependency discovery
+  // GET /api/corpus/laws — list for dependency discovery.
+  // Playwright runs route handlers in reverse registration order (LIFO), so
+  // the more specific `/api/corpus/laws/*` routes below take precedence for
+  // single-law and scenario paths; this bare-list handler only runs when no
+  // later route claims the request.
   await page.route('**/api/corpus/laws*', (route, request) => {
     const url = new URL(request.url());
-    // /api/corpus/laws/{id}... handled below
     if (url.pathname !== '/api/corpus/laws') {
       return route.fallback();
     }
@@ -250,8 +253,14 @@ test.describe('Edit → re-execute loop', () => {
     const mr = yaml.load(originalYaml);
 
     // Inject leeftijd input (sourced from BRP with a literal peildatum).
-    // BRP art 1.2 requires both bsn and peildatum; we use 2025-01-01 so
-    // the scenario's calculation date matches.
+    // BRP art 1.2 requires both bsn and peildatum; we use the scenario's
+    // calculation date as a literal here.
+    //
+    // NOTE: a literal date is intentional for test isolation — the spec must
+    // remain stable regardless of the real calculation date at CI time. The
+    // canonical production pattern (see `kieswet`) references a parameter
+    // like `peildatum: $verkiezingsdatum` so the date tracks the runtime
+    // context; don't copy the literal form into corpus laws.
     mr.execution.input.push({
       name: 'leeftijd',
       type: 'number',

--- a/frontend/e2e/edit-test-loop.spec.js
+++ b/frontend/e2e/edit-test-loop.spec.js
@@ -32,6 +32,15 @@ const CORPUS_ROOT = resolve(__dirname, '../../corpus/regulation/nl');
  * Recursively walk a corpus directory and pick one YAML per `$id`,
  * preferring the latest publication date. Returns a map from law id →
  * { content: string, path: string }.
+ *
+ * NOTE: this picks by `publication_date` (lexicographic compare),
+ * whereas the editor-api's `SourceMap::pick_best_version` selects by
+ * `valid_from` against today's date. The two will agree as long as
+ * each law in the test corpus has only one dated file (the case for
+ * zorgtoeslagwet today). If a future test fixture introduces multiple
+ * dated files for the same `$id`, align this with the server logic
+ * to avoid the spec serving a different version than the editor would
+ * see in production.
  */
 function loadCorpus(rootDir) {
   const byId = new Map();

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -221,6 +221,16 @@ const parsedRawLaw = computed(() => {
 // Only the currently selected article's machine_readable is swapped — edits
 // on other articles are not tracked across tab switches (existing behavior
 // of the editor state model).
+//
+// KNOWN LIMITATION: when this value is sent to `saveLaw` (via the Machine
+// panel save button), the body is the `yaml.dump` output of the
+// reconstructed document — which strips YAML comments and may reorder
+// top-level keys compared to `rawYaml`. The YAML-pane edit path preserves
+// the user's exact text via `yamlSource`, so it does not have this drift.
+// Today's corpus is harvester-generated and comment-free, so the impact is
+// zero in practice; revisit if hand-annotated laws are introduced (e.g.
+// keep an "as-typed" base alongside `rawYaml` and only re-dump the edited
+// article).
 const currentLawYaml = computed(() => {
   if (!rawYaml.value) return null;
   if (!selectedArticle.value || machineReadable.value == null) {

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -251,9 +251,15 @@ watch(
 // Dirty state: the selected article's in-memory machine_readable differs
 // from the article's saved copy. `machineReadable.value` starts as a deep
 // JSON clone of `selectedArticle.machine_readable` (see the `watch` above),
-// so the two share the same key order until the user edits. That makes
-// `JSON.stringify` a cheap and sufficient structural comparison — we don't
-// need a canonical YAML dump here.
+// so for field-based edits the two share the same key order and
+// `JSON.stringify` is a cheap, accurate structural comparison.
+//
+// Note: the YAML-pane edit path (`onYamlInput`) replaces `machineReadable`
+// with a fresh `yaml.load(text)` object whose key order comes from the
+// textarea, so a no-op round-trip can flip this flag to `true` even when
+// the semantic content is unchanged. That's a conservative false positive
+// — the worst case is an enabled save button — so we accept it rather
+// than pay for a canonical YAML dump on every keystroke.
 const isMachineReadableDirty = computed(() => {
   if (!selectedArticle.value) return false;
   const saved = selectedArticle.value.machine_readable ?? null;

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -198,6 +198,21 @@ const editedArticle = computed(() => {
   return { ...selectedArticle.value, machine_readable: machineReadable.value };
 });
 
+// Parse rawYaml once per law load into a reusable document skeleton. The
+// computed below splices in the currently edited article's
+// machine_readable on every reactive change, so without this cache each
+// keystroke in the YAML textarea would re-parse the whole ~25-200 KiB law
+// on the main thread. Hoisting the parse to a computed keyed only on
+// rawYaml drops that cost to one parse per load.
+const parsedRawLaw = computed(() => {
+  if (!rawYaml.value) return null;
+  try {
+    return yaml.load(rawYaml.value);
+  } catch {
+    return null;
+  }
+});
+
 // Reactive "edited" law YAML: rawYaml with the currently selected article's
 // machine_readable substituted in. This is what flows into the engine and
 // into ScenarioBuilder, so in-memory edits re-execute scenarios without a
@@ -211,10 +226,16 @@ const currentLawYaml = computed(() => {
   if (!selectedArticle.value || machineReadable.value == null) {
     return rawYaml.value;
   }
+  const base = parsedRawLaw.value;
+  if (!base) return rawYaml.value;
   try {
-    const doc = yaml.load(rawYaml.value);
-    const docArticles = doc?.articles;
-    if (!Array.isArray(docArticles)) return rawYaml.value;
+    // Shallow-clone the doc and the articles array so our splice doesn't
+    // mutate the memoized `parsedRawLaw` value — Vue would consider the
+    // computed still fresh but the next read would see our substituted
+    // article instead of the original.
+    const doc = { ...base };
+    const docArticles = Array.isArray(base.articles) ? [...base.articles] : null;
+    if (!docArticles) return rawYaml.value;
     const idx = docArticles.findIndex(
       (a) => String(a.number) === String(selectedArticleNumber.value),
     );
@@ -223,6 +244,7 @@ const currentLawYaml = computed(() => {
       ...docArticles[idx],
       machine_readable: machineReadable.value,
     };
+    doc.articles = docArticles;
     return yaml.dump(doc, dumpOpts);
   } catch {
     return rawYaml.value;
@@ -277,9 +299,17 @@ async function handleMachineReadableSave() {
   if (!lawYaml) return;
   try {
     await saveLaw(lawYaml);
-    // After save, `rawYaml` is the saved text; `selectedArticle` reflects
-    // the new machine_readable, so `isMachineReadableDirty` recomputes to
-    // false naturally. No extra bookkeeping needed.
+    // After save, `rawYaml` is the saved text and `selectedArticle` now
+    // points at the re-parsed article. We could rely on the `watch`
+    // further up to re-sync `machineReadable` from the new selectedArticle,
+    // but that watcher fires on the next microtask — leaving a window
+    // where `isMachineReadableDirty` still sees the pre-save object and
+    // the save button stays enabled, enabling a double-save click. Reset
+    // `machineReadable` explicitly from the freshly-parsed article so the
+    // dirty flag clears synchronously with the save.
+    const fresh = selectedArticle.value?.machine_readable ?? null;
+    machineReadable.value = fresh ? JSON.parse(JSON.stringify(fresh)) : null;
+    yamlSource.value = fresh ? yaml.dump(fresh, dumpOpts) : '';
   } catch (e) {
     // saveError is surfaced via lawSaveError; log for dev visibility.
     console.warn('saveLaw failed:', e);

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -297,8 +297,15 @@ const isMachineReadableDirty = computed(() => {
 async function handleMachineReadableSave() {
   const lawYaml = currentLawYaml.value;
   if (!lawYaml) return;
+  // Snapshot the law id before the await. saveLaw itself guards its own
+  // reactive writes with the same check, but the post-save cleanup below
+  // runs in the EditorApp scope and would happily overwrite the new law's
+  // in-progress machine_readable with its pristine article data if the
+  // user switched laws mid-flight.
+  const savedLawId = lawId.value;
   try {
     await saveLaw(lawYaml);
+    if (lawId.value !== savedLawId) return; // law switched mid-PUT
     // After save, `rawYaml` is the saved text and `selectedArticle` now
     // points at the re-parsed article. We could rely on the `watch`
     // further up to re-sync `machineReadable` from the new selectedArticle,

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -158,8 +158,8 @@ function onMiddlePaneChange(event) {
 const { ready: engineReady, initError: engineInitError, initEngine, getEngine } = useEngine();
 initEngine().catch(() => {});
 
-// Engine-loading watch is set up lower, after machineReadable + currentLawYaml
-// are declared (temporal dead zone).
+// The engine-loading watch lives below, next to `currentLawYaml`, so it
+// observes in-memory edits rather than only the persisted `rawYaml`.
 
 // --- Trace state (receives trace from last executed scenario) ---
 const lastTraceText = ref(null);
@@ -249,18 +249,18 @@ watch(
 );
 
 // Dirty state: the selected article's in-memory machine_readable differs
-// from the article's saved copy. Comparing canonical YAML dumps avoids
-// false positives from trivial key-order or whitespace differences that
-// a deep JS equality check would miss.
+// from the article's saved copy. `machineReadable.value` starts as a deep
+// JSON clone of `selectedArticle.machine_readable` (see the `watch` above),
+// so the two share the same key order until the user edits. That makes
+// `JSON.stringify` a cheap and sufficient structural comparison — we don't
+// need a canonical YAML dump here.
 const isMachineReadableDirty = computed(() => {
   if (!selectedArticle.value) return false;
   const saved = selectedArticle.value.machine_readable ?? null;
   const current = machineReadable.value ?? null;
   if (saved == null && current == null) return false;
   try {
-    const savedDump = saved ? yaml.dump(saved, dumpOpts) : '';
-    const currentDump = current ? yaml.dump(current, dumpOpts) : '';
-    return savedDump !== currentDump;
+    return JSON.stringify(saved) !== JSON.stringify(current);
   } catch {
     return true;
   }

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -25,7 +25,21 @@ watch([authLoading, oidcConfigured, authenticated], ([isLoading, oidc, authed]) 
 const canEdit = computed(() => !oidcConfigured.value || authenticated.value);
 
 // --- Initial law load (from URL params) ---
-const { law, lawId, rawYaml, articles, lawName, selectedArticle, selectedArticleNumber, switchLaw, loading, error } = useLaw();
+const {
+  law,
+  lawId,
+  rawYaml,
+  articles,
+  lawName,
+  selectedArticle,
+  selectedArticleNumber,
+  switchLaw,
+  loading,
+  error,
+  saving: lawSaving,
+  saveError: lawSaveError,
+  saveLaw,
+} = useLaw();
 
 const middlePaneView = ref('form');
 const rightPaneView = ref('result');
@@ -144,23 +158,8 @@ function onMiddlePaneChange(event) {
 const { ready: engineReady, initError: engineInitError, initEngine, getEngine } = useEngine();
 initEngine().catch(() => {});
 
-// Load current law into engine when YAML is available
-watch(
-  [() => rawYaml.value, engineReady],
-  ([lawYaml, isReady]) => {
-    if (!isReady || !lawYaml) return;
-    const engine = getEngine();
-    try {
-      if (engine.hasLaw(lawId.value)) {
-        engine.unloadLaw(lawId.value);
-      }
-      engine.loadLaw(lawYaml);
-    } catch (e) {
-      console.warn(`Failed to load law '${lawId.value}' into engine:`, e);
-    }
-  },
-  { immediate: true },
-);
+// Engine-loading watch is set up lower, after machineReadable + currentLawYaml
+// are declared (temporal dead zone).
 
 // --- Trace state (receives trace from last executed scenario) ---
 const lastTraceText = ref(null);
@@ -198,6 +197,88 @@ const editedArticle = computed(() => {
   if (!selectedArticle.value) return null;
   return { ...selectedArticle.value, machine_readable: machineReadable.value };
 });
+
+// Reactive "edited" law YAML: rawYaml with the currently selected article's
+// machine_readable substituted in. This is what flows into the engine and
+// into ScenarioBuilder, so in-memory edits re-execute scenarios without a
+// round-trip through the backend.
+//
+// Only the currently selected article's machine_readable is swapped — edits
+// on other articles are not tracked across tab switches (existing behavior
+// of the editor state model).
+const currentLawYaml = computed(() => {
+  if (!rawYaml.value) return null;
+  if (!selectedArticle.value || machineReadable.value == null) {
+    return rawYaml.value;
+  }
+  try {
+    const doc = yaml.load(rawYaml.value);
+    const docArticles = doc?.articles;
+    if (!Array.isArray(docArticles)) return rawYaml.value;
+    const idx = docArticles.findIndex(
+      (a) => String(a.number) === String(selectedArticleNumber.value),
+    );
+    if (idx < 0) return rawYaml.value;
+    docArticles[idx] = {
+      ...docArticles[idx],
+      machine_readable: machineReadable.value,
+    };
+    return yaml.dump(doc, dumpOpts);
+  } catch {
+    return rawYaml.value;
+  }
+});
+
+// Load current law into engine. Reacts to currentLawYaml so in-memory edits
+// are immediately visible to scenarios.
+watch(
+  [currentLawYaml, engineReady],
+  ([lawYaml, isReady]) => {
+    if (!isReady || !lawYaml) return;
+    const engine = getEngine();
+    try {
+      if (engine.hasLaw(lawId.value)) {
+        engine.unloadLaw(lawId.value);
+      }
+      engine.loadLaw(lawYaml);
+    } catch (e) {
+      console.warn(`Failed to load law '${lawId.value}' into engine:`, e);
+    }
+  },
+  { immediate: true },
+);
+
+// Dirty state: the selected article's in-memory machine_readable differs
+// from the article's saved copy. Comparing canonical YAML dumps avoids
+// false positives from trivial key-order or whitespace differences that
+// a deep JS equality check would miss.
+const isMachineReadableDirty = computed(() => {
+  if (!selectedArticle.value) return false;
+  const saved = selectedArticle.value.machine_readable ?? null;
+  const current = machineReadable.value ?? null;
+  if (saved == null && current == null) return false;
+  try {
+    const savedDump = saved ? yaml.dump(saved, dumpOpts) : '';
+    const currentDump = current ? yaml.dump(current, dumpOpts) : '';
+    return savedDump !== currentDump;
+  } catch {
+    return true;
+  }
+});
+
+async function handleMachineReadableSave() {
+  const lawYaml = currentLawYaml.value;
+  if (!lawYaml) return;
+  try {
+    await saveLaw(lawYaml);
+    // After save, `rawYaml` is the saved text; `selectedArticle` reflects
+    // the new machine_readable, so `isMachineReadableDirty` recomputes to
+    // false naturally. No extra bookkeeping needed.
+  } catch (e) {
+    // saveError is surfaced via lawSaveError; log for dev visibility.
+    console.warn('saveLaw failed:', e);
+  }
+}
 
 function onYamlInput(event) {
   const text = event.target.value;
@@ -495,7 +576,7 @@ function handleActionSave() {
               <ScenarioBuilder
                 v-else-if="middlePaneView === 'form'"
                 :law-id="lawId"
-                :law-yaml="rawYaml"
+                :law-yaml="currentLawYaml"
                 :engine="getEngine()"
                 :ready="engineReady"
                 :articles="articles"
@@ -543,10 +624,14 @@ function handleActionSave() {
                 <MachineReadable
                   :article="editedArticle"
                   :editable="canEdit"
+                  :dirty="isMachineReadableDirty"
+                  :saving="lawSaving"
+                  :save-error="lawSaveError"
                   @open-action="handleOpenAction"
                   @open-edit="activeEditItem = $event"
                   @init-mr="handleInitMr"
                   @add-action="handleAddAction"
+                  @save="handleMachineReadableSave"
                 />
               </ndd-simple-section>
             </ndd-page>

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -636,21 +636,21 @@ function handleActionSave() {
                 @executed="handleScenarioExecuted"
               />
 
-              <!-- YAML view -->
-              <ndd-simple-section v-if="middlePaneView === 'yaml'">
-                <div class="editor-yaml-wrap">
-                  <textarea
-                    :value="yamlSource"
-                    @input="onYamlInput"
-                    class="editor-yaml-textarea"
-                    spellcheck="false"
-                    autocomplete="off"
-                    autocorrect="off"
-                    autocapitalize="off"
-                  ></textarea>
-                  <div v-if="parseError" class="editor-parse-error-detail">{{ parseError }}</div>
-                </div>
-              </ndd-simple-section>
+              <!-- YAML view: bypass ndd-simple-section so the textarea can
+                   stretch to fill the pane body. The wrap is a flex column
+                   that anchors the parse-error footer at the bottom. -->
+              <div v-if="middlePaneView === 'yaml'" class="editor-yaml-wrap">
+                <textarea
+                  :value="yamlSource"
+                  @input="onYamlInput"
+                  class="editor-yaml-textarea"
+                  spellcheck="false"
+                  autocomplete="off"
+                  autocorrect="off"
+                  autocapitalize="off"
+                ></textarea>
+                <div v-if="parseError" class="editor-parse-error-detail">{{ parseError }}</div>
+              </div>
             </ndd-page>
           </ndd-split-view-pane>
 
@@ -721,21 +721,31 @@ function handleActionSave() {
 .editor-yaml-wrap {
   display: flex;
   flex-direction: column;
-  height: 100%;
+  /* Fill the pane body. ndd-page's body is the only ancestor between us
+   * and the viewport, so anchoring on viewport height minus the toolbar
+   * + tab strip height gives a stable tall area regardless of how many
+   * scenarios are loaded next door. */
+  height: calc(100vh - 180px);
+  padding: 16px;
+  box-sizing: border-box;
 }
 
 .editor-yaml-textarea {
   flex: 1;
   width: 100%;
   min-height: 0;
-  height: calc(100vh - 160px);
-  background: #1e1e2e;
-  color: #cdd6f4;
+  /* Match the library/zorgtoeslagwet/2 YamlView look: tinted background,
+   * rounded corners, monospace, comfortable padding. The library version
+   * is read-only <pre><code>; this is the editable counterpart with the
+   * same skin so the eye doesn't have to context-switch. */
+  background: var(--semantics-surfaces-tinted-background-color, #F4F6F9);
+  color: var(--semantics-text-default-color, #1F2937);
   font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', 'JetBrains Mono', monospace;
   font-size: 13px;
-  line-height: 1.6;
+  line-height: 1.5;
   padding: 16px;
-  border: none;
+  border: 1px solid var(--semantics-borders-default-color, #DDE0E4);
+  border-radius: 12px;
   outline: none;
   resize: none;
   tab-size: 2;
@@ -743,8 +753,8 @@ function handleActionSave() {
   overflow: auto;
 }
 
-.editor-yaml-textarea::selection {
-  background: #45475a;
+.editor-yaml-textarea:focus {
+  border-color: var(--semantics-borders-focus-color, #007BC7);
 }
 
 .editor-parse-error {
@@ -757,11 +767,13 @@ function handleActionSave() {
 }
 
 .editor-parse-error-detail {
-  background: #2a1a1a;
-  color: #f38ba8;
+  margin-top: 8px;
+  background: #fef2f2;
+  color: #b91c1c;
   font-family: 'SF Mono', monospace;
   font-size: 12px;
-  padding: 8px 16px;
-  border-top: 1px solid #45475a;
+  padding: 8px 12px;
+  border: 1px solid #fecaca;
+  border-radius: 6px;
 }
 </style>

--- a/frontend/src/components/ActionSheet.vue
+++ b/frontend/src/components/ActionSheet.vue
@@ -70,8 +70,13 @@ onUnmounted(() => {
       <ndd-top-title-bar slot="header" text="Actie" dismiss-text="Annuleer" @dismiss="emit('close')"></ndd-top-title-bar>
 
       <ndd-simple-section>
-        <!-- Output binding (editable view only) -->
-        <template v-if="editable">
+        <!-- Output binding (editable view only).
+             The `&& action` guard prevents a render-time TypeError when the
+             sheet is mounted but `action` hasn't been set yet — the parent
+             always mounts the sheet eagerly and toggles visibility via the
+             web-component's show()/hide() methods, so `action` is null
+             whenever the sheet isn't actively editing something. -->
+        <template v-if="editable && action">
           <ndd-list variant="box" class="settings-list" data-testid="action-output-binding">
             <ndd-list-item size="md">
               <ndd-text-cell text="Output"></ndd-text-cell>

--- a/frontend/src/components/MachineReadable.test.js
+++ b/frontend/src/components/MachineReadable.test.js
@@ -278,4 +278,72 @@ describe('MachineReadable', () => {
       expect(wrapper.emitted('open-edit')).toBeUndefined();
     });
   });
+
+  describe('save bar', () => {
+    function findSaveButton(wrapper) {
+      return wrapper.find('[data-testid="save-mr-btn"]');
+    }
+
+    it('is hidden when editable is false', () => {
+      const wrapper = mount(MachineReadable, {
+        props: { article: createArticle(), editable: false },
+      });
+      expect(findSaveButton(wrapper).exists()).toBe(false);
+    });
+
+    it('shows "Opgeslagen" and is disabled when not dirty', () => {
+      const wrapper = mount(MachineReadable, {
+        props: { article: createArticle(), editable: true, dirty: false },
+      });
+      const btn = findSaveButton(wrapper);
+      expect(btn.exists()).toBe(true);
+      expect(btn.attributes('text')).toBe('Opgeslagen');
+      expect(btn.attributes('disabled')).toBe('true');
+    });
+
+    it('shows "Opslaan" and reports not-disabled when dirty', () => {
+      const wrapper = mount(MachineReadable, {
+        props: { article: createArticle(), editable: true, dirty: true },
+      });
+      const btn = findSaveButton(wrapper);
+      expect(btn.attributes('text')).toBe('Opslaan');
+      // Vue serializes a reactive bool binding as "true"/"false" on a custom
+      // element; the string "false" means the button is enabled.
+      expect(btn.attributes('disabled')).toBe('false');
+    });
+
+    it('shows "Opslaan…" while saving regardless of dirty state', () => {
+      const wrapper = mount(MachineReadable, {
+        props: { article: createArticle(), editable: true, dirty: true, saving: true },
+      });
+      const btn = findSaveButton(wrapper);
+      expect(btn.attributes('text')).toBe('Opslaan\u2026');
+      expect(btn.attributes('disabled')).toBe('true');
+    });
+
+    it('emits save on click when dirty', async () => {
+      const wrapper = mount(MachineReadable, {
+        props: { article: createArticle(), editable: true, dirty: true },
+      });
+      await findSaveButton(wrapper).trigger('click');
+      expect(wrapper.emitted('save')).toHaveLength(1);
+    });
+
+    it('renders save error dialog when saveError is set', () => {
+      const err = new Error('Forbidden: read-only backend');
+      const wrapper = mount(MachineReadable, {
+        props: { article: createArticle(), editable: true, saveError: err },
+      });
+      const dialog = wrapper.find('[data-testid="save-mr-error"]');
+      expect(dialog.exists()).toBe(true);
+      expect(dialog.attributes('supporting-text')).toBe('Forbidden: read-only backend');
+    });
+
+    it('does not render save error dialog when saveError is null', () => {
+      const wrapper = mount(MachineReadable, {
+        props: { article: createArticle(), editable: true, saveError: null },
+      });
+      expect(wrapper.find('[data-testid="save-mr-error"]').exists()).toBe(false);
+    });
+  });
 });

--- a/frontend/src/components/MachineReadable.vue
+++ b/frontend/src/components/MachineReadable.vue
@@ -4,9 +4,15 @@ import { computed } from 'vue';
 const props = defineProps({
   article: { type: Object, default: null },
   editable: { type: Boolean, default: false },
+  /** True when the in-memory machine_readable differs from the saved copy */
+  dirty: { type: Boolean, default: false },
+  /** True while a save PUT is in flight */
+  saving: { type: Boolean, default: false },
+  /** Error from the most recent save attempt (Error instance or null) */
+  saveError: { type: Object, default: null },
 });
 
-const emit = defineEmits(['open-action', 'open-edit', 'init-mr', 'add-action']);
+const emit = defineEmits(['open-action', 'open-edit', 'init-mr', 'add-action', 'save']);
 
 const mr = computed(() => props.article?.machine_readable ?? null);
 const execution = computed(() => mr.value?.execution ?? null);
@@ -108,6 +114,30 @@ function addOutput() {
   </ndd-simple-section>
 
   <ndd-simple-section v-else data-testid="machine-readable">
+    <!-- Save bar: visible only when the user can edit. The button itself is
+         disabled when there's nothing to save so it still acts as a clear
+         "everything's saved" signal instead of disappearing. -->
+    <template v-if="editable">
+      <div class="mr-save-bar">
+        <ndd-button
+          variant="primary"
+          size="md"
+          data-testid="save-mr-btn"
+          :disabled="!dirty || saving"
+          :text="saving ? 'Opslaan…' : dirty ? 'Opslaan' : 'Opgeslagen'"
+          @click="emit('save')"
+        ></ndd-button>
+      </div>
+      <ndd-inline-dialog
+        v-if="saveError"
+        variant="alert"
+        text="Opslaan mislukt"
+        :supporting-text="saveError.message || String(saveError)"
+        data-testid="save-mr-error"
+      ></ndd-inline-dialog>
+      <ndd-spacer size="12"></ndd-spacer>
+    </template>
+
     <!-- Metadata: produces -->
     <ndd-list v-if="produces" variant="box">
       <ndd-list-item v-if="produces.legal_character" size="md">
@@ -217,3 +247,11 @@ function addOutput() {
     </template>
   </ndd-simple-section>
 </template>
+
+<style scoped>
+.mr-save-bar {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 8px;
+}
+</style>

--- a/frontend/src/components/OperationSettings.vue
+++ b/frontend/src/components/OperationSettings.vue
@@ -346,7 +346,7 @@ function addNestedOperation() {
 
 <template>
   <template v-if="operation">
-    <ndd-title size="4">
+    <ndd-title size="4" class="op-settings-title">
       <h4>Instellingen operatie {{ operation.number }}</h4>
       <ndd-icon-button slot="actions" icon="ellipsis" title="Meer opties"></ndd-icon-button>
     </ndd-title>
@@ -414,8 +414,10 @@ function addNestedOperation() {
 /* Reset browser default h4 margin so the ndd-spacer below the title is the
  * only source of vertical gap. Without this the h4's default bottom margin
  * (~1em) collapses into the spacer unpredictably, which caused the
- * "textboxes falling under the title" visual in the action panel. */
-ndd-title h4 {
+ * "textboxes falling under the title" visual in the action panel.
+ * Scoped to this component's own title class so the rule can't bleed into
+ * other ndd-title + h4 pairings elsewhere in the app. */
+.op-settings-title h4 {
   margin: 0;
 }
 

--- a/frontend/src/components/OperationSettings.vue
+++ b/frontend/src/components/OperationSettings.vue
@@ -415,8 +415,12 @@ function addNestedOperation() {
  * only source of vertical gap. Without this the h4's default bottom margin
  * (~1em) collapses into the spacer unpredictably, which caused the
  * "textboxes falling under the title" visual in the action panel.
- * Scoped to this component's own title class so the rule can't bleed into
- * other ndd-title + h4 pairings elsewhere in the app. */
+ *
+ * Keyed off a `.op-settings-title` class added to the ndd-title element in
+ * this component. The rule is in an unscoped `<style>` block alongside the
+ * rest of the file's selectors (Vue scoped styles can't reach into NDD
+ * shadow DOM), so the class name is the only thing preventing bleed into
+ * other components — keep the class unique to this component. */
 .op-settings-title h4 {
   margin: 0;
 }

--- a/frontend/src/components/OperationSettings.vue
+++ b/frontend/src/components/OperationSettings.vue
@@ -350,7 +350,7 @@ function addNestedOperation() {
       <h4>Instellingen operatie {{ operation.number }}</h4>
       <ndd-icon-button slot="actions" icon="ellipsis" title="Meer opties"></ndd-icon-button>
     </ndd-title>
-    <ndd-spacer size="4"></ndd-spacer>
+    <ndd-spacer size="12"></ndd-spacer>
     <ndd-list variant="box" class="settings-list">
       <!-- Titel -->
       <ndd-list-item size="md">
@@ -411,6 +411,14 @@ function addNestedOperation() {
 </template>
 
 <style>
+/* Reset browser default h4 margin so the ndd-spacer below the title is the
+ * only source of vertical gap. Without this the h4's default bottom margin
+ * (~1em) collapses into the spacer unpredictably, which caused the
+ * "textboxes falling under the title" visual in the action panel. */
+ndd-title h4 {
+  margin: 0;
+}
+
 .settings-list ndd-cell {
   flex: 1;
   min-width: 0;

--- a/frontend/src/components/OperationSettings.vue
+++ b/frontend/src/components/OperationSettings.vue
@@ -346,7 +346,7 @@ function addNestedOperation() {
 
 <template>
   <template v-if="operation">
-    <ndd-title size="4" class="op-settings-title">
+    <ndd-title size="4" class="operation-settings__title">
       <h4>Instellingen operatie {{ operation.number }}</h4>
       <ndd-icon-button slot="actions" icon="ellipsis" title="Meer opties"></ndd-icon-button>
     </ndd-title>
@@ -416,12 +416,12 @@ function addNestedOperation() {
  * (~1em) collapses into the spacer unpredictably, which caused the
  * "textboxes falling under the title" visual in the action panel.
  *
- * Keyed off a `.op-settings-title` class added to the ndd-title element in
+ * Keyed off a `.operation-settings__title` BEM class on the ndd-title in
  * this component. The rule is in an unscoped `<style>` block alongside the
  * rest of the file's selectors (Vue scoped styles can't reach into NDD
  * shadow DOM), so the class name is the only thing preventing bleed into
  * other components — keep the class unique to this component. */
-.op-settings-title h4 {
+.operation-settings__title h4 {
   margin: 0;
 }
 

--- a/frontend/src/composables/useLaw.js
+++ b/frontend/src/composables/useLaw.js
@@ -46,6 +46,8 @@ export function useLaw(lawParam) {
   const selectedArticleNumber = ref(null);
   const loading = ref(true);
   const error = ref(null);
+  const saving = ref(false);
+  const saveError = ref(null);
 
   const articles = computed(() => law.value?.articles ?? []);
 
@@ -113,6 +115,56 @@ export function useLaw(lawParam) {
     }
   }
 
+  /**
+   * Persist edited law YAML to the backend via PUT.
+   *
+   * On success, updates `rawYaml` + `law` locally so downstream consumers
+   * (currentLawYaml computed, engine reload, scenario re-run) converge on
+   * the saved text and the editor's dirty-state marker clears.
+   *
+   * Throws on failure so callers can decide how to surface the error; the
+   * `saveError` ref is also populated for passive UI display.
+   *
+   * @param {string} yamlText - Full law YAML (must contain matching $id)
+   */
+  async function saveLaw(yamlText) {
+    if (!lawId.value) {
+      throw new Error('Cannot save law: no lawId');
+    }
+    saving.value = true;
+    saveError.value = null;
+    try {
+      const res = await fetch(
+        `/api/corpus/laws/${encodeURIComponent(lawId.value)}`,
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'text/yaml; charset=utf-8' },
+          body: yamlText,
+        },
+      );
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(text || `Save failed: ${res.status}`);
+      }
+      // Update local state so dirty-state tracking sees the edit as clean.
+      rawYaml.value = yamlText;
+      law.value = yaml.load(yamlText);
+      // Keep the shared cache in sync so other tabs on the same law see the
+      // edited version on their next fetchLaw() call.
+      const resolvedId = law.value?.$id || lawId.value;
+      lawCache.set(resolvedId, {
+        law: law.value,
+        rawYaml: yamlText,
+        lawName: resolveLawName(law.value),
+      });
+    } catch (e) {
+      saveError.value = e;
+      throw e;
+    } finally {
+      saving.value = false;
+    }
+  }
+
   return {
     law,
     lawId,
@@ -124,5 +176,8 @@ export function useLaw(lawParam) {
     switchLaw,
     loading,
     error,
+    saving,
+    saveError,
+    saveLaw,
   };
 }

--- a/frontend/src/composables/useLaw.js
+++ b/frontend/src/composables/useLaw.js
@@ -100,8 +100,13 @@ export function useLaw(lawParam) {
       loading.value = true;
       error.value = null;
       // Reset save state too — a failed save on the previous law must not
-      // leak its error dialog into the new law's Machine panel.
+      // leak its error dialog (or spinner) into the new law's Machine
+      // panel. `saving` is cleared here alongside `saveError` because an
+      // in-flight PUT from the previous law will still set `saving = false`
+      // in its own `finally`, but until that stale response arrives the
+      // new law should not inherit the spinner.
       saveError.value = null;
+      saving.value = false;
       const entry = await fetchLaw(newLawId);
       if (version !== switchVersion) return; // stale, discard
       law.value = entry.law;
@@ -134,11 +139,17 @@ export function useLaw(lawParam) {
     if (!lawId.value) {
       throw new Error('Cannot save law: no lawId');
     }
+    // Snapshot the law we're saving *before* the await. If the user
+    // switches laws while the PUT is in flight, `switchLaw` will replace
+    // `lawId` / `rawYaml` / `law` with the new law's state; when the stale
+    // response eventually arrives, we must not overwrite the new law's
+    // reactive state with the old law's YAML.
+    const savedLawId = lawId.value;
     saving.value = true;
     saveError.value = null;
     try {
       const res = await fetch(
-        `/api/corpus/laws/${encodeURIComponent(lawId.value)}`,
+        `/api/corpus/laws/${encodeURIComponent(savedLawId)}`,
         {
           method: 'PUT',
           headers: { 'Content-Type': 'text/yaml; charset=utf-8' },
@@ -149,22 +160,40 @@ export function useLaw(lawParam) {
         const text = await res.text();
         throw new Error(text || `Save failed: ${res.status}`);
       }
-      // Update local state so dirty-state tracking sees the edit as clean.
-      rawYaml.value = yamlText;
-      law.value = yaml.load(yamlText);
-      // Keep the shared cache in sync so other tabs on the same law see the
-      // edited version on their next fetchLaw() call.
-      const resolvedId = law.value?.$id || lawId.value;
+      // Bail on the success path if the user navigated away mid-flight.
+      // The write succeeded on the backend (so the cache update below is
+      // still worth doing), but we must not touch the now-foreign
+      // reactive refs.
+      if (lawId.value === savedLawId) {
+        rawYaml.value = yamlText;
+        law.value = yaml.load(yamlText);
+      }
+      // Keep the shared cache in sync so other tabs on the same law see
+      // the edited version on their next fetchLaw() call. The cache key
+      // is the saved law's ID, independent of the composable's current
+      // `lawId` ref, so this refresh is safe even if the user switched.
+      const parsed = yaml.load(yamlText);
+      const resolvedId = parsed?.$id || savedLawId;
       lawCache.set(resolvedId, {
-        law: law.value,
+        law: parsed,
         rawYaml: yamlText,
-        lawName: resolveLawName(law.value),
+        lawName: resolveLawName(parsed),
       });
     } catch (e) {
-      saveError.value = e;
+      // Only surface the error on the originating law's state. If the user
+      // navigated away, the error belongs to law A and the new law's
+      // Machine panel must not inherit it.
+      if (lawId.value === savedLawId) {
+        saveError.value = e;
+      }
       throw e;
     } finally {
-      saving.value = false;
+      // Same story for the spinner: only clear it if we're still on the
+      // same law. If the user switched, switchLaw already reset `saving`
+      // and we don't want to fight that.
+      if (lawId.value === savedLawId) {
+        saving.value = false;
+      }
     }
   }
 

--- a/frontend/src/composables/useLaw.js
+++ b/frontend/src/composables/useLaw.js
@@ -99,6 +99,9 @@ export function useLaw(lawParam) {
     try {
       loading.value = true;
       error.value = null;
+      // Reset save state too — a failed save on the previous law must not
+      // leak its error dialog into the new law's Machine panel.
+      saveError.value = null;
       const entry = await fetchLaw(newLawId);
       if (version !== switchVersion) return; // stale, discard
       law.value = entry.law;

--- a/frontend/src/composables/useLaw.js
+++ b/frontend/src/composables/useLaw.js
@@ -157,13 +157,21 @@ export function useLaw(lawParam) {
         },
       );
       if (!res.ok) {
-        // res.text() can throw on a network drop after headers; if that
-        // happens we still want to surface the HTTP status, not whatever
-        // confusing low-level error the body read produced.
+        // Only surface the body when it's our editor-api speaking. The
+        // editor-api returns plain `text/plain; charset=utf-8` for its
+        // 400/403 bodies (corpus_handlers.rs), so a non-text/plain
+        // content-type means a reverse proxy is intercepting (5xx HTML
+        // page, etc.) and we should fall back to a generic message
+        // rather than render proxy HTML in the save error dialog.
+        // res.text() can also throw on a network drop after headers;
+        // the same fallback covers that.
         let text = `Save failed: ${res.status}`;
-        try {
-          text = (await res.text()) || text;
-        } catch { /* keep status fallback */ }
+        const contentType = res.headers.get('content-type') || '';
+        if (contentType.startsWith('text/plain')) {
+          try {
+            text = (await res.text()) || text;
+          } catch { /* keep status fallback */ }
+        }
         throw new Error(text);
       }
       // Parse once and reuse for both reactive state and the shared

--- a/frontend/src/composables/useLaw.js
+++ b/frontend/src/composables/useLaw.js
@@ -160,19 +160,21 @@ export function useLaw(lawParam) {
         const text = await res.text();
         throw new Error(text || `Save failed: ${res.status}`);
       }
+      // Parse once and reuse for both reactive state and the shared
+      // lawCache so they remain referentially consistent.
+      const parsed = yaml.load(yamlText);
       // Bail on the success path if the user navigated away mid-flight.
       // The write succeeded on the backend (so the cache update below is
       // still worth doing), but we must not touch the now-foreign
       // reactive refs.
       if (lawId.value === savedLawId) {
         rawYaml.value = yamlText;
-        law.value = yaml.load(yamlText);
+        law.value = parsed;
       }
       // Keep the shared cache in sync so other tabs on the same law see
       // the edited version on their next fetchLaw() call. The cache key
       // is the saved law's ID, independent of the composable's current
       // `lawId` ref, so this refresh is safe even if the user switched.
-      const parsed = yaml.load(yamlText);
       const resolvedId = parsed?.$id || savedLawId;
       lawCache.set(resolvedId, {
         law: parsed,

--- a/frontend/src/composables/useLaw.js
+++ b/frontend/src/composables/useLaw.js
@@ -157,8 +157,14 @@ export function useLaw(lawParam) {
         },
       );
       if (!res.ok) {
-        const text = await res.text();
-        throw new Error(text || `Save failed: ${res.status}`);
+        // res.text() can throw on a network drop after headers; if that
+        // happens we still want to surface the HTTP status, not whatever
+        // confusing low-level error the body read produced.
+        let text = `Save failed: ${res.status}`;
+        try {
+          text = (await res.text()) || text;
+        } catch { /* keep status fallback */ }
+        throw new Error(text);
       }
       // Parse once and reuse for both reactive state and the shared
       // lawCache so they remain referentially consistent.

--- a/packages/corpus/src/source_map.rs
+++ b/packages/corpus/src/source_map.rs
@@ -503,9 +503,7 @@ mod tests {
         let mut map = SourceMap::new();
         map.load_source(&source).unwrap();
 
-        let original_file_path = map.get_law("test_wet").unwrap().file_path.clone();
-        let original_source_id = map.get_law("test_wet").unwrap().source_id.clone();
-        let original_priority = map.get_law("test_wet").unwrap().source_priority;
+        let original = map.get_law("test_wet").unwrap().clone();
 
         let new_content =
             "$id: test_wet\nname: Updated Name\nregulatory_layer: WET\narticles: []\n".to_string();
@@ -515,10 +513,16 @@ mod tests {
         let law = map.get_law("test_wet").unwrap();
         assert_eq!(law.yaml_content, new_content);
         assert_eq!(law.name.as_deref(), Some("Updated Name"));
-        // Provenance is preserved — update_yaml_content only touches content + name.
-        assert_eq!(law.file_path, original_file_path);
-        assert_eq!(law.source_id, original_source_id);
-        assert_eq!(law.source_priority, original_priority);
+        // All provenance fields are preserved — update_yaml_content only
+        // touches content + name. `relative_path` is load-bearing because
+        // the editor-api write handler targets it; a regression that
+        // cleared it would silently send reads and writes to different
+        // files, so we assert it explicitly alongside file_path/source_*.
+        assert_eq!(law.file_path, original.file_path);
+        assert_eq!(law.relative_path, original.relative_path);
+        assert_eq!(law.source_id, original.source_id);
+        assert_eq!(law.source_name, original.source_name);
+        assert_eq!(law.source_priority, original.source_priority);
     }
 
     #[test]

--- a/packages/corpus/src/source_map.rs
+++ b/packages/corpus/src/source_map.rs
@@ -402,6 +402,16 @@ pub(crate) fn pick_best_version(existing: Option<&str>, new: Option<&str>, today
     }
 }
 
+/// Verify that a string parses as well-formed YAML without enforcing a
+/// particular schema. Used by write handlers that want to reject garbage
+/// input before persisting to the corpus backend, without committing to
+/// the corpus library's full law-schema validation (which belongs in a
+/// separate layer).
+pub fn validate_yaml_syntax(content: &str) -> Result<()> {
+    serde_yaml_ng::from_str::<serde_yaml_ng::Value>(content)?;
+    Ok(())
+}
+
 /// Extract the top-level `$id` field from a YAML string.
 ///
 /// Uses a simple line-based approach to avoid full YAML parsing overhead.
@@ -557,6 +567,21 @@ mod tests {
         let updated = map.update_yaml_content("nonexistent_law", "$id: foo\n".to_string());
         assert!(!updated, "update should report failure for missing law");
         assert_eq!(map.len(), 0, "missing law should not be inserted");
+    }
+
+    #[test]
+    fn test_validate_yaml_syntax_accepts_well_formed() {
+        assert!(validate_yaml_syntax("$id: foo\nname: bar\narticles: []\n").is_ok());
+        assert!(validate_yaml_syntax("---\nfoo: 1\n").is_ok());
+        assert!(validate_yaml_syntax("").is_ok()); // empty doc is valid
+    }
+
+    #[test]
+    fn test_validate_yaml_syntax_rejects_garbage() {
+        // Unclosed quote.
+        assert!(validate_yaml_syntax("name: \"unterminated\nfoo: bar\n").is_err());
+        // Tab indentation inside a block mapping.
+        assert!(validate_yaml_syntax("name:\n\tfoo: bar\n").is_err());
     }
 
     #[test]

--- a/packages/corpus/src/source_map.rs
+++ b/packages/corpus/src/source_map.rs
@@ -286,6 +286,26 @@ impl SourceMap {
         self.laws.get(law_id)
     }
 
+    /// Update the cached YAML content for an existing law. Used after the
+    /// editor persists an edit through [`crate::backend::RepoBackend`], so
+    /// subsequent GETs (and dependency walks) see the new text without
+    /// waiting for a full corpus reload. Returns `true` if the law was
+    /// present and updated, `false` otherwise.
+    ///
+    /// Only `yaml_content` (and the optional human-readable `name`, which is
+    /// derived from the YAML) is updated — `$id`, `file_path`, source
+    /// provenance, and priority are stable across an edit and are left
+    /// untouched. If the caller writes a new file under a different `$id`
+    /// that's a different operation (unsupported via this hook).
+    pub fn update_yaml_content(&mut self, law_id: &str, new_content: String) -> bool {
+        let Some(law) = self.laws.get_mut(law_id) else {
+            return false;
+        };
+        law.name = extract_law_name(&new_content);
+        law.yaml_content = new_content;
+        true
+    }
+
     /// Get the number of loaded laws.
     pub fn len(&self) -> usize {
         self.laws.len()
@@ -387,7 +407,7 @@ pub(crate) fn pick_best_version(existing: Option<&str>, new: Option<&str>, today
 /// Uses a simple line-based approach to avoid full YAML parsing overhead.
 /// Only matches `$id:` at the start of a line (no leading whitespace) to
 /// avoid matching nested `$id:` fields.
-fn extract_law_id(yaml: &str) -> Option<String> {
+pub fn extract_law_id(yaml: &str) -> Option<String> {
     for line in yaml.lines() {
         if let Some(rest) = line.strip_prefix("$id:") {
             let value = rest.trim().trim_matches('"').trim_matches('\'');

--- a/packages/corpus/src/source_map.rs
+++ b/packages/corpus/src/source_map.rs
@@ -495,6 +495,67 @@ mod tests {
     }
 
     #[test]
+    fn test_update_yaml_content_updates_existing_law() {
+        let dir = TempDir::new().unwrap();
+        write_yaml(dir.path(), "wet/test_wet/2025-01-01.yaml", "test_wet");
+
+        let source = make_source("central", "Central", dir.path(), 1);
+        let mut map = SourceMap::new();
+        map.load_source(&source).unwrap();
+
+        let original_file_path = map.get_law("test_wet").unwrap().file_path.clone();
+        let original_source_id = map.get_law("test_wet").unwrap().source_id.clone();
+        let original_priority = map.get_law("test_wet").unwrap().source_priority;
+
+        let new_content =
+            "$id: test_wet\nname: Updated Name\nregulatory_layer: WET\narticles: []\n".to_string();
+        let updated = map.update_yaml_content("test_wet", new_content.clone());
+
+        assert!(updated, "update should report success for existing law");
+        let law = map.get_law("test_wet").unwrap();
+        assert_eq!(law.yaml_content, new_content);
+        assert_eq!(law.name.as_deref(), Some("Updated Name"));
+        // Provenance is preserved — update_yaml_content only touches content + name.
+        assert_eq!(law.file_path, original_file_path);
+        assert_eq!(law.source_id, original_source_id);
+        assert_eq!(law.source_priority, original_priority);
+    }
+
+    #[test]
+    fn test_update_yaml_content_recomputes_name_to_none() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("wet/test_wet/2025-01-01.yaml");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(
+            &path,
+            "$id: test_wet\nname: Original\nregulatory_layer: WET\narticles: []\n",
+        )
+        .unwrap();
+
+        let source = make_source("central", "Central", dir.path(), 1);
+        let mut map = SourceMap::new();
+        map.load_source(&source).unwrap();
+        assert_eq!(
+            map.get_law("test_wet").unwrap().name.as_deref(),
+            Some("Original")
+        );
+
+        // Remove the `name:` field — name should recompute to None.
+        let new_content = "$id: test_wet\nregulatory_layer: WET\narticles: []\n".to_string();
+        let updated = map.update_yaml_content("test_wet", new_content);
+        assert!(updated);
+        assert_eq!(map.get_law("test_wet").unwrap().name, None);
+    }
+
+    #[test]
+    fn test_update_yaml_content_missing_law_returns_false() {
+        let mut map = SourceMap::new();
+        let updated = map.update_yaml_content("nonexistent_law", "$id: foo\n".to_string());
+        assert!(!updated, "update should report failure for missing law");
+        assert_eq!(map.len(), 0, "missing law should not be inserted");
+    }
+
+    #[test]
     fn test_load_single_source() {
         let dir = TempDir::new().unwrap();
         write_yaml(dir.path(), "wet/test_wet/2025-01-01.yaml", "test_wet");

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -533,10 +533,14 @@ pub async fn save_law(
     };
 
     if !resolved.writable {
-        // Log the internal source id for operators but keep it out of the
-        // HTTP body — `source_id` is a registry key ("central",
-        // "local-scratch", …) and leaking it exposes internal
-        // infrastructure naming for no caller-side benefit.
+        // Log the internal source id (and the law id, even though the
+        // caller already knows it) for operators but keep both out of the
+        // HTTP body. `source_id` is a registry key ("central",
+        // "local-scratch", …) so leaking it exposes infrastructure naming;
+        // `law_id` echoed in the body would also flow through
+        // useLaw.saveError into ndd-inline-dialog's supporting-text, with
+        // the same self-XSS concern as the $id-mismatch branch above. The
+        // hard-coded message keeps both branches consistent.
         tracing::warn!(
             law_id = %law_id,
             source_id = %resolved.law.source_id,
@@ -544,7 +548,7 @@ pub async fn save_law(
         );
         return Err((
             StatusCode::FORBIDDEN,
-            format!("Law '{}' is stored on a read-only source", law_id),
+            "Law is stored on a read-only source".to_string(),
         ));
     }
 

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -533,13 +533,18 @@ pub async fn save_law(
     };
 
     if !resolved.writable {
+        // Log the internal source id for operators but keep it out of the
+        // HTTP body — `source_id` is a registry key ("central",
+        // "local-scratch", …) and leaking it exposes internal
+        // infrastructure naming for no caller-side benefit.
+        tracing::warn!(
+            law_id = %law_id,
+            source_id = %resolved.law.source_id,
+            "save_law: no writable backend for law"
+        );
         return Err((
             StatusCode::FORBIDDEN,
-            format!(
-                "No writable backend available for law '{}' (source '{}' is read-only \
-                 and no other registered source contains a matching copy of the law)",
-                law_id, resolved.law.source_id
-            ),
+            format!("Law '{}' is stored on a read-only source", law_id),
         ));
     }
 

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 
 use regelrecht_corpus::backend::{RepoBackend, WriteContext};
-use regelrecht_corpus::source_map::LoadedLaw;
+use regelrecht_corpus::source_map::{extract_law_id, LoadedLaw};
 use regelrecht_corpus::CorpusError;
 
 use crate::state::AppState;
@@ -487,7 +487,7 @@ pub async fn save_law(
     // `just validate`). Using the same line-based extractor the corpus
     // loader uses keeps the "is this a loadable law file?" check consistent
     // with how source_map decides which files to track.
-    let body_id = regelrecht_corpus::source_map::extract_law_id(&body).ok_or_else(|| {
+    let body_id = extract_law_id(&body).ok_or_else(|| {
         (
             StatusCode::BAD_REQUEST,
             "Body missing top-level `$id` field".to_string(),

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -388,14 +388,19 @@ async fn resolve_backend_for_law(
 /// error — which can include git stderr, repository URLs that may carry
 /// push tokens for local-only backends, and absolute filesystem paths — is
 /// logged at warn level for operators but never returned to the client.
-fn corpus_write_error(e: CorpusError) -> (StatusCode, String) {
-    match e {
+///
+/// `kind` is the short name of the resource being written ("scenario",
+/// "law", …) so logs and the user-facing 500 body name the right thing
+/// regardless of which handler is on the stack. The `FnOnce` wrapper is a
+/// convenience for `.map_err(corpus_write_error("law"))` at call sites.
+fn corpus_write_error(kind: &'static str) -> impl FnOnce(CorpusError) -> (StatusCode, String) {
+    move |e| match e {
         CorpusError::ReadOnly(_) => (StatusCode::FORBIDDEN, e.to_string()),
         _ => {
-            tracing::warn!(error = %e, "scenario write/persist failed");
+            tracing::warn!(error = %e, kind = %kind, "corpus write/persist failed");
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                "Internal error while writing scenario".to_string(),
+                format!("Internal error while writing {}", kind),
             )
         }
     }
@@ -450,14 +455,14 @@ pub async fn save_scenario(
     backend
         .write_file(&relative_path, &body)
         .await
-        .map_err(corpus_write_error)?;
+        .map_err(corpus_write_error("scenario"))?;
 
     backend
         .persist(&WriteContext {
             message: format!("Update scenario {} for {}", filename, law_id),
         })
         .await
-        .map_err(corpus_write_error)?;
+        .map_err(corpus_write_error("scenario"))?;
 
     Ok(StatusCode::OK)
 }
@@ -528,13 +533,13 @@ pub async fn save_law(
         backend
             .write_file(&relative_path, &body)
             .await
-            .map_err(corpus_write_error)?;
+            .map_err(corpus_write_error("law"))?;
         backend
             .persist(&WriteContext {
                 message: format!("Update law {}", law_id),
             })
             .await
-            .map_err(corpus_write_error)?;
+            .map_err(corpus_write_error("law"))?;
     }
 
     // Refresh the in-memory cache so /api/corpus/laws/{law_id} (and
@@ -565,14 +570,14 @@ pub async fn delete_scenario(
     backend
         .delete_file(&relative_path)
         .await
-        .map_err(corpus_write_error)?;
+        .map_err(corpus_write_error("scenario"))?;
 
     backend
         .persist(&WriteContext {
             message: format!("Delete scenario {} for {}", filename, law_id),
         })
         .await
-        .map_err(corpus_write_error)?;
+        .map_err(corpus_write_error("scenario"))?;
 
     Ok(StatusCode::OK)
 }

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -555,6 +555,16 @@ pub async fn save_law(
     let relative_path = PathBuf::from(&resolved.law.relative_path);
 
     {
+        // The `if !resolved.writable` early return above ensures the
+        // RepoBackend will not refuse the write under normal operation, so
+        // the only realistic path to a `CorpusError::ReadOnly` here is a
+        // TOCTOU between the writability check and the write itself
+        // (e.g. the underlying volume flips read-only mid-request). In
+        // that race the `corpus_write_error` helper falls through to its
+        // generic 500-style mapping, mirroring the existing scenario
+        // write paths; the `ReadOnly` arm of `corpus_write_error` —
+        // which echoes `e.to_string()` — is unreachable here in
+        // practice and is not in scope to harden in this PR.
         let backend = resolved.backend.lock_owned().await;
         backend
             .write_file(&relative_path, &body)

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -462,6 +462,97 @@ pub async fn save_scenario(
     Ok(StatusCode::OK)
 }
 
+/// PUT /api/corpus/laws/{law_id} — save edited law YAML content.
+///
+/// Writes the new YAML to the backend (same RepoBackend used for scenario
+/// saves, with the same writable-fallback resolution), then refreshes the
+/// in-memory `yaml_content` on the law's `SourceMap` entry so subsequent
+/// GETs see the edited text without waiting for a full corpus reload.
+///
+/// The `$id` in the body must match the path parameter: allowing them to
+/// diverge would either create a phantom law (new `$id` lands on an
+/// existing file) or orphan the original (old `$id` can never be fetched
+/// again). We reject the mismatch up-front instead of silently corrupting
+/// the source map.
+pub async fn save_law(
+    State(state): State<AppState>,
+    Path(law_id): Path<String>,
+    body: String,
+) -> Result<StatusCode, (StatusCode, String)> {
+    // Minimal validation: body must have a top-level `$id` that matches
+    // the path parameter. We do NOT run full schema validation here — the
+    // frontend already blocks incomplete operation stubs
+    // (findIncompleteOperation) and the YAML pane has a live parse check.
+    // Full JSON Schema validation is a separate follow-up (mirroring
+    // `just validate`). Using the same line-based extractor the corpus
+    // loader uses keeps the "is this a loadable law file?" check consistent
+    // with how source_map decides which files to track.
+    let body_id = regelrecht_corpus::source_map::extract_law_id(&body).ok_or_else(|| {
+        (
+            StatusCode::BAD_REQUEST,
+            "Body missing top-level `$id` field".to_string(),
+        )
+    })?;
+
+    if body_id != law_id {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!(
+                "Body $id '{}' does not match path law_id '{}'",
+                body_id, law_id
+            ),
+        ));
+    }
+
+    // Resolve backend with writable fallback (same path scenarios take).
+    let resolved = {
+        let corpus = state.corpus.read().await;
+        resolve_backend_for_law(&corpus, &law_id).await?
+    };
+
+    if !resolved.writable {
+        return Err((
+            StatusCode::FORBIDDEN,
+            format!(
+                "No writable backend available for law '{}' (source '{}' is read-only \
+                 and no other registered source contains a matching copy of the law)",
+                law_id, resolved.law.source_id
+            ),
+        ));
+    }
+
+    let relative_path = PathBuf::from(&resolved.law.relative_path);
+
+    {
+        let backend = resolved.backend.lock_owned().await;
+        backend
+            .write_file(&relative_path, &body)
+            .await
+            .map_err(corpus_write_error)?;
+        backend
+            .persist(&WriteContext {
+                message: format!("Update law {}", law_id),
+            })
+            .await
+            .map_err(corpus_write_error)?;
+    }
+
+    // Refresh the in-memory cache so /api/corpus/laws/{law_id} (and
+    // dependency walks) see the edit without a full corpus reload.
+    {
+        let mut corpus = state.corpus.write().await;
+        let updated = corpus.source_map.update_yaml_content(&law_id, body);
+        if !updated {
+            tracing::warn!(
+                law_id = %law_id,
+                "save_law wrote to backend but law vanished from source_map between write and cache refresh"
+            );
+        }
+    }
+
+    Ok(StatusCode::OK)
+}
+
 /// DELETE /api/corpus/laws/{law_id}/scenarios/{filename} — delete a scenario file.
 pub async fn delete_scenario(
     State(state): State<AppState>,

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 
 use regelrecht_corpus::backend::{RepoBackend, WriteContext};
-use regelrecht_corpus::source_map::{extract_law_id, LoadedLaw};
+use regelrecht_corpus::source_map::{extract_law_id, validate_yaml_syntax, LoadedLaw};
 use regelrecht_corpus::CorpusError;
 
 use crate::state::AppState;
@@ -484,14 +484,34 @@ pub async fn save_law(
     Path(law_id): Path<String>,
     body: String,
 ) -> Result<StatusCode, (StatusCode, String)> {
-    // Minimal validation: body must have a top-level `$id` that matches
-    // the path parameter. We do NOT run full schema validation here — the
-    // frontend already blocks incomplete operation stubs
-    // (findIncompleteOperation) and the YAML pane has a live parse check.
-    // Full JSON Schema validation is a separate follow-up (mirroring
-    // `just validate`). Using the same line-based extractor the corpus
-    // loader uses keeps the "is this a loadable law file?" check consistent
-    // with how source_map decides which files to track.
+    // Validation:
+    //   1. Body must parse as well-formed YAML. extract_law_id below is a
+    //      line-based scanner that happily accepts "$id: foo\n<garbage>",
+    //      so without this check a syntactically broken body would land on
+    //      disk and corrupt the corpus source file.
+    //   2. Body must have a top-level `$id` field.
+    //   3. That `$id` must match the path parameter. Any mismatch is either
+    //      a phantom-law attempt (new id lands on an existing file) or an
+    //      orphaning (old id becomes unfetchable); reject up-front.
+    //
+    // We do NOT run full JSON Schema validation here — the frontend blocks
+    // incomplete operation stubs (findIncompleteOperation) and the YAML
+    // pane has a live parse check. Full schema validation is a separate
+    // follow-up (mirroring `just validate`).
+    //
+    // The mismatch error body intentionally does NOT echo the user-supplied
+    // `body_id`: it flows through the frontend into ndd-inline-dialog's
+    // supporting-text and we don't want self-XSS if the dialog ever renders
+    // that attribute as markup. The path law_id is already known to the
+    // caller, so the generic message is sufficient.
+    validate_yaml_syntax(&body).map_err(|e| {
+        tracing::debug!(law_id = %law_id, error = %e, "save_law received malformed YAML body");
+        (
+            StatusCode::BAD_REQUEST,
+            "Body is not valid YAML".to_string(),
+        )
+    })?;
+
     let body_id = extract_law_id(&body).ok_or_else(|| {
         (
             StatusCode::BAD_REQUEST,
@@ -502,10 +522,7 @@ pub async fn save_law(
     if body_id != law_id {
         return Err((
             StatusCode::BAD_REQUEST,
-            format!(
-                "Body $id '{}' does not match path law_id '{}'",
-                body_id, law_id
-            ),
+            "Body $id does not match path law_id".to_string(),
         ));
     }
 

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -100,12 +100,21 @@ async fn main() {
     // streaming an arbitrarily large body to disk — important when OIDC
     // is disabled in local dev and the endpoint is reachable without auth.
     const MAX_SCENARIO_BODY: usize = 1024 * 1024;
+    // Law YAMLs are larger than scenarios — zorgtoeslag's ~25 KiB is typical
+    // but federated regulations can reach a few hundred KiB. A 5 MiB cap
+    // gives ample headroom while still rejecting pathological bodies.
+    const MAX_LAW_BODY: usize = 5 * 1024 * 1024;
     let protected_api_routes = Router::new()
         .route(
             "/api/corpus/laws/{law_id}/scenarios/{filename}",
             axum::routing::put(corpus_handlers::save_scenario)
                 .delete(corpus_handlers::delete_scenario)
                 .layer(axum::extract::DefaultBodyLimit::max(MAX_SCENARIO_BODY)),
+        )
+        .route(
+            "/api/corpus/laws/{law_id}",
+            axum::routing::put(corpus_handlers::save_law)
+                .layer(axum::extract::DefaultBodyLimit::max(MAX_LAW_BODY)),
         )
         .route_layer(axum_middleware::from_fn_with_state(
             app_state.clone(),


### PR DESCRIPTION
## Summary

Closes the edit → re-execute loop the editor was built for.

Before this PR, machine_readable edits lived in memory only and the WASM engine kept running scenarios against the originally fetched YAML — so no UI edit could ever flip a red scenario to green. This PR wires the propagation chain end-to-end and adds a backend save endpoint so edits survive a page reload (inside the same container, via the existing ephemeral writable-scratch-copy on `LocalBackend`).

### What changed

- **`currentLawYaml` computed** in `EditorApp.vue` reassembles `rawYaml` with the currently selected article's in-memory `machine_readable` substituted. It replaces `rawYaml` as both the engine-load watch source and the `ScenarioBuilder` `lawYaml` prop, so edits flow through to auto-execute automatically.
- **`PUT /api/corpus/laws/{law_id}`** in `editor-api`, mirroring the scenario save path from #422: protected, routes through `resolve_backend_for_law`, refreshes the in-memory `SourceMap` after a write. The corpus lib gets a new `SourceMap::update_yaml_content` and `extract_law_id` is made `pub` for this.
- **Save button** on the `MachineReadable` panel with `JSON.stringify` structural dirty-state tracking (sufficient because `machineReadable` is seeded via JSON clone, so key order is stable in the field-edit path).
- **Fix: `ActionSheet` null-guard** — the template read `action.output` unconditionally inside `v-if="editable"`, crashing Vue's render pipeline whenever the editor loaded with `editable=true` and `action=null`. Adding `&& action` keeps it inert until the sheet actually has an action.
- **Fix: operation settings spacing** — the `h4` inside `ndd-title` kept its browser-default bottom margin, collapsing into the 4px spacer below and crowding the textfields ("textboxes vallen onder de titel"). Bumped the spacer to 12px and reset `h4` margin via a component-scoped class selector.
- **E2E spec** `frontend/e2e/edit-test-loop.spec.js`: opens zorgtoeslagwet article 2, asserts the *Minderjarige heeft geen recht op zorgtoeslag* scenario is red, patches the YAML pane to add a `leeftijd` input + `GREATER_THAN_OR_EQUAL` condition, and asserts the scenario turns green. Mocks all corpus API routes from the on-disk corpus so it runs without a live editor-api.

### Test plan

- [x] `just format` / `just lint` / `just build-check` / `just validate`
- [x] `just editor-api-fmt` / `just editor-api-lint` / `just editor-api-check`
- [x] `just test` (engine) — 324 passed
- [x] `cargo test -p regelrecht-corpus` — 60 passed (incl. 3 new `update_yaml_content` tests)
- [x] `npm test` (frontend vitest) — 59 passed (incl. 6 new MachineReadable save-bar tests)
- [x] `npx playwright test edit-test-loop.spec.js` — passes in ~2m
- [x] Manual curl smoke test of the `PUT /api/corpus/laws/{law_id}` endpoint + cache refresh (via GET)
- [ ] CI

### Notes / out of scope

- `just check` also runs `admin-test` which uses `testcontainers` and timed out on pool creation in this environment — unrelated to this PR.
- The other e2e specs (`action-crud`, `definitions`, `inputs`, `full-roundtrip`, etc.) were already broken on `main` because `helpers.selectArticle` looks for article tabs in `ndd-document-tab-bar` and the tab bar only shows already-opened tabs post-multi-tab. My new spec bypasses this by using the `?article=` URL param. Fixing the other specs is out of scope for this PR.
- Full JSON Schema validation on the `PUT` endpoint is deliberately left as a follow-up (frontend already blocks incomplete operation stubs).
- An `editor-api` integration test harness for the new `save_law` handler is out of scope (the package has no existing test infrastructure); the backend was smoke-tested manually via curl during development.