### PR TITLE
fix(grafana): scope daily summary queries to prod namespace

### DIFF
--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -4074,9 +4074,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/packages/grafana/provisioning/alerting/alerts.yaml
+++ b/packages/grafana/provisioning/alerting/alerts.yaml
@@ -89,7 +89,7 @@ groups:
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
-              expr: max(regelrecht_laws{status="harvested", namespace="rig-prd-regel-k4c"})
+              expr: max(regelrecht_laws{status="harvested", deployment="regelrecht"})
               instant: true
               refId: A
           - refId: B
@@ -98,7 +98,7 @@ groups:
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
-              expr: max(regelrecht_laws{status="enriched", namespace="rig-prd-regel-k4c"})
+              expr: max(regelrecht_laws{status="enriched", deployment="regelrecht"})
               instant: true
               refId: B
           - refId: E
@@ -107,7 +107,7 @@ groups:
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
-              expr: max(regelrecht_jobs{status="pending", namespace="rig-prd-regel-k4c"})
+              expr: max(regelrecht_jobs{status="pending", deployment="regelrecht"})
               instant: true
               refId: E
           - refId: F
@@ -116,7 +116,7 @@ groups:
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
-              expr: max(regelrecht_jobs{status="completed", namespace="rig-prd-regel-k4c"})
+              expr: max(regelrecht_jobs{status="completed", deployment="regelrecht"})
               instant: true
               refId: F
           # Per-type failed metrics for harvest/enrich split.
@@ -126,7 +126,7 @@ groups:
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
-              expr: max(regelrecht_jobs_failed_harvest_24h{namespace="rig-prd-regel-k4c"})
+              expr: max(regelrecht_jobs_failed_harvest_24h{deployment="regelrecht"})
               instant: true
               refId: I
           - refId: J
@@ -135,7 +135,7 @@ groups:
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
-              expr: max(regelrecht_jobs_failed_enrich_24h{namespace="rig-prd-regel-k4c"})
+              expr: max(regelrecht_jobs_failed_enrich_24h{deployment="regelrecht"})
               instant: true
               refId: J
           - refId: K
@@ -144,7 +144,7 @@ groups:
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
-              expr: max(regelrecht_jobs_failed_harvest{namespace="rig-prd-regel-k4c"})
+              expr: max(regelrecht_jobs_failed_harvest{deployment="regelrecht"})
               instant: true
               refId: K
           - refId: L
@@ -153,7 +153,7 @@ groups:
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
-              expr: max(regelrecht_jobs_failed_enrich{namespace="rig-prd-regel-k4c"})
+              expr: max(regelrecht_jobs_failed_enrich{deployment="regelrecht"})
               instant: true
               refId: L
           - refId: M
@@ -162,7 +162,7 @@ groups:
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
-              expr: max(regelrecht_exhausted_harvest{namespace="rig-prd-regel-k4c"})
+              expr: max(regelrecht_exhausted_harvest{deployment="regelrecht"})
               instant: true
               refId: M
           - refId: N
@@ -171,7 +171,7 @@ groups:
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
-              expr: max(regelrecht_exhausted_enrich{namespace="rig-prd-regel-k4c"})
+              expr: max(regelrecht_exhausted_enrich{deployment="regelrecht"})
               instant: true
               refId: N
           # Always-fire: A + B + 1 is always > 0.

--- a/packages/grafana/provisioning/alerting/alerts.yaml
+++ b/packages/grafana/provisioning/alerting/alerts.yaml
@@ -89,7 +89,7 @@ groups:
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
-              expr: max(regelrecht_laws{status="harvested"})
+              expr: max(regelrecht_laws{status="harvested", namespace="rig-prd-regel-k4c"})
               instant: true
               refId: A
           - refId: B
@@ -98,7 +98,7 @@ groups:
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
-              expr: max(regelrecht_laws{status="enriched"})
+              expr: max(regelrecht_laws{status="enriched", namespace="rig-prd-regel-k4c"})
               instant: true
               refId: B
           - refId: E
@@ -107,7 +107,7 @@ groups:
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
-              expr: max(regelrecht_jobs{status="pending"})
+              expr: max(regelrecht_jobs{status="pending", namespace="rig-prd-regel-k4c"})
               instant: true
               refId: E
           - refId: F
