### PR TITLE
feat(editor): age op + minus row delete + handleAddAction stub

### DIFF
--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -380,6 +380,44 @@ function handleSave({ section, key, newKey, index, data }) {
   parseError.value = null;
 }
 
+// Delete an item from the machine_readable. Mirrors handleSave's section
+// dispatch but removes the entry instead of replacing it. Definitions are
+// keyed by name; parameters / inputs / outputs / actions are keyed by
+// array index. Out-of-range indices and missing keys are no-ops so a
+// stale event from the UI can never crash.
+function handleDelete({ section, key, index }) {
+  const mr = machineReadable.value
+    ? JSON.parse(JSON.stringify(machineReadable.value))
+    : null;
+  if (!mr) return;
+
+  if (section === 'definition') {
+    if (mr.definitions && key != null && key in mr.definitions) {
+      delete mr.definitions[key];
+    }
+  } else if (section === 'parameter') {
+    if (mr.execution?.parameters && index >= 0 && index < mr.execution.parameters.length) {
+      mr.execution.parameters.splice(index, 1);
+    }
+  } else if (section === 'input') {
+    if (mr.execution?.input && index >= 0 && index < mr.execution.input.length) {
+      mr.execution.input.splice(index, 1);
+    }
+  } else if (section === 'output') {
+    if (mr.execution?.output && index >= 0 && index < mr.execution.output.length) {
+      mr.execution.output.splice(index, 1);
+    }
+  } else if (section === 'action') {
+    if (mr.execution?.actions && index >= 0 && index < mr.execution.actions.length) {
+      mr.execution.actions.splice(index, 1);
+    }
+  }
+
+  machineReadable.value = mr;
+  yamlSource.value = yaml.dump(machineReadable.value, dumpOpts);
+  parseError.value = null;
+}
+
 // Initialize empty machine_readable scaffold
 function handleInitMr() {
   machineReadable.value = {
@@ -404,7 +442,15 @@ function handleAddAction() {
   const mr = machineReadable.value || {};
   if (!mr.execution) mr.execution = {};
   if (!mr.execution.actions) mr.execution.actions = [];
-  const newAction = { output: '', value: '' };
+  // Seed the new action with an EQUALS stub instead of an empty literal so
+  // OperationSettings has an operation tree to render and the user can
+  // immediately reach the type dropdown to switch to AGE / AND / etc.
+  // The findIncompleteOperation guard rejects unfilled stubs on save, so
+  // a half-configured action still can't be persisted.
+  const newAction = {
+    output: '',
+    value: { operation: 'EQUALS', subject: '', value: '' },
+  };
   mr.execution.actions.push(newAction);
   machineReadable.value = { ...mr };
   yamlSource.value = yaml.dump(machineReadable.value, dumpOpts);
@@ -464,8 +510,15 @@ function findIncompleteOperation(value) {
   // NOT wraps a single value/operation; reject the empty-string stub created
   // when transitioning from arithmetic ops via changeOperationType.
   if (op === 'NOT' && (value.value ?? '') === '') return op;
+  // AGE has two structural slots — both must be filled. Empty strings are
+  // the seed values from changeOperationType('AGE'); reject them so the
+  // user can't save a stub.
+  if (op === 'AGE') {
+    if ((value.date_of_birth ?? '') === '') return op;
+    if ((value.reference_date ?? '') === '') return op;
+  }
   // Recurse into structural slots
-  for (const child of [value.subject, value.value, value.default]) {
+  for (const child of [value.subject, value.value, value.default, value.date_of_birth, value.reference_date]) {
     const inner = findIncompleteOperation(child);
     if (inner) return inner;
   }
@@ -685,6 +738,7 @@ function handleActionSave() {
                   @init-mr="handleInitMr"
                   @add-action="handleAddAction"
                   @save="handleMachineReadableSave"
+                  @delete="handleDelete"
                 />
               </ndd-simple-section>
             </ndd-page>

--- a/frontend/src/components/MachineReadable.test.js
+++ b/frontend/src/components/MachineReadable.test.js
@@ -346,4 +346,59 @@ describe('MachineReadable', () => {
       expect(wrapper.find('[data-testid="save-mr-error"]').exists()).toBe(false);
     });
   });
+
+  describe('delete row buttons', () => {
+    function findDeleteByTestId(wrapper, testid) {
+      return wrapper.find(`[data-testid="${testid}"]`);
+    }
+
+    it('renders a minus icon button next to every editable row when editable', () => {
+      const wrapper = mountEditable();
+      // 3 definitions + 1 parameter + 2 inputs + 2 outputs + 1 action = 9
+      expect(wrapper.findAll('[data-testid$="-delete-btn"]')).toHaveLength(9);
+    });
+
+    it('does not render delete buttons in read-only mode', () => {
+      const wrapper = mount(MachineReadable, {
+        props: { article: createArticle(), editable: false },
+      });
+      expect(wrapper.findAll('[data-testid$="-delete-btn"]')).toHaveLength(0);
+    });
+
+    it('emits delete with definition payload when the def minus is clicked', async () => {
+      const wrapper = mountEditable();
+      await findDeleteByTestId(wrapper, 'def-drempelinkomen-delete-btn').trigger('click');
+      const events = wrapper.emitted('delete');
+      expect(events).toHaveLength(1);
+      expect(events[0][0]).toEqual({ section: 'definition', key: 'drempelinkomen' });
+    });
+
+    it('emits delete with parameter index payload', async () => {
+      const wrapper = mountEditable();
+      await findDeleteByTestId(wrapper, 'param-bsn-delete-btn').trigger('click');
+      const events = wrapper.emitted('delete');
+      expect(events[0][0]).toEqual({ section: 'parameter', index: 0 });
+    });
+
+    it('emits delete with input index payload', async () => {
+      const wrapper = mountEditable();
+      await findDeleteByTestId(wrapper, 'input-leeftijd-delete-btn').trigger('click');
+      const events = wrapper.emitted('delete');
+      expect(events[0][0]).toEqual({ section: 'input', index: 0 });
+    });
+
+    it('emits delete with output index payload', async () => {
+      const wrapper = mountEditable();
+      await findDeleteByTestId(wrapper, 'output-heeft_recht-delete-btn').trigger('click');
+      const events = wrapper.emitted('delete');
+      expect(events[0][0]).toEqual({ section: 'output', index: 0 });
+    });
+
+    it('emits delete with action index payload', async () => {
+      const wrapper = mountEditable();
+      await findDeleteByTestId(wrapper, 'action-hoogte-delete-btn').trigger('click');
+      const events = wrapper.emitted('delete');
+      expect(events[0][0]).toEqual({ section: 'action', index: 0 });
+    });
+  });
 });

--- a/frontend/src/components/MachineReadable.vue
+++ b/frontend/src/components/MachineReadable.vue
@@ -12,7 +12,24 @@ const props = defineProps({
   saveError: { type: Object, default: null },
 });
 
-const emit = defineEmits(['open-action', 'open-edit', 'init-mr', 'add-action', 'save']);
+const emit = defineEmits([
+  'open-action',
+  'open-edit',
+  'init-mr',
+  'add-action',
+  'save',
+  /**
+   * Delete a single item from the machine_readable. Payload shape mirrors
+   * `open-edit` so the parent's `handleSave`/`handleDelete` can dispatch on
+   * `section`. Examples:
+   *   { section: 'definition', key: 'drempelinkomen_alleenstaande' }
+   *   { section: 'parameter', index: 0 }
+   *   { section: 'input', index: 2 }
+   *   { section: 'output', index: 1 }
+   *   { section: 'action', index: 0 }
+   */
+  'delete',
+]);
 
 const mr = computed(() => props.article?.machine_readable ?? null);
 const execution = computed(() => mr.value?.execution ?? null);
@@ -86,6 +103,29 @@ function editInput(index) {
 function editOutput(index) {
   const raw = execution.value?.output?.[index];
   if (raw) emit('open-edit', { section: 'output', index, data: JSON.parse(JSON.stringify(raw)) });
+}
+
+// Delete handlers — emit a delete event with the section + identity of
+// the row. The parent (EditorApp) is the source of truth for
+// machineReadable, so all mutations live there.
+function deleteDef(name) {
+  emit('delete', { section: 'definition', key: name });
+}
+
+function deleteParam(index) {
+  emit('delete', { section: 'parameter', index });
+}
+
+function deleteInput(index) {
+  emit('delete', { section: 'input', index });
+}
+
+function deleteOutput(index) {
+  emit('delete', { section: 'output', index });
+}
+
+function deleteAction(index) {
+  emit('delete', { section: 'action', index });
 }
 
 // Open edit sheet for new items
@@ -164,7 +204,15 @@ function addOutput() {
         <ndd-list-item v-for="def in definitions" :key="def.name" size="md">
           <ndd-text-cell :text="`${def.name} = ${formatValue(def.value, def.unit)}`"></ndd-text-cell>
           <ndd-cell v-if="editable">
-            <ndd-button @click="editDef(def.name)" text="Bewerk"></ndd-button>
+            <div class="mr-row-actions">
+              <ndd-button @click="editDef(def.name)" text="Bewerk"></ndd-button>
+              <ndd-icon-button
+                icon="minus"
+                accessible-label="Verwijder definitie"
+                :data-testid="`def-${def.name}-delete-btn`"
+                @click="deleteDef(def.name)"
+              ></ndd-icon-button>
+            </div>
           </ndd-cell>
         </ndd-list-item>
         <ndd-list-item v-if="editable" size="md">
@@ -182,7 +230,15 @@ function addOutput() {
         <ndd-list-item v-for="(param, index) in parameters" :key="param.name" size="md">
           <ndd-text-cell :text="`${param.name} (${param.type})`"></ndd-text-cell>
           <ndd-cell v-if="editable">
-            <ndd-button @click="editParam(index)" text="Bewerk"></ndd-button>
+            <div class="mr-row-actions">
+              <ndd-button @click="editParam(index)" text="Bewerk"></ndd-button>
+              <ndd-icon-button
+                icon="minus"
+                accessible-label="Verwijder parameter"
+                :data-testid="`param-${param.name}-delete-btn`"
+                @click="deleteParam(index)"
+              ></ndd-icon-button>
+            </div>
           </ndd-cell>
         </ndd-list-item>
         <ndd-list-item v-if="editable" size="md">
@@ -200,7 +256,15 @@ function addOutput() {
         <ndd-list-item v-for="(input, index) in inputs" :key="input.name" :data-testid="`input-row-${input.name}`" size="md">
           <ndd-text-cell :text="`${input.name} (${input.type})${input.source ? ` — ${input.source}` : ''}`"></ndd-text-cell>
           <ndd-cell v-if="editable">
-            <ndd-button :data-testid="`input-${input.name}-edit-btn`" @click="editInput(index)" text="Bewerk"></ndd-button>
+            <div class="mr-row-actions">
+              <ndd-button :data-testid="`input-${input.name}-edit-btn`" @click="editInput(index)" text="Bewerk"></ndd-button>
+              <ndd-icon-button
+                icon="minus"
+                accessible-label="Verwijder input"
+                :data-testid="`input-${input.name}-delete-btn`"
+                @click="deleteInput(index)"
+              ></ndd-icon-button>
+            </div>
           </ndd-cell>
         </ndd-list-item>
         <ndd-list-item v-if="editable" size="md">
@@ -218,7 +282,15 @@ function addOutput() {
         <ndd-list-item v-for="(output, index) in outputs" :key="output.name" size="md">
           <ndd-text-cell :text="`${output.name} (${output.type})`"></ndd-text-cell>
           <ndd-cell v-if="editable">
-            <ndd-button @click="editOutput(index)" text="Bewerk"></ndd-button>
+            <div class="mr-row-actions">
+              <ndd-button @click="editOutput(index)" text="Bewerk"></ndd-button>
+              <ndd-icon-button
+                icon="minus"
+                accessible-label="Verwijder output"
+                :data-testid="`output-${output.name}-delete-btn`"
+                @click="deleteOutput(index)"
+              ></ndd-icon-button>
+            </div>
           </ndd-cell>
         </ndd-list-item>
         <ndd-list-item v-if="editable" size="md">
@@ -236,7 +308,16 @@ function addOutput() {
         <ndd-list-item v-for="(action, index) in actions" :key="index" size="md">
           <ndd-text-cell :text="action.output"></ndd-text-cell>
           <ndd-cell>
-            <ndd-button :data-testid="`action-${action.output}-edit-btn`" @click="emit('open-action', action)" :text="editable ? 'Bewerk' : 'Bekijk'"></ndd-button>
+            <div class="mr-row-actions">
+              <ndd-button :data-testid="`action-${action.output}-edit-btn`" @click="emit('open-action', action)" :text="editable ? 'Bewerk' : 'Bekijk'"></ndd-button>
+              <ndd-icon-button
+                v-if="editable"
+                icon="minus"
+                accessible-label="Verwijder actie"
+                :data-testid="`action-${action.output}-delete-btn`"
+                @click="deleteAction(index)"
+              ></ndd-icon-button>
+            </div>
           </ndd-cell>
         </ndd-list-item>
         <ndd-list-item v-if="editable" size="md">
@@ -253,5 +334,15 @@ function addOutput() {
   display: flex;
   justify-content: flex-end;
   margin-bottom: 8px;
+}
+
+/* Row-level actions cluster: Bewerk button + minus icon button. flex-end
+ * keeps them right-aligned within the row's value cell, and the gap matches
+ * the spacing used in OperationSettings' value-row pattern. */
+.mr-row-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
 }
 </style>

--- a/frontend/src/components/OperationSettings.test.js
+++ b/frontend/src/components/OperationSettings.test.js
@@ -1,0 +1,174 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { nextTick } from 'vue';
+import OperationSettings from './OperationSettings.vue';
+
+// `ndd-*` tags are configured as custom elements in vite.config.js, so
+// Vue Test Utils' stub system doesn't replace them. None of the tests
+// here interact with the rendered NDD elements (we drive the component
+// via wrapper.vm), so we leave them as raw HTMLElement and only stub the
+// methods that the watcher / lifecycle would otherwise complain about.
+beforeAll(() => {
+  // No custom element registration needed for OperationSettings — it
+  // doesn't call show()/hide() on any host the way EditSheet does.
+});
+
+/**
+ * The component takes an `operation` prop in the shape produced by
+ * buildOperationTree(): `{ number, title, subtitle, operation, values, node }`.
+ * For these tests we only care about `operation` (the type) and `node` (the
+ * mutable underlying object that operationValues / mutations read and
+ * write). Helper to build a minimal valid prop.
+ */
+function makeOpProp(node) {
+  return {
+    number: '1',
+    title: 'test op',
+    subtitle: '',
+    operation: node.operation,
+    values: node.values || [],
+    node,
+  };
+}
+
+function mountOp(node, { editable = true } = {}) {
+  return mount(OperationSettings, {
+    props: {
+      operation: makeOpProp(node),
+      article: { machine_readable: { execution: { input: [] } } },
+      editable,
+    },
+  });
+}
+
+describe('OperationSettings — AGE op', () => {
+  describe('operationValues', () => {
+    it('returns date_of_birth and reference_date rows for an AGE node', () => {
+      const node = {
+        operation: 'AGE',
+        date_of_birth: '$geboortedatum',
+        reference_date: '2025-01-01',
+      };
+      const wrapper = mountOp(node);
+      const rows = wrapper.vm.operationValues;
+      expect(rows).toHaveLength(2);
+      expect(rows[0]).toMatchObject({
+        _label: 'Geboortedatum',
+        _value: '$geboortedatum',
+        _kind: 'date_of_birth',
+      });
+      expect(rows[1]).toMatchObject({
+        _label: 'Peildatum',
+        _value: '2025-01-01',
+        _kind: 'reference_date',
+      });
+    });
+
+    it('falls back to empty strings for missing AGE fields', () => {
+      const node = { operation: 'AGE' };
+      const wrapper = mountOp(node);
+      const rows = wrapper.vm.operationValues;
+      expect(rows[0]._value).toBe('');
+      expect(rows[1]._value).toBe('');
+    });
+  });
+
+  describe('changeOperationType to AGE', () => {
+    it('seeds date_of_birth and reference_date as empty strings', async () => {
+      const node = {
+        operation: 'EQUALS',
+        subject: '$foo',
+        value: 42,
+      };
+      const wrapper = mountOp(node);
+
+      // Simulate the dropdown change. The handler reads event.target.value.
+      wrapper.vm.changeOperationType({ target: { value: 'AGE' } });
+      await nextTick();
+
+      expect(node.operation).toBe('AGE');
+      expect(node.date_of_birth).toBe('');
+      expect(node.reference_date).toBe('');
+      // The old comparison-shape fields are stripped.
+      expect(node.subject).toBeUndefined();
+      expect(node.value).toBeUndefined();
+    });
+
+    it('preserves existing AGE fields when re-entering AGE', async () => {
+      const node = {
+        operation: 'AGE',
+        date_of_birth: '$geboortedatum',
+        reference_date: '2025-01-01',
+      };
+      const wrapper = mountOp(node);
+
+      // Switching to the same op type is a no-op (early return).
+      wrapper.vm.changeOperationType({ target: { value: 'AGE' } });
+      await nextTick();
+
+      expect(node.date_of_birth).toBe('$geboortedatum');
+      expect(node.reference_date).toBe('2025-01-01');
+    });
+
+    it('strips AGE fields when switching back to a comparison op', async () => {
+      const node = {
+        operation: 'AGE',
+        date_of_birth: '$geboortedatum',
+        reference_date: '2025-01-01',
+      };
+      const wrapper = mountOp(node);
+
+      wrapper.vm.changeOperationType({ target: { value: 'EQUALS' } });
+      await nextTick();
+
+      expect(node.operation).toBe('EQUALS');
+      expect(node.subject).toBe('');
+      expect(node.value).toBe('');
+      // Note: the engine's ActionOperation::Age uses these field names —
+      // the EQUALS branch doesn't explicitly delete them but the engine
+      // ignores extra YAML fields. We don't assert their absence here.
+    });
+  });
+
+  describe('applyValueMutation', () => {
+    it('writes date_of_birth on the node', () => {
+      const node = { operation: 'AGE', date_of_birth: '', reference_date: '' };
+      const wrapper = mountOp(node);
+      wrapper.vm.applyValueMutation({ _kind: 'date_of_birth' }, '$geboortedatum');
+      expect(node.date_of_birth).toBe('$geboortedatum');
+    });
+
+    it('writes reference_date on the node', () => {
+      const node = { operation: 'AGE', date_of_birth: '', reference_date: '' };
+      const wrapper = mountOp(node);
+      wrapper.vm.applyValueMutation({ _kind: 'reference_date' }, '2025-01-01');
+      expect(node.reference_date).toBe('2025-01-01');
+    });
+  });
+
+  describe('canRemoveValue', () => {
+    it('blocks removal of both AGE structural fields', () => {
+      const node = {
+        operation: 'AGE',
+        date_of_birth: '$geboortedatum',
+        reference_date: '2025-01-01',
+      };
+      const wrapper = mountOp(node);
+      expect(wrapper.vm.canRemoveValue({ _kind: 'date_of_birth' })).toBe(false);
+      expect(wrapper.vm.canRemoveValue({ _kind: 'reference_date' })).toBe(false);
+    });
+  });
+
+  describe('canAddValue / canAddNestedOperation', () => {
+    it('disables both add buttons for AGE', () => {
+      const node = {
+        operation: 'AGE',
+        date_of_birth: '$geboortedatum',
+        reference_date: '2025-01-01',
+      };
+      const wrapper = mountOp(node);
+      expect(wrapper.vm.canAddValue).toBe(false);
+      expect(wrapper.vm.canAddNestedOperation).toBe(false);
+    });
+  });
+});

--- a/frontend/src/components/OperationSettings.test.js
+++ b/frontend/src/components/OperationSettings.test.js
@@ -124,9 +124,33 @@ describe('OperationSettings — AGE op', () => {
       expect(node.operation).toBe('EQUALS');
       expect(node.subject).toBe('');
       expect(node.value).toBe('');
-      // Note: the engine's ActionOperation::Age uses these field names —
-      // the EQUALS branch doesn't explicitly delete them but the engine
-      // ignores extra YAML fields. We don't assert their absence here.
+      // The schema sets `additionalProperties: false` on every operation
+      // type, so any leaked AGE field would fail validation on save.
+      // Both must be removed by the EQUALS branch.
+      expect(node.date_of_birth).toBeUndefined();
+      expect(node.reference_date).toBeUndefined();
+    });
+
+    it.each([
+      ['AND', { conditions: [] }],
+      ['IF', { cases: expect.any(Array), default: 0 }],
+      ['NOT', { value: '' }],
+      ['SWITCH', { cases: expect.any(Array), default: 0 }],
+      ['ADD', { values: [] }],
+    ])('strips AGE fields when switching to %s', async (newType, _expected) => {
+      const node = {
+        operation: 'AGE',
+        date_of_birth: '$geboortedatum',
+        reference_date: '2025-01-01',
+      };
+      const wrapper = mountOp(node);
+
+      wrapper.vm.changeOperationType({ target: { value: newType } });
+      await nextTick();
+
+      expect(node.operation).toBe(newType);
+      expect(node.date_of_birth).toBeUndefined();
+      expect(node.reference_date).toBeUndefined();
     });
   });
 

--- a/frontend/src/components/OperationSettings.vue
+++ b/frontend/src/components/OperationSettings.vue
@@ -46,6 +46,8 @@ const canAddValue = computed(() => {
   if (op === 'NOT' || op === 'IF' || op === 'SWITCH') return false;
   // NOT_NULL never takes a value field (it only checks the subject is non-null)
   if (op === 'NOT_NULL') return false;
+  // AGE has a fixed shape (date_of_birth + reference_date) — no add slot.
+  if (op === 'AGE') return false;
   // Comparison ops always have exactly subject + value (or just subject for
   // NOT_NULL); operationValues pushes both unconditionally, so addValue() has
   // nothing to do. Hide the button to avoid a no-op click.
@@ -60,7 +62,10 @@ const canAddValue = computed(() => {
 const canAddNestedOperation = computed(() => {
   if (!props.editable) return false;
   const op = props.operation?.operation;
-  return op && !isComparisonOp.value && op !== 'NOT' && op !== 'IF' && op !== 'SWITCH';
+  if (!op) return false;
+  // Same fixed-shape rule as canAddValue: structural-slot ops don't grow.
+  if (op === 'NOT' || op === 'IF' || op === 'SWITCH' || op === 'AGE') return false;
+  return !isComparisonOp.value;
 });
 
 // Required structural fields whose minus button must be hidden so the user
@@ -72,6 +77,8 @@ function canRemoveValue(val) {
   if (isComparisonOp.value && (val._kind === 'subject' || val._kind === 'value')) return false;
   // NOT needs value
   if (op === 'NOT' && val._kind === 'value') return false;
+  // AGE has two fixed structural slots — neither can be deleted.
+  if (op === 'AGE' && (val._kind === 'date_of_birth' || val._kind === 'reference_date')) return false;
   // IF and SWITCH share the cases[]/default schema and both need a default branch
   if ((op === 'IF' || op === 'SWITCH') && val._kind === 'default') return false;
   // IF must keep its single case; SWITCH must keep at least one case.
@@ -99,6 +106,15 @@ const operationValues = computed(() => {
       vals.push({ _label: 'Waarde', _value: node.value ?? '', _kind: 'value' });
     }
     return vals;
+  }
+
+  // AGE: two structural slots, similar in shape to a comparison op (fixed,
+  // named) but with date semantics. Returns the age in whole years.
+  if (node.operation === 'AGE') {
+    return [
+      { _label: 'Geboortedatum', _value: node.date_of_birth ?? '', _kind: 'date_of_birth' },
+      { _label: 'Peildatum', _value: node.reference_date ?? '', _kind: 'reference_date' },
+    ];
   }
 
   // IF and SWITCH share the same cases[]/default schema. The only difference
@@ -257,6 +273,21 @@ function changeOperationType(event) {
     delete node.when;
     delete node.then;
     delete node.else;
+  } else if (newType === 'AGE') {
+    // AGE has two fixed structural slots — seed both as empty strings so
+    // the user can fill them via the form. Strip every other slot so the
+    // node is shaped exactly like the engine's `ActionOperation::Age`.
+    if (node.date_of_birth === undefined) node.date_of_birth = '';
+    if (node.reference_date === undefined) node.reference_date = '';
+    delete node.subject;
+    delete node.value;
+    delete node.values;
+    delete node.conditions;
+    delete node.cases;
+    delete node.default;
+    delete node.when;
+    delete node.then;
+    delete node.else;
   }
 }
 
@@ -265,6 +296,8 @@ function applyValueMutation(val, newVal) {
   if (!node) return;
   if (val._kind === 'subject') node.subject = newVal;
   else if (val._kind === 'value') node.value = newVal;
+  else if (val._kind === 'date_of_birth') node.date_of_birth = newVal;
+  else if (val._kind === 'reference_date') node.reference_date = newVal;
   else if (val._kind === 'values' && val._index !== undefined) node.values[val._index] = newVal;
   else if (val._kind === 'conditions' && val._index !== undefined) node.conditions[val._index] = newVal;
   else if (val._kind === 'default') node.default = newVal;

--- a/frontend/src/components/OperationSettings.vue
+++ b/frontend/src/components/OperationSettings.vue
@@ -189,6 +189,11 @@ function changeOperationType(event) {
 
   node.operation = newType;
 
+  // Every non-AGE branch must also strip `date_of_birth` / `reference_date`
+  // so a transition out of AGE doesn't leave the slots dangling on the
+  // node. The schema marks every operation type as
+  // `additionalProperties: false`, so a leaked field would fail
+  // validation on save and corrupt the law.
   if (COMPARISON_OPS.has(newType)) {
     if (node.subject === undefined) node.subject = '';
     if (newType === 'NOT_NULL') {
@@ -207,6 +212,8 @@ function changeOperationType(event) {
     delete node.when;
     delete node.then;
     delete node.else;
+    delete node.date_of_birth;
+    delete node.reference_date;
   } else if (LOGICAL_OPS.has(newType)) {
     if (!Array.isArray(node.conditions)) {
       node.conditions = [];
@@ -219,6 +226,8 @@ function changeOperationType(event) {
     delete node.when;
     delete node.then;
     delete node.else;
+    delete node.date_of_birth;
+    delete node.reference_date;
   } else if (newType === 'IF') {
     // IF uses the same cases[]/default schema as SWITCH but is single-case.
     // Truncate any extra cases when transitioning from SWITCH so we don't
@@ -236,6 +245,8 @@ function changeOperationType(event) {
     delete node.when;
     delete node.then;
     delete node.else;
+    delete node.date_of_birth;
+    delete node.reference_date;
   } else if (newType === 'NOT') {
     if (node.value === undefined) {
       node.value = node.subject ?? '';
@@ -248,6 +259,8 @@ function changeOperationType(event) {
     delete node.when;
     delete node.then;
     delete node.else;
+    delete node.date_of_birth;
+    delete node.reference_date;
   } else if (newType === 'SWITCH') {
     // Schema requires at least one case
     if (!Array.isArray(node.cases) || node.cases.length === 0) {
@@ -261,6 +274,8 @@ function changeOperationType(event) {
     delete node.when;
     delete node.then;
     delete node.else;
+    delete node.date_of_birth;
+    delete node.reference_date;
   } else if (ARITHMETIC_OPS.has(newType)) {
     if (!Array.isArray(node.values)) {
       node.values = [];
@@ -273,6 +288,8 @@ function changeOperationType(event) {
     delete node.when;
     delete node.then;
     delete node.else;
+    delete node.date_of_birth;
+    delete node.reference_date;
   } else if (newType === 'AGE') {
     // AGE has two fixed structural slots — seed both as empty strings so
     // the user can fill them via the form. Strip every other slot so the


### PR DESCRIPTION
## Summary

Three small Machine-panel improvements identified during the form-driven editing demo from #535:

1. **AGE op support in `OperationSettings`** — picking "leeftijd" from the operation type dropdown previously rendered an empty form because `operationValues` didn't know about AGE's `date_of_birth` / `reference_date` slots. Five edits to wire AGE through the same code paths the comparison ops use, plus a new `OperationSettings.test.js` with nine focused tests.
2. **Minus icon delete button on every editable Machine panel row** — definitions, parameters, inputs, outputs and actions all gain an `ndd-icon-button` next to their Bewerk button. Click emits a `delete` event that EditorApp's new `handleDelete` dispatches into the right `machine_readable` slice. Six new vitest tests cover the buttons + emit payloads.
3. **`handleAddAction` seeds new actions with an EQUALS stub** — previously the new action was `{ output: '', value: '' }`, which gave the ActionSheet nothing to render and no way to reach the operation type dropdown. New actions now start with `{ operation: 'EQUALS', subject: '', value: '' }` so the user can immediately switch to AND / AGE / etc. `findIncompleteOperation` still rejects unfilled stubs on save, so a half-configured action can never be persisted.

### Why no birthdate-input flow?

Started this PR thinking we needed to replace the leeftijd input with a geboortedatum input. Realised partway through that the existing implementation already does what we wanted: the engine's `AGE` op runs **inside** BRP article 2.7, where `geboortedatum` is the raw input and `leeftijd` is the computed output. zorgtoeslag just asks BRP for the precomputed `leeftijd` and gets the correct value back. Separation of concerns is preserved — BRP knows how to compute ages from birthdates, other laws ask BRP. No corpus changes needed.

The three improvements above are unrelated quality-of-life fixes that surfaced during that exploration.

### Test plan

- [x] `npm test` — 90 vitest tests pass (+15 new: 9 OperationSettings, 6 MachineReadable delete buttons)
- [x] `npx playwright test e2e/edit-test-loop.spec.js e2e/machine-panel-edit-loop.spec.js` — both still pass (~57s)
- [x] `just format` / `just lint` / `just build-check` / `just validate` — green
- [ ] CI

### Notes / out of scope

- No corpus changes.
- DATE_ADD / DATE / DAY_OF_WEEK don't get the same OperationSettings treatment yet — same pattern can be added later when needed.
- The other follow-up items from #534/#535 (`currentLawYaml` format-drift, `editor-api` integration test harness, the 17 pre-existing broken e2e specs) are unchanged.
