### PR TITLE
feat(editor): trace stepping on the law graph (PR2 of 3)

### DIFF
--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -264,6 +264,19 @@ function handleScenarioExecuted({ result, traceText, error, expectations, scenar
   resultSheetOpen.value = true;
 }
 
+// Clear the captured trace whenever the active law changes — otherwise
+// LawGraphView would re-flatten the old trace under the new lawId,
+// misattribute every step to the new law, and pin the "▶ start" badge
+// to a leaf that just happens to share the previous output's name.
+watch(lawId, () => {
+  lastResult.value = null;
+  lastTraceText.value = null;
+  lastError.value = null;
+  lastExpectations.value = {};
+  lastScenarioName.value = '';
+  lastOutputName.value = null;
+});
+
 // --- Editor state ---
 const activeAction = ref(null);
 const activeEditItem = ref(null);

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -250,13 +250,17 @@ const lastResult = ref(null);
 const lastError = ref(null);
 const lastExpectations = ref({});
 const lastScenarioName = ref('');
+// The scenario's entry output (e.g. "is_rechthebbende"). The graph pane
+// uses this to pin its "▶ start" marker to the right leaf.
+const lastOutputName = ref(null);
 
-function handleScenarioExecuted({ result, traceText, error, expectations, scenarioName }) {
+function handleScenarioExecuted({ result, traceText, error, expectations, scenarioName, outputName }) {
   lastResult.value = result;
   lastTraceText.value = traceText;
   lastError.value = error || null;
   lastExpectations.value = expectations || {};
   lastScenarioName.value = scenarioName || '';
+  lastOutputName.value = outputName || null;
   resultSheetOpen.value = true;
 }
 
@@ -845,7 +849,12 @@ function handleActionSave() {
           <nldd-split-view-pane v-if="showGraphPane" :slot="paneSlot('graph')">
             <nldd-page sticky-header>
               <nldd-top-title-bar slot="header" text="Wettengraaf"></nldd-top-title-bar>
-              <LawGraphView :law-id="lawId" />
+              <LawGraphView
+                :law-id="lawId"
+                :result="lastResult"
+                :output-name="lastOutputName"
+                :expectations="lastExpectations"
+              />
             </nldd-page>
           </nldd-split-view-pane>
         </nldd-side-by-side-split-view>

--- a/frontend/src/components/LawGraphView.vue
+++ b/frontend/src/components/LawGraphView.vue
@@ -16,6 +16,7 @@ import TraceStepList from './graph/TraceStepList.vue';
 import TraceStepDetail from './graph/TraceStepDetail.vue';
 import { useLawGraph, rootOfId } from '../composables/useLawGraph.js';
 import { useTraceStepping } from '../composables/useTraceStepping.js';
+import { stepHasHighlights } from '../lib/traceEdges.js';
 
 const props = defineProps({
   lawId: { type: String, default: null },
@@ -71,7 +72,7 @@ const filter = ref('highlights'); // 'highlights' | 'all'
 
 function stepIsVisible(step) {
   if (filter.value === 'all') return true;
-  return step.edgeIds.length > 0 || step.nodeIds.length > 0;
+  return stepHasHighlights(step);
 }
 
 // Filter-aware nav: when the user has the "Met highlights" filter on,

--- a/frontend/src/components/LawGraphView.vue
+++ b/frontend/src/components/LawGraphView.vue
@@ -69,6 +69,44 @@ const {
 const hasTrace = computed(() => steps.value.length > 0);
 const filter = ref('highlights'); // 'highlights' | 'all'
 
+function stepIsVisible(step) {
+  if (filter.value === 'all') return true;
+  return step.edgeIds.length > 0 || step.nodeIds.length > 0;
+}
+
+// Filter-aware nav: when the user has the "Met highlights" filter on,
+// Vorige/Volgende must skip context-only steps that aren't rendered in
+// the list — otherwise the counter advances onto a row that the user
+// can't see and the step list looks frozen.
+function nextVisible() {
+  for (let i = currentStepIdx.value + 1; i < steps.value.length; i++) {
+    if (stepIsVisible(steps.value[i])) {
+      goto(i);
+      return;
+    }
+  }
+}
+function prevVisible() {
+  for (let i = currentStepIdx.value - 1; i >= 0; i--) {
+    if (stepIsVisible(steps.value[i])) {
+      goto(i);
+      return;
+    }
+  }
+}
+const hasNextVisible = computed(() => {
+  for (let i = currentStepIdx.value + 1; i < steps.value.length; i++) {
+    if (stepIsVisible(steps.value[i])) return true;
+  }
+  return false;
+});
+const hasPrevVisible = computed(() => {
+  for (let i = currentStepIdx.value - 1; i >= 0; i--) {
+    if (stepIsVisible(steps.value[i])) return true;
+  }
+  return false;
+});
+
 // --- Click-highlight state (PR1 feature, preserved) ---------------------
 
 // Which root law's edges are currently highlighted (inbound/outbound).
@@ -191,14 +229,14 @@ const currentStep = computed(() =>
           <button
             type="button"
             class="law-graph-trace__btn"
-            :disabled="currentStepIdx <= 0"
-            @click="prev"
+            :disabled="!hasPrevVisible"
+            @click="prevVisible"
           >◀ Vorige</button>
           <button
             type="button"
             class="law-graph-trace__btn"
-            :disabled="currentStepIdx >= steps.length - 1"
-            @click="next"
+            :disabled="!hasNextVisible"
+            @click="nextVisible"
           >Volgende ▶</button>
           <span class="law-graph-trace__counter">
             Stap <strong>{{ currentStepIdx + 1 }}</strong> / {{ steps.length }}

--- a/frontend/src/components/LawGraphView.vue
+++ b/frontend/src/components/LawGraphView.vue
@@ -12,10 +12,21 @@ import './graph/graph-styles.css';
 
 import LawNode from './graph/LawNode.vue';
 import LeafNode from './graph/LeafNode.vue';
+import TraceStepList from './graph/TraceStepList.vue';
+import TraceStepDetail from './graph/TraceStepDetail.vue';
 import { useLawGraph, rootOfId } from '../composables/useLawGraph.js';
+import { useTraceStepping } from '../composables/useTraceStepping.js';
 
 const props = defineProps({
   lawId: { type: String, default: null },
+  // Latest scenario execution result (TraceResult). When set, the graph
+  // enters trace-stepping mode: step list + detail panel appear below
+  // the graph and nodes/edges get .trace-active/.trace-visited classes.
+  result: { type: Object, default: null },
+  // The scenario's entry output name — pins the "▶ start" marker to the
+  // matching output leaf on the root law.
+  outputName: { type: String, default: null },
+  expectations: { type: Object, default: () => ({}) },
 });
 
 async function fetchLawYaml(lawId) {
@@ -34,7 +45,31 @@ const { nodes, edges, loading, error, missingDeps } = useLawGraph({
   fetchLawYaml,
 });
 
-// --- Local UI state -----------------------------------------------------
+// --- Trace stepping state -----------------------------------------------
+
+const {
+  steps,
+  currentStepIdx,
+  next,
+  prev,
+  goto,
+  startNodeIds,
+  activeEdgeIds,
+  activeNodeIds,
+  visitedEdgeIds,
+  visitedNodeIds,
+} = useTraceStepping({
+  result: toRef(props, 'result'),
+  nodes,
+  edges,
+  rootLawId: toRef(props, 'lawId'),
+  outputName: toRef(props, 'outputName'),
+});
+
+const hasTrace = computed(() => steps.value.length > 0);
+const filter = ref('highlights'); // 'highlights' | 'all'
+
+// --- Click-highlight state (PR1 feature, preserved) ---------------------
 
 // Which root law's edges are currently highlighted (inbound/outbound).
 // null = no highlight. Toggles off when the same law is clicked twice.
@@ -43,8 +78,8 @@ const selectedRoot = ref(null);
 // Laws the user hid via the close button (visible but excluded).
 const hiddenLaws = ref(new Set());
 
-// Reset local UI state when the underlying law changes, otherwise the
-// hidden set / selection carries over to an unrelated graph.
+// Reset local UI state when the underlying law changes — the hidden set /
+// selection shouldn't bleed into an unrelated graph.
 watch(() => props.lawId, () => {
   selectedRoot.value = null;
   hiddenLaws.value = new Set();
@@ -52,25 +87,40 @@ watch(() => props.lawId, () => {
 
 const visibleNodes = computed(() => {
   const hidden = hiddenLaws.value;
-  return nodes.value.map((n) => ({
-    ...n,
-    hidden: hidden.has(rootOfId(n.id)),
-  }));
+  const starts = startNodeIds.value;
+  const active = activeNodeIds.value;
+  const visited = visitedNodeIds.value;
+  return nodes.value.map((n) => {
+    const classes = [];
+    if (n.class) classes.push(n.class);
+    if (starts.has(n.id)) classes.push('trace-start');
+    if (active.has(n.id)) classes.push('trace-active');
+    else if (visited.has(n.id)) classes.push('trace-visited');
+    return {
+      ...n,
+      hidden: hidden.has(rootOfId(n.id)),
+      class: classes.join(' ') || undefined,
+    };
+  });
 });
 
 const visibleEdges = computed(() => {
   const hidden = hiddenLaws.value;
   const highlight = selectedRoot.value;
+  const active = activeEdgeIds.value;
+  const visited = visitedEdgeIds.value;
   return edges.value.map((e) => {
     const sourceRoot = rootOfId(e.source);
     const targetRoot = rootOfId(e.target);
     const edgeHidden = hidden.has(sourceRoot) || hidden.has(targetRoot);
-    let cls = '';
+    const classes = [];
     if (highlight) {
-      if (sourceRoot === highlight) cls = 'inbound';
-      else if (targetRoot === highlight) cls = 'outbound';
+      if (sourceRoot === highlight) classes.push('inbound');
+      else if (targetRoot === highlight) classes.push('outbound');
     }
-    return { ...e, hidden: edgeHidden, class: cls || undefined };
+    if (active.has(e.id)) classes.push('trace-active');
+    else if (visited.has(e.id)) classes.push('trace-visited');
+    return { ...e, hidden: edgeHidden, class: classes.join(' ') || undefined };
   });
 });
 
@@ -96,6 +146,12 @@ function handleNodeClick({ node, event }) {
 function miniMapNodeColor(node) {
   return node.class?.includes('root') && !node.hidden ? '#ccc' : 'transparent';
 }
+
+const currentStep = computed(() =>
+  currentStepIdx.value >= 0 && currentStepIdx.value < steps.value.length
+    ? steps.value[currentStepIdx.value]
+    : null,
+);
 </script>
 
 <template>
@@ -108,25 +164,82 @@ function miniMapNodeColor(node) {
       <nldd-inline-dialog text="Open een wet om de graaf te zien."></nldd-inline-dialog>
     </div>
 
-    <div v-else class="law-graph-container">
-      <div v-if="loading" class="law-graph-loading">Bezig met laden…</div>
-      <div v-else-if="missingDeps.length > 0" class="law-graph-warning" :title="missingDeps.join(', ')">
-        Kon {{ missingDeps.length }} afhankelijkhe{{ missingDeps.length === 1 ? 'id' : 'den' }} niet laden
+    <template v-else>
+      <div class="law-graph-container">
+        <div v-if="loading" class="law-graph-loading">Bezig met laden…</div>
+        <div v-else-if="missingDeps.length > 0" class="law-graph-warning" :title="missingDeps.join(', ')">
+          Kon {{ missingDeps.length }} afhankelijkhe{{ missingDeps.length === 1 ? 'id' : 'den' }} niet laden
+        </div>
+        <VueFlow
+          :nodes="visibleNodes"
+          :edges="visibleEdges"
+          :node-types="nodeTypes"
+          :nodes-connectable="false"
+          :min-zoom="0.1"
+          fit-view-on-init
+          @node-click="handleNodeClick"
+        >
+          <Controls :show-lock="false" />
+          <Background variant="dots" />
+          <MiniMap zoomable pannable :node-color="miniMapNodeColor" />
+        </VueFlow>
       </div>
-      <VueFlow
-        :nodes="visibleNodes"
-        :edges="visibleEdges"
-        :node-types="nodeTypes"
-        :nodes-connectable="false"
-        :min-zoom="0.1"
-        fit-view-on-init
-        @node-click="handleNodeClick"
-      >
-        <Controls :show-lock="false" />
-        <Background variant="dots" />
-        <MiniMap zoomable pannable :node-color="miniMapNodeColor" />
-      </VueFlow>
-    </div>
+
+      <!-- Trace stepper — shown after a scenario runs -->
+      <div v-if="hasTrace" class="law-graph-trace">
+        <div class="law-graph-trace__toolbar">
+          <button
+            type="button"
+            class="law-graph-trace__btn"
+            :disabled="currentStepIdx <= 0"
+            @click="prev"
+          >◀ Vorige</button>
+          <button
+            type="button"
+            class="law-graph-trace__btn"
+            :disabled="currentStepIdx >= steps.length - 1"
+            @click="next"
+          >Volgende ▶</button>
+          <span class="law-graph-trace__counter">
+            Stap <strong>{{ currentStepIdx + 1 }}</strong> / {{ steps.length }}
+          </span>
+
+          <div class="law-graph-trace__filter">
+            <span>Filter:</span>
+            <button
+              type="button"
+              class="law-graph-trace__toggle"
+              :class="{ 'law-graph-trace__toggle--active': filter === 'highlights' }"
+              @click="filter = 'highlights'"
+            >Met highlights</button>
+            <button
+              type="button"
+              class="law-graph-trace__toggle"
+              :class="{ 'law-graph-trace__toggle--active': filter === 'all' }"
+              @click="filter = 'all'"
+            >Alles ({{ steps.length }})</button>
+          </div>
+        </div>
+
+        <div class="law-graph-trace__body">
+          <div class="law-graph-trace__list">
+            <TraceStepList
+              :steps="steps"
+              :current-step-idx="currentStepIdx"
+              :filter="filter"
+              @select-step="goto"
+            />
+          </div>
+          <div class="law-graph-trace__detail">
+            <TraceStepDetail
+              :step="currentStep"
+              :outputs="result?.outputs || {}"
+              :expectations="expectations"
+            />
+          </div>
+        </div>
+      </div>
+    </template>
   </div>
 </template>
 
@@ -175,5 +288,75 @@ function miniMapNodeColor(node) {
 .law-graph-empty,
 .law-graph-error {
   padding: 16px;
+}
+
+/* --- Trace stepper panel ------------------------------------------ */
+
+.law-graph-trace {
+  display: flex;
+  flex-direction: column;
+  flex: 0 0 40vh;
+  min-height: 220px;
+  border-top: 2px solid #f59e0b;
+  background: white;
+  font-size: 13px;
+}
+
+.law-graph-trace__toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border-bottom: 1px solid #e5e7eb;
+  background: #fef3c7;
+}
+
+.law-graph-trace__btn,
+.law-graph-trace__toggle {
+  border: 1px solid #9ca3af;
+  background: white;
+  border-radius: 4px;
+  padding: 2px 8px;
+  font-size: 12px;
+  cursor: pointer;
+  font-family: inherit;
+}
+.law-graph-trace__btn:hover:not(:disabled),
+.law-graph-trace__toggle:hover { background: #f9fafb; }
+.law-graph-trace__btn:disabled { opacity: 0.4; cursor: not-allowed; }
+
+.law-graph-trace__toggle--active {
+  border-color: #f59e0b;
+  background: #fef3c7;
+  font-weight: 600;
+}
+
+.law-graph-trace__counter { color: #4b5563; }
+
+.law-graph-trace__filter {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  color: #6b7280;
+}
+
+.law-graph-trace__body {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+}
+.law-graph-trace__list {
+  flex: 1;
+  border-right: 1px solid #e5e7eb;
+  min-width: 0;
+  overflow: hidden;
+}
+.law-graph-trace__detail {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
 }
 </style>

--- a/frontend/src/components/ScenarioBuilder.vue
+++ b/frontend/src/components/ScenarioBuilder.vue
@@ -229,6 +229,9 @@ function onShowDetails(index) {
       error: data.error,
       expectations: data.expectations || {},
       scenarioName,
+      // Forward the scenario's entry output so the graph view can pin
+      // its "▶ start" marker to the right output leaf.
+      outputName: data.outputName || null,
     });
   }
 }

--- a/frontend/src/components/ScenarioForm.vue
+++ b/frontend/src/components/ScenarioForm.vue
@@ -164,6 +164,9 @@ function getExecutionData() {
     traceText: result.value?.trace_text || errorTraceText.value || null,
     error: error.value,
     expectations: expectations.value,
+    // Expose the scenario's entry output so the graph view can mark the
+    // starting leaf (see useTraceStepping.startNodeIds).
+    outputName: props.scenario.execution?.outputName || selectedOutputs.value[0] || null,
   };
 }
 

--- a/frontend/src/components/graph/TraceStepDetail.vue
+++ b/frontend/src/components/graph/TraceStepDetail.vue
@@ -1,0 +1,189 @@
+<script setup>
+import { computed } from 'vue';
+import { formatValue, formatOutputValue, normalizeForCompare, matchStatus as _matchStatus } from '../../utils/outputFormat.js';
+
+const props = defineProps({
+  step: { type: Object, default: null },
+  outputs: { type: Object, default: () => ({}) },
+  expectations: { type: Object, default: () => ({}) },
+});
+
+function matchStatus(name, value) {
+  return _matchStatus(name, value, props.expectations);
+}
+
+function truncate(v) {
+  const s = formatValue(v);
+  return s.length > 80 ? `${s.substring(0, 77)}…` : s;
+}
+
+const outputEntries = computed(() => Object.entries(props.outputs || {}));
+const expectationEntries = computed(() => Object.entries(props.expectations || {}));
+</script>
+
+<template>
+  <div class="step-detail">
+    <div v-if="step" class="step-detail__card">
+      <div class="step-detail__head">
+        <span class="step-detail__chip" :class="`node-type-${step.nodeType}`">
+          {{ step.nodeType.replace(/_/g, ' ') }}
+        </span>
+        <span class="step-detail__name">{{ step.name }}</span>
+      </div>
+      <dl class="step-detail__dl">
+        <div class="step-detail__row">
+          <dt>Wet:</dt>
+          <dd class="mono">{{ step.lawId }}</dd>
+        </div>
+        <div v-if="step.resolveType" class="step-detail__row">
+          <dt>Resolve:</dt>
+          <dd class="mono indigo">{{ step.resolveType }}</dd>
+        </div>
+        <div v-if="step.result !== undefined && step.result !== null" class="step-detail__row">
+          <dt>Resultaat:</dt>
+          <dd class="mono emerald">{{ truncate(step.result) }}</dd>
+        </div>
+        <div v-if="step.durationUs !== undefined" class="step-detail__row">
+          <dt>Duur:</dt>
+          <dd class="mono">{{ step.durationUs }}µs</dd>
+        </div>
+        <div v-if="step.message" class="step-detail__row">
+          <dt>Bericht:</dt>
+          <dd class="italic">{{ step.message }}</dd>
+        </div>
+      </dl>
+    </div>
+
+    <h3 class="step-detail__section-title">Outputs</h3>
+    <dl class="step-detail__outputs">
+      <div v-for="[k, v] in outputEntries" :key="k" class="step-detail__row">
+        <dt>{{ k }}:</dt>
+        <dd class="mono">{{ formatOutputValue(v, k) }}</dd>
+      </div>
+      <div v-if="outputEntries.length === 0" class="step-detail__empty">Geen outputs</div>
+    </dl>
+
+    <template v-if="expectationEntries.length > 0">
+      <h3 class="step-detail__section-title">Verwachtingen</h3>
+      <ul class="step-detail__expectations">
+        <li v-for="[name, expected] in expectationEntries" :key="name">
+          <span
+            class="step-detail__marker"
+            :class="{
+              'pass': matchStatus(name, outputs[name]) === 'passed',
+              'fail': matchStatus(name, outputs[name]) === 'failed',
+            }"
+          >{{ matchStatus(name, outputs[name]) === 'failed' ? '✗' : '✓' }}</span>
+          <span class="mono">
+            {{ name }} = {{ formatValue(normalizeForCompare(expected)) }}
+            <span v-if="matchStatus(name, outputs[name]) === 'failed'" class="fail">
+              (kreeg {{ formatValue(outputs[name]) }})
+            </span>
+          </span>
+        </li>
+      </ul>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.step-detail {
+  overflow-y: auto;
+  padding: 12px;
+  background: var(--semantics-surfaces-tinted-background-color, #f9fafb);
+  font-size: 12px;
+}
+
+.step-detail__card {
+  margin-bottom: 12px;
+  border: 1px solid #fcd34d;
+  background: #fef3c7;
+  border-radius: 6px;
+  padding: 8px;
+}
+
+.step-detail__head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+.step-detail__chip {
+  font-size: 10px;
+  padding: 1px 4px;
+  border-radius: 3px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.step-detail__name {
+  font-family: 'SF Mono', 'Fira Code', monospace;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.step-detail__dl,
+.step-detail__outputs {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-family: 'SF Mono', 'Fira Code', monospace;
+  font-size: 11px;
+  margin: 0;
+}
+
+.step-detail__row {
+  display: flex;
+  gap: 8px;
+}
+.step-detail__row dt {
+  width: 80px;
+  color: #6b7280;
+  flex-shrink: 0;
+}
+.step-detail__row dd {
+  margin: 0;
+  color: #111827;
+  min-width: 0;
+  word-break: break-word;
+}
+
+.mono { font-family: 'SF Mono', 'Fira Code', monospace; }
+.indigo { color: #4f46e5; }
+.emerald { color: #047857; }
+.italic { font-style: italic; color: #6b7280; }
+
+.step-detail__section-title {
+  margin: 8px 0 4px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #374151;
+}
+
+.step-detail__empty {
+  color: #9ca3af;
+  font-style: italic;
+  font-size: 11px;
+}
+
+.step-detail__expectations {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  font-family: 'SF Mono', 'Fira Code', monospace;
+  font-size: 11px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.step-detail__expectations li {
+  display: flex;
+  gap: 6px;
+}
+.step-detail__marker {
+  font-weight: 700;
+}
+.step-detail__marker.pass,
+.pass { color: #047857; }
+.step-detail__marker.fail,
+.fail { color: #dc2626; }
+</style>

--- a/frontend/src/components/graph/TraceStepList.vue
+++ b/frontend/src/components/graph/TraceStepList.vue
@@ -1,0 +1,150 @@
+<script setup>
+import { computed, watch, nextTick } from 'vue';
+import { formatValue } from '../../utils/outputFormat.js';
+
+const props = defineProps({
+  steps: { type: Array, required: true },
+  currentStepIdx: { type: Number, required: true },
+  filter: { type: String, default: 'highlights' }, // 'highlights' | 'all'
+});
+
+const emit = defineEmits(['select-step']);
+
+const visibleSteps = computed(() => {
+  if (props.filter === 'all') return props.steps;
+  return props.steps.filter((s) => s.edgeIds.length > 0 || s.nodeIds.length > 0);
+});
+
+function truncate(v) {
+  const s = formatValue(v);
+  return s.length > 60 ? `${s.substring(0, 57)}…` : s;
+}
+
+// Keep the active step in view when navigation moves it out of the
+// visible area. queueMicrotask in demo; Vue's nextTick is the idiomatic
+// equivalent.
+watch(
+  () => props.currentStepIdx,
+  (idx) => {
+    if (idx < 0) return;
+    nextTick(() => {
+      const el = document.querySelector(`[data-step-idx="${idx}"]`);
+      if (el) el.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+    });
+  },
+);
+</script>
+
+<template>
+  <div class="step-list">
+    <button
+      v-for="step in visibleSteps"
+      :key="steps.indexOf(step)"
+      type="button"
+      class="step-row"
+      :class="{ 'step-row--active': steps.indexOf(step) === currentStepIdx }"
+      :data-step-idx="steps.indexOf(step)"
+      :style="{ paddingLeft: `${step.depth * 10 + 12}px` }"
+      @click="emit('select-step', steps.indexOf(step))"
+    >
+      <div class="step-row__head">
+        <span class="step-row__idx">{{ steps.indexOf(step) + 1 }}.</span>
+        <span class="step-row__chip" :class="`node-type-${step.nodeType}`">
+          {{ step.nodeType.replace(/_/g, ' ') }}
+        </span>
+        <span class="step-row__name">{{ step.name }}</span>
+        <span v-if="step.resolveType" class="step-row__resolve">[{{ step.resolveType }}]</span>
+      </div>
+      <div v-if="step.result !== undefined && step.result !== null" class="step-row__result">
+        = {{ truncate(step.result) }}
+      </div>
+      <div v-if="step.message" class="step-row__message">{{ step.message }}</div>
+      <div v-if="step.edgeIds.length > 0 || step.nodeIds.length > 0" class="step-row__counts">
+        <template v-if="step.edgeIds.length > 0">→ {{ step.edgeIds.length }} edge{{ step.edgeIds.length === 1 ? '' : 's' }}</template>
+        <template v-if="step.nodeIds.length > 0">{{ step.edgeIds.length > 0 ? ', ' : '→ ' }}{{ step.nodeIds.length }} node{{ step.nodeIds.length === 1 ? '' : 's' }}</template>
+      </div>
+    </button>
+    <div v-if="visibleSteps.length === 0" class="step-list__empty">
+      Geen stappen met highlights. Zet het filter op "Alles" om alle {{ steps.length }} stappen te zien.
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.step-list {
+  overflow-y: auto;
+  font-family: 'SF Mono', 'Fira Code', monospace;
+}
+
+.step-row {
+  display: block;
+  width: 100%;
+  border: 0;
+  border-bottom: 1px solid #f3f4f6;
+  background: transparent;
+  padding: 4px 12px;
+  text-align: left;
+  font-size: 12px;
+  cursor: pointer;
+  font-family: inherit;
+}
+.step-row:hover { background: #f9fafb; }
+.step-row--active {
+  background: #fef3c7;
+  font-weight: 600;
+  color: #78350f;
+}
+
+.step-row__head {
+  display: flex;
+  align-items: baseline;
+  gap: 4px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.step-row__idx {
+  display: inline-block;
+  width: 28px;
+  text-align: right;
+  color: #9ca3af;
+}
+.step-row__chip {
+  font-size: 10px;
+  padding: 1px 4px;
+  border-radius: 3px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.step-row__name { overflow: hidden; text-overflow: ellipsis; }
+.step-row__resolve {
+  font-size: 10px;
+  color: #4f46e5;
+}
+.step-row__result {
+  padding-left: 32px;
+  font-size: 11px;
+  color: #047857;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.step-row__message {
+  padding-left: 32px;
+  font-size: 10px;
+  font-style: italic;
+  color: #6b7280;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.step-row__counts {
+  padding-left: 32px;
+  font-size: 10px;
+  color: #d97706;
+}
+
+.step-list__empty {
+  padding: 16px;
+  font-size: 12px;
+  color: var(--semantics-text-color-secondary, #6b7280);
+}
+</style>

--- a/frontend/src/components/graph/TraceStepList.vue
+++ b/frontend/src/components/graph/TraceStepList.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, watch, nextTick } from 'vue';
+import { computed, ref, watch, nextTick } from 'vue';
 import { formatValue } from '../../utils/outputFormat.js';
 
 const props = defineProps({
@@ -10,9 +10,16 @@ const props = defineProps({
 
 const emit = defineEmits(['select-step']);
 
+const listEl = ref(null);
+
+// Tag each visible step with its index in the unfiltered `steps` array
+// so the template can read it directly — avoids an O(n) `steps.indexOf`
+// per row, per render (the loop itself was O(visibleSteps × steps)).
 const visibleSteps = computed(() => {
-  if (props.filter === 'all') return props.steps;
-  return props.steps.filter((s) => s.edgeIds.length > 0 || s.nodeIds.length > 0);
+  const all = props.steps;
+  const entries = all.map((step, idx) => ({ step, idx }));
+  if (props.filter === 'all') return entries;
+  return entries.filter(({ step }) => step.edgeIds.length > 0 || step.nodeIds.length > 0);
 });
 
 function truncate(v) {
@@ -22,13 +29,16 @@ function truncate(v) {
 
 // Keep the active step in view when navigation moves it out of the
 // visible area. queueMicrotask in demo; Vue's nextTick is the idiomatic
-// equivalent.
+// equivalent. Scope the lookup to this component's root so a second
+// graph pane (e.g. during a route transition) can't be matched.
 watch(
   () => props.currentStepIdx,
   (idx) => {
     if (idx < 0) return;
     nextTick(() => {
-      const el = document.querySelector(`[data-step-idx="${idx}"]`);
+      const root = listEl.value;
+      if (!root) return;
+      const el = root.querySelector(`[data-step-idx="${idx}"]`);
       if (el) el.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
     });
   },
@@ -36,32 +46,32 @@ watch(
 </script>
 
 <template>
-  <div class="step-list">
+  <div ref="listEl" class="step-list">
     <button
-      v-for="step in visibleSteps"
-      :key="steps.indexOf(step)"
+      v-for="entry in visibleSteps"
+      :key="entry.idx"
       type="button"
       class="step-row"
-      :class="{ 'step-row--active': steps.indexOf(step) === currentStepIdx }"
-      :data-step-idx="steps.indexOf(step)"
-      :style="{ paddingLeft: `${step.depth * 10 + 12}px` }"
-      @click="emit('select-step', steps.indexOf(step))"
+      :class="{ 'step-row--active': entry.idx === currentStepIdx }"
+      :data-step-idx="entry.idx"
+      :style="{ paddingLeft: `${entry.step.depth * 10 + 12}px` }"
+      @click="emit('select-step', entry.idx)"
     >
       <div class="step-row__head">
-        <span class="step-row__idx">{{ steps.indexOf(step) + 1 }}.</span>
-        <span class="step-row__chip" :class="`node-type-${step.nodeType}`">
-          {{ step.nodeType.replace(/_/g, ' ') }}
+        <span class="step-row__idx">{{ entry.idx + 1 }}.</span>
+        <span class="step-row__chip" :class="`node-type-${entry.step.nodeType}`">
+          {{ entry.step.nodeType.replace(/_/g, ' ') }}
         </span>
-        <span class="step-row__name">{{ step.name }}</span>
-        <span v-if="step.resolveType" class="step-row__resolve">[{{ step.resolveType }}]</span>
+        <span class="step-row__name">{{ entry.step.name }}</span>
+        <span v-if="entry.step.resolveType" class="step-row__resolve">[{{ entry.step.resolveType }}]</span>
       </div>
-      <div v-if="step.result !== undefined && step.result !== null" class="step-row__result">
-        = {{ truncate(step.result) }}
+      <div v-if="entry.step.result !== undefined && entry.step.result !== null" class="step-row__result">
+        = {{ truncate(entry.step.result) }}
       </div>
-      <div v-if="step.message" class="step-row__message">{{ step.message }}</div>
-      <div v-if="step.edgeIds.length > 0 || step.nodeIds.length > 0" class="step-row__counts">
-        <template v-if="step.edgeIds.length > 0">→ {{ step.edgeIds.length }} edge{{ step.edgeIds.length === 1 ? '' : 's' }}</template>
-        <template v-if="step.nodeIds.length > 0">{{ step.edgeIds.length > 0 ? ', ' : '→ ' }}{{ step.nodeIds.length }} node{{ step.nodeIds.length === 1 ? '' : 's' }}</template>
+      <div v-if="entry.step.message" class="step-row__message">{{ entry.step.message }}</div>
+      <div v-if="entry.step.edgeIds.length > 0 || entry.step.nodeIds.length > 0" class="step-row__counts">
+        <template v-if="entry.step.edgeIds.length > 0">→ {{ entry.step.edgeIds.length }} edge{{ entry.step.edgeIds.length === 1 ? '' : 's' }}</template>
+        <template v-if="entry.step.nodeIds.length > 0">{{ entry.step.edgeIds.length > 0 ? ', ' : '→ ' }}{{ entry.step.nodeIds.length }} node{{ entry.step.nodeIds.length === 1 ? '' : 's' }}</template>
       </div>
     </button>
     <div v-if="visibleSteps.length === 0" class="step-list__empty">

--- a/frontend/src/components/graph/TraceStepList.vue
+++ b/frontend/src/components/graph/TraceStepList.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { computed, ref, watch, nextTick } from 'vue';
 import { formatValue } from '../../utils/outputFormat.js';
+import { stepHasHighlights } from '../../lib/traceEdges.js';
 
 const props = defineProps({
   steps: { type: Array, required: true },
@@ -19,7 +20,7 @@ const visibleSteps = computed(() => {
   const all = props.steps;
   const entries = all.map((step, idx) => ({ step, idx }));
   if (props.filter === 'all') return entries;
-  return entries.filter(({ step }) => step.edgeIds.length > 0 || step.nodeIds.length > 0);
+  return entries.filter(({ step }) => stepHasHighlights(step));
 });
 
 function truncate(v) {

--- a/frontend/src/components/graph/graph-styles.css
+++ b/frontend/src/components/graph/graph-styles.css
@@ -82,6 +82,9 @@
  * stroke that impl/override/hook edges set so the trace path always wins. */
 .vue-flow__edge.trace-active path {
   stroke: #f59e0b !important;
+  /* Match the keyframe start so the first paint frame doesn't flash
+   * the inherited (thinner) edge width before the animation begins. */
+  stroke-width: 6 !important;
   stroke-dasharray: none !important;
   animation: trace-pulse 1.2s ease-in-out infinite;
 }

--- a/frontend/src/components/graph/graph-styles.css
+++ b/frontend/src/components/graph/graph-styles.css
@@ -9,7 +9,7 @@
  * useLawGraph.js. Keep the two in sync.
  *
  * Trace-stepping highlights (.trace-active, .trace-visited, .trace-start)
- * will land in PR2 when useTraceStepping is introduced.
+ * are applied via the `class` prop on nodes/edges from useTraceStepping.
  */
 
 .vue-flow .root {
@@ -75,3 +75,93 @@
 .vue-flow__edge.outbound path:first-child {
   marker-end: none;
 }
+
+/* --- Trace stepping highlights -------------------------------------- */
+
+/* Active edge pulses amber. !important overrides the per-edge inline
+ * stroke that impl/override/hook edges set so the trace path always wins. */
+.vue-flow__edge.trace-active path {
+  stroke: #f59e0b !important;
+  stroke-dasharray: none !important;
+  animation: trace-pulse 1.2s ease-in-out infinite;
+}
+.vue-flow__edge.trace-visited path {
+  stroke: #fbbf24 !important;
+  stroke-width: 4 !important;
+  opacity: 0.75;
+}
+@keyframes trace-pulse {
+  0%, 100% { stroke-width: 6; }
+  50% { stroke-width: 10; }
+}
+
+/* Active node: leaves get a solid amber fill; law/group containers get
+ * an outline + glow so nested content stays visible. */
+.vue-flow__node.trace-active {
+  z-index: 10;
+}
+.vue-flow__node-leaf.trace-active {
+  background: #f59e0b !important;
+  color: #1f2937 !important;
+  font-weight: 700 !important;
+  outline: 3px solid #b45309 !important;
+  outline-offset: 0 !important;
+  box-shadow: 0 0 20px rgba(245, 158, 11, 0.8) !important;
+}
+.vue-flow__node-law.trace-active,
+.vue-flow__node-default.trace-active {
+  outline: 4px solid #f59e0b !important;
+  outline-offset: 2px !important;
+  box-shadow: 0 0 24px rgba(245, 158, 11, 0.75) !important;
+}
+
+.vue-flow__node-leaf.trace-visited {
+  background: #fde68a !important;
+  color: #78350f !important;
+}
+.vue-flow__node-law.trace-visited,
+.vue-flow__node-default.trace-visited {
+  outline: 2px solid #fbbf24 !important;
+  outline-offset: 1px !important;
+}
+
+/* Start point — sticky dashed blue outline + "▶ start" label on the
+ * scenario's root law and initial output leaf. Stays visible across
+ * all steps so users can always see where the trace began. */
+.vue-flow__node.trace-start {
+  outline: 3px dashed #2563eb;
+  outline-offset: 4px;
+  z-index: 9;
+}
+.vue-flow__node.trace-start::before {
+  content: '▶ start';
+  position: absolute;
+  top: -18px;
+  left: -4px;
+  background: #2563eb;
+  color: white;
+  font-size: 10px;
+  font-weight: 700;
+  padding: 1px 6px;
+  border-radius: 3px;
+  letter-spacing: 0.04em;
+  pointer-events: none;
+  z-index: 11;
+}
+/* Combine outlines cleanly when a start node is also active. */
+.vue-flow__node.trace-start.trace-active {
+  outline: 3px solid #f59e0b;
+  box-shadow: 0 0 0 7px rgba(37, 99, 235, 0.35), 0 0 16px rgba(245, 158, 11, 0.55);
+}
+
+/* Step-type chips used by the left-side step list. */
+.node-type-article { background: #bfdbfe; color: #1e3a8a; }
+.node-type-action { background: #a7f3d0; color: #065f46; }
+.node-type-requirement { background: #bae6fd; color: #0c4a6e; }
+.node-type-resolve { background: #e2e8f0; color: #334155; }
+.node-type-operation { background: #e5e7eb; color: #374151; }
+.node-type-cached { background: #f3f4f6; color: #4b5563; }
+.node-type-cross_law_reference { background: #fde68a; color: #92400e; }
+.node-type-open_term_resolution { background: #bbf7d0; color: #166534; }
+.node-type-hook_resolution { background: #e9d5ff; color: #5b21b6; }
+.node-type-override_resolution { background: #fecaca; color: #991b1b; }

--- a/frontend/src/composables/useTraceStepping.js
+++ b/frontend/src/composables/useTraceStepping.js
@@ -1,0 +1,135 @@
+/**
+ * useTraceStepping — step through a WASM `TraceResult` against the current
+ * law graph and expose active/visited node & edge sets for CSS
+ * highlighting.
+ *
+ * Ported from demo/graph/src/routes/+page.svelte:984-1200 on branch
+ * feature/demo-leenstelsel-tegemoetkoming. The enrichment (flattenTraceSteps
+ * → edgeIdsForStep / graphNodeIdsForStep) runs once per (result, nodes,
+ * edges) change and is cached in a computed, so `next`/`prev`/`goto`
+ * stay O(1).
+ */
+import { computed, ref, watch } from 'vue';
+import { flattenTraceSteps, edgeIdsForStep, graphNodeIdsForStep } from '../lib/traceEdges.js';
+
+/**
+ * @param {object} opts
+ * @param {import('vue').Ref<object|null>} opts.result  — TraceResult from engine
+ * @param {import('vue').Ref<Array>} opts.nodes         — Vue Flow nodes
+ * @param {import('vue').Ref<Array>} opts.edges         — Vue Flow edges
+ * @param {import('vue').Ref<string|null>} opts.rootLawId
+ * @param {import('vue').Ref<string|null>} opts.outputName
+ */
+export function useTraceStepping({ result, nodes, edges, rootLawId, outputName }) {
+  const currentStepIdx = ref(-1);
+
+  // Raw trace → enriched steps (with edgeIds / nodeIds resolved against the
+  // current graph). Recomputes when the trace, graph, or root law changes.
+  const steps = computed(() => {
+    const trace = result.value?.trace;
+    if (!trace || !rootLawId.value) return [];
+    const flat = flattenTraceSteps(trace, rootLawId.value);
+    const ns = nodes.value || [];
+    const es = edges.value || [];
+    return flat.map((s) => ({
+      ...s,
+      edgeIds: edgeIdsForStep(s, es),
+      nodeIds: graphNodeIdsForStep(s, ns),
+    }));
+  });
+
+  // Reset the pointer to step 0 when a fresh trace arrives; clear when the
+  // trace is cleared. Watching `steps` (not `result`) keeps the reset in
+  // sync with the enrichment — important because an in-flight graph build
+  // can produce an empty `steps` for a brief moment before nodes/edges land.
+  watch(
+    () => result.value,
+    (r) => {
+      currentStepIdx.value = r?.trace ? 0 : -1;
+    },
+  );
+
+  // Pin to the last valid index if `steps` shrinks (e.g. the graph rebuilt
+  // and fewer edges matched), but never below 0 when there are steps.
+  watch(steps, (list) => {
+    if (list.length === 0) {
+      currentStepIdx.value = -1;
+    } else if (currentStepIdx.value >= list.length) {
+      currentStepIdx.value = list.length - 1;
+    } else if (currentStepIdx.value < 0) {
+      currentStepIdx.value = 0;
+    }
+  });
+
+  function next() {
+    if (currentStepIdx.value < steps.value.length - 1) currentStepIdx.value += 1;
+  }
+
+  function prev() {
+    if (currentStepIdx.value > 0) currentStepIdx.value -= 1;
+  }
+
+  function goto(idx) {
+    if (idx < 0 || idx >= steps.value.length) return;
+    currentStepIdx.value = idx;
+  }
+
+  // Start point: the scenario's root law + its initial output leaf. Sticky
+  // across all steps so the user can always see where the trace began.
+  const startNodeIds = computed(() => {
+    const ids = new Set();
+    const lawId = rootLawId.value;
+    const out = outputName.value;
+    if (!lawId) return ids;
+    const nodeIdSet = new Set((nodes.value || []).map((n) => n.id));
+    if (nodeIdSet.has(lawId)) ids.add(lawId);
+    if (out) {
+      const outId = `${lawId}-output-${out}`;
+      if (nodeIdSet.has(outId)) ids.add(outId);
+    }
+    return ids;
+  });
+
+  const activeEdgeIds = computed(() => {
+    const idx = currentStepIdx.value;
+    if (idx < 0 || idx >= steps.value.length) return new Set();
+    return new Set(steps.value[idx].edgeIds);
+  });
+
+  const activeNodeIds = computed(() => {
+    const idx = currentStepIdx.value;
+    if (idx < 0 || idx >= steps.value.length) return new Set();
+    return new Set(steps.value[idx].nodeIds);
+  });
+
+  const visitedEdgeIds = computed(() => {
+    const idx = currentStepIdx.value;
+    const out = new Set();
+    for (let i = 0; i < idx; i++) {
+      for (const id of steps.value[i].edgeIds) out.add(id);
+    }
+    return out;
+  });
+
+  const visitedNodeIds = computed(() => {
+    const idx = currentStepIdx.value;
+    const out = new Set();
+    for (let i = 0; i < idx; i++) {
+      for (const id of steps.value[i].nodeIds) out.add(id);
+    }
+    return out;
+  });
+
+  return {
+    steps,
+    currentStepIdx,
+    next,
+    prev,
+    goto,
+    startNodeIds,
+    activeEdgeIds,
+    activeNodeIds,
+    visitedEdgeIds,
+    visitedNodeIds,
+  };
+}

--- a/frontend/src/composables/useTraceStepping.js
+++ b/frontend/src/composables/useTraceStepping.js
@@ -38,10 +38,15 @@ export function useTraceStepping({ result, nodes, edges, rootLawId, outputName }
     }));
   });
 
-  // Reset the pointer to step 0 when a fresh trace arrives; clear when the
-  // trace is cleared. Watching `steps` (not `result`) keeps the reset in
-  // sync with the enrichment — important because an in-flight graph build
-  // can produce an empty `steps` for a brief moment before nodes/edges land.
+  // Two watchers cooperate on the step pointer:
+  // - The first listens to `result`: when a fresh trace arrives we want
+  //   step 0 selected immediately, even before the graph has been
+  //   enriched. The pointer may briefly point at a step that does not
+  //   exist yet — that's fine, the second watcher clamps it once
+  //   `steps` updates.
+  // - The second listens to `steps`: when enrichment finishes, or the
+  //   graph rebuilds and `steps` shrinks, the pointer is clamped to a
+  //   valid index (or -1 when there's nothing to step through).
   watch(
     () => result.value,
     (r) => {
@@ -49,8 +54,6 @@ export function useTraceStepping({ result, nodes, edges, rootLawId, outputName }
     },
   );
 
-  // Pin to the last valid index if `steps` shrinks (e.g. the graph rebuilt
-  // and fewer edges matched), but never below 0 when there are steps.
   watch(steps, (list) => {
     if (list.length === 0) {
       currentStepIdx.value = -1;

--- a/frontend/src/composables/useTraceStepping.js
+++ b/frontend/src/composables/useTraceStepping.js
@@ -4,10 +4,16 @@
  * highlighting.
  *
  * Ported from demo/graph/src/routes/+page.svelte:984-1200 on branch
- * feature/demo-leenstelsel-tegemoetkoming. The enrichment (flattenTraceSteps
- * → edgeIdsForStep / graphNodeIdsForStep) runs once per (result, nodes,
- * edges) change and is cached in a computed, so `next`/`prev`/`goto`
- * stay O(1).
+ * feature/demo-leenstelsel-tegemoetkoming.
+ *
+ * Cost model:
+ *   - `steps`            — O(N) per (result, nodes, edges) change. Cached.
+ *   - `next`/`prev`/`goto` — O(1) on the pointer itself.
+ *   - `activeEdgeIds` / `activeNodeIds` — O(1) per `currentStepIdx` change.
+ *   - `visitedEdgeIds` / `visitedNodeIds` — O(currentStepIdx) per
+ *     `currentStepIdx` change. Forward traversal of an N-step trace is
+ *     therefore O(N²). Acceptable today (typical traces are <100 steps).
+ *     PR3 polish: amortise via mutated refs in next/prev/goto.
  */
 import { computed, ref, watch } from 'vue';
 import { flattenTraceSteps, edgeIdsForStep, graphNodeIdsForStep } from '../lib/traceEdges.js';

--- a/frontend/src/lib/traceEdges.js
+++ b/frontend/src/lib/traceEdges.js
@@ -143,6 +143,12 @@ export function edgeIdsForStep(step, edges) {
   switch (step.nodeType) {
     case 'cross_law_reference': {
       const [targetLaw, outputName] = splitQualifiedName(step.name);
+      // TODO(PR3): when the consumer renames the input locally
+      // (consumer-side `input.name` differs from `source_output`), this
+      // match fails because we use the producer's output name. A richer
+      // match would index `useLawGraph` edges by `data.refersToService`
+      // plus the consumer's local input name. Carrying over the demo
+      // limitation for now.
       const src = `${step.lawId}-input-${outputName}`;
       return edges
         .filter((e) => {

--- a/frontend/src/lib/traceEdges.js
+++ b/frontend/src/lib/traceEdges.js
@@ -1,0 +1,297 @@
+/**
+ * traceEdges — flatten a PathNode trace tree into a linear step list and
+ * match each step to graph edge / node IDs for highlighting.
+ *
+ * Ported 1:1 from demo/graph/src/lib/traceEdges.ts on branch
+ * feature/demo-leenstelsel-tegemoetkoming. Framework-agnostic pure JS.
+ *
+ * Edge ID formats MUST match what composables/useLawGraph.js emits:
+ *   - cross-law input:  `${lawA}-input-${name}->${lawB}-output-${sourceOutput||name}`
+ *   - implements:       `impl:${lawA}:${art}->${implLaw}:${openTerm}`
+ *   - override:         `ovr:${lawA}:${art}->${ovrLaw}:${ovrArticle}`
+ *   - hook:             `hook:${hookLaw}:${art}->${producerLaw}:${producerArt}`
+ *
+ * Leaf node ID formats (emitted by buildGraph in useLawGraph.js):
+ *   - root:     `${lawId}`
+ *   - source:   `${lawId}-source-${name}`    (parameters)
+ *   - input:    `${lawId}-input-${name}`
+ *   - output:   `${lawId}-output-${name}`
+ *   - delegate: `${lawId}-delegate-${name}`
+ *   - impl:     `${lawId}-impl-${name}`
+ *
+ * If you change either scheme, update BOTH this file and useLawGraph.js —
+ * the integration test in traceEdges.test.js is the tripwire.
+ */
+
+const HIGHLIGHT_TYPES = new Set([
+  'cross_law_reference',
+  'open_term_resolution',
+  'hook_resolution',
+  'override_resolution',
+]);
+
+const CONTEXT_TYPES = new Set([
+  'article',
+  'action',
+  'requirement',
+  'resolve',
+  'operation',
+  'cached',
+]);
+
+function nodeLabel(node) {
+  switch (node.node_type) {
+    case 'cross_law_reference':
+      return `Cross-law reference: ${node.name}`;
+    case 'open_term_resolution':
+      return `Open term (IoC): ${node.name}`;
+    case 'hook_resolution':
+      return `Hook: ${node.name}`;
+    case 'override_resolution':
+      return `Override: ${node.name}`;
+    case 'article':
+      return `Article ${node.name}`;
+    case 'action':
+      return `Action: ${node.name}`;
+    case 'requirement':
+      return `Requirement: ${node.name}`;
+    case 'resolve':
+      return `Resolve: ${node.name}`;
+    case 'operation':
+      return `Operation: ${node.name}`;
+    case 'cached':
+      return `Cached: ${node.name}`;
+    default:
+      return `${node.node_type}: ${node.name}`;
+  }
+}
+
+/**
+ * Walk the trace tree depth-first, producing a flat list of interesting +
+ * structural steps. Tracks the current law_id as we descend into cross-law
+ * references so that action/resolve steps inside the referenced subtree get
+ * the correct law attribution.
+ */
+export function flattenTraceSteps(root, rootLawId) {
+  const steps = [];
+
+  function walk(node, currentLawId, depth) {
+    const isHighlight = HIGHLIGHT_TYPES.has(node.node_type);
+    const isContext = CONTEXT_TYPES.has(node.node_type);
+
+    if (isHighlight || isContext) {
+      steps.push({
+        label: nodeLabel(node),
+        nodeType: node.node_type,
+        lawId: currentLawId,
+        name: node.name,
+        resolveType: node.resolve_type,
+        result: node.result,
+        message: node.message,
+        durationUs: node.duration_us,
+        depth,
+        edgeIds: [],
+        nodeIds: [],
+      });
+    }
+
+    // For cross-law refs the subtree executes in the referenced law, so we
+    // try to pin the descent lawId from the node name (`targetLaw#output`).
+    let descendLawId = currentLawId;
+    if (node.node_type === 'cross_law_reference') {
+      const hashIdx = node.name.indexOf('#');
+      if (hashIdx > 0) {
+        descendLawId = node.name.substring(0, hashIdx);
+      }
+    }
+
+    const children = node.children ?? [];
+    for (const c of children) {
+      walk(c, descendLawId, depth + 1);
+    }
+  }
+
+  walk(root, rootLawId, 0);
+  return steps;
+}
+
+/**
+ * Parse a trace node name into (targetLaw, localName) when it encodes a
+ * cross-law target. Supports `law#output` and `law:article:lid` shapes.
+ */
+function splitQualifiedName(name) {
+  const hashIdx = name.indexOf('#');
+  if (hashIdx >= 0) {
+    return [name.substring(0, hashIdx), name.substring(hashIdx + 1)];
+  }
+  const colonIdx = name.indexOf(':');
+  if (colonIdx >= 0) {
+    return [name.substring(0, colonIdx), name.substring(colonIdx + 1)];
+  }
+  return [null, name];
+}
+
+/**
+ * Return edge IDs that should light up for the given step.
+ *
+ * For cross-law references the trace node name is typically of the form
+ * `target_law#output_name`; we extract the output name and match on the
+ * source leaf `${sourceLaw}-input-${output}`. Multiple candidate edges all
+ * get highlighted.
+ */
+export function edgeIdsForStep(step, edges) {
+  switch (step.nodeType) {
+    case 'cross_law_reference': {
+      const [targetLaw, outputName] = splitQualifiedName(step.name);
+      const src = `${step.lawId}-input-${outputName}`;
+      return edges
+        .filter((e) => {
+          if (e.source !== src) return false;
+          if (targetLaw && typeof e.target === 'string') {
+            return e.target.startsWith(`${targetLaw}-`);
+          }
+          return true;
+        })
+        .map((e) => e.id);
+    }
+    case 'open_term_resolution': {
+      // name is the open_term id; lawId is the law that implements it.
+      // Edge ID format: `impl:${implLawId}:${art}->${higherLaw}:${openTerm}`
+      return edges
+        .filter(
+          (e) =>
+            e.id.startsWith(`impl:${step.lawId}:`) && e.id.endsWith(`:${step.name}`),
+        )
+        .map((e) => e.id);
+    }
+    case 'hook_resolution': {
+      // The trace node's lawId is the producer law (where the hook fires).
+      // The name is a qualified hook ref like `hookLaw:art`.
+      // Edge ID format: `hook:${hookLaw}:${art}->${producerLaw}:${producerArt}`
+      const hookPrefix = `hook:${step.name}->`;
+      return edges
+        .filter((e) => {
+          if (!e.id.startsWith(hookPrefix)) return false;
+          return e.id.includes(`->${step.lawId}:`);
+        })
+        .map((e) => e.id);
+    }
+    case 'override_resolution': {
+      // Edge ID format: `ovr:${lawA}:${art}->${lawB}:${article}`
+      return edges
+        .filter((e) => e.id.startsWith(`ovr:${step.lawId}:`))
+        .map((e) => e.id);
+    }
+    default:
+      return [];
+  }
+}
+
+/**
+ * Return graph node IDs that should light up for the given step. Matches
+ * trace nodes to leaf nodes (parameter/input/output/delegate/impl) plus
+ * the root law node so users can see which law is executing.
+ */
+export function graphNodeIdsForStep(step, nodes) {
+  const nodeSet = new Set(nodes.map((n) => n.id));
+  const out = [];
+  const add = (id) => {
+    if (id && nodeSet.has(id) && !out.includes(id)) out.push(id);
+  };
+
+  /**
+   * Find any leaf node whose id ends with `-${suffix}-${name}`, regardless
+   * of which law it belongs to. Fallback for hook-actions where the output
+   * lives on a different law than the one firing.
+   */
+  const findLeafByName = (suffix, name) => {
+    const tail = `-${suffix}-${name}`;
+    return nodes.map((n) => n.id).filter((id) => id.endsWith(tail));
+  };
+
+  // Always highlight the current law root so the user can track which law
+  // is executing at every step.
+  add(step.lawId);
+
+  switch (step.nodeType) {
+    case 'article': {
+      // Article name is typically `${lawId} (${output})`; also highlight
+      // the output leaf if the name encodes one.
+      const m = step.name.match(/\(([^)]+)\)/);
+      if (m) {
+        const outName = m[1];
+        add(`${step.lawId}-output-${outName}`);
+        if (!nodeSet.has(`${step.lawId}-output-${outName}`)) {
+          for (const id of findLeafByName('output', outName)) add(id);
+        }
+      }
+      break;
+    }
+    case 'action': {
+      // Action writes to an output. Prefer the current law; fall back to
+      // any law that owns a leaf with the same name (hook-actions write
+      // to outputs defined on the hook's originating law).
+      const primary = `${step.lawId}-output-${step.name}`;
+      if (nodeSet.has(primary)) {
+        add(primary);
+      } else {
+        for (const id of findLeafByName('output', step.name)) add(id);
+      }
+      break;
+    }
+    case 'requirement':
+      // Just the law root — nothing more specific.
+      break;
+    case 'resolve': {
+      const rt = step.resolveType;
+      if (rt === 'PARAMETER') {
+        add(`${step.lawId}-source-${step.name}`);
+      } else if (rt === 'INPUT' || rt === 'RESOLVED_INPUT') {
+        add(`${step.lawId}-input-${step.name}`);
+      } else if (rt === 'OUTPUT' || rt === 'DEFINITION') {
+        const primary = `${step.lawId}-output-${step.name}`;
+        if (nodeSet.has(primary)) {
+          add(primary);
+        } else {
+          for (const id of findLeafByName('output', step.name)) add(id);
+        }
+      } else {
+        // Fall back: any leaf whose suffix matches in the current law
+        for (const suffix of ['source', 'input', 'output']) {
+          const id = `${step.lawId}-${suffix}-${step.name}`;
+          if (nodeSet.has(id)) {
+            add(id);
+            break;
+          }
+        }
+        if (out.length <= 1) {
+          for (const id of findLeafByName('output', step.name)) add(id);
+          for (const id of findLeafByName('input', step.name)) add(id);
+        }
+      }
+      break;
+    }
+    case 'cross_law_reference': {
+      const [targetLaw, outputName] = splitQualifiedName(step.name);
+      add(`${step.lawId}-input-${outputName}`);
+      if (targetLaw) {
+        add(targetLaw);
+        add(`${targetLaw}-output-${outputName}`);
+      }
+      break;
+    }
+    case 'open_term_resolution':
+      add(`${step.lawId}-impl-${step.name}`);
+      add(`${step.lawId}-delegate-${step.name}`);
+      break;
+    case 'hook_resolution': {
+      const [hookLaw] = splitQualifiedName(step.name);
+      if (hookLaw) add(hookLaw);
+      break;
+    }
+    case 'override_resolution':
+      break;
+  }
+
+  return out;
+}

--- a/frontend/src/lib/traceEdges.js
+++ b/frontend/src/lib/traceEdges.js
@@ -23,6 +23,15 @@
  * the integration test in traceEdges.test.js is the tripwire.
  */
 
+/**
+ * Whether a step is rendered when the user has the "Met highlights"
+ * filter on. Centralised here so LawGraphView's nav and TraceStepList's
+ * row filter can't drift apart.
+ */
+export function stepHasHighlights(step) {
+  return step.edgeIds.length > 0 || step.nodeIds.length > 0;
+}
+
 const HIGHLIGHT_TYPES = new Set([
   'cross_law_reference',
   'open_term_resolution',
@@ -161,13 +170,19 @@ export function edgeIdsForStep(step, edges) {
         .map((e) => e.id);
     }
     case 'open_term_resolution': {
-      // name is the open_term id; lawId is the law that implements it.
+      // The step's `name` is the open_term id. `lawId` is ambiguous —
+      // `flattenTraceSteps` only switches `descendLawId` on
+      // cross_law_reference, so an open_term node carries whichever
+      // law was active when the engine emitted it (the higher law that
+      // *declared* the term, not the lower law that *implements* it).
+      // We therefore can't filter by `lawId` here; an
+      // `impl:${implLaw}:...->${higherLaw}:${openTerm}` edge is
+      // identified end-to-end by its `:${openTerm}` suffix. False
+      // positives are bounded: an open_term name is unique per
+      // declaring higher-law in practice.
       // Edge ID format: `impl:${implLawId}:${art}->${higherLaw}:${openTerm}`
       return edges
-        .filter(
-          (e) =>
-            e.id.startsWith(`impl:${step.lawId}:`) && e.id.endsWith(`:${step.name}`),
-        )
+        .filter((e) => e.id.startsWith('impl:') && e.id.endsWith(`:${step.name}`))
         .map((e) => e.id);
     }
     case 'hook_resolution': {
@@ -184,6 +199,11 @@ export function edgeIdsForStep(step, edges) {
     }
     case 'override_resolution': {
       // Edge ID format: `ovr:${lawA}:${art}->${lawB}:${article}`
+      // TODO(PR3): step.name carries the overridden output but goes
+      // unused — when one law overrides multiple outputs all `ovr:`
+      // edges from that law light up simultaneously. A precise match
+      // would also constrain by source/target output name once the
+      // engine starts emitting the output in the trace node.
       return edges
         .filter((e) => e.id.startsWith(`ovr:${step.lawId}:`))
         .map((e) => e.id);

--- a/frontend/src/lib/traceEdges.test.js
+++ b/frontend/src/lib/traceEdges.test.js
@@ -1,0 +1,246 @@
+import { describe, it, expect } from 'vitest';
+import { flattenTraceSteps, edgeIdsForStep, graphNodeIdsForStep } from './traceEdges.js';
+
+/**
+ * Locks the contract between traceEdges and useLawGraph.js. Both files
+ * encode the same edge/node ID formats; if either moves these tests
+ * catch the drift.
+ */
+
+describe('flattenTraceSteps', () => {
+  it('produces a linear depth-indexed list in DFS order', () => {
+    const tree = {
+      node_type: 'article',
+      name: 'wet_A (is_rechthebbende)',
+      children: [
+        {
+          node_type: 'requirement',
+          name: 'leeftijd',
+          children: [
+            { node_type: 'resolve', name: 'leeftijd', resolve_type: 'PARAMETER' },
+          ],
+        },
+        { node_type: 'action', name: 'is_rechthebbende' },
+      ],
+    };
+
+    const steps = flattenTraceSteps(tree, 'wet_A');
+
+    expect(steps.map((s) => [s.depth, s.nodeType])).toEqual([
+      [0, 'article'],
+      [1, 'requirement'],
+      [2, 'resolve'],
+      [1, 'action'],
+    ]);
+    expect(steps[0].lawId).toBe('wet_A');
+  });
+
+  it('switches lawId on cross_law_reference with `targetLaw#output` name', () => {
+    const tree = {
+      node_type: 'article',
+      name: 'wet_A',
+      children: [
+        {
+          node_type: 'cross_law_reference',
+          name: 'wet_B#output_x',
+          children: [
+            { node_type: 'action', name: 'output_x' },
+          ],
+        },
+      ],
+    };
+
+    const steps = flattenTraceSteps(tree, 'wet_A');
+    const action = steps.find((s) => s.nodeType === 'action');
+    expect(action.lawId).toBe('wet_B');
+  });
+
+  it('does not emit steps for unknown node types', () => {
+    const tree = {
+      node_type: 'unknown_type',
+      name: 'anything',
+      children: [{ node_type: 'action', name: 'x' }],
+    };
+    const steps = flattenTraceSteps(tree, 'wet_A');
+    expect(steps.map((s) => s.nodeType)).toEqual(['action']);
+  });
+
+  it('labels nodes with a readable prefix per type', () => {
+    const cases = [
+      ['article', 'art 1', 'Article art 1'],
+      ['action', 'x', 'Action: x'],
+      ['cross_law_reference', 'wet_B#y', 'Cross-law reference: wet_B#y'],
+      ['open_term_resolution', 'term', 'Open term (IoC): term'],
+      ['hook_resolution', 'awb:3:46', 'Hook: awb:3:46'],
+      ['override_resolution', 'out', 'Override: out'],
+    ];
+    for (const [node_type, name, expected] of cases) {
+      const steps = flattenTraceSteps(
+        { node_type, name, children: [] },
+        'wet_A',
+      );
+      expect(steps[0].label).toBe(expected);
+    }
+  });
+});
+
+describe('edgeIdsForStep', () => {
+  const edges = [
+    // cross-law input: wet_A reads output_x from wet_B
+    {
+      id: 'wet_A-input-output_x->wet_B-output-output_x',
+      source: 'wet_A-input-output_x',
+      target: 'wet_B-output-output_x',
+    },
+    // implements: wet_C implements open_term `gezinslid_norm` of wet_A
+    {
+      id: 'impl:wet_C:5:3->wet_A:gezinslid_norm',
+      source: 'wet_C-impl-gezinslid_norm',
+      target: 'wet_A-delegate-gezinslid_norm',
+    },
+    // override: wet_D overrides output_x of wet_A
+    {
+      id: 'ovr:wet_D:2:1->wet_A:3:1',
+      source: 'wet_D-output-output_x',
+      target: 'wet_A-output-output_x',
+    },
+    // hook: awb fires on wet_A producer-article `3:2`
+    {
+      id: 'hook:algemene_wet_bestuursrecht:3:46->wet_A:3:2',
+      source: 'algemene_wet_bestuursrecht-output-termijn',
+      target: 'wet_A-output-x',
+    },
+  ];
+
+  it('matches a cross-law-reference step to its input→output edge', () => {
+    const step = {
+      nodeType: 'cross_law_reference',
+      lawId: 'wet_A',
+      name: 'wet_B#output_x',
+    };
+    expect(edgeIdsForStep(step, edges)).toEqual([
+      'wet_A-input-output_x->wet_B-output-output_x',
+    ]);
+  });
+
+  it('matches an open_term_resolution to its `impl:` edge', () => {
+    const step = {
+      nodeType: 'open_term_resolution',
+      lawId: 'wet_C',
+      name: 'gezinslid_norm',
+    };
+    expect(edgeIdsForStep(step, edges)).toEqual([
+      'impl:wet_C:5:3->wet_A:gezinslid_norm',
+    ]);
+  });
+
+  it('matches an override_resolution to its `ovr:` edge', () => {
+    const step = {
+      nodeType: 'override_resolution',
+      lawId: 'wet_D',
+      name: 'irrelevant',
+    };
+    expect(edgeIdsForStep(step, edges)).toEqual(['ovr:wet_D:2:1->wet_A:3:1']);
+  });
+
+  it('matches a hook_resolution to its `hook:` edge using producer law', () => {
+    const step = {
+      nodeType: 'hook_resolution',
+      // lawId = producer law (trace attribution)
+      lawId: 'wet_A',
+      // name = qualified hook ref `hookLaw:art`
+      name: 'algemene_wet_bestuursrecht:3:46',
+    };
+    expect(edgeIdsForStep(step, edges)).toEqual([
+      'hook:algemene_wet_bestuursrecht:3:46->wet_A:3:2',
+    ]);
+  });
+
+  it('returns [] for non-highlight step types (articles, actions, etc.)', () => {
+    for (const nodeType of ['article', 'action', 'requirement', 'resolve', 'operation', 'cached']) {
+      expect(edgeIdsForStep({ nodeType, lawId: 'wet_A', name: 'x' }, edges)).toEqual([]);
+    }
+  });
+});
+
+describe('graphNodeIdsForStep', () => {
+  const nodes = [
+    { id: 'wet_A' },
+    { id: 'wet_A-source-bsn' },
+    { id: 'wet_A-input-output_x' },
+    { id: 'wet_A-output-is_rechthebbende' },
+    { id: 'wet_A-impl-gezinslid_norm' },
+    { id: 'wet_A-delegate-gezinslid_norm' },
+    { id: 'wet_B' },
+    { id: 'wet_B-output-output_x' },
+  ];
+
+  it('always highlights the step lawId root', () => {
+    const step = { nodeType: 'requirement', lawId: 'wet_A', name: 'x' };
+    expect(graphNodeIdsForStep(step, nodes)).toEqual(['wet_A']);
+  });
+
+  it('resolves PARAMETER resolves to the source leaf', () => {
+    const step = {
+      nodeType: 'resolve',
+      lawId: 'wet_A',
+      name: 'bsn',
+      resolveType: 'PARAMETER',
+    };
+    expect(graphNodeIdsForStep(step, nodes)).toEqual(['wet_A', 'wet_A-source-bsn']);
+  });
+
+  it('resolves INPUT and RESOLVED_INPUT to the input leaf', () => {
+    for (const rt of ['INPUT', 'RESOLVED_INPUT']) {
+      const step = { nodeType: 'resolve', lawId: 'wet_A', name: 'output_x', resolveType: rt };
+      expect(graphNodeIdsForStep(step, nodes)).toContain('wet_A-input-output_x');
+    }
+  });
+
+  it('resolves OUTPUT/DEFINITION to the current law output, else falls back across laws', () => {
+    // Current law owns the leaf
+    let step = { nodeType: 'resolve', lawId: 'wet_A', name: 'is_rechthebbende', resolveType: 'OUTPUT' };
+    expect(graphNodeIdsForStep(step, nodes)).toContain('wet_A-output-is_rechthebbende');
+
+    // Current law does NOT own the output, fallback to any law with it
+    step = { nodeType: 'resolve', lawId: 'wet_A', name: 'output_x', resolveType: 'OUTPUT' };
+    expect(graphNodeIdsForStep(step, nodes)).toContain('wet_B-output-output_x');
+  });
+
+  it('highlights the output leaf (+ fallback) for an action', () => {
+    const step = { nodeType: 'action', lawId: 'wet_A', name: 'is_rechthebbende' };
+    expect(graphNodeIdsForStep(step, nodes)).toContain('wet_A-output-is_rechthebbende');
+  });
+
+  it('highlights the input + target law for a cross_law_reference', () => {
+    const step = {
+      nodeType: 'cross_law_reference',
+      lawId: 'wet_A',
+      name: 'wet_B#output_x',
+    };
+    const ids = graphNodeIdsForStep(step, nodes);
+    expect(ids).toEqual(
+      expect.arrayContaining(['wet_A', 'wet_A-input-output_x', 'wet_B', 'wet_B-output-output_x']),
+    );
+  });
+
+  it('highlights impl + delegate leaves for open_term_resolution', () => {
+    const step = {
+      nodeType: 'open_term_resolution',
+      lawId: 'wet_A',
+      name: 'gezinslid_norm',
+    };
+    expect(graphNodeIdsForStep(step, nodes)).toEqual(
+      expect.arrayContaining(['wet_A-impl-gezinslid_norm', 'wet_A-delegate-gezinslid_norm']),
+    );
+  });
+
+  it('parses an article name like `${law} (${output})` and highlights the output', () => {
+    const step = {
+      nodeType: 'article',
+      lawId: 'wet_A',
+      name: 'wet_A (is_rechthebbende)',
+    };
+    expect(graphNodeIdsForStep(step, nodes)).toContain('wet_A-output-is_rechthebbende');
+  });
+});

--- a/frontend/src/lib/traceEdges.test.js
+++ b/frontend/src/lib/traceEdges.test.js
@@ -123,10 +123,25 @@ describe('edgeIdsForStep', () => {
     ]);
   });
 
-  it('matches an open_term_resolution to its `impl:` edge', () => {
+  // open_term_resolution: step.lawId is ambiguous — flattenTraceSteps
+  // doesn't switch descendLawId on this node type, so the engine emits
+  // it under whichever law is currently active (typically the higher
+  // declaring law, e.g. wet_A). The matcher must work for either id.
+  it('matches an open_term_resolution edge regardless of step.lawId (higher law)', () => {
     const step = {
       nodeType: 'open_term_resolution',
-      lawId: 'wet_C',
+      lawId: 'wet_A', // higher / declaring law
+      name: 'gezinslid_norm',
+    };
+    expect(edgeIdsForStep(step, edges)).toEqual([
+      'impl:wet_C:5:3->wet_A:gezinslid_norm',
+    ]);
+  });
+
+  it('matches an open_term_resolution edge regardless of step.lawId (impl law)', () => {
+    const step = {
+      nodeType: 'open_term_resolution',
+      lawId: 'wet_C', // implementing law
       name: 'gezinslid_norm',
     };
     expect(edgeIdsForStep(step, edges)).toEqual([
@@ -164,13 +179,17 @@ describe('edgeIdsForStep', () => {
 });
 
 describe('graphNodeIdsForStep', () => {
+  // Realistic IoC topology: wet_A declares the open term (so it owns
+  // the `delegate-` leaf), wet_C implements it (so it owns the
+  // `impl-` leaf). useLawGraph never puts both leaves on the same law.
   const nodes = [
     { id: 'wet_A' },
     { id: 'wet_A-source-bsn' },
     { id: 'wet_A-input-output_x' },
     { id: 'wet_A-output-is_rechthebbende' },
-    { id: 'wet_A-impl-gezinslid_norm' },
     { id: 'wet_A-delegate-gezinslid_norm' },
+    { id: 'wet_C' },
+    { id: 'wet_C-impl-gezinslid_norm' },
     { id: 'wet_B' },
     { id: 'wet_B-output-output_x' },
   ];
@@ -224,15 +243,30 @@ describe('graphNodeIdsForStep', () => {
     );
   });
 
-  it('highlights impl + delegate leaves for open_term_resolution', () => {
+  // graphNodeIdsForStep is intentionally defensive against the same
+  // step.lawId ambiguity that edgeIdsForStep handles: only one of the
+  // two leaves exists per law in any real graph, so trying both
+  // candidate ids and letting `nodeSet.has` filter is correct.
+  it('highlights the delegate leaf when step.lawId is the higher law', () => {
     const step = {
       nodeType: 'open_term_resolution',
       lawId: 'wet_A',
       name: 'gezinslid_norm',
     };
-    expect(graphNodeIdsForStep(step, nodes)).toEqual(
-      expect.arrayContaining(['wet_A-impl-gezinslid_norm', 'wet_A-delegate-gezinslid_norm']),
-    );
+    const ids = graphNodeIdsForStep(step, nodes);
+    expect(ids).toContain('wet_A-delegate-gezinslid_norm');
+    expect(ids).not.toContain('wet_A-impl-gezinslid_norm'); // no such leaf on wet_A
+  });
+
+  it('highlights the impl leaf when step.lawId is the implementing law', () => {
+    const step = {
+      nodeType: 'open_term_resolution',
+      lawId: 'wet_C',
+      name: 'gezinslid_norm',
+    };
+    const ids = graphNodeIdsForStep(step, nodes);
+    expect(ids).toContain('wet_C-impl-gezinslid_norm');
+    expect(ids).not.toContain('wet_C-delegate-gezinslid_norm'); // no such leaf on wet_C
   });
 
   it('parses an article name like `${law} (${output})` and highlights the output', () => {


### PR DESCRIPTION
## Summary

Follow-up to #579. After a scenario runs, the Wettengraaf pane now **visualises the engine's execution trace**: each PathNode becomes a step the user can walk through with Vorige/Volgende, and the active node + edge pulse amber while already-visited ones stay dimly highlighted. The scenario's entry point gets a sticky blue "▶ start" marker.

## Rollout

| PR | Status |
|----|--------|
| #579 PR1 — graph rendering + click highlighting | ✅ merged |
| **This PR (PR2)** — trace stepping + highlights | pending |
| PR3 — polish (boom-view toggle, assertion bar, perf, filter UX) | pending |

## What's in

**New files:**
- `frontend/src/lib/traceEdges.js` + `traceEdges.test.js` (17 cases) — framework-agnostic port of the demo's `traceEdges.ts`. Flattens a PathNode tree into Steps and resolves each Step to edge / node IDs (`impl:`, `ovr:`, `hook:`, cross-law input). The test file locks the edge-ID format contract with `useLawGraph.js`.
- `frontend/src/composables/useTraceStepping.js` — consumes `{result, nodes, edges, rootLawId, outputName}`, exposes `{steps, currentStepIdx, next/prev/goto, startNodeIds, active* / visited*}`. Trace enrichment runs once per (result, graph) change; stepping is O(1).
- `frontend/src/components/graph/TraceStepList.vue` — scrollable depth-indented step list, "Met highlights" / "Alles" filter, auto-scrolls the active step into view.
- `frontend/src/components/graph/TraceStepDetail.vue` — step card (law / resolve / result / duration / message) + outputs + assertion pass/fail.

**Modified:**
- `ScenarioForm.vue` + `ScenarioBuilder.vue` — forward `outputName` on the `@executed` event so the graph can pin its start marker.
- `LawGraphView.vue` — composes `useTraceStepping`, stacks trace classes on `visibleNodes` / `visibleEdges` (preserves PR1's inbound/outbound click highlight), mounts the step list + detail below the graph when a trace is present.
- `EditorApp.vue` — plumbs `lastOutputName` into the graph pane props.
- `graph-styles.css` — `.trace-active` (pulsing amber), `.trace-visited` (faded amber), `.trace-start` (dashed blue outline + "▶ start" badge) + node-type chip colours for the step list.

## Scope boundaries

Deliberately **not** in this PR (deferred to PR3):
- "Stappen" vs "Boom" box-drawing toggle (reusing the engine's `trace_text`)
- Assertion pass/fail summary bar above the graph
- Perf sweep for corpus laws with ≥30 transitive deps
- elkjs layout fallback

Also not porting: the demo's bekendmaking second-run flow (leenstelsel-specific).

## Test plan

- [ ] `npm test` frontend — 114 passing (97 pre-existing + 17 new traceEdges cases)
- [ ] `npm run build` clean
- [ ] Enable "Wettengraaf" in the account-menu
- [ ] Open a law with cross-law refs (e.g. `wet_op_de_zorgtoeslag/2025-01-01`) and a scenario
- [ ] Run a scenario; graph pane shows: root law + start leaf marked ▶ blue dashed
- [ ] Step list appears under the graph; click a step → matching nodes/edges light up amber
- [ ] Vorige/Volgende walks the list; auto-scrolls active into view
- [ ] Filter "Met highlights" hides no-op steps; "Alles" shows all
- [ ] ZAD preview deploy: verify `deploy-preview` passes