### PR TITLE
feat(engine): add TextQuoteSelector note resolver, schema and WASM

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -36,6 +36,11 @@ build-check:
 validate *FILES:
     script/validate.sh {{FILES}}
 
+# Validate note sidecar files (RFC-005, RFC-016)
+# Orphaned/ambiguous notes and unknown tags are warnings, not errors.
+validate-annotations *FILES:
+    script/validate-annotations.sh {{FILES}}
+
 # Run all quality checks (format + lint + check + validate + tests)
 # Note: pipeline-integration-test excluded — it requires Docker (testcontainers)
 check: format lint build-check validate test harvester-test pipeline-test admin-fmt admin-lint admin-check admin-test admin-frontend editor-api-fmt editor-api-lint editor-api-check

--- a/corpus/annotations/_vocabulary/ambiguity.yaml
+++ b/corpus/annotations/_vocabulary/ambiguity.yaml
@@ -1,5 +1,5 @@
 ---
-# Controlled vocabulary for ambiguity tags on questioning notes (RFC-016 Decision 9).
+# Controlled vocabulary for ambiguity tags on questioning notes (RFC-018 Decision 9).
 #
 # A questioning note over an open norm carries a tagging body whose `value` is
 # one of the `id`s below. This list is intentionally not a JSON Schema enum:

--- a/corpus/annotations/_vocabulary/ambiguity.yaml
+++ b/corpus/annotations/_vocabulary/ambiguity.yaml
@@ -1,0 +1,34 @@
+---
+# Controlled vocabulary for ambiguity tags on questioning notes (RFC-016 Decision 9).
+#
+# A questioning note over an open norm carries a tagging body whose `value` is
+# one of the `id`s below. This list is intentionally not a JSON Schema enum:
+# the set is still emerging from interpretation research, and freezing it would
+# turn every new state into a schema bump plus migration. `just
+# validate-annotations` warns (does not fail) on a tag value that is not here.
+ambiguity:
+  - id: open-norm-not-filled
+    label: Open norm, nog niet ingevuld
+    description: >-
+      An open norm (delegation to lower regulation or discretionary power)
+      whose implementing text has not been written or located yet.
+  - id: open-norm-partial
+    label: Open norm, deels ingevuld
+    description: >-
+      An open norm that is partially implemented; some parts are resolved,
+      others still need work.
+  - id: needs-uitvoeringsbeleid
+    label: Behoeft uitleg door uitvoeringsbeleid
+    description: >-
+      The provision cannot be made executable without implementation policy
+      (beleidsregels, werkinstructies) that interprets it.
+  - id: missing-document
+    label: Document ontbreekt
+    description: >-
+      A document needed to resolve the provision is referenced but not present
+      in the corpus; it is still being searched for.
+  - id: conflicting-interpretation
+    label: Tegenstrijdige interpretatie
+    description: >-
+      Two sources (e.g. competent authority and a court ruling) interpret the
+      provision differently; the executable reading is contested.

--- a/corpus/annotations/zorgtoeslagwet/annotations.yaml
+++ b/corpus/annotations/zorgtoeslagwet/annotations.yaml
@@ -1,6 +1,6 @@
 ---
 # Stand-off notes on the Healthcare Allowance Act (Wet op de zorgtoeslag).
-# Format: RFC-005. Infrastructure: RFC-016. Validated by `just validate-annotations`.
+# Format: RFC-005. Infrastructure: RFC-018. Validated by `just validate-annotations`.
 $schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/heads/main/schema/v0.5.2/annotation-schema.json
 annotations:
   # Linking note: connects the text granting the allowance to the
@@ -45,7 +45,7 @@ annotations:
       language: nl
     resolution: found
 
-  # Questioning note over an open norm (RFC-016 Decision 6). The percentages
+  # Questioning note over an open norm (RFC-018 Decision 6). The percentages
   # can be changed by ministerial regulation; until that regulation is located
   # and modelled, this is an open norm that is only partially filled in.
   - type: Annotation

--- a/corpus/annotations/zorgtoeslagwet/annotations.yaml
+++ b/corpus/annotations/zorgtoeslagwet/annotations.yaml
@@ -1,0 +1,73 @@
+---
+# Stand-off notes on the Healthcare Allowance Act (Wet op de zorgtoeslag).
+# Format: RFC-005. Infrastructure: RFC-016. Validated by `just validate-annotations`.
+$schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/heads/main/schema/v0.5.2/annotation-schema.json
+annotations:
+  # Linking note: connects the text granting the allowance to the
+  # machine_readable element that computes its amount. This makes the
+  # interpretation chain from law text to executable logic auditable.
+  - type: Annotation
+    motivation: linking
+    creator: Dienst Toeslagen
+    target:
+      source: regelrecht://zorgtoeslagwet
+      selector:
+        type: TextQuoteSelector
+        exact: zorgtoeslag
+        prefix: 'heeft de verzekerde aanspraak op een '
+        suffix: ' ter grootte van dat verschil'
+    body:
+      type: SpecificResource
+      source: regelrecht://zorgtoeslagwet/hoogte_zorgtoeslag#hoogte_zorgtoeslag
+      purpose: linking
+    resolution: found
+    workflow: resolved
+
+  # Commenting note: explains a domain term for readers.
+  - type: Annotation
+    motivation: commenting
+    creator: J. de Vries
+    target:
+      source: regelrecht://zorgtoeslagwet
+      selector:
+        type: TextQuoteSelector
+        exact: normpremie
+        prefix: 'Indien de '
+        suffix: ' voor een verzekerde'
+    body:
+      type: TextualBody
+      value: >-
+        De normpremie is een fictief bedrag dat staat voor wat de verzekerde
+        geacht wordt zelf aan zorgkosten bij te dragen. Het hangt af van het
+        inkomen, niet van de feitelijk betaalde premie.
+      purpose: commenting
+      format: text/plain
+      language: nl
+    resolution: found
+
+  # Questioning note over an open norm (RFC-016 Decision 6). The percentages
+  # can be changed by ministerial regulation; until that regulation is located
+  # and modelled, this is an open norm that is only partially filled in.
+  - type: Annotation
+    motivation: questioning
+    creator: interpreter-team
+    target:
+      source: regelrecht://zorgtoeslagwet
+      selector:
+        type: TextQuoteSelector
+        exact: ministeriële regeling
+        prefix: 'Bij '
+        suffix: ' kunnen deze percentages'
+    body:
+      - type: TextualBody
+        value: >-
+          De percentages kunnen bij ministeriële regeling worden gewijzigd.
+          De vigerende regeling is nog niet in het corpus opgenomen; de
+          hardcoded percentages in machine_readable gelden tot dan.
+        purpose: questioning
+        format: text/plain
+        language: nl
+      - type: TextualBody
+        value: open-norm-partial
+        purpose: tagging
+    workflow: open

--- a/features/notes.feature
+++ b/features/notes.feature
@@ -1,0 +1,102 @@
+Feature: Note resolution (RFC-005, RFC-016)
+  A note anchors to legal text via a W3C TextQuoteSelector: an exact quote
+  plus optional prefix/suffix context. The selector is content-addressed, so
+  a note resolves on any law version where the text exists, surviving article
+  renumbering and minor textual changes (via fuzzy matching).
+
+  Scenario: Exact match
+    Given a law with the following articles:
+      | number | text                                                                         |
+      | 2      | heeft de verzekerde aanspraak op een zorgtoeslag ter grootte van dat verschil |
+    And a note selecting "zorgtoeslag" with prefix "op een " and suffix " ter grootte"
+    When the note is resolved
+    Then the note resolves to article "2"
+    And the note is an exact match
+
+  Scenario: Article renumbered keeps the note anchored to the text
+    # A new article 1a is inserted; the annotated text moves to article 4a.
+    # The content-addressed selector still finds it.
+    Given a law with the following articles:
+      | number | text                                                                         |
+      | 1a     | Een nieuw ingevoegd artikel zonder relevante inhoud.                          |
+      | 4a     | heeft de verzekerde aanspraak op een zorgtoeslag ter grootte van dat verschil |
+    And a note selecting "zorgtoeslag" with prefix "op een " and suffix " ter grootte"
+    When the note is resolved
+    Then the note resolves to article "4a"
+
+  Scenario: Minor text change still resolves via fuzzy matching
+    # Staatsblad 2008, 516 changed wording; the note survives as a fuzzy match.
+    Given a law with the following articles:
+      | number | text                                                                       |
+      | 2      | heeft de verzekerde recht op een zorgtoeslag ter grootte van het verschil  |
+    And a note selecting "aanspraak op een zorgtoeslag" with prefix "heeft de verzekerde " and suffix " ter grootte van dat verschil"
+    When the note is resolved
+    Then the note resolves to article "2"
+    And the note is a fuzzy match
+
+  Scenario: Text removed orphans the note
+    Given a law with the following articles:
+      | number | text                                          |
+      | 2      | Geheel andere tekst zonder de gezochte zin.   |
+    And a note selecting "zorgtoeslag ter grootte van dat verschil" with prefix "aanspraak op een " and suffix ""
+    When the note is resolved
+    Then the note is orphaned
+
+  Scenario: Common word without context is ambiguous
+    Given a law with the following articles:
+      | number | text                                                  |
+      | 2      | de verzekerde en de verzekerde en nog een verzekerde  |
+    And a note selecting "verzekerde"
+    When the note is resolved
+    Then the note is ambiguous
+
+  Scenario: Context disambiguates a common word
+    Given a law with the following articles:
+      | number | text                                                                                       |
+      | 2      | de verzekerde betaalt; de verzekerde ontvangt; heeft de verzekerde aanspraak op zorgtoeslag |
+    And a note selecting "verzekerde" with prefix "heeft de " and suffix " aanspraak"
+    When the note is resolved
+    Then the note resolves to article "2"
+
+  Scenario: A correct hint finds the match
+    Given a law with the following articles:
+      | number | text                                                  |
+      | 1      | Onbelangrijke inleidende tekst.                       |
+      | 2      | heeft de verzekerde aanspraak op een zorgtoeslag hier |
+    And a note selecting "zorgtoeslag" with prefix "op een " and suffix " hier"
+    And the note hints article "2"
+    When the note is resolved
+    Then the note resolves to article "2"
+
+  Scenario: An outdated hint falls back to a full search
+    # The hint points at article 9, which no longer contains the text.
+    # Resolution must still find it in article 2.
+    Given a law with the following articles:
+      | number | text                                                  |
+      | 2      | heeft de verzekerde aanspraak op een zorgtoeslag hier |
+      | 9      | Niets relevants in dit artikel.                       |
+    And a note selecting "zorgtoeslag" with prefix "op een " and suffix " hier"
+    And the note hints article "9" at position 0 to 5
+    When the note is resolved
+    Then the note resolves to article "2"
+
+  # === Ambiguity tracking (RFC-016 Decision 6) ===
+  # A questioning note over an open norm still has to resolve to the text it
+  # is about; the ambiguity state lives in a tagging body, the resolver only
+  # cares about anchoring.
+
+  Scenario: A questioning note over an open norm resolves to the delegating text
+    Given a law with the following articles:
+      | number | text                                                                              |
+      | 2      | Bij ministeriële regeling worden nadere regels gesteld over de hardheidsclausule. |
+    And a note selecting "bij ministeriële regeling" with prefix "" and suffix " worden nadere regels"
+    When the note is resolved
+    Then the note resolves to article "2"
+
+  Scenario: A note about a missing document anchors to the text that requires it
+    Given a law with the following articles:
+      | number | text                                                                          |
+      | 5      | De Belastingdienst handelt overeenkomstig de beleidsregels van de Belastingdienst omtrent hardheid. |
+    And a note selecting "beleidsregels van de Belastingdienst" with prefix "overeenkomstig de " and suffix " omtrent"
+    When the note is resolved
+    Then the note resolves to article "5"

--- a/features/notes.feature
+++ b/features/notes.feature
@@ -1,4 +1,4 @@
-Feature: Note resolution (RFC-005, RFC-016)
+Feature: Note resolution (RFC-005, RFC-018)
   A note anchors to legal text via a W3C TextQuoteSelector: an exact quote
   plus optional prefix/suffix context. The selector is content-addressed, so
   a note resolves on any law version where the text exists, surviving article
@@ -33,6 +33,33 @@ Feature: Note resolution (RFC-005, RFC-016)
     When the note is resolved
     Then the note resolves to article "2"
     And the note is a fuzzy match
