### PR TITLE
docs: genereer VitePress RFC-sidebar en index uit rfc-*.md

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vitepress'
 import { withMermaid } from 'vitepress-plugin-mermaid'
+import { rfcSidebarItems } from './rfcs'
 
 export default withMermaid(
   defineConfig({
@@ -143,25 +144,7 @@ export default withMermaid(
         '/rfcs/': [
           {
             text: 'RFCs',
-            items: [
-              { text: 'Overview', link: '/rfcs/' },
-              { text: 'RFC-000: RFC Process', link: '/rfcs/rfc-000' },
-              { text: 'RFC-001: YAML Schema', link: '/rfcs/rfc-001' },
-              { text: 'RFC-002: Authority Roles', link: '/rfcs/rfc-002' },
-              { text: 'RFC-003: Inversion of Control', link: '/rfcs/rfc-003' },
-              { text: 'RFC-004: Uniform Operations', link: '/rfcs/rfc-004' },
-              { text: 'RFC-005: Stand-off Notes', link: '/rfcs/rfc-005' },
-              { text: 'RFC-006: Language Choice', link: '/rfcs/rfc-006' },
-              { text: 'RFC-007: Cross-Law Execution', link: '/rfcs/rfc-007' },
-              { text: 'RFC-008: Bestuursrecht/AWB', link: '/rfcs/rfc-008' },
-              { text: 'RFC-009: Multi-Org Execution', link: '/rfcs/rfc-009' },
-              { text: 'RFC-010: Federated Corpus', link: '/rfcs/rfc-010' },
-              { text: 'RFC-012: Untranslatables', link: '/rfcs/rfc-012' },
-              { text: 'RFC-013: Execution Provenance', link: '/rfcs/rfc-013' },
-              { text: 'RFC-014: Engine Conformance', link: '/rfcs/rfc-014' },
-              { text: 'RFC-015: Engine Policy', link: '/rfcs/rfc-015' },
-              { text: 'RFC-018: Note Infrastructure', link: '/rfcs/rfc-018' },
-            ],
+            items: rfcSidebarItems(),
           },
         ],
         '/reference/': [

--- a/docs/.vitepress/rfcs.ts
+++ b/docs/.vitepress/rfcs.ts
@@ -37,6 +37,7 @@ const SHORT_TITLE = /^\*\*Short title:\*\*\s*(.+?)\s*$/m
  */
 export function getRfcs(): RfcEntry[] {
   const entries: RfcEntry[] = []
+  const seen = new Map<number, string>()
 
   for (const filename of readdirSync(RFCS_DIR)) {
     // This filter excludes index.md and template.md by construction.
@@ -52,10 +53,23 @@ export function getRfcs(): RfcEntry[] {
     }
 
     const num = parseInt(h1[1], 10)
+    const existing = seen.get(num)
+    if (existing) {
+      throw new Error(
+        `RFC-${num} declared in both ${existing} and ${filename}; ` +
+          'RFC numbers must be unique',
+      )
+    }
+    seen.set(num, filename)
+
     const title = h1[2]
     const status = content.match(STATUS)?.[1] ?? 'Unknown'
     const shortTitle = content.match(SHORT_TITLE)?.[1] ?? title
 
+    // The link is derived from a filename we just read, so it provably
+    // resolves to a real page. This is why a bare <a href> in the index
+    // component is safe even though it sidesteps VitePress dead-link
+    // checking: a non-existent target cannot be produced here.
     entries.push({
       num,
       id: `RFC-${String(num).padStart(3, '0')}`,

--- a/docs/.vitepress/rfcs.ts
+++ b/docs/.vitepress/rfcs.ts
@@ -1,0 +1,78 @@
+// Single source of truth for the RFC list.
+//
+// Both the VitePress sidebar (config.ts) and the index table (via a data
+// loader) are generated from docs/rfcs/rfc-*.md, so they cannot drift apart.
+// This module is pure Node — no Vue/VitePress imports — so it runs in the
+// VitePress config and in the data loader at build time.
+
+import { readdirSync, readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+export interface RfcEntry {
+  /** Numeric RFC number, e.g. 8 */
+  num: number
+  /** Zero-padded id, e.g. "RFC-008" */
+  id: string
+  /** Full H1 title — used in the index table */
+  title: string
+  /** Optional **Short title:** value, falls back to title — used in the sidebar */
+  shortTitle: string
+  /** Status from the **Status:** preamble line */
+  status: string
+  /** Site-relative link derived from the real filename, e.g. "/rfcs/rfc-008" */
+  link: string
+}
+
+const RFCS_DIR = fileURLToPath(new URL('../rfcs', import.meta.url))
+
+const RFC_FILE = /^rfc-(\d+)\.md$/
+const H1 = /^#\s*RFC-(\d+):\s*(.+?)\s*$/m
+const STATUS = /^\*\*Status:\*\*\s*(.+?)\s*$/m
+const SHORT_TITLE = /^\*\*Short title:\*\*\s*(.+?)\s*$/m
+
+/**
+ * Scan docs/rfcs for rfc-NNN.md files and parse number, title, status and
+ * optional short title from each. Throws if an RFC file lacks a parseable H1,
+ * so a broken RFC fails the build loudly instead of silently disappearing.
+ */
+export function getRfcs(): RfcEntry[] {
+  const entries: RfcEntry[] = []
+
+  for (const filename of readdirSync(RFCS_DIR)) {
+    // This filter excludes index.md and template.md by construction.
+    if (!RFC_FILE.test(filename)) continue
+
+    const content = readFileSync(`${RFCS_DIR}/${filename}`, 'utf-8')
+
+    const h1 = content.match(H1)
+    if (!h1) {
+      throw new Error(
+        `docs/rfcs/${filename}: no parseable "# RFC-NNN: Title" heading found`,
+      )
+    }
+
+    const num = parseInt(h1[1], 10)
+    const title = h1[2]
+    const status = content.match(STATUS)?.[1] ?? 'Unknown'
+    const shortTitle = content.match(SHORT_TITLE)?.[1] ?? title
+
+    entries.push({
+      num,
+      id: `RFC-${String(num).padStart(3, '0')}`,
+      title,
+      shortTitle,
+      status,
+      link: `/rfcs/${filename.replace(/\.md$/, '')}`,
+    })
+  }
+
+  return entries.sort((a, b) => a.num - b.num)
+}
+
+/** Sidebar items for the `/rfcs/` section, with the Overview entry first. */
+export function rfcSidebarItems(): { text: string; link: string }[] {
+  return [
+    { text: 'Overview', link: '/rfcs/' },
+    ...getRfcs().map((r) => ({ text: `${r.id}: ${r.shortTitle}`, link: r.link })),
+  ]
+}

--- a/docs/.vitepress/theme/components/RfcIndexTable.vue
+++ b/docs/.vitepress/theme/components/RfcIndexTable.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+import { data as rfcs } from '../../../rfcs/index.data'
+</script>
+
+<template>
+  <table>
+    <thead>
+      <tr>
+        <th>RFC</th>
+        <th>Title</th>
+        <th>Status</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr v-for="rfc in rfcs" :key="rfc.num">
+        <td><a :href="rfc.link">{{ rfc.id }}</a></td>
+        <td>{{ rfc.title }}</td>
+        <td>{{ rfc.status }}</td>
+      </tr>
+    </tbody>
+  </table>
+</template>

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,10 +1,13 @@
 import DefaultTheme from 'vitepress/theme'
 import type { Theme } from 'vitepress'
 import './custom.css'
+import RfcIndexTable from './components/RfcIndexTable.vue'
 
 export default {
   extends: DefaultTheme,
   enhanceApp({ app }) {
+    app.component('RfcIndexTable', RfcIndexTable)
+
     // Import design system tokens and components (client-side only)
     // @nldd/design-system is optional — the site works without it
     if (typeof window !== 'undefined') {

--- a/docs/rfcs/index.data.ts
+++ b/docs/rfcs/index.data.ts
@@ -1,0 +1,14 @@
+import { defineLoader } from 'vitepress'
+import { getRfcs, type RfcEntry } from '../.vitepress/rfcs'
+
+declare const data: RfcEntry[]
+export { data }
+
+export default defineLoader({
+  // Glob is relative to this file (docs/rfcs/), so dev-server HMR fires
+  // whenever an RFC's title or status changes.
+  watch: ['./rfc-*.md'],
+  load(): RfcEntry[] {
+    return getRfcs()
+  },
+})

--- a/docs/rfcs/index.md
+++ b/docs/rfcs/index.md
@@ -4,24 +4,7 @@ Design decisions in RegelRecht are documented through RFCs. Each RFC captures th
 
 ## Index
 
-| RFC | Title | Status |
-|-----|-------|--------|
-| [RFC-000](./rfc-000) | RFC Process | Accepted |
-| [RFC-001](./rfc-001) | YAML Schema Design Decisions | Accepted |
-| [RFC-002](./rfc-002) | Authority Roles and Relationships | Accepted |
-| [RFC-003](./rfc-003) | Inversion of Control | Accepted |
-| [RFC-004](./rfc-004) | Uniform Operation Syntax | Accepted |
-| [RFC-005](./rfc-005) | Stand-off Notes for Legal Texts | Accepted |
-| [RFC-006](./rfc-006) | Language Choice | Accepted |
-| [RFC-007](./rfc-007) | Cross-Law Execution | Accepted |
-| [RFC-008](./rfc-008) | Bestuursrecht / AWB Procedures | Accepted |
-| [RFC-009](./rfc-009) | Multi-Organisation Execution | Proposed |
-| [RFC-010](./rfc-010) | Federated Corpus | Accepted |
-| [RFC-012](./rfc-012) | Untranslatables | Proposed |
-| [RFC-013](./rfc-013) | Execution Provenance | Draft |
-| [RFC-014](./rfc-014) | Engine Conformance | Draft |
-| [RFC-015](./rfc-015) | Engine Policy | Proposed |
-| [RFC-018](./rfc-018) | Note Infrastructure | Accepted |
+<RfcIndexTable />
 
 ## Writing an RFC
 

--- a/docs/rfcs/rfc-001.md
+++ b/docs/rfcs/rfc-001.md
@@ -1,6 +1,6 @@
 # RFC-001: YAML Schema Design Decisions
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2025-11-20
 **Authors:** regelrecht team
 

--- a/docs/rfcs/rfc-002.md
+++ b/docs/rfcs/rfc-002.md
@@ -1,6 +1,6 @@
 # RFC-002: Bevoegdheid (Authority) in Machine-Readable Law
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2025-11-21
 **Authors:** Tim de Jager
 

--- a/docs/rfcs/rfc-004.md
+++ b/docs/rfcs/rfc-004.md
@@ -1,6 +1,6 @@
 # RFC-004: Uniform Operation Syntax
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2025-12-12
 **Authors:** regelrecht team
 

--- a/docs/rfcs/rfc-006.md
+++ b/docs/rfcs/rfc-006.md
@@ -1,6 +1,6 @@
 # RFC-006: Language Choice for Law Execution Engine
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2025-01-26
 **Authors:** regelrecht team
 

--- a/docs/rfcs/rfc-007.md
+++ b/docs/rfcs/rfc-007.md
@@ -1,6 +1,6 @@
 # RFC-007: Cross-Law Execution Model
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-03-21
 **Authors:** Eelco Hotting
 

--- a/docs/rfcs/rfc-008.md
+++ b/docs/rfcs/rfc-008.md
@@ -1,6 +1,6 @@
 # RFC-008: AWB Administrative Procedures
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-03-21
 **Authors:** Eelco Hotting
 **Depends on:** RFC-007 (Cross-Law Execution Model)

--- a/docs/rfcs/rfc-010.md
+++ b/docs/rfcs/rfc-010.md
@@ -1,6 +1,6 @@
 # RFC-010: Federated Corpus
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-03-18
 **Authors:** Anne Schuth
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2018,9 +2018,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Probleem

De RFC-lijst stond op drie plekken die handmatig in sync moesten blijven: de `rfc-NNN.md` bestanden zelf, de tabel in `docs/rfcs/index.md`, en de sidebar in `docs/.vitepress/config.ts`. Dat dreef aantoonbaar uit elkaar — RFC-008 had drie verschillende titels, RFC-005 een verouderde sidebar-titel, RFC-018 ontbrak helemaal in de sidebar (quick-fix #635).

## Aanpak

Eén gedeelde Node/fs-parser, `docs/.vitepress/rfcs.ts`, scant `docs/rfcs/rfc-*.md` en haalt per bestand het nummer, de H1-titel, de status en een optionele `**Short title:**`-regel op. De sidebar gebruikt die parser direct (config.ts draait in Node). De index-tabel gaat via een VitePress data-loader (`docs/rfcs/index.data.ts`) plus een globaal geregistreerde component (`RfcIndexTable.vue`), zodat fs-toegang build-time blijft en SSR-veilig is.

Het RFC-bestand is nu de enige bron van waarheid. Een nieuwe of hernoemde RFC verschijnt automatisch in sidebar én index, met de juiste titel en status.

- Sidebar-label = H1-titel, of de optionele `**Short title:**`-regel als die in de preamble staat.
- Index-tabel = volledige H1 + `**Status:**` uit het bestand.

## Bewust gevolg

Weergegeven titels worden gecorrigeerd naar de echte H1. RFC-008 toont nu "AWB Administrative Procedures" i.p.v. het oude handmatige "Bestuursrecht/AWB". Wie een korter menu-label wil, voegt een `**Short title:**`-regel toe aan dat RFC-bestand — geen aparte lijst meer om bij te werken.

## Verificatie

- `npm run build` in `docs/` slaagt schoon (parser gooit op een kapotte RFC, dus een schone build bewijst dat alle 16 RFC's geparset zijn; geen dode `/rfcs/rfc-*`-links).
- Gegenereerde HTML gecontroleerd: 16 tabelrijen, RFC-008 toont de echte H1, sidebar valt correct terug op de volle H1 waar geen short title is gezet.

Closes #636