### PR TITLE
feat: per-user favorieten in database

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -32,18 +32,20 @@ WORKDIR /build
 # Stage 3: Plan dependencies
 FROM chef AS planner
 COPY packages/Cargo.lock ./
-RUN printf '[workspace]\nresolver = "2"\nmembers = [\n    "packages/auth",\n    "packages/editor-api",\n    "packages/corpus",\n    "packages/engine",\n    "packages/shared",\n]\n' > Cargo.toml
+RUN printf '[workspace]\nresolver = "2"\nmembers = [\n    "packages/auth",\n    "packages/editor-api",\n    "packages/corpus",\n    "packages/engine",\n    "packages/harvester",\n    "packages/pipeline",\n    "packages/shared",\n]\n' > Cargo.toml
 COPY packages/auth/ packages/auth/
 COPY packages/editor-api/ packages/editor-api/
 COPY packages/corpus/ packages/corpus/
 COPY packages/engine/ packages/engine/
+COPY packages/harvester/ packages/harvester/
+COPY packages/pipeline/ packages/pipeline/
 COPY packages/shared/ packages/shared/
 RUN cargo chef prepare --recipe-path recipe.json
 
 # Stage 4: Build Rust binary (deps cached separately from source)
 FROM chef AS builder
 COPY packages/Cargo.lock ./
-RUN printf '[workspace]\nresolver = "2"\nmembers = [\n    "packages/auth",\n    "packages/editor-api",\n    "packages/corpus",\n    "packages/engine",\n    "packages/shared",\n]\n' > Cargo.toml
+RUN printf '[workspace]\nresolver = "2"\nmembers = [\n    "packages/auth",\n    "packages/editor-api",\n    "packages/corpus",\n    "packages/engine",\n    "packages/harvester",\n    "packages/pipeline",\n    "packages/shared",\n]\n' > Cargo.toml
 COPY --from=planner /build/recipe.json recipe.json
 RUN cargo chef cook --release --recipe-path recipe.json
 
@@ -51,6 +53,8 @@ COPY packages/auth/ packages/auth/
 COPY packages/editor-api/ packages/editor-api/
 COPY packages/corpus/ packages/corpus/
 COPY packages/engine/ packages/engine/
+COPY packages/harvester/ packages/harvester/
+COPY packages/pipeline/ packages/pipeline/
 COPY packages/shared/ packages/shared/
 # Invalidate cargo's fingerprint cache so it recompiles with real source
 # instead of using the stub binary from cargo-chef cook.

--- a/frontend/Dockerfile.dockerignore
+++ b/frontend/Dockerfile.dockerignore
@@ -14,7 +14,5 @@ __pycache__
 .github
 # Exclude packages not needed for editor-api build
 packages/admin
-packages/harvester
-packages/pipeline
 packages/tui
-# Keep: packages/editor-api, packages/corpus, packages/engine, packages/shared, packages/Cargo.*
+# Keep: packages/editor-api, packages/corpus, packages/engine, packages/harvester, packages/pipeline, packages/shared, packages/Cargo.*

