### PR TITLE
feat(harvester): add CVDR harvesting for decentrale regelgeving

### DIFF
--- a/.claude/skills/law-download/download_law.py
+++ b/.claude/skills/law-download/download_law.py
@@ -73,7 +73,6 @@ def parse_wti_metadata(wti_tree):
         "GRONDWET", "WET", "AMVB", "KONINKLIJK_BESLUIT", "MINISTERIELE_REGELING",
         "BELEIDSREGEL", "EU_VERORDENING", "EU_RICHTLIJN", "VERDRAG",
         "UITVOERINGSBELEID", "GEMEENTELIJKE_VERORDENING", "PROVINCIALE_VERORDENING",
-        "WATERSCHAPS_VERORDENING",
     }
     soort = wti_tree.find(f".//{{{NS}}}soort-regeling")
     if soort is not None:
@@ -91,7 +90,7 @@ def parse_wti_metadata(wti_tree):
         if layer not in VALID_LAYERS:
             raise ValueError(
                 f"'{soort_text}' maps to '{layer}' which is not a valid "
-                f"a valid regulatory_layer. Map manually to e.g. AMVB."
+                f"schema v0.5.0 regulatory_layer. Map manually to e.g. AMVB."
             )
         metadata["regulatory_layer"] = layer
 

--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -3598,8 +3598,8 @@ dependencies = [
  "prometheus-client",
  "regelrecht-auth",
  "regelrecht-corpus",
+ "regelrecht-harvester",
  "regelrecht-pipeline",
- "regex",
  "reqwest 0.12.28",
  "rsa",
  "serde",
@@ -3722,6 +3722,7 @@ dependencies = [
 name = "regelrecht-harvester"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "chrono",
  "clap",
  "console",

--- a/packages/admin/Cargo.toml
+++ b/packages/admin/Cargo.toml
@@ -20,6 +20,7 @@ axum = "0.8"
 regelrecht-auth = { path = "../auth" }
 sqlx = { version = "0.8", features = ["runtime-tokio", "tls-rustls", "postgres", "uuid", "chrono"] }
 regelrecht-corpus = { path = "../corpus", default-features = false }
+regelrecht-harvester = { path = "../harvester" }
 regelrecht-pipeline = { path = "../pipeline" }
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1", features = ["serde"] }
@@ -27,7 +28,6 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tower-http = { version = "0.6", features = ["fs", "trace"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-regex = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 openidconnect = "4.0"

--- a/packages/admin/frontend-src/src/components/JobCreation.vue
+++ b/packages/admin/frontend-src/src/components/JobCreation.vue
@@ -23,10 +23,10 @@ async function onSubmit() {
   if (submitting.value) return;
   const el = inputRef.value;
   if (!el) return;
-  const bwbId = getFieldValue(el).trim();
-  if (!bwbId) return;
-  if (!/^BWBR\d{7}$/.test(bwbId)) {
-    alert('BWB ID format: BWBR followed by 7 digits (e.g. BWBR0018451)');
+  const lawId = getFieldValue(el).trim();
+  if (!lawId) return;
+  if (!/^BWBR\d{7}$/.test(lawId) && !/^CVDR\d{3,}$/.test(lawId)) {
+    alert('Expected a BWB ID (e.g. BWBR0018451) or CVDR ID (e.g. CVDR681386)');
     return;
   }
 
@@ -37,7 +37,7 @@ async function onSubmit() {
     const response = await fetch('api/harvest-jobs', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ bwb_id: bwbId }),
+      body: JSON.stringify({ law_id: lawId }),
     });
     if (response.status === 401) {
       redirectToLogin();
@@ -75,7 +75,7 @@ function onKeydown(e) {
     <ndd-text-field
       ref="inputRef"
       size="md"
-      placeholder="BWB ID (e.g. BWBR0018451)"
+      placeholder="BWB or CVDR ID (e.g. BWBR0018451, CVDR681386)"
       @keydown="onKeydown"
     />
     <ndd-button

--- a/packages/admin/src/handlers.rs
+++ b/packages/admin/src/handlers.rs
@@ -439,14 +439,9 @@ pub async fn create_harvest_job(
         ));
     }
 
-    let source = regelrecht_harvester::detect_source(&raw_id).map_err(|e| {
+    // detect_source validates the ID format (prefix + digit count)
+    regelrecht_harvester::detect_source(&raw_id).map_err(|e| {
         tracing::debug!(law_id = %raw_id, error = %e, "rejected invalid law ID");
-        ApiError::BadRequest(format!("invalid law ID format: {e}"))
-    })?;
-
-    // Validate the ID against the source-specific rules (e.g. exact digit count for BWB).
-    source.validate_id(&raw_id).map_err(|e| {
-        tracing::debug!(law_id = %raw_id, error = %e, "law ID validation failed");
         ApiError::BadRequest(format!("invalid law ID: {e}"))
     })?;
 
@@ -531,23 +526,7 @@ pub async fn create_harvest_job(
         ApiError::Internal("failed to upsert law entry".to_string())
     })?;
 
-    let payload = if source.name() == "BWB" {
-        HarvestPayload {
-            bwb_id: Some(law_id.clone()),
-            cvdr_id: None,
-            date: body.date,
-            max_size_mb: None,
-            depth: None,
-        }
-    } else {
-        HarvestPayload {
-            bwb_id: None,
-            cvdr_id: Some(law_id.clone()),
-            date: body.date,
-            max_size_mb: None,
-            depth: None,
-        }
-    };
+    let payload = HarvestPayload::for_law(&law_id, body.date);
 
     let priority = Priority::new(body.priority.unwrap_or(50));
 
@@ -1081,15 +1060,14 @@ mod tests {
 
     #[test]
     fn validate_bwb_id_too_few_digits() {
-        // detect_source succeeds on prefix, but validate_id rejects bad format
-        let source = regelrecht_harvester::detect_source("BWBR123").unwrap();
-        assert!(source.validate_id("BWBR123").is_err());
+        // detect_source validates internally — short BWB IDs are rejected
+        assert!(regelrecht_harvester::detect_source("BWBR123").is_err());
     }
 
     #[test]
     fn validate_cvdr_id_too_few_digits() {
-        let source = regelrecht_harvester::detect_source("CVDR12").unwrap();
-        assert!(source.validate_id("CVDR12").is_err());
+        // detect_source validates internally — short CVDR IDs are rejected
+        assert!(regelrecht_harvester::detect_source("CVDR12").is_err());
     }
 
     #[test]

--- a/packages/admin/src/handlers.rs
+++ b/packages/admin/src/handlers.rs
@@ -1,5 +1,3 @@
-use std::sync::LazyLock;
-
 use axum::extract::{Query, State};
 use axum::http::StatusCode;
 use axum::Json;
@@ -8,7 +6,6 @@ use regelrecht_pipeline::job_queue::{
 };
 use regelrecht_pipeline::law_status::{set_enrich_job, set_harvest_job};
 use regelrecht_pipeline::{EnrichPayload, HarvestPayload, JobType, Priority, ENRICH_PROVIDERS};
-use regex::Regex;
 use serde::{Deserialize, Serialize};
 
 use crate::error::ApiError;
@@ -28,31 +25,6 @@ pub async fn platform_info() -> Json<PlatformInfo> {
         deployment_name: std::env::var("DEPLOYMENT_NAME").unwrap_or_default(),
         component_name: std::env::var("COMPONENT_NAME").unwrap_or_default(),
     })
-}
-
-#[allow(clippy::expect_used)]
-static BWB_ID_PATTERN: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^BWBR\d{7}$").expect("valid regex"));
-
-#[allow(clippy::expect_used)]
-static CVDR_ID_PATTERN: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^CVDR\d{3,}$").expect("valid regex"));
-
-/// Identifies the source type of a law identifier.
-enum LawIdType {
-    Bwb(String),
-    Cvdr(String),
-}
-
-/// Validate and classify a law identifier as BWB or CVDR.
-fn classify_law_id(id: &str) -> Option<LawIdType> {
-    if BWB_ID_PATTERN.is_match(id) {
-        Some(LawIdType::Bwb(id.to_string()))
-    } else if CVDR_ID_PATTERN.is_match(id) {
-        Some(LawIdType::Cvdr(id.to_string()))
-    } else {
-        None
-    }
 }
 
 /// Validate a sort column against an allowlist. Returns `None` if not allowed.
@@ -467,16 +439,18 @@ pub async fn create_harvest_job(
         ));
     }
 
-    let law_id_type = classify_law_id(&raw_id).ok_or_else(|| {
-        tracing::debug!(law_id = %raw_id, "rejected invalid law ID");
-        ApiError::BadRequest(
-            "invalid law ID format: expected BWBR followed by 7 digits, or CVDR followed by 3+ digits".to_string(),
-        )
+    let source = regelrecht_harvester::detect_source(&raw_id).map_err(|e| {
+        tracing::debug!(law_id = %raw_id, error = %e, "rejected invalid law ID");
+        ApiError::BadRequest(format!("invalid law ID format: {e}"))
     })?;
 
-    let law_id = match &law_id_type {
-        LawIdType::Bwb(id) | LawIdType::Cvdr(id) => id.clone(),
-    };
+    // Validate the ID against the source-specific rules (e.g. exact digit count for BWB).
+    source.validate_id(&raw_id).map_err(|e| {
+        tracing::debug!(law_id = %raw_id, error = %e, "law ID validation failed");
+        ApiError::BadRequest(format!("invalid law ID: {e}"))
+    })?;
+
+    let law_id = raw_id;
 
     if let Some(ref date) = body.date {
         if chrono::NaiveDate::parse_from_str(date, "%Y-%m-%d").is_err() {
@@ -557,21 +531,22 @@ pub async fn create_harvest_job(
         ApiError::Internal("failed to upsert law entry".to_string())
     })?;
 
-    let payload = match law_id_type {
-        LawIdType::Bwb(ref id) => HarvestPayload {
-            bwb_id: Some(id.clone()),
+    let payload = if source.name() == "BWB" {
+        HarvestPayload {
+            bwb_id: Some(law_id.clone()),
             cvdr_id: None,
             date: body.date,
             max_size_mb: None,
             depth: None,
-        },
-        LawIdType::Cvdr(ref id) => HarvestPayload {
+        }
+    } else {
+        HarvestPayload {
             bwb_id: None,
-            cvdr_id: Some(id.clone()),
+            cvdr_id: Some(law_id.clone()),
             date: body.date,
             max_size_mb: None,
             depth: None,
-        },
+        }
     };
 
     let priority = Priority::new(body.priority.unwrap_or(50));
@@ -1084,30 +1059,37 @@ mod tests {
         assert!(body.date.is_none());
     }
 
-    // --- classify_law_id ---
+    // --- detect_source (via harvester crate) ---
 
     #[test]
-    fn classify_bwb_id() {
-        assert!(matches!(
-            classify_law_id("BWBR0018451"),
-            Some(LawIdType::Bwb(_))
-        ));
+    fn detect_bwb_source() {
+        let source = regelrecht_harvester::detect_source("BWBR0018451").unwrap();
+        assert_eq!(source.name(), "BWB");
     }
 
     #[test]
-    fn classify_cvdr_id() {
-        assert!(matches!(
-            classify_law_id("CVDR681386"),
-            Some(LawIdType::Cvdr(_))
-        ));
+    fn detect_cvdr_source() {
+        let source = regelrecht_harvester::detect_source("CVDR681386").unwrap();
+        assert_eq!(source.name(), "CVDR");
     }
 
     #[test]
-    fn classify_invalid_id() {
-        assert!(classify_law_id("INVALID").is_none());
-        assert!(classify_law_id("").is_none());
-        assert!(classify_law_id("BWBR123").is_none()); // too few digits
-        assert!(classify_law_id("CVDR12").is_none()); // too few digits
+    fn detect_invalid_source() {
+        assert!(regelrecht_harvester::detect_source("INVALID").is_err());
+        assert!(regelrecht_harvester::detect_source("").is_err());
+    }
+
+    #[test]
+    fn validate_bwb_id_too_few_digits() {
+        // detect_source succeeds on prefix, but validate_id rejects bad format
+        let source = regelrecht_harvester::detect_source("BWBR123").unwrap();
+        assert!(source.validate_id("BWBR123").is_err());
+    }
+
+    #[test]
+    fn validate_cvdr_id_too_few_digits() {
+        let source = regelrecht_harvester::detect_source("CVDR12").unwrap();
+        assert!(source.validate_id("CVDR12").is_err());
     }
 
     #[test]

--- a/packages/admin/src/handlers.rs
+++ b/packages/admin/src/handlers.rs
@@ -34,6 +34,27 @@ pub async fn platform_info() -> Json<PlatformInfo> {
 static BWB_ID_PATTERN: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^BWBR\d{7}$").expect("valid regex"));
 
+#[allow(clippy::expect_used)]
+static CVDR_ID_PATTERN: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^CVDR\d{3,}$").expect("valid regex"));
+
+/// Identifies the source type of a law identifier.
+enum LawIdType {
+    Bwb(String),
+    Cvdr(String),
+}
+
+/// Validate and classify a law identifier as BWB or CVDR.
+fn classify_law_id(id: &str) -> Option<LawIdType> {
+    if BWB_ID_PATTERN.is_match(id) {
+        Some(LawIdType::Bwb(id.to_string()))
+    } else if CVDR_ID_PATTERN.is_match(id) {
+        Some(LawIdType::Cvdr(id.to_string()))
+    } else {
+        None
+    }
+}
+
 /// Validate a sort column against an allowlist. Returns `None` if not allowed.
 fn validated_sort_column<'a>(
     sort: Option<&'a str>,
@@ -414,7 +435,11 @@ pub async fn list_jobs_summary(
 
 #[derive(Deserialize)]
 pub struct CreateJobBody {
-    pub bwb_id: String,
+    /// Law identifier — BWB (e.g. "BWBR0018451") or CVDR (e.g. "CVDR681386").
+    /// Also accepts the legacy `bwb_id` field for backward compatibility.
+    pub law_id: Option<String>,
+    /// Legacy field — use `law_id` instead. If both are set, `law_id` takes precedence.
+    pub bwb_id: Option<String>,
     pub priority: Option<i32>,
     pub date: Option<String>,
 }
@@ -429,17 +454,29 @@ pub async fn create_harvest_job(
     State(state): State<AppState>,
     Json(body): Json<CreateJobBody>,
 ) -> Result<(StatusCode, Json<CreateJobResponse>), ApiError> {
-    let bwb_id = body.bwb_id.trim().to_string();
-    if bwb_id.is_empty() {
-        return Err(ApiError::BadRequest("bwb_id must not be empty".to_string()));
-    }
+    // Accept `law_id` with `bwb_id` as fallback for backward compatibility.
+    let raw_id = body
+        .law_id
+        .or(body.bwb_id)
+        .map(|s| s.trim().to_string())
+        .unwrap_or_default();
 
-    if !BWB_ID_PATTERN.is_match(&bwb_id) {
-        tracing::debug!(bwb_id, "rejected invalid BWB ID");
+    if raw_id.is_empty() {
         return Err(ApiError::BadRequest(
-            "invalid BWB ID format: expected BWBR followed by 7 digits".to_string(),
+            "law_id must not be empty (BWB or CVDR identifier)".to_string(),
         ));
     }
+
+    let law_id_type = classify_law_id(&raw_id).ok_or_else(|| {
+        tracing::debug!(law_id = %raw_id, "rejected invalid law ID");
+        ApiError::BadRequest(
+            "invalid law ID format: expected BWBR followed by 7 digits, or CVDR followed by 3+ digits".to_string(),
+        )
+    })?;
+
+    let law_id = match &law_id_type {
+        LawIdType::Bwb(id) | LawIdType::Cvdr(id) => id.clone(),
+    };
 
     if let Some(ref date) = body.date {
         if chrono::NaiveDate::parse_from_str(date, "%Y-%m-%d").is_err() {
@@ -457,16 +494,16 @@ pub async fn create_harvest_job(
         ApiError::Internal("internal server error".to_string())
     })?;
 
-    // Acquire an advisory lock keyed on the bwb_id to serialize concurrent requests
+    // Acquire an advisory lock keyed on the law_id to serialize concurrent requests
     // for the same law. This prevents the TOCTOU race where two requests both see
     // no existing job and both create one. The lock is released when the transaction
     // commits or rolls back.
     sqlx::query("SELECT pg_advisory_xact_lock(hashtext($1))")
-        .bind(&bwb_id)
+        .bind(&law_id)
         .execute(&mut *tx)
         .await
         .map_err(|e| {
-            tracing::error!(error = %e, law_id = %bwb_id, "failed to acquire advisory lock");
+            tracing::error!(error = %e, law_id = %law_id, "failed to acquire advisory lock");
             ApiError::Internal("internal server error".to_string())
         })?;
 
@@ -476,11 +513,11 @@ pub async fn create_harvest_job(
          WHERE law_id = $1 AND job_type = 'harvest' AND status IN ('pending', 'processing') \
          LIMIT 1",
     )
-    .bind(&bwb_id)
+    .bind(&law_id)
     .fetch_optional(&mut *tx)
     .await
     .map_err(|e| {
-        tracing::error!(error = %e, law_id = %bwb_id, "failed to check for existing jobs");
+        tracing::error!(error = %e, law_id = %law_id, "failed to check for existing jobs");
         ApiError::Internal("failed to check for existing jobs".to_string())
     })?;
 
@@ -492,9 +529,9 @@ pub async fn create_harvest_job(
 
     // Check if law is exhausted for harvest.
     // RowNotFound is fine (new law, can't be exhausted); other errors should propagate.
-    match regelrecht_pipeline::law_status::get_law(&mut *tx, &bwb_id).await {
+    match regelrecht_pipeline::law_status::get_law(&mut *tx, &law_id).await {
         Ok(law) if law.status == regelrecht_pipeline::LawStatusValue::HarvestExhausted => {
-            return Err(ApiError::Conflict(format!("{bwb_id} is harvest_exhausted — reset via /api/law_entries/{bwb_id}/reset-exhausted first")));
+            return Err(ApiError::Conflict(format!("{law_id} is harvest_exhausted — reset via /api/law_entries/{law_id}/reset-exhausted first")));
         }
         Err(regelrecht_pipeline::PipelineError::LawNotFound(_)) => {}
         Err(e) => {
@@ -512,24 +549,34 @@ pub async fn create_harvest_job(
          ON CONFLICT (law_id) DO UPDATE SET status = 'queued', updated_at = NOW() \
          WHERE law_entries.status NOT IN ('harvesting', 'enriching')",
     )
-    .bind(&bwb_id)
+    .bind(&law_id)
     .execute(&mut *tx)
     .await
     .map_err(|e| {
-        tracing::error!(error = %e, law_id = %bwb_id, "failed to upsert law entry");
+        tracing::error!(error = %e, law_id = %law_id, "failed to upsert law entry");
         ApiError::Internal("failed to upsert law entry".to_string())
     })?;
 
-    let payload = HarvestPayload {
-        bwb_id: bwb_id.clone(),
-        date: body.date,
-        max_size_mb: None,
-        depth: None,
+    let payload = match law_id_type {
+        LawIdType::Bwb(ref id) => HarvestPayload {
+            bwb_id: Some(id.clone()),
+            cvdr_id: None,
+            date: body.date,
+            max_size_mb: None,
+            depth: None,
+        },
+        LawIdType::Cvdr(ref id) => HarvestPayload {
+            bwb_id: None,
+            cvdr_id: Some(id.clone()),
+            date: body.date,
+            max_size_mb: None,
+            depth: None,
+        },
     };
 
     let priority = Priority::new(body.priority.unwrap_or(50));
 
-    let req = CreateJobRequest::new(JobType::Harvest, &bwb_id)
+    let req = CreateJobRequest::new(JobType::Harvest, &law_id)
         .with_priority(priority)
         .with_payload(serde_json::to_value(&payload).map_err(|e| {
             tracing::error!(error = %e, "failed to serialize payload");
@@ -537,13 +584,13 @@ pub async fn create_harvest_job(
         })?);
 
     let job = create_job(&mut *tx, req).await.map_err(|e| {
-        tracing::error!(error = %e, law_id = %bwb_id, "failed to create harvest job");
+        tracing::error!(error = %e, law_id = %law_id, "failed to create harvest job");
         ApiError::Internal("failed to create harvest job".to_string())
     })?;
 
     // Link the harvest job to the law entry.
-    set_harvest_job(&mut *tx, &bwb_id, job.id).await.map_err(|e| {
-        tracing::error!(error = %e, law_id = %bwb_id, job_id = %job.id, "failed to link harvest job to law entry");
+    set_harvest_job(&mut *tx, &law_id, job.id).await.map_err(|e| {
+        tracing::error!(error = %e, law_id = %law_id, job_id = %job.id, "failed to link harvest job to law entry");
         ApiError::Internal("failed to link harvest job to law entry".to_string())
     })?;
 
@@ -552,13 +599,13 @@ pub async fn create_harvest_job(
         ApiError::Internal("internal server error".to_string())
     })?;
 
-    tracing::info!(job_id = %job.id, law_id = %bwb_id, "created harvest job");
+    tracing::info!(job_id = %job.id, law_id = %law_id, "created harvest job");
 
     Ok((
         StatusCode::CREATED,
         Json(CreateJobResponse {
             job_id: job.id.to_string(),
-            law_id: bwb_id,
+            law_id,
         }),
     ))
 }
@@ -1003,28 +1050,64 @@ mod tests {
     // --- CreateJobBody deserialization ---
 
     #[test]
-    fn create_job_body_full() {
-        let json = r#"{"bwb_id": "BWBR0018451", "priority": 80, "date": "2026-01-01"}"#;
+    fn create_job_body_with_law_id() {
+        let json = r#"{"law_id": "BWBR0018451", "priority": 80, "date": "2026-01-01"}"#;
         let body: CreateJobBody = serde_json::from_str(json).unwrap();
-        assert_eq!(body.bwb_id, "BWBR0018451");
+        assert_eq!(body.law_id.as_deref(), Some("BWBR0018451"));
         assert_eq!(body.priority, Some(80));
         assert_eq!(body.date.as_deref(), Some("2026-01-01"));
     }
 
     #[test]
-    fn create_job_body_minimal() {
-        let json = r#"{"bwb_id": "BWBR0018451"}"#;
+    fn create_job_body_with_cvdr_id() {
+        let json = r#"{"law_id": "CVDR681386"}"#;
         let body: CreateJobBody = serde_json::from_str(json).unwrap();
-        assert_eq!(body.bwb_id, "BWBR0018451");
-        assert_eq!(body.priority, None);
-        assert_eq!(body.date, None);
+        assert_eq!(body.law_id.as_deref(), Some("CVDR681386"));
     }
 
     #[test]
-    fn create_job_body_missing_bwb_id() {
-        let json = r#"{"priority": 50}"#;
-        let result = serde_json::from_str::<CreateJobBody>(json);
-        assert!(result.is_err());
+    fn create_job_body_legacy_bwb_id() {
+        // Backward compatibility: old clients sending bwb_id
+        let json = r#"{"bwb_id": "BWBR0018451"}"#;
+        let body: CreateJobBody = serde_json::from_str(json).unwrap();
+        assert!(body.law_id.is_none());
+        assert_eq!(body.bwb_id.as_deref(), Some("BWBR0018451"));
+    }
+
+    #[test]
+    fn create_job_body_minimal_empty() {
+        let json = r#"{}"#;
+        let body: CreateJobBody = serde_json::from_str(json).unwrap();
+        assert!(body.law_id.is_none());
+        assert!(body.bwb_id.is_none());
+        assert!(body.priority.is_none());
+        assert!(body.date.is_none());
+    }
+
+    // --- classify_law_id ---
+
+    #[test]
+    fn classify_bwb_id() {
+        assert!(matches!(
+            classify_law_id("BWBR0018451"),
+            Some(LawIdType::Bwb(_))
+        ));
+    }
+
+    #[test]
+    fn classify_cvdr_id() {
+        assert!(matches!(
+            classify_law_id("CVDR681386"),
+            Some(LawIdType::Cvdr(_))
+        ));
+    }
+
+    #[test]
+    fn classify_invalid_id() {
+        assert!(classify_law_id("INVALID").is_none());
+        assert!(classify_law_id("").is_none());
+        assert!(classify_law_id("BWBR123").is_none()); // too few digits
+        assert!(classify_law_id("CVDR12").is_none()); // too few digits
     }
 
     #[test]

--- a/packages/harvester/Cargo.toml
+++ b/packages/harvester/Cargo.toml
@@ -28,6 +28,7 @@ regex = "1.11"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 reqwest = "0.13"
+async-trait = "0.1"
 tokio = { version = "1", features = ["time", "rt-multi-thread", "macros"] }
 roxmltree = "0.21"
 clap = { version = "4.6", features = ["derive"] }

--- a/packages/harvester/src/cli.rs
+++ b/packages/harvester/src/cli.rs
@@ -7,10 +7,9 @@ use console::style;
 use indicatif::{ProgressBar, ProgressStyle};
 
 use crate::config::DEFAULT_MAX_RESPONSE_SIZE;
-use crate::cvdr::download_cvdr_law;
 use crate::error::{HarvesterError, Result};
-use crate::harvester::download_law_with_max_size;
 use crate::http::create_client;
+use crate::source::{self, BwbSource};
 use crate::yaml::save_yaml;
 
 /// RegelRecht Harvester - Download Dutch legislation from BWB and CVDR repositories.
@@ -46,25 +45,6 @@ pub enum Commands {
     },
 }
 
-/// Detected law source based on the ID prefix.
-enum LawSource {
-    /// National law from BWB (Basiswettenbestand).
-    Bwb,
-    /// Decentrale regelgeving from CVDR.
-    Cvdr,
-}
-
-/// Detect whether a law ID is BWB or CVDR based on its prefix.
-fn detect_law_source(law_id: &str) -> Result<LawSource> {
-    if law_id.starts_with("BWBR") {
-        Ok(LawSource::Bwb)
-    } else if law_id.starts_with("CVDR") {
-        Ok(LawSource::Cvdr)
-    } else {
-        Err(HarvesterError::InvalidLawId(law_id.to_string()))
-    }
-}
-
 /// Run the CLI.
 pub async fn run() -> Result<()> {
     let cli = Cli::parse();
@@ -79,6 +59,21 @@ pub async fn run() -> Result<()> {
     }
 }
 
+/// Build the appropriate `LawSource` for a CLI download.
+///
+/// Uses `detect_source` as the base, but applies the CLI-specific
+/// `max_size_mb` override for BWB sources.
+fn build_cli_source(law_id: &str, max_size_mb: u64) -> Result<Box<dyn source::LawSource>> {
+    let law_source = source::detect_source(law_id)?;
+    if law_source.name() == "BWB" {
+        Ok(Box::new(BwbSource {
+            max_size_mb: Some(max_size_mb),
+        }))
+    } else {
+        Ok(law_source)
+    }
+}
+
 /// Execute the download command.
 async fn download_command(
     law_id: &str,
@@ -86,8 +81,9 @@ async fn download_command(
     output: Option<&std::path::Path>,
     max_size_mb: u64,
 ) -> Result<()> {
-    // Detect source type
-    let source = detect_law_source(law_id)?;
+    // Build source with CLI-specific max_size override
+    let law_source = build_cli_source(law_id, max_size_mb)?;
+    law_source.validate_id(law_id)?;
 
     // Use today if no date provided
     let effective_date = date
@@ -110,16 +106,11 @@ async fn download_command(
         }
     }
 
-    let source_label = match source {
-        LawSource::Bwb => "BWB",
-        LawSource::Cvdr => "CVDR",
-    };
-
     println!(
         "{} {} ({}) for date {}",
         style("Downloading").bold(),
         style(law_id).cyan(),
-        source_label,
+        law_source.name(),
         style(&effective_date).green()
     );
     println!();
@@ -138,26 +129,12 @@ async fn download_command(
 
     pb.enable_steady_tick(std::time::Duration::from_millis(100));
 
-    let law = match source {
-        LawSource::Bwb => {
-            pb.set_message("Downloading WTI metadata...");
-            match download_law_with_max_size(&client, law_id, &effective_date, max_size_mb).await {
-                Ok(law) => law,
-                Err(e) => {
-                    pb.finish_and_clear();
-                    return Err(e);
-                }
-            }
-        }
-        LawSource::Cvdr => {
-            pb.set_message("Searching CVDR via SRU...");
-            match download_cvdr_law(&client, law_id, date).await {
-                Ok(law) => law,
-                Err(e) => {
-                    pb.finish_and_clear();
-                    return Err(e);
-                }
-            }
+    pb.set_message(format!("Downloading from {}...", law_source.name()));
+    let law = match law_source.download(&client, law_id, date).await {
+        Ok(law) => law,
+        Err(e) => {
+            pb.finish_and_clear();
+            return Err(e);
         }
     };
 
@@ -254,24 +231,20 @@ mod tests {
     }
 
     #[test]
-    fn test_detect_law_source_bwb() {
-        assert!(matches!(
-            detect_law_source("BWBR0018451"),
-            Ok(LawSource::Bwb)
-        ));
+    fn test_build_cli_source_bwb() {
+        let src = build_cli_source("BWBR0018451", 100).unwrap();
+        assert_eq!(src.name(), "BWB");
     }
 
     #[test]
-    fn test_detect_law_source_cvdr() {
-        assert!(matches!(
-            detect_law_source("CVDR681386"),
-            Ok(LawSource::Cvdr)
-        ));
+    fn test_build_cli_source_cvdr() {
+        let src = build_cli_source("CVDR681386", 100).unwrap();
+        assert_eq!(src.name(), "CVDR");
     }
 
     #[test]
-    fn test_detect_law_source_invalid() {
-        assert!(detect_law_source("INVALID").is_err());
-        assert!(detect_law_source("").is_err());
+    fn test_build_cli_source_invalid() {
+        assert!(build_cli_source("INVALID", 100).is_err());
+        assert!(build_cli_source("", 100).is_err());
     }
 }

--- a/packages/harvester/src/cli.rs
+++ b/packages/harvester/src/cli.rs
@@ -7,12 +7,13 @@ use console::style;
 use indicatif::{ProgressBar, ProgressStyle};
 
 use crate::config::DEFAULT_MAX_RESPONSE_SIZE;
+use crate::cvdr::download_cvdr_law;
 use crate::error::{HarvesterError, Result};
 use crate::harvester::download_law_with_max_size;
 use crate::http::create_client;
 use crate::yaml::save_yaml;
 
-/// RegelRecht Harvester - Download Dutch legislation from BWB repository.
+/// RegelRecht Harvester - Download Dutch legislation from BWB and CVDR repositories.
 #[derive(Parser)]
 #[command(name = "regelrecht-harvester")]
 #[command(version, about, long_about = None)]
@@ -23,10 +24,10 @@ pub struct Cli {
 
 #[derive(Subcommand)]
 pub enum Commands {
-    /// Download a law by BWB ID and convert to YAML.
+    /// Download a law by BWB or CVDR ID and convert to YAML.
     Download {
-        /// BWB identifier (e.g., BWBR0018451)
-        bwb_id: String,
+        /// Law identifier: BWB ID (e.g., BWBR0018451) or CVDR ID (e.g., CVDR681386)
+        law_id: String,
 
         /// Effective date in YYYY-MM-DD format (default: today)
         #[arg(short, long)]
@@ -45,27 +46,49 @@ pub enum Commands {
     },
 }
 
+/// Detected law source based on the ID prefix.
+enum LawSource {
+    /// National law from BWB (Basiswettenbestand).
+    Bwb,
+    /// Decentrale regelgeving from CVDR.
+    Cvdr,
+}
+
+/// Detect whether a law ID is BWB or CVDR based on its prefix.
+fn detect_law_source(law_id: &str) -> Result<LawSource> {
+    if law_id.starts_with("BWBR") {
+        Ok(LawSource::Bwb)
+    } else if law_id.starts_with("CVDR") {
+        Ok(LawSource::Cvdr)
+    } else {
+        Err(HarvesterError::InvalidLawId(law_id.to_string()))
+    }
+}
+
 /// Run the CLI.
 pub async fn run() -> Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
         Commands::Download {
-            bwb_id,
+            law_id,
             date,
             output,
             max_size,
-        } => download_command(&bwb_id, date.as_deref(), output.as_deref(), max_size).await,
+        } => download_command(&law_id, date.as_deref(), output.as_deref(), max_size).await,
     }
 }
 
 /// Execute the download command.
 async fn download_command(
-    bwb_id: &str,
+    law_id: &str,
     date: Option<&str>,
     output: Option<&std::path::Path>,
     max_size_mb: u64,
 ) -> Result<()> {
+    // Detect source type
+    let source = detect_law_source(law_id)?;
+
     // Use today if no date provided
     let effective_date = date
         .map(String::from)
@@ -87,10 +110,16 @@ async fn download_command(
         }
     }
 
+    let source_label = match source {
+        LawSource::Bwb => "BWB",
+        LawSource::Cvdr => "CVDR",
+    };
+
     println!(
-        "{} {} for date {}",
+        "{} {} ({}) for date {}",
         style("Downloading").bold(),
-        style(bwb_id).cyan(),
+        style(law_id).cyan(),
+        source_label,
         style(&effective_date).green()
     );
     println!();
@@ -107,16 +136,28 @@ async fn download_command(
     // Create HTTP client
     let client = create_client()?;
 
-    // Download and parse
-    pb.set_message("Downloading WTI metadata...");
     pb.enable_steady_tick(std::time::Duration::from_millis(100));
 
-    let law = match download_law_with_max_size(&client, bwb_id, &effective_date, max_size_mb).await
-    {
-        Ok(law) => law,
-        Err(e) => {
-            pb.finish_and_clear();
-            return Err(e);
+    let law = match source {
+        LawSource::Bwb => {
+            pb.set_message("Downloading WTI metadata...");
+            match download_law_with_max_size(&client, law_id, &effective_date, max_size_mb).await {
+                Ok(law) => law,
+                Err(e) => {
+                    pb.finish_and_clear();
+                    return Err(e);
+                }
+            }
+        }
+        LawSource::Cvdr => {
+            pb.set_message("Searching CVDR via SRU...");
+            match download_cvdr_law(&client, law_id, date).await {
+                Ok(law) => law,
+                Err(e) => {
+                    pb.finish_and_clear();
+                    return Err(e);
+                }
+            }
         }
     };
 
@@ -124,6 +165,9 @@ async fn download_command(
 
     println!("  Title: {}", style(&law.metadata.title).green());
     println!("  Type: {}", law.metadata.regulatory_layer.as_str());
+    if let Some(creator) = &law.metadata.creator {
+        println!("  Creator: {}", style(creator).cyan());
+    }
     println!("  Articles: {}", law.articles.len());
     if !law.warnings.is_empty() {
         println!("  Warnings: {}", style(law.warnings.len()).yellow().bold());
@@ -157,19 +201,27 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_cli_parse_download() {
+    fn test_cli_parse_download_bwb() {
         let cli = Cli::parse_from(["regelrecht-harvester", "download", "BWBR0018451"]);
 
         let Commands::Download {
-            bwb_id,
+            law_id,
             date,
             output,
             max_size,
         } = cli.command;
-        assert_eq!(bwb_id, "BWBR0018451");
+        assert_eq!(law_id, "BWBR0018451");
         assert!(date.is_none());
         assert!(output.is_none());
         assert_eq!(max_size, 100); // Default 100 MB
+    }
+
+    #[test]
+    fn test_cli_parse_download_cvdr() {
+        let cli = Cli::parse_from(["regelrecht-harvester", "download", "CVDR681386"]);
+
+        let Commands::Download { law_id, .. } = cli.command;
+        assert_eq!(law_id, "CVDR681386");
     }
 
     #[test]
@@ -182,8 +234,8 @@ mod tests {
             "2025-01-01",
         ]);
 
-        let Commands::Download { bwb_id, date, .. } = cli.command;
-        assert_eq!(bwb_id, "BWBR0018451");
+        let Commands::Download { law_id, date, .. } = cli.command;
+        assert_eq!(law_id, "BWBR0018451");
         assert_eq!(date, Some("2025-01-01".to_string()));
     }
 
@@ -199,5 +251,27 @@ mod tests {
 
         let Commands::Download { max_size, .. } = cli.command;
         assert_eq!(max_size, 200);
+    }
+
+    #[test]
+    fn test_detect_law_source_bwb() {
+        assert!(matches!(
+            detect_law_source("BWBR0018451"),
+            Ok(LawSource::Bwb)
+        ));
+    }
+
+    #[test]
+    fn test_detect_law_source_cvdr() {
+        assert!(matches!(
+            detect_law_source("CVDR681386"),
+            Ok(LawSource::Cvdr)
+        ));
+    }
+
+    #[test]
+    fn test_detect_law_source_invalid() {
+        assert!(detect_law_source("INVALID").is_err());
+        assert!(detect_law_source("").is_err());
     }
 }

--- a/packages/harvester/src/cli.rs
+++ b/packages/harvester/src/cli.rs
@@ -65,7 +65,7 @@ pub async fn run() -> Result<()> {
 /// `max_size_mb` override for BWB sources.
 fn build_cli_source(law_id: &str, max_size_mb: u64) -> Result<Box<dyn source::LawSource>> {
     let law_source = source::detect_source(law_id)?;
-    if law_source.name() == "BWB" {
+    if law_source.source_type() == source::LawSourceType::Bwb {
         Ok(Box::new(BwbSource {
             max_size_mb: Some(max_size_mb),
         }))
@@ -81,9 +81,8 @@ async fn download_command(
     output: Option<&std::path::Path>,
     max_size_mb: u64,
 ) -> Result<()> {
-    // Build source with CLI-specific max_size override
+    // Build source with CLI-specific max_size override (detect_source validates the ID)
     let law_source = build_cli_source(law_id, max_size_mb)?;
-    law_source.validate_id(law_id)?;
 
     // Use today if no date provided
     let effective_date = date

--- a/packages/harvester/src/config.rs
+++ b/packages/harvester/src/config.rs
@@ -33,6 +33,11 @@ pub const TEXT_WRAP_WIDTH: usize = 115;
 static BWB_ID_PATTERN: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^BWBR\d{7}$").expect("valid regex"));
 
+/// CVDR ID pattern: CVDR followed by 3 or more digits.
+#[allow(clippy::expect_used)] // Static regex that is guaranteed to be valid
+static CVDR_ID_PATTERN: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^CVDR\d{3,}$").expect("valid regex"));
+
 /// Date pattern: YYYY-MM-DD.
 #[allow(clippy::expect_used)] // Static regex that is guaranteed to be valid
 static DATE_PATTERN: LazyLock<Regex> =
@@ -228,6 +233,58 @@ pub fn wetten_url(
     url
 }
 
+/// Base URL for CVDR SRU search service.
+pub const CVDR_SRU_URL: &str = "https://zoekservice.overheid.nl/sru/Search";
+
+/// Validate CVDR ID format.
+///
+/// # Arguments
+/// * `cvdr_id` - The CVDR identifier to validate
+///
+/// # Returns
+/// * `Ok(())` if valid
+/// * `Err(HarvesterError::InvalidCvdrId)` if invalid
+///
+/// # Examples
+/// ```
+/// use regelrecht_harvester::config::validate_cvdr_id;
+///
+/// assert!(validate_cvdr_id("CVDR681386").is_ok());
+/// assert!(validate_cvdr_id("INVALID").is_err());
+/// ```
+pub fn validate_cvdr_id(cvdr_id: &str) -> Result<()> {
+    if CVDR_ID_PATTERN.is_match(cvdr_id) {
+        Ok(())
+    } else {
+        Err(HarvesterError::InvalidCvdrId(cvdr_id.to_string()))
+    }
+}
+
+/// Build SRU search URL for a CVDR regulation.
+///
+/// # Arguments
+/// * `cvdr_id` - The CVDR identifier (e.g., "CVDR681386")
+///
+/// # Returns
+/// URL for the SRU search query
+pub fn cvdr_sru_search_url(cvdr_id: &str) -> String {
+    format!(
+        "{}?operation=searchRetrieve&version=1.2&x-connection=CVDR&query=dcterms.identifier%3D%3D{}",
+        CVDR_SRU_URL, cvdr_id
+    )
+}
+
+/// Build lokaleregelgeving.overheid.nl URL for a CVDR regulation.
+///
+/// # Arguments
+/// * `cvdr_id` - The CVDR identifier (e.g., "CVDR681386")
+///
+/// # Returns
+/// Public URL to lokaleregelgeving.overheid.nl
+pub fn lokaleregelgeving_url(cvdr_id: &str) -> String {
+    format!("https://lokaleregelgeving.overheid.nl/{cvdr_id}")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -407,6 +464,38 @@ mod tests {
                 None
             ),
             "https://wetten.overheid.nl/BWBR0009950#Artikel1scriptalertxssscript"
+        );
+    }
+
+    #[test]
+    fn test_validate_cvdr_id_valid() {
+        assert!(validate_cvdr_id("CVDR681386").is_ok());
+        assert!(validate_cvdr_id("CVDR123").is_ok());
+        assert!(validate_cvdr_id("CVDR1234567890").is_ok());
+    }
+
+    #[test]
+    fn test_validate_cvdr_id_invalid() {
+        assert!(validate_cvdr_id("").is_err());
+        assert!(validate_cvdr_id("CVDR").is_err()); // No digits
+        assert!(validate_cvdr_id("CVDR12").is_err()); // Only 2 digits
+        assert!(validate_cvdr_id("BWBR0018451").is_err()); // BWB, not CVDR
+        assert!(validate_cvdr_id("cvdr681386").is_err()); // Lowercase
+    }
+
+    #[test]
+    fn test_cvdr_sru_search_url() {
+        assert_eq!(
+            cvdr_sru_search_url("CVDR681386"),
+            "https://zoekservice.overheid.nl/sru/Search?operation=searchRetrieve&version=1.2&x-connection=CVDR&query=dcterms.identifier%3D%3DCVDR681386"
+        );
+    }
+
+    #[test]
+    fn test_lokaleregelgeving_url() {
+        assert_eq!(
+            lokaleregelgeving_url("CVDR681386"),
+            "https://lokaleregelgeving.overheid.nl/CVDR681386"
         );
     }
 }

--- a/packages/harvester/src/config.rs
+++ b/packages/harvester/src/config.rs
@@ -22,7 +22,7 @@ pub const DEFAULT_MAX_RESPONSE_SIZE: u64 = 100 * 1024 * 1024;
 
 /// Schema URL for regelrecht YAML files.
 pub const SCHEMA_URL: &str =
-    "https://raw.githubusercontent.com/MinBZK/regelrecht/refs/heads/main/schema/v0.3.1/schema.json";
+    "https://raw.githubusercontent.com/MinBZK/regelrecht/refs/heads/main/schema/v0.5.2/schema.json";
 
 /// Text wrap width for YAML output.
 /// Accounts for up to 6 spaces of YAML block scalar indent (125 - 6 = 119, with margin).

--- a/packages/harvester/src/cvdr/content.rs
+++ b/packages/harvester/src/cvdr/content.rs
@@ -1,0 +1,39 @@
+//! CVDR XML content downloading.
+//!
+//! Downloads the regulation XML from the URL resolved during SRU search.
+
+use reqwest::Client;
+
+use crate::error::{HarvesterError, Result};
+use crate::http::{bytes_to_string, download_bytes_default};
+
+/// Download CVDR regulation XML content.
+///
+/// # Arguments
+/// * `client` - HTTP client to use
+/// * `xml_url` - URL to the XML content (resolved from SRU search)
+/// * `cvdr_id` - The CVDR identifier (for error context)
+///
+/// # Returns
+/// Raw XML content as a string
+pub async fn download_cvdr_content(
+    client: &Client,
+    xml_url: &str,
+    cvdr_id: &str,
+) -> Result<String> {
+    let bytes = download_bytes_default(client, xml_url).await.map_err(|e| {
+        if let HarvesterError::Http(source) = e {
+            HarvesterError::CvdrContentDownload {
+                cvdr_id: cvdr_id.to_string(),
+                source,
+            }
+        } else {
+            e
+        }
+    })?;
+
+    Ok(bytes_to_string(
+        bytes,
+        &format!("CVDR XML content for {cvdr_id}"),
+    ))
+}

--- a/packages/harvester/src/cvdr/mod.rs
+++ b/packages/harvester/src/cvdr/mod.rs
@@ -1,0 +1,70 @@
+//! CVDR (Centrale Voorziening Decentrale Regelgeving) harvester module.
+//!
+//! Downloads decentrale regelgeving (municipal, provincial, and water board
+//! regulations) from lokaleregelgeving.overheid.nl via the SRU search API.
+//!
+//! # Flow
+//!
+//! 1. SRU search to get metadata and XML content URL
+//! 2. Download XML content from the resolved URL
+//! 3. Parse articles from CVDR XML format
+//! 4. Return a `Law` object compatible with the existing YAML generation pipeline
+
+pub mod content;
+pub mod parse;
+pub mod search;
+
+use reqwest::Client;
+
+use crate::config::{lokaleregelgeving_url, validate_cvdr_id, validate_date};
+use crate::error::Result;
+use crate::types::Law;
+use content::download_cvdr_content;
+use parse::parse_cvdr_articles;
+use search::search_cvdr;
+
+/// Download and parse a CVDR law.
+///
+/// # Arguments
+/// * `client` - HTTP client to use
+/// * `cvdr_id` - The CVDR identifier (e.g., "CVDR681386")
+/// * `date` - Optional effective date in YYYY-MM-DD format
+///
+/// # Returns
+/// A `Law` object containing metadata, articles, and any warnings encountered during parsing
+pub async fn download_cvdr_law(client: &Client, cvdr_id: &str, date: Option<&str>) -> Result<Law> {
+    // Validate inputs
+    validate_cvdr_id(cvdr_id)?;
+    if let Some(d) = date {
+        validate_date(d)?;
+    }
+
+    // Step 1: SRU search to get metadata
+    let metadata_result = search_cvdr(client, cvdr_id).await?;
+
+    // Step 2: Download XML content
+    let xml_content = download_cvdr_content(client, &metadata_result.xml_url, cvdr_id).await?;
+
+    // Step 3: Parse articles from CVDR XML
+    let effective_date = date
+        .map(String::from)
+        .or_else(|| metadata_result.effective_date.clone())
+        .unwrap_or_else(|| chrono::Local::now().format("%Y-%m-%d").to_string());
+
+    let base_url = lokaleregelgeving_url(cvdr_id);
+    let parsed = parse_cvdr_articles(&xml_content, &base_url)?;
+
+    // Build metadata from SRU search result
+    let law_metadata = metadata_result.to_law_metadata(&effective_date);
+
+    // Combine warnings
+    let mut warnings = metadata_result.warnings;
+    warnings.extend(parsed.warnings);
+
+    Ok(Law {
+        metadata: law_metadata,
+        preamble: None,
+        articles: parsed.articles,
+        warnings,
+    })
+}

--- a/packages/harvester/src/cvdr/parse.rs
+++ b/packages/harvester/src/cvdr/parse.rs
@@ -1,0 +1,235 @@
+//! CVDR XML parsing into Article structs.
+//!
+//! CVDR XML uses a similar but different structure compared to BWB XML:
+//! - Root: `<regeling>` → `<regeling-tekst>` → `<body>`
+//! - Articles: `<artikel>` with `<kop>/<nr>` for numbering
+//! - Paragraphs: `<lid>` with `<lidnr>` for numbering
+//! - Text: `<al>` elements
+//! - Lists: `<lijst>` with `<li>` items
+//!
+//! We reuse the existing splitting module where possible since the inner
+//! article structure (artikel > lid > lijst > li) is identical to BWB.
+
+use roxmltree::Document;
+
+use crate::error::Result;
+use crate::splitting::{create_dutch_law_hierarchy, LeafSplitStrategy, SplitContext, SplitEngine};
+use crate::types::Article;
+use crate::xml::{find_by_path, get_tag_name, get_text};
+
+/// Parsed content from CVDR XML.
+pub struct ParsedCvdrContent {
+    /// Parsed articles.
+    pub articles: Vec<Article>,
+
+    /// Non-fatal warnings encountered during parsing.
+    pub warnings: Vec<String>,
+}
+
+/// Parse articles from CVDR XML content.
+///
+/// The CVDR XML structure differs from BWB at the top level:
+/// ```text
+/// <cvdr:body>
+///   <regeling>
+///     <regeling-tekst>
+///       <body>
+///         <hoofdstuk>       (optional)
+///           <artikel>...
+/// ```
+///
+/// But the inner article structure (artikel > lid > lijst > li) is the same,
+/// so we reuse the existing `SplitEngine` for article splitting.
+///
+/// # Arguments
+/// * `xml` - Raw CVDR XML string
+/// * `base_url` - Base URL for the regulation on lokaleregelgeving.overheid.nl
+///
+/// # Returns
+/// `ParsedCvdrContent` with articles and warnings
+pub fn parse_cvdr_articles(xml: &str, base_url: &str) -> Result<ParsedCvdrContent> {
+    let doc = Document::parse(xml)?;
+    let mut articles = Vec::new();
+    let mut all_warnings: Vec<String> = Vec::new();
+
+    // Create split engine (reuses BWB article splitting logic)
+    let hierarchy = create_dutch_law_hierarchy();
+    let engine = SplitEngine::new(hierarchy, LeafSplitStrategy);
+
+    // Find all artikel elements regardless of their position in the tree
+    // CVDR structure varies: may be under body, hoofdstuk, paragraaf, afdeling, etc.
+    for artikel in doc
+        .descendants()
+        .filter(|n| n.is_element() && get_tag_name(*n) == "artikel")
+    {
+        // Get article number
+        let artikel_nr = if let Some(nr_node) = find_by_path(artikel, "kop/nr") {
+            get_text(nr_node)
+        } else if let Some(label) = artikel.attribute("label") {
+            label.strip_prefix("Artikel ").unwrap_or(label).to_string()
+        } else {
+            continue; // Skip articles without number
+        };
+
+        // Build article URL
+        let artikel_nr_url = artikel_nr.replace(' ', "_");
+        let article_url = format!("{base_url}#Artikel{artikel_nr_url}");
+
+        // Create split context
+        // Use an empty string for bwb_id since CVDR doesn't use BWB references
+        let context = SplitContext::new("", "", article_url);
+
+        // Split the artikel using the shared engine
+        let components = engine.split(artikel, context);
+
+        // Convert components to articles and collect warnings
+        for component in components {
+            for warning in &component.warnings {
+                all_warnings.push(format!("Article {}: {}", component.to_number(), warning));
+            }
+            articles.push(component.to_article());
+        }
+    }
+
+    Ok(ParsedCvdrContent {
+        articles,
+        warnings: all_warnings,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_simple_cvdr_article() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<cvdr:body xmlns:cvdr="https://purl.overheid.nl/cvdr/def/">
+  <regeling>
+    <regeling-tekst>
+      <body>
+        <artikel>
+          <kop><nr>1</nr><titel>Begripsbepalingen</titel></kop>
+          <al>In deze verordening wordt verstaan onder gemeente: de gemeente Amsterdam.</al>
+        </artikel>
+      </body>
+    </regeling-tekst>
+  </regeling>
+</cvdr:body>"#;
+
+        let result =
+            parse_cvdr_articles(xml, "https://lokaleregelgeving.overheid.nl/CVDR681386").unwrap();
+
+        assert_eq!(result.articles.len(), 1);
+        assert_eq!(result.articles[0].number, "1");
+        assert!(result.articles[0].text.contains("gemeente Amsterdam"));
+    }
+
+    #[test]
+    fn test_parse_cvdr_article_with_lid() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<body>
+  <artikel>
+    <kop><nr>2</nr><titel>Toepassingsgebied</titel></kop>
+    <lid>
+      <lidnr>1.</lidnr>
+      <al>Eerste lid tekst.</al>
+    </lid>
+    <lid>
+      <lidnr>2.</lidnr>
+      <al>Tweede lid tekst.</al>
+    </lid>
+  </artikel>
+</body>"#;
+
+        let result =
+            parse_cvdr_articles(xml, "https://lokaleregelgeving.overheid.nl/CVDR123456").unwrap();
+
+        assert_eq!(result.articles.len(), 2);
+        assert_eq!(result.articles[0].number, "2.1");
+        assert_eq!(result.articles[1].number, "2.2");
+    }
+
+    #[test]
+    fn test_parse_cvdr_article_with_lijst() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<body>
+  <artikel>
+    <kop><nr>3</nr></kop>
+    <lid>
+      <lidnr>1.</lidnr>
+      <al>In deze verordening wordt verstaan onder:</al>
+      <lijst>
+        <li><li.nr>a.</li.nr><al>begrip a: definitie a;</al></li>
+        <li><li.nr>b.</li.nr><al>begrip b: definitie b.</al></li>
+      </lijst>
+    </lid>
+  </artikel>
+</body>"#;
+
+        let result =
+            parse_cvdr_articles(xml, "https://lokaleregelgeving.overheid.nl/CVDR123456").unwrap();
+
+        // Should have: intro + 2 list items = 3 components
+        assert_eq!(result.articles.len(), 3);
+        assert_eq!(result.articles[0].number, "3.1");
+        assert_eq!(result.articles[1].number, "3.1.a");
+        assert_eq!(result.articles[2].number, "3.1.b");
+    }
+
+    #[test]
+    fn test_parse_cvdr_article_in_hoofdstuk() {
+        // CVDR articles can be nested inside hoofdstuk (chapter) elements
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<body>
+  <hoofdstuk>
+    <kop><nr>1</nr><titel>Algemene bepalingen</titel></kop>
+    <artikel>
+      <kop><nr>1</nr></kop>
+      <al>Eerste artikel in hoofdstuk.</al>
+    </artikel>
+    <artikel>
+      <kop><nr>2</nr></kop>
+      <al>Tweede artikel in hoofdstuk.</al>
+    </artikel>
+  </hoofdstuk>
+</body>"#;
+
+        let result =
+            parse_cvdr_articles(xml, "https://lokaleregelgeving.overheid.nl/CVDR123456").unwrap();
+
+        assert_eq!(result.articles.len(), 2);
+        assert_eq!(result.articles[0].number, "1");
+        assert_eq!(result.articles[1].number, "2");
+    }
+
+    #[test]
+    fn test_parse_cvdr_empty_xml() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?><body/>"#;
+
+        let result =
+            parse_cvdr_articles(xml, "https://lokaleregelgeving.overheid.nl/CVDR123456").unwrap();
+
+        assert!(result.articles.is_empty());
+        assert!(result.warnings.is_empty());
+    }
+
+    #[test]
+    fn test_parse_cvdr_article_url_format() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<body>
+  <artikel>
+    <kop><nr>1</nr></kop>
+    <al>Test text.</al>
+  </artikel>
+</body>"#;
+
+        let result =
+            parse_cvdr_articles(xml, "https://lokaleregelgeving.overheid.nl/CVDR681386").unwrap();
+
+        assert_eq!(
+            result.articles[0].url,
+            "https://lokaleregelgeving.overheid.nl/CVDR681386#Artikel1"
+        );
+    }
+}

--- a/packages/harvester/src/cvdr/search.rs
+++ b/packages/harvester/src/cvdr/search.rs
@@ -51,7 +51,7 @@ impl CvdrMetadata {
     #[must_use]
     pub fn to_law_metadata(&self, effective_date: &str) -> LawMetadata {
         LawMetadata {
-            bwb_id: self.cvdr_id.clone(),
+            bwb_id: String::new(),
             cvdr_id: Some(self.cvdr_id.clone()),
             title: self.title.clone(),
             regulatory_layer: self.regulatory_layer,
@@ -134,13 +134,13 @@ fn parse_sru_response(xml: &str, cvdr_id: &str) -> Result<CvdrMetadata> {
         .unwrap_or(record);
 
     // Extract title from dcterms.title or dc.title
-    let title = find_dc_element(&gzd, "title").unwrap_or_default();
+    let title = find_element_text(&gzd, "title").unwrap_or_default();
 
     // Extract creator (organisation name)
-    let creator = find_dc_element(&gzd, "creator").unwrap_or_default();
+    let creator = find_element_text(&gzd, "creator").unwrap_or_default();
 
     // Extract organisation type from overheid.organisatietype
-    let organisation_type = find_overheidsbm_element(&gzd, "organisatietype").unwrap_or_default();
+    let organisation_type = find_element_text(&gzd, "organisatietype").unwrap_or_default();
 
     // Map organisation type to regulatory layer
     let (regulatory_layer, layer_warning) =
@@ -151,10 +151,10 @@ fn parse_sru_response(xml: &str, cvdr_id: &str) -> Result<CvdrMetadata> {
 
     // Extract publication date (dcterms.available or dcterms.issued)
     let publication_date =
-        find_dc_element(&gzd, "issued").or_else(|| find_dc_element(&gzd, "available"));
+        find_element_text(&gzd, "issued").or_else(|| find_element_text(&gzd, "available"));
 
     // Extract effective date (overheidproduct:inwerkingtredingDatum)
-    let effective_date = find_overheidproduct_element(&gzd, "inwerkingtredingDatum");
+    let effective_date = find_element_text(&gzd, "inwerkingtredingDatum");
 
     // Find the XML content URL from enrichedData or meta
     let xml_url = find_xml_content_url(&doc, cvdr_id)?;
@@ -177,29 +177,11 @@ fn local_name<'a>(node: &roxmltree::Node<'a, '_>) -> &'a str {
     node.tag_name().name()
 }
 
-/// Find a Dublin Core (dc/dcterms) element value in the metadata.
-fn find_dc_element(parent: &roxmltree::Node<'_, '_>, name: &str) -> Option<String> {
-    parent
-        .descendants()
-        .find(|n| n.is_element() && local_name(n) == name)
-        .and_then(|n| n.text())
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-}
-
-/// Find an overheid-specific (overheidsbm) element value.
-fn find_overheidsbm_element(parent: &roxmltree::Node<'_, '_>, name: &str) -> Option<String> {
-    // The element may appear as overheidXX:name or just name in the tree
-    parent
-        .descendants()
-        .find(|n| n.is_element() && local_name(n) == name)
-        .and_then(|n| n.text())
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-}
-
-/// Find an overheidproduct-specific element value.
-fn find_overheidproduct_element(parent: &roxmltree::Node<'_, '_>, name: &str) -> Option<String> {
+/// Find a descendant element by local name and return its trimmed text content.
+///
+/// Works for any namespace (Dublin Core, overheid, overheidproduct, etc.)
+/// because it matches on local name only.
+fn find_element_text(parent: &roxmltree::Node<'_, '_>, name: &str) -> Option<String> {
     parent
         .descendants()
         .find(|n| n.is_element() && local_name(n) == name)
@@ -261,7 +243,7 @@ fn find_xml_content_url(doc: &Document<'_>, cvdr_id: &str) -> Result<String> {
     // Try the direct XML download pattern
     Ok(format!(
         "https://repository.overheid.nl/frbr/cvdr/{}/1/xml/{}_1.xml",
-        &cvdr_id[4..], // Strip "CVDR" prefix to get numeric part
+        cvdr_id.get(4..).unwrap_or_default(), // Strip "CVDR" prefix to get numeric part
         cvdr_id
     ))
 }
@@ -375,7 +357,7 @@ mod tests {
         };
 
         let law_meta = metadata.to_law_metadata("2025-01-01");
-        assert_eq!(law_meta.bwb_id, "CVDR681386");
+        assert_eq!(law_meta.bwb_id, "");
         assert_eq!(law_meta.cvdr_id, Some("CVDR681386".to_string()));
         assert_eq!(law_meta.title, "Test Verordening");
         assert_eq!(

--- a/packages/harvester/src/cvdr/search.rs
+++ b/packages/harvester/src/cvdr/search.rs
@@ -1,0 +1,388 @@
+//! SRU search API for CVDR metadata retrieval.
+//!
+//! Uses the Overheid.nl SRU (Search/Retrieve via URL) service to look up
+//! CVDR regulation metadata including title, creator, organisation type,
+//! and the URL to the XML content.
+
+use reqwest::Client;
+use roxmltree::Document;
+
+use crate::config::cvdr_sru_search_url;
+use crate::error::{HarvesterError, Result};
+use crate::http::{bytes_to_string, download_bytes_default};
+use crate::types::{LawMetadata, RegulatoryLayer};
+
+/// Metadata extracted from CVDR SRU search results.
+#[derive(Debug, Clone)]
+pub struct CvdrMetadata {
+    /// CVDR identifier (e.g., "CVDR681386").
+    pub cvdr_id: String,
+
+    /// Official title of the regulation.
+    pub title: String,
+
+    /// Creator organisation name (e.g., "Gemeente Amsterdam").
+    pub creator: String,
+
+    /// Organisation type (e.g., "gemeenten", "provincies", "waterschappen").
+    pub organisation_type: String,
+
+    /// Mapped regulatory layer based on organisation type.
+    pub regulatory_layer: RegulatoryLayer,
+
+    /// Publication date (optional).
+    pub publication_date: Option<String>,
+
+    /// Effective date (optional).
+    pub effective_date: Option<String>,
+
+    /// URL to the XML content of the regulation.
+    pub xml_url: String,
+
+    /// Non-fatal warnings encountered during metadata extraction.
+    pub warnings: Vec<String>,
+}
+
+impl CvdrMetadata {
+    /// Convert CVDR metadata to a `LawMetadata` struct.
+    ///
+    /// # Arguments
+    /// * `effective_date` - The effective date to use
+    #[must_use]
+    pub fn to_law_metadata(&self, effective_date: &str) -> LawMetadata {
+        LawMetadata {
+            bwb_id: self.cvdr_id.clone(),
+            cvdr_id: Some(self.cvdr_id.clone()),
+            title: self.title.clone(),
+            regulatory_layer: self.regulatory_layer,
+            publication_date: self.publication_date.clone(),
+            effective_date: Some(effective_date.to_string()),
+            creator: Some(self.creator.clone()),
+            scope_code: None, // Could be extracted from SRU if available
+        }
+    }
+}
+
+/// Map CVDR organisation type to `RegulatoryLayer`.
+///
+/// Returns `(layer, warning)` where warning is present for unknown types.
+fn regulatory_layer_from_organisation_type(org_type: &str) -> (RegulatoryLayer, Option<String>) {
+    match org_type.to_lowercase().as_str() {
+        "gemeenten" => (RegulatoryLayer::GemeentelijkeVerordening, None),
+        "provincies" => (RegulatoryLayer::ProvincialeVerordening, None),
+        "waterschappen" => (RegulatoryLayer::WaterschapsVerordening, None),
+        unknown => {
+            tracing::warn!(
+                organisation_type = %unknown,
+                "Unknown CVDR organisation type, defaulting to GEMEENTELIJKE_VERORDENING"
+            );
+            (
+                RegulatoryLayer::GemeentelijkeVerordening,
+                Some(format!(
+                    "Unknown organisation type '{unknown}', defaulting to GEMEENTELIJKE_VERORDENING"
+                )),
+            )
+        }
+    }
+}
+
+/// Search CVDR SRU API for regulation metadata.
+///
+/// # Arguments
+/// * `client` - HTTP client to use
+/// * `cvdr_id` - The CVDR identifier (e.g., "CVDR681386")
+///
+/// # Returns
+/// `CvdrMetadata` with extracted metadata
+pub async fn search_cvdr(client: &Client, cvdr_id: &str) -> Result<CvdrMetadata> {
+    let url = cvdr_sru_search_url(cvdr_id);
+
+    let bytes = download_bytes_default(client, &url).await.map_err(|e| {
+        if let HarvesterError::Http(source) = e {
+            HarvesterError::CvdrContentDownload {
+                cvdr_id: cvdr_id.to_string(),
+                source,
+            }
+        } else {
+            e
+        }
+    })?;
+
+    let xml_string = bytes_to_string(bytes, &format!("SRU search for {cvdr_id}"));
+    parse_sru_response(&xml_string, cvdr_id)
+}
+
+/// Parse SRU XML response to extract CVDR metadata.
+fn parse_sru_response(xml: &str, cvdr_id: &str) -> Result<CvdrMetadata> {
+    let doc = Document::parse(xml)?;
+
+    let mut warnings = Vec::new();
+
+    // Check for records in the SRU response
+    let record = doc
+        .descendants()
+        .find(|n| n.is_element() && local_name(n) == "recordData")
+        .ok_or_else(|| HarvesterError::CvdrSearchFailed {
+            cvdr_id: cvdr_id.to_string(),
+            message: "No records found in SRU response".to_string(),
+        })?;
+
+    // Extract the gzd (overheid metadata) element within the record
+    let gzd = record
+        .descendants()
+        .find(|n| n.is_element() && local_name(n) == "gzd")
+        .unwrap_or(record);
+
+    // Extract title from dcterms.title or dc.title
+    let title = find_dc_element(&gzd, "title").unwrap_or_default();
+
+    // Extract creator (organisation name)
+    let creator = find_dc_element(&gzd, "creator").unwrap_or_default();
+
+    // Extract organisation type from overheid.organisatietype
+    let organisation_type = find_overheidsbm_element(&gzd, "organisatietype").unwrap_or_default();
+
+    // Map organisation type to regulatory layer
+    let (regulatory_layer, layer_warning) =
+        regulatory_layer_from_organisation_type(&organisation_type);
+    if let Some(warning) = layer_warning {
+        warnings.push(warning);
+    }
+
+    // Extract publication date (dcterms.available or dcterms.issued)
+    let publication_date =
+        find_dc_element(&gzd, "issued").or_else(|| find_dc_element(&gzd, "available"));
+
+    // Extract effective date (overheidproduct:inwerkingtredingDatum)
+    let effective_date = find_overheidproduct_element(&gzd, "inwerkingtredingDatum");
+
+    // Find the XML content URL from enrichedData or meta
+    let xml_url = find_xml_content_url(&doc, cvdr_id)?;
+
+    Ok(CvdrMetadata {
+        cvdr_id: cvdr_id.to_string(),
+        title,
+        creator,
+        organisation_type,
+        regulatory_layer,
+        publication_date,
+        effective_date,
+        xml_url,
+        warnings,
+    })
+}
+
+/// Get the local name of an XML element (without namespace).
+fn local_name<'a>(node: &roxmltree::Node<'a, '_>) -> &'a str {
+    node.tag_name().name()
+}
+
+/// Find a Dublin Core (dc/dcterms) element value in the metadata.
+fn find_dc_element(parent: &roxmltree::Node<'_, '_>, name: &str) -> Option<String> {
+    parent
+        .descendants()
+        .find(|n| n.is_element() && local_name(n) == name)
+        .and_then(|n| n.text())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// Find an overheid-specific (overheidsbm) element value.
+fn find_overheidsbm_element(parent: &roxmltree::Node<'_, '_>, name: &str) -> Option<String> {
+    // The element may appear as overheidXX:name or just name in the tree
+    parent
+        .descendants()
+        .find(|n| n.is_element() && local_name(n) == name)
+        .and_then(|n| n.text())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// Find an overheidproduct-specific element value.
+fn find_overheidproduct_element(parent: &roxmltree::Node<'_, '_>, name: &str) -> Option<String> {
+    parent
+        .descendants()
+        .find(|n| n.is_element() && local_name(n) == name)
+        .and_then(|n| n.text())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// Find the XML content URL from the SRU response.
+///
+/// Looks for the URL in enrichedData or constructs it from the CVDR ID.
+fn find_xml_content_url(doc: &Document<'_>, cvdr_id: &str) -> Result<String> {
+    // Try to find in enrichedData section (stukIdentifier or contentUrl)
+    for node in doc.descendants() {
+        if !node.is_element() {
+            continue;
+        }
+        let name = local_name(&node);
+
+        // Look for the XML content URL in various locations
+        if name == "content" || name == "url" || name == "locatie" {
+            if let Some(href) = node
+                .attribute("src")
+                .or_else(|| node.attribute("resourceIdentifier"))
+            {
+                if href.ends_with(".xml") || href.contains("/xml/") {
+                    return Ok(href.to_string());
+                }
+            }
+            if let Some(text) = node.text() {
+                let text = text.trim();
+                if (text.ends_with(".xml") || text.contains("/xml/")) && text.starts_with("http") {
+                    return Ok(text.to_string());
+                }
+            }
+        }
+
+        // Look for gzd:enrichedData containing the XML URL
+        if name == "enrichedData" {
+            for child in node.descendants() {
+                if child.is_element() && local_name(&child) == "stukIdentifier" {
+                    if let Some(text) = child.text() {
+                        let text = text.trim();
+                        if !text.is_empty() {
+                            // The stukIdentifier often contains a URL to the XML
+                            if text.starts_with("http") {
+                                return Ok(text.to_string());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Fallback: construct URL from CVDR ID using the known pattern
+    // CVDR regulations are available at: https://lokaleregelgeving.overheid.nl/CVDRXXXXX/1 (XML endpoint)
+    // Or via the SRU result itself which may contain the XML inline
+    // Try the direct XML download pattern
+    Ok(format!(
+        "https://repository.overheid.nl/frbr/cvdr/{}/1/xml/{}_1.xml",
+        &cvdr_id[4..], // Strip "CVDR" prefix to get numeric part
+        cvdr_id
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_regulatory_layer_from_organisation_type() {
+        let (layer, warning) = regulatory_layer_from_organisation_type("gemeenten");
+        assert_eq!(layer, RegulatoryLayer::GemeentelijkeVerordening);
+        assert!(warning.is_none());
+
+        let (layer, warning) = regulatory_layer_from_organisation_type("provincies");
+        assert_eq!(layer, RegulatoryLayer::ProvincialeVerordening);
+        assert!(warning.is_none());
+
+        let (layer, warning) = regulatory_layer_from_organisation_type("waterschappen");
+        assert_eq!(layer, RegulatoryLayer::WaterschapsVerordening);
+        assert!(warning.is_none());
+
+        let (layer, warning) = regulatory_layer_from_organisation_type("unknown_type");
+        assert_eq!(layer, RegulatoryLayer::GemeentelijkeVerordening);
+        assert!(warning.is_some());
+    }
+
+    #[test]
+    fn test_regulatory_layer_from_organisation_type_case_insensitive() {
+        let (layer, _) = regulatory_layer_from_organisation_type("Gemeenten");
+        assert_eq!(layer, RegulatoryLayer::GemeentelijkeVerordening);
+
+        let (layer, _) = regulatory_layer_from_organisation_type("WATERSCHAPPEN");
+        assert_eq!(layer, RegulatoryLayer::WaterschapsVerordening);
+    }
+
+    #[test]
+    fn test_parse_sru_response_basic() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<searchRetrieveResponse xmlns="http://www.loc.gov/zing/srw/">
+  <numberOfRecords>1</numberOfRecords>
+  <records>
+    <record>
+      <recordData>
+        <gzd xmlns:dcterms="http://purl.org/dc/terms/"
+             xmlns:overheidproduct="http://standaarden.overheid.nl/product/"
+             xmlns:overheid="http://standaarden.overheid.nl/owms/terms/">
+          <originalData>
+            <overheidcvdr:meta xmlns:overheidcvdr="http://standaarden.overheid.nl/cvdr/terms/">
+              <owmskern xmlns:dcterms="http://purl.org/dc/terms/">
+                <title>Verordening maatschappelijke ondersteuning gemeente Amsterdam 2020</title>
+                <creator>Gemeente Amsterdam</creator>
+                <identifier>CVDR681386</identifier>
+              </owmskern>
+              <owmsmantel>
+                <issued>2020-01-01</issued>
+              </owmsmantel>
+            </overheidcvdr:meta>
+          </originalData>
+          <enrichedData>
+            <organisatietype>gemeenten</organisatietype>
+            <inwerkingtredingDatum>2020-03-01</inwerkingtredingDatum>
+          </enrichedData>
+        </gzd>
+      </recordData>
+    </record>
+  </records>
+</searchRetrieveResponse>"#;
+
+        let result = parse_sru_response(xml, "CVDR681386").unwrap();
+        assert_eq!(result.cvdr_id, "CVDR681386");
+        assert_eq!(
+            result.title,
+            "Verordening maatschappelijke ondersteuning gemeente Amsterdam 2020"
+        );
+        assert_eq!(result.creator, "Gemeente Amsterdam");
+        assert_eq!(result.organisation_type, "gemeenten");
+        assert_eq!(
+            result.regulatory_layer,
+            RegulatoryLayer::GemeentelijkeVerordening
+        );
+        assert_eq!(result.publication_date, Some("2020-01-01".to_string()));
+        assert_eq!(result.effective_date, Some("2020-03-01".to_string()));
+        assert!(result.warnings.is_empty());
+    }
+
+    #[test]
+    fn test_parse_sru_response_no_records() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<searchRetrieveResponse xmlns="http://www.loc.gov/zing/srw/">
+  <numberOfRecords>0</numberOfRecords>
+  <records/>
+</searchRetrieveResponse>"#;
+
+        let result = parse_sru_response(xml, "CVDR000000");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_cvdr_metadata_to_law_metadata() {
+        let metadata = CvdrMetadata {
+            cvdr_id: "CVDR681386".to_string(),
+            title: "Test Verordening".to_string(),
+            creator: "Gemeente Test".to_string(),
+            organisation_type: "gemeenten".to_string(),
+            regulatory_layer: RegulatoryLayer::GemeentelijkeVerordening,
+            publication_date: Some("2020-01-01".to_string()),
+            effective_date: Some("2020-03-01".to_string()),
+            xml_url: "https://example.com/test.xml".to_string(),
+            warnings: Vec::new(),
+        };
+
+        let law_meta = metadata.to_law_metadata("2025-01-01");
+        assert_eq!(law_meta.bwb_id, "CVDR681386");
+        assert_eq!(law_meta.cvdr_id, Some("CVDR681386".to_string()));
+        assert_eq!(law_meta.title, "Test Verordening");
+        assert_eq!(
+            law_meta.regulatory_layer,
+            RegulatoryLayer::GemeentelijkeVerordening
+        );
+        assert_eq!(law_meta.creator, Some("Gemeente Test".to_string()));
+        assert_eq!(law_meta.effective_date, Some("2025-01-01".to_string()));
+    }
+}

--- a/packages/harvester/src/error.rs
+++ b/packages/harvester/src/error.rs
@@ -103,10 +103,6 @@ pub enum HarvesterError {
         #[source]
         source: reqwest::Error,
     },
-
-    /// CVDR XML parsing failed.
-    #[error("Failed to parse CVDR XML for {cvdr_id}: {message}")]
-    CvdrParseFailed { cvdr_id: String, message: String },
 }
 
 /// Result type alias for harvester operations.

--- a/packages/harvester/src/error.rs
+++ b/packages/harvester/src/error.rs
@@ -83,6 +83,30 @@ pub enum HarvesterError {
     /// No consolidation found for the given date.
     #[error("No consolidation found for {bwb_id} at date {date}")]
     NoConsolidation { bwb_id: String, date: String },
+
+    /// Invalid CVDR ID format.
+    #[error("Invalid CVDR ID format: '{0}'. Expected CVDR followed by 3 or more digits (e.g., CVDR681386)")]
+    InvalidCvdrId(String),
+
+    /// Invalid law ID format (neither BWB nor CVDR).
+    #[error("Invalid law ID format: '{0}'. Expected BWB ID (BWBRXXXXXXX) or CVDR ID (CVDRXXX...)")]
+    InvalidLawId(String),
+
+    /// CVDR SRU search failed.
+    #[error("CVDR SRU search failed for {cvdr_id}: {message}")]
+    CvdrSearchFailed { cvdr_id: String, message: String },
+
+    /// CVDR content download failed.
+    #[error("Failed to download CVDR content for {cvdr_id}: {source}")]
+    CvdrContentDownload {
+        cvdr_id: String,
+        #[source]
+        source: reqwest::Error,
+    },
+
+    /// CVDR XML parsing failed.
+    #[error("Failed to parse CVDR XML for {cvdr_id}: {message}")]
+    CvdrParseFailed { cvdr_id: String, message: String },
 }
 
 /// Result type alias for harvester operations.

--- a/packages/harvester/src/lib.rs
+++ b/packages/harvester/src/lib.rs
@@ -59,7 +59,7 @@ pub use cvdr::download_cvdr_law;
 pub use harvester::{download_law, download_law_with_max_size};
 
 // Re-export source trait and detection
-pub use source::{detect_source, BwbSource, CvdrSource, LawSource};
+pub use source::{detect_source, BwbSource, CvdrSource, LawSource, LawSourceType};
 
 // Re-export commonly used items
 pub use config::{validate_bwb_id, validate_cvdr_id, validate_date};

--- a/packages/harvester/src/lib.rs
+++ b/packages/harvester/src/lib.rs
@@ -36,6 +36,7 @@
 //! - [`yaml`]: YAML output generation
 //! - [`cli`]: Command-line interface
 //! - [`harvester`]: Main harvester service
+//! - [`source`]: Strategy trait for law sources (BWB, CVDR)
 
 pub mod cli;
 pub mod config;
@@ -46,6 +47,7 @@ pub mod harvester;
 pub mod http;
 pub mod manifest;
 pub mod registry;
+pub mod source;
 pub mod splitting;
 pub mod types;
 pub mod wti;
@@ -55,6 +57,9 @@ pub mod yaml;
 // Re-export main functions
 pub use cvdr::download_cvdr_law;
 pub use harvester::{download_law, download_law_with_max_size};
+
+// Re-export source trait and detection
+pub use source::{detect_source, BwbSource, CvdrSource, LawSource};
 
 // Re-export commonly used items
 pub use config::{validate_bwb_id, validate_cvdr_id, validate_date};

--- a/packages/harvester/src/lib.rs
+++ b/packages/harvester/src/lib.rs
@@ -1,8 +1,9 @@
-//! RegelRecht Harvester - Download Dutch legislation from BWB repository.
+//! RegelRecht Harvester - Download Dutch legislation from BWB and CVDR repositories.
 //!
 //! This crate provides functionality to download Dutch laws from the
-//! Basiswettenbestand (BWB) repository and convert them to schema-compliant
-//! YAML format.
+//! Basiswettenbestand (BWB) repository and decentrale regelgeving from
+//! CVDR (Centrale Voorziening Decentrale Regelgeving), converting them
+//! to schema-compliant YAML format.
 //!
 //! # Example
 //!
@@ -12,6 +13,9 @@
 //! // Validate BWB ID and date
 //! assert!(config::validate_bwb_id("BWBR0018451").is_ok());
 //! assert!(config::validate_date("2025-01-01").is_ok());
+//!
+//! // Validate CVDR ID
+//! assert!(config::validate_cvdr_id("CVDR681386").is_ok());
 //! ```
 //!
 //! # Architecture
@@ -21,10 +25,11 @@
 //! - [`config`]: Configuration constants and validation
 //! - [`types`]: Core data types (Law, Article, Reference, etc.)
 //! - [`error`]: Error types and Result alias
-//! - [`http`]: HTTP client for downloading from BWB
-//! - [`wti`]: WTI metadata parsing
+//! - [`http`]: HTTP client for downloading from BWB/CVDR
+//! - [`wti`]: WTI metadata parsing (BWB)
 //! - [`manifest`]: BWB manifest parsing for consolidation date resolution
-//! - [`content`]: Content XML downloading
+//! - [`content`]: Content XML downloading (BWB)
+//! - [`cvdr`]: CVDR harvester (search, download, parse)
 //! - [`xml`]: XML utilities
 //! - [`registry`]: Extensible element handler system
 //! - [`splitting`]: Article splitting logic
@@ -35,6 +40,7 @@
 pub mod cli;
 pub mod config;
 pub mod content;
+pub mod cvdr;
 pub mod error;
 pub mod harvester;
 pub mod http;
@@ -47,9 +53,10 @@ pub mod xml;
 pub mod yaml;
 
 // Re-export main functions
+pub use cvdr::download_cvdr_law;
 pub use harvester::{download_law, download_law_with_max_size};
 
 // Re-export commonly used items
-pub use config::{validate_bwb_id, validate_date};
+pub use config::{validate_bwb_id, validate_cvdr_id, validate_date};
 pub use error::{HarvesterError, Result};
 pub use types::{Article, Law, LawMetadata, Preamble, Reference, RegulatoryLayer};

--- a/packages/harvester/src/source.rs
+++ b/packages/harvester/src/source.rs
@@ -1,0 +1,184 @@
+//! Strategy trait for downloading laws from different sources.
+//!
+//! Provides a unified interface over BWB (national laws) and CVDR
+//! (decentral regulations), so consumers can work with a single
+//! `dyn LawSource` instead of if/else routing.
+
+use async_trait::async_trait;
+use reqwest::Client;
+
+use crate::config::{
+    lokaleregelgeving_url, validate_bwb_id, validate_cvdr_id, DEFAULT_MAX_RESPONSE_SIZE,
+};
+use crate::error::{HarvesterError, Result};
+use crate::types::Law;
+
+/// Strategy trait for downloading laws from different sources.
+#[async_trait]
+pub trait LawSource: Send + Sync {
+    /// Validate that the given ID is valid for this source.
+    fn validate_id(&self, id: &str) -> Result<()>;
+
+    /// Download and parse a law.
+    async fn download(&self, client: &Client, id: &str, date: Option<&str>) -> Result<Law>;
+
+    /// Build the public URL for a law.
+    fn public_url(&self, id: &str) -> String;
+
+    /// Source name for logging/display.
+    fn name(&self) -> &'static str;
+}
+
+/// BWB (Basiswettenbestand) source for national laws.
+#[derive(Debug, Default)]
+pub struct BwbSource {
+    /// Maximum response size in megabytes.
+    pub max_size_mb: Option<u64>,
+}
+
+#[async_trait]
+impl LawSource for BwbSource {
+    fn validate_id(&self, id: &str) -> Result<()> {
+        validate_bwb_id(id)
+    }
+
+    async fn download(&self, client: &Client, id: &str, date: Option<&str>) -> Result<Law> {
+        // BWB requires a date; default to today if not provided.
+        let effective_date = date
+            .map(String::from)
+            .unwrap_or_else(|| chrono::Local::now().format("%Y-%m-%d").to_string());
+
+        let max_mb = self
+            .max_size_mb
+            .unwrap_or(DEFAULT_MAX_RESPONSE_SIZE / (1024 * 1024));
+
+        crate::harvester::download_law_with_max_size(client, id, &effective_date, max_mb).await
+    }
+
+    fn public_url(&self, id: &str) -> String {
+        format!("https://wetten.overheid.nl/{id}")
+    }
+
+    fn name(&self) -> &'static str {
+        "BWB"
+    }
+}
+
+/// CVDR (Centrale Voorziening Decentrale Regelgeving) source for decentral regulations.
+#[derive(Debug, Default)]
+pub struct CvdrSource;
+
+#[async_trait]
+impl LawSource for CvdrSource {
+    fn validate_id(&self, id: &str) -> Result<()> {
+        validate_cvdr_id(id)
+    }
+
+    async fn download(&self, client: &Client, id: &str, date: Option<&str>) -> Result<Law> {
+        crate::cvdr::download_cvdr_law(client, id, date).await
+    }
+
+    fn public_url(&self, id: &str) -> String {
+        lokaleregelgeving_url(id)
+    }
+
+    fn name(&self) -> &'static str {
+        "CVDR"
+    }
+}
+
+/// Detect the law source from an ID and return the appropriate strategy.
+///
+/// # Errors
+/// Returns `HarvesterError::InvalidLawId` if the ID prefix is not recognized.
+///
+/// # Examples
+/// ```
+/// use regelrecht_harvester::source::detect_source;
+///
+/// let source = detect_source("BWBR0018451").unwrap();
+/// assert_eq!(source.name(), "BWB");
+///
+/// let source = detect_source("CVDR681386").unwrap();
+/// assert_eq!(source.name(), "CVDR");
+///
+/// assert!(detect_source("INVALID").is_err());
+/// ```
+pub fn detect_source(law_id: &str) -> Result<Box<dyn LawSource>> {
+    if law_id.starts_with("BWBR") {
+        Ok(Box::new(BwbSource::default()))
+    } else if law_id.starts_with("CVDR") {
+        Ok(Box::new(CvdrSource))
+    } else {
+        Err(HarvesterError::InvalidLawId(law_id.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_bwb_source() {
+        let source = detect_source("BWBR0018451").unwrap();
+        assert_eq!(source.name(), "BWB");
+    }
+
+    #[test]
+    fn detect_cvdr_source() {
+        let source = detect_source("CVDR681386").unwrap();
+        assert_eq!(source.name(), "CVDR");
+    }
+
+    #[test]
+    fn detect_invalid_source() {
+        assert!(detect_source("INVALID").is_err());
+        assert!(detect_source("").is_err());
+    }
+
+    #[test]
+    fn bwb_source_validates_id() {
+        let source = BwbSource::default();
+        assert!(source.validate_id("BWBR0018451").is_ok());
+        assert!(source.validate_id("INVALID").is_err());
+    }
+
+    #[test]
+    fn cvdr_source_validates_id() {
+        let source = CvdrSource;
+        assert!(source.validate_id("CVDR681386").is_ok());
+        assert!(source.validate_id("INVALID").is_err());
+    }
+
+    #[test]
+    fn bwb_source_public_url() {
+        let source = BwbSource::default();
+        assert_eq!(
+            source.public_url("BWBR0018451"),
+            "https://wetten.overheid.nl/BWBR0018451"
+        );
+    }
+
+    #[test]
+    fn cvdr_source_public_url() {
+        let source = CvdrSource;
+        assert_eq!(
+            source.public_url("CVDR681386"),
+            "https://lokaleregelgeving.overheid.nl/CVDR681386"
+        );
+    }
+
+    #[test]
+    fn bwb_source_default_max_size() {
+        let source = BwbSource::default();
+        assert!(source.max_size_mb.is_none());
+    }
+
+    #[test]
+    fn bwb_source_custom_max_size() {
+        let source = BwbSource {
+            max_size_mb: Some(200),
+        };
+        assert_eq!(source.max_size_mb, Some(200));
+    }
+}

--- a/packages/harvester/src/source.rs
+++ b/packages/harvester/src/source.rs
@@ -13,6 +13,15 @@ use crate::config::{
 use crate::error::{HarvesterError, Result};
 use crate::types::Law;
 
+/// Enum identifying the law source type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LawSourceType {
+    /// National law from BWB (Basiswettenbestand).
+    Bwb,
+    /// Decentral regulation from CVDR.
+    Cvdr,
+}
+
 /// Strategy trait for downloading laws from different sources.
 #[async_trait]
 pub trait LawSource: Send + Sync {
@@ -27,6 +36,9 @@ pub trait LawSource: Send + Sync {
 
     /// Source name for logging/display.
     fn name(&self) -> &'static str;
+
+    /// Source type enum for type-safe dispatch.
+    fn source_type(&self) -> LawSourceType;
 }
 
 /// BWB (Basiswettenbestand) source for national laws.
@@ -62,6 +74,10 @@ impl LawSource for BwbSource {
     fn name(&self) -> &'static str {
         "BWB"
     }
+
+    fn source_type(&self) -> LawSourceType {
+        LawSourceType::Bwb
+    }
 }
 
 /// CVDR (Centrale Voorziening Decentrale Regelgeving) source for decentral regulations.
@@ -85,6 +101,10 @@ impl LawSource for CvdrSource {
     fn name(&self) -> &'static str {
         "CVDR"
     }
+
+    fn source_type(&self) -> LawSourceType {
+        LawSourceType::Cvdr
+    }
 }
 
 /// Detect the law source from an ID and return the appropriate strategy.
@@ -105,13 +125,15 @@ impl LawSource for CvdrSource {
 /// assert!(detect_source("INVALID").is_err());
 /// ```
 pub fn detect_source(law_id: &str) -> Result<Box<dyn LawSource>> {
-    if law_id.starts_with("BWBR") {
-        Ok(Box::new(BwbSource::default()))
+    let source: Box<dyn LawSource> = if law_id.starts_with("BWBR") {
+        Box::new(BwbSource::default())
     } else if law_id.starts_with("CVDR") {
-        Ok(Box::new(CvdrSource))
+        Box::new(CvdrSource)
     } else {
-        Err(HarvesterError::InvalidLawId(law_id.to_string()))
-    }
+        return Err(HarvesterError::InvalidLawId(law_id.to_string()));
+    };
+    source.validate_id(law_id)?;
+    Ok(source)
 }
 
 #[cfg(test)]

--- a/packages/harvester/src/types.rs
+++ b/packages/harvester/src/types.rs
@@ -68,11 +68,15 @@ pub fn regulatory_layer_from_soort_regeling(text: &str) -> (RegulatoryLayer, Opt
     }
 }
 
-/// Metadata extracted from WTI file.
+/// Metadata extracted from WTI file or CVDR SRU search.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LawMetadata {
     /// BWB identifier (e.g., "BWBR0018451").
+    /// For CVDR laws, this is set to the CVDR ID.
     pub bwb_id: String,
+
+    /// CVDR identifier (e.g., "CVDR681386"), if this law came from CVDR.
+    pub cvdr_id: Option<String>,
 
     /// Official title (citeertitel).
     pub title: String,
@@ -85,6 +89,12 @@ pub struct LawMetadata {
 
     /// Effective date (optional, usually set from request).
     pub effective_date: Option<String>,
+
+    /// Organisation name (e.g., "Gemeente Amsterdam"), for CVDR laws.
+    pub creator: Option<String>,
+
+    /// Scope code (e.g., "GM0363", "WS0155", "PV27"), for CVDR laws.
+    pub scope_code: Option<String>,
 }
 
 /// Regex for slug generation - matches non-word characters.
@@ -109,10 +119,13 @@ impl LawMetadata {
     ///
     /// let metadata = LawMetadata {
     ///     bwb_id: "BWBR0018451".to_string(),
+    ///     cvdr_id: None,
     ///     title: "Wet op de zorgtoeslag".to_string(),
     ///     regulatory_layer: RegulatoryLayer::Wet,
     ///     publication_date: None,
     ///     effective_date: None,
+    ///     creator: None,
+    ///     scope_code: None,
     /// };
     /// assert_eq!(metadata.to_slug(), "wet_op_de_zorgtoeslag");
     /// ```
@@ -399,10 +412,13 @@ mod tests {
     fn test_law_metadata_to_slug() {
         let metadata = LawMetadata {
             bwb_id: "BWBR0018451".to_string(),
+            cvdr_id: None,
             title: "Wet op de zorgtoeslag".to_string(),
             regulatory_layer: RegulatoryLayer::Wet,
             publication_date: None,
             effective_date: None,
+            creator: None,
+            scope_code: None,
         };
         assert_eq!(metadata.to_slug(), "wet_op_de_zorgtoeslag");
     }
@@ -411,10 +427,13 @@ mod tests {
     fn test_law_metadata_to_slug_special_chars() {
         let metadata = LawMetadata {
             bwb_id: "BWBR0000000".to_string(),
+            cvdr_id: None,
             title: "Wet (test) - special!".to_string(),
             regulatory_layer: RegulatoryLayer::Wet,
             publication_date: None,
             effective_date: None,
+            creator: None,
+            scope_code: None,
         };
         assert_eq!(metadata.to_slug(), "wet_test_special");
     }
@@ -423,10 +442,13 @@ mod tests {
     fn test_law_metadata_to_slug_diacritics() {
         let metadata = LawMetadata {
             bwb_id: "BWBR0000000".to_string(),
+            cvdr_id: None,
             title: "Ministeriële regeling".to_string(),
             regulatory_layer: RegulatoryLayer::MinisterieleRegeling,
             publication_date: None,
             effective_date: None,
+            creator: None,
+            scope_code: None,
         };
         // ë should be normalized to e
         assert_eq!(metadata.to_slug(), "ministeriele_regeling");
@@ -436,10 +458,13 @@ mod tests {
     fn test_law_metadata_to_slug_various_diacritics() {
         let metadata = LawMetadata {
             bwb_id: "BWBR0000000".to_string(),
+            cvdr_id: None,
             title: "Café résumé naïve".to_string(),
             regulatory_layer: RegulatoryLayer::Wet,
             publication_date: None,
             effective_date: None,
+            creator: None,
+            scope_code: None,
         };
         // é, é, ï should all be normalized to their ASCII equivalents
         assert_eq!(metadata.to_slug(), "cafe_resume_naive");
@@ -576,10 +601,13 @@ mod tests {
     fn test_law_add_article() {
         let metadata = LawMetadata {
             bwb_id: "BWBR0018451".to_string(),
+            cvdr_id: None,
             title: "Test Law".to_string(),
             regulatory_layer: RegulatoryLayer::Wet,
             publication_date: None,
             effective_date: None,
+            creator: None,
+            scope_code: None,
         };
 
         let mut law = Law::new(metadata);

--- a/packages/harvester/src/wti.rs
+++ b/packages/harvester/src/wti.rs
@@ -96,10 +96,13 @@ pub fn parse_wti_metadata(doc: &Document<'_>) -> WtiParseResult {
     WtiParseResult {
         metadata: LawMetadata {
             bwb_id,
+            cvdr_id: None,
             title,
             regulatory_layer,
             publication_date,
             effective_date: None,
+            creator: None,
+            scope_code: None,
         },
         warnings,
     }

--- a/packages/harvester/src/yaml/writer.rs
+++ b/packages/harvester/src/yaml/writer.rs
@@ -92,12 +92,13 @@ struct YamlLaw {
     valid_from: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     bwb_id: Option<String>,
+    // NOTE: cvdr_id is not yet in the schema; emitted as an extension for traceability.
     #[serde(skip_serializing_if = "Option::is_none")]
     cvdr_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     officiele_titel: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    creator: Option<String>,
+    organisation: Option<String>,
     url: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     preamble: Option<YamlPreamble>,
@@ -148,7 +149,7 @@ fn generate_yaml_struct(law: &Law, effective_date: &str) -> YamlLaw {
         .collect();
 
     // Build URL and IDs based on source type
-    let (bwb_id, cvdr_id, officiele_titel, creator, url) = if is_cvdr {
+    let (bwb_id, cvdr_id, officiele_titel, organisation, url) = if is_cvdr {
         let cvdr_id_str = law.metadata.cvdr_id.as_deref().unwrap_or_default();
         let url = format!("https://lokaleregelgeving.overheid.nl/{cvdr_id_str}");
         (
@@ -184,7 +185,7 @@ fn generate_yaml_struct(law: &Law, effective_date: &str) -> YamlLaw {
         bwb_id,
         cvdr_id,
         officiele_titel,
-        creator,
+        organisation,
         url,
         preamble,
         articles,

--- a/packages/harvester/src/yaml/writer.rs
+++ b/packages/harvester/src/yaml/writer.rs
@@ -90,7 +90,14 @@ struct YamlLaw {
     regulatory_layer: String,
     publication_date: String,
     valid_from: String,
-    bwb_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    bwb_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cvdr_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    officiele_titel: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    creator: Option<String>,
     url: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     preamble: Option<YamlPreamble>,
@@ -100,6 +107,7 @@ struct YamlLaw {
 /// Generate a schema-compliant YAML structure from a Law object.
 fn generate_yaml_struct(law: &Law, effective_date: &str) -> YamlLaw {
     let law_id = law.metadata.to_slug();
+    let is_cvdr = law.metadata.cvdr_id.is_some();
 
     // Convert preamble if present
     let preamble = law.preamble.as_ref().map(|p| {
@@ -139,6 +147,30 @@ fn generate_yaml_struct(law: &Law, effective_date: &str) -> YamlLaw {
         })
         .collect();
 
+    // Build URL and IDs based on source type
+    let (bwb_id, cvdr_id, officiele_titel, creator, url) = if is_cvdr {
+        let cvdr_id_str = law.metadata.cvdr_id.as_deref().unwrap_or_default();
+        let url = format!("https://lokaleregelgeving.overheid.nl/{cvdr_id_str}");
+        (
+            None,
+            law.metadata.cvdr_id.clone(),
+            Some(law.metadata.title.clone()),
+            law.metadata.creator.clone(),
+            url,
+        )
+    } else {
+        (
+            Some(law.metadata.bwb_id.clone()),
+            None,
+            None,
+            None,
+            format!(
+                "https://wetten.overheid.nl/{}/{}",
+                law.metadata.bwb_id, effective_date
+            ),
+        )
+    };
+
     YamlLaw {
         schema: SCHEMA_URL.to_string(),
         id: law_id,
@@ -149,11 +181,11 @@ fn generate_yaml_struct(law: &Law, effective_date: &str) -> YamlLaw {
             .clone()
             .unwrap_or_else(|| effective_date.to_string()),
         valid_from: effective_date.to_string(),
-        bwb_id: law.metadata.bwb_id.clone(),
-        url: format!(
-            "https://wetten.overheid.nl/{}/{}",
-            law.metadata.bwb_id, effective_date
-        ),
+        bwb_id,
+        cvdr_id,
+        officiele_titel,
+        creator,
+        url,
         preamble,
         articles,
     }
@@ -388,10 +420,13 @@ mod tests {
     fn create_test_law() -> Law {
         let metadata = LawMetadata {
             bwb_id: "BWBR0018451".to_string(),
+            cvdr_id: None,
             title: "Wet op de zorgtoeslag".to_string(),
             regulatory_layer: RegulatoryLayer::Wet,
             publication_date: Some("2005-12-29".to_string()),
             effective_date: None,
+            creator: None,
+            scope_code: None,
         };
 
         let mut law = Law::new(metadata);

--- a/packages/pipeline/src/harvest.rs
+++ b/packages/pipeline/src/harvest.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::Result;
 use regelrecht_harvester::manifest;
+use regelrecht_harvester::LawSource;
 
 /// Maximum recursion depth for follow-up harvest jobs.
 /// Prevents unbounded job creation from circular or deeply nested law references.
@@ -86,10 +87,13 @@ pub struct LawStatusFile {
 
 /// Execute a harvest: download, parse, and save a law as YAML.
 ///
-/// Routes to BWB or CVDR download based on the payload fields:
-/// - `cvdr_id` set → CVDR (decentral regulations)
-/// - `bwb_id` set → BWB (national laws)
-/// - neither set → error
+/// Uses the `LawSource` trait to detect the source from the payload's law ID
+/// and delegates downloading to the appropriate strategy (BWB or CVDR).
+///
+/// For BWB laws, the manifest is consulted to resolve the consolidation date
+/// before downloading. This BWB-specific step is handled here because it
+/// depends on pipeline-level logic (manifest resolution) that lives outside
+/// the harvester crate.
 ///
 /// Returns the harvest result and a list of file paths that were written
 /// (for git staging).
@@ -99,133 +103,45 @@ pub async fn execute_harvest(
     output_base: &str,
     http_client: &Client,
 ) -> Result<(HarvestResult, Vec<PathBuf>)> {
-    if let Some(ref cvdr_id) = payload.cvdr_id {
-        execute_harvest_cvdr(cvdr_id, payload, repo_path, output_base, http_client).await
-    } else if let Some(ref bwb_id) = payload.bwb_id {
-        execute_harvest_bwb(bwb_id, payload, repo_path, output_base, http_client).await
-    } else {
-        Err(crate::error::PipelineError::InvalidInput(
+    let law_id = payload.law_id().ok_or_else(|| {
+        crate::error::PipelineError::InvalidInput(
             "harvest payload must have either bwb_id or cvdr_id".into(),
-        ))
-    }
-}
-
-/// Execute a BWB harvest (national laws).
-async fn execute_harvest_bwb(
-    bwb_id: &str,
-    payload: &HarvestPayload,
-    repo_path: &Path,
-    output_base: &str,
-    http_client: &Client,
-) -> Result<(HarvestResult, Vec<PathBuf>)> {
-    let bwb_manifest = manifest::download_manifest(http_client, bwb_id).await?;
-    let effective_date =
-        manifest::resolve_consolidation_date(&bwb_manifest, payload.date.as_deref())?;
-    tracing::info!(bwb_id = %bwb_id, resolved_date = %effective_date, "resolved consolidation date from manifest");
-
-    tracing::info!(bwb_id = %bwb_id, date = %effective_date, "downloading law XML from BWB");
-    let law = if let Some(max_mb) = payload.max_size_mb {
-        regelrecht_harvester::download_law_with_max_size(
-            http_client,
-            bwb_id,
-            &effective_date,
-            max_mb,
         )
-        .await?
-    } else {
-        regelrecht_harvester::download_law(http_client, bwb_id, &effective_date).await?
-    };
+    })?;
 
-    tracing::info!(bwb_id = %bwb_id, title = %law.metadata.title, "law XML downloaded successfully");
-    let law_name = law.metadata.title.clone();
-    let slug = law.metadata.to_slug();
-    let layer = law.metadata.regulatory_layer.as_str().to_string();
-    let article_count = law.articles.len();
-    let warning_count = law.warning_count();
-    let warnings = law.warnings.clone();
+    let source = regelrecht_harvester::detect_source(law_id)?;
+    let source_type = source.name().to_lowercase();
 
-    let mut referenced_bwb_ids: Vec<String> = law
-        .articles
-        .iter()
-        .flat_map(|a| a.references.iter())
-        .map(|r| r.bwb_id.clone())
-        .filter(|id| id != bwb_id)
-        .collect::<HashSet<_>>()
-        .into_iter()
-        .collect();
-    referenced_bwb_ids.sort();
+    // For BWB, resolve the effective date from the manifest.
+    // For CVDR, use the requested date, the law's metadata date, or today.
+    let (law, effective_date) = if source.name() == "BWB" {
+        let bwb_manifest = manifest::download_manifest(http_client, law_id).await?;
+        let resolved_date =
+            manifest::resolve_consolidation_date(&bwb_manifest, payload.date.as_deref())?;
+        tracing::info!(law_id = %law_id, resolved_date = %resolved_date, "resolved consolidation date from manifest");
 
-    let output_base_path = repo_path.join(output_base);
-    let law_for_save = law;
-    let date_for_save = effective_date.clone();
-    let yaml_path = tokio::task::spawn_blocking(move || {
-        regelrecht_harvester::yaml::save_yaml(
-            &law_for_save,
-            &date_for_save,
-            Some(&output_base_path),
-        )
-    })
-    .await??;
-
-    let status_file_path = yaml_path
-        .parent()
-        .map(|p| p.join("status.yaml"))
-        .unwrap_or_else(|| PathBuf::from("status.yaml"));
-
-    let status = LawStatusFile {
-        law_id: bwb_id.to_string(),
-        law_name: law_name.clone(),
-        slug: slug.clone(),
-        status: "harvested".to_string(),
-        last_harvested: Utc::now().to_rfc3339(),
-        harvest_date: effective_date.clone(),
-        article_count,
-        warning_count,
-        warnings: warnings.clone(),
-    };
-
-    let status_yaml = serde_yaml_ng::to_string(&status)?;
-    let status_content = format!("---\n{status_yaml}");
-    tokio::fs::write(&status_file_path, status_content).await?;
-
-    let relative_path = yaml_path
-        .strip_prefix(repo_path)
-        .unwrap_or(&yaml_path)
-        .to_string_lossy()
-        .to_string();
-
-    let result = HarvestResult {
-        law_name,
-        slug,
-        layer,
-        file_path: relative_path,
-        article_count,
-        warning_count,
-        warnings,
-        referenced_bwb_ids,
-        harvest_date: effective_date,
-        source_type: "bwb".to_string(),
-    };
-
-    let written_files = vec![yaml_path, status_file_path];
-    Ok((result, written_files))
-}
-
-/// Execute a CVDR harvest (decentral regulations).
-async fn execute_harvest_cvdr(
-    cvdr_id: &str,
-    payload: &HarvestPayload,
-    repo_path: &Path,
-    output_base: &str,
-    http_client: &Client,
-) -> Result<(HarvestResult, Vec<PathBuf>)> {
-    tracing::info!(cvdr_id = %cvdr_id, "downloading law from CVDR");
-
-    let law =
-        regelrecht_harvester::download_cvdr_law(http_client, cvdr_id, payload.date.as_deref())
+        tracing::info!(law_id = %law_id, date = %resolved_date, "downloading law XML from BWB");
+        let bwb_source = regelrecht_harvester::BwbSource {
+            max_size_mb: payload.max_size_mb,
+        };
+        let law = bwb_source
+            .download(http_client, law_id, Some(&resolved_date))
             .await?;
+        (law, resolved_date)
+    } else {
+        tracing::info!(law_id = %law_id, source = source.name(), "downloading law from {}", source.name());
+        let law = source
+            .download(http_client, law_id, payload.date.as_deref())
+            .await?;
+        let effective_date = payload
+            .date
+            .clone()
+            .or_else(|| law.metadata.effective_date.clone())
+            .unwrap_or_else(|| Utc::now().format("%Y-%m-%d").to_string());
+        (law, effective_date)
+    };
 
-    tracing::info!(cvdr_id = %cvdr_id, title = %law.metadata.title, "CVDR law downloaded successfully");
+    tracing::info!(law_id = %law_id, title = %law.metadata.title, "law downloaded successfully");
     let law_name = law.metadata.title.clone();
     let slug = law.metadata.to_slug();
     let layer = law.metadata.regulatory_layer.as_str().to_string();
@@ -233,25 +149,16 @@ async fn execute_harvest_cvdr(
     let warning_count = law.warning_count();
     let warnings = law.warnings.clone();
 
-    // CVDR laws typically don't have cross-references to BWB laws in the same way,
-    // but we still collect any references that exist.
     let mut referenced_bwb_ids: Vec<String> = law
         .articles
         .iter()
         .flat_map(|a| a.references.iter())
         .map(|r| r.bwb_id.clone())
-        .filter(|id| id != cvdr_id)
+        .filter(|id| id != law_id)
         .collect::<HashSet<_>>()
         .into_iter()
         .collect();
     referenced_bwb_ids.sort();
-
-    // Determine effective date — use the requested date, metadata date, or today
-    let effective_date = payload
-        .date
-        .clone()
-        .or_else(|| law.metadata.effective_date.clone())
-        .unwrap_or_else(|| Utc::now().format("%Y-%m-%d").to_string());
 
     let output_base_path = repo_path.join(output_base);
     let law_for_save = law;
@@ -271,7 +178,7 @@ async fn execute_harvest_cvdr(
         .unwrap_or_else(|| PathBuf::from("status.yaml"));
 
     let status = LawStatusFile {
-        law_id: cvdr_id.to_string(),
+        law_id: law_id.to_string(),
         law_name: law_name.clone(),
         slug: slug.clone(),
         status: "harvested".to_string(),
@@ -302,7 +209,7 @@ async fn execute_harvest_cvdr(
         warnings,
         referenced_bwb_ids,
         harvest_date: effective_date,
-        source_type: "cvdr".to_string(),
+        source_type,
     };
 
     let written_files = vec![yaml_path, status_file_path];

--- a/packages/pipeline/src/harvest.rs
+++ b/packages/pipeline/src/harvest.rs
@@ -26,7 +26,7 @@ pub const MAX_HARVEST_DEPTH: u32 = 1000;
 pub struct HarvestPayload {
     /// BWB identifier for national laws (e.g. "BWBR0018451").
     /// Previously a required `String`; now optional to support CVDR sources.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub bwb_id: Option<String>,
     /// CVDR identifier for decentral regulations (e.g. "CVDR681386").
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -44,6 +44,28 @@ impl HarvestPayload {
     /// Returns the law identifier (BWB or CVDR) for this payload.
     pub fn law_id(&self) -> Option<&str> {
         self.bwb_id.as_deref().or(self.cvdr_id.as_deref())
+    }
+
+    /// Create a harvest payload for a law, auto-detecting BWB vs CVDR from the ID prefix.
+    #[must_use]
+    pub fn for_law(law_id: &str, date: Option<String>) -> Self {
+        if law_id.starts_with("BWBR") {
+            Self {
+                bwb_id: Some(law_id.to_string()),
+                cvdr_id: None,
+                date,
+                max_size_mb: None,
+                depth: None,
+            }
+        } else {
+            Self {
+                bwb_id: None,
+                cvdr_id: Some(law_id.to_string()),
+                date,
+                max_size_mb: None,
+                depth: None,
+            }
+        }
     }
 }
 
@@ -74,6 +96,7 @@ fn default_source_type() -> String {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LawStatusFile {
     /// Law identifier (BWB or CVDR).
+    #[serde(alias = "bwb_id")]
     pub law_id: String,
     pub law_name: String,
     pub slug: String,
@@ -114,7 +137,8 @@ pub async fn execute_harvest(
 
     // For BWB, resolve the effective date from the manifest.
     // For CVDR, use the requested date, the law's metadata date, or today.
-    let (law, effective_date) = if source.name() == "BWB" {
+    let (law, effective_date) = if source.source_type() == regelrecht_harvester::LawSourceType::Bwb
+    {
         let bwb_manifest = manifest::download_manifest(http_client, law_id).await?;
         let resolved_date =
             manifest::resolve_consolidation_date(&bwb_manifest, payload.date.as_deref())?;

--- a/packages/pipeline/src/harvest.rs
+++ b/packages/pipeline/src/harvest.rs
@@ -13,9 +13,23 @@ use regelrecht_harvester::manifest;
 pub const MAX_HARVEST_DEPTH: u32 = 1000;
 
 /// Payload for a harvest job, stored as JSON in the job queue.
+///
+/// Supports both BWB (national) and CVDR (decentral) law sources.
+/// Exactly one of `bwb_id` or `cvdr_id` should be set.
+///
+/// The `bwb_id` field uses `#[serde(default)]` for backward compatibility:
+/// existing queued jobs serialized as `{"bwb_id": "BWBR..."}` (a plain String)
+/// will deserialize correctly because serde treats a present string value as
+/// `Some(...)`, while new payloads omit it entirely when only `cvdr_id` is set.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HarvestPayload {
-    pub bwb_id: String,
+    /// BWB identifier for national laws (e.g. "BWBR0018451").
+    /// Previously a required `String`; now optional to support CVDR sources.
+    #[serde(default)]
+    pub bwb_id: Option<String>,
+    /// CVDR identifier for decentral regulations (e.g. "CVDR681386").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cvdr_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub date: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -23,6 +37,13 @@ pub struct HarvestPayload {
     /// Current recursion depth for follow-up harvests. `None` or `0` means this is a root job.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub depth: Option<u32>,
+}
+
+impl HarvestPayload {
+    /// Returns the law identifier (BWB or CVDR) for this payload.
+    pub fn law_id(&self) -> Option<&str> {
+        self.bwb_id.as_deref().or(self.cvdr_id.as_deref())
+    }
 }
 
 /// Result of a successful harvest execution.
@@ -39,12 +60,20 @@ pub struct HarvestResult {
     pub referenced_bwb_ids: Vec<String>,
     /// The resolved effective date used for this harvest.
     pub harvest_date: String,
+    /// Source type: "bwb" or "cvdr".
+    #[serde(default = "default_source_type")]
+    pub source_type: String,
+}
+
+fn default_source_type() -> String {
+    "bwb".to_string()
 }
 
 /// Status file written alongside the law YAML.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LawStatusFile {
-    pub bwb_id: String,
+    /// Law identifier (BWB or CVDR).
+    pub law_id: String,
     pub law_name: String,
     pub slug: String,
     pub status: String,
@@ -57,6 +86,11 @@ pub struct LawStatusFile {
 
 /// Execute a harvest: download, parse, and save a law as YAML.
 ///
+/// Routes to BWB or CVDR download based on the payload fields:
+/// - `cvdr_id` set → CVDR (decentral regulations)
+/// - `bwb_id` set → BWB (national laws)
+/// - neither set → error
+///
 /// Returns the harvest result and a list of file paths that were written
 /// (for git staging).
 pub async fn execute_harvest(
@@ -65,25 +99,44 @@ pub async fn execute_harvest(
     output_base: &str,
     http_client: &Client,
 ) -> Result<(HarvestResult, Vec<PathBuf>)> {
-    let bwb_manifest = manifest::download_manifest(http_client, &payload.bwb_id).await?;
+    if let Some(ref cvdr_id) = payload.cvdr_id {
+        execute_harvest_cvdr(cvdr_id, payload, repo_path, output_base, http_client).await
+    } else if let Some(ref bwb_id) = payload.bwb_id {
+        execute_harvest_bwb(bwb_id, payload, repo_path, output_base, http_client).await
+    } else {
+        Err(crate::error::PipelineError::InvalidInput(
+            "harvest payload must have either bwb_id or cvdr_id".into(),
+        ))
+    }
+}
+
+/// Execute a BWB harvest (national laws).
+async fn execute_harvest_bwb(
+    bwb_id: &str,
+    payload: &HarvestPayload,
+    repo_path: &Path,
+    output_base: &str,
+    http_client: &Client,
+) -> Result<(HarvestResult, Vec<PathBuf>)> {
+    let bwb_manifest = manifest::download_manifest(http_client, bwb_id).await?;
     let effective_date =
         manifest::resolve_consolidation_date(&bwb_manifest, payload.date.as_deref())?;
-    tracing::info!(bwb_id = %payload.bwb_id, resolved_date = %effective_date, "resolved consolidation date from manifest");
+    tracing::info!(bwb_id = %bwb_id, resolved_date = %effective_date, "resolved consolidation date from manifest");
 
-    tracing::info!(bwb_id = %payload.bwb_id, date = %effective_date, "downloading law XML from BWB");
+    tracing::info!(bwb_id = %bwb_id, date = %effective_date, "downloading law XML from BWB");
     let law = if let Some(max_mb) = payload.max_size_mb {
         regelrecht_harvester::download_law_with_max_size(
             http_client,
-            &payload.bwb_id,
+            bwb_id,
             &effective_date,
             max_mb,
         )
         .await?
     } else {
-        regelrecht_harvester::download_law(http_client, &payload.bwb_id, &effective_date).await?
+        regelrecht_harvester::download_law(http_client, bwb_id, &effective_date).await?
     };
 
-    tracing::info!(bwb_id = %payload.bwb_id, title = %law.metadata.title, "law XML downloaded successfully");
+    tracing::info!(bwb_id = %bwb_id, title = %law.metadata.title, "law XML downloaded successfully");
     let law_name = law.metadata.title.clone();
     let slug = law.metadata.to_slug();
     let layer = law.metadata.regulatory_layer.as_str().to_string();
@@ -96,7 +149,7 @@ pub async fn execute_harvest(
         .iter()
         .flat_map(|a| a.references.iter())
         .map(|r| r.bwb_id.clone())
-        .filter(|id| id != &payload.bwb_id)
+        .filter(|id| id != bwb_id)
         .collect::<HashSet<_>>()
         .into_iter()
         .collect();
@@ -120,7 +173,7 @@ pub async fn execute_harvest(
         .unwrap_or_else(|| PathBuf::from("status.yaml"));
 
     let status = LawStatusFile {
-        bwb_id: payload.bwb_id.clone(),
+        law_id: bwb_id.to_string(),
         law_name: law_name.clone(),
         slug: slug.clone(),
         status: "harvested".to_string(),
@@ -151,6 +204,105 @@ pub async fn execute_harvest(
         warnings,
         referenced_bwb_ids,
         harvest_date: effective_date,
+        source_type: "bwb".to_string(),
+    };
+
+    let written_files = vec![yaml_path, status_file_path];
+    Ok((result, written_files))
+}
+
+/// Execute a CVDR harvest (decentral regulations).
+async fn execute_harvest_cvdr(
+    cvdr_id: &str,
+    payload: &HarvestPayload,
+    repo_path: &Path,
+    output_base: &str,
+    http_client: &Client,
+) -> Result<(HarvestResult, Vec<PathBuf>)> {
+    tracing::info!(cvdr_id = %cvdr_id, "downloading law from CVDR");
+
+    let law =
+        regelrecht_harvester::download_cvdr_law(http_client, cvdr_id, payload.date.as_deref())
+            .await?;
+
+    tracing::info!(cvdr_id = %cvdr_id, title = %law.metadata.title, "CVDR law downloaded successfully");
+    let law_name = law.metadata.title.clone();
+    let slug = law.metadata.to_slug();
+    let layer = law.metadata.regulatory_layer.as_str().to_string();
+    let article_count = law.articles.len();
+    let warning_count = law.warning_count();
+    let warnings = law.warnings.clone();
+
+    // CVDR laws typically don't have cross-references to BWB laws in the same way,
+    // but we still collect any references that exist.
+    let mut referenced_bwb_ids: Vec<String> = law
+        .articles
+        .iter()
+        .flat_map(|a| a.references.iter())
+        .map(|r| r.bwb_id.clone())
+        .filter(|id| id != cvdr_id)
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect();
+    referenced_bwb_ids.sort();
+
+    // Determine effective date — use the requested date, metadata date, or today
+    let effective_date = payload
+        .date
+        .clone()
+        .or_else(|| law.metadata.effective_date.clone())
+        .unwrap_or_else(|| Utc::now().format("%Y-%m-%d").to_string());
+
+    let output_base_path = repo_path.join(output_base);
+    let law_for_save = law;
+    let date_for_save = effective_date.clone();
+    let yaml_path = tokio::task::spawn_blocking(move || {
+        regelrecht_harvester::yaml::save_yaml(
+            &law_for_save,
+            &date_for_save,
+            Some(&output_base_path),
+        )
+    })
+    .await??;
+
+    let status_file_path = yaml_path
+        .parent()
+        .map(|p| p.join("status.yaml"))
+        .unwrap_or_else(|| PathBuf::from("status.yaml"));
+
+    let status = LawStatusFile {
+        law_id: cvdr_id.to_string(),
+        law_name: law_name.clone(),
+        slug: slug.clone(),
+        status: "harvested".to_string(),
+        last_harvested: Utc::now().to_rfc3339(),
+        harvest_date: effective_date.clone(),
+        article_count,
+        warning_count,
+        warnings: warnings.clone(),
+    };
+
+    let status_yaml = serde_yaml_ng::to_string(&status)?;
+    let status_content = format!("---\n{status_yaml}");
+    tokio::fs::write(&status_file_path, status_content).await?;
+
+    let relative_path = yaml_path
+        .strip_prefix(repo_path)
+        .unwrap_or(&yaml_path)
+        .to_string_lossy()
+        .to_string();
+
+    let result = HarvestResult {
+        law_name,
+        slug,
+        layer,
+        file_path: relative_path,
+        article_count,
+        warning_count,
+        warnings,
+        referenced_bwb_ids,
+        harvest_date: effective_date,
+        source_type: "cvdr".to_string(),
     };
 
     let written_files = vec![yaml_path, status_file_path];
@@ -164,7 +316,8 @@ mod tests {
     #[test]
     fn test_harvest_payload_serde_roundtrip() {
         let payload = HarvestPayload {
-            bwb_id: "BWBR0018451".to_string(),
+            bwb_id: Some("BWBR0018451".to_string()),
+            cvdr_id: None,
             date: Some("2025-01-01".to_string()),
             max_size_mb: Some(100),
             depth: Some(2),
@@ -173,21 +326,71 @@ mod tests {
         let json = serde_json::to_string(&payload).unwrap();
         let deserialized: HarvestPayload = serde_json::from_str(&json).unwrap();
 
-        assert_eq!(deserialized.bwb_id, "BWBR0018451");
+        assert_eq!(deserialized.bwb_id.as_deref(), Some("BWBR0018451"));
         assert_eq!(deserialized.date.as_deref(), Some("2025-01-01"));
         assert_eq!(deserialized.max_size_mb, Some(100));
         assert_eq!(deserialized.depth, Some(2));
     }
 
     #[test]
-    fn test_harvest_payload_minimal() {
+    fn test_harvest_payload_minimal_bwb() {
         let json = r#"{"bwb_id":"BWBR0018451"}"#;
         let payload: HarvestPayload = serde_json::from_str(json).unwrap();
 
-        assert_eq!(payload.bwb_id, "BWBR0018451");
+        assert_eq!(payload.bwb_id.as_deref(), Some("BWBR0018451"));
+        assert!(payload.cvdr_id.is_none());
         assert!(payload.date.is_none());
         assert!(payload.max_size_mb.is_none());
         assert!(payload.depth.is_none());
+    }
+
+    #[test]
+    fn test_harvest_payload_cvdr() {
+        let json = r#"{"cvdr_id":"CVDR681386"}"#;
+        let payload: HarvestPayload = serde_json::from_str(json).unwrap();
+
+        assert!(payload.bwb_id.is_none());
+        assert_eq!(payload.cvdr_id.as_deref(), Some("CVDR681386"));
+    }
+
+    #[test]
+    fn test_harvest_payload_law_id_helper() {
+        let bwb_payload = HarvestPayload {
+            bwb_id: Some("BWBR0018451".to_string()),
+            cvdr_id: None,
+            date: None,
+            max_size_mb: None,
+            depth: None,
+        };
+        assert_eq!(bwb_payload.law_id(), Some("BWBR0018451"));
+
+        let cvdr_payload = HarvestPayload {
+            bwb_id: None,
+            cvdr_id: Some("CVDR681386".to_string()),
+            date: None,
+            max_size_mb: None,
+            depth: None,
+        };
+        assert_eq!(cvdr_payload.law_id(), Some("CVDR681386"));
+
+        let empty_payload = HarvestPayload {
+            bwb_id: None,
+            cvdr_id: None,
+            date: None,
+            max_size_mb: None,
+            depth: None,
+        };
+        assert_eq!(empty_payload.law_id(), None);
+    }
+
+    /// Backward compatibility: existing queued jobs with `bwb_id` as a plain String
+    /// must still deserialize correctly.
+    #[test]
+    fn test_harvest_payload_backward_compat_plain_string() {
+        let json = r#"{"bwb_id":"BWBR0018451","date":"2025-01-01"}"#;
+        let payload: HarvestPayload = serde_json::from_str(json).unwrap();
+        assert_eq!(payload.bwb_id.as_deref(), Some("BWBR0018451"));
+        assert!(payload.cvdr_id.is_none());
     }
 
     #[test]
@@ -202,12 +405,14 @@ mod tests {
             warnings: vec!["warning1".to_string(), "warning2".to_string()],
             referenced_bwb_ids: vec!["BWBR0002629".to_string(), "BWBR0018450".to_string()],
             harvest_date: "2025-01-01".to_string(),
+            source_type: "bwb".to_string(),
         };
 
         let json = serde_json::to_value(&result).unwrap();
         assert_eq!(json["law_name"], "Wet op de zorgtoeslag");
         assert_eq!(json["article_count"], 10);
         assert_eq!(json["harvest_date"], "2025-01-01");
+        assert_eq!(json["source_type"], "bwb");
 
         let refs = json["referenced_bwb_ids"].as_array().unwrap();
         assert_eq!(refs.len(), 2);
@@ -215,10 +420,18 @@ mod tests {
         assert_eq!(refs[1], "BWBR0018450");
     }
 
+    /// Backward compatibility: HarvestResult without source_type defaults to "bwb".
+    #[test]
+    fn test_harvest_result_default_source_type() {
+        let json = r#"{"law_name":"test","slug":"test","layer":"WET","file_path":"test.yaml","article_count":0,"warning_count":0,"warnings":[],"referenced_bwb_ids":[],"harvest_date":"2025-01-01"}"#;
+        let result: HarvestResult = serde_json::from_str(json).unwrap();
+        assert_eq!(result.source_type, "bwb");
+    }
+
     #[test]
     fn test_law_status_file_serde() {
         let status = LawStatusFile {
-            bwb_id: "BWBR0018451".to_string(),
+            law_id: "BWBR0018451".to_string(),
             law_name: "Wet op de zorgtoeslag".to_string(),
             slug: "wet_op_de_zorgtoeslag".to_string(),
             status: "harvested".to_string(),
@@ -230,7 +443,25 @@ mod tests {
         };
 
         let yaml = serde_yaml_ng::to_string(&status).unwrap();
-        assert!(yaml.contains("bwb_id: BWBR0018451"));
+        assert!(yaml.contains("law_id: BWBR0018451"));
         assert!(yaml.contains("status: harvested"));
+    }
+
+    #[test]
+    fn test_law_status_file_cvdr() {
+        let status = LawStatusFile {
+            law_id: "CVDR681386".to_string(),
+            law_name: "Verordening test".to_string(),
+            slug: "verordening_test".to_string(),
+            status: "harvested".to_string(),
+            last_harvested: "2025-01-01T00:00:00Z".to_string(),
+            harvest_date: "2025-01-01".to_string(),
+            article_count: 5,
+            warning_count: 0,
+            warnings: vec![],
+        };
+
+        let yaml = serde_yaml_ng::to_string(&status).unwrap();
+        assert!(yaml.contains("law_id: CVDR681386"));
     }
 }

--- a/packages/pipeline/src/worker.rs
+++ b/packages/pipeline/src/worker.rs
@@ -144,12 +144,21 @@ async fn process_next_job(
                 return Ok(true);
             }
         },
-        None => HarvestPayload {
-            bwb_id: job.law_id.clone(),
-            date: None,
-            max_size_mb: None,
-            depth: None,
-        },
+        None => {
+            // Infer source type from law_id prefix when no payload is stored.
+            let (bwb_id, cvdr_id) = if job.law_id.starts_with("CVDR") {
+                (None, Some(job.law_id.clone()))
+            } else {
+                (Some(job.law_id.clone()), None)
+            };
+            HarvestPayload {
+                bwb_id,
+                cvdr_id,
+                date: None,
+                max_size_mb: None,
+                depth: None,
+            }
+        }
     };
 
     if let Err(e) = law_status::upsert_law(pool, &job.law_id, None).await {
@@ -300,8 +309,10 @@ async fn process_next_job(
                     // When None (no date specified), each law independently resolves
                     // its own latest consolidation from BWB — this ensures we always
                     // harvest the version that is valid today.
+                    // Follow-up jobs from referenced_bwb_ids are always BWB laws.
                     let follow_up_payload = HarvestPayload {
-                        bwb_id: bwb_id.clone(),
+                        bwb_id: Some(bwb_id.clone()),
+                        cvdr_id: None,
                         date: payload.date.clone(),
                         max_size_mb: payload.max_size_mb,
                         depth: Some(next_depth),

--- a/packages/pipeline/tests/harvest_tests.rs
+++ b/packages/pipeline/tests/harvest_tests.rs
@@ -9,7 +9,8 @@ fn test_harvest_payload_from_json_full() {
     });
 
     let payload: HarvestPayload = serde_json::from_value(json).unwrap();
-    assert_eq!(payload.bwb_id, "BWBR0018451");
+    assert_eq!(payload.bwb_id.as_deref(), Some("BWBR0018451"));
+    assert!(payload.cvdr_id.is_none());
     assert_eq!(payload.date.as_deref(), Some("2025-01-01"));
     assert_eq!(payload.max_size_mb, Some(100));
     assert!(payload.depth.is_none());
@@ -20,10 +21,24 @@ fn test_harvest_payload_from_json_minimal() {
     let json = serde_json::json!({ "bwb_id": "BWBR0018451" });
 
     let payload: HarvestPayload = serde_json::from_value(json).unwrap();
-    assert_eq!(payload.bwb_id, "BWBR0018451");
+    assert_eq!(payload.bwb_id.as_deref(), Some("BWBR0018451"));
+    assert!(payload.cvdr_id.is_none());
     assert!(payload.date.is_none());
     assert!(payload.max_size_mb.is_none());
     assert!(payload.depth.is_none());
+}
+
+#[test]
+fn test_harvest_payload_cvdr() {
+    let json = serde_json::json!({
+        "cvdr_id": "CVDR681386",
+        "date": "2025-06-01"
+    });
+
+    let payload: HarvestPayload = serde_json::from_value(json).unwrap();
+    assert!(payload.bwb_id.is_none());
+    assert_eq!(payload.cvdr_id.as_deref(), Some("CVDR681386"));
+    assert_eq!(payload.date.as_deref(), Some("2025-06-01"));
 }
 
 #[test]
@@ -41,7 +56,8 @@ fn test_harvest_payload_with_depth() {
 #[test]
 fn test_harvest_payload_roundtrip() {
     let payload = HarvestPayload {
-        bwb_id: "BWBR0018451".to_string(),
+        bwb_id: Some("BWBR0018451".to_string()),
+        cvdr_id: None,
         date: Some("2025-01-01".to_string()),
         max_size_mb: None,
         depth: Some(1),
@@ -50,24 +66,83 @@ fn test_harvest_payload_roundtrip() {
     let json = serde_json::to_value(&payload).unwrap();
     let back: HarvestPayload = serde_json::from_value(json).unwrap();
     assert_eq!(back.bwb_id, payload.bwb_id);
+    assert_eq!(back.cvdr_id, payload.cvdr_id);
     assert_eq!(back.date, payload.date);
     assert_eq!(back.max_size_mb, payload.max_size_mb);
     assert_eq!(back.depth, payload.depth);
 }
 
 #[test]
+fn test_harvest_payload_roundtrip_cvdr() {
+    let payload = HarvestPayload {
+        bwb_id: None,
+        cvdr_id: Some("CVDR681386".to_string()),
+        date: Some("2025-06-01".to_string()),
+        max_size_mb: None,
+        depth: None,
+    };
+
+    let json = serde_json::to_value(&payload).unwrap();
+    let back: HarvestPayload = serde_json::from_value(json).unwrap();
+    assert_eq!(back.bwb_id, None);
+    assert_eq!(back.cvdr_id.as_deref(), Some("CVDR681386"));
+}
+
+#[test]
 fn test_harvest_payload_skip_none_fields() {
     let payload = HarvestPayload {
-        bwb_id: "BWBR0018451".to_string(),
+        bwb_id: Some("BWBR0018451".to_string()),
+        cvdr_id: None,
         date: None,
         max_size_mb: None,
         depth: None,
     };
 
     let json = serde_json::to_string(&payload).unwrap();
+    assert!(!json.contains("cvdr_id"));
     assert!(!json.contains("date"));
     assert!(!json.contains("max_size_mb"));
     assert!(!json.contains("depth"));
+}
+
+#[test]
+fn test_harvest_payload_law_id_helper() {
+    let bwb = HarvestPayload {
+        bwb_id: Some("BWBR0018451".to_string()),
+        cvdr_id: None,
+        date: None,
+        max_size_mb: None,
+        depth: None,
+    };
+    assert_eq!(bwb.law_id(), Some("BWBR0018451"));
+
+    let cvdr = HarvestPayload {
+        bwb_id: None,
+        cvdr_id: Some("CVDR681386".to_string()),
+        date: None,
+        max_size_mb: None,
+        depth: None,
+    };
+    assert_eq!(cvdr.law_id(), Some("CVDR681386"));
+}
+
+/// Backward compatibility: payloads with `bwb_id` as a plain String
+/// (from existing queued jobs) must still deserialize.
+#[test]
+fn test_harvest_payload_backward_compat() {
+    let json = r#"{"bwb_id":"BWBR0018451","date":"2025-01-01"}"#;
+    let payload: HarvestPayload = serde_json::from_str(json).unwrap();
+    assert_eq!(payload.bwb_id.as_deref(), Some("BWBR0018451"));
+    assert!(payload.cvdr_id.is_none());
+}
+
+/// Empty JSON object should deserialize with bwb_id defaulting to None.
+#[test]
+fn test_harvest_payload_empty_json() {
+    let json = r#"{}"#;
+    let payload: HarvestPayload = serde_json::from_str(json).unwrap();
+    assert!(payload.bwb_id.is_none());
+    assert!(payload.cvdr_id.is_none());
 }
 
 #[test]
@@ -86,6 +161,7 @@ fn test_harvest_result_serialization() {
         ],
         referenced_bwb_ids: vec!["BWBR0002629".to_string()],
         harvest_date: "2025-01-01".to_string(),
+        source_type: "bwb".to_string(),
     };
 
     let json = serde_json::to_value(&result).unwrap();
@@ -96,7 +172,27 @@ fn test_harvest_result_serialization() {
     assert_eq!(json["warning_count"], 3);
     assert_eq!(json["warnings"].as_array().unwrap().len(), 3);
     assert_eq!(json["harvest_date"], "2025-01-01");
+    assert_eq!(json["source_type"], "bwb");
     assert_eq!(json["referenced_bwb_ids"].as_array().unwrap().len(), 1);
+}
+
+#[test]
+fn test_harvest_result_cvdr_source_type() {
+    let result = HarvestResult {
+        law_name: "Verordening test".to_string(),
+        slug: "verordening_test".to_string(),
+        layer: "VERORDENING".to_string(),
+        file_path: "/tmp/regulation/nl/verordening/verordening_test/2025-01-01.yaml".to_string(),
+        article_count: 5,
+        warning_count: 0,
+        warnings: vec![],
+        referenced_bwb_ids: vec![],
+        harvest_date: "2025-01-01".to_string(),
+        source_type: "cvdr".to_string(),
+    };
+
+    let json = serde_json::to_value(&result).unwrap();
+    assert_eq!(json["source_type"], "cvdr");
 }
 
 /// Integration test: download and harvest a real law.
@@ -111,7 +207,8 @@ async fn test_execute_harvest_real_law() {
     let repo_path = tmp.path();
 
     let payload = HarvestPayload {
-        bwb_id: "BWBR0018451".to_string(),
+        bwb_id: Some("BWBR0018451".to_string()),
+        cvdr_id: None,
         date: Some("2025-01-01".to_string()),
         max_size_mb: Some(50),
         depth: None,
@@ -125,6 +222,7 @@ async fn test_execute_harvest_real_law() {
     assert!(!result.law_name.is_empty());
     assert!(!result.slug.is_empty());
     assert!(result.article_count > 0);
+    assert_eq!(result.source_type, "bwb");
     assert_eq!(written_files.len(), 2);
     for f in &written_files {
         assert!(f.exists(), "expected file to exist: {}", f.display());


### PR DESCRIPTION
## Summary
- Add CVDR harvester module to automatically download regulations from lokaleregelgeving.overheid.nl (gemeenten, provincies, waterschappen)
- SRU API integration for metadata discovery (title, creator, organisatietype → regulatory layer)
- Pipeline + admin support: CVDR IDs accepted alongside BWB IDs with auto-detection
- Admin UI updated to accept both BWB and CVDR formats

## Architecture
```
CVDR ID (input)
    → SRU API search (metadata + XML URL)
    → Download XML from repository.overheid.nl
    → Parse articles (reuses existing split engine)
    → Generate YAML with scope codes (waterschap_code, gemeente_code, etc.)
```

## Test plan
- [x] `just format` passes
- [x] `just lint` passes
- [x] `just test` — all 346 tests pass
- [x] Pre-commit hooks pass
- [ ] Manual test: `regelrecht-harvester download CVDR756485`
- [ ] Manual test: submit CVDR ID via admin UI