### PR TITLE
fix(pipeline): merge development into enrichment branch before enriching

### DIFF
--- a/packages/corpus/src/client.rs
+++ b/packages/corpus/src/client.rs
@@ -322,45 +322,39 @@ impl CorpusClient {
         Ok(())
     }
 
-    /// Fetch a base branch and merge it into the current branch.
+    /// Fetch a base branch and check out specific paths from it into the
+    /// current working tree.
     ///
     /// Used by the enricher to pull in newly harvested laws from `development`
     /// into long-lived enrichment branches (`enrich/opencode`, `enrich/claude`).
     /// Without this, laws harvested after the enrichment branch was created
     /// would be missing from the checkout.
     ///
-    /// Uses `--allow-unrelated-histories` because shallow clones lack a common
-    /// ancestor. Merge conflicts are not expected (enrichment only adds
-    /// `machine_readable` sections while harvesting adds new law files).
-    pub async fn merge_base_branch(&self, base_branch: &str) -> Result<()> {
+    /// Unlike a merge, this does **not** create a merge commit. The checked-out
+    /// files become staged changes on the current branch. When the enrichment
+    /// later commits, the new law file and its `machine_readable` additions
+    /// appear together in a single commit — which survives `git rebase` cleanly.
+    pub async fn checkout_from_branch(&self, base_branch: &str, paths: &[&str]) -> Result<()> {
         self.run_git(&["fetch", "--depth", "1", "origin", base_branch])
             .await?;
 
         let remote_ref = format!("origin/{base_branch}");
-        let result = self
-            .run_git(&[
-                "merge",
-                &remote_ref,
-                "--allow-unrelated-histories",
-                "--no-edit",
-            ])
-            .await;
+        let mut args = vec!["checkout", &remote_ref, "--"];
+        args.extend(paths);
+        self.run_git(&args).await?;
 
-        match result {
-            Ok(()) => {
-                tracing::info!(
-                    base = %base_branch,
-                    branch = %self.config.branch,
-                    "merged base branch into enrichment branch"
-                );
-                Ok(())
-            }
-            Err(e) => {
-                // Abort the merge to leave the working tree clean for the next attempt.
-                let _ = self.run_git(&["merge", "--abort"]).await;
-                Err(e)
-            }
-        }
+        // Unstage the checked-out files so they don't pollute an empty
+        // `git status --porcelain` check before the enrichment commits.
+        let mut reset_args = vec!["reset", "HEAD", "--"];
+        reset_args.extend(paths);
+        self.run_git(&reset_args).await?;
+
+        tracing::info!(
+            base = %base_branch,
+            paths = ?paths,
+            "checked out paths from base branch"
+        );
+        Ok(())
     }
 
     async fn configure_git_user(&self) -> Result<()> {
@@ -830,7 +824,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_merge_base_branch_incorporates_new_files() {
+    async fn test_checkout_from_branch_incorporates_new_files() {
         let dir = tempfile::tempdir().unwrap();
         let bare_path = setup_bare_repo(dir.path()).await;
         let bare_url = format!("file://{}", bare_path.display());
@@ -869,8 +863,11 @@ mod tests {
             .join("regulation/nl/wet/new_law/2025-01-01.yaml")
             .exists());
 
-        // Merge development — new law should now be present
-        client.merge_base_branch("development").await.unwrap();
+        // Checkout the law dir from development — file should now be present
+        client
+            .checkout_from_branch("development", &["regulation/nl/wet/new_law"])
+            .await
+            .unwrap();
         assert!(repo_path
             .join("regulation/nl/wet/new_law/2025-01-01.yaml")
             .exists());

--- a/packages/corpus/src/client.rs
+++ b/packages/corpus/src/client.rs
@@ -331,7 +331,7 @@ impl CorpusClient {
     /// would be missing from the checkout.
     ///
     /// Unlike a merge, this does **not** create a merge commit. The checked-out
-    /// files become staged changes on the current branch. When the enrichment
+    /// files are left as unstaged working-tree changes. When the enrichment
     /// later commits, the new law file and its `machine_readable` additions
     /// appear together in a single commit — which survives `git rebase` cleanly.
     pub async fn checkout_from_branch(&self, base_branch: &str, paths: &[&str]) -> Result<()> {
@@ -903,6 +903,83 @@ mod tests {
             !status_str.contains("A "),
             "file should not be staged: {status_str}"
         );
+    }
+
+    #[tokio::test]
+    async fn test_checkout_from_branch_fetches_new_version_when_old_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        let bare_path = setup_bare_repo(dir.path()).await;
+        let bare_url = format!("file://{}", bare_path.display());
+
+        // Push an old version of a law to development
+        let tmp = dir.path().join("setup");
+        clone_with_config(&bare_path, &tmp).await;
+        let law_dir = tmp.join("regulation/nl/wet/some_law");
+        tokio::fs::create_dir_all(&law_dir).await.unwrap();
+        tokio::fs::write(law_dir.join("2024-01-01.yaml"), "old version")
+            .await
+            .unwrap();
+        for args in [
+            vec!["add", "."],
+            vec!["commit", "-m", "harvest old version"],
+            vec!["push", "origin", "development"],
+        ] {
+            Command::new("git")
+                .args(&args)
+                .current_dir(&tmp)
+                .output()
+                .await
+                .unwrap();
+        }
+
+        // Create enrichment branch (inherits old version from development)
+        let repo_path = dir.path().join("enrich-clone");
+        let mut config = CorpusConfig::new(&bare_url, &repo_path);
+        config.branch = "enrich/test".into();
+        let mut client = CorpusClient::new(config);
+        client.ensure_repo().await.unwrap();
+        assert!(repo_path
+            .join("regulation/nl/wet/some_law/2024-01-01.yaml")
+            .exists());
+
+        // Push a NEW version to development
+        tokio::fs::write(law_dir.join("2025-01-01.yaml"), "new version")
+            .await
+            .unwrap();
+        for args in [
+            vec!["add", "."],
+            vec!["commit", "-m", "harvest new version"],
+            vec!["push", "origin", "development"],
+        ] {
+            Command::new("git")
+                .args(&args)
+                .current_dir(&tmp)
+                .output()
+                .await
+                .unwrap();
+        }
+
+        // New version should NOT be on the enrichment branch yet
+        assert!(!repo_path
+            .join("regulation/nl/wet/some_law/2025-01-01.yaml")
+            .exists());
+
+        // Checkout the specific new file (not the directory!)
+        client
+            .checkout_from_branch(
+                "development",
+                &["regulation/nl/wet/some_law/2025-01-01.yaml"],
+            )
+            .await
+            .unwrap();
+
+        // New version present, old version still intact
+        assert!(repo_path
+            .join("regulation/nl/wet/some_law/2025-01-01.yaml")
+            .exists());
+        assert!(repo_path
+            .join("regulation/nl/wet/some_law/2024-01-01.yaml")
+            .exists());
     }
 
     #[tokio::test]

--- a/packages/corpus/src/client.rs
+++ b/packages/corpus/src/client.rs
@@ -335,23 +335,41 @@ impl CorpusClient {
     /// later commits, the new law file and its `machine_readable` additions
     /// appear together in a single commit — which survives `git rebase` cleanly.
     pub async fn checkout_from_branch(&self, base_branch: &str, paths: &[&str]) -> Result<()> {
+        // Skip paths already tracked on this branch to avoid overwriting
+        // enrichment-branch content (e.g. prior machine_readable additions)
+        // with the raw development version.
+        let mut missing: Vec<&str> = Vec::new();
+        for path in paths {
+            if self
+                .run_git(&["ls-files", "--error-unmatch", "--", path])
+                .await
+                .is_err()
+            {
+                missing.push(path);
+            }
+        }
+        if missing.is_empty() {
+            tracing::debug!(paths = ?paths, "all paths already tracked, skipping checkout from base");
+            return Ok(());
+        }
+
         self.run_git(&["fetch", "--depth", "1", "origin", base_branch])
             .await?;
 
         let remote_ref = format!("origin/{base_branch}");
         let mut args = vec!["checkout", &remote_ref, "--"];
-        args.extend(paths);
+        args.extend(&missing);
         self.run_git(&args).await?;
 
         // Unstage the checked-out files so they don't pollute an empty
         // `git status --porcelain` check before the enrichment commits.
         let mut reset_args = vec!["reset", "HEAD", "--"];
-        reset_args.extend(paths);
+        reset_args.extend(&missing);
         self.run_git(&reset_args).await?;
 
         tracing::info!(
             base = %base_branch,
-            paths = ?paths,
+            paths = ?missing,
             "checked out paths from base branch"
         );
         Ok(())
@@ -871,6 +889,20 @@ mod tests {
         assert!(repo_path
             .join("regulation/nl/wet/new_law/2025-01-01.yaml")
             .exists());
+
+        // The file should be unstaged (reset HEAD) so git status is clean.
+        // This prevents commit_and_push from seeing spurious staged changes.
+        let status = Command::new("git")
+            .args(["status", "--porcelain"])
+            .current_dir(&repo_path)
+            .output()
+            .await
+            .unwrap();
+        let status_str = String::from_utf8_lossy(&status.stdout);
+        assert!(
+            !status_str.contains("A "),
+            "file should not be staged: {status_str}"
+        );
     }
 
     #[tokio::test]

--- a/packages/corpus/src/client.rs
+++ b/packages/corpus/src/client.rs
@@ -881,17 +881,22 @@ mod tests {
             .join("regulation/nl/wet/new_law/2025-01-01.yaml")
             .exists());
 
-        // Checkout the law dir from development — file should now be present
+        // Checkout the specific file from development (matches production code path)
         client
-            .checkout_from_branch("development", &["regulation/nl/wet/new_law"])
+            .checkout_from_branch(
+                "development",
+                &["regulation/nl/wet/new_law/2025-01-01.yaml"],
+            )
             .await
             .unwrap();
         assert!(repo_path
             .join("regulation/nl/wet/new_law/2025-01-01.yaml")
             .exists());
 
-        // The file should be unstaged (reset HEAD) so git status is clean.
-        // This prevents commit_and_push from seeing spurious staged changes.
+        // Unstaged so the file appears as `??` (untracked) rather than `A`
+        // (staged-new). commit_and_push uses explicit `git add -- <paths>`
+        // which picks up untracked files, so the machine_readable additions
+        // and new file land in the same commit.
         let status = Command::new("git")
             .args(["status", "--porcelain"])
             .current_dir(&repo_path)
@@ -902,6 +907,68 @@ mod tests {
         assert!(
             !status_str.contains("A "),
             "file should not be staged: {status_str}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_checkout_from_branch_skips_already_tracked_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let bare_path = setup_bare_repo(dir.path()).await;
+        let bare_url = format!("file://{}", bare_path.display());
+
+        // Push a law file to development
+        let tmp = dir.path().join("setup");
+        clone_with_config(&bare_path, &tmp).await;
+        let law_dir = tmp.join("regulation/nl/wet/enriched_law");
+        tokio::fs::create_dir_all(&law_dir).await.unwrap();
+        tokio::fs::write(law_dir.join("2025-01-01.yaml"), "raw content")
+            .await
+            .unwrap();
+        for args in [
+            vec!["add", "."],
+            vec!["commit", "-m", "harvest law"],
+            vec!["push", "origin", "development"],
+        ] {
+            Command::new("git")
+                .args(&args)
+                .current_dir(&tmp)
+                .output()
+                .await
+                .unwrap();
+        }
+
+        // Create enrichment branch (inherits the law from development)
+        let repo_path = dir.path().join("enrich-clone");
+        let mut config = CorpusConfig::new(&bare_url, &repo_path);
+        config.branch = "enrich/test".into();
+        let mut client = CorpusClient::new(config);
+        client.ensure_repo().await.unwrap();
+
+        // Simulate enrichment: modify the file with machine_readable content
+        let yaml_path = repo_path.join("regulation/nl/wet/enriched_law/2025-01-01.yaml");
+        tokio::fs::write(&yaml_path, "enriched content with machine_readable")
+            .await
+            .unwrap();
+        client
+            .commit_and_push(&[yaml_path.clone()], "enrich: add machine_readable")
+            .await
+            .unwrap();
+
+        // Now call checkout_from_branch — it should SKIP the file because
+        // it's already tracked on the enrichment branch
+        client
+            .checkout_from_branch(
+                "development",
+                &["regulation/nl/wet/enriched_law/2025-01-01.yaml"],
+            )
+            .await
+            .unwrap();
+
+        // File content should still be the enriched version, NOT overwritten
+        let content = tokio::fs::read_to_string(&yaml_path).await.unwrap();
+        assert_eq!(
+            content, "enriched content with machine_readable",
+            "already-tracked file should not be overwritten by development version"
         );
     }
 

--- a/packages/corpus/src/client.rs
+++ b/packages/corpus/src/client.rs
@@ -322,9 +322,7 @@ impl CorpusClient {
         Ok(())
     }
 
-    /// Fetch `base_branch` and check out `paths` from it without a merge commit,
-    /// leaving the files unstaged so they land in the enrichment's own commit
-    /// and survive `commit_and_push`'s `pull --rebase`.
+    /// Pull `paths` from `base_branch` into the working tree without a merge commit, leaving them unstaged so the next `commit_and_push` absorbs them.
     pub async fn checkout_from_branch(&self, base_branch: &str, paths: &[&str]) -> Result<()> {
         // Skip already-tracked paths so prior machine_readable additions
         // aren't overwritten by the raw base-branch version.

--- a/packages/corpus/src/client.rs
+++ b/packages/corpus/src/client.rs
@@ -322,25 +322,12 @@ impl CorpusClient {
         Ok(())
     }
 
-    /// Fetch a base branch and check out specific paths from it into the
-    /// current working tree.
-    ///
-    /// Used by the enricher to pull in newly harvested laws from `development`
-    /// into long-lived enrichment branches (`enrich/opencode`, `enrich/claude`).
-    /// Without this, laws harvested after the enrichment branch was created
-    /// would be missing from the checkout.
-    ///
-    /// Unlike a merge, this does **not** create a merge commit. The checked-out
-    /// files are left as unstaged working-tree changes. When the enrichment
-    /// later commits, the new law file and its `machine_readable` additions
-    /// appear together in a single commit — which survives `git rebase` cleanly.
+    /// Fetch `base_branch` and check out `paths` from it without a merge commit,
+    /// leaving the files unstaged so they land in the enrichment's own commit
+    /// and survive `commit_and_push`'s `pull --rebase`.
     pub async fn checkout_from_branch(&self, base_branch: &str, paths: &[&str]) -> Result<()> {
-        // Skip paths already tracked on this branch to avoid overwriting
-        // enrichment-branch content (e.g. prior machine_readable additions)
-        // with the raw development version. `ls-files` without
-        // `--error-unmatch` returns empty stdout for untracked paths and
-        // exits non-zero only on genuine git failures, so transient errors
-        // propagate instead of being silently treated as "file missing".
+        // Skip already-tracked paths so prior machine_readable additions
+        // aren't overwritten by the raw base-branch version.
         let mut missing: Vec<&str> = Vec::new();
         for path in paths {
             let listed = self.run_git_output(&["ls-files", "--", path]).await?;

--- a/packages/corpus/src/client.rs
+++ b/packages/corpus/src/client.rs
@@ -322,6 +322,47 @@ impl CorpusClient {
         Ok(())
     }
 
+    /// Fetch a base branch and merge it into the current branch.
+    ///
+    /// Used by the enricher to pull in newly harvested laws from `development`
+    /// into long-lived enrichment branches (`enrich/opencode`, `enrich/claude`).
+    /// Without this, laws harvested after the enrichment branch was created
+    /// would be missing from the checkout.
+    ///
+    /// Uses `--allow-unrelated-histories` because shallow clones lack a common
+    /// ancestor. Merge conflicts are not expected (enrichment only adds
+    /// `machine_readable` sections while harvesting adds new law files).
+    pub async fn merge_base_branch(&self, base_branch: &str) -> Result<()> {
+        self.run_git(&["fetch", "--depth", "1", "origin", base_branch])
+            .await?;
+
+        let remote_ref = format!("origin/{base_branch}");
+        let result = self
+            .run_git(&[
+                "merge",
+                &remote_ref,
+                "--allow-unrelated-histories",
+                "--no-edit",
+            ])
+            .await;
+
+        match result {
+            Ok(()) => {
+                tracing::info!(
+                    base = %base_branch,
+                    branch = %self.config.branch,
+                    "merged base branch into enrichment branch"
+                );
+                Ok(())
+            }
+            Err(e) => {
+                // Abort the merge to leave the working tree clean for the next attempt.
+                let _ = self.run_git(&["merge", "--abort"]).await;
+                Err(e)
+            }
+        }
+    }
+
     async fn configure_git_user(&self) -> Result<()> {
         self.run_git(&["config", "user.name", &self.config.git_author_name])
             .await?;

--- a/packages/corpus/src/client.rs
+++ b/packages/corpus/src/client.rs
@@ -337,14 +337,14 @@ impl CorpusClient {
     pub async fn checkout_from_branch(&self, base_branch: &str, paths: &[&str]) -> Result<()> {
         // Skip paths already tracked on this branch to avoid overwriting
         // enrichment-branch content (e.g. prior machine_readable additions)
-        // with the raw development version.
+        // with the raw development version. `ls-files` without
+        // `--error-unmatch` returns empty stdout for untracked paths and
+        // exits non-zero only on genuine git failures, so transient errors
+        // propagate instead of being silently treated as "file missing".
         let mut missing: Vec<&str> = Vec::new();
         for path in paths {
-            if self
-                .run_git(&["ls-files", "--error-unmatch", "--", path])
-                .await
-                .is_err()
-            {
+            let listed = self.run_git_output(&["ls-files", "--", path]).await?;
+            if listed.trim().is_empty() {
                 missing.push(path);
             }
         }

--- a/packages/corpus/src/client.rs
+++ b/packages/corpus/src/client.rs
@@ -898,7 +898,7 @@ mod tests {
         // which picks up untracked files, so the machine_readable additions
         // and new file land in the same commit.
         let status = Command::new("git")
-            .args(["status", "--porcelain"])
+            .args(["status", "--porcelain", "--untracked-files=all"])
             .current_dir(&repo_path)
             .output()
             .await
@@ -907,6 +907,10 @@ mod tests {
         assert!(
             !status_str.contains("A "),
             "file should not be staged: {status_str}"
+        );
+        assert!(
+            status_str.contains("?? regulation/nl/wet/new_law/2025-01-01.yaml"),
+            "file should be untracked: {status_str}"
         );
     }
 

--- a/packages/corpus/src/client.rs
+++ b/packages/corpus/src/client.rs
@@ -830,6 +830,53 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_merge_base_branch_incorporates_new_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let bare_path = setup_bare_repo(dir.path()).await;
+        let bare_url = format!("file://{}", bare_path.display());
+
+        // ensure_repo with a non-existent branch creates it from development
+        // (mirrors production: enrichment branches are born from development)
+        let repo_path = dir.path().join("enrich-clone");
+        let mut config = CorpusConfig::new(&bare_url, &repo_path);
+        config.branch = "enrich/test".into();
+        let mut client = CorpusClient::new(config);
+        client.ensure_repo().await.unwrap();
+
+        // Push a new file to development (simulating a harvested law)
+        let tmp = dir.path().join("setup");
+        clone_with_config(&bare_path, &tmp).await;
+        let new_law = tmp.join("regulation/nl/wet/new_law");
+        tokio::fs::create_dir_all(&new_law).await.unwrap();
+        tokio::fs::write(new_law.join("2025-01-01.yaml"), "new law content")
+            .await
+            .unwrap();
+        for args in [
+            vec!["add", "."],
+            vec!["commit", "-m", "harvest new law"],
+            vec!["push", "origin", "development"],
+        ] {
+            Command::new("git")
+                .args(&args)
+                .current_dir(&tmp)
+                .output()
+                .await
+                .unwrap();
+        }
+
+        // The new law should NOT be present on the enrichment branch yet
+        assert!(!repo_path
+            .join("regulation/nl/wet/new_law/2025-01-01.yaml")
+            .exists());
+
+        // Merge development — new law should now be present
+        client.merge_base_branch("development").await.unwrap();
+        assert!(repo_path
+            .join("regulation/nl/wet/new_law/2025-01-01.yaml")
+            .exists());
+    }
+
+    #[tokio::test]
     async fn test_ensure_repo_creates_branch_if_missing() {
         let dir = tempfile::tempdir().unwrap();
         let repo_path = dir.path().join("corpus");

--- a/packages/pipeline/src/enrich.rs
+++ b/packages/pipeline/src/enrich.rs
@@ -414,12 +414,16 @@ pub async fn create_enrich_corpus(
     // an absolute path it cannot handle.
     let normalized = normalize_yaml_path(yaml_path)?;
 
+    // Derive the law directory once — used for both sparse checkout and
+    // checking out missing files from development.
+    let law_dir = Path::new(&normalized)
+        .parent()
+        .map(|p| p.to_string_lossy().to_string())
+        .filter(|d| !d.is_empty());
+
     // Sparse checkout: only the law directory + features/
-    if let Some(law_dir) = Path::new(&normalized).parent() {
-        let law_dir_str = law_dir.to_string_lossy().to_string();
-        if !law_dir_str.is_empty() {
-            config.sparse_paths = Some(vec![law_dir_str, "features".to_string()]);
-        }
+    if let Some(ref dir) = law_dir {
+        config.sparse_paths = Some(vec![dir.clone(), "features".to_string()]);
     }
 
     // Use a separate checkout directory per branch + job to avoid conflicts
@@ -441,10 +445,7 @@ pub async fn create_enrich_corpus(
     //
     // Uses checkout (not merge) so the file addition ends up in the same
     // commit as the enrichment — which survives `git rebase` in commit_and_push.
-    let law_dir = Path::new(&normalized)
-        .parent()
-        .map(|p| p.to_string_lossy().to_string());
-    if let Some(ref dir) = law_dir.filter(|d| !d.is_empty()) {
+    if let Some(ref dir) = law_dir {
         client.checkout_from_branch("development", &[dir]).await?;
     }
 

--- a/packages/pipeline/src/enrich.rs
+++ b/packages/pipeline/src/enrich.rs
@@ -434,6 +434,12 @@ pub async fn create_enrich_corpus(
 
     let mut client = CorpusClient::new(config);
     client.ensure_repo().await?;
+
+    // Merge development into the enrichment branch so newly harvested laws
+    // are available. Without this, laws harvested after the enrichment branch
+    // was created would be missing and cause "file not found" errors.
+    client.merge_base_branch("development").await?;
+
     Ok(client)
 }
 

--- a/packages/pipeline/src/enrich.rs
+++ b/packages/pipeline/src/enrich.rs
@@ -435,10 +435,18 @@ pub async fn create_enrich_corpus(
     let mut client = CorpusClient::new(config);
     client.ensure_repo().await?;
 
-    // Merge development into the enrichment branch so newly harvested laws
+    // Check out the law directory from development so newly harvested laws
     // are available. Without this, laws harvested after the enrichment branch
     // was created would be missing and cause "file not found" errors.
-    client.merge_base_branch("development").await?;
+    //
+    // Uses checkout (not merge) so the file addition ends up in the same
+    // commit as the enrichment — which survives `git rebase` in commit_and_push.
+    let law_dir = Path::new(&normalized)
+        .parent()
+        .map(|p| p.to_string_lossy().to_string());
+    if let Some(ref dir) = law_dir {
+        client.checkout_from_branch("development", &[dir]).await?;
+    }
 
     Ok(client)
 }

--- a/packages/pipeline/src/enrich.rs
+++ b/packages/pipeline/src/enrich.rs
@@ -414,8 +414,6 @@ pub async fn create_enrich_corpus(
     // an absolute path it cannot handle.
     let normalized = normalize_yaml_path(yaml_path)?;
 
-    // Derive the law directory once — used for both sparse checkout and
-    // checking out missing files from development.
     let law_dir = Path::new(&normalized)
         .parent()
         .map(|p| p.to_string_lossy().to_string())
@@ -439,16 +437,9 @@ pub async fn create_enrich_corpus(
     let mut client = CorpusClient::new(config);
     client.ensure_repo().await?;
 
-    // Check out the specific law file from development so newly harvested
-    // laws are available. Without this, laws harvested after the enrichment
-    // branch was created would be missing and cause "file not found" errors.
-    //
-    // Uses the file path (not directory) so `ls-files --error-unmatch` checks
-    // the exact file. A directory check would pass if any older version exists,
-    // missing newly harvested versions of the same law.
-    //
-    // Uses checkout (not merge) so the file addition ends up in the same
-    // commit as the enrichment — which survives `git rebase` in commit_and_push.
+    // Pull the exact file (not the directory) from development so a newly
+    // harvested version of an already-known law isn't mistaken for "tracked"
+    // by the directory-level check inside checkout_from_branch.
     client
         .checkout_from_branch("development", &[&normalized])
         .await?;

--- a/packages/pipeline/src/enrich.rs
+++ b/packages/pipeline/src/enrich.rs
@@ -437,9 +437,9 @@ pub async fn create_enrich_corpus(
     let mut client = CorpusClient::new(config);
     client.ensure_repo().await?;
 
-    // Pull the exact file (not the directory) from development so a newly
-    // harvested version of an already-known law isn't mistaken for "tracked"
-    // by the directory-level check inside checkout_from_branch.
+    // Pass the exact file path (not the directory) so the `ls-files` guard
+    // inside `checkout_from_branch` doesn't match sibling files and skip
+    // fetching a newly harvested version of an already-known law.
     client
         .checkout_from_branch("development", &[&normalized])
         .await?;

--- a/packages/pipeline/src/enrich.rs
+++ b/packages/pipeline/src/enrich.rs
@@ -444,7 +444,7 @@ pub async fn create_enrich_corpus(
     let law_dir = Path::new(&normalized)
         .parent()
         .map(|p| p.to_string_lossy().to_string());
-    if let Some(ref dir) = law_dir {
+    if let Some(ref dir) = law_dir.filter(|d| !d.is_empty()) {
         client.checkout_from_branch("development", &[dir]).await?;
     }
 

--- a/packages/pipeline/src/enrich.rs
+++ b/packages/pipeline/src/enrich.rs
@@ -439,15 +439,19 @@ pub async fn create_enrich_corpus(
     let mut client = CorpusClient::new(config);
     client.ensure_repo().await?;
 
-    // Check out the law directory from development so newly harvested laws
-    // are available. Without this, laws harvested after the enrichment branch
-    // was created would be missing and cause "file not found" errors.
+    // Check out the specific law file from development so newly harvested
+    // laws are available. Without this, laws harvested after the enrichment
+    // branch was created would be missing and cause "file not found" errors.
+    //
+    // Uses the file path (not directory) so `ls-files --error-unmatch` checks
+    // the exact file. A directory check would pass if any older version exists,
+    // missing newly harvested versions of the same law.
     //
     // Uses checkout (not merge) so the file addition ends up in the same
     // commit as the enrichment — which survives `git rebase` in commit_and_push.
-    if let Some(ref dir) = law_dir {
-        client.checkout_from_branch("development", &[dir]).await?;
-    }
+    client
+        .checkout_from_branch("development", &[&normalized])
+        .await?;
 
     Ok(client)
 }


### PR DESCRIPTION
## Summary

- Adds `checkout_from_branch()` to `CorpusClient` that fetches a base branch and checks out specific file paths from it (skipping paths already tracked on the current branch)
- Calls it in `create_enrich_corpus()` to pull the law file from `development` into the enrichment branch before starting enrichment, so the new file lands in the same commit as the `machine_readable` additions

## Problem

The enricher clones the `enrich/{provider}` branch directly. This branch was created from `development` at some point, but never receives new laws that the harvester pushes to `development` afterwards. Result: "law YAML file not found" errors for recently harvested laws.

## Approach

File-level checkout (not a merge) so no merge commit is introduced. `git rebase` inside `commit_and_push` would otherwise drop the merge commit and fail to push. The `ls-files --error-unmatch` guard skips paths already tracked on the enrichment branch, so previously enriched content is never overwritten by the raw development version.

## Test plan

- [x] `just build-check` passes
- [x] `just pipeline-test` — 23 tests pass
- [x] `just format` + `just lint` pass
- [ ] Deploy to preview and verify enrichment succeeds for laws that previously failed with "file not found"