### PR TITLE
fix(harvester): replace blocking HTTP client with async reqwest

### DIFF
--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -3735,6 +3735,7 @@ dependencies = [
  "tempfile",
  "textwrap",
  "thiserror 2.0.18",
+ "tokio",
  "tracing",
  "tracing-subscriber",
  "unicode-normalization",

--- a/packages/harvester/Cargo.toml
+++ b/packages/harvester/Cargo.toml
@@ -27,7 +27,8 @@ chrono = { version = "0.4", features = ["serde"] }
 regex = "1.11"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-reqwest = { version = "0.13", features = ["blocking"] }
+reqwest = "0.13"
+tokio = { version = "1", features = ["time", "rt-multi-thread", "macros"] }
 roxmltree = "0.21"
 clap = { version = "4.6", features = ["derive"] }
 indicatif = "0.18"

--- a/packages/harvester/src/cli.rs
+++ b/packages/harvester/src/cli.rs
@@ -9,6 +9,7 @@ use indicatif::{ProgressBar, ProgressStyle};
 use crate::config::DEFAULT_MAX_RESPONSE_SIZE;
 use crate::error::{HarvesterError, Result};
 use crate::harvester::download_law_with_max_size;
+use crate::http::create_client;
 use crate::yaml::save_yaml;
 
 /// RegelRecht Harvester - Download Dutch legislation from BWB repository.
@@ -45,7 +46,7 @@ pub enum Commands {
 }
 
 /// Run the CLI.
-pub fn run() -> Result<()> {
+pub async fn run() -> Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
@@ -54,12 +55,12 @@ pub fn run() -> Result<()> {
             date,
             output,
             max_size,
-        } => download_command(&bwb_id, date.as_deref(), output.as_deref(), max_size),
+        } => download_command(&bwb_id, date.as_deref(), output.as_deref(), max_size).await,
     }
 }
 
 /// Execute the download command.
