### PR TITLE
feat(pipeline): sparse checkout for enricher corpus to fix OOM

### DIFF
--- a/packages/corpus/src/client.rs
+++ b/packages/corpus/src/client.rs
@@ -206,19 +206,25 @@ impl CorpusClient {
     async fn git_clone(&self) -> Result<()> {
         let url = self.config.clone_url();
         let path_str = self.config.repo_path.to_string_lossy().to_string();
+        let sparse = self.config.sparse_paths.is_some();
+
+        let mut args = vec![
+            "clone",
+            "--depth",
+            "1",
+            "--quiet",
+            "--branch",
+            &self.config.branch,
+            "--single-branch",
+        ];
+        if sparse {
+            args.push("--no-checkout");
+        }
+        args.push(&url);
+        args.push(&path_str);
 
         let output = Command::new("git")
-            .args([
-                "clone",
-                "--depth",
-                "1",
-                "--quiet",
-                "--branch",
-                &self.config.branch,
-                "--single-branch",
-                &url,
-                &path_str,
-            ])
+            .args(&args)
             .envs(self.git_env())
             .output()
             .await?;
@@ -240,6 +246,7 @@ impl CorpusClient {
         }
 
         self.configure_git_user().await?;
+        self.setup_sparse_checkout().await?;
         Ok(())
     }
 
@@ -247,19 +254,25 @@ impl CorpusClient {
     async fn git_clone_and_create_branch(&self) -> Result<()> {
         let url = self.config.clone_url();
         let path_str = self.config.repo_path.to_string_lossy().to_string();
+        let sparse = self.config.sparse_paths.is_some();
+
+        let mut args = vec![
+            "clone",
+            "--depth",
+            "1",
+            "--quiet",
+            "--branch",
+            "development",
+            "--single-branch",
+        ];
+        if sparse {
+            args.push("--no-checkout");
+        }
+        args.push(&url);
+        args.push(&path_str);
 
         let output = Command::new("git")
-            .args([
-                "clone",
-                "--depth",
-                "1",
-                "--quiet",
-                "--branch",
-                "development",
-                "--single-branch",
-                &url,
-                &path_str,
-            ])
+            .args(&args)
             .envs(self.git_env())
             .output()
             .await?;
@@ -273,6 +286,7 @@ impl CorpusClient {
         }
 
         self.configure_git_user().await?;
+        self.setup_sparse_checkout().await?;
 
         // Create the target branch and push it
         self.run_git(&["checkout", "-b", &self.config.branch])
@@ -281,6 +295,30 @@ impl CorpusClient {
             .await?;
 
         tracing::info!(branch = %self.config.branch, "created and pushed new branch");
+        Ok(())
+    }
+
+    /// Configure sparse-checkout if `sparse_paths` is set on the config.
+    ///
+    /// Uses cone mode so only the listed directory trees are materialized.
+    /// No-op when `sparse_paths` is `None` (full checkout).
+    async fn setup_sparse_checkout(&self) -> Result<()> {
+        let paths = match self.config.sparse_paths {
+            Some(ref p) if !p.is_empty() => p,
+            _ => return Ok(()),
+        };
+
+        self.run_git(&["sparse-checkout", "init", "--cone"]).await?;
+
+        let mut args = vec!["sparse-checkout", "set"];
+        let refs: Vec<&str> = paths.iter().map(|s| s.as_str()).collect();
+        args.extend(refs);
+        self.run_git(&args).await?;
+
+        // Materialize the working tree (only the sparse paths)
+        self.run_git(&["checkout"]).await?;
+
+        tracing::info!(paths = ?paths, "sparse checkout configured");
         Ok(())
     }
 
@@ -655,6 +693,99 @@ mod tests {
             .unwrap();
         let branch_str = String::from_utf8_lossy(&branch.stdout);
         assert_eq!(branch_str.trim(), "editor/test-session");
+    }
+
+    /// Create a bare repo with files in multiple directories for sparse checkout testing.
+    async fn setup_bare_repo_with_files(dir: &Path) -> PathBuf {
+        let bare_path = dir.join("bare.git");
+        Command::new("git")
+            .args(["init", "--bare", "--initial-branch=development"])
+            .arg(&bare_path)
+            .output()
+            .await
+            .unwrap();
+
+        let tmp_clone = dir.join("tmp-clone");
+        let bare_url = format!("file://{}", bare_path.display());
+        Command::new("git")
+            .args(["clone", &bare_url])
+            .arg(&tmp_clone)
+            .output()
+            .await
+            .unwrap();
+
+        for args in [
+            vec!["config", "user.name", "test"],
+            vec!["config", "user.email", "test@test.nl"],
+        ] {
+            Command::new("git")
+                .args(&args)
+                .current_dir(&tmp_clone)
+                .output()
+                .await
+                .unwrap();
+        }
+
+        // Create files in multiple directories
+        let law_a = tmp_clone.join("regulation/nl/wet/law_a");
+        let law_b = tmp_clone.join("regulation/nl/wet/law_b");
+        let features = tmp_clone.join("features");
+        tokio::fs::create_dir_all(&law_a).await.unwrap();
+        tokio::fs::create_dir_all(&law_b).await.unwrap();
+        tokio::fs::create_dir_all(&features).await.unwrap();
+
+        tokio::fs::write(law_a.join("2025-01-01.yaml"), "law_a content")
+            .await
+            .unwrap();
+        tokio::fs::write(law_b.join("2025-01-01.yaml"), "law_b content")
+            .await
+            .unwrap();
+        tokio::fs::write(features.join("law_a.feature"), "feature content")
+            .await
+            .unwrap();
+
+        for args in [
+            vec!["add", "."],
+            vec!["commit", "-m", "add test files"],
+            vec!["push", "origin", "development"],
+        ] {
+            Command::new("git")
+                .args(&args)
+                .current_dir(&tmp_clone)
+                .output()
+                .await
+                .unwrap();
+        }
+
+        bare_path
+    }
+
+    #[tokio::test]
+    async fn test_sparse_checkout_only_materializes_requested_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let bare_path = setup_bare_repo_with_files(dir.path()).await;
+        let bare_url = format!("file://{}", bare_path.display());
+        let repo_path = dir.path().join("sparse-corpus");
+
+        let mut config = CorpusConfig::new(&bare_url, &repo_path);
+        config.sparse_paths = Some(vec![
+            "regulation/nl/wet/law_a".to_string(),
+            "features".to_string(),
+        ]);
+
+        let mut client = CorpusClient::new(config);
+        client.ensure_repo().await.unwrap();
+
+        // law_a should be present
+        assert!(repo_path
+            .join("regulation/nl/wet/law_a/2025-01-01.yaml")
+            .exists());
+        // features should be present
+        assert!(repo_path.join("features/law_a.feature").exists());
+        // law_b should NOT be present (excluded by sparse checkout)
+        assert!(!repo_path
+            .join("regulation/nl/wet/law_b/2025-01-01.yaml")
+            .exists());
     }
 
     #[tokio::test]

--- a/packages/corpus/src/config.rs
+++ b/packages/corpus/src/config.rs
@@ -10,6 +10,9 @@ pub struct CorpusConfig {
     pub git_author_name: String,
     pub git_author_email: String,
     git_token: Option<String>,
+    /// Optional sparse-checkout paths (cone mode). When set, only these
+    /// directory trees are materialized in the working copy after clone.
+    pub sparse_paths: Option<Vec<String>>,
 }
 
 impl std::fmt::Debug for CorpusConfig {
@@ -21,6 +24,7 @@ impl std::fmt::Debug for CorpusConfig {
             .field("git_author_name", &self.git_author_name)
             .field("git_author_email", &self.git_author_email)
             .field("git_token", &self.git_token.as_ref().map(|_| "***"))
+            .field("sparse_paths", &self.sparse_paths)
             .finish()
     }
 }
@@ -50,6 +54,7 @@ impl CorpusConfig {
             git_author_name: "regelrecht-harvester".into(),
             git_author_email: "noreply@minbzk.nl".into(),
             git_token: None,
+            sparse_paths: None,
         }
     }
 
@@ -89,6 +94,7 @@ impl CorpusConfig {
             git_author_name,
             git_author_email,
             git_token,
+            sparse_paths: None,
         })
     }
 
