### PR TITLE
fix(editor): use read-only ArticleText in Tekst pane (disable WYSIWYG)

### DIFF
--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -9,7 +9,7 @@ import { useFeatureFlags } from './composables/useFeatureFlags.js';
 import { useColorScheme } from './composables/useColorScheme.js';
 import { lastLibraryPath } from './composables/useLastVisitedRoute.js';
 import { SUPPORT_EMAIL } from './constants.js';
-import ArticleTextEditor from './components/ArticleTextEditor.vue';
+import ArticleText from './components/ArticleText.vue';
 import ActionSheet from './components/ActionSheet.vue';
 import EditSheet from './components/EditSheet.vue';
 import SearchPopover from './components/SearchPopover.vue';
@@ -1242,16 +1242,9 @@ function handleActionSave() {
                 <span v-if="view === 'yaml' && parseError" class="editor-parse-error">YAML parse error</span>
               </div>
 
-              <!-- Tekst -->
+              <!-- Tekst (read-only fallback while the WYSIWYG editor is disabled for demos) -->
               <nldd-simple-section v-if="view === 'text'" full-width>
-                <ArticleTextEditor
-                  :ref="setTextEditorRef(idx)"
-                  :article="selectedArticle"
-                  :editable="canEditArticleText"
-                  :save-error="articleTextSaveError"
-                  :model-value="editedText"
-                  @update:model-value="editedText = $event"
-                />
+                <ArticleText :article="selectedArticle" />
               </nldd-simple-section>
               <!-- Footer + Save button only on the first text pane (mirrors the machine pattern). -->
               <nldd-container

--- a/frontend/src/components/ArticleTextEditor.vue
+++ b/frontend/src/components/ArticleTextEditor.vue
@@ -180,19 +180,8 @@ defineExpose({
   text-align: center;
 }
 
-.article-text-editor__body {
-  background: var(--semantics-surfaces-tinted-background-color, #F4F6F9);
-  border: 1px solid var(--semantics-borders-default-color, #DDE0E4);
-  border-radius: 12px;
-  padding: 16px;
-  min-height: 200px;
-  line-height: 1.6;
-  font-size: 14px;
-}
-
 .article-text-editor__body :deep(.ProseMirror) {
   outline: none;
-  min-height: 160px;
 }
 
 .article-text-editor__body :deep(.ProseMirror p) {

--- a/frontend/src/components/ArticleTextEditor.vue
+++ b/frontend/src/components/ArticleTextEditor.vue
@@ -180,8 +180,19 @@ defineExpose({
   text-align: center;
 }
 
+.article-text-editor__body {
+  background: var(--semantics-surfaces-tinted-background-color, #F4F6F9);
+  border: 1px solid var(--semantics-borders-default-color, #DDE0E4);
+  border-radius: 12px;
+  padding: 16px;
+  min-height: 200px;
+  line-height: 1.6;
+  font-size: 14px;
+}
+
 .article-text-editor__body :deep(.ProseMirror) {
   outline: none;
+  min-height: 160px;
 }
 
 .article-text-editor__body :deep(.ProseMirror p) {


### PR DESCRIPTION
## Summary
- Swaps `ArticleTextEditor` for the existing read-only `ArticleText.vue` in the Tekst pane of `EditorApp`, so the pane renders identically to how it looked before #589.
- WYSIWYG editor (`ArticleTextEditor.vue`) and its surrounding wiring (refs, dirty state, save handler, format toolbar template) stay in place — the toolbar and save footer auto-hide via existing v-if gates. Easy to re-enable once the editor styling is finalised.
- Net diff vs main is just the `<ArticleTextEditor>` → `<ArticleText>` swap in `EditorApp.vue` (3 lines added, 10 removed).

## Why
Demo coming up; the WYSIWYG version doesn't look polished enough yet. This keeps the editor work on `main` for later revival while showing the rich-text rendering users had pre-#589.

## Test plan
- [ ] Open editor locally, select an article, view Tekst pane → renders via `nldd-rich-text`, no editor box, no format toolbar, no save footer.
- [ ] Machine pane / save flow on Machine pane still works.