### PR TITLE
feat(frontend): search dropdown overlay in library toolbar

### DIFF
--- a/frontend/src/LibraryApp.vue
+++ b/frontend/src/LibraryApp.vue
@@ -6,6 +6,7 @@ import ArticleText from './components/ArticleText.vue';
 import MachineReadable from './components/MachineReadable.vue';
 import YamlView from './components/YamlView.vue';
 import ActionSheet from './components/ActionSheet.vue';
+import SearchWindow from './components/SearchWindow.vue';
 import { useAuth } from './composables/useAuth.js';
 
 const { authenticated, loading: authLoading, oidcConfigured, person, login, logout } = useAuth();
@@ -17,7 +18,20 @@ const laws = ref([]);
 const favorites = ref(null);
 const loading = ref(true);
 const indexError = ref(null);
-const search = ref('');
+const searchOpen = ref(false);
+const searchAnchorRef = ref(null);
+const searchAnchorRect = ref(null);
+
+function openSearch() {
+  const el = searchAnchorRef.value;
+  if (el) {
+    const rect = el.getBoundingClientRect();
+    const pad = 13;
+    const maxWidth = Math.min(800, window.innerWidth - rect.left + pad - 16);
+    searchAnchorRect.value = { top: rect.top - pad, left: rect.left - pad, width: maxWidth };
+  }
+  searchOpen.value = true;
+}
 
 const selectedLawId = ref(null);
 const selectedLaw = shallowRef(null);
@@ -32,18 +46,13 @@ function onDetailViewChange(event) {
   if (value) detailView.value = value;
 }
 
