### PR TITLE
feat(frontend): pane navigation, error states, sheet polish

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@cucumber/gherkin": "^39.0.0",
         "@cucumber/messages": "^32.3.1",
-        "@nldd/design-system": "^0.8.38",
+        "@nldd/design-system": "^0.8.41",
         "@vue-flow/background": "^1.3.2",
         "@vue-flow/controls": "^1.1.3",
         "@vue-flow/core": "^1.48.2",
@@ -244,14 +244,15 @@
       }
     },
     "node_modules/@nldd/design-system": {
-      "version": "0.8.38",
-      "resolved": "https://registry.npmjs.org/@nldd/design-system/-/design-system-0.8.38.tgz",
-      "integrity": "sha512-q0U25o+XZoqGeyXXZFwiMn6+SQFNFYE3eMqpJqb1IMagPb69TR7OxmpkJJXz13+tK60yYY6O6cy73KVgmu/ILg==",
+      "version": "0.8.41",
+      "resolved": "https://registry.npmjs.org/@nldd/design-system/-/design-system-0.8.41.tgz",
+      "integrity": "sha512-jo8Zog22XQeZZYFRYdUNi96196QbImNL1eKRbg1zOGpBtF8grf65+oE2PQqR1Zh/56qM1x3HHW5qgViM4yzroA==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@floating-ui/dom": "^1.7.6",
         "@rijkshuisstijl-community/font": "^1.1.2",
-        "lit": "^3.3.1"
+        "lit": "^3.3.1",
+        "prismjs": "^1.30.0"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -2430,6 +2431,15 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prismjs": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/proto-list": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@cucumber/gherkin": "^39.0.0",
     "@cucumber/messages": "^32.3.1",
-    "@nldd/design-system": "^0.8.38",
+    "@nldd/design-system": "^0.8.41",
     "@vue-flow/background": "^1.3.2",
     "@vue-flow/controls": "^1.1.3",
     "@vue-flow/core": "^1.48.2",

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -80,9 +80,13 @@ function loadPaneViews() {
   return VIEW_DEFINITIONS.map(v => v.id);
 }
 
+// Every paneViews mutation goes through `paneViews.value = next`
+// (setPaneView, the availableViews sync watcher), so the top-level ref
+// identity always changes. No deep:true needed; in-place mutations are
+// not used and shouldn't be relied on.
 watch(paneViews, (val) => {
   localStorage.setItem(PANE_VIEWS_KEY, JSON.stringify(val));
-}, { deep: true });
+});
 
 // Sync paneViews with availableViews when a flag flips:
 // - Drop panes whose view is no longer available (flag off → pane gone)

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -1012,6 +1012,16 @@ function handleActionSave() {
           </nldd-simple-section>
         </nldd-page>
 
+        <!-- All editor flags off — paneViews is empty so the
+             side-by-side view would render zero pane slots. Surface an
+             explicit empty-state with a CTA to the settings menu so
+             the user understands the editor isn't broken. -->
+        <nldd-page v-else-if="paneViews.length === 0">
+          <nldd-simple-section full-width>
+            <nldd-inline-dialog text="Geen editors actief. Schakel ten minste één editor in via Instellingen."></nldd-inline-dialog>
+          </nldd-simple-section>
+        </nldd-page>
+
         <!-- One pane per entry in `paneViews`. Each pane independently
              picks its view via the dropdown in its header. The split-view
              auto-hides panes from the right when the viewport is too narrow.

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -132,6 +132,7 @@ const {
 } = useLaw(route.params.lawId, route.params.articleNumber);
 
 const resultSheetOpen = ref(false);
+const graphSheetOpen = ref(false);
 
 // --- Corpus search (reuse LibraryApp's SearchPopover) ---
 const corpusLaws = ref([]);
@@ -186,6 +187,12 @@ watch(resultSheetOpen, async (open) => {
   await nextTick();
   if (open) resultSheetEl.value?.show();
   else resultSheetEl.value?.hide();
+});
+const graphSheetEl = ref(null);
+watch(graphSheetOpen, async (open) => {
+  await nextTick();
+  if (open) graphSheetEl.value?.show();
+  else graphSheetEl.value?.hide();
 });
 
 // --- Multi-law tab state (persisted in localStorage) ---
@@ -352,20 +359,18 @@ const lastScenarioName = ref('');
 // uses this to pin its "▶ start" marker to the right leaf.
 const lastOutputName = ref(null);
 
-const RESULT_SHEET_VIEW_KEY = 'regelrecht-result-sheet-view';
-const resultSheetView = ref(localStorage.getItem(RESULT_SHEET_VIEW_KEY) || 'trace');
-watch(resultSheetView, (val) => {
-  localStorage.setItem(RESULT_SHEET_VIEW_KEY, val);
-});
-
-function handleScenarioExecuted({ result, traceText, error, expectations, scenarioName, outputName }) {
+function handleScenarioExecuted({ result, traceText, error, expectations, scenarioName, outputName, view }) {
   lastResult.value = result;
   lastTraceText.value = traceText;
   lastError.value = error || null;
   lastExpectations.value = expectations || {};
   lastScenarioName.value = scenarioName || '';
   lastOutputName.value = outputName || null;
-  resultSheetOpen.value = true;
+  if (view === 'graph') {
+    graphSheetOpen.value = true;
+  } else {
+    resultSheetOpen.value = true;
+  }
 }
 
 // Clear the captured trace whenever the active law changes — otherwise
@@ -1105,10 +1110,13 @@ function handleActionSave() {
     @harvest-available="onSearchHarvestAvailable"
   />
 
-  <!-- Result of the most recently executed scenario, opened as a bottom sheet. -->
+  <!-- Trace sheet — execution trace + expected outcomes for the most
+       recently executed scenario. Opened from a scenario card's "Toon
+       resultaat" button. -->
   <nldd-sheet
     ref="resultSheetEl"
     placement="bottom"
+    full-height
     @close="resultSheetOpen = false"
   >
     <nldd-page sticky-header>
@@ -1116,35 +1124,33 @@ function handleActionSave() {
       <nldd-simple-section full-width>
         <nldd-title id="result-scenario-title" size="4"><h3>{{ lastScenarioName ? `Resultaat: ${lastScenarioName}` : 'Resultaat' }}</h3></nldd-title>
         <nldd-spacer size="16"></nldd-spacer>
-        <nldd-tab-bar size="md">
-          <nldd-tab-bar-item
-            :selected="resultSheetView === 'trace' || undefined"
-            text="Trace"
-            @click="resultSheetView = 'trace'"
-          ></nldd-tab-bar-item>
-          <nldd-tab-bar-item
-            :selected="resultSheetView === 'graph' || undefined"
-            text="Graaf"
-            @click="resultSheetView = 'graph'"
-          ></nldd-tab-bar-item>
-        </nldd-tab-bar>
-        <nldd-spacer size="16"></nldd-spacer>
         <ExecutionTraceView
-          v-if="resultSheetView === 'trace'"
           :result="lastResult"
           :trace-text="lastTraceText"
           :error="lastError"
           :expectations="lastExpectations"
           :scenario-name="lastScenarioName"
         />
-        <LawGraphView
-          v-else-if="resultSheetView === 'graph'"
-          :law-id="lawId"
-          :result="lastResult"
-          :output-name="lastOutputName"
-          :expectations="lastExpectations"
-        />
       </nldd-simple-section>
+    </nldd-page>
+  </nldd-sheet>
+
+  <!-- Graph sheet — visual law graph with the scenario's trace overlay.
+       Opened from a scenario card's "Graaf" button. -->
+  <nldd-sheet
+    ref="graphSheetEl"
+    placement="bottom"
+    full-height
+    @close="graphSheetOpen = false"
+  >
+    <nldd-page sticky-header>
+      <nldd-top-title-bar slot="header" :text="lastScenarioName ? `Graaf: ${lastScenarioName}` : 'Graaf'" dismiss-text="Sluit" @dismiss="graphSheetOpen = false"></nldd-top-title-bar>
+      <LawGraphView
+        :law-id="lawId"
+        :result="lastResult"
+        :output-name="lastOutputName"
+        :expectations="lastExpectations"
+      />
     </nldd-page>
   </nldd-sheet>
 </template>

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -1224,7 +1224,6 @@ function handleActionSave() {
           :trace-text="lastTraceText"
           :error="lastError"
           :expectations="lastExpectations"
-          :scenario-name="lastScenarioName"
         />
       </nldd-simple-section>
     </nldd-page>

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -408,6 +408,9 @@ function handleScenarioExecuted({ result, traceText, error, expectations, scenar
 // LawGraphView would re-flatten the old trace under the new lawId,
 // misattribute every step to the new law, and pin the "▶ start" badge
 // to a leaf that just happens to share the previous output's name.
+// The trace and graph sheets close along with the trace they were
+// showing: leaving them open over an empty graph or a fresh law the
+// user just navigated into is more confusing than auto-dismissing.
 watch(lawId, () => {
   lastResult.value = null;
   lastTraceText.value = null;
@@ -415,6 +418,8 @@ watch(lawId, () => {
   lastExpectations.value = {};
   lastScenarioName.value = '';
   lastOutputName.value = null;
+  resultSheetOpen.value = false;
+  graphSheetOpen.value = false;
 });
 
 // --- Editor state ---

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -61,7 +61,17 @@ const paneViews = ref(loadPaneViews());
 function loadPaneViews() {
   try {
     const stored = JSON.parse(localStorage.getItem(PANE_VIEWS_KEY) ?? 'null');
-    if (Array.isArray(stored) && stored.length > 0 && stored.every(v => typeof v === 'string')) {
+    // Only accept entries we still recognise — a stale value left over
+    // from a removed view (e.g. 'form' before scenario was renamed) or
+    // an externally injected string would otherwise produce a pane with
+    // no v-if branch matching it, briefly flashing an empty body before
+    // the availableViews watcher corrects it on the next tick.
+    const knownIds = new Set(VIEW_DEFINITIONS.map(v => v.id));
+    if (
+      Array.isArray(stored) &&
+      stored.length > 0 &&
+      stored.every(v => typeof v === 'string' && knownIds.has(v))
+    ) {
       return stored;
     }
   } catch {

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -592,7 +592,12 @@ async function handleMachineReadableSave() {
 }
 
 function onYamlInput(event) {
-  const text = event.target.value;
+  // nldd-code-editor dispatches a CustomEvent with the new value in
+  // event.detail.value (see the design-system 0.8.41 component). The
+  // host's `value` property is updated before dispatch so
+  // event.target.value would also work, but reading from detail keeps
+  // the contract explicit and matches how the storybook docs the API.
+  const text = event.detail?.value ?? event.target?.value ?? '';
   yamlSource.value = text;
   try {
     const parsed = yaml.load(text);

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -912,7 +912,7 @@ function handleActionSave() {
           <nldd-split-view-pane v-if="showTextPane" :slot="paneSlot('text')">
             <nldd-page sticky-header>
               <nldd-top-title-bar slot="header" text="Tekst"></nldd-top-title-bar>
-              <nldd-simple-section full-width :align="selectedArticle ? undefined : 'center'">
+              <nldd-simple-section full-width>
                 <ArticleText :article="selectedArticle" raw />
               </nldd-simple-section>
             </nldd-page>

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -1046,7 +1046,7 @@ function handleActionSave() {
           >
             <nldd-page
               sticky-header
-              :sticky-footer="view === 'machine' && canEdit && (isMachineReadableDirty || lawSaving)"
+              :sticky-footer="view === 'machine' && canEdit && (isMachineReadableDirty || lawSaving) && paneViews.indexOf('machine') === idx"
             >
               <div slot="header" class="pane-header">
                 <nldd-button
@@ -1090,8 +1090,11 @@ function handleActionSave() {
                   @delete="handleDelete"
                 />
               </nldd-simple-section>
+              <!-- Footer + Save button only on the first machine pane.
+                   Duplicates would render redundant Save buttons over
+                   the same shared dirty state — not broken, just noisy. -->
               <nldd-container
-                v-if="view === 'machine' && canEdit && (isMachineReadableDirty || lawSaving)"
+                v-if="view === 'machine' && canEdit && (isMachineReadableDirty || lawSaving) && paneViews.indexOf('machine') === idx"
                 slot="footer"
                 padding="16"
               >

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -1188,7 +1188,13 @@ function handleActionSave() {
   >
     <nldd-page sticky-header>
       <nldd-top-title-bar slot="header" :text="lastScenarioName ? `Graaf: ${lastScenarioName}` : 'Graaf'" dismiss-text="Sluit" @dismiss="graphSheetOpen = false"></nldd-top-title-bar>
+      <!-- Lazy-mount: building the Vue Flow graph for laws with many
+           cross-law references is non-trivial and the sheet is hidden
+           by default. Render only while the sheet is open; the remount
+           cost on each subsequent open is acceptable next to dragging
+           an unused Vue Flow tree behind every editor session. -->
       <LawGraphView
+        v-if="graphSheetOpen"
         :law-id="lawId"
         :result="lastResult"
         :output-name="lastOutputName"

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -7,6 +7,7 @@ import { useEngine } from './composables/useEngine.js';
 import { useAuth } from './composables/useAuth.js';
 import { useFeatureFlags } from './composables/useFeatureFlags.js';
 import { useColorScheme } from './composables/useColorScheme.js';
+import { lastLibraryPath } from './composables/useLastVisitedRoute.js';
 import ArticleText from './components/ArticleText.vue';
 import ActionSheet from './components/ActionSheet.vue';
 import EditSheet from './components/EditSheet.vue';
@@ -33,46 +34,75 @@ const editorPanelFlags = [
   ['panel.yaml_editor', 'YAML editor'],
 ];
 
-// Left and middle panes are specific named editors. The right pane is a
-// category — anything that isn't text or machine lives there, and when more
-// than one is enabled they share the slot via a dropdown switcher in the
-// header. Adding a new editor: append to RIGHT_PANES and render its body in
-// the right-pane v-if chain in the template.
-const showTextPane = computed(() => isEnabled('panel.article_text'));
-const showMachinePane = computed(() => isEnabled('panel.machine_readable'));
-
-const RIGHT_PANES = [
-  { key: 'form', flag: 'panel.scenario_form', label: "Scenario's" },
-  { key: 'yaml', flag: 'panel.yaml_editor', label: 'YAML' },
+// Per-pane view selection. Each pane independently picks one of the
+// available views (Tekst, Machine, Scenario's, YAML). Same view can be
+// in multiple panes (e.g. two YAML panes for diff). Layout always has
+// one pane per view; nldd-side-by-side-split-view auto-hides panes
+// from the right when the viewport is too narrow, so left = highest
+// priority. Visibility flags via panel.* feature flags filter what's
+// pickable in the menu.
+const VIEW_DEFINITIONS = [
+  { id: 'text', flag: 'panel.article_text', label: 'Tekst' },
+  { id: 'machine', flag: 'panel.machine_readable', label: 'Machine' },
+  { id: 'scenario', flag: 'panel.scenario_form', label: "Scenario's" },
+  { id: 'yaml', flag: 'panel.yaml_editor', label: 'YAML' },
 ];
-const enabledRightPanes = computed(() => RIGHT_PANES.filter(p => isEnabled(p.flag)));
 
-const ACTIVE_RIGHT_PANE_KEY = 'regelrecht-active-right-pane';
-const activeRightPane = ref(localStorage.getItem(ACTIVE_RIGHT_PANE_KEY) || RIGHT_PANES[0].key);
-watch(enabledRightPanes, (panes) => {
-  if (panes.length > 0 && !panes.some(p => p.key === activeRightPane.value)) {
-    activeRightPane.value = panes[0].key;
+const availableViews = computed(() => VIEW_DEFINITIONS.filter(v => isEnabled(v.flag)));
+
+function viewLabel(viewId) {
+  return VIEW_DEFINITIONS.find(v => v.id === viewId)?.label ?? viewId;
+}
+
+const PANE_VIEWS_KEY = 'regelrecht-pane-views';
+const paneViews = ref(loadPaneViews());
+
+function loadPaneViews() {
+  try {
+    const stored = JSON.parse(localStorage.getItem(PANE_VIEWS_KEY) ?? 'null');
+    if (Array.isArray(stored) && stored.length > 0 && stored.every(v => typeof v === 'string')) {
+      return stored;
+    }
+  } catch {
+    /* fall through to default */
+  }
+  return VIEW_DEFINITIONS.map(v => v.id);
+}
+
+watch(paneViews, (val) => {
+  localStorage.setItem(PANE_VIEWS_KEY, JSON.stringify(val));
+}, { deep: true });
+
+// Sync paneViews with availableViews when a flag flips:
+// - Drop panes whose view is no longer available (flag off → pane gone)
+// - Append a pane for any view that was just enabled and isn't already
+//   shown — so re-enabling a flag brings the pane back instead of
+//   silently leaving the user without it
+// When everything is filtered out, reset to one pane per available view
+// as the safe default.
+watch(availableViews, (views) => {
+  const allowedIds = new Set(views.map(v => v.id));
+  const filtered = paneViews.value.filter(v => allowedIds.has(v));
+  const shown = new Set(filtered);
+  const missing = views.filter(v => !shown.has(v.id)).map(v => v.id);
+  const next = [...filtered, ...missing];
+  if (next.length === 0 && views.length > 0) {
+    paneViews.value = views.map(v => v.id);
+    return;
+  }
+  if (
+    next.length !== paneViews.value.length ||
+    next.some((v, i) => v !== paneViews.value[i])
+  ) {
+    paneViews.value = next;
   }
 }, { immediate: true });
-watch(activeRightPane, (val) => {
-  localStorage.setItem(ACTIVE_RIGHT_PANE_KEY, val);
-});
-const activeRightPaneLabel = computed(
-  () => enabledRightPanes.value.find(p => p.key === activeRightPane.value)?.label ?? '',
-);
 
-// Compute visible pane count and slot assignments for the split view.
-const visiblePanes = computed(() => {
-  const panes = [];
-  if (showTextPane.value) panes.push('text');
-  if (showMachinePane.value) panes.push('machine');
-  if (enabledRightPanes.value.length > 0) panes.push('right');
-  return panes.length > 0 ? panes : ['text', 'machine', 'right'];
-});
-const paneSlot = (name) => {
-  const idx = visiblePanes.value.indexOf(name);
-  return idx >= 0 ? `pane-${idx + 1}` : undefined;
-};
+function setPaneView(idx, viewId) {
+  const next = [...paneViews.value];
+  next[idx] = viewId;
+  paneViews.value = next;
+}
 
 // All edit operations are gated behind SSO. When OIDC is configured the user
 // must be authenticated; when OIDC is disabled the editor is fully open.
@@ -778,7 +808,7 @@ function handleActionSave() {
           <nldd-toolbar size="md">
             <nldd-toolbar-item slot="start">
               <nldd-tab-bar size="md">
-                <nldd-tab-bar-item href="/library" @click.prevent="router.push('/library')" text="Bibliotheek"></nldd-tab-bar-item>
+                <nldd-tab-bar-item :href="lastLibraryPath" @click.prevent="router.push(lastLibraryPath)" text="Bibliotheek"></nldd-tab-bar-item>
                 <nldd-tab-bar-item selected text="Editor"></nldd-tab-bar-item>
               </nldd-tab-bar>
             </nldd-toolbar-item>
@@ -824,7 +854,7 @@ function handleActionSave() {
           <nldd-toolbar size="md">
             <nldd-toolbar-item slot="start">
               <nldd-tab-bar size="md">
-                <nldd-tab-bar-item href="/library" @click.prevent="router.push('/library')" text="Bibliotheek"></nldd-tab-bar-item>
+                <nldd-tab-bar-item :href="lastLibraryPath" @click.prevent="router.push(lastLibraryPath)" text="Bibliotheek"></nldd-tab-bar-item>
                 <nldd-tab-bar-item selected text="Editor"></nldd-tab-bar-item>
               </nldd-tab-bar>
             </nldd-toolbar-item>
@@ -906,83 +936,49 @@ function handleActionSave() {
           </nldd-simple-section>
         </nldd-page>
 
-        <!-- Dynamic column layout based on feature flags -->
-        <nldd-side-by-side-split-view v-else :panes="String(visiblePanes.length)">
-          <!-- Left: Article Text -->
-          <nldd-split-view-pane v-if="showTextPane" :slot="paneSlot('text')">
-            <nldd-page sticky-header>
-              <nldd-top-title-bar slot="header" text="Tekst"></nldd-top-title-bar>
-              <nldd-simple-section full-width>
+        <!-- One pane per entry in `paneViews`. Each pane independently
+             picks its view via the dropdown in its header. The split-view
+             auto-hides panes from the right when the viewport is too narrow.
+             Hidden panes stay in the DOM so state is preserved when the
+             viewport widens. -->
+        <nldd-side-by-side-split-view v-else :panes="String(paneViews.length)">
+          <nldd-split-view-pane
+            v-for="(view, idx) in paneViews"
+            :key="idx"
+            :slot="`pane-${idx + 1}`"
+          >
+            <nldd-page
+              sticky-header
+              :sticky-footer="view === 'machine' && canEdit && (isMachineReadableDirty || lawSaving) || undefined"
+            >
+              <div slot="header" class="pane-header">
+                <nldd-button
+                  :id="`pane-view-btn-${idx}`"
+                  size="md"
+                  expandable
+                  :text="viewLabel(view)"
+                  :popovertarget="`pane-view-menu-${idx}`"
+                ></nldd-button>
+                <nldd-menu :id="`pane-view-menu-${idx}`" :anchor="`pane-view-btn-${idx}`">
+                  <nldd-menu-item
+                    v-for="opt in availableViews"
+                    :key="opt.id"
+                    type="radio"
+                    :selected="view === opt.id || undefined"
+                    :text="opt.label"
+                    @select="setPaneView(idx, opt.id)"
+                  ></nldd-menu-item>
+                </nldd-menu>
+                <span v-if="view === 'yaml' && parseError" class="editor-parse-error">YAML parse error</span>
+              </div>
+
+              <!-- Tekst -->
+              <nldd-simple-section v-if="view === 'text'" full-width>
                 <ArticleText :article="selectedArticle" raw />
               </nldd-simple-section>
-            </nldd-page>
-          </nldd-split-view-pane>
 
-          <!-- Right pane: any non-text/non-machine editor. When more than one
-               is enabled they share this slot with a dropdown switcher. -->
-          <nldd-split-view-pane v-if="enabledRightPanes.length > 0" :slot="paneSlot('right')">
-            <nldd-page sticky-header>
-              <template v-if="enabledRightPanes.length > 1">
-                <div slot="header" class="right-pane-header">
-                  <nldd-button
-                    id="right-pane-menu-btn"
-                    size="md"
-                    expandable
-                    :text="activeRightPaneLabel"
-                    popovertarget="right-pane-menu"
-                  ></nldd-button>
-                  <nldd-menu id="right-pane-menu" anchor="right-pane-menu-btn">
-                    <nldd-menu-item
-                      v-for="pane in enabledRightPanes"
-                      :key="pane.key"
-                      type="radio"
-                      :selected="activeRightPane === pane.key || undefined"
-                      :text="pane.label"
-                      @select="activeRightPane = pane.key"
-                    ></nldd-menu-item>
-                  </nldd-menu>
-                  <span v-if="activeRightPane === 'yaml' && parseError" class="editor-parse-error">YAML parse error</span>
-                </div>
-              </template>
-              <nldd-top-title-bar v-else slot="header" :text="activeRightPaneLabel">
-                <span v-if="activeRightPane === 'yaml' && parseError" slot="toolbar" class="editor-parse-error">YAML parse error</span>
-              </nldd-top-title-bar>
-
-              <template v-if="activeRightPane === 'form'">
-                <nldd-simple-section full-width v-if="engineInitError">
-                  <nldd-inline-dialog variant="alert" text="WASM engine niet geladen" :supporting-text="`${engineInitError.message} — voer 'just wasm-build' uit om de WASM module te bouwen.`"></nldd-inline-dialog>
-                </nldd-simple-section>
-                <ScenarioBuilder
-                  v-else
-                  :law-id="lawId"
-                  :law-yaml="currentLawYaml"
-                  :engine="getEngine()"
-                  :ready="engineReady"
-                  :articles="articles"
-                  @executed="handleScenarioExecuted"
-                />
-              </template>
-
-              <div v-else-if="activeRightPane === 'yaml'" class="editor-yaml-wrap">
-                <textarea
-                  :value="yamlSource"
-                  @input="onYamlInput"
-                  class="editor-yaml-textarea"
-                  spellcheck="false"
-                  autocomplete="off"
-                  autocorrect="off"
-                  autocapitalize="off"
-                ></textarea>
-                <div v-if="parseError" class="editor-parse-error-detail">{{ parseError }}</div>
-              </div>
-            </nldd-page>
-          </nldd-split-view-pane>
-
-          <!-- Machine Readable -->
-          <nldd-split-view-pane v-if="showMachinePane" :slot="paneSlot('machine')">
-            <nldd-page sticky-header :sticky-footer="canEdit && (isMachineReadableDirty || lawSaving) || undefined">
-              <nldd-top-title-bar slot="header" text="Machine"></nldd-top-title-bar>
-              <nldd-simple-section full-width>
+              <!-- Machine readable -->
+              <nldd-simple-section v-else-if="view === 'machine'" full-width>
                 <MachineReadable
                   :article="editedArticle"
                   :editable="canEdit"
@@ -997,7 +993,11 @@ function handleActionSave() {
                   @delete="handleDelete"
                 />
               </nldd-simple-section>
-              <nldd-container v-if="canEdit && (isMachineReadableDirty || lawSaving)" slot="footer" padding="16">
+              <nldd-container
+                v-if="view === 'machine' && canEdit && (isMachineReadableDirty || lawSaving)"
+                slot="footer"
+                padding="16"
+              >
                 <nldd-button
                   variant="primary"
                   size="md"
@@ -1008,9 +1008,39 @@ function handleActionSave() {
                   @click="handleMachineReadableSave"
                 ></nldd-button>
               </nldd-container>
+
+              <!-- Scenario builder -->
+              <template v-else-if="view === 'scenario'">
+                <nldd-simple-section v-if="engineInitError" full-width>
+                  <nldd-inline-dialog
+                    variant="alert"
+                    text="WASM engine niet geladen"
+                    :supporting-text="`${engineInitError.message} — voer 'just wasm-build' uit om de WASM module te bouwen.`"
+                  ></nldd-inline-dialog>
+                </nldd-simple-section>
+                <ScenarioBuilder
+                  v-else
+                  :law-id="lawId"
+                  :law-yaml="currentLawYaml"
+                  :engine="getEngine()"
+                  :ready="engineReady"
+                  :articles="articles"
+                  @executed="handleScenarioExecuted"
+                />
+              </template>
+
+              <!-- YAML -->
+              <nldd-simple-section v-else-if="view === 'yaml'" full-width>
+                <nldd-code-editor
+                  resize="none"
+                  accessible-label="YAML"
+                  :value="yamlSource"
+                  @input="onYamlInput"
+                ></nldd-code-editor>
+                <div v-if="parseError" class="editor-parse-error-detail">{{ parseError }}</div>
+              </nldd-simple-section>
             </nldd-page>
           </nldd-split-view-pane>
-
         </nldd-side-by-side-split-view>
       </nldd-split-view-pane>
 
@@ -1020,7 +1050,7 @@ function handleActionSave() {
           <nldd-toolbar size="md">
             <nldd-toolbar-item slot="start">
               <nldd-tab-bar compact>
-                <nldd-tab-bar-item href="/library" @click.prevent="router.push('/library')" icon="stack" text="Bibliotheek"></nldd-tab-bar-item>
+                <nldd-tab-bar-item :href="lastLibraryPath" @click.prevent="router.push(lastLibraryPath)" icon="stack" text="Bibliotheek"></nldd-tab-bar-item>
                 <nldd-tab-bar-item selected icon="edit" text="Editor"></nldd-tab-bar-item>
               </nldd-tab-bar>
             </nldd-toolbar-item>
@@ -1082,34 +1112,39 @@ function handleActionSave() {
     @close="resultSheetOpen = false"
   >
     <nldd-page sticky-header>
-      <nldd-top-title-bar slot="header" text="Resultaat" dismiss-text="Sluit" @dismiss="resultSheetOpen = false"></nldd-top-title-bar>
-      <nldd-tab-bar size="md">
-        <nldd-tab-bar-item
-          :selected="resultSheetView === 'trace' || undefined"
-          text="Trace"
-          @click="resultSheetView = 'trace'"
-        ></nldd-tab-bar-item>
-        <nldd-tab-bar-item
-          :selected="resultSheetView === 'graph' || undefined"
-          text="Graaf"
-          @click="resultSheetView = 'graph'"
-        ></nldd-tab-bar-item>
-      </nldd-tab-bar>
-      <ExecutionTraceView
-        v-if="resultSheetView === 'trace'"
-        :result="lastResult"
-        :trace-text="lastTraceText"
-        :error="lastError"
-        :expectations="lastExpectations"
-        :scenario-name="lastScenarioName"
-      />
-      <LawGraphView
-        v-else-if="resultSheetView === 'graph'"
-        :law-id="lawId"
-        :result="lastResult"
-        :output-name="lastOutputName"
-        :expectations="lastExpectations"
-      />
+      <nldd-top-title-bar slot="header" :text="lastScenarioName ? `Resultaat: ${lastScenarioName}` : 'Resultaat'" collapse-anchor="result-scenario-title" dismiss-text="Sluit" @dismiss="resultSheetOpen = false"></nldd-top-title-bar>
+      <nldd-simple-section full-width>
+        <nldd-title id="result-scenario-title" size="4"><h3>{{ lastScenarioName ? `Resultaat: ${lastScenarioName}` : 'Resultaat' }}</h3></nldd-title>
+        <nldd-spacer size="16"></nldd-spacer>
+        <nldd-tab-bar size="md">
+          <nldd-tab-bar-item
+            :selected="resultSheetView === 'trace' || undefined"
+            text="Trace"
+            @click="resultSheetView = 'trace'"
+          ></nldd-tab-bar-item>
+          <nldd-tab-bar-item
+            :selected="resultSheetView === 'graph' || undefined"
+            text="Graaf"
+            @click="resultSheetView = 'graph'"
+          ></nldd-tab-bar-item>
+        </nldd-tab-bar>
+        <nldd-spacer size="16"></nldd-spacer>
+        <ExecutionTraceView
+          v-if="resultSheetView === 'trace'"
+          :result="lastResult"
+          :trace-text="lastTraceText"
+          :error="lastError"
+          :expectations="lastExpectations"
+          :scenario-name="lastScenarioName"
+        />
+        <LawGraphView
+          v-else-if="resultSheetView === 'graph'"
+          :law-id="lawId"
+          :result="lastResult"
+          :output-name="lastOutputName"
+          :expectations="lastExpectations"
+        />
+      </nldd-simple-section>
     </nldd-page>
   </nldd-sheet>
 </template>
@@ -1134,11 +1169,11 @@ function handleActionSave() {
   border-radius: 3px;
 }
 
-/* Header for the right pane when multiple right-pane editors are enabled:
-   dropdown button sits where the title would normally be, with the YAML
-   parse-error pill floating after it. Mirrors nldd-top-title-bar's compact
-   spacing so the row height matches the other panes' headers. */
-.right-pane-header {
+/* Per-pane header: view-picker dropdown sits where the title would
+   normally be, with the YAML parse-error pill floating after it.
+   Mirrors nldd-top-title-bar's compact spacing so the row height
+   matches other panes' headers. */
+.pane-header {
   display: flex;
   align-items: center;
   gap: 12px;
@@ -1147,44 +1182,7 @@ function handleActionSave() {
   box-sizing: border-box;
 }
 
-.editor-yaml-wrap {
-  display: flex;
-  flex-direction: column;
-  /* Fill the pane body. nldd-page's body is the only ancestor between us
-   * and the viewport, so anchoring on viewport height minus the toolbar
-   * + tab strip height gives a stable tall area regardless of how many
-   * scenarios are loaded next door. */
-  height: calc(100vh - 180px);
-  padding: 16px;
-  box-sizing: border-box;
-}
 
-.editor-yaml-textarea {
-  flex: 1;
-  width: 100%;
-  min-height: 0;
-  /* Match the library/zorgtoeslagwet/2 YamlView look: tinted background,
-   * rounded corners, monospace, comfortable padding. The library version
-   * is read-only <pre><code>; this is the editable counterpart with the
-   * same skin so the eye doesn't have to context-switch. */
-  background: var(--semantics-surfaces-tinted-background-color, #F4F6F9);
-  color: var(--semantics-text-default-color, #1F2937);
-  font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', 'JetBrains Mono', monospace;
-  font-size: 13px;
-  line-height: 1.5;
-  padding: 16px;
-  border: 1px solid var(--semantics-borders-default-color, #DDE0E4);
-  border-radius: 12px;
-  outline: none;
-  resize: none;
-  tab-size: 2;
-  white-space: pre;
-  overflow: auto;
-}
-
-.editor-yaml-textarea:focus {
-  border-color: var(--semantics-borders-focus-color, #007BC7);
-}
 
 .editor-parse-error {
   font-size: 12px;

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -997,7 +997,7 @@ function handleActionSave() {
           >
             <nldd-page
               sticky-header
-              :sticky-footer="view === 'machine' && canEdit && (isMachineReadableDirty || lawSaving) || undefined"
+              :sticky-footer="view === 'machine' && canEdit && (isMachineReadableDirty || lawSaving)"
             >
               <div slot="header" class="pane-header">
                 <nldd-button

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -617,7 +617,10 @@ function onYamlInput(event) {
   // host's `value` property is updated before dispatch so
   // event.target.value would also work, but reading from detail keeps
   // the contract explicit and matches how the storybook docs the API.
-  const text = event.detail?.value ?? event.target?.value ?? '';
+  // Final fallback is the current yamlSource so a misfired event (no
+  // detail, no value on target) becomes a no-op instead of silently
+  // wiping the user's content.
+  const text = event.detail?.value ?? event.target?.value ?? yamlSource.value;
   yamlSource.value = text;
   try {
     const parsed = yaml.load(text);

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -8,6 +8,7 @@ import { useAuth } from './composables/useAuth.js';
 import { useFeatureFlags } from './composables/useFeatureFlags.js';
 import { useColorScheme } from './composables/useColorScheme.js';
 import { lastLibraryPath } from './composables/useLastVisitedRoute.js';
+import { SUPPORT_EMAIL } from './constants.js';
 import ArticleText from './components/ArticleText.vue';
 import ActionSheet from './components/ActionSheet.vue';
 import EditSheet from './components/EditSheet.vue';
@@ -150,6 +151,27 @@ loadCorpusLaws();
 
 function openSearch(e, initialSearch = '') {
   searchPopoverRef.value?.show(e?.currentTarget, initialSearch);
+}
+
+/**
+ * Display name for the failed law on the error inline-dialog. Tries the
+ * corpus index (loaded for the search popover) first; falls back to the
+ * URL slug so the user always sees a concrete identifier.
+ */
+const failedLawName = computed(() => {
+  const id = lawId.value;
+  if (!id) return '';
+  return corpusLaws.value.find(l => l.law_id === id)?.name || id;
+});
+
+/**
+ * Retry the failed law fetch. switchLaw clears `error` and re-runs the
+ * fetch; failed responses don't enter the cache so a retry actually hits
+ * the network again.
+ */
+function retryLoadLaw() {
+  if (!lawId.value) return;
+  switchLaw(lawId.value, selectedArticleNumber.value);
 }
 
 /**
@@ -927,17 +949,29 @@ function handleActionSave() {
 
       <!-- Main content area -->
       <nldd-split-view-pane slot="main">
-        <!-- Empty state: no tabs open -->
+        <!-- Empty state: no tabs open. The CTA points back to the library
+             since that's the only way to create new tabs; mention the tab
+             bar too because closed tabs may still be visible alongside this
+             empty state on the next pane. -->
         <nldd-page v-if="!activeTab">
           <nldd-simple-section full-width>
-            <nldd-inline-dialog text="Open een artikel vanuit de bibliotheek om te bewerken"></nldd-inline-dialog>
+            <nldd-inline-dialog text="Open een artikel vanuit de tabbalk of de bibliotheek om te bewerken.">
+              <nldd-button slot="actions" variant="secondary" text="Ga naar bibliotheek" :href="lastLibraryPath" @click.prevent="router.push(lastLibraryPath)"></nldd-button>
+            </nldd-inline-dialog>
           </nldd-simple-section>
         </nldd-page>
 
-        <!-- Error state -->
+        <!-- Error state — mirrors the library's law-load failure pattern. -->
         <nldd-page v-else-if="error">
           <nldd-simple-section full-width>
-            <nldd-inline-dialog variant="alert" text="Kon de wet niet laden" :supporting-text="error.message"></nldd-inline-dialog>
+            <nldd-inline-dialog
+              variant="alert"
+              :text="`${failedLawName} is niet geladen`"
+              supporting-text="De gegevens konden niet worden opgehaald."
+            >
+              <nldd-button slot="actions" variant="primary" text="Probeer opnieuw" @click="retryLoadLaw"></nldd-button>
+              <nldd-button slot="actions" variant="secondary" text="Neem contact op via e-mail" :href="`mailto:${SUPPORT_EMAIL}`"></nldd-button>
+            </nldd-inline-dialog>
           </nldd-simple-section>
         </nldd-page>
 

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -990,9 +990,15 @@ function handleActionSave() {
              Hidden panes stay in the DOM so state is preserved when the
              viewport widens. -->
         <nldd-side-by-side-split-view v-else :panes="String(paneViews.length)">
+          <!-- Compound key: when a flag flip shifts which view sits at a
+               given index, Vue would otherwise patch the existing pane in
+               place — leaking ScenarioBuilder form state and engine
+               results into a different view. Re-keying on the view id
+               forces an unmount + remount on identity change, at the
+               (acceptable) cost of losing pane scroll position. -->
           <nldd-split-view-pane
             v-for="(view, idx) in paneViews"
-            :key="idx"
+            :key="`${view}-${idx}`"
             :slot="`pane-${idx + 1}`"
           >
             <nldd-page

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -76,17 +76,26 @@ watch(paneViews, (val) => {
 
 // Sync paneViews with availableViews when a flag flips:
 // - Drop panes whose view is no longer available (flag off → pane gone)
-// - Append a pane for any view that was just enabled and isn't already
-//   shown — so re-enabling a flag brings the pane back instead of
-//   silently leaving the user without it
+// - Append a pane for any view that was JUST enabled by this change
+//   (in current available, not in previous) — so re-enabling a flag
+//   brings the pane back instead of silently leaving the user without
+//   it. The previous version compared "missing from paneViews" against
+//   the full available set, which spuriously appended every available
+//   view a user happened not to have open whenever any unrelated flag
+//   flipped.
 // When everything is filtered out, reset to one pane per available view
 // as the safe default.
-watch(availableViews, (views) => {
+watch(availableViews, (views, oldViews) => {
   const allowedIds = new Set(views.map(v => v.id));
   const filtered = paneViews.value.filter(v => allowedIds.has(v));
-  const shown = new Set(filtered);
-  const missing = views.filter(v => !shown.has(v.id)).map(v => v.id);
-  const next = [...filtered, ...missing];
+  // On the very first run (immediate: true) oldViews is undefined; treat
+  // it as "no diff" so we don't append every available view on top of
+  // whatever the user had restored from localStorage.
+  const previousIds = new Set((oldViews ?? []).map(v => v.id));
+  const newlyEnabled = views
+    .filter(v => oldViews !== undefined && !previousIds.has(v.id))
+    .map(v => v.id);
+  const next = [...filtered, ...newlyEnabled];
   if (next.length === 0 && views.length > 0) {
     paneViews.value = views.map(v => v.id);
     return;

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -621,11 +621,18 @@ function onYamlInput(event) {
   // host's `value` property is updated before dispatch so
   // event.target.value would also work, but reading from detail keeps
   // the contract explicit and matches how the storybook docs the API.
-  // Final fallback to yamlSource only catches a structurally broken
-  // event (no detail, no value on target) — `??` skips null/undefined
-  // but lets a deliberate `''` through, which is what we want when the
-  // user clears the editor.
-  const text = event.detail?.value ?? event.target?.value ?? yamlSource.value;
+  // `??` skips only null/undefined — a deliberate empty string passes
+  // through as a valid "user cleared the editor" input.
+  const text = event.detail?.value ?? event.target?.value;
+  if (text == null) {
+    // Structurally broken event (no detail, no value on target). Don't
+    // touch yamlSource — silently overwriting with the previous value
+    // would swallow keystrokes a user can see in the textarea but
+    // never sees committed to the reactive source. Surface it loudly
+    // instead so the regression is obvious in dev console.
+    console.warn('onYamlInput: unexpected event shape, ignoring', event);
+    return;
+  }
   yamlSource.value = text;
   try {
     const parsed = yaml.load(text);

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -397,9 +397,14 @@ function handleScenarioExecuted({ result, traceText, error, expectations, scenar
   lastExpectations.value = expectations || {};
   lastScenarioName.value = scenarioName || '';
   lastOutputName.value = outputName || null;
+  // Open exactly one of the two sheets — opening the second on top of
+  // the first would leave the previous one as a stale layer that
+  // re-appears when the user dismisses the foreground sheet.
   if (view === 'graph') {
+    resultSheetOpen.value = false;
     graphSheetOpen.value = true;
   } else {
+    graphSheetOpen.value = false;
     resultSheetOpen.value = true;
   }
 }

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -617,9 +617,10 @@ function onYamlInput(event) {
   // host's `value` property is updated before dispatch so
   // event.target.value would also work, but reading from detail keeps
   // the contract explicit and matches how the storybook docs the API.
-  // Final fallback is the current yamlSource so a misfired event (no
-  // detail, no value on target) becomes a no-op instead of silently
-  // wiping the user's content.
+  // Final fallback to yamlSource only catches a structurally broken
+  // event (no detail, no value on target) — `??` skips null/undefined
+  // but lets a deliberate `''` through, which is what we want when the
+  // user clears the editor.
   const text = event.detail?.value ?? event.target?.value ?? yamlSource.value;
   yamlSource.value = text;
   try {

--- a/frontend/src/LibraryApp.vue
+++ b/frontend/src/LibraryApp.vue
@@ -71,11 +71,6 @@ const selectedArticleNumber = ref(null);
 const detailView = ref('tekst');
 const activeAction = ref(null);
 
-function onDetailViewChange(event) {
-  const value = event.target?.value ?? event.detail?.[0];
-  if (value) detailView.value = value;
-}
-
 const sidebarLaws = computed(() => {
   const list = laws.value;
   if (favorites.value) {
@@ -621,11 +616,11 @@ loadIndex();
                   <nldd-spacer size="16"></nldd-spacer>
                   <nldd-toolbar>
                     <nldd-toolbar-item slot="start">
-                      <nldd-segmented-control size="md" :value="detailView" @change="onDetailViewChange">
-                        <nldd-segmented-control-item value="tekst" text="Tekst"></nldd-segmented-control-item>
-                        <nldd-segmented-control-item value="machine" text="Machine"></nldd-segmented-control-item>
-                        <nldd-segmented-control-item value="yaml" text="YAML"></nldd-segmented-control-item>
-                      </nldd-segmented-control>
+                      <nldd-tab-bar size="md">
+                        <nldd-tab-bar-item :selected="detailView === 'tekst' || undefined" text="Tekst" @click="detailView = 'tekst'"></nldd-tab-bar-item>
+                        <nldd-tab-bar-item :selected="detailView === 'machine' || undefined" text="Machine" @click="detailView = 'machine'"></nldd-tab-bar-item>
+                        <nldd-tab-bar-item :selected="detailView === 'yaml' || undefined" text="YAML" @click="detailView = 'yaml'"></nldd-tab-bar-item>
+                      </nldd-tab-bar>
                     </nldd-toolbar-item>
                     <nldd-toolbar-item slot="end">
                       <nldd-button v-if="selectedLawId" variant="primary" text="Bewerk" :href="`/editor/${encodeURIComponent(selectedLawId)}/${encodeURIComponent(selectedArticleNumber)}`" @click.prevent="router.push(`/editor/${encodeURIComponent(selectedLawId)}/${encodeURIComponent(selectedArticleNumber)}`)"></nldd-button>

--- a/frontend/src/LibraryApp.vue
+++ b/frontend/src/LibraryApp.vue
@@ -294,6 +294,11 @@ function retryLoadLaw() {
 
 function retryLoadCorpus() {
   indexError.value = null;
+  // loadIndex only flips loading back to false in its finally block —
+  // it never sets it to true. So after the first failure (loading is
+  // false, indexError is truthy) we have to flip the spinner back on
+  // here, otherwise the retry shows the error pane until the next
+  // round-trip resolves.
   loading.value = true;
   loadIndex();
 }

--- a/frontend/src/LibraryApp.vue
+++ b/frontend/src/LibraryApp.vue
@@ -285,6 +285,12 @@ function retryLoadLaw() {
   loadLaw(selectedLawId.value);
 }
 
+function retryLoadCorpus() {
+  indexError.value = null;
+  loading.value = true;
+  loadIndex();
+}
+
 function editInEditor() {
   if (!selectedLawId.value || !selectedArticleNumber.value) return;
   activeAction.value = null;
@@ -516,8 +522,10 @@ loadIndex();
       <nldd-split-view-pane slot="main">
         <nldd-navigation-split-view @back="onPaneBack">
 
-          <!-- Sidebar: Wetten Browser -->
-          <nldd-split-view-pane slot="sidebar" has-content>
+          <!-- Sidebar: Wetten Browser. Hidden on corpus load failure so the
+               navigation-split-view collapses and the main pane carries the
+               error state on its own (mirrors the law-load failure pattern). -->
+          <nldd-split-view-pane v-if="!indexError" slot="sidebar" has-content>
             <nldd-page sticky-header>
               <nldd-top-title-bar slot="header" :text="LIBRARY_HOME_TITLE" collapse-anchor="home-titel"></nldd-top-title-bar>
 
@@ -525,7 +533,6 @@ loadIndex();
                 <nldd-title id="home-titel" size="3"><h3>{{ LIBRARY_HOME_TITLE }}</h3></nldd-title>
                 <nldd-spacer size="16"></nldd-spacer>
                 <nldd-inline-dialog v-if="loading" text="Laden..."></nldd-inline-dialog>
-                <nldd-inline-dialog v-else-if="indexError" variant="alert" text="Fout bij laden" :supporting-text="indexError.message"></nldd-inline-dialog>
                 <nldd-list v-else variant="simple">
                   <nldd-list-item
                     v-for="law in sidebarLaws"
@@ -552,7 +559,7 @@ loadIndex();
                selected. When deselected the pane is removed from the DOM
                so the navigation-split-view reflows to spatial mode and
                shows the sidebar (Wetten Browser) alongside main. -->
-          <nldd-split-view-pane v-if="selectedLawId && !lawError" slot="secondary-sidebar" has-content>
+          <nldd-split-view-pane v-if="selectedLawId && !lawError && !indexError" slot="secondary-sidebar" has-content>
             <nldd-page sticky-header>
               <nldd-top-title-bar
                 slot="header"
@@ -588,17 +595,27 @@ loadIndex();
           </nldd-split-view-pane>
 
           <!-- Main: Artikel Detail -->
-          <nldd-split-view-pane slot="main" :has-content="selectedArticle || lawError || articleNotFound ? true : undefined">
+          <nldd-split-view-pane slot="main" :has-content="selectedArticle || lawError || articleNotFound || indexError ? true : undefined">
             <nldd-page sticky-header>
               <nldd-top-title-bar
                 slot="header"
                 :text="selectedArticle ? `Artikel ${selectedArticle.number}` : undefined"
                 :supporting-text="selectedArticle ? lawName : undefined"
-                :back-text="lawError ? LIBRARY_HOME_TITLE : (lawName || 'Terug')"
+                :back-text="indexError ? undefined : (lawError ? LIBRARY_HOME_TITLE : (lawName || 'Terug'))"
                 :collapse-anchor="selectedArticle ? 'article-titel' : undefined"
               ></nldd-top-title-bar>
 
-              <nldd-simple-section full-width v-if="!selectedLawId">
+              <nldd-simple-section full-width v-if="indexError">
+                <nldd-inline-dialog
+                  variant="alert"
+                  text="Wetten en regels zijn niet geladen"
+                  supporting-text="De gegevens konden niet worden opgehaald."
+                >
+                  <nldd-button slot="actions" variant="primary" text="Probeer opnieuw" @click="retryLoadCorpus"></nldd-button>
+                  <nldd-button slot="actions" variant="secondary" text="Neem contact op via e-mail" :href="`mailto:${SUPPORT_EMAIL}`"></nldd-button>
+                </nldd-inline-dialog>
+              </nldd-simple-section>
+              <nldd-simple-section full-width v-else-if="!selectedLawId">
                 <nldd-inline-dialog text="Selecteer een wet"></nldd-inline-dialog>
               </nldd-simple-section>
               <nldd-simple-section full-width v-else-if="lawError">

--- a/frontend/src/LibraryApp.vue
+++ b/frontend/src/LibraryApp.vue
@@ -288,6 +288,13 @@ async function loadLaw(lawId) {
 
 function retryLoadLaw() {
   if (!selectedLawId.value) return;
+  // No explicit selectedLawLoading.value = true here (unlike
+  // retryLoadCorpus → loadIndex): loadLaw sets it as the first
+  // statement inside its try block, which runs synchronously before
+  // any await yields. The next reactivity flush sees both
+  // lawError = null and selectedLawLoading = true together, so the
+  // template can't briefly fall through to the "Selecteer een wet"
+  // empty state.
   lawError.value = null;
   loadLaw(selectedLawId.value);
 }

--- a/frontend/src/LibraryApp.vue
+++ b/frontend/src/LibraryApp.vue
@@ -368,7 +368,11 @@ function onPaneBack(e) {
   const pane = path.find(el => el.tagName === 'NLDD-SPLIT-VIEW-PANE');
   if (!pane) return;
   const slot = pane.getAttribute('slot');
-  if (slot === 'main') return lawError.value ? goToLibraryRoot() : goToLawRoot();
+  // On any error state — corpus load failed (indexError) or this
+  // specific law failed (lawError) — back from the main pane should
+  // return to the library root, not /library/<lawId>. The latter would
+  // route the user back into the same error they just dismissed.
+  if (slot === 'main') return (lawError.value || indexError.value) ? goToLibraryRoot() : goToLawRoot();
   if (slot === 'secondary-sidebar') return goToLibraryRoot();
 }
 

--- a/frontend/src/LibraryApp.vue
+++ b/frontend/src/LibraryApp.vue
@@ -83,11 +83,11 @@ const detailView = computed({
     // Reject anything we don't recognise rather than silently stripping
     // the hash — every call site today hard-codes a literal, so an
     // unknown value is a programmer error, not a user-supplied string.
+    // Bail silently: no production code path can reach this branch, and
+    // a console.warn would just be noise if a future tab gets added
+    // without updating VIEW_TO_HASH.
     const hash = VIEW_TO_HASH[value];
-    if (!hash) {
-      console.warn(`[detailView] ignoring unknown value: ${value}`);
-      return;
-    }
+    if (!hash) return;
     if (hash !== route.hash) {
       router.replace({ path: route.path, query: route.query, hash });
     }

--- a/frontend/src/LibraryApp.vue
+++ b/frontend/src/LibraryApp.vue
@@ -10,6 +10,7 @@ import SearchPopover from './components/SearchPopover.vue';
 import { useAuth } from './composables/useAuth.js';
 import { useFeatureFlags } from './composables/useFeatureFlags.js';
 import { useColorScheme } from './composables/useColorScheme.js';
+import { SUPPORT_EMAIL } from './constants.js';
 
 const { authenticated, loading: authLoading, oidcConfigured, person, login, logout } = useAuth();
 const { isEnabled, toggle: toggleFlag } = useFeatureFlags();
@@ -117,12 +118,27 @@ const lawName = computed(() => {
   return humanizeLawId(selectedLaw.value.$id || selectedLaw.value.law_id || '');
 });
 
+// Display name resolved from the index. Used in the load-error state where
+// `selectedLaw` is null and `lawName` would be empty.
+const indexedLawName = computed(() => {
+  if (!selectedLawId.value) return '';
+  const law = laws.value.find(l => l.law_id === selectedLawId.value);
+  return law ? displayName(law) : humanizeLawId(selectedLawId.value);
+});
+
 const selectedArticle = computed(() => {
   if (!selectedArticleNumber.value) return null;
   return articles.value.find(
     (a) => String(a.number) === String(selectedArticleNumber.value)
   ) ?? null;
 });
+
+// True when the URL points at an article that doesn't exist in the
+// loaded law. Distinct from "no article selected" (where no article
+// number is in the URL).
+const articleNotFound = computed(() =>
+  !!(selectedLaw.value && selectedArticleNumber.value && !selectedArticle.value)
+);
 
 // Reflect navigation depth in the document title:
 //   "Art. 5 · Wet op de zorgtoeslag · RegelRecht"
@@ -136,7 +152,10 @@ const selectedArticle = computed(() => {
 watchEffect(() => {
   const detail = [];
   if (selectedArticle.value) detail.push(`Art. ${selectedArticle.value.number}`);
-  if (lawName.value) detail.push(lawName.value);
+  // Fall back to indexedLawName so the title reflects the URL even when the
+  // law itself failed to load.
+  const name = lawName.value || indexedLawName.value;
+  if (name) detail.push(name);
   document.title = detail.length > 0
     ? `${detail.join(' · ')} · RegelRecht`
     : 'Bibliotheek · RegelRecht';
@@ -233,16 +252,10 @@ async function loadLaw(lawId) {
     if (gen !== loadLawGeneration) return; // stale response, discard
     const text = await res.text();
     selectedLaw.value = yaml.load(text);
-    if (articles.value.length > 0) {
-      // Use article from route if valid; otherwise show nothing (empty state).
-      const routeArticle = route.params.articleNumber;
-      if (routeArticle && articles.value.some(a => String(a.number) === String(routeArticle))) {
-        selectedArticleNumber.value = String(routeArticle);
-      } else if (routeArticle) {
-        // Route had an invalid article number — strip it so the URL reflects the empty state.
-        router.replace({ name: 'library', params: { lawId } });
-      }
-    }
+    // selectedArticleNumber is set from the route on initial mount and via
+    // onBeforeRouteUpdate; we don't validate here so an invalid number
+    // surfaces as the articleNotFound error state instead of being silently
+    // stripped from the URL.
   } catch (e) {
     if (gen !== loadLawGeneration) return;
     selectedLaw.value = null;
@@ -252,6 +265,12 @@ async function loadLaw(lawId) {
       selectedLawLoading.value = false;
     }
   }
+}
+
+function retryLoadLaw() {
+  if (!selectedLawId.value) return;
+  lawError.value = null;
+  loadLaw(selectedLawId.value);
 }
 
 function editInEditor() {
@@ -312,7 +331,7 @@ function onPaneBack(e) {
   const pane = path.find(el => el.tagName === 'NLDD-SPLIT-VIEW-PANE');
   if (!pane) return;
   const slot = pane.getAttribute('slot');
-  if (slot === 'main') return goToLawRoot();
+  if (slot === 'main') return lawError.value ? goToLibraryRoot() : goToLawRoot();
   if (slot === 'secondary-sidebar') return goToLibraryRoot();
 }
 
@@ -373,6 +392,9 @@ async function onHarvestAvailable(slug) {
 // Initial load from route
 if (route.params.lawId) {
   selectedLawId.value = route.params.lawId;
+  if (route.params.articleNumber) {
+    selectedArticleNumber.value = String(route.params.articleNumber);
+  }
   loadLaw(route.params.lawId);
 }
 loadIndex();
@@ -487,7 +509,7 @@ loadIndex();
             <nldd-page sticky-header>
               <nldd-top-title-bar slot="header" :text="LIBRARY_HOME_TITLE" collapse-anchor="home-titel"></nldd-top-title-bar>
 
-              <nldd-simple-section full-width :align="loading || indexError ? 'center' : undefined">
+              <nldd-simple-section full-width>
                 <nldd-title id="home-titel" size="3"><h3>{{ LIBRARY_HOME_TITLE }}</h3></nldd-title>
                 <nldd-spacer size="16"></nldd-spacer>
                 <nldd-inline-dialog v-if="loading" text="Laden..."></nldd-inline-dialog>
@@ -518,20 +540,19 @@ loadIndex();
                selected. When deselected the pane is removed from the DOM
                so the navigation-split-view reflows to spatial mode and
                shows the sidebar (Wetten Browser) alongside main. -->
-          <nldd-split-view-pane v-if="selectedLawId" slot="secondary-sidebar" has-content>
+          <nldd-split-view-pane v-if="selectedLawId && !lawError" slot="secondary-sidebar" has-content>
             <nldd-page sticky-header>
               <nldd-top-title-bar
                 slot="header"
-                :text="lawName || 'Selecteer een wet'"
+                :text="lawName || indexedLawName || 'Selecteer een wet'"
                 :back-text="LIBRARY_HOME_TITLE"
                 collapse-anchor="wet-titel"
               ></nldd-top-title-bar>
 
-              <nldd-simple-section full-width :align="selectedLawLoading || lawError || !selectedLaw ? 'center' : undefined">
+              <nldd-simple-section full-width>
                 <nldd-title id="wet-titel" size="3"><h3>{{ lawName || 'Selecteer een wet' }}</h3></nldd-title>
                 <nldd-spacer size="16"></nldd-spacer>
                 <nldd-inline-dialog v-if="selectedLawLoading" text="Laden..."></nldd-inline-dialog>
-                <nldd-inline-dialog v-else-if="lawError" variant="alert" text="Fout bij laden" :supporting-text="lawError.message"></nldd-inline-dialog>
                 <nldd-inline-dialog v-else-if="!selectedLaw" text="Selecteer een wet"></nldd-inline-dialog>
                 <nldd-list v-else variant="simple">
                   <nldd-list-item
@@ -555,18 +576,38 @@ loadIndex();
           </nldd-split-view-pane>
 
           <!-- Main: Artikel Detail -->
-          <nldd-split-view-pane slot="main" :has-content="selectedArticle ? true : undefined">
+          <nldd-split-view-pane slot="main" :has-content="selectedArticle || lawError || articleNotFound ? true : undefined">
             <nldd-page sticky-header>
               <nldd-top-title-bar
                 slot="header"
                 :text="selectedArticle ? `Artikel ${selectedArticle.number}` : undefined"
                 :supporting-text="selectedArticle ? lawName : undefined"
-                :back-text="lawName || 'Terug'"
+                :back-text="lawError ? LIBRARY_HOME_TITLE : (lawName || 'Terug')"
                 :collapse-anchor="selectedArticle ? 'article-titel' : undefined"
               ></nldd-top-title-bar>
 
               <nldd-simple-section full-width v-if="!selectedLawId">
                 <nldd-inline-dialog text="Selecteer een wet"></nldd-inline-dialog>
+              </nldd-simple-section>
+              <nldd-simple-section full-width v-else-if="lawError">
+                <nldd-inline-dialog
+                  variant="alert"
+                  :text="`${indexedLawName} is niet geladen`"
+                  supporting-text="De gegevens konden niet worden opgehaald."
+                >
+                  <nldd-button slot="actions" variant="primary" text="Probeer opnieuw" @click="retryLoadLaw"></nldd-button>
+                  <nldd-button slot="actions" variant="secondary" text="Neem contact op via e-mail" :href="`mailto:${SUPPORT_EMAIL}`"></nldd-button>
+                </nldd-inline-dialog>
+              </nldd-simple-section>
+              <nldd-simple-section full-width v-else-if="articleNotFound">
+                <nldd-inline-dialog
+                  variant="alert"
+                  :text="`Artikel ${selectedArticleNumber} van ${lawName || indexedLawName} bestaat niet`"
+                  supporting-text="Mogelijk klopt de URL niet. Neem contact op als je verwacht dat dit artikel wel bestaat."
+                >
+                  <nldd-button slot="actions" class="article-not-found__back-button" variant="primary" text="Bekijk artikelen" @click="goToLawRoot"></nldd-button>
+                  <nldd-button slot="actions" variant="secondary" text="Neem contact op via e-mail" :href="`mailto:${SUPPORT_EMAIL}`"></nldd-button>
+                </nldd-inline-dialog>
               </nldd-simple-section>
               <nldd-simple-section full-width v-else-if="!selectedArticle">
                 <nldd-inline-dialog text="Selecteer een artikel"></nldd-inline-dialog>
@@ -666,3 +707,11 @@ loadIndex();
     @harvest-available="onHarvestAvailable"
   />
 </template>
+
+<style>
+/* "Bekijk artikelen" alleen tonen wanneer de artikelenlijst niet naast
+   de main pane zichtbaar is (full-stack mode = single pane op mobile). */
+nldd-navigation-split-view:not(.full-stack) .article-not-found__back-button {
+  display: none;
+}
+</style>

--- a/frontend/src/LibraryApp.vue
+++ b/frontend/src/LibraryApp.vue
@@ -11,6 +11,7 @@ import { useAuth } from './composables/useAuth.js';
 import { useFeatureFlags } from './composables/useFeatureFlags.js';
 import { useColorScheme } from './composables/useColorScheme.js';
 import { SUPPORT_EMAIL } from './constants.js';
+import { lastEditorPath } from './composables/useLastVisitedRoute.js';
 
 const { authenticated, loading: authLoading, oidcConfigured, person, login, logout } = useAuth();
 const { isEnabled, toggle: toggleFlag } = useFeatureFlags();
@@ -68,7 +69,23 @@ const selectedLaw = shallowRef(null);
 const selectedLawLoading = ref(false);
 const lawError = ref(null);
 const selectedArticleNumber = ref(null);
-const detailView = ref('tekst');
+// Detail view (tekst/machine/yaml) is reflected in the URL hash so the
+// state is bookmarkable and shareable. English keys in the hash because
+// they're stable identifiers, not labels.
+const VIEW_TO_HASH = { tekst: '#text', machine: '#machine', yaml: '#yaml' };
+const HASH_TO_VIEW = { '#text': 'tekst', '#machine': 'machine', '#yaml': 'yaml' };
+
+const detailView = computed({
+  get() {
+    return HASH_TO_VIEW[route.hash] ?? 'tekst';
+  },
+  set(value) {
+    const hash = VIEW_TO_HASH[value] ?? '';
+    if (hash !== route.hash) {
+      router.replace({ path: route.path, query: route.query, hash });
+    }
+  },
+});
 const activeAction = ref(null);
 
 const sidebarLaws = computed(() => {
@@ -304,7 +321,7 @@ function selectArticle(number) {
   if (articleStr === selectedArticleNumber.value) return;
   selectedArticleNumber.value = articleStr;
   activeAction.value = null;
-  router.replace({ name: 'library', params: { lawId: selectedLawId.value, articleNumber: articleStr } });
+  router.replace({ name: 'library', params: { lawId: selectedLawId.value, articleNumber: articleStr }, hash: route.hash });
 }
 
 /**
@@ -405,7 +422,7 @@ loadIndex();
             <nldd-toolbar-item slot="start">
               <nldd-tab-bar size="md">
                 <nldd-tab-bar-item selected text="Bibliotheek"></nldd-tab-bar-item>
-                <nldd-tab-bar-item href="/editor" @click.prevent="router.push('/editor')" text="Editor"></nldd-tab-bar-item>
+                <nldd-tab-bar-item :href="lastEditorPath" @click.prevent="router.push(lastEditorPath)" text="Editor"></nldd-tab-bar-item>
               </nldd-tab-bar>
             </nldd-toolbar-item>
             <nldd-toolbar-item slot="end">
@@ -451,7 +468,7 @@ loadIndex();
             <nldd-toolbar-item slot="start">
               <nldd-tab-bar size="md">
                 <nldd-tab-bar-item selected text="Bibliotheek"></nldd-tab-bar-item>
-                <nldd-tab-bar-item href="/editor" @click.prevent="router.push('/editor')" text="Editor"></nldd-tab-bar-item>
+                <nldd-tab-bar-item :href="lastEditorPath" @click.prevent="router.push(lastEditorPath)" text="Editor"></nldd-tab-bar-item>
               </nldd-tab-bar>
             </nldd-toolbar-item>
             <nldd-toolbar-item slot="center" min-width="240px" width="33%">
@@ -623,7 +640,7 @@ loadIndex();
                       </nldd-tab-bar>
                     </nldd-toolbar-item>
                     <nldd-toolbar-item slot="end">
-                      <nldd-button v-if="selectedLawId" variant="primary" text="Bewerk" :href="`/editor/${encodeURIComponent(selectedLawId)}/${encodeURIComponent(selectedArticleNumber)}`" @click.prevent="router.push(`/editor/${encodeURIComponent(selectedLawId)}/${encodeURIComponent(selectedArticleNumber)}`)"></nldd-button>
+                      <nldd-button v-if="selectedLawId" variant="secondary" text="Bewerken" :href="`/editor/${encodeURIComponent(selectedLawId)}/${encodeURIComponent(selectedArticleNumber)}`" @click.prevent="router.push(`/editor/${encodeURIComponent(selectedLawId)}/${encodeURIComponent(selectedArticleNumber)}`)"></nldd-button>
                     </nldd-toolbar-item>
                   </nldd-toolbar>
                   <nldd-spacer size="24"></nldd-spacer>
@@ -647,7 +664,7 @@ loadIndex();
             <nldd-toolbar-item slot="start">
               <nldd-tab-bar compact>
                 <nldd-tab-bar-item selected icon="stack" text="Bibliotheek"></nldd-tab-bar-item>
-                <nldd-tab-bar-item href="/editor" @click.prevent="router.push('/editor')" icon="edit" text="Editor"></nldd-tab-bar-item>
+                <nldd-tab-bar-item :href="lastEditorPath" @click.prevent="router.push(lastEditorPath)" icon="edit" text="Editor"></nldd-tab-bar-item>
               </nldd-tab-bar>
             </nldd-toolbar-item>
             <nldd-toolbar-item slot="end">

--- a/frontend/src/LibraryApp.vue
+++ b/frontend/src/LibraryApp.vue
@@ -82,12 +82,16 @@ const detailView = computed({
   set(value) {
     // Reject anything we don't recognise rather than silently stripping
     // the hash — every call site today hard-codes a literal, so an
-    // unknown value is a programmer error, not a user-supplied string.
-    // Bail silently: no production code path can reach this branch, and
-    // a console.warn would just be noise if a future tab gets added
-    // without updating VIEW_TO_HASH.
+    // unknown value is a programmer error. Warn in dev so a future
+    // contributor adding a tab without updating VIEW_TO_HASH catches
+    // it immediately; production silently no-ops to avoid console noise.
     const hash = VIEW_TO_HASH[value];
-    if (!hash) return;
+    if (!hash) {
+      if (import.meta.env.DEV) {
+        console.warn(`[detailView] ignoring unknown value: ${value}`);
+      }
+      return;
+    }
     if (hash !== route.hash) {
       router.replace({ path: route.path, query: route.query, hash });
     }

--- a/frontend/src/LibraryApp.vue
+++ b/frontend/src/LibraryApp.vue
@@ -80,7 +80,14 @@ const detailView = computed({
     return HASH_TO_VIEW[route.hash] ?? 'tekst';
   },
   set(value) {
-    const hash = VIEW_TO_HASH[value] ?? '';
+    // Reject anything we don't recognise rather than silently stripping
+    // the hash — every call site today hard-codes a literal, so an
+    // unknown value is a programmer error, not a user-supplied string.
+    const hash = VIEW_TO_HASH[value];
+    if (!hash) {
+      console.warn(`[detailView] ignoring unknown value: ${value}`);
+      return;
+    }
     if (hash !== route.hash) {
       router.replace({ path: route.path, query: route.query, hash });
     }

--- a/frontend/src/LibraryApp.vue
+++ b/frontend/src/LibraryApp.vue
@@ -745,7 +745,14 @@ loadIndex();
 </template>
 
 <style>
-/* "Bekijk artikelen" alleen tonen wanneer de artikelenlijst niet naast
+/* Unscoped on purpose: nldd-navigation-split-view is a custom element
+   with its own shadow root, but the `.full-stack` class is reflected on
+   the host element from light-DOM space, so a scoped selector here
+   wouldn't match any longer than the scoping attribute the Vue compiler
+   would inject. The class name is namespaced (`article-not-found__…`)
+   to make accidental collisions outside this view unlikely.
+
+   "Bekijk artikelen" alleen tonen wanneer de artikelenlijst niet naast
    de main pane zichtbaar is (full-stack mode = single pane op mobile). */
 nldd-navigation-split-view:not(.full-stack) .article-not-found__back-button {
   display: none;

--- a/frontend/src/components/ActionSheet.vue
+++ b/frontend/src/components/ActionSheet.vue
@@ -84,7 +84,7 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <nldd-sheet ref="sheetEl" placement="right" width="640px" @close="emit('close')">
+  <nldd-sheet ref="sheetEl" placement="right" width="640px" full-height @close="emit('close')">
     <!-- :key forces nldd-page to remount whenever a NEW action opens.
          nldd-page captures the sticky-header height ONCE per mount via
          requestAnimationFrame; when the sheet opens with a new action the

--- a/frontend/src/components/ActionSheet.vue
+++ b/frontend/src/components/ActionSheet.vue
@@ -171,7 +171,7 @@ onUnmounted(() => {
 
       <nldd-container slot="footer" padding="16">
         <nldd-button v-if="editable" variant="primary" size="md" full-width data-testid="action-sheet-save-btn" @click="emit('save')" text="Opslaan"></nldd-button>
-        <nldd-button v-else variant="primary" size="md" full-width data-testid="action-sheet-edit-btn" @click="emit('edit')" text="Wijzig"></nldd-button>
+        <nldd-button v-else variant="secondary" size="md" full-width data-testid="action-sheet-edit-btn" @click="emit('edit')" text="Bewerken"></nldd-button>
       </nldd-container>
     </nldd-page>
   </nldd-sheet>

--- a/frontend/src/components/EditSheet.vue
+++ b/frontend/src/components/EditSheet.vue
@@ -354,7 +354,7 @@ const sectionLabels = {
 </script>
 
 <template>
-  <nldd-sheet ref="sheetEl" placement="right" width="640px" @close="emit('close')">
+  <nldd-sheet ref="sheetEl" placement="right" width="640px" full-height @close="emit('close')">
     <!-- `:key` forces nldd-page to remount whenever the section changes.
          nldd-page captures the sticky-header height ONCE per mount via
          requestAnimationFrame; if the header text changes after that

--- a/frontend/src/components/EditSheet.vue
+++ b/frontend/src/components/EditSheet.vue
@@ -343,13 +343,13 @@ function save() {
 
 const sectionLabels = {
   'definition': 'Definitie',
-  'add-definition': 'Nieuwe definitie',
+  'add-definition': 'Definitie toevoegen',
   'parameter': 'Parameter',
-  'add-parameter': 'Nieuwe parameter',
+  'add-parameter': 'Parameter toevoegen',
   'input': 'Input',
-  'add-input': 'Nieuwe input',
+  'add-input': 'Input toevoegen',
   'output': 'Output',
-  'add-output': 'Nieuwe output',
+  'add-output': 'Output toevoegen',
 };
 </script>
 

--- a/frontend/src/components/ExecutionTraceView.vue
+++ b/frontend/src/components/ExecutionTraceView.vue
@@ -35,23 +35,12 @@ const overallStatus = computed(() => {
 </script>
 
 <template>
-  <nldd-simple-section v-if="!hasContent">
-    <nldd-inline-dialog text="Klik op &quot;Details&quot; bij een scenario om de trace te bekijken."></nldd-inline-dialog>
-  </nldd-simple-section>
+  <nldd-inline-dialog v-if="!hasContent" text="Klik op &quot;Details&quot; bij een scenario om de trace te bekijken."></nldd-inline-dialog>
 
-  <nldd-simple-section v-else-if="error && !result && !traceText">
-    <nldd-inline-dialog variant="alert" text="Fout bij uitvoering" :supporting-text="error"></nldd-inline-dialog>
-  </nldd-simple-section>
+  <nldd-inline-dialog v-else-if="error && !result && !traceText" variant="alert" text="Fout bij uitvoering" :supporting-text="error"></nldd-inline-dialog>
 
-  <nldd-simple-section v-else>
-    <template v-if="result && scenarioName">
-      <nldd-title size="4"><span>{{ scenarioName }}</span></nldd-title>
-      <nldd-spacer size="16"></nldd-spacer>
-    </template>
-
+  <template v-else>
     <template v-if="result && Object.keys(expectations).length">
-      <nldd-title size="5" class="etv-section-title"><span>Verwachte uitkomsten</span></nldd-title>
-      <nldd-spacer size="4"></nldd-spacer>
       <nldd-list variant="simple">
         <nldd-list-item size="md">
           <nldd-text-cell size="md" color="secondary" text=""></nldd-text-cell>
@@ -105,29 +94,14 @@ const overallStatus = computed(() => {
 
     <template v-if="result && traceText">
       <nldd-title size="5" class="etv-section-title"><span>Execution trace</span></nldd-title>
-      <nldd-spacer size="4"></nldd-spacer>
-      <pre class="etv-trace-text">{{ traceText }}</pre>
+      <nldd-spacer size="8"></nldd-spacer>
+      <nldd-code>{{ traceText }}</nldd-code>
     </template>
 
     <template v-if="error && traceText && !result">
       <nldd-title size="5" class="etv-section-title"><span>Partial trace (tot fout)</span></nldd-title>
-      <nldd-spacer size="4"></nldd-spacer>
-      <pre class="etv-trace-text">{{ traceText }}</pre>
+      <nldd-spacer size="8"></nldd-spacer>
+      <nldd-code>{{ traceText }}</nldd-code>
     </template>
-  </nldd-simple-section>
+  </template>
 </template>
-
-<style scoped>
-.etv-trace-text {
-  font-family: 'SF Mono', 'Fira Code', monospace;
-  font-size: 11px;
-  line-height: 1.5;
-  padding: 8px;
-  background: #1e1e2e;
-  color: #cdd6f4;
-  border-radius: 6px;
-  overflow-x: auto;
-  white-space: pre;
-  margin: 0;
-}
-</style>

--- a/frontend/src/components/ExecutionTraceView.vue
+++ b/frontend/src/components/ExecutionTraceView.vue
@@ -11,8 +11,6 @@ const props = defineProps({
   expectations: { type: Object, default: () => ({}) },
   /** Error message if execution failed */
   error: { type: String, default: null },
-  /** Name of the scenario being displayed */
-  scenarioName: { type: String, default: '' },
 });
 
 function matchStatus(outputName, actualValue) {

--- a/frontend/src/components/LawGraphView.vue
+++ b/frontend/src/components/LawGraphView.vue
@@ -284,15 +284,14 @@ const currentStep = computed(() =>
 
 <style scoped>
 .law-graph-view {
-  /* Fill the pane. nldd-page gives us a flex body; claim the viewport
-   * minus toolbar + tab-bar chrome (mirrors the YAML textarea).
-   * 180px = primary toolbar (~48px) + document tab bar (~56px) +
-   * right-pane title bar (~48px) + spacer (~28px). Update this if the
-   * chrome layout changes (e.g. a new toolbar row is added). */
-  height: calc(100vh - 180px);
+  /* Fill the pane. nldd-page wraps slotted content in a flex column,
+   * so flex-grow + min-height: 0 lets us claim every pixel the parent
+   * gives us — works equally inside a side pane and inside a bottom
+   * sheet, no chrome-height arithmetic needed. */
   display: flex;
   flex-direction: column;
-  min-height: 400px;
+  flex-grow: 1;
+  min-height: 0;
 }
 
 .law-graph-container {

--- a/frontend/src/components/LawGraphView.vue
+++ b/frontend/src/components/LawGraphView.vue
@@ -183,27 +183,28 @@ function handleNodeClick({ node, event }) {
   selectedRoot.value = selectedRoot.value === node.id ? null : node.id;
 }
 
-// Resolve the palette token whenever the user-controlled colour scheme
-// changes. Vue Flow's MiniMap takes a flat colour string (not a CSS
-// variable), and getComputedStyle is one-shot — without a reactive
-// dependency the marker would otherwise stay frozen at its mount-time
-// value when the user toggles light/dark. This doesn't catch OS-level
-// scheme changes while colorScheme === 'auto', which is acceptable
-// (the next graph re-render will pick the new value up; the minimap
-// marker is decorative).
+// Vue Flow's MiniMap takes a flat colour string (not a CSS variable),
+// so the palette token has to be resolved through getComputedStyle.
+// That call is one-shot and untracked — wrapping it in a computed
+// would need a fragile "touch colorScheme to register a dep" trick.
+// Instead, push the resolved value into a plain ref from a watcher:
+// the colorScheme dependency is now visible in the watch() argument
+// list, so a future cleanup can't accidentally drop it.
+//
+// OS-level scheme changes while colorScheme === 'auto' aren't tracked
+// (the composable doesn't expose that). Acceptable — the marker is
+// decorative and the next graph re-render picks the new value up.
 const { colorScheme } = useColorScheme();
-const miniMapMarkerColor = computed(() => {
-  // DO NOT remove this `void` line: it's the only thing tying the
-  // computed to colorScheme reactivity. Without it the read below uses
-  // getComputedStyle (one-shot, untracked) and the marker freezes at
-  // its mount-time value forever. The actual colour comes from the CSS
-  // token so the palette's light-dark() resolution stays the source of
-  // truth; this line just forces the computed to re-evaluate on scheme
-  // change.
-  void colorScheme.value;
-  return getComputedStyle(document.documentElement)
-    .getPropertyValue('--primitives-color-coolgray-400').trim() || '#ccc';
-});
+const miniMapMarkerColor = ref('#ccc');
+
+function resolveMiniMapMarkerColor() {
+  miniMapMarkerColor.value =
+    getComputedStyle(document.documentElement)
+      .getPropertyValue('--primitives-color-coolgray-400').trim() || '#ccc';
+}
+
+resolveMiniMapMarkerColor();
+watch(colorScheme, resolveMiniMapMarkerColor);
 
 function miniMapNodeColor(node) {
   if (!(node.class?.includes('root') && !node.hidden)) return 'transparent';

--- a/frontend/src/components/LawGraphView.vue
+++ b/frontend/src/components/LawGraphView.vue
@@ -16,6 +16,7 @@ import TraceStepList from './graph/TraceStepList.vue';
 import TraceStepDetail from './graph/TraceStepDetail.vue';
 import { useLawGraph, rootOfId } from '../composables/useLawGraph.js';
 import { useTraceStepping } from '../composables/useTraceStepping.js';
+import { useColorScheme } from '../composables/useColorScheme.js';
 import { stepHasHighlights } from '../lib/traceEdges.js';
 
 const props = defineProps({
@@ -182,13 +183,27 @@ function handleNodeClick({ node, event }) {
   selectedRoot.value = selectedRoot.value === node.id ? null : node.id;
 }
 
-function miniMapNodeColor(node) {
-  if (!(node.class?.includes('root') && !node.hidden)) return 'transparent';
-  // Resolve the palette token at call time so the marker swaps with the
-  // colour scheme — Vue Flow's MiniMap takes a flat colour string, not a
-  // CSS variable, so the var() can't live in the SVG attribute itself.
+// Resolve the palette token whenever the user-controlled colour scheme
+// changes. Vue Flow's MiniMap takes a flat colour string (not a CSS
+// variable), and getComputedStyle is one-shot — without a reactive
+// dependency the marker would otherwise stay frozen at its mount-time
+// value when the user toggles light/dark. This doesn't catch OS-level
+// scheme changes while colorScheme === 'auto', which is acceptable
+// (the next graph re-render will pick the new value up; the minimap
+// marker is decorative).
+const { colorScheme } = useColorScheme();
+const miniMapMarkerColor = computed(() => {
+  // Touch colorScheme so the computed re-runs when the user picks a
+  // different scheme; the actual value is read from CSS so the token's
+  // light-dark() resolution stays the source of truth.
+  void colorScheme.value;
   return getComputedStyle(document.documentElement)
     .getPropertyValue('--primitives-color-coolgray-400').trim() || '#ccc';
+});
+
+function miniMapNodeColor(node) {
+  if (!(node.class?.includes('root') && !node.hidden)) return 'transparent';
+  return miniMapMarkerColor.value;
 }
 
 const currentStep = computed(() =>

--- a/frontend/src/components/LawGraphView.vue
+++ b/frontend/src/components/LawGraphView.vue
@@ -193,9 +193,13 @@ function handleNodeClick({ node, event }) {
 // marker is decorative).
 const { colorScheme } = useColorScheme();
 const miniMapMarkerColor = computed(() => {
-  // Touch colorScheme so the computed re-runs when the user picks a
-  // different scheme; the actual value is read from CSS so the token's
-  // light-dark() resolution stays the source of truth.
+  // DO NOT remove this `void` line: it's the only thing tying the
+  // computed to colorScheme reactivity. Without it the read below uses
+  // getComputedStyle (one-shot, untracked) and the marker freezes at
+  // its mount-time value forever. The actual colour comes from the CSS
+  // token so the palette's light-dark() resolution stays the source of
+  // truth; this line just forces the computed to re-evaluate on scheme
+  // change.
   void colorScheme.value;
   return getComputedStyle(document.documentElement)
     .getPropertyValue('--primitives-color-coolgray-400').trim() || '#ccc';

--- a/frontend/src/components/LawGraphView.vue
+++ b/frontend/src/components/LawGraphView.vue
@@ -183,7 +183,12 @@ function handleNodeClick({ node, event }) {
 }
 
 function miniMapNodeColor(node) {
-  return node.class?.includes('root') && !node.hidden ? '#ccc' : 'transparent';
+  if (!(node.class?.includes('root') && !node.hidden)) return 'transparent';
+  // Resolve the palette token at call time so the marker swaps with the
+  // colour scheme — Vue Flow's MiniMap takes a flat colour string, not a
+  // CSS variable, so the var() can't live in the SVG attribute itself.
+  return getComputedStyle(document.documentElement)
+    .getPropertyValue('--primitives-color-coolgray-400').trim() || '#ccc';
 }
 
 const currentStep = computed(() =>
@@ -312,14 +317,14 @@ const currentStep = computed(() =>
 }
 
 .law-graph-loading {
-  background: var(--semantics-surfaces-tinted-background-color, #f5f5f5);
-  color: var(--semantics-text-color-secondary, #666);
+  background: var(--semantics-surfaces-tinted-background-color);
+  color: var(--semantics-content-secondary-color);
 }
 
 .law-graph-warning {
-  background: #fef3c7;
-  color: #92400e;
-  border: 1px solid #fde68a;
+  background: var(--primitives-color-donkergeel-100);
+  color: var(--primitives-color-donkergeel-800);
+  border: 1px solid var(--primitives-color-donkergeel-300);
   cursor: help;
 }
 
@@ -335,8 +340,9 @@ const currentStep = computed(() =>
   flex-direction: column;
   flex: 0 0 40vh;
   min-height: 220px;
-  border-top: 2px solid #f59e0b;
-  background: white;
+  border-top: 2px solid var(--primitives-color-donkergeel-500);
+  background: var(--semantics-surfaces-background-color);
+  color: var(--semantics-content-color);
   font-size: 13px;
 }
 
@@ -346,14 +352,15 @@ const currentStep = computed(() =>
   align-items: center;
   gap: 8px;
   padding: 6px 12px;
-  border-bottom: 1px solid #e5e7eb;
-  background: #fef3c7;
+  border-bottom: 1px solid var(--semantics-dividers-color);
+  background: var(--primitives-color-donkergeel-100);
 }
 
 .law-graph-trace__btn,
 .law-graph-trace__toggle {
-  border: 1px solid #9ca3af;
-  background: white;
+  border: 1px solid var(--primitives-color-coolgray-400);
+  background: var(--semantics-surfaces-background-color);
+  color: var(--semantics-content-color);
   border-radius: 4px;
   padding: 2px 8px;
   font-size: 12px;
@@ -361,16 +368,17 @@ const currentStep = computed(() =>
   font-family: inherit;
 }
 .law-graph-trace__btn:hover:not(:disabled),
-.law-graph-trace__toggle:hover { background: #f9fafb; }
+.law-graph-trace__toggle:hover { background: var(--semantics-surfaces-tinted-background-color); }
 .law-graph-trace__btn:disabled { opacity: 0.4; cursor: not-allowed; }
 
 .law-graph-trace__toggle--active {
-  border-color: #f59e0b;
-  background: #fef3c7;
+  border-color: var(--primitives-color-donkergeel-500);
+  background: var(--primitives-color-donkergeel-100);
+  color: var(--primitives-color-donkergeel-800);
   font-weight: 600;
 }
 
-.law-graph-trace__counter { color: #4b5563; }
+.law-graph-trace__counter { color: var(--semantics-content-secondary-color); }
 
 .law-graph-trace__filter {
   margin-left: auto;
@@ -378,7 +386,7 @@ const currentStep = computed(() =>
   align-items: center;
   gap: 4px;
   font-size: 12px;
-  color: #6b7280;
+  color: var(--semantics-content-secondary-color);
 }
 
 .law-graph-trace__body {
@@ -388,7 +396,7 @@ const currentStep = computed(() =>
 }
 .law-graph-trace__list {
   flex: 1;
-  border-right: 1px solid #e5e7eb;
+  border-right: 1px solid var(--semantics-dividers-color);
   min-width: 0;
   overflow: hidden;
 }

--- a/frontend/src/components/MachineReadable.test.js
+++ b/frontend/src/components/MachineReadable.test.js
@@ -74,8 +74,24 @@ async function clickBewerk(wrapper, index) {
   await buttons[index].trigger('click');
 }
 
-function findAddButton(wrapper, text) {
-  return wrapper.findAll('nldd-button').find((b) => b.attributes('text')?.includes(`Nieuwe ${text}`));
+// Add buttons all carry a stable data-testid (`add-{section}-btn`); using
+// it sidesteps copy churn — we changed labels from "Nieuwe X" to
+// "X toevoegen" and don't want the test to break on the next reword.
+const ADD_BTN_TESTID = {
+  definitie: 'add-def-btn',
+  parameter: 'add-param-btn',
+  input: 'add-input-btn',
+  output: 'add-output-btn',
+};
+function findAddButton(wrapper, section) {
+  return wrapper.find(`[data-testid="${ADD_BTN_TESTID[section]}"]`);
+}
+
+// The destructive button in the confirm modal that actually emits the
+// delete event. There's one per pendingDelete (the modal renders only
+// when something is staged) so a single global lookup is fine.
+function findConfirmDeleteButton(wrapper) {
+  return wrapper.find('nldd-button[variant="destructive"][text="Verwijder"]');
 }
 
 describe('MachineReadable', () => {
@@ -221,7 +237,8 @@ describe('MachineReadable', () => {
       const wrapper = mount(MachineReadable, {
         props: { article: createArticle(), editable: false },
       });
-      const addButtons = wrapper.findAll('nldd-button').filter((b) => b.attributes('text')?.includes('Nieuwe'));
+      // No add-X-btn data-testid should be present in read-only mode.
+      const addButtons = wrapper.findAll('[data-testid^="add-"][data-testid$="-btn"]');
       expect(addButtons.length).toBe(0);
     });
 
@@ -317,38 +334,53 @@ describe('MachineReadable', () => {
       expect(wrapper.findAll('[data-testid$="-delete-btn"]')).toHaveLength(0);
     });
 
-    it('emits delete with definition payload when the def minus is clicked', async () => {
+    // The minus icon now stages a confirmation in `pendingDelete` and the
+    // destructive button in the modal-dialog is what actually emits the
+    // delete event. Each test exercises that two-step flow so we cover the
+    // user-facing contract, not the internal staging state.
+    async function clickDeleteAndConfirm(wrapper, testid) {
+      await findDeleteByTestId(wrapper, testid).trigger('click');
+      await findConfirmDeleteButton(wrapper).trigger('click');
+    }
+
+    it('emits delete with definition payload after confirming', async () => {
       const wrapper = mountEditable();
-      await findDeleteByTestId(wrapper, 'def-drempelinkomen-delete-btn').trigger('click');
+      await clickDeleteAndConfirm(wrapper, 'def-drempelinkomen-delete-btn');
       const events = wrapper.emitted('delete');
       expect(events).toHaveLength(1);
       expect(events[0][0]).toEqual({ section: 'definition', key: 'drempelinkomen' });
     });
 
-    it('emits delete with parameter index payload', async () => {
+    it('does not emit delete on the minus click alone (waits for confirmation)', async () => {
       const wrapper = mountEditable();
-      await findDeleteByTestId(wrapper, 'param-bsn-delete-btn').trigger('click');
+      await findDeleteByTestId(wrapper, 'def-drempelinkomen-delete-btn').trigger('click');
+      expect(wrapper.emitted('delete')).toBeUndefined();
+    });
+
+    it('emits delete with parameter index payload after confirming', async () => {
+      const wrapper = mountEditable();
+      await clickDeleteAndConfirm(wrapper, 'param-bsn-delete-btn');
       const events = wrapper.emitted('delete');
       expect(events[0][0]).toEqual({ section: 'parameter', index: 0 });
     });
 
-    it('emits delete with input index payload', async () => {
+    it('emits delete with input index payload after confirming', async () => {
       const wrapper = mountEditable();
-      await findDeleteByTestId(wrapper, 'input-leeftijd-delete-btn').trigger('click');
+      await clickDeleteAndConfirm(wrapper, 'input-leeftijd-delete-btn');
       const events = wrapper.emitted('delete');
       expect(events[0][0]).toEqual({ section: 'input', index: 0 });
     });
 
-    it('emits delete with output index payload', async () => {
+    it('emits delete with output index payload after confirming', async () => {
       const wrapper = mountEditable();
-      await findDeleteByTestId(wrapper, 'output-heeft_recht-delete-btn').trigger('click');
+      await clickDeleteAndConfirm(wrapper, 'output-heeft_recht-delete-btn');
       const events = wrapper.emitted('delete');
       expect(events[0][0]).toEqual({ section: 'output', index: 0 });
     });
 
-    it('emits delete with action index payload', async () => {
+    it('emits delete with action index payload after confirming', async () => {
       const wrapper = mountEditable();
-      await findDeleteByTestId(wrapper, 'action-hoogte-delete-btn').trigger('click');
+      await clickDeleteAndConfirm(wrapper, 'action-hoogte-delete-btn');
       const events = wrapper.emitted('delete');
       expect(events[0][0]).toEqual({ section: 'action', index: 0 });
     });

--- a/frontend/src/components/MachineReadable.test.js
+++ b/frontend/src/components/MachineReadable.test.js
@@ -82,6 +82,7 @@ const ADD_BTN_TESTID = {
   parameter: 'add-param-btn',
   input: 'add-input-btn',
   output: 'add-output-btn',
+  action: 'add-action-btn',
 };
 function findAddButton(wrapper, section) {
   return wrapper.find(`[data-testid="${ADD_BTN_TESTID[section]}"]`);

--- a/frontend/src/components/MachineReadable.vue
+++ b/frontend/src/components/MachineReadable.vue
@@ -235,7 +235,9 @@ function addOutput() {
       <nldd-spacer size="12"></nldd-spacer>
       <nldd-list variant="box">
         <nldd-list-item v-for="def in definitions" :key="def.name" size="md">
-          <nldd-text-cell :text="`${def.name} = ${formatValue(def.value, def.unit)}`"></nldd-text-cell>
+          <nldd-text-cell :text="def.name"></nldd-text-cell>
+          <nldd-spacer-cell size="8"></nldd-spacer-cell>
+          <nldd-text-cell width="fit-content" horizontal-alignment="right" :text="formatValue(def.value, def.unit)"></nldd-text-cell>
           <nldd-spacer-cell v-if="editable" size="8"></nldd-spacer-cell>
           <nldd-cell v-if="editable">
             <div class="mr-row-actions">

--- a/frontend/src/components/MachineReadable.vue
+++ b/frontend/src/components/MachineReadable.vue
@@ -179,6 +179,13 @@ function confirmDelete() {
 }
 
 function cancelDelete() {
+  // Idempotent guard: the Behoud button's @click and the modal's @close
+  // both wire to this handler. Clicking Behoud sets pendingDelete = null,
+  // the watcher then calls el.hide(), which fires @close → cancelDelete
+  // again. Vue's ref equality check makes the second assignment a no-op
+  // today, but a future side-effect would silently double-fire without
+  // this early return.
+  if (pendingDelete.value === null) return;
   pendingDelete.value = null;
 }
 

--- a/frontend/src/components/MachineReadable.vue
+++ b/frontend/src/components/MachineReadable.vue
@@ -135,8 +135,16 @@ const pendingSectionLabel = computed(
 
 watch(pendingDelete, async (val) => {
   await nextTick();
-  if (val) deleteModalEl.value?.show();
-  else deleteModalEl.value?.hide();
+  // Guard against test envs where the modal-dialog custom element isn't
+  // upgraded — the ref then holds a plain HTMLElement without show/hide.
+  // Optional-chaining on `?.show()` would still throw because it only
+  // skips when `.value` is nullish, not when `.show` itself is undefined.
+  const el = deleteModalEl.value;
+  if (val) {
+    if (typeof el?.show === 'function') el.show();
+  } else {
+    if (typeof el?.hide === 'function') el.hide();
+  }
 });
 
 function deleteDef(name) {

--- a/frontend/src/components/MachineReadable.vue
+++ b/frontend/src/components/MachineReadable.vue
@@ -235,9 +235,7 @@ function addOutput() {
       <nldd-spacer size="12"></nldd-spacer>
       <nldd-list variant="box">
         <nldd-list-item v-for="def in definitions" :key="def.name" size="md">
-          <nldd-text-cell :text="def.name"></nldd-text-cell>
-          <nldd-spacer-cell size="8"></nldd-spacer-cell>
-          <nldd-text-cell width="fit-content" horizontal-alignment="right" :text="formatValue(def.value, def.unit)"></nldd-text-cell>
+          <nldd-text-cell :text="`${def.name} = ${formatValue(def.value, def.unit)}`"></nldd-text-cell>
           <nldd-spacer-cell v-if="editable" size="8"></nldd-spacer-cell>
           <nldd-cell v-if="editable">
             <div class="mr-row-actions">

--- a/frontend/src/components/MachineReadable.vue
+++ b/frontend/src/components/MachineReadable.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed } from 'vue';
+import { computed, ref, watch, nextTick } from 'vue';
 import { humanize } from '../utils/outputFormat.js';
 import { useCorpusLaws } from '../composables/useCorpusLaws.js';
 
@@ -114,27 +114,64 @@ function editOutput(index) {
   if (raw) emit('open-edit', { section: 'output', index, data: snapshot(raw) });
 }
 
-// Delete handlers — emit a delete event with the section + identity of
-// the row. The parent (EditorApp) is the source of truth for
-// machineReadable, so all mutations live there.
+// Delete handlers — stage a confirmation in `pendingDelete`, then on
+// confirm emit the delete event with the section + identity of the row.
+// The parent (EditorApp) is the source of truth for machineReadable,
+// so all mutations live there. The modal-dialog confirmation is here
+// because there is no undo yet.
+const SECTION_LABELS = {
+  definition: 'definitie',
+  parameter: 'parameter',
+  input: 'input',
+  output: 'output',
+  action: 'actie',
+};
+
+const pendingDelete = ref(null);
+const deleteModalEl = ref(null);
+const pendingSectionLabel = computed(
+  () => (pendingDelete.value ? SECTION_LABELS[pendingDelete.value.section] ?? '' : ''),
+);
+
+watch(pendingDelete, async (val) => {
+  await nextTick();
+  if (val) deleteModalEl.value?.show();
+  else deleteModalEl.value?.hide();
+});
+
 function deleteDef(name) {
-  emit('delete', { section: 'definition', key: name });
+  pendingDelete.value = { section: 'definition', key: name, label: `definitie '${name}'` };
 }
 
 function deleteParam(index) {
-  emit('delete', { section: 'parameter', index });
+  const p = parameters.value[index];
+  pendingDelete.value = { section: 'parameter', index, label: `parameter '${p?.name ?? index}'` };
 }
 
 function deleteInput(index) {
-  emit('delete', { section: 'input', index });
+  const i = inputs.value[index];
+  pendingDelete.value = { section: 'input', index, label: `input '${i?.name ?? index}'` };
 }
 
 function deleteOutput(index) {
-  emit('delete', { section: 'output', index });
+  const o = outputs.value[index];
+  pendingDelete.value = { section: 'output', index, label: `output '${o?.name ?? index}'` };
 }
 
 function deleteAction(index) {
-  emit('delete', { section: 'action', index });
+  const a = actions.value[index];
+  pendingDelete.value = { section: 'action', index, label: `actie '${a?.output ?? index}'` };
+}
+
+function confirmDelete() {
+  if (!pendingDelete.value) return;
+  const { label, ...payload } = pendingDelete.value;
+  emit('delete', payload);
+  pendingDelete.value = null;
+}
+
+function cancelDelete() {
+  pendingDelete.value = null;
 }
 
 // Open edit sheet for new items
@@ -199,6 +236,7 @@ function addOutput() {
       <nldd-list variant="box">
         <nldd-list-item v-for="def in definitions" :key="def.name" size="md">
           <nldd-text-cell :text="`${def.name} = ${formatValue(def.value, def.unit)}`"></nldd-text-cell>
+          <nldd-spacer-cell v-if="editable" size="8"></nldd-spacer-cell>
           <nldd-cell v-if="editable">
             <div class="mr-row-actions">
               <nldd-button @click="editDef(def.name)" text="Bewerk"></nldd-button>
@@ -213,7 +251,7 @@ function addOutput() {
         </nldd-list-item>
         <nldd-list-item v-if="editable" size="md">
           <nldd-cell width="stretch">
-            <nldd-button full-width start-icon="plus-small" data-testid="add-def-btn" @click="addDef" text="Nieuwe definitie"></nldd-button>
+            <nldd-button full-width start-icon="plus-small" data-testid="add-def-btn" @click="addDef" text="Definitie toevoegen"></nldd-button>
           </nldd-cell>
         </nldd-list-item>
       </nldd-list>
@@ -227,6 +265,7 @@ function addOutput() {
       <nldd-list variant="box">
         <nldd-list-item v-for="(param, index) in parameters" :key="param.name" size="md">
           <nldd-text-cell :text="`${param.name} (${param.type})`"></nldd-text-cell>
+          <nldd-spacer-cell v-if="editable" size="8"></nldd-spacer-cell>
           <nldd-cell v-if="editable">
             <div class="mr-row-actions">
               <nldd-button @click="editParam(index)" text="Bewerk"></nldd-button>
@@ -241,7 +280,7 @@ function addOutput() {
         </nldd-list-item>
         <nldd-list-item v-if="editable" size="md">
           <nldd-cell width="stretch">
-            <nldd-button full-width start-icon="plus-small" data-testid="add-param-btn" @click="addParam" text="Nieuwe parameter"></nldd-button>
+            <nldd-button full-width start-icon="plus-small" data-testid="add-param-btn" @click="addParam" text="Parameter toevoegen"></nldd-button>
           </nldd-cell>
         </nldd-list-item>
       </nldd-list>
@@ -258,6 +297,7 @@ function addOutput() {
             :text="`${input.name} (${input.type})`"
             :supporting-text="input.source ? lawDisplayName(input.source) : undefined"
           ></nldd-text-cell>
+          <nldd-spacer-cell v-if="editable" size="8"></nldd-spacer-cell>
           <nldd-cell v-if="editable">
             <div class="mr-row-actions">
               <nldd-button :data-testid="`input-${input.name}-edit-btn`" @click="editInput(index)" text="Bewerk"></nldd-button>
@@ -272,7 +312,7 @@ function addOutput() {
         </nldd-list-item>
         <nldd-list-item v-if="editable" size="md">
           <nldd-cell width="stretch">
-            <nldd-button full-width start-icon="plus-small" data-testid="add-input-btn" @click="addInput" text="Nieuwe input"></nldd-button>
+            <nldd-button full-width start-icon="plus-small" data-testid="add-input-btn" @click="addInput" text="Input toevoegen"></nldd-button>
           </nldd-cell>
         </nldd-list-item>
       </nldd-list>
@@ -286,6 +326,7 @@ function addOutput() {
       <nldd-list variant="box">
         <nldd-list-item v-for="(output, index) in outputs" :key="output.name" size="md">
           <nldd-text-cell :text="`${output.name} (${output.type})`"></nldd-text-cell>
+          <nldd-spacer-cell v-if="editable" size="8"></nldd-spacer-cell>
           <nldd-cell v-if="editable">
             <div class="mr-row-actions">
               <nldd-button @click="editOutput(index)" text="Bewerk"></nldd-button>
@@ -300,7 +341,7 @@ function addOutput() {
         </nldd-list-item>
         <nldd-list-item v-if="editable" size="md">
           <nldd-cell width="stretch">
-            <nldd-button full-width start-icon="plus-small" data-testid="add-output-btn" @click="addOutput" text="Nieuwe output"></nldd-button>
+            <nldd-button full-width start-icon="plus-small" data-testid="add-output-btn" @click="addOutput" text="Output toevoegen"></nldd-button>
           </nldd-cell>
         </nldd-list-item>
       </nldd-list>
@@ -320,6 +361,7 @@ function addOutput() {
           @click="!editable && emit('open-action', action)"
         >
           <nldd-text-cell :text="action.output"></nldd-text-cell>
+          <nldd-spacer-cell v-if="editable" size="8"></nldd-spacer-cell>
           <nldd-cell v-if="editable">
             <div class="mr-row-actions">
               <nldd-button :data-testid="`action-${action.output}-edit-btn`" @click="emit('open-action', action)" text="Bewerk"></nldd-button>
@@ -340,12 +382,23 @@ function addOutput() {
         </nldd-list-item>
         <nldd-list-item v-if="editable" size="md">
           <nldd-cell width="stretch">
-            <nldd-button full-width start-icon="plus-small" data-testid="add-action-btn" @click="emit('add-action')" text="Voeg actie toe"></nldd-button>
+            <nldd-button full-width start-icon="plus-small" data-testid="add-action-btn" @click="emit('add-action')" text="Actie toevoegen"></nldd-button>
           </nldd-cell>
         </nldd-list-item>
       </nldd-list>
     </template>
   </div>
+
+  <nldd-modal-dialog
+    ref="deleteModalEl"
+    variant="alert"
+    :text="pendingDelete ? `Weet je zeker dat je ${pendingDelete.label} wilt verwijderen?` : ''"
+    supporting-text="Deze actie kan niet ongedaan gemaakt worden."
+    @close="cancelDelete"
+  >
+    <nldd-button slot="actions" variant="primary" :text="`Behoud ${pendingSectionLabel}`" @click="cancelDelete"></nldd-button>
+    <nldd-button slot="actions" variant="destructive" text="Verwijder" @click="confirmDelete"></nldd-button>
+  </nldd-modal-dialog>
 </template>
 
 <style scoped>

--- a/frontend/src/components/MachineReadable.vue
+++ b/frontend/src/components/MachineReadable.vue
@@ -235,8 +235,15 @@ function addOutput() {
       <nldd-spacer size="12"></nldd-spacer>
       <nldd-list variant="box">
         <nldd-list-item v-for="def in definitions" :key="def.name" size="md">
-          <nldd-text-cell :text="`${def.name} = ${formatValue(def.value, def.unit)}`"></nldd-text-cell>
-          <nldd-spacer-cell v-if="editable" size="8"></nldd-spacer-cell>
+          <template v-if="editable">
+            <nldd-text-cell :text="`${def.name} = ${formatValue(def.value, def.unit)}`"></nldd-text-cell>
+            <nldd-spacer-cell size="8"></nldd-spacer-cell>
+          </template>
+          <template v-else>
+            <nldd-text-cell :text="def.name"></nldd-text-cell>
+            <nldd-spacer-cell size="8"></nldd-spacer-cell>
+            <nldd-text-cell width="fit-content" horizontal-alignment="right" :text="formatValue(def.value, def.unit)"></nldd-text-cell>
+          </template>
           <nldd-cell v-if="editable">
             <div class="mr-row-actions">
               <nldd-button @click="editDef(def.name)" text="Bewerk"></nldd-button>

--- a/frontend/src/components/OperationSettings.vue
+++ b/frontend/src/components/OperationSettings.vue
@@ -533,8 +533,8 @@ function addNestedOperation() {
       <!-- Add value -->
       <nldd-list-item v-if="canAddValue || canAddNestedOperation" size="md">
         <div class="add-value-buttons">
-          <nldd-button v-if="canAddValue" size="md" start-icon="plus-small" data-testid="add-value-btn" @click="addValue" text="Voeg waarde toe"></nldd-button>
-          <nldd-button v-if="canAddNestedOperation" size="md" start-icon="plus-small" data-testid="add-nested-op-btn" @click="addNestedOperation" text="Voeg operatie toe"></nldd-button>
+          <nldd-button v-if="canAddValue" size="md" start-icon="plus-small" data-testid="add-value-btn" @click="addValue" text="Waarde toevoegen"></nldd-button>
+          <nldd-button v-if="canAddNestedOperation" size="md" start-icon="plus-small" data-testid="add-nested-op-btn" @click="addNestedOperation" text="Operatie toevoegen"></nldd-button>
         </div>
       </nldd-list-item>
     </nldd-list>

--- a/frontend/src/components/ScenarioBuilder.vue
+++ b/frontend/src/components/ScenarioBuilder.vue
@@ -373,7 +373,7 @@ defineExpose({ save: onSave });
 
       <nldd-inline-dialog
         v-else-if="!scenariosLoading && !depsLoading"
-        text="Geen scenario's beschikbaar voor deze wet."
+        text="Geen scenario's beschikbaar voor dit artikel."
       ></nldd-inline-dialog>
     </nldd-simple-section>
 

--- a/frontend/src/components/ScenarioBuilder.vue
+++ b/frontend/src/components/ScenarioBuilder.vue
@@ -208,7 +208,9 @@ watch(
 );
 
 // --- Details handler: emit to right panel ---
-function onShowDetails(index) {
+// `view` indicates which sheet the parent should open: 'trace' for
+// the execution-trace sheet (default), 'graph' for the law-graph sheet.
+function onShowDetails(index, view = 'trace') {
   // Prefer fresh data from the form ref, but its state may have been reset
   // after a save/reload — fall back to the cached result in that case.
   const formRef = scenarioRefs.value[index];
@@ -226,6 +228,7 @@ function onShowDetails(index) {
       // Forward the scenario's entry output so the graph view can pin
       // its "▶ start" marker to the right output leaf.
       outputName: data.outputName || null,
+      view,
     });
   }
 }
@@ -359,7 +362,12 @@ defineExpose({ save: onSave });
                   variant="primary"
                   :disabled="!scenarioResults.get(i) || undefined"
                   text="Toon resultaat"
-                  @click="onShowDetails(i)"
+                  @click="onShowDetails(i, 'trace')"
+                ></nldd-button>
+                <nldd-button
+                  :disabled="!scenarioResults.get(i) || undefined"
+                  text="Graaf"
+                  @click="onShowDetails(i, 'graph')"
                 ></nldd-button>
                 <nldd-button
                   text="Bewerk"
@@ -385,6 +393,7 @@ defineExpose({ save: onSave });
       ref="scenarioSheetEl"
       placement="right"
       width="640px"
+      full-height
       @close="cancelEdits"
     >
       <nldd-page sticky-header :sticky-footer="isDirty || undefined">

--- a/frontend/src/components/ScenarioBuilder.vue
+++ b/frontend/src/components/ScenarioBuilder.vue
@@ -365,6 +365,7 @@ defineExpose({ save: onSave });
                   @click="onShowDetails(i, 'trace')"
                 ></nldd-button>
                 <nldd-button
+                  variant="secondary"
                   :disabled="!scenarioResults.get(i) || undefined"
                   text="Graaf"
                   @click="onShowDetails(i, 'graph')"

--- a/frontend/src/components/YamlView.vue
+++ b/frontend/src/components/YamlView.vue
@@ -15,19 +15,5 @@ const yamlText = computed(() => {
 
 <template>
   <nldd-inline-dialog v-if="!yamlText" text="Geen machine-leesbare gegevens voor dit artikel"></nldd-inline-dialog>
-  <pre v-else class="yaml-source"><code>{{ yamlText }}</code></pre>
+  <nldd-code v-else language="yaml">{{ yamlText }}</nldd-code>
 </template>
-
-<style>
-.yaml-source {
-  background: var(--semantics-surfaces-tinted-background-color, #F4F6F9);
-  border-radius: 12px;
-  padding: 16px;
-  font-size: 13px;
-  line-height: 1.5;
-  overflow-x: auto;
-  white-space: pre-wrap;
-  word-break: break-word;
-  margin: 0;
-}
-</style>

--- a/frontend/src/components/graph/LawNode.vue
+++ b/frontend/src/components/graph/LawNode.vue
@@ -30,9 +30,13 @@ defineProps({
   float: right;
   cursor: pointer;
   border-radius: 6px;
-  background: rgba(2, 6, 23, 0.65);
+  /* Translucent ink so the close button sits on any service colour
+   * (light or dark mode) without a per-mode override. color-mix on
+   * --semantics-content-color picks up the theme's high-contrast
+   * ink — black-ish in light, white-ish in dark — at 65% opacity. */
+  background: color-mix(in oklch, var(--semantics-content-color), transparent 35%);
   padding: 4px;
-  color: white;
+  color: var(--semantics-surfaces-background-color);
   border: 0;
   line-height: 0;
 }

--- a/frontend/src/components/graph/LawNode.vue
+++ b/frontend/src/components/graph/LawNode.vue
@@ -33,7 +33,15 @@ defineProps({
   /* Translucent ink so the close button sits on any service colour
    * (light or dark mode) without a per-mode override. color-mix on
    * --semantics-content-color picks up the theme's high-contrast
-   * ink — black-ish in light, white-ish in dark — at 65% opacity. */
+   * ink — black-ish in light, white-ish in dark — at 65% opacity.
+   *
+   * color-mix(in oklch, ...) needs Chrome 111+/FF 113+/Safari 16.2+,
+   * which is strictly within the design system's existing light-dark()
+   * floor (Chrome 123+/FF 120+/Safari 17.5+) — anything that can paint
+   * the rest of the page can paint this too. The fallback color
+   * declaration below makes the button visible on the (long-defunct)
+   * older browsers that load this stylesheet but can't parse color-mix. */
+  background: var(--semantics-content-color);
   background: color-mix(in oklch, var(--semantics-content-color), transparent 35%);
   padding: 4px;
   color: var(--semantics-surfaces-background-color);

--- a/frontend/src/components/graph/TraceStepDetail.vue
+++ b/frontend/src/components/graph/TraceStepDetail.vue
@@ -90,14 +90,16 @@ const expectationEntries = computed(() => Object.entries(props.expectations || {
 .step-detail {
   overflow-y: auto;
   padding: 12px;
-  background: var(--semantics-surfaces-tinted-background-color, #f9fafb);
+  background: var(--semantics-surfaces-tinted-background-color);
+  color: var(--semantics-content-color);
   font-size: 12px;
 }
 
 .step-detail__card {
   margin-bottom: 12px;
-  border: 1px solid #fcd34d;
-  background: #fef3c7;
+  border: 1px solid var(--primitives-color-donkergeel-300);
+  background: var(--primitives-color-donkergeel-100);
+  color: var(--primitives-color-donkergeel-900);
   border-radius: 6px;
   padding: 8px;
 }
@@ -137,30 +139,30 @@ const expectationEntries = computed(() => Object.entries(props.expectations || {
 }
 .step-detail__row dt {
   width: 80px;
-  color: #6b7280;
+  color: var(--semantics-content-secondary-color);
   flex-shrink: 0;
 }
 .step-detail__row dd {
   margin: 0;
-  color: #111827;
+  color: var(--semantics-content-color);
   min-width: 0;
   word-break: break-word;
 }
 
 .mono { font-family: 'SF Mono', 'Fira Code', monospace; }
-.indigo { color: #4f46e5; }
-.emerald { color: #047857; }
-.italic { font-style: italic; color: #6b7280; }
+.indigo { color: var(--primitives-color-paars-700); }
+.emerald { color: var(--primitives-color-mintgroen-700); }
+.italic { font-style: italic; color: var(--semantics-content-secondary-color); }
 
 .step-detail__section-title {
   margin: 8px 0 4px;
   font-size: 12px;
   font-weight: 600;
-  color: #374151;
+  color: var(--semantics-content-color);
 }
 
 .step-detail__empty {
-  color: #9ca3af;
+  color: var(--semantics-content-secondary-color);
   font-style: italic;
   font-size: 11px;
 }
@@ -183,7 +185,7 @@ const expectationEntries = computed(() => Object.entries(props.expectations || {
   font-weight: 700;
 }
 .step-detail__marker.pass,
-.pass { color: #047857; }
+.pass { color: var(--primitives-color-mintgroen-700); }
 .step-detail__marker.fail,
-.fail { color: #dc2626; }
+.fail { color: var(--primitives-color-rood-600); }
 </style>

--- a/frontend/src/components/graph/TraceStepList.vue
+++ b/frontend/src/components/graph/TraceStepList.vue
@@ -91,19 +91,20 @@ watch(
   display: block;
   width: 100%;
   border: 0;
-  border-bottom: 1px solid #f3f4f6;
+  border-bottom: 1px solid var(--semantics-dividers-color);
   background: transparent;
+  color: var(--semantics-content-color);
   padding: 4px 12px;
   text-align: left;
   font-size: 12px;
   cursor: pointer;
   font-family: inherit;
 }
-.step-row:hover { background: #f9fafb; }
+.step-row:hover { background: var(--semantics-surfaces-tinted-background-color); }
 .step-row--active {
-  background: #fef3c7;
+  background: var(--primitives-color-donkergeel-100);
   font-weight: 600;
-  color: #78350f;
+  color: var(--primitives-color-donkergeel-800);
 }
 
 .step-row__head {
@@ -118,7 +119,7 @@ watch(
   display: inline-block;
   width: 28px;
   text-align: right;
-  color: #9ca3af;
+  color: var(--semantics-content-secondary-color);
 }
 .step-row__chip {
   font-size: 10px;
@@ -130,12 +131,12 @@ watch(
 .step-row__name { overflow: hidden; text-overflow: ellipsis; }
 .step-row__resolve {
   font-size: 10px;
-  color: #4f46e5;
+  color: var(--primitives-color-paars-700);
 }
 .step-row__result {
   padding-left: 32px;
   font-size: 11px;
-  color: #047857;
+  color: var(--primitives-color-mintgroen-700);
   overflow: hidden;
   text-overflow: ellipsis;
 }
@@ -143,19 +144,19 @@ watch(
   padding-left: 32px;
   font-size: 10px;
   font-style: italic;
-  color: #6b7280;
+  color: var(--semantics-content-secondary-color);
   overflow: hidden;
   text-overflow: ellipsis;
 }
 .step-row__counts {
   padding-left: 32px;
   font-size: 10px;
-  color: #d97706;
+  color: var(--primitives-color-donkergeel-700);
 }
 
 .step-list__empty {
   padding: 16px;
   font-size: 12px;
-  color: var(--semantics-text-color-secondary, #6b7280);
+  color: var(--semantics-content-secondary-color);
 }
 </style>

--- a/frontend/src/components/graph/graph-styles.css
+++ b/frontend/src/components/graph/graph-styles.css
@@ -10,45 +10,54 @@
  *
  * Trace-stepping highlights (.trace-active, .trace-visited, .trace-start)
  * are applied via the `class` prop on nodes/edges from useTraceStepping.
+ *
+ * Dark-mode strategy: every color is sourced from the design-system
+ * palette tokens, which use light-dark() under the hood. -700 borders
+ * stay dark on light bg / light on dark bg; -100 backgrounds stay pale
+ * on light / deep-tinted on dark. Both flip together so the contrast
+ * pattern survives the scheme switch without per-mode forks.
  */
 
 .vue-flow .root {
-  border-radius: 6px;
-  border: 1px solid black;
-  padding: 8px;
+	border-radius: 6px;
+	border: 1px solid var(--semantics-content-color);
+	padding: 8px;
+	color: var(--semantics-content-color);
 }
 
 /* Service colors — one per regulatory_layer index (see LAYER_COLOR_INDEX
- * in useLawGraph.js). Chosen from Tailwind's palette so the editor and
- * the demo read the same. */
-.vue-flow .service-0.root { border-color: #1e40af; background: #eff6ff; }
-.vue-flow .service-0.property-group { border: 1px solid #1e40af; background: #dbeafe; }
-.vue-flow .service-1.root { border-color: #9d174d; background: #fdf2f8; }
-.vue-flow .service-1.property-group { border: 1px solid #9d174d; background: #fce7f3; }
-.vue-flow .service-2.root { border-color: #065f46; background: #ecfdf5; }
-.vue-flow .service-2.property-group { border: 1px solid #065f46; background: #d1fae5; }
-.vue-flow .service-3.root { border-color: #92400e; background: #fffbeb; }
-.vue-flow .service-3.property-group { border: 1px solid #92400e; background: #fef3c7; }
-.vue-flow .service-4.root { border-color: #6b21a8; background: #faf5ff; }
-.vue-flow .service-4.property-group { border: 1px solid #6b21a8; background: #f3e8ff; }
-.vue-flow .service-5.root { border-color: #854d0e; background: #fefce8; }
-.vue-flow .service-5.property-group { border: 1px solid #854d0e; background: #fef9c3; }
-.vue-flow .service-6.root { border-color: #1e293b; background: #f8fafc; }
-.vue-flow .service-6.property-group { border: 1px solid #1e293b; background: #f1f5f9; }
+ * in useLawGraph.js). Each hue maps to a NLDD palette family; the -700
+ * border + -100 background combo auto-flips for dark mode through the
+ * baked-in light-dark() in palettes.generated.css. */
+.vue-flow .service-0.root { border-color: var(--primitives-color-lintblauw-700); background: var(--primitives-color-lintblauw-100); }
+.vue-flow .service-0.property-group { border: 1px solid var(--primitives-color-lintblauw-700); background: var(--primitives-color-lintblauw-200); }
+.vue-flow .service-1.root { border-color: var(--primitives-color-violet-700); background: var(--primitives-color-violet-100); }
+.vue-flow .service-1.property-group { border: 1px solid var(--primitives-color-violet-700); background: var(--primitives-color-violet-200); }
+.vue-flow .service-2.root { border-color: var(--primitives-color-mintgroen-700); background: var(--primitives-color-mintgroen-100); }
+.vue-flow .service-2.property-group { border: 1px solid var(--primitives-color-mintgroen-700); background: var(--primitives-color-mintgroen-200); }
+.vue-flow .service-3.root { border-color: var(--primitives-color-donkergeel-700); background: var(--primitives-color-donkergeel-100); }
+.vue-flow .service-3.property-group { border: 1px solid var(--primitives-color-donkergeel-700); background: var(--primitives-color-donkergeel-200); }
+.vue-flow .service-4.root { border-color: var(--primitives-color-paars-700); background: var(--primitives-color-paars-100); }
+.vue-flow .service-4.property-group { border: 1px solid var(--primitives-color-paars-700); background: var(--primitives-color-paars-200); }
+.vue-flow .service-5.root { border-color: var(--primitives-color-geel-700); background: var(--primitives-color-geel-100); }
+.vue-flow .service-5.property-group { border: 1px solid var(--primitives-color-geel-700); background: var(--primitives-color-geel-200); }
+.vue-flow .service-6.root { border-color: var(--primitives-color-coolgray-700); background: var(--primitives-color-coolgray-100); }
+.vue-flow .service-6.property-group { border: 1px solid var(--primitives-color-coolgray-700); background: var(--primitives-color-coolgray-200); }
 
 .vue-flow .property-group,
 .vue-flow .vue-flow__node-input,
 .vue-flow .vue-flow__node-source,
 .vue-flow .vue-flow__node-output {
-  cursor: grab;
-  overflow: hidden;
-  text-overflow: ellipsis;
+	cursor: grab;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	color: var(--semantics-content-color);
 }
 
 .vue-flow {
-  --vf-edge-stroke: #3b82f6;
-  --vf-edge-stroke-selected: #1d4ed8;
-  --vf-edge-stroke-width: 3;
+	--vf-edge-stroke: var(--primitives-color-lintblauw-500);
+	--vf-edge-stroke-selected: var(--primitives-color-lintblauw-700);
+	--vf-edge-stroke-width: 3;
 }
 
 /* Arrowhead color is set per-edge via `markerEnd.color` in useLawGraph.js
@@ -57,23 +66,23 @@
  * arrowhead to sky-blue regardless of stroke. */
 
 .vue-flow__edge.selected {
-  --vf-edge-stroke-width: 5;
+	--vf-edge-stroke-width: 5;
 }
 
 /* Click-highlight: inbound = edges that come into the clicked law,
  * outbound = edges that leave it. Thicker + color-swapped so the
  * direction is unambiguous at a glance. */
 .vue-flow__edge.inbound path {
-  stroke: #ef4444 !important;
-  stroke-width: 5 !important;
+	stroke: var(--primitives-color-rood-500) !important;
+	stroke-width: 5 !important;
 }
 .vue-flow__edge.outbound path {
-  stroke: #22c55e !important;
-  stroke-width: 5 !important;
+	stroke: var(--primitives-color-groen-500) !important;
+	stroke-width: 5 !important;
 }
 .vue-flow__edge.inbound path:first-child,
 .vue-flow__edge.outbound path:first-child {
-  marker-end: none;
+	marker-end: none;
 }
 
 /* --- Trace stepping highlights -------------------------------------- */
@@ -81,90 +90,98 @@
 /* Active edge pulses amber. !important overrides the per-edge inline
  * stroke that impl/override/hook edges set so the trace path always wins. */
 .vue-flow__edge.trace-active path {
-  stroke: #f59e0b !important;
-  /* Match the keyframe start so the first paint frame doesn't flash
-   * the inherited (thinner) edge width before the animation begins. */
-  stroke-width: 6 !important;
-  stroke-dasharray: none !important;
-  animation: trace-pulse 1.2s ease-in-out infinite;
+	stroke: var(--primitives-color-donkergeel-500) !important;
+	/* Match the keyframe start so the first paint frame doesn't flash
+	 * the inherited (thinner) edge width before the animation begins. */
+	stroke-width: 6 !important;
+	stroke-dasharray: none !important;
+	animation: trace-pulse 1.2s ease-in-out infinite;
 }
 .vue-flow__edge.trace-visited path {
-  stroke: #fbbf24 !important;
-  stroke-width: 4 !important;
-  opacity: 0.75;
+	stroke: var(--primitives-color-donkergeel-300) !important;
+	stroke-width: 4 !important;
+	opacity: 0.75;
 }
 @keyframes trace-pulse {
-  0%, 100% { stroke-width: 6; }
-  50% { stroke-width: 10; }
+	0%, 100% { stroke-width: 6; }
+	50% { stroke-width: 10; }
 }
 
 /* Active node: leaves get a solid amber fill; law/group containers get
  * an outline + glow so nested content stays visible. */
 .vue-flow__node.trace-active {
-  z-index: 10;
+	z-index: 10;
 }
 .vue-flow__node-leaf.trace-active {
-  background: #f59e0b !important;
-  color: #1f2937 !important;
-  font-weight: 700 !important;
-  outline: 3px solid #b45309 !important;
-  outline-offset: 0 !important;
-  box-shadow: 0 0 20px rgba(245, 158, 11, 0.8) !important;
+	background: var(--primitives-color-donkergeel-500) !important;
+	color: var(--primitives-color-donkergeel-900) !important;
+	font-weight: 700 !important;
+	outline: 3px solid var(--primitives-color-donkergeel-700) !important;
+	outline-offset: 0 !important;
+	box-shadow: 0 0 20px color-mix(in oklch, var(--primitives-color-donkergeel-500), transparent 20%) !important;
 }
 .vue-flow__node-law.trace-active,
 .vue-flow__node-default.trace-active {
-  outline: 4px solid #f59e0b !important;
-  outline-offset: 2px !important;
-  box-shadow: 0 0 24px rgba(245, 158, 11, 0.75) !important;
+	outline: 4px solid var(--primitives-color-donkergeel-500) !important;
+	outline-offset: 2px !important;
+	box-shadow: 0 0 24px color-mix(in oklch, var(--primitives-color-donkergeel-500), transparent 25%) !important;
 }
 
 .vue-flow__node-leaf.trace-visited {
-  background: #fde68a !important;
-  color: #78350f !important;
+	background: var(--primitives-color-donkergeel-200) !important;
+	color: var(--primitives-color-donkergeel-800) !important;
 }
 .vue-flow__node-law.trace-visited,
 .vue-flow__node-default.trace-visited {
-  outline: 2px solid #fbbf24 !important;
-  outline-offset: 1px !important;
+	outline: 2px solid var(--primitives-color-donkergeel-300) !important;
+	outline-offset: 1px !important;
 }
 
 /* Start point — sticky dashed blue outline + "▶ start" label on the
  * scenario's root law and initial output leaf. Stays visible across
  * all steps so users can always see where the trace began. */
 .vue-flow__node.trace-start {
-  outline: 3px dashed #2563eb;
-  outline-offset: 4px;
-  z-index: 9;
+	outline: 3px dashed var(--primitives-color-lintblauw-600);
+	outline-offset: 4px;
+	z-index: 9;
 }
 .vue-flow__node.trace-start::before {
-  content: '▶ start';
-  position: absolute;
-  top: -18px;
-  left: -4px;
-  background: #2563eb;
-  color: white;
-  font-size: 10px;
-  font-weight: 700;
-  padding: 1px 6px;
-  border-radius: 3px;
-  letter-spacing: 0.04em;
-  pointer-events: none;
-  z-index: 11;
+	content: '▶ start';
+	position: absolute;
+	top: -18px;
+	left: -4px;
+	background: var(--primitives-color-lintblauw-600);
+	/* Use neutral-0 so the label stays white-on-blue in light mode and
+	 * picks up the auto-flipped near-black on light-blue in dark mode —
+	 * both retain comfortable contrast against the auto-adjusted bg. */
+	color: var(--primitives-color-neutral-0);
+	font-size: 10px;
+	font-weight: 700;
+	padding: 1px 6px;
+	border-radius: 3px;
+	letter-spacing: 0.04em;
+	pointer-events: none;
+	z-index: 11;
 }
 /* Combine outlines cleanly when a start node is also active. */
 .vue-flow__node.trace-start.trace-active {
-  outline: 3px solid #f59e0b;
-  box-shadow: 0 0 0 7px rgba(37, 99, 235, 0.35), 0 0 16px rgba(245, 158, 11, 0.55);
+	outline: 3px solid var(--primitives-color-donkergeel-500);
+	box-shadow:
+		0 0 0 7px color-mix(in oklch, var(--primitives-color-lintblauw-600), transparent 65%),
+		0 0 16px color-mix(in oklch, var(--primitives-color-donkergeel-500), transparent 45%);
 }
 
-/* Step-type chips used by the left-side step list. */
-.node-type-article { background: #bfdbfe; color: #1e3a8a; }
-.node-type-action { background: #a7f3d0; color: #065f46; }
-.node-type-requirement { background: #bae6fd; color: #0c4a6e; }
-.node-type-resolve { background: #e2e8f0; color: #334155; }
-.node-type-operation { background: #e5e7eb; color: #374151; }
-.node-type-cached { background: #f3f4f6; color: #4b5563; }
-.node-type-cross_law_reference { background: #fde68a; color: #92400e; }
-.node-type-open_term_resolution { background: #bbf7d0; color: #166534; }
-.node-type-hook_resolution { background: #e9d5ff; color: #5b21b6; }
-.node-type-override_resolution { background: #fecaca; color: #991b1b; }
+/* Step-type chips used by the left-side step list. Each chip uses the
+ * same hue at -200 (pale tint) for background and -800 (saturated) for
+ * text. Both flip together in dark mode, keeping the legibility pattern
+ * intact without writing a separate dark theme. */
+.node-type-article { background: var(--primitives-color-lintblauw-200); color: var(--primitives-color-lintblauw-800); }
+.node-type-action { background: var(--primitives-color-mintgroen-200); color: var(--primitives-color-mintgroen-800); }
+.node-type-requirement { background: var(--primitives-color-donkerblauw-200); color: var(--primitives-color-donkerblauw-800); }
+.node-type-resolve { background: var(--primitives-color-coolgray-200); color: var(--primitives-color-coolgray-800); }
+.node-type-operation { background: var(--primitives-color-coolgray-100); color: var(--primitives-color-coolgray-700); }
+.node-type-cached { background: var(--primitives-color-coolgray-100); color: var(--primitives-color-coolgray-600); }
+.node-type-cross_law_reference { background: var(--primitives-color-donkergeel-200); color: var(--primitives-color-donkergeel-800); }
+.node-type-open_term_resolution { background: var(--primitives-color-groen-200); color: var(--primitives-color-groen-800); }
+.node-type-hook_resolution { background: var(--primitives-color-paars-200); color: var(--primitives-color-paars-800); }
+.node-type-override_resolution { background: var(--primitives-color-rood-200); color: var(--primitives-color-rood-800); }

--- a/frontend/src/components/graph/graph-styles.css
+++ b/frontend/src/components/graph/graph-styles.css
@@ -16,6 +16,13 @@
  * stay dark on light bg / light on dark bg; -100 backgrounds stay pale
  * on light / deep-tinted on dark. Both flip together so the contrast
  * pattern survives the scheme switch without per-mode forks.
+ *
+ * Browser floor: light-dark() (Chrome 123+/FF 120+/Safari 17.5+) is
+ * already the design system's minimum. The color-mix(in oklch, …) glow
+ * effects below need only Chrome 111+/FF 113+/Safari 16.2+, so they're
+ * strictly inside that floor. On the rare browser old enough to skip
+ * the glow but still load this stylesheet, the trace highlight outline
+ * + background remain — the missing shadow degrades cleanly.
  */
 
 .vue-flow .root {

--- a/frontend/src/components/graph/graph-styles.css
+++ b/frontend/src/components/graph/graph-styles.css
@@ -19,10 +19,10 @@
  */
 
 .vue-flow .root {
-	border-radius: 6px;
-	border: 1px solid var(--semantics-content-color);
-	padding: 8px;
-	color: var(--semantics-content-color);
+  border-radius: 6px;
+  border: 1px solid var(--semantics-content-color);
+  padding: 8px;
+  color: var(--semantics-content-color);
 }
 
 /* Service colors — one per regulatory_layer index (see LAYER_COLOR_INDEX
@@ -48,16 +48,16 @@
 .vue-flow .vue-flow__node-input,
 .vue-flow .vue-flow__node-source,
 .vue-flow .vue-flow__node-output {
-	cursor: grab;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	color: var(--semantics-content-color);
+  cursor: grab;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--semantics-content-color);
 }
 
 .vue-flow {
-	--vf-edge-stroke: var(--primitives-color-lintblauw-500);
-	--vf-edge-stroke-selected: var(--primitives-color-lintblauw-700);
-	--vf-edge-stroke-width: 3;
+  --vf-edge-stroke: var(--primitives-color-lintblauw-500);
+  --vf-edge-stroke-selected: var(--primitives-color-lintblauw-700);
+  --vf-edge-stroke-width: 3;
 }
 
 /* Arrowhead color is set per-edge via `markerEnd.color` in useLawGraph.js
@@ -66,23 +66,23 @@
  * arrowhead to sky-blue regardless of stroke. */
 
 .vue-flow__edge.selected {
-	--vf-edge-stroke-width: 5;
+  --vf-edge-stroke-width: 5;
 }
 
 /* Click-highlight: inbound = edges that come into the clicked law,
  * outbound = edges that leave it. Thicker + color-swapped so the
  * direction is unambiguous at a glance. */
 .vue-flow__edge.inbound path {
-	stroke: var(--primitives-color-rood-500) !important;
-	stroke-width: 5 !important;
+  stroke: var(--primitives-color-rood-500) !important;
+  stroke-width: 5 !important;
 }
 .vue-flow__edge.outbound path {
-	stroke: var(--primitives-color-groen-500) !important;
-	stroke-width: 5 !important;
+  stroke: var(--primitives-color-groen-500) !important;
+  stroke-width: 5 !important;
 }
 .vue-flow__edge.inbound path:first-child,
 .vue-flow__edge.outbound path:first-child {
-	marker-end: none;
+  marker-end: none;
 }
 
 /* --- Trace stepping highlights -------------------------------------- */
@@ -90,85 +90,85 @@
 /* Active edge pulses amber. !important overrides the per-edge inline
  * stroke that impl/override/hook edges set so the trace path always wins. */
 .vue-flow__edge.trace-active path {
-	stroke: var(--primitives-color-donkergeel-500) !important;
-	/* Match the keyframe start so the first paint frame doesn't flash
-	 * the inherited (thinner) edge width before the animation begins. */
-	stroke-width: 6 !important;
-	stroke-dasharray: none !important;
-	animation: trace-pulse 1.2s ease-in-out infinite;
+  stroke: var(--primitives-color-donkergeel-500) !important;
+  /* Match the keyframe start so the first paint frame doesn't flash
+   * the inherited (thinner) edge width before the animation begins. */
+  stroke-width: 6 !important;
+  stroke-dasharray: none !important;
+  animation: trace-pulse 1.2s ease-in-out infinite;
 }
 .vue-flow__edge.trace-visited path {
-	stroke: var(--primitives-color-donkergeel-300) !important;
-	stroke-width: 4 !important;
-	opacity: 0.75;
+  stroke: var(--primitives-color-donkergeel-300) !important;
+  stroke-width: 4 !important;
+  opacity: 0.75;
 }
 @keyframes trace-pulse {
-	0%, 100% { stroke-width: 6; }
-	50% { stroke-width: 10; }
+  0%, 100% { stroke-width: 6; }
+  50% { stroke-width: 10; }
 }
 
 /* Active node: leaves get a solid amber fill; law/group containers get
  * an outline + glow so nested content stays visible. */
 .vue-flow__node.trace-active {
-	z-index: 10;
+  z-index: 10;
 }
 .vue-flow__node-leaf.trace-active {
-	background: var(--primitives-color-donkergeel-500) !important;
-	color: var(--primitives-color-donkergeel-900) !important;
-	font-weight: 700 !important;
-	outline: 3px solid var(--primitives-color-donkergeel-700) !important;
-	outline-offset: 0 !important;
-	box-shadow: 0 0 20px color-mix(in oklch, var(--primitives-color-donkergeel-500), transparent 20%) !important;
+  background: var(--primitives-color-donkergeel-500) !important;
+  color: var(--primitives-color-donkergeel-900) !important;
+  font-weight: 700 !important;
+  outline: 3px solid var(--primitives-color-donkergeel-700) !important;
+  outline-offset: 0 !important;
+  box-shadow: 0 0 20px color-mix(in oklch, var(--primitives-color-donkergeel-500), transparent 20%) !important;
 }
 .vue-flow__node-law.trace-active,
 .vue-flow__node-default.trace-active {
-	outline: 4px solid var(--primitives-color-donkergeel-500) !important;
-	outline-offset: 2px !important;
-	box-shadow: 0 0 24px color-mix(in oklch, var(--primitives-color-donkergeel-500), transparent 25%) !important;
+  outline: 4px solid var(--primitives-color-donkergeel-500) !important;
+  outline-offset: 2px !important;
+  box-shadow: 0 0 24px color-mix(in oklch, var(--primitives-color-donkergeel-500), transparent 25%) !important;
 }
 
 .vue-flow__node-leaf.trace-visited {
-	background: var(--primitives-color-donkergeel-200) !important;
-	color: var(--primitives-color-donkergeel-800) !important;
+  background: var(--primitives-color-donkergeel-200) !important;
+  color: var(--primitives-color-donkergeel-800) !important;
 }
 .vue-flow__node-law.trace-visited,
 .vue-flow__node-default.trace-visited {
-	outline: 2px solid var(--primitives-color-donkergeel-300) !important;
-	outline-offset: 1px !important;
+  outline: 2px solid var(--primitives-color-donkergeel-300) !important;
+  outline-offset: 1px !important;
 }
 
 /* Start point — sticky dashed blue outline + "▶ start" label on the
  * scenario's root law and initial output leaf. Stays visible across
  * all steps so users can always see where the trace began. */
 .vue-flow__node.trace-start {
-	outline: 3px dashed var(--primitives-color-lintblauw-600);
-	outline-offset: 4px;
-	z-index: 9;
+  outline: 3px dashed var(--primitives-color-lintblauw-600);
+  outline-offset: 4px;
+  z-index: 9;
 }
 .vue-flow__node.trace-start::before {
-	content: '▶ start';
-	position: absolute;
-	top: -18px;
-	left: -4px;
-	background: var(--primitives-color-lintblauw-600);
-	/* Use neutral-0 so the label stays white-on-blue in light mode and
-	 * picks up the auto-flipped near-black on light-blue in dark mode —
-	 * both retain comfortable contrast against the auto-adjusted bg. */
-	color: var(--primitives-color-neutral-0);
-	font-size: 10px;
-	font-weight: 700;
-	padding: 1px 6px;
-	border-radius: 3px;
-	letter-spacing: 0.04em;
-	pointer-events: none;
-	z-index: 11;
+  content: '▶ start';
+  position: absolute;
+  top: -18px;
+  left: -4px;
+  background: var(--primitives-color-lintblauw-600);
+  /* Use neutral-0 so the label stays white-on-blue in light mode and
+   * picks up the auto-flipped near-black on light-blue in dark mode —
+   * both retain comfortable contrast against the auto-adjusted bg. */
+  color: var(--primitives-color-neutral-0);
+  font-size: 10px;
+  font-weight: 700;
+  padding: 1px 6px;
+  border-radius: 3px;
+  letter-spacing: 0.04em;
+  pointer-events: none;
+  z-index: 11;
 }
 /* Combine outlines cleanly when a start node is also active. */
 .vue-flow__node.trace-start.trace-active {
-	outline: 3px solid var(--primitives-color-donkergeel-500);
-	box-shadow:
-		0 0 0 7px color-mix(in oklch, var(--primitives-color-lintblauw-600), transparent 65%),
-		0 0 16px color-mix(in oklch, var(--primitives-color-donkergeel-500), transparent 45%);
+  outline: 3px solid var(--primitives-color-donkergeel-500);
+  box-shadow:
+    0 0 0 7px color-mix(in oklch, var(--primitives-color-lintblauw-600), transparent 65%),
+    0 0 16px color-mix(in oklch, var(--primitives-color-donkergeel-500), transparent 45%);
 }
 
 /* Step-type chips used by the left-side step list. Each chip uses the

--- a/frontend/src/composables/useLastVisitedRoute.js
+++ b/frontend/src/composables/useLastVisitedRoute.js
@@ -29,7 +29,10 @@ function save() {
 
 export function recordLastVisited(routeName, fullPath) {
   if (!routeName) return;
-  _lastVisited.value = { ..._lastVisited.value, [routeName]: fullPath };
+  // Mutate in place rather than re-spreading. The ref wraps a reactive
+  // object so a property assignment still notifies the lastLibraryPath /
+  // lastEditorPath computeds. Avoids GC churn if the section list grows.
+  _lastVisited.value[routeName] = fullPath;
   save();
 }
 

--- a/frontend/src/composables/useLastVisitedRoute.js
+++ b/frontend/src/composables/useLastVisitedRoute.js
@@ -1,0 +1,37 @@
+import { ref, computed } from 'vue';
+
+// Track the last visited fullPath per route name so the top-level
+// Bibliotheek/Editor tab switch returns the user to where they were
+// instead of the section root.
+//
+// Backed by sessionStorage so a refresh keeps the state for the same
+// tab session, but doesn't bleed across browser tabs/windows.
+
+const STORAGE_KEY = 'regelrecht:last-visited';
+
+function load() {
+  try {
+    return JSON.parse(sessionStorage.getItem(STORAGE_KEY) ?? '{}');
+  } catch {
+    return {};
+  }
+}
+
+const _lastVisited = ref(load());
+
+function save() {
+  try {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(_lastVisited.value));
+  } catch {
+    /* storage may be disabled / quota exceeded — fall back to memory only */
+  }
+}
+
+export function recordLastVisited(routeName, fullPath) {
+  if (!routeName) return;
+  _lastVisited.value = { ..._lastVisited.value, [routeName]: fullPath };
+  save();
+}
+
+export const lastLibraryPath = computed(() => _lastVisited.value.library ?? '/library');
+export const lastEditorPath = computed(() => _lastVisited.value.editor ?? '/editor');

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -1,0 +1,1 @@
+export const SUPPORT_EMAIL = 'regelrecht@minbzk.nl';

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -1,6 +1,7 @@
 import { createRouter, createWebHistory } from 'vue-router';
 import LibraryApp from './LibraryApp.vue';
 import { ensureAuthReady, useAuth } from './composables/useAuth.js';
+import { recordLastVisited } from './composables/useLastVisitedRoute.js';
 
 const router = createRouter({
   history: createWebHistory(),
@@ -52,6 +53,12 @@ router.beforeEach(async (to) => {
     return false;
   }
   return true;
+});
+
+// Track the last fullPath per route name so the Bibliotheek/Editor tab
+// switch can restore the user's prior position in each section.
+router.afterEach((to) => {
+  recordLastVisited(to.name, to.fullPath);
 });
 
 // Note: document.title is owned by the route components (LibraryApp, EditorApp)


### PR DESCRIPTION
## Summary

Two parallel threads — editor pane management overhaul and library
error/UX polish — bundled because they share the new design-system
primitives (sheet `full-height`, `nldd-code` + `nldd-code-editor`,
tab-bar swap, button-group default).

## Editor

- **Pane management**: replace the flag-driven left/middle/right layout
  with a flat `paneViews` array. Each pane independently picks a view
  (Tekst / Machine / Scenario's / YAML) via a header dropdown — duplicates
  allowed (two YAML panes for diff is fine). Persisted in localStorage;
  feature-flag toggles append/remove panes.
- **Responsive**: `nldd-side-by-side-split-view` auto-hides panes from
  the right when the viewport narrows, leftmost pane always wins.
  Hidden panes keep state for when the viewport widens.
- **YAML pane**: bespoke `<textarea>` swapped for `nldd-code-editor` in
  an `nldd-simple-section` — same chrome as the read-only viewer, same
  monospace tokens. Drops the `calc(100vh - 180px)` hack.
- **Scenario result UX**: "Toon resultaat" en de nieuwe **Graaf** knop
  openen aparte bottom sheets met dezelfde scenario-naam als context.
  Geen tab-bar in de sheet — de keuze zit in de knop.
- **Sheets**: alle vijf sh