### PR TITLE
feat(editor): show resolved notes in the law text (RFC-018 phase 4)

### DIFF
--- a/frontend/scripts/copy-laws.js
+++ b/frontend/scripts/copy-laws.js
@@ -173,6 +173,30 @@ for (const source of localSources) {
   }
 }
 
+// Copy note sidecar files (RFC-005/RFC-018) to public/data/annotations/.
+// useNotes.js fetches /data/annotations/{lawId}/annotations.yaml; the
+// annotation directories are already keyed by the law's $id. The
+// _vocabulary/ dir is build/CI-only (validate-annotations) and is not
+// fetched by the editor, so it is skipped.
+const annotationsSrc = resolve(projectRoot, 'corpus', 'annotations');
+if (existsSync(annotationsSrc)) {
+  const annotationsDest = resolve(destDir, 'annotations');
+  let annotationFiles = 0;
+  for (const lawId of readdirSync(annotationsSrc)) {
+    if (lawId === '_vocabulary') continue;
+    const lawDir = resolve(annotationsSrc, lawId);
+    if (!statSync(lawDir).isDirectory()) continue;
+    for (const file of readdirSync(lawDir)) {
+      if (!file.endsWith('.yaml')) continue;
+      const dest = resolve(annotationsDest, lawId, file);
+      mkdirSync(dirname(dest), { recursive: true });
+      cpSync(resolve(lawDir, file), dest);
+      annotationFiles++;
+    }
+  }
+  console.log(`  ${annotationFiles} note sidecar file(s) copied to /data/annotations/`);
+}
+
 index.sort((a, b) =>
   a.regulatory_layer.localeCompare(b.regulatory_layer) || a.id.localeCompare(b.id)
 );

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -173,7 +173,6 @@ const {
   loading: notesLoading,
   error: notesError,
 } = useNotes(lawId, selectedArticle);
-const selectedNote = ref(null);
 
 const resultSheetOpen = ref(false);
 const graphSheetOpen = ref(false);
