### PR TITLE
fix(frontend): correct heart-filled icon name for favorites button

### DIFF
--- a/frontend/src/LibraryApp.vue
+++ b/frontend/src/LibraryApp.vue
@@ -382,7 +382,7 @@ loadIndex();
                 <ndd-toolbar>
                   <ndd-toolbar-item v-if="authenticated" slot="start">
                     <ndd-icon-button
-                      :icon="favorites?.has(selectedLawId) ? 'heart-fill' : 'heart'"
+                      :icon="favorites?.has(selectedLawId) ? 'heart-filled' : 'heart'"
                       :title="favorites?.has(selectedLawId) ? 'Verwijder uit favorieten' : 'Voeg toe aan favorieten'"
                       @click="toggleFavorite(selectedLawId)"
                     ></ndd-icon-button>


### PR DESCRIPTION
## Summary
- The favorite toggle in `LibraryApp.vue` used `'heart-fill'`, but the design system (`@minbzk/storybook`) ships the filled variant as `'heart-filled'`.
- When the selected law was in favorites, `ndd-icon-button` resolved to a non-existent icon and rendered empty.
- One-character fix: `heart-fill` → `heart-filled`.

## Test plan
- [ ] Open the library, select a law that is in favorites → filled heart is visible
- [ ] Select a law that is not in favorites → outline heart is visible
- [ ] Toggle favorite on/off → icon swaps correctly