+
+  # Scoring boundary guard (RFC-018). The resolver scores fuzzy candidates
+  # with normalised Levenshtein, not the Python PoC's SequenceMatcher; the two
+  # disagree near the 0.7 threshold. These two scenarios pin the boundary so a
+  # scoring-function or threshold change cannot silently re-classify notes.
+
+  Scenario: A near-identical change stays above the fuzzy threshold
+    # The article reads "vaststelt"; the note's exact is "stelt vast" (a small
+    # word-order/spelling drift). Levenshtein similarity stays well above 0.7,
+    # so the note still resolves, as a fuzzy match (confidence < 1.0).
+    Given a law with the following articles:
+      | number | text                                                                  |
+      | 2      | de inspecteur die het verzamelinkomen van de belanghebbende vaststelt |
+    And a note selecting "het verzamelinkomen van de belanghebbende stelt vast" with prefix "de inspecteur die " and suffix ""
+    When the note is resolved
+    Then the note resolves to article "2"
+    And the note is a fuzzy match
+
+  Scenario: A wholesale rewrite falls below the fuzzy threshold
+    # The exact phrase shares a word but the text is otherwise unrelated:
+    # similarity below 0.7, so the note must orphan rather than mis-anchor.
+    Given a law with the following articles:
+      | number | text                                                      |
+      | 2      | De Belastingdienst kent op aanvraag een voorschot toe.    |
+    And a note selecting "stelt het verzamelinkomen van de belanghebbende ambtshalve vast" with prefix "de inspecteur " and suffix " voor het jaar"
+    When the note is resolved
+    Then the note is orphaned
 
   Scenario: Text removed orphans the note
     Given a law with the following articles:
@@ -80,7 +107,7 @@ Feature: Note resolution (RFC-005, RFC-016)
     When the note is resolved
     Then the note resolves to article "2"
 
-  # === Ambiguity tracking (RFC-016 Decision 6) ===
+  # === Ambiguity tracking (RFC-018 Decision 6) ===
   # A questioning note over an open norm still has to resolve to the text it
   # is about; the ambiguity state lives in a tagging body, the resolver only
   # cares about anchoring.

