### PR TITLE
feat(admin): add fake SSO for PR deployments

### DIFF
--- a/.claude/skills/law-download/download_law.py
+++ b/.claude/skills/law-download/download_law.py
@@ -73,6 +73,7 @@ def parse_wti_metadata(wti_tree):
         "GRONDWET", "WET", "AMVB", "KONINKLIJK_BESLUIT", "MINISTERIELE_REGELING",
         "BELEIDSREGEL", "EU_VERORDENING", "EU_RICHTLIJN", "VERDRAG",
         "UITVOERINGSBELEID", "GEMEENTELIJKE_VERORDENING", "PROVINCIALE_VERORDENING",
+        "WATERSCHAPS_VERORDENING",
     }
     soort = wti_tree.find(f".//{{{NS}}}soort-regeling")
     if soort is not None:
@@ -90,7 +91,7 @@ def parse_wti_metadata(wti_tree):
         if layer not in VALID_LAYERS:
             raise ValueError(
                 f"'{soort_text}' maps to '{layer}' which is not a valid "
-                f"schema v0.5.0 regulatory_layer. Map manually to e.g. AMVB."
+                f"a valid regulatory_layer. Map manually to e.g. AMVB."
             )
         metadata["regulatory_layer"] = layer
 

--- a/packages/admin/frontend-src/css/admin.css
+++ b/packages/admin/frontend-src/css/admin.css
@@ -322,3 +322,47 @@
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
+
+
+/* ============================================================
+   Login choice screen (preview deployments only)
+   ============================================================ */
+
+.login-choice {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  padding: var(--primitives-space-24);
+  background: var(--semantics-background-color, #f5f5f5);
+}
+
+.login-choice__card {
+  max-width: 420px;
+  width: 100%;
+  padding: var(--primitives-space-32, 32px);
+  background: #fff;
+  border: 1px solid var(--semantics-border-color, #e5e7eb);
+  border-radius: var(--primitives-corner-radius-md, 8px);
+  text-align: center;
+}
+
+.login-choice__title {
+  margin: 0 0 var(--primitives-space-8, 8px);
+  font-family: var(--primitives-font-family-body);
+  font-size: var(--primitives-font-size-140, 20px);
+  font-weight: var(--primitives-font-weight-body-extra-bold);
+  color: var(--semantics-content-color);
+}
+
+.login-choice__subtitle {
+  margin: 0 0 var(--primitives-space-24, 24px);
+  font-size: var(--primitives-font-size-80, 14px);
+  color: var(--semantics-content-secondary-color);
+}
+
+.login-choice__actions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--primitives-space-8, 8px);
+}

--- a/packages/admin/frontend-src/main.js
+++ b/packages/admin/frontend-src/main.js
@@ -1,10 +1,16 @@
-import '@minbzk/storybook';
-import '@minbzk/storybook/styles';
+// Intercept ?test-sso before Vue loads. The router redirects / → /law-entries
+// which drops query params, so we must check here before anything else runs.
+if (new URLSearchParams(window.location.search).has('test-sso')) {
+  window.location.replace('/auth/test-login');
+} else {
+  import('@minbzk/storybook');
+  import('@minbzk/storybook/styles');
 
-import { createApp } from 'vue';
-import App from './src/App.vue';
-import router from './src/router.js';
+  const { createApp } = await import('vue');
+  const { default: App } = await import('./src/App.vue');
+  const { default: router } = await import('./src/router.js');
 
-const app = createApp(App);
-app.use(router);
-app.mount('#admin-app');
+  const app = createApp(App);
+  app.use(router);
+  app.mount('#admin-app');
+}

--- a/packages/admin/frontend-src/src/App.vue
+++ b/packages/admin/frontend-src/src/App.vue
@@ -6,7 +6,10 @@ import { usePlatformInfo } from './composables/usePlatformInfo.js';
 
 const route = useRoute();
 const router = useRouter();
