### PR TITLE
fix(editor): library panel layout and scenario result activation

### DIFF
--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -180,6 +180,7 @@ function handleScenarioExecuted({ result, traceText, error, expectations, scenar
   lastError.value = error || null;
   lastExpectations.value = expectations || {};
   lastScenarioName.value = scenarioName || '';
+  rightPaneView.value = 'result';
 }
 
 // --- Editor state ---

--- a/frontend/src/LibraryApp.vue
+++ b/frontend/src/LibraryApp.vue
@@ -321,6 +321,11 @@ loadIndex();
                   <ndd-toolbar-item slot="start">
                     <ndd-button text="Filter"></ndd-button>
                   </ndd-toolbar-item>
+                  <ndd-toolbar-item slot="start">
+                    <a v-if="selectedLawId && selectedArticleNumber" :href="`/editor/${encodeURIComponent(selectedLawId)}/${encodeURIComponent(selectedArticleNumber)}`" @click.prevent="router.push(`/editor/${encodeURIComponent(selectedLawId)}/${encodeURIComponent(selectedArticleNumber)}`)">
+                      <ndd-icon-button icon="pencil" title="Bewerk in editor"></ndd-icon-button>
+                    </a>
+                  </ndd-toolbar-item>
                 </ndd-toolbar>
                 <ndd-spacer size="16"></ndd-spacer>
                 <ndd-inline-dialog v-if="selectedLawLoading" text="Laden..."></ndd-inline-dialog>
@@ -367,14 +372,7 @@ loadIndex();
               <div v-else class="library-detail-content" :class="`library-detail-content--${detailView}`">
                 <KeepAlive>
                   <ArticleText v-if="detailView === 'tekst'" :article="selectedArticle" />
-                  <div v-else-if="detailView === 'machine'">
-                    <ndd-simple-section>
-                      <a v-if="selectedLawId" :href="`/editor/${encodeURIComponent(selectedLawId)}/${encodeURIComponent(selectedArticleNumber)}`" @click.prevent="router.push(`/editor/${encodeURIComponent(selectedLawId)}/${encodeURIComponent(selectedArticleNumber)}`)">
-                        <ndd-button variant="primary" text="Bewerk in editor"></ndd-button>
-                      </a>
-                    </ndd-simple-section>
-                    <MachineReadable :article="selectedArticle" @open-action="activeAction = $event" />
-                  </div>
+                  <MachineReadable v-else-if="detailView === 'machine'" :article="selectedArticle" @open-action="activeAction = $event" />
                   <YamlView v-else-if="detailView === 'yaml'" :article="selectedArticle" />
                 </KeepAlive>
               </div>

--- a/frontend/src/LibraryApp.vue
+++ b/frontend/src/LibraryApp.vue
@@ -359,10 +359,6 @@ loadIndex();
                   <ndd-segmented-control-item value="machine" text="Machine"></ndd-segmented-control-item>
                   <ndd-segmented-control-item value="yaml" text="YAML"></ndd-segmented-control-item>
                 </ndd-segmented-control>
-                <a v-if="selectedLawId" slot="toolbar" :href="`/editor/${encodeURIComponent(selectedLawId)}/${encodeURIComponent(selectedArticleNumber)}`" @click.prevent="router.push(`/editor/${encodeURIComponent(selectedLawId)}/${encodeURIComponent(selectedArticleNumber)}`)">
-                  <ndd-button variant="primary" text="Bewerk"></ndd-button>
-                </a>
-                <ndd-button v-else slot="toolbar" variant="primary" disabled text="Bewerk"></ndd-button>
               </ndd-top-title-bar>
 
               <ndd-simple-section v-if="!selectedArticle" align="center">
@@ -371,7 +367,14 @@ loadIndex();
               <div v-else class="library-detail-content" :class="`library-detail-content--${detailView}`">
                 <KeepAlive>
                   <ArticleText v-if="detailView === 'tekst'" :article="selectedArticle" />
-                  <MachineReadable v-else-if="detailView === 'machine'" :article="selectedArticle" @open-action="activeAction = $event" />
+                  <div v-else-if="detailView === 'machine'">
+                    <ndd-simple-section>
+                      <a v-if="selectedLawId" :href="`/editor/${encodeURIComponent(selectedLawId)}/${encodeURIComponent(selectedArticleNumber)}`" @click.prevent="router.push(`/editor/${encodeURIComponent(selectedLawId)}/${encodeURIComponent(selectedArticleNumber)}`)">
+                        <ndd-button variant="primary" text="Bewerk in editor"></ndd-button>
+                      </a>
+                    </ndd-simple-section>
+                    <MachineReadable :article="selectedArticle" @open-action="activeAction = $event" />
+                  </div>
                   <YamlView v-else-if="detailView === 'yaml'" :article="selectedArticle" />
                 </KeepAlive>
               </div>

--- a/frontend/src/LibraryApp.vue
+++ b/frontend/src/LibraryApp.vue
@@ -27,6 +27,11 @@ const selectedArticleNumber = ref(null);
 const detailView = ref('machine');
 const activeAction = ref(null);
 
+function onDetailViewChange(event) {
+  const value = event.target?.value ?? event.detail?.[0];
+  if (value) detailView.value = value;
+}
+
 const filteredLaws = computed(() => {
   let list = laws.value;
   if (favorites.value) {
@@ -343,30 +348,22 @@ loadIndex();
 
           <!-- Main: Artikel Detail -->
           <ndd-split-view-pane slot="main" has-content>
-            <ndd-page sticky-header background="default">
-              <div slot="header" class="library-detail-header">
-                <ndd-top-title-bar
-                  :text="selectedArticle ? `Artikel ${selectedArticle.number}` : 'Selecteer een artikel'"
-                  :back-text="lawName || 'Terug'"
-                ></ndd-top-title-bar>
-                <ndd-container padding-inline="16">
-                  <ndd-toolbar>
-                    <ndd-toolbar-item slot="start">
-                      <ndd-tab-bar>
-                        <ndd-tab-bar-item :selected="detailView === 'tekst' || undefined" @click="detailView = 'tekst'" text="Tekst"></ndd-tab-bar-item>
-                        <ndd-tab-bar-item :selected="detailView === 'machine' || undefined" @click="detailView = 'machine'" text="Machine"></ndd-tab-bar-item>
-                        <ndd-tab-bar-item :selected="detailView === 'yaml' || undefined" @click="detailView = 'yaml'" text="YAML"></ndd-tab-bar-item>
-                      </ndd-tab-bar>
-                    </ndd-toolbar-item>
-                    <ndd-toolbar-item slot="end">
-                      <a v-if="selectedLawId" :href="`/editor/${encodeURIComponent(selectedLawId)}/${encodeURIComponent(selectedArticleNumber)}`" @click.prevent="router.push(`/editor/${encodeURIComponent(selectedLawId)}/${encodeURIComponent(selectedArticleNumber)}`)">
-                        <ndd-button variant="primary" text="Bewerk"></ndd-button>
-                      </a>
-                      <ndd-button v-else variant="primary" disabled text="Bewerk"></ndd-button>
-                    </ndd-toolbar-item>
-                  </ndd-toolbar>
-                </ndd-container>
-              </div>
+            <ndd-page sticky-header>
+              <ndd-top-title-bar
+                slot="header"
+                :text="selectedArticle ? `Artikel ${selectedArticle.number}` : 'Selecteer een artikel'"
+                :back-text="lawName || 'Terug'"
+              >
+                <ndd-segmented-control slot="toolbar" size="md" :value="detailView" @change="onDetailViewChange">
+                  <ndd-segmented-control-item value="tekst" text="Tekst"></ndd-segmented-control-item>
+                  <ndd-segmented-control-item value="machine" text="Machine"></ndd-segmented-control-item>
+                  <ndd-segmented-control-item value="yaml" text="YAML"></ndd-segmented-control-item>
+                </ndd-segmented-control>
+                <a v-if="selectedLawId" slot="toolbar" :href="`/editor/${encodeURIComponent(selectedLawId)}/${encodeURIComponent(selectedArticleNumber)}`" @click.prevent="router.push(`/editor/${encodeURIComponent(selectedLawId)}/${encodeURIComponent(selectedArticleNumber)}`)">
+                  <ndd-button variant="primary" text="Bewerk"></ndd-button>
+                </a>
+                <ndd-button v-else slot="toolbar" variant="primary" disabled text="Bewerk"></ndd-button>
+              </ndd-top-title-bar>
 
               <ndd-simple-section v-if="!selectedArticle" align="center">
                 <ndd-inline-dialog text="Selecteer een artikel"></ndd-inline-dialog>
@@ -392,10 +389,6 @@ loadIndex();
 </template>
 
 <style scoped>
-.library-detail-header {
-  background: var(--semantics-surfaces-background-color, white);
-}
-
 .library-detail-content {
   flex: 1;
   min-height: 0;

--- a/frontend/src/LibraryApp.vue
+++ b/frontend/src/LibraryApp.vue
@@ -343,8 +343,8 @@ loadIndex();
 
           <!-- Main: Artikel Detail -->
           <ndd-split-view-pane slot="main" has-content>
-            <ndd-page sticky-header>
-              <div slot="header">
+            <ndd-page sticky-header background="default">
+              <div slot="header" class="library-detail-header">
                 <ndd-top-title-bar
                   :text="selectedArticle ? `Artikel ${selectedArticle.number}` : 'Selecteer een artikel'"
                   :back-text="lawName || 'Terug'"
@@ -371,13 +371,13 @@ loadIndex();
               <ndd-simple-section v-if="!selectedArticle" align="center">
                 <ndd-inline-dialog text="Selecteer een artikel"></ndd-inline-dialog>
               </ndd-simple-section>
-              <template v-else>
+              <div v-else class="library-detail-content" :class="`library-detail-content--${detailView}`">
                 <KeepAlive>
                   <ArticleText v-if="detailView === 'tekst'" :article="selectedArticle" />
                   <MachineReadable v-else-if="detailView === 'machine'" :article="selectedArticle" @open-action="activeAction = $event" />
                   <YamlView v-else-if="detailView === 'yaml'" :article="selectedArticle" />
                 </KeepAlive>
-              </template>
+              </div>
             </ndd-page>
           </ndd-split-view-pane>
 
@@ -390,3 +390,27 @@ loadIndex();
        so the output field is hidden and the footer button just closes the sheet. -->
   <ActionSheet :action="activeAction" :article="selectedArticle" :editable="false" @close="activeAction = null" @save="activeAction = null" />
 </template>
+
+<style>
+.library-detail-header {
+  background: var(--semantics-surfaces-background-color, white);
+}
+
+.library-detail-content {
+  flex: 1;
+  min-height: 0;
+}
+
+.library-detail-content--machine,
+.library-detail-content--yaml {
+  background: var(--semantics-surfaces-tinted-background-color, #F4F6F9);
+  border-top-left-radius: 12px;
+  border-top-right-radius: 12px;
+  margin-inline: 4px;
+}
+
+.library-detail-content--yaml .yaml-source {
+  border-radius: 0;
+  background: transparent;
+}
+</style>

--- a/frontend/src/LibraryApp.vue
+++ b/frontend/src/LibraryApp.vue
@@ -321,11 +321,6 @@ loadIndex();
                   <ndd-toolbar-item slot="start">
                     <ndd-button text="Filter"></ndd-button>
                   </ndd-toolbar-item>
-                  <ndd-toolbar-item slot="start">
-                    <a v-if="selectedLawId && selectedArticleNumber" :href="`/editor/${encodeURIComponent(selectedLawId)}/${encodeURIComponent(selectedArticleNumber)}`" @click.prevent="router.push(`/editor/${encodeURIComponent(selectedLawId)}/${encodeURIComponent(selectedArticleNumber)}`)">
-                      <ndd-icon-button icon="pencil" title="Bewerk in editor"></ndd-icon-button>
-                    </a>
-                  </ndd-toolbar-item>
                 </ndd-toolbar>
                 <ndd-spacer size="16"></ndd-spacer>
                 <ndd-inline-dialog v-if="selectedLawLoading" text="Laden..."></ndd-inline-dialog>
@@ -358,24 +353,40 @@ loadIndex();
                 slot="header"
                 :text="selectedArticle ? `Artikel ${selectedArticle.number}` : 'Selecteer een artikel'"
                 :back-text="lawName || 'Terug'"
-              >
-                <ndd-segmented-control slot="toolbar" size="md" :value="detailView" @change="onDetailViewChange">
-                  <ndd-segmented-control-item value="tekst" text="Tekst"></ndd-segmented-control-item>
-                  <ndd-segmented-control-item value="machine" text="Machine"></ndd-segmented-control-item>
-                  <ndd-segmented-control-item value="yaml" text="YAML"></ndd-segmented-control-item>
-                </ndd-segmented-control>
-              </ndd-top-title-bar>
+                collapse-anchor="article-titel"
+              ></ndd-top-title-bar>
 
               <ndd-simple-section v-if="!selectedArticle" align="center">
                 <ndd-inline-dialog text="Selecteer een artikel"></ndd-inline-dialog>
               </ndd-simple-section>
-              <div v-else class="library-detail-content" :class="`library-detail-content--${detailView}`">
-                <KeepAlive>
-                  <ArticleText v-if="detailView === 'tekst'" :article="selectedArticle" />
-                  <MachineReadable v-else-if="detailView === 'machine'" :article="selectedArticle" @open-action="activeAction = $event" />
-                  <YamlView v-else-if="detailView === 'yaml'" :article="selectedArticle" />
-                </KeepAlive>
-              </div>
+              <template v-else>
+                <ndd-simple-section>
+                  <ndd-title id="article-titel" size="3"><h3>Artikel {{ selectedArticle.number }}</h3></ndd-title>
+                  <ndd-spacer size="8"></ndd-spacer>
+                  <ndd-toolbar>
+                    <ndd-toolbar-item slot="start">
+                      <ndd-segmented-control size="md" :value="detailView" @change="onDetailViewChange">
+                        <ndd-segmented-control-item value="tekst" text="Tekst"></ndd-segmented-control-item>
+                        <ndd-segmented-control-item value="machine" text="Machine"></ndd-segmented-control-item>
+                        <ndd-segmented-control-item value="yaml" text="YAML"></ndd-segmented-control-item>
+                      </ndd-segmented-control>
+                    </ndd-toolbar-item>
+                    <ndd-toolbar-item slot="end">
+                      <a v-if="selectedLawId" :href="`/editor/${encodeURIComponent(selectedLawId)}/${encodeURIComponent(selectedArticleNumber)}`" @click.prevent="router.push(`/editor/${encodeURIComponent(selectedLawId)}/${encodeURIComponent(selectedArticleNumber)}`)">
+                        <ndd-button variant="primary" text="Bewerk"></ndd-button>
+                      </a>
+                    </ndd-toolbar-item>
+                  </ndd-toolbar>
+                  <ndd-spacer size="16"></ndd-spacer>
+                </ndd-simple-section>
+                <div class="library-detail-content" :class="`library-detail-content--${detailView}`">
+                  <KeepAlive>
+                    <ArticleText v-if="detailView === 'tekst'" :article="selectedArticle" />
+                    <MachineReadable v-else-if="detailView === 'machine'" :article="selectedArticle" @open-action="activeAction = $event" />
+                    <YamlView v-else-if="detailView === 'yaml'" :article="selectedArticle" />
+                  </KeepAlive>
+                </div>
+              </template>
             </ndd-page>
           </ndd-split-view-pane>
 

--- a/frontend/src/LibraryApp.vue
+++ b/frontend/src/LibraryApp.vue
@@ -362,7 +362,7 @@ loadIndex();
               <template v-else>
                 <ndd-simple-section>
                   <ndd-title id="article-titel" size="3"><h3>Artikel {{ selectedArticle.number }}</h3></ndd-title>
-                  <ndd-spacer size="8"></ndd-spacer>
+                  <ndd-spacer size="16"></ndd-spacer>
                   <ndd-toolbar>
                     <ndd-toolbar-item slot="start">
                       <ndd-segmented-control size="md" :value="detailView" @change="onDetailViewChange">

--- a/frontend/src/LibraryApp.vue
+++ b/frontend/src/LibraryApp.vue
@@ -391,7 +391,7 @@ loadIndex();
   <ActionSheet :action="activeAction" :article="selectedArticle" :editable="false" @close="activeAction = null" @save="activeAction = null" />
 </template>
 
-<style>
+<style scoped>
 .library-detail-header {
   background: var(--semantics-surfaces-background-color, white);
 }
@@ -409,7 +409,7 @@ loadIndex();
   margin-inline: 4px;
 }
 
-.library-detail-content--yaml .yaml-source {
+.library-detail-content--yaml :deep(.yaml-source) {
   border-radius: 0;
   background: transparent;
 }

--- a/frontend/src/components/ExecutionTraceView.vue
+++ b/frontend/src/components/ExecutionTraceView.vue
@@ -25,7 +25,9 @@ const hasContent = computed(() =>
 
 const overallStatus = computed(() => {
   if (!props.result) return null;
-  for (const name of Object.keys(props.expectations)) {
+  const keys = Object.keys(props.expectations);
+  if (keys.length === 0) return null;
+  for (const name of keys) {
     if (matchStatus(name, props.result.outputs?.[name]) === 'failed') return 'failed';
   }
   return 'passed';
@@ -52,7 +54,7 @@ const overallStatus = computed(() => {
     <!-- Output summary — only outputs with expectations -->
     <ndd-simple-section v-if="Object.keys(expectations).length">
       <ndd-title size="5" class="etv-section-title"><span>Verwachte uitkomsten</span></ndd-title>
-      <div class="etv-expectations-block" :class="`etv-expectations-block--${overallStatus}`">
+      <div class="etv-expectations-block" :class="overallStatus ? `etv-expectations-block--${overallStatus}` : ''">
         <div
           v-for="name in Object.keys(expectations)"
           :key="name"

--- a/frontend/src/components/ExecutionTraceView.vue
+++ b/frontend/src/components/ExecutionTraceView.vue
@@ -22,6 +22,14 @@ function matchStatus(outputName, actualValue) {
 const hasContent = computed(() =>
   props.result || props.traceText || props.error,
 );
+
+const overallStatus = computed(() => {
+  if (!props.result) return null;
+  for (const name of Object.keys(props.expectations)) {
+    if (matchStatus(name, props.result.outputs?.[name]) === 'failed') return 'failed';
+  }
+  return 'passed';
+});
 </script>
 
 <template>
@@ -44,33 +52,27 @@ const hasContent = computed(() =>
     <!-- Output summary — only outputs with expectations -->
     <ndd-simple-section v-if="Object.keys(expectations).length">
       <ndd-title size="5" class="etv-section-title"><span>Verwachte uitkomsten</span></ndd-title>
-      <div class="etv-outputs">
-        <template
+      <div class="etv-expectations-block" :class="`etv-expectations-block--${overallStatus}`">
+        <div
           v-for="name in Object.keys(expectations)"
           :key="name"
+          class="etv-expectation-item"
         >
-          <div
-            v-for="status in [matchStatus(name, result.outputs?.[name])]"
-            :key="name"
-            class="etv-output-row"
-            :class="`etv-output-row--${status}`"
-          >
-            <div class="etv-output-name">{{ name }}</div>
-            <div class="etv-output-detail">
-              <span class="etv-output-expected">{{ formatValue(normalizeForCompare(expectations[name])) }}</span>
-              <span class="etv-output-arrow">&rarr;</span>
-              <span class="etv-output-actual">{{ formatOutputValue(result.outputs?.[name], name) }}</span>
-              <span
-                v-if="status === 'passed'"
-                class="etv-badge etv-badge--pass"
-              >GESLAAGD</span>
-              <span
-                v-if="status === 'failed'"
-                class="etv-badge etv-badge--fail"
-              >MISLUKT</span>
-            </div>
-          </div>
-        </template>
+          <span class="etv-expectation-name">{{ name }}</span>
+          <span class="etv-expectation-detail">
+            <span>{{ formatValue(normalizeForCompare(expectations[name])) }}</span>
+            <span class="etv-expectation-arrow">&rarr;</span>
+            <span>{{ formatOutputValue(result.outputs?.[name], name) }}</span>
+            <span
+              v-if="matchStatus(name, result.outputs?.[name]) === 'passed'"
+              class="etv-badge etv-badge--pass"
+            >GESLAAGD</span>
+            <span
+              v-if="matchStatus(name, result.outputs?.[name]) === 'failed'"
+              class="etv-badge etv-badge--fail"
+            >MISLUKT</span>
+          </span>
+        </div>
       </div>
     </ndd-simple-section>
 
@@ -93,49 +95,47 @@ const hasContent = computed(() =>
   margin-bottom: 4px;
 }
 
-.etv-outputs {
+/* Single continuous block with left border */
+.etv-expectations-block {
+  border-left: 3px solid transparent;
+  padding: 8px 10px;
+  border-radius: 4px;
+  background: var(--semantics-surfaces-tinted-background-color, #f5f5f5);
   display: flex;
   flex-direction: column;
   gap: 6px;
 }
 
-.etv-output-row {
-  border-left: 3px solid transparent;
-  padding: 6px 10px;
-  border-radius: 4px;
-  background: var(--semantics-surface-color-secondary, #f5f5f5);
-}
-
-.etv-output-row--passed {
+.etv-expectations-block--passed {
   border-left-color: #2e7d32;
 }
 
-.etv-output-row--failed {
+.etv-expectations-block--failed {
   border-left-color: #c62828;
 }
 
-.etv-output-name {
-  font-weight: 600;
-  font-size: 13px;
-  margin-bottom: 2px;
-  color: var(--semantics-text-color-primary, #1C2029);
-}
-
-.etv-output-detail {
+.etv-expectation-item {
   display: flex;
   flex-wrap: wrap;
-  align-items: center;
+  align-items: baseline;
   gap: 6px;
   font-size: 13px;
 }
 
-.etv-output-expected,
-.etv-output-actual {
-  font-family: 'SF Mono', 'Fira Code', monospace;
-  font-size: 12px;
+.etv-expectation-name {
+  font-weight: 600;
+  color: var(--semantics-text-color-primary, #1C2029);
 }
 
-.etv-output-arrow {
+.etv-expectation-detail {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--semantics-text-color-primary, #1C2029);
+}
+
+.etv-expectation-arrow {
   flex-shrink: 0;
   color: var(--semantics-text-color-secondary, #666);
 }

--- a/frontend/src/components/ExecutionTraceView.vue
+++ b/frontend/src/components/ExecutionTraceView.vue
@@ -125,7 +125,7 @@ const overallStatus = computed(() => {
 }
 
 .etv-expectation-name {
-  font-weight: 600;
+  font-weight: 400;
   color: var(--semantics-text-color-primary, #1C2029);
 }
 

--- a/frontend/src/components/ScenarioBuilder.vue
+++ b/frontend/src/components/ScenarioBuilder.vue
@@ -200,6 +200,12 @@ function onShowDetails(index) {
   }
 }
 
+function onAccordionToggle(event, index) {
+  if (event.target.open) {
+    onShowDetails(index);
+  }
+}
+
 // Memoized setup per scenario (avoids new object on every render)
 const scenarioSetups = computed(() => {
   if (!formState.value) return [];
@@ -290,6 +296,7 @@ async function onSave() {
           v-for="(scenario, i) in formState.scenarios"
           :key="i"
           class="sb-accordion"
+          @toggle="onAccordionToggle($event, i)"
         >
           <summary
             class="sb-accordion-header"

--- a/frontend/src/components/ScenarioForm.vue
+++ b/frontend/src/components/ScenarioForm.vue
@@ -202,6 +202,14 @@ function matchStatus(outputName, actualValue) {
 }
 
 const hasExpectations = computed(() => Object.keys(expectations.value).length > 0);
+
+const overallStatus = computed(() => {
+  if (!result.value) return null;
+  for (const name of Object.keys(expectations.value)) {
+    if (matchStatus(name, result.value.outputs?.[name]) === 'failed') return 'failed';
+  }
+  return 'passed';
+});
 </script>
 
 <template>
@@ -209,24 +217,26 @@ const hasExpectations = computed(() => Object.keys(expectations.value).length > 
     <!-- Expected outputs at top -->
     <template v-if="hasExpectations">
       <ndd-title size="5" class="sf-section-title"><span>Verwachte uitkomsten</span></ndd-title>
-      <ndd-list variant="box" class="sf-expectations-list">
-        <ndd-list-item
+      <div
+        class="sf-expectations-block"
+        :class="result ? `sf-expectations-block--${overallStatus}` : (error ? 'sf-expectations-block--failed' : '')"
+      >
+        <div
           v-for="(exp, name) in expectations"
           :key="name"
-          size="md"
-          class="sf-expectation"
-          :class="result ? `sf-expectation--${matchStatus(name, result.outputs?.[name])}` : (error ? 'sf-expectation--failed' : '')"
+          class="sf-expectation-item"
         >
-          <ndd-text-cell :text="articleMap?.outputToArticle?.get(name) ? `${name} (Art. ${articleMap.outputToArticle.get(name)})` : name" max-width="140"></ndd-text-cell>
-          <ndd-cell>
-            <div class="sf-expectation-values">
-              <ndd-text-field size="md" :value="formatValue(normalizeForCompare(exp))" readonly></ndd-text-field>
-              <span v-if="result && result.outputs" class="sf-expectation-arrow">&rarr;</span>
-              <ndd-text-field v-if="result && result.outputs" size="md" :value="formatOutputValue(result.outputs[name], name)" readonly class="sf-expectation-actual"></ndd-text-field>
-            </div>
-          </ndd-cell>
-        </ndd-list-item>
-      </ndd-list>
+          <span class="sf-expectation-name">{{ name }}</span>
+          <span v-if="articleMap?.outputToArticle?.get(name)" class="sf-article-tag">Art. {{ articleMap.outputToArticle.get(name) }}</span>
+          <span class="sf-expectation-detail">
+            <span>{{ formatValue(normalizeForCompare(exp)) }}</span>
+            <template v-if="result && result.outputs">
+              <span class="sf-expectation-arrow">&rarr;</span>
+              <span>{{ formatOutputValue(result.outputs[name], name) }}</span>
+            </template>
+          </span>
+        </div>
+      </div>
     </template>
 
     <!-- Error -->
@@ -295,24 +305,53 @@ const hasExpectations = computed(() => Object.keys(expectations.value).length > 
   margin-top: 0;
 }
 
-/* Expected outputs */
-.sf-expectation {
+/* Expected outputs — single continuous block with left border */
+.sf-expectations-block {
   border-left: 3px solid transparent;
+  padding: 8px 10px;
+  border-radius: 4px;
+  background: var(--semantics-surfaces-tinted-background-color, #f5f5f5);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
 }
 
-.sf-expectation--passed {
+.sf-expectations-block--passed {
   border-left-color: #2e7d32;
 }
 
-.sf-expectation--failed {
+.sf-expectations-block--failed {
   border-left-color: #c62828;
 }
 
-.sf-expectation-values {
+.sf-expectation-item {
   display: flex;
-  align-items: center;
-  gap: 8px;
-  width: 100%;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 6px;
+  font-size: 13px;
+}
+
+.sf-expectation-name {
+  font-weight: 600;
+  color: var(--semantics-text-color-primary, #1C2029);
+}
+
+.sf-article-tag {
+  font-size: 10px;
+  font-weight: 600;
+  color: #666;
+  background: rgba(0, 0, 0, 0.06);
+  padding: 1px 5px;
+  border-radius: 3px;
+}
+
+.sf-expectation-detail {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--semantics-text-color-primary, #1C2029);
 }
 
 .sf-expectation-arrow {
@@ -347,26 +386,18 @@ const hasExpectations = computed(() => Object.keys(expectations.value).length > 
 
 <style>
 /* Unscoped: ndd web components need global selectors */
-.sf-expectations-list ndd-text-cell,
 .sf-input-list ndd-text-cell {
   width: 140px;
   min-width: 140px;
   flex-shrink: 0;
 }
 
-.sf-expectations-list ndd-cell,
 .sf-input-list ndd-cell {
   flex: 1;
   min-width: 0;
 }
 
-.sf-expectations-list ndd-text-field,
 .sf-input-list ndd-text-field {
   width: 100%;
-}
-
-.sf-expectation-values ndd-text-field {
-  flex: 1;
-  min-width: 0;
 }
 </style>

--- a/frontend/src/components/ScenarioForm.vue
+++ b/frontend/src/components/ScenarioForm.vue
@@ -335,7 +335,7 @@ const overallStatus = computed(() => {
 }
 
 .sf-expectation-name {
-  font-weight: 600;
+  font-weight: 400;
   color: var(--semantics-text-color-primary, #1C2029);
 }
 

--- a/frontend/src/components/ScenarioForm.vue
+++ b/frontend/src/components/ScenarioForm.vue
@@ -205,7 +205,9 @@ const hasExpectations = computed(() => Object.keys(expectations.value).length > 
 
 const overallStatus = computed(() => {
   if (!result.value) return null;
-  for (const name of Object.keys(expectations.value)) {
+  const keys = Object.keys(expectations.value);
+  if (keys.length === 0) return null;
+  for (const name of keys) {
     if (matchStatus(name, result.value.outputs?.[name]) === 'failed') return 'failed';
   }
   return 'passed';


### PR DESCRIPTION
## Summary
- Fix library article detail panel: add `background="default"` to the sticky-header page so the header is opaque and content doesn't bleed through on scroll
- Add rounded top corners with tinted background to the Machine and YAML panels in the library detail view
- When expanding a scenario accordion in the editor, immediately populate the result panel with that scenario's execution data
- Automatically switch the right pane to "Resultaat" view when scenario execution data arrives

## Test plan
- [ ] Open library, select a law and article, verify content is not hidden behind header/tab bar
- [ ] Switch between Tekst/Machine/YAML tabs and verify Machine and YAML have rounded top corners
- [ ] Open editor, expand a scenario accordion, verify the result panel activates and shows that scenario's result