-const filteredLaws = computed(() => {
-  let list = laws.value;
+const sidebarLaws = computed(() => {
+  const list = laws.value;
   if (favorites.value) {
     const favList = list.filter(law => favorites.value.has(law.law_id));
-    if (favList.length > 0) list = favList;
+    if (favList.length > 0) return favList;
   }
-  const q = search.value.toLowerCase();
-  if (!q) return list;
-  return list.filter(law =>
-    law.law_id.toLowerCase().includes(q) ||
-    displayName(law).toLowerCase().includes(q)
-  );
+  return list;
 });
 
 const articles = computed(() => selectedLaw.value?.articles ?? []);
@@ -184,7 +193,7 @@ onBeforeRouteUpdate((to) => {
     selectedArticleNumber.value = null;
     activeAction.value = null;
     lawError.value = null;
-    const list = filteredLaws.value;
+    const list = sidebarLaws.value;
     if (list.length > 0) {
       const firstLawId = list[0].law_id;
       selectedLawId.value = firstLawId;
@@ -234,9 +243,11 @@ loadIndex();
             </ndd-toolbar-item>
             <ndd-toolbar-item slot="center" min-width="240px" width="40%">
               <ndd-search-field
+                ref="searchAnchorRef"
                 size="md"
                 placeholder="Zoeken"
-                @input="search = $event.target.value"
+                @focus="openSearch"
+                @click="openSearch"
               ></ndd-search-field>
             </ndd-toolbar-item>
             <ndd-toolbar-item slot="end">
@@ -283,7 +294,7 @@ loadIndex();
                 <ndd-inline-dialog v-else-if="indexError" variant="alert" text="Fout bij laden" :supporting-text="indexError.message"></ndd-inline-dialog>
                 <ndd-list v-else variant="simple">
                   <ndd-list-item
-                    v-for="law in filteredLaws"
+                    v-for="law in sidebarLaws"
                     :key="law.law_id"
                     size="md"
                     type="button"
@@ -398,6 +409,13 @@ loadIndex();
   <!-- LibraryApp is a read-only browser; ActionSheet is mounted without editable
        so the output field is hidden and the footer button just closes the sheet. -->
   <ActionSheet :action="activeAction" :article="selectedArticle" :editable="false" @close="activeAction = null" @save="activeAction = null" />
+  <SearchWindow
+    v-model="searchOpen"
+    :laws="laws"
+    :favorites="favorites"
+    :anchor-rect="searchAnchorRect"
+    @select-law="selectLaw"
+  />
 </template>
 
 <style scoped>

--- a/frontend/src/LibraryApp.vue
+++ b/frontend/src/LibraryApp.vue
@@ -23,6 +23,7 @@ const searchAnchorRef = ref(null);
 const searchAnchorRect = ref(null);
 
 function openSearch() {
+  if (searchOpen.value) return;
   const el = searchAnchorRef.value;
   if (el) {
     const rect = el.getBoundingClientRect();
@@ -412,7 +413,6 @@ loadIndex();
   <SearchWindow
     v-model="searchOpen"
     :laws="laws"
-    :favorites="favorites"
     :anchor-rect="searchAnchorRect"
     @select-law="selectLaw"
   />

--- a/frontend/src/components/SearchWindow.vue
+++ b/frontend/src/components/SearchWindow.vue
@@ -1,0 +1,195 @@
+<script setup>
+import { ref, computed, watch, nextTick } from 'vue';
+
+const props = defineProps({
+  laws: { type: Array, default: () => [] },
+  favorites: { type: Object, default: null },
+  modelValue: { type: Boolean, default: false },
+  anchorRect: { type: Object, default: null },
+});
+
+const emit = defineEmits(['update:modelValue', 'select-law']);
+
+const search = ref('');
+const searchFieldRef = ref(null);
+
+function displayName(law) {
+  if (law.name) return law.name;
+  return law.law_id.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+}
+
+const filteredLaws = computed(() => {
+  const q = search.value.toLowerCase();
+  if (!q) return props.laws;
+  return props.laws.filter(law =>
+    law.law_id.toLowerCase().includes(q) ||
+    displayName(law).toLowerCase().includes(q)
+  );
+});
+
+const hasSearch = computed(() => search.value.length > 0);
+
+function close() {
+  search.value = '';
+  emit('update:modelValue', false);
+}
+
+function selectLaw(lawId) {
+  emit('select-law', lawId);
+  close();
+}
+
+function onKeydown(e) {
+  if (e.key === 'Escape') close();
+}
+
+watch(() => props.modelValue, async (open) => {
+  if (open) {
+    await nextTick();
+    const input = searchFieldRef.value?.shadowRoot?.querySelector('input')
+      ?? searchFieldRef.value?.querySelector('input');
+    input?.focus();
+  }
+});
+</script>
+
+<template>
+  <Teleport to="body">
+    <div v-if="modelValue" class="search-window-backdrop" @click="close"></div>
+    <div
+      v-if="modelValue"
+      class="search-window"
+      :style="anchorRect ? {
+        top: anchorRect.top + 'px',
+        left: anchorRect.left + 'px',
+        width: anchorRect.width + 'px',
+      } : {}"
+      @keydown="onKeydown"
+    >
+      <div class="search-window-header">
+        <div class="search-window-search-row">
+          <ndd-search-field
+            ref="searchFieldRef"
+            size="md"
+            placeholder="Zoeken"
+            :value="search"
+            @input="search = $event.target.value"
+          ></ndd-search-field>
+          <ndd-button size="md" text="Sluit" @click="close"></ndd-button>
+        </div>
+        <div class="search-window-filters">
+          <ndd-button size="sm" expandable disabled text="Alle ministeries"></ndd-button>
+          <ndd-button size="sm" expandable disabled text="Alle regelgeving"></ndd-button>
+          <ndd-button size="sm" expandable disabled text="Alle onderdelen"></ndd-button>
+          <ndd-button size="sm" expandable disabled text="Alle periodes"></ndd-button>
+        </div>
+      </div>
+
+      <div v-if="hasSearch" class="search-window-results">
+        <div v-if="filteredLaws.length === 0" class="search-window-empty">
+          <div class="search-window-empty-title">Geen resultaten gevonden</div>
+          <div class="search-window-empty-subtitle">Pas je zoektermen of voorkeuren aan</div>
+        </div>
+        <ndd-list v-else variant="simple">
+          <ndd-list-item
+            v-for="law in filteredLaws"
+            :key="law.law_id"
+            size="md"
+            type="button"
+            @click="selectLaw(law.law_id)"
+          >
+            <ndd-text-cell :text="displayName(law)" :supporting-text="law.source_name">
+            </ndd-text-cell>
+          </ndd-list-item>
+        </ndd-list>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<style>
+.search-window-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+}
+
+.search-window {
+  position: fixed;
+  max-height: calc(100vh - 100px);
+  display: flex;
+  flex-direction: column;
+  background: light-dark(
+    var(--primitives-color-neutral-0, #fff),
+    var(--primitives-color-neutral-950, #0c0e14)
+  );
+  border: 1px solid light-dark(
+    var(--primitives-color-neutral-200, #e2e8f0),
+    var(--primitives-color-neutral-800, #1e293b)
+  );
+  border-radius: var(--primitives-corner-radius-lg, 12px);
+  box-shadow:
+    0 4px 6px -1px rgba(0, 0, 0, 0.1),
+    0 10px 15px -3px rgba(0, 0, 0, 0.2),
+    0 20px 25px -5px rgba(0, 0, 0, 0.15);
+  z-index: 201;
+  overflow: hidden;
+}
+
+.search-window-header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--primitives-space-8, 8px);
+  padding: var(--primitives-space-12, 12px);
+}
+
+.search-window-search-row {
+  display: flex;
+  align-items: center;
+  gap: var(--primitives-space-8, 8px);
+}
+
+.search-window-search-row ndd-search-field {
+  flex: 1;
+}
+
+.search-window-filters {
+  display: flex;
+  gap: var(--primitives-space-6, 6px);
+  flex-wrap: wrap;
+}
+
+.search-window-results {
+  flex: 1;
+  overflow-y: auto;
+  max-height: 340px;
+  padding: 0 var(--primitives-space-12, 12px) var(--primitives-space-12, 12px);
+}
+
+.search-window-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: var(--primitives-space-64, 64px) var(--primitives-space-16, 16px);
+  text-align: center;
+}
+
+.search-window-empty-title {
+  font-size: var(--primitives-font-size-200, 1.125rem);
+  font-weight: var(--primitives-font-weight-medium, 500);
+  color: light-dark(
+    var(--primitives-color-neutral-400, #94a3b8),
+    var(--primitives-color-neutral-500, #64748b)
+  );
+  margin-bottom: var(--primitives-space-4, 4px);
+}
+
+.search-window-empty-subtitle {
+  font-size: var(--primitives-font-size-100, 0.875rem);
+  color: light-dark(
+    var(--primitives-color-neutral-350, #a1aab8),
+    var(--primitives-color-neutral-550, #556275)
+  );
+}
+</style>

--- a/frontend/src/components/SearchWindow.vue
+++ b/frontend/src/components/SearchWindow.vue
@@ -3,7 +3,6 @@ import { ref, computed, watch, nextTick } from 'vue';
 
 const props = defineProps({
   laws: { type: Array, default: () => [] },
-  favorites: { type: Object, default: null },
   modelValue: { type: Boolean, default: false },
   anchorRect: { type: Object, default: null },
 });


### PR DESCRIPTION
## Summary
- Replace inline search field with expandable search window overlay in the library toolbar
- Search dropdown anchored to toolbar search field position, opens on click/focus
- Includes placeholder filter buttons (Alle ministeries, Alle regelgeving, Alle onderdelen, Alle periodes)
- Empty state with "Geen resultaten gevonden" message
- Close via Sluit button, Escape key, or backdrop click

## Test plan
- [ ] Open library view and click the search field
- [ ] Verify dropdown overlays toolbar with search field aligned
- [ ] Type a search query and verify results filter
- [ ] Verify empty state when no results match
- [ ] Close dropdown via "Sluit" button, Escape key, and backdrop click
- [ ] Click a search result and verify navigation to the law
