### PR TITLE
feat(editor): notities inchecken via PR (federated schrijfpad)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,6 +12,12 @@ doc
 !package-lock.json
 !Cargo.toml
 !Cargo.lock
+# The note (annotation) JSON schema is embedded at compile time by
+# regelrecht-corpus (annotation-validation feature) in the editor-api
+# image build. The blanket *.json exclude above would drop it from the
+# build context; re-include the schema tree so `include_str!` resolves.
+!schema
+!schema/**
 .vscode
 .idea
 # Exclude .claude but keep skill files needed by the enrich worker image.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,13 +1,15 @@
 # Code owners. A matching owner is auto-requested for review on any PR
-# touching the matched paths (and, if branch protection requires owner
-# review, gates the merge).
+# touching the matched paths.
+#
+# IMPORTANT: this only REQUESTS a reviewer. It gates a merge solely when
+# branch protection on the target branch has `require_code_owner_reviews`
+# enabled. That is a repository setting, not something this file controls;
+# until it is on, a PR here can still be merged with no domain review.
 #
 # Stand-off notes (RFC-005 / RFC-018). The editor write path opens PRs
 # against a source repo's annotations/ on a contributor's behalf. This
-# rule scopes the central corpus (this repo): a note PR here gets a domain
-# review. Federated note sources live in their own repos and carry their
-# own CODEOWNERS; this file cannot gate those. Content review here is the
-# first of the two-layer review; schema/resolve correctness is enforced
-# separately by validate-annotations in CI (warn-only for orphaned/
-# ambiguous per RFC-018 §8).
+# rule scopes the central corpus (this repo) only; federated note sources
+# live in their own repos with their own CODEOWNERS. When enforced, this
+# is the content half of the two-layer review; the schema/resolve half is
+# validate-annotations in CI (warn-only for orphaned/ambiguous, RFC-018 §8).
 /corpus/annotations/ @MinBZK/regelrecht-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# Code owners. A matching owner is auto-requested for review on any PR
+# touching the matched paths (and, if branch protection requires owner
+# review, gates the merge).
+#
+# Stand-off notes (RFC-005 / RFC-018). The editor write path opens PRs
+# against a source repo's annotations/ on a contributor's behalf. This
+# rule scopes the central corpus (this repo): a note PR here gets a domain
+# review. Federated note sources live in their own repos and carry their
+# own CODEOWNERS; this file cannot gate those. Content review here is the
+# first of the two-layer review; schema/resolve correctness is enforced
+# separately by validate-annotations in CI (warn-only for orphaned/
+# ambiguous per RFC-018 §8).
+/corpus/annotations/ @MinBZK/regelrecht-team

--- a/deny.toml
+++ b/deny.toml
@@ -37,6 +37,14 @@ allow = [
 allow = ["LGPL-2.1-or-later"]
 crate = "r-efi"
 
+# borrow-or-share is MIT-0 (MIT No Attribution): OSI-approved and strictly
+# more permissive than the allowed MIT (it drops the attribution clause).
+# Pulled transitively via jsonschema -> fluent-uri for the editor-api note
+# schema validation. Scoped exception rather than allowing MIT-0 globally.
+[[licenses.exceptions]]
+allow = ["MIT-0"]
+crate = "borrow-or-share"
+
 [bans]
 multiple-versions = "warn"
 wildcards = "allow"

--- a/docs/rfcs/rfc-018.md
+++ b/docs/rfcs/rfc-018.md
@@ -697,13 +697,33 @@ resolved positions, renders `<mark>` spans. Each span carries:
 6. Export button downloads the updated note YAML for manual git commit
 
 > **Amended after implementation.** Step 6 is no longer the only way out.
-> The editor can also write notes back through `editor-api`, which opens a
-> PR on the same per-(session, source) branch that law and scenario edits
-> use (RFC-010 §4). The manual export stays for the offline case.
+> The editor can also write notes back through `editor-api`. The manual
+> export stays for the offline case.
+>
+> The write runs through the **active traject**, exactly like law and
+> scenario edits since the traject concept landed (PR #632). A traject is
+> a named, member-scoped editing project with its own federated corpus
+> config; its `write_target_for_source` map decides which backend (and
+> branch) a given law's edits land in. The notes sidecar for `law_id` is
+> written to `annotations/{law_id}/annotations.yaml` through that same
+> backend, so a note and a law edit made in one session ride the same
+> branch and PR. There is no separate per-session branch and no
+> `X-Editor-Session` header: the session cookie carries the active
+> traject. With no active traject the save returns `403`, the same rule
+> the law and scenario writes follow.
+>
+> This also settles the federated-target question from Decision 2 without
+> a per-note source picker. An org annotating another org's law into its
+> own repo configures that as its traject's writable source; the traject's
+> routing map then sends the notes there. Routing is a property of the
+> traject, decided once when the traject is set up, not a free per-request
+> override. The earlier `?source=` override is gone: a second routing
+> mechanism that could disagree with the traject's own config was a
+> privilege gap, not federation.
 >
 > The write is **append-only**, and this matters. The browser sends only
 > the notes it just created, not a rebuilt file. `editor-api` reads the
-> current sidecar from the session branch, appends the new notes
+> current sidecar from the traject branch, appends the new notes
 > (deduplicated by content), validates the merged document against the
 > schema, and refuses any result smaller than the base. An earlier sketch
 > had the browser send the whole file rebuilt from the static `/data`
@@ -717,15 +737,6 @@ resolved positions, renders `<mark>` spans. Each span carries:
 > whose source is absent or not a `regelrecht://{law_id}` URI is rejected,
 > not skipped. It is the note-side counterpart of the `$id`/path guard on
 > `save_law`.
->
-> The target source defaults to the law's own source. An explicit override
-> is accepted only for the law's source or an unrestricted source (the
-> central corpus). The federated case from Decision 2, an org annotating
-> another org's law into its own repo, needs a verified author identity
-> before it is safe: `editor-api` pushes with a shared per-source token, so
-> "any authenticated user may PR into any source" is a privilege gap, not
-> federation. That waits for RFC-009's identity model and is deliberately
-> not built here.
 >
 > The content-review half of Decision 8's two-layer model relies on
 > branch protection requiring code-owner review on `main`. A `CODEOWNERS`

--- a/docs/rfcs/rfc-018.md
+++ b/docs/rfcs/rfc-018.md
@@ -724,13 +724,28 @@ resolved positions, renders `<mark>` spans. Each span carries:
 > The write is **append-only**, and this matters. The browser sends only
 > the notes it just created, not a rebuilt file. `editor-api` reads the
 > current sidecar from the traject branch, appends the new notes
-> (deduplicated by content), validates the merged document against the
-> schema, and refuses any result smaller than the base. An earlier sketch
-> had the browser send the whole file rebuilt from the static `/data`
-> mirror; that mirror is the corpus at deploy time, not the branch, so a
-> save silently discarded notes other contributors had added. Append-only
-> follows directly from Decision 8: notes layer, they do not conflict, so
-> the write path must never overwrite, only add.
+> (deduplicated by content), and validates the merged document against the
+> schema. The non-shrink property is structural, not a post-hoc size
+> check: the normal path keeps the existing file's bytes verbatim and only
+> appends, so it cannot drop a note. The one path that rebuilds the file
+> (a base whose `annotations` is not a readable block sequence, e.g. flow
+> style or non-LF) carries an explicit destructive-shrink guard that
+> refuses rather than rebuild over content it could not parse. An earlier
+> sketch had the browser send the whole file rebuilt from the static
+> `/data` mirror; that mirror is the corpus at deploy time, not the
+> branch, so a save silently discarded notes other contributors had added.
+> Append-only follows directly from Decision 8: notes layer, they do not
+> conflict, so the write path must never overwrite, only add.
+>
+> Known limitation: read-your-writes holds within a single `editor-api`
+> process (the traject's checkout accumulates its own commits on disk),
+> but the checkout is cloned once per traject and not pulled before each
+> read. Under horizontal scaling, or if the traject branch is updated
+> out-of-band, a replica can read a stale base. Append-only bounds the
+> blast radius — the worst case is a dedup miss or a non-fast-forward push
+> that fails loudly, not the silent loss of others' notes the `/data`
+> mirror caused — but a strict cross-replica guarantee needs a
+> pull-before-read (or a single-writer assumption) and is not yet built.
 >
 > Every note's `target.source` must resolve to the law the path names. The
 > schema allows any string there, so this is checked explicitly: a note

--- a/docs/rfcs/rfc-018.md
+++ b/docs/rfcs/rfc-018.md
@@ -696,6 +696,44 @@ resolved positions, renders `<mark>` spans. Each span carries:
 5. New note added to local state and persisted in `localStorage`
 6. Export button downloads the updated note YAML for manual git commit
 
+> **Amended after implementation.** Step 6 is no longer the only way out.
+> The editor can also write notes back through `editor-api`, which opens a
+> PR on the same per-(session, source) branch that law and scenario edits
+> use (RFC-010 §4). The manual export stays for the offline case.
+>
+> The write is **append-only**, and this matters. The browser sends only
+> the notes it just created, not a rebuilt file. `editor-api` reads the
+> current sidecar from the session branch, appends the new notes
+> (deduplicated by content), validates the merged document against the
+> schema, and refuses any result smaller than the base. An earlier sketch
+> had the browser send the whole file rebuilt from the static `/data`
+> mirror; that mirror is the corpus at deploy time, not the branch, so a
+> save silently discarded notes other contributors had added. Append-only
+> follows directly from Decision 8: notes layer, they do not conflict, so
+> the write path must never overwrite, only add.
+>
+> Every note's `target.source` must resolve to the law the path names. The
+> schema allows any string there, so this is checked explicitly: a note
+> whose source is absent or not a `regelrecht://{law_id}` URI is rejected,
+> not skipped. It is the note-side counterpart of the `$id`/path guard on
+> `save_law`.
+>
+> The target source defaults to the law's own source. An explicit override
+> is accepted only for the law's source or an unrestricted source (the
+> central corpus). The federated case from Decision 2, an org annotating
+> another org's law into its own repo, needs a verified author identity
+> before it is safe: `editor-api` pushes with a shared per-source token, so
+> "any authenticated user may PR into any source" is a privilege gap, not
+> federation. That waits for RFC-009's identity model and is deliberately
+> not built here.
+>
+> The content-review half of Decision 8's two-layer model relies on
+> branch protection requiring code-owner review on `main`. A `CODEOWNERS`
+> entry for `corpus/annotations/` exists, but on its own it only requests a
+> reviewer; it gates a merge only once the repository enables
+> `require_code_owner_reviews`. Until then the schema/resolve checks in CI
+> are the only enforced layer.
+
 #### Editor layout
 
 The right pane's segmented control gains a third option, labelled **Notities**:

--- a/docs/rfcs/rfc-018.md
+++ b/docs/rfcs/rfc-018.md
@@ -733,6 +733,19 @@ resolved positions, renders `<mark>` spans. Each span carries:
 > reviewer; it gates a merge only once the repository enables
 > `require_code_owner_reviews`. Until then the schema/resolve checks in CI
 > are the only enforced layer.
+>
+> Known limitation: schema drift on an existing sidecar. The merged file
+> is validated against the current schema before it is written. If the
+> sidecar already on the branch contains a note that no longer satisfies
+> the schema (a version bump landed without migrating that file), the
+> append cannot proceed: writing it would commit a file CI then rejects.
+> The write path validates the existing file separately and returns a
+> distinct `409` ("the file is itself invalid, this is not your note")
+> rather than the generic note-invalid `400`, so the author is not sent
+> chasing a fault in their own valid note. The fix is to repair or
+> migrate the offending file; this is rare and a hard, clearly-attributed
+> stop is preferred over silently appending into a file that will fail
+> the gate anyway.
 
 #### Editor layout
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -74,6 +74,13 @@ COPY packages/engine/ engine/
 COPY packages/harvester/ harvester/
 COPY packages/pipeline/ pipeline/
 COPY packages/shared/ shared/
+# regelrecht-corpus (annotation-validation feature) embeds the note schema
+# via `include_str!("../../../schema/...")`, relative to packages/corpus/src/.
+# WORKDIR is /build and the crate is COPYed to /build/corpus/, so that
+# literal resolves to /schema/... here. Put the canonical schema there so
+# the embed compiles; this is the same file the source tree has at repo
+# root (no second copy — it is COPYed, not vendored).
+COPY schema/ /schema/
 # Invalidate cargo's fingerprint cache so it recompiles with real source
 # instead of using the stub binary from cargo-chef cook.
 RUN find . -name '*.rs' -exec touch {} + && \

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -321,13 +321,19 @@ const notesSources = ref([]);
 const notesTargetSource = ref('');
 const savingNotes = ref(false);
 const notesSaveError = ref(null);
+const notesSourcesFailed = ref(false);
 async function loadNotesSources() {
   if (notesSources.value.length) return;
   try {
     const res = await fetch('/api/sources');
-    if (res.ok) notesSources.value = await res.json();
+    if (!res.ok) throw new Error(`sources ${res.status}`);
+    notesSources.value = await res.json();
+    notesSourcesFailed.value = false;
   } catch {
-    // Dropdown just stays empty → save uses the default (law's) source.
+    // Surface the failure rather than silently defaulting to the law's
+    // source: a federated note that quietly lands in the wrong repo is
+    // worse than a visible "couldn't load targets, retry" state.
+    notesSourcesFailed.value = true;
   }
 }
 async function saveNotesToRepo() {
@@ -1558,7 +1564,7 @@ async function handleActionSave() {
                       :icon-color="hiddenDraftCount > 0 ? 'warning' : undefined"
                     >
                       <nldd-dropdown
-                        v-if="notesSources.length > 1"
+                        v-if="notesSources.length >= 1"
                         slot="actions"
                         label="Opslaan naar"
                         @change="notesTargetSource = $event.detail?.value ?? $event.target?.value ?? notesTargetSource"
@@ -1577,7 +1583,7 @@ async function handleActionSave() {
                         size="md"
                         variant="primary"
                         :text="savingNotes ? 'Opslaan…' : 'Opslaan naar repo'"
-                        :disabled="savingNotes || null"
+                        :disabled="savingNotes || notesSourcesFailed || null"
                         data-testid="save-notes-btn"
                         @click="saveNotesToRepo"
                       ></nldd-button>
@@ -1597,6 +1603,13 @@ async function handleActionSave() {
                         @click="askClearDrafts"
                       ></nldd-button>
                     </nldd-inline-dialog>
+                    <nldd-inline-dialog
+                      v-if="notesSourcesFailed"
+                      variant="warning"
+                      data-testid="notes-sources-failed"
+                      text="Doelbronnen konden niet geladen worden"
+                      supporting-text="Opslaan naar repo is uitgeschakeld tot de bronlijst opnieuw geladen is. Exporteer YAML werkt wel."
+                    ></nldd-inline-dialog>
                     <nldd-inline-dialog
                       v-if="notesSaveError"
                       variant="alert"

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -323,13 +323,18 @@ const notesSaveError = ref(null);
 // Explicit success signal: a PR-less / NoChange save must not look like
 // the work vanished (the drafts get cleared either way).
 const notesSaveStatus = ref(null);
-// The save status/error describe the LAST save. Once the draft set
-// changes (a new note added, or drafts wiped), that confirmation is stale
-// and showing "Opslaan gelukt" next to "1 concept, nog niet opgeslagen"
-// is a contradictory state. Clear both whenever the draft count moves.
-watch(draftCount, () => {
-  notesSaveStatus.value = null;
-  notesSaveError.value = null;
+// The save status/error describe the LAST save. A NEW draft appearing
+// after that save makes the confirmation stale ("Opslaan gelukt" next to
+// "1 concept, nog niet opgeslagen" is contradictory), so clear it then.
+// But a successful save itself drains drafts to zero — clearing on a
+// DECREASE would wipe the very confirmation `saveNotesToRepo` is about to
+// set, a race that previously only worked by microtask-ordering luck.
+// Only react to an increase; the count going down is the save completing.
+watch(draftCount, (count, prev) => {
+  if (count > prev) {
+    notesSaveStatus.value = null;
+    notesSaveError.value = null;
+  }
 });
 async function saveNotesToRepo() {
   if (savingNotes.value) return;

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -325,6 +325,14 @@ const notesSaveError = ref(null);
 // the work vanished (the drafts get cleared either way).
 const notesSaveStatus = ref(null);
 const notesSourcesFailed = ref(false);
+// The save status/error describe the LAST save. Once the draft set
+// changes (a new note added, or drafts wiped), that confirmation is stale
+// and showing "Opslaan gelukt" next to "1 concept, nog niet opgeslagen"
+// is a contradictory state. Clear both whenever the draft count moves.
+watch(draftCount, () => {
+  notesSaveStatus.value = null;
+  notesSaveError.value = null;
+});
 async function loadNotesSources() {
   if (notesSources.value.length) return;
   try {

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -321,6 +321,9 @@ const notesSources = ref([]);
 const notesTargetSource = ref('');
 const savingNotes = ref(false);
 const notesSaveError = ref(null);
+// Explicit success signal: a PR-less / NoChange save must not look like
+// the work vanished (the drafts get cleared either way).
+const notesSaveStatus = ref(null);
 const notesSourcesFailed = ref(false);
 async function loadNotesSources() {
   if (notesSources.value.length) return;
@@ -340,8 +343,18 @@ async function saveNotesToRepo() {
   if (savingNotes.value) return;
   savingNotes.value = true;
   notesSaveError.value = null;
+  notesSaveStatus.value = null;
   try {
-    await saveToRepo(notesTargetSource.value || undefined);
+    const { pr, noChange } = await saveToRepo(
+      notesTargetSource.value || undefined,
+    );
+    if (noChange) {
+      notesSaveStatus.value = 'Notities waren al opgeslagen.';
+    } else if (pr) {
+      notesSaveStatus.value = `Opgeslagen in PR #${pr.number}.`;
+    } else {
+      notesSaveStatus.value = 'Notities opgeslagen.';
+    }
   } catch (e) {
     notesSaveError.value = e?.message || 'Opslaan mislukt';
   } finally {
@@ -1616,6 +1629,13 @@ async function handleActionSave() {
                       data-testid="notes-save-error"
                       text="Notities opslaan mislukt"
                       :supporting-text="notesSaveError"
+                    ></nldd-inline-dialog>
+                    <nldd-inline-dialog
+                      v-if="notesSaveStatus && !notesSaveError"
+                      variant="success"
+                      data-testid="notes-save-status"
+                      text="Opslaan gelukt"
+                      :supporting-text="notesSaveStatus"
                     ></nldd-inline-dialog>
                   </template>
                 </template>

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -222,6 +222,7 @@ const {
   addDraft,
   clearDrafts,
   exportYaml,
+  saveToRepo,
 } = useDraftNotes(lawId);
 const { draftNotesForArticle } = useResolvedDraftNotes(
   draftNotes,
@@ -310,6 +311,40 @@ async function exportNotes() {
     exporting.value = false;
   }
 }
+
+// Note write-back: PUT the sidecar to editor-api, which validates it and
+// opens/updates the session PR. The "PR #N" toolbar badge is driven by the
+// shared lastSavedPr ref, so a successful save lights it up with no extra
+// wiring here. `notesSources` feeds the target-source dropdown; the law's
+// own source is the default, overridable for the federated case (RFC-018 §2).
+const notesSources = ref([]);
+const notesTargetSource = ref('');
+const savingNotes = ref(false);
+const notesSaveError = ref(null);
+async function loadNotesSources() {
+  if (notesSources.value.length) return;
+  try {
+    const res = await fetch('/api/sources');
+    if (res.ok) notesSources.value = await res.json();
+  } catch {
+    // Dropdown just stays empty → save uses the default (law's) source.
+  }
+}
+async function saveNotesToRepo() {
+  if (savingNotes.value) return;
+  savingNotes.value = true;
+  notesSaveError.value = null;
+  try {
+    await saveToRepo(notesTargetSource.value || undefined);
+  } catch (e) {
+    notesSaveError.value = e?.message || 'Opslaan mislukt';
+  } finally {
+    savingNotes.value = false;
+  }
+}
+watch(canCreateNotes, (on) => {
+  if (on) loadNotesSources();
+});
 
 const resultSheetOpen = ref(false);
 const graphSheetOpen = ref(false);
@@ -1504,10 +1539,13 @@ async function handleActionSave() {
                       :text="`${noteIssues.length} notitie(s) niet verankerd`"
                       :supporting-text="noteIssues.map(i => i.reason).join('; ')"
                     ></nldd-inline-dialog>
-                    <!-- Draft notes are local-only until exported (RFC-018
-                         write path MVP: no write API, git stays the source
-                         of truth). The export downloads committed + draft
-                         notes as one sidecar YAML to commit by hand. -->
+                    <!-- Draft notes live in localStorage until written back.
+                         "Opslaan naar repo" PUTs the sidecar to editor-api,
+                         which validates it and opens the session PR (same
+                         branch+PR as law/scenario edits). The target source
+                         defaults to the law's own; the dropdown overrides it
+                         for a federated note (RFC-018 §2). "Exporteer YAML"
+                         stays for the offline / manual-commit case. -->
                     <nldd-inline-dialog
                       v-if="canCreateNotes && draftCount > 0"
                       data-testid="draft-notes-bar"
@@ -1519,6 +1557,30 @@ async function handleActionSave() {
                       "
                       :icon-color="hiddenDraftCount > 0 ? 'warning' : undefined"
                     >
+                      <nldd-dropdown
+                        v-if="notesSources.length > 1"
+                        slot="actions"
+                        label="Opslaan naar"
+                        @change="notesTargetSource = $event.detail?.value ?? $event.target?.value ?? notesTargetSource"
+                      >
+                        <select :value="notesTargetSource" data-testid="notes-target-source">
+                          <option value="">Bron van de wet (standaard)</option>
+                          <option
+                            v-for="s in notesSources"
+                            :key="s.id"
+                            :value="s.id"
+                          >{{ s.name }}</option>
+                        </select>
+                      </nldd-dropdown>
+                      <nldd-button
+                        slot="actions"
+                        size="md"
+                        variant="primary"
+                        :text="savingNotes ? 'Opslaan…' : 'Opslaan naar repo'"
+                        :disabled="savingNotes || null"
+                        data-testid="save-notes-btn"
+                        @click="saveNotesToRepo"
+                      ></nldd-button>
                       <nldd-button
                         slot="actions"
                         size="md"
@@ -1535,6 +1597,13 @@ async function handleActionSave() {
                         @click="askClearDrafts"
                       ></nldd-button>
                     </nldd-inline-dialog>
+                    <nldd-inline-dialog
+                      v-if="notesSaveError"
+                      variant="alert"
+                      data-testid="notes-save-error"
+                      text="Notities opslaan mislukt"
+                      :supporting-text="notesSaveError"
+                    ></nldd-inline-dialog>
                   </template>
                 </template>
                 <ArticleText v-else :article="selectedArticle" />

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -312,19 +312,17 @@ async function exportNotes() {
   }
 }
 
-// Note write-back: PUT the sidecar to editor-api, which validates it and
-// opens/updates the session PR. The "PR #N" toolbar badge is driven by the
-// shared lastSavedPr ref, so a successful save lights it up with no extra
-// wiring here. `notesSources` feeds the target-source dropdown; the law's
-// own source is the default, overridable for the federated case (RFC-018 §2).
-const notesSources = ref([]);
-const notesTargetSource = ref('');
+// Note write-back: PUT the new drafts to editor-api, which appends them to
+// the sidecar on the active traject's branch (same write model as law and
+// scenario edits since #632). No source picker — the traject's own corpus
+// config decides where the notes land. The "PR #N" toolbar badge is driven
+// by the shared lastSavedPr ref, so a save that produced a PR lights it up
+// with no extra wiring here.
 const savingNotes = ref(false);
 const notesSaveError = ref(null);
 // Explicit success signal: a PR-less / NoChange save must not look like
 // the work vanished (the drafts get cleared either way).
 const notesSaveStatus = ref(null);
-const notesSourcesFailed = ref(false);
 // The save status/error describe the LAST save. Once the draft set
 // changes (a new note added, or drafts wiped), that confirmation is stale
 // and showing "Opslaan gelukt" next to "1 concept, nog niet opgeslagen"
@@ -333,29 +331,13 @@ watch(draftCount, () => {
   notesSaveStatus.value = null;
   notesSaveError.value = null;
 });
-async function loadNotesSources() {
-  if (notesSources.value.length) return;
-  try {
-    const res = await fetch('/api/sources');
-    if (!res.ok) throw new Error(`sources ${res.status}`);
-    notesSources.value = await res.json();
-    notesSourcesFailed.value = false;
-  } catch {
-    // Surface the failure rather than silently defaulting to the law's
-    // source: a federated note that quietly lands in the wrong repo is
-    // worse than a visible "couldn't load targets, retry" state.
-    notesSourcesFailed.value = true;
-  }
-}
 async function saveNotesToRepo() {
   if (savingNotes.value) return;
   savingNotes.value = true;
   notesSaveError.value = null;
   notesSaveStatus.value = null;
   try {
-    const { pr, noChange } = await saveToRepo(
-      notesTargetSource.value || undefined,
-    );
+    const { pr, noChange } = await saveToRepo();
     if (noChange) {
       notesSaveStatus.value = 'Notities waren al opgeslagen.';
     } else if (pr) {
@@ -369,9 +351,6 @@ async function saveNotesToRepo() {
     savingNotes.value = false;
   }
 }
-watch(canCreateNotes, (on) => {
-  if (on) loadNotesSources();
-});
 
 const resultSheetOpen = ref(false);
 const graphSheetOpen = ref(false);
@@ -1567,11 +1546,13 @@ async function handleActionSave() {
                       :supporting-text="noteIssues.map(i => i.reason).join('; ')"
                     ></nldd-inline-dialog>
                     <!-- Draft notes live in localStorage until written back.
-                         "Opslaan naar repo" PUTs the sidecar to editor-api,
-                         which validates it and opens the session PR (same
-                         branch+PR as law/scenario edits). The target source
-                         defaults to the law's own; the dropdown overrides it
-                         for a federated note (RFC-018 §2). "Exporteer YAML"
+                         "Opslaan naar repo" appends them to the sidecar on
+                         the active traject's branch (same write model as
+                         law/scenario edits since #632). No source picker —
+                         the traject's own corpus config decides the target.
+                         Without an active traject the save button is
+                         disabled, mirroring the law-edit buttons, so the
+                         backend 403 is never a surprise. "Exporteer YAML"
                          stays for the offline / manual-commit case. -->
                     <nldd-inline-dialog
                       v-if="canCreateNotes && draftCount > 0"
@@ -1584,27 +1565,12 @@ async function handleActionSave() {
                       "
                       :icon-color="hiddenDraftCount > 0 ? 'warning' : undefined"
                     >
-                      <nldd-dropdown
-                        v-if="notesSources.length >= 1"
-                        slot="actions"
-                        label="Opslaan naar"
-                        @change="notesTargetSource = $event.detail?.value ?? $event.target?.value ?? notesTargetSource"
-                      >
-                        <select :value="notesTargetSource" data-testid="notes-target-source">
-                          <option value="">Bron van de wet (standaard)</option>
-                          <option
-                            v-for="s in notesSources"
-                            :key="s.id"
-                            :value="s.id"
-                          >{{ s.name }}</option>
-                        </select>
-                      </nldd-dropdown>
                       <nldd-button
                         slot="actions"
                         size="md"
                         variant="primary"
                         :text="savingNotes ? 'Opslaan…' : 'Opslaan naar repo'"
-                        :disabled="savingNotes || notesSourcesFailed || null"
+                        :disabled="savingNotes || !canEdit || null"
                         data-testid="save-notes-btn"
                         @click="saveNotesToRepo"
                       ></nldd-button>
@@ -1625,11 +1591,11 @@ async function handleActionSave() {
                       ></nldd-button>
                     </nldd-inline-dialog>
                     <nldd-inline-dialog
-                      v-if="notesSourcesFailed"
+                      v-if="canCreateNotes && draftCount > 0 && !canEdit"
                       variant="warning"
-                      data-testid="notes-sources-failed"
-                      text="Doelbronnen konden niet geladen worden"
-                      supporting-text="Opslaan naar repo is uitgeschakeld tot de bronlijst opnieuw geladen is. Exporteer YAML werkt wel."
+                      data-testid="notes-no-traject"
+                      text="Selecteer eerst een traject"
+                      supporting-text="Opslaan naar repo werkt pas als er een actief traject is. Exporteer YAML werkt wel."
                     ></nldd-inline-dialog>
                     <nldd-inline-dialog
                       v-if="notesSaveError"

--- a/frontend/src/composables/useDraftNotes.js
+++ b/frontend/src/composables/useDraftNotes.js
@@ -1,10 +1,12 @@
 /**
  * useDraftNotes — local-only note authoring store (RFC-018 write path, MVP).
  *
- * The MVP does not write the sidecar back to the repo: notes a user creates in
- * the editor live in `localStorage`, keyed per law, and are exported as a YAML
- * document the user commits to `corpus/annotations/{lawId}/annotations.yaml`
- * by hand (RFC-018 step 6 — git stays the source of truth, no write API).
+ * Notes a user creates in the editor live in `localStorage`, keyed per law,
+ * until they are written back. Two ways out: `exportYaml` produces a YAML
+ * document for a manual commit (the original RFC-018 §10 MVP, still here for
+ * the offline case), and `saveToRepo` PUTs that same document to editor-api,
+ * which validates it and opens a PR against the chosen source — the same
+ * per-(session, source) branch+PR path law and scenario edits already use.
  *
  * Draft notes are merged into the resolved-notes list by the caller so they
  * highlight live, exactly like committed notes; they just carry an extra
@@ -12,6 +14,11 @@
  */
 import { ref, computed, watch } from 'vue';
 import yaml from 'js-yaml';