@@ -116,7 +116,7 @@ groups:
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
-              expr: max(regelrecht_jobs{status="completed"})
+              expr: max(regelrecht_jobs{status="completed", namespace="rig-prd-regel-k4c"})
               instant: true
               refId: F
           # Per-type failed metrics for harvest/enrich split.
@@ -126,7 +126,7 @@ groups:
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
-              expr: regelrecht_jobs_failed_harvest_24h
+              expr: max(regelrecht_jobs_failed_harvest_24h{namespace="rig-prd-regel-k4c"})
               instant: true
               refId: I
           - refId: J
@@ -135,7 +135,7 @@ groups:
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
-              expr: regelrecht_jobs_failed_enrich_24h
+              expr: max(regelrecht_jobs_failed_enrich_24h{namespace="rig-prd-regel-k4c"})
               instant: true
               refId: J
           - refId: K
@@ -144,7 +144,7 @@ groups:
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
-              expr: regelrecht_jobs_failed_harvest
+              expr: max(regelrecht_jobs_failed_harvest{namespace="rig-prd-regel-k4c"})
               instant: true
               refId: K
           - refId: L
@@ -153,7 +153,7 @@ groups:
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
-              expr: regelrecht_jobs_failed_enrich
+              expr: max(regelrecht_jobs_failed_enrich{namespace="rig-prd-regel-k4c"})
               instant: true
               refId: L
           - refId: M
@@ -162,7 +162,7 @@ groups:
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
-              expr: regelrecht_exhausted_harvest
+              expr: max(regelrecht_exhausted_harvest{namespace="rig-prd-regel-k4c"})
               instant: true
               refId: M
           - refId: N
@@ -171,7 +171,7 @@ groups:
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
-              expr: regelrecht_exhausted_enrich
+              expr: max(regelrecht_exhausted_enrich{namespace="rig-prd-regel-k4c"})
               instant: true
               refId: N
           # Always-fire: A + B + 1 is always > 0.


### PR DESCRIPTION
## Summary

The daily Mattermost summary was reporting wrong numbers — e.g. **Mislukt harvesting (24u): 2011 jobs** while **Totaal mislukt harvesting: 171**, arithmetically impossible (24h ≤ total).

Ground truth from the admin API against the prod DB:

| | DB | Mattermost |
|---|---|---|
| Failed harvest total | 181 | 171 ❌ |
| Failed harvest 24h | 0 | 2011 ❌ |
| Failed enrich total | 7573 | 7573 ✓ |

## Root cause

The datasource is the **shared RIG Prometheus** (`prometheus.rig-prd-operations.svc.cluster.local:9090`) which scrapes every active deployment — prod, preview PRs, and `upload`. The alert rule's PromQL expressions had no label filter, so each returned one series per deployment. Grafana alerting can then latch onto a preview's value.

Confirmed in Grafana Explore against `regelrecht_jobs{status="pending"}`:

| deployment | pending |
|---|---|
| `regelrecht` (prod) | **0** |
| `pr568` | 4350 |
| `pr575` | 0 |

Preview `pr568` has 4350 pending jobs in its test DB, which is the kind of contamination that broke the summary.

Note: preview deployments share the prod namespace (`rig-prd-regel-k4c`) — the label that actually distinguishes them is `deployment` (values `regelrecht`, `pr568`, `pr575`, …).

Additionally, refIds I/J/K/L (added in #393) and M/N (added in #424) were missing the `max()` wrapper that A/B/E/F already used.

## Fix

Scope every query in the daily-summary alert to `deployment="regelrecht"`, keeping `max()` for defensive behavior. Applies to all 10 refIds (A, B, E, F, I, J, K, L, M, N).

## Test plan

- [ ] Once merged, wait for the next midnight Mattermost summary
- [ ] Expect: `Mislukt harvesting (24u): 0`, `Totaal mislukt harvesting: 181`, `Openstaand: 0` (or prod's actual value, not 5794)
- [ ] Known follow-up (not in this PR): the `regelrecht-overview.json` dashboard panels have the same cross-deployment issue