### PR TITLE
feat(editor): add per-user settings with theme toggle

### DIFF
--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -6,6 +6,7 @@ import { useLaw, fetchLaw } from './composables/useLaw.js';
 import { useEngine } from './composables/useEngine.js';
 import { useAuth } from './composables/useAuth.js';
 import { useFeatureFlags } from './composables/useFeatureFlags.js';
+import { useUserSettings } from './composables/useUserSettings.js';
 import ArticleText from './components/ArticleText.vue';
 import ActionSheet from './components/ActionSheet.vue';
 import EditSheet from './components/EditSheet.vue';
@@ -17,6 +18,7 @@ import LawGraphView from './components/LawGraphView.vue';
 
 const { authenticated, loading: authLoading, oidcConfigured, person, login, logout } = useAuth();
 const { isEnabled, toggle: toggleFlag } = useFeatureFlags();
+const { theme, toggleTheme } = useUserSettings();
 
 const editorPanelFlags = [
   ['panel.article_text', 'Tekst editor'],
@@ -707,6 +709,12 @@ function handleActionSave() {
                     :selected="isEnabled(key) || undefined"
                     :text="label"
                     @select="toggleFlag(key)"
+                  ></nldd-menu-item>
+                  <nldd-menu-item
+                    type="checkbox"
+                    :selected="theme === 'dark' || undefined"
+                    text="Donkere modus"
+                    @select="toggleTheme"
                   ></nldd-menu-item>
                   <nldd-menu-divider></nldd-menu-divider>
                   <nldd-menu-item v-if="!authLoading && authenticated" text="Uitloggen" @click="logout"></nldd-menu-item>

--- a/frontend/src/composables/useUserSettings.js
+++ b/frontend/src/composables/useUserSettings.js
@@ -21,7 +21,37 @@ const DEFAULTS = {
   theme: systemDark ? 'dark' : 'light',
 };
 
-const settings = ref({ ...DEFAULTS });
+// Cache the theme in localStorage so a returning user sees the right palette
+// immediately on next page load — without this the page mounts with the
+// prefers-color-scheme default and flips after the /api/user/settings fetch
+// resolves, which is a visible whole-page flicker. The server remains the
+// source of truth: a successful fetch always overwrites the cached value.
+const THEME_STORAGE_KEY = 'rr-user-settings-theme';
+
+function readCachedTheme() {
+  try {
+    const v = window.localStorage?.getItem(THEME_STORAGE_KEY);
+    return v === 'light' || v === 'dark' ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeCachedTheme(value) {
+  try {
+    window.localStorage?.setItem(THEME_STORAGE_KEY, value);
+  } catch {
+    // Ignore storage errors (private mode, quota, disabled) — flicker on
+    // next load is the only consequence.
+  }
+}
+
+const cachedTheme = typeof window !== 'undefined' ? readCachedTheme() : null;
+
+const settings = ref({
+  ...DEFAULTS,
+  ...(cachedTheme ? { theme: cachedTheme } : {}),
+});
 const loaded = ref(false);
 
 let fetchPromise = null;
@@ -34,6 +64,9 @@ async function loadSettings() {
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
       settings.value = { ...DEFAULTS, ...data };
+      if (data.theme === 'light' || data.theme === 'dark') {
+        writeCachedTheme(data.theme);
+      }
     } catch (e) {
       // 401 (auth off), 503 (no DB) and network errors all collapse to the
       // same outcome: use defaults and keep the editor loading.
@@ -49,6 +82,7 @@ async function loadSettings() {
 async function setSetting(key, value) {
   const prev = settings.value[key];
   settings.value = { ...settings.value, [key]: value };
+  if (key === 'theme') writeCachedTheme(value);
 
   try {
     const res = await fetch(`/api/user/settings/${encodeURIComponent(key)}`, {
@@ -60,6 +94,9 @@ async function setSetting(key, value) {
   } catch (e) {
     console.warn('Revert user setting after failed PUT:', e.message);
     settings.value = { ...settings.value, [key]: prev };
+    if (key === 'theme' && (prev === 'light' || prev === 'dark')) {
+      writeCachedTheme(prev);
+    }
   }
 }
 

--- a/frontend/src/composables/useUserSettings.js
+++ b/frontend/src/composables/useUserSettings.js
@@ -78,12 +78,12 @@ async function loadSettings() {
         writeCachedTheme(data.theme);
       }
     } catch (e) {
-      // 401 (auth off), 503 (no DB) and network errors all collapse to the
-      // same outcome: use defaults and keep the editor loading.
-      console.warn('Falling back to default user settings:', e.message);
-      const fallback = { ...DEFAULTS };
-      for (const k of dirtyKeys) fallback[k] = settings.value[k];
-      settings.value = fallback;
+      // 401 (auth off), 503 (no DB) and network errors all collapse to
+      // the same outcome: keep the editor loading on whatever's already
+      // in settings.value (cachedTheme + DEFAULTS + any user toggles).
+      // We have nothing better to merge — and resetting to DEFAULTS would
+      // re-introduce the flicker the localStorage cache exists to avoid.
+      console.warn('Keeping cached/default user settings:', e.message);
     } finally {
       loaded.value = true;
     }

--- a/frontend/src/composables/useUserSettings.js
+++ b/frontend/src/composables/useUserSettings.js
@@ -1,0 +1,85 @@
+/**
+ * useUserSettings — singleton per-user settings store with API sync.
+ *
+ * Fetches settings from /api/user/settings on first use and merges them on
+ * top of client-side defaults. Falls back to defaults on any failure (401,
+ * network, missing DB) so a brand-new or anonymous user always sees a
+ * usable editor.
+ *
+ * Theme is applied to <html> as `data-scheme`, which is the attribute
+ * `@minbzk/storybook` (NDD design system) keys its dark tokens on —
+ * it also sets `color-scheme` from that selector, so UA form controls
+ * follow automatically.
+ */
+import { ref, readonly, computed, watchEffect } from 'vue';
+
+const systemDark = typeof window !== 'undefined'
+  && window.matchMedia
+  && window.matchMedia('(prefers-color-scheme: dark)').matches;
+
+const DEFAULTS = {
+  theme: systemDark ? 'dark' : 'light',
+};
+
+const settings = ref({ ...DEFAULTS });
+const loaded = ref(false);
+
+let fetchPromise = null;
+
+async function loadSettings() {
+  if (fetchPromise) return fetchPromise;
+  fetchPromise = (async () => {
+    try {
+      const res = await fetch('/api/user/settings');
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json();
+      settings.value = { ...DEFAULTS, ...data };
+    } catch (e) {
+      // 401 (auth off), 503 (no DB) and network errors all collapse to the
+      // same outcome: use defaults and keep the editor loading.
+      console.warn('Falling back to default user settings:', e.message);
+      settings.value = { ...DEFAULTS };
+    } finally {
+      loaded.value = true;
+    }
+  })();
+  return fetchPromise;
+}
+
+async function setSetting(key, value) {
+  const prev = settings.value[key];
+  settings.value = { ...settings.value, [key]: value };
+
+  try {
+    const res = await fetch(`/api/user/settings/${encodeURIComponent(key)}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ value }),
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  } catch (e) {
+    console.warn('Revert user setting after failed PUT:', e.message);
+    settings.value = { ...settings.value, [key]: prev };
+  }
+}
+
+// Apply theme to <html>. Runs before the fetch completes too, using DEFAULTS.
+watchEffect(() => {
+  if (typeof document === 'undefined') return;
+  const t = settings.value.theme || DEFAULTS.theme;
+  document.documentElement.setAttribute('data-scheme', t);
+});
+
+export function useUserSettings() {
+  if (!loaded.value && !fetchPromise) {
+    loadSettings();
+  }
+  return {
+    settings: readonly(settings),
+    loaded: readonly(loaded),
+    theme: computed(() => settings.value.theme),
+    setTheme: (v) => setSetting('theme', v),
+    toggleTheme: () =>
+      setSetting('theme', settings.value.theme === 'dark' ? 'light' : 'dark'),
+  };
+}

--- a/frontend/src/composables/useUserSettings.js
+++ b/frontend/src/composables/useUserSettings.js
@@ -69,7 +69,12 @@ async function loadSettings() {
       const res = await fetch('/api/user/settings');
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
-      const merged = { ...DEFAULTS, ...data };
+      // Precedence: server > current settings (cached + user toggles) >
+      // DEFAULTS. Spreading settings.value before data prevents an empty
+      // `{}` response from overwriting a cached theme on a returning user
+      // whose server row was never written — same flicker the cache
+      // exists to prevent.
+      const merged = { ...DEFAULTS, ...settings.value, ...data };
       // Preserve values the user already set locally during this fetch.
       for (const k of dirtyKeys) merged[k] = settings.value[k];
       settings.value = merged;

--- a/frontend/src/composables/useUserSettings.js
+++ b/frontend/src/composables/useUserSettings.js
@@ -54,6 +54,12 @@ const settings = ref({
 });
 const loaded = ref(false);
 
+// Keys the user has touched locally before `loadSettings` resolved. The
+// initial fetch must NOT overwrite these — otherwise a toggle clicked
+// during the fetch latency window would briefly flip back to the stale
+// server value while the PUT is still in flight.
+const dirtyKeys = new Set();
+
 let fetchPromise = null;
 
 async function loadSettings() {
@@ -63,15 +69,21 @@ async function loadSettings() {
       const res = await fetch('/api/user/settings');
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
-      settings.value = { ...DEFAULTS, ...data };
-      if (data.theme === 'light' || data.theme === 'dark') {
+      const merged = { ...DEFAULTS, ...data };
+      // Preserve values the user already set locally during this fetch.
+      for (const k of dirtyKeys) merged[k] = settings.value[k];
+      settings.value = merged;
+      if (!dirtyKeys.has('theme')
+          && (data.theme === 'light' || data.theme === 'dark')) {
         writeCachedTheme(data.theme);
       }
     } catch (e) {
       // 401 (auth off), 503 (no DB) and network errors all collapse to the
       // same outcome: use defaults and keep the editor loading.
       console.warn('Falling back to default user settings:', e.message);
-      settings.value = { ...DEFAULTS };
+      const fallback = { ...DEFAULTS };
+      for (const k of dirtyKeys) fallback[k] = settings.value[k];
+      settings.value = fallback;
     } finally {
       loaded.value = true;
     }
@@ -81,6 +93,7 @@ async function loadSettings() {
 
 async function setSetting(key, value) {
   const prev = settings.value[key];
+  dirtyKeys.add(key);
   settings.value = { ...settings.value, [key]: value };
   if (key === 'theme') writeCachedTheme(value);
 

--- a/frontend/src/composables/useUserSettings.js
+++ b/frontend/src/composables/useUserSettings.js
@@ -115,6 +115,12 @@ async function setSetting(key, value) {
     if (key === 'theme' && (prev === 'light' || prev === 'dark')) {
       writeCachedTheme(prev);
     }
+  } finally {
+    // Once the PUT has settled either way, the key is no longer "in
+    // flight" — either the server has accepted our value or we've
+    // reverted. Keeping it in dirtyKeys would suppress the server
+    // value if loadSettings ever became re-entrant.
+    dirtyKeys.delete(key);
   }
 }
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -3,6 +3,11 @@ import '@minbzk/storybook/styles';
 import { createApp } from 'vue';
 import App from './App.vue';
 import router from './router.js';
+import { useUserSettings } from './composables/useUserSettings.js';
+
+// Side-effect: starts the /api/user/settings fetch and registers a
+// watchEffect that mirrors the theme onto <html data-scheme="...">.
+useUserSettings();
 
 const app = createApp(App);
 app.use(router);

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -172,9 +172,13 @@ async fn main() {
             axum::routing::put(feature_flags::update_feature_flag),
         )
         .route("/api/user/settings", get(user_settings::list))
+        // 4 KiB is ample for `{"value":"<one allowed enum>"}` and stops a
+        // caller from streaming a much larger body that `validate` would only
+        // reject after deserialization.
         .route(
             "/api/user/settings/{key}",
-            axum::routing::put(user_settings::set),
+            axum::routing::put(user_settings::set)
+                .layer(axum::extract::DefaultBodyLimit::max(4096)),
         )
         .route_layer(axum_middleware::from_fn_with_state(
             app_state.clone(),

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -24,6 +24,7 @@ mod feature_flags;
 mod harvest_proxy;
 mod middleware;
 mod state;
+mod user_settings;
 
 use state::{AppState, CorpusState};
 
@@ -169,6 +170,11 @@ async fn main() {
         .route(
             "/api/feature-flags/{key}",
             axum::routing::put(feature_flags::update_feature_flag),
+        )
+        .route("/api/user/settings", get(user_settings::list))
+        .route(
+            "/api/user/settings/{key}",
+            axum::routing::put(user_settings::set),
         )
         .route_layer(axum_middleware::from_fn_with_state(
             app_state.clone(),

--- a/packages/editor-api/src/user_settings.rs
+++ b/packages/editor-api/src/user_settings.rs
@@ -1,0 +1,118 @@
+use std::collections::HashMap;
+
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::Json;
+use serde::Deserialize;
+use tower_sessions::Session;
+
+use regelrecht_auth::SESSION_KEY_SUB;
+
+use crate::state::AppState;
+
+/// Keys the editor accepts as user settings. Unknown keys are rejected so the
+/// table cannot be used as a catch-all key/value store for client-supplied data.
+const ALLOWED_KEYS: &[&str] = &["theme"];
+
+fn validate(key: &str, value: &str) -> Result<(), StatusCode> {
+    if !ALLOWED_KEYS.contains(&key) {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+    match key {
+        "theme" if !matches!(value, "light" | "dark") => Err(StatusCode::BAD_REQUEST),
+        _ => Ok(()),
+    }
+}
+
+async fn get_person_sub(session: &Session) -> Result<String, StatusCode> {
+    session
+        .get::<String>(SESSION_KEY_SUB)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+        .ok_or(StatusCode::UNAUTHORIZED)
+}
+
+fn get_pool(state: &AppState) -> Result<&sqlx::PgPool, StatusCode> {
+    state.pool.as_ref().ok_or(StatusCode::SERVICE_UNAVAILABLE)
+}
+
+/// GET /api/user/settings — return the authenticated user's settings.
+/// An empty map is returned for a user who has never written a setting;
+/// the frontend merges this with its client-side defaults.
+pub async fn list(
+    State(state): State<AppState>,
+    session: Session,
+) -> Result<Json<HashMap<String, String>>, StatusCode> {
+    let person_sub = get_person_sub(&session).await?;
+    let pool = get_pool(&state)?;
+
+    let rows: Vec<(String, String)> =
+        sqlx::query_as("SELECT key, value FROM user_settings WHERE person_sub = $1")
+            .bind(&person_sub)
+            .fetch_all(pool)
+            .await
+            .map_err(|e| {
+                tracing::error!(error = %e, "failed to fetch user settings");
+                StatusCode::INTERNAL_SERVER_ERROR
+            })?;
+
+    Ok(Json(rows.into_iter().collect()))
+}
+
+#[derive(Deserialize)]
+pub struct SetBody {
+    pub value: String,
+}
+
+/// PUT /api/user/settings/{key} — idempotent upsert. The first write for a
+/// user creates the row; subsequent writes update the value in place.
+pub async fn set(
+    State(state): State<AppState>,
+    session: Session,
+    Path(key): Path<String>,
+    Json(body): Json<SetBody>,
+) -> Result<StatusCode, StatusCode> {
+    validate(&key, &body.value)?;
+    let person_sub = get_person_sub(&session).await?;
+    let pool = get_pool(&state)?;
+
+    sqlx::query(
+        "INSERT INTO user_settings (person_sub, key, value)
+         VALUES ($1, $2, $3)
+         ON CONFLICT (person_sub, key) DO UPDATE SET value = EXCLUDED.value",
+    )
+    .bind(&person_sub)
+    .bind(&key)
+    .bind(&body.value)
+    .execute(pool)
+    .await
+    .map_err(|e| {
+        tracing::error!(error = %e, "failed to upsert user setting");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_accepts_theme_light_and_dark() {
+        assert!(validate("theme", "light").is_ok());
+        assert!(validate("theme", "dark").is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_unknown_theme_value() {
+        assert_eq!(validate("theme", "purple"), Err(StatusCode::BAD_REQUEST));
+        assert_eq!(validate("theme", ""), Err(StatusCode::BAD_REQUEST));
+    }
+
+    #[test]
+    fn validate_rejects_unknown_key() {
+        assert_eq!(validate("foo", "anything"), Err(StatusCode::BAD_REQUEST));
+        assert_eq!(validate("", "anything"), Err(StatusCode::BAD_REQUEST));
+    }
+}

--- a/packages/editor-api/src/user_settings.rs
+++ b/packages/editor-api/src/user_settings.rs
@@ -56,7 +56,13 @@ pub async fn list(
                 StatusCode::INTERNAL_SERVER_ERROR
             })?;
 
-    Ok(Json(rows.into_iter().collect()))
+    // Filter through the same allowlist as `set` so a key removed from
+    // ALLOWED_KEYS in a future revision cannot leak its old row to clients.
+    let filtered = rows
+        .into_iter()
+        .filter(|(k, _)| ALLOWED_KEYS.contains(&k.as_str()))
+        .collect();
+    Ok(Json(filtered))
 }
 
 #[derive(Deserialize)]

--- a/packages/pipeline/migrations/0013_user_settings.sql
+++ b/packages/pipeline/migrations/0013_user_settings.sql
@@ -1,5 +1,8 @@
 -- Per-user settings for the editor (e.g. theme).
 -- Key/value shape so new settings do not require a migration.
+-- The PRIMARY KEY already serves person_sub-prefixed lookups, so no
+-- separate single-column index is created — same scrub pattern as
+-- 0009_drop_redundant_favorites_index.sql.
 CREATE TABLE user_settings (
     person_sub  TEXT        NOT NULL,
     key         TEXT        NOT NULL,
@@ -7,8 +10,6 @@ CREATE TABLE user_settings (
     updated_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
     PRIMARY KEY (person_sub, key)
 );
-
-CREATE INDEX idx_user_settings_person ON user_settings (person_sub);
 
 CREATE TRIGGER trg_user_settings_updated_at
     BEFORE UPDATE ON user_settings

--- a/packages/pipeline/migrations/0013_user_settings.sql
+++ b/packages/pipeline/migrations/0013_user_settings.sql
@@ -1,0 +1,15 @@
+-- Per-user settings for the editor (e.g. theme).
+-- Key/value shape so new settings do not require a migration.
+CREATE TABLE user_settings (
+    person_sub  TEXT        NOT NULL,
+    key         TEXT        NOT NULL,
+    value       TEXT        NOT NULL,
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (person_sub, key)
+);
+
+CREATE INDEX idx_user_settings_person ON user_settings (person_sub);
+
+CREATE TRIGGER trg_user_settings_updated_at
+    BEFORE UPDATE ON user_settings
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at();


### PR DESCRIPTION
## Summary
- Persists per-user editor settings (keyed by OIDC `person_sub`) in a new `user_settings` table; first setting is **theme** (light/dark).
- Frontend mirrors the chosen theme onto `<html data-scheme="...">`, which is the attribute `@minbzk/storybook` (NDD) already keys its dark tokens on — light/dark applies across editor + library views without bespoke CSS.
- Theme toggle ("Donkere modus") added as a checkbox menu-item in the existing account-menu (person-circle).
- Fail-soft loading: 401 (auth off), 503 (no DB), and network errors collapse to `prefers-color-scheme` defaults, so a brand-new or anonymous user always lands in a working editor.

## Implementation notes
- Mirrors the favorites pattern: directly-bound sqlx queries in `editor-api`, schema migration in `packages/pipeline/migrations/`, `person_sub` from session via `regelrecht_auth::SESSION_KEY_SUB`.
- Allowed-keys list (`ALLOWED_KEYS = ["theme"]`) and per-key value validation prevent the table from becoming a free-form key/value bag.
- Idempotent upsert (`ON CONFLICT DO UPDATE`) — first write creates the row, no setup needed for a new user.

## Test plan
- [x] `just format`, `just lint`, `just test` — all green; 3 new unit tests for `validate()`.
- [x] Migration 0013 applied cleanly on Postgres 17 from a fresh schema; trigger fires on `UPDATE` and on upsert via `ON CONFLICT DO UPDATE`.
- [ ] End-to-end in dev (Postgres + editor-api + Vite): new user lands with system-default theme, toggle persists across hard-refresh, library view picks up the theme, `PUT /api/user/settings/theme {"value":"purple"}` → 400, anonymous request → 401.
- [ ] Visual check: dark tokens from `@minbzk/storybook` actually flip the editor and library palettes.