### PR TITLE
fix(corpus): use FETCH_HEAD in checkout_from_branch for single-branch clones

### DIFF
--- a/packages/corpus/src/client.rs
+++ b/packages/corpus/src/client.rs
@@ -341,8 +341,11 @@ impl CorpusClient {
         self.run_git(&["fetch", "--depth", "1", "origin", base_branch])
             .await?;
 
-        let remote_ref = format!("origin/{base_branch}");
-        let mut args = vec!["checkout", &remote_ref, "--"];
+        // Use FETCH_HEAD rather than `origin/<base_branch>`: the enrichment
+        // clone is `--single-branch` for `enrich/<provider>`, so its fetch
+        // refspec never creates `refs/remotes/origin/<base_branch>` even
+        // after `git fetch origin <base_branch>`. FETCH_HEAD is always set.
+        let mut args = vec!["checkout", "FETCH_HEAD", "--"];
         args.extend(&missing);
         self.run_git(&args).await?;
 
@@ -1035,6 +1038,92 @@ mod tests {
             .exists());
         assert!(repo_path
             .join("regulation/nl/wet/some_law/2024-01-01.yaml")
+            .exists());
+    }
+
+    #[tokio::test]
+    async fn test_checkout_from_branch_works_with_preexisting_enrichment_branch() {
+        // Regression: when the enrichment branch already exists on the remote,
+        // ensure_repo clones it with `--single-branch --branch enrich/<provider>`.
+        // The configured fetch refspec then only matches enrich/<provider>, so
+        // `git fetch origin development` does NOT update refs/remotes/origin/development.
+        // checkout_from_branch must still be able to reach the fetched commit —
+        // which it does via FETCH_HEAD.
+        let dir = tempfile::tempdir().unwrap();
+        let bare_path = setup_bare_repo(dir.path()).await;
+        let bare_url = format!("file://{}", bare_path.display());
+
+        // Pre-create enrich/test on the bare, branching from development.
+        let tmp = dir.path().join("setup");
+        clone_with_config(&bare_path, &tmp).await;
+        for args in [
+            vec!["checkout", "-b", "enrich/test"],
+            vec!["push", "-u", "origin", "enrich/test"],
+            vec!["checkout", "development"],
+        ] {
+            Command::new("git")
+                .args(&args)
+                .current_dir(&tmp)
+                .output()
+                .await
+                .unwrap();
+        }
+
+        // Now push a new law to development (not yet on enrich/test).
+        let law_dir = tmp.join("regulation/nl/wet/new_law");
+        tokio::fs::create_dir_all(&law_dir).await.unwrap();
+        tokio::fs::write(law_dir.join("2025-01-01.yaml"), "new law content")
+            .await
+            .unwrap();
+        for args in [
+            vec!["add", "."],
+            vec!["commit", "-m", "harvest new law"],
+            vec!["push", "origin", "development"],
+        ] {
+            Command::new("git")
+                .args(&args)
+                .current_dir(&tmp)
+                .output()
+                .await
+                .unwrap();
+        }
+
+        // Clone enrich/test — this goes through git_clone (not the fallback),
+        // so the fetch refspec is +refs/heads/enrich/test:refs/remotes/origin/enrich/test only.
+        let repo_path = dir.path().join("enrich-clone");
+        let mut config = CorpusConfig::new(&bare_url, &repo_path);
+        config.branch = "enrich/test".into();
+        let mut client = CorpusClient::new(config);
+        client.ensure_repo().await.unwrap();
+
+        // Sanity-check: origin/development must NOT exist as a remote-tracking ref.
+        let refs = Command::new("git")
+            .args([
+                "for-each-ref",
+                "--format=%(refname)",
+                "refs/remotes/origin/",
+            ])
+            .current_dir(&repo_path)
+            .output()
+            .await
+            .unwrap();
+        let refs_str = String::from_utf8_lossy(&refs.stdout);
+        assert!(
+            !refs_str.contains("refs/remotes/origin/development"),
+            "expected no origin/development tracking ref before checkout_from_branch, got: {refs_str}"
+        );
+
+        // This would fail with `invalid reference: origin/development` before the FETCH_HEAD fix.
+        client
+            .checkout_from_branch(
+                "development",
+                &["regulation/nl/wet/new_law/2025-01-01.yaml"],
+            )
+            .await
+            .unwrap();
+
+        assert!(repo_path
+            .join("regulation/nl/wet/new_law/2025-01-01.yaml")
             .exists());
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #569. That fix was supposed to pull newly harvested laws from \`development\` into long-lived enrichment branches, but it never worked in production — every enrichment still failed with \`law YAML file not found\`, the exact error #569 targeted.

## Root cause

\`ensure_repo\` clones the enrichment branch with \`--single-branch --branch enrich/<provider>\`, which configures the remote's fetch refspec as:

\`\`\`
+refs/heads/enrich/<provider>:refs/remotes/origin/enrich/<provider>
\`\`\`

\`git fetch --depth 1 origin development\` then downloads the commits but does **not** create \`refs/remotes/origin/development\` (the refspec doesn't match). The follow-up \`git checkout origin/development -- <path>\` fails with:

\`\`\`
fatal: invalid reference: origin/development
\`\`\`

Production log confirms:
\`\`\`
failed to create enrichment branch corpus, proceeding without
  error=corpus error: git command failed: git checkout failed: fatal: invalid reference: origin/development
\`\`\`

The worker caught that error as a WARN and fell back to the default \`/tmp/corpus-repo/\` path, which doesn't contain the newly harvested law → \"file not found\".

My #569 tests passed because \`ensure_repo\`, when the target branch does not yet exist on the remote, falls back to \`git_clone_and_create_branch\` which clones \`--branch development --single-branch\` — giving it the matching refspec. Production had the branch already.

## Fix

\`git fetch\` always updates \`FETCH_HEAD\` regardless of refspec. Switch the checkout to use \`FETCH_HEAD\`:

\`\`\`rust
self.run_git(&[\"fetch\", \"--depth\", \"1\", \"origin\", base_branch]).await?;
let mut args = vec![\"checkout\", \"FETCH_HEAD\", \"--\"];
\`\`\`

## Regression test

Added \`test_checkout_from_branch_works_with_preexisting_enrichment_branch\` that:
- Pre-creates \`enrich/test\` on the bare remote (the production scenario)
- Clones it via \`ensure_repo\` → single-branch refspec for \`enrich/test\`
- Asserts \`refs/remotes/origin/development\` does NOT exist
- Calls \`checkout_from_branch(\"development\", ...)\` and verifies the file is present

Confirmed the test reproduces the bug: reverting the fix produces the exact \`fatal: invalid reference: origin/development\` error.

## Test plan

- [x] 4/4 \`checkout_from_branch\` tests pass with fix
- [x] New regression test fails without fix with the production error message
- [x] \`just format\`, \`just lint\` pass
- [ ] Verify on prod: submit an enrich for a newly harvested law, watch enrichworker logs for \`checked out paths from base branch\` and a successful commit