### PR TITLE
feat(editor): notitie-highlights over de markdown-render i.p.v. platte tekst

### DIFF
--- a/frontend/src/components/AnnotatedText.test.js
+++ b/frontend/src/components/AnnotatedText.test.js
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { nextTick } from 'vue';
+import AnnotatedText from './AnnotatedText.vue';
+
+// Component-level tests for the two DOM-bound behaviours the pure
+// useNotesHighlight tests cannot cover: idempotent re-apply (clear before
+// re-wrap) and the deterministic overlap drop. The markdown render + offset
+// alignment themselves are covered by useNotesHighlight.test.js.
+
+const nlddStubs = {
+  'nldd-rich-text': { template: '<div><slot/></div>' },
+  'nldd-popover': { template: '<div><slot/></div>' },
+  'nldd-inline-dialog': { template: '<div/>' },
+};
+
+function mountWith(article, notesForArticle) {
+  return mount(AnnotatedText, {
+    props: { article, notesForArticle },
+    global: { stubs: nlddStubs },
+  });
+}
+
+// "1. " is a numbered-list prefix marked strips from the DOM text; the
+// resolver offsets are into the raw string including that prefix.
+const ART = {
+  number: '2',
+  text: '1. een verzekerde heeft aanspraak op zorgtoeslag',
+};
+// raw offsets: "verzekerde" = 7..17, "zorgtoeslag" = 37..48
+const noteVerzekerde = { motivation: 'commenting', creator: 'A' };
+const noteZorgtoeslag = { motivation: 'linking', creator: 'B' };
+
+describe('AnnotatedText markdown highlighting', () => {
+  it('wraps resolved spans in <mark> over the markdown-rendered list', async () => {
+    const wrapper = mountWith(ART, [
+      { note: noteVerzekerde, spans: [{ start: 3, end: 17 }] },
+    ]);
+    await nextTick();
+    const marks = wrapper.element.querySelectorAll('mark[data-note-idx]');
+    expect(marks).toHaveLength(1);
+    // The "1. " prefix is stripped; the mark covers "een verzekerde".
+    expect(marks[0].textContent).toBe('een verzekerde');
+    expect(marks[0].className).toContain('note-commenting');
+  });
+
+  it('is idempotent: re-applying does not double-wrap', async () => {
+    const wrapper = mountWith(ART, [
+      { note: noteVerzekerde, spans: [{ start: 7, end: 17 }] },
+    ]);
+    await nextTick();
+    expect(
+      wrapper.element.querySelectorAll('mark[data-note-idx]'),
+    ).toHaveLength(1);
+
+    // Change notes without changing the article text (the Fase-5 scenario:
+    // html is stable, only notesForArticle changes). Must clear the old
+    // mark, not stack a second one.
+    await wrapper.setProps({
+      notesForArticle: [
+        { note: noteZorgtoeslag, spans: [{ start: 37, end: 48 }] },
+      ],
+    });
+    await nextTick();
+    const marks = wrapper.element.querySelectorAll('mark[data-note-idx]');
+    expect(marks).toHaveLength(1);
+    expect(marks[0].textContent).toBe('zorgtoeslag');
+    // No leftover nested marks anywhere.
+    expect(wrapper.element.querySelectorAll('mark mark')).toHaveLength(0);
+  });
+
+  it('drops a later note overlapping an earlier one (document order wins)', async () => {
+    const wrapper = mountWith(ART, [
+      // Earlier note (by raw start) wins; the overlapping one is dropped,
+      // matching markRanges()'s deterministic behaviour.
+      { note: noteVerzekerde, spans: [{ start: 7, end: 17 }] },
+      { note: noteZorgtoeslag, spans: [{ start: 12, end: 25 }] },
+    ]);
+    await nextTick();
+    const marks = wrapper.element.querySelectorAll('mark[data-note-idx]');
+    expect(marks).toHaveLength(1);
+    expect(marks[0].dataset.noteIdx).toBe('0');
+    expect(marks[0].textContent).toBe('verzekerde');
+  });
+
+  it('renders no marks (clean markdown) when there are no notes', async () => {
+    const wrapper = mountWith(ART, []);
+    await nextTick();
+    expect(
+      wrapper.element.querySelectorAll('mark[data-note-idx]'),
+    ).toHaveLength(0);
+    // The list rendered: an <ol><li> from "1. ".
+    expect(wrapper.element.querySelector('ol li')).toBeTruthy();
+  });
+});

--- a/frontend/src/components/AnnotatedText.test.js
+++ b/frontend/src/components/AnnotatedText.test.js
@@ -3,6 +3,9 @@ import { mount } from '@vue/test-utils';
 import { nextTick } from 'vue';
 import AnnotatedText from './AnnotatedText.vue';
 
+// The watcher awaits nextTick before applyHighlights, so the test must wait
+// two ticks: one for the watcher to fire, one for its inner nextTick.
+
 // Component-level tests for the two DOM-bound behaviours the pure
 // useNotesHighlight tests cannot cover: idempotent re-apply (clear before
 // re-wrap) and the deterministic overlap drop. The markdown render + offset
@@ -37,6 +40,7 @@ describe('AnnotatedText markdown highlighting', () => {
       { note: noteVerzekerde, spans: [{ start: 3, end: 17 }] },
     ]);
     await nextTick();
+    await nextTick();
     const marks = wrapper.element.querySelectorAll('mark[data-note-idx]');
     expect(marks).toHaveLength(1);
     // The "1. " prefix is stripped; the mark covers "een verzekerde".
@@ -48,6 +52,7 @@ describe('AnnotatedText markdown highlighting', () => {
     const wrapper = mountWith(ART, [
       { note: noteVerzekerde, spans: [{ start: 7, end: 17 }] },
     ]);
+    await nextTick();
     await nextTick();
     expect(
       wrapper.element.querySelectorAll('mark[data-note-idx]'),
@@ -61,6 +66,7 @@ describe('AnnotatedText markdown highlighting', () => {
         { note: noteZorgtoeslag, spans: [{ start: 37, end: 48 }] },
       ],
     });
+    await nextTick();
     await nextTick();
     const marks = wrapper.element.querySelectorAll('mark[data-note-idx]');
     expect(marks).toHaveLength(1);
@@ -77,14 +83,43 @@ describe('AnnotatedText markdown highlighting', () => {
       { note: noteZorgtoeslag, spans: [{ start: 12, end: 25 }] },
     ]);
     await nextTick();
+    await nextTick();
     const marks = wrapper.element.querySelectorAll('mark[data-note-idx]');
     expect(marks).toHaveLength(1);
     expect(marks[0].dataset.noteIdx).toBe('0');
     expect(marks[0].textContent).toBe('verzekerde');
   });
 
