### PR TITLE
feat(editor): default panel.law_graph flag to true

### DIFF
--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -31,7 +31,6 @@ const editorPanelFlags = [
   ['panel.machine_readable', 'Machine editor'],
   ['panel.scenario_form', 'Scenario editor'],
   ['panel.yaml_editor', 'YAML editor'],
-  ['panel.law_graph', 'Graaf'],
 ];
 
 // Left and middle panes are specific named editors. The right pane is a
@@ -45,7 +44,6 @@ const showMachinePane = computed(() => isEnabled('panel.machine_readable'));
 const RIGHT_PANES = [
   { key: 'form', flag: 'panel.scenario_form', label: "Scenario's" },
   { key: 'yaml', flag: 'panel.yaml_editor', label: 'YAML' },
-  { key: 'graph', flag: 'panel.law_graph', label: 'Graaf' },
 ];
 const enabledRightPanes = computed(() => RIGHT_PANES.filter(p => isEnabled(p.flag)));
 
@@ -320,9 +318,15 @@ const lastResult = ref(null);
 const lastError = ref(null);
 const lastExpectations = ref({});
 const lastScenarioName = ref('');
-// The scenario's entry output (e.g. "is_rechthebbende"). The graph pane
+// The scenario's entry output (e.g. "is_rechthebbende"). The graph view
 // uses this to pin its "▶ start" marker to the right leaf.
 const lastOutputName = ref(null);
+
+const RESULT_SHEET_VIEW_KEY = 'regelrecht-result-sheet-view';
+const resultSheetView = ref(localStorage.getItem(RESULT_SHEET_VIEW_KEY) || 'trace');
+watch(resultSheetView, (val) => {
+  localStorage.setItem(RESULT_SHEET_VIEW_KEY, val);
+});
 
 function handleScenarioExecuted({ result, traceText, error, expectations, scenarioName, outputName }) {
   lastResult.value = result;
@@ -971,14 +975,6 @@ function handleActionSave() {
                 ></textarea>
                 <div v-if="parseError" class="editor-parse-error-detail">{{ parseError }}</div>
               </div>
-
-              <LawGraphView
-                v-else-if="activeRightPane === 'graph'"
-                :law-id="lawId"
-                :result="lastResult"
-                :output-name="lastOutputName"
-                :expectations="lastExpectations"
-              />
             </nldd-page>
           </nldd-split-view-pane>
 
@@ -1087,12 +1083,32 @@ function handleActionSave() {
   >
     <nldd-page sticky-header>
       <nldd-top-title-bar slot="header" text="Resultaat" dismiss-text="Sluit" @dismiss="resultSheetOpen = false"></nldd-top-title-bar>
+      <nldd-tab-bar size="md">
+        <nldd-tab-bar-item
+          :selected="resultSheetView === 'trace' || undefined"
+          text="Trace"
+          @click="resultSheetView = 'trace'"
+        ></nldd-tab-bar-item>
+        <nldd-tab-bar-item
+          :selected="resultSheetView === 'graph' || undefined"
+          text="Graaf"
+          @click="resultSheetView = 'graph'"
+        ></nldd-tab-bar-item>
+      </nldd-tab-bar>
       <ExecutionTraceView
+        v-if="resultSheetView === 'trace'"
         :result="lastResult"
         :trace-text="lastTraceText"
         :error="lastError"
         :expectations="lastExpectations"
         :scenario-name="lastScenarioName"
+      />
+      <LawGraphView
+        v-else-if="resultSheetView === 'graph'"
+        :law-id="lawId"
+        :result="lastResult"
+        :output-name="lastOutputName"
+        :expectations="lastExpectations"
       />
     </nldd-page>
   </nldd-sheet>

--- a/frontend/src/composables/useFeatureFlags.js
+++ b/frontend/src/composables/useFeatureFlags.js
@@ -11,7 +11,6 @@ const DEFAULTS = {
   'panel.scenario_form': true,
   'panel.yaml_editor': true,
   'panel.machine_readable': true,
-  'panel.law_graph': true,
 };
 
 // Local overrides survive refresh when the backend has no persistence (dev).

--- a/frontend/src/composables/useFeatureFlags.js
+++ b/frontend/src/composables/useFeatureFlags.js
@@ -11,7 +11,7 @@ const DEFAULTS = {
   'panel.scenario_form': true,
   'panel.yaml_editor': true,
   'panel.machine_readable': true,
-  'panel.law_graph': false,
+  'panel.law_graph': true,
 };
 
 // Local overrides survive refresh when the backend has no persistence (dev).


### PR DESCRIPTION
## Summary
- Flip the `panel.law_graph` default from `false` → `true` in `useFeatureFlags.js`
- Makes the **Graaf** option visible in the right-pane dropdown out of the box, so users discover the trace-stepping visualisation built in #579 / #588 / #595 without manually flipping a flag

## Context
Verified end-to-end with Playwright on a fresh worktree of `origin/main`:

1. Open the editor on `uitvoeringsregeling_invorderingswet_1990`
2. Run a scenario via "Toon resultaat" — all expectations pass
3. Switch right pane to **Graaf** — graph + step list + detail render
4. Step **Vorige / Volgende** through the 169-step trace — active node highlights orange, step detail updates, assertions tracked

The connection from `ScenarioBuilder @executed → handleScenarioExecuted → LawGraphView` already existed; the only barrier was the off-by-default flag.

Local overrides via `/api/feature-flags` (POST) or `localStorage['regelrecht-feature-flags']` continue to take precedence, so anyone wanting to hide the pane can still do so.

## Test plan
- [ ] CI green
- [ ] On `editor-prN.regelrecht.rijks.app`: open any law with scenarios, confirm right-pane dropdown shows **Scenario's / YAML / Graaf**
- [ ] Run a scenario, switch to Graaf — verify graph + step list render and Vorige / Volgende work