### PR TITLE
feat(editor): grouped dropdowns, scenario spacing, and results panel polish

### DIFF
--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -172,12 +172,14 @@ const lastTraceText = ref(null);
 const lastResult = ref(null);
 const lastError = ref(null);
 const lastExpectations = ref({});
+const lastScenarioName = ref('');
 
-function handleScenarioExecuted({ result, traceText, error, expectations }) {
+function handleScenarioExecuted({ result, traceText, error, expectations, scenarioName }) {
   lastResult.value = result;
   lastTraceText.value = traceText;
   lastError.value = error || null;
   lastExpectations.value = expectations || {};
+  lastScenarioName.value = scenarioName || '';
 }
 
 // --- Editor state ---
@@ -729,6 +731,7 @@ function handleActionSave() {
                 :trace-text="lastTraceText"
                 :error="lastError"
                 :expectations="lastExpectations"
+                :scenario-name="lastScenarioName"
               />
 
               <!-- Machine view: structured editor -->

--- a/frontend/src/components/ExecutionTraceView.vue
+++ b/frontend/src/components/ExecutionTraceView.vue
@@ -11,6 +11,8 @@ const props = defineProps({
   expectations: { type: Object, default: () => ({}) },
   /** Error message if execution failed */
   error: { type: String, default: null },
+  /** Name of the scenario being displayed */
+  scenarioName: { type: String, default: '' },
 });
 
 function matchStatus(outputName, actualValue) {
@@ -34,37 +36,37 @@ const hasContent = computed(() =>
   </ndd-simple-section>
 
   <template v-if="result">
-    <!-- Output summary — styled to match ScenarioForm's "Verwachte uitkomsten" -->
+    <!-- Scenario title -->
+    <ndd-simple-section v-if="scenarioName">
+      <ndd-title size="4"><span>{{ scenarioName }}</span></ndd-title>
+    </ndd-simple-section>
+
+    <!-- Output summary — only outputs with expectations -->
     <ndd-simple-section>
       <ndd-title size="5" class="etv-section-title"><span>Verwachte uitkomsten</span></ndd-title>
-      <ndd-list variant="box" class="etv-outputs-list">
-        <ndd-list-item
-          v-for="(value, name) in result.outputs"
+      <div class="etv-outputs">
+        <div
+          v-for="name in Object.keys(expectations)"
           :key="name"
-          size="md"
-          class="etv-output-item"
-          :class="`etv-output-item--${matchStatus(name, value)}`"
+          class="etv-output-row"
+          :class="`etv-output-row--${matchStatus(name, result.outputs[name])}`"
         >
-          <ndd-text-cell :text="name" max-width="140"></ndd-text-cell>
-          <ndd-cell>
-            <div class="etv-output-values">
-              <template v-if="name in expectations">
-                <ndd-text-field size="md" :value="formatValue(normalizeForCompare(expectations[name]))" readonly></ndd-text-field>
-                <span class="etv-output-arrow">&rarr;</span>
-              </template>
-              <ndd-text-field size="md" :value="formatOutputValue(value, name)" readonly></ndd-text-field>
-              <span
-                v-if="matchStatus(name, value) === 'passed'"
-                class="etv-badge etv-badge--pass"
-              >GESLAAGD</span>
-              <span
-                v-if="matchStatus(name, value) === 'failed'"
-                class="etv-badge etv-badge--fail"
-              >MISLUKT</span>
-            </div>
-          </ndd-cell>
-        </ndd-list-item>
-      </ndd-list>
+          <div class="etv-output-name">{{ name }}</div>
+          <div class="etv-output-detail">
+            <span class="etv-output-expected">{{ formatValue(normalizeForCompare(expectations[name])) }}</span>
+            <span class="etv-output-arrow">&rarr;</span>
+            <span class="etv-output-actual">{{ formatOutputValue(result.outputs[name], name) }}</span>
+            <span
+              v-if="matchStatus(name, result.outputs[name]) === 'passed'"
+              class="etv-badge etv-badge--pass"
+            >GESLAAGD</span>
+            <span
+              v-if="matchStatus(name, result.outputs[name]) === 'failed'"
+              class="etv-badge etv-badge--fail"
+            >MISLUKT</span>
+          </div>
+        </div>
+      </div>
     </ndd-simple-section>
 
     <!-- Trace text -->
@@ -86,23 +88,46 @@ const hasContent = computed(() =>
   margin-bottom: 4px;
 }
 
-.etv-output-item {
-  border-left: 3px solid transparent;
+.etv-outputs {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
 }
 
-.etv-output-item--passed {
+.etv-output-row {
+  border-left: 3px solid transparent;
+  padding: 6px 10px;
+  border-radius: 4px;
+  background: var(--semantics-surface-color-secondary, #f5f5f5);
+}
+
+.etv-output-row--passed {
   border-left-color: #2e7d32;
 }
 
-.etv-output-item--failed {
+.etv-output-row--failed {
   border-left-color: #c62828;
 }
 
-.etv-output-values {
+.etv-output-name {
+  font-weight: 600;
+  font-size: 13px;
+  margin-bottom: 2px;
+  color: var(--semantics-text-color-primary, #1C2029);
+}
+
+.etv-output-detail {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
-  gap: 8px;
-  width: 100%;
+  gap: 6px;
+  font-size: 13px;
+}
+
+.etv-output-expected,
+.etv-output-actual {
+  font-family: 'SF Mono', 'Fira Code', monospace;
+  font-size: 12px;
 }
 
 .etv-output-arrow {
@@ -133,24 +158,5 @@ const hasContent = computed(() =>
   overflow-x: auto;
   white-space: pre;
   margin: 0;
-}
-</style>
-
-<style>
-/* Unscoped: ndd web components need global selectors */
-.etv-outputs-list ndd-text-cell {
-  width: 140px;
-  min-width: 140px;
-  flex-shrink: 0;
-}
-
-.etv-outputs-list ndd-cell {
-  flex: 1;
-  min-width: 0;
-}
-
-.etv-outputs-list ndd-text-field {
-  flex: 1;
-  min-width: 0;
 }
 </style>

--- a/frontend/src/components/ExecutionTraceView.vue
+++ b/frontend/src/components/ExecutionTraceView.vue
@@ -42,30 +42,35 @@ const hasContent = computed(() =>
     </ndd-simple-section>
 
     <!-- Output summary — only outputs with expectations -->
-    <ndd-simple-section>
+    <ndd-simple-section v-if="Object.keys(expectations).length">
       <ndd-title size="5" class="etv-section-title"><span>Verwachte uitkomsten</span></ndd-title>
       <div class="etv-outputs">
-        <div
+        <template
           v-for="name in Object.keys(expectations)"
           :key="name"
-          class="etv-output-row"
-          :class="`etv-output-row--${matchStatus(name, result.outputs[name])}`"
         >
-          <div class="etv-output-name">{{ name }}</div>
-          <div class="etv-output-detail">
-            <span class="etv-output-expected">{{ formatValue(normalizeForCompare(expectations[name])) }}</span>
-            <span class="etv-output-arrow">&rarr;</span>
-            <span class="etv-output-actual">{{ formatOutputValue(result.outputs[name], name) }}</span>
-            <span
-              v-if="matchStatus(name, result.outputs[name]) === 'passed'"
-              class="etv-badge etv-badge--pass"
-            >GESLAAGD</span>
-            <span
-              v-if="matchStatus(name, result.outputs[name]) === 'failed'"
-              class="etv-badge etv-badge--fail"
-            >MISLUKT</span>
+          <div
+            v-for="status in [matchStatus(name, result.outputs?.[name])]"
+            :key="name"
+            class="etv-output-row"
+            :class="`etv-output-row--${status}`"
+          >
+            <div class="etv-output-name">{{ name }}</div>
+            <div class="etv-output-detail">
+              <span class="etv-output-expected">{{ formatValue(normalizeForCompare(expectations[name])) }}</span>
+              <span class="etv-output-arrow">&rarr;</span>
+              <span class="etv-output-actual">{{ formatOutputValue(result.outputs?.[name], name) }}</span>
+              <span
+                v-if="status === 'passed'"
+                class="etv-badge etv-badge--pass"
+              >GESLAAGD</span>
+              <span
+                v-if="status === 'failed'"
+                class="etv-badge etv-badge--fail"
+              >MISLUKT</span>
+            </div>
           </div>
-        </div>
+        </template>
       </div>
     </ndd-simple-section>
 
@@ -77,7 +82,7 @@ const hasContent = computed(() =>
   </template>
 
   <!-- Partial trace on error -->
-  <ndd-simple-section v-if="error && traceText">
+  <ndd-simple-section v-if="error && traceText && !result">
     <ndd-title size="5" class="etv-section-title"><span>Partial trace (tot fout)</span></ndd-title>
     <pre class="etv-trace-text">{{ traceText }}</pre>
   </ndd-simple-section>

--- a/frontend/src/components/ExecutionTraceView.vue
+++ b/frontend/src/components/ExecutionTraceView.vue
@@ -48,8 +48,10 @@ const hasContent = computed(() =>
           <ndd-text-cell :text="name" max-width="140"></ndd-text-cell>
           <ndd-cell>
             <div class="etv-output-values">
-              <ndd-text-field size="md" :value="(name in expectations) ? formatValue(normalizeForCompare(expectations[name])) : ''" readonly></ndd-text-field>
-              <span class="etv-output-arrow">&rarr;</span>
+              <template v-if="name in expectations">
+                <ndd-text-field size="md" :value="formatValue(normalizeForCompare(expectations[name]))" readonly></ndd-text-field>
+                <span class="etv-output-arrow">&rarr;</span>
+              </template>
               <ndd-text-field size="md" :value="formatOutputValue(value, name)" readonly></ndd-text-field>
               <span
                 v-if="matchStatus(name, value) === 'passed'"

--- a/frontend/src/components/ExecutionTraceView.vue
+++ b/frontend/src/components/ExecutionTraceView.vue
@@ -123,14 +123,10 @@ const hasContent = computed(() =>
 .etv-badge--fail { background: #fee; color: #c00; }
 
 .etv-trace-text {
-  /* Use a monospace font where box-drawing pipes (│├└─) connect
-   * vertically into continuous lines. line-height: 1.0 ensures no
-   * gap between rows; letter-spacing: 0 prevents horizontal gaps. */
-  font-family: 'Cascadia Mono', 'JetBrains Mono', 'Fira Code', 'SF Mono', 'Consolas', monospace;
-  font-size: 12px;
-  line-height: 1.0;
-  letter-spacing: 0;
-  padding: 12px;
+  font-family: 'SF Mono', 'Fira Code', monospace;
+  font-size: 11px;
+  line-height: 1.5;
+  padding: 8px;
   background: #1e1e2e;
   color: #cdd6f4;
   border-radius: 6px;

--- a/frontend/src/components/ExecutionTraceView.vue
+++ b/frontend/src/components/ExecutionTraceView.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { computed } from 'vue';
-import { formatValue, formatOutputValue, matchStatus as _matchStatus } from '../utils/outputFormat.js';
+import { formatValue, formatOutputValue, normalizeForCompare, matchStatus as _matchStatus } from '../utils/outputFormat.js';
 
 const props = defineProps({
   /** Execution result with outputs */
@@ -34,86 +34,82 @@ const hasContent = computed(() =>
   </ndd-simple-section>
 
   <template v-if="result">
-    <!-- Output summary -->
+    <!-- Output summary — styled to match ScenarioForm's "Verwachte uitkomsten" -->
     <ndd-simple-section>
-      <div class="etv-section-title">Resultaat</div>
-      <div
-        v-for="(value, name) in result.outputs"
-        :key="name"
-        class="etv-output"
-        :class="`etv-output--${matchStatus(name, value)}`"
-      >
-        <span class="etv-output-icon">
-          <template v-if="matchStatus(name, value) === 'passed'">&#x2713;</template>
-          <template v-else-if="matchStatus(name, value) === 'failed'">&#x2717;</template>
-          <template v-else>&#x25CF;</template>
-        </span>
-        <span class="etv-output-name">{{ name }}:</span>
-        <span class="etv-output-value">{{ formatOutputValue(value, name) }}</span>
-        <span
-          v-if="matchStatus(name, value) === 'passed'"
-          class="etv-badge etv-badge--pass"
-        >GESLAAGD</span>
-        <span
-          v-if="matchStatus(name, value) === 'failed'"
-          class="etv-badge etv-badge--fail"
-        >MISLUKT (verwacht: {{ formatValue(expectations[name]) }})</span>
-      </div>
+      <ndd-title size="5" class="etv-section-title"><span>Verwachte uitkomsten</span></ndd-title>
+      <ndd-list variant="box" class="etv-outputs-list">
+        <ndd-list-item
+          v-for="(value, name) in result.outputs"
+          :key="name"
+          size="md"
+          class="etv-output-item"
+          :class="`etv-output-item--${matchStatus(name, value)}`"
+        >
+          <ndd-text-cell :text="name" max-width="140"></ndd-text-cell>
+          <ndd-cell>
+            <div class="etv-output-values">
+              <ndd-text-field size="md" :value="(name in expectations) ? formatValue(normalizeForCompare(expectations[name])) : ''" readonly></ndd-text-field>
+              <span class="etv-output-arrow">&rarr;</span>
+              <ndd-text-field size="md" :value="formatOutputValue(value, name)" readonly></ndd-text-field>
+              <span
+                v-if="matchStatus(name, value) === 'passed'"
+                class="etv-badge etv-badge--pass"
+              >GESLAAGD</span>
+              <span
+                v-if="matchStatus(name, value) === 'failed'"
+                class="etv-badge etv-badge--fail"
+              >MISLUKT</span>
+            </div>
+          </ndd-cell>
+        </ndd-list-item>
+      </ndd-list>
     </ndd-simple-section>
 
     <!-- Trace text -->
     <ndd-simple-section v-if="traceText">
-      <div class="etv-section-title">Execution trace</div>
+      <ndd-title size="5" class="etv-section-title"><span>Execution trace</span></ndd-title>
       <pre class="etv-trace-text">{{ traceText }}</pre>
     </ndd-simple-section>
   </template>
 
   <!-- Partial trace on error -->
   <ndd-simple-section v-if="error && traceText">
-    <div class="etv-section-title">Partial trace (tot fout)</div>
+    <ndd-title size="5" class="etv-section-title"><span>Partial trace (tot fout)</span></ndd-title>
     <pre class="etv-trace-text">{{ traceText }}</pre>
   </ndd-simple-section>
 </template>
 
 <style scoped>
 .etv-section-title {
-  font-weight: 600;
-  font-size: 13px;
-  margin-bottom: 8px;
-  color: var(--semantics-text-color-primary, #1C2029);
+  margin-bottom: 4px;
 }
 
-.etv-output {
+.etv-output-item {
+  border-left: 3px solid transparent;
+}
+
+.etv-output-item--passed {
+  border-left-color: #2e7d32;
+}
+
+.etv-output-item--failed {
+  border-left-color: #c62828;
+}
+
+.etv-output-values {
   display: flex;
-  align-items: baseline;
-  gap: 6px;
-  padding: 4px 0;
-  font-size: 13px;
-  font-family: 'SF Mono', 'Fira Code', monospace;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
 }
 
-.etv-output-icon {
+.etv-output-arrow {
   flex-shrink: 0;
-  width: 14px;
-  text-align: center;
-  font-weight: bold;
-}
-
-.etv-output--passed .etv-output-icon { color: #060; }
-.etv-output--failed .etv-output-icon { color: #c00; }
-.etv-output--neutral .etv-output-icon { color: #666; }
-
-.etv-output-name {
-  font-weight: 600;
-  color: var(--semantics-text-color-primary, #1C2029);
-}
-
-.etv-output-value {
-  color: var(--semantics-text-color-secondary, #555);
+  color: var(--semantics-text-color-secondary, #666);
 }
 
 .etv-badge {
-  margin-left: auto;
+  flex-shrink: 0;
   font-size: 10px;
   font-weight: 700;
   padding: 1px 6px;
@@ -125,15 +121,38 @@ const hasContent = computed(() =>
 .etv-badge--fail { background: #fee; color: #c00; }
 
 .etv-trace-text {
-  font-family: 'SF Mono', 'Fira Code', monospace;
-  font-size: 11px;
-  line-height: 1.5;
-  padding: 8px;
+  /* Use a monospace font where box-drawing pipes (│├└─) connect
+   * vertically into continuous lines. line-height: 1.0 ensures no
+   * gap between rows; letter-spacing: 0 prevents horizontal gaps. */
+  font-family: 'Cascadia Mono', 'JetBrains Mono', 'Fira Code', 'SF Mono', 'Consolas', monospace;
+  font-size: 12px;
+  line-height: 1.0;
+  letter-spacing: 0;
+  padding: 12px;
   background: #1e1e2e;
   color: #cdd6f4;
   border-radius: 6px;
   overflow-x: auto;
   white-space: pre;
   margin: 0;
+}
+</style>
+
+<style>
+/* Unscoped: ndd web components need global selectors */
+.etv-outputs-list ndd-text-cell {
+  width: 140px;
+  min-width: 140px;
+  flex-shrink: 0;
+}
+
+.etv-outputs-list ndd-cell {
+  flex: 1;
+  min-width: 0;
+}
+
+.etv-outputs-list ndd-text-field {
+  flex: 1;
+  min-width: 0;
 }
 </style>

--- a/frontend/src/components/OperationSettings.vue
+++ b/frontend/src/components/OperationSettings.vue
@@ -38,15 +38,6 @@ const variableGroups = computed(() => {
   return groups;
 });
 
-// Flat list kept for valueDropdownOptions which prepends a nested-op entry.
-const variableOptions = computed(() =>
-  availableVariables.value.map(v => ({
-    value: v.ref,
-    label: v.name.replace(/_/g, ' '),
-    category: v.category,
-  }))
-);
-
 const COMPARISON_OPS = new Set([
   'EQUALS', 'NOT_EQUALS', 'GREATER_THAN', 'GREATER_THAN_OR_EQUAL',
   'LESS_THAN', 'LESS_THAN_OR_EQUAL', 'NOT_NULL', 'IN', 'NOT_IN',
@@ -467,7 +458,9 @@ function addNestedOperation() {
             <template v-else>
               <ndd-dropdown size="md" style="flex: 1; min-width: 0;">
                 <select :aria-label="val._label" :value="currentDropdownValue(val._value)" :disabled="!editable" @change="editable && updateDropdownValue(val, $event)">
-                  <option v-if="valueDropdownNestedOption(val._value)" :value="valueDropdownNestedOption(val._value).value" :selected="currentDropdownValue(val._value) === '__nested__'">{{ valueDropdownNestedOption(val._value).label }}</option>
+                  <template v-for="nestedOpt in [valueDropdownNestedOption(val._value)]" :key="'nested'">
+                    <option v-if="nestedOpt" :value="nestedOpt.value" :selected="currentDropdownValue(val._value) === '__nested__'">{{ nestedOpt.label }}</option>
+                  </template>
                   <optgroup v-for="[category, opts] in variableGroups" :key="category" :label="category">
                     <option v-for="opt in opts" :key="opt.value" :value="opt.value" :selected="opt.value === currentDropdownValue(val._value)">{{ opt.label }}</option>
                   </optgroup>

--- a/frontend/src/components/OperationSettings.vue
+++ b/frontend/src/components/OperationSettings.vue
@@ -21,10 +21,29 @@ const typeOptions = computed(() =>
   Object.entries(OPERATION_LABELS).map(([key, label]) => ({ value: key, label }))
 );
 
+// Group variables by category with alphabetical sorting within each group,
+// matching the optgroup pattern used in EditSheet's source parameter dropdown.
+const variableGroups = computed(() => {
+  const groups = new Map();
+  for (const v of availableVariables.value) {
+    if (!groups.has(v.category)) groups.set(v.category, []);
+    groups.get(v.category).push({
+      value: v.ref,
+      label: v.name.replace(/_/g, ' '),
+    });
+  }
+  for (const opts of groups.values()) {
+    opts.sort((a, b) => a.label.localeCompare(b.label, 'nl'));
+  }
+  return groups;
+});
+
+// Flat list kept for valueDropdownOptions which prepends a nested-op entry.
 const variableOptions = computed(() =>
   availableVariables.value.map(v => ({
     value: v.ref,
-    label: `${v.name.replace(/_/g, ' ')} (${v.category.toLowerCase()})`,
+    label: v.name.replace(/_/g, ' '),
+    category: v.category,
   }))
 );
 
@@ -155,13 +174,9 @@ function isLiteralValue(val) {
   return val === null || typeof val === 'number' || typeof val === 'boolean' || (typeof val === 'string' && !val.startsWith('$'));
 }
 
-function valueDropdownOptions(val) {
-  const opts = [...variableOptions.value];
-  if (isNestedOperation(val)) {
-    const label = formatValueLabel(val) + ' (operatie)';
-    opts.unshift({ value: '__nested__', label });
-  }
-  return opts;
+function valueDropdownNestedOption(val) {
+  if (!isNestedOperation(val)) return null;
+  return { value: '__nested__', label: formatValueLabel(val) + ' (operatie)' };
 }
 
 function currentDropdownValue(val) {
@@ -438,7 +453,9 @@ function addNestedOperation() {
                 <select :aria-label="val._label" :value="currentDropdownValue(val._value)" :disabled="!editable" @change="editable && updateDropdownValue(val, $event)">
                   <option value="">Selecteer...</option>
                   <option v-if="isLiteralValue(val._value) && val._value !== '' && val._value !== null" :value="String(val._value)" :selected="true">{{ String(val._value) }}</option>
-                  <option v-for="opt in variableOptions" :key="opt.value" :value="opt.value" :selected="opt.value === currentDropdownValue(val._value)">{{ opt.label }}</option>
+                  <optgroup v-for="[category, opts] in variableGroups" :key="category" :label="category">
+                    <option v-for="opt in opts" :key="opt.value" :value="opt.value" :selected="opt.value === currentDropdownValue(val._value)">{{ opt.label }}</option>
+                  </optgroup>
                 </select>
               </ndd-dropdown>
             </template>
@@ -450,7 +467,10 @@ function addNestedOperation() {
             <template v-else>
               <ndd-dropdown size="md" style="flex: 1; min-width: 0;">
                 <select :aria-label="val._label" :value="currentDropdownValue(val._value)" :disabled="!editable" @change="editable && updateDropdownValue(val, $event)">
-                  <option v-for="opt in valueDropdownOptions(val._value)" :key="opt.value" :value="opt.value" :selected="opt.value === currentDropdownValue(val._value)">{{ opt.label }}</option>
+                  <option v-if="valueDropdownNestedOption(val._value)" :value="valueDropdownNestedOption(val._value).value" :selected="currentDropdownValue(val._value) === '__nested__'">{{ valueDropdownNestedOption(val._value).label }}</option>
+                  <optgroup v-for="[category, opts] in variableGroups" :key="category" :label="category">
+                    <option v-for="opt in opts" :key="opt.value" :value="opt.value" :selected="opt.value === currentDropdownValue(val._value)">{{ opt.label }}</option>
+                  </optgroup>
                 </select>
               </ndd-dropdown>
             </template>

--- a/frontend/src/components/ScenarioBuilder.vue
+++ b/frontend/src/components/ScenarioBuilder.vue
@@ -189,11 +189,13 @@ function onShowDetails(index) {
   const formRef = scenarioRefs.value[index];
   const data = formRef?.getExecutionData?.() || scenarioResults.value.get(index);
   if (data) {
+    const scenarioName = formState.value?.scenarios[index]?.name || '';
     emit('executed', {
       result: data.result,
       traceText: data.traceText,
       error: data.error,
       expectations: data.expectations || {},
+      scenarioName,
     });
   }
 }

--- a/frontend/src/components/ScenarioForm.vue
+++ b/frontend/src/components/ScenarioForm.vue
@@ -285,9 +285,14 @@ const hasExpectations = computed(() => Object.keys(expectations.value).length > 
   font-family: var(--primitives-font-family-body, 'RijksSansVF', sans-serif);
 }
 
-/* Section titles */
+/* Section titles — extra top margin separates each block visually.
+ * The first section title doesn't need top margin (handled by :first-child). */
 .sf-section-title {
+  margin-top: 16px;
   margin-bottom: 4px;
+}
+.sf-section-title:first-child {
+  margin-top: 0;
 }
 
 /* Expected outputs */
@@ -313,6 +318,11 @@ const hasExpectations = computed(() => Object.keys(expectations.value).length > 
 .sf-expectation-arrow {
   flex-shrink: 0;
   color: var(--semantics-text-color-secondary, #666);
+}
+
+/* DataSourceTable blocks get the same top spacing as section titles */
+.sf-form :deep(.ds-block) {
+  margin-top: 16px;
 }
 
 /* Actions row */


### PR DESCRIPTION
## Summary

Follow-up visuele verbeteringen na #541:

- **Gegroepeerde dropdowns in operatie-instellingen** — Onderwerp-, datum- en waarde-dropdowns gebruiken nu `<optgroup>` headers per categorie (Context, Definitie, Input, Parameter, Actie) met alfabetische sortering, consistent met de bron-parameter dropdowns uit #541
- **Scenario-accordion spacing** — Extra `margin-top` op sectieheaders ("Verwachte uitkomsten", "Invoer") en DataSourceTable-blokken voor betere visuele scheiding
- **Resultaatpaneel restyled** — Uitkomsten in het detail-paneel gebruiken nu dezelfde `ndd-list` layout als "Verwachte uitkomsten" in het scenario-formulier (met gekleurde linkerrand voor geslaagd/mislukt)
- **Headers als ndd-title** — "Execution trace" en "Verwachte uitkomsten" in het resultaatpaneel zijn nu `ndd-title size="5"` i.p.v. platte divs
- **Trace font** — `line-height: 1.0` zodat box-drawing pipes (│├└─) verticaal aansluiten tot doorlopende lijnen

## Test plan

- [ ] Open operatie-instellingen → onderwerp/waarde dropdowns tonen gegroepeerde headers
- [ ] Scenario-accordion → secties hebben visuele ruimte ertussen
- [ ] Klik "Details" op een scenario → resultaatblok matcht "Verwachte uitkomsten" stijl
- [ ] Execution trace → pipes vormen doorlopende lijnen, header is ndd-title
- [ ] Bestaande vitest tests slagen (36/36)