### PR TITLE
fix(editor): operation type binding + subject/param dropdowns

### DIFF
--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -749,7 +749,7 @@ function handleActionSave() {
   </ndd-app-view>
 
   <ActionSheet :action="activeAction" :article="editedArticle" :editable="canEdit" @close="handleActionClose" @save="handleActionSave" />
-  <EditSheet :item="activeEditItem" @save="handleSave" @close="activeEditItem = null" />
+  <EditSheet :item="activeEditItem" :article="editedArticle" @save="handleSave" @close="activeEditItem = null" />
 </template>
 
 <style>

--- a/frontend/src/components/EditSheet.vue
+++ b/frontend/src/components/EditSheet.vue
@@ -515,6 +515,7 @@ const sectionLabels = {
                   <ndd-dropdown v-if="paramValueOptions.length > 0" size="md" :data-testid="`source-param-value-${param._rowId}`">
                     <select :value="param.value" :aria-label="`Waarde voor ${param.key}`" @change="param.value = $event.target.value">
                       <option value="">Selecteer...</option>
+                      <option v-if="param.value && !param.value.startsWith('$')" :value="param.value" :selected="true">{{ param.value }}</option>
                       <option v-for="opt in paramValueOptions" :key="opt.value" :value="opt.value" :selected="opt.value === param.value">{{ opt.label }}</option>
                     </select>
                   </ndd-dropdown>

--- a/frontend/src/components/EditSheet.vue
+++ b/frontend/src/components/EditSheet.vue
@@ -498,7 +498,7 @@ const sectionLabels = {
             <ndd-spacer size="8"></ndd-spacer>
             <ndd-list variant="box" class="edit-settings-list" data-testid="source-parameters-list">
               <ndd-list-item
-                v-for="(param, idx) in values.sourceParameters"
+                v-for="param in values.sourceParameters"
                 :key="param._rowId"
                 size="md"
               >

--- a/frontend/src/components/EditSheet.vue
+++ b/frontend/src/components/EditSheet.vue
@@ -1,8 +1,10 @@
 <script setup>
 import { ref, computed, watch, nextTick } from 'vue';
+import { collectAvailableVariables } from '../utils/operationTree.js';
 
 const props = defineProps({
   item: { type: Object, default: null },
+  article: { type: Object, default: null },
 });
 
 const emit = defineEmits(['save', 'close']);
@@ -13,6 +15,16 @@ const inputWrapperEl = ref(null);
 const values = ref({});
 
 const typeOptions = ['string', 'number', 'boolean', 'amount'];
+
+// Available variables from the article's machine_readable for parameter
+// value dropdowns. Reuses the same collectAvailableVariables utility that
+// OperationSettings uses for subject dropdowns.
+const paramValueOptions = computed(() =>
+  collectAvailableVariables(props.article).map(v => ({
+    value: v.ref,
+    label: `${v.name.replace(/_/g, ' ')} (${v.category.toLowerCase()})`,
+  })),
+);
 
 // --- Law search / output selection ---
 let lawsCache = null;
@@ -93,12 +105,13 @@ function onOutputSelected(outputName) {
     }
     // Always set type from the source output — it's determined by the external law
     values.value.type = match.output_type || 'string';
-    // Pre-populate source parameters from the selected output's article
-    if (match.parameters?.length > 0) {
-      values.value.sourceParameters = match.parameters.map(p =>
-        makeParamRow(p.name, ''),
-      );
-    }
+    // Always reset and pre-populate source parameters from the selected
+    // output's article. Without the unconditional reset, switching to an
+    // output with fewer (or no) parameters would leave stale rows that
+    // produce invalid source.parameters on save.
+    values.value.sourceParameters = (match.parameters ?? []).map(p =>
+      makeParamRow(p.name, ''),
+    );
   }
 }
 
@@ -494,12 +507,19 @@ const sectionLabels = {
                     size="md"
                     placeholder="naam"
                     :value="param.key"
+                    readonly
                     :data-testid="`source-param-key-${param._rowId}`"
-                    @input="param.key = $event.target?.value ?? $event.detail?.value ?? param.key"
                   ></ndd-text-field>
                 </ndd-cell>
                 <ndd-cell>
+                  <ndd-dropdown v-if="paramValueOptions.length > 0" size="md" :data-testid="`source-param-value-${param._rowId}`">
+                    <select :value="param.value" :aria-label="`Waarde voor ${param.key}`" @change="param.value = $event.target.value">
+                      <option value="">Selecteer...</option>
+                      <option v-for="opt in paramValueOptions" :key="opt.value" :value="opt.value" :selected="opt.value === param.value">{{ opt.label }}</option>
+                    </select>
+                  </ndd-dropdown>
                   <ndd-text-field
+                    v-else
                     size="md"
                     placeholder="waarde (bijv. $bsn)"
                     :value="param.value"
@@ -507,22 +527,6 @@ const sectionLabels = {
                     @input="param.value = $event.target?.value ?? $event.detail?.value ?? param.value"
                   ></ndd-text-field>
                 </ndd-cell>
-                <ndd-cell>
-                  <ndd-icon-button
-                    icon="minus"
-                    title="Verwijder parameter"
-                    :data-testid="`source-param-remove-${param._rowId}`"
-                    @click="values.sourceParameters.splice(idx, 1)"
-                  ></ndd-icon-button>
-                </ndd-cell>
-              </ndd-list-item>
-              <ndd-list-item size="md">
-                <ndd-button
-                  start-icon="plus-small"
-                  data-testid="source-param-add-btn"
-                  text="Voeg parameter toe"
-                  @click="values.sourceParameters.push(makeParamRow())"
-                ></ndd-button>
               </ndd-list-item>
             </ndd-list>
           </template>

--- a/frontend/src/components/OperationSettings.vue
+++ b/frontend/src/components/OperationSettings.vue
@@ -429,11 +429,15 @@ function addNestedOperation() {
         <ndd-text-cell :text="val._label" max-width="120"></ndd-text-cell>
         <ndd-cell>
           <div class="value-row">
-            <!-- Subject fields always show a dropdown of available variables -->
+            <!-- Subject/date fields show a dropdown of available variables.
+                 If the field already holds a literal value (e.g. "2025-01-01"),
+                 it's included as the first option so it stays visible and
+                 selectable. -->
             <template v-if="val._kind === 'subject' || val._kind === 'date_of_birth' || val._kind === 'reference_date'">
               <ndd-dropdown size="md" style="flex: 1; min-width: 0;">
                 <select :aria-label="val._label" :value="currentDropdownValue(val._value)" :disabled="!editable" @change="editable && updateDropdownValue(val, $event)">
                   <option value="">Selecteer...</option>
+                  <option v-if="isLiteralValue(val._value) && val._value !== '' && val._value !== null" :value="String(val._value)" :selected="true">{{ String(val._value) }}</option>
                   <option v-for="opt in variableOptions" :key="opt.value" :value="opt.value" :selected="opt.value === currentDropdownValue(val._value)">{{ opt.label }}</option>
                 </select>
               </ndd-dropdown>

--- a/frontend/src/components/OperationSettings.vue
+++ b/frontend/src/components/OperationSettings.vue
@@ -418,7 +418,7 @@ function addNestedOperation() {
         <ndd-cell>
           <ndd-dropdown size="md" data-testid="operation-type-dropdown">
             <select aria-label="Operatie type" :value="operation.operation" :disabled="!editable" @change="editable && changeOperationType($event)">
-              <option v-for="opt in typeOptions" :key="opt.value" :value="opt.value">{{ opt.label }}</option>
+              <option v-for="opt in typeOptions" :key="opt.value" :value="opt.value" :selected="opt.value === operation.operation">{{ opt.label }}</option>
             </select>
           </ndd-dropdown>
         </ndd-cell>
@@ -429,9 +429,20 @@ function addNestedOperation() {
         <ndd-text-cell :text="val._label" max-width="120"></ndd-text-cell>
         <ndd-cell>
           <div class="value-row">
-            <template v-if="isLiteralValue(val._value)">
+            <!-- Subject fields always show a dropdown of available variables -->
+            <template v-if="val._kind === 'subject' || val._kind === 'date_of_birth' || val._kind === 'reference_date'">
+              <ndd-dropdown size="md" style="flex: 1; min-width: 0;">
+                <select :aria-label="val._label" :value="currentDropdownValue(val._value)" :disabled="!editable" @change="editable && updateDropdownValue(val, $event)">
+                  <option value="">Selecteer...</option>
+                  <option v-for="opt in variableOptions" :key="opt.value" :value="opt.value" :selected="opt.value === currentDropdownValue(val._value)">{{ opt.label }}</option>
+                </select>
+              </ndd-dropdown>
+            </template>
+            <!-- Literal values show a text field -->
+            <template v-else-if="isLiteralValue(val._value)">
               <ndd-text-field size="md" :value="String(val._value)" is-full-width :readonly="!editable" @input="editable && updateValue(val, $event)"></ndd-text-field>
             </template>
+            <!-- Variable references and nested operations show a full dropdown -->
             <template v-else>
               <ndd-dropdown size="md" style="flex: 1; min-width: 0;">
                 <select :aria-label="val._label" :value="currentDropdownValue(val._value)" :disabled="!editable" @change="editable && updateDropdownValue(val, $event)">

--- a/frontend/src/utils/operationTree.js
+++ b/frontend/src/utils/operationTree.js
@@ -29,9 +29,15 @@ export const OPERATION_LABELS = {
 };
 
 export function collectAvailableVariables(article) {
-  if (!article?.machine_readable) return [];
+  // Engine built-in context variables — always available regardless of
+  // article content. `referencedate` is the calculation date injected by
+  // the engine from the scenario's "Given the calculation date is ..."
+  const vars = [
+    { name: 'referencedate', ref: '$referencedate', category: 'Context' },
+  ];
+
+  if (!article?.machine_readable) return vars;
   const mr = article.machine_readable;
-  const vars = [];
 
   if (mr.definitions) {
     for (const name of Object.keys(mr.definitions)) {


### PR DESCRIPTION
## Summary

Six UX improvements addressing review feedback from #538 and issues found during hands-on testing:

1. **Stale params fix** — `onOutputSelected` now always resets `sourceParameters`, preventing stale rows when switching to an output with fewer/no parameters
2. **Type dropdown binding** — added `:selected` on options so `ndd-dropdown` reflects the correct initial value (was showing "groter dan" for AND operations)
3. **Subject always a dropdown** — Onderwerp, Geboortedatum, and Peildatum fields now show a dropdown of available variables instead of a free text field
4. **Parameter names readonly** — source parameter names come from the external law and can't be edited
5. **Parameter values dropdown** — source parameter values are now a dropdown of available variables ($bsn, $referencedate, etc.)
6. **Removed add/remove param buttons** — parameters are determined by the external law

### Test plan

- [x] `npm test` — 102 vitest tests pass
- [ ] CI