### PR TITLE
feat(editor): compose operation titles as subject operator value

### DIFF
--- a/frontend/src/utils/operationTree.js
+++ b/frontend/src/utils/operationTree.js
@@ -1,12 +1,3 @@
-const OPERATION_SYMBOLS = {
-  EQUALS: '=',
-  GREATER_THAN: '>',
-  GREATER_THAN_OR_EQUAL: '>=',
-  LESS_THAN: '<',
-  LESS_THAN_OR_EQUAL: '<=',
-  IN: 'in',
-};
-
 export const OPERATION_LABELS = {
   // Rekenkundig
   ADD: 'optellen',
@@ -192,21 +183,11 @@ function formatArgName(v) {
 }
 
 export function humanizeTitle(node) {
-  const symbol = OPERATION_SYMBOLS[node.operation];
-  if (symbol && node.subject != null) {
+  const label = OPERATION_LABELS[node.operation] || node.operation;
+
+  if (node.subject != null) {
     const subject = getReadableName(node.subject) ?? formatArgName(node.subject);
-    if (node.value !== undefined && !isOperationNode(node.value)) {
-      const value = getReadableName(node.value) ?? formatArgName(node.value);
-      return `${subject} ${symbol} ${value}`;
-    }
-    if (isOperationNode(node.value)) {
-      return `${subject} ${symbol} (...)`;
-    }
-    if (Array.isArray(node.values)) {
-      const items = node.values.map((v) => getReadableName(v) ?? formatArgName(v));
-      return `${subject} ${symbol} [${items.join(', ')}]`;
-    }
-    return `${subject} ${symbol}`;
+    return `${subject} (${label})`;
   }
 
   const names = [];

--- a/frontend/src/utils/operationTree.js
+++ b/frontend/src/utils/operationTree.js
@@ -199,6 +199,9 @@ export function humanizeTitle(node) {
       const value = getReadableName(node.value) ?? formatArgName(node.value);
       return `${subject} ${symbol} ${value}`;
     }
+    if (isOperationNode(node.value)) {
+      return `${subject} ${symbol} (...)`;
+    }
     if (Array.isArray(node.values)) {
       const items = node.values.map((v) => getReadableName(v) ?? formatArgName(v));
       return `${subject} ${symbol} [${items.join(', ')}]`;

--- a/frontend/src/utils/operationTree.js
+++ b/frontend/src/utils/operationTree.js
@@ -1,3 +1,15 @@
+const OPERATION_SYMBOLS = {
+  EQUALS: '=',
+  NOT_EQUALS: '≠',
+  GREATER_THAN: '>',
+  GREATER_THAN_OR_EQUAL: '>=',
+  LESS_THAN: '<',
+  LESS_THAN_OR_EQUAL: '<=',
+  IN: 'in',
+  NOT_IN: 'niet in',
+  NOT_NULL: '≠ null',
+};
+
 export const OPERATION_LABELS = {
   // Rekenkundig
   ADD: 'optellen',
@@ -183,6 +195,16 @@ function formatArgName(v) {
 }
 
 export function humanizeTitle(node) {
+  const symbol = OPERATION_SYMBOLS[node.operation];
+  if (symbol && node.subject != null) {
+    const subject = getReadableName(node.subject) || formatArgName(node.subject);
+    if (node.value !== undefined && !isOperationNode(node.value)) {
+      const value = getReadableName(node.value) ?? formatArgName(node.value);
+      return `${subject} ${symbol} ${value}`;
+    }
+    return `${subject} ${symbol}`;
+  }
+
   const names = [];
 
   if (Array.isArray(node.values)) {

--- a/frontend/src/utils/operationTree.js
+++ b/frontend/src/utils/operationTree.js
@@ -1,13 +1,10 @@
 const OPERATION_SYMBOLS = {
   EQUALS: '=',
-  NOT_EQUALS: '≠',
   GREATER_THAN: '>',
   GREATER_THAN_OR_EQUAL: '>=',
   LESS_THAN: '<',
   LESS_THAN_OR_EQUAL: '<=',
   IN: 'in',
-  NOT_IN: 'niet in',
-  NOT_NULL: '≠ null',
 };
 
 export const OPERATION_LABELS = {
@@ -197,10 +194,14 @@ function formatArgName(v) {
 export function humanizeTitle(node) {
   const symbol = OPERATION_SYMBOLS[node.operation];
   if (symbol && node.subject != null) {
-    const subject = getReadableName(node.subject) || formatArgName(node.subject);
+    const subject = getReadableName(node.subject) ?? formatArgName(node.subject);
     if (node.value !== undefined && !isOperationNode(node.value)) {
       const value = getReadableName(node.value) ?? formatArgName(node.value);
       return `${subject} ${symbol} ${value}`;
+    }
+    if (Array.isArray(node.values)) {
+      const items = node.values.map((v) => getReadableName(v) ?? formatArgName(v));
+      return `${subject} ${symbol} [${items.join(', ')}]`;
     }
     return `${subject} ${symbol}`;
   }


### PR DESCRIPTION
## Summary
- Operatie-titels in de structured editor tonen nu een samenvatting van alle velden, bijv. "leeftijd >= 18" in plaats van alleen "leeftijd"
- Nieuwe `OPERATION_SYMBOLS` mapping voor vergelijkingsoperaties (=, >, >=, <, <=, etc.)
- Niet-vergelijkingsoperaties (AND, IF, ADD, etc.) blijven ongewijzigd

## Test plan
- [ ] Open een wet met vergelijkingsoperaties in de structured editor
- [ ] Controleer dat titels in de bovenliggende operaties-lijst het format "subject operator value" tonen
- [ ] Controleer dat niet-vergelijkingsoperaties ongewijzigd zijn