+import {
+  getEditorSessionId,
+  lastSavedPr,
+  sanitizeSavedPr,
+} from './useEditorSession.js';
 
 const STORAGE_PREFIX = 'regelrecht-draft-notes:';
 
@@ -94,8 +101,11 @@ export function useDraftNotes(lawId) {
    * for a law that has no committed notes yet — the export is then just the
    * drafts.
    */
-  async function exportYaml() {
-    const id = lawId.value;
+  async function exportYaml(lawIdOverride) {
+    // saveToRepo passes its own snapshot so the PUT URL and the exported
+    // body provably share one law id even if the law switches in the
+    // synchronous gap before this call. Default: read it here.
+    const id = lawIdOverride ?? lawId.value;
     // Snapshot drafts BEFORE the await: watch(lawId) swaps drafts.value
     // synchronously on a law switch, so reading it after the fetch could mix
     // law A's committed notes with law B's drafts. Drafts are the only copy
@@ -129,6 +139,57 @@ export function useDraftNotes(lawId) {
     return yaml.dump(doc, { lineWidth: -1, noRefs: true });
   }
 
+  /**
+   * Write the full sidecar to the repo via editor-api and open/update the
+   * session PR. `targetSourceId` is optional: omit it to write to the law's
+   * own source (the default), or pass a registered source id to route an
+   * advisory note to the annotating organisation's repo (RFC-018 §2).
+   *
+   * On success the drafts are cleared (they are now in the PR) and the
+   * shared `lastSavedPr` ref is updated so EditorApp's "Bekijk op GitHub"
+   * badge shows this PR — exactly like a law or scenario save.
+   *
+   * Throws an Error with the editor-api message on failure (e.g. a schema
+   * 400 or a read-only-source 403) so the caller can surface it; drafts are
+   * left untouched in that case so no work is lost.
+   */
+  async function saveToRepo(targetSourceId) {
+    const id = lawId.value;
+    // Pass `id` so the body is built for the same law the URL targets.
+    const yamlText = await exportYaml(id);
+    let url = `/api/corpus/laws/${encodeURIComponent(id)}/annotations`;
+    if (targetSourceId) {
+      url += `?source=${encodeURIComponent(targetSourceId)}`;
+    }
+    const res = await fetch(url, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'text/yaml; charset=utf-8',
+        'X-Editor-Session': getEditorSessionId(),
+      },
+      body: yamlText,
+    });
+    if (!res.ok) {
+      // Same content-type guard as useLaw.saveLaw: only render the body
+      // when it's editor-api's own text/plain error, never a proxy's HTML.
+      let text = `Opslaan mislukt: ${res.status}`;
+      const contentType = res.headers.get('content-type') || '';
+      if (contentType.startsWith('text/plain')) {
+        try {
+          text = (await res.text()) || text;
+        } catch { /* keep status fallback */ }
+      }
+      throw new Error(text);
+    }
+    try {
+      const json = await res.json();
+      lastSavedPr.value = sanitizeSavedPr(json?.pr);
+    } catch {
+      // Local source → no PR body; treat as success, keep any prior PR.
+    }
+    clearDrafts();
+  }
+
   const draftCount = computed(() => drafts.value.length);
 
   return {
@@ -138,6 +199,7 @@ export function useDraftNotes(lawId) {
     removeDraft,
     clearDrafts,
     exportYaml,
+    saveToRepo,
   };
 }
 

--- a/frontend/src/composables/useDraftNotes.js
+++ b/frontend/src/composables/useDraftNotes.js
@@ -198,15 +198,30 @@ export function useDraftNotes(lawId) {
       }
       throw new Error(text);
     }
