### PR TITLE
feat(ci): validate-annotations in just check + ambiguïteit-use-case (RFC-018 Fase 6)

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -41,9 +41,9 @@ validate *FILES:
 validate-annotations *FILES:
     script/validate-annotations.sh {{FILES}}
 
-# Run all quality checks (format + lint + check + validate + tests)
+# Run all quality checks (format + lint + check + validate + validate-annotations + tests)
 # Note: pipeline-integration-test excluded — it requires Docker (testcontainers)
-check: format lint build-check validate test harvester-test pipeline-test admin-fmt admin-lint admin-check admin-test admin-frontend editor-api-fmt editor-api-lint editor-api-check
+check: format lint build-check validate validate-annotations test harvester-test pipeline-test admin-fmt admin-lint admin-check admin-test admin-frontend editor-api-fmt editor-api-lint editor-api-check
 
 # --- Tests ---
 

--- a/corpus/annotations/zorgtoeslagwet/annotations.yaml
+++ b/corpus/annotations/zorgtoeslagwet/annotations.yaml
@@ -71,3 +71,32 @@ annotations:
         value: open-norm-partial
         purpose: tagging
     workflow: open
+
+  # The resolved end of the same lifecycle (RFC-018 Decision 6). The concrete
+  # percentage for a verzekerde with a toeslagpartner is spelled out in the
+  # law text and is modelled in machine_readable, so this part of the open
+  # norm is filled in: the questioning note is kept for audit history but its
+  # workflow is resolved.
+  - type: Annotation
+    motivation: questioning
+    creator: interpreter-team
+    target:
+      source: regelrecht://zorgtoeslagwet
+      selector:
+        type: TextQuoteSelector
+        exact: 4,273 procent
+        prefix: 'voor een verzekerde met een toeslagpartner '
+        suffix: ' van het drempelinkomen'
+    body:
+      - type: TextualBody
+        value: >-
+          Het percentage voor een verzekerde met toeslagpartner is in de
+          wettekst opgenomen en gemodelleerd in machine_readable. Deze open
+          norm is daarmee ingevuld; de note blijft staan voor de auditketen.
+        purpose: questioning
+        format: text/plain
+        language: nl
+      - type: TextualBody
+        value: open-norm-partial
+        purpose: tagging
+    workflow: resolved

--- a/corpus/annotations/zorgtoeslagwet/annotations.yaml
+++ b/corpus/annotations/zorgtoeslagwet/annotations.yaml
@@ -86,7 +86,7 @@ annotations:
         type: TextQuoteSelector
         exact: 4,273 procent
         prefix: 'voor een verzekerde met een toeslagpartner '
-        suffix: ' van het drempelinkomen'
+        suffix: ' van het'
     body:
       - type: TextualBody
         value: >-

--- a/features/notes.feature
+++ b/features/notes.feature
@@ -127,3 +127,17 @@ Feature: Note resolution (RFC-005, RFC-018)
     And a note selecting "beleidsregels van de Belastingdienst" with prefix "overeenkomstig de " and suffix " omtrent"
     When the note is resolved
     Then the note resolves to article "5"
+
+  # The resolved end of the open->resolved lifecycle. Once the implementing
+  # regulation is located and the open norm is filled in, the questioning note
+  # moves to workflow: resolved. The anchor is now the concrete implementing
+  # sentence; the resolver must still place it on exactly that text. (The
+  # workflow field itself is sidecar metadata validated by
+  # validate-annotations, not resolver logic.)
+  Scenario: A resolved questioning note anchors to the now-filled-in norm
+    Given a law with the following articles:
+      | number | text                                                                                      |
+      | 3      | De normpremie bedraagt 2,7 procent van het drempelinkomen, vermeerderd met het toetsingsinkomen. |
+    And a note selecting "2,7 procent van het drempelinkomen" with prefix "bedraagt " and suffix ", vermeerderd"
+    When the note is resolved
+    Then the note resolves to article "3"


### PR DESCRIPTION
Sluit **Fase 6** van het notes-plan af (CI-validatie + ambiguïteit-use-case). Hiermee is het 6-fasen-plan voor stand-off notes compleet.

## Wat erin zit

- **`validate-annotations` in de `just check` kwaliteitspoort**, naast `validate`. Orphaned/ambiguous notes en onbekende tag-waarden blijven *warnings*, geen errors, conform RFC-018 (`just check` faalt er dus niet op).
- **Levend voorbeeld van de open→resolved levenscyclus.** De zorgtoeslagwet-sidecar had al een `workflow: open` questioning-note (open norm, deels ingevuld). Daar staat nu een `workflow: resolved` tegenhanger naast: dezelfde open norm, maar met het concrete percentage dat inmiddels in de wettekst staat en in `machine_readable` is gemodelleerd. De note blijft staan voor de auditketen. Resolveert uniek tegen de echte wettekst (geen `validate-annotations` warning).
- **BDD-scenario achter de resolved-state.** Het `workflow`-veld is sidecar-metadata (gevalideerd door `validate-annotations`), geen resolver-logica. Het nieuwe scenario pint wat de resolver wél doet: een questioning-note over een inmiddels ingevulde open norm anchort exact op de concrete implementerende tekst.

## Verificatie

- `just bdd`: 66 scenario's groen, 390 steps.
- `just validate-annotations`: zorgtoeslagwet-sidecar OK, geen warnings.
- `just --dry-run check`: `validate-annotations` zit in de dependency-chain.
- Pre-commit hooks groen.