### PR TITLE
feat(editor): search/select UI for input sources

### DIFF
--- a/frontend/e2e/helpers-corpus.js
+++ b/frontend/e2e/helpers-corpus.js
@@ -11,6 +11,7 @@
 import { readFileSync, readdirSync, statSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import yaml from 'js-yaml';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -95,16 +96,38 @@ export async function mockCorpusApi(page, corpus, scenarioLaw, scenarioFile) {
     if (url.pathname !== '/api/corpus/laws') {
       return route.fallback();
     }
-    const entries = [...corpus.entries()].map(([law_id]) => ({
-      law_id,
-      name: null,
-      source_id: 'local',
-      source_name: 'Local Test Corpus',
-    }));
+    const entries = [...corpus.entries()].map(([law_id, entry]) => {
+      const displayName = resolveDisplayName(entry.content);
+      return {
+        law_id,
+        name: null,
+        display_name: displayName,
+        source_id: 'local',
+        source_name: 'Local Test Corpus',
+      };
+    });
     return route.fulfill({
       status: 200,
       contentType: 'application/json',
       body: JSON.stringify(entries),
+    });
+  });
+
+  // GET /api/corpus/laws/{law_id}/outputs — list outputs from all articles.
+  await page.route('**/api/corpus/laws/*/outputs', (route, request) => {
+    const url = new URL(request.url());
+    const match = url.pathname.match(/\/api\/corpus\/laws\/([^/]+)\/outputs$/);
+    if (!match) return route.fallback();
+    const lawId = decodeURIComponent(match[1]);
+    const entry = corpus.get(lawId);
+    if (!entry) {
+      return route.fulfill({ status: 404, body: `Law '${lawId}' not found` });
+    }
+    const outputs = collectOutputs(entry.content);
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(outputs),
     });
   });
 
@@ -114,7 +137,7 @@ export async function mockCorpusApi(page, corpus, scenarioLaw, scenarioFile) {
   await page.route('**/api/corpus/laws/*', (route, request) => {
     const url = new URL(request.url());
     const pathname = url.pathname;
-    if (pathname.includes('/scenarios')) {
+    if (pathname.includes('/scenarios') || pathname.includes('/outputs')) {
       return route.fallback();
     }
     const lawId = decodeURIComponent(pathname.split('/').pop());
@@ -186,4 +209,57 @@ export async function mockCorpusApi(page, corpus, scenarioLaw, scenarioFile) {
       body: JSON.stringify({ authenticated: false, oidc_configured: false }),
     }),
   );
+}
+
+/**
+ * Resolve a law's display name from its YAML content. Mirrors the backend's
+ * `resolve_display_name` logic: literal name → return it; `#ref` → find the
+ * matching action output value.
+ */
+function resolveDisplayName(yamlContent) {
+  try {
+    const doc = yaml.load(yamlContent);
+    if (!doc) return null;
+    const name = doc.name;
+    if (typeof name === 'string' && !name.startsWith('#')) return name;
+    if (typeof name === 'string' && name.startsWith('#')) {
+      const ref = name.slice(1);
+      for (const article of doc.articles || []) {
+        for (const action of article.machine_readable?.execution?.actions || []) {
+          if (action.output === ref && typeof action.value === 'string') {
+            return action.value;
+          }
+        }
+      }
+    }
+  } catch { /* ignore parse errors */ }
+  return null;
+}
+
+/**
+ * Collect all outputs declared across all articles in a law's YAML.
+ * Returns `[{ name, output_type, article_number }]`, deduplicated by name.
+ */
+function collectOutputs(yamlContent) {
+  try {
+    const doc = yaml.load(yamlContent);
+    if (!doc?.articles) return [];
+    const seen = new Set();
+    const results = [];
+    for (const article of doc.articles) {
+      const outputs = article.machine_readable?.execution?.output || [];
+      for (const out of outputs) {
+        if (out.name && !seen.has(out.name)) {
+          seen.add(out.name);
+          results.push({
+            name: out.name,
+            output_type: out.type || 'string',
+            article_number: String(article.number || ''),
+          });
+        }
+      }
+    }
+    results.sort((a, b) => a.name.localeCompare(b.name));
+    return results;
+  } catch { return []; }
 }

--- a/frontend/e2e/helpers-corpus.js
+++ b/frontend/e2e/helpers-corpus.js
@@ -247,14 +247,20 @@ function collectOutputs(yamlContent) {
     const seen = new Set();
     const results = [];
     for (const article of doc.articles) {
-      const outputs = article.machine_readable?.execution?.output || [];
-      for (const out of outputs) {
+      const exec = article.machine_readable?.execution;
+      if (!exec) continue;
+      const params = (exec.parameters || []).map(p => ({
+        name: p.name,
+        param_type: p.type || 'string',
+      }));
+      for (const out of exec.output || []) {
         if (out.name && !seen.has(out.name)) {
           seen.add(out.name);
           results.push({
             name: out.name,
             output_type: out.type || 'string',
             article_number: String(article.number || ''),
+            parameters: params,
           });
         }
       }

--- a/frontend/src/components/EditSheet.test.js
+++ b/frontend/src/components/EditSheet.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
 import { nextTick } from 'vue';
 import EditSheet from './EditSheet.vue';
@@ -421,6 +421,138 @@ describe('EditSheet', () => {
       await nextTick();
       const events = wrapper.emitted('save');
       expect(events[0][0].data.type_spec).toEqual({ unit: 'eurocent' });
+    });
+  });
+
+  describe('input — law search/select', () => {
+    const mockLaws = [
+      { law_id: 'wet_basisregistratie_personen', name: null, display_name: 'Wet basisregistratie personen', source_id: 'local', source_name: 'Local' },
+      { law_id: 'zorgtoeslagwet', name: null, display_name: 'Wet op de zorgtoeslag', source_id: 'local', source_name: 'Local' },
+      { law_id: 'kieswet', name: 'Kieswet', display_name: 'Kieswet', source_id: 'local', source_name: 'Local' },
+    ];
+    const mockOutputs = [
+      { name: 'leeftijd', output_type: 'number', article_number: '2.7' },
+      { name: 'heeft_partner', output_type: 'boolean', article_number: '2.8' },
+    ];
+    let fetchSpy;
+
+    beforeEach(() => {
+      fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+        const urlStr = typeof url === 'string' ? url : url.toString();
+        if (urlStr.includes('/api/corpus/laws') && urlStr.includes('/outputs')) {
+          return { ok: true, json: async () => mockOutputs };
+        }
+        if (urlStr.includes('/api/corpus/laws')) {
+          return { ok: true, json: async () => mockLaws };
+        }
+        return { ok: false, json: async () => ({}) };
+      });
+    });
+
+    afterEach(() => {
+      fetchSpy.mockRestore();
+    });
+
+    it('selectLaw sets sourceRegulation and fetches outputs', async () => {
+      const wrapper = mountSheet();
+      await setItem(wrapper, { section: 'add-input', isNew: true });
+      // Wait for fetchLawsList to complete
+      await vi.waitFor(() => expect(wrapper.vm.allLaws.length).toBeGreaterThan(0));
+
+      await wrapper.vm.selectLaw(mockLaws[0]);
+      await nextTick();
+
+      expect(wrapper.vm.values.sourceRegulation).toBe('wet_basisregistratie_personen');
+      expect(wrapper.vm.lawSearchQuery).toBe('Wet basisregistratie personen');
+      expect(wrapper.vm.showLawResults).toBe(false);
+      // Outputs should be fetched
+      await vi.waitFor(() => expect(wrapper.vm.availableOutputs.length).toBeGreaterThan(0));
+      expect(wrapper.vm.availableOutputs).toEqual(mockOutputs);
+    });
+
+    it('onOutputSelected auto-populates name and type when empty', async () => {
+      const wrapper = mountSheet();
+      await setItem(wrapper, { section: 'add-input', isNew: true });
+      await vi.waitFor(() => expect(wrapper.vm.allLaws.length).toBeGreaterThan(0));
+
+      // Set up outputs
+      await wrapper.vm.selectLaw(mockLaws[0]);
+      await vi.waitFor(() => expect(wrapper.vm.availableOutputs.length).toBeGreaterThan(0));
+
+      // Name is empty, type is default 'string'
+      expect(wrapper.vm.values.name).toBe('');
+      wrapper.vm.onOutputSelected('leeftijd');
+      expect(wrapper.vm.values.name).toBe('leeftijd');
+      expect(wrapper.vm.values.type).toBe('number');
+    });
+
+    it('onOutputSelected does NOT overwrite user-edited name', async () => {
+      const wrapper = mountSheet();
+      await setItem(wrapper, { section: 'add-input', isNew: true });
+      await vi.waitFor(() => expect(wrapper.vm.allLaws.length).toBeGreaterThan(0));
+
+      await wrapper.vm.selectLaw(mockLaws[0]);
+      await vi.waitFor(() => expect(wrapper.vm.availableOutputs.length).toBeGreaterThan(0));
+
+      // User already set a custom name
+      wrapper.vm.values.name = 'custom_input';
+      wrapper.vm.onOutputSelected('leeftijd');
+      expect(wrapper.vm.values.name).toBe('custom_input');
+    });
+
+    it('filteredLaws filters by display name', async () => {
+      const wrapper = mountSheet();
+      await setItem(wrapper, { section: 'add-input', isNew: true });
+      await vi.waitFor(() => expect(wrapper.vm.allLaws.length).toBeGreaterThan(0));
+
+      wrapper.vm.lawSearchQuery = 'zorgtoeslag';
+      await nextTick();
+      expect(wrapper.vm.filteredLaws.length).toBe(1);
+      expect(wrapper.vm.filteredLaws[0].law_id).toBe('zorgtoeslagwet');
+    });
+
+    it('filteredLaws also matches on law_id', async () => {
+      const wrapper = mountSheet();
+      await setItem(wrapper, { section: 'add-input', isNew: true });
+      await vi.waitFor(() => expect(wrapper.vm.allLaws.length).toBeGreaterThan(0));
+
+      wrapper.vm.lawSearchQuery = 'kieswet';
+      await nextTick();
+      expect(wrapper.vm.filteredLaws.length).toBe(1);
+      expect(wrapper.vm.filteredLaws[0].law_id).toBe('kieswet');
+    });
+
+    it('save emits correct data after search/select flow', async () => {
+      const wrapper = mountSheet();
+      await setItem(wrapper, { section: 'add-input', isNew: true });
+      await vi.waitFor(() => expect(wrapper.vm.allLaws.length).toBeGreaterThan(0));
+
+      await wrapper.vm.selectLaw(mockLaws[0]);
+      await vi.waitFor(() => expect(wrapper.vm.availableOutputs.length).toBeGreaterThan(0));
+      wrapper.vm.onOutputSelected('leeftijd');
+
+      wrapper.vm.save();
+      await nextTick();
+      const events = wrapper.emitted('save');
+      expect(events[0][0]).toMatchObject({
+        section: 'add-input',
+        data: {
+          name: 'leeftijd',
+          type: 'number',
+          source: {
+            regulation: 'wet_basisregistratie_personen',
+            output: 'leeftijd',
+          },
+        },
+      });
+    });
+
+    it('displayName resolves display_name, then name, then title-cased law_id', () => {
+      const wrapper = mountSheet();
+      const dn = wrapper.vm.displayName;
+      expect(dn({ display_name: 'Foo', name: 'Bar', law_id: 'baz' })).toBe('Foo');
+      expect(dn({ display_name: null, name: 'Bar', law_id: 'baz' })).toBe('Bar');
+      expect(dn({ display_name: null, name: null, law_id: 'wet_brp' })).toBe('Wet Brp');
     });
   });
 });

