### PR TITLE
fix(deps): bump postcss to 8.5.12 (GHSA-qx2v-qp2m-jg93)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2718,9 +2718,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "funding": [
         {
           "type": "opencollective",

--- a/packages/admin/frontend-src/package-lock.json
+++ b/packages/admin/frontend-src/package-lock.json
@@ -1655,9 +1655,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "funding": [
         {
           "type": "opencollective",


### PR DESCRIPTION
## Summary
- `npm audit fix --package-lock-only` in `frontend/` and `packages/admin/frontend-src/`
- Resolves moderate-severity advisory [GHSA-qx2v-qp2m-jg93](https://github.com/advisories/GHSA-qx2v-qp2m-jg93) (PostCSS XSS via unescaped `</style>`)
- Unblocks Security Audit CI on all 5 open Dependabot PRs (#582, #583, #584, #585, #586)

## Test plan
- [ ] CI Security Audit passes
- [ ] Frontend builds (admin + editor) succeed