### PR TITLE
fix(editor): derive pipeline-api URL from pod HOSTNAME, not stale env

### DIFF
--- a/packages/corpus/src/config.rs
+++ b/packages/corpus/src/config.rs
@@ -38,7 +38,7 @@ impl std::fmt::Debug for CorpusConfig {
 /// pod-name shape). A dev box named `pr42`, `pr42-workstation`, or
 /// `pr42-a-b` therefore returns `None` and can't shadow an explicit
 /// `CORPUS_BRANCH`.
-fn deployment_from_hostname(hostname: &str) -> Option<String> {
+pub fn deployment_from_hostname(hostname: &str) -> Option<String> {
     // Require the full K8s pod-name shape: at least three `-` characters,
     // matching `{deployment}-{component}-{rs-hash}-{pod-hash}`. Anything
     // shorter is almost certainly not a pod.

--- a/packages/corpus/src/lib.rs
+++ b/packages/corpus/src/lib.rs
@@ -11,7 +11,7 @@ pub mod source_map;
 pub mod validation;
 
 pub use client::CorpusClient;
-pub use config::CorpusConfig;
+pub use config::{deployment_from_hostname, CorpusConfig};
 pub use error::CorpusError;
 #[cfg(feature = "github")]
 pub use github::{FetchResult, GitHubFetcher};

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -67,10 +67,13 @@ async fn main() {
     let hostname = env::var("HOSTNAME").ok();
     let pipeline_api_url =
         resolve_pipeline_api_url(hostname.as_deref(), env::var("PIPELINE_API_URL").ok());
+    let hostname_log = hostname.as_deref().unwrap_or("<none>");
     match &pipeline_api_url {
-        Some(url) => tracing::info!(url = %url, hostname = ?hostname, "pipeline-api proxy target"),
+        Some(url) => {
+            tracing::info!(url = %url, hostname = %hostname_log, "pipeline-api proxy target")
+        }
         None => tracing::info!(
-            hostname = ?hostname,
+            hostname = %hostname_log,
             "no pipeline-api URL configured, harvest proxy disabled"
         ),
     }

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -64,12 +64,11 @@ async fn main() {
     let static_dir = env::var("STATIC_DIR").unwrap_or_else(|_| "static".to_string());
     let corpus_state = init_corpus(&static_dir).await;
 
-    let pipeline_api_url = resolve_pipeline_api_url(
-        env::var("HOSTNAME").ok().as_deref(),
-        env::var("PIPELINE_API_URL").ok(),
-    );
+    let hostname = env::var("HOSTNAME").ok();
+    let pipeline_api_url =
+        resolve_pipeline_api_url(hostname.as_deref(), env::var("PIPELINE_API_URL").ok());
     match &pipeline_api_url {
-        Some(url) => tracing::info!(url = %url, "pipeline-api proxy target"),
+        Some(url) => tracing::info!(url = %url, hostname = ?hostname, "pipeline-api proxy target"),
         None => tracing::info!("no pipeline-api URL configured, harvest proxy disabled"),
     }
 
@@ -469,6 +468,11 @@ fn empty_registry() -> regelrecht_corpus::CorpusRegistry {
 ///
 /// `PIPELINE_API_URL` remains as an explicit override for local dev where
 /// HOSTNAME doesn't match the `{deployment}-{component}-{rs}-{pod}` shape.
+///
+/// Edge case: a dev machine whose HOSTNAME happens to match that shape *and*
+/// starts with `regelrecht` or `pr<N>` would silently derive a cluster-internal
+/// URL that won't resolve locally. `deployment_from_hostname`'s whitelist is
+/// the sole guard here; the old `KUBERNETES_SERVICE_HOST` gate is gone.
 fn resolve_pipeline_api_url(hostname: Option<&str>, env_url: Option<String>) -> Option<String> {
     hostname
         .and_then(regelrecht_corpus::deployment_from_hostname)

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -64,9 +64,10 @@ async fn main() {
     let static_dir = env::var("STATIC_DIR").unwrap_or_else(|_| "static".to_string());
     let corpus_state = init_corpus(&static_dir).await;
 
-    let pipeline_api_url = env::var("PIPELINE_API_URL")
-        .ok()
-        .or_else(discover_pipeline_api_url_from_k8s);
+    let pipeline_api_url = resolve_pipeline_api_url(
+        env::var("HOSTNAME").ok().as_deref(),
+        env::var("PIPELINE_API_URL").ok(),
+    );
     match &pipeline_api_url {
         Some(url) => tracing::info!(url = %url, "pipeline-api proxy target"),
         None => tracing::info!("no pipeline-api URL configured, harvest proxy disabled"),
@@ -453,33 +454,73 @@ fn empty_registry() -> regelrecht_corpus::CorpusRegistry {
         .unwrap_or_else(|_| unreachable!())
 }
 
-/// Fallback when `PIPELINE_API_URL` is not set: discover pipelineapi from the
-/// pod's own HOSTNAME. ZAD's alias-based env injection is resolved at
-/// component-creation time, so it gets stuck with stale ports when the
-/// pipelineapi component is recreated. ZAD pod/Service names follow the
-/// convention `<deployment>-<component>`, so we derive the deployment from
-/// HOSTNAME's first segment and reach pipelineapi via cluster-internal DNS.
+/// Resolve the pipeline-api URL, preferring pod HOSTNAME over environment
+/// override.
 ///
-/// Gated on `KUBERNETES_SERVICE_HOST` so dev machines (where HOSTNAME is also
-/// set but maps to the machine name) fall through to `None` and harvest calls
-/// cleanly return 503 "not configured" instead of 502 network errors.
+/// Priority: `HOSTNAME` → `PIPELINE_API_URL` → `None`.
 ///
-/// Assumption: ZAD deployment names do not contain hyphens. If they did,
-/// splitting on `-` would pick up only the first segment (e.g. "mijn" from
-/// `mijn-regelrecht-editor-...`) and the resulting URL would silently point at
-/// the wrong service. Today all regel-k4c deployments follow single-word
-/// (`regelrecht`) or `pr<N>` naming. Set `PIPELINE_API_URL` explicitly if a
-/// multi-hyphen deployment ever lands.
-fn discover_pipeline_api_url_from_k8s() -> Option<String> {
-    env::var("KUBERNETES_SERVICE_HOST").ok()?;
-    let hostname = env::var("HOSTNAME").ok()?;
-    let deployment = hostname.split('-').next().filter(|s| !s.is_empty())?;
-    let url = format!("http://{deployment}-pipelineapi:8000");
-    tracing::info!(
-        hostname = %hostname,
-        deployment = %deployment,
-        url = %url,
-        "derived pipeline-api URL from HOSTNAME — if deployment name contains hyphens, set PIPELINE_API_URL explicitly",
-    );
-    Some(url)
+/// HOSTNAME wins because ZAD's alias-based env injection is resolved at
+/// component-creation time and gets stuck with stale values when the
+/// pipelineapi component is renamed or its port changes. The pod hostname
+/// is bound by Kubernetes and also cannot be inherited via ZAD's
+/// `clone-from`, so it is the only reliable "which deployment am I?" signal
+/// — matching the pattern `regelrecht_corpus::deployment_from_hostname`
+/// uses for corpus branch resolution (see PR #574 for the corpus rationale).
+///
+/// `PIPELINE_API_URL` remains as an explicit override for local dev where
+/// HOSTNAME doesn't match the `{deployment}-{component}-{rs}-{pod}` shape.
+fn resolve_pipeline_api_url(hostname: Option<&str>, env_url: Option<String>) -> Option<String> {
+    hostname
+        .and_then(regelrecht_corpus::deployment_from_hostname)
+        .map(|deployment| format!("http://{deployment}-pipelineapi:8000"))
+        .or(env_url)
+}
+
+#[cfg(test)]
+mod pipeline_api_url_tests {
+    use super::resolve_pipeline_api_url;
+
+    #[test]
+    fn prod_pod_hostname_derives_regelrecht_pipelineapi() {
+        let url = resolve_pipeline_api_url(Some("regelrecht-editor-abc-xyz"), None);
+        assert_eq!(url.as_deref(), Some("http://regelrecht-pipelineapi:8000"));
+    }
+
+    #[test]
+    fn pr_preview_pod_hostname_derives_pr_pipelineapi() {
+        let url = resolve_pipeline_api_url(Some("pr123-editor-abc-xyz"), None);
+        assert_eq!(url.as_deref(), Some("http://pr123-pipelineapi:8000"));
+    }
+
+    /// Regression test: even with a stale `PIPELINE_API_URL` shadowing the
+    /// resolution (e.g. ZAD alias injection leftover pointing at an old
+    /// `pipelineapi-pr552:8001`), HOSTNAME must still win.
+    #[test]
+    fn hostname_wins_over_stale_env_var() {
+        let url = resolve_pipeline_api_url(
+            Some("regelrecht-editor-abc-xyz"),
+            Some("http://pipelineapi-pr552:8001".to_string()),
+        );
+        assert_eq!(url.as_deref(), Some("http://regelrecht-pipelineapi:8000"));
+    }
+
+    #[test]
+    fn dev_hostname_falls_back_to_env_override() {
+        let url = resolve_pipeline_api_url(
+            Some("tim-laptop"),
+            Some("http://localhost:8001".to_string()),
+        );
+        assert_eq!(url.as_deref(), Some("http://localhost:8001"));
+    }
+
+    #[test]
+    fn no_hostname_and_no_env_returns_none() {
+        assert!(resolve_pipeline_api_url(None, None).is_none());
+    }
+
+    #[test]
+    fn no_hostname_uses_env_override() {
+        let url = resolve_pipeline_api_url(None, Some("http://localhost:8001".to_string()));
+        assert_eq!(url.as_deref(), Some("http://localhost:8001"));
+    }
 }

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -69,7 +69,10 @@ async fn main() {
         resolve_pipeline_api_url(hostname.as_deref(), env::var("PIPELINE_API_URL").ok());
     match &pipeline_api_url {
         Some(url) => tracing::info!(url = %url, hostname = ?hostname, "pipeline-api proxy target"),
-        None => tracing::info!("no pipeline-api URL configured, harvest proxy disabled"),
+        None => tracing::info!(
+            hostname = ?hostname,
+            "no pipeline-api URL configured, harvest proxy disabled"
+        ),
     }
 
     let mut app_state = AppState {
@@ -512,6 +515,19 @@ mod pipeline_api_url_tests {
     fn dev_hostname_falls_back_to_env_override() {
         let url = resolve_pipeline_api_url(
             Some("tim-laptop"),
+            Some("http://localhost:8001".to_string()),
+        );
+        assert_eq!(url.as_deref(), Some("http://localhost:8001"));
+    }
+
+    /// A non-whitelisted pod-shaped hostname (≥3 hyphens but first segment is
+    /// not `regelrecht` or `pr<N>`) must not be trusted as a deployment name —
+    /// `deployment_from_hostname` returns `None` and we fall through to the
+    /// env override. Documents the whitelist boundary explicitly.
+    #[test]
+    fn non_whitelisted_pod_hostname_falls_back_to_env() {
+        let url = resolve_pipeline_api_url(
+            Some("feature-editor-abc-xyz"),
             Some("http://localhost:8001".to_string()),
         );
         assert_eq!(url.as_deref(), Some("http://localhost:8001"));


### PR DESCRIPTION
## Summary

Productie-editor (`https://editor.regelrecht.rijks.app`) belde de pr552 preview pipeline-api in plaats van zijn eigen:

```
Pipeline API request failed: error sending request for url
(http://pipelineapi-pr552:8001/harvest/search?q=Volkshuisvesting)
```

De `PIPELINE_API_URL` env-var op het `regelrecht-editor` ZAD-component was stale geraakt (oude naam `pipelineapi-pr552`, oude port `8001`) nadat het pipelineapi-component was hernoemd en de port was gewijzigd. De bestaande HOSTNAME-fallback werd nooit gebruikt omdat de stale env-var hem overschaduwde — exact dezelfde bug die #574 al had opgelost voor de corpus-branch-resolutie in de harvester.

## Changes

- **Omdraaien van de prioriteit** in `packages/editor-api/src/main.rs`: `HOSTNAME` → `PIPELINE_API_URL` → `None` (was: env eerst, HOSTNAME als fallback).
- **Hergebruik** van `regelrecht_corpus::deployment_from_hostname` (uit PR #574) in plaats van een eigen, minder robuuste pod-name parser. `deployment_from_hostname` is nu `pub` en ge-re-exporteerd uit `regelrecht_corpus`.
- **Nieuwe pure helper** `resolve_pipeline_api_url(hostname, env_url)` die puur genoeg is om testbaar te zijn zonder env-manipulatie.
- **7 unit-tests** incl. een regressietest `hostname_wins_over_stale_env_var` die exact deze bug afdekt.
- **Verwijderd**: de oude `discover_pipeline_api_url_from_k8s` helper (inclusief de `KUBERNETES_SERVICE_HOST` gate — overbodig omdat `deployment_from_hostname` al een ≥3-hyphen pod-shape guard + `regelrecht`/`pr<N>`-whitelist heeft).

## Effect

Na deploy: de stale `PIPELINE_API_URL` op productie wordt simpelweg genegeerd. Geen ZAD-ingreep nodig — hij hoeft niet opgeschoond te worden.

- Productie (HOSTNAME=`regelrecht-editor-...`) → `http://regelrecht-pipelineapi:8000`
- PR preview (HOSTNAME=`pr<N>-editor-...`) → `http://pr<N>-pipelineapi:8000`
- Lokale dev (HOSTNAME=`tim-laptop` o.i.d.) → valt door naar `PIPELINE_API_URL` env-var of `None` (503).

## Test plan

- [x] Unit tests `cargo test --package regelrecht-editor-api` (7 passed)
- [x] `cargo test --package regelrecht-corpus --lib` (88 passed — resolve_branch-tests ongewijzigd)
- [x] `just editor-api-fmt`, `just editor-api-check`, `just editor-api-lint` groen
- [ ] Preview deploy: `zad logs --deployment pr<N> --component editor` moet startup-regel `pipeline-api proxy target url=http://pr<N>-pipelineapi:8000` tonen
- [ ] Na merge op productie: BWB-zoeken werkt weer op https://editor.regelrecht.rijks.app/library/zorgtoeslagwet