### PR TITLE
feat(corpus): machine_readable for HHNK kwijtschelding waterschapsbelastingen

### DIFF
--- a/corpus/regulation/nl/beleidsregel/leidraad_invordering_2008/2026-01-01.yaml
+++ b/corpus/regulation/nl/beleidsregel/leidraad_invordering_2008/2026-01-01.yaml
@@ -1,5 +1,5 @@
 ---
-$schema: v0.5.2/schema.json
+$schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/tags/schema-v0.5.2/schema/v0.5.2/schema.json
 $id: leidraad_invordering_2008
 regulatory_layer: BELEIDSREGEL
 publication_date: '2026-01-01'
@@ -179,6 +179,73 @@ articles:
       aanwezige financiële middelen worden aangesproken. Dit houdt in dat geen kwijtschelding kan worden verleend als de
       belastingaanslag binnen een jaar door middel van verrekening kan worden aangezuiverd.
     url: https://wetten.overheid.nl/BWBR0024096/2026-01-01#Circulaire.divisie26.1.9
+    machine_readable:
+      execution:
+        parameters:
+          - name: gegevens_onvolledig_of_onjuist
+            type: boolean
+            required: false
+            description: Gevraagde gegevens niet/onvolledig/onjuist verstrekt (punt 1 van 26.1.9).
+          - name: bezwaar_of_beroep_aanhangig
+            type: boolean
+            required: false
+            description: Bezwaarschrift of beroepschrift tegen aanslag in behandeling (punt 4).
+          - name: zekerheid_gesteld
+            type: boolean
+            required: false
+            description: Voor deze aanslag is zekerheid gesteld (punt 5).
+          - name: meerdere_belastingschuldigen
+            type: boolean
+            required: false
+            description: Er is sprake van meer dan een belastingschuldige (punt 6).
+          - name: derde_aansprakelijk_gesteld
+            type: boolean
+            required: false
+            description: Een derde kan nog voor deze belastingschuld aansprakelijk worden gesteld (punt 7).
+          - name: verwijtbaarheid_belastingschuld
+            type: boolean
+            required: false
+            description: |
+              Het kan belastingschuldige worden toegerekend dat aanslag niet voldaan kan worden
+              (punt 8, sub a-h; opzet, teruggaaf niet aangewend, voldoende middelen aanwezig,
+              kon vermoeden aanslag, onjuiste loonbelastingverklaring, onjuiste voorlopige
+              teruggaaf, negatieve voorlopige aanslag).
+          - name: in_faillissement_of_surseance_zonder_akkoord
+            type: boolean
+            required: false
+            description: Belastingschuldige is in surseance/faillissement zonder akkoord artikel 138/252 FW
+              (punt 9).
+        output:
+          - name: uitgesloten_van_kwijtschelding
+            type: boolean
+            description: True als een van de weigergronden van artikel 26.1.9 van toepassing is; kwijtschelding
+              wordt dan geweigerd onafhankelijk van de financiele beoordeling.
+        actions:
+          - output: uitgesloten_van_kwijtschelding
+            value:
+              operation: OR
+              conditions:
+                - operation: EQUALS
+                  subject: $gegevens_onvolledig_of_onjuist
+                  value: true
+                - operation: EQUALS
+                  subject: $bezwaar_of_beroep_aanhangig
+                  value: true
+                - operation: EQUALS
+                  subject: $zekerheid_gesteld
+                  value: true
+                - operation: EQUALS
+                  subject: $meerdere_belastingschuldigen
+                  value: true
+                - operation: EQUALS
+                  subject: $derde_aansprakelijk_gesteld
+                  value: true
+                - operation: EQUALS
+                  subject: $verwijtbaarheid_belastingschuld
+                  value: true
+                - operation: EQUALS
+                  subject: $in_faillissement_of_surseance_zonder_akkoord
+                  value: true
   - number: 26.1.10
     text: |
       Als een ex-ondernemer om kwijtschelding vraagt, past de ontvanger het kwijtscheldingsbeleid voor particulieren toe.

--- a/corpus/regulation/nl/beleidsregel/leidraad_invordering_2008/2026-01-01.yaml
+++ b/corpus/regulation/nl/beleidsregel/leidraad_invordering_2008/2026-01-01.yaml
@@ -1,0 +1,694 @@
+---
+$schema: v0.5.2/schema.json
+$id: leidraad_invordering_2008
+regulatory_layer: BELEIDSREGEL
+publication_date: '2026-01-01'
+valid_from: '2026-01-01'
+bwb_id: BWBR0024096
+name: Leidraad Invordering 2008
+url: https://wetten.overheid.nl/BWBR0024096/2026-01-01
+articles:
+  - number: '26'
+    text: |
+      In aansluiting op artikel 26 van de wet beschrijft dit artikel het beleid over:
+
+      – algemene uitgangspunten van het kwijtscheldingsbeleid;
+      – kwijtschelding van rijksbelastingen voor particulieren;
+      – kwijtschelding van rijksbelastingen voor ondernemers;
+      – administratief beroep;
+      – voortzetting van de invordering na afwijzing verzoek om kwijtschelding;
+      – geen verdere invorderingsmaatregelen en afwijzing verzoek om kwijtschelding.
+    url: https://wetten.overheid.nl/BWBR0024096/2026-01-01#Circulaire.divisie26
+  - number: 26.1.1
+    text: |
+      De ontvanger verleent ook kwijtschelding van belastingaanslagen die al zijn betaald, als aan de volgende voorwaarden is
+      voldaan:
+
+      – De belastingschuldige dient het verzoek om kwijtschelding in binnen drie maanden nadat de (laatste) betaling op de
+      belastingaanslag heeft plaatsgevonden.
+      – De belastingschuldige heeft betaald onder omstandigheden die aanleiding zouden hebben gegeven tot kwijtschelding als
+      hij daar eerder om had verzocht.
+
+      Als de ontvanger het verzoek toewijst, betaalt hij de belastingschuldige het bedrag terug waarvoor kwijtschelding is
+      verleend.
+    url: https://wetten.overheid.nl/BWBR0024096/2026-01-01#Circulaire.divisie26.1.1
+  - number: 26.1.2
+    text: |
+      Het verzoek om kwijtschelding moet worden ingediend bij de ontvanger waaronder de belastingschuldige ressorteert op een
+      daartoe ingesteld verzoekformulier.
+
+      Als de belastingschuldige een verzoek om kwijtschelding indient, maar dit niet doet op het daartoe bestemde formulier,
+      neemt de ontvanger het verzoek niet als zodanig in behandeling. De ontvanger stelt de belastingschuldige in dat geval
+      in de gelegenheid het verzoek alsnog binnen twee weken op het daartoe bestemde formulier in te dienen.
+
+      In afwachting hiervan wordt de invordering in beginsel opgeschort. Als de belastingschuldige het formulier niet
+      terugzendt, wijst de ontvanger het verzoek af.
+    url: https://wetten.overheid.nl/BWBR0024096/2026-01-01#Circulaire.divisie26.1.2
+  - number: 26.1.3
+    text: |
+      Als de ontvanger een uitgereikt of toegezonden verzoekformulier onvolledig ingevuld terugontvangt, stelt hij de
+      belastingschuldige in de gelegenheid de ontbrekende gegevens alsnog binnen twee weken te verstrekken. In afwachting
+      daarvan schort de ontvanger de invordering in beginsel op.
+
+      De ontvanger vraagt de gegevens slechts éénmaal op. Als de belastingschuldige niet alle gevraagde nadere gegevens
+      bijvoegt, beschouwt de ontvanger het verzoek ook als onvolledig ingevuld en wijst hij het verzoek af.
+    url: https://wetten.overheid.nl/BWBR0024096/2026-01-01#Circulaire.divisie26.1.3
+  - number: 26.1.4
+    text: |
+      Bij de beoordeling van het verzoek zijn de gegevens en normen van belang die gelden op het moment van indiening van het
+      verzoek, tenzij in de leidraad anders is aangegeven.
+    url: https://wetten.overheid.nl/BWBR0024096/2026-01-01#Circulaire.divisie26.1.4
+  - number: 26.1.5
+    text: |
+      Als de ontvanger besluit dat kwijtschelding zal worden verleend nadat aan één of meer voorwaarden is voldaan, dan neemt
+      hij die voorwaarden in de beschikking op.
+
+      Als de ontvanger in de voorwaarden heeft opgenomen dat verrekening zal plaatsvinden van uit te betalen bedragen, dan
+      stelt hij tevens de termijn vast waarin verrekening van die bedragen zal plaatsvinden. De termijn bedraagt maximaal
+      drie jaar, te rekenen vanaf de dagtekening van de kennisgeving, dan wel – als dit minder is – de tijd die nog
+      overblijft voordat de verjaring van de belastingaanslag intreedt.
+
+      Als tot de voorwaarden de voldoening van een deel van de schuld behoort, dan moet de ontvanger de belastingschuldige
+      uitnodigen om binnen een termijn van veertien dagen een voorstel te doen met betrekking tot de betaling van dat deel.
+      Hierbij is het uitstelbeleid (zie artikel 25 van deze leidraad) van toepassing. Als tot de voorwaarden naast de
+      voldoening van een deel van de schuld ook de verrekening van teruggaven behoort, wordt het te betalen bedrag niet
+      beïnvloed door de hoogte van de verrekende teruggaven.
+    url: https://wetten.overheid.nl/BWBR0024096/2026-01-01#Circulaire.divisie26.1.5
+  - number: 26.1.6
+    text: |
+      Als de ontvanger het verzoek om kwijtschelding afwijst, moet hij motiveren waarom hij tot afwijzing van het verzoek
+      heeft besloten. Daarbij moet hij alle afwijzingsgronden noemen.
+    url: https://wetten.overheid.nl/BWBR0024096/2026-01-01#Circulaire.divisie26.1.6
+  - number: 26.1.7
+    text: |
+      Als de ontvanger afwijzend heeft beslist op een verzoek om kwijtschelding of een aangeboden akkoord, of de directeur
+      afwijzend heeft beslist op een ingediend beroepschrift tegen een afwijzende beschikking van de ontvanger, voldoet de
+      belastingschuldige het op de belastingaanslag(en) verschuldigde bedrag binnen veertien dagen na dagtekening van de
+      afwijzende beschikking of binnen de betaaltermijnen die op het aanslagbiljet zijn aangegeven. Na deze termijn kan de
+      ontvanger de invordering aanvangen dan wel voortzetten. Artikel 9 van de regeling is gedurende deze wachttijd van
+      overeenkomstige toepassing.
+
+      De termijn van veertien dagen geldt niet als sprake is van een situatie als bedoeld in artikel 10 van de wet. De
+      termijn wordt daarnaast niet of niet geheel verleend als naar het oordeel van de ontvanger aanwijzingen bestaan dat
+      door het niet direct aanvangen of vervolgen van de invordering de belangen van de Staat worden geschaad.
+    url: https://wetten.overheid.nl/BWBR0024096/2026-01-01#Circulaire.divisie26.1.7
+  - number: 26.1.8
+    text: |
+      Om de belangen van de Staat niet te schaden, kan de ontvanger de beslissing op een kort voor de executoriale verkoop
+      ingediend verzoek om kwijtschelding mondeling bekend maken. De ontvanger bevestigt deze beslissing zo spoedig mogelijk
+      bij beschikking. In dat geval geldt niet de termijn van veertien dagen waarbinnen de ontvanger de invordering niet mag
+      aanvangen of voortzetten.
+
+      Evenzo geldt voor een kort voor de executoriale verkoop gedaan verzoek dat niet is ingediend op een verzoekformulier of
+      op een verzoekformulier dat onvolledig is ingevuld, dat de ontvanger de belastingschuldige niet in de gelegenheid stelt
+      het verzoek in te dienen op het daartoe bestemde formulier of de belastingschuldige niet in de gelegenheid stelt de
+      ontbrekende gegevens aan te vullen (zoals bepaald in de artikelen 26.1.2 en 26.1.3 van deze leidraad), maar het verzoek
+      afwijst.
+    url: https://wetten.overheid.nl/BWBR0024096/2026-01-01#Circulaire.divisie26.1.8
+  - number: 26.1.9
+    text: |
+      Er wordt geen kwijtschelding verleend als:
+
+      – de gevraagde gegevens voor de beoordeling van het verzoek niet, niet volledig, onjuist, of niet op het door de
+      ontvanger uitgereikte formulier (zie ook de artikelen 26.1.2 en 26.1.3 van deze leidraad) zijn verstrekt;
+      – uit de verstrekte gegevens voor de beoordeling van het verzoek een onevenredige verhouding blijkt tussen de omvang
+      van de uitgaven enerzijds en het inkomen anderzijds en de belastingschuldige de in dat verband door de ontvanger
+      gevraagde opheldering niet – of naar het oordeel van de ontvanger – in onvoldoende mate verschaft;
+      – de belastingschuldige heeft nagelaten de vereiste aangifte in te dienen. In dat geval wordt de belastingschuldige
+      meegedeeld dat een nieuw verzoek om kwijtschelding niet eerder kan worden ingediend, dan nadat de inspecteur op grond
+      van de alsnog verstrekte gegevens de belastingaanslag tot het juiste bedrag heeft kunnen vaststellen. Het verzoek dat
+      wordt ingediend nadat de belastingaanslag tot het juiste bedrag is vastgesteld, behandelt de ontvanger als een eerste
+      verzoek.
+      – een bezwaarschrift tegen de hoogte van de belastingaanslag in behandeling is bij de inspecteur, dan wel een
+      beroepschrift tegen de hoogte van de belastingaanslag in behandeling is bij de rechtbank of (in hoger beroep) bij het
+      gerechtshof. Een eventuele vermindering of vernietiging van de belastingaanslag dient namelijk aan kwijtschelding
+      vooraf te gaan. De belastingschuldige wordt meegedeeld dat een nieuw verzoek om kwijtschelding niet eerder kan worden
+      ingediend dan nadat op het bezwaarschrift of beroepschrift (in hoger beroep) is beslist.
+      – voor de desbetreffende belastingaanslag zekerheid is gesteld;
+      – er sprake is van meer dan één belastingschuldige;
+      – een derde nog voor de belastingschuld aansprakelijk kan worden gesteld;
+      – het aan de belastingschuldige kan worden toegerekend dat de belastingaanslag niet kan worden voldaan. Daarvan is
+      onder andere sprake als:
+        a. het aan opzet of grove schuld van de belastingschuldige is te wijten dat te weinig belasting is geheven;
+        b. (vervallen);
+        c. een uitbetaald bedrag (bijvoorbeeld een belastingteruggaaf) niet is aangewend ter voldoening van de schuld waarvan
+        kwijtschelding wordt gevraagd, tenzij het een voorlopige teruggaaf betreft voor zover die niet voor beslag vatbaar
+        is;
+        d. vanaf de bekendmaking van de belastingaanslag tot aan de indiening van het verzoek om kwijtschelding op enig
+        moment voldoende middelen aanwezig waren om de aanslag te kunnen voldoen;
+        e. de belastingschuldige wist of redelijkerwijs kon vermoeden dat een belastingaanslag zou worden opgelegd en nalatig
+        is gebleven in verband daarmee middelen te reserveren;
+        f. het verzoek is ingediend voor een belastingaanslag die het gevolg is van het feit dat een loonbelastingverklaring
+        niet of onjuist is ingevuld, tenzij de belastingschuldige aannemelijk maakt dat het niet of onjuist invullen niet aan
+        hem kan worden verweten;
+        g. het verzoek is ingediend voor een belastingaanslag die het gevolg is van het feit dat de belastingschuldige ten
+        onrechte een verzoek, dan wel een onjuist verzoek om een voorlopige teruggaaf heeft ingediend, tenzij de
+        belastingschuldige aannemelijk maakt dat hem dit niet kan worden verweten. Als het verzoek naar waarheid is ingevuld
+        en de belastingschuldige redelijkerwijs niet kon voorzien dat zich wijzigingen in zijn situatie zouden voordoen die
+        van invloed zijn op de aanspraak op een voorlopige teruggaaf, wordt het in de vorige volzin bedoelde bewijs geacht te
+        zijn geleverd;
+        h. aan de belastingaanslag een negatieve voorlopige aanslag is voorafgegaan die vastgesteld is overeenkomstig de
+        ingediende aangifte, tenzij de belastingschuldige aannemelijk maakt dat het hem niet kan worden verweten dat een
+        correctie van die aangifte heeft plaatsgevonden. De afwijzende beslissing op het kwijtscheldingsverzoek blijft
+        beperkt tot het deel van de belastingaanslag waarvoor de belastingschuldige verwijtbaarheid treft.
+      – de belastingschuldige in surseance van betaling of in staat van faillissement verkeert, tenzij een akkoord is
+      gesloten als bedoeld in de artikelen 138 en 252 FW;
+      – ten aanzien van de belastingschuldige de schuldsaneringsregeling natuurlijke personen van toepassing is verklaard,
+      tenzij sprake is van een akkoord als bedoeld in artikel 329 FW, dan wel van een belastingaanslag, niet zijnde een
+      belastingaanslag als bedoeld in artikel 8, tweede lid, van de regeling, voor zover die materieel verschuldigd is
+      geworden op een tijdstip of over een tijdvak dat is gelegen na de uitspraak waarbij de schuldsaneringsregeling van
+      toepassing is verklaard, en niet kan worden aangemerkt als een boedelschuld;
+      – het verzoek is ingediend voor een voorlopige aanslag én die aanslag nog niet is gevolgd door een (definitieve)
+      aanslag. In gevallen dat het verzoek overigens zou moeten worden toegewezen, verleent de ontvanger tegelijkertijd
+      (ambtshalve) uitstel van betaling totdat de definitieve aanslag is opgelegd. In de eventuele uitstelbeschikking deelt
+      de ontvanger de belastingschuldige mee dat na oplegging van de definitieve aanslag desgewenst een nieuw
+      kwijtscheldingsverzoek kan worden ingediend waarin naast de voorlopige aanslag de definitieve aanslag kan worden
+      betrokken;
+      – door de ontvanger nadere voorwaarden zijn gesteld en aan die voorwaarden nog niet is voldaan. Zodra aan de gestelde
+      voorwaarden is voldaan, kan alsnog kwijtschelding worden verleend;
+      – de gemeentelijke sociale dienst de belastingaanslag vergoedt.
+
+      Ook wordt geen kwijtschelding verleend voor het bedrag van de te betalen belasting waarop het verzoek betrekking heeft
+      als aannemelijk is dat dit bedrag kan worden voldaan omdat:
+
+      – binnen twee jaren na het verzoek als gevolg van sterk wisselende inkomens een hoger inkomen is te verwachten;
+      – binnen een jaar na indiening van het verzoek een verbetering is te verwachten in de financiële omstandigheden;
+      – binnen een jaar na het verzoek een belastingteruggaaf, anders dan de voorlopige teruggaaf, bedoeld in artikel 14,
+      tweede lid, van de regeling kan worden verwacht. De vraag of buitengewoon bezwaar bestaat de verschuldigde belasting te
+      betalen, kan immers slechts betrekking hebben op een per saldo verschuldigd bedrag. Alleen voor dat saldo moeten de
+      aanwezige financiële middelen worden aangesproken. Dit houdt in dat geen kwijtschelding kan worden verleend als de
+      belastingaanslag binnen een jaar door middel van verrekening kan worden aangezuiverd.
+    url: https://wetten.overheid.nl/BWBR0024096/2026-01-01#Circulaire.divisie26.1.9
+  - number: 26.1.10
+    text: |
+      Als een ex-ondernemer om kwijtschelding vraagt, past de ontvanger het kwijtscheldingsbeleid voor particulieren toe.
+
+      Er is geen sprake van een ex-ondernemer als (een deel van) het bedrijfsvermogen nog aanwezig is. In dat geval zal het
+      verzoek om kwijtschelding moeten worden behandeld overeenkomstig het bepaalde in artikel 26.3 van deze leidraad. Het
+      nog aanwezige bedrijfsvermogen zal geheel moeten worden gebruikt ter aflossing van de openstaande (zakelijke)
+      belastingaanslagen.
+    url: https://wetten.overheid.nl/BWBR0024096/2026-01-01#Circulaire.divisie26.1.10
+  - number: 26.1.11
+    text: |
+      De ontvanger houdt de invordering aan als er een verzoekschrift is ingediend bij Zijne Majesteit de Koning, de
+      Commissie voor de Verzoekschriften en Burgerinitiatieven uit de Tweede Kamer of de Commissie voor de Verzoekschriften
+      uit de Eerste Kamer der Staten-Generaal, de Nationale Ombudsman of het Ministerie van Financiën tot op dat
+      verzoekschrift is beslist. Als naar het oordeel van de ontvanger aanwijzingen bestaan dat door het niet direct
+      aanvangen of vervolgen van de invordering de belangen van de Staat worden geschaad, kan de ontvanger na voorafgaande
+      toestemming van het ministerie toch invorderingsmaatregelen treffen.
+    url: https://wetten.overheid.nl/BWBR0024096/2026-01-01#Circulaire.divisie26.1.11
+  - number: 26.2.1
+    text: |
+      Onder vermogen wordt verstaan de waarde in het economische verkeer van de bezittingen van de belastingschuldige en zijn
+      echtgenoot, verminderd met de schulden van de belastingschuldige en de echtgenoot die hoger bevoorrecht zijn dan de
+      rijksbelastingen.
+    url: https://wetten.overheid.nl/BWBR0024096/2026-01-01#Circulaire.divisie26.2.1
+  - number: 26.2.2
+    text: |
+      De waarde van de inboedel wordt niet als vermogensbestanddeel in aanmerking genomen als deze bij gedwongen verkoop niet
+      meer dan € 2269 bedraagt.
+    url: https://wetten.overheid.nl/BWBR0024096/2026-01-01#Circulaire.divisie26.2.2
+  - number: 26.2.3
+    text: |
+      De waarde van de personenauto wordt niet als vermogensbestanddeel in aanmerking genomen als deze op het moment waarop
+      het verzoek wordt ingediend een waarde heeft van € 3350 of minder. Als de waarde meer bedraagt, wordt de volle waarde
+      als vermogen in aanmerking genomen. Als op de auto voor een financier een pandrecht is gevestigd, moet ter vaststelling
+      van de actuele (over)waarde de financieringsschuld in mindering worden gebracht.
+
+      Een auto wordt niet als een vermogensbestanddeel in aanmerking genomen als de belastingschuldige aan de ontvanger – zo
+      nodig na een verzoek daartoe – aannemelijk kan maken dat die auto absoluut onmisbaar is voor de uitoefening van het
+      beroep dan wel absoluut onmisbaar is in verband met invaliditeit of ziekte van de belastingschuldige of zijn
+      gezinsleden. Met gezinsleden wordt bedoeld de echtgenoot van belastingschuldige, of zijn kind(eren) voor zover deze
+      geen eigen inkomen/vermogen heeft (hebben) waaruit de auto in beginsel zou kunnen worden betaald.
+    url: https://wetten.overheid.nl/BWBR0024096/2026-01-01#Circulaire.divisie26.2.3
+  - number: 26.2.4
+    text: |
+      Incidentele ontvangsten op een bankrekening (zoals vakantiegeld) worden voor de bepaling van een aanwezig
+      vermogensbestanddeel ook in aanmerking genomen, tenzij bij de berekening van de betalingscapaciteit met dat bedrag
+      rekening is gehouden. Deze situatie zal zich met name voordoen bij de vakantiegelduitkering.
+
+      Als de belastingschuldige een energietoeslag heeft ontvangen als bedoeld in artikel 35, vierde of vijfde lid, Pw, wordt
+      een bedrag ter hoogte van het ontvangen bedrag aan energietoeslag, niet in aanmerking genomen als vermogen voor de
+      beoordeling van het recht op kwijtschelding.
+
+      De nog beschikbare kredietruimte van een doorlopend krediet wordt in de kwijtscheldingsregeling niet als een
+      vermogensbestanddeel aangemerkt.
+    url: https://wetten.overheid.nl/BWBR0024096/2026-01-01#Circulaire.divisie26.2.4
+  - number: 26.2.5
+    text: |
+      De waarde van onroerende zaken die een belastingschuldige in zijn bezit heeft, wordt aangemerkt als een
+      vermogensbestanddeel. Voor de waardebepaling van de onroerende zaak is uitgangspunt de waarde van de onroerende zaak
+      bij verkoop vrij te aanvaarden.
+
+      Als de aanwezigheid van vermogen vastgelegd in onroerende zaken leidt tot de afwijzing van een verzoek om
+      kwijtschelding en de belastingaanslag wordt vervolgens niet betaald, kan de voortzetting van de invordering bij oudere
+      belastingschuldigen die hun laatste levensjaren in hun eigen woning willen slijten, leiden tot een onverdedigbare
+      hardheid. Een gedwongen verhuizing in verband met de verkoop van de woning zal voor deze groep belastingschuldigen een
+      onevenredig grotere belasting zijn dan voor andere belastingschuldigen. In die gevallen kan de ontvanger in overleg met
+      de belastingschuldige afzien van prompte invordering en in plaats daarvan uitstel van betaling verlenen, gedekt door
+      een hypotheek op de eigen woning of door het leggen van een beslag op de woning. De hypotheek moet opeisbaar zijn na
+      het overlijden van de langstlevende of bij een eerder vrijkomen van de woning.
+
+      Het verlenen van een zodanig uitstel blijft beperkt tot uitzonderlijke gevallen.
+    url: https://wetten.overheid.nl/BWBR0024096/2026-01-01#Circulaire.divisie26.2.5
+  - number: 26.2.6
+    text: |
+      Als bij de belastingschuldige kinderen thuis wonen die over een eigen vermogen beschikken, wordt dat vermogen bij de
+      beoordeling van het door de ouder ingediende verzoek om kwijtschelding niet in aanmerking genomen, tenzij die ouder
+      (een deel van) zijn vermogen heeft toebedeeld aan zijn kind(eren) om daaruit een fiscaal voordeel te behalen.
+    url: https://wetten.overheid.nl/BWBR0024096/2026-01-01#Circulaire.divisie26.2.6
+  - number: 26.2.7
+    text: |
+      Voor de beoordeling van een verzoek om kwijtschelding van belastingaanslagen ten name van overledenen zijn de
+      financiële omstandigheden van de erfgenamen in beginsel niet van belang. Alleen de vraag of de belastingaanslagen uit
+      het actief van de nalatenschap (hadden) kunnen worden voldaan is van belang.
+
+      Dit uitgangspunt geldt niet als het verzoek wordt gedaan door de langstlevende echtgenoot. In dat geval worden de
+      persoonlijke financiële omstandigheden wel mede in aanmerking genomen, ook al zouden bijvoorbeeld de kinderen als
+      mede-erfgenamen voor een deel van de belastingschuld kunnen worden aangesproken.
+
+      Als een erfgenaam op grond van een ingediend verzoek voor kwijtschelding in aanmerking zou komen, wordt de betrokkene
+      bij beschikking voor zijn aandeel in de belastingschuld ontslag van betalingsverplichting verleend. Deze werkwijze
+      wordt ook gevolgd als de partner van de erflater het verzoek om kwijtschelding indient.
+    url: https://wetten.overheid.nl/BWBR0024096/2026-01-01#Circulaire.divisie26.2.7
+  - number: 26.2.8
+    text: |
+      Vervallen.
+    url: https://wetten.overheid.nl/BWBR0024096/2026-01-01#Circulaire.divisie26.2.8
+  - number: 26.2.9
+    text: |
+      Vervallen.
+    url: https://wetten.overheid.nl/BWBR0024096/2026-01-01#Circulaire.divisie26.2.9
+  - number: 26.2.10
+    text: |
+      Als is vastgesteld dat geen of onvoldoende vermogensbestanddelen aanwezig zijn om de openstaande belastingaanslag te
+      voldoen, moet worden beoordeeld in hoeverre de aanwezige betalingscapaciteit voldoende is om de belastingaanslag te
+      voldoen.
+
+      De betalingscapaciteit wordt gevormd door het positieve verschil tussen het gemiddeld per maand te verwachten netto
+      besteedbaar inkomen van de belastingschuldige en de gemiddeld per maand te verwachten kosten van bestaan in de periode
+      van twaalf maanden vanaf de datum waarop het verzoek om kwijtschelding is ingediend.
+
+      Het netto besteedbaar inkomen van de belastingschuldige wordt vermeerderd met het gemiddeld per maand te verwachten
+      netto besteedbaar inkomen van zijn echtgenoot in de periode van twaalf maanden vanaf de datum waarop het verzoek om
+      kwijtschelding is ingediend. De vaststelling van het totale netto besteedbaar inkomen staat los van de
+      aansprakelijkheid tot betaling van de aanslagen waarvoor kwijtschelding wordt verzocht.
+
+      De verantwoordelijkheid van de echtgenoot voor schulden van de belastingschuldige, wordt beperkt tot de (materiële)
+      belastingschulden die betrekking hebben op de huwelijkse periode dan wel uit de periode waarin de gezamenlijke
+      huishouding is gevoerd. Dat kan tot gevolg hebben dat in voorkomende gevallen de belastingaanslag moet worden
+      gesplitst. Het vermogen en de betalingscapaciteit van de echtgenoot van belastingschuldige, worden dus buiten
+      beschouwing gelaten voor zover een door de belastingschuldige ingediend verzoek om kwijtschelding betrekking heeft op
+      belastingschulden die zijn ontstaan buiten de huwelijkse periode dan wel de gezamenlijke huishouding. Het toe te passen
+      normbedrag is in dit geval het normbedrag voor een alleenstaande of een alleenstaande ouder (zie artikel 16 van de
+      regeling).
+    url: https://wetten.overheid.nl/BWBR0024096/2026-01-01#Circulaire.divisie26.2.10
+  - number: 26.2.11
+    text: |
+      Tot het inkomen wordt ook het vakantiegeld gerekend. Het vakantiegeld wordt gesteld op 7% van de aan loonheffingen
+      onderworpen inkomsten waarbij aanspraak bestaat op vakantiegeld.
+
+      Als uit het ingediende verzoekformulier blijkt, dan wel de ontvanger uit eigen wetenschap bekend is, dat het reëel
+      genoten vakantiegeld meer of minder bedraagt dan 7%, wordt het reëel genoten vakantiegeld in aanmerking genomen. Zo is
+      bijvoorbeeld sprake van een lager percentage dan 7 in het geval de belastingschuldige een bijstandsuitkering geniet. In
+      dat geval moet dus worden uitgegaan van het percentage genoemd in artikel 19, derde lid, van de Pw.
+    url: https://wetten.overheid.nl/BWBR0024096/2026-01-01#Circulaire.divisie26.2.11
+  - number: 26.2.12
+    text: |
+      Bij de berekening van het netto besteedbare inkomen wordt rekening gehouden met inkomsten die studenten ontvangen op
+      grond van de WSF en hoofdstuk 4 van de Wet tegemoetkoming onderwijsbijdrage en schoolkosten (WTOS VO-18+).
+
+      Studenten in het hoger en middelbaar beroepsonderwijs hebben recht op een normbudget voor levensonderhoud: in het kader
+      van de kwijtscheldingsregeling is dit normbudget de optelsom van basisbeurs, maximale aanvullende beurs en maximale
+      basislening. Daarbij wordt voor zover van toepassing rekening gehouden met het feit of de student thuiswonend, dan wel
+      uitwonend is. In voorkomend geval wordt dit normbudget verhoogd met de één-oudertoeslag.
+
+      De inkomsten van een student worden gesteld op een forfaitair bedrag.
+
+      A. Voor studenten in het hoger onderwijs is dit het bedrag voor het normbudget voor levensonderhoud verminderd met een
+      forfaitair bedrag voor boeken en leermiddelen groot € 80.
+      B. Voor studenten in het middelbaar beroepsonderwijs is dit het bedrag voor het normbudget voor levensonderhoud
+      verminderd met een forfaitair bedrag voor boeken en leermiddelen groot € 70 en met het bedrag aan onderwijsretributie.
+
+      Als de belastingschuldige naast studiefinanciering beschikt over eigen inkomsten wordt eveneens uitgegaan van de
+      forfaitaire inkomsten, zoals hiervoor berekend onder A en B. Als de daadwerkelijk genoten studiefinanciering (exclusief
+      het ontvangen collegegeldkrediet voor studenten in het hoger onderwijs) en de eigen inkomsten uitstijgen boven de voor
+      het desbetreffende huishoudtype maximaal geldende kosten van bestaan worden om de betalingscapaciteit te kunnen
+      berekenen de navolgende formules gebruikt:
+
+      Formule 1: (P + Q) – R – S = X
+
+      In deze formule wordt met P aangegeven het totaal van de daadwerkelijk genoten studiefinanciering (exclusief het
+      ontvangen collegegeldkrediet voor studenten in het hoger onderwijs). Het totaal van de eigen inkomsten wordt aangegeven
+      met Q. Met R wordt aangegeven het voor de kwijtschelding geldende normbudget voor levensonderhoud. Het in mindering te
+      brengen bedrag van de daadwerkelijk ontvangen lening van de IB-groep wordt aangeduid met S. De uitkomst van deze
+      berekening wordt aangegeven met X, met dien verstande dat X altijd tenminste nul bedraagt.
+
+      Formule 2: X + Y = T
+
+      In deze formule wordt met Y aangegeven het forfaitaire bedrag aan inkomsten van de betreffende student zoals bedoeld
+      onder A of B. Het resultaat van de berekening volgens formule 1 (X) vermeerderd met Y is het inkomen (T). Dit inkomen
+      vormt vervolgens het uitgangspunt om het netto-besteedbaar inkomen te kunnen berekenen en de betalingscapaciteit.
+
+      In sommige gevallen bestaat de studiefinanciering voor een groot deel of zelfs geheel uit een lening. In die situaties
+      wordt ook uitgegaan van de vorenvermelde forfaitaire inkomsten en is hetgeen in dit artikel is vermeld van
+      overeenkomstige toepassing.
+    url: https://wetten.overheid.nl/BWBR0024096/2026-01-01#Circulaire.divisie26.2.12
+  - number: 26.2.13
+    text: |
+      Uitkeringen die worden ontvangen in het kader van bijzondere bijstand en die zijn bestemd voor bestrijding van
+      specifieke kosten waarin de reguliere bijstandsuitkering niet voorziet, worden niet als inkomen in aanmerking genomen.
+
+      De bijzondere (aanvullende) bijstand voor personen jonger dan 21 jaar, wordt daarentegen wél als inkomen in aanmerking
+      genomen, evenals de ouderlijke bijdrage in geld die deze jongeren ontvangen. In dat geval is de bijzondere bijstand
+      niet bestemd voor bestrijding van specifieke kosten waarin de reguliere bijstandsuitkering niet voorziet. De bijzondere
+      bijstand voor jongeren dient ter aanvulling van de zeer lage bijstandsnorm, als de ouderlijke bijdrage – die geacht
+      wordt deze lage bijstandsnorm aan te vullen tot het niveau van de bijstandsnorm voor personen van 21 tot 65 jaar –
+      geheel of gedeeltelijk ontbreekt.
+    url: https://wetten.overheid.nl/BWBR0024096/2026-01-01#Circulaire.divisie26.2.13
+  - number: 26.2.13a
+    text: |
+      Verstrekkingen die worden ontvangen uit een persoonsgebonden budget voor specifieke kosten op het gebied van zorg,
+      begeleiding of hulp en waarop geen aanspraak bestaat vanuit de zorgverzekering of de reguliere bijstand, worden niet
+      als inkomen in aanmerking genomen.
+    url: https://wetten.overheid.nl/BWBR0024096/2026-01-01#Circulaire.divisie26.2.13a
+  - number: 26.2.14
+    text: |
+      Bij de berekening van het netto besteedbaar inkomen wordt geen rekening gehouden met belastingaanslagen die in de loop
+      van de periode van twaalf maanden vanaf de datum waarop het verzoek is ingediend, nog zullen worden opgelegd.
+
+      Tot betalingen op belastingschulden worden ook de betalingen gerekend die worden verricht op gemeentelijke belastingen
+      (met uitzondering van de rechten die zijn vermeld in artikel 229 van de Gemeentewet), waterschapsbelastingen en andere
+      belastingen en heffingen van lokale overheden.
+    url: https://wetten.overheid.nl/BWBR0024096/2026-01-01#Circulaire.divisie26.2.14
+  - number: 26.2.15
+    text: |
+      Als het verzoek om kwijtschelding wordt gedaan voor belastingschulden die zijn ontstaan voor de aanvang van de
+      huwelijkse periode, dan wel de gezamenlijke huishouding in de zin van artikel 3 Pw (zie artikel 26.2.10 van deze
+      leidraad), worden de woonlasten in aanmerking genomen tot ten hoogste 50% van het bedrag dat de uitkomst is van de
+      berekening op grond van artikel 15, eerste lid, onderdeel b, van de regeling.
+    url: https://wetten.overheid.nl/BWBR0024096/2026-01-01#Circulaire.divisie26.2.15
+  - number: 26.2.15.a
+    text: |
+      Vervallen.
+    url: https://wetten.overheid.nl/BWBR0024096/2026-01-01#Circulaire.divisie26.2.15.a
+  - number: 26.2.16
+    text: |
+      Naast de alimentatieverplichtingen wordt bij de berekening van het netto besteedbaar inkomen de daadwerkelijk betaalde
+      onderhoudsbijdrage – de bijdrage die een gemeente op grond van de Pw van een ex-partner vordert in de kosten van
+      bijstand – in mindering gebracht.
+    url: https://wetten.overheid.nl/BWBR0024096/2026-01-01#Circulaire.divisie26.2.16
+  - number: 26.2.17
+    text: |
+      Als sprake is van een belastingschuldige ten aanzien van wie de schuldsaneringsregeling natuurlijke personen van
+      toepassing is verklaard, en die belastingschuldige verzoekt om kwijtschelding van nadien opgekomen belastingschulden
+      die niet zijn aan te merken als boedelschuld, dan wordt het verzoek behandeld overeenkomstig het bestaande beleid.
+
+      Dit betekent dus onder meer dat bij de berekening van de betalingscapaciteit op het inkomen van de belastingschuldige
+      niet in mindering wordt gebracht dat deel van het inkomen dat onder beheer van de bewindvoerder naar de boedel gaat.
+      Verder wordt opgemerkt dat de middelen die de boedel vormen en onder beheer van de bewindvoerder berusten, niet
+      beschouwd worden als vermogen in de zin van artikel 12 van de regeling.
+    url: https://wetten.overheid.nl/BWBR0024096/2026-01-01#Circulaire.divisie26.2.17
+  - number: 26.2.18
+    text: |
+      Van de kunstenaar die in het voorafgaande kalenderjaar geen Wik-uitkering heeft genoten worden de totale inkomsten
+      gesteld op het bedrag van de voor hem geldende bijstandsnorm, met inbegrip van de maximale toeslag.
+    url: https://wetten.overheid.nl/BWBR0024096/2026-01-01#Circulaire.divisie26.2.18
+  - number: 26.2.19
+    text: |
+      De normpremie, bedoeld in artikel 2 van de Wet op de zorgtoeslag, voor zover is begrepen in de bijstandsnorm, bedraagt
+      voor een alleenstaande of een alleenstaande ouder € 47 per maand en voor echtgenoten € 106 per maand.
+    url: https://wetten.overheid.nl/BWBR0024096/2026-01-01#Circulaire.divisie26.2.19
+  - number: 26.2.20
+    text: |
+      De hier te lande alleenwonende gehuwde belastingschuldige die zijn in het buitenland verblijvende echtgenote en/of
+      kinderen daadwerkelijk onderhoudt, wordt voor de berekening van de betalingscapaciteit niet als een alleenstaande
+      aangemerkt. Uitgegaan wordt van het normbedrag voor echtgenoten in de zin van artikel 3 Pw. Als huur wordt de hier te
+      lande betaalde huur in aanmerking genomen. Door toepassing van het normbedrag voor echtgenoten in de zin van artikel 3
+      Pw, wordt in het kwijtscheldingsbeleid op forfaitaire wijze rekening gehouden met de bedragen die de buitenlandse
+      werknemer aan zijn bloed- of aanverwanten overmaakt voor de kosten van levensonderhoud. Met de werkelijke bedragen die
+      de buitenlandse belastingschuldige overmaakt, wordt geen rekening gehouden.
+    url: https://wetten.overheid.nl/BWBR0024096/2026-01-01#Circulaire.divisie26.2.20
+  - number: 26.3.1
+    text: |
+      Kwijtschelding voor ondernemers vindt alleen plaats bij een saneringsakkoord tussen de schuldenaar en alle schuldeisers
+      tot gedeeltelijke betaling van de schuld tegen finale kwijting.
+
+      Deze kwijtschelding komt pas aan de orde nadat alle gestelde zekerheden zijn uitgewonnen.
+
+      Ook als er geen andere schuldeisers zijn of alleen speciale crediteuren als bedoeld in artikel 26.3.8 van deze leidraad
+      kan de ontvanger kwijtschelding verlenen. De ontvanger zal bij dergelijke saneringsverzoeken de volgende aspecten
+      meewegen in de beoordeling van het verzoek:
+
+      1. Kan de belastingschuldige een verwijt worden gemaakt ter zake van het onbetaald blijven van de belastingschulden
+      (zie artikel 8 van de regeling en artikel 26.1.9 van deze leidraad)?
+      2. Is er sprake van een situatie waarin de belastingschuldige de ontvanger als enig schuldeiser heeft overgelaten door
+      de andere schuldeisers bij voorrang te voldoen (zie artikel 26.3.5 van deze leidraad)?
+        De voorwaarden van artikel 22 van de regeling voor medewerking van de ontvanger aan een saneringsakkoord zijn voor
+        zover mogelijk van overeenkomstige toepassing.
+    url: https://wetten.overheid.nl/BWBR0024096/2026-01-01#Circulaire.divisie26.3.1
+  - number: 26.3.2
+    text: |
+      Voordat de ontvanger toetreedt tot een saneringsakkoord gaat hij na of de mogelijkheid bestaat (een) derde(n)
+      aansprakelijk te stellen voor onbetaald gebleven belastingschuld. Als de (te verwachten) opbrengst uit de
+      aansprakelijkstelling zodanig is dat het aanbod tot een saneringsakkoord voor de ontvanger geen betere perspectieven
+      biedt, treedt de ontvanger niet toe tot het akkoord.
+
+      Bij toetreding tot een saneringsakkoord kan de ontvanger er van afzien derden alsnog aansprakelijk te stellen. In dat
+      geval moet bij de vaststelling van het bedrag dat aan de ontvanger moet worden voldaan rekening worden gehouden met het
+      bedrag dat uit de aansprakelijkstelling geïnd had kunnen worden.
+
+      Als de ontvanger toetreedt tot een saneringsakkoord en daarnaast nog derden aansprakelijk stelt, blijft bij de
+      vaststelling van het bedrag dat in het akkoord moet worden voldaan een (eventuele) opbrengst uit de
+      aansprakelijkstelling buiten beschouwing. In de situatie dat de aansprakelijkgestelde zijn regresrecht op de gesaneerde
+      onderneming uitoefent en het bedrijf daardoor opnieuw in moeilijkheden komt, eist de ontvanger niet dat de onderneming
+      het ontstane tekort alsnog aanvult. Als later blijkt dat de aansprakelijkgestelde niet kan betalen, eist de ontvanger
+      evenmin het ontstane tekort op.
+    url: https://wetten.overheid.nl/BWBR0024096/2026-01-01#Circulaire.divisie26.3.2
+  - number: 26.3.3
+    text: |
+      In aanvulling van artikel 22 van de regeling werkt de ontvanger uitsluitend mee aan een saneringsakkoord als de
+      communautaire middelen volledig worden voldaan.
+
+      De ontvanger verleent geen medewerking aan een saneringsakkoord waarbij één of meer schuldeisers het gedeelte van hun
+      vordering dat niet wordt voldaan niet kwijtschelden maar overdragen aan een derde of omzetten in aandelenkapitaal.
+    url: https://wetten.overheid.nl/BWBR0024096/2026-01-01#Circulaire.divisie26.3.3
+  - number: 26.3.4
+    text: |
+      Bij de beoordeling van het aangeboden saneringsakkoord bekijkt de ontvanger welke belastingaanslagen in het akkoord
+      kunnen worden betrokken. Uitgangspunt hierbij is de formele belastingschuld ten tijde van het verzoek.
+
+      Bij de behandeling van het aangeboden akkoord is het de taak van de belastingschuldige/ondernemer er voor te zorgen dat
+      de formele schuld zo nauwkeurig mogelijk overeenstemt met de materiële schuld. Als de belastingschuldige niet de
+      gegevens overlegt die (kunnen) leiden tot een juiste vaststelling van de verschuldigde belasting, is er geen aanleiding
+      voor de ontvanger toe te treden tot het aangeboden akkoord.
+
+      Ook de Belastingdienst heeft de inspanningsverplichting om de te saneren schuld zo volledig mogelijk en tot het juiste
+      bedrag vast te stellen en de eventueel nog (materieel) verschuldigde belastingen over tijdvakken tot aan het tijdstip
+      waarop het verzoek om sanering is ingediend, te formaliseren.
+    url: https://wetten.overheid.nl/BWBR0024096/2026-01-01#Circulaire.divisie26.3.4
+  - number: 26.3.5
+    text: |
+      Voor de berekening van het dubbele percentage dat aan de fiscus moet worden uitgekeerd, brengt de ontvanger op de
+      vorderingen van de concurrente crediteuren eerst in mindering de bedragen die de concurrente crediteuren door zekerheid
+      hebben gedekt. Het begrip ‘ten minste’ verdient in elk geval extra aandacht als in het verleden onevenredige betalingen
+      aan concurrente schuldeisers zijn gedaan.
+
+      Voordat een beoordeling van het aanbod plaatsvindt, moet worden nagegaan of in de periode direct voorafgaand aan het
+      tijdstip waarop het verzoek tot sanering wordt ontvangen wellicht extra aflossingen aan bepaalde andere crediteuren
+      hebben plaatsgevonden. Als hiervan sprake is, moet aan de ontvanger – met doorbreking van de eis dat het dubbele
+      percentage moet worden aangeboden – een hoger percentage dan het dubbele ten goede komen.
+
+      Om de totstandkoming van minnelijke saneringsakkoorden van ondernemers te bevorderen, neemt de ontvanger van 1 augustus
+      2022 tot 1 april 2024 genoegen met ten minste hetzelfde uitkeringspercentage als aan concurrente crediteuren wordt
+      aangeboden. Voor de toepassing van dit artikel moet daarom voor verzoeken om sanering die in de periode van 1 augustus
+      2022 tot 1 april 2024 zijn ontvangen, in plaats van het dubbele uitkeringspercentage, hetzelfde uitkeringspercentage
+      dat aan concurrente crediteuren op hun vordering zal worden uitgekeerd, worden beoordeeld.
+    url: https://wetten.overheid.nl/BWBR0024096/2026-01-01#Circulaire.divisie26.3.5
+  - number: 26.3.5a
+    text: |
+      Om de totstandkoming van minnelijke saneringsakkoorden van ondernemers te bevorderen, neemt de ontvanger van 1 augustus
+      2022 tot 1 april 2024 genoegen met ten minste hetzelfde uitkeringspercentage als aan concurrente crediteuren op hun
+      vorderingen wordt aangeboden.
+
+      Voor een saneringsakkoord als bedoeld in artikel 21 van de regeling (zie ook artikel 26.3.1) betekent dit dat de
+      ontvanger daarmee in kan stemmen, als het door hem te ontvangen deel van de belastingschuld, ten minste hetzelfde
+      percentage bedraagt als hetgeen aan concurrente crediteuren die in het akkoord zijn betrokken, op hun vorderingen wordt
+      aangeboden. Dit is van overeenkomstige toepassing in de situatie bedoeld in artikel 26.3.8, tweede gedachtestreepje.
+
+      Deze tijdelijke maatregel is van toepassing op verzoeken om sanering als bedoeld in artikel 21 van de regeling (zie ook
+      artikel 26.3.1) die in de periode van 1 augustus 2022 tot 1 april 2024 zijn ontvangen, voor zover het verzoeken betreft
+      van ondernemers die hun onderneming voortzetten.
+    url: https://wetten.overheid.nl/BWBR0024096/2026-01-01#Circulaire.divisie26.3.5a
+  - number: 26.3.6
+    text: |
+      Bestuurlijke boeten moeten ook integraal in het akkoord worden betrokken. Uitgangspunt is dat het heffingstraject moet
+      worden afgewerkt voordat tot sanering kan worden overgegaan. Daarna past de ontvanger het akkoordpercentage toe op de
+      belastingschuld én op de bestuurlijke boete.
+    url: https://wetten.overheid.nl/BWBR0024096/2026-01-01#Circulaire.divisie26.3.6
+  - number: 26.3.7
+    text: |
+      De ontvanger betrekt rente en kosten integraal in het akkoord. Het bedrag dat op basis van het akkoord is betaald,
+      wordt in afwijking van artikel 7 van de wet op de hoofdsom afgeboekt. De ontvanger vermeldt dit in de beschikking.
+    url: https://wetten.overheid.nl/BWBR0024096/2026-01-01#Circulaire.divisie26.3.7
+  - number: 26.3.8
+    text: |
+      Een aantal crediteuren neemt een zodanige positie in dat zij niet noodzakelijkerwijs tot een akkoord hoeven toe te
+      treden om (een deel van) de vordering die zij hebben, te kunnen innen. Tot die crediteuren behoren onder meer:
+
+      – Pandhouders, omdat het recht van voorrang van de pandhouder op het in pand gegeven goed boven het voorrecht van de
+      fiscus gaat, staat het niet deelnemen van de pandhouder aan het akkoord niet aan een deelname daaraan door de ontvanger
+      in de weg. Vanzelfsprekend zal in aanmerking moeten worden genomen dat het recht van voorrang van de pandhouder
+      afhankelijk is van – en dus qua belang beperkt is tot – de waarde van het in pand gegeven goed. Voor het niet door pand
+      gedekte gedeelte van zijn vordering kan de pandhouder slechts als concurrent schuldeiser worden aangemerkt. De
+      bezitloos pandhouder wiens pandrecht betrekking heeft op een zaak als bedoeld in artikel 21, tweede lid, tweede volzin,
+      van de wet is voor die zaak lager bevoorrecht dan de fiscus. Voor hem geldt het voorgaande dus niet.
+      – Leveranciers die de eigendom van de geleverde zaak hebben voorbehouden. Als een leverancier de eigendom van de
+      geleverde zaak heeft voorbehouden, moet bij het bepalen van de grootte van zijn vordering rekening worden gehouden met
+      dat eigendomsvoorbehoud. Het voorgaande is niet van toepassing als de ontvanger met toepassing van het bodemrecht
+      beslag heeft gelegd op deze zaak. In dat geval moet integrale voldoening van de waarde van de bodemzaak worden geëist
+      en voor het restant van de fiscale vordering (ten minste) het dubbele percentage.
+      – Cessionarissen, als sprake is van rechtsgeldige gecedeerde uit te betalen bedragen en de ontvanger heeft eveneens met
+      de cessie ingestemd, dan wordt bij een akkoord de vordering van de crediteur/cessionaris in aanmerking genomen met
+      inachtneming van de te verwachten uit te betalen bedragen. De hoogte van de vordering van de ontvanger wordt bepaald
+      zonder rekening te houden met de te verwachten – maar rechtsgeldig gecedeerde – uit te betalen bedragen.
+      – Dwangcrediteuren. Onder ‘dwangcrediteuren’ worden in dit verband handelscrediteuren verstaan van wie het aannemelijk
+      is dat zij niet bereid zullen zijn aan een akkoord mee te werken, terwijl zonder de betrokkenheid van deze
+      handelscrediteuren de onderneming na de totstandkoming van het saneringsakkoord niet kan worden voortgezet.
+      – De boekhouder of adviseur die stukken moet produceren die voor de beoordeling van een saneringsakkoord nodig zijn.
+      Bij de beoordeling van het akkoord houdt de ontvanger rekening met de volledige betaling van de vordering van de
+      boekhouder of adviseur voor zover deze ziet op die werkzaamheden.
+      – Publieke schuldeisers, indien en voor zover die een vordering hebben op belastingschuldige waarop artikel 107, eerste
+      lid, van het Verdrag betreffende de werking van de Europese Unie van toepassing is en die daarom niet mag worden
+      kwijtgescholden, tenzij die vordering vanwege het verwijtbaar handelen of nalaten van belastingschuldige is ontstaan of
+      onbetaald gebleven.
+    url: https://wetten.overheid.nl/BWBR0024096/2026-01-01#Circulaire.divisie26.3.8
+  - number: 26.3.9
+    text: |
+      De betaling van het bedrag van het saneringsakkoord vindt in beginsel zonder uitstel plaats. De ontvanger kan echter
+      toestaan dat het bedrag in termijnen wordt betaald. Dit kan indien de belastingschuldige na de sanering het bedrijf of
+      zelfstandig beroep blijft uitoefenen en aannemelijk maakt dat de termijnen, bedoeld in de tweede volzin, evenals de
+      nieuw opkomende fiscale verplichtingen tijdig kunnen worden nagekomen. In het geval de ontvanger betaling in termijnen
+      heeft toegestaan, treedt hij voorwaardelijk toe tot het akkoord. Op de betalingsregeling voor het bedrag van het
+      saneringsakkoord zijn de artikelen 25.6.1, 25.6.2 en 25.6.2a van overeenkomstige toepassing waarbij in afwijking van:
+
+      − artikel 25.4.3 van deze leidraad geen verrekening plaatsvindt van belastingteruggaven en andere teruggaven voor zover
+      die materieel zijn ontstaan na de dag waarop het verzoek tot het sluiten van het saneringsakkoord is ingediend;
+      − artikel 25.6.1 van deze leidraad de looptijd van twaalf maanden aanvangt op de dag na de dagtekening van de
+      voorwaardelijke beschikking tot kwijtschelding;
+      − artikel 25.6.2 van deze leidraad de belastingschuldige nieuw opkomende fiscale en andere financiële verplichtingen,
+      waarvan de invordering aan de ontvanger is opgedragen, niet alleen gedurende de uitstelregeling, maar gedurende de
+      gehele looptijd van de saneringsprocedure nakomt;
+      − artikel 25.6.2 van deze leidraad de belastingschuldige geen zekerheid hoeft te stellen;
+      − artikel 25.6.2a van deze leidraad het bedrag van het saneringsakkoord in meer dan twaalf maandelijkse termijnen kan
+      worden betaald, indien de belastingschuldige aannemelijk maakt dat hij het bedrag van het saneringsakkoord niet binnen
+      twaalf maandelijkse termijnen kan voldoen en nakoming van het akkoord is geborgd. Daarnaast hoeft de belastingschuldige
+      met een verklaring van een derde deskundige alleen aannemelijk te maken dat de betalingsproblemen met het
+      saneringsakkoord zullen worden opgelost en dat er sprake is van een levensvatbare onderneming. De tweede alinea van
+      artikel 25.6.2b van deze leidraad is van overeenkomstige toepassing.
+
+      De ontvanger verleent kwijtschelding indien het saneringsakkoord in het geheel is nagekomen.
+    url: https://wetten.overheid.nl/BWBR0024096/2026-01-01#Circulaire.divisie26.3.9
+  - number: 26.4.1
+    text: |
+      Als de belastingschuldige zich niet kan verenigen met de beschikking van de ontvanger op het verzoek om kwijtschelding,
+      kan hij een gemotiveerd beroepschrift richten tot de directeur. Het beroepschrift wordt ingediend bij de ontvanger. In
+      verband met het aan de directeur uit te brengen advies zendt de ontvanger zo nodig opnieuw een verzoekformulier aan de
+      belastingschuldige toe.
+
+      Als de belastingschuldige het nader toegezonden verzoekformulier niet terugzendt, stelt de ontvanger hem in de
+      gelegenheid dit alsnog te doen. Als de belastingschuldige hieraan geen gevolg geeft, stelt de ontvanger de directeur
+      daarvan in kennis. De ontvanger adviseert de directeur dan om niet aan het beroepschrift tegemoet te komen.
+    url: https://wetten.overheid.nl/BWBR0024096/2026-01-01#Circulaire.divisie26.4.1
+  - number: 26.4.2
+    text: |
+      De ontvanger merkt een door de belastingschuldige gemaakt bezwaar tegen de beslissing op het verzoek om kwijtschelding
+      aan als een administratief beroep dat is gericht aan de directeur. Dit geldt ook als de belastingschuldige een nieuw
+      verzoek om kwijtschelding indient voor dezelfde belastingschuld waarvoor de ontvanger eerder een verzoek om
+      kwijtschelding geheel of gedeeltelijk heeft afgewezen en daarbij geen andere feiten of veranderde omstandigheden
+      vermeldt.
+
+      In de hiervoor genoemde situaties geeft de ontvanger een nieuwe voor administratief beroep vatbare beschikking af als
+      hij aanleiding ziet om een voor de belastingschuldige gunstigere beslissing te nemen.
+
+      Als de belastingschuldige een nieuw verzoek om kwijtschelding doet voor dezelfde belastingschuld en hij vermeldt hierin
+      andere feiten of veranderde omstandigheden, dan beslist de ontvanger op dat verzoek bij voor administratief beroep
+      vatbare beschikking. Bij deze beslissing houdt hij rekening met deze andere feiten of veranderde omstandigheden. Dit
+      geldt ook als het een belastingschuld betreft waarvoor de directeur al op een administratief beroep afwijzend heeft
+      beslist.
+
+      Als de belastingschuldige opnieuw verzoekt om kwijtschelding ter zake van een belastingschuld waarvoor de directeur al
+      op een administratief beroep afwijzend heeft beslist zonder daarbij andere feiten of veranderde omstandigheden te
+      vermelden, wijst de ontvanger dit verzoek af onder verwijzing naar de uitspraak van de directeur bij voor
+      administratief beroep vatbare beschikking.
+    url: https://wetten.overheid.nl/BWBR0024096/2026-01-01#Circulaire.divisie26.4.2
+  - number: 26.4.3
+    text: |
+      Als uit het beroepschrift niet duidelijk blijkt waarop het beroep is gebaseerd, verzoekt de ontvanger de
+      belastingschuldige het beroepschrift binnen een redelijke termijn (nader) te motiveren. De ontvanger wijst daarbij op
+      een mogelijke niet-ontvankelijkverklaring bij het niet voldoen aan deze motiveringsplicht.
+    url: https://wetten.overheid.nl/BWBR0024096/2026-01-01#Circulaire.divisie26.4.3
+  - number: 26.4.4
+    text: |
+      Bij de behandeling van het beroepschrift of het herhaalde verzoek om kwijtschelding zijn de gegevens en normen van
+      belang die van toepassing waren bij de beoordeling van het eerste verzoek. Wanneer echter blijkt dat het inkomen van de
+      belastingschuldige ten opzichte van het eerste verzoek zodanig is gedaald dat de betalingscapaciteit destijds in
+      belangrijke mate tot een te hoog bedrag is vastgesteld, vindt een herberekening plaats. Ook wijzigingen in de aanspraak
+      inzake huurtoeslag en zorgtoeslag kunnen leiden tot een herberekening. Een herberekening vindt niet plaats bij
+      wijzigingen in de kosten van bestaan.
+    url: https://wetten.overheid.nl/BWBR0024096/2026-01-01#Circulaire.divisie26.4.4
+  - number: 26.4.5
+    text: |
+      In alle gevallen waarin de directeur het beroep gegrond oordeelt, kan hij de zaak inhoudelijk afdoen. Hetzij door het
+      verzoek alsnog toe te wijzen, hetzij door het af te wijzen onder verbetering of vervanging van de gronden.
+    url: https://wetten.overheid.nl/BWBR0024096/2026-01-01#Circulaire.divisie26.4.5
+  - number: 26.4.6
+    text: |
+      Als binnen de termijn van tien dagen als bedoeld in artikel 24 van de regeling een beroepschrift wordt ingediend, dan
+      wordt gedurende de behandeling van dit beroepschrift gehandeld overeenkomstig artikel 9 van de regeling.
+
+      Indiening van het beroepschrift na de termijn van tien dagen leidt tot niet-ontvankelijkheid. Dit neemt echter niet weg
+      dat – als het belang van de invordering zich daartegen niet verzet – van de directeur mag worden verwacht dat hij
+      alsnog ambtshalve de grieven die in het beroepschrift zijn aangedragen op hun waarde beoordeelt. Ook in dat geval wordt
+      gehandeld overeenkomstig artikel 9 van de regeling.
+
+      Of het belang van de invordering zich tegen ambtshalve behandeling verzet, hangt af van de omstandigheden. Hiervan is
+      echter in ieder geval sprake als inmiddels onherroepelijke invorderingsmaatregelen zijn genomen.
+    url: https://wetten.overheid.nl/BWBR0024096/2026-01-01#Circulaire.divisie26.4.6
+  - number: 26.4.7
+    text: |
+      Als de ontvanger nalaat om tijdig een beslissing te nemen op een verzoek om kwijtschelding, kan de belastingschuldige
+      hiertegen beroep instellen bij de directeur. Hieraan is geen termijn gebonden.
+
+      Als tijdens de beroepsprocedure blijkt dat de ontvanger kwijtschelding had moeten verlenen, dan hoeft de directeur niet
+      te volstaan met de uitspraak dat de ontvanger niet tijdig heeft beslist, maar kan hij op het beroepschrift van de
+      belastingschuldige inhoudelijk beslissen.
+    url: https://wetten.overheid.nl/BWBR0024096/2026-01-01#Circulaire.divisie26.4.7
+  - number: 26.5.1
+    text: |
+      Vervallen.
+    url: https://wetten.overheid.nl/BWBR0024096/2026-01-01#Circulaire.divisie26.5.1
+  - number: '26.6'
+    text: |
+      Als de belastingschuldige niet in aanmerking komt voor kwijtschelding maar de ontvanger voortzetting van de invordering
+      niet gewenst vindt, wijst de ontvanger het verzoek om kwijtschelding af. De ontvanger neemt in die beschikking op in
+      hoeverre hij geen invorderingsmaatregelen zal treffen. Tegen het besluit van de ontvanger om geen
+      invorderingsmaatregelen meer te treffen staat geen administratief beroep open.
+
+      Als de ontvanger besluit tot het niet meer nemen van invorderingsmaatregelen voor de nog openstaande schuld zonder dat
+      hij daaraan voorwaarden verbindt, heeft de beslissing voor de belastingschuldige materieel dezelfde gevolgen als
+      kwijtschelding.
+
+      De ontvanger kan ook besluiten geen invorderingsmaatregelen meer te nemen voor de nog openstaande schuld onder de
+      voorwaarde dat eventuele uit te betalen bedragen verrekend worden met de buiten de invordering gelaten schuld. De
+      termijn waarbinnen verrekening plaatsvindt bedraagt maximaal drie jaar, te rekenen vanaf de datum van de beschikking,
+      dan wel – als dit minder is – de tijd die nog overblijft voordat de verjaring van de belastingaanslag intreedt. De
+      ontvanger neemt deze verrekeningsvoorwaarde uitdrukkelijk in de beschikking op.
+
+      Als de ontvanger besluit voorlopig geen invorderingsmaatregelen meer te nemen, zal hij in zijn beschikking voorwaarden
+      of een tijdsbepaling opnemen. Anders dan kwijtschelding is een dergelijke beschikking herroepelijk. Als de
+      belastingschuldige de voorwaarden niet nakomt, neemt de ontvanger een nieuwe beschikking, waarbij hij zijn eerdere
+      beschikking intrekt. De ontvanger kan hiertoe pas overgaan nadat hij de belastingschuldige een brief heeft gestuurd
+      over zijn voornemen de eerdere beschikking in te trekken en niet binnen veertien dagen alsnog aan de voorwaarden of de
+      tijdsbepaling is voldaan.
+    url: https://wetten.overheid.nl/BWBR0024096/2026-01-01#Circulaire.divisie26.6

--- a/corpus/regulation/nl/ministeriele_regeling/regeling_kwijtschelding_belastingen_medeoverheden/2022-09-17.yaml
+++ b/corpus/regulation/nl/ministeriele_regeling/regeling_kwijtschelding_belastingen_medeoverheden/2022-09-17.yaml
@@ -1,5 +1,5 @@
 ---
-$schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/heads/main/schema/v0.5.2/schema.json
+$schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/tags/schema-v0.5.2/schema/v0.5.2/schema.json
 $id: regeling_kwijtschelding_belastingen_medeoverheden
 regulatory_layer: MINISTERIELE_REGELING
 publication_date: '2022-09-16'

--- a/corpus/regulation/nl/ministeriele_regeling/regeling_kwijtschelding_belastingen_medeoverheden/2022-09-17.yaml
+++ b/corpus/regulation/nl/ministeriele_regeling/regeling_kwijtschelding_belastingen_medeoverheden/2022-09-17.yaml
@@ -1,0 +1,99 @@
+---
+$schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/heads/main/schema/v0.5.2/schema.json
+$id: regeling_kwijtschelding_belastingen_medeoverheden
+regulatory_layer: MINISTERIELE_REGELING
+publication_date: '2022-09-16'
+valid_from: '2022-09-17'
+bwb_id: BWBR0047157
+url: https://wetten.overheid.nl/BWBR0047157/2022-09-17
+name: Regeling kwijtschelding belastingen medeoverheden
+competent_authority:
+  name: Minister van Binnenlandse Zaken en Koninkrijksrelaties
+legal_basis:
+  - law_id: invorderingswet_1990
+    article: '26'
+articles:
+  - number: '1'
+    url: https://wetten.overheid.nl/BWBR0047157/2022-09-17#Artikel1
+    text: |
+      In deze regeling wordt verstaan onder:
+
+      - alleenstaande: alleenstaande als bedoeld in artikel 4, eerste lid, onderdeel a, van de Participatiewet;
+
+      - alleenstaande ouder: alleenstaande ouder als bedoeld in artikel 4, eerste lid, onderdeel b, van de Participatiewet;
+
+      - echtgenoot: echtgenoot als bedoeld in artikel 3 van de Participatiewet;
+
+      - pensioengerechtigde: persoon die de pensioengerechtigde leeftijd, bedoeld in artikel 7a van de Algemene Ouderdomswet,
+      heeft bereikt;
+
+      - Uitvoeringsregeling: Uitvoeringsregeling Invorderingswet 1990;
+
+      - verordening: verordening van provinciale staten van een provincie, de raad van een gemeente of het algemeen bestuur
+      van een waterschap.
+  - number: '2'
+    url: https://wetten.overheid.nl/BWBR0047157/2022-09-17#Artikel2
+    text: |
+      Bij verordening kan van de in artikel 16 van de Uitvoeringsregeling genoemde percentages worden afgeweken, mits:
+
+      a. de percentages ten minste 90 en ten hoogste 100 bedragen; en
+
+      b. het percentage voor alle belastingschuldigen, bedoeld in artikel 16 van de Uitvoeringsregeling, hetzelfde is.
+  - number: '3'
+    url: https://wetten.overheid.nl/BWBR0047157/2022-09-17#Artikel3
+    text: |
+      1. Onverminderd het bepaalde in artikel 2 kan bij verordening worden bepaald dat voor de vaststelling van de kosten van
+      bestaan van pensioengerechtigden in plaats van de bijstandsnorm het netto-ouderdomspensioen wordt gehanteerd.
+
+      2. Het hanteren van het netto-ouderdomspensioen, bedoeld in het eerste lid, geschiedt door:
+
+      a. voor de pensioengerechtigden, bedoeld in artikel 16, tweede lid, onderdeel a, van de Uitvoeringsregeling, in plaats
+      van de norm, genoemd in het toepasselijke artikelonderdeel, tweemaal het netto-ouderdomspensioen voor een gehuwde
+      pensioengerechtigde als bedoeld in artikel 9, eerste lid, onderdeel b, van de Algemene Ouderdomswet te hanteren;
+
+      b. voor de belastingschuldigen, bedoeld in artikel 16, tweede lid, onderdelen b en d, van de Uitvoeringsregeling, die
+      tevens pensioengerechtigd zijn, bij de berekening van de norm, genoemd in die artikelonderdelen, in plaats van factor
+      B, genoemd in artikel 22a, eerste lid, van de Participatiewet, tweemaal het netto-ouderdomspensioen voor een gehuwde
+      pensioengerechtigde als bedoeld in artikel 9, eerste lid, onderdeel b, van de Algemene Ouderdomswet te hanteren; en
+
+      c. voor de pensioengerechtigden, bedoeld in artikel 16, tweede lid, onderdeel c, van de Uitvoeringsregeling, in plaats
+      van de norm, genoemd in het betreffende artikelonderdeel, éénmaal het netto-ouderdomspensioen voor een ongehuwde
+      pensioengerechtigde als bedoeld in artikel 9, eerste lid, onderdeel a, van de Algemene Ouderdomswet te hanteren.
+
+      3. Het netto-ouderdomspensioen wordt berekend door het bruto-ouderdomspensioen, bedoeld in artikel 9, vijfde lid, van
+      de Algemene Ouderdomswet, te verminderen met:
+
+      a. de verschuldigde loonbelasting;
+
+      b. de premies voor de volksverzekeringen; en
+
+      c. de inkomensafhankelijke bijdrage, bedoeld in artikel 41 van de Zorgverzekeringswet.
+  - number: '4'
+    url: https://wetten.overheid.nl/BWBR0047157/2022-09-17#Artikel4
+    text: |
+      Bij verordening kan in afwijking van artikel 12, tweede lid, onderdeel d, van de Uitvoeringsregeling het totale bedrag
+      aan financiële middelen, bedoeld in dat onderdeel, worden verhoogd, mits:
+
+      a. de verhoging voor de belastingschuldige en zijn echtgenoot ten hoogste € 2.000 bedraagt;
+
+      b. de verhoging voor een alleenstaande 75 procent bedraagt van de verhoging, bedoeld in onderdeel a; en
+
+      c. de verhoging voor een alleenstaande ouder 90 procent bedraagt van de verhoging, bedoeld in onderdeel a.
+  - number: '5'
+    url: https://wetten.overheid.nl/BWBR0047157/2022-09-17#Artikel5
+    text: |
+      De Regeling van de Staatssecretaris van Binnenlandse Zaken en de Minister van Verkeer en Waterstaat van 2 mei 1996
+      houdende Nadere regels kwijtschelding gemeentelijke en waterschapsbelastingen (Stcrt. 1996, 98) wordt ingetrokken.
+  - number: '6'
+    url: https://wetten.overheid.nl/BWBR0047157/2022-09-17#Artikel6
+    text: |
+      1. Deze regeling treedt in werking met ingang van de dag na de datum van uitgifte van de Staatscourant waarin zij wordt
+      geplaatst en werkt terug tot en met 1 januari 2022.
+
+      2. Met ingang van 1 januari 2022 berusten verordeningen ter uitvoering van de artikelen 1 of 1a van de Regeling van de
+      Staatssecretaris van Binnenlandse Zaken en de Minister van Verkeer en Waterstaat van 2 mei 1996 houdende Nadere regels
+      kwijtschelding gemeentelijke en waterschapsbelastingen (Stcrt. 1996, 98) mede op de artikelen 2 of 3 van deze regeling.
+  - number: '7'
+    url: https://wetten.overheid.nl/BWBR0047157/2022-09-17#Artikel7
+    text: |
+      Deze regeling wordt aangehaald als: Regeling kwijtschelding belastingen medeoverheden.

--- a/corpus/regulation/nl/ministeriele_regeling/uitvoeringsregeling_invorderingswet_1990/2026-01-01.yaml
+++ b/corpus/regulation/nl/ministeriele_regeling/uitvoeringsregeling_invorderingswet_1990/2026-01-01.yaml
@@ -74,6 +74,11 @@ articles:
             type_spec:
               unit: eurocent
             required: true
+          - name: extra_uitgaven_maand
+            type: amount
+            type_spec:
+              unit: eurocent
+            required: false
           - name: aanslagbedrag
             type: amount
             type_spec:
@@ -94,6 +99,7 @@ articles:
                 netto_besteedbaar_inkomen_partner_maand: $netto_besteedbaar_inkomen_partner_maand
                 huishoudtype: $huishoudtype
                 is_pensioengerechtigd: $is_pensioengerechtigd
+                extra_uitgaven_maand: $extra_uitgaven_maand
         output:
           - name: aanwendbare_betalingscapaciteit
             type: amount
@@ -381,6 +387,15 @@ articles:
           - name: is_pensioengerechtigd
             type: boolean
             required: true
+          - name: extra_uitgaven_maand
+            type: amount
+            type_spec:
+              unit: eurocent
+            required: false
+            description: Aanvullende maandelijkse uitgaven die niet al zijn verwerkt in netto_besteedbaar_inkomen,
+              maar wel op grond van artikel 15 (eventueel via een verordening zoals artikel 3 van HHNK
+              Kwijtscheldingsregeling + artikel 28 lid 3 URI 1990 voor netto kinderopvangkosten) in aanmerking worden
+              genomen. Verlaagt betalingscapaciteit. Default 0.
         input:
           - name: kostennorm_bedrag
             type: amount
@@ -410,10 +425,13 @@ articles:
                     - 12
                     - operation: SUBTRACT
                       values:
-                        - operation: ADD
+                        - operation: SUBTRACT
                           values:
-                            - $netto_besteedbaar_inkomen_maand
-                            - $netto_besteedbaar_inkomen_partner_maand
+                            - operation: ADD
+                              values:
+                                - $netto_besteedbaar_inkomen_maand
+                                - $netto_besteedbaar_inkomen_partner_maand
+                            - $extra_uitgaven_maand
                         - $kostennorm_bedrag
   - number: '14'
     url: https://wetten.overheid.nl/BWBR0004766/2026-01-01#Artikel14

--- a/corpus/regulation/nl/ministeriele_regeling/uitvoeringsregeling_invorderingswet_1990/2026-01-01.yaml
+++ b/corpus/regulation/nl/ministeriele_regeling/uitvoeringsregeling_invorderingswet_1990/2026-01-01.yaml
@@ -1,0 +1,498 @@
+---
+$schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/heads/main/schema/v0.5.2/schema.json
+$id: uitvoeringsregeling_invorderingswet_1990
+regulatory_layer: MINISTERIELE_REGELING
+publication_date: '2025-07-11'
+valid_from: '2026-01-01'
+bwb_id: BWBR0004766
+url: https://wetten.overheid.nl/BWBR0004766/2026-01-01
+name: Uitvoeringsregeling Invorderingswet 1990
+competent_authority:
+  name: Minister van Financiën
+legal_basis:
+  - law_id: invorderingswet_1990
+    article: '26'
+articles:
+  - number: '10'
+    url: https://wetten.overheid.nl/BWBR0004766/2026-01-01#Artikel10
+    text: |
+      1. Deze afdeling heeft betrekking op kwijtschelding van inkomstenbelasting verschuldigd door natuurlijke personen die
+      geen bedrijf of niet zelfstandig een beroep uitoefenen, van loonbelasting verschuldigd door werknemers alsmede van door
+      natuurlijke personen verschuldigd successierecht, schenkingsrecht, recht van overgang en verschuldigde belastingen van
+      rechtsverkeer.
+
+      2. Deze afdeling heeft voorts, in afwijking in zoverre van artikel 20 betrekking op kwijtschelding van
+      inkomstenbelasting verschuldigd door natuurlijke personen die een uitkering genieten ingevolge de Wet
+      inkomensvoorziening kunstenaars.
+  - number: '11'
+    url: https://wetten.overheid.nl/BWBR0004766/2026-01-01#Artikel11
+    text: |
+      Kwijtschelding wordt verleend voor:
+
+      a. het gehele op de belastingaanslag openstaande bedrag indien geen vermogen en geen betalingscapaciteit aanwezig is;
+
+      b. het openstaande bedrag van de belastingaanslag dat resteert nadat:
+
+      1°. het aanwezige vermogen is aangewend ter voldoening van de belastingaanslag;
+
+      2°. ten minste 80 percent van de betalingscapaciteit is aangewend;
+
+      een en ander onverminderd het bepaalde in artikel 8, artikel 17 en artikel 18.
+    machine_readable:
+      execution:
+        produces:
+          legal_character: BESCHIKKING
+          decision_type: TOEKENNING
+        parameters:
+          - name: bsn
+            type: string
+            required: true
+          - name: waterschap_code
+            type: string
+            required: false
+          - name: gemeente_code
+            type: string
+            required: false
+          - name: netto_besteedbaar_inkomen_maand
+            type: amount
+            type_spec:
+              unit: eurocent
+            required: true
+          - name: netto_besteedbaar_inkomen_partner_maand
+            type: amount
+            type_spec:
+              unit: eurocent
+            required: false
+          - name: huishoudtype
+            type: string
+            required: true
+          - name: is_pensioengerechtigd
+            type: boolean
+            required: true
+          - name: vermogen
+            type: amount
+            type_spec:
+              unit: eurocent
+            required: true
+          - name: aanslagbedrag
+            type: amount
+            type_spec:
+              unit: eurocent
+            required: true
+        input:
+          - name: betalingscapaciteit
+            type: amount
+            type_spec:
+              unit: eurocent
+            source:
+              output: betalingscapaciteit
+              parameters:
+                bsn: $bsn
+                waterschap_code: $waterschap_code
+                gemeente_code: $gemeente_code
+                netto_besteedbaar_inkomen_maand: $netto_besteedbaar_inkomen_maand
+                netto_besteedbaar_inkomen_partner_maand: $netto_besteedbaar_inkomen_partner_maand
+                huishoudtype: $huishoudtype
+                is_pensioengerechtigd: $is_pensioengerechtigd
+        output:
+          - name: aanwendbare_betalingscapaciteit
+            type: amount
+            type_spec:
+              unit: eurocent
+          - name: hoogte_kwijtschelding
+            type: amount
+            type_spec:
+              unit: eurocent
+          - name: kan_kwijtschelding_worden_verleend
+            type: boolean
+        actions:
+          - output: aanwendbare_betalingscapaciteit
+            value:
+              operation: MULTIPLY
+              values:
+                - 0.8
+                - $betalingscapaciteit
+          - output: hoogte_kwijtschelding
+            value:
+              operation: MAX
+              values:
+                - 0
+                - operation: SUBTRACT
+                  values:
+                    - operation: SUBTRACT
+                      values:
+                        - $aanslagbedrag
+                        - $vermogen
+                    - $aanwendbare_betalingscapaciteit
+          - output: kan_kwijtschelding_worden_verleend
+            value:
+              operation: GREATER_THAN
+              subject: $hoogte_kwijtschelding
+              value: 0
+  - number: '12'
+    url: https://wetten.overheid.nl/BWBR0004766/2026-01-01#Artikel12
+    text: |
+      1. Onder vermogen als bedoeld in artikel 11 wordt verstaan de waarde in het economische verkeer van de bezittingen van
+      de belastingschuldige en van zijn echtgenoot, bedoeld in artikel 3 van de Algemene bijstandswet, verminderd met de
+      schulden van de belastingschuldige en deze persoon die hoger bevoorrecht zijn dan de rijksbelastingen.
+
+      2. Onder bezittingen wordt niet begrepen:
+
+      a. de inboedel voor zover de waarde hiervan niet meer bedraagt dan € 2269;
+
+      b. rechten op kapitaalsuitkeringen of prestaties uit levensverzekering, uitsluitend bestaande uit een kapitaaluitkering
+      bij overlijden van de belastingschuldige of zijn echtgenoot, mits deze kapitaaluitkering is bestemd voor de verzorging
+      van de uitvaart van de belastingschuldige of zijn echtgenoot, dan wel op prestaties in natura ter zake van de
+      verzorging van een uitvaart van de belastingschuldige of zijn echtgenoot;
+
+      c. een auto die op het moment van het verzoek een waarde heeft van € 2269 of minder; een auto met een waarde van meer
+      dan € 2269 wordt niet als vermogen beschouwd indien jegens de ontvanger aannemelijk kan worden gemaakt dat die auto
+      absoluut onmisbaar is voor de uitoefening van een beroep dan wel absoluut onmisbaar is in verband met invaliditeit;
+
+      d. het totale bedrag aan financiële middelen, andere dan de onder f bedoelde, voor zover dat bedrag de ingevolge
+      artikel 16 in aanmerking te nemen kosten van bestaan vermeerderd met een bedrag ter grootte van het per maand
+      gemiddelde bedrag van de uitgaven bedoeld in artikel 15, onderdelen b en c, niet te boven gaat;
+
+      e. het bedrag op een bank- of girorekening dat in het kader van de Wet studiefinanciering 2000 of de Wet tegemoetkoming
+      studiekosten is verkregen in de vorm van leningen of dat is verkregen in het kader van een regeling voor
+      persoonsgebonden budget, welke regeling is gegrond op artikel 1p, eerste lid, onderdeel d, van de Ziekenfondswet;
+
+      f. een bedrag van € 2269 aan financiële middelen per persoon voor personen die op 31 december 1999 de leeftijd van 65
+      jaar hebben bereikt.
+
+      3. Onder waarde, bedoeld in het tweede lid, onderdeel c, wordt verstaan de prijs die de autohandel bereid is te betalen
+      bij inkoop zonder gelijktijdige verkoop van een andere auto.
+
+      4. Indien de uitgaven, bedoeld in artikel 15, onderdelen b en c, verschuldigd zijn over een termijn van langer dan een
+      maand wordt in plaats van het per maand gemiddelde bedrag in aanmerking genomen het deel van het termijnbedrag voor
+      zover dat, gelet op de vervaldatum van de termijnbetaling, op het moment van het verzoek om kwijtschelding
+      redelijkerwijs kan worden aangemerkt als reservering voor die termijnbetaling.
+  - number: '13'
+    url: https://wetten.overheid.nl/BWBR0004766/2026-01-01#Artikel13
+    text: |
+      1. Onder betalingscapaciteit, bedoeld in artikel 11, wordt verstaan het positieve verschil in de periode van 12 maanden
+      vanaf de datum waarop het verzoek om kwijtschelding is ingediend van het gemiddeld per maand te verwachten
+      netto-besteedbare inkomen van de belastingschuldige in die periode en de gemiddeld per maand te verwachten kosten van
+      bestaan in die periode.
+
+      2. Het netto-besteedbare inkomen van de belastingschuldige, bedoeld in het eerste lid, wordt vermeerderd met het
+      gemiddeld per maand te verwachten netto-besteedbare inkomen in de periode van twaalf maanden vanaf de datum waarop het
+      verzoek om kwijtschelding is ingediend van zijn echtgenoot, bedoeld in artikel 3 van de Algemene bijstandswet.
+    machine_readable:
+      execution:
+        parameters:
+          - name: bsn
+            type: string
+            required: true
+          - name: waterschap_code
+            type: string
+            required: false
+          - name: gemeente_code
+            type: string
+            required: false
+          - name: netto_besteedbaar_inkomen_maand
+            type: amount
+            type_spec:
+              unit: eurocent
+            required: true
+          - name: netto_besteedbaar_inkomen_partner_maand
+            type: amount
+            type_spec:
+              unit: eurocent
+            required: false
+          - name: huishoudtype
+            type: string
+            required: true
+          - name: is_pensioengerechtigd
+            type: boolean
+            required: true
+        input:
+          - name: kostennorm_bedrag
+            type: amount
+            type_spec:
+              unit: eurocent
+            source:
+              output: kostennorm_bedrag
+              parameters:
+                bsn: $bsn
+                waterschap_code: $waterschap_code
+                gemeente_code: $gemeente_code
+                huishoudtype: $huishoudtype
+                is_pensioengerechtigd: $is_pensioengerechtigd
+        output:
+          - name: betalingscapaciteit
+            type: amount
+            type_spec:
+              unit: eurocent
+        actions:
+          - output: betalingscapaciteit
+            value:
+              operation: MAX
+              values:
+                - 0
+                - operation: MULTIPLY
+                  values:
+                    - 12
+                    - operation: SUBTRACT
+                      values:
+                        - operation: ADD
+                          values:
+                            - $netto_besteedbaar_inkomen_maand
+                            - $netto_besteedbaar_inkomen_partner_maand
+                        - $kostennorm_bedrag
+  - number: '14'
+    url: https://wetten.overheid.nl/BWBR0004766/2026-01-01#Artikel14
+    text: |
+      1. Onder het netto-besteedbare inkomen, bedoeld in artikel 13, wordt verstaan het met de in artikel 15 vermelde
+      uitgaven verminderde gezamenlijke bedrag van:
+
+      a. de aan inhouding van loonbelasting/premie voor de volksverzekeringen onderworpen inkomsten verminderd met de
+      wettelijke inhoudingen en de ingehouden pensioenpremies en premies ziektekostenverzekering;
+
+      b. uitkeringen voor levensonderhoud ingevolge de artikelen 157, 158 of 404 van Boek 1 van het Burgerlijk Wetboek;
+
+      c. overige inkomsten met uitzondering van de uitkeringen ingevolge de Algemene Kinderbijslagwet, de artikelen 229d,
+      tweede lid, en 255a van de Gemeentewet en een regeling voor persoonsgebonden budget, welke regeling is gegrond op
+      artikel 1p, eerste lid, onderdeel d, van de Ziekenfondswet, alsmede inkomsten als bedoeld in artikel 43, tweede lid,
+      onderdelen i, j, m en n, van de Algemene bijstandswet en, tot ten hoogste het bedrag genoemd in artikel 43, tweede lid,
+      onderdeel p, van de Algemene bijstandswet, de subsidies, bedoeld in artikel 3, eerste lid, van de Wet inschakeling
+      werkzoekenden, voorzover deze subsidies niet kunnen worden aangemerkt als premies als bedoeld in artikel 43, tweede
+      lid, onderdelen i en j, van de Algemene bijstandswet.
+
+      2. Tot de inkomsten, bedoeld in het eerste lid, onderdeel c, wordt ook gerekend de voorlopige teruggaaf, bedoeld in
+      artikel 13, tweede lid, van de Algemene wet inzake rijksbelastingen, daaronder begrepen de aanspraak op een zodanige
+      teruggaaf, met uitzondering van de daarin begrepen kinderkorting, aanvullende kinderkorting of toetrederskorting,
+      bedoeld in hoofdstuk 8 van de Wet inkomstenbelasting 2001.
+
+      3. Indien bij de vaststelling van de voorlopige teruggaaf rekening is gehouden met kinderkorting, aanvullende
+      kinderkorting of toetrederskorting wordt voor de toepassing van het tweede lid het bedrag van de voorlopige teruggaaf
+      zoveel mogelijk geacht betrekking te hebben op die kortingen.
+
+      4. Voor de belastingschuldige, bedoeld in artikel 10, tweede lid, die in het kalenderjaar voorafgaande aan het verzoek
+      om kwijtschelding een uitkering heeft genoten ingevolge de Wet inkomensvoorziening kunstenaars worden tot de inkomsten,
+      bedoeld in het eerste lid, onderdeel c, ook gerekend de inkomsten uit de beroepsuitoefening. Deze inkomsten worden in
+      aanmerking genomen voor het bedrag dat blijkt uit de opgave van de in het kalenderjaar genoten inkomsten die de
+      belastingschuldige aan het college van burgemeester en wethouders moet verstrekken ten behoeve van de definitieve
+      vaststelling van de hoogte van de uitkering, bedoeld in artikel 10 van de Wet inkomensvoorziening kunstenaars.
+
+      5. Voor de belastingschuldige, bedoeld in artikel 10, tweede lid, die in het kalenderjaar voorafgaande aan het verzoek
+      om kwijtschelding geen uitkering heeft genoten ingevolge de Wet inkomensvoorziening kunstenaars worden de inkomsten,
+      bedoeld in het eerste lid, gesteld op de op hem van toepassing zijnde bijstandsnorm ingevolge hoofdstuk IV, afdeling 1,
+      van de Algemene bijstandswet.
+  - number: '15'
+    url: https://wetten.overheid.nl/BWBR0004766/2026-01-01#Artikel15
+    text: |
+      Als uitgaven als bedoeld in artikel 14, eerste lid, worden in aanmerking genomen:
+
+      a. betalingen op belastingschulden, met uitzondering van die genoemd in artikel 8, tweede lid;
+
+      b. het bedrag van de voor rekening van de belastingschuldige komende netto-woonlasten tot maximaal het bedrag, genoemd
+      in artikel 13, eerste lid, onderdeel a, van de Huursubsidiewet, voorzover dit meer is dan het bedrag, genoemd in
+      artikel 17, tweede lid, van die wet. Onder netto-woonlasten wordt verstaan: de op de belastingschuldige drukkende
+      huurprijs, bedoeld in artikel 5, eerste lid, van genoemde wet, dan wel hypotheekrente en erfpachtcanon ter zake van een
+      door hem bewoonde woning voorzover deze hem voor gebruik ter beschikking staat, verminderd met de ontvangen
+      huursubsidie en bijzondere bijdrage in de huurlasten op grond van artikel 26b van genoemde wet of met de ontvangen
+      woonkostentoeslag, andere dan die in de vorm van de verhogingen, genoemd in artikel 21, eerste lid, onderdeel d, van
+      genoemde wet, onderscheidenlijk een daarmee overeenkomende verhoging ingevolge hoofdstuk IV, afdeling 2, van de
+      Algemene bijstandswet;
+
+      c. de niet door de werkgever ingehouden premies ziektekostenverzekering en de nominale premies ingevolge de
+      Ziekenfondswet en de Algemene Wet Bijzondere Ziektekosten;
+
+      d. betaalde uitkeringen voor levensonderhoud ingevolge de artikelen 157, 158 of 404 van Boek 1 van het Burgerlijk
+      Wetboek;
+
+      e. aflossingen op leningen voor zover die zijn aangewend voor de betaling van belastingschulden, met uitzondering van
+      die genoemd in artikel 8, tweede lid;
+
+      f. de met het houden van kostgangers verbonden kosten tot het totaal van:
+
+      - het bedrag, genoemd in artikel 32, eerste lid, van de Uitvoeringsregeling loonbelasting 2001, voor een ontbijt en
+      voor een warme maaltijd, en
+
+      - het bedrag per dag, genoemd in artikel 34, eerste lid, onderdelen a, b, d en e, van de Uitvoeringsregeling
+      loonbelasting 2001,
+
+      doch ten hoogste de met het houden van kostgangers genoten inkomsten. Bij de bepaling van het aantal dagen wordt een
+      volle maand op 30 dagen gesteld.
+  - number: '16'
+    url: https://wetten.overheid.nl/BWBR0004766/2026-01-01#Artikel16
+    text: |
+      1. De kosten van bestaan, bedoeld in artikel 13, eerste lid, bedragen voor belastingschuldigen die worden aangemerkt
+      als:
+
+      a. echtgenoten als bedoeld in artikel 3 van de Algemene bijstandswet: 90 percent van het gezamenlijke bedrag, bedoeld
+      in artikel 14, eerste lid, doch ten minste 90 percent van de bijstandsnorm, genoemd in artikel 30, eerste lid,
+      onderdeel c, van de Algemene bijstandswet nadat deze is verminderd met het bedrag, genoemd in artikel 33, tweede lid,
+      van die wet, en ten hoogste 90 percent van de bijstandsnorm, genoemd in artikel 30, eerste lid, onderdeel c, van die
+      wet;
+
+      b. een alleenstaande en een alleenstaande ouder als bedoeld in artikel 4, onderdeel a, onderscheidenlijk onderdeel b,
+      van de Algemene bijstandswet: 90 percent van het gezamenlijke bedrag, bedoeld in artikel 14, eerste lid, doch ten
+      minste 90 percent van de bijstandsnorm, genoemd in artikel 30, eerste lid, onderdeel a, onderscheidenlijk onderdeel b,
+      van de Algemene bijstandswet, en ten hoogste 90 percent van die bijstandsnorm nadat deze is verhoogd met het bedrag,
+      genoemd in artikel 33, tweede lid, van die wet.
+
+      2. De kosten van bestaan, bedoeld in artikel 13, eerste lid, bedragen, in afwijking van het eerste lid, voor
+      belastingschuldigen die worden aangemerkt als:
+
+      a. echtgenoten als bedoeld in artikel 3 van de Algemene bijstandswet die 65 jaar of ouder zijn, onderscheidenlijk
+      waarvan een echtgenoot 65 jaar of ouder is: 90 percent van de bijstandsnorm, genoemd in artikel 30, tweede lid,
+      onderdeel c, onderscheidenlijk onderdeel d, van de Algemene bijstandswet;
+
+      b. een alleenstaande en een alleenstaande ouder als bedoeld in artikel 4, onderdeel a, onderscheidenlijk onderdeel b,
+      van de Algemene bijstandswet die 65 jaar of ouder zijn: 90 percent van de bijstandsnorm, genoemd in artikel 30, tweede
+      lid, onderdeel a, onderscheidenlijk onderdeel b, van de Algemene bijstandswet.
+
+      3. De kosten van bestaan, bedoeld in artikel 13, eerste lid, bedragen, in afwijking van de vorige leden, voor de
+      belastingschuldige die ter verzorging of verpleging in een daartoe bestemde inrichting is opgenomen: de prijs die is
+      verschuldigd voor verzorging dan wel verpleging, verhoogd met twee derden van de op hem van toepassing zijnde
+      bijstandsnorm, genoemd in artikel 31 van de Algemene bijstandswet.
+    machine_readable:
+      definitions:
+        bijstandsnorm_alleenstaand:
+          value: 140150
+        bijstandsnorm_alleenstaande_ouder:
+          value: 140150
+        bijstandsnorm_echtgenoten:
+          value: 200213
+        bijstandsnorm_aow_alleenstaand:
+          value: 156469
+        bijstandsnorm_aow_echtgenoten:
+          value: 214416
+      open_terms:
+        - id: kostennorm_percentage
+          description: Percentage van de bijstandsnorm dat als kosten van bestaan geldt. Bij ministeriele regeling (Regeling
+            kwijtschelding belastingen medeoverheden, artikel 2) kan een verordening van een medeoverheid dit verhogen tot
+            maximaal 100 procent.
+          type: number
+          required: false
+          delegated_to: provincie, gemeente of waterschap
+          delegation_type: WATERSCHAPS_VERORDENING
+          legal_basis: artikel 2 Regeling kwijtschelding belastingen medeoverheden
+          default:
+            actions:
+              - output: kostennorm_percentage
+                value: 0.9
+      execution:
+        parameters:
+          - name: bsn
+            type: string
+            required: true
+          - name: waterschap_code
+            type: string
+            required: false
+          - name: gemeente_code
+            type: string
+            required: false
+          - name: huishoudtype
+            type: string
+            required: true
+          - name: is_pensioengerechtigd
+            type: boolean
+            required: true
+        output:
+          - name: kostennorm_bedrag
+            type: amount
+            type_spec:
+              unit: eurocent
+        actions:
+          - output: kostennorm_bedrag
+            value:
+              operation: MULTIPLY
+              values:
+                - $kostennorm_percentage
+                - operation: IF
+                  cases:
+                    - when:
+                        operation: EQUALS
+                        subject: $is_pensioengerechtigd
+                        value: true
+                      then:
+                        operation: IF
+                        cases:
+                          - when:
+                              operation: EQUALS
+                              subject: $huishoudtype
+                              value: echtgenoten
+                            then: $bijstandsnorm_aow_echtgenoten
+                        default: $bijstandsnorm_aow_alleenstaand
+                  default:
+                    operation: IF
+                    cases:
+                      - when:
+                          operation: EQUALS
+                          subject: $huishoudtype
+                          value: echtgenoten
+                        then: $bijstandsnorm_echtgenoten
+                      - when:
+                          operation: EQUALS
+                          subject: $huishoudtype
+                          value: alleenstaande_ouder
+                        then: $bijstandsnorm_alleenstaande_ouder
+                    default: $bijstandsnorm_alleenstaand
+  - number: '17'
+    url: https://wetten.overheid.nl/BWBR0004766/2026-01-01#Artikel17
+    text: |
+      Indien geen betalingscapaciteit aanwezig is of wel betalingscapaciteit aanwezig is doch die betalingscapaciteit niet
+      voldoende is om de belastingaanslagen waarvoor kwijtschelding is verzocht te voldoen, wordt ingeval sprake is van
+      aflossingen op schulden, andere dan die waarmee bij de berekening van de betalingscapaciteit rekening is gehouden en
+      die aflossingen meer dan € 136 per maand bedragen, slechts in zeer bijzondere omstandigheden kwijtschelding verleend.
+  - number: '27'
+    url: https://wetten.overheid.nl/BWBR0004766/2026-01-01#Artikel27
+    text: |
+      Deze afdeling heeft betrekking op:
+
+      a. provinciale belastingen als bedoeld in hoofdstuk XV, paragraaf 2, van de Provinciewet alsmede belastingen waarvan de
+      heffing krachtens andere wetten door de provincie geschiedt;
+
+      b. gemeentelijke belastingen als bedoeld in hoofdstuk XV, paragraaf 2 en 3, van de Gemeentewet alsmede belastingen
+      waarvan de heffing krachtens andere wetten door de gemeente geschiedt;
+
+      c. waterschapsbelastingen als bedoeld in hoofdstuk XVI van de Waterschapswet alsmede belastingen waarvan de heffing
+      krachtens bijzondere wetten door het waterschap geschiedt;
+
+      d. de beveiligingsheffing ingevolge artikel 37j van de Luchtvaartwet;
+
+      e. de geluidsheffing burgerluchtvaart ingevolge artikel 77 van de Luchtvaartwet;
+
+      f. de heffingen ingevolge hoofdstuk IV van de Meststoffenwet;
+
+      g. de heffing ingevolge artikel 91a van de Gezondheids- en welzijnswet voor dieren, alsmede bij algemene maatregel van
+      bestuur ingevolge artikel 91h of artikel 92 van die wet ingevoerde heffingen;
+
+      h. de verontreinigingsheffing rijkswateren ingevolge artikel 23 van de Wet verontreiniging oppervlaktewateren.
+  - number: '28'
+    url: https://wetten.overheid.nl/BWBR0004766/2026-01-01#Artikel28
+    text: |
+      1. Met betrekking tot een verzoek om kwijtschelding van de in artikel 27 genoemde belastingen en heffingen verschuldigd
+      door:
+
+      a. een natuurlijk persoon die geen bedrijf of niet zelfstandig een beroep uitoefent, zijn de afdelingen 1, 2 en 5 van
+      overeenkomstige toepassing;
+
+      b. een natuurlijk persoon die een bedrijf of zelfstandig een beroep uitoefent, zijn de afdelingen 1, 3, 4 en 5 van
+      overeenkomstige toepassing;
+
+      c. een rechtspersoon zijn de afdelingen 1, 3 en 5 van overeenkomstige toepassing;
+
+      d. een natuurlijk persoon die een uitkering geniet ingevolge de Wet inkomensvoorziening kunstenaars zijn de artikelen
+      10, tweede lid, en 14, vierde en vijfde lid, van overeenkomstige toepassing.
+
+      2. Waar in artikel 9, tweede lid, en in afdeling 5 sprake is van directeur wordt voor:
+
+      a. provinciale belastingen gelezen: gedeputeerde staten;
+
+      b. gemeentelijke belastingen gelezen: het college van burgemeester en wethouders;
+
+      c. waterschapsbelastingen gelezen: het dagelijks bestuur;
+
+      d. de beveiligingsheffing gelezen: het hoofd van de Directie Politie van het Ministerie van Justitie;
+
+      e. de geluidsheffing burgerluchtvaart gelezen: de directeur-hoofdinspecteur van de divisie Luchtvaart van de Inspectie
+      Verkeer en Waterstaat;
+
+      f. de heffingen ingevolge hoofdstuk IV van de Meststoffenwet, de heffing ingevolge artikel 91a van de Gezondheids- en
+      welzijnswet voor dieren, alsmede bij algemene maatregel van bestuur ingevolge artikel 91h of artikel 92 van die wet
+      ingevoerde heffingen gelezen: de directeur Financiële en Economische Zaken van het Ministerie van Landbouw,
+      Natuurbeheer en Visserij.

--- a/corpus/regulation/nl/ministeriele_regeling/uitvoeringsregeling_invorderingswet_1990/2026-01-01.yaml
+++ b/corpus/regulation/nl/ministeriele_regeling/uitvoeringsregeling_invorderingswet_1990/2026-01-01.yaml
@@ -1,5 +1,5 @@
 ---
-$schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/heads/main/schema/v0.5.2/schema.json
+$schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/tags/schema-v0.5.2/schema/v0.5.2/schema.json
 $id: uitvoeringsregeling_invorderingswet_1990
 regulatory_layer: MINISTERIELE_REGELING
 publication_date: '2025-07-11'
@@ -62,7 +62,7 @@ articles:
             type: amount
             type_spec:
               unit: eurocent
-            required: false
+            required: true
           - name: huishoudtype
             type: string
             required: true
@@ -199,7 +199,7 @@ articles:
             type: amount
             type_spec:
               unit: eurocent
-            required: false
+            required: true
           - name: huishoudtype
             type: string
             required: true
@@ -351,14 +351,30 @@ articles:
     machine_readable:
       definitions:
         bijstandsnorm_alleenstaand:
+          description: Bijstandsnorm (eurocent per maand) voor een alleenstaande van 21 jaar of ouder en jonger dan de
+            pensioengerechtigde leeftijd, artikel 21 onderdeel a Participatiewet. Bedrag per 1 januari 2026 inclusief 5%
+            vakantie-uitkering.
           value: 140150
         bijstandsnorm_alleenstaande_ouder:
+          description: Bijstandsnorm (eurocent per maand) voor een alleenstaande ouder. Sinds de Participatiewet-
+            hervorming per 1 januari 2015 is de afzonderlijke alleenstaande-ouder-norm afgeschaft; de aanvullende
+            bijstand voor alleenstaande ouders is vervangen door het kindgebonden budget. De norm is daarom gelijk aan
+            die van de alleenstaande (artikel 21 onderdeel a Participatiewet). Bedrag per 1 januari 2026 inclusief 5%
+            vakantie-uitkering.
           value: 140150
         bijstandsnorm_echtgenoten:
+          description: Bijstandsnorm (eurocent per maand) voor gehuwden/samenwonenden waarvan beide echtgenoten 21 jaar of
+            ouder zijn en jonger dan de pensioengerechtigde leeftijd, artikel 21 onderdeel b Participatiewet. Bedrag per
+            1 januari 2026 inclusief 5% vakantie-uitkering.
           value: 200213
         bijstandsnorm_aow_alleenstaand:
+          description: Bijstandsnorm (eurocent per maand) voor een alleenstaande die de pensioengerechtigde leeftijd heeft
+            bereikt, artikel 22 onderdeel a Participatiewet. Bedrag per 1 januari 2026 inclusief 5% vakantie-uitkering.
           value: 156469
         bijstandsnorm_aow_echtgenoten:
+          description: Bijstandsnorm (eurocent per maand) voor gehuwden/samenwonenden waarvan ten minste een echtgenoot de
+            pensioengerechtigde leeftijd heeft bereikt, artikel 22 onderdeel b Participatiewet. Bedrag per 1 januari 2026
+            inclusief 5% vakantie-uitkering.
           value: 214416
       open_terms:
         - id: kostennorm_percentage

--- a/corpus/regulation/nl/ministeriele_regeling/uitvoeringsregeling_invorderingswet_1990/2026-01-01.yaml
+++ b/corpus/regulation/nl/ministeriele_regeling/uitvoeringsregeling_invorderingswet_1990/2026-01-01.yaml
@@ -167,6 +167,181 @@ articles:
       maand wordt in plaats van het per maand gemiddelde bedrag in aanmerking genomen het deel van het termijnbedrag voor
       zover dat, gelet op de vervaldatum van de termijnbetaling, op het moment van het verzoek om kwijtschelding
       redelijkerwijs kan worden aangemerkt als reservering voor die termijnbetaling.
+    machine_readable:
+      definitions:
+        drempelwaarde_inboedel_auto:
+          description: Drempelwaarde (eurocent) waarboven de inboedel of een auto als vermogen wordt beschouwd,
+            artikel 12 tweede lid onderdelen a en c. Origineel vastgesteld op f 5000 (1990) en nooit geindexeerd;
+            actuele waarde 226900 eurocent (= EUR 2269).
+          value: 226900
+      open_terms:
+        - id: verhoging_financiele_middelen_vrijstelling
+          description: Verhoging (eurocent) van de vrijstelling voor financiele middelen bovenop kostennorm en
+            gemiddelde maand-uitgaven. Per artikel 4 Regeling kwijtschelding belastingen medeoverheden mag een
+            verordening deze verhogen; HHNK art 4 stelt deze op 200000 (echtgenoten), 180000 (alleenstaande ouder)
+            en 150000 (alleenstaande) eurocent.
+          type: amount
+          required: false
+          delegated_to: provincie, gemeente of waterschap
+          delegation_type: WATERSCHAPS_VERORDENING
+          legal_basis: artikel 4 Regeling kwijtschelding belastingen medeoverheden
+          default:
+            actions:
+              - output: verhoging_financiele_middelen_vrijstelling
+                value: 0
+      execution:
+        parameters:
+          - name: bsn
+            type: string
+            required: true
+          - name: waterschap_code
+            type: string
+            required: false
+          - name: gemeente_code
+            type: string
+            required: false
+          - name: huishoudtype
+            type: string
+            required: true
+          - name: is_pensioengerechtigd
+            type: boolean
+            required: true
+          - name: inboedel_waarde
+            type: amount
+            type_spec:
+              unit: eurocent
+            required: true
+          - name: auto_waarde
+            type: amount
+            type_spec:
+              unit: eurocent
+            required: true
+          - name: auto_onmisbaar
+            type: boolean
+            required: true
+          - name: onroerend_goed_waarde
+            type: amount
+            type_spec:
+              unit: eurocent
+            required: true
+          - name: andere_bezittingen
+            type: amount
+            type_spec:
+              unit: eurocent
+            required: true
+          - name: hoger_bevoorrechte_schulden
+            type: amount
+            type_spec:
+              unit: eurocent
+            required: true
+          - name: liquide_middelen
+            type: amount
+            type_spec:
+              unit: eurocent
+            required: true
+        input:
+          - name: kostennorm_bedrag
+            type: amount
+            type_spec:
+              unit: eurocent
+            source:
+              output: kostennorm_bedrag
+              parameters:
+                bsn: $bsn
+                waterschap_code: $waterschap_code
+                gemeente_code: $gemeente_code
+                huishoudtype: $huishoudtype
+                is_pensioengerechtigd: $is_pensioengerechtigd
+        output:
+          - name: inboedel_als_vermogen
+            type: amount
+            type_spec:
+              unit: eurocent
+          - name: auto_als_vermogen
+            type: amount
+            type_spec:
+              unit: eurocent
+          - name: financiele_middelen_vrijstelling
+            type: amount
+            type_spec:
+              unit: eurocent
+          - name: liquide_als_vermogen
+            type: amount
+            type_spec:
+              unit: eurocent
+          - name: totaal_bezittingen
+            type: amount
+            type_spec:
+              unit: eurocent
+          - name: vermogen_bedrag
+            type: amount
+            type_spec:
+              unit: eurocent
+        actions:
+          - output: inboedel_als_vermogen
+            value:
+              operation: IF
+              cases:
+                - when:
+                    operation: GREATER_THAN
+                    subject: $inboedel_waarde
+                    value: $drempelwaarde_inboedel_auto
+                  then: $inboedel_waarde
+              default: 0
+          - output: auto_als_vermogen
+            value:
+              operation: IF
+              cases:
+                - when:
+                    operation: AND
+                    conditions:
+                      - operation: GREATER_THAN
+                        subject: $auto_waarde
+                        value: $drempelwaarde_inboedel_auto
+                      - operation: EQUALS
+                        subject: $auto_onmisbaar
+                        value: false
+                  then: $auto_waarde
+              default: 0
+          - output: financiele_middelen_vrijstelling
+            value:
+              operation: ADD
+              values:
+                - $kostennorm_bedrag
+                - $verhoging_financiele_middelen_vrijstelling
+          - output: liquide_als_vermogen
+            value:
+              operation: MAX
+              values:
+                - 0
+                - operation: SUBTRACT
+                  values:
+                    - $liquide_middelen
+                    - $financiele_middelen_vrijstelling
+          - output: totaal_bezittingen
+            value:
+              operation: ADD
+              values:
+                - $inboedel_als_vermogen
+                - operation: ADD
+                  values:
+                    - $auto_als_vermogen
+                    - operation: ADD
+                      values:
+                        - $onroerend_goed_waarde
+                        - operation: ADD
+                          values:
+                            - $liquide_als_vermogen
+                            - $andere_bezittingen
+          - output: vermogen_bedrag
+            value:
+              operation: MAX
+              values:
+                - 0
+                - operation: SUBTRACT
+                  values:
+                    - $totaal_bezittingen
+                    - $hoger_bevoorrechte_schulden
   - number: '13'
     url: https://wetten.overheid.nl/BWBR0004766/2026-01-01#Artikel13
     text: |

--- a/corpus/regulation/nl/ministeriele_regeling/uitvoeringsregeling_invorderingswet_1990/2026-01-01.yaml
+++ b/corpus/regulation/nl/ministeriele_regeling/uitvoeringsregeling_invorderingswet_1990/2026-01-01.yaml
@@ -376,6 +376,19 @@ articles:
             pensioengerechtigde leeftijd heeft bereikt, artikel 22 onderdeel b Participatiewet. Bedrag per 1 januari 2026
             inclusief 5% vakantie-uitkering.
           value: 214416
+        netto_ouderdomspensioen_alleenstaand:
+          description: Netto-ouderdomspensioen (eurocent per maand) voor een ongehuwde pensioengerechtigde, artikel 9 lid 1
+            onderdeel a Algemene Ouderdomswet, na aftrek loonbelasting + premies volksverzekeringen + inkomensafhankelijke
+            bijdrage Zvw (artikel 41 Zvw). Conform artikel 3 lid 3 Regeling kwijtschelding belastingen medeoverheden.
+            Bruto-bedrag 2026 per SVB-publicatie Staatscourant 2025 inclusief 5% vakantie-uitkering; netto-omrekening op
+            basis van tarieven eerste schijf loonbelasting 2026.
+          value: 155815
+        netto_ouderdomspensioen_echtgenoten:
+          description: Netto-ouderdomspensioen (eurocent per maand, gezamenlijk) voor twee gehuwde pensioengerechtigden
+            (tweemaal het netto-AOW-bedrag voor een gehuwde pensioengerechtigde per artikel 9 lid 1 onderdeel b AOW).
+            Conform artikel 3 lid 2 onderdeel a Regeling kwijtschelding belastingen medeoverheden. Bedrag per 1 januari 2026
+            per SVB-publicatie inclusief 5% vakantie-uitkering.
+          value: 213540
       open_terms:
         - id: kostennorm_percentage
           description: Percentage van de bijstandsnorm dat als kosten van bestaan geldt. Bij ministeriele regeling (Regeling
@@ -431,8 +444,8 @@ articles:
                               operation: EQUALS
                               subject: $huishoudtype
                               value: echtgenoten
-                            then: $bijstandsnorm_aow_echtgenoten
-                        default: $bijstandsnorm_aow_alleenstaand
+                            then: $netto_ouderdomspensioen_echtgenoten
+                        default: $netto_ouderdomspensioen_alleenstaand
                   default:
                     operation: IF
                     cases:

--- a/corpus/regulation/nl/waterschaps_verordening/hhnk/kwijtscheldingsregeling_waterschapsbelastingen/2023-01-01.yaml
+++ b/corpus/regulation/nl/waterschaps_verordening/hhnk/kwijtscheldingsregeling_waterschapsbelastingen/2023-01-01.yaml
@@ -109,6 +109,14 @@ articles:
             type_spec:
               unit: eurocent
             required: true
+          - name: kinderopvang_nettokosten_maand
+            type: amount
+            type_spec:
+              unit: eurocent
+            required: false
+            description: Nettokosten van kinderopvang per maand. Per HHNK art 3 jo URI art 28 lid 3 worden
+              deze als uitgaven meegenomen in de berekening van netto-besteedbaar inkomen (artikel 14-15 URI).
+              Verlaagt de betalingscapaciteit. Default 0.
           - name: is_ondernemer
             type: boolean
             required: true
@@ -155,6 +163,7 @@ articles:
                 huishoudtype: $huishoudtype
                 is_pensioengerechtigd: $is_pensioengerechtigd
                 vermogen: $vermogen_bedrag
+                extra_uitgaven_maand: $kinderopvang_nettokosten_maand
                 aanslagbedrag: $aanslagbedrag
           - name: hoogte_kwijtschelding_uri
             type: amount
@@ -171,6 +180,7 @@ articles:
                 huishoudtype: $huishoudtype
                 is_pensioengerechtigd: $is_pensioengerechtigd
                 vermogen: $vermogen_bedrag
+                extra_uitgaven_maand: $kinderopvang_nettokosten_maand
                 aanslagbedrag: $aanslagbedrag
         output:
           - name: belastingsoort_in_scope
@@ -251,6 +261,20 @@ articles:
       28, lid 3, van de Uitvoeringsregeling Invorderingswet 1990 als uitgaven mede in aanmerking genomen de nettokosten van
       kinderopvang.
     url: https://lokaleregelgeving.overheid.nl/CVDR686061/1#artikel_3
+    machine_readable:
+      execution:
+        output:
+          - name: kinderopvang_in_aanmerking
+            type: boolean
+            description: |
+              Documenteert dat HHNK artikel 28 lid 3 URI 1990 activeert voor deze kwijtscheldingsregeling:
+              nettokosten kinderopvang zijn uitgaven in de zin van artikel 15 URI en verlagen dus het
+              netto-besteedbaar inkomen (artikel 14 URI). Operationeel verwerkt via de parameter
+              'kinderopvang_nettokosten_maand' op HHNK art 1, die als extra_uitgaven_maand wordt doorgegeven
+              aan URI art 13.
+        actions:
+          - output: kinderopvang_in_aanmerking
+            value: true
 
   - number: '4'
     text: |-

--- a/corpus/regulation/nl/waterschaps_verordening/hhnk/kwijtscheldingsregeling_waterschapsbelastingen/2023-01-01.yaml
+++ b/corpus/regulation/nl/waterschaps_verordening/hhnk/kwijtscheldingsregeling_waterschapsbelastingen/2023-01-01.yaml
@@ -32,6 +32,138 @@ articles:
       degene die krachtens eigendom, bezit of beperkt recht het genot heeft van een gebouwde onroerende zaak die geheel of
       gedeeltelijk bij hem in gebruik is als woonruimte;
     url: https://lokaleregelgeving.overheid.nl/CVDR686061/1#artikel_1
+    machine_readable:
+      definitions:
+        belastingsoorten_in_scope:
+          value:
+            - watersysteemheffing_ingezetenen
+            - watersysteemheffing_gebouwd_woonruimte
+            - zuiveringsheffing_woonruimte
+            - verontreinigingsheffing_woonruimte
+            - wegenheffing_ingezetenen
+            - wegenheffing_gebouwd_woonruimte
+      execution:
+        produces:
+          legal_character: BESCHIKKING
+          decision_type: TOEKENNING
+        parameters:
+          - name: bsn
+            type: string
+            required: true
+          - name: waterschap_code
+            type: string
+            required: true
+          - name: belastingsoort
+            type: string
+            required: true
+          - name: netto_besteedbaar_inkomen_maand
+            type: amount
+            type_spec:
+              unit: eurocent
+            required: true
+          - name: netto_besteedbaar_inkomen_partner_maand
+            type: amount
+            type_spec:
+              unit: eurocent
+            required: false
+          - name: huishoudtype
+            type: string
+            required: true
+          - name: is_pensioengerechtigd
+            type: boolean
+            required: true
+          - name: vermogen
+            type: amount
+            type_spec:
+              unit: eurocent
+            required: true
+          - name: aanslagbedrag
+            type: amount
+            type_spec:
+              unit: eurocent
+            required: true
+          - name: is_ondernemer
+            type: boolean
+            required: true
+          - name: belasting_zakelijk
+            type: boolean
+            required: true
+        input:
+          - name: ondernemer_komt_in_aanmerking
+            type: boolean
+            source:
+              output: ondernemer_komt_in_aanmerking
+              parameters:
+                is_ondernemer: $is_ondernemer
+                belasting_zakelijk: $belasting_zakelijk
+          - name: kan_kwijtschelding_verleend_uri
+            type: boolean
+            source:
+              regulation: uitvoeringsregeling_invorderingswet_1990
+              output: kan_kwijtschelding_worden_verleend
+              parameters:
+                bsn: $bsn
+                waterschap_code: $waterschap_code
+                netto_besteedbaar_inkomen_maand: $netto_besteedbaar_inkomen_maand
+                netto_besteedbaar_inkomen_partner_maand: $netto_besteedbaar_inkomen_partner_maand
+                huishoudtype: $huishoudtype
+                is_pensioengerechtigd: $is_pensioengerechtigd
+                vermogen: $vermogen
+                aanslagbedrag: $aanslagbedrag
+          - name: hoogte_kwijtschelding_uri
+            type: amount
+            type_spec:
+              unit: eurocent
+            source:
+              regulation: uitvoeringsregeling_invorderingswet_1990
+              output: hoogte_kwijtschelding
+              parameters:
+                bsn: $bsn
+                waterschap_code: $waterschap_code
+                netto_besteedbaar_inkomen_maand: $netto_besteedbaar_inkomen_maand
+                netto_besteedbaar_inkomen_partner_maand: $netto_besteedbaar_inkomen_partner_maand
+                huishoudtype: $huishoudtype
+                is_pensioengerechtigd: $is_pensioengerechtigd
+                vermogen: $vermogen
+                aanslagbedrag: $aanslagbedrag
+        output:
+          - name: belastingsoort_in_scope
+            type: boolean
+          - name: kan_kwijtschelding_worden_verleend
+            type: boolean
+          - name: hoogte_kwijtschelding
+            type: amount
+            type_spec:
+              unit: eurocent
+        actions:
+          - output: belastingsoort_in_scope
+            value:
+              operation: IN
+              subject: $belastingsoort
+              value: $belastingsoorten_in_scope
+          - output: kan_kwijtschelding_worden_verleend
+            value:
+              operation: AND
+              conditions:
+                - operation: EQUALS
+                  subject: $belastingsoort_in_scope
+                  value: true
+                - operation: EQUALS
+                  subject: $ondernemer_komt_in_aanmerking
+                  value: true
+                - operation: EQUALS
+                  subject: $kan_kwijtschelding_verleend_uri
+                  value: true
+          - output: hoogte_kwijtschelding
+            value:
+              operation: IF
+              cases:
+                - when:
+                    operation: EQUALS
+                    subject: $kan_kwijtschelding_worden_verleend
+                    value: true
+                  then: $hoogte_kwijtschelding_uri
+              default: 0
 
   - number: '2'
     text: |-
@@ -44,6 +176,19 @@ articles:
       2. In afwijking van het eerste lid worden voor pensioengerechtigde personen de kosten van bestaan gesteld op 100% van
       de in artikel 3 van de Regeling kwijtschelding belastingen medeoverheden bedoelde netto-ouderdomspensioen.
     url: https://lokaleregelgeving.overheid.nl/CVDR686061/1#artikel_2
+    machine_readable:
+      implements:
+        - law: uitvoeringsregeling_invorderingswet_1990
+          article: '16'
+          open_term: kostennorm_percentage
+          gelet_op: Gelet op artikel 2 van de Regeling kwijtschelding belastingen medeoverheden
+      execution:
+        output:
+          - name: kostennorm_percentage
+            type: number
+        actions:
+          - output: kostennorm_percentage
+            value: 1.0
 
   - number: '3'
     text: |-
@@ -77,6 +222,29 @@ articles:
       met de uitoefening van een bedrijf of beroep, verschuldigd door een natuurlijk persoon die een bedrijf of zelfstandig
       een beroep uitoefent.
     url: https://lokaleregelgeving.overheid.nl/CVDR686061/1#artikel_5
+    machine_readable:
+      execution:
+        parameters:
+          - name: is_ondernemer
+            type: boolean
+            required: true
+          - name: belasting_zakelijk
+            type: boolean
+            required: true
+        output:
+          - name: ondernemer_komt_in_aanmerking
+            type: boolean
+        actions:
+          - output: ondernemer_komt_in_aanmerking
+            value:
+              operation: OR
+              conditions:
+                - operation: EQUALS
+                  subject: $is_ondernemer
+                  value: false
+                - operation: EQUALS
+                  subject: $belasting_zakelijk
+                  value: false
 
   - number: '6'
     text: |-

--- a/corpus/regulation/nl/waterschaps_verordening/hhnk/kwijtscheldingsregeling_waterschapsbelastingen/2023-01-01.yaml
+++ b/corpus/regulation/nl/waterschaps_verordening/hhnk/kwijtscheldingsregeling_waterschapsbelastingen/2023-01-01.yaml
@@ -185,6 +185,13 @@ articles:
         output:
           - name: kostennorm_percentage
             type: number
+            description: |
+              Implementeert lid 1: 100% van de bijstandsnorm (afwijking van federale 90% per art 2 Regeling
+              kwijtschelding belastingen medeoverheden). Lid 2 (pensioengerechtigden: 100% van
+              netto-ouderdomspensioen per Regeling medeoverheden art 3) is hier vereenvoudigd: de caller zet
+              is_pensioengerechtigd=true, waarop URI 1990 art 16 de bijstandsnorm_aow_* (art 30 lid 2 Abw) gebruikt.
+              Voor een precieze implementatie van lid 2 moet het netto-ouderdomspensioen als aparte open_term op
+              de Regeling medeoverheden worden gemodelleerd.
         actions:
           - output: kostennorm_percentage
             value: 1.0

--- a/corpus/regulation/nl/waterschaps_verordening/hhnk/kwijtscheldingsregeling_waterschapsbelastingen/2023-01-01.yaml
+++ b/corpus/regulation/nl/waterschaps_verordening/hhnk/kwijtscheldingsregeling_waterschapsbelastingen/2023-01-01.yaml
@@ -71,7 +71,35 @@ articles:
           - name: is_pensioengerechtigd
             type: boolean
             required: true
-          - name: vermogen
+          - name: inboedel_waarde
+            type: amount
+            type_spec:
+              unit: eurocent
+            required: true
+          - name: auto_waarde
+            type: amount
+            type_spec:
+              unit: eurocent
+            required: true
+          - name: auto_onmisbaar
+            type: boolean
+            required: true
+          - name: onroerend_goed_waarde
+            type: amount
+            type_spec:
+              unit: eurocent
+            required: true
+          - name: andere_bezittingen
+            type: amount
+            type_spec:
+              unit: eurocent
+            required: true
+          - name: hoger_bevoorrechte_schulden
+            type: amount
+            type_spec:
+              unit: eurocent
+            required: true
+          - name: liquide_middelen
             type: amount
             type_spec:
               unit: eurocent
@@ -95,6 +123,25 @@ articles:
               parameters:
                 is_ondernemer: $is_ondernemer
                 belasting_zakelijk: $belasting_zakelijk
+          - name: vermogen_bedrag
+            type: amount
+            type_spec:
+              unit: eurocent
+            source:
+              regulation: uitvoeringsregeling_invorderingswet_1990
+              output: vermogen_bedrag
+              parameters:
+                bsn: $bsn
+                waterschap_code: $waterschap_code
+                huishoudtype: $huishoudtype
+                is_pensioengerechtigd: $is_pensioengerechtigd
+                inboedel_waarde: $inboedel_waarde
+                auto_waarde: $auto_waarde
+                auto_onmisbaar: $auto_onmisbaar
+                onroerend_goed_waarde: $onroerend_goed_waarde
+                andere_bezittingen: $andere_bezittingen
+                hoger_bevoorrechte_schulden: $hoger_bevoorrechte_schulden
+                liquide_middelen: $liquide_middelen
           - name: kan_kwijtschelding_verleend_uri
             type: boolean
             source:
@@ -107,7 +154,7 @@ articles:
                 netto_besteedbaar_inkomen_partner_maand: $netto_besteedbaar_inkomen_partner_maand
                 huishoudtype: $huishoudtype
                 is_pensioengerechtigd: $is_pensioengerechtigd
-                vermogen: $vermogen
+                vermogen: $vermogen_bedrag
                 aanslagbedrag: $aanslagbedrag
           - name: hoogte_kwijtschelding_uri
             type: amount
@@ -123,7 +170,7 @@ articles:
                 netto_besteedbaar_inkomen_partner_maand: $netto_besteedbaar_inkomen_partner_maand
                 huishoudtype: $huishoudtype
                 is_pensioengerechtigd: $is_pensioengerechtigd
-                vermogen: $vermogen
+                vermogen: $vermogen_bedrag
                 aanslagbedrag: $aanslagbedrag
         output:
           - name: belastingsoort_in_scope
@@ -219,6 +266,43 @@ articles:
 
       c. € 1.500 voor een alleenstaande.
     url: https://lokaleregelgeving.overheid.nl/CVDR686061/1#artikel_4
+    machine_readable:
+      implements:
+        - law: uitvoeringsregeling_invorderingswet_1990
+          article: '12'
+          open_term: verhoging_financiele_middelen_vrijstelling
+          gelet_op: Gelet op artikel 4 van de Regeling kwijtschelding belastingen medeoverheden
+      execution:
+        parameters:
+          - name: huishoudtype
+            type: string
+            required: true
+        output:
+          - name: verhoging_financiele_middelen_vrijstelling
+            type: amount
+            type_spec:
+              unit: eurocent
+        actions:
+          - output: verhoging_financiele_middelen_vrijstelling
+            value:
+              operation: IF
+              cases:
+                - when:
+                    operation: EQUALS
+                    subject: $huishoudtype
+                    value: echtgenoten
+                  then: 200000
+                - when:
+                    operation: EQUALS
+                    subject: $huishoudtype
+                    value: alleenstaande_ouder
+                  then: 180000
+                - when:
+                    operation: EQUALS
+                    subject: $huishoudtype
+                    value: alleenstaande
+                  then: 150000
+              default: 0
 
   - number: '5'
     text: |-

--- a/corpus/regulation/nl/waterschaps_verordening/hhnk/kwijtscheldingsregeling_waterschapsbelastingen/2023-01-01.yaml
+++ b/corpus/regulation/nl/waterschaps_verordening/hhnk/kwijtscheldingsregeling_waterschapsbelastingen/2023-01-01.yaml
@@ -123,6 +123,27 @@ articles:
           - name: belasting_zakelijk
             type: boolean
             required: true
+          - name: gegevens_onvolledig_of_onjuist
+            type: boolean
+            required: false
+          - name: bezwaar_of_beroep_aanhangig
+            type: boolean
+            required: false
+          - name: zekerheid_gesteld
+            type: boolean
+            required: false
+          - name: meerdere_belastingschuldigen
+            type: boolean
+            required: false
+          - name: derde_aansprakelijk_gesteld
+            type: boolean
+            required: false
+          - name: verwijtbaarheid_belastingschuld
+            type: boolean
+            required: false
+          - name: in_faillissement_of_surseance_zonder_akkoord
+            type: boolean
+            required: false
         input:
           - name: ondernemer_komt_in_aanmerking
             type: boolean
@@ -131,6 +152,19 @@ articles:
               parameters:
                 is_ondernemer: $is_ondernemer
                 belasting_zakelijk: $belasting_zakelijk
+          - name: uitgesloten_van_kwijtschelding
+            type: boolean
+            source:
+              regulation: leidraad_invordering_2008
+              output: uitgesloten_van_kwijtschelding
+              parameters:
+                gegevens_onvolledig_of_onjuist: $gegevens_onvolledig_of_onjuist
+                bezwaar_of_beroep_aanhangig: $bezwaar_of_beroep_aanhangig
+                zekerheid_gesteld: $zekerheid_gesteld
+                meerdere_belastingschuldigen: $meerdere_belastingschuldigen
+                derde_aansprakelijk_gesteld: $derde_aansprakelijk_gesteld
+                verwijtbaarheid_belastingschuld: $verwijtbaarheid_belastingschuld
+                in_faillissement_of_surseance_zonder_akkoord: $in_faillissement_of_surseance_zonder_akkoord
           - name: vermogen_bedrag
             type: amount
             type_spec:
@@ -207,6 +241,9 @@ articles:
                 - operation: EQUALS
                   subject: $ondernemer_komt_in_aanmerking
                   value: true
+                - operation: EQUALS
+                  subject: $uitgesloten_van_kwijtschelding
+                  value: false
                 - operation: EQUALS
                   subject: $kan_kwijtschelding_verleend_uri
                   value: true

--- a/corpus/regulation/nl/waterschaps_verordening/hhnk/kwijtscheldingsregeling_waterschapsbelastingen/2023-01-01.yaml
+++ b/corpus/regulation/nl/waterschaps_verordening/hhnk/kwijtscheldingsregeling_waterschapsbelastingen/2023-01-01.yaml
@@ -8,7 +8,6 @@ waterschap_code: WS0155
 officiele_titel: Kwijtscheldingsregeling waterschapsbelastingen HHNK 2023
 url: https://lokaleregelgeving.overheid.nl/CVDR686061
 name: Kwijtscheldingsregeling waterschapsbelastingen HHNK 2023
-
 articles:
   - number: '1'
     text: |-
@@ -65,7 +64,7 @@ articles:
             type: amount
             type_spec:
               unit: eurocent
-            required: false
+            required: true
           - name: huishoudtype
             type: string
             required: true

--- a/corpus/regulation/nl/waterschaps_verordening/hhnk/kwijtscheldingsregeling_waterschapsbelastingen/2023-01-01.yaml
+++ b/corpus/regulation/nl/waterschaps_verordening/hhnk/kwijtscheldingsregeling_waterschapsbelastingen/2023-01-01.yaml
@@ -1,0 +1,93 @@
+---
+$schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/tags/schema-v0.5.2/schema/v0.5.2/schema.json
+$id: kwijtscheldingsregeling_waterschapsbelastingen_hhnk
+regulatory_layer: WATERSCHAPS_VERORDENING
+publication_date: '2022-12-14'
+valid_from: '2023-01-01'
+waterschap_code: WS0155
+officiele_titel: Kwijtscheldingsregeling waterschapsbelastingen HHNK 2023
+url: https://lokaleregelgeving.overheid.nl/CVDR686061
+name: Kwijtscheldingsregeling waterschapsbelastingen HHNK 2023
+
+articles:
+  - number: '1'
+    text: |-
+      **Reikwijdte**
+
+      Kwijtschelding kan worden verleend voor de volgende waterschapsbelastingen:
+
+      a. watersysteemheffing ingezetenen (artikel 117, aanhef en onder a, van de Waterschapswet);
+
+      b. watersysteemheffing gebouwd (artikel 117, aanhef en onder d, van de Waterschapswet), voor zover de heffing wordt
+      geheven van degene die krachtens eigendom, bezit of beperkt recht het genot heeft van een gebouwde onroerende zaak die
+      geheel of gedeeltelijk bij hem in gebruik is als woonruimte;
+
+      c. zuiveringsheffing woonruimte (artikel 122d, lid 2, onder a van de Waterschapswet);
+
+      d. verontreinigingsheffing woonruimte (artikel 7.2, lid 3, onder a, van de Waterwet).
+
+      e. wegenheffing ingezetenen (artikel 122a, lid 2, onder a, van de Waterschapswet);
+
+      f. wegenheffing gebouwd (artikel 122a, lid 2, onder d, van de Waterschapswet), voor zover de heffing wordt geheven van
+      degene die krachtens eigendom, bezit of beperkt recht het genot heeft van een gebouwde onroerende zaak die geheel of
+      gedeeltelijk bij hem in gebruik is als woonruimte;
+    url: https://lokaleregelgeving.overheid.nl/CVDR686061/1#artikel_1
+
+  - number: '2'
+    text: |-
+      **Kosten van bestaan**
+
+      1. Bij de kwijtschelding van de in artikel 1 genoemde waterschapsbelastingen wordt, voor wat betreft de kosten van
+      bestaan, aangesloten bij artikel 16 van de Uitvoeringsregeling Invorderingswet 1990, met dien verstande dat bij de
+      berekening van deze kosten wordt uitgegaan van een percentage van 100% van de bijstandsnorm.
+
+      2. In afwijking van het eerste lid worden voor pensioengerechtigde personen de kosten van bestaan gesteld op 100% van
+      de in artikel 3 van de Regeling kwijtschelding belastingen medeoverheden bedoelde netto-ouderdomspensioen.
+    url: https://lokaleregelgeving.overheid.nl/CVDR686061/1#artikel_2
+
+  - number: '3'
+    text: |-
+      **Nettokosten kinderopvang**
+
+      Bij de kwijtschelding van de in artikel 1 genoemde waterschapsbelastingen worden overeenkomstig het bepaalde in artikel
+      28, lid 3, van de Uitvoeringsregeling Invorderingswet 1990 als uitgaven mede in aanmerking genomen de nettokosten van
+      kinderopvang.
+    url: https://lokaleregelgeving.overheid.nl/CVDR686061/1#artikel_3
+
+  - number: '4'
+    text: |-
+      **Extra toegestane financiële middelen**
+
+      Bij de kwijtschelding van de in artikel 1 genoemde waterschapsbelastingen wordt in afwijking van artikel 12, tweede
+      lid, onderdeel d, van de Uitvoeringsregeling Invorderingswet 1990 het totale bedrag aan financiële middelen, bedoeld in
+      dat onderdeel, verhoogd met:
+
+      a. € 2.000 voor de belastingschuldige en echtgenoot;
+
+      b. € 1.800 voor een alleenstaande ouder; en
+
+      c. € 1.500 voor een alleenstaande.
+    url: https://lokaleregelgeving.overheid.nl/CVDR686061/1#artikel_4
+
+  - number: '5'
+    text: |-
+      **Kwijtschelding ondernemers**
+
+      Deze regeling vindt mede toepassing op verzoeken om kwijtschelding van waterschapsbelastingen, die geen verband houden
+      met de uitoefening van een bedrijf of beroep, verschuldigd door een natuurlijk persoon die een bedrijf of zelfstandig
+      een beroep uitoefent.
+    url: https://lokaleregelgeving.overheid.nl/CVDR686061/1#artikel_5
+
+  - number: '6'
+    text: |-
+      **Citeertitel en inwerkingtreding**
+
+      1. Deze regeling kan worden aangehaald als 'Kwijtscheldingsregeling waterschapsbelastingen HHNK 2023' of
+      'Kwijtscheldingsregeling waterschapsbelastingen Hoogheemraadschap Hollands Noorderkwartier 2023'.
+
+      2. Deze regeling treedt in werking met ingang van 1 januari 2023.
+
+      3. De 'Kwijtscheldingsregeling Hoogheemraadschap Hollands Noorderkwartier 2019' wordt ingetrokken, met dien verstande
+      dat deze van toepassing blijft op belastingaanslagen, waarvan de dagtekening is gelegen voor de in het tweede lid
+      genoemde datum.
+    url: https://lokaleregelgeving.overheid.nl/CVDR686061/1#artikel_6

--- a/corpus/regulation/nl/waterschaps_verordening/hhnk/kwijtscheldingsregeling_waterschapsbelastingen/2023-01-01.yaml
+++ b/corpus/regulation/nl/waterschaps_verordening/hhnk/kwijtscheldingsregeling_waterschapsbelastingen/2023-01-01.yaml
@@ -188,10 +188,10 @@ articles:
             description: |
               Implementeert lid 1: 100% van de bijstandsnorm (afwijking van federale 90% per art 2 Regeling
               kwijtschelding belastingen medeoverheden). Lid 2 (pensioengerechtigden: 100% van
-              netto-ouderdomspensioen per Regeling medeoverheden art 3) is hier vereenvoudigd: de caller zet
-              is_pensioengerechtigd=true, waarop URI 1990 art 16 de bijstandsnorm_aow_* (art 30 lid 2 Abw) gebruikt.
-              Voor een precieze implementatie van lid 2 moet het netto-ouderdomspensioen als aparte open_term op
-              de Regeling medeoverheden worden gemodelleerd.
+              netto-ouderdomspensioen per Regeling medeoverheden art 3) wordt automatisch afgedekt wanneer de
+              caller is_pensioengerechtigd=true zet: URI art 16 gebruikt dan de definitions
+              netto_ouderdomspensioen_alleenstaand/echtgenoten (exacte SVB-bedragen 2026) in plaats van
+              bijstandsnorm_aow_*, ook met kostennorm_percentage=1.0.
         actions:
           - output: kostennorm_percentage
             value: 1.0

--- a/corpus/regulation/nl/waterschaps_verordening/hhnk/leidraad_invordering_waterschapsbelastingen/2023-01-01.yaml
+++ b/corpus/regulation/nl/waterschaps_verordening/hhnk/leidraad_invordering_waterschapsbelastingen/2023-01-01.yaml
@@ -1,0 +1,6607 @@
+---
+$schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/tags/schema-v0.5.2/schema/v0.5.2/schema.json
+$id: leidraad_invordering_waterschapsbelastingen_hhnk
+regulatory_layer: WATERSCHAPS_VERORDENING
+publication_date: '2023-09-08'
+valid_from: '2023-09-08'
+waterschap_code: WS0155
+officiele_titel: Leidraad invordering waterschapsbelastingen HHNK 2023
+url: https://lokaleregelgeving.overheid.nl/CVDR691525
+name: Leidraad invordering waterschapsbelastingen HHNK 2023
+
+articles:
+  - number: '1'
+    text: |-
+      **Inleiding en toepassingsgebied**
+
+      Dit artikel bevat in 1.1 de inleiding van de Leidraad invordering waterschapsbelastingen HHNK 2023.
+
+      In 1.2 is het beleid over het toepassingsgebied van de Invorderingswet 1990 opgenomen in aansluiting op artikel 1 van
+      die wet.
+
+      1.1 Inleiding
+
+      Voor u ligt de Leidraad invordering waterschapsbelastingen HHNK 2023. Het is een reactie op de halfjaarlijkse wijziging
+      van de Leidraad Invordering 2008 door het Ministerie van Financiën.
+
+      Bij de opmaak van deze leidraad is aansluiting gezocht bij de Leidraad Invordering 2008 van de Rijksoverheid. Het
+      betreft echter geen kopie. Daar waar noodzakelijk zijn bepalingen opgenomen die afwijken van de Rijksleidraad. Bij de
+      benaming wordt gekozen voor het huidige jaartal om de actualiteit naar voren te laten komen.
+
+      Qua indeling in afdelingen, artikelen en paragrafen is aansluiting gezocht bij de Rijksleidraad. Bij diverse artikelen
+      treft u de opmerking aan: ‘Niet van toepassing voor HHNK’. Reden hiervoor is om de nummering van de Rijksleidraad niet
+      te veranderen, de halfjaarlijkse wijzigingen van het Ministerie van Financiën kunnen dan sneller gevonden en veranderd
+      worden.
+
+      In de tekst is de benaming ‘ontvanger’ gebleven, vanwege de leesbaarheid. In de Waterschapswet is gekozen om de term
+      ontvanger te vertalen door: ambtenaar belast met de invordering. Hierbij wordt dan ook verwezen naar dit
+      vertaalartikel. In de andere gevallen is wel gekozen voor de directe vertaling van (Rijks)belastingfunctionarissen naar
+      de lokale benamingen.
+
+      Dit besluit wordt aangehaald als 'Leidraad invordering waterschapsbelastingen Hoogheemraadschap Hollands
+      Noorderkwartier 2023' of 'Leidraad invordering waterschapsbelastingen HHNK 2023'.
+
+      Het besluit 'Leidraad invordering waterschapsbelastingen HHNK 2022' met registratienummer 22.0536590 wordt ingetrokken
+      met ingang van de inwerkingtreding van dit besluit.
+
+      Dit besluit treedt in werking met ingang van de eerste dag na de bekendmaking in het Waterschapsblad.
+
+      Het Reglement automatische incasso waterschapsbelastingen HHNK is als bijlage bijgevoegd.
+
+      1.1.1 Lijst met gebruikte afkortingen
+
+      Afkorting
+
+      Omschrijving
+
+      Awb
+
+      Algemene wet bestuursrecht
+
+      AWR
+
+      Algemene wet inzake rijksbelastingen
+
+      BW
+
+      Burgerlijk Wetboek
+
+      D&H
+
+      college van dijkgraaf en hoogheemraden
+
+      FW
+
+      Faillissementswet
+
+      MSNP
+
+      minnelijke schuldsanering natuurlijke personen
+
+      Pw
+
+      Participatiewet
+
+      Rv
+
+      Wetboek van Burgerlijke Rechtsvordering
+
+      Sr
+
+      Wetboek van Strafrecht
+
+      Sv
+
+      Wetboek van Strafvordering
+
+      WHOA
+
+      Wet homologatie onderhands akkoord
+
+      Wschw
+
+      Waterschapswet
+
+      WSF
+
+      Wet Studiefinanciering 2000
+
+      WSNP
+
+      wettelijke schuldsanering natuurlijke personen
+
+      1.1.2 Definities
+
+      •
+
+      belasting(en): belastingen die door HHNK worden geheven;
+
+      •
+
+      belastingdeurwaarder: de aangewezen belastingdeurwaarder van HHNK, bedoeld in artikel 123, derde lid, onder e, Wschw;
+
+      •
+
+      belastingverordening(en): de verordening tot heffing en invordering van belasting of rechten van het algemeen bestuur
+      van HHNK;
+
+      •
+
+      besluit (het): het Uitvoeringsbesluit Invorderingswet 1990;
+
+      •
+
+      directeur: de secretaris-directeur van HHNK;
+
+      •
+
+      echtgenoot: de echtgenoot bedoeld in artikel 3 Pw;
+
+      •
+
+      HHNK: Hoogheemraadschap Hollands Noorderkwartier;
+
+      •
+
+      inspecteur: de aangewezen ambtenaar belast met de heffing, bedoeld in artikel 123, derde lid, onderdeel b, Wschw met
+      inbegrip van de ambtenaren aan wie ter zake mandaat is verleend door de inspecteur;
+
+      •
+
+      ministerie: ministerie van Financiën, directoraat-generaal Belastingdienst, team particulieren en formeel recht of team
+      ondernemingen;
+
+      •
+
+      ondernemer: de belastingschuldige die een onderneming drijft of zelfstandig een beroep uitoefent;
+
+      •
+
+      ontvanger: de aangewezen ambtenaar belast met de invordering, bedoeld in artikel 123, derde lid, onderdeel b, Wschw;
+
+      •
+
+      particulier: de belastingschuldige die niet als ondernemer wordt aangemerkt;
+
+      •
+
+      regeling (de): de Uitvoeringsregeling Invorderingswet 1990;
+
+      •
+
+      wet (de): de wet van 30 mei 1990 op de invordering van rijksbelastingen (Invorderingswet 1990).
+
+      Onder de overige in deze leidraad gebruikte begrippen wordt hetzelfde verstaan als de wet daaronder verstaat.
+
+      1.1.3 Reikwijdte beleidsvoorschriften
+
+      Niet van toepassing voor HHNK.
+
+      1.1.4 Aansprakelijkgestelden en andere derden
+
+      De invordering met betrekking tot aansprakelijkgestelden en andere derden vindt voor een groot deel op overeenkomstige
+      wijze plaats als de invordering met betrekking tot belastingschuldigen. Omwille van de leesbaarheid is vermeden steeds
+      de aansprakelijkgestelden en andere derden te noemen, zonder dat hiermee wordt beoogd de toepasselijkheid van die
+      voorschriften te beperken.
+
+      1.1.5 Awb en algemene beginselen van behoorlijk bestuur
+
+      In de invordering wordt zoveel mogelijk gehandeld in overeenstemming met de Awb en het Besluit Fiscaal bestuursrecht,
+      ondanks het feit dat artikel 3:40, titels 4.1 tot en met 4.3, artikel 4:125, titel 5.2, de hoofdstukken 6 en 7 en
+      afdeling 10.2.1 Awb niet van toepassing zijn op de wet.
+
+      Dit betekent onder meer dat de beslistermijnen uit de Awb inclusief de mogelijkheden tot verlenging van toepassing
+      zijn, tenzij de wet, de regeling of deze leidraad anders bepaalt.
+
+      •
+
+      Voor beschikkingen op aanvraag, vergezeld met een volledig ingevuld verzoekformulier, geldt een termijn van acht weken
+      na ontvangst van het volledig ingevuld formulier, met de mogelijkheid hiervan af te wijken door een redelijke termijn
+      te noemen (zie artikel 4:13, 4:14 en 4:15 Awb).
+
+      •
+
+      Voor het beslissen op bezwaarschriften geldt een termijn van zes weken en een verdagingstermijn van maximaal zes weken,
+      met de mogelijkheid tot verder uitstel in gezamenlijk overleg (artikel 7:10 Awb).
+
+      •
+
+      Voor beslissingen op beroepschriften bij administratief beroep wordt niet afgeweken van artikel 7:24 Awb. De
+      beslistermijn is zes weken, met de mogelijkheid tot verlenging met zes weken, gerekend vanaf het moment waarop het
+      beroepschrift is ingediend, met de mogelijkheid tot verder uitstel in gezamenlijk overleg.
+
+      Het uitgangspunt met betrekking tot de Awb-conforme werkwijze geldt niet voor de regeling inzake de dwangsom bij niet
+      tijdig beslissen (paragraaf 4.1.3.2 Awb). Het laatste betekent dat bij de uitvoering van de wet de dwangsom uitsluitend
+      van toepassing is op de volgende gevallen:
+
+      •
+
+      bezwaarschriften tegen beschikkingen invorderingsrente als bedoeld in artikel 30, eerste lid, van de wet;
+
+      •
+
+      bezwaarschriften tegen beschikkingen aansprakelijkstelling als bedoeld in artikel 49, eerste lid, van de wet;
+
+      •
+
+      bezwaar- en beroepschriften als bedoeld in artikel 7, eerste lid, van de Kostenwet invordering rijksbelastingen;
+
+      •
+
+      bezwaarschriften tegen beschikkingen kostenvergoedingen bij een onrechtmatig opgelegde verplichting als bedoeld in
+      artikel 62a, eerste lid, van de wet;
+
+      •
+
+      bezwaarschriften tegen beschikkingen bestuurlijke boete als bedoeld in artikel 63b van de wet
+
+      Naast het zoveel mogelijk handelen in overeenstemming met de Awb moet de ontvanger bij zijn handelen de algemene
+      beginselen van behoorlijk bestuur in acht te nemen, ook als sprake is van privaatrechtelijke handelingen (beslag,
+      executoriale verkoop en dergelijke).
+
+      1.1.5a Toepassing artikel 4:84 Awb
+
+      Artikel 4:84 Awb is van overeenkomstige toepassing bij de invordering van rijksbelastingen. Op grond hiervan is het
+      onder omstandigheden mogelijk om af te wijken van beleidsregels zoals die zijn opgenomen in een beleidsbesluit dat van
+      toepassing is voor de praktijk van de ontvanger, zoals deze leidraad. Afwijking van beleidsregels is gerechtvaardigd
+      als toepassing van die regels voor een of meer belanghebbenden gevolgen zou hebben, die vanwege bijzondere
+      omstandigheden onevenredig zijn in verhouding tot de doelen die de beleidsregels dienen.
+
+      Toepassing van artikel 4:84 Awb zal slechts bij hoge uitzondering aan de orde zijn. Het afwijken van beleidsregels
+      leidt in de regel immers tot schending van het gelijkheidsbeginsel. Er moet dus sprake zijn van daadwerkelijk
+      bijzondere omstandigheden waardoor onverkorte toepassing van de beleidsregels onevenredig nadeel voor de betrokkene zou
+      opleveren. Dit criterium gaat aanzienlijk verder dan een belangenafweging als bedoeld in artikel 3:4 Awb.
+
+      1.1.6 Keuze uit verschillende invorderingsmaatregelen
+
+      Als de invordering op verschillende manieren kan plaatsvinden, heeft de eenvoudigste, snelste en minst kostbare wijze
+      voor HHNK de voorkeur.
+
+      1.1.7 Invorderingsmaatregelen tegen grote bedrijven
+
+      Als de ontvanger invorderingsmaatregelen wil treffen die het voortbestaan kunnen bedreigen van een bedrijf met meer dan
+      vijftig werknemers, dan vraagt hij daartoe toestemming aan D&H. Onder een bedrijf wordt in dit verband ook verstaan een
+      geheel van bij elkaar behorende bedrijven of een zelfstandig uitgeoefend beroep.
+
+      Beslaglegging hoeft niet het hiervoor bedoelde effect te hebben, als de ontvanger op een zodanige wijze kan handelen
+      dat derden daarvan geheel onwetend blijven.
+
+      De ontvanger vraagt altijd toestemming als:
+
+      •
+
+      met de beslaglegging op korte termijn de verkoop van (een deel van) de activa van het bedrijf wordt beoogd;
+
+      •
+
+      door de beslaglegging de werkvoorraad en/of geldmiddelen geheel of nagenoeg geheel worden vastgelegd;
+
+      •
+
+      derden niet onkundig blijven van de beslaglegging, zoals steeds het geval is bij derdenbeslag;
+
+      •
+
+      de ontvanger aan een schuldeiser zodanige inlichtingen omtrent openstaande belastingaanslagen verstrekt, dat deze
+      kunnen dienen als steunvorderingen bij het aanvragen van faillissement door die schuldeiser.
+
+      1.1.8 Voor de invordering minder geschikte dagen
+
+      De ontvanger zal geen invorderingsmaatregelen nemen tegen particulieren op dagen die daarvoor minder geschikt kunnen
+      worden geacht, als die maatregelen zonder bezwaar naar een later tijdstip kunnen worden verschoven.
+
+      Deze terughoudendheid geldt bij ondernemers slechts voor zover sprake is van invorderingsmaatregelen die betrekking
+      hebben op bezittingen die tot de privésfeer kunnen worden gerekend.
+
+      Voor invordering minder geschikte dagen zijn met name:
+
+      •
+
+      de Nieuwjaarsdag, de Christelijke tweede Paas- en Pinksterdag, de beide Kerstdagen, de Hemelvaartsdag, de dag waarop de
+      verjaardag van de Koning wordt gevierd, de vijfde mei en de Goede Vrijdag, alle met inbegrip van de daaraan
+      voorafgaande en de daarop volgende dag;
+
+      •
+
+      regionaal vrij algemeen erkende feest- en gedenkdagen met inbegrip van de daaraan voorafgaande en de daarop volgende
+      dag;
+
+      •
+
+      de dagen tussen de beide Kerstdagen en Nieuwjaarsdag.
+
+      1.1.9 Binnenkomst van bescheiden
+
+      Als aan het indienen van bepaalde bescheiden rechtsgevolgen zijn verbonden dan wel rechten kunnen worden ontleend dan
+      geldt als datum van binnenkomst van die stukken de datum van binnenkomst bij HHNK.
+
+      Als de ontvanger in de tussentijd heeft verrekend of dwangmaatregelen heeft genomen ter invordering van de
+      belastingschuld, dan blijven deze gehandhaafd als hij niet van de indiening op de hoogte was en er redelijkerwijs ook
+      niet van op de hoogte kon zijn. Onder dwangmaatregelen moeten in dit verband worden verstaan: alle maatregelen in het
+      kader van de dwanginvordering respectievelijk invordering langs civielrechtelijke weg, en het aansprakelijk stellen van
+      derden.
+
+      1.1.10 Positie belastingdeurwaarder
+
+      Belastingdeurwaarder is een door of namens D&H aangewezen ambtenaar van HHNK, dan wel een als belastingdeurwaarder van
+      HHNK aangewezen deurwaarder. In de uitoefening van zijn functie is de belastingdeurwaarder bestuursorgaan in de zin van
+      de Awb, dan wel handelt hij onder de verantwoordelijkheid van een bestuursorgaan (de ontvanger).
+
+      Als zodanig vervult hij zijn taak zonder vooringenomenheid. Hij gebruikt zijn bevoegdheid niet voor een ander doel dan
+      waarvoor die bevoegdheid is verleend. Hij handelt integer en overeenkomstig de Leidraad invordering
+      waterschapsbelastingen van HHNK. Hij waakt ervoor dat de nadelige gevolgen van zijn handelen niet onevenredig zijn in
+      verhouding tot de doelen die hij met die handelingen dient.
+
+      Om misverstanden te voorkomen, meldt de belastingdeurwaarder steeds in welke hoedanigheid hij optreedt en hij
+      legitimeert zich desgevraagd. Op grond van artikel 67 van de wet is het de belastingdeurwaarder verboden om hetgeen hem
+      over de persoon of de zaken van een ander blijkt of wordt meegedeeld – in enige werkzaamheid bij de uitvoering van de
+      wet, of in verband daarmee – verder bekend te maken dan nodig is voor de uitvoering van de wet of voor de heffing van
+      enige rijksbelasting.
+
+      De leiding van de invordering berust steeds in handen van de ontvanger. Dit brengt met zich mee dat de
+      belastingdeurwaarder de bevoegdheden die hij rechtstreeks ontleent aan de wet en aan het Wetboek van Burgerlijke
+      Rechtsvordering, slechts uitoefent nadat hij daartoe een opdracht van de ontvanger heeft verkregen en zich bij de
+      uitoefening van die bevoegdheden houdt aan diens aanwijzingen.
+
+      Op grond van artikel 9:1 Awb heeft een ieder het recht om een klacht in te dienen over de wijze waarop de
+      belastingdeurwaarder zich jegens hem of een ander heeft gedragen. Klachten in verband met zijn ambtsuitoefening kunnen
+      worden ingediend bij de ontvanger in wiens opdracht en onder wiens verantwoordelijkheid de belastingdeurwaarder
+      werkzaam is.
+
+      De ontvanger legt deze klacht voor aan de klachtencoördinator van HHNK. Op de klacht volgt een uitspraak door de
+      directeur.
+
+      1.1.11 Bewaren invorderingsbescheiden
+
+      De ontvanger bewaart de bescheiden die direct betrekking hebben op de invordering gedurende drie jaar na afdoening, of
+      zoveel langer als het recht tot dwanginvordering van de belastingaanslag die daaraan ten grondslag ligt nog niet is
+      verjaard.
+
+      De bescheiden die op kwijtschelding betrekking hebben, worden gedurende ten minste drie jaar na de verleende
+      kwijtschelding bewaard, of zoveel langer als redelijkerwijs nog niet kan worden aangenomen dat zij hun belang
+      definitief hebben verloren.
+
+      Bescheiden die geen betrekking hebben op één of meer bepaalde belastingaanslagen, worden eveneens gedurende ten minste
+      drie jaar bewaard, of zoveel langer als redelijkerwijs nog niet kan worden aangenomen dat zij hun belang definitief
+      hebben verloren.
+
+      1.1.12 Verklaring inzake nakoming fiscale verplichtingen
+
+      Op verzoek van de belanghebbende of zijn gemachtigde geeft de ontvanger een verklaring af over het betalingsgedrag van
+      de belanghebbende. De verklaring ziet op formele belastingschulden of andere vorderingen ten name van de belanghebbende
+      waarvan de invordering aan de ontvanger is opgedragen op het moment van afgifte van de verklaring. De verklaring biedt
+      geen garantie dat de materieel verschuldigde belastingen tot het moment van afgifte van de verklaring volledig zijn
+      voldaan. Tevens verklaart de ontvanger desgevraagd dat zich in het verleden – voor wat betreft de invordering – geen
+      moeilijkheden hebben voorgedaan. In de verklaring kan de ontvanger nadere bijzonderheden vermelden.
+
+      De ontvanger zendt de verklaring aan het adres van de belanghebbende of reikt deze aan hem uit. Toezending of
+      uitreiking aan een ander dan de belanghebbende blijft achterwege, tenzij de ontvanger zich ervan heeft overtuigd dat
+      die ander tot ontvangst van de verklaring bevoegd is.
+
+      1.1.13 Informatieplicht
+
+      De ontvanger maakt van de bevoegdheden van hoofdstuk VII van de wet enkel gebruik bij een betalingsachterstand, dat wil
+      zeggen als niet is betaald binnen de betalingstermijn(en) die voor de belastingaanslag gelden. De informatieplicht
+      vervalt zodra volledige betaling plaatsvindt.
+
+      De ontvanger kan altijd gebruikmaken van zijn bevoegdheid van hoofdstuk VII als de toepassing van artikel 10 van de wet
+      aan de orde kan komen.
+
+      1.1.14 Diplomatieke status
+
+      De invordering van belastingschulden van personen met een diplomatieke status gebeurt door tussenkomst van de minister
+      van Buitenlandse Zaken. De ontvanger richt een verzoek om bemiddeling rechtstreeks tot:
+
+      Ministerie van Buitenlandse Zaken
+
+      Directie Kabinet en Protocol
+
+      Postbus 20061
+
+      2500 EB 'S-GRAVENHAGE
+
+      1.2 Toepassingsgebied
+
+      Het eerste lid van artikel 1 van de wet regelt het toepassingsgebied van de wet. Het tweede lid bepaalt dat een deel
+      van de Awb niet van toepassing is op de wet.
+
+      De ontvanger handelt zoveel mogelijk in overeenstemming met de Awb en het Besluit fiscaal bestuursrecht (zie ook
+      artikel 1 onderdeel 1.8 van deze leidraad).
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_1
+
+  - number: '2'
+    text: |-
+      **Begrippen**
+
+      In aansluiting op artikel 2 van de wet beschrijft dit artikel het beleid over het begrip 'woonplaats' en de
+      vertaalbepaling van de Waterschapswet.
+
+      2.1 Woonplaats
+
+      De begrippen 'woonplaats' en 'plaats van vestiging' hebben bij de uitvoering van de wet niet steeds dezelfde inhoud.
+
+      Als het gaat om de betekening van stukken of om andere handelingen overeenkomstig het Wetboek van Burgerlijke
+      Rechtsvordering, sluit de ontvanger aan bij het begrip 'woonplaats' als bedoeld in de artikelen 1:10 en volgende van
+      het BW.
+
+      Bij de aansprakelijkheidsbepalingen van Afdeling 1 van Hoofdstuk IV van de wet ligt het voor de hand om aan te sluiten
+      bij de begrippen 'woonplaats' en 'plaats van vestiging' die gelden voor de heffingswet op grond waarvan de
+      belastingschuld – waarvoor de aansprakelijkheid bestaat – is ontstaan.
+
+      2.2 Vertaalbepaling Waterschapswet
+
+      In artikel 123, tweede lid, Wschw is de wet van toepassing verklaard op de invordering van waterschapsbelastingen.
+      Tegelijkertijd zijn in artikel 138 Wschw enkele artikelen uit de wet genoemd die buiten toepassing blijven.
+
+      In artikel 123 Wschw is tevens bepaald aan welke colleges of functionarissen van HHNK de in de wet genoemde
+      bevoegdheden toekomen. Het gaat daarbij om een vertaling van de functionarissen die in artikel 2 van de wet worden
+      genoemd naar colleges en functionarissen van HHNK.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_2
+
+  - number: '3'
+    text: |-
+      **Bevoegdheden ontvanger**
+
+      Artikel 3 van de wet geeft een afbakening van de bevoegdheden van de ontvanger. Hij kan daarbij gebruikmaken van de
+      bijzondere bevoegdheden die de wet hem geeft. Hij kan bovendien alle bevoegdheden uitoefenen die iedere andere
+      schuldeiser ook heeft.
+
+      De bepalingen van deze leidraad zijn zoveel mogelijk van overeenkomstige toepassing op de invordering op
+      civielrechtelijke wijze.
+
+      De ontvanger treedt in alle rechtsgedingen die voortvloeien uit de uitoefening van zijn taak als zodanig in rechte op.
+
+      In aansluiting op artikel 3 van de wet beschrijft dit artikel het beleid over:
+
+      •
+
+      de fiscale en civiele bevoegdheden van de ontvanger;
+
+      •
+
+      het leggen van conservatoir beslag;
+
+      •
+
+      het vragen van toestemming bij gerechtelijke procedures.
+
+      3.1 Fiscale en civiele bevoegdheden
+
+      De ontvanger beschikt op grond van de wet over diverse specifieke bevoegdheden om een belastingschuld in te vorderen.
+      Daarnaast heeft hij alle bevoegdheden die op grond van enigerlei wettelijke bepaling aan een schuldeiser toekomen. Dit
+      leidt er in veel gevallen toe dat de ontvanger zowel gebruik kan maken van zijn specifieke fiscale bevoegdheden, als
+      van zijn algemene civielrechtelijke bevoegdheden om zijn doel te bereiken.
+
+      De ontvanger is vrij in de keuze van de invorderingsinstrumenten die hij het meest geschikt acht voor een juiste
+      uitoefening van zijn taak. Als de ontvanger het wenselijk of noodzakelijk acht van fiscale bevoegdheden over te
+      schakelen op civielrechtelijke bevoegdheden of andersom, dan doet hij dit alleen als het belang van de invordering
+      opweegt tegen de belangen van de belastingschuldige en eventuele derden.
+
+      3.2 Conservatoir beslag
+
+      Om de rechten van HHNK veilig te stellen heeft de ontvanger naast de versnelde invordering de mogelijkheid conservatoir
+      beslag te leggen. Feiten en omstandigheden bepalen de keuze van de ontvanger.
+
+      3.2.1 Geen conservatoir beslag dan ook geen versnelde invordering
+
+      Als de voorzieningenrechter van de rechtbank geen toestemming verleent tot het leggen van conservatoir beslag omdat hij
+      gegronde vrees voor verduistering van de goederen niet aanwezig acht, dan legt de ontvanger niet alsnog om dezelfde
+      reden executoriaal beslag op grond van de artikelen 10 en 15 van de wet.
+
+      3.2.2 Ontbreken belastingaanslag en conservatoir beslag
+
+      Als het niet mogelijk is eerst een belastingaanslag op te leggen, vraagt de ontvanger slechts verlof om conservatoir
+      beslag te leggen aan de voorzieningenrechter als de belasting in redelijkheid materieel verschuldigd geacht mag worden.
+      Het opleggen van de belastingaanslag wordt beschouwd als het instellen van een eis in de hoofdzaak als bedoeld in
+      artikel 700, derde lid, Rv.
+
+      3.3 Gerechtelijke procedures – toestemming
+
+      In gerechtelijke procedures voor de burgerlijke rechter waarin de ontvanger als eiser optreedt, moet hij toestemming
+      hebben van D&H. Het voorgaande geldt niet voor:
+
+      •
+
+      verklaringsprocedures in het kader van derdenbeslagen;
+
+      •
+
+      kantonzaken;
+
+      •
+
+      verzoekschriftprocedures;
+
+      •
+
+      procedures die worden ingesteld naar aanleiding van een verzet ex artikel 435, derde lid, dan wel artikel 708, tweede
+      lid, Rv.
+
+      In afwijking van de vorige volzin geldt voor in hoger beroep te voeren zaken dat altijd toestemming van D&H nodig is.
+
+      3.4 Rijksadvocaat
+
+      Niet van toepassing voor HHNK.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_3
+
+  - number: 3a
+    text: |-
+      Er zijn in deze leidraad op artikel 3a van de wet geen beleidsregels gemaakt.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_3a
+
+  - number: '4'
+    text: |-
+      **Bevoegdheid belastingdeurwaarder**
+
+      In artikel 4 van de wet is bepaald dat voor het verrichten van deurwaarderswerkzaamheden in opdracht van een ontvanger
+      voor de invordering van rijksbelastingen, uitsluitend een belastingdeurwaarder bevoegd is. In aansluiting op artikel 4
+      van de wet beschrijft dit artikel het beleid over de reikwijdte van die bevoegdheid.
+
+      4.1 Reikwijdte bevoegdheid belastingdeurwaarder
+
+      De belastingdeurwaarder is bevoegd tot het uitbrengen van alle exploten en het treffen van alle invorderingsmaatregelen
+      die rechtstreeks verband houden met de invorderingstaak en de hieruit voortvloeiende bevoegdheden van de ontvanger.
+
+      Dit brengt met zich mee dat de belastingdeurwaarder ook bevoegd is tot die werkzaamheden die voortvloeien uit de
+      invordering langs civielrechtelijke weg, waartoe de ontvanger op grond van artikel 4:124 Awb gerechtigd is en tot die
+      werkzaamheden die verricht moeten worden, wanneer de ontvanger zelfstandig eisend en verwerend in rechte optreedt.
+
+      4.2 Bescherming
+
+      Belastingdeurwaarders zijn ambtenaar in de zin van de artikelen 179 en 180 Sr. Daardoor genieten zij van de
+      strafrechtelijke bescherming, voor zover zij hun wettelijke taken en bevoegdheden uitoefenen.
+
+      4.3 Aanwijzing
+
+      Belastingdeurwaarders worden aangesteld door D&H van HHNK.
+
+      Indien de ontvanger gebruik wil maken van belastingdeurwaarders die niet in loondienst zijn van HHNK, dient aanstelling
+      plaats te vinden door D&H. Deze laatstgenoemde bevoegdheid tot aanstelling is door D&H gemandateerd aan de ontvanger.
+
+      4.4 Legitimatie
+
+      Voor de uitoefening van de aan hem opgedragen invorderingstaken kan de belastingdeurwaarder op verzoek zich legitimeren
+      aan de belastingschuldige en/of zijn/haar gemachtigden.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_4
+
+  - number: '5'
+    text: |-
+      Niet van toepassing voor HHNK.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_5
+
+  - number: '6'
+    text: |-
+      **Reikwijdte van de wet**
+
+      In aansluiting op artikel 6 van de wet beschrijft dit artikel het beleid over rente en kosten.
+
+      6.1 Rente en kosten in het kader van de reikwijdte van de wet
+
+      Onder rente als bedoeld in artikel 6 van de wet wordt alleen verstaan: de invorderingsrente.
+
+      Onder kosten wordt verstaan: alle kosten die op de voet van de Kostenwet invordering rijksbelastingen aan de
+      belastingschuldige in rekening worden gebracht. Hieronder vallen ook de kosten die zijn verbonden aan de werkzaamheden
+      die de belastingdeurwaarder verricht bij de invordering langs civielrechtelijke weg.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_6
+
+  - number: '7'
+    text: |-
+      **Betaling en afboeking**
+
+      Artikel 7 van de wet schrijft voor hoe de toerekening van betalingen moet plaatsvinden:
+
+      •
+
+      lid 1 bepaalt dat toerekening van betalingen achtereenvolgens gebeurt aan de kosten, de betalingskorting, de rente en
+      de belastingaanslag;
+
+      •
+
+      lid 2 bepaalt hoe de afboeking aan de verschillende componenten van de belastingaanslag plaatsvindt.
+
+      In aansluiting op artikel 7 van de wet beschrijft dit artikel het beleid over:
+
+      •
+
+      het tijdstip van de betaling;
+
+      •
+
+      de afboeking van de betaling;
+
+      •
+
+      teveelbetalingen;
+
+      •
+
+      het rekenen van rente en kosten bij afboeking;
+
+      •
+
+      het toerekenen van kosten bij meerdere aanslagen;
+
+      •
+
+      de afboeking van de betaling op de bestuurlijke boete;
+
+      •
+
+      de afboeking van betalingen door aansprakelijkgestelden;
+
+      •
+
+      betaling bij vergissing;
+
+      •
+
+      het verzenden van een mededeling bij een afboeking van een betaling;
+
+      •
+
+      betaling in kleine bedragen.
+
+      7.1 Tijdstip betaling
+
+      •
+
+      Als tijdstip van betaling geldt de datum van bijschrijving op de rekening van HHNK.
+
+      •
+
+      Bij betaling bij een bank of betaaldienstverlener door middel van storting van contant geld of door middel van storting
+      met een pinpas, geldt als tijdstip van betaling de eerste werkdag volgend op de dag van de storting of pin-transactie.
+      Eventuele stortingskosten zijn voor rekening van de belastingschuldige.
+
+      •
+
+      Bij rechtstreekse betaling door middel van een pin- of creditcardtransactie aan HHNK geldt de dag van de pin- of
+      creditcardtransactie als tijdstip van betaling.
+
+      •
+
+      Bij betaling aan de belastingdeurwaarder geldt de dag waarop het bedrag aan de belastingdeurwaarder is betaald.
+
+      •
+
+      Als een cheque uit het buitenland is ontvangen, wordt de dag van ontvangst van de cheque als de dag van betaling
+      beschouwd, tenzij de ontvanger constateert dat sprake is van misbruik.
+
+      7.2 De afboeking van de betaling
+
+      Bij de afboeking van betalingen gelden de volgende richtlijnen:
+
+      •
+
+      Betalingen waarvan de bestemming is aangegeven, worden afgeboekt overeenkomstig de opgave van de betaler, tenzij de
+      aangegeven bestemming strijdig is met de in artikel 7 van de wet neergelegde wijze van toerekening van betalingen.
+
+      •
+
+      Betalingen waarvoor geen bestemming is aangegeven (de zogenoemde ongerichte betalingen), worden afgeboekt op de oudste
+      openstaande belastingaanslagen, met dien verstande dat de aard van die belastingaanslagen aanleiding kan zijn hiervan
+      af te wijken.
+
+      7.3 Teveelbetaling
+
+      Als de aangegeven bestemming van de betaling een belastingaanslag betreft die al is betaald terwijl nog diverse andere
+      belastingaanslagen openstaan, wordt die betaling aangemerkt als een ongerichte betaling en dienovereenkomstig
+      behandeld.
+
+      7.4 Rente en kosten bij afboeking betalingen
+
+      Onder kosten wordt verstaan: alle kosten die op de voet van de Kostenwet invordering rijksbelastingen aan de
+      belastingschuldige in rekening worden gebracht. Hieronder vallen ook de kosten die verbonden zijn aan de werkzaamheden
+      die de belastingdeurwaarder verricht bij de invordering langs civielrechtelijke weg.
+
+      Onder rente als bedoeld in artikel 7 van de wet wordt alleen verstaan: de invorderingsrente.
+
+      7.5 Het toerekenen van kosten bij meerdere aanslagen
+
+      Kosten die niet betrekking hebben op één specifieke belastingaanslag worden toegerekend aan een van de
+      belastingaanslagen waarvoor de kosten zijn gemaakt.
+
+      7.6 Afboeking betaling op bestuurlijke boeten waarvoor uitstel van betaling is verleend
+
+      Als sprake is van een belastingaanslag en een in verband met die aanslag vastgestelde bestuurlijke boete, vindt
+      toerekening uitsluitend plaats aan de belasting, als voor de betaling van de bestuurlijke boete uitstel van betaling is
+      verleend in verband met een ingediend bezwaarschrift of beroepschrift (in hoger beroep).
+
+      Als echter – ondanks dit uitstel – zoveel wordt betaald dat er na afboeking op de belasting nog een bedrag overblijft,
+      dan wordt dit bedrag afgeboekt op de bestuurlijke boete. Als op de bestuurlijke boete is afgeboekt en de bestuurlijke
+      boete wordt alsnog aangevochten, dan blijven de afboekingen gehandhaafd.
+
+      7.7 Afboeking van betalingen door aansprakelijkgestelden
+
+      Als een betaling wordt verricht door een aansprakelijkgestelde, worden eerst de vervolgingskosten afgeboekt die aan de
+      aansprakelijkgestelde zelf in rekening zijn gebracht.
+
+      Het resterende bedrag wordt afgeboekt op de onderliggende belastingaanslag – waarbij artikel 7 van de wet wel van
+      toepassing is – echter met dien verstande dat de invorderingsrente en kosten die op die aanslag zelf betrekking hebben
+      alleen worden afgeboekt indien en voor zover men hiervoor aansprakelijk is gesteld.
+
+      Als na afboeking van genoemd resterend bedrag nog een bedrag overblijft, dan wordt dit op de belastingaanslag
+      afgeboekt, met inachtneming van de toerekeningsbepaling van artikel 7, tweede lid, van de wet. Zowel de
+      belastingschuldige als de aansprakelijkgestelde worden schriftelijk in kennis gesteld over de wijze van afboeking van
+      de betaling door de ontvanger.
+
+      7.8 Betaling bij vergissing
+
+      Met de terugbetaling van een bedrag dat is voldaan ten gevolge van een evidente vergissing of misverstand aan de zijde
+      van de betaler, wordt bijzondere voorzichtigheid betracht.
+
+      Het is zeer wel mogelijk dat de betaling niet onverschuldigd heeft plaatsgehad, zodat de schuldvordering is
+      tenietgegaan en invordering niet zonder meer opnieuw kan plaatshebben.
+
+      In die gevallen wordt het betaalde bedrag niet terugbetaald, tenzij voor de ontvanger wordt verklaard dat geen beroep
+      zal worden gedaan op het feit dat de schuld in een eerder stadium teniet is gegaan en dat de schuld te gelegener tijd
+      op juiste wijze zal worden voldaan.
+
+      Indien een bedrag wordt betaald als gewetensgeld, wordt dit gezien als het voldoen aan een natuurlijke verbintenis.
+      Terugbetaling vindt dan niet plaats.
+
+      7.9 Mededeling afboeking betaling
+
+      De ontvanger stelt de belastingschuldige niet van de afboeking van een betaling op de hoogte. Van de eventueel
+      berekende invorderingsrente stelt de ontvanger de belastingschuldige schriftelijk op de hoogte nadat de
+      belastingaanslag geheel is voldaan.
+
+      Op aanvraag van belastingschuldige kan de ontvanger een overzicht aan belastingschuldige sturen van berekende
+      invorderingsrente en -kosten indien de belastingaanslag nog niet volledig is voldaan.
+
+      Een kennisgeving blijft achterwege als betaling plaatsvindt op grond van een machtiging tot automatische afschrijving
+      en daarbij geen vervolgingskosten worden afgeboekt.
+
+      7.10 Betaling van kleine bedragen
+
+      Betalingen van belastingaanslagen in kleinere bedragen dan die van de termijnen worden niet geweigerd, tenzij dit door
+      de ambtenaar belast met invordering aangemerkt wordt als nodeloos overlast. In dat geval treedt hij in contact met de
+      belastingschuldige om de betalingswijze aan te passen.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_7
+
+  - number: 7a
+    text: |-
+      **Uitbetaling van belastingteruggaven**
+
+      Artikel 7a van de wet regelt de wijze waarop de ontvanger bedragen uitbetaalt. Uitbetaling vindt primair plaats door
+      bijschrijving op een daartoe door de belastingschuldige aangewezen bankrekening bestemd voor betaling. Het maakt
+      daarbij niet uit of bedoelde rekening op naam staat van de belastingschuldige of van een andere persoon.
+
+      In gevallen waarbij deze aanwijzing door de belastingschuldige niet heeft plaatsgevonden, kan uitbetaling van het uit
+      te betalen bedrag plaatsvinden door middel van bijschrijving op een rekening bestemd voor girale betaling, die op naam
+      staat van de belastingschuldige.
+
+      In aansluiting op artikel 4:89 Awb en artikel 7a van de wet beschrijft dit artikel het beleid over:
+
+      •
+
+      de aanwijzing van het rekeningnummer voor uitbetaling;
+
+      •
+
+      de controle van een aangewezen bankrekening op de tenaamstelling;
+
+      •
+
+      uitbetalingsfouten.
+
+      7a.1 – Aanwijzen bankrekening voor uitbetaling
+
+      De aanwijzing door de belastingschuldige vindt in beginsel plaats bij de aangifte of het verzoek in verband waarmee het
+      desbetreffende uit te betalen bedrag wordt vastgesteld. Als de belastingschuldige niet reageert op het schriftelijk ter
+      verificatie aanbieden van het bij HHNK bekende rekeningnummer door HHNK, geldt dit ook als aanwijzing.
+
+      Als de belastingschuldige bij een volgende gelegenheid met betrekking tot hetzelfde belastingmiddel en hetzelfde soort
+      uit te betalen bedrag een ander rekeningnummer aanwijst, dan wordt laatstbedoeld rekeningnummer geacht ook te zijn
+      aangewezen voor het doen van uitbetalingen voortvloeiend uit eerdere aangiften of verzoeken.
+
+      Aanwijzing moet voor het overige per uitbetaling schriftelijk plaatsvinden en wel op een zodanig tijdstip, dat daarmee
+      redelijkerwijze bij de uitbetaling rekening kan worden gehouden.
+
+      7a.2 – Controle van een aangewezen bankrekening op de tenaamstelling
+
+      Niet van toepassing voor HHNK.
+
+      7a.3 – Uitbetalingsfouten
+
+      Als uitbetaling van een uit te betalen bedrag plaatsvindt op een andere rekening van de belastingschuldige dan die
+      daarvoor door hem is aangewezen, dan moet de ontvanger in beginsel opnieuw uitbetalen. De ontvanger verbindt daaraan de
+      voorwaarde dat het eerder betaalde bedrag eerst wordt gerestitueerd.
+
+      In afwijking van de vorige volzin vindt hernieuwde uitbetaling direct plaats als de belastingschuldige aantoont dat:
+
+      •
+
+      hij tijdig vóór de uitbetaling bij de ontvanger heeft aangegeven dat de uitbetaling niet meer op de desbetreffende
+      rekening moet geschieden, en
+
+      •
+
+      hij niet over het uitbetaalde bedrag kan beschikken omdat de bankinstelling heeft aangegeven dat de rekening waarop de
+      uitbetaling heeft plaatsgevonden, geblokkeerd is.
+
+      Indien en voor zover blijkt dat het eerder betaalde bedrag niet ter beschikking van de belastingschuldige is gekomen –
+      bijvoorbeeld omdat de rekening ten tijde van de bijschrijving een debetstand kent en ook de (eventuele)
+      kredietfaciliteit van de rekening de restitutie niet toelaat – vindt hernieuwde uitbetaling direct plaats.
+
+      Indien en voor zover aan de daartoe gestelde (wettelijke) voorwaarden wordt voldaan, zal de ontvanger het aldus teveel
+      betaalde bedrag vervolgens terugvorderen uit ongerechtvaardigde verrijking.
+
+      Uitbetalingsfouten die het gevolg zijn van de aanwijzing door de belastingschuldige van een niet op zijn naam staande
+      bankrekening, blijven voor diens rekening. De ontvanger beroept zich in dat geval op het bevrijdende karakter van de
+      (uit)betaling (artikel 6:34 BW). Desgevraagd wordt de belastingschuldige op de hoogte gesteld omtrent de naam-, adres-
+      en woonplaatsgegevens van de derde aan wie onverschuldigd is betaald.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_7a
+
+  - number: 7b
+    text: |-
+      Niet van toepassing voor HHNK.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_7b
+
+  - number: '8'
+    text: |-
+      **Bekendmaking aanslag**
+
+      Artikel 8 van de wet regelt dat de ontvanger de belastingaanslag bekendmaakt door toezending of uitreiking aan de
+      belastingschuldige. De belastingschuldige is de belastingaanslag in zijn geheel verschuldigd.
+
+      In aansluiting op artikel 8 van de wet beschrijft dit artikel het beleid over:
+
+      •
+
+      de verzending of uitreiking van het aanslagbiljet in bijzondere situaties;
+
+      •
+
+      bekendmaking van de aanslag aan een rechtspersoon die (vermoedelijk) is opgehouden te bestaan;
+
+      •
+
+      de gehoudenheid tot betalen belastingaanslag en aanslagbiljet;
+
+      •
+
+      het verzenden van een uitnodiging tot betaling aan erfgenamen.
+
+      8.1 Verzending of uitreiking van het aanslagbiljet in bijzondere situaties
+
+      De toezending of uitreiking van het aanslagbiljet gebeurt aan de belastingschuldige of aan zijn wettelijke
+      vertegenwoordiger, met dien verstande dat:
+
+      •
+
+      aanslagbiljetten ten name van een onder curatele gestelde aan de curator worden gezonden;
+
+      •
+
+      ingeval van faillissement het aanslagbiljet aan de curator wordt gezonden als de belasting schuld in het faillissement
+      valt dan wel een boedelschuld vormt;
+
+      •
+
+      als de belastingschuldige minderjarig is, het aanslagbiljet aan de wettelijke vertegenwoordiger wordt gezonden als
+      bekend is dat verzending aan de belastingschuldige zelf al eerder problemen heeft opgeleverd;
+
+      •
+
+      aanslagbiljetten ten name van een belastingschuldige van wie bekend is dat hij is overleden, worden gezonden aan de
+      executeur, de bewindvoerder over de nalatenschap of de erfgenamen.
+
+      8.2 Bekendmaking als de rechtspersoon (vermoedelijk) is opgehouden te bestaan
+
+      Als een rechtspersoon (vermoedelijk) is opgehouden te bestaan, is de wijze van bekendmaking van de belastingaanslag ter
+      beoordeling aan de ontvanger. Bij deze beoordeling kunnen onder andere de volgende factoren een rol spelen:
+
+      •
+
+      het recht waarnaar de rechtspersoon is opgericht;
+
+      •
+
+      het belang van een snelle bekendmaking in verband met vrees voor onverhaalbaarheid.
+
+      8.3 Gehoudenheid tot betalen belastingaanslag en aanslagbiljet
+
+      De gehoudenheid tot betalen wordt niet ongedaan gemaakt door de omstandigheid dat de schuld vermeld op de
+      belastingaanslag afwijkt van hetgeen materieel is verschuldigd, noch door de omstandigheid dat de belastingaanslag ten
+      name staat van een ander dan degene die de belasting materieel is verschuldigd.
+
+      8.4 Vooraf uitnodigen erfgenamen tot betalen belastingaanslag
+
+      Als voor een belastingaanslag ten name van een overledene tegen de erfgenamen afzonderlijk moet worden opgetreden,
+      worden zij zoveel mogelijk vooraf schriftelijk uitgenodigd het verschuldigde binnen een redelijk termijn te voldoen.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_8
+
+  - number: '9'
+    text: |-
+      **Betalingstermijnen**
+
+      Artikel 9 van de wet regelt binnen welke betalingstermijnen belastingaanslagen moeten worden betaald.
+
+      In aansluiting op artikel 9 van de wet beschrijft dit artikel het beleid over:
+
+      •
+
+      de dagtekening van het aanslagbiljet;
+
+      •
+
+      het begrip maand bij betalingstermijnen;
+
+      •
+
+      het verzuim van de ontvanger bij uitbetaling;
+
+      •
+
+      de afwijkende betalingstermijnen;
+
+      •
+
+      de automatische incasso.
+
+      9.1 Afwijking van de betalingstermijnen in geval van voorlopige aanslagen
+
+      Niet van toepassing voor HHNK.
+
+      9.2 Afwijking van de betalingstermijnen in geval van voorlopige teruggaven
+
+      Niet van toepassing voor HHNK.
+
+      9.3 Uitbetaling voorlopige teruggave in één termijn
+
+      Niet van toepassing voor HHNK
+
+      9.4 Dagtekening aanslagbiljet
+
+      De dagtekening van het aanslagbiljet wordt normaliter zodanig bepaald dat de belastingschuldige het biljet enige dagen
+      voor de dag van dagtekening ontvangt. Hiervan kan worden afgeweken als op grond van artikel 10 van de wet versnelde
+      invordering wordt toegepast.
+
+      9.5 Begrippen bij betalingstermijnen
+
+      Als de betalingstermijn van een aanslag is gesteld op twee maanden, dan houdt dat in dat als de dagtekening van een
+      aanslagbiljet valt op 31 oktober, de betalingstermijn van twee maanden vervalt op 31 december.
+
+      9.6 Verzuim ontvanger bij uitbetaling
+
+      Op grond van artikel 2, tweede lid, onderdeel e, van de wet wordt onder het begrip ‘invorderen van rijksbelasting’ mede
+      verstaan het betalen van een terug te geven bedrag aan waterschapsbelastingen. Op grond van deze definitie is de
+      betalingstermijn voor een belastingaanslag zoals vastgelegd in de belastingverordeningen, of bij ontbreken daarvan in
+      artikel 9, eerste lid, van de wet, ook van toepassing op de uitbetaling van een belastingteruggaaf. Hieruit volgt dat
+      de ontvanger niet in verzuim is met de uitbetaling van een belastingteruggaaf zolang die binnen deze betalingstermijn
+      plaatsvindt.
+
+      9.7 Regeling betalingstermijnen
+
+      Op grond van artikel 139, eerste lid, Wschw kan de belastingverordening van een waterschap van artikel 9 van de wet
+      afwijkende voorschriften inhouden.
+
+      9.8 Automatische incasso
+
+      HHNK stelt belastingplichtigen in de gelegenheid de aanslag te voldoen via een automatische incasso. Nadere regels
+      hieromtrent zijn vastgelegd in het Reglement automatische incasso waterschapsbelastingen HHNK dat als bijlage bij deze
+      leidraad is bijgevoegd.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_9
+
+  - number: '10'
+    text: |-
+      **Versnelde invordering**
+
+      Artikel 10, eerste lid, van de wet geeft een limitatieve opsomming van bijzondere situaties waarin de ontvanger met
+      doorbreking van de in artikel 9 van de wet voorgeschreven betalingstermijnen een belastingaanslag terstond en tot het
+      volle bedrag kan invorderen.
+
+      Artikel 10, tweede en derde lid, van de wet bevatten uitzonderingsbepalingen met betrekking tot de toepassing van deze
+      versnelde invordering.
+
+      In aansluiting op artikel 10 van de wet beschrijft dit artikel het beleid over:
+
+      •
+
+      de reikwijdte van de versnelde invordering;
+
+      •
+
+      de vrees voor verduistering;
+
+      •
+
+      het metterwoon verlaten van Nederland;
+
+      •
+
+      geen vaste woonplaats in Nederland;
+
+      •
+
+      als er al beslag ligt;
+
+      •
+
+      de verkoop namens derden;
+
+      •
+
+      de vordering ex artikel 19.
+
+      10.1 Reikwijdte versnelde invordering
+
+      Als de ontvanger het in een specifiek geval noodzakelijk acht daadwerkelijk tot versnelde invordering (als bedoeld in
+      artikel 10 van de wet) over te gaan, dan vermeldt hij op het uit te reiken of te verzenden aanslagbiljet dat de
+      belastingaanslag terstond en tot het volle bedrag invorderbaar is. Voorts vermeldt de ontvanger op het aanslagbiljet
+      het onderdeel van het eerste lid van artikel 10 van de wet op grond waarvan hij tot versnelde invordering overgaat.
+
+      Als versnelde invordering zich voordoet nadat het aanslagbiljet is uitgereikt of verzonden – maar voordat de
+      belastingaanslag (geheel) invorderbaar is – deelt de ontvanger de belastingschuldige schriftelijk mee dat hij de
+      belastingaanslag terstond en tot het volle bedrag invorderbaar verklaart en dat de op het aanslagbiljet vermelde
+      betalingstermijnen niet meer gelden. Hij doet dit eveneens onder opgave van het onderdeel van het eerste lid van
+      artikel 10 van de wet op grond waarvan hij tot versnelde invordering overgaat.
+
+      Veelal zal dan ook gebruik worden gemaakt van de versnelde dwanginvorderingsprocedure als bedoeld in artikel 15 van de
+      wet, zodat vermelding op het dwangbevel dat de belastingaanslag terstond en tot het volle bedrag invorderbaar is
+      verklaard tot de mogelijkheden van mededeling behoort. In het laatste geval zal de betekening van het dwangbevel
+      overigens niet per post kunnen plaatsvinden. De belastingdeurwaarder zal voordat tot de versnelde dwanginvordering als
+      bedoeld in artikel 15 van de wet wordt overgegaan – als sprake is van direct contact met de belastingschuldige – deze
+      eerst in de gelegenheid stellen om onmiddellijk te betalen.
+
+      Als versnelde invordering zich voordoet nadat een dwangbevel is betekend – maar voordat de termijn van twee dagen van
+      het bevel tot betaling is verstreken (bij een per post betekend dwangbevel in feite vier dagen) – vermeldt de ontvanger
+      op het beslagexploot of op een aparte schriftelijke kennisgeving: artikel 15 in combinatie met artikel 10, eerste lid,
+      van de wet, gevolgd door het desbetreffende onderdeel.
+
+      Hetzelfde geldt als de noodzaak tot versnelde invordering zich voordoet na het betekenen van het hernieuwd bevel tot
+      betaling en de tweedagentermijn die daarbij geldt nog niet is verstreken. Er hoeft geen nieuw dwangbevel te worden
+      betekend. De belastingschuldige wordt – als sprake is van direct contact met laatstgenoemde – eerst in de gelegenheid
+      gesteld om onmiddellijk te betalen.
+
+      Een belastingaanslag die op grond van artikel 10, eerste lid, van de wet terecht geheel opeisbaar is geworden, blijft
+      geheel opeisbaar ook al zouden de feiten en omstandigheden die daartoe aanleiding hebben gevormd zich niet langer
+      voordoen. Op verzoek van de belastingschuldige verleent de ontvanger in zo'n situatie altijd uitstel van betaling, welk
+      uitstel overeenkomt met de betalingstermijn(en) die normaal zou(den) gelden.
+
+      10.2 Vrees voor verduistering en versnelde invordering
+
+      Van gegronde vrees voor verduistering van goederen van de belastingschuldige als bedoeld in artikel 10, eerste lid,
+      onderdeel b, van de wet is sprake, als de ontvanger aannemelijk kan maken dat redelijkerwijs te verwachten is dat niet
+      alleen het verhaal op een aantal goederen van de belastingschuldige metterdaad onmogelijk zal worden gemaakt, maar ook
+      dat daardoor de verhaalbaarheid van de belastingschuld in ernstig gevaar zal komen.
+
+      De vrees voor verduistering zal in de regel gelegen zijn in gedragingen van de belastingschuldige, maar kan in bepaalde
+      situaties ook ontstaan door gedragingen van derden (bijvoorbeeld crediteuren), die aanleiding geven voor de
+      veronderstelling dat voor onverhaalbaarheid moet worden gevreesd.
+
+      Als verduistering wordt gevreesd van goederen waarvan na versnelde beslaglegging blijkt dat deze uitsluitend van een
+      derde zijn, is niet voldaan aan artikel 10, eerste lid, onderdeel b, van de wet en is het beslag niet rechtsgeldig. Het
+      beslag hoeft dan niet formeel te worden opgeheven, maar de ontvanger moet de betrokkenen wel informeren over het feit
+      dat er geen beslag ligt.
+
+      10.3 Metterwoon verlaten van Nederland en versnelde invordering
+
+      Naast het redelijke vermoeden van de ontvanger dat de belastingschuldige van plan is Nederland metterwoon te verlaten,
+      dan wel zijn plaats van vestiging naar een plaats buiten Nederland wil verplaatsen, moet de ontvanger – alvorens de
+      belastingaanslag op grond van artikel 10, eerste lid, onderdeel c, van de wet dadelijk en tot het volle bedrag
+      invorderbaar te verklaren – er in redelijkheid van overtuigd zijn dat de belastingaanslag na het verstrijken van de
+      gebruikelijke betalingstermijn niet meer verhaald kan worden op goederen van de belastingschuldige die zich in
+      Nederland bevinden.
+
+      10.4 Geen vaste woonplaats in Nederland en versnelde invordering
+
+      Het enkele feit dat de belastingschuldige buiten Nederland woont of is gevestigd, is op zich geen reden voor de
+      ontvanger om de belastingaanslag dadelijk en tot het volle bedrag in te vorderen. Er moet een situatie bestaan waarin
+      de ontvanger er redelijkerwijs vanuit kan gaan dat de belastingschuld niet binnen de termijnen zal worden voldaan en de
+      belastingschuld niet in Nederland kan worden verhaald.
+
+      10.5 Beslag en versnelde invordering
+
+      Nadat de ontvanger verhaalsbeslag heeft doen leggen op bepaalde goederen, zijn andere belastingschulden van de
+      belastingschuldige – waaronder hier wordt verstaan alle schulden waarvan de invordering aan de ontvanger is opgedragen
+      – dadelijk en ineens invorderbaar.
+
+      10.6 Verkoop namens derden en versnelde invordering
+
+      Ingeval van dwanginvordering door derden kan de dadelijke invorderbaarheid pas ontstaan door de (aankondiging van de)
+      executoriale verkoop, zodat de ontvanger op deze grond niet eerder maatregelen kan treffen dan op het moment dat
+      redelijkerwijs vaststaat dat verkoop zal plaatshebben.
+
+      10.7 Vordering ex artikel 19 en versnelde invordering
+
+      De ontvanger mag geen vordering als bedoeld in artikel 19 van de wet doen, enkel om te bereiken dat daardoor een
+      belastingaanslag terstond en tot het volle bedrag invorderbaar wordt.
+
+      Als de ontvanger met betrekking tot een bepaalde belastingaanslag een vordering jegens een derde heeft gedaan en nadien
+      worden andere belastingaanslagen opgelegd, dan kunnen ook die aanslagen tot het volle bedrag worden ingevorderd, ook
+      als de betalingstermijnen van die nieuwe aanslagen nog niet zijn verstreken.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_10
+
+  - number: '11'
+    text: |-
+      **Aanmaning**
+
+      In artikel 11 van de wet is opgenomen dat als een belastingaanslag niet binnen de daartoe gestelde termijnen wordt
+      betaald, de ontvanger overgaat tot vervolging van de belastingschuldige door de verzending van een aanmaning.
+
+      In aansluiting op artikel 11 van de wet beschrijft dit artikel het beleid over:
+
+      •
+
+      de geadresseerde van de aanmaning;
+
+      •
+
+      als de aanmaning ten onrechte is verzonden;
+
+      •
+
+      het achterwege laten van tussentijdse vervolging;
+
+      •
+
+      de gedeeltelijke voldoening na aanmaning;
+
+      •
+
+      de betalingsherinnering;
+
+      •
+
+      de aanmaning bij invordering langs civielrechtelijke weg.
+
+      11.1 De geadresseerde van de aanmaning
+
+      De ontvanger zendt de aanmaning aan degene aan wie het aanslagbiljet is verzonden of uitgereikt.
+
+      Als naderhand blijkt dat de ontvanger de vervolging voort moet zetten voor een belastingschuldige die minderjarig is of
+      onder curatele staat, dan zendt de ontvanger alsnog een aanmaning naar het adres van de wettelijke vertegenwoordiger.
+
+      Als de belastingschuldige is overleden, dan zendt de ontvanger de aanmaning naar de gezamenlijke erfgenamen. Als de
+      ontvanger weet dat de nalatenschap al is verdeeld, dan zendt hij een aanmaning aan iedere erfgenaam afzonderlijk.
+
+      11.2 Aanmaning ten onrechte verzonden
+
+      Als een belanghebbende zich tot de ontvanger wendt met de mededeling dat hem ten onrechte een aanmaning is toegezonden,
+      dan wordt de vervolging niet voortgezet voordat dit is opgehelderd.
+
+      Als de ontvanger concrete aanwijzingen heeft dat moet worden gevreesd voor de verhaalbaarheid van de
+      belastingaanslagen, of dat de mededeling is gedaan om de invordering te traineren, dan kan hij maatregelen nemen die de
+      rechten van de fiscus veilig stellen.
+
+      11.3 Achterwege laten van tussentijdse vervolging en aanmaning
+
+      Niet van toepassing voor HHNK.
+
+      11.4 Gedeeltelijke voldoening aan de aanmaning
+
+      Als na de verzending van een aanmaning een gedeelte van het achterstallige bedrag wordt voldaan, dan wordt de
+      uitvaardiging van een dwangbevel voor het restant niet door een nieuwe aanmaning voorafgegaan.
+
+      11.5 Betalingsherinnering
+
+      Als de aard of omvang van de belastingschuld dan wel het betalingsgedrag van de belastingschuldige daartoe aanleiding
+      geven, kan de ontvanger de belastingschuldige eerst (kosteloos) een schriftelijke betalingsherinnering toezenden.
+
+      Als er geen betalingsherinnering wordt verzonden of als deze niet of niet tijdig tot algehele voldoening van de
+      belastingschuld leidt, verzendt de ontvanger een aanmaning.
+
+      11.6 Aanmaning bij invordering langs civielrechtelijke weg
+
+      Als de ontvanger invordert langs civielrechtelijke weg, dan gaat de ontvanger over tot het uitbrengen van een
+      dagvaarding. De dagvaarding hoeft niet vooraf te worden gegaan door een ingebrekestelling. Wel verzendt de ontvanger
+      eerst een aanmaning.
+
+      De ontvanger verzendt echter geen aanmaning als reeds conservatoir beslag is gelegd.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_11
+
+  - number: '12'
+    text: |-
+      **Dwangbevel**
+
+      Artikel 12 van de wet bepaalt dat de ontvanger een dwangbevel kan uitvaardigen als de belastingschuldige na de
+      aanmaning in gebreke blijft de belastingaanslag te betalen.
+
+      Op grond van dit dwangbevel kan de ontvanger overgaan tot invordering van de belastingaanslag.
+
+      In aansluiting op artikel 12 van de wet beschrijft dit artikel het beleid over:
+
+      •
+
+      het onderwerp van het dwangbevel;
+
+      •
+
+      tegen wie een dwangbevel wordt verleend.
+
+      12.1 Onderwerp van het dwangbevel
+
+      De ontvanger vaardigt een dwangbevel uit voor het per saldo verschuldigde bedrag vermeld op een aanslagbiljet van
+      voorkomende belastingaanslagen en beschikkingen.
+
+      Als een bedrag in termijnen mag worden voldaan, vaardigt de ontvanger een dwangbevel uit voor het per saldo
+      verschuldigde bedrag van de termijnen waarvoor een aanmaning is verzonden.
+
+      De ontvanger vermindert het bedrag van een dwangbevel met:
+
+      •
+
+      de inmiddels gedane betalingen;
+
+      •
+
+      verleende verminderingen;
+
+      •
+
+      bedragen waarvoor kwijtschelding of uitstel van betaling is verleend.
+
+      12.2 Tegen wie verleent de ontvanger een dwangbevel
+
+      De ontvanger verleent een dwangbevel tegen de belastingschuldige of diens rechtsopvolgers. Als de ontvanger het
+      dwangbevel verleent tegen een ander dan de belastingschuldige, moet duidelijk blijken op welke gronden dit gebeurt.
+
+      Als de ontvanger bekend is met de minderjarigheid of curatele van een belastingschuldige, dan brengt hij dit in het
+      dwangbevel tot uitdrukking. Als de ontvanger hiermee niet bekend is, hoeft hij niet vooraf een daarop gericht onderzoek
+      in te stellen.
+
+      Als de ontvanger een belastingschuld van een overledene moet verhalen op diens onverdeelde nalatenschap, verleent hij
+      één dwangbevel tegen de gezamenlijke erfgenamen.
+
+      Als betekening ten aanzien van de gezamenlijke erfgenamen van een overledene op de voet van artikel 53 Rv niet mogelijk
+      of niet wenselijk is, dan vermeldt de ontvanger alle erfgenamen met naam en adres alsmede met hun kwaliteit van
+      erfgenaam van de overleden belastingschuldige in het dwangbevel. De ontvanger brengt daarbij evenwel niet het deel van
+      ieders aansprakelijkheid tot uitdrukking.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_12
+
+  - number: '13'
+    text: |-
+      **Betekening van het dwangbevel**
+
+      In artikel 13 van de wet is de wijze van betekening van het dwangbevel beschreven. Het dwangbevel wordt bekendgemaakt
+      door middel van betekening. De betekening van het dwangbevel met bevel tot betaling kan plaatsvinden:
+
+      •
+
+      door de belastingdeurwaarder;
+
+      •
+
+      per post door de ontvanger.
+
+      De ontvanger maakt zoveel mogelijk gebruik van de mogelijkheid het dwangbevel per post te betekenen.
+
+      In aansluiting op artikel 13 van de wet beschrijft dit artikel het beleid over:
+
+      •
+
+      de betekening van het dwangbevel per post;
+
+      •
+
+      de betekening van het dwangbevel door de deurwaarder;
+
+      •
+
+      bijzondere gevallen van betekening van het dwangbevel.
+
+      13.1 Betekening dwangbevel per post
+
+      De betekening van het dwangbevel per post met het bevel tot betaling vindt plaats door het ter post bezorgen door de
+      ontvanger van een voor de belastingschuldige bestemd afschrift van het dwangbevel met bevel tot betaling.
+
+      Onder ter post bezorging wordt verstaan: het door de ontvanger ter verzending aanbieden van het afschrift aan een
+      externe bezorger van poststukken. Als betekeningsdatum geldt in het algemeen de datum van de terpostbezorging.
+
+      De ontvanger maakt zoveel mogelijk gebruik van de mogelijkheid het dwangbevel per post te betekenen.
+
+      13.1.1 Adressering van per post betekende dwangbevelen
+
+      Verzending van het voor de belastingschuldige bestemde afschrift van het dwangbevel met bevel tot betaling vindt plaats
+      aan het in de administratie van HHNK bekende adres van de belastingschuldige.
+
+      Voor in Nederland woonachtige natuurlijke personen zal dit over het algemeen het adres van de belastingschuldige zijn,
+      dat in de Basisregistratie personen is geregistreerd. Als de belastingschuldige te kennen heeft gegeven voor hem
+      bestemde poststukken te willen ontvangen op een ander adres dan het adres volgens de Basisregistratie personen –
+      bijvoorbeeld een postbusadres – kan verzending ook plaatsvinden aan dat adres.
+
+      Als achteraf mocht blijken dat het afschrift van het dwangbevel aan een – ten tijde van de terpostbezorging – onjuist
+      adres is verzonden en de belastingschuldige niet heeft bereikt, dan wordt aan het dwangbevel geen rechtsgevolg
+      verbonden.
+
+      Als het afschrift van het dwangbevel aan het juiste adres van de belastingschuldige is verzonden, maar laatstgenoemde
+      beweert het afschrift niet te hebben ontvangen, dan geldt het dwangbevel als betekend. Dit is niet het geval als de
+      belastingschuldige bijzondere omstandigheden aannemelijk kan maken op grond waarvan moet worden aangenomen dat het
+      afschrift van het dwangbevel het bestemde adres niet heeft bereikt.
+
+      13.2 Betekening dwangbevel door de belastingdeurwaarder
+
+      Als bij de betekening van een dwangbevel door de belastingdeurwaarder aanwijzingen bestaan dat de belastingschuldige
+      bezwaar heeft tegen kennisneming van de inhoud van het dwangbevel door de huisgenoot aan wie de belastingdeurwaarder
+      het afschrift moet achterlaten, dan betekent de belastingdeurwaarder het dwangbevel op de wijze als bepaald in artikel
+      47, eerste lid, Rv.
+
+      Deze handelwijze volgt de belastingdeurwaarder ook als hij verwacht dat achterlating van het afschrift van het
+      dwangbevel aan de huisgenoot er niet toe zal leiden dat het afschrift de belastingschuldige ook daadwerkelijk zal
+      bereiken.
+
+      Bij de betekening van het dwangbevel wordt domicilie gekozen op het adres van HHNK waar de belastingdeurwaarder zijn
+      standplaats heeft, tenzij de belastingdeurwaarder in dienst is bij een extern deurwaarderskantoor. In dat geval wordt
+      domicilie gekozen op het adres van het deurwaarderskantoor.
+
+      De domiciliekeuze geldt ook voor de situaties waarin het dwangbevel is uitgevaardigd door de ontvanger van een ander
+      waterschap.
+
+      13.3 Bijzondere gevallen van betekening dwangbevel
+
+      Een dwangbevel dat – hetzij door terpostbezorging, hetzij door de belastingdeurwaarder – is betekend aan een
+      minderjarige of onder curatele gestelde, moet mede worden betekend aan de wettelijke vertegenwoordiger alvorens tot
+      tenuitvoerlegging ervan kan worden overgegaan. Zo nodig zal aan de laatstbedoelde betekening het verzenden van een
+      aanmaning aan de wettelijke vertegenwoordiger voorafgaan.
+
+      Ten aanzien van schippers zonder vaste woonplaats aan de wal, is betekening mogelijk op het adres van het verplicht
+      gekozen domicilie.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_13
+
+  - number: '14'
+    text: |-
+      **Tenuitvoerlegging van het dwangbevel**
+
+      Artikel 14 van de wet gaat over de tenuitvoerlegging van het dwangbevel.
+
+      In aansluiting op artikel 4:116 Awb en artikel 14 van de wet beschrijft dit artikel het beleid over:
+
+      •
+
+      de algemene regels over tenuitvoerlegging;
+
+      •
+
+      beslag op roerende zaken die geen registergoederen zijn;
+
+      •
+
+      beslag op onroerende zaken;
+
+      •
+
+      beslag onder derden;
+
+      •
+
+      beslag op schepen.
+
+      14.1 Tenuitvoerlegging algemeen
+
+      14.1.1 Keuze van invorderingsmaatregelen [Vervallen per 10-11-2020]
+
+      14.1.2 Houding van de belastingdeurwaarder tijdens tenuitvoerlegging
+
+      De tenuitvoerlegging van verschillende dwangbevelen tegen dezelfde belastingschuldige gebeurt zoveel mogelijk
+      tegelijkertijd. Bij de tenuitvoerlegging wordt onnodige ruchtbaarheid vermeden. Ook wordt de nodige soepelheid
+      betracht. Dit brengt met zich mee dat de formeel voorgeschreven handelwijze wordt onderbroken, als het uit menselijk of
+      tactisch oogpunt wenselijk is eerst persoonlijk contact met de belastingschuldige op te nemen.
+
+      In dit verband kan het verantwoord zijn dat de belastingdeurwaarder niet dadelijk tot beslaglegging overgaat of deze
+      onderbreekt of beëindigt, als hij vermoedt dat de ontvanger de beslagopdracht niet zou hebben gegeven als alle
+      omstandigheden bekend waren geweest.
+
+      Dit geldt ook als de belastingschuldige aantoont dat de betaling inmiddels heeft plaatsgevonden of dat een verzoek om
+      uitstel van betaling of kwijtschelding, dan wel een verzoekschrift als genoemd in artikel 25.1 (uitstel) of 26.1
+      (kwijtschelding) van deze leidraad, en de beslagopdracht elkaar hebben gekruist.
+
+      Als het dwangbevel eenmaal ten uitvoer is gelegd door middel van beslag, wordt onverwijld tot uitwinning van de
+      goederen waarop beslag is gelegd, overgegaan. Hiervan kan worden afgeweken als de belastingschuldige een voorstel doet
+      tot minnelijke afdoening van het beslag. Voorwaarde is dan wel dat met de afdoening – gelet op de omstandigheden – naar
+      het oordeel van de ontvanger akkoord kan worden gegaan. Hierbij geldt als uitgangspunt dat een minnelijke afdoening
+      moet passen in het in deze leidraad geformuleerde beleid.
+
+      14.1.3 Tenuitvoerlegging dwangbevel als de belastingschuldige is overleden
+
+      Als degene tegen wie het dwangbevel is uitgevaardigd, is overleden, gaat de belastingdeurwaarder pas tot
+      tenuitvoerlegging over nadat de termijn van drie maanden als bedoeld in artikel 4:185 BW, is verstreken.
+
+      Als alle erfgenamen de nalatenschap zuiver hebben aanvaard, kan de rechtbank de termijn van drie maanden verlengen.
+
+      Als de nalatenschap wordt vereffend, kan de ontvanger gedurende de vereffening zijn vordering niet op de nalatenschap
+      verhalen.
+
+      14.1.4 Volgorde van uitwinning bij beslag
+
+      Als de ontvanger naast zaken van de belastingschuldige, ook zaken in beslag heeft genomen waar derden rechten op
+      hebben, dan wint hij die zaken uit in de volgorde:
+
+      •
+
+      zaken van belastingschuldige zelf;
+
+      •
+
+      zaken waar anderen dan de belastingschuldige een beperkt recht op hebben;
+
+      •
+
+      zaken die eigendom zijn van derden.
+
+      De ontvanger hoeft deze volgorde niet in acht te nemen als op voorhand duidelijk is dat:
+
+      •
+
+      de hoogte van de belastingschuld aantasting van de rechten van derden onvermijdelijk maakt of;
+
+      •
+
+      het belang van de invordering zich hiertegen verzet.
+
+      14.1.5 Verhaal op met vruchtgebruik of recht van gebruik bezwaarde zaken
+
+      Voordat verhaal wordt gezocht op met vruchtgebruik of recht van gebruik bezwaarde zaken, of op goederen verkregen onder
+      de ontbindende voorwaarde van overlijden waarbij zich een opschortende voorwaarde ten gunste van een verwachter
+      aansluit, licht de ontvanger andere belanghebbenden dan de erfgenamen van de belastingschuldige zoveel mogelijk in over
+      zijn voornemen.
+
+      14.1.6 Beslaglegging voor vordering van derden
+
+      Als de ontvanger voor een belastingschuld beslag heeft gelegd, gaat hij ook over tot beslaglegging voor vorderingen van
+      derden met gelijke preferentie, waarvan de invordering aan hem is opgedragen, ongeacht de executiewaarde van de in
+      beslag genomen zaken.
+
+      14.1.7 Opheffing beslag na gedeeltelijke betaling of voldoening aan voorwaarden
+
+      De ontvanger kan een beschikking afgegeven, die inhoudt dat voor een openstaande belasting schuld geen
+      invorderingsmaatregelen meer worden getroffen wanneer alsnog een bepaald bedrag wordt voldaan dan wel dat aan bepaalde
+      voorwaarden moet zijn voldaan.
+
+      De ontvanger heft de gelegde beslagen op nadat dit bedrag is betaald of aan die voorwaarden is voldaan.
+
+      14.1.8 Opheffing beslag tegen betaling door een derde
+
+      Als de ontvanger van een derde een bedrag krijgt aangeboden ter opheffing van het beslag, dan kan de ontvanger hieraan
+      zijn medewerking verlenen als ten minste is voldaan aan de volgende voorwaarden:
+
+      •
+
+      het aangeboden geldbedrag komt niet direct of indirect uit het vermogen van de belastingschuldige;
+
+      •
+
+      het aangeboden geldbedrag is aanzienlijk hoger dan de opbrengst die naar verwachting zou zijn verkregen bij een
+      executie;
+
+      •
+
+      de belangen van HHNK worden niet geschaad.
+
+      De ontvanger houdt bij zijn beslissing rekening met de gerechtvaardigde belangen van andere schuldeisers die op de
+      betreffende zaken verhaal zoeken, en hij kan aan zijn medewerking nadere voorwaarden verbinden.
+
+      14.1.9 Opschorten van de executie
+
+      De belastingdeurwaarder stelt bij het opmaken van het proces-verbaal van beslag een verkoopdatum vast. Op deze datum
+      vindt de openbare verkoop plaats, tenzij de ontvanger ervan overtuigd is dat betaling van de belastingschuld alsnog op
+      zeer korte termijn zal plaatsvinden. In dat geval kan de ontvanger besluiten de verkoopdatum op te schorten tot (in
+      totaal) maximaal vier maanden na de datum waarop het beslag is gelegd.
+
+      Als sprake is van beslag op roerende zaken, dan deelt de belastingdeurwaarder de nieuwe verkoopdatum bij exploot aan de
+      belastingschuldige mee, tenzij deze nieuwe datum op grond van een schriftelijke overeenkomst tussen de ontvanger en de
+      belastingschuldige is verschoven. Het opschorten van de verkoopdatum houdt op zich geen uitstel van betaling in, in de
+      zin van artikel 25 van de wet.
+
+      14.1.10 Onderhandse verkoop [Vervallen per 10-11-2020]
+
+      14.1.11 Samenloop opheffing beslag en onderhandse verkoop [Vervallen per 10-11-2020]
+
+      14.1.12 Strafrechtelijk beslag
+
+      Als op een in beslag genomen goed ook een strafrechtelijk beslag ex artikel 94 Sv rust – dat wil zeggen niet zijnde een
+      beslag in het kader van een ontnemingsmaatregel – dan wordt het beslag dat de belastingdeurwaarder heeft gelegd pas
+      vervolgd nadat het strafrechtelijke beslag is opgeheven.
+
+      Zolang niet duidelijk is wat er met het strafrechtelijke beslag gebeurt, kan het fiscale beslag blijven liggen.
+
+      14.1.13 Invordering en ontnemingswetgeving
+
+      HHNK belemmert zo min mogelijk de strafrechtelijke sanctionering en ontneming van wederrechtelijk verkregen voordelen,
+      tenzij hiermee de belangen van HHNK worden geschaad. Hierbij is het niet van belang of de erfgenamen de nalatenschap
+      zuiver hebben aanvaard.
+
+      14.2 Beslag op roerende zaken die geen registergoederen zijn
+
+      14.2.1 Kennisgeving vooraf en beslag roerende zaken
+
+      Als de belastingdeurwaarder op het woonadres van de belastingschuldige niemand thuis treft en beslag op roerende zaken
+      alleen kan plaatsvinden met gebruikmaking van artikel 444 Rv, dan blijft deze wijze van tenuitvoerlegging vooralsnog
+      achterwege.
+
+      De belastingdeurwaarder laat in dat geval een schriftelijke kennisgeving achter met vermelding van dag en uur waarop
+      hij zich weer op het woonadres zal vervoegen.
+
+      Deze handeling blijft achterwege als een belastingschuldige het stelselmatig hierop laat aankomen, dan wel van deze
+      handelwijze misbruik wordt gemaakt of op andere wijze het belang van de invordering zich tegen deze handelwijze verzet.
+
+      14.2.2 Domiciliekeuze en beslag roerende zaken
+
+      Als het beslag wordt gelegd door een belastingdeurwaarder van een ander waterschap dan het kantoor waar bij de
+      betekening van het dwangbevel domicilie is gekozen, dan wordt in het beslag-exploot tevens domicilie gekozen ten
+      kantore van HHNK waar de belastingdeurwaarder die het beslag legt zijn standplaats heeft.
+
+      14.2.3 Aanbod van betaling en beslag roerende zaken
+
+      Als de belastingschuldige ter voorkoming van beslaglegging aan de belastingdeurwaarder aanbiedt om ter plekke te
+      betalen, aanvaardt de deurwaarder deze betaling.
+
+      Van de betaling wordt een kwitantie opgemaakt, waarvan een afschrift aan de belastingschuldige wordt gelaten.
+
+      14.2.4 Omvang van het beslag op roerende zaken
+
+      1.
+
+      Het beslag wordt gelegd op zoveel zaken als, naar het oordeel van de belastingdeurwaarder, in elk geval nodig is voor
+      dekking van de openstaande schuld inclusief rente en kosten.
+
+      2.
+
+      Gezien het bepaalde in artikel 441, derde lid, Rv, wordt geen beslag gelegd op zaken indien redelijkerwijs voorzienbaar
+      is dat de opbrengst die gerealiseerd kan worden door het verhaal op die zaken aanmerkelijk minder bedraagt dan de
+      kosten van de beslaglegging en de daaruit voortvloeiende executie. De belastingdeurwaarder kan wel beslag leggen op
+      deze zaken als de belastingschuldige door het beslag en de executie niet op onevenredig zware wijze in zijn belangen
+      wordt getroffen. Daarvan is sprake als het aannemelijk is dat het onbetaald blijven van de belastingschulden waarvoor
+      beslag wordt gelegd, te wijten is aan onwil van de belastingschuldige of als het aannemelijk is dat door de
+      executoriale verkoop van de betreffende zaken kan worden voorkomen dat belastingschulden verder oplopen.
+
+      14.2.5 Beslag op roerende zaken van derden
+
+      Niet van toepassing voor HHNK.
+
+      14.2.6 Beroep of verzet door een derde tegen inbeslagneming roerende zaken
+
+      Als een derde bij de belastingdeurwaarder bezwaar maakt tegen de inbeslagname van bepaalde roerende zaken waarvan hij
+      de eigendom claimt, wijst de belastingdeurwaarder op de mogelijkheid een beroepschrift in te dienen bij D&H op grond
+      van artikel 22, eerste lid, van de wet en eventueel in verzet te gaan op grond van artikel 456 of artikel 435 Rv.
+
+      Als aan de eigendom van een derde niet kan worden getwijfeld en vaststaat dat de ontvanger zijn verhaalsrecht niet kan
+      effectueren, blijft inbeslagname achterwege.
+
+      14.2.7 Voldoening zekerheidsschuld door ontvanger en beslag roerende zaken
+
+      De ontvanger kan het restant van de schuld van belastingschuldige aan een derde op grond van artikel 6:30 BW voldoen in
+      afwachting van verrekening met de belastingschuldige, als de belastingdeurwaarder de volgende zaken aantreft:
+
+      •
+
+      zaken die niet onder het bodemrecht vallen
+
+      •
+
+      eigendom zijn van een derde en;
+
+      •
+
+      strekken tot zekerheid voor de voldoening van een schuld die de belastingschuldige aan de derde heeft (bijvoorbeeld
+      huurkoop, eigendomsvoorbehoud) en;
+
+      •
+
+      waarop de ontvanger zich na voldoening van die schuld zou kunnen verhalen.
+
+      De ontvanger maakt van deze mogelijkheid slechts gebruik als de executiewaarde van de desbetreffende zaken beduidend
+      hoger is dan het restant van de schuld. Dit geldt ook als het gaat om zaken van de belastingschuldige die bij een derde
+      in beslag zijn genomen en waarop deze derde een retentierecht heeft.
+
+      14.2.8 Beslag roerende zaken bij derden
+
+      Op zaken van de belastingschuldige die zich bij een derde bevinden, verhaalt de belastingdeurwaarder de belastingschuld
+      zoveel mogelijk door het leggen van een beslag op roerende zaken.
+
+      De deurwaarder zal in de volgende gevallen echter beslag onder derden leggen als:
+
+      •
+
+      de derde geen medewerking verleent aan het leggen van een beslag roerende zaken;
+
+      •
+
+      het voor de belastingdeurwaarder feitelijk onmogelijk is om de zaken zelf te zien, dan wel te inventariseren;
+
+      •
+
+      de derde een beroep doet als bedoeld in artikel 461d Rv, voordat het exploot van beslag op roerende zaken is
+      afgesloten.
+
+      Als de derde een dergelijk beroep doet nadat het exploot van beslag op roerende zaken is afgesloten, legt de
+      belastingdeurwaarder geen afzonderlijk derdenbeslag maar geldt het beslag roerende zaken als derdenbeslag. De
+      belastingdeurwaarder betekent in dat geval een formulier als bedoeld in artikel 475, tweede lid, Rv, binnen drie dagen
+      nadat de derde zich erop heeft beroepen dat hij het beslag niet behoeft te dulden.
+
+      Dit laatste geldt ook als de verwachting is gerechtvaardigd dat de derde voor de executoriale verkoop een beroep zal
+      doen als bedoeld in artikel 461d Rv.
+
+      14.2.9 Wegvoeren van beslagen zaken
+
+      Nadat op roerende zaken beslag is gelegd, wordt zoveel mogelijk aan de belastingschuldige het feitelijk gebruik
+      gelaten.
+
+      Onder bijzondere omstandigheden kan de belastingdeurwaarder beslagen zaken wegvoeren. Hij stelt daartoe een
+      gerechtelijke bewaarder aan als bedoeld in Rv. Het aanstellen van een bewaarder ontheft de ontvanger niet van zijn
+      verantwoordelijkheid met betrekking tot de in beslag genomen zaken.
+
+      Het wegvoeren van zaken is mogelijk, als dit voor het behoud van die zaken redelijkerwijze noodzakelijk is (artikel 446
+      Rv). Dit is bijvoorbeeld aan de orde als de zaken dreigen te worden verduisterd of beschadigd. Hetzelfde geldt als er
+      gegronde vrees bestaat dat verhaal op de zaken ernstig bemoeilijkt wordt of feitelijk onmogelijk is, indien de zaken
+      niet worden afgevoerd. Bijvoorbeeld als de belastingdeurwaarder administratief beslag als bedoeld in artikel 442,
+      eerste lid, Rv, heeft gelegd op een motorrijtuig of een aanhangwagen, en de geëxecuteerde het motorrijtuig of de
+      aanhangwagen niet heeft ingeleverd, nadat de belastingdeurwaarder hem daartoe twee keer in de gelegenheid heeft
+      gesteld.
+
+      Van de mogelijkheid tot het wegvoeren van de beslagen zaken wordt slechts gebruikgemaakt:
+
+      •
+
+      als de verwachting bestaat dat zonder het wegvoeren de schuld niet volledig kan worden ingevorderd en;
+
+      •
+
+      de ontvanger na marginale toetsing niet heeft kunnen constateren dat de belastingaanslagen materieel onverschuldigd
+      moeten worden geacht.
+
+      Het wegvoeren van zaken gebeurt niet door de belastingdeurwaarder dan na daartoe verkregen toestemming van de ontvanger
+      van HHNK, of zijn plaatsvervanger.
+
+      Bij het in beslag nemen van een voertuig is het aan de belastingdeurwaarder ter keuze om een wielklem, of een ander
+      middel, aan te brengen ter zekerheid tegen verduistering.
+
+      Het wegvoeren van zaken, waaronder motorrijtuigen naar aanleiding van een actie op grond van artikel 18 van de wet,
+      gebeurt niet dan na daartoe verkregen toestemming van de ontvanger van HHNK of zijn plaatsvervanger waar de
+      belastingdeurwaarder die de zaken wil wegvoeren werkzaam is.
+
+      14.2.10 Belasting van personenauto’s en motorrijwielen en belasting zware motorrijtuigen en beslag roerende zaken
+
+      Niet van toepassing voor HHNK.
+
+      14.2.11 Afsluiting en beslag roerende zaken
+
+      De deurwaarder dan wel de bewaarder kan tot afsluiting van de ruimte overgaan waarin ten laste van de onderneming in
+      beslag genomen zaken zich bevinden, als:
+
+      •
+
+      de omstandigheden zich voordoen als genoemd in artikel 14.2.9 van deze leidraad en;
+
+      •
+
+      de desbetreffende zaken niet of slechts tegen naar verhouding zeer hoge kosten kunnen worden afgevoerd.
+
+      Na afsluiting zal zo spoedig mogelijk tot executoriale verkoop worden overgegaan.
+
+      Voor afsluiting is voorafgaande toestemming vereist van de ontvanger van HHNK of zijn plaatsvervanger.
+
+      14.2.12 Bewaarder en beslag roerende zaken
+
+      Als zaken op grond van artikel 14.2.9 van deze leidraad worden weggevoerd of op grond van artikel 14.2.11 van deze
+      leidraad afsluiting plaatsvindt, stelt de belastingdeurwaarder daarbij een bewaarder aan die in staat moet worden
+      geacht ook daadwerkelijk de taken verbonden aan het bewaarderschap met betrekking tot die zaken uit te oefenen. De
+      aanstelling van de bewaarder wordt vermeld in het proces-verbaal als genoemd in artikel 14.2.9 respectievelijk artikel
+      14.2.11 van deze leidraad.
+
+      Als een ambtenaar van HHNK als bewaarder wordt aangesteld, is dit zoveel mogelijk een belastingdeurwaarder, niet zijnde
+      de belastingdeurwaarder die het beslag heeft gelegd. Aan de ambtenaar die tot bewaarder is aangesteld, wordt hiervoor
+      geen vergoeding gegeven.
+
+      De tot bewaarder aangestelde ambtenaar draagt er zorg voor dat de beslagen zaken waarover hij tot bewaarder is
+      aangesteld zo nodig worden vervoerd of opgeslagen op een wijze die het risico van fysiek of economisch bederf
+      minimaliseert, meer dan voor de onderhavige zaken onder normale omstandigheden gebruikelijk is. De in dit verband te
+      nemen maatregelen en de daaraan verbonden kosten moeten in een redelijke verhouding staan tot de aard en de waarde van
+      de desbetreffende zaken.
+
+      Tijdens de periode dat het beslag ligt, wordt in de navolgende gevallen aan de bewaarder het bewaarderschap ontnomen en
+      een ander tot bewaarder aangesteld:
+
+      •
+
+      als de bewaarder geacht moet worden gedurende langere tijd lichamelijk of geestelijk niet in staat te zijn de aan het
+      bewaarderschap verbonden taken uit te oefenen;
+
+      •
+
+      als de bewaarder is overleden; in dit geval hoeft het bewaarderschap niet uitdrukkelijk te worden ontnomen;
+
+      •
+
+      als een ambtenaar van HHNK tot bewaarder is aangesteld en deze ambtenaar door oorzaken van personele of
+      organisatorische aard redelijkerwijs moet worden geacht geen betrokkenheid meer te (kunnen) hebben bij het beslag.
+
+      Ontslag van een bewaarder gebeurt steeds schriftelijk; in voorkomend geval kan dit bij deurwaardersexploot.
+
+      14.2.13 Executoriale verkoop computerapparatuur
+
+      Als de belastingdeurwaarder beslag legt op computerapparatuur, dan valt alleen de zogenoemde 'hardware' onder dit
+      beslag. De belastingdeurwaarder moet – voordat tot executoriale verkoop wordt overgegaan – nagaan of deze apparatuur
+      nog de zogenoemde 'software' bevat (bestanden, programma's en dergelijke). Als dat het geval is, dan moet de
+      belastingschuldige de mogelijkheid worden geboden om die software te verwijderen en een back-up te maken.
+
+      14.2.14 Executoriale verkoop zilveren, gouden en platina werken
+
+      De ontvanger moet ervoor zorgdragen dat geen zilveren, gouden of platina werken die niet zijn voorzien van de
+      stempeltekenen die volgens de Waarborgwet 2019 vereist zijn, in openbare verkoop worden gebracht of met dat doel worden
+      tentoongesteld.
+
+      Van het houden van een openbare verkoop waarin zilveren, gouden of platina werken voorkomen – al dan niet met het
+      vereiste stempelteken – moet de ontvanger aangifte doen zoals artikel 46 van de Waarborgwet 2019 dat voorschrijft.
+
+      14.2.15 Beslag op illegale zaken
+
+      Als voor beslag vatbare zaken worden aangetroffen waarvan in beginsel de vervaardiging, het bezit of het gebruik
+      strafbaar is (of het vermoeden van strafbaarheid bestaat), kan de beslaglegging op de normale wijze doorgang vinden.
+      Wel wordt direct of zo snel mogelijk na de beslaglegging de politie ingeschakeld om te bezien in hoeverre aanleiding
+      bestaat om strafrechtelijke maatregelen te nemen. Hierbij geldt het bepaalde in artikel 14.1.12 van deze leidraad.
+
+      Als geen strafrechtelijke maatregelen worden getroffen (de voormelde zaken worden niet verbeurd verklaard of onttrokken
+      aan het verkeer), dan moet de ontvanger contact opnemen met D&H voordat maatregelen worden getroffen om tot
+      executoriale verkoop van de in beslag genomen zaken over te gaan.
+
+      14.2.16 Bieden voor rekening van HHNK en beslag roerende zaken
+
+      Om een zo hoog mogelijke opbrengst te verkrijgen, kan de ontvanger een andere belastingdeurwaarder dan de deurwaarder
+      die met de verkoop belast is, opdragen voor rekening van HHNK te bieden.
+
+      14.2.17 Opheffing van het beslag op roerende zaken
+
+      Als de belastingschuldige er uitdrukkelijk om verzoekt of als de ontvanger dit wenselijk acht, wordt opheffing van het
+      beslag bij deurwaardersexploot kenbaar gemaakt.
+
+      Opheffing van het beslag op roerende zaken als bedoeld in artikel 445 Rv, wordt altijd kenbaar gemaakt bij
+      deurwaardersexploot.
+
+      14.2.18 Afboeking executieopbrengst verkoop roerende zaken
+
+      De ontvanger verhaalt de openstaande schuld waarvoor het beslag roerende zaken is gelegd op de executieopbrengst,
+      inclusief de daarin begrepen omzetbelasting. Voordat de opbrengst op de openstaande schuld wordt afgeboekt, worden
+      eerst de kosten van de executie verrekend. De ontvanger boekt de opbrengst vervolgens af met inachtneming van het
+      bepaalde bij artikel 7 van deze leidraad.
+
+      Als er andere schuldeisers zijn die beslag hebben gelegd of als er beperkt gerechtigden zijn van wie het recht door de
+      executie is vervallen, dan wordt zoveel mogelijk getracht in der minne overeenstemming te bereiken over de toedeling
+      van de netto-executieopbrengst. Als dat niet mogelijk blijkt, dan zijn de artikelen 481 en volgende Rv van toepassing.
+
+      14.2.19 Proces-verbaal van verkoop roerende zaken
+
+      Als de belastingschuldige te kennen geeft dat hij een afschrift van het proces-verbaal van verkoop wenst, wordt hem dit
+      zo spoedig mogelijk toegezonden, met dien verstande dat de namen en woonplaatsen van de kopers onleesbaar zijn gemaakt.
+
+      14.2.20 Gegevensverstrekking omtrent beslag roerende zaken
+
+      Als de belastingschuldige of een belanghebbende derde de ontvanger vraagt of een beslag nog ligt, dan verstrekt de
+      ontvanger deze informatie tenzij het belang van de invordering zich daartegen verzet.
+
+      14.2a Administratief beslag op motorrijtuigen en aanhangwagens
+
+      1.
+
+      De belastingdeurwaarder neemt zo nodig in het proces-verbaal van inbeslagneming van een motorrijtuig of aanhangwagen op
+      de voet van artikel 442, eerste lid, Rv, een instructie op inzake het afgeven van het motorrijtuig of de aanhangwagen,
+      als bedoeld in artikel 442, eerste lid, onder e, Rv. Daarin vermeldt de belastingdeurwaarder de plaats, datum en het
+      tijdstip waarop het motorrijtuig of de aanhangwagen ingeleverd moet worden.
+
+      2.
+
+      Als de geëxecuteerde het motorrijtuig of de aanhangwagen niet inlevert volgens de in het eerste lid bedoelde
+      instructie, stelt de belastingdeurwaarder eenmalig opnieuw een inlevermoment vast en stelt hij de geëxecuteerde hiervan
+      schriftelijk op de hoogte. De belastingdeurwaarder vermeldt in de schriftelijke kennisgeving in ieder geval de plaats,
+      datum en het tijdstip waarop het motorrijtuig of de aanhangwagen ingeleverd moet worden.
+
+      14.3 Beslag op onroerende zaken
+
+      14.3.1 Bewaring van in beslag genomen roerende zaken bij beslag onroerende zaken
+
+      Als gelijktijdig met het beslag op de onroerende zaak beslag wordt gelegd op roerende zaken die in of op de onroerende
+      zaak aanwezig zijn, kan de belastingdeurwaarder deze zaken afvoeren om in bewaring te geven als dit voor het behoud van
+      die zaken redelijkerwijs noodzakelijk is. De belastingdeurwaarder heeft hiervoor toestemming nodig van de ontvanger
+      (zie ook artikel 14.2.9 van deze leidraad).
+
+      14.3.2 Nieuwe belastingschuld en beslag onroerende zaken
+
+      Als de ontvanger voor een belastingschuld beslag op een onroerende zaak heeft gelegd, zal hij voor een nader opgekomen
+      belastingschuld zoveel mogelijk opnieuw tot beslaglegging overgaan.
+
+      In gevallen waarin de ontvanger zelf de eerste beslaglegger is, gaat hij altijd tot beslaglegging over voor vorderingen
+      van derden waarvan de invordering aan hem is opgedragen.
+
+      14.3.3 Verhuurde of verpachte onroerende zaken
+
+      De ontvanger die beslag op de onroerende zaak heeft laten leggen en tevens de huur of pacht wil incasseren, doet
+      hiervoor zoveel mogelijk een vordering ex artikel 19 van de wet onder de huurder of pachter. Er wordt in zo’n geval dus
+      niet gehandeld als bedoeld in artikel 507, derde lid, Rv.
+
+      14.3.4 Voorwaarden van verkoop van onroerende zaken
+
+      De ontvanger vraagt de notaris een afschrift van de veilingvoorwaarden die op de verkoop van toepassing zijn en hij
+      treedt zo nodig in overleg over de inhoud van deze voorwaarden.
+
+      In overleg met de notaris wordt in de voorwaarden van verkoop bepaald dat de kosten van executie, toewijzing en
+      eventuele rangregeling door de executant zullen worden voldaan uit de koopprijs en dat het tekort – als de koopprijs
+      niet toereikend mocht zijn – door de executant zal worden aangezuiverd.
+
+      14.3.5 Opheffing van het beslag onroerende zaken
+
+      Van de opheffing van een beslag op een onroerende zaak wordt schriftelijk mededeling gedaan aan de belastingschuldige.
+      Als het beslag aan de huurder of pachter is betekend, ontvangt deze ook een schriftelijke mededeling.
+
+      Ook wordt van deze opheffing bij deurwaardersexploot mededeling gedaan aan de (eventuele) derde-eigenaar, aan alle
+      (eventuele) hypotheekhouders en – indien van toepassing – aan de bewaarder.
+
+      14.4 Beslag onder derden
+
+      14.4.1 Beslag op vordering van een derde
+
+      In de artikelen 475 en volgende Rv is de mogelijkheid gegeven ten laste van de belastingschuldige beslag te leggen
+      onder een derde. Als blijkt dat – na het afleggen van de buitengerechtelijke verklaring – de derde geen gelden of zaken
+      onder zich heeft, dan blijkt het beslag nooit te hebben gelegen. De ontvanger stelt de derde hiervan op de hoogte.
+
+      Een belastingaanslag kan ook worden verhaald door het leggen van derdenbeslag op een vordering die formeel aan een
+      ander dan de belastingschuldige toebehoort, dan wel op naam van die ander – bijvoorbeeld door een bank – wordt
+      geadministreerd.
+
+      In het beslagexploot (waarvan afschrift wordt gelaten aan de derdebeslagene) dat zowel aan de belastingschuldige als
+      aan degene aan wie de vordering formeel toebehoort binnen acht dagen na het leggen van het beslag moet worden betekend,
+      moet de ontvanger zoveel mogelijk aangeven op welke gronden hij de vordering die op naam van die ander is
+      geadministreerd, meent te kunnen uitwinnen ter verhaal van een vordering op de belastingschuldige.
+
+      14.4.1a Geen beslag op coronabonus zorgprofessional
+
+      De ontvanger laat geen derdenbeslag leggen onder een zorgaanbieder als bedoeld in artikel 1 van de Subsidieregeling
+      bonus zorgprofessionals COVID-19, voor een bonus die door de zorgaanbieder wordt uitgekeerd aan een zorgprofessional
+      als bedoeld in artikel 1 van de Subsidieregeling bonus zorgprofessionals COVID-19, voor zover aan de zorgaanbieder een
+      subsidie is verstrekt op grond van de Subsidieregeling bonus zorgprofessionals COVID-19. Als reeds beslag is gelegd
+      onder de zorgaanbieder, verzoekt de ontvanger niet om afdracht van de bonus of betaalt de ontvanger de bonus alsnog aan
+      de zorgprofessional uit als de zorgaanbieder de bonus al aan de ontvanger heeft afgedragen.
+
+      14.4.1b. Bankbeslag en energietoeslag
+
+      Als de ontvanger bankbeslag legt ten laste van een belastingschuldige die op grond van artikel 35, vierde of vijfde
+      lid, Pw, een energietoeslag heeft ontvangen, geldt voor de duur van maximaal een jaar na ontvangst van deze toeslag het
+      volgende.
+
+      Op schriftelijk verzoek van de belastingschuldige betaalt de ontvanger het door de bank op het bankbeslag afgedragen
+      bedrag terug, tot maximaal het bedrag van de ontvangen energietoeslag.
+
+      14.4.2 Derdenbeslag of vordering ex artikel 19
+
+      Als naast een derdenbeslag ook een vordering op grond van artikel 19 van de wet mogelijk is, kiest de ontvanger voor
+      het doen van een vordering.
+
+      14.4.3 Roerende zaken bij derden
+
+      Als zich onder de derde roerende zaken van de belastingschuldige bevinden, wordt gehandeld overeenkomstig hetgeen is
+      bepaald in artikel 14.2.8 van deze leidraad.
+
+      14.4.4 Plaats beslaglegging en omvang derdenbeslag
+
+      Aan de nauwkeurige vermelding in het exploot van beslag van de naam en de eventuele rechtsvorm van de derde wordt
+      bijzondere aandacht geschonken. De situatie kan zich voordoen dat de derde een hoofdkantoor heeft en een of meerdere
+      bijkantoren. In dat geval legt de belastingdeurwaarder het beslag zoveel mogelijk bij het hoofdkantoor dan wel het
+      filiaal of bijkantoor dat bemoeienis heeft met de gelden of zaken waarop verhaal wordt gezocht.
+
+      In spoedeisende gevallen kan het beslag worden gelegd onder een ander filiaal of bijkantoor. De executant kiest in alle
+      gevallen domicilie bij de belastingdeurwaarder.
+
+      Als er aanleiding toe bestaat, kan de ontvanger de omvang van het beslag bij de beslaglegging beperken. Voor zover niet
+      door een andere schuldeiser beslag is gelegd, kan de omvang ook op een later tijdstip nog worden beperkt. Van de
+      beperking wordt in het beslagexploot of in een afzonderlijk geschrift aan de derde uitdrukkelijk melding gemaakt.
+
+      14.4.5 Derdenbeslag op een vordering waar geen beslagvrije voet voor geldt
+
+      Als beslag is gelegd in een situatie als bedoeld in artikel 475e dan wel artikel 475f Rv en de belastingschuldige toont
+      aan dat hij voor zijn levensonderhoud volledig afhankelijk is van de beslagen betalingen, dan past de ontvanger zonder
+      rechterlijke tussenkomst de regeling van de beslagvrije voet toe als bedoeld in de artikelen 475b en 475d Rv. Indien de
+      belastingschuldige kenbaar maakt dat de beslagvrije voet onjuist is vastgesteld, maar niet de juiste informatie
+      verstrekt voor de goede vaststelling ervan, stelt de ontvanger hem in de gelegenheid om binnen een redelijke termijn
+      alsnog de juiste informatie te verstrekken. Indien de belastingschuldige de juiste informatie binnen de door de
+      ontvanger gestelde termijn aanlevert, herstelt de ontvanger de beslagvrije voet met ingang van de inhouding volgend op
+      het moment waarop de belastingschuldige kenbaar maakte dat de beslagvrije voet onjuist was vastgesteld.
+
+      14.4.5a Derdenbeslag en kosten van levensonderhoud
+
+      Wanneer de ontvanger derdenbeslag legt als gevolg waarvan de belastingschuldige niet meer kan voorzien in zijn
+      levensonderhoud, verleent de ontvanger zijn medewerking aan (gedeeltelijke) opheffing van het beslag dan wel stelt hij
+      een passend deel van het door de derde betaalde bedrag beschikbaar aan de belastingschuldige. De ontvanger verleent
+      slechts medewerking onder voorwaarde dat de belastingschuldige voldoende aannemelijk heeft gemaakt dat hij als gevolg
+      van het beslag gedurende een bepaalde periode niet meer kan voorzien in de kosten van levensonderhoud. Voor de
+      vaststelling van het passend deel gaat de ontvanger uit van de kosten van bestaan als bedoeld in artikel 16 van de
+      regeling.
+
+      14.4.5b Vrij te laten bedrag en beslag onder derden bij geen adres in Nederland
+
+      Als de ontvanger bankbeslag legt ten laste van een belastingschuldige die op grond van de basisregistratie personen
+      geen adres in Nederland heeft, geldt het volgende. Als de belastingschuldige op grond van de basisregistratie personen
+      geen adres in Nederland heeft, stelt de ontvanger bij het leggen van derdenbeslag geen vrij te laten bedrag vast als
+      bedoeld in artikel 475a, vijfde lid, Rv. Als de belastingschuldige inzicht geeft in zijn leefsituatie en aannemelijk
+      maakt dat hij door het beslag onvoldoende middelen van bestaan overhoudt, kan hij de ontvanger verzoeken alsnog
+      rekening te houden met het voor hem geldende vrij te laten bedrag. De ontvanger stelt in dat geval het voor de
+      leefsituatie van de belastingschuldige geldende vrij te laten bedrag vast. De ontvanger betaalt het verschil tussen het
+      initieel vastgestelde vrij te laten bedrag en het op verzoek vastgestelde vrij te laten bedrag aan de
+      belastingschuldige. Dit doet de ontvanger nadat de bank op het beslag heeft afgedragen.
+
+      14.4.5c Toepassing 5%-regeling
+
+      De ontvanger past de zogeheten 5% regeling, bedoeld in artikel 475dc Rv, in beginsel niet toe bij het leggen van
+      derdenbeslag. De ontvanger past die regeling alleen toe als is voldaan aan de voorwaarden van artikel 19, tweede lid,
+      van de wet en artikel 19.1.7 of als de ontvanger van mening is dat de belangen van HHNK worden geschaad als hij de
+      5%-regeling niet toepast.
+
+      14.4.6 Bij derdenbeslag in gebreke blijven tot het doen van verklaring [Vervallen per 10-11-2020]
+
+      14.4.7 Bij derdenbeslag niet afdragen na het doen van verklaring [Vervallen per 10-11-2020]
+
+      14.4.8 Afdracht binnen de vierwekentermijn bij derdenbeslag [Vervallen per 10-11-2020]
+
+      14.4.9 Derdenbeslag op polis van levens- of spaarverzekering of lijfrente
+
+      Bij een derdenbeslag op een polis van een levens- of spaarverzekering of lijfrente geldt – naast de voorschriften in
+      artikel 479l en volgende Rv het volgende:
+
+      •
+
+      De ontvanger stelt zich terughoudend op bij het leggen van derdenbeslag als er sprake is van een niet-bovenmatige
+      oudedagsvoorziening.
+
+      •
+
+      De ontvanger betrekt in zijn overwegingen de verhouding tussen de openstaande belastingschuld en de opbrengst bij
+      afkoop of belening van de polis. Bij de bepaling van de opbrengst houdt de ontvanger rekening met het feit dat een
+      (voortijdige) afkoop of belening van de polis in bepaalde gevallen wordt aangemerkt als een verboden handeling die tot
+      negatieve uitgaven voor inkomensvoorzieningen leiden als gevolg waarvan een aanslag in de inkomstenbelasting kan worden
+      opgelegd.
+
+      •
+
+      Als de netto-opbrengst van de polis minder dan € 1.000 bedraagt, de polis wordt afgekocht of het derdenbeslag is gelegd
+      drie jaren voor de expiratiedatum, wint de ontvanger het derdenbeslag niet uit en gaat hij niet over tot afkoop of
+      belening. In dat geval laat de ontvanger – in overleg met belastingschuldige – het beslag liggen tot de expiratiedatum.
+
+      •
+
+      De omstandigheid dat het verzekerde bedrag pas na lange tijd tot uitkering komt, staat op zich een derdenbeslag niet in
+      de weg.
+
+      •
+
+      De belastingaanslagen waarvoor het derdenbeslag wordt gelegd moeten onherroepelijk vast staan en in redelijkheid
+      materieel verschuldigd worden geacht.
+
+      14.4.10 Retentierecht en derdenbeslag
+
+      Als de derde-beslagene een retentierecht heeft op de zaken die door het derdenbeslag van de ontvanger zijn getroffen,
+      dan kan de ontvanger op grond van artikel 6:30 BW overgaan tot betaling van het bedrag waarvoor het retentierecht geldt
+      in afwachting van verrekening met de belastingschuldige. Het bedrag moet dan wel beduidend lager zijn dan de
+      executiewaarde van de desbetreffende zaak.
+
+      14.4.11 Opheffing van het derdenbeslag
+
+      Als de belastingschuldige er uitdrukkelijk om verzoekt of als de ontvanger dit wenselijk acht, wordt opheffing van het
+      beslag bij deurwaardersexploot kenbaar gemaakt aan zowel de belastingschuldige als de derde.
+
+      In andere gevallen wordt van de opheffing schriftelijk kennis gegeven aan de derde-beslagene. De ontvanger zendt aan de
+      belastingschuldige een afschrift van deze kennisgeving.
+
+      14.4.12 Onverschuldigde betaling en derdenbeslag
+
+      Als een derde tegen de ontvanger een vordering uit onverschuldigde betaling instelt en de ontvanger aan deze vordering
+      voldoet, wordt de belastingaanslag waarvoor het derdenbeslag is gelegd, geacht in zoverre niet te zijn voldaan.
+
+      De ontvanger kan de invordering van die aanslag dan ook hervatten alsof er geen derdenbeslag is gelegd.
+
+      14.4.13 Derdenbeslag onder de Staat of de ontvanger en het doen van verklaring
+
+      Niet van toepassing voor HHNK.
+
+      14.4.14 Derdenbeslag op voorlopige teruggaaf
+
+      Als derdenbeslag onder de ontvanger van de rijksbelastingdienst wordt gelegd op een voorlopige teruggaaf
+      inkomstenbelasting, dan wordt rekening gehouden met de regeling van de beslagvrije voet. Dit geldt ook als het
+      termijnbedrag niet groter is dan € 23 per maand.
+
+      In het laatste geval wordt in overeenstemming met het bepaalde in artikel 9.3 van deze leidraad het bedrag dat
+      ingevolge het gelegd beslag moet worden voldaan, berekend uitgaande van het termijnbedrag.
+
+      14.5 Beslag op schepen
+
+      14.5.1 Beletten van het vertrek van het schip
+
+      De belastingdeurwaarder kan een bewaarder aanstellen en de nodige maatregelen nemen om het vertrek van het schip te
+      beletten. Denk hierbij bijvoorbeeld aan het 'aan de ketting leggen' van het schip. Zo nodig voorziet de
+      belastingdeurwaarder zich – na daartoe overleg te hebben gepleegd met de ontvanger – van deskundige bijstand. De kosten
+      van deze bijstand komen voor rekening van de belastingschuldige.
+
+      In daartoe aanleiding gevende gevallen kan het feitelijk gebruik van het schip weer aan de belastingschuldige worden
+      gelaten, bijvoorbeeld wanneer ter voorkoming van een executoriale verkoop door de belastingschuldige een voorstel tot
+      minnelijke afdoening is gedaan en dit voorstel voor de ontvanger – gelet op de omstandigheden – aanvaardbaar is.
+
+      In ieder geval zal een minnelijke afdoening moeten passen in het bij artikel 25 van deze leidraad geformuleerde
+      uitstelbeleid.
+
+      14.5.2 De executie van schepen
+
+      Tenzij een andere wijze van verkoop is toegestaan of voorgeschreven gebeurt de executoriale verkoop van een schip ten
+      overstaan van een bevoegde notaris.
+
+      De verkoop van een buitenlands zeeschip kan ook plaatsvinden ten overstaan van de rechtbank. Van deze mogelijkheid zal
+      met name gebruik moeten worden gemaakt als het land van herkomst de verkoop door een notaris niet erkent.
+
+      De executie van niet-teboekgestelde schepen gebeurt op dezelfde wijze als de executie van andere roerende zaken die
+      geen registergoederen zijn. Om een zo hoog mogelijke opbrengst te verkrijgen, kan de ontvanger een andere
+      belastingdeurwaarder dan de belastingdeurwaarder die met de verkoop is belast, opdragen voor rekening van HHNK te
+      bieden. De ontvanger geeft deze belastingdeurwaarder zo nodig nadere aanwijzingen.
+
+      14.5.3 Afgelasting van de verkoop van een schip
+
+      Als een aangekondigde verkoop van een schip om enigerlei reden geen doorgang kan vinden, dan draagt de ontvanger er
+      zorg voor dat de aanplakbiljetten onmiddellijk worden verwijderd. Hij treft ook voor op andere wijze gedane
+      aankondigingen dienovereenkomstige maatregelen.
+
+      Als de belastingschuldige niet van de afgelasting op de hoogte is, dan wordt hem hiervan onverwijld schriftelijk en
+      gemotiveerd mededeling gedaan. Als verwacht mag worden dat deze mededeling de belastingschuldige niet meer voor het
+      aangekondigde tijdstip van verkoop bereikt, dan stelt de ontvanger hem zo mogelijk op een andere wijze in kennis.
+
+      14.5.4 Deskundige hulp en beslag op schepen
+
+      Als bij een executie deskundige hulp is gewenst, kan de ontvanger een makelaar of een andere ter zake kundige
+      inschakelen.
+
+      14.5.5 Opheffing van het beslag op schepen
+
+      Van de opheffing van het beslag wordt schriftelijk mededeling gedaan aan de belastingschuldige. Ook wordt – ingeval van
+      teboekgestelde schepen – van de opheffing bij deurwaardersexploot mededeling gedaan aan de ingeschreven schuldeisers.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_14
+
+  - number: '15'
+    text: |-
+      Er zijn in deze leidraad op artikel 15 van de wet geen beleidsregels gemaakt.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_15
+
+  - number: '16'
+    text: |-
+      Niet van toepassing voor HHNK.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_16
+
+  - number: '17'
+    text: |-
+      **Verzet tegen tenuitvoerlegging dwangbevel**
+
+      Artikel 17 van de wet geeft een zelfstandige regeling voor het instellen van verzet tegen de tenuitvoerlegging van een
+      dwangbevel. Naast de belastingschuldige kan een ieder tegen wie de dwanginvordering is gericht in verzet komen.
+
+      Verzet is mogelijk zodra de betekening van het dwangbevel heeft plaatsgevonden. Het verzet schorst de tenuitvoerlegging
+      van het dwangbevel, voor zover dit door het verzet wordt bestreden. Ook kan verzet worden gedaan tegen een vordering
+      als bedoeld in artikel 19 van de wet.
+
+      Er kan geen verzet worden ingesteld tegen de in rekening gebrachte kosten van de aanmaning en de betekeningskosten van
+      het dwangbevel.
+
+      In aansluiting op artikel 17 van de wet beschrijft dit artikel het beleid over:
+
+      •
+
+      het aanhouden van de tenuitvoerlegging van een dwangbevel bij verzet;
+
+      •
+
+      verzet tegen tenuitvoerlegging van dwangbevel bij onjuiste adressering.
+
+      17.1 Aanhouden tenuitvoerlegging bij verzet
+
+      Als de belastingschuldige zich in rechte verzet tegen de tenuitvoerlegging van het dwangbevel, houdt de ontvanger de
+      (verdere) tenuitvoerlegging van het dwangbevel aan, tenzij:
+
+      •
+
+      de gronden van het verzet naar het oordeel van de ontvanger kansloos zijn, en;
+
+      •
+
+      de belangen van HHNK zich verzetten tegen schorsing van de tenuitvoerlegging.
+
+      17.2 Verzet tegen tenuitvoerlegging van dwangbevel bij onjuiste adressering
+
+      Als het aanslagbiljet, de aanmaning of het afschrift van het per post betekende dwangbevel aan een onjuist adres is
+      verzonden en daarom de belastingschuldige niet heeft bereikt, is verzet mogelijk.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_17
+
+  - number: '18'
+    text: |-
+      Er zijn in deze leidraad op artikel 18 van de wet geen beleidsregels gemaakt.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_18
+
+  - number: '19'
+    text: |-
+      **Doen van een vordering**
+
+      De in artikel 19 van de wet omschreven vordering geeft de ontvanger de mogelijkheid om in bepaalde gevallen op
+      eenvoudige wijze belastingschuld te verhalen op hetgeen een derde aan de belastingschuldige is verschuldigd of ten
+      behoeve van hem onder zich heeft of zal krijgen.
+
+      In aansluiting op artikel 19 van de wet beschrijft dit artikel het beleid over:
+
+      •
+
+      de algemene regels over het doen van een vordering;
+
+      •
+
+      de faillissementsvordering;
+
+      •
+
+      vorderingen met betrekking tot periodieke uitkeringen;
+
+      •
+
+      de overheidsvordering, bedoeld in artikel 19, vierde lid, van de wet.
+
+      19.1 Vordering algemeen
+
+      Als het doen van een vordering rechtens mogelijk is, wordt mede ter besparing van kosten aan dit eenvoudige
+      invorderingsmiddel de voorkeur gegeven boven derdenbeslag.
+
+      Ingeval van twijfel of degene aan wie de vordering zou moeten worden gericht wel houder van penningen is, moet al naar
+      gelang de omstandigheden worden beoordeeld of het leggen van derdenbeslag de voorkeur verdient.
+
+      19.1.1 Bekendmaking vordering
+
+      De ontvanger maakt de vordering bekend door toezending van de beschikking aan degene aan wie de vordering is gedaan en
+      aan de belastingschuldige.
+
+      Als de ontvanger dat wenselijk acht, kan hij de vordering ook aan genoemde personen laten betekenen door de
+      belastingdeurwaarder. Bij de betekening van een vordering handelt de belastingdeurwaarder overeenkomstig de voor
+      betekening van exploten geldende regels van het Wetboek van Burgerlijke Rechtsvordering.
+
+      Voor de betekening brengt de belastingdeurwaarder geen kosten in rekening.
+
+      19.1.2 Voldoen aan de vordering
+
+      Als de derde betaalt op een vordering die betrekking heeft op twee of meer belastingaanslagen heeft hij niet het recht
+      om aan te geven ter voldoening van welke belastingaanslag de betaling strekt.
+
+      19.1.3 Niet voldoen aan de vordering
+
+      Derdenbeslag wordt alleen gelegd als aan de vordering ten onrechte niet is voldaan, dan wel de derde hierop ten
+      onrechte niet heeft gereageerd. Hiervan is zeker sprake als blijkt dat het uitblijven van het voldoen aan de vordering
+      te wijten is aan de derde.
+
+      Als de ontvanger in verband met de kosten of om andere redenen derdenbeslag niet opportuun acht, wordt daarvan afgezien
+      en wordt de vordering ingetrokken.
+
+      Als wordt overgegaan tot het leggen van derdenbeslag wordt in het beslagexploot melding gemaakt van de vordering die
+      aan het beslag is voorafgegaan en van de datum waarop die vordering is gedaan.
+
+      19.1.4 Intrekken van een vordering
+
+      Zodra een vordering om enigerlei reden niet langer hoeft te worden gehandhaafd, trekt de ontvanger deze bij beschikking
+      in.
+
+      De ontvanger maakt deze beschikking bekend aan degene aan wie de vordering is gedaan.
+
+      19.1.5 Vermindering of vernietiging van de belastingaanslag in relatie tot vordering
+
+      Als een derde op vordering van de ontvanger betaalt en naderhand vermindert of vernietigt de inspecteur de
+      belastingaanslag, dan wordt de hieruit voortvloeiende teruggaaf verrekend of uitbetaald aan de belastingschuldige.
+
+      19.1.6 Doorbreken beslagverboden en vordering
+
+      Bij de toepassing van artikel 19, eerste lid, van de wet (het vereenvoudigd beslag op vorderingen van de
+      belastingschuldige op derden) bestaat onder voorwaarden de mogelijkheid een wettelijk beslagverbod gedeeltelijk te
+      negeren. Van deze mogelijkheid maakt de ontvanger alleen gebruik als de belastingschuldige kan worden gekwalificeerd
+      als een notoire wanbetaler in de zin van artikel 19, tweede lid, van de wet.
+
+      De vordering waarbij een beroep wordt gedaan op de verruimde beslagmogelijkheid vindt steeds separaat plaats en wordt
+      vooraf schriftelijk aangekondigd aan de belastingschuldige, onder vermelding van het bijzondere karakter daarvan.
+
+      De vordering kan niet plaatsvinden voor kinderbijslag onder welke benaming dan ook. In voorkomend geval wordt voor de
+      toepassing van de verruimde beslagmogelijkheid uitgegaan van het maximale bereik: een tiende deel van het bedrag dat op
+      grond van de wet niet vatbaar is voor beslag. De ontvanger zal de zogeheten 5%-regeling niet gelijktijdig toepassen met
+      de regeling, bedoeld in artikel 19, eerste lid, van de wet.
+
+      19.1.6a Toepassing 5%-regeling
+
+      De ontvanger past de zogeheten 5%-regeling, bedoeld in artikel 475dc Rv, in beginsel niet toe bij het doen van een
+      vordering als bedoeld in artikel 19, eerste lid, van de wet. De ontvanger past die regeling alleen toe als is voldaan
+      aan de voorwaarden van artikel 19, tweede lid, van de wet en artikel 19.1.7 of als hij van mening is dat de belangen
+      van HHNK worden geschaad als hij de 5%-regeling niet toepast.
+
+      19.1.6b Geen vordering voor coronabonus zorgprofessional
+
+      De ontvanger doet geen vordering op grond van artikel 19, eerste lid, van de wet, voor een bonus die door een
+      zorgaanbieder als bedoeld in artikel 1 van de Subsidieregeling bonus zorgprofessionals COVID-19 wordt uitgekeerd aan
+      een zorgprofessional als bedoeld in artikel 1 van de Subsidieregeling bonus zorgprofessionals COVID-19, voor zover aan
+      de zorgaanbieder voor de bonus een subsidie is verstrekt op grond van de Subsidieregeling bonus zorgprofessionals
+      COVID-19. Als reeds een vordering is gedaan, is de zorgaanbieder niet verplicht die bonus aan de ontvanger af te
+      dragen, of betaalt de ontvanger de bonus alsnog aan de zorgprofessional uit als de zorgaanbieder de bonus al aan de
+      ontvanger heeft afgedragen.
+
+      19.1.7 Notoire wanbetaler en vordering
+
+      In afwijking in zoverre van artikel 19, tweede lid, van de wet vindt de vordering waarbij de doorbreking van een
+      wettelijk beslagverbod wordt ingeroepen slechts plaats indien voldaan is aan de volgende voorwaarden:
+
+      •
+
+      op het tijdstip waarop de vordering plaatsvindt, heeft de belastingschuldige meer dan één aanslag onbetaald gelaten;
+
+      •
+
+      de enige of laatste betalingstermijn van deze aanslagen is op het tijdstip waarop de vordering plaatsvindt met ten
+      minste twee maanden overschreden;
+
+      •
+
+      de belastingschuldige komt niet voor uitstel van betaling of kwijtschelding in aanmerking omdat hij, naar de ontvanger
+      bekend is, beschikt over voldoende vermogen of voldoende betalingscapaciteit om de belastingaanslagen te voldoen.
+
+      19.1.8 Vordering ten laste van de echtgenoot
+
+      Als de echtgenoot van de belastingschuldige recht heeft op gelden, penningen of een vordering heeft op een derde die in
+      de huwelijksgemeenschap vallen, dan kan de ontvanger een vordering ten laste van de echtgenoot doen. Als de vordering
+      ziet op een belastingschuld die niet tot de gemeenschap behoort, beperkt de ontvanger zijn vordering tot de helft van
+      het voor beslag vatbare deel van de vordering op de derde. Deze beperking geldt niet als de echtgenoot instemt met
+      verhaal op het geheel. De bekendmaking van de vordering dient zo spoedig mogelijk, maar uiterlijk binnen acht dagen na
+      het doen van de vordering, te geschieden aan de belastingschuldige en de echtgenoot afzonderlijk. Voor zover het
+      periodieke uitkeringen betreft die onder de opsomming van artikel 19, eerste lid, van de wet vallen, past de ontvanger
+      de beslagvrije voet toe alsof de echtgenoot de belastingschuldige is. Voor zover de vordering wordt gedaan op een
+      vordering die de echtgenoot van de belastingschuldige heeft op een betaaldienstverlener, is het bepaalde in artikel
+      1cbis.2 van de regeling van overeenkomstige toepassing.
+
+      19.2 De faillissementsvordering
+
+      19.2.1 Aan te melden schulden in faillissement
+
+      In een faillissement vallen de belastingschulden voor zover zij materieel zijn ontstaan vóór de dag van de
+      faillietverklaring, dan wel materieel zijn ontstaan na de faillietverklaring, maar voortvloeien uit een al bestaande
+      rechtsverhouding van voor de faillietverklaring. Hierbij wordt ervan uitgegaan dat de materiële belastingschuld
+      ontstaat van dag tot dag tenzij het tegendeel blijkt.
+
+      Belastingschulden ontstaan vanaf de datum van het faillissement die niet voortvloeien uit een al bestaande
+      rechtsverhouding van voor de faillietverklaring, zijn niet verifieerbaar en moeten eventueel als boedelschuld worden
+      aangemerkt.
+
+      De ontvanger splitst de belastingaanslag naar tijdsevenredigheid of tijdstip en doet twee aparte vorderingen:
+
+      •
+
+      één voor het gedeelte dat ter verificatie kan worden aangemeld;
+
+      •
+
+      één voor het gedeelte dat als boedelschuld kan worden aangemerkt.
+
+      Voorlopige aanslagen voor bedrijven kan de ontvanger direct aanmelden. De ontvanger splitst de voorlopige aanslagen wel
+      naar tijdsevenredigheid of tijdstip.
+
+      Bij het bepalen of een bestuurlijke boete in een faillissement valt, is uitsluitend van belang de dagtekening van de
+      desbetreffende beschikking. Als die beschikking is gedagtekend voor het faillissement, kan de ontvanger de boete in het
+      faillissement aanmelden. Als de dagtekening ligt na uitspraak van het faillissement, dan kan de ontvanger de boete niet
+      meer in het faillissement aanmelden, ook al heeft de boete betrekking op een situatie vóór het faillissement.
+
+      19.2.2 Belastingschulden ontstaan gedurende een surseance zijn boedelschulden in faillissement
+
+      Belastingschulden die materieel zijn ontstaan gedurende de periode van een surseance van betaling die aan het
+      faillissement voorafgaat, kunnen op grond van artikel 249 FW worden beschouwd als boedelschulden in het faillissement.
+
+      Het bepaalde in artikel 19.1 van de wet is op deze schulden en de belastingaanslagen die hierop betrekking hebben op
+      soortgelijke wijze van toepassing.
+
+      19.2.3 Opkomen in faillissement
+
+      Van de bevoegdheid om van de curator dadelijke voldoening aan de vordering te verlangen maakt de ontvanger geen
+      gebruik, tenzij bijzondere omstandigheden met het oog op het belang van de invordering daartoe noodzaken.
+
+      In alle gevallen waarin de ontvanger in het faillissement opkomt, vermeldt hij in de vordering dat hij aanspraak maakt
+      op eventuele voorrang. Als de curator tijdens het faillissement materieel ontstane belastingschulden die als
+      boedelschuld kunnen worden aangemerkt, ten onrechte niet voldoet, dan wendt de ontvanger zich in beginsel eerst tot de
+      curator om langs minnelijke weg alsnog voldoening te bewerkstelligen.
+
+      Als dit niet leidt tot een bevredigende oplossing, wendt de ontvanger zich met zijn grieven tot de rechter-commissaris.
+      In het uiterste geval kan de ontvanger zich rechtstreeks verhalen op de boedel.
+
+      19.3 Vorderingen met betrekking tot periodieke uitkeringen
+
+      19.3.1 Overwegen van vordering op periodieke uitkeringen
+
+      Bij de beoordeling van de vraag of een vordering wordt gedaan met betrekking tot een periodieke uitkering, is
+      doorslaggevend het feit dat de vordering een bijzonder invorderingsinstrument betreft waarmee een doelmatige en
+      doeltreffende invordering van belastingschulden is beoogd.
+
+      Dit betekent dat de vordering in beginsel de voorkeur verdient boven andere invorderingsmaatregelen waarbij het
+      dwangbevel ten uitvoer wordt gelegd door middel van beslag. Als het invordering van zeer geringe bedragen betreft,
+      bestaat er aanleiding eerst andere invorderingsmaatregelen te proberen alvorens de derde via de vordering te betrekken.
+
+      19.3.2 Vooraankondiging van vordering op periodieke uitkeringen
+
+      Als de ontvanger het dwangbevel per post heeft betekend en de invordering vervolgt door middel van een vordering onder
+      de werkgever of door een andere vordering op een periodieke uitkering waaraan een beslagvrije voet is verbonden, is hij
+      verplicht de belastingschuldige vooraf schriftelijk in kennis te stellen van zijn voornemen een vordering te doen.
+
+      De ontvanger doet de vooraankondiging niet eerder dan nadat vier dagen zijn verstreken na de datum waarop hij het
+      afschrift van het dwangbevel met bevel tot betaling ter post heeft bezorgd.
+
+      De ontvanger doet de betreffende vordering niet eerder dan zeven dagen na de dagtekening van de vooraankondiging. De
+      vooraankondiging blijft achterwege als de ontvanger de vordering doet bij een werkgever of uitkeringsinstantie die
+      reeds op vordering van de ontvanger een belastingaanslag van de belastingschuldige betaalt of zou moeten betalen.
+
+      19.3.3 Beslagvrije voet en vordering op periodieke uitkeringen
+
+      Als een vordering wordt gedaan op periodieke uitkeringen waarvoor geen beslagvrije voet geldt en de belastingschuldige
+      toont aan dat hij voor zijn levensonderhoud volledig afhankelijk is van deze uitkeringen, dan past de ontvanger de
+      artikelen 475b en 475d tot en met 475e Rv toe.
+
+      In dat geval geldt de vordering nog slechts voor het gedeelte waarmee de periodieke uitkering de beslagvrije voet
+      overtreft. Hetzelfde geldt bij vorderingen ten laste van een belastingschuldige die niet in Nederland woont of vast
+      verblijft.
+
+      Voor een alleenstaande, jonger dan 21 jaar, en een alleenstaande ouder jonger dan 21 jaar – indien zij een ander
+      inkomen genieten dan een bijstandsuitkering – geldt een beslagvrije voet van 90% van het feitelijk inkomen (+
+      vakantieaanspraak) met een minimum van 90% van de bijstandsnorm genoemd in artikel 21, onderdeel a onderscheidenlijk
+      onderdeel b van de Participatiewet en een maximum van 90% van de bijstandsnorm nadat deze verhoogd is met het bedrag
+      genoemd in artikel 25 van die wet.
+
+      19.3.3a Beslagvrije voet en vakantiegeld [Vervallen per 01-01-2015]
+
+      19.3.4 Beslagvrije voet voor belastingschuldige zonder vaste woon- of verblijfplaats in Nederland
+
+      Als de ontvanger een vordering doet op een periodieke uitkering waaraan een beslagvrije voet is verbonden, ten laste
+      van een belastingschuldige van wie geen woon- of verblijfadres bekend is, stelt hij de beslagvrije voet vast
+      overeenkomstig artikel 475da, vierde lid, Rv. Zodra de ontvanger bekend wordt met het feit dat de belastingschuldige in
+      Nederland woont of een vaste verblijfplaats heeft, stelt de ontvanger alsnog de juiste beslagvrije voet vast en past
+      deze toe vanaf de eerstvolgende inhouding, dus zonder terugwerkende kracht. Het laatste geldt niet als de
+      belastingschuldige kan aantonen dat het ontbreken van het adresgegeven niet aan hem te wijten is.
+
+      19.3.5 Belastingschuldige woont in buitenland en beslagvrije voet
+
+      Als de belastingschuldige buiten Nederland een vaste woon- of verblijfplaats heeft, stelt de ontvanger overeenkomstig
+      artikel 475da, vierde lid, Rv de beslagvrije voet vast bij het doen van een vordering op een periodieke uitkering
+      waaraan een beslagvrije voet is verbonden. Na de vooraankondiging van de vordering kan de belastingschuldige door
+      middel van het aanleveren van informatie de ontvanger op de hoogte stellen over zijn leefsituatie en bronnen van
+      inkomsten. Als de belastingschuldige aantoont wat zijn leefsituatie en inkomen is, stelt de ontvanger op basis van de
+      verstrekte informatie de beslagvrije voet vast. Als de belastingschuldige geen inzicht verschaft of onduidelijkheid
+      blijft bestaan over zijn leefsituatie en inkomstenbronnen blijft de ontvanger uitgaan van de beslagvrije voet
+      overeenkomstig artikel 475da, vierde lid, Rv.
+
+      Eventuele periodieke inkomsten die de belastingschuldige uit zijn woonland geniet, komen in mindering op de beslagvrije
+      voet. Indien de belastingschuldige kenbaar maakt dat de beslagvrije voet onjuist is vastgesteld, maar niet de juiste
+      informatie verstrekt voor de goede vaststelling ervan, stelt de ontvanger hem in de gelegenheid om binnen een redelijke
+      termijn alsnog de juiste informatie te verstrekken. Indien de belastingschuldige de juiste informatie binnen de door de
+      ontvanger gestelde termijn aanlevert, herstelt de ontvanger de beslagvrije voet met ingang van de inhouding volgend op
+      het moment waarop de belastingschuldige kenbaar maakte dat de beslagvrije voet onjuist was vastgesteld.
+
+      Als de belastingschuldige buiten Nederland een vaste woon- of verblijfplaats heeft, kan hij uit Nederland een
+      periodieke uitkering genieten die in het woonland belast is op grond van een overeenkomst inzake voorkoming van dubbele
+      belasting. In dat geval wordt op verzoek van de belastingschuldige het beslag op de periodieke uitkering beperkt met de
+      belasting die in het woonland over die uitkering verschuldigd is. De belastingschuldige moet bij zijn verzoek gegevens
+      overleggen waaruit deze belasting blijkt.
+
+      19.3.6 Verrekening ex artikel 117 Ambtenarenwet [Vervallen per 01-01-2021]
+
+      19.3.7 Periodieke uitkeringen onder de bijstandsnorm
+
+      Periodieke uitkeringen kunnen lager zijn dan de bijstandsnorm omdat de betrokkene in natura geniet wat een
+      bijstandsgerechtigde uit de bijstandsnorm geacht wordt te betalen.
+
+      In een dergelijk geval vermindert de ontvanger de beslagvrije voet met het bedrag dat aan deze genietingen in natura
+      kan worden toegerekend.
+
+      19.3.8 Vordering in relatie tot voorlopige teruggaaf
+
+      Niet van toepassing voor HHNK.
+
+      19.3.9 Toepassing beslagvrije voet bij AOW-gerechtigden
+
+      De ontvanger kan ten laste van in Nederland woonachtige belastingschuldigen die de AOW-gerechtigde leeftijd hebben
+      bereikt, een vordering doen op een periodieke uitkering waaraan een beslagvrije voet is verbonden. Hierbij houdt hij
+      rekening met de hoogste beslagvrije voet die op grond van artikel 475da, eerste lid, Rv, geldt voor de leefsituatie van
+      de belastingschuldige.
+
+      19.4 Beslagvrije voet en overheidsvordering
+
+      Als de belastingschuldige aannemelijk maakt dat hij vanwege de toepassing van de overheidsvordering, bedoeld in artikel
+      19, vierde lid, van de wet een lager bedrag aan bestaansmiddelen overhoudt dan overeenkomt met de voor hem geldende
+      beslagvrije voet, maakt de ontvanger de overheidsvordering op verzoek van de belastingschuldige in zoverre ongedaan met
+      inachtneming van hetgeen hierna volgt.
+
+      Bij het verzoek verstrekt de belastingschuldige naast de gegevens die van belang zijn voor de vaststelling van de
+      beslagvrije voet een overzicht van de banktegoeden, waaronder begrepen spaartegoeden, waarover de belastingschuldige
+      onmiddellijk na de overheidsvordering kon beschikken. Ongedaan making blijft beperkt tot de laatste overheidsvordering
+      voorafgaand aan het verzoek van de belastingschuldige.
+
+      Als sprake is van een belastingschuldige als bedoeld in artikel 19, tweede lid, van de wet, berekent de ontvanger de
+      beslagvrije voet met inachtneming van het bepaalde in artikel 19, eerste lid, laatste volzin van de wet.
+
+      Voordat de ontvanger tot teruggaaf overgaat, gaat hij na of de belastingschuldige op het moment dat de
+      overheidsvordering is gedaan, beschikte over banktegoeden, waaronder begrepen spaartegoeden. Als het totaal van de
+      banktegoeden waarover de belastingschuldige onmiddellijk na de overheidsvordering kon beschikken groter is dan de voor
+      hem geldende beslagvrije voet, vermindert de ontvanger de teruggaaf met het meerdere.
+
+      19.5 Vrij te laten bedrag en betalingsvordering bij geen adres in Nederland
+
+      Als de belastingschuldige op grond van de basisregistratie personen geen adres in Nederland heeft en geen vaste woon-
+      of verblijfplaats buiten Nederland heeft, stelt de ontvanger een vrij te laten bedrag vast, als bedoeld in artikel
+      1cbis.2, tweede lid, van de regeling. In het geval de belastingschuldige buiten Nederland een vaste woon- of
+      verblijfplaats heeft, stelt de ontvanger geen vrij te laten bedrag vast.
+
+      De belastingschuldige, zijnde een natuurlijk persoon, bij wie de ontvanger een betalingsvordering doet, kan een verzoek
+      indienen als bedoeld in artikel 1cbis.2 van de regeling. Indien de belastingschuldige in dit verzoek aantoont wat zijn
+      leefsituatie is, stelt de ontvanger alsnog het (volledige) voor de leefsituatie van de belastingschuldige geldende vrij
+      te laten bedrag vast en stelt dit beschikbaar aan de belastingschuldige nadat op de vordering is afgedragen, ten
+      hoogste tot het verschil tussen het eerder vastgestelde vrij te laten bedrag en het na het verzoek vastgestelde vrij te
+      laten bedrag.
+
+      19.6. Vordering en energietoeslag
+
+      Als de ontvanger bij een belastingschuldige die op grond van artikel 35, vierde of vijfde lid, Pw, een energietoeslag
+      heeft ontvangen, een overheidsvordering doet of een betalingsvordering doet, geldt voor de duur van maximaal een jaar
+      na ontvangst van deze toeslag het volgende.
+
+      Op schriftelijk verzoek van de belastingschuldige betaalt de ontvanger het daarop afgedragen bedrag terug, tot maximaal
+      het bedrag van de ontvangen energietoeslag.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_19
+
+  - number: '20'
+    text: |-
+      Niet van toepassing voor HHNK.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_20
+
+  - number: '22'
+    text: |-
+      **Bodemrecht**
+
+      Artikel 22 van de wet gaat over het bodemrecht.
+
+      In aansluiting op artikel 22 van de wet beschrijft dit artikel het beleid over:
+
+      •
+
+      de werkingssfeer van het bodemrecht;
+
+      •
+
+      bodemrecht en bestuurlijke boeten;
+
+      •
+
+      overbetekening bodembeslag;
+
+      •
+
+      de volgorde uitwinning bodembeslag buiten faillissement;
+
+      •
+
+      de volgorde uitwinning bodembeslag in faillissement;
+
+      •
+
+      bodemrecht en insolventie van de derde-eigenaar;
+
+      •
+
+      bodemrecht en voorrang;
+
+      •
+
+      verzet en beroep.
+
+      22.1 Werkingssfeer en reikwijdte bodemrecht
+
+      Derden die de eigendom pretenderen van inbeslaggenomen roerende of onroerende zaken, kunnen hun rechten op die zaken –
+      op de voet van de artikelen 456 respectievelijk 538 en volgende Rv – geldend maken. Op grond van artikel 435 Rv kunnen
+      derden zich ook tegen het beslag verzetten.
+
+      Onafhankelijk hiervan kunnen derden die geheel of gedeeltelijk recht menen te hebben op roerende zaken waarop voor een
+      belastingschuld beslag is gelegd, hun bezwaren tegen de beslaglegging van die zaken in de administratieve sfeer door
+      middel van een beroepschrift voorleggen aan D&H van HHNK.
+
+      Met derden worden hier niet alleen bedoeld degenen die zich op een eigendomsrecht beroepen, maar ook degenen die een
+      beperkt recht op de zaak menen te hebben. Een tijdig ingediend beroepschrift op de voet van artikel 22, eerste lid, van
+      de wet schort de executie van rechtswege op.
+
+      Artikel 22, derde lid, van de wet ontneemt derden de mogelijkheid van verzet in rechte tegen de inbeslagneming van de
+      in dat artikel bedoelde zaken en genoemde belastingaanslagen. Dit noemt men het bodemrecht van de fiscus. Dit voorrecht
+      is niet toepasbaar door de ontvanger van HHNK.
+
+      22.2 Bodemrecht en bestuurlijke boeten
+
+      Niet van toepassing voor HHNK.
+
+      22.3 Overbetekening bodembeslag
+
+      Als de ontvanger bekend is met de omstandigheid dat zaken mogelijk in eigendom toebehoren aan een derde, dan is hij op
+      grond van artikel 435, derde lid, Rv verplicht bij beslaglegging op die zaken, dit beslag binnen acht dagen na de
+      beslaglegging aan die derde te doen betekenen door de belastingdeurwaarder.
+
+      Bij deze overbetekening moet de derde schriftelijk worden gemeld dat hij de mogelijkheid heeft een beroepschrift tegen
+      de inbeslagneming te richten aan D&H van HHNK.
+
+      De ontvanger gaat onmiddellijk tot betekening aan de derde over als hij op enig later tijdstip – maar vóór de geplande
+      verkoopdatum – kennis krijgt van het feit dat de in beslag genomen zaken mogelijk eigendom zijn van die derde. Als
+      tussen het moment van de betekening aan de derde en de vastgestelde verkoopdatum minder dan acht dagen liggen, gaat de
+      ontvanger over tot het vaststellen van een nieuwe verkoopdatum.
+
+      22.4 Volgorde uitwinning bodembeslag buiten faillissement
+
+      Niet van toepassing voor HHNK.
+
+      22.5 Volgorde uitwinning bodembeslag in faillissement
+
+      Niet van toepassing voor HHNK.
+
+      22.6 Bodemrecht en insolventie van de derde-eigenaar
+
+      Niet van toepassing voor HHNK.
+
+      22.7 Bodemrecht en voorrang
+
+      Niet van toepassing voor HHNK.
+
+      22.8 Verzet en beroep
+
+      22.8.1 Verzet artikel 435, derde lid, Rv tegen bodembeslag
+
+      Als uit een verzetschrift ex artikel 435, derde lid, Rv blijkt dat de derde geen eigenaar is van de zaken genoemd in
+      dat verzetschrift, of voor de ontvanger anderszins duidelijk is dat de derde geen eigenaar is van de betreffende zaken,
+      dan vindt executie van die zaken in beginsel doorgang.
+
+      22.8.2 Taken met betrekking tot de schriftelijke mededeling ex artikel 435, derde lid, Rv inzake bodembeslag
+
+      Als de derde een schriftelijke mededeling ex artikel 435, derde lid, Rv heeft gedaan, heft de ontvanger het beslag op
+      als zonder meer duidelijk is dat het zaken betreft waarop de ontvanger geen verhaal kan nemen.
+
+      In de overige gevallen zendt de ontvanger de schriftelijke mededeling door naar D&H. Als ook D&H geen aanleiding ziet
+      aan het verzet tegemoet te komen, dan stuurt de ontvanger de stukken door naar de huisadvocaat met het verzoek een
+      procedure aan te spannen om een executoriale titel tegen de derde te verkrijgen.
+
+      22.8.3 Opschorting verkoop na verzet in rechte tegen bodembeslag
+
+      Een verzet op de voet van artikel 456 Rv tegen de verkoop van roerende zaken schort de voortgang van de executie niet
+      van rechtswege op.
+
+      Niettemin schort de ontvanger de invordering in het algemeen op en neemt hij geen onherroepelijke maatregelen, tenzij
+      naar het oordeel van de ontvanger het opschorten van de invordering de belangen van de HHNK schaadt.
+
+      22.8.4 Beroepschrift ex artikel 22 van de wet
+
+      Het beroepschrift ex artikel 22 van de wet moet worden ingediend bij de ontvanger, waaronder de belastingschuldige
+      ressorteert. Een beroepschrift kan niet meer worden ingediend als het beslag is opgeheven of vervallen.
+
+      Als toch een beroepschrift wordt ingediend, dan zal D&H dit beroepschrift niet in behandeling nemen omdat het beslag
+      niet meer ligt.
+
+      22.8.5 Beroepschriftprocedure ex artikel 22 van de wet
+
+      Onverminderd het bepaalde in artikel 22 van de wet geldt voor de beroepsfase dat als uit een beroepschrift niet
+      duidelijk blijkt waarop het beroep is gebaseerd, de ontvanger de indiener verzoekt om het beroepschrift binnen een
+      redelijke termijn (nader) te motiveren. De ontvanger wijst de indiener op een mogelijke niet-ontvankelijkverklaring bij
+      het niet voldoen aan de motiveringsplicht.
+
+      22.8.6 Taak van de ontvanger met betrekking tot beroepschrift ex artikel 22, eerste lid, van de wet
+
+      Een beroepschrift dat te laat is ingediend – maar dat betrekking heeft op een beslag dat nog steeds ligt – zal D&H niet
+      ontvankelijk verklaren, tenzij hij van oordeel is dat de indiener niet in verzuim is geweest.
+
+      Een beroepschrift dat in verband met te late indiening niet-ontvankelijk is verklaard, zal D&H ambtshalve in
+      behandeling nemen. De ontvanger schort in het algemeen eveneens de verkoop op – ongeacht de eventuele wettelijke
+      noodzaak daartoe – als een tijdig ingediend beroepschrift niet op alle in beslag genomen zaken betrekking heeft.
+
+      Als de belanghebbende zich met zijn bezwaren tot de ontvanger wendt voordat hij een beroepschrift indient of een
+      procedure aanspant, dan wijst de ontvanger de belanghebbende op de mogelijkheid een beroepschrift tot D&H te richten.
+      Als de ontvanger in dit stadium met de belanghebbende tot een oplossing kan komen, verdient dit uiteraard aanbeveling.
+      In geval van leasing geldt echter dat de ontvanger een beslag niet opheft dan na overleg met D&H.
+
+      22.8.7 Beslissing D&H op het beroepschrift tegen een bodembeslag
+
+      D&H motiveert de beslissing ook als sprake is van een te laat ingediend beroepschrift. D&H zendt zijn beslissing op een
+      ontvankelijk verklaard beroepschrift aan de ontvanger. De ontvanger draagt zorg voor onmiddellijke betekening van de
+      beslissing aan de derde, aan de belastingschuldige of hun gemachtigden en – zo nodig – aan de bewaarder. Voor de
+      betekening van de beslissing van D&H worden geen kosten in rekening gebracht.
+
+      Een beslissing op een niet-ontvankelijk verklaard beroepschrift wordt hetzij door D&H rechtstreeks aan de adressant of
+      zijn gemachtigde en zo nodig aan de bewaarder gezonden, hetzij op verzoek van D&H betekend op de wijze die geldt voor
+      een ontvankelijk verklaard beroepschrift.
+
+      Als het gewenst is dat de zaken – in afwachting van de beslissing op het beroepschrift – spoedig worden verkocht, dan
+      kan de ontvanger na overleg met D&H erin toestemmen dat de verkoop door de derde gebeurt mits de opbrengst – die in de
+      plaats van de zaken treedt – in afwachting van de beslissing bij de ontvanger wordt gedeponeerd.
+
+      22.8.8 Onduidelijk bezwaar tegen bodembeslag
+
+      De situatie kan zich voordoen dat de ontvanger uit het ingediende bezwaarschrift niet kan opmaken of is beoogd
+      administratief beroep in te stellen op grond van artikel 22, eerste lid, van de wet dan wel verzet aan te tekenen op
+      grond van artikel 435, derde lid, Rv.
+
+      Als dat het geval is, nodigt de ontvanger de derde uit zich daarover binnen tien dagen uit te laten. Als de derde niet
+      reageert, wordt het geschrift aangemerkt als een beroepschrift ex artikel 22, eerste lid, van de wet.
+
+      22.8.9 Samenloop administratief beroep en verzet tegen bodembeslag
+
+      Als de derde zowel een beroepschrift ex artikel 22, eerste lid, van de wet indient als een schriftelijke mededeling
+      doet als bedoeld in artikel 435, derde lid, Rv, dan zendt de ontvanger eerst het beroepschrift ter behandeling aan D&H,
+      voordat hij het verzet ex artikel 435, derde lid, Rv behandelt.
+
+      Als de ontvanger daarbij van oordeel is dat het beslag kan worden opgeheven, dan bevordert hij de intrekking van het
+      beroepschrift ex artikel 22 van de wet. Bij een verzetprocedure beslist D&H op het beroepschrift, in die zin dat hij
+      zich zal houden aan de uitspraak gewezen in de verzetprocedure.
+
+      22.9 Terughoudend beleid bij reëel eigendom derde
+
+      Niet van toepassing voor HHNK.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_22
+
+  - number: 22bis
+    text: |-
+      Niet van toepassing voor HHNK.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_22bis
+
+  - number: '24'
+    text: |-
+      **Verrekening**
+
+      Artikel 24 van de wet regelt de verrekening door de ontvanger van in te vorderen en uit te betalen bedragen. Bij de
+      verrekening mag de ontvanger geen gebruik maken van de algemene bepalingen van het BW. Tijdens faillissement, surseance
+      en WSNP geldt artikel 24 van de wet niet; dan zijn de artikelen 53 tot en met 56, 234, 235 en 307 FW van toepassing.
+
+      In aansluiting op artikel 24 van de wet beschrijft dit artikel het beleid over:
+
+      •
+
+      wanneer verrekening;
+
+      •
+
+      betwiste schuld en verrekening;
+
+      •
+
+      reikwijdte van de verrekening;
+
+      •
+
+      bekendmaking verrekening;
+
+      •
+
+      instemmingsregeling bij cessie en verpanding.
+
+      24.1 Wanneer verrekening
+
+      De verrekening vindt niet van rechtswege plaats. De ontvanger bepaalt of al dan niet tot verrekening wordt overgegaan.
+
+      Als de belastingschuldige de ontvanger verzoekt een bepaalde belastingteruggaaf of een ander uit te betalen bedrag met
+      een bepaalde openstaande aanslag of andere vordering te verrekenen, dan willigt de ontvanger dit verzoek altijd in.
+
+      Dit geldt ook als het verzoek wordt gedaan nog voordat de teruggaaf is geformaliseerd of het uit te betalen bedrag is
+      vastgesteld. In dat geval schort de ontvanger de invordering echter niet zonder meer op. Zo nodig kan de
+      belastingschuldige om uitstel van betaling in verband met de te verwachten teruggaaf respectievelijk het te verwachten
+      uit te betalen bedrag verzoeken (zie artikel 25.3 van deze leidraad).
+
+      24.1.1 Verrekening voorlopige teruggaaf inkomstenbelasting en beslagvrije voet
+
+      Niet van toepassing voor HHNK.
+
+      24.2 Betwiste schuld en verrekening
+
+      In het algemeen gaat de ontvanger niet tot verrekening over met een te betalen bedrag dat de belastingschuldige betwist
+      en waarvoor de ontvanger uitstel van betaling heeft verleend op grond van artikel 25.2 van deze leidraad.
+
+      De ontvanger kan wel verrekenen als de financiële situatie van de belastingschuldige zodanig is dat vrees voor
+      onverhaalbaarheid bestaat.
+
+      24.3 Reikwijdte van de verrekening
+
+      Ondanks het feit dat de wet daartoe wel de mogelijkheid biedt, worden uit te betalen bedragen niet automatisch
+      verrekend met aanslagen die (nog) niet invorderbaar zijn. Dit laat onverlet dat de ontvanger bevoegd is om in daartoe
+      aanleiding gevende gevallen binnen de betalingstermijn te verrekenen.
+
+      Bij belastingaanslag waarvan een termijnbetaling is verstreken, kan de ontvanger alleen verrekenen voor zover de
+      termijnen zijn verstreken.
+
+      Hierop maakt de ontvanger een uitzondering als er sprake is van een situatie als bedoeld in artikel 10, eerste lid,
+      onderdelen b, c of d van de wet. Dan is verrekening mogelijk met alle termijnen van de voorlopige aanslag vanaf het
+      moment dat zich één van de genoemde situaties voordoet.
+
+      Verrekening met andere bedragen waarvan de invordering aan de ontvanger is opgedragen, kan plaatsvinden vanaf het
+      moment waarop de invordering aan de ontvanger is opgedragen.
+
+      24.3a Verrekening teruggaaf artikel 29, eerste lid, Wet op de omzetbelasting
+
+      Niet van toepassing voor HHNK.
+
+      24.4 Bekendmaking verrekening
+
+      Verrekening van een uit te betalen bedrag door de ontvanger gebeurt bij beschikking. De beschikking wordt aan de
+      belastingschuldige bekendgemaakt door toezending of uitreiking van een kennisgeving.
+
+      24.5 Verrekening en fiscale eenheid vennootschapsbelasting
+
+      Niet van toepassing voor HHNK.
+
+      24.5a Verrekeningsbevoegdheid fiscale eenheid vennootschapsbelasting tijdens faillissement
+
+      Niet van toepassing voor HHNK.
+
+      24.6 Instemmingsregeling bij cessie en verpanding
+
+      24.6.1 Geen verrekening bij instemming cessie of verpanding
+
+      In artikel 24, vierde lid, van de wet is een instemmingsregeling opgenomen die verrekening uitsluit als de ontvanger
+      instemt met cessie (artikel 3:94 BW) of stille verpanding (artikel 3:239 BW) van een uit te betalen bedrag.
+
+      Als de ontvanger niet heeft ingestemd, kan hij tot verrekening met openstaande schulden overgaan ook al is de cessie of
+      verpanding aan hem meegedeeld. De ontvanger verrekent het uit te betalen bedrag met de belastingschulden die openstaan
+      op het moment van formalisering van het uit te betalen bedrag.
+
+      Bij openbare verpanding van een uit te betalen bedrag geldt geen instemmingsregeling.
+
+      24.6.2 Mogelijkheid van cessie of verpanding uit te betalen bedragen
+
+      Cessie of stille verpanding van een uit te betalen bedrag is mogelijk mits dit bedrag voldoende bepaald is omschreven.
+
+      Stille verpanding is mogelijk vanaf het moment dat de aanspraak op teruggaaf van het saldo van positieve en negatieve
+      elementen van de belastingaanslag of de teruggaafbeschikking materieel vaststaat. Dit is op zijn vroegst het geval na
+      het einde van het jaar of tijdvak waarop de teruggaaf betrekking heeft.
+
+      24.6.3 Instemming of weigering met een cessie of verpanding
+
+      De weigering van een instemming met de cessie of verpanding heeft betrekking op de gehele cessie of verpanding. De
+      instemming wordt niet gedeeltelijk verleend. Wel bestaat de mogelijkheid om een uit te betalen bedrag in gedeelten te
+      cederen of te verpanden. De ontvanger moet dan bij iedere cessie of verpanding afzonderlijk beoordelen of hij daarmee
+      instemt.
+
+      Instemming met een cessie of verpanding wordt alleen geweigerd als de ontvanger gegronde redenen heeft om aan te nemen
+      dat instemmen met de cessie of verpanding zal kunnen leiden tot oninbaarheid dan wel onverhaalbaarheid van een ten
+      tijde van de mededeling invorderbare belastingaanslag (of anderszins voor verrekening vatbare schuld) waarmee het uit
+      te betalen bedrag zonder cessie of verpanding had kunnen worden verrekend. De weigering voorkomt aldus dat de
+      invordering van deze aanslag wordt gefrustreerd. Deze situatie zal zich onder meer voordoen bij een belastingschuldige
+      die bekend staat als een notoir slechte betaler.
+
+      Met nadruk wordt vermeld dat bij de beoordeling of met een cessie of verpanding moet worden ingestemd geen rekening
+      wordt gehouden met materieel ontstane belastingschulden die nog niet zijn geformaliseerd in een belastingaanslag. De
+      ontvanger is verplicht met een cessie of verpanding in te stemmen als op het tijdstip van de mededeling van de cessie
+      of verpanding ten name van de belastingschuldige geen voor verrekening vatbare (en dus geformaliseerde) schuld
+      invorderbaar is.
+
+      De ontvanger maakt zijn beschikking aan de belastingschuldige en aan de derde – in dit geval de pandhouder of
+      cessionaris – bekend door middel van een gedagtekende kennisgeving, waarbij de belastingschuldige op de mogelijkheid
+      wordt gewezen bij D&H beroep in te stellen.
+
+      24.6.4 Beroepsprocedure weigeren instemming cessie of verpanding en Awb
+
+      Onverminderd het bepaalde in artikel 24 van de wet geldt met betrekking tot een beroepschrift waaruit niet direct
+      duidelijk blijkt waarop het beroep is gebaseerd, dat de ontvanger de indiener verzoekt het beroepschrift binnen een
+      redelijke termijn (nader) te motiveren. De ontvanger wijst de indiener op een mogelijke niet-ontvankelijkverklaring bij
+      het niet voldoen aan deze motiveringsplicht.
+
+      24.6.5 Bekendmaking beschikking D&H bij cessie of verpanding
+
+      De beschikking van D&H op het beroepschrift wordt bekendgemaakt door toezending of uitreiking van de beschikking aan
+      zowel de belastingschuldige als de derde, in dit geval de pandhouder of cessionaris.
+
+      24.6.6 Houding ontvanger bij procedure tegen weigeren instemming met cessie of verpanding
+
+      De belastingschuldige kan zich tot de voorzieningenrechter wenden met het verzoek de ontvanger te verbieden de
+      instemming te weigeren. Totdat de voorzieningenrechter uitspraak heeft gedaan, gaat de ontvanger niet tot verrekening
+      over.
+
+      Als de rechter het verzoek afwijst, dan verrekent de ontvanger niet eerder dan nadat veertien dagen zijn verstreken na
+      de dag van de uitspraak, tenzij tegen deze uitspraak hoger beroep is ingesteld.
+
+      Als de rechter het verzoek ook in hoger beroep afwijst, verrekent de ontvanger niet eerder dan nadat de uitspraak in
+      hoger beroep onherroepelijk vaststaat.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_24
+
+  - number: '25'
+    text: |-
+      **Uitstel van betaling**
+
+      Op grond van artikel 25 van de wet kan de ontvanger – onder door hem te stellen voorwaarden – uitstel van betaling
+      verlenen aan de belastingschuldige voor (een gedeelte van) een opgelegde belastingaanslag.
+
+      Het verlenen van uitstel van betaling gebeurt in beginsel op schriftelijk verzoek van de belastingschuldige. In daartoe
+      aanleiding gevende gevallen kan de ontvanger ook ambtshalve uitstel van betaling verlenen.
+
+      De ontvanger kan een verleend uitstel van betaling bij beschikking tussentijds beëindigen.
+
+      In aansluiting op artikel 25 van de wet beschrijft dit artikel het beleid over:
+
+      •
+
+      de algemene uitgangspunten van het uitstelbeleid;
+
+      •
+
+      uitstel in verband met bezwaar tegen een belastingaanslag.
+
+      •
+
+      uitstel in verband met een te verwachten uit te betalen bedrag;
+
+      •
+
+      uitstel in verband met betalingsproblemen;
+
+      •
+
+      betalingsregeling voor particulieren;
+
+      •
+
+      betalingsregeling voor ondernemers.
+
+      25.1 Algemene uitgangspunten uitstelbeleid
+
+      25.1.1 Houding van de ontvanger tijdens behandeling verzoek om uitstel
+
+      Gedurende de behandeling van het verzoek om uitstel van betaling handelt de ontvanger overeenkomstig het beleid dat
+      wordt gevoerd als het verzoek is toegewezen.
+
+      Als er aanwijzingen zijn dat de belangen van HHNK kunnen worden geschaad, kan de ontvanger ondanks het verzoek om
+      uitstel wel invorderingsmaatregelen treffen.
+
+      25.1.2 Toewijzing van het verzoek om uitstel van betaling
+
+      Bij toewijzing van het verzoek vermeldt de ontvanger de voorwaarden waaronder hij uitstel van betaling verleent in de
+      beschikking.
+
+      25.1.3 Redenen afwijzing verzoek om uitstel
+
+      Een verzoek om uitstel van betaling wordt in ieder geval afgewezen als:
+
+      •
+
+      het verzoek niet schriftelijk is ingediend, tenzij sprake is van een verzoek om uitstel als bedoeld in artikel 25.5.3;
+
+      •
+
+      de medewerking van de verzoeker aan HHNK naar het oordeel van de ontvanger onvoldoende is;
+
+      •
+
+      onjuiste gegevens worden verstrekt;
+
+      •
+
+      de gevraagde gegevens niet (volledig) binnen de door de ontvanger daartoe gestelde termijn zijn verstrekt. Als de
+      gegevens onvolledig zijn, stelt de ontvanger de belastingschuldige in de gelegenheid de ontbrekende gegevens alsnog
+      binnen twee weken te verstrekken;
+
+      •
+
+      de gevraagde zekerheid niet wordt gesteld (zie artikel 25.1.1, 25.2.6, 25.5.2 en 25.6.2 van deze leidraad);
+
+      •
+
+      de waarde van vermogensobjecten in redelijkheid te gelde kan worden gemaakt teneinde daarmee de verschuldigde belasting
+      te betalen;
+
+      •
+
+      de berekende betalingscapaciteit zodanig is dat de schuld direct voldaan kan worden;
+
+      •
+
+      de betalingsregeling zich over een voor de ontvanger onaanvaardbare termijn uitstrekt;
+
+      •
+
+      de betalingsproblemen structureel zijn en een betalingsregeling volgens de ontvanger geen uitkomst zal bieden;
+
+      •
+
+      sprake is van een verzoek om uitstel van betaling van een belastingaanslag in verband met betalingsmoeilijkheden en
+      voorafgaande aan dat verzoek uitstel is genoten in verband met een bezwaar- of beroepsprocedure tegen die aanslag,
+      terwijl gedurende die procedure betalingsmiddelen ter beschikking hebben gestaan, waarmee de belastingschuld kon worden
+      betaald;
+
+      •
+
+      voor zover het een bezwaar betreft dat direct of indirect gericht is tegen een onherroepelijk vaststaande
+      WOZ-beschikking bij een gemeentelijke belastingdienst;
+
+      •
+
+      indien de belastingschuldige reeds eerder een regeling heeft genoten, maar deze niet is nagekomen;
+
+      •
+
+      indien ter zake van de aanslag reeds een beslagopdracht naar de belastingdeurwaarder is uitgegaan dan wel door de
+      belastingdeurwaarder reeds beslag is gelegd;
+
+      •
+
+      in geval van een vordering op grond van artikel 19 van de wet;
+
+      •
+
+      indien voor hetzelfde tijdvak de automatische incasso niet is nagekomen door de belastingschuldige.
+
+      De ontvanger is niet verplicht de belastingschuldige in de gelegenheid te stellen zijn zienswijze naar voren te laten
+      brengen voordat hij het verzoek om uitstel geheel of gedeeltelijk afwijst. Als het verzoek om uitstel wordt afgewezen,
+      moet gemotiveerd worden waarom tot afwijzing van het verzoek is besloten. Daarbij wordt getracht alle afwijzingsgronden
+      te noemen; er kan echter worden volstaan met het noemen van de voornaamste afwijzingsgrond.
+
+      25.1.4 Redenen beëindigen uitstel
+
+      Het uitstel wordt in ieder geval beëindigd als:
+
+      •
+
+      niet aan de voorwaarden wordt voldaan waaronder het uitstel is verleend;
+
+      •
+
+      tijdens de looptijd van het uitstel blijkt dat onjuiste gegevens zijn verstrekt;
+
+      •
+
+      de aanleiding tot uitstel van betaling is weggevallen;
+
+      •
+
+      de financiële omstandigheden van de belastingschuldige zodanig veranderen of zijn veranderd dat het naar het oordeel
+      van de ontvanger onjuist is het uitstel te continueren;
+
+      •
+
+      de medewerking van de verzoeker aan HHNK naar het oordeel van de ontvanger onvoldoende is;
+
+      •
+
+      zich een situatie voordoet zoals omschreven in artikel 10 van de wet en de ontvanger van mening is dat de
+      verhaalbaarheid van de belastingschuld waarvoor uitstel is verleend, ernstig in gevaar komt;
+
+      •
+
+      belastingschuldige in staat van faillissement wordt verklaard, hem surseance van betaling wordt verleend of hij wordt
+      toegelaten tot de WSNP.
+
+      25.1.5 Beëindigen van een betalingsregeling met meer dan één termijn
+
+      Als de belastingschuldige een betalingsregeling van meer dan één termijn niet nakomt, kan de ontvanger alvorens hij de
+      regeling beëindigt, de belastingschuldige in de gelegenheid stellen om alsnog binnen veertien dagen de achterstand te
+      voldoen.
+
+      25.1.6 Van rechtswege vervallen van een verleend uitstel
+
+      Als de ontvanger uitstel heeft verleend tot een bepaald tijdstip en dit tijdstip is verstreken, dan is daardoor het
+      uitstel van rechtswege vervallen.
+
+      25.1.7 Geen invordering tijdens verleend uitstel
+
+      Tenzij in de leidraad anders is aangegeven, kan de ontvanger voor een belastingaanslag waarvoor hij uitstel van
+      betaling heeft verleend, geen invorderingsmaatregelen nemen. Tenzij naar het oordeel van de ontvanger aanwijzingen
+      bestaan dat door het niet onmiddellijk aanvangen of vervolgen van de invordering de belangen van HHNK worden geschaad.
+
+      25.1.8 Na (afwijzen) uitstel veertien dagen wachttijd
+
+      Als de ontvanger geen (verder) uitstel van betaling verleent of een verleend uitstel beëindigt, of als D&H afwijzend
+      heeft beslist op een ingediend beroepschrift tegen de afwijzing of beëindiging, dan wordt de vervolging in beginsel
+      niet aangevangen of voortgezet binnen een termijn van veertien dagen na dagtekening van de beschikking. Hetzelfde geldt
+      als het uitstel van betaling van rechtswege is vervallen en daarvan een mededeling is gedaan.
+
+      Een dergelijke mededeling blijft overigens achterwege als op telefonisch verzoek uitstel is verleend. In dat geval
+      geldt de termijn van veertien dagen niet.
+
+      Verkorting of het niet verlenen van deze termijn vindt onder meer plaats als naar het oordeel van de ontvanger
+      aanwijzingen bestaan dat door het niet onmiddellijk aanvangen of vervolgen van de invordering de belangen van HHNK
+      worden geschaad. Verder geldt deze termijn niet als een executieverkoop wordt opgeschort en in verband daarmee uitstel
+      van betaling is verleend in samenhang met een prolongatieovereenkomst.
+
+      25.1.9 Uitstel voor een ambtshalve belastingaanslag
+
+      Niet van toepassing voor HHNK.
+
+      25.1.10 Uitstel voor een aanslag ter behoud van rechten
+
+      Niet van toepassing voor HHNK.
+
+      25.1.11 Uitstel voor een bestuurlijke boete
+
+      De ontvanger verleent uitstel van betaling voor een bestuurlijke boete in verband met bezwaar, beroep of hoger beroep
+      tegen de bestuurlijke boete.
+
+      De ontvanger verleent ook uitstel van betaling voor een bestuurlijke boete als sprake is van een bezwaarschrift tegen
+      een belastingaanslag en de bedragen van die belastingaanslag en die van de boetebeschikking op één aanslagbiljet zijn
+      vermeld. De ontvanger verleent dit uitstel niet als uit het bezwaarschrift blijkt dat het bezwaar zich niet richt tegen
+      de bestuurlijke boete.
+
+      Aan het uitstel kan de ontvanger voorwaarden verbinden die ertoe strekken de belangen van HHNK veilig te stellen. De
+      ontvanger verleent het uitstel tot het moment waarop op het bezwaarschrift is beslist.
+
+      25.1.12 Tijdens uitstel nieuwe aanslagen voldoen [Vervallen per 01-07-2016]
+
+      25.1.13 Zekerheid bij uitstel
+
+      De ontvanger kan bij het verlenen van uitstel van betaling de voorwaarde stellen dat de belastingschuldige of een derde
+      zekerheid stelt. Bij het stellen van zekerheid gaat de voorkeur uit naar zekerheden die op eenvoudige wijze kunnen
+      worden gesteld, bewaakt en uitgewonnen.
+
+      Een aangeboden zekerheid in de vorm van een bezitloze verpanding van voorraden is in beginsel niet aanvaardbaar vanwege
+      de aard van deze zekerheid. De ontvanger aanvaardt een bezitloze verpanding van voorraden slechts als aannemelijk is
+      dat de belastingschuld niet kan worden betaald en andere zekerheidsvormen niet voorhanden zijn.
+
+      25.1.14 Tijdstip indiening verzoek om uitstel
+
+      De ontvanger neemt een verzoek om uitstel van betaling altijd in behandeling, ongeacht het tijdstip van indiening en
+      het stadium van de invordering.
+
+      De ontvanger wijst een verzoek om uitstel van betaling in verband met betalingsproblemen in het algemeen af als het
+      verzoek is ingediend nadat aankondiging van een ten laste van de belastingschuldige te houden executoriale verkoop
+      heeft plaatsgevonden, of als publicatie daarvan niet meer is te voorkomen.
+
+      Om de belangen van HHNK niet te schaden, kan de ontvanger de beslissing op een vlak voor de executoriale verkoop
+      ingediend verzoek om uitstel mondeling bekendmaken. De ontvanger bevestigt deze beslissing zo spoedig mogelijk bij
+      beschikking. In dat geval geldt uiteraard niet de termijn van veertien dagen waarbinnen de ontvanger de invordering
+      niet mag aanvangen of voortzetten.
+
+      De ontvanger willigt geen enkel verzoek om uitstel meer in als de belastingdeurwaarder is begonnen met de executoriale
+      verkoop.
+
+      25.1.15 Verzoekschriften aan andere instellingen
+
+      Niet van toepassing voor HHNK.
+
+      25.2 Uitstel in verband met bezwaar tegen een belastingaanslag
+
+      25.2.1 Bezwaar tegen hoogte belastingaanslag
+
+      De belastingschuldige kan bezwaren tegen de hoogte van een belastingaanslag door middel van een bezwaar- of
+      beroepschrift kenbaar maken. Onder een bezwaarschrift wordt ook begrepen een door de belastingschuldige ingediend
+      (hoger) beroepschrift. Een in verband daarmee gevraagd uitstel van betaling kan de ontvanger verlenen tot het moment
+      waarop de inspecteur uitspraak op het bezwaarschrift doet.
+
+      Het in artikel 25.2 van deze leidraad beschreven uitstelbeleid heeft uitsluitend betrekking op het door de
+      belastingschuldige bestreden deel van de belastingaanslag waarvoor uitstel is verzocht of verleend.
+
+      De ontvanger kan – als erom wordt verzocht – ook uitstel van betaling verlenen als bij de gemeente bezwaar is gemaakt
+      tegen de WOZ-beschikking in het geval dat een belastingaanslag is geregeld met inachtneming van de bestreden
+      WOZ-taxatiewaarde. Om te kunnen beoordelen in hoeverre de WOZ-taxatie wordt bestreden, moet de belastingschuldige een
+      kopie van het bezwaarschrift tegen de WOZ-beschikking overleggen. De belastingschuldige hoeft geen bezwaar te maken
+      tegen de aanslag omdat de ambtenaar belast met de heffing de aanslag automatisch herziet als de taxatiewaarde wijzigt.
+
+      25.2.2 Bezwaarschrift geldt als verzoek om uitstel; beroepschrift niet
+
+      Als de belastingschuldige een gemotiveerd bezwaarschrift tegen een belastingaanslag indient, merkt de ontvanger het
+      bezwaarschrift aan als een verzoek om uitstel van betaling. Dit geldt echter uitsluitend als de belastingschuldige in
+      het bezwaarschrift tevens het bestreden bedrag van de belastingaanslag en de berekening van dat bedrag vermeldt.
+
+      Een beroepschrift tegen de uitspraak van de inspecteur op het bezwaarschrift en een door de belastingschuldige
+      ingesteld hoger beroep of beroep in cassatie tegen een rechterlijke uitspraak over de juistheid van een dergelijke
+      uitspraak, gelden niet als een verzoek om uitstel van betaling. In die gevallen moet de belastingschuldige dus een
+      afzonderlijk verzoek om uitstel van betaling indienen bij de ontvanger.
+
+      25.2.2a Afzonderlijk verzoek om uitstel in verband met een bezwaarschrift
+
+      Als de belastingschuldige een verzoek om uitstel indient bij de ontvanger in verband met een bezwaarschrift tegen de
+      belastingaanslag dan moet hij in het verzoek het bestreden bedrag van de aanslag en de berekening van dat bedrag
+      vermelden.
+
+      25.2.2b Nadere gegevens
+
+      De ontvanger kan aan de belastingschuldige nadere gegevens vragen ter bepaling van de hoogte van het bestreden bedrag.
+      De ontvanger geeft de belastingschuldige een termijn van ten hoogste een maand vanaf de dagtekening van zijn verzoek om
+      nadere gegevens. De invordering wordt voor die termijn geschorst.
+
+      Een langere termijn (of verlenging van de eerder gegeven termijn) is mogelijk als de ontvanger van oordeel is dat dit
+      redelijk is. Als de belastingschuldige de verleende termijn ongebruikt voorbij laat gaan, wijst de ontvanger het
+      verzoek om uitstel af.
+
+      Hetgeen in dit artikel is vermeld is van overeenkomstige toepassing op een uitdrukkelijk verzoek om uitstel van
+      betaling opgenomen in het bezwaarschrift zelf.
+
+      Ook is hetgeen in dit artikel is vermeld van overeenkomstige toepassing op een door de belastingschuldige bij de
+      ontvanger ingediend verzoek om uitstel in verband met een op korte termijn in te dienen bezwaarschrift. In dit laatste
+      geval licht de ontvanger de inspecteur daaromtrent in en wordt het verzoek tevens aangemerkt als een pro forma
+      bezwaarschrift.
+
+      Als sprake is van een verzoek om uitstel in verband met een ingediend beroepschrift, dient tevens een kopie van het
+      beroepschrift te worden overgelegd.
+
+      25.2.3 De beslissing op het verzoek om uitstel van betaling
+
+      In het algemeen wijst de ontvanger een verzoek om uitstel van betaling in verband met een bezwaarschrift toe als aan de
+      in het artikel 25.2.2, 25.2.2a en 25.2.2b gestelde eisen is voldaan.
+
+      De ontvanger kan aan het uitstel voorwaarden verbinden. De toewijzende beslissing strekt zich niet verder uit dan tot
+      het bestreden bedrag.
+
+      25.2.4 Uitstel in verband met een onderlinge overlegprocedure
+
+      Niet van toepassing voor HHNK.
+
+      25.2.5 Zekerheid bij uitstel in verband met bezwaar
+
+      Als voorwaarde voor het verlenen van uitstel van betaling kan de ontvanger zekerheid verlangen voor de bestreden
+      belastingschuld. In beginsel vraagt de ontvanger alleen zekerheid, als de aard en omvang van de belastingschuld in
+      relatie tot de verhaalsmogelijkheden die bij de ontvanger bekend zijn daartoe aanleiding geven. Bij zijn beslissing
+      houdt de ontvanger ook rekening met het aangifte- en betalingsgedrag in het verleden.
+
+      25.2.6 Onherroepelijke invorderingsmaatregelen voor bestreden belastingschuld
+
+      Zolang de belastingaanslag waartegen een bezwaarschrift is ingediend niet onherroepelijk vaststaat, treft de ontvanger
+      voor de betwiste belastingschuld in beginsel geen onherroepelijke invorderingsmaatregelen.
+
+      Als echter aanwijzingen bestaan dat de belangen van HHNK of de belangen van de belastingschuldige door het achterwege
+      laten van onherroepelijke invorderingsmaatregelen worden geschaad, dan kan de ontvanger die maatregelen wel treffen.
+
+      Het leggen van beslag dat feitelijk dienst doet als een bewaringsmaatregel geldt niet als een onherroepelijke
+      invorderingsmaatregel.
+
+      25.2.7 Verrekening tijdens uitstel in verband met bezwaar
+
+      Als de ontvanger uitstel heeft verleend, blijft verrekening van het bestreden bedrag met een teruggaaf op een andere
+      belastingaanslag of andere uit te betalen bedragen achterwege, in afwachting van de uitspraak op het bezwaarschrift.
+
+      Hiervan kan worden afgeweken als de financiële situatie van de belastingschuldige zodanig is – bijvoorbeeld gelet op de
+      solvabiliteit van diens onderneming in relatie tot de hoogte van de (bestreden) belastingschuld – dat vrees voor
+      onverhaalbaarheid bestaat en verder niet voldoende zekerheid is gesteld.
+
+      Als de ontvanger overgaat tot verrekening, licht hij de belastingschuldige in bij de bekendmaking van de beschikking
+      omtrent zijn beweegredenen.
+
+      25.2.7a Nadere voorwaarden bij herbeoordeling verleend uitstel
+
+      Als de ontvanger bij het verlenen van het uitstel geen nadere voorwaarden heeft gesteld, kan hij uiterlijk binnen vier
+      maanden vanaf de datum dat het uitstel is verleend voor het ingediende bezwaarschrift schriftelijk aan de
+      belastingschuldige nadere voorwaarden stellen. Hierbij kijkt de ontvanger of de looptijd voor het afdoen van het
+      bezwaarschrift in relatie tot de hoogte van het bestreden bedrag van de aanslag daartoe aanleiding geeft. Voor de
+      beoordeling of hij zekerheid verlangt voor de bestreden belastingschuld, past de ontvanger de in artikel 25.2.5 van
+      deze leidraad opgenomen voorwaarden toe. Indien de belastingschuldige tijdig voldoet aan deze voorwaarden, continueert
+      de ontvanger het uitstel. De ontvanger trekt het uitstel in als de belastingschuldige niet aan deze voorwaarden
+      voldoet.
+
+      25.2.8 Geen uitstel voor het niet-bestreden bedrag
+
+      Als sprake is van een bestreden en niet-bestreden bedrag van een belastingaanslag, dan verleent de ontvanger uitstel
+      onder de opschortende voorwaarde dat het niet-bestreden bedrag per omgaande dan wel tijdig wordt betaald.
+
+      Als niet per omgaande dan wel niet tijdig wordt betaald, wordt de invordering zonder nadere aankondiging voor de gehele
+      belastingaanslag aangevangen dan wel voortgezet.
+
+      Een nieuw verzoek om uitstel voor de betreffende belastingaanslag in verband met bezwaar neemt de ontvanger pas in
+      behandeling als het niet-bestreden gedeelte van de belastingaanslag is voldaan.
+
+      25.2.9 Ten onrechte uitstel voor het gehele bedrag van de belastingaanslag
+
+      De ontvanger trekt het uitstel van betaling in, als dit is verleend in verband met bezwaar voor het volledige bedrag
+      van de belastingaanslag en later blijkt dat het bezwaar slechts betrekking heeft op een gedeelte van dat bedrag.
+
+      De ontvanger deelt daarbij mee dat hij een nieuw verzoek om uitstel voor de betreffende belastingaanslag in verband met
+      bezwaar pas in behandeling neemt, als het niet-bestreden gedeelte van de belastingaanslag tijdig is voldaan.
+
+      25.3 Uitstel in verband met een te verwachten uit te betalen bedrag
+
+      25.3.1 Uitstel in verband met een belastingteruggaaf en andere uit te betalen bedragen
+
+      Als binnen afzienbare tijd een door de ontvanger uit te betalen bedrag wordt verwacht, kan de ontvanger uitstel van
+      betaling verlenen tot het moment waarop hij dit uit te betalen bedrag kan verrekenen met de belastingaanslag waarvoor
+      uitstel wordt gevraagd.
+
+      Er is sprake van een binnen afzienbare tijd te verwachten belastingteruggaaf als:
+
+      •
+
+      het belastingjaar of belastingtijdvak waarover de teruggaaf wordt verwacht is afgelopen en;
+
+      •
+
+      de belastingschuldige een verzoek om teruggaaf heeft ingediend en;
+
+      •
+
+      over die teruggaaf tussen de inspecteur en de belastingplichtige geen verschil van mening bestaat.
+
+      25.3.2 Berekening van het uit te betalen bedrag bij uitstel
+
+      Bij het verzoek om uitstel moet een berekening van het uit te betalen bedrag zijn gevoegd. Als dit ontbreekt of
+      onvoldoende is gemotiveerd, geeft de ontvanger de belastingschuldige een termijn van ten hoogste een maand om alsnog
+      zijn verzoek (nader) te motiveren. De termijn begint te lopen vanaf de dagtekening van de kennisgeving van de ontvanger
+      dat de belastingschuldige zijn verzoek (nader) moet motiveren. De invordering wordt voor die termijn geschorst.
+
+      Een langere termijn (of verlenging van de eerder gegeven termijn) is mogelijk als de ontvanger van oordeel is dat dit
+      redelijk is. Als de belastingschuldige de verleende termijn ongebruikt voorbij laat gaan, wijst de ontvanger het
+      verzoek om uitstel af.
+
+      25.3.3 Beslissing op het verzoek om uitstel in verband met een uit te betalen bedrag
+
+      De ontvanger beslist – onder door hem te stellen voorwaarden – in het algemeen positief op een volledig gemotiveerd
+      verzoek om uitstel van betaling. De toewijzende beslissing strekt zich niet verder uit dan tot het te verrekenen
+      bedrag.
+
+      Het verschil tussen het bedrag van de belastingaanslag en het te verrekenen bedrag moet de belastingschuldige tijdig
+      betalen. De ontvanger kan echter een betalingsregeling toestaan als daartoe aanleiding bestaat.
+
+      25.3.4 Verrekening en uitstel in verband met een te verwachten uit te betalen bedrag
+
+      Uit te betalen bedragen waarop het uitstel geen betrekking heeft, verrekent de ontvanger met de openstaande
+      belastingschuld waarvoor uitstel van betaling is verleend in verband met een te verwachten uit te betalen bedrag.
+
+      Als volgens de ontvanger de continuïteit van de bedrijfsvoering direct gevaar loopt als gevolg van een eventuele
+      verrekening van teruggaven en niet hoeft te worden gevreesd voor onverhaalbaarheid van de schuld, dan kan hij deze
+      teruggaven (gedeeltelijk) uitbetalen.
+
+      25.4 Uitstel in verband met betalingsproblemen
+
+      25.4.1 Beslissing op een verzoek om uitstel in verband met betalingsproblemen
+
+      Als de belastingschuldige de belasting – geheel of gedeeltelijk – niet binnen de wettelijke betalingstermijnen kan
+      voldoen, kan de ontvanger aan de belastingschuldige op diens verzoek een betalingsregeling toestaan. De ontvanger kan
+      daarbij voorwaarden stellen.
+
+      Bij de beoordeling van het verzoek om uitstel spelen niet alleen de omstandigheden van dat moment een rol. Als de
+      belastingschuldige in het verleden bijvoorbeeld niet heeft gereserveerd voor redelijkerwijs voorzienbare schulden of
+      nalatig is geweest bij het doen van aangiften of betalingen, kan dit een rol spelen bij het toestaan en verlengen van
+      een betalingsregeling of bij het stellen van voorwaarden bij een betalingsregeling.
+
+      De ontvanger zal een betalingsregeling in ieder geval niet toestaan als de betalingsproblemen zijn terug te voeren op
+      structurele problemen of activiteiten die geen perspectief bieden.
+
+      25.4.2 Uitstel en autobelasting
+
+      Niet van toepassing voor HHNK.
+
+      25.4.3 Verrekening tijdens een betalingsregeling
+
+      Tijdens een betalingsregeling verrekent de ontvanger belastingteruggaven en andere teruggaven met een openstaande
+      belastingschuld. Als daar aanleiding toe is, kan de ontvanger afzien van het verrekenen van bepaalde teruggaven.
+
+      25.4.4 Uitstel in verband met faillissement, WSNP en surseance
+
+      Faillissementsschulden en belastingaanslagen waarop de WSNP van toepassing is, moet de ontvanger op de gebruikelijke
+      wijze bij de curator dan wel de bewindvoerder aanmelden. Voor deze schulden treft de ontvanger geen betalingsregeling.
+
+      De ontvanger verleent tijdens een surseance van betaling uitstel van betaling voor de belastingschuld die voor de
+      aanvang van de surseance materieel verschuldigd is geworden. De ontvanger stelt daarbij de voorwaarde dat de
+      belastingschuldige nieuw opkomende verplichtingen stipt nakomt.
+
+      Zo lang onzeker is of alle boedelschulden uit de boedel kunnen worden voldaan kan de ontvanger voor de betaling daarvan
+      uitstel verlenen.
+
+      Als voor belastingaanslagen zekerheid is gesteld, wint de ontvanger deze uit. Daarna informeert hij de curator dan wel
+      de bewindvoerder over de wijziging in de hoogte van de belastingschuld.
+
+      25.4.5 Uitstel van betaling erfbelasting bij verkrijging eigen woning door broers of zussen van de erflater
+
+      Niet van toepassing voor HHNK.
+
+      25.5 Betalingsregeling voor particulieren
+
+      25.5.1 Duur betalingsregeling particulieren
+
+      De ontvanger verleent de belastingschuldige uitstel van betaling voor het aantal maandelijkse termijnen dat nog
+      mogelijk is alsof vanaf dagtekening van de belastingaanslag geparticipeerd was aan de automatische incasso. Het aantal
+      termijnen is ten hoogste tien maanden, te rekenen vanaf de datum waarop de ontvanger de betalingsregeling bij
+      beschikking toestaat.
+
+      Slechts als er volgens de ontvanger bijzondere omstandigheden zijn, kan hij de belastingschuldige een langere termijn
+      gunnen dan tien maanden.
+
+      Indien uit het verzoek om uitstel blijkt dat de belastingschuldige over onvoldoende betalingscapaciteit beschikt om
+      binnen tien maanden zijn schuld te betalen, dan neemt de ontvanger dat verzoek ambtshalve in behandeling als een
+      verzoek om kwijtschelding. Bij de beoordeling daarvan neemt hij de gehele belastingschuld in beschouwing. Artikel
+      26.1.2 is in deze situatie niet van toepassing indien en voor zover de belastingschuldige gebruikmaakt van het daartoe
+      ingestelde verzoekformulier voor uitstel van betaling en hij dit formulier volledig invult.
+
+      25.5.2 Voorwaarden aan betalingsregeling particulieren
+
+      De ontvanger kan aan het verlenen van uitstel verschillende voorwaarden verbinden. In ieder geval stelt de ontvanger
+      aan het verlenen van een betalingsregeling de voorwaarde dat nieuw opkomende fiscale en andere financiële
+      verplichtingen – waarvan de invordering aan de ontvanger is opgedragen – tijdig worden nagekomen. De ontvanger kan
+      echter op verzoek van de belastingschuldige toestaan dat nieuwe belastingaanslagen, waarvan het ontstaan of onbetaald
+      laten niet aan de belastingschuldige kan worden toegerekend, in een bestaande betalingsregeling worden opgenomen.
+      Voorwaarde is dat de belastingschuldige zijn gehele betalingscapaciteit al heeft ingezet in het kader van de bestaande
+      betalingsregeling.
+
+      Daarnaast kan de ontvanger aan het verlenen van een betalingsregeling de voorwaarde stellen dat betaling dient plaats
+      te vinden door middel van automatische incasso, afgegeven aan HHNK.
+
+      De ontvanger kan alvorens het uitstel te verlenen, zekerheid eisen als de aard van de belastingschuld dan wel de omvang
+      van de belastingschuld in relatie tot de verhaalsmogelijkheden die bij de ontvanger bekend zijn, daartoe aanleiding
+      geeft. Ook het aangifte- en betalingsgedrag in het verleden kan aanleiding zijn voor het eisen van zekerheid.
+
+      25.5.3 Kort uitstel particulieren
+
+      Op schriftelijk of telefonisch verzoek kan zonder nader onderzoek een korte betalingsregeling worden getroffen als aan
+      de volgende cumulatieve voorwaarden is voldaan.
+
+      a.
+
+      De totale openstaande schuld van de belastingschuldige bedraagt minder dan € 500. Hierbij wordt geen rekening gehouden
+      met belastingschuld waarvoor uitstel van betaling in verband met een ingediend bezwaar- of beroepschrift is verleend.
+
+      b.
+
+      Aan de belastingschuldige is niet voor dezelfde belastingaanslag of voor andere belastingaanslagen uitstel van betaling
+      in verband met betalingsproblemen of uitstel in verband met een te verwachten uit te betalen bedrag verleend.
+
+      c.
+
+      De belastingschuldige heeft geen belastingschuld openstaan waarvoor een dwangbevel is betekend door de
+      belastingdeurwaarder of een postdwangbevel is verzonden waarvan de betalingstermijn is verstreken.
+
+      d.
+
+      De belastingschuldige heeft in de afgelopen drie jaren goed betalingsgedrag vertoond. Goed betalingsgedrag is te
+      omschrijven dat geen executoriale maatregelen dienden te worden genomen door de belastingdeurwaarder.
+
+      Daarbij geldt dat het voor belastingschuldigen verplicht is om mee te doen via de automatische incassoregeling.
+
+      Indien niet aan de automatische incasso meegedaan kan worden, dan is geen uitstel van betaling mogelijk.
+
+      25.5.4 Behandeling verzoek betalingsregeling particulieren
+
+      In andere gevallen als bedoeld in artikel 25.5.3 van deze leidraad kan de ontvanger, aan de hand van de daartoe door de
+      verzoeker verstrekte gegevens, overgaan tot de berekening van de betalingscapaciteit en de beoordeling van de
+      vermogenspositie. De ontvanger verleent in ieder geval geen uitstel van betaling als voor de belastingschuld waarvoor
+      uitstel wordt gevraagd al uitstel op grond van artikel 25.5.3 van deze leidraad is verleend, ongeacht of dit uitstel
+      nog loopt of reeds is beëindigd.
+
+      Voor de berekening van de betalingscapaciteit vraagt de ontvanger zo nodig nadere gegevens bij de verzoeker op. Bij de
+      berekening van de betalingscapaciteit gaat de ontvanger uit van de begrippen en normen die gelden bij het
+      kwijtscheldingsbeleid, behalve voor zover daarvan in de artikelen 25.5.6 tot en met 25.5.11 van deze leidraad wordt
+      afgeweken. Ook met betrekking tot het vermogen gaat de ontvanger uit van het vermogensbegrip zoals dat geldt in de
+      kwijtscheldingsregeling.
+
+      25.5.5 Vermogen en betalingsregeling particulieren
+
+      De aanwezigheid van vermogen op het moment van het indienen van het verzoek staat een betalingsregeling in het algemeen
+      in de weg. Dit geldt met name indien het vermogen zonder bezwaar liquide is te maken.
+
+      Het vermogen dat onder het kwijtscheldingsbeleid voor particulieren is vrijgesteld, staat een betalingsregeling echter
+      niet in de weg. Onder vermogen wordt in dit verband verstaan de bezittingen van de belastingschuldige en diens
+      echtgenoot (zoals bedoeld in artikel 3 Pw), verminderd met de schulden die een hogere preferentie hebben dan de
+      belastingschuld.
+
+      Met toepassing van artikel 3 Pw wordt als echtgenoot ook aangemerkt de ongehuwde die met een ander een gezamenlijke
+      huishouding voert, tenzij het een bloedverwant in de eerste graad betreft.
+
+      25.5.6 Betalingscapaciteit en betalingsregeling particulieren
+
+      Naast het aanwezige vermogen speelt bij de beoordeling van de financiële omstandigheden de zogenoemde
+      betalingscapaciteit van de verzoeker een belangrijke rol, zowel ten tijde van het indienen van het verzoek als
+      gedurende de looptijd van de betalingsregeling. De betalingscapaciteit van de belastingschuldige die door de ontvanger
+      wordt berekend, bepaalt in belangrijke mate het bedrag dat de belastingschuldige (periodiek) op de achterstallige
+      schuld moet aflossen.
+
+      De betalingscapaciteit geeft ook aan in hoeverre een betalingsregeling zinvol is.
+
+      Bij de berekening van de betalingscapaciteit gaat de ontvanger met betrekking tot de huur- en hypotheekverplichtingen
+      voor de woning waarin de belastingschuldige feitelijk verblijft uit van de werkelijke uitgaven.
+
+      De betalingscapaciteit bestaat uit het netto besteedbaar inkomen na aftrek van het normbedrag voor levensonderhoud.
+      Voor de betalingsregeling eist de ontvanger 80% van de betalingscapaciteit op.
+
+      25.5.7 Berekening betalingscapaciteit – bijzondere uitgaven
+
+      De ontvanger kan – afhankelijk van de concrete situatie van de belastingschuldige en zijn gezin – bepaalde aanvaardbare
+      uitgaven op de berekende betalingscapaciteit in mindering brengen. Het moet dan gaan om uitgaven die samenhangen met de
+      maatschappelijke positie van de belastingschuldige, en die naar het oordeel van de ontvanger niet in redelijkheid
+      kunnen worden betaald uit het normbedrag voor levensonderhoud en de zogenoemde uitvoeringstolerantie van 20%.
+
+      25.5.8 Berekening betalingscapaciteit – aflossingsverplichtingen aan derden
+
+      In het algemeen blijven bij de berekening van de betalingscapaciteit de aflossingsverplichtingen aan derden buiten
+      beschouwing. De ontvanger kan een uitzondering maken voor aflossingen op schulden waarvan het niet-betalen tot
+      ongewenste effecten kan leiden.
+
+      25.5.9 Berekening betalingscapaciteit – extra inkomsten
+
+      Bij de berekening van de betalingscapaciteit houdt de ontvanger slechts rekening met extra inkomsten, zoals
+      vakantiegeld, tantièmes en dergelijke, voor zover uitbetaling daarvan plaatsvindt dan wel zou moeten plaatsvinden in de
+      periode waarvoor de betalingsregeling geldt.
+
+      25.5.10 Belastingschuldige stelt zelf een betalingsregeling voor
+
+      Als een belastingschuldige uitstel vraagt en tegelijkertijd een betalingsregeling voorstelt waarbij de schuld binnen
+      tien maanden wordt afbetaald en deze regeling afwijkt van hetgeen de ontvanger heeft berekend, dan hoeft een niet al te
+      grote afwijking niet te leiden tot afwijzing van het verzoek.
+
+      Als de regeling die door de belastingschuldige is voorgesteld voor de ontvanger niet aanvaardbaar is, maar een andere
+      regeling wel ingewilligd kan worden, dan deelt de ontvanger onder afwijzing van het verzoek de belastingschuldige mee
+      welke regeling hij desgevraagd wel kan verlenen.
+
+      25.5.11 Betalingsregeling langer dan tien maanden
+
+      Het beleid zoals beschreven bij de berekening van de betalingscapaciteit bij regelingen tot en met tien maanden, is van
+      overeenkomstige toepassing op een regeling die vanwege bijzondere omstandigheden langer dan tien maanden duurt. Hierbij
+      moet in acht worden genomen dat de belastingschuldige zijn van de kwijtscheldingsnormen afwijkende uitgaven – waaronder
+      ook de huur of de hypotheeklasten – in de eerste vijf maanden van de betalingsregeling zodanig moet verminderen, dat na
+      de vijfde maand zoveel mogelijk de volledige betalingscapaciteit die aan het kwijtscheldingsbeleid is ontleend, kan
+      worden benut om de schuld te voldoen. De ontvanger sluit met de betalingsregeling hier op aan.
+
+      25.6 Betalingsregeling voor ondernemers
+
+      25.6.1 Duur betalingsregeling ondernemers
+
+      Een betalingsregeling moet een zo kort mogelijke periode beslaan. Bij het vaststellen van de duur van de
+      betalingsregeling houdt de ontvanger rekening met de omstandigheden, bijvoorbeeld de aard en de omvang van de schuld,
+      de liquiditeits- en de vermogenspositie van de onderneming en het aangifte- en betalingsgedrag in het verleden.
+
+      De betalingsregeling zal in elk geval een looptijd van tien maanden niet te boven gaan, gerekend vanaf de (laatste)
+      vervaldag van de belastingaanslag.
+
+      De ontvanger stelt als voorwaarde dat de belastingschuldige verplicht meedoet aan de automatische incassoregeling.
+
+      25.6.2 Voorwaarden betalingsregeling ondernemers
+
+      Aan het verlenen van een betalingsregeling stelt de ontvanger de voorwaarde dat de belastingschuldige nieuw opkomende
+      fiscale en andere financiële verplichtingen – waarvan de invordering aan de ontvanger is opgedragen – bijhoudt.
+
+      De ontvanger kan bij het verlenen van een betalingsregeling zekerheid eisen (zie artikel 25.1.13). Dit zal hij in ieder
+      geval doen als het aangifte- en betalingsgedrag van de belastingschuldige in het verleden, of de aard of de omvang van
+      de belastingschuld waarvoor om uitstel wordt verzocht, daartoe aanleiding geeft. Uitgangspunt voor de hoogte van de
+      zekerheid is de hoogte van de schuld waarvoor uitstel is verzocht.
+
+      25.6.2a Bijzondere omstandigheden betalingsregeling ondernemers
+
+      Niet van toepassing voor HHNK.
+
+      25.6.2b Verklaring derde deskundige
+
+      Niet van toepassing voor HHNK.
+
+      25.6.2c Geen uitstel voor ondernemers in verband met betalingsproblemen als al kort uitstel is verleend
+
+      Niet van toepassing voor HHNK.
+
+      25.6.2d Kort uitstel van betaling voor ondernemers
+
+      Niet van toepassing voor HHNK.
+
+      25.6.3 Uitstelbeleid particulieren geldt voor ex-ondernemers
+
+      Voor ex-ondernemers is het uitstelbeleid van toepassing zoals dat geldt voor particulieren, ook als de belastingschuld
+      betrekking heeft op de ondernemingsperiode.
+
+      25.6.4 Uitstel voor ondernemers en overheidssteun/subsidie
+
+      Als het de ontvanger bekend is dat van overheidszijde een onderzoek wordt ingesteld naar de mogelijkheid van subsidie-
+      of steunverlening om de schuld te voldoen of een sanering mogelijk te maken, dan verleent de ontvanger uitstel van
+      betaling als hij de verwachting heeft dat het verzoek door de (potentiële) subsidiënt zal worden gehonoreerd. De
+      belastingschuldige moet dan wel aan de lopende verplichtingen voldoen.
+
+      25.7 Administratief beroep
+
+      25.7.1 Toetsing uitstelbeschikking door D&H
+
+      Als de belastingschuldige het niet eens is met een door de ontvanger genomen beslissing op grond van artikel 25, eerste
+      lid of tweede lid, van de wet, kan de belastingschuldige daartegen administratief beroep instellen bij D&H. De
+      belastingschuldige moet het beroepschrift indienen bij de ontvanger die de beschikking heeft genomen.
+
+      Gedurende de behandeling van het beroepschrift handelt de ontvanger overeenkomstig het beleid dat wordt gevoerd als het
+      verzoek om uitstel is toegewezen.
+
+      Als er aanwijzingen zijn dat de belangen van HHNK kunnen worden geschaad, kan de ontvanger ondanks de behandeling van
+      het beroep wel invorderingsmaatregelen treffen.
+
+      25.7.2 Beroepsfase uitstel
+
+      De termijn voor het indienen van een beroepschrift bedraagt tien dagen na dagtekening van de bestreden beschikking. Als
+      uit het beroepschrift niet duidelijk blijkt waarop het beroep gebaseerd is, verzoekt de ontvanger de belastingschuldige
+      het beroepschrift binnen een redelijke termijn (nader) te motiveren. De ontvanger wijst daarbij op een mogelijke
+      niet-ontvankelijkverklaring bij het niet voldoen aan deze motiveringsplicht.
+
+      25.7.3 Beslissing D&H op beroepschrift bij uitstel
+
+      In alle gevallen waarin D&H van HHNK het beroep gegrond oordeelt, kan hij de zaak inhoudelijk afdoen, hetzij door het
+      verzoek alsnog toe te wijzen, hetzij door het af te wijzen onder verbetering of vervanging van de gronden.
+
+      25.7.4 Niet tijdig beslissen op een verzoek om uitstel
+
+      De belastingschuldige kan beroep instellen bij D&H tegen het niet tijdig nemen van een beslissing op een verzoek om
+      uitstel van betaling. Het indienen van een beroepschrift is in deze situatie niet aan een termijn gebonden.
+
+      Als tijdens de beroepsprocedure blijkt dat de ontvanger uitstel van betaling had moeten verlenen, dan hoeft D&H niet te
+      volstaan met de uitspraak dat de ontvanger niet tijdig heeft beslist, maar kan hij op het beroepschrift van de
+      belastingschuldige inhoudelijk beslissen.
+
+      25.7.5 Beroep, bezwaar, of nieuw verzoek om uitstel van betaling bij de ontvanger
+
+      1.
+
+      De ontvanger merkt een door de belastingschuldige ingediend bezwaarschrift tegen de beslissing op het verzoek om
+      uitstel aan als een beroepschrift. Dit geldt ook als de belastingschuldige een nieuw verzoek om uitstel indient voor
+      dezelfde belastingschuld als waarvoor de ontvanger eerder een verzoek om uitstel geheel of gedeeltelijk had afgewezen,
+      zonder daarbij andere feiten of veranderde omstandigheden te vermelden.
+
+      2.
+
+      In de in het eerste lid bedoelde situaties geeft de ontvanger een nieuwe beschikking af, als hij op dat moment
+      aanleiding ziet om een voor de belastingschuldige gunstigere beslissing te nemen. Als de belastingschuldige het ook met
+      de nieuwe beschikking niet eens is, kan hij daartegen binnen tien dagen in beroep gaan bij D&H van HHNK.
+
+      3.
+
+      Als de belastingschuldige in zijn nieuwe verzoek om uitstel voor dezelfde belastingschuld andere feiten of veranderde
+      omstandigheden vermeldt, beslist de ontvanger zelf op dat verzoek. Bij zijn beslissing houdt hij rekening met deze
+      feiten of veranderde omstandigheden. Als de belastingschuldige het ook met de nieuwe beschikking niet eens is, dan kan
+      hij daartegen binnen tien dagen in beroep gaan bij D&H.
+
+      4.
+
+      Als de belastingschuldige opnieuw verzoekt om uitstel van betaling, ter zake van een belastingschuld waarvoor D&H reeds
+      op een administratief beroep afwijzend heeft beslist, zonder daarbij nieuw gebleken feiten of veranderde omstandigheden
+      te vermelden, wijst de ontvanger dit verzoek af onder verwijzing naar de uitspraak van D&H. Als de belastingschuldige
+      het met deze beschikking niet eens is, dan kan hij daartegen binnen tien dagen in beroep gaan bij D&H.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_25
+
+  - number: 25a
+    text: |-
+      Niet van toepassing voor HHNK.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_25a
+
+  - number: '26'
+    text: |-
+      **Kwijtschelding van belastingen**
+
+      In artikel 26, eerste lid, van de wet is bepaald dat bij ministeriële regeling regels worden gegeven voor gehele of
+      gedeeltelijke kwijtschelding van rijksbelastingen. De ontvanger verleent gehele of gedeeltelijke kwijtschelding als de
+      belastingschuldige niet in staat is anders dan met buitengewoon bezwaar de belastingaanslag te betalen. In het algemeen
+      zal van buitengewoon bezwaar sprake zijn als de middelen om een belastingaanslag te betalen, ontbreken en ook niet
+      binnen afzienbare tijd worden verwacht.
+
+      De kwijtscheldingsregels op basis van artikel 26 van de wet zijn vastgelegd in de regeling. In de artikelen 19a en 22a
+      van deze regeling zijn de doelstellingen van de schuldsaneringsregeling natuurlijke personen in de belastingsfeer tot
+      uitdrukking gebracht.
+
+      Aan een aansprakelijkgestelde kan geen kwijtschelding worden verleend. Wel kan hij op zijn verzoek worden ontslagen van
+      de betalingsverplichting. In artikel 53, derde lid, van de wet is bepaald dat bij ministeriële regeling regels worden
+      gegeven op grond waarvan de ontvanger de aansprakelijkgestelde geheel of gedeeltelijk van zijn betalingsverplichting
+      kan ontslaan als deze niet in staat is anders dan met buitengewoon bezwaar te betalen.
+
+      De voorwaarden voor het al dan niet verlenen van kwijtschelding, gelden ook voor het ontslag van de
+      betalingsverplichting.
+
+      In aansluiting op artikel 26 van de wet beschrijft dit artikel het beleid over:
+
+      •
+
+      algemene uitgangspunten van het kwijtscheldingsbeleid;
+
+      •
+
+      kwijtschelding van (rijks)belastingen voor particulieren;
+
+      •
+
+      kwijtschelding van (rijks)belastingen voor ondernemers;
+
+      •
+
+      administratief beroep;
+
+      •
+
+      voortzetting van de invordering na afwijzing verzoek om kwijtschelding.
+
+      26.1 Algemene uitgangspunten kwijtscheldingsbeleid
+
+      26.1.1 Kwijtschelding van betaalde belastingschulden
+
+      De ontvanger verleent ook kwijtschelding van bedragen die op belastingaanslagen zijn betaald, als aan de volgende
+      voorwaarden is voldaan:
+
+      •
+
+      De belastingschuldige dient het verzoek om kwijtschelding in binnen drie maanden nadat de (laatste) betaling op de
+      belastingaanslag heeft plaatsgevonden;
+
+      •
+
+      De belastingschuldige heeft betaald onder omstandigheden die aanleiding zouden hebben gegeven tot kwijtschelding als
+      hij daar eerder om had verzocht.
+
+      Als de ontvanger het verzoek toewijst, betaalt hij de belastingschuldige de bedragen terug die tot maximaal drie
+      maanden voorafgaand aan de datum van indiening van het verzoek zijn verricht.
+
+      26.1.2 Het indienen van een verzoek om kwijtschelding
+
+      Het verzoek om kwijtschelding moet worden ingediend bij de ontvanger waaronder de belastingschuldige ressorteert, via
+      digitale weg door middel van "Mijn loket" op www.hhnk.nl (zie verder artikel 26.7), of op een daartoe ingesteld
+      kwijtscheldingsformulier.
+
+      Als de belastingschuldige dit kwijtscheldingsformulier onvolledig indient (bijvoorbeeld door ontbrekende gegevens),
+      stelt hij de belastingschuldige in de gelegenheid deze ontbrekende gegevens alsnog binnen twee weken te verstrekken. In
+      afwachting daarvan schort de ontvanger de invordering in beginsel op. Als ontbrekende gegevens niet van direct belang
+      zijn voor de beoordeling van het verzoekschrift dan worden de ontbrekende gegevens niet opgevraagd.
+
+      De ontvanger vraagt de gegevens slechts éénmaal op. Als de belastingschuldige niet alle gevraagde nadere gegevens
+      bijvoegt, beschouwt de ontvanger het verzoek ook als onvolledig ingevuld en wijst hij het verzoek af.
+
+      De termijn van behandeling van het verzoek om kwijtschelding begint nadat de ontvanger het aanvraagformulier – volledig
+      ingevuld en vergezeld van alle gevraagde kopieën – heeft ontvangen.
+
+      26.1.3 Niet ingevuld of onjuist ingevuld verzoekformulier om kwijtschelding
+
+      Als de ontvanger een uitgereikt of toegezonden verzoekformulier onvolledig ingevuld terug ontvangt, stelt hij de
+      belastingschuldige in de gelegenheid de ontbrekende gegevens alsnog binnen een maand te verstrekken. In afwachting
+      daarvan schort de ontvanger de invordering niet op. De ontvanger vraagt de gegevens slechts eenmaal op. Als de
+      belastingschuldige niet alle gevraagde nadere gegevens bijvoegt, beschouwt de ontvanger het verzoek ook als onvolledig
+      ingevuld.
+
+      Als een formulier volledig is ingevuld en alle noodzakelijke bijlagen zijn bijgevoegd, kan de ontvanger toch nadere
+      vragen stellen.
+
+      De termijn van behandeling van het verzoek om kwijtschelding begint nadat de ontvanger het aanvraagformulier – volledig
+      ingevuld en vergezeld van alle gevraagde kopieën – heeft ontvangen.
+
+      26.1.4 Gegevens en normen ten tijde van indiening verzoek om kwijtschelding
+
+      Bij de beoordeling van het verzoek zijn de gegevens en normen van belang die gelden op het moment van indiening van het
+      verzoek, tenzij in de leidraad anders is aangegeven.
+
+      26.1.5 Toewijzing van het verzoek om kwijtschelding onder voorwaarden
+
+      Als de ontvanger besluit dat kwijtschelding zal worden verleend nadat aan één of meer voorwaarden is voldaan, dan neemt
+      hij die voorwaarden in de beschikking op.
+
+      Als de ontvanger in de voorwaarden heeft opgenomen dat verrekening zal plaatsvinden van uit te betalen bedragen, dan
+      stelt hij tevens de termijn vast waarin verrekening van die bedragen zal plaatsvinden. De termijn bedraagt maximaal
+      drie jaar, te rekenen vanaf de dagtekening van de kennisgeving, dan wel – als dit minder is – de tijd die nog
+      overblijft voordat de verjaring van de belastingaanslag intreedt.
+
+      Als tot de voorwaarden de voldoening van een deel van de schuld behoort, dan moet de ontvanger de belastingschuldige
+      uitnodigen om binnen een termijn van veertien dagen een voorstel te doen met betrekking tot de betaling van dat deel.
+      Hierbij is het uitstelbeleid (zie artikel 25 van deze leidraad) van toepassing. Als tot de voorwaarden naast de
+      voldoening van een deel van de schuld ook de verrekening van teruggaven behoort, wordt het te betalen bedrag niet
+      beïnvloed door de hoogte van de verrekende teruggaven.
+
+      26.1.6 Motivering afwijzing van het verzoek om kwijtschelding
+
+      Als de ontvanger het verzoek om kwijtschelding afwijst, moet hij motiveren waarom hij tot afwijzing van het verzoek
+      heeft besloten. Daarbij moet hij alle afwijzingsgronden noemen.
+
+      26.1.7 Na afwijzen kwijtschelding veertien dagen wachttijd bij voortzetting invordering
+
+      Als de ontvanger afwijzend heeft beslist op een verzoek om kwijtschelding of een aangeboden akkoord, of D&H afwijzend
+      heeft beslist op een ingediend beroepschrift tegen een afwijzende beschikking van de ontvanger, voldoet de
+      belastingschuldige het op de belastingaanslag(en) verschuldigde bedrag binnen veertien dagen na dagtekening van de
+      afwijzende beschikking of binnen de betaaltermijnen die op het aanslagbiljet zijn aangegeven. Na deze termijn kan de
+      ontvanger de invordering aanvangen dan wel voortzetten. Artikel 9 van de regeling is gedurende deze wachttijd van
+      overeenkomstige toepassing.
+
+      De termijn van veertien dagen geldt niet als sprake is van een situatie als bedoeld in artikel 10 van de wet. De
+      termijn wordt daarnaast niet of niet geheel verleend als naar het oordeel van de ontvanger aanwijzingen bestaan dat
+      door het niet direct aanvangen of vervolgen van de invordering de belangen van HHNK worden geschaad.
+
+      26.1.8 Mondeling meedelen afwijzen kwijtschelding
+
+      Om de belangen van HHNK niet te schaden, kan de ontvanger de beslissing op een kort voor de executoriale verkoop
+      ingediend verzoek om kwijtschelding mondeling bekend maken. De ontvanger bevestigt deze beslissing zo spoedig mogelijk
+      bij beschikking. In dat geval geldt niet de termijn van veertien dagen waarbinnen de ontvanger de invordering niet mag
+      aanvangen of voortzetten.
+
+      Evenzo geldt voor een kort voor de executoriale verkoop gedaan verzoek dat niet is ingediend op een verzoekformulier of
+      op een verzoekformulier dat onvolledig is ingevuld, dat de ontvanger de belastingschuldige niet in de gelegenheid stelt
+      het verzoek in te dienen op het daartoe bestemde formulier of de belastingschuldige niet in de gelegenheid stelt de
+      ontbrekende gegevens aan te vullen (zoals bepaald in de artikelen 26.1.2 en 26.1.3 van deze leidraad), maar het verzoek
+      afwijst.
+
+      26.1.9 Wanneer wordt geen kwijtschelding verleend
+
+      Er wordt geen kwijtschelding verleend als:
+
+      •
+
+      de gevraagde gegevens voor de beoordeling van het verzoek niet, niet volledig, onjuist, of niet op het door de
+      ontvanger uitgereikte formulier (zie ook de artikelen 26.1.2 en 26.1.3 van deze leidraad) zijn verstrekt;
+
+      •
+
+      uit de verstrekte gegevens voor de beoordeling van het verzoek een onevenredige verhouding blijkt tussen de omvang van
+      de uitgaven enerzijds en het inkomen anderzijds en de belastingschuldige de in dat verband door de ontvanger gevraagde
+      opheldering niet – of naar het oordeel van de ontvanger – in onvoldoende mate verschaft;
+
+      •
+
+      de belastingschuldige heeft nagelaten de vereiste aangifte in te dienen. In dat geval wordt de belastingschuldige
+      meegedeeld dat een nieuw verzoek om kwijtschelding niet eerder kan worden ingediend, dan nadat de inspecteur op grond
+      van de alsnog verstrekte gegevens de belastingaanslag tot het juiste bedrag heeft kunnen vaststellen. Het verzoek dat
+      wordt ingediend nadat de belastingaanslag tot het juiste bedrag is vastgesteld, behandelt de ontvanger als een eerste
+      verzoek;
+
+      •
+
+      een bezwaarschrift tegen de hoogte van de belastingaanslag in behandeling is bij de heffingsambtenaar, dan wel een
+      beroepschrift tegen de hoogte van de belastingaanslag in behandeling is bij de rechtbank of (in hoger beroep) bij het
+      gerechtshof/Hoge Raad. Een eventuele vermindering of vernietiging van de belastingaanslag dient namelijk aan
+      kwijtschelding vooraf te gaan. De belastingschuldige wordt meegedeeld dat een nieuw verzoek om kwijtschelding niet
+      eerder kan worden ingediend dan nadat op het bezwaarschrift of beroepschrift (in hoger beroep) is beslist;
+
+      •
+
+      voor de desbetreffende belastingaanslag zekerheid is gesteld;
+
+      •
+
+      er sprake is van meer dan één belastingschuldige;
+
+      •
+
+      een derde nog voor de belastingschuld aansprakelijk kan worden gesteld;
+
+      •
+
+      het aan de belastingschuldige kan worden toegerekend dat de belastingaanslag niet kan worden voldaan. Daarvan is onder
+      andere sprake als:
+
+      a.
+
+      het aan opzet of grove schuld van de belastingschuldige is te wijten dat te weinig belasting is geheven;
+
+      b.
+
+      (vervallen);
+
+      c.
+
+      een uitbetaald bedrag (bijvoorbeeld een belastingteruggaaf) niet is aangewend ter voldoening van de schuld waarvan
+      kwijtschelding wordt gevraagd, tenzij het een voorlopige teruggaaf betreft voor zover die niet voor beslag vatbaar is;
+
+      d.
+
+      vanaf de bekendmaking van de belastingaanslag tot aan de indiening van het verzoek om kwijtschelding op enig moment
+      voldoende middelen aanwezig waren om de aanslag te kunnen voldoen;
+
+      e.
+
+      de belastingschuldige wist of redelijkerwijs kon vermoeden dat een belastingaanslag zou worden opgelegd en nalatig is
+      gebleven in verband daarmee middelen te reserveren;
+
+      f.
+
+      niet van toepassing;
+
+      g.
+
+      niet van toepassing;
+
+      h.
+
+      niet van toepassing;
+
+      •
+
+      de belastingschuldige in surseance van betaling of in staat van faillissement verkeert, tenzij een akkoord is gesloten
+      als bedoeld in de artikelen 138 en 252 FW;
+
+      •
+
+      ten aanzien van de belastingschuldige de schuldsaneringsregeling natuurlijke personen van toepassing is verklaard,
+      tenzij sprake is van een akkoord als bedoeld in artikel 329 FW, dan wel van een belastingaanslag, niet zijnde een
+      belastingaanslag als bedoeld in artikel 8, tweede lid van de regeling, voor zover die materieel verschuldigd is
+      geworden op een tijdstip of over een tijdvak dat is gelegen na de uitspraak waarbij de schuldsaneringsregeling van
+      toepassing is verklaard, en niet kan worden aangemerkt als een boedelschuld;
+
+      •
+
+      niet van toepassing;
+
+      •
+
+      door de ontvanger nadere voorwaarden zijn gesteld en aan die voorwaarden nog niet is voldaan. Zodra aan de gestelde
+      voorwaarden is voldaan, kan alsnog kwijtschelding worden verleend;
+
+      •
+
+      De gemeentelijke sociale dienst de belastingaanslag vergoedt.
+
+      Ook wordt geen kwijtschelding verleend voor het bedrag van de te betalen belasting waarop het verzoek betrekking heeft
+      als aannemelijk is dat dit bedrag kan worden voldaan omdat:
+
+      •
+
+      binnen twee jaren na het verzoek als gevolg van sterk wisselende inkomens een hoger inkomen is te verwachten;
+
+      •
+
+      binnen een jaar na indiening van het verzoek een verbetering is te verwachten in de financiële omstandigheden.
+
+      26.1.10 Begrip 'ex-ondernemer' en kwijtschelding
+
+      Als een belastingschuldige, of zijn partner, zijn bedrijf of zelfstandige beroepsuitoefening in het afgelopen jaar
+      heeft gestaakt en aannemelijk is dat die belastingschuldige in de toekomst geen bedrijf of niet zelfstandig een beroep
+      meer zal uitoefenen, kan kwijtschelding van de belastingen worden verleend. Als een ex-ondernemer om kwijtschelding
+      vraagt, past de ontvanger het kwijtscheldingsbeleid voor particulieren toe.
+
+      Er is geen sprake van een ex-ondernemer als (een deel van) het bedrijfsvermogen nog aanwezig is. In dat geval zal het
+      verzoek om kwijtschelding moeten worden behandeld overeenkomstig het bepaalde in artikel 26.3 van deze leidraad. Het
+      nog aanwezige bedrijfsvermogen zal geheel moeten worden gebruikt ter aflossing van de openstaande (zakelijke)
+      belastingaanslagen.
+
+      26.1.11 Verzoekschriften aan andere instellingen
+
+      Niet van toepassing voor HHNK.
+
+      26.2 Kwijtschelding van belastingen voor particulieren
+
+      26.2.1 Vermogen en kwijtschelding particulieren
+
+      Onder vermogen wordt verstaan de waarde in het economische verkeer van de bezittingen van de belastingschuldige en zijn
+      echtgenoot als bedoeld in artikel 3 Pw, verminderd met de schulden van de belastingschuldige en de echtgenoot die hoger
+      bevoorrecht zijn dan de rijksbelastingen.
+
+      26.2.2 De inboedel en kwijtschelding particulieren [Vervallen per 01-01-2023]
+
+      26.2.3 Motorvoertuigen en kwijtschelding particulieren
+
+      De waarde van de motorvoertuigen wordt niet als vermogensbestanddeel in aanmerking genomen als deze op het moment
+      waarop het verzoek wordt ingediend een waarde heeft van € 3.350 of minder. Als de waarde meer bedraagt, wordt de volle
+      waarde als vermogen in aanmerking genomen. Als op het motorvoertuig voor een financier een pandrecht is gevestigd, moet
+      ter vaststelling van de actuele (over)waarde de financieringsschuld in mindering worden gebracht.
+
+      Bij bezit van meerdere motorvoertuigen valt het motorvoertuig met de laagste waarde onder de vrijstellingsdrempel en
+      wordt het motorvoertuig met de hoogste waarde volledig als vermogen aangemerkt.
+
+      Een motorvoertuig wordt niet als een vermogensbestanddeel in aanmerking genomen als de belastingschuldige aan de
+      ontvanger – zo nodig na een verzoek daartoe – aannemelijk kan maken dat dit motorvoertuig absoluut onmisbaar is voor de
+      uitoefening van het beroep dan wel absoluut onmisbaar is in verband met invaliditeit of ziekte van de
+      belastingschuldige of zijn gezinsleden. Met gezinsleden wordt bedoeld de echtgenoot van belastingschuldige als bedoeld
+      in artikel 3 Pw, of zijn kind(eren) voor zover deze geen eigen inkomen/vermogen heeft (hebben) waaruit de
+      motorvoertuigen in beginsel zou kunnen worden betaald.
+
+      26.2.4 Saldo op bankrekening en kwijtschelding voor particulieren
+
+      Incidentele ontvangsten op een bankrekening (zoals bijvoorbeeld vakantiegeld) worden voor de bepaling van een aanwezig
+      vermogensbestanddeel ook in aanmerking genomen, tenzij bij de berekening van de betalingscapaciteit met dat bedrag
+      rekening is gehouden. Deze situatie zal zich met name voordoen bij de vakantiegelduitkering.
+
+      Als de belastingschuldige een energietoeslag heeft ontvangen als bedoeld in artikel 35, vierde of vijfde lid, Pw, wordt
+      een bedrag ter hoogte van het ontvangen bedrag aan energietoeslag, voor de duur van maximaal een jaar na ontvangst niet
+      in aanmerking genomen als vermogen voor de beoordeling van het recht op kwijtschelding.
+
+      De nog beschikbare kredietruimte van een doorlopend krediet wordt in de kwijtscheldingsregeling niet als een
+      vermogensbestanddeel aangemerkt.
+
+      26.2.5 De eigen woning en kwijtschelding voor particulieren
+
+      De waarde van onroerende zaken die een belastingschuldige in zijn bezit heeft, wordt aangemerkt als een
+      vermogensbestanddeel. Voor de waardebepaling van de onroerende zaak is uitgangspunt de waarde van de onroerende zaak
+      bij verkoop vrij te aanvaarden.
+
+      Als de aanwezigheid van vermogen vastgelegd in onroerende zaken leidt tot de afwijzing van een verzoek om
+      kwijtschelding en de belastingaanslag wordt vervolgens niet betaald, kan de voortzetting van de invordering bij oudere
+      belastingschuldigen die hun laatste levensjaren in hun eigen woning willen slijten, leiden tot een onverdedigbare
+      hardheid. Een gedwongen verhuizing in verband met de verkoop van de woning zal voor deze groep belastingschuldigen een
+      onevenredig grotere belasting zijn dan voor andere belastingschuldigen. In die gevallen kan de ontvanger in overleg met
+      de belastingschuldige afzien van prompte invordering en in plaats daarvan uitstel van betaling verlenen, gedekt door
+      een hypotheek op de eigen woning of door het leggen van een beslag op de woning. De hypotheek moet opeisbaar zijn na
+      het overlijden van de langstlevende of bij een eerder vrijkomen van de woning.
+
+      Het verlenen van een zodanig uitstel blijft beperkt tot uitzonderlijke gevallen.
+
+      26.2.6 Vermogen van kinderen en kwijtschelding voor particulieren
+
+      Als bij de belastingschuldige kinderen thuis wonen die over een eigen vermogen beschikken, wordt dat vermogen bij de
+      beoordeling van het door de ouder ingediende verzoek om kwijtschelding niet in aanmerking genomen, tenzij die ouder
+      (een deel van) zijn vermogen heeft toebedeeld aan zijn kind(eren) om daaruit een fiscaal voordeel te behalen.
+
+      26.2.7 Nalatenschappen en kwijtschelding voor particulieren
+
+      Voor de beoordeling van een verzoek om kwijtschelding van belastingaanslagen ten name van overledenen zijn de
+      financiële omstandigheden van de erfgenamen in beginsel niet van belang. Alleen de vraag of de belastingaanslagen uit
+      het actief van de nalatenschap (hadden) kunnen worden voldaan is van belang.
+
+      Dit uitgangspunt geldt niet als het verzoek wordt gedaan door de overblijvende partner/erfgenaam. In dat geval worden
+      de persoonlijke financiële omstandigheden wel mee in aanmerking genomen, ook al zouden bijvoorbeeld de kinderen als
+      mede-erfgenamen voor een deel van de belastingschuld kunnen worden aangesproken.
+
+      Als een erfgenaam op grond van een ingediend verzoek voor kwijtschelding in aanmerking zou komen, wordt de betrokkene
+      bij beschikking voor zijn aandeel in de belastingschuld ontslag van betalingsverplichting verleend. Deze werkwijze
+      wordt ook gevolgd als de partner van de erflater het verzoek om kwijtschelding indient.
+
+      26.2.8 Levensloopregeling en kwijtschelding voor particulieren [Vervallen per 27-02-2009]
+
+      26.2.9 Beroepsvermogen wikker en kwijtschelding voor particulieren [Vervallen per 01-01-2020]
+
+      26.2.10 Betalingscapaciteit en kwijtschelding voor particulieren
+
+      Als is vastgesteld dat geen of onvoldoende vermogensbestanddelen aanwezig zijn om de openstaande belastingaanslag te
+      voldoen, moet worden beoordeeld in hoeverre de aanwezige betalingscapaciteit voldoende is om de belastingaanslag te
+      voldoen.
+
+      De betalingscapaciteit wordt gevormd door het positieve verschil tussen het gemiddeld per maand te verwachten netto
+      besteedbaar inkomen van de belastingschuldige en de gemiddeld per maand te verwachten kosten van bestaan in de periode
+      van twaalf maanden vanaf de datum waarop het verzoek om kwijtschelding is ingediend.
+
+      Het netto besteedbaar inkomen van de belastingschuldige wordt vermeerderd met het gemiddeld per maand te verwachten
+      netto besteedbaar inkomen van zijn echtgenoot (als bedoeld in artikel 3 Pw) in de periode van twaalf maanden vanaf de
+      datum waarop het verzoek om kwijtschelding is ingediend. De vaststelling van het totale netto besteedbaar inkomen staat
+      los van de aansprakelijkheid tot betaling van de aanslagen waarvan kwijtschelding wordt verzocht.
+
+      De verantwoordelijkheid van de echtgenoot als bedoeld in artikel 3 Pw, voor schulden van de belastingschuldige, wordt
+      beperkt tot de (materiële) belastingschulden die betrekking hebben op de huwelijkse periode dan wel uit de periode
+      waarin de gezamenlijke huishouding is gevoerd. Dat kan tot gevolg hebben dat in voorkomende gevallen de
+      belastingaanslag moet worden gesplitst. Het vermogen en de betalingscapaciteit van de in artikel 3 Pw bedoelde
+      echtgenoot van belastingschuldige, worden dus buiten beschouwing gelaten voor zover een door de belastingschuldige
+      ingediend verzoek om kwijtschelding betrekking heeft op belastingschulden die zijn ontstaan buiten de huwelijkse
+      periode dan wel de gezamenlijke huishouding. Het toe te passen normbedrag is in dit geval het normbedrag voor een
+      alleenstaande of alleenstaande ouder (zie artikel 16 van de regeling).
+
+      26.2.11 Vakantiegeld en kwijtschelding voor particulieren
+
+      Tot het inkomen wordt ook het vakantiegeld gerekend. Het vakantiegeld wordt gesteld op 7% van de – aan loonheffing
+      onderworpen – inkomsten waarbij aanspraak bestaat op vakantiegeld.
+
+      Als uit het ingediende verzoekformulier blijkt, dan wel de ontvanger uit eigen wetenschap bekend is dat het reëel
+      genoten vakantiegeld meer of minder bedraagt dan 7%, wordt het reëel genoten vakantiegeld in aanmerking genomen.
+
+      Zo is bijvoorbeeld sprake van een lager percentage dan 7% in het geval de belastingschuldige een bijstandsuitkering
+      geniet. In dat geval moet dus worden uitgegaan van het percentage genoemd in artikel 19, derde lid, Pw.
+
+      26.2.12 Studiefinanciering en kwijtschelding voor particulieren
+
+      Bij de berekening van het netto besteedbare inkomen wordt rekening gehouden met inkomsten die studenten ontvangen op
+      grond van de WSF en hoofdstuk 4 van de Wet tegemoetkoming onderwijsbijdrage en schoolkosten (WTOS VO-18+).
+
+      Studenten in het hoger en middelbaar beroepsonderwijs hebben recht op een normbudget voor levensonderhoud: in het kader
+      van de kwijtscheldingsregeling is dit normbudget de optelsom van basisbeurs, maximale aanvullende beurs en maximale
+      basislening. Daarbij wordt voor zover van toepassing rekening gehouden met het feit of de student thuiswonend, dan wel
+      uitwonend is. In voorkomend geval wordt dit normbudget verhoogd met de eenoudertoeslag.
+
+      De inkomsten van een student worden gesteld op een forfaitair bedrag.
+
+      A.
+
+      Voor studenten in het hoger onderwijs is dit het bedrag voor het normbudget voor levensonderhoud verminderd met een
+      forfaitair bedrag voor boeken en leermiddelen groot € 67.
+
+      B.
+
+      Voor studenten in het middelbaar beroepsonderwijs is dit het bedrag voor het normbudget voor levensonderhoud verminderd
+      met een forfaitair bedrag voor boeken en leermiddelen groot € 60 en met het bedrag aan onderwijsretributie.
+
+      Als de belastingschuldige naast studiefinanciering beschikt over eigen inkomsten wordt eveneens uitgegaan van de
+      forfaitaire inkomsten, zoals hiervoor berekend onder A en B.
+
+      Als de daadwerkelijk genoten studiefinanciering (exclusief het ontvangen collegegeldkrediet voor studenten in het hoger
+      onderwijs) en de eigen inkomsten uitstijgen boven de voor het desbetreffende huishoudtype maximaal geldende kosten van
+      bestaan worden om de betalingscapaciteit te kunnen berekenen de navolgende formules gebruikt:
+
+      Formule 1: (P + Q) – R – S = X
+
+      In deze formule wordt met P aangegeven het totaal van de daadwerkelijk genoten studiefinanciering (exclusief het
+      ontvangen collegegeldkrediet voor studenten in het hoger onderwijs). Het totaal van de eigen inkomsten wordt aangegeven
+      met Q. Met R wordt aangegeven het voor de kwijtschelding geldende normbudget voor levensonderhoud. Het in mindering te
+      brengen bedrag van de daadwerkelijk ontvangen basislening wordt aangeduid met S. De uitkomst van deze berekening wordt
+      aangegeven met X, met dien verstande dat X altijd ten minste nul bedraagt.
+
+      Formule 2: X + Y = T
+
+      In deze formule wordt met Y aangegeven het forfaitaire bedrag aan inkomsten van de betreffende student zoals bedoeld
+      onder A of B. Het resultaat van de berekening volgens formule 1 (X) vermeerderd met Y is het inkomen (T). Dit inkomen
+      vormt vervolgens het uitgangspunt om het netto besteedbaar inkomen en de betalingscapaciteit te kunnen berekenen.
+
+      In sommige gevallen bestaat de studiefinanciering voor een groot deel of zelfs geheel uit een lening. In die situaties
+      wordt ook uitgegaan van de voornoemde forfaitaire inkomsten en is hetgeen in dit artikel is vermeld van overeenkomstige
+      toepassing.
+
+      26.2.13 Bijzondere bijstand/ouderlijke bijdrage en kwijtschelding voor particulieren
+
+      Uitkeringen die worden ontvangen in het kader van bijzondere bijstand en die zijn bestemd voor bestrijding van
+      specifieke kosten waarin de reguliere bijstandsuitkering niet voorziet, worden niet als inkomen in aanmerking genomen.
+
+      De bijzondere (aanvullende) bijstand voor personen jonger dan 21 jaar, wordt daarentegen wél als inkomen in aanmerking
+      genomen, evenals de ouderlijke bijdrage in geld die deze jongeren ontvangen. In dat geval is de bijzondere bijstand
+      niet bestemd voor bestrijding van specifieke kosten waarin de reguliere bijstandsuitkering niet voorziet. De bijzondere
+      bijstand voor jongeren dient ter aanvulling van de zeer lage bijstandsnorm, als de ouderlijke bijdrage – die geacht
+      wordt deze lage bijstandsnorm aan te vullen tot het niveau van de bijstandsnorm voor personen van 21 tot 65 jaar –
+      geheel of gedeeltelijk ontbreekt.
+
+      26.2.13a Persoonsgebonden budget en kwijtschelding voor particulieren
+
+      Verstrekkingen die worden ontvangen uit een persoonsgebonden budget voor specifieke kosten op het gebied van zorg,
+      begeleiding of hulpen waarop geen aanspraak bestaat vanuit de zorgverzekering of de reguliere bijstand, worden niet als
+      inkomen in aanmerking genomen.
+
+      26.2.14 Betalingen op belastingschulden en kwijtschelding voor particulieren
+
+      Bij de berekening van het netto besteedbaar inkomen wordt geen rekening gehouden met belastingaanslagen die in de loop
+      van de periode van twaalf maanden vanaf de datum waarop het verzoek is ingediend, nog zullen worden opgelegd.
+
+      Tot betalingen op belastingschulden worden ook de betalingen gerekend die worden verricht op gemeentelijke belastingen
+      (met uitzondering van de rechten die zijn vermeld in artikel 229 van de Gemeentewet) en andere belastingen en heffingen
+      van lokale overheden, voor zover deze geen betrekking hebben op het lopende belastingjaar.
+
+      26.2.15 Woonlasten en kwijtschelding van voorhuwelijkse belastingschulden
+
+      Als het verzoek om kwijtschelding wordt gedaan voor belastingschulden die zijn ontstaan voor de aanvang van de
+      huwelijkse periode, dan wel de gezamenlijke huishouding in de zin van artikel 3 Pw (zie artikel 26.2.10 van deze
+      leidraad), worden de woonlasten in aanmerking genomen tot ten hoogste 50% van het bedrag dat de uitkomst is van de
+      berekening op grond van artikel 15, eerste lid, onderdeel b, van de regeling.
+
+      26.2.15a Woonlasten van meerpersoonshuishoudens [Vervallen per 01-01-2018]
+
+      26.2.16 Uitgaven in verband met onderhoudsverplichtingen en kwijtschelding voor particulieren
+
+      Naast de alimentatieverplichtingen wordt bij de berekening van het netto besteedbaar inkomen de daadwerkelijk betaalde
+      onderhoudsbijdrage – de bijdrage die een gemeente op grond van de Pw van een ex-partner vordert in de kosten van
+      bijstand – in mindering gebracht.
+
+      Bij de beoordeling van een kwijtscheldingsverzoek wordt bij het bepalen van het netto besteedbare inkomen rekening
+      gehouden met de netto-kosten van kinderopvang (na aftrek ontvangen kinderopvangtoeslag en tegemoetkomingen
+      kinderopvang).
+
+      Voor de berekening van de kosten wordt gerekend met de maximum uurprijs zoals vermeld in artikel 4, eerste lid, van het
+      Besluit kinderopvangtoeslag.
+
+      26.2.17 Kwijtschelding tijdens WSNP
+
+      Als sprake is van een belastingschuldige ten aanzien van wie de WSNP van toepassing is verklaard, en die
+      belastingschuldige verzoekt om kwijtschelding van nadien opgekomen belastingschulden die niet zijn aan te merken als
+      boedelschuld, dan wordt het verzoek behandeld overeenkomstig het bestaande beleid.
+
+      Dit betekent dus onder meer dat bij de berekening van de betalingscapaciteit op het inkomen van de belastingschuldige
+      niet in mindering wordt gebracht dat deel van het inkomen dat onder beheer van de bewindvoerder naar de boedel gaat.
+      Verder wordt opgemerkt dat de middelen die de boedel vormen en onder beheer van de bewindvoerder berusten, niet
+      beschouwd worden als vermogen in de zin van artikel 12 van de regeling.
+
+      26.2.18 Inkomen wikker [Vervallen per 01-01-2022]
+
+      26.2.19 Normpremie zorgverzekering begrepen in de bijstandsuitkering
+
+      De normpremie, bedoeld in artikel 2 van de Wet op de zorgtoeslag, voor zover is begrepen in de bijstandsnorm, bedraagt
+      voor een alleenstaande of een alleenstaande ouder € 3 per maand en voor echtgenoten € 50 per maand.
+
+      26.2.20 Onderhoud gezinsleden in het buitenland
+
+      De hier te lande alleenwonende gehuwde belastingschuldige die zijn in het buitenland verblijvende echtgenote en/of
+      kinderen daadwerkelijk onderhoudt, wordt voor de berekening van de betalingscapaciteit niet als een alleenstaande
+      aangemerkt. Uitgegaan wordt van het normbedrag voor echtgenoten in de zin van artikel 3 Pw. Als huur wordt de hier te
+      lande betaalde huur in aanmerking genomen. Door toepassing van het normbedrag voor echtgenoten in de zin van artikel 3
+      Pw, wordt in het kwijtscheldingsbeleid op forfaitaire wijze rekening gehouden met de bedragen die de buitenlandse
+      werknemer aan zijn bloed- of aanverwanten overmaakt voor de kosten van levensonderhoud. Met de werkelijke bedragen die
+      de buitenlandse belastingschuldige overmaakt, wordt geen rekening gehouden.
+
+      26.3 Kwijtschelding van waterschapsbelastingen voor ondernemers
+
+      26.3.1 Kwijtschelding voor ondernemers bij een saneringsakkoord
+
+      Kwijtschelding voor een ondernemer, en voor degene die een zelfstandig beroep uitoefent, vindt alleen plaats bij een
+      saneringsakkoord tussen de schuldenaar en alle schuldeisers tot gedeeltelijke betaling van de schuld tegen finale
+      kwijting. Deze kwijtschelding komt pas aan de orde nadat alle gestelde zekerheden zijn uitgewonnen.
+
+      Ook als er geen andere schuldeisers zijn of alleen speciale crediteuren als bedoeld in artikel 26.3.8 van deze leidraad
+      kan de ontvanger kwijtschelding verlenen. De ontvanger zal bij dergelijke saneringsverzoeken de volgende aspecten
+      meewegen in de beoordeling van het verzoek:
+
+      1.
+
+      Kan de belastingschuldige een verwijt worden gemaakt ter zake van het onbetaald blijven van de belastingschulden (zie
+      artikel 8 van de regeling en artikel 26.1.9 van deze leidraad)?
+
+      2.
+
+      Is er sprake van een situatie waarin de belastingschuldige de ontvanger als enig schuldeiser heeft overgelaten door de
+      andere schuldeisers bij voorrang te voldoen?
+
+      De voorwaarden van artikel 22 van de regeling voor medewerking van de ontvanger aan een saneringsakkoord zijn voor
+      zover mogelijk van overeenkomstige toepassing.
+
+      Kwijtschelding is niet mogelijk voor stichtingen en verenigingen.
+
+      26.3.1a Kwijtschelding voor ondernemers getroffen door coronamaatregelen
+
+      In afwijking van artikel 26.3.1 vindt kwijtschelding plaats voor de belastingschuld die opeisbaar is geworden tussen 16
+      maart 2020 en 16 maart 2022, van een ondernemer, en voor degene die een zelfstandig beroep uitoefent, die:
+
+      •
+
+      kan aantonen dat hij voor de afkondiging van de beperkende maatregelen op 16 maart 2020 over voldoende inkomsten
+      beschikte om zijn opeisbare schulden te voldoen;
+
+      •
+
+      kan aantonen dat hij sinds de afkondiging van de beperkende maatregelen op 16 maart 2020 een omzetverlies van ten
+      minste 20% heeft geleden;
+
+      •
+
+      een overzicht kan overleggen van de hoogte van de schulden en het bedrag tegen finale kwijting toegezegd aan alle
+      schuldeisers.
+
+      De voorwaarden van artikel 22 van de regeling voor medewerking van de ontvanger aan een saneringsakkoord zijn voor
+      zover mogelijk van overeenkomstige toepassing.
+
+      Kwijtschelding op basis van dit artikel is alleen mogelijk voor de belastingschuld die voortvloeit uit de heffingen als
+      bedoeld in artikel 122d, eerste lid, van de Waterschapswet en artikel 7.2, tweede lid, van de Waterwet.
+
+      26.3.2 Aansprakelijkheid en kwijtschelding voor ondernemers
+
+      Voordat de ontvanger toetreedt tot een saneringsakkoord gaat hij na of de mogelijkheid bestaat (een) derde(n)
+      aansprakelijk te stellen voor onbetaald gebleven belastingschuld. Als de (te
+
+      verwachten) opbrengst uit de aansprakelijkstelling zodanig is dat het aanbod tot een saneringsakkoord voor de ontvanger
+      geen betere perspectieven biedt, treedt de ontvanger niet toe tot het akkoord.
+
+      Bij toetreding tot een saneringsakkoord kan de ontvanger er van afzien derden alsnog aansprakelijk te stellen. In dat
+      geval moet bij de vaststelling van het bedrag dat aan de ontvanger moet worden voldaan rekening worden gehouden met het
+      bedrag dat uit de aansprakelijkstelling geïnd had kunnen worden.
+
+      Als de ontvanger toetreedt tot een saneringsakkoord en daarnaast nog derden aansprakelijk stelt, blijft bij de
+      vaststelling van het bedrag dat in het akkoord moet worden voldaan een (eventuele) opbrengst uit de
+      aansprakelijkstelling buiten beschouwing. In de situatie dat de aansprakelijkgestelde zijn regresrecht op de gesaneerde
+      onderneming uitoefent en het bedrijf daardoor opnieuw in moeilijkheden komt, eist de ontvanger niet dat de onderneming
+      het ontstane tekort alsnog aanvult. Als later blijkt dat de aansprakelijkgestelde niet kan betalen, eist de ontvanger
+      evenmin het ontstane tekort op.
+
+      26.3.3 Voorwaarden tot deelname aan een saneringsakkoord
+
+      In aanvulling van artikel 22 van de regeling werkt de ontvanger uitsluitend mee aan een saneringsakkoord als de
+      communautaire middelen volledig worden voldaan.
+
+      De ontvanger verleent geen medewerking aan een saneringsakkoord waarbij één of meer schuldeisers het gedeelte van hun
+      vordering dat niet wordt voldaan niet kwijtschelden maar overdragen aan een derde of omzetten in aandelenkapitaal.
+
+      26.3.4 Toepassingsbereik saneringsakkoord
+
+      Bij de beoordeling van het aangeboden saneringsakkoord bekijkt de ontvanger welke belastingaanslagen in het akkoord
+      kunnen worden betrokken. Uitgangspunt hierbij is de formele belastingschuld ten tijde van het verzoek.
+
+      Bij de behandeling van het aangeboden akkoord is het de taak van de belastingschuldige/ondernemer ervoor te zorgen dat
+      de formele schuld zo nauwkeurig mogelijk overeenstemt met de materiële schuld. Als de belastingschuldige niet de
+      gegevens overlegt die (kunnen) leiden tot een juiste vaststelling van de verschuldigde belasting, is er geen aanleiding
+      voor de ontvanger toe te treden tot het aangeboden akkoord.
+
+      Ook HHNK heeft de inspanningsverplichting om de te saneren schuld zo volledig mogelijk en tot het juiste bedrag vast te
+      stellen en de eventueel nog (materieel) verschuldigde belastingen over tijdvakken tot aan het tijdstip waarop het
+      verzoek om sanering is ingediend, te formaliseren.
+
+      26.3.5 Ten minste dubbele percentage en saneringsakkoord
+
+      Niet van toepassing voor HHNK.
+
+      26.3.6 Bestuurlijke boeten en saneringsakkoord
+
+      Bestuurlijke boeten moeten ook integraal in het akkoord worden betrokken. Uitgangspunt is dat het heffingstraject moet
+      worden afgewerkt voordat tot sanering kan worden overgegaan. Daarna past de ontvanger het akkoordpercentage toe op de
+      belastingschuld én op de bestuurlijke boete.
+
+      26.3.7 Rente en kosten en saneringsakkoord
+
+      De ontvanger betrekt rente en kosten integraal in het akkoord. Het bedrag dat op basis van het akkoord is betaald,
+      wordt in afwijking van artikel 7 van de wet op de hoofdsom afgeboekt. De ontvanger vermeldt dit in de beschikking.
+
+      26.3.8 Speciale crediteuren en saneringsakkoord
+
+      Een aantal crediteuren neemt een zodanige positie in dat zij niet noodzakelijkerwijs tot een akkoord hoeven toe te
+      treden om (een deel van) de vordering die zij hebben te kunnen innen. Tot die crediteuren behoren onder meer:
+
+      •
+
+      Pandhouders, omdat het recht van voorrang van de pandhouder op het in pand gegeven goed boven het voorrecht van de
+      fiscus gaat, staat het niet deelnemen van de pandhouder aan het akkoord niet aan een deelname daaraan door de ontvanger
+      in de weg. Vanzelfsprekend zal in aanmerking moeten worden genomen dat het recht van voorrang van de pandhouder
+      afhankelijk is van – en dus qua belang beperkt is tot – de waarde van het in pand gegeven goed. Voor het niet door pand
+      gedekte gedeelte van zijn vordering kan de pandhouder slechts als concurrent schuldeiser worden aangemerkt. De
+      bezitloos pandhouder wiens pandrecht betrekking heeft op een zaak als bedoeld in artikel 21, tweede lid, tweede volzin
+      van de wet is voor die zaak lager bevoorrecht dan de fiscus. Voor hem geldt het voorgaande dus niet;
+
+      •
+
+      Leveranciers die de eigendom van de geleverde zaak hebben voorbehouden. Als een leverancier de eigendom van de
+      geleverde zaak heeft voorbehouden, moet bij het bepalen van de grootte van zijn vordering rekening worden gehouden met
+      dat eigendomsvoorbehoud. Het voorgaande is niet van toepassing als de ontvanger met toepassing van het bodemrecht
+      beslag heeft gelegd op deze zaak. In dat geval moet integrale voldoening van de waarde van de bodemzaak worden geëist
+      en voor het restant van de fiscale vordering (ten minste) het dubbele percentage;
+
+      •
+
+      Cessionarissen, als sprake is van rechtsgeldige gecedeerde uit te betalen bedragen en de ontvanger heeft eveneens met
+      de cessie ingestemd, dan wordt bij een akkoord de vordering van de crediteur/cessionaris in aanmerking genomen met
+      inachtneming van de te verwachten uit te betalen bedragen. De hoogte van de vordering van de ontvanger wordt bepaald
+      zonder rekening te houden met de te verwachten – maar rechtsgeldig gecedeerde – uit te betalen bedragen.
+
+      •
+
+      Dwangcrediteuren. Onder ‘dwangcrediteuren’ worden in dit verband verstaan leveranciers die niet bereid zijn aan een
+      akkoord mee te werken terwijl de onderneming zonder hen niet verder kan werken. Hiermee vergelijkbaar is de
+      adviseur/boekhouder die de stukken moet produceren die voor de beoordeling van het aanbod nodig zijn. Bij de
+      beoordeling van het akkoord houdt de ontvanger rekening met de volledige betaling van de vordering van de adviseur/
+      boekhouder.
+
+      •
+
+      Publieke schuldeisers, indien en voor zover die een vordering hebben op belastingschuldige waarop artikel 107, eerste
+      lid, van het Verdrag betreffende de werking van de Europese Unie van toepassing is en die daarom niet mag worden
+      kwijtgescholden, tenzij die vordering vanwege het verwijtbaar handelen of nalaten van belastingschuldige is ontstaan of
+      onbetaald gebleven.
+
+      26.3.9 Betaling bedrag saneringsakkoord
+
+      Betaling van het bedrag van het saneringsakkoord vindt in beginsel zonder uitstel plaats. De ontvanger kan echter
+      toestaan dat het bedrag in termijnen wordt betaald. Dit kan enkel indien de belastingschuldige een bedrijf of
+      zelfstandig beroep uitoefent en aannemelijk maakt dat de termijnen, bedoeld in de tweede volzin, evenals de nieuw
+      opkomende fiscale verplichtingen tijdig kunnen worden nagekomen. In het geval de ontvanger betaling in termijnen heeft
+      toegestaan, treedt hij voorwaardelijk toe tot het akkoord. Op de betalingsregeling voor het bedrag van het
+      saneringsakkoord zijn de artikelen 25.6.1 en 25.6.2 van toepassing met dien verstande dat in afwijking van:
+
+      •
+
+      artikel 25.4.3 van deze leidraad geen verrekening plaatsvindt van belastingteruggaven en andere teruggaven voor zover
+      die materieel zijn ontstaan na de dag waarop het verzoek tot het sluiten van het saneringsakkoord is ingediend;
+
+      •
+
+      artikel 25.6.1 van deze leidraad de looptijd van tien maanden aanvangt op de dag na de dagtekening van de
+      voorwaardelijke beschikking tot kwijtschelding;
+
+      •
+
+      artikel 25.6.2 van deze leidraad de belastingschuldige nieuw opkomende fiscale en andere financiële verplichtingen,
+      waarvan de invordering aan de ontvanger is opgedragen, niet alleen gedurende de uitstelregeling, maar gedurende de
+      gehele looptijd van de saneringsprocedure nakomt;
+
+      •
+
+      artikel 25.6.2 van deze leidraad de belastingschuldige geen zekerheid hoeft te stellen.
+
+      Kwijtschelding wordt pas verleend indien het saneringsakkoord in al zijn onderdelen is nagekomen.
+
+      26.3.10 Kwijtschelding zelfstandig ondernemer
+
+      Naast eerder genoemde mogelijkheden, namelijk kwijtschelding:
+
+      •
+
+      voor een (ex)ondernemer, of zijn partner, na staken van het bedrijf of zelfstandig beroep in het afgelopen jaar
+      (artikel 26.1.10);
+
+      •
+
+      in het kader van een saneringsakkoord tussen schuldenaar en alle schuldeisers, tot gedeeltelijke betaling van de schuld
+      tegen finale kwijtschelding (artikel 26.3.1),
+
+      is er de mogelijkheid voor een zelfstandig ondernemer om voor kwijtschelding van zijn (privé)aanslagen in aanmerking te
+      komen. Hierbij zijn dezelfde voorwaarden van toepassing als bij kwijtschelding van belasting voor particulieren.
+
+      26.4 Administratief beroep
+
+      26.4.1 Administratief beroep tegen de afwijzing van een verzoek om kwijtschelding
+
+      Als de belastingschuldige zich niet kan verenigen met de beschikking van de ontvanger op het verzoek om kwijtschelding,
+      kan hij een gemotiveerd beroepschrift richten tot D&H. Het beroepschrift wordt ingediend bij de ontvanger. In verband
+      met het aan D&H uit te brengen advies zendt de ontvanger zo nodig opnieuw een verzoekformulier aan de
+      belastingschuldige toe.
+
+      Als de belastingschuldige het nader toegezonden verzoekformulier niet terugzendt, stelt de ontvanger hem in de
+      gelegenheid dit alsnog te doen. Als de belastingschuldige hieraan geen gevolg geeft, stelt de ontvanger D&H daarvan in
+      kennis. De ontvanger adviseert D&H dan om niet aan het beroepschrift tegemoet te komen.
+
+      26.4.2 Herhaald verzoek om kwijtschelding
+
+      De ontvanger merkt een herhaald verzoek om kwijtschelding aan als een beroepschrift dat gericht is aan D&H. Als de
+      ontvanger aanleiding ziet om een gunstigere beslissing te nemen dan in zijn eerdere beschikking, handelt hij het
+      herhaalde verzoek zelf af.
+
+      De ontvanger zelf behandelt een herhaald verzoek om kwijtschelding als een eerste verzoek als het verzoek is afgewezen
+      als gevolg van een duidelijke, ambtelijke fout.
+
+      In deze gevallen kan de belastingschuldige na de beslissing van de ontvanger een beroepschrift indienen bij D&H.
+
+      26.4.3 Beroepsfase kwijtschelding
+
+      Als uit het beroepschrift niet duidelijk blijkt waarop het beroep is gebaseerd, verzoekt de ontvanger de
+      belastingschuldige het beroepschrift binnen een redelijke termijn (nader) te motiveren. De ontvanger wijst daarbij op
+      een mogelijke niet-ontvankelijkverklaring bij het niet voldoen aan deze motiveringsplicht.
+
+      26.4.4 Gegevens en normen eerste verzoek om kwijtschelding
+
+      Bij de behandeling van het beroepschrift of het herhaalde verzoek om kwijtschelding zijn de gegevens en normen van
+      belang die van toepassing waren bij de beoordeling van het eerste verzoek. Wanneer echter blijkt dat het inkomen van de
+      belastingschuldige ten opzichte van het eerste verzoek zodanig is gedaald dat de betalingscapaciteit destijds in
+      belangrijke mate tot een te hoog bedrag is vastgesteld, vindt een herberekening plaats. Ook wijzigingen in de aanspraak
+      inzake huurtoeslag en zorgtoeslag kunnen leiden tot een herberekening. Een herberekening vindt niet plaats bij
+      wijzigingen in de kosten van bestaan.
+
+      26.4.5 Beslissing D&H op beroep bij kwijtschelding
+
+      In alle gevallen waarin D&H het beroep gegrond oordeelt, kan hij de zaak inhoudelijk afdoen. Hetzij door het verzoek
+      alsnog toe te wijzen, hetzij door het af te wijzen onder verbetering of vervanging van de gronden.
+
+      26.4.6 Invordering tijdens administratief beroep en herhaald verzoek om kwijtschelding en ambtshalve behandeling
+      beroepschrift
+
+      Als binnen de termijn van tien dagen als bedoeld in artikel 24 van de regeling een beroepschrift wordt ingediend, dan
+      wordt gedurende de behandeling van dit beroepschrift gehandeld overeenkomstig artikel 9 van de regeling.
+
+      Als een verzoek om kwijtschelding wordt afgewezen, wordt de invordering niet eerder voortgezet dan nadat veertien dagen
+      zijn verstreken. Artikel 9 van de regeling is van overeenkomstige toepassing.
+
+      Indiening van het beroepschrift na de termijn van tien dagen leidt tot niet-ontvankelijkheid. Dit neemt echter niet weg
+      dat – als het belang van de invordering zich daartegen niet verzet – van D&H mag worden verwacht dat hij alsnog
+      ambtshalve de grieven die in het beroepschrift zijn aangedragen op hun waarde beoordeelt. Ook in dat geval wordt
+      gehandeld overeenkomstig artikel 9 van de regeling.
+
+      Of het belang van de invordering zich tegen ambtshalve behandeling verzet, hangt af van de omstandigheden. Hiervan is
+      echter in ieder geval sprake als inmiddels onherroepelijke invorderingsmaatregelen zijn genomen.
+
+      26.4.7 Niet tijdig beslissen op een verzoek om kwijtschelding
+
+      Als de ontvanger nalaat om tijdig een beslissing te nemen op een verzoek om kwijtschelding, kan de belastingschuldige
+      hiertegen beroep instellen bij D&H. Hieraan is geen termijn gebonden.
+
+      Als tijdens de beroepsprocedure blijkt dat de ontvanger kwijtschelding had moeten verlenen, dan hoeft D&H niet te
+      volstaan met de uitspraak dat de ontvanger niet tijdig heeft beslist, maar kan hij op het beroepschrift van de
+      belastingschuldige inhoudelijk beslissen.
+
+      26.5 Voortzetting van de invordering na afwijzing verzoek om kwijtschelding [Vervallen per 01-01-2020]
+
+      26.6 Geen verdere invorderingsmaatregelen en afwijzing verzoek om kwijtschelding
+
+      Als de belastingschuldige niet in aanmerking komt voor kwijtschelding maar de ontvanger voortzetting van de invordering
+      niet gewenst vindt, wijst de ontvanger het verzoek om kwijtschelding af. De ontvanger neemt in die beschikking op in
+      hoeverre hij geen invorderingsmaatregelen zal treffen. Tegen het besluit van de ontvanger om geen
+      invorderingsmaatregelen meer te treffen staat geen administratief beroep open.
+
+      Als de ontvanger besluit tot het niet meer nemen van invorderingsmaatregelen voor de nog openstaande schuld zonder dat
+      hij daaraan voorwaarden verbindt, heeft de beslissing voor de belastingschuldige materieel dezelfde gevolgen als
+      kwijtschelding.
+
+      De ontvanger kan ook besluiten geen invorderingsmaatregelen meer te nemen voor de nog openstaande schuld onder de
+      voorwaarde dat eventuele uit te betalen bedragen verrekend worden met de buiten de invordering gelaten schuld. De
+      termijn waarbinnen verrekening plaatsvindt bedraagt maximaal drie jaar, te rekenen vanaf de datum van de beschikking,
+      dan wel – als dit minder is – de tijd die nog overblijft voordat de verjaring van de belastingaanslag intreedt. De
+      ontvanger neemt deze verrekeningsvoorwaarde uitdrukkelijk in de beschikking op.
+
+      Als de ontvanger besluit voorlopig geen invorderingsmaatregelen meer te nemen, zal hij in zijn beschikking voorwaarden
+      of een tijdsbepaling opnemen. Anders dan kwijtschelding is een dergelijke beschikking herroepelijk. Als de
+      belastingschuldige de voorwaarden niet nakomt, neemt de ontvanger een nieuwe beschikking, waarbij hij zijn eerdere
+      beschikking intrekt. De ontvanger kan hiertoe pas overgaan nadat hij de belastingschuldige een brief heeft gestuurd
+      over zijn voornemen de eerdere beschikking in te trekken en niet binnen veertien dagen alsnog aan de voorwaarden of de
+      tijdsbepaling is voldaan.
+
+      26.7 Geautomatiseerde toetsing bij kwijtschelding
+
+      Als HHNK gebruik maakt van de mogelijkheid van geautomatiseerde toetsing bij kwijtschelding, wordt er op twee manieren
+      getoetst:
+
+      •
+
+      in het laatste kwartaal van het jaar voorafgaande aan het belastingjaar worden alle verleende kwijtscheldingsverzoeken
+      van het voorafgaande jaar getoetst of kwijtschelding eventueel kan worden verleend voor het volgende jaar;
+
+      •
+
+      nieuwe verzoeken om kwijtschelding worden maandelijks getoetst, in de maand of de maand hierop volgend, waarin het
+      verzoek is binnengekomen.
+
+      Beide toetsingen vinden plaats door Stichting Inlichtingenbureau aan de hand van jaarlijks vastgestelde criteria. Deze
+      criteria worden vastgesteld door het Ministerie van Sociale Zaken. Als op grond van deze toetsing geen recht bestaat op
+      geautomatiseerde kwijtschelding kan in een later stadium belastingschuldige alsnog een individueel verzoek indienen.
+      Dit individuele verzoek dient dan te voldoen aan de criteria vermeld in artikel 26.1.2 van deze leidraad.
+
+      De termijn van behandeling van het individueel kwijtscheldingsformulier start vanaf het moment dat het volledig
+      ingevulde verzoek om kwijtschelding door de ontvanger is ontvangen.
+
+      Tijdens de in de eerste alinea genoemde maandelijkse toetsing door Stichting Inlichtingenbureau wordt de invordering
+      door de ontvanger bij de aanvraag gestopt totdat de geautomatiseerde toets is genomen en belastingschuldige
+      schriftelijk bericht heeft ontvangen. De betalingen via automatische incasso worden echter niet opgeschort en worden
+      ook gedurende de periode van aanvraag tot en met uitspraak op het verzoek om kwijtschelding maandelijks geïnd.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_26
+
+  - number: '27'
+    text: |-
+      **Verjaring**
+
+      In aanvulling op afdeling 4.4.3 (artikelen 4:104 tot en met 4:111) Awb regelt artikel 27 van de wet enkele specifieke
+      (aanvullende) zaken met betrekking tot verjaring:
+
+      •
+
+      Dat stuiting van de verjaring door de ontvanger mogelijk is door het zenden van een schriftelijke mededeling waarin het
+      recht op betaling ondubbelzinnig wordt voorbehouden.
+
+      •
+
+      Als de belastingschuldige heeft opgehouden te bestaan (oftewel: de onderneming bestaat niet meer) en er is iemand
+      aansprakelijk gesteld voor de belastingschuld, dan treedt de aansprakelijkgestelde in de plaats van de
+      belastingschuldige (oftewel: in dat geval kan ook de aansprakelijkheidsschuld zelfstandig worden gestuit of verlengd).
+
+      In aansluiting op afdeling 4.4.3 Awb en artikel 27 van de wet beschrijft dit artikel het beleid over:
+
+      •
+
+      versnelde invordering en verjaring;
+
+      •
+
+      aansprakelijkgestelden en verjaring;
+
+      •
+
+      stuiting van de verjaring;
+
+      •
+
+      schorsing van de verjaring;
+
+      •
+
+      afstand van verjaring;
+
+      •
+
+      rente en kosten en verjaring;
+
+      •
+
+      verjaring van belastingteruggaven.
+
+      27.1 Versnelde invordering en verjaring
+
+      Als de invordering is aangevangen met toepassing van artikel 10 van de wet begint de verjaringstermijn te lopen op het
+      moment dat de belastingaanslagen onmiddellijk en tot het volle bedrag invorderbaar werden. De oorspronkelijke vervaldag
+      heeft op dat moment voor de verjaring geen belang meer.
+
+      27.2 Aansprakelijkgestelden en verjaring
+
+      Een aansprakelijkheidsschuld (beschikking ex artikel 49 van de wet) is niet voor zelfstandige verjaring vatbaar. Door
+      verjaring van de belastingaanslag ter zake waarvan aansprakelijk is gesteld, eindigt ook het recht van dwanginvordering
+      en verrekening van de aansprakelijkheidsvordering.
+
+      27.3 Stuiting van de verjaring
+
+      Als de betekening van een dwangbevel uitsluitend plaatsvindt om de verjaring te stuiten, dan licht de ontvanger de
+      belastingschuldige in over het doel van de betekening. Deze betekening is kosteloos.
+
+      Om de verjaring te stuiten kan een dwangbevel meer dan eenmaal worden betekend. Als de ontvanger de verjaring van een
+      rechtsvordering tot betaling stuit door een schriftelijke mededeling, maakt hij die schriftelijke mededeling bekend aan
+      de belastingschuldige.
+
+      27.4 Schorsing van de verjaring
+
+      Uitstel van betaling voor een gedeelte van de belastingaanslag verlengt de verjaringstermijn voor de gehele
+      belastingaanslag.
+
+      27.5 Afstand van verjaring
+
+      Van eenmaal verkregen verjaring kan afstand worden gedaan. De ontvanger beroept zich echter alleen op afstand van
+      verjaring, als zonder meer duidelijk is dat de belastingschuldige daadwerkelijk bedoelt afstand van de verjaring te
+      doen.
+
+      27.6 Rente en kosten en verjaring
+
+      De op een belastingaanslag belopen rente en kosten zijn onlosmakelijk met de belastingaanslag verbonden. Als voor een
+      belastingaanslag de verjaring is ingetreden, laat de ontvanger dus ook voor de rente en kosten invordering en
+      verrekening achterwege.
+
+      27.7 Na verjaring geen civiele vordering
+
+      Na intreding van de verjaring maakt de ontvanger geen gebruik van de mogelijkheid om een belastingschuld in te vorderen
+      door middel van een dagvaarding.
+
+      27.8 Verjaring van belastingteruggaven
+
+      Voor de verjaring van belastingteruggaven geldt eenzelfde verjaringstermijn als voor belastingschulden. Na verjaring
+      ontstaat een natuurlijke verbintenis. De ontvanger zal een beroep op de verjaring doen, tenzij hij gerede twijfel heeft
+      of de belastingaanslag aan de belastingschuldige is bekend gemaakt.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_27
+
+  - number: 27a
+    text: |-
+      Niet van toepassing voor HHNK.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_27a
+
+  - number: '28'
+    text: |-
+      **Invorderingsrente**
+
+      Artikel 28 van de wet regelt het in rekening brengen en vergoeden van invorderingsrente.
+
+      De ontvanger brengt rente in rekening als een belastingschuldige te laat is met betalen van zijn belasting. Te laat is:
+      bij overschrijding van de enige of laatste betalingstermijn die voor de belastingaanslag geldt.
+
+      In aansluiting op artikel 28 van de wet beschrijft dit artikel het beleid over:
+
+      •
+
+      correctie berekende invorderingsrente;
+
+      •
+
+      vermindering terecht in rekening gebrachte invorderingsrente;
+
+      •
+
+      verzuim van HHNK en invorderingsrente;
+
+      •
+
+      rente- of schadevergoeding;
+
+      •
+
+      kwijtschelding invorderingsrente niet mogelijk;
+
+      28.1 Cheque buitenland en invorderingsrente [Vervallen per 01-01-2010]
+
+      28.2 Correctie berekende invorderingsrente
+
+      De ontvanger corrigeert de renteberekening als daarbij onjuiste gegevens zijn gebruikt. Dit geldt ook voor een
+      belastingaanslag waaraan een nieuwe dagtekening wordt toegekend die leidt tot een ander aanvangstijdstip voor de
+      renteberekening.
+
+      Daarnaast wordt invorderingsrente gecorrigeerd in de volgende gevallen:
+
+      •
+
+      Voor zover na het in rekening brengen van de invorderingsrente een afname van de schuld, anders dan door betaling,
+      kwijtschelding of verrekening tot stand is gekomen en geen rente wordt vergoed op grond van artikel 28b van de wet.
+      Deze situatie zal zich voordoen:
+
+      •
+
+      bij vermindering van belastingaanslagen, en;
+
+      •
+
+      als een positieve belastingaanslag wordt gevolgd door een negatieve belastingaanslag over dezelfde belasting en
+      hetzelfde tijdvak.
+
+      28.3 Vermindering terecht in rekening gebrachte invorderingsrente
+
+      Als de ontvanger als gevolg van een te late betaling terecht rente in rekening brengt, kan er slechts in uitzonderlijke
+      situaties aanleiding bestaan die rente te verminderen. De ontvanger moet dan van mening zijn dat het niet tijdig
+      voldoen van de belastingschuld niet kan worden verweten aan de belastingschuldige en bovendien dat de invordering van
+      rente onredelijk en onbillijk is.
+
+      De ontvanger kan slechts naar aanleiding van een ingediend bezwaarschrift de verschuldigde rente verminderen.
+
+      28.4 Verzuim van HHNK en invorderingsrente [Vervallen per 01-01-2013]
+
+      28.5 Rente- of schadevergoeding [Vervallen per 01-01-2013]
+
+      28.6 Kwijtschelding invorderingsrente niet mogelijk
+
+      Kwijtschelding van uitsluitend invorderingsrente is niet mogelijk. De ontvanger doet ook geen toezegging dat de rente
+      niet zal worden ingevorderd. Dit laat onverlet dat de ontvanger kwijtschelding verleent of rente buiten invordering
+      laat, als hij de hoofdsom kwijtscheldt of buiten invordering laat op grond van het bepaalde in artikel 26 van deze
+      leidraad.
+
+      28.7 Verminderingen en toepassing artikel 28, zesde lid, van de wet [Vervallen per 01-01-2013]
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_28
+
+  - number: 28a
+    text: |-
+      Er zijn in deze leidraad op de artikelen 28a en 28b van de wet geen beleidsregels gemaakt.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_28a
+
+  - number: 28c
+    text: |-
+      Er zijn in deze leidraad op artikel 28c van de wet geen beleidsregels gemaakt.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_28c
+
+  - number: '29'
+    text: |-
+      Er zijn in deze leidraad op artikel 29 van de wet geen beleidsregels gemaakt.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_29
+
+  - number: '30'
+    text: |-
+      **Beschikking betalingskorting en invorderingsrente**
+
+      Artikel 30 van de wet bepaalt dat de ontvanger het bedrag van de invorderingsrente vaststelt bij een voor bezwaar
+      vatbare beschikking. Op deze beschikking is hoofdstuk V van de AWR van toepassing.
+
+      In aansluiting op artikel 30 van de wet beschrijft dit artikel het beleid over:
+
+      •
+
+      verzoek tot vermindering rente is bezwaar;
+
+      •
+
+      invorderingsrente: (hoger) beroep en cassatie;
+
+      •
+
+      invorderingsrente: uitstel van betaling.
+
+      30.1 Beschikking terugnemen betalingskorting
+
+      Niet van toepassing voor HHNK.
+
+      30.2 Verzoek tot vermindering rente is bezwaar
+
+      Een verzoek van de belastingschuldige tot vermindering van in rekening gebrachte rente merkt de ontvanger aan als een
+      bezwaarschrift.
+
+      30.3 Betalingskorting en invorderingsrente – (hoger) beroep en cassatie
+
+      Als de belastingschuldige in beroep gaat tegen de uitspraak op het bezwaar, handelt de ontvanger overeenkomstig de
+      voorschriften van het Besluit Beroep in Belastingzaken, met dien verstande dat de ontvanger in een procedure niet
+      dezelfde stukken hoeft over te leggen als de inspecteur. De ontvanger kan zich beperken tot de stukken die in de
+      procedure over de toepassing van de regeling invorderingsrente relevant zijn.
+
+      30.4 Teruggenomen betalingskorting en invorderingsrente: uitstel van betaling
+
+      Indiening van een bezwaar- of beroepschrift (in hoger beroep) schort de verplichting om de invorderingsrente te betalen
+      niet op. Als om uitstel van betaling wordt verzocht is het beleid van artikel 25 van deze leidraad en artikel 34 van de
+      regeling van overeenkomstige toepassing.
+
+      30.5 Geen bezwaar mogelijk tegen de niet verleende betalingskorting
+
+      Niet van toepassing voor HHNK.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_30
+
+  - number: '31'
+    text: |-
+      van de wet geeft D&H de mogelijkheid om nadere regels te stellen over de berekening van invorderingsrente. Dit kan door
+      het van overeenkomstige toepassing verklaren van de regeling waarin nadere regels staan over de berekening van
+      invorderingsrente. Het Besluit nadere regels met betrekking tot de heffing en invordering van waterschapsbelastingen en
+      leges 2011 (10.37000) voorziet hierin.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_31
+
+  - number: 31a
+    text: |-
+      Niet van toepassing voor HHNK.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_31a
+
+  - number: '32'
+    text: |-
+      **Samenloop fiscale en civiele aansprakelijkheidsbepalingen**
+
+      Artikel 32 van de wet bepaalt dat naast de aansprakelijkheidsbepalingen die in hoofdstuk VI van de wet zijn opgenomen,
+      de ontvanger ook een beroep kan doen op aansprakelijkheidsbepalingen in andere wettelijke regelingen. De ontvanger kan
+      dus ook een beroep doen op aansprakelijkheidsbepalingen uit bijvoorbeeld het BW of het Wetboek van Koophandel.
+
+      In aansluiting op artikel 32 van de wet beschrijft dit artikel het beleid over:
+
+      •
+
+      keuze aansprakelijkheid;
+
+      •
+
+      gemeenschapsschulden en aansprakelijkheid.
+
+      32.1 Keuze aansprakelijkheid
+
+      In situaties waarin de ontvanger feitelijk de keuze heeft tussen de toepassing van zowel een aansprakelijkheidsbepaling
+      uit de wet als een aansprakelijkheidsbepaling uit het civiele recht, geldt in beginsel hetgeen is vermeld in artikel
+      3.1 van deze leidraad.
+
+      In de belangenafweging die aan de aansprakelijkstelling voorafgaat, wordt in beginsel doorslaggevend gewicht toegekend
+      aan die aansprakelijkheidsbepaling waarbij de aansprakelijke in de gelegenheid is zich te disculperen.
+
+      32.2 Gemeenschapsschulden [Vervallen per 01-07-2022]
+
+      32.3 Belastingrente, heffingsrente en aansprakelijkheid [Vervallen per 01-01-2019]
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_32
+
+  - number: '33'
+    text: |-
+      **Aansprakelijkheid van bestuurder, leider vaste inrichting, vaste vertegenwoordiger**
+
+      Artikel 33 van de wet bevat hoofdelijke aansprakelijkheidsregels die gelden voor de invordering van alle
+      rijksbelastingen.
+
+      Deze regels dienen ertoe om in geval dat op een in dit artikel genoemd lichaam geen verhaal meer kan worden
+      uitgeoefend, die personen voor de nog verschuldigde belasting aan te spreken, die in een nauwe betrekking staan of
+      stonden tot het desbetreffende lichaam en invloed (hadden) kunnen uitoefenen op het betalen van de belastingschulden.
+
+      In aansluiting op artikel 33 van de wet beschrijft dit artikel het beleid over:
+
+      •
+
+      leider vaste inrichting en vaste vertegenwoordiger;
+
+      •
+
+      feitelijke vestiging;
+
+      •
+
+      lichaam dat is ontbonden;
+
+      •
+
+      vereffenaar;
+
+      •
+
+      bestuurder;
+
+      •
+
+      gewezen bestuurder.
+
+      33.1 Leider vaste inrichting en vaste vertegenwoordiger bij aansprakelijkheid
+
+      De begrippen vaste inrichting en vaste vertegenwoordiger zijn dezelfde als bij de heffing van de diverse belastingen.
+
+      33.2 Feitelijke vestiging bij aansprakelijkheid
+
+      Het begrip 'gevestigd' in artikel 33, eerste lid, onderdeel b van de wet, heeft een feitelijke betekenis. Waar een
+      lichaam is gevestigd, moet worden beoordeeld naar de omstandigheden van het geval.
+
+      De ontvanger moet hierbij aansluiting zoeken bij het materiële vestigingsbegrip van artikel 4, eerste lid van de AWR.
+
+      33.3 Lichaam dat is ontbonden bij aansprakelijkheid
+
+      De ontbinding van het lichaam waarop artikel 33, eerste lid, onderdeel c van de wet doelt, kan – behalve op grond van
+      de verschillende formele ontbindingsbepalingen – onder omstandigheden ook worden afgeleid uit handelingen van vennoten
+      of organen van rechtspersonen.
+
+      Voor de berekening van de driejaarstermijn wordt de stilzwijgende ontbinding – bedoeld in de vorige volzin – geacht
+      zich te hebben voltrokken ten tijde van het verrichten van de handelingen.
+
+      Als ontbinding kan niet worden aangemerkt het feitelijk staken van de bedrijfsuitoefening en/of het voortzetten van de
+      activiteiten van de vennootschap in een andere rechtsvorm, het zogenaamde 'leeg' maken van het lichaam.
+
+      33.4 Vereffenaar bij aansprakelijkheid
+
+      Niet alleen degene die met de vereffening is belast, is aansprakelijk op grond van artikel 33, eerste lid, onderdeel c
+      van de wet, maar ook degene die feitelijk als vereffenaar is opgetreden zonder dat van een uitdrukkelijke lastgeving
+      sprake is.
+
+      De ontvanger moet aannemelijk maken dat het niet-betalen van de belastingschuld is te wijten aan kennelijk onbehoorlijk
+      bestuur van de vereffenaar. De betekenis van het begrip kennelijk onbehoorlijk bestuur in dit lid is dezelfde als in
+      artikel 36 van de wet.
+
+      33.5 Bestuurder bij aansprakelijkheid [Vervallen per 01-01-2018]
+
+      33.6 Gewezen bestuurder bij aansprakelijkheid
+
+      De ontvanger kan de gewezen bestuurder aansprakelijk stellen voor de belastingschuld waarvoor hij ten tijde van zijn
+      bestuursperiode hoofdelijk aansprakelijk was, te weten de schuld die in deze periode materieel is ontstaan.
+
+      33.7 Disculpatie bestuurders, leiders en vaste vertegenwoordigers
+
+      Bestuurders van lichamen zonder rechtspersoonlijkheid of van een rechtspersoonlijkheid bezittend lichaam dat niet
+      volledig rechtsbevoegd is alsmede leiders van een vaste inrichting van een niet in Nederland gevestigd lichaam dan wel
+      de in Nederland wonende of gevestigde vaste vertegenwoordiger van dat lichaam, zijn niet aansprakelijk voor zover zij
+      bewijzen dat de niet-betaling niet aan hen is te wijten.
+
+      Niet-verwijtbaarheid wordt naar redelijkheid en billijkheid beoordeeld, waarbij veel afhankelijk is van de feitelijke
+      omstandigheden. Zo kan van niet-verwijtbaarheid sprake zijn als een ondernemer, hoewel hij de nodige voorzieningen
+      heeft getroffen om eventuele tegenslagen in zijn bedrijf het hoofd te bieden, toch wordt geconfronteerd met niet te
+      voorziene calamiteiten. Daaronder is begrepen een sterk verslechterde economische situatie van zodanige omvang dat hij
+      ondanks zijn voorzorgen niet meer in staat is zijn betalingsverplichtingen na te komen.
+
+      Ook kan plotseling betalingsonmacht ontstaan door een bijzondere gebeurtenis, bijvoorbeeld een niet voorzienbare,
+      omvangrijke miscalculatie of door het faillissement van een belangrijke debiteur. Bij dit laatste geldt echter dat een
+      ondernemer die zijn bedrijf uitoefent op een te zwakke financiële basis zich niet gemakkelijk op niet-verwijtbaarheid
+      zal kunnen beroepen.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_33
+
+  - number: 33a
+    text: |-
+      Niet van toepassing voor HHNK.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_33a
+
+  - number: '48'
+    text: |-
+      **Beperking aansprakelijkheid van erfgenamen**
+
+      Artikel 48 van de wet regelt niet de aansprakelijkheid van de erfgenaam, maar geeft aan dat de erfgenaam – als
+      rechtsopvolger van de erflater – niet voor alle belastingaanslagen voor het volle bedrag zal worden aangesproken.
+
+      In aansluiting op artikel 48 van de wet beschrijft dit artikel het beleid over:
+
+      •
+
+      beneficiaire aanvaarding;
+
+      •
+
+      invordering ten laste van een erfgenaam blijft achterwege.
+
+      48.1 Beneficiaire aanvaarding
+
+      Als een nalatenschap onder het voorrecht van boedelbeschrijving is aanvaard, wordt de vereffening van de boedel
+      afgewacht, met dien verstande dat de ontvanger maatregelen neemt ter beveiliging van zijn rechten (zie artikel 14.1.3
+      van deze leidraad).
+
+      Aantasting van het vermogen van de erfgenamen blijft uiteraard achterwege.
+
+      48.2 Invordering ten laste van een erfgenaam blijft achterwege
+
+      Als voor een belastingaanslag ten name van een overledene niet meer tegen de gezamenlijke erfgenamen kan worden
+      opgetreden, blijft invordering ten laste van een erfgenaam van wie minder dan € 23 moet worden ingevorderd achterwege,
+      tenzij het de hoofdsom van de aanslag betreft.
+
+      Er kan ook aanleiding bestaan een gering restbedrag op tactische gronden buiten invordering te laten.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_48
+
+  - number: 48a
+    text: |-
+      Niet van toepassing voor HHNK.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_48a
+
+  - number: '49'
+    text: |-
+      **Formele bepalingen voor aansprakelijkstelling**
+
+      Artikel 49 van de wet regelt de formele bepalingen voor aansprakelijkstellingen. Het geeft aan op welke wijze een
+      materiële aansprakelijkheid wordt omgezet in een formele aansprakelijkstelling. De bepalingen gelden niet alleen voor
+      de in de wet opgenomen aansprakelijkheidsregels, maar gelden ook voor de aansprakelijkheid in enige andere wettelijke
+      regeling, bijvoorbeeld in het BW en het Wetboek van Koophandel.
+
+      De aansprakelijkstelling vindt plaats bij voor bezwaar vatbare beschikking, en wel afzonderlijk voor ieder die
+      aansprakelijk wordt gesteld.
+
+      In aansluiting op artikel 49 van de wet beschrijft dit artikel het beleid over:
+
+      •
+
+      aansprakelijkstelling voor bestuurlijke boete;
+
+      •
+
+      aansprakelijkstelling voor invorderingsrente;
+
+      •
+
+      vooraankondiging aansprakelijkstelling;
+
+      •
+
+      de aansprakelijkstelling – in gebreke zijn;
+
+      •
+
+      informatieverstrekking in beschikking aansprakelijkstelling keten- en inlenersaansprakelijkheid;
+
+      •
+
+      informatieverstrekking aan aansprakelijkgestelden;
+
+      •
+
+      eerst uitwinning belastingschuldige;
+
+      •
+
+      volgorde van aansprakelijk stellen;
+
+      •
+
+      bezwaar en uitstel van betaling;
+
+      •
+
+      overgangsrecht.
+
+      49.1 Aansprakelijkstelling voor bestuurlijke boete
+
+      De ontvanger kan de beschikking aansprakelijkstelling voor de bestuurlijke boete opnemen in dezelfde brief waarbij hij
+      ook de beschikking voor de aansprakelijkstelling voor de belastingschuld bekendmaakt. De ontvanger moet dan in de
+      beschikking de gronden vermelden waarop de aansprakelijkstelling voor de boete berust.
+
+      Als geen gebruik wordt gemaakt van de gelegenheid om de gronden, waarop het voornemen tot een aansprakelijkstelling
+      voor de vergrijpboete berust, te betwisten of de ontvanger is van oordeel dat de betwisting van de aansprakelijke
+      ongegrond is, dan zal hij de derde daarvan op de hoogte stellen en overgaan tot aansprakelijkstelling voor de
+      bestuurlijke boete op de voet van artikel 49, eerste lid, van de wet.
+
+      49.2 Aansprakelijkstelling voor invorderingsrente
+
+      Als aan de aansprakelijkgestelde invorderingsrente in rekening moet worden gebracht, dan wordt de rente berekend over
+      het bedrag waarvoor hij aansprakelijk is gesteld.
+
+      Voor zover in het bedrag van de aansprakelijkstellingsbeschikking tevens een bedrag aan invorderingsrente is opgenomen,
+      wordt over dat bedrag geen rente in rekening gebracht.
+
+      49.2a Vooraankondiging aansprakelijkstelling
+
+      Niet van toepassing voor HHNK.
+
+      49.3 De aansprakelijkstelling – in gebreke zijn
+
+      49.3.1 Wanneer in gebreke
+
+      De belastingschuldige is in gebreke als de betaling van zijn belastingschuld niet heeft plaats gevonden binnen de
+      betalingstermijn die voor de belastingaanslag geldt.
+
+      49.3.2 In gebreke zijn en versnelde invordering
+
+      De belastingschuldige wordt ook geacht in gebreke te zijn als de belastingaanslag op grond van artikel 10 van de wet
+      terstond invorderbaar is.
+
+      49.3.3 In gebreke zijn en een beschikking ‘geen verdere invorderingsmaatregelen’
+
+      Als de ontvanger aan de belastingschuldige een beschikking heeft gestuurd waarin hij toezegt geen verdere
+      invorderingsmaatregelen tegen de belastingschuldige meer te nemen, kan een derde voor de desbetreffende belastingschuld
+      niettemin aansprakelijk worden gesteld, mits die mogelijkheid uitdrukkelijk in de beschikking is vermeld.
+
+      49.4 Informatieverstrekking in beschikking aansprakelijkstelling keten- en inlenersaansprakelijkheid
+
+      Niet van toepassing voor HHNK.
+
+      49.5 Informatieverstrekking aan aansprakelijkgestelden
+
+      Op grond van het bepaalde in artikel 49, zesde lid, van de wet moet de ontvanger de aansprakelijkgestelde desgevraagd
+      op de hoogte stellen van de gegevens over de belasting waarvoor hij aansprakelijk is gesteld.
+
+      Tot de gegevens die op grond van genoemde bepaling moeten worden verstrekt, behoren in elk geval de stukken die op de
+      zaak betrekking hebben als bedoeld in de artikelen 7:4 en 8:42 Awb. Hieronder worden verstaan alle stukken die bij het
+      nemen van het besluit een rol hebben gespeeld. Naast de gegevens die zijn vastgelegd in de genoemde stukken moeten
+      desgevraagd ook andere gegevens worden verstrekt, mits die gegevens redelijkerwijs van belang kunnen worden geacht voor
+      het maken van bezwaar of het instellen van beroep.
+
+      De gegevens worden – na een daartoe strekkend verzoek van de aansprakelijkgestelde – vooruitlopend op het indienen van
+      een bezwaarschrift of op het instellen van beroep verstrekt.
+
+      Hoewel artikel 49, zesde lid, van de wet betrekking heeft op de gegevens over de belasting, is goedgekeurd dat de
+      gegevensverstrekking zich daartoe niet beperkt, maar mede betrekking heeft op (alle) andere aspecten van de
+      aansprakelijkheidsbeslissing. Voorwaarde is wel dat deze gegevens hetzij gerekend kunnen worden tot de stukken die op
+      de zaak betrekking hebben als hiervoor genoemd, hetzij redelijkerwijs van belang kunnen worden geacht voor het maken
+      van bezwaar tegen de aansprakelijkheidsbeschikking of het instellen van beroep tegen daarop volgende beslissingen.
+
+      49.6 Aansprakelijkheid – eerst uitwinning belastingschuldige
+
+      De ontvanger zal zich in beginsel eerst verhalen op vermogensbestanddelen van de belastingschuldige voordat hij
+      overgaat tot uitwinning van de vermogensbestanddelen van de aansprakelijkgestelde, tenzij zich een situatie voordoet
+      als bedoeld in artikel 14.1.4 van de leidraad.
+
+      49.7 Volgorde van aansprakelijk stellen
+
+      Als de ontvanger een derde aansprakelijk kan stellen op grond van meer dan één fiscale of civielrechtelijke
+      aansprakelijkheidsbepaling, dan hoeft hij daarbij geen volgorde in acht te nemen. Hetzelfde geldt als de ontvanger
+      verscheidene derden op grond van dezelfde dan wel op grond van verschillende aansprakelijkheidsbepalingen aansprakelijk
+      kan stellen.
+
+      Dit geldt niet in de gevallen waarvoor in de wet of deze leidraad anders is bepaald.
+
+      49.8 Bezwaar, beroep, hoger beroep en beroep in cassatie tegen de beschikking aansprakelijkstelling
+
+      49.8.1 Uitstel in verband met bezwaar tegen een beschikking aansprakelijkstelling
+
+      Het beleid voor uitstel van betaling verwoord in artikel 25.2 is van overeenkomstige toepassing:
+
+      a.
+
+      als bezwaar wordt gemaakt tegen de beschikking aansprakelijkstelling;
+
+      b.
+
+      als beroep wordt ingesteld tegen de uitspraak van de ontvanger op het bezwaarschrift tegen een beschikking
+      aansprakelijkstelling, en;
+
+      c.
+
+      als hoger beroep of beroep in cassatie wordt ingesteld tegen een rechterlijke uitspraak.
+
+      49.8.2 Beslissing op het bezwaarschrift [Vervallen per 24-10-2008]
+
+      49.9 Overgangsrecht [Vervallen per 01-01-2019]
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_49
+
+  - number: '51'
+    text: |-
+      **Conservatoir beslag bij aansprakelijkheid**
+
+      De versnelde invordering op grond van de artikelen 10 en 15 van de wet is niet van toepassing op een
+      aansprakelijkgestelde. Wel heeft de ontvanger de mogelijkheid conservatoir beslag te leggen op grond van artikel 51 van
+      de wet met toepassing van de regels van het Wetboek van Burgerlijke Rechtsvordering.
+
+      In aansluiting op artikel 51 van de wet beschrijft dit artikel het beleid over conservatoir beslag en uitstel in
+      verband met bezwaar.
+
+      51.1 Conservatoir beslag en uitstel in verband met bezwaar
+
+      Als er conservatoir beslag ligt en de aansprakelijkgestelde verzoekt om uitstel van betaling in verband met een bezwaar
+      tegen de beschikking, dan verleent de ontvanger alleen uitstel van betaling als er zekerheid wordt gesteld.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_51
+
+  - number: '52'
+    text: |-
+      **Betalingstermijn beschikking aansprakelijkstelling**
+
+      Overeenkomstig artikel 52, eerste lid, van de wet heeft de aansprakelijkgestelde een betalingstermijn van zes weken na
+      dagtekening van de beschikking van de aansprakelijkstelling.
+
+      Als na het verstrijken van deze termijn geen betaling heeft plaatsgevonden en geen bezwaarschrift tegen de beschikking
+      is ingediend, is het in de beschikking vermelde bedrag invorderbaar.
+
+      In aansluiting op artikel 52 van de wet beschrijft dit artikel het beleid over vermindering van de belastingaanslag.
+
+      52.1 Vermindering van de belastingaanslag en aansprakelijkstelling
+
+      Als de inspecteur de aanslag vermindert, past de ontvanger het bedrag van de aansprakelijkstellingsbeschikking aan voor
+      zover dat voortvloeit uit de vermindering en deelt dat mee aan de aansprakelijkgestelde.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_52
+
+  - number: '53'
+    text: |-
+      **Aansprakelijkheid: verhaalsrechten en kwijtschelding**
+
+      •
+
+      Geen zelfstandige verjaring van de aansprakelijkheidsschuld;
+
+      •
+
+      ontslag van betalingsverplichting aansprakelijk gestelde bestuurder en verwijtbaarheid.
+
+      53.1 Geen zelfstandige verjaring van de aansprakelijkheidsschuld
+
+      Een aansprakelijkheidsschuld (beschikking ex artikel 49 van de wet) is niet voor zelfstandige verjaring vatbaar. Door
+      verjaring van de belastingaanslag waarvoor aansprakelijk is gesteld, eindigt ook het recht van dwanginvordering en
+      verrekening van de aansprakelijkheidsvordering.
+
+      53.2. Ontslag van betalingsverplichting aansprakelijk gestelde bestuurder en verwijtbaarheid
+
+      De ontvanger verleent geen ontslag van betalingsverplichting als sprake is van verwijtbaarheid van de kant van de
+      aansprakelijk gestelde. Dit volgt uit artikel 8, eerste lid, onderdeel a, van de regeling. De vraag of sprake is van
+      verwijtbaarheid beoordeelt de ontvanger op basis van gedragingen van de aansprakelijk gestelde. Dit betekent dat als de
+      aansprakelijkstelling van een
+
+      bestuurder is gebaseerd op artikel 36, vierde lid, van de wet, het enkele feit dat het lichaam niet op de juiste wijze
+      heeft gemeld niet in de weg hoeft te staan aan ontslag van betalingsverplichting.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_53
+
+  - number: '54'
+    text: |-
+      **Mededeling aan de aansprakelijkgestelde**
+
+      Artikel 54 van de wet regelt de uitbetaling van een teruggaaf aan de aansprakelijkgestelde die het gevolg is van een
+      vermindering van de belastingaanslag waarvoor hij aansprakelijk is gesteld.
+
+      54.1 Betaling teruggaaf aanhouden bij aansprakelijkstelling
+
+      De ontvanger houdt de betaling van de teruggaaf – als bedoeld in artikel 54, eerste lid, van de wet – aan gedurende
+      vier weken na de dagtekening van de schriftelijke mededeling aan de belastingschuldige.
+
+      In deze periode kan de belastingschuldige – als de derde zich al voor de aansprakelijkheidsschuld op hem heeft verhaald
+      – derdenbeslag leggen onder de ontvanger op het bedrag van de teruggaaf. In de derdenbeslagprocedure zal worden
+      uitgemaakt aan wie de ontvanger het bedrag van de teruggaaf moet betalen.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_54
+
+  - number: '55'
+    text: |-
+      Er zijn in deze leidraad op de artikelen 55 tot en met 57 van de wet geen beleidsregels gemaakt.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_55
+
+  - number: '58'
+    text: |-
+      **Informatieverplichtingen van de belastingschuldige of de aansprakelijkgestelde**
+
+      Artikel 58 van de wet regelt de verplichting voor de belastingschuldige en de aansprakelijkgestelde tot het verstrekken
+      van gegevens en inlichtingen en het ter beschikking stellen van gegevensdragers die voor de invordering van de 'eigen'
+      belastingschulden van belang zijn.
+
+      Verder regelt artikel 58 van de wet de identificatieverplichting tegenover de ontvanger.
+
+      Onder de gegevens die voor de invordering van de 'eigen' belastingschulden van de belastingschuldige van belang zijn,
+      vallen ook de gegevens die de ontvanger nodig heeft om te beoordelen of hij mogelijk derden aansprakelijk kan stellen.
+
+      In aansluiting op artikel 58 van de wet beschrijft dit artikel het beleid over:
+
+      •
+
+      invorderingsonderzoek tijdens een gerechtelijke procedure;
+
+      •
+
+      gegevens voor invordering ‘eigen’ belastingschulden.
+
+      58.1 Geen invorderingsonderzoek tijdens een gerechtelijke procedure
+
+      Het is de ontvanger niet toegestaan een invorderingsonderzoek te doen instellen, nadat de rechter de ontvanger in de
+      gelegenheid heeft gesteld bewijs te leveren voor in een procedure aangevoerde stellingen, indien en voor zover dat
+      onderzoek wordt ingesteld om gegevens te verwerven om dat bewijs te kunnen leveren.
+
+      58.2 Gegevens voor invordering van ‘eigen’ belastingschulden
+
+      Onder gegevens die voor de invordering van de ‘eigen’ belastingschulden van de belastingschuldige van belang zijn,
+      vallen ook de gegevens die de ontvanger nodig heeft om te beoordelen of hij mogelijk derden aansprakelijk kan stellen.
+
+      58.3 Invorderingsonderzoek tijdens faillissement
+
+      In faillissement worden de belangen van de ontvanger – naast die van andere schuldeisers – feitelijk behartigd door de
+      curator. Als de ontvanger een verzoek krijgt van de curator om een onderzoek in te stellen, moet het onderzoek in het
+      teken van het invorderingsbelang staan. De ontvanger stelt geen onderzoek in als hij vermoedt dat de informatie er
+      slechts toe strekt dat de curator de (niet fiscale) boedelschulden kan innen.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_58
+
+  - number: '59'
+    text: |-
+      Niet van toepassing voor HHNK.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_59
+
+  - number: '60'
+    text: |-
+      **Formele bepalingen voor de informatieverplichtingen**
+
+      Artikel 60 van de wet regelt de formele bepalingen voor de informatieverplichtingen.
+
+      In aansluiting op artikel 60 van de wet beschrijft dit artikel het beleid over:
+
+      •
+
+      het stellen van een redelijke termijn voor verstrekken van informatie;
+
+      •
+
+      de kwaliteit van de gegevens en wijze van verstrekking of beschikbaar stellen.
+
+      60.1 Redelijke termijn voor verstrekken van informatie
+
+      De ontvanger stelt een redelijke termijn voor het verstrekken van de gegevens en inlichtingen of het ter beschikking
+      stellen van de gegevensdragers.
+
+      Als de ontvanger belang heeft bij een spoedige verstrekking of beschikbaarstelling kan deze termijn ook terstond zijn.
+
+      60.2 Kwaliteit van de gegevens en wijze van verstrekking of beschikbaar stellen
+
+      Als de opgevraagde gegevens niet duidelijk, stellig en zonder voorbehoud worden verstrekt, herhaalt de ontvanger zijn
+      verzoek en vordert hij op basis van artikel 60, eerste lid, van de wet correcte en concrete gegevens.
+
+      Als de gegevens ook na herhaald verzoek niet voldoen aan de gestelde eisen, beoordeelt de ontvanger of hij een civiele
+      procedure begint of de strafsancties van Hoofdstuk VIII van de wet toepast.
+
+      Aan de belastingschuldige die niet voldoet aan de verplichting van artikel 60, tweede lid, van de wet, kan de ontvanger
+      een verzuimboete als bedoeld in artikel 63b, tweede lid, van de wet opleggen.
+
+      Gegevensverstrekking vindt in beginsel uitsluitend schriftelijk plaats. In uitzonderingssituaties kan de ontvanger
+      toestaan dat de gegevens mondeling worden verstrekt. In verband met de bewijsvoering zorgt de ontvanger voor een
+      vastlegging van het gesprek.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_60
+
+  - number: '61'
+    text: |-
+      **Geen geheimhoudingsplicht bij de informatieverplichtingen**
+
+      Artikel 61 van de wet bepaalt voor de in de artikelen 58, 59 en 60 van de wet opgenomen verplichtingen dat niemand zich
+      op geheimhouding kan beroepen, zelfs niet als die geheimhoudingsverplichting bij wettelijk voorschrift zou zijn
+      opgelegd.
+
+      In aansluiting op artikel 61 van de wet beschrijft dit artikel het beleid over niet van de administratie gescheiden
+      (beroeps-)vertrouwelijke gegevens.
+
+      61.1 Niet van de administratie gescheiden (beroeps-)vertrouwelijke gegevens
+
+      De ontvanger heeft alleen belang bij die gegevens en inlichtingen en gegevensdragers die hem inzicht verschaffen in de
+      financiële positie van de belastingschuldige.
+
+      Doorgaans zijn de beroepsvertrouwelijke gegevens en de financiële gegevens gescheiden. Als het onvermijdelijk is dat de
+      ontvanger privacygegevens onder ogen krijgt, vormt dit geen grond om de verstrekking van gegevens of de
+      beschikbaarstelling van gegevensdragers te weigeren. De ontvanger is op grond van artikel 67, eerste lid, van de wet
+      gehouden tot geheimhouding van die gegevens.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_61
+
+  - number: '62'
+    text: |-
+      Niet van toepassing voor HHNK.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_62
+
+  - number: 62bis
+    text: |-
+      Er zijn in deze leidraad op de artikelen 62bis tot en met 63ab van de wet geen beleidsregels gemaakt.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_62bis
+
+  - number: 63b
+    text: |-
+      Niet van toepassing voor HHNK.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_63b
+
+  - number: 63c
+    text: |-
+      Er zijn in deze leidraad op de artikelen 63c en 64 van de wet geen beleidsregels gemaakt.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_63c
+
+  - number: '65'
+    text: |-
+      **Niet nakomen informatieverplichting: strafmaat voor misdrijf**
+
+      Bij het niet of niet correct nakomen van een verplichting tot het verstrekken van gegevens of het ter beschikking
+      stellen van gegevensdragers, kan sprake zijn van opzet.
+
+      In artikel 65, eerste en tweede lid, van de wet wordt de strafmaat voor dit strafbare feit gegeven. De beide straffen
+      die in die leden zijn genoemd, kunnen cumulatief worden toegepast. Artikel 65a van de wet merkt dit strafbare feit aan
+      als een misdrijf.
+
+      Het derde lid van artikel 65 van de wet bevat de zogenaamde 'inkeerregeling': het recht op strafvervolging vervalt als
+      een persoon tijdig tot inkeer komt en alsnog zorgt voor een juiste en volledige verstrekking van informatie.
+
+      In aansluiting op artikel 65 van de wet beschrijft dit artikel het beleid over de reikwijdte opzetcriterium bij een
+      misdrijf.
+
+      65.1 Reikwijdte opzetcriterium bij misdrijf
+
+      De vereiste opzet voor de toepassing van artikel 65, eerste en tweede lid, van de wet behoeft zich niet uit te strekken
+      tot het feit dat te weinig belasting wordt ingevorderd.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_65
+
+  - number: 65a
+    text: |-
+      Er zijn in deze leidraad op de artikelen 65a en 66 van de wet geen beleidsregels gemaakt.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_65a
+
+  - number: '67'
+    text: |-
+      **Geheimhoudingsplicht**
+
+      Artikel 67 van de wet regelt de geheimhoudingsplicht. In het tweede lid van dat artikel is bepaald dat de
+      geheimhoudingsplicht niet geldt als:
+
+      •
+
+      bekendmaking verplicht is volgens een wettelijk voorschrift;
+
+      •
+
+      sprake is van structurele gegevensverstrekking aan bestuursorganen die bij ministeriële regeling zijn aangewezen;
+
+      •
+
+      de bekendmaking plaatsvindt aan de belastingschuldige zelf voor zover deze gegevens door of namens hem zijn verstrekt.
+
+      Daarnaast kan D&H op grond van het derde lid ontheffing van de geheimhoudingsplicht verlenen.
+
+      In aansluiting op artikel 67 van de wet beschrijft dit artikel het beleid over:
+
+      •
+
+      bekendmaking gegevens op verzoek van de belastingschuldige zelf;
+
+      •
+
+      informatieverstrekking aan gerechtsdeurwaarder over periodieke betalingen.
+
+      67.1 Bekendmaking aan de belastingschuldige
+
+      De geheimhoudingsplicht geldt niet voor de bekendmaking van gegevens aan degene op wie zij betrekking hebben (de
+      belastingschuldige) voor zover deze gegevens door of namens hem zijn verstrekt. Ook het verstrekken van informatie over
+      belastingschulden aan de belastingschuldige zelf valt niet onder de geheimhoudingsplicht. Onder belastingschuldige moet
+      hier mede worden verstaan: diens vertegenwoordiger, curator, bewindvoerder of erfgenaam.
+
+      67.2 Bekendmaking aan derden in het belang van de invordering
+
+      De geheimhoudingsplicht geldt niet voor zover de bekendmaking van gegevens noodzakelijk is voor de uitvoering van de
+      wet. Dat laatste moet ruim worden opgevat. Als bekendmaking van belang is voor de invordering van de verschuldigde
+      belasting (aanslag) of een aansprakelijkheidsvordering (beschikking), kan de bekendmaking (aan derden) plaatsvinden
+      zonder dat daarmee de geheimhoudingsplicht wordt geschonden.
+
+      67.3 Informatieverstrekking aan gerechtsdeurwaarder over periodieke betalingen
+
+      Niet van toepassing voor HHNK.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_67
+
+  - number: 67a
+    text: |-
+      Er zijn in deze leidraad op artikel 67a van de wet geen beleidsregels gemaakt.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_67a
+
+  - number: '68'
+    text: |-
+      Niet van toepassing voor HHNK.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_68
+
+  - number: '70'
+    text: |-
+      Er zijn in deze leidraad op artikel 70 van de wet geen beleidsregels gemaakt.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_70
+
+  - number: 70a
+    text: |-
+      Niet van toepassing voor HHNK.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_70a
+
+  - number: 70b
+    text: |-
+      Er zijn in deze leidraad op de artikelen 70b tot en met 72 van de wet geen beleidsregels gemaakt.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_70b
+
+  - number: '73'
+    text: |-
+      **Insolventieprocedures**
+
+      In dit artikel is het volgende beleid over insolventieprocedures opgenomen:
+
+      •
+
+      de algemene uitgangspunten insolventieprocedures;
+
+      •
+
+      insolventieprocedure en WSNP;
+
+      •
+
+      insolventieprocedure en surseance;
+
+      •
+
+      insolventieprocedure en faillissement;
+
+      •
+
+      insolventieprocedure en MSNP door leden van de Vereniging voor schuldhulpverlening en sociaal bankieren (‘NVVK’) of
+      gemeenten;
+
+      •
+
+      insolventieprocedure en MSNP door anderen dan leden van de NVVK of gemeenten;
+
+      •
+
+      insolventieprocedures en akkoorden;
+
+      •
+
+      wettelijk breed moratorium.
+
+      73.1 Algemene uitgangspunten insolventieprocedures
+
+      73.1.1 Aanmelden belastingschulden in WSNP of faillissement
+
+      Uiterlijk veertien dagen vóór de verificatievergadering meldt de ontvanger zijn vorderingen ter verificatie aan bij de
+      bewindvoerder. Daarbij wordt ervan uitgegaan dat belastingschulden die naar tijdvak worden geheven, geacht worden van
+      dag tot dag te ontstaan.
+
+      De ontvanger meldt ook conserverende belastingschulden ter verificatie aan bij de bewindvoerder.
+
+      Voor het indienen van vorderingen in het faillissement wordt verwezen naar artikel 19.2 van deze leidraad. De ontvanger
+      maakt ook voor rechten bij invoer gebruik van deze vordering.
+
+      73.1.2 Invorderingsmaatregelen tijdens de toepassing van WSNP of faillissement
+
+      Het uitbrengen van aansprakelijkstellingen voor belastingaanslagen tijdens zowel het faillissement als tijdens de WSNP
+      is mogelijk.
+
+      73.1.3 Boedelschulden
+
+      De ontvanger ziet erop toe dat de boedelschulden tijdig door de curator worden voldaan. Als belastingschulden die als
+      boedelschulden kunnen worden aangemerkt, ten onrechte niet worden voldaan, wendt de ontvanger zich in beginsel eerst
+      tot de curator teneinde informatie te verkrijgen over de toestand van de boedel en zo mogelijk langs minnelijke weg
+      alsnog voldoening te bewerkstelligen. Als dit niet leidt tot een bevredigende oplossing wendt de ontvanger zich met
+      zijn grieven tot de rechter-commissaris. In het uiterste geval kan de ontvanger rechtstreeks verhaal zoeken op de
+      boedel.
+
+      Het voorgaande is ook van toepassing bij een WSNP.
+
+      Bij de invordering van boedelschulden kan de ontvanger tijdens de WSNP niet het faillissement van de schuldenaar
+      aanvragen.
+
+      Belastingschulden ontstaan gedurende een surseance zijn boedelschulden in het faillissement (zie artikel 19.2.2 van
+      deze leidraad).
+
+      73.1.4 Proceskostengarantie
+
+      Als de curator een gerechtelijke procedure (niet zijnde de bestuurdersaansprakelijkheidsprocedure) moet aanspannen om
+      een bate voor de boedel te kunnen realiseren, en de aanwezige baten van de boedel niet toereikend zijn om de
+      proceskosten te voldoen, kan de curator bij de ontvanger een gemotiveerd verzoek indienen om garantstelling voor het
+      bedrag dat niet uit de boedel kan worden voldaan.
+
+      Bij de beoordeling van het verzoek neemt de ontvanger als uitgangspunt dat:
+
+      •
+
+      de boedel bij de actie van de curator moet zijn gebaat;
+
+      •
+
+      de ontvanger (een deel van) de in het faillissement ingediende vordering zal kunnen innen.
+
+      Daarnaast stelt de ontvanger de eis dat de schuldeisers – die bij een verdeling van de activa eveneens zullen
+      profiteren van de vermoedelijke opbrengst van de procedure – bereid zijn om naar evenredigheid mee garant te staan voor
+      de proceskosten. Dit geldt ook voor boedelschuldeisers. Als een bewindvoerder in de WSNP de ontvanger een verzoek om
+      garantstelling doet, treedt de ontvanger in overleg met D&H.
+
+      73.1.5 Belangenbehartiging door de bewindvoerder of de curator
+
+      Niet van toepassing voor HHNK.
+
+      73.1.6 Bodemvoorrecht in WSNP en faillissement
+
+      Niet van toepassing voor HHNK.
+
+      73.1.7 Bodemrecht en insolventie van de derde-eigenaar
+
+      Niet van toepassing voor HHNK.
+
+      73.1.8 Uitstel in relatie tot WSNP en faillissement
+
+      Voor uitstel van betaling in relatie tot WSNP en faillissement wordt verwezen naar artikel 25.1.4 en 25.4.4 van deze
+      leidraad.
+
+      73.1.9 Kwijtschelding in relatie tot WSNP en faillissement
+
+      Zie voor kwijtschelding in relatie tot WSNP en faillissement artikel 26.1.9 van deze leidraad.
+
+      73.1.10 Ketenaansprakelijkheid en bestuurdersaansprakelijkheid in relatie tot WSNP en faillissement
+
+      Niet van toepassing voor HHNK.
+
+      73.1.11 Toeslagenschuld in relatie tot MSNP, WSNP en faillissement
+
+      Niet van toepassing voor HHNK.
+
+      73.1.12 Verplichtingensignaal in relatie tot MSNP, WSNP en faillissement
+
+      Niet van toepassing voor HHNK.
+
+      73.2 Insolventieprocedure – WSNP
+
+      73.2.1 Kwijtschelding tijdens WSNP
+
+      Voor de situatie dat een belastingschuldige, ten aanzien van wie de schuldsaneringsregeling natuurlijke personen van
+      toepassing is verklaard, verzoekt om kwijtschelding van nadien opgekomen belastingschulden die niet zijn aan te merken
+      als boedelschuld, wordt verwezen naar artikel 26.2.18 van deze leidraad.
+
+      73.2.2 De WSNP is beëindigd met een schone lei
+
+      Belastingvorderingen waarop de WSNP van toepassing is en voor zover die na de beëindiging op grond van artikel 356,
+      tweede lid, FW onvoldaan zijn gebleven, zijn aan te merken als natuurlijke verbintenissen ongeacht of de vorderingen
+      door de ontvanger bij de bewindvoerder zijn aangemeld.
+
+      Met betrekking tot te betalen belastingaanslagen die betrekking hebben op de periode waarin de WSNP van toepassing was
+      en die zijn vastgesteld na beëindiging (met schone lei) van die regeling, zal de ontvanger in beginsel afzien van
+      invordering. Daarbij geldt dat aannemelijk moet zijn dat:
+
+      •
+
+      de bewindvoerder de aan de betreffende aanslag voorafgaande voorlopige aanslagen / teruggaven voldoende op juistheid
+      heeft getoetst; en
+
+      •
+
+      over de resultaten van die toetsing in voorkomend geval tijdig contact heeft opgenomen met HHNK.
+
+      Belastingteruggaven met een dagtekening gelegen na de datum waarop de WSNP is geëindigd met een schone lei, die
+      materieel betrekking hebben op een periode vóór de uitspraak van de toepassing van de WSNP, zal de ontvanger in
+      beginsel niet verrekenen met de vorderingen die tot een natuurlijke verbintenis zijn getransformeerd. De ontvanger
+      verrekent deze belastingteruggaven alleen als het in de gegeven omstandigheden naar maatstaven van redelijkheid en
+      billijkheid onaanvaardbaar zou zijn als de hij de belastingteruggave niet kan verrekenen. Daarvan is in ieder geval
+      sprake als de vordering van de ontvanger, en de belastingteruggaaf zien op dezelfde belasting en hetzelfde tijdvak.
+
+      Met betrekking tot belastingteruggaven die betrekking hebben op de periode voor de beëindiging (met schone lei) van de
+      WSNP en die worden vastgesteld na beëindiging van die regeling, geldt het volgende. Teruggaven (na mogelijke
+      verrekening met openstaande schulden) van minder dan € 500 worden uitbetaald aan de belastingschuldige zelf. Indien de
+      belastingteruggave (na mogelijke verrekening met openstaande schulden) € 500 of meer bedraagt, zal de ontvanger contact
+      opnemen met de gewezen bewindvoerder om met hem te overleggen of de vereffening moet worden heropend.
+
+      Ook na beëindiging van de WSNP kan de ontvanger derden nog aansprakelijk stellen voor niet-betaalde belastingaanslagen
+      die als natuurlijke verbintenissen moeten worden aangemerkt.
+
+      Reeds in gang gezette aansprakelijkheidsprocedures kan de ontvanger voortzetten.
+
+      73.2.3 De WSNP is beëindigd zonder schone lei of de schone lei is ingetrokken
+
+      De WSNP kan ook eindigen zonder schone lei (artikel 358, tweede lid, Fw) en de reeds verstrekte schone lei kan worden
+      ingetrokken (artikel 358a, eerste lid, Fw). In die situaties kan de ontvanger de invordering hervatten.
+
+      73.2.4 De WSNP is tussentijds beëindigd
+
+      Als een schuldsaneringsregeling tussentijds wordt beëindigd in de zin van artikel 350, vijfde lid, Fw, blijft omzetting
+      in faillissement achterwege als er geen baten beschikbaar zijn. In die situatie geldt het invorderingsbeleid voor
+      natuurlijke personen bij opheffing van een faillissement wegens gebrek aan baten (artikel 73.4.14).
+
+      73.3 Insolventieprocedure – surseance
+
+      73.3.1 Uitstel, kwijtschelding en surseance
+
+      Voor uitstel van betaling in relatie tot surseance wordt verwezen naar artikel 25.1.4 en 25.4.4 van deze leidraad.
+
+      Voor kwijtschelding in relatie tot surseance wordt verwezen naar artikel 26.1.9 van deze leidraad.
+
+      73.3.2 Ketenaansprakelijkheid en bestuurdersaansprakelijkheid in relatie tot surseance
+
+      Niet van toepassing voor HHNK.
+
+      73.3a WHOA-akkoord
+
+      73.3a.1 Geldend beleid bij aangeboden WHOA-akkoord
+
+      Het beleid in deze leidraad en in de regeling dat ziet op kwijtschelding van belastingen is ook van toepassing op een
+      verzoek om instemming met een akkoord als bedoeld in artikel 370, eerste lid, FW, tenzij daarvan wordt afgeweken in de
+      volgende artikelen.
+
+      73.3a.2 Voorwaarden WHOA-akkoord
+
+      1.
+
+      De ontvanger kan instemmen met een aan hem aangeboden akkoord als bedoeld in artikel 370, eerste lid, FW, als aan de
+      volgende voorwaarden wordt voldaan:
+
+      •
+
+      het akkoord is schriftelijk aangeboden en voldoet aan de in artikel 375 FW gestelde eisen;
+
+      •
+
+      de ontvanger is in een klasse ingedeeld waarin zijn wettelijke preferentie voldoende tot uiting komt;
+
+      •
+
+      het is aannemelijk dat het aangeboden akkoord, afgezien van de daarvoor nog te verrichten formaliteiten, door de
+      rechtbank zou worden gehomologeerd.
+
+      2.
+
+      De ontvanger houdt bij de beoordeling van een aan hem aangeboden bedrag in het kader van een akkoord als bedoeld in
+      artikel 370, eerste lid, FW, rekening met de zogenoemde 20%-regel als bedoeld in artikel 374, tweede lid, FW. De
+      ontvanger kan daardoor onder omstandigheden medewerking verlenen aan een akkoord ondanks dat hij niet het dubbele
+      percentage ontvangt van hetgeen aan concurrente schuldeisers als bedoeld in artikel 374, tweede lid, FW op hun
+      vorderingen zal worden uitgekeerd.
+
+      3.
+
+      De ontvanger kan ook instemmen met een aan hem aangeboden akkoord als bedoeld in artikel 370 FW, als dit niet ziet op
+      alle schuldeisers van de belastingschuldige. De ontvanger kan eveneens instemmen met een akkoord als er nog een
+      redelijke mogelijkheid is om een derde aansprakelijk te stellen. Zie in dit verband artikel 73.3a.3.
+
+      4.
+
+      De ontvanger kan instemmen met een aan hem aangeboden akkoord als bedoeld in artikel 370, eerste lid, FW, waarbij een
+      of meer schuldeisers het gedeelte van hun vordering dat niet wordt voldaan, niet kwijtschelden maar omzetten in
+      aandelen. De ontvanger stemt echter niet in met een akkoord als de betaling van het akkoordbedrag aan hem, geschiedt
+      door omzetting van de belastingschuld in aandelenkapitaal of enige andere betalingsvorm van gelijke strekking.
+
+      5.
+
+      Deze regeling is ook van toepassing op belastingaanslagen waarvoor in beginsel geen kwijtschelding wordt verleend.
+
+      73.3a.3 Gevolgen homologatie WHOA-akkoord bij instemming
+
+      Als de ontvanger instemt met een akkoord als bedoeld in artikel 370, eerste lid, FW, verleent hij kwijtschelding voor
+      het deel van de belastingschuld dat onbetaald blijft, nadat het akkoord tot stand is gekomen dan wel is gehomologeerd
+      en hij het bedrag dat hem op grond van het akkoord toekomt, heeft ontvangen.
+
+      De ontvanger kan voor belastingaanslagen waarvoor derden in redelijkheid aansprakelijk kunnen worden gesteld toezeggen
+      dat daarvoor ten aanzien van de belastingschuldige geen verdere invorderingsmaatregelen worden genomen in plaats van
+      kwijtschelding te verlenen. De ontvanger vermeldt in dat geval in de beschikking dat hij zich het recht voorbehoudt om
+      derden aansprakelijk te stellen voor de betreffende belastingaanslagen.
+
+      73.3a.4 Gevolgen homologatie WHOA-akkoord zonder instemming
+
+      Als een akkoord als bedoeld in artikel 370, eerste lid, FW, waarmee de ontvanger niet heeft ingestemd, door de
+      rechtbank wordt gehomologeerd, verleent de ontvanger voor het resterende deel van de belastingaanslagen geen
+      kwijtschelding maar neemt hij geen verdere invorderingsmaatregelen.
+
+      De belastingvorderingen die resteren na homologatie van een akkoord zijn aan te merken als natuurlijke verbintenissen.
+
+      Belastingteruggaven met een dagtekening gelegen na de datum van homologatie van een akkoord die materieel betrekking
+      hebben op een periode waarop het akkoord betrekking heeft, zal de ontvanger in beginsel niet verrekenen met de
+      vorderingen die tot een natuurlijke verbintenis zijn getransformeerd. De ontvanger verrekent deze belastingteruggaven
+      alleen als het in de gegeven omstandigheden naar maatstaven van redelijkheid en billijkheid onaanvaardbaar zou zijn als
+      hij de belastingteruggaaf niet kan verrekenen. Daarvan is in ieder geval sprake als de vordering van de ontvanger en de
+      belastingteruggaaf zien op dezelfde belasting en hetzelfde tijdvak.
+
+      73.4 Insolventieprocedure – faillissement
+
+      73.4.1 Faillissementsaanvraag – algemeen
+
+      De belastingaanslag(en) waarvoor de ontvanger het faillissement aanvraagt, moet(en) onherroepelijk vaststaan of in
+      redelijkheid materieel verschuldigd worden geacht. Een faillissementsaanvraag blijft achterwege als de
+      belastingschuldige aantoont dat de betalingsonmacht van korte duur is.
+
+      Voor een voorlopige aanslag vraagt de ontvanger slechts een faillissement aan als:
+
+      •
+
+      die aanslag is gevolgd door een definitieve aanslag; of
+
+      •
+
+      naast de voorlopige aanslag ook andere aanslagen onbetaald zijn gebleven.
+
+      73.4.2 Ontbinding van rechtspersonen in plaats van faillissementsaanvraag
+
+      Als sprake is van een rechtspersoon die geen activiteiten meer uitoefent, en bovendien bekend is dat geen baten
+      aanwezig noch te verwachten zijn, dan wordt de voorkeur gegeven aan het treffen van maatregelen die moeten leiden tot
+      ontbinding van die rechtspersoon conform artikel 2:19a BW boven het aanvragen van het faillissement van die
+      rechtspersoon.
+
+      73.4.3 Particulieren en faillissement
+
+      Het aanvragen van het faillissement van een particulier blijft achterwege als wordt verwacht dat de ontvanger de
+      eventuele vermogensbestanddelen ook geheel of nagenoeg geheel zonder faillissement kan uitwinnen, zelfs als daarbij
+      niet de gehele schuld wordt voldaan.
+
+      Particulieren zijn in dit verband natuurlijke personen die niet een onderneming drijven of zelfstandig een beroep
+      uitoefenen en waarvan niet aannemelijk is dat zij van plan zijn dit te doen.
+
+      Voor zover de openstaande belastingschulden het gevolg zijn van bedrijfsvoering of uitoefening van een zelfstandig
+      beroep, worden natuurlijke personen die hun bedrijf of zelfstandige beroepsuitoefening hebben gestaakt in dit verband
+      niet beschouwd als particulieren.
+
+      73.4.4 Saneringsaanbod en faillissementsaanvraag
+
+      Als de belastingschuldige – voordat de faillissementsaanvraag in behandeling is genomen – een verzoek om kwijtschelding
+      doet, dan wel een buitengerechtelijk akkoord aanbiedt (een en ander in de zin van artikel 73.6 van deze leidraad), dan
+      zal de ontvanger de faillissementsaanvraag aanhouden dan wel intrekken om het verzoek dan wel het aanbod aan een nader
+      oordeel te onderwerpen.
+
+      Hiervan wordt afgeweken als op voorhand duidelijk is dat het verzoek dan wel het aanbod louter is gedaan om de
+      behandeling van de faillissementsaanvraag te traineren. Er wordt ook van afgeweken als het aanbod onvoldoende past
+      binnen het door de HHNK gehanteerde kwijtscheldingsbeleid respectievelijk het in het kwijtscheldingsbeleid opgenomen
+      saneringsbeleid, en/of gebaseerd is op een onjuiste voorstelling van zaken. In deze gevallen wijst de ontvanger het
+      verzoek dan wel het aanbod bij beschikking gemotiveerd af, zonder de faillissementsaanvraag in te trekken of aan te
+      houden.
+
+      73.4.5 Verzoek om uitstel van betaling vóór behandeling faillissementsaanvraag door rechter
+
+      Als de belastingschuldige een verzoek om uitstel van betaling doet, voordat de rechtbank de faillissementsaanvraag in
+      behandeling heeft genomen, dan zal de ontvanger de faillissementsaanvraag aanhouden dan wel intrekken om het verzoek
+      aan een nader oordeel te onderwerpen.
+
+      De ontvanger doet dit niet als duidelijk is dat het verzoek louter is gedaan om de behandeling van de
+      faillissementsaanvraag te traineren, of als het verzoek onvoldoende past binnen het door HHNK gehanteerde
+      uitstelbeleid, en/of gebaseerd is op een onjuiste voorstelling van zaken. In deze gevallen wijst de ontvanger het
+      verzoek bij beschikking gemotiveerd af, zonder de faillissementsaanvraag in te trekken of aan te houden.
+
+      73.4.6 Toestemming voor faillissementsaanvraag
+
+      De ontvanger moet voor iedere faillissementsaanvraag schriftelijk toestemming van D&H hebben.
+
+      Het voorgaande geldt ook voor in hoger beroep te voeren zaken over een faillissementsaanvraag.
+
+      73.4.7 Steunvordering derden voor faillissementsaanvraag [Vervallen per 25-02-2011]
+
+      73.4.8 Verlenen van steunvordering en faillissementsaanvraag
+
+      Voor het verstrekken van de gegevens van de belastingschuldige geldt niet hetgeen in artikel 73.4.1 tot en met 73.4.6
+      is vermeld met betrekking tot een faillissementsaanvraag door de ontvanger.
+
+      Wel is voor het verstrekken van de gegevens toestemming van D&H vereist, als het een belastingschuldige betreft die een
+      bedrijf voert of zelfstandig een beroep uitoefent waaraan in totaal meer dan vijftig werknemers zijn verbonden. De
+      gegevens worden uitsluitend schriftelijk verstrekt.
+
+      Als de ontvanger zelf het initiatief neemt om een andere schuldeiser van de belastingschuldige te benaderen met het
+      verzoek het faillissement van de belastingschuldige aan te vragen met gebruikmaking van de belastingschuld als
+      steunvordering, dan geldt wel hetgeen is vermeld in artikel 73.4.1, 73.4.3 en 73.4.6 van deze leidraad. In dat geval is
+      dus ook toestemming van D&H vereist.
+
+      73.4.9 Verzet tegen faillietverklaring
+
+      Als de ontvanger gebruik wil maken van de mogelijkheid tot verzet tegen de faillietverklaring als bedoeld in artikel 10
+      FW heeft hij hiervoor toestemming van D&H nodig.
+
+      73.4.10 Beroep op regresrecht in faillissement
+
+      Niet van toepassing voor HHNK.
+
+      73.4.11 Verzending of uitreiking aanslagbiljet bij faillissement
+
+      Voor toezending of uitreiking van het aanslagbiljet ingeval van faillissement wordt verwezen naar artikel 8.1 van deze
+      leidraad.
+
+      73.4.12 Opkomen in faillissement
+
+      Van de bevoegdheid op grond van artikel 19 van de wet om van de curator dadelijke voldoening aan de vordering te
+      verlangen wordt verwezen naar artikel 19.2.3 van deze leidraad.
+
+      73.4.13 Volgorde uitwinning bodembeslag in faillissement
+
+      Niet van toepassing voor HHNK.
+
+      73.4.14 Na de toepassing van het faillissement
+
+      De ontvanger maakt in beginsel geen gebruik van de bevoegdheid van artikel 196 Fw, om na de beëindiging van een
+      faillissement het proces-verbaal van de verificatievergadering voor het onbetaald gebleven bedrag tegen de schuldenaar
+      te executeren. Als er wel aanleiding tot invordering bestaat, doet de ontvanger dit zoveel mogelijk bij dwangbevel.
+
+      Bij natuurlijke personen hervat de ontvanger slechts in bijzondere omstandigheden de invordering na beëindiging van het
+      faillissement. Deze omstandigheden doen zich onder andere voor als de betrokkene binnen vijf jaar na het faillissement
+      beschikt over een meer dan modaal inkomen of over vermogensbestanddelen van substantiële waarde.
+
+      Als na beëindiging van het faillissement daaruit ontvangen gelden moeten worden terugbetaald, treedt de ontvanger in
+      verband met artikel 194 FW in overleg met de curator.
+
+      73.4.15 Opening nationale (secundaire) insolventieprocedure
+
+      Als de belastingschuldige woont of gevestigd is in een lidstaat van de EU – niet Denemarken – en aldaar in staat van
+      insolventie verkeert terwijl in Nederland sprake is van een nevenvestiging, kan in Nederland op grond van de
+      EG-insolventieverordening een zogenoemde territoriale of secundaire procedure worden geopend.
+
+      Onmiddellijk na kennisname van de in het buitenland geopende hoofdprocedure, beoordeelt de ontvanger of hij baat heeft
+      bij het openen van een secundaire of territoriale procedure in Nederland. Een secundaire procedure betreft alleen de
+      liquidatieprocedure – dus niet de surseance van betaling – en wordt afgewikkeld volgens het in Nederland geldende
+      recht. De staat van insolventie behoeft daarbij niet te worden aangetoond.
+
+      73.4.16 Omzetting faillissement in WSNP
+
+      Als omzetting van een faillissement in een WSNP mogelijk is, toetst de ontvanger – als de schuldenaar hier
+      uitdrukkelijk om verzoekt – een door de schuldenaar in het faillissement aangeboden akkoord aan het beleid ingevolge
+      artikel 19a en 22a van de regeling.
+
+      73.5 Insolventieprocedure – MSNP door leden van de NVVK of gemeenten
+
+      73.5.1 Voorwaarden voor MSNP
+
+      Stabilisatiefase
+
+      Een schuldhulpverleningstraject vangt in het algemeen aan met een stabilisatie-overeenkomst tussen schuldenaar en de
+      schuldhulpverlener (welke lid is van de NVVK, of een gemeente is) als hierna bedoeld in onderdeel b. Voor de toepassing
+      van dit artikel wordt met een stabilisatieovereenkomst gelijkgesteld een mededeling van de schuldhulpverlener waarin
+      staat dat hij activiteiten ontplooit die erop gericht zijn de financiële situatie van de schuldenaar op korte termijn
+      te stabiliseren.
+
+      Vanaf de ontvangst van een afschrift van de stabilisatie-overeenkomst neemt de ontvanger gedurende een periode van
+      maximaal 240 dagen geen dwanginvorderingsmaatregelen. Lopende invorderingsmaatregelen schort de ontvanger op, zo nodig
+      in overleg met de schuldhulpverlener. Daarnaast vindt verrekening alleen plaats met belastingteruggaven die (materieel)
+      zijn ontstaan tot en met de dag waarop het afschrift van de stabilisatie-overeenkomst is ontvangen. Het in deze alinea
+      beschreven terughoudende beleid geldt niet in situaties waarin op voorhand duidelijk is dat de belastingschuldige niet
+      in aanmerking komt voor uitstel van betaling op basis van het hierna in dit artikel beschreven beleid. De ontvanger
+      informeert de schuldhulpverlener hierover.
+
+      Schuldenregelingsovereenkomst
+
+      Nadat de schuldhulpverlener de ontvanger schriftelijk heeft bericht dat de overeenkomst tot schuldregeling tot stand is
+      gekomen, verleent de ontvanger uitstel van betaling voor een periode van in beginsel maximaal 36 maanden als:
+
+      a.
+
+      de schuldregeling betrekking heeft op natuurlijke personen;
+
+      b.
+
+      de schuldhulpverlener lid is van de NVVK of de schuldregeling wordt uitgevoerd door een gemeente in eigen beheer (zie
+      ook artikel 73.5a);
+
+      c.
+
+      een schuldregelingsovereenkomst in de zin van de Gedragscode Schuldhulpverlening van de NVVK tot stand is gekomen of
+      een overeenkomst tot stand is gekomen die dezelfde strekking heeft als die gedragscode en waarbij voor de berekening
+      van de aflossingscapaciteit wordt uitgegaan van de door Recofa gepubliceerde normen;
+
+      d.
+
+      een schuldregelingsovereenkomst tot stand is gekomen conform de Module Schuldregeling in het kader van
+      schuldhulpverlening voor ondernemers van de NVVK of een daarmee gelijk te stellen overeenkomst en waarbij voor de
+      berekening van de aflossingscapaciteit wordt uitgegaan van de door Recofa gepubliceerde normen, voor zover de
+      schuldregeling ziet op een natuurlijk persoon, zijnde ondernemer;
+
+      e.
+
+      het aannemelijk is dat het bedrijf of beroep tijdens en na het volledig hebben doorlopen van de schuldregeling met een
+      levensvatbare bedrijfsuitoefening kan worden voortgezet, voor zover de schuldregeling ziet op een natuurlijk persoon,
+      zijnde ondernemer;
+
+      f.
+
+      redelijkerwijs mag worden aangenomen dat de belastingschuldige – afgezien van de formaliteiten die daarvoor verricht
+      moeten worden – in aanmerking zou komen voor een schuldregeling als bedoeld in artikel 287a FW;
+
+      g.
+
+      aan het eind van de looptijd van de schuldregelingsovereenkomst een bedrag zal zijn betaald van ten minste dezelfde
+      omvang als kan worden verkregen indien er sprake zou zijn van een WSNP.
+
+      De voorwaarden onder d en e zijn niet van toepassing op een ex-ondernemer indien aannemelijk is dat hij in de toekomst
+      geen bedrijf zal uitoefenen of niet zelfstandig een beroep zal uitoefenen.
+
+      De ontvanger kan in bijzondere omstandigheden een langere termijn voor uitstel van betaling toekennen dan 36 maanden.
+      Daarbij gelden als voorwaarden dat de schuldhulpverlener daar schriftelijk om verzoekt en aannemelijk maakt dat sprake
+      is van bijzondere omstandigheden die een langere periode rechtvaardigen en dat de belangen van de belastingschuldige
+      onevenredig worden geschaad als wordt vastgehouden aan de termijn van 36 maanden.
+
+      De ontvanger kan ervoor kiezen om aanslagen, waarvoor hij redelijkerwijs derden aansprakelijk kan stellen, niet te
+      betrekken in de schuldregeling, voor zover deze ziet op een natuurlijk persoon, zijnde ondernemer. Artikel 26.3.2 is
+      hierbij van overeenkomstige toepassing.
+
+      Het uitstel vangt aan met ingang van de datum van de schuldregelingsovereenkomst. Na totstandkoming van een
+      schuldregelingsovereenkomst onderzoekt de schuldhulpverlener of een schuldregeling met de schuldeisers tot stand kan
+      worden gebracht. De schuldhulpverlener streeft ernaar dit onderzoek af te ronden binnen 120 dagen, maar uiterlijk
+      binnen 240 dagen, gerekend vanaf de datum van de schuldregelingsovereenkomst. Wanneer de schuldregeling met de
+      schuldeisers tot stand is gebracht, zet de schuldhulpverlener de schuldregelingsovereenkomst voort; hij stelt de
+      schuldeisers daarvan schriftelijk op de hoogte. Slaagt de schuldhulpverlener niet tijdig in het tot stand brengen van
+      de schuldregeling, dan beëindigt hij de schuldregelingsovereenkomst.
+
+      Deze regeling is ook van toepassing op belastingaanslagen waarvan in beginsel geen kwijtschelding wordt verleend, omdat
+      de WSNP ook van toepassing is op die belastingaanslagen.
+
+      De uitstelregeling geldt voor belastingaanslagen die betrekking hebben op de (materieel) verschuldigde belasting tot en
+      met de dag van de dagtekening van de schuldregelingsovereenkomst en is definitief in die zin dat daarop van de zijde
+      van de ontvanger in beginsel niet meer kan worden teruggekomen. In voorkomend geval wordt het bedrag van de
+      verschuldigde belastingen door middel van schatting bepaald. In het geval de in de vorige volzin bedoelde schatting
+      naar achteraf blijkt substantieel te laag mocht zijn, kan de ontvanger daarop alleen terugkomen indien ter zake van die
+      belasting ten tijde van de schatting ten onrechte geen aangifte was gedaan dan wel indien de belastingschuldige of de
+      schuldhulpverlener wisten of behoorden te weten dat de schatting te laag was.
+
+      73.5.2 Opschorten invorderingsmaatregelen na verzoek MSNP [Vervallen per 01-01-2017]
+
+      73.5.3 Gevolgen uitstel MSNP voor invorderingsmaatregelen
+
+      Eventuele gelegde beslagen vervallen zodra een schuldregeling tussen de schuldenaar en diens schuldeisers tot stand is
+      gekomen (en de schuldregelingsovereenkomst dus wordt voortgezet). Verrekening kan plaatsvinden met teruggaven die
+      betrekking hebben op belasting die (materieel) is ontstaan tot en met de dag waarop het afschrift van de
+      stabilisatie-overeenkomst is ontvangen.
+
+      73.5.4 Houding ontvanger tijdens uitstel MSNP
+
+      Als sprake is van een verleend uitstel van betaling op grond van een schuldregelingsovereenkomst handelt de ontvanger
+      gedurende de periode van uitstel op dezelfde wijze als bij een WSNP.
+
+      Als de belastingschuldige verzoekt om kwijtschelding van belastingschulden die materieel zijn ontstaan na de dag van de
+      dagtekening van de schuldregelingsovereenkomst, dan wordt het verzoek behandeld overeenkomstig het bestaande beleid.
+
+      Dit houdt onder meer in dat bij de berekening van de in artikel 13 van de regeling bedoelde betalingscapaciteit op het
+      inkomen van de belastingschuldige niet in mindering wordt gebracht dat deel van het inkomen dat onder het financieel
+      beheer door de schuldhulpverlener valt. Verder wordt opgemerkt dat de middelen die onder financieel beheer van de
+      schuldhulpverlener berusten, niet worden beschouwd als vermogen in de zin van artikel 12 van de regeling.
+
+      73.5.5 Intrekken uitstel gedurende MSNP
+
+      De ontvanger trekt het uitstel in als:
+
+      •
+
+      hij niet uiterlijk binnen 240 dagen na de dagtekening van de schuldregelingsovereenkomst door de schuldhulpverlener
+      schriftelijk is geïnformeerd dat de schuldregelingsovereenkomst wordt voortgezet;
+
+      •
+
+      de schuldenaar nieuw opkomende belastingschulden die (materieel) betrekking hebben op belasting verschuldigd na de dag
+      van de dagtekening van de schuldregelingsovereenkomst, onbetaald laat;
+
+      •
+
+      de schuldenaar zijn lopende fiscale verplichtingen niet nakomt;
+
+      •
+
+      de schuldenaar zijn schuldeisers tracht te benadelen;
+
+      •
+
+      de schuldregelingsovereenkomst wordt beëindigd, anders dan in de zin van artikel 73.5.6.
+
+      Het uitstel wordt in de situatie genoemd bij het eerste gedachtestreepje niet ingetrokken als blijkt dat een verzoek om
+      een schuldregeling, als bedoeld in artikel 287a van de Faillissementswet, is ingediend bij de rechter. De ontvanger
+      trekt het uitstel in deze situatie niet eerder in, dan nadat de rechter heeft beslist op het verzoek.
+
+      De ontvanger trekt in de situaties genoemd bij het tweede, derde en vierde gedachtestreepje het uitstel niet eerder in,
+      dan nadat hij de schuldhulpverlener heeft bericht over zijn voornemen het uitstel in te trekken als belastingschuldige
+      niet binnen veertien dagen zijn verplichtingen correct nakomt.
+
+      73.5.6 De schuldenaar voldoet aan zijn verplichtingen MSNP
+
+      Als de ontvanger uitstel van betaling heeft verleend voor de periode van de MSNP, wordt een schriftelijke kennisgeving
+      van de schuldhulpverlener na afloop van de overeenkomst tot schuldregeling aangemerkt als het aanbieden van een
+      buitengerechtelijk akkoord in de zin van artikel 19a van de regeling of artikel 22a van de regeling.
+
+      In de kennisgeving moet zijn gesteld dat de overeenkomst na eindcontrole is beëindigd en de schuldenaar aan zijn
+      verplichtingen heeft voldaan.
+
+      73.5.7 Na de toepassing van de MSNP
+
+      Met betrekking tot te betalen belastingaanslagen die betrekking hebben op de periode waarin de MSNP van toepassing was
+      en die zijn vastgesteld na beëindiging van die regeling, zal de ontvanger in beginsel, als de schuldenaar aan zijn
+      verplichtingen uit die regeling heeft voldaan, afzien van invordering. Daarbij geldt dat aannemelijk moet zijn dat:
+
+      •
+
+      de schuldhulpverlener de aan de betreffende aanslag of terugvordering voorafgaande voorlopige aanslagen/teruggaven of
+      voorschotten op voldoende juistheid heeft getoetst; en
+
+      •
+
+      hij over de resultaten van die toetsing in voorkomend geval tijdig contact heeft opgenomen met de Belastingdienst.
+
+      73.5a Insolventieprocedure – MSNP door anderen dan leden van de NVVK of gemeenten
+
+      Verzoeken om een MSNP gedaan door een persoon of instelling als bedoeld in artikel 48, eerste lid, van de Wet op het
+      consumentenkrediet, niet zijnde een NVVK-lid of een gemeente, worden in behandeling genomen met inachtneming van het
+      volgende. De ontvanger zal een belangenafweging moeten maken en zich daarbij moeten afvragen of hij al dan niet tot
+      instemming met de schuldregeling kan komen, in aanmerking genomen de onevenredigheid tussen het belang dat hij heeft
+      bij de uitoefening van de bevoegdheid tot weigering en het belang van de schuldenaar dat door die weigering wordt
+      geschaad. Artikel 73.5 is daarbij van overeenkomstige toepassing. Dit betekent onder meer dat de schuldregeling
+      betrekking moet hebben op natuurlijke personen.
+
+      Bij die belangenafweging zullen de volgende omstandigheden een rol kunnen spelen:
+
+      1.
+
+      is het schikkingsvoorstel goed en betrouwbaar gedocumenteerd;
+
+      2.
+
+      is voldoende duidelijk gemaakt dat het aanbod het uiterste is waartoe de schuldenaar financieel in staat moet worden
+      geacht;
+
+      3.
+
+      biedt het alternatief van faillissement of schuldsanering enig uitzicht voor de schuldenaar;
+
+      4.
+
+      biedt het alternatief van faillissement of schuldsanering enig uitzicht voor de ontvanger: hoe groot is de kans dat de
+      weigerende ontvanger dan evenveel of meer zal ontvangen;
+
+      5.
+
+      bestaat er precedentwerking voor vergelijkbare gevallen;
+
+      6.
+
+      wat is de zwaarte van het financiële belang dat de ontvanger heeft bij volledige nakoming;
+
+      7.
+
+      hoe groot is het aandeel van de weigerende ontvanger in de totale schuldenlast;
+
+      8.
+
+      staat de weigerende ontvanger alleen naast de overige met de schuldregeling instemmende schuldeisers;
+
+      9.
+
+      is er eerder een minnelijke of een gedwongen schuldregeling geweest die niet naar behoren is nagekomen.
+
+      Als uit de belangenafweging volgt dat kan worden ingestemd met een dergelijk verzoek dan verleent de ontvanger op het
+      moment van het ingaan van de schuldregeling voor 36 maanden uitstel van betaling.
+
+      73.6 Insolventieprocedures – akkoorden
+
+      73.6.1 Buitengerechtelijk akkoord
+
+      In het tweede lid van de artikelen 19a en 22a van de regeling zijn bepalingen opgenomen die de doelstellingen van de
+      WSNP – namelijk het sluiten van een buitengerechtelijk akkoord met de gezamenlijke schuldeisers over de sanering van de
+      schulden zonder tussenkomst van een rechter – ook voor HHNK laten gelden.
+
+      Deze bepalingen zijn ook van toepassing op betalingsverplichting van een aansprakelijkgestelde van wie redelijkerwijs
+      mag worden aangenomen dat de WSNP op hem van toepassing is.
+
+      Een verzoek tot het sluiten van een buitengerechtelijk akkoord kan een ieder indienen, ook de schuldenaar.
+
+      73.6.2 Voorwaarden voor toetreding tot een buitengerechtelijk akkoord [Vervallen per 01-07-2018]
+
+      73.6.2a Betaling bedrag saneringsakkoord
+
+      De betaling van het aangeboden bedrag moet in beginsel ineens plaatsvinden. Als de ontvanger bij wijze van uitzondering
+      instemt met betaling in termijnen eist hij zekerheid.
+
+      Als in het buitengerechtelijk akkoord belastingschulden zijn begrepen waarvoor derden aansprakelijk kunnen worden
+      gesteld, neemt de ontvanger als voorwaarde op dat de kwijtschelding pas wordt geëffectueerd op het moment dat op grond
+      van die aansprakelijkheid geen baten meer kunnen worden verkregen. De ontvanger ziet van deze voorwaarde af als in het
+      aangeboden bedrag de baten in de aansprakelijkheid tot uitdrukking komen.
+
+      De ontvanger stemt alleen in met een buitengerechtelijk akkoord als het bodemvoorrecht of de waarde van de bodemzaken
+      tot uitdrukking komt in het aangeboden bedrag.
+
+      73.6.3 Gevolgen buitengerechtelijk akkoord
+
+      Als de ontvanger toetreedt tot een buitengerechtelijk akkoord verleent hij kwijtschelding voor het deel van de
+      belastingschuld dat onbetaald blijft, nadat hij het bedrag dat hem op grond van het akkoord toekomt, heeft ontvangen.
+      Zo nodig stelt hij een derdenbeslag of houder van penningen op de hoogte van het verval van het beslag en zorgt voor
+      doorhaling van een beslag op een registergoed.
+
+      Een buitengerechtelijk akkoord is niet van invloed op gelegde beslagen. De ontvanger heft de beslagen op zodra hij
+      ontvangt wat hij heeft gevorderd op grond van het buitengerechtelijk akkoord.
+
+      73.6.4 Voorwaarden voor toetreding tot een gerechtelijk akkoord
+
+      De betaling van het aangeboden bedrag moet in beginsel ineens plaatsvinden. Als de ontvanger bij wijze van uitzondering
+      instemt met betaling in termijnen eist hij zekerheid.
+
+      Als in het akkoord belastingschulden zijn begrepen waarvoor derden aansprakelijk kunnen worden gesteld, neemt de
+      ontvanger als voorwaarde op dat de kwijtschelding pas wordt geëffectueerd op het moment dat op grond van die
+      aansprakelijkheid geen baten meer kunnen worden verkregen. De ontvanger ziet van deze voorwaarde af als in het
+      aangeboden bedrag de baten in de aansprakelijkheid tot uitdrukking komen.
+
+      De ontvanger stemt alleen in met een akkoord als het bodemvoorrecht of de waarde van de bodemzaken tot uitdrukking komt
+      in het aangeboden bedrag.
+
+      73.6.5 Gevolgen toetreden tot gerechtelijk akkoord
+
+      Als de ontvanger vrijwillig toetreedt tot een gerechtelijk akkoord verleent hij kwijtschelding voor het deel van de
+      belastingschuld dat onbetaald blijft, nadat hij het bedrag dat hem op grond van het akkoord toekomt, heeft ontvangen.
+
+      73.6.6 Begrip belastingschuld en (buiten)gerechtelijk akkoord
+
+      Bij de beoordeling van een akkoord stelt de ontvanger eerst vast op welke belastingaanslagen het akkoord betrekking
+      heeft. Uitgangspunt daarbij is de materiële belastingschuld die is ontstaan tot aan de dag dat de WSNP is uitgesproken
+      of de dag waarop een buitengerechtelijk akkoord wordt aangeboden.
+
+      Er rust een inspanningsverplichting op HHNK om de te saneren schuld zo volledig mogelijk en tot het juiste bedrag vast
+      te stellen, in die zin dat de materieel verschuldigde belasting wordt geformaliseerd in een aanslag.
+
+      De ontvanger betrekt bestuurlijke boeten, rente en kosten integraal in een akkoord.
+
+      73.6.7 Schuldig nalatig en (buiten)gerechtelijk akkoord
+
+      Niet van toepassing voor HHNK.
+
+      73.6.8 Gevolgen dwangakkoord
+
+      Als de rechter in het kader van een WSNP een dwangakkoord oplegt aan de gezamenlijke schuldeisers, lijdt de ontvanger
+      het deel van de belastingschuld dat onvoldaan blijft oninbaar.
+
+      Aangezien de ontvanger niet heeft ingestemd met het akkoord, verleent hij geen kwijtschelding. De belastingvorderingen
+      die resteren na het dwangakkoord blijven als natuurlijke verbintenissen over.
+
+      Belastingteruggaven met een dagtekening gelegen na de datum van het akkoord die betrekking hebben op een periode vóór
+      de uitspraak van de toepassing van de wettelijke schuldsaneringsregeling, zal de ontvanger in beginsel niet verrekenen
+      met de vorderingen die tot een natuurlijke verbintenis zijn getransformeerd. De ontvanger verrekent deze
+      belastingteruggaven alleen als het in de gegeven omstandigheden naar maatstaven van redelijkheid en billijkheid
+      onaanvaardbaar zou zijn de belastingteruggaaf niet te kunnen verrekenen. Daarvan is in ieder geval sprake als de
+      vordering van de ontvanger en de belastingteruggaaf zien op dezelfde belasting en hetzelfde tijdvak
+
+      73.6.9 Kwijtschelding voor ondernemers bij een saneringsakkoord
+
+      Indien een akkoord op grond van artikel 22a van de regeling niet mogelijk is, vindt kwijtschelding voor ondernemers
+      uitsluitend plaats bij een zogenaamd saneringsakkoord in de zin van artikel 22 van de regeling. Zie ook artikel 26.3
+      van deze leidraad.
+
+      73.7 Wettelijk breed moratorium
+
+      Gedurende een door de rechtbank afgekondigde afkoelingsperiode als bedoeld in artikel 5 van de Wet gemeentelijke
+      schuldhulpverlening, schort de ontvanger lopende invorderingsmaatregelen op. Verrekening met belastingteruggaven vinden
+      gedurende de afkoelingsperiode niet plaats ongeacht de periode waarop de teruggaaf betrekking heeft. De
+      afkoelingsperiode is niet van invloed op een eventueel verleend uitstel van betaling. Hierop blijft het in deze
+      leidraad opgenomen beleid op artikel 25 van de wet van toepassing. Gedurende de afkoelingsperiode schort de ontvanger
+      de uitbetaling aan een derde op in verband met een executoriaal beslag op belastingteruggaven aan de belastingschuldige
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_73
+
+  - number: '74'
+    text: |-
+      Niet van toepassing voor HHNK.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_74
+
+  - number: '75'
+    text: |-
+      **Kosten van vervolging**
+
+      Dit artikel beschrijft het beleid bij het in rekening brengen van kosten van vervolging.
+
+      Met 'vervolgingskosten of kosten' wordt bedoeld de kosten die op grond van de Kostenwet invordering rijksbelastingen
+      (Kostenwet) in rekening worden gebracht.
+
+      Hieronder vallen ook de kosten die verbonden zijn aan de werkzaamheden die de belastingdeurwaarder verricht voor de
+      invordering op civiele wijze.
+
+      In dit artikel is het volgende beleid over kosten van vervolging opgenomen:
+
+      •
+
+      gevorderde som bevat geen vervolgingskosten;
+
+      •
+
+      aan derden toekomende bedragen;
+
+      •
+
+      rechtsmiddelen en vervolgingskosten;
+
+      •
+
+      verzoek om vermindering vervolgingskosten aanmerken als bezwaar;
+
+      •
+
+      niet in rekening brengen van vervolgingskosten;
+
+      •
+
+      onverschuldigdheid van vervolgingskosten;
+
+      •
+
+      niet-verwijtbaarheid en vervolgingskosten;
+
+      •
+
+      versnelde invordering en vervolgingskosten;
+
+      •
+
+      aansprakelijkgestelden en vervolgingskosten;
+
+      •
+
+      geen kwijtschelding van vervolgingskosten;
+
+      •
+
+      limitering betekeningskosten dwangbevel.
+
+      75.1 Gevorderde som bevat geen vervolgingskosten
+
+      De gevorderde som bij een aanmaning of dwangbevel (waarvan onderscheidenlijk sprake is in artikel 2 en artikel 3,
+      eerste lid van de Kostenwet invordering rijksbelastingen) is te verstaan als het belastingbedrag waarvoor de aanmaning
+      of het dwangbevel is uitgevaardigd, dus zonder de vervolgingskosten en eventuele – pro memorie opgenomen – rente.
+
+      75.2 Aan derden toekomende bedragen
+
+      Onder de bedragen die op grond van artikel 6 van de Kostenwet invordering rijksbelastingen aan de belastingschuldige in
+      rekening worden gebracht, vallen:
+
+      •
+
+      de kosten van de advertenties als bedoeld in artikel 3, vierde lid, en artikel 4, eerste lid, van de Kostenwet
+      invordering rijksbelastingen;
+
+      •
+
+      de vergoeding van de bewaarder dan wel door hem ingeschakelde derden;
+
+      •
+
+      de kosten van het openen van deuren en huisraad als bedoeld in artikel 444 Rv;
+
+      •
+
+      de kosten van het aanbrengen en verwijderen door derden van wielklemmen of andere bestanddelen die verhindering van
+      gebruik, vervoer en belasting van de in beslaggenomen roerende zaken bewerkstelligen;
+
+      •
+
+      kosten van derden met betrekking tot informatievergaring ten behoeve van de invordering;
+
+      •
+
+      kosten van derden met betrekking tot verzenden van artikel 19en;
+
+      •
+
+      de kosten van het verrichten van werkzaamheden voor de verkoop ter plaatse van de in beslag genomen zaken;
+
+      •
+
+      de kosten van het verrichten van werkzaamheden door makelaars, deskundigen en afslagers;
+
+      •
+
+      de kosten van opslag, afvoer en bewaarneming van in beslag genomen roerende zaken;
+
+      •
+
+      de kosten van het doen overbrengen van de in beslag genomen zaken als de verkoop elders plaatsvindt.
+
+      Om redenen van beleid worden de laatstgenoemde kosten enkel in rekening gebracht als de verkoop op uitdrukkelijk
+      verzoek van de belastingschuldige elders gebeurt dan wel als daarbij voornamelijk zijn belang is gediend. Eventuele
+      gemaakte reiskosten door HHNK voor de betekening en de tenuitvoerlegging van het dwangbevel kunnen niet op de
+      belastingschuldige worden verhaald, evenals mogelijke porti- en telefoonkosten.
+
+      75.3 Rechtsmiddelen en vervolgingskosten
+
+      Als de belastingschuldige in beroep gaat tegen de uitspraak op het bezwaar, handelt de ontvanger overeenkomstig de
+      voorschriften van het Besluit Beroep in Belastingzaken.
+
+      De ontvanger kan zich beperken tot de stukken die in de procedure over de toepassing van de Kostenwet relevant zijn.
+
+      Indiening van een bezwaarschrift of beroepschrift (in hoger beroep) stuit op grond van artikel 6:16 Awb niet de aanvang
+      of de voortzetting van de tenuitvoerlegging van de akte van vervolging.
+
+      Als om uitstel van betaling wordt verzocht, is het beleid dat is verwoord in artikel 25.1 en 25.2 van deze leidraad van
+      overeenkomstige toepassing.
+
+      75.4 Verzoek om vermindering vervolgingskosten aanmerken als bezwaar
+
+      Een verzoek van de belastingschuldige tot vermindering van de in rekening gebrachte kosten wordt aangemerkt als een
+      bezwaarschrift. Het bepaalde in artikel 75.3 van deze leidraad is van overeenkomstige is van overeenkomstige
+      toepassing.
+
+      75.5 Niet in rekening brengen van vervolgingskosten
+
+      In de volgende gevallen brengt de ontvanger voor het uitbrengen van exploten geen vervolgingskosten in rekening:
+
+      •
+
+      herhaalde betekening van een dwangbevel;
+
+      •
+
+      (herhaalde) betekening van een dwangbevel uitsluitend ter stuiting van de verjaring;
+
+      •
+
+      betekening van een vordering;
+
+      •
+
+      betekening aan een minderjarige of onder curatele gestelde als bedoeld in artikel 13.3 van deze leidraad met dien
+      verstande dat de eerste betekening wel, maar de tweede betekening (aan de wettelijke vertegenwoordiger) niet in
+      rekening wordt gebracht;
+
+      •
+
+      betekening van een beslissing van D&H op een beroepschrift tegen de inbeslagneming van roerende zaken aan de derde die
+      het beroepschrift heeft ingediend, de beslagene en zo nodig de bewaarder, al dan niet gepaard gaande met gehele of
+      gedeeltelijke opheffing van het beslag;
+
+      •
+
+      betekening van een proces-verbaal van overgang van de bewaring van beslagen roerende zaken, anders dan op verzoek of
+      door toedoen van de belastingschuldige.
+
+      75.6 Onverschuldigdheid van vervolgingskosten
+
+      Naast de gevallen waarin ten aanzien van de kostenberekening rekenfouten zijn gemaakt dan wel een onjuist tarief is
+      gehanteerd, zijn kosten niet verschuldigd in de volgende gevallen.
+
+      •
+
+      Als de betaling op de rekening van HHNK is bijgeschreven op of voorafgaand aan de dag waarop de kosten verschuldigd
+      zijn geworden.
+
+      •
+
+      Voor zover na het in rekening brengen van de kosten een afname van de schuld, anders dan door betaling, kwijtschelding
+      of verrekening tot stand is gekomen. Deze situatie zal zich voordoen:
+
+      •
+
+      bij vermindering van belastingaanslagen;
+
+      •
+
+      als een positieve belastingaanslag wordt gevolgd door een negatieve belastingaanslag over dezelfde belasting en
+      hetzelfde tijdvak.
+
+      •
+
+      Als er achteraf bezien al voor het in rekening brengen van de kosten om beleidsmatige redenen aanleiding is geweest om
+      de invordering op te schorten. Hierbij valt te denken aan:
+
+      •
+
+      een schriftelijk ingediend verzoek om uitstel;
+
+      •
+
+      een ingediend aanvraagformulier voor kwijtschelding, mits volledig ingevuld.
+
+      Volledigheidshalve wordt opgemerkt dat zich omstandigheden kunnen voordoen waarin het noodzakelijk is de invordering
+      wel voort te zetten. In dat geval komen de hieraan verbonden kosten vanzelfsprekend niet voor een tegemoetkoming in
+      aanmerking.
+
+      Kosten worden in afwijking van het voorgaande altijd in rekening gebracht als sprake is van traineren van de
+      invordering.
+
+      •
+
+      Als na het in rekening brengen van de kosten aan de belastingaanslag een nieuwe dagtekening is toegekend.
+
+      •
+
+      Als een derdenbeslag nooit blijkt te hebben gelegen als bedoeld in artikel 14.4.1 van deze leidraad.
+
+      •
+
+      Als zaken – die in een onroerende zaak aanwezig zijn – zowel in een beslag op roerende als in een beslag op onroerende
+      zaken zijn begrepen omdat twijfel bestaat over de vraag of deze zaken roerend dan wel onroerend zijn en duidelijkheid
+      is verkregen door middel van welk beslag die zaken moeten worden uitgewonnen. In dat geval zijn de kosten die verband
+      houden met het niet voortgezette beslag niet verschuldigd.
+
+      •
+
+      Als zaken – die op of in een schip van de belastingschuldige aanwezig zijn – zowel in een beslag op het schip als in
+      een beslag op roerende zaken zijn begrepen omdat twijfel bestaat over de vraag of deze zaken een bestanddeel vormen van
+      het schip dan wel zelfstandige roerende zaken zijn, en duidelijkheid is verkregen door middel van welk beslag die zaken
+      moeten worden uitgewonnen. In dat geval zijn de kosten die verband houden met het niet voortgezette beslag niet
+      verschuldigd.
+
+      •
+
+      Als invorderingsmaatregelen worden getroffen met inachtneming van de artikelen 10 en 15 van de wet, en de
+      belastingschuldige binnen twee werkdagen na uitreiking van het aanslagbiljet de openstaande belastingschuld betaalt.
+
+      75.7 Niet-verwijtbaarheid en vervolgingskosten
+
+      In uitzonderlijke situaties kan er voor de ontvanger aanleiding bestaan de in rekening gebrachte vervolgingskosten –
+      hoezeer ook verschuldigd – te verminderen als de belastingschuldige hier schriftelijk om verzoekt.
+
+      Van zo’n situatie kan sprake zijn als de belastingschuldige aantoont in omstandigheden te hebben verkeerd die het hem
+      feitelijk onmogelijk maakten zijn verplichtingen tijdig na te komen en bovendien de invordering van vervolgingskosten –
+      gezien de omstandigheden van het specifieke geval – onredelijk en onbillijk is.
+
+      75.8 Versnelde invordering en vervolgingskosten
+
+      Als invorderingsmaatregelen worden getroffen met inachtneming van de artikelen 10 en 15 van de wet, vermeldt de
+      belastingdeurwaarder in de akte van betekening bij het dwangbevel dat de in verband met die maatregelen berekende
+      vervolgingskosten niet verschuldigd zijn als de openstaande belastingschuld binnen twee werkdagen na uitreiking van het
+      aanslagbiljet wordt betaald. De vorige volzin is van overeenkomstige toepassing op de beslagkosten.
+
+      75.9 Aansprakelijkgestelden en vervolgingskosten
+
+      Voor de door aansprakelijkgestelden verschuldigde kosten die het gevolg zijn van invorderingsmaatregelen die tegen de
+      aansprakelijkgestelde zijn genomen, is dit hoofdstuk van overeenkomstige toepassing.
+
+      75.10 Geen kwijtschelding van vervolgingskosten
+
+      Kwijtschelding van vervolgingskosten is niet mogelijk wegens vermeende betalingsonmacht. De ontvanger doet in dat geval
+      ook geen toezegging dat deze kosten niet zullen worden ingevorderd.
+
+      Het voorgaande laat onverlet dat kwijtschelding wordt verleend dan wel kosten buiten invordering worden gelaten,
+      wanneer de hoofdsom wordt kwijtgescholden dan wel buiten invordering gelaten. Hiervoor wordt verwezen naar hetgeen is
+      vermeld bij artikel 26 van deze leidraad.
+
+      75.11 Limitering betekeningskosten dwangbevel
+
+      Als door de ontvanger of de belastingdeurwaarder op dezelfde dag aan een belastingschuldige meerdere dwangbevelen
+      worden betekend, is de belastingschuldige niet meer betekeningskosten verschuldigd dan het, op grond van artikel 3,
+      eerste lid, van de Kostenwet invordering rijksbelastingen, maximaal in rekening te brengen bedrag voor het betekenen
+      van een dwangbevel.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_75
+
+  - number: '76'
+    text: |-
+      Niet van toepassing voor HHNK.
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_76
+
+  - number: '80'
+    text: |-
+      **Invordering, Awb en het moment van vaststelling van (naheffings)aanslagen**
+
+      In dit artikel is beleid opgenomen met betrekking tot artikel 4:121 Awb en het moment van vaststelling van
+      (naheffings)aanslagen.
+
+      80.1 Tenuitvoerlegging termijndwangbevel
+
+      Een eenmaal ingestelde vervolging voor één of meer van de vervallen termijnen van de belastingaanslag wordt met
+      dezelfde voortvarendheid voltooid als de eindvervolging.
+
+      80.2 Moment van vaststelling van (naheffings)aanslagen
+
+      Het overgangsrecht met betrekking tot afdeling 4.4.1 Awb (Vaststelling en inhoud van de verplichting tot betaling)
+      bepaalt kort gezegd het volgende. Op een betalingsverplichting die is vastgesteld of ontstaan voor 1 juli 2009 geldt
+      het recht van voor die datum. Voor betalingsverplichtingen van na 1 juli 2009 geldt de genoemde afdeling 4.4.1.
+
+      Bij aanslagbelastingen geldt als moment van vaststelling de datum van dagtekening van de aanslag.
+
+      Ondertekening
+
+      Aldus besloten in de vergadering van 24 januari 2023 van het college van dijkgraaf en hoogheemraden,
+
+      de secretaris, de voorzitter,
+
+      M.J. Kuipers R. Veenman
+
+      Reglement automatische incasso waterschapsbelastingen HHNK
+
+      Artikel 1 Begripsbepalingen
+
+      Dit reglement verstaat onder:
+
+      a.
+
+      belastingjaar: tijdvak van 1 januari tot en met 31 december waarover de belastingen worden geheven;
+
+      b.
+
+      belastingschuldige: degene op wiens naam de belastingaanslag is gesteld;
+
+      c.
+
+      belastingen: de waterschapsbelastingen welke op grond van de geldende belastingverordeningen automatisch geïncasseerd
+      kunnen worden;
+
+      d.
+
+      formele belastingschuld: het totale bedrag dat verschuldigd is aan belastingen, die op een aanslag vermeld is;
+
+      e.
+
+      incassant: de ambtenaar bedoeld in artikel 123, derde lid, onderdeel c, van de Waterschapswet.
+
+      Artikel 2 Doelstelling en toepassingsbereik
+
+      1.
+
+      De automatische incasso heeft tot doel de formele belastingschuld van de belastingschuldige te spreiden en door middel
+      van maandelijkse termijnen automatisch te incasseren.
+
+      2.
+
+      Betaling via automatische incasso is mogelijk door of ten behoeve van belastingschuldigen, aan wie één of meerdere
+      belastingen zijn opgelegd.
+
+      3.
+
+      De incassant kan betaling via automatische incasso weigeren, indien er omstandigheden worden geconstateerd of vermoed
+      die het regelmatig verloop van de termijnbetalingen belemmeren of zouden kunnen belemmeren.
+
+      Artikel 3 Machtiging tot automatische incasso
+
+      1.
+
+      Het verstrekken van een machtiging tot automatische incasso vindt plaats:
+
+      a.
+
+      via de website van het hoogheemraadschap;
+
+      b.
+
+      door het bij de belastingaanslag bijgevoegde machtigingsformulier ingevuld en ondertekend terug te sturen naar de
+      incassant;
+
+      c.
+
+      door een ondertekende brief met daarin adresgegevens, vorderingsnummer en rekeningnummer te versturen naar de
+      incassant.
+
+      2.
+
+      Met de machtiging wordt toestemming verleend om de belastingaanslag in maximaal tien gelijke termijnen van het
+      opgegeven rekeningnummer te incasseren.
+
+      3.
+
+      De machtiging kan vooraf worden verstrekt of moet uiterlijk binnen drie weken na dagtekening van de aanslag door de
+      incassant zijn ontvangen.
+
+      4.
+
+      De incassant kan de machtiging die na de in het derde lid bedoelde termijn door hem zijn ontvangen, accepteren in het
+      geval dit redelijkerwijs nog mogelijk is voordat de laatste vervaldag voor betaling van de aanslag is verstreken.
+
+      5.
+
+      De machtiging geldt tot wederopzegging en is mede van toepassing op daarvoor in aanmerking komende aanslagen welke nog
+      aan de belastingschuldige worden opgelegd.
+
+      6.
+
+      Een machtiging die meer dan 36 maanden niet is gebruikt komt automatisch te vervallen.
+
+      Artikel 4 Berekening termijnbedrag
+
+      1.
+
+      Het termijnbedrag wordt berekend over maximaal tien gelijke termijnen.
+
+      2.
+
+      Indien de machtiging niet binnen drie weken na dagtekening van de aanslag door de incassant is geaccepteerd, wordt het
+      termijnbedrag berekend over de nog resterende termijnen.
+
+      3.
+
+      Het minimumbedrag bij automatische incasso is € 10 per termijn. Als het bedrag van de aanslag minder is dan € 100,
+      wordt het bedrag in minder dan tien termijnen afgeschreven.
+
+      4.
+
+      Betalingen buiten de automatische incasso, verminderingen en ontheffingen resulteren in een verlaging van het
+      termijnbedrag.
+
+      5.
+
+      Indien de laatste termijn niet geïncasseerd kan worden, dient het resterende invorderbare bedrag per omgaande door de
+      belastingschuldige te worden voldaan.
+
+      Artikel 5 Tijdstip van afschrijving
+
+      1.
+
+      De eerste termijn wordt een maand na dagtekening van de aanslag afgeschreven en elk van de volgende termijnen telkens
+      een maand later.
+
+      2.
+
+      De incassant zal het termijnbedrag automatisch afschrijven rond de 28ste van elke maand.
+
+      Artikel 6 Ontbindende voorwaarden
+
+      1.
+
+      De automatische incasso wordt beëindigd indien:
+
+      a.
+
+      de automatische incasso gedurende twee, al dan niet opeenvolgende, pogingen niet slaagt, tenzij in dit reglement anders
+      is aangegeven. De incassant geeft belastingschuldige schriftelijk te kennen dat de automatische incasso per direct is
+      beëindigd en dat het resterend invorderbaar bedrag van alle belastingaanslagen van het hoogheemraadschap per omgaande
+      dienen te worden betaald;
+
+      b.
+
+      na een eerste poging blijkt dat een volgende incasso op voorhand onmogelijk is, hieronder wordt onder meer begrepen de
+      verstrekte machtiging betreffende een niet-bestaand rekeningnummer, een geblokkeerd rekeningnummer of een beëindigd
+      rekeningnummer;
+
+      c.
+
+      de belastingschuldige surseance heeft aangevraagd, in staat van faillissement is gesteld, naar het buitenland vertrekt
+      of dreigt te vertrekken of indien anderszins omstandigheden worden geconstateerd die een regelmatig verloop van de
+      incasso belemmeren.
+
+      2.
+
+      Bij beëindiging van de automatische incasso dient het resterend invorderbaar bedrag per omgaande door de
+      belastingschuldige te worden voldaan.
+
+      Artikel 7 Overlijden
+
+      1.
+
+      Overlijden van de belastingschuldige beëindigt de automatische incasso niet.
+
+      2.
+
+      De erven van de belastingschuldige kunnen de automatische incasso stopzetten door middel van een schriftelijke
+      opzegging aan de incassant.
+
+      Artikel 8 Huwelijk, geregistreerd partnerschap en samenlevingsovereenkomst
+
+      1.
+
+      Echtscheiding, beëindiging van een geregistreerd partnerschap of ontbinding van de samenlevingsovereenkomst van de
+      belastingschuldige beëindigt de automatische incasso niet.
+
+      2.
+
+      Indien als gevolg van echtscheiding, beëindiging van een geregistreerd partnerschap of ontbinding van de
+      samenlevingsovereenkomst niet meer kan worden geïncasseerd op het bij de machtiging opgegeven rekeningnummer, dient de
+      belastingschuldige aan de incassant zo spoedig mogelijk via de website van het hoogheemraadschap, of schriftelijk, een
+      rekeningnummer op te geven waarop de automatische incasso kan worden voortgezet.
+
+      Artikel 9 Verhuizing
+
+      Verhuizing van de belastingschuldige beëindigt de automatische incasso niet.
+
+      Artikel 10 Automatische incasso bij bezwaar en kwijtschelding
+
+      In de periode dat een bezwaar of een verzoek om kwijtschelding in behandeling is wordt de automatische incasso niet
+      stopgezet. Als blijkt dat het bezwaar (deels) gegrond is, of het verzoek om kwijtschelding (deels) wordt toegewezen,
+      wordt een eventueel teveel betaald bedrag terugbetaald.
+
+      Artikel 11 Wijziging rekeningnummer
+
+      Wijzigingen betreffende het op de automatische incasso betrekking hebbende rekeningnummer dienen onmiddellijk
+      schriftelijk of via de website van het hoogheemraadschap te worden gemeld.
+
+      Artikel 12 Niet eens met afschrijving
+
+      Indien de belastingschuldige het niet eens is met een afgeschreven termijnbedrag, kan deze binnen 56 dagen na incasso
+      de bankinstelling opdracht geven het termijnbedrag op zijn rekening terug te storten.
+
+      Artikel 13 Terugbetaling
+
+      De opdracht tot terugbetaling van een teveel betaald bedrag zoals bedoeld in artikel 10 vindt niet eerder plaats dan 56
+      dagen na incasso.
+
+      Artikel 14 Intrekken machtiging automatische incasso
+
+      1.
+
+      De automatische incasso kan door de belastingschuldige te allen tijde schriftelijk of via de website van het
+      hoogheemraadschap worden beëindigd.
+
+      2.
+
+      Bij beëindiging van de automatische incasso dient het resterend invorderbaar bedrag per omgaande door de
+      belastingschuldige te worden betaald.
+
+      Ziet u een fout in deze regeling?
+
+      Bent u van mening dat de inhoud niet juist is? Neem dan contact op met de organisatie die de regelgeving heeft
+      gepubliceerd. Deze organisatie is namelijk zelf verantwoordelijk voor de inhoud van de regelgeving. De naam van de
+      organisatie ziet u bovenaan de regelgeving. De contactgegevens van de organisatie kunt u hier opzoeken:
+      organisaties.overheid.nl.
+
+      Werkt de website of een link niet goed? Stuur dan een e-mail naar regelgeving@overheid.nl
+
+      Over deze website
+
+      Contact
+
+      English
+
+      Help
+
+      Zoeken
+
+      Informatie hergebruiken
+
+      Privacy en cookies
+
+      Toegankelijkheid
+
+      Sitemap
+
+      Kwetsbaarheid melden
+
+      Open data
+
+      Linked Data Overheid
+
+      PUC Open Data
+
+      MijnOverheid.nl
+
+      Rijksoverheid.nl
+
+      Ondernemersplein.nl
+
+      Werkenbijdeoverheid.nl
+    url: https://lokaleregelgeving.overheid.nl/CVDR691525/1#artikel_80

--- a/features/kwijtschelding_hhnk.feature
+++ b/features/kwijtschelding_hhnk.feature
@@ -104,3 +104,48 @@ Feature: HHNK kwijtschelding waterschapsbelastingen
     Then the execution succeeds
     And the output "kan_kwijtschelding_worden_verleend" is "false"
     And the output "hoogte_kwijtschelding" is "0"
+
+  # Hoog inkomen: alleenstaande, inkomen 300000 eurocent, HHNK-kostennorm 100%
+  # (140150). Betalingscapaciteit = 12 x (300000 - 140150) = 1918200 eurocent.
+  # Aanwendbaar = 80% x 1918200 = 1534560 eurocent, ver boven de aanslag van 15000.
+  # Dus geen kwijtschelding mogelijk.
+  Scenario: Hoog inkomen wordt afgewezen
+    Given the calculation date is "2026-06-01"
+    And a citizen with the following data:
+      | bsn                                     | 999993653                       |
+      | waterschap_code                         | WS0155                          |
+      | belastingsoort                          | watersysteemheffing_ingezetenen |
+      | netto_besteedbaar_inkomen_maand         | 300000                          |
+      | netto_besteedbaar_inkomen_partner_maand | 0                               |
+      | huishoudtype                            | alleenstaande                   |
+      | is_pensioengerechtigd                   | false                           |
+      | vermogen                                | 0                               |
+      | aanslagbedrag                           | 15000                           |
+      | is_ondernemer                           | false                           |
+      | belasting_zakelijk                      | false                           |
+    When the law "kwijtscheldingsregeling_waterschapsbelastingen_hhnk" is executed for outputs "kan_kwijtschelding_worden_verleend,hoogte_kwijtschelding"
+    Then the execution succeeds
+    And the output "kan_kwijtschelding_worden_verleend" is "false"
+    And the output "hoogte_kwijtschelding" is "0"
+
+  # Ondernemer met uitsluitend privé-aanslag (niet zakelijk) valt wel binnen de
+  # regeling: HHNK art 5 sluit alleen zakelijke belastingschulden uit. Verder
+  # identiek aan het eerste scenario, dus volledige kwijtschelding.
+  Scenario: Ondernemer met privé-aanslag wordt wel toegelaten
+    Given the calculation date is "2026-06-01"
+    And a citizen with the following data:
+      | bsn                                     | 999993653                       |
+      | waterschap_code                         | WS0155                          |
+      | belastingsoort                          | watersysteemheffing_ingezetenen |
+      | netto_besteedbaar_inkomen_maand         | 140150                          |
+      | netto_besteedbaar_inkomen_partner_maand | 0                               |
+      | huishoudtype                            | alleenstaande                   |
+      | is_pensioengerechtigd                   | false                           |
+      | vermogen                                | 0                               |
+      | aanslagbedrag                           | 15000                           |
+      | is_ondernemer                           | true                            |
+      | belasting_zakelijk                      | false                           |
+    When the law "kwijtscheldingsregeling_waterschapsbelastingen_hhnk" is executed for outputs "kan_kwijtschelding_worden_verleend,hoogte_kwijtschelding"
+    Then the execution succeeds
+    And the output "kan_kwijtschelding_worden_verleend" is "true"
+    And the output "hoogte_kwijtschelding" is "15000"

--- a/features/kwijtschelding_hhnk.feature
+++ b/features/kwijtschelding_hhnk.feature
@@ -23,6 +23,13 @@ Feature: HHNK kwijtschelding waterschapsbelastingen
       | kinderopvang_nettokosten_maand          | 0                               |
       | is_ondernemer                           | false                           |
       | belasting_zakelijk                      | false                           |
+      | gegevens_onvolledig_of_onjuist                | false                           |
+      | bezwaar_of_beroep_aanhangig                   | false                           |
+      | zekerheid_gesteld                             | false                           |
+      | meerdere_belastingschuldigen                  | false                           |
+      | derde_aansprakelijk_gesteld                   | false                           |
+      | verwijtbaarheid_belastingschuld               | false                           |
+      | in_faillissement_of_surseance_zonder_akkoord  | false                           |
     When the law "kwijtscheldingsregeling_waterschapsbelastingen_hhnk" is executed for outputs "kan_kwijtschelding_worden_verleend,hoogte_kwijtschelding"
     Then the execution succeeds
     And the output "kan_kwijtschelding_worden_verleend" is "true"
@@ -52,6 +59,13 @@ Feature: HHNK kwijtschelding waterschapsbelastingen
       | kinderopvang_nettokosten_maand          | 0                          |
       | is_ondernemer                           | false                      |
       | belasting_zakelijk                      | false                      |
+      | gegevens_onvolledig_of_onjuist                | false                      |
+      | bezwaar_of_beroep_aanhangig                   | false                      |
+      | zekerheid_gesteld                             | false                      |
+      | meerdere_belastingschuldigen                  | false                      |
+      | derde_aansprakelijk_gesteld                   | false                      |
+      | verwijtbaarheid_belastingschuld               | false                      |
+      | in_faillissement_of_surseance_zonder_akkoord  | false                      |
     When the law "kwijtscheldingsregeling_waterschapsbelastingen_hhnk" is executed for outputs "kan_kwijtschelding_worden_verleend,hoogte_kwijtschelding"
     Then the execution succeeds
     And the output "kan_kwijtschelding_worden_verleend" is "true"
@@ -79,6 +93,13 @@ Feature: HHNK kwijtschelding waterschapsbelastingen
       | kinderopvang_nettokosten_maand          | 0                               |
       | is_ondernemer                           | true                            |
       | belasting_zakelijk                      | true                            |
+      | gegevens_onvolledig_of_onjuist                | false                           |
+      | bezwaar_of_beroep_aanhangig                   | false                           |
+      | zekerheid_gesteld                             | false                           |
+      | meerdere_belastingschuldigen                  | false                           |
+      | derde_aansprakelijk_gesteld                   | false                           |
+      | verwijtbaarheid_belastingschuld               | false                           |
+      | in_faillissement_of_surseance_zonder_akkoord  | false                           |
     When the law "kwijtscheldingsregeling_waterschapsbelastingen_hhnk" is executed for outputs "kan_kwijtschelding_worden_verleend,hoogte_kwijtschelding"
     Then the execution succeeds
     And the output "kan_kwijtschelding_worden_verleend" is "false"
@@ -108,6 +129,13 @@ Feature: HHNK kwijtschelding waterschapsbelastingen
       | kinderopvang_nettokosten_maand          | 0                             |
       | is_ondernemer                           | false                         |
       | belasting_zakelijk                      | false                         |
+      | gegevens_onvolledig_of_onjuist                | false                         |
+      | bezwaar_of_beroep_aanhangig                   | false                         |
+      | zekerheid_gesteld                             | false                         |
+      | meerdere_belastingschuldigen                  | false                         |
+      | derde_aansprakelijk_gesteld                   | false                         |
+      | verwijtbaarheid_belastingschuld               | false                         |
+      | in_faillissement_of_surseance_zonder_akkoord  | false                         |
     When the law "kwijtscheldingsregeling_waterschapsbelastingen_hhnk" is executed for outputs "kan_kwijtschelding_worden_verleend,hoogte_kwijtschelding"
     Then the execution succeeds
     And the output "kan_kwijtschelding_worden_verleend" is "true"
@@ -136,6 +164,13 @@ Feature: HHNK kwijtschelding waterschapsbelastingen
       | kinderopvang_nettokosten_maand          | 0                               |
       | is_ondernemer                           | false                           |
       | belasting_zakelijk                      | false                           |
+      | gegevens_onvolledig_of_onjuist                | false                           |
+      | bezwaar_of_beroep_aanhangig                   | false                           |
+      | zekerheid_gesteld                             | false                           |
+      | meerdere_belastingschuldigen                  | false                           |
+      | derde_aansprakelijk_gesteld                   | false                           |
+      | verwijtbaarheid_belastingschuld               | false                           |
+      | in_faillissement_of_surseance_zonder_akkoord  | false                           |
     When the law "kwijtscheldingsregeling_waterschapsbelastingen_hhnk" is executed for outputs "kan_kwijtschelding_worden_verleend,hoogte_kwijtschelding"
     Then the execution succeeds
     And the output "kan_kwijtschelding_worden_verleend" is "true"
@@ -167,10 +202,52 @@ Feature: HHNK kwijtschelding waterschapsbelastingen
       | kinderopvang_nettokosten_maand          | 60000                           |
       | is_ondernemer                           | false                           |
       | belasting_zakelijk                      | false                           |
+      | gegevens_onvolledig_of_onjuist                | false                           |
+      | bezwaar_of_beroep_aanhangig                   | false                           |
+      | zekerheid_gesteld                             | false                           |
+      | meerdere_belastingschuldigen                  | false                           |
+      | derde_aansprakelijk_gesteld                   | false                           |
+      | verwijtbaarheid_belastingschuld               | false                           |
+      | in_faillissement_of_surseance_zonder_akkoord  | false                           |
     When the law "kwijtscheldingsregeling_waterschapsbelastingen_hhnk" is executed for outputs "kan_kwijtschelding_worden_verleend,hoogte_kwijtschelding"
     Then the execution succeeds
     And the output "kan_kwijtschelding_worden_verleend" is "true"
     And the output "hoogte_kwijtschelding" is "45000"
+
+  # Lopend bezwaar of beroep tegen de aanslag (Leidraad 26.1.9, 4e punt) sluit kwijtschelding
+  # uit tot na de uitspraak — ongeacht de financiele beoordeling.
+  Scenario: Lopend bezwaar tegen aanslag blokkeert kwijtschelding
+    Given the calculation date is "2026-06-01"
+    And a citizen with the following data:
+      | bsn                                     | 999993653                       |
+      | waterschap_code                         | WS0155                          |
+      | belastingsoort                          | watersysteemheffing_ingezetenen |
+      | netto_besteedbaar_inkomen_maand         | 140150                          |
+      | netto_besteedbaar_inkomen_partner_maand | 0                               |
+      | huishoudtype                            | alleenstaande                   |
+      | is_pensioengerechtigd                   | false                           |
+      | inboedel_waarde                         | 0                               |
+      | auto_waarde                             | 0                               |
+      | auto_onmisbaar                          | false                           |
+      | onroerend_goed_waarde                   | 0                               |
+      | andere_bezittingen                      | 0                               |
+      | hoger_bevoorrechte_schulden             | 0                               |
+      | liquide_middelen                        | 0                               |
+      | aanslagbedrag                           | 15000                           |
+      | kinderopvang_nettokosten_maand          | 0                               |
+      | is_ondernemer                           | false                           |
+      | belasting_zakelijk                      | false                           |
+      | gegevens_onvolledig_of_onjuist                | false                           |
+      | bezwaar_of_beroep_aanhangig                   | true                            |
+      | zekerheid_gesteld                             | false                           |
+      | meerdere_belastingschuldigen                  | false                           |
+      | derde_aansprakelijk_gesteld                   | false                           |
+      | verwijtbaarheid_belastingschuld               | false                           |
+      | in_faillissement_of_surseance_zonder_akkoord  | false                           |
+    When the law "kwijtscheldingsregeling_waterschapsbelastingen_hhnk" is executed for outputs "kan_kwijtschelding_worden_verleend,hoogte_kwijtschelding"
+    Then the execution succeeds
+    And the output "kan_kwijtschelding_worden_verleend" is "false"
+    And the output "hoogte_kwijtschelding" is "0"
 
   # Auto boven drempelwaarde van EUR 2269 (226900 eurocent) die absoluut onmisbaar is voor werk
   # of vanwege invaliditeit wordt niet als vermogen beschouwd (URI art 12 lid 2 onderdeel c).
@@ -196,6 +273,13 @@ Feature: HHNK kwijtschelding waterschapsbelastingen
       | kinderopvang_nettokosten_maand          | 0                               |
       | is_ondernemer                           | false                           |
       | belasting_zakelijk                      | false                           |
+      | gegevens_onvolledig_of_onjuist                | false                           |
+      | bezwaar_of_beroep_aanhangig                   | false                           |
+      | zekerheid_gesteld                             | false                           |
+      | meerdere_belastingschuldigen                  | false                           |
+      | derde_aansprakelijk_gesteld                   | false                           |
+      | verwijtbaarheid_belastingschuld               | false                           |
+      | in_faillissement_of_surseance_zonder_akkoord  | false                           |
     When the law "kwijtscheldingsregeling_waterschapsbelastingen_hhnk" is executed for outputs "kan_kwijtschelding_worden_verleend,hoogte_kwijtschelding"
     Then the execution succeeds
     And the output "kan_kwijtschelding_worden_verleend" is "true"
@@ -225,6 +309,13 @@ Feature: HHNK kwijtschelding waterschapsbelastingen
       | kinderopvang_nettokosten_maand          | 0                               |
       | is_ondernemer                           | false                           |
       | belasting_zakelijk                      | false                           |
+      | gegevens_onvolledig_of_onjuist                | false                           |
+      | bezwaar_of_beroep_aanhangig                   | false                           |
+      | zekerheid_gesteld                             | false                           |
+      | meerdere_belastingschuldigen                  | false                           |
+      | derde_aansprakelijk_gesteld                   | false                           |
+      | verwijtbaarheid_belastingschuld               | false                           |
+      | in_faillissement_of_surseance_zonder_akkoord  | false                           |
     When the law "kwijtscheldingsregeling_waterschapsbelastingen_hhnk" is executed for outputs "kan_kwijtschelding_worden_verleend,hoogte_kwijtschelding"
     Then the execution succeeds
     And the output "kan_kwijtschelding_worden_verleend" is "false"
@@ -252,6 +343,13 @@ Feature: HHNK kwijtschelding waterschapsbelastingen
       | kinderopvang_nettokosten_maand          | 0                                     |
       | is_ondernemer                           | false                                 |
       | belasting_zakelijk                      | false                                 |
+      | gegevens_onvolledig_of_onjuist                | false                                 |
+      | bezwaar_of_beroep_aanhangig                   | false                                 |
+      | zekerheid_gesteld                             | false                                 |
+      | meerdere_belastingschuldigen                  | false                                 |
+      | derde_aansprakelijk_gesteld                   | false                                 |
+      | verwijtbaarheid_belastingschuld               | false                                 |
+      | in_faillissement_of_surseance_zonder_akkoord  | false                                 |
     When the law "kwijtscheldingsregeling_waterschapsbelastingen_hhnk" is executed for outputs "kan_kwijtschelding_worden_verleend,hoogte_kwijtschelding"
     Then the execution succeeds
     And the output "kan_kwijtschelding_worden_verleend" is "false"
@@ -282,6 +380,13 @@ Feature: HHNK kwijtschelding waterschapsbelastingen
       | kinderopvang_nettokosten_maand          | 0                               |
       | is_ondernemer                           | false                           |
       | belasting_zakelijk                      | false                           |
+      | gegevens_onvolledig_of_onjuist                | false                           |
+      | bezwaar_of_beroep_aanhangig                   | false                           |
+      | zekerheid_gesteld                             | false                           |
+      | meerdere_belastingschuldigen                  | false                           |
+      | derde_aansprakelijk_gesteld                   | false                           |
+      | verwijtbaarheid_belastingschuld               | false                           |
+      | in_faillissement_of_surseance_zonder_akkoord  | false                           |
     When the law "kwijtscheldingsregeling_waterschapsbelastingen_hhnk" is executed for outputs "kan_kwijtschelding_worden_verleend,hoogte_kwijtschelding"
     Then the execution succeeds
     And the output "kan_kwijtschelding_worden_verleend" is "false"
@@ -311,6 +416,13 @@ Feature: HHNK kwijtschelding waterschapsbelastingen
       | kinderopvang_nettokosten_maand          | 0                               |
       | is_ondernemer                           | true                            |
       | belasting_zakelijk                      | false                           |
+      | gegevens_onvolledig_of_onjuist                | false                           |
+      | bezwaar_of_beroep_aanhangig                   | false                           |
+      | zekerheid_gesteld                             | false                           |
+      | meerdere_belastingschuldigen                  | false                           |
+      | derde_aansprakelijk_gesteld                   | false                           |
+      | verwijtbaarheid_belastingschuld               | false                           |
+      | in_faillissement_of_surseance_zonder_akkoord  | false                           |
     When the law "kwijtscheldingsregeling_waterschapsbelastingen_hhnk" is executed for outputs "kan_kwijtschelding_worden_verleend,hoogte_kwijtschelding"
     Then the execution succeeds
     And the output "kan_kwijtschelding_worden_verleend" is "true"

--- a/features/kwijtschelding_hhnk.feature
+++ b/features/kwijtschelding_hhnk.feature
@@ -1,0 +1,106 @@
+Feature: HHNK kwijtschelding waterschapsbelastingen
+
+  # Alleenstaande met inkomen gelijk aan de bijstandsnorm heeft geen betalingscapaciteit;
+  # bij afwezig vermogen wordt de hele aanslag kwijtgescholden.
+  Scenario: Alleenstaande bijstandsgerechtigde krijgt volledige kwijtschelding
+    Given the calculation date is "2026-06-01"
+    And a citizen with the following data:
+      | bsn                                     | 999993653                       |
+      | waterschap_code                         | WS0155                          |
+      | belastingsoort                          | watersysteemheffing_ingezetenen |
+      | netto_besteedbaar_inkomen_maand         | 140150                          |
+      | netto_besteedbaar_inkomen_partner_maand | 0                               |
+      | huishoudtype                            | alleenstaande                   |
+      | is_pensioengerechtigd                   | false                           |
+      | vermogen                                | 0                               |
+      | aanslagbedrag                           | 15000                           |
+      | is_ondernemer                           | false                           |
+      | belasting_zakelijk                      | false                           |
+    When the law "kwijtscheldingsregeling_waterschapsbelastingen_hhnk" is executed for outputs "kan_kwijtschelding_worden_verleend,hoogte_kwijtschelding"
+    Then the execution succeeds
+    And the output "kan_kwijtschelding_worden_verleend" is "true"
+    And the output "hoogte_kwijtschelding" is "15000"
+
+  # Tweepersoonshuishouden met inkomen €50 boven de echtgenoten-bijstandsnorm:
+  # betalingscapaciteit = 12 x (205213 - 200213) = 60000 eurocent.
+  # 80% daarvan = 48000 wordt aangewend; hoogte = 60000 - 0 - 48000 = 12000 eurocent.
+  Scenario: Tweepersoonshuishouden net boven norm krijgt gedeeltelijke kwijtschelding
+    Given the calculation date is "2026-06-01"
+    And a citizen with the following data:
+      | bsn                                     | 999993653                  |
+      | waterschap_code                         | WS0155                     |
+      | belastingsoort                          | zuiveringsheffing_woonruimte |
+      | netto_besteedbaar_inkomen_maand         | 205213                     |
+      | netto_besteedbaar_inkomen_partner_maand | 0                          |
+      | huishoudtype                            | echtgenoten                |
+      | is_pensioengerechtigd                   | false                      |
+      | vermogen                                | 0                          |
+      | aanslagbedrag                           | 60000                      |
+      | is_ondernemer                           | false                      |
+      | belasting_zakelijk                      | false                      |
+    When the law "kwijtscheldingsregeling_waterschapsbelastingen_hhnk" is executed for outputs "kan_kwijtschelding_worden_verleend,hoogte_kwijtschelding"
+    Then the execution succeeds
+    And the output "kan_kwijtschelding_worden_verleend" is "true"
+    And the output "hoogte_kwijtschelding" is "12000"
+
+  # Ondernemer met zakelijke belastingschuld valt buiten de regeling (art 5 HHNK).
+  Scenario: Ondernemer met zakelijke belastingschuld wordt afgewezen
+    Given the calculation date is "2026-06-01"
+    And a citizen with the following data:
+      | bsn                                     | 999993653                       |
+      | waterschap_code                         | WS0155                          |
+      | belastingsoort                          | watersysteemheffing_ingezetenen |
+      | netto_besteedbaar_inkomen_maand         | 140150                          |
+      | netto_besteedbaar_inkomen_partner_maand | 0                               |
+      | huishoudtype                            | alleenstaande                   |
+      | is_pensioengerechtigd                   | false                           |
+      | vermogen                                | 0                               |
+      | aanslagbedrag                           | 15000                           |
+      | is_ondernemer                           | true                            |
+      | belasting_zakelijk                      | true                            |
+    When the law "kwijtscheldingsregeling_waterschapsbelastingen_hhnk" is executed for outputs "kan_kwijtschelding_worden_verleend,hoogte_kwijtschelding"
+    Then the execution succeeds
+    And the output "kan_kwijtschelding_worden_verleend" is "false"
+    And the output "hoogte_kwijtschelding" is "0"
+
+  # Pensioengerechtigde alleenstaande: kostennorm gebruikt bijstandsnorm_aow_alleenstaand
+  # (156469 eurocent). Bij inkomen gelijk aan die norm is betalingscapaciteit 0,
+  # dus de volledige aanslag wordt kwijtgescholden.
+  Scenario: AOW-gerechtigde alleenstaande krijgt kwijtschelding met pensioen-norm
+    Given the calculation date is "2026-06-01"
+    And a citizen with the following data:
+      | bsn                                     | 999993653                     |
+      | waterschap_code                         | WS0155                        |
+      | belastingsoort                          | verontreinigingsheffing_woonruimte |
+      | netto_besteedbaar_inkomen_maand         | 156469                        |
+      | netto_besteedbaar_inkomen_partner_maand | 0                             |
+      | huishoudtype                            | alleenstaande                 |
+      | is_pensioengerechtigd                   | true                          |
+      | vermogen                                | 0                             |
+      | aanslagbedrag                           | 20000                         |
+      | is_ondernemer                           | false                         |
+      | belasting_zakelijk                      | false                         |
+    When the law "kwijtscheldingsregeling_waterschapsbelastingen_hhnk" is executed for outputs "kan_kwijtschelding_worden_verleend,hoogte_kwijtschelding"
+    Then the execution succeeds
+    And the output "kan_kwijtschelding_worden_verleend" is "true"
+    And the output "hoogte_kwijtschelding" is "20000"
+
+  # Niet-begunstigde belastingsoort (niet genoemd in HHNK art 1) valt buiten scope.
+  Scenario: Belastingsoort buiten de HHNK-scope wordt afgewezen
+    Given the calculation date is "2026-06-01"
+    And a citizen with the following data:
+      | bsn                                     | 999993653                             |
+      | waterschap_code                         | WS0155                                |
+      | belastingsoort                          | watersysteemheffing_gebouwd_bedrijven |
+      | netto_besteedbaar_inkomen_maand         | 140150                                |
+      | netto_besteedbaar_inkomen_partner_maand | 0                                     |
+      | huishoudtype                            | alleenstaande                         |
+      | is_pensioengerechtigd                   | false                                 |
+      | vermogen                                | 0                                     |
+      | aanslagbedrag                           | 15000                                 |
+      | is_ondernemer                           | false                                 |
+      | belasting_zakelijk                      | false                                 |
+    When the law "kwijtscheldingsregeling_waterschapsbelastingen_hhnk" is executed for outputs "kan_kwijtschelding_worden_verleend,hoogte_kwijtschelding"
+    Then the execution succeeds
+    And the output "kan_kwijtschelding_worden_verleend" is "false"
+    And the output "hoogte_kwijtschelding" is "0"

--- a/features/kwijtschelding_hhnk.feature
+++ b/features/kwijtschelding_hhnk.feature
@@ -63,16 +63,16 @@ Feature: HHNK kwijtschelding waterschapsbelastingen
     And the output "kan_kwijtschelding_worden_verleend" is "false"
     And the output "hoogte_kwijtschelding" is "0"
 
-  # Pensioengerechtigde alleenstaande: kostennorm gebruikt bijstandsnorm_aow_alleenstaand
-  # (156469 eurocent). Bij inkomen gelijk aan die norm is betalingscapaciteit 0,
-  # dus de volledige aanslag wordt kwijtgescholden.
-  Scenario: AOW-gerechtigde alleenstaande krijgt kwijtschelding met pensioen-norm
+  # Pensioengerechtigde alleenstaande: kostennorm gebruikt netto_ouderdomspensioen_alleenstaand
+  # (155815 eurocent = netto AOW alleenstaand 2026 per RKBM art 3).
+  # Bij inkomen gelijk aan netto-AOW is betalingscapaciteit 0, dus volledige kwijtschelding.
+  Scenario: AOW-gerechtigde alleenstaande krijgt kwijtschelding met netto-ouderdomspensioen-norm
     Given the calculation date is "2026-06-01"
     And a citizen with the following data:
       | bsn                                     | 999993653                     |
       | waterschap_code                         | WS0155                        |
       | belastingsoort                          | verontreinigingsheffing_woonruimte |
-      | netto_besteedbaar_inkomen_maand         | 156469                        |
+      | netto_besteedbaar_inkomen_maand         | 155815                        |
       | netto_besteedbaar_inkomen_partner_maand | 0                             |
       | huishoudtype                            | alleenstaande                 |
       | is_pensioengerechtigd                   | true                          |
@@ -84,6 +84,27 @@ Feature: HHNK kwijtschelding waterschapsbelastingen
     Then the execution succeeds
     And the output "kan_kwijtschelding_worden_verleend" is "true"
     And the output "hoogte_kwijtschelding" is "20000"
+
+  # AOW-gerechtigde echtgenoten: kostennorm gebruikt netto_ouderdomspensioen_echtgenoten
+  # (213540 eurocent = tweemaal netto AOW gehuwd 2026 per RKBM art 3 lid 2 sub a).
+  Scenario: AOW-gerechtigde echtgenoten krijgen kwijtschelding met AOW-gehuwd-norm
+    Given the calculation date is "2026-06-01"
+    And a citizen with the following data:
+      | bsn                                     | 999993653                       |
+      | waterschap_code                         | WS0155                          |
+      | belastingsoort                          | watersysteemheffing_ingezetenen |
+      | netto_besteedbaar_inkomen_maand         | 213540                          |
+      | netto_besteedbaar_inkomen_partner_maand | 0                               |
+      | huishoudtype                            | echtgenoten                     |
+      | is_pensioengerechtigd                   | true                            |
+      | vermogen                                | 0                               |
+      | aanslagbedrag                           | 25000                           |
+      | is_ondernemer                           | false                           |
+      | belasting_zakelijk                      | false                           |
+    When the law "kwijtscheldingsregeling_waterschapsbelastingen_hhnk" is executed for outputs "kan_kwijtschelding_worden_verleend,hoogte_kwijtschelding"
+    Then the execution succeeds
+    And the output "kan_kwijtschelding_worden_verleend" is "true"
+    And the output "hoogte_kwijtschelding" is "25000"
 
   # Niet-begunstigde belastingsoort (niet genoemd in HHNK art 1) valt buiten scope.
   Scenario: Belastingsoort buiten de HHNK-scope wordt afgewezen

--- a/features/kwijtschelding_hhnk.feature
+++ b/features/kwijtschelding_hhnk.feature
@@ -12,7 +12,13 @@ Feature: HHNK kwijtschelding waterschapsbelastingen
       | netto_besteedbaar_inkomen_partner_maand | 0                               |
       | huishoudtype                            | alleenstaande                   |
       | is_pensioengerechtigd                   | false                           |
-      | vermogen                                | 0                               |
+      | inboedel_waarde                         | 0                               |
+      | auto_waarde                             | 0                               |
+      | auto_onmisbaar                          | false                           |
+      | onroerend_goed_waarde                   | 0                               |
+      | andere_bezittingen                      | 0                               |
+      | hoger_bevoorrechte_schulden             | 0                               |
+      | liquide_middelen                        | 0                               |
       | aanslagbedrag                           | 15000                           |
       | is_ondernemer                           | false                           |
       | belasting_zakelijk                      | false                           |
@@ -34,7 +40,13 @@ Feature: HHNK kwijtschelding waterschapsbelastingen
       | netto_besteedbaar_inkomen_partner_maand | 0                          |
       | huishoudtype                            | echtgenoten                |
       | is_pensioengerechtigd                   | false                      |
-      | vermogen                                | 0                          |
+      | inboedel_waarde                         | 0                          |
+      | auto_waarde                             | 0                          |
+      | auto_onmisbaar                          | false                      |
+      | onroerend_goed_waarde                   | 0                          |
+      | andere_bezittingen                      | 0                          |
+      | hoger_bevoorrechte_schulden             | 0                          |
+      | liquide_middelen                        | 0                          |
       | aanslagbedrag                           | 60000                      |
       | is_ondernemer                           | false                      |
       | belasting_zakelijk                      | false                      |
@@ -54,7 +66,13 @@ Feature: HHNK kwijtschelding waterschapsbelastingen
       | netto_besteedbaar_inkomen_partner_maand | 0                               |
       | huishoudtype                            | alleenstaande                   |
       | is_pensioengerechtigd                   | false                           |
-      | vermogen                                | 0                               |
+      | inboedel_waarde                         | 0                               |
+      | auto_waarde                             | 0                               |
+      | auto_onmisbaar                          | false                           |
+      | onroerend_goed_waarde                   | 0                               |
+      | andere_bezittingen                      | 0                               |
+      | hoger_bevoorrechte_schulden             | 0                               |
+      | liquide_middelen                        | 0                               |
       | aanslagbedrag                           | 15000                           |
       | is_ondernemer                           | true                            |
       | belasting_zakelijk                      | true                            |
@@ -76,7 +94,13 @@ Feature: HHNK kwijtschelding waterschapsbelastingen
       | netto_besteedbaar_inkomen_partner_maand | 0                             |
       | huishoudtype                            | alleenstaande                 |
       | is_pensioengerechtigd                   | true                          |
-      | vermogen                                | 0                             |
+      | inboedel_waarde                         | 0                             |
+      | auto_waarde                             | 0                             |
+      | auto_onmisbaar                          | false                         |
+      | onroerend_goed_waarde                   | 0                             |
+      | andere_bezittingen                      | 0                             |
+      | hoger_bevoorrechte_schulden             | 0                             |
+      | liquide_middelen                        | 0                             |
       | aanslagbedrag                           | 20000                         |
       | is_ondernemer                           | false                         |
       | belasting_zakelijk                      | false                         |
@@ -97,7 +121,13 @@ Feature: HHNK kwijtschelding waterschapsbelastingen
       | netto_besteedbaar_inkomen_partner_maand | 0                               |
       | huishoudtype                            | echtgenoten                     |
       | is_pensioengerechtigd                   | true                            |
-      | vermogen                                | 0                               |
+      | inboedel_waarde                         | 0                               |
+      | auto_waarde                             | 0                               |
+      | auto_onmisbaar                          | false                           |
+      | onroerend_goed_waarde                   | 0                               |
+      | andere_bezittingen                      | 0                               |
+      | hoger_bevoorrechte_schulden             | 0                               |
+      | liquide_middelen                        | 0                               |
       | aanslagbedrag                           | 25000                           |
       | is_ondernemer                           | false                           |
       | belasting_zakelijk                      | false                           |
@@ -105,6 +135,62 @@ Feature: HHNK kwijtschelding waterschapsbelastingen
     Then the execution succeeds
     And the output "kan_kwijtschelding_worden_verleend" is "true"
     And the output "hoogte_kwijtschelding" is "25000"
+
+  # Auto boven drempelwaarde van EUR 2269 (226900 eurocent) die absoluut onmisbaar is voor werk
+  # of vanwege invaliditeit wordt niet als vermogen beschouwd (URI art 12 lid 2 onderdeel c).
+  # Alleenstaande met bijstand + essential auto -> volledige kwijtschelding.
+  Scenario: Auto onmisbaar voor werk/invaliditeit telt niet als vermogen
+    Given the calculation date is "2026-06-01"
+    And a citizen with the following data:
+      | bsn                                     | 999993653                       |
+      | waterschap_code                         | WS0155                          |
+      | belastingsoort                          | watersysteemheffing_ingezetenen |
+      | netto_besteedbaar_inkomen_maand         | 140150                          |
+      | netto_besteedbaar_inkomen_partner_maand | 0                               |
+      | huishoudtype                            | alleenstaande                   |
+      | is_pensioengerechtigd                   | false                           |
+      | inboedel_waarde                         | 0                               |
+      | auto_waarde                             | 500000                          |
+      | auto_onmisbaar                          | true                            |
+      | onroerend_goed_waarde                   | 0                               |
+      | andere_bezittingen                      | 0                               |
+      | hoger_bevoorrechte_schulden             | 0                               |
+      | liquide_middelen                        | 0                               |
+      | aanslagbedrag                           | 15000                           |
+      | is_ondernemer                           | false                           |
+      | belasting_zakelijk                      | false                           |
+    When the law "kwijtscheldingsregeling_waterschapsbelastingen_hhnk" is executed for outputs "kan_kwijtschelding_worden_verleend,hoogte_kwijtschelding"
+    Then the execution succeeds
+    And the output "kan_kwijtschelding_worden_verleend" is "true"
+    And the output "hoogte_kwijtschelding" is "15000"
+
+  # Liquide middelen boven de HHNK-vrijstelling (kostennorm 140150 + art 4 verhoging alleenstaand
+  # 150000 = 290150 eurocent) tellen bovenmatig mee als vermogen. Bij liquide 400000 is
+  # 400000 - 290150 = 109850 vermogen. Vermogen > aanslag 80000 -> hoogte = 0.
+  Scenario: Vermogen boven de HHNK-vrijstelling blokkeert kwijtschelding
+    Given the calculation date is "2026-06-01"
+    And a citizen with the following data:
+      | bsn                                     | 999993653                       |
+      | waterschap_code                         | WS0155                          |
+      | belastingsoort                          | watersysteemheffing_ingezetenen |
+      | netto_besteedbaar_inkomen_maand         | 140150                          |
+      | netto_besteedbaar_inkomen_partner_maand | 0                               |
+      | huishoudtype                            | alleenstaande                   |
+      | is_pensioengerechtigd                   | false                           |
+      | inboedel_waarde                         | 0                               |
+      | auto_waarde                             | 0                               |
+      | auto_onmisbaar                          | false                           |
+      | onroerend_goed_waarde                   | 0                               |
+      | andere_bezittingen                      | 0                               |
+      | hoger_bevoorrechte_schulden             | 0                               |
+      | liquide_middelen                        | 400000                          |
+      | aanslagbedrag                           | 80000                           |
+      | is_ondernemer                           | false                           |
+      | belasting_zakelijk                      | false                           |
+    When the law "kwijtscheldingsregeling_waterschapsbelastingen_hhnk" is executed for outputs "kan_kwijtschelding_worden_verleend,hoogte_kwijtschelding"
+    Then the execution succeeds
+    And the output "kan_kwijtschelding_worden_verleend" is "false"
+    And the output "hoogte_kwijtschelding" is "0"
 
   # Niet-begunstigde belastingsoort (niet genoemd in HHNK art 1) valt buiten scope.
   Scenario: Belastingsoort buiten de HHNK-scope wordt afgewezen
@@ -117,7 +203,13 @@ Feature: HHNK kwijtschelding waterschapsbelastingen
       | netto_besteedbaar_inkomen_partner_maand | 0                                     |
       | huishoudtype                            | alleenstaande                         |
       | is_pensioengerechtigd                   | false                                 |
-      | vermogen                                | 0                                     |
+      | inboedel_waarde                         | 0                                     |
+      | auto_waarde                             | 0                                     |
+      | auto_onmisbaar                          | false                                 |
+      | onroerend_goed_waarde                   | 0                                     |
+      | andere_bezittingen                      | 0                                     |
+      | hoger_bevoorrechte_schulden             | 0                                     |
+      | liquide_middelen                        | 0                                     |
       | aanslagbedrag                           | 15000                                 |
       | is_ondernemer                           | false                                 |
       | belasting_zakelijk                      | false                                 |
@@ -140,7 +232,13 @@ Feature: HHNK kwijtschelding waterschapsbelastingen
       | netto_besteedbaar_inkomen_partner_maand | 0                               |
       | huishoudtype                            | alleenstaande                   |
       | is_pensioengerechtigd                   | false                           |
-      | vermogen                                | 0                               |
+      | inboedel_waarde                         | 0                               |
+      | auto_waarde                             | 0                               |
+      | auto_onmisbaar                          | false                           |
+      | onroerend_goed_waarde                   | 0                               |
+      | andere_bezittingen                      | 0                               |
+      | hoger_bevoorrechte_schulden             | 0                               |
+      | liquide_middelen                        | 0                               |
       | aanslagbedrag                           | 15000                           |
       | is_ondernemer                           | false                           |
       | belasting_zakelijk                      | false                           |
@@ -162,7 +260,13 @@ Feature: HHNK kwijtschelding waterschapsbelastingen
       | netto_besteedbaar_inkomen_partner_maand | 0                               |
       | huishoudtype                            | alleenstaande                   |
       | is_pensioengerechtigd                   | false                           |
-      | vermogen                                | 0                               |
+      | inboedel_waarde                         | 0                               |
+      | auto_waarde                             | 0                               |
+      | auto_onmisbaar                          | false                           |
+      | onroerend_goed_waarde                   | 0                               |
+      | andere_bezittingen                      | 0                               |
+      | hoger_bevoorrechte_schulden             | 0                               |
+      | liquide_middelen                        | 0                               |
       | aanslagbedrag                           | 15000                           |
       | is_ondernemer                           | true                            |
       | belasting_zakelijk                      | false                           |

--- a/features/kwijtschelding_hhnk.feature
+++ b/features/kwijtschelding_hhnk.feature
@@ -20,6 +20,7 @@ Feature: HHNK kwijtschelding waterschapsbelastingen
       | hoger_bevoorrechte_schulden             | 0                               |
       | liquide_middelen                        | 0                               |
       | aanslagbedrag                           | 15000                           |
+      | kinderopvang_nettokosten_maand          | 0                               |
       | is_ondernemer                           | false                           |
       | belasting_zakelijk                      | false                           |
     When the law "kwijtscheldingsregeling_waterschapsbelastingen_hhnk" is executed for outputs "kan_kwijtschelding_worden_verleend,hoogte_kwijtschelding"
@@ -48,6 +49,7 @@ Feature: HHNK kwijtschelding waterschapsbelastingen
       | hoger_bevoorrechte_schulden             | 0                          |
       | liquide_middelen                        | 0                          |
       | aanslagbedrag                           | 60000                      |
+      | kinderopvang_nettokosten_maand          | 0                          |
       | is_ondernemer                           | false                      |
       | belasting_zakelijk                      | false                      |
     When the law "kwijtscheldingsregeling_waterschapsbelastingen_hhnk" is executed for outputs "kan_kwijtschelding_worden_verleend,hoogte_kwijtschelding"
@@ -74,6 +76,7 @@ Feature: HHNK kwijtschelding waterschapsbelastingen
       | hoger_bevoorrechte_schulden             | 0                               |
       | liquide_middelen                        | 0                               |
       | aanslagbedrag                           | 15000                           |
+      | kinderopvang_nettokosten_maand          | 0                               |
       | is_ondernemer                           | true                            |
       | belasting_zakelijk                      | true                            |
     When the law "kwijtscheldingsregeling_waterschapsbelastingen_hhnk" is executed for outputs "kan_kwijtschelding_worden_verleend,hoogte_kwijtschelding"
@@ -102,6 +105,7 @@ Feature: HHNK kwijtschelding waterschapsbelastingen
       | hoger_bevoorrechte_schulden             | 0                             |
       | liquide_middelen                        | 0                             |
       | aanslagbedrag                           | 20000                         |
+      | kinderopvang_nettokosten_maand          | 0                             |
       | is_ondernemer                           | false                         |
       | belasting_zakelijk                      | false                         |
     When the law "kwijtscheldingsregeling_waterschapsbelastingen_hhnk" is executed for outputs "kan_kwijtschelding_worden_verleend,hoogte_kwijtschelding"
@@ -129,12 +133,44 @@ Feature: HHNK kwijtschelding waterschapsbelastingen
       | hoger_bevoorrechte_schulden             | 0                               |
       | liquide_middelen                        | 0                               |
       | aanslagbedrag                           | 25000                           |
+      | kinderopvang_nettokosten_maand          | 0                               |
       | is_ondernemer                           | false                           |
       | belasting_zakelijk                      | false                           |
     When the law "kwijtscheldingsregeling_waterschapsbelastingen_hhnk" is executed for outputs "kan_kwijtschelding_worden_verleend,hoogte_kwijtschelding"
     Then the execution succeeds
     And the output "kan_kwijtschelding_worden_verleend" is "true"
     And the output "hoogte_kwijtschelding" is "25000"
+
+  # Kinderopvangkosten (HHNK art 3 jo URI art 28 lid 3) verlagen netto-besteedbaar-inkomen.
+  # Tweepersoons met inkomen 250000 + 60000 eurocent kinderopvang/maand:
+  # effectief inkomen = 250000-60000=190000 vs kostennorm 200213 -> betalingscap = 0 (clamped).
+  # Zonder kinderopvang zou betalingscap = 12 x (250000-200213) = 597444, dus dit scenario
+  # demonstreert dat kinderopvang de volledige aanslag kwijtschelding mogelijk maakt.
+  Scenario: Kinderopvangkosten activeren volledige kwijtschelding (HHNK art 3)
+    Given the calculation date is "2026-06-01"
+    And a citizen with the following data:
+      | bsn                                     | 999993653                       |
+      | waterschap_code                         | WS0155                          |
+      | belastingsoort                          | watersysteemheffing_ingezetenen |
+      | netto_besteedbaar_inkomen_maand         | 250000                          |
+      | netto_besteedbaar_inkomen_partner_maand | 0                               |
+      | huishoudtype                            | echtgenoten                     |
+      | is_pensioengerechtigd                   | false                           |
+      | inboedel_waarde                         | 0                               |
+      | auto_waarde                             | 0                               |
+      | auto_onmisbaar                          | false                           |
+      | onroerend_goed_waarde                   | 0                               |
+      | andere_bezittingen                      | 0                               |
+      | hoger_bevoorrechte_schulden             | 0                               |
+      | liquide_middelen                        | 0                               |
+      | aanslagbedrag                           | 45000                           |
+      | kinderopvang_nettokosten_maand          | 60000                           |
+      | is_ondernemer                           | false                           |
+      | belasting_zakelijk                      | false                           |
+    When the law "kwijtscheldingsregeling_waterschapsbelastingen_hhnk" is executed for outputs "kan_kwijtschelding_worden_verleend,hoogte_kwijtschelding"
+    Then the execution succeeds
+    And the output "kan_kwijtschelding_worden_verleend" is "true"
+    And the output "hoogte_kwijtschelding" is "45000"
 
   # Auto boven drempelwaarde van EUR 2269 (226900 eurocent) die absoluut onmisbaar is voor werk
   # of vanwege invaliditeit wordt niet als vermogen beschouwd (URI art 12 lid 2 onderdeel c).
@@ -157,6 +193,7 @@ Feature: HHNK kwijtschelding waterschapsbelastingen
       | hoger_bevoorrechte_schulden             | 0                               |
       | liquide_middelen                        | 0                               |
       | aanslagbedrag                           | 15000                           |
+      | kinderopvang_nettokosten_maand          | 0                               |
       | is_ondernemer                           | false                           |
       | belasting_zakelijk                      | false                           |
     When the law "kwijtscheldingsregeling_waterschapsbelastingen_hhnk" is executed for outputs "kan_kwijtschelding_worden_verleend,hoogte_kwijtschelding"
@@ -185,6 +222,7 @@ Feature: HHNK kwijtschelding waterschapsbelastingen
       | hoger_bevoorrechte_schulden             | 0                               |
       | liquide_middelen                        | 400000                          |
       | aanslagbedrag                           | 80000                           |
+      | kinderopvang_nettokosten_maand          | 0                               |
       | is_ondernemer                           | false                           |
       | belasting_zakelijk                      | false                           |
     When the law "kwijtscheldingsregeling_waterschapsbelastingen_hhnk" is executed for outputs "kan_kwijtschelding_worden_verleend,hoogte_kwijtschelding"
@@ -211,6 +249,7 @@ Feature: HHNK kwijtschelding waterschapsbelastingen
       | hoger_bevoorrechte_schulden             | 0                                     |
       | liquide_middelen                        | 0                                     |
       | aanslagbedrag                           | 15000                                 |
+      | kinderopvang_nettokosten_maand          | 0                                     |
       | is_ondernemer                           | false                                 |
       | belasting_zakelijk                      | false                                 |
     When the law "kwijtscheldingsregeling_waterschapsbelastingen_hhnk" is executed for outputs "kan_kwijtschelding_worden_verleend,hoogte_kwijtschelding"
@@ -240,6 +279,7 @@ Feature: HHNK kwijtschelding waterschapsbelastingen
       | hoger_bevoorrechte_schulden             | 0                               |
       | liquide_middelen                        | 0                               |
       | aanslagbedrag                           | 15000                           |
+      | kinderopvang_nettokosten_maand          | 0                               |
       | is_ondernemer                           | false                           |
       | belasting_zakelijk                      | false                           |
     When the law "kwijtscheldingsregeling_waterschapsbelastingen_hhnk" is executed for outputs "kan_kwijtschelding_worden_verleend,hoogte_kwijtschelding"
@@ -268,6 +308,7 @@ Feature: HHNK kwijtschelding waterschapsbelastingen
       | hoger_bevoorrechte_schulden             | 0                               |
       | liquide_middelen                        | 0                               |
       | aanslagbedrag                           | 15000                           |
+      | kinderopvang_nettokosten_maand          | 0                               |
       | is_ondernemer                           | true                            |
       | belasting_zakelijk                      | false                           |
     When the law "kwijtscheldingsregeling_waterschapsbelastingen_hhnk" is executed for outputs "kan_kwijtschelding_worden_verleend,hoogte_kwijtschelding"

--- a/packages/engine/Cargo.toml
+++ b/packages/engine/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["law", "legal", "wasm", "dutch", "regelrecht"]
 categories = ["wasm", "parsing"]
 
 [package.metadata.regelrecht]
-supported-schemas = ["v0.2.0", "v0.3.0", "v0.3.1", "v0.3.2", "v0.4.0", "v0.5.0", "v0.5.1"]
+supported-schemas = ["v0.2.0", "v0.3.0", "v0.3.1", "v0.3.2", "v0.4.0", "v0.5.0", "v0.5.1", "v0.5.2"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/packages/engine/src/config.rs
+++ b/packages/engine/src/config.rs
@@ -62,7 +62,7 @@ pub const MAX_OPERATION_DEPTH: usize = 100;
 /// rejected at load time. This list must match the `supported-schemas`
 /// metadata in Cargo.toml.
 pub const SUPPORTED_SCHEMAS: &[&str] = &[
-    "v0.2.0", "v0.3.0", "v0.3.1", "v0.3.2", "v0.4.0", "v0.5.0", "v0.5.1",
+    "v0.2.0", "v0.3.0", "v0.3.1", "v0.3.2", "v0.4.0", "v0.5.0", "v0.5.1", "v0.5.2",
 ];
 
 /// Maximum recursion depth for dot notation property access.


### PR DESCRIPTION
## Summary

Voegt executable logica toe voor HHNK kwijtschelding van waterschapsbelastingen. Bouwt voort op #559 (tekst-harvest) en maakt de wetten uitvoerbaar door de engine.

**Architectuur:**
- **URI 1990** (BWBR0004766, nieuw geharvest): authoritative bron — bevat de kwijtschelding-formule (art 11), vermogenstoets met exemptions (art 12), betalingscapaciteit (art 13) en kostennorm met `open_term: kostennorm_percentage` (art 16)
- **Regeling kwijtschelding belastingen medeoverheden** (BWBR0047157, nieuw geharvest, text-only): de juridische delegatie-machtiging
- **HHNK Kwijtscheldingsregeling** (#559, uitgebreid): orchestrator-scope op art 1, `implements: kostennorm_percentage=1.00` op art 2, kinderopvang-wiring op art 3, `implements: verhoging_financiele_middelen_vrijstelling` op art 4 (€2000/1800/1500 per huishoudtype), ondernemer-filter op art 5
- **Leidraad Invordering 2008** (#559, uitgebreid): machine_readable op art 26.1.9 voor procedurele weigergronden (7 boolean-filters → `uitgesloten_van_kwijtschelding`). HHNK Leidraad blijft text-only (gespiegelde waterschap-variant van Leidraad 2008).

**Entrypoint:**
```
evaluate \"kan_kwijtschelding_worden_verleend\" of
  \"kwijtscheldingsregeling_waterschapsbelastingen_hhnk\"
met parameters (25):
  bsn, waterschap_code=WS0155, belastingsoort,
  netto_besteedbaar_inkomen_maand, netto_besteedbaar_inkomen_partner_maand,
  huishoudtype, is_pensioengerechtigd,
  inboedel_waarde, auto_waarde, auto_onmisbaar, onroerend_goed_waarde,
  andere_bezittingen, hoger_bevoorrechte_schulden, liquide_middelen,
  aanslagbedrag, kinderopvang_nettokosten_maand,
  is_ondernemer, belasting_zakelijk,
  gegevens_onvolledig_of_onjuist, bezwaar_of_beroep_aanhangig,
  zekerheid_gesteld, meerdere_belastingschuldigen,
  derde_aansprakelijk_gesteld, verwijtbaarheid_belastingschuld,
  in_faillissement_of_surseance_zonder_akkoord
```

Stakt op #559 (dat eerst gemerged moet worden).

## Test plan

- [x] Schema-validatie v0.5.2 slaagt voor alle 5 betrokken wetten
- [x] yamllint clean
- [x] Pre-commit hooks groen
- [x] BDD: 12 golden-path scenarios (65/65 totaal groen, geen regressie op bestaande 53)
- [x] Cross-law dispatch HHNK → URI 1990 → Leidraad 2008 werkt (scope via waterschap_code)
- [x] \`open_term\` delegation resolvers:
  - kostennorm_percentage: 0.9 (federaal default) → 1.0 (HHNK override)
  - verhoging_financiele_middelen_vrijstelling: 0 (federaal default) → 200000/180000/150000 (HHNK per huishoudtype)
- [x] Pensioner-branch gebruikt exacte netto-AOW 2026 (SVB-publicatie)
- [x] Vermogenstoets: inboedel/auto > €2269 drempel, auto-onmisbaar-uitzondering, liquide middelen boven vrijstelling
- [x] Kinderopvang-uitgaven verlagen betalingscapaciteit
- [x] Procedurele weigergronden (bezwaar/beroep, zekerheid, verwijtbaarheid etc.) blokkeren kwijtschelding short-circuit

## Scope

### Gedekt
- [x] Kwijtschelding-ja/nee + bedrag (URI art 11)
- [x] Vermogenstoets detail (URI art 12: inboedel/auto drempels, onmisbaar-uitzondering, onroerend goed, liquide middelen vs vrijstelling, hoger bevoorrechte schulden)
- [x] Betalingscapaciteit-formule met kinderopvang-uitgaven (URI art 13 + extra_uitgaven_maand)
- [x] Kostennorm met pensioen-override precisie via netto_ouderdomspensioen_* (URI art 16 + RKBM art 3)
- [x] Ondernemer-filter (HHNK art 5)
- [x] Belastingsoort-scope (HHNK art 1)
- [x] HHNK art 3 (kinderopvang) — als extra_uitgaven doorgegeven aan URI art 13
- [x] HHNK art 4 (verhoogde vermogensvrijstellingen) — implements open_term
- [x] Procedurele weigergronden (Leidraad 26.1.9): 7 boolean filters short-circuiten de decision

### Niet gedekt (expliciet uit scope)
- [ ] URI art 12 lid 2 onderdelen b, e, f (kapitaalsuitkeringen uitvaartverzekering, WSF/PGB-rekening, €2269 per 65+ op 31-12-1999)
- [ ] URI art 12 lid 4 (termijnbetalingen > maand als reservering)
- [ ] Leidraad 26.1.9 tweede cluster (hoger inkomen/verbetering/teruggaaf binnen 1-2 jaar verwacht): vereist tijdreeksen-modellering
- [ ] Leidraad 26.1.1–26.1.8 (aanvraag-procedure + herstelmomenten)
- [ ] URI art 14+15 volledige modellering (inkomens/uitgaven-samenstelling): wordt gesimuleerd door caller die netto_besteedbaar_inkomen_maand samenstelt
- [ ] HHNK Leidraad 26.x (waterschap-procedure): puur interpretief, URI art 11 is authoritative
- [ ] Ex-ondernemers (Leidraad 26.1.10), onverdeelde nalatenschappen, IB/LB-specifieke aspecten