### PR TITLE
fix(editor): redirect to original page after login

### DIFF
--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -12,14 +12,14 @@ import MachineReadable from './components/MachineReadable.vue';
 import ScenarioBuilder from './components/ScenarioBuilder.vue';
 import ExecutionTraceView from './components/ExecutionTraceView.vue';
 
-const { authenticated, loading: authLoading, oidcConfigured, person, logout } = useAuth();
+const { authenticated, loading: authLoading, oidcConfigured, person, login, logout } = useAuth();
 
 // Redirect to login when OIDC is configured but user is not authenticated.
 // { immediate: true } is needed because in SPA navigation the auth state may
 // already be resolved by the time EditorApp mounts (useAuth is a singleton).
 watch([authLoading, oidcConfigured, authenticated], ([isLoading, oidc, authed]) => {
   if (!isLoading && oidc && !authed) {
-    window.location.href = '/auth/login';
+    login();
   }
 }, { immediate: true });
 
@@ -616,7 +616,7 @@ function handleActionSave() {
                     <ndd-menu-item text="Uitloggen" @click="logout"></ndd-menu-item>
                   </template>
                   <template v-else-if="!authLoading && oidcConfigured">
-                    <ndd-menu-item text="Inloggen" @click="() => window.location.href = '/auth/login'"></ndd-menu-item>
+                    <ndd-menu-item text="Inloggen" @click="login"></ndd-menu-item>
                   </template>
                 </ndd-menu>
               </ndd-button-bar>

--- a/frontend/src/composables/useAuth.js
+++ b/frontend/src/composables/useAuth.js
@@ -29,7 +29,7 @@ export function useAuth() {
   }
 
   function login() {
-    const returnUrl = window.location.pathname + window.location.search;
+    const returnUrl = window.location.pathname + window.location.search + window.location.hash;
     window.location.href = '/auth/login?return_url=' + encodeURIComponent(returnUrl);
   }
 

--- a/frontend/src/composables/useAuth.js
+++ b/frontend/src/composables/useAuth.js
@@ -29,7 +29,8 @@ export function useAuth() {
   }
 
   function login() {
-    window.location.href = '/auth/login';
+    const returnUrl = window.location.pathname + window.location.search;
+    window.location.href = '/auth/login?return_url=' + encodeURIComponent(returnUrl);
   }
 
   function logout() {

--- a/packages/admin/frontend-src/src/components/JobCreation.vue
+++ b/packages/admin/frontend-src/src/components/JobCreation.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { ref } from 'vue';
+import { redirectToLogin } from '../composables/useAuth.js';
 
 const emit = defineEmits(['job-created']);
 const inputRef = ref(null);
@@ -39,7 +40,7 @@ async function onSubmit() {
       body: JSON.stringify({ bwb_id: bwbId }),
     });
     if (response.status === 401) {
-      window.location.href = '/auth/login';
+      redirectToLogin();
       return;
     }
     if (response.status === 409) {

--- a/packages/admin/frontend-src/src/components/RowActions.vue
+++ b/packages/admin/frontend-src/src/components/RowActions.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { ref } from 'vue';
 import { RE_HARVESTABLE_STATUSES, ENRICHABLE_STATUSES } from '../constants.js';
+import { redirectToLogin } from '../composables/useAuth.js';
 
 const props = defineProps({
   row: { type: Object, required: true },
@@ -26,7 +27,7 @@ async function onHarvest() {
       body: JSON.stringify({ bwb_id: props.row.law_id }),
     });
     if (response.status === 401) {
-      window.location.href = '/auth/login';
+      redirectToLogin();
       return;
     }
     if (response.status === 409) {
@@ -60,7 +61,7 @@ async function onEnrich() {
       body: JSON.stringify({ law_id: props.row.law_id }),
     });
     if (response.status === 401) {
-      window.location.href = '/auth/login';
+      redirectToLogin();
       return;
     }
     if (response.status === 409) {
@@ -92,7 +93,7 @@ async function onResetExhausted() {
       method: 'POST',
     });
     if (response.status === 401) {
-      window.location.href = '/auth/login';
+      redirectToLogin();
       return;
     }
     if (!response.ok) {

--- a/packages/admin/frontend-src/src/composables/useAuth.js
+++ b/packages/admin/frontend-src/src/composables/useAuth.js
@@ -26,7 +26,7 @@ function logout() {
 }
 
 export function redirectToLogin() {
-  const returnUrl = window.location.pathname + window.location.search;
+  const returnUrl = window.location.pathname + window.location.search + window.location.hash;
   window.location.href = '/auth/login?return_url=' + encodeURIComponent(returnUrl);
 }
 

--- a/packages/admin/frontend-src/src/composables/useAuth.js
+++ b/packages/admin/frontend-src/src/composables/useAuth.js
@@ -25,8 +25,9 @@ function logout() {
   window.location.href = '/auth/logout';
 }
 
-function redirectToLogin() {
-  window.location.href = '/auth/login';
+export function redirectToLogin() {
+  const returnUrl = window.location.pathname + window.location.search;
+  window.location.href = '/auth/login?return_url=' + encodeURIComponent(returnUrl);
 }
 
 export function useAuth() {

--- a/packages/admin/frontend-src/src/composables/usePollingFetch.js
+++ b/packages/admin/frontend-src/src/composables/usePollingFetch.js
@@ -1,4 +1,5 @@
 import { ref, onUnmounted } from 'vue';
+import { redirectToLogin } from './useAuth.js';
 
 export function usePollingFetch(buildUrl, options = {}) {
   const { interval = 20_000 } = options;
@@ -22,7 +23,7 @@ export function usePollingFetch(buildUrl, options = {}) {
       const response = await fetch(url);
 
       if (response.status === 401) {
-        window.location.href = '/auth/login';
+        redirectToLogin();
         return;
       }
 

--- a/packages/auth/src/handlers.rs
+++ b/packages/auth/src/handlers.rs
@@ -89,7 +89,13 @@ fn validate_return_url(url: Option<&str>) -> Option<String> {
     // Must be a relative path — reject absolute URLs and protocol-relative URLs.
     // Also reject backslashes: some browsers normalise `\` to `/`, so `/\evil.com`
     // could be interpreted as the protocol-relative `//evil.com`.
-    if !url.starts_with('/') || url.starts_with("//") || url.contains('\\') {
+    // Reject control characters (CR, LF, etc.) — Axum's Redirect::temporary panics
+    // on header values containing them, which would DoS the OIDC callback.
+    if !url.starts_with('/')
+        || url.starts_with("//")
+        || url.contains('\\')
+        || url.bytes().any(|b| b < 0x20 || b == 0x7f)
+    {
         return None;
     }
     Some(url.to_string())
@@ -580,5 +586,19 @@ mod tests {
             validate_return_url(Some("/library#section")),
             Some("/library#section".to_string())
         );
+    }
+
+    #[test]
+    fn return_url_rejects_control_characters() {
+        // CRLF injection — would panic in Axum's Redirect::temporary
+        assert_eq!(
+            validate_return_url(Some("/library\r\nX-Injected: header")),
+            None
+        );
+        assert_eq!(validate_return_url(Some("/library\nheader")), None);
+        // DEL character
+        assert_eq!(validate_return_url(Some("/library\x7f")), None);
+        // Null byte
+        assert_eq!(validate_return_url(Some("/library\0")), None);
     }
 }

--- a/packages/auth/src/handlers.rs
+++ b/packages/auth/src/handlers.rs
@@ -87,7 +87,9 @@ fn validate_return_url(url: Option<&str>) -> Option<String> {
         return None;
     }
     // Must be a relative path — reject absolute URLs and protocol-relative URLs.
-    if !url.starts_with('/') || url.starts_with("//") {
+    // Also reject backslashes: some browsers normalise `\` to `/`, so `/\evil.com`
+    // could be interpreted as the protocol-relative `//evil.com`.
+    if !url.starts_with('/') || url.starts_with("//") || url.contains('\\') {
         return None;
     }
     Some(url.to_string())
@@ -558,5 +560,25 @@ mod tests {
     #[test]
     fn return_url_rejects_protocol_relative() {
         assert_eq!(validate_return_url(Some("//evil.com/steal")), None);
+    }
+
+    #[test]
+    fn return_url_rejects_backslash() {
+        assert_eq!(validate_return_url(Some("/\\evil.com")), None);
+        assert_eq!(validate_return_url(Some("/path\\segment")), None);
+    }
+
+    #[test]
+    fn return_url_rejects_whitespace_only() {
+        assert_eq!(validate_return_url(Some("   ")), None);
+        assert_eq!(validate_return_url(Some("  /  ")), None);
+    }
+
+    #[test]
+    fn return_url_allows_fragment() {
+        assert_eq!(
+            validate_return_url(Some("/library#section")),
+            Some("/library#section".to_string())
+        );
     }
 }

--- a/packages/auth/src/handlers.rs
+++ b/packages/auth/src/handlers.rs
@@ -27,6 +27,7 @@ pub const SESSION_KEY_EMAIL: &str = "person_email";
 pub const SESSION_KEY_NAME: &str = "person_name";
 pub const SESSION_KEY_ID_TOKEN: &str = "id_token_hint";
 const SESSION_KEY_BASE_URL: &str = "oidc_base_url";
+const SESSION_KEY_RETURN_URL: &str = "oidc_return_url";
 
 /// Derive the base URL from `BASE_URL` env or request headers.
 ///
@@ -73,10 +74,30 @@ struct RealmAccess {
     roles: Vec<String>,
 }
 
+#[derive(Deserialize)]
+pub struct LoginQuery {
+    pub return_url: Option<String>,
+}
+
+/// Validate that a return URL is a safe relative path (starts with `/`,
+/// no protocol or host). Returns `None` for invalid or missing values.
+fn validate_return_url(url: Option<&str>) -> Option<String> {
+    let url = url?.trim();
+    if url.is_empty() || url == "/" {
+        return None;
+    }
+    // Must be a relative path — reject absolute URLs and protocol-relative URLs.
+    if !url.starts_with('/') || url.starts_with("//") {
+        return None;
+    }
+    Some(url.to_string())
+}
+
 pub async fn login<S: OidcAppState>(
     State(state): State<S>,
     headers: HeaderMap,
     session: Session,
+    axum::extract::Query(params): axum::extract::Query<LoginQuery>,
 ) -> Result<Response, StatusCode> {
     let client = state.oidc_client().ok_or(StatusCode::NOT_IMPLEMENTED)?;
 
@@ -115,6 +136,10 @@ pub async fn login<S: OidcAppState>(
     )
     .await?;
     session_insert(&session, SESSION_KEY_BASE_URL, base_url).await?;
+
+    if let Some(return_url) = validate_return_url(params.return_url.as_deref()) {
+        session_insert(&session, SESSION_KEY_RETURN_URL, return_url).await?;
+    }
 
     Ok(Redirect::temporary(auth_url.as_str()).into_response())
 }
@@ -297,7 +322,15 @@ pub async fn callback<S: OidcAppState>(
 
     tracing::debug!(email = %email, "OIDC login successful");
 
-    Ok(Redirect::temporary(&format!("{base_url}/")).into_response())
+    let return_url: Option<String> = session.get(SESSION_KEY_RETURN_URL).await.ok().flatten();
+    let _ = session.remove::<String>(SESSION_KEY_RETURN_URL).await;
+
+    let redirect_target = match validate_return_url(return_url.as_deref()) {
+        Some(path) => format!("{base_url}{path}"),
+        None => format!("{base_url}/"),
+    };
+
+    Ok(Redirect::temporary(&redirect_target).into_response())
 }
 
 pub async fn logout<S: OidcAppState>(
@@ -486,5 +519,44 @@ mod tests {
         let roles = extract_realm_roles(&jwt).unwrap();
         assert!(roles.contains(&"allowed-user".to_string()));
         assert!(!roles.contains(&"admin".to_string()));
+    }
+
+    // --- validate_return_url ---
+
+    #[test]
+    fn return_url_valid_path() {
+        assert_eq!(
+            validate_return_url(Some("/library/some-law/article-5")),
+            Some("/library/some-law/article-5".to_string())
+        );
+    }
+
+    #[test]
+    fn return_url_with_query() {
+        assert_eq!(
+            validate_return_url(Some("/library?tab=jobs")),
+            Some("/library?tab=jobs".to_string())
+        );
+    }
+
+    #[test]
+    fn return_url_rejects_root() {
+        assert_eq!(validate_return_url(Some("/")), None);
+    }
+
+    #[test]
+    fn return_url_rejects_empty() {
+        assert_eq!(validate_return_url(Some("")), None);
+        assert_eq!(validate_return_url(None), None);
+    }
+
+    #[test]
+    fn return_url_rejects_absolute_url() {
+        assert_eq!(validate_return_url(Some("https://evil.com/steal")), None);
+    }
+
+    #[test]
+    fn return_url_rejects_protocol_relative() {
+        assert_eq!(validate_return_url(Some("//evil.com/steal")), None);
     }
 }


### PR DESCRIPTION
## Summary
- After OIDC login, the callback always redirected to `/` which lands on `/library` without the specific law/article the user was trying to reach
- Now the frontends pass a `return_url` query parameter to `/auth/login`, the backend stores it in the session, and the OIDC callback redirects there instead
- The return URL is validated server-side (must be a relative path starting with `/`) to prevent open-redirect attacks
- Applied to both editor and admin frontends

## Test plan
- [ ] Visit a deep link (e.g. `/library/some-law/article-5`) while not logged in → after login, verify you land on that page
- [ ] Visit the editor page while not logged in → after login, verify you land on the editor
- [ ] On the admin dashboard, let session expire, trigger a 401 → after re-login, verify you're back on the same admin tab
- [ ] Verify that `return_url` values like `https://evil.com` or `//evil.com` are rejected (should fall back to `/`)