### PR TITLE
feat(editor): notities aanmaken via tekstselectie (RFC-018 Fase 5)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4293,9 +4293,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/frontend/scripts/copy-laws.js
+++ b/frontend/scripts/copy-laws.js
@@ -176,14 +176,14 @@ for (const source of localSources) {
 // Copy note sidecar files (RFC-005/RFC-018) to public/data/annotations/.
 // useNotes.js fetches /data/annotations/{lawId}/annotations.yaml; the
 // annotation directories are already keyed by the law's $id. The
-// _vocabulary/ dir is build/CI-only (validate-annotations) and is not
-// fetched by the editor, so it is skipped.
+// _vocabulary/ dir is also copied: the note creator's ambiguity-tag picker
+// (RFC-018 write path) reads it so the editor's tag list and the CI
+// soft-validation list cannot drift — one source of truth.
 const annotationsSrc = resolve(projectRoot, 'corpus', 'annotations');
 if (existsSync(annotationsSrc)) {
   const annotationsDest = resolve(destDir, 'annotations');
   let annotationFiles = 0;
   for (const lawId of readdirSync(annotationsSrc)) {
-    if (lawId === '_vocabulary') continue;
     const lawDir = resolve(annotationsSrc, lawId);
     if (!statSync(lawDir).isDirectory()) continue;
     for (const file of readdirSync(lawDir)) {

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -6,7 +6,8 @@ import { useLaw, fetchLaw } from './composables/useLaw.js';
 import { useEngine } from './composables/useEngine.js';
 import { useAuth } from './composables/useAuth.js';
 import { useFeatureFlags } from './composables/useFeatureFlags.js';
-import { useNotes } from './composables/useNotes.js';
+import { useNotes, useResolvedDraftNotes } from './composables/useNotes.js';
+import { useDraftNotes } from './composables/useDraftNotes.js';
 import { useColorScheme } from './composables/useColorScheme.js';
 import { lastLibraryPath } from './composables/useLastVisitedRoute.js';
 import { SUPPORT_EMAIL } from './constants.js';
@@ -40,6 +41,10 @@ const editorPanelFlags = [
   // toggle that overlays resolved notes on the article text. Not a
   // separate pane (notes are a layer over the text, not other content).
   ['panel.notes', 'Notities'],
+  // Note authoring (RFC-018 write path). Separate gate from panel.notes so
+  // notes can be shown read-only without exposing the (MVP, local-only)
+  // creation + export flow.
+  ['notes.create', 'Notities aanmaken'],
   ['editor.article_text_edit', 'Tekst bewerken'],
 ];
 
@@ -170,7 +175,7 @@ const {
 
 // Notes (RFC-005/RFC-018) for the current law, resolved against its text.
 const {
-  notesForArticle,
+  notesForArticle: committedNotesForArticle,
   issues: noteIssues,
   loading: notesLoading,
   error: notesError,
@@ -190,6 +195,56 @@ watch(showNotes, (v) => {
 const notesActive = computed(
   () => isEnabled('panel.notes') && showNotes.value && !canEditArticleText.value,
 );
+
+// Note authoring (RFC-018 write path). Draft notes live in localStorage per
+// law until exported; they resolve and highlight live alongside committed
+// ones, so the author sees the new note anchored immediately. The WASM engine
+// is handed to NoteCreator for selector-uniqueness checks; useNotes already
+// initialises it, this just exposes the instance once ready (null until then,
+// NoteCreator guards on it).
+const noteEngine = ref(null);
+useEngine()
+  .initEngine()
+  .then((e) => {
+    noteEngine.value = e;
+  })
+  .catch(() => {});
+const {
+  drafts: draftNotes,
+  draftCount,
+  addDraft,
+  clearDrafts,
+  exportYaml,
+} = useDraftNotes(lawId);
+const { draftNotesForArticle } = useResolvedDraftNotes(
+  draftNotes,
+  lawId,
+  selectedArticle,
+);
+const canCreateNotes = computed(
+  () => isEnabled('notes.create') && notesActive.value,
+);
+// Committed + draft notes share the highlight path. Draft entries already
+// carry __draft so the popover can mark them unsaved.
+const notesForArticle = computed(() => [
+  ...committedNotesForArticle.value,
+  ...draftNotesForArticle.value,
+]);
+
+function onCreateNote(note) {
+  addDraft(note);
+}
+
+async function exportNotes() {
+  const text = await exportYaml();
+  const blob = new Blob([text], { type: 'text/yaml' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'annotations.yaml';
+  a.click();
+  URL.revokeObjectURL(url);
+}
 
 const resultSheetOpen = ref(false);
 const graphSheetOpen = ref(false);
@@ -1367,6 +1422,10 @@ async function handleActionSave() {
                     <AnnotatedText
                       :article="selectedArticle"
                       :notes-for-article="notesForArticle"
+                      :can-create="canCreateNotes"
+                      :law-id="lawId"
+                      :engine="noteEngine"
+                      @create-note="onCreateNote"
                     />
                     <nldd-inline-dialog
                       v-if="noteIssues.length"
@@ -1374,6 +1433,35 @@ async function handleActionSave() {
                       :text="`${noteIssues.length} notitie(s) niet verankerd`"
                       :supporting-text="noteIssues.map(i => i.reason).join('; ')"
                     ></nldd-inline-dialog>
+                    <!-- Draft notes are local-only until exported (RFC-018
+                         write path MVP: no write API, git stays the source
+                         of truth). The export downloads committed + draft
+                         notes as one sidecar YAML to commit by hand. -->
+                    <nldd-container
+                      v-if="canCreateNotes && draftCount > 0"
+                      padding="12"
+                      class="draft-notes-bar"
+                      data-testid="draft-notes-bar"
+                    >
+                      <span class="draft-notes-bar__count">
+                        {{ draftCount }} concept-notitie(s), nog niet opgeslagen
+                      </span>
+                      <span class="draft-notes-bar__actions">
+                        <nldd-button
+                          size="md"
+                          text="Exporteer YAML"
+                          data-testid="export-notes-btn"
+                          @click="exportNotes"
+                        ></nldd-button>
+                        <nldd-button
+                          size="md"
+                          variant="destructive"
+                          text="Concepten wissen"
+                          data-testid="clear-drafts-btn"
+                          @click="clearDrafts"
+                        ></nldd-button>
+                      </span>
+                    </nldd-container>
                   </template>
                 </template>
                 <ArticleText v-else :article="selectedArticle" />
@@ -1660,5 +1748,24 @@ async function handleActionSave() {
   padding: 8px 12px;
   border: 1px solid #fecaca;
   border-radius: 6px;
+}
+
+.draft-notes-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-top: 12px;
+  border: 1px dashed rgba(249, 115, 22, 0.6);
+  border-radius: 6px;
+}
+.draft-notes-bar__count {
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+.draft-notes-bar__actions {
+  display: flex;
+  gap: 8px;
 }
 </style>

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -1481,39 +1481,33 @@ async function handleActionSave() {
                          write path MVP: no write API, git stays the source
                          of truth). The export downloads committed + draft
                          notes as one sidecar YAML to commit by hand. -->
-                    <nldd-container
+                    <nldd-inline-dialog
                       v-if="canCreateNotes && draftCount > 0"
-                      padding="12"
-                      class="draft-notes-bar"
                       data-testid="draft-notes-bar"
+                      :text="`${draftCount} concept-notitie(s), nog niet opgeslagen`"
+                      :supporting-text="
+                        hiddenDraftCount > 0
+                          ? `${hiddenDraftCount} overlapt een bestaande notitie en wordt niet gemarkeerd.`
+                          : undefined
+                      "
+                      :icon-color="hiddenDraftCount > 0 ? 'warning' : undefined"
                     >
-                      <span class="draft-notes-bar__count">
-                        {{ draftCount }} concept-notitie(s), nog niet opgeslagen
-                        <span
-                          v-if="hiddenDraftCount > 0"
-                          class="draft-notes-bar__hidden"
-                          data-testid="draft-overlap-warning"
-                        >
-                          — {{ hiddenDraftCount }} overlapt een bestaande
-                          notitie en wordt niet gemarkeerd
-                        </span>
-                      </span>
-                      <span class="draft-notes-bar__actions">
-                        <nldd-button
-                          size="md"
-                          text="Exporteer YAML"
-                          data-testid="export-notes-btn"
-                          @click="exportNotes"
-                        ></nldd-button>
-                        <nldd-button
-                          size="md"
-                          variant="destructive"
-                          text="Concepten wissen"
-                          data-testid="clear-drafts-btn"
-                          @click="askClearDrafts"
-                        ></nldd-button>
-                      </span>
-                    </nldd-container>
+                      <nldd-button
+                        slot="actions"
+                        size="md"
+                        text="Exporteer YAML"
+                        data-testid="export-notes-btn"
+                        @click="exportNotes"
+                      ></nldd-button>
+                      <nldd-button
+                        slot="actions"
+                        size="md"
+                        variant="destructive"
+                        text="Concepten wissen"
+                        data-testid="clear-drafts-btn"
+                        @click="askClearDrafts"
+                      ></nldd-button>
+                    </nldd-inline-dialog>
                   </template>
                 </template>
                 <ArticleText v-else :article="selectedArticle" />
@@ -1814,28 +1808,5 @@ async function handleActionSave() {
   padding: 8px 12px;
   border: 1px solid #fecaca;
   border-radius: 6px;
-}
-
-.draft-notes-bar {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  flex-wrap: wrap;
-  margin-top: 12px;
-  border: 1px dashed rgba(249, 115, 22, 0.6);
-  border-radius: 6px;
-}
-.draft-notes-bar__count {
-  font-size: 0.85rem;
-  font-weight: 600;
-}
-.draft-notes-bar__hidden {
-  font-weight: 400;
-  color: #c2410c;
-}
-.draft-notes-bar__actions {
-  display: flex;
-  gap: 8px;
 }
 </style>

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -258,14 +258,28 @@ function onCreateNote(note) {
 }
 
 // Wiping drafts is irreversible (local-only until exported), so it goes
-// through a confirm modal rather than firing on the bare button click.
+// through a confirm modal. nldd-modal-dialog's API is show()/hide() (there
+// is no close()); a flag drives those via a watch, and @close just clears
+// the flag — same pattern as MachineReadable's delete confirm, which avoids
+// the hide() -> @close -> hide() recursion.
 const clearDraftsModalEl = ref(null);
+const clearDraftsPending = ref(false);
+watch(clearDraftsPending, (open) => {
+  const el = clearDraftsModalEl.value;
+  if (!el) return;
+  if (open && typeof el.show === 'function') el.show();
+  else if (!open && typeof el.hide === 'function') el.hide();
+});
 function askClearDrafts() {
-  clearDraftsModalEl.value?.show?.();
+  clearDraftsPending.value = true;
+}
+function cancelClearDrafts() {
+  if (clearDraftsPending.value === false) return; // idempotent: @close + button
+  clearDraftsPending.value = false;
 }
 function confirmClearDrafts() {
   clearDrafts();
-  clearDraftsModalEl.value?.close?.();
+  clearDraftsPending.value = false;
 }
 
 const exporting = ref(false);
@@ -1672,9 +1686,9 @@ async function handleActionSave() {
     text="Alle concept-notities wissen?"
     supporting-text="Niet-geëxporteerde concepten gaan definitief verloren. Exporteer eerst als je ze wilt bewaren."
     data-testid="clear-drafts-confirm"
-    @close="clearDraftsModalEl?.close?.()"
+    @close="cancelClearDrafts"
   >
-    <nldd-button slot="actions" variant="primary" text="Behoud concepten" @click="clearDraftsModalEl?.close?.()"></nldd-button>
+    <nldd-button slot="actions" variant="primary" text="Behoud concepten" @click="cancelClearDrafts"></nldd-button>
     <nldd-button slot="actions" variant="destructive" text="Wis alles" data-testid="clear-drafts-confirm-btn" @click="confirmClearDrafts"></nldd-button>
   </nldd-modal-dialog>
 

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -231,19 +231,63 @@ const notesForArticle = computed(() => [
   ...draftNotesForArticle.value,
 ]);
 
+// AnnotatedText paints a flat partition: a draft whose span overlaps a
+// committed note's span resolves fine but is silently not highlighted (the
+// earlier note wins, RFC-018's documented overlapping-notes limitation).
+// Through the write path that is confusing — the count says "1 concept" but
+// nothing lights up — so detect it and tell the user explicitly.
+const hiddenDraftCount = computed(() => {
+  const committed = committedNotesForArticle.value.flatMap((n) => n.spans);
+  let hidden = 0;
+  for (const d of draftNotesForArticle.value) {
+    for (const s of d.spans) {
+      const overlaps = committed.some(
+        (c) => s.start < c.end && c.start < s.end,
+      );
+      if (overlaps) {
+        hidden++;
+        break;
+      }
+    }
+  }
+  return hidden;
+});
+
 function onCreateNote(note) {
   addDraft(note);
 }
 
+// Wiping drafts is irreversible (local-only until exported), so it goes
+// through a confirm modal rather than firing on the bare button click.
+const clearDraftsModalEl = ref(null);
+function askClearDrafts() {
+  clearDraftsModalEl.value?.show?.();
+}
+function confirmClearDrafts() {
+  clearDrafts();
+  clearDraftsModalEl.value?.close?.();
+}
+
+const exporting = ref(false);
 async function exportNotes() {
-  const text = await exportYaml();
-  const blob = new Blob([text], { type: 'text/yaml' });
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement('a');
-  a.href = url;
-  a.download = 'annotations.yaml';
-  a.click();
-  URL.revokeObjectURL(url);
+  if (exporting.value) return; // a second click would download a duplicate
+  exporting.value = true;
+  let url;
+  try {
+    const text = await exportYaml();
+    const blob = new Blob([text], { type: 'text/yaml' });
+    url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'annotations.yaml';
+    a.click();
+  } finally {
+    // Revoke on a later tick: a programmatic anchor download starts
+    // asynchronously, and revoking synchronously after click() races the
+    // browser fetching the blob (unreliable in Safari/Firefox).
+    if (url) setTimeout(() => URL.revokeObjectURL(url), 0);
+    exporting.value = false;
+  }
 }
 
 const resultSheetOpen = ref(false);
@@ -1445,6 +1489,14 @@ async function handleActionSave() {
                     >
                       <span class="draft-notes-bar__count">
                         {{ draftCount }} concept-notitie(s), nog niet opgeslagen
+                        <span
+                          v-if="hiddenDraftCount > 0"
+                          class="draft-notes-bar__hidden"
+                          data-testid="draft-overlap-warning"
+                        >
+                          — {{ hiddenDraftCount }} overlapt een bestaande
+                          notitie en wordt niet gemarkeerd
+                        </span>
                       </span>
                       <span class="draft-notes-bar__actions">
                         <nldd-button
@@ -1458,7 +1510,7 @@ async function handleActionSave() {
                           variant="destructive"
                           text="Concepten wissen"
                           data-testid="clear-drafts-btn"
-                          @click="clearDrafts"
+                          @click="askClearDrafts"
                         ></nldd-button>
                       </span>
                     </nldd-container>
@@ -1618,6 +1670,20 @@ async function handleActionSave() {
     @harvest-available="onSearchHarvestAvailable"
   />
 
+  <!-- Drafts are local-only until exported (RFC-018: git is the source of
+       truth). Wiping them is irreversible and the only copy, so confirm. -->
+  <nldd-modal-dialog
+    ref="clearDraftsModalEl"
+    variant="alert"
+    text="Alle concept-notities wissen?"
+    supporting-text="Niet-geëxporteerde concepten gaan definitief verloren. Exporteer eerst als je ze wilt bewaren."
+    data-testid="clear-drafts-confirm"
+    @close="clearDraftsModalEl?.close?.()"
+  >
+    <nldd-button slot="actions" variant="primary" text="Behoud concepten" @click="clearDraftsModalEl?.close?.()"></nldd-button>
+    <nldd-button slot="actions" variant="destructive" text="Wis alles" data-testid="clear-drafts-confirm-btn" @click="confirmClearDrafts"></nldd-button>
+  </nldd-modal-dialog>
+
   <!-- Trace sheet — execution trace + expected outcomes for the most
        recently executed scenario. Opened from a scenario card's "Toon
        resultaat" button. -->
@@ -1763,6 +1829,10 @@ async function handleActionSave() {
 .draft-notes-bar__count {
   font-size: 0.85rem;
   font-weight: 600;
+}
+.draft-notes-bar__hidden {
+  font-weight: 400;
+  color: #c2410c;
 }
 .draft-notes-bar__actions {
   display: flex;

--- a/frontend/src/components/AnnotatedText.test.js
+++ b/frontend/src/components/AnnotatedText.test.js
@@ -1,7 +1,15 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
 import { nextTick } from 'vue';
 import AnnotatedText from './AnnotatedText.vue';
+
+// The authoring tests mount NoteCreator, which fetches the ambiguity
+// vocabulary on first use. Stub fetch so no real request dangles.
+beforeEach(() => {
+  globalThis.fetch = vi
+    .fn()
+    .mockResolvedValue({ ok: true, text: async () => 'ambiguity: []\n' });
+});
 
 // The watcher awaits nextTick before applyHighlights, so the test must wait
 // two ticks: one for the watcher to fire, one for its inner nextTick.
@@ -15,11 +23,15 @@ const nlddStubs = {
   'nldd-rich-text': { template: '<div><slot/></div>' },
   'nldd-popover': { template: '<div><slot/></div>' },
   'nldd-inline-dialog': { template: '<div/>' },
+  'nldd-segmented-control': { template: '<div><slot/></div>' },
+  'nldd-segmented-control-item': { template: '<div/>' },
+  'nldd-text-field': { template: '<input/>' },
+  'nldd-button': { template: '<button><slot/></button>' },
 };
 
-function mountWith(article, notesForArticle) {
+function mountWith(article, notesForArticle, extraProps = {}) {
   return mount(AnnotatedText, {
-    props: { article, notesForArticle },
+    props: { article, notesForArticle, ...extraProps },
     global: { stubs: nlddStubs },
   });
 }
@@ -125,6 +137,32 @@ describe('AnnotatedText markdown highlighting', () => {
       wrapper.element.querySelectorAll('mark[data-note-idx]'),
     ).toHaveLength(0);
     // The list rendered: an <ol><li> from "1. ".
+    expect(wrapper.element.querySelector('ol li')).toBeTruthy();
+  });
+
+  it('renders no authoring UI in the default read-only mode', async () => {
+    const wrapper = mountWith(ART, []);
+    await nextTick();
+    // canCreate defaults false: no NoteCreator, no floating button, no
+    // selection anchor — the pane is purely a read view.
+    expect(wrapper.find('[data-testid="create-note-btn"]').exists()).toBe(
+      false,
+    );
+    expect(wrapper.find('.sel-anchor').exists()).toBe(false);
+    expect(wrapper.findComponent({ name: 'NoteCreator' }).exists()).toBe(false);
+  });
+
+  it('mounts the authoring path without disturbing the highlight render', async () => {
+    const wrapper = mountWith(ART, [{ note: noteVerzekerde, spans: [] }], {
+      canCreate: true,
+      lawId: 'zorgtoeslagwet',
+      engine: { resolveNote: () => ({ status: 'orphaned', matches: [] }) },
+    });
+    await nextTick();
+    await nextTick();
+    // NoteCreator is present (gated on canCreate) but its popover is closed
+    // until a selection is made, and the read render is unaffected.
+    expect(wrapper.findComponent({ name: 'NoteCreator' }).exists()).toBe(true);
     expect(wrapper.element.querySelector('ol li')).toBeTruthy();
   });
 });

--- a/frontend/src/components/AnnotatedText.test.js
+++ b/frontend/src/components/AnnotatedText.test.js
@@ -165,4 +165,28 @@ describe('AnnotatedText markdown highlighting', () => {
     expect(wrapper.findComponent({ name: 'NoteCreator' }).exists()).toBe(true);
     expect(wrapper.element.querySelector('ol li')).toBeTruthy();
   });
+
+  it('tears down an open creator when the article changes', async () => {
+    const wrapper = mountWith(ART, [], {
+      canCreate: true,
+      lawId: 'zorgtoeslagwet',
+      engine: { resolveNote: () => ({ status: 'found', matches: [] }) },
+    });
+    await nextTick();
+    // Simulate a selection captured + creator opened against ART.
+    wrapper.vm.pendingRange = { start: 3, end: 9 };
+    wrapper.vm.openCreator();
+    await nextTick();
+    expect(wrapper.vm.creatorOpen).toBe(true);
+    expect(wrapper.vm.selectionRange).toEqual({ start: 3, end: 9 });
+    // Navigating to another article must reset the creation flow so
+    // NoteCreator never builds a selector with stale offsets against the
+    // new article's text (must-fix 2c).
+    await wrapper.setProps({
+      article: { number: '3', text: 'Een heel ander artikel hier.' },
+    });
+    await nextTick();
+    expect(wrapper.vm.creatorOpen).toBe(false);
+    expect(wrapper.vm.selectionRange).toBe(null);
+  });
 });

--- a/frontend/src/components/AnnotatedText.vue
+++ b/frontend/src/components/AnnotatedText.vue
@@ -477,6 +477,7 @@ onBeforeUnmount(() => {
       ref="popoverEl"
       accessible-label="Notitie"
       placement="bottom-start"
+      width="380px"
       @mouseenter="cancelClose"
       @mouseleave="scheduleClose"
     >

--- a/frontend/src/components/AnnotatedText.vue
+++ b/frontend/src/components/AnnotatedText.vue
@@ -6,12 +6,21 @@ import {
   spanToNodeSlices,
   cpToUtf16,
 } from '../composables/useNotesHighlight.js';
+import { selectionToRawRange } from '../composables/useTextSelection.js';
+import NoteCreator from './NoteCreator.vue';
 
 const props = defineProps({
   article: { type: Object, default: null },
   // [{ note, spans }] for the current article, from useNotes().notesForArticle
   notesForArticle: { type: Array, default: () => [] },
+  // Note authoring (RFC-018 write path). Off keeps the pure read-only view.
+  canCreate: { type: Boolean, default: false },
+  lawId: { type: String, default: '' },
+  // Loaded WASM engine, for selector uniqueness validation in NoteCreator.
+  engine: { type: Object, default: null },
 });
+
+const emit = defineEmits(['create-note']);
 
 // Render the law text as markdown, identical to the Tekst pane with notes
 // off (shared pipeline so the two cannot drift — #646). The resolver matched
@@ -270,6 +279,105 @@ function noteCreator(note) {
   if (!note?.creator) return '';
   return typeof note.creator === 'string' ? note.creator : note.creator.name || '';
 }
+
+// --- Note authoring (RFC-018 write path) --------------------------------
+// On a non-empty selection inside the rendered text, show a small "Notitie"
+// button at the selection. Clicking it maps the selection to a raw char range
+// (selectionToRawRange handles the markdown DOM -> raw text gap) and opens
+// NoteCreator. The button is positioned over the selection's bounding rect.
+const selectionRange = ref(null); // raw [start,end) for NoteCreator
+const creatorOpen = ref(false);
+const selBtnStyle = ref(null); // position of the floating "Notitie" button
+const anchorStyle = ref(null); // position of the popover anchor (persists)
+const selAnchorEl = useTemplateRef('selAnchorEl');
+
+function clearSelectionUi() {
+  if (creatorOpen.value) return; // keep anchor + form while the form is open
+  selBtnStyle.value = null;
+  anchorStyle.value = null;
+  selectionRange.value = null;
+}
+
+function onSelectionChange() {
+  if (!props.canCreate || creatorOpen.value) return;
+  const root = richTextEl.value;
+  const sel = window.getSelection?.();
+  if (!root || !sel || sel.rangeCount === 0 || sel.isCollapsed) {
+    clearSelectionUi();
+    return;
+  }
+  const domRange = sel.getRangeAt(0);
+  if (!root.contains(domRange.commonAncestorContainer)) {
+    clearSelectionUi();
+    return;
+  }
+  const rect = domRange.getBoundingClientRect();
+  const wrap = root.closest('.annotated-wrap');
+  const wrapRect = wrap?.getBoundingClientRect();
+  if (!wrapRect || rect.width === 0) {
+    clearSelectionUi();
+    return;
+  }
+  // Position the button just below the selection, relative to the wrap. The
+  // anchor sits at the selection start so the popover opens against the text.
+  const top = rect.bottom - wrapRect.top + 6;
+  const left = rect.left - wrapRect.left;
+  selBtnStyle.value = { position: 'absolute', top: `${top}px`, left: `${left}px`, zIndex: 5 };
+  anchorStyle.value = {
+    position: 'absolute',
+    top: `${rect.top - wrapRect.top}px`,
+    left: `${left}px`,
+    width: `${rect.width}px`,
+    height: `${rect.height}px`,
+    pointerEvents: 'none',
+  };
+}
+
+function openCreator() {
+  const root = richTextEl.value;
+  const rawText = props.article?.text || '';
+  if (!root || !rawText) return;
+  const range = selectionToRawRange(rawText, root);
+  if (!range) {
+    // The selection could not be mapped (e.g. it spans only stripped
+    // structure). Drop the UI rather than open an unanchorable form.
+    selBtnStyle.value = null;
+    return;
+  }
+  selectionRange.value = range;
+  creatorOpen.value = true;
+  selBtnStyle.value = null; // hide the button; the anchor persists for the popover
+}
+
+function onNoteCreated(note) {
+  creatorOpen.value = false;
+  selectionRange.value = null;
+  anchorStyle.value = null; // drop the now-orphaned invisible anchor span
+  window.getSelection?.()?.removeAllRanges();
+  emit('create-note', note);
+}
+
+function onCreatorCancel() {
+  creatorOpen.value = false;
+  selectionRange.value = null;
+  anchorStyle.value = null;
+}
+
+watch(
+  () => props.canCreate,
+  (on) => {
+    if (on) {
+      document.addEventListener('selectionchange', onSelectionChange);
+    } else {
+      document.removeEventListener('selectionchange', onSelectionChange);
+      clearSelectionUi();
+    }
+  },
+  { immediate: true },
+);
+onBeforeUnmount(() => {
+  document.removeEventListener('selectionchange', onSelectionChange);
+});
 </script>
 
 <template>
@@ -283,6 +391,37 @@ function noteCreator(note) {
       @focusout="onFocusOut"
     >
       <nldd-rich-text ref="richTextEl" v-html="html"></nldd-rich-text>
+
+      <!-- Note authoring (RFC-018). The anchor span tracks the selection
+           rect and persists while the form is open so NoteCreator's popover
+           stays attached to the text after the native selection is gone. -->
+      <span
+        v-if="canCreate && anchorStyle"
+        ref="selAnchorEl"
+        class="sel-anchor"
+        :style="anchorStyle"
+      ></span>
+      <span v-if="canCreate && selBtnStyle" class="sel-btn" :style="selBtnStyle">
+        <nldd-button
+          size="sm"
+          variant="primary"
+          text="Notitie"
+          data-testid="create-note-btn"
+          @click="openCreator"
+        ></nldd-button>
+      </span>
+
+      <NoteCreator
+        v-if="canCreate"
+        :range="creatorOpen ? selectionRange : null"
+        :raw-text="article?.text || ''"
+        :law-id="lawId"
+        :article="article"
+        :engine="engine"
+        :anchor="selAnchorEl"
+        @create="onNoteCreated"
+        @cancel="onCreatorCancel"
+      />
     </div>
 
     <!-- Single shared popover; anchorElement is repointed per hovered mark. -->
@@ -324,6 +463,15 @@ function noteCreator(note) {
 </template>
 
 <style scoped>
+/* Positioning context for the selection button + popover anchor, which are
+   placed absolutely over the selection rect (RFC-018 write path). */
+.annotated-wrap {
+  position: relative;
+}
+.sel-anchor {
+  display: block;
+}
+
 /* Marks are wrapped imperatively into nldd-rich-text's slotted light DOM, so
    they are not tagged with Vue's scoped data attribute; reach them with
    :deep(). Motivation -> background colour, authority -> border style, same

--- a/frontend/src/components/AnnotatedText.vue
+++ b/frontend/src/components/AnnotatedText.vue
@@ -291,11 +291,22 @@ const selBtnStyle = ref(null); // position of the floating "Notitie" button
 const anchorStyle = ref(null); // position of the popover anchor (persists)
 const selAnchorEl = useTemplateRef('selAnchorEl');
 
+// The raw [start,end) is captured here, at selectionchange time, NOT at
+// button-click time. applyHighlights mutates the DOM (it wraps <mark> and
+// calls parent.normalize(), which destroys the live Selection's boundary
+// nodes); if the DOM->raw mapping were deferred to openCreator() a draft
+// resolving between selection and click would collapse the selection and the
+// note could not be created while any other note is highlighted. Mapping the
+// selection the instant it is made — while the live selection and the DOM it
+// was made against are still in sync — removes that race entirely.
+const pendingRange = ref(null);
+
 function clearSelectionUi() {
   if (creatorOpen.value) return; // keep anchor + form while the form is open
   selBtnStyle.value = null;
   anchorStyle.value = null;
   selectionRange.value = null;
+  pendingRange.value = null;
 }
 
 function onSelectionChange() {
@@ -318,6 +329,16 @@ function onSelectionChange() {
     clearSelectionUi();
     return;
   }
+  // Map the selection to raw offsets NOW, against the DOM it was made in.
+  const rawText = props.article?.text || '';
+  const range = rawText ? selectionToRawRange(rawText, root) : null;
+  if (!range) {
+    // Unmappable selection (spans only stripped structure, or the render
+    // desynced) — no actionable note, drop the UI.
+    clearSelectionUi();
+    return;
+  }
+  pendingRange.value = range;
   // Position the button just below the selection, relative to the wrap. The
   // anchor sits at the selection start so the popover opens against the text.
   const top = rect.bottom - wrapRect.top + 6;
@@ -334,49 +355,76 @@ function onSelectionChange() {
 }
 
 function openCreator() {
-  const root = richTextEl.value;
-  const rawText = props.article?.text || '';
-  if (!root || !rawText) return;
-  const range = selectionToRawRange(rawText, root);
-  if (!range) {
-    // The selection could not be mapped (e.g. it spans only stripped
-    // structure). Drop the UI rather than open an unanchorable form.
-    selBtnStyle.value = null;
-    return;
-  }
-  selectionRange.value = range;
+  if (!pendingRange.value) return;
+  selectionRange.value = pendingRange.value;
   creatorOpen.value = true;
   selBtnStyle.value = null; // hide the button; the anchor persists for the popover
 }
 
-function onNoteCreated(note) {
+function resetCreator() {
   creatorOpen.value = false;
   selectionRange.value = null;
-  anchorStyle.value = null; // drop the now-orphaned invisible anchor span
+  pendingRange.value = null;
+  anchorStyle.value = null;
+}
+
+function onNoteCreated(note) {
+  resetCreator();
   window.getSelection?.()?.removeAllRanges();
   emit('create-note', note);
 }
 
 function onCreatorCancel() {
-  creatorOpen.value = false;
-  selectionRange.value = null;
-  anchorStyle.value = null;
+  resetCreator();
+}
+
+// The selected article can change while the creator is open (router nav).
+// selectionRange holds offsets into the OLD article text; NoteCreator's
+// :raw-text would switch to the new article and buildSelector would slice a
+// garbage substring at stale offsets — potentially persisting a note on the
+// wrong text. Tear the creation flow down on any article change.
+watch(
+  () => props.article,
+  () => {
+    resetCreator();
+    selBtnStyle.value = null;
+  },
+);
+
+// selectionchange fires on every caret move during a drag. onSelectionChange
+// rebuilds the raw<->DOM alignment (a full text-node walk), so debounce to
+// the selection settling rather than running it per tick.
+let selChangeTimer = null;
+function onSelectionChangeDebounced() {
+  if (selChangeTimer) clearTimeout(selChangeTimer);
+  selChangeTimer = setTimeout(() => {
+    selChangeTimer = null;
+    onSelectionChange();
+  }, 120);
 }
 
 watch(
   () => props.canCreate,
   (on) => {
     if (on) {
-      document.addEventListener('selectionchange', onSelectionChange);
+      document.addEventListener('selectionchange', onSelectionChangeDebounced);
     } else {
-      document.removeEventListener('selectionchange', onSelectionChange);
+      document.removeEventListener(
+        'selectionchange',
+        onSelectionChangeDebounced,
+      );
+      if (selChangeTimer) {
+        clearTimeout(selChangeTimer);
+        selChangeTimer = null;
+      }
       clearSelectionUi();
     }
   },
   { immediate: true },
 );
 onBeforeUnmount(() => {
-  document.removeEventListener('selectionchange', onSelectionChange);
+  document.removeEventListener('selectionchange', onSelectionChangeDebounced);
+  if (selChangeTimer) clearTimeout(selChangeTimer);
 });
 </script>
 

--- a/frontend/src/components/NoteCreator.test.js
+++ b/frontend/src/components/NoteCreator.test.js
@@ -146,6 +146,27 @@ describe('NoteCreator', () => {
     expect(w.emitted('create')).toBeUndefined();
   });
 
+  it('hides the whole form when the selection is unusable', async () => {
+    const w = mountCreator({
+      engine: {
+        resolveNote: () => ({ status: 'orphaned', matches: [] }),
+      },
+    });
+    await nextTick();
+    // Only the warning + a single "Annuleren" — no type picker, no save.
+    expect(w.find('[data-testid="note-creator-status"]').exists()).toBe(true);
+    expect(w.find('[data-testid="note-save"]').exists()).toBe(false);
+    expect(w.find('[data-testid="note-comment-text"]').exists()).toBe(false);
+    expect(w.find('[data-testid="note-cancel"]').exists()).toBe(true);
+  });
+
+  it('shows the full form once the selection resolves uniquely', async () => {
+    const w = mountCreator(); // engine returns a matching unique result
+    await nextTick();
+    expect(w.find('[data-testid="note-creator-status"]').exists()).toBe(false);
+    expect(w.find('[data-testid="note-save"]').exists()).toBe(true);
+  });
+
   it('remembers the creator across mounts via localStorage', async () => {
     const w = mountCreator();
     await nextTick();

--- a/frontend/src/components/NoteCreator.test.js
+++ b/frontend/src/components/NoteCreator.test.js
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { nextTick } from 'vue';
+import NoteCreator from './NoteCreator.vue';
+
+// NoteCreator pulls in useAmbiguityVocabulary, which fetches the vocabulary
+// file on first use. Stub fetch so the test does not hit the network (and
+// does not leave an aborted request dangling at teardown).
+beforeEach(() => {
+  localStorage.clear();
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    text: async () =>
+      'ambiguity:\n  - id: open-norm-partial\n    label: Open norm, deels ingevuld\n',
+  });
+});
+
+// NoteCreator builds the W3C Annotation a draft becomes. The body shape is
+// motivation-dependent and is the contract useDraftNotes exports and the
+// resolver re-reads, so it is worth pinning per motivation.
+
+const stubs = {
+  'nldd-popover': {
+    template: '<div><slot/></div>',
+    methods: { showPopover() {}, hidePopover() {}, matches() { return false; } },
+  },
+  'nldd-inline-dialog': { template: '<div/>' },
+  'nldd-segmented-control': { template: '<div><slot/></div>' },
+  'nldd-segmented-control-item': { template: '<div/>' },
+  'nldd-text-field': { template: '<input/>' },
+  'nldd-button': {
+    props: ['disabled'],
+    template: '<button :disabled="disabled" @click="$emit(\'click\')"><slot/></button>',
+  },
+};
+
+const RAW = 'Indien de normpremie voor een verzekerde';
+
+function mountCreator(extraProps = {}) {
+  const engine = {
+    resolveNote: () => ({
+      status: 'found',
+      matches: [{ article_number: '1', start: 10, end: 20 }],
+    }),
+  };
+  return mount(NoteCreator, {
+    props: {
+      range: { start: 10, end: 20 }, // "normpremie"
+      rawText: RAW,
+      lawId: 'zorgtoeslagwet',
+      article: {
+        number: '1',
+        machine_readable: {
+          execution: { output: [{ name: 'hoogte_zorgtoeslag' }] },
+        },
+      },
+      engine,
+      anchor: document.createElement('span'),
+      ...extraProps,
+    },
+    global: { stubs },
+  });
+}
+
+describe('NoteCreator', () => {
+  it('builds a commenting note with a TextualBody', async () => {
+    const w = mountCreator();
+    await nextTick();
+    w.vm.commentText = 'uitleg over de normpremie';
+    await nextTick();
+    w.vm.save();
+    const [[note]] = w.emitted('create');
+    expect(note.motivation).toBe('commenting');
+    expect(note.target.selector.exact).toBe('normpremie');
+    expect(note.body).toEqual({
+      type: 'TextualBody',
+      value: 'uitleg over de normpremie',
+      purpose: 'commenting',
+      format: 'text/plain',
+      language: 'nl',
+    });
+    expect(note.__draft).toBe(true);
+  });
+
+  it('builds a linking note with a SpecificResource body', async () => {
+    const w = mountCreator();
+    await nextTick();
+    w.vm.motivation = 'linking';
+    w.vm.linkTarget = 'hoogte_zorgtoeslag';
+    await nextTick();
+    w.vm.save();
+    const [[note]] = w.emitted('create');
+    expect(note.motivation).toBe('linking');
+    expect(note.body).toEqual({
+      type: 'SpecificResource',
+      source: 'regelrecht://zorgtoeslagwet/hoogte_zorgtoeslag#hoogte_zorgtoeslag',
+      purpose: 'linking',
+    });
+  });
+
+  it('builds a questioning note with question text + ambiguity tag', async () => {
+    const w = mountCreator();
+    await nextTick();
+    w.vm.motivation = 'questioning';
+    w.vm.commentText = 'is dit een open norm?';
+    w.vm.ambiguityTag = 'open-norm-partial';
+    w.vm.workflow = 'open';
+    await nextTick();
+    w.vm.save();
+    const [[note]] = w.emitted('create');
+    expect(note.workflow).toBe('open');
+    expect(Array.isArray(note.body)).toBe(true);
+    expect(note.body[1]).toEqual({
+      type: 'TextualBody',
+      value: 'open-norm-partial',
+      purpose: 'tagging',
+    });
+  });
+
+  it('builds a tagging note with just the tag', async () => {
+    const w = mountCreator();
+    await nextTick();
+    w.vm.motivation = 'tagging';
+    w.vm.ambiguityTag = 'missing-document';
+    await nextTick();
+    w.vm.save();
+    const [[note]] = w.emitted('create');
+    expect(note.body).toEqual({
+      type: 'TextualBody',
+      value: 'missing-document',
+      purpose: 'tagging',
+    });
+  });
+
+  it('does not save while the selector is ambiguous', async () => {
+    const w = mountCreator({
+      engine: {
+        resolveNote: () => ({ status: 'ambiguous', matches: [{}, {}] }),
+      },
+    });
+    await nextTick();
+    w.vm.commentText = 'iets';
+    await nextTick();
+    expect(w.vm.canSave).toBe(false);
+    w.vm.save();
+    expect(w.emitted('create')).toBeUndefined();
+  });
+
+  it('remembers the creator across mounts via localStorage', async () => {
+    const w = mountCreator();
+    await nextTick();
+    w.vm.creator = 'J. de Vries';
+    w.vm.commentText = 'x';
+    await nextTick();
+    w.vm.save();
+    expect(localStorage.getItem('regelrecht-note-creator')).toBe('J. de Vries');
+  });
+});

--- a/frontend/src/components/NoteCreator.vue
+++ b/frontend/src/components/NoteCreator.vue
@@ -196,6 +196,7 @@ defineExpose({ popoverEl });
     ref="popoverEl"
     accessible-label="Notitie aanmaken"
     placement="bottom-start"
+    width="480px"
   >
     <div v-if="range" class="note-creator" data-testid="note-creator">
       <div class="nc-quote">
@@ -314,13 +315,13 @@ defineExpose({ popoverEl });
 .note-creator {
   font-family: 'RijksSansVF', system-ui, sans-serif;
   padding: 16px;
-  /* Grow with the content (the 4-button type control + textarea are the
-     widest elements) instead of a fixed 360px that ellipsised the
-     segmented-control labels. Clamp so it stays readable and never wider
-     than the viewport. */
-  width: max-content;
-  min-width: 420px;
-  max-width: min(640px, 92vw);
+  /* The popover host owns the width (set via the `width="480px"` attribute on
+     <nldd-popover>, which it reflects to --components-popover-default-width;
+     its default is only 320px, too narrow for the 4-button type control).
+     The slotted card just fills that, so a child width here would only fight
+     the host. box-sizing keeps the 16px padding inside the 480px. */
+  box-sizing: border-box;
+  width: 100%;
   display: flex;
   flex-direction: column;
   gap: 12px;

--- a/frontend/src/components/NoteCreator.vue
+++ b/frontend/src/components/NoteCreator.vue
@@ -204,14 +204,23 @@ defineExpose({ popoverEl });
         <span class="nc-quote__text">{{ exact }}</span>
       </div>
 
-      <nldd-inline-dialog
-        v-if="statusMessage"
-        variant="warning"
-        text="Selectie niet uniek"
-        :supporting-text="statusMessage"
-        data-testid="note-creator-status"
-      ></nldd-inline-dialog>
+      <!-- Unusable selection (ambiguous/orphaned): the form would only lead
+           to a permanently-disabled save, so show just the warning and a way
+           out. The full form appears once the selection resolves uniquely. -->
+      <template v-if="statusMessage">
+        <nldd-inline-dialog
+          icon="warning"
+          icon-color="warning"
+          text="Selectie niet bruikbaar"
+          :supporting-text="statusMessage"
+          data-testid="note-creator-status"
+        ></nldd-inline-dialog>
+        <div class="nc-actions">
+          <nldd-button size="md" text="Annuleren" data-testid="note-cancel" @click="cancel"></nldd-button>
+        </div>
+      </template>
 
+      <template v-else>
       <label class="nc-field">
         <span class="nc-field__label">Type</span>
         <nldd-segmented-control
@@ -307,6 +316,7 @@ defineExpose({ popoverEl });
           @click="save"
         ></nldd-button>
       </div>
+      </template>
     </div>
   </nldd-popover>
 </template>

--- a/frontend/src/components/NoteCreator.vue
+++ b/frontend/src/components/NoteCreator.vue
@@ -73,6 +73,7 @@ const selectorResult = computed(() => {
 
 const exact = computed(() => selectorResult.value?.exact ?? '');
 const selectorStatus = computed(() => selectorResult.value?.status ?? null);
+const selectorReason = computed(() => selectorResult.value?.reason ?? null);
 
 const canSave = computed(() => {
   if (!selectorResult.value) return false;
@@ -172,41 +173,29 @@ function buildBody() {
   return text;
 }
 
-// Why a selection is unusable, explained concretely. The resolver matches
-// against the *raw* law text, but the editor renders it through markdown:
-// numbered-lid prefixes ("1. ") and collapsed whitespace are stripped from
-// what you see, so a visually-exact selection can still miss. The hints name
-// the actual likely causes and the fix, instead of a generic "select exact
-// text" that does not tell the user what went wrong.
+// One sharp line per failure reason — what went wrong + the single most
+// useful fix. No bullet wall: the reason from buildSelector already
+// distinguishes "too common" from "not located", so the message can be
+// precise instead of listing every possibility.
 const statusInfo = computed(() => {
-  const q = exact.value.trim();
-  const short = q.length > 0 && q.length < 4;
-  if (selectorStatus.value === 'ambiguous') {
-    return {
-      title: 'Selectie komt vaker voor',
-      lead:
-        'Dit fragment staat op meerdere plekken in de wet (of week net te veel af), dus de notitie kan niet eenduidig aan één plek worden gekoppeld.',
-      hints: [
-        short
-          ? `"${q}" is te kort en komt overal voor — selecteer een langere, kenmerkende zinsnede.`
-          : 'Selecteer een langer fragment, inclusief de omringende, kenmerkende woorden.',
-        'Begin en eindig op een woordgrens; selecteer een hele zin of zinsdeel in plaats van een los woord.',
-      ],
-    };
+  if (!selectorStatus.value || selectorStatus.value === 'found') return null;
+  switch (selectorReason.value) {
+    case 'too-common':
+      return {
+        title: 'Te algemeen',
+        lead: 'Dit fragment komt te vaak voor om aan één plek te koppelen. Selecteer een langere, kenmerkende zinsnede.',
+      };
+    case 'mis-anchor':
+      return {
+        title: 'Niet eenduidig',
+        lead: 'Dit fragment is hier niet uniek. Breid de selectie uit met de omringende woorden.',
+      };
+    default: // 'not-found'
+      return {
+        title: 'Niet teruggevonden',
+        lead: 'Selecteer geen lidnummer ("1.") of opsommingsteken mee en blijf binnen één lid.',
+      };
   }
-  if (selectorStatus.value === 'orphaned') {
-    return {
-      title: 'Selectie niet teruggevonden',
-      lead:
-        'De wettekst wordt opgemaakt weergegeven; de notitie wordt op de onbewerkte brontekst verankerd. Daardoor kan een selectie die er hetzelfde uitziet toch nét niet matchen.',
-      hints: [
-        'Selecteer geen lidnummer ("1.", "2.") of opsommingsteken mee — die staan niet in de brontekst zoals ze hier getoond worden.',
-        'Blijf binnen één lid of zin; selecteer niet over een witregel of lid-grens heen.',
-        'Vermijd het meeselecteren van inspringing of dubbele spaties aan begin of eind; selecteer strak om de woorden.',
-      ],
-    };
-  }
-  return null;
 });
 
 defineExpose({ popoverEl });
@@ -235,11 +224,7 @@ defineExpose({ popoverEl });
           :text="statusInfo.title"
           :supporting-text="statusInfo.lead"
           data-testid="note-creator-status"
-        >
-          <ul class="nc-hints">
-            <li v-for="(h, i) in statusInfo.hints" :key="i">{{ h }}</li>
-          </ul>
-        </nldd-inline-dialog>
+        ></nldd-inline-dialog>
         <div class="nc-actions">
           <nldd-button size="md" text="Annuleren" data-testid="note-cancel" @click="cancel"></nldd-button>
         </div>
@@ -412,15 +397,6 @@ defineExpose({ popoverEl });
 .nc-hint {
   font-size: 0.74rem;
   opacity: 0.6;
-}
-.nc-hints {
-  margin: 8px 0 0;
-  padding-left: 1.1em;
-  font-size: 0.82rem;
-  line-height: 1.5;
-}
-.nc-hints li + li {
-  margin-top: 4px;
 }
 .nc-actions {
   display: flex;

--- a/frontend/src/components/NoteCreator.vue
+++ b/frontend/src/components/NoteCreator.vue
@@ -101,11 +101,16 @@ watch(
       }
     } else {
       pop.hidePopover?.();
+      // Clear the form too: range goes null on cancel/article-switch, and
+      // stale commentText/linkTarget/tag would otherwise pre-fill the next
+      // selection's form.
+      reset();
     }
   },
 );
 
 function reset() {
+  motivation.value = 'commenting'; // back to the default, not sticky on linking
   commentText.value = '';
   linkTarget.value = '';
   ambiguityTag.value = '';
@@ -197,8 +202,6 @@ const statusInfo = computed(() => {
       };
   }
 });
-
-defineExpose({ popoverEl });
 </script>
 
 <template>
@@ -248,15 +251,15 @@ defineExpose({ popoverEl });
       <!-- Linking: pick a machine_readable element of this article. -->
       <label v-if="motivation === 'linking'" class="nc-field">
         <span class="nc-field__label">Koppel aan element</span>
-        <select
-          class="nc-select"
-          :value="linkTarget"
-          data-testid="note-link-target"
-          @change="linkTarget = $event.target.value"
+        <nldd-dropdown
+          size="md"
+          @change="linkTarget = $event.detail?.value ?? $event.target?.value ?? linkTarget"
         >
-          <option value="" disabled>Kies een element…</option>
-          <option v-for="el in linkableElements" :key="el" :value="el">{{ el }}</option>
-        </select>
+          <select :value="linkTarget" data-testid="note-link-target">
+            <option value="" disabled>Kies een element…</option>
+            <option v-for="el in linkableElements" :key="el" :value="el">{{ el }}</option>
+          </select>
+        </nldd-dropdown>
         <span v-if="linkableElements.length === 0" class="nc-hint">
           Dit artikel heeft geen machine_readable-elementen om aan te koppelen.
         </span>
@@ -265,13 +268,13 @@ defineExpose({ popoverEl });
       <!-- Comment / question body. -->
       <label v-if="motivation === 'commenting' || motivation === 'questioning'" class="nc-field">
         <span class="nc-field__label">{{ motivation === 'questioning' ? 'Vraag' : 'Toelichting' }}</span>
-        <textarea
-          class="nc-textarea"
-          rows="3"
+        <nldd-multi-line-text-field
           :value="commentText"
+          rows="3"
+          resize="auto"
           data-testid="note-comment-text"
-          @input="commentText = $event.target.value"
-        ></textarea>
+          @input="commentText = $event.target?.value ?? $event.detail?.value ?? commentText"
+        ></nldd-multi-line-text-field>
       </label>
 
       <!-- Ambiguity tag: required for tagging, optional for questioning. -->
@@ -279,17 +282,17 @@ defineExpose({ popoverEl });
         <span class="nc-field__label">
           Ambiguïteit-label{{ motivation === 'questioning' ? ' (optioneel)' : '' }}
         </span>
-        <select
-          class="nc-select"
-          :value="ambiguityTag"
-          data-testid="note-ambiguity-tag"
-          @change="ambiguityTag = $event.target.value"
+        <nldd-dropdown
+          size="md"
+          @change="ambiguityTag = $event.detail?.value ?? $event.target?.value ?? ambiguityTag"
         >
-          <option value="">{{ motivation === 'tagging' ? 'Kies een label…' : 'Geen' }}</option>
-          <option v-for="t in ambiguityItems" :key="t.id" :value="t.id">
-            {{ t.label }}
-          </option>
-        </select>
+          <select :value="ambiguityTag" data-testid="note-ambiguity-tag">
+            <option value="">{{ motivation === 'tagging' ? 'Kies een label…' : 'Geen' }}</option>
+            <option v-for="t in ambiguityItems" :key="t.id" :value="t.id">
+              {{ t.label }}
+            </option>
+          </select>
+        </nldd-dropdown>
       </label>
 
       <!-- Workflow only applies to questioning notes (RFC-018 Decision 6). -->
@@ -380,19 +383,6 @@ defineExpose({ popoverEl });
    card so the four labels show in full instead of ellipsising. */
 .nc-field nldd-segmented-control {
   width: 100%;
-}
-.nc-select,
-.nc-textarea {
-  font: inherit;
-  padding: 6px 8px;
-  border: 1px solid rgba(15, 23, 42, 0.25);
-  border-radius: 4px;
-  background: var(--nldd-color-surface, #fff);
-  color: inherit;
-}
-.nc-textarea {
-  resize: vertical;
-  min-height: 60px;
 }
 .nc-hint {
   font-size: 0.74rem;

--- a/frontend/src/components/NoteCreator.vue
+++ b/frontend/src/components/NoteCreator.vue
@@ -173,8 +173,14 @@ function buildBody() {
 }
 
 const statusMessage = computed(() => {
+  // 'ambiguous' here covers two cases buildSelector cannot tell apart from
+  // the caller's side: the quote genuinely repeats verbatim, or the resolver
+  // anchored a unique/fuzzy match somewhere other than the selection (so it
+  // was rejected as a mis-anchor). Both are fixed the same way — pick a
+  // longer, verbatim fragment — so the message covers both without
+  // over-claiming which it is.
   if (selectorStatus.value === 'ambiguous') {
-    return 'Deze selectie komt meerdere keren voor, ook met context. Selecteer een langer of unieker fragment.';
+    return 'Deze selectie kon niet eenduidig op de gekozen tekst worden vastgepind (komt vaker voor of week net af). Selecteer een langer fragment dat exact zo in de wettekst staat.';
   }
   if (selectorStatus.value === 'orphaned') {
     return 'De resolver vindt deze selectie niet terug. Selecteer tekst die exact in de wettekst staat.';

--- a/frontend/src/components/NoteCreator.vue
+++ b/frontend/src/components/NoteCreator.vue
@@ -314,8 +314,13 @@ defineExpose({ popoverEl });
 .note-creator {
   font-family: 'RijksSansVF', system-ui, sans-serif;
   padding: 16px;
-  width: 360px;
-  max-width: 90vw;
+  /* Grow with the content (the 4-button type control + textarea are the
+     widest elements) instead of a fixed 360px that ellipsised the
+     segmented-control labels. Clamp so it stays readable and never wider
+     than the viewport. */
+  width: max-content;
+  min-width: 420px;
+  max-width: min(640px, 92vw);
   display: flex;
   flex-direction: column;
   gap: 12px;
@@ -337,6 +342,9 @@ defineExpose({ popoverEl });
 .nc-quote__text {
   font-size: 0.88rem;
   font-style: italic;
+  /* A long selected fragment must wrap inside the card, not force it wider
+     than max-width or get clipped. */
+  overflow-wrap: anywhere;
 }
 .nc-field {
   display: flex;
@@ -346,6 +354,11 @@ defineExpose({ popoverEl });
 .nc-field__label {
   font-size: 0.78rem;
   font-weight: 600;
+}
+/* The type picker is the widest control; let it span the (now content-sized)
+   card so the four labels show in full instead of ellipsising. */
+.nc-field nldd-segmented-control {
+  width: 100%;
 }
 .nc-select,
 .nc-textarea {

--- a/frontend/src/components/NoteCreator.vue
+++ b/frontend/src/components/NoteCreator.vue
@@ -1,0 +1,367 @@
+<script setup>
+/**
+ * NoteCreator — the note authoring form (RFC-018 write path, steps 3-5).
+ *
+ * Opened by AnnotatedText when the user selects text and clicks "Notitie".
+ * Receives the raw [start,end) range the selection mapped to (selectionToRaw
+ * already did the DOM->raw work). This component builds the TextQuoteSelector
+ * (growing context until it is unique), lets the user pick a motivation and
+ * fill the matching body, and emits a complete W3C Annotation object. It does
+ * not persist — useDraftNotes (owned by EditorApp) does, so the new note
+ * highlights live alongside committed ones.
+ */
+import { ref, computed, watch } from 'vue';
+import { buildSelector } from '../composables/useTextSelection.js';
+import { useAmbiguityVocabulary } from '../composables/useAmbiguityVocabulary.js';
+
+const props = defineProps({
+  // Raw char range from selectionToRawRange(), or null when closed.
+  range: { type: Object, default: null },
+  rawText: { type: String, default: '' },
+  lawId: { type: String, default: '' },
+  // The selected article object, for the linking target picker.
+  article: { type: Object, default: null },
+  // Loaded WASM engine (resolveNote) for selector uniqueness validation.
+  engine: { type: Object, default: null },
+  // Anchor element for the popover (the <mark>-less selection rectangle is
+  // gone once the form opens, so AnnotatedText passes a stable anchor).
+  anchor: { type: Object, default: null },
+});
+
+const emit = defineEmits(['create', 'cancel']);
+
+const popoverEl = ref(null);
+
+const motivation = ref('commenting');
+const creator = ref(localStorage.getItem('regelrecht-note-creator') || '');
+const commentText = ref('');
+const linkTarget = ref('');
+const ambiguityTag = ref('');
+const workflow = ref('open');
+
+const { items: ambiguityItems } = useAmbiguityVocabulary();
+
+// Flatten the article's machine_readable element names so a linking note can
+// point at one. Outputs and definitions are the link-worthy elements (RFC-018
+// linking example targets #hoogte_zorgtoeslag, an output).
+const linkableElements = computed(() => {
+  const mr = props.article?.machine_readable;
+  if (!mr) return [];
+  const names = new Set();
+  for (const o of mr.execution?.output ?? []) {
+    if (o?.name) names.add(o.name);
+  }
+  for (const key of Object.keys(mr.definitions ?? {})) names.add(key);
+  return [...names];
+});
+
+// Selector for the current selection, recomputed when the range changes.
+// buildSelector grows prefix/suffix until the resolver finds it uniquely;
+// `status` drives the warning shown below the quote.
+const selectorResult = computed(() => {
+  if (!props.range || !props.rawText || !props.engine || !props.lawId) {
+    return null;
+  }
+  return buildSelector(
+    props.rawText,
+    props.range,
+    props.lawId,
+    props.engine,
+    props.article?.number,
+  );
+});
+
+const exact = computed(() => selectorResult.value?.exact ?? '');
+const selectorStatus = computed(() => selectorResult.value?.status ?? null);
+
+const canSave = computed(() => {
+  if (!selectorResult.value) return false;
+  if (selectorStatus.value !== 'found') return false; // ambiguous/orphaned: fix first
+  if (motivation.value === 'linking') return !!linkTarget.value;
+  if (motivation.value === 'commenting') return commentText.value.trim().length > 0;
+  if (motivation.value === 'questioning') return commentText.value.trim().length > 0;
+  if (motivation.value === 'tagging') return !!ambiguityTag.value;
+  return false;
+});
+
+// Show/hide the popover with the range. nldd-popover is the same primitive
+// AnnotatedText uses for the hover card.
+watch(
+  () => props.range,
+  (range) => {
+    const pop = popoverEl.value;
+    if (!pop) return;
+    if (range && props.anchor) {
+      pop.anchorElement = props.anchor;
+      try {
+        if (!pop.matches?.(':popover-open')) pop.showPopover?.();
+      } catch {
+        /* already open */
+      }
+    } else {
+      pop.hidePopover?.();
+    }
+  },
+);
+
+function reset() {
+  commentText.value = '';
+  linkTarget.value = '';
+  ambiguityTag.value = '';
+  workflow.value = 'open';
+}
+
+function cancel() {
+  popoverEl.value?.hidePopover?.();
+  reset();
+  emit('cancel');
+}
+
+function save() {
+  if (!canSave.value) return;
+  const note = {
+    type: 'Annotation',
+    motivation: motivation.value,
+    target: {
+      source: `regelrecht://${props.lawId}`,
+      selector: selectorResult.value.selector,
+    },
+    body: buildBody(),
+  };
+  const who = creator.value.trim();
+  if (who) {
+    note.creator = who;
+    localStorage.setItem('regelrecht-note-creator', who);
+  }
+  if (motivation.value === 'questioning') {
+    note.workflow = workflow.value;
+  }
+  note.__draft = true;
+  popoverEl.value?.hidePopover?.();
+  reset();
+  emit('create', note);
+}
+
+function buildBody() {
+  if (motivation.value === 'linking') {
+    return {
+      type: 'SpecificResource',
+      source: `regelrecht://${props.lawId}/${linkTarget.value}#${linkTarget.value}`,
+      purpose: 'linking',
+    };
+  }
+  if (motivation.value === 'tagging') {
+    return {
+      type: 'TextualBody',
+      value: ambiguityTag.value,
+      purpose: 'tagging',
+    };
+  }
+  const text = {
+    type: 'TextualBody',
+    value: commentText.value.trim(),
+    purpose: motivation.value,
+    format: 'text/plain',
+    language: 'nl',
+  };
+  // A questioning note over an open norm carries both the question text and
+  // the controlled ambiguity tag (RFC-018 Decision 9), so the body is a list.
+  if (motivation.value === 'questioning' && ambiguityTag.value) {
+    return [text, { type: 'TextualBody', value: ambiguityTag.value, purpose: 'tagging' }];
+  }
+  return text;
+}
+
+const statusMessage = computed(() => {
+  if (selectorStatus.value === 'ambiguous') {
+    return 'Deze selectie komt meerdere keren voor, ook met context. Selecteer een langer of unieker fragment.';
+  }
+  if (selectorStatus.value === 'orphaned') {
+    return 'De resolver vindt deze selectie niet terug. Selecteer tekst die exact in de wettekst staat.';
+  }
+  return '';
+});
+
+defineExpose({ popoverEl });
+</script>
+
+<template>
+  <nldd-popover
+    ref="popoverEl"
+    accessible-label="Notitie aanmaken"
+    placement="bottom-start"
+  >
+    <div v-if="range" class="note-creator" data-testid="note-creator">
+      <div class="nc-quote">
+        <span class="nc-quote__label">Geselecteerd</span>
+        <span class="nc-quote__text">{{ exact }}</span>
+      </div>
+
+      <nldd-inline-dialog
+        v-if="statusMessage"
+        variant="warning"
+        text="Selectie niet uniek"
+        :supporting-text="statusMessage"
+        data-testid="note-creator-status"
+      ></nldd-inline-dialog>
+
+      <label class="nc-field">
+        <span class="nc-field__label">Type</span>
+        <nldd-segmented-control
+          size="md"
+          :value="motivation"
+          @change="motivation = $event.target?.value ?? $event.detail?.value ?? motivation"
+        >
+          <nldd-segmented-control-item value="commenting" text="Toelichting"></nldd-segmented-control-item>
+          <nldd-segmented-control-item value="linking" text="Koppeling"></nldd-segmented-control-item>
+          <nldd-segmented-control-item value="questioning" text="Vraag"></nldd-segmented-control-item>
+          <nldd-segmented-control-item value="tagging" text="Label"></nldd-segmented-control-item>
+        </nldd-segmented-control>
+      </label>
+
+      <!-- Linking: pick a machine_readable element of this article. -->
+      <label v-if="motivation === 'linking'" class="nc-field">
+        <span class="nc-field__label">Koppel aan element</span>
+        <select
+          class="nc-select"
+          :value="linkTarget"
+          data-testid="note-link-target"
+          @change="linkTarget = $event.target.value"
+        >
+          <option value="" disabled>Kies een element…</option>
+          <option v-for="el in linkableElements" :key="el" :value="el">{{ el }}</option>
+        </select>
+        <span v-if="linkableElements.length === 0" class="nc-hint">
+          Dit artikel heeft geen machine_readable-elementen om aan te koppelen.
+        </span>
+      </label>
+
+      <!-- Comment / question body. -->
+      <label v-if="motivation === 'commenting' || motivation === 'questioning'" class="nc-field">
+        <span class="nc-field__label">{{ motivation === 'questioning' ? 'Vraag' : 'Toelichting' }}</span>
+        <textarea
+          class="nc-textarea"
+          rows="3"
+          :value="commentText"
+          data-testid="note-comment-text"
+          @input="commentText = $event.target.value"
+        ></textarea>
+      </label>
+
+      <!-- Ambiguity tag: required for tagging, optional for questioning. -->
+      <label v-if="motivation === 'tagging' || motivation === 'questioning'" class="nc-field">
+        <span class="nc-field__label">
+          Ambiguïteit-label{{ motivation === 'questioning' ? ' (optioneel)' : '' }}
+        </span>
+        <select
+          class="nc-select"
+          :value="ambiguityTag"
+          data-testid="note-ambiguity-tag"
+          @change="ambiguityTag = $event.target.value"
+        >
+          <option value="">{{ motivation === 'tagging' ? 'Kies een label…' : 'Geen' }}</option>
+          <option v-for="t in ambiguityItems" :key="t.id" :value="t.id">
+            {{ t.label }}
+          </option>
+        </select>
+      </label>
+
+      <!-- Workflow only applies to questioning notes (RFC-018 Decision 6). -->
+      <label v-if="motivation === 'questioning'" class="nc-field">
+        <span class="nc-field__label">Status</span>
+        <nldd-segmented-control
+          size="md"
+          :value="workflow"
+          @change="workflow = $event.target?.value ?? $event.detail?.value ?? workflow"
+        >
+          <nldd-segmented-control-item value="open" text="Open"></nldd-segmented-control-item>
+          <nldd-segmented-control-item value="resolved" text="Afgehandeld"></nldd-segmented-control-item>
+        </nldd-segmented-control>
+      </label>
+
+      <label class="nc-field">
+        <span class="nc-field__label">Auteur (optioneel)</span>
+        <nldd-text-field
+          size="md"
+          :value="creator"
+          data-testid="note-creator-field"
+          @input="creator = $event.target?.value ?? $event.detail?.value ?? creator"
+        ></nldd-text-field>
+      </label>
+
+      <div class="nc-actions">
+        <nldd-button size="md" text="Annuleren" data-testid="note-cancel" @click="cancel"></nldd-button>
+        <nldd-button
+          size="md"
+          variant="primary"
+          text="Notitie toevoegen"
+          data-testid="note-save"
+          :disabled="!canSave || undefined"
+          @click="save"
+        ></nldd-button>
+      </div>
+    </div>
+  </nldd-popover>
+</template>
+
+<style scoped>
+.note-creator {
+  font-family: 'RijksSansVF', system-ui, sans-serif;
+  padding: 16px;
+  width: 360px;
+  max-width: 90vw;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.nc-quote {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 8px 10px;
+  background: rgba(148, 163, 184, 0.16);
+  border-radius: 4px;
+}
+.nc-quote__label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  opacity: 0.6;
+}
+.nc-quote__text {
+  font-size: 0.88rem;
+  font-style: italic;
+}
+.nc-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.nc-field__label {
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+.nc-select,
+.nc-textarea {
+  font: inherit;
+  padding: 6px 8px;
+  border: 1px solid rgba(15, 23, 42, 0.25);
+  border-radius: 4px;
+  background: var(--nldd-color-surface, #fff);
+  color: inherit;
+}
+.nc-textarea {
+  resize: vertical;
+  min-height: 60px;
+}
+.nc-hint {
+  font-size: 0.74rem;
+  opacity: 0.6;
+}
+.nc-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 4px;
+}
+</style>

--- a/frontend/src/components/NoteCreator.vue
+++ b/frontend/src/components/NoteCreator.vue
@@ -172,20 +172,41 @@ function buildBody() {
   return text;
 }
 
-const statusMessage = computed(() => {
-  // 'ambiguous' here covers two cases buildSelector cannot tell apart from
-  // the caller's side: the quote genuinely repeats verbatim, or the resolver
-  // anchored a unique/fuzzy match somewhere other than the selection (so it
-  // was rejected as a mis-anchor). Both are fixed the same way — pick a
-  // longer, verbatim fragment — so the message covers both without
-  // over-claiming which it is.
+// Why a selection is unusable, explained concretely. The resolver matches
+// against the *raw* law text, but the editor renders it through markdown:
+// numbered-lid prefixes ("1. ") and collapsed whitespace are stripped from
+// what you see, so a visually-exact selection can still miss. The hints name
+// the actual likely causes and the fix, instead of a generic "select exact
+// text" that does not tell the user what went wrong.
+const statusInfo = computed(() => {
+  const q = exact.value.trim();
+  const short = q.length > 0 && q.length < 4;
   if (selectorStatus.value === 'ambiguous') {
-    return 'Deze selectie kon niet eenduidig op de gekozen tekst worden vastgepind (komt vaker voor of week net af). Selecteer een langer fragment dat exact zo in de wettekst staat.';
+    return {
+      title: 'Selectie komt vaker voor',
+      lead:
+        'Dit fragment staat op meerdere plekken in de wet (of week net te veel af), dus de notitie kan niet eenduidig aan één plek worden gekoppeld.',
+      hints: [
+        short
+          ? `"${q}" is te kort en komt overal voor — selecteer een langere, kenmerkende zinsnede.`
+          : 'Selecteer een langer fragment, inclusief de omringende, kenmerkende woorden.',
+        'Begin en eindig op een woordgrens; selecteer een hele zin of zinsdeel in plaats van een los woord.',
+      ],
+    };
   }
   if (selectorStatus.value === 'orphaned') {
-    return 'De resolver vindt deze selectie niet terug. Selecteer tekst die exact in de wettekst staat.';
+    return {
+      title: 'Selectie niet teruggevonden',
+      lead:
+        'De wettekst wordt opgemaakt weergegeven; de notitie wordt op de onbewerkte brontekst verankerd. Daardoor kan een selectie die er hetzelfde uitziet toch nét niet matchen.',
+      hints: [
+        'Selecteer geen lidnummer ("1.", "2.") of opsommingsteken mee — die staan niet in de brontekst zoals ze hier getoond worden.',
+        'Blijf binnen één lid of zin; selecteer niet over een witregel of lid-grens heen.',
+        'Vermijd het meeselecteren van inspringing of dubbele spaties aan begin of eind; selecteer strak om de woorden.',
+      ],
+    };
   }
-  return '';
+  return null;
 });
 
 defineExpose({ popoverEl });
@@ -207,14 +228,18 @@ defineExpose({ popoverEl });
       <!-- Unusable selection (ambiguous/orphaned): the form would only lead
            to a permanently-disabled save, so show just the warning and a way
            out. The full form appears once the selection resolves uniquely. -->
-      <template v-if="statusMessage">
+      <template v-if="statusInfo">
         <nldd-inline-dialog
           icon="warning"
           icon-color="warning"
-          text="Selectie niet bruikbaar"
-          :supporting-text="statusMessage"
+          :text="statusInfo.title"
+          :supporting-text="statusInfo.lead"
           data-testid="note-creator-status"
-        ></nldd-inline-dialog>
+        >
+          <ul class="nc-hints">
+            <li v-for="(h, i) in statusInfo.hints" :key="i">{{ h }}</li>
+          </ul>
+        </nldd-inline-dialog>
         <div class="nc-actions">
           <nldd-button size="md" text="Annuleren" data-testid="note-cancel" @click="cancel"></nldd-button>
         </div>
@@ -387,6 +412,15 @@ defineExpose({ popoverEl });
 .nc-hint {
   font-size: 0.74rem;
   opacity: 0.6;
+}
+.nc-hints {
+  margin: 8px 0 0;
+  padding-left: 1.1em;
+  font-size: 0.82rem;
+  line-height: 1.5;
+}
+.nc-hints li + li {
+  margin-top: 4px;
 }
 .nc-actions {
   display: flex;

--- a/frontend/src/composables/useAmbiguityVocabulary.js
+++ b/frontend/src/composables/useAmbiguityVocabulary.js
@@ -1,0 +1,48 @@
+/**
+ * useAmbiguityVocabulary — the controlled tag list for questioning notes.
+ *
+ * RFC-018 Decision 9: a questioning note over an open norm carries a tagging
+ * body whose value is one of these ids. The list is deliberately *not* a JSON
+ * Schema enum (it is still emerging from interpretation research); `just
+ * validate-annotations` only warns on an unknown value. The same file is
+ * copied to /data/annotations/_vocabulary/ by copy-laws.js so the editor's
+ * picker and the CI check read one source and cannot drift.
+ */
+import { ref } from 'vue';
+import yaml from 'js-yaml';
+
+// Session cache: the file does not change while the editor is open.
+let cached = null;
+
+const items = ref([]);
+const loaded = ref(false);
+
+async function load() {
+  if (cached) {
+    items.value = cached;
+    loaded.value = true;
+    return cached;
+  }
+  try {
+    const res = await fetch('/data/annotations/_vocabulary/ambiguity.yaml');
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const doc = yaml.load(await res.text());
+    const list = Array.isArray(doc?.ambiguity) ? doc.ambiguity : [];
+    cached = list;
+    items.value = list;
+  } catch (e) {
+    // A missing vocabulary must not block note creation: the tag field just
+    // falls back to free text. Surfaced via the empty list.
+    console.warn('Kon ambiguïteit-vocabulary niet laden:', e.message);
+    cached = [];
+    items.value = [];
+  } finally {
+    loaded.value = true;
+  }
+  return cached;
+}
+
+export function useAmbiguityVocabulary() {
+  if (!loaded.value) load();
+  return { items, loaded, reload: load };
+}

--- a/frontend/src/composables/useAmbiguityVocabulary.js
+++ b/frontend/src/composables/useAmbiguityVocabulary.js
@@ -42,7 +42,15 @@ async function load() {
   return cached;
 }
 
+// loaded.value stays false until load()'s finally settles, so two components
+// mounting in the same tick would each dispatch a fetch. Hold the in-flight
+// promise so the second caller reuses the first load.
+let loadPromise = null;
 export function useAmbiguityVocabulary() {
-  if (!loaded.value) load();
+  if (!loaded.value && !loadPromise) {
+    loadPromise = load().finally(() => {
+      loadPromise = null;
+    });
+  }
   return { items, loaded, reload: load };
 }

--- a/frontend/src/composables/useDraftNotes.js
+++ b/frontend/src/composables/useDraftNotes.js
@@ -1,0 +1,145 @@
+/**
+ * useDraftNotes — local-only note authoring store (RFC-018 write path, MVP).
+ *
+ * The MVP does not write the sidecar back to the repo: notes a user creates in
+ * the editor live in `localStorage`, keyed per law, and are exported as a YAML
+ * document the user commits to `corpus/annotations/{lawId}/annotations.yaml`
+ * by hand (RFC-018 step 6 — git stays the source of truth, no write API).
+ *
+ * Draft notes are merged into the resolved-notes list by the caller so they
+ * highlight live, exactly like committed notes; they just carry an extra
+ * `__draft` marker so the UI can show them as unsaved and offer delete/export.
+ */
+import { ref, computed, watch } from 'vue';
+import yaml from 'js-yaml';
+
+const STORAGE_PREFIX = 'regelrecht-draft-notes:';
+
+function storageKey(lawId) {
+  return `${STORAGE_PREFIX}${lawId}`;
+}
+
+function loadFor(lawId) {
+  if (!lawId) return [];
+  try {
+    const raw = localStorage.getItem(storageKey(lawId));
+    const parsed = raw ? JSON.parse(raw) : [];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function persist(lawId, list) {
+  try {
+    localStorage.setItem(storageKey(lawId), JSON.stringify(list));
+  } catch {
+    /* quota/full or disabled — drafts are best-effort in the MVP */
+  }
+}
+
+/**
+ * @param {import('vue').Ref<string>} lawId reactive law $id
+ */
+export function useDraftNotes(lawId) {
+  const drafts = ref(loadFor(lawId.value));
+
+  // Re-read from storage whenever the law changes. A real watch (not a lazy
+  // resync inside every method/computed) keeps `drafts` authoritative for the
+  // current law at all times, so useResolvedDraftNotes — which watches lawId
+  // independently — never resolves the previous law's selectors against the
+  // new law between a law switch and the next store method call.
+  watch(lawId, (id) => {
+    drafts.value = loadFor(id);
+  });
+
+  /**
+   * Append a note. `note` is a full W3C Annotation object (already validated
+   * shape from NoteCreator). Returns the stored note (with its draft marker).
+   */
+  function addDraft(note) {
+    const stored = {
+      ...note,
+      created: note.created || new Date().toISOString(),
+    };
+    drafts.value = [...drafts.value, stored];
+    persist(lawId.value, drafts.value);
+    return stored;
+  }
+
+  /** Remove the draft at `index` (index into the current drafts array). */
+  function removeDraft(index) {
+    if (index < 0 || index >= drafts.value.length) return;
+    drafts.value = drafts.value.filter((_, i) => i !== index);
+    persist(lawId.value, drafts.value);
+  }
+
+  /** Drop every draft for the current law (after a successful export/commit). */
+  function clearDrafts() {
+    drafts.value = [];
+    persist(lawId.value, []);
+  }
+
+  /**
+   * The full sidecar YAML for this law: every committed note plus the drafts.
+   *
+   * The committed notes are read from the *raw sidecar file*, not from the
+   * resolver output. The WASM resolver drops notes whose target.source names a
+   * different law (federated sidecars may carry notes for several laws — see
+   * resolveNotes in wasm.rs); rebuilding the export from resolved notes would
+   * silently truncate those on commit. Re-parsing the original file preserves
+   * every committed note verbatim and only appends the drafts.
+   *
+   * Async because it fetches the sidecar; a missing sidecar (404) is normal
+   * for a law that has no committed notes yet — the export is then just the
+   * drafts.
+   */
+  async function exportYaml() {
+    const id = lawId.value;
+    let committed = [];
+    try {
+      const res = await fetch(
+        `/data/annotations/${encodeURIComponent(id)}/annotations.yaml`,
+      );
+      if (res.ok) {
+        const doc = yaml.load(await res.text());
+        if (Array.isArray(doc?.annotations)) committed = doc.annotations;
+      }
+      // 404 (no sidecar yet) and parse failures fall through to drafts-only;
+      // the author still gets a valid file to commit.
+    } catch {
+      /* network/parse error — export the drafts so work is not lost */
+    }
+    const annotations = [
+      ...committed.map(stripDraftMarker),
+      ...drafts.value.map(stripDraftMarker),
+    ];
+    const doc = {
+      $schema:
+        'https://raw.githubusercontent.com/MinBZK/regelrecht/refs/heads/main/schema/v0.5.2/annotation-schema.json',
+      annotations,
+    };
+    // lineWidth -1: never fold long body strings, so the YAML diff stays
+    // readable and selectors are not silently wrapped.
+    return yaml.dump(doc, { lineWidth: -1, noRefs: true });
+  }
+
+  const draftCount = computed(() => drafts.value.length);
+
+  return {
+    drafts,
+    draftCount,
+    addDraft,
+    removeDraft,
+    clearDrafts,
+    exportYaml,
+  };
+}
+
+function stripDraftMarker(note) {
+  if (note && typeof note === 'object' && '__draft' in note) {
+    const { __draft, ...rest } = note;
+    return rest;
+  }
+  return note;
+}

--- a/frontend/src/composables/useDraftNotes.js
+++ b/frontend/src/composables/useDraftNotes.js
@@ -96,6 +96,11 @@ export function useDraftNotes(lawId) {
    */
   async function exportYaml() {
     const id = lawId.value;
+    // Snapshot drafts BEFORE the await: watch(lawId) swaps drafts.value
+    // synchronously on a law switch, so reading it after the fetch could mix
+    // law A's committed notes with law B's drafts. Drafts are the only copy
+    // of unsaved work — silent loss is the worst outcome here.
+    const snapshotDrafts = [...drafts.value];
     let committed = [];
     try {
       const res = await fetch(
@@ -112,7 +117,7 @@ export function useDraftNotes(lawId) {
     }
     const annotations = [
       ...committed.map(stripDraftMarker),
-      ...drafts.value.map(stripDraftMarker),
+      ...snapshotDrafts.map(stripDraftMarker),
     ];
     const doc = {
       $schema:

--- a/frontend/src/composables/useDraftNotes.test.js
+++ b/frontend/src/composables/useDraftNotes.test.js
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ref } from 'vue';
+import yaml from 'js-yaml';
+import { useDraftNotes } from './useDraftNotes.js';
+
+/** Stub the sidecar fetch exportYaml does. `committed` is the file's notes. */
+function stubSidecar(committed) {
+  globalThis.fetch = vi.fn().mockResolvedValue(
+    committed == null
+      ? { ok: false, status: 404 }
+      : {
+          ok: true,
+          text: async () => yaml.dump({ annotations: committed }),
+        },
+  );
+}
+
+// useDraftNotes is the local-only authoring store (RFC-018 write path MVP):
+// per-law localStorage, append/clear, and a committed+drafts YAML export.
+// These pin the storage keying, the per-law isolation, and the export shape
+// (the file a user commits by hand).
+
+const NOTE = {
+  type: 'Annotation',
+  motivation: 'commenting',
+  target: {
+    source: 'regelrecht://zorgtoeslagwet',
+    selector: { type: 'TextQuoteSelector', exact: 'normpremie' },
+  },
+  body: { type: 'TextualBody', value: 'uitleg', purpose: 'commenting' },
+};
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('useDraftNotes', () => {
+  it('appends a draft and persists it under a per-law key', () => {
+    const lawId = ref('zorgtoeslagwet');
+    const { addDraft, drafts } = useDraftNotes(lawId);
+    addDraft(NOTE);
+    expect(drafts.value).toHaveLength(1);
+    const raw = localStorage.getItem('regelrecht-draft-notes:zorgtoeslagwet');
+    expect(JSON.parse(raw)).toHaveLength(1);
+  });
+
+  it('stamps created when the note has none', () => {
+    const { addDraft } = useDraftNotes(ref('w'));
+    const stored = addDraft(NOTE);
+    expect(stored.created).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('keeps an explicit created timestamp', () => {
+    const { addDraft } = useDraftNotes(ref('w'));
+    const stored = addDraft({ ...NOTE, created: '2020-01-01T00:00:00Z' });
+    expect(stored.created).toBe('2020-01-01T00:00:00Z');
+  });
+
+  it('isolates drafts per law', () => {
+    localStorage.setItem(
+      'regelrecht-draft-notes:lawA',
+      JSON.stringify([NOTE]),
+    );
+    const a = useDraftNotes(ref('lawA'));
+    expect(a.drafts.value).toHaveLength(1);
+    const b = useDraftNotes(ref('lawB'));
+    expect(b.drafts.value).toHaveLength(0);
+  });
+
+  it('removeDraft drops the right index', () => {
+    const { addDraft, removeDraft, drafts } = useDraftNotes(ref('w'));
+    addDraft({ ...NOTE, body: { ...NOTE.body, value: 'a' } });
+    addDraft({ ...NOTE, body: { ...NOTE.body, value: 'b' } });
+    removeDraft(0);
+    expect(drafts.value).toHaveLength(1);
+    expect(drafts.value[0].body.value).toBe('b');
+  });
+
+  it('clearDrafts empties storage', () => {
+    const { addDraft, clearDrafts, drafts } = useDraftNotes(ref('w'));
+    addDraft(NOTE);
+    clearDrafts();
+    expect(drafts.value).toHaveLength(0);
+    expect(
+      JSON.parse(localStorage.getItem('regelrecht-draft-notes:w')),
+    ).toEqual([]);
+  });
+
+  it('exports the raw sidecar notes + drafts (preserving cross-law notes)', async () => {
+    // The committed file carries a note for ANOTHER law (federated sidecar).
+    // The resolver would drop it; exportYaml must NOT — it re-parses the file.
+    const otherLawNote = {
+      ...NOTE,
+      target: { ...NOTE.target, source: 'regelrecht://andere_wet' },
+    };
+    stubSidecar([{ ...NOTE, creator: 'Dienst Toeslagen' }, otherLawNote]);
+    const { addDraft, exportYaml } = useDraftNotes(ref('w'));
+    addDraft({ ...NOTE, __draft: true });
+    const doc = yaml.load(await exportYaml());
+    expect(doc.$schema).toContain('annotation-schema.json');
+    // 2 committed (incl. the other-law one) + 1 draft.
+    expect(doc.annotations).toHaveLength(3);
+    expect(doc.annotations[0].creator).toBe('Dienst Toeslagen');
+    expect(doc.annotations[1].target.source).toBe('regelrecht://andere_wet');
+    // The internal __draft marker must never reach the exported YAML.
+    expect(JSON.stringify(doc)).not.toContain('__draft');
+  });
+
+  it('exports drafts only when there is no sidecar yet (404)', async () => {
+    stubSidecar(null);
+    const { addDraft, exportYaml } = useDraftNotes(ref('w'));
+    addDraft({ ...NOTE, __draft: true });
+    const doc = yaml.load(await exportYaml());
+    expect(doc.annotations).toHaveLength(1);
+  });
+
+  it('does not fold long body strings in the export', async () => {
+    stubSidecar(null);
+    const longValue = 'x '.repeat(120).trim();
+    const { addDraft, exportYaml } = useDraftNotes(ref('w'));
+    addDraft({
+      ...NOTE,
+      body: { type: 'TextualBody', value: longValue, purpose: 'commenting' },
+    });
+    // lineWidth -1: the value stays on one logical line (no YAML fold marker).
+    const reparsed = yaml.load(await exportYaml());
+    expect(reparsed.annotations[0].body.value).toBe(longValue);
+  });
+});

--- a/frontend/src/composables/useFeatureFlags.js
+++ b/frontend/src/composables/useFeatureFlags.js
@@ -14,6 +14,9 @@ const DEFAULTS = {
   // Notes pane (RFC-005/RFC-018). Off by default until the feature is past
   // the display-only MVP and the corpus has notes for more than one law.
   'panel.notes': false,
+  // Note authoring (RFC-018 write path, MVP: localStorage + manual export).
+  // Off by default: it is a separate, opt-in capability on top of viewing.
+  'notes.create': false,
   // Gates write access on the Tekst pane independently from its visibility.
   // Default off so users see article text in read-only mode until they
   // explicitly opt in — the first-save markdown normalisation rewrites the

--- a/frontend/src/composables/useNotes.js
+++ b/frontend/src/composables/useNotes.js
@@ -146,7 +146,80 @@ export function useNotes(lawId, selectedArticle) {
       })),
   );
 
-  return { resolved, notesForArticle, issues, loading, error, reload: load };
+  return { notesForArticle, issues, loading, error, reload: load };
+}
+
+/**
+ * Resolve a list of in-memory draft notes against the loaded law and project
+ * them onto the selected article, returning the same `{ note, spans }` shape
+ * as `notesForArticle` so the editor highlights drafts exactly like committed
+ * notes. Drafts live only in localStorage until exported (RFC-018 write path);
+ * they are resolved here per-note via the same WASM resolver, not refetched.
+ *
+ * @param {import('vue').Ref<Array>} draftNotes reactive list of W3C Annotation
+ * @param {import('vue').Ref<string>} lawId
+ * @param {import('vue').Ref<object>} selectedArticle
+ */
+export function useResolvedDraftNotes(draftNotes, lawId, selectedArticle) {
+  const { initEngine, loadDependency } = useEngine();
+  const resolvedDrafts = ref([]); // [{ note, match }]
+
+  // Generation guard: resolve() awaits initEngine/loadDependency (slow on a
+  // law switch). Without this, a resolve started before a law switch can
+  // finish after the one started by the switch and overwrite it with stale
+  // data — and because draft selectors resolve per-law, that would highlight
+  // the previous law's drafts on the new law. useNotes.load() guards the same
+  // race the same way.
+  let generation = 0;
+
+  async function resolve() {
+    const id = lawId.value;
+    const notes = draftNotes.value;
+    const gen = ++generation;
+    const isStale = () => gen !== generation;
+    if (!id || !notes || notes.length === 0) {
+      resolvedDrafts.value = [];
+      return;
+    }
+    try {
+      const engine = await initEngine();
+      if (!engine.hasLaw(id)) await loadDependency(id);
+      const out = [];
+      for (const note of notes) {
+        const selector = note?.target?.selector;
+        if (!selector) continue;
+        let match;
+        try {
+          match = engine.resolveNote(id, selector);
+        } catch {
+          continue; // a malformed draft selector simply does not highlight
+        }
+        out.push({ note, match });
+      }
+      if (!isStale()) resolvedDrafts.value = out;
+    } catch {
+      if (!isStale()) resolvedDrafts.value = [];
+    }
+  }
+
+  watch([draftNotes, lawId], resolve, { immediate: true, deep: true });
+
+  const draftNotesForArticle = computed(() => {
+    const articleNr = selectedArticle.value?.number;
+    if (articleNr == null || articleNr === '') return [];
+    const target = String(articleNr);
+    const out = [];
+    for (const entry of resolvedDrafts.value) {
+      if (!entry.match || entry.match.status !== 'found') continue;
+      const spans = entry.match.matches.filter(
+        (m) => String(m.article_number) === target,
+      );
+      if (spans.length > 0) out.push({ note: entry.note, spans });
+    }
+    return out;
+  });
+
+  return { draftNotesForArticle };
 }
 
 /**

--- a/frontend/src/composables/useTextSelection.js
+++ b/frontend/src/composables/useTextSelection.js
@@ -263,6 +263,20 @@ export function buildSelector(rawText, range, lawId, engine, articleNumber) {
   const exact = chars.slice(range.start, range.end).join('');
   const wantArticle = String(articleNumber);
 
+  // A whitespace-only quote is meaningless as an anchor: it satisfies the
+  // schema's minLength:1 and the resolver's non-empty guard, but a note
+  // quoting " " points at nothing a reader can see. selectionToRawRange
+  // already rejects an empty/zero-length range; this rejects the
+  // collapsed-whitespace-only case (a selection that maps to just the space
+  // between two words). Reported as orphaned so the UI asks for real text.
+  if (exact.trim() === '') {
+    return {
+      selector: { type: 'TextQuoteSelector', exact },
+      exact,
+      status: 'orphaned',
+    };
+  }
+
   // The resolver returns article-relative `char` offsets. range is into this
   // article's text, so a correct unique match has exactly these offsets in
   // this article.

--- a/frontend/src/composables/useTextSelection.js
+++ b/frontend/src/composables/useTextSelection.js
@@ -1,0 +1,315 @@
+/**
+ * useTextSelection — turn a DOM selection in the rendered article into a
+ * TextQuoteSelector against the *raw* law text (RFC-018 write path, step 2).
+ *
+ * The Tekst pane renders the raw article text through marked (list prefixes
+ * stripped, whitespace collapsed — see useNotesHighlight.js). A user selecting
+ * "zorgtoeslag" with the mouse selects it in that rendered DOM, but a note's
+ * TextQuoteSelector must quote the *raw* text the resolver matches against, or
+ * it will not round-trip. So a selection is mapped DOM -> raw using the same
+ * two-pointer alignment the highlight path uses in reverse, then `exact`,
+ * `prefix` and `suffix` are sliced from the raw string.
+ *
+ * Uniqueness: a bare `exact` often occurs many times ("verzekerde" appears
+ * dozens of times in the Zorgtoeslagwet). The selector is only useful if it
+ * resolves to exactly one span, so context is grown until the resolver
+ * (`engine.resolveNote`) reports a single match, or we run out of article and
+ * report it as still ambiguous so the UI can ask the user to select more.
+ */
+import { buildAlignment } from './useNotesHighlight.js';
+
+// W3C TextQuoteSelector context length. RFC-018 §write-path says 30-50 chars;
+// 40 is the midpoint and enough to disambiguate every repeated phrase in the
+// current corpus while staying readable in the note YAML.
+const CONTEXT = 40;
+
+/**
+ * Walk `root`'s text nodes (document order) and return them with text, the
+ * shape buildAlignment expects.
+ */
+function collectTextNodes(root) {
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  const out = [];
+  let n;
+  while ((n = walker.nextNode())) {
+    out.push({ node: n, text: n.textContent });
+  }
+  return out;
+}
+
+/** UTF-16 offset within `text` -> code-point offset (inverse of cpToUtf16). */
+function utf16ToCp(text, u16Offset) {
+  let cp = 0;
+  let u = 0;
+  for (const ch of text) {
+    if (u >= u16Offset) break;
+    u += ch.length;
+    cp++;
+  }
+  return cp;
+}
+
+/**
+ * Build a DOM-position -> raw-char-offset map by inverting the raw->DOM
+ * alignment. `buildAlignment` already solves the hard direction (it knows
+ * which raw chars marked dropped); inverting it is exact for every DOM char
+ * that has a raw counterpart, which is all of them under the resolver's
+ * raw-only-transforms assumption.
+ *
+ * @returns {{ domToRaw: Map<Node, Array<number>>, desynced: boolean }}
+ *   domToRaw.get(node)[cpOffset] === raw char offset, or undefined if that DOM
+ *   char has no raw counterpart (should not happen for corpus text).
+ */
+function buildDomToRaw(rawText, domNodes) {
+  const { rawToDom, desynced } = buildAlignment(rawText, domNodes);
+  const domToRaw = new Map();
+  for (let r = 0; r < rawToDom.length; r++) {
+    const pos = rawToDom[r];
+    if (!pos) continue;
+    let arr = domToRaw.get(pos.node);
+    if (!arr) {
+      arr = [];
+      domToRaw.set(pos.node, arr);
+    }
+    // First raw char wins a DOM slot: collapsed whitespace maps several raw
+    // chars to one DOM char, and the selection should anchor at the start of
+    // the run, not the end.
+    if (arr[pos.offset] === undefined) arr[pos.offset] = r;
+  }
+  return { domToRaw, desynced };
+}
+
+/**
+ * First *mappable* text node (present in domToRaw) inside `node`'s subtree,
+ * scanning forward (fromEnd=false) or backward (fromEnd=true) in document
+ * order. Whitespace-only nodes (marked's inter-tag "\n" in `<ol>\n<li>`) are
+ * skipped because buildAlignment skips them, so they have no domToRaw entry;
+ * an endpoint landing on one must traverse past it, not dead-end.
+ */
+function firstMappableTextNode(node, fromEnd, domToRaw) {
+  if (!node) return null;
+  if (node.nodeType === Node.TEXT_NODE) {
+    return domToRaw.has(node) ? node : null;
+  }
+  const kids = node.childNodes;
+  const order = fromEnd ? [...kids.keys()].reverse() : [...kids.keys()];
+  for (const i of order) {
+    const tn = firstMappableTextNode(kids[i], fromEnd, domToRaw);
+    if (tn) return tn;
+  }
+  return null;
+}
+
+/**
+ * Mappable text node reached by scanning `parent`'s children from `fromIdx`
+ * in document order (forward for a start endpoint, backward for an end one).
+ * Unlike firstMappableTextNode this does not dead-end when child `fromIdx` is
+ * itself a whitespace-only text node (marked's inter-tag "\n"): it keeps
+ * walking siblings. This is the `(ol, 0)`-style element endpoint case.
+ */
+function mappableFromChild(parent, fromIdx, fromEnd, domToRaw) {
+  const kids = parent.childNodes;
+  if (kids.length === 0) return null;
+  const start = Math.max(0, Math.min(fromIdx, kids.length - 1));
+  if (fromEnd) {
+    for (let i = start; i >= 0; i--) {
+      const tn = firstMappableTextNode(kids[i], true, domToRaw);
+      if (tn) return tn;
+    }
+  } else {
+    for (let i = start; i < kids.length; i++) {
+      const tn = firstMappableTextNode(kids[i], false, domToRaw);
+      if (tn) return tn;
+    }
+  }
+  return null;
+}
+
+/**
+ * Resolve a selection endpoint (container + UTF-16 offset) to a raw char
+ * offset. Returns the offset, or null if nothing maps.
+ *
+ * Two boundary cases the naive "look in this node only" approach gets wrong,
+ * both common with marked's `<ol><li>` structure:
+ *  - the end caret sits at offset 0 of a node (drag ended exactly at a
+ *    paragraph/list-item start): there is no char before it *in this node*, so
+ *    fall through to the previous mappable node's end;
+ *  - the endpoint is on an element node (e.g. `(ol, 0)`): descend to the
+ *    first/last mappable text node, skipping inter-tag whitespace.
+ * `nodeOrder` is the document-order list of mappable text nodes so the scan
+ * can cross node boundaries.
+ */
+function endpointToRaw(domToRaw, nodeOrder, container, u16, isEnd) {
+  let node = container;
+  let offset = u16;
+  if (node.nodeType !== Node.TEXT_NODE) {
+    // Element endpoint, e.g. `(ol, 0)`. The DOM child at the boundary index
+    // is often marked's inter-tag "\n" (not mappable), so scan siblings from
+    // there in the endpoint's direction rather than dead-ending on it. For
+    // the end the char is *before* the boundary (offset-1).
+    const fromIdx = isEnd ? offset - 1 : offset;
+    const tn = mappableFromChild(node, fromIdx, isEnd, domToRaw);
+    if (!tn) return null;
+    node = tn;
+    offset = isEnd ? tn.textContent.length : 0;
+  }
+  let arr;
+  const cp = utf16ToCp(node.textContent, offset);
+
+  const startIdx = nodeOrder.indexOf(node);
+  if (startIdx < 0) return null;
+
+  if (isEnd) {
+    // Caret is after the last selected char: map char (cp-1), return +1.
+    // If this node has no mapped char before the caret (cp === 0, drag ended
+    // at a node edge), walk back into the previous mappable nodes.
+    for (let ni = startIdx; ni >= 0; ni--) {
+      arr = domToRaw.get(nodeOrder[ni]);
+      const from = ni === startIdx ? cp - 1 : arr.length - 1;
+      for (let i = from; i >= 0; i--) {
+        if (arr[i] !== undefined) return arr[i] + 1;
+      }
+    }
+    return null;
+  }
+
+  // Start: first mapped char at or after the caret; if none in this node,
+  // continue into the following mappable nodes.
+  for (let ni = startIdx; ni < nodeOrder.length; ni++) {
+    arr = domToRaw.get(nodeOrder[ni]);
+    const from = ni === startIdx ? cp : 0;
+    for (let i = from; i < arr.length; i++) {
+      if (arr[i] !== undefined) return arr[i];
+    }
+  }
+  return null;
+}
+
+/**
+ * Turn the current window selection (which must lie inside `rootEl`) into a
+ * raw `[start, end)` char range, or null if there is no usable selection.
+ *
+ * @param {string} rawText  the exact article text the resolver matches against
+ * @param {Element} rootEl  the element the markdown was rendered into
+ */
+export function selectionToRawRange(rawText, rootEl) {
+  const sel = window.getSelection?.();
+  if (!sel || sel.rangeCount === 0 || sel.isCollapsed) return null;
+  const range = sel.getRangeAt(0);
+  if (!rootEl.contains(range.commonAncestorContainer)) return null;
+
+  const domNodes = collectTextNodes(rootEl);
+  if (domNodes.length === 0) return null;
+  const { domToRaw, desynced } = buildDomToRaw(rawText, domNodes);
+  // If the render diverged from raw beyond the known raw-only transforms the
+  // map is untrustworthy; refuse rather than anchor a note at a wrong offset.
+  if (desynced) return null;
+
+  // Document-order list of mappable text nodes, so endpointToRaw can cross
+  // node boundaries when a caret sits at a node edge.
+  const nodeOrder = domNodes
+    .map(({ node }) => node)
+    .filter((n) => domToRaw.has(n));
+
+  const start = endpointToRaw(
+    domToRaw,
+    nodeOrder,
+    range.startContainer,
+    range.startOffset,
+    false,
+  );
+  const end = endpointToRaw(
+    domToRaw,
+    nodeOrder,
+    range.endContainer,
+    range.endOffset,
+    true,
+  );
+  if (start == null || end == null || end <= start) return null;
+  return { start, end };
+}
+
+/**
+ * Build a TextQuoteSelector from a raw range, growing prefix/suffix context
+ * until the resolver finds exactly the span the user selected.
+ *
+ * "Found" from the resolver is necessary but not sufficient: the resolver's
+ * exact-match prefix/suffix check trims a one-char-slack window
+ * (resolver.rs verify_at_position), so when the same `exact` repeats and a
+ * grown context happens to satisfy the trimmed comparison at the *other*
+ * occurrence, the resolver returns `found` pointing at the wrong span. For a
+ * legal-text product that silent mis-anchor is unacceptable, so a `found`
+ * result is only accepted when the single match lands in the article the user
+ * selected in, at exactly the offsets they selected. Otherwise context keeps
+ * growing; if it never converges the status is reported as ambiguous so the
+ * UI asks the author to extend the selection rather than persisting a note on
+ * the wrong sentence.
+ *
+ * @param {string} rawText           the selected article's text
+ * @param {{start:number,end:number}} range  raw char offsets into rawText
+ * @param {string} lawId
+ * @param {{ resolveNote: Function }} engine  loaded WASM engine
+ * @param {string|number} articleNumber  the article `range` is in; the
+ *        resolver returns article-relative offsets + article_number, so the
+ *        match is verified against this
+ * @returns {{
+ *   selector: object,
+ *   exact: string,
+ *   status: 'found'|'ambiguous'|'orphaned',
+ * }}
+ */
+export function buildSelector(rawText, range, lawId, engine, articleNumber) {
+  const chars = Array.from(rawText);
+  const exact = chars.slice(range.start, range.end).join('');
+  const wantArticle = String(articleNumber);
+
+  // The resolver returns article-relative `char` offsets. range is into this
+  // article's text, so a correct unique match has exactly these offsets in
+  // this article.
+  const isExactlyOurSelection = (result) => {
+    if (result?.status !== 'found') return false;
+    const matches = result.matches ?? [];
+    if (matches.length !== 1) return false;
+    const m = matches[0];
+    return (
+      String(m.article_number) === wantArticle &&
+      m.start === range.start &&
+      m.end === range.end
+    );
+  };
+
+  // Try increasing context: no context, then CONTEXT chars each side, then
+  // double. Short-circuit as soon as the match is provably our selection.
+  const widths = [0, CONTEXT, CONTEXT * 2];
+  let last = null;
+  for (const w of widths) {
+    const prefix =
+      w > 0 ? chars.slice(Math.max(0, range.start - w), range.start).join('') : '';
+    const suffix =
+      w > 0 ? chars.slice(range.end, range.end + w).join('') : '';
+    const selector = { type: 'TextQuoteSelector', exact };
+    if (prefix) selector.prefix = prefix;
+    if (suffix) selector.suffix = suffix;
+
+    let result;
+    try {
+      result = engine.resolveNote(lawId, selector);
+    } catch {
+      // Resolver threw (law not loaded etc.) — caller surfaces it.
+      return { selector, exact, status: 'orphaned' };
+    }
+    if (isExactlyOurSelection(result)) {
+      return { selector, exact, status: 'found' };
+    }
+    // A unique `found` that is NOT our selection is a mis-anchor: treat it as
+    // ambiguous (more context may still pin the right one) rather than
+    // accepting it. Only a genuine orphaned short-circuits.
+    const status = result?.status === 'orphaned' ? 'orphaned' : 'ambiguous';
+    last = { selector, exact, status };
+    if (status === 'orphaned') return last;
+  }
+  // Widest context still did not provably pin our selection: report ambiguous
+  // so the UI asks for a longer/uniquer selection. Carry the widest selector
+  // so a human extending it starts from maximum context.
+  return last;
+}

--- a/frontend/src/composables/useTextSelection.js
+++ b/frontend/src/composables/useTextSelection.js
@@ -256,7 +256,13 @@ export function selectionToRawRange(rawText, rootEl) {
  *   selector: object,
  *   exact: string,
  *   status: 'found'|'ambiguous'|'orphaned',
+ *   reason: 'ok'|'too-common'|'not-found'|'mis-anchor',
  * }}
+ *   `reason` is for the UI message only; it does not change accept/reject.
+ *   'too-common' = the bare quote already matched several places (RFC-018
+ *   §5.4 "common word without context") even if widening context later
+ *   degrades to orphaned; 'not-found' = genuinely not locatable; 'mis-anchor'
+ *   = a unique match landed off the selection.
  */
 export function buildSelector(rawText, range, lawId, engine, articleNumber) {
   const chars = Array.from(rawText);
@@ -274,6 +280,7 @@ export function buildSelector(rawText, range, lawId, engine, articleNumber) {
       selector: { type: 'TextQuoteSelector', exact },
       exact,
       status: 'orphaned',
+      reason: 'not-found',
     };
   }
 
@@ -296,6 +303,11 @@ export function buildSelector(rawText, range, lawId, engine, articleNumber) {
   // double. Short-circuit as soon as the match is provably our selection.
   const widths = [0, CONTEXT, CONTEXT * 2];
   let last = null;
+  // The bare quote (no context) matching several places is the RFC-018 §5.4
+  // "common word" case. Remember it: even if widening context later degrades
+  // to orphaned (markdown-stripped prefix/suffix no longer matches), the
+  // user-facing reason is still "too common", not "not found".
+  let sawMultiple = false;
   for (const w of widths) {
     const prefix =
       w > 0 ? chars.slice(Math.max(0, range.start - w), range.start).join('') : '';
@@ -310,20 +322,27 @@ export function buildSelector(rawText, range, lawId, engine, articleNumber) {
       result = engine.resolveNote(lawId, selector);
     } catch {
       // Resolver threw (law not loaded etc.) — caller surfaces it.
-      return { selector, exact, status: 'orphaned' };
+      return { selector, exact, status: 'orphaned', reason: 'not-found' };
     }
     if (isExactlyOurSelection(result)) {
-      return { selector, exact, status: 'found' };
+      return { selector, exact, status: 'found', reason: 'ok' };
     }
+    if ((result?.matches?.length ?? 0) > 1) sawMultiple = true;
     // A unique `found` that is NOT our selection is a mis-anchor: treat it as
     // ambiguous (more context may still pin the right one) rather than
     // accepting it. Only a genuine orphaned short-circuits.
-    const status = result?.status === 'orphaned' ? 'orphaned' : 'ambiguous';
-    last = { selector, exact, status };
-    if (status === 'orphaned') return last;
+    const orphaned = result?.status === 'orphaned';
+    const status = orphaned ? 'orphaned' : 'ambiguous';
+    const reason = sawMultiple
+      ? 'too-common'
+      : orphaned
+        ? 'not-found'
+        : result?.status === 'found'
+          ? 'mis-anchor'
+          : 'too-common';
+    last = { selector, exact, status, reason };
+    if (orphaned) return last;
   }
-  // Widest context still did not provably pin our selection: report ambiguous
-  // so the UI asks for a longer/uniquer selection. Carry the widest selector
-  // so a human extending it starts from maximum context.
+  // Widest context still did not provably pin our selection.
   return last;
 }

--- a/frontend/src/composables/useTextSelection.test.js
+++ b/frontend/src/composables/useTextSelection.test.js
@@ -1,0 +1,185 @@
+import { describe, it, expect } from 'vitest';
+import { selectionToRawRange, buildSelector } from './useTextSelection.js';
+
+// useTextSelection turns a DOM selection in the markdown-rendered article back
+// into raw char offsets, then grows TextQuoteSelector context until the
+// resolver finds it uniquely. The raw<->DOM gap (stripped "1. " prefixes,
+// collapsed whitespace) is the same one useNotesHighlight handles; these tests
+// pin the inverse direction and the context-growing loop.
+
+/** Build a DOM tree from HTML and select a substring of one text node. */
+function selectIn(html, findText) {
+  document.body.innerHTML = `<div id="root">${html}</div>`;
+  const root = document.getElementById('root');
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  let node;
+  while ((node = walker.nextNode())) {
+    const i = node.textContent.indexOf(findText);
+    if (i === -1) continue;
+    const range = document.createRange();
+    range.setStart(node, i);
+    range.setEnd(node, i + findText.length);
+    const sel = window.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(range);
+    return root;
+  }
+  throw new Error(`text ${JSON.stringify(findText)} not found in DOM`);
+}
+
+describe('selectionToRawRange', () => {
+  it('maps a selection in plain rendered text to raw offsets', () => {
+    const raw = 'heeft de verzekerde aanspraak op zorgtoeslag';
+    const root = selectIn(`<p>${raw}</p>`, 'zorgtoeslag');
+    const range = selectionToRawRange(raw, root);
+    expect(range).not.toBeNull();
+    expect(raw.slice(range.start, range.end)).toBe('zorgtoeslag');
+  });
+
+  it('accounts for a list prefix marked stripped from the DOM', () => {
+    // Raw lid: "1. Indien de normpremie"; rendered as <li> without "1. ".
+    const raw = '1. Indien de normpremie';
+    const root = selectIn('<ol><li>Indien de normpremie</li></ol>', 'normpremie');
+    const range = selectionToRawRange(raw, root);
+    expect(range).not.toBeNull();
+    // The raw offset must include the stripped "1. " (3 chars): "normpremie"
+    // starts at raw index 13, not the DOM index 10.
+    expect(raw.slice(range.start, range.end)).toBe('normpremie');
+    expect(range.start).toBe(13);
+  });
+
+  it('maps a selection that starts at an element boundary (ol, 0)', () => {
+    // marked renders "<ol>\n<li>..." — childNodes[0] of <ol> is a "\n" text
+    // node with no raw counterpart. A drag starting at the very beginning of
+    // the list reports start as (ol, 0); the scan must skip the "\n" and not
+    // dead-end. Regression for the element-endpoint-on-whitespace bug.
+    const raw = '1. eerste lid\n\n2. tweede lid';
+    document.body.innerHTML =
+      '<div id="root"><ol>\n<li>eerste lid</li>\n<li>tweede lid</li>\n</ol></div>';
+    const root = document.getElementById('root');
+    const ol = root.querySelector('ol');
+    const firstLiText = ol.querySelectorAll('li')[0].firstChild;
+    const range = document.createRange();
+    range.setStart(ol, 0); // element boundary, before the "\n"
+    range.setEnd(firstLiText, 'eerste'.length);
+    const sel = window.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(range);
+    const out = selectionToRawRange(raw, root);
+    expect(out).not.toBeNull();
+    // "eerste" is at raw offset 3 (after the stripped "1. ").
+    expect(raw.slice(out.start, out.end)).toBe('eerste');
+  });
+
+  it('returns null for a collapsed (empty) selection', () => {
+    const raw = 'abc';
+    document.body.innerHTML = '<div id="root"><p>abc</p></div>';
+    const root = document.getElementById('root');
+    window.getSelection().removeAllRanges();
+    expect(selectionToRawRange(raw, root)).toBeNull();
+  });
+
+  it('returns null when the selection is outside the root', () => {
+    const raw = 'abc';
+    document.body.innerHTML =
+      '<div id="root"><p>abc</p></div><p id="other">def</p>';
+    const root = document.getElementById('root');
+    const other = document.getElementById('other');
+    const range = document.createRange();
+    range.selectNodeContents(other);
+    const sel = window.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(range);
+    expect(selectionToRawRange(raw, root)).toBeNull();
+  });
+});
+
+describe('buildSelector', () => {
+  const raw = 'Indien de normpremie voor een verzekerde hoger is dan de normpremie';
+
+  function engineReturning(bySelector) {
+    return {
+      resolveNote(_lawId, selector) {
+        return bySelector(selector);
+      },
+    };
+  }
+
+  it('accepts a bare selector only when the unique match IS our selection', () => {
+    const range = { start: 10, end: 20 }; // "normpremie" (first)
+    const engine = engineReturning(() => ({
+      status: 'found',
+      matches: [{ article_number: '1', start: 10, end: 20 }],
+    }));
+    const out = buildSelector(raw, range, 'w', engine, '1');
+    expect(out.status).toBe('found');
+    expect(out.selector.exact).toBe('normpremie');
+    expect(out.selector.prefix).toBeUndefined();
+    expect(out.selector.suffix).toBeUndefined();
+  });
+
+  it('rejects a unique match at the WRONG offsets as a mis-anchor', () => {
+    // The resolver found a single match, but at offsets 56..66, not the
+    // 10..20 the user selected (the trimmed prefix/suffix check matched the
+    // other "normpremie"). This must NOT be accepted: it would silently
+    // anchor the note to a different sentence.
+    const range = { start: 10, end: 20 };
+    const engine = engineReturning(() => ({
+      status: 'found',
+      matches: [{ article_number: '1', start: 56, end: 66 }],
+    }));
+    const out = buildSelector(raw, range, 'w', engine, '1');
+    expect(out.status).toBe('ambiguous');
+  });
+
+  it('rejects a unique match in the WRONG article', () => {
+    const range = { start: 10, end: 20 };
+    const engine = engineReturning(() => ({
+      status: 'found',
+      matches: [{ article_number: '3', start: 10, end: 20 }],
+    }));
+    const out = buildSelector(raw, range, 'w', engine, '1');
+    expect(out.status).toBe('ambiguous');
+  });
+
+  it('grows context until the match lands on our exact selection', () => {
+    const range = { start: 10, end: 20 }; // "normpremie", appears twice
+    const calls = [];
+    const engine = engineReturning((sel) => {
+      calls.push(sel);
+      if (!sel.prefix && !sel.suffix) {
+        return { status: 'ambiguous', matches: [{}, {}] };
+      }
+      return {
+        status: 'found',
+        matches: [{ article_number: '1', start: 10, end: 20 }],
+      };
+    });
+    const out = buildSelector(raw, range, 'w', engine, '1');
+    expect(out.status).toBe('found');
+    expect(out.selector.prefix).toBeTruthy();
+    expect(calls.length).toBeGreaterThan(1);
+  });
+
+  it('reports still-ambiguous when even wide context does not disambiguate', () => {
+    const range = { start: 10, end: 20 };
+    const engine = engineReturning(() => ({
+      status: 'ambiguous',
+      matches: [{}, {}],
+    }));
+    const out = buildSelector(raw, range, 'w', engine, '1');
+    expect(out.status).toBe('ambiguous');
+  });
+
+  it('stops immediately on an orphaned result', () => {
+    const range = { start: 10, end: 20 };
+    let calls = 0;
+    const engine = engineReturning(() => {
+      calls++;
+      return { status: 'orphaned', matches: [] };
+    });
+    const out = buildSelector(raw, range, 'w', engine, '1');
+    expect(out.status).toBe('orphaned');
+    expect(calls).toBe(1);
+  });
+});

--- a/frontend/src/composables/useTextSelection.test.js
+++ b/frontend/src/composables/useTextSelection.test.js
@@ -105,6 +105,21 @@ describe('buildSelector', () => {
     };
   }
 
+  it('rejects a whitespace-only exact without calling the resolver', () => {
+    // A selection that maps to just the space between two words: schema
+    // minLength:1 and the resolver's non-empty guard would both pass it,
+    // but a note quoting " " anchors nothing visible. Must short-circuit.
+    const r = 'de  normpremie'; // two spaces at 2..4
+    let called = false;
+    const engine = engineReturning(() => {
+      called = true;
+      return { status: 'found', matches: [{}] };
+    });
+    const out = buildSelector(r, { start: 2, end: 4 }, 'w', engine, '1');
+    expect(out.status).toBe('orphaned');
+    expect(called).toBe(false);
+  });
+
   it('accepts a bare selector only when the unique match IS our selection', () => {
     const range = { start: 10, end: 20 }; // "normpremie" (first)
     const engine = engineReturning(() => ({

--- a/frontend/src/composables/useTextSelection.test.js
+++ b/frontend/src/composables/useTextSelection.test.js
@@ -157,6 +157,29 @@ describe('buildSelector', () => {
     expect(out.status).toBe('ambiguous');
   });
 
+  it('reports reason "too-common" when the bare quote matched many, even if widening degrades to orphaned', () => {
+    // The "in"-case: no-context match is ambiguous (occurs everywhere), but
+    // with markdown-stripped context the wider attempts can't relocate it and
+    // the resolver returns orphaned. The user-facing reason must stay
+    // "too-common", not "not-found".
+    const range = { start: 10, end: 20 };
+    const engine = engineReturning((sel) =>
+      !sel.prefix && !sel.suffix
+        ? { status: 'ambiguous', matches: [{}, {}, {}] }
+        : { status: 'orphaned', matches: [] },
+    );
+    const out = buildSelector(raw, range, 'w', engine, '1');
+    expect(out.reason).toBe('too-common');
+  });
+
+  it('reports reason "not-found" when nothing matched at any width', () => {
+    const range = { start: 10, end: 20 };
+    const engine = engineReturning(() => ({ status: 'orphaned', matches: [] }));
+    const out = buildSelector(raw, range, 'w', engine, '1');
+    expect(out.status).toBe('orphaned');
+    expect(out.reason).toBe('not-found');
+  });
+
   it('grows context until the match lands on our exact selection', () => {
     const range = { start: 10, end: 20 }; // "normpremie", appears twice
     const calls = [];

--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -91,7 +91,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -102,7 +102,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -123,9 +123,9 @@ dependencies = [
 
 [[package]]
 name = "astral-tokio-tar"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ce73b17c62717c4b6a9af10b43e87c578b0cac27e00666d48304d3b7d2c0693"
+checksum = "cb50a7aae84a03bf55b067832bc376f4961b790c97e64d3eacee97d389b90277"
 dependencies = [
  "filetime",
  "futures-core",
@@ -1240,7 +1240,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2540,7 +2540,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4005,7 +4005,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4064,7 +4064,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4473,7 +4473,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4903,7 +4903,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6008,7 +6008,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/packages/editor-api/src/feature_flags.rs
+++ b/packages/editor-api/src/feature_flags.rs
@@ -21,6 +21,11 @@ static DEFAULTS: LazyLock<HashMap<String, bool>> = LazyLock::new(|| {
         // 400s and the frontend silently reverts it (see the editor.* note
         // below — same allow-list mechanism).
         ("panel.notes".into(), false),
+        // Note authoring (RFC-018 write path, MVP: localStorage + manual
+        // export). Separate gate from panel.notes so notes can be shown
+        // read-only without exposing creation. Same allow-list rule: without
+        // this key the toggle PUT 400s and the frontend silently reverts it.
+        ("notes.create".into(), false),
         // Editor capability flags — visibility is panel.*, editability is editor.*.
         // The frontend wires editor.article_text_edit (default off) to gate
         // write access on the Tekst pane. Without the key here the backend's


### PR DESCRIPTION
Fase 5 van de notities-feature (RFC-005/RFC-018, vervolg op #647). Een
gebruiker selecteert tekst in de Tekst-pane en maakt een W3C Web
Annotation aan. Concepten leven lokaal tot ze als sidecar-YAML
geëxporteerd en met de hand gecommit worden — geen schrijf-API, git
blijft de bron (RFC-018 write path).

## Wat

- **`useTextSelection`** — mapt een DOM-selectie in de markdown-render
  terug naar ruwe tekenoffsets (inverteert de uitlijning uit #646) en
  bouwt een `TextQuoteSelector` met groeiende prefix/suffix tot de
  resolver hem uniek vindt.
- **`useDraftNotes`** — localStorage-store per wet; export leest de
  ruwe sidecar opnieuw in en voegt de concepten toe.
- **`useAmbiguityVocabulary`** + `copy-laws.js` — `_vocabulary/` wordt
  meegekopieerd zodat de editor-tagkeuze en de CI-softvalidatie één
  bron delen.
- **`NoteCreator.vue`** — popover-formulier; body-vorm per motivation
  (toelichting/koppeling/vraag/label), linking koppelt aan een
  machine_readable-element van het artikel.
- **`AnnotatedText.vue`** — selectie-knop + creator achter een aparte
  feature flag `notes.create`; concepten highlighten live naast
  vastgelegde notities.

## Veiligheid van de verankering

Een unieke `found` van de resolver wordt alleen geaccepteerd als hij
exact op de geselecteerde offsets in het gekozen artikel valt. De
exact-match-check van de resolver trimt een tekenvenster, dus een
herhaalde frase kan elders "uniek" matchen; zo'n match wordt als
ambigu behandeld en de UI vraagt om een langere selectie in plaats van
de notitie stil op de verkeerde zin te verankeren.

## Review

Twee zelfreview-rondes met subagents. Bevindingen verwerkt:
- mis-anker bij herhaalde frasen (verificatie op exacte offsets);
- dataverlies bij export van federated sidecars (ruwe sidecar
  herinlezen i.p.v. resolver-output);
- selectie-randgevallen (caret op nodegrens, element-endpoint op
  inter-tag whitespace) — incl. een bug die de tweede ronde in de
  eerste fix vond, met regressietest;
- stale-overwrite-race bij wetwissel (generatie-guard);
- Vue computed-side-effect verwijderd.

## Tests

180 frontend-tests groen (+28 nieuw): `useTextSelection`,
`useDraftNotes`, `NoteCreator`, en uitbreiding van `AnnotatedText`.
`just validate-annotations` groen. Geen Rust-wijzigingen.

Standaard uit: `notes.create` staat default op `false` (MVP, opt-in).