### PR TITLE
feat(editor): markdown-backed editable Tekst panel

### DIFF
--- a/docs/rfcs/rfc-010.md
+++ b/docs/rfcs/rfc-010.md
@@ -263,15 +263,64 @@ corpus-registry.yaml
 
 #### Write path (editor)
 
-The editor can write directly to a GitHub repo via the GitHub Contents API, without a backend intermediary.
+> **Amended after implementation (Phase 6).** The original sketch had the
+> editor speak the GitHub Contents API directly from the browser. We
+> reversed that decision and route writes through `editor-api`. The
+> tradeoffs below explain why.
+
+`editor-api` mediates every write. The frontend does not know which
+GitHub repo backs a given law — it just calls
+`PUT /api/corpus/laws/{law_id}` and the backend resolves the source
+from the in-memory `SourceMap`, looks up the per-source token from the
+existing auth config (env var or `corpus-auth.yaml`), and pushes /
+opens the PR upstream.
 
 Flow:
-1. User edits YAML in the editor
-2. Preview and validation against the schema
-3. Commit via `PUT /repos/{owner}/{repo}/contents/{path}` using the GitHub token from the browser
-4. Branch management: the editor works on a feature branch and can create a PR via the GitHub API (`POST /repos/{owner}/{repo}/pulls`)
+1. User edits YAML in the editor.
+2. Preview and validation against the schema.
+3. The frontend sends `PUT /api/corpus/laws/{law_id}` (or
+   `/scenarios/{filename}` for scenario edits) with an
+   `X-Editor-Session: <uuid>` header. The UUID is minted in
+   `sessionStorage` on first use and is stable for the browser tab.
+4. `editor-api` looks up the law's source. For a GitHub source it
+   resolves (or lazily creates) a `SessionGitBackend` keyed on
+   `(session_id, source_id)`. For a local source it falls through to
+   the existing local-write path so the dev loop is unchanged.
+5. The session backend writes the file into its working clone, calls
+   `commit_and_push_to_branch` (always rebases on the source's
+   configured branch, then fast-forward pushes the session branch
+   `editor/session-<uuid>`), and finally `ensure_pr` against the source
+   repo's Pulls API. Subsequent saves in the same session add commits
+   to the same branch and reuse the same PR.
+6. The save response is JSON `{ pr: { url, number, branch } | null }`.
+   The editor surfaces a "PR #N" link in the toolbar that stays visible
+   for the rest of the session.
 
-This makes the editor a full YAML editor for municipalities (*gemeenten*): edit, validate, commit, create PR, without needing a local development environment.
+**Identity / attribution.** Commits are authored by a service identity
+(the bot configured for the corpus push token). The human editor is
+credited via a `Co-Authored-By: <name> <email>` trailer on every
+commit, sourced from the OIDC session (`person_name`, `person_email`).
+The PR body also names the submitter. We do not ask the editor user to
+paste a personal GitHub PAT — that path is closed by this amendment.
+
+**Branch scope.** One PR per editor session. Closing the browser tab
+purges `sessionStorage`; the next visit gets a new UUID and a new PR.
+Two tabs in the same browser get two independent PRs. The branch
+name (`editor/session-<uuid>`) is stable for the lifetime of that
+session so multiple saves accumulate on one PR until merged or closed.
+
+**Read-only sources.** A GitHub source with no token configured is
+write-disabled: the save returns `403 Forbidden` with a
+"source is not configured for write-back" message. We deliberately do
+not silently degrade to a local-only commit (the user would think the
+edit reached upstream).
+
+**Why backend-mediated.** The frontend stays ignorant of which repos
+sit behind the corpus, the per-source tokens never leave the server,
+and a single integration point (the `RepoBackend` trait) handles both
+the harvester's bulk writes and the editor's interactive writes. Cost:
+each editor pod needs the per-source push tokens it would have lived
+without in the browser-direct model.
 
 #### Admin API
 
@@ -342,7 +391,12 @@ Add `/api/sources`, `/api/corpus/laws`, and `/api/sources/{id}/sync` endpoints t
 Source picker, source badge per law, and direct GitHub access from the editor (via the GitHub API, not via the admin backend).
 
 **Phase 6 - Editor writing**
-Commit via GitHub Contents API, branch management, and PR creation from the editor.
+Implemented backend-mediated (see "Write path (editor)" amendment above):
+`SessionGitBackend` per `(editor session, source)` pushes to
+`editor/session-<uuid>` and ensures a PR via the GitHub Pulls API.
+Service-identity commits with `Co-Authored-By` trailer for the OIDC
+user. The browser-direct Contents API approach the original sketch
+described was dropped during implementation.
 
 **Phase 7 - Validation and polish**
 Scope validation, schema version compatibility checks, collision reporting, and edge case handling.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,12 +11,16 @@
         "@cucumber/gherkin": "^39.0.0",
         "@cucumber/messages": "^32.3.1",
         "@minbzk/storybook": "^0.8.35",
+        "@tiptap/core": "^3.22.4",
+        "@tiptap/starter-kit": "^3.22.4",
+        "@tiptap/vue-3": "^3.22.4",
         "@vue-flow/background": "^1.3.2",
         "@vue-flow/controls": "^1.1.3",
         "@vue-flow/core": "^1.48.2",
         "@vue-flow/minimap": "^1.5.4",
         "dompurify": "^3.4.1",
-        "marked": "^18.0.2"
+        "marked": "^18.0.2",
+        "tiptap-markdown": "^0.9.0"
       },
       "devDependencies": {
         "@playwright/test": "^1.59.1",
@@ -916,6 +920,427 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tiptap/core": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.22.4.tgz",
+      "integrity": "sha512-vGIGm/HpqLg8EAAQXQ+koV+/S828OEpzocfWcPOwo1u2QUVf9dQG47Yy6JJ8zFFaJwfv4dBcOXli+7BrJwsxDQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/pm": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-blockquote": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.22.4.tgz",
+      "integrity": "sha512-7/61kNPbGFhMgM//zMknD0pSb69rGdRIkpulXOWS1JBrFHkH6hjZDfrOETNzgKkO+NlmzVl9rXSTv0xauS3lzA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-bold": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-3.22.4.tgz",
+      "integrity": "sha512-jIaPKfNOQu2lhpbLDvtwlQqM+mjF+Kk+auHpzYjBnsuwUli1Cl5ZOau7RH+rru/SQvZe1DtpQlANujDywugZAA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-bubble-menu": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.22.4.tgz",
+      "integrity": "sha512-v4pux5Ql3THAEjaLMY4ldtdy/Xy2qU7PJLBkq8ugLp8qicaKC+tpqxp6sGif4vLIjz7Ap5hurRbTNbXzszyyHA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4",
+        "@tiptap/pm": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-bullet-list": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.22.4.tgz",
+      "integrity": "sha512-TB+d3fGcTixYjO7coKqTr1mGTJuqr8hjDCPUFgzuvKyJnBhqWITmBzQ/8CLq4rr6mihgGURbD3N+xkQuPAKFiw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-code": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-3.22.4.tgz",
+      "integrity": "sha512-cnbxmVhAcc7X3G81QUYEmKP0ve2hRmvAiFXBuuv9RUtQlBiRnzmhHoJOMgkX0CsMR7+8kMRpTfeDUYq2xp5s5w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-code-block": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.22.4.tgz",
+      "integrity": "sha512-MEurzNXfMET3rhjpoPJYUgMfxTdTqbzT9+ToFrqNGAHocdXVm6m1hhO2frVC7fEtHPnxXKsn0Z3NUbCRkRTLuA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4",
+        "@tiptap/pm": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-document": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.22.4.tgz",
+      "integrity": "sha512-XQKla1+703FqQJC48tPDVgt9ucGiFbIEmQdOg5L5o07z9a6/NzuaZAc+1zJ7NxcUZzy+z6wBn1PrVMTiqiSXlw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-dropcursor": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-3.22.4.tgz",
+      "integrity": "sha512-N9/yMDC35jJp0V/naL0+6gi4gUDUIcPpWEzFdCDWUSYBA8mt41c1kI1ZU7UTKYIBzTClenhYHRc2XKZxxx0+LQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-floating-menu": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-3.22.4.tgz",
+      "integrity": "sha512-DFuyYxgaZPgxum5z1yvJPbfYCvDdO8geXsdyqt0qYYdiat3aGE4ncJhiLRIFDhSHBhaZg5eCgu/YPYAN6jZnrA==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@floating-ui/dom": "^1.0.0",
+        "@tiptap/core": "3.22.4",
+        "@tiptap/pm": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-gapcursor": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-3.22.4.tgz",
+      "integrity": "sha512-UYBEUj3SFpKINIE7AdzcyeS3xICK+ee+YLBbuqNXyHStYChjJOohzJehqiqhjR16A88KQQ+ZjgyDcItKGygSog==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-hard-break": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.22.4.tgz",
+      "integrity": "sha512-xq+a4dE7T6VwApCkh/yU3p30gn3F8g8Arb9CyEZm58/WIJUIGvHSTjDdHmvU16+kiWSBg+wOOsaFHhYjJjxcKA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-heading": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-3.22.4.tgz",
+      "integrity": "sha512-TUaj5f0Ir5qy9HKKt2ocnwfXKpZDYeHgbbP9gshKFzdq5PLe1RbIgkjfy6bnoI865cYjmPYWRjcT7XsKyIcb9Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-horizontal-rule": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.22.4.tgz",
+      "integrity": "sha512-cCI1HekGQwhY/MbgaKQ0R/7HcH5ZM1oFAyI/J72QGLC0XnF403S/OXoHMuBWr1mCu8hNiQWCzeNRJUty0iytNw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4",
+        "@tiptap/pm": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-italic": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-3.22.4.tgz",
+      "integrity": "sha512-fVSDx5AYXgDI3v2zZIqb7V8EewthwM2NJ/ZCX+XaxRsqNEpnjVhgHs7UlvDqK1wj2OJ6zmUNjPtVlAFRxwT+HQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-link": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.22.4.tgz",
+      "integrity": "sha512-uoP3yus02uwGPVzW2QaEPJWVIrUb/r5nKm6c8DiJv9fNSX1+gykZZMg42c6GwRFLZ/vyfWjVCbAE03VMUqafgA==",
+      "license": "MIT",
+      "dependencies": {
+        "linkifyjs": "^4.3.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4",
+        "@tiptap/pm": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-list": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.22.4.tgz",
+      "integrity": "sha512-Xe8UFvvHmyp/c/TJsFwlwU9CWACYbBirNsluJ3U1+H8BTu1wqdrT/AXR5uIXeyCl5kiWKgX5q71eHWbYFOrqrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4",
+        "@tiptap/pm": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-list-item": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-3.22.4.tgz",
+      "integrity": "sha512-H659KXTvggSypIDWSOJBZ37jh9pKjQriDDvYPYvOZCdfij0D0hsDXN/wXoypArneUkoBdgruHfTtMkFOaQlgkw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-list-keymap": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-keymap/-/extension-list-keymap-3.22.4.tgz",
+      "integrity": "sha512-t/zhker4oIS78AIGYDdFFfZC6zSBlszfD7z/zqFLGCg5PHNNgkZK5hKj6Vyix6D2SapRn/ajnx+8mhbKIUH5eA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-ordered-list": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.22.4.tgz",
+      "integrity": "sha512-w77hPVf7pcHt97vfrybg/l0t5CimCd4y75OJKuHuo3CfgM5xbUP/gaPNMDyLLe7MYole/UHi/XvG3XjgzqTzAw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-paragraph": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.22.4.tgz",
+      "integrity": "sha512-de6dFkIhigiENESY6rNJ3yTVS/337ybfP30dNPudTwGe9oAu9ZCS+04j6QCvXSjhlI3ULiv7wiSHqrP26Gd+Hw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-strike": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-3.22.4.tgz",
+      "integrity": "sha512-aRHWQj42HiailXSC9LkKYM3jWMcSeGwOjbqM4PiuxQZmHVDRFmeHkfJItOdn2cSHaO0vuEVK+TvrWUWsBFi3pg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-text": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.22.4.tgz",
+      "integrity": "sha512-mM69uUW5cSxIhyEpWXi/YcfyupcJMDLCPEfYi62awH0iOP/LRoCv/nHjJq4Hyj/KxRJbe8HKwIUnqaCUf7m5Pg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-underline": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.22.4.tgz",
+      "integrity": "sha512-08kGdbhIrA6h10GWXqOkqIveaBj5tmxclK208/nUIAlonI9hPd739vu7fmVtpnmqCnSSNpoRtU4u6Gj5at0ZpA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extensions": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.22.4.tgz",
+      "integrity": "sha512-fOe8VptJvLPs32bNdUYo8SRyljwqKNQVXWW056VoXIc5en/59OdJlJQVeHI0jRRciH3MtrqODi/gfJR0VHNZ8A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4",
+        "@tiptap/pm": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/pm": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.22.4.tgz",
+      "integrity": "sha512-hj8Qka6WcHRllHUdeSjDnq2XaisUo4KsoGJc1WcFpoa1Yd+OeD861zUMnV7DFVGdZRy45Obht0CUYJpXQ4yA4w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-changeset": "^2.3.0",
+        "prosemirror-commands": "^1.6.2",
+        "prosemirror-dropcursor": "^1.8.1",
+        "prosemirror-gapcursor": "^1.3.2",
+        "prosemirror-history": "^1.4.1",
+        "prosemirror-keymap": "^1.2.2",
+        "prosemirror-model": "^1.24.1",
+        "prosemirror-schema-list": "^1.5.0",
+        "prosemirror-state": "^1.4.3",
+        "prosemirror-tables": "^1.6.4",
+        "prosemirror-transform": "^1.10.2",
+        "prosemirror-view": "^1.38.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
+    "node_modules/@tiptap/starter-kit": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.22.4.tgz",
+      "integrity": "sha512-qWjw+vfdin1rzMRpRU4cC5tLTwMJtUpXeQukv+6mOqqvhptuwuZBjUHImVEJaSPoHXS7+1ut+nTnrLyWyEuE5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@tiptap/core": "^3.22.4",
+        "@tiptap/extension-blockquote": "^3.22.4",
+        "@tiptap/extension-bold": "^3.22.4",
+        "@tiptap/extension-bullet-list": "^3.22.4",
+        "@tiptap/extension-code": "^3.22.4",
+        "@tiptap/extension-code-block": "^3.22.4",
+        "@tiptap/extension-document": "^3.22.4",
+        "@tiptap/extension-dropcursor": "^3.22.4",
+        "@tiptap/extension-gapcursor": "^3.22.4",
+        "@tiptap/extension-hard-break": "^3.22.4",
+        "@tiptap/extension-heading": "^3.22.4",
+        "@tiptap/extension-horizontal-rule": "^3.22.4",
+        "@tiptap/extension-italic": "^3.22.4",
+        "@tiptap/extension-link": "^3.22.4",
+        "@tiptap/extension-list": "^3.22.4",
+        "@tiptap/extension-list-item": "^3.22.4",
+        "@tiptap/extension-list-keymap": "^3.22.4",
+        "@tiptap/extension-ordered-list": "^3.22.4",
+        "@tiptap/extension-paragraph": "^3.22.4",
+        "@tiptap/extension-strike": "^3.22.4",
+        "@tiptap/extension-text": "^3.22.4",
+        "@tiptap/extension-underline": "^3.22.4",
+        "@tiptap/extensions": "^3.22.4",
+        "@tiptap/pm": "^3.22.4"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
+    "node_modules/@tiptap/vue-3": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/vue-3/-/vue-3-3.22.4.tgz",
+      "integrity": "sha512-fcqUWt6LlA5PbcFaDXyV1apWwAs8j80m0kWwoL5+DgKdkGxsB5LgDZU1pTWle0zvR5zmGvJ7LmB6EGAYIBjdmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "optionalDependencies": {
+        "@tiptap/extension-bubble-menu": "^3.22.4",
+        "@tiptap/extension-floating-menu": "^3.22.4"
+      },
+      "peerDependencies": {
+        "@floating-ui/dom": "^1.0.0",
+        "@tiptap/core": "3.22.4",
+        "@tiptap/pm": "3.22.4",
+        "vue": "^3.0.0"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -950,6 +1375,28 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.5.tgz",
+      "integrity": "sha512-yg6E+u0/+Zjva+buc3EIb+29XEg4wltq7cSmd4Uc2EE/1nUVmxyzpX6gUXD0V8jIrG0r7YeOGVIbYRkxeooCtw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "13.0.9",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-13.0.9.tgz",
+      "integrity": "sha512-1XPwR0+MgXLWfTn9gCsZ55AHOKW1WN+P9vr0PaQh5aerR9LLQXUbjfEAFhjmEmyoYFWAyuN2Mqkn40MZ4ukjBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^3",
+        "@types/mdurl": "^1"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.5.tgz",
+      "integrity": "sha512-6L6VymKTzYSrEf4Nev4Xa1LCHKrlTlYCBMTlQKFuddo1CvQcE52I0mwfOJayueUC7MJuXOeHTcIU683lzd0cUA==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -1503,7 +1950,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/assertion-error": {
@@ -2391,6 +2837,21 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
+    "node_modules/linkifyjs": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.2.tgz",
+      "integrity": "sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==",
+      "license": "MIT"
+    },
     "node_modules/lit": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
@@ -2472,6 +2933,41 @@
         "url": "https://github.com/sponsors/sxzz"
       }
     },
+    "node_modules/markdown-it": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it-task-lists": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it-task-lists/-/markdown-it-task-lists-2.1.1.tgz",
+      "integrity": "sha512-TxFAc76Jnhb2OUu+n3yz9RMu4CwGfaT788br6HhEDlvWfdeJcLUsxk1Hgw2yJio0OXsxv7pyIPmvECY7bMbluA==",
+      "license": "ISC"
+    },
+    "node_modules/markdown-it/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/marked": {
       "version": "18.0.2",
       "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.2.tgz",
@@ -2483,6 +2979,12 @@
       "engines": {
         "node": ">= 20"
       }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "license": "MIT"
     },
     "node_modules/minimatch": {
       "version": "9.0.9",
@@ -2599,6 +3101,12 @@
         "https://github.com/sponsors/sxzz",
         "https://opencollective.com/debug"
       ],
+      "license": "MIT"
+    },
+    "node_modules/orderedmap": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
+      "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
       "license": "MIT"
     },
     "node_modules/package-json-from-dist": {
@@ -2755,12 +3263,183 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prosemirror-changeset": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.4.1.tgz",
+      "integrity": "sha512-96WBLhOaYhJ+kPhLg3uW359Tz6I/MfcrQfL4EGv4SrcqKEMC1gmoGrXHecPE8eOwTVCJ4IwgfzM8fFad25wNfw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-commands": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.7.1.tgz",
+      "integrity": "sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.10.2"
+      }
+    },
+    "node_modules/prosemirror-dropcursor": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.8.2.tgz",
+      "integrity": "sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0",
+        "prosemirror-view": "^1.1.0"
+      }
+    },
+    "node_modules/prosemirror-gapcursor": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.4.1.tgz",
+      "integrity": "sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.0.0",
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-view": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-history": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.5.0.tgz",
+      "integrity": "sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.2.2",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.31.0",
+        "rope-sequence": "^1.3.0"
+      }
+    },
+    "node_modules/prosemirror-keymap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.3.tgz",
+      "integrity": "sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "w3c-keyname": "^2.2.0"
+      }
+    },
+    "node_modules/prosemirror-markdown": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-markdown/-/prosemirror-markdown-1.13.4.tgz",
+      "integrity": "sha512-D98dm4cQ3Hs6EmjK500TdAOew4Z03EV71ajEFiWra3Upr7diytJsjF4mPV2dW+eK5uNectiRj0xFxYI9NLXDbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/markdown-it": "^14.0.0",
+        "markdown-it": "^14.0.0",
+        "prosemirror-model": "^1.25.0"
+      }
+    },
+    "node_modules/prosemirror-markdown/node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "license": "MIT"
+    },
+    "node_modules/prosemirror-markdown/node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/prosemirror-markdown/node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "license": "MIT"
+    },
+    "node_modules/prosemirror-model": {
+      "version": "1.25.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
+      "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
+      "license": "MIT",
+      "dependencies": {
+        "orderedmap": "^2.0.0"
+      }
+    },
+    "node_modules/prosemirror-schema-list": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.5.1.tgz",
+      "integrity": "sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.7.3"
+      }
+    },
+    "node_modules/prosemirror-state": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
+      "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.27.0"
+      }
+    },
+    "node_modules/prosemirror-tables": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.8.5.tgz",
+      "integrity": "sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.2.3",
+        "prosemirror-model": "^1.25.4",
+        "prosemirror-state": "^1.4.4",
+        "prosemirror-transform": "^1.10.5",
+        "prosemirror-view": "^1.41.4"
+      }
+    },
+    "node_modules/prosemirror-transform": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.12.0.tgz",
+      "integrity": "sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.21.0"
+      }
+    },
+    "node_modules/prosemirror-view": {
+      "version": "1.41.8",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.8.tgz",
+      "integrity": "sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.20.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0"
+      }
+    },
     "node_modules/proto-list": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
       "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/quansync": {
       "version": "0.2.11",
@@ -2837,6 +3516,12 @@
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
       "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rope-sequence": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
+      "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
       "license": "MIT"
     },
     "node_modules/sass": {
@@ -3093,6 +3778,24 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tiptap-markdown": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/tiptap-markdown/-/tiptap-markdown-0.9.0.tgz",
+      "integrity": "sha512-dKLQ9iiuGNgrlGVjrNauF/UBzWu4LYOx5pkD0jNkmQt/GOwfCJsBuzZTsf1jZ204ANHOm572mZ9PYvGh1S7tpQ==",
+      "license": "MIT",
+      "workspaces": [
+        "example"
+      ],
+      "dependencies": {
+        "@types/markdown-it": "^13.0.7",
+        "markdown-it": "^14.1.0",
+        "markdown-it-task-lists": "^2.1.1",
+        "prosemirror-markdown": "^1.11.1"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.0.1"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -3100,6 +3803,12 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
     },
     "node_modules/ufo": {
       "version": "1.6.3",
@@ -3418,6 +4127,12 @@
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     },
     "node_modules/webpack-virtual-modules": {
       "version": "0.6.2",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,12 +11,16 @@
         "@cucumber/gherkin": "^39.1.0",
         "@cucumber/messages": "^32.3.1",
         "@nldd/design-system": "^0.8.41",
+        "@tiptap/core": "^3.22.4",
+        "@tiptap/starter-kit": "^3.22.4",
+        "@tiptap/vue-3": "^3.22.4",
         "@vue-flow/background": "^1.3.2",
         "@vue-flow/controls": "^1.1.3",
         "@vue-flow/core": "^1.48.2",
         "@vue-flow/minimap": "^1.5.4",
         "dompurify": "^3.4.2",
-        "marked": "^18.0.3"
+        "marked": "^18.0.3",
+        "tiptap-markdown": "^0.9.0"
       },
       "devDependencies": {
         "@playwright/test": "^1.59.1",
@@ -32,6 +36,8 @@
     },
     "node_modules/@babel/generator": {
       "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -47,6 +53,8 @@
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -54,6 +62,8 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -76,6 +86,8 @@
     },
     "node_modules/@babel/types": {
       "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -96,6 +108,8 @@
     },
     "node_modules/@cucumber/messages": {
       "version": "32.3.1",
+      "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-32.3.1.tgz",
+      "integrity": "sha512-yNQq1KoXRYaEKrWMFmpUQX7TdeQuU9jeGgJAZ3dArTsC/T4NpJ6DnqaJIIgwPnz/wtQIQTNX7/h0rOuF5xY4qQ==",
       "license": "MIT",
       "dependencies": {
         "class-transformer": "0.5.1",
@@ -138,6 +152,8 @@
     },
     "node_modules/@floating-ui/core": {
       "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/utils": "^0.2.11"
@@ -145,6 +161,8 @@
     },
     "node_modules/@floating-ui/dom": {
       "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/core": "^1.7.5",
@@ -153,10 +171,14 @@
     },
     "node_modules/@floating-ui/utils": {
       "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
     },
     "node_modules/@fontsource/fira-sans": {
       "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@fontsource/fira-sans/-/fira-sans-5.2.7.tgz",
+      "integrity": "sha512-5DE4AealD/VnbwdzMgnpWfCttMQBbteNiK9DCJE7cVwZEbDTPLUoFDMMvxNQ498nZc5in7Mta9c/s+3Ehh0BAg==",
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"
@@ -164,6 +186,8 @@
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -180,6 +204,8 @@
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -189,6 +215,8 @@
     },
     "node_modules/@jridgewell/remapping": {
       "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -198,6 +226,8 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -206,10 +236,14 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -219,10 +253,14 @@
     },
     "node_modules/@lit-labs/ssr-dom-shim": {
       "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@lit/reactive-element": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.5.0"
@@ -264,6 +302,8 @@
     },
     "node_modules/@one-ini/wasm": {
       "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
+      "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==",
       "dev": true,
       "license": "MIT"
     },
@@ -279,6 +319,8 @@
     },
     "node_modules/@parcel/watcher": {
       "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
+      "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -333,6 +375,8 @@
     },
     "node_modules/@parcel/watcher-darwin-arm64": {
       "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
+      "integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
       "cpu": [
         "arm64"
       ],
@@ -571,6 +615,8 @@
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -580,6 +626,8 @@
     },
     "node_modules/@playwright/test": {
       "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -594,6 +642,8 @@
     },
     "node_modules/@rijkshuisstijl-community/font": {
       "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rijkshuisstijl-community/font/-/font-1.1.3.tgz",
+      "integrity": "sha512-JJhvg6cWpxaFN1UEAwqKMVTh5Tg/Y0DgNAQ4b0PmLzbvogO7CpmO8KJrG8S0sAKQvFvaM8/hOYKtcgDIKlBcIA==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@fontsource/fira-sans": "5.2.7",
@@ -859,13 +909,438 @@
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.13.tgz",
+      "integrity": "sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@tiptap/core": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.22.4.tgz",
+      "integrity": "sha512-vGIGm/HpqLg8EAAQXQ+koV+/S828OEpzocfWcPOwo1u2QUVf9dQG47Yy6JJ8zFFaJwfv4dBcOXli+7BrJwsxDQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/pm": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-blockquote": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.22.4.tgz",
+      "integrity": "sha512-7/61kNPbGFhMgM//zMknD0pSb69rGdRIkpulXOWS1JBrFHkH6hjZDfrOETNzgKkO+NlmzVl9rXSTv0xauS3lzA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-bold": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-3.22.4.tgz",
+      "integrity": "sha512-jIaPKfNOQu2lhpbLDvtwlQqM+mjF+Kk+auHpzYjBnsuwUli1Cl5ZOau7RH+rru/SQvZe1DtpQlANujDywugZAA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-bubble-menu": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.22.4.tgz",
+      "integrity": "sha512-v4pux5Ql3THAEjaLMY4ldtdy/Xy2qU7PJLBkq8ugLp8qicaKC+tpqxp6sGif4vLIjz7Ap5hurRbTNbXzszyyHA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4",
+        "@tiptap/pm": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-bullet-list": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.22.4.tgz",
+      "integrity": "sha512-TB+d3fGcTixYjO7coKqTr1mGTJuqr8hjDCPUFgzuvKyJnBhqWITmBzQ/8CLq4rr6mihgGURbD3N+xkQuPAKFiw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-code": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-3.22.4.tgz",
+      "integrity": "sha512-cnbxmVhAcc7X3G81QUYEmKP0ve2hRmvAiFXBuuv9RUtQlBiRnzmhHoJOMgkX0CsMR7+8kMRpTfeDUYq2xp5s5w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-code-block": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.22.4.tgz",
+      "integrity": "sha512-MEurzNXfMET3rhjpoPJYUgMfxTdTqbzT9+ToFrqNGAHocdXVm6m1hhO2frVC7fEtHPnxXKsn0Z3NUbCRkRTLuA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4",
+        "@tiptap/pm": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-document": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.22.4.tgz",
+      "integrity": "sha512-XQKla1+703FqQJC48tPDVgt9ucGiFbIEmQdOg5L5o07z9a6/NzuaZAc+1zJ7NxcUZzy+z6wBn1PrVMTiqiSXlw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-dropcursor": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-3.22.4.tgz",
+      "integrity": "sha512-N9/yMDC35jJp0V/naL0+6gi4gUDUIcPpWEzFdCDWUSYBA8mt41c1kI1ZU7UTKYIBzTClenhYHRc2XKZxxx0+LQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-floating-menu": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-3.22.4.tgz",
+      "integrity": "sha512-DFuyYxgaZPgxum5z1yvJPbfYCvDdO8geXsdyqt0qYYdiat3aGE4ncJhiLRIFDhSHBhaZg5eCgu/YPYAN6jZnrA==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@floating-ui/dom": "^1.0.0",
+        "@tiptap/core": "3.22.4",
+        "@tiptap/pm": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-gapcursor": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-3.22.4.tgz",
+      "integrity": "sha512-UYBEUj3SFpKINIE7AdzcyeS3xICK+ee+YLBbuqNXyHStYChjJOohzJehqiqhjR16A88KQQ+ZjgyDcItKGygSog==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-hard-break": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.22.4.tgz",
+      "integrity": "sha512-xq+a4dE7T6VwApCkh/yU3p30gn3F8g8Arb9CyEZm58/WIJUIGvHSTjDdHmvU16+kiWSBg+wOOsaFHhYjJjxcKA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-heading": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-3.22.4.tgz",
+      "integrity": "sha512-TUaj5f0Ir5qy9HKKt2ocnwfXKpZDYeHgbbP9gshKFzdq5PLe1RbIgkjfy6bnoI865cYjmPYWRjcT7XsKyIcb9Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-horizontal-rule": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.22.4.tgz",
+      "integrity": "sha512-cCI1HekGQwhY/MbgaKQ0R/7HcH5ZM1oFAyI/J72QGLC0XnF403S/OXoHMuBWr1mCu8hNiQWCzeNRJUty0iytNw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4",
+        "@tiptap/pm": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-italic": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-3.22.4.tgz",
+      "integrity": "sha512-fVSDx5AYXgDI3v2zZIqb7V8EewthwM2NJ/ZCX+XaxRsqNEpnjVhgHs7UlvDqK1wj2OJ6zmUNjPtVlAFRxwT+HQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-link": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.22.4.tgz",
+      "integrity": "sha512-uoP3yus02uwGPVzW2QaEPJWVIrUb/r5nKm6c8DiJv9fNSX1+gykZZMg42c6GwRFLZ/vyfWjVCbAE03VMUqafgA==",
+      "license": "MIT",
+      "dependencies": {
+        "linkifyjs": "^4.3.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4",
+        "@tiptap/pm": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-list": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.22.4.tgz",
+      "integrity": "sha512-Xe8UFvvHmyp/c/TJsFwlwU9CWACYbBirNsluJ3U1+H8BTu1wqdrT/AXR5uIXeyCl5kiWKgX5q71eHWbYFOrqrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4",
+        "@tiptap/pm": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-list-item": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-3.22.4.tgz",
+      "integrity": "sha512-H659KXTvggSypIDWSOJBZ37jh9pKjQriDDvYPYvOZCdfij0D0hsDXN/wXoypArneUkoBdgruHfTtMkFOaQlgkw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-list-keymap": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-keymap/-/extension-list-keymap-3.22.4.tgz",
+      "integrity": "sha512-t/zhker4oIS78AIGYDdFFfZC6zSBlszfD7z/zqFLGCg5PHNNgkZK5hKj6Vyix6D2SapRn/ajnx+8mhbKIUH5eA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-ordered-list": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.22.4.tgz",
+      "integrity": "sha512-w77hPVf7pcHt97vfrybg/l0t5CimCd4y75OJKuHuo3CfgM5xbUP/gaPNMDyLLe7MYole/UHi/XvG3XjgzqTzAw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-paragraph": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.22.4.tgz",
+      "integrity": "sha512-de6dFkIhigiENESY6rNJ3yTVS/337ybfP30dNPudTwGe9oAu9ZCS+04j6QCvXSjhlI3ULiv7wiSHqrP26Gd+Hw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-strike": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-3.22.4.tgz",
+      "integrity": "sha512-aRHWQj42HiailXSC9LkKYM3jWMcSeGwOjbqM4PiuxQZmHVDRFmeHkfJItOdn2cSHaO0vuEVK+TvrWUWsBFi3pg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-text": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.22.4.tgz",
+      "integrity": "sha512-mM69uUW5cSxIhyEpWXi/YcfyupcJMDLCPEfYi62awH0iOP/LRoCv/nHjJq4Hyj/KxRJbe8HKwIUnqaCUf7m5Pg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extension-underline": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.22.4.tgz",
+      "integrity": "sha512-08kGdbhIrA6h10GWXqOkqIveaBj5tmxclK208/nUIAlonI9hPd739vu7fmVtpnmqCnSSNpoRtU4u6Gj5at0ZpA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/extensions": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.22.4.tgz",
+      "integrity": "sha512-fOe8VptJvLPs32bNdUYo8SRyljwqKNQVXWW056VoXIc5en/59OdJlJQVeHI0jRRciH3MtrqODi/gfJR0VHNZ8A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4",
+        "@tiptap/pm": "3.22.4"
+      }
+    },
+    "node_modules/@tiptap/pm": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.22.4.tgz",
+      "integrity": "sha512-hj8Qka6WcHRllHUdeSjDnq2XaisUo4KsoGJc1WcFpoa1Yd+OeD861zUMnV7DFVGdZRy45Obht0CUYJpXQ4yA4w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-changeset": "^2.3.0",
+        "prosemirror-commands": "^1.6.2",
+        "prosemirror-dropcursor": "^1.8.1",
+        "prosemirror-gapcursor": "^1.3.2",
+        "prosemirror-history": "^1.4.1",
+        "prosemirror-keymap": "^1.2.2",
+        "prosemirror-model": "^1.24.1",
+        "prosemirror-schema-list": "^1.5.0",
+        "prosemirror-state": "^1.4.3",
+        "prosemirror-tables": "^1.6.4",
+        "prosemirror-transform": "^1.10.2",
+        "prosemirror-view": "^1.38.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
+    "node_modules/@tiptap/starter-kit": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.22.4.tgz",
+      "integrity": "sha512-qWjw+vfdin1rzMRpRU4cC5tLTwMJtUpXeQukv+6mOqqvhptuwuZBjUHImVEJaSPoHXS7+1ut+nTnrLyWyEuE5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@tiptap/core": "^3.22.4",
+        "@tiptap/extension-blockquote": "^3.22.4",
+        "@tiptap/extension-bold": "^3.22.4",
+        "@tiptap/extension-bullet-list": "^3.22.4",
+        "@tiptap/extension-code": "^3.22.4",
+        "@tiptap/extension-code-block": "^3.22.4",
+        "@tiptap/extension-document": "^3.22.4",
+        "@tiptap/extension-dropcursor": "^3.22.4",
+        "@tiptap/extension-gapcursor": "^3.22.4",
+        "@tiptap/extension-hard-break": "^3.22.4",
+        "@tiptap/extension-heading": "^3.22.4",
+        "@tiptap/extension-horizontal-rule": "^3.22.4",
+        "@tiptap/extension-italic": "^3.22.4",
+        "@tiptap/extension-link": "^3.22.4",
+        "@tiptap/extension-list": "^3.22.4",
+        "@tiptap/extension-list-item": "^3.22.4",
+        "@tiptap/extension-list-keymap": "^3.22.4",
+        "@tiptap/extension-ordered-list": "^3.22.4",
+        "@tiptap/extension-paragraph": "^3.22.4",
+        "@tiptap/extension-strike": "^3.22.4",
+        "@tiptap/extension-text": "^3.22.4",
+        "@tiptap/extension-underline": "^3.22.4",
+        "@tiptap/extensions": "^3.22.4",
+        "@tiptap/pm": "^3.22.4"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
+    "node_modules/@tiptap/vue-3": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/vue-3/-/vue-3-3.22.4.tgz",
+      "integrity": "sha512-fcqUWt6LlA5PbcFaDXyV1apWwAs8j80m0kWwoL5+DgKdkGxsB5LgDZU1pTWle0zvR5zmGvJ7LmB6EGAYIBjdmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "optionalDependencies": {
+        "@tiptap/extension-bubble-menu": "^3.22.4",
+        "@tiptap/extension-floating-menu": "^3.22.4"
+      },
+      "peerDependencies": {
+        "@floating-ui/dom": "^1.0.0",
+        "@tiptap/core": "3.22.4",
+        "@tiptap/pm": "3.22.4",
+        "vue": "^3.0.0"
+      }
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",
@@ -880,6 +1355,8 @@
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -889,16 +1366,44 @@
     },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.5.tgz",