--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -3707,6 +3707,7 @@ dependencies = [
  "serde_json",
  "serde_yaml_ng",
  "sha2",
+ "strsim",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/packages/engine/Cargo.toml
+++ b/packages/engine/Cargo.toml
@@ -46,6 +46,11 @@ path = "src/bin/validate.rs"
 required-features = ["validate"]
 
 [[bin]]
+name = "validate-annotations"
+path = "src/bin/validate_annotations.rs"
+required-features = ["validate"]
+
+[[bin]]
 name = "evaluate"
 path = "src/bin/evaluate.rs"
 

--- a/packages/engine/Cargo.toml
+++ b/packages/engine/Cargo.toml
@@ -25,6 +25,7 @@ thiserror.workspace = true
 chrono.workspace = true
 sha2.workspace = true
 hex = "0.4"
+strsim = "0.11"
 tracing.workspace = true
 
 [dependencies.jsonschema]

--- a/packages/engine/src/annotation/mod.rs
+++ b/packages/engine/src/annotation/mod.rs
@@ -1,0 +1,14 @@
+//! Stand-off note resolution (RFC-005, RFC-016).
+//!
+//! Notes anchor to legal text via a W3C [`TextQuoteSelector`]: an exact quote
+//! plus optional prefix/suffix context. The selector is content-addressed, so a
+//! note resolves on any law version where the text exists, surviving article
+//! renumbering and minor textual changes (via fuzzy matching).
+//!
+//! See [`crate::annotation::resolver`] for the resolution algorithm.
+
+pub mod resolver;
+pub mod types;
+
+pub use resolver::resolve;
+pub use types::{MatchResult, MatchStatus, SelectorHint, TextMatch, TextQuoteSelector};

--- a/packages/engine/src/annotation/mod.rs
+++ b/packages/engine/src/annotation/mod.rs
@@ -1,4 +1,4 @@
-//! Stand-off note resolution (RFC-005, RFC-016).
+//! Stand-off note resolution (RFC-005, RFC-018).
 //!
 //! Notes anchor to legal text via a W3C [`TextQuoteSelector`]: an exact quote
 //! plus optional prefix/suffix context. The selector is content-addressed, so a
@@ -12,3 +12,15 @@ pub mod types;
 
 pub use resolver::resolve;
 pub use types::{MatchResult, MatchStatus, SelectorHint, TextMatch, TextQuoteSelector};
+
+/// Extract the law `$id` from a note's `target.source` URI.
+///
+/// `regelrecht://zorgtoeslagwet` and
+/// `regelrecht://zorgtoeslagwet/hoogte_zorgtoeslag#field` both yield
+/// `"zorgtoeslagwet"`. Returns `None` if the URI is not a `regelrecht://`
+/// reference. Shared by the WASM bindings and `validate-annotations` so the
+/// two cannot drift.
+pub fn law_id_from_source(source: &str) -> Option<&str> {
+    let rest = source.strip_prefix("regelrecht://")?;
+    Some(rest.split('/').next().unwrap_or(rest))
+}

--- a/packages/engine/src/annotation/resolver.rs
+++ b/packages/engine/src/annotation/resolver.rs
@@ -1,4 +1,4 @@
-//! TextQuoteSelector resolution algorithm (RFC-005, RFC-016).
+//! TextQuoteSelector resolution algorithm (RFC-005, RFC-018).
 //!
 //! Resolution order:
 //! 1. If a hint is present, try the hinted article first; on failure fall
@@ -6,14 +6,25 @@
 //! 2. Exact match: locate `prefix + exact + suffix` as a substring, with
 //!    whitespace-tolerant prefix/suffix checks.
 //! 3. Fuzzy match: a sliding window over the text scored
-//!    `exact*0.5 + prefix*0.25 + suffix*0.25` using normalised Levenshtein
-//!    similarity, keeping candidates at or above the threshold (0.7).
-//! 4. One match → [`MatchStatus::Found`], several equally-good →
-//!    [`MatchStatus::Ambiguous`], none → [`MatchStatus::Orphaned`].
+//!    `exact*0.5 + prefix*0.25 + suffix*0.25`, keeping candidates at or above
+//!    the threshold (0.7).
+//! 4. One match (or a clear winner) is [`MatchStatus::Found`], several
+//!    equally-good are [`MatchStatus::Ambiguous`], none is
+//!    [`MatchStatus::Orphaned`].
 //!
-//! Ported from the Python proof-of-concept on the `feature/annotation-resolver`
-//! branch; the Rust port is the single source of truth (it also runs in the
-//! browser via WASM).
+//! Structurally ported from the Python proof-of-concept on the
+//! `feature/annotation-resolver` branch (resolution order, hint fallback,
+//! dedup, tiebreak margin). The scoring function differs deliberately: the
+//! PoC used `difflib.SequenceMatcher.ratio()` (Ratcliff-Obershelp); this uses
+//! normalised Levenshtein per RFC-018, which is harsher on block moves. The
+//! two disagree near the 0.7 threshold, so a boundary BDD scenario guards the
+//! behaviour. The Rust port is the single source of truth (it also runs in
+//! the browser via WASM).
+//!
+//! All offsets ([`TextMatch::start`]/`end`, [`SelectorHint`] positions) are
+//! **`char` offsets** (Unicode scalar values), not byte or UTF-16 code-unit
+//! offsets. JS consumers indexing the law text must account for this; see the
+//! WASM binding docs.
 
 use crate::annotation::types::{MatchResult, SelectorHint, TextMatch, TextQuoteSelector};
 use crate::article::Article;
@@ -181,14 +192,19 @@ fn verify_at_position(
     if !selector.prefix.is_empty() {
         let prefix_start = start.saturating_sub(selector.prefix.chars().count() + 1);
         let actual: String = chars[prefix_start..start].iter().collect();
-        if !actual.trim().contains(selector.prefix.trim()) {
+        // The prefix is the text immediately *before* `exact`, so the window
+        // must *end with* it (ends_with, not contains: prefix "een" must not
+        // be satisfied by "geen").
+        if !actual.trim().ends_with(selector.prefix.trim()) {
             return None;
         }
     }
     if !selector.suffix.is_empty() {
         let suffix_end = (end + selector.suffix.chars().count() + 1).min(chars.len());
         let actual: String = chars[end..suffix_end].iter().collect();
-        if !actual.trim().contains(selector.suffix.trim()) {
+        // The suffix is the text immediately *after* `exact`, so the window
+        // must *start with* it.
+        if !actual.trim().starts_with(selector.suffix.trim()) {
             return None;
         }
     }
@@ -220,17 +236,22 @@ fn find_exact_matches(text: &str, selector: &TextQuoteSelector) -> Vec<TextMatch
         let pos = from + rel;
         let end = pos + exact.len();
 
+        // Prefix is the text right before `exact`: the window must end with
+        // it. Suffix is the text right after: the window must start with it.
+        // ends_with/starts_with (not contains) so prefix "een" is not
+        // satisfied by "geen". The +1 char of slack plus trim() keeps the
+        // check whitespace-tolerant.
         let prefix_ok = selector.prefix.is_empty() || {
             let p_len = selector.prefix.chars().count();
             let p_start = pos.saturating_sub(p_len + 1);
             let actual: String = chars[p_start..pos].iter().collect();
-            actual.trim().contains(selector.prefix.trim())
+            actual.trim().ends_with(selector.prefix.trim())
         };
         let suffix_ok = selector.suffix.is_empty() || {
             let s_len = selector.suffix.chars().count();
             let s_end = (end + s_len + 1).min(chars.len());
             let actual: String = chars[end..s_end].iter().collect();
-            actual.trim().contains(selector.suffix.trim())
+            actual.trim().starts_with(selector.suffix.trim())
         };
 
         if prefix_ok && suffix_ok {
@@ -263,6 +284,11 @@ fn find_fuzzy_matches(text: &str, selector: &TextQuoteSelector, threshold: f64) 
     let min_w = exact_len.saturating_sub(tolerance).max(1);
     let max_w = exact_len + tolerance;
 
+    // Constant for the whole scan: compute once, not per window position.
+    let exact_words = significant_words(&selector.exact);
+    let prefix_len = selector.prefix.chars().count();
+    let suffix_len = selector.suffix.chars().count();
+
     let mut matches: Vec<TextMatch> = Vec::new();
     for window in min_w..=max_w {
         if window > chars.len() {
@@ -270,12 +296,10 @@ fn find_fuzzy_matches(text: &str, selector: &TextQuoteSelector, threshold: f64) 
         }
         for i in 0..=(chars.len() - window) {
             let candidate: String = chars[i..i + window].iter().collect();
-            if !shares_significant_content(&selector.exact, &candidate) {
+            if !shares_significant_content(&exact_words, &candidate) {
                 continue;
             }
 
-            let prefix_len = selector.prefix.chars().count();
-            let suffix_len = selector.suffix.chars().count();
             let p_start = i.saturating_sub(prefix_len);
             let actual_prefix: String = chars[p_start..i].iter().collect();
             let s_end = (i + window + suffix_len).min(chars.len());
@@ -314,7 +338,7 @@ fn find_fuzzy_matches(text: &str, selector: &TextQuoteSelector, threshold: f64) 
     matches
 }
 
-/// Normalised Levenshtein similarity in `[0.0, 1.0]` (RFC-016).
+/// Normalised Levenshtein similarity in `[0.0, 1.0]` (RFC-018).
 fn similarity(a: &str, b: &str) -> f64 {
     if a.is_empty() && b.is_empty() {
         return 1.0;
@@ -325,17 +349,30 @@ fn similarity(a: &str, b: &str) -> f64 {
     strsim::normalized_levenshtein(a, b)
 }
 
-/// Cheap pre-filter: do the two strings share a word longer than 3 chars?
-/// Avoids scoring obviously unrelated windows.
-fn shares_significant_content(a: &str, b: &str) -> bool {
-    let words_a: std::collections::HashSet<String> = a
+/// Significant words (longer than 3 chars, lowercased) of a string.
+///
+/// Computed once for `exact` before the sliding-window scan; "significant"
+/// excludes short function words (articles, prepositions) so the pre-filter
+/// keys on content words.
+fn significant_words(s: &str) -> std::collections::HashSet<String> {
+    s.to_lowercase()
+        .split_whitespace()
+        .filter(|w| w.chars().count() > 3)
+        .map(String::from)
+        .collect()
+}
+
+/// Cheap pre-filter: does the candidate share a significant word with `exact`?
+/// Avoids scoring obviously unrelated windows. `exact_words` is precomputed by
+/// the caller so this allocates nothing per window.
+fn shares_significant_content(
+    exact_words: &std::collections::HashSet<String>,
+    candidate: &str,
+) -> bool {
+    candidate
         .to_lowercase()
         .split_whitespace()
-        .map(String::from)
-        .collect();
-    b.to_lowercase()
-        .split_whitespace()
-        .any(|w| w.chars().count() > 3 && words_a.contains(w))
+        .any(|w| w.chars().count() > 3 && exact_words.contains(w))
 }
 
 /// Keep only the highest-confidence match for each overlapping region.

--- a/packages/engine/src/annotation/resolver.rs
+++ b/packages/engine/src/annotation/resolver.rs
@@ -189,22 +189,23 @@ fn verify_at_position(
 ) -> Option<TextMatch> {
     let chars: Vec<char> = text.chars().collect();
 
+    // The window is exactly `len + 1` chars wide and sits flush against
+    // `exact`, so after trimming it must *equal* the prefix/suffix. Equality
+    // (not ends_with/starts_with) rejects word-internal false positives: with
+    // prefix "op een", the window before a wrong occurrence in "strop een"
+    // trims to "rop een", which `ends_with("op een")` would wrongly accept.
+    // The +1 char of slack absorbs a single whitespace difference.
     if !selector.prefix.is_empty() {
         let prefix_start = start.saturating_sub(selector.prefix.chars().count() + 1);
         let actual: String = chars[prefix_start..start].iter().collect();
-        // The prefix is the text immediately *before* `exact`, so the window
-        // must *end with* it (ends_with, not contains: prefix "een" must not
-        // be satisfied by "geen").
-        if !actual.trim().ends_with(selector.prefix.trim()) {
+        if actual.trim() != selector.prefix.trim() {
             return None;
         }
     }
     if !selector.suffix.is_empty() {
         let suffix_end = (end + selector.suffix.chars().count() + 1).min(chars.len());
         let actual: String = chars[end..suffix_end].iter().collect();
-        // The suffix is the text immediately *after* `exact`, so the window
-        // must *start with* it.
-        if !actual.trim().starts_with(selector.suffix.trim()) {
+        if actual.trim() != selector.suffix.trim() {
             return None;
         }
     }
@@ -236,22 +237,22 @@ fn find_exact_matches(text: &str, selector: &TextQuoteSelector) -> Vec<TextMatch
         let pos = from + rel;
         let end = pos + exact.len();
 
-        // Prefix is the text right before `exact`: the window must end with
-        // it. Suffix is the text right after: the window must start with it.
-        // ends_with/starts_with (not contains) so prefix "een" is not
-        // satisfied by "geen". The +1 char of slack plus trim() keeps the
-        // check whitespace-tolerant.
+        // Window is exactly `len + 1` chars flush against `exact`, so after
+        // trimming it must *equal* the prefix/suffix. Equality (not
+        // ends_with/starts_with) rejects word-internal false positives, e.g.
+        // prefix "op een" must not be satisfied by "rop een". The +1 char of
+        // slack plus trim() absorbs a single whitespace difference.
         let prefix_ok = selector.prefix.is_empty() || {
             let p_len = selector.prefix.chars().count();
             let p_start = pos.saturating_sub(p_len + 1);
             let actual: String = chars[p_start..pos].iter().collect();
-            actual.trim().ends_with(selector.prefix.trim())
+            actual.trim() == selector.prefix.trim()
         };
         let suffix_ok = selector.suffix.is_empty() || {
             let s_len = selector.suffix.chars().count();
             let s_end = (end + s_len + 1).min(chars.len());
             let actual: String = chars[end..s_end].iter().collect();
-            actual.trim().starts_with(selector.suffix.trim())
+            actual.trim() == selector.suffix.trim()
         };
 
         if prefix_ok && suffix_ok {
@@ -474,6 +475,23 @@ mod tests {
         let sel = selector("verzekerde", "heeft de ", " aanspraak");
         let r = resolve(&sel, &arts);
         assert!(r.is_found());
+    }
+
+    #[test]
+    fn prefix_rejects_word_internal_false_positive() {
+        // "op een" must not be satisfied by the word-internal "...rop een"
+        // (the bug an `ends_with` check would let through). Only the genuine
+        // occurrence preceded by exactly "op een" should match.
+        let arts = vec![article(
+            "2",
+            "de stroop een zoetstof; recht op een zorgtoeslag",
+        )];
+        let sel = selector("zorgtoeslag", "op een ", "");
+        let r = resolve(&sel, &arts);
+        assert!(r.is_found(), "expected the genuine 'op een ' occurrence");
+        let m = r.single().unwrap();
+        // It must be the second "zorgtoeslag"-context, not anchored via "stroop een".
+        assert_eq!(m.matched_text, "zorgtoeslag");
     }
 
     #[test]

--- a/packages/engine/src/annotation/resolver.rs
+++ b/packages/engine/src/annotation/resolver.rs
@@ -1,0 +1,506 @@
+//! TextQuoteSelector resolution algorithm (RFC-005, RFC-016).
+//!
+//! Resolution order:
+//! 1. If a hint is present, try the hinted article first; on failure fall
+//!    through to a full search (the hint is non-authoritative).
+//! 2. Exact match: locate `prefix + exact + suffix` as a substring, with
+//!    whitespace-tolerant prefix/suffix checks.
+//! 3. Fuzzy match: a sliding window over the text scored
+//!    `exact*0.5 + prefix*0.25 + suffix*0.25` using normalised Levenshtein
+//!    similarity, keeping candidates at or above the threshold (0.7).
+//! 4. One match → [`MatchStatus::Found`], several equally-good →
+//!    [`MatchStatus::Ambiguous`], none → [`MatchStatus::Orphaned`].
+//!
+//! Ported from the Python proof-of-concept on the `feature/annotation-resolver`
+//! branch; the Rust port is the single source of truth (it also runs in the
+//! browser via WASM).
+
+use crate::annotation::types::{MatchResult, SelectorHint, TextMatch, TextQuoteSelector};
+use crate::article::Article;
+
+/// Default minimum weighted score for a fuzzy match to count.
+pub const DEFAULT_FUZZY_THRESHOLD: f64 = 0.7;
+
+/// Allowed window-length variation around `exact.len()` when scanning for
+/// fuzzy candidates (30%).
+const WINDOW_TOLERANCE: f64 = 0.3;
+
+/// Margin by which the best fuzzy match must beat the second-best to be
+/// treated as unambiguous.
+const TIEBREAK_MARGIN: f64 = 0.1;
+
+/// Resolve `selector` against the articles of a law.
+///
+/// Article numbers on the returned matches identify where the text was found.
+/// A present hint is tried first but never overrides a full-text search.
+pub fn resolve(selector: &TextQuoteSelector, articles: &[Article]) -> MatchResult {
+    resolve_with_threshold(selector, articles, DEFAULT_FUZZY_THRESHOLD)
+}
+
+/// [`resolve`] with an explicit fuzzy threshold (used by tests).
+pub fn resolve_with_threshold(
+    selector: &TextQuoteSelector,
+    articles: &[Article],
+    threshold: f64,
+) -> MatchResult {
+    if let Some(hint) = &selector.hint {
+        let hinted = resolve_hint(selector, articles, threshold, hint);
+        if hinted.is_found() {
+            return hinted;
+        }
+        // Hint failed: fall through to a full search.
+    }
+
+    // Exact match across all articles.
+    let mut exact: Vec<TextMatch> = Vec::new();
+    for article in articles {
+        for mut m in find_exact_matches(&article.text, selector) {
+            m.article_number = article.number.clone();
+            exact.push(m);
+        }
+    }
+    if !exact.is_empty() {
+        return if exact.len() == 1 {
+            MatchResult::found(exact)
+        } else {
+            MatchResult::ambiguous(exact)
+        };
+    }
+
+    // Fuzzy match across all articles.
+    let mut fuzzy: Vec<TextMatch> = Vec::new();
+    for article in articles {
+        for mut m in find_fuzzy_matches(&article.text, selector, threshold) {
+            m.article_number = article.number.clone();
+            fuzzy.push(m);
+        }
+    }
+    finalize_fuzzy(fuzzy)
+}
+
+/// Resolve a selector against a single raw text body (no article context).
+pub fn resolve_in_text(selector: &TextQuoteSelector, text: &str, threshold: f64) -> MatchResult {
+    let exact = find_exact_matches(text, selector);
+    if !exact.is_empty() {
+        return if exact.len() == 1 {
+            MatchResult::found(exact)
+        } else {
+            MatchResult::ambiguous(exact)
+        };
+    }
+    finalize_fuzzy(find_fuzzy_matches(text, selector, threshold))
+}
+
+/// Collapse fuzzy candidates into a final [`MatchResult`].
+///
+/// Overlapping spans are deduplicated keeping the highest confidence. A single
+/// surviving match, or a clear winner (more than [`TIEBREAK_MARGIN`] ahead of
+/// the runner-up), is `Found`; otherwise `Ambiguous`; empty is `Orphaned`.
+fn finalize_fuzzy(matches: Vec<TextMatch>) -> MatchResult {
+    if matches.is_empty() {
+        return MatchResult::orphaned();
+    }
+    let deduped = deduplicate_overlapping(matches);
+    if deduped.len() == 1 {
+        return MatchResult::found(deduped);
+    }
+    if deduped.len() > 1 && deduped[0].confidence - deduped[1].confidence > TIEBREAK_MARGIN {
+        return MatchResult::found(vec![deduped[0].clone()]);
+    }
+    MatchResult::ambiguous(deduped)
+}
+
+/// Try the hinted article (optionally a hinted position) before any full
+/// search. Returns `Orphaned` on failure so the caller falls back.
+fn resolve_hint(
+    selector: &TextQuoteSelector,
+    articles: &[Article],
+    threshold: f64,
+    hint: &SelectorHint,
+) -> MatchResult {
+    let Some(article) = articles.iter().find(|a| a.number == hint.article_number) else {
+        return MatchResult::orphaned();
+    };
+
+    // Exact position hint: verify the exact text sits at the given offsets.
+    if let (Some(start), Some(end)) = (hint.start, hint.end) {
+        let chars: Vec<char> = article.text.chars().collect();
+        if start <= end && end <= chars.len() {
+            let at: String = chars[start..end].iter().collect();
+            if at == selector.exact {
+                if let Some(m) =
+                    verify_at_position(&article.text, selector, start, end, &article.number)
+                {
+                    return MatchResult::found(vec![m]);
+                }
+            }
+        }
+    }
+
+    // Search the whole hinted article (exact then fuzzy).
+    let mut exact = find_exact_matches(&article.text, selector);
+    for m in &mut exact {
+        m.article_number = article.number.clone();
+    }
+    if !exact.is_empty() {
+        return if exact.len() == 1 {
+            MatchResult::found(exact)
+        } else {
+            MatchResult::ambiguous(exact)
+        };
+    }
+
+    let mut fuzzy = find_fuzzy_matches(&article.text, selector, threshold);
+    for m in &mut fuzzy {
+        m.article_number = article.number.clone();
+    }
+    if fuzzy.is_empty() {
+        return MatchResult::orphaned();
+    }
+    let deduped = deduplicate_overlapping(fuzzy);
+    if deduped.len() == 1 {
+        MatchResult::found(deduped)
+    } else if deduped.len() > 1 && deduped[0].confidence - deduped[1].confidence > TIEBREAK_MARGIN {
+        MatchResult::found(vec![deduped[0].clone()])
+    } else {
+        MatchResult::orphaned()
+    }
+}
+
+/// Confirm a candidate at a fixed position has the expected (whitespace-
+/// tolerant) prefix and suffix.
+fn verify_at_position(
+    text: &str,
+    selector: &TextQuoteSelector,
+    start: usize,
+    end: usize,
+    article_number: &str,
+) -> Option<TextMatch> {
+    let chars: Vec<char> = text.chars().collect();
+
+    if !selector.prefix.is_empty() {
+        let prefix_start = start.saturating_sub(selector.prefix.chars().count() + 1);
+        let actual: String = chars[prefix_start..start].iter().collect();
+        if !actual.trim().contains(selector.prefix.trim()) {
+            return None;
+        }
+    }
+    if !selector.suffix.is_empty() {
+        let suffix_end = (end + selector.suffix.chars().count() + 1).min(chars.len());
+        let actual: String = chars[end..suffix_end].iter().collect();
+        if !actual.trim().contains(selector.suffix.trim()) {
+            return None;
+        }
+    }
+
+    Some(TextMatch {
+        article_number: article_number.to_string(),
+        start,
+        end,
+        confidence: 1.0,
+        matched_text: chars[start..end].iter().collect(),
+    })
+}
+
+/// All exact occurrences of `exact` whose (whitespace-normalised) prefix and
+/// suffix match. Offsets are in `char`s, not bytes.
+fn find_exact_matches(text: &str, selector: &TextQuoteSelector) -> Vec<TextMatch> {
+    let chars: Vec<char> = text.chars().collect();
+    let exact: Vec<char> = selector.exact.chars().collect();
+    if exact.is_empty() {
+        return Vec::new();
+    }
+
+    let mut matches = Vec::new();
+    let mut from = 0usize;
+    while from + exact.len() <= chars.len() {
+        let Some(rel) = find_subslice(&chars[from..], &exact) else {
+            break;
+        };
+        let pos = from + rel;
+        let end = pos + exact.len();
+
+        let prefix_ok = selector.prefix.is_empty() || {
+            let p_len = selector.prefix.chars().count();
+            let p_start = pos.saturating_sub(p_len + 1);
+            let actual: String = chars[p_start..pos].iter().collect();
+            actual.trim().contains(selector.prefix.trim())
+        };
+        let suffix_ok = selector.suffix.is_empty() || {
+            let s_len = selector.suffix.chars().count();
+            let s_end = (end + s_len + 1).min(chars.len());
+            let actual: String = chars[end..s_end].iter().collect();
+            actual.trim().contains(selector.suffix.trim())
+        };
+
+        if prefix_ok && suffix_ok {
+            matches.push(TextMatch {
+                article_number: String::new(),
+                start: pos,
+                end,
+                confidence: 1.0,
+                matched_text: selector.exact.clone(),
+            });
+        }
+        from = pos + 1;
+    }
+    matches
+}
+
+/// Fuzzy candidates at or above `threshold`, sorted by confidence descending.
+///
+/// Mirrors the Python proof-of-concept: collect exact occurrences plus
+/// sliding windows of `len(exact) ± 30%` that share a significant word with
+/// `exact`, then score each by weighted Levenshtein similarity.
+fn find_fuzzy_matches(text: &str, selector: &TextQuoteSelector, threshold: f64) -> Vec<TextMatch> {
+    let chars: Vec<char> = text.chars().collect();
+    let exact_len = selector.exact.chars().count();
+    if exact_len == 0 || chars.is_empty() {
+        return Vec::new();
+    }
+
+    let tolerance = ((exact_len as f64) * WINDOW_TOLERANCE) as usize;
+    let min_w = exact_len.saturating_sub(tolerance).max(1);
+    let max_w = exact_len + tolerance;
+
+    let mut matches: Vec<TextMatch> = Vec::new();
+    for window in min_w..=max_w {
+        if window > chars.len() {
+            break;
+        }
+        for i in 0..=(chars.len() - window) {
+            let candidate: String = chars[i..i + window].iter().collect();
+            if !shares_significant_content(&selector.exact, &candidate) {
+                continue;
+            }
+
+            let prefix_len = selector.prefix.chars().count();
+            let suffix_len = selector.suffix.chars().count();
+            let p_start = i.saturating_sub(prefix_len);
+            let actual_prefix: String = chars[p_start..i].iter().collect();
+            let s_end = (i + window + suffix_len).min(chars.len());
+            let actual_suffix: String = chars[i + window..s_end].iter().collect();
+
+            let exact_score = similarity(&selector.exact, &candidate);
+            let prefix_score = if selector.prefix.is_empty() {
+                1.0
+            } else {
+                similarity(&selector.prefix, &actual_prefix)
+            };
+            let suffix_score = if selector.suffix.is_empty() {
+                1.0
+            } else {
+                similarity(&selector.suffix, &actual_suffix)
+            };
+
+            let weighted = exact_score * 0.5 + prefix_score * 0.25 + suffix_score * 0.25;
+            if weighted >= threshold {
+                matches.push(TextMatch {
+                    article_number: String::new(),
+                    start: i,
+                    end: i + window,
+                    confidence: weighted,
+                    matched_text: candidate,
+                });
+            }
+        }
+    }
+
+    matches.sort_by(|a, b| {
+        b.confidence
+            .partial_cmp(&a.confidence)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    matches
+}
+
+/// Normalised Levenshtein similarity in `[0.0, 1.0]` (RFC-016).
+fn similarity(a: &str, b: &str) -> f64 {
+    if a.is_empty() && b.is_empty() {
+        return 1.0;
+    }
+    if a.is_empty() || b.is_empty() {
+        return 0.0;
+    }
+    strsim::normalized_levenshtein(a, b)
+}
+
+/// Cheap pre-filter: do the two strings share a word longer than 3 chars?
+/// Avoids scoring obviously unrelated windows.
+fn shares_significant_content(a: &str, b: &str) -> bool {
+    let words_a: std::collections::HashSet<String> = a
+        .to_lowercase()
+        .split_whitespace()
+        .map(String::from)
+        .collect();
+    b.to_lowercase()
+        .split_whitespace()
+        .any(|w| w.chars().count() > 3 && words_a.contains(w))
+}
+
+/// Keep only the highest-confidence match for each overlapping region.
+fn deduplicate_overlapping(mut matches: Vec<TextMatch>) -> Vec<TextMatch> {
+    matches.sort_by(|a, b| {
+        b.confidence
+            .partial_cmp(&a.confidence)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    let mut kept: Vec<TextMatch> = Vec::new();
+    for m in matches {
+        let overlaps = kept
+            .iter()
+            .any(|k| m.article_number == k.article_number && m.start < k.end && k.start < m.end);
+        if !overlaps {
+            kept.push(m);
+        }
+    }
+    kept
+}
+
+/// First index of `needle` within `haystack`, comparing `char`s.
+fn find_subslice(haystack: &[char], needle: &[char]) -> Option<usize> {
+    if needle.is_empty() || needle.len() > haystack.len() {
+        return None;
+    }
+    (0..=haystack.len() - needle.len()).find(|&i| haystack[i..i + needle.len()] == *needle)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn article(number: &str, text: &str) -> Article {
+        Article {
+            number: number.to_string(),
+            text: text.to_string(),
+            url: None,
+            machine_readable: None,
+        }
+    }
+
+    fn selector(exact: &str, prefix: &str, suffix: &str) -> TextQuoteSelector {
+        TextQuoteSelector {
+            exact: exact.to_string(),
+            prefix: prefix.to_string(),
+            suffix: suffix.to_string(),
+            hint: None,
+        }
+    }
+
+    #[test]
+    fn exact_match_single() {
+        let arts = vec![article(
+            "2",
+            "heeft de verzekerde aanspraak op een zorgtoeslag ter grootte van dat verschil",
+        )];
+        let sel = selector("zorgtoeslag", "op een ", " ter grootte");
+        let r = resolve(&sel, &arts);
+        assert!(r.is_found());
+        assert_eq!(r.single().unwrap().article_number, "2");
+        assert_eq!(r.single().unwrap().confidence, 1.0);
+    }
+
+    #[test]
+    fn article_renumbered_still_resolves() {
+        // Same text, different article number: content-addressed lookup wins.
+        let arts = vec![
+            article("1a", "Een nieuw ingevoegd artikel."),
+            article(
+                "4a",
+                "heeft de verzekerde aanspraak op een zorgtoeslag ter grootte van dat verschil",
+            ),
+        ];
+        let sel = selector("zorgtoeslag", "op een ", " ter grootte");
+        let r = resolve(&sel, &arts);
+        assert!(r.is_found());
+        assert_eq!(r.single().unwrap().article_number, "4a");
+    }
+
+    #[test]
+    fn ambiguous_without_context() {
+        let arts = vec![article(
+            "2",
+            "de verzekerde en de verzekerde en nog een verzekerde",
+        )];
+        let sel = selector("verzekerde", "", "");
+        let r = resolve(&sel, &arts);
+        assert!(r.is_ambiguous());
+        assert!(r.matches.len() >= 2);
+    }
+
+    #[test]
+    fn unique_with_context() {
+        let arts = vec![article(
+            "2",
+            "de verzekerde betaalt; de verzekerde ontvangt; heeft de verzekerde aanspraak op zorgtoeslag",
+        )];
+        let sel = selector("verzekerde", "heeft de ", " aanspraak");
+        let r = resolve(&sel, &arts);
+        assert!(r.is_found());
+    }
+
+    #[test]
+    fn orphaned_when_text_removed() {
+        let arts = vec![article("2", "Geheel andere tekst zonder de gezochte zin.")];
+        let sel = selector(
+            "zorgtoeslag ter grootte van dat verschil",
+            "aanspraak op een ",
+            "",
+        );
+        let r = resolve(&sel, &arts);
+        assert!(r.is_orphaned());
+    }
+
+    #[test]
+    fn fuzzy_match_on_minor_change() {
+        // "aanspraak op een" -> "recht op een"; suffix slightly changed too.
+        let arts = vec![article(
+            "2",
+            "heeft de verzekerde recht op een zorgtoeslag ter grootte van het verschil",
+        )];
+        let sel = selector(
+            "aanspraak op een zorgtoeslag",
+            "heeft de verzekerde ",
+            " ter grootte van dat verschil",
+        );
+        let r = resolve(&sel, &arts);
+        assert!(r.is_found(), "expected fuzzy match, got {:?}", r.status);
+        assert!(r.single().unwrap().confidence < 1.0);
+    }
+
+    #[test]
+    fn hint_optimisation_finds_match() {
+        let arts = vec![
+            article("1", "Onbelangrijke tekst."),
+            article("2", "heeft de verzekerde aanspraak op een zorgtoeslag hier"),
+        ];
+        let mut sel = selector("zorgtoeslag", "op een ", " hier");
+        sel.hint = Some(SelectorHint {
+            article_number: "2".to_string(),
+            start: None,
+            end: None,
+        });
+        let r = resolve(&sel, &arts);
+        assert!(r.is_found());
+        assert_eq!(r.single().unwrap().article_number, "2");
+    }
+
+    #[test]
+    fn outdated_hint_falls_back_to_full_search() {
+        // Hint points at article 9 which does not contain the text;
+        // resolver must still find it in article 2.
+        let arts = vec![
+            article("2", "heeft de verzekerde aanspraak op een zorgtoeslag hier"),
+            article("9", "Niets relevants."),
+        ];
+        let mut sel = selector("zorgtoeslag", "op een ", " hier");
+        sel.hint = Some(SelectorHint {
+            article_number: "9".to_string(),
+            start: Some(0),
+            end: Some(5),
+        });
+        let r = resolve(&sel, &arts);
+        assert!(r.is_found());
+        assert_eq!(r.single().unwrap().article_number, "2");
+    }
+}

--- a/packages/engine/src/annotation/types.rs
+++ b/packages/engine/src/annotation/types.rs
@@ -97,14 +97,21 @@ pub enum MatchStatus {
 }
 
 /// A single located span in the law text.
+///
+/// `start`/`end` are **`char` offsets** (Unicode scalar values) into the
+/// article text, article-relative, not byte offsets and not UTF-16 code
+/// units. A JS consumer slicing the text (e.g. to build a DOM Range) must map
+/// these to UTF-16 indices itself; they will differ for any text containing
+/// non-BMP characters, and the convention must match the offsets the editor
+/// writes into a `regelrecht:hint`.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TextMatch {
     /// Article the match was found in (empty when resolving raw text).
     #[serde(default)]
     pub article_number: String,
-    /// Character offset (article-relative) where the match begins.
+    /// `char` offset (article-relative) where the match begins.
     pub start: usize,
-    /// Character offset (article-relative) where the match ends.
+    /// `char` offset (article-relative) where the match ends.
     pub end: usize,
     /// Confidence: `1.0` for an exact match, `< 1.0` for a fuzzy match.
     pub confidence: f64,

--- a/packages/engine/src/annotation/types.rs
+++ b/packages/engine/src/annotation/types.rs
@@ -1,0 +1,222 @@
+//! Data types for note resolution.
+//!
+//! These mirror the W3C Web Annotation `TextQuoteSelector` and the
+//! `regelrecht:hint` performance extension defined in RFC-005.
+
+use serde::{Deserialize, Serialize};
+
+/// A W3C Web Annotation `TextQuoteSelector`.
+///
+/// Selects text by an exact quote plus optional surrounding context. The
+/// prefix/suffix disambiguate when the exact text occurs more than once.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TextQuoteSelector {
+    /// The exact text to locate.
+    pub exact: String,
+    /// Text expected immediately before `exact` (for disambiguation).
+    #[serde(default)]
+    pub prefix: String,
+    /// Text expected immediately after `exact` (for disambiguation).
+    #[serde(default)]
+    pub suffix: String,
+    /// Optional, non-authoritative performance hint (`regelrecht:hint`).
+    #[serde(default, rename = "regelrecht:hint")]
+    pub hint: Option<SelectorHint>,
+}
+
+/// Performance hint: where to look first.
+///
+/// Parsed from a `regelrecht:hint` CssSelector (`article[number='N']`)
+/// optionally refined by a TextPositionSelector. The hint is never
+/// authoritative: if the text is not found at the hinted location, the whole
+/// law is searched.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(from = "HintWire")]
+pub struct SelectorHint {
+    /// Article number to search first (e.g. "2", "4a").
+    pub article_number: String,
+    /// Optional character offset where the match should begin (article-relative).
+    pub start: Option<usize>,
+    /// Optional character offset where the match should end (article-relative).
+    pub end: Option<usize>,
+}
+
+/// Wire format of a `regelrecht:hint` as it appears in YAML/JSON.
+///
+/// Deserialised then flattened into [`SelectorHint`]. The article number is
+/// extracted from a `CssSelector` value of the form `article[number='N']`.
+#[derive(Debug, Clone, Deserialize)]
+struct HintWire {
+    #[serde(default)]
+    value: String,
+    #[serde(default, rename = "refinedBy")]
+    refined_by: Option<RefinedBy>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RefinedBy {
+    #[serde(default)]
+    start: Option<usize>,
+    #[serde(default)]
+    end: Option<usize>,
+}
+
+impl From<HintWire> for SelectorHint {
+    fn from(wire: HintWire) -> Self {
+        let article_number = parse_article_number(&wire.value).unwrap_or_default();
+        let (start, end) = wire
+            .refined_by
+            .map(|r| (r.start, r.end))
+            .unwrap_or((None, None));
+        SelectorHint {
+            article_number,
+            start,
+            end,
+        }
+    }
+}
+
+/// Extract `N` from a CssSelector value like `article[number='N']`.
+fn parse_article_number(css_value: &str) -> Option<String> {
+    let after = css_value.split("number=").nth(1)?;
+    let trimmed = after.trim_start_matches(['\'', '"']);
+    let end = trimmed.find(['\'', '"'])?;
+    Some(trimmed[..end].to_string())
+}
+
+/// Whether a selector could be located, and how unambiguously.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MatchStatus {
+    /// Exactly one match (exact, or a clearly-best fuzzy match).
+    Found,
+    /// No match above the fuzzy threshold; the note is orphaned.
+    Orphaned,
+    /// Multiple equally-good matches; the note is ambiguous.
+    Ambiguous,
+}
+
+/// A single located span in the law text.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TextMatch {
+    /// Article the match was found in (empty when resolving raw text).
+    #[serde(default)]
+    pub article_number: String,
+    /// Character offset (article-relative) where the match begins.
+    pub start: usize,
+    /// Character offset (article-relative) where the match ends.
+    pub end: usize,
+    /// Confidence: `1.0` for an exact match, `< 1.0` for a fuzzy match.
+    pub confidence: f64,
+    /// The actual text that was matched.
+    pub matched_text: String,
+}
+
+/// The outcome of resolving a [`TextQuoteSelector`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MatchResult {
+    /// Overall resolution status.
+    pub status: MatchStatus,
+    /// Located spans. One element when `Found`, several when `Ambiguous`,
+    /// empty when `Orphaned`.
+    pub matches: Vec<TextMatch>,
+}
+
+impl MatchResult {
+    pub(crate) fn found(matches: Vec<TextMatch>) -> Self {
+        Self {
+            status: MatchStatus::Found,
+            matches,
+        }
+    }
+
+    pub(crate) fn orphaned() -> Self {
+        Self {
+            status: MatchStatus::Orphaned,
+            matches: Vec::new(),
+        }
+    }
+
+    pub(crate) fn ambiguous(matches: Vec<TextMatch>) -> Self {
+        Self {
+            status: MatchStatus::Ambiguous,
+            matches,
+        }
+    }
+
+    /// True when exactly one location was found.
+    pub fn is_found(&self) -> bool {
+        self.status == MatchStatus::Found
+    }
+
+    /// True when no location was found.
+    pub fn is_orphaned(&self) -> bool {
+        self.status == MatchStatus::Orphaned
+    }
+
+    /// True when multiple equally-good locations were found.
+    pub fn is_ambiguous(&self) -> bool {
+        self.status == MatchStatus::Ambiguous
+    }
+
+    /// The single match, when [`is_found`](Self::is_found).
+    pub fn single(&self) -> Option<&TextMatch> {
+        if self.is_found() {
+            self.matches.first()
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_article_number_from_css_selector() {
+        assert_eq!(
+            parse_article_number("article[number='4a']").as_deref(),
+            Some("4a")
+        );
+        assert_eq!(
+            parse_article_number("article[number=\"2\"]").as_deref(),
+            Some("2")
+        );
+        assert_eq!(parse_article_number("article").as_deref(), None);
+    }
+
+    #[test]
+    fn deserialises_hint_from_w3c_shape() {
+        let yaml = r#"
+exact: zorgtoeslag
+prefix: "op een "
+suffix: " ter grootte"
+regelrecht:hint:
+  type: CssSelector
+  value: "article[number='2']"
+  refinedBy:
+    type: TextPositionSelector
+    start: 45
+    end: 56
+"#;
+        let sel: TextQuoteSelector = serde_yaml_ng::from_str(yaml).unwrap();
+        let hint = sel.hint.expect("hint present");
+        assert_eq!(hint.article_number, "2");
+        assert_eq!(hint.start, Some(45));
+        assert_eq!(hint.end, Some(56));
+    }
+
+    #[test]
+    fn selector_without_hint() {
+        let yaml = r#"
+exact: verzekerde
+prefix: "de "
+"#;
+        let sel: TextQuoteSelector = serde_yaml_ng::from_str(yaml).unwrap();
+        assert_eq!(sel.exact, "verzekerde");
+        assert_eq!(sel.prefix, "de ");
+        assert_eq!(sel.suffix, "");
+        assert!(sel.hint.is_none());
+    }
+}

--- a/packages/engine/src/bin/validate_annotations.rs
+++ b/packages/engine/src/bin/validate_annotations.rs
@@ -1,14 +1,14 @@
-//! Validate note sidecar files (RFC-005, RFC-016).
+//! Validate note sidecar files (RFC-005, RFC-018).
 //!
 //! For each note file:
 //! 1. JSON Schema validation against the embedded annotation schema.
 //! 2. Resolve every note's selector against its target law (loaded from the
 //!    corpus by `$id`). Orphaned or ambiguous notes are reported as
-//!    **warnings**, not errors (RFC-016 Decision 8): law text legitimately
+//!    **warnings**, not errors (RFC-018 Decision 8): law text legitimately
 //!    drifts away from notes over time.
 //! 3. Tagging-body values are checked against the controlled vocabulary
 //!    (`corpus/annotations/_vocabulary/ambiguity.yaml`); unknown values are
-//!    **warnings** (RFC-016 Decision 9).
+//!    **warnings** (RFC-018 Decision 9).
 //!
 //! Exit code is non-zero only on schema validation failures.
 
@@ -17,7 +17,7 @@ use std::path::{Path, PathBuf};
 use std::process;
 
 use jsonschema::Validator;
-use regelrecht_engine::annotation::{resolve, TextQuoteSelector};
+use regelrecht_engine::annotation::{law_id_from_source, resolve, TextQuoteSelector};
 use regelrecht_engine::article::ArticleBasedLaw;
 
 const ANNOTATION_SCHEMA: &str = include_str!("../../../../schema/v0.5.2/annotation-schema.json");
@@ -87,7 +87,7 @@ fn main() {
     }
 
     if warnings > 0 {
-        eprintln!("\n{warnings} warning(s). Orphaned/ambiguous notes and unknown tags do not fail the build (RFC-016).");
+        eprintln!("\n{warnings} warning(s). Orphaned/ambiguous notes and unknown tags do not fail the build (RFC-018).");
     }
     if failed {
         process::exit(1);
@@ -108,7 +108,7 @@ fn check_notes(path: &Path, doc: &serde_json::Value, vocabulary: &HashSet<String
             .and_then(|t| t.get("source"))
             .and_then(|s| s.as_str())
             .and_then(law_id_from_source)
-            .and_then(|id| load_law_by_id(&id))
+            .and_then(load_law_by_id)
         {
             if let Some(selector) = note
                 .get("target")
@@ -147,12 +147,6 @@ fn check_notes(path: &Path, doc: &serde_json::Value, vocabulary: &HashSet<String
         }
     }
     warnings
-}
-
-/// Extract `{law_id}` from a `regelrecht://{law_id}` (or `.../...`) source URI.
-fn law_id_from_source(source: &str) -> Option<String> {
-    let rest = source.strip_prefix("regelrecht://")?;
-    Some(rest.split('/').next().unwrap_or(rest).to_string())
 }
 
 /// Collect every `TextualBody` value whose `purpose` is `tagging`.
@@ -235,10 +229,14 @@ fn collect_law_yaml(dir: &Path, law_id: &str, out: &mut Vec<PathBuf>) {
         if p.is_dir() {
             collect_law_yaml(&p, law_id, out);
         } else if p.extension().and_then(|e| e.to_str()) == Some("yaml") {
+            // Parse the top-level `$id` rather than substring-matching the
+            // file: a comment or a nested string containing "$id: x" would
+            // otherwise produce a false positive.
             if let Ok(content) = std::fs::read_to_string(&p) {
-                // Cheap pre-check before a full parse.
-                if content.contains(&format!("$id: {law_id}")) {
-                    out.push(p);
+                if let Ok(doc) = serde_yaml_ng::from_str::<serde_json::Value>(&content) {
+                    if doc.get("$id").and_then(|v| v.as_str()) == Some(law_id) {
+                        out.push(p);
+                    }
                 }
             }
         }

--- a/packages/engine/src/bin/validate_annotations.rs
+++ b/packages/engine/src/bin/validate_annotations.rs
@@ -1,0 +1,273 @@
+//! Validate note sidecar files (RFC-005, RFC-016).
+//!
+//! For each note file:
+//! 1. JSON Schema validation against the embedded annotation schema.
+//! 2. Resolve every note's selector against its target law (loaded from the
+//!    corpus by `$id`). Orphaned or ambiguous notes are reported as
+//!    **warnings**, not errors (RFC-016 Decision 8): law text legitimately
+//!    drifts away from notes over time.
+//! 3. Tagging-body values are checked against the controlled vocabulary
+//!    (`corpus/annotations/_vocabulary/ambiguity.yaml`); unknown values are
+//!    **warnings** (RFC-016 Decision 9).
+//!
+//! Exit code is non-zero only on schema validation failures.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::process;
+
+use jsonschema::Validator;
+use regelrecht_engine::annotation::{resolve, TextQuoteSelector};
+use regelrecht_engine::article::ArticleBasedLaw;
+
+const ANNOTATION_SCHEMA: &str = include_str!("../../../../schema/v0.5.2/annotation-schema.json");
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let files: Vec<PathBuf> = if args.is_empty() {
+        discover_note_files()
+    } else {
+        args.iter().map(PathBuf::from).collect()
+    };
+
+    if files.is_empty() {
+        eprintln!("No note files found.");
+        return;
+    }
+
+    let schema: serde_json::Value = match serde_json::from_str(ANNOTATION_SCHEMA) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("FATAL: embedded annotation schema is not valid JSON: {e}");
+            process::exit(2);
+        }
+    };
+    let validator = match Validator::new(&schema) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("FATAL: annotation schema does not compile: {e}");
+            process::exit(2);
+        }
+    };
+
+    let vocabulary = load_vocabulary();
+    let mut failed = false;
+    let mut warnings = 0usize;
+
+    for path in &files {
+        let content = match std::fs::read_to_string(path) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("FAIL: {}: read: {e}", path.display());
+                failed = true;
+                continue;
+            }
+        };
+        let doc: serde_json::Value = match serde_yaml_ng::from_str(&content) {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!("FAIL: {}: yaml parse: {e}", path.display());
+                failed = true;
+                continue;
+            }
+        };
+
+        let errors: Vec<_> = validator.iter_errors(&doc).collect();
+        if !errors.is_empty() {
+            eprintln!("FAIL: {}: schema", path.display());
+            for err in &errors {
+                eprintln!("  - {}: {}", err.instance_path(), err);
+            }
+            failed = true;
+            continue;
+        }
+        eprintln!("OK: {} (annotation schema v0.5.2)", path.display());
+
+        warnings += check_notes(path, &doc, &vocabulary);
+    }
+
+    if warnings > 0 {
+        eprintln!("\n{warnings} warning(s). Orphaned/ambiguous notes and unknown tags do not fail the build (RFC-016).");
+    }
+    if failed {
+        process::exit(1);
+    }
+}
+
+/// Resolve each note and check tag values; return the warning count.
+fn check_notes(path: &Path, doc: &serde_json::Value, vocabulary: &HashSet<String>) -> usize {
+    let Some(notes) = doc.get("annotations").and_then(|v| v.as_array()) else {
+        return 0;
+    };
+
+    let mut warnings = 0;
+    for (i, note) in notes.iter().enumerate() {
+        // Resolve the selector against the target law, if we can find it.
+        if let Some(law) = note
+            .get("target")
+            .and_then(|t| t.get("source"))
+            .and_then(|s| s.as_str())
+            .and_then(law_id_from_source)
+            .and_then(|id| load_law_by_id(&id))
+        {
+            if let Some(selector) = note
+                .get("target")
+                .and_then(|t| t.get("selector"))
+                .and_then(|s| serde_json::from_value::<TextQuoteSelector>(s.clone()).ok())
+            {
+                let result = resolve(&selector, &law.articles);
+                if result.is_orphaned() {
+                    eprintln!(
+                        "  WARN: {} note[{i}]: orphaned (selector {:?} not found in law)",
+                        path.display(),
+                        selector.exact
+                    );
+                    warnings += 1;
+                } else if result.is_ambiguous() {
+                    eprintln!(
+                        "  WARN: {} note[{i}]: ambiguous ({} matches for {:?}; add prefix/suffix)",
+                        path.display(),
+                        result.matches.len(),
+                        selector.exact
+                    );
+                    warnings += 1;
+                }
+            }
+        }
+
+        // Check tagging-body values against the controlled vocabulary.
+        for tag in tagging_values(note) {
+            if !vocabulary.contains(&tag) {
+                eprintln!(
+                    "  WARN: {} note[{i}]: tag {tag:?} not in _vocabulary/ambiguity.yaml",
+                    path.display()
+                );
+                warnings += 1;
+            }
+        }
+    }
+    warnings
+}
+
+/// Extract `{law_id}` from a `regelrecht://{law_id}` (or `.../...`) source URI.
+fn law_id_from_source(source: &str) -> Option<String> {
+    let rest = source.strip_prefix("regelrecht://")?;
+    Some(rest.split('/').next().unwrap_or(rest).to_string())
+}
+
+/// Collect every `TextualBody` value whose `purpose` is `tagging`.
+fn tagging_values(note: &serde_json::Value) -> Vec<String> {
+    let mut out = Vec::new();
+    let bodies = match note.get("body") {
+        Some(serde_json::Value::Array(a)) => a.clone(),
+        Some(other) => vec![other.clone()],
+        None => return out,
+    };
+    for body in bodies {
+        let is_tag = body.get("purpose").and_then(|p| p.as_str()) == Some("tagging");
+        if is_tag {
+            if let Some(v) = body.get("value").and_then(|v| v.as_str()) {
+                out.push(v.to_string());
+            }
+        }
+    }
+    out
+}
+
+/// Repo root: two levels up from this crate (`packages/engine`).
+///
+/// `CARGO_MANIFEST_DIR` is `<repo>/packages/engine`, so two `..` segments
+/// always yield the repo root; this never fails at runtime.
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+}
+
+/// All `corpus/annotations/**/annotations.yaml` files (skips `_vocabulary`).
+fn discover_note_files() -> Vec<PathBuf> {
+    let dir = repo_root().join("corpus/annotations");
+    let mut out = Vec::new();
+    collect_yaml(&dir, &mut out);
+    out.sort();
+    out
+}
+
+fn collect_yaml(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let p = entry.path();
+        if p.is_dir() {
+            if p.file_name().and_then(|n| n.to_str()) == Some("_vocabulary") {
+                continue;
+            }
+            collect_yaml(&p, out);
+        } else if p.extension().and_then(|e| e.to_str()) == Some("yaml") {
+            out.push(p);
+        }
+    }
+}
+
+/// Load the latest version of a law identified by its `$id` from the corpus.
+///
+/// Scans `corpus/regulation/` for a YAML whose `$id` matches, preferring the
+/// lexicographically last filename (latest `valid_from`).
+fn load_law_by_id(law_id: &str) -> Option<ArticleBasedLaw> {
+    let mut candidates: Vec<PathBuf> = Vec::new();
+    collect_law_yaml(
+        &repo_root().join("corpus/regulation"),
+        law_id,
+        &mut candidates,
+    );
+    candidates.sort();
+    let path = candidates.last()?;
+    ArticleBasedLaw::from_yaml_file(path).ok()
+}
+
+fn collect_law_yaml(dir: &Path, law_id: &str, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let p = entry.path();
+        if p.is_dir() {
+            collect_law_yaml(&p, law_id, out);
+        } else if p.extension().and_then(|e| e.to_str()) == Some("yaml") {
+            if let Ok(content) = std::fs::read_to_string(&p) {
+                // Cheap pre-check before a full parse.
+                if content.contains(&format!("$id: {law_id}")) {
+                    out.push(p);
+                }
+            }
+        }
+    }
+}
+
+/// Load the ambiguity vocabulary `id`s. Missing file means an empty set
+/// (every tag will warn), which surfaces the misconfiguration.
+fn load_vocabulary() -> HashSet<String> {
+    let path = repo_root().join("corpus/annotations/_vocabulary/ambiguity.yaml");
+    let Ok(content) = std::fs::read_to_string(&path) else {
+        eprintln!("WARN: vocabulary not found at {}", path.display());
+        return HashSet::new();
+    };
+    let doc: serde_json::Value = match serde_yaml_ng::from_str(&content) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("WARN: vocabulary parse error: {e}");
+            return HashSet::new();
+        }
+    };
+    doc.get("ambiguity")
+        .and_then(|v| v.as_array())
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|it| it.get("id").and_then(|v| v.as_str()))
+                .map(String::from)
+                .collect()
+        })
+        .unwrap_or_default()
+}

--- a/packages/engine/src/lib.rs
+++ b/packages/engine/src/lib.rs
@@ -54,7 +54,7 @@ pub mod telemetry;
 
 // Re-export commonly used items
 pub use annotation::{
-    resolve as resolve_annotation, MatchResult, MatchStatus, SelectorHint, TextMatch,
+    law_id_from_source, resolve as resolve_note, MatchResult, MatchStatus, SelectorHint, TextMatch,
     TextQuoteSelector,
 };
 pub use article::{

--- a/packages/engine/src/lib.rs
+++ b/packages/engine/src/lib.rs
@@ -26,6 +26,7 @@
 //! )?;
 //! ```
 
+pub mod annotation;
 pub mod article;
 pub mod config;
 pub mod context;
@@ -52,6 +53,10 @@ pub mod wasm;
 pub mod telemetry;
 
 // Re-export commonly used items
+pub use annotation::{
+    resolve as resolve_annotation, MatchResult, MatchStatus, SelectorHint, TextMatch,
+    TextQuoteSelector,
+};
 pub use article::{
     Action, ActionOperation, ActionValue, Article, ArticleBasedLaw, Case, Execution,
     HookDeclaration, HookFilter, HookPoint, MachineReadable, OverrideDeclaration,

--- a/packages/engine/src/wasm.rs
+++ b/packages/engine/src/wasm.rs
@@ -58,10 +58,11 @@ use serde_wasm_bindgen::Serializer;
 use std::collections::BTreeMap;
 use wasm_bindgen::prelude::*;
 
+use crate::annotation::{self, TextQuoteSelector};
 use crate::config;
 use crate::engine::OutputProvenance;
 use crate::error::EngineError;
-use crate::service::LawExecutionService;
+use crate::service::{LawExecutionService, ServiceProvider};
 use crate::trace::{PathNode, TraceBuilder};
 use crate::types::{RegulatoryLayer, Value};
 
@@ -500,6 +501,84 @@ impl WasmEngine {
     #[wasm_bindgen(js_name = lawCount)]
     pub fn law_count(&self) -> usize {
         self.service.law_count()
+    }
+
+    /// Resolve a single TextQuoteSelector against a loaded law (RFC-005).
+    ///
+    /// The law must already be loaded via `loadLaw()`. The selector is
+    /// content-addressed, so it resolves on whichever version is loaded.
+    ///
+    /// # Arguments
+    /// * `law_id` - ID of the loaded law
+    /// * `selector` - JS object: `{ exact, prefix?, suffix?, "regelrecht:hint"? }`
+    ///
+    /// # Returns
+    /// * `Ok(JsValue)` - `MatchResult`: `{ status, matches: [{ article_number,
+    ///   start, end, confidence, matched_text }] }`
+    /// * `Err(JsValue)` - Error if the law is not loaded or the selector is invalid
+    #[wasm_bindgen(js_name = resolveAnnotation)]
+    pub fn resolve_annotation(&self, law_id: &str, selector: JsValue) -> Result<JsValue, JsValue> {
+        let selector: TextQuoteSelector = serde_wasm_bindgen::from_value(selector)
+            .map_err(|e| wasm_error(&format!("Invalid selector: {e}")))?;
+        let law = ServiceProvider::get_law(&self.service, law_id)
+            .ok_or_else(|| wasm_error(&format!("Law not loaded: {law_id}")))?;
+        let result = annotation::resolve(&selector, &law.articles);
+        result
+            .serialize(&js_serializer())
+            .map_err(|e| wasm_error(&format!("Serialization error: {e}")))
+    }
+
+    /// Resolve all notes in a note-sidecar YAML string against a loaded law.
+    ///
+    /// Parses an `annotations:` document (the format validated by
+    /// `just validate-annotations`) and resolves every note's selector. Notes
+    /// whose `target.source` law id differs from `law_id` are skipped.
+    ///
+    /// # Arguments
+    /// * `law_id` - ID of the loaded law to resolve against
+    /// * `annotations_yaml` - Contents of an `annotations.yaml` sidecar file
+    ///
+    /// # Returns
+    /// * `Ok(JsValue)` - Array of `{ note, match }` objects, where `match` is
+    ///   the `MatchResult` for that note's selector
+    /// * `Err(JsValue)` - Error if the law is not loaded or the YAML is invalid
+    #[wasm_bindgen(js_name = resolveAnnotations)]
+    pub fn resolve_annotations(
+        &self,
+        law_id: &str,
+        annotations_yaml: &str,
+    ) -> Result<JsValue, JsValue> {
+        let law = ServiceProvider::get_law(&self.service, law_id)
+            .ok_or_else(|| wasm_error(&format!("Law not loaded: {law_id}")))?;
+
+        let doc: serde_json::Value = serde_yaml_ng::from_str(annotations_yaml)
+            .map_err(|e| wasm_error(&format!("Invalid annotations YAML: {e}")))?;
+        let notes = doc
+            .get("annotations")
+            .and_then(|v| v.as_array())
+            .ok_or_else(|| wasm_error("Missing 'annotations' list"))?;
+
+        let mut resolved: Vec<serde_json::Value> = Vec::with_capacity(notes.len());
+        for note in notes {
+            let Some(selector_value) = note.get("target").and_then(|t| t.get("selector")) else {
+                continue;
+            };
+            let Ok(selector) = serde_json::from_value::<TextQuoteSelector>(selector_value.clone())
+            else {
+                continue;
+            };
+            let result = annotation::resolve(&selector, &law.articles);
+            let match_value = serde_json::to_value(&result)
+                .map_err(|e| wasm_error(&format!("Serialization error: {e}")))?;
+            resolved.push(serde_json::json!({
+                "note": note,
+                "match": match_value,
+            }));
+        }
+
+        serde_json::Value::Array(resolved)
+            .serialize(&js_serializer())
+            .map_err(|e| wasm_error(&format!("Serialization error: {e}")))
     }
 
     /// Register a tabular data source from flat records.

--- a/packages/engine/src/wasm.rs
+++ b/packages/engine/src/wasm.rs
@@ -518,8 +518,8 @@ impl WasmEngine {
     ///   offsets** (Unicode scalar values), not UTF-16 code units: JS code
     ///   slicing the article text must convert accordingly.
     /// * `Err(JsValue)` - Error if the law is not loaded or the selector is invalid
-    #[wasm_bindgen(js_name = resolveAnnotation)]
-    pub fn resolve_annotation(&self, law_id: &str, selector: JsValue) -> Result<JsValue, JsValue> {
+    #[wasm_bindgen(js_name = resolveNote)]
+    pub fn resolve_note(&self, law_id: &str, selector: JsValue) -> Result<JsValue, JsValue> {
         let selector: TextQuoteSelector = serde_wasm_bindgen::from_value(selector)
             .map_err(|e| wasm_error(&format!("Invalid selector: {e}")))?;
         let law = ServiceProvider::get_law(&self.service, law_id)
@@ -552,12 +552,8 @@ impl WasmEngine {
     ///   or a message string. Match `start`/`end` are **`char` offsets**, not
     ///   UTF-16 code units.
     /// * `Err(JsValue)` - Error if the law is not loaded or the YAML is invalid
-    #[wasm_bindgen(js_name = resolveAnnotations)]
-    pub fn resolve_annotations(
-        &self,
-        law_id: &str,
-        annotations_yaml: &str,
-    ) -> Result<JsValue, JsValue> {
+    #[wasm_bindgen(js_name = resolveNotes)]
+    pub fn resolve_notes(&self, law_id: &str, annotations_yaml: &str) -> Result<JsValue, JsValue> {
         let law = ServiceProvider::get_law(&self.service, law_id)
             .ok_or_else(|| wasm_error(&format!("Law not loaded: {law_id}")))?;
 

--- a/packages/engine/src/wasm.rs
+++ b/packages/engine/src/wasm.rs
@@ -58,7 +58,7 @@ use serde_wasm_bindgen::Serializer;
 use std::collections::BTreeMap;
 use wasm_bindgen::prelude::*;
 
-use crate::annotation::{self, TextQuoteSelector};
+use crate::annotation::{self, law_id_from_source, TextQuoteSelector};
 use crate::config;
 use crate::engine::OutputProvenance;
 use crate::error::EngineError;
@@ -514,7 +514,9 @@ impl WasmEngine {
     ///
     /// # Returns
     /// * `Ok(JsValue)` - `MatchResult`: `{ status, matches: [{ article_number,
-    ///   start, end, confidence, matched_text }] }`
+    ///   start, end, confidence, matched_text }] }`. `start`/`end` are **`char`
+    ///   offsets** (Unicode scalar values), not UTF-16 code units: JS code
+    ///   slicing the article text must convert accordingly.
     /// * `Err(JsValue)` - Error if the law is not loaded or the selector is invalid
     #[wasm_bindgen(js_name = resolveAnnotation)]
     pub fn resolve_annotation(&self, law_id: &str, selector: JsValue) -> Result<JsValue, JsValue> {
@@ -531,16 +533,24 @@ impl WasmEngine {
     /// Resolve all notes in a note-sidecar YAML string against a loaded law.
     ///
     /// Parses an `annotations:` document (the format validated by
-    /// `just validate-annotations`) and resolves every note's selector. Notes
-    /// whose `target.source` law id differs from `law_id` are skipped.
+    /// `just validate-annotations`) and resolves every note's selector.
+    ///
+    /// Notes whose `target.source` names a different law than `law_id` are
+    /// skipped (a sidecar may legitimately carry notes for several laws). A
+    /// note with a missing or unparseable selector is **not** silently
+    /// dropped: it appears in the result with an `error` string and a `null`
+    /// `match`, so the caller can distinguish "no notes" from "notes that
+    /// failed to parse".
     ///
     /// # Arguments
     /// * `law_id` - ID of the loaded law to resolve against
     /// * `annotations_yaml` - Contents of an `annotations.yaml` sidecar file
     ///
     /// # Returns
-    /// * `Ok(JsValue)` - Array of `{ note, match }` objects, where `match` is
-    ///   the `MatchResult` for that note's selector
+    /// * `Ok(JsValue)` - Array of `{ note, match, error }` objects. `match` is
+    ///   the `MatchResult` (or `null` on error); `error` is `null` on success
+    ///   or a message string. Match `start`/`end` are **`char` offsets**, not
+    ///   UTF-16 code units.
     /// * `Err(JsValue)` - Error if the law is not loaded or the YAML is invalid
     #[wasm_bindgen(js_name = resolveAnnotations)]
     pub fn resolve_annotations(
@@ -560,19 +570,48 @@ impl WasmEngine {
 
         let mut resolved: Vec<serde_json::Value> = Vec::with_capacity(notes.len());
         for note in notes {
-            let Some(selector_value) = note.get("target").and_then(|t| t.get("selector")) else {
-                continue;
+            // Skip notes that target a different law (federated sidecars may
+            // carry notes for several laws).
+            if let Some(source) = note
+                .get("target")
+                .and_then(|t| t.get("source"))
+                .and_then(|s| s.as_str())
+            {
+                if let Some(target_law) = law_id_from_source(source) {
+                    if target_law != law_id {
+                        continue;
+                    }
+                }
+            }
+
+            let (match_value, error) = match note.get("target").and_then(|t| t.get("selector")) {
+                None => (
+                    serde_json::Value::Null,
+                    Some("note has no target.selector".to_string()),
+                ),
+                Some(selector_value) => {
+                    match serde_json::from_value::<TextQuoteSelector>(selector_value.clone()) {
+                        Err(e) => (
+                            serde_json::Value::Null,
+                            Some(format!("invalid selector: {e}")),
+                        ),
+                        Ok(selector) => {
+                            let result = annotation::resolve(&selector, &law.articles);
+                            match serde_json::to_value(&result) {
+                                Ok(v) => (v, None),
+                                Err(e) => (
+                                    serde_json::Value::Null,
+                                    Some(format!("serialization error: {e}")),
+                                ),
+                            }
+                        }
+                    }
+                }
             };
-            let Ok(selector) = serde_json::from_value::<TextQuoteSelector>(selector_value.clone())
-            else {
-                continue;
-            };
-            let result = annotation::resolve(&selector, &law.articles);
-            let match_value = serde_json::to_value(&result)
-                .map_err(|e| wasm_error(&format!("Serialization error: {e}")))?;
             resolved.push(serde_json::json!({
                 "note": note,
                 "match": match_value,
+                "error": error,
             }));
         }
 

--- a/packages/engine/tests/bdd/steps/mod.rs
+++ b/packages/engine/tests/bdd/steps/mod.rs
@@ -3,5 +3,6 @@
 //! This module contains all Given/When/Then step implementations.
 
 pub mod given;
+pub mod notes;
 pub mod then;
 pub mod when;

--- a/packages/engine/tests/bdd/steps/notes.rs
+++ b/packages/engine/tests/bdd/steps/notes.rs
@@ -1,4 +1,4 @@
-//! Step definitions for note resolution (RFC-005, RFC-016).
+//! Step definitions for note resolution (RFC-005, RFC-018).
 //!
 //! Scenarios set up article text inline (so they are self-contained and do not
 //! depend on the corpus), build a TextQuoteSelector, resolve it, and assert on

--- a/packages/engine/tests/bdd/steps/notes.rs
+++ b/packages/engine/tests/bdd/steps/notes.rs
@@ -1,0 +1,139 @@
+//! Step definitions for note resolution (RFC-005, RFC-016).
+//!
+//! Scenarios set up article text inline (so they are self-contained and do not
+//! depend on the corpus), build a TextQuoteSelector, resolve it, and assert on
+//! the resulting [`MatchResult`].
+
+use cucumber::gherkin::Step;
+use cucumber::{given, then, when};
+use regelrecht_engine::{annotation, Article, SelectorHint, TextQuoteSelector};
+
+use crate::world::RegelrechtWorld;
+
+#[given(expr = "a law with the following articles:")]
+fn set_note_articles(world: &mut RegelrechtWorld, step: &Step) {
+    let table = step.table.as_ref().expect("articles table required");
+    world.note_articles.clear();
+    // First row is the header (number | text).
+    for row in table.rows.iter().skip(1) {
+        world.note_articles.push(Article {
+            number: row[0].trim().to_string(),
+            text: row[1].trim().to_string(),
+            url: None,
+            machine_readable: None,
+        });
+    }
+}
+
+#[given(expr = "a note selecting {string}")]
+fn set_note_selector_exact(world: &mut RegelrechtWorld, exact: String) {
+    world.note_selector = Some(TextQuoteSelector {
+        exact,
+        prefix: String::new(),
+        suffix: String::new(),
+        hint: None,
+    });
+}
+
+#[given(expr = "a note selecting {string} with prefix {string} and suffix {string}")]
+fn set_note_selector_context(
+    world: &mut RegelrechtWorld,
+    exact: String,
+    prefix: String,
+    suffix: String,
+) {
+    world.note_selector = Some(TextQuoteSelector {
+        exact,
+        prefix,
+        suffix,
+        hint: None,
+    });
+}
+
+#[given(expr = "the note hints article {string}")]
+fn set_note_hint_article(world: &mut RegelrechtWorld, article: String) {
+    let selector = world
+        .note_selector
+        .as_mut()
+        .expect("selector must be set before adding a hint");
+    selector.hint = Some(SelectorHint {
+        article_number: article,
+        start: None,
+        end: None,
+    });
+}
+
+#[given(expr = "the note hints article {string} at position {int} to {int}")]
+fn set_note_hint_position(world: &mut RegelrechtWorld, article: String, start: usize, end: usize) {
+    let selector = world
+        .note_selector
+        .as_mut()
+        .expect("selector must be set before adding a hint");
+    selector.hint = Some(SelectorHint {
+        article_number: article,
+        start: Some(start),
+        end: Some(end),
+    });
+}
+
+#[when(expr = "the note is resolved")]
+fn resolve_note(world: &mut RegelrechtWorld) {
+    let selector = world
+        .note_selector
+        .as_ref()
+        .expect("selector must be set before resolving");
+    world.note_result = Some(annotation::resolve(selector, &world.note_articles));
+}
+
+#[then(expr = "the note resolves to article {string}")]
+fn assert_resolves_to_article(world: &mut RegelrechtWorld, article: String) {
+    let result = world.note_result.as_ref().expect("note must be resolved");
+    assert!(
+        result.is_found(),
+        "expected Found, got {:?} ({} matches)",
+        result.status,
+        result.matches.len()
+    );
+    assert_eq!(
+        result.single().expect("single match").article_number,
+        article
+    );
+}
+
+#[then(expr = "the note is an exact match")]
+fn assert_exact_match(world: &mut RegelrechtWorld) {
+    let result = world.note_result.as_ref().expect("note must be resolved");
+    let m = result.single().expect("expected a single match");
+    assert_eq!(m.confidence, 1.0, "expected exact (confidence 1.0)");
+}
+
+#[then(expr = "the note is a fuzzy match")]
+fn assert_fuzzy_match(world: &mut RegelrechtWorld) {
+    let result = world.note_result.as_ref().expect("note must be resolved");
+    let m = result.single().expect("expected a single match");
+    assert!(
+        m.confidence < 1.0,
+        "expected fuzzy (confidence < 1.0), got {}",
+        m.confidence
+    );
+}
+
+#[then(expr = "the note is orphaned")]
+fn assert_orphaned(world: &mut RegelrechtWorld) {
+    let result = world.note_result.as_ref().expect("note must be resolved");
+    assert!(
+        result.is_orphaned(),
+        "expected Orphaned, got {:?}",
+        result.status
+    );
+}
+
+#[then(expr = "the note is ambiguous")]
+fn assert_ambiguous(world: &mut RegelrechtWorld) {
+    let result = world.note_result.as_ref().expect("note must be resolved");
+    assert!(
+        result.is_ambiguous(),
+        "expected Ambiguous, got {:?}",
+        result.status
+    );
+}

--- a/packages/engine/tests/bdd/world.rs
+++ b/packages/engine/tests/bdd/world.rs
@@ -5,7 +5,9 @@
 #![allow(unused_imports)]
 
 use cucumber::World;
-use regelrecht_engine::{ArticleResult, EngineError, LawExecutionService, Value};
+use regelrecht_engine::{
+    Article, ArticleResult, EngineError, LawExecutionService, MatchResult, TextQuoteSelector, Value,
+};
 use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 use std::path::PathBuf;
@@ -32,6 +34,12 @@ pub struct RegelrechtWorld {
     pub error: Option<EngineError>,
     /// External data sources for zorgtoeslag scenarios
     pub external_data: ExternalData,
+    /// Articles set up for note-resolution scenarios (RFC-005, RFC-016)
+    pub note_articles: Vec<Article>,
+    /// Selector built for the current note-resolution scenario
+    pub note_selector: Option<TextQuoteSelector>,
+    /// Result of the last note resolution
+    pub note_result: Option<MatchResult>,
 }
 
 impl fmt::Debug for RegelrechtWorld {
@@ -96,6 +104,9 @@ impl RegelrechtWorld {
             result: None,
             error: None,
             external_data: ExternalData::default(),
+            note_articles: Vec::new(),
+            note_selector: None,
+            note_result: None,
         }
     }
 
@@ -107,6 +118,9 @@ impl RegelrechtWorld {
         self.result = None;
         self.error = None;
         self.external_data = ExternalData::default();
+        self.note_articles.clear();
+        self.note_selector = None;
+        self.note_result = None;
     }
 
     /// Returns true if trace output is enabled via the `TRACE` env var.

--- a/packages/engine/tests/bdd/world.rs
+++ b/packages/engine/tests/bdd/world.rs
@@ -34,7 +34,7 @@ pub struct RegelrechtWorld {
     pub error: Option<EngineError>,
     /// External data sources for zorgtoeslag scenarios
     pub external_data: ExternalData,
-    /// Articles set up for note-resolution scenarios (RFC-005, RFC-016)
+    /// Articles set up for note-resolution scenarios (RFC-005, RFC-018)
     pub note_articles: Vec<Article>,
     /// Selector built for the current note-resolution scenario
     pub note_selector: Option<TextQuoteSelector>,

--- a/schema/v0.5.2/annotation-schema.json
+++ b/schema/v0.5.2/annotation-schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://raw.githubusercontent.com/MinBZK/regelrecht/refs/heads/main/schema/v0.5.2/annotation-schema.json",
   "title": "RegelRecht Note Sidecar Schema v0.5.2",
-  "description": "Stand-off notes on legal texts (RFC-005, RFC-016). A note file holds a list of W3C Web Annotation objects anchored to law text via a TextQuoteSelector. The feature is called 'notes' (RFC-005 terminology); the W3C entity is named 'Annotation'.",
+  "description": "Stand-off notes on legal texts (RFC-005, RFC-018). A note file holds a list of W3C Web Annotation objects anchored to law text via a TextQuoteSelector. The feature is called 'notes' (RFC-005 terminology); the W3C entity is named 'Annotation'.",
   "type": "object",
   "required": ["annotations"],
   "properties": {
@@ -74,7 +74,7 @@
         },
         "workflow": {
           "type": "string",
-          "description": "Process dimension: has the issue been addressed? Used with the questioning motivation for ambiguity tracking (RFC-016).",
+          "description": "Process dimension: has the issue been addressed? Used with the questioning motivation for ambiguity tracking (RFC-018).",
           "enum": ["open", "resolved"],
           "default": "open"
         },
@@ -190,7 +190,7 @@
             "type": { "const": "SpecificResource" },
             "source": {
               "type": "string",
-              "description": "Target URI, e.g. regelrecht://zorgtoeslagwet/artikel_2#hoogte_zorgtoeslag."
+              "description": "Target URI, e.g. regelrecht://zorgtoeslagwet/hoogte_zorgtoeslag#hoogte_zorgtoeslag."
             },
             "purpose": {
               "type": "string",

--- a/schema/v0.5.2/annotation-schema.json
+++ b/schema/v0.5.2/annotation-schema.json
@@ -68,8 +68,8 @@
         },
         "resolution": {
           "type": "string",
-          "description": "Technical dimension: can the selector locate the text? Derived at resolution time; stored value is advisory.",
-          "enum": ["found", "orphaned"],
+          "description": "Technical dimension: can the selector locate the text? Derived at resolution time; the stored value is advisory and mirrors the resolver's MatchStatus (found / orphaned / ambiguous).",
+          "enum": ["found", "orphaned", "ambiguous"],
           "default": "found"
         },
         "workflow": {

--- a/schema/v0.5.2/annotation-schema.json
+++ b/schema/v0.5.2/annotation-schema.json
@@ -1,0 +1,219 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/MinBZK/regelrecht/refs/heads/main/schema/v0.5.2/annotation-schema.json",
+  "title": "RegelRecht Note Sidecar Schema v0.5.2",
+  "description": "Stand-off notes on legal texts (RFC-005, RFC-016). A note file holds a list of W3C Web Annotation objects anchored to law text via a TextQuoteSelector. The feature is called 'notes' (RFC-005 terminology); the W3C entity is named 'Annotation'.",
+  "type": "object",
+  "required": ["annotations"],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "Reference to this schema."
+    },
+    "annotations": {
+      "type": "array",
+      "description": "The notes in this sidecar file.",
+      "items": { "$ref": "#/definitions/Annotation" }
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "Annotation": {
+      "type": "object",
+      "required": ["type", "motivation", "target", "body"],
+      "properties": {
+        "type": { "const": "Annotation" },
+        "motivation": {
+          "type": "string",
+          "description": "W3C motivation: why this note exists. W3C makes this optional; RegelRecht requires it for explicit intent.",
+          "enum": [
+            "assessing",
+            "bookmarking",
+            "classifying",
+            "commenting",
+            "describing",
+            "editing",
+            "highlighting",
+            "identifying",
+            "linking",
+            "moderating",
+            "questioning",
+            "replying",
+            "tagging"
+          ]
+        },
+        "creator": {
+          "description": "Who created the note. MVP: a string (org name, person, or tool). Future: a structured W3C Agent.",
+          "oneOf": [
+            { "type": "string" },
+            {
+              "type": "object",
+              "required": ["name"],
+              "properties": {
+                "type": { "type": "string" },
+                "name": { "type": "string" },
+                "organisation_id": { "type": "string" }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "created": {
+          "type": "string",
+          "description": "Optional ISO 8601 creation timestamp (for systems not using Git history)."
+        },
+        "modified": {
+          "type": "string",
+          "description": "Optional ISO 8601 modification timestamp."
+        },
+        "resolution": {
+          "type": "string",
+          "description": "Technical dimension: can the selector locate the text? Derived at resolution time; stored value is advisory.",
+          "enum": ["found", "orphaned"],
+          "default": "found"
+        },
+        "workflow": {
+          "type": "string",
+          "description": "Process dimension: has the issue been addressed? Used with the questioning motivation for ambiguity tracking (RFC-016).",
+          "enum": ["open", "resolved"],
+          "default": "open"
+        },
+        "target": { "$ref": "#/definitions/Target" },
+        "body": {
+          "description": "One body, or a list of bodies (W3C permits multiple).",
+          "oneOf": [
+            { "$ref": "#/definitions/Body" },
+            {
+              "type": "array",
+              "items": { "$ref": "#/definitions/Body" },
+              "minItems": 1
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "Target": {
+      "type": "object",
+      "required": ["source", "selector"],
+      "properties": {
+        "source": {
+          "type": "string",
+          "description": "URI of the annotated law (e.g. regelrecht://zorgtoeslagwet)."
+        },
+        "selector": { "$ref": "#/definitions/TextQuoteSelector" }
+      },
+      "additionalProperties": false
+    },
+    "TextQuoteSelector": {
+      "type": "object",
+      "required": ["type", "exact"],
+      "properties": {
+        "type": { "const": "TextQuoteSelector" },
+        "exact": {
+          "type": "string",
+          "description": "The exact text to locate.",
+          "minLength": 1
+        },
+        "prefix": {
+          "type": "string",
+          "description": "Text immediately before the exact match (disambiguation)."
+        },
+        "suffix": {
+          "type": "string",
+          "description": "Text immediately after the exact match (disambiguation)."
+        },
+        "regelrecht:hint": {
+          "type": "object",
+          "description": "Non-authoritative performance hint. If the text is not found here, the whole law is searched.",
+          "required": ["type", "value"],
+          "properties": {
+            "type": { "const": "CssSelector" },
+            "value": {
+              "type": "string",
+              "pattern": "^article\\[number=['\"][^'\"]+['\"]\\]$",
+              "description": "CSS selector for the article, e.g. article[number='2']."
+            },
+            "refinedBy": {
+              "type": "object",
+              "required": ["type", "start", "end"],
+              "properties": {
+                "type": { "const": "TextPositionSelector" },
+                "start": { "type": "integer", "minimum": 0 },
+                "end": { "type": "integer", "minimum": 0 }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "Body": {
+      "oneOf": [
+        {
+          "type": "object",
+          "description": "Inline textual body (comment, question, or tag value).",
+          "required": ["type", "value", "purpose"],
+          "properties": {
+            "type": { "const": "TextualBody" },
+            "value": { "type": "string" },
+            "purpose": {
+              "type": "string",
+              "enum": [
+                "assessing",
+                "bookmarking",
+                "classifying",
+                "commenting",
+                "describing",
+                "editing",
+                "highlighting",
+                "identifying",
+                "linking",
+                "moderating",
+                "questioning",
+                "replying",
+                "tagging"
+              ]
+            },
+            "format": { "type": "string" },
+            "language": { "type": "string" }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "description": "Link to another resource (e.g. a machine_readable element).",
+          "required": ["type", "source", "purpose"],
+          "properties": {
+            "type": { "const": "SpecificResource" },
+            "source": {
+              "type": "string",
+              "description": "Target URI, e.g. regelrecht://zorgtoeslagwet/artikel_2#hoogte_zorgtoeslag."
+            },
+            "purpose": {
+              "type": "string",
+              "enum": [
+                "assessing",
+                "bookmarking",
+                "classifying",
+                "commenting",
+                "describing",
+                "editing",
+                "highlighting",
+                "identifying",
+                "linking",
+                "moderating",
+                "questioning",
+                "replying",
+                "tagging"
+              ]
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    }
+  }
+}

--- a/script/validate-annotations.sh
+++ b/script/validate-annotations.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Validate note sidecar files against the annotation schema (RFC-005, RFC-016).
+# Validate note sidecar files against the annotation schema (RFC-005, RFC-018).
 #
 # Resolves every note against its target law and reports orphaned/ambiguous
 # notes and unknown tag values as warnings (not errors).

--- a/script/validate-annotations.sh
+++ b/script/validate-annotations.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Validate note sidecar files against the annotation schema (RFC-005, RFC-016).
+#
+# Resolves every note against its target law and reports orphaned/ambiguous
+# notes and unknown tag values as warnings (not errors).
+#
+# Usage:
+#   script/validate-annotations.sh                       # all note files
+#   script/validate-annotations.sh corpus/annotations/zorgtoeslagwet/annotations.yaml
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+exec cargo run --manifest-path "$REPO_ROOT/packages/engine/Cargo.toml" \
+    --features validate --bin validate-annotations -- "$@"


### PR DESCRIPTION
Implementatie van de notes-infrastructuur uit RFC-005 + RFC-016. Bouwt op #633 (de RFC-PR); merge die eerst, dan herbaseert deze vanzelf op `main`.

## Fasen in deze PR

**Fase 1 — Rust resolver** (`packages/engine/src/annotation/`)
Versie-bestendige TextQuoteSelector-resolutie: hint → exacte match → fuzzy (sliding window, `exact*0.5 + prefix*0.25 + suffix*0.25`, drempel 0.7, normalized Levenshtein via `strsim`) → found / ambiguous / orphaned. Geport van de Python-PoC op `feature/annotation-resolver`; de Rust-port is de single source of truth (draait ook in de browser via WASM). 11 unit tests + `features/notes.feature` met 8 geporte + 2 ambiguïteit-scenario's.

**Fase 2 — Schema + eerste notes**
`schema/v0.5.2/annotation-schema.json` (W3C Web Annotation). Echte notes op de Zorgtoeslagwet: linking (tekst → `hoogte_zorgtoeslag`), commenting (op `normpremie`), questioning (open norm bij ministeriële regeling, met ambiguïteit-tag). `corpus/annotations/_vocabulary/ambiguity.yaml`. `just validate-annotations` (binary + recipe): schema-validatie + resolutie tegen de doelwet (orphaned/ambiguous = warning) + tag-check tegen de vocabulary.

**Fase 3 — WASM-bindings**
`WasmEngine::resolveAnnotation` en `resolveAnnotations`. Dezelfde resolver in de browser; geen JS-duplicaat. `just wasm-build` slaagt, bindings geëxporteerd in de glue.

## Verificatie

`just format`, `just lint`, `just validate-annotations`, 11 unit tests, 63 BDD-scenario's en `cargo build --target wasm32-unknown-unknown` groen. De drie echte notes resolven zonder warnings.

## Nog niet in deze PR

Fase 4-6 (editor: notes tonen + aanmaken, CI-koppeling in `just check`) volgen.