### PR TITLE
docs(schema): accept RFC-005 and add RFC-018 note infrastructure

### DIFF
--- a/docs/rfcs/index.md
+++ b/docs/rfcs/index.md
@@ -11,7 +11,7 @@ Design decisions in RegelRecht are documented through RFCs. Each RFC captures th
 | [RFC-002](./rfc-002) | Authority Roles and Relationships | Accepted |
 | [RFC-003](./rfc-003) | Inversion of Control | Accepted |
 | [RFC-004](./rfc-004) | Uniform Operation Syntax | Accepted |
-| [RFC-005](./rfc-005) | Standoff Annotations | Accepted |
+| [RFC-005](./rfc-005) | Stand-off Notes for Legal Texts | Accepted |
 | [RFC-006](./rfc-006) | Language Choice | Accepted |
 | [RFC-007](./rfc-007) | Cross-Law Execution | Accepted |
 | [RFC-008](./rfc-008) | Bestuursrecht / AWB Procedures | Accepted |
@@ -21,6 +21,7 @@ Design decisions in RegelRecht are documented through RFCs. Each RFC captures th
 | [RFC-013](./rfc-013) | Execution Provenance | Draft |
 | [RFC-014](./rfc-014) | Engine Conformance | Draft |
 | [RFC-015](./rfc-015) | Engine Policy | Proposed |
+| [RFC-016](./rfc-016) | Note Infrastructure | Accepted |
 
 ## Writing an RFC
 

--- a/docs/rfcs/index.md
+++ b/docs/rfcs/index.md
@@ -21,7 +21,7 @@ Design decisions in RegelRecht are documented through RFCs. Each RFC captures th
 | [RFC-013](./rfc-013) | Execution Provenance | Draft |
 | [RFC-014](./rfc-014) | Engine Conformance | Draft |
 | [RFC-015](./rfc-015) | Engine Policy | Proposed |
-| [RFC-016](./rfc-016) | Note Infrastructure | Accepted |
+| [RFC-018](./rfc-018) | Note Infrastructure | Accepted |
 
 ## Writing an RFC
 

--- a/docs/rfcs/rfc-005.md
+++ b/docs/rfcs/rfc-005.md
@@ -1,27 +1,40 @@
-# RFC-005: Stand-off Annotations for Legal Texts
+# RFC-005: Stand-off Notes for Legal Texts
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2025-12-16
 **Authors:** Anne Schuth
 
+## Terminology
+
+We call this feature **notes** (NL: *notities*), not "annotations". In Dutch legal
+practice an *annotatie* (or *noot*, "m.nt.") is a protected genre: a scholarly
+commentary written by a renowned jurist on a court ruling, published in a
+jurisprudence journal. Using "annotation" for arbitrary text comments would clash
+with that established meaning.
+
+The W3C standard we adopt names its core entity `Annotation`. We keep that
+technical term where it refers to the data model itself (`type: Annotation`, the
+W3C *Web Annotation Data Model*), but everywhere we speak about the feature, the
+UI, or files, the word is **note**.
+
 ## Context
 
-Legal texts are stored as verbatim text in YAML files. We want to add annotations
-at word or character level, without modifying the legal text itself. Annotations
-must be version-resilient: when text changes or moves, an annotation should
-automatically find its new location. Annotations should resolve on
+Legal texts are stored as verbatim text in YAML files. We want to add notes
+at word or character level, without modifying the legal text itself. Notes
+must be version-resilient: when text changes or moves, a note should
+automatically find its new location. Notes should resolve on
 **any version** of a law where the annotated text exists - both older and newer
 versions - without requiring migration logic or change tracking.
 
-**Scope:** This RFC defines the annotation *format*, not storage. Annotations
+**Scope:** This RFC defines the note *format*, not storage. Notes
 could be stored in a central database, distributed across systems, or provided