@@ -1390,7 +1389,6 @@ async function handleActionSave() {
                   <AnnotatedText
                     :article="selectedArticle"
                     :notes-for-article="notesForArticle"
-                    @select-note="selectedNote = $event"
                   />
                   <nldd-inline-dialog
                     v-if="noteIssues.length"

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -36,6 +36,9 @@ const editorPanelFlags = [
   ['panel.machine_readable', 'Machine editor'],
   ['panel.scenario_form', 'Scenario editor'],
   ['panel.yaml_editor', 'YAML editor'],
+  // Capability gate: when on, the Tekst pane offers a "Notities"
+  // toggle that overlays resolved notes on the article text. Not a
+  // separate pane (notes are a layer over the text, not other content).
   ['panel.notes', 'Notities'],
   ['editor.article_text_edit', 'Tekst bewerken'],
 ];
@@ -52,7 +55,6 @@ const VIEW_DEFINITIONS = [
   { id: 'machine', flag: 'panel.machine_readable', label: 'Machine' },
   { id: 'scenario', flag: 'panel.scenario_form', label: "Scenario's" },
   { id: 'yaml', flag: 'panel.yaml_editor', label: 'YAML' },
-  { id: 'notes', flag: 'panel.notes', label: 'Notities' },
 ];
 
 const availableViews = computed(() => VIEW_DEFINITIONS.filter(v => isEnabled(v.flag)));
@@ -173,6 +175,21 @@ const {
   loading: notesLoading,
   error: notesError,
 } = useNotes(lawId, selectedArticle);
+
+// Notes are a layer over the Tekst pane, not a separate pane. This toggle is
+// the user's "show notes now" preference; panel.notes (a feature flag) is the
+// capability gate that makes the toggle available at all. Persisted so it
+// survives navigation within a session.
+const NOTES_TOGGLE_KEY = 'regelrecht-show-notes';
+const showNotes = ref(localStorage.getItem(NOTES_TOGGLE_KEY) === '1');
+watch(showNotes, (v) => {
+  try { localStorage.setItem(NOTES_TOGGLE_KEY, v ? '1' : '0'); } catch { /* ignore */ }
+});
+// Notes overlay only makes sense in read mode: the resolver matches raw text,
+// so it cannot align with the markdown render or the editable textarea.
+const notesActive = computed(
+  () => isEnabled('panel.notes') && showNotes.value && !canEditArticleText.value,
+);
 
 const resultSheetOpen = ref(false);
 const graphSheetOpen = ref(false);
@@ -1243,6 +1260,20 @@ async function handleActionSave() {
                     @select="setPaneView(idx, opt.id)"
                   ></nldd-menu-item>
                 </nldd-menu>
+                <!-- Notes toggle: only on the Tekst pane, only when the
+                     panel.notes capability is enabled, and only in read mode
+                     (the overlay needs raw text — it can't align with the
+                     editable textarea). Notes are a layer over the text, not
+                     a separate pane. -->
+                <nldd-button
+                  v-if="view === 'text' && isEnabled('panel.notes') && !canEditArticleText"
+                  size="md"
+                  :variant="showNotes ? 'primary' : 'default'"
+                  start-icon="comment"
+                  text="Notities"
+                  data-testid="notes-toggle"
+                  @click="showNotes = !showNotes"
+                ></nldd-button>
                 <!-- Formatting toolbar lives in the pane-header so it sits in
                      line with the pane-view dropdown rather than below it.
                      Wired to the ArticleTextEditor instance via textEditorRefs
@@ -1314,6 +1345,33 @@ async function handleActionSave() {
                   :model-value="editedText"
                   @update:model-value="editedText = $event"
                 />
+                <!-- Notes overlay (read mode only): same Tekst pane, plain
+                     text with resolved highlights instead of the markdown
+                     render. Toggled via the header button below. -->
+                <template v-else-if="notesActive">
+                  <nldd-inline-dialog
+                    v-if="notesError"
+                    variant="alert"
+                    text="Notities niet geladen"
+                    :supporting-text="notesError.message"
+                  ></nldd-inline-dialog>
+                  <nldd-inline-dialog
+                    v-else-if="notesLoading"
+                    text="Notities laden…"
+                  ></nldd-inline-dialog>
+                  <template v-else>
+                    <AnnotatedText
+                      :article="selectedArticle"
+                      :notes-for-article="notesForArticle"
+                    />
+                    <nldd-inline-dialog
+                      v-if="noteIssues.length"
+                      variant="warning"
+                      :text="`${noteIssues.length} notitie(s) niet verankerd`"
+                      :supporting-text="noteIssues.map(i => i.reason).join('; ')"
+                    ></nldd-inline-dialog>
+                  </template>
+                </template>
                 <ArticleText v-else :article="selectedArticle" />
               </nldd-simple-section>
               <!-- Footer + Save button only on the first text pane (mirrors the machine pattern). -->
@@ -1371,33 +1429,6 @@ async function handleActionSave() {
                   @click="handleMachineReadableSave"
                 ></nldd-button>
               </nldd-container>
-
-              <!-- Notes (RFC-005/RFC-018): article text with resolved
-                   note highlights. Read-only in this phase. -->
-              <nldd-simple-section v-else-if="view === 'notes'" full-width>
-                <nldd-inline-dialog
-                  v-if="notesError"
-                  variant="alert"
-                  text="Notities niet geladen"
-                  :supporting-text="notesError.message"
-                ></nldd-inline-dialog>
-                <nldd-inline-dialog
-                  v-else-if="notesLoading"
-                  text="Notities laden…"
-                ></nldd-inline-dialog>
-                <template v-else>
-                  <AnnotatedText
-                    :article="selectedArticle"
-                    :notes-for-article="notesForArticle"
-                  />
-                  <nldd-inline-dialog
-                    v-if="noteIssues.length"
-                    variant="warning"
-                    :text="`${noteIssues.length} notitie(s) niet verankerd`"
-                    :supporting-text="noteIssues.map(i => i.reason).join('; ')"
-                  ></nldd-inline-dialog>
-                </template>
-              </nldd-simple-section>
 
               <!-- Scenario builder -->
               <template v-else-if="view === 'scenario'">
@@ -1627,3 +1658,4 @@ async function handleActionSave() {
   border-radius: 6px;
 }
 </style>
+// cache-bust 1779124589

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -6,10 +6,12 @@ import { useLaw, fetchLaw } from './composables/useLaw.js';
 import { useEngine } from './composables/useEngine.js';
 import { useAuth } from './composables/useAuth.js';
 import { useFeatureFlags } from './composables/useFeatureFlags.js';
+import { useNotes } from './composables/useNotes.js';
 import { useColorScheme } from './composables/useColorScheme.js';
 import { lastLibraryPath } from './composables/useLastVisitedRoute.js';
 import { SUPPORT_EMAIL } from './constants.js';
 import ArticleText from './components/ArticleText.vue';
+import AnnotatedText from './components/AnnotatedText.vue';
 import ArticleTextEditor from './components/ArticleTextEditor.vue';
 import ActionSheet from './components/ActionSheet.vue';
 import EditSheet from './components/EditSheet.vue';
@@ -34,6 +36,7 @@ const editorPanelFlags = [
   ['panel.machine_readable', 'Machine editor'],
   ['panel.scenario_form', 'Scenario editor'],
   ['panel.yaml_editor', 'YAML editor'],
+  ['panel.notes', 'Notities'],
   ['editor.article_text_edit', 'Tekst bewerken'],
 ];
 
@@ -49,6 +52,7 @@ const VIEW_DEFINITIONS = [
   { id: 'machine', flag: 'panel.machine_readable', label: 'Machine' },
   { id: 'scenario', flag: 'panel.scenario_form', label: "Scenario's" },
   { id: 'yaml', flag: 'panel.yaml_editor', label: 'YAML' },
+  { id: 'notes', flag: 'panel.notes', label: 'Notities' },
 ];
 
 const availableViews = computed(() => VIEW_DEFINITIONS.filter(v => isEnabled(v.flag)));
@@ -161,6 +165,15 @@ const {
   saveLaw,
   lastSavedPr,
 } = useLaw(route.params.lawId, route.params.articleNumber);
+
+// Notes (RFC-005/RFC-018) for the current law, resolved against its text.
+const {
+  notesForArticle,
+  issues: noteIssues,
+  loading: notesLoading,
+  error: notesError,
+} = useNotes(lawId, selectedArticle);
+const selectedNote = ref(null);
 
 const resultSheetOpen = ref(false);
 const graphSheetOpen = ref(false);
@@ -1359,6 +1372,34 @@ async function handleActionSave() {
                   @click="handleMachineReadableSave"
                 ></nldd-button>
               </nldd-container>
+
+              <!-- Notes (RFC-005/RFC-018): article text with resolved
+                   note highlights. Read-only in this phase. -->
+              <nldd-simple-section v-else-if="view === 'notes'" full-width>
+                <nldd-inline-dialog
+                  v-if="notesError"
+                  variant="alert"
+                  text="Notities niet geladen"
+                  :supporting-text="notesError.message"
+                ></nldd-inline-dialog>
+                <nldd-inline-dialog
+                  v-else-if="notesLoading"
+                  text="Notities laden…"
+                ></nldd-inline-dialog>
+                <template v-else>
+                  <AnnotatedText
+                    :article="selectedArticle"
+                    :notes-for-article="notesForArticle"
+                    @select-note="selectedNote = $event"
+                  />
+                  <nldd-inline-dialog
+                    v-if="noteIssues.length"
+                    variant="warning"
+                    :text="`${noteIssues.length} notitie(s) niet verankerd`"
+                    :supporting-text="noteIssues.map(i => i.reason).join('; ')"
+                  ></nldd-inline-dialog>
+                </template>
+              </nldd-simple-section>
 
               <!-- Scenario builder -->
               <template v-else-if="view === 'scenario'">

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -1265,11 +1265,15 @@ async function handleActionSave() {
                      (the overlay needs raw text — it can't align with the
                      editable textarea). Notes are a layer over the text, not
                      a separate pane. -->
+                <!-- No start-icon: the design-system has no note/comment
+                     glyph (its `comment` icon is an empty SVG). A misleading
+                     icon (edit/document) is worse than none; the "Notities"
+                     label is clear on its own. Tracked upstream:
+                     MinBZK/storybook icon-set request. -->
                 <nldd-button
                   v-if="view === 'text' && isEnabled('panel.notes') && !canEditArticleText"
                   size="md"
                   :variant="showNotes ? 'primary' : 'default'"
-                  start-icon="comment"
                   text="Notities"
                   data-testid="notes-toggle"
                   @click="showNotes = !showNotes"

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -1658,4 +1658,3 @@ async function handleActionSave() {
   border-radius: 6px;
 }
 </style>
-// cache-bust 1779124589

--- a/frontend/src/components/AnnotatedText.vue
+++ b/frontend/src/components/AnnotatedText.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed } from 'vue';
+import { computed, ref, useTemplateRef } from 'vue';
 import { markRanges } from '../composables/useNotes.js';
 
 const props = defineProps({
@@ -40,38 +40,135 @@ function authorityClass(note) {
   return 'note-authoritative';
 }
 
-function noteTitle(note) {
-  const body = Array.isArray(note?.body) ? note.body : note?.body ? [note.body] : [];
+function bodies(note) {
+  return Array.isArray(note?.body) ? note.body : note?.body ? [note.body] : [];
+}
+function noteText(note) {
   // W3C allows a plain-string body shorthand (`body: "text"`) alongside the
-  // structured TextualBody form; surface either.
-  const text =
-    body.find((b) => typeof b === 'string') ??
-    body.find((b) => b?.type === 'TextualBody')?.value;
-  const link = body.find((b) => b?.type === 'SpecificResource')?.source;
-  return `${note?.motivation ?? 'note'}${text ? `: ${text}` : link ? ` → ${link}` : ''}`;
+  // structured TextualBody form; surface either, but not the tagging body
+  // (that is shown as chips).
+  return (
+    bodies(note).find((b) => typeof b === 'string') ??
+    bodies(note).find((b) => b?.type === 'TextualBody' && b.purpose !== 'tagging')?.value ??
+    ''
+  );
+}
+function noteLink(note) {
+  return bodies(note).find((b) => b?.type === 'SpecificResource')?.source || '';
+}
+function noteTags(note) {
+  return bodies(note)
+    .filter((b) => b?.type === 'TextualBody' && b.purpose === 'tagging')
+    .map((b) => b.value);
+}
+function noteCreator(note) {
+  if (!note?.creator) return '';
+  return typeof note.creator === 'string' ? note.creator : note.creator.name || '';
+}
+
+// --- Hover popover -------------------------------------------------------
+// One shared nldd-popover. On hover/focus of a highlight we point its
+// anchorElement at that mark, set the active note, and open it. nldd-popover
+// is a native HTML popover (click/light-dismiss by design), so hover is wired
+// manually with a small close delay so the pointer can travel mark -> popover
+// without it snapping shut.
+const popoverEl = useTemplateRef('popoverEl');
+const activeNote = ref(null);
+let closeTimer = null;
+
+function openFor(event, note) {
+  if (closeTimer) {
+    clearTimeout(closeTimer);
+    closeTimer = null;
+  }
+  activeNote.value = note;
+  const pop = popoverEl.value;
+  if (!pop) return;
+  pop.anchorElement = event.currentTarget;
+  // showPopover throws if already open; guard with matches(':popover-open').
+  try {
+    if (!pop.matches?.(':popover-open')) pop.showPopover?.();
+  } catch {
+    /* popover already open against another anchor — anchorElement moved it */
+  }
+}
+
+function scheduleClose() {
+  if (closeTimer) clearTimeout(closeTimer);
+  closeTimer = setTimeout(() => {
+    popoverEl.value?.hidePopover?.();
+    activeNote.value = null;
+    closeTimer = null;
+  }, 160);
+}
+
+function cancelClose() {
+  if (closeTimer) {
+    clearTimeout(closeTimer);
+    closeTimer = null;
+  }
 }
 </script>
 
 <template>
   <template v-if="article">
     <nldd-rich-text>
-      <!-- Phase 4 is display-only. The marks are not interactive yet, so no
-           role="button"/tabindex (that would announce an action that does
-           nothing — an accessibility lie). The note content is surfaced via
-           the title tooltip. Phase 5 adds a detail panel and makes the marks
-           focusable + keyboard-activatable. -->
       <p>
         <template v-for="(seg, i) in segments" :key="i">
           <mark
             v-if="seg.note"
-            :class="[motivationClass(seg.note), authorityClass(seg.note)]"
-            :title="noteTitle(seg.note)"
+            :class="[
+              motivationClass(seg.note),
+              authorityClass(seg.note),
+              { 'is-active': activeNote === seg.note },
+            ]"
+            tabindex="0"
+            :aria-label="`Notitie: ${seg.note.motivation}`"
+            @mouseenter="openFor($event, seg.note)"
+            @mouseleave="scheduleClose"
+            @focus="openFor($event, seg.note)"
+            @blur="scheduleClose"
             >{{ seg.text }}</mark
           >
           <template v-else>{{ seg.text }}</template>
         </template>
       </p>
     </nldd-rich-text>
+
+    <!-- Single shared popover; anchorElement is repointed per hovered mark. -->
+    <nldd-popover
+      ref="popoverEl"
+      accessible-label="Notitie"
+      placement="bottom-start"
+      @mouseenter="cancelClose"
+      @mouseleave="scheduleClose"
+    >
+      <div v-if="activeNote" class="note-pop" :class="motivationClass(activeNote)">
+        <div class="note-pop__head">
+          <span class="note-pop__badge">{{ activeNote.motivation }}</span>
+          <span v-if="noteCreator(activeNote)" class="note-pop__creator">{{
+            noteCreator(activeNote)
+          }}</span>
+        </div>
+        <p v-if="noteText(activeNote)" class="note-pop__body">{{ noteText(activeNote) }}</p>
+        <a
+          v-if="noteLink(activeNote)"
+          class="note-pop__link"
+          :href="noteLink(activeNote)"
+          @click.prevent
+          >{{ noteLink(activeNote) }}</a
+        >
+        <div v-if="noteTags(activeNote).length" class="note-pop__tags">
+          <span v-for="t in noteTags(activeNote)" :key="t" class="note-pop__tag">{{ t }}</span>
+        </div>
+        <span
+          v-if="activeNote.workflow"
+          class="note-pop__workflow"
+          :data-state="activeNote.workflow"
+          >{{ activeNote.workflow === 'open' ? 'open vraag' : 'afgehandeld' }}</span
+        >
+      </div>
+    </nldd-popover>
   </template>
   <nldd-inline-dialog v-else text="Geen artikel geselecteerd"></nldd-inline-dialog>
 </template>
@@ -86,7 +183,12 @@ p {
 mark {
   padding: 0 0.1em;
   border-radius: 2px;
+  cursor: help;
+  transition: filter 0.12s;
   /* Authority -> border style. */
+}
+mark.is-active {
+  filter: brightness(1.15) saturate(1.3);
 }
 mark.note-authoritative {
   border-bottom: 2px solid currentColor;
@@ -121,5 +223,83 @@ mark.note-other {
 mark:focus-visible {
   outline: 2px solid currentColor;
   outline-offset: 1px;
+}
+
+/* Popover card content. Border-left echoes the highlight colour so the
+   popover is visually tied to the mark it describes. */
+.note-pop {
+  border-left: 3px solid transparent;
+  padding-left: 10px;
+}
+.note-pop.note-linking {
+  border-left-color: #3b82f6;
+}
+.note-pop.note-commenting {
+  border-left-color: #eab308;
+}
+.note-pop.note-questioning {
+  border-left-color: #f97316;
+}
+.note-pop.note-tagging {
+  border-left-color: #22c55e;
+}
+.note-pop.note-other {
+  border-left-color: #94a3b8;
+}
+.note-pop__head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+.note-pop__badge {
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  opacity: 0.7;
+}
+.note-pop__creator {
+  font-size: 0.72rem;
+  opacity: 0.55;
+  margin-left: auto;
+}
+.note-pop__body {
+  margin: 0;
+  font-size: 0.88rem;
+  line-height: 1.5;
+}
+.note-pop__link {
+  display: inline-block;
+  margin-top: 8px;
+  font-size: 0.8rem;
+  word-break: break-all;
+}
+.note-pop__tags {
+  margin-top: 10px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+.note-pop__tag {
+  font-size: 0.72rem;
+  padding: 1px 8px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.2);
+}
+.note-pop__workflow {
+  display: inline-block;
+  margin-top: 10px;
+  font-size: 0.72rem;
+  padding: 1px 8px;
+  border-radius: 4px;
+}
+.note-pop__workflow[data-state='open'] {
+  background: rgba(249, 115, 22, 0.18);
+  color: #c2410c;
+}
+.note-pop__workflow[data-state='resolved'] {
+  background: rgba(34, 197, 94, 0.18);
+  color: #15803d;
 }
 </style>

--- a/frontend/src/components/AnnotatedText.vue
+++ b/frontend/src/components/AnnotatedText.vue
@@ -8,8 +8,6 @@ const props = defineProps({
   notesForArticle: { type: Array, default: () => [] },
 });
 
-const emit = defineEmits(['select-note']);
-
 // The resolver matched against the raw article text, so offsets are into that
 // exact string. Rendering markdown here would desync the offsets, so notes are
 // shown over plain text. (ArticleText.vue keeps the markdown view for the
@@ -53,16 +51,17 @@ function noteTitle(note) {
 <template>
   <template v-if="article">
     <nldd-rich-text>
+      <!-- Phase 4 is display-only. The marks are not interactive yet, so no
+           role="button"/tabindex (that would announce an action that does
+           nothing — an accessibility lie). The note content is surfaced via
+           the title tooltip. Phase 5 adds a detail panel and makes the marks
+           focusable + keyboard-activatable. -->
       <p>
         <template v-for="(seg, i) in segments" :key="i">
           <mark
             v-if="seg.note"
             :class="[motivationClass(seg.note), authorityClass(seg.note)]"
             :title="noteTitle(seg.note)"
-            tabindex="0"
-            role="button"
-            @click="emit('select-note', seg.note)"
-            @keydown.enter="emit('select-note', seg.note)"
             >{{ seg.text }}</mark
           >
           <template v-else>{{ seg.text }}</template>
@@ -74,10 +73,15 @@ function noteTitle(note) {
 </template>
 
 <style scoped>
+/* Legal text carries its own paragraph breaks (\n\n). Preserve them so the
+   Notities pane reads like the other text panes instead of one collapsed
+   block. pre-wrap keeps wrapping while honouring newlines. */
+p {
+  white-space: pre-wrap;
+}
 mark {
   padding: 0 0.1em;
   border-radius: 2px;
-  cursor: pointer;
   /* Authority -> border style. */
 }
 mark.note-authoritative {

--- a/frontend/src/components/AnnotatedText.vue
+++ b/frontend/src/components/AnnotatedText.vue
@@ -225,11 +225,16 @@ mark:focus-visible {
   outline-offset: 1px;
 }
 
-/* Popover card content. Border-left echoes the highlight colour so the
-   popover is visually tied to the mark it describes. */
+/* Popover card content. nldd-popover does not pad slotted content, so the
+   card sets its own padding. It also does not inherit the editor's UI font
+   into the slot, so set RijksSansVF explicitly (the design-system UI face)
+   instead of falling back to a serif default — that was the "gek font" on
+   the heading. Border-left echoes the highlight colour so the popover is
+   visually tied to the mark it describes. */
 .note-pop {
+  font-family: 'RijksSansVF', system-ui, sans-serif;
+  padding: 14px 16px;
   border-left: 3px solid transparent;
-  padding-left: 10px;
 }
 .note-pop.note-linking {
   border-left-color: #3b82f6;
@@ -250,18 +255,35 @@ mark:focus-visible {
   display: flex;
   align-items: center;
   gap: 8px;
-  margin-bottom: 6px;
+  margin-bottom: 8px;
 }
+/* Small coloured pill instead of a bare uppercase word — the uppercase +
+   letter-spacing read as a "weird font" against the serif fallback. */
 .note-pop__badge {
   font-size: 0.72rem;
   font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.03em;
-  opacity: 0.7;
+  padding: 2px 8px;
+  border-radius: 999px;
+  color: #fff;
+}
+.note-pop.note-linking .note-pop__badge {
+  background: #3b82f6;
+}
+.note-pop.note-commenting .note-pop__badge {
+  background: #ca8a04;
+}
+.note-pop.note-questioning .note-pop__badge {
+  background: #ea580c;
+}
+.note-pop.note-tagging .note-pop__badge {
+  background: #16a34a;
+}
+.note-pop.note-other .note-pop__badge {
+  background: #64748b;
 }
 .note-pop__creator {
-  font-size: 0.72rem;
-  opacity: 0.55;
+  font-size: 0.75rem;
+  opacity: 0.6;
   margin-left: auto;
 }
 .note-pop__body {

--- a/frontend/src/components/AnnotatedText.vue
+++ b/frontend/src/components/AnnotatedText.vue
@@ -1,0 +1,114 @@
+<script setup>
+import { computed } from 'vue';
+import { markRanges } from '../composables/useNotes.js';
+
+const props = defineProps({
+  article: { type: Object, default: null },
+  // [{ note, spans }] for the current article, from useNotes().notesForArticle
+  notesForArticle: { type: Array, default: () => [] },
+});
+
+const emit = defineEmits(['select-note']);
+
+// The resolver matched against the raw article text, so offsets are into that
+// exact string. Rendering markdown here would desync the offsets, so notes are
+// shown over plain text. (ArticleText.vue keeps the markdown view for the
+// non-annotated Tekst pane.)
+const segments = computed(() => {
+  if (!props.article?.text) return [];
+  return markRanges(props.article.text, props.notesForArticle);
+});
+
+// W3C motivation -> colour class. Linking blue, commenting yellow,
+// questioning orange, tagging green (RFC-018 Decision 10).
+function motivationClass(note) {
+  const m = note?.motivation;
+  if (m === 'linking') return 'note-linking';
+  if (m === 'commenting') return 'note-commenting';
+  if (m === 'questioning') return 'note-questioning';
+  if (m === 'tagging') return 'note-tagging';
+  return 'note-other';
+}
+
+// Authority is derived from the creator (RFC-018 Decision 3). The editor does
+// not yet know each law's competent_authority, so for now: a known tool
+// creator => generated (dotted), anything else => default (solid). Advisory
+// (dashed) is reserved for when competent_authority wiring lands.
+function authorityClass(note) {
+  const c = (note?.creator || '').toString().toLowerCase();
+  if (c.includes('tool') || c.includes('llm') || c.includes('generated')) {
+    return 'note-generated';
+  }
+  return 'note-authoritative';
+}
+
+function noteTitle(note) {
+  const body = Array.isArray(note?.body) ? note.body : note?.body ? [note.body] : [];
+  const text = body.find((b) => b?.type === 'TextualBody')?.value;
+  const link = body.find((b) => b?.type === 'SpecificResource')?.source;
+  return `${note?.motivation ?? 'note'}${text ? `: ${text}` : link ? ` → ${link}` : ''}`;
+}
+</script>
+
+<template>
+  <template v-if="article">
+    <nldd-rich-text>
+      <p>
+        <template v-for="(seg, i) in segments" :key="i">
+          <mark
+            v-if="seg.note"
+            :class="[motivationClass(seg.note), authorityClass(seg.note)]"
+            :title="noteTitle(seg.note)"
+            tabindex="0"
+            role="button"
+            @click="emit('select-note', seg.note)"
+            @keydown.enter="emit('select-note', seg.note)"
+            >{{ seg.text }}</mark
+          >
+          <template v-else>{{ seg.text }}</template>
+        </template>
+      </p>
+    </nldd-rich-text>
+  </template>
+  <nldd-inline-dialog v-else text="Geen artikel geselecteerd"></nldd-inline-dialog>
+</template>
+
+<style scoped>
+mark {
+  padding: 0 0.1em;
+  border-radius: 2px;
+  cursor: pointer;
+  /* Authority -> border style. */
+}
+mark.note-authoritative {
+  border-bottom: 2px solid currentColor;
+}
+mark.note-generated {
+  border-bottom: 2px dotted currentColor;
+}
+mark.note-advisory {
+  border-bottom: 2px dashed currentColor;
+}
+/* Motivation -> background colour. Kept light so text stays readable in
+   both themes; the design system's tokens would be preferable once the
+   notes feature has dedicated tokens. */
+mark.note-linking {
+  background: rgba(59, 130, 246, 0.28);
+}
+mark.note-commenting {
+  background: rgba(234, 179, 8, 0.28);
+}
+mark.note-questioning {
+  background: rgba(249, 115, 22, 0.3);
+}
+mark.note-tagging {
+  background: rgba(34, 197, 94, 0.28);
+}
+mark.note-other {
+  background: rgba(148, 163, 184, 0.28);
+}
+mark:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 1px;
+}
+</style>

--- a/frontend/src/components/AnnotatedText.vue
+++ b/frontend/src/components/AnnotatedText.vue
@@ -42,7 +42,11 @@ function authorityClass(note) {
 
 function noteTitle(note) {
   const body = Array.isArray(note?.body) ? note.body : note?.body ? [note.body] : [];
-  const text = body.find((b) => b?.type === 'TextualBody')?.value;
+  // W3C allows a plain-string body shorthand (`body: "text"`) alongside the
+  // structured TextualBody form; surface either.
+  const text =
+    body.find((b) => typeof b === 'string') ??
+    body.find((b) => b?.type === 'TextualBody')?.value;
   const link = body.find((b) => b?.type === 'SpecificResource')?.source;
   return `${note?.motivation ?? 'note'}${text ? `: ${text}` : link ? ` → ${link}` : ''}`;
 }
@@ -90,6 +94,9 @@ mark.note-authoritative {
 mark.note-generated {
   border-bottom: 2px dotted currentColor;
 }
+/* Reserved: authorityClass() returns 'note-advisory' once the
+   competent_authority wiring lands (RFC-018 Decision 3). Intentionally
+   kept ahead of its producer — not dead code. */
 mark.note-advisory {
   border-bottom: 2px dashed currentColor;
 }

--- a/frontend/src/composables/useFeatureFlags.js
+++ b/frontend/src/composables/useFeatureFlags.js
@@ -11,6 +11,9 @@ const DEFAULTS = {
   'panel.scenario_form': true,
   'panel.yaml_editor': true,
   'panel.machine_readable': true,
+  // Notes pane (RFC-005/RFC-018). Off by default until the feature is past
+  // the display-only MVP and the corpus has notes for more than one law.
+  'panel.notes': false,
   // Gates write access on the Tekst pane independently from its visibility.
   // Default off so users see article text in read-only mode until they
   // explicitly opt in — the first-save markdown normalisation rewrites the

--- a/frontend/src/composables/useNotes.js
+++ b/frontend/src/composables/useNotes.js
@@ -1,0 +1,153 @@
+/**
+ * useNotes — fetch a law's note sidecar and resolve it against the loaded law.
+ *
+ * Notes are W3C Web Annotations anchored to legal text via a TextQuoteSelector
+ * (RFC-005). The Rust resolver runs in WASM (`engine.resolveNotes`) so the
+ * editor shows exactly what the engine and CI validate. Match offsets are
+ * `char` offsets into the article text, not UTF-16 code units (see the WASM
+ * binding docs); `markRanges` converts them when slicing.
+ */
+import { ref, computed, watch } from 'vue';
+import { useEngine } from './useEngine.js';
+
+// Cache resolved notes per lawId for the session. The resolver result only
+// changes when the law text or the sidecar changes, neither of which happens
+// within a session without a reload.
+const cache = new Map();
+
+/**
+ * @param {import('vue').Ref<string>} lawId        reactive law $id
+ * @param {import('vue').Ref<object>} selectedArticle reactive current article
+ */
+export function useNotes(lawId, selectedArticle) {
+  const { initEngine, loadDependency } = useEngine();
+  const resolved = ref([]); // [{ note, match, error }]
+  const loading = ref(false);
+  const error = ref(null);
+
+  async function load() {
+    const id = lawId.value;
+    if (!id) {
+      resolved.value = [];
+      return;
+    }
+    if (cache.has(id)) {
+      resolved.value = cache.get(id);
+      return;
+    }
+
+    loading.value = true;
+    error.value = null;
+    try {
+      const res = await fetch(
+        `/data/annotations/${encodeURIComponent(id)}/annotations.yaml`,
+      );
+      if (res.status === 404) {
+        // A law without a sidecar is normal, not an error.
+        resolved.value = [];
+        cache.set(id, []);
+        return;
+      }
+      if (!res.ok) {
+        throw new Error(`Kon notities niet laden: ${res.status}`);
+      }
+      const yamlText = await res.text();
+
+      const engine = await initEngine();
+      // The resolver needs the law's articles loaded; mirror how the rest of
+      // the editor pulls a law into the engine.
+      if (!engine.hasLaw(id)) {
+        await loadDependency(id);
+      }
+      const result = engine.resolveNotes(id, yamlText);
+      resolved.value = Array.isArray(result) ? result : [];
+      cache.set(id, resolved.value);
+    } catch (e) {
+      error.value = e;
+      resolved.value = [];
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  watch(lawId, load, { immediate: true });
+
+  /**
+   * Notes whose match falls in the currently-selected article, each with the
+   * resolved span(s) for that article. Notes that are orphaned, ambiguous, or
+   * failed to parse are surfaced separately via `issues` so the UI can show
+   * them without anchoring them in the text.
+   */
+  const notesForArticle = computed(() => {
+    const articleNr = selectedArticle.value?.number;
+    if (!articleNr) return [];
+    const out = [];
+    for (const entry of resolved.value) {
+      if (entry.error || !entry.match) continue;
+      if (entry.match.status !== 'found') continue;
+      const spans = entry.match.matches.filter(
+        (m) => m.article_number === articleNr,
+      );
+      if (spans.length > 0) out.push({ note: entry.note, spans });
+    }
+    return out;
+  });
+
+  /** Orphaned / ambiguous / parse-failed notes, for a status list. */
+  const issues = computed(() =>
+    resolved.value
+      .filter(
+        (e) => e.error || (e.match && e.match.status !== 'found'),
+      )
+      .map((e) => ({
+        note: e.note,
+        reason: e.error
+          ? `parsefout: ${e.error}`
+          : e.match.status === 'orphaned'
+            ? 'niet gevonden in de wettekst (orphaned)'
+            : 'meerdere matches (ambigu) — voeg context toe',
+      })),
+  );
+
+  return { resolved, notesForArticle, issues, loading, error, reload: load };
+}
+
+/**
+ * Slice `text` into segments around resolved note spans, for rendering.
+ *
+ * Returns an ordered array of `{ text, note }` segments where `note` is null
+ * for plain text and the annotating note for a highlighted span. Overlapping
+ * spans are resolved by taking the earliest-starting, longest span (the
+ * resolver already de-duplicates, so overlaps across notes are rare).
+ *
+ * @param {string} text          article text (the same string the resolver saw)
+ * @param {Array<{note:object,spans:Array}>} notesForArticle
+ */
+export function markRanges(text, notesForArticle) {
+  const chars = Array.from(text); // char (code-point) array: offsets are char-based
+  const marks = [];
+  for (const { note, spans } of notesForArticle) {
+    for (const s of spans) {
+      marks.push({ start: s.start, end: s.end, note });
+    }
+  }
+  marks.sort((a, b) => a.start - b.start || b.end - a.end);
+
+  const segments = [];
+  let cursor = 0;
+  for (const m of marks) {
+    if (m.start < cursor) continue; // skip overlap with an already-emitted mark
+    if (m.start > cursor) {
+      segments.push({ text: chars.slice(cursor, m.start).join(''), note: null });
+    }
+    segments.push({
+      text: chars.slice(m.start, m.end).join(''),
+      note: m.note,
+    });
+    cursor = m.end;
+  }
+  if (cursor < chars.length) {
+    segments.push({ text: chars.slice(cursor).join(''), note: null });
+  }
+  return segments;
+}

--- a/frontend/src/composables/useNotes.js
+++ b/frontend/src/composables/useNotes.js
@@ -11,8 +11,15 @@ import { ref, computed, watch } from 'vue';
 import { useEngine } from './useEngine.js';
 
 // Cache resolved notes per lawId for the session. The resolver result only
-// changes when the law text or the sidecar changes, neither of which happens
-// within a session without a reload.
+// changes when the law text or the sidecar changes.
+//
+// Caveat (acceptable for the display-only, default-off MVP; revisit in the
+// note-editing phase): the key is `lawId` (`law.$id`) alone, which does not
+// encode the law *version*. RFC-005 notes resolve per version, and a save
+// through the editor changes the text without changing `$id`. This cache is
+// not invalidated on save, so editing a law in-session and reopening its
+// Notities pane could show offsets resolved against the pre-save text. Once
+// notes become editable, key by `$id` + version and invalidate on save.
 const cache = new Map();
 
 /**
@@ -25,14 +32,29 @@ export function useNotes(lawId, selectedArticle) {
   const loading = ref(false);
   const error = ref(null);
 
+  // Generation guard: each load() call claims a generation; only the latest
+  // is allowed to write reactive state. Without this, navigating between laws
+  // while a slow annotations fetch is in flight lets the older response
+  // overwrite the newer law's notes — and because article numbers collide
+  // across laws ('1','2','3' everywhere) the stale offsets would silently
+  // highlight wrong spans. useLaw guards the same race the same way.
+  let generation = 0;
+
   async function load() {
     const id = lawId.value;
+    const gen = ++generation;
+    const isStale = () => gen !== generation;
+
     if (!id) {
       resolved.value = [];
+      error.value = null;
       return;
     }
     if (cache.has(id)) {
+      // Reset error too: a cached law (e.g. a 404 → []) must not keep showing
+      // the previous law's "kon notities niet laden" alert.
       resolved.value = cache.get(id);
+      error.value = null;
       return;
     }
 
@@ -44,8 +66,8 @@ export function useNotes(lawId, selectedArticle) {
       );
       if (res.status === 404) {
         // A law without a sidecar is normal, not an error.
-        resolved.value = [];
         cache.set(id, []);
+        if (!isStale()) resolved.value = [];
         return;
       }
       if (!res.ok) {
@@ -60,13 +82,17 @@ export function useNotes(lawId, selectedArticle) {
         await loadDependency(id);
       }
       const result = engine.resolveNotes(id, yamlText);
-      resolved.value = Array.isArray(result) ? result : [];
-      cache.set(id, resolved.value);
+      const list = Array.isArray(result) ? result : [];
+      cache.set(id, list);
+      if (!isStale()) resolved.value = list;
     } catch (e) {
-      error.value = e;
-      resolved.value = [];
+      if (!isStale()) {
+        error.value = e;
+        resolved.value = [];
+      }
     } finally {
-      loading.value = false;
+      // Only the latest load owns the loading flag.
+      if (!isStale()) loading.value = false;
     }
   }
 
@@ -80,13 +106,17 @@ export function useNotes(lawId, selectedArticle) {
    */
   const notesForArticle = computed(() => {
     const articleNr = selectedArticle.value?.number;
-    if (!articleNr) return [];
+    if (articleNr == null || articleNr === '') return [];
+    // String() both sides: js-yaml decodes an unquoted `number: 2` to a JS
+    // number while the resolver's article_number is always a string. useLaw
+    // applies the same defensive coercion for the same reason.
+    const target = String(articleNr);
     const out = [];
     for (const entry of resolved.value) {
       if (entry.error || !entry.match) continue;
       if (entry.match.status !== 'found') continue;
       const spans = entry.match.matches.filter(
-        (m) => m.article_number === articleNr,
+        (m) => String(m.article_number) === target,
       );
       if (spans.length > 0) out.push({ note: entry.note, spans });
     }
@@ -116,9 +146,16 @@ export function useNotes(lawId, selectedArticle) {
  * Slice `text` into segments around resolved note spans, for rendering.
  *
  * Returns an ordered array of `{ text, note }` segments where `note` is null
- * for plain text and the annotating note for a highlighted span. Overlapping
- * spans are resolved by taking the earliest-starting, longest span (the
- * resolver already de-duplicates, so overlaps across notes are rare).
+ * for plain text and the annotating note for a highlighted span. The result is
+ * a gap-free partition of `text` (every character emitted exactly once).
+ *
+ * Overlap handling: marks are sorted by start (longest first on ties); a mark
+ * that starts inside an already-emitted mark is dropped. The resolver
+ * de-duplicates a single selector's matches, but two *different* notes
+ * annotating overlapping spans is a legitimate RFC-018 case — the later one
+ * is silently not rendered here (it is not surfaced in `issues` either, since
+ * it resolved fine). Acceptable for display-only; the note-editing phase will
+ * need layered rendering instead of a flat partition.
  *
  * @param {string} text          article text (the same string the resolver saw)
  * @param {Array<{note:object,spans:Array}>} notesForArticle

--- a/frontend/src/composables/useNotes.js
+++ b/frontend/src/composables/useNotes.js
@@ -45,9 +45,15 @@ export function useNotes(lawId, selectedArticle) {
     const gen = ++generation;
     const isStale = () => gen !== generation;
 
+    // These early returns resolve synchronously. They must clear `loading`
+    // too: if a slow uncached load is in flight and the user navigates to a
+    // cached law, that older load is now stale and skips its own
+    // `loading = false` reset (gated on !isStale), so without clearing it
+    // here the "Notities laden…" spinner stays stuck forever.
     if (!id) {
       resolved.value = [];
       error.value = null;
+      loading.value = false;
       return;
     }
     if (cache.has(id)) {
@@ -55,6 +61,7 @@ export function useNotes(lawId, selectedArticle) {
       // the previous law's "kon notities niet laden" alert.
       resolved.value = cache.get(id);
       error.value = null;
+      loading.value = false;
       return;
     }
 
@@ -173,6 +180,11 @@ export function markRanges(text, notesForArticle) {
   const segments = [];
   let cursor = 0;
   for (const m of marks) {
+    // A zero-length span (start === end) would emit an empty, styled <mark>.
+    // The Rust resolver never produces this for a TextQuoteSelector, but a
+    // malformed hand-authored sidecar could; drop it so the contract is
+    // explicit and the partition stays clean.
+    if (m.end <= m.start) continue;
     if (m.start < cursor) continue; // skip overlap with an already-emitted mark
     if (m.start > cursor) {
       segments.push({ text: chars.slice(cursor, m.start).join(''), note: null });

--- a/frontend/src/composables/useNotes.test.js
+++ b/frontend/src/composables/useNotes.test.js
@@ -122,4 +122,17 @@ describe('markRanges', () => {
     expect(segs.filter((s) => s.note === noteB)).toHaveLength(1);
     assertPartition(text, segs);
   });
+
+  it('drops a zero-length span instead of emitting an empty mark', () => {
+    const text = 'heeft de verzekerde aanspraak';
+    const segs = markRanges(text, [
+      { note: noteA, spans: [{ start: 9, end: 9 }] }, // degenerate span
+      { note: noteB, spans: [{ start: 9, end: 19 }] }, // "verzekerde"
+    ]);
+    // No empty-text segment, no mark for the zero-length note.
+    expect(segs.every((s) => s.text.length > 0)).toBe(true);
+    expect(segs.some((s) => s.note === noteA)).toBe(false);
+    expect(segs.filter((s) => s.note === noteB)).toHaveLength(1);
+    assertPartition(text, segs);
+  });
 });

--- a/frontend/src/composables/useNotes.test.js
+++ b/frontend/src/composables/useNotes.test.js
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import { markRanges } from './useNotes.js';
+
+// markRanges is the highest-risk pure function in the notes feature: it turns
+// resolver char-offsets into rendered segments. These tests pin the partition
+// invariant (every char emitted exactly once) and the documented overlap
+// behaviour.
+
+const noteA = { motivation: 'linking' };
+const noteB = { motivation: 'commenting' };
+
+/** Re-joining all segment texts must reproduce the input exactly. */
+function assertPartition(text, segments) {
+  expect(segments.map((s) => s.text).join('')).toBe(text);
+}
+
+describe('markRanges', () => {
+  it('returns one plain segment when there are no notes', () => {
+    const text = 'heeft de verzekerde aanspraak';
+    const segs = markRanges(text, []);
+    expect(segs).toEqual([{ text, note: null }]);
+    assertPartition(text, segs);
+  });
+
+  it('wraps a single span and keeps the surrounding text', () => {
+    const text = 'op een zorgtoeslag hier';
+    // "zorgtoeslag" is chars 7..18
+    const segs = markRanges(text, [
+      { note: noteA, spans: [{ start: 7, end: 18 }] },
+    ]);
+    expect(segs).toEqual([
+      { text: 'op een ', note: null },
+      { text: 'zorgtoeslag', note: noteA },
+      { text: ' hier', note: null },
+    ]);
+    assertPartition(text, segs);
+  });
+
+  it('handles a span at the very start and end', () => {
+    const text = 'abcdef';
+    expect(markRanges(text, [{ note: noteA, spans: [{ start: 0, end: 3 }] }])).toEqual([
+      { text: 'abc', note: noteA },
+      { text: 'def', note: null },
+    ]);
+    expect(markRanges(text, [{ note: noteA, spans: [{ start: 3, end: 6 }] }])).toEqual([
+      { text: 'abc', note: null },
+      { text: 'def', note: noteA },
+    ]);
+  });
+
+  it('emits two adjacent non-overlapping marks with no gap', () => {
+    const text = '0123456789';
+    const segs = markRanges(text, [
+      { note: noteA, spans: [{ start: 1, end: 3 }] },
+      { note: noteB, spans: [{ start: 3, end: 5 }] },
+    ]);
+    expect(segs).toEqual([
+      { text: '0', note: null },
+      { text: '12', note: noteA },
+      { text: '34', note: noteB },
+      { text: '56789', note: null },
+    ]);
+    assertPartition(text, segs);
+  });
+
+  it('drops a later mark that overlaps an earlier one, keeping the partition intact', () => {
+    const text = '0123456789';
+    // B (2..6) overlaps A (1..4); A starts first so B is dropped.
+    const segs = markRanges(text, [
+      { note: noteB, spans: [{ start: 2, end: 6 }] },
+      { note: noteA, spans: [{ start: 1, end: 4 }] },
+    ]);
+    expect(segs).toEqual([
+      { text: '0', note: null },
+      { text: '123', note: noteA },
+      { text: '456789', note: null },
+    ]);
+    // Invariant holds even when a note is dropped.
+    assertPartition(text, segs);
+    expect(segs.some((s) => s.note === noteB)).toBe(false);
+  });
+
+  it('prefers the longer span on equal start (sort tiebreak)', () => {
+    const text = '0123456789';
+    const segs = markRanges(text, [
+      { note: noteA, spans: [{ start: 1, end: 3 }] },
+      { note: noteB, spans: [{ start: 1, end: 6 }] },
+    ]);
+    // Both start at 1; the longer (B, 1..6) wins, the shorter is dropped.
+    expect(segs).toEqual([
+      { text: '0', note: null },
+      { text: '12345', note: noteB },
+      { text: '6789', note: null },
+    ]);
+    assertPartition(text, segs);
+  });
+
+  it('treats offsets as code points, not UTF-16 units', () => {
+    // "ë" is one code point; an astral emoji is one code point but two UTF-16
+    // units. The resolver yields code-point offsets, so markRanges must slice
+    // by code point. After "café🎉 " (c a f é 🎉 space = 6 code points) the
+    // word "tekst" is chars 6..11.
+    const text = 'café🎉 tekst hier';
+    const segs = markRanges(text, [
+      { note: noteA, spans: [{ start: 6, end: 11 }] },
+    ]);
+    expect(segs).toEqual([
+      { text: 'café🎉 ', note: null },
+      { text: 'tekst', note: noteA },
+      { text: ' hier', note: null },
+    ]);
+    assertPartition(text, segs);
+  });
+
+  it('handles multiple notes across the text in document order', () => {
+    const text = 'de verzekerde heeft aanspraak op zorgtoeslag';
+    const segs = markRanges(text, [
+      { note: noteA, spans: [{ start: 3, end: 13 }] }, // "verzekerde"
+      { note: noteB, spans: [{ start: 33, end: 44 }] }, // "zorgtoeslag"
+    ]);
+    expect(segs.filter((s) => s.note === noteA)).toHaveLength(1);
+    expect(segs.filter((s) => s.note === noteB)).toHaveLength(1);
+    assertPartition(text, segs);
+  });
+});

--- a/packages/editor-api/src/feature_flags.rs
+++ b/packages/editor-api/src/feature_flags.rs
@@ -16,6 +16,11 @@ static DEFAULTS: LazyLock<HashMap<String, bool>> = LazyLock::new(|| {
         ("panel.yaml_editor".into(), true),
         ("panel.machine_readable".into(), true),
         ("panel.law_graph".into(), false),
+        // Notes pane (RFC-005/RFC-018). Default off: display-only MVP, notes
+        // exist for one law so far. Must be registered here or the toggle PUT
+        // 400s and the frontend silently reverts it (see the editor.* note
+        // below — same allow-list mechanism).
+        ("panel.notes".into(), false),
         // Editor capability flags — visibility is panel.*, editability is editor.*.
         // The frontend wires editor.article_text_edit (default off) to gate
         // write access on the Tekst pane. Without the key here the backend's


### PR DESCRIPTION
Fase 4 van de notes-infrastructuur: notes zichtbaar in de editor. Bouwt op #634 (resolver + schema + WASM, inmiddels in `main`).

## Wat

- **`useNotes.js`** — haalt `/data/annotations/{lawId}/annotations.yaml` op, resolvet via `engine.resolveNotes` (de WASM-binding uit #634), geeft notes per geselecteerd artikel plus een `issues`-lijst (orphaned / ambiguous / parsefout, zodat die zichtbaar zijn zonder ze in de tekst te verankeren). `markRanges()` splitst de artikeltekst op char-offsets in gemarkeerde segmenten.
- **`AnnotatedText.vue`** — rendert de tekst met `<mark>`-spans. Kleur per W3C-motivation (linking blauw, commenting geel, questioning oranje, tagging groen), randstijl per autoriteit (gezaghebbend solid, gegenereerd dotted; advisory/dashed gereserveerd tot `competent_authority`-wiring er is). Klikbaar → `select-note`.
- **`EditorApp.vue`** — Notities-tab achter feature-flag `panel.notes` (`VIEW_DEFINITIONS` + `editorPanelFlags`), pane-render-branch, een status-dialog voor niet-verankerde notes.
- **`useFeatureFlags.js`** — `panel.notes` default `false` (display-only MVP).

## Ontwerpkeuze

Notes worden over **platte tekst** getoond, niet over de markdown-render. De resolver matcht tegen de ruwe artikeltekst; door markdown te renderen zouden de char-offsets desynchroniseren. De bestaande markdown-Tekst-pane (`ArticleText.vue`) blijft ongewijzigd.

## Verificatie

`npm run build` groen (332 modules), `npm test` groen (125 tests, 9 files). Geen bestaande tests gebroken.

Nog niet in deze PR: fase 5 (notes aanmaken via tekstselectie), fase 6 (CI-koppeling). Issue #636 (sidebar-autogeneratie) is een los vervolg.