--- a/frontend/src/components/EditSheet.test.js
+++ b/frontend/src/components/EditSheet.test.js
@@ -431,8 +431,8 @@ describe('EditSheet', () => {
       { law_id: 'kieswet', name: 'Kieswet', display_name: 'Kieswet', source_id: 'local', source_name: 'Local' },
     ];
     const mockOutputs = [
-      { name: 'leeftijd', output_type: 'number', article_number: '2.7' },
-      { name: 'heeft_partner', output_type: 'boolean', article_number: '2.8' },
+      { name: 'leeftijd', output_type: 'number', article_number: '2.7', parameters: [{ name: 'bsn', param_type: 'string' }, { name: 'peildatum', param_type: 'date' }] },
+      { name: 'heeft_partner', output_type: 'boolean', article_number: '2.8', parameters: [{ name: 'bsn', param_type: 'string' }] },
     ];
     let fetchSpy;
 
@@ -470,7 +470,7 @@ describe('EditSheet', () => {
       expect(wrapper.vm.availableOutputs).toEqual(mockOutputs);
     });
 
-    it('onOutputSelected auto-populates name and type when empty', async () => {
+    it('onOutputSelected auto-populates name, type, and parameters', async () => {
       const wrapper = mountSheet();
       await setItem(wrapper, { section: 'add-input', isNew: true });
       await vi.waitFor(() => expect(wrapper.vm.allLaws.length).toBeGreaterThan(0));
@@ -484,6 +484,9 @@ describe('EditSheet', () => {
       wrapper.vm.onOutputSelected('leeftijd');
       expect(wrapper.vm.values.name).toBe('leeftijd');
       expect(wrapper.vm.values.type).toBe('number');
+      // Parameters pre-populated from the output's article
+      const paramKeys = wrapper.vm.values.sourceParameters.map(p => p.key);
+      expect(paramKeys).toEqual(['bsn', 'peildatum']);
     });
 
     it('onOutputSelected does NOT overwrite user-edited name', async () => {

--- a/frontend/src/components/EditSheet.vue
+++ b/frontend/src/components/EditSheet.vue
@@ -21,7 +21,7 @@ async function fetchLawsList() {
     if (!res.ok) return [];
     lawsCache = await res.json();
   } catch {
-    lawsCache = [];
+    return [];
   }
   return lawsCache;
 }

--- a/frontend/src/components/EditSheet.vue
+++ b/frontend/src/components/EditSheet.vue
@@ -162,6 +162,20 @@ watch(() => props.item, async (item) => {
   } else if (s === 'input' || s === 'add-input') {
     // Flatten source.parameters into an ordered key/value pair list so the
     // user can edit existing entries and add new ones via the form.
+    //
+    // Design decisions:
+    //   - Each row gets a stable `_rowId` (monotonic counter) so Vue's
+    //     v-for keying survives deletions without confusing focus or
+    //     data-testid attributes.
+    //   - `_origValue` preserves the original (un-stringified) value so
+    //     numeric/boolean parameters round-trip correctly when the user
+    //     doesn't touch the value field (avoids `peildatum: 2024` becoming
+    //     `peildatum: '2024'`). On save, if the stringified form hasn't
+    //     changed we emit the original typed value.
+    //   - Non-scalar parameter values (objects/arrays) are stashed in
+    //     `sourceParametersOverflow` and merged back on save so they
+    //     survive untouched — the user can only edit those via the YAML
+    //     pane.
     const params = item.data?.source?.parameters;
     const paramList = [];
     const overflowParams = {};
@@ -569,6 +583,7 @@ ndd-sheet.edit-sheet {
 }
 .law-search-container {
   position: relative;
+  z-index: 10;
   width: 100%;
 }
 .law-search-container ndd-search-field {
@@ -579,13 +594,13 @@ ndd-sheet.edit-sheet {
   top: 100%;
   left: 0;
   right: 0;
-  z-index: 100;
+  z-index: 1000;
   max-height: 240px;
   overflow-y: auto;
   background: var(--semantics-surface-primary-color, #fff);
   border: 1px solid var(--semantics-border-primary-color, #d1d5db);
   border-radius: 4px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
 }
 .law-search-result-item {
   cursor: pointer;

--- a/frontend/src/components/EditSheet.vue
+++ b/frontend/src/components/EditSheet.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, watch, nextTick } from 'vue';
+import { ref, computed, watch, nextTick } from 'vue';
 
 const props = defineProps({
   item: { type: Object, default: null },
@@ -11,6 +11,93 @@ const sheetEl = ref(null);
 const values = ref({});
 
 const typeOptions = ['string', 'number', 'boolean', 'amount'];
+
+// --- Law search / output selection ---
+let lawsCache = null;
+async function fetchLawsList() {
+  if (lawsCache) return lawsCache;
+  try {
+    const res = await fetch('/api/corpus/laws?limit=1000');
+    if (!res.ok) return [];
+    lawsCache = await res.json();
+  } catch {
+    lawsCache = [];
+  }
+  return lawsCache;
+}
+
+const allLaws = ref([]);
+const lawSearchQuery = ref('');
+const showLawResults = ref(false);
+const availableOutputs = ref([]);
+const outputsLoading = ref(false);
+
+function displayName(law) {
+  if (law.display_name) return law.display_name;
+  if (law.name) return law.name;
+  return law.law_id.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+}
+
+const filteredLaws = computed(() => {
+  const q = lawSearchQuery.value.toLowerCase().trim();
+  if (!q) return allLaws.value.slice(0, 20);
+  return allLaws.value.filter(law =>
+    displayName(law).toLowerCase().includes(q) ||
+    law.law_id.toLowerCase().includes(q),
+  ).slice(0, 20);
+});
+
+function onLawSearchInput(event) {
+  lawSearchQuery.value = event.target?.value ?? event.detail?.value ?? '';
+  showLawResults.value = true;
+}
+
+async function fetchOutputsForLaw(lawId) {
+  if (!lawId) {
+    availableOutputs.value = [];
+    return;
+  }
+  outputsLoading.value = true;
+  try {
+    const res = await fetch(`/api/corpus/laws/${encodeURIComponent(lawId)}/outputs`);
+    if (res.ok) {
+      availableOutputs.value = await res.json();
+    } else {
+      availableOutputs.value = [];
+    }
+  } catch {
+    availableOutputs.value = [];
+  } finally {
+    outputsLoading.value = false;
+  }
+}
+
+async function selectLaw(law) {
+  values.value.sourceRegulation = law.law_id;
+  lawSearchQuery.value = displayName(law);
+  showLawResults.value = false;
+  values.value.sourceOutput = '';
+  await fetchOutputsForLaw(law.law_id);
+}
+
+function onOutputSelected(outputName) {
+  values.value.sourceOutput = outputName;
+  if (!outputName) return;
+  const match = availableOutputs.value.find(o => o.name === outputName);
+  if (match) {
+    if (!values.value.name) {
+      values.value.name = outputName;
+    }
+    if (values.value.type === 'string' && match.output_type !== 'string') {
+      values.value.type = match.output_type;
+    }
+  }
+}
+
+function closeLawResults() {
+  // Delay to allow click on results to register before closing
+  setTimeout(() => { showLawResults.value = false; }, 200);
+}
 
 // Monotonic counter for stable v-for keys on the source.parameters rows.
 // We can't use the row index as a key because that would let Vue reuse the
@@ -74,25 +161,7 @@ watch(() => props.item, async (item) => {
     };
   } else if (s === 'input' || s === 'add-input') {
     // Flatten source.parameters into an ordered key/value pair list so the
-    // user can edit existing entries and add new ones via the form. We use
-    // an array (not an object) because two rows can briefly share an empty
-    // key while typing, and Object.entries would silently collapse them.
-    //
-    // Each row carries a stable `_rowId` so the v-for key survives row
-    // deletions (otherwise Vue reuses DOM by index and the data-testids
-    // bound to row positions point at stale rows).
-    //
-    // Hydration is value-type aware:
-    //   - string / number / boolean → represent as a string the user can
-    //     edit, and stash the original on `_origValue` so save() can
-    //     emit the original primitive type if the user didn't touch the
-    //     value field.
-    //   - object / array → unsupported in the form editor today (no UI
-    //     for nested literal values). The original value is stashed in
-    //     `_overflowParams` (separate from the editable rows) so save()
-    //     can merge it back into the output untouched. Without that
-    //     overflow, an unrelated edit on the input would silently drop
-    //     the entire non-scalar parameter from the law on the next save.
+    // user can edit existing entries and add new ones via the form.
     const params = item.data?.source?.parameters;
     const paramList = [];
     const overflowParams = {};
@@ -117,6 +186,21 @@ watch(() => props.item, async (item) => {
       sourceParameters: paramList,
       sourceParametersOverflow: overflowParams,
     };
+
+    // Load law list for search and pre-populate outputs if editing existing input
+    showLawResults.value = false;
+    availableOutputs.value = [];
+    fetchLawsList().then(laws => {
+      allLaws.value = laws;
+      const reg = item.data?.source?.regulation;
+      if (reg) {
+        const match = laws.find(l => l.law_id === reg);
+        lawSearchQuery.value = match ? displayName(match) : reg;
+        fetchOutputsForLaw(reg);
+      } else {
+        lawSearchQuery.value = '';
+      }
+    });
   } else if (s === 'output' || s === 'add-output') {
     values.value = {
       name: item.data?.name ?? '',
@@ -319,13 +403,40 @@ const sectionLabels = {
               <ndd-list-item size="md">
                 <ndd-text-cell text="Bron regelgeving" max-width="140"></ndd-text-cell>
                 <ndd-cell>
-                  <ndd-text-field size="md" :value="values.sourceRegulation" @input="values.sourceRegulation = $event.target?.value ?? $event.detail?.value ?? values.sourceRegulation"></ndd-text-field>
+                  <div class="law-search-container" @focusout="closeLawResults">
+                    <ndd-search-field
+                      size="md"
+                      placeholder="Zoek regelgeving..."
+                      :value="lawSearchQuery"
+                      data-testid="law-search-field"
+                      @input="onLawSearchInput($event)"
+                      @focus="showLawResults = true"
+                    ></ndd-search-field>
+                    <ndd-list v-if="showLawResults && filteredLaws.length > 0" variant="box" class="law-search-results" data-testid="law-search-results">
+                      <ndd-list-item
+                        v-for="law in filteredLaws"
+                        :key="law.law_id"
+                        size="sm"
+                        class="law-search-result-item"
+                        :data-testid="`law-result-${law.law_id}`"
+                        @mousedown.prevent="selectLaw(law)"
+                      >
+                        <ndd-text-cell :text="displayName(law)" :supporting-text="law.law_id"></ndd-text-cell>
+                      </ndd-list-item>
+                    </ndd-list>
+                  </div>
                 </ndd-cell>
               </ndd-list-item>
               <ndd-list-item size="md">
                 <ndd-text-cell text="Bron output" max-width="140"></ndd-text-cell>
                 <ndd-cell>
-                  <ndd-text-field size="md" :value="values.sourceOutput" @input="values.sourceOutput = $event.target?.value ?? $event.detail?.value ?? values.sourceOutput"></ndd-text-field>
+                  <ndd-dropdown v-if="availableOutputs.length > 0" size="md" data-testid="output-dropdown">
+                    <select :value="values.sourceOutput" @change="onOutputSelected($event.target.value)" aria-label="Bron output">
+                      <option value="">Selecteer output...</option>
+                      <option v-for="out in availableOutputs" :key="out.name" :value="out.name">{{ out.name }} ({{ out.output_type }})</option>
+                    </select>
+                  </ndd-dropdown>
+                  <ndd-text-field v-else size="md" :value="values.sourceOutput" data-testid="output-text-field" @input="values.sourceOutput = $event.target?.value ?? $event.detail?.value ?? values.sourceOutput"></ndd-text-field>
                 </ndd-cell>
               </ndd-list-item>
             </ndd-list>
@@ -455,5 +566,28 @@ ndd-sheet.edit-sheet {
   font-weight: 500;
   color: var(--semantics-text-secondary-color, #6B7280);
   flex-shrink: 0;
+}
+.law-search-container {
+  position: relative;
+  width: 100%;
+}
+.law-search-container ndd-search-field {
+  width: 100%;
+}
+.law-search-results {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  z-index: 100;
+  max-height: 240px;
+  overflow-y: auto;
+  background: var(--semantics-surface-primary-color, #fff);
+  border: 1px solid var(--semantics-border-primary-color, #d1d5db);
+  border-radius: 4px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+.law-search-result-item {
+  cursor: pointer;
 }
 </style>

--- a/frontend/src/components/EditSheet.vue
+++ b/frontend/src/components/EditSheet.vue
@@ -8,6 +8,8 @@ const props = defineProps({
 const emit = defineEmits(['save', 'close']);
 
 const sheetEl = ref(null);
+const searchFieldEl = ref(null);
+const inputWrapperEl = ref(null);
 const values = ref({});
 
 const typeOptions = ['string', 'number', 'boolean', 'amount'];
@@ -50,6 +52,7 @@ const filteredLaws = computed(() => {
 function onLawSearchInput(event) {
   lawSearchQuery.value = event.target?.value ?? event.detail?.value ?? '';
   showLawResults.value = true;
+  nextTick(() => updateResultsPosition());
 }
 
 async function fetchOutputsForLaw(lawId) {
@@ -97,6 +100,15 @@ function onOutputSelected(outputName) {
 function closeLawResults() {
   // Delay to allow click on results to register before closing
   setTimeout(() => { showLawResults.value = false; }, 200);
+}
+
+const resultsTopPx = ref(0);
+
+function updateResultsPosition() {
+  if (!searchFieldEl.value || !inputWrapperEl.value) return;
+  const fieldRect = searchFieldEl.value.getBoundingClientRect();
+  const wrapperRect = inputWrapperEl.value.getBoundingClientRect();
+  resultsTopPx.value = fieldRect.bottom - wrapperRect.top;
 }
 
 // Monotonic counter for stable v-for keys on the source.parameters rows.
@@ -397,66 +409,70 @@ const sectionLabels = {
 
           <!-- Input -->
           <template v-if="item.section === 'input' || item.section === 'add-input'">
-            <ndd-list variant="box" class="edit-settings-list">
-              <ndd-list-item size="md">
-                <ndd-text-cell text="Naam" max-width="140"></ndd-text-cell>
-                <ndd-cell>
-                  <ndd-text-field size="md" :value="values.name" @input="values.name = $event.target?.value ?? $event.detail?.value ?? values.name"></ndd-text-field>
-                </ndd-cell>
-              </ndd-list-item>
-              <ndd-list-item size="md">
-                <ndd-text-cell text="Type" max-width="140"></ndd-text-cell>
-                <ndd-cell>
-                  <ndd-dropdown size="md">
-                    <select :value="values.type" @change="values.type = $event.target.value" aria-label="Type">
-                      <option v-for="t in typeOptions" :key="t" :value="t">{{ t }}</option>
-                    </select>
-                  </ndd-dropdown>
-                </ndd-cell>
-              </ndd-list-item>
-              <ndd-list-item size="md">
-                <ndd-text-cell text="Bron regelgeving" max-width="140"></ndd-text-cell>
-                <ndd-cell>
-                  <ndd-search-field
-                    size="md"
-                    placeholder="Zoek regelgeving..."
-                    :value="lawSearchQuery"
-                    data-testid="law-search-field"
-                    @input="onLawSearchInput($event)"
-                    @focus="showLawResults = true"
-                    @focusout="closeLawResults"
-                  ></ndd-search-field>
-                </ndd-cell>
-              </ndd-list-item>
-              <ndd-list-item size="md">
-                <ndd-text-cell text="Bron output" max-width="140"></ndd-text-cell>
-                <ndd-cell>
-                  <ndd-dropdown v-if="availableOutputs.length > 0" size="md" data-testid="output-dropdown">
-                    <select :value="values.sourceOutput" @change="onOutputSelected($event.target.value)" aria-label="Bron output">
-                      <option value="">Selecteer output...</option>
-                      <option v-for="out in availableOutputs" :key="out.name" :value="out.name">{{ out.name }} ({{ out.output_type }})</option>
-                    </select>
-                  </ndd-dropdown>
-                  <ndd-text-field v-else size="md" :value="values.sourceOutput" data-testid="output-text-field" @input="values.sourceOutput = $event.target?.value ?? $event.detail?.value ?? values.sourceOutput"></ndd-text-field>
-                </ndd-cell>
-              </ndd-list-item>
-            </ndd-list>
-
-            <!-- Law search results rendered outside the ndd-list to avoid
-                 shadow DOM overflow clipping from ndd-list-item. -->
-            <div v-if="showLawResults && filteredLaws.length > 0" class="law-search-results" data-testid="law-search-results">
-              <ndd-list variant="box">
-                <ndd-list-item
-                  v-for="law in filteredLaws"
-                  :key="law.law_id"
-                  size="sm"
-                  class="law-search-result-item"
-                  :data-testid="`law-result-${law.law_id}`"
-                  @mousedown.prevent="selectLaw(law)"
-                >
-                  <ndd-text-cell :text="displayName(law)" :supporting-text="law.law_id"></ndd-text-cell>
+            <div class="input-fields-wrapper" ref="inputWrapperEl">
+              <ndd-list variant="box" class="edit-settings-list">
+                <ndd-list-item size="md">
+                  <ndd-text-cell text="Naam" max-width="140"></ndd-text-cell>
+                  <ndd-cell>
+                    <ndd-text-field size="md" :value="values.name" @input="values.name = $event.target?.value ?? $event.detail?.value ?? values.name"></ndd-text-field>
+                  </ndd-cell>
+                </ndd-list-item>
+                <ndd-list-item size="md">
+                  <ndd-text-cell text="Type" max-width="140"></ndd-text-cell>
+                  <ndd-cell>
+                    <ndd-dropdown size="md">
+                      <select :value="values.type" @change="values.type = $event.target.value" aria-label="Type">
+                        <option v-for="t in typeOptions" :key="t" :value="t">{{ t }}</option>
+                      </select>
+                    </ndd-dropdown>
+                  </ndd-cell>
+                </ndd-list-item>
+                <ndd-list-item size="md">
+                  <ndd-text-cell text="Bron regelgeving" max-width="140"></ndd-text-cell>
+                  <ndd-cell>
+                    <ndd-search-field
+                      ref="searchFieldEl"
+                      size="md"
+                      placeholder="Zoek regelgeving..."
+                      :value="lawSearchQuery"
+                      data-testid="law-search-field"
+                      @input="onLawSearchInput($event)"
+                      @focus="showLawResults = true; nextTick(() => updateResultsPosition())"
+                      @focusout="closeLawResults"
+                    ></ndd-search-field>
+                  </ndd-cell>
+                </ndd-list-item>
+                <ndd-list-item size="md">
+                  <ndd-text-cell text="Bron output" max-width="140"></ndd-text-cell>
+                  <ndd-cell>
+                    <ndd-dropdown v-if="availableOutputs.length > 0" size="md" data-testid="output-dropdown">
+                      <select :value="values.sourceOutput" @change="onOutputSelected($event.target.value)" aria-label="Bron output">
+                        <option value="">Selecteer output...</option>
+                        <option v-for="out in availableOutputs" :key="out.name" :value="out.name">{{ out.name }} ({{ out.output_type }})</option>
+                      </select>
+                    </ndd-dropdown>
+                    <ndd-text-field v-else size="md" :value="values.sourceOutput" data-testid="output-text-field" @input="values.sourceOutput = $event.target?.value ?? $event.detail?.value ?? values.sourceOutput"></ndd-text-field>
+                  </ndd-cell>
                 </ndd-list-item>
               </ndd-list>
+
+              <!-- Absolute overlay: rendered outside the ndd-list to escape
+                   shadow DOM overflow clipping, but positioned over the
+                   controls below (Bron output, parameters) via z-index. -->
+              <div v-if="showLawResults && filteredLaws.length > 0" class="law-search-results" :style="{ top: resultsTopPx + 'px' }" data-testid="law-search-results">
+                <ndd-list variant="box">
+                  <ndd-list-item
+                    v-for="law in filteredLaws"
+                    :key="law.law_id"
+                    size="sm"
+                    class="law-search-result-item"
+                    :data-testid="`law-result-${law.law_id}`"
+                    @mousedown.prevent="selectLaw(law)"
+                  >
+                    <ndd-text-cell :text="displayName(law)" :supporting-text="law.law_id"></ndd-text-cell>
+                  </ndd-list-item>
+                </ndd-list>
+              </div>
             </div>
 
             <ndd-spacer size="12"></ndd-spacer>
@@ -585,13 +601,20 @@ ndd-sheet.edit-sheet {
   color: var(--semantics-text-secondary-color, #6B7280);
   flex-shrink: 0;
 }
+.input-fields-wrapper {
+  position: relative;
+}
 .law-search-results {
-  max-height: 200px;
+  position: absolute;
+  left: 0;
+  right: 0;
+  z-index: 100;
+  max-height: 240px;
   overflow-y: auto;
+  background: var(--semantics-surface-primary-color, #fff);
   border: 1px solid var(--semantics-border-primary-color, #d1d5db);
   border-radius: 4px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-  margin-top: -1px;
 }
 .law-search-result-item {
   cursor: pointer;

--- a/frontend/src/components/EditSheet.vue
+++ b/frontend/src/components/EditSheet.vue
@@ -417,28 +417,15 @@ const sectionLabels = {
               <ndd-list-item size="md">
                 <ndd-text-cell text="Bron regelgeving" max-width="140"></ndd-text-cell>
                 <ndd-cell>
-                  <div class="law-search-container" @focusout="closeLawResults">
-                    <ndd-search-field
-                      size="md"
-                      placeholder="Zoek regelgeving..."
-                      :value="lawSearchQuery"
-                      data-testid="law-search-field"
-                      @input="onLawSearchInput($event)"
-                      @focus="showLawResults = true"
-                    ></ndd-search-field>
-                    <ndd-list v-if="showLawResults && filteredLaws.length > 0" variant="box" class="law-search-results" data-testid="law-search-results">
-                      <ndd-list-item
-                        v-for="law in filteredLaws"
-                        :key="law.law_id"
-                        size="sm"
-                        class="law-search-result-item"
-                        :data-testid="`law-result-${law.law_id}`"
-                        @mousedown.prevent="selectLaw(law)"
-                      >
-                        <ndd-text-cell :text="displayName(law)" :supporting-text="law.law_id"></ndd-text-cell>
-                      </ndd-list-item>
-                    </ndd-list>
-                  </div>
+                  <ndd-search-field
+                    size="md"
+                    placeholder="Zoek regelgeving..."
+                    :value="lawSearchQuery"
+                    data-testid="law-search-field"
+                    @input="onLawSearchInput($event)"
+                    @focus="showLawResults = true"
+                    @focusout="closeLawResults"
+                  ></ndd-search-field>
                 </ndd-cell>
               </ndd-list-item>
               <ndd-list-item size="md">
@@ -454,6 +441,23 @@ const sectionLabels = {
                 </ndd-cell>
               </ndd-list-item>
             </ndd-list>
+
+            <!-- Law search results rendered outside the ndd-list to avoid
+                 shadow DOM overflow clipping from ndd-list-item. -->
+            <div v-if="showLawResults && filteredLaws.length > 0" class="law-search-results" data-testid="law-search-results">
+              <ndd-list variant="box">
+                <ndd-list-item
+                  v-for="law in filteredLaws"
+                  :key="law.law_id"
+                  size="sm"
+                  class="law-search-result-item"
+                  :data-testid="`law-result-${law.law_id}`"
+                  @mousedown.prevent="selectLaw(law)"
+                >
+                  <ndd-text-cell :text="displayName(law)" :supporting-text="law.law_id"></ndd-text-cell>
+                </ndd-list-item>
+              </ndd-list>
+            </div>
 
             <ndd-spacer size="12"></ndd-spacer>
             <ndd-title size="6"><h6>Bron parameters</h6></ndd-title>
@@ -581,26 +585,13 @@ ndd-sheet.edit-sheet {
   color: var(--semantics-text-secondary-color, #6B7280);
   flex-shrink: 0;
 }
-.law-search-container {
-  position: relative;
-  z-index: 10;
-  width: 100%;
-}
-.law-search-container ndd-search-field {
-  width: 100%;
-}
 .law-search-results {
-  position: absolute;
-  top: 100%;
-  left: 0;
-  right: 0;
-  z-index: 1000;
-  max-height: 240px;
+  max-height: 200px;
   overflow-y: auto;
-  background: var(--semantics-surface-primary-color, #fff);
   border: 1px solid var(--semantics-border-primary-color, #d1d5db);
   border-radius: 4px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  margin-top: -1px;
 }
 .law-search-result-item {
   cursor: pointer;

--- a/frontend/src/components/EditSheet.vue
+++ b/frontend/src/components/EditSheet.vue
@@ -91,8 +91,13 @@ function onOutputSelected(outputName) {
     if (!values.value.name) {
       values.value.name = outputName;
     }
-    if (values.value.type === 'string' && match.output_type !== 'string' && typeOptions.includes(match.output_type)) {
-      values.value.type = match.output_type;
+    // Always set type from the source output — it's determined by the external law
+    values.value.type = match.output_type || 'string';
+    // Pre-populate source parameters from the selected output's article
+    if (match.parameters?.length > 0) {
+      values.value.sourceParameters = match.parameters.map(p =>
+        makeParamRow(p.name, ''),
+      );
     }
   }
 }
@@ -417,7 +422,7 @@ const sectionLabels = {
                     <ndd-text-field size="md" :value="values.name" @input="values.name = $event.target?.value ?? $event.detail?.value ?? values.name"></ndd-text-field>
                   </ndd-cell>
                 </ndd-list-item>
-                <ndd-list-item size="md">
+                <ndd-list-item v-if="!values.sourceOutput" size="md">
                   <ndd-text-cell text="Type" max-width="140"></ndd-text-cell>
                   <ndd-cell>
                     <ndd-dropdown size="md">

--- a/frontend/src/components/EditSheet.vue
+++ b/frontend/src/components/EditSheet.vue
@@ -88,7 +88,7 @@ function onOutputSelected(outputName) {
     if (!values.value.name) {
       values.value.name = outputName;
     }
-    if (values.value.type === 'string' && match.output_type !== 'string') {
+    if (values.value.type === 'string' && match.output_type !== 'string' && typeOptions.includes(match.output_type)) {
       values.value.type = match.output_type;
     }
   }

--- a/packages/corpus/src/source_map.rs
+++ b/packages/corpus/src/source_map.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 use serde::Deserialize;
@@ -554,7 +554,7 @@ pub fn collect_law_outputs(yaml: &str) -> Vec<(String, String, String)> {
         Err(_) => return Vec::new(),
     };
 
-    let mut seen = HashMap::new();
+    let mut seen = HashSet::new();
     let mut results = Vec::new();
 
     for article in &doc.articles {
@@ -566,8 +566,8 @@ pub fn collect_law_outputs(yaml: &str) -> Vec<(String, String, String)> {
             continue;
         };
         for output in &exec.output {
-            if !output.name.is_empty() && !seen.contains_key(&output.name) {
-                seen.insert(output.name.clone(), ());
+            if !output.name.is_empty() && !seen.contains(&output.name) {
+                seen.insert(output.name.clone());
                 results.push((
                     output.name.clone(),
                     output

--- a/packages/corpus/src/source_map.rs
+++ b/packages/corpus/src/source_map.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::path::Path;
 
+use serde::Deserialize;
 use walkdir::WalkDir;
 
 use crate::error::{CorpusError, Result};
@@ -445,6 +446,144 @@ fn extract_law_name(yaml: &str) -> Option<String> {
     None
 }
 
+/// Extract the raw `name:` value including `#` references.
+fn extract_raw_name(yaml: &str) -> Option<String> {
+    for line in yaml.lines() {
+        if let Some(rest) = line.strip_prefix("name:") {
+            let value = rest.trim().trim_matches('"').trim_matches('\'');
+            if !value.is_empty() {
+                return Some(value.to_string());
+            }
+            return None;
+        }
+    }
+    None
+}
+
+// --- Minimal deserialization types for display-name and output resolution ---
+
+#[derive(Deserialize, Default)]
+struct LawDoc {
+    #[serde(default)]
+    articles: Vec<LawArticle>,
+}
+
+#[derive(Deserialize, Default)]
+struct LawArticle {
+    #[serde(default)]
+    number: Option<String>,
+    #[serde(default)]
+    machine_readable: Option<LawMr>,
+}
+
+#[derive(Deserialize, Default)]
+struct LawMr {
+    #[serde(default)]
+    execution: Option<LawExec>,
+}
+
+#[derive(Deserialize, Default)]
+struct LawExec {
+    #[serde(default)]
+    actions: Vec<LawAction>,
+    #[serde(default)]
+    output: Vec<LawOutput>,
+}
+
+#[derive(Deserialize, Default)]
+struct LawAction {
+    #[serde(default)]
+    output: Option<String>,
+    #[serde(default)]
+    value: Option<serde_yaml_ng::Value>,
+}
+
+/// An output entry from `execution.output`.
+#[derive(Deserialize, Default)]
+struct LawOutput {
+    #[serde(default)]
+    name: String,
+    #[serde(default, rename = "type")]
+    output_type: Option<String>,
+}
+
+/// Resolve a law's human-readable display name.
+///
+/// If the YAML has a literal `name:` field (e.g. `name: Kieswet`), returns
+/// that. If the name is an output reference (e.g. `name: '#wet_naam'`),
+/// parses the YAML to find the action whose output matches the reference
+/// and returns its scalar value. Returns `None` when no name can be resolved.
+pub fn resolve_display_name(yaml: &str) -> Option<String> {
+    // Fast path: literal name
+    if let Some(name) = extract_law_name(yaml) {
+        return Some(name);
+    }
+
+    // Check for # reference
+    let raw = extract_raw_name(yaml)?;
+    let reference = raw.strip_prefix('#')?;
+
+    // Parse YAML to find the action that resolves this reference
+    let doc: LawDoc = serde_yaml_ng::from_str(yaml).ok()?;
+    for article in &doc.articles {
+        let Some(mr) = &article.machine_readable else {
+            continue;
+        };
+        let Some(exec) = &mr.execution else {
+            continue;
+        };
+        for action in &exec.actions {
+            if action.output.as_deref() == Some(reference) {
+                if let Some(serde_yaml_ng::Value::String(s)) = &action.value {
+                    return Some(s.clone());
+                }
+            }
+        }
+    }
+
+    None
+}
+
+/// Collect all outputs declared across all articles in a law.
+///
+/// Returns `(name, type, article_number)` tuples, deduplicated by name
+/// (first occurrence wins).
+pub fn collect_law_outputs(yaml: &str) -> Vec<(String, String, String)> {
+    let doc: LawDoc = match serde_yaml_ng::from_str(yaml) {
+        Ok(d) => d,
+        Err(_) => return Vec::new(),
+    };
+
+    let mut seen = HashMap::new();
+    let mut results = Vec::new();
+
+    for article in &doc.articles {
+        let article_number = article.number.as_deref().unwrap_or("").to_string();
+        let Some(mr) = &article.machine_readable else {
+            continue;
+        };
+        let Some(exec) = &mr.execution else {
+            continue;
+        };
+        for output in &exec.output {
+            if !output.name.is_empty() && !seen.contains_key(&output.name) {
+                seen.insert(output.name.clone(), ());
+                results.push((
+                    output.name.clone(),
+                    output
+                        .output_type
+                        .clone()
+                        .unwrap_or_else(|| "string".to_string()),
+                    article_number.clone(),
+                ));
+            }
+        }
+    }
+
+    results.sort_by(|a, b| a.0.cmp(&b.0));
+    results
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
@@ -742,5 +881,112 @@ mod tests {
         map.load_source(&source_high).unwrap();
 
         assert_eq!(map.get_law("contested_law").unwrap().source_id, "high");
+    }
+
+    #[test]
+    fn test_resolve_display_name_literal() {
+        let yaml = "$id: kieswet\nname: Kieswet\narticles: []\n";
+        assert_eq!(resolve_display_name(yaml), Some("Kieswet".to_string()));
+    }
+
+    #[test]
+    fn test_resolve_display_name_output_reference() {
+        let yaml = r#"$id: zorgtoeslagwet
+name: '#wet_naam'
+articles:
+  - number: '8'
+    machine_readable:
+      execution:
+        actions:
+          - output: wet_naam
+            value: Wet op de zorgtoeslag
+"#;
+        assert_eq!(
+            resolve_display_name(yaml),
+            Some("Wet op de zorgtoeslag".to_string())
+        );
+    }
+
+    #[test]
+    fn test_resolve_display_name_unresolvable_reference() {
+        let yaml = "$id: test\nname: '#missing_output'\narticles: []\n";
+        assert_eq!(resolve_display_name(yaml), None);
+    }
+
+    #[test]
+    fn test_resolve_display_name_no_name_field() {
+        let yaml = "$id: test\narticles: []\n";
+        assert_eq!(resolve_display_name(yaml), None);
+    }
+
+    #[test]
+    fn test_collect_law_outputs() {
+        let yaml = r#"$id: brp
+articles:
+  - number: '2.7'
+    machine_readable:
+      execution:
+        output:
+          - name: leeftijd
+            type: number
+        actions: []
+  - number: '2.8'
+    machine_readable:
+      execution:
+        output:
+          - name: heeft_partner
+            type: boolean
+        actions: []
+"#;
+        let outputs = collect_law_outputs(yaml);
+        assert_eq!(outputs.len(), 2);
+        assert_eq!(
+            outputs[0],
+            (
+                "heeft_partner".to_string(),
+                "boolean".to_string(),
+                "2.8".to_string()
+            )
+        );
+        assert_eq!(
+            outputs[1],
+            (
+                "leeftijd".to_string(),
+                "number".to_string(),
+                "2.7".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn test_collect_law_outputs_deduplicates() {
+        let yaml = r#"$id: test
+articles:
+  - number: '1'
+    machine_readable:
+      execution:
+        output:
+          - name: foo
+            type: string
+        actions: []
+  - number: '2'
+    machine_readable:
+      execution:
+        output:
+          - name: foo
+            type: number
+        actions: []
+"#;
+        let outputs = collect_law_outputs(yaml);
+        assert_eq!(outputs.len(), 1);
+        // First occurrence wins
+        assert_eq!(outputs[0].1, "string");
+    }
+
+    #[test]
+    fn test_collect_law_outputs_empty() {
+        let yaml = "$id: test\narticles: []\n";
+        let outputs = collect_law_outputs(yaml);
+        assert!(outputs.is_empty());
     }
 }

--- a/packages/corpus/src/source_map.rs
+++ b/packages/corpus/src/source_map.rs
@@ -488,6 +488,17 @@ struct LawExec {
     actions: Vec<LawAction>,
     #[serde(default)]
     output: Vec<LawOutput>,
+    #[serde(default)]
+    parameters: Vec<LawParam>,
+}
+
+/// A parameter entry from `execution.parameters`.
+#[derive(Deserialize, Default, Clone)]
+struct LawParam {
+    #[serde(default)]
+    name: String,
+    #[serde(default, rename = "type")]
+    param_type: Option<String>,
 }
 
 #[derive(Deserialize, Default)]
@@ -544,11 +555,22 @@ pub fn resolve_display_name(yaml: &str) -> Option<String> {
     None
 }
 
+/// A collected output with the parameters required by its article's execution block.
+pub struct CollectedOutput {
+    pub name: String,
+    pub output_type: String,
+    pub article_number: String,
+    /// Parameters declared on the execution block that contains this output.
+    /// The caller needs to supply these when referencing this output as a source.
+    pub parameters: Vec<(String, String)>, // (name, type)
+}
+
 /// Collect all outputs declared across all articles in a law.
 ///
-/// Returns `(name, type, article_number)` tuples, deduplicated by name
-/// (first occurrence wins).
-pub fn collect_law_outputs(yaml: &str) -> Vec<(String, String, String)> {
+/// Each output includes the parameters required by its article's execution
+/// block, so the UI can pre-populate source.parameters when the user selects
+/// an output.
+pub fn collect_law_outputs(yaml: &str) -> Vec<CollectedOutput> {
     let doc: LawDoc = match serde_yaml_ng::from_str(yaml) {
         Ok(d) => d,
         Err(_) => return Vec::new(),
@@ -565,22 +587,34 @@ pub fn collect_law_outputs(yaml: &str) -> Vec<(String, String, String)> {
         let Some(exec) = &mr.execution else {
             continue;
         };
+        let params: Vec<(String, String)> = exec
+            .parameters
+            .iter()
+            .map(|p| {
+                (
+                    p.name.clone(),
+                    p.param_type.clone().unwrap_or_else(|| "string".to_string()),
+                )
+            })
+            .collect();
+
         for output in &exec.output {
             if !output.name.is_empty() && !seen.contains(&output.name) {
                 seen.insert(output.name.clone());
-                results.push((
-                    output.name.clone(),
-                    output
+                results.push(CollectedOutput {
+                    name: output.name.clone(),
+                    output_type: output
                         .output_type
                         .clone()
                         .unwrap_or_else(|| "string".to_string()),
-                    article_number.clone(),
-                ));
+                    article_number: article_number.clone(),
+                    parameters: params.clone(),
+                });
             }
         }
     }
 
-    results.sort_by(|a, b| a.0.cmp(&b.0));
+    results.sort_by(|a, b| a.name.cmp(&b.name));
     results
 }
 
@@ -926,6 +960,11 @@ articles:
   - number: '2.7'
     machine_readable:
       execution:
+        parameters:
+          - name: bsn
+            type: string
+          - name: peildatum
+            type: date
         output:
           - name: leeftijd
             type: number
@@ -933,6 +972,9 @@ articles:
   - number: '2.8'
     machine_readable:
       execution:
+        parameters:
+          - name: bsn
+            type: string
         output:
           - name: heeft_partner
             type: boolean
@@ -940,21 +982,23 @@ articles:
 "#;
         let outputs = collect_law_outputs(yaml);
         assert_eq!(outputs.len(), 2);
+        assert_eq!(outputs[0].name, "heeft_partner");
+        assert_eq!(outputs[0].output_type, "boolean");
+        assert_eq!(outputs[0].article_number, "2.8");
         assert_eq!(
-            outputs[0],
-            (
-                "heeft_partner".to_string(),
-                "boolean".to_string(),
-                "2.8".to_string()
-            )
+            outputs[0].parameters,
+            vec![("bsn".to_string(), "string".to_string())]
         );
+
+        assert_eq!(outputs[1].name, "leeftijd");
+        assert_eq!(outputs[1].output_type, "number");
+        assert_eq!(outputs[1].article_number, "2.7");
         assert_eq!(
-            outputs[1],
-            (
-                "leeftijd".to_string(),
-                "number".to_string(),
-                "2.7".to_string()
-            )
+            outputs[1].parameters,
+            vec![
+                ("bsn".to_string(), "string".to_string()),
+                ("peildatum".to_string(), "date".to_string()),
+            ]
         );
     }
 
@@ -980,7 +1024,7 @@ articles:
         let outputs = collect_law_outputs(yaml);
         assert_eq!(outputs.len(), 1);
         // First occurrence wins
-        assert_eq!(outputs[0].1, "string");
+        assert_eq!(outputs[0].output_type, "string");
     }
 
     #[test]

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -8,7 +8,9 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 
 use regelrecht_corpus::backend::{RepoBackend, WriteContext};
-use regelrecht_corpus::source_map::{extract_law_id, validate_yaml_syntax, LoadedLaw};
+use regelrecht_corpus::source_map::{
+    collect_law_outputs, extract_law_id, resolve_display_name, validate_yaml_syntax, LoadedLaw,
+};
 use regelrecht_corpus::CorpusError;
 
 use crate::state::AppState;
@@ -41,8 +43,22 @@ pub struct SourceSummary {
 pub struct CorpusLawEntry {
     pub law_id: String,
     pub name: Option<String>,
+    /// Resolved human-readable name. For laws with a literal `name:` field
+    /// this equals `name`. For laws with `name: '#output_ref'` this is the
+    /// resolved value from the matching action output. Falls back to `None`
+    /// when the reference cannot be resolved.
+    pub display_name: Option<String>,
     pub source_id: String,
     pub source_name: String,
+}
+
+/// An output entry from a law's machine_readable.execution.output.
+#[derive(Debug, Serialize)]
+pub struct LawOutputEntry {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub output_type: String,
+    pub article_number: String,
 }
 
 /// GET /api/sources — list all registered corpus sources with law counts.
@@ -94,11 +110,15 @@ pub async fn list_corpus_laws(
     let mut entries: Vec<CorpusLawEntry> = corpus
         .source_map
         .laws()
-        .map(|law| CorpusLawEntry {
-            law_id: law.law_id.clone(),
-            name: law.name.clone(),
-            source_id: law.source_id.clone(),
-            source_name: law.source_name.clone(),
+        .map(|law| {
+            let display_name = resolve_display_name(&law.yaml_content);
+            CorpusLawEntry {
+                law_id: law.law_id.clone(),
+                name: law.name.clone(),
+                display_name,
+                source_id: law.source_id.clone(),
+                source_name: law.source_name.clone(),
+            }
         })
         .collect();
 
@@ -137,6 +157,30 @@ pub async fn get_corpus_law(
         [(axum::http::header::CONTENT_TYPE, "text/yaml; charset=utf-8")],
         law.yaml_content.clone(),
     ))
+}
+
+/// GET /api/corpus/laws/{law_id}/outputs — list all outputs declared across articles.
+pub async fn list_law_outputs(
+    State(state): State<AppState>,
+    Path(law_id): Path<String>,
+) -> Result<Json<Vec<LawOutputEntry>>, (StatusCode, String)> {
+    let corpus = state.corpus.read().await;
+
+    let law = corpus
+        .source_map
+        .get_law(&law_id)
+        .ok_or_else(|| (StatusCode::NOT_FOUND, format!("Law '{}' not found", law_id)))?;
+
+    let outputs: Vec<LawOutputEntry> = collect_law_outputs(&law.yaml_content)
+        .into_iter()
+        .map(|(name, output_type, article_number)| LawOutputEntry {
+            name,
+            output_type,
+            article_number,
+        })
+        .collect();
+
+    Ok(Json(outputs))
 }
 
 /// A scenario file entry.

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -56,7 +56,6 @@ pub struct CorpusLawEntry {
 #[derive(Debug, Serialize)]
 pub struct LawOutputEntry {
     pub name: String,
-    #[serde(rename = "type")]
     pub output_type: String,
     pub article_number: String,
 }

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -52,12 +52,22 @@ pub struct CorpusLawEntry {
     pub source_name: String,
 }
 
+/// A parameter required by the execution block that declares an output.
+#[derive(Debug, Serialize)]
+pub struct LawParamEntry {
+    pub name: String,
+    pub param_type: String,
+}
+
 /// An output entry from a law's machine_readable.execution.output.
 #[derive(Debug, Serialize)]
 pub struct LawOutputEntry {
     pub name: String,
     pub output_type: String,
     pub article_number: String,
+    /// Parameters required by the article's execution block. The caller
+    /// must supply these via `source.parameters` when referencing this output.
+    pub parameters: Vec<LawParamEntry>,
 }
 
 /// GET /api/sources — list all registered corpus sources with law counts.
@@ -172,10 +182,15 @@ pub async fn list_law_outputs(
 
     let outputs: Vec<LawOutputEntry> = collect_law_outputs(&law.yaml_content)
         .into_iter()
-        .map(|(name, output_type, article_number)| LawOutputEntry {
-            name,
-            output_type,
-            article_number,
+        .map(|out| LawOutputEntry {
+            name: out.name,
+            output_type: out.output_type,
+            article_number: out.article_number,
+            parameters: out
+                .parameters
+                .into_iter()
+                .map(|(name, param_type)| LawParamEntry { name, param_type })
+                .collect(),
         })
         .collect();
 

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -83,6 +83,10 @@ async fn main() {
             get(corpus_handlers::get_corpus_law),
         )
         .route(
+            "/api/corpus/laws/{law_id}/outputs",
+            get(corpus_handlers::list_law_outputs),
+        )
+        .route(
             "/api/corpus/laws/{law_id}/scenarios",
             get(corpus_handlers::list_scenarios),
         )


### PR DESCRIPTION
## Summary

Replace the manual text fields for "Bron regelgeving" and "Bron output" in EditSheet with a search/select flow:

1. **Law search** — `ndd-search-field` with type-ahead filtering by display name or law ID. Results show in a dropdown list below the search field.
2. **Output dropdown** — after selecting a law, a dropdown shows all outputs declared across its articles. Falls back to a plain text field when no outputs are available.
3. **Auto-populate** — selecting an output auto-fills the input name and type fields (only when they're still at their defaults).

### Backend changes

- `resolve_display_name()` in `source_map.rs` resolves `#output_reference` names (e.g. `name: '#wet_naam'`) by parsing the YAML to find the matching action output value
- `collect_law_outputs()` walks all articles to collect `execution.output` entries
- `GET /api/corpus/laws` now includes a `display_name` field on each entry
- New `GET /api/corpus/laws/{law_id}/outputs` endpoint returns all outputs with name, type, and article number

### Test plan

- [x] `just format` / `just lint` / `just build-check` / `just validate` — green
- [x] `just test` — Rust unit tests pass (7 new: 4 resolve_display_name + 3 collect_law_outputs)
- [x] `npm test` — 102 vitest tests pass (7 new EditSheet search/select tests)
- [ ] CI