-fn download_command(
+async fn download_command(
     bwb_id: &str,
     date: Option<&str>,
     output: Option<&std::path::Path>,
@@ -103,11 +104,15 @@ fn download_command(
             .expect("valid template"),
     );
 
+    // Create HTTP client
+    let client = create_client()?;
+
     // Download and parse
     pb.set_message("Downloading WTI metadata...");
     pb.enable_steady_tick(std::time::Duration::from_millis(100));
 
-    let law = match download_law_with_max_size(bwb_id, &effective_date, max_size_mb) {
+    let law = match download_law_with_max_size(&client, bwb_id, &effective_date, max_size_mb).await
+    {
         Ok(law) => law,
         Err(e) => {
             pb.finish_and_clear();

--- a/packages/harvester/src/content.rs
+++ b/packages/harvester/src/content.rs
@@ -2,7 +2,7 @@
 //!
 //! Content files contain the actual legal text of Dutch laws in XML format.
 
-use reqwest::blocking::Client;
+use reqwest::Client;
 
 use crate::config::content_url;
 use crate::error::{HarvesterError, Result};
@@ -21,14 +21,14 @@ use crate::http::{bytes_to_string, download_bytes};
 ///
 /// # Returns
 /// Raw XML content as a string
-pub fn download_content_xml(
+pub async fn download_content_xml(
     client: &Client,
     bwb_id: &str,
     date: &str,
     max_size: u64,
 ) -> Result<String> {
     let url = content_url(bwb_id, date);
-    let bytes = download_bytes(client, &url, max_size).map_err(|e| {
+    let bytes = download_bytes(client, &url, max_size).await.map_err(|e| {
         if let HarvesterError::Http(source) = e {
             HarvesterError::ContentDownload {
                 bwb_id: bwb_id.to_string(),

--- a/packages/harvester/src/harvester.rs
+++ b/packages/harvester/src/harvester.rs
@@ -2,10 +2,11 @@
 
 use roxmltree::Document;
 
+use reqwest::Client;
+
 use crate::config::{validate_bwb_id, validate_date, wetten_url, DEFAULT_MAX_RESPONSE_SIZE};
 use crate::content::download_content_xml;
 use crate::error::Result;
-use crate::http::create_client;
 use crate::splitting::{create_dutch_law_hierarchy, LeafSplitStrategy, SplitContext, SplitEngine};
 use crate::types::{Law, Preamble};
 use crate::wti::download_wti;
@@ -14,39 +15,49 @@ use crate::xml::{find_bijlage_context, find_by_path, find_children, get_tag_name
 /// Download and parse a Dutch law.
 ///
 /// # Arguments
+/// * `client` - HTTP client to use
 /// * `bwb_id` - The BWB identifier (e.g., "BWBR0018451")
 /// * `date` - The effective date in YYYY-MM-DD format
 ///
 /// # Returns
 /// A `Law` object containing metadata, articles, and any warnings encountered during parsing
-pub fn download_law(bwb_id: &str, date: &str) -> Result<Law> {
-    download_law_with_max_size(bwb_id, date, DEFAULT_MAX_RESPONSE_SIZE / (1024 * 1024))
+pub async fn download_law(client: &Client, bwb_id: &str, date: &str) -> Result<Law> {
+    download_law_with_max_size(
+        client,
+        bwb_id,
+        date,
+        DEFAULT_MAX_RESPONSE_SIZE / (1024 * 1024),
+    )
+    .await
 }
 
 /// Download and parse a Dutch law with configurable max response size.
 ///
 /// # Arguments
+/// * `client` - HTTP client to use
 /// * `bwb_id` - The BWB identifier (e.g., "BWBR0018451")
 /// * `date` - The effective date in YYYY-MM-DD format
 /// * `max_size_mb` - Maximum response size in megabytes
 ///
 /// # Returns
 /// A `Law` object containing metadata, articles, and any warnings encountered during parsing
-pub fn download_law_with_max_size(bwb_id: &str, date: &str, max_size_mb: u64) -> Result<Law> {
+pub async fn download_law_with_max_size(
+    client: &Client,
+    bwb_id: &str,
+    date: &str,
+    max_size_mb: u64,
+) -> Result<Law> {
     // Validate inputs
     validate_bwb_id(bwb_id)?;
     validate_date(date)?;
 
     let max_size_bytes = max_size_mb * 1024 * 1024;
 
-    // Create HTTP client
-    let client = create_client()?;
-
     // Download and parse WTI metadata
-    let wti_result = download_wti(&client, bwb_id)?;
+    let wti_result = download_wti(client, bwb_id).await?;
 
     // Download content XML
-    let content_xml = download_content_xml(&client, bwb_id, date, max_size_bytes)?;
+    let content_xml = download_content_xml(client, bwb_id, date, max_size_bytes).await?;
 
     // Parse articles from content
     let parsed = parse_articles(&content_xml, bwb_id, date)?;

--- a/packages/harvester/src/http.rs
+++ b/packages/harvester/src/http.rs
@@ -1,9 +1,8 @@
 //! HTTP client wrapper for downloading from BWB repository.
 
-use std::thread;
 use std::time::Duration;
 
-use reqwest::blocking::Client;
+use reqwest::Client;
 
 use crate::config::{DEFAULT_MAX_RESPONSE_SIZE, HTTP_TIMEOUT_SECS};
 use crate::error::{HarvesterError, Result};
@@ -20,7 +19,7 @@ const RETRY_BASE_DELAY_MS: u64 = 500;
 /// Create a configured HTTP client.
 ///
 /// # Returns
-/// A `reqwest::blocking::Client` configured with appropriate timeout and user agent.
+/// A `reqwest::Client` configured with appropriate timeout and user agent.
 pub fn create_client() -> Result<Client> {
     let client = Client::builder()
         .timeout(Duration::from_secs(HTTP_TIMEOUT_SECS))
@@ -40,7 +39,7 @@ pub fn create_client() -> Result<Client> {
 ///
 /// # Returns
 /// Raw bytes of the response body
-pub fn download_bytes(client: &Client, url: &str, max_size: u64) -> Result<Vec<u8>> {
+pub async fn download_bytes(client: &Client, url: &str, max_size: u64) -> Result<Vec<u8>> {
     let mut last_error: Option<String> = None;
 
     for attempt in 0..MAX_RETRIES {
@@ -48,10 +47,10 @@ pub fn download_bytes(client: &Client, url: &str, max_size: u64) -> Result<Vec<u
             // Exponential backoff: 500ms, 1000ms, 2000ms
             let delay = RETRY_BASE_DELAY_MS * (1 << (attempt - 1));
             tracing::debug!(attempt, delay_ms = delay, "Retrying after delay");
-            thread::sleep(Duration::from_millis(delay));
+            tokio::time::sleep(Duration::from_millis(delay)).await;
         }
 
-        match client.get(url).send() {
+        match client.get(url).send().await {
             Ok(response) => {
                 let status = response.status();
 
@@ -80,7 +79,7 @@ pub fn download_bytes(client: &Client, url: &str, max_size: u64) -> Result<Vec<u
                     }
                 }
 
-                let bytes = response.bytes()?;
+                let bytes = response.bytes().await?;
 
                 // Also check actual size (Content-Length may be missing or wrong)
                 if bytes.len() as u64 > max_size {
@@ -127,8 +126,8 @@ pub fn download_bytes(client: &Client, url: &str, max_size: u64) -> Result<Vec<u
 ///
 /// # Returns
 /// Raw bytes of the response body
-pub fn download_bytes_default(client: &Client, url: &str) -> Result<Vec<u8>> {
-    download_bytes(client, url, DEFAULT_MAX_RESPONSE_SIZE)
+pub async fn download_bytes_default(client: &Client, url: &str) -> Result<Vec<u8>> {
+    download_bytes(client, url, DEFAULT_MAX_RESPONSE_SIZE).await
 }
 
 /// Convert bytes to a string, preferring strict UTF-8 but falling back to lossy conversion.

--- a/packages/harvester/src/main.rs
+++ b/packages/harvester/src/main.rs
@@ -3,7 +3,8 @@
 use regelrecht_harvester::cli;
 use tracing_subscriber::EnvFilter;
 
-fn main() {
+#[tokio::main]
+async fn main() {
     // Initialize tracing with WARN level by default, respecting RUST_LOG
     tracing_subscriber::fmt()
         .with_env_filter(
@@ -12,7 +13,7 @@ fn main() {
         .with_target(false)
         .init();
 
-    if let Err(e) = cli::run() {
+    if let Err(e) = cli::run().await {
         eprintln!("Error: {e}");
         std::process::exit(1);
     }

--- a/packages/harvester/src/manifest.rs
+++ b/packages/harvester/src/manifest.rs
@@ -4,7 +4,7 @@
 //! file contains all available consolidation dates with their validity periods.
 //! This module downloads and parses the manifest to find the correct consolidation date.
 
-use reqwest::blocking::Client;
+use reqwest::Client;
 use roxmltree::Document;
 
 use crate::config::{manifest_url, DEFAULT_MAX_RESPONSE_SIZE};
@@ -39,18 +39,20 @@ pub struct Consolidation {
 /// # Arguments
 /// * `client` - HTTP client to use
 /// * `bwb_id` - The BWB identifier (e.g., "BWBR0015703")
-pub fn download_manifest(client: &Client, bwb_id: &str) -> Result<BwbManifest> {
+pub async fn download_manifest(client: &Client, bwb_id: &str) -> Result<BwbManifest> {
     let url = manifest_url(bwb_id);
-    let bytes = download_bytes(client, &url, DEFAULT_MAX_RESPONSE_SIZE).map_err(|e| {
-        if let HarvesterError::Http(source) = e {
-            HarvesterError::ManifestDownload {
-                bwb_id: bwb_id.to_string(),
-                source,
+    let bytes = download_bytes(client, &url, DEFAULT_MAX_RESPONSE_SIZE)
+        .await
+        .map_err(|e| {
+            if let HarvesterError::Http(source) = e {
+                HarvesterError::ManifestDownload {
+                    bwb_id: bwb_id.to_string(),
+                    source,
+                }
+            } else {
+                e
             }
-        } else {
-            e
-        }
-    })?;
+        })?;
 
     let xml = bytes_to_string(bytes, &format!("manifest for {bwb_id}"));
     parse_manifest(&xml, bwb_id)

--- a/packages/harvester/src/wti.rs
+++ b/packages/harvester/src/wti.rs
@@ -6,7 +6,7 @@
 //! - Type of regulation (soort-regeling)
 //! - Publication date
 
-use reqwest::blocking::Client;
+use reqwest::Client;
 use roxmltree::Document;
 
 use crate::config::wti_url;
@@ -22,9 +22,9 @@ use crate::types::{LawMetadata, RegulatoryLayer};
 ///
 /// # Returns
 /// Raw XML content as a string
-pub fn download_wti_xml(client: &Client, bwb_id: &str) -> Result<String> {
+pub async fn download_wti_xml(client: &Client, bwb_id: &str) -> Result<String> {
     let url = wti_url(bwb_id);
-    let bytes = download_bytes_default(client, &url).map_err(|e| {
+    let bytes = download_bytes_default(client, &url).await.map_err(|e| {
         if let HarvesterError::Http(source) = e {
             HarvesterError::WtiDownload {
                 bwb_id: bwb_id.to_string(),
@@ -52,8 +52,8 @@ pub fn download_wti_xml(client: &Client, bwb_id: &str) -> Result<String> {
 ///
 /// # Returns
 /// `WtiParseResult` with extracted metadata and any warnings
-pub fn download_wti(client: &Client, bwb_id: &str) -> Result<WtiParseResult> {
-    let xml = download_wti_xml(client, bwb_id)?;
+pub async fn download_wti(client: &Client, bwb_id: &str) -> Result<WtiParseResult> {
+    let xml = download_wti_xml(client, bwb_id).await?;
     let doc = Document::parse(&xml)?;
     Ok(parse_wti_metadata(&doc))
 }

--- a/packages/pipeline/Cargo.toml
+++ b/packages/pipeline/Cargo.toml
@@ -30,7 +30,7 @@ thiserror = "2.0"
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1", features = ["v4", "serde"] }
 strum = { version = "0.28", features = ["derive"] }
-reqwest = { version = "0.13", default-features = false, features = ["blocking"] }
+reqwest = { version = "0.13", default-features = false }
 sha2 = "0.10"
 tokio-util = "0.7"
 async-trait = "0.1"

--- a/packages/pipeline/src/harvest.rs
+++ b/packages/pipeline/src/harvest.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 use chrono::Utc;
-use reqwest::blocking::Client;
+use reqwest::Client;
 use serde::{Deserialize, Serialize};
 
 use crate::error::Result;
@@ -65,28 +65,23 @@ pub async fn execute_harvest(
     output_base: &str,
     http_client: &Client,
 ) -> Result<(HarvestResult, Vec<PathBuf>)> {
-    let bwb_id_for_manifest = payload.bwb_id.clone();
-    let date_for_manifest = payload.date.clone();
-    let client_for_manifest = http_client.clone();
-    let effective_date = tokio::task::spawn_blocking(move || {
-        let bwb_manifest = manifest::download_manifest(&client_for_manifest, &bwb_id_for_manifest)?;
-        manifest::resolve_consolidation_date(&bwb_manifest, date_for_manifest.as_deref())
-    })
-    .await??;
+    let bwb_manifest = manifest::download_manifest(http_client, &payload.bwb_id).await?;
+    let effective_date =
+        manifest::resolve_consolidation_date(&bwb_manifest, payload.date.as_deref())?;
     tracing::info!(bwb_id = %payload.bwb_id, resolved_date = %effective_date, "resolved consolidation date from manifest");
-    let bwb_id = payload.bwb_id.clone();
-    let date_for_download = effective_date.clone();
-    let max_size_mb = payload.max_size_mb;
 
     tracing::info!(bwb_id = %payload.bwb_id, date = %effective_date, "downloading law XML from BWB");
-    let law = tokio::task::spawn_blocking(move || {
-        if let Some(max_mb) = max_size_mb {
-            regelrecht_harvester::download_law_with_max_size(&bwb_id, &date_for_download, max_mb)
-        } else {
-            regelrecht_harvester::download_law(&bwb_id, &date_for_download)
-        }
-    })
-    .await??;
+    let law = if let Some(max_mb) = payload.max_size_mb {
+        regelrecht_harvester::download_law_with_max_size(
+            http_client,
+            &payload.bwb_id,
+            &effective_date,
+            max_mb,
+        )
+        .await?
+    } else {
+        regelrecht_harvester::download_law(http_client, &payload.bwb_id, &effective_date).await?
+    };
 
     tracing::info!(bwb_id = %payload.bwb_id, title = %law.metadata.title, "law XML downloaded successfully");
     let law_name = law.metadata.title.clone();

--- a/packages/pipeline/src/worker.rs
+++ b/packages/pipeline/src/worker.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 use std::time::Duration;
 
 use regelrecht_corpus::{CorpusClient, CorpusConfig};
-use reqwest::blocking::Client;
+use reqwest::Client;
 use sqlx::PgPool;
 use tokio::signal::unix::{signal, SignalKind};
 


### PR DESCRIPTION
## Summary
- Converteert de harvester library van `reqwest::blocking::Client` naar async `reqwest::Client`
- Elimineert geneste tokio runtimes die 171 harvest failures veroorzaakten ("event loop thread panicked") bij depth 10-11
- Pipeline gebruikt nu directe `.await` calls in plaats van `spawn_blocking` voor HTTP-operaties

## Root cause
`reqwest::blocking::Client` maakt intern een eigen tokio runtime aan. Wanneer dit via `tokio::task::spawn_blocking()` wordt aangeroepen vanuit de pipeline worker (die al op tokio draait), ontstaan geneste runtimes. Bij hoge concurrency met diepe recursieve harvests (depth 10-11) leidt dit tot resource-uitputting en panics.

## Wijzigingen
- **harvester library**: alle HTTP functies zijn nu `async`, `thread::sleep` → `tokio::time::sleep`, `download_law` accepteert `&Client` parameter
- **CLI binary**: gebruikt `#[tokio::main]`
- **pipeline**: verwijdert `spawn_blocking` wrappers voor HTTP calls, behoudt `spawn_blocking` voor CPU-bound `save_yaml`

## Test plan
- [x] `just build-check` — compileert
- [x] `just test` — unit tests slagen
- [x] `just pipeline-test` — pipeline tests slagen
- [x] `just lint` — geen clippy warnings
- [x] `just format` — formatting correct
- [ ] Deploy naar preview en harvest jobs testen