@@ -147,6 +153,7 @@ mod tests {
             git_author_name: "test".into(),
             git_author_email: "test@test.nl".into(),
             git_token: Some("ghp_abc123".into()),
+            sparse_paths: None,
         };
         // Token should NOT appear in the URL — only the username
         let url = config.clone_url();
@@ -163,6 +170,7 @@ mod tests {
             git_author_name: "test".into(),
             git_author_email: "test@test.nl".into(),
             git_token: None,
+            sparse_paths: None,
         };
         assert_eq!(
             config.clone_url(),
@@ -179,6 +187,7 @@ mod tests {
             git_author_name: "test".into(),
             git_author_email: "test@test.nl".into(),
             git_token: Some("ghp_abc123".into()),
+            sparse_paths: None,
         };
         // SSH URLs should not be modified
         assert_eq!(
@@ -235,6 +244,7 @@ mod tests {
             git_author_name: "test".into(),
             git_author_email: "test@test.nl".into(),
             git_token: Some("ghp_abc123".into()),
+            sparse_paths: None,
         };
         let debug_output = format!("{:?}", config);
         assert!(!debug_output.contains("ghp_abc123"));

--- a/packages/pipeline/src/enrich.rs
+++ b/packages/pipeline/src/enrich.rs
@@ -394,13 +394,27 @@ fn build_command(
 ///
 /// Each invocation uses a unique checkout directory (keyed by branch + job ID)
 /// to prevent concurrent workers from clobbering each other's checkouts.
+///
+/// Uses sparse checkout to only materialize the law directory being enriched
+/// plus the `features/` directory. This prevents the LLM subprocess from
+/// indexing the entire corpus (thousands of files), which would exceed context
+/// limits and cause excessive memory usage.
 pub async fn create_enrich_corpus(
     base_config: &CorpusConfig,
     branch: &str,
     job_id: Uuid,
+    yaml_path: &str,
 ) -> Result<CorpusClient> {
     let mut config = base_config.clone();
     config.branch = branch.into();
+
+    // Sparse checkout: only the law directory + features/
+    if let Some(law_dir) = Path::new(yaml_path).parent() {
+        let law_dir_str = law_dir.to_string_lossy().to_string();
+        if !law_dir_str.is_empty() {
+            config.sparse_paths = Some(vec![law_dir_str, "features".to_string()]);
+        }
+    }
 
     // Use a separate checkout directory per branch + job to avoid conflicts
     // between concurrent workers processing different laws on the same branch.

--- a/packages/pipeline/src/enrich.rs
+++ b/packages/pipeline/src/enrich.rs
@@ -408,8 +408,14 @@ pub async fn create_enrich_corpus(
     let mut config = base_config.clone();
     config.branch = branch.into();
 
+    // Normalize the yaml_path to strip legacy absolute prefixes (e.g.
+    // `/tmp/corpus-repo/regulation/…`) before deriving the law directory
+    // for sparse checkout. Without this, git sparse-checkout would receive
+    // an absolute path it cannot handle.
+    let normalized = normalize_yaml_path(yaml_path)?;
+
     // Sparse checkout: only the law directory + features/
-    if let Some(law_dir) = Path::new(yaml_path).parent() {
+    if let Some(law_dir) = Path::new(&normalized).parent() {
         let law_dir_str = law_dir.to_string_lossy().to_string();
         if !law_dir_str.is_empty() {
             config.sparse_paths = Some(vec![law_dir_str, "features".to_string()]);

--- a/packages/pipeline/src/worker.rs
+++ b/packages/pipeline/src/worker.rs
@@ -616,7 +616,7 @@ async fn process_next_enrich_job(
     // Pass the job ID to get a unique checkout directory per worker.
     let branch = enrich_branch_name(effective_config.provider.name());
     let enrich_corpus = if let Some(base_config) = corpus_config {
-        match create_enrich_corpus(base_config, &branch, job.id).await {
+        match create_enrich_corpus(base_config, &branch, job.id, &payload.yaml_path).await {
             Ok(client) => {
                 tracing::info!(branch = %branch, "created enrichment branch corpus");
                 Some(client)


### PR DESCRIPTION
## Summary

- Adds sparse checkout support to `CorpusClient` — when `sparse_paths` is set, only the specified directory trees are materialized in the working copy
- The enricher now sets sparse checkout to only include the law directory being enriched + `features/`
- Reduces the corpus checkout from thousands of files (~500MB) to ~10 files (~5MB)

## Problem

The enricher's LLM subprocess (OpenCode) was doing `ls -R` on the entire corpus checkout at session start. With 1000+ law directories and thousands of YAML files, this produced 130KB+ output that:
1. Exceeded the 32K VLAM context window
2. Consumed excessive memory in the Node.js process (512MB cap)
3. Caused enrichment failures ("no machine_readable sections produced")
4. Auto-retry (up to 10x) amplified the memory spikes, hitting the ZAD pod memory limit

## Changes

| File | Change |
|------|--------|
| `packages/corpus/src/config.rs` | Added `sparse_paths: Option<Vec<String>>` field |
| `packages/corpus/src/client.rs` | `setup_sparse_checkout()` helper, `--no-checkout` in clone |
| `packages/pipeline/src/enrich.rs` | `create_enrich_corpus()` derives law dir from yaml_path |
| `packages/pipeline/src/worker.rs` | Passes `yaml_path` to `create_enrich_corpus()` |

## Test plan

- [x] `just build-check` passes
- [x] `just format` passes
- [x] `just lint` passes
- [x] `just pipeline-test` — 23 tests pass
- [x] Corpus tests — 70 tests pass (including new sparse checkout test)
- [x] New test `test_sparse_checkout_only_materializes_requested_paths` verifies sparse checkout excludes non-requested directories
- [ ] Deploy to preview and verify enrichment succeeds with reduced memory