--- a/frontend/src/LibraryApp.vue
+++ b/frontend/src/LibraryApp.vue
@@ -143,7 +143,7 @@ async function loadIndex() {
   try {
     const [corpusRes] = await Promise.all([
       fetch('/api/corpus/laws?limit=1000'),
-      authenticated.value ? loadFavorites() : Promise.resolve(),
+      loadFavorites(),
     ]);
     if (!corpusRes.ok) throw new Error(`Failed to load corpus: ${corpusRes.status}`);
     const corpusLaws = await corpusRes.json();

--- a/frontend/src/LibraryApp.vue
+++ b/frontend/src/LibraryApp.vue
@@ -121,22 +121,19 @@ async function toggleFavorite(lawId) {
   else updated.add(lawId);
   favorites.value = updated;
 
-  try {
-    const method = isFav ? 'DELETE' : 'PUT';
-    const res = await fetch(`/api/favorites/${encodeURIComponent(lawId)}`, { method });
-    if (!res.ok) {
-      // Revert on failure
-      const reverted = new Set(favorites.value);
-      if (isFav) reverted.add(lawId);
-      else reverted.delete(lawId);
-      favorites.value = reverted;
-    }
-  } catch {
-    // Revert on network error
+  const revert = () => {
     const reverted = new Set(favorites.value);
     if (isFav) reverted.add(lawId);
     else reverted.delete(lawId);
     favorites.value = reverted;
+  };
+
+  try {
+    const method = isFav ? 'DELETE' : 'PUT';
+    const res = await fetch(`/api/favorites/${encodeURIComponent(lawId)}`, { method });
+    if (!res.ok) revert();
+  } catch {
+    revert();
   } finally {
     togglingFavorites.value.delete(lawId);
   }
@@ -146,7 +143,7 @@ async function loadIndex() {
   try {
     const [corpusRes] = await Promise.all([
       fetch('/api/corpus/laws?limit=1000'),
-      loadFavorites(),
+      authenticated.value ? loadFavorites() : Promise.resolve(),
     ]);
     if (!corpusRes.ok) throw new Error(`Failed to load corpus: ${corpusRes.status}`);
     const corpusLaws = await corpusRes.json();

--- a/frontend/src/LibraryApp.vue
+++ b/frontend/src/LibraryApp.vue
@@ -98,14 +98,21 @@ async function loadFavorites() {
     if (res.ok) {
       const favIds = await res.json();
       favorites.value = new Set(favIds);
+    } else if (res.status >= 500) {
+      console.warn(`Failed to load favorites: ${res.status}`);
     }
   } catch {
     // Not authenticated or endpoint unavailable — no favorites
   }
 }
 
+const togglingFavorites = ref(new Set());
+
 async function toggleFavorite(lawId) {
   if (!authenticated.value || !lawId) return;
+  if (togglingFavorites.value.has(lawId)) return;
+
+  togglingFavorites.value.add(lawId);
   const isFav = favorites.value?.has(lawId);
 
   // Optimistic update
@@ -114,24 +121,29 @@ async function toggleFavorite(lawId) {
   else updated.add(lawId);
   favorites.value = updated;
 
-  const method = isFav ? 'DELETE' : 'PUT';
-  const res = await fetch(`/api/favorites/${encodeURIComponent(lawId)}`, { method });
-  if (!res.ok) {
-    // Revert on failure
-    const reverted = new Set(favorites.value);
-    if (isFav) reverted.add(lawId);
-    else reverted.delete(lawId);
-    favorites.value = reverted;
+  try {
+    const method = isFav ? 'DELETE' : 'PUT';
+    const res = await fetch(`/api/favorites/${encodeURIComponent(lawId)}`, { method });
+    if (!res.ok) {
+      // Revert on failure
+      const reverted = new Set(favorites.value);
+      if (isFav) reverted.add(lawId);
+      else reverted.delete(lawId);
+      favorites.value = reverted;
+    }
+  } finally {
+    togglingFavorites.value.delete(lawId);
   }
 }
 
 async function loadIndex() {
   try {
-    const corpusRes = await fetch('/api/corpus/laws?limit=1000');
+    const [corpusRes] = await Promise.all([
+      fetch('/api/corpus/laws?limit=1000'),
+      loadFavorites(),
+    ]);
     if (!corpusRes.ok) throw new Error(`Failed to load corpus: ${corpusRes.status}`);
     const corpusLaws = await corpusRes.json();
-
-    await loadFavorites();
 
     laws.value = corpusLaws.sort((a, b) => a.law_id.localeCompare(b.law_id));
 

--- a/frontend/src/LibraryApp.vue
+++ b/frontend/src/LibraryApp.vue
@@ -131,6 +131,12 @@ async function toggleFavorite(lawId) {
       else reverted.delete(lawId);
       favorites.value = reverted;
     }
+  } catch {
+    // Revert on network error
+    const reverted = new Set(favorites.value);
+    if (isFav) reverted.add(lawId);
+    else reverted.delete(lawId);
+    favorites.value = reverted;
   } finally {
     togglingFavorites.value.delete(lawId);
   }

--- a/frontend/src/LibraryApp.vue
+++ b/frontend/src/LibraryApp.vue
@@ -92,19 +92,46 @@ function articleDescription(article) {
   return firstLine.length > 80 ? firstLine.slice(0, 80) + '...' : firstLine;
 }
 
+async function loadFavorites() {
+  try {
+    const res = await fetch('/api/favorites');
+    if (res.ok) {
+      const favIds = await res.json();
+      favorites.value = new Set(favIds);
+    }
+  } catch {
+    // Not authenticated or endpoint unavailable — no favorites
+  }
+}
+
+async function toggleFavorite(lawId) {
+  if (!authenticated.value || !lawId) return;
+  const isFav = favorites.value?.has(lawId);
+
+  // Optimistic update
+  const updated = new Set(favorites.value || []);
+  if (isFav) updated.delete(lawId);
+  else updated.add(lawId);
+  favorites.value = updated;
+
+  const method = isFav ? 'DELETE' : 'PUT';
+  const res = await fetch(`/api/favorites/${encodeURIComponent(lawId)}`, { method });
+  if (!res.ok) {
+    // Revert on failure
+    const reverted = new Set(favorites.value);
+    if (isFav) reverted.add(lawId);
+    else reverted.delete(lawId);
+    favorites.value = reverted;
+  }
+}
+
 async function loadIndex() {
   try {
-    const [corpusRes, favRes] = await Promise.all([
-      fetch('/api/corpus/laws?limit=1000'),
-      fetch('/favorites.json'),
-    ]);
+    const corpusRes = await fetch('/api/corpus/laws?limit=1000');
     if (!corpusRes.ok) throw new Error(`Failed to load corpus: ${corpusRes.status}`);
     const corpusLaws = await corpusRes.json();
 
-    if (favRes.ok) {
-      const favIds = await favRes.json();
-      favorites.value = new Set(favIds);
-    }
+    await loadFavorites();
 
     laws.value = corpusLaws.sort((a, b) => a.law_id.localeCompare(b.law_id));
 
@@ -327,8 +354,12 @@ loadIndex();
                 <ndd-title id="wet-titel" size="3"><h3>{{ lawName || 'Selecteer een wet' }}</h3></ndd-title>
                 <ndd-spacer size="16"></ndd-spacer>
                 <ndd-toolbar>
-                  <ndd-toolbar-item slot="start">
-                    <ndd-icon-button icon="heart" title="Favoriet"></ndd-icon-button>
+                  <ndd-toolbar-item v-if="authenticated" slot="start">
+                    <ndd-icon-button
+                      :icon="favorites?.has(selectedLawId) ? 'heart-fill' : 'heart'"
+                      :title="favorites?.has(selectedLawId) ? 'Verwijder uit favorieten' : 'Voeg toe aan favorieten'"
+                      @click="toggleFavorite(selectedLawId)"
+                    ></ndd-icon-button>
                   </ndd-toolbar-item>
                   <ndd-toolbar-item slot="start">
                     <ndd-button text="Filter"></ndd-button>

--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -3675,6 +3675,7 @@ dependencies = [
  "axum",
  "regelrecht-auth",
  "regelrecht-corpus",
+ "regelrecht-pipeline",
  "reqwest 0.12.28",
  "serde",
  "serde_json",

--- a/packages/auth/src/lib.rs
+++ b/packages/auth/src/lib.rs
@@ -11,7 +11,7 @@ pub mod middleware;
 pub mod oidc;
 
 pub use config::{parse_base_url, parse_oidc_from_env, OidcConfig};
-pub use handlers::{AuthStatus, PersonInfo, SESSION_KEY_AUTHENTICATED};
+pub use handlers::{AuthStatus, PersonInfo, SESSION_KEY_AUTHENTICATED, SESSION_KEY_SUB};
 pub use middleware::{require_session_auth, security_headers};
 pub use oidc::{discover_client, ConfiguredClient, DiscoveryResult};
 

--- a/packages/editor-api/Cargo.toml
+++ b/packages/editor-api/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/main.rs"
 axum = "0.8"
 regelrecht-auth = { path = "../auth" }
 regelrecht-corpus = { path = "../corpus", features = ["github"] }
+regelrecht-pipeline = { path = "../pipeline" }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tower-http = { version = "0.6", features = ["fs", "trace"] }
 tower-sessions = "0.14"

--- a/packages/editor-api/src/favorites.rs
+++ b/packages/editor-api/src/favorites.rs
@@ -1,0 +1,88 @@
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::Json;
+use tower_sessions::Session;
+
+use crate::state::AppState;
+
+const SESSION_KEY_SUB: &str = "person_sub";
+
+async fn get_person_sub(session: &Session) -> Result<String, StatusCode> {
+    session
+        .get::<String>(SESSION_KEY_SUB)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+        .ok_or(StatusCode::UNAUTHORIZED)
+}
+
+fn get_pool(state: &AppState) -> Result<&sqlx::PgPool, StatusCode> {
+    state.pool.as_ref().ok_or(StatusCode::SERVICE_UNAVAILABLE)
+}
+
+/// GET /api/favorites — list the authenticated user's favorites.
+pub async fn list(
+    State(state): State<AppState>,
+    session: Session,
+) -> Result<Json<Vec<String>>, StatusCode> {
+    let person_sub = get_person_sub(&session).await?;
+    let pool = get_pool(&state)?;
+
+    let rows: Vec<(String,)> = sqlx::query_as(
+        "SELECT law_id FROM user_favorites WHERE person_sub = $1 ORDER BY created_at",
+    )
+    .bind(&person_sub)
+    .fetch_all(pool)
+    .await
+    .map_err(|e| {
+        tracing::error!(error = %e, "failed to fetch favorites");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    Ok(Json(rows.into_iter().map(|(id,)| id).collect()))
+}
+
+/// PUT /api/favorites/{law_id} — add a law to the user's favorites.
+pub async fn add(
+    State(state): State<AppState>,
+    session: Session,
+    Path(law_id): Path<String>,
+) -> Result<StatusCode, StatusCode> {
+    let person_sub = get_person_sub(&session).await?;
+    let pool = get_pool(&state)?;
+
+    sqlx::query(
+        "INSERT INTO user_favorites (person_sub, law_id) VALUES ($1, $2) ON CONFLICT DO NOTHING",
+    )
+    .bind(&person_sub)
+    .bind(&law_id)
+    .execute(pool)
+    .await
+    .map_err(|e| {
+        tracing::error!(error = %e, "failed to add favorite");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    Ok(StatusCode::CREATED)
+}
+
+/// DELETE /api/favorites/{law_id} — remove a law from the user's favorites.
+pub async fn remove(
+    State(state): State<AppState>,
+    session: Session,
+    Path(law_id): Path<String>,
+) -> Result<StatusCode, StatusCode> {
+    let person_sub = get_person_sub(&session).await?;
+    let pool = get_pool(&state)?;
+
+    sqlx::query("DELETE FROM user_favorites WHERE person_sub = $1 AND law_id = $2")
+        .bind(&person_sub)
+        .bind(&law_id)
+        .execute(pool)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, "failed to remove favorite");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    Ok(StatusCode::NO_CONTENT)
+}

--- a/packages/editor-api/src/favorites.rs
+++ b/packages/editor-api/src/favorites.rs
@@ -58,7 +58,7 @@ pub async fn add(
     let person_sub = get_person_sub(&session).await?;
     let pool = get_pool(&state)?;
 
-    sqlx::query(
+    let result = sqlx::query(
         "INSERT INTO user_favorites (person_sub, law_id) VALUES ($1, $2) ON CONFLICT DO NOTHING",
     )
     .bind(&person_sub)
@@ -70,7 +70,11 @@ pub async fn add(
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
-    Ok(StatusCode::CREATED)
+    if result.rows_affected() > 0 {
+        Ok(StatusCode::CREATED)
+    } else {
+        Ok(StatusCode::NO_CONTENT)
+    }
 }
 
 /// DELETE /api/favorites/{law_id} — remove a law from the user's favorites.

--- a/packages/editor-api/src/favorites.rs
+++ b/packages/editor-api/src/favorites.rs
@@ -41,12 +41,20 @@ pub async fn list(
     Ok(Json(rows.into_iter().map(|(id,)| id).collect()))
 }
 
+fn validate_law_id(law_id: &str) -> Result<(), StatusCode> {
+    if law_id.is_empty() || law_id.len() > 256 {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+    Ok(())
+}
+
 /// PUT /api/favorites/{law_id} — add a law to the user's favorites.
 pub async fn add(
     State(state): State<AppState>,
     session: Session,
     Path(law_id): Path<String>,
 ) -> Result<StatusCode, StatusCode> {
+    validate_law_id(&law_id)?;
     let person_sub = get_person_sub(&session).await?;
     let pool = get_pool(&state)?;
 
@@ -71,6 +79,7 @@ pub async fn remove(
     session: Session,
     Path(law_id): Path<String>,
 ) -> Result<StatusCode, StatusCode> {
+    validate_law_id(&law_id)?;
     let person_sub = get_person_sub(&session).await?;
     let pool = get_pool(&state)?;
 

--- a/packages/editor-api/src/favorites.rs
+++ b/packages/editor-api/src/favorites.rs
@@ -3,9 +3,9 @@ use axum::http::StatusCode;
 use axum::Json;
 use tower_sessions::Session;
 
-use crate::state::AppState;
+use regelrecht_auth::SESSION_KEY_SUB;
 
-const SESSION_KEY_SUB: &str = "person_sub";
+use crate::state::AppState;
 
 async fn get_person_sub(session: &Session) -> Result<String, StatusCode> {
     session

--- a/packages/editor-api/src/favorites.rs
+++ b/packages/editor-api/src/favorites.rs
@@ -28,7 +28,7 @@ pub async fn list(
     let pool = get_pool(&state)?;
 
     let rows: Vec<(String,)> = sqlx::query_as(
-        "SELECT law_id FROM user_favorites WHERE person_sub = $1 ORDER BY created_at",
+        "SELECT law_id FROM user_favorites WHERE person_sub = $1 ORDER BY created_at LIMIT 1000",
     )
     .bind(&person_sub)
     .fetch_all(pool)
@@ -42,6 +42,7 @@ pub async fn list(
 }
 
 fn validate_law_id(law_id: &str) -> Result<(), StatusCode> {
+    // .len() returns bytes, which equals character count for ASCII-only law IDs.
     if law_id.is_empty() || law_id.len() > 256 {
         return Err(StatusCode::BAD_REQUEST);
     }

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -154,6 +154,10 @@ async fn main() {
                 std::process::exit(1);
             });
 
+        // The editor shares a database with the pipeline; ensure_schema runs
+        // all pipeline migrations (including 0008_user_favorites). If the
+        // services are ever split to separate databases this should be replaced
+        // with an editor-specific migration runner.
         if let Err(e) = regelrecht_pipeline::ensure_schema(&pool).await {
             tracing::error!(error = %e, "database migration failed");
             std::process::exit(1);

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -19,6 +19,7 @@ use tracing_subscriber::EnvFilter;
 
 mod config;
 mod corpus_handlers;
+mod favorites;
 mod middleware;
 mod state;
 
@@ -61,12 +62,13 @@ async fn main() {
     let static_dir = env::var("STATIC_DIR").unwrap_or_else(|_| "static".to_string());
     let corpus_state = init_corpus(&static_dir).await;
 
-    let app_state = AppState {
+    let mut app_state = AppState {
         corpus: Arc::new(RwLock::new(corpus_state)),
         oidc_client,
         end_session_url,
         config: Arc::new(app_config),
         http_client,
+        pool: None, // set below when auth is enabled
     };
 
     let index_file = PathBuf::from(&static_dir).join("index.html");
@@ -120,6 +122,11 @@ async fn main() {
             axum::routing::put(corpus_handlers::save_law)
                 .layer(axum::extract::DefaultBodyLimit::max(MAX_LAW_BODY)),
         )
+        .route("/api/favorites", get(favorites::list))
+        .route(
+            "/api/favorites/{law_id}",
+            axum::routing::put(favorites::add).delete(favorites::remove),
+        )
         .route_layer(axum_middleware::from_fn_with_state(
             app_state.clone(),
             middleware::require_session_auth::<AppState>,
@@ -146,6 +153,13 @@ async fn main() {
                 tracing::error!(error = %e, "failed to connect to database");
                 std::process::exit(1);
             });
+
+        if let Err(e) = regelrecht_pipeline::ensure_schema(&pool).await {
+            tracing::error!(error = %e, "database migration failed");
+            std::process::exit(1);
+        }
+
+        app_state.pool = Some(pool.clone());
 
         let session_store = PostgresStore::new(pool);
         if let Err(e) = session_store.migrate().await {

--- a/packages/editor-api/src/state.rs
+++ b/packages/editor-api/src/state.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use regelrecht_auth::{ConfiguredClient, OidcAppState, OidcConfig};
 use regelrecht_corpus::backend::RepoBackend;
 use regelrecht_corpus::SourceMap;
+use sqlx::PgPool;
 use tokio::sync::{Mutex, RwLock};
 
 use crate::config::AppConfig;
@@ -16,6 +17,8 @@ pub struct AppState {
     pub end_session_url: Option<String>,
     pub config: Arc<AppConfig>,
     pub http_client: reqwest::Client,
+    /// Database connection pool (available when auth is enabled).
+    pub pool: Option<PgPool>,
 }
 
 impl OidcAppState for AppState {

--- a/packages/pipeline/migrations/0008_user_favorites.sql
+++ b/packages/pipeline/migrations/0008_user_favorites.sql
@@ -1,0 +1,8 @@
+CREATE TABLE user_favorites (
+    person_sub  TEXT        NOT NULL,
+    law_id      TEXT        NOT NULL,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (person_sub, law_id)
+);
+
+CREATE INDEX idx_user_favorites_person ON user_favorites (person_sub);

--- a/packages/pipeline/migrations/0008_user_favorites.sql
+++ b/packages/pipeline/migrations/0008_user_favorites.sql
@@ -4,3 +4,5 @@ CREATE TABLE user_favorites (
     created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
     PRIMARY KEY (person_sub, law_id)
 );
+
+CREATE INDEX idx_user_favorites_person ON user_favorites (person_sub);

--- a/packages/pipeline/migrations/0008_user_favorites.sql
+++ b/packages/pipeline/migrations/0008_user_favorites.sql
@@ -4,5 +4,3 @@ CREATE TABLE user_favorites (
     created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
     PRIMARY KEY (person_sub, law_id)
 );
-
-CREATE INDEX idx_user_favorites_person ON user_favorites (person_sub);

--- a/packages/pipeline/migrations/0009_drop_redundant_favorites_index.sql
+++ b/packages/pipeline/migrations/0009_drop_redundant_favorites_index.sql
@@ -1,0 +1,3 @@
+-- The composite PK (person_sub, law_id) already covers lookups by person_sub,
+-- making this standalone index redundant.
+DROP INDEX IF EXISTS idx_user_favorites_person;


### PR DESCRIPTION
## Summary
- Vervangt hardcoded `favorites.json` door per-user favorieten opgeslagen in PostgreSQL
- Nieuwe `user_favorites` tabel (migratie 0008) met composite PK `(person_sub, law_id)`
- `GET/PUT/DELETE /api/favorites` endpoints in editor-api, beschermd door bestaande auth middleware
- Frontend: heart-button togglet favorieten met optimistic updates; alleen zichtbaar voor ingelogde gebruikers
- Niet-ingelogde gebruikers zien alle wetten zonder favorietenfilter
- `favorites.json` blijft bestaan voor corpus pre-loading bij startup (apart concept)

## Test plan
- [ ] Login via OIDC, controleer dat heart-button verschijnt
- [ ] Klik heart: wet wordt favoriet (filled heart), sidebar filtert op favorieten
- [ ] Klik filled heart: favoriet verwijderd, sidebar toont weer alle wetten
- [ ] Refresh pagina: favorieten blijven staan (uit DB geladen)
- [ ] Niet ingelogd: geen heart-button, alle wetten zichtbaar
- [ ] Verify migratie draait correct via `ensure_schema`