+    let pr = null;
+    let noChange = false;
     try {
       const json = await res.json();
-      lastSavedPr.value = sanitizeSavedPr(json?.pr);
+      pr = sanitizeSavedPr(json?.pr);
+      // Backend sets no_change when every submitted note was already
+      // committed and it skipped the write/commit/PR entirely.
+      noChange = json?.no_change === true;
     } catch {
-      // Local source → no PR body; treat as success, keep any prior PR.
+      // No JSON body — treat as success, pr stays null.
+    }
+    // Only OVERWRITE the badge when this save produced a PR. A PR-less
+    // 200 (local source, or a NoChange re-save) must NOT null an existing
+    // badge — same "keep any prior PR" rule as useLaw.saveLaw. Nulling it
+    // here made a re-save look like the work vanished.
+    if (pr) {
+      lastSavedPr.value = pr;
     }
     // Clear the law we saved, not lawId.value, which may have switched
     // during the await.
     clearDrafts(id);
+    // Caller shows an explicit "opgeslagen (PR #N)" vs "waren al
+    // opgeslagen" instead of silently emptying drafts with no signal.
+    return { pr, noChange };
   }
 
   const draftCount = computed(() => drafts.value.length);

--- a/frontend/src/composables/useDraftNotes.js
+++ b/frontend/src/composables/useDraftNotes.js
@@ -14,11 +14,7 @@
  */
 import { ref, computed, watch } from 'vue';
 import yaml from 'js-yaml';
-import {
-  getEditorSessionId,
-  lastSavedPr,
-  sanitizeSavedPr,
-} from './useEditorSession.js';
+import { lastSavedPr, sanitizeSavedPr } from './useEditorSession.js';
 
 const STORAGE_PREFIX = 'regelrecht-draft-notes:';
 
@@ -152,37 +148,34 @@ export function useDraftNotes(lawId) {
   }
 
   /**
-   * Append the local drafts to the law's sidecar via editor-api and
-   * open/update the session PR. `targetSourceId` is optional: omit it for
-   * the law's own source (the common case); a value is only honoured by
-   * the backend when it passes the cross-tenant allowlist (the law's
-   * source or the unrestricted central corpus).
+   * Append the local drafts to the law's sidecar via editor-api. The save
+   * is routed through the session's active traject (same model as law and
+   * scenario edits since #632): the notes land in that traject's writable
+   * branch, so a note and a law edit made in the same session ride the
+   * same PR. No source is chosen here — the traject's own corpus config
+   * decides the target. With no active traject the backend returns 403.
    *
    * The request body is **only the new drafts**, not the merged file: the
-   * backend reads the current sidecar from the session branch and appends.
+   * backend reads the current sidecar from the traject branch and appends.
    * That is why there is no `/data` fetch here — rebuilding the file
    * client-side from the stale static mirror was the blind-overwrite bug.
    *
-   * On success the saved law's drafts are cleared (they are in the PR now)
-   * and the shared `lastSavedPr` ref is updated so EditorApp's badge shows
-   * the PR. Throws with the editor-api message on failure; drafts are left
-   * untouched so no work is lost.
+   * On success the saved law's drafts are cleared (they are committed now)
+   * and, if the save produced a PR, the shared `lastSavedPr` ref is
+   * updated so EditorApp's badge shows it. Throws with the editor-api
+   * message on failure; drafts are left untouched so no work is lost.
    */
