### PR TITLE
feat(editor): re-enable WYSIWYG Tekst editor behind editor.article_text_edit flag

### DIFF
--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -10,6 +10,7 @@ import { useColorScheme } from './composables/useColorScheme.js';
 import { lastLibraryPath } from './composables/useLastVisitedRoute.js';
 import { SUPPORT_EMAIL } from './constants.js';
 import ArticleText from './components/ArticleText.vue';
+import ArticleTextEditor from './components/ArticleTextEditor.vue';
 import ActionSheet from './components/ActionSheet.vue';
 import EditSheet from './components/EditSheet.vue';
 import SearchPopover from './components/SearchPopover.vue';
@@ -1242,9 +1243,23 @@ function handleActionSave() {
                 <span v-if="view === 'yaml' && parseError" class="editor-parse-error">YAML parse error</span>
               </div>
 
-              <!-- Tekst (read-only fallback while the WYSIWYG editor is disabled for demos) -->
+              <!-- Tekst — WYSIWYG editor when the editor.article_text_edit
+                   feature flag is on, otherwise the read-only ArticleText
+                   display (matches the pre-#589 look). The toolbar in the
+                   pane-header above guards on `textEditorRefs[idx]`, which
+                   is only populated by the WYSIWYG component, so it auto-
+                   hides when the flag is off. -->
               <nldd-simple-section v-if="view === 'text'" full-width>
-                <ArticleText :article="selectedArticle" />
+                <ArticleTextEditor
+                  v-if="canEditArticleText"
+                  :ref="setTextEditorRef(idx)"
+                  :article="selectedArticle"
+                  :editable="canEditArticleText"
+                  :save-error="articleTextSaveError"
+                  :model-value="editedText"
+                  @update:model-value="editedText = $event"
+                />
+                <ArticleText v-else :article="selectedArticle" />
               </nldd-simple-section>
               <!-- Footer + Save button only on the first text pane (mirrors the machine pattern). -->
               <nldd-container

--- a/packages/editor-api/src/feature_flags.rs
+++ b/packages/editor-api/src/feature_flags.rs
@@ -16,6 +16,14 @@ static DEFAULTS: LazyLock<HashMap<String, bool>> = LazyLock::new(|| {
         ("panel.yaml_editor".into(), true),
         ("panel.machine_readable".into(), true),
         ("panel.law_graph".into(), false),
+        // Editor capability flags — visibility is panel.*, editability is editor.*.
+        // The frontend wires editor.article_text_edit (default off) to gate
+        // write access on the Tekst pane. Without the key here the backend's
+        // allow-list check rejects the toggle PUT with 400, and the frontend
+        // treats that as a failure and silently reverts the user's change —
+        // so the editor would stay read-only no matter how many times the
+        // menu toggle is flipped.
+        ("editor.article_text_edit".into(), false),
     ])
 });
 


### PR DESCRIPTION
## Summary

Builds on #624 (which reverted the Tekst pane to read-only ArticleText for the demo) by wiring the existing \`editor.article_text_edit\` feature flag to a runtime switch between the two renderers:

- **Flag on**  → ArticleTextEditor (WYSIWYG, format toolbar in pane-header, save footer when dirty)
- **Flag off** → ArticleText (read-only, same look #624 restored — matches pre-#589 baseline)

Also fixes the backend bug that prevented the toggle from sticking: the new flag was in the frontend defaults but never in the backend's allow-list, so PUTs returned 400 and the optimistic update silently reverted.

## Why

#589 landed the markdown-backed editor, #624 disabled it again because the styling needed more work. Both renderers are kept in the tree; this PR lets users opt back into the WYSIWYG via the settings menu without another redeploy, and keeps the demo default clean.

## Changes

- **\`packages/editor-api/src/feature_flags.rs\`** — add \`editor.article_text_edit\` (default false) to the backend allow-list. Without it the PUT returns 400, the frontend treats that as a hard failure and reverts the toggle; with it the PUT returns 200 (DB present) or 503 (no DB) — the frontend already handles 503 by persisting to localStorage, so the change sticks across refreshes even in DB-less dev runs.
- **\`frontend/src/EditorApp.vue\`** — import \`ArticleTextEditor\` alongside \`ArticleText\`, and \`v-if=\"canEditArticleText\"\` between the two inside the Tekst pane. The pane-header toolbar already guards on \`textEditorRefs[idx]\` (only populated by the WYSIWYG branch), so it auto-hides when the flag is off.

## Test plan

- [ ] Default load: Tekst pane shows read-only ArticleText (no toolbar, no save footer).
- [ ] Toggle \"Tekst bewerken\" on via the settings menu — Tekst pane swaps to ArticleTextEditor with the format toolbar in the pane-header.
- [ ] Type something, save footer appears, click Opslaan → PR-link badge updates.
- [ ] Refresh the page — toggle state survives, pane stays in the chosen mode.
- [ ] Toggle off again — pane reverts to read-only ArticleText.