-const { authenticated, person, oidcConfigured, loading: authLoading, logout, redirectToLogin } = useAuth();
+const {
+  authenticated, person, oidcConfigured, testSsoAvailable,
+  loading: authLoading, logout, redirectToLogin,
+} = useAuth();
 const { info } = usePlatformInfo();
 
 const deploymentName = computed(() =>
@@ -27,13 +30,19 @@ const tabs = [
 const activeTab = computed(() => route.name);
 
 // Redirect to OIDC login if configured but not authenticated.
-// The ?test-sso param is handled in main.js before Vue loads.
+// On preview deployments (testSsoAvailable) we render a choice screen instead,
+// so users/agents can opt into test login without hitting Keycloak's 2FA.
+// The ?test-sso query param is handled in main.js before Vue loads.
 watch(authLoading, (loading) => {
   if (loading || authenticated.value) return;
-  if (oidcConfigured.value) {
+  if (oidcConfigured.value && !testSsoAvailable.value) {
     redirectToLogin();
   }
 });
+
+function testLogin() {
+  window.location.href = '/auth/test-login';
+}
 
 function onAccountClick() {
   logout();
@@ -42,6 +51,30 @@ function onAccountClick() {
 
 <template>
   <div v-if="authLoading" />
+  <div v-else-if="!authenticated && testSsoAvailable" class="login-choice">
+    <span v-if="deploymentName" class="env-badge">{{ deploymentName }}</span>
+    <div class="login-choice__card">
+      <h1 class="login-choice__title">RegelRecht admin</h1>
+      <p class="login-choice__subtitle">
+        Preview-omgeving — kies een login-methode.
+      </p>
+      <div class="login-choice__actions">
+        <ndd-button
+          variant="accent-filled"
+          size="md"
+          text="Test login"
+          title="Log in als test-gebruiker (alleen preview)"
+          @click="testLogin"
+        />
+        <ndd-button
+          variant="neutral-tinted"
+          size="md"
+          text="Log in met Keycloak"
+          @click="redirectToLogin"
+        />
+      </div>
+    </div>
+  </div>
   <template v-else>
     <span v-if="deploymentName" class="env-badge">{{ deploymentName }}</span>
     <ndd-app-view>

--- a/packages/admin/frontend-src/src/App.vue
+++ b/packages/admin/frontend-src/src/App.vue
@@ -26,9 +26,11 @@ const tabs = [
 
 const activeTab = computed(() => route.name);
 
-// Redirect to login if OIDC configured but not authenticated
-watch([authLoading, oidcConfigured, authenticated], ([loading, oidc, auth]) => {
-  if (!loading && oidc && !auth) {
+// Redirect to OIDC login if configured but not authenticated.
+// The ?test-sso param is handled in main.js before Vue loads.
+watch(authLoading, (loading) => {
+  if (loading || authenticated.value) return;
+  if (oidcConfigured.value) {
     redirectToLogin();
   }
 });

--- a/packages/admin/frontend-src/src/composables/useAuth.js
+++ b/packages/admin/frontend-src/src/composables/useAuth.js
@@ -3,6 +3,7 @@ import { ref } from 'vue';
 const authenticated = ref(false);
 const person = ref(null);
 const oidcConfigured = ref(false);
+const testSsoAvailable = ref(false);
 const loading = ref(true);
 let fetched = false;
 
@@ -12,8 +13,10 @@ async function checkAuth() {
     if (!response.ok) return;
     const status = await response.json();
     authenticated.value = status.authenticated;
-    oidcConfigured.value = status.oidc_configured;
     person.value = status.person || null;
+    // Set test SSO before OIDC so the watcher sees both atomically.
+    testSsoAvailable.value = status.test_sso_available || false;
+    oidcConfigured.value = status.oidc_configured;
   } catch {
     // Auth check failed — leave as unauthenticated
   } finally {
@@ -36,5 +39,8 @@ export function useAuth() {
     checkAuth();
   }
 
-  return { authenticated, person, oidcConfigured, loading, logout, redirectToLogin };
+  return {
+    authenticated, person, oidcConfigured, testSsoAvailable,
+    loading, logout, redirectToLogin,
+  };
 }

--- a/packages/admin/src/config.rs
+++ b/packages/admin/src/config.rs
@@ -13,6 +13,8 @@ pub struct AppConfig {
     pub api_key_hash: Option<[u8; 32]>,
     /// Pre-computed SHA-256 hash of the metrics auth token (sent by Prometheus).
     pub metrics_token_hash: Option<[u8; 32]>,
+    /// Enable test SSO for PR deployments. Blocked in production.
+    pub test_sso: bool,
 }
 
 impl std::fmt::Debug for AppConfig {
@@ -26,6 +28,7 @@ impl std::fmt::Debug for AppConfig {
                 "metrics_token_hash",
                 &self.metrics_token_hash.map(|_| "[REDACTED]"),
             )
+            .field("test_sso", &self.test_sso)
             .finish()
     }
 }
@@ -84,12 +87,48 @@ impl AppConfig {
             .as_ref()
             .map(|k| Sha256::digest(k.as_bytes()).into());
 
+        let deployment = env::var("DEPLOYMENT_NAME").unwrap_or_default();
+        let is_preview = deployment.starts_with("pr")
+            && deployment.len() > 2
+            && deployment[2..].bytes().all(|b| b.is_ascii_digit());
+
+        let test_sso_explicit = env::var("TEST_SSO")
+            .ok()
+            .filter(|s| !s.is_empty())
+            .map(|v| match v.to_ascii_lowercase().as_str() {
+                "true" | "1" | "yes" => Ok(true),
+                "false" | "0" | "no" => Ok(false),
+                _ => Err(format!(
+                    "Invalid TEST_SSO value '{v}'. Use 'true' or 'false'."
+                )),
+            })
+            .transpose()?;
+
+        // Auto-enable for PR deployments, allow explicit override via TEST_SSO=false.
+        let test_sso = match test_sso_explicit {
+            Some(val) => val,
+            None => is_preview,
+        };
+
+        // Allowlist: test SSO may only be enabled for confirmed PR deployments (pr<N>).
+        if test_sso && !is_preview {
+            return Err(format!(
+                "TEST_SSO may only be enabled for PR deployments (DEPLOYMENT_NAME=pr<N>). \
+                 Current DEPLOYMENT_NAME is '{deployment}'."
+            ));
+        }
+
+        if test_sso {
+            tracing::warn!("TEST SSO is enabled — for test/PR deployments only");
+        }
+
         Ok(Self {
             oidc,
             base_url,
             api_key,
             api_key_hash,
             metrics_token_hash,
+            test_sso,
         })
     }
 
@@ -122,6 +161,8 @@ mod tests {
         env::remove_var("ADMIN_API_KEY");
         env::remove_var("BASE_URL");
         env::remove_var("METRICS_AUTH_TOKEN");
+        env::remove_var("TEST_SSO");
+        env::remove_var("DEPLOYMENT_NAME");
     }
 
     fn set_complete_oidc_env() {
@@ -211,6 +252,170 @@ mod tests {
 
         let config = AppConfig::try_from_env().expect("should succeed");
         assert!(config.metrics_token_hash.is_none());
+
+        clear_env();
+    }
+
+    #[test]
+    fn test_sso_enabled_from_env() {
+        let _lock = ENV_LOCK.lock();
+        clear_env();
+        env::set_var("TEST_SSO", "true");
+        env::set_var("DEPLOYMENT_NAME", "pr42");
+
+        let config = AppConfig::try_from_env().expect("should succeed");
+        assert!(config.test_sso);
+
+        clear_env();
+    }
+
+    #[test]
+    fn test_sso_disabled_by_default() {
+        let _lock = ENV_LOCK.lock();
+        clear_env();
+
+        let config = AppConfig::try_from_env().expect("should succeed");
+        assert!(!config.test_sso);
+
+        clear_env();
+    }
+
+    #[test]
+    fn test_sso_blocks_production() {
+        let _lock = ENV_LOCK.lock();
+        clear_env();
+        env::set_var("TEST_SSO", "true");
+        env::set_var("DEPLOYMENT_NAME", "regelrecht");
+
+        let result = AppConfig::try_from_env();
+        assert!(result.is_err());
+
+        clear_env();
+    }
+
+    #[test]
+    fn test_sso_blocks_non_pr_deployment() {
+        let _lock = ENV_LOCK.lock();
+        clear_env();
+        env::set_var("TEST_SSO", "true");
+        env::set_var("DEPLOYMENT_NAME", "staging");
+
+        let result = AppConfig::try_from_env();
+        assert!(result.is_err());
+
+        clear_env();
+    }
+
+    #[test]
+    fn test_sso_blocks_when_deployment_unset() {
+        let _lock = ENV_LOCK.lock();
+        clear_env();
+        env::set_var("TEST_SSO", "true");
+
+        let result = AppConfig::try_from_env();
+        assert!(result.is_err());
+
+        clear_env();
+    }
+
+    #[test]
+    fn test_sso_case_insensitive() {
+        let _lock = ENV_LOCK.lock();
+        clear_env();
+        env::set_var("TEST_SSO", "True");
+        env::set_var("DEPLOYMENT_NAME", "pr99");
+
+        let config = AppConfig::try_from_env().expect("should succeed");
+        assert!(config.test_sso);
+
+        clear_env();
+    }
+
+    #[test]
+    fn test_sso_accepts_1_as_true() {
+        let _lock = ENV_LOCK.lock();
+        clear_env();
+        env::set_var("TEST_SSO", "1");
+        env::set_var("DEPLOYMENT_NAME", "pr10");
+
+        let config = AppConfig::try_from_env().expect("should succeed");
+        assert!(config.test_sso);
+
+        clear_env();
+    }
+
+    #[test]
+    fn test_sso_rejects_invalid_value() {
+        let _lock = ENV_LOCK.lock();
+        clear_env();
+        env::set_var("TEST_SSO", "banana");
+        env::set_var("DEPLOYMENT_NAME", "pr10");
+
+        let result = AppConfig::try_from_env();
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.contains("Invalid TEST_SSO value"));
+
+        clear_env();
+    }
+
+    #[test]
+    fn test_sso_false_string() {
+        let _lock = ENV_LOCK.lock();
+        clear_env();
+        env::set_var("TEST_SSO", "false");
+
+        let config = AppConfig::try_from_env().expect("should succeed");
+        assert!(!config.test_sso);
+
+        clear_env();
+    }
+
+    #[test]
+    fn test_sso_auto_enabled_for_pr_deployment() {
+        let _lock = ENV_LOCK.lock();
+        clear_env();
+        env::set_var("DEPLOYMENT_NAME", "pr42");
+
+        let config = AppConfig::try_from_env().expect("should succeed");
+        assert!(config.test_sso);
+
+        clear_env();
+    }
+
+    #[test]
+    fn test_sso_not_auto_enabled_for_preview_deployment() {
+        let _lock = ENV_LOCK.lock();
+        clear_env();
+        env::set_var("DEPLOYMENT_NAME", "preview");
+
+        let config = AppConfig::try_from_env().expect("should succeed");
+        assert!(!config.test_sso);
+
+        clear_env();
+    }
+
+    #[test]
+    fn test_sso_not_auto_enabled_for_production() {
+        let _lock = ENV_LOCK.lock();
+        clear_env();
+        env::set_var("DEPLOYMENT_NAME", "regelrecht");
+
+        let config = AppConfig::try_from_env().expect("should succeed");
+        assert!(!config.test_sso);
+
+        clear_env();
+    }
+
+    #[test]
+    fn test_sso_explicit_false_overrides_pr_auto() {
+        let _lock = ENV_LOCK.lock();
+        clear_env();
+        env::set_var("DEPLOYMENT_NAME", "pr42");
+        env::set_var("TEST_SSO", "false");
+
+        let config = AppConfig::try_from_env().expect("should succeed");
+        assert!(!config.test_sso);
 
         clear_env();
     }

--- a/packages/admin/src/middleware.rs
+++ b/packages/admin/src/middleware.rs
@@ -141,6 +141,7 @@ mod tests {
                 Sha256::digest(k.as_bytes()).into()
             }),
             metrics_token_hash: None,
+            test_sso: false,
         };
 
         #[allow(clippy::expect_used)]
@@ -450,6 +451,7 @@ mod tests {
                 use sha2::{Digest, Sha256};
                 Sha256::digest(k.as_bytes()).into()
             }),
+            test_sso: false,
         };
 
         #[allow(clippy::expect_used)]

--- a/packages/admin/src/state.rs
+++ b/packages/admin/src/state.rs
@@ -40,6 +40,9 @@ impl OidcAppState for AppState {
     fn http_client(&self) -> &reqwest::Client {
         &self.http_client
     }
+    fn is_test_sso_enabled(&self) -> bool {
+        self.config.test_sso
+    }
 }
 
 /// State for the corpus subsystem.

--- a/packages/admin/tests/handler_tests.rs
+++ b/packages/admin/tests/handler_tests.rs
@@ -32,6 +32,7 @@ fn test_app(pool: sqlx::PgPool) -> Router {
             api_key: None,
             api_key_hash: None,
             metrics_token_hash: None,
+            test_sso: false,
         }),
         metrics_cache: Arc::new(metrics::new_cache()),
         http_client: reqwest::Client::new(),

--- a/packages/auth/src/handlers.rs
+++ b/packages/auth/src/handlers.rs
@@ -58,6 +58,7 @@ fn base_url_from_config_or_request<S: OidcAppState>(state: &S, headers: &HeaderM
 pub struct AuthStatus {
     pub authenticated: bool,
     pub oidc_configured: bool,
+    pub test_sso_available: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub person: Option<PersonInfo>,
 }
@@ -427,8 +428,67 @@ pub async fn status<S: OidcAppState>(State(state): State<S>, session: Session) -
     Json(AuthStatus {
         authenticated,
         oidc_configured,
+        test_sso_available: state.is_test_sso_enabled(),
         person,
     })
+}
+
+#[derive(Deserialize)]
+pub struct TestLoginQuery {
+    pub name: Option<String>,
+    pub email: Option<String>,
+}
+
+pub async fn test_login<S: OidcAppState>(
+    State(state): State<S>,
+    headers: HeaderMap,
+    session: Session,
+    axum::extract::Query(params): axum::extract::Query<TestLoginQuery>,
+) -> Result<Response, StatusCode> {
+    if !state.is_test_sso_enabled() {
+        return Err(StatusCode::NOT_FOUND);
+    }
+
+    let name = params
+        .name
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "Test User".to_string());
+    let email = params
+        .email
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "test-user@regelrecht.test".to_string());
+
+    // Generate a deterministic sub based on the name (lowercase, trimmed).
+    let sub = format!(
+        "test-sso-{}",
+        name.to_lowercase()
+            .replace(|c: char| !c.is_alphanumeric(), "-")
+    );
+
+    session.cycle_id().await.map_err(|e| {
+        tracing::error!(error = %e, "failed to cycle session ID");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    session
+        .insert(SESSION_KEY_AUTHENTICATED, true)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, "failed to insert authenticated flag into session");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+    session_insert(&session, SESSION_KEY_SUB, sub).await?;
+    session_insert(&session, SESSION_KEY_EMAIL, email.clone()).await?;
+    session_insert(&session, SESSION_KEY_NAME, name.clone()).await?;
+
+    // Store base_url in session for logout redirect (same as real OIDC flow).
+    let base_url = base_url_from_config_or_request(&state, &headers);
+    session_insert(&session, SESSION_KEY_BASE_URL, base_url).await?;
+
+    tracing::info!(name = %name, email = %email, "test SSO login");
+
+    // Use relative redirect to avoid open-redirect via Host header manipulation.
+    Ok(Redirect::temporary("/").into_response())
 }
 
 #[derive(Deserialize)]
@@ -600,5 +660,48 @@ mod tests {
         assert_eq!(validate_return_url(Some("/library\x7f")), None);
         // Null byte
         assert_eq!(validate_return_url(Some("/library\0")), None);
+    }
+
+    // --- TestLoginQuery deserialization ---
+
+    #[test]
+    fn test_login_query_defaults() {
+        let q: TestLoginQuery = serde_json::from_str("{}").unwrap();
+        assert!(q.name.is_none());
+        assert!(q.email.is_none());
+    }
+
+    #[test]
+    fn test_login_query_with_params() {
+        let q: TestLoginQuery =
+            serde_json::from_str(r#"{"name":"Test","email":"test@example.com"}"#).unwrap();
+        assert_eq!(q.name.unwrap(), "Test");
+        assert_eq!(q.email.unwrap(), "test@example.com");
+    }
+
+    // --- AuthStatus serialization ---
+
+    #[test]
+    fn auth_status_includes_test_sso_field() {
+        let status = AuthStatus {
+            authenticated: false,
+            oidc_configured: true,
+            test_sso_available: true,
+            person: None,
+        };
+        let json = serde_json::to_value(&status).unwrap();
+        assert_eq!(json["test_sso_available"], true);
+    }
+
+    #[test]
+    fn auth_status_test_sso_false() {
+        let status = AuthStatus {
+            authenticated: false,
+            oidc_configured: true,
+            test_sso_available: false,
+            person: None,
+        };
+        let json = serde_json::to_value(&status).unwrap();
+        assert_eq!(json["test_sso_available"], false);
     }
 }

--- a/packages/auth/src/lib.rs
+++ b/packages/auth/src/lib.rs
@@ -24,6 +24,12 @@ pub trait OidcAppState: Clone + Send + Sync + 'static {
     fn is_auth_enabled(&self) -> bool;
     fn base_url(&self) -> Option<&str>;
     fn http_client(&self) -> &reqwest::Client;
+
+    /// Whether test SSO is available (for PR/test deployments).
+    /// Defaults to `false`; override in services that support it.
+    fn is_test_sso_enabled(&self) -> bool {
+        false
+    }
 }
 
 /// Build the standard auth routes (login, callback, logout, status)
@@ -34,4 +40,5 @@ pub fn auth_routes<S: OidcAppState>() -> Router<S> {
         .route("/auth/callback", get(handlers::callback::<S>))
         .route("/auth/logout", get(handlers::logout::<S>))
         .route("/auth/status", get(handlers::status::<S>))
+        .route("/auth/test-login", get(handlers::test_login::<S>))
 }


### PR DESCRIPTION
## Summary

- Adds `/auth/fake-login` endpoint that creates an authenticated session without real OIDC
- Frontend shows a login choice screen when fake SSO is available (real SSO vs test login)
- Configurable test user via query params (`?name=...&email=...`)
- Production guard: refuses to start if `FAKE_SSO=true` and `DEPLOYMENT_NAME=regelrecht`

## Motivation

In PR deployments the real Keycloak SSO requires 2FA and a government account. This makes it impossible for automated Claude agents to test authenticated endpoints, and prevents testing with different user profiles.

## Configuration

Set `FAKE_SSO=true` as environment variable in PR deployments. No other changes needed.

## Test plan

- [ ] `just build-check` passes
- [ ] `just format && just lint` clean
- [ ] Unit tests pass (5 config tests + 4 auth tests)
- [ ] Manual test: visit admin panel with `FAKE_SSO=true` → login choice screen appears
- [ ] Manual test: click "Test Login" → authenticated as fake user
- [ ] Manual test: real SSO button still works alongside fake login
- [ ] Verify production guard: `FAKE_SSO=true DEPLOYMENT_NAME=regelrecht` → app refuses to start