### PR TITLE
fix(deps): update rustls-webpki to fix RUSTSEC-2026-0098

### DIFF
--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -4067,9 +4067,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## Summary
- Updates `rustls-webpki` 0.103.10 → 0.103.12 to fix RUSTSEC-2026-0098 (GHSA-965h-392x-2mh5)
- URI name constraints were incorrectly accepted, now rejected unconditionally
- This advisory is blocking all open Dependabot PRs via the Security Audit check

## Test plan
- [ ] Security Audit CI check passes
- [ ] No regressions in existing tests