### PR TITLE
fix(harvester): resolve CVDR version via repository manifest

### DIFF
--- a/packages/harvester/src/config.rs
+++ b/packages/harvester/src/config.rs
@@ -233,6 +233,9 @@ pub fn wetten_url(
     url
 }
 
+/// Base URL for CVDR repository (manifest and XML files).
+pub const CVDR_REPOSITORY_URL: &str = "https://repository.officiele-overheidspublicaties.nl/cvdr";
+
 /// Base URL for CVDR SRU search service.
 pub const CVDR_SRU_URL: &str = "https://zoekservice.overheid.nl/sru/Search";
 
@@ -283,6 +286,17 @@ pub fn cvdr_sru_search_url(cvdr_id: &str) -> String {
 /// Public URL to lokaleregelgeving.overheid.nl
 pub fn lokaleregelgeving_url(cvdr_id: &str) -> String {
     format!("https://lokaleregelgeving.overheid.nl/{cvdr_id}")
+}
+
+/// Build manifest URL for a CVDR regulation.
+///
+/// # Arguments
+/// * `cvdr_id` - The CVDR identifier (e.g., "CVDR691525")
+///
+/// # Returns
+/// URL to the manifest.xml file in the CVDR repository
+pub fn cvdr_manifest_url(cvdr_id: &str) -> String {
+    format!("{CVDR_REPOSITORY_URL}/{cvdr_id}/manifest.xml")
 }
 
 #[cfg(test)]
@@ -496,6 +510,14 @@ mod tests {
         assert_eq!(
             lokaleregelgeving_url("CVDR681386"),
             "https://lokaleregelgeving.overheid.nl/CVDR681386"
+        );
+    }
+
+    #[test]
+    fn test_cvdr_manifest_url() {
+        assert_eq!(
+            cvdr_manifest_url("CVDR691525"),
+            "https://repository.officiele-overheidspublicaties.nl/cvdr/CVDR691525/manifest.xml"
         );
     }
 }

--- a/packages/harvester/src/config.rs
+++ b/packages/harvester/src/config.rs
@@ -33,10 +33,10 @@ pub const TEXT_WRAP_WIDTH: usize = 115;
 static BWB_ID_PATTERN: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^BWBR\d{7}$").expect("valid regex"));
 
-/// CVDR ID pattern: CVDR followed by 3 or more digits.
+/// CVDR ID pattern: CVDR followed by 3+ digits, with optional version suffix (e.g., _1).
 #[allow(clippy::expect_used)] // Static regex that is guaranteed to be valid
 static CVDR_ID_PATTERN: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^CVDR\d{3,}$").expect("valid regex"));
+    LazyLock::new(|| Regex::new(r"^CVDR\d{3,}(_\d+)?$").expect("valid regex"));
 
 /// Date pattern: YYYY-MM-DD.
 #[allow(clippy::expect_used)] // Static regex that is guaranteed to be valid

