### PR TITLE
refactor: upgrade @nldd/design-system 0.8.44 + editor/admin/library UX polish

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "regelrecht-docs",
       "version": "1.0.0",
+      "dependencies": {
+        "@nldd/design-system": "^0.8.44"
+      },
       "devDependencies": {
         "mermaid": "^11.4.1",
         "vitepress": "^1.6.3",
@@ -14,7 +17,7 @@
         "vue": "^3.5.30"
       },
       "optionalDependencies": {
-        "@nldd/design-system": "^0.8.42"
+        "@nldd/design-system": "^0.8.44"
       }
     },
     "node_modules/@algolia/abtesting": {
@@ -1010,9 +1013,9 @@
       }
     },
     "node_modules/@nldd/design-system": {
-      "version": "0.8.42",
-      "resolved": "https://registry.npmjs.org/@nldd/design-system/-/design-system-0.8.42.tgz",
-      "integrity": "sha512-NPDK+Lhk7QkjKW3wAPZ5Wjqo9k4Q0M75sJkj0iuLtw6tuFyJ1B3sD0MJoGVcZhdIlU8bZy9liYQKMPd0cmjwtA==",
+      "version": "0.8.44",
+      "resolved": "https://registry.npmjs.org/@nldd/design-system/-/design-system-0.8.44.tgz",
+      "integrity": "sha512-0PMUl/t0BrItxAHWIBNBkxAFU3855BMu2PaXX3oQwb+svWyT6iRMcFxfrG0MlEpxm8lFvTKTaP+d1vjyzzAvrQ==",
       "license": "EUPL-1.2",
       "optional": true,
       "dependencies": {

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -7,9 +7,6 @@
     "": {
       "name": "regelrecht-docs",
       "version": "1.0.0",
-      "dependencies": {
-        "@nldd/design-system": "^0.8.44"
-      },
       "devDependencies": {
         "mermaid": "^11.4.1",
         "vitepress": "^1.6.3",

--- a/docs/package.json
+++ b/docs/package.json
@@ -9,7 +9,7 @@
     "preview": "vitepress preview"
   },
   "optionalDependencies": {
-    "@nldd/design-system": "^0.8.42"
+    "@nldd/design-system": "^0.8.44"
   },
   "overrides": {
     "esbuild": "^0.25.0",

--- a/frontend-lawmaking/package-lock.json
+++ b/frontend-lawmaking/package-lock.json
@@ -8,7 +8,7 @@
       "name": "regelrecht-frontend-lawmaking",
       "version": "1.0.0",
       "dependencies": {
-        "@nldd/design-system": "^0.8.42",
+        "@nldd/design-system": "^0.8.44",
         "vue": "^3.5.30"
       },
       "devDependencies": {
@@ -169,9 +169,9 @@
       }
     },
     "node_modules/@nldd/design-system": {
-      "version": "0.8.42",
-      "resolved": "https://registry.npmjs.org/@nldd/design-system/-/design-system-0.8.42.tgz",
-      "integrity": "sha512-NPDK+Lhk7QkjKW3wAPZ5Wjqo9k4Q0M75sJkj0iuLtw6tuFyJ1B3sD0MJoGVcZhdIlU8bZy9liYQKMPd0cmjwtA==",
+      "version": "0.8.44",
+      "resolved": "https://registry.npmjs.org/@nldd/design-system/-/design-system-0.8.44.tgz",
+      "integrity": "sha512-0PMUl/t0BrItxAHWIBNBkxAFU3855BMu2PaXX3oQwb+svWyT6iRMcFxfrG0MlEpxm8lFvTKTaP+d1vjyzzAvrQ==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@floating-ui/dom": "^1.7.6",

--- a/frontend-lawmaking/package.json
+++ b/frontend-lawmaking/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@nldd/design-system": "^0.8.42",
+    "@nldd/design-system": "^0.8.44",
     "vue": "^3.5.30"
   },
   "devDependencies": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@cucumber/gherkin": "^39.1.0",
         "@cucumber/messages": "^32.3.1",
-        "@nldd/design-system": "^0.8.41",
+        "@nldd/design-system": "^0.8.44",
         "@tiptap/core": "^3.22.4",
         "@tiptap/starter-kit": "^3.22.4",
         "@tiptap/vue-3": "^3.22.4",
@@ -286,9 +286,9 @@
       }
     },
     "node_modules/@nldd/design-system": {
-      "version": "0.8.41",
-      "resolved": "https://registry.npmjs.org/@nldd/design-system/-/design-system-0.8.41.tgz",
-      "integrity": "sha512-jo8Zog22XQeZZYFRYdUNi96196QbImNL1eKRbg1zOGpBtF8grf65+oE2PQqR1Zh/56qM1x3HHW5qgViM4yzroA==",
+      "version": "0.8.44",
+      "resolved": "https://registry.npmjs.org/@nldd/design-system/-/design-system-0.8.44.tgz",
+      "integrity": "sha512-0PMUl/t0BrItxAHWIBNBkxAFU3855BMu2PaXX3oQwb+svWyT6iRMcFxfrG0MlEpxm8lFvTKTaP+d1vjyzzAvrQ==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@floating-ui/dom": "^1.7.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@cucumber/gherkin": "^39.1.0",
     "@cucumber/messages": "^32.3.1",
-    "@nldd/design-system": "^0.8.41",
+    "@nldd/design-system": "^0.8.44",
     "@tiptap/core": "^3.22.4",
     "@tiptap/starter-kit": "^3.22.4",
     "@tiptap/vue-3": "^3.22.4",

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -1354,7 +1354,7 @@ function handleActionSave() {
           <nldd-toolbar size="md">
             <nldd-toolbar-item slot="start">
               <nldd-tab-bar compact>
-                <nldd-tab-bar-item :href="lastLibraryPath" @click.prevent="router.push(lastLibraryPath)" icon="stack" text="Bibliotheek"></nldd-tab-bar-item>
+                <nldd-tab-bar-item :href="lastLibraryPath" @click.prevent="router.push(lastLibraryPath)" icon="books" text="Bibliotheek"></nldd-tab-bar-item>
                 <nldd-tab-bar-item selected icon="edit" text="Editor"></nldd-tab-bar-item>
               </nldd-tab-bar>
             </nldd-toolbar-item>

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -1118,7 +1118,7 @@ function handleActionSave() {
              bar too because closed tabs may still be visible alongside this
              empty state on the next pane. -->
         <nldd-page v-if="!activeTab">
-          <nldd-simple-section full-width>
+          <nldd-simple-section width="full">
             <nldd-inline-dialog text="Open een artikel vanuit de tabbalk of de bibliotheek om te bewerken.">
               <nldd-button slot="actions" variant="secondary" text="Ga naar bibliotheek" :href="lastLibraryPath" @click.prevent="router.push(lastLibraryPath)"></nldd-button>
             </nldd-inline-dialog>
@@ -1127,7 +1127,7 @@ function handleActionSave() {
 
         <!-- Error state — mirrors the library's law-load failure pattern. -->
         <nldd-page v-else-if="error">
-          <nldd-simple-section full-width>
+          <nldd-simple-section width="full">
             <nldd-inline-dialog
               variant="alert"
               :text="`${failedLawName} is niet geladen`"
@@ -1144,7 +1144,7 @@ function handleActionSave() {
              explicit empty-state with a CTA to the settings menu so
              the user understands the editor isn't broken. -->
         <nldd-page v-else-if="paneViews.length === 0">
-          <nldd-simple-section full-width>
+          <nldd-simple-section width="full">
             <nldd-inline-dialog text="Geen editors actief. Schakel ten minste één editor in via Instellingen."></nldd-inline-dialog>
           </nldd-simple-section>
         </nldd-page>
@@ -1249,7 +1249,7 @@ function handleActionSave() {
                    pane-header above guards on `textEditorRefs[idx]`, which
                    is only populated by the WYSIWYG component, so it auto-
                    hides when the flag is off. -->
-              <nldd-simple-section v-if="view === 'text'" full-width>
+              <nldd-simple-section v-if="view === 'text'" width="full">
                 <ArticleTextEditor
                   v-if="canEditArticleText"
                   :ref="setTextEditorRef(idx)"
@@ -1270,7 +1270,7 @@ function handleActionSave() {
                 <nldd-button
                   variant="primary"
                   size="md"
-                  full-width
+                  width="full"
                   data-testid="save-text-btn"
                   :disabled="lawSaving || undefined"
                   :text="lawSaving ? 'Opslaan…' : 'Opslaan'"
@@ -1279,7 +1279,7 @@ function handleActionSave() {
               </nldd-container>
 
               <!-- Machine readable -->
-              <nldd-simple-section v-else-if="view === 'machine'" full-width>
+              <nldd-simple-section v-else-if="view === 'machine'" width="full">
                 <MachineReadable
                   :article="editedArticle"
                   :editable="canEdit"
@@ -1305,7 +1305,7 @@ function handleActionSave() {
                 <nldd-button
                   variant="primary"
                   size="md"
-                  full-width
+                  width="full"
                   data-testid="save-mr-btn"
                   :disabled="lawSaving || undefined"
                   :text="lawSaving ? 'Opslaan…' : 'Opslaan'"
@@ -1315,7 +1315,7 @@ function handleActionSave() {
 
               <!-- Scenario builder -->
               <template v-else-if="view === 'scenario'">
-                <nldd-simple-section v-if="engineInitError" full-width>
+                <nldd-simple-section v-if="engineInitError" width="full">
                   <nldd-inline-dialog
                     variant="alert"
                     text="WASM engine niet geladen"
@@ -1334,7 +1334,7 @@ function handleActionSave() {
               </template>
 
               <!-- YAML -->
-              <nldd-simple-section v-else-if="view === 'yaml'" full-width>
+              <nldd-simple-section v-else-if="view === 'yaml'" width="full">
                 <nldd-code-editor
                   resize="none"
                   accessible-label="YAML"
@@ -1415,12 +1415,11 @@ function handleActionSave() {
   <nldd-sheet
     ref="resultSheetEl"
     placement="bottom"
-    full-height
     @close="resultSheetOpen = false"
   >
     <nldd-page sticky-header>
       <nldd-top-title-bar slot="header" :text="lastScenarioName ? `Resultaat: ${lastScenarioName}` : 'Resultaat'" collapse-anchor="result-scenario-title" dismiss-text="Sluit" @dismiss="resultSheetOpen = false"></nldd-top-title-bar>
-      <nldd-simple-section full-width>
+      <nldd-simple-section width="full">
         <nldd-title id="result-scenario-title" size="4"><h3>{{ lastScenarioName ? `Resultaat: ${lastScenarioName}` : 'Resultaat' }}</h3></nldd-title>
         <nldd-spacer size="16"></nldd-spacer>
         <ExecutionTraceView
@@ -1438,7 +1437,6 @@ function handleActionSave() {
   <nldd-sheet
     ref="graphSheetEl"
     placement="bottom"
-    full-height
     @close="graphSheetOpen = false"
   >
     <nldd-page sticky-header>

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -458,6 +458,9 @@ watch(lawId, () => {
 
 // --- Editor state ---
 const activeAction = ref(null);
+// True while the open action sheet is for a freshly added action, so its
+// Save button is always offered (no edit required to create it).
+const activeActionIsNew = ref(false);
 const activeEditItem = ref(null);
 const parseError = ref(null);
 
@@ -744,7 +747,7 @@ function onYamlInput(event) {
 
 function handleSave({ section, key, newKey, index, data }) {
   const mr = machineReadable.value
-    ? structuredClone(machineReadable.value)
+    ? JSON.parse(JSON.stringify(machineReadable.value))
     : {};
 
   if (!mr.definitions) mr.definitions = {};
@@ -770,6 +773,10 @@ function handleSave({ section, key, newKey, index, data }) {
     mr.execution.output[index] = data;
   } else if (section === 'add-output') {
     mr.execution.output.push(data);
+  } else if (section === 'produces') {
+    if (!mr.execution.produces) mr.execution.produces = {};
+    if (data == null) delete mr.execution.produces[key];
+    else mr.execution.produces[key] = data;
   }
 
   machineReadable.value = mr;
@@ -784,7 +791,7 @@ function handleSave({ section, key, newKey, index, data }) {
 // stale event from the UI can never crash.
 function handleDelete({ section, key, index }) {
   const mr = machineReadable.value
-    ? structuredClone(machineReadable.value)
+    ? JSON.parse(JSON.stringify(machineReadable.value))
     : null;
   if (!mr) return;
 
@@ -852,11 +859,13 @@ function handleAddAction() {
   machineReadable.value = { ...mr };
   yamlSource.value = yaml.dump(machineReadable.value, dumpOpts);
   parseError.value = null;
+  activeActionIsNew.value = true;
   activeAction.value = newAction;
 }
 
 function handleOpenAction(action) {
   actionSnapshot = JSON.stringify(machineReadable.value);
+  activeActionIsNew.value = false;
   activeAction.value = action;
   // Clear any stale parse error from a previous failed save
   parseError.value = null;
@@ -968,7 +977,7 @@ async function handleActionSave() {
   // separate dirty/save affordance for sheet edits. On a failed PUT the
   // edits stay in the model and the Machine pane's normal dirty/save
   // affordance is the fallback — no data loss either way.
-  machineReadable.value = structuredClone(machineReadable.value);
+  machineReadable.value = JSON.parse(JSON.stringify(machineReadable.value));
   yamlSource.value = yaml.dump(machineReadable.value, dumpOpts);
   parseError.value = null;
   await handleLawSave();
@@ -1305,6 +1314,7 @@ async function handleActionSave() {
                   @init-mr="handleInitMr"
                   @add-action="handleAddAction"
                   @save="handleMachineReadableSave"
+                  @patch="handleSave"
                   @delete="handleDelete"
                 />
               </nldd-simple-section>
@@ -1417,7 +1427,7 @@ async function handleActionSave() {
     </nldd-bar-split-view>
   </nldd-app-view>
 
-  <ActionSheet :action="activeAction" :article="editedArticle" :editable="canEdit" @close="handleActionClose" @save="handleActionSave" />
+  <ActionSheet :action="activeAction" :article="editedArticle" :editable="canEdit" :is-new="activeActionIsNew" @close="handleActionClose" @save="handleActionSave" />
   <EditSheet :item="activeEditItem" :article="editedArticle" @save="handleSave" @close="activeEditItem = null" />
   <SearchPopover
     ref="searchPopoverRef"

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -1173,7 +1173,7 @@ async function handleActionSave() {
           >
             <nldd-page
               sticky-header
-              :sticky-footer="(view === 'machine' && canEdit && (isMachineReadableDirty || lawSaving) && paneViews.indexOf('machine') === idx) || (view === 'text' && canEditArticleText && (isArticleTextDirty || lawSaving) && paneViews.indexOf('text') === idx)"
+              :sticky-footer="(view === 'machine' && canEdit && !activeAction && (isMachineReadableDirty || lawSaving) && paneViews.indexOf('machine') === idx) || (view === 'text' && canEditArticleText && (isArticleTextDirty || lawSaving) && paneViews.indexOf('text') === idx)"
             >
               <div slot="header" class="pane-header">
                 <nldd-button
@@ -1301,9 +1301,12 @@ async function handleActionSave() {
               </nldd-simple-section>
               <!-- Footer + Save button only on the first machine pane.
                    Duplicates would render redundant Save buttons over
-                   the same shared dirty state — not broken, just noisy. -->
+                   the same shared dirty state — not broken, just noisy.
+                   Hidden while the action sheet is open: the sheet's
+                   "Opslaan" is the real save for those in-place edits, so a
+                   second Machine-pane Save button behind it just distracts. -->
               <nldd-container
-                v-if="view === 'machine' && canEdit && (isMachineReadableDirty || lawSaving) && paneViews.indexOf('machine') === idx"
+                v-if="view === 'machine' && canEdit && !activeAction && (isMachineReadableDirty || lawSaving) && paneViews.indexOf('machine') === idx"
                 slot="footer"
                 padding="16"
               >

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -1181,6 +1181,7 @@ async function handleActionSave() {
           >
             <nldd-page
               sticky-header
+              :background="view === 'scenario' ? 'tinted' : undefined"
               :sticky-footer="(view === 'machine' && canEdit && !activeAction && (isMachineReadableDirty || lawSaving) && paneViews.indexOf('machine') === idx) || (view === 'text' && canEditArticleText && (isArticleTextDirty || lawSaving) && paneViews.indexOf('text') === idx)"
             >
               <div slot="header" class="pane-header">

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -410,11 +410,17 @@ const lastScenarioName = ref('');
 // The scenario's entry output (e.g. "is_rechthebbende"). The graph view
 // uses this to pin its "▶ start" marker to the right leaf.
 const lastOutputName = ref(null);
+// Loading state of the last scenario and a bound re-run callback, so the
+// result sheet can show "running…" / an error with a reload action.
+const lastRunning = ref(false);
+const lastReload = ref(null);
 
-function handleScenarioExecuted({ result, traceText, error, expectations, scenarioName, outputName, view }) {
+function handleScenarioExecuted({ result, traceText, error, running, expectations, scenarioName, outputName, reload, view }) {
   lastResult.value = result;
   lastTraceText.value = traceText;
   lastError.value = error || null;
+  lastRunning.value = !!running;
+  lastReload.value = typeof reload === 'function' ? reload : null;
   lastExpectations.value = expectations || {};
   lastScenarioName.value = scenarioName || '';
   lastOutputName.value = outputName || null;
@@ -441,6 +447,8 @@ watch(lawId, () => {
   lastResult.value = null;
   lastTraceText.value = null;
   lastError.value = null;
+  lastRunning.value = false;
+  lastReload.value = null;
   lastExpectations.value = {};
   lastScenarioName.value = '';
   lastOutputName.value = null;
@@ -1434,7 +1442,10 @@ async function handleActionSave() {
           :result="lastResult"
           :trace-text="lastTraceText"
           :error="lastError"
+          :running="lastRunning"
           :expectations="lastExpectations"
+          :can-reload="!!lastReload"
+          @reload="lastReload && lastReload()"
         />
       </nldd-simple-section>
     </nldd-page>

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -777,6 +777,11 @@ function handleSave({ section, key, newKey, index, data }) {
     if (!mr.execution.produces) mr.execution.produces = {};
     if (data == null) delete mr.execution.produces[key];
     else mr.execution.produces[key] = data;
+    // Drop the container once every field is cleared, otherwise the YAML
+    // dump emits a bare `produces: {}` which the schema rejects.
+    if (Object.keys(mr.execution.produces).length === 0) {
+      delete mr.execution.produces;
+    }
   }
 
   machineReadable.value = mr;

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -746,6 +746,10 @@ function onYamlInput(event) {
 }
 
 function handleSave({ section, key, newKey, index, data }) {
+  // JSON round-trip clone: Vue reactive proxies aren't structuredClone-able
+  // in all envs. Safe because law YAML is JSON-plain — but Date/undefined
+  // are NOT preserved, which only matters if a future field becomes
+  // date-typed (use an explicit serialiser then).
   const mr = machineReadable.value
     ? JSON.parse(JSON.stringify(machineReadable.value))
     : {};
@@ -795,6 +799,8 @@ function handleSave({ section, key, newKey, index, data }) {
 // array index. Out-of-range indices and missing keys are no-ops so a
 // stale event from the UI can never crash.
 function handleDelete({ section, key, index }) {
+  // JSON clone — see handleSave: Date/undefined not preserved (fine for
+  // JSON-plain law data).
   const mr = machineReadable.value
     ? JSON.parse(JSON.stringify(machineReadable.value))
     : null;
@@ -982,6 +988,8 @@ async function handleActionSave() {
   // separate dirty/save affordance for sheet edits. On a failed PUT the
   // edits stay in the model and the Machine pane's normal dirty/save
   // affordance is the fallback — no data loss either way.
+  // JSON clone — see handleSave: reactive proxy not structuredClone-able;
+  // Date/undefined not preserved (fine for JSON-plain law YAML).
   machineReadable.value = JSON.parse(JSON.stringify(machineReadable.value));
   yamlSource.value = yaml.dump(machineReadable.value, dumpOpts);
   parseError.value = null;

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -980,9 +980,16 @@ async function handleActionSave() {
   machineReadable.value = JSON.parse(JSON.stringify(machineReadable.value));
   yamlSource.value = yaml.dump(machineReadable.value, dumpOpts);
   parseError.value = null;
-  await handleLawSave();
-  actionSnapshot = null;
-  activeAction.value = null;
+  // Close the sheet unconditionally: the mutations are already committed
+  // above, so even if handleLawSave() throws the sheet must not stay open
+  // showing a now-clean (isDirty === false) state. A failed PUT falls back
+  // to the Machine pane's normal dirty/save affordance — no data loss.
+  try {
+    await handleLawSave();
+  } finally {
+    actionSnapshot = null;
+    activeAction.value = null;
+  }
 }
 
 </script>

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -933,7 +933,7 @@ function findIncompleteOperation(value) {
 }
 
 // Sync YAML when ActionSheet saves (mutations happened in-place)
-function handleActionSave() {
+async function handleActionSave() {
   const action = activeAction.value;
   if (action) {
     // Output is required by the schema and the engine cannot load a law
@@ -955,12 +955,17 @@ function handleActionSave() {
       return;
     }
   }
-  actionSnapshot = null;
-  activeAction.value = null;
-  // Re-assign to trigger reactivity + re-dump YAML
+  // Commit the in-place mutations, then actually persist the law. The
+  // sheet's "Opslaan" is a real save, so the Machine pane won't show a
+  // separate dirty/save affordance for sheet edits. On a failed PUT the
+  // edits stay in the model and the Machine pane's normal dirty/save
+  // affordance is the fallback — no data loss either way.
   machineReadable.value = structuredClone(machineReadable.value);
   yamlSource.value = yaml.dump(machineReadable.value, dumpOpts);
   parseError.value = null;
+  await handleLawSave();
+  actionSnapshot = null;
+  activeAction.value = null;
 }
 
 </script>

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -24,7 +24,7 @@ const { isEnabled, toggle: toggleFlag } = useFeatureFlags();
 const { colorScheme, setColorScheme } = useColorScheme();
 
 const colorSchemeOptions = [
-  ['auto', 'Automatisch'],
+  ['auto', 'Systeem'],
   ['light', 'Licht'],
   ['dark', 'Donker'],
 ];
@@ -998,10 +998,8 @@ function handleActionSave() {
             <nldd-toolbar-item slot="end">
               <nldd-button id="settings-menu-btn-md" size="md" start-icon="global-settings" text="Instellingen" expandable popovertarget="settings-menu-md"></nldd-button>
               <nldd-menu id="settings-menu-md" anchor="settings-menu-btn-md">
-                <template v-if="!authLoading && authenticated">
-                  <nldd-menu-item :text="person?.name || person?.email" disabled></nldd-menu-item>
-                  <nldd-menu-divider></nldd-menu-divider>
-                </template>
+                <nldd-menu-item v-if="!authLoading && authenticated" :text="person?.name || person?.email" disabled></nldd-menu-item>
+                <nldd-menu-group text="Functies">
                 <nldd-menu-item
                   v-for="[key, label] in editorPanelFlags"
                   :key="key"
@@ -1010,7 +1008,8 @@ function handleActionSave() {
                   :text="label"
                   @select="toggleFlag(key)"
                 ></nldd-menu-item>
-                <nldd-menu-divider></nldd-menu-divider>
+                </nldd-menu-group>
+                <nldd-menu-group text="Thema">
                 <nldd-menu-item
                   v-for="[value, label] in colorSchemeOptions"
                   :key="`scheme-md-${value}`"
@@ -1019,6 +1018,7 @@ function handleActionSave() {
                   :text="label"
                   @select="setColorScheme(value)"
                 ></nldd-menu-item>
+                </nldd-menu-group>
                 <nldd-menu-divider></nldd-menu-divider>
                 <nldd-menu-item v-if="!authLoading && authenticated" text="Uitloggen" @click="logout"></nldd-menu-item>
                 <nldd-menu-item v-else-if="!authLoading && oidcConfigured" text="Inloggen" @click="login"></nldd-menu-item>
@@ -1060,10 +1060,8 @@ function handleActionSave() {
             <nldd-toolbar-item slot="end">
               <nldd-button id="settings-menu-btn-lg" size="md" start-icon="global-settings" text="Instellingen" expandable popovertarget="settings-menu-lg"></nldd-button>
               <nldd-menu id="settings-menu-lg" anchor="settings-menu-btn-lg">
-                <template v-if="!authLoading && authenticated">
-                  <nldd-menu-item :text="person?.name || person?.email" disabled></nldd-menu-item>
-                  <nldd-menu-divider></nldd-menu-divider>
-                </template>
+                <nldd-menu-item v-if="!authLoading && authenticated" :text="person?.name || person?.email" disabled></nldd-menu-item>
+                <nldd-menu-group text="Functies">
                 <nldd-menu-item
                   v-for="[key, label] in editorPanelFlags"
                   :key="key"
@@ -1072,7 +1070,8 @@ function handleActionSave() {
                   :text="label"
                   @select="toggleFlag(key)"
                 ></nldd-menu-item>
-                <nldd-menu-divider></nldd-menu-divider>
+                </nldd-menu-group>
+                <nldd-menu-group text="Thema">
                 <nldd-menu-item
                   v-for="[value, label] in colorSchemeOptions"
                   :key="`scheme-lg-${value}`"
@@ -1081,6 +1080,7 @@ function handleActionSave() {
                   :text="label"
                   @select="setColorScheme(value)"
                 ></nldd-menu-item>
+                </nldd-menu-group>
                 <nldd-menu-divider></nldd-menu-divider>
                 <nldd-menu-item v-if="!authLoading && authenticated" text="Uitloggen" @click="logout"></nldd-menu-item>
                 <nldd-menu-item v-else-if="!authLoading && oidcConfigured" text="Inloggen" @click="login"></nldd-menu-item>
@@ -1368,10 +1368,8 @@ function handleActionSave() {
                 <nldd-icon-button id="settings-menu-btn-sm" size="lg" icon="global-settings" text="Instellingen" popovertarget="settings-menu-sm"></nldd-icon-button>
               </span>
               <nldd-menu id="settings-menu-sm" anchor="settings-menu-btn-sm">
-                <template v-if="!authLoading && authenticated">
-                  <nldd-menu-item :text="person?.name || person?.email" disabled></nldd-menu-item>
-                  <nldd-menu-divider></nldd-menu-divider>
-                </template>
+                <nldd-menu-item v-if="!authLoading && authenticated" :text="person?.name || person?.email" disabled></nldd-menu-item>
+                <nldd-menu-group text="Functies">
                 <nldd-menu-item
                   v-for="[key, label] in editorPanelFlags"
                   :key="key"
@@ -1380,7 +1378,8 @@ function handleActionSave() {
                   :text="label"
                   @select="toggleFlag(key)"
                 ></nldd-menu-item>
-                <nldd-menu-divider></nldd-menu-divider>
+                </nldd-menu-group>
+                <nldd-menu-group text="Thema">
                 <nldd-menu-item
                   v-for="[value, label] in colorSchemeOptions"
                   :key="`scheme-sm-${value}`"
@@ -1389,6 +1388,7 @@ function handleActionSave() {
                   :text="label"
                   @select="setColorScheme(value)"
                 ></nldd-menu-item>
+                </nldd-menu-group>
                 <nldd-menu-divider></nldd-menu-divider>
                 <nldd-menu-item v-if="!authLoading && authenticated" text="Uitloggen" @click="logout"></nldd-menu-item>
                 <nldd-menu-item v-else-if="!authLoading && oidcConfigured" text="Inloggen" @click="login"></nldd-menu-item>

--- a/frontend/src/LibraryApp.vue
+++ b/frontend/src/LibraryApp.vue
@@ -23,7 +23,7 @@ const { colorScheme, setColorScheme } = useColorScheme();
 const LIBRARY_HOME_TITLE = 'Wetten en regels';
 
 const colorSchemeOptions = [
-  ['auto', 'Automatisch'],
+  ['auto', 'Systeem'],
   ['light', 'Licht'],
   ['dark', 'Donker'],
 ];
@@ -464,10 +464,8 @@ loadIndex();
             <nldd-toolbar-item slot="end">
               <nldd-button id="settings-menu-btn-md" size="md" start-icon="global-settings" text="Instellingen" expandable popovertarget="settings-menu-md"></nldd-button>
               <nldd-menu id="settings-menu-md" anchor="settings-menu-btn-md">
-                <template v-if="!authLoading && authenticated">
-                  <nldd-menu-item :text="person?.name || person?.email" disabled></nldd-menu-item>
-                  <nldd-menu-divider></nldd-menu-divider>
-                </template>
+                <nldd-menu-item v-if="!authLoading && authenticated" :text="person?.name || person?.email" disabled></nldd-menu-item>
+                <nldd-menu-group text="Functies">
                 <nldd-menu-item
                   v-for="[key, label] in editorPanelFlags"
                   :key="key"
@@ -476,7 +474,8 @@ loadIndex();
                   :text="label"
                   @select="toggleFlag(key)"
                 ></nldd-menu-item>
-                <nldd-menu-divider></nldd-menu-divider>
+                </nldd-menu-group>
+                <nldd-menu-group text="Thema">
                 <nldd-menu-item
                   v-for="[value, label] in colorSchemeOptions"
                   :key="`scheme-md-${value}`"
@@ -485,6 +484,7 @@ loadIndex();
                   :text="label"
                   @select="setColorScheme(value)"
                 ></nldd-menu-item>
+                </nldd-menu-group>
                 <nldd-menu-divider></nldd-menu-divider>
                 <nldd-menu-item v-if="!authLoading && authenticated" text="Uitloggen" @click="logout"></nldd-menu-item>
                 <nldd-menu-item v-else-if="!authLoading && oidcConfigured" text="Inloggen" @click="login"></nldd-menu-item>
@@ -515,10 +515,8 @@ loadIndex();
             <nldd-toolbar-item slot="end">
               <nldd-button id="settings-menu-btn-lg" size="md" start-icon="global-settings" text="Instellingen" expandable popovertarget="settings-menu-lg"></nldd-button>
               <nldd-menu id="settings-menu-lg" anchor="settings-menu-btn-lg">
-                <template v-if="!authLoading && authenticated">
-                  <nldd-menu-item :text="person?.name || person?.email" disabled></nldd-menu-item>
-                  <nldd-menu-divider></nldd-menu-divider>
-                </template>
+                <nldd-menu-item v-if="!authLoading && authenticated" :text="person?.name || person?.email" disabled></nldd-menu-item>
+                <nldd-menu-group text="Functies">
                 <nldd-menu-item
                   v-for="[key, label] in editorPanelFlags"
                   :key="key"
@@ -527,7 +525,8 @@ loadIndex();
                   :text="label"
                   @select="toggleFlag(key)"
                 ></nldd-menu-item>
-                <nldd-menu-divider></nldd-menu-divider>
+                </nldd-menu-group>
+                <nldd-menu-group text="Thema">
                 <nldd-menu-item
                   v-for="[value, label] in colorSchemeOptions"
                   :key="`scheme-lg-${value}`"
@@ -536,6 +535,7 @@ loadIndex();
                   :text="label"
                   @select="setColorScheme(value)"
                 ></nldd-menu-item>
+                </nldd-menu-group>
                 <nldd-menu-divider></nldd-menu-divider>
                 <nldd-menu-item v-if="!authLoading && authenticated" text="Uitloggen" @click="logout"></nldd-menu-item>
                 <nldd-menu-item v-else-if="!authLoading && oidcConfigured" text="Inloggen" @click="login"></nldd-menu-item>
@@ -721,10 +721,8 @@ loadIndex();
                 <nldd-icon-button id="settings-menu-btn-sm" size="lg" icon="global-settings" text="Instellingen" popovertarget="settings-menu-sm"></nldd-icon-button>
               </span>
               <nldd-menu id="settings-menu-sm" anchor="settings-menu-btn-sm">
-                <template v-if="!authLoading && authenticated">
-                  <nldd-menu-item :text="person?.name || person?.email" disabled></nldd-menu-item>
-                  <nldd-menu-divider></nldd-menu-divider>
-                </template>
+                <nldd-menu-item v-if="!authLoading && authenticated" :text="person?.name || person?.email" disabled></nldd-menu-item>
+                <nldd-menu-group text="Functies">
                 <nldd-menu-item
                   v-for="[key, label] in editorPanelFlags"
                   :key="key"
@@ -733,7 +731,8 @@ loadIndex();
                   :text="label"
                   @select="toggleFlag(key)"
                 ></nldd-menu-item>
-                <nldd-menu-divider></nldd-menu-divider>
+                </nldd-menu-group>
+                <nldd-menu-group text="Thema">
                 <nldd-menu-item
                   v-for="[value, label] in colorSchemeOptions"
                   :key="`scheme-sm-${value}`"
@@ -742,6 +741,7 @@ loadIndex();
                   :text="label"
                   @select="setColorScheme(value)"
                 ></nldd-menu-item>
+                </nldd-menu-group>
                 <nldd-menu-divider></nldd-menu-divider>
                 <nldd-menu-item v-if="!authLoading && authenticated" text="Uitloggen" @click="logout"></nldd-menu-item>
                 <nldd-menu-item v-else-if="!authLoading && oidcConfigured" text="Inloggen" @click="login"></nldd-menu-item>

--- a/frontend/src/LibraryApp.vue
+++ b/frontend/src/LibraryApp.vue
@@ -17,10 +17,12 @@ const { authenticated, loading: authLoading, oidcConfigured, person, login, logo
 const { isEnabled, toggle: toggleFlag } = useFeatureFlags();
 const { colorScheme, setColorScheme } = useColorScheme();
 
-// Single source of truth for the library home title — used as the
-// sidebar header and as the back-text on the secondary-sidebar so the
-// two stay in sync.
-const LIBRARY_HOME_TITLE = 'Wetten en regels';
+// Library home title (sidebar header + home heading) and the label of
+// the back-button that returns to it from underlying pages. They differ
+// intentionally: the page is titled "RegelRecht", but a back-button
+// reads more naturally as "Home".
+const LIBRARY_HOME_TITLE = 'RegelRecht';
+const LIBRARY_HOME_BACK_TEXT = 'Home';
 
 const colorSchemeOptions = [
   ['auto', 'Systeem'],
@@ -591,7 +593,7 @@ loadIndex();
               <nldd-top-title-bar
                 slot="header"
                 :text="lawName || indexedLawName || 'Selecteer een wet'"
-                :back-text="LIBRARY_HOME_TITLE"
+                :back-text="LIBRARY_HOME_BACK_TEXT"
                 collapse-anchor="wet-titel"
               ></nldd-top-title-bar>
 
@@ -628,7 +630,7 @@ loadIndex();
                 slot="header"
                 :text="selectedArticle ? `Artikel ${selectedArticle.number}` : undefined"
                 :supporting-text="selectedArticle ? lawName : undefined"
-                :back-text="indexError ? undefined : (lawError ? LIBRARY_HOME_TITLE : (lawName || 'Terug'))"
+                :back-text="indexError ? undefined : (lawError ? LIBRARY_HOME_BACK_TEXT : (lawName || 'Terug'))"
                 :collapse-anchor="selectedArticle ? 'article-titel' : undefined"
               ></nldd-top-title-bar>
 
@@ -689,7 +691,7 @@ loadIndex();
                   </nldd-toolbar>
                   <nldd-spacer size="24"></nldd-spacer>
                   <KeepAlive>
-                    <ArticleText v-if="detailView === 'tekst'" :article="selectedArticle" />
+                    <ArticleText v-if="detailView === 'tekst'" :article="selectedArticle" centered />
                     <MachineReadable v-else-if="detailView === 'machine'" :article="selectedArticle" @open-action="activeAction = $event" />
                     <YamlView v-else-if="detailView === 'yaml'" :article="selectedArticle" />
                   </KeepAlive>
@@ -707,7 +709,7 @@ loadIndex();
           <nldd-toolbar size="md">
             <nldd-toolbar-item slot="start">
               <nldd-tab-bar compact>
-                <nldd-tab-bar-item selected icon="stack" text="Bibliotheek"></nldd-tab-bar-item>
+                <nldd-tab-bar-item selected icon="books" text="Bibliotheek"></nldd-tab-bar-item>
                 <nldd-tab-bar-item :href="lastEditorPath" @click.prevent="router.push(lastEditorPath)" icon="edit" text="Editor"></nldd-tab-bar-item>
               </nldd-tab-bar>
             </nldd-toolbar-item>

--- a/frontend/src/LibraryApp.vue
+++ b/frontend/src/LibraryApp.vue
@@ -455,9 +455,9 @@ loadIndex();
         <nldd-container padding="8">
           <nldd-toolbar size="md">
             <nldd-toolbar-item slot="start">
-              <nldd-tab-bar size="md">
-                <nldd-tab-bar-item selected text="Bibliotheek"></nldd-tab-bar-item>
-                <nldd-tab-bar-item :href="lastEditorPath" @click.prevent="router.push(lastEditorPath)" text="Editor"></nldd-tab-bar-item>
+              <nldd-tab-bar size="md" navigation>
+                <nldd-tab-bar-item :selected="route.name === 'library' || undefined" text="Bibliotheek"></nldd-tab-bar-item>
+                <nldd-tab-bar-item :selected="route.name === 'editor' || undefined" :href="lastEditorPath" @click.prevent="router.push(lastEditorPath)" text="Editor"></nldd-tab-bar-item>
               </nldd-tab-bar>
             </nldd-toolbar-item>
             <nldd-toolbar-item slot="end">
@@ -501,9 +501,9 @@ loadIndex();
         <nldd-container padding="8">
           <nldd-toolbar size="md">
             <nldd-toolbar-item slot="start">
-              <nldd-tab-bar size="md">
-                <nldd-tab-bar-item selected text="Bibliotheek"></nldd-tab-bar-item>
-                <nldd-tab-bar-item :href="lastEditorPath" @click.prevent="router.push(lastEditorPath)" text="Editor"></nldd-tab-bar-item>
+              <nldd-tab-bar size="md" navigation>
+                <nldd-tab-bar-item :selected="route.name === 'library' || undefined" text="Bibliotheek"></nldd-tab-bar-item>
+                <nldd-tab-bar-item :selected="route.name === 'editor' || undefined" :href="lastEditorPath" @click.prevent="router.push(lastEditorPath)" text="Editor"></nldd-tab-bar-item>
               </nldd-tab-bar>
             </nldd-toolbar-item>
             <nldd-toolbar-item slot="center" min-width="240px" width="33%">
@@ -708,9 +708,9 @@ loadIndex();
         <nldd-container padding="8">
           <nldd-toolbar size="md">
             <nldd-toolbar-item slot="start">
-              <nldd-tab-bar compact>
-                <nldd-tab-bar-item selected icon="books" text="Bibliotheek"></nldd-tab-bar-item>
-                <nldd-tab-bar-item :href="lastEditorPath" @click.prevent="router.push(lastEditorPath)" icon="edit" text="Editor"></nldd-tab-bar-item>
+              <nldd-tab-bar compact navigation>
+                <nldd-tab-bar-item :selected="route.name === 'library' || undefined" icon="books" text="Bibliotheek"></nldd-tab-bar-item>
+                <nldd-tab-bar-item :selected="route.name === 'editor' || undefined" :href="lastEditorPath" @click.prevent="router.push(lastEditorPath)" icon="edit" text="Editor"></nldd-tab-bar-item>
               </nldd-tab-bar>
             </nldd-toolbar-item>
             <nldd-toolbar-item slot="end">

--- a/frontend/src/LibraryApp.vue
+++ b/frontend/src/LibraryApp.vue
@@ -556,7 +556,7 @@ loadIndex();
             <nldd-page sticky-header>
               <nldd-top-title-bar slot="header" :text="LIBRARY_HOME_TITLE" collapse-anchor="home-titel"></nldd-top-title-bar>
 
-              <nldd-simple-section full-width>
+              <nldd-simple-section width="full">
                 <nldd-title id="home-titel" size="3"><h3>{{ LIBRARY_HOME_TITLE }}</h3></nldd-title>
                 <nldd-spacer size="16"></nldd-spacer>
                 <nldd-inline-dialog v-if="loading" text="Laden..."></nldd-inline-dialog>
@@ -595,7 +595,7 @@ loadIndex();
                 collapse-anchor="wet-titel"
               ></nldd-top-title-bar>
 
-              <nldd-simple-section full-width>
+              <nldd-simple-section width="full">
                 <nldd-title id="wet-titel" size="3"><h3>{{ lawName || 'Selecteer een wet' }}</h3></nldd-title>
                 <nldd-spacer size="16"></nldd-spacer>
                 <nldd-inline-dialog v-if="selectedLawLoading" text="Laden..."></nldd-inline-dialog>
@@ -632,7 +632,7 @@ loadIndex();
                 :collapse-anchor="selectedArticle ? 'article-titel' : undefined"
               ></nldd-top-title-bar>
 
-              <nldd-simple-section full-width v-if="indexError">
+              <nldd-simple-section width="full" v-if="indexError">
                 <nldd-inline-dialog
                   variant="alert"
                   text="Wetten en regels zijn niet geladen"
@@ -642,10 +642,10 @@ loadIndex();
                   <nldd-button slot="actions" variant="secondary" text="Neem contact op via e-mail" :href="`mailto:${SUPPORT_EMAIL}`"></nldd-button>
                 </nldd-inline-dialog>
               </nldd-simple-section>
-              <nldd-simple-section full-width v-else-if="!selectedLawId">
+              <nldd-simple-section width="full" v-else-if="!selectedLawId">
                 <nldd-inline-dialog text="Selecteer een wet"></nldd-inline-dialog>
               </nldd-simple-section>
-              <nldd-simple-section full-width v-else-if="lawError">
+              <nldd-simple-section width="full" v-else-if="lawError">
                 <nldd-inline-dialog
                   variant="alert"
                   :text="`${indexedLawName} is niet geladen`"
@@ -655,7 +655,7 @@ loadIndex();
                   <nldd-button slot="actions" variant="secondary" text="Neem contact op via e-mail" :href="`mailto:${SUPPORT_EMAIL}`"></nldd-button>
                 </nldd-inline-dialog>
               </nldd-simple-section>
-              <nldd-simple-section full-width v-else-if="articleNotFound">
+              <nldd-simple-section width="full" v-else-if="articleNotFound">
                 <nldd-inline-dialog
                   variant="alert"
                   :text="`Artikel ${selectedArticleNumber} van ${lawName || indexedLawName} bestaat niet`"
@@ -665,11 +665,11 @@ loadIndex();
                   <nldd-button slot="actions" variant="secondary" text="Neem contact op via e-mail" :href="`mailto:${SUPPORT_EMAIL}`"></nldd-button>
                 </nldd-inline-dialog>
               </nldd-simple-section>
-              <nldd-simple-section full-width v-else-if="!selectedArticle">
+              <nldd-simple-section width="full" v-else-if="!selectedArticle">
                 <nldd-inline-dialog text="Selecteer een artikel"></nldd-inline-dialog>
               </nldd-simple-section>
               <template v-else>
-                <nldd-simple-section full-width>
+                <nldd-simple-section width="full">
                   <nldd-title id="article-titel" size="3">
                     <h3>Artikel {{ selectedArticle.number }}</h3>
                     <span slot="subtitle">{{ lawName }}</span>

--- a/frontend/src/components/ActionSheet.vue
+++ b/frontend/src/components/ActionSheet.vue
@@ -84,7 +84,7 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <nldd-sheet ref="sheetEl" placement="right" width="480px" @close="emit('close')">
+  <nldd-sheet ref="sheetEl" placement="right" :width="editable ? '640px' : '480px'" @close="emit('close')">
     <!-- :key forces nldd-page to remount whenever a NEW action opens.
          nldd-page captures the sticky-header height ONCE per mount via
          requestAnimationFrame; when the sheet opens with a new action the
@@ -109,7 +109,7 @@ onUnmounted(() => {
         <template v-if="editable && action">
           <nldd-list variant="box" class="settings-list" data-testid="action-output-binding">
             <nldd-list-item size="md">
-              <nldd-text-cell text="Output" width="fit-content"></nldd-text-cell>
+              <nldd-text-cell text="Output" width="120px"></nldd-text-cell>
               <nldd-spacer-cell size="12"></nldd-spacer-cell>
               <nldd-cell>
                 <nldd-text-field size="md" :value="action.output" @input="action.output = $event.target?.value ?? $event.detail?.value ?? action.output" data-testid="action-output-field"></nldd-text-field>

--- a/frontend/src/components/ActionSheet.vue
+++ b/frontend/src/components/ActionSheet.vue
@@ -100,56 +100,48 @@ onUnmounted(() => {
       <nldd-top-title-bar slot="header" text="Actie" :dismiss-text="editable ? 'Annuleer' : 'Sluit'" @dismiss="emit('close')"></nldd-top-title-bar>
 
       <nldd-simple-section>
-        <!-- Output binding (editable view only).
-             The `&& action` guard prevents a render-time TypeError when the
-             sheet is mounted but `action` hasn't been set yet — the parent
-             always mounts the sheet eagerly and toggles visibility via the
-             web-component's show()/hide() methods, so `action` is null
-             whenever the sheet isn't actively editing something. -->
-        <template v-if="editable && action">
-          <nldd-list variant="box" class="settings-list" data-testid="action-output-binding">
-            <nldd-list-item size="md">
-              <nldd-text-cell text="Output" width="120px"></nldd-text-cell>
-              <nldd-spacer-cell size="12"></nldd-spacer-cell>
-              <nldd-cell>
-                <nldd-text-field size="md" :value="action.output" @input="action.output = $event.target?.value ?? $event.detail?.value ?? action.output" data-testid="action-output-field"></nldd-text-field>
-              </nldd-cell>
-            </nldd-list-item>
-          </nldd-list>
-
-          <nldd-spacer size="8"></nldd-spacer>
-        </template>
+        <!-- Output binding lives inside the operation's settings list (via
+             OperationSettings' lead-row slot) at the top level, or in the
+             direct-value list below — so it sits in the same box as the
+             other root rows instead of a separate box. -->
 
         <!-- Section A: Bovenliggende operaties -->
         <template v-if="parentOperations.length">
           <nldd-list variant="box">
+            <!-- Back/up navigation — clickable parent rows with a
+                 chevron-left, identical in view and edit: click any
+                 ancestor to jump up one or more levels. -->
             <nldd-list-item
               v-for="op in parentOperations"
               :key="op.number"
               size="md"
               :data-testid="`parent-op-${op.number}`"
-              :type="editable ? undefined : 'button'"
-              @click="!editable && selectOperation(op)"
+              type="button"
+              @click="selectOperation(op)"
             >
-              <template v-if="!editable">
-                <nldd-icon-cell size="20">
-                  <nldd-icon name="chevron-left"></nldd-icon>
-                </nldd-icon-cell>
-                <nldd-spacer-cell size="12"></nldd-spacer-cell>
-              </template>
+              <nldd-icon-cell size="20">
+                <nldd-icon name="chevron-left"></nldd-icon>
+              </nldd-icon-cell>
+              <nldd-spacer-cell size="12"></nldd-spacer-cell>
               <nldd-text-cell :text="`${op.number}. ${op.title}`" :supporting-text="op.subtitle">
               </nldd-text-cell>
-              <nldd-spacer-cell v-if="editable" size="8"></nldd-spacer-cell>
-              <nldd-cell v-if="editable">
-                <nldd-button :data-testid="`parent-op-${op.number}-edit-btn`" @click="selectOperation(op)" text="Bewerk"></nldd-button>
-              </nldd-cell>
             </nldd-list-item>
           </nldd-list>
         </template>
 
         <!-- Section B: Operation Settings -->
         <nldd-spacer v-if="parentOperations.length && selectedOperation" size="24"></nldd-spacer>
-        <OperationSettings v-if="selectedOperation" :operation="selectedOperation" :article="article" :editable="editable" @select-operation="selectOperationByNode" />
+        <OperationSettings v-if="selectedOperation" :operation="selectedOperation" :article="article" :editable="editable" :hide-title-row="editable && !parentOperations.length" @select-operation="selectOperationByNode">
+          <template #lead-row>
+            <nldd-list-item v-if="editable && action && !parentOperations.length" size="md">
+              <nldd-text-cell text="Output" width="120px"></nldd-text-cell>
+              <nldd-spacer-cell size="12"></nldd-spacer-cell>
+              <nldd-cell>
+                <nldd-text-field size="md" :value="action.output" @input="action.output = $event.target?.value ?? $event.detail?.value ?? action.output" data-testid="action-output-field"></nldd-text-field>
+              </nldd-cell>
+            </nldd-list-item>
+          </template>
+        </OperationSettings>
 
         <!-- Direct value: action has no operation, just outputs a value
              (literal or $VAR reference). Mirror OperationSettings' Titel +
@@ -157,9 +149,12 @@ onUnmounted(() => {
              which action they're looking at. -->
         <nldd-list v-if="directValue" variant="box">
           <nldd-list-item size="md">
-            <nldd-text-cell text="Output" width="fit-content"></nldd-text-cell>
+            <nldd-text-cell text="Output" :width="editable ? '120px' : 'fit-content'"></nldd-text-cell>
             <nldd-spacer-cell size="12"></nldd-spacer-cell>
-            <nldd-text-cell horizontal-alignment="right" :text="action.output || '(leeg)'"></nldd-text-cell>
+            <nldd-cell v-if="editable">
+              <nldd-text-field size="md" :value="action.output" @input="action.output = $event.target?.value ?? $event.detail?.value ?? action.output" data-testid="action-output-field"></nldd-text-field>
+            </nldd-cell>
+            <nldd-text-cell v-else horizontal-alignment="right" :text="action.output || '(leeg)'"></nldd-text-cell>
           </nldd-list-item>
           <nldd-list-item size="md">
             <nldd-text-cell text="Waarde" width="fit-content"></nldd-text-cell>

--- a/frontend/src/components/ActionSheet.vue
+++ b/frontend/src/components/ActionSheet.vue
@@ -7,6 +7,9 @@ const props = defineProps({
   action: { type: Object, default: null },
   article: { type: Object, default: null },
   editable: { type: Boolean, default: false },
+  /** A freshly added action — Save is always offered (you opened the
+   *  sheet to create it), regardless of the dirty snapshot. */
+  isNew: { type: Boolean, default: false },
 });
 
 const emit = defineEmits(['close', 'save', 'edit']);
@@ -179,7 +182,7 @@ onUnmounted(() => {
       </nldd-simple-section>
 
       <nldd-container slot="footer" padding="16">
-        <nldd-button v-if="editable && isDirty" variant="primary" size="md" width="full" data-testid="action-sheet-save-btn" @click="emit('save')" text="Opslaan"></nldd-button>
+        <nldd-button v-if="editable && (isNew || isDirty)" variant="primary" size="md" width="full" data-testid="action-sheet-save-btn" @click="emit('save')" text="Opslaan"></nldd-button>
         <nldd-button v-else-if="!editable" variant="secondary" size="md" width="full" data-testid="action-sheet-edit-btn" @click="emit('edit')" text="Bewerken"></nldd-button>
       </nldd-container>
     </nldd-page>

--- a/frontend/src/components/ActionSheet.vue
+++ b/frontend/src/components/ActionSheet.vue
@@ -23,6 +23,19 @@ const selectedOpIndex = ref(0);
 let actionSeq = 0;
 const actionKey = ref('none');
 
+// Snapshot the action when it opens so we can show "Opslaan" only when
+// something actually changed. Edits mutate the action in place, so a
+// JSON compare of the live action vs this baseline is the dirty signal.
+const actionBaseline = ref('');
+const isDirty = computed(() => {
+  if (!props.action) return false;
+  try {
+    return JSON.stringify(props.action) !== actionBaseline.value;
+  } catch {
+    return true;
+  }
+});
+
 watch(() => props.action, async (action) => {
   selectedOpIndex.value = 0;
   actionKey.value = action ? String(++actionSeq) : 'none';
@@ -31,6 +44,7 @@ watch(() => props.action, async (action) => {
     sheetEl.value?.hide();
     return;
   }
+  actionBaseline.value = JSON.stringify(action);
   await nextTick();
   sheetEl.value?.show();
 }, { immediate: true });
@@ -165,8 +179,8 @@ onUnmounted(() => {
       </nldd-simple-section>
 
       <nldd-container slot="footer" padding="16">
-        <nldd-button v-if="editable" variant="primary" size="md" width="full" data-testid="action-sheet-save-btn" @click="emit('save')" text="Opslaan"></nldd-button>
-        <nldd-button v-else variant="secondary" size="md" width="full" data-testid="action-sheet-edit-btn" @click="emit('edit')" text="Bewerken"></nldd-button>
+        <nldd-button v-if="editable && isDirty" variant="primary" size="md" width="full" data-testid="action-sheet-save-btn" @click="emit('save')" text="Opslaan"></nldd-button>
+        <nldd-button v-else-if="!editable" variant="secondary" size="md" width="full" data-testid="action-sheet-edit-btn" @click="emit('edit')" text="Bewerken"></nldd-button>
       </nldd-container>
     </nldd-page>
   </nldd-sheet>

--- a/frontend/src/components/ActionSheet.vue
+++ b/frontend/src/components/ActionSheet.vue
@@ -84,7 +84,7 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <nldd-sheet ref="sheetEl" placement="right" width="640px" full-height @close="emit('close')">
+  <nldd-sheet ref="sheetEl" placement="right" width="640px" @close="emit('close')">
     <!-- :key forces nldd-page to remount whenever a NEW action opens.
          nldd-page captures the sticky-header height ONCE per mount via
          requestAnimationFrame; when the sheet opens with a new action the
@@ -170,8 +170,8 @@ onUnmounted(() => {
       </nldd-simple-section>
 
       <nldd-container slot="footer" padding="16">
-        <nldd-button v-if="editable" variant="primary" size="md" full-width data-testid="action-sheet-save-btn" @click="emit('save')" text="Opslaan"></nldd-button>
-        <nldd-button v-else variant="secondary" size="md" full-width data-testid="action-sheet-edit-btn" @click="emit('edit')" text="Bewerken"></nldd-button>
+        <nldd-button v-if="editable" variant="primary" size="md" width="full" data-testid="action-sheet-save-btn" @click="emit('save')" text="Opslaan"></nldd-button>
+        <nldd-button v-else variant="secondary" size="md" width="full" data-testid="action-sheet-edit-btn" @click="emit('edit')" text="Bewerken"></nldd-button>
       </nldd-container>
     </nldd-page>
   </nldd-sheet>

--- a/frontend/src/components/ActionSheet.vue
+++ b/frontend/src/components/ActionSheet.vue
@@ -84,7 +84,7 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <nldd-sheet ref="sheetEl" placement="right" width="640px" @close="emit('close')">
+  <nldd-sheet ref="sheetEl" placement="right" width="480px" @close="emit('close')">
     <!-- :key forces nldd-page to remount whenever a NEW action opens.
          nldd-page captures the sticky-header height ONCE per mount via
          requestAnimationFrame; when the sheet opens with a new action the
@@ -109,8 +109,8 @@ onUnmounted(() => {
         <template v-if="editable && action">
           <nldd-list variant="box" class="settings-list" data-testid="action-output-binding">
             <nldd-list-item size="md">
-              <nldd-text-cell text="Output" max-width="120px"></nldd-text-cell>
-              <nldd-spacer-cell size="8"></nldd-spacer-cell>
+              <nldd-text-cell text="Output" width="fit-content"></nldd-text-cell>
+              <nldd-spacer-cell size="12"></nldd-spacer-cell>
               <nldd-cell>
                 <nldd-text-field size="md" :value="action.output" @input="action.output = $event.target?.value ?? $event.detail?.value ?? action.output" data-testid="action-output-field"></nldd-text-field>
               </nldd-cell>
@@ -157,13 +157,13 @@ onUnmounted(() => {
              which action they're looking at. -->
         <nldd-list v-if="directValue" variant="box">
           <nldd-list-item size="md">
-            <nldd-text-cell text="Output" max-width="120px"></nldd-text-cell>
-            <nldd-spacer-cell size="8"></nldd-spacer-cell>
+            <nldd-text-cell text="Output" width="fit-content"></nldd-text-cell>
+            <nldd-spacer-cell size="12"></nldd-spacer-cell>
             <nldd-text-cell horizontal-alignment="right" :text="action.output || '(leeg)'"></nldd-text-cell>
           </nldd-list-item>
           <nldd-list-item size="md">
-            <nldd-text-cell text="Waarde" max-width="120px"></nldd-text-cell>
-            <nldd-spacer-cell size="8"></nldd-spacer-cell>
+            <nldd-text-cell text="Waarde" width="fit-content"></nldd-text-cell>
+            <nldd-spacer-cell size="12"></nldd-spacer-cell>
             <nldd-text-cell horizontal-alignment="right" :text="directValue.label"></nldd-text-cell>
           </nldd-list-item>
         </nldd-list>

--- a/frontend/src/components/ActionSheet.vue
+++ b/frontend/src/components/ActionSheet.vue
@@ -29,6 +29,12 @@ const actionKey = ref('none');
 // Snapshot the action when it opens so we can show "Opslaan" only when
 // something actually changed. Edits mutate the action in place, so a
 // JSON compare of the live action vs this baseline is the dirty signal.
+// Perf note: this is O(action tree) and re-runs whenever any nested
+// field changes (an edit), not on every unrelated render. It's the
+// same snapshot approach EditSheet/ScenarioBuilder use deliberately for
+// consistency. If a pathologically deep SWITCH/IF tree ever makes the
+// per-keystroke stringify noticeable, swap to a deep watch that flips a
+// boolean (O(change) instead of O(tree)).
 const actionBaseline = ref('');
 const isDirty = computed(() => {
   if (!props.action) return false;

--- a/frontend/src/components/ArticleText.vue
+++ b/frontend/src/components/ArticleText.vue
@@ -6,6 +6,9 @@ import DOMPurify from 'dompurify';
 const props = defineProps({
   article: { type: Object, default: null },
   raw: { type: Boolean, default: false },
+  // Center the rich-text column. Opt-in so the library reading view can
+  // center while the editor's read-only pane stays left-aligned.
+  centered: { type: Boolean, default: false },
 });
 
 // marked v18 no longer sanitizes HTML in Markdown by default; run its output
@@ -25,10 +28,10 @@ const paragraphs = computed(() => {
 
 <template>
   <template v-if="article">
-    <nldd-rich-text v-if="raw">
+    <nldd-rich-text v-if="raw" :centered="centered || undefined">
       <p v-for="(p, i) in paragraphs" :key="i">{{ p }}</p>
     </nldd-rich-text>
-    <nldd-rich-text v-else v-html="html"></nldd-rich-text>
+    <nldd-rich-text v-else :centered="centered || undefined" v-html="html"></nldd-rich-text>
   </template>
   <nldd-inline-dialog v-else text="Geen artikel geselecteerd"></nldd-inline-dialog>
 </template>

--- a/frontend/src/components/BreakableName.vue
+++ b/frontend/src/components/BreakableName.vue
@@ -1,0 +1,29 @@
+<script setup>
+import { computed } from 'vue';
+
+/**
+ * Renders an identifier so the browser may wrap *after* each underscore.
+ *
+ * Long snake_case names (e.g. `geldige_partnertypen`) have no native break
+ * opportunity, so a narrow column breaks them mid-word — one character per
+ * line in the worst case. Splitting on `_` and emitting a real <wbr> just
+ * *before* each underscore gives a clean, opt-in break point: the name stays
+ * on one line when it fits, and wraps only at underscores when it doesn't,
+ * with the underscore leading the continuation line (a clearer "this
+ * continues" signal than a trailing underscore). Unlike a zero-width space
+ * this leaves nothing behind in copied text.
+ *
+ * Read-only display only — editable fields keep the raw value.
+ */
+const props = defineProps({
+  name: { type: String, required: true },
+});
+
+// 'a_b_c' → ['a', 'b', 'c']. Rendered as: a + <wbr> + '_b' + <wbr> + '_c'
+const segments = computed(() => String(props.name).split('_'));
+</script>
+
+<template><span class="breakable-name"><template
+  v-for="(seg, i) in segments"
+  :key="i"
+><template v-if="i > 0"><wbr>_</template>{{ seg }}</template></span></template>

--- a/frontend/src/components/DataSourceTable.vue
+++ b/frontend/src/components/DataSourceTable.vue
@@ -13,6 +13,9 @@ const props = defineProps({
   // When the table is shown one level deep in a drill-in sheet there's no
   // accordion: the title is a plain heading and the body is always visible.
   drilledIn: { type: Boolean, default: false },
+  // Optional id put on the drilled-in heading so the sheet's top-title-bar
+  // can use it as its `collapse-anchor` (full back button until scrolled).
+  anchorId: { type: String, default: '' },
 });
 
 const emit = defineEmits(['update:modelValue']);
@@ -111,7 +114,7 @@ const showBody = computed(() => props.drilledIn || expanded.value);
       </nldd-title>
       <span class="ds-block-badge" v-if="rowCount > 0">{{ rowCount }}</span>
     </button>
-    <nldd-title v-else size="5" class="ds-block-heading">
+    <nldd-title v-else size="5" class="ds-block-heading" :id="anchorId || undefined">
       <span>{{ title }}</span>
     </nldd-title>
 
@@ -120,57 +123,58 @@ const showBody = computed(() => props.drilledIn || expanded.value);
         Geen gegevens &mdash; vul in indien relevant
       </div>
 
-      <!-- One card per data row -->
-      <div v-for="(row, ri) in rows" :key="row._id ?? ri">
-        <div v-if="rows.length > 1" class="ds-row-card-header">
-          <span class="ds-row-card-label">Rij {{ ri + 1 }}</span>
-          <nldd-icon-button
-            v-if="!readonly"
-            icon="minus"
-            title="Rij verwijderen"
-            @click="removeRow(ri)"
-          ></nldd-icon-button>
-        </div>
+      <!-- One box list per row — identical layout regardless of row count,
+           with the delete button at the bottom of each list. -->
+      <nldd-list
+        v-for="(row, ri) in rows"
+        :key="row._id ?? ri"
+        variant="box"
+        class="ds-datasource-list"
+      >
+        <nldd-list-item v-for="col in allColumns" :key="col.name" size="md">
+          <nldd-text-cell :text="col.name" max-width="140px" :class="{ 'ds-key-label': col.isKey }"></nldd-text-cell>
+          <nldd-spacer-cell v-if="!readonly" size="8"></nldd-spacer-cell>
+          <template v-if="readonly">
+            <nldd-text-cell :text="String(row[col.name] ?? '')"></nldd-text-cell>
+          </template>
+          <nldd-cell v-else-if="col.type === 'boolean'">
+            <nldd-dropdown size="md">
+              <select
+                :aria-label="col.name"
+                :value="String(row[col.name] || 'null')"
+                @change="updateCell(ri, col.name, $event.target.value)"
+              >
+                <option value="true">true</option>
+                <option value="false">false</option>
+                <option value="null">null</option>
+              </select>
+            </nldd-dropdown>
+          </nldd-cell>
+          <nldd-cell v-else>
+            <nldd-text-field
+              size="md"
+              :type="inputType(col.type)"
+              :value="String(row[col.name] ?? '')"
+              :placeholder="col.name"
+              @input="updateCell(ri, col.name, $event.target?.value ?? $event.detail?.value ?? '')"
+            ></nldd-text-field>
+          </nldd-cell>
+        </nldd-list-item>
 
-        <nldd-list variant="box" class="ds-datasource-list">
-          <nldd-list-item v-for="col in allColumns" :key="col.name" size="md">
-            <nldd-text-cell :text="col.name" max-width="140px" :class="{ 'ds-key-label': col.isKey }"></nldd-text-cell>
-            <nldd-spacer-cell v-if="!readonly" size="8"></nldd-spacer-cell>
-            <template v-if="readonly">
-              <nldd-text-cell :text="String(row[col.name] ?? '')"></nldd-text-cell>
-            </template>
-            <nldd-cell v-else-if="col.type === 'boolean'">
-              <nldd-dropdown size="md">
-                <select
-                  :aria-label="col.name"
-                  :value="String(row[col.name] || 'null')"
-                  @change="updateCell(ri, col.name, $event.target.value)"
-                >
-                  <option value="true">true</option>
-                  <option value="false">false</option>
-                  <option value="null">null</option>
-                </select>
-              </nldd-dropdown>
-            </nldd-cell>
-            <nldd-cell v-else>
-              <nldd-text-field
-                size="md"
-                :type="inputType(col.type)"
-                :value="String(row[col.name] ?? '')"
-                :placeholder="col.name"
-                @input="updateCell(ri, col.name, $event.target?.value ?? $event.detail?.value ?? '')"
-              ></nldd-text-field>
-            </nldd-cell>
-          </nldd-list-item>
+        <nldd-list-item v-if="!readonly" size="md">
+          <nldd-cell width="full">
+            <nldd-button size="md" width="full" start-icon="minus" @click="removeRow(ri)" text="Verwijder"></nldd-button>
+          </nldd-cell>
+        </nldd-list-item>
+      </nldd-list>
 
-          <!-- Single-row inline delete -->
-          <nldd-list-item v-if="!readonly && rows.length === 1" size="md">
-            <nldd-button size="md" width="full" start-icon="minus" @click="removeRow(ri)" text="Rij verwijderen"></nldd-button>
-          </nldd-list-item>
-        </nldd-list>
-      </div>
-
-      <nldd-button v-if="!readonly" size="md" width="full" start-icon="plus-small" @click="addRow" text="Rij toevoegen"></nldd-button>
+      <nldd-list v-if="!readonly" variant="box">
+        <nldd-list-item size="md">
+          <nldd-cell width="full">
+            <nldd-button size="md" width="full" start-icon="plus-small" @click="addRow" text="Voeg toe"></nldd-button>
+          </nldd-cell>
+        </nldd-list-item>
+      </nldd-list>
     </div>
   </div>
 </template>
@@ -229,20 +233,6 @@ const showBody = computed(() => props.drilledIn || expanded.value);
   font-size: 14px;
   color: var(--semantics-text-color-secondary, #999);
   font-style: italic;
-}
-
-.ds-row-card-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 2px;
-}
-
-.ds-row-card-label {
-  font-family: var(--primitives-font-family-body, 'RijksSansVF', sans-serif);
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--semantics-text-color-secondary, #545D68);
 }
 
 .ds-key-label {

--- a/frontend/src/components/DataSourceTable.vue
+++ b/frontend/src/components/DataSourceTable.vue
@@ -16,6 +16,8 @@ const props = defineProps({
   // Optional id put on the drilled-in heading so the sheet's top-title-bar
   // can use it as its `collapse-anchor` (full back button until scrolled).
   anchorId: { type: String, default: '' },
+  // Secondary line under the drilled-in heading (e.g. the scenario name).
+  subtitle: { type: String, default: '' },
 });
 
 const emit = defineEmits(['update:modelValue']);
@@ -114,9 +116,13 @@ const showBody = computed(() => props.drilledIn || expanded.value);
       </nldd-title>
       <span class="ds-block-badge" v-if="rowCount > 0">{{ rowCount }}</span>
     </button>
-    <nldd-title v-else size="5" class="ds-block-heading" :id="anchorId || undefined">
-      <span>{{ title }}</span>
-    </nldd-title>
+    <template v-else>
+      <nldd-title size="5" class="ds-block-heading" :id="anchorId || undefined">
+        <span>{{ title }}</span>
+      </nldd-title>
+      <p v-if="subtitle" class="ds-block-subtitle">{{ subtitle }}</p>
+      <nldd-spacer size="8"></nldd-spacer>
+    </template>
 
     <div v-if="showBody" class="ds-block-body">
       <div v-if="rows.length === 0" class="ds-block-empty">
@@ -163,7 +169,7 @@ const showBody = computed(() => props.drilledIn || expanded.value);
 
         <nldd-list-item v-if="!readonly" size="md">
           <nldd-cell width="full">
-            <nldd-button size="md" width="full" start-icon="minus" @click="removeRow(ri)" text="Verwijder"></nldd-button>
+            <nldd-button variant="destructive" size="md" width="full" start-icon="minus" @click="removeRow(ri)" text="Verwijder"></nldd-button>
           </nldd-cell>
         </nldd-list-item>
       </nldd-list>
@@ -197,7 +203,14 @@ const showBody = computed(() => props.drilledIn || expanded.value);
 }
 
 .ds-block-heading {
-  margin: 0 0 4px 0;
+  margin: 0;
+}
+
+.ds-block-subtitle {
+  margin: 2px 0 0 0;
+  font-family: var(--primitives-font-family-body, 'RijksSansVF', sans-serif);
+  font-size: 13px;
+  color: var(--semantics-text-color-secondary, #545D68);
 }
 
 .ds-block-chevron {

--- a/frontend/src/components/DataSourceTable.vue
+++ b/frontend/src/components/DataSourceTable.vue
@@ -115,10 +115,10 @@ const showBody = computed(() => props.drilledIn || expanded.value);
       <span class="ds-block-badge" v-if="rowCount > 0">{{ rowCount }}</span>
     </button>
     <template v-else>
-      <nldd-title size="5" :id="anchorId || undefined">
+      <nldd-title size="3" :id="anchorId || undefined">
         <h2>{{ title }}</h2>
       </nldd-title>
-      <nldd-spacer size="12"></nldd-spacer>
+      <nldd-spacer size="8"></nldd-spacer>
     </template>
 
     <template v-if="showBody">

--- a/frontend/src/components/DataSourceTable.vue
+++ b/frontend/src/components/DataSourceTable.vue
@@ -156,12 +156,12 @@ const rowCount = computed(() => rows.value.length);
 
           <!-- Single-row inline delete -->
           <nldd-list-item v-if="!readonly && rows.length === 1" size="md">
-            <nldd-button size="md" full-width start-icon="minus" @click="removeRow(ri)" text="Rij verwijderen"></nldd-button>
+            <nldd-button size="md" width="full" start-icon="minus" @click="removeRow(ri)" text="Rij verwijderen"></nldd-button>
           </nldd-list-item>
         </nldd-list>
       </div>
 
-      <nldd-button v-if="!readonly" size="md" full-width start-icon="plus-small" @click="addRow" text="Rij toevoegen"></nldd-button>
+      <nldd-button v-if="!readonly" size="md" width="full" start-icon="plus-small" @click="addRow" text="Rij toevoegen"></nldd-button>
     </div>
   </div>
 </template>

--- a/frontend/src/components/DataSourceTable.vue
+++ b/frontend/src/components/DataSourceTable.vue
@@ -138,7 +138,7 @@ const showBody = computed(() => props.drilledIn || expanded.value);
         class="ds-datasource-list"
       >
         <nldd-list-item v-for="col in allColumns" :key="col.name" size="md">
-          <nldd-text-cell :text="col.name" max-width="140px" :class="{ 'ds-key-label': col.isKey }"></nldd-text-cell>
+          <nldd-text-cell :text="col.name" max-width="280px" :class="{ 'ds-key-label': col.isKey }"></nldd-text-cell>
           <nldd-spacer-cell v-if="!readonly" size="8"></nldd-spacer-cell>
           <template v-if="readonly">
             <nldd-text-cell :text="String(row[col.name] ?? '')"></nldd-text-cell>
@@ -256,14 +256,14 @@ const showBody = computed(() => props.drilledIn || expanded.value);
 <style>
 /* Unscoped: nldd web components need global selectors */
 .ds-datasource-list nldd-text-cell {
-  width: 140px;
   min-width: 140px;
-  flex-shrink: 0;
+  flex: 1;
 }
 
 .ds-datasource-list nldd-cell {
   flex: 1;
   min-width: 0;
+  max-width: 280px;
 }
 
 .ds-datasource-list nldd-text-field,

--- a/frontend/src/components/DataSourceTable.vue
+++ b/frontend/src/components/DataSourceTable.vue
@@ -136,12 +136,12 @@ const showBody = computed(() => props.drilledIn || expanded.value);
         <nldd-spacer v-if="ri > 0" size="12"></nldd-spacer>
         <nldd-list variant="box">
         <nldd-list-item v-for="col in allColumns" :key="col.name" size="md">
-          <nldd-text-cell :text="col.isKey ? `**${col.name}**` : col.name" min-width="120px" max-width="280px"></nldd-text-cell>
+          <nldd-text-cell :text="col.isKey ? `**${col.name}**` : col.name" min-width="120px" max-width="200px"></nldd-text-cell>
           <nldd-spacer-cell v-if="!readonly" size="8"></nldd-spacer-cell>
           <template v-if="readonly">
             <nldd-text-cell :text="String(row[col.name] ?? '')"></nldd-text-cell>
           </template>
-          <nldd-cell v-else-if="col.type === 'boolean'" width="full" min-width="120px" max-width="320px">
+          <nldd-cell v-else-if="col.type === 'boolean'" width="full" min-width="120px">
             <nldd-dropdown size="md">
               <select
                 :aria-label="col.name"
@@ -154,7 +154,7 @@ const showBody = computed(() => props.drilledIn || expanded.value);
               </select>
             </nldd-dropdown>
           </nldd-cell>
-          <nldd-cell v-else width="full" min-width="120px" max-width="320px">
+          <nldd-cell v-else width="full" min-width="120px">
             <nldd-text-field
               size="md"
               :type="inputType(col.type)"

--- a/frontend/src/components/DataSourceTable.vue
+++ b/frontend/src/components/DataSourceTable.vue
@@ -141,7 +141,7 @@ const showBody = computed(() => props.drilledIn || expanded.value);
           <template v-if="readonly">
             <nldd-text-cell :text="String(row[col.name] ?? '')"></nldd-text-cell>
           </template>
-          <nldd-cell v-else-if="col.type === 'boolean'" width="full" min-width="100px" max-width="320px">
+          <nldd-cell v-else-if="col.type === 'boolean'" width="full" min-width="120px" max-width="320px">
             <nldd-dropdown size="md">
               <select
                 :aria-label="col.name"
@@ -154,7 +154,7 @@ const showBody = computed(() => props.drilledIn || expanded.value);
               </select>
             </nldd-dropdown>
           </nldd-cell>
-          <nldd-cell v-else width="full" min-width="100px" max-width="320px">
+          <nldd-cell v-else width="full" min-width="120px" max-width="320px">
             <nldd-text-field
               size="md"
               :type="inputType(col.type)"

--- a/frontend/src/components/DataSourceTable.vue
+++ b/frontend/src/components/DataSourceTable.vue
@@ -16,8 +16,6 @@ const props = defineProps({
   // Optional id put on the drilled-in heading so the sheet's top-title-bar
   // can use it as its `collapse-anchor` (full back button until scrolled).
   anchorId: { type: String, default: '' },
-  // Secondary line under the drilled-in heading (e.g. the scenario name).
-  subtitle: { type: String, default: '' },
 });
 
 const emit = defineEmits(['update:modelValue']);
@@ -119,7 +117,6 @@ const showBody = computed(() => props.drilledIn || expanded.value);
     <template v-else>
       <nldd-title size="5" :id="anchorId || undefined">
         <h2>{{ title }}</h2>
-        <p v-if="subtitle" slot="subtitle">{{ subtitle }}</p>
       </nldd-title>
       <nldd-spacer size="12"></nldd-spacer>
     </template>

--- a/frontend/src/components/DataSourceTable.vue
+++ b/frontend/src/components/DataSourceTable.vue
@@ -107,7 +107,7 @@ const showBody = computed(() => props.drilledIn || expanded.value);
 </script>
 
 <template>
-  <div class="ds-block">
+  <div>
     <!-- Header: accordion toggle, or a plain heading when drilled in -->
     <button v-if="!drilledIn" class="ds-block-toggle" :aria-expanded="expanded" @click="toggleExpand" type="button">
       <span class="ds-block-chevron" :class="{ 'ds-block-chevron--open': expanded }">&#9656;</span>
@@ -124,19 +124,17 @@ const showBody = computed(() => props.drilledIn || expanded.value);
       <nldd-spacer size="12"></nldd-spacer>
     </template>
 
-    <div v-if="showBody" class="ds-block-body">
+    <template v-if="showBody">
       <div v-if="rows.length === 0" class="ds-block-empty">
         Geen gegevens &mdash; vul in indien relevant
       </div>
 
       <!-- One box list per row — identical layout regardless of row count,
-           with the delete button at the bottom of each list. -->
-      <nldd-list
-        v-for="(row, ri) in rows"
-        :key="row._id ?? ri"
-        variant="box"
-        class="ds-datasource-list"
-      >
+           with the delete button at the bottom of each list. Spacers (not a
+           flex-gap container) separate the stacked lists. -->
+      <template v-for="(row, ri) in rows" :key="row._id ?? ri">
+        <nldd-spacer v-if="ri > 0" size="12"></nldd-spacer>
+        <nldd-list variant="box" class="ds-datasource-list">
         <nldd-list-item v-for="col in allColumns" :key="col.name" size="md">
           <nldd-text-cell :text="col.name" max-width="280px" :class="{ 'ds-key-label': col.isKey }"></nldd-text-cell>
           <nldd-spacer-cell v-if="!readonly" size="8"></nldd-spacer-cell>
@@ -172,8 +170,10 @@ const showBody = computed(() => props.drilledIn || expanded.value);
             <nldd-button variant="destructive" size="md" width="full" start-icon="minus" @click="removeRow(ri)" text="Verwijder"></nldd-button>
           </nldd-cell>
         </nldd-list-item>
-      </nldd-list>
+        </nldd-list>
+      </template>
 
+      <nldd-spacer v-if="!readonly" size="12"></nldd-spacer>
       <nldd-list v-if="!readonly" variant="box">
         <nldd-list-item size="md">
           <nldd-cell width="full">
@@ -181,15 +181,11 @@ const showBody = computed(() => props.drilledIn || expanded.value);
           </nldd-cell>
         </nldd-list-item>
       </nldd-list>
-    </div>
+    </template>
   </div>
 </template>
 
 <style scoped>
-.ds-block + .ds-block {
-  margin-top: 12px;
-}
-
 .ds-block-toggle {
   display: flex;
   align-items: center;
@@ -221,12 +217,6 @@ const showBody = computed(() => props.drilledIn || expanded.value);
   background: var(--color-primary);
   color: white;
   flex-shrink: 0;
-}
-
-.ds-block-body {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
 }
 
 .ds-block-empty {

--- a/frontend/src/components/DataSourceTable.vue
+++ b/frontend/src/components/DataSourceTable.vue
@@ -134,14 +134,14 @@ const showBody = computed(() => props.drilledIn || expanded.value);
            flex-gap container) separate the stacked lists. -->
       <template v-for="(row, ri) in rows" :key="row._id ?? ri">
         <nldd-spacer v-if="ri > 0" size="12"></nldd-spacer>
-        <nldd-list variant="box" class="ds-datasource-list">
+        <nldd-list variant="box">
         <nldd-list-item v-for="col in allColumns" :key="col.name" size="md">
-          <nldd-text-cell :text="col.name" max-width="280px" :class="{ 'ds-key-label': col.isKey }"></nldd-text-cell>
+          <nldd-text-cell :text="col.isKey ? `**${col.name}**` : col.name" min-width="120px" max-width="280px"></nldd-text-cell>
           <nldd-spacer-cell v-if="!readonly" size="8"></nldd-spacer-cell>
           <template v-if="readonly">
             <nldd-text-cell :text="String(row[col.name] ?? '')"></nldd-text-cell>
           </template>
-          <nldd-cell v-else-if="col.type === 'boolean'">
+          <nldd-cell v-else-if="col.type === 'boolean'" width="full" min-width="100px" max-width="320px">
             <nldd-dropdown size="md">
               <select
                 :aria-label="col.name"
@@ -154,7 +154,7 @@ const showBody = computed(() => props.drilledIn || expanded.value);
               </select>
             </nldd-dropdown>
           </nldd-cell>
-          <nldd-cell v-else>
+          <nldd-cell v-else width="full" min-width="100px" max-width="320px">
             <nldd-text-field
               size="md"
               :type="inputType(col.type)"
@@ -225,33 +225,5 @@ const showBody = computed(() => props.drilledIn || expanded.value);
   font-size: 14px;
   color: var(--semantics-text-color-secondary, #999);
   font-style: italic;
-}
-
-.ds-key-label {
-  font-weight: 700;
-}
-</style>
-
-<style>
-/* Unscoped: nldd web components need global selectors */
-.ds-datasource-list nldd-text-cell {
-  min-width: 140px;
-  flex: 1;
-}
-
-.ds-datasource-list nldd-cell {
-  flex: 1;
-  min-width: 0;
-}
-
-/* Cap only the input cells, so the full-width Verwijder button cell still
-   spans the whole row. */
-.ds-datasource-list nldd-cell:not([width="full"]) {
-  max-width: 280px;
-}
-
-.ds-datasource-list nldd-text-field,
-.ds-datasource-list nldd-dropdown {
-  width: 100%;
 }
 </style>

--- a/frontend/src/components/DataSourceTable.vue
+++ b/frontend/src/components/DataSourceTable.vue
@@ -119,8 +119,8 @@ const showBody = computed(() => props.drilledIn || expanded.value);
     <template v-else>
       <nldd-title size="5" class="ds-block-heading" :id="anchorId || undefined">
         <span>{{ title }}</span>
+        <span v-if="subtitle" slot="subtitle">{{ subtitle }}</span>
       </nldd-title>
-      <p v-if="subtitle" class="ds-block-subtitle">{{ subtitle }}</p>
       <nldd-spacer size="8"></nldd-spacer>
     </template>
 
@@ -204,13 +204,6 @@ const showBody = computed(() => props.drilledIn || expanded.value);
 
 .ds-block-heading {
   margin: 0;
-}
-
-.ds-block-subtitle {
-  margin: 2px 0 0 0;
-  font-family: var(--primitives-font-family-body, 'RijksSansVF', sans-serif);
-  font-size: 13px;
-  color: var(--semantics-text-color-secondary, #545D68);
 }
 
 .ds-block-chevron {

--- a/frontend/src/components/DataSourceTable.vue
+++ b/frontend/src/components/DataSourceTable.vue
@@ -117,11 +117,11 @@ const showBody = computed(() => props.drilledIn || expanded.value);
       <span class="ds-block-badge" v-if="rowCount > 0">{{ rowCount }}</span>
     </button>
     <template v-else>
-      <nldd-title size="5" class="ds-block-heading" :id="anchorId || undefined">
-        <span>{{ title }}</span>
-        <span v-if="subtitle" slot="subtitle">{{ subtitle }}</span>
+      <nldd-title size="5" :id="anchorId || undefined">
+        <h2>{{ title }}</h2>
+        <p v-if="subtitle" slot="subtitle">{{ subtitle }}</p>
       </nldd-title>
-      <nldd-spacer size="8"></nldd-spacer>
+      <nldd-spacer size="12"></nldd-spacer>
     </template>
 
     <div v-if="showBody" class="ds-block-body">
@@ -200,10 +200,6 @@ const showBody = computed(() => props.drilledIn || expanded.value);
   padding: 0;
   width: 100%;
   margin-bottom: 4px;
-}
-
-.ds-block-heading {
-  margin: 0;
 }
 
 .ds-block-chevron {

--- a/frontend/src/components/DataSourceTable.vue
+++ b/frontend/src/components/DataSourceTable.vue
@@ -122,9 +122,7 @@ const showBody = computed(() => props.drilledIn || expanded.value);
     </template>
 
     <template v-if="showBody">
-      <div v-if="rows.length === 0" class="ds-block-empty">
-        Geen gegevens &mdash; vul in indien relevant
-      </div>
+      <nldd-inline-dialog v-if="rows.length === 0" text="Geen gegevens — vul in indien relevant"></nldd-inline-dialog>
 
       <!-- One box list per row — identical layout regardless of row count,
            with the delete button at the bottom of each list. Spacers (not a
@@ -156,7 +154,6 @@ const showBody = computed(() => props.drilledIn || expanded.value);
               size="md"
               :type="inputType(col.type)"
               :value="String(row[col.name] ?? '')"
-              :placeholder="col.name"
               @input="updateCell(ri, col.name, $event.target?.value ?? $event.detail?.value ?? '')"
             ></nldd-text-field>
           </nldd-cell>
@@ -164,7 +161,7 @@ const showBody = computed(() => props.drilledIn || expanded.value);
 
         <nldd-list-item v-if="!readonly" size="md">
           <nldd-cell width="full">
-            <nldd-button variant="destructive" size="md" width="full" start-icon="minus" @click="removeRow(ri)" text="Verwijder"></nldd-button>
+            <nldd-button variant="destructive" size="md" width="full" start-icon="delete" @click="removeRow(ri)" text="Verwijder"></nldd-button>
           </nldd-cell>
         </nldd-list-item>
         </nldd-list>
@@ -216,11 +213,4 @@ const showBody = computed(() => props.drilledIn || expanded.value);
   flex-shrink: 0;
 }
 
-.ds-block-empty {
-  padding: 12px;
-  text-align: center;
-  font-size: 14px;
-  color: var(--semantics-text-color-secondary, #999);
-  font-style: italic;
-}
 </style>

--- a/frontend/src/components/DataSourceTable.vue
+++ b/frontend/src/components/DataSourceTable.vue
@@ -105,7 +105,7 @@ const showBody = computed(() => props.drilledIn || expanded.value);
 </script>
 
 <template>
-  <div>
+  <div class="ds-root">
     <!-- Header: accordion toggle, or a plain heading when drilled in -->
     <button v-if="!drilledIn" class="ds-block-toggle" :aria-expanded="expanded" @click="toggleExpand" type="button">
       <span class="ds-block-chevron" :class="{ 'ds-block-chevron--open': expanded }">&#9656;</span>
@@ -122,7 +122,9 @@ const showBody = computed(() => props.drilledIn || expanded.value);
     </template>
 
     <template v-if="showBody">
-      <nldd-inline-dialog v-if="rows.length === 0" text="Geen gegevens — vul in indien relevant"></nldd-inline-dialog>
+      <nldd-inline-dialog v-if="rows.length === 0" text="Geen gegevens — vul in indien relevant">
+        <nldd-button v-if="!readonly" slot="actions" size="md" start-icon="plus-small" @click="addRow" text="Voeg toe"></nldd-button>
+      </nldd-inline-dialog>
 
       <!-- One box list per row — identical layout regardless of row count,
            with the delete button at the bottom of each list. Spacers (not a
@@ -167,19 +169,29 @@ const showBody = computed(() => props.drilledIn || expanded.value);
         </nldd-list>
       </template>
 
-      <nldd-spacer v-if="!readonly" size="12"></nldd-spacer>
-      <nldd-list v-if="!readonly" variant="box">
-        <nldd-list-item size="md">
-          <nldd-cell width="full">
-            <nldd-button size="md" width="full" start-icon="plus-small" @click="addRow" text="Voeg toe"></nldd-button>
-          </nldd-cell>
-        </nldd-list-item>
-      </nldd-list>
+      <!-- Empty state offers "Voeg toe" inside the inline-dialog instead. -->
+      <template v-if="!readonly && rows.length > 0">
+        <nldd-spacer size="12"></nldd-spacer>
+        <nldd-list variant="box">
+          <nldd-list-item size="md">
+            <nldd-cell width="full">
+              <nldd-button size="md" width="full" start-icon="plus-small" @click="addRow" text="Voeg toe"></nldd-button>
+            </nldd-cell>
+          </nldd-list-item>
+        </nldd-list>
+      </template>
     </template>
   </div>
 </template>
 
 <style scoped>
+/* The component needs a single root, but it must not generate a box —
+ * otherwise it blocks the nldd flex layout (flex-grow / centering of the
+ * empty-state inline-dialog) of the enclosing simple-section. */
+.ds-root {
+  display: contents;
+}
+
 .ds-block-toggle {
   display: flex;
   align-items: center;

--- a/frontend/src/components/DataSourceTable.vue
+++ b/frontend/src/components/DataSourceTable.vue
@@ -13,9 +13,6 @@ const props = defineProps({
   // When the table is shown one level deep in a drill-in sheet there's no
   // accordion: the title is a plain heading and the body is always visible.
   drilledIn: { type: Boolean, default: false },
-  // Optional id put on the drilled-in heading so the sheet's top-title-bar
-  // can use it as its `collapse-anchor` (full back button until scrolled).
-  anchorId: { type: String, default: '' },
 });
 
 const emit = defineEmits(['update:modelValue']);
@@ -115,7 +112,7 @@ const showBody = computed(() => props.drilledIn || expanded.value);
       <span class="ds-block-badge" v-if="rowCount > 0">{{ rowCount }}</span>
     </button>
     <template v-else>
-      <nldd-title size="3" :id="anchorId || undefined">
+      <nldd-title size="3">
         <h2>{{ title }}</h2>
       </nldd-title>
       <nldd-spacer size="8"></nldd-spacer>

--- a/frontend/src/components/DataSourceTable.vue
+++ b/frontend/src/components/DataSourceTable.vue
@@ -256,6 +256,11 @@ const showBody = computed(() => props.drilledIn || expanded.value);
 .ds-datasource-list nldd-cell {
   flex: 1;
   min-width: 0;
+}
+
+/* Cap only the input cells, so the full-width Verwijder button cell still
+   spans the whole row. */
+.ds-datasource-list nldd-cell:not([width="full"]) {
   max-width: 280px;
 }
 

--- a/frontend/src/components/DataSourceTable.vue
+++ b/frontend/src/components/DataSourceTable.vue
@@ -136,7 +136,7 @@ const showBody = computed(() => props.drilledIn || expanded.value);
         <nldd-spacer v-if="ri > 0" size="12"></nldd-spacer>
         <nldd-list variant="box">
         <nldd-list-item v-for="col in allColumns" :key="col.name" size="md">
-          <nldd-text-cell :text="col.isKey ? `**${col.name}**` : col.name" min-width="120px" max-width="200px"></nldd-text-cell>
+          <nldd-text-cell :text="col.name" min-width="120px" max-width="200px"></nldd-text-cell>
           <nldd-spacer-cell v-if="!readonly" size="8"></nldd-spacer-cell>
           <template v-if="readonly">
             <nldd-text-cell :text="String(row[col.name] ?? '')"></nldd-text-cell>

--- a/frontend/src/components/DataSourceTable.vue
+++ b/frontend/src/components/DataSourceTable.vue
@@ -129,40 +129,40 @@ const showBody = computed(() => props.drilledIn || expanded.value);
       <template v-for="(row, ri) in rows" :key="row._id ?? ri">
         <nldd-spacer v-if="ri > 0" size="12"></nldd-spacer>
         <nldd-list variant="box">
-        <nldd-list-item v-for="col in allColumns" :key="col.name" size="md">
-          <nldd-text-cell :text="col.name" min-width="120px" max-width="200px"></nldd-text-cell>
-          <nldd-spacer-cell v-if="!readonly" size="8"></nldd-spacer-cell>
-          <template v-if="readonly">
-            <nldd-text-cell :text="String(row[col.name] ?? '')"></nldd-text-cell>
-          </template>
-          <nldd-cell v-else-if="col.type === 'boolean'" width="full" min-width="120px">
-            <nldd-dropdown size="md">
-              <select
-                :aria-label="col.name"
-                :value="String(row[col.name] || 'null')"
-                @change="updateCell(ri, col.name, $event.target.value)"
-              >
-                <option value="true">true</option>
-                <option value="false">false</option>
-                <option value="null">null</option>
-              </select>
-            </nldd-dropdown>
-          </nldd-cell>
-          <nldd-cell v-else width="full" min-width="120px">
-            <nldd-text-field
-              size="md"
-              :type="inputType(col.type)"
-              :value="String(row[col.name] ?? '')"
-              @input="updateCell(ri, col.name, $event.target?.value ?? $event.detail?.value ?? '')"
-            ></nldd-text-field>
-          </nldd-cell>
-        </nldd-list-item>
+          <nldd-list-item v-for="col in allColumns" :key="col.name" size="md">
+            <nldd-text-cell :text="col.name" min-width="120px" max-width="200px"></nldd-text-cell>
+            <nldd-spacer-cell v-if="!readonly" size="8"></nldd-spacer-cell>
+            <template v-if="readonly">
+              <nldd-text-cell :text="String(row[col.name] ?? '')"></nldd-text-cell>
+            </template>
+            <nldd-cell v-else-if="col.type === 'boolean'" width="full" min-width="120px">
+              <nldd-dropdown size="md">
+                <select
+                  :aria-label="col.name"
+                  :value="String(row[col.name] || 'null')"
+                  @change="updateCell(ri, col.name, $event.target.value)"
+                >
+                  <option value="true">true</option>
+                  <option value="false">false</option>
+                  <option value="null">null</option>
+                </select>
+              </nldd-dropdown>
+            </nldd-cell>
+            <nldd-cell v-else width="full" min-width="120px">
+              <nldd-text-field
+                size="md"
+                :type="inputType(col.type)"
+                :value="String(row[col.name] ?? '')"
+                @input="updateCell(ri, col.name, $event.target?.value ?? $event.detail?.value ?? '')"
+              ></nldd-text-field>
+            </nldd-cell>
+          </nldd-list-item>
 
-        <nldd-list-item v-if="!readonly" size="md">
-          <nldd-cell width="full">
-            <nldd-button variant="destructive" size="md" width="full" start-icon="delete" @click="removeRow(ri)" text="Verwijder"></nldd-button>
-          </nldd-cell>
-        </nldd-list-item>
+          <nldd-list-item v-if="!readonly" size="md">
+            <nldd-cell width="full">
+              <nldd-button variant="destructive" size="md" width="full" start-icon="delete" @click="removeRow(ri)" text="Verwijder"></nldd-button>
+            </nldd-cell>
+          </nldd-list-item>
         </nldd-list>
       </template>
 

--- a/frontend/src/components/DataSourceTable.vue
+++ b/frontend/src/components/DataSourceTable.vue
@@ -10,6 +10,9 @@ const props = defineProps({
   modelValue: { type: Array, default: () => [] },
   defaultExpanded: { type: Boolean, default: false },
   readonly: { type: Boolean, default: false },
+  // When the table is shown one level deep in a drill-in sheet there's no
+  // accordion: the title is a plain heading and the body is always visible.
+  drilledIn: { type: Boolean, default: false },
 });
 
 const emit = defineEmits(['update:modelValue']);
@@ -93,20 +96,26 @@ const allColumns = computed(() => {
 });
 
 const rowCount = computed(() => rows.value.length);
+
+// Drilled-in tables have no toggle, so the body is always shown.
+const showBody = computed(() => props.drilledIn || expanded.value);
 </script>
 
 <template>
   <div class="ds-block">
-    <!-- Header -->
-    <button class="ds-block-toggle" :aria-expanded="expanded" @click="toggleExpand" type="button">
+    <!-- Header: accordion toggle, or a plain heading when drilled in -->
+    <button v-if="!drilledIn" class="ds-block-toggle" :aria-expanded="expanded" @click="toggleExpand" type="button">
       <span class="ds-block-chevron" :class="{ 'ds-block-chevron--open': expanded }">&#9656;</span>
       <nldd-title size="5" style="flex: 1; text-align: left;">
         <span>{{ title }}</span>
       </nldd-title>
       <span class="ds-block-badge" v-if="rowCount > 0">{{ rowCount }}</span>
     </button>
+    <nldd-title v-else size="5" class="ds-block-heading">
+      <span>{{ title }}</span>
+    </nldd-title>
 
-    <div v-if="expanded" class="ds-block-body">
+    <div v-if="showBody" class="ds-block-body">
       <div v-if="rows.length === 0" class="ds-block-empty">
         Geen gegevens &mdash; vul in indien relevant
       </div>
@@ -181,6 +190,10 @@ const rowCount = computed(() => rows.value.length);
   padding: 0;
   width: 100%;
   margin-bottom: 4px;
+}
+
+.ds-block-heading {
+  margin: 0 0 4px 0;
 }
 
 .ds-block-chevron {

--- a/frontend/src/components/EditSheet.vue
+++ b/frontend/src/components/EditSheet.vue
@@ -14,10 +14,12 @@ const lawComboBoxEl = ref(null);
 const outputComboBoxEl = ref(null);
 const values = ref({});
 
-// Snapshot of the form taken when an item opens, so the Save button only
-// appears once the user actually changes something (mirrors ActionSheet).
+// Snapshot of the form taken when an item opens. For a NEW item the Save
+// button is always shown (you opened the sheet to add it); for an existing
+// item it only appears once the user actually changes something.
 const baseline = ref('');
 const isDirty = computed(() => {
+  if (props.item?.isNew) return true;
   try {
     return JSON.stringify(values.value) !== baseline.value;
   } catch {
@@ -412,6 +414,7 @@ const sectionLabels = {
                     :step="values.controlType === 'currency' ? '0.01' : (values.controlType === 'percentage' ? '0.001' : undefined)"
                     width="full"
                     hide-spin-buttons
+                    @input="values.displayValue = $event.detail?.value ?? values.displayValue"
                     @change="values.displayValue = $event.detail?.value ?? values.displayValue"
                   ></nldd-number-field>
                 </nldd-cell>

--- a/frontend/src/components/EditSheet.vue
+++ b/frontend/src/components/EditSheet.vue
@@ -354,7 +354,7 @@ const sectionLabels = {
 </script>
 
 <template>
-  <nldd-sheet ref="sheetEl" placement="right" width="640px" full-height @close="emit('close')">
+  <nldd-sheet ref="sheetEl" placement="right" width="640px" @close="emit('close')">
     <!-- `:key` forces nldd-page to remount whenever the section changes.
          nldd-page captures the sticky-header height ONCE per mount via
          requestAnimationFrame; if the header text changes after that
@@ -398,7 +398,7 @@ const sectionLabels = {
                   <nldd-number-field
                     :value="values.displayValue"
                     :step="values.controlType === 'currency' ? '0.01' : (values.controlType === 'percentage' ? '0.001' : undefined)"
-                    full-width
+                    width="full"
                     hide-spin-buttons
                     @change="values.displayValue = $event.detail?.value ?? values.displayValue"
                   ></nldd-number-field>
@@ -576,7 +576,7 @@ const sectionLabels = {
       </nldd-simple-section>
 
       <nldd-container slot="footer" padding="16">
-        <nldd-button variant="primary" size="md" full-width data-testid="edit-sheet-save-btn" @click="save" text="Opslaan"></nldd-button>
+        <nldd-button variant="primary" size="md" width="full" data-testid="edit-sheet-save-btn" @click="save" text="Opslaan"></nldd-button>
       </nldd-container>
     </nldd-page>
   </nldd-sheet>

--- a/frontend/src/components/EditSheet.vue
+++ b/frontend/src/components/EditSheet.vue
@@ -14,6 +14,17 @@ const lawComboBoxEl = ref(null);
 const outputComboBoxEl = ref(null);
 const values = ref({});
 
+// Snapshot of the form taken when an item opens, so the Save button only
+// appears once the user actually changes something (mirrors ActionSheet).
+const baseline = ref('');
+const isDirty = computed(() => {
+  try {
+    return JSON.stringify(values.value) !== baseline.value;
+  } catch {
+    return true;
+  }
+});
+
 const typeOptions = ['string', 'number', 'boolean', 'amount'];
 
 // Available variables from the article's machine_readable for parameter
@@ -251,6 +262,7 @@ watch(() => props.item, async (item) => {
     };
   }
 
+  baseline.value = JSON.stringify(values.value);
   await nextTick();
   sheetEl.value?.show();
 }, { immediate: true });
@@ -577,7 +589,7 @@ const sectionLabels = {
           </template>
       </nldd-simple-section>
 
-      <nldd-container slot="footer" padding="16">
+      <nldd-container v-if="isDirty" slot="footer" padding="16">
         <nldd-button variant="primary" size="md" width="full" data-testid="edit-sheet-save-btn" @click="save" text="Opslaan"></nldd-button>
       </nldd-container>
     </nldd-page>

--- a/frontend/src/components/EditSheet.vue
+++ b/frontend/src/components/EditSheet.vue
@@ -408,7 +408,13 @@ const sectionLabels = {
                        the visual clutter that felt out of place for "fixed
                        value from law" semantics. The plain text-field used
                        previously silently produced NaN on Dutch comma input
-                       and 0 on cleared field. -->
+                       and 0 on cleared field.
+                       Both @input and @change are intentional, not a
+                       copy-paste: @input gives live-as-you-type updates
+                       (dirty marking); @change delivers the value the
+                       field normalises on commit/blur (locale/step). The
+                       assignment is idempotent so a same-tick double-fire
+                       is harmless — do not drop @change. -->
                   <nldd-number-field
                     :value="values.displayValue"
                     :step="values.controlType === 'currency' ? '0.01' : (values.controlType === 'percentage' ? '0.001' : undefined)"

--- a/frontend/src/components/EditSheet.vue
+++ b/frontend/src/components/EditSheet.vue
@@ -473,6 +473,7 @@ const sectionLabels = {
                   <nldd-combo-box
                     ref="lawComboBoxEl"
                     size="md"
+                    width="100%"
                     placeholder="Zoek regelgeving..."
                     accessible-label="Bron regelgeving"
                     :value="values.sourceRegulation"
@@ -500,6 +501,7 @@ const sectionLabels = {
                     v-if="availableOutputs.length > 0"
                     ref="outputComboBoxEl"
                     size="md"
+                    width="100%"
                     placeholder="Selecteer output..."
                     accessible-label="Bron output"
                     :value="values.sourceOutput"

--- a/frontend/src/components/ExecutionTraceView.vue
+++ b/frontend/src/components/ExecutionTraceView.vue
@@ -11,7 +11,13 @@ const props = defineProps({
   expectations: { type: Object, default: () => ({}) },
   /** Error message if execution failed */
   error: { type: String, default: null },
+  /** Scenario is currently executing */
+  running: { type: Boolean, default: false },
+  /** Whether a re-run action is available */
+  canReload: { type: Boolean, default: false },
 });
+
+const emit = defineEmits(['reload']);
 
 function matchStatus(outputName, actualValue) {
   return _matchStatus(outputName, actualValue, props.expectations);
@@ -33,9 +39,23 @@ const overallStatus = computed(() => {
 </script>
 
 <template>
-  <nldd-inline-dialog v-if="!hasContent" text="Klik op &quot;Details&quot; bij een scenario om de trace te bekijken."></nldd-inline-dialog>
+  <nldd-inline-dialog v-if="running" text="Bezig met uitvoeren…"></nldd-inline-dialog>
 
-  <nldd-inline-dialog v-else-if="error && !result && !traceText" variant="alert" text="Fout bij uitvoering" :supporting-text="error"></nldd-inline-dialog>
+  <template v-else-if="error && !result && !traceText">
+    <nldd-inline-dialog variant="alert" text="Fout bij uitvoering" :supporting-text="error"></nldd-inline-dialog>
+    <template v-if="canReload">
+      <nldd-spacer size="12"></nldd-spacer>
+      <nldd-button size="md" text="Opnieuw uitvoeren" @click="emit('reload')"></nldd-button>
+    </template>
+  </template>
+
+  <template v-else-if="!hasContent">
+    <nldd-inline-dialog text="Nog geen resultaat voor dit scenario."></nldd-inline-dialog>
+    <template v-if="canReload">
+      <nldd-spacer size="12"></nldd-spacer>
+      <nldd-button size="md" text="Opnieuw uitvoeren" @click="emit('reload')"></nldd-button>
+    </template>
+  </template>
 
   <template v-else>
     <template v-if="result && Object.keys(expectations).length">
@@ -100,6 +120,10 @@ const overallStatus = computed(() => {
       <nldd-title size="5" class="etv-section-title"><span>Partial trace (tot fout)</span></nldd-title>
       <nldd-spacer size="8"></nldd-spacer>
       <nldd-code>{{ traceText }}</nldd-code>
+      <template v-if="canReload">
+        <nldd-spacer size="12"></nldd-spacer>
+        <nldd-button size="md" text="Opnieuw uitvoeren" @click="emit('reload')"></nldd-button>
+      </template>
     </template>
   </template>
 </template>

--- a/frontend/src/components/MachineReadable.test.js
+++ b/frontend/src/components/MachineReadable.test.js
@@ -113,10 +113,13 @@ describe('MachineReadable', () => {
       expect(titles).toContain('Acties');
     });
 
-    it('shows produces metadata', () => {
+    it('shows produces metadata as editable dropdowns', () => {
       const wrapper = mountEditable();
-      expect(wrapper.find('nldd-button[text="beschikking"]').exists()).toBe(true);
-      expect(wrapper.find('nldd-button[text="toekenning"]').exists()).toBe(true);
+      expect(wrapper.find('select[aria-label="Juridische basis"]').exists()).toBe(true);
+      expect(wrapper.find('select[aria-label="Besluit-type"]').exists()).toBe(true);
+      const opts = wrapper.findAll('option').map((o) => o.text());
+      expect(opts).toContain('beschikking');
+      expect(opts).toContain('toekenning');
     });
 
     it('shows empty state when no machine_readable', () => {
@@ -128,19 +131,25 @@ describe('MachineReadable', () => {
 
     it('formats percentage values (0 < v < 1)', () => {
       const wrapper = mountEditable();
-      const cells = wrapper.findAll('nldd-text-cell').map(c => c.attributes('text') || '');
+      // The value sits in the `text` attribute (read-only cells) or as
+      // slot text next to BreakableName (editable definition rows).
+      const cells = wrapper.findAll('nldd-text-cell').map(c => `${c.attributes('text') || ''} ${c.text()}`);
       expect(cells.some(t => /1,896\s*%/.test(t))).toBe(true);
     });
 
     it('formats eurocent values as currency', () => {
       const wrapper = mountEditable();
-      const cells = wrapper.findAll('nldd-text-cell').map(c => c.attributes('text') || '');
+      // The value sits in the `text` attribute (read-only cells) or as
+      // slot text next to BreakableName (editable definition rows).
+      const cells = wrapper.findAll('nldd-text-cell').map(c => `${c.attributes('text') || ''} ${c.text()}`);
       expect(cells.some(t => /1\.500,00/.test(t))).toBe(true);
     });
 
     it('shows plain number when no unit', () => {
       const wrapper = mountEditable();
-      const cells = wrapper.findAll('nldd-text-cell').map(c => c.attributes('text') || '');
+      // The value sits in the `text` attribute (read-only cells) or as
+      // slot text next to BreakableName (editable definition rows).
+      const cells = wrapper.findAll('nldd-text-cell').map(c => `${c.attributes('text') || ''} ${c.text()}`);
       expect(cells.some(t => t.includes('3971900'))).toBe(true);
     });
 

--- a/frontend/src/components/MachineReadable.test.js
+++ b/frontend/src/components/MachineReadable.test.js
@@ -61,8 +61,13 @@ function mountEditable(articleOverrides = {}) {
   });
 }
 
+// "Bewerk" moved from an inline nldd-button to a RowActionsMenu menu-item
+// (the more-menu). In mount() custom elements aren't upgraded, so the
+// menu-item is just a DOM node and triggering click still fires the
+// component's @click → emit('edit'). DOM order per row is unchanged, so
+// the index mapping used by the tests is preserved.
 function findBewerkButtons(wrapper) {
-  return wrapper.findAll('nldd-button[text="Bewerk"]');
+  return wrapper.findAll('nldd-menu-item[text="Bewerk"]');
 }
 
 function findBekijkButtons(wrapper) {

--- a/frontend/src/components/MachineReadable.vue
+++ b/frontend/src/components/MachineReadable.vue
@@ -282,6 +282,14 @@ function addOutput() {
               @change="updateProduces('legal_character', $event.target.value)"
             >
               <option value="">(geen)</option>
+              <!-- Preserve a value the hardcoded enum doesn't know (e.g. a
+                   law authored against a newer schema, or set via the YAML
+                   view): show + keep it instead of silently collapsing to
+                   (geen), which any stray edit would then commit. -->
+              <option
+                v-if="produces.legal_character && !LEGAL_CHARACTERS.includes(produces.legal_character)"
+                :value="produces.legal_character"
+              >{{ humanize(produces.legal_character) }}</option>
               <option v-for="v in LEGAL_CHARACTERS" :key="v" :value="v">{{ humanize(v) }}</option>
             </select>
           </nldd-dropdown>
@@ -300,6 +308,12 @@ function addOutput() {
               @change="updateProduces('decision_type', $event.target.value)"
             >
               <option value="">(geen)</option>
+              <!-- Same as legal_character: keep an out-of-enum value
+                   visible/selected so it isn't silently cleared. -->
+              <option
+                v-if="produces.decision_type && !DECISION_TYPES.includes(produces.decision_type)"
+                :value="produces.decision_type"
+              >{{ humanize(produces.decision_type) }}</option>
               <option v-for="v in DECISION_TYPES" :key="v" :value="v">{{ humanize(v) }}</option>
             </select>
           </nldd-dropdown>

--- a/frontend/src/components/MachineReadable.vue
+++ b/frontend/src/components/MachineReadable.vue
@@ -272,8 +272,8 @@ function addOutput() {
           </nldd-cell>
         </nldd-list-item>
         <nldd-list-item v-if="editable" size="md">
-          <nldd-cell width="stretch">
-            <nldd-button full-width start-icon="plus-small" data-testid="add-def-btn" @click="addDef" text="Definitie toevoegen"></nldd-button>
+          <nldd-cell width="full">
+            <nldd-button width="full" start-icon="plus-small" data-testid="add-def-btn" @click="addDef" text="Definitie toevoegen"></nldd-button>
           </nldd-cell>
         </nldd-list-item>
       </nldd-list>
@@ -301,8 +301,8 @@ function addOutput() {
           </nldd-cell>
         </nldd-list-item>
         <nldd-list-item v-if="editable" size="md">
-          <nldd-cell width="stretch">
-            <nldd-button full-width start-icon="plus-small" data-testid="add-param-btn" @click="addParam" text="Parameter toevoegen"></nldd-button>
+          <nldd-cell width="full">
+            <nldd-button width="full" start-icon="plus-small" data-testid="add-param-btn" @click="addParam" text="Parameter toevoegen"></nldd-button>
           </nldd-cell>
         </nldd-list-item>
       </nldd-list>
@@ -333,8 +333,8 @@ function addOutput() {
           </nldd-cell>
         </nldd-list-item>
         <nldd-list-item v-if="editable" size="md">
-          <nldd-cell width="stretch">
-            <nldd-button full-width start-icon="plus-small" data-testid="add-input-btn" @click="addInput" text="Input toevoegen"></nldd-button>
+          <nldd-cell width="full">
+            <nldd-button width="full" start-icon="plus-small" data-testid="add-input-btn" @click="addInput" text="Input toevoegen"></nldd-button>
           </nldd-cell>
         </nldd-list-item>
       </nldd-list>
@@ -362,8 +362,8 @@ function addOutput() {
           </nldd-cell>
         </nldd-list-item>
         <nldd-list-item v-if="editable" size="md">
-          <nldd-cell width="stretch">
-            <nldd-button full-width start-icon="plus-small" data-testid="add-output-btn" @click="addOutput" text="Output toevoegen"></nldd-button>
+          <nldd-cell width="full">
+            <nldd-button width="full" start-icon="plus-small" data-testid="add-output-btn" @click="addOutput" text="Output toevoegen"></nldd-button>
           </nldd-cell>
         </nldd-list-item>
       </nldd-list>
@@ -403,8 +403,8 @@ function addOutput() {
           </template>
         </nldd-list-item>
         <nldd-list-item v-if="editable" size="md">
-          <nldd-cell width="stretch">
-            <nldd-button full-width start-icon="plus-small" data-testid="add-action-btn" @click="emit('add-action')" text="Actie toevoegen"></nldd-button>
+          <nldd-cell width="full">
+            <nldd-button width="full" start-icon="plus-small" data-testid="add-action-btn" @click="emit('add-action')" text="Actie toevoegen"></nldd-button>
           </nldd-cell>
         </nldd-list-item>
       </nldd-list>

--- a/frontend/src/components/MachineReadable.vue
+++ b/frontend/src/components/MachineReadable.vue
@@ -66,7 +66,11 @@ const definitions = computed(() => {
 
 const produces = computed(() => execution.value?.produces ?? null);
 
-// Enum values from the law schema (schema/v0.4.0 — produces.*).
+// Enum values copied from the law schema. Keep in sync with
+// schema/latest/schema.json → execution.produces.legal_character.enum
+// and .decision_type.enum. Currently identical across v0.4.0..v0.5.2;
+// if the schema adds a value here, add it here too or the dropdown
+// silently can't set it.
 const LEGAL_CHARACTERS = [
   'BESCHIKKING', 'TOETS', 'WAARDEBEPALING', 'BESLUIT_VAN_ALGEMENE_STREKKING', 'INFORMATIEF',
 ];

--- a/frontend/src/components/MachineReadable.vue
+++ b/frontend/src/components/MachineReadable.vue
@@ -383,7 +383,7 @@ function addOutput() {
       <nldd-list variant="box">
         <nldd-list-item v-for="(input, index) in inputs" :key="input.name" :data-testid="`input-row-${input.name}`" size="md">
           <nldd-text-cell
-            :supporting-text="input.sourceRegulation ? lawDisplayName(input.sourceRegulation) : 'Geen bron regelgeving'"
+            :supporting-text="input.sourceRegulation ? lawDisplayName(input.sourceRegulation) : undefined"
           ><BreakableName :name="input.name" /> <nldd-tag size="sm" :text="input.type"></nldd-tag></nldd-text-cell>
           <nldd-spacer-cell v-if="editable" size="8"></nldd-spacer-cell>
           <nldd-cell v-if="editable">

--- a/frontend/src/components/MachineReadable.vue
+++ b/frontend/src/components/MachineReadable.vue
@@ -3,6 +3,7 @@ import { computed, ref, watch, nextTick } from 'vue';
 import { humanize } from '../utils/outputFormat.js';
 import { useCorpusLaws } from '../composables/useCorpusLaws.js';
 import BreakableName from './BreakableName.vue';
+import RowActionsMenu from './RowActionsMenu.vue';
 
 const { displayName: lawDisplayName } = useCorpusLaws();
 
@@ -283,15 +284,12 @@ function addOutput() {
             ></nldd-text-cell>
           </template>
           <nldd-cell v-if="editable">
-            <div class="mr-row-actions">
-              <nldd-button @click="editDef(def.name)" text="Bewerk"></nldd-button>
-              <nldd-icon-button
-                icon="minus"
-                accessible-label="Verwijder definitie"
-                :data-testid="`def-${def.name}-delete-btn`"
-                @click="deleteDef(def.name)"
-              ></nldd-icon-button>
-            </div>
+            <RowActionsMenu
+              :accessible-label="`Acties voor definitie ${def.name}`"
+              :delete-testid="`def-${def.name}-delete-btn`"
+              @edit="editDef(def.name)"
+              @delete="deleteDef(def.name)"
+            />
           </nldd-cell>
         </nldd-list-item>
         <nldd-list-item v-if="editable" size="md">
@@ -312,15 +310,12 @@ function addOutput() {
           <nldd-text-cell><BreakableName :name="param.name" /> <nldd-tag size="sm" :text="param.type"></nldd-tag></nldd-text-cell>
           <nldd-spacer-cell v-if="editable" size="8"></nldd-spacer-cell>
           <nldd-cell v-if="editable">
-            <div class="mr-row-actions">
-              <nldd-button @click="editParam(index)" text="Bewerk"></nldd-button>
-              <nldd-icon-button
-                icon="minus"
-                accessible-label="Verwijder parameter"
-                :data-testid="`param-${param.name}-delete-btn`"
-                @click="deleteParam(index)"
-              ></nldd-icon-button>
-            </div>
+            <RowActionsMenu
+              :accessible-label="`Acties voor parameter ${param.name}`"
+              :delete-testid="`param-${param.name}-delete-btn`"
+              @edit="editParam(index)"
+              @delete="deleteParam(index)"
+            />
           </nldd-cell>
         </nldd-list-item>
         <nldd-list-item v-if="editable" size="md">
@@ -343,15 +338,13 @@ function addOutput() {
           ><BreakableName :name="input.name" /> <nldd-tag size="sm" :text="input.type"></nldd-tag></nldd-text-cell>
           <nldd-spacer-cell v-if="editable" size="8"></nldd-spacer-cell>
           <nldd-cell v-if="editable">
-            <div class="mr-row-actions">
-              <nldd-button :data-testid="`input-${input.name}-edit-btn`" @click="editInput(index)" text="Bewerk"></nldd-button>
-              <nldd-icon-button
-                icon="minus"
-                accessible-label="Verwijder input"
-                :data-testid="`input-${input.name}-delete-btn`"
-                @click="deleteInput(index)"
-              ></nldd-icon-button>
-            </div>
+            <RowActionsMenu
+              :accessible-label="`Acties voor input ${input.name}`"
+              :edit-testid="`input-${input.name}-edit-btn`"
+              :delete-testid="`input-${input.name}-delete-btn`"
+              @edit="editInput(index)"
+              @delete="deleteInput(index)"
+            />
           </nldd-cell>
         </nldd-list-item>
         <nldd-list-item v-if="editable" size="md">
@@ -372,15 +365,12 @@ function addOutput() {
           <nldd-text-cell><BreakableName :name="output.name" /> <nldd-tag size="sm" :text="output.type"></nldd-tag></nldd-text-cell>
           <nldd-spacer-cell v-if="editable" size="8"></nldd-spacer-cell>
           <nldd-cell v-if="editable">
-            <div class="mr-row-actions">
-              <nldd-button @click="editOutput(index)" text="Bewerk"></nldd-button>
-              <nldd-icon-button
-                icon="minus"
-                accessible-label="Verwijder output"
-                :data-testid="`output-${output.name}-delete-btn`"
-                @click="deleteOutput(index)"
-              ></nldd-icon-button>
-            </div>
+            <RowActionsMenu
+              :accessible-label="`Acties voor output ${output.name}`"
+              :delete-testid="`output-${output.name}-delete-btn`"
+              @edit="editOutput(index)"
+              @delete="deleteOutput(index)"
+            />
           </nldd-cell>
         </nldd-list-item>
         <nldd-list-item v-if="editable" size="md">
@@ -407,15 +397,13 @@ function addOutput() {
           <nldd-text-cell :text="action.output"></nldd-text-cell>
           <nldd-spacer-cell v-if="editable" size="8"></nldd-spacer-cell>
           <nldd-cell v-if="editable">
-            <div class="mr-row-actions">
-              <nldd-button :data-testid="`action-${action.output}-edit-btn`" @click="emit('open-action', action)" text="Bewerk"></nldd-button>
-              <nldd-icon-button
-                icon="minus"
-                accessible-label="Verwijder actie"
-                :data-testid="`action-${action.output}-delete-btn`"
-                @click="deleteAction(index)"
-              ></nldd-icon-button>
-            </div>
+            <RowActionsMenu
+              :accessible-label="`Acties voor actie ${action.output}`"
+              :edit-testid="`action-${action.output}-edit-btn`"
+              :delete-testid="`action-${action.output}-delete-btn`"
+              @edit="emit('open-action', action)"
+              @delete="deleteAction(index)"
+            />
           </nldd-cell>
           <template v-else>
             <nldd-spacer-cell size="8"></nldd-spacer-cell>
@@ -444,15 +432,3 @@ function addOutput() {
     <nldd-button slot="actions" variant="destructive" text="Verwijder" @click="confirmDelete"></nldd-button>
   </nldd-modal-dialog>
 </template>
-
-<style scoped>
-/* Row-level actions cluster: Bewerk button + minus icon button. flex-end
- * keeps them right-aligned within the row's value cell, and the gap matches
- * the spacing used in OperationSettings' value-row pattern. */
-.mr-row-actions {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 8px;
-}
-</style>

--- a/frontend/src/components/MachineReadable.vue
+++ b/frontend/src/components/MachineReadable.vue
@@ -23,7 +23,15 @@ const emit = defineEmits([
   'open-edit',
   'init-mr',
   'add-action',
+  // The Machine-pane "Opslaan" button — a real backend save of the law.
   'save',
+  /**
+   * Patch a single machine_readable field in place (no backend save, just
+   * marks the model dirty). Same `{ section, key, data }` shape the parent's
+   * handleSave dispatches on — used for inline edits like the produces
+   * dropdowns. Distinct from `save` (which is the law PUT).
+   */
+  'patch',
   /**
    * Delete a single item from the machine_readable. Payload shape mirrors
    * `open-edit` so the parent's `handleSave`/`handleDelete` can dispatch on
@@ -57,6 +65,22 @@ const definitions = computed(() => {
 });
 
 const produces = computed(() => execution.value?.produces ?? null);
+
+// Enum values from the law schema (schema/v0.4.0 — produces.*).
+const LEGAL_CHARACTERS = [
+  'BESCHIKKING', 'TOETS', 'WAARDEBEPALING', 'BESLUIT_VAN_ALGEMENE_STREKKING', 'INFORMATIEF',
+];
+const DECISION_TYPES = [
+  'TOEKENNING', 'AFWIJZING', 'GOEDKEURING', 'GEEN_BESLUIT',
+  'ALGEMEEN_VERBINDEND_VOORSCHRIFT', 'BELEIDSREGEL', 'VOORBEREIDINGSBESLUIT',
+  'ANDERE_HANDELING', 'AANSLAG',
+];
+
+// Mutations live in the parent; emit a save with the produces section.
+// An empty selection clears the key (data: null).
+function updateProduces(key, value) {
+  emit('patch', { section: 'produces', key, data: value === '' ? null : value });
+}
 
 const parameters = computed(() =>
   (execution.value?.parameters ?? []).map((p) => ({
@@ -242,17 +266,39 @@ function addOutput() {
 
     <!-- Metadata: produces -->
     <nldd-list v-if="produces" variant="box">
-      <nldd-list-item v-if="produces.legal_character" size="md">
-        <nldd-text-cell text="Juridische basis"></nldd-text-cell>
-        <nldd-cell v-if="editable">
-          <nldd-button size="md" expandable :text="humanize(produces.legal_character)"></nldd-button>
+      <nldd-list-item v-if="produces.legal_character || editable" size="md">
+        <nldd-text-cell text="Juridische basis" min-width="120px"></nldd-text-cell>
+        <nldd-spacer-cell size="8"></nldd-spacer-cell>
+        <nldd-cell v-if="editable" width="full" min-width="120px" max-width="280px">
+          <nldd-dropdown size="md">
+            <select
+              :key="`lc-${article?.number}`"
+              aria-label="Juridische basis"
+              :value="produces.legal_character || ''"
+              @change="updateProduces('legal_character', $event.target.value)"
+            >
+              <option value="">(geen)</option>
+              <option v-for="v in LEGAL_CHARACTERS" :key="v" :value="v">{{ humanize(v) }}</option>
+            </select>
+          </nldd-dropdown>
         </nldd-cell>
         <nldd-text-cell v-else horizontal-alignment="right" :text="humanize(produces.legal_character)"></nldd-text-cell>
       </nldd-list-item>
-      <nldd-list-item v-if="produces.decision_type" size="md">
-        <nldd-text-cell text="Besluit-type"></nldd-text-cell>
-        <nldd-cell v-if="editable">
-          <nldd-button size="md" expandable :text="humanize(produces.decision_type)"></nldd-button>
+      <nldd-list-item v-if="produces.decision_type || editable" size="md">
+        <nldd-text-cell text="Besluit-type" min-width="120px"></nldd-text-cell>
+        <nldd-spacer-cell size="8"></nldd-spacer-cell>
+        <nldd-cell v-if="editable" width="full" min-width="120px" max-width="280px">
+          <nldd-dropdown size="md">
+            <select
+              :key="`dt-${article?.number}`"
+              aria-label="Besluit-type"
+              :value="produces.decision_type || ''"
+              @change="updateProduces('decision_type', $event.target.value)"
+            >
+              <option value="">(geen)</option>
+              <option v-for="v in DECISION_TYPES" :key="v" :value="v">{{ humanize(v) }}</option>
+            </select>
+          </nldd-dropdown>
         </nldd-cell>
         <nldd-text-cell v-else horizontal-alignment="right" :text="humanize(produces.decision_type)"></nldd-text-cell>
       </nldd-list-item>
@@ -260,13 +306,13 @@ function addOutput() {
 
     <!-- Definities -->
     <template v-if="definitions.length || editable">
-      <nldd-spacer size="24"></nldd-spacer>
+      <nldd-spacer size="16"></nldd-spacer>
       <nldd-title size="5" data-testid="section-definitions"><h5>Definities</h5></nldd-title>
-      <nldd-spacer size="12"></nldd-spacer>
+      <nldd-spacer size="8"></nldd-spacer>
       <nldd-list variant="box">
         <nldd-list-item v-for="def in definitions" :key="def.name" size="md">
           <template v-if="editable">
-            <nldd-text-cell :text="`${def.name} = ${formatValue(def.value, def.unit)}`"></nldd-text-cell>
+            <nldd-text-cell><BreakableName :name="def.name" /> = {{ formatValue(def.value, def.unit) }}</nldd-text-cell>
             <nldd-spacer-cell size="8"></nldd-spacer-cell>
           </template>
           <template v-else>
@@ -305,9 +351,9 @@ function addOutput() {
 
     <!-- Parameters -->
     <template v-if="parameters.length || editable">
-      <nldd-spacer size="24"></nldd-spacer>
+      <nldd-spacer size="16"></nldd-spacer>
       <nldd-title size="5" data-testid="section-parameters"><h5>Parameters</h5></nldd-title>
-      <nldd-spacer size="12"></nldd-spacer>
+      <nldd-spacer size="8"></nldd-spacer>
       <nldd-list variant="box">
         <nldd-list-item v-for="(param, index) in parameters" :key="param.name" size="md">
           <nldd-text-cell><BreakableName :name="param.name" /> <nldd-tag size="sm" :text="param.type"></nldd-tag></nldd-text-cell>
@@ -331,13 +377,13 @@ function addOutput() {
 
     <!-- Inputs -->
     <template v-if="inputs.length || editable">
-      <nldd-spacer size="24"></nldd-spacer>
+      <nldd-spacer size="16"></nldd-spacer>
       <nldd-title size="5" data-testid="section-inputs"><h5>Inputs</h5></nldd-title>
-      <nldd-spacer size="12"></nldd-spacer>
+      <nldd-spacer size="8"></nldd-spacer>
       <nldd-list variant="box">
         <nldd-list-item v-for="(input, index) in inputs" :key="input.name" :data-testid="`input-row-${input.name}`" size="md">
           <nldd-text-cell
-            :supporting-text="input.sourceRegulation ? lawDisplayName(input.sourceRegulation) : undefined"
+            :supporting-text="input.sourceRegulation ? lawDisplayName(input.sourceRegulation) : 'Geen bron regelgeving'"
           ><BreakableName :name="input.name" /> <nldd-tag size="sm" :text="input.type"></nldd-tag></nldd-text-cell>
           <nldd-spacer-cell v-if="editable" size="8"></nldd-spacer-cell>
           <nldd-cell v-if="editable">
@@ -360,9 +406,9 @@ function addOutput() {
 
     <!-- Outputs -->
     <template v-if="outputs.length || editable">
-      <nldd-spacer size="24"></nldd-spacer>
+      <nldd-spacer size="16"></nldd-spacer>
       <nldd-title size="5" data-testid="section-outputs"><h5>Outputs</h5></nldd-title>
-      <nldd-spacer size="12"></nldd-spacer>
+      <nldd-spacer size="8"></nldd-spacer>
       <nldd-list variant="box">
         <nldd-list-item v-for="(output, index) in outputs" :key="output.name" size="md">
           <nldd-text-cell><BreakableName :name="output.name" /> <nldd-tag size="sm" :text="output.type"></nldd-tag></nldd-text-cell>
@@ -386,9 +432,9 @@ function addOutput() {
 
     <!-- Acties -->
     <template v-if="actions.length || editable">
-      <nldd-spacer size="24"></nldd-spacer>
+      <nldd-spacer size="16"></nldd-spacer>
       <nldd-title size="5" data-testid="section-actions"><h5>Acties</h5></nldd-title>
-      <nldd-spacer size="12"></nldd-spacer>
+      <nldd-spacer size="8"></nldd-spacer>
       <nldd-list variant="box">
         <nldd-list-item
           v-for="(action, index) in actions"

--- a/frontend/src/components/MachineReadable.vue
+++ b/frontend/src/components/MachineReadable.vue
@@ -70,7 +70,10 @@ const inputs = computed(() =>
   (execution.value?.input ?? []).map((i) => ({
     name: i.name,
     type: i.type,
-    source: i.source?.regulation ?? i.source?.output ?? null,
+    // Only an actual source regulation gets a supporting line. A cross-law
+    // output reference humanises to roughly the field name, which would
+    // just duplicate it.
+    sourceRegulation: i.source?.regulation ?? null,
   }))
 );
 
@@ -334,7 +337,7 @@ function addOutput() {
       <nldd-list variant="box">
         <nldd-list-item v-for="(input, index) in inputs" :key="input.name" :data-testid="`input-row-${input.name}`" size="md">
           <nldd-text-cell
-            :supporting-text="input.source ? lawDisplayName(input.source) : undefined"
+            :supporting-text="input.sourceRegulation ? lawDisplayName(input.sourceRegulation) : undefined"
           ><BreakableName :name="input.name" /> <nldd-tag size="sm" :text="input.type"></nldd-tag></nldd-text-cell>
           <nldd-spacer-cell v-if="editable" size="8"></nldd-spacer-cell>
           <nldd-cell v-if="editable">

--- a/frontend/src/components/MachineReadable.vue
+++ b/frontend/src/components/MachineReadable.vue
@@ -2,6 +2,7 @@
 import { computed, ref, watch, nextTick } from 'vue';
 import { humanize } from '../utils/outputFormat.js';
 import { useCorpusLaws } from '../composables/useCorpusLaws.js';
+import BreakableName from './BreakableName.vue';
 
 const { displayName: lawDisplayName } = useCorpusLaws();
 
@@ -44,7 +45,13 @@ const definitions = computed(() => {
   return Object.entries(defs).map(([name, def]) => {
     const val = typeof def === 'object' ? def.value : def;
     const unit = typeof def === 'object' ? def.type_spec?.unit : undefined;
-    return { name, value: val, unit };
+    // Per-token parts for read-only display: a list keeps its raw items
+    // (each wrapped in <wbr>-breakable tokens), a scalar is the formatted
+    // single value. Lets long underscore identifiers wrap instead of
+    // overflowing the (no longer fit-content) value cell.
+    const isList = Array.isArray(val);
+    const parts = isList ? val.map((v) => String(v)) : [formatValue(val, unit)];
+    return { name, value: val, unit, isList, parts };
   });
 });
 
@@ -84,6 +91,10 @@ function formatValue(val, unit) {
       return (val * 100).toLocaleString('nl-NL', { maximumFractionDigits: 3 }) + '%';
     }
   }
+  // A list definition value (YAML sequence) renders here; String([...])
+  // joins with a bare comma ("a,b,c") which has no break opportunity and
+  // pushes the column width. Use comma + space so it can wrap.
+  if (Array.isArray(val)) return val.join(', ');
   return String(val);
 }
 
@@ -255,9 +266,21 @@ function addOutput() {
             <nldd-spacer-cell size="8"></nldd-spacer-cell>
           </template>
           <template v-else>
-            <nldd-text-cell :text="def.name"></nldd-text-cell>
+            <nldd-text-cell min-width="120px"><BreakableName :name="def.name" /></nldd-text-cell>
             <nldd-spacer-cell size="8"></nldd-spacer-cell>
-            <nldd-text-cell width="fit-content" horizontal-alignment="right" :text="formatValue(def.value, def.unit)"></nldd-text-cell>
+            <nldd-text-cell
+              v-if="def.isList"
+              horizontal-alignment="right"
+            ><template
+              v-for="(part, i) in def.parts"
+              :key="i"
+            ><span v-if="i > 0">, </span><BreakableName :name="part" /></template></nldd-text-cell>
+            <nldd-text-cell
+              v-else
+              width="fit-content"
+              horizontal-alignment="right"
+              :text="def.parts[0]"
+            ></nldd-text-cell>
           </template>
           <nldd-cell v-if="editable">
             <div class="mr-row-actions">
@@ -286,7 +309,7 @@ function addOutput() {
       <nldd-spacer size="12"></nldd-spacer>
       <nldd-list variant="box">
         <nldd-list-item v-for="(param, index) in parameters" :key="param.name" size="md">
-          <nldd-text-cell :text="`${param.name} (${param.type})`"></nldd-text-cell>
+          <nldd-text-cell><BreakableName :name="param.name" /> <nldd-tag size="sm" :text="param.type"></nldd-tag></nldd-text-cell>
           <nldd-spacer-cell v-if="editable" size="8"></nldd-spacer-cell>
           <nldd-cell v-if="editable">
             <div class="mr-row-actions">
@@ -316,9 +339,8 @@ function addOutput() {
       <nldd-list variant="box">
         <nldd-list-item v-for="(input, index) in inputs" :key="input.name" :data-testid="`input-row-${input.name}`" size="md">
           <nldd-text-cell
-            :text="`${input.name} (${input.type})`"
             :supporting-text="input.source ? lawDisplayName(input.source) : undefined"
-          ></nldd-text-cell>
+          ><BreakableName :name="input.name" /> <nldd-tag size="sm" :text="input.type"></nldd-tag></nldd-text-cell>
           <nldd-spacer-cell v-if="editable" size="8"></nldd-spacer-cell>
           <nldd-cell v-if="editable">
             <div class="mr-row-actions">
@@ -347,7 +369,7 @@ function addOutput() {
       <nldd-spacer size="12"></nldd-spacer>
       <nldd-list variant="box">
         <nldd-list-item v-for="(output, index) in outputs" :key="output.name" size="md">
-          <nldd-text-cell :text="`${output.name} (${output.type})`"></nldd-text-cell>
+          <nldd-text-cell><BreakableName :name="output.name" /> <nldd-tag size="sm" :text="output.type"></nldd-tag></nldd-text-cell>
           <nldd-spacer-cell v-if="editable" size="8"></nldd-spacer-cell>
           <nldd-cell v-if="editable">
             <div class="mr-row-actions">

--- a/frontend/src/components/OperationSettings.test.js
+++ b/frontend/src/components/OperationSettings.test.js
@@ -183,8 +183,10 @@ describe('OperationSettings — AGE op', () => {
     });
   });
 
-  describe('canAddValue / canAddNestedOperation', () => {
-    it('disables both add buttons for AGE', () => {
+  describe('canAddValue', () => {
+    // Operations are added by switching a value's Type via the per-row
+    // menu, so there is only the single "Voeg waarde toe" path now.
+    it('disables the add-value button for AGE', () => {
       const node = {
         operation: 'AGE',
         date_of_birth: '$geboortedatum',
@@ -192,7 +194,6 @@ describe('OperationSettings — AGE op', () => {
       };
       const wrapper = mountOp(node);
       expect(wrapper.vm.canAddValue).toBe(false);
-      expect(wrapper.vm.canAddNestedOperation).toBe(false);
     });
   });
 });

--- a/frontend/src/components/OperationSettings.vue
+++ b/frontend/src/components/OperationSettings.vue
@@ -3,7 +3,6 @@ import { computed } from 'vue';
 import {
   OPERATION_LABELS,
   collectAvailableVariables,
-  describeSubtitle,
   derivedTitle,
 } from '../utils/operationTree.js';
 import BreakableName from './BreakableName.vue';
@@ -160,9 +159,13 @@ function isLiteralValue(val) {
   return val === null || typeof val === 'number' || typeof val === 'boolean' || (typeof val === 'string' && !val.startsWith('$'));
 }
 
+// Mirror the read-only Waarde row (readonlyValueText): show the nested op's
+// own title when the author supplied one, falling back to the derived
+// expression. Keeps the dropdown label identical to the Titel row the user
+// sees after clicking "Bewerken" into that operation.
 function valueDropdownNestedOption(val) {
   if (!isNestedOperation(val)) return null;
-  return { value: '__nested__', label: `${derivedTitle(val)} (operatie)` };
+  return { value: '__nested__', label: `${val.title ?? derivedTitle(val)} (operatie)` };
 }
 
 function currentDropdownValue(val) {
@@ -556,8 +559,12 @@ function addValue() {
               ></nldd-menu-item>
             </nldd-menu>
           </div>
-          <p v-if="isNestedOperation(val._value)" class="value-help-text">
-            {{ describeSubtitle(val._value) }}
+          <!-- Subtitle only when a user title masks the derived form: then
+               the derived expression is the extra technical detail. Without a
+               title the dropdown already shows derivedTitle, so a subtitle
+               would just repeat it (matches read-only nestedSupportingText). -->
+          <p v-if="isNestedOperation(val._value) && val._value.title" class="value-help-text">
+            {{ derivedTitle(val._value) }}
           </p>
         </nldd-cell>
         <template v-else>

--- a/frontend/src/components/OperationSettings.vue
+++ b/frontend/src/components/OperationSettings.vue
@@ -73,15 +73,6 @@ const canAddValue = computed(() => {
   return true;
 });
 
-const canAddNestedOperation = computed(() => {
-  if (!props.editable) return false;
-  const op = props.operation?.operation;
-  if (!op) return false;
-  // Same fixed-shape rule as canAddValue: structural-slot ops don't grow.
-  if (op === 'NOT' || op === 'IF' || op === 'SWITCH' || op === 'AGE') return false;
-  return !isComparisonOp.value;
-});
-
 // Required structural fields whose minus button must be hidden so the user
 // cannot delete them and silently produce an invalid node.
 function canRemoveValue(val) {
@@ -348,6 +339,26 @@ function updateDropdownValue(val, event) {
 }
 
 
+// The Type radio (Waarde / Operatie) only applies to value slots that can
+// hold either a literal or a nested operation — not subject/date pickers.
+function canChangeValueKind(val) {
+  return val._kind !== 'subject'
+    && val._kind !== 'date_of_birth'
+    && val._kind !== 'reference_date';
+}
+
+// Switch a value between a literal and a nested operation, writing through
+// applyValueMutation so it lands in the correct slot for this _kind. The
+// default operation mirrors the old "Operatie toevoegen" shape.
+function changeValueKind(val, kind) {
+  const isOp = isNestedOperation(val._value);
+  if (kind === 'operatie' && !isOp) {
+    applyValueMutation(val, { operation: 'ADD', values: [] });
+  } else if (kind === 'value' && isOp) {
+    applyValueMutation(val, '');
+  }
+}
+
 function readonlyValueText(val) {
   const v = val._value;
   if (v === null || v === undefined || v === '') return '(leeg)';
@@ -415,17 +426,6 @@ function addValue() {
   }
 }
 
-function addNestedOperation() {
-  const node = props.operation?.node;
-  if (!node || isComparisonOp.value) return;
-  if (node.operation === 'NOT' || node.operation === 'IF' || node.operation === 'SWITCH') return;
-
-  if (Array.isArray(node.conditions)) {
-    node.conditions.push({ operation: 'EQUALS', subject: '', value: '' });
-  } else if (Array.isArray(node.values)) {
-    node.values.push({ operation: 'ADD', values: [] });
-  }
-}
 </script>
 
 <template>
@@ -509,12 +509,45 @@ function addNestedOperation() {
                 </select>
               </nldd-dropdown>
             </template>
-            <nldd-icon-button v-if="canRemoveValue(val)" icon="minus" title="Verwijder waarde" @click="removeValue(val)">
-            </nldd-icon-button>
+            <nldd-icon-button
+              :id="`val-actions-${operation.number}-${i}`"
+              icon="more"
+              text="Acties"
+              tooltip-timing="never"
+              variant="neutral-tinted"
+            ></nldd-icon-button>
+            <nldd-menu :anchor="`val-actions-${operation.number}-${i}`">
+              <nldd-menu-item
+                v-if="isNestedOperation(val._value)"
+                text="Bewerk"
+                icon="edit"
+                @click.stop="emit('select-operation', val._value)"
+              ></nldd-menu-item>
+              <nldd-menu-group v-if="canChangeValueKind(val)" text="Type">
+                <nldd-menu-item
+                  type="radio"
+                  text="Waarde"
+                  :selected="!isNestedOperation(val._value) || undefined"
+                  @click.stop="changeValueKind(val, 'value')"
+                ></nldd-menu-item>
+                <nldd-menu-item
+                  type="radio"
+                  text="Operatie"
+                  :selected="isNestedOperation(val._value) || undefined"
+                  @click.stop="changeValueKind(val, 'operatie')"
+                ></nldd-menu-item>
+              </nldd-menu-group>
+              <nldd-menu-divider v-if="canRemoveValue(val)"></nldd-menu-divider>
+              <nldd-menu-item
+                v-if="canRemoveValue(val)"
+                text="Verwijder"
+                icon="delete"
+                @click.stop="removeValue(val)"
+              ></nldd-menu-item>
+            </nldd-menu>
           </div>
           <p v-if="isNestedOperation(val._value)" class="value-help-text">
             {{ describeSubtitle(val._value) }}
-            <a href="#" @click.prevent="emit('select-operation', val._value)">Bewerk</a>
           </p>
         </nldd-cell>
         <template v-else>
@@ -532,11 +565,10 @@ function addNestedOperation() {
       </nldd-list-item>
 
       <!-- Add value -->
-      <nldd-list-item v-if="canAddValue || canAddNestedOperation" size="md">
-        <div class="add-value-buttons">
-          <nldd-button v-if="canAddValue" size="md" start-icon="plus-small" data-testid="add-value-btn" @click="addValue" text="Waarde toevoegen"></nldd-button>
-          <nldd-button v-if="canAddNestedOperation" size="md" start-icon="plus-small" data-testid="add-nested-op-btn" @click="addNestedOperation" text="Operatie toevoegen"></nldd-button>
-        </div>
+      <nldd-list-item v-if="canAddValue" size="md">
+        <nldd-cell width="full">
+          <nldd-button width="full" size="md" start-icon="plus-small" data-testid="add-value-btn" @click="addValue" text="Voeg waarde toe"></nldd-button>
+        </nldd-cell>
       </nldd-list-item>
     </nldd-list>
   </template>
@@ -578,12 +610,6 @@ function addNestedOperation() {
   min-width: 0;
 }
 
-.add-value-buttons {
-  display: flex;
-  gap: 8px;
-  width: 100%;
-}
-
 .value-help-text {
   font-family: var(--primitives-font-family-body, 'RijksSansVF', sans-serif);
   font-size: 14px;
@@ -591,14 +617,5 @@ function addNestedOperation() {
   line-height: 1.25;
   color: var(--semantics-text-secondary-color, #545D68);
   margin: 2px 0 0 0;
-}
-
-.value-help-text a {
-  color: var(--semantics-text-accent-color, #007BC7);
-  text-decoration: none;
-}
-
-.value-help-text a:hover {
-  text-decoration: underline;
 }
 </style>

--- a/frontend/src/components/OperationSettings.vue
+++ b/frontend/src/components/OperationSettings.vue
@@ -576,7 +576,7 @@ function addValue() {
                   @click.stop="changeValueKind(val, 'operatie')"
                 ></nldd-menu-item>
               </nldd-menu-group>
-              <nldd-menu-divider v-if="canRemoveValue(val)"></nldd-menu-divider>
+              <nldd-menu-divider v-if="canChangeValueKind(val) && canRemoveValue(val)"></nldd-menu-divider>
               <nldd-menu-item
                 v-if="canRemoveValue(val)"
                 text="Verwijder"

--- a/frontend/src/components/OperationSettings.vue
+++ b/frontend/src/components/OperationSettings.vue
@@ -347,6 +347,13 @@ function canChangeValueKind(val) {
     && val._kind !== 'reference_date';
 }
 
+// The actions menu only contains the Type group and Verwijder. When neither
+// applies (e.g. a comparison op's fixed subject/value), the menu would render
+// empty ("Geen opties beschikbaar"), so suppress the more-button entirely.
+function hasValueMenu(val) {
+  return canChangeValueKind(val) || canRemoveValue(val);
+}
+
 // Switch a value between a literal and a nested operation, writing through
 // applyValueMutation so it lands in the correct slot for this _kind. The
 // default operation mirrors the old "Operatie toevoegen" shape.
@@ -518,13 +525,14 @@ function addValue() {
               @click="emit('select-operation', val._value)"
             ></nldd-icon-button>
             <nldd-icon-button
+              v-if="hasValueMenu(val)"
               :id="`val-actions-${operation.number}-${i}`"
               icon="more"
               text="Acties"
               tooltip-timing="never"
               variant="neutral-tinted"
             ></nldd-icon-button>
-            <nldd-menu :anchor="`val-actions-${operation.number}-${i}`">
+            <nldd-menu v-if="hasValueMenu(val)" :anchor="`val-actions-${operation.number}-${i}`">
               <nldd-menu-group v-if="canChangeValueKind(val)" text="Type">
                 <nldd-menu-item
                   type="radio"

--- a/frontend/src/components/OperationSettings.vue
+++ b/frontend/src/components/OperationSettings.vue
@@ -492,7 +492,7 @@ function addNestedOperation() {
             </template>
             <!-- Literal values show a text field -->
             <template v-else-if="isLiteralValue(val._value)">
-              <nldd-text-field size="md" :value="String(val._value)" is-full-width @input="updateValue(val, $event)"></nldd-text-field>
+              <nldd-text-field size="md" :value="String(val._value)" width="full" @input="updateValue(val, $event)"></nldd-text-field>
             </template>
             <!-- Variable references and nested operations show a full dropdown -->
             <template v-else>

--- a/frontend/src/components/OperationSettings.vue
+++ b/frontend/src/components/OperationSettings.vue
@@ -335,8 +335,13 @@ function updateValue(val, event) {
 
 function updateDropdownValue(val, event) {
   const selected = event.target.value;
+  // The '__nested__' sentinel is just the current operation's own row in
+  // the list — re-picking it means "keep the operation" (edit it via the
+  // pencil), so it's a no-op. Picking anything else (a variable, literal,
+  // or the empty option) replaces the value, including replacing a nested
+  // operation — otherwise switching e.g. an IF op to $bsn silently does
+  // nothing and never marks the action dirty.
   if (selected === '__nested__') return;
-  if (isNestedOperation(val._value)) return;
   const newVal = selected.startsWith('$') ? selected : parseInputValue(selected);
   applyValueMutation(val, newVal);
 }

--- a/frontend/src/components/OperationSettings.vue
+++ b/frontend/src/components/OperationSettings.vue
@@ -464,7 +464,19 @@ function addValue() {
         <nldd-spacer-cell size="12"></nldd-spacer-cell>
         <nldd-cell v-if="editable">
           <nldd-dropdown size="md" data-testid="operation-type-dropdown">
-            <select aria-label="Operatie type" :value="operation.operation" @change="changeOperationType($event.target.value)">
+            <!-- Same stale-collapsed-label issue as the value dropdown: the
+                 <option> list (typeOptions) is constant, so navigating to a
+                 different operation only changes the bound value, and a
+                 native <select> reused in place keeps showing the previous
+                 op's type label. Key on the operation identity + its type so
+                 the element is recreated and the collapsed text stays in
+                 sync with the selected option. -->
+            <select
+              :key="`op-type-${operation.number}-${operation.operation}`"
+              aria-label="Operatie type"
+              :value="operation.operation"
+              @change="changeOperationType($event.target.value)"
+            >
               <option v-for="opt in typeOptions" :key="opt.value" :value="opt.value" :selected="opt.value === operation.operation">{{ opt.label }}</option>
             </select>
           </nldd-dropdown>
@@ -509,8 +521,22 @@ function addValue() {
             <!-- Variable references and nested operations show a full dropdown -->
             <template v-else>
               <nldd-dropdown size="md" style="flex: 1; min-width: 0;">
-                <select :aria-label="val._label" :value="currentDropdownValue(val._value)" @change="updateDropdownValue(val, $event)">
-                  <template v-for="nestedOpt in [valueDropdownNestedOption(val._value)]" :key="'nested'">
+                <!-- A nested op's option value is the constant '__nested__',
+                     and so is the select's bound value. Native <select>
+                     only re-renders its COLLAPSED label when value changes,
+                     so navigating to a different operation (which only swaps
+                     the option TEXT, not its value) leaves the closed
+                     control showing the previous op's label while the open
+                     list shows the correct one. Keying the <select> on the
+                     displayed identity forces a fresh element so the
+                     collapsed text always matches the selected option. -->
+                <select
+                  :key="`val-sel-${i}-${valueDropdownNestedOption(val._value)?.label ?? currentDropdownValue(val._value)}`"
+                  :aria-label="val._label"
+                  :value="currentDropdownValue(val._value)"
+                  @change="updateDropdownValue(val, $event)"
+                >
+                  <template v-for="nestedOpt in [valueDropdownNestedOption(val._value)]" :key="nestedOpt?.label ?? 'nested'">
                     <option v-if="nestedOpt" :value="nestedOpt.value" :selected="currentDropdownValue(val._value) === '__nested__'">{{ nestedOpt.label }}</option>
                   </template>
                   <optgroup v-for="[category, opts] in variableGroups" :key="category" :label="category">

--- a/frontend/src/components/OperationSettings.vue
+++ b/frontend/src/components/OperationSettings.vue
@@ -510,6 +510,14 @@ function addValue() {
               </nldd-dropdown>
             </template>
             <nldd-icon-button
+              v-if="isNestedOperation(val._value)"
+              icon="edit"
+              text="Bewerken"
+              tooltip-timing="never"
+              variant="neutral-tinted"
+              @click="emit('select-operation', val._value)"
+            ></nldd-icon-button>
+            <nldd-icon-button
               :id="`val-actions-${operation.number}-${i}`"
               icon="more"
               text="Acties"

--- a/frontend/src/components/OperationSettings.vue
+++ b/frontend/src/components/OperationSettings.vue
@@ -11,6 +11,10 @@ const props = defineProps({
   operation: { type: Object, default: null },
   article: { type: Object, default: null },
   editable: { type: Boolean, default: false },
+  // Suppress the read-only "Titel" row. The action sheet sets this at the
+  // top level in edit mode, where the editable Output field takes that
+  // first/name position instead (avoiding a duplicate name row).
+  hideTitleRow: { type: Boolean, default: false },
 });
 
 const emit = defineEmits(['select-operation']);
@@ -433,8 +437,12 @@ function addNestedOperation() {
       <nldd-spacer size="12"></nldd-spacer>
     </template>
     <nldd-list variant="box" class="settings-list">
+      <!-- Optional lead row, rendered as the first item of THIS list so
+           the action sheet's Output field sits in the same box as Type /
+           conditions on the root of an action. -->
+      <slot name="lead-row"></slot>
       <!-- Titel -->
-      <nldd-list-item size="md">
+      <nldd-list-item v-if="!hideTitleRow" size="md">
         <nldd-text-cell text="Titel" :width="editable ? '120px' : 'fit-content'"></nldd-text-cell>
         <nldd-spacer-cell size="12"></nldd-spacer-cell>
         <nldd-text-cell horizontal-alignment="right"><BreakableName :name="operation.title || '(leeg)'" /></nldd-text-cell>

--- a/frontend/src/components/OperationSettings.vue
+++ b/frontend/src/components/OperationSettings.vue
@@ -6,6 +6,7 @@ import {
   describeSubtitle,
   derivedTitle,
 } from '../utils/operationTree.js';
+import BreakableName from './BreakableName.vue';
 const props = defineProps({
   operation: { type: Object, default: null },
   article: { type: Object, default: null },
@@ -434,14 +435,15 @@ function addNestedOperation() {
     <nldd-list variant="box" class="settings-list">
       <!-- Titel -->
       <nldd-list-item size="md">
-        <nldd-text-cell text="Titel" max-width="120px"></nldd-text-cell>
-        <nldd-text-cell horizontal-alignment="right" :text="operation.title || '(leeg)'"></nldd-text-cell>
+        <nldd-text-cell text="Titel" width="fit-content"></nldd-text-cell>
+        <nldd-spacer-cell size="12"></nldd-spacer-cell>
+        <nldd-text-cell horizontal-alignment="right"><BreakableName :name="operation.title || '(leeg)'" /></nldd-text-cell>
       </nldd-list-item>
 
       <!-- Type -->
       <nldd-list-item size="md">
-        <nldd-text-cell text="Type" max-width="120px"></nldd-text-cell>
-        <nldd-spacer-cell v-if="editable" size="8"></nldd-spacer-cell>
+        <nldd-text-cell text="Type" width="fit-content"></nldd-text-cell>
+        <nldd-spacer-cell size="12"></nldd-spacer-cell>
         <nldd-cell v-if="editable">
           <nldd-dropdown size="md" data-testid="operation-type-dropdown">
             <select aria-label="Operatie type" :value="operation.operation" @change="changeOperationType($event.target.value)">
@@ -450,7 +452,7 @@ function addNestedOperation() {
           </nldd-dropdown>
         </nldd-cell>
         <template v-else>
-          <nldd-text-cell horizontal-alignment="right" :text="OPERATION_LABELS[operation.operation] || operation.operation || '(leeg)'"></nldd-text-cell>
+          <nldd-text-cell horizontal-alignment="right"><BreakableName :name="OPERATION_LABELS[operation.operation] || operation.operation || '(leeg)'" /></nldd-text-cell>
         </template>
       </nldd-list-item>
 
@@ -463,8 +465,8 @@ function addNestedOperation() {
         :type="!editable && isNestedOperation(val._value) ? 'button' : undefined"
         @click="!editable && isNestedOperation(val._value) && emit('select-operation', val._value)"
       >
-        <nldd-text-cell :text="val._label" max-width="120px"></nldd-text-cell>
-        <nldd-spacer-cell v-if="editable" size="8"></nldd-spacer-cell>
+        <nldd-text-cell :text="val._label" width="fit-content"></nldd-text-cell>
+        <nldd-spacer-cell size="12"></nldd-spacer-cell>
         <nldd-cell v-if="editable">
           <div class="value-row">
             <!-- Subject/date fields show a dropdown of available variables.
@@ -510,9 +512,8 @@ function addNestedOperation() {
         <template v-else>
           <nldd-text-cell
             horizontal-alignment="right"
-            :text="readonlyValueText(val)"
             :supporting-text="nestedSupportingText(val)"
-          ></nldd-text-cell>
+          ><BreakableName :name="readonlyValueText(val)" /></nldd-text-cell>
           <template v-if="isNestedOperation(val._value)">
             <nldd-spacer-cell size="12"></nldd-spacer-cell>
             <nldd-icon-cell size="20">

--- a/frontend/src/components/OperationSettings.vue
+++ b/frontend/src/components/OperationSettings.vue
@@ -1,11 +1,19 @@
 <script setup>
-import { computed } from 'vue';
+import { computed, useId } from 'vue';
 import {
   OPERATION_LABELS,
   collectAvailableVariables,
   derivedTitle,
 } from '../utils/operationTree.js';
 import BreakableName from './BreakableName.vue';
+
+// Per-instance prefix for the per-value action menu DOM ids. operation.number
+// is stable within a law but identical across editor panes, so two panes
+// showing the same operation would collide and nldd-menu would anchor to the
+// first match (wrong pane). useId() is unique per component instance; ${i}
+// still disambiguates the value rows within one instance. Mirrors the
+// useId() pattern in RowActionsMenu.vue.
+const valueMenuId = useId();
 const props = defineProps({
   operation: { type: Object, default: null },
   article: { type: Object, default: null },
@@ -563,13 +571,13 @@ function addValue() {
           <template v-if="hasValueMenu(val)">
             <nldd-spacer-cell size="8"></nldd-spacer-cell>
             <nldd-icon-button
-              :id="`val-actions-${operation.number}-${i}`"
+              :id="`val-actions-${valueMenuId}-${i}`"
               icon="more"
               text="Acties"
               tooltip-timing="never"
               variant="neutral-tinted"
             ></nldd-icon-button>
-            <nldd-menu :anchor="`val-actions-${operation.number}-${i}`">
+            <nldd-menu :anchor="`val-actions-${valueMenuId}-${i}`">
               <nldd-menu-group v-if="canChangeValueKind(val)" text="Type">
                 <nldd-menu-item
                   type="radio"

--- a/frontend/src/components/OperationSettings.vue
+++ b/frontend/src/components/OperationSettings.vue
@@ -525,12 +525,6 @@ function addValue() {
               variant="neutral-tinted"
             ></nldd-icon-button>
             <nldd-menu :anchor="`val-actions-${operation.number}-${i}`">
-              <nldd-menu-item
-                v-if="isNestedOperation(val._value)"
-                text="Bewerk"
-                icon="edit"
-                @click.stop="emit('select-operation', val._value)"
-              ></nldd-menu-item>
               <nldd-menu-group v-if="canChangeValueKind(val)" text="Type">
                 <nldd-menu-item
                   type="radio"

--- a/frontend/src/components/OperationSettings.vue
+++ b/frontend/src/components/OperationSettings.vue
@@ -340,7 +340,10 @@ function updateDropdownValue(val, event) {
   // pencil), so it's a no-op. Picking anything else (a variable, literal,
   // or the empty option) replaces the value, including replacing a nested
   // operation — otherwise switching e.g. an IF op to $bsn silently does
-  // nothing and never marks the action dirty.
+  // nothing and never marks the action dirty. Consequence: picking the
+  // empty "Selecteer…" option discards a nested op tree in one click,
+  // same destructive trade as changeValueKind(); recovery is the
+  // ActionSheet "Annuleren" snapshot-restore (smoke-test this path).
   if (selected === '__nested__') return;
   const newVal = selected.startsWith('$') ? selected : parseInputValue(selected);
   applyValueMutation(val, newVal);

--- a/frontend/src/components/OperationSettings.vue
+++ b/frontend/src/components/OperationSettings.vue
@@ -526,6 +526,7 @@ function addValue() {
                   :value="currentDropdownValue(val._value)"
                   @change="updateDropdownValue(val, $event)"
                 >
+                  <option value="">Selecteer...</option>
                   <template v-for="nestedOpt in [valueDropdownNestedOption(val._value)]" :key="nestedOpt?.label ?? 'nested'">
                     <option v-if="nestedOpt" :value="nestedOpt.value" :selected="currentDropdownValue(val._value) === '__nested__'">{{ nestedOpt.label }}</option>
                   </template>

--- a/frontend/src/components/OperationSettings.vue
+++ b/frontend/src/components/OperationSettings.vue
@@ -370,6 +370,11 @@ function changeValueKind(val, kind) {
   if (kind === 'operatie' && !isOp) {
     applyValueMutation(val, { operation: 'ADD', values: [] });
   } else if (kind === 'value' && isOp) {
+    // Replaces the whole nested op with '' in one click. Deliberately
+    // unconfirmed: this matches the equally-destructive sibling
+    // removeValue() in the same menu — both rely on the ActionSheet
+    // "Annuleren" snapshot-restore as the single, consistent undo,
+    // rather than introducing a one-off confirm dialog here.
     applyValueMutation(val, '');
   }
 }

--- a/frontend/src/components/OperationSettings.vue
+++ b/frontend/src/components/OperationSettings.vue
@@ -156,10 +156,6 @@ const operationValues = computed(() => {
   return vals;
 });
 
-const hasClickableRow = computed(() =>
-  !props.editable && operationValues.value.some(v => isNestedOperation(v._value))
-);
-
 function isNestedOperation(val) {
   return val != null && typeof val === 'object' && val.operation;
 }
@@ -354,6 +350,10 @@ function readonlyValueText(val) {
   // derived expression. Mirrors the buildOperationTree title rule so the
   // Waarde row reads identically to the Titel row after clicking in.
   if (isNestedOperation(v)) return v.title ?? derivedTitle(v);
+  // A YAML list renders as a value; String([...]) joins with a bare comma
+  // ("a,b,c") which has no break opportunity and pushes the column width.
+  // Use comma + space so it can wrap and reads naturally.
+  if (Array.isArray(v)) return v.join(', ');
   return String(v);
 }
 
@@ -436,10 +436,6 @@ function addNestedOperation() {
       <nldd-list-item size="md">
         <nldd-text-cell text="Titel" max-width="120px"></nldd-text-cell>
         <nldd-text-cell horizontal-alignment="right" :text="operation.title || '(leeg)'"></nldd-text-cell>
-        <template v-if="!editable && hasClickableRow">
-          <nldd-spacer-cell size="12"></nldd-spacer-cell>
-          <nldd-icon-cell size="20"></nldd-icon-cell>
-        </template>
       </nldd-list-item>
 
       <!-- Type -->
@@ -455,10 +451,6 @@ function addNestedOperation() {
         </nldd-cell>
         <template v-else>
           <nldd-text-cell horizontal-alignment="right" :text="OPERATION_LABELS[operation.operation] || operation.operation || '(leeg)'"></nldd-text-cell>
-          <template v-if="hasClickableRow">
-            <nldd-spacer-cell size="12"></nldd-spacer-cell>
-            <nldd-icon-cell size="20"></nldd-icon-cell>
-          </template>
         </template>
       </nldd-list-item>
 
@@ -521,10 +513,10 @@ function addNestedOperation() {
             :text="readonlyValueText(val)"
             :supporting-text="nestedSupportingText(val)"
           ></nldd-text-cell>
-          <template v-if="hasClickableRow">
+          <template v-if="isNestedOperation(val._value)">
             <nldd-spacer-cell size="12"></nldd-spacer-cell>
             <nldd-icon-cell size="20">
-              <nldd-icon v-if="isNestedOperation(val._value)" name="chevron-right"></nldd-icon>
+              <nldd-icon name="chevron-right"></nldd-icon>
             </nldd-icon-cell>
           </template>
         </template>

--- a/frontend/src/components/OperationSettings.vue
+++ b/frontend/src/components/OperationSettings.vue
@@ -383,16 +383,6 @@ function readonlyValueText(val) {
   return String(v);
 }
 
-// Supporting-text for a Waarde row holding a nested op: only show the
-// derived expression when a user-title masked it as the primary text.
-// Without a user-title the row text IS the derived expression, so a
-// supporting-text would just repeat it.
-function nestedSupportingText(val) {
-  const v = val._value;
-  if (!isNestedOperation(v) || !v.title) return undefined;
-  return derivedTitle(v);
-}
-
 function removeValue(val) {
   const node = props.operation?.node;
   if (!node) return;
@@ -497,14 +487,14 @@ function addValue() {
       >
         <nldd-text-cell :text="val._label" :width="editable ? '120px' : 'fit-content'"></nldd-text-cell>
         <nldd-spacer-cell size="12"></nldd-spacer-cell>
-        <nldd-cell v-if="editable">
-          <div class="value-row">
+        <template v-if="editable">
+          <nldd-cell>
             <!-- Subject/date fields show a dropdown of available variables.
                  If the field already holds a literal value (e.g. "2025-01-01"),
                  it's included as the first option so it stays visible and
                  selectable. -->
             <template v-if="val._kind === 'subject' || val._kind === 'date_of_birth' || val._kind === 'reference_date'">
-              <nldd-dropdown size="md" style="flex: 1; min-width: 0;">
+              <nldd-dropdown size="md">
                 <select :aria-label="val._label" :value="currentDropdownValue(val._value)" @change="updateDropdownValue(val, $event)">
                   <option value="">Selecteer...</option>
                   <option v-if="isLiteralValue(val._value) && val._value !== '' && val._value !== null" :value="String(val._value)" :selected="true">{{ String(val._value) }}</option>
@@ -520,7 +510,7 @@ function addValue() {
             </template>
             <!-- Variable references and nested operations show a full dropdown -->
             <template v-else>
-              <nldd-dropdown size="md" style="flex: 1; min-width: 0;">
+              <nldd-dropdown size="md">
                 <!-- A nested op's option value is the constant '__nested__',
                      and so is the select's bound value. Native <select>
                      only re-renders its COLLAPSED label when value changes,
@@ -545,23 +535,27 @@ function addValue() {
                 </select>
               </nldd-dropdown>
             </template>
+          </nldd-cell>
+          <template v-if="isNestedOperation(val._value)">
+            <nldd-spacer-cell size="8"></nldd-spacer-cell>
             <nldd-icon-button
-              v-if="isNestedOperation(val._value)"
               icon="edit"
               text="Bewerken"
               tooltip-timing="never"
               variant="neutral-tinted"
               @click="emit('select-operation', val._value)"
             ></nldd-icon-button>
+          </template>
+          <template v-if="hasValueMenu(val)">
+            <nldd-spacer-cell size="8"></nldd-spacer-cell>
             <nldd-icon-button
-              v-if="hasValueMenu(val)"
               :id="`val-actions-${operation.number}-${i}`"
               icon="more"
               text="Acties"
               tooltip-timing="never"
               variant="neutral-tinted"
             ></nldd-icon-button>
-            <nldd-menu v-if="hasValueMenu(val)" :anchor="`val-actions-${operation.number}-${i}`">
+            <nldd-menu :anchor="`val-actions-${operation.number}-${i}`">
               <nldd-menu-group v-if="canChangeValueKind(val)" text="Type">
                 <nldd-menu-item
                   type="radio"
@@ -584,20 +578,10 @@ function addValue() {
                 @click.stop="removeValue(val)"
               ></nldd-menu-item>
             </nldd-menu>
-          </div>
-          <!-- Subtitle only when a user title masks the derived form: then
-               the derived expression is the extra technical detail. Without a
-               title the dropdown already shows derivedTitle, so a subtitle
-               would just repeat it (matches read-only nestedSupportingText). -->
-          <p v-if="isNestedOperation(val._value) && val._value.title" class="value-help-text">
-            {{ derivedTitle(val._value) }}
-          </p>
-        </nldd-cell>
+          </template>
+        </template>
         <template v-else>
-          <nldd-text-cell
-            horizontal-alignment="right"
-            :supporting-text="nestedSupportingText(val)"
-          ><BreakableName :name="readonlyValueText(val)" /></nldd-text-cell>
+          <nldd-text-cell horizontal-alignment="right"><BreakableName :name="readonlyValueText(val)" /></nldd-text-cell>
           <template v-if="isNestedOperation(val._value)">
             <nldd-spacer-cell size="12"></nldd-spacer-cell>
             <nldd-icon-cell size="20">
@@ -639,26 +623,5 @@ function addValue() {
 .settings-list nldd-text-field,
 .settings-list nldd-dropdown {
   width: 100%;
-}
-
-.value-row {
-  display: flex;
-  gap: 8px;
-  align-items: center;
-  width: 100%;
-}
-.value-row nldd-text-field,
-.value-row nldd-dropdown {
-  flex: 1;
-  min-width: 0;
-}
-
-.value-help-text {
-  font-family: var(--primitives-font-family-body, 'RijksSansVF', sans-serif);
-  font-size: 14px;
-  font-weight: 400;
-  line-height: 1.25;
-  color: var(--semantics-text-secondary-color, #545D68);
-  margin: 2px 0 0 0;
 }
 </style>

--- a/frontend/src/components/OperationSettings.vue
+++ b/frontend/src/components/OperationSettings.vue
@@ -435,14 +435,14 @@ function addNestedOperation() {
     <nldd-list variant="box" class="settings-list">
       <!-- Titel -->
       <nldd-list-item size="md">
-        <nldd-text-cell text="Titel" width="fit-content"></nldd-text-cell>
+        <nldd-text-cell text="Titel" :width="editable ? '120px' : 'fit-content'"></nldd-text-cell>
         <nldd-spacer-cell size="12"></nldd-spacer-cell>
         <nldd-text-cell horizontal-alignment="right"><BreakableName :name="operation.title || '(leeg)'" /></nldd-text-cell>
       </nldd-list-item>
 
       <!-- Type -->
       <nldd-list-item size="md">
-        <nldd-text-cell text="Type" width="fit-content"></nldd-text-cell>
+        <nldd-text-cell text="Type" :width="editable ? '120px' : 'fit-content'"></nldd-text-cell>
         <nldd-spacer-cell size="12"></nldd-spacer-cell>
         <nldd-cell v-if="editable">
           <nldd-dropdown size="md" data-testid="operation-type-dropdown">
@@ -465,7 +465,7 @@ function addNestedOperation() {
         :type="!editable && isNestedOperation(val._value) ? 'button' : undefined"
         @click="!editable && isNestedOperation(val._value) && emit('select-operation', val._value)"
       >
-        <nldd-text-cell :text="val._label" width="fit-content"></nldd-text-cell>
+        <nldd-text-cell :text="val._label" :width="editable ? '120px' : 'fit-content'"></nldd-text-cell>
         <nldd-spacer-cell size="12"></nldd-spacer-cell>
         <nldd-cell v-if="editable">
           <div class="value-row">

--- a/frontend/src/components/RowActionsMenu.vue
+++ b/frontend/src/components/RowActionsMenu.vue
@@ -1,0 +1,51 @@
+<script setup>
+import { useId } from 'vue';
+
+/**
+ * Compact row-actions control: a single "more" icon-button that opens a
+ * menu with Edit + Delete. Replaces the inline "Bewerk" button + "—"
+ * delete icon-button pair to save horizontal space in dense list rows
+ * (machine-readable definitions / parameters / inputs / outputs /
+ * actions).
+ *
+ * Emits `edit` and `delete`; the parent owns the actual handlers and the
+ * delete-confirmation flow. The test-id props are forwarded onto the
+ * matching menu-items so existing data-testid selectors keep working.
+ */
+defineProps({
+  // Accessible label / tooltip for the trigger (e.g. "Acties voor input bsn").
+  accessibleLabel: { type: String, default: 'Acties' },
+  editTestid: { type: String, default: undefined },
+  deleteTestid: { type: String, default: undefined },
+});
+
+defineEmits(['edit', 'delete']);
+
+// Unique id so multiple instances in the same list anchor their own menu.
+const anchorId = `row-actions-${useId()}`;
+</script>
+
+<template>
+  <nldd-icon-button
+    :id="anchorId"
+    icon="more"
+    :text="accessibleLabel"
+    tooltip-timing="never"
+    variant="neutral-tinted"
+  ></nldd-icon-button>
+  <nldd-menu :anchor="anchorId">
+    <nldd-menu-item
+      text="Bewerk"
+      icon="edit"
+      :data-testid="editTestid"
+      @click.stop="$emit('edit')"
+    ></nldd-menu-item>
+    <nldd-menu-divider></nldd-menu-divider>
+    <nldd-menu-item
+      text="Verwijder"
+      icon="delete"
+      :data-testid="deleteTestid"
+      @click.stop="$emit('delete')"
+    ></nldd-menu-item>
+  </nldd-menu>
+</template>

--- a/frontend/src/components/ScenarioBuilder.vue
+++ b/frontend/src/components/ScenarioBuilder.vue
@@ -266,6 +266,13 @@ function onShowDetails(index, view = 'trace') {
     result: data?.result || null,
     traceText: data?.traceText || null,
     error: data?.error || null,
+    // Always false today: execute() is synchronous (see the CONTRACT
+    // note on ScenarioForm.execute) so `running` is reset in its finally
+    // before getExecutionData() is read here. The "Bezig met uitvoeren…"
+    // branch in ExecutionTraceView and the lastRunning/lastReload
+    // scaffolding in EditorApp are therefore unreachable *by design* —
+    // deliberately kept so the async path lights up for free if that
+    // contract is ever lifted. Not dead code to be removed in isolation.
     running: !!fresh?.running,
     expectations: data?.expectations || {},
     scenarioName,
@@ -332,6 +339,13 @@ async function onSave() {
     await saveScenario(selectedScenarioFile.value, gherkin);
     saveSuccess.value = true;
     isDirty.value = false;
+    // The just-saved state is the new clean baseline. Re-snapshot here so
+    // the dirty check stays correct even if the sheet is *not* closed on
+    // save (today selectedScenarioIndex is nulled below, but don't let the
+    // invariant depend on that): without this, reverting back to the saved
+    // state would still compare unequal to the pre-edit baseline and keep
+    // the Save footer wrongly visible.
+    dirtyBaseline = editSnapshot();
     selectedScenarioIndex.value = null;
     setTimeout(() => { saveSuccess.value = false; }, 3000);
   } catch (e) {

--- a/frontend/src/components/ScenarioBuilder.vue
+++ b/frontend/src/components/ScenarioBuilder.vue
@@ -352,20 +352,16 @@ async function onSaveAndShow() {
 }
 
 function cancelEdits() {
-  // Only discard when there were actual edits. Re-parsing/replacing
-  // formState otherwise needlessly remounts the whole overview — clearing
-  // cached results/refs (via the formState watcher) and resetting the
-  // pane's scroll position — just from opening and closing a scenario.
-  // Each ScenarioForm's deep watcher resets its local inputs when its
-  // `scenario`/`setup` props are replaced.
-  if (isDirty.value) {
-    const text = featureText.value;
-    if (text) {
-      try {
-        const parsed = parseFeature(text);
-        formState.value = mapFeatureToForm(parsed);
-      } catch { /* keep the previous state */ }
-    }
+  // Discard unsaved edits *without* replacing formState. Re-parsing it
+  // remounts the whole overview — clearing cached results/refs (via the
+  // formState watcher) and resetting the scenarios-pane scroll position.
+  // Edits live entirely in the edited ScenarioForm's local refs (only
+  // synced into formState on save), so asking that form to re-init from
+  // its unchanged props discards them while leaving the overview — and
+  // its scroll position — intact, exactly as when nothing was edited.
+  const idx = selectedScenarioIndex.value;
+  if (isDirty.value && idx !== null) {
+    scenarioRefs.value[idx]?.discardEdits?.();
   }
   isDirty.value = false;
   selectedScenarioIndex.value = null;

--- a/frontend/src/components/ScenarioBuilder.vue
+++ b/frontend/src/components/ScenarioBuilder.vue
@@ -460,8 +460,8 @@ defineExpose({ save: onSave });
         ></nldd-top-title-bar>
         <nldd-simple-section>
           <template v-if="!drilledSourceName">
-            <nldd-title id="scenario-title-anchor" size="4"><h2>{{ currentScenarioName }}</h2></nldd-title>
-            <nldd-spacer size="24"></nldd-spacer>
+            <nldd-title id="scenario-title-anchor" size="3"><h2>{{ currentScenarioName }}</h2></nldd-title>
+            <nldd-spacer size="16"></nldd-spacer>
           </template>
           <ScenarioForm
             v-for="(scenario, i) in formState.scenarios"

--- a/frontend/src/components/ScenarioBuilder.vue
+++ b/frontend/src/components/ScenarioBuilder.vue
@@ -276,6 +276,15 @@ function onShowDetails(index, view = 'trace') {
     // Bound to this builder + scenario so the result sheet's reload
     // action re-runs exactly the right scenario regardless of how many
     // ScenarioBuilder instances (panes) exist.
+    //
+    // Known limitation: `index` is captured by value and the result
+    // sheet can outlive the scenario sheet. It stays correct in practice
+    // because scenario count/order is stable across an inputs-only save
+    // and cancelEdits() no longer replaces formState — so nothing
+    // reindexes scenarios while the sheet is open, and the UI has no
+    // reorder/delete-scenario affordance. If the index ever did go out
+    // of bounds, reExecute()'s optional chaining makes it a safe no-op
+    // (empty result) rather than running the wrong scenario.
     reload: () => reExecute(index),
     view,
   });

--- a/frontend/src/components/ScenarioBuilder.vue
+++ b/frontend/src/components/ScenarioBuilder.vue
@@ -359,7 +359,6 @@ defineExpose({ save: onSave });
             <nldd-container slot="footer" padding-inline="16" padding-bottom="16">
               <nldd-button-group orientation="horizontal">
                 <nldd-button
-                  variant="primary"
                   :disabled="!scenarioResults.get(i) || undefined"
                   text="Toon resultaat"
                   @click="onShowDetails(i, 'trace')"

--- a/frontend/src/components/ScenarioBuilder.vue
+++ b/frontend/src/components/ScenarioBuilder.vue
@@ -76,13 +76,14 @@ const currentScenarioName = computed(() =>
 // keeps the bar non-compact (full text back button) until the user scrolls
 // past the table heading, then it compacts to show title + supporting text.
 // Overview: title = scenario name, no back button (empty back-text hides it).
+const capitalize = (s) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : s);
 const titleBarText = computed(() =>
-  drilledSourceName.value ? humanize(drilledSourceName.value) : currentScenarioName.value,
+  drilledSourceName.value ? capitalize(humanize(drilledSourceName.value)) : currentScenarioName.value,
 );
 const titleBarSupportingText = computed(() =>
   drilledSourceName.value ? currentScenarioName.value : '',
 );
-const titleBarBackText = computed(() => (drilledSourceName.value ? currentScenarioName.value : ''));
+const titleBarBackText = computed(() => (drilledSourceName.value ? 'Scenario' : ''));
 const titleBarCollapseAnchor = computed(() => (drilledSourceName.value ? 'ds-drill-anchor' : ''));
 
 function onTitleBack() {

--- a/frontend/src/components/ScenarioBuilder.vue
+++ b/frontend/src/components/ScenarioBuilder.vue
@@ -71,20 +71,11 @@ const currentScenarioName = computed(() =>
     ? formState.value?.scenarios?.[selectedScenarioIndex.value]?.name ?? ''
     : '',
 );
-// Drilled in: title = humanised source name, scenario name as supporting
-// text, and a back button to the scenario overview. The collapse-anchor
-// keeps the bar non-compact (full text back button) until the user scrolls
-// past the table heading, then it compacts to show title + supporting text.
-// Overview: title = scenario name, no back button (empty back-text hides it).
-const capitalize = (s) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : s);
-const titleBarText = computed(() =>
-  drilledSourceName.value ? capitalize(humanize(drilledSourceName.value)) : currentScenarioName.value,
-);
-const titleBarSupportingText = computed(() =>
-  drilledSourceName.value ? currentScenarioName.value : '',
-);
-const titleBarBackText = computed(() => (drilledSourceName.value ? 'Scenario' : ''));
-const titleBarCollapseAnchor = computed(() => (drilledSourceName.value ? 'ds-drill-anchor' : ''));
+// The title bar is a static "Scenario"; the readable scenario name lives as
+// an nldd-title at the top of the section content instead (so it can't get
+// truncated). The back button only appears when drilled into a data source
+// — its label is the scenario name as the accessible "back to" target.
+const titleBarBackText = computed(() => (drilledSourceName.value ? currentScenarioName.value : ''));
 
 function onTitleBack() {
   const idx = selectedScenarioIndex.value;
@@ -345,15 +336,20 @@ async function onSaveAndShow() {
 }
 
 function cancelEdits() {
-  // Discard edits by re-parsing the last-loaded feature text into formState.
+  // Only discard when there were actual edits. Re-parsing/replacing
+  // formState otherwise needlessly remounts the whole overview — clearing
+  // cached results/refs (via the formState watcher) and resetting the
+  // pane's scroll position — just from opening and closing a scenario.
   // Each ScenarioForm's deep watcher resets its local inputs when its
   // `scenario`/`setup` props are replaced.
-  const text = featureText.value;
-  if (text) {
-    try {
-      const parsed = parseFeature(text);
-      formState.value = mapFeatureToForm(parsed);
-    } catch { /* keep the previous state */ }
+  if (isDirty.value) {
+    const text = featureText.value;
+    if (text) {
+      try {
+        const parsed = parseFeature(text);
+        formState.value = mapFeatureToForm(parsed);
+      } catch { /* keep the previous state */ }
+    }
   }
   isDirty.value = false;
   selectedScenarioIndex.value = null;
@@ -450,15 +446,17 @@ defineExpose({ save: onSave });
       <nldd-page sticky-header :sticky-footer="isDirty || undefined">
         <nldd-top-title-bar
           slot="header"
-          :text="titleBarText"
-          :supporting-text="titleBarSupportingText"
+          text="Scenario"
           :back-text="titleBarBackText"
-          :collapse-anchor="titleBarCollapseAnchor"
           dismiss-text="Annuleer"
           @back="onTitleBack"
           @dismiss="cancelEdits"
         ></nldd-top-title-bar>
         <nldd-simple-section>
+          <template v-if="!drilledSourceName">
+            <nldd-title size="4"><h2>{{ currentScenarioName }}</h2></nldd-title>
+            <nldd-spacer size="24"></nldd-spacer>
+          </template>
           <ScenarioForm
             v-for="(scenario, i) in formState.scenarios"
             v-show="selectedScenarioIndex === i"

--- a/frontend/src/components/ScenarioBuilder.vue
+++ b/frontend/src/components/ScenarioBuilder.vue
@@ -284,8 +284,10 @@ function onShowDetails(index, view = 'trace') {
 }
 
 // Re-run a scenario from the result sheet's reload action, then refresh the
-// sheet with the fresh outcome. execute() is synchronous, so the data is
-// ready by the time onShowDetails reads it back.
+// sheet with the fresh outcome. ScenarioForm.execute() runs the WASM engine
+// in-process and synchronously (no API call, no await; `running` is reset in
+// its finally before it returns), so the result/error is already set by the
+// time onShowDetails reads it back via getExecutionData().
 function reExecute(index) {
   const formRef = scenarioRefs.value[index];
   if (formRef?.execute) formRef.execute();

--- a/frontend/src/components/ScenarioBuilder.vue
+++ b/frontend/src/components/ScenarioBuilder.vue
@@ -55,15 +55,15 @@ const scenarioSheetEl = ref(null);
 const drilledSourceName = ref(null);
 
 watch(selectedScenarioIndex, async (idx) => {
-  // Opening / switching a scenario always lands on its overview.
+  // Opening / switching a scenario always lands on its overview. Reset every
+  // form's drill state so at most one drilled DataSourceTable exists at a
+  // time — its heading carries the constant `ds-drill-anchor` id used as the
+  // top-title-bar collapse anchor, so a second one would duplicate the id.
   drilledSourceName.value = null;
   await nextTick();
-  if (idx !== null) {
-    scenarioRefs.value[idx]?.clearDrill?.();
-    scenarioSheetEl.value?.show();
-  } else {
-    scenarioSheetEl.value?.hide();
-  }
+  scenarioRefs.value.forEach((f) => f?.clearDrill?.());
+  if (idx !== null) scenarioSheetEl.value?.show();
+  else scenarioSheetEl.value?.hide();
 });
 
 const currentScenarioName = computed(() =>
@@ -71,10 +71,19 @@ const currentScenarioName = computed(() =>
     ? formState.value?.scenarios?.[selectedScenarioIndex.value]?.name ?? ''
     : '',
 );
-// Drilled in: title = source name, back button → scenario overview.
-// Otherwise: title = scenario name, no back button (empty back-text hides it).
-const titleBarText = computed(() => drilledSourceName.value ?? currentScenarioName.value);
+// Drilled in: title = humanised source name, scenario name as supporting
+// text, and a back button to the scenario overview. The collapse-anchor
+// keeps the bar non-compact (full text back button) until the user scrolls
+// past the table heading, then it compacts to show title + supporting text.
+// Overview: title = scenario name, no back button (empty back-text hides it).
+const titleBarText = computed(() =>
+  drilledSourceName.value ? humanize(drilledSourceName.value) : currentScenarioName.value,
+);
+const titleBarSupportingText = computed(() =>
+  drilledSourceName.value ? currentScenarioName.value : '',
+);
 const titleBarBackText = computed(() => (drilledSourceName.value ? currentScenarioName.value : ''));
+const titleBarCollapseAnchor = computed(() => (drilledSourceName.value ? 'ds-drill-anchor' : ''));
 
 function onTitleBack() {
   const idx = selectedScenarioIndex.value;
@@ -425,7 +434,9 @@ defineExpose({ save: onSave });
         <nldd-top-title-bar
           slot="header"
           :text="titleBarText"
+          :supporting-text="titleBarSupportingText"
           :back-text="titleBarBackText"
+          :collapse-anchor="titleBarCollapseAnchor"
           dismiss-text="Annuleer"
           @back="onTitleBack"
           @dismiss="cancelEdits"

--- a/frontend/src/components/ScenarioBuilder.vue
+++ b/frontend/src/components/ScenarioBuilder.vue
@@ -394,7 +394,6 @@ defineExpose({ save: onSave });
       ref="scenarioSheetEl"
       placement="right"
       width="640px"
-      full-height
       @close="cancelEdits"
     >
       <nldd-page sticky-header :sticky-footer="isDirty || undefined">

--- a/frontend/src/components/ScenarioBuilder.vue
+++ b/frontend/src/components/ScenarioBuilder.vue
@@ -55,10 +55,8 @@ const scenarioSheetEl = ref(null);
 const drilledSourceName = ref(null);
 
 watch(selectedScenarioIndex, async (idx) => {
-  // Opening / switching a scenario always lands on its overview. Reset every
-  // form's drill state so at most one drilled DataSourceTable exists at a
-  // time — its heading carries the constant `ds-drill-anchor` id used as the
-  // top-title-bar collapse anchor, so a second one would duplicate the id.
+  // Opening / switching a scenario always lands on its overview, so reset
+  // every form's drill state (only the active form can be drilled into).
   drilledSourceName.value = null;
   await nextTick();
   scenarioRefs.value.forEach((f) => f?.clearDrill?.());

--- a/frontend/src/components/ScenarioBuilder.vue
+++ b/frontend/src/components/ScenarioBuilder.vue
@@ -253,20 +253,36 @@ function onShowDetails(index, view = 'trace') {
   const fresh = formRef?.getExecutionData?.();
   const hasFresh = fresh && (fresh.result || fresh.traceText || fresh.error);
   const data = hasFresh ? fresh : scenarioResults.value.get(index);
-  if (data) {
-    const scenarioName = formState.value?.scenarios[index]?.name || '';
-    emit('executed', {
-      result: data.result,
-      traceText: data.traceText,
-      error: data.error,
-      expectations: data.expectations || {},
-      scenarioName,
-      // Forward the scenario's entry output so the graph view can pin
-      // its "▶ start" marker to the right output leaf.
-      outputName: data.outputName || null,
-      view,
-    });
-  }
+  const scenarioName = formState.value?.scenarios[index]?.name || '';
+  // Always emit so the sheet opens: the result sheet itself handles the
+  // loading / error (with reload) / empty states instead of the button
+  // being a dead gate.
+  emit('executed', {
+    result: data?.result || null,
+    traceText: data?.traceText || null,
+    error: data?.error || null,
+    running: !!fresh?.running,
+    expectations: data?.expectations || {},
+    scenarioName,
+    // Forward the scenario's entry output so the graph view can pin
+    // its "▶ start" marker to the right output leaf.
+    outputName: data?.outputName || null,
+    index,
+    // Bound to this builder + scenario so the result sheet's reload
+    // action re-runs exactly the right scenario regardless of how many
+    // ScenarioBuilder instances (panes) exist.
+    reload: () => reExecute(index),
+    view,
+  });
+}
+
+// Re-run a scenario from the result sheet's reload action, then refresh the
+// sheet with the fresh outcome. execute() is synchronous, so the data is
+// ready by the time onShowDetails reads it back.
+function reExecute(index) {
+  const formRef = scenarioRefs.value[index];
+  if (formRef?.execute) formRef.execute();
+  onShowDetails(index);
 }
 
 // Memoized setup per scenario (avoids new object on every render)

--- a/frontend/src/components/ScenarioBuilder.vue
+++ b/frontend/src/components/ScenarioBuilder.vue
@@ -360,7 +360,7 @@ defineExpose({ save: onSave });
               <nldd-button-group orientation="horizontal">
                 <nldd-button
                   :disabled="!scenarioResults.get(i) || undefined"
-                  text="Toon resultaat"
+                  text="Resultaat"
                   @click="onShowDetails(i, 'trace')"
                 ></nldd-button>
                 <nldd-button

--- a/frontend/src/components/ScenarioBuilder.vue
+++ b/frontend/src/components/ScenarioBuilder.vue
@@ -71,12 +71,6 @@ const currentScenarioName = computed(() =>
     ? formState.value?.scenarios?.[selectedScenarioIndex.value]?.name ?? ''
     : '',
 );
-// The title bar is a static "Scenario"; the readable scenario name lives as
-// an nldd-title at the top of the section content instead (so it can't get
-// truncated). The back button only appears when drilled into a data source
-// — its label is the scenario name as the accessible "back to" target.
-const titleBarBackText = computed(() => (drilledSourceName.value ? currentScenarioName.value : ''));
-
 function onTitleBack() {
   const idx = selectedScenarioIndex.value;
   if (idx !== null) scenarioRefs.value[idx]?.clearDrill?.();
@@ -444,17 +438,29 @@ defineExpose({ save: onSave });
       @close="cancelEdits"
     >
       <nldd-page sticky-header :sticky-footer="isDirty || undefined">
+        <!-- Overview header: scenario name (revealed in the bar on scroll
+             via the content-title anchor), no back. -->
         <nldd-top-title-bar
+          v-if="!drilledSourceName"
           slot="header"
-          text="Scenario"
-          :back-text="titleBarBackText"
+          :text="currentScenarioName"
+          collapse-anchor="scenario-title-anchor"
+          dismiss-text="Annuleer"
+          @dismiss="cancelEdits"
+        ></nldd-top-title-bar>
+        <!-- Drilled-in header: its own bar — a back button to the scenario
+             overview (the data-source heading lives in the content). -->
+        <nldd-top-title-bar
+          v-else
+          slot="header"
+          :back-text="currentScenarioName"
           dismiss-text="Annuleer"
           @back="onTitleBack"
           @dismiss="cancelEdits"
         ></nldd-top-title-bar>
         <nldd-simple-section>
           <template v-if="!drilledSourceName">
-            <nldd-title size="4"><h2>{{ currentScenarioName }}</h2></nldd-title>
+            <nldd-title id="scenario-title-anchor" size="4"><h2>{{ currentScenarioName }}</h2></nldd-title>
             <nldd-spacer size="24"></nldd-spacer>
           </template>
           <ScenarioForm

--- a/frontend/src/components/ScenarioBuilder.vue
+++ b/frontend/src/components/ScenarioBuilder.vue
@@ -62,9 +62,31 @@ watch(selectedScenarioIndex, async (idx) => {
   drilledSourceName.value = null;
   await nextTick();
   scenarioRefs.value.forEach((f) => f?.clearDrill?.());
-  if (idx !== null) scenarioSheetEl.value?.show();
-  else scenarioSheetEl.value?.hide();
+  if (idx !== null) {
+    // Baseline the editable state so Save can disappear again once the
+    // user manually reverts every change (markDirty re-compares).
+    dirtyBaseline = editSnapshot();
+    isDirty.value = false;
+    scenarioSheetEl.value?.show();
+  } else {
+    scenarioSheetEl.value?.hide();
+  }
 });
+
+// Serialised editable surface: the (in-place edited) scenario objects plus
+// each ScenarioForm's local input values. Compared against the baseline so
+// reverting an edit clears the dirty state.
+let dirtyBaseline = '';
+function editSnapshot() {
+  try {
+    return JSON.stringify({
+      s: formState.value?.scenarios ?? null,
+      f: scenarioRefs.value.map((r) => (r?.getFormValues ? r.getFormValues() : null)),
+    });
+  } catch {
+    return `dirty-${Date.now()}`;
+  }
+}
 
 const currentScenarioName = computed(() =>
   selectedScenarioIndex.value !== null
@@ -79,7 +101,7 @@ function onTitleBack() {
 watch(isDirty, (val) => emit('dirty-change', val));
 
 function markDirty() {
-  if (!isDirty.value) isDirty.value = true;
+  isDirty.value = editSnapshot() !== dirtyBaseline;
 }
 
 function scenarioExpectations(index) {

--- a/frontend/src/components/ScenarioBuilder.vue
+++ b/frontend/src/components/ScenarioBuilder.vue
@@ -49,11 +49,37 @@ const isDirty = ref(false);
 const selectedScenarioIndex = ref(null);
 const scenarioSheetEl = ref(null);
 
+// Name of the data source the active ScenarioForm is drilled into (null =
+// scenario overview). Reported by ScenarioForm via @drill-change; the
+// top-title-bar back button uses it to pop one level back out.
+const drilledSourceName = ref(null);
+
 watch(selectedScenarioIndex, async (idx) => {
+  // Opening / switching a scenario always lands on its overview.
+  drilledSourceName.value = null;
   await nextTick();
-  if (idx !== null) scenarioSheetEl.value?.show();
-  else scenarioSheetEl.value?.hide();
+  if (idx !== null) {
+    scenarioRefs.value[idx]?.clearDrill?.();
+    scenarioSheetEl.value?.show();
+  } else {
+    scenarioSheetEl.value?.hide();
+  }
 });
+
+const currentScenarioName = computed(() =>
+  selectedScenarioIndex.value !== null
+    ? formState.value?.scenarios?.[selectedScenarioIndex.value]?.name ?? ''
+    : '',
+);
+// Drilled in: title = source name, back button → scenario overview.
+// Otherwise: title = scenario name, no back button (empty back-text hides it).
+const titleBarText = computed(() => drilledSourceName.value ?? currentScenarioName.value);
+const titleBarBackText = computed(() => (drilledSourceName.value ? currentScenarioName.value : ''));
+
+function onTitleBack() {
+  const idx = selectedScenarioIndex.value;
+  if (idx !== null) scenarioRefs.value[idx]?.clearDrill?.();
+}
 
 watch(isDirty, (val) => emit('dirty-change', val));
 
@@ -398,8 +424,10 @@ defineExpose({ save: onSave });
       <nldd-page sticky-header :sticky-footer="isDirty || undefined">
         <nldd-top-title-bar
           slot="header"
-          :text="selectedScenarioIndex !== null ? formState.scenarios[selectedScenarioIndex].name : ''"
+          :text="titleBarText"
+          :back-text="titleBarBackText"
           dismiss-text="Annuleer"
+          @back="onTitleBack"
           @dismiss="cancelEdits"
         ></nldd-top-title-bar>
         <nldd-simple-section>
@@ -417,6 +445,7 @@ defineExpose({ save: onSave });
             @show-details="() => onShowDetails(i)"
             @executed="(data) => onScenarioResult(i, data)"
             @change="markDirty"
+            @drill-change="(name) => { if (selectedScenarioIndex === i) drilledSourceName = name; }"
           />
         </nldd-simple-section>
         <nldd-container v-if="isDirty" slot="footer" padding="16">

--- a/frontend/src/components/ScenarioForm.vue
+++ b/frontend/src/components/ScenarioForm.vue
@@ -55,6 +55,13 @@ function clearDrill() {
   selectedSource.value = null;
 }
 
+// Data-source names render human-readable AND sentence-cased ("personal_data"
+// → "Personal data"). humanize() only de-snakes; it doesn't capitalise.
+function sourceLabel(name) {
+  const h = humanize(name);
+  return h ? h.charAt(0).toUpperCase() + h.slice(1) : h;
+}
+
 watch(selectedSource, (idx) => {
   emit('drill-change', idx == null ? null : (dataSources.value[idx]?.sourceName ?? null));
 });
@@ -295,7 +302,7 @@ const hasExpectations = computed(() => Object.keys(expectations.value).length > 
           :data-testid="`ds-row-${i}`"
           @click="selectedSource = i"
         >
-          <nldd-text-cell :text="humanize(ds.sourceName)"></nldd-text-cell>
+          <nldd-text-cell :text="sourceLabel(ds.sourceName)"></nldd-text-cell>
           <nldd-spacer-cell size="12"></nldd-spacer-cell>
           <nldd-text-cell horizontal-alignment="right" :text="ds.rows.length ? String(ds.rows.length) : ''"></nldd-text-cell>
           <nldd-spacer-cell size="12"></nldd-spacer-cell>
@@ -310,7 +317,8 @@ const hasExpectations = computed(() => Object.keys(expectations.value).length > 
     <template v-else>
       <DataSourceTable
         :key="dataSources[selectedSource].sourceName"
-        :title="humanize(dataSources[selectedSource].sourceName)"
+        :title="sourceLabel(dataSources[selectedSource].sourceName)"
+        :subtitle="scenario.name"
         :key-field="dataSources[selectedSource].keyField"
         :fields="dataSources[selectedSource].fields"
         :model-value="dataSources[selectedSource].rows"

--- a/frontend/src/components/ScenarioForm.vue
+++ b/frontend/src/components/ScenarioForm.vue
@@ -346,12 +346,6 @@ const hasExpectations = computed(() => Object.keys(expectations.value).length > 
   margin-top: 0;
 }
 
-/* Expected outputs — single continuous block with left border */
-/* DataSourceTable blocks get the same top spacing as section titles */
-.sf-form :deep(.ds-block) {
-  margin-top: 16px;
-}
-
 .sf-running {
   font-size: 12px;
   color: var(--semantics-text-color-secondary, #666);

--- a/frontend/src/components/ScenarioForm.vue
+++ b/frontend/src/components/ScenarioForm.vue
@@ -234,17 +234,13 @@ function matchStatus(outputName, actualValue) {
 
 const hasExpectations = computed(() => Object.keys(expectations.value).length > 0);
 
-// Minimal field-level validation: an empty/unparseable date, or the
-// "Variable not found: <name>" engine error, is mapped back onto the
-// offending input so the user sees which field is wrong (the raw engine
-// message still shows as context). No auto-revert — the input stays.
-const dateInvalid = computed(
-  () => !calculationDate.value || /date/i.test(error.value || ''),
-);
-const missingVar = computed(() => {
-  const m = /Variable not found:\s*(\S+)/i.exec(error.value || '');
-  return m ? m[1] : null;
-});
+// Minimal field-level validation: a missing date, or an empty input that
+// caused an execution error, is marked invalid so the user sees which
+// field to fill (the raw engine message still shows as context). No
+// auto-revert — the input stays. We deliberately do NOT map engine error
+// strings onto data-source columns: that produced confusing cross-field
+// invalid states (e.g. changing bsn flagged loon_uit_dienstbetrekking).
+const dateInvalid = computed(() => !calculationDate.value);
 </script>
 
 <template>
@@ -301,7 +297,7 @@ const missingVar = computed(() => {
           <nldd-cell width="full" min-width="120px">
             <nldd-text-field
               size="md"
-              :invalid="missingVar === name || undefined"
+              :invalid="(!!error && (value === '' || value == null)) || undefined"
               :value="value"
               @input="parameterValues = { ...parameterValues, [name]: $event.target?.value ?? $event.detail?.value ?? '' }; emit('change')"
             ></nldd-text-field>

--- a/frontend/src/components/ScenarioForm.vue
+++ b/frontend/src/components/ScenarioForm.vue
@@ -92,8 +92,12 @@ const running = ref(false);
 const error = ref(null);
 const errorTraceText = ref(null);
 
-// Re-init when scenario/setup changes
-watch([() => props.setup, () => props.scenario], () => {
+// Re-initialise every local input/result ref from the (read-only) props.
+// All edits live in these refs and are only written back to formState on
+// save, so re-initialising here fully discards unsaved edits. Used both
+// when the scenario/setup props change and when the parent discards edits
+// (cancel / click-away) without replacing formState — see ScenarioBuilder.
+function discardEdits() {
   calculationDate.value = props.setup.calculationDate || new Date().toISOString().slice(0, 10);
   parameterValues.value = Object.fromEntries(
     (props.setup.parameters || []).map((p) => [p.name, p.value ?? '']),
@@ -109,7 +113,10 @@ watch([() => props.setup, () => props.scenario], () => {
   result.value = null;
   error.value = null;
   errorTraceText.value = null;
-}, { deep: true });
+}
+
+// Re-init when scenario/setup changes
+watch([() => props.setup, () => props.scenario], discardEdits, { deep: true });
 
 function execute() {
   if (!props.engine || !props.ready) return;
@@ -202,7 +209,7 @@ function getFormValues() {
   };
 }
 
-defineExpose({ execute, getExecutionData, getFormValues, clearDrill });
+defineExpose({ execute, getExecutionData, getFormValues, clearDrill, discardEdits });
 
 // --- Auto-re-execute when input values change ---
 let executeTimer = null;

--- a/frontend/src/components/ScenarioForm.vue
+++ b/frontend/src/components/ScenarioForm.vue
@@ -118,6 +118,14 @@ function discardEdits() {
 // Re-init when scenario/setup changes
 watch([() => props.setup, () => props.scenario], discardEdits, { deep: true });
 
+// CONTRACT: execute() must stay fully synchronous. The WASM engine runs
+// in-process with no I/O, so `result`/`error`/`running` are all settled
+// (running reset in finally) before this returns, and callers read them
+// back immediately from the return value or getExecutionData() — e.g.
+// ScenarioBuilder.reExecute() / onSaveAndShow() and the auto-execute
+// loop. Introducing any await/timer/microtask here would make those
+// callers observe `running: true` and stale data. If async execution is
+// ever needed, return a Promise and update every caller to await it.
 function execute() {
   if (!props.engine || !props.ready) return;
 

--- a/frontend/src/components/ScenarioForm.vue
+++ b/frontend/src/components/ScenarioForm.vue
@@ -277,16 +277,16 @@ const hasExpectations = computed(() => Object.keys(expectations.value).length > 
       <nldd-spacer size="12"></nldd-spacer>
       <nldd-list variant="box">
         <nldd-list-item size="md">
-          <nldd-text-cell text="Datum" min-width="120px" max-width="280px"></nldd-text-cell>
+          <nldd-text-cell text="Datum" min-width="120px" max-width="200px"></nldd-text-cell>
           <nldd-spacer-cell size="8"></nldd-spacer-cell>
-          <nldd-cell width="full" min-width="120px" max-width="280px">
+          <nldd-cell width="full" min-width="120px">
             <nldd-text-field size="md" type="date" :value="calculationDate" @input="calculationDate = $event.target?.value ?? $event.detail?.value ?? calculationDate; emit('change')"></nldd-text-field>
           </nldd-cell>
         </nldd-list-item>
         <nldd-list-item v-for="(value, name) in parameterValues" :key="name" size="md">
-          <nldd-text-cell :text="articleMap?.paramToArticle?.get(name) ? `${name} (Art. ${articleMap.paramToArticle.get(name)})` : name" min-width="120px" max-width="280px"></nldd-text-cell>
+          <nldd-text-cell :text="articleMap?.paramToArticle?.get(name) ? `${name} (Art. ${articleMap.paramToArticle.get(name)})` : name" min-width="120px" max-width="200px"></nldd-text-cell>
           <nldd-spacer-cell size="8"></nldd-spacer-cell>
-          <nldd-cell width="full" min-width="120px" max-width="280px">
+          <nldd-cell width="full" min-width="120px">
             <nldd-text-field
               size="md"
               :value="value"

--- a/frontend/src/components/ScenarioForm.vue
+++ b/frontend/src/components/ScenarioForm.vue
@@ -235,12 +235,12 @@ const hasExpectations = computed(() => Object.keys(expectations.value).length > 
 </script>
 
 <template>
-  <div class="sf-form">
+  <div>
     <!-- Scenario overview -->
     <template v-if="selectedSource === null">
       <!-- Expected outputs -->
       <template v-if="hasExpectations">
-        <nldd-title size="5" class="sf-section-title"><span>Verwachte uitkomsten</span></nldd-title>
+        <nldd-title size="5"><h2>Verwachte uitkomsten</h2></nldd-title>
         <nldd-spacer size="4"></nldd-spacer>
         <nldd-list variant="box">
           <nldd-list-item v-for="(exp, name) in expectations" :key="name" size="md">
@@ -258,7 +258,6 @@ const hasExpectations = computed(() => Object.keys(expectations.value).length > 
           @click="emit('show-details')"
           text="Resultaat"
         ></nldd-button>
-        <nldd-spacer size="16"></nldd-spacer>
       </template>
 
       <!-- Error -->
@@ -268,7 +267,9 @@ const hasExpectations = computed(() => Object.keys(expectations.value).length > 
       <div v-if="running" class="sf-running">Uitvoeren...</div>
 
       <!-- Input: date + parameters -->
-      <nldd-title size="5" class="sf-section-title"><span>Invoer</span></nldd-title>
+      <nldd-spacer v-if="hasExpectations" size="16"></nldd-spacer>
+      <nldd-title size="5"><h2>Invoer</h2></nldd-title>
+      <nldd-spacer size="4"></nldd-spacer>
       <nldd-list variant="box" class="sf-input-list">
         <nldd-list-item size="md">
           <nldd-text-cell text="Datum" max-width="280px"></nldd-text-cell>
@@ -292,7 +293,9 @@ const hasExpectations = computed(() => Object.keys(expectations.value).length > 
       </nldd-list>
 
       <!-- Data sources: a row per source, drill in one level deeper -->
-      <nldd-title size="5" class="sf-section-title"><span>Gegevensbronnen</span></nldd-title>
+      <nldd-spacer size="16"></nldd-spacer>
+      <nldd-title size="5"><h2>Gegevensbronnen</h2></nldd-title>
+      <nldd-spacer size="4"></nldd-spacer>
       <nldd-list variant="box">
         <nldd-list-item
           v-for="(ds, i) in dataSources"
@@ -332,20 +335,6 @@ const hasExpectations = computed(() => Object.keys(expectations.value).length > 
 </template>
 
 <style scoped>
-.sf-form {
-  font-family: var(--primitives-font-family-body, 'RijksSansVF', sans-serif);
-}
-
-/* Section titles — extra top margin separates each block visually.
- * The first section title doesn't need top margin (handled by :first-child). */
-.sf-section-title {
-  margin-top: 16px;
-  margin-bottom: 4px;
-}
-.sf-section-title:first-child {
-  margin-top: 0;
-}
-
 .sf-running {
   font-size: 12px;
   color: var(--semantics-text-color-secondary, #666);

--- a/frontend/src/components/ScenarioForm.vue
+++ b/frontend/src/components/ScenarioForm.vue
@@ -242,7 +242,7 @@ const hasExpectations = computed(() => Object.keys(expectations.value).length > 
       <!-- Expected outputs -->
       <template v-if="hasExpectations">
         <nldd-title size="5"><h2>Verwachte uitkomsten</h2></nldd-title>
-        <nldd-spacer size="12"></nldd-spacer>
+        <nldd-spacer size="8"></nldd-spacer>
         <nldd-list variant="box">
           <nldd-list-item v-for="(exp, name) in expectations" :key="name" size="md">
             <nldd-text-cell size="md" :text="humanize(name)"></nldd-text-cell>
@@ -272,9 +272,9 @@ const hasExpectations = computed(() => Object.keys(expectations.value).length > 
       <div v-if="running" class="sf-running">Uitvoeren...</div>
 
       <!-- Input: date + parameters -->
-      <nldd-spacer v-if="hasExpectations" size="24"></nldd-spacer>
+      <nldd-spacer v-if="hasExpectations" size="16"></nldd-spacer>
       <nldd-title size="5"><h2>Invoer</h2></nldd-title>
-      <nldd-spacer size="12"></nldd-spacer>
+      <nldd-spacer size="8"></nldd-spacer>
       <nldd-list variant="box">
         <nldd-list-item size="md">
           <nldd-text-cell text="Datum" min-width="120px" max-width="200px"></nldd-text-cell>
@@ -298,9 +298,9 @@ const hasExpectations = computed(() => Object.keys(expectations.value).length > 
       </nldd-list>
 
       <!-- Data sources: a row per source, drill in one level deeper -->
-      <nldd-spacer size="24"></nldd-spacer>
+      <nldd-spacer size="16"></nldd-spacer>
       <nldd-title size="5"><h2>Bronnen</h2></nldd-title>
-      <nldd-spacer size="12"></nldd-spacer>
+      <nldd-spacer size="8"></nldd-spacer>
       <nldd-list variant="box">
         <nldd-list-item
           v-for="(ds, i) in dataSources"

--- a/frontend/src/components/ScenarioForm.vue
+++ b/frontend/src/components/ScenarioForm.vue
@@ -240,16 +240,7 @@ const hasExpectations = computed(() => Object.keys(expectations.value).length > 
     <template v-if="selectedSource === null">
       <!-- Expected outputs -->
       <template v-if="hasExpectations">
-        <nldd-title size="5">
-          <h2>Verwachte uitkomsten</h2>
-          <nldd-button
-            slot="actions"
-            size="xs"
-            :disabled="!result && !error || undefined"
-            @click="emit('show-details')"
-            text="Resultaat"
-          ></nldd-button>
-        </nldd-title>
+        <nldd-title size="5"><h2>Verwachte uitkomsten</h2></nldd-title>
         <nldd-spacer size="12"></nldd-spacer>
         <nldd-list variant="box">
           <nldd-list-item v-for="(exp, name) in expectations" :key="name" size="md">
@@ -259,6 +250,17 @@ const hasExpectations = computed(() => Object.keys(expectations.value).length > 
               horizontal-alignment="right"
               :text="humanize(formatValue(normalizeForCompare(exp)))"
             ></nldd-text-cell>
+          </nldd-list-item>
+          <nldd-list-item size="md">
+            <nldd-cell width="full">
+              <nldd-button
+                size="md"
+                width="full"
+                :disabled="!result && !error || undefined"
+                @click="emit('show-details')"
+                text="Bekijk resultaat"
+              ></nldd-button>
+            </nldd-cell>
           </nldd-list-item>
         </nldd-list>
       </template>
@@ -273,18 +275,18 @@ const hasExpectations = computed(() => Object.keys(expectations.value).length > 
       <nldd-spacer v-if="hasExpectations" size="24"></nldd-spacer>
       <nldd-title size="5"><h2>Invoer</h2></nldd-title>
       <nldd-spacer size="12"></nldd-spacer>
-      <nldd-list variant="box" class="sf-input-list">
+      <nldd-list variant="box">
         <nldd-list-item size="md">
-          <nldd-text-cell text="Datum" max-width="280px"></nldd-text-cell>
+          <nldd-text-cell text="Datum" min-width="140px" max-width="280px"></nldd-text-cell>
           <nldd-spacer-cell size="8"></nldd-spacer-cell>
-          <nldd-cell>
+          <nldd-cell width="full" max-width="280px">
             <nldd-text-field size="md" type="date" :value="calculationDate" @input="calculationDate = $event.target?.value ?? $event.detail?.value ?? calculationDate; emit('change')"></nldd-text-field>
           </nldd-cell>
         </nldd-list-item>
         <nldd-list-item v-for="(value, name) in parameterValues" :key="name" size="md">
-          <nldd-text-cell :text="articleMap?.paramToArticle?.get(name) ? `${name} (Art. ${articleMap.paramToArticle.get(name)})` : name" max-width="280px"></nldd-text-cell>
+          <nldd-text-cell :text="articleMap?.paramToArticle?.get(name) ? `${name} (Art. ${articleMap.paramToArticle.get(name)})` : name" min-width="140px" max-width="280px"></nldd-text-cell>
           <nldd-spacer-cell size="8"></nldd-spacer-cell>
-          <nldd-cell>
+          <nldd-cell width="full" max-width="280px">
             <nldd-text-field
               size="md"
               :value="value"
@@ -350,23 +352,5 @@ const hasExpectations = computed(() => Object.keys(expectations.value).length > 
   color: #c00;
   word-break: break-word;
   padding: 4px 0;
-}
-</style>
-
-<style>
-/* Unscoped: nldd web components need global selectors */
-.sf-input-list nldd-text-cell {
-  min-width: 140px;
-  flex: 1;
-}
-
-.sf-input-list nldd-cell {
-  flex: 1;
-  min-width: 0;
-  max-width: 280px;
-}
-
-.sf-input-list nldd-text-field {
-  width: 100%;
 }
 </style>

--- a/frontend/src/components/ScenarioForm.vue
+++ b/frontend/src/components/ScenarioForm.vue
@@ -299,7 +299,7 @@ const hasExpectations = computed(() => Object.keys(expectations.value).length > 
 
       <!-- Data sources: a row per source, drill in one level deeper -->
       <nldd-spacer size="24"></nldd-spacer>
-      <nldd-title size="5"><h2>Gegevensbronnen</h2></nldd-title>
+      <nldd-title size="5"><h2>Bronnen</h2></nldd-title>
       <nldd-spacer size="12"></nldd-spacer>
       <nldd-list variant="box">
         <nldd-list-item

--- a/frontend/src/components/ScenarioForm.vue
+++ b/frontend/src/components/ScenarioForm.vue
@@ -244,7 +244,7 @@ const hasExpectations = computed(() => Object.keys(expectations.value).length > 
           <h2>Verwachte uitkomsten</h2>
           <nldd-button
             slot="actions"
-            size="sm"
+            size="xs"
             :disabled="!result && !error || undefined"
             @click="emit('show-details')"
             text="Resultaat"

--- a/frontend/src/components/ScenarioForm.vue
+++ b/frontend/src/components/ScenarioForm.vue
@@ -342,7 +342,6 @@ const dateErrorId = useId();
         :fields="dataSources[selectedSource].fields"
         :model-value="dataSources[selectedSource].rows"
         :drilled-in="true"
-        anchor-id="ds-drill-anchor"
         @update:model-value="updateDataSourceRows(selectedSource, $event)"
       />
     </template>

--- a/frontend/src/components/ScenarioForm.vue
+++ b/frontend/src/components/ScenarioForm.vue
@@ -258,8 +258,12 @@ const hasExpectations = computed(() => Object.keys(expectations.value).length > 
 // caused an execution error, is marked invalid so the user sees which
 // field to fill (the raw engine message still shows as context). No
 // auto-revert — the input stays. We deliberately do NOT map engine error
-// strings onto data-source columns: that produced confusing cross-field
-// invalid states (e.g. changing bsn flagged loon_uit_dienstbetrekking).
+// strings onto fields (incl. substring-matching the error against a param
+// name): that produced confusing cross-field invalid states (changing bsn
+// flagged loon_uit_dienstbetrekking) and was explicitly reverted. The
+// broad "any error + this field empty" mark is the accepted trade — it
+// can over-mark a legitimately-blank optional param, but it never
+// mis-points at an unrelated field, which was the worse failure.
 const dateInvalid = computed(() => !calculationDate.value);
 // Unique id so the inline message can be aria-associated with the field
 // (ScenarioForm is mounted once per scenario, so a static id would clash).

--- a/frontend/src/components/ScenarioForm.vue
+++ b/frontend/src/components/ScenarioForm.vue
@@ -326,7 +326,6 @@ const hasExpectations = computed(() => Object.keys(expectations.value).length > 
       <DataSourceTable
         :key="dataSources[selectedSource].sourceName"
         :title="sourceLabel(dataSources[selectedSource].sourceName)"
-        :subtitle="scenario.name"
         :key-field="dataSources[selectedSource].keyField"
         :fields="dataSources[selectedSource].fields"
         :model-value="dataSources[selectedSource].rows"

--- a/frontend/src/components/ScenarioForm.vue
+++ b/frontend/src/components/ScenarioForm.vue
@@ -183,6 +183,7 @@ function getExecutionData() {
     result: result.value,
     traceText: result.value?.trace_text || errorTraceText.value || null,
     error: error.value,
+    running: running.value,
     expectations: expectations.value,
     // Expose the scenario's entry output so the graph view can mark the
     // starting leaf (see useTraceStepping.startNodeIds).
@@ -256,7 +257,6 @@ const hasExpectations = computed(() => Object.keys(expectations.value).length > 
               <nldd-button
                 size="md"
                 width="full"
-                :disabled="!result && !error || undefined"
                 @click="emit('show-details')"
                 text="Bekijk resultaat"
               ></nldd-button>

--- a/frontend/src/components/ScenarioForm.vue
+++ b/frontend/src/components/ScenarioForm.vue
@@ -19,7 +19,7 @@ const props = defineProps({
   articleMap: { type: Object, default: null },
 });
 
-const emit = defineEmits(['show-details', 'executed', 'change']);
+const emit = defineEmits(['show-details', 'executed', 'change', 'drill-change']);
 
 // --- Form state (initialized from scenario setup) ---
 const calculationDate = ref(props.setup.calculationDate || new Date().toISOString().slice(0, 10));
@@ -45,8 +45,19 @@ function initDataSources() {
 const dataSources = ref(initDataSources());
 
 // Drill-in navigation: null = scenario overview, otherwise the index of the
-// data source whose table is shown one level deeper in the sheet.
+// data source whose table is shown one level deeper in the sheet. The back
+// affordance lives in the sheet's top-title-bar (a single level deep, so the
+// ActionSheet-style breadcrumb rows would be overkill), so the parent needs
+// to know the drilled source name and be able to pop back out.
 const selectedSource = ref(null);
+
+function clearDrill() {
+  selectedSource.value = null;
+}
+
+watch(selectedSource, (idx) => {
+  emit('drill-change', idx == null ? null : (dataSources.value[idx]?.sourceName ?? null));
+});
 
 // Expectations from scenario assertions
 const expectations = ref(
@@ -183,7 +194,7 @@ function getFormValues() {
   };
 }
 
-defineExpose({ execute, getExecutionData, getFormValues });
+defineExpose({ execute, getExecutionData, getFormValues, clearDrill });
 
 // --- Auto-re-execute when input values change ---
 let executeTimer = null;
@@ -293,16 +304,10 @@ const hasExpectations = computed(() => Object.keys(expectations.value).length > 
       </nldd-list>
     </template>
 
-    <!-- One level deeper: a single data source's table + back to scenario -->
+    <!-- One level deeper: a single data source's table. Back to the scenario
+         overview is the sheet's top-title-bar back button (driven by the
+         parent via clearDrill / drill-change). -->
     <template v-else>
-      <nldd-list variant="box">
-        <nldd-list-item size="md" type="button" data-testid="ds-back" @click="selectedSource = null">
-          <nldd-icon-cell size="20"><nldd-icon name="chevron-left"></nldd-icon></nldd-icon-cell>
-          <nldd-spacer-cell size="12"></nldd-spacer-cell>
-          <nldd-text-cell text="Scenario"></nldd-text-cell>
-        </nldd-list-item>
-      </nldd-list>
-      <nldd-spacer size="16"></nldd-spacer>
       <DataSourceTable
         :key="dataSources[selectedSource].sourceName"
         :title="dataSources[selectedSource].sourceName"

--- a/frontend/src/components/ScenarioForm.vue
+++ b/frontend/src/components/ScenarioForm.vue
@@ -231,7 +231,7 @@ const hasExpectations = computed(() => Object.keys(expectations.value).length > 
       <nldd-button
         :disabled="!result && !error || undefined"
         @click="emit('show-details')"
-        text="Toon resultaat"
+        text="Resultaat"
       ></nldd-button>
       <nldd-spacer size="16"></nldd-spacer>
     </template>

--- a/frontend/src/components/ScenarioForm.vue
+++ b/frontend/src/components/ScenarioForm.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed, watch, onBeforeUnmount } from 'vue';
+import { ref, computed, watch, onBeforeUnmount, useId } from 'vue';
 import { parseValue } from '../gherkin/steps.js';
 import { formatValue, formatOutputValue, normalizeForCompare, matchStatus as _matchStatus, humanize } from '../utils/outputFormat.js';
 import DataSourceTable from './DataSourceTable.vue';
@@ -241,6 +241,9 @@ const hasExpectations = computed(() => Object.keys(expectations.value).length > 
 // strings onto data-source columns: that produced confusing cross-field
 // invalid states (e.g. changing bsn flagged loon_uit_dienstbetrekking).
 const dateInvalid = computed(() => !calculationDate.value);
+// Unique id so the inline message can be aria-associated with the field
+// (ScenarioForm is mounted once per scenario, so a static id would clash).
+const dateErrorId = useId();
 </script>
 
 <template>
@@ -288,7 +291,8 @@ const dateInvalid = computed(() => !calculationDate.value);
           <nldd-text-cell text="Datum" min-width="120px" max-width="200px"></nldd-text-cell>
           <nldd-spacer-cell size="8"></nldd-spacer-cell>
           <nldd-cell width="full" min-width="120px">
-            <nldd-text-field size="md" type="date" :invalid="dateInvalid || undefined" :value="calculationDate" @input="calculationDate = $event.target?.value ?? $event.detail?.value ?? calculationDate; emit('change')"></nldd-text-field>
+            <nldd-text-field size="md" type="date" :invalid="dateInvalid || undefined" :error-message-ids="dateInvalid ? dateErrorId : undefined" :value="calculationDate" @input="calculationDate = $event.target?.value ?? $event.detail?.value ?? calculationDate; emit('change')"></nldd-text-field>
+            <span v-if="dateInvalid" :id="dateErrorId" class="sf-error">Datum is verplicht</span>
           </nldd-cell>
         </nldd-list-item>
         <nldd-list-item v-for="(value, name) in parameterValues" :key="name" size="md">

--- a/frontend/src/components/ScenarioForm.vue
+++ b/frontend/src/components/ScenarioForm.vue
@@ -242,7 +242,7 @@ const hasExpectations = computed(() => Object.keys(expectations.value).length > 
       <template v-if="hasExpectations">
         <nldd-title size="5" class="sf-section-title"><span>Verwachte uitkomsten</span></nldd-title>
         <nldd-spacer size="4"></nldd-spacer>
-        <nldd-list variant="simple">
+        <nldd-list variant="box">
           <nldd-list-item v-for="(exp, name) in expectations" :key="name" size="md">
             <nldd-text-cell size="md" :text="humanize(name)"></nldd-text-cell>
             <nldd-text-cell
@@ -271,14 +271,14 @@ const hasExpectations = computed(() => Object.keys(expectations.value).length > 
       <nldd-title size="5" class="sf-section-title"><span>Invoer</span></nldd-title>
       <nldd-list variant="box" class="sf-input-list">
         <nldd-list-item size="md">
-          <nldd-text-cell text="Datum" max-width="140px"></nldd-text-cell>
+          <nldd-text-cell text="Datum" max-width="280px"></nldd-text-cell>
           <nldd-spacer-cell size="8"></nldd-spacer-cell>
           <nldd-cell>
             <nldd-text-field size="md" type="date" :value="calculationDate" @input="calculationDate = $event.target?.value ?? $event.detail?.value ?? calculationDate; emit('change')"></nldd-text-field>
           </nldd-cell>
         </nldd-list-item>
         <nldd-list-item v-for="(value, name) in parameterValues" :key="name" size="md">
-          <nldd-text-cell :text="articleMap?.paramToArticle?.get(name) ? `${name} (Art. ${articleMap.paramToArticle.get(name)})` : name" max-width="140px"></nldd-text-cell>
+          <nldd-text-cell :text="articleMap?.paramToArticle?.get(name) ? `${name} (Art. ${articleMap.paramToArticle.get(name)})` : name" max-width="280px"></nldd-text-cell>
           <nldd-spacer-cell size="8"></nldd-spacer-cell>
           <nldd-cell>
             <nldd-text-field
@@ -370,14 +370,14 @@ const hasExpectations = computed(() => Object.keys(expectations.value).length > 
 <style>
 /* Unscoped: nldd web components need global selectors */
 .sf-input-list nldd-text-cell {
-  width: 140px;
   min-width: 140px;
-  flex-shrink: 0;
+  flex: 1;
 }
 
 .sf-input-list nldd-cell {
   flex: 1;
   min-width: 0;
+  max-width: 280px;
 }
 
 .sf-input-list nldd-text-field {

--- a/frontend/src/components/ScenarioForm.vue
+++ b/frontend/src/components/ScenarioForm.vue
@@ -267,7 +267,7 @@ const hasExpectations = computed(() => Object.keys(expectations.value).length > 
       <div v-if="running" class="sf-running">Uitvoeren...</div>
 
       <!-- Input: date + parameters -->
-      <nldd-spacer v-if="hasExpectations" size="16"></nldd-spacer>
+      <nldd-spacer v-if="hasExpectations" size="24"></nldd-spacer>
       <nldd-title size="5"><h2>Invoer</h2></nldd-title>
       <nldd-spacer size="12"></nldd-spacer>
       <nldd-list variant="box" class="sf-input-list">
@@ -293,7 +293,7 @@ const hasExpectations = computed(() => Object.keys(expectations.value).length > 
       </nldd-list>
 
       <!-- Data sources: a row per source, drill in one level deeper -->
-      <nldd-spacer size="16"></nldd-spacer>
+      <nldd-spacer size="24"></nldd-spacer>
       <nldd-title size="5"><h2>Gegevensbronnen</h2></nldd-title>
       <nldd-spacer size="12"></nldd-spacer>
       <nldd-list variant="box">

--- a/frontend/src/components/ScenarioForm.vue
+++ b/frontend/src/components/ScenarioForm.vue
@@ -241,7 +241,7 @@ const hasExpectations = computed(() => Object.keys(expectations.value).length > 
       <!-- Expected outputs -->
       <template v-if="hasExpectations">
         <nldd-title size="5"><h2>Verwachte uitkomsten</h2></nldd-title>
-        <nldd-spacer size="4"></nldd-spacer>
+        <nldd-spacer size="12"></nldd-spacer>
         <nldd-list variant="box">
           <nldd-list-item v-for="(exp, name) in expectations" :key="name" size="md">
             <nldd-text-cell size="md" :text="humanize(name)"></nldd-text-cell>
@@ -269,7 +269,7 @@ const hasExpectations = computed(() => Object.keys(expectations.value).length > 
       <!-- Input: date + parameters -->
       <nldd-spacer v-if="hasExpectations" size="16"></nldd-spacer>
       <nldd-title size="5"><h2>Invoer</h2></nldd-title>
-      <nldd-spacer size="4"></nldd-spacer>
+      <nldd-spacer size="12"></nldd-spacer>
       <nldd-list variant="box" class="sf-input-list">
         <nldd-list-item size="md">
           <nldd-text-cell text="Datum" max-width="280px"></nldd-text-cell>
@@ -295,7 +295,7 @@ const hasExpectations = computed(() => Object.keys(expectations.value).length > 
       <!-- Data sources: a row per source, drill in one level deeper -->
       <nldd-spacer size="16"></nldd-spacer>
       <nldd-title size="5"><h2>Gegevensbronnen</h2></nldd-title>
-      <nldd-spacer size="4"></nldd-spacer>
+      <nldd-spacer size="12"></nldd-spacer>
       <nldd-list variant="box">
         <nldd-list-item
           v-for="(ds, i) in dataSources"

--- a/frontend/src/components/ScenarioForm.vue
+++ b/frontend/src/components/ScenarioForm.vue
@@ -240,7 +240,16 @@ const hasExpectations = computed(() => Object.keys(expectations.value).length > 
     <template v-if="selectedSource === null">
       <!-- Expected outputs -->
       <template v-if="hasExpectations">
-        <nldd-title size="5"><h2>Verwachte uitkomsten</h2></nldd-title>
+        <nldd-title size="5">
+          <h2>Verwachte uitkomsten</h2>
+          <nldd-button
+            slot="actions"
+            size="sm"
+            :disabled="!result && !error || undefined"
+            @click="emit('show-details')"
+            text="Resultaat"
+          ></nldd-button>
+        </nldd-title>
         <nldd-spacer size="12"></nldd-spacer>
         <nldd-list variant="box">
           <nldd-list-item v-for="(exp, name) in expectations" :key="name" size="md">
@@ -252,12 +261,6 @@ const hasExpectations = computed(() => Object.keys(expectations.value).length > 
             ></nldd-text-cell>
           </nldd-list-item>
         </nldd-list>
-        <nldd-spacer size="8"></nldd-spacer>
-        <nldd-button
-          :disabled="!result && !error || undefined"
-          @click="emit('show-details')"
-          text="Resultaat"
-        ></nldd-button>
       </template>
 
       <!-- Error -->

--- a/frontend/src/components/ScenarioForm.vue
+++ b/frontend/src/components/ScenarioForm.vue
@@ -295,9 +295,9 @@ const hasExpectations = computed(() => Object.keys(expectations.value).length > 
           :data-testid="`ds-row-${i}`"
           @click="selectedSource = i"
         >
-          <nldd-text-cell :text="ds.sourceName"></nldd-text-cell>
+          <nldd-text-cell :text="humanize(ds.sourceName)"></nldd-text-cell>
           <nldd-spacer-cell size="12"></nldd-spacer-cell>
-          <nldd-text-cell horizontal-alignment="right"><nldd-tag v-if="ds.rows.length" size="sm" :text="String(ds.rows.length)"></nldd-tag></nldd-text-cell>
+          <nldd-text-cell horizontal-alignment="right" :text="ds.rows.length ? String(ds.rows.length) : ''"></nldd-text-cell>
           <nldd-spacer-cell size="12"></nldd-spacer-cell>
           <nldd-icon-cell size="20"><nldd-icon name="chevron-right"></nldd-icon></nldd-icon-cell>
         </nldd-list-item>
@@ -310,11 +310,12 @@ const hasExpectations = computed(() => Object.keys(expectations.value).length > 
     <template v-else>
       <DataSourceTable
         :key="dataSources[selectedSource].sourceName"
-        :title="dataSources[selectedSource].sourceName"
+        :title="humanize(dataSources[selectedSource].sourceName)"
         :key-field="dataSources[selectedSource].keyField"
         :fields="dataSources[selectedSource].fields"
         :model-value="dataSources[selectedSource].rows"
         :drilled-in="true"
+        anchor-id="ds-drill-anchor"
         @update:model-value="updateDataSourceRows(selectedSource, $event)"
       />
     </template>

--- a/frontend/src/components/ScenarioForm.vue
+++ b/frontend/src/components/ScenarioForm.vue
@@ -110,6 +110,11 @@ function discardEdits() {
       .map((a) => [a.outputName, String(a.value)]),
   );
   selectedOutputs.value = initOutputs();
+  // Wiping the local result is safe even on a cancel-with-edits: the
+  // builder keeps the last run in its scenarioResults map, and
+  // onShowDetails() falls back to that when getExecutionData() returns
+  // no fresh result (hasFresh === false). So the result sheet keeps
+  // showing the previous outcome instead of going blank.
   result.value = null;
   error.value = null;
   errorTraceText.value = null;

--- a/frontend/src/components/ScenarioForm.vue
+++ b/frontend/src/components/ScenarioForm.vue
@@ -44,6 +44,10 @@ function initDataSources() {
 
 const dataSources = ref(initDataSources());
 
+// Drill-in navigation: null = scenario overview, otherwise the index of the
+// data source whose table is shown one level deeper in the sheet.
+const selectedSource = ref(null);
+
 // Expectations from scenario assertions
 const expectations = ref(
   Object.fromEntries(
@@ -77,6 +81,7 @@ watch([() => props.setup, () => props.scenario], () => {
     (props.setup.parameters || []).map((p) => [p.name, p.value ?? '']),
   );
   dataSources.value = initDataSources();
+  selectedSource.value = null;
   expectations.value = Object.fromEntries(
     (props.scenario.assertions || [])
       .filter((a) => a.outputName && a.value !== null && a.value !== undefined)
@@ -213,70 +218,101 @@ const hasExpectations = computed(() => Object.keys(expectations.value).length > 
 
 <template>
   <div class="sf-form">
-    <!-- Expected outputs -->
-    <template v-if="hasExpectations">
-      <nldd-title size="5" class="sf-section-title"><span>Verwachte uitkomsten</span></nldd-title>
-      <nldd-spacer size="4"></nldd-spacer>
-      <nldd-list variant="simple">
-        <nldd-list-item v-for="(exp, name) in expectations" :key="name" size="md">
-          <nldd-text-cell size="md" :text="humanize(name)"></nldd-text-cell>
-          <nldd-text-cell
-            size="md"
-            horizontal-alignment="right"
-            :text="humanize(formatValue(normalizeForCompare(exp)))"
-          ></nldd-text-cell>
+    <!-- Scenario overview -->
+    <template v-if="selectedSource === null">
+      <!-- Expected outputs -->
+      <template v-if="hasExpectations">
+        <nldd-title size="5" class="sf-section-title"><span>Verwachte uitkomsten</span></nldd-title>
+        <nldd-spacer size="4"></nldd-spacer>
+        <nldd-list variant="simple">
+          <nldd-list-item v-for="(exp, name) in expectations" :key="name" size="md">
+            <nldd-text-cell size="md" :text="humanize(name)"></nldd-text-cell>
+            <nldd-text-cell
+              size="md"
+              horizontal-alignment="right"
+              :text="humanize(formatValue(normalizeForCompare(exp)))"
+            ></nldd-text-cell>
+          </nldd-list-item>
+        </nldd-list>
+        <nldd-spacer size="8"></nldd-spacer>
+        <nldd-button
+          :disabled="!result && !error || undefined"
+          @click="emit('show-details')"
+          text="Resultaat"
+        ></nldd-button>
+        <nldd-spacer size="16"></nldd-spacer>
+      </template>
+
+      <!-- Error -->
+      <div v-if="error && !running" class="sf-error">{{ error }}</div>
+
+      <!-- Loading indicator -->
+      <div v-if="running" class="sf-running">Uitvoeren...</div>
+
+      <!-- Input: date + parameters -->
+      <nldd-title size="5" class="sf-section-title"><span>Invoer</span></nldd-title>
+      <nldd-list variant="box" class="sf-input-list">
+        <nldd-list-item size="md">
+          <nldd-text-cell text="Datum" max-width="140px"></nldd-text-cell>
+          <nldd-spacer-cell size="8"></nldd-spacer-cell>
+          <nldd-cell>
+            <nldd-text-field size="md" type="date" :value="calculationDate" @input="calculationDate = $event.target?.value ?? $event.detail?.value ?? calculationDate; emit('change')"></nldd-text-field>
+          </nldd-cell>
+        </nldd-list-item>
+        <nldd-list-item v-for="(value, name) in parameterValues" :key="name" size="md">
+          <nldd-text-cell :text="articleMap?.paramToArticle?.get(name) ? `${name} (Art. ${articleMap.paramToArticle.get(name)})` : name" max-width="140px"></nldd-text-cell>
+          <nldd-spacer-cell size="8"></nldd-spacer-cell>
+          <nldd-cell>
+            <nldd-text-field
+              size="md"
+              :value="value"
+              :placeholder="name"
+              @input="parameterValues = { ...parameterValues, [name]: $event.target?.value ?? $event.detail?.value ?? '' }; emit('change')"
+            ></nldd-text-field>
+          </nldd-cell>
         </nldd-list-item>
       </nldd-list>
-      <nldd-spacer size="8"></nldd-spacer>
-      <nldd-button
-        :disabled="!result && !error || undefined"
-        @click="emit('show-details')"
-        text="Resultaat"
-      ></nldd-button>
-      <nldd-spacer size="16"></nldd-spacer>
+
+      <!-- Data sources: a row per source, drill in one level deeper -->
+      <nldd-title size="5" class="sf-section-title"><span>Gegevensbronnen</span></nldd-title>
+      <nldd-list variant="box">
+        <nldd-list-item
+          v-for="(ds, i) in dataSources"
+          :key="ds.sourceName"
+          size="md"
+          type="button"
+          :data-testid="`ds-row-${i}`"
+          @click="selectedSource = i"
+        >
+          <nldd-text-cell :text="ds.sourceName"></nldd-text-cell>
+          <nldd-spacer-cell size="12"></nldd-spacer-cell>
+          <nldd-text-cell horizontal-alignment="right"><nldd-tag v-if="ds.rows.length" size="sm" :text="String(ds.rows.length)"></nldd-tag></nldd-text-cell>
+          <nldd-spacer-cell size="12"></nldd-spacer-cell>
+          <nldd-icon-cell size="20"><nldd-icon name="chevron-right"></nldd-icon></nldd-icon-cell>
+        </nldd-list-item>
+      </nldd-list>
     </template>
 
-    <!-- Error -->
-    <div v-if="error && !running" class="sf-error">{{ error }}</div>
-
-    <!-- Loading indicator -->
-    <div v-if="running" class="sf-running">Uitvoeren...</div>
-
-    <!-- Input: date + parameters -->
-    <nldd-title size="5" class="sf-section-title"><span>Invoer</span></nldd-title>
-    <nldd-list variant="box" class="sf-input-list">
-      <nldd-list-item size="md">
-        <nldd-text-cell text="Datum" max-width="140px"></nldd-text-cell>
-        <nldd-spacer-cell size="8"></nldd-spacer-cell>
-        <nldd-cell>
-          <nldd-text-field size="md" type="date" :value="calculationDate" @input="calculationDate = $event.target?.value ?? $event.detail?.value ?? calculationDate; emit('change')"></nldd-text-field>
-        </nldd-cell>
-      </nldd-list-item>
-      <nldd-list-item v-for="(value, name) in parameterValues" :key="name" size="md">
-        <nldd-text-cell :text="articleMap?.paramToArticle?.get(name) ? `${name} (Art. ${articleMap.paramToArticle.get(name)})` : name" max-width="140px"></nldd-text-cell>
-        <nldd-spacer-cell size="8"></nldd-spacer-cell>
-        <nldd-cell>
-          <nldd-text-field
-            size="md"
-            :value="value"
-            :placeholder="name"
-            @input="parameterValues = { ...parameterValues, [name]: $event.target?.value ?? $event.detail?.value ?? '' }; emit('change')"
-          ></nldd-text-field>
-        </nldd-cell>
-      </nldd-list-item>
-    </nldd-list>
-
-    <!-- Data sources -->
-    <DataSourceTable
-      v-for="(ds, i) in dataSources"
-      :key="ds.sourceName"
-      :title="ds.sourceName"
-      :key-field="ds.keyField"
-      :fields="ds.fields"
-      :model-value="ds.rows"
-      :default-expanded="false"
-      @update:model-value="updateDataSourceRows(i, $event)"
-    />
+    <!-- One level deeper: a single data source's table + back to scenario -->
+    <template v-else>
+      <nldd-list variant="box">
+        <nldd-list-item size="md" type="button" data-testid="ds-back" @click="selectedSource = null">
+          <nldd-icon-cell size="20"><nldd-icon name="chevron-left"></nldd-icon></nldd-icon-cell>
+          <nldd-spacer-cell size="12"></nldd-spacer-cell>
+          <nldd-text-cell text="Scenario"></nldd-text-cell>
+        </nldd-list-item>
+      </nldd-list>
+      <nldd-spacer size="16"></nldd-spacer>
+      <DataSourceTable
+        :key="dataSources[selectedSource].sourceName"
+        :title="dataSources[selectedSource].sourceName"
+        :key-field="dataSources[selectedSource].keyField"
+        :fields="dataSources[selectedSource].fields"
+        :model-value="dataSources[selectedSource].rows"
+        :drilled-in="true"
+        @update:model-value="updateDataSourceRows(selectedSource, $event)"
+      />
+    </template>
 
   </div>
 </template>

--- a/frontend/src/components/ScenarioForm.vue
+++ b/frontend/src/components/ScenarioForm.vue
@@ -244,7 +244,7 @@ const dateInvalid = computed(() => !calculationDate.value);
 </script>
 
 <template>
-  <div>
+  <div class="sf-root">
     <!-- Scenario overview -->
     <template v-if="selectedSource === null">
       <!-- Expected outputs -->
@@ -292,7 +292,7 @@ const dateInvalid = computed(() => !calculationDate.value);
           </nldd-cell>
         </nldd-list-item>
         <nldd-list-item v-for="(value, name) in parameterValues" :key="name" size="md">
-          <nldd-text-cell :text="articleMap?.paramToArticle?.get(name) ? `${name} (Art. ${articleMap.paramToArticle.get(name)})` : name" min-width="120px" max-width="200px"></nldd-text-cell>
+          <nldd-text-cell :text="name" :supporting-text="articleMap?.paramToArticle?.get(name) ? `Artikel ${articleMap.paramToArticle.get(name)}` : undefined" min-width="120px" max-width="200px"></nldd-text-cell>
           <nldd-spacer-cell size="8"></nldd-spacer-cell>
           <nldd-cell width="full" min-width="120px">
             <nldd-text-field
@@ -347,6 +347,13 @@ const dateInvalid = computed(() => !calculationDate.value);
 </template>
 
 <style scoped>
+/* Single component root required for v-show, but it must not generate a
+ * box — otherwise it blocks the enclosing simple-section's nldd flex
+ * layout (flex-grow / centering of an empty data source's dialog). */
+.sf-root {
+  display: contents;
+}
+
 .sf-running {
   font-size: 12px;
   color: var(--semantics-text-color-secondary, #666);

--- a/frontend/src/components/ScenarioForm.vue
+++ b/frontend/src/components/ScenarioForm.vue
@@ -277,16 +277,16 @@ const hasExpectations = computed(() => Object.keys(expectations.value).length > 
       <nldd-spacer size="12"></nldd-spacer>
       <nldd-list variant="box">
         <nldd-list-item size="md">
-          <nldd-text-cell text="Datum" min-width="140px" max-width="280px"></nldd-text-cell>
+          <nldd-text-cell text="Datum" min-width="120px" max-width="280px"></nldd-text-cell>
           <nldd-spacer-cell size="8"></nldd-spacer-cell>
-          <nldd-cell width="full" max-width="280px">
+          <nldd-cell width="full" min-width="120px" max-width="280px">
             <nldd-text-field size="md" type="date" :value="calculationDate" @input="calculationDate = $event.target?.value ?? $event.detail?.value ?? calculationDate; emit('change')"></nldd-text-field>
           </nldd-cell>
         </nldd-list-item>
         <nldd-list-item v-for="(value, name) in parameterValues" :key="name" size="md">
-          <nldd-text-cell :text="articleMap?.paramToArticle?.get(name) ? `${name} (Art. ${articleMap.paramToArticle.get(name)})` : name" min-width="140px" max-width="280px"></nldd-text-cell>
+          <nldd-text-cell :text="articleMap?.paramToArticle?.get(name) ? `${name} (Art. ${articleMap.paramToArticle.get(name)})` : name" min-width="120px" max-width="280px"></nldd-text-cell>
           <nldd-spacer-cell size="8"></nldd-spacer-cell>
-          <nldd-cell width="full" max-width="280px">
+          <nldd-cell width="full" min-width="120px" max-width="280px">
             <nldd-text-field
               size="md"
               :value="value"

--- a/frontend/src/components/ScenarioForm.vue
+++ b/frontend/src/components/ScenarioForm.vue
@@ -233,6 +233,18 @@ function matchStatus(outputName, actualValue) {
 }
 
 const hasExpectations = computed(() => Object.keys(expectations.value).length > 0);
+
+// Minimal field-level validation: an empty/unparseable date, or the
+// "Variable not found: <name>" engine error, is mapped back onto the
+// offending input so the user sees which field is wrong (the raw engine
+// message still shows as context). No auto-revert — the input stays.
+const dateInvalid = computed(
+  () => !calculationDate.value || /date/i.test(error.value || ''),
+);
+const missingVar = computed(() => {
+  const m = /Variable not found:\s*(\S+)/i.exec(error.value || '');
+  return m ? m[1] : null;
+});
 </script>
 
 <template>
@@ -280,7 +292,7 @@ const hasExpectations = computed(() => Object.keys(expectations.value).length > 
           <nldd-text-cell text="Datum" min-width="120px" max-width="200px"></nldd-text-cell>
           <nldd-spacer-cell size="8"></nldd-spacer-cell>
           <nldd-cell width="full" min-width="120px">
-            <nldd-text-field size="md" type="date" :value="calculationDate" @input="calculationDate = $event.target?.value ?? $event.detail?.value ?? calculationDate; emit('change')"></nldd-text-field>
+            <nldd-text-field size="md" type="date" :invalid="dateInvalid || undefined" :value="calculationDate" @input="calculationDate = $event.target?.value ?? $event.detail?.value ?? calculationDate; emit('change')"></nldd-text-field>
           </nldd-cell>
         </nldd-list-item>
         <nldd-list-item v-for="(value, name) in parameterValues" :key="name" size="md">
@@ -289,8 +301,8 @@ const hasExpectations = computed(() => Object.keys(expectations.value).length > 
           <nldd-cell width="full" min-width="120px">
             <nldd-text-field
               size="md"
+              :invalid="missingVar === name || undefined"
               :value="value"
-              :placeholder="name"
               @input="parameterValues = { ...parameterValues, [name]: $event.target?.value ?? $event.detail?.value ?? '' }; emit('change')"
             ></nldd-text-field>
           </nldd-cell>

--- a/frontend/src/components/ScenarioVisual.vue
+++ b/frontend/src/components/ScenarioVisual.vue
@@ -158,16 +158,17 @@ function dataSourceToTableProps(ds) {
 
         <!-- Data sources (collapsed by default for compactness) -->
         <div v-if="scenario.setup.dataSources.length > 0" class="sv-ds-section">
-          <DataSourceTable
-            v-for="(ds, di) in scenario.setup.dataSources"
-            :key="di"
-            :title="ds.sourceName"
-            :key-field="dataSourceToTableProps(ds).keyField"
-            :fields="dataSourceToTableProps(ds).fields"
-            :model-value="dataSourceToTableProps(ds).rows"
-            :default-expanded="false"
-            :readonly="readonly"
-          />
+          <template v-for="(ds, di) in scenario.setup.dataSources" :key="di">
+            <nldd-spacer v-if="di > 0" size="12"></nldd-spacer>
+            <DataSourceTable
+              :title="ds.sourceName"
+              :key-field="dataSourceToTableProps(ds).keyField"
+              :fields="dataSourceToTableProps(ds).fields"
+              :model-value="dataSourceToTableProps(ds).rows"
+              :default-expanded="false"
+              :readonly="readonly"
+            />
+          </template>
         </div>
 
         <!-- Execution -->

--- a/frontend/src/components/SearchPopover.vue
+++ b/frontend/src/components/SearchPopover.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed, watch, nextTick } from 'vue';
+import { ref, computed, watch } from 'vue';
 import { useBwbSearch, MIN_QUERY_LENGTH } from '../composables/useBwbSearch.js';
 import { useBwbHarvest } from '../composables/useBwbHarvest.js';
 import { useAuth } from '../composables/useAuth.js';
@@ -128,41 +128,64 @@ function selectLaw(lawId) {
  * bar's search-field intercepts the keystroke and forwards it as the
  * initial query in the popover.
  */
-async function show(anchorEl, initialSearch = '') {
-  if (!popoverRef.value) return;
-  if (anchorEl) popoverRef.value.anchorElement = anchorEl;
+/**
+ * Open + focus MUST stay synchronous within the trusted tap gesture.
+ *
+ * iOS/iPadOS (and partly Android) only raise the on-screen keyboard when
+ * `input.focus()` runs synchronously inside the user-activation of the
+ * originating tap. An `await nextTick()` (or focusing later from the
+ * popover's `open` event, after its async _manageFocus) breaks that
+ * activation: focus still lands in the field but the keyboard never
+ * appears. So no `await` may run before show()+focus().
+ *
+ * The nextTick previously existed only to let Vue propagate the
+ * `centered`/`top`/`width` props before the first Floating-UI reposition
+ * (md anchored mode). We instead set those props imperatively on the
+ * element here, which is effective synchronously — keeping positioning
+ * correct without breaking the gesture, on every viewport (phone + iPad).
+ */
+function show(anchorEl, initialSearch = '') {
+  const pop = popoverRef.value;
+  if (!pop) return;
+  if (anchorEl) pop.anchorElement = anchorEl;
   if (initialSearch) search.value = initialSearch;
-  // On lg the popover is centered top (large dropdown overlay style).
-  // On md it anchors below the trigger button (Floating UI placement),
-  // matching the smaller toolbar's button-as-trigger feel.
-  // On sm the popover renders as a full-height sheet (CSS-driven).
-  useCenteredPosition.value = window.matchMedia(`(min-width: ${BREAKPOINT_LG_MIN}px)`).matches;
-  isAnchored.value = window.matchMedia(`(min-width: ${BREAKPOINT_MD_MIN}px) and (max-width: ${BREAKPOINT_LG_MIN - 1}px)`).matches;
-  // Wait for Vue to propagate the new `centered` / `top` / `width` props
-  // onto the popover element before opening — otherwise the first
-  // reposition() inside the popover's toggle handler runs against the
-  // previous breakpoint's props (e.g. centered=true held over from lg)
-  // and the popover lands in the wrong position. The Lit-side update on
-  // prop change DOES re-trigger reposition, but in some cases the
-  // initial Floating-UI run wins for the visual frame.
-  await nextTick();
-  popoverRef.value.show();
+
+  // lg: centered top overlay · md: anchored below trigger · sm: CSS sheet
+  const centered = window.matchMedia(`(min-width: ${BREAKPOINT_LG_MIN}px)`).matches;
+  const anchored = window.matchMedia(`(min-width: ${BREAKPOINT_MD_MIN}px) and (max-width: ${BREAKPOINT_LG_MIN - 1}px)`).matches;
+  useCenteredPosition.value = centered;
+  isAnchored.value = anchored;
+
+  // Set positioning props imperatively so they take effect this tick
+  // (no await). Vue's reactive bindings re-apply the same values on the
+  // next update — no conflict.
+  pop.centered = centered || null;
+  pop.top = centered ? '0' : null;
+  pop.width = centered ? '720px' : '360px';
+
+  pop.show();
+  focusSearchInput();
 }
 
 /**
- * Auto-focus the internal search input on open. Listening to the popover's
- * `open` event (rather than awaiting nextTick after show()) is the only
- * reliable hook: popover's own _manageFocus() runs after computePosition +
- * updateComplete and would otherwise steal focus back to the host. The
- * `open` event fires AFTER _manageFocus, so our focus call wins last.
+ * Focus the internal search input. Called synchronously from show()
+ * (raises the mobile keyboard, in-gesture) and again from the popover's
+ * `open` event as a desktop fallback — the popover's own _manageFocus()
+ * runs after computePosition + updateComplete and would otherwise steal
+ * focus back to the host; re-focusing the same input is idempotent and
+ * does not dismiss an already-open keyboard.
  *
- * The shadow-root vs light-DOM lookup is to be defensive — different
- * design-system versions may render the <input> differently.
+ * Shadow-root vs light-DOM lookup is defensive — different design-system
+ * versions may render the <input> differently.
  */
-function onPopoverOpen() {
+function focusSearchInput() {
   const field = popoverRef.value?.querySelector('nldd-search-field');
   const native = field?.shadowRoot?.querySelector('input') ?? field?.querySelector('input');
   native?.focus();
+}
+
+function onPopoverOpen() {
+  focusSearchInput();
 }
 
 defineExpose({ show });

--- a/frontend/src/components/SearchPopover.vue
+++ b/frontend/src/components/SearchPopover.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed, watch } from 'vue';
+import { ref, computed, watch, nextTick } from 'vue';
 import { useBwbSearch, MIN_QUERY_LENGTH } from '../composables/useBwbSearch.js';
 import { useBwbHarvest } from '../composables/useBwbHarvest.js';
 import { useAuth } from '../composables/useAuth.js';
@@ -128,64 +128,41 @@ function selectLaw(lawId) {
  * bar's search-field intercepts the keystroke and forwards it as the
  * initial query in the popover.
  */
-/**
- * Open + focus MUST stay synchronous within the trusted tap gesture.
- *
- * iOS/iPadOS (and partly Android) only raise the on-screen keyboard when
- * `input.focus()` runs synchronously inside the user-activation of the
- * originating tap. An `await nextTick()` (or focusing later from the
- * popover's `open` event, after its async _manageFocus) breaks that
- * activation: focus still lands in the field but the keyboard never
- * appears. So no `await` may run before show()+focus().
- *
- * The nextTick previously existed only to let Vue propagate the
- * `centered`/`top`/`width` props before the first Floating-UI reposition
- * (md anchored mode). We instead set those props imperatively on the
- * element here, which is effective synchronously — keeping positioning
- * correct without breaking the gesture, on every viewport (phone + iPad).
- */
-function show(anchorEl, initialSearch = '') {
-  const pop = popoverRef.value;
-  if (!pop) return;
-  if (anchorEl) pop.anchorElement = anchorEl;
+async function show(anchorEl, initialSearch = '') {
+  if (!popoverRef.value) return;
+  if (anchorEl) popoverRef.value.anchorElement = anchorEl;
   if (initialSearch) search.value = initialSearch;
-
-  // lg: centered top overlay · md: anchored below trigger · sm: CSS sheet
-  const centered = window.matchMedia(`(min-width: ${BREAKPOINT_LG_MIN}px)`).matches;
-  const anchored = window.matchMedia(`(min-width: ${BREAKPOINT_MD_MIN}px) and (max-width: ${BREAKPOINT_LG_MIN - 1}px)`).matches;
-  useCenteredPosition.value = centered;
-  isAnchored.value = anchored;
-
-  // Set positioning props imperatively so they take effect this tick
-  // (no await). Vue's reactive bindings re-apply the same values on the
-  // next update — no conflict.
-  pop.centered = centered || null;
-  pop.top = centered ? '0' : null;
-  pop.width = centered ? '720px' : '360px';
-
-  pop.show();
-  focusSearchInput();
+  // On lg the popover is centered top (large dropdown overlay style).
+  // On md it anchors below the trigger button (Floating UI placement),
+  // matching the smaller toolbar's button-as-trigger feel.
+  // On sm the popover renders as a full-height sheet (CSS-driven).
+  useCenteredPosition.value = window.matchMedia(`(min-width: ${BREAKPOINT_LG_MIN}px)`).matches;
+  isAnchored.value = window.matchMedia(`(min-width: ${BREAKPOINT_MD_MIN}px) and (max-width: ${BREAKPOINT_LG_MIN - 1}px)`).matches;
+  // Wait for Vue to propagate the new `centered` / `top` / `width` props
+  // onto the popover element before opening — otherwise the first
+  // reposition() inside the popover's toggle handler runs against the
+  // previous breakpoint's props (e.g. centered=true held over from lg)
+  // and the popover lands in the wrong position. The Lit-side update on
+  // prop change DOES re-trigger reposition, but in some cases the
+  // initial Floating-UI run wins for the visual frame.
+  await nextTick();
+  popoverRef.value.show();
 }
 
 /**
- * Focus the internal search input. Called synchronously from show()
- * (raises the mobile keyboard, in-gesture) and again from the popover's
- * `open` event as a desktop fallback — the popover's own _manageFocus()
- * runs after computePosition + updateComplete and would otherwise steal
- * focus back to the host; re-focusing the same input is idempotent and
- * does not dismiss an already-open keyboard.
+ * Auto-focus the internal search input on open. Listening to the popover's
+ * `open` event (rather than awaiting nextTick after show()) is the only
+ * reliable hook: popover's own _manageFocus() runs after computePosition +
+ * updateComplete and would otherwise steal focus back to the host. The
+ * `open` event fires AFTER _manageFocus, so our focus call wins last.
  *
- * Shadow-root vs light-DOM lookup is defensive — different design-system
- * versions may render the <input> differently.
+ * The shadow-root vs light-DOM lookup is to be defensive — different
+ * design-system versions may render the <input> differently.
  */
-function focusSearchInput() {
+function onPopoverOpen() {
   const field = popoverRef.value?.querySelector('nldd-search-field');
   const native = field?.shadowRoot?.querySelector('input') ?? field?.querySelector('input');
   native?.focus();
-}
-
-function onPopoverOpen() {
-  focusSearchInput();
 }
 
 defineExpose({ show });

--- a/packages/admin/frontend-src/package-lock.json
+++ b/packages/admin/frontend-src/package-lock.json
@@ -8,7 +8,7 @@
       "name": "regelrecht-admin-ui",
       "version": "1.0.0",
       "dependencies": {
-        "@nldd/design-system": "^0.8.42",
+        "@nldd/design-system": "^0.8.44",
         "vue": "^3.5.34",
         "vue-router": "^5.0.6"
       },
@@ -227,9 +227,9 @@
       }
     },
     "node_modules/@nldd/design-system": {
-      "version": "0.8.42",
-      "resolved": "https://registry.npmjs.org/@nldd/design-system/-/design-system-0.8.42.tgz",
-      "integrity": "sha512-NPDK+Lhk7QkjKW3wAPZ5Wjqo9k4Q0M75sJkj0iuLtw6tuFyJ1B3sD0MJoGVcZhdIlU8bZy9liYQKMPd0cmjwtA==",
+      "version": "0.8.44",
+      "resolved": "https://registry.npmjs.org/@nldd/design-system/-/design-system-0.8.44.tgz",
+      "integrity": "sha512-0PMUl/t0BrItxAHWIBNBkxAFU3855BMu2PaXX3oQwb+svWyT6iRMcFxfrG0MlEpxm8lFvTKTaP+d1vjyzzAvrQ==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@floating-ui/dom": "^1.7.6",

--- a/packages/admin/frontend-src/package.json
+++ b/packages/admin/frontend-src/package.json
@@ -8,7 +8,7 @@
     "build": "vite build"
   },
   "dependencies": {
-    "@nldd/design-system": "^0.8.42",
+    "@nldd/design-system": "^0.8.44",
     "vue": "^3.5.34",
     "vue-router": "^5.0.6"
   },

--- a/packages/admin/frontend-src/src/App.vue
+++ b/packages/admin/frontend-src/src/App.vue
@@ -39,17 +39,17 @@ watch([authLoading, oidcConfigured, authenticated], ([loading, oidc, auth]) => {
     <nldd-tag
       v-if="deploymentName"
       class="env-badge"
-      variant="warning"
+      color="warning"
       size="sm"
       :text="deploymentName"
     />
     <nldd-bar-split-view>
       <nldd-container slot="toolbar" padding="8" padding-left="16">
         <nldd-toolbar size="md">
-          <nldd-toolbar-title-group
+          <nldd-toolbar-title
             slot="start"
             text="Admin"
-            subtext="RegelRecht"
+            supporting-text="RegelRecht"
             min-width="fit-content"
           />
           <nldd-toolbar-item slot="center">
@@ -67,7 +67,7 @@ watch([authLoading, oidcConfigured, authenticated], ([loading, oidc, auth]) => {
             <nldd-icon-button
               icon="plus-small"
               text="Add"
-              hide-tooltip
+              tooltip-timing="never"
               variant="neutral-tinted"
               @click="openNewHarvestJob"
             />

--- a/packages/admin/frontend-src/src/App.vue
+++ b/packages/admin/frontend-src/src/App.vue
@@ -4,6 +4,7 @@ import { useRoute, useRouter } from 'vue-router';
 import { useAuth } from './composables/useAuth.js';
 import { usePlatformInfo } from './composables/usePlatformInfo.js';
 import { useNewHarvestJob } from './composables/useNewHarvestJob.js';
+import { useColorScheme } from './composables/useColorScheme.js';
 import NewHarvestJobSheet from './components/NewHarvestJobSheet.vue';
 
 const route = useRoute();
@@ -11,6 +12,13 @@ const router = useRouter();
 const { authenticated, oidcConfigured, loading: authLoading, logout, redirectToLogin } = useAuth();
 const { info } = usePlatformInfo();
 const { open: openNewHarvestJob } = useNewHarvestJob();
+const { colorScheme, setColorScheme } = useColorScheme();
+
+const themeOptions = [
+  ['auto', 'Match system'],
+  ['dark', 'Dark'],
+  ['light', 'Light'],
+];
 
 const deploymentName = computed(() =>
   info.value?.deployment_name && info.value.deployment_name !== 'regelrecht'
@@ -73,11 +81,32 @@ watch([authLoading, oidcConfigured, authenticated], ([loading, oidc, auth]) => {
             />
           </nldd-toolbar-item>
           <nldd-toolbar-item slot="end">
-            <nldd-button
-              text="Logout"
-              end-icon="logout"
-              @click="logout"
+            <nldd-icon-button
+              id="account-menu-trigger"
+              icon="person-circle"
+              text="Account"
+              expandable
+              tooltip-timing="never"
+              variant="neutral-tinted"
             />
+            <nldd-menu anchor="account-menu-trigger">
+              <nldd-menu-group text="Theme">
+                <nldd-menu-item
+                  v-for="[value, label] in themeOptions"
+                  :key="value"
+                  type="radio"
+                  :text="label"
+                  :selected="colorScheme === value || undefined"
+                  @click.stop="setColorScheme(value)"
+                />
+              </nldd-menu-group>
+              <nldd-menu-divider />
+              <nldd-menu-item
+                text="Logout"
+                icon="logout"
+                @click.stop="logout"
+              />
+            </nldd-menu>
           </nldd-toolbar-item>
         </nldd-toolbar>
       </nldd-container>

--- a/packages/admin/frontend-src/src/App.vue
+++ b/packages/admin/frontend-src/src/App.vue
@@ -15,7 +15,7 @@ const { open: openNewHarvestJob } = useNewHarvestJob();
 const { colorScheme, setColorScheme } = useColorScheme();
 
 const themeOptions = [
-  ['auto', 'Match system'],
+  ['auto', 'System'],
   ['dark', 'Dark'],
   ['light', 'Light'],
 ];

--- a/packages/admin/frontend-src/src/components/DataTable.vue
+++ b/packages/admin/frontend-src/src/components/DataTable.vue
@@ -28,7 +28,7 @@ function formatCellValue(value, key) {
 </script>
 
 <template>
-  <nldd-simple-section full-width>
+  <nldd-simple-section width="full">
     <TableToolbar
       :columns="columns"
       :sort-options="sortOptions"

--- a/packages/admin/frontend-src/src/components/DataTable.vue
+++ b/packages/admin/frontend-src/src/components/DataTable.vue
@@ -45,7 +45,7 @@ function formatCellValue(value, key) {
 </script>
 
 <template>
-  <nldd-simple-section width="full">
+  <nldd-simple-section>
     <template v-if="data.length > 0 || hasActiveFilters">
       <TableToolbar
         :columns="columns"

--- a/packages/admin/frontend-src/src/components/DataTable.vue
+++ b/packages/admin/frontend-src/src/components/DataTable.vue
@@ -91,7 +91,7 @@ function formatCellValue(value, key) {
           @click="clickableRows && emit('row-click', row)"
         >
           <template v-for="(col, idx) in columns" :key="col.key">
-            <nldd-spacer-cell v-if="idx > 0" size="12" />
+            <nldd-spacer-cell v-if="idx > 0" size="12" :hide-below="col.hideBelow" />
             <nldd-cell
               v-if="$slots['cell-' + col.key]"
               :width="col.width || 'stretch'"
@@ -115,6 +115,7 @@ function formatCellValue(value, key) {
               :width="col.width || 'stretch'"
               :min-width="col.minWidth"
               :horizontal-alignment="col.align"
+              :hide-below="col.hideBelow"
             />
             <nldd-cell
               v-else-if="col.key === 'id' || col.key === 'law_id'"

--- a/packages/admin/frontend-src/src/components/DataTable.vue
+++ b/packages/admin/frontend-src/src/components/DataTable.vue
@@ -1,8 +1,8 @@
 <script setup>
-import { computed } from 'vue';
 import StatusBadge from './StatusBadge.vue';
 import TableToolbar from './TableToolbar.vue';
 import { formatDate, formatCoverageScore, truncateUuid } from '../formatters.js';
+import { useTableFilters } from '../composables/useTableFilters.js';
 
 const props = defineProps({
   columns: { type: Array, required: true },
@@ -19,21 +19,7 @@ const props = defineProps({
 
 const emit = defineEmits(['sort', 'filter-change', 'row-click']);
 
-// A search/filter is active when any filter holds a non-empty value. Used to
-// tell an *empty* state (no data at all → hide the toolbar) apart from a
-// *no-results* state (filters excluded everything → keep the toolbar so the
-// user can clear or change the search).
-const hasActiveFilters = computed(() =>
-  Object.values(props.filters || {}).some((v) => v !== '' && v != null),
-);
-
-// Clear every active filter by emitting an empty value per key — the parent's
-// setFilter handler deletes a filter when given a falsy value.
-function clearFilters() {
-  for (const key of Object.keys(props.filters || {})) {
-    emit('filter-change', key, '');
-  }
-}
+const { hasActiveFilters, clearFilters } = useTableFilters(() => props.filters, emit);
 
 function formatCellValue(value, key) {
   if (value === null || value === undefined || value === '') return null;

--- a/packages/admin/frontend-src/src/components/DataTable.vue
+++ b/packages/admin/frontend-src/src/components/DataTable.vue
@@ -1,4 +1,5 @@
 <script setup>
+import { computed } from 'vue';
 import StatusBadge from './StatusBadge.vue';
 import TableToolbar from './TableToolbar.vue';
 import { formatDate, formatCoverageScore, truncateUuid } from '../formatters.js';
@@ -18,6 +19,22 @@ const props = defineProps({
 
 const emit = defineEmits(['sort', 'filter-change', 'row-click']);
 
+// A search/filter is active when any filter holds a non-empty value. Used to
+// tell an *empty* state (no data at all → hide the toolbar) apart from a
+// *no-results* state (filters excluded everything → keep the toolbar so the
+// user can clear or change the search).
+const hasActiveFilters = computed(() =>
+  Object.values(props.filters || {}).some((v) => v !== '' && v != null),
+);
+
+// Clear every active filter by emitting an empty value per key — the parent's
+// setFilter handler deletes a filter when given a falsy value.
+function clearFilters() {
+  for (const key of Object.keys(props.filters || {})) {
+    emit('filter-change', key, '');
+  }
+}
+
 function formatCellValue(value, key) {
   if (value === null || value === undefined || value === '') return null;
   if (key === 'id') return truncateUuid(value);
@@ -29,23 +46,36 @@ function formatCellValue(value, key) {
 
 <template>
   <nldd-simple-section width="full">
-    <TableToolbar
-      :columns="columns"
-      :sort-options="sortOptions"
-      :sort="sort"
-      :order="order"
-      :filters="filters"
-      @sort="(key, order) => emit('sort', key, order)"
-      @filter-change="(key, value) => emit('filter-change', key, value)"
-    >
-      <template #prefix>
-        <slot name="toolbar-prefix" />
-      </template>
-    </TableToolbar>
-    <nldd-spacer size="16" />
+    <template v-if="data.length > 0 || hasActiveFilters">
+      <TableToolbar
+        :columns="columns"
+        :sort-options="sortOptions"
+        :sort="sort"
+        :order="order"
+        :filters="filters"
+        @sort="(key, order) => emit('sort', key, order)"
+        @filter-change="(key, value) => emit('filter-change', key, value)"
+      >
+        <template #prefix>
+          <slot name="toolbar-prefix" />
+        </template>
+      </TableToolbar>
+      <nldd-spacer size="16" />
+    </template>
 
     <nldd-inline-dialog v-if="loading && data.length === 0" text="Loading…"></nldd-inline-dialog>
     <nldd-inline-dialog v-else-if="error && data.length === 0" :text="'Failed to load data: ' + error"></nldd-inline-dialog>
+    <nldd-inline-dialog
+      v-else-if="data.length === 0 && hasActiveFilters"
+      text="No results match the current filters."
+    >
+      <nldd-button
+        slot="actions"
+        variant="secondary"
+        text="Clear filters"
+        @click="clearFilters"
+      />
+    </nldd-inline-dialog>
     <nldd-inline-dialog v-else-if="data.length === 0" :text="emptyText">
       <slot name="empty-action" />
     </nldd-inline-dialog>

--- a/packages/admin/frontend-src/src/components/DetailPanel.vue
+++ b/packages/admin/frontend-src/src/components/DetailPanel.vue
@@ -66,7 +66,6 @@ function onSheetClose() {
     <nldd-sheet
       ref="sheetRef"
       placement="right"
-      full-height
       accessible-label="Job details"
       @close="onSheetClose"
     >
@@ -79,7 +78,7 @@ function onSheetClose() {
               <nldd-spacer-cell size="12" />
               <nldd-cell
                 v-if="label === 'Status'"
-                width="stretch"
+                width="full"
                 style="align-items: flex-end"
               >
                 <StatusBadge :status="value" size="md" />

--- a/packages/admin/frontend-src/src/components/DetailPanel.vue
+++ b/packages/admin/frontend-src/src/components/DetailPanel.vue
@@ -70,7 +70,12 @@ function onSheetClose() {
       @close="onSheetClose"
     >
       <nldd-page sticky-header>
-        <nldd-top-title-bar slot="header" text="Job details" />
+        <nldd-top-title-bar
+          slot="header"
+          text="Job details"
+          dismiss-text="Close"
+          @dismiss="$emit('close')"
+        />
         <nldd-simple-section v-if="job">
           <nldd-list variant="simple">
             <nldd-list-item v-for="[label, value] in infoFields" :key="label">

--- a/packages/admin/frontend-src/src/components/GroupedTable.vue
+++ b/packages/admin/frontend-src/src/components/GroupedTable.vue
@@ -1,8 +1,8 @@
 <script setup>
-import { computed } from 'vue';
 import TableToolbar from './TableToolbar.vue';
 import { GROUPED_COLUMNS } from '../constants.js';
 import { formatDate } from '../formatters.js';
+import { useTableFilters } from '../composables/useTableFilters.js';
 
 const props = defineProps({
   data: { type: Array, required: true },
@@ -17,21 +17,7 @@ const props = defineProps({
 
 const emit = defineEmits(['sort', 'filter-change', 'view-jobs']);
 
-// A search/filter is active when any filter holds a non-empty value. Used to
-// tell an *empty* state (no data at all → hide the toolbar) apart from a
-// *no-results* state (filters excluded everything → keep the toolbar so the
-// user can clear or change the search).
-const hasActiveFilters = computed(() =>
-  Object.values(props.filters || {}).some((v) => v !== '' && v != null),
-);
-
-// Clear every active filter by emitting an empty value per key — the parent's
-// setFilter handler deletes a filter when given a falsy value.
-function clearFilters() {
-  for (const key of Object.keys(props.filters || {})) {
-    emit('filter-change', key, '');
-  }
-}
+const { hasActiveFilters, clearFilters } = useTableFilters(() => props.filters, emit);
 
 const columns = GROUPED_COLUMNS;
 

--- a/packages/admin/frontend-src/src/components/GroupedTable.vue
+++ b/packages/admin/frontend-src/src/components/GroupedTable.vue
@@ -100,12 +100,12 @@ function statusBarTitle(group) {
         @click="emit('view-jobs', group.law_id)"
       >
         <template v-for="(col, idx) in columns" :key="col.key">
-          <nldd-spacer-cell v-if="idx > 0" size="12" />
+          <nldd-spacer-cell v-if="idx > 0" size="12" :hide-below="col.hideBelow" />
           <nldd-cell
             v-if="col.key === 'status_bar'"
             :width="col.width || 'stretch'"
           >
-            <nldd-tooltip :text="statusBarTitle(group)" placement="top">
+            <nldd-tooltip :text="statusBarTitle(group)" placement="top" timing="instant">
               <div class="status-bar">
                 <div
                   v-for="seg in statusSegments(group)"
@@ -132,6 +132,7 @@ function statusBarTitle(group) {
             :width="col.width || 'stretch'"
             :min-width="col.minWidth"
             :horizontal-alignment="col.align"
+            :hide-below="col.hideBelow"
           />
         </template>
         <nldd-spacer-cell size="12" />

--- a/packages/admin/frontend-src/src/components/GroupedTable.vue
+++ b/packages/admin/frontend-src/src/components/GroupedTable.vue
@@ -1,9 +1,10 @@
 <script setup>
+import { computed } from 'vue';
 import TableToolbar from './TableToolbar.vue';
 import { GROUPED_COLUMNS } from '../constants.js';
 import { formatDate } from '../formatters.js';
 
-defineProps({
+const props = defineProps({
   data: { type: Array, required: true },
   loading: { type: Boolean, default: false },
   error: { type: String, default: null },
@@ -15,6 +16,22 @@ defineProps({
 });
 
 const emit = defineEmits(['sort', 'filter-change', 'view-jobs']);
+
+// A search/filter is active when any filter holds a non-empty value. Used to
+// tell an *empty* state (no data at all → hide the toolbar) apart from a
+// *no-results* state (filters excluded everything → keep the toolbar so the
+// user can clear or change the search).
+const hasActiveFilters = computed(() =>
+  Object.values(props.filters || {}).some((v) => v !== '' && v != null),
+);
+
+// Clear every active filter by emitting an empty value per key — the parent's
+// setFilter handler deletes a filter when given a falsy value.
+function clearFilters() {
+  for (const key of Object.keys(props.filters || {})) {
+    emit('filter-change', key, '');
+  }
+}
 
 const columns = GROUPED_COLUMNS;
 
@@ -39,23 +56,36 @@ function statusBarTitle(group) {
 
 <template>
   <nldd-simple-section width="full">
-    <TableToolbar
-      :columns="columns"
-      :sort-options="sortOptions"
-      :sort="sort"
-      :order="order"
-      :filters="filters"
-      @sort="(key, order) => emit('sort', key, order)"
-      @filter-change="(key, value) => emit('filter-change', key, value)"
-    >
-      <template #prefix>
-        <slot name="toolbar-prefix" />
-      </template>
-    </TableToolbar>
-    <nldd-spacer size="16" />
+    <template v-if="data.length > 0 || hasActiveFilters">
+      <TableToolbar
+        :columns="columns"
+        :sort-options="sortOptions"
+        :sort="sort"
+        :order="order"
+        :filters="filters"
+        @sort="(key, order) => emit('sort', key, order)"
+        @filter-change="(key, value) => emit('filter-change', key, value)"
+      >
+        <template #prefix>
+          <slot name="toolbar-prefix" />
+        </template>
+      </TableToolbar>
+      <nldd-spacer size="16" />
+    </template>
 
     <nldd-inline-dialog v-if="loading && data.length === 0" text="Loading…"></nldd-inline-dialog>
     <nldd-inline-dialog v-else-if="error && data.length === 0" :text="'Failed to load data: ' + error"></nldd-inline-dialog>
+    <nldd-inline-dialog
+      v-else-if="data.length === 0 && hasActiveFilters"
+      text="No results match the current filters."
+    >
+      <nldd-button
+        slot="actions"
+        variant="secondary"
+        text="Clear filters"
+        @click="clearFilters"
+      />
+    </nldd-inline-dialog>
     <nldd-inline-dialog v-else-if="data.length === 0" :text="emptyText">
       <slot name="empty-action" />
     </nldd-inline-dialog>

--- a/packages/admin/frontend-src/src/components/GroupedTable.vue
+++ b/packages/admin/frontend-src/src/components/GroupedTable.vue
@@ -55,7 +55,7 @@ function statusBarTitle(group) {
 </script>
 
 <template>
-  <nldd-simple-section width="full">
+  <nldd-simple-section>
     <template v-if="data.length > 0 || hasActiveFilters">
       <TableToolbar
         :columns="columns"

--- a/packages/admin/frontend-src/src/components/GroupedTable.vue
+++ b/packages/admin/frontend-src/src/components/GroupedTable.vue
@@ -38,7 +38,7 @@ function statusBarTitle(group) {
 </script>
 
 <template>
-  <nldd-simple-section full-width>
+  <nldd-simple-section width="full">
     <TableToolbar
       :columns="columns"
       :sort-options="sortOptions"

--- a/packages/admin/frontend-src/src/components/LawJobsSheet.vue
+++ b/packages/admin/frontend-src/src/components/LawJobsSheet.vue
@@ -123,7 +123,6 @@ const codeSections = computed(() => {
     <nldd-sheet
       ref="sheetRef"
       placement="right"
-      full-height
       accessible-label="Jobs"
       @close="onSheetClose"
     >
@@ -189,7 +188,7 @@ const codeSections = computed(() => {
               <nldd-spacer-cell size="12" />
               <nldd-cell
                 v-if="label === 'Status'"
-                width="stretch"
+                width="full"
                 style="align-items: flex-end"
               >
                 <StatusBadge :status="value" size="md" />

--- a/packages/admin/frontend-src/src/components/LawJobsSheet.vue
+++ b/packages/admin/frontend-src/src/components/LawJobsSheet.vue
@@ -165,12 +165,13 @@ const codeSections = computed(() => {
               @click="selectedJob = job"
             >
               <nldd-text-cell
-                :text="job.id"
-                :supporting-text="jobSubtitle(job)"
+                :overline="job.id"
+                :text="jobSubtitle(job)"
+                :supporting-text="job.result?.error || undefined"
               />
               <nldd-spacer-cell size="12" />
               <nldd-cell width="fit-content">
-                <StatusBadge :status="job.status || 'unknown'" :error-message="job.result?.error" />
+                <StatusBadge :status="job.status || 'unknown'" />
               </nldd-cell>
               <nldd-spacer-cell size="12" />
               <nldd-icon-cell icon="chevron-right" size="20" />

--- a/packages/admin/frontend-src/src/components/LawJobsSheet.vue
+++ b/packages/admin/frontend-src/src/components/LawJobsSheet.vue
@@ -131,12 +131,16 @@ const codeSections = computed(() => {
           v-if="!selectedJob"
           slot="header"
           :text="`Jobs for ${lawId || ''}`"
+          dismiss-text="Close"
+          @dismiss="close"
         />
         <nldd-top-title-bar
           v-else
           slot="header"
           :back-text="`Jobs for ${lawId}`"
+          dismiss-text="Close"
           @back="onBack"
+          @dismiss="close"
         />
 
         <nldd-simple-section v-if="!selectedJob">

--- a/packages/admin/frontend-src/src/components/NewHarvestJobSheet.vue
+++ b/packages/admin/frontend-src/src/components/NewHarvestJobSheet.vue
@@ -112,7 +112,6 @@ function onSheetClose() {
     <nldd-sheet
       ref="sheetRef"
       placement="right"
-      full-height
       accessible-label="New harvest job"
       @close="onSheetClose"
     >

--- a/packages/admin/frontend-src/src/components/NewHarvestJobSheet.vue
+++ b/packages/admin/frontend-src/src/components/NewHarvestJobSheet.vue
@@ -116,7 +116,12 @@ function onSheetClose() {
       @close="onSheetClose"
     >
       <nldd-page sticky-header>
-        <nldd-top-title-bar slot="header" text="New harvest job" />
+        <nldd-top-title-bar
+          slot="header"
+          text="New harvest job"
+          dismiss-text="Cancel"
+          @dismiss="close"
+        />
         <nldd-simple-section>
           <nldd-form>
             <nldd-form-field

--- a/packages/admin/frontend-src/src/components/PaginationControls.vue
+++ b/packages/admin/frontend-src/src/components/PaginationControls.vue
@@ -14,7 +14,7 @@ function onPageChange(event) {
 <template>
   <nldd-pagination
     v-if="totalPages > 1"
-    full-width
+    centered
     :current="currentPage"
     :total="totalPages"
     @page-change="onPageChange"

--- a/packages/admin/frontend-src/src/components/RowActions.vue
+++ b/packages/admin/frontend-src/src/components/RowActions.vue
@@ -98,7 +98,7 @@ async function onResetExhausted() {
     :id="menuAnchor"
     icon="ellipsis"
     text="Actions"
-    hide-tooltip
+    tooltip-timing="never"
     variant="neutral-tinted"
     size="md"
   />

--- a/packages/admin/frontend-src/src/components/StatusBadge.vue
+++ b/packages/admin/frontend-src/src/components/StatusBadge.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { computed } from 'vue';
 import { STATUS_BADGE_MAP } from '../constants.js';
+import { formatStatus } from '../formatters.js';
 
 const props = defineProps({
   status: { type: String, required: true },
@@ -8,14 +9,16 @@ const props = defineProps({
   errorMessage: { type: String, default: null },
 });
 
+// Colour stays keyed on the raw enum value; only the visible label is humanised.
 const variant = computed(() => STATUS_BADGE_MAP[props.status] || 'neutral');
+const label = computed(() => formatStatus(props.status));
 </script>
 
 <template>
-  <nldd-tooltip v-if="errorMessage" :text="errorMessage" placement="top">
+  <nldd-tooltip v-if="errorMessage" :text="errorMessage" placement="top" timing="instant">
     <nldd-tag
       :color="variant"
-      :text="status"
+      :text="label"
       :size="size"
       icon="info"
     />
@@ -23,7 +26,7 @@ const variant = computed(() => STATUS_BADGE_MAP[props.status] || 'neutral');
   <nldd-tag
     v-else
     :color="variant"
-    :text="status"
+    :text="label"
     :size="size"
   />
 </template>

--- a/packages/admin/frontend-src/src/components/StatusBadge.vue
+++ b/packages/admin/frontend-src/src/components/StatusBadge.vue
@@ -6,7 +6,6 @@ import { formatStatus } from '../formatters.js';
 const props = defineProps({
   status: { type: String, required: true },
   size: { type: String, default: 'sm' },
-  errorMessage: { type: String, default: null },
 });
 
 // Colour stays keyed on the raw enum value; only the visible label is humanised.
@@ -15,18 +14,5 @@ const label = computed(() => formatStatus(props.status));
 </script>
 
 <template>
-  <nldd-tooltip v-if="errorMessage" :text="errorMessage" placement="top" timing="instant">
-    <nldd-tag
-      :color="variant"
-      :text="label"
-      :size="size"
-      icon="info"
-    />
-  </nldd-tooltip>
-  <nldd-tag
-    v-else
-    :color="variant"
-    :text="label"
-    :size="size"
-  />
+  <nldd-tag :color="variant" :text="label" :size="size" />
 </template>

--- a/packages/admin/frontend-src/src/components/StatusBadge.vue
+++ b/packages/admin/frontend-src/src/components/StatusBadge.vue
@@ -14,7 +14,7 @@ const variant = computed(() => STATUS_BADGE_MAP[props.status] || 'neutral');
 <template>
   <nldd-tooltip v-if="errorMessage" :text="errorMessage" placement="top">
     <nldd-tag
-      :variant="variant"
+      :color="variant"
       :text="status"
       :size="size"
       icon="info"
@@ -22,7 +22,7 @@ const variant = computed(() => STATUS_BADGE_MAP[props.status] || 'neutral');
   </nldd-tooltip>
   <nldd-tag
     v-else
-    :variant="variant"
+    :color="variant"
     :text="status"
     :size="size"
   />

--- a/packages/admin/frontend-src/src/components/TableToolbar.vue
+++ b/packages/admin/frontend-src/src/components/TableToolbar.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { computed, onUnmounted, useId } from 'vue';
+import { formatStatus } from '../formatters.js';
 
 const props = defineProps({
   columns: { type: Array, required: true },
@@ -59,7 +60,7 @@ function getFilterButtonLabel(col) {
   const key = getFilterKey(col);
   const value = props.filters[key];
   const label = getFilterLabel(col);
-  return `${label}: ${value || 'All'}`;
+  return `${label}: ${value ? formatStatus(value) : 'All'}`;
 }
 
 function onSortSelect(event) {
@@ -143,7 +144,7 @@ onUnmounted(() => Object.values(debounceTimers).forEach(clearTimeout));
           v-for="v in col.filter.options"
           :key="v"
           type="radio"
-          :text="v"
+          :text="formatStatus(v)"
           :value="v"
           :selected="filters[getFilterKey(col)] === v"
         />

--- a/packages/admin/frontend-src/src/components/ViewToggle.vue
+++ b/packages/admin/frontend-src/src/components/ViewToggle.vue
@@ -7,7 +7,7 @@ defineEmits(['change']);
 </script>
 
 <template>
-  <nldd-segmented-control size="sm" :value="value" @change="$emit('change', $event)">
+  <nldd-segmented-control size="sm" width="fit-content" :value="value" @change="$emit('change', $event)">
     <nldd-segmented-control-item value="grouped" text="Grouped" />
     <nldd-segmented-control-item value="flat" text="Flat" />
   </nldd-segmented-control>

--- a/packages/admin/frontend-src/src/composables/useColorScheme.js
+++ b/packages/admin/frontend-src/src/composables/useColorScheme.js
@@ -1,0 +1,59 @@
+/**
+ * useColorScheme — color scheme picker for the admin app.
+ *
+ * Values: 'auto' | 'light' | 'dark'. Applied to <html> as the `data-scheme`
+ * attribute that @nldd/design-system keys its dark tokens on; 'auto' is
+ * encoded as the *absence* of the attribute so the OS-level
+ * `prefers-color-scheme` media query takes over.
+ *
+ * Unlike the editor's server-backed user settings, the admin has no user
+ * settings endpoint, so the preference is persisted in localStorage only.
+ */
+import { ref, readonly, computed, watchEffect } from 'vue';
+
+const VALID_THEMES = ['auto', 'light', 'dark'];
+const STORAGE_KEY = 'rr-admin-theme';
+
+function readCached() {
+  try {
+    const v = window.localStorage?.getItem(STORAGE_KEY);
+    return VALID_THEMES.includes(v) ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeCached(value) {
+  try {
+    window.localStorage?.setItem(STORAGE_KEY, value);
+  } catch {
+    // Ignore storage errors (private mode, quota, disabled) — the only
+    // consequence is the scheme resets to 'auto' on next load.
+  }
+}
+
+const theme = ref(
+  (typeof window !== 'undefined' && readCached()) || 'auto',
+);
+
+// Apply to <html>. 'auto' removes the attribute so the design-system's
+// `@media (prefers-color-scheme: dark)` selector drives the palette.
+watchEffect(() => {
+  if (typeof document === 'undefined') return;
+  const root = document.documentElement;
+  if (theme.value === 'auto') root.removeAttribute('data-scheme');
+  else root.setAttribute('data-scheme', theme.value);
+});
+
+function setColorScheme(value) {
+  if (!VALID_THEMES.includes(value)) return;
+  theme.value = value;
+  writeCached(value);
+}
+
+export function useColorScheme() {
+  return {
+    colorScheme: readonly(theme),
+    setColorScheme,
+  };
+}

--- a/packages/admin/frontend-src/src/composables/useTableFilters.js
+++ b/packages/admin/frontend-src/src/composables/useTableFilters.js
@@ -1,0 +1,28 @@
+import { computed } from 'vue';
+
+/**
+ * Shared filter helpers for the data/grouped tables.
+ *
+ * A search/filter is "active" when any filter holds a non-empty value. This
+ * lets the caller tell an *empty* state (no data at all → hide the toolbar)
+ * apart from a *no-results* state (filters excluded everything → keep the
+ * toolbar so the user can clear or change the search).
+ *
+ * @param {() => object} getFilters - returns the current filters object
+ * @param {(event: string, ...args: unknown[]) => void} emit - component emit
+ */
+export function useTableFilters(getFilters, emit) {
+  const hasActiveFilters = computed(() =>
+    Object.values(getFilters() || {}).some((v) => v !== '' && v != null),
+  );
+
+  // Clear every active filter by emitting an empty value per key — the
+  // parent's setFilter handler deletes a filter when given a falsy value.
+  function clearFilters() {
+    for (const key of Object.keys(getFilters() || {})) {
+      emit('filter-change', key, '');
+    }
+  }
+
+  return { hasActiveFilters, clearFilters };
+}

--- a/packages/admin/frontend-src/src/constants.js
+++ b/packages/admin/frontend-src/src/constants.js
@@ -54,6 +54,7 @@ export const JOB_COLUMNS = [
     width: 'fit-content',
     minWidth: '40px',
     align: 'right',
+    hideBelow: '640px',
     text: (row) => `Prio ${row.priority ?? '—'}`,
   },
 ];
@@ -69,7 +70,7 @@ export const GROUPED_COLUMNS = [
       g.latest_created_at ? `Updated at ${formatDate(g.latest_created_at)}` : undefined,
   },
   { key: 'status_bar', label: 'Status', sortable: false, width: '80px' },
-  { key: 'total_jobs', label: 'Jobs', sortable: true, filter: { key: 'status', options: JOB_STATUSES, label: 'Status' }, width: 'fit-content', minWidth: '24px', align: 'right' },
+  { key: 'total_jobs', label: 'Jobs', sortable: true, filter: { key: 'status', options: JOB_STATUSES, label: 'Status' }, width: 'fit-content', minWidth: '24px', align: 'right', hideBelow: '640px' },
 ];
 
 // Sort menus are independent from visible columns — users should be able to

--- a/packages/admin/frontend-src/src/constants.js
+++ b/packages/admin/frontend-src/src/constants.js
@@ -42,9 +42,11 @@ export const JOB_COLUMNS = [
     label: 'Job',
     sortable: true,
     filter: { key: 'law_id', type: 'text', label: 'Law ID' },
-    overline: (row) => row.law_id,
-    text: (row) => row.id,
-    supportingText: (row) => jobSubtitle(row),
+    overline: (row) => `${row.law_id} › ${row.id}`,
+    // Every row has the same shape: subtitle as the main text; a failed
+    // job's error message goes underneath as supporting text.
+    text: (row) => jobSubtitle(row),
+    supportingText: (row) => row.result?.error || undefined,
   },
   { key: 'status', label: 'Status', sortable: true, filter: { options: JOB_STATUSES }, width: 110 },
   {

--- a/packages/admin/frontend-src/src/formatters.js
+++ b/packages/admin/frontend-src/src/formatters.js
@@ -19,6 +19,14 @@ export function truncateUuid(value) {
   return str.length > 8 ? str.substring(0, 8) : str;
 }
 
+// snake_case status → human-readable sentence case, e.g.
+// 'harvest_failed' → 'Harvest failed', 'enriching' → 'Enriching'.
+export function formatStatus(value) {
+  if (value === null || value === undefined || value === '') return '';
+  const s = String(value).replace(/_/g, ' ');
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
 export function jobSubtitle(job) {
   const type = job.job_type
     ? job.job_type.charAt(0).toUpperCase() + job.job_type.slice(1)

--- a/packages/admin/frontend-src/src/views/JobsView.vue
+++ b/packages/admin/frontend-src/src/views/JobsView.vue
@@ -82,7 +82,7 @@ function onViewChange(event) {
       <ViewToggle :value="viewMode" @change="onViewChange" />
     </template>
     <template #cell-status="{ row }">
-      <StatusBadge :status="row.status || 'unknown'" :error-message="row.result?.error" />
+      <StatusBadge :status="row.status || 'unknown'" />
     </template>
     <template #empty-action>
       <nldd-button

--- a/packages/admin/frontend-src/vite.config.js
+++ b/packages/admin/frontend-src/vite.config.js
@@ -3,6 +3,14 @@ import vue from '@vitejs/plugin-vue';
 
 export default defineConfig({
   root: '.',
+  // Vite's built-in SPA history-fallback (the default for appType 'spa')
+  // already serves index.html for client-side routes while correctly
+  // excluding vite internals (/@vite/client, /@id/, /node_modules, …) and
+  // requests with a file extension. A previous hand-rolled
+  // `admin-spa-fallback` plugin rewrote *every* extensionless request —
+  // including /@vite/client — to /index.html, which breaks module loading
+  // under Vite 8 (blank screen in `vite dev`). Rely on the built-in instead.
+  appType: 'spa',
   plugins: [
     vue({
       template: {
@@ -11,18 +19,6 @@ export default defineConfig({
         },
       },
     }),
-    {
-      name: 'admin-spa-fallback',
-      configureServer(server) {
-        server.middlewares.use((req, _res, next) => {
-          const url = req.url.split('?')[0];
-          if (!url.includes('.') && url !== '/') {
-            req.url = '/index.html';
-          }
-          next();
-        });
-      },
-    },
   ],
   build: {
     cssTarget: ['chrome123', 'edge123', 'firefox120', 'safari18'],


### PR DESCRIPTION
## Summary
- Migrate frontend, admin, docs and lawmaking to the `@nldd/design-system@0.8.44` API
- Editor: action-sheet edit flow, per-value menus, editable produces dropdowns, reliable machine_readable edits (DataCloneError fix), result sheet loading/error+reload, scenario data-source drill-in, nldd-native layout/spacing, empty-input validation
- Library: route-driven Bibliotheek/Editor tab bar, RegelRecht title, books icon
- Admin: 0.8.44 migration, account/theme menu, empty-vs-no-results states, job error message as row text, responsive columns
- 71 commits, 40 files (+1213 / −706); branch rebased on current main

## Test plan
- [ ] `frontend`: `npx vitest run` (125 tests) + `npx vite build`
- [ ] `packages/admin/frontend-src`: `npx vite build`
- [ ] Smoke-test editor: action sheet, machine view (produces dropdowns, save), scenario sheet (drill-in, validation, Save dirty/revert)
- [ ] Smoke-test library tab navigation (Bibliotheek ↔ Editor incl. auth redirect + browser back)
- [ ] Smoke-test admin jobs flat/grouped views

🤖 Generated with [Claude Code](https://claude.com/claude-code)