### PR TITLE
feat(editor): merge scenario/yaml/graph panes with dropdown switcher

### DIFF
--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -49,7 +49,7 @@ watch(enabledRightPanes, (panes) => {
   }
 }, { immediate: true });
 watch(activeRightPane, (val) => {
-  if (val) localStorage.setItem(ACTIVE_RIGHT_PANE_KEY, val);
+  localStorage.setItem(ACTIVE_RIGHT_PANE_KEY, val);
 });
 const activeRightPaneLabel = computed(
   () => enabledRightPanes.value.find(p => p.key === activeRightPane.value)?.label ?? '',

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -30,7 +30,7 @@ const editorPanelFlags = [
 // category — anything that isn't text or machine lives there, and when more
 // than one is enabled they share the slot via a dropdown switcher in the
 // header. Adding a new editor: append to RIGHT_PANES and render its body in
-// the v-if chain below.
+// the right-pane v-if chain in the template.
 const showTextPane = computed(() => isEnabled('panel.article_text'));
 const showMachinePane = computed(() => isEnabled('panel.machine_readable'));
 
@@ -41,7 +41,7 @@ const RIGHT_PANES = [
 ];
 const enabledRightPanes = computed(() => RIGHT_PANES.filter(p => isEnabled(p.flag)));
 
-const ACTIVE_RIGHT_PANE_KEY = 'regelrecht-active-output-tab';
+const ACTIVE_RIGHT_PANE_KEY = 'regelrecht-active-right-pane';
 const activeRightPane = ref(localStorage.getItem(ACTIVE_RIGHT_PANE_KEY) || RIGHT_PANES[0].key);
 watch(enabledRightPanes, (panes) => {
   if (panes.length > 0 && !panes.some(p => p.key === activeRightPane.value)) {

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -820,7 +820,7 @@ function handleActionSave() {
                     <nldd-menu-item
                       v-for="pane in enabledRightPanes"
                       :key="pane.key"
-                      type="checkbox"
+                      type="radio"
                       :selected="activeRightPane === pane.key || undefined"
                       :text="pane.label"
                       @select="activeRightPane = pane.key"

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -26,44 +26,42 @@ const editorPanelFlags = [
   ['panel.law_graph', 'Wettengraaf'],
 ];
 
+// Left and middle panes are specific named editors. The right pane is a
+// category — anything that isn't text or machine lives there, and when more
+// than one is enabled they share the slot via a dropdown switcher in the
+// header. Adding a new editor: append to RIGHT_PANES and render its body in
+// the v-if chain below.
 const showTextPane = computed(() => isEnabled('panel.article_text'));
-const showFormPane = computed(() => isEnabled('panel.scenario_form'));
-const showYamlPane = computed(() => isEnabled('panel.yaml_editor'));
 const showMachinePane = computed(() => isEnabled('panel.machine_readable'));
-const showGraphPane = computed(() => isEnabled('panel.law_graph'));
 
-// Scenarios / YAML / Wettengraaf share one pane with a dropdown switcher when
-// more than one is enabled. With one enabled, that pane behaves like a regular
-// titled pane.
-const OUTPUT_TAB_LABELS = { form: "Scenario's", yaml: 'YAML', graph: 'Wettengraaf' };
-const groupedOutputKeys = computed(() => {
-  const keys = [];
-  if (showFormPane.value) keys.push('form');
-  if (showYamlPane.value) keys.push('yaml');
-  if (showGraphPane.value) keys.push('graph');
-  return keys;
-});
+const RIGHT_PANES = [
+  { key: 'form', flag: 'panel.scenario_form', label: "Scenario's" },
+  { key: 'yaml', flag: 'panel.yaml_editor', label: 'YAML' },
+  { key: 'graph', flag: 'panel.law_graph', label: 'Wettengraaf' },
+];
+const enabledRightPanes = computed(() => RIGHT_PANES.filter(p => isEnabled(p.flag)));
 
-const ACTIVE_OUTPUT_TAB_KEY = 'regelrecht-active-output-tab';
-const activeOutputTab = ref(localStorage.getItem(ACTIVE_OUTPUT_TAB_KEY) || 'form');
-watch(groupedOutputKeys, (keys) => {
-  if (keys.length > 0 && !keys.includes(activeOutputTab.value)) {
-    activeOutputTab.value = keys[0];
+const ACTIVE_RIGHT_PANE_KEY = 'regelrecht-active-output-tab';
+const activeRightPane = ref(localStorage.getItem(ACTIVE_RIGHT_PANE_KEY) || RIGHT_PANES[0].key);
+watch(enabledRightPanes, (panes) => {
+  if (panes.length > 0 && !panes.some(p => p.key === activeRightPane.value)) {
+    activeRightPane.value = panes[0].key;
   }
 }, { immediate: true });
-watch(activeOutputTab, (val) => {
-  if (val) localStorage.setItem(ACTIVE_OUTPUT_TAB_KEY, val);
+watch(activeRightPane, (val) => {
+  if (val) localStorage.setItem(ACTIVE_RIGHT_PANE_KEY, val);
 });
-const activeOutputTabLabel = computed(() => OUTPUT_TAB_LABELS[activeOutputTab.value] ?? '');
+const activeRightPaneLabel = computed(
+  () => enabledRightPanes.value.find(p => p.key === activeRightPane.value)?.label ?? '',
+);
 
-// Compute visible pane count and slot assignments for split view. The three
-// "output" sub-panes share one slot regardless of how many are enabled.
+// Compute visible pane count and slot assignments for the split view.
 const visiblePanes = computed(() => {
   const panes = [];
   if (showTextPane.value) panes.push('text');
   if (showMachinePane.value) panes.push('machine');
-  if (groupedOutputKeys.value.length > 0) panes.push('output');
-  return panes.length > 0 ? panes : ['text', 'machine', 'output'];
+  if (enabledRightPanes.value.length > 0) panes.push('right');
+  return panes.length > 0 ? panes : ['text', 'machine', 'right'];
 });
 const paneSlot = (name) => {
   const idx = visiblePanes.value.indexOf(name);
@@ -805,37 +803,37 @@ function handleActionSave() {
             </nldd-page>
           </nldd-split-view-pane>
 
-          <!-- Output: Scenarios / YAML / Wettengraaf — share one pane with a
-               dropdown switcher in the header when more than one is enabled. -->
-          <nldd-split-view-pane v-if="groupedOutputKeys.length > 0" :slot="paneSlot('output')">
+          <!-- Right pane: any non-text/non-machine editor. When more than one
+               is enabled they share this slot with a dropdown switcher. -->
+          <nldd-split-view-pane v-if="enabledRightPanes.length > 0" :slot="paneSlot('right')">
             <nldd-page sticky-header>
-              <template v-if="groupedOutputKeys.length > 1">
-                <div slot="header" class="output-pane-header">
+              <template v-if="enabledRightPanes.length > 1">
+                <div slot="header" class="right-pane-header">
                   <nldd-button
-                    id="output-pane-menu-btn"
+                    id="right-pane-menu-btn"
                     size="md"
                     expandable
-                    :text="activeOutputTabLabel"
-                    popovertarget="output-pane-menu"
+                    :text="activeRightPaneLabel"
+                    popovertarget="right-pane-menu"
                   ></nldd-button>
-                  <nldd-menu id="output-pane-menu" anchor="output-pane-menu-btn">
+                  <nldd-menu id="right-pane-menu" anchor="right-pane-menu-btn">
                     <nldd-menu-item
-                      v-for="key in groupedOutputKeys"
-                      :key="key"
+                      v-for="pane in enabledRightPanes"
+                      :key="pane.key"
                       type="checkbox"
-                      :selected="activeOutputTab === key || undefined"
-                      :text="OUTPUT_TAB_LABELS[key]"
-                      @select="activeOutputTab = key"
+                      :selected="activeRightPane === pane.key || undefined"
+                      :text="pane.label"
+                      @select="activeRightPane = pane.key"
                     ></nldd-menu-item>
                   </nldd-menu>
-                  <span v-if="activeOutputTab === 'yaml' && parseError" class="editor-parse-error">YAML parse error</span>
+                  <span v-if="activeRightPane === 'yaml' && parseError" class="editor-parse-error">YAML parse error</span>
                 </div>
               </template>
-              <nldd-top-title-bar v-else slot="header" :text="activeOutputTabLabel">
-                <span v-if="activeOutputTab === 'yaml' && parseError" slot="toolbar" class="editor-parse-error">YAML parse error</span>
+              <nldd-top-title-bar v-else slot="header" :text="activeRightPaneLabel">
+                <span v-if="activeRightPane === 'yaml' && parseError" slot="toolbar" class="editor-parse-error">YAML parse error</span>
               </nldd-top-title-bar>
 
-              <template v-if="activeOutputTab === 'form'">
+              <template v-if="activeRightPane === 'form'">
                 <nldd-simple-section v-if="engineInitError" align="center">
                   <nldd-inline-dialog variant="alert" text="WASM engine niet geladen" :supporting-text="`${engineInitError.message} — voer 'just wasm-build' uit om de WASM module te bouwen.`"></nldd-inline-dialog>
                 </nldd-simple-section>
@@ -850,7 +848,7 @@ function handleActionSave() {
                 />
               </template>
 
-              <div v-else-if="activeOutputTab === 'yaml'" class="editor-yaml-wrap">
+              <div v-else-if="activeRightPane === 'yaml'" class="editor-yaml-wrap">
                 <textarea
                   :value="yamlSource"
                   @input="onYamlInput"
@@ -864,7 +862,7 @@ function handleActionSave() {
               </div>
 
               <LawGraphView
-                v-else-if="activeOutputTab === 'graph'"
+                v-else-if="activeRightPane === 'graph'"
                 :law-id="lawId"
                 :result="lastResult"
                 :output-name="lastOutputName"
@@ -959,11 +957,11 @@ function handleActionSave() {
   border-radius: 3px;
 }
 
-/* Header for the merged Scenario's / YAML / Wettengraaf pane: dropdown button
-   sits where the title would normally be, with the YAML parse-error pill
-   floating after it. Mirrors nldd-top-title-bar's compact spacing so the row
-   height matches the other panes' headers. */
-.output-pane-header {
+/* Header for the right pane when multiple right-pane editors are enabled:
+   dropdown button sits where the title would normally be, with the YAML
+   parse-error pill floating after it. Mirrors nldd-top-title-bar's compact
+   spacing so the row height matches the other panes' headers. */
+.right-pane-header {
   display: flex;
   align-items: center;
   gap: 12px;

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -32,15 +32,38 @@ const showYamlPane = computed(() => isEnabled('panel.yaml_editor'));
 const showMachinePane = computed(() => isEnabled('panel.machine_readable'));
 const showGraphPane = computed(() => isEnabled('panel.law_graph'));
 
-// Compute visible pane count and slot assignments for split view.
+// Scenarios / YAML / Wettengraaf share one pane with a dropdown switcher when
+// more than one is enabled. With one enabled, that pane behaves like a regular
+// titled pane.
+const OUTPUT_TAB_LABELS = { form: "Scenario's", yaml: 'YAML', graph: 'Wettengraaf' };
+const groupedOutputKeys = computed(() => {
+  const keys = [];
+  if (showFormPane.value) keys.push('form');
+  if (showYamlPane.value) keys.push('yaml');
+  if (showGraphPane.value) keys.push('graph');
+  return keys;
+});
+
+const ACTIVE_OUTPUT_TAB_KEY = 'regelrecht-active-output-tab';
+const activeOutputTab = ref(localStorage.getItem(ACTIVE_OUTPUT_TAB_KEY) || 'form');
+watch(groupedOutputKeys, (keys) => {
+  if (keys.length > 0 && !keys.includes(activeOutputTab.value)) {
+    activeOutputTab.value = keys[0];
+  }
+}, { immediate: true });
+watch(activeOutputTab, (val) => {
+  if (val) localStorage.setItem(ACTIVE_OUTPUT_TAB_KEY, val);
+});
+const activeOutputTabLabel = computed(() => OUTPUT_TAB_LABELS[activeOutputTab.value] ?? '');
+
+// Compute visible pane count and slot assignments for split view. The three
+// "output" sub-panes share one slot regardless of how many are enabled.
 const visiblePanes = computed(() => {
   const panes = [];
   if (showTextPane.value) panes.push('text');
   if (showMachinePane.value) panes.push('machine');
-  if (showFormPane.value) panes.push('form');
-  if (showYamlPane.value) panes.push('yaml');
-  if (showGraphPane.value) panes.push('graph');
-  return panes.length > 0 ? panes : ['text', 'machine', 'form', 'yaml'];
+  if (groupedOutputKeys.value.length > 0) panes.push('output');
+  return panes.length > 0 ? panes : ['text', 'machine', 'output'];
 });
 const paneSlot = (name) => {
   const idx = visiblePanes.value.indexOf(name);
@@ -782,35 +805,52 @@ function handleActionSave() {
             </nldd-page>
           </nldd-split-view-pane>
 
-          <!-- Scenarios -->
-          <nldd-split-view-pane v-if="showFormPane" :slot="paneSlot('form')">
+          <!-- Output: Scenarios / YAML / Wettengraaf — share one pane with a
+               dropdown switcher in the header when more than one is enabled. -->
+          <nldd-split-view-pane v-if="groupedOutputKeys.length > 0" :slot="paneSlot('output')">
             <nldd-page sticky-header>
-              <nldd-top-title-bar slot="header" text="Scenario's"></nldd-top-title-bar>
-
-              <nldd-simple-section v-if="engineInitError" align="center">
-                <nldd-inline-dialog variant="alert" text="WASM engine niet geladen" :supporting-text="`${engineInitError.message} — voer 'just wasm-build' uit om de WASM module te bouwen.`"></nldd-inline-dialog>
-              </nldd-simple-section>
-
-              <ScenarioBuilder
-                v-else
-                :law-id="lawId"
-                :law-yaml="currentLawYaml"
-                :engine="getEngine()"
-                :ready="engineReady"
-                :articles="articles"
-                @executed="handleScenarioExecuted"
-              />
-            </nldd-page>
-          </nldd-split-view-pane>
-
-          <!-- YAML -->
-          <nldd-split-view-pane v-if="showYamlPane" :slot="paneSlot('yaml')">
-            <nldd-page sticky-header>
-              <nldd-top-title-bar slot="header" text="YAML">
-                <span v-if="parseError" slot="toolbar" class="editor-parse-error">YAML parse error</span>
+              <template v-if="groupedOutputKeys.length > 1">
+                <div slot="header" class="output-pane-header">
+                  <nldd-button
+                    id="output-pane-menu-btn"
+                    size="md"
+                    expandable
+                    :text="activeOutputTabLabel"
+                    popovertarget="output-pane-menu"
+                  ></nldd-button>
+                  <nldd-menu id="output-pane-menu" anchor="output-pane-menu-btn">
+                    <nldd-menu-item
+                      v-for="key in groupedOutputKeys"
+                      :key="key"
+                      type="checkbox"
+                      :selected="activeOutputTab === key || undefined"
+                      :text="OUTPUT_TAB_LABELS[key]"
+                      @select="activeOutputTab = key"
+                    ></nldd-menu-item>
+                  </nldd-menu>
+                  <span v-if="activeOutputTab === 'yaml' && parseError" class="editor-parse-error">YAML parse error</span>
+                </div>
+              </template>
+              <nldd-top-title-bar v-else slot="header" :text="activeOutputTabLabel">
+                <span v-if="activeOutputTab === 'yaml' && parseError" slot="toolbar" class="editor-parse-error">YAML parse error</span>
               </nldd-top-title-bar>
 
-              <div class="editor-yaml-wrap">
+              <template v-if="activeOutputTab === 'form'">
+                <nldd-simple-section v-if="engineInitError" align="center">
+                  <nldd-inline-dialog variant="alert" text="WASM engine niet geladen" :supporting-text="`${engineInitError.message} — voer 'just wasm-build' uit om de WASM module te bouwen.`"></nldd-inline-dialog>
+                </nldd-simple-section>
+                <ScenarioBuilder
+                  v-else
+                  :law-id="lawId"
+                  :law-yaml="currentLawYaml"
+                  :engine="getEngine()"
+                  :ready="engineReady"
+                  :articles="articles"
+                  @executed="handleScenarioExecuted"
+                />
+              </template>
+
+              <div v-else-if="activeOutputTab === 'yaml'" class="editor-yaml-wrap">
                 <textarea
                   :value="yamlSource"
                   @input="onYamlInput"
@@ -822,6 +862,14 @@ function handleActionSave() {
                 ></textarea>
                 <div v-if="parseError" class="editor-parse-error-detail">{{ parseError }}</div>
               </div>
+
+              <LawGraphView
+                v-else-if="activeOutputTab === 'graph'"
+                :law-id="lawId"
+                :result="lastResult"
+                :output-name="lastOutputName"
+                :expectations="lastExpectations"
+              />
             </nldd-page>
           </nldd-split-view-pane>
 
@@ -858,18 +906,6 @@ function handleActionSave() {
             </nldd-page>
           </nldd-split-view-pane>
 
-          <!-- Law dependency graph -->
-          <nldd-split-view-pane v-if="showGraphPane" :slot="paneSlot('graph')">
-            <nldd-page sticky-header>
-              <nldd-top-title-bar slot="header" text="Wettengraaf"></nldd-top-title-bar>
-              <LawGraphView
-                :law-id="lawId"
-                :result="lastResult"
-                :output-name="lastOutputName"
-                :expectations="lastExpectations"
-              />
-            </nldd-page>
-          </nldd-split-view-pane>
         </nldd-side-by-side-split-view>
       </nldd-split-view-pane>
     </nldd-bar-split-view>
@@ -921,6 +957,19 @@ function handleActionSave() {
   background: #eee;
   padding: 1px 4px;
   border-radius: 3px;
+}
+
+/* Header for the merged Scenario's / YAML / Wettengraaf pane: dropdown button
+   sits where the title would normally be, with the YAML parse-error pill
+   floating after it. Mirrors nldd-top-title-bar's compact spacing so the row
+   height matches the other panes' headers. */
+.output-pane-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  min-height: 56px;
+  box-sizing: border-box;
 }
 
 .editor-yaml-wrap {

--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -91,7 +91,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -102,7 +102,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -123,9 +123,9 @@ dependencies = [
 
 [[package]]
 name = "astral-tokio-tar"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c23f3af104b40a3430ccb90ed5f7bd877a8dc5c26fc92fde51a22b40890dcf9"
+checksum = "4ce73b17c62717c4b6a9af10b43e87c578b0cac27e00666d48304d3b7d2c0693"
 dependencies = [
  "filetime",
  "futures-core",
@@ -1240,7 +1240,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2550,7 +2550,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4012,7 +4012,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4071,7 +4071,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4480,7 +4480,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4910,7 +4910,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6015,7 +6015,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Combines the three "output" panes (Scenario's, YAML, Wettengraaf) into one shared split-view pane. When **>1** of them is enabled, the header is an `nldd-button expandable` that opens a menu of the enabled tabs; with **1** enabled, the pane behaves like a normal titled pane. Article-text and Machine-readable stay independent panes — they are typically viewed alongside the output pane, not as alternatives to it.

The active tab is persisted in `localStorage` (`regelrecht-active-output-tab`) so it survives reloads.

## Why

Wettengraaf trace-stepping (#588) made it useful to flip between Scenario's, YAML, and Wettengraaf in the same screen real-estate while iterating on a law. Three side-by-side panes get cramped on smaller widths; merging them keeps the layout flexible and matches the Figma direction (dropdown switcher in the pane header).

## Behaviour

- 0 of {form, yaml, graph} enabled → output pane disappears (only text/machine panes)
- 1 enabled → plain titled pane (no dropdown — no point)
- ≥2 enabled → dropdown header, last-active tab restored from `localStorage`
- YAML parse-error pill is bound to `activeOutputTab === 'yaml'` so it only shows when YAML is the active tab

## Out of scope

- Existing per-pane feature flags (`panel.scenario_form`, `panel.yaml_editor`, `panel.law_graph`) are unchanged — users can still toggle each on/off via the account-menu
- No styling changes to the dropdown beyond a thin `.output-pane-header` wrapper that matches `nldd-top-title-bar`'s row height

## Test plan

- [ ] `npm run build` clean
- [ ] Default flags (form + yaml on, graph off) → output pane shows "Scenario's ⌄" with two menu items
- [ ] Enable Wettengraaf via account-menu → dropdown gets a third item, active tab unchanged
- [ ] Switch tab, reload → previously-active tab is restored
- [ ] Disable two of three so only one remains → header reverts to plain title (no dropdown)
- [ ] Type invalid YAML in yaml tab → "YAML parse error" pill shows in header; switch to Scenario's → pill disappears
- [ ] Run a scenario in form tab, switch to graph tab → trace-stepping still works (lastResult/lastOutputName/lastExpectations propagate correctly)