### PR TITLE
fix(editor): ux tweaks for action sheet and source parameter dropdowns

### DIFF
--- a/frontend/src/components/ActionSheet.vue
+++ b/frontend/src/components/ActionSheet.vue
@@ -18,8 +18,7 @@ const operationTree = computed(() => props.action ? buildOperationTree(props.act
 const selectedOpIndex = ref(0);
 
 watch(() => props.action, async (action) => {
-  const tree = operationTree.value;
-  selectedOpIndex.value = tree.length > 0 ? tree.length - 1 : 0;
+  selectedOpIndex.value = 0;
 
   if (!action) {
     sheetEl.value?.hide();
@@ -66,7 +65,14 @@ onUnmounted(() => {
 
 <template>
   <ndd-sheet ref="sheetEl" placement="right" class="action-sheet" @close="emit('close')">
-    <ndd-page sticky-header>
+    <!-- :key forces ndd-page to remount whenever the action changes.
+         ndd-page captures the sticky-header height ONCE per mount via
+         requestAnimationFrame; when the sheet opens with a new action the
+         header may already be rendered but the measurement happened while
+         the sheet was still hidden, producing a zero-height offset that
+         lets the body content slide up under the title bar (visible as a
+         fade). Remounting fixes the measurement. -->
+    <ndd-page :key="action?.output ?? 'none'" sticky-header>
       <ndd-top-title-bar slot="header" text="Actie" dismiss-text="Annuleer" @dismiss="emit('close')"></ndd-top-title-bar>
 
       <ndd-simple-section>

--- a/frontend/src/components/ActionSheet.vue
+++ b/frontend/src/components/ActionSheet.vue
@@ -17,8 +17,15 @@ const operationTree = computed(() => props.action ? buildOperationTree(props.act
 
 const selectedOpIndex = ref(0);
 
+// Stable key for the ndd-page element. Captured once when the action
+// changes (via the watcher below) so that editing the output text field
+// — which mutates action.output — does NOT change the :key and trigger
+// a full remount on every keystroke.
+const actionKey = ref('none');
+
 watch(() => props.action, async (action) => {
   selectedOpIndex.value = 0;
+  actionKey.value = action?.output ?? 'none';
 
   if (!action) {
     sheetEl.value?.hide();
@@ -65,14 +72,18 @@ onUnmounted(() => {
 
 <template>
   <ndd-sheet ref="sheetEl" placement="right" class="action-sheet" @close="emit('close')">
-    <!-- :key forces ndd-page to remount whenever the action changes.
+    <!-- :key forces ndd-page to remount whenever a NEW action opens.
          ndd-page captures the sticky-header height ONCE per mount via
          requestAnimationFrame; when the sheet opens with a new action the
          header may already be rendered but the measurement happened while
          the sheet was still hidden, producing a zero-height offset that
          lets the body content slide up under the title bar (visible as a
-         fade). Remounting fixes the measurement. -->
-    <ndd-page :key="action?.output ?? 'none'" sticky-header>
+         fade). Remounting fixes the measurement.
+
+         actionKey is captured once when the action changes (in the
+         watcher), NOT reactively bound to action.output, so editing the
+         output text field does not trigger a remount on every keystroke. -->
+    <ndd-page :key="actionKey" sticky-header>
       <ndd-top-title-bar slot="header" text="Actie" dismiss-text="Annuleer" @dismiss="emit('close')"></ndd-top-title-bar>
 
       <ndd-simple-section>

--- a/frontend/src/components/ActionSheet.vue
+++ b/frontend/src/components/ActionSheet.vue
@@ -17,15 +17,15 @@ const operationTree = computed(() => props.action ? buildOperationTree(props.act
 
 const selectedOpIndex = ref(0);
 
-// Stable key for the ndd-page element. Captured once when the action
-// changes (via the watcher below) so that editing the output text field
-// — which mutates action.output — does NOT change the :key and trigger
-// a full remount on every keystroke.
+// Monotonic counter used as :key for the ndd-page element so it remounts
+// every time a new action opens (fixing the sticky-header height
+// measurement) without remounting on every keystroke in the output field.
+let actionSeq = 0;
 const actionKey = ref('none');
 
 watch(() => props.action, async (action) => {
   selectedOpIndex.value = 0;
-  actionKey.value = action?.output ?? 'none';
+  actionKey.value = action ? String(++actionSeq) : 'none';
 
   if (!action) {
     sheetEl.value?.hide();

--- a/frontend/src/components/EditSheet.vue
+++ b/frontend/src/components/EditSheet.vue
@@ -17,14 +17,24 @@ const values = ref({});
 const typeOptions = ['string', 'number', 'boolean', 'amount'];
 
 // Available variables from the article's machine_readable for parameter
-// value dropdowns. Reuses the same collectAvailableVariables utility that
+// value dropdowns, grouped by category with alphabetical sorting within
+// each group. Reuses the same collectAvailableVariables utility that
 // OperationSettings uses for subject dropdowns.
-const paramValueOptions = computed(() =>
-  collectAvailableVariables(props.article).map(v => ({
-    value: v.ref,
-    label: `${v.name.replace(/_/g, ' ')} (${v.category.toLowerCase()})`,
-  })),
-);
+const paramValueGroups = computed(() => {
+  const vars = collectAvailableVariables(props.article);
+  const groups = new Map();
+  for (const v of vars) {
+    if (!groups.has(v.category)) groups.set(v.category, []);
+    groups.get(v.category).push({
+      value: v.ref,
+      label: v.name.replace(/_/g, ' '),
+    });
+  }
+  for (const opts of groups.values()) {
+    opts.sort((a, b) => a.label.localeCompare(b.label));
+  }
+  return groups;
+});
 
 // --- Law search / output selection ---
 let lawsCache = null;
@@ -512,21 +522,15 @@ const sectionLabels = {
                   ></ndd-text-field>
                 </ndd-cell>
                 <ndd-cell>
-                  <ndd-dropdown v-if="paramValueOptions.length > 0" size="md" :data-testid="`source-param-value-${param._rowId}`">
+                  <ndd-dropdown size="md" :data-testid="`source-param-value-${param._rowId}`">
                     <select :value="param.value" :aria-label="`Waarde voor ${param.key}`" @change="param.value = $event.target.value">
                       <option value="">Selecteer...</option>
                       <option v-if="param.value && !param.value.startsWith('$')" :value="param.value" :selected="true">{{ param.value }}</option>
-                      <option v-for="opt in paramValueOptions" :key="opt.value" :value="opt.value" :selected="opt.value === param.value">{{ opt.label }}</option>
+                      <optgroup v-for="[category, opts] in paramValueGroups" :key="category" :label="category">
+                        <option v-for="opt in opts" :key="opt.value" :value="opt.value" :selected="opt.value === param.value">{{ opt.label }}</option>
+                      </optgroup>
                     </select>
                   </ndd-dropdown>
-                  <ndd-text-field
-                    v-else
-                    size="md"
-                    placeholder="waarde (bijv. $bsn)"
-                    :value="param.value"
-                    :data-testid="`source-param-value-${param._rowId}`"
-                    @input="param.value = $event.target?.value ?? $event.detail?.value ?? param.value"
-                  ></ndd-text-field>
                 </ndd-cell>
               </ndd-list-item>
             </ndd-list>

--- a/frontend/src/components/EditSheet.vue
+++ b/frontend/src/components/EditSheet.vue
@@ -31,7 +31,7 @@ const paramValueGroups = computed(() => {
     });
   }
   for (const opts of groups.values()) {
-    opts.sort((a, b) => a.label.localeCompare(b.label));
+    opts.sort((a, b) => a.label.localeCompare(b.label, 'nl'));
   }
   return groups;
 });


### PR DESCRIPTION
## Summary

Follow-up fixes for #538 and #540:

- **Grouped param dropdowns** — Source parameter value dropdowns now use `<optgroup>` headers to group variables by category (Parameter, Context, Input, etc.) with alphabetical sorting within each group
- **Action sheet fade fix** — Add `:key` to `ndd-page` so the sticky header height re-measures when the action changes, fixing the content-behind-header fade
- **Root operation default** — Opening an action now selects the root operation (not the deepest nested one), so the action title appears in "Instellingen operatie" instead of confusingly under "Bovenliggende operaties"
- **Dead code removal** — Remove unreachable `v-else` text field for param values (`paramValueOptions` always has at least `$referencedate`)

## Test plan

- [ ] Open an input with source parameters → verify dropdown shows grouped headers (Parameter / Context) with alphabetical order
- [ ] Open an action → verify no fade/content overlap at the top
- [ ] Open "heeft recht op zorgtoeslag" → verify it shows directly in operation settings, not under "Bovenliggende operaties"
- [ ] Existing vitest tests pass (36/36)