+      "integrity": "sha512-yg6E+u0/+Zjva+buc3EIb+29XEg4wltq7cSmd4Uc2EE/1nUVmxyzpX6gUXD0V8jIrG0r7YeOGVIbYRkxeooCtw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "13.0.9",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-13.0.9.tgz",
+      "integrity": "sha512-1XPwR0+MgXLWfTn9gCsZ55AHOKW1WN+P9vr0PaQh5aerR9LLQXUbjfEAFhjmEmyoYFWAyuN2Mqkn40MZ4ukjBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^3",
+        "@types/mdurl": "^1"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.5.tgz",
+      "integrity": "sha512-6L6VymKTzYSrEf4Nev4Xa1LCHKrlTlYCBMTlQKFuddo1CvQcE52I0mwfOJayueUC7MJuXOeHTcIU683lzd0cUA==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
+      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -907,19 +1412,27 @@
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT"
     },
     "node_modules/@types/web-bluetooth": {
       "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.20.tgz",
+      "integrity": "sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==",
       "license": "MIT"
     },
     "node_modules/@types/whatwg-mimetype": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -928,6 +1441,8 @@
     },
     "node_modules/@vitejs/plugin-vue": {
       "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.6.tgz",
+      "integrity": "sha512-u9HHgfrq3AjXlysn0eINFnWQOJQLO9WN6VprZ8FXl7A2bYisv3Hui9Ij+7QZ41F/WYWarHjwBbXtD7dKg3uxbg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -943,6 +1458,8 @@
     },
     "node_modules/@vitest/expect": {
       "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -959,6 +1476,8 @@
     },
     "node_modules/@vitest/mocker": {
       "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -984,6 +1503,8 @@
     },
     "node_modules/@vitest/pretty-format": {
       "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -995,6 +1516,8 @@
     },
     "node_modules/@vitest/runner": {
       "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1007,6 +1530,8 @@
     },
     "node_modules/@vitest/snapshot": {
       "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1021,6 +1546,8 @@
     },
     "node_modules/@vitest/spy": {
       "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1029,6 +1556,8 @@
     },
     "node_modules/@vitest/utils": {
       "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1042,6 +1571,8 @@
     },
     "node_modules/@vue-flow/background": {
       "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@vue-flow/background/-/background-1.3.2.tgz",
+      "integrity": "sha512-eJPhDcLj1wEo45bBoqTXw1uhl0yK2RaQGnEINqvvBsAFKh/camHJd5NPmOdS1w+M9lggc9igUewxaEd3iCQX2w==",
       "license": "MIT",
       "peerDependencies": {
         "@vue-flow/core": "^1.23.0",
@@ -1050,6 +1581,8 @@
     },
     "node_modules/@vue-flow/controls": {
       "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@vue-flow/controls/-/controls-1.1.3.tgz",
+      "integrity": "sha512-XCf+G+jCvaWURdFlZmOjifZGw3XMhN5hHlfMGkWh9xot+9nH9gdTZtn+ldIJKtarg3B21iyHU8JjKDhYcB6JMw==",
       "license": "MIT",
       "peerDependencies": {
         "@vue-flow/core": "^1.23.0",
@@ -1058,6 +1591,8 @@
     },
     "node_modules/@vue-flow/core": {
       "version": "1.48.2",
+      "resolved": "https://registry.npmjs.org/@vue-flow/core/-/core-1.48.2.tgz",
+      "integrity": "sha512-raxhgKWE+G/mcEvXJjGFUDYW9rAI3GOtiHR3ZkNpwBWuIaCC1EYiBmKGwJOoNzVFgwO7COgErnK7i08i287AFA==",
       "license": "MIT",
       "dependencies": {
         "@vueuse/core": "^10.5.0",
@@ -1072,6 +1607,8 @@
     },
     "node_modules/@vue-flow/minimap": {
       "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@vue-flow/minimap/-/minimap-1.5.4.tgz",
+      "integrity": "sha512-l4C+XTAXnRxsRpUdN7cAVFBennC1sVRzq4bDSpVK+ag7tdMczAnhFYGgbLkUw3v3sY6gokyWwMl8CDonp8eB2g==",
       "license": "MIT",
       "dependencies": {
         "d3-selection": "^3.0.0",
@@ -1084,6 +1621,8 @@
     },
     "node_modules/@vue-macros/common": {
       "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@vue-macros/common/-/common-3.1.2.tgz",
+      "integrity": "sha512-h9t4ArDdniO9ekYHAD95t9AZcAbb19lEGK+26iAjUODOIJKmObDNBSe4+6ELQAA3vtYiFPPBtHh7+cQCKi3Dng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1156,6 +1695,8 @@
     },
     "node_modules/@vue/compiler-sfc/node_modules/estree-walker": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "license": "MIT"
     },
     "node_modules/@vue/compiler-ssr": {
@@ -1170,6 +1711,8 @@
     },
     "node_modules/@vue/devtools-api": {
       "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-8.1.1.tgz",
+      "integrity": "sha512-bsDMJ07b3GN1puVwJb/fyFnj/U2imyswK5UQVLZwVl7O05jDrt6BHxeG5XffmOOdasOj/bOmIjxJvGPxU7pcqw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1178,6 +1721,8 @@
     },
     "node_modules/@vue/devtools-kit": {
       "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-8.1.1.tgz",
+      "integrity": "sha512-gVBaBv++i+adg4JpH71k9ppl4soyR7Y2McEqO5YNgv0BI1kMZ7BDX5gnwkZ5COYgiCyhejZG+yGNrBAjj6Coqg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1189,6 +1734,8 @@
     },
     "node_modules/@vue/devtools-shared": {
       "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-8.1.1.tgz",
+      "integrity": "sha512-+h4ttmJYl/txpxHKaoZcaKpC+pvckgLzIDiSQlaQ7kKthKh8KuwoLW2D8hPJEnqKzXOvu15UHEoGyngAXCz0EQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1244,6 +1791,8 @@
     },
     "node_modules/@vue/test-utils": {
       "version": "2.4.10",
+      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-2.4.10.tgz",
+      "integrity": "sha512-SmoZ5EA1kYiAFs9NkYdiFFQF+cSnUwnvlYEbY+DogWQZUiqOm/Y29eSbc5T6yi75SgSF9863SBeXniIEoPajCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1263,6 +1812,8 @@
     },
     "node_modules/@vueuse/core": {
       "version": "10.11.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.11.1.tgz",
+      "integrity": "sha512-guoy26JQktXPcz+0n3GukWIy/JDNKti9v6VEMu6kV2sYBsWuGiTU8OWdg+ADfUbHg3/3DlqySDe7JmdHrktiww==",
       "license": "MIT",
       "dependencies": {
         "@types/web-bluetooth": "^0.0.20",
@@ -1276,6 +1827,8 @@
     },
     "node_modules/@vueuse/core/node_modules/vue-demi": {
       "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -1300,6 +1853,8 @@
     },
     "node_modules/@vueuse/metadata": {
       "version": "10.11.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.11.1.tgz",
+      "integrity": "sha512-IGa5FXd003Ug1qAZmyE8wF3sJ81xGLSqTqtQ6jaVfkeZ4i5kS2mwQF61yhVqojRnenVew5PldLyRgvdl4YYuSw==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/antfu"
@@ -1307,6 +1862,8 @@
     },
     "node_modules/@vueuse/shared": {
       "version": "10.11.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.11.1.tgz",
+      "integrity": "sha512-LHpC8711VFZlDaYUXEBbFBCQ7GS3dVU9mjOhhMhXP6txTV4EhYQg/KGnQuvt/sPAtoUKq7VVUnL6mVtFoL42sA==",
       "license": "MIT",
       "dependencies": {
         "vue-demi": ">=0.14.8"
@@ -1317,6 +1874,8 @@
     },
     "node_modules/@vueuse/shared/node_modules/vue-demi": {
       "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -1341,6 +1900,8 @@
     },
     "node_modules/abbrev": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
+      "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -1349,6 +1910,8 @@
     },
     "node_modules/acorn": {
       "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1360,6 +1923,8 @@
     },
     "node_modules/ansi-regex": {
       "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1371,6 +1936,8 @@
     },
     "node_modules/ansi-styles": {
       "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1382,11 +1949,14 @@
     },
     "node_modules/argparse": {
       "version": "2.0.1",
-      "dev": true,
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1395,6 +1965,8 @@
     },
     "node_modules/ast-kit": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ast-kit/-/ast-kit-2.2.0.tgz",
+      "integrity": "sha512-m1Q/RaVOnTp9JxPX+F+Zn7IcLYMzM8kZofDImfsKZd8MbR+ikdOzTeztStWqfrqIxZnYWryyI9ePm3NGjnZgGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1410,6 +1982,8 @@
     },
     "node_modules/ast-walker-scope": {
       "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/ast-walker-scope/-/ast-walker-scope-0.8.3.tgz",
+      "integrity": "sha512-cbdCP0PGOBq0ASG+sjnKIoYkWMKhhz+F/h9pRexUdX2Hd38+WOlBkRKlqkGOSm0YQpcFMQBJeK4WspUAkwsEdg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1425,6 +1999,8 @@
     },
     "node_modules/balanced-match": {
       "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1433,6 +2009,8 @@
     },
     "node_modules/birpc": {
       "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
+      "integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1441,6 +2019,8 @@
     },
     "node_modules/brace-expansion": {
       "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1452,6 +2032,8 @@
     },
     "node_modules/chai": {
       "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1460,6 +2042,8 @@
     },
     "node_modules/chokidar": {
       "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
@@ -1473,10 +2057,14 @@
     },
     "node_modules/class-transformer": {
       "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
       "license": "MIT"
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1488,11 +2076,15 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/commander": {
       "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1501,11 +2093,15 @@
     },
     "node_modules/confbox": {
       "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
+      "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/config-chain": {
       "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1515,11 +2111,15 @@
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1539,6 +2139,8 @@
     },
     "node_modules/d3-color": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -1546,6 +2148,8 @@
     },
     "node_modules/d3-dispatch": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -1553,6 +2157,8 @@
     },
     "node_modules/d3-drag": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
       "license": "ISC",
       "dependencies": {
         "d3-dispatch": "1 - 3",
@@ -1564,6 +2170,8 @@
     },
     "node_modules/d3-ease": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=12"
@@ -1571,6 +2179,8 @@
     },
     "node_modules/d3-interpolate": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
       "license": "ISC",
       "dependencies": {
         "d3-color": "1 - 3"
@@ -1581,6 +2191,8 @@
     },
     "node_modules/d3-selection": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -1588,6 +2200,8 @@
     },
     "node_modules/d3-timer": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -1595,6 +2209,8 @@
     },
     "node_modules/d3-transition": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
       "license": "ISC",
       "dependencies": {
         "d3-color": "1 - 3",
@@ -1612,6 +2228,8 @@
     },
     "node_modules/d3-zoom": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
       "license": "ISC",
       "dependencies": {
         "d3-dispatch": "1 - 3",
@@ -1626,6 +2244,8 @@
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1643,11 +2263,15 @@
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/editorconfig": {
       "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-1.0.7.tgz",
+      "integrity": "sha512-e0GOtq/aTQhVdNyDU9e02+wz9oDDM+SIOQxWME2QRjzRX5yyLAuHDE+0aE8vHb9XRC8XD37eO2u57+F09JqFhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1665,11 +2289,15 @@
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/entities": {
       "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -1680,11 +2308,15 @@
     },
     "node_modules/es-module-lexer": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/estree-walker": {
       "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1693,6 +2325,8 @@
     },
     "node_modules/expect-type": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1701,11 +2335,15 @@
     },
     "node_modules/exsolve": {
       "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
+      "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1722,6 +2360,8 @@
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1737,7 +2377,10 @@
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
+      "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1749,6 +2392,9 @@
     },
     "node_modules/glob": {
       "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1768,6 +2414,8 @@
     },
     "node_modules/happy-dom": {
       "version": "20.9.0",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.9.0.tgz",
+      "integrity": "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1784,20 +2432,28 @@
     },
     "node_modules/hookable": {
       "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/immutable": {
       "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
+      "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
       "license": "MIT"
     },
     "node_modules/ini": {
       "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -1806,6 +2462,8 @@
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1814,6 +2472,8 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1825,11 +2485,15 @@
     },
     "node_modules/isexe": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -1844,6 +2508,8 @@
     },
     "node_modules/js-beautify": {
       "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.15.4.tgz",
+      "integrity": "sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1864,6 +2530,8 @@
     },
     "node_modules/js-cookie": {
       "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1872,6 +2540,8 @@
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1883,6 +2553,8 @@
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1894,6 +2566,8 @@
     },
     "node_modules/json5": {
       "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1905,6 +2579,8 @@
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
@@ -1954,6 +2630,8 @@
     },
     "node_modules/lightningcss-darwin-arm64": {
       "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
       "cpu": [
         "arm64"
       ],
@@ -2160,8 +2838,25 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
+    "node_modules/linkifyjs": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.2.tgz",
+      "integrity": "sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==",
+      "license": "MIT"
+    },
     "node_modules/lit": {
       "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit/reactive-element": "^2.1.0",
@@ -2171,6 +2866,8 @@
     },
     "node_modules/lit-element": {
       "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.5.0",
@@ -2180,6 +2877,8 @@
     },
     "node_modules/lit-html": {
       "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
@@ -2187,6 +2886,8 @@
     },
     "node_modules/local-pkg": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.1.2.tgz",
+      "integrity": "sha512-arhlxbFRmoQHl33a0Zkle/YWlmNwoyt6QNZEIJcqNbdrsix5Lvc4HyyI3EnwxTYlZYc32EbYrQ8SzEZ7dqgg9A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2203,11 +2904,15 @@
     },
     "node_modules/lru-cache": {
       "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -2215,6 +2920,8 @@
     },
     "node_modules/magic-string-ast": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/magic-string-ast/-/magic-string-ast-1.0.3.tgz",
+      "integrity": "sha512-CvkkH1i81zl7mmb94DsRiFeG9V2fR2JeuK8yDgS8oiZSFa++wWLEgZ5ufEOyLHbvSbD1gTRKv9NdX69Rnvr9JA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2225,6 +2932,41 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sxzz"
+      }
+    },
+    "node_modules/markdown-it": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it-task-lists": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it-task-lists/-/markdown-it-task-lists-2.1.1.tgz",
+      "integrity": "sha512-TxFAc76Jnhb2OUu+n3yz9RMu4CwGfaT788br6HhEDlvWfdeJcLUsxk1Hgw2yJio0OXsxv7pyIPmvECY7bMbluA==",
+      "license": "ISC"
+    },
+    "node_modules/markdown-it/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/marked": {
@@ -2239,8 +2981,16 @@
         "node": ">= 20"
       }
     },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "license": "MIT"
+    },
     "node_modules/minimatch": {
       "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2255,6 +3005,8 @@
     },
     "node_modules/minipass": {
       "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -2263,6 +3015,8 @@
     },
     "node_modules/mlly": {
       "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2274,11 +3028,15 @@
     },
     "node_modules/mlly/node_modules/confbox": {
       "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/mlly/node_modules/pkg-types": {
       "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2289,11 +3047,15 @@
     },
     "node_modules/muggle-string": {
       "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
+      "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
       "funding": [
         {
           "type": "github",
@@ -2310,11 +3072,15 @@
     },
     "node_modules/node-addon-api": {
       "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "license": "MIT",
       "optional": true
     },
     "node_modules/nopt": {
       "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
+      "integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2329,6 +3095,8 @@
     },
     "node_modules/obug": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/sxzz",
@@ -2336,13 +3104,23 @@
       ],
       "license": "MIT"
     },
+    "node_modules/orderedmap": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
+      "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
+      "license": "MIT"
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/path-key": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2351,6 +3129,8 @@
     },
     "node_modules/path-scurry": {
       "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -2366,20 +3146,28 @@
     },
     "node_modules/pathe": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/perfect-debounce": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.1.0.tgz",
+      "integrity": "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "devOptional": true,
       "license": "MIT",
       "engines": {
@@ -2391,6 +3179,8 @@
     },
     "node_modules/pkg-types": {
       "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
+      "integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2401,6 +3191,8 @@
     },
     "node_modules/playwright": {
       "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2418,6 +3210,8 @@
     },
     "node_modules/playwright-core": {
       "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2429,7 +3223,10 @@
     },
     "node_modules/playwright/node_modules/fsevents": {
       "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
+      "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2476,13 +3273,188 @@
         "node": ">=6"
       }
     },
+    "node_modules/prosemirror-changeset": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.4.1.tgz",
+      "integrity": "sha512-96WBLhOaYhJ+kPhLg3uW359Tz6I/MfcrQfL4EGv4SrcqKEMC1gmoGrXHecPE8eOwTVCJ4IwgfzM8fFad25wNfw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-commands": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.7.1.tgz",
+      "integrity": "sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.10.2"
+      }
+    },
+    "node_modules/prosemirror-dropcursor": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.8.2.tgz",
+      "integrity": "sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0",
+        "prosemirror-view": "^1.1.0"
+      }
+    },
+    "node_modules/prosemirror-gapcursor": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.4.1.tgz",
+      "integrity": "sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.0.0",
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-view": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-history": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.5.0.tgz",
+      "integrity": "sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.2.2",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.31.0",
+        "rope-sequence": "^1.3.0"
+      }
+    },
+    "node_modules/prosemirror-keymap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.3.tgz",
+      "integrity": "sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "w3c-keyname": "^2.2.0"
+      }
+    },
+    "node_modules/prosemirror-markdown": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-markdown/-/prosemirror-markdown-1.13.4.tgz",
+      "integrity": "sha512-D98dm4cQ3Hs6EmjK500TdAOew4Z03EV71ajEFiWra3Upr7diytJsjF4mPV2dW+eK5uNectiRj0xFxYI9NLXDbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/markdown-it": "^14.0.0",
+        "markdown-it": "^14.0.0",
+        "prosemirror-model": "^1.25.0"
+      }
+    },
+    "node_modules/prosemirror-markdown/node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "license": "MIT"
+    },
+    "node_modules/prosemirror-markdown/node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/prosemirror-markdown/node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "license": "MIT"
+    },
+    "node_modules/prosemirror-model": {
+      "version": "1.25.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
+      "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
+      "license": "MIT",
+      "dependencies": {
+        "orderedmap": "^2.0.0"
+      }
+    },
+    "node_modules/prosemirror-schema-list": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.5.1.tgz",
+      "integrity": "sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.7.3"
+      }
+    },
+    "node_modules/prosemirror-state": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
+      "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.27.0"
+      }
+    },
+    "node_modules/prosemirror-tables": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.8.5.tgz",
+      "integrity": "sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.2.3",
+        "prosemirror-model": "^1.25.4",
+        "prosemirror-state": "^1.4.4",
+        "prosemirror-transform": "^1.10.5",
+        "prosemirror-view": "^1.41.4"
+      }
+    },
+    "node_modules/prosemirror-transform": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.12.0.tgz",
+      "integrity": "sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.21.0"
+      }
+    },
+    "node_modules/prosemirror-view": {
+      "version": "1.41.8",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.8.tgz",
+      "integrity": "sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.20.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0"
+      }
+    },
     "node_modules/proto-list": {
       "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/quansync": {
       "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
+      "integrity": "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==",
       "dev": true,
       "funding": [
         {
@@ -2498,6 +3470,8 @@
     },
     "node_modules/readdirp": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
       "license": "MIT",
       "engines": {
         "node": ">= 14.18.0"
@@ -2509,6 +3483,8 @@
     },
     "node_modules/reflect-metadata": {
       "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
       "license": "Apache-2.0"
     },
     "node_modules/rolldown": {
@@ -2552,8 +3528,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/rope-sequence": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
+      "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
+      "license": "MIT"
+    },
     "node_modules/sass": {
       "version": "1.97.3",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.97.3.tgz",
+      "integrity": "sha512-fDz1zJpd5GycprAbu4Q2PV/RprsRtKC/0z82z0JLgdytmcq0+ujJbJ/09bPGDxCLkKY3Np5cRAOcWiVkLXJURg==",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^4.0.0",
@@ -2572,11 +3556,15 @@
     },
     "node_modules/scule": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/scule/-/scule-1.3.0.tgz",
+      "integrity": "sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -2588,6 +3576,8 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2599,6 +3589,8 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2607,11 +3599,15 @@
     },
     "node_modules/siginfo": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/signal-exit": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -2623,6 +3619,8 @@
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -2630,16 +3628,22 @@
     },
     "node_modules/stackback": {
       "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/std-env": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2657,6 +3661,8 @@
     "node_modules/string-width-cjs": {
       "name": "string-width",
       "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2670,6 +3676,8 @@
     },
     "node_modules/string-width-cjs/node_modules/ansi-regex": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2678,11 +3686,15 @@
     },
     "node_modules/string-width-cjs/node_modules/emoji-regex": {
       "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/string-width-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2694,6 +3706,8 @@
     },
     "node_modules/strip-ansi": {
       "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2709,6 +3723,8 @@
     "node_modules/strip-ansi-cjs": {
       "name": "strip-ansi",
       "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2720,6 +3736,8 @@
     },
     "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2728,11 +3746,15 @@
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyexec": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2741,6 +3763,8 @@
     },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2756,10 +3780,30 @@
     },
     "node_modules/tinyrainbow": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tiptap-markdown": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/tiptap-markdown/-/tiptap-markdown-0.9.0.tgz",
+      "integrity": "sha512-dKLQ9iiuGNgrlGVjrNauF/UBzWu4LYOx5pkD0jNkmQt/GOwfCJsBuzZTsf1jZ204ANHOm572mZ9PYvGh1S7tpQ==",
+      "license": "MIT",
+      "workspaces": [
+        "example"
+      ],
+      "dependencies": {
+        "@types/markdown-it": "^13.0.7",
+        "markdown-it": "^14.1.0",
+        "markdown-it-task-lists": "^2.1.1",
+        "prosemirror-markdown": "^1.11.1"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.0.1"
       }
     },
     "node_modules/tslib": {
@@ -2770,18 +3814,30 @@
       "license": "0BSD",
       "optional": true
     },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
+    },
     "node_modules/ufo": {
       "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
+      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/unplugin": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-3.0.0.tgz",
+      "integrity": "sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2795,6 +3851,8 @@
     },
     "node_modules/unplugin-utils": {
       "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/unplugin-utils/-/unplugin-utils-0.3.1.tgz",
+      "integrity": "sha512-5lWVjgi6vuHhJ526bI4nlCOmkCIF3nnfXkCMDeMJrtdvxTs6ZFCM8oNufGTsDbKv/tJ/xj8RpvXjRuPBZJuJog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2888,6 +3946,8 @@
     },
     "node_modules/vitest": {
       "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2997,11 +4057,15 @@
     },
     "node_modules/vue-component-type-helpers": {
       "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-3.2.7.tgz",
+      "integrity": "sha512-+gPp5YGmhfsj1IN+xUo7y0fb4clfnOiiUA39y07yW1VzCRjzVgwLbtmdWlghh7mXrPsEaYc7rrIir/HT6C8vYQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/vue-router": {
       "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-5.0.6.tgz",
+      "integrity": "sha512-9+kmUTGbKMyW9Asoy98IXXYIzrTMT7JDAdpDDeEkorHvybpUvBI2wsrSM5jFOXrFydpzRFJ9vAh+80DN2PGu9w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3046,6 +4110,8 @@
     },
     "node_modules/vue-router/node_modules/chokidar": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3060,6 +4126,8 @@
     },
     "node_modules/vue-router/node_modules/readdirp": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3070,13 +4138,23 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