-  async function saveToRepo(targetSourceId) {
+  async function saveToRepo() {
     const id = lawId.value;
     // Snapshot drafts BEFORE any await (watch(lawId) swaps drafts.value on
     // a law switch). Strip the internal __draft marker; the backend gets
     // clean W3C Annotation objects.
     const newNotes = drafts.value.map(stripDraftMarker);
-    let url = `/api/corpus/laws/${encodeURIComponent(id)}/annotations`;
-    if (targetSourceId) {
-      url += `?source=${encodeURIComponent(targetSourceId)}`;
-    }
+    const url = `/api/corpus/laws/${encodeURIComponent(id)}/annotations`;
     const res = await fetch(url, {
       method: 'PUT',
       headers: {
         'Content-Type': 'application/json',
-        'X-Editor-Session': getEditorSessionId(),
       },
       body: JSON.stringify(newNotes),
     });

--- a/frontend/src/composables/useDraftNotes.js
+++ b/frontend/src/composables/useDraftNotes.js
@@ -81,10 +81,22 @@ export function useDraftNotes(lawId) {
     persist(lawId.value, drafts.value);
   }
 
-  /** Drop every draft for the current law (after a successful export/commit). */
-  function clearDrafts() {
-    drafts.value = [];
-    persist(lawId.value, []);
+  /**
+   * Drop every draft for a law (after a successful save/commit).
+   *
+   * `lawIdOverride` lets a caller clear the *law it actually saved* rather
+   * than `lawId.value`, which may have changed during the save's awaits. A
+   * `watch(lawId)` resyncs `drafts` to the now-current law, so this also
+   * persists the cleared list under the right key and only resets the
+   * in-memory `drafts` ref when it still belongs to the saved law (clearing
+   * it would otherwise wipe the freshly-switched law's drafts on screen).
+   */
+  function clearDrafts(lawIdOverride) {
+    const id = lawIdOverride ?? lawId.value;
+    persist(id, []);
+    if (lawId.value === id) {
+      drafts.value = [];
+    }
   }
 
   /**
@@ -140,23 +152,28 @@ export function useDraftNotes(lawId) {
   }
 
   /**
-   * Write the full sidecar to the repo via editor-api and open/update the
-   * session PR. `targetSourceId` is optional: omit it to write to the law's
-   * own source (the default), or pass a registered source id to route an
-   * advisory note to the annotating organisation's repo (RFC-018 §2).
+   * Append the local drafts to the law's sidecar via editor-api and
+   * open/update the session PR. `targetSourceId` is optional: omit it for
+   * the law's own source (the common case); a value is only honoured by
+   * the backend when it passes the cross-tenant allowlist (the law's
+   * source or the unrestricted central corpus).
    *
-   * On success the drafts are cleared (they are now in the PR) and the
-   * shared `lastSavedPr` ref is updated so EditorApp's "Bekijk op GitHub"
-   * badge shows this PR — exactly like a law or scenario save.
+   * The request body is **only the new drafts**, not the merged file: the
+   * backend reads the current sidecar from the session branch and appends.
+   * That is why there is no `/data` fetch here — rebuilding the file
+   * client-side from the stale static mirror was the blind-overwrite bug.
    *
-   * Throws an Error with the editor-api message on failure (e.g. a schema
-   * 400 or a read-only-source 403) so the caller can surface it; drafts are
-   * left untouched in that case so no work is lost.
+   * On success the saved law's drafts are cleared (they are in the PR now)
+   * and the shared `lastSavedPr` ref is updated so EditorApp's badge shows
+   * the PR. Throws with the editor-api message on failure; drafts are left
+   * untouched so no work is lost.
    */
   async function saveToRepo(targetSourceId) {
     const id = lawId.value;
-    // Pass `id` so the body is built for the same law the URL targets.
-    const yamlText = await exportYaml(id);
+    // Snapshot drafts BEFORE any await (watch(lawId) swaps drafts.value on
+    // a law switch). Strip the internal __draft marker; the backend gets
+    // clean W3C Annotation objects.
+    const newNotes = drafts.value.map(stripDraftMarker);
     let url = `/api/corpus/laws/${encodeURIComponent(id)}/annotations`;
     if (targetSourceId) {
       url += `?source=${encodeURIComponent(targetSourceId)}`;
@@ -164,10 +181,10 @@ export function useDraftNotes(lawId) {
     const res = await fetch(url, {
       method: 'PUT',
       headers: {
-        'Content-Type': 'text/yaml; charset=utf-8',
+        'Content-Type': 'application/json',
         'X-Editor-Session': getEditorSessionId(),
       },
-      body: yamlText,
+      body: JSON.stringify(newNotes),
     });
     if (!res.ok) {
       // Same content-type guard as useLaw.saveLaw: only render the body
@@ -187,7 +204,9 @@ export function useDraftNotes(lawId) {
     } catch {
       // Local source → no PR body; treat as success, keep any prior PR.
     }
-    clearDrafts();
+    // Clear the law we saved, not lawId.value, which may have switched
+    // during the await.
+    clearDrafts(id);
   }
 
   const draftCount = computed(() => drafts.value.length);

--- a/frontend/src/composables/useDraftNotes.test.js
+++ b/frontend/src/composables/useDraftNotes.test.js
@@ -129,15 +129,11 @@ describe('useDraftNotes', () => {
   });
 });
 
-// saveToRepo PUTs the exported sidecar to editor-api. fetch is called
-// twice per save: the sidecar GET inside exportYaml, then the annotations
-// PUT. This stub answers GET with a 404 (drafts-only export) and the PUT
-// with the supplied response.
+// saveToRepo now does ONE request: a PUT whose body is the JSON array of
+// new drafts. No /data GET — the backend reads the base from the session
+// branch and appends. Single stub for the PUT.
 function stubSave(putResponse) {
-  globalThis.fetch = vi.fn((url, opts) => {
-    if (opts?.method === 'PUT') return Promise.resolve(putResponse);
-    return Promise.resolve({ ok: false, status: 404 });
-  });
+  globalThis.fetch = vi.fn(() => Promise.resolve(putResponse));
 }
 
 describe('useDraftNotes.saveToRepo', () => {
@@ -145,7 +141,7 @@ describe('useDraftNotes.saveToRepo', () => {
     lastSavedPr.value = null;
   });
 
-  it('PUTs to the law annotations endpoint, clears drafts, sets the PR', async () => {
+  it('PUTs only the new drafts as JSON, clears drafts, sets the PR', async () => {
     stubSave({
       ok: true,
       json: async () => ({
@@ -157,11 +153,17 @@ describe('useDraftNotes.saveToRepo', () => {
 
     await saveToRepo();
 
-    const putCall = globalThis.fetch.mock.calls.find(
-      ([, o]) => o?.method === 'PUT',
-    );
-    expect(putCall[0]).toBe('/api/corpus/laws/zorgtoeslagwet/annotations');
-    expect(putCall[1].headers['X-Editor-Session']).toBeTruthy();
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    const [url, opts] = globalThis.fetch.mock.calls[0];
+    expect(url).toBe('/api/corpus/laws/zorgtoeslagwet/annotations');
+    expect(opts.method).toBe('PUT');
+    expect(opts.headers['Content-Type']).toBe('application/json');
+    expect(opts.headers['X-Editor-Session']).toBeTruthy();
+    const sent = JSON.parse(opts.body);
+    expect(Array.isArray(sent)).toBe(true);
+    expect(sent).toHaveLength(1);
+    // The internal __draft marker must never reach the wire.
+    expect(JSON.stringify(sent)).not.toContain('__draft');
     expect(drafts.value).toHaveLength(0);
     expect(lastSavedPr.value).toEqual({
       url: 'https://github.com/x/y/pull/7',
@@ -177,10 +179,7 @@ describe('useDraftNotes.saveToRepo', () => {
 
     await saveToRepo('amsterdam');
 
-    const putCall = globalThis.fetch.mock.calls.find(
-      ([, o]) => o?.method === 'PUT',
-    );
-    expect(putCall[0]).toBe(
+    expect(globalThis.fetch.mock.calls[0][0]).toBe(
       '/api/corpus/laws/zorgtoeslagwet/annotations?source=amsterdam',
     );
   });
@@ -190,12 +189,43 @@ describe('useDraftNotes.saveToRepo', () => {
       ok: false,
       status: 400,
       headers: { get: () => 'text/plain; charset=utf-8' },
-      text: async () => 'Note file is invalid:\n/annotations: required',
+      text: async () => 'Notes are not valid against the annotation schema',
     });
     const { addDraft, saveToRepo, drafts } = useDraftNotes(ref('w'));
     addDraft({ ...NOTE, __draft: true });
 
-    await expect(saveToRepo()).rejects.toThrow(/Note file is invalid/);
+    await expect(saveToRepo()).rejects.toThrow(/not valid against/);
     expect(drafts.value).toHaveLength(1);
+  });
+
+  it('clears the saved law, not the law switched to mid-save', async () => {
+    // Regression for the hostile-review finding: a law switch during the
+    // PUT must not wipe the new law's drafts nor leave the saved law's.
+    let resolvePut;
+    globalThis.fetch = vi.fn(
+      () => new Promise((r) => { resolvePut = r; }),
+    );
+    const lawId = ref('lawA');
+    const { addDraft, saveToRepo, drafts } = useDraftNotes(lawId);
+    addDraft({ ...NOTE, __draft: true }); // a draft on lawA
+
+    const p = saveToRepo(); // snapshots id = 'lawA'
+    // User switches to lawB before the PUT resolves; lawB has its own draft.
+    localStorage.setItem(
+      'regelrecht-draft-notes:lawB',
+      JSON.stringify([{ ...NOTE, body: { ...NOTE.body, value: 'B' } }]),
+    );
+    lawId.value = 'lawB';
+    await Promise.resolve(); // let watch(lawId) resync drafts to lawB
+    resolvePut({ ok: true, json: async () => ({ pr: null }) });
+    await p;
+
+    // lawB's draft (on screen now) is untouched.
+    expect(drafts.value).toHaveLength(1);
+    expect(drafts.value[0].body.value).toBe('B');
+    // lawA's drafts were cleared in storage (they are in the PR).
+    expect(
+      JSON.parse(localStorage.getItem('regelrecht-draft-notes:lawA')),
+    ).toEqual([]);
   });
 });

--- a/frontend/src/composables/useDraftNotes.test.js
+++ b/frontend/src/composables/useDraftNotes.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { ref } from 'vue';
 import yaml from 'js-yaml';
 import { useDraftNotes } from './useDraftNotes.js';
+import { lastSavedPr } from './useEditorSession.js';
 
 /** Stub the sidecar fetch exportYaml does. `committed` is the file's notes. */
 function stubSidecar(committed) {
@@ -125,5 +126,76 @@ describe('useDraftNotes', () => {
     // lineWidth -1: the value stays on one logical line (no YAML fold marker).
     const reparsed = yaml.load(await exportYaml());
     expect(reparsed.annotations[0].body.value).toBe(longValue);
+  });
+});
+
+// saveToRepo PUTs the exported sidecar to editor-api. fetch is called
+// twice per save: the sidecar GET inside exportYaml, then the annotations
+// PUT. This stub answers GET with a 404 (drafts-only export) and the PUT
+// with the supplied response.
+function stubSave(putResponse) {
+  globalThis.fetch = vi.fn((url, opts) => {
+    if (opts?.method === 'PUT') return Promise.resolve(putResponse);
+    return Promise.resolve({ ok: false, status: 404 });
+  });
+}
+
+describe('useDraftNotes.saveToRepo', () => {
+  beforeEach(() => {
+    lastSavedPr.value = null;
+  });
+
+  it('PUTs to the law annotations endpoint, clears drafts, sets the PR', async () => {
+    stubSave({
+      ok: true,
+      json: async () => ({
+        pr: { url: 'https://github.com/x/y/pull/7', number: 7, branch: 'b' },
+      }),
+    });
+    const { addDraft, saveToRepo, drafts } = useDraftNotes(ref('zorgtoeslagwet'));
+    addDraft({ ...NOTE, __draft: true });
+
+    await saveToRepo();
+
+    const putCall = globalThis.fetch.mock.calls.find(
+      ([, o]) => o?.method === 'PUT',
+    );
+    expect(putCall[0]).toBe('/api/corpus/laws/zorgtoeslagwet/annotations');
+    expect(putCall[1].headers['X-Editor-Session']).toBeTruthy();
+    expect(drafts.value).toHaveLength(0);
+    expect(lastSavedPr.value).toEqual({
+      url: 'https://github.com/x/y/pull/7',
+      number: 7,
+      branch: 'b',
+    });
+  });
+
+  it('appends ?source= when a target source is given', async () => {
+    stubSave({ ok: true, json: async () => ({ pr: null }) });
+    const { addDraft, saveToRepo } = useDraftNotes(ref('zorgtoeslagwet'));
+    addDraft({ ...NOTE, __draft: true });
+
+    await saveToRepo('amsterdam');
+
+    const putCall = globalThis.fetch.mock.calls.find(
+      ([, o]) => o?.method === 'PUT',
+    );
+    expect(putCall[0]).toBe(
+      '/api/corpus/laws/zorgtoeslagwet/annotations?source=amsterdam',
+    );
+  });
+
+  it('throws the editor-api message and keeps drafts on a 400', async () => {
+    stubSave({
+      ok: false,
+      status: 400,
+      headers: { get: () => 'text/plain; charset=utf-8' },
+      text: async () => 'Note file is invalid:\n/annotations: required',
+    });
+    const { addDraft, saveToRepo, drafts } = useDraftNotes(ref('w'));
+    addDraft({ ...NOTE, __draft: true });
+
+    await expect(saveToRepo()).rejects.toThrow(/Note file is invalid/);
+    expect(drafts.value).toHaveLength(1);
   });
 });

--- a/frontend/src/composables/useDraftNotes.test.js
+++ b/frontend/src/composables/useDraftNotes.test.js
@@ -158,7 +158,9 @@ describe('useDraftNotes.saveToRepo', () => {
     expect(url).toBe('/api/corpus/laws/zorgtoeslagwet/annotations');
     expect(opts.method).toBe('PUT');
     expect(opts.headers['Content-Type']).toBe('application/json');
-    expect(opts.headers['X-Editor-Session']).toBeTruthy();
+    // No X-Editor-Session: the traject is implicit in the session cookie
+    // (same as law/scenario saves since #632).
+    expect(opts.headers['X-Editor-Session']).toBeUndefined();
     const sent = JSON.parse(opts.body);
     expect(Array.isArray(sent)).toBe(true);
     expect(sent).toHaveLength(1);
@@ -172,15 +174,17 @@ describe('useDraftNotes.saveToRepo', () => {
     });
   });
 
-  it('appends ?source= when a target source is given', async () => {
+  it('never appends a ?source= query — the traject decides the target', async () => {
     stubSave({ ok: true, json: async () => ({ pr: null }) });
     const { addDraft, saveToRepo } = useDraftNotes(ref('zorgtoeslagwet'));
     addDraft({ ...NOTE, __draft: true });
 
+    // saveToRepo takes no source argument anymore; even if one is passed
+    // it must not leak into the URL.
     await saveToRepo('amsterdam');
 
     expect(globalThis.fetch.mock.calls[0][0]).toBe(
-      '/api/corpus/laws/zorgtoeslagwet/annotations?source=amsterdam',
+      '/api/corpus/laws/zorgtoeslagwet/annotations',
     );
   });
 

--- a/frontend/src/composables/useDraftNotes.test.js
+++ b/frontend/src/composables/useDraftNotes.test.js
@@ -184,6 +184,29 @@ describe('useDraftNotes.saveToRepo', () => {
     );
   });
 
+  it('keeps the existing PR badge on a NoChange re-save', async () => {
+    // Regression for hostile-review #4: a PR-less 200 (every note already
+    // committed) must NOT null an existing badge and must report noChange
+    // so the UI can say "already saved" instead of looking like loss.
+    lastSavedPr.value = { url: 'https://github.com/x/y/pull/3', number: 3, branch: 'b' };
+    stubSave({ ok: true, json: async () => ({ pr: null, no_change: true }) });
+    const { addDraft, saveToRepo, drafts } = useDraftNotes(ref('w'));
+    addDraft({ ...NOTE, __draft: true });
+
+    const result = await saveToRepo();
+
+    expect(result).toEqual({ pr: null, noChange: true });
+    // Badge untouched — the earlier PR is still shown.
+    expect(lastSavedPr.value).toEqual({
+      url: 'https://github.com/x/y/pull/3',
+      number: 3,
+      branch: 'b',
+    });
+    // Drafts cleared (they are already upstream) — that is fine because
+    // the caller now has noChange to show an explicit message.
+    expect(drafts.value).toHaveLength(0);
+  });
+
   it('throws the editor-api message and keeps drafts on a 400', async () => {
     stubSave({
       ok: false,

--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -3680,6 +3680,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "serde_yaml_ng",
  "sqlx",
  "time",
  "tokio",

--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -3653,6 +3653,7 @@ name = "regelrecht-corpus"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "jsonschema",
  "regelrecht-engine",
  "reqwest 0.13.2",
  "serde",

--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -3682,6 +3682,7 @@ dependencies = [
  "serde_json",
  "serde_yaml_ng",
  "sqlx",
+ "tempfile",
  "time",
  "tokio",
  "tower-http",

--- a/packages/corpus/Cargo.toml
+++ b/packages/corpus/Cargo.toml
@@ -18,11 +18,16 @@ thiserror.workspace = true
 serde.workspace = true
 serde_yaml_ng.workspace = true
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"], optional = true }
+serde_json = { workspace = true, optional = true }
+jsonschema = { version = "0.46", optional = true }
 walkdir.workspace = true
 
 [features]
 default = ["github"]
 github = ["dep:reqwest"]
+# Schema validation for note (annotation) YAML. Pulls in jsonschema; only
+# the editor-api write path needs it, so it stays optional.
+annotation-validation = ["dep:jsonschema", "dep:serde_json"]
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "process", "fs"] }

--- a/packages/corpus/src/annotation_schema.rs
+++ b/packages/corpus/src/annotation_schema.rs
@@ -119,23 +119,25 @@ pub enum AppendOutcome {
 /// and the new notes are appended as text.
 ///
 /// - Base has an `annotations:` block: serialise only the *new, deduped*
-///   notes as a YAML sequence, re-indent by two spaces, and append after
-///   the existing content. Existing bytes are untouched, so the git diff
-///   is exactly the added lines.
+///   notes as a YAML sequence, re-indented to match the base sequence's
+///   actual list-item indentation (detected from the text, not assumed),
+///   and append after the existing content. Existing bytes are untouched,
+///   so the git diff is exactly the added lines. This handles both the
+///   serde_yaml_ng `- ` at column 0 (what `serialize_annotation_doc`
+///   itself produces, so a first save's file and a second save's append
+///   agree) and a 2-space curated file.
 /// - No base, or a base without an `annotations:` key (nothing to
 ///   preserve): build a fresh full document. There is no history or
 ///   comment to protect in that case.
 /// - All new notes already present: [`AppendOutcome::NoChange`].
 ///
-/// Format assumption: the 2-space re-indent produces a valid file only
-/// when the base uses the 2-space LF list convention every corpus tool
-/// emits (`js-yaml` export, `serde_yaml_ng`, the committed sidecars). A
-/// hand-edited base with 4-space indent, a flow sequence, or CRLF endings
-/// would yield a malformed or mixed-ending result. This is **not** a
-/// silent corruption: the caller re-parses and schema-validates the
-/// produced text, so such a base fails the save loudly rather than
-/// committing garbage. It is a hard stop on an exotic layout, not a
-/// "preserves any file" guarantee.
+/// Remaining format assumption: a uniform-space block sequence with LF
+/// endings (every corpus tool: `js-yaml` export, `serde_yaml_ng`, the
+/// committed sidecars). A flow sequence (`annotations: [...]`) or CRLF
+/// base still yields a malformed result, but that is caught: the caller
+/// re-parses and schema-validates the produced text, so such a base fails
+/// the save loudly rather than committing garbage. Not a silent
+/// corruption, and no longer the everyday-path break it was.
 ///
 /// `new_notes` are assumed schema-checked by the caller; the caller must
 /// still validate the *resulting* document.
@@ -186,32 +188,74 @@ pub fn append_notes_to_sidecar(
         return Ok(AppendOutcome::Write(serialize_annotation_doc(&doc)?));
     }
 
-    // Serialise ONLY the new notes as a sequence, then re-indent every
-    // line by two spaces so the items sit under the existing
-    // `annotations:` key (the sidecar's list convention). serde_yaml_ng
-    // emits a top-level sequence as `- ...` at column 0 with 2-space field
-    // indentation; prefixing two spaces yields `  - ...`.
+    // Detect the base sequence's actual list-item indentation and match
+    // it. Earlier this hardcoded two spaces, which broke whenever the base
+    // used a different indent — including the common case where the base
+    // was itself produced by `serialize_annotation_doc` (serde_yaml_ng
+    // emits `- ` at column 0), so the first save's file and the second
+    // save's append disagreed and produced invalid YAML. We read the real
+    // indent from the file instead of assuming one.
+    let base = base_text.unwrap_or_default();
+    let base_indent = sequence_item_indent(base);
+
+    // serde_yaml_ng emits a top-level sequence as `- ...` at column 0.
+    // Re-indent each line by `base_indent` spaces so the new items sit at
+    // exactly the same depth as the existing ones under `annotations:`.
     let owned: Vec<serde_json::Value> = to_add.iter().map(|n| (*n).clone()).collect();
     let seq = serde_yaml_ng::to_string(&owned)
         .map_err(|e| format!("failed to serialise new notes: {e}"))?;
+    let pad = " ".repeat(base_indent);
     let indented: String = seq
         .lines()
         .map(|line| {
             if line.is_empty() {
                 String::from("\n")
             } else {
-                format!("  {line}\n")
+                format!("{pad}{line}\n")
             }
         })
         .collect();
 
-    let base = base_text.unwrap_or_default();
     // Exactly one newline between the existing content and the appended
     // items, regardless of whether the base ended with 0, 1 or more.
     let mut out = base.trim_end_matches('\n').to_string();
     out.push('\n');
     out.push_str(&indented);
     Ok(AppendOutcome::Write(out))
+}
+
+/// Indentation (in spaces) of the `annotations:` block-sequence items in a
+/// sidecar's text.
+///
+/// A YAML block sequence under `annotations:` has items written as
+/// `<indent>- ...`. serde_yaml_ng emits them at column 0; a hand-curated
+/// file may use 2. We must append new items at the *same* depth or the
+/// result is structurally invalid YAML (the bug that produced
+/// "did not find expected key"). Scans from the `annotations:` key to the
+/// first sequence-entry line and returns its leading-space count; falls
+/// back to 0 (serde_yaml_ng's native depth) when it cannot tell.
+fn sequence_item_indent(text: &str) -> usize {
+    let mut after_key = false;
+    for line in text.lines() {
+        if !after_key {
+            // Top-level `annotations:` key (no leading space).
+            if line.trim_end() == "annotations:" || line.starts_with("annotations:") {
+                after_key = true;
+            }
+            continue;
+        }
+        let trimmed = line.trim_start();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        if trimmed.starts_with("- ") || trimmed == "-" {
+            return line.len() - trimmed.len();
+        }
+        // First non-blank, non-comment line after the key that is not a
+        // sequence entry: not a block sequence we can match. Bail to 0.
+        break;
+    }
+    0
 }
 
 /// The law id a note's `target.source` URI refers to.
@@ -515,5 +559,51 @@ annotations:
             append_notes_to_sidecar(None, &[], "https://s"),
             Ok(AppendOutcome::NoChange)
         ));
+    }
+
+    #[test]
+    fn second_append_onto_a_serde_produced_base_stays_valid() {
+        // The live 500: the FIRST save builds the file via the fresh-doc
+        // path (serialize_annotation_doc → serde_yaml_ng → `- ` at column
+        // 0). The SECOND save reads that file as the base and appends. The
+        // old code re-indented by a hardcoded 2 spaces, producing a
+        // column-2 item after column-0 items → "did not find expected
+        // key". This pins the round-trip: serialise, then append, then the
+        // result must still parse and have grown by one.
+        let n1 = note("eerste");
+        let first = match append_notes_to_sidecar(None, &[n1], "https://s") {
+            Ok(AppendOutcome::Write(t)) => t,
+            _ => panic!("expected fresh-doc Write"),
+        };
+        // Sanity: the fresh doc really is column-0 (the failing shape).
+        assert_eq!(sequence_item_indent(&first), 0);
+
+        let n2 = note("tweede");
+        let second = match append_notes_to_sidecar(Some(&first), &[n2], "https://s") {
+            Ok(AppendOutcome::Write(t)) => t,
+            other => panic!(
+                "expected Write, got NoChange={}",
+                matches!(other, Ok(AppendOutcome::NoChange))
+            ),
+        };
+        // The whole point: it parses (it did NOT before the fix).
+        let doc: serde_json::Value = serde_yaml_ng::from_str(&second)
+            .expect("second append onto a serde-produced base must stay valid YAML");
+        assert_eq!(doc["annotations"].as_array().unwrap().len(), 2);
+        // Base preserved verbatim as prefix; only lines added.
+        assert!(second.starts_with(first.trim_end_matches('\n')));
+    }
+
+    #[test]
+    fn sequence_item_indent_reads_real_depth() {
+        // serde_yaml_ng / fresh-doc shape: column 0.
+        assert_eq!(
+            sequence_item_indent("$schema: x\nannotations:\n- type: Annotation\n"),
+            0
+        );
+        // Curated 2-space shape.
+        assert_eq!(sequence_item_indent(CURATED_BASE), 2);
+        // No sequence yet → fall back to 0 (fresh-doc path handles it).
+        assert_eq!(sequence_item_indent("$schema: x\nannotations: []\n"), 0);
     }
 }

--- a/packages/corpus/src/annotation_schema.rs
+++ b/packages/corpus/src/annotation_schema.rs
@@ -87,6 +87,126 @@ pub fn serialize_annotation_doc(doc: &serde_json::Value) -> Result<String, Strin
     serde_yaml_ng::to_string(doc).map_err(|e| format!("failed to serialise notes: {e}"))
 }
 
+/// The notes already present in a sidecar's text, as JSON values.
+///
+/// Used to dedupe an append against what is already committed. Returns an
+/// empty vec when the file has no `annotations:` sequence (or is absent).
+pub fn notes_in_sidecar(base_text: &str) -> Vec<serde_json::Value> {
+    serde_yaml_ng::from_str::<serde_json::Value>(base_text)
+        .ok()
+        .and_then(|doc| doc.get("annotations").and_then(|a| a.as_array()).cloned())
+        .unwrap_or_default()
+}
+
+/// Outcome of preparing an append-only write of `new_notes` onto a sidecar.
+pub enum AppendOutcome {
+    /// Nothing to write: every new note was already present (dedup left
+    /// zero). The caller must skip the write/commit/PR entirely so a
+    /// no-op save produces no branch noise (review finding NEW-2).
+    NoChange,
+    /// The full text to write. Either the verbatim base with new note
+    /// items appended (history/comments preserved), or a freshly built
+    /// document when there was no base sequence to preserve.
+    Write(String),
+}
+
+/// Append `new_notes` to a sidecar **without rewriting the existing file**.
+///
+/// RFC-018 Decision 1 promises `git blame` shows who added each note and
+/// when; RFC-005's whole premise is that a stand-off file must not be
+/// rewritten under the content it annotates. Parsing the base and
+/// re-serialising it (even "losslessly") reorders keys, drops the curated
+/// *motivering* comments (RFC-018 §Why / AWB 3:46), and reassigns every
+/// line's blame to the last writer. So the base bytes are kept **verbatim**
+/// and the new notes are appended as text.
+///
+/// - Base has an `annotations:` block: serialise only the *new, deduped*
+///   notes as a YAML sequence, re-indent to the sidecar's 2-space list
+///   convention, and append after the existing content. Existing bytes are
+///   untouched, so the git diff is exactly the added lines.
+/// - No base, or a base without an `annotations:` key (nothing to
+///   preserve): build a fresh full document. There is no history or
+///   comment to protect in that case.
+/// - All new notes already present: [`AppendOutcome::NoChange`].
+///
+/// `new_notes` are assumed schema-checked by the caller; the caller must
+/// still validate the *resulting* document (a malformed base would
+/// otherwise pass through).
+pub fn append_notes_to_sidecar(
+    base_text: Option<&str>,
+    new_notes: &[serde_json::Value],
+    schema_url: &str,
+) -> Result<AppendOutcome, String> {
+    let base_notes: Vec<serde_json::Value> = base_text.map(notes_in_sidecar).unwrap_or_default();
+
+    let seen: std::collections::HashSet<String> = base_notes
+        .iter()
+        .filter_map(|n| serde_json::to_string(n).ok())
+        .collect();
+
+    // Preserve order; dedupe new notes against the base and against each
+    // other (a double-submit of the same draft is idempotent).
+    let mut to_add: Vec<&serde_json::Value> = Vec::new();
+    let mut added_keys: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for note in new_notes {
+        let Ok(key) = serde_json::to_string(note) else {
+            continue;
+        };
+        if !seen.contains(&key) && added_keys.insert(key) {
+            to_add.push(note);
+        }
+    }
+
+    if to_add.is_empty() {
+        return Ok(AppendOutcome::NoChange);
+    }
+
+    // Decide whether there is a base sequence to preserve. We only treat
+    // the base as appendable when it actually parses and carries an
+    // `annotations` array; anything else is rebuilt from scratch (no
+    // history/comments at stake).
+    let base_has_sequence = base_text
+        .and_then(|t| serde_yaml_ng::from_str::<serde_json::Value>(t).ok())
+        .and_then(|d| d.get("annotations").map(|a| a.is_array()))
+        .unwrap_or(false);
+
+    if !base_has_sequence {
+        // Fresh document: base + new notes, full serialise is fine here
+        // because there is nothing to protect.
+        let mut all = base_notes;
+        all.extend(to_add.iter().map(|n| (*n).clone()));
+        let doc = serde_json::json!({ "$schema": schema_url, "annotations": all });
+        return Ok(AppendOutcome::Write(serialize_annotation_doc(&doc)?));
+    }
+
+    // Serialise ONLY the new notes as a sequence, then re-indent every
+    // line by two spaces so the items sit under the existing
+    // `annotations:` key (the sidecar's list convention). serde_yaml_ng
+    // emits a top-level sequence as `- ...` at column 0 with 2-space field
+    // indentation; prefixing two spaces yields `  - ...`.
+    let owned: Vec<serde_json::Value> = to_add.iter().map(|n| (*n).clone()).collect();
+    let seq = serde_yaml_ng::to_string(&owned)
+        .map_err(|e| format!("failed to serialise new notes: {e}"))?;
+    let indented: String = seq
+        .lines()
+        .map(|line| {
+            if line.is_empty() {
+                String::from("\n")
+            } else {
+                format!("  {line}\n")
+            }
+        })
+        .collect();
+
+    let base = base_text.unwrap_or_default();
+    // Exactly one newline between the existing content and the appended
+    // items, regardless of whether the base ended with 0, 1 or more.
+    let mut out = base.trim_end_matches('\n').to_string();
+    out.push('\n');
+    out.push_str(&indented);
+    Ok(AppendOutcome::Write(out))
+}
+
 /// The law id a note's `target.source` URI refers to.
 ///
 /// `target.source` is a `regelrecht://<law_id>[/...]` URI (RFC-005); the
@@ -264,5 +384,129 @@ annotations:
             first_note_not_targeting_law(&serde_json::json!({}), "x"),
             None
         );
+    }
+
+    // A base sidecar with the curated shape the real corpus file uses:
+    // `---`, comments, an explanatory header, semantic key order, a
+    // multi-line block scalar. Appending must not touch any of this.
+    const CURATED_BASE: &str = "\
+---
+# Stand-off notes. RFC-005 / RFC-018.
+$schema: https://example/schema.json
+annotations:
+  # Linking note: curated explanation that must survive.
+  - type: Annotation
+    motivation: linking
+    creator: Dienst Toeslagen
+    target:
+      source: regelrecht://zorgtoeslagwet
+      selector:
+        type: TextQuoteSelector
+        exact: zorgtoeslag
+    body:
+      type: SpecificResource
+      source: regelrecht://zorgtoeslagwet/x#y
+      purpose: linking
+";
+
+    fn note(exact: &str) -> serde_json::Value {
+        serde_json::json!({
+            "type": "Annotation",
+            "motivation": "commenting",
+            "creator": "tester",
+            "target": {
+                "source": "regelrecht://zorgtoeslagwet",
+                "selector": { "type": "TextQuoteSelector", "exact": exact }
+            },
+            "body": { "type": "TextualBody", "value": "x", "purpose": "commenting" }
+        })
+    }
+
+    #[test]
+    fn append_keeps_the_base_verbatim_and_only_adds_lines() {
+        let new = vec![note("normpremie")];
+        let out = match append_notes_to_sidecar(Some(CURATED_BASE), &new, "https://s") {
+            Ok(AppendOutcome::Write(t)) => t,
+            other => panic!(
+                "expected Write, got {:?}",
+                matches!(other, Ok(AppendOutcome::NoChange))
+            ),
+        };
+        // Every original byte/line is still there, in order: the comments,
+        // the $schema, the curated note. The base is a strict prefix
+        // (modulo the single trailing-newline normalisation).
+        assert!(out.starts_with(CURATED_BASE.trim_end_matches('\n')));
+        assert!(out.contains("# Linking note: curated explanation that must survive."));
+        assert!(out.contains("creator: Dienst Toeslagen"));
+        // The appended note sits under `annotations:` at the 2-space list
+        // convention and carries its content.
+        assert!(out.contains("\n  - "));
+        assert!(out.contains("normpremie"));
+        // Result parses and the sequence grew by exactly one.
+        let doc: serde_json::Value = serde_yaml_ng::from_str(&out).unwrap();
+        assert_eq!(doc["annotations"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn append_dedups_against_the_base_and_is_idempotent() {
+        // The base already contains the linking note; re-submitting an
+        // identical-content note must not duplicate it. Reconstruct that
+        // note exactly as it parses out of the base.
+        let base_doc: serde_json::Value = serde_yaml_ng::from_str(CURATED_BASE).unwrap();
+        let existing = base_doc["annotations"][0].clone();
+
+        // Only the existing note resubmitted → nothing to write.
+        assert!(matches!(
+            append_notes_to_sidecar(Some(CURATED_BASE), &[existing.clone()], "https://s"),
+            Ok(AppendOutcome::NoChange)
+        ));
+
+        // Existing + one genuinely new → only the new one is appended.
+        let out = match append_notes_to_sidecar(
+            Some(CURATED_BASE),
+            &[existing, note("uniek")],
+            "https://s",
+        ) {
+            Ok(AppendOutcome::Write(t)) => t,
+            _ => panic!("expected Write"),
+        };
+        let doc: serde_json::Value = serde_yaml_ng::from_str(&out).unwrap();
+        assert_eq!(doc["annotations"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn append_with_no_base_builds_a_fresh_document() {
+        let out = match append_notes_to_sidecar(None, &[note("a")], "https://s") {
+            Ok(AppendOutcome::Write(t)) => t,
+            _ => panic!("expected Write"),
+        };
+        let doc: serde_json::Value = serde_yaml_ng::from_str(&out).unwrap();
+        assert_eq!(doc["$schema"], "https://s");
+        assert_eq!(doc["annotations"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn append_to_base_without_annotations_key_rebuilds() {
+        // A file that parses but has no annotations sequence: nothing to
+        // preserve, so a fresh full doc is fine.
+        let bare = "$schema: https://old\n";
+        let out = match append_notes_to_sidecar(Some(bare), &[note("a")], "https://s") {
+            Ok(AppendOutcome::Write(t)) => t,
+            _ => panic!("expected Write"),
+        };
+        let doc: serde_json::Value = serde_yaml_ng::from_str(&out).unwrap();
+        assert_eq!(doc["annotations"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn append_empty_input_is_nochange() {
+        assert!(matches!(
+            append_notes_to_sidecar(Some(CURATED_BASE), &[], "https://s"),
+            Ok(AppendOutcome::NoChange)
+        ));
+        assert!(matches!(
+            append_notes_to_sidecar(None, &[], "https://s"),
+            Ok(AppendOutcome::NoChange)
+        ));
     }
 }

--- a/packages/corpus/src/annotation_schema.rs
+++ b/packages/corpus/src/annotation_schema.rs
@@ -132,12 +132,18 @@ pub enum AppendOutcome {
 /// - All new notes already present: [`AppendOutcome::NoChange`].
 ///
 /// Remaining format assumption: a uniform-space block sequence with LF
-/// endings (every corpus tool: `js-yaml` export, `serde_yaml_ng`, the
-/// committed sidecars). A flow sequence (`annotations: [...]`) or CRLF
-/// base still yields a malformed result, but that is caught: the caller
-/// re-parses and schema-validates the produced text, so such a base fails
-/// the save loudly rather than committing garbage. Not a silent
-/// corruption, and no longer the everyday-path break it was.
+/// endings (every corpus tool — `js-yaml` export, `serde_yaml_ng`, the
+/// committed sidecars — produces exactly this). Two non-conforming bases
+/// behave differently, both non-silently:
+/// - A flow sequence (`annotations: [...]`) or any base whose notes the
+///   parser cannot read as a block sequence takes the rebuild path, where
+///   the destructive-shrink guard refuses outright rather than dropping
+///   the existing notes.
+/// - A CRLF base parses (YAML accepts CRLF), so the verbatim-append path
+///   runs and yields a file with mixed endings. The re-parse + schema
+///   gate does NOT reject this (it is still valid YAML); the pre-commit
+///   `yamllint`/EOF hook is what catches it. The whole committed corpus
+///   is LF, so this is not a path the corpus produces.
 ///
 /// `new_notes` are assumed schema-checked by the caller; the caller must
 /// still validate the *resulting* document.
@@ -182,6 +188,30 @@ pub fn append_notes_to_sidecar(
     if !base_has_sequence {
         // Fresh document: base + new notes, full serialise is fine here
         // because there is nothing to protect.
+        //
+        // Destructive-shrink guard. This is the ONLY path that rebuilds
+        // the file instead of appending verbatim, so it is the only path
+        // that can lose notes: `notes_in_sidecar` returns `[]` for a base
+        // that does not parse as a block sequence (flow style
+        // `annotations: [...]`, CRLF that breaks the parser, an anchor/
+        // alias the loader rejects). If we rebuilt from an empty
+        // `base_notes` while the raw file clearly carried note-like
+        // content, we would silently drop the lot. Refuse instead: a
+        // loud abort with the bytes untouched beats a quiet corpus
+        // deletion. RFC-018 §10 / RFC-005 verbatim-preservation.
+        if base_notes.is_empty() {
+            if let Some(raw) = base_text {
+                if raw.contains("type: Annotation") || raw.contains("\"type\": \"Annotation\"") {
+                    return Err(
+                        "refusing to rebuild a notes file whose existing content could not \
+                         be parsed as a block sequence: this would discard the notes already \
+                         in it. The sidecar must be repaired (LF endings, block-style \
+                         `annotations:` list) before new notes can be added."
+                            .to_string(),
+                    );
+                }
+            }
+        }
         let mut all = base_notes;
         all.extend(to_add.iter().map(|n| (*n).clone()));
         let doc = serde_json::json!({ "$schema": schema_url, "annotations": all });
@@ -239,7 +269,7 @@ fn sequence_item_indent(text: &str) -> usize {
     for line in text.lines() {
         if !after_key {
             // Top-level `annotations:` key (no leading space).
-            if line.trim_end() == "annotations:" || line.starts_with("annotations:") {
+            if line.trim_end() == "annotations:" || line.starts_with("annotations: ") {
                 after_key = true;
             }
             continue;
@@ -426,7 +456,8 @@ annotations:
         );
 
         // Empty / absent array is vacuously fine — the destructive-shrink
-        // guard, not this function, handles an empty body.
+        // guard in `append_notes_to_sidecar` (the rebuild path), not this
+        // function, refuses a base whose notes failed to parse.
         assert_eq!(
             first_note_not_targeting_law(&serde_json::json!({"annotations": []}), "x"),
             None
@@ -547,6 +578,35 @@ annotations:
         };
         let doc: serde_json::Value = serde_yaml_ng::from_str(&out).unwrap();
         assert_eq!(doc["annotations"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn rebuild_path_refuses_to_drop_unparseable_existing_notes() {
+        // A base that carries real note content but does NOT parse, so
+        // `notes_in_sidecar` yields `[]` and the verbatim-append path is
+        // skipped. Without the guard the rebuild path would emit a file
+        // containing only the new note, silently discarding the existing
+        // one. Regression for the "shrink guard" the RFC promises
+        // (previously fictional). The trigger is a YAML syntax fault
+        // (here: a tab in indentation, which serde_yaml_ng rejects) in a
+        // file that still clearly holds an Annotation.
+        let broken_base =
+            "$schema: https://s\nannotations:\n  - type: Annotation\n\tmotivation: commenting\n";
+        assert!(
+            serde_yaml_ng::from_str::<serde_json::Value>(broken_base).is_err(),
+            "test premise: base must be unparseable"
+        );
+        match append_notes_to_sidecar(Some(broken_base), &[note("new")], "https://s") {
+            Err(e) => assert!(e.contains("refusing to rebuild"), "{e}"),
+            Ok(_) => panic!("must refuse to rebuild over unparseable existing notes"),
+        }
+
+        // Sanity: a genuinely empty/contentless base is still a normal
+        // fresh build, NOT a refusal (the guard keys on note-like content).
+        assert!(matches!(
+            append_notes_to_sidecar(Some("$schema: https://s\n"), &[note("a")], "https://s"),
+            Ok(AppendOutcome::Write(_))
+        ));
     }
 
     #[test]

--- a/packages/corpus/src/annotation_schema.rs
+++ b/packages/corpus/src/annotation_schema.rs
@@ -1,0 +1,207 @@
+//! Note (annotation) YAML schema validation.
+//!
+//! The editor write path (`PUT /api/corpus/laws/{id}/annotations`) must
+//! reject a malformed note file *before* a commit and PR are created —
+//! once a branch exists, an invalid file is a dead PR someone has to clean
+//! up. This is the technical half of the two-layer review: schema
+//! correctness is enforced here, resolve correctness (orphaned/ambiguous
+//! selectors) stays a warning in `validate-annotations` per RFC-018 §8.
+//!
+//! The same schema is embedded by the `validate-annotations` engine binary.
+//! Keeping a second compiled copy here avoids editor-api depending on the
+//! engine crate; the schema file itself is the single source of truth.
+
+use std::sync::LazyLock;
+
+use jsonschema::Validator;
+
+/// The note schema, embedded at build time. Path is relative to this
+/// source file: `packages/corpus/src/` → repo `schema/v0.5.2/`.
+const ANNOTATION_SCHEMA: &str = include_str!("../../../schema/v0.5.2/annotation-schema.json");
+
+/// Compiled once on first use. The embedded schema not compiling is a
+/// build/release fault, not a per-request one — but the workspace bans
+/// `expect()`, so init is total: the error is carried in the `Result` and
+/// surfaced from [`validate_annotation_yaml`]. `schema_compiles` pins the
+/// build-time guarantee that this `Err` arm is unreachable in practice.
+static VALIDATOR: LazyLock<Result<Validator, String>> = LazyLock::new(|| {
+    let schema: serde_json::Value = serde_json::from_str(ANNOTATION_SCHEMA)
+        .map_err(|e| format!("embedded annotation schema is not valid JSON: {e}"))?;
+    Validator::new(&schema).map_err(|e| format!("embedded annotation schema does not compile: {e}"))
+});
+
+/// Parse a note file's YAML and validate it against
+/// `schema/v0.5.2/annotation-schema.json`, returning the parsed document on
+/// success.
+///
+/// On failure returns a list of error strings (a YAML parse error, or the
+/// schema violations as instance-path + message). Callers that surface
+/// these to a client should treat them as **diagnostic detail to log**, not
+/// as a safe response body: instance paths can echo attacker-controlled map
+/// keys (the schema is `additionalProperties: false`, so an unknown key's
+/// name lands in the path) and that flows into UI dialogs — the same
+/// self-XSS vector `save_law` avoids by not echoing the request `$id`.
+pub fn parse_and_validate_annotation_yaml(yaml: &str) -> Result<serde_json::Value, Vec<String>> {
+    let validator = VALIDATOR.as_ref().map_err(|e| vec![e.clone()])?;
+
+    let doc: serde_json::Value =
+        serde_yaml_ng::from_str(yaml).map_err(|e| vec![format!("YAML parse error: {e}")])?;
+
+    let errors: Vec<String> = validator
+        .iter_errors(&doc)
+        .map(|err| format!("{}: {}", err.instance_path(), err))
+        .collect();
+
+    if errors.is_empty() {
+        Ok(doc)
+    } else {
+        Err(errors)
+    }
+}
+
+/// Validate without keeping the parsed document. Thin wrapper over
+/// [`parse_and_validate_annotation_yaml`] for callers that only need the
+/// pass/fail (e.g. the `validate-annotations` style check).
+pub fn validate_annotation_yaml(yaml: &str) -> Result<(), Vec<String>> {
+    parse_and_validate_annotation_yaml(yaml).map(|_| ())
+}
+
+/// The law id a note's `target.source` URI refers to.
+///
+/// `target.source` is a `regelrecht://<law_id>[/...]` URI (RFC-005); the
+/// law id is the first path segment. Mirrors `regelrecht_engine`'s
+/// `annotation::law_id_from_source` so the editor write path and the engine
+/// resolver agree on what a note is "about".
+pub fn law_id_from_source(source: &str) -> Option<&str> {
+    let rest = source.strip_prefix("regelrecht://")?;
+    Some(rest.split('/').next().unwrap_or(rest))
+}
+
+/// Every distinct law id referenced by the notes in a (schema-valid)
+/// document's `target.source`. Used to reject a note file whose contents
+/// are about a different law than the path it is being written to —
+/// the note-side analogue of `save_law`'s `$id`/path-mismatch guard.
+pub fn note_target_law_ids(doc: &serde_json::Value) -> Vec<String> {
+    let Some(notes) = doc.get("annotations").and_then(|v| v.as_array()) else {
+        return Vec::new();
+    };
+    let mut ids: Vec<String> = notes
+        .iter()
+        .filter_map(|n| {
+            n.get("target")
+                .and_then(|t| t.get("source"))
+                .and_then(|s| s.as_str())
+                .and_then(law_id_from_source)
+                .map(str::to_string)
+        })
+        .collect();
+    ids.sort();
+    ids.dedup();
+    ids
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SCHEMA_URL: &str = "https://raw.githubusercontent.com/MinBZK/regelrecht/refs/heads/main/schema/v0.5.2/annotation-schema.json";
+
+    #[test]
+    fn schema_compiles() {
+        // The embedded schema must be valid JSON and a compilable JSON
+        // Schema. This is the build-time guarantee that the VALIDATOR
+        // `Err` arm is unreachable in production.
+        assert!(VALIDATOR.as_ref().is_ok(), "{:?}", VALIDATOR.as_ref().err());
+    }
+
+    #[test]
+    fn valid_minimal_note_passes() {
+        let yaml = format!(
+            r#"
+$schema: "{SCHEMA_URL}"
+annotations:
+  - type: Annotation
+    motivation: commenting
+    creator: tester
+    target:
+      source: "regelrecht://zorgtoeslagwet"
+      selector:
+        type: TextQuoteSelector
+        exact: zorgtoeslag
+    body:
+      type: TextualBody
+      value: een toelichting
+      purpose: commenting
+"#
+        );
+        assert!(validate_annotation_yaml(&yaml).is_ok());
+    }
+
+    #[test]
+    fn missing_required_field_fails_with_message() {
+        // No `target` — schema requires it on an Annotation.
+        let yaml = format!(
+            r#"
+$schema: "{SCHEMA_URL}"
+annotations:
+  - type: Annotation
+    motivation: commenting
+"#
+        );
+        let errs = validate_annotation_yaml(&yaml).unwrap_err();
+        assert!(!errs.is_empty());
+    }
+
+    #[test]
+    fn malformed_yaml_reports_parse_error() {
+        let errs = validate_annotation_yaml("annotations: [unterminated").unwrap_err();
+        assert_eq!(errs.len(), 1);
+        assert!(errs[0].contains("YAML parse error"));
+    }
+
+    #[test]
+    fn law_id_from_source_takes_the_host_segment() {
+        assert_eq!(
+            law_id_from_source("regelrecht://zorgtoeslagwet"),
+            Some("zorgtoeslagwet")
+        );
+        assert_eq!(
+            law_id_from_source("regelrecht://zorgtoeslagwet/hoogte#out"),
+            Some("zorgtoeslagwet")
+        );
+        assert_eq!(law_id_from_source("https://example.com/x"), None);
+    }
+
+    #[test]
+    fn note_target_law_ids_are_distinct_and_sorted() {
+        let yaml = format!(
+            r#"
+$schema: "{SCHEMA_URL}"
+annotations:
+  - type: Annotation
+    motivation: commenting
+    target:
+      source: "regelrecht://zorgtoeslagwet"
+      selector: {{ type: TextQuoteSelector, exact: a }}
+    body: {{ type: TextualBody, value: x, purpose: commenting }}
+  - type: Annotation
+    motivation: linking
+    target:
+      source: "regelrecht://andere_wet/hoogte"
+      selector: {{ type: TextQuoteSelector, exact: b }}
+    body: {{ type: SpecificResource, source: "regelrecht://andere_wet/x#y", purpose: linking }}
+  - type: Annotation
+    motivation: commenting
+    target:
+      source: "regelrecht://zorgtoeslagwet"
+      selector: {{ type: TextQuoteSelector, exact: c }}
+    body: {{ type: TextualBody, value: z, purpose: commenting }}
+"#
+        );
+        let doc = parse_and_validate_annotation_yaml(&yaml).expect("schema-valid fixture");
+        assert_eq!(
+            note_target_law_ids(&doc),
+            vec!["andere_wet".to_string(), "zorgtoeslagwet".to_string()]
+        );
+    }
+}

--- a/packages/corpus/src/annotation_schema.rs
+++ b/packages/corpus/src/annotation_schema.rs
@@ -1,15 +1,20 @@
 //! Note (annotation) YAML schema validation.
 //!
 //! The editor write path (`PUT /api/corpus/laws/{id}/annotations`) must
-//! reject a malformed note file *before* a commit and PR are created —
-//! once a branch exists, an invalid file is a dead PR someone has to clean
-//! up. This is the technical half of the two-layer review: schema
-//! correctness is enforced here, resolve correctness (orphaned/ambiguous
-//! selectors) stays a warning in `validate-annotations` per RFC-018 §8.
+//! reject a malformed note file before a commit and PR are created. Once a
+//! branch exists, an invalid file is a dead PR someone has to clean up.
+//! This is the technical half of the two-layer review: schema correctness
+//! is enforced here, resolve correctness (orphaned/ambiguous selectors)
+//! stays a warning in `validate-annotations` per RFC-018 §8.
 //!
-//! The same schema is embedded by the `validate-annotations` engine binary.
-//! Keeping a second compiled copy here avoids editor-api depending on the
-//! engine crate; the schema file itself is the single source of truth.
+//! NOTE: this is a *second* embedded copy of
+//! `schema/v0.5.2/annotation-schema.json`. The `validate-annotations`
+//! engine binary embeds the same file independently (it does not call this
+//! module), so editor-api need not depend on the engine crate. The JSON
+//! file is the single source of truth; the duplication is a known drift
+//! risk. `schema_compiles` pins this copy at build time; the engine binary
+//! pins the other. If they ever diverge, the file is what is authoritative
+//! and both `include_str!`s must point at it.
 
 use std::sync::LazyLock;
 
@@ -20,9 +25,9 @@ use jsonschema::Validator;
 const ANNOTATION_SCHEMA: &str = include_str!("../../../schema/v0.5.2/annotation-schema.json");
 
 /// Compiled once on first use. The embedded schema not compiling is a
-/// build/release fault, not a per-request one — but the workspace bans
+/// build/release fault, not a per-request one, but the workspace bans
 /// `expect()`, so init is total: the error is carried in the `Result` and
-/// surfaced from [`validate_annotation_yaml`]. `schema_compiles` pins the
+/// surfaced from [`validate_annotation_doc`]. `schema_compiles` pins the
 /// build-time guarantee that this `Err` arm is unreachable in practice.
 static VALIDATOR: LazyLock<Result<Validator, String>> = LazyLock::new(|| {
     let schema: serde_json::Value = serde_json::from_str(ANNOTATION_SCHEMA)
@@ -70,13 +75,6 @@ pub fn validate_annotation_doc(doc: &serde_json::Value) -> Result<(), Vec<String
     }
 }
 
-/// Validate without keeping the parsed document. Thin wrapper over
-/// [`parse_and_validate_annotation_yaml`] for callers that only need the
-/// pass/fail (e.g. the `validate-annotations` style check).
-pub fn validate_annotation_yaml(yaml: &str) -> Result<(), Vec<String>> {
-    parse_and_validate_annotation_yaml(yaml).map(|_| ())
-}
-
 /// Serialise a sidecar document back to YAML for writing.
 ///
 /// The editor write path builds the merged document as JSON in-memory;
@@ -121,17 +119,26 @@ pub enum AppendOutcome {
 /// and the new notes are appended as text.
 ///
 /// - Base has an `annotations:` block: serialise only the *new, deduped*
-///   notes as a YAML sequence, re-indent to the sidecar's 2-space list
-///   convention, and append after the existing content. Existing bytes are
-///   untouched, so the git diff is exactly the added lines.
+///   notes as a YAML sequence, re-indent by two spaces, and append after
+///   the existing content. Existing bytes are untouched, so the git diff
+///   is exactly the added lines.
 /// - No base, or a base without an `annotations:` key (nothing to
 ///   preserve): build a fresh full document. There is no history or
 ///   comment to protect in that case.
 /// - All new notes already present: [`AppendOutcome::NoChange`].
 ///
+/// Format assumption: the 2-space re-indent produces a valid file only
+/// when the base uses the 2-space LF list convention every corpus tool
+/// emits (`js-yaml` export, `serde_yaml_ng`, the committed sidecars). A
+/// hand-edited base with 4-space indent, a flow sequence, or CRLF endings
+/// would yield a malformed or mixed-ending result. This is **not** a
+/// silent corruption: the caller re-parses and schema-validates the
+/// produced text, so such a base fails the save loudly rather than
+/// committing garbage. It is a hard stop on an exotic layout, not a
+/// "preserves any file" guarantee.
+///
 /// `new_notes` are assumed schema-checked by the caller; the caller must
-/// still validate the *resulting* document (a malformed base would
-/// otherwise pass through).
+/// still validate the *resulting* document.
 pub fn append_notes_to_sidecar(
     base_text: Option<&str>,
     new_notes: &[serde_json::Value],
@@ -300,7 +307,7 @@ annotations:
       purpose: commenting
 "#
         );
-        assert!(validate_annotation_yaml(&yaml).is_ok());
+        assert!(parse_and_validate_annotation_yaml(&yaml).is_ok());
     }
 
     #[test]
@@ -314,13 +321,13 @@ annotations:
     motivation: commenting
 "#
         );
-        let errs = validate_annotation_yaml(&yaml).unwrap_err();
+        let errs = parse_and_validate_annotation_yaml(&yaml).unwrap_err();
         assert!(!errs.is_empty());
     }
 
     #[test]
     fn malformed_yaml_reports_parse_error() {
-        let errs = validate_annotation_yaml("annotations: [unterminated").unwrap_err();
+        let errs = parse_and_validate_annotation_yaml("annotations: [unterminated").unwrap_err();
         assert_eq!(errs.len(), 1);
         assert!(errs[0].contains("YAML parse error"));
     }

--- a/packages/corpus/src/annotation_schema.rs
+++ b/packages/corpus/src/annotation_schema.rs
@@ -42,18 +42,29 @@ static VALIDATOR: LazyLock<Result<Validator, String>> = LazyLock::new(|| {
 /// name lands in the path) and that flows into UI dialogs — the same
 /// self-XSS vector `save_law` avoids by not echoing the request `$id`.
 pub fn parse_and_validate_annotation_yaml(yaml: &str) -> Result<serde_json::Value, Vec<String>> {
-    let validator = VALIDATOR.as_ref().map_err(|e| vec![e.clone()])?;
-
     let doc: serde_json::Value =
         serde_yaml_ng::from_str(yaml).map_err(|e| vec![format!("YAML parse error: {e}")])?;
+    validate_annotation_doc(&doc)?;
+    Ok(doc)
+}
+
+/// Validate an already-parsed sidecar document against the note schema.
+///
+/// Used by the editor write path, which builds the merged document
+/// in-memory (base notes from the branch + new notes) and must validate
+/// the *result* before it is written. Same error-handling caveat as
+/// [`parse_and_validate_annotation_yaml`]: log the errors, do not echo
+/// them to the client.
+pub fn validate_annotation_doc(doc: &serde_json::Value) -> Result<(), Vec<String>> {
+    let validator = VALIDATOR.as_ref().map_err(|e| vec![e.clone()])?;
 
     let errors: Vec<String> = validator
-        .iter_errors(&doc)
+        .iter_errors(doc)
         .map(|err| format!("{}: {}", err.instance_path(), err))
         .collect();
 
     if errors.is_empty() {
-        Ok(doc)
+        Ok(())
     } else {
         Err(errors)
     }
@@ -64,6 +75,16 @@ pub fn parse_and_validate_annotation_yaml(yaml: &str) -> Result<serde_json::Valu
 /// pass/fail (e.g. the `validate-annotations` style check).
 pub fn validate_annotation_yaml(yaml: &str) -> Result<(), Vec<String>> {
     parse_and_validate_annotation_yaml(yaml).map(|_| ())
+}
+
+/// Serialise a sidecar document back to YAML for writing.
+///
+/// The editor write path builds the merged document as JSON in-memory;
+/// the on-disk corpus format is YAML. Centralised here so the dump options
+/// (block style, no anchors) stay consistent with the frontend export and
+/// the committed files, keeping git diffs readable.
+pub fn serialize_annotation_doc(doc: &serde_json::Value) -> Result<String, String> {
+    serde_yaml_ng::to_string(doc).map_err(|e| format!("failed to serialise notes: {e}"))
 }
 
 /// The law id a note's `target.source` URI refers to.
@@ -77,27 +98,52 @@ pub fn law_id_from_source(source: &str) -> Option<&str> {
     Some(rest.split('/').next().unwrap_or(rest))
 }
 
-/// Every distinct law id referenced by the notes in a (schema-valid)
-/// document's `target.source`. Used to reject a note file whose contents
-/// are about a different law than the path it is being written to —
-/// the note-side analogue of `save_law`'s `$id`/path-mismatch guard.
-pub fn note_target_law_ids(doc: &serde_json::Value) -> Vec<String> {
-    let Some(notes) = doc.get("annotations").and_then(|v| v.as_array()) else {
-        return Vec::new();
-    };
-    let mut ids: Vec<String> = notes
-        .iter()
-        .filter_map(|n| {
-            n.get("target")
-                .and_then(|t| t.get("source"))
-                .and_then(|s| s.as_str())
-                .and_then(law_id_from_source)
-                .map(str::to_string)
-        })
-        .collect();
-    ids.sort();
-    ids.dedup();
-    ids
+/// Why a note's `target.source` is not an acceptable reference to the law
+/// the sidecar is being written for.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NoteTargetError {
+    /// `target.source` absent or not a string (schema permits any string).
+    Unparseable,
+    /// `target.source` is a string but not a `regelrecht://<law_id>` URI.
+    NotRegelrechtUri,
+    /// Parsed to a law id, but a *different* one than expected.
+    WrongLaw(String),
+}
+
+/// Reject the sidecar unless **every** note's `target.source` resolves to
+/// exactly `law_id`.
+///
+/// This is an *allowlist*, deliberately: an earlier version collected the
+/// parseable law ids and looked for a mismatch, which silently let a note
+/// whose source was `https://evil/...` or absent slip through (the schema
+/// only requires `target.source` to be *a string*, no `regelrecht://`
+/// pattern). RFC-018 §1 keys the sidecar by law id — one file is one law's
+/// notes — so anything that does not provably refer to `law_id` is
+/// rejected, the note-side analogue of `save_law`'s `$id`/path guard.
+/// Returns the first offending note (by array index) and why.
+pub fn first_note_not_targeting_law(
+    doc: &serde_json::Value,
+    law_id: &str,
+) -> Option<(usize, NoteTargetError)> {
+    let notes = doc.get("annotations").and_then(|v| v.as_array())?;
+    for (i, note) in notes.iter().enumerate() {
+        let source = note
+            .get("target")
+            .and_then(|t| t.get("source"))
+            .and_then(|s| s.as_str());
+        let err = match source {
+            None => Some(NoteTargetError::Unparseable),
+            Some(s) => match law_id_from_source(s) {
+                None => Some(NoteTargetError::NotRegelrechtUri),
+                Some(id) if id == law_id => None,
+                Some(id) => Some(NoteTargetError::WrongLaw(id.to_string())),
+            },
+        };
+        if let Some(e) = err {
+            return Some((i, e));
+        }
+    }
+    None
 }
 
 #[cfg(test)]
@@ -173,35 +219,50 @@ annotations:
     }
 
     #[test]
-    fn note_target_law_ids_are_distinct_and_sorted() {
-        let yaml = format!(
-            r#"
-$schema: "{SCHEMA_URL}"
-annotations:
-  - type: Annotation
-    motivation: commenting
-    target:
-      source: "regelrecht://zorgtoeslagwet"
-      selector: {{ type: TextQuoteSelector, exact: a }}
-    body: {{ type: TextualBody, value: x, purpose: commenting }}
-  - type: Annotation
-    motivation: linking
-    target:
-      source: "regelrecht://andere_wet/hoogte"
-      selector: {{ type: TextQuoteSelector, exact: b }}
-    body: {{ type: SpecificResource, source: "regelrecht://andere_wet/x#y", purpose: linking }}
-  - type: Annotation
-    motivation: commenting
-    target:
-      source: "regelrecht://zorgtoeslagwet"
-      selector: {{ type: TextQuoteSelector, exact: c }}
-    body: {{ type: TextualBody, value: z, purpose: commenting }}
-"#
-        );
-        let doc = parse_and_validate_annotation_yaml(&yaml).expect("schema-valid fixture");
+    fn first_note_not_targeting_law_is_an_allowlist() {
+        // All on-law → None.
+        let ok = serde_json::json!({"annotations": [
+            {"target": {"source": "regelrecht://zorgtoeslagwet"}},
+            {"target": {"source": "regelrecht://zorgtoeslagwet/hoogte#x"}},
+        ]});
+        assert_eq!(first_note_not_targeting_law(&ok, "zorgtoeslagwet"), None);
+
+        // A different law → WrongLaw at its index.
+        let wrong = serde_json::json!({"annotations": [
+            {"target": {"source": "regelrecht://zorgtoeslagwet"}},
+            {"target": {"source": "regelrecht://andere_wet"}},
+        ]});
         assert_eq!(
-            note_target_law_ids(&doc),
-            vec!["andere_wet".to_string(), "zorgtoeslagwet".to_string()]
+            first_note_not_targeting_law(&wrong, "zorgtoeslagwet"),
+            Some((1, NoteTargetError::WrongLaw("andere_wet".to_string())))
+        );
+
+        // Non-regelrecht:// source must be REJECTED, not silently skipped
+        // (the bypass the hostile review found).
+        let evil = serde_json::json!({"annotations": [
+            {"target": {"source": "https://evil/zorgtoeslagwet"}},
+        ]});
+        assert_eq!(
+            first_note_not_targeting_law(&evil, "zorgtoeslagwet"),
+            Some((0, NoteTargetError::NotRegelrechtUri))
+        );
+
+        // Absent target.source → Unparseable, also rejected.
+        let bare = serde_json::json!({"annotations": [{"target": {}}]});
+        assert_eq!(
+            first_note_not_targeting_law(&bare, "zorgtoeslagwet"),
+            Some((0, NoteTargetError::Unparseable))
+        );
+
+        // Empty / absent array is vacuously fine — the destructive-shrink
+        // guard, not this function, handles an empty body.
+        assert_eq!(
+            first_note_not_targeting_law(&serde_json::json!({"annotations": []}), "x"),
+            None
+        );
+        assert_eq!(
+            first_note_not_targeting_law(&serde_json::json!({}), "x"),
+            None
         );
     }
 }

--- a/packages/corpus/src/lib.rs
+++ b/packages/corpus/src/lib.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "annotation-validation")]
+pub mod annotation_schema;
 pub mod auth;
 pub mod backend;
 pub mod client;

--- a/packages/editor-api/Cargo.toml
+++ b/packages/editor-api/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 axum.workspace = true
 regelrecht-auth = { path = "../auth" }
 regelrecht-shared = { path = "../shared", features = ["telemetry"] }
-regelrecht-corpus = { path = "../corpus", features = ["github"] }
+regelrecht-corpus = { path = "../corpus", features = ["github", "annotation-validation"] }
 regelrecht-pipeline = { path = "../pipeline" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tower-http = { workspace = true, features = ["fs", "trace"] }

--- a/packages/editor-api/Cargo.toml
+++ b/packages/editor-api/Cargo.toml
@@ -39,6 +39,7 @@ url.workspace = true
 [dev-dependencies]
 regelrecht-pipeline = { path = "../pipeline", features = ["test-utils"] }
 pretty_assertions.workspace = true
+tempfile.workspace = true
 
 [lints]
 workspace = true

--- a/packages/editor-api/Cargo.toml
+++ b/packages/editor-api/Cargo.toml
@@ -31,6 +31,7 @@ sqlx = { workspace = true, features = ["runtime-tokio", "tls-rustls", "postgres"
 uuid = { workspace = true, features = ["v4"] }
 serde.workspace = true
 serde_json.workspace = true
+serde_yaml_ng.workspace = true
 time.workspace = true
 tracing.workspace = true
 url.workspace = true

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -10,6 +10,10 @@ use tower_sessions::Session;
 use uuid::Uuid;
 
 use regelrecht_auth::handlers::{SESSION_KEY_EMAIL, SESSION_KEY_NAME, SESSION_KEY_SUB};
+use regelrecht_corpus::annotation_schema::{
+    append_notes_to_sidecar, first_note_not_targeting_law, parse_and_validate_annotation_yaml,
+    validate_annotation_doc, AppendOutcome,
+};
 use regelrecht_corpus::backend::{EditorUser, PersistOutcome, RepoBackend, WriteContext};
 use regelrecht_corpus::dto::{build_source_summaries, PaginationParams, SourceSummary};
 use regelrecht_corpus::source_map::{
@@ -30,6 +34,13 @@ use crate::trajects::read_active_from_session;
 #[derive(Debug, Serialize)]
 pub struct SaveResponse {
     pub pr: Option<SavePrInfo>,
+    /// `true` when a notes save was a no-op: every submitted note was
+    /// already present on the branch, so nothing was written/committed.
+    /// Lets the frontend show "al opgeslagen" and keep any existing PR
+    /// badge instead of treating a PR-less 200 as a lost save (review
+    /// finding NEW-2). Always `false` for law/scenario saves; those
+    /// clients ignore it.
+    pub no_change: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -672,6 +683,29 @@ async fn resolve_traject_scenario_target(
     })
 }
 
+/// Resolve the write target for a law's stand-off notes sidecar within the
+/// active traject.
+///
+/// The path is `annotations/{law_id}/annotations.yaml` at the source root,
+/// NOT under the law's own `regulation/...` directory: RFC-018 §1 keys the
+/// sidecar by law id, independent of where the law file lives. Routing,
+/// writability and membership checks all come from `resolve_traject_law_write`
+/// (same backend the law/scenario writes use), so notes land in the same
+/// traject branch/PR as the rest of the edits in the session.
+async fn resolve_traject_annotation_target(
+    state: &AppState,
+    session: &Session,
+    law_id: &str,
+) -> Result<EditorWriteTarget, (StatusCode, String)> {
+    let (_law, backend) = resolve_traject_law_write(state, session, law_id).await?;
+    Ok(EditorWriteTarget {
+        relative_path: PathBuf::from("annotations")
+            .join(law_id)
+            .join("annotations.yaml"),
+        backend,
+    })
+}
+
 /// Build a [`SaveResponse`] for a traject write. Traject backends commit
 /// straight to the configured branch without opening a PR for now, so the
 /// outcome typically carries `pr: None` and the response is just `{ pr:
@@ -683,6 +717,7 @@ fn save_response_from_traject(outcome: PersistOutcome) -> SaveResponse {
             url: pr.html_url,
             number: pr.number,
         }),
+        no_change: false,
     }
 }
 
@@ -718,6 +753,182 @@ pub async fn save_scenario(
         })
         .await
         .map_err(corpus_write_error("scenario"))?;
+
+    Ok(Json(save_response_from_traject(outcome)))
+}
+
+/// Schema the produced notes document is validated against before it is
+/// written. Must match the version embedded in `regelrecht-corpus`'
+/// annotation validator (kept in lockstep with the engine's resolver).
+const ANNOTATION_SCHEMA_URL: &str = "https://raw.githubusercontent.com/MinBZK/regelrecht/refs/heads/main/schema/v0.5.2/annotation-schema.json";
+
+/// Upper bound on notes accepted in a single save. The body limit on the
+/// route already caps raw size; this caps the *count* so a single request
+/// cannot append an unreasonable number of notes in one commit.
+const MAX_NOTES_PER_SAVE: usize = 500;
+
+/// PUT /api/corpus/laws/{law_id}/annotations — append stand-off notes.
+///
+/// Requires an active traject, exactly like `save_law`/`save_scenario`:
+/// the notes land in that traject's writable backend (its branch), so a
+/// note and a law edit made in the same session ride the same PR. Without
+/// an active traject the underlying `resolve_traject_law_write` returns 403.
+///
+/// The body is a JSON array of *new* notes (drafts). The handler reads the
+/// sidecar as it stands on the traject branch and appends only the new,
+/// deduped notes, keeping the existing bytes verbatim (RFC-018 Dec. 1 /
+/// RFC-005: per-note `git blame` and the curated motivering comments must
+/// survive). Error bodies are deliberately generic — schema instance paths
+/// can echo attacker-controlled map keys and would flow into an nldd
+/// dialog (the self-XSS vector `save_law` also avoids).
+pub async fn save_annotations(
+    State(state): State<AppState>,
+    session: Session,
+    Path(law_id): Path<String>,
+    body: String,
+) -> Result<Json<SaveResponse>, (StatusCode, String)> {
+    let author = editor_user_from_session(&session).await;
+
+    // Body is a JSON array of new notes. Parse + bound it before touching
+    // the backend.
+    let new_notes: Vec<serde_json::Value> = serde_json::from_str(&body).map_err(|e| {
+        tracing::debug!(law_id = %law_id, error = %e, "save_annotations: body is not a JSON note array");
+        (
+            StatusCode::BAD_REQUEST,
+            "Request body must be a JSON array of notes".to_string(),
+        )
+    })?;
+    if new_notes.len() > MAX_NOTES_PER_SAVE {
+        return Err((
+            StatusCode::PAYLOAD_TOO_LARGE,
+            format!("Too many notes in one save (max {})", MAX_NOTES_PER_SAVE),
+        ));
+    }
+
+    let target = resolve_traject_annotation_target(&state, &session, &law_id).await?;
+    let EditorWriteTarget {
+        relative_path,
+        backend,
+    } = target;
+
+    // Read the current sidecar from the traject backend (the branch this
+    // traject's PR is built on — read-your-writes within the traject).
+    // Absent file = first notes for this law.
+    let base_text: Option<String> = backend
+        .read_file(&relative_path)
+        .await
+        .map_err(corpus_write_error("annotations"))?;
+
+    // Validate the EXISTING file first, before merging in the new notes.
+    // The post-merge validation below cannot tell "your note is invalid"
+    // from "the file on the branch was already invalid" — same generic
+    // message for both, so a user with a perfectly good note would edit it
+    // forever while the real fault is a pre-existing note they did not
+    // write. Schema drift on a committed sidecar is rare, but when it
+    // happens the user must get a distinct, actionable error. Accepted
+    // limitation documented in RFC-018 §10.
+    if let Some(text) = base_text.as_deref() {
+        if !text.trim().is_empty() {
+            if let Err(errors) = parse_and_validate_annotation_yaml(text) {
+                tracing::warn!(
+                    law_id = %law_id,
+                    errors = ?errors,
+                    "save_annotations: existing sidecar fails the current schema; blocking append"
+                );
+                return Err((
+                    StatusCode::CONFLICT,
+                    "The notes file on the branch is itself invalid against the \
+                     current schema. This is not a problem with your note; the \
+                     existing file must be repaired before new notes can be added."
+                        .to_string(),
+                ));
+            }
+        }
+    }
+
+    // Append-only: keep the base file's bytes verbatim (preserves the
+    // curated motivering comments and per-note git blame, RFC-018 Dec. 1 /
+    // RFC-005) and append only the new, deduped notes. NoChange short-
+    // circuits the whole write/commit so a no-op save is silent.
+    let new_text =
+        match append_notes_to_sidecar(base_text.as_deref(), &new_notes, ANNOTATION_SCHEMA_URL)
+            .map_err(|e| {
+                tracing::error!(law_id = %law_id, error = %e, "save_annotations: append failed");
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Failed to prepare notes for writing".to_string(),
+                )
+            })? {
+            AppendOutcome::NoChange => {
+                // Nothing new survived dedup (re-save of already-committed
+                // notes). Skip write/commit entirely — no empty commit, no
+                // branch noise (review finding NEW-2). `no_change: true` tells
+                // the frontend to show "al opgeslagen" and keep the existing
+                // PR badge instead of treating a PR-less 200 as a lost save.
+                tracing::debug!(law_id = %law_id, "save_annotations: no new notes, skipping write");
+                return Ok(Json(SaveResponse {
+                    pr: None,
+                    no_change: true,
+                }));
+            }
+            AppendOutcome::Write(text) => text,
+        };
+
+    // Validate the *resulting* document. The base was already validated
+    // separately above (a pre-existing-invalid file returns a distinct
+    // 409), so a failure here means the newly submitted notes are bad, or
+    // serialisation produced something off. Detailed errors are logged,
+    // never returned (self-XSS stance, as `save_law`).
+    let doc: serde_json::Value = serde_yaml_ng::from_str(&new_text).map_err(|e| {
+        tracing::error!(law_id = %law_id, error = %e, "save_annotations: produced YAML does not parse");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Produced an invalid notes file".to_string(),
+        )
+    })?;
+    if let Err(errors) = validate_annotation_doc(&doc) {
+        tracing::debug!(
+            law_id = %law_id,
+            errors = ?errors,
+            "save_annotations rejected: resulting document failed schema validation"
+        );
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "Notes are not valid against the annotation schema".to_string(),
+        ));
+    }
+
+    // Every note must be about the law this path writes to (RFC-018 §1
+    // keys the sidecar by law id). Allowlist, not blocklist: a note whose
+    // `target.source` is absent or not a parseable `regelrecht://{law_id}`
+    // is rejected, not silently ignored — the note-side analogue of
+    // `save_law`'s `$id`/path guard. Runs on the merged result so a hostile
+    // appended note cannot reference another law.
+    if let Some((idx, err)) = first_note_not_targeting_law(&doc, &law_id) {
+        tracing::debug!(
+            law_id = %law_id,
+            note_index = idx,
+            reason = ?err,
+            "save_annotations rejected: a note's target.source does not resolve to this law"
+        );
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "A note's target does not match the law it is being saved to".to_string(),
+        ));
+    }
+
+    backend
+        .write_file(&relative_path, &new_text)
+        .await
+        .map_err(corpus_write_error("annotations"))?;
+
+    let outcome = backend
+        .persist(&WriteContext {
+            message: format!("Notities bijgewerkt voor {}", law_id),
+            author,
+        })
+        .await
+        .map_err(corpus_write_error("annotations"))?;
 
     Ok(Json(save_response_from_traject(outcome)))
 }
@@ -950,5 +1161,7 @@ mod tests {
     fn save_response_from_traject_returns_none_for_plain_commit() {
         let body = save_response_from_traject(PersistOutcome { pr: None });
         assert!(body.pr.is_none());
+        // Law/scenario saves are never a notes no-op.
+        assert!(!body.no_change);
     }
 }

--- a/packages/editor-api/src/lib.rs
+++ b/packages/editor-api/src/lib.rs
@@ -7,6 +7,7 @@
 
 pub mod accounts;
 pub mod config;
+pub mod corpus_handlers;
 pub mod state;
 pub mod traject_corpus;
 pub mod trajects;

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -187,6 +187,11 @@ async fn main() {
                 .layer(axum::extract::DefaultBodyLimit::max(MAX_LAW_BODY)),
         )
         .route(
+            "/api/corpus/laws/{law_id}/annotations",
+            axum::routing::put(corpus_handlers::save_annotations)
+                .layer(axum::extract::DefaultBodyLimit::max(MAX_SCENARIO_BODY)),
+        )
+        .route(
             "/api/favorites/{law_id}",
             axum::routing::put(favorites::add).delete(favorites::remove),
         )

--- a/packages/editor-api/tests/save_annotations_test.rs
+++ b/packages/editor-api/tests/save_annotations_test.rs
@@ -1,0 +1,286 @@
+//! Integration tests for the traject-routed notes write path
+//! (`corpus_handlers::save_annotations`).
+//!
+//! This is the first end-to-end coverage of the traject save path at all:
+//! #632 shipped the traject model with handler-CRUD tests only, and PR
+//! #652's earlier tests were against the deleted per-session backend. The
+//! path is hard to exercise by hand locally (it needs an authenticated
+//! user + an active traject, and OIDC is off in the local stack), so it
+//! is pinned here instead.
+//!
+//! Each test spins up an isolated Postgres container via
+//! `regelrecht_pipeline::test_utils::TestDb` (so `0014_trajects.sql` runs
+//! for real) and a hermetic, **local** writable-own traject source backed
+//! by a `tempfile` corpus — no GitHub clone, no network. The handler is
+//! called directly with inline `axum` extractors, exactly like
+//! `trajects_test.rs`.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::Json;
+use pretty_assertions::assert_eq;
+use sqlx::PgPool;
+use tokio::sync::{Mutex, RwLock};
+use tower_sessions::Session;
+use tower_sessions_memory_store::MemoryStore;
+use uuid::Uuid;
+
+use regelrecht_auth::handlers::SESSION_KEY_SUB;
+use regelrecht_editor_api::config::AppConfig;
+use regelrecht_editor_api::corpus_handlers::{save_annotations, SaveResponse};
+use regelrecht_editor_api::state::{AppState, CorpusState};
+use regelrecht_editor_api::traject_corpus::TrajectCorpusCache;
+use regelrecht_editor_api::trajects::SESSION_KEY_ACTIVE_TRAJECT;
+
+use regelrecht_pipeline::test_utils::TestDb;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const LAW_ID: &str = "zorgtoeslagwet";
+
+fn empty_state(pool: PgPool) -> AppState {
+    AppState {
+        corpus: Arc::new(RwLock::new(CorpusState::empty())),
+        oidc_client: None,
+        end_session_url: None,
+        config: Arc::new(AppConfig {
+            oidc: None,
+            base_url: None,
+        }),
+        http_client: reqwest::Client::new(),
+        pool: Some(pool),
+        pipeline_api_url: None,
+        reload_lock: Arc::new(Mutex::new(())),
+        trajects: Arc::new(TrajectCorpusCache::new()),
+        favorites: Arc::new(HashSet::new()),
+    }
+}
+
+/// Seed an account and return its `person_sub` (what the session carries).
+async fn seed_account(pool: &PgPool, email: &str) -> (Uuid, String) {
+    let sub = format!("sub-{email}");
+    let (id,): (Uuid,) = sqlx::query_as(
+        "INSERT INTO accounts (person_sub, email, name) VALUES ($1, $2, $3) RETURNING id",
+    )
+    .bind(&sub)
+    .bind(email)
+    .bind("Test User")
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    (id, sub)
+}
+
+/// A minimal but schema-valid law file so the source map's `$id` scan
+/// resolves `LAW_ID` to a file with a `relative_path`.
+fn write_law(corpus_dir: &std::path::Path) {
+    let law_dir = corpus_dir.join("wet").join(LAW_ID);
+    std::fs::create_dir_all(&law_dir).unwrap();
+    std::fs::write(
+        law_dir.join("2025-01-01.yaml"),
+        format!("$id: {LAW_ID}\nname: Zorgtoeslagwet\n"),
+    )
+    .unwrap();
+}
+
+/// One well-formed W3C annotation targeting `target_law`, as the browser
+/// would send it (no `__draft` marker — that is stripped client-side).
+fn note(target_law: &str, exact: &str) -> serde_json::Value {
+    serde_json::json!({
+        "type": "Annotation",
+        "motivation": "commenting",
+        "creator": "tester",
+        "target": {
+            "source": format!("regelrecht://{target_law}"),
+            "selector": { "type": "TextQuoteSelector", "exact": exact }
+        },
+        "body": { "type": "TextualBody", "value": "een toelichting", "purpose": "commenting" }
+    })
+}
+
+/// Create a traject with a single **local** writable-own source whose
+/// path is `corpus_dir`. No GitHub seed, so `build_traject_corpus` never
+/// touches the network. Returns the traject id; `owner_id` is made a
+/// member so the handler's membership re-check passes.
+async fn local_traject(pool: &PgPool, owner_id: Uuid, corpus_dir: &std::path::Path) -> Uuid {
+    let (traject_id,): (Uuid,) = sqlx::query_as(
+        "INSERT INTO trajects (name, description, scope, created_by)
+         VALUES ('Test', '', '', $1) RETURNING id",
+    )
+    .bind(owner_id)
+    .fetch_one(pool)
+    .await
+    .unwrap();
+
+    sqlx::query(
+        "INSERT INTO traject_members (traject_id, account_id, role)
+         VALUES ($1, $2, 'beheerder')",
+    )
+    .bind(traject_id)
+    .bind(owner_id)
+    .execute(pool)
+    .await
+    .unwrap();
+
+    // The local source is writable_own with no auth_ref: it writes back
+    // through its own backend (no write_target_for_source entry needed —
+    // the law is read from this very source).
+    sqlx::query(
+        "INSERT INTO traject_corpus_sources
+         (traject_id, source_id, name, source_type, local_path,
+          priority, scopes, is_writable_own)
+         VALUES ($1, 'local', 'Local', 'local'::corpus_source_type, $2,
+                 0, '[]'::jsonb, TRUE)",
+    )
+    .bind(traject_id)
+    .bind(corpus_dir.to_string_lossy().to_string())
+    .execute(pool)
+    .await
+    .unwrap();
+
+    traject_id
+}
+
+async fn session_for(sub: &str, traject_id: Option<Uuid>) -> Session {
+    let session = Session::new(None, Arc::new(MemoryStore::default()), None);
+    session.insert(SESSION_KEY_SUB, sub).await.unwrap();
+    if let Some(id) = traject_id {
+        session
+            .insert(SESSION_KEY_ACTIVE_TRAJECT, id)
+            .await
+            .unwrap();
+    }
+    session
+}
+
+fn sidecar_path(corpus_dir: &std::path::Path) -> std::path::PathBuf {
+    corpus_dir
+        .join("annotations")
+        .join(LAW_ID)
+        .join("annotations.yaml")
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn writes_a_note_to_the_traject_local_sidecar() {
+    let db = TestDb::new().await;
+    let state = empty_state(db.pool.clone());
+    let (owner, sub) = seed_account(&db.pool, "alice@test.local").await;
+
+    let corpus = tempfile::tempdir().unwrap();
+    write_law(corpus.path());
+    let traject_id = local_traject(&db.pool, owner, corpus.path()).await;
+    let session = session_for(&sub, Some(traject_id)).await;
+
+    let body = serde_json::to_string(&[note(LAW_ID, "zorgtoeslag")]).unwrap();
+    let Json(SaveResponse { pr, no_change }) =
+        save_annotations(State(state), session, Path(LAW_ID.to_string()), body)
+            .await
+            .expect("save should succeed");
+
+    // A local backend commits in place, no PR; the note is new, so it is
+    // not a no-op.
+    assert!(pr.is_none());
+    assert!(!no_change);
+
+    // The sidecar landed at annotations/{law_id}/annotations.yaml under
+    // the source root and contains the note.
+    let written = std::fs::read_to_string(sidecar_path(corpus.path()))
+        .expect("sidecar must exist on the traject source");
+    let doc: serde_json::Value = serde_yaml_ng::from_str(&written).unwrap();
+    let notes = doc["annotations"].as_array().unwrap();
+    assert_eq!(notes.len(), 1);
+    assert_eq!(notes[0]["target"]["selector"]["exact"], "zorgtoeslag");
+}
+
+#[tokio::test]
+async fn no_active_traject_is_403() {
+    let db = TestDb::new().await;
+    let state = empty_state(db.pool.clone());
+    let (_owner, sub) = seed_account(&db.pool, "alice@test.local").await;
+    // Session has a subject but NO active traject.
+    let session = session_for(&sub, None).await;
+
+    let body = serde_json::to_string(&[note(LAW_ID, "x")]).unwrap();
+    let err = save_annotations(State(state), session, Path(LAW_ID.to_string()), body)
+        .await
+        .expect_err("must refuse without an active traject");
+
+    assert_eq!(err.0, StatusCode::FORBIDDEN, "{}", err.1);
+}
+
+#[tokio::test]
+async fn a_note_targeting_another_law_is_rejected() {
+    let db = TestDb::new().await;
+    let state = empty_state(db.pool.clone());
+    let (owner, sub) = seed_account(&db.pool, "alice@test.local").await;
+
+    let corpus = tempfile::tempdir().unwrap();
+    write_law(corpus.path());
+    let traject_id = local_traject(&db.pool, owner, corpus.path()).await;
+    let session = session_for(&sub, Some(traject_id)).await;
+
+    // The note's target.source points at a DIFFERENT law than the path.
+    let body = serde_json::to_string(&[note("andere_wet", "x")]).unwrap();
+    let err = save_annotations(State(state), session, Path(LAW_ID.to_string()), body)
+        .await
+        .expect_err("cross-law note must be rejected");
+
+    assert_eq!(err.0, StatusCode::BAD_REQUEST, "{}", err.1);
+    // And nothing was written.
+    assert!(!sidecar_path(corpus.path()).exists());
+}
+
+#[tokio::test]
+async fn re_saving_an_already_committed_note_is_a_no_op() {
+    let db = TestDb::new().await;
+    let state = empty_state(db.pool.clone());
+    let (owner, sub) = seed_account(&db.pool, "alice@test.local").await;
+
+    let corpus = tempfile::tempdir().unwrap();
+    write_law(corpus.path());
+    let traject_id = local_traject(&db.pool, owner, corpus.path()).await;
+
+    let body = serde_json::to_string(&[note(LAW_ID, "zorgtoeslag")]).unwrap();
+
+    // First save writes the note.
+    let session1 = session_for(&sub, Some(traject_id)).await;
+    let _ = save_annotations(
+        State(state.clone()),
+        session1,
+        Path(LAW_ID.to_string()),
+        body.clone(),
+    )
+    .await
+    .expect("first save ok");
+    let after_first = std::fs::read_to_string(sidecar_path(corpus.path())).unwrap();
+
+    // Second save of the SAME note: dedup leaves nothing, so no_change is
+    // reported and the file is byte-identical (no empty commit / churn).
+    let session2 = session_for(&sub, Some(traject_id)).await;
+    let Json(SaveResponse { pr, no_change }) =
+        save_annotations(State(state), session2, Path(LAW_ID.to_string()), body)
+            .await
+            .expect("second save ok");
+
+    assert!(pr.is_none());
+    assert!(
+        no_change,
+        "a re-save of an already-present note must be a no-op"
+    );
+    let after_second = std::fs::read_to_string(sidecar_path(corpus.path())).unwrap();
+    assert_eq!(
+        after_first, after_second,
+        "the sidecar must not change on a no-op re-save"
+    );
+}


### PR DESCRIPTION
## Wat

Sluit het uitgestelde schrijfpad uit RFC-018 §10. Notities werden lokaal in `localStorage` bewaard en moesten handmatig als YAML geëxporteerd en gecommit worden. Nu PUT't de editor de sidecar naar `editor-api`, dat 'm valideert en een PR opent — via hetzelfde per-`(sessie, source)` `SessionGitBackend` dat wet- en scenario-edits al gebruiken (RFC-010 §4 amendement). De "PR #N"-toolbarbadge werkt automatisch mee omdat de gedeelde `lastSavedPr`-ref hergebruikt wordt.

## Hoe

- **corpus**: optionele feature `annotation-validation`; nieuwe `annotation_schema`-module valideert tegen `schema/v0.5.2/annotation-schema.json` en levert de target-law-ids per notitie. `LazyLock<Result<Validator, String>>` i.p.v. `expect` (clippy-ban), met een `schema_compiles`-test als build-time-garantie.
- **editor-api**: `PUT /api/corpus/laws/{law_id}/annotations` spiegelt `save_law` (sessie, auth, `Co-Authored-By`, lock-ordering, foutmapping). Federated: optionele `?source=` kiest de doel-source met de source van de wet als standaard — een adviserende notitie van een andere org kan zo naar de eigen repo (RFC-018 §2). Schemavalidatie én een cross-law-target-check (de notitie-variant van `save_law`'s `$id`/pad-guard) gebeuren vóór elke write.
- **frontend**: `useDraftNotes.saveToRepo` PUT't de export, zet `lastSavedPr` en leegt de concepten bij succes; `EditorApp` krijgt een "Opslaan naar repo"-knop, source-dropdown en foutmelding. Export-YAML blijft als offline-pad.
- **.github/CODEOWNERS**: `corpus/annotations/` → `@MinBZK/regelrecht-team` als inhoudelijke reviewlaag. Schema/resolve-correctheid blijft `validate-annotations` in CI (warn-only voor orphaned/ambiguous per RFC-018 §8).

## Veiligheid

Schemafouten en de `?source=`-waarde gaan naar de log; de client krijgt een generieke 400/404 — geen attacker-controlled input in de respons, dezelfde stance die `save_law` bewust hanteert tegen self-XSS in de nldd-dialogen.

## Tests

- corpus `annotation_schema`: 6 unit-tests (compile, valid, missing-field, malformed, `law_id_from_source`, `note_target_law_ids`).
- editor-api: cross-law-mismatch detect/accept + pad-keying (RFC-018 §1).
- frontend `useDraftNotes`: `saveToRepo` URL, `?source=`, 400-behoudt-concepten, PR-set.
- `just check` volledig groen; 189 frontend-tests groen.

Self-review via code-reviewer-subagent: verdict REQUEST CHANGES, geen blockers; alle should-fix/nice-to-have/nit-punten verwerkt (cross-law-guard, generieke foutbodies, cache-asymmetrie gedocumenteerd, `exportYaml(id)`, CODEOWNERS-scope-comment).