### PR TITLE
feat(corpus): derive branch from pod hostname for PR deployments

### DIFF
--- a/packages/corpus/src/client.rs
+++ b/packages/corpus/src/client.rs
@@ -688,6 +688,23 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_remote_branch_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        let bare_path = setup_bare_repo(dir.path()).await;
+        let bare_url = format!("file://{}", bare_path.display());
+        let repo_path = dir.path().join("corpus");
+        clone_with_config(&bare_path, &repo_path).await;
+
+        let config = CorpusConfig::new(&bare_url, &repo_path);
+        let client = CorpusClient::new(config);
+
+        // `setup_bare_repo` creates the remote with `development` branch.
+        assert!(client.remote_branch_exists("development").await.unwrap());
+        // A branch that doesn't exist yet on the remote.
+        assert!(!client.remote_branch_exists("pr574").await.unwrap());
+    }
+
+    #[tokio::test]
     async fn test_commit_local_without_push() {
         let dir = tempfile::tempdir().unwrap();
         let bare_path = setup_bare_repo(dir.path()).await;

--- a/packages/corpus/src/client.rs
+++ b/packages/corpus/src/client.rs
@@ -381,6 +381,15 @@ impl CorpusClient {
         Ok(())
     }
 
+    /// Check whether a branch exists on the configured `origin` remote.
+    pub async fn remote_branch_exists(&self, branch: &str) -> Result<bool> {
+        let refspec = format!("refs/heads/{}", branch);
+        let output = self
+            .run_git_output(&["ls-remote", "origin", &refspec])
+            .await?;
+        Ok(!output.trim().is_empty())
+    }
+
     /// Run a git command in the repo directory and check for success.
     async fn run_git(&self, args: &[&str]) -> Result<()> {
         let output = Command::new("git")

--- a/packages/corpus/src/config.rs
+++ b/packages/corpus/src/config.rs
@@ -91,8 +91,8 @@ impl CorpusConfig {
     ///
     /// Required: `CORPUS_REPO_URL`
     /// Optional: `CORPUS_REPO_PATH` (default: `/tmp/corpus-repo`),
-    ///           `CORPUS_BRANCH` (default: `HOSTNAME` prefix for PR previews,
-    ///            else `DEPLOYMENT_NAME`, else `development`),
+    ///           `CORPUS_BRANCH` (used only when `HOSTNAME` is not a recognised
+    ///            ZAD prefix; see `resolve_branch` for the full priority chain),
     ///           `CORPUS_GIT_AUTHOR_NAME` (default: `regelrecht-harvester`),
     ///           `CORPUS_GIT_AUTHOR_EMAIL` (default: `noreply@minbzk.nl`),
     ///           `CORPUS_GIT_TOKEN` (for authentication)

--- a/packages/corpus/src/config.rs
+++ b/packages/corpus/src/config.rs
@@ -308,6 +308,18 @@ mod tests {
     }
 
     #[test]
+    fn resolve_branch_empty_deployment_name_falls_through_to_hostname() {
+        assert_eq!(
+            resolve_branch(
+                None,
+                Some("".into()),
+                Some("pr429-harvester-worker-abc-xyz".into())
+            ),
+            "pr429"
+        );
+    }
+
+    #[test]
     fn deployment_from_hostname_recognises_pr_and_prod() {
         assert_eq!(
             deployment_from_hostname("pr568-enrichworker-abc-xyz"),

--- a/packages/corpus/src/config.rs
+++ b/packages/corpus/src/config.rs
@@ -46,7 +46,8 @@ fn deployment_from_hostname(hostname: &str) -> Option<String> {
 /// Resolve the corpus branch from explicit config and platform variables.
 ///
 /// Priority: `CORPUS_BRANCH` > `DEPLOYMENT_NAME` > `HOSTNAME` prefix > `"development"`.
-/// Production deployment name (`"regelrecht"`) is ignored so it falls through
+/// Both `DEPLOYMENT_NAME` and the hostname-derived prefix are ignored when they
+/// equal `"regelrecht"` (production), so production workers always fall through
 /// to the default `"development"` branch.
 fn resolve_branch(
     corpus_branch: Option<String>,
@@ -291,6 +292,18 @@ mod tests {
                 Some("regelrecht-harvester-worker-abc-xyz".into())
             ),
             "pr99"
+        );
+    }
+
+    #[test]
+    fn resolve_branch_production_deployment_name_beats_pr_hostname() {
+        assert_eq!(
+            resolve_branch(
+                None,
+                Some("regelrecht".into()),
+                Some("pr429-harvester-worker-abc-xyz".into())
+            ),
+            "development"
         );
     }
 

--- a/packages/corpus/src/config.rs
+++ b/packages/corpus/src/config.rs
@@ -33,9 +33,15 @@ impl std::fmt::Debug for CorpusConfig {
 ///
 /// Pod hostnames follow `{deployment}-{component}-{rs-hash}-{pod-hash}`.
 /// Only the literal `regelrecht` (production) and `pr<digits>` (PR previews)
-/// are recognised; anything else returns `None` so a stray multi-segment
-/// deployment name can't be misread as a bare first segment.
+/// are recognised, and the hostname must contain at least one `-` — a bare
+/// first segment without the pod suffix (e.g. a dev box literally named
+/// `pr42`) returns `None` so it can't shadow an explicit `CORPUS_BRANCH`.
 fn deployment_from_hostname(hostname: &str) -> Option<String> {
+    // Require the K8s pod-name shape: at least one `-` must follow the
+    // deployment segment. Anything shorter is almost certainly not a pod.
+    if !hostname.contains('-') {
+        return None;
+    }
     let first = hostname.split('-').next()?;
     let is_pr_preview = first
         .strip_prefix("pr")
@@ -91,8 +97,10 @@ impl CorpusConfig {
     ///
     /// Required: `CORPUS_REPO_URL`
     /// Optional: `CORPUS_REPO_PATH` (default: `/tmp/corpus-repo`),
-    ///           `CORPUS_BRANCH` (used only when `HOSTNAME` is not a recognised
-    ///            ZAD prefix; see `resolve_branch` for the full priority chain),
+    ///           `CORPUS_BRANCH` (used when `HOSTNAME` resolves to no usable
+    ///            branch — i.e. not a ZAD PR prefix — or when `HOSTNAME` is
+    ///            the production deployment name `regelrecht`; see
+    ///            `resolve_branch` for the full priority chain),
     ///           `CORPUS_GIT_AUTHOR_NAME` (default: `regelrecht-harvester`),
     ///           `CORPUS_GIT_AUTHOR_EMAIL` (default: `noreply@minbzk.nl`),
     ///           `CORPUS_GIT_TOKEN` (for authentication)
@@ -336,7 +344,7 @@ mod tests {
     }
 
     #[test]
-    fn resolve_branch_empty_deployment_name_falls_through_to_hostname() {
+    fn resolve_branch_hostname_wins_over_empty_deployment_name() {
         assert_eq!(
             resolve_branch(
                 None,
@@ -365,6 +373,26 @@ mod tests {
         assert_eq!(deployment_from_hostname("prabc-foo-a-b"), None);
         assert_eq!(deployment_from_hostname("pr-foo-a-b"), None);
         assert_eq!(deployment_from_hostname(""), None);
+    }
+
+    #[test]
+    fn deployment_from_hostname_rejects_bare_names() {
+        // A bare `pr42` (no K8s pod suffix) is most likely a dev box, not a
+        // pod; treating it as a ZAD deployment would silently shadow an
+        // explicit CORPUS_BRANCH on that machine.
+        assert_eq!(deployment_from_hostname("pr42"), None);
+        assert_eq!(deployment_from_hostname("regelrecht"), None);
+    }
+
+    #[test]
+    fn resolve_branch_bare_pr_hostname_does_not_shadow_corpus_branch() {
+        // A dev machine with HOSTNAME=pr42 (no pod suffix) must not override
+        // an explicit CORPUS_BRANCH; the hostname-derivation requires the
+        // full K8s pod-name shape.
+        assert_eq!(
+            resolve_branch(Some("feature-x".into()), None, Some("pr42".into())),
+            "feature-x"
+        );
     }
 
     #[test]

--- a/packages/corpus/src/config.rs
+++ b/packages/corpus/src/config.rs
@@ -45,22 +45,29 @@ fn deployment_from_hostname(hostname: &str) -> Option<String> {
 
 /// Resolve the corpus branch from explicit config and platform variables.
 ///
-/// Priority: `CORPUS_BRANCH` > `DEPLOYMENT_NAME` > `HOSTNAME` prefix > `"development"`.
-/// Both `DEPLOYMENT_NAME` and the hostname-derived prefix are ignored when they
-/// equal `"regelrecht"` (production), so production workers always fall through
-/// to the default `"development"` branch.
+/// Priority: `HOSTNAME` prefix > `CORPUS_BRANCH` > `DEPLOYMENT_NAME` > `"development"`.
+/// `HOSTNAME` comes first because it is intrinsic to the pod and cannot be
+/// inherited by ZAD's `clone-from` — so a PR preview that copies production's
+/// env vars (e.g. `CORPUS_BRANCH=development`) still picks up its own
+/// `pr<N>` branch. Both `DEPLOYMENT_NAME` and the hostname-derived prefix are
+/// ignored when they equal `"regelrecht"` (production), so production workers
+/// always fall through to the default `"development"` branch.
 fn resolve_branch(
     corpus_branch: Option<String>,
     deployment_name: Option<String>,
     hostname: Option<String>,
 ) -> String {
+    if let Some(name) = hostname
+        .as_deref()
+        .and_then(deployment_from_hostname)
+        .filter(|n| n != "regelrecht")
+    {
+        return name;
+    }
     if let Some(branch) = corpus_branch.filter(|b| !b.is_empty()) {
         return branch;
     }
-    let derived = deployment_name
-        .filter(|n| !n.is_empty())
-        .or_else(|| hostname.as_deref().and_then(deployment_from_hostname));
-    if let Some(name) = derived.filter(|n| n != "regelrecht") {
+    if let Some(name) = deployment_name.filter(|n| !n.is_empty() && n != "regelrecht") {
         return name;
     }
     "development".into()
@@ -84,8 +91,8 @@ impl CorpusConfig {
     ///
     /// Required: `CORPUS_REPO_URL`
     /// Optional: `CORPUS_REPO_PATH` (default: `/tmp/corpus-repo`),
-    ///           `CORPUS_BRANCH` (default: `DEPLOYMENT_NAME`, else `HOSTNAME` prefix
-    ///            for PR previews, else `development`),
+    ///           `CORPUS_BRANCH` (default: `HOSTNAME` prefix for PR previews,
+    ///            else `DEPLOYMENT_NAME`, else `development`),
     ///           `CORPUS_GIT_AUTHOR_NAME` (default: `regelrecht-harvester`),
     ///           `CORPUS_GIT_AUTHOR_EMAIL` (default: `noreply@minbzk.nl`),
     ///           `CORPUS_GIT_TOKEN` (for authentication)
@@ -226,12 +233,14 @@ mod tests {
     }
 
     #[test]
-    fn resolve_branch_uses_corpus_branch() {
+    fn resolve_branch_uses_corpus_branch_when_hostname_nonmatching() {
+        // HOSTNAME without a ZAD prefix (e.g. local dev box) falls through to
+        // CORPUS_BRANCH, which in turn beats DEPLOYMENT_NAME.
         assert_eq!(
             resolve_branch(
                 Some("custom".into()),
                 Some("pr42".into()),
-                Some("pr99-harvester-worker-abc-xyz".into())
+                Some("devbox".into())
             ),
             "custom"
         );
@@ -284,7 +293,8 @@ mod tests {
     }
 
     #[test]
-    fn resolve_branch_deployment_name_beats_hostname() {
+    fn resolve_branch_deployment_name_used_when_hostname_is_production() {
+        // Production hostname is suppressed; deployment_name fills in.
         assert_eq!(
             resolve_branch(
                 None,
@@ -296,14 +306,32 @@ mod tests {
     }
 
     #[test]
-    fn resolve_branch_production_deployment_name_beats_pr_hostname() {
+    fn resolve_branch_pr_hostname_beats_inherited_production_deployment_name() {
+        // ZAD's `clone-from: regelrecht` copies production's DEPLOYMENT_NAME
+        // into the PR deployment. The pod's own hostname must still win,
+        // otherwise the PR worker harvests into `development` instead of `pr429`.
         assert_eq!(
             resolve_branch(
                 None,
                 Some("regelrecht".into()),
                 Some("pr429-harvester-worker-abc-xyz".into())
             ),
-            "development"
+            "pr429"
+        );
+    }
+
+    #[test]
+    fn resolve_branch_pr_hostname_beats_inherited_corpus_branch() {
+        // Production sets CORPUS_BRANCH=development explicitly; the PR
+        // deployment inherits it via clone-from. The pod's own hostname
+        // must still win so the PR worker uses its own branch.
+        assert_eq!(
+            resolve_branch(
+                Some("development".into()),
+                None,
+                Some("pr574-harvester-worker-abc-xyz".into())
+            ),
+            "pr574"
         );
     }
 

--- a/packages/corpus/src/config.rs
+++ b/packages/corpus/src/config.rs
@@ -31,15 +31,18 @@ impl std::fmt::Debug for CorpusConfig {
 
 /// Extract the ZAD deployment name from a Kubernetes pod hostname.
 ///
-/// Pod hostnames follow `{deployment}-{component}-{rs-hash}-{pod-hash}`.
-/// Only the literal `regelrecht` (production) and `pr<digits>` (PR previews)
-/// are recognised, and the hostname must contain at least one `-` — a bare
-/// first segment without the pod suffix (e.g. a dev box literally named
-/// `pr42`) returns `None` so it can't shadow an explicit `CORPUS_BRANCH`.
+/// Pod hostnames follow `{deployment}-{component}-{rs-hash}-{pod-hash}` —
+/// always four or more dash-separated segments. Only the literal
+/// `regelrecht` (production) and `pr<digits>` (PR previews) are recognised,
+/// and the hostname must have at least three `-` characters (the minimum
+/// pod-name shape). A dev box named `pr42`, `pr42-workstation`, or
+/// `pr42-a-b` therefore returns `None` and can't shadow an explicit
+/// `CORPUS_BRANCH`.
 fn deployment_from_hostname(hostname: &str) -> Option<String> {
-    // Require the K8s pod-name shape: at least one `-` must follow the
-    // deployment segment. Anything shorter is almost certainly not a pod.
-    if !hostname.contains('-') {
+    // Require the full K8s pod-name shape: at least three `-` characters,
+    // matching `{deployment}-{component}-{rs-hash}-{pod-hash}`. Anything
+    // shorter is almost certainly not a pod.
+    if hostname.matches('-').count() < 3 {
         return None;
     }
     let first = hostname.split('-').next()?;
@@ -377,11 +380,13 @@ mod tests {
 
     #[test]
     fn deployment_from_hostname_rejects_bare_names() {
-        // A bare `pr42` (no K8s pod suffix) is most likely a dev box, not a
-        // pod; treating it as a ZAD deployment would silently shadow an
-        // explicit CORPUS_BRANCH on that machine.
+        // Require at least three dashes — the minimum K8s pod-name shape.
+        // Bare names and short dash-separated dev hostnames both fall short
+        // and must not silently shadow CORPUS_BRANCH on developer machines.
         assert_eq!(deployment_from_hostname("pr42"), None);
         assert_eq!(deployment_from_hostname("regelrecht"), None);
+        assert_eq!(deployment_from_hostname("pr42-workstation"), None);
+        assert_eq!(deployment_from_hostname("pr42-a-b"), None);
     }
 
     #[test]

--- a/packages/corpus/src/config.rs
+++ b/packages/corpus/src/config.rs
@@ -29,16 +29,37 @@ impl std::fmt::Debug for CorpusConfig {
     }
 }
 
+/// Extract the ZAD deployment name from a Kubernetes pod hostname.
+///
+/// Pod hostnames follow `{deployment}-{component}-{rs-hash}-{pod-hash}`.
+/// Only the literal `regelrecht` (production) and `pr<digits>` (PR previews)
+/// are recognised; anything else returns `None` so a stray multi-segment
+/// deployment name can't be misread as a bare first segment.
+fn deployment_from_hostname(hostname: &str) -> Option<String> {
+    let first = hostname.split('-').next()?;
+    let is_pr_preview = first
+        .strip_prefix("pr")
+        .is_some_and(|rest| !rest.is_empty() && rest.chars().all(|c| c.is_ascii_digit()));
+    (first == "regelrecht" || is_pr_preview).then(|| first.to_string())
+}
+
 /// Resolve the corpus branch from explicit config and platform variables.
 ///
-/// Priority: `CORPUS_BRANCH` > `DEPLOYMENT_NAME` (if preview) > `"development"`.
+/// Priority: `CORPUS_BRANCH` > `DEPLOYMENT_NAME` > `HOSTNAME` prefix > `"development"`.
 /// Production deployment name (`"regelrecht"`) is ignored so it falls through
 /// to the default `"development"` branch.
-fn resolve_branch(corpus_branch: Option<String>, deployment_name: Option<String>) -> String {
+fn resolve_branch(
+    corpus_branch: Option<String>,
+    deployment_name: Option<String>,
+    hostname: Option<String>,
+) -> String {
     if let Some(branch) = corpus_branch.filter(|b| !b.is_empty()) {
         return branch;
     }
-    if let Some(name) = deployment_name.filter(|n| !n.is_empty() && n != "regelrecht") {
+    let derived = deployment_name
+        .filter(|n| !n.is_empty())
+        .or_else(|| hostname.as_deref().and_then(deployment_from_hostname));
+    if let Some(name) = derived.filter(|n| n != "regelrecht") {
         return name;
     }
     "development".into()
@@ -62,7 +83,8 @@ impl CorpusConfig {
     ///
     /// Required: `CORPUS_REPO_URL`
     /// Optional: `CORPUS_REPO_PATH` (default: `/tmp/corpus-repo`),
-    ///           `CORPUS_BRANCH` (default: `DEPLOYMENT_NAME` in previews, else `development`),
+    ///           `CORPUS_BRANCH` (default: `DEPLOYMENT_NAME`, else `HOSTNAME` prefix
+    ///            for PR previews, else `development`),
     ///           `CORPUS_GIT_AUTHOR_NAME` (default: `regelrecht-harvester`),
     ///           `CORPUS_GIT_AUTHOR_EMAIL` (default: `noreply@minbzk.nl`),
     ///           `CORPUS_GIT_TOKEN` (for authentication)
@@ -77,6 +99,7 @@ impl CorpusConfig {
         let branch = resolve_branch(
             std::env::var("CORPUS_BRANCH").ok(),
             std::env::var("DEPLOYMENT_NAME").ok(),
+            std::env::var("HOSTNAME").ok(),
         );
 
         let git_author_name = std::env::var("CORPUS_GIT_AUTHOR_NAME")
@@ -198,31 +221,35 @@ mod tests {
 
     #[test]
     fn resolve_branch_defaults_to_development() {
-        assert_eq!(resolve_branch(None, None), "development");
+        assert_eq!(resolve_branch(None, None, None), "development");
     }
 
     #[test]
     fn resolve_branch_uses_corpus_branch() {
         assert_eq!(
-            resolve_branch(Some("custom".into()), Some("pr42".into())),
+            resolve_branch(
+                Some("custom".into()),
+                Some("pr42".into()),
+                Some("pr99-harvester-worker-abc-xyz".into())
+            ),
             "custom"
         );
     }
 
     #[test]
     fn resolve_branch_uses_corpus_branch_without_deployment() {
-        assert_eq!(resolve_branch(Some("custom".into()), None), "custom");
+        assert_eq!(resolve_branch(Some("custom".into()), None, None), "custom");
     }
 
     #[test]
     fn resolve_branch_uses_deployment_name_for_preview() {
-        assert_eq!(resolve_branch(None, Some("pr42".into())), "pr42");
+        assert_eq!(resolve_branch(None, Some("pr42".into()), None), "pr42");
     }
 
     #[test]
     fn resolve_branch_ignores_production_deployment() {
         assert_eq!(
-            resolve_branch(None, Some("regelrecht".into())),
+            resolve_branch(None, Some("regelrecht".into()), None),
             "development"
         );
     }
@@ -230,9 +257,61 @@ mod tests {
     #[test]
     fn resolve_branch_ignores_empty_values() {
         assert_eq!(
-            resolve_branch(Some("".into()), Some("".into())),
+            resolve_branch(Some("".into()), Some("".into()), Some("".into())),
             "development"
         );
+    }
+
+    #[test]
+    fn resolve_branch_uses_pr_hostname_when_deployment_name_missing() {
+        assert_eq!(
+            resolve_branch(None, None, Some("pr429-harvester-worker-abc-xyz".into())),
+            "pr429"
+        );
+    }
+
+    #[test]
+    fn resolve_branch_ignores_production_hostname() {
+        assert_eq!(
+            resolve_branch(
+                None,
+                None,
+                Some("regelrecht-harvester-worker-abc-xyz".into())
+            ),
+            "development"
+        );
+    }
+
+    #[test]
+    fn resolve_branch_deployment_name_beats_hostname() {
+        assert_eq!(
+            resolve_branch(
+                None,
+                Some("pr99".into()),
+                Some("regelrecht-harvester-worker-abc-xyz".into())
+            ),
+            "pr99"
+        );
+    }
+
+    #[test]
+    fn deployment_from_hostname_recognises_pr_and_prod() {
+        assert_eq!(
+            deployment_from_hostname("pr568-enrichworker-abc-xyz"),
+            Some("pr568".into())
+        );
+        assert_eq!(
+            deployment_from_hostname("regelrecht-harvester-admin-abc-xyz"),
+            Some("regelrecht".into())
+        );
+    }
+
+    #[test]
+    fn deployment_from_hostname_rejects_unknown_prefixes() {
+        assert_eq!(deployment_from_hostname("feature-x-foo-a-b"), None);
+        assert_eq!(deployment_from_hostname("prabc-foo-a-b"), None);
+        assert_eq!(deployment_from_hostname("pr-foo-a-b"), None);
+        assert_eq!(deployment_from_hostname(""), None);
     }
 
     #[test]

--- a/packages/pipeline/src/enrich.rs
+++ b/packages/pipeline/src/enrich.rs
@@ -438,32 +438,31 @@ pub async fn create_enrich_corpus(
     client.ensure_repo().await?;
 
     // Prefer the worker's own base branch (e.g. `pr574`) so PR deployments
-    // enrich their own harvested YAML, not production's. Fall back to
-    // `development` for a fresh PR whose harvester hasn't pushed yet.
+    // enrich their own harvested YAML, not production's. Probe the remote
+    // first and fall back to `development` only when the branch doesn't
+    // exist yet — which covers a fresh PR whose harvester hasn't pushed.
+    // Probing explicitly (instead of try-then-fallback on any error)
+    // prevents an unrelated `checkout` or `reset` failure from silently
+    // dropping the enrichment back to production's branch.
     //
     // Pass the exact file path (not the directory) so the `ls-files` guard
     // inside `checkout_from_branch` doesn't match sibling files and skip
     // fetching a newly harvested version of an already-known law.
     let preferred_base = base_config.branch.as_str();
-    if preferred_base != "development" {
-        if let Err(e) = client
-            .checkout_from_branch(preferred_base, &[&normalized])
-            .await
-        {
-            tracing::warn!(
+    let base_branch =
+        if preferred_base == "development" || client.remote_branch_exists(preferred_base).await? {
+            preferred_base
+        } else {
+            tracing::info!(
                 branch = %preferred_base,
-                error = %e,
-                "base branch not available on remote, falling back to development"
+                "base branch not yet published on remote, using development for first enrichment"
             );
-            client
-                .checkout_from_branch("development", &[&normalized])
-                .await?;
-        }
-    } else {
-        client
-            .checkout_from_branch("development", &[&normalized])
-            .await?;
-    }
+            "development"
+        };
+
+    client
+        .checkout_from_branch(base_branch, &[&normalized])
+        .await?;
 
     Ok(client)
 }

--- a/packages/pipeline/src/enrich.rs
+++ b/packages/pipeline/src/enrich.rs
@@ -1,4 +1,6 @@
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
 
 use regelrecht_corpus::{CorpusClient, CorpusConfig};
@@ -7,6 +9,28 @@ use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
 use crate::error::{PipelineError, Result};
+
+/// Per-process cache of branch names already confirmed to exist on the
+/// corpus remote. Branches are never deleted once created, so a positive
+/// probe is permanent for the life of the worker — caching skips the
+/// ls-remote round-trip on every subsequent enrich job for the same PR.
+fn known_remote_branches() -> &'static Mutex<HashSet<String>> {
+    static CACHE: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+fn branch_is_known(branch: &str) -> bool {
+    known_remote_branches()
+        .lock()
+        .map(|cache| cache.contains(branch))
+        .unwrap_or(false)
+}
+
+fn remember_branch(branch: &str) {
+    if let Ok(mut cache) = known_remote_branches().lock() {
+        cache.insert(branch.to_string());
+    }
+}
 
 /// Trait abstracting the LLM invocation so `execute_enrich` can be tested
 /// with a fake provider that doesn't spawn real processes.
@@ -449,16 +473,18 @@ pub async fn create_enrich_corpus(
     // inside `checkout_from_branch` doesn't match sibling files and skip
     // fetching a newly harvested version of an already-known law.
     let preferred_base = base_config.branch.as_str();
-    let base_branch =
-        if preferred_base == "development" || client.remote_branch_exists(preferred_base).await? {
-            preferred_base
-        } else {
-            tracing::info!(
-                branch = %preferred_base,
-                "base branch not yet published on remote, using development for first enrichment"
-            );
-            "development"
-        };
+    let base_branch = if preferred_base == "development" || branch_is_known(preferred_base) {
+        preferred_base
+    } else if client.remote_branch_exists(preferred_base).await? {
+        remember_branch(preferred_base);
+        preferred_base
+    } else {
+        tracing::info!(
+            branch = %preferred_base,
+            "base branch not yet published on remote, using development for first enrichment"
+        );
+        "development"
+    };
 
     client
         .checkout_from_branch(base_branch, &[&normalized])

--- a/packages/pipeline/src/enrich.rs
+++ b/packages/pipeline/src/enrich.rs
@@ -437,12 +437,33 @@ pub async fn create_enrich_corpus(
     let mut client = CorpusClient::new(config);
     client.ensure_repo().await?;
 
+    // Prefer the worker's own base branch (e.g. `pr574`) so PR deployments
+    // enrich their own harvested YAML, not production's. Fall back to
+    // `development` for a fresh PR whose harvester hasn't pushed yet.
+    //
     // Pass the exact file path (not the directory) so the `ls-files` guard
     // inside `checkout_from_branch` doesn't match sibling files and skip
     // fetching a newly harvested version of an already-known law.
-    client
-        .checkout_from_branch("development", &[&normalized])
-        .await?;
+    let preferred_base = base_config.branch.as_str();
+    if preferred_base != "development" {
+        if let Err(e) = client
+            .checkout_from_branch(preferred_base, &[&normalized])
+            .await
+        {
+            tracing::warn!(
+                branch = %preferred_base,
+                error = %e,
+                "base branch not available on remote, falling back to development"
+            );
+            client
+                .checkout_from_branch("development", &[&normalized])
+                .await?;
+        }
+    } else {
+        client
+            .checkout_from_branch("development", &[&normalized])
+            .await?;
+    }
 
     Ok(client)
 }

--- a/packages/pipeline/src/enrich.rs
+++ b/packages/pipeline/src/enrich.rs
@@ -32,6 +32,18 @@ fn remember_branch(branch: &str) {
     }
 }
 
+/// Pick the base branch to check out the law YAML from, given the worker's
+/// preferred branch and whether that branch exists on the remote. Pure
+/// function so the branch-selection contract can be pinned by unit tests
+/// without a live git remote.
+fn pick_enrich_base(preferred: &str, preferred_exists: bool) -> &str {
+    if preferred == "development" || preferred_exists {
+        preferred
+    } else {
+        "development"
+    }
+}
+
 /// Trait abstracting the LLM invocation so `execute_enrich` can be tested
 /// with a fake provider that doesn't spawn real processes.
 #[async_trait::async_trait]
@@ -473,18 +485,22 @@ pub async fn create_enrich_corpus(
     // inside `checkout_from_branch` doesn't match sibling files and skip
     // fetching a newly harvested version of an already-known law.
     let preferred_base = base_config.branch.as_str();
-    let base_branch = if preferred_base == "development" || branch_is_known(preferred_base) {
-        preferred_base
-    } else if client.remote_branch_exists(preferred_base).await? {
-        remember_branch(preferred_base);
-        preferred_base
+    let preferred_exists = if preferred_base == "development" || branch_is_known(preferred_base) {
+        true
     } else {
+        let exists = client.remote_branch_exists(preferred_base).await?;
+        if exists {
+            remember_branch(preferred_base);
+        }
+        exists
+    };
+    let base_branch = pick_enrich_base(preferred_base, preferred_exists);
+    if !preferred_exists {
         tracing::info!(
             branch = %preferred_base,
             "base branch not yet published on remote, using development for first enrichment"
         );
-        "development"
-    };
+    }
 
     client
         .checkout_from_branch(base_branch, &[&normalized])
@@ -821,6 +837,26 @@ fn count_machine_readable_in_value(value: &serde_yaml_ng::Value) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn pick_enrich_base_uses_preferred_when_remote_has_it() {
+        assert_eq!(pick_enrich_base("pr574", true), "pr574");
+    }
+
+    #[test]
+    fn pick_enrich_base_falls_back_when_preferred_missing() {
+        // Fresh PR deployment whose harvester hasn't pushed its branch yet:
+        // enrichment must fall back to development instead of failing.
+        assert_eq!(pick_enrich_base("pr574", false), "development");
+    }
+
+    #[test]
+    fn pick_enrich_base_short_circuits_for_development() {
+        // When the worker's own base is already `development`, the
+        // remote-exists bool is moot and we always use `development`.
+        assert_eq!(pick_enrich_base("development", true), "development");
+        assert_eq!(pick_enrich_base("development", false), "development");
+    }
 
     #[test]
     fn test_enrich_payload_serde_roundtrip() {


### PR DESCRIPTION
## Summary

- Workers had no signal to distinguish production from a PR preview and always harvested into `development`.
- ZAD does not inject `DEPLOYMENT_NAME`, but K8s sets `$HOSTNAME` to `{deployment}-{component}-{rs}-{pod}` (confirmed via ZAD logs API: `regelrecht-harvester-worker-…`, `pr429-harvester-worker-…`).
- `resolve_branch` now treats a `regelrecht` or `pr<digits>` hostname prefix as a third-priority signal, below explicit `CORPUS_BRANCH` and `DEPLOYMENT_NAME`. Unknown prefixes fall through to `development` so a future multi-segment deployment name can't be misread.
- No workflow, Dockerfile or ZAD changes — purely a Rust-side code path in `packages/corpus/src/config.rs` used by the harvester-worker and enrich-worker via `CorpusConfig::from_env`.

## Test plan

- [x] Unit tests cover the new hostname-derivation path (PR hostname, prod hostname, unknown prefixes, precedence with `DEPLOYMENT_NAME`/`CORPUS_BRANCH`).
- [x] `just format` clean.
- [x] `just lint` clean across the workspace.
- [ ] Deploy preview → confirm `pr<N>` branch is cloned in the PR deployment's harvester-worker logs.
- [ ] Production (after merge) → confirm behaviour unchanged: harvester still uses `development`.