+    },
     "node_modules/webpack-virtual-modules": {
       "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
+      "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/whatwg-mimetype": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3085,6 +4163,8 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3099,6 +4179,8 @@
     },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3114,6 +4196,8 @@
     },
     "node_modules/wrap-ansi": {
       "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3131,6 +4215,8 @@
     "node_modules/wrap-ansi-cjs": {
       "name": "wrap-ansi",
       "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3147,6 +4233,8 @@
     },
     "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3155,6 +4243,8 @@
     },
     "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3169,11 +4259,15 @@
     },
     "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
       "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/wrap-ansi-cjs/node_modules/string-width": {
       "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3187,6 +4281,8 @@
     },
     "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3198,6 +4294,8 @@
     },
     "node_modules/ws": {
       "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3218,6 +4316,8 @@
     },
     "node_modules/yaml": {
       "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "dev": true,
       "license": "ISC",
       "bin": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,12 +17,16 @@
     "@cucumber/gherkin": "^39.0.0",
     "@cucumber/messages": "^32.3.1",
     "@minbzk/storybook": "^0.8.35",
+    "@tiptap/core": "^3.22.4",
+    "@tiptap/starter-kit": "^3.22.4",
+    "@tiptap/vue-3": "^3.22.4",
     "@vue-flow/background": "^1.3.2",
     "@vue-flow/controls": "^1.1.3",
     "@vue-flow/core": "^1.48.2",
     "@vue-flow/minimap": "^1.5.4",
     "dompurify": "^3.4.1",
-    "marked": "^18.0.2"
+    "marked": "^18.0.2",
+    "tiptap-markdown": "^0.9.0"
   },
   "overrides": {
     "brace-expansion": "^5.0.5"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,12 +17,16 @@
     "@cucumber/gherkin": "^39.1.0",
     "@cucumber/messages": "^32.3.1",
     "@nldd/design-system": "^0.8.41",
+    "@tiptap/core": "^3.22.4",
+    "@tiptap/starter-kit": "^3.22.4",
+    "@tiptap/vue-3": "^3.22.4",
     "@vue-flow/background": "^1.3.2",
     "@vue-flow/controls": "^1.1.3",
     "@vue-flow/core": "^1.48.2",
     "@vue-flow/minimap": "^1.5.4",
     "dompurify": "^3.4.2",
-    "marked": "^18.0.3"
+    "marked": "^18.0.3",
+    "tiptap-markdown": "^0.9.0"
   },
   "overrides": {
     "brace-expansion": "^5.0.5"

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -789,12 +789,9 @@ function handleActionSave() {
               <ArticleTextEditor
                 :article="selectedArticle"
                 :editable="canEdit"
-                :dirty="isArticleTextDirty"
-                :saving="lawSaving"
                 :save-error="lawSaveError"
                 :model-value="editedText"
                 @update:model-value="editedText = $event"
-                @save="handleLawSave"
               />
               <nldd-container v-if="canEdit && (isArticleTextDirty || lawSaving)" slot="footer" padding="16">
                 <nldd-button

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -6,7 +6,7 @@ import { useLaw, fetchLaw } from './composables/useLaw.js';
 import { useEngine } from './composables/useEngine.js';
 import { useAuth } from './composables/useAuth.js';
 import { useFeatureFlags } from './composables/useFeatureFlags.js';
-import ArticleText from './components/ArticleText.vue';
+import ArticleTextEditor from './components/ArticleTextEditor.vue';
 import ActionSheet from './components/ActionSheet.vue';
 import EditSheet from './components/EditSheet.vue';
 import SearchWindow from './components/SearchWindow.vue';
@@ -267,6 +267,10 @@ const parseError = ref(null);
 
 const machineReadable = ref(null);
 const yamlSource = ref('');
+// In-memory markdown for the currently selected article's `text` field.
+// Seeded on article switch alongside machineReadable so the Tekst and Machine
+// panes reset in lockstep when the user tabs to a different article.
+const editedText = ref('');
 
 const dumpOpts = { lineWidth: 80, noRefs: true };
 
@@ -276,12 +280,17 @@ watch(selectedArticle, (article) => {
   const mr = article?.machine_readable;
   machineReadable.value = mr ? JSON.parse(JSON.stringify(mr)) : null;
   yamlSource.value = mr ? yaml.dump(mr, dumpOpts) : '';
+  editedText.value = article?.text ?? '';
   parseError.value = null;
 }, { immediate: true });
 
 const editedArticle = computed(() => {
   if (!selectedArticle.value) return null;
-  return { ...selectedArticle.value, machine_readable: machineReadable.value };
+  return {
+    ...selectedArticle.value,
+    text: editedText.value,
+    machine_readable: machineReadable.value,
+  };
 });
 
 // Parse rawYaml once per law load into a reusable document skeleton. The
@@ -319,9 +328,7 @@ const parsedRawLaw = computed(() => {
 // article).
 const currentLawYaml = computed(() => {
   if (!rawYaml.value) return null;
-  if (!selectedArticle.value || machineReadable.value == null) {
-    return rawYaml.value;
-  }
+  if (!selectedArticle.value) return rawYaml.value;
   const base = parsedRawLaw.value;
   if (!base) return rawYaml.value;
   try {
@@ -336,10 +343,18 @@ const currentLawYaml = computed(() => {
       (a) => String(a.number) === String(selectedArticleNumber.value),
     );
     if (idx < 0) return rawYaml.value;
-    docArticles[idx] = {
-      ...docArticles[idx],
-      machine_readable: machineReadable.value,
-    };
+    // Only splice fields that have diverged from the base — passing
+    // `machineReadable.value` verbatim when it's null would erase the
+    // article's machine_readable from the serialized doc, and similarly
+    // for text. The dirty computeds below drive this same contract.
+    const patched = { ...docArticles[idx] };
+    if (editedText.value !== (docArticles[idx].text ?? '')) {
+      patched.text = editedText.value;
+    }
+    if (machineReadable.value != null) {
+      patched.machine_readable = machineReadable.value;
+    }
+    docArticles[idx] = patched;
     doc.articles = docArticles;
     return yaml.dump(doc, dumpOpts);
   } catch {
@@ -390,34 +405,47 @@ const isMachineReadableDirty = computed(() => {
   }
 });
 
-async function handleMachineReadableSave() {
+const isArticleTextDirty = computed(() => {
+  if (!selectedArticle.value) return false;
+  return (selectedArticle.value.text ?? '') !== (editedText.value ?? '');
+});
+
+// Single save handler shared by the Tekst and Machine panes. The PUT writes
+// the whole law YAML, so one click persists every in-memory edit for the
+// selected article regardless of which pane surfaced the button.
+async function handleLawSave() {
   const lawYaml = currentLawYaml.value;
   if (!lawYaml) return;
   // Snapshot the law id before the await. saveLaw itself guards its own
   // reactive writes with the same check, but the post-save cleanup below
   // runs in the EditorApp scope and would happily overwrite the new law's
-  // in-progress machine_readable with its pristine article data if the
-  // user switched laws mid-flight.
+  // in-progress edits with its pristine article data if the user switched
+  // laws mid-flight.
   const savedLawId = lawId.value;
   try {
     await saveLaw(lawYaml);
     if (lawId.value !== savedLawId) return; // law switched mid-PUT
     // After save, `rawYaml` is the saved text and `selectedArticle` now
-    // points at the re-parsed article. We could rely on the `watch`
-    // further up to re-sync `machineReadable` from the new selectedArticle,
-    // but that watcher fires on the next microtask — leaving a window
-    // where `isMachineReadableDirty` still sees the pre-save object and
-    // the save button stays enabled, enabling a double-save click. Reset
-    // `machineReadable` explicitly from the freshly-parsed article so the
-    // dirty flag clears synchronously with the save.
-    const fresh = selectedArticle.value?.machine_readable ?? null;
-    machineReadable.value = fresh ? JSON.parse(JSON.stringify(fresh)) : null;
-    yamlSource.value = fresh ? yaml.dump(fresh, dumpOpts) : '';
+    // points at the re-parsed article. The `watch(selectedArticle)` above
+    // fires on the next microtask — leaving a window where the dirty
+    // computeds still see the pre-save values and the save button stays
+    // enabled, enabling a double-save click. Reset local state explicitly
+    // from the freshly-parsed article so both dirty flags clear
+    // synchronously with the save.
+    const fresh = selectedArticle.value;
+    const freshMr = fresh?.machine_readable ?? null;
+    machineReadable.value = freshMr ? JSON.parse(JSON.stringify(freshMr)) : null;
+    yamlSource.value = freshMr ? yaml.dump(freshMr, dumpOpts) : '';
+    editedText.value = fresh?.text ?? '';
   } catch (e) {
     // saveError is surfaced via lawSaveError; log for dev visibility.
     console.warn('saveLaw failed:', e);
   }
 }
+
+// Alias kept to minimise template churn; both panes ultimately call the
+// same whole-law save.
+const handleMachineReadableSave = handleLawSave;
 
 function onYamlInput(event) {
   const text = event.target.value;
@@ -757,11 +785,28 @@ function handleActionSave() {
         <nldd-side-by-side-split-view v-else :panes="String(visiblePanes.length)">
           <!-- Left: Article Text -->
           <nldd-split-view-pane v-if="showTextPane" :slot="paneSlot('text')">
-            <nldd-page sticky-header>
-              <nldd-top-title-bar slot="header" text="Tekst"></nldd-top-title-bar>
-              <nldd-simple-section :align="selectedArticle ? undefined : 'center'">
-                <ArticleText :article="selectedArticle" raw />
-              </nldd-simple-section>
+            <nldd-page :sticky-footer="canEdit && (isArticleTextDirty || lawSaving) || undefined">
+              <ArticleTextEditor
+                :article="selectedArticle"
+                :editable="canEdit"
+                :dirty="isArticleTextDirty"
+                :saving="lawSaving"
+                :save-error="lawSaveError"
+                :model-value="editedText"
+                @update:model-value="editedText = $event"
+                @save="handleLawSave"
+              />
+              <nldd-container v-if="canEdit && (isArticleTextDirty || lawSaving)" slot="footer" padding="16">
+                <nldd-button
+                  variant="primary"
+                  size="md"
+                  full-width
+                  data-testid="save-text-btn"
+                  :disabled="lawSaving || undefined"
+                  :text="lawSaving ? 'Opslaan…' : 'Opslaan'"
+                  @click="handleLawSave"
+                ></nldd-button>
+              </nldd-container>
             </nldd-page>
           </nldd-split-view-pane>
 

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -9,7 +9,7 @@ import { useFeatureFlags } from './composables/useFeatureFlags.js';
 import { useColorScheme } from './composables/useColorScheme.js';
 import { lastLibraryPath } from './composables/useLastVisitedRoute.js';
 import { SUPPORT_EMAIL } from './constants.js';
-import ArticleText from './components/ArticleText.vue';
+import ArticleTextEditor from './components/ArticleTextEditor.vue';
 import ActionSheet from './components/ActionSheet.vue';
 import EditSheet from './components/EditSheet.vue';
 import SearchPopover from './components/SearchPopover.vue';
@@ -448,6 +448,10 @@ const parseError = ref(null);
 
 const machineReadable = ref(null);
 const yamlSource = ref('');
+// In-memory markdown for the currently selected article's `text` field.
+// Seeded on article switch alongside machineReadable so the Tekst and Machine
+// panes reset in lockstep when the user tabs to a different article.
+const editedText = ref('');
 
 const dumpOpts = { lineWidth: 80, noRefs: true };
 
@@ -457,6 +461,7 @@ watch(selectedArticle, (article) => {
   const mr = article?.machine_readable;
   machineReadable.value = mr ? structuredClone(mr) : null;
   yamlSource.value = mr ? yaml.dump(mr, dumpOpts) : '';
+  editedText.value = article?.text ?? '';
   parseError.value = null;
 }, { immediate: true });
 
@@ -477,7 +482,11 @@ watchEffect(() => {
 
 const editedArticle = computed(() => {
   if (!selectedArticle.value) return null;
-  return { ...selectedArticle.value, machine_readable: machineReadable.value };
+  return {
+    ...selectedArticle.value,
+    text: editedText.value,
+    machine_readable: machineReadable.value,
+  };
 });
 
 // Parse rawYaml once per law load into a reusable document skeleton. The
@@ -515,9 +524,7 @@ const parsedRawLaw = computed(() => {
 // article).
 const currentLawYaml = computed(() => {
   if (!rawYaml.value) return null;
-  if (!selectedArticle.value || machineReadable.value == null) {
-    return rawYaml.value;
-  }
+  if (!selectedArticle.value) return rawYaml.value;
   const base = parsedRawLaw.value;
   if (!base) return rawYaml.value;
   try {
@@ -532,10 +539,18 @@ const currentLawYaml = computed(() => {
       (a) => String(a.number) === String(selectedArticleNumber.value),
     );
     if (idx < 0) return rawYaml.value;
-    docArticles[idx] = {
-      ...docArticles[idx],
-      machine_readable: machineReadable.value,
-    };
+    // Only splice fields that have diverged from the base — passing
+    // `machineReadable.value` verbatim when it's null would erase the
+    // article's machine_readable from the serialized doc, and similarly
+    // for text. The dirty computeds below drive this same contract.
+    const patched = { ...docArticles[idx] };
+    if (editedText.value !== (docArticles[idx].text ?? '')) {
+      patched.text = editedText.value;
+    }
+    if (machineReadable.value != null) {
+      patched.machine_readable = machineReadable.value;
+    }
+    docArticles[idx] = patched;
     doc.articles = docArticles;
     return yaml.dump(doc, dumpOpts);
   } catch {
@@ -586,34 +601,46 @@ const isMachineReadableDirty = computed(() => {
   }
 });
 
-async function handleMachineReadableSave() {
+const isArticleTextDirty = computed(() => {
+  if (!selectedArticle.value) return false;
+  return (selectedArticle.value.text ?? '') !== (editedText.value ?? '');
+});
+
+// Single save handler shared by the Tekst and Machine panes. The PUT writes
+// the whole law YAML, so one click persists every in-memory edit for the
+// selected article regardless of which pane surfaced the button.
+async function handleLawSave() {
   const lawYaml = currentLawYaml.value;
   if (!lawYaml) return;
   // Snapshot the law id before the await. saveLaw itself guards its own
   // reactive writes with the same check, but the post-save cleanup below
   // runs in the EditorApp scope and would happily overwrite the new law's
-  // in-progress machine_readable with its pristine article data if the
-  // user switched laws mid-flight.
+  // in-progress edits with its pristine article data if the user switched
+  // laws mid-flight.
   const savedLawId = lawId.value;
   try {
     await saveLaw(lawYaml);
     if (lawId.value !== savedLawId) return; // law switched mid-PUT
-    // After save, `rawYaml` is the saved text and `selectedArticle` now
-    // points at the re-parsed article. We could rely on the `watch`
-    // further up to re-sync `machineReadable` from the new selectedArticle,
-    // but that watcher fires on the next microtask — leaving a window
-    // where `isMachineReadableDirty` still sees the pre-save object and
-    // the save button stays enabled, enabling a double-save click. Reset
-    // `machineReadable` explicitly from the freshly-parsed article so the
-    // dirty flag clears synchronously with the save.
-    const fresh = selectedArticle.value?.machine_readable ?? null;
-    machineReadable.value = fresh ? structuredClone(fresh) : null;
-    yamlSource.value = fresh ? yaml.dump(fresh, dumpOpts) : '';
+    // points at the re-parsed article. The `watch(selectedArticle)` above
+    // fires on the next microtask — leaving a window where the dirty
+    // computeds still see the pre-save values and the save button stays
+    // enabled, enabling a double-save click. Reset local state explicitly
+    // from the freshly-parsed article so both dirty flags clear
+    // synchronously with the save.
+    const fresh = selectedArticle.value;
+    const freshMr = fresh?.machine_readable ?? null;
+    machineReadable.value = freshMr ? structuredClone(freshMr) : null;
+    yamlSource.value = freshMr ? yaml.dump(freshMr, dumpOpts) : '';
+    editedText.value = fresh?.text ?? '';
   } catch (e) {
     // saveError is surfaced via lawSaveError; log for dev visibility.
     console.warn('saveLaw failed:', e);
   }
 }
+
+// Alias kept to minimise template churn; both panes ultimately call the
+// same whole-law save.
+const handleMachineReadableSave = handleLawSave;
 
 function onYamlInput(event) {
   // nldd-code-editor dispatches a CustomEvent with the new value in
@@ -1053,7 +1080,7 @@ function handleActionSave() {
           >
             <nldd-page
               sticky-header
-              :sticky-footer="view === 'machine' && canEdit && (isMachineReadableDirty || lawSaving) && paneViews.indexOf('machine') === idx"
+              :sticky-footer="(view === 'machine' && canEdit && (isMachineReadableDirty || lawSaving) && paneViews.indexOf('machine') === idx) || (view === 'text' && canEdit && (isArticleTextDirty || lawSaving) && paneViews.indexOf('text') === idx)"
             >
               <div slot="header" class="pane-header">
                 <nldd-button
@@ -1078,8 +1105,33 @@ function handleActionSave() {
 
               <!-- Tekst -->
               <nldd-simple-section v-if="view === 'text'" full-width>
-                <ArticleText :article="selectedArticle" raw />
+                <ArticleTextEditor
+                  :article="selectedArticle"
+                  :editable="canEdit"
+                  :dirty="isArticleTextDirty"
+                  :saving="lawSaving"
+                  :save-error="lawSaveError"
+                  :model-value="editedText"
+                  @update:model-value="editedText = $event"
+                  @save="handleLawSave"
+                />
               </nldd-simple-section>
+              <!-- Footer + Save button only on the first text pane (mirrors the machine pattern). -->
+              <nldd-container
+                v-if="view === 'text' && canEdit && (isArticleTextDirty || lawSaving) && paneViews.indexOf('text') === idx"
+                slot="footer"
+                padding="16"
+              >
+                <nldd-button
+                  variant="primary"
+                  size="md"
+                  full-width
+                  data-testid="save-text-btn"
+                  :disabled="lawSaving || undefined"
+                  :text="lawSaving ? 'Opslaan…' : 'Opslaan'"
+                  @click="handleLawSave"
+                ></nldd-button>
+              </nldd-container>
 
               <!-- Machine readable -->
               <nldd-simple-section v-else-if="view === 'machine'" full-width>

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -540,12 +540,24 @@ const currentLawYaml = computed(() => {
       (a) => String(a.number) === String(selectedArticleNumber.value),
     );
     if (idx < 0) return rawYaml.value;
+    // Short-circuit when neither pane has been touched: a `yaml.dump`
+    // round-trip can cosmetically reformat the parsed doc (key ordering,
+    // string quoting), and `handleActionSave` calls `saveLaw(currentLawYaml)`
+    // without checking dirty flags, so a no-op action-modal save on a
+    // pristine article would otherwise produce a reformat-only commit.
+    const baseArticle = docArticles[idx];
+    const textPristine = editedText.value === (baseArticle.text ?? '');
+    const baselineMr = baseArticle.machine_readable ?? null;
+    const currentMr = machineReadable.value ?? null;
+    const mrPristine = baselineMr === currentMr
+      || JSON.stringify(baselineMr) === JSON.stringify(currentMr);
+    if (textPristine && mrPristine) return rawYaml.value;
     // Only splice fields that have diverged from the base — passing
     // `machineReadable.value` verbatim when it's null would erase the
     // article's machine_readable from the serialized doc, and similarly
     // for text. The dirty computeds below drive this same contract.
-    const patched = { ...docArticles[idx] };
-    if (editedText.value !== (docArticles[idx].text ?? '')) {
+    const patched = { ...baseArticle };
+    if (!textPristine) {
       patched.text = editedText.value;
     }
     if (machineReadable.value != null) {

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -33,6 +33,7 @@ const editorPanelFlags = [
   ['panel.machine_readable', 'Machine editor'],
   ['panel.scenario_form', 'Scenario editor'],
   ['panel.yaml_editor', 'YAML editor'],
+  ['editor.article_text_edit', 'Tekst bewerken'],
 ];
 
 // Per-pane view selection. Each pane independently picks one of the
@@ -134,6 +135,10 @@ function setPaneView(idx, viewId) {
 // and blocks unauthenticated users before this component mounts, so canEdit
 // is always true here — the computed remains as a safety net.
 const canEdit = computed(() => !oidcConfigured.value || authenticated.value);
+// Tekst-pane is only editable when the user has write access AND the
+// `editor.article_text_edit` flag is on. Visibility of the pane is
+// controlled separately by `panel.article_text`.
+const canEditArticleText = computed(() => canEdit.value && isEnabled('editor.article_text_edit'));
 
 const route = useRoute();
 const router = useRouter();
@@ -1162,7 +1167,7 @@ function handleActionSave() {
           >
             <nldd-page
               sticky-header
-              :sticky-footer="(view === 'machine' && canEdit && (isMachineReadableDirty || lawSaving) && paneViews.indexOf('machine') === idx) || (view === 'text' && canEdit && (isArticleTextDirty || lawSaving) && paneViews.indexOf('text') === idx)"
+              :sticky-footer="(view === 'machine' && canEdit && (isMachineReadableDirty || lawSaving) && paneViews.indexOf('machine') === idx) || (view === 'text' && canEditArticleText && (isArticleTextDirty || lawSaving) && paneViews.indexOf('text') === idx)"
             >
               <div slot="header" class="pane-header">
                 <nldd-button
@@ -1198,7 +1203,7 @@ function handleActionSave() {
                       size="md"
                       accessible-label="Vet"
                       data-testid="fmt-bold"
-                      :disabled="!canEdit || undefined"
+                      :disabled="!canEditArticleText || undefined"
                       @click="textEditorRefs[idx].toggleBold()"
                     ></nldd-icon-button>
                   </span>
@@ -1208,7 +1213,7 @@ function handleActionSave() {
                       size="md"
                       accessible-label="Schuin"
                       data-testid="fmt-italic"
-                      :disabled="!canEdit || undefined"
+                      :disabled="!canEditArticleText || undefined"
                       @click="textEditorRefs[idx].toggleItalic()"
                     ></nldd-icon-button>
                   </span>
@@ -1219,7 +1224,7 @@ function handleActionSave() {
                       size="md"
                       accessible-label="Opsomming"
                       data-testid="fmt-bullet-list"
-                      :disabled="!canEdit || undefined"
+                      :disabled="!canEditArticleText || undefined"
                       @click="textEditorRefs[idx].toggleBulletList()"
                     ></nldd-icon-button>
                   </span>
@@ -1229,7 +1234,7 @@ function handleActionSave() {
                       size="md"
                       accessible-label="Genummerde lijst"
                       data-testid="fmt-ordered-list"
-                      :disabled="!canEdit || undefined"
+                      :disabled="!canEditArticleText || undefined"
                       @click="textEditorRefs[idx].toggleOrderedList()"
                     ></nldd-icon-button>
                   </span>
@@ -1242,7 +1247,7 @@ function handleActionSave() {
                 <ArticleTextEditor
                   :ref="setTextEditorRef(idx)"
                   :article="selectedArticle"
-                  :editable="canEdit"
+                  :editable="canEditArticleText"
                   :save-error="articleTextSaveError"
                   :model-value="editedText"
                   @update:model-value="editedText = $event"
@@ -1250,7 +1255,7 @@ function handleActionSave() {
               </nldd-simple-section>
               <!-- Footer + Save button only on the first text pane (mirrors the machine pattern). -->
               <nldd-container
-                v-if="view === 'text' && canEdit && (isArticleTextDirty || lawSaving) && paneViews.indexOf('text') === idx"
+                v-if="view === 'text' && canEditArticleText && (isArticleTextDirty || lawSaving) && paneViews.indexOf('text') === idx"
                 slot="footer"
                 padding="16"
               >

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -562,6 +562,12 @@ const currentLawYaml = computed(() => {
     }
     if (machineReadable.value != null) {
       patched.machine_readable = machineReadable.value;
+    } else if (baselineMr != null) {
+      // The user opened an article that had machine_readable and cleared the
+      // YAML editor. The spread above carried the original key over; we have
+      // to drop it explicitly so the save persists the deletion rather than
+      // silently round-tripping the original content.
+      delete patched.machine_readable;
     }
     docArticles[idx] = patched;
     doc.articles = docArticles;

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed, watch, watchEffect, nextTick } from 'vue';
+import { ref, computed, reactive, watch, watchEffect, nextTick } from 'vue';
 import { useRoute, useRouter, onBeforeRouteUpdate } from 'vue-router';
 import yaml from 'js-yaml';
 import { useLaw, fetchLaw } from './composables/useLaw.js';
@@ -453,6 +453,22 @@ const yamlSource = ref('');
 // Seeded on article switch alongside machineReadable so the Tekst and Machine
 // panes reset in lockstep when the user tabs to a different article.
 const editedText = ref('');
+
+// Per-pane refs to the ArticleTextEditor instance so the pane-header can
+// render the formatting toolbar (Bold/Italic/lists) next to the existing
+// pane-view dropdown rather than the editor drawing its own duplicate
+// label dropdown inside the body. Functional ref keeps the map in sync as
+// panes mount/unmount.
+const textEditorRefs = reactive({});
+function setTextEditorRef(idx) {
+  return (el) => {
+    if (el) {
+      textEditorRefs[idx] = el;
+    } else {
+      delete textEditorRefs[idx];
+    }
+  };
+}
 
 const dumpOpts = { lineWidth: 80, noRefs: true };
 
@@ -1166,12 +1182,65 @@ function handleActionSave() {
                     @select="setPaneView(idx, opt.id)"
                   ></nldd-menu-item>
                 </nldd-menu>
+                <!-- Formatting toolbar lives in the pane-header so it sits in
+                     line with the pane-view dropdown rather than below it.
+                     Wired to the ArticleTextEditor instance via textEditorRefs
+                     so the active-format chips update in lockstep with the
+                     editor's selection. -->
+                <div
+                  v-if="view === 'text' && selectedArticle && textEditorRefs[idx]"
+                  class="fmt-group"
+                  data-testid="article-text-fmt-group"
+                >
+                  <span class="fmt-btn" :class="{ 'is-active': textEditorRefs[idx].activeFormats.bold }">
+                    <nldd-icon-button
+                      icon="bold"
+                      size="md"
+                      accessible-label="Vet"
+                      data-testid="fmt-bold"
+                      :disabled="!canEdit || undefined"
+                      @click="textEditorRefs[idx].toggleBold()"
+                    ></nldd-icon-button>
+                  </span>
+                  <span class="fmt-btn" :class="{ 'is-active': textEditorRefs[idx].activeFormats.italic }">
+                    <nldd-icon-button
+                      icon="italic"
+                      size="md"
+                      accessible-label="Schuin"
+                      data-testid="fmt-italic"
+                      :disabled="!canEdit || undefined"
+                      @click="textEditorRefs[idx].toggleItalic()"
+                    ></nldd-icon-button>
+                  </span>
+                  <span class="fmt-divider" role="separator" aria-orientation="vertical"></span>
+                  <span class="fmt-btn" :class="{ 'is-active': textEditorRefs[idx].activeFormats.bulletList }">
+                    <nldd-icon-button
+                      icon="bullet-list"
+                      size="md"
+                      accessible-label="Opsomming"
+                      data-testid="fmt-bullet-list"
+                      :disabled="!canEdit || undefined"
+                      @click="textEditorRefs[idx].toggleBulletList()"
+                    ></nldd-icon-button>
+                  </span>
+                  <span class="fmt-btn" :class="{ 'is-active': textEditorRefs[idx].activeFormats.orderedList }">
+                    <nldd-icon-button
+                      icon="numbered-list"
+                      size="md"
+                      accessible-label="Genummerde lijst"
+                      data-testid="fmt-ordered-list"
+                      :disabled="!canEdit || undefined"
+                      @click="textEditorRefs[idx].toggleOrderedList()"
+                    ></nldd-icon-button>
+                  </span>
+                </div>
                 <span v-if="view === 'yaml' && parseError" class="editor-parse-error">YAML parse error</span>
               </div>
 
               <!-- Tekst -->
               <nldd-simple-section v-if="view === 'text'" full-width>
                 <ArticleTextEditor
+                  :ref="setTextEditorRef(idx)"
                   :article="selectedArticle"
                   :editable="canEdit"
                   :save-error="articleTextSaveError"
@@ -1410,7 +1479,33 @@ function handleActionSave() {
   box-sizing: border-box;
 }
 
+/* Formatting buttons embedded in the text-pane header. The nldd-icon-button
+ * library doesn't carry a pressed state of its own, so the wrapper span
+ * paints the active background locally — same approach the previous
+ * in-component toolbar used. */
+.fmt-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
 
+.fmt-btn {
+  display: inline-flex;
+  border-radius: 8px;
+  transition: background-color 120ms ease;
+}
+
+.fmt-btn.is-active {
+  background-color: var(--semantics-surfaces-accent-tinted-background-color, rgba(0, 123, 199, 0.14));
+}
+
+.fmt-divider {
+  display: inline-block;
+  width: 1px;
+  height: 20px;
+  margin: 0 4px;
+  background-color: var(--semantics-borders-default-color, #DDE0E4);
+}
 
 .editor-parse-error {
   font-size: 12px;

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -607,6 +607,14 @@ const isArticleTextDirty = computed(() => {
   return (selectedArticle.value.text ?? '') !== (editedText.value ?? '');
 });
 
+// Tracks which pane(s) had dirty edits at the time of the most recent save
+// attempt. Used to scope `lawSaveError` to the pane that actually triggered
+// the save — without this, a save initiated from the machine pane that
+// fails would surface the "Opslaan mislukt" dialog inside the text-pane
+// body too, blaming a pane the user didn't touch.
+const lastSaveTouchedText = ref(false);
+const lastSaveTouchedMachine = ref(false);
+
 // Single save handler shared by the Tekst and Machine panes. The PUT writes
 // the whole law YAML, so one click persists every in-memory edit for the
 // selected article regardless of which pane surfaced the button.
@@ -619,6 +627,8 @@ async function handleLawSave() {
   // in-progress edits with its pristine article data if the user switched
   // laws mid-flight.
   const savedLawId = lawId.value;
+  lastSaveTouchedText.value = isArticleTextDirty.value;
+  lastSaveTouchedMachine.value = isMachineReadableDirty.value;
   try {
     await saveLaw(lawYaml);
     if (lawId.value !== savedLawId) return; // law switched mid-PUT
@@ -633,11 +643,24 @@ async function handleLawSave() {
     machineReadable.value = freshMr ? structuredClone(freshMr) : null;
     yamlSource.value = freshMr ? yaml.dump(freshMr, dumpOpts) : '';
     editedText.value = fresh?.text ?? '';
+    // Successful save — the dialog flags drop back to false.
+    lastSaveTouchedText.value = false;
+    lastSaveTouchedMachine.value = false;
   } catch (e) {
     // saveError is surfaced via lawSaveError; log for dev visibility.
     console.warn('saveLaw failed:', e);
   }
 }
+
+// Per-pane scoped views of lawSaveError. The error is only visible in the
+// pane that contributed to the failing save, even though the underlying
+// failure (and lawSaveError itself) is the same for both panes.
+const articleTextSaveError = computed(() =>
+  lastSaveTouchedText.value ? lawSaveError.value : null,
+);
+const machineReadableSaveError = computed(() =>
+  lastSaveTouchedMachine.value ? lawSaveError.value : null,
+);
 
 // Alias kept to minimise template churn; both panes ultimately call the
 // same whole-law save.
@@ -1133,7 +1156,7 @@ function handleActionSave() {
                 <ArticleTextEditor
                   :article="selectedArticle"
                   :editable="canEdit"
-                  :save-error="lawSaveError"
+                  :save-error="articleTextSaveError"
                   :model-value="editedText"
                   @update:model-value="editedText = $event"
                 />
@@ -1162,7 +1185,7 @@ function handleActionSave() {
                   :editable="canEdit"
                   :dirty="isMachineReadableDirty"
                   :saving="lawSaving"
-                  :save-error="lawSaveError"
+                  :save-error="machineReadableSaveError"
                   @open-action="handleOpenAction"
                   @open-edit="activeEditItem = $event"
                   @init-mr="handleInitMr"

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -153,6 +153,7 @@ const {
   saving: lawSaving,
   saveError: lawSaveError,
   saveLaw,
+  lastSavedPr,
 } = useLaw(route.params.lawId, route.params.articleNumber);
 
 const resultSheetOpen = ref(false);
@@ -915,6 +916,19 @@ function handleActionSave() {
                 <nldd-tab-bar-item selected text="Editor"></nldd-tab-bar-item>
               </nldd-tab-bar>
             </nldd-toolbar-item>
+            <nldd-toolbar-item v-if="lastSavedPr" slot="end">
+              <!-- Federated write-back indicator. Stays visible across pane
+                   switches so the user always knows where their edits are
+                   accumulating. New tab so the editor state isn't lost. -->
+              <nldd-button
+                size="md"
+                start-icon="external-link"
+                :text="`PR #${lastSavedPr.number}`"
+                :href="lastSavedPr.url"
+                target="_blank"
+                rel="noopener"
+              ></nldd-button>
+            </nldd-toolbar-item>
             <nldd-toolbar-item slot="end">
               <nldd-button size="md" start-icon="search" text="Zoeken" @click="openSearch"></nldd-button>
             </nldd-toolbar-item>
@@ -968,6 +982,17 @@ function handleActionSave() {
                 @click="openSearch"
                 @keydown="onBarSearchKeydown"
               ></nldd-search-field>
+            </nldd-toolbar-item>
+            <nldd-toolbar-item v-if="lastSavedPr" slot="end">
+              <!-- Same federated write-back indicator as the md toolbar. -->
+              <nldd-button
+                size="md"
+                start-icon="external-link"
+                :text="`PR #${lastSavedPr.number}`"
+                :href="lastSavedPr.url"
+                target="_blank"
+                rel="noopener"
+              ></nldd-button>
             </nldd-toolbar-item>
             <nldd-toolbar-item slot="end">
               <nldd-button id="settings-menu-btn-lg" size="md" start-icon="global-settings" text="Instellingen" expandable popovertarget="settings-menu-lg"></nldd-button>

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -1108,12 +1108,9 @@ function handleActionSave() {
                 <ArticleTextEditor
                   :article="selectedArticle"
                   :editable="canEdit"
-                  :dirty="isArticleTextDirty"
-                  :saving="lawSaving"
                   :save-error="lawSaveError"
                   :model-value="editedText"
                   @update:model-value="editedText = $event"
-                  @save="handleLawSave"
                 />
               </nldd-simple-section>
               <!-- Footer + Save button only on the first text pane (mirrors the machine pattern). -->

--- a/frontend/src/components/ArticleTextEditor.test.js
+++ b/frontend/src/components/ArticleTextEditor.test.js
@@ -77,6 +77,17 @@ describe('ArticleTextEditor', () => {
     expect(wrapper.find('[data-testid="save-text-error"]').exists()).toBe(false);
   });
 
+  it('does not render the save error dialog when no article is selected', () => {
+    // Without the article guard the error and the empty-state inline-dialog
+    // would render side-by-side after a save failure followed by a deselect.
+    const err = new Error('Forbidden: read-only backend');
+    const wrapper = mount(ArticleTextEditor, {
+      props: { article: null, editable: true, saveError: err, modelValue: '' },
+    });
+    expect(wrapper.find('[data-testid="save-text-error"]').exists()).toBe(false);
+    expect(wrapper.find('.article-text-editor__empty').exists()).toBe(true);
+  });
+
   // The remaining tests exercise tiptap under happy-dom. If the editor instance
   // doesn't initialise (e.g. because happy-dom lacks a DOM API tiptap depends
   // on), we skip the assertion rather than fail — the toolbar/empty-state

--- a/frontend/src/components/ArticleTextEditor.test.js
+++ b/frontend/src/components/ArticleTextEditor.test.js
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { nextTick } from 'vue';
+import ArticleTextEditor from './ArticleTextEditor.vue';
+
+// Vite is configured with `isCustomElement: tag => tag.startsWith('nldd-')`
+// (vite.config.js), so Vue treats <nldd-*> tags as raw HTML elements. No
+// stubs are needed; happy-dom is happy to render unknown HTML.
+
+function mountEditor(props = {}) {
+  return mount(ArticleTextEditor, {
+    props: {
+      article: { number: '1', text: '' },
+      editable: true,
+      modelValue: '',
+      ...props,
+    },
+  });
+}
+
+describe('ArticleTextEditor', () => {
+  it('mounts cleanly with markdown modelValue and renders the toolbar buttons', () => {
+    const wrapper = mountEditor({ modelValue: '**hello**' });
+
+    // Toolbar buttons (one per icon) — match the storybook custom elements.
+    expect(wrapper.find('[data-testid="fmt-bold"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="fmt-italic"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="fmt-bullet-list"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="fmt-ordered-list"]').exists()).toBe(true);
+
+    // Their accessible labels are in Dutch.
+    expect(wrapper.find('[data-testid="fmt-bold"]').attributes('accessible-label')).toBe('Vet');
+    expect(wrapper.find('[data-testid="fmt-italic"]').attributes('accessible-label')).toBe('Schuin');
+    expect(wrapper.find('[data-testid="fmt-bullet-list"]').attributes('accessible-label')).toBe('Opsomming');
+    expect(wrapper.find('[data-testid="fmt-ordered-list"]').attributes('accessible-label')).toBe('Genummerde lijst');
+
+    // Panel label dropdown
+    const panel = wrapper.find('[data-testid="article-text-panel-label"]');
+    expect(panel.exists()).toBe(true);
+    expect(panel.text()).toContain('Tekst');
+  });
+
+  it('shows the empty state when no article is selected', () => {
+    const wrapper = mount(ArticleTextEditor, {
+      props: { article: null, editable: true, modelValue: '' },
+    });
+    const empty = wrapper.find('.article-text-editor__empty');
+    expect(empty.exists()).toBe(true);
+    expect(empty.find('nldd-inline-dialog').attributes('text')).toContain('Geen artikel geselecteerd');
+  });
+
+  it('renders the save error dialog when saveError is set and editable', () => {
+    const err = new Error('Forbidden: read-only backend');
+    const wrapper = mountEditor({ saveError: err });
+    const dialog = wrapper.find('[data-testid="save-text-error"]');
+    expect(dialog.exists()).toBe(true);
+    expect(dialog.attributes('supporting-text')).toBe('Forbidden: read-only backend');
+  });
+
+  it('does not render the save error dialog in read-only mode', () => {
+    const err = new Error('boom');
+    const wrapper = mountEditor({ editable: false, saveError: err });
+    expect(wrapper.find('[data-testid="save-text-error"]').exists()).toBe(false);
+  });
+
+  // The remaining tests exercise tiptap under happy-dom. If the editor instance
+  // doesn't initialise (e.g. because happy-dom lacks a DOM API tiptap depends
+  // on), we skip the assertion rather than fail — the toolbar/empty-state
+  // coverage above is the load-bearing part.
+  it('emits update:modelValue with markdown when editor content changes', async () => {
+    const wrapper = mountEditor({ modelValue: 'start' });
+    // Wait for the editor instance to be created (async via useEditor).
+    await nextTick();
+    await nextTick();
+
+    // Reach into the internal editor via the editor-content child if needed.
+    // tiptap-vue-3 doesn't auto-expose the editor on wrapper.vm, but we can
+    // dig it out of the EditorContent child component's props.
+    const editorContent = wrapper.findComponent({ name: 'EditorContent' });
+    if (!editorContent.exists() || !editorContent.props('editor')) {
+      // Editor failed to mount under happy-dom — skip without failing the suite.
+      return;
+    }
+    const editor = editorContent.props('editor');
+
+    // Replace content with new markdown by issuing a tiptap command.
+    editor.commands.setContent('hello');
+    // setContent with default options doesn't fire onUpdate; explicitly insert
+    // text to trigger an update event.
+    editor.commands.insertContent(' world');
+    await nextTick();
+
+    const events = wrapper.emitted('update:modelValue');
+    expect(events).toBeDefined();
+    expect(events.length).toBeGreaterThan(0);
+    // The last emission should be a string containing the inserted text.
+    const last = events[events.length - 1][0];
+    expect(typeof last).toBe('string');
+    expect(last).toContain('world');
+  });
+
+  it('updates the editor content when modelValue changes externally', async () => {
+    const wrapper = mountEditor({ modelValue: 'first' });
+    await nextTick();
+    await nextTick();
+
+    const editorContent = wrapper.findComponent({ name: 'EditorContent' });
+    if (!editorContent.exists() || !editorContent.props('editor')) {
+      return; // tiptap not available under happy-dom; skip.
+    }
+    const editor = editorContent.props('editor');
+
+    await wrapper.setProps({ modelValue: 'second paragraph' });
+    await nextTick();
+
+    const md = editor.storage.markdown.getMarkdown();
+    expect(md).toContain('second paragraph');
+  });
+});

--- a/frontend/src/components/ArticleTextEditor.test.js
+++ b/frontend/src/components/ArticleTextEditor.test.js
@@ -49,6 +49,20 @@ describe('ArticleTextEditor', () => {
     expect(empty.find('nldd-inline-dialog').attributes('text')).toContain('Geen artikel geselecteerd');
   });
 
+  it('hides the formatting toolbar when no article is selected', () => {
+    // Toolbar buttons would otherwise stay clickable in the empty state and
+    // fire no-op/stale toggles on a tiptap editor whose mount point isn't in
+    // the DOM. The empty state should take over the whole pane.
+    const wrapper = mount(ArticleTextEditor, {
+      props: { article: null, editable: true, modelValue: '' },
+    });
+    expect(wrapper.find('.article-text-editor__toolbar').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="fmt-bold"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="fmt-italic"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="fmt-bullet-list"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="fmt-ordered-list"]').exists()).toBe(false);
+  });
+
   it('renders the save error dialog when saveError is set and editable', () => {
     const err = new Error('Forbidden: read-only backend');
     const wrapper = mountEditor({ saveError: err });

--- a/frontend/src/components/ArticleTextEditor.test.js
+++ b/frontend/src/components/ArticleTextEditor.test.js
@@ -19,25 +19,22 @@ function mountEditor(props = {}) {
 }
 
 describe('ArticleTextEditor', () => {
-  it('mounts cleanly with markdown modelValue and renders the toolbar buttons', () => {
+  it('mounts cleanly with markdown modelValue and exposes format toggles', () => {
     const wrapper = mountEditor({ modelValue: '**hello**' });
 
-    // Toolbar buttons (one per icon) — match the storybook custom elements.
-    expect(wrapper.find('[data-testid="fmt-bold"]').exists()).toBe(true);
-    expect(wrapper.find('[data-testid="fmt-italic"]').exists()).toBe(true);
-    expect(wrapper.find('[data-testid="fmt-bullet-list"]').exists()).toBe(true);
-    expect(wrapper.find('[data-testid="fmt-ordered-list"]').exists()).toBe(true);
-
-    // Their accessible labels are in Dutch.
-    expect(wrapper.find('[data-testid="fmt-bold"]').attributes('accessible-label')).toBe('Vet');
-    expect(wrapper.find('[data-testid="fmt-italic"]').attributes('accessible-label')).toBe('Schuin');
-    expect(wrapper.find('[data-testid="fmt-bullet-list"]').attributes('accessible-label')).toBe('Opsomming');
-    expect(wrapper.find('[data-testid="fmt-ordered-list"]').attributes('accessible-label')).toBe('Genummerde lijst');
-
-    // Panel label dropdown
-    const panel = wrapper.find('[data-testid="article-text-panel-label"]');
-    expect(panel.exists()).toBe(true);
-    expect(panel.text()).toContain('Tekst');
+    // The toolbar lives in the parent pane-header now; this component
+    // only needs to expose its format helpers so the parent can drive
+    // them. Verify the contract used by EditorApp.vue's pane-header.
+    const exposed = wrapper.vm;
+    expect(typeof exposed.toggleBold).toBe('function');
+    expect(typeof exposed.toggleItalic).toBe('function');
+    expect(typeof exposed.toggleBulletList).toBe('function');
+    expect(typeof exposed.toggleOrderedList).toBe('function');
+    // activeFormats reflects the editor's current selection — only the shape
+    // is part of the contract with the parent toolbar.
+    expect(Object.keys(exposed.activeFormats).sort()).toEqual([
+      'bold', 'bulletList', 'italic', 'orderedList',
+    ]);
   });
 
   it('shows the empty state when no article is selected', () => {
@@ -47,20 +44,6 @@ describe('ArticleTextEditor', () => {
     const empty = wrapper.find('.article-text-editor__empty');
     expect(empty.exists()).toBe(true);
     expect(empty.find('nldd-inline-dialog').attributes('text')).toContain('Geen artikel geselecteerd');
-  });
-
-  it('hides the formatting toolbar when no article is selected', () => {
-    // Toolbar buttons would otherwise stay clickable in the empty state and
-    // fire no-op/stale toggles on a tiptap editor whose mount point isn't in
-    // the DOM. The empty state should take over the whole pane.
-    const wrapper = mount(ArticleTextEditor, {
-      props: { article: null, editable: true, modelValue: '' },
-    });
-    expect(wrapper.find('.article-text-editor__toolbar').exists()).toBe(false);
-    expect(wrapper.find('[data-testid="fmt-bold"]').exists()).toBe(false);
-    expect(wrapper.find('[data-testid="fmt-italic"]').exists()).toBe(false);
-    expect(wrapper.find('[data-testid="fmt-bullet-list"]').exists()).toBe(false);
-    expect(wrapper.find('[data-testid="fmt-ordered-list"]').exists()).toBe(false);
   });
 
   it('renders the save error dialog when saveError is set and editable', () => {

--- a/frontend/src/components/ArticleTextEditor.vue
+++ b/frontend/src/components/ArticleTextEditor.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, watch, onBeforeUnmount } from 'vue';
+import { ref, watch } from 'vue';
 import { useEditor, EditorContent } from '@tiptap/vue-3';
 import StarterKit from '@tiptap/starter-kit';
 import { Markdown } from 'tiptap-markdown';
@@ -20,7 +20,9 @@ const editor = useEditor({
   editable: props.editable,
   extensions: [
     StarterKit,
+    // Strict commonmark — HTML in source markdown is dropped rather than partially mapping into the schema.
     Markdown.configure({
+      html: false,
       tightLists: true,
       bulletListMarker: '-',
       transformPastedText: true,
@@ -38,9 +40,9 @@ const selectionTick = ref(0);
 watch(editor, (inst) => {
   if (!inst) return;
   const bump = () => { selectionTick.value++; };
-  // Listeners are freed when `editor.destroy()` runs in onBeforeUnmount; we
-  // don't .off() explicitly because the editor instance is stable across the
-  // component's lifetime.
+  // Listeners are freed when `useEditor`'s built-in destroy runs on unmount;
+  // we don't .off() explicitly because the editor instance is stable across
+  // the component's lifetime.
   inst.on('selectionUpdate', bump);
   inst.on('transaction', bump);
 }, { immediate: true });
@@ -58,10 +60,6 @@ watch(() => props.modelValue, (next) => {
 
 watch(() => props.editable, (next) => {
   editor.value?.setEditable(next);
-});
-
-onBeforeUnmount(() => {
-  editor.value?.destroy();
 });
 
 function isActive(name, attrs) {

--- a/frontend/src/components/ArticleTextEditor.vue
+++ b/frontend/src/components/ArticleTextEditor.vue
@@ -78,7 +78,7 @@ function toggleOrderedList() { editor.value?.chain().focus().toggleOrderedList()
 
 <template>
   <div class="article-text-editor" data-testid="article-text-editor">
-    <nldd-toolbar size="md" class="article-text-editor__toolbar">
+    <nldd-toolbar v-if="article" size="md" class="article-text-editor__toolbar">
       <nldd-toolbar-item slot="start">
         <!-- Single-option panel-label dropdown; future revisions will let users switch the pane to other views (e.g. structured outline). Disabled today because there's only one option. -->
         <nldd-dropdown size="md">

--- a/frontend/src/components/ArticleTextEditor.vue
+++ b/frontend/src/components/ArticleTextEditor.vue
@@ -7,17 +7,13 @@ import { Markdown } from 'tiptap-markdown';
 const props = defineProps({
   article: { type: Object, default: null },
   editable: { type: Boolean, default: false },
-  /** True when the in-memory text differs from the saved copy */
-  dirty: { type: Boolean, default: false },
-  /** True while a save PUT is in flight */
-  saving: { type: Boolean, default: false },
   /** Error from the most recent save attempt (Error instance or null) */
   saveError: { type: Object, default: null },
   /** Markdown source, v-model-bound to the parent editor state */
   modelValue: { type: String, default: '' },
 });
 
-const emit = defineEmits(['update:modelValue', 'save']);
+const emit = defineEmits(['update:modelValue']);
 
 const editor = useEditor({
   content: props.modelValue,
@@ -42,6 +38,9 @@ const selectionTick = ref(0);
 watch(editor, (inst) => {
   if (!inst) return;
   const bump = () => { selectionTick.value++; };
+  // Listeners are freed when `editor.destroy()` runs in onBeforeUnmount; we
+  // don't .off() explicitly because the editor instance is stable across the
+  // component's lifetime.
   inst.on('selectionUpdate', bump);
   inst.on('transaction', bump);
 }, { immediate: true });

--- a/frontend/src/components/ArticleTextEditor.vue
+++ b/frontend/src/components/ArticleTextEditor.vue
@@ -20,7 +20,17 @@ const editor = useEditor({
   editable: props.editable,
   extensions: [
     StarterKit,
-    // Strict commonmark — HTML in source markdown is dropped rather than partially mapping into the schema.
+    // Strict commonmark — HTML embedded in source markdown is dropped rather
+    // than partially mapping into the prosemirror schema.
+    //
+    // Side effect: editing an article whose stored `text` already contains
+    // raw HTML (e.g. <em>, <sup>, <br> from a harvested corpus entry) will
+    // strip that HTML on first save. The engine ignores `text`, so this is
+    // functionally lossless, but it produces a larger first-save diff than
+    // the PR description's "numbered-prose normalization" implies. If the
+    // corpus grows HTML-heavy `text` fields later, revisit by either
+    // tolerating html: true with explicit schema mappings, or pre-stripping
+    // and surfacing a warning before the user starts typing.
     Markdown.configure({
       html: false,
       tightLists: true,
@@ -133,7 +143,7 @@ function toggleOrderedList() { editor.value?.chain().focus().toggleOrderedList()
     </nldd-toolbar>
 
     <div class="article-text-editor__body-wrap">
-      <template v-if="editable && saveError">
+      <template v-if="article && editable && saveError">
         <nldd-inline-dialog
           variant="alert"
           text="Opslaan mislukt"

--- a/frontend/src/components/ArticleTextEditor.vue
+++ b/frontend/src/components/ArticleTextEditor.vue
@@ -1,0 +1,246 @@
+<script setup>
+import { ref, watch, onBeforeUnmount } from 'vue';
+import { useEditor, EditorContent } from '@tiptap/vue-3';
+import StarterKit from '@tiptap/starter-kit';
+import { Markdown } from 'tiptap-markdown';
+
+const props = defineProps({
+  article: { type: Object, default: null },
+  editable: { type: Boolean, default: false },
+  /** True when the in-memory text differs from the saved copy */
+  dirty: { type: Boolean, default: false },
+  /** True while a save PUT is in flight */
+  saving: { type: Boolean, default: false },
+  /** Error from the most recent save attempt (Error instance or null) */
+  saveError: { type: Object, default: null },
+  /** Markdown source, v-model-bound to the parent editor state */
+  modelValue: { type: String, default: '' },
+});
+
+const emit = defineEmits(['update:modelValue', 'save']);
+
+const editor = useEditor({
+  content: props.modelValue,
+  editable: props.editable,
+  extensions: [
+    StarterKit,
+    Markdown.configure({
+      tightLists: true,
+      bulletListMarker: '-',
+      transformPastedText: true,
+    }),
+  ],
+  onUpdate: ({ editor }) => {
+    emit('update:modelValue', editor.storage.markdown.getMarkdown());
+  },
+});
+
+// Reactive tick used to re-evaluate `editor.isActive(...)` in the template
+// on every selection change. Without this the toolbar active-state never
+// updates because the editor instance reference is stable.
+const selectionTick = ref(0);
+watch(editor, (inst) => {
+  if (!inst) return;
+  const bump = () => { selectionTick.value++; };
+  inst.on('selectionUpdate', bump);
+  inst.on('transaction', bump);
+}, { immediate: true });
+
+// Re-seed content when the parent swaps articles or a save completes. Skip if
+// the markdown already matches what the editor holds — calling setContent on
+// every keystroke would reset the cursor.
+watch(() => props.modelValue, (next) => {
+  const inst = editor.value;
+  if (!inst) return;
+  const current = inst.storage.markdown.getMarkdown();
+  if (current === next) return;
+  inst.commands.setContent(next || '', { emitUpdate: false });
+});
+
+watch(() => props.editable, (next) => {
+  editor.value?.setEditable(next);
+});
+
+onBeforeUnmount(() => {
+  editor.value?.destroy();
+});
+
+// eslint-disable-next-line no-unused-vars
+const _touch = selectionTick; // kept so template re-evaluates on bumps
+
+function isActive(name, attrs) {
+  // eslint-disable-next-line no-unused-expressions
+  selectionTick.value;
+  return editor.value?.isActive(name, attrs) ?? false;
+}
+
+function toggleBold() { editor.value?.chain().focus().toggleBold().run(); }
+function toggleItalic() { editor.value?.chain().focus().toggleItalic().run(); }
+function toggleBulletList() { editor.value?.chain().focus().toggleBulletList().run(); }
+function toggleOrderedList() { editor.value?.chain().focus().toggleOrderedList().run(); }
+</script>
+
+<template>
+  <div class="article-text-editor" data-testid="article-text-editor">
+    <nldd-toolbar size="md" class="article-text-editor__toolbar">
+      <nldd-toolbar-item slot="start">
+        <nldd-dropdown size="md">
+          <select disabled aria-label="Paneel" data-testid="article-text-panel-label">
+            <option value="tekst">Tekst</option>
+          </select>
+        </nldd-dropdown>
+      </nldd-toolbar-item>
+      <nldd-toolbar-item slot="center">
+        <div class="fmt-group">
+          <span class="fmt-btn" :class="{ 'is-active': isActive('bold') }">
+            <nldd-icon-button
+              icon="bold"
+              size="md"
+              accessible-label="Vet"
+              data-testid="fmt-bold"
+              :disabled="!editable || undefined"
+              @click="toggleBold"
+            ></nldd-icon-button>
+          </span>
+          <span class="fmt-btn" :class="{ 'is-active': isActive('italic') }">
+            <nldd-icon-button
+              icon="italic"
+              size="md"
+              accessible-label="Schuin"
+              data-testid="fmt-italic"
+              :disabled="!editable || undefined"
+              @click="toggleItalic"
+            ></nldd-icon-button>
+          </span>
+          <span class="fmt-divider" role="separator" aria-orientation="vertical"></span>
+          <span class="fmt-btn" :class="{ 'is-active': isActive('bulletList') }">
+            <nldd-icon-button
+              icon="bullet-list"
+              size="md"
+              accessible-label="Opsomming"
+              data-testid="fmt-bullet-list"
+              :disabled="!editable || undefined"
+              @click="toggleBulletList"
+            ></nldd-icon-button>
+          </span>
+          <span class="fmt-btn" :class="{ 'is-active': isActive('orderedList') }">
+            <nldd-icon-button
+              icon="numbered-list"
+              size="md"
+              accessible-label="Genummerde lijst"
+              data-testid="fmt-ordered-list"
+              :disabled="!editable || undefined"
+              @click="toggleOrderedList"
+            ></nldd-icon-button>
+          </span>
+        </div>
+      </nldd-toolbar-item>
+    </nldd-toolbar>
+
+    <div class="article-text-editor__body-wrap">
+      <template v-if="editable && saveError">
+        <nldd-inline-dialog
+          variant="alert"
+          text="Opslaan mislukt"
+          :supporting-text="saveError.message || String(saveError)"
+          data-testid="save-text-error"
+        ></nldd-inline-dialog>
+        <nldd-spacer size="12"></nldd-spacer>
+      </template>
+
+      <div v-if="!article" class="article-text-editor__empty">
+        <nldd-inline-dialog text="Geen artikel geselecteerd"></nldd-inline-dialog>
+      </div>
+      <editor-content v-else :editor="editor" class="article-text-editor__body" />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.article-text-editor {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.article-text-editor__toolbar {
+  /* Pin at the top of the pane body; the scrolling area is the editor body
+   * below, not the toolbar. */
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.fmt-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.fmt-btn {
+  display: inline-flex;
+  border-radius: 8px;
+  transition: background-color 120ms ease;
+}
+
+/* Toggled formatting buttons: the library's nldd-icon-button has no built-in
+ * pressed state, so we paint it ourselves. A follow-up upstream PR to
+ * MinBZK/storybook can add a real `pressed` attr; until then this scoped
+ * wrapper keeps the indication local. */
+.fmt-btn.is-active {
+  background-color: var(--semantics-surfaces-accent-tinted-background-color, rgba(0, 123, 199, 0.14));
+}
+
+/* Vertical separator between the inline/mark toggles and the list toggles.
+ * `nldd-button-bar-divider` only renders when nested inside `nldd-button-bar`;
+ * here we're already inside `nldd-toolbar-item`, so we draw the line locally. */
+.fmt-divider {
+  display: inline-block;
+  width: 1px;
+  height: 20px;
+  margin: 0 4px;
+  background-color: var(--semantics-borders-default-color, #DDE0E4);
+}
+
+.article-text-editor__body-wrap {
+  padding: 16px;
+}
+
+.article-text-editor__empty {
+  padding: 32px 16px;
+  text-align: center;
+}
+
+.article-text-editor__body {
+  background: var(--semantics-surfaces-tinted-background-color, #F4F6F9);
+  border: 1px solid var(--semantics-borders-default-color, #DDE0E4);
+  border-radius: 12px;
+  padding: 16px;
+  min-height: 200px;
+  line-height: 1.6;
+  font-size: 14px;
+}
+
+.article-text-editor__body :deep(.ProseMirror) {
+  outline: none;
+  min-height: 160px;
+}
+
+.article-text-editor__body :deep(.ProseMirror p) {
+  margin: 0 0 12px;
+}
+
+.article-text-editor__body :deep(.ProseMirror p:last-child) {
+  margin-bottom: 0;
+}
+
+.article-text-editor__body :deep(.ProseMirror ul),
+.article-text-editor__body :deep(.ProseMirror ol) {
+  margin: 0 0 12px;
+  padding-left: 24px;
+}
+
+.article-text-editor__body :deep(.ProseMirror li) {
+  margin-bottom: 4px;
+}
+</style>

--- a/frontend/src/components/ArticleTextEditor.vue
+++ b/frontend/src/components/ArticleTextEditor.vue
@@ -64,9 +64,6 @@ onBeforeUnmount(() => {
   editor.value?.destroy();
 });
 
-// eslint-disable-next-line no-unused-vars
-const _touch = selectionTick; // kept so template re-evaluates on bumps
-
 function isActive(name, attrs) {
   // eslint-disable-next-line no-unused-expressions
   selectionTick.value;
@@ -83,6 +80,7 @@ function toggleOrderedList() { editor.value?.chain().focus().toggleOrderedList()
   <div class="article-text-editor" data-testid="article-text-editor">
     <nldd-toolbar size="md" class="article-text-editor__toolbar">
       <nldd-toolbar-item slot="start">
+        <!-- Single-option panel-label dropdown; future revisions will let users switch the pane to other views (e.g. structured outline). Disabled today because there's only one option. -->
         <nldd-dropdown size="md">
           <select disabled aria-label="Paneel" data-testid="article-text-panel-label">
             <option value="tekst">Tekst</option>

--- a/frontend/src/components/ArticleTextEditor.vue
+++ b/frontend/src/components/ArticleTextEditor.vue
@@ -129,66 +129,22 @@ function toggleBold() { editor.value?.chain().focus().toggleBold().run(); }
 function toggleItalic() { editor.value?.chain().focus().toggleItalic().run(); }
 function toggleBulletList() { editor.value?.chain().focus().toggleBulletList().run(); }
 function toggleOrderedList() { editor.value?.chain().focus().toggleOrderedList().run(); }
+
+// Expose the active-format state and toggle handlers so the parent can
+// render the formatting buttons inside its own pane-header (next to the
+// existing pane-view dropdown) rather than this component re-drawing its
+// own toolbar with a duplicate label dropdown.
+defineExpose({
+  activeFormats,
+  toggleBold,
+  toggleItalic,
+  toggleBulletList,
+  toggleOrderedList,
+});
 </script>
 
 <template>
   <div class="article-text-editor" data-testid="article-text-editor">
-    <nldd-toolbar v-if="article" size="md" class="article-text-editor__toolbar">
-      <nldd-toolbar-item slot="start">
-        <!-- Single-option panel-label dropdown; future revisions will let users switch the pane to other views (e.g. structured outline). Disabled today because there's only one option. -->
-        <nldd-dropdown size="md">
-          <select disabled aria-label="Paneel" data-testid="article-text-panel-label">
-            <option value="tekst">Tekst</option>
-          </select>
-        </nldd-dropdown>
-      </nldd-toolbar-item>
-      <nldd-toolbar-item slot="center">
-        <div class="fmt-group">
-          <span class="fmt-btn" :class="{ 'is-active': activeFormats.bold }">
-            <nldd-icon-button
-              icon="bold"
-              size="md"
-              accessible-label="Vet"
-              data-testid="fmt-bold"
-              :disabled="!editable || undefined"
-              @click="toggleBold"
-            ></nldd-icon-button>
-          </span>
-          <span class="fmt-btn" :class="{ 'is-active': activeFormats.italic }">
-            <nldd-icon-button
-              icon="italic"
-              size="md"
-              accessible-label="Schuin"
-              data-testid="fmt-italic"
-              :disabled="!editable || undefined"
-              @click="toggleItalic"
-            ></nldd-icon-button>
-          </span>
-          <span class="fmt-divider" role="separator" aria-orientation="vertical"></span>
-          <span class="fmt-btn" :class="{ 'is-active': activeFormats.bulletList }">
-            <nldd-icon-button
-              icon="bullet-list"
-              size="md"
-              accessible-label="Opsomming"
-              data-testid="fmt-bullet-list"
-              :disabled="!editable || undefined"
-              @click="toggleBulletList"
-            ></nldd-icon-button>
-          </span>
-          <span class="fmt-btn" :class="{ 'is-active': activeFormats.orderedList }">
-            <nldd-icon-button
-              icon="numbered-list"
-              size="md"
-              accessible-label="Genummerde lijst"
-              data-testid="fmt-ordered-list"
-              :disabled="!editable || undefined"
-              @click="toggleOrderedList"
-            ></nldd-icon-button>
-          </span>
-        </div>
-      </nldd-toolbar-item>
-    </nldd-toolbar>
-
     <div class="article-text-editor__body-wrap">
       <template v-if="article && editable && saveError">
         <nldd-inline-dialog
@@ -213,45 +169,6 @@ function toggleOrderedList() { editor.value?.chain().focus().toggleOrderedList()
   display: flex;
   flex-direction: column;
   min-height: 0;
-}
-
-.article-text-editor__toolbar {
-  /* Pin at the top of the pane body; the scrolling area is the editor body
-   * below, not the toolbar. */
-  position: sticky;
-  top: 0;
-  z-index: 1;
-}
-
-.fmt-group {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-}
-
-.fmt-btn {
-  display: inline-flex;
-  border-radius: 8px;
-  transition: background-color 120ms ease;
-}
-
-/* Toggled formatting buttons: the library's nldd-icon-button has no built-in
- * pressed state, so we paint it ourselves. A follow-up upstream PR to
- * MinBZK/storybook can add a real `pressed` attr; until then this scoped
- * wrapper keeps the indication local. */
-.fmt-btn.is-active {
-  background-color: var(--semantics-surfaces-accent-tinted-background-color, rgba(0, 123, 199, 0.14));
-}
-
-/* Vertical separator between the inline/mark toggles and the list toggles.
- * `nldd-button-bar-divider` only renders when nested inside `nldd-button-bar`;
- * here we're already inside `nldd-toolbar-item`, so we draw the line locally. */
-.fmt-divider {
-  display: inline-block;
-  width: 1px;
-  height: 20px;
-  margin: 0 4px;
-  background-color: var(--semantics-borders-default-color, #DDE0E4);
 }
 
 .article-text-editor__body-wrap {

--- a/frontend/src/components/ArticleTextEditor.vue
+++ b/frontend/src/components/ArticleTextEditor.vue
@@ -61,17 +61,24 @@ watch(editor, (inst) => {
 // the markdown already matches what the editor holds — calling setContent on
 // every keystroke would reset the cursor.
 //
-// When we do replace the content (typically an article switch), also reset
-// the selection to the start of the document. Without this, ProseMirror
-// keeps the previous cursor offset, which can land in the middle of the
-// new article (or out of range, snapping to the end) and confuses the user.
+// Track the previously-rendered article so we only reset the cursor on an
+// actual article switch. ProseMirror otherwise keeps the previous cursor
+// offset, which can land in the middle of the new article (or snap to the
+// end) and confuses the user. Within a single article we leave the selection
+// alone — e.g. a server-side save that round-trips an unchanged markdown
+// string should not yank the cursor to position 0.
+let lastArticleNumber = props.article ? String(props.article.number) : null;
 watch(() => props.modelValue, (next) => {
   const inst = editor.value;
   if (!inst) return;
   const current = inst.storage.markdown.getMarkdown();
   if (current === next) return;
   inst.commands.setContent(next || '', { emitUpdate: false });
-  inst.commands.setTextSelection(0);
+  const currentArticleNumber = props.article ? String(props.article.number) : null;
+  if (currentArticleNumber !== lastArticleNumber) {
+    inst.commands.setTextSelection(0);
+    lastArticleNumber = currentArticleNumber;
+  }
 });
 
 watch(() => props.editable, (next) => {

--- a/frontend/src/components/ArticleTextEditor.vue
+++ b/frontend/src/components/ArticleTextEditor.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { useEditor, EditorContent } from '@tiptap/vue-3';
 import StarterKit from '@tiptap/starter-kit';
 import { Markdown } from 'tiptap-markdown';
@@ -107,11 +107,23 @@ watch(() => props.editable, (next) => {
   editor.value?.setEditable(next);
 });
 
-function isActive(name, attrs) {
-  // eslint-disable-next-line no-unused-expressions
+// Compute the active-format map once per selection/transaction tick. The
+// template binds against `activeFormats.bold` etc., which makes the
+// reactive dependency on `selectionTick` explicit (no side-effect read +
+// lint suppression). Add another mark name here when the toolbar grows a
+// new format button.
+const activeFormats = computed(() => {
+  // Subscribe to selection/transaction changes.
   selectionTick.value;
-  return editor.value?.isActive(name, attrs) ?? false;
-}
+  const inst = editor.value;
+  if (!inst) return { bold: false, italic: false, bulletList: false, orderedList: false };
+  return {
+    bold: inst.isActive('bold'),
+    italic: inst.isActive('italic'),
+    bulletList: inst.isActive('bulletList'),
+    orderedList: inst.isActive('orderedList'),
+  };
+});
 
 function toggleBold() { editor.value?.chain().focus().toggleBold().run(); }
 function toggleItalic() { editor.value?.chain().focus().toggleItalic().run(); }
@@ -132,7 +144,7 @@ function toggleOrderedList() { editor.value?.chain().focus().toggleOrderedList()
       </nldd-toolbar-item>
       <nldd-toolbar-item slot="center">
         <div class="fmt-group">
-          <span class="fmt-btn" :class="{ 'is-active': isActive('bold') }">
+          <span class="fmt-btn" :class="{ 'is-active': activeFormats.bold }">
             <nldd-icon-button
               icon="bold"
               size="md"
@@ -142,7 +154,7 @@ function toggleOrderedList() { editor.value?.chain().focus().toggleOrderedList()
               @click="toggleBold"
             ></nldd-icon-button>
           </span>
-          <span class="fmt-btn" :class="{ 'is-active': isActive('italic') }">
+          <span class="fmt-btn" :class="{ 'is-active': activeFormats.italic }">
             <nldd-icon-button
               icon="italic"
               size="md"
@@ -153,7 +165,7 @@ function toggleOrderedList() { editor.value?.chain().focus().toggleOrderedList()
             ></nldd-icon-button>
           </span>
           <span class="fmt-divider" role="separator" aria-orientation="vertical"></span>
-          <span class="fmt-btn" :class="{ 'is-active': isActive('bulletList') }">
+          <span class="fmt-btn" :class="{ 'is-active': activeFormats.bulletList }">
             <nldd-icon-button
               icon="bullet-list"
               size="md"
@@ -163,7 +175,7 @@ function toggleOrderedList() { editor.value?.chain().focus().toggleOrderedList()
               @click="toggleBulletList"
             ></nldd-icon-button>
           </span>
-          <span class="fmt-btn" :class="{ 'is-active': isActive('orderedList') }">
+          <span class="fmt-btn" :class="{ 'is-active': activeFormats.orderedList }">
             <nldd-icon-button
               icon="numbered-list"
               size="md"

--- a/frontend/src/components/ArticleTextEditor.vue
+++ b/frontend/src/components/ArticleTextEditor.vue
@@ -60,12 +60,18 @@ watch(editor, (inst) => {
 // Re-seed content when the parent swaps articles or a save completes. Skip if
 // the markdown already matches what the editor holds — calling setContent on
 // every keystroke would reset the cursor.
+//
+// When we do replace the content (typically an article switch), also reset
+// the selection to the start of the document. Without this, ProseMirror
+// keeps the previous cursor offset, which can land in the middle of the
+// new article (or out of range, snapping to the end) and confuses the user.
 watch(() => props.modelValue, (next) => {
   const inst = editor.value;
   if (!inst) return;
   const current = inst.storage.markdown.getMarkdown();
   if (current === next) return;
   inst.commands.setContent(next || '', { emitUpdate: false });
+  inst.commands.setTextSelection(0);
 });
 
 watch(() => props.editable, (next) => {

--- a/frontend/src/components/ArticleTextEditor.vue
+++ b/frontend/src/components/ArticleTextEditor.vue
@@ -9,7 +9,18 @@ const props = defineProps({
   editable: { type: Boolean, default: false },
   /** Error from the most recent save attempt (Error instance or null) */
   saveError: { type: Object, default: null },
-  /** Markdown source, v-model-bound to the parent editor state */
+  /**
+   * Markdown source, v-model-bound to the parent editor state.
+   *
+   * WARNING: tiptap-markdown is configured with `html: false`, so raw HTML
+   * tags in the incoming markdown (e.g. `<em>`, `<sup>`, `<br>` from a
+   * harvested corpus entry) are silently dropped on load. Editing such an
+   * article and saving will strip the HTML from the persisted YAML even if
+   * the user typed nothing — the diff at the first save will be larger than
+   * the "numbered-prose normalization" framing in the PR description
+   * suggests. The engine ignores `text` so this is functionally lossless,
+   * but the rendered output in downstream readers will change.
+   */
   modelValue: { type: String, default: '' },
 });
 
@@ -50,11 +61,22 @@ const selectionTick = ref(0);
 watch(editor, (inst) => {
   if (!inst) return;
   const bump = () => { selectionTick.value++; };
-  // Listeners are freed when `useEditor`'s built-in destroy runs on unmount;
-  // we don't .off() explicitly because the editor instance is stable across
-  // the component's lifetime.
+  // `selectionUpdate` alone misses Ctrl+B style commands that change marks
+  // without moving the cursor. `transaction` covers those, but fires on
+  // every keystroke too — gate it on a doc-or-selection change so the
+  // toolbar re-render doesn't run on pure cursor motion within a paragraph.
+  const onTransaction = ({ transaction: tr }) => {
+    if (tr.docChanged || tr.selectionSet) bump();
+  };
   inst.on('selectionUpdate', bump);
-  inst.on('transaction', bump);
+  inst.on('transaction', onTransaction);
+  // Return a cleanup so Vue removes the listeners if the watcher re-runs
+  // (HMR while the component stays mounted re-evaluates the callback with
+  // the same editor instance, which would otherwise stack listeners).
+  return () => {
+    inst.off('selectionUpdate', bump);
+    inst.off('transaction', onTransaction);
+  };
 }, { immediate: true });
 
 // Re-seed content when the parent swaps articles or a save completes. Skip if

--- a/frontend/src/composables/useEditorSession.js
+++ b/frontend/src/composables/useEditorSession.js
@@ -1,0 +1,75 @@
+/**
+ * Editor session id — minted once per browser tab, used to scope the
+ * federated write-back path's per-(session, source) feature branch + PR.
+ *
+ * Why sessionStorage and not localStorage:
+ * - Closing the tab (or the browser) purges the id, so the next visit
+ *   gets a fresh PR. That matches the "one PR per editor session"
+ *   contract the backend enforces — no separate server-side TTL needed.
+ * - Two tabs on the same browser get two ids, hence two parallel PRs.
+ *   That is intentional: independent edit streams shouldn't collide on
+ *   one branch.
+ *
+ * The id is sent on every write request as `X-Editor-Session`. The backend
+ * uses it (alongside the law's source id) to look up or lazily build a
+ * `SessionGitBackend` that pushes to `editor/session-<id>` and ensures a
+ * PR upstream.
+ *
+ * Format: a UUID without dashes-prefix, just to keep the resulting branch
+ * name short and human-readable when it shows up on GitHub.
+ */
+
+const STORAGE_KEY = 'regelrecht-editor-session-id';
+
+/**
+ * Returns this tab's editor session id, minting + persisting one on first
+ * call. Stable for the lifetime of the tab.
+ *
+ * Falls back to an in-memory id when sessionStorage is unavailable
+ * (e.g. private-mode quirks): saves still work, but the user gets a new
+ * PR each page load. That's degraded behaviour, not a hard failure.
+ */
+export function getEditorSessionId() {
+  let id = readFromStorage();
+  if (id) return id;
+  id = mintSessionId();
+  writeToStorage(id);
+  return id;
+}
+
+function readFromStorage() {
+  try {
+    return window.sessionStorage.getItem(STORAGE_KEY) || null;
+  } catch {
+    return null;
+  }
+}
+
+function writeToStorage(id) {
+  try {
+    window.sessionStorage.setItem(STORAGE_KEY, id);
+  } catch {
+    // ignore — we'll fall back to in-memory minting on the next call
+  }
+}
+
+/**
+ * Mint a new id. Uses the platform `crypto.randomUUID()` when available
+ * (modern browsers, http*s* origins) and falls back to a math-based
+ * generator that's not cryptographically random but is good enough as
+ * an opaque key — this id is not a secret, it just needs to be unique.
+ */
+function mintSessionId() {
+  const cryptoApi = typeof crypto !== 'undefined' ? crypto : null;
+  if (cryptoApi && typeof cryptoApi.randomUUID === 'function') {
+    return cryptoApi.randomUUID().replace(/-/g, '');
+  }
+  // Fallback: 16 random bytes hex-encoded.
+  const bytes = new Uint8Array(16);
+  if (cryptoApi && typeof cryptoApi.getRandomValues === 'function') {
+    cryptoApi.getRandomValues(bytes);
+  } else {
+    for (let i = 0; i < bytes.length; i++) bytes[i] = Math.floor(Math.random() * 256);
+  }
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+}

--- a/frontend/src/composables/useEditorSession.js
+++ b/frontend/src/composables/useEditorSession.js
@@ -34,6 +34,20 @@ const STORAGE_KEY = 'regelrecht-editor-session-id';
 export const lastSavedPr = ref(null);
 
 /**
+ * Sanitize a PR payload from the editor-api before storing it in
+ * `lastSavedPr`. Only PRs whose `url` is an explicit `https://` link survive
+ * — anything else (missing url, `javascript:`, relative paths) is collapsed
+ * to `null` so the `<a :href>` binding can never accept an attacker-controlled
+ * scheme even if the backend ever misbehaves.
+ */
+export function sanitizeSavedPr(pr) {
+  if (!pr || typeof pr.url !== 'string' || !pr.url.startsWith('https://')) {
+    return null;
+  }
+  return pr;
+}
+
+/**
  * Returns this tab's editor session id, minting + persisting one on first
  * call. Stable for the lifetime of the tab.
  *

--- a/frontend/src/composables/useEditorSession.js
+++ b/frontend/src/composables/useEditorSession.js
@@ -19,7 +19,19 @@
  * name short and human-readable when it shows up on GitHub.
  */
 
+import { ref } from 'vue';
+
 const STORAGE_KEY = 'regelrecht-editor-session-id';
+
+/**
+ * Module-level shared ref so every composable that performs a save
+ * (useLaw, useScenarios, …) updates the same value — and EditorApp's
+ * "Bekijk op GitHub" badge picks up the most recent PR regardless of
+ * which pane triggered the save. Mirrors the "one PR per editor session"
+ * contract: every save in the same browser tab lands on the same upstream
+ * branch, so a single shared ref is exactly what the badge needs.
+ */
+export const lastSavedPr = ref(null);
 
 /**
  * Returns this tab's editor session id, minting + persisting one on first

--- a/frontend/src/composables/useFeatureFlags.js
+++ b/frontend/src/composables/useFeatureFlags.js
@@ -11,6 +11,11 @@ const DEFAULTS = {
   'panel.scenario_form': true,
   'panel.yaml_editor': true,
   'panel.machine_readable': true,
+  // Gates write access on the Tekst pane independently from its visibility.
+  // Default off so users see article text in read-only mode until they
+  // explicitly opt in — the first-save markdown normalisation rewrites the
+  // YAML enough that we want the toggle to be deliberate.
+  'editor.article_text_edit': false,
 };
 
 // Local overrides survive refresh when the backend has no persistence (dev).

--- a/frontend/src/composables/useLaw.js
+++ b/frontend/src/composables/useLaw.js
@@ -1,5 +1,6 @@
 import { computed, ref, shallowRef } from 'vue';
 import yaml from 'js-yaml';
+import { getEditorSessionId } from './useEditorSession.js';
 
 // --- Shared law cache ---
 const lawCache = new Map();
@@ -48,6 +49,12 @@ export function useLaw(lawParam, articleParam) {
   const error = ref(null);
   const saving = ref(false);
   const saveError = ref(null);
+  // PR opened or updated by the most recent successful save through the
+  // federated write-back path (RFC-010 phase 6). Stays populated across
+  // saves in the same editor session — every successful save returns the
+  // same PR info from the backend until the session ends or the PR is
+  // merged/closed. Null for local-source saves (no upstream PR).
+  const lastSavedPr = ref(null);
 
   const articles = computed(() => law.value?.articles ?? []);
 
@@ -152,7 +159,12 @@ export function useLaw(lawParam, articleParam) {
         `/api/corpus/laws/${encodeURIComponent(savedLawId)}`,
         {
           method: 'PUT',
-          headers: { 'Content-Type': 'text/yaml; charset=utf-8' },
+          headers: {
+            'Content-Type': 'text/yaml; charset=utf-8',
+            // Required by editor-api on every write — scopes this save to
+            // a per-(session, source) feature branch + PR upstream.
+            'X-Editor-Session': getEditorSessionId(),
+          },
           body: yamlText,
         },
       );
@@ -173,6 +185,19 @@ export function useLaw(lawParam, articleParam) {
           } catch { /* keep status fallback */ }
         }
         throw new Error(text);
+      }
+      // Backend returns `{ pr: { url, number, branch } | null }` on 200.
+      // We only update `lastSavedPr` for the originating law — same logic
+      // as `rawYaml`/`law` updates below: a stale response after the user
+      // switched laws shouldn't repaint the new law's PR badge.
+      try {
+        const json = await res.json();
+        if (lawId.value === savedLawId) {
+          lastSavedPr.value = json?.pr ?? null;
+        }
+      } catch {
+        // Older deployments return a bare 200 without JSON — keep the
+        // existing PR (if any) and treat the save as successful.
       }
       // Parse once and reuse for both reactive state and the shared
       // lawCache so they remain referentially consistent.
@@ -227,5 +252,6 @@ export function useLaw(lawParam, articleParam) {
     saving,
     saveError,
     saveLaw,
+    lastSavedPr,
   };
 }

--- a/frontend/src/composables/useLaw.js
+++ b/frontend/src/composables/useLaw.js
@@ -1,6 +1,6 @@
 import { computed, ref, shallowRef } from 'vue';
 import yaml from 'js-yaml';
-import { getEditorSessionId } from './useEditorSession.js';
+import { getEditorSessionId, lastSavedPr } from './useEditorSession.js';
 
 // --- Shared law cache ---
 const lawCache = new Map();
@@ -50,11 +50,14 @@ export function useLaw(lawParam, articleParam) {
   const saving = ref(false);
   const saveError = ref(null);
   // PR opened or updated by the most recent successful save through the
-  // federated write-back path (RFC-010 phase 6). Stays populated across
-  // saves in the same editor session — every successful save returns the
-  // same PR info from the backend until the session ends or the PR is
-  // merged/closed. Null for local-source saves (no upstream PR).
-  const lastSavedPr = ref(null);
+  // federated write-back path (RFC-010 phase 6). Imported as a
+  // module-shared ref from useEditorSession so the badge in EditorApp
+  // reflects the most recent save regardless of which composable issued
+  // it (law-content saves via useLaw, scenario saves via useScenarios).
+  // Stays populated across saves in the same editor session — every
+  // successful save returns the same PR info from the backend until the
+  // session ends or the PR is merged/closed. Null for local-source saves
+  // (no upstream PR).
 
   const articles = computed(() => law.value?.articles ?? []);
 

--- a/frontend/src/composables/useLaw.js
+++ b/frontend/src/composables/useLaw.js
@@ -190,14 +190,14 @@ export function useLaw(lawParam, articleParam) {
         throw new Error(text);
       }
       // Backend returns `{ pr: { url, number, branch } | null }` on 200.
-      // We only update `lastSavedPr` for the originating law — same logic
-      // as `rawYaml`/`law` updates below: a stale response after the user
-      // switched laws shouldn't repaint the new law's PR badge.
+      // Update `lastSavedPr` unconditionally — the badge represents "last
+      // save's PR" not "current law's PR", and `useScenarios.saveScenario`
+      // applies the same rule. The reactive refs for `rawYaml`/`law` are
+      // still gated on `lawId.value === savedLawId` below because writing
+      // them after a law-switch would corrupt the new law's editor state.
       try {
         const json = await res.json();
-        if (lawId.value === savedLawId) {
-          lastSavedPr.value = json?.pr ?? null;
-        }
+        lastSavedPr.value = json?.pr ?? null;
       } catch {
         // Older deployments return a bare 200 without JSON — keep the
         // existing PR (if any) and treat the save as successful.

--- a/frontend/src/composables/useLaw.js
+++ b/frontend/src/composables/useLaw.js
@@ -1,6 +1,6 @@
 import { computed, ref, shallowRef } from 'vue';
 import yaml from 'js-yaml';
-import { getEditorSessionId, lastSavedPr } from './useEditorSession.js';
+import { getEditorSessionId, lastSavedPr, sanitizeSavedPr } from './useEditorSession.js';
 
 // --- Shared law cache ---
 const lawCache = new Map();
@@ -197,7 +197,7 @@ export function useLaw(lawParam, articleParam) {
       // them after a law-switch would corrupt the new law's editor state.
       try {
         const json = await res.json();
-        lastSavedPr.value = json?.pr ?? null;
+        lastSavedPr.value = sanitizeSavedPr(json?.pr);
       } catch {
         // Older deployments return a bare 200 without JSON — keep the
         // existing PR (if any) and treat the save as successful.

--- a/frontend/src/composables/useScenarios.js
+++ b/frontend/src/composables/useScenarios.js
@@ -2,6 +2,7 @@
  * useScenarios — fetch, manage, and save scenario files for a law.
  */
 import { ref, watch } from 'vue';
+import { getEditorSessionId } from './useEditorSession.js';
 
 export function useScenarios(lawId) {
   const scenarios = ref([]);
@@ -11,6 +12,10 @@ export function useScenarios(lawId) {
   const saving = ref(false);
   const error = ref(null);
   const saveError = ref(null);
+  // Same shape as useLaw's `lastSavedPr` — the editor renders one PR link
+  // for both law-content and scenario edits because every save in a
+  // session lands on the same upstream feature branch.
+  const lastSavedPr = ref(null);
 
   async function fetchScenarios() {
     if (!lawId.value) return;
@@ -77,13 +82,24 @@ export function useScenarios(lawId) {
         `/api/corpus/laws/${encodeURIComponent(lawId.value)}/scenarios/${encodeURIComponent(filename)}`,
         {
           method: 'PUT',
-          headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+          headers: {
+            'Content-Type': 'text/plain; charset=utf-8',
+            'X-Editor-Session': getEditorSessionId(),
+          },
           body: content,
         },
       );
       if (!res.ok) {
         const text = await res.text();
         throw new Error(text || `Save failed: ${res.status}`);
+      }
+      // Same `{ pr }` shape as the law-content save; capture for the
+      // shared "Bekijk op GitHub" badge in EditorApp.vue.
+      try {
+        const json = await res.json();
+        lastSavedPr.value = json?.pr ?? null;
+      } catch {
+        // Older deployments returned a bare 200 — keep the prior PR.
       }
       // Update local state with saved content
       featureText.value = content;
@@ -113,5 +129,6 @@ export function useScenarios(lawId) {
     selectScenario,
     fetchScenarios,
     saveScenario,
+    lastSavedPr,
   };
 }

--- a/frontend/src/composables/useScenarios.js
+++ b/frontend/src/composables/useScenarios.js
@@ -2,7 +2,7 @@
  * useScenarios — fetch, manage, and save scenario files for a law.
  */
 import { ref, watch } from 'vue';
-import { getEditorSessionId, lastSavedPr } from './useEditorSession.js';
+import { getEditorSessionId, lastSavedPr, sanitizeSavedPr } from './useEditorSession.js';
 
 export function useScenarios(lawId) {
   const scenarios = ref([]);
@@ -97,7 +97,7 @@ export function useScenarios(lawId) {
       // shared "Bekijk op GitHub" badge in EditorApp.vue.
       try {
         const json = await res.json();
-        lastSavedPr.value = json?.pr ?? null;
+        lastSavedPr.value = sanitizeSavedPr(json?.pr);
       } catch {
         // Older deployments returned a bare 200 — keep the prior PR.
       }

--- a/frontend/src/composables/useScenarios.js
+++ b/frontend/src/composables/useScenarios.js
@@ -2,7 +2,7 @@
  * useScenarios — fetch, manage, and save scenario files for a law.
  */
 import { ref, watch } from 'vue';
-import { getEditorSessionId } from './useEditorSession.js';
+import { getEditorSessionId, lastSavedPr } from './useEditorSession.js';
 
 export function useScenarios(lawId) {
   const scenarios = ref([]);
@@ -12,10 +12,10 @@ export function useScenarios(lawId) {
   const saving = ref(false);
   const error = ref(null);
   const saveError = ref(null);
-  // Same shape as useLaw's `lastSavedPr` — the editor renders one PR link
-  // for both law-content and scenario edits because every save in a
-  // session lands on the same upstream feature branch.
-  const lastSavedPr = ref(null);
+  // `lastSavedPr` is imported as a module-shared ref from useEditorSession
+  // so scenario saves and law-content saves both update the same value,
+  // and EditorApp's "Bekijk op GitHub" badge stays in sync regardless of
+  // which pane the user pressed Save in.
 
   async function fetchScenarios() {
     if (!lawId.value) return;

--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -3656,12 +3656,14 @@ dependencies = [
  "regelrecht-engine",
  "reqwest 0.13.2",
  "serde",
+ "serde_json",
  "serde_yaml_ng",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
  "walkdir",
+ "wiremock",
 ]
 
 [[package]]

--- a/packages/corpus/Cargo.toml
+++ b/packages/corpus/Cargo.toml
@@ -28,6 +28,8 @@ github = ["dep:reqwest"]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "process", "fs"] }
 tempfile.workspace = true
 regelrecht-engine = { path = "../engine" }
+wiremock.workspace = true
+serde_json.workspace = true
 
 [lints]
 workspace = true

--- a/packages/corpus/src/backend.rs
+++ b/packages/corpus/src/backend.rs
@@ -581,12 +581,13 @@ impl RepoBackend for GitBackend {
 /// edit reached upstream).
 ///
 /// File ops mirror `GitBackend`: read/write/delete/list go through the
-/// shared local checkout (`CorpusClient.repo_path()`). Session backends
-/// for the same source share the on-disk clone but write to different
-/// branches; the editor-api serialises persists per session via the
-/// surrounding mutex on this backend so two sessions for the same source
-/// never run `commit_and_push_to_branch` concurrently against the same
-/// working tree.
+/// local checkout owned by this backend's `CorpusClient`
+/// (`CorpusClient.repo_path()`). The editor-api gives **each** `(editor
+/// session, source)` pair its own on-disk clone (see
+/// `SessionRegistry::resolve_session_backend`), so two sessions writing
+/// to the same source do not share a working tree — the per-session
+/// mutex on this backend exists to serialise concurrent saves issued
+/// against the *same* session.
 #[cfg(feature = "github")]
 pub struct SessionGitBackend {
     client: CorpusClient,
@@ -673,10 +674,21 @@ impl SessionGitBackend {
         let mut body = String::new();
         body.push_str("Bewerkingen aangebracht via de Regelrecht-editor.\n\n");
         if let Some(author) = &ctx.author {
-            // \n is intentional — GitHub renders this on a new line.
+            // The OIDC display name and email come from an upstream IdP
+            // and are not under our control. Strip control characters
+            // before splicing into the Markdown body so a hostile name
+            // can't break PR layout (extra newlines flipping the trailing
+            // line into a heading, NUL bytes confusing GitHub's renderer,
+            // etc.). Plain Markdown special characters are left alone —
+            // GitHub sanitises HTML/script on its end, and stripping `*`
+            // / `_` would mangle legitimate names with diacritics-adjacent
+            // punctuation.
+            //
+            // \n at end is intentional — GitHub renders the next line below.
             body.push_str(&format!(
                 "Ingediend door: {} <{}>\n",
-                author.name, author.email
+                sanitize_pr_body_value(&author.name),
+                sanitize_pr_body_value(&author.email),
             ));
         }
         body.push_str(
@@ -684,6 +696,28 @@ impl SessionGitBackend {
         );
         (title, body)
     }
+}
+
+/// Strip ASCII / Unicode control characters from a value before splicing
+/// it into the PR body Markdown. Whitespace runs are collapsed to a
+/// single space so a trailing newline can't break the surrounding
+/// formatting.
+#[cfg(feature = "github")]
+fn sanitize_pr_body_value(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut last_was_space = false;
+    for c in s.chars() {
+        if c.is_control() {
+            if !last_was_space {
+                out.push(' ');
+                last_was_space = true;
+            }
+        } else {
+            out.push(c);
+            last_was_space = false;
+        }
+    }
+    out.trim().to_string()
 }
 
 #[cfg(feature = "github")]
@@ -1298,6 +1332,30 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(second.pr.unwrap().number, 99);
+    }
+
+    #[cfg(feature = "github")]
+    #[test]
+    fn sanitize_pr_body_value_strips_control_chars() {
+        // Newlines, tabs, NUL bytes in an OIDC display name must not bleed
+        // into the PR body Markdown — they could break layout (extra
+        // headings) or confuse GitHub's renderer.
+        let dirty = "Anne\nSchuth\u{0000}\t<X>";
+        let clean = sanitize_pr_body_value(dirty);
+        assert!(!clean.contains('\n'));
+        assert!(!clean.contains('\t'));
+        assert!(!clean.contains('\u{0000}'));
+        // Display characters survive, and consecutive control chars are
+        // collapsed to a single space rather than a run of spaces.
+        assert_eq!(clean, "Anne Schuth <X>");
+    }
+
+    #[cfg(feature = "github")]
+    #[test]
+    fn sanitize_pr_body_value_preserves_unicode_letters() {
+        // Diacritics and non-ASCII letters must pass through unchanged.
+        let s = "Renée Müller";
+        assert_eq!(sanitize_pr_body_value(s), s);
     }
 
     #[cfg(feature = "github")]

--- a/packages/corpus/src/backend.rs
+++ b/packages/corpus/src/backend.rs
@@ -713,18 +713,15 @@ fn sanitize_pr_body_value(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
     let mut last_was_space = false;
     for c in s.chars() {
-        if c.is_control() || c == '<' || c == '>' {
+        let is_whitespace_like = c.is_control() || c == '<' || c == '>' || c == ' ';
+        if is_whitespace_like {
             if !last_was_space {
                 out.push(' ');
                 last_was_space = true;
             }
         } else {
             out.push(c);
-            // Treat a regular space as already-emitted whitespace so a
-            // following control character (or `<`/`>`) does not produce
-            // a double space — e.g. "Foo <evil>" → "Foo evil" instead of
-            // "Foo  evil".
-            last_was_space = c == ' ';
+            last_was_space = false;
         }
     }
     out.trim().to_string()

--- a/packages/corpus/src/backend.rs
+++ b/packages/corpus/src/backend.rs
@@ -7,15 +7,63 @@ use crate::config::CorpusConfig;
 use crate::error::{CorpusError, Result};
 use crate::models::{Source, SourceType};
 
+/// Identifies the human editor behind a write — surfaced as a
+/// `Co-Authored-By` trailer on the commit and named in the PR body.
+///
+/// Optional because non-editor write paths (harvester, enrich worker) have
+/// no human in the loop. The git author/committer stays the service
+/// identity in all cases — this is a *credit* line, not an authentication
+/// claim.
+#[derive(Debug, Clone)]
+pub struct EditorUser {
+    /// Display name for the trailer. Should be a real human-readable name
+    /// when available; falls back to `email`'s local-part otherwise.
+    pub name: String,
+    /// Email used in the trailer. GitHub matches this to a user account if
+    /// it's registered as a verified email on someone's profile.
+    pub email: String,
+}
+
 /// Metadata for a write operation (used as commit message for git backends).
 pub struct WriteContext {
     pub message: String,
+    /// Human editor to credit on the resulting commit / PR. `None` for
+    /// non-editor paths (harvester etc.) which keep the existing
+    /// service-only attribution.
+    pub author: Option<EditorUser>,
 }
 
 /// A file entry returned by list operations.
 pub struct FileEntry {
     /// Filename only (not a full path), e.g. "eligibility.feature".
     pub name: String,
+}
+
+/// Identifies a PR opened or updated as part of a [`RepoBackend::persist`]
+/// call. Returned via [`PersistOutcome`] so the editor-api can surface the
+/// URL to the frontend after a save.
+///
+/// Lives on `backend` (not `pr_client`) so the type is available even when
+/// the `github` feature is disabled — keeps the [`PersistOutcome`] shape
+/// uniform across builds.
+#[derive(Debug, Clone)]
+pub struct PrInfo {
+    /// PR number on the source repo. Used to construct the title in
+    /// subsequent updates and to build the GitHub URL.
+    pub number: u64,
+    /// User-facing HTML URL of the PR.
+    pub html_url: String,
+}
+
+/// Result of a [`RepoBackend::persist`] call.
+///
+/// Most backends return [`PersistOutcome::default()`] (`pr: None`). The
+/// session-mode `GitBackend` populates `pr` with the PR it opened or
+/// updated; the editor-api forwards this to the save-response JSON so the
+/// frontend can render a "Bekijk op GitHub" link.
+#[derive(Debug, Default)]
+pub struct PersistOutcome {
+    pub pr: Option<PrInfo>,
 }
 
 /// Abstraction over different corpus storage backends.
@@ -41,9 +89,11 @@ pub trait RepoBackend: Send + Sync {
 
     /// Persist pending changes.
     ///
-    /// No-op for local backends. For git backends this commits dirty files and
-    /// pushes to the remote.
-    async fn persist(&self, ctx: &WriteContext) -> Result<()>;
+    /// No-op for local backends. For git backends this commits dirty files
+    /// and pushes to the remote. Returns a [`PersistOutcome`] describing
+    /// any side-effects the caller may want to surface (e.g. the PR opened
+    /// by a session-mode `GitBackend`).
+    async fn persist(&self, ctx: &WriteContext) -> Result<PersistOutcome>;
 
     /// Prepare the backend for use (validate directories, clone repos, etc.).
     async fn ensure_ready(&mut self) -> Result<()>;
@@ -227,9 +277,9 @@ impl RepoBackend for LocalBackend {
         Ok(entries)
     }
 
-    async fn persist(&self, _ctx: &WriteContext) -> Result<()> {
+    async fn persist(&self, _ctx: &WriteContext) -> Result<PersistOutcome> {
         // Local writes are immediate — nothing to persist.
-        Ok(())
+        Ok(PersistOutcome::default())
     }
 
     async fn ensure_ready(&mut self) -> Result<()> {
@@ -454,14 +504,14 @@ impl RepoBackend for GitBackend {
         Ok(entries)
     }
 
-    async fn persist(&self, ctx: &WriteContext) -> Result<()> {
+    async fn persist(&self, ctx: &WriteContext) -> Result<PersistOutcome> {
         let paths: Vec<PathBuf> = {
             let mut dirty = self.dirty_files.lock().await;
             std::mem::take(&mut *dirty)
         };
 
         if paths.is_empty() {
-            return Ok(());
+            return Ok(PersistOutcome::default());
         }
 
         let result = if self.local_only {
@@ -496,7 +546,11 @@ impl RepoBackend for GitBackend {
             return Err(e);
         }
 
-        Ok(())
+        // The harvester / non-session GitBackend doesn't open PRs — it
+        // pushes to the configured branch directly. PR info is only
+        // populated by the session-mode `GitBackend` (see
+        // `SessionGitBackend`).
+        Ok(PersistOutcome::default())
     }
 
     async fn ensure_ready(&mut self) -> Result<()> {
@@ -507,6 +561,261 @@ impl RepoBackend for GitBackend {
     /// mode (no push token) edits are committed to a local session branch.
     /// "Writable" here means "the backend will accept `write_file` calls",
     /// not "the backend will push to a remote".
+    fn is_writable(&self) -> bool {
+        true
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SessionGitBackend
+// ---------------------------------------------------------------------------
+
+/// Backend used by the editor write-back path (RFC-010 phase 6).
+///
+/// Each `(editor session, source repo)` pair gets its own
+/// `SessionGitBackend`. `persist` always pushes to a per-session feature
+/// branch and ensures an open PR exists against the source's configured
+/// branch — never pushes straight to the source's main branch and never
+/// silently degrades to local-only when no token is configured (a write
+/// without a push destination would mislead the user into thinking the
+/// edit reached upstream).
+///
+/// File ops mirror `GitBackend`: read/write/delete/list go through the
+/// shared local checkout (`CorpusClient.repo_path()`). Session backends
+/// for the same source share the on-disk clone but write to different
+/// branches; the editor-api serialises persists per session via the
+/// surrounding mutex on this backend so two sessions for the same source
+/// never run `commit_and_push_to_branch` concurrently against the same
+/// working tree.
+#[cfg(feature = "github")]
+pub struct SessionGitBackend {
+    client: CorpusClient,
+    repo_subpath: Option<String>,
+    dirty_files: tokio::sync::Mutex<Vec<PathBuf>>,
+    pr_client: crate::pr_client::PullRequestClient,
+    /// GitHub coordinates of the source — used for PR API calls.
+    github_owner: String,
+    github_repo: String,
+    /// Branch the PR targets (the source's configured branch).
+    base_branch: String,
+    /// Per-session feature branch this backend pushes to.
+    session_branch: String,
+    /// Bearer token used for both git push (already on `client`) and PR
+    /// API calls. Empty token is rejected at construction time.
+    pr_token: String,
+    /// Memoised PR info from the most recent successful persist.
+    /// Surfaced via `persist()`'s `PersistOutcome.pr` so subsequent saves
+    /// in the same session can keep returning the same URL without an
+    /// extra round-trip.
+    last_pr: tokio::sync::Mutex<Option<PrInfo>>,
+}
+
+#[cfg(feature = "github")]
+impl SessionGitBackend {
+    /// Build a session backend. Returns an error when `pr_token` is empty
+    /// — without a token there is no way to open the PR upstream and the
+    /// editor must surface that as a 403 rather than silently dropping
+    /// the edit.
+    pub fn new(
+        client: CorpusClient,
+        repo_subpath: Option<String>,
+        session_branch: String,
+        base_branch: String,
+        github_owner: String,
+        github_repo: String,
+        pr_token: String,
+    ) -> Result<Self> {
+        if pr_token.is_empty() {
+            return Err(CorpusError::Config(
+                "session GitBackend requires a non-empty PR token".to_string(),
+            ));
+        }
+        Ok(Self {
+            client,
+            repo_subpath,
+            dirty_files: tokio::sync::Mutex::new(Vec::new()),
+            pr_client: crate::pr_client::PullRequestClient::new()?,
+            github_owner,
+            github_repo,
+            base_branch,
+            session_branch,
+            pr_token,
+            last_pr: tokio::sync::Mutex::new(None),
+        })
+    }
+
+    /// Test-only: swap the PR client for one pointed at a wiremock server.
+    #[cfg(test)]
+    pub(crate) fn with_pr_client(mut self, pr_client: crate::pr_client::PullRequestClient) -> Self {
+        self.pr_client = pr_client;
+        self
+    }
+
+    fn resolve(&self, relative: &Path) -> Result<PathBuf> {
+        validate_relative_path(relative)?;
+        let base = match &self.repo_subpath {
+            Some(sub) => self.client.repo_path().join(sub),
+            None => self.client.repo_path().to_path_buf(),
+        };
+        Ok(base.join(relative))
+    }
+
+    /// Build the PR title and body. Recomputed on every persist so a
+    /// subsequent edit can refresh the body to reflect new context (the
+    /// PATCH side of `ensure_pr` carries this through).
+    fn pr_title_body(&self, ctx: &WriteContext) -> (String, String) {
+        let session_id = self
+            .session_branch
+            .strip_prefix("editor/session-")
+            .unwrap_or(&self.session_branch);
+        let title = format!("Editor session {session_id}");
+
+        let mut body = String::new();
+        body.push_str("Bewerkingen aangebracht via de Regelrecht-editor.\n\n");
+        if let Some(author) = &ctx.author {
+            // \n is intentional — GitHub renders this on a new line.
+            body.push_str(&format!(
+                "Ingediend door: {} <{}>\n",
+                author.name, author.email
+            ));
+        }
+        body.push_str(
+            "\n_Branch wordt automatisch bijgewerkt zolang dezelfde editor-sessie open blijft._\n",
+        );
+        (title, body)
+    }
+}
+
+#[cfg(feature = "github")]
+#[async_trait]
+impl RepoBackend for SessionGitBackend {
+    async fn read_file(&self, relative_path: &Path) -> Result<Option<String>> {
+        let abs = self.resolve(relative_path)?;
+        match tokio::fs::read_to_string(&abs).await {
+            Ok(content) => Ok(Some(content)),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    async fn write_file(&self, relative_path: &Path, content: &str) -> Result<()> {
+        let abs = self.resolve(relative_path)?;
+        if let Some(parent) = abs.parent() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+        tokio::fs::write(&abs, content).await?;
+        self.dirty_files.lock().await.push(abs);
+        Ok(())
+    }
+
+    async fn delete_file(&self, relative_path: &Path) -> Result<()> {
+        let abs = self.resolve(relative_path)?;
+        match tokio::fs::remove_file(&abs).await {
+            Ok(()) => {
+                self.dirty_files.lock().await.push(abs);
+                Ok(())
+            }
+            // Idempotent: missing-file delete is a no-op and does NOT
+            // enqueue a dirty entry, so a clean tree → empty persist →
+            // no commit / no push (consistent with `GitBackend`).
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    async fn list_files(&self, dir: &Path, extension: Option<&str>) -> Result<Vec<FileEntry>> {
+        let abs = self.resolve(dir)?;
+        let mut entries = Vec::new();
+
+        let mut read_dir = match tokio::fs::read_dir(&abs).await {
+            Ok(rd) => rd,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(entries),
+            Err(e) => return Err(e.into()),
+        };
+
+        while let Some(entry) = read_dir.next_entry().await? {
+            let ft = entry.file_type().await?;
+            if !ft.is_file() {
+                continue;
+            }
+            let path = entry.path();
+            if let Some(ext) = extension {
+                if path.extension().is_none_or(|e| e != ext) {
+                    continue;
+                }
+            }
+            if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                entries.push(FileEntry {
+                    name: name.to_string(),
+                });
+            }
+        }
+
+        entries.sort_by(|a, b| a.name.cmp(&b.name));
+        Ok(entries)
+    }
+
+    async fn persist(&self, ctx: &WriteContext) -> Result<PersistOutcome> {
+        let paths: Vec<PathBuf> = {
+            let mut dirty = self.dirty_files.lock().await;
+            std::mem::take(&mut *dirty)
+        };
+
+        if paths.is_empty() {
+            // Nothing to commit. If we already opened a PR earlier in the
+            // session, return that — the editor still wants the link.
+            return Ok(PersistOutcome {
+                pr: self.last_pr.lock().await.clone(),
+            });
+        }
+
+        let co_authored_by = ctx
+            .author
+            .as_ref()
+            .map(|a| (a.name.as_str(), a.email.as_str()));
+
+        if let Err(e) = self
+            .client
+            .commit_and_push_to_branch(
+                &self.session_branch,
+                &self.base_branch,
+                &paths,
+                &ctx.message,
+                co_authored_by,
+            )
+            .await
+        {
+            // Restore dirty files so the next save can retry. Note we do
+            // NOT restore them on PR-API failure below: at that point the
+            // commit + push succeeded so the data is upstream; only the
+            // PR open/update failed and the next persist would create a
+            // duplicate commit.
+            self.dirty_files.lock().await.extend(paths);
+            return Err(e);
+        }
+
+        let (title, body) = self.pr_title_body(ctx);
+        let pr = self
+            .pr_client
+            .ensure_pr(
+                &self.github_owner,
+                &self.github_repo,
+                &self.session_branch,
+                &self.base_branch,
+                &title,
+                &body,
+                &self.pr_token,
+            )
+            .await?;
+
+        *self.last_pr.lock().await = Some(pr.clone());
+        Ok(PersistOutcome { pr: Some(pr) })
+    }
+
+    async fn ensure_ready(&mut self) -> Result<()> {
+        self.client.ensure_repo().await
+    }
+
     fn is_writable(&self) -> bool {
         true
     }
@@ -584,6 +893,7 @@ mod tests {
         backend
             .persist(&WriteContext {
                 message: "test".to_string(),
+                author: None,
             })
             .await
             .unwrap();
@@ -735,6 +1045,7 @@ mod tests {
         backend
             .persist(&WriteContext {
                 message: "add test scenario".to_string(),
+                author: None,
             })
             .await
             .unwrap();
@@ -770,5 +1081,244 @@ mod tests {
             .unwrap();
         let remote_str = String::from_utf8_lossy(&remote_log.stdout);
         assert!(!remote_str.contains("add test scenario"));
+    }
+
+    /// Set up a bare repo on `development` and a checkout. Returns
+    /// (bare_path, working_repo_path, bare_url).
+    #[cfg(feature = "github")]
+    async fn setup_bare_with_checkout(dir: &Path) -> (PathBuf, PathBuf, String) {
+        use tokio::process::Command;
+
+        let bare_path = dir.join("bare.git");
+        Command::new("git")
+            .args(["init", "--bare", "--initial-branch=development"])
+            .arg(&bare_path)
+            .output()
+            .await
+            .unwrap();
+
+        let bare_url = format!("file://{}", bare_path.display());
+
+        // Seed initial commit on development
+        let seed = dir.join("seed");
+        Command::new("git")
+            .args(["clone", &bare_url])
+            .arg(&seed)
+            .output()
+            .await
+            .unwrap();
+        for args in [
+            vec!["config", "user.name", "test"],
+            vec!["config", "user.email", "test@test.nl"],
+            vec!["commit", "--allow-empty", "-m", "init"],
+            vec!["push", "origin", "development"],
+        ] {
+            Command::new("git")
+                .args(&args)
+                .current_dir(&seed)
+                .output()
+                .await
+                .unwrap();
+        }
+
+        // Working checkout the SessionGitBackend will use
+        let work = dir.join("work");
+        Command::new("git")
+            .args(["clone", "--branch", "development", &bare_url])
+            .arg(&work)
+            .output()
+            .await
+            .unwrap();
+        for args in [
+            vec!["config", "user.name", "Editor Service"],
+            vec!["config", "user.email", "editor@regelrecht.local"],
+        ] {
+            Command::new("git")
+                .args(&args)
+                .current_dir(&work)
+                .output()
+                .await
+                .unwrap();
+        }
+
+        (bare_path, work, bare_url)
+    }
+
+    #[cfg(feature = "github")]
+    #[tokio::test]
+    async fn session_backend_persists_then_opens_pr() {
+        use crate::pr_client::PullRequestClient;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let dir = TempDir::new().unwrap();
+        let (bare_path, work, bare_url) = setup_bare_with_checkout(dir.path()).await;
+
+        // Mock GitHub Pulls API.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/repos/minbzk/test-source/pulls"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/repos/minbzk/test-source/pulls"))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                "number": 12,
+                "html_url": "https://github.com/minbzk/test-source/pull/12",
+            })))
+            .mount(&server)
+            .await;
+
+        // Build the session backend.
+        let mut config = CorpusConfig::new(&bare_url, &work);
+        config.branch = "development".to_string();
+        let client = CorpusClient::new(config);
+
+        let pr_client = PullRequestClient::new()
+            .unwrap()
+            .with_base_url(server.uri());
+
+        let backend = SessionGitBackend::new(
+            client,
+            None,
+            "editor/session-abc123".to_string(),
+            "development".to_string(),
+            "minbzk".to_string(),
+            "test-source".to_string(),
+            "test-token".to_string(),
+        )
+        .unwrap()
+        .with_pr_client(pr_client);
+
+        // Edit + persist.
+        backend
+            .write_file(Path::new("article.md"), "edited body")
+            .await
+            .unwrap();
+
+        let outcome = backend
+            .persist(&WriteContext {
+                message: "Update article.md".to_string(),
+                author: Some(EditorUser {
+                    name: "Anne Schuth".to_string(),
+                    email: "anne@example.gov".to_string(),
+                }),
+            })
+            .await
+            .unwrap();
+
+        // PR returned to caller
+        let pr = outcome.pr.expect("persist should return PR info");
+        assert_eq!(pr.number, 12);
+        assert_eq!(pr.html_url, "https://github.com/minbzk/test-source/pull/12");
+
+        // Session branch exists on remote with our commit + trailer
+        let log = tokio::process::Command::new("git")
+            .args(["log", "editor/session-abc123", "--format=%B", "-1"])
+            .current_dir(&bare_path)
+            .output()
+            .await
+            .unwrap();
+        let body = String::from_utf8_lossy(&log.stdout);
+        assert!(
+            body.contains("Update article.md"),
+            "missing message in commit: {body}"
+        );
+        assert!(
+            body.contains("Co-authored-by: Anne Schuth <anne@example.gov>"),
+            "missing co-authored-by trailer: {body}"
+        );
+    }
+
+    #[cfg(feature = "github")]
+    #[tokio::test]
+    async fn session_backend_empty_persist_returns_cached_pr() {
+        use crate::pr_client::PullRequestClient;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let dir = TempDir::new().unwrap();
+        let (_bare, work, bare_url) = setup_bare_with_checkout(dir.path()).await;
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/repos/minbzk/test-source/pulls"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/repos/minbzk/test-source/pulls"))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                "number": 99,
+                "html_url": "https://github.com/minbzk/test-source/pull/99",
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let mut config = CorpusConfig::new(&bare_url, &work);
+        config.branch = "development".to_string();
+        let client = CorpusClient::new(config);
+        let pr_client = PullRequestClient::new()
+            .unwrap()
+            .with_base_url(server.uri());
+
+        let backend = SessionGitBackend::new(
+            client,
+            None,
+            "editor/session-cached".to_string(),
+            "development".to_string(),
+            "minbzk".to_string(),
+            "test-source".to_string(),
+            "test-token".to_string(),
+        )
+        .unwrap()
+        .with_pr_client(pr_client);
+
+        // First persist makes a real PR
+        backend.write_file(Path::new("a.md"), "hi").await.unwrap();
+        let first = backend
+            .persist(&WriteContext {
+                message: "edit".to_string(),
+                author: None,
+            })
+            .await
+            .unwrap();
+        assert_eq!(first.pr.unwrap().number, 99);
+
+        // Second persist with no dirty files returns the cached PR — no
+        // new HTTP calls (the wiremock `.expect(1)` enforces this).
+        let second = backend
+            .persist(&WriteContext {
+                message: "noop".to_string(),
+                author: None,
+            })
+            .await
+            .unwrap();
+        assert_eq!(second.pr.unwrap().number, 99);
+    }
+
+    #[cfg(feature = "github")]
+    #[tokio::test]
+    async fn session_backend_rejects_empty_token() {
+        let dir = TempDir::new().unwrap();
+        let (_bare, work, bare_url) = setup_bare_with_checkout(dir.path()).await;
+
+        let mut config = CorpusConfig::new(&bare_url, &work);
+        config.branch = "development".to_string();
+        let client = CorpusClient::new(config);
+
+        let result = SessionGitBackend::new(
+            client,
+            None,
+            "editor/session-x".to_string(),
+            "development".to_string(),
+            "owner".to_string(),
+            "repo".to_string(),
+            String::new(),
+        );
+        assert!(result.is_err(), "empty token must be rejected");
     }
 }

--- a/packages/corpus/src/backend.rs
+++ b/packages/corpus/src/backend.rs
@@ -803,10 +803,19 @@ impl RepoBackend for SessionGitBackend {
             });
         }
 
-        let co_authored_by = ctx
-            .author
+        // Sanitise name/email before they land in the commit message so a
+        // crafted OIDC display name can't inject extra Git trailers (e.g. a
+        // newline followed by `Reviewer-suggested-by: …`). Matches the
+        // identical defence applied to the PR body above.
+        let sanitized_author = ctx.author.as_ref().map(|a| {
+            (
+                sanitize_pr_body_value(&a.name),
+                sanitize_pr_body_value(&a.email),
+            )
+        });
+        let co_authored_by = sanitized_author
             .as_ref()
-            .map(|a| (a.name.as_str(), a.email.as_str()));
+            .map(|(name, email)| (name.as_str(), email.as_str()));
 
         if let Err(e) = self
             .client

--- a/packages/corpus/src/backend.rs
+++ b/packages/corpus/src/backend.rs
@@ -699,22 +699,32 @@ impl SessionGitBackend {
 }
 
 /// Strip ASCII / Unicode control characters from a value before splicing
-/// it into the PR body Markdown. Whitespace runs are collapsed to a
-/// single space so a trailing newline can't break the surrounding
-/// formatting.
+/// it into the PR body Markdown or a commit-message trailer. Whitespace
+/// runs are collapsed to a single space so a trailing newline can't break
+/// the surrounding formatting.
+///
+/// `<` and `>` are also replaced with a space: the call sites use these
+/// as delimiters around the email (`Name <email>` in the PR body and in
+/// the `Co-authored-by` trailer), so a display name like
+/// `"Foo <attacker@evil>"` would otherwise produce a malformed trailer
+/// (`Co-authored-by: Foo <attacker@evil> <real@email>`).
 #[cfg(feature = "github")]
 fn sanitize_pr_body_value(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
     let mut last_was_space = false;
     for c in s.chars() {
-        if c.is_control() {
+        if c.is_control() || c == '<' || c == '>' {
             if !last_was_space {
                 out.push(' ');
                 last_was_space = true;
             }
         } else {
             out.push(c);
-            last_was_space = false;
+            // Treat a regular space as already-emitted whitespace so a
+            // following control character (or `<`/`>`) does not produce
+            // a double space — e.g. "Foo <evil>" → "Foo evil" instead of
+            // "Foo  evil".
+            last_was_space = c == ' ';
         }
     }
     out.trim().to_string()
@@ -817,7 +827,7 @@ impl RepoBackend for SessionGitBackend {
             .as_ref()
             .map(|(name, email)| (name.as_str(), email.as_str()));
 
-        if let Err(e) = self
+        let pushed = match self
             .client
             .commit_and_push_to_branch(
                 &self.session_branch,
@@ -828,13 +838,28 @@ impl RepoBackend for SessionGitBackend {
             )
             .await
         {
-            // Restore dirty files so the next save can retry. Note we do
-            // NOT restore them on PR-API failure below: at that point the
-            // commit + push succeeded so the data is upstream; only the
-            // PR open/update failed and the next persist would create a
-            // duplicate commit.
-            self.dirty_files.lock().await.extend(paths);
-            return Err(e);
+            Ok(pushed) => pushed,
+            Err(e) => {
+                // Restore dirty files so the next save can retry. Note we
+                // do NOT restore them on PR-API failure below: at that
+                // point the commit + push succeeded so the data is
+                // upstream; only the PR open/update failed and the next
+                // persist would create a duplicate commit.
+                self.dirty_files.lock().await.extend(paths);
+                return Err(e);
+            }
+        };
+
+        // No commit was created (paths matched base content after
+        // snapshot+replay — typical when the user hits Save on a freshly
+        // loaded article without typing). Skip `ensure_pr`: on a brand-new
+        // session the branch was never pushed and GitHub would reject the
+        // PR open with a 422. Return the previously memoised PR (if any)
+        // so the editor keeps showing the existing badge.
+        if !pushed {
+            return Ok(PersistOutcome {
+                pr: self.last_pr.lock().await.clone(),
+            });
         }
 
         let (title, body) = self.pr_title_body(ctx);
@@ -1349,14 +1374,30 @@ mod tests {
         // Newlines, tabs, NUL bytes in an OIDC display name must not bleed
         // into the PR body Markdown — they could break layout (extra
         // headings) or confuse GitHub's renderer.
-        let dirty = "Anne\nSchuth\u{0000}\t<X>";
+        let dirty = "Anne\nSchuth\u{0000}\tX";
         let clean = sanitize_pr_body_value(dirty);
         assert!(!clean.contains('\n'));
         assert!(!clean.contains('\t'));
         assert!(!clean.contains('\u{0000}'));
         // Display characters survive, and consecutive control chars are
         // collapsed to a single space rather than a run of spaces.
-        assert_eq!(clean, "Anne Schuth <X>");
+        assert_eq!(clean, "Anne Schuth X");
+    }
+
+    #[cfg(feature = "github")]
+    #[test]
+    fn sanitize_pr_body_value_strips_angle_brackets() {
+        // `<` and `>` are reserved as the email delimiter in both the PR
+        // body line ("Ingediend door: Name <email>") and in the
+        // `Co-authored-by` trailer. A name like "Foo <attacker@evil>" must
+        // not survive — otherwise the resulting trailer
+        // "Co-authored-by: Foo <attacker@evil> <real@email>" is malformed
+        // and the attacker-controlled email may end up linked to the
+        // commit instead of the real author.
+        let clean = sanitize_pr_body_value("Foo <attacker@evil>");
+        assert!(!clean.contains('<'));
+        assert!(!clean.contains('>'));
+        assert_eq!(clean, "Foo attacker@evil");
     }
 
     #[cfg(feature = "github")]

--- a/packages/corpus/src/client.rs
+++ b/packages/corpus/src/client.rs
@@ -240,6 +240,26 @@ impl CorpusClient {
                 .await?;
         }
 
+        // Snapshot the dirty paths in memory BEFORE the checkout so we can
+        // restore them on top of `start_point`. Without this snapshot,
+        // `checkout -B branch <start_point>` would fail with "Your local
+        // changes would be overwritten" when the session branch was deleted
+        // upstream (start_point flips to origin/<base>) and the working
+        // tree's dirty file content conflicts with the base. A missing
+        // file in the snapshot means the caller invoked `delete_file`; we
+        // record `None` and replay by removing the file post-checkout so
+        // deletes survive the rebase onto `start_point`.
+        let mut snapshots: Vec<(PathBuf, Option<Vec<u8>>)> = Vec::with_capacity(paths.len());
+        for p in paths {
+            match tokio::fs::read(p).await {
+                Ok(bytes) => snapshots.push((p.clone(), Some(bytes))),
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                    snapshots.push((p.clone(), None));
+                }
+                Err(e) => return Err(e.into()),
+            }
+        }
+
         // Position on the session branch. `-B` resets-or-creates. Safe
         // because the session branch is single-writer per session UUID and
         // the editor-api process serialises persists for one session via
@@ -250,8 +270,39 @@ impl CorpusClient {
         } else {
             format!("origin/{base_branch}")
         };
+        // Remove the snapshot paths from disk so the subsequent
+        // `checkout -B` can never fail on "would be overwritten". We then
+        // replay the snapshot to put the user's edits back on top of
+        // `start_point`. Removing the file directly (rather than `git
+        // reset --hard`) avoids clobbering any *other* in-flight
+        // sibling-session edits in the same working tree.
+        for (path, _) in &snapshots {
+            match tokio::fs::remove_file(path).await {
+                Ok(()) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => return Err(e.into()),
+            }
+        }
         self.run_git(&["checkout", "-B", branch, &start_point])
             .await?;
+
+        // Replay the snapshot: write back tracked content, remove paths
+        // that were marked for deletion.
+        for (path, content) in &snapshots {
+            match content {
+                Some(bytes) => {
+                    if let Some(parent) = path.parent() {
+                        tokio::fs::create_dir_all(parent).await?;
+                    }
+                    tokio::fs::write(path, bytes).await?;
+                }
+                None => match tokio::fs::remove_file(path).await {
+                    Ok(()) => {}
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(e) => return Err(e.into()),
+                },
+            }
+        }
 
         // Stage the explicitly provided paths. Anything else dirty in the
         // working tree (left over from a previous sibling-session write)
@@ -1384,6 +1435,104 @@ mod tests {
         let out = String::from_utf8_lossy(&log.stdout);
         assert!(out.contains("first edit"), "missing first commit: {out}");
         assert!(out.contains("second edit"), "missing second commit: {out}");
+    }
+
+    /// Regression test: when the session branch is force-deleted upstream
+    /// while the working tree still carries dirty edits for files that
+    /// also exist on `base_branch` with different content, the next
+    /// `commit_and_push_to_branch` must NOT fail with "Your local changes
+    /// would be overwritten". The snapshot-then-replay path preserves
+    /// the user's edits across the rebase onto `origin/<base>`.
+    #[tokio::test]
+    async fn commit_and_push_to_branch_recovers_after_session_branch_deleted_upstream() {
+        let dir = tempfile::tempdir().unwrap();
+        let bare_path = setup_bare_repo(dir.path()).await;
+        let bare_url = format!("file://{}", bare_path.display());
+        let repo_path = dir.path().join("corpus");
+        clone_with_config(&bare_path, &repo_path).await;
+
+        // Seed development with a file that the editor will later edit.
+        let seed = repo_path.join("article.md");
+        tokio::fs::write(&seed, "original").await.unwrap();
+        for args in [
+            vec!["add", "."],
+            vec!["commit", "-m", "seed"],
+            vec!["push", "origin", "development"],
+        ] {
+            Command::new("git")
+                .args(&args)
+                .current_dir(&repo_path)
+                .output()
+                .await
+                .unwrap();
+        }
+
+        let mut config = CorpusConfig::new(&bare_url, &repo_path);
+        config.branch = "development".to_string();
+        let client = CorpusClient::new(config);
+
+        // First save creates the session branch upstream.
+        tokio::fs::write(&seed, "edit 1").await.unwrap();
+        client
+            .commit_and_push_to_branch(
+                "editor/session-rolled",
+                "development",
+                &[seed.clone()],
+                "first edit",
+                None,
+            )
+            .await
+            .unwrap();
+
+        // Simulate upstream force-deletion of the session branch.
+        Command::new("git")
+            .args(["branch", "-D", "editor/session-rolled"])
+            .current_dir(&bare_path)
+            .output()
+            .await
+            .unwrap();
+
+        // User edits again — working tree now diverges from origin/development.
+        tokio::fs::write(&seed, "edit 2").await.unwrap();
+
+        // This previously failed with "Your local changes would be
+        // overwritten" because the session branch was gone, `start_point`
+        // flipped to origin/development, and the dirty working tree
+        // conflicted with the base. The fix snapshots the dirty content
+        // before resetting and replays it after.
+        client
+            .commit_and_push_to_branch(
+                "editor/session-rolled",
+                "development",
+                &[seed.clone()],
+                "second edit",
+                None,
+            )
+            .await
+            .unwrap();
+
+        // The recovered session branch on the remote contains the second
+        // edit (no first edit, because it died with the force-deleted
+        // branch).
+        let log = Command::new("git")
+            .args(["log", "editor/session-rolled", "--oneline"])
+            .current_dir(&bare_path)
+            .output()
+            .await
+            .unwrap();
+        let out = String::from_utf8_lossy(&log.stdout);
+        assert!(out.contains("second edit"), "missing second edit: {out}");
+
+        // And the file content on the recovered branch reflects the
+        // user's most recent edit, not the base-branch version.
+        let show = Command::new("git")
+            .args(["show", "editor/session-rolled:article.md"])
+            .current_dir(&bare_path)
+            .output()
+            .await
+            .unwrap();
+        let content = String::from_utf8_lossy(&show.stdout);
+        assert_eq!(content.trim(), "edit 2");
     }
 
     #[tokio::test]

--- a/packages/corpus/src/client.rs
+++ b/packages/corpus/src/client.rs
@@ -203,6 +203,95 @@ impl CorpusClient {
         Err(last_error.unwrap_or_else(|| CorpusError::Git("push failed after retries".into())))
     }
 
+    /// Stage paths, commit, and push to a session branch (not the configured
+    /// branch). Used by the editor write-back path: each editor session owns
+    /// its own branch on the source repo, and `persist` calls land as
+    /// fast-forward commits on that branch (which a PR then surfaces).
+    ///
+    /// The session branch is single-writer per (session UUID, source). On
+    /// the first call it is created from `origin/{base_branch}`; on
+    /// subsequent calls it picks up wherever `origin/{branch}` left off so
+    /// the editor-api can restart between saves without losing progress
+    /// (the branch is the source of truth, not the in-memory state).
+    ///
+    /// Push is **not** force: if a second writer ever races us, the second
+    /// push fails with non-fast-forward and the user retries. Force-pushing
+    /// would silently drop the racing commit.
+    ///
+    /// `co_authored_by` is `(name, email)`; when present it gets appended
+    /// as a `Co-authored-by` trailer so GitHub credits the human editor on
+    /// the commit even though the git author/committer stays the service
+    /// identity.
+    pub async fn commit_and_push_to_branch(
+        &self,
+        branch: &str,
+        base_branch: &str,
+        paths: &[PathBuf],
+        message: &str,
+        co_authored_by: Option<(&str, &str)>,
+    ) -> Result<()> {
+        // Make sure we have the latest base, and the session branch tip
+        // when one already exists on the remote.
+        self.run_git(&["fetch", "--depth", "1", "origin", base_branch])
+            .await?;
+        let session_remote_exists = self.remote_branch_exists(branch).await?;
+        if session_remote_exists {
+            self.run_git(&["fetch", "--depth", "1", "origin", branch])
+                .await?;
+        }
+
+        // Position on the session branch. `-B` resets-or-creates. Safe
+        // because the session branch is single-writer per session UUID and
+        // the editor-api process serialises persists for one session via
+        // the SessionRegistry mutex; the local checkout is just a workspace
+        // we keep moving onto whichever session branch is being written.
+        let start_point = if session_remote_exists {
+            format!("origin/{branch}")
+        } else {
+            format!("origin/{base_branch}")
+        };
+        self.run_git(&["checkout", "-B", branch, &start_point])
+            .await?;
+
+        // Stage the explicitly provided paths. Anything else dirty in the
+        // working tree (left over from a previous sibling-session write)
+        // stays unstaged and won't be committed.
+        let mut add_args = vec!["add", "--"];
+        let path_strings: Vec<String> = paths
+            .iter()
+            .map(|p| p.to_string_lossy().to_string())
+            .collect();
+        for p in &path_strings {
+            add_args.push(p);
+        }
+        self.run_git(&add_args).await?;
+
+        // Skip empty commits — the user may have hit Save without changes.
+        let status = self.run_git_output(&["status", "--porcelain"]).await?;
+        if status.trim().is_empty() {
+            tracing::debug!(branch = %branch, "no changes to commit on session branch");
+            return Ok(());
+        }
+
+        let commit_message = match co_authored_by {
+            Some((name, email)) => format!("{message}\n\nCo-authored-by: {name} <{email}>"),
+            None => message.to_string(),
+        };
+        self.run_git(&["commit", "-m", &commit_message]).await?;
+
+        // First push of a new session branch needs `-u` to set upstream;
+        // after that the remote tracking is in place. Use `-u` always for
+        // safety — git is idempotent here.
+        self.run_git(&["push", "-u", "origin", branch]).await?;
+
+        tracing::info!(
+            branch = %branch,
+            base = %base_branch,
+            "pushed editor session commit"
+        );
+        Ok(())
+    }
+
     async fn git_clone(&self) -> Result<()> {
         let url = self.config.clone_url();
         let path_str = self.config.repo_path.to_string_lossy().to_string();
@@ -1187,5 +1276,145 @@ mod tests {
             .unwrap();
         let branches = String::from_utf8_lossy(&output.stdout);
         assert!(branches.contains("pr999"));
+    }
+
+    #[tokio::test]
+    async fn commit_and_push_to_branch_creates_session_branch_with_trailer() {
+        let dir = tempfile::tempdir().unwrap();
+        let bare_path = setup_bare_repo(dir.path()).await;
+        let bare_url = format!("file://{}", bare_path.display());
+        let repo_path = dir.path().join("corpus");
+        clone_with_config(&bare_path, &repo_path).await;
+
+        // Configure the client against `development` (the base) — the test
+        // covers the case where the session branch does NOT yet exist on
+        // the remote.
+        let mut config = CorpusConfig::new(&bare_url, &repo_path);
+        config.branch = "development".to_string();
+        let client = CorpusClient::new(config);
+
+        let edit = repo_path.join("article.md");
+        tokio::fs::write(&edit, "edit 1").await.unwrap();
+
+        client
+            .commit_and_push_to_branch(
+                "editor/session-test1",
+                "development",
+                &[edit.clone()],
+                "Update article.md",
+                Some(("Anne Schuth", "anne@example.gov")),
+            )
+            .await
+            .unwrap();
+
+        // Session branch should exist on the bare remote
+        let branches = Command::new("git")
+            .args(["branch"])
+            .current_dir(&bare_path)
+            .output()
+            .await
+            .unwrap();
+        let out = String::from_utf8_lossy(&branches.stdout);
+        assert!(
+            out.contains("editor/session-test1"),
+            "session branch missing from remote: {out}"
+        );
+
+        // The commit on that branch should carry the Co-authored-by trailer
+        let log = Command::new("git")
+            .args(["log", "editor/session-test1", "--format=%B", "-1"])
+            .current_dir(&bare_path)
+            .output()
+            .await
+            .unwrap();
+        let body = String::from_utf8_lossy(&log.stdout);
+        assert!(
+            body.contains("Co-authored-by: Anne Schuth <anne@example.gov>"),
+            "missing trailer in commit body: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn commit_and_push_to_branch_appends_to_existing_session_branch() {
+        let dir = tempfile::tempdir().unwrap();
+        let bare_path = setup_bare_repo(dir.path()).await;
+        let bare_url = format!("file://{}", bare_path.display());
+        let repo_path = dir.path().join("corpus");
+        clone_with_config(&bare_path, &repo_path).await;
+
+        let mut config = CorpusConfig::new(&bare_url, &repo_path);
+        config.branch = "development".to_string();
+        let client = CorpusClient::new(config);
+
+        // First commit on the session branch
+        let f1 = repo_path.join("a.md");
+        tokio::fs::write(&f1, "first").await.unwrap();
+        client
+            .commit_and_push_to_branch(
+                "editor/session-multi",
+                "development",
+                &[f1],
+                "first edit",
+                None,
+            )
+            .await
+            .unwrap();
+
+        // Second commit on the SAME session branch
+        let f2 = repo_path.join("b.md");
+        tokio::fs::write(&f2, "second").await.unwrap();
+        client
+            .commit_and_push_to_branch(
+                "editor/session-multi",
+                "development",
+                &[f2],
+                "second edit",
+                None,
+            )
+            .await
+            .unwrap();
+
+        // Both commits should be on the session branch on the remote
+        let log = Command::new("git")
+            .args(["log", "editor/session-multi", "--oneline"])
+            .current_dir(&bare_path)
+            .output()
+            .await
+            .unwrap();
+        let out = String::from_utf8_lossy(&log.stdout);
+        assert!(out.contains("first edit"), "missing first commit: {out}");
+        assert!(out.contains("second edit"), "missing second commit: {out}");
+    }
+
+    #[tokio::test]
+    async fn commit_and_push_to_branch_no_changes_is_noop() {
+        let dir = tempfile::tempdir().unwrap();
+        let bare_path = setup_bare_repo(dir.path()).await;
+        let bare_url = format!("file://{}", bare_path.display());
+        let repo_path = dir.path().join("corpus");
+        clone_with_config(&bare_path, &repo_path).await;
+
+        let mut config = CorpusConfig::new(&bare_url, &repo_path);
+        config.branch = "development".to_string();
+        let client = CorpusClient::new(config);
+
+        // Empty paths and clean tree → should not error and should not
+        // create the branch on the remote.
+        client
+            .commit_and_push_to_branch("editor/session-empty", "development", &[], "no-op", None)
+            .await
+            .unwrap();
+
+        let branches = Command::new("git")
+            .args(["branch"])
+            .current_dir(&bare_path)
+            .output()
+            .await
+            .unwrap();
+        let out = String::from_utf8_lossy(&branches.stdout);
+        assert!(
+            !out.contains("editor/session-empty"),
+            "no-op should not create remote branch: {out}"
+        );
     }
 }

--- a/packages/corpus/src/client.rs
+++ b/packages/corpus/src/client.rs
@@ -222,6 +222,13 @@ impl CorpusClient {
     /// as a `Co-authored-by` trailer so GitHub credits the human editor on
     /// the commit even though the git author/committer stays the service
     /// identity.
+    ///
+    /// Returns `Ok(true)` when a commit was created and pushed to the
+    /// remote, `Ok(false)` when there was nothing to commit (empty `paths`
+    /// or all files matched the base content after snapshot+replay). The
+    /// caller uses this to gate downstream side-effects like opening a PR
+    /// — calling PR-open against a branch that was never pushed would
+    /// return a 422 from GitHub.
     pub async fn commit_and_push_to_branch(
         &self,
         branch: &str,
@@ -229,7 +236,7 @@ impl CorpusClient {
         paths: &[PathBuf],
         message: &str,
         co_authored_by: Option<(&str, &str)>,
-    ) -> Result<()> {
+    ) -> Result<bool> {
         // Make sure we have the latest base, and the session branch tip
         // when one already exists on the remote.
         self.run_git(&["fetch", "--depth", "1", "origin", base_branch])
@@ -321,7 +328,7 @@ impl CorpusClient {
         let status = self.run_git_output(&["status", "--porcelain"]).await?;
         if status.trim().is_empty() {
             tracing::debug!(branch = %branch, "no changes to commit on session branch");
-            return Ok(());
+            return Ok(false);
         }
 
         let commit_message = match co_authored_by {
@@ -340,7 +347,7 @@ impl CorpusClient {
             base = %base_branch,
             "pushed editor session commit"
         );
-        Ok(())
+        Ok(true)
     }
 
     async fn git_clone(&self) -> Result<()> {
@@ -1549,10 +1556,14 @@ mod tests {
 
         // Empty paths and clean tree → should not error and should not
         // create the branch on the remote.
-        client
+        let pushed = client
             .commit_and_push_to_branch("editor/session-empty", "development", &[], "no-op", None)
             .await
             .unwrap();
+        assert!(
+            !pushed,
+            "no-op call must report `pushed=false` so callers can skip PR-open"
+        );
 
         let branches = Command::new("git")
             .args(["branch"])
@@ -1564,6 +1575,75 @@ mod tests {
         assert!(
             !out.contains("editor/session-empty"),
             "no-op should not create remote branch: {out}"
+        );
+    }
+
+    /// Regression for the iteration-3 finding: when `paths` is non-empty
+    /// but every path's content already matches the base after
+    /// snapshot+replay, no commit is created and no branch is pushed.
+    /// The function must report `pushed=false` so the editor's
+    /// `SessionGitBackend::persist` can skip `ensure_pr` (calling the
+    /// GitHub PR-open API against a branch that was never pushed returns
+    /// 422).
+    #[tokio::test]
+    async fn commit_and_push_to_branch_reports_no_push_when_content_matches_base() {
+        let dir = tempfile::tempdir().unwrap();
+        let bare_path = setup_bare_repo(dir.path()).await;
+        let bare_url = format!("file://{}", bare_path.display());
+        let repo_path = dir.path().join("corpus");
+        clone_with_config(&bare_path, &repo_path).await;
+
+        // Seed `development` with a file the user will later "save"
+        // without actually changing.
+        let seed = repo_path.join("article.md");
+        tokio::fs::write(&seed, "base content").await.unwrap();
+        for args in [
+            vec!["add", "."],
+            vec!["commit", "-m", "seed"],
+            vec!["push", "origin", "development"],
+        ] {
+            Command::new("git")
+                .args(&args)
+                .current_dir(&repo_path)
+                .output()
+                .await
+                .unwrap();
+        }
+
+        let mut config = CorpusConfig::new(&bare_url, &repo_path);
+        config.branch = "development".to_string();
+        let client = CorpusClient::new(config);
+
+        // The user "edits" the file but the content is identical to
+        // origin/development — the editor still passes the path through
+        // `dirty_files` because `write_file` cannot cheaply distinguish.
+        tokio::fs::write(&seed, "base content").await.unwrap();
+
+        let pushed = client
+            .commit_and_push_to_branch(
+                "editor/session-unchanged",
+                "development",
+                &[seed.clone()],
+                "no-op save",
+                None,
+            )
+            .await
+            .unwrap();
+        assert!(
+            !pushed,
+            "content-matches-base must report `pushed=false` so callers can skip PR-open"
+        );
+
+        let branches = Command::new("git")
+            .args(["branch"])
+            .current_dir(&bare_path)
+            .output()
+            .await
+            .unwrap();
+        let out = String::from_utf8_lossy(&branches.stdout);
+        assert!(
+            !out.contains("editor/session-unchanged"),
+            "no-commit path must not push branch to remote: {out}"
         );
     }
 }

--- a/packages/corpus/src/client.rs
+++ b/packages/corpus/src/client.rs
@@ -5,6 +5,27 @@ use tokio::process::Command;
 use crate::config::CorpusConfig;
 use crate::error::{CorpusError, Result};
 
+/// Best-effort: write the snapshot contents back to disk after a failed
+/// `checkout -B`. Used only on the error path so the working tree does not
+/// look truncated to the user while their dirty content is still preserved
+/// in memory by the caller. Filesystem errors are swallowed deliberately —
+/// the original git error is what the caller cares about.
+async fn replay_snapshot_best_effort(snapshots: &[(PathBuf, Option<Vec<u8>>)]) {
+    for (path, content) in snapshots {
+        match content {
+            Some(bytes) => {
+                if let Some(parent) = path.parent() {
+                    let _ = tokio::fs::create_dir_all(parent).await;
+                }
+                let _ = tokio::fs::write(path, bytes).await;
+            }
+            None => {
+                let _ = tokio::fs::remove_file(path).await;
+            }
+        }
+    }
+}
+
 pub struct CorpusClient {
     config: CorpusConfig,
     askpass_path: Option<PathBuf>,
@@ -290,8 +311,20 @@ impl CorpusClient {
                 Err(e) => return Err(e.into()),
             }
         }
-        self.run_git(&["checkout", "-B", branch, &start_point])
-            .await?;
+        // If `checkout -B` fails, the dirty paths are still removed from disk
+        // (above). The caller's `persist` keeps the in-memory `dirty_files`
+        // list intact, but a follow-up save would re-write the paths before
+        // committing — so the *content* is recoverable from browser state. To
+        // avoid leaving the working tree visibly missing files in the meantime,
+        // best-effort replay the snapshot back to disk before propagating the
+        // checkout error.
+        if let Err(e) = self
+            .run_git(&["checkout", "-B", branch, &start_point])
+            .await
+        {
+            replay_snapshot_best_effort(&snapshots).await;
+            return Err(e);
+        }
 
         // Replay the snapshot: write back tracked content, remove paths
         // that were marked for deletion.

--- a/packages/corpus/src/lib.rs
+++ b/packages/corpus/src/lib.rs
@@ -7,15 +7,22 @@ pub mod error;
 #[cfg(feature = "github")]
 pub mod github;
 pub mod models;
+#[cfg(feature = "github")]
+pub mod pr_client;
 pub mod registry;
 pub mod source_map;
 pub mod validation;
 
+pub use backend::PrInfo;
+#[cfg(feature = "github")]
+pub use backend::SessionGitBackend;
 pub use client::CorpusClient;
 pub use config::{deployment_from_hostname, CorpusConfig};
 pub use error::CorpusError;
 #[cfg(feature = "github")]
 pub use github::{FetchResult, GitHubFetcher};
 pub use models::{RegistryManifest, Source, SourceType};
+#[cfg(feature = "github")]
+pub use pr_client::PullRequestClient;
 pub use registry::CorpusRegistry;
 pub use source_map::SourceMap;

--- a/packages/corpus/src/pr_client.rs
+++ b/packages/corpus/src/pr_client.rs
@@ -53,8 +53,10 @@ mod inner {
         /// Build a client. Uses the standard `regelrecht-corpus/0.1` UA so
         /// requests are traceable in GitHub audit logs the same way reads are.
         pub fn new() -> Result<Self> {
+            // User-Agent is set per-request in `default_headers` so requests
+            // remain traceable in GitHub audit logs without configuring it
+            // twice on the client.
             let client = reqwest::Client::builder()
-                .user_agent("regelrecht-corpus/0.1")
                 .connect_timeout(std::time::Duration::from_secs(30))
                 .timeout(std::time::Duration::from_secs(60))
                 .build()

--- a/packages/corpus/src/pr_client.rs
+++ b/packages/corpus/src/pr_client.rs
@@ -1,0 +1,413 @@
+//! GitHub Pull Request API client.
+//!
+//! A small, focused client for the three Pulls API calls the editor's
+//! write-back path needs:
+//! - `GET /repos/{owner}/{repo}/pulls?head={owner}:{branch}&state=open`
+//!   to look for an open PR on a session branch.
+//! - `POST /repos/{owner}/{repo}/pulls` to open a new PR.
+//! - `PATCH /repos/{owner}/{repo}/pulls/{number}` to refresh title/body
+//!   when a session adds more commits to an existing PR.
+//!
+//! Hand-rolled with `reqwest` rather than pulling in `octocrab` because the
+//! surface is tiny and the corpus crate already speaks `reqwest` for the
+//! Trees/Contents API. Reconsider if PR comments / review state get added.
+
+#[cfg(feature = "github")]
+mod inner {
+    use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, AUTHORIZATION, USER_AGENT};
+    use serde::{Deserialize, Serialize};
+
+    use crate::backend::PrInfo;
+    use crate::error::{CorpusError, Result};
+
+    /// Hand-rolled GitHub Pulls API client.
+    pub struct PullRequestClient {
+        client: reqwest::Client,
+        /// Base URL of the GitHub API. Always `https://api.github.com` in
+        /// production; overridable via [`PullRequestClient::with_base_url`]
+        /// for tests that point at a wiremock server.
+        base_url: String,
+    }
+
+    #[derive(Debug, Serialize)]
+    struct CreatePrBody<'a> {
+        title: &'a str,
+        body: &'a str,
+        head: &'a str,
+        base: &'a str,
+    }
+
+    #[derive(Debug, Serialize)]
+    struct UpdatePrBody<'a> {
+        title: &'a str,
+        body: &'a str,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct PrResponse {
+        number: u64,
+        html_url: String,
+    }
+
+    impl PullRequestClient {
+        /// Build a client. Uses the standard `regelrecht-corpus/0.1` UA so
+        /// requests are traceable in GitHub audit logs the same way reads are.
+        pub fn new() -> Result<Self> {
+            let client = reqwest::Client::builder()
+                .user_agent("regelrecht-corpus/0.1")
+                .connect_timeout(std::time::Duration::from_secs(30))
+                .timeout(std::time::Duration::from_secs(60))
+                .build()
+                .map_err(|e| {
+                    CorpusError::Config(format!("failed to create PR HTTP client: {}", e))
+                })?;
+            Ok(Self {
+                client,
+                base_url: "https://api.github.com".to_string(),
+            })
+        }
+
+        /// Override the API base URL. Intended for tests that point at a
+        /// wiremock server. `base_url` should not include a trailing slash.
+        pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
+            self.base_url = base_url.into();
+            self
+        }
+
+        /// Idempotently ensure there is an open PR for `head` against `base`.
+        ///
+        /// - If an open PR for `head` already exists, refresh its title/body
+        ///   (so subsequent saves in the same session can update the
+        ///   description with new context) and return its info.
+        /// - Otherwise open a new PR.
+        ///
+        /// Returns the resulting [`PrInfo`]. Errors when the API call fails
+        /// or the response can't be parsed; the caller surfaces those as a
+        /// 5xx on the save endpoint.
+        ///
+        /// `head` is the branch name on the source repo (no `owner:` prefix
+        /// — this client always pushes to and PRs from the same repo, so a
+        /// fork-style `owner:branch` reference is unnecessary). The
+        /// `head=...` query parameter on the list call is built internally
+        /// using `repo_owner:head` per the GitHub API spec.
+        // The seven-arg signature mirrors the GitHub Pulls API shape; bundling
+        // them into a struct would just shuffle the same data into named
+        // fields without making call sites clearer (there's only one caller,
+        // and it builds the args from named struct fields anyway).
+        #[allow(clippy::too_many_arguments)]
+        pub async fn ensure_pr(
+            &self,
+            owner: &str,
+            repo: &str,
+            head: &str,
+            base: &str,
+            title: &str,
+            body: &str,
+            token: &str,
+        ) -> Result<PrInfo> {
+            if let Some(existing) = self.find_open_pr(owner, repo, head, token).await? {
+                self.update_pr(owner, repo, existing.number, title, body, token)
+                    .await
+            } else {
+                self.create_pr(owner, repo, head, base, title, body, token)
+                    .await
+            }
+        }
+
+        async fn find_open_pr(
+            &self,
+            owner: &str,
+            repo: &str,
+            head: &str,
+            token: &str,
+        ) -> Result<Option<PrResponse>> {
+            // Per GitHub spec, `head` filter must be `owner:branch`.
+            let url = format!(
+                "{}/repos/{}/{}/pulls?state=open&head={}:{}",
+                self.base_url, owner, repo, owner, head
+            );
+
+            let response = self
+                .client
+                .get(&url)
+                .headers(self.default_headers(token))
+                .send()
+                .await
+                .map_err(|e| CorpusError::Git(format!("PR list request failed: {}", e)))?;
+
+            if !response.status().is_success() {
+                return Err(CorpusError::Git(format!(
+                    "GitHub PR list returned {}: {}",
+                    response.status(),
+                    response.text().await.unwrap_or_default()
+                )));
+            }
+
+            let prs: Vec<PrResponse> = response
+                .json()
+                .await
+                .map_err(|e| CorpusError::Git(format!("failed to parse PR list: {}", e)))?;
+
+            // Multiple open PRs for the same head shouldn't happen in
+            // practice (GitHub blocks duplicates), but if it does we pick
+            // the first to keep behaviour deterministic.
+            Ok(prs.into_iter().next())
+        }
+
+        #[allow(clippy::too_many_arguments)]
+        async fn create_pr(
+            &self,
+            owner: &str,
+            repo: &str,
+            head: &str,
+            base: &str,
+            title: &str,
+            body: &str,
+            token: &str,
+        ) -> Result<PrInfo> {
+            let url = format!("{}/repos/{}/{}/pulls", self.base_url, owner, repo);
+            let payload = CreatePrBody {
+                title,
+                body,
+                head,
+                base,
+            };
+
+            let response = self
+                .client
+                .post(&url)
+                .headers(self.default_headers(token))
+                .json(&payload)
+                .send()
+                .await
+                .map_err(|e| CorpusError::Git(format!("PR create request failed: {}", e)))?;
+
+            if !response.status().is_success() {
+                return Err(CorpusError::Git(format!(
+                    "GitHub PR create returned {}: {}",
+                    response.status(),
+                    response.text().await.unwrap_or_default()
+                )));
+            }
+
+            let pr: PrResponse = response.json().await.map_err(|e| {
+                CorpusError::Git(format!("failed to parse PR create response: {}", e))
+            })?;
+
+            Ok(PrInfo {
+                number: pr.number,
+                html_url: pr.html_url,
+            })
+        }
+
+        async fn update_pr(
+            &self,
+            owner: &str,
+            repo: &str,
+            number: u64,
+            title: &str,
+            body: &str,
+            token: &str,
+        ) -> Result<PrInfo> {
+            let url = format!(
+                "{}/repos/{}/{}/pulls/{}",
+                self.base_url, owner, repo, number
+            );
+            let payload = UpdatePrBody { title, body };
+
+            let response = self
+                .client
+                .patch(&url)
+                .headers(self.default_headers(token))
+                .json(&payload)
+                .send()
+                .await
+                .map_err(|e| CorpusError::Git(format!("PR update request failed: {}", e)))?;
+
+            if !response.status().is_success() {
+                return Err(CorpusError::Git(format!(
+                    "GitHub PR update returned {}: {}",
+                    response.status(),
+                    response.text().await.unwrap_or_default()
+                )));
+            }
+
+            let pr: PrResponse = response.json().await.map_err(|e| {
+                CorpusError::Git(format!("failed to parse PR update response: {}", e))
+            })?;
+
+            Ok(PrInfo {
+                number: pr.number,
+                html_url: pr.html_url,
+            })
+        }
+
+        fn default_headers(&self, token: &str) -> HeaderMap {
+            let mut headers = HeaderMap::new();
+            headers.insert(
+                USER_AGENT,
+                HeaderValue::from_static("regelrecht-corpus/0.1"),
+            );
+            headers.insert(
+                ACCEPT,
+                HeaderValue::from_static("application/vnd.github+json"),
+            );
+            headers.insert(
+                "X-GitHub-Api-Version",
+                HeaderValue::from_static("2022-11-28"),
+            );
+            if let Ok(val) = HeaderValue::from_str(&format!("Bearer {}", token)) {
+                headers.insert(AUTHORIZATION, val);
+            }
+            headers
+        }
+    }
+
+    #[cfg(test)]
+    #[allow(clippy::unwrap_used)]
+    mod tests {
+        use super::*;
+        use wiremock::matchers::{body_partial_json, header, method, path, query_param};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        fn client_for(server: &MockServer) -> PullRequestClient {
+            PullRequestClient::new()
+                .unwrap()
+                .with_base_url(server.uri())
+        }
+
+        #[tokio::test]
+        async fn ensure_pr_creates_when_none_exists() {
+            let server = MockServer::start().await;
+
+            // No existing PR for this head
+            Mock::given(method("GET"))
+                .and(path("/repos/org/repo/pulls"))
+                .and(query_param("state", "open"))
+                .and(query_param("head", "org:editor/session-abc"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+                .expect(1)
+                .mount(&server)
+                .await;
+
+            // Create call returns 201 + new PR
+            Mock::given(method("POST"))
+                .and(path("/repos/org/repo/pulls"))
+                .and(header("Authorization", "Bearer test-token"))
+                .and(body_partial_json(serde_json::json!({
+                    "head": "editor/session-abc",
+                    "base": "main",
+                    "title": "Editor session abc",
+                })))
+                .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                    "number": 42,
+                    "html_url": "https://github.com/org/repo/pull/42",
+                })))
+                .expect(1)
+                .mount(&server)
+                .await;
+
+            let pr = client_for(&server)
+                .ensure_pr(
+                    "org",
+                    "repo",
+                    "editor/session-abc",
+                    "main",
+                    "Editor session abc",
+                    "Submitted via Regelrecht editor",
+                    "test-token",
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(pr.number, 42);
+            assert_eq!(pr.html_url, "https://github.com/org/repo/pull/42");
+        }
+
+        #[tokio::test]
+        async fn ensure_pr_updates_existing_open_pr() {
+            let server = MockServer::start().await;
+
+            // Existing open PR returned by list call
+            Mock::given(method("GET"))
+                .and(path("/repos/org/repo/pulls"))
+                .and(query_param("head", "org:editor/session-xyz"))
+                .respond_with(
+                    ResponseTemplate::new(200).set_body_json(serde_json::json!([{
+                        "number": 7,
+                        "html_url": "https://github.com/org/repo/pull/7",
+                    }])),
+                )
+                .expect(1)
+                .mount(&server)
+                .await;
+
+            // PATCH refreshes title/body and returns the same PR
+            Mock::given(method("PATCH"))
+                .and(path("/repos/org/repo/pulls/7"))
+                .and(body_partial_json(serde_json::json!({
+                    "title": "Editor session xyz (3 edits)",
+                })))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "number": 7,
+                    "html_url": "https://github.com/org/repo/pull/7",
+                })))
+                .expect(1)
+                .mount(&server)
+                .await;
+
+            // Reject any POST (create) — we must NOT open a new PR
+            Mock::given(method("POST"))
+                .and(path("/repos/org/repo/pulls"))
+                .respond_with(ResponseTemplate::new(500))
+                .expect(0)
+                .mount(&server)
+                .await;
+
+            let pr = client_for(&server)
+                .ensure_pr(
+                    "org",
+                    "repo",
+                    "editor/session-xyz",
+                    "main",
+                    "Editor session xyz (3 edits)",
+                    "updated body",
+                    "test-token",
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(pr.number, 7);
+        }
+
+        #[tokio::test]
+        async fn ensure_pr_propagates_api_error() {
+            let server = MockServer::start().await;
+
+            Mock::given(method("GET"))
+                .and(path("/repos/org/repo/pulls"))
+                .respond_with(ResponseTemplate::new(403).set_body_string("forbidden"))
+                .mount(&server)
+                .await;
+
+            let err = client_for(&server)
+                .ensure_pr(
+                    "org",
+                    "repo",
+                    "editor/session-foo",
+                    "main",
+                    "title",
+                    "body",
+                    "no-perms-token",
+                )
+                .await
+                .expect_err("403 must error");
+
+            let msg = err.to_string();
+            assert!(msg.contains("403"), "error should include status: {msg}");
+        }
+    }
+}
+
+#[cfg(feature = "github")]
+pub use inner::*;

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -585,17 +585,31 @@ struct EditorWriteTarget {
 /// Resolve the write target for a law-content (`save_law`) edit by routing
 /// through the [`SessionRegistry`] for GitHub sources and falling back to
 /// the existing global backend resolution for local sources.
-async fn resolve_law_write_target(
+/// Common write-target resolution: look up the law under a single corpus
+/// read guard, snapshot the source, drop the guard, resolve the session
+/// backend, enforce writability for local sources, and acquire the
+/// backend's owned mutex. Callers compute the final `relative_path` from
+/// the returned `LoadedLaw`.
+///
+/// Held as a single helper because both the law-content and scenario
+/// write paths need the exact same lock ordering and writability check —
+/// previously this lived as two near-identical copies that would have
+/// diverged silently if the slow-path semantics were ever revisited.
+async fn resolve_session_write_backend(
     state: &AppState,
     session_id: &str,
     law_id: &str,
-) -> Result<EditorWriteTarget, (StatusCode, String)> {
-    // Look up the law (and snapshot the source state) under a single
-    // corpus read guard, then drop it before calling into the
-    // SessionRegistry. The slow-path session-backend init runs `git
-    // clone` and we must not hold the corpus read guard across that —
-    // otherwise a concurrent `POST /api/corpus/reload` (which takes the
-    // write guard) is starved for the duration of the clone.
+) -> Result<
+    (
+        LoadedLaw,
+        tokio::sync::OwnedMutexGuard<Box<dyn RepoBackend>>,
+    ),
+    (StatusCode, String),
+> {
+    // Snapshot under a single corpus read guard, then drop it. The
+    // slow-path session-backend init runs `git clone`; holding the corpus
+    // read guard across it would starve any concurrent
+    // `POST /api/corpus/reload` (which takes the write guard).
     let (law, snapshot) = {
         let corpus = state.corpus.read().await;
         let law = corpus
@@ -629,14 +643,20 @@ async fn resolve_law_write_target(
             backend.is_writable()
         };
         if !writable {
-            return Err((
-                StatusCode::FORBIDDEN,
-                "Law is stored on a read-only source".to_string(),
-            ));
+            return Err((StatusCode::FORBIDDEN, "Source is read-only".to_string()));
         }
     }
 
     let backend = resolved.backend.lock_owned().await;
+    Ok((law, backend))
+}
+
+async fn resolve_law_write_target(
+    state: &AppState,
+    session_id: &str,
+    law_id: &str,
+) -> Result<EditorWriteTarget, (StatusCode, String)> {
+    let (law, backend) = resolve_session_write_backend(state, session_id, law_id).await?;
     Ok(EditorWriteTarget {
         relative_path: PathBuf::from(&law.relative_path),
         backend,
@@ -651,46 +671,8 @@ async fn resolve_scenario_write_target(
     law_id: &str,
     filename: &str,
 ) -> Result<EditorWriteTarget, (StatusCode, String)> {
-    // Snapshot under a single corpus read guard, then drop it — same
-    // reasoning as `resolve_law_write_target` above (the slow-path
-    // session-backend init runs `git clone` and must not hold the corpus
-    // read guard across that or `POST /api/corpus/reload` is starved).
-    let (law, snapshot) = {
-        let corpus = state.corpus.read().await;
-        let law = corpus
-            .source_map
-            .get_law(law_id)
-            .ok_or_else(|| (StatusCode::NOT_FOUND, format!("Law '{}' not found", law_id)))?
-            .clone();
-        let snapshot = corpus
-            .snapshot_source_for_session(&law.source_id)
-            .ok_or_else(|| {
-                session_resolve_error(
-                    law_id,
-                    SessionResolveError::SourceNotFound(law.source_id.clone()),
-                )
-            })?;
-        (law, snapshot)
-    };
-
-    let resolved = state
-        .sessions
-        .resolve_session_backend(&snapshot, session_id, &law.source_id)
-        .await
-        .map_err(|e| session_resolve_error(law_id, e))?;
-
-    if !resolved.uses_session_pr {
-        let writable = {
-            let backend = resolved.backend.lock().await;
-            backend.is_writable()
-        };
-        if !writable {
-            return Err((StatusCode::FORBIDDEN, "Source is read-only".to_string()));
-        }
-    }
-
+    let (law, backend) = resolve_session_write_backend(state, session_id, law_id).await?;
     let rel_dir = law_relative_dir(&law)?;
-    let backend = resolved.backend.lock_owned().await;
     Ok(EditorWriteTarget {
         relative_path: rel_dir.join("scenarios").join(filename),
         backend,

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -550,6 +550,16 @@ fn session_resolve_error(law_id: &str, e: SessionResolveError) -> (StatusCode, S
                 "Source is not configured for write-back".to_string(),
             )
         }
+        SessionResolveError::CapacityExceeded => {
+            tracing::warn!(
+                law_id = %law_id,
+                "save: session registry at capacity, refusing new (session, source) backend"
+            );
+            (
+                StatusCode::SERVICE_UNAVAILABLE,
+                "Editor is at capacity — try again in a moment".to_string(),
+            )
+        }
         SessionResolveError::Other(msg) => {
             tracing::error!(
                 law_id = %law_id,

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -189,8 +189,14 @@ pub async fn list_scenarios(
     State(state): State<AppState>,
     Path(law_id): Path<String>,
 ) -> Result<Json<Vec<ScenarioEntry>>, (StatusCode, String)> {
-    // Route reads through the same backend resolution as writes so a save
-    // followed by a list/get always sees its own writes.
+    // Reads use the global backend resolution (writable fallback included).
+    // For federated GitHub sources this is NOT the same backend writes use
+    // (writes go through the per-session `SessionGitBackend`), so a save
+    // followed immediately by a list/get returns the pre-edit content from
+    // the global clone until the session branch is rebased back into it.
+    // Frontend already keeps the just-saved content in local state, so
+    // editor UX is unaffected; a follow-up can route reads through the
+    // session backend if a strict read-your-writes guarantee is needed.
     let resolved = {
         let corpus = state.corpus.read().await;
         resolve_backend_for_law(&corpus, &law_id).await?

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -2,19 +2,46 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use axum::extract::{Path, Query, State};
-use axum::http::StatusCode;
+use axum::http::{HeaderMap, StatusCode};
 use axum::Json;
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
+use tower_sessions::Session;
 
-use regelrecht_corpus::backend::{RepoBackend, WriteContext};
+use regelrecht_auth::handlers::{SESSION_KEY_EMAIL, SESSION_KEY_NAME};
+use regelrecht_corpus::backend::{EditorUser, PersistOutcome, RepoBackend, WriteContext};
 use regelrecht_corpus::dto::{build_source_summaries, PaginationParams, SourceSummary};
 use regelrecht_corpus::source_map::{
     collect_law_outputs, extract_law_id, resolve_display_name, validate_yaml_syntax, LoadedLaw,
 };
 use regelrecht_corpus::CorpusError;
 
-use crate::state::AppState;
+use crate::state::{AppState, SessionResolveError};
+
+/// Header used by the frontend to scope writes to one editor session.
+///
+/// The frontend mints a UUID in `sessionStorage` on first load and sends
+/// it on every save. The backend uses it to key per-(session, source)
+/// `SessionGitBackend`s so all edits in one browser session land on the
+/// same upstream feature branch / PR.
+const EDITOR_SESSION_HEADER: &str = "X-Editor-Session";
+
+/// Response body for a successful save.
+///
+/// `pr` is `None` for local-source saves (no upstream PR to open) and
+/// populated for federated GitHub-source saves so the frontend can render
+/// a "Bekijk op GitHub" link.
+#[derive(Debug, Serialize)]
+pub struct SaveResponse {
+    pub pr: Option<SavePrInfo>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SavePrInfo {
+    pub url: String,
+    pub number: u64,
+    pub branch: String,
+}
 
 /// A law entry with source provenance.
 #[derive(Debug, Serialize)]
@@ -285,13 +312,14 @@ fn law_relative_dir(law: &LoadedLaw) -> Result<PathBuf, (StatusCode, String)> {
     })
 }
 
-/// Resolved backend information for a law.
+/// Resolved backend information for a law (read-path only).
+///
+/// The federated write path goes through [`SessionRegistry`] instead and
+/// returns its own resolved target shape ([`EditorWriteTarget`]), so this
+/// struct doesn't need a writability flag.
 struct ResolvedBackend {
     law: LoadedLaw,
     backend: Arc<Mutex<Box<dyn RepoBackend>>>,
-    /// Whether the resolved backend supports writes. Read handlers ignore
-    /// this; write handlers must reject the request with 403 if `false`.
-    writable: bool,
 }
 
 /// Resolve the backend that should be used for a law's scenario files.
@@ -332,7 +360,6 @@ async fn resolve_backend_for_law(
             return Ok(ResolvedBackend {
                 law,
                 backend: entry.backend.clone(),
-                writable: true,
             });
         }
     }
@@ -359,23 +386,21 @@ async fn resolve_backend_for_law(
                 law_id = %law_id,
                 law_source = %law.source_id,
                 fallback_source = %source_id,
-                "law's own source has no writable backend; routing reads and writes through verified-matching source"
+                "law's own source has no writable backend; routing reads through verified-matching source"
             );
             return Ok(ResolvedBackend {
                 law,
                 backend: entry.backend.clone(),
-                writable: true,
             });
         }
     }
 
     // 3. Fall through to the law's own read-only backend so reads still
-    //    work. Write handlers turn this into a 403.
+    //    work.
     if let Some(entry) = corpus.backends.get(&law.source_id) {
         return Ok(ResolvedBackend {
             law,
             backend: entry.backend.clone(),
-            writable: entry.writable,
         });
     }
 
@@ -422,61 +447,251 @@ fn corpus_write_error(kind: &'static str) -> impl FnOnce(CorpusError) -> (Status
 // Save / Delete scenario endpoints
 // ---------------------------------------------------------------------------
 
-/// Resolve write target: pick the backend, compute the scenario path, and
-/// lock the backend. Shared by save and delete handlers. Returns 403 if the
-/// resolved backend is read-only — the caller cannot recover from this.
-async fn resolve_write_target(
-    state: &AppState,
-    law_id: &str,
-    filename: &str,
-) -> Result<(PathBuf, tokio::sync::OwnedMutexGuard<Box<dyn RepoBackend>>), (StatusCode, String)> {
-    let resolved = {
-        let corpus = state.corpus.read().await;
-        resolve_backend_for_law(&corpus, law_id).await?
-    };
-
-    if !resolved.writable {
+/// Read the editor session id from the `X-Editor-Session` header.
+///
+/// Required on every editor write. We deliberately accept-then-validate
+/// (rather than minting one server-side) so the editor controls session
+/// scope: closing the browser tab purges `sessionStorage`, the next save
+/// arrives with a fresh UUID, and the user gets a fresh PR — matching
+/// "one PR per editor session" without any server-side TTL bookkeeping.
+fn require_editor_session(headers: &HeaderMap) -> Result<String, (StatusCode, String)> {
+    let value = headers.get(EDITOR_SESSION_HEADER).ok_or((
+        StatusCode::BAD_REQUEST,
+        format!("Missing {} header", EDITOR_SESSION_HEADER),
+    ))?;
+    let s = value.to_str().map_err(|_| {
+        (
+            StatusCode::BAD_REQUEST,
+            format!("{} header is not valid UTF-8", EDITOR_SESSION_HEADER),
+        )
+    })?;
+    // Loose validation: non-empty + ASCII-safe for use in a git ref name.
+    // Tighter shape (UUID) lives at the editor layer where it's minted.
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
         return Err((
-            StatusCode::FORBIDDEN,
+            StatusCode::BAD_REQUEST,
+            format!("{} header is empty", EDITOR_SESSION_HEADER),
+        ));
+    }
+    if !trimmed
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        return Err((
+            StatusCode::BAD_REQUEST,
             format!(
-                "No writable backend available for law '{}' (source '{}' is read-only \
-                 and no other registered source contains a matching copy of the law)",
-                law_id, resolved.law.source_id
+                "{} header contains characters that are not allowed in a git ref",
+                EDITOR_SESSION_HEADER
             ),
         ));
     }
+    Ok(trimmed.to_string())
+}
 
-    let rel_dir = law_relative_dir(&resolved.law)?;
-    let relative_path = rel_dir.join("scenarios").join(filename);
+/// Pull the editor user identity out of the OIDC session, when both name
+/// and email are populated.
+///
+/// Returns `None` when auth is disabled or the relevant session keys
+/// haven't been set — in those cases the resulting commit just has no
+/// `Co-Authored-By` trailer, which is harmless. We do NOT fail the save
+/// over a missing identity.
+async fn editor_user_from_session(session: &Session) -> Option<EditorUser> {
+    let name: Option<String> = session.get(SESSION_KEY_NAME).await.ok().flatten();
+    let email: Option<String> = session.get(SESSION_KEY_EMAIL).await.ok().flatten();
+    match (name, email) {
+        (Some(name), Some(email)) if !name.is_empty() && !email.is_empty() => {
+            Some(EditorUser { name, email })
+        }
+        _ => None,
+    }
+}
+
+/// Map a [`SessionResolveError`] into an HTTP error tuple suitable for an
+/// `Result<_, (StatusCode, String)>` save handler.
+fn session_resolve_error(law_id: &str, e: SessionResolveError) -> (StatusCode, String) {
+    match e {
+        SessionResolveError::SourceNotFound(_) => (
+            StatusCode::NOT_FOUND,
+            format!("Law '{}' references an unknown source", law_id),
+        ),
+        SessionResolveError::NoToken(source_id) => {
+            tracing::warn!(
+                law_id = %law_id,
+                source_id = %source_id,
+                "save: source has no PR token configured"
+            );
+            (
+                StatusCode::FORBIDDEN,
+                "Source is not configured for write-back".to_string(),
+            )
+        }
+        SessionResolveError::Other(msg) => {
+            tracing::error!(
+                law_id = %law_id,
+                error = %msg,
+                "save: failed to resolve session backend"
+            );
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to prepare write target".to_string(),
+            )
+        }
+    }
+}
+
+/// Resolved write target for editor saves: a backend lock + the file
+/// path. PR info comes back via `PersistOutcome.pr` from the actual
+/// `persist` call, so we don't need to flag the backend here.
+struct EditorWriteTarget {
+    relative_path: PathBuf,
+    backend: tokio::sync::OwnedMutexGuard<Box<dyn RepoBackend>>,
+}
+
+/// Resolve the write target for a law-content (`save_law`) edit by routing
+/// through the [`SessionRegistry`] for GitHub sources and falling back to
+/// the existing global backend resolution for local sources.
+async fn resolve_law_write_target(
+    state: &AppState,
+    session_id: &str,
+    law_id: &str,
+) -> Result<EditorWriteTarget, (StatusCode, String)> {
+    // Look up the law (and its source) once.
+    let law = {
+        let corpus = state.corpus.read().await;
+        corpus
+            .source_map
+            .get_law(law_id)
+            .ok_or_else(|| (StatusCode::NOT_FOUND, format!("Law '{}' not found", law_id)))?
+            .clone()
+    };
+
+    let resolved = {
+        let corpus = state.corpus.read().await;
+        state
+            .sessions
+            .resolve_session_backend(&corpus, session_id, &law.source_id)
+            .await
+            .map_err(|e| session_resolve_error(law_id, e))?
+    };
+
+    // For local sources the SessionRegistry hands back the existing global
+    // backend, which may be read-only (baked-in container fs). Surface
+    // that as 403, matching the previous behaviour.
+    if !resolved.uses_session_pr {
+        let writable = {
+            let backend = resolved.backend.lock().await;
+            backend.is_writable()
+        };
+        if !writable {
+            return Err((
+                StatusCode::FORBIDDEN,
+                "Law is stored on a read-only source".to_string(),
+            ));
+        }
+    }
 
     let backend = resolved.backend.lock_owned().await;
+    Ok(EditorWriteTarget {
+        relative_path: PathBuf::from(&law.relative_path),
+        backend,
+    })
+}
 
-    Ok((relative_path, backend))
+/// Resolve the write target for a scenario file edit. Mirrors
+/// `resolve_law_write_target` but appends the scenario subdir + filename.
+async fn resolve_scenario_write_target(
+    state: &AppState,
+    session_id: &str,
+    law_id: &str,
+    filename: &str,
+) -> Result<EditorWriteTarget, (StatusCode, String)> {
+    let law = {
+        let corpus = state.corpus.read().await;
+        corpus
+            .source_map
+            .get_law(law_id)
+            .ok_or_else(|| (StatusCode::NOT_FOUND, format!("Law '{}' not found", law_id)))?
+            .clone()
+    };
+
+    let resolved = {
+        let corpus = state.corpus.read().await;
+        state
+            .sessions
+            .resolve_session_backend(&corpus, session_id, &law.source_id)
+            .await
+            .map_err(|e| session_resolve_error(law_id, e))?
+    };
+
+    if !resolved.uses_session_pr {
+        let writable = {
+            let backend = resolved.backend.lock().await;
+            backend.is_writable()
+        };
+        if !writable {
+            return Err((StatusCode::FORBIDDEN, "Source is read-only".to_string()));
+        }
+    }
+
+    let rel_dir = law_relative_dir(&law)?;
+    let backend = resolved.backend.lock_owned().await;
+    Ok(EditorWriteTarget {
+        relative_path: rel_dir.join("scenarios").join(filename),
+        backend,
+    })
+}
+
+/// Build a [`SaveResponse`] from a successful [`PersistOutcome`]. Pulls
+/// the branch name out so the frontend can show "session-abc123" without
+/// re-deriving it from the URL.
+fn save_response_from(outcome: PersistOutcome, session_id: &str) -> SaveResponse {
+    SaveResponse {
+        pr: outcome.pr.map(|pr| SavePrInfo {
+            url: pr.html_url,
+            number: pr.number,
+            branch: format!("editor/session-{session_id}"),
+        }),
+    }
 }
 
 /// PUT /api/corpus/laws/{law_id}/scenarios/{filename} — save a scenario file.
+///
+/// Requires the `X-Editor-Session` header on every call; the session id
+/// scopes the per-(session, source) feature branch + PR for federated
+/// write-back. For local sources the session header is still required
+/// (uniform contract with the frontend) but is otherwise ignored.
 pub async fn save_scenario(
     State(state): State<AppState>,
+    session: Session,
+    headers: HeaderMap,
     Path((law_id, filename)): Path<(String, String)>,
     body: String,
-) -> Result<StatusCode, (StatusCode, String)> {
+) -> Result<Json<SaveResponse>, (StatusCode, String)> {
     validate_scenario_filename(&filename)?;
+    let session_id = require_editor_session(&headers)?;
+    let author = editor_user_from_session(&session).await;
 
-    let (relative_path, backend) = resolve_write_target(&state, &law_id, &filename).await?;
+    let target = resolve_scenario_write_target(&state, &session_id, &law_id, &filename).await?;
+    let EditorWriteTarget {
+        relative_path,
+        backend,
+    } = target;
 
     backend
         .write_file(&relative_path, &body)
         .await
         .map_err(corpus_write_error("scenario"))?;
 
-    backend
+    let outcome = backend
         .persist(&WriteContext {
             message: format!("Update scenario {} for {}", filename, law_id),
+            author,
         })
         .await
         .map_err(corpus_write_error("scenario"))?;
 
-    Ok(StatusCode::OK)
+    Ok(Json(save_response_from(outcome, &session_id)))
 }
 
 /// PUT /api/corpus/laws/{law_id} — save edited law YAML content.
@@ -493,9 +708,14 @@ pub async fn save_scenario(
 /// the source map.
 pub async fn save_law(
     State(state): State<AppState>,
+    session: Session,
+    headers: HeaderMap,
     Path(law_id): Path<String>,
     body: String,
-) -> Result<StatusCode, (StatusCode, String)> {
+) -> Result<Json<SaveResponse>, (StatusCode, String)> {
+    let session_id = require_editor_session(&headers)?;
+    let author = editor_user_from_session(&session).await;
+
     // Validation:
     //   1. Body must parse as well-formed YAML. extract_law_id below is a
     //      line-based scanner that happily accepts "$id: foo\n<garbage>",
@@ -538,46 +758,18 @@ pub async fn save_law(
         ));
     }
 
-    // Resolve backend with writable fallback (same path scenarios take).
-    let resolved = {
-        let corpus = state.corpus.read().await;
-        resolve_backend_for_law(&corpus, &law_id).await?
-    };
+    let target = resolve_law_write_target(&state, &session_id, &law_id).await?;
+    let EditorWriteTarget {
+        relative_path,
+        backend,
+    } = target;
 
-    if !resolved.writable {
-        // Log the internal source id (and the law id, even though the
-        // caller already knows it) for operators but keep both out of the
-        // HTTP body. `source_id` is a registry key ("central",
-        // "local-scratch", …) so leaking it exposes infrastructure naming;
-        // `law_id` echoed in the body would also flow through
-        // useLaw.saveError into ndd-inline-dialog's supporting-text, with
-        // the same self-XSS concern as the $id-mismatch branch above. The
-        // hard-coded message keeps both branches consistent.
-        tracing::warn!(
-            law_id = %law_id,
-            source_id = %resolved.law.source_id,
-            "save_law: no writable backend for law"
-        );
-        return Err((
-            StatusCode::FORBIDDEN,
-            "Law is stored on a read-only source".to_string(),
-        ));
-    }
-
-    let relative_path = PathBuf::from(&resolved.law.relative_path);
-
-    {
-        // The `if !resolved.writable` early return above ensures the
-        // RepoBackend will not refuse the write under normal operation, so
-        // the only realistic path to a `CorpusError::ReadOnly` here is a
-        // TOCTOU between the writability check and the write itself
-        // (e.g. the underlying volume flips read-only mid-request). In
-        // that race the `corpus_write_error` helper falls through to its
-        // generic 500-style mapping, mirroring the existing scenario
-        // write paths; the `ReadOnly` arm of `corpus_write_error` —
-        // which echoes `e.to_string()` — is unreachable here in
-        // practice and is not in scope to harden in this PR.
-        let backend = resolved.backend.lock_owned().await;
+    let outcome = {
+        // The earlier write-target resolution checks writability for local
+        // sources; for federated GitHub sources a missing token is a 403
+        // before we even get here. The remaining failure mode here is a
+        // TOCTOU on local backend writability (volume flips read-only
+        // mid-request); `corpus_write_error` maps that as a generic 500.
         backend
             .write_file(&relative_path, &body)
             .await
@@ -585,10 +777,11 @@ pub async fn save_law(
         backend
             .persist(&WriteContext {
                 message: format!("Update law {}", law_id),
+                author,
             })
             .await
-            .map_err(corpus_write_error("law"))?;
-    }
+            .map_err(corpus_write_error("law"))?
+    };
 
     // Refresh the in-memory cache so /api/corpus/laws/{law_id} (and
     // dependency walks) see the edit without a full corpus reload.
@@ -603,31 +796,40 @@ pub async fn save_law(
         }
     }
 
-    Ok(StatusCode::OK)
+    Ok(Json(save_response_from(outcome, &session_id)))
 }
 
 /// DELETE /api/corpus/laws/{law_id}/scenarios/{filename} — delete a scenario file.
 pub async fn delete_scenario(
     State(state): State<AppState>,
+    session: Session,
+    headers: HeaderMap,
     Path((law_id, filename)): Path<(String, String)>,
-) -> Result<StatusCode, (StatusCode, String)> {
+) -> Result<Json<SaveResponse>, (StatusCode, String)> {
     validate_scenario_filename(&filename)?;
+    let session_id = require_editor_session(&headers)?;
+    let author = editor_user_from_session(&session).await;
 
-    let (relative_path, backend) = resolve_write_target(&state, &law_id, &filename).await?;
+    let target = resolve_scenario_write_target(&state, &session_id, &law_id, &filename).await?;
+    let EditorWriteTarget {
+        relative_path,
+        backend,
+    } = target;
 
     backend
         .delete_file(&relative_path)
         .await
         .map_err(corpus_write_error("scenario"))?;
 
-    backend
+    let outcome = backend
         .persist(&WriteContext {
             message: format!("Delete scenario {} for {}", filename, law_id),
+            author,
         })
         .await
         .map_err(corpus_write_error("scenario"))?;
 
-    Ok(StatusCode::OK)
+    Ok(Json(save_response_from(outcome, &session_id)))
 }
 
 /// POST /api/corpus/reload — refetch corpus from all sources.

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -580,24 +580,35 @@ async fn resolve_law_write_target(
     session_id: &str,
     law_id: &str,
 ) -> Result<EditorWriteTarget, (StatusCode, String)> {
-    // Look up the law (and its source) once.
-    let law = {
+    // Look up the law (and snapshot the source state) under a single
+    // corpus read guard, then drop it before calling into the
+    // SessionRegistry. The slow-path session-backend init runs `git
+    // clone` and we must not hold the corpus read guard across that —
+    // otherwise a concurrent `POST /api/corpus/reload` (which takes the
+    // write guard) is starved for the duration of the clone.
+    let (law, snapshot) = {
         let corpus = state.corpus.read().await;
-        corpus
+        let law = corpus
             .source_map
             .get_law(law_id)
             .ok_or_else(|| (StatusCode::NOT_FOUND, format!("Law '{}' not found", law_id)))?
-            .clone()
+            .clone();
+        let snapshot = corpus
+            .snapshot_source_for_session(&law.source_id)
+            .ok_or_else(|| {
+                session_resolve_error(
+                    law_id,
+                    SessionResolveError::SourceNotFound(law.source_id.clone()),
+                )
+            })?;
+        (law, snapshot)
     };
 
-    let resolved = {
-        let corpus = state.corpus.read().await;
-        state
-            .sessions
-            .resolve_session_backend(&corpus, session_id, &law.source_id)
-            .await
-            .map_err(|e| session_resolve_error(law_id, e))?
-    };
+    let resolved = state
+        .sessions
+        .resolve_session_backend(&snapshot, session_id, &law.source_id)
+        .await
+        .map_err(|e| session_resolve_error(law_id, e))?;
 
     // For local sources the SessionRegistry hands back the existing global
     // backend, which may be read-only (baked-in container fs). Surface
@@ -630,23 +641,33 @@ async fn resolve_scenario_write_target(
     law_id: &str,
     filename: &str,
 ) -> Result<EditorWriteTarget, (StatusCode, String)> {
-    let law = {
+    // Snapshot under a single corpus read guard, then drop it — same
+    // reasoning as `resolve_law_write_target` above (the slow-path
+    // session-backend init runs `git clone` and must not hold the corpus
+    // read guard across that or `POST /api/corpus/reload` is starved).
+    let (law, snapshot) = {
         let corpus = state.corpus.read().await;
-        corpus
+        let law = corpus
             .source_map
             .get_law(law_id)
             .ok_or_else(|| (StatusCode::NOT_FOUND, format!("Law '{}' not found", law_id)))?
-            .clone()
+            .clone();
+        let snapshot = corpus
+            .snapshot_source_for_session(&law.source_id)
+            .ok_or_else(|| {
+                session_resolve_error(
+                    law_id,
+                    SessionResolveError::SourceNotFound(law.source_id.clone()),
+                )
+            })?;
+        (law, snapshot)
     };
 
-    let resolved = {
-        let corpus = state.corpus.read().await;
-        state
-            .sessions
-            .resolve_session_backend(&corpus, session_id, &law.source_id)
-            .await
-            .map_err(|e| session_resolve_error(law_id, e))?
-    };
+    let resolved = state
+        .sessions
+        .resolve_session_backend(&snapshot, session_id, &law.source_id)
+        .await
+        .map_err(|e| session_resolve_error(law_id, e))?;
 
     if !resolved.uses_session_pr {
         let writable = {

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -845,6 +845,15 @@ pub async fn save_law(
 }
 
 /// DELETE /api/corpus/laws/{law_id}/scenarios/{filename} — delete a scenario file.
+///
+/// CONTRACT NOTE: this endpoint now requires an `X-Editor-Session` header
+/// (same as `save_scenario` and `save_law`). The federated write-back path
+/// scopes every write to a per-session feature branch; without the session
+/// id we cannot route the deletion to the correct branch, so the endpoint
+/// returns `400 Bad Request` rather than silently falling back to the
+/// global backend. This is a contract change from the previous implementation
+/// where `delete_scenario` was unauthenticated — non-browser callers
+/// (curl, admin scripts, integration tests) must send the header.
 pub async fn delete_scenario(
     State(state): State<AppState>,
     session: Session,

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -447,6 +447,15 @@ fn corpus_write_error(kind: &'static str) -> impl FnOnce(CorpusError) -> (Status
 // Save / Delete scenario endpoints
 // ---------------------------------------------------------------------------
 
+/// Maximum accepted length of the `X-Editor-Session` header value.
+///
+/// The header ends up as a path segment on disk
+/// (`/tmp/regelrecht-editor-sessions/.../<session_id>`) and as a git ref
+/// name (`editor/session-<id>`). 128 bytes comfortably fits a UUID, hex,
+/// or other opaque identifier the frontend mints, while rejecting a
+/// pathological client that sends a multi-kilobyte value.
+const EDITOR_SESSION_MAX_LEN: usize = 128;
+
 /// Read the editor session id from the `X-Editor-Session` header.
 ///
 /// Required on every editor write. We deliberately accept-then-validate
@@ -472,6 +481,15 @@ fn require_editor_session(headers: &HeaderMap) -> Result<String, (StatusCode, St
         return Err((
             StatusCode::BAD_REQUEST,
             format!("{} header is empty", EDITOR_SESSION_HEADER),
+        ));
+    }
+    if trimmed.len() > EDITOR_SESSION_MAX_LEN {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!(
+                "{} header exceeds {} characters",
+                EDITOR_SESSION_HEADER, EDITOR_SESSION_MAX_LEN
+            ),
         ));
     }
     if !trimmed
@@ -900,4 +918,103 @@ pub struct ReloadRequest {
 #[derive(Debug, Serialize)]
 pub struct ReloadResponse {
     pub law_count: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    //! Tests for the small, pure helpers in this module: header validation,
+    //! error mapping, and response shaping. The full save/delete handlers
+    //! require an axum harness with sessions + sqlx + a real source map
+    //! and live behind separate integration tests.
+    use super::*;
+    use axum::http::HeaderValue;
+    use regelrecht_corpus::backend::PrInfo;
+
+    fn headers_with(value: &str) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        h.insert(EDITOR_SESSION_HEADER, HeaderValue::from_str(value).unwrap());
+        h
+    }
+
+    #[test]
+    fn require_editor_session_missing_header_is_400() {
+        let h = HeaderMap::new();
+        let err = require_editor_session(&h).unwrap_err();
+        assert_eq!(err.0, StatusCode::BAD_REQUEST);
+        assert!(err.1.contains("Missing"));
+    }
+
+    #[test]
+    fn require_editor_session_empty_value_is_400() {
+        let h = headers_with("   ");
+        let err = require_editor_session(&h).unwrap_err();
+        assert_eq!(err.0, StatusCode::BAD_REQUEST);
+        assert!(err.1.contains("empty"));
+    }
+
+    #[test]
+    fn require_editor_session_invalid_chars_is_400() {
+        // Slashes are not allowed in a git ref segment and must be rejected.
+        let h = headers_with("foo/bar");
+        let err = require_editor_session(&h).unwrap_err();
+        assert_eq!(err.0, StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn require_editor_session_oversized_value_is_400() {
+        // Defence against pathological clients sending a megabyte-long
+        // header — that would end up as a branch name on disk.
+        let h = headers_with(&"a".repeat(1024));
+        let err = require_editor_session(&h).unwrap_err();
+        assert_eq!(err.0, StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn require_editor_session_accepts_uuid_shape() {
+        let h = headers_with("abc123-def4567890");
+        let session_id = require_editor_session(&h).unwrap();
+        assert_eq!(session_id, "abc123-def4567890");
+    }
+
+    #[test]
+    fn session_resolve_error_source_not_found_is_404() {
+        let err = session_resolve_error("law_x", SessionResolveError::SourceNotFound("src".into()));
+        assert_eq!(err.0, StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn session_resolve_error_no_token_is_403() {
+        let err = session_resolve_error("law_x", SessionResolveError::NoToken("src".into()));
+        assert_eq!(err.0, StatusCode::FORBIDDEN);
+    }
+
+    #[test]
+    fn session_resolve_error_other_is_500() {
+        let err = session_resolve_error("law_x", SessionResolveError::Other("boom".into()));
+        assert_eq!(err.0, StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[test]
+    fn save_response_from_local_source_has_no_pr() {
+        // PersistOutcome.pr is None for local-source saves; the response
+        // must mirror that shape so the frontend hides the PR badge.
+        let out = PersistOutcome { pr: None };
+        let body = save_response_from(out, "sess-abc");
+        assert!(body.pr.is_none());
+    }
+
+    #[test]
+    fn save_response_from_github_source_carries_pr_with_session_branch() {
+        let out = PersistOutcome {
+            pr: Some(PrInfo {
+                number: 42,
+                html_url: "https://github.com/x/y/pull/42".to_string(),
+            }),
+        };
+        let body = save_response_from(out, "sess-abc");
+        let pr = body.pr.expect("session-pr response must carry pr");
+        assert_eq!(pr.number, 42);
+        assert_eq!(pr.url, "https://github.com/x/y/pull/42");
+        assert_eq!(pr.branch, "editor/session-sess-abc");
+    }
 }

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -83,6 +83,7 @@ async fn main() {
         pool: None, // set below when auth is enabled
         pipeline_api_url,
         reload_lock: Arc::new(tokio::sync::Mutex::new(())),
+        sessions: Arc::new(state::SessionRegistry::new()),
     };
 
     let index_file = PathBuf::from(&static_dir).join("index.html");

--- a/packages/editor-api/src/state.rs
+++ b/packages/editor-api/src/state.rs
@@ -175,6 +175,16 @@ type SharedBackend = Arc<Mutex<Box<dyn RepoBackend>>>;
 /// **different** keys never block each other on the slow path. Concurrent
 /// callers on the **same** key serialise inside the cell's `get_or_try_init`
 /// — which is the desired behaviour for that case.
+/// Hard cap on the number of `(session, source)` backends kept in the
+/// registry simultaneously. Each entry holds a full on-disk git clone,
+/// so unbounded growth is a disk-exhaustion vector — a misbehaving (or
+/// hostile authenticated) client that rotates `X-Editor-Session` values
+/// would otherwise be able to fill `/tmp` until the pod fails. A proper
+/// LRU reaper that prunes idle sessions is tracked separately; this cap
+/// is the minimum guard so the registry refuses new keys with `503`
+/// rather than crashing the process.
+pub const SESSION_REGISTRY_MAX_ENTRIES: usize = 5_000;
+
 #[derive(Default)]
 pub struct SessionRegistry {
     /// Backends keyed by `(session_id, source_id)`. The cells are
@@ -240,6 +250,13 @@ impl SessionRegistry {
                 // by a clone in flight elsewhere.
                 let cell = {
                     let mut map = self.backends.write().await;
+                    // Refuse new keys once the cap is reached. Existing keys
+                    // (already in the map) still resolve so an in-flight
+                    // session is not killed mid-edit; only NEW (session,
+                    // source) pairs hit the 503.
+                    if !map.contains_key(&key) && map.len() >= SESSION_REGISTRY_MAX_ENTRIES {
+                        return Err(SessionResolveError::CapacityExceeded);
+                    }
                     map.entry(key)
                         .or_insert_with(|| Arc::new(OnceCell::new()))
                         .clone()
@@ -315,7 +332,7 @@ impl SessionRegistry {
 }
 
 /// Errors from [`SessionRegistry::resolve_session_backend`]. The
-/// editor-api maps these to HTTP statuses (404 / 403 / 500) at the
+/// editor-api maps these to HTTP statuses (404 / 403 / 503 / 500) at the
 /// handler boundary — keeps the registry independent of axum types.
 #[derive(Debug)]
 pub enum SessionResolveError {
@@ -326,6 +343,12 @@ pub enum SessionResolveError {
     /// message; we deliberately do not silently fall back to a local-only
     /// commit because the user would think their edit reached upstream.
     NoToken(String),
+    /// The registry has hit its hard cap on concurrent (session, source)
+    /// backends. Each backend holds an on-disk git clone, so unbounded
+    /// growth is a disk-exhaustion vector; this guards against rotation
+    /// attacks or honest leaks until a proper LRU reaper lands. Surfaced
+    /// as 503 to tell the caller "try again later".
+    CapacityExceeded,
     /// Anything else (clone failure, bad config, IO error). Surfaced as
     /// 500 with a generic message; the underlying error is logged.
     Other(String),
@@ -339,6 +362,11 @@ impl std::fmt::Display for SessionResolveError {
                 f,
                 "source '{}' is not configured for write-back (no auth token)",
                 id
+            ),
+            Self::CapacityExceeded => write!(
+                f,
+                "session registry at capacity ({} entries)",
+                SESSION_REGISTRY_MAX_ENTRIES
             ),
             Self::Other(msg) => write!(f, "{}", msg),
         }

--- a/packages/editor-api/src/state.rs
+++ b/packages/editor-api/src/state.rs
@@ -3,8 +3,11 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use regelrecht_auth::{ConfiguredClient, OidcAppState, OidcConfig};
-use regelrecht_corpus::backend::RepoBackend;
-use regelrecht_corpus::SourceMap;
+use regelrecht_corpus::auth::resolve_token_for_source;
+use regelrecht_corpus::backend::{RepoBackend, SessionGitBackend};
+use regelrecht_corpus::config::CorpusConfig;
+use regelrecht_corpus::models::SourceType;
+use regelrecht_corpus::{CorpusClient, SourceMap};
 use sqlx::PgPool;
 use tokio::sync::{Mutex, RwLock};
 
@@ -28,6 +31,9 @@ pub struct AppState {
     /// authenticated user could burn through the 5000 req/hr token quota
     /// with a single `xargs -P` and block corpus reads for everyone.
     pub reload_lock: Arc<Mutex<()>>,
+    /// Per-(editor session, source) write-back backends used by the
+    /// federated PR write-path. Lazily created on first save.
+    pub sessions: Arc<SessionRegistry>,
 }
 
 impl OidcAppState for AppState {
@@ -83,3 +89,202 @@ impl CorpusState {
         }
     }
 }
+
+/// Outcome of resolving a write target through the [`SessionRegistry`].
+///
+/// For GitHub-sourced laws the registry hands back a per-(session, source)
+/// [`SessionGitBackend`] that pushes to a feature branch and opens/updates
+/// a PR upstream. For local-sourced laws it returns the existing global
+/// backend so the on-disk dev workflow keeps working unchanged.
+pub struct ResolvedSessionBackend {
+    pub backend: Arc<Mutex<Box<dyn RepoBackend>>>,
+    /// `true` when the resolved backend opens a PR on `persist`. The
+    /// editor-api uses this flag to decide whether the JSON response for
+    /// `save_law` / `save_scenario` should expose `pr_url` / `pr_number`.
+    pub uses_session_pr: bool,
+}
+
+/// Composite key used by [`SessionRegistry`]: `(editor session id, source
+/// id)`. Both are stable strings; the tuple lets us look up "the backend
+/// session X uses to write to source Y" without separate maps.
+type SessionBackendKey = (String, String);
+
+/// Aliased to keep the [`SessionRegistry`] field type readable. The shape
+/// matches the existing read-path `BackendEntry.backend` so the trait
+/// object goes through the same `Arc<Mutex<Box<dyn RepoBackend>>>` chain.
+type SharedBackend = Arc<Mutex<Box<dyn RepoBackend>>>;
+
+/// Lazy registry of per-(session, source) backends used for federated
+/// write-back.
+///
+/// Each editor session (a UUID minted in the browser, sent as
+/// `X-Editor-Session`) gets its own [`SessionGitBackend`] per source it
+/// writes to. The backend pushes to a stable feature branch on the source
+/// repo (`editor/session-<uuid>`) and ensures an open PR against the
+/// source's configured branch — so all edits a user makes in one sitting
+/// land on the same review-ready PR.
+///
+/// Backends are created lazily on first write to keep `editor-api` startup
+/// cheap (no clone-per-session up front). The registry survives for the
+/// process lifetime; restart loses the in-memory map and a fresh save will
+/// re-clone, finding any prior session branch on the remote and continuing
+/// from there.
+#[derive(Default)]
+pub struct SessionRegistry {
+    /// Backends keyed by `(session_id, source_id)`.
+    backends: RwLock<HashMap<SessionBackendKey, SharedBackend>>,
+}
+
+impl SessionRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Resolve the backend for a (session, source) write.
+    ///
+    /// - **Local sources**: returns the existing global backend. There is
+    ///   no upstream to PR to and the dev loop expects writes to land on
+    ///   the local filesystem immediately.
+    /// - **GitHub sources**: returns (or lazily creates) a
+    ///   [`SessionGitBackend`] for this session+source. Requires a token
+    ///   configured for the source — without one we surface a 403 because
+    ///   silently dropping edits is worse than a clear error.
+    ///
+    /// `corpus` is read-locked once to look up the source definition and
+    /// (for the local case) hand back the global backend. The session
+    /// backend itself does not borrow from `corpus`.
+    pub async fn resolve_session_backend(
+        &self,
+        corpus: &CorpusState,
+        session_id: &str,
+        source_id: &str,
+    ) -> std::result::Result<ResolvedSessionBackend, SessionResolveError> {
+        let source = corpus
+            .registry
+            .get_source(source_id)
+            .ok_or_else(|| SessionResolveError::SourceNotFound(source_id.to_string()))?;
+
+        match &source.source_type {
+            SourceType::Local { .. } => corpus
+                .backends
+                .get(source_id)
+                .map(|entry| ResolvedSessionBackend {
+                    backend: entry.backend.clone(),
+                    uses_session_pr: false,
+                })
+                .ok_or_else(|| SessionResolveError::SourceNotFound(source_id.to_string())),
+            SourceType::GitHub { github } => {
+                let key = (session_id.to_string(), source_id.to_string());
+
+                // Fast path: backend already exists for this session+source.
+                if let Some(existing) = self.backends.read().await.get(&key) {
+                    return Ok(ResolvedSessionBackend {
+                        backend: existing.clone(),
+                        uses_session_pr: true,
+                    });
+                }
+
+                // Slow path: build the backend under a write lock. We
+                // re-check inside the write lock to avoid two racing
+                // creators producing two backends for the same key.
+                let mut map = self.backends.write().await;
+                if let Some(existing) = map.get(&key) {
+                    return Ok(ResolvedSessionBackend {
+                        backend: existing.clone(),
+                        uses_session_pr: true,
+                    });
+                }
+
+                let token = resolve_token_for_source(
+                    source_id,
+                    source.auth_ref.as_deref(),
+                    corpus.auth_file.as_deref(),
+                )
+                .map_err(|e| SessionResolveError::Other(e.to_string()))?
+                .ok_or_else(|| SessionResolveError::NoToken(source_id.to_string()))?;
+
+                // Per-(session, source) clone path: keeps each session
+                // isolated so a checkout for session A doesn't disturb
+                // session B's working tree mid-persist. Trade disk for
+                // simplicity — cleanup on session expiry is a follow-up.
+                let host_id = std::env::var("HOSTNAME").unwrap_or_else(|_| "local".to_string());
+                let repo_path = std::env::temp_dir()
+                    .join("regelrecht-editor-sessions")
+                    .join(host_id)
+                    .join(source_id)
+                    .join(session_id);
+
+                let repo_url = format!("https://github.com/{}/{}.git", github.owner, github.repo);
+                let mut config = CorpusConfig::new(&repo_url, &repo_path);
+                config.branch = github.effective_ref().to_string();
+                config = config.with_token(&token);
+                let client = CorpusClient::new(config);
+
+                let session_branch = format!("editor/session-{session_id}");
+                let mut backend: Box<dyn RepoBackend> = Box::new(
+                    SessionGitBackend::new(
+                        client,
+                        github.path.clone(),
+                        session_branch,
+                        github.effective_ref().to_string(),
+                        github.owner.clone(),
+                        github.repo.clone(),
+                        token,
+                    )
+                    .map_err(|e| SessionResolveError::Other(e.to_string()))?,
+                );
+
+                // Clone the source on first use of this (session, source).
+                // ensure_ready may take a second or two; the write lock
+                // means concurrent saves on the SAME (session, source)
+                // serialise here — that's fine, those callers literally
+                // need this backend.
+                backend
+                    .ensure_ready()
+                    .await
+                    .map_err(|e| SessionResolveError::Other(e.to_string()))?;
+
+                let arc = Arc::new(Mutex::new(backend));
+                map.insert(key, arc.clone());
+
+                Ok(ResolvedSessionBackend {
+                    backend: arc,
+                    uses_session_pr: true,
+                })
+            }
+        }
+    }
+}
+
+/// Errors from [`SessionRegistry::resolve_session_backend`]. The
+/// editor-api maps these to HTTP statuses (404 / 403 / 500) at the
+/// handler boundary — keeps the registry independent of axum types.
+#[derive(Debug)]
+pub enum SessionResolveError {
+    /// No source registered with that id.
+    SourceNotFound(String),
+    /// A GitHub source has no token configured. Surfaced to the user as
+    /// 403 with a clear "source X is not configured for write-back"
+    /// message; we deliberately do not silently fall back to a local-only
+    /// commit because the user would think their edit reached upstream.
+    NoToken(String),
+    /// Anything else (clone failure, bad config, IO error). Surfaced as
+    /// 500 with a generic message; the underlying error is logged.
+    Other(String),
+}
+
+impl std::fmt::Display for SessionResolveError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::SourceNotFound(id) => write!(f, "source '{}' not found in registry", id),
+            Self::NoToken(id) => write!(
+                f,
+                "source '{}' is not configured for write-back (no auth token)",
+                id
+            ),
+            Self::Other(msg) => write!(f, "{}", msg),
+        }
+    }
+}
+
+impl std::error::Error for SessionResolveError {}

--- a/packages/editor-api/src/state.rs
+++ b/packages/editor-api/src/state.rs
@@ -6,7 +6,7 @@ use regelrecht_auth::{ConfiguredClient, OidcAppState, OidcConfig};
 use regelrecht_corpus::auth::resolve_token_for_source;
 use regelrecht_corpus::backend::{RepoBackend, SessionGitBackend};
 use regelrecht_corpus::config::CorpusConfig;
-use regelrecht_corpus::models::SourceType;
+use regelrecht_corpus::models::{Source, SourceType};
 use regelrecht_corpus::{CorpusClient, SourceMap};
 use sqlx::PgPool;
 use tokio::sync::{Mutex, OnceCell, RwLock};
@@ -88,6 +88,45 @@ impl CorpusState {
             auth_file: None,
         }
     }
+
+    /// Snapshot the corpus state needed by
+    /// [`SessionRegistry::resolve_session_backend`] so the caller can drop
+    /// the corpus read guard before the (potentially slow) session backend
+    /// init runs. The init future allocates a per-(session, source)
+    /// `SessionGitBackend` and runs `ensure_ready` — which on a cold cache
+    /// performs a full `git clone` — and we must not hold the corpus
+    /// `RwLock` read guard across that or a concurrent `POST
+    /// /api/corpus/reload` write-locker is starved for the duration.
+    ///
+    /// Returns `None` when no source with `source_id` is registered. The
+    /// caller maps that to a 404 at the HTTP boundary.
+    pub fn snapshot_source_for_session(&self, source_id: &str) -> Option<SessionSourceSnapshot> {
+        let source = self.registry.get_source(source_id)?.clone();
+        let local_backend = self.backends.get(source_id).map(|e| e.backend.clone());
+        Some(SessionSourceSnapshot {
+            source,
+            local_backend,
+            auth_file: self.auth_file.clone(),
+        })
+    }
+}
+
+/// Owned snapshot of the corpus state that
+/// [`SessionRegistry::resolve_session_backend`] needs to decide how to
+/// route a (session, source) write. Built via
+/// [`CorpusState::snapshot_source_for_session`] while holding the corpus
+/// read guard; the guard can be dropped before the resolver runs so the
+/// slow-path `git clone` does not block concurrent corpus-reload
+/// writers.
+pub struct SessionSourceSnapshot {
+    pub source: Source,
+    /// Currently-registered global backend for this source, if any. Only
+    /// used when `source.source_type` is `Local` — GitHub sources route
+    /// to a freshly created per-session backend.
+    pub local_backend: Option<Arc<Mutex<Box<dyn RepoBackend>>>>,
+    /// Path to corpus-auth.yaml; cloned out of the corpus guard so the
+    /// resolver can read it without holding the lock.
+    pub auth_file: Option<PathBuf>,
 }
 
 /// Outcome of resolving a write target through the [`SessionRegistry`].
@@ -158,26 +197,24 @@ impl SessionRegistry {
     ///   configured for the source — without one we surface a 403 because
     ///   silently dropping edits is worse than a clear error.
     ///
-    /// `corpus` is read-locked once to look up the source definition and
-    /// (for the local case) hand back the global backend. The session
-    /// backend itself does not borrow from `corpus`.
+    /// `snapshot` is an owned slice of the corpus state captured via
+    /// [`CorpusState::snapshot_source_for_session`]. Callers MUST drop the
+    /// `state.corpus` read guard before invoking this method — the
+    /// GitHub-source slow path runs `git clone` inside the cell, and
+    /// holding the corpus `RwLock` read guard across that would starve
+    /// concurrent `POST /api/corpus/reload` write-lockers.
     pub async fn resolve_session_backend(
         &self,
-        corpus: &CorpusState,
+        snapshot: &SessionSourceSnapshot,
         session_id: &str,
         source_id: &str,
     ) -> std::result::Result<ResolvedSessionBackend, SessionResolveError> {
-        let source = corpus
-            .registry
-            .get_source(source_id)
-            .ok_or_else(|| SessionResolveError::SourceNotFound(source_id.to_string()))?;
-
-        match &source.source_type {
-            SourceType::Local { .. } => corpus
-                .backends
-                .get(source_id)
-                .map(|entry| ResolvedSessionBackend {
-                    backend: entry.backend.clone(),
+        match &snapshot.source.source_type {
+            SourceType::Local { .. } => snapshot
+                .local_backend
+                .as_ref()
+                .map(|backend| ResolvedSessionBackend {
+                    backend: backend.clone(),
                     uses_session_pr: false,
                 })
                 .ok_or_else(|| SessionResolveError::SourceNotFound(source_id.to_string())),
@@ -215,8 +252,8 @@ impl SessionRegistry {
                     .get_or_try_init(|| async {
                         let token = resolve_token_for_source(
                             source_id,
-                            source.auth_ref.as_deref(),
-                            corpus.auth_file.as_deref(),
+                            snapshot.source.auth_ref.as_deref(),
+                            snapshot.auth_file.as_deref(),
                         )
                         .map_err(|e| SessionResolveError::Other(e.to_string()))?
                         .ok_or_else(|| SessionResolveError::NoToken(source_id.to_string()))?;
@@ -345,15 +382,10 @@ mod tests {
 ",
         );
         let corpus = corpus_state_from_yaml(&yaml);
-        let reg = SessionRegistry::new();
-        let result = reg
-            .resolve_session_backend(&corpus, "sess-1", "unknown")
-            .await;
-        match result {
-            Err(SessionResolveError::SourceNotFound(id)) => assert_eq!(id, "unknown"),
-            Err(other) => panic!("expected SourceNotFound, got {other:?}"),
-            Ok(_) => panic!("expected SourceNotFound, got Ok"),
-        }
+        // Unknown source has no snapshot — the handler maps that to 404
+        // upstream of the resolver. The resolver itself is only invoked
+        // for known sources.
+        assert!(corpus.snapshot_source_for_session("unknown").is_none());
     }
 
     #[tokio::test]
@@ -371,9 +403,12 @@ mod tests {
 ",
         );
         let corpus = corpus_state_from_yaml(&yaml);
+        let snapshot = corpus
+            .snapshot_source_for_session("local-src")
+            .expect("source is registered");
         let reg = SessionRegistry::new();
         let result = reg
-            .resolve_session_backend(&corpus, "sess-1", "local-src")
+            .resolve_session_backend(&snapshot, "sess-1", "local-src")
             .await;
         match result {
             Err(SessionResolveError::SourceNotFound(_)) => {}
@@ -399,9 +434,12 @@ mod tests {
 ",
         );
         let corpus = corpus_state_from_yaml(&yaml);
+        let snapshot = corpus
+            .snapshot_source_for_session("gh-src")
+            .expect("source is registered");
         let reg = SessionRegistry::new();
         let result = reg
-            .resolve_session_backend(&corpus, "sess-1", "gh-src")
+            .resolve_session_backend(&snapshot, "sess-1", "gh-src")
             .await;
         match result {
             Err(SessionResolveError::NoToken(id)) => assert_eq!(id, "gh-src"),

--- a/packages/editor-api/src/state.rs
+++ b/packages/editor-api/src/state.rs
@@ -9,7 +9,7 @@ use regelrecht_corpus::config::CorpusConfig;
 use regelrecht_corpus::models::SourceType;
 use regelrecht_corpus::{CorpusClient, SourceMap};
 use sqlx::PgPool;
-use tokio::sync::{Mutex, RwLock};
+use tokio::sync::{Mutex, OnceCell, RwLock};
 
 use crate::config::AppConfig;
 
@@ -129,10 +129,18 @@ type SharedBackend = Arc<Mutex<Box<dyn RepoBackend>>>;
 /// process lifetime; restart loses the in-memory map and a fresh save will
 /// re-clone, finding any prior session branch on the remote and continuing
 /// from there.
+///
+/// Each map entry is an [`Arc<OnceCell<SharedBackend>>`]. The registry
+/// write lock is held only long enough to insert the placeholder cell;
+/// the actual clone runs against the per-key cell so two callers on
+/// **different** keys never block each other on the slow path. Concurrent
+/// callers on the **same** key serialise inside the cell's `get_or_try_init`
+/// — which is the desired behaviour for that case.
 #[derive(Default)]
 pub struct SessionRegistry {
-    /// Backends keyed by `(session_id, source_id)`.
-    backends: RwLock<HashMap<SessionBackendKey, SharedBackend>>,
+    /// Backends keyed by `(session_id, source_id)`. The cells are
+    /// initialised lazily by the first caller for each key.
+    backends: RwLock<HashMap<SessionBackendKey, Arc<OnceCell<SharedBackend>>>>,
 }
 
 impl SessionRegistry {
@@ -176,79 +184,92 @@ impl SessionRegistry {
             SourceType::GitHub { github } => {
                 let key = (session_id.to_string(), source_id.to_string());
 
-                // Fast path: backend already exists for this session+source.
-                if let Some(existing) = self.backends.read().await.get(&key) {
-                    return Ok(ResolvedSessionBackend {
-                        backend: existing.clone(),
-                        uses_session_pr: true,
-                    });
+                // Fast path: backend already exists and is initialised for
+                // this session+source.
+                if let Some(cell) = self.backends.read().await.get(&key) {
+                    if let Some(existing) = cell.get() {
+                        return Ok(ResolvedSessionBackend {
+                            backend: existing.clone(),
+                            uses_session_pr: true,
+                        });
+                    }
                 }
 
-                // Slow path: build the backend under a write lock. We
-                // re-check inside the write lock to avoid two racing
-                // creators producing two backends for the same key.
-                let mut map = self.backends.write().await;
-                if let Some(existing) = map.get(&key) {
-                    return Ok(ResolvedSessionBackend {
-                        backend: existing.clone(),
-                        uses_session_pr: true,
-                    });
-                }
+                // Get or insert a per-key OnceCell under the write lock,
+                // then release the lock immediately. The slow `ensure_ready`
+                // (which does a full `git clone`) runs against the cell
+                // outside the registry lock, so callers writing to a
+                // **different** (session, source) key are never blocked
+                // by a clone in flight elsewhere.
+                let cell = {
+                    let mut map = self.backends.write().await;
+                    map.entry(key)
+                        .or_insert_with(|| Arc::new(OnceCell::new()))
+                        .clone()
+                };
 
-                let token = resolve_token_for_source(
-                    source_id,
-                    source.auth_ref.as_deref(),
-                    corpus.auth_file.as_deref(),
-                )
-                .map_err(|e| SessionResolveError::Other(e.to_string()))?
-                .ok_or_else(|| SessionResolveError::NoToken(source_id.to_string()))?;
+                // `get_or_try_init` runs the init future exactly once per
+                // cell; concurrent callers on the SAME key serialise here,
+                // which is what we want — they all need the same backend.
+                let backend = cell
+                    .get_or_try_init(|| async {
+                        let token = resolve_token_for_source(
+                            source_id,
+                            source.auth_ref.as_deref(),
+                            corpus.auth_file.as_deref(),
+                        )
+                        .map_err(|e| SessionResolveError::Other(e.to_string()))?
+                        .ok_or_else(|| SessionResolveError::NoToken(source_id.to_string()))?;
 
-                // Per-(session, source) clone path: keeps each session
-                // isolated so a checkout for session A doesn't disturb
-                // session B's working tree mid-persist. Trade disk for
-                // simplicity — cleanup on session expiry is a follow-up.
-                let host_id = std::env::var("HOSTNAME").unwrap_or_else(|_| "local".to_string());
-                let repo_path = std::env::temp_dir()
-                    .join("regelrecht-editor-sessions")
-                    .join(host_id)
-                    .join(source_id)
-                    .join(session_id);
+                        // Per-(session, source) clone path: keeps each session
+                        // isolated so a checkout for session A doesn't disturb
+                        // session B's working tree mid-persist. Trade disk for
+                        // simplicity — cleanup on session expiry is a follow-up.
+                        let host_id =
+                            std::env::var("HOSTNAME").unwrap_or_else(|_| "local".to_string());
+                        let repo_path = std::env::temp_dir()
+                            .join("regelrecht-editor-sessions")
+                            .join(host_id)
+                            .join(source_id)
+                            .join(session_id);
 
-                let repo_url = format!("https://github.com/{}/{}.git", github.owner, github.repo);
-                let mut config = CorpusConfig::new(&repo_url, &repo_path);
-                config.branch = github.effective_ref().to_string();
-                config = config.with_token(&token);
-                let client = CorpusClient::new(config);
+                        let repo_url =
+                            format!("https://github.com/{}/{}.git", github.owner, github.repo);
+                        let mut config = CorpusConfig::new(&repo_url, &repo_path);
+                        config.branch = github.effective_ref().to_string();
+                        config = config.with_token(&token);
+                        let client = CorpusClient::new(config);
 
-                let session_branch = format!("editor/session-{session_id}");
-                let mut backend: Box<dyn RepoBackend> = Box::new(
-                    SessionGitBackend::new(
-                        client,
-                        github.path.clone(),
-                        session_branch,
-                        github.effective_ref().to_string(),
-                        github.owner.clone(),
-                        github.repo.clone(),
-                        token,
-                    )
-                    .map_err(|e| SessionResolveError::Other(e.to_string()))?,
-                );
+                        let session_branch = format!("editor/session-{session_id}");
+                        let mut backend: Box<dyn RepoBackend> = Box::new(
+                            SessionGitBackend::new(
+                                client,
+                                github.path.clone(),
+                                session_branch,
+                                github.effective_ref().to_string(),
+                                github.owner.clone(),
+                                github.repo.clone(),
+                                token,
+                            )
+                            .map_err(|e| SessionResolveError::Other(e.to_string()))?,
+                        );
 
-                // Clone the source on first use of this (session, source).
-                // ensure_ready may take a second or two; the write lock
-                // means concurrent saves on the SAME (session, source)
-                // serialise here — that's fine, those callers literally
-                // need this backend.
-                backend
-                    .ensure_ready()
-                    .await
-                    .map_err(|e| SessionResolveError::Other(e.to_string()))?;
+                        // Clone the source on first use of this (session, source).
+                        // ensure_ready may take a second or two; runs **without**
+                        // the registry write lock held so other keys are
+                        // unaffected.
+                        backend
+                            .ensure_ready()
+                            .await
+                            .map_err(|e| SessionResolveError::Other(e.to_string()))?;
 
-                let arc = Arc::new(Mutex::new(backend));
-                map.insert(key, arc.clone());
+                        Ok::<SharedBackend, SessionResolveError>(Arc::new(Mutex::new(backend)))
+                    })
+                    .await?
+                    .clone();
 
                 Ok(ResolvedSessionBackend {
-                    backend: arc,
+                    backend,
                     uses_session_pr: true,
                 })
             }
@@ -288,3 +309,104 @@ impl std::fmt::Display for SessionResolveError {
 }
 
 impl std::error::Error for SessionResolveError {}
+
+#[cfg(test)]
+mod tests {
+    //! SessionRegistry resolution tests. The GitHub-source happy path
+    //! (the actual `git clone` + PR open) is covered by
+    //! `SessionGitBackend` integration tests in `regelrecht-corpus`; here
+    //! we lock down the routing decisions (local pass-through, source-
+    //! not-found, no-token mapping).
+    use super::*;
+
+    fn registry_yaml_for(source_yaml: &str) -> String {
+        format!("schema_version: '1'\nsources:\n{source_yaml}")
+    }
+
+    fn corpus_state_from_yaml(yaml: &str) -> CorpusState {
+        let registry = regelrecht_corpus::CorpusRegistry::from_yaml(yaml).unwrap();
+        CorpusState {
+            registry,
+            source_map: SourceMap::new(),
+            backends: HashMap::new(),
+            auth_file: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_unknown_source_returns_source_not_found() {
+        let yaml = registry_yaml_for(
+            r"  - id: known
+    name: Known
+    type: local
+    local:
+      path: /tmp/does-not-matter
+    priority: 1
+",
+        );
+        let corpus = corpus_state_from_yaml(&yaml);
+        let reg = SessionRegistry::new();
+        let result = reg
+            .resolve_session_backend(&corpus, "sess-1", "unknown")
+            .await;
+        match result {
+            Err(SessionResolveError::SourceNotFound(id)) => assert_eq!(id, "unknown"),
+            Err(other) => panic!("expected SourceNotFound, got {other:?}"),
+            Ok(_) => panic!("expected SourceNotFound, got Ok"),
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_local_source_without_registered_backend_is_source_not_found() {
+        // Source is declared in the registry but no backend was registered
+        // for it. The handler maps SourceNotFound → 404, which is correct
+        // because the source is effectively unusable for writes.
+        let yaml = registry_yaml_for(
+            r"  - id: local-src
+    name: Local
+    type: local
+    local:
+      path: /tmp/does-not-matter
+    priority: 1
+",
+        );
+        let corpus = corpus_state_from_yaml(&yaml);
+        let reg = SessionRegistry::new();
+        let result = reg
+            .resolve_session_backend(&corpus, "sess-1", "local-src")
+            .await;
+        match result {
+            Err(SessionResolveError::SourceNotFound(_)) => {}
+            Err(other) => panic!("expected SourceNotFound, got {other:?}"),
+            Ok(_) => panic!("expected SourceNotFound, got Ok"),
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_github_source_without_token_is_no_token() {
+        // No auth_ref and no auth_file → resolve_token_for_source returns
+        // Ok(None), which the registry must surface as NoToken so the
+        // handler can map it to 403 (not silently fall back).
+        let yaml = registry_yaml_for(
+            r"  - id: gh-src
+    name: GH
+    type: github
+    github:
+      owner: minbzk
+      repo: test
+      branch: main
+    priority: 1
+",
+        );
+        let corpus = corpus_state_from_yaml(&yaml);
+        let reg = SessionRegistry::new();
+        let result = reg
+            .resolve_session_backend(&corpus, "sess-1", "gh-src")
+            .await;
+        match result {
+            Err(SessionResolveError::NoToken(id)) => assert_eq!(id, "gh-src"),
+            Err(other) => panic!("expected NoToken, got {other:?}"),
+            Ok(_) => panic!("expected NoToken, got Ok"),
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Replaces the read-only left `Tekst` pane with a TipTap-based WYSIWYG editor that round-trips `articles[].text` as markdown.
- Toolbar uses `@minbzk/storybook` components: `nldd-toolbar` / `nldd-icon-button` / `nldd-dropdown`, with Bold, Italic, bullet list, and numbered list buttons.
- Reuses the machine-panel save infrastructure: both panes now share a single `handleLawSave` that PUTs the full law YAML via the existing `useLaw.saveLaw` flow. A dirty-state footer `Opslaan` button appears in whichever pane has pending edits.

## Behaviour notes

- **First-save YAML normalization.** Articles whose `text` is still plain-numbered prose (`"1. …\n\n2. …"`) will be normalized to canonical ordered-list markdown on first save. The engine ignores `text`, so this is functionally lossless, but the YAML diff will look substantial for articles edited for the first time.
- **Active-state styling is local.** `nldd-icon-button` has no `pressed` attribute today, so each format button is wrapped in a span that adds a subtle tint via scoped CSS. Upstreaming a proper pressed state to `MinBZK/storybook` is a follow-up.
- **`nldd-button-bar-divider` requires `nldd-button-bar`.** Outside that context it renders 0×0, so the separator between the inline-mark and list toggles is a local 1×20px styled `<span>`.
- **`ArticleText.vue` stays.** Still consumed read-only by `LibraryApp.vue` for the library detail view.

## Critical files

- `frontend/src/components/ArticleTextEditor.vue` — new
- `frontend/src/EditorApp.vue` — adds `editedText`, extends the `currentLawYaml` splice + dirty computed, factors `handleLawSave`, swaps the left-pane contents, adds the text-pane footer save button
- `frontend/package.json` — adds `@tiptap/core`, `@tiptap/vue-3`, `@tiptap/starter-kit`, `tiptap-markdown`

## Test plan

- [x] `npm test` (97 tests passing in frontend vitest suite)
- [x] `npm run build` — clean build, bundle grew ~60 KB gzipped (lazy-loaded `EditorApp` route chunk)
- [x] Manual smoke test via Playwright against vite dev server: bold / italic / bullet list / numbered list all toggle correctly, active-state on the toolbar reflects selection, footer `Opslaan` appears when dirty, state re-seeds cleanly on reload
- [ ] End-to-end save-to-disk verified in a preview environment (same `saveLaw` PUT as machine_readable, which is already production-proven)
- [ ] Library detail view still renders `ArticleText.vue` unchanged

## Follow-ups (out of scope)

- Upstream an `nldd-rich-text-editor` (or at least a toggled-state `nldd-icon-button`) to `MinBZK/storybook` so the local scoped active-state and divider hacks can go away.
- One-shot script to migrate existing corpus `articles[].text` to canonical markdown so the first-save normalization isn't distributed across future edits.