--- a/packages/harvester/src/cvdr/manifest.rs
+++ b/packages/harvester/src/cvdr/manifest.rs
@@ -1,0 +1,370 @@
+//! CVDR manifest parsing for version resolution.
+//!
+//! The CVDR repository stores manifest files listing all versions of a regulation.
+//! When a user provides a bare CVDR ID (e.g., `CVDR691525`), we need to resolve the
+//! latest versioned identifier (e.g., `CVDR691525_2`) before querying the SRU API.
+//!
+//! Manifest URL pattern:
+//! `https://repository.officiele-overheidspublicaties.nl/cvdr/{CVDR_ID}/manifest.xml`
+
+use reqwest::Client;
+use roxmltree::Document;
+
+use crate::config::cvdr_manifest_url;
+use crate::error::{HarvesterError, Result};
+use crate::http::{bytes_to_string, download_bytes_default};
+
+/// A resolved CVDR version from the manifest.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CvdrVersion {
+    /// The versioned CVDR identifier (e.g., "CVDR691525_2").
+    pub versioned_id: String,
+
+    /// The version number (e.g., 2).
+    pub version: u32,
+
+    /// Direct URL to the XML content for this version.
+    pub xml_url: String,
+}
+
+/// Resolve the latest version of a CVDR regulation from its manifest.
+///
+/// Downloads the manifest XML from the CVDR repository, parses all available
+/// versions, and returns the latest one (either marked with `_latestItem` or
+/// the highest version number).
+///
+/// # Arguments
+/// * `client` - HTTP client to use
+/// * `cvdr_id` - The bare CVDR identifier (e.g., "CVDR691525")
+///
+/// # Returns
+/// A `CvdrVersion` with the resolved versioned ID and XML URL
+pub async fn resolve_latest_cvdr_version(client: &Client, cvdr_id: &str) -> Result<CvdrVersion> {
+    let url = cvdr_manifest_url(cvdr_id);
+
+    tracing::debug!(cvdr_id = %cvdr_id, url = %url, "Downloading CVDR manifest");
+
+    let bytes = download_bytes_default(client, &url).await.map_err(|e| {
+        if let HarvesterError::Http(source) = e {
+            HarvesterError::CvdrContentDownload {
+                cvdr_id: cvdr_id.to_string(),
+                source,
+            }
+        } else {
+            e
+        }
+    })?;
+
+    let xml_string = bytes_to_string(bytes, &format!("CVDR manifest for {cvdr_id}"));
+    parse_cvdr_manifest(&xml_string, cvdr_id)
+}
+
+/// Parse a CVDR manifest XML to find the latest version.
+///
+/// The manifest structure contains expression elements with versioned filenames.
+/// We look for the `_latestItem` attribute first, then fall back to finding the
+/// highest version number among all expressions.
+fn parse_cvdr_manifest(xml: &str, cvdr_id: &str) -> Result<CvdrVersion> {
+    let doc = Document::parse(xml)?;
+
+    // Try to find a _latestItem attribute on the work element
+    let latest_from_attr = doc
+        .descendants()
+        .find(|n| n.is_element() && n.has_tag_name("work"))
+        .and_then(|n| n.attribute("_latestItem"))
+        .and_then(|item| extract_version_from_path(item, cvdr_id));
+
+    // Collect all versions from expression elements
+    let mut versions: Vec<CvdrVersion> = Vec::new();
+
+    for node in doc.descendants() {
+        if !node.is_element() {
+            continue;
+        }
+
+        // Look for expression elements or item elements that contain version info
+        if node.has_tag_name("expression") || node.has_tag_name("item") {
+            if let Some(label) = node.attribute("label") {
+                if let Some(version) = extract_version_from_path(label, cvdr_id) {
+                    // Check for duplicates
+                    if !versions.iter().any(|v| v.version == version.version) {
+                        versions.push(version);
+                    }
+                }
+            }
+        }
+    }
+
+    // If we got a _latestItem match and it exists in our versions, prefer it
+    if let Some(ref latest) = latest_from_attr {
+        if versions.iter().any(|v| v.version == latest.version) {
+            tracing::debug!(
+                cvdr_id = %cvdr_id,
+                version = latest.version,
+                versioned_id = %latest.versioned_id,
+                "Resolved CVDR version from _latestItem"
+            );
+            return Ok(latest.clone());
+        }
+    }
+
+    // Fall back to the highest version number
+    if let Some(latest) = versions.into_iter().max_by_key(|v| v.version) {
+        tracing::debug!(
+            cvdr_id = %cvdr_id,
+            version = latest.version,
+            versioned_id = %latest.versioned_id,
+            "Resolved CVDR version from highest version number"
+        );
+        return Ok(latest);
+    }
+
+    // If _latestItem matched but wasn't in versions list, still use it
+    if let Some(latest) = latest_from_attr {
+        tracing::debug!(
+            cvdr_id = %cvdr_id,
+            version = latest.version,
+            versioned_id = %latest.versioned_id,
+            "Resolved CVDR version from _latestItem (no expressions found)"
+        );
+        return Ok(latest);
+    }
+
+    Err(HarvesterError::CvdrSearchFailed {
+        cvdr_id: cvdr_id.to_string(),
+        message: "No versions found in CVDR manifest".to_string(),
+    })
+}
+
+/// Extract a `CvdrVersion` from a manifest path or label.
+///
+/// Handles patterns like:
+/// - `CVDR691525_2.xml`
+/// - `CVDR691525_2/xml/CVDR691525_2.xml`
+/// - `1/xml/CVDR691525_1.xml`
+/// - `2` (just the version number as label for expression elements)
+fn extract_version_from_path(path: &str, cvdr_id: &str) -> Option<CvdrVersion> {
+    // Try to find a versioned identifier pattern: CVDR{digits}_{version}
+    let prefix = format!("{cvdr_id}_");
+
+    // Search for the pattern in the path
+    if let Some(start) = path.find(&prefix) {
+        let after_prefix = &path[start + prefix.len()..];
+        // Extract digits until we hit a non-digit character
+        let version_str: String = after_prefix
+            .chars()
+            .take_while(|c| c.is_ascii_digit())
+            .collect();
+        if let Ok(version) = version_str.parse::<u32>() {
+            let versioned_id = format!("{cvdr_id}_{version}");
+            let xml_url = cvdr_xml_url(cvdr_id, version);
+            return Some(CvdrVersion {
+                versioned_id,
+                version,
+                xml_url,
+            });
+        }
+    }
+
+    // Try parsing the path as just a version number (expression label)
+    let trimmed = path.trim();
+    if let Ok(version) = trimmed.parse::<u32>() {
+        let versioned_id = format!("{cvdr_id}_{version}");
+        let xml_url = cvdr_xml_url(cvdr_id, version);
+        return Some(CvdrVersion {
+            versioned_id,
+            version,
+            xml_url,
+        });
+    }
+
+    None
+}
+
+/// Build the direct XML download URL for a CVDR version.
+fn cvdr_xml_url(cvdr_id: &str, version: u32) -> String {
+    format!(
+        "https://repository.officiele-overheidspublicaties.nl/cvdr/{cvdr_id}/{version}/xml/{cvdr_id}_{version}.xml"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_version_from_xml_filename() {
+        let result = extract_version_from_path("CVDR691525_2.xml", "CVDR691525");
+        assert_eq!(
+            result,
+            Some(CvdrVersion {
+                versioned_id: "CVDR691525_2".to_string(),
+                version: 2,
+                xml_url: "https://repository.officiele-overheidspublicaties.nl/cvdr/CVDR691525/2/xml/CVDR691525_2.xml".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn test_extract_version_from_full_path() {
+        let result = extract_version_from_path("1/xml/CVDR756485_1.xml", "CVDR756485");
+        assert_eq!(
+            result,
+            Some(CvdrVersion {
+                versioned_id: "CVDR756485_1".to_string(),
+                version: 1,
+                xml_url: "https://repository.officiele-overheidspublicaties.nl/cvdr/CVDR756485/1/xml/CVDR756485_1.xml".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn test_extract_version_from_number_label() {
+        let result = extract_version_from_path("2", "CVDR691525");
+        assert_eq!(
+            result,
+            Some(CvdrVersion {
+                versioned_id: "CVDR691525_2".to_string(),
+                version: 2,
+                xml_url: "https://repository.officiele-overheidspublicaties.nl/cvdr/CVDR691525/2/xml/CVDR691525_2.xml".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn test_extract_version_no_match() {
+        let result = extract_version_from_path("no_match_here", "CVDR691525");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_extract_version_wrong_cvdr_id() {
+        // Path references a different CVDR ID
+        let result = extract_version_from_path("CVDR999999_1.xml", "CVDR691525");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_cvdr_xml_url() {
+        assert_eq!(
+            cvdr_xml_url("CVDR691525", 2),
+            "https://repository.officiele-overheidspublicaties.nl/cvdr/CVDR691525/2/xml/CVDR691525_2.xml"
+        );
+    }
+
+    #[test]
+    fn test_parse_manifest_single_version() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<repository>
+  <work _latestItem="1/xml/CVDR756485_1.xml">
+    <expression label="1">
+      <manifestation label="xml">
+        <item label="CVDR756485_1.xml" />
+      </manifestation>
+    </expression>
+  </work>
+</repository>"#;
+
+        let result = parse_cvdr_manifest(xml, "CVDR756485").unwrap();
+        assert_eq!(result.versioned_id, "CVDR756485_1");
+        assert_eq!(result.version, 1);
+        assert_eq!(
+            result.xml_url,
+            "https://repository.officiele-overheidspublicaties.nl/cvdr/CVDR756485/1/xml/CVDR756485_1.xml"
+        );
+    }
+
+    #[test]
+    fn test_parse_manifest_multiple_versions() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<repository>
+  <work _latestItem="2/xml/CVDR691525_2.xml">
+    <expression label="1">
+      <manifestation label="xml">
+        <item label="CVDR691525_1.xml" />
+      </manifestation>
+    </expression>
+    <expression label="2">
+      <manifestation label="xml">
+        <item label="CVDR691525_2.xml" />
+      </manifestation>
+    </expression>
+  </work>
+</repository>"#;
+
+        let result = parse_cvdr_manifest(xml, "CVDR691525").unwrap();
+        assert_eq!(result.versioned_id, "CVDR691525_2");
+        assert_eq!(result.version, 2);
+    }
+
+    #[test]
+    fn test_parse_manifest_latest_item_wins() {
+        // Even though version 3 is higher, _latestItem says version 2
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<repository>
+  <work _latestItem="2/xml/CVDR691525_2.xml">
+    <expression label="1">
+      <manifestation label="xml">
+        <item label="CVDR691525_1.xml" />
+      </manifestation>
+    </expression>
+    <expression label="2">
+      <manifestation label="xml">
+        <item label="CVDR691525_2.xml" />
+      </manifestation>
+    </expression>
+    <expression label="3">
+      <manifestation label="xml">
+        <item label="CVDR691525_3.xml" />
+      </manifestation>
+    </expression>
+  </work>
+</repository>"#;
+
+        let result = parse_cvdr_manifest(xml, "CVDR691525").unwrap();
+        assert_eq!(result.versioned_id, "CVDR691525_2");
+        assert_eq!(result.version, 2);
+    }
+
+    #[test]
+    fn test_parse_manifest_no_versions_fails() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<repository>
+  <work>
+  </work>
+</repository>"#;
+
+        let result = parse_cvdr_manifest(xml, "CVDR691525");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_manifest_falls_back_to_highest_version() {
+        // No _latestItem attribute
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<repository>
+  <work>
+    <expression label="1">
+      <manifestation label="xml">
+        <item label="CVDR691525_1.xml" />
+      </manifestation>
+    </expression>
+    <expression label="3">
+      <manifestation label="xml">
+        <item label="CVDR691525_3.xml" />
+      </manifestation>
+    </expression>
+    <expression label="2">
+      <manifestation label="xml">
+        <item label="CVDR691525_2.xml" />
+      </manifestation>
+    </expression>
+  </work>
+</repository>"#;
+
+        let result = parse_cvdr_manifest(xml, "CVDR691525").unwrap();
+        // Should pick version 3 as the highest
+        assert_eq!(result.versioned_id, "CVDR691525_3");
+        assert_eq!(result.version, 3);
+    }
+}

--- a/packages/harvester/src/cvdr/manifest.rs
+++ b/packages/harvester/src/cvdr/manifest.rs
@@ -183,9 +183,8 @@ fn extract_version_from_path(path: &str, cvdr_id: &str) -> Option<CvdrVersion> {
 
 /// Build the direct XML download URL for a CVDR version.
 fn cvdr_xml_url(cvdr_id: &str, version: u32) -> String {
-    format!(
-        "https://repository.officiele-overheidspublicaties.nl/cvdr/{cvdr_id}/{version}/xml/{cvdr_id}_{version}.xml"
-    )
+    use crate::config::CVDR_REPOSITORY_URL;
+    format!("{CVDR_REPOSITORY_URL}/{cvdr_id}/{version}/xml/{cvdr_id}_{version}.xml")
 }
 
 #[cfg(test)]

--- a/packages/harvester/src/cvdr/mod.rs
+++ b/packages/harvester/src/cvdr/mod.rs
@@ -5,12 +5,14 @@
 //!
 //! # Flow
 //!
-//! 1. SRU search to get metadata and XML content URL
-//! 2. Download XML content from the resolved URL
-//! 3. Parse articles from CVDR XML format
-//! 4. Return a `Law` object compatible with the existing YAML generation pipeline
+//! 1. If the CVDR ID has no version suffix, resolve via manifest
+//! 2. SRU search to get metadata (using versioned ID)
+//! 3. Download XML content from the manifest-resolved URL (more reliable than SRU)
+//! 4. Parse articles from CVDR XML format
+//! 5. Return a `Law` object compatible with the existing YAML generation pipeline
 
 pub mod content;
+pub mod manifest;
 pub mod parse;
 pub mod search;
 
@@ -20,14 +22,20 @@ use crate::config::{lokaleregelgeving_url, validate_cvdr_id, validate_date};
 use crate::error::Result;
 use crate::types::Law;
 use content::download_cvdr_content;
+use manifest::resolve_latest_cvdr_version;
 use parse::parse_cvdr_articles;
 use search::search_cvdr;
 
 /// Download and parse a CVDR law.
 ///
+/// If the CVDR ID has no version suffix (e.g., "CVDR691525"), resolves the
+/// latest version via the CVDR manifest first. Then uses the versioned ID
+/// for the SRU metadata search and the manifest-resolved XML URL for content
+/// download.
+///
 /// # Arguments
 /// * `client` - HTTP client to use
-/// * `cvdr_id` - The CVDR identifier (e.g., "CVDR681386")
+/// * `cvdr_id` - The CVDR identifier (e.g., "CVDR681386" or "CVDR681386_1")
 /// * `date` - Optional effective date in YYYY-MM-DD format
 ///
 /// # Returns
@@ -39,13 +47,34 @@ pub async fn download_cvdr_law(client: &Client, cvdr_id: &str, date: Option<&str
         validate_date(d)?;
     }
 
-    // Step 1: SRU search to get metadata
-    let metadata_result = search_cvdr(client, cvdr_id).await?;
+    // Step 1: Resolve version via manifest if needed
+    let (versioned_id, manifest_xml_url) = if cvdr_id.contains('_') {
+        // Already has a version suffix, use as-is
+        (cvdr_id.to_string(), None)
+    } else {
+        // Bare ID — resolve latest version from manifest
+        let version_info = resolve_latest_cvdr_version(client, cvdr_id).await?;
+        tracing::info!(
+            cvdr_id = %cvdr_id,
+            versioned_id = %version_info.versioned_id,
+            version = version_info.version,
+            "Resolved CVDR version from manifest"
+        );
+        let xml_url = version_info.xml_url.clone();
+        (version_info.versioned_id, Some(xml_url))
+    };
 
-    // Step 2: Download XML content
-    let xml_content = download_cvdr_content(client, &metadata_result.xml_url, cvdr_id).await?;
+    // Step 2: SRU search to get metadata (using versioned ID)
+    let metadata_result = search_cvdr(client, &versioned_id, manifest_xml_url.as_deref()).await?;
 
-    // Step 3: Parse articles from CVDR XML
+    // Step 3: Download XML content
+    // Prefer the manifest-resolved XML URL (more reliable than SRU enrichedData)
+    let xml_url = manifest_xml_url
+        .as_deref()
+        .unwrap_or(&metadata_result.xml_url);
+    let xml_content = download_cvdr_content(client, xml_url, &versioned_id).await?;
+
+    // Step 4: Parse articles from CVDR XML
     let effective_date = date
         .map(String::from)
         .or_else(|| metadata_result.effective_date.clone())

--- a/packages/harvester/src/cvdr/mod.rs
+++ b/packages/harvester/src/cvdr/mod.rs
@@ -65,7 +65,7 @@ pub async fn download_cvdr_law(client: &Client, cvdr_id: &str, date: Option<&str
     };
 
     // Step 2: SRU search to get metadata (using versioned ID)
-    let metadata_result = search_cvdr(client, &versioned_id, manifest_xml_url.as_deref()).await?;
+    let metadata_result = search_cvdr(client, &versioned_id).await?;
 
     // Step 3: Download XML content
     // Prefer the manifest-resolved XML URL (more reliable than SRU enrichedData)

--- a/packages/harvester/src/cvdr/search.rs
+++ b/packages/harvester/src/cvdr/search.rs
@@ -65,12 +65,15 @@ impl CvdrMetadata {
 
 /// Map CVDR organisation type to `RegulatoryLayer`.
 ///
+/// Accepts both plural forms (from SRU metadata, e.g., "gemeenten") and
+/// singular forms (e.g., "gemeente") for robustness.
+///
 /// Returns `(layer, warning)` where warning is present for unknown types.
 fn regulatory_layer_from_organisation_type(org_type: &str) -> (RegulatoryLayer, Option<String>) {
     match org_type.to_lowercase().as_str() {
-        "gemeenten" => (RegulatoryLayer::GemeentelijkeVerordening, None),
-        "provincies" => (RegulatoryLayer::ProvincialeVerordening, None),
-        "waterschappen" => (RegulatoryLayer::WaterschapsVerordening, None),
+        "gemeenten" | "gemeente" => (RegulatoryLayer::GemeentelijkeVerordening, None),
+        "provincies" | "provincie" => (RegulatoryLayer::ProvincialeVerordening, None),
+        "waterschappen" | "waterschap" => (RegulatoryLayer::WaterschapsVerordening, None),
         unknown => {
             tracing::warn!(
                 organisation_type = %unknown,
@@ -90,11 +93,18 @@ fn regulatory_layer_from_organisation_type(org_type: &str) -> (RegulatoryLayer, 
 ///
 /// # Arguments
 /// * `client` - HTTP client to use
-/// * `cvdr_id` - The CVDR identifier (e.g., "CVDR681386")
+/// * `cvdr_id` - The CVDR identifier (e.g., "CVDR681386" or "CVDR681386_1")
+/// * `pre_resolved_xml_url` - Optional XML URL from manifest resolution.
+///   If provided, this URL is used instead of the one extracted from SRU enrichedData,
+///   which is more reliable.
 ///
 /// # Returns
 /// `CvdrMetadata` with extracted metadata
-pub async fn search_cvdr(client: &Client, cvdr_id: &str) -> Result<CvdrMetadata> {
+pub async fn search_cvdr(
+    client: &Client,
+    cvdr_id: &str,
+    pre_resolved_xml_url: Option<&str>,
+) -> Result<CvdrMetadata> {
     let url = cvdr_sru_search_url(cvdr_id);
 
     let bytes = download_bytes_default(client, &url).await.map_err(|e| {
@@ -109,7 +119,14 @@ pub async fn search_cvdr(client: &Client, cvdr_id: &str) -> Result<CvdrMetadata>
     })?;
 
     let xml_string = bytes_to_string(bytes, &format!("SRU search for {cvdr_id}"));
-    parse_sru_response(&xml_string, cvdr_id)
+    let mut metadata = parse_sru_response(&xml_string, cvdr_id)?;
+
+    // Override the XML URL with the pre-resolved one from the manifest if available
+    if let Some(resolved_url) = pre_resolved_xml_url {
+        metadata.xml_url = resolved_url.to_string();
+    }
+
+    Ok(metadata)
 }
 
 /// Parse SRU XML response to extract CVDR metadata.
@@ -278,6 +295,21 @@ mod tests {
 
         let (layer, _) = regulatory_layer_from_organisation_type("WATERSCHAPPEN");
         assert_eq!(layer, RegulatoryLayer::WaterschapsVerordening);
+    }
+
+    #[test]
+    fn test_regulatory_layer_from_organisation_type_singular() {
+        let (layer, warning) = regulatory_layer_from_organisation_type("gemeente");
+        assert_eq!(layer, RegulatoryLayer::GemeentelijkeVerordening);
+        assert!(warning.is_none());
+
+        let (layer, warning) = regulatory_layer_from_organisation_type("provincie");
+        assert_eq!(layer, RegulatoryLayer::ProvincialeVerordening);
+        assert!(warning.is_none());
+
+        let (layer, warning) = regulatory_layer_from_organisation_type("waterschap");
+        assert_eq!(layer, RegulatoryLayer::WaterschapsVerordening);
+        assert!(warning.is_none());
     }
 
     #[test]

--- a/packages/harvester/src/cvdr/search.rs
+++ b/packages/harvester/src/cvdr/search.rs
@@ -93,18 +93,11 @@ fn regulatory_layer_from_organisation_type(org_type: &str) -> (RegulatoryLayer, 
 ///
 /// # Arguments
 /// * `client` - HTTP client to use
-/// * `cvdr_id` - The CVDR identifier (e.g., "CVDR681386" or "CVDR681386_1")
-/// * `pre_resolved_xml_url` - Optional XML URL from manifest resolution.
-///   If provided, this URL is used instead of the one extracted from SRU enrichedData,
-///   which is more reliable.
+/// * `cvdr_id` - The CVDR identifier (e.g., "CVDR681386_1")
 ///
 /// # Returns
 /// `CvdrMetadata` with extracted metadata
-pub async fn search_cvdr(
-    client: &Client,
-    cvdr_id: &str,
-    pre_resolved_xml_url: Option<&str>,
-) -> Result<CvdrMetadata> {
+pub async fn search_cvdr(client: &Client, cvdr_id: &str) -> Result<CvdrMetadata> {
     let url = cvdr_sru_search_url(cvdr_id);
 
     let bytes = download_bytes_default(client, &url).await.map_err(|e| {
@@ -119,14 +112,7 @@ pub async fn search_cvdr(
     })?;
 
     let xml_string = bytes_to_string(bytes, &format!("SRU search for {cvdr_id}"));
-    let mut metadata = parse_sru_response(&xml_string, cvdr_id)?;
-
-    // Override the XML URL with the pre-resolved one from the manifest if available
-    if let Some(resolved_url) = pre_resolved_xml_url {
-        metadata.xml_url = resolved_url.to_string();
-    }
-
-    Ok(metadata)
+    parse_sru_response(&xml_string, cvdr_id)
 }
 
 /// Parse SRU XML response to extract CVDR metadata.


### PR DESCRIPTION
## Summary
- Fix CVDR harvesting failure when users enter bare IDs (e.g. `CVDR756485`)
- Resolve latest version by fetching repository manifest at `repository.officiele-overheidspublicaties.nl/cvdr/{ID}/manifest.xml`
- Accept singular organisation types (waterschap, gemeente, provincie)

## Root cause
The SRU API requires versioned identifiers (`CVDR756485_1`) but users naturally enter bare IDs (`CVDR756485`). The manifest lists all consolidations and marks the latest.

## Test plan
- [x] All tests pass (346 unit + integration + doc)
- [x] Manifest parsing tested with single/multi version fixtures
- [ ] Manual test: `CVDR756485` → should resolve to `_1` and harvest successfully
- [ ] Manual test: `CVDR691525` → should resolve to `_2` (latest consolidation)