-by external parties ("bring your own annotations"). The format is intentionally
+by external parties ("bring your own notes"). The format is intentionally
 storage-agnostic.
 
 ## Decision
 
 We adopt the [W3C Web Annotation Data Model](https://www.w3.org/TR/annotation-model/), a
-W3C Recommendation since 2017. This standard defines a common format for annotations
+W3C Recommendation since 2017. This standard defines a common format for notes
 on the web, used by tools like Hypothesis, Apache Annotator, and Recogito.
 
 Specifically, we use **TextQuoteSelector** from the
@@ -54,21 +67,21 @@ The content of the article remains identical.
 
 The TextQuoteSelector searches for text in the entire document. It doesn't matter
 where that text is located - if the prefix/suffix/exact combination is unique,
-the annotation resolves correctly.
+the note resolves correctly.
 
-**Scenario: Viewing annotations across law versions**
+**Scenario: Viewing notes across law versions**
 
-An annotation created today should also be visible when viewing an older version
+A note created today should also be visible when viewing an older version
 of the law (e.g., the 2020 version), as long as the annotated text existed then.
 
-| Approach | Annotation today → view on 2020 version | Complexity |
+| Approach | Note today → view on 2020 version | Complexity |
 |----------|----------------------------------------|------------|
 | Article + version + change tracking | ❌ Requires reverse migration of all changes | High |
 | TextQuoteSelector | ✅ Automatic - just search for the text | Low |
 
-TextQuoteSelector is **content-addressed**: the annotation finds text by its
+TextQuoteSelector is **content-addressed**: the note finds text by its
 content, not by its structural location. This means:
-- An annotation made today automatically resolves on older law versions (if the text existed)
+- A note made today automatically resolves on older law versions (if the text existed)
 - No migration logic needed when laws change
 - Works bidirectionally in time without extra effort
 
@@ -149,7 +162,7 @@ body:
 ## Fuzzy Matching
 
 When the exact text is no longer found (e.g., due to a minor textual change),
-fuzzy matching can still resolve the annotation.
+fuzzy matching can still resolve the note.
 
 ### How It Works
 
@@ -168,7 +181,7 @@ heeft de verzekerde aanspraak op een zorgtoeslag ter grootte van dat verschil
 heeft de verzekerde recht op een zorgtoeslag ter grootte van het verschil
 ```
 
-The annotation searches for:
+The note searches for:
 - prefix: `"heeft de verzekerde "`
 - exact: `"aanspraak op een zorgtoeslag"`
 - suffix: `" ter grootte van dat verschil"`
@@ -229,11 +242,11 @@ def resolve_annotation(text: str, selector: TextQuoteSelector) -> Match | None:
 
 ### When Fuzzy Matching Fails
 
-For large text changes (score < threshold), the annotation is marked as "orphaned".
-The annotation is preserved with its original context, so that:
+For large text changes (score < threshold), the note is marked as "orphaned".
+The note is preserved with its original context, so that:
 - Users can see what was annotated
 - Manual re-anchoring is possible
-- The annotation history is preserved
+- The note history is preserved
 
 ## Implementation Notes
 
@@ -244,7 +257,7 @@ Fuzzy matching through an entire law can be expensive. Recommended strategy:
 1. **Exact match first** - Search for `prefix + exact + suffix` as a simple substring.
    This succeeds in 99% of cases and is O(n).
 
-2. **Optional hint** - Add `regelrecht:hint` with a W3C selector as optimization.
+2. **Optional hint** - Add `regelrecht:hint` with a W3C selector as optimisation.
    The hint is non-authoritative: if the text doesn't match there, search the
    entire law.
 
@@ -273,21 +286,21 @@ Fuzzy matching through an entire law can be expensive. Recommended strategy:
    2. Search for TextQuoteSelector within that search space
    3. Not found? → search entire law (hint was outdated)
 
-3. **Caching** - Cache resolved positions per `(annotation_id, law_version)`.
+3. **Caching** - Cache resolved positions per `(note_id, law_version)`.
    Invalidate only when a new law version is published.
 
 ### Uniqueness
 
 A selector must match uniquely within the law. Multiple matches make the
-annotation ambiguous and unreliable to resolve.
+note ambiguous and unreliable to resolve.
 
-**When creating an annotation:**
+**When creating a note:**
 - Validate that the selector is unique in the current law version
 - If not: error message "add more context to prefix/suffix"
 
-**When resolving an annotation:**
+**When resolving a note:**
 - If there are multiple matches with equal score: mark as "ambiguous"
-- Let the user choose or manually re-anchor the annotation
+- Let the user choose or manually re-anchor the note
 
 **Rule of thumb:** prefix and suffix of ~30-50 characters are usually sufficient
 to be unique, even for common words.
@@ -297,28 +310,29 @@ to be unique, even for common words.
 ### Benefits
 
 1. **Version resilience**: TextQuoteSelector finds text regardless of where it is
-2. **Renumbering-proof**: Article numbers can change without breaking annotations
+2. **Renumbering-proof**: Article numbers can change without breaking notes
 3. **Fuzzy matching**: Minor text changes are automatically handled
-4. **No changes to legal text**: Annotations are completely separate from source text
+4. **No changes to legal text**: Notes are completely separate from source text
 5. **W3C standard**: Interoperable with existing annotation tools (Hypothesis, etc.)
 6. **Simple**: One selector type, no complex fallback logic needed
 
 ### Tradeoffs
 
 - Prefix/suffix must be long enough to be unique within the law (~20-50 characters)
-- Fuzzy matching can fail for large changes (annotation becomes "orphaned")
+- Fuzzy matching can fail for large changes (note becomes "orphaned")
 - Resolution requires searching through the entire text (no direct lookup)
 
 ### Alternatives Considered
 
 **Article + version with change tracking**
-- Requires explicitly modeling every type of legal change (renumbering, amendments, etc.)
-- Annotations become version-bound; viewing across versions requires migration logic
+- Requires explicitly modelling every type of legal change (renumbering, amendments, etc.)
+- Notes become version-bound; viewing across versions requires migration logic
 - Higher complexity for a problem TextQuoteSelector solves automatically
 
 **CssSelector for article scope**
 - Breaks when articles are renumbered
 - Adds no value if TextQuoteSelector is already unique
+- Article numbers serve only as non-authoritative performance hints
 
 **TextPositionSelector (character offsets)**
 - Too brittle: any text change breaks all annotations
@@ -382,7 +396,7 @@ properties:
   motivation:
     type: string
     description: |
-      W3C motivation - why this annotation exists.
+      W3C motivation - why this note exists.
       W3C: optional (SHOULD). Regelrecht: required.
     enum:
       # W3C standard vocabulary:
@@ -457,13 +471,20 @@ properties:
 
 | Field | Dimension | Values | Description |
 |-------|-----------|--------|-------------|
-| `motivation` | Intent | commenting, linking, tagging, ... | W3C standard: why does this annotation exist? |
+| `motivation` | Intent | commenting, linking, tagging, ... | W3C standard: why does this note exist? |
 | `resolution` | Technical | found, orphaned | Can the selector locate the text? |
 | `workflow` | Process | open, resolved | Has the issue been addressed? |
 
 `motivation` and `purpose` use the [W3C Web Annotation vocabulary](https://www.w3.org/TR/annotation-model/#motivation-and-purpose) (13 values). W3C makes these optional; we require them for explicit intent.
 
-`resolution` and `workflow` are orthogonal: an annotation can be `orphaned` + `resolved`.
+`resolution` and `workflow` are orthogonal: a note can be `orphaned` + `resolved`.
+
+The `questioning` motivation combined with `workflow` is how we track *ambiguity*
+in work-in-progress laws (a known need from interpretation research: "open norm
+partially filled", "needs explanation by implementation policy", a reference to a
+document we are still searching for). The specific ambiguity state is carried as a
+`tagging` body, not as a new schema field, so the vocabulary can grow without a
+schema change. RFC-016 details this and the controlled vocabulary that backs it.
 
 ## References
 

--- a/docs/rfcs/rfc-005.md
+++ b/docs/rfcs/rfc-005.md
@@ -343,6 +343,12 @@ to be unique, even for common words.
 
 ## Schema
 
+The blocks below are illustrative. The authoritative, machine-checked schema is
+`schema/v0.5.2/annotation-schema.json`, which additionally defines `creator`,
+`created`, and `modified` (see RFC-018 Decision 3 for the authority model that
+relies on `creator`). Validate note files against that file via
+`just validate-annotations`, not against the excerpts here.
+
 ### TextQuoteSelector
 
 ```yaml
@@ -484,7 +490,7 @@ in work-in-progress laws (a known need from interpretation research: "open norm
 partially filled", "needs explanation by implementation policy", a reference to a
 document we are still searching for). The specific ambiguity state is carried as a
 `tagging` body, not as a new schema field, so the vocabulary can grow without a
-schema change. RFC-016 details this and the controlled vocabulary that backs it.
+schema change. RFC-018 details this and the controlled vocabulary that backs it.
 
 ## References
 

--- a/docs/rfcs/rfc-016.md
+++ b/docs/rfcs/rfc-016.md
@@ -1,0 +1,849 @@
+# RFC-016: Note Infrastructure: Storage, Resolution, and Editor Integration
+
+**Status:** Accepted
+**Date:** 2026-05-18
+**Authors:** Anne Schuth
+
+## Terminology
+
+This RFC uses **note** (NL: *notitie*) for the feature, following the terminology
+decision in [RFC-005](./rfc-005). The W3C technical term `Annotation` is kept only
+where it refers to the data model itself. "Annotation" as a Dutch legal genre
+(*annotatie*, *noot*, "m.nt.") is deliberately not what this feature is called.
+
+## Context
+
+RFC-005 defines the note *format*: the W3C Web Annotation Data Model with
+TextQuoteSelector for version-resilient text anchoring. It specifies what a note
+looks like (selector, motivation, body, resolution states) but is explicitly
+storage-agnostic. It does not say where notes live, how they are loaded, who
+creates them, or how they are displayed.
+
+This RFC addresses the implementation questions RFC-005 leaves open. They map
+directly onto the open design questions raised in interpretation discussions:
+
+1. **Working notes**: needed for the editor to bridge the gap between law text
+   and `machine_readable` execution logic.
+2. **Conflict resolution for generated notes**: when notes are produced by
+   tooling (e.g., an LLM suggesting linking notes), how are conflicts between
+   generated and human-authored notes handled?
+3. **Responsible law-to-YAML mapping**: linking notes connect specific text
+   fragments to the corresponding `machine_readable` elements, making the
+   interpretation chain explicit and auditable.
+4. **Note types and storage locations**: different note types serve different
+   purposes and may live in different places.
+5. **Note history**: version tracking via Git.
+6. **Note scope**: what does a note relate to? The entire law across all
+   versions? A specific version? Is it personal or public? Does it target
+   structure or content?
+7. **Ambiguity tracking in work-in-progress laws**: labelling diepte-casussen
+   where we have imperfect information ("we don't know what we don't know"):
+   open norms partially filled, open norms not yet filled, provisions that need
+   explanation by implementation policy, and notes about *missing documents* that
+   are still being searched for.
+
+Two other RFCs shape the infrastructure:
+
+- **[RFC-009](./rfc-009)** (Multi-Organisation Execution) introduces
+  `competent_authority` (*bevoegd gezag*) as the boundary that determines who can
+  authoritatively execute what. The same concept applies to notes: the competent
+  authority's note linking text to `machine_readable` represents the official
+  interpretation (*gezaghebbende interpretatie*). Other organisations, legal
+  experts, and citizens can bring their own notes alongside, as advisory
+  perspectives, not as the authoritative reading.
+
+- **[RFC-010](./rfc-010)** (Federated Corpus) introduces a "bring your own
+  regulations" model where municipalities (*gemeenten*), provinces (*provincies*),
+  and other organisations maintain laws in their own repositories. Notes need the
+  same federated model: any organisation can annotate any law from their own
+  perspective, in their own repository.
+
+### Current state
+
+Nothing is implemented on `main`. A historical Python proof-of-concept exists on
+the `feature/annotation-resolver` branch (TextQuoteSelector resolution, fuzzy
+matching, BDD tests), but the stack has moved to Rust (engine) and Vue 3
+(frontend). The Python code is not reused; the BDD scenarios are ported. An
+earlier draft of this RFC circulated as PR #328 numbered "RFC-013"; that number is
+taken on `main` (Execution Provenance), so this RFC is numbered 016 and PR #328 is
+closed in favour of it.
+
+## Decision
+
+Nine interconnected decisions form the note infrastructure.
+
+### 1. Storage: Sidecar YAML files
+
+Notes are stored in separate YAML files alongside law files, not embedded in the
+law YAML. This preserves the verbatim legal text (RFC-005 requirement: notes must
+not modify the source) and enables independent versioning.
+
+**Directory convention:**
+
+```
+corpus/
+  regulation/nl/
+    wet/
+      wet_op_de_zorgtoeslag/
+        2025-01-01.yaml                        # law text (unchanged)
+  annotations/
+    wet_op_de_zorgtoeslag/
+      annotations.yaml                          # law-level notes (all versions)
+      2025-01-01.annotations.yaml               # version-specific notes (optional)
+    _vocabulary/
+      ambiguity.yaml                            # controlled vocabulary (Decision 9)
+```
+
+- `annotations.yaml`: law-level notes that apply across all versions. The
+  TextQuoteSelector resolves on whichever version is being viewed.
+- `{valid_from}.annotations.yaml`: notes specific to a particular law version.
+  Used when the annotated text only exists in that version (e.g., a percentage
+  that was changed in a later amendment).
+
+The directory is named `annotations/` (not `notes/`) because it stores W3C
+`Annotation` objects; the storage path follows the data model, the feature name
+follows RFC-005.
+
+**Discovery:** convention-based. Given a law with `$id: zorgtoeslagwet`, the
+engine looks for notes at `corpus/annotations/zorgtoeslagwet/annotations.yaml`. No
+registry manifest is needed for local notes.
+
+**Validation:** note files conform to `schema/v0.5.2/annotation-schema.json`,
+validated by `just validate-annotations`.
+
+**Example note file:**
+
+```yaml
+# corpus/annotations/wet_op_de_zorgtoeslag/annotations.yaml
+$schema: "https://raw.githubusercontent.com/MinBZK/regelrecht/refs/heads/main/schema/v0.5.2/annotation-schema.json"
+annotations:
+  - type: Annotation
+    motivation: linking
+    creator: "Dienst Toeslagen"
+    target:
+      source: "regelrecht://zorgtoeslagwet"
+      selector:
+        type: TextQuoteSelector
+        exact: "zorgtoeslag ter grootte van dat verschil"
+        prefix: "heeft de verzekerde aanspraak op een "
+        suffix: ""
+        regelrecht:hint:
+          type: CssSelector
+          value: "article[number='2']"
+          refinedBy:
+            type: TextPositionSelector
+            start: 112
+            end: 152
+    body:
+      type: SpecificResource
+      source: "regelrecht://zorgtoeslagwet/artikel_2#hoogte_zorgtoeslag"
+      purpose: linking
+    resolution: found
+    workflow: resolved
+```
+
+### 2. Federated note sources
+
+Notes follow the same "bring your own" pattern as laws in RFC-010. Any
+organisation can maintain notes in their own repository, alongside their
+regulations or in a dedicated note repository.
+
+**Required structure in a source repository:**
+
+```
+annotations/
+  {law_id}/
+    annotations.yaml
+```
+
+When a source in `corpus-registry.yaml` (RFC-010) includes an `annotations/`
+directory, the engine discovers and loads those notes alongside the source's
+regulations.
+
+**Example: a municipality (*gemeente*) annotating a national law:**
+
+```
+# In gemeente-amsterdam/regelrecht-amsterdam repo:
+regulation/nl/
+  verordening/
+    afstemmingsverordening/
+      2025-01-01.yaml                           # Amsterdam's ordinance
+annotations/
+  wet_op_de_zorgtoeslag/
+    annotations.yaml                             # Amsterdam's perspective on national law
+  afstemmingsverordening/
+    annotations.yaml                             # notes on their own ordinance
+```
+
+Amsterdam's note on the Healthcare Allowance Act (*Wet op de zorgtoeslag*) might
+link text about "toeslagpartner" to their local implementation of the partner
+check, or add a comment explaining how Amsterdam interprets a provision in the
+context of their municipal social assistance (*bijstand*) policy.
+
+**Personal notes:** a `.local.annotations.yaml` file (gitignored) follows the
+RFC-010 `.local.yaml` override pattern. Personal notes are loaded alongside public
+notes but not committed.
+
+**Loading order:** the engine loads notes from all registered sources. Notes from
+different sources are **layered**, not prioritised (see Decision 7).
+
+### 3. Note authority and provenance
+
+Each note carries a `creator` field (part of the W3C Web Annotation Data Model)
+identifying who created it. The relationship between the creator and the annotated
+law determines the note's authority level.
+
+| Creator | Relationship to `competent_authority` | Authority level | Example |
+|---------|--------------------------------------|----------------|---------|
+| Competent authority (*bevoegd gezag*) | Same org | Authoritative (*gezaghebbend*) | Allowances Service (*Dienst Toeslagen*) annotates Healthcare Allowance Act |
+| Other government org | Different org | Advisory (*adviserend*) | Municipality (*gemeente*) annotates national law from local perspective |
+| Legal expert / researcher | No org | Personal (*persoonlijk*) | Law professor adds explanatory comment |
+| Automated tooling | Generated | Generated (*gegenereerd*) | LLM-produced linking note |
+
+The authority level is **derived at display time**, not stored. It follows the
+same principle as RFC-009's execute/accept boundary: the law determines authority,
+the engine derives behaviour.
+
+**Derivation logic:**
+
+```
+Is the note's creator the competent_authority for the target law?
+  YES → Authoritative
+  NO  →
+    Is the creator a government organisation?
+      YES → Advisory
+      NO  →
+        Is the creator an automated tool?
+          YES → Generated
+          NO  → Personal
+```
+
+For the MVP, `creator` is a string field (e.g., `"Dienst Toeslagen"`,
+`"LLM-generated"`, `"J. de Vries"`). When RFC-009's identity model
+(`EngineIdentity` with OIN) is implemented, `creator` can carry a structured
+identity with signature verification. The schema accommodates both:
+
+```yaml
+# MVP: simple string
+creator: "Dienst Toeslagen"
+
+# Future: structured identity (W3C Agent)
+creator:
+  type: Organisation
+  name: "Dienst Toeslagen"
+  organisation_id: "00000004003214345000"  # OIN
+```
+
+**Provenance:** the note file's Git history provides when each note was created
+and by whom (`git log`, `git blame`). The schema optionally includes `created` and
+`modified` timestamps for systems that do not use Git.
+
+### 4. Scope model
+
+Each scope dimension maps to a concrete mechanism:
+
+| Scope dimension | Mechanism | How it works |
+|-----------------|-----------|--------------|
+| Entire law, all versions (*hele wet, alle versies*) | Law-level `annotations.yaml` | TextQuoteSelector resolves on whichever version is being viewed. A note on "zorgtoeslag" finds the word in both the 2020 and 2025 versions. |
+| Specific version (*specifieke versie*) | Version-specific `{valid_from}.annotations.yaml` | A note on a percentage changed by Staatsblad 2008, 516 only makes sense on the pre-2008 version. |
+| Personal / public (*persoonlijk / publiek*) | Public: in Git. Personal: `.local.annotations.yaml` (gitignored) | An expert's draft notes before publishing; a student's study notes. |
+| Structure or content (*structuur of inhoud*) | Notes target *text content* via TextQuoteSelector | The note on "zorgtoeslag" finds the word regardless of which article it is in. If article 2 is renumbered to article 3, the note follows the text. Article numbers appear only as performance hints (non-authoritative). |
+
+### 5. Note types and their use cases
+
+The W3C Web Annotation vocabulary defines 13 motivation types. Four are primary
+for regelrecht.
+
+#### Linking (*koppeling*)
+
+Connects text to a `machine_readable` element. This is the most critical type: it
+makes the interpretation chain from law text to executable logic explicit and
+auditable.
+
+```yaml
+- type: Annotation
+  motivation: linking
+  creator: "Dienst Toeslagen"
+  target:
+    source: "regelrecht://zorgtoeslagwet"
+    selector:
+      type: TextQuoteSelector
+      exact: "zorgtoeslag ter grootte van dat verschil"
+      prefix: "heeft de verzekerde aanspraak op een "
+      suffix: ""
+  body:
+    type: SpecificResource
+    source: "regelrecht://zorgtoeslagwet/artikel_2#hoogte_zorgtoeslag"
+    purpose: linking
+```
+
+The `body.source` uses a `regelrecht://` URI (as defined in
+`packages/engine/src/uri.rs`) pointing to the specific execution element. The
+fragment (`#hoogte_zorgtoeslag`) identifies the output name.
+
+#### Commenting (*toelichting*)
+
+Human explanation of a legal concept or provision.
+
+```yaml
+- type: Annotation
+  motivation: commenting
+  creator: "J. de Vries"
+  target:
+    source: "regelrecht://zorgtoeslagwet"
+    selector:
+      type: TextQuoteSelector
+      exact: "normpremie"
+      prefix: "Indien de "
+      suffix: " voor een verzekerde"
+  body:
+    type: TextualBody
+    value: >-
+      The normative premium (normpremie) is a notional amount representing what
+      the insured person is expected to contribute to health insurance. It is
+      based on income, not on the actual premium paid.
+    purpose: commenting
+    format: text/plain
+    language: en
+```
+
+#### Tagging (*classificatie*)
+
+Classification of legal concepts for search, analysis, and cross-referencing. Also
+the carrier for ambiguity state (Decision 9).
+
+```yaml
+- type: Annotation
+  motivation: tagging
+  creator: "regelrecht-tooling"
+  target:
+    source: "regelrecht://zorgtoeslagwet"
+    selector:
+      type: TextQuoteSelector
+      exact: "verzekerde"
+      prefix: "heeft de "
+      suffix: " aanspraak op een zorgtoeslag"
+  body:
+    type: TextualBody
+    value: "legal-subject"
+    purpose: tagging
+```
+
+#### Questioning (*vraag*)
+
+Open question raised during interpretation. Tracked via the `workflow` field. This
+type carries the ambiguity-tracking use case (Decision 9).
+
+```yaml
+- type: Annotation
+  motivation: questioning
+  creator: "interpreter-team"
+  target:
+    source: "regelrecht://zorgtoeslagwet"
+    selector:
+      type: TextQuoteSelector
+      exact: "drempelinkomen"
+      prefix: "procent van het "
+      suffix: ", vermeerderd met"
+  body:
+    type: TextualBody
+    value: "Is this the same drempelinkomen defined in Awir article 2?"
+    purpose: questioning
+  workflow: open
+```
+
+### 6. Ambiguity tracking and missing documents
+
+This decision answers the original interpretation-research need: labelling
+ambiguity in work-in-progress laws, where we start from existing law with
+(possibly unknown) implementation policy and want to reach a validated executable
+rule set, knowing we have imperfect information.
+
+**The states are not a fixed list.** Today there are a handful ("open norm
+partially filled", "open norm not yet filled", "needs explanation by
+implementation policy", "document still being searched for"); the set will grow as
+the interpretation process matures. Freezing it into a validated schema enum would
+mean every new state is a schema version bump plus a migration of existing note
+files plus an RFC amendment. That is exactly the brittleness RFC-005 avoids for
+text anchoring; we avoid it here too.
+
+**Model.** Ambiguity is expressed with the existing W3C dimensions, no schema
+extension:
+
+- `motivation: questioning`: there is an open interpretation issue here.
+- `workflow: open | resolved`: has the issue been addressed?
+- a `tagging` body whose `value` is the specific ambiguity state, drawn from a
+  controlled vocabulary (Decision 9).
+
+A note can carry both a `questioning` body (the question in prose) and a `tagging`
+body (the machine-readable state). The W3C model permits multiple bodies.
+
+**Example: an open norm that is only partially filled in.**
+
+```yaml
+- type: Annotation
+  motivation: questioning
+  creator: "interpreter-team"
+  target:
+    source: "regelrecht://zorgtoeslagwet"
+    selector:
+      type: TextQuoteSelector
+      exact: "bij ministeriële regeling"
+      prefix: "worden "
+      suffix: " nadere regels gesteld"
+  body:
+    - type: TextualBody
+      value: >-
+        Ministerial regulation partially located. The income brackets are
+        implemented; the hardship clause is referenced but the implementing text
+        has not been found yet.
+      purpose: questioning
+      format: text/plain
+      language: en
+    - type: TextualBody
+      value: "open-norm-partial"
+      purpose: tagging
+  workflow: open
+```
+
+**Missing documents.** A note can be about a document that does not exist in the
+corpus yet but is needed to resolve a provision. The target is the text fragment
+that triggers the search; the body describes what is missing. This makes "what are
+we still looking for" a queryable property of the corpus, not tribal knowledge.
+
+```yaml
+- type: Annotation
+  motivation: questioning
+  creator: "interpreter-team"
+  target:
+    source: "regelrecht://zorgtoeslagwet"
+    selector:
+      type: TextQuoteSelector
+      exact: "beleidsregels van de Belastingdienst"
+      prefix: "overeenkomstig de "
+      suffix: " omtrent"
+  body:
+    - type: TextualBody
+      value: >-
+        These policy rules (beleidsregels) govern the discretionary hardship
+        assessment but are not in the corpus. Searching Staatscourant and the
+        Belastingdienst policy register.
+      purpose: questioning
+      format: text/plain
+      language: en
+    - type: TextualBody
+      value: "missing-document"
+      purpose: tagging
+  workflow: open
+```
+
+### 7. Resolver architecture
+
+The TextQuoteSelector resolver is implemented in Rust as a module within the
+engine crate. It is exposed to the frontend via WASM.
+
+**Module structure:**
+
+```
+packages/engine/src/
+  annotation/
+    mod.rs           # pub mod types; pub mod resolver;
+    types.rs         # Data types
+    resolver.rs      # Resolution algorithm
+```
+
+**Types** (in `types.rs`):
+
+```rust
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TextQuoteSelector {
+    pub exact: String,
+    pub prefix: Option<String>,
+    pub suffix: Option<String>,
+    pub hint: Option<SelectorHint>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SelectorHint {
+    pub article_number: String,
+    pub start: Option<usize>,
+    pub end: Option<usize>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MatchResult {
+    pub status: MatchStatus,
+    pub matches: Vec<TextMatch>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum MatchStatus {
+    Found,
+    Orphaned,
+    Ambiguous,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TextMatch {
+    pub article_number: String,
+    pub start: usize,
+    pub end: usize,
+    pub confidence: f64,
+    pub matched_text: String,
+}
+```
+
+**Resolution algorithm** (in `resolver.rs`):
+
+```
+resolve(selector, articles) -> MatchResult:
+  1. Build full text from all articles, tracking article boundaries
+  2. Try exact match:
+     - Search for prefix + exact + suffix as substring
+     - If found: return Found with confidence 1.0
+  3. If hint is present:
+     - Try exact match within hinted article only
+     - If found: return Found
+     - If not: continue to full search (hint was outdated)
+  4. Fuzzy match:
+     - For each sliding window of len(exact) +/- 30% in the full text:
+       - exact_score = levenshtein_similarity(exact, window_text)
+       - prefix_score = levenshtein_similarity(prefix, text_before_window)
+       - suffix_score = levenshtein_similarity(suffix, text_after_window)
+       - score = exact_score * 0.5 + prefix_score * 0.25 + suffix_score * 0.25
+     - Collect matches above threshold (0.7)
+  5. If one match: return Found with confidence = score
+  6. If multiple matches with equal score: return Ambiguous
+  7. If no matches: return Orphaned
+```
+
+**Dependency:** `strsim` crate for Levenshtein distance.
+
+**WASM bindings** (additions to `packages/engine/src/wasm.rs`):
+
+```rust
+#[wasm_bindgen]
+impl WasmEngine {
+    /// Resolve a single TextQuoteSelector against a loaded law
+    pub fn resolve_annotation(
+        &self,
+        law_id: &str,
+        selector: JsValue,
+    ) -> Result<JsValue, JsValue>;
+
+    /// Resolve all notes from a YAML string against a loaded law
+    pub fn resolve_annotations(
+        &self,
+        law_id: &str,
+        annotations_yaml: &str,
+    ) -> Result<JsValue, JsValue>;
+}
+```
+
+**BDD tests:** port the 8 scenarios from
+`feature/annotation-resolver:features/annotation.feature` into
+`features/notes.feature`:
+
+1. Exact match: Zorgtoeslagwet 2025 article 4a
+2. Article renumbered: Staatsblad 2024, 291 (article 3 → article 4a)
+3. Text change: Staatsblad 2008, 516 (percentage 3,5 → 2,7)
+4. Orphaned note: text fully removed
+5. Ambiguous match: common word without context
+6. Unique with context: prefix/suffix disambiguation
+7. Hint optimisation: correct hint
+8. Hint fallback: outdated hint
+
+Plus ambiguity scenarios (Decision 6): a `questioning` note with
+`workflow: open` and a `tagging` body `open-norm-partial` resolving correctly, and
+a `workflow: resolved` variant.
+
+### 8. Conflict resolution and layering
+
+Notes from different sources **layer**: they do not conflict. This is
+fundamentally different from laws, where RFC-010 uses priority to resolve `$id`
+collisions. Two organisations can both annotate the same text fragment; both notes
+are valid and visible.
+
+**Layering model:**
+
+```
+Law text: "heeft de verzekerde aanspraak op een zorgtoeslag ter grootte van dat verschil"
+           ─────────────────────────────────────────────
+                                    │
+           ┌────────────────────────┼─────────────────────────┐
+           │                        │                          │
+    Dienst Toeslagen         Gemeente Amsterdam          LLM-generated
+    motivation: linking      motivation: commenting      motivation: linking
+    body: #hoogte_zorg-      body: "Core provision our    body: #berekening_
+          toeslag                  bijstand calc refs"          zorgtoeslag
+    authority: authoritative  authority: advisory         authority: generated
+```
+
+All three coexist. The editor displays them layered, with authoritative notes
+visually distinguished (solid highlight vs dashed border).
+
+**When law text changes:**
+
+1. The resolver runs all notes against the new version
+2. Notes that still match: `resolution: found` (no action needed)
+3. Notes that no longer match above threshold: `resolution: orphaned`
+4. Orphaned notes are preserved with their original selector context
+5. CI reports orphaned notes as warnings, not errors
+
+**Tooling-generated notes:**
+
+- carry `creator: "{tool-name}"` and authority level `generated`
+- are treated as suggestions: visible in the editor but visually distinguished
+- a human reviewer can promote a generated note by changing the creator to their
+  own identity
+- conflicting generated notes (two tools suggesting different linking targets for
+  the same text) are both shown; the human picks the correct one
+
+### 9. Controlled vocabulary for tagging values
+
+Tagging bodies (including ambiguity states from Decision 6) draw their `value`
+from a controlled vocabulary stored as a plain YAML list:
+
+```yaml
+# corpus/annotations/_vocabulary/ambiguity.yaml
+ambiguity:
+  - id: open-norm-not-filled
+    label: "Open norm, nog niet ingevuld"
+    description: "An open norm whose implementing text has not been written or located."
+  - id: open-norm-partial
+    label: "Open norm, deels ingevuld"
+    description: "An open norm partially implemented; some parts still unresolved."
+  - id: needs-uitvoeringsbeleid
+    label: "Behoeft uitleg door uitvoeringsbeleid"
+    description: "The provision cannot be made executable without implementation policy."
+  - id: missing-document
+    label: "Document ontbreekt"
+    description: "A document needed to resolve the provision is not in the corpus."
+```
+
+`just validate-annotations` warns (does not fail) when a `tagging` body's `value`
+is not in the vocabulary. This catches typos and keeps the set queryable, without
+forking the W3C standard and without a schema bump when a state is added. The
+warning-not-error stance mirrors how orphaned notes are reported (Decision 8).
+
+### 10. Editor integration
+
+#### Read path
+
+```
+                                                  ┌─────────────────────┐
+                                                  │   useNotes.js        │
+┌──────────────────┐    fetch    ┌────────────┐   │                     │
+│ /data/annotations│───────────>│ annotations │──>│  WASM resolve()     │
+│ /{lawId}/        │            │    .yaml    │   │         │           │
+│ annotations.yaml │            └────────────┘   │         v           │
+└──────────────────┘                              │  resolved positions │
+                                                  └─────────┬───────────┘
+                                                            │
+                                                            v
+                                                  ┌─────────────────────┐
+                                                  │  AnnotatedText.vue  │
+                                                  │  <mark> spans with  │
+                                                  │  colour by motivation│
+                                                  └─────────────────────┘
+```
+
+**`frontend/src/composables/useNotes.js`:**
+
+1. Fetches note YAML from `/data/annotations/{lawId}/annotations.yaml`
+2. Calls `WasmEngine.resolveAnnotations()` to get match positions per article
+3. Returns a reactive list of `{ note, match }` objects, filtered by the selected
+   article
+
+**`frontend/src/components/AnnotatedText.vue`:**
+
+A variant of `ArticleText.vue` for the editor's Tekst pane. Takes article text and
+resolved positions, renders `<mark>` spans. Each span carries:
+
+- background colour by motivation (linking: blue, commenting: yellow, questioning:
+  orange, tagging: green)
+- border style by authority (authoritative: solid, advisory: dashed, generated:
+  dotted)
+- click handler to show note details
+
+#### Write path (MVP)
+
+1. User selects text in `AnnotatedText.vue`
+2. `useTextSelection.js` captures the selection, extracts `exact`, computes
+   `prefix` (30-50 chars before) and `suffix` (30-50 chars after)
+3. Validates uniqueness via `WasmEngine.resolveAnnotation()`: if the selector
+   matches multiple locations, asks for more context
+4. `NoteCreator.vue` opens as a popover: pick motivation, select target
+   `machine_readable` element (linking), type text (commenting/questioning), or
+   pick an ambiguity tag from the vocabulary (questioning)
+5. New note added to local state and persisted in `localStorage`
+6. Export button downloads the updated note YAML for manual git commit
+
+#### Editor layout
+
+The right pane's segmented control gains a third option, labelled **Notities**:
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  [ Machine ]  [ YAML ]  [ Notities ]                     │
+├──────────────────────────────────────────────────────────┤
+│  Notities voor Artikel 2                                 │
+│                                                          │
+│  ┌─ Gezaghebbend (Dienst Toeslagen) ──────────────────┐ │
+│  │ ► "zorgtoeslag ter grootte van dat verschil"        │ │
+│  │   → #hoogte_zorgtoeslag (linking)                   │ │
+│  └─────────────────────────────────────────────────────┘ │
+│  ┌─ Adviserend (Gemeente Amsterdam) ──────────────────┐  │
+│  │ ► "zorgtoeslag"  "Core provision..." (commenting)   │ │
+│  └─────────────────────────────────────────────────────┘ │
+│  ┌─ Vraag (interpreter-team) ────────────────────────┐  │
+│  │ ► "bij ministeriële regeling"                       │ │
+│  │   [open-norm-partial]  workflow: open               │ │
+│  └─────────────────────────────────────────────────────┘ │
+└──────────────────────────────────────────────────────────┘
+```
+
+## Why
+
+### Benefits
+
+- **Git gives full note history for free.** Every change is a commit with author,
+  timestamp, and diff. `git blame` shows who added each note and when.
+
+- **Sidecar files preserve verbatim legal text.** The law YAML is never modified
+  (RFC-005 requirement). Essential for legal integrity: the source must be
+  identical to the official publication.
+
+- **Federated model lets every org bring their own notes.** A municipality can
+  annotate national laws from their perspective without touching the central
+  corpus. This mirrors RFC-010.
+
+- **Authority model reflects legal reality.** The competent authority's
+  interpretation carries more weight, as in administrative law. Authority is
+  derived from existing schema fields (`competent_authority`), following RFC-009.
+
+- **Linking notes make interpretation auditable.** Every connection between text
+  and `machine_readable` logic is an explicit, reviewable note. This supports the
+  reasoning requirement (*motiveringsplicht*, AWB 3:46): the chain from law text to
+  computation can be inspected by citizens, courts, and oversight bodies.
+
+- **Ambiguity is tracked without freezing a vocabulary.** Interpretation research
+  can label open norms and missing documents today and refine the categories
+  later, without schema migrations.
+
+- **W3C standard enables interoperability.** The format works with Hypothesis,
+  Apache Annotator, and Recogito. External parties can produce notes without the
+  regelrecht editor.
+
+- **Rust resolver is the single source of truth.** The same resolver runs in the
+  engine (CI validation, server-side) and the browser (WASM). No divergence
+  between what the editor shows and what the engine validates.
+
+### Tradeoffs
+
+- **Two places to look.** A law's notes live in a separate directory from its YAML
+  source. Tooling must load both. Convention-based discovery keeps this
+  straightforward but it is an extra step.
+
+- **No real-time collaboration.** Notes are Git-based. Concurrent editing requires
+  branches and pull requests. Acceptable for the MVP; production may need a
+  collaboration layer.
+
+- **WASM adds build complexity.** The `wasm-pack build` step is additional. The
+  engine already supports WASM compilation, so the incremental cost is low.
+
+- **Authority derivation requires `competent_authority` in the law.** Laws without
+  a declared `competent_authority` cannot distinguish authoritative from advisory
+  notes. This is an existing gap (RFC-009 also depends on it).
+
+- **Tag vocabulary is soft-validated.** A typo in a tagging value produces a
+  warning, not a hard failure. Deliberate: it keeps the vocabulary growable
+  without ceremony.
+
+### Alternatives Considered
+
+**Notes inside law YAML.** Embed an `annotations` array in the law file. Rejected:
+modifies the verbatim source (RFC-005 forbids this) and creates noisy Git diffs
+where note changes obscure law changes.
+
+**Database storage.** Store notes in PostgreSQL (the pipeline already uses it).
+Rejected for MVP: introduces a backend dependency where none exists, and loses
+Git's built-in versioning, blame, and merge workflow. A database layer can be
+added later without changing the format.
+
+**JavaScript-only resolver.** Implement TextQuoteSelector resolution in JS.
+Rejected: duplicates the fuzzy matching algorithm. The engine needs resolution for
+CI validation; a separate JS implementation would diverge. WASM compiles the same
+Rust code for the browser.
+
+**Centralised note authority.** Designate one organisation as the note authority
+per law. Rejected: does not match RFC-010's federated model or RFC-009's multi-org
+reality. The layering model accommodates multiple legitimate annotators.
+
+**Dedicated `regelrecht:ambiguity` enum field.** Add a validated enum to the
+schema for ambiguity states. Rejected: the state set is still emerging; an enum
+makes every new state a schema version bump plus migration plus RFC amendment. The
+tagging-body plus controlled-vocabulary approach gives queryability and typo
+detection without forking the W3C model.
+
+### Implementation Notes
+
+Implementation is planned in six phases, each delivering a working whole.
+
+**Phase 0: RFC review**
+RFC-005 and this RFC accepted and merged before code lands.
+
+**Phase 1: Rust resolver + BDD tests**
+Implement the `annotation` module (`types.rs`, `resolver.rs`). Port the 8 BDD
+scenarios. Add `strsim` to `Cargo.toml`.
+
+**Phase 2: Note schema + first notes**
+Create `schema/v0.5.2/annotation-schema.json`. Write the first real linking and
+commenting notes for the Healthcare Allowance Act article 2 plus the ambiguity
+vocabulary. Add `validate-annotations` to the Justfile.
+
+**Phase 3: WASM bindings**
+Add `resolve_annotation()` and `resolve_annotations()` to `WasmEngine`.
+
+**Phase 4: Frontend display**
+Create `useNotes.js` and `AnnotatedText.vue`. Integrate behind a feature flag.
+Update the build script to copy note files.
+
+**Phase 5: Frontend creation**
+Create `useTextSelection.js` and `NoteCreator.vue`.
+
+**Phase 6: CI validation + ambiguity use case**
+Add `validate-annotations` to the quality gate (orphaned notes as warnings). Add
+ambiguity BDD scenarios and one concrete ambiguity note in the corpus.
+
+#### Affected components
+
+| File/Directory | Change |
+|----------------|--------|
+| `packages/engine/src/annotation/` | New: resolver module (`mod.rs`, `types.rs`, `resolver.rs`) |
+| `packages/engine/src/lib.rs` | Add `pub mod annotation` and re-exports |
+| `packages/engine/src/wasm.rs` | Add `resolve_annotation()`, `resolve_annotations()` |
+| `packages/engine/Cargo.toml` | Add `strsim` dependency |
+| `schema/v0.5.2/annotation-schema.json` | New: JSON Schema for note files |
+| `corpus/annotations/` | New: note sidecar files + `_vocabulary/ambiguity.yaml` |
+| `features/notes.feature` | New: BDD scenarios (ported + ambiguity) |
+| `packages/engine/tests/bdd/steps/` | New: note step definitions |
+| `frontend/src/components/AnnotatedText.vue` | New: text with highlights |
+| `frontend/src/components/NoteCreator.vue` | New: note creation form |
+| `frontend/src/composables/useNotes.js` | New: note loading and resolution |
+| `frontend/src/composables/useTextSelection.js` | New: text selection capture |
+| `frontend/src/EditorApp.vue` | Add Notities tab, use `AnnotatedText` behind a flag |
+| `frontend/scripts/copy-laws.js` | Copy note files to `public/data/annotations/` |
+| `Justfile` | Add `validate-annotations` recipe |
+
+## References
+
+- [RFC-005: Stand-off Notes for Legal Texts](./rfc-005): note format specification
+- [RFC-009: Multi-Organisation Execution](./rfc-009): competent authority boundaries
+- [RFC-010: Federated Corpus](./rfc-010): federated source model
+- [RFC-003: Inversion of Control](./rfc-003): `open_terms` and `implements`
+- [W3C Web Annotation Data Model](https://www.w3.org/TR/annotation-model/)
+- [W3C Selectors and States](https://www.w3.org/TR/selectors-states/)
+- [Hypothesis Fuzzy Anchoring](https://web.hypothes.is/blog/fuzzy-anchoring/)

--- a/docs/rfcs/rfc-018.md
+++ b/docs/rfcs/rfc-018.md
@@ -1,4 +1,4 @@
-# RFC-016: Note Infrastructure: Storage, Resolution, and Editor Integration
+# RFC-018: Note Infrastructure: Storage, Resolution, and Editor Integration
 
 **Status:** Accepted
 **Date:** 2026-05-18
@@ -63,14 +63,19 @@ Two other RFCs shape the infrastructure:
 Nothing is implemented on `main`. A historical Python proof-of-concept exists on
 the `feature/annotation-resolver` branch (TextQuoteSelector resolution, fuzzy
 matching, BDD tests), but the stack has moved to Rust (engine) and Vue 3
-(frontend). The Python code is not reused; the BDD scenarios are ported. An
-earlier draft of this RFC circulated as PR #328 numbered "RFC-013"; that number is
-taken on `main` (Execution Provenance), so this RFC is numbered 016 and PR #328 is
-closed in favour of it.
+(frontend). The Python code is not reused; the BDD scenarios are ported.
+
+This RFC has been renumbered twice. An earlier draft circulated as PR #328
+numbered "RFC-013"; that number was already taken on `main` (Execution
+Provenance), so it became RFC-016. RFC-016 in turn collided with the open
+PR #510, which uses that number for Collection Operations (foreach). RFC-016 is
+the older claim, so the note infrastructure RFC takes the next free number,
+**RFC-018** (`rfc-011` was never used; `rfc-016` and `rfc-017` are claimed by
+PR #510). PR #328 is closed in favour of this RFC.
 
 ## Decision
 
-Nine interconnected decisions form the note infrastructure.
+Ten interconnected decisions form the note infrastructure.
 
 ### 1. Storage: Sidecar YAML files
 
@@ -84,15 +89,19 @@ not modify the source) and enables independent versioning.
 corpus/
   regulation/nl/
     wet/
-      wet_op_de_zorgtoeslag/
-        2025-01-01.yaml                        # law text (unchanged)
+      wet_op_de_zorgtoeslag/                     # filesystem path
+        2025-01-01.yaml                          # law text, $id: zorgtoeslagwet
   annotations/
-    wet_op_de_zorgtoeslag/
-      annotations.yaml                          # law-level notes (all versions)
-      2025-01-01.annotations.yaml               # version-specific notes (optional)
+    zorgtoeslagwet/                              # keyed by the law's $id
+      annotations.yaml                           # law-level notes (all versions)
+      2025-01-01.annotations.yaml                # version-specific notes (optional)
     _vocabulary/
-      ambiguity.yaml                            # controlled vocabulary (Decision 9)
+      ambiguity.yaml                             # controlled vocabulary (Decision 9)
 ```
+
+The annotation directory is keyed by the law's `$id` (e.g. `zorgtoeslagwet`),
+not by its filesystem path under `regulation/` (e.g. `wet_op_de_zorgtoeslag`).
+The `$id` is the stable identifier laws reference each other by.
 
 - `annotations.yaml`: law-level notes that apply across all versions. The
   TextQuoteSelector resolves on whichever version is being viewed.
@@ -114,7 +123,7 @@ validated by `just validate-annotations`.
 **Example note file:**
 
 ```yaml
-# corpus/annotations/wet_op_de_zorgtoeslag/annotations.yaml
+# corpus/annotations/zorgtoeslagwet/annotations.yaml
 $schema: "https://raw.githubusercontent.com/MinBZK/regelrecht/refs/heads/main/schema/v0.5.2/annotation-schema.json"
 annotations:
   - type: Annotation
@@ -126,7 +135,7 @@ annotations:
         type: TextQuoteSelector
         exact: "zorgtoeslag ter grootte van dat verschil"
         prefix: "heeft de verzekerde aanspraak op een "
-        suffix: ""
+        suffix: ". Voor een verzekerde met een toeslagpartner"
         regelrecht:hint:
           type: CssSelector
           value: "article[number='2']"
@@ -136,7 +145,7 @@ annotations:
             end: 152
     body:
       type: SpecificResource
-      source: "regelrecht://zorgtoeslagwet/artikel_2#hoogte_zorgtoeslag"
+      source: "regelrecht://zorgtoeslagwet/hoogte_zorgtoeslag#hoogte_zorgtoeslag"
       purpose: linking
     resolution: found
     workflow: resolved
@@ -169,7 +178,7 @@ regulation/nl/
     afstemmingsverordening/
       2025-01-01.yaml                           # Amsterdam's ordinance
 annotations/
-  wet_op_de_zorgtoeslag/
+  zorgtoeslagwet/
     annotations.yaml                             # Amsterdam's perspective on national law
   afstemmingsverordening/
     annotations.yaml                             # notes on their own ordinance
@@ -270,10 +279,10 @@ auditable.
       type: TextQuoteSelector
       exact: "zorgtoeslag ter grootte van dat verschil"
       prefix: "heeft de verzekerde aanspraak op een "
-      suffix: ""
+      suffix: ". Voor een verzekerde met een toeslagpartner"
   body:
     type: SpecificResource
-    source: "regelrecht://zorgtoeslagwet/artikel_2#hoogte_zorgtoeslag"
+    source: "regelrecht://zorgtoeslagwet/hoogte_zorgtoeslag#hoogte_zorgtoeslag"
     purpose: linking
 ```
 
@@ -497,26 +506,32 @@ pub struct TextMatch {
 
 **Resolution algorithm** (in `resolver.rs`):
 
+The hint is checked **first** so it provides an actual fast path: searching one
+article is O(article length) versus O(law length) for the full scan. The hint is
+non-authoritative, so a miss falls through to the full search rather than
+failing.
+
 ```
 resolve(selector, articles) -> MatchResult:
-  1. Build full text from all articles, tracking article boundaries
-  2. Try exact match:
-     - Search for prefix + exact + suffix as substring
+  1. If hint is present (fast path):
+     - Try exact match within the hinted article only
+       (if the hint has a position, verify exact text at that offset first)
      - If found: return Found with confidence 1.0
-  3. If hint is present:
-     - Try exact match within hinted article only
-     - If found: return Found
-     - If not: continue to full search (hint was outdated)
-  4. Fuzzy match:
-     - For each sliding window of len(exact) +/- 30% in the full text:
+     - If not: hint was outdated, fall through to the full search
+  2. Try exact match across all articles:
+     - Search for prefix + exact + suffix as substring
+     - One match: return Found (confidence 1.0)
+     - Multiple matches: return Ambiguous
+  3. Fuzzy match across all articles:
+     - For each sliding window of len(exact) +/- 30%:
        - exact_score = levenshtein_similarity(exact, window_text)
        - prefix_score = levenshtein_similarity(prefix, text_before_window)
        - suffix_score = levenshtein_similarity(suffix, text_after_window)
        - score = exact_score * 0.5 + prefix_score * 0.25 + suffix_score * 0.25
-     - Collect matches above threshold (0.7)
-  5. If one match: return Found with confidence = score
-  6. If multiple matches with equal score: return Ambiguous
-  7. If no matches: return Orphaned
+     - Collect matches above threshold (0.7), deduplicate overlapping spans
+  4. One match (or a clear winner > 0.1 ahead): return Found, confidence = score
+  5. Multiple equally-good matches: return Ambiguous
+  6. No matches: return Orphaned
 ```
 
 **Dependency:** `strsim` crate for Levenshtein distance.


### PR DESCRIPTION
## Wat

Twee RFC's voor de **notes**-feature (eerder "annotaties"):

- **RFC-005** status `Proposed` → `Accepted`. Hernoemd van "annotations" naar **notes** (NL: *notities*). In juridische zin is een *annotatie* een beschermd genre (rechtsgeleerd commentaar bij een uitspraak, "m.nt."); de feature heet daarom intern notes. De technische W3C-term `Annotation` blijft waar het het datamodel betreft.
- **RFC-016** (nieuw): note-infrastructuur. Gebaseerd op de tekst uit gesloten PR #328 ("RFC-013"), maar hernummerd want RFC-013 is op `main` al *Execution Provenance*. Referenties naar RFC-009/010/003 gefixt.

## Belangrijkste ontwerpkeuzes

- Stand-off notes via W3C Web Annotation + TextQuoteSelector (versie-bestendig, content-addressed).
- Sidecar YAML, gesleuteld op de wet-`$id`. Git = versiebeheer.
- Federatief ("bring your own notes"), gelaagd i.p.v. geprioriteerd.
- Autoriteit afgeleid uit `competent_authority` (RFC-009), niet apart geconfigureerd.
- **Ambiguïteit-tracking** (Daans use-case): `motivation: questioning` + `workflow` + een tagging-body met de specifieke state, gevoed door een soft-validated controlled vocabulary. Geen schema-uitbreiding, zodat de vocabulaire kan groeien zonder migratie. Notes over ontbrekende documenten zijn een erkende use-case.

## Vervolg

Implementatie (resolver, schema, WASM, editor) staat op `feat/notes-annotations` en komt als aparte PR die op deze RFC-PR bouwt. PR #328 is gesloten ten gunste hiervan.