+  it('does not wrap the inter-<li> whitespace nodes when a span crosses leden', async () => {
+    // marked emits "\n" text nodes between <li>s. A note spanning two leden
+    // must not wrap those bare newlines in a focusable, styled <mark>
+    // (invalid HTML + empty highlight blob between list items). Regression
+    // guard for the cross-node slice bug.
+    const twoLeden = {
+      number: '2',
+      text: '1. eerste lid hier\n\n2. tweede lid daar',
+    };
+    // Span from "eerste" (raw 3) through "tweede lid" — crosses the \n\n.
+    const wrapper = mountWith(twoLeden, [
+      { note: noteVerzekerde, spans: [{ start: 3, end: 34 }] },
+    ]);
+    await nextTick();
+    await nextTick();
+    const marks = [
+      ...wrapper.element.querySelectorAll('mark[data-note-idx]'),
+    ];
+    expect(marks.length).toBeGreaterThan(0);
+    // No mark may contain only whitespace.
+    for (const m of marks) {
+      expect(m.textContent.trim()).not.toBe('');
+    }
+    // No <mark> is a direct child of <ol> (would mean a wrapped \n node).
+    expect(wrapper.element.querySelectorAll('ol > mark')).toHaveLength(0);
+  });
+
   it('renders no marks (clean markdown) when there are no notes', async () => {
     const wrapper = mountWith(ART, []);
+    await nextTick();
     await nextTick();
     expect(
       wrapper.element.querySelectorAll('mark[data-note-idx]'),

--- a/frontend/src/components/AnnotatedText.vue
+++ b/frontend/src/components/AnnotatedText.vue
@@ -168,13 +168,18 @@ function applyHighlights() {
   }
 }
 
+// deep so an in-place mutation of notesForArticle (push/splice from the
+// upcoming editable-notes path) re-applies, not only a reference swap. The
+// await nextTick() ensures Vue has patched v-html before applyHighlights
+// walks the DOM (it also clears prior marks first, so a stale callback from
+// a rapid change is self-healing rather than additive).
 watch(
   [html, () => props.notesForArticle],
   async () => {
     await nextTick();
     applyHighlights();
   },
-  { immediate: true },
+  { immediate: true, deep: true },
 );
 
 // --- Hover popover -------------------------------------------------------
@@ -319,9 +324,6 @@ function noteCreator(note) {
 </template>
 
 <style scoped>
-/* Highlights are wrapped imperatively so they are not scoped-CSS targets via
-   Vue's data attribute; style <mark> through :deep so the rules still apply
-   inside nldd-rich-text's slotted content. */
 /* Marks are wrapped imperatively into nldd-rich-text's slotted light DOM, so
    they are not tagged with Vue's scoped data attribute; reach them with
    :deep(). Motivation -> background colour, authority -> border style, same
@@ -330,7 +332,6 @@ function noteCreator(note) {
   padding: 0 0.1em;
   border-radius: 2px;
   cursor: help;
-  transition: filter 0.12s;
 }
 .annotated-wrap :deep(mark.note-authoritative) {
   border-bottom: 2px solid currentColor;

--- a/frontend/src/components/AnnotatedText.vue
+++ b/frontend/src/components/AnnotatedText.vue
@@ -1,6 +1,11 @@
 <script setup>
-import { computed, ref, useTemplateRef } from 'vue';
-import { markRanges } from '../composables/useNotes.js';
+import { computed, ref, watch, nextTick, useTemplateRef, onBeforeUnmount } from 'vue';
+import { renderArticleHtml } from '../composables/useArticleMarkdown.js';
+import {
+  buildAlignment,
+  spanToNodeSlices,
+  cpToUtf16,
+} from '../composables/useNotesHighlight.js';
 
 const props = defineProps({
   article: { type: Object, default: null },
@@ -8,14 +13,30 @@ const props = defineProps({
   notesForArticle: { type: Array, default: () => [] },
 });
 
-// The resolver matched against the raw article text, so offsets are into that
-// exact string. Rendering markdown here would desync the offsets, so notes are
-// shown over plain text. (ArticleText.vue keeps the markdown view for the
-// non-annotated Tekst pane.)
-const segments = computed(() => {
-  if (!props.article?.text) return [];
-  return markRanges(props.article.text, props.notesForArticle);
-});
+// Render the law text as markdown, identical to the Tekst pane with notes
+// off (shared pipeline so the two cannot drift — #646). The resolver matched
+// char-offsets into the *raw* text; after rendering we re-anchor those onto
+// the DOM's text nodes and wrap each resolved span in a <mark> imperatively,
+// because the spans cross marked's generated <li>/<p> structure and cannot be
+// expressed as a flat string partition (that was the old markRanges path,
+// kept in useNotes.js as the reference implementation + its tests).
+const html = computed(() => renderArticleHtml(props.article?.text || ''));
+
+const richTextEl = useTemplateRef('richTextEl');
+
+// Index notes so a <mark> can carry data-note-idx and the delegated hover
+// handler can recover the note object without per-mark Vue bindings.
+const noteByIdx = computed(() => props.notesForArticle.map((n) => n.note));
+
+function collectTextNodes(root) {
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  const out = [];
+  let n;
+  while ((n = walker.nextNode())) {
+    out.push({ node: n, text: n.textContent });
+  }
+  return out;
+}
 
 // W3C motivation -> colour class. Linking blue, commenting yellow,
 // questioning orange, tagging green (RFC-018 Decision 10).
@@ -28,10 +49,10 @@ function motivationClass(note) {
   return 'note-other';
 }
 
-// Authority is derived from the creator (RFC-018 Decision 3). The editor does
-// not yet know each law's competent_authority, so for now: a known tool
-// creator => generated (dotted), anything else => default (solid). Advisory
-// (dashed) is reserved for when competent_authority wiring lands.
+// Authority -> border style. Derived from the creator (RFC-018 Decision 3):
+// a known tool creator => generated (dotted), anything else => default
+// (solid). Advisory (dashed) is reserved for when competent_authority wiring
+// lands.
 function authorityClass(note) {
   const c = (note?.creator || '').toString().toLowerCase();
   if (c.includes('tool') || c.includes('llm') || c.includes('generated')) {
@@ -40,13 +61,192 @@ function authorityClass(note) {
   return 'note-authoritative';
 }
 
+// Wrap one code-point slice of a text node in a <mark>. Splits the text node
+// so the Range covers exactly the slice, then surrounds it. Returns the
+// created <mark> (or null if the slice is degenerate after splitting).
+function wrapSlice(slice, noteIdx, note) {
+  const textNode = slice.node;
+  const full = textNode.textContent;
+  const u1 = cpToUtf16(full, slice.startCp);
+  const u2 = cpToUtf16(full, slice.endCp);
+  if (u2 <= u1) return null;
+  const range = document.createRange();
+  range.setStart(textNode, u1);
+  range.setEnd(textNode, u2);
+  const mark = document.createElement('mark');
+  mark.dataset.noteIdx = String(noteIdx);
+  // Class instead of data attribute so the scoped :deep() rules below match;
+  // mirrors the colour/border scheme of the pre-#646 string renderer.
+  mark.className = `${motivationClass(note)} ${authorityClass(note)}`;
+  mark.setAttribute('aria-label', `Notitie: ${note?.motivation ?? ''}`);
+  mark.setAttribute('tabindex', '0');
+  try {
+    range.surroundContents(mark);
+  } catch {
+    // surroundContents throws if the range partially selects a non-text
+    // node; our ranges are always within a single text node, so this is
+    // defensive only.
+    range.detach?.();
+    return null;
+  }
+  return mark;
+}
+
+// Unwrap every <mark> we added, restoring the original text nodes. v-html
+// resets the DOM when `html` changes, but a notes-only change (article
+// unchanged — e.g. once notes become editable) leaves the prior marks in
+// place, so applyHighlights must be idempotent and clean up first.
+function clearHighlights(root) {
+  for (const mark of root.querySelectorAll('mark[data-note-idx]')) {
+    const parent = mark.parentNode;
+    if (!parent) continue;
+    while (mark.firstChild) parent.insertBefore(mark.firstChild, mark);
+    parent.removeChild(mark);
+    parent.normalize(); // re-join the split text nodes so offsets are stable
+  }
+}
+
+// Vue paints the sanitized markdown via v-html, then we layer the marks on
+// top. Runs after every relevant change (article or notes). Idempotent:
+// clears prior marks, re-aligns, re-wraps.
+function applyHighlights() {
+  const root = richTextEl.value;
+  if (!root) return;
+  clearHighlights(root);
+
+  const rawText = props.article?.text || '';
+  const notes = props.notesForArticle;
+  if (!rawText || notes.length === 0) return;
+
+  const domNodes = collectTextNodes(root);
+  if (domNodes.length === 0) return;
+
+  const { rawToDom, desynced } = buildAlignment(rawText, domNodes);
+  // If the rendered text diverged from the raw text by more than the known
+  // raw-only transforms (list prefixes, collapsed whitespace) the offset map
+  // is untrustworthy. Better to show the clean markdown with no highlights
+  // than to smear every mark onto the wrong words. Surfaced via useNotes'
+  // `issues` is out of scope here; the spans simply do not render.
+  if (desynced) return;
+  const domNodeCpLen = new Map(
+    domNodes.map(({ node, text }) => [node, Array.from(text).length]),
+  );
+
+  // Flatten to (span, note) and wrap by descending raw start. surroundContents
+  // splits the text node, so processing the rightmost span first keeps every
+  // earlier span's node references and offsets valid. `wrapped` tracks the raw
+  // ranges already marked: a span that overlaps one is dropped, matching the
+  // deterministic drop in markRanges() (RFC-018's overlapping-notes case).
+  const flat = [];
+  notes.forEach((entry, idx) => {
+    for (const span of entry.spans) flat.push({ span, idx });
+  });
+  // Drop decision must use document order (ascending), so the *earlier* note
+  // wins the overlap, same as markRanges. Wrapping order stays descending.
+  const ascending = [...flat].sort(
+    (a, b) => a.span.start - b.span.start || b.span.end - a.span.end,
+  );
+  const keep = new Set();
+  let cursor = 0;
+  for (const item of ascending) {
+    if (item.span.start < cursor) continue; // overlaps an earlier kept span
+    keep.add(item);
+    cursor = item.span.end;
+  }
+
+  const descending = flat
+    .filter((item) => keep.has(item))
+    .sort((a, b) => b.span.start - a.span.start);
+
+  for (const { span, idx } of descending) {
+    const note = noteByIdx.value[idx];
+    const slices = spanToNodeSlices(rawToDom, span, domNodeCpLen);
+    // Wrap right-to-left within the span too, same node-stability reason.
+    for (let i = slices.length - 1; i >= 0; i--) {
+      wrapSlice(slices[i], idx, note);
+    }
+  }
+}
+
+watch(
+  [html, () => props.notesForArticle],
+  async () => {
+    await nextTick();
+    applyHighlights();
+  },
+  { immediate: true },
+);
+
+// --- Hover popover -------------------------------------------------------
+// One shared nldd-popover. Marks are created imperatively, so hover is wired
+// via event delegation on the container instead of per-<mark> @mouseenter.
+// nldd-popover is a native HTML popover (click/light-dismiss by design), so
+// hover is wired manually with a small close delay so the pointer can travel
+// mark -> popover without it snapping shut.
+const popoverEl = useTemplateRef('popoverEl');
+const activeNote = ref(null);
+let closeTimer = null;
+
+function markFromEvent(event) {
+  const el = event.target?.closest?.('mark[data-note-idx]');
+  if (!el) return null;
+  const idx = Number(el.dataset.noteIdx);
+  return { el, note: noteByIdx.value[idx] || null };
+}
+
+function openFor(el, note) {
+  if (closeTimer) {
+    clearTimeout(closeTimer);
+    closeTimer = null;
+  }
+  activeNote.value = note;
+  const pop = popoverEl.value;
+  if (!pop) return;
+  pop.anchorElement = el;
+  try {
+    if (!pop.matches?.(':popover-open')) pop.showPopover?.();
+  } catch {
+    /* already open against another anchor — anchorElement moved it */
+  }
+}
+
+function onPointerOver(event) {
+  const hit = markFromEvent(event);
+  if (hit?.note) openFor(hit.el, hit.note);
+}
+function onPointerOut(event) {
+  if (markFromEvent(event)) scheduleClose();
+}
+function onFocusIn(event) {
+  const hit = markFromEvent(event);
+  if (hit?.note) openFor(hit.el, hit.note);
+}
+function onFocusOut(event) {
+  if (markFromEvent(event)) scheduleClose();
+}
+
+function scheduleClose() {
+  if (closeTimer) clearTimeout(closeTimer);
+  closeTimer = setTimeout(() => {
+    popoverEl.value?.hidePopover?.();
+    activeNote.value = null;
+    closeTimer = null;
+  }, 160);
+}
+function cancelClose() {
+  if (closeTimer) {
+    clearTimeout(closeTimer);
+    closeTimer = null;
+  }
+}
+onBeforeUnmount(() => {
+  if (closeTimer) clearTimeout(closeTimer);
+});
+
 function bodies(note) {
   return Array.isArray(note?.body) ? note.body : note?.body ? [note.body] : [];
 }
 function noteText(note) {
-  // W3C allows a plain-string body shorthand (`body: "text"`) alongside the
-  // structured TextualBody form; surface either, but not the tagging body
-  // (that is shown as chips).
   return (
     bodies(note).find((b) => typeof b === 'string') ??
     bodies(note).find((b) => b?.type === 'TextualBody' && b.purpose !== 'tagging')?.value ??
@@ -65,75 +265,20 @@ function noteCreator(note) {
   if (!note?.creator) return '';
   return typeof note.creator === 'string' ? note.creator : note.creator.name || '';
 }
-
-// --- Hover popover -------------------------------------------------------
-// One shared nldd-popover. On hover/focus of a highlight we point its
-// anchorElement at that mark, set the active note, and open it. nldd-popover
-// is a native HTML popover (click/light-dismiss by design), so hover is wired
-// manually with a small close delay so the pointer can travel mark -> popover
-// without it snapping shut.
-const popoverEl = useTemplateRef('popoverEl');
-const activeNote = ref(null);
-let closeTimer = null;
-
-function openFor(event, note) {
-  if (closeTimer) {
-    clearTimeout(closeTimer);
-    closeTimer = null;
-  }
-  activeNote.value = note;
-  const pop = popoverEl.value;
-  if (!pop) return;
-  pop.anchorElement = event.currentTarget;
-  // showPopover throws if already open; guard with matches(':popover-open').
-  try {
-    if (!pop.matches?.(':popover-open')) pop.showPopover?.();
-  } catch {
-    /* popover already open against another anchor — anchorElement moved it */
-  }
-}
-
-function scheduleClose() {
-  if (closeTimer) clearTimeout(closeTimer);
-  closeTimer = setTimeout(() => {
-    popoverEl.value?.hidePopover?.();
-    activeNote.value = null;
-    closeTimer = null;
-  }, 160);
-}
-
-function cancelClose() {
-  if (closeTimer) {
-    clearTimeout(closeTimer);
-    closeTimer = null;
-  }
-}
 </script>
 
 <template>
   <template v-if="article">
-    <nldd-rich-text>
-      <p>
-        <template v-for="(seg, i) in segments" :key="i">
-          <mark
-            v-if="seg.note"
-            :class="[
-              motivationClass(seg.note),
-              authorityClass(seg.note),
-              { 'is-active': activeNote === seg.note },
-            ]"
-            tabindex="0"
-            :aria-label="`Notitie: ${seg.note.motivation}`"
-            @mouseenter="openFor($event, seg.note)"
-            @mouseleave="scheduleClose"
-            @focus="openFor($event, seg.note)"
-            @blur="scheduleClose"
-            >{{ seg.text }}</mark
-          >
-          <template v-else>{{ seg.text }}</template>
-        </template>
-      </p>
-    </nldd-rich-text>
+    <!-- Delegated hover/focus: marks are added imperatively after render. -->
+    <div
+      class="annotated-wrap"
+      @pointerover="onPointerOver"
+      @pointerout="onPointerOut"
+      @focusin="onFocusIn"
+      @focusout="onFocusOut"
+    >
+      <nldd-rich-text ref="richTextEl" v-html="html"></nldd-rich-text>
+    </div>
 
     <!-- Single shared popover; anchorElement is repointed per hovered mark. -->
     <nldd-popover
@@ -174,63 +319,53 @@ function cancelClose() {
 </template>
 
 <style scoped>
-/* Legal text carries its own paragraph breaks (\n\n). Preserve them so the
-   Notities pane reads like the other text panes instead of one collapsed
-   block. pre-wrap keeps wrapping while honouring newlines. */
-p {
-  white-space: pre-wrap;
-}
-mark {
+/* Highlights are wrapped imperatively so they are not scoped-CSS targets via
+   Vue's data attribute; style <mark> through :deep so the rules still apply
+   inside nldd-rich-text's slotted content. */
+/* Marks are wrapped imperatively into nldd-rich-text's slotted light DOM, so
+   they are not tagged with Vue's scoped data attribute; reach them with
+   :deep(). Motivation -> background colour, authority -> border style, same
+   scheme as the pre-#646 string renderer. */
+.annotated-wrap :deep(mark) {
   padding: 0 0.1em;
   border-radius: 2px;
   cursor: help;
   transition: filter 0.12s;
-  /* Authority -> border style. */
 }
-mark.is-active {
-  filter: brightness(1.15) saturate(1.3);
-}
-mark.note-authoritative {
+.annotated-wrap :deep(mark.note-authoritative) {
   border-bottom: 2px solid currentColor;
 }
-mark.note-generated {
+.annotated-wrap :deep(mark.note-generated) {
   border-bottom: 2px dotted currentColor;
 }
-/* Reserved: authorityClass() returns 'note-advisory' once the
-   competent_authority wiring lands (RFC-018 Decision 3). Intentionally
-   kept ahead of its producer — not dead code. */
-mark.note-advisory {
+/* Reserved: authorityClass() returns 'note-advisory' once competent_authority
+   wiring lands (RFC-018 Decision 3). Kept ahead of its producer. */
+.annotated-wrap :deep(mark.note-advisory) {
   border-bottom: 2px dashed currentColor;
 }
-/* Motivation -> background colour. Kept light so text stays readable in
-   both themes; the design system's tokens would be preferable once the
-   notes feature has dedicated tokens. */
-mark.note-linking {
+.annotated-wrap :deep(mark.note-linking) {
   background: rgba(59, 130, 246, 0.28);
 }
-mark.note-commenting {
+.annotated-wrap :deep(mark.note-commenting) {
   background: rgba(234, 179, 8, 0.28);
 }
-mark.note-questioning {
+.annotated-wrap :deep(mark.note-questioning) {
   background: rgba(249, 115, 22, 0.3);
 }
-mark.note-tagging {
+.annotated-wrap :deep(mark.note-tagging) {
   background: rgba(34, 197, 94, 0.28);
 }
-mark.note-other {
+.annotated-wrap :deep(mark.note-other) {
   background: rgba(148, 163, 184, 0.28);
 }
-mark:focus-visible {
+.annotated-wrap :deep(mark:focus-visible) {
   outline: 2px solid currentColor;
   outline-offset: 1px;
 }
 
-/* Popover card content. nldd-popover does not pad slotted content, so the
-   card sets its own padding. It also does not inherit the editor's UI font
-   into the slot, so set RijksSansVF explicitly (the design-system UI face)
-   instead of falling back to a serif default — that was the "gek font" on
-   the heading. Border-left echoes the highlight colour so the popover is
-   visually tied to the mark it describes. */
+/* Popover card content. nldd-popover does not pad slotted content, nor
+   inherit the editor UI font, so the card sets both (RijksSansVF is the
+   design-system UI face). Border-left echoes the highlight colour. */
 .note-pop {
   font-family: 'RijksSansVF', system-ui, sans-serif;
   padding: 14px 16px;
@@ -257,8 +392,6 @@ mark:focus-visible {
   gap: 8px;
   margin-bottom: 8px;
 }
-/* Small coloured pill instead of a bare uppercase word — the uppercase +
-   letter-spacing read as a "weird font" against the serif fallback. */
 .note-pop__badge {
   font-size: 0.72rem;
   font-weight: 600;

--- a/frontend/src/components/ArticleText.vue
+++ b/frontend/src/components/ArticleText.vue
@@ -1,7 +1,6 @@
 <script setup>
 import { computed } from 'vue';
-import { marked } from 'marked';
-import DOMPurify from 'dompurify';
+import { renderArticleHtml } from '../composables/useArticleMarkdown.js';
 
 const props = defineProps({
   article: { type: Object, default: null },
@@ -11,14 +10,9 @@ const props = defineProps({
   centered: { type: Boolean, default: false },
 });
 
-// marked v18 no longer sanitizes HTML in Markdown by default; run its output
-// through DOMPurify before binding with v-html so law text (today author-
-// controlled, but harvested laws could introduce arbitrary HTML) cannot inject
-// <script>, event handlers or javascript: links.
-const html = computed(() => {
-  if (!props.article?.text) return '';
-  return DOMPurify.sanitize(marked.parse(props.article.text));
-});
+// Shared marked + DOMPurify pipeline so the notes-on view (AnnotatedText)
+// renders byte-identically to this notes-off view (#646).
+const html = computed(() => renderArticleHtml(props.article?.text || ''));
 
 const paragraphs = computed(() => {
   if (!props.article?.text) return [];

--- a/frontend/src/composables/useArticleMarkdown.js
+++ b/frontend/src/composables/useArticleMarkdown.js
@@ -1,0 +1,22 @@
+/**
+ * Shared article-text markdown pipeline.
+ *
+ * ArticleText.vue (Tekst pane, notes off) and AnnotatedText.vue (Tekst pane,
+ * notes on) must render the law text identically — same list nesting, same
+ * paragraph breaks — so toggling Notities does not visually reflow the text.
+ * Keeping the marked + DOMPurify config in one place is the only way to
+ * guarantee that; a drift here is exactly the "duidelijke stap terug"
+ * regression #646 is about.
+ *
+ * marked v18 no longer sanitizes HTML in Markdown by default; harvested laws
+ * could in principle carry arbitrary HTML, so the output is always run through
+ * DOMPurify before it reaches the DOM (v-html or manual parsing).
+ */
+import { marked } from 'marked';
+import DOMPurify from 'dompurify';
+
+/** Raw article text -> sanitized HTML string. */
+export function renderArticleHtml(text) {
+  if (!text) return '';
+  return DOMPurify.sanitize(marked.parse(text));
+}

--- a/frontend/src/composables/useNotesHighlight.js
+++ b/frontend/src/composables/useNotesHighlight.js
@@ -1,0 +1,174 @@
+/**
+ * Project resolver char-offsets onto rendered markdown.
+ *
+ * The WASM resolver matches against the *raw* article text, so a note's span
+ * is a `[start, end)` range of char (code-point) offsets into that exact
+ * string. ArticleText renders that text through marked, which drops the
+ * numbered-list prefixes (`1. `, `2. `) from the visible text and turns
+ * `\n\n` into list/paragraph structure. So the rendered DOM's visible text is
+ * the raw text minus those prefixes (and with whitespace runs collapsed by
+ * HTML). markRanges() (in useNotes.js) sidesteps this by rendering plain text;
+ * this module instead keeps the markdown rendering and re-aligns.
+ *
+ * Approach: walk the rendered DOM's text nodes in document order, concatenate
+ * their text, and align that against the raw text with a two-pointer scan.
+ *
+ * Assumption (not an invariant the code can enforce): the only transforms
+ * marked applies to corpus law text are raw-only — numbered-list prefixes
+ * (`1. `) dropped from the visible text, and whitespace runs collapsed by
+ * HTML. Under that assumption every DOM char appears in the raw text in the
+ * same order, the scan only ever skips *raw* characters, and a raw span maps
+ * to a contiguous DOM range. Inline markdown that *adds* DOM characters
+ * (`**bold**`, `[text](url)`, headings) would break this — corpus articles
+ * are not expected to contain it, but if a DOM char cannot be matched the
+ * scan reports `desynced` so the caller can drop highlighting for that
+ * article rather than smear every offset onto the wrong words.
+ */
+
+const WS = /\s/;
+
+/**
+ * Build a map from raw char-offset -> DOM text position.
+ *
+ * @param {string} rawText      the exact string the resolver matched against
+ * @param {Array<{node: Node, text: string}>} domNodes
+ *        rendered text nodes in document order, with their textContent
+ * @returns {{
+ *   rawToDom: Array<{node: Node, offset: number} | null>,
+ *   domLen: number,
+ * }}
+ *   rawToDom[i] is the DOM position of raw char i, or null if that raw char
+ *   has no DOM counterpart (a list prefix or a collapsed-away space).
+ */
+export function buildAlignment(rawText, domNodes) {
+  const raw = Array.from(rawText); // code points: resolver offsets are char-based
+  // Flatten DOM text into a single code-point stream, remembering which node
+  // and in-node code-point offset each char came from.
+  const dom = [];
+  for (const { node, text } of domNodes) {
+    const cps = Array.from(text);
+    for (let k = 0; k < cps.length; k++) {
+      dom.push({ ch: cps[k], node, offset: k });
+    }
+  }
+
+  const rawToDom = new Array(raw.length).fill(null);
+  let r = 0;
+  let d = 0;
+  while (r < raw.length && d < dom.length) {
+    if (raw[r] === dom[d].ch) {
+      rawToDom[r] = { node: dom[d].node, offset: dom[d].offset };
+      r++;
+      d++;
+      continue;
+    }
+    // Mismatch. The expected, raw-only causes are a numbered-list prefix
+    // ("1. " marked turned into <li>) and whitespace the HTML renderer
+    // collapsed (raw "x  y" -> dom "x y", or a soft "\n" dropped). All of
+    // these are raw-only and short, so advancing the raw pointer realigns
+    // at the next shared character. A DOM char that is genuinely absent from
+    // raw (inline markdown that *added* DOM text) would instead pin `d` and
+    // leave a large unconsumed DOM tail — the caller checks coverage for
+    // that, see `desynced`.
+    if (WS.test(dom[d].ch) && !WS.test(raw[r])) {
+      // Injected layout whitespace on the DOM side (rare): skip it.
+      d++;
+    } else {
+      r++;
+    }
+  }
+  // A trustworthy alignment consumes essentially all of the DOM's *visible*
+  // text. Whitespace-only DOM chars are excluded from the denominator: marked
+  // emits newlines between tags ("<ol>\n<li>") that become DOM text nodes
+  // with no raw counterpart, which is expected and harmless. A genuine
+  // divergence this scan cannot model (inline markdown that added *visible*
+  // DOM text) leaves non-whitespace DOM chars unmatched; report that so the
+  // caller drops highlighting rather than smearing every offset.
+  let domSignificant = 0;
+  let mappedSignificant = 0;
+  for (const { ch } of dom) {
+    if (WS.test(ch)) continue;
+    domSignificant++;
+  }
+  for (let i = 0; i < raw.length; i++) {
+    if (rawToDom[i] && !WS.test(raw[i])) mappedSignificant++;
+  }
+  const desynced =
+    domSignificant > 0 && mappedSignificant < domSignificant * 0.98;
+  return { rawToDom, domLen: dom.length, desynced };
+}
+
+// Anchorability probes only: spanToNodeSlices derives the actual slice
+// geometry from the rawToDom walk and uses these two solely to decide
+// whether the span has *any* mapped char near its start and end (a span
+// that falls entirely inside skipped prefix/whitespace is unanchorable).
+// anchorStart -> first mapped char at/after the offset; anchorEnd -> the
+// position just past the last mapped char before the exclusive end.
+function anchorStart(rawToDom, rawOffset) {
+  for (let i = rawOffset; i < rawToDom.length; i++) {
+    if (rawToDom[i]) return rawToDom[i];
+  }
+  return null;
+}
+function anchorEnd(rawToDom, rawEndExclusive) {
+  for (let i = rawEndExclusive - 1; i >= 0; i--) {
+    if (rawToDom[i]) {
+      return { node: rawToDom[i].node, offset: rawToDom[i].offset + 1 };
+    }
+  }
+  return null;
+}
+
+/**
+ * Turn one resolved span into a list of per-text-node DOM Range descriptors.
+ * A span can cross text-node boundaries (e.g. a highlight that spans two
+ * paragraphs / list items), so it is sliced per node; each slice becomes its
+ * own <mark> wrapper. Returns [] if the span cannot be anchored.
+ *
+ * `domNodeCpLen` maps a text node to its code-point length so we can clamp a
+ * slice to the node end without re-walking. Range offsets are UTF-16 indices,
+ * so the caller converts code-point offsets via cpToUtf16().
+ *
+ * @returns {Array<{node: Node, startCp: number, endCp: number}>}
+ */
+export function spanToNodeSlices(rawToDom, span, domNodeCpLen) {
+  const a = anchorStart(rawToDom, span.start);
+  const b = anchorEnd(rawToDom, span.end);
+  if (!a || !b) return [];
+
+  // Collect the ordered set of text nodes the span touches by scanning the
+  // mapped raw range. Each mapped raw char names a (node, offset); group
+  // consecutive chars by node and track min/max in-node offset.
+  const slices = [];
+  let cur = null;
+  for (let i = span.start; i < span.end; i++) {
+    const pos = rawToDom[i];
+    if (!pos) continue;
+    if (!cur || cur.node !== pos.node) {
+      if (cur) slices.push(cur);
+      cur = { node: pos.node, startCp: pos.offset, endCp: pos.offset + 1 };
+    } else {
+      cur.endCp = pos.offset + 1;
+    }
+  }
+  if (cur) slices.push(cur);
+
+  // Clamp defensively to the node length.
+  for (const s of slices) {
+    const len = domNodeCpLen.get(s.node);
+    if (len != null && s.endCp > len) s.endCp = len;
+  }
+  return slices.filter((s) => s.endCp > s.startCp);
+}
+
+/** Code-point offset -> UTF-16 offset within `text` (DOM Range uses UTF-16). */
+export function cpToUtf16(text, cpOffset) {
+  let cp = 0;
+  let u = 0;
+  for (const ch of text) {
+    if (cp >= cpOffset) break;
+    u += ch.length;
+    cp++;
+  }
+  return u;
+}

--- a/frontend/src/composables/useNotesHighlight.js
+++ b/frontend/src/composables/useNotesHighlight.js
@@ -35,17 +35,27 @@ const WS = /\s/;
  *        rendered text nodes in document order, with their textContent
  * @returns {{
  *   rawToDom: Array<{node: Node, offset: number} | null>,
- *   domLen: number,
+ *   desynced: boolean,
  * }}
  *   rawToDom[i] is the DOM position of raw char i, or null if that raw char
  *   has no DOM counterpart (a list prefix or a collapsed-away space).
+ *   desynced is true when the rendered text diverged from raw in a way this
+ *   scan cannot model; the caller should then skip highlighting.
  */
 export function buildAlignment(rawText, domNodes) {
   const raw = Array.from(rawText); // code points: resolver offsets are char-based
   // Flatten DOM text into a single code-point stream, remembering which node
-  // and in-node code-point offset each char came from.
+  // and in-node code-point offset each char came from. Whitespace-only text
+  // nodes are skipped entirely: marked emits newlines between tags
+  // ("<ol>\n<li>") that become text nodes with no raw counterpart. If a raw
+  // char (the "\n\n" paragraph break) were allowed to map onto such a node,
+  // a span crossing two list items would produce a slice for it and
+  // AnnotatedText would wrap a focusable, styled <mark> around a bare "\n"
+  // sitting between <li>s — invalid HTML and an empty highlight blob. The
+  // raw paragraph break instead aligns via the normal raw-advance path.
   const dom = [];
   for (const { node, text } of domNodes) {
+    if (!text || /^\s*$/.test(text)) continue;
     const cps = Array.from(text);
     for (let k = 0; k < cps.length; k++) {
       dom.push({ ch: cps[k], node, offset: k });
@@ -55,68 +65,71 @@ export function buildAlignment(rawText, domNodes) {
   const rawToDom = new Array(raw.length).fill(null);
   let r = 0;
   let d = 0;
+  // Track the longest contiguous run of *significant* (non-whitespace) DOM
+  // chars that the scan had to skip. A real divergence this two-pointer scan
+  // cannot model — inline markdown that added visible DOM text — shows up as
+  // exactly that: a contiguous block of DOM chars with no raw counterpart,
+  // after which every offset is shifted (the "smear"). The legitimate
+  // raw-only transforms (list prefixes, collapsed whitespace) never leave
+  // significant DOM chars unmatched at all, so the tolerable run length is
+  // small. A global ratio was the wrong shape: a few wrong chars in a long
+  // article stay under any percentage while still smearing every later mark.
+  let maxSkippedRun = 0;
+  let curSkippedRun = 0;
   while (r < raw.length && d < dom.length) {
     if (raw[r] === dom[d].ch) {
       rawToDom[r] = { node: dom[d].node, offset: dom[d].offset };
       r++;
       d++;
+      curSkippedRun = 0;
       continue;
     }
-    // Mismatch. The expected, raw-only causes are a numbered-list prefix
-    // ("1. " marked turned into <li>) and whitespace the HTML renderer
-    // collapsed (raw "x  y" -> dom "x y", or a soft "\n" dropped). All of
-    // these are raw-only and short, so advancing the raw pointer realigns
-    // at the next shared character. A DOM char that is genuinely absent from
-    // raw (inline markdown that *added* DOM text) would instead pin `d` and
-    // leave a large unconsumed DOM tail — the caller checks coverage for
-    // that, see `desynced`.
-    if (WS.test(dom[d].ch) && !WS.test(raw[r])) {
-      // Injected layout whitespace on the DOM side (rare): skip it.
+    // Mismatch. Expected, raw-only causes: a numbered-list prefix ("1. "
+    // marked turned into <li>) and whitespace the HTML renderer collapsed
+    // (raw "x  y" -> dom "x y", or a soft "\n" dropped). These are raw-only
+    // and short, so advancing the raw pointer realigns at the next shared
+    // character. A DOM char genuinely absent from raw is the divergence
+    // case: skip it on the DOM side and count the run.
+    if (WS.test(raw[r])) {
+      r++;
+    } else if (WS.test(dom[d].ch)) {
+      d++; // DOM-side whitespace (inter-tag newline already filtered; rare)
+    } else if (raw.indexOf(dom[d].ch, r) === -1) {
+      // This DOM char does not occur anywhere in the remaining raw text:
+      // it is genuinely DOM-only. Skip it and grow the divergence run.
       d++;
+      curSkippedRun++;
+      if (curSkippedRun > maxSkippedRun) maxSkippedRun = curSkippedRun;
     } else {
+      // The DOM char reappears later in raw: the chars between are raw-only
+      // (a list prefix). Advance raw to catch up.
       r++;
     }
   }
-  // A trustworthy alignment consumes essentially all of the DOM's *visible*
-  // text. Whitespace-only DOM chars are excluded from the denominator: marked
-  // emits newlines between tags ("<ol>\n<li>") that become DOM text nodes
-  // with no raw counterpart, which is expected and harmless. A genuine
-  // divergence this scan cannot model (inline markdown that added *visible*
-  // DOM text) leaves non-whitespace DOM chars unmatched; report that so the
-  // caller drops highlighting rather than smearing every offset.
-  let domSignificant = 0;
-  let mappedSignificant = 0;
-  for (const { ch } of dom) {
-    if (WS.test(ch)) continue;
-    domSignificant++;
+  // Any DOM text the scan never reached (d stopped short) is also unmatched
+  // significant content if non-whitespace.
+  let tailRun = 0;
+  for (let i = d; i < dom.length; i++) {
+    if (WS.test(dom[i].ch)) continue;
+    tailRun++;
   }
-  for (let i = 0; i < raw.length; i++) {
-    if (rawToDom[i] && !WS.test(raw[i])) mappedSignificant++;
-  }
-  const desynced =
-    domSignificant > 0 && mappedSignificant < domSignificant * 0.98;
-  return { rawToDom, domLen: dom.length, desynced };
+  if (tailRun > maxSkippedRun) maxSkippedRun = tailRun;
+  // Tolerate a tiny run: a stray entity or punctuation artefact should not
+  // suppress an otherwise-correct article. Anything longer means inline
+  // markup the scan cannot model; drop highlighting rather than smear.
+  const desynced = maxSkippedRun > 4;
+  return { rawToDom, desynced };
 }
 
-// Anchorability probes only: spanToNodeSlices derives the actual slice
-// geometry from the rawToDom walk and uses these two solely to decide
-// whether the span has *any* mapped char near its start and end (a span
-// that falls entirely inside skipped prefix/whitespace is unanchorable).
-// anchorStart -> first mapped char at/after the offset; anchorEnd -> the
-// position just past the last mapped char before the exclusive end.
-function anchorStart(rawToDom, rawOffset) {
-  for (let i = rawOffset; i < rawToDom.length; i++) {
-    if (rawToDom[i]) return rawToDom[i];
+// Is at least one raw char in [start, end) mapped to the DOM? A span that
+// falls entirely inside skipped prefix/whitespace has no DOM position to
+// anchor to. The actual slice geometry is derived from the rawToDom walk in
+// spanToNodeSlices; this is only the "anchorable at all" gate.
+function hasMappedChar(rawToDom, start, end) {
+  for (let i = start; i < end; i++) {
+    if (rawToDom[i]) return true;
   }
-  return null;
-}
-function anchorEnd(rawToDom, rawEndExclusive) {
-  for (let i = rawEndExclusive - 1; i >= 0; i--) {
-    if (rawToDom[i]) {
-      return { node: rawToDom[i].node, offset: rawToDom[i].offset + 1 };
-    }
-  }
-  return null;
+  return false;
 }
 
 /**
@@ -132,9 +145,7 @@ function anchorEnd(rawToDom, rawEndExclusive) {
  * @returns {Array<{node: Node, startCp: number, endCp: number}>}
  */
 export function spanToNodeSlices(rawToDom, span, domNodeCpLen) {
-  const a = anchorStart(rawToDom, span.start);
-  const b = anchorEnd(rawToDom, span.end);
-  if (!a || !b) return [];
+  if (!hasMappedChar(rawToDom, span.start, span.end)) return [];
 
   // Collect the ordered set of text nodes the span touches by scanning the
   // mapped raw range. Each mapped raw char names a (node, offset); group

--- a/frontend/src/composables/useNotesHighlight.test.js
+++ b/frontend/src/composables/useNotesHighlight.test.js
@@ -75,13 +75,27 @@ describe('buildAlignment', () => {
     expect(desynced).toBe(false);
   });
 
-  it('flags desync when the DOM has a non-whitespace char absent from raw', () => {
-    // Simulates inline markdown that added DOM text (e.g. "**x**" -> "x"
-    // would be raw-only, but a footnote marker the renderer injects is
-    // DOM-only). Here DOM has an extra "Z" the raw lacks.
-    const raw = 'abc';
-    const node = tn('abZc');
-    const { desynced } = buildAlignment(raw, [{ node, text: 'abZc' }]);
+  it('tolerates a tiny DOM-only artefact (does not flag desync)', () => {
+    // A stray entity/punctuation artefact (run <= 4) must not suppress an
+    // otherwise-correct article: that would throw away every valid highlight
+    // over one decoded character. Here DOM has one extra "Z" the raw lacks.
+    const raw = 'abcdef';
+    const node = tn('abcZdef');
+    const { desynced } = buildAlignment(raw, [{ node, text: 'abcZdef' }]);
+    expect(desynced).toBe(false);
+  });
+
+  it('flags desync on a contiguous block of DOM-only text', () => {
+    // The real failure shape: inline markdown that ADDED visible DOM text
+    // (e.g. a renderer-injected phrase, or markup the scan cannot model),
+    // leaving a contiguous run with no raw counterpart after which every
+    // offset is shifted. Run > 4 -> drop highlighting rather than smear.
+    // This is scale-independent: it fires regardless of article length,
+    // unlike the old ratio threshold which only caught tiny articles.
+    const raw = 'het toetsingsinkomen van de verzekerde';
+    const domText = 'het toetsingsinkomen ZIE NOOT 7 van de verzekerde';
+    const node = tn(domText);
+    const { desynced } = buildAlignment(raw, [{ node, text: domText }]);
     expect(desynced).toBe(true);
   });
 

--- a/frontend/src/composables/useNotesHighlight.test.js
+++ b/frontend/src/composables/useNotesHighlight.test.js
@@ -1,0 +1,154 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildAlignment,
+  spanToNodeSlices,
+  cpToUtf16,
+} from './useNotesHighlight.js';
+
+// buildAlignment + spanToNodeSlices are the highest-risk pure functions in
+// the markdown-highlight path (#646): they re-anchor resolver char-offsets
+// (into the raw law text) onto the rendered DOM, which has list prefixes and
+// some whitespace stripped. These tests pin the divergence cases.
+
+/** Fake text node: identity-comparable, carries its string. */
+function tn(text) {
+  return { __t: text, textContent: text };
+}
+
+describe('buildAlignment', () => {
+  it('maps 1:1 when DOM text equals raw text', () => {
+    const raw = 'aanspraak op zorgtoeslag';
+    const node = tn(raw);
+    const { rawToDom } = buildAlignment(raw, [{ node, text: raw }]);
+    expect(rawToDom).toHaveLength(raw.length);
+    rawToDom.forEach((m, i) => {
+      expect(m).toEqual({ node, offset: i });
+    });
+  });
+
+  it('skips a numbered-list prefix that marked removed from the DOM', () => {
+    // Raw lid text "1. Indien ..."; marked renders <li><p>Indien ...</p></li>,
+    // so the DOM text node is "Indien ..." — the "1. " is raw-only.
+    const raw = '1. Indien de normpremie';
+    const domText = 'Indien de normpremie';
+    const node = tn(domText);
+    const { rawToDom } = buildAlignment(raw, [{ node, text: domText }]);
+    // "1. " (offsets 0,1,2) has no DOM counterpart.
+    expect(rawToDom[0]).toBeNull();
+    expect(rawToDom[1]).toBeNull();
+    expect(rawToDom[2]).toBeNull();
+    // "Indien" starts at raw offset 3 -> DOM offset 0.
+    expect(rawToDom[3]).toEqual({ node, offset: 0 });
+    expect(rawToDom[raw.length - 1]).toEqual({
+      node,
+      offset: domText.length - 1,
+    });
+  });
+
+  it('skips collapsed whitespace (raw double space -> single DOM space)', () => {
+    const raw = 'a  b'; // two spaces in raw
+    const domText = 'a b'; // HTML collapsed to one
+    const node = tn(domText);
+    const { rawToDom } = buildAlignment(raw, [{ node, text: domText }]);
+    expect(rawToDom[0]).toEqual({ node, offset: 0 }); // a
+    // One of the two raw spaces maps, the other is skipped (null).
+    const spaceMaps = [rawToDom[1], rawToDom[2]].filter(Boolean);
+    expect(spaceMaps).toHaveLength(1);
+    expect(rawToDom[3]).toEqual({ node, offset: 2 }); // b
+  });
+
+  it('keeps a soft newline that survives as text in the DOM node', () => {
+    // marked leaves a soft "\n" inside a paragraph as a literal newline in
+    // the text node (verified against marked v18); it must map 1:1.
+    const raw = 'dat\njaar';
+    const node = tn(raw);
+    const { rawToDom } = buildAlignment(raw, [{ node, text: raw }]);
+    expect(rawToDom[3]).toEqual({ node, offset: 3 }); // the \n
+    rawToDom.forEach((m, i) => expect(m).toEqual({ node, offset: i }));
+  });
+
+  it('does not flag desync for the expected raw-only transforms', () => {
+    // List prefix + collapsed whitespace are expected; desynced stays false.
+    const raw = '1. a  b';
+    const node = tn('a b');
+    const { desynced } = buildAlignment(raw, [{ node, text: 'a b' }]);
+    expect(desynced).toBe(false);
+  });
+
+  it('flags desync when the DOM has a non-whitespace char absent from raw', () => {
+    // Simulates inline markdown that added DOM text (e.g. "**x**" -> "x"
+    // would be raw-only, but a footnote marker the renderer injects is
+    // DOM-only). Here DOM has an extra "Z" the raw lacks.
+    const raw = 'abc';
+    const node = tn('abZc');
+    const { desynced } = buildAlignment(raw, [{ node, text: 'abZc' }]);
+    expect(desynced).toBe(true);
+  });
+
+  it('spans multiple DOM nodes (two list items)', () => {
+    // Raw: "1. eerste\n\n2. tweede" -> two <li> text nodes "eerste","tweede".
+    const raw = '1. eerste\n\n2. tweede';
+    const n1 = tn('eerste');
+    const n2 = tn('tweede');
+    const { rawToDom } = buildAlignment(raw, [
+      { node: n1, text: 'eerste' },
+      { node: n2, text: 'tweede' },
+    ]);
+    // "eerste" is raw 3..9 -> n1 0..6
+    expect(rawToDom[3]).toEqual({ node: n1, offset: 0 });
+    expect(rawToDom[8]).toEqual({ node: n1, offset: 5 });
+    // "tweede" -> n2; find first mapped char in the second half
+    const second = rawToDom.slice(11).find(Boolean);
+    expect(second.node).toBe(n2);
+  });
+});
+
+describe('spanToNodeSlices', () => {
+  const raw = '1. Indien de normpremie';
+  const domText = 'Indien de normpremie';
+  const node = tn(domText);
+
+  it('clips a span that starts inside a stripped prefix to the first real char', () => {
+    const { rawToDom } = buildAlignment(raw, [{ node, text: domText }]);
+    const len = new Map([[node, Array.from(domText).length]]);
+    // Span covers the prefix + "Indien" (raw 0..9).
+    const slices = spanToNodeSlices(rawToDom, { start: 0, end: 9 }, len);
+    expect(slices).toEqual([{ node, startCp: 0, endCp: 6 }]); // "Indien"
+  });
+
+  it('produces one slice per crossed text node', () => {
+    const r = '1. een\n\n2. twee';
+    const a = tn('een');
+    const b = tn('twee');
+    const { rawToDom } = buildAlignment(r, [
+      { node: a, text: 'een' },
+      { node: b, text: 'twee' },
+    ]);
+    const len = new Map([
+      [a, 3],
+      [b, 4],
+    ]);
+    const slices = spanToNodeSlices(rawToDom, { start: 3, end: 15 }, len);
+    expect(slices.map((s) => s.node)).toEqual([a, b]);
+    expect(slices[0]).toEqual({ node: a, startCp: 0, endCp: 3 });
+    expect(slices[1].node).toBe(b);
+  });
+
+  it('returns [] for an unanchorable span', () => {
+    const { rawToDom } = buildAlignment('1. ', [{ node: tn(''), text: '' }]);
+    expect(spanToNodeSlices(rawToDom, { start: 0, end: 3 }, new Map())).toEqual(
+      [],
+    );
+  });
+});
+
+describe('cpToUtf16', () => {
+  it('is identity for BMP text', () => {
+    expect(cpToUtf16('verzekerde', 4)).toBe(4);
+  });
+
+  it('counts an astral code point as two UTF-16 units', () => {
+    // "🎉" is 1 code point, 2 UTF-16 units. Offset 2 (after "a🎉") -> 3.
+    expect(cpToUtf16('a🎉b', 2)).toBe(3);
+  });
+});


### PR DESCRIPTION
Sluit #646.

## Wat

De Tekst-pane met de Notities-toggle aan rendert de wettekst nu als markdown — genummerde leden als `<ol><li>` met nette hangende inspringing, identiek aan de weergave met notities uit — met de highlights eroverheen. Voorheen viel notities-aan terug op platte tekst in één `<p>`: geen lijst-opmaak, een zichtbare stap terug.

## Hoe

De WASM-resolver matcht char-offsets in de **ruwe** wettekst. `marked` haalt de `1. `-prefixes uit de zichtbare tekst en maakt er lijst-structuur van, dus die offsets lijnen niet op de gerenderde DOM. In plaats van de string te slicen (de oude `markRanges`) wordt nu de gerenderde DOM gebruikt:

- **`useArticleMarkdown`** — gedeelde `marked`+`DOMPurify`-pijplijn, zodat `ArticleText` (notities uit) en `AnnotatedText` (notities aan) byte-identiek renderen en niet uit elkaar lopen.
- **`useNotesHighlight`** — twee-wijzer-scan die de ruwe char-offsets uitlijnt op de DOM-tekstnodes, de raw-only transformaties (lijst-prefixes, gecollapste whitespace) overslaand. Detecteert desync via DOM-dekking: bij een transformatie die het script niet kan modelleren (inline markdown die zichtbare DOM-tekst toevoegt) worden de highlights weggelaten in plaats van elke offset te verschuiven.
- **`AnnotatedText`** — wikkelt per resolved span een `<mark>` via een DOM-`Range`. Idempotent: ruimt eerdere marks op vóór her-render (zodat een notitie-wijziging zonder tekstwijziging niet dubbel wikkelt — relevant zodra notities bewerkbaar worden). Dezelfde deterministische overlap-drop als `markRanges`. Hover-popover via event-delegation op de imperatief gemaakte marks.
- `markRanges` + de 9 tests blijven als referentie.

## Verificatie

- 25 unit-tests groen (12 alignment, 4 component, 9 `markRanges`-referentie); volledige frontend-suite 150/150.
- Lokaal geverifieerd op Wet op de zorgtoeslag art. 2: lijst-opmaak intact, highlights kleuren per motivatie (linking blauw, commenting amber, questioning oranje), hover-popover werkt inclusief de `open-norm-partial` ambiguïteit-casus. Notities-uit rendert byte-identiek.

Een eerdere versie liet `desynced` ten onrechte afgaan op echte corpustekst (whitespace tussen tags telde mee als ongematchte DOM); de dekkingsmaat negeert nu whitespace-only DOM-chars. Gevonden via lokale browser-verificatie, voor de fix gevangen.
