### PR TITLE
feat(editor): /trajects/:id/docs read-only docs route (stubbed; depends on #632 + #626)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,6 +20,7 @@
         "@vue-flow/minimap": "^1.5.4",
         "dompurify": "^3.4.2",
         "marked": "^18.0.3",
+        "mermaid": "^11.4.1",
         "tiptap-markdown": "^0.9.0"
       },
       "devDependencies": {
@@ -32,6 +33,19 @@
         "vitest": "^4.1.5",
         "vue": "^3.5.34",
         "vue-router": "^5.0.6"
+      }
+    },
+    "node_modules/@antfu/install-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "package-manager-detector": "^1.3.0",
+        "tinyexec": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@babel/generator": {
@@ -96,6 +110,18 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@braintree/sanitize-url": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
+      "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
+      "license": "MIT"
+    },
+    "node_modules/@chevrotain/types": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
+      "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
+      "license": "Apache-2.0"
     },
     "node_modules/@cucumber/gherkin": {
       "version": "39.1.0",
@@ -184,6 +210,23 @@
         "url": "https://github.com/sponsors/ayuhito"
       }
     },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "license": "MIT"
+    },
+    "node_modules/@iconify/utils": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.3.tgz",
+      "integrity": "sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@antfu/install-pkg": "^1.1.0",
+        "@iconify/types": "^2.0.0",
+        "import-meta-resolve": "^4.2.0"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -264,6 +307,15 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
+    "node_modules/@mermaid-js/parser": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.1.tgz",
+      "integrity": "sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@chevrotain/types": "~11.1.1"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -1364,6 +1416,259 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
+      "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -1376,6 +1681,12 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "license": "MIT"
     },
     "node_modules/@types/linkify-it": {
@@ -1437,6 +1748,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@upsetjs/venn.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
+      "integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "d3-selection": "^3.0.0",
+        "d3-transition": "^3.0.1"
       }
     },
     "node_modules/@vitejs/plugin-vue": {
@@ -2116,6 +2437,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cose-base": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
+      "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^1.0.0"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2137,11 +2467,173 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/cytoscape": {
+      "version": "3.33.3",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.3.tgz",
+      "integrity": "sha512-Gej7U+OKR+LZ8kvX7rb2HhCYJ0IhvEFsnkud4SB1PR+BUY/TsSO0dmOW59WEVLu51b1Rm+gQRKoz4bLYxGSZ2g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/cytoscape-cose-bilkent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^1.0.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+      "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^2.2.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/cose-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
+      "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^2.0.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/layout-base": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
+      "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
+      "license": "MIT"
+    },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-color": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
       "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
       "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
       "engines": {
         "node": ">=12"
       }
@@ -2168,11 +2660,101 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/d3-ease": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
       "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
       "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
@@ -2189,11 +2771,152 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-sankey/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "license": "ISC"
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-selection": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
       "engines": {
         "node": ">=12"
       }
@@ -2240,6 +2963,31 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/dagre-d3-es": {
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
+      "integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "lodash-es": "^4.17.21"
+      }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "license": "MIT"
+    },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
       }
     },
     "node_modules/detect-libc": {
@@ -2312,6 +3060,16 @@
       "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
+      "integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/estree-walker": {
       "version": "3.0.3",
@@ -2412,6 +3170,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/hachure-fill": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
+      "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
+      "license": "MIT"
+    },
     "node_modules/happy-dom": {
       "version": "20.9.0",
       "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.9.0.tgz",
@@ -2437,11 +3201,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/immutable": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
       "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
       "license": "MIT"
+    },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/ini": {
       "version": "1.3.8",
@@ -2449,6 +3235,15 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -2576,6 +3371,42 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/khroma": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
+      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
+    },
+    "node_modules/layout-base": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
+      "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
+      "license": "MIT"
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -2902,6 +3733,12 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
@@ -2986,6 +3823,47 @@
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
       "license": "MIT"
+    },
+    "node_modules/mermaid": {
+      "version": "11.15.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.15.0.tgz",
+      "integrity": "sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@braintree/sanitize-url": "^7.1.1",
+        "@iconify/utils": "^3.0.2",
+        "@mermaid-js/parser": "^1.1.1",
+        "@types/d3": "^7.4.3",
+        "@upsetjs/venn.js": "^2.0.0",
+        "cytoscape": "^3.33.1",
+        "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-fcose": "^2.2.0",
+        "d3": "^7.9.0",
+        "d3-sankey": "^0.12.3",
+        "dagre-d3-es": "7.0.14",
+        "dayjs": "^1.11.19",
+        "dompurify": "^3.3.1",
+        "es-toolkit": "^1.45.1",
+        "katex": "^0.16.25",
+        "khroma": "^2.1.0",
+        "marked": "^16.3.0",
+        "roughjs": "^4.6.6",
+        "stylis": "^4.3.6",
+        "ts-dedent": "^2.2.0",
+        "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
+      }
+    },
+    "node_modules/mermaid/node_modules/marked": {
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
+      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/minimatch": {
       "version": "9.0.9",
@@ -3117,6 +3995,18 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/package-manager-detector": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
+      "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
+      "license": "MIT"
+    },
+    "node_modules/path-data-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+      "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
+      "license": "MIT"
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -3234,6 +4124,22 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/points-on-curve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
+      "license": "MIT"
+    },
+    "node_modules/points-on-path": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
+      "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+      "license": "MIT",
+      "dependencies": {
+        "path-data-parser": "0.1.0",
+        "points-on-curve": "0.2.0"
       }
     },
     "node_modules/postcss": {
@@ -3487,6 +4393,12 @@
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
       "license": "Apache-2.0"
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
+    },
     "node_modules/rolldown": {
       "version": "1.0.0-rc.18",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.18.tgz",
@@ -3532,6 +4444,30 @@
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
       "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
+      "license": "MIT"
+    },
+    "node_modules/roughjs": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
+      "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hachure-fill": "^0.5.2",
+        "path-data-parser": "^0.1.0",
+        "points-on-curve": "^0.2.0",
+        "points-on-path": "^0.2.1"
+      }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
     "node_modules/sass": {
@@ -3744,6 +4680,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/stylis": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
+      "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -3755,7 +4697,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
       "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -3804,6 +4745,15 @@
       },
       "peerDependencies": {
         "@tiptap/core": "^3.0.1"
+      }
+    },
+    "node_modules/ts-dedent": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
+      "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.10"
       }
     },
     "node_modules/tslib": {
@@ -3864,6 +4814,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sxzz"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,6 +26,7 @@
     "@vue-flow/minimap": "^1.5.4",
     "dompurify": "^3.4.2",
     "marked": "^18.0.3",
+    "mermaid": "^11.4.1",
     "tiptap-markdown": "^0.9.0"
   },
   "overrides": {

--- a/frontend/src/TrajectDocsApp.vue
+++ b/frontend/src/TrajectDocsApp.vue
@@ -1,0 +1,105 @@
+<script setup>
+// Root view for the /trajects/:trajectId/docs/:sourceId?/:path* route.
+//
+// Two-pane layout: DocsSidebar (left) lists the traject's corpus sources
+// and their docs trees; DocsContent (right) renders the currently-selected
+// page as markdown (+ mermaid).
+//
+// Selection state lives in the URL; clicks update the router and let route
+// reactivity drive the data refetch. That way refresh/back/forward all
+// work without local-state tricks.
+
+import { computed } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+
+import DocsSidebar from './components/docs/DocsSidebar.vue';
+import DocsContent from './components/docs/DocsContent.vue';
+import { useDocsPage, useDocsTree } from './composables/useDocs.js';
+
+const route = useRoute();
+const router = useRouter();
+
+const trajectId = computed(() => route.params.trajectId || '');
+const sourceId = computed(() => route.params.sourceId || '');
+const path = computed(() => {
+  const match = route.params.pathMatch;
+  if (Array.isArray(match)) return match.join('/');
+  return match || '';
+});
+
+const { tree, loading: treeLoading, error: treeError } = useDocsTree(trajectId);
+const {
+  text,
+  loading: pageLoading,
+  error: pageError,
+} = useDocsPage(trajectId, sourceId, path);
+
+function onSelect({ sourceId: src, path: p }) {
+  router.push({
+    name: 'traject-docs',
+    params: {
+      trajectId: trajectId.value,
+      sourceId: src,
+      pathMatch: p.split('/'),
+    },
+  });
+}
+
+const hasSelection = computed(() => sourceId.value && path.value);
+</script>
+
+<template>
+  <div class="traject-docs">
+    <DocsSidebar
+      :tree="tree"
+      :selected-source="sourceId"
+      :selected-path="path"
+      @select="onSelect"
+    />
+    <main class="docs-main">
+      <div v-if="treeError" class="error">
+        Kon docs-overzicht niet laden. Mogelijk ben je geen lid van dit traject.
+      </div>
+      <div v-else-if="!hasSelection && !treeLoading" class="placeholder">
+        <h1>Documentatie</h1>
+        <p>Kies een pagina links om te lezen.</p>
+      </div>
+      <div v-else-if="pageError" class="error">
+        Kon de pagina niet laden.
+      </div>
+      <div v-else-if="pageLoading" class="placeholder">Laden…</div>
+      <DocsContent v-else :text="text" />
+    </main>
+  </div>
+</template>
+
+<style scoped>
+.traject-docs {
+  display: grid;
+  grid-template-columns: minmax(220px, 280px) 1fr;
+  min-height: calc(100vh - var(--site-header-height, 56px));
+}
+
+.docs-main {
+  padding: 1.5rem 2rem;
+  overflow-x: hidden;
+}
+
+.placeholder {
+  color: var(--nldd-color-text-subtle, #666);
+}
+
+.error {
+  padding: 1rem;
+  background: var(--nldd-color-danger-subtle, #fdecea);
+  border-left: 4px solid var(--nldd-color-danger, #c1432a);
+  border-radius: 2px;
+  color: var(--nldd-color-danger-strong, #842c1e);
+}
+
+@media (max-width: 768px) {
+  .traject-docs {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/frontend/src/TrajectDocsApp.vue
+++ b/frontend/src/TrajectDocsApp.vue
@@ -1,13 +1,10 @@
 <script setup>
 // Root view for the /trajects/:trajectId/docs/:sourceId?/:path* route.
 //
-// Two-pane layout: DocsSidebar (left) lists the traject's corpus sources
-// and their docs trees; DocsContent (right) renders the currently-selected
-// page as markdown (+ mermaid).
-//
-// Selection state lives in the URL; clicks update the router and let route
-// reactivity drive the data refetch. That way refresh/back/forward all
-// work without local-state tricks.
+// Layout mirrors LibraryApp: `nldd-app-view` → `nldd-navigation-split-view`
+// with a navigation pane on the left (DocsSidebar) and the main pane on
+// the right (DocsContent). Selection state lives in the URL — clicks push
+// the route, and the route drives all data refetches via the composables.
 
 import { computed } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
@@ -27,7 +24,7 @@ const path = computed(() => {
   return match || '';
 });
 
-const { tree, loading: treeLoading, error: treeError } = useDocsTree(trajectId);
+const { tree, error: treeError } = useDocsTree(trajectId);
 const {
   text,
   loading: pageLoading,
@@ -49,57 +46,37 @@ const hasSelection = computed(() => sourceId.value && path.value);
 </script>
 
 <template>
-  <div class="traject-docs">
-    <DocsSidebar
-      :tree="tree"
-      :selected-source="sourceId"
-      :selected-path="path"
-      @select="onSelect"
-    />
-    <main class="docs-main">
-      <div v-if="treeError" class="error">
-        Kon docs-overzicht niet laden. Mogelijk ben je geen lid van dit traject.
-      </div>
-      <div v-else-if="!hasSelection && !treeLoading" class="placeholder">
-        <h1>Documentatie</h1>
-        <p>Kies een pagina links om te lezen.</p>
-      </div>
-      <div v-else-if="pageError" class="error">
-        Kon de pagina niet laden.
-      </div>
-      <div v-else-if="pageLoading" class="placeholder">Laden…</div>
-      <DocsContent v-else :text="text" />
-    </main>
-  </div>
+  <nldd-app-view>
+    <nldd-navigation-split-view>
+      <nldd-split-view-pane slot="navigation">
+        <nldd-container padding="12">
+          <DocsSidebar
+            :tree="tree"
+            :selected-source="sourceId"
+            :selected-path="path"
+            @select="onSelect"
+          />
+        </nldd-container>
+      </nldd-split-view-pane>
+
+      <nldd-split-view-pane>
+        <nldd-container padding="16">
+          <nldd-inline-dialog
+            v-if="treeError"
+            text="Kon docs-overzicht niet laden. Mogelijk ben je geen lid van dit traject."
+          ></nldd-inline-dialog>
+          <nldd-inline-dialog
+            v-else-if="!hasSelection"
+            text="Kies een pagina links om te lezen."
+          ></nldd-inline-dialog>
+          <nldd-inline-dialog
+            v-else-if="pageError"
+            text="Kon de pagina niet laden."
+          ></nldd-inline-dialog>
+          <nldd-inline-dialog v-else-if="pageLoading" text="Laden…"></nldd-inline-dialog>
+          <DocsContent v-else :text="text" />
+        </nldd-container>
+      </nldd-split-view-pane>
+    </nldd-navigation-split-view>
+  </nldd-app-view>
 </template>
-
-<style scoped>
-.traject-docs {
-  display: grid;
-  grid-template-columns: minmax(220px, 280px) 1fr;
-  min-height: calc(100vh - var(--site-header-height, 56px));
-}
-
-.docs-main {
-  padding: 1.5rem 2rem;
-  overflow-x: hidden;
-}
-
-.placeholder {
-  color: var(--nldd-color-text-subtle, #666);
-}
-
-.error {
-  padding: 1rem;
-  background: var(--nldd-color-danger-subtle, #fdecea);
-  border-left: 4px solid var(--nldd-color-danger, #c1432a);
-  border-radius: 2px;
-  color: var(--nldd-color-danger-strong, #842c1e);
-}
-
-@media (max-width: 768px) {
-  .traject-docs {
-    grid-template-columns: 1fr;
-  }
-}
-</style>

--- a/frontend/src/TrajectDocsApp.vue
+++ b/frontend/src/TrajectDocsApp.vue
@@ -48,34 +48,48 @@ const hasSelection = computed(() => sourceId.value && path.value);
 <template>
   <nldd-app-view>
     <nldd-navigation-split-view>
-      <nldd-split-view-pane slot="navigation">
-        <nldd-container padding="12">
-          <DocsSidebar
-            :tree="tree"
-            :selected-source="sourceId"
-            :selected-path="path"
-            @select="onSelect"
-          />
-        </nldd-container>
+      <!-- Sidebar pane. LibraryApp's nested split-view passes confirm the
+           slot is `sidebar` (not `navigation`) and the main content is the
+           default-slot pane without an explicit `slot=` attribute. -->
+      <nldd-split-view-pane slot="sidebar" has-content>
+        <nldd-page sticky-header>
+          <nldd-top-title-bar slot="header" text="Documentatie"></nldd-top-title-bar>
+          <nldd-simple-section width="full">
+            <DocsSidebar
+              :tree="tree"
+              :selected-source="sourceId"
+              :selected-path="path"
+              @select="onSelect"
+            />
+          </nldd-simple-section>
+        </nldd-page>
       </nldd-split-view-pane>
 
-      <nldd-split-view-pane>
-        <nldd-container padding="16">
-          <nldd-inline-dialog
-            v-if="treeError"
-            text="Kon docs-overzicht niet laden. Mogelijk ben je geen lid van dit traject."
-          ></nldd-inline-dialog>
-          <nldd-inline-dialog
-            v-else-if="!hasSelection"
-            text="Kies een pagina links om te lezen."
-          ></nldd-inline-dialog>
-          <nldd-inline-dialog
-            v-else-if="pageError"
-            text="Kon de pagina niet laden."
-          ></nldd-inline-dialog>
-          <nldd-inline-dialog v-else-if="pageLoading" text="Laden…"></nldd-inline-dialog>
-          <DocsContent v-else :text="text" />
-        </nldd-container>
+      <!-- Main content pane. nldd-navigation-split-view only reveals the
+           main pane when `has-content` is truthy (same gate LibraryApp uses
+           on its article pane); without it the pane stays collapsed and a
+           click on the sidebar shows nothing. We always have *something* to
+           show (placeholder / error / loading / page), so has-content is
+           effectively always true here. -->
+      <nldd-split-view-pane slot="main" has-content>
+        <nldd-page sticky-header>
+          <nldd-simple-section width="full">
+            <nldd-inline-dialog
+              v-if="treeError"
+              text="Kon docs-overzicht niet laden. Mogelijk ben je geen lid van dit traject."
+            ></nldd-inline-dialog>
+            <nldd-inline-dialog
+              v-else-if="!hasSelection"
+              text="Kies een pagina links om te lezen."
+            ></nldd-inline-dialog>
+            <nldd-inline-dialog
+              v-else-if="pageError"
+              text="Kon de pagina niet laden."
+            ></nldd-inline-dialog>
+            <nldd-inline-dialog v-else-if="pageLoading" text="Laden…"></nldd-inline-dialog>
+            <DocsContent v-else :text="text" />
+          </nldd-simple-section>
+        </nldd-page>
       </nldd-split-view-pane>
     </nldd-navigation-split-view>
   </nldd-app-view>

--- a/frontend/src/components/docs/DocsContent.vue
+++ b/frontend/src/components/docs/DocsContent.vue
@@ -1,16 +1,17 @@
 <script setup>
-// Read-only docs renderer for /trajects/:id/docs pages.
+// Read-only docs renderer.
 //
-// Re-uses the shared marked + DOMPurify pipeline from useArticleMarkdown so
-// docs and law-text stay visually consistent (same list nesting, paragraph
-// breaks, link styling). On top of that, ```mermaid``` code blocks are
-// upgraded into rendered SVGs via a post-render pass on the DOM — kept here
-// rather than in the shared pipeline because mermaid is a docs-only concern
-// and the helper must stay generic.
+// Wraps the shared marked + DOMPurify pipeline (`useArticleMarkdown`,
+// reused for visual parity with ArticleText / AnnotatedText) into an
+// `<nldd-rich-text>` so the typography, link styling, list spacing,
+// and code-block treatment match the rest of the editor without any
+// custom CSS of our own.
 //
-// The post-render approach (replace <pre><code class="language-mermaid"> with
-// <div class="mermaid"> + mermaid.run()) avoids touching marked's renderer
-// or DOMPurify's allow-list, both of which are shared with other panes.
+// On top, ```mermaid``` fenced code blocks are upgraded into rendered
+// SVGs via a post-render DOM pass — `nldd-rich-text` keeps its slot
+// content in the light DOM, so `querySelectorAll` from the ref works
+// without shadow-DOM piercing (same approach AnnotatedText uses for
+// note highlights).
 
 import { computed, nextTick, onMounted, ref, useTemplateRef, watch } from 'vue';
 import mermaid from 'mermaid';
@@ -18,35 +19,35 @@ import mermaid from 'mermaid';
 import { renderArticleHtml } from '../../composables/useArticleMarkdown.js';
 
 const props = defineProps({
-  /** Raw markdown source. Empty string renders nothing. */
+  /** Raw markdown source. Empty string renders an empty rich-text block. */
   text: { type: String, default: '' },
 });
 
 const html = computed(() => renderArticleHtml(props.text));
-const rootEl = useTemplateRef('rootEl');
+const richTextEl = useTemplateRef('richTextEl');
 const mermaidReady = ref(false);
 
 onMounted(() => {
-  // Initialize once per component lifecycle. Theme matches the editor's
-  // NLDD light scheme; revisit when dark-mode lands repo-wide.
+  // Initialize once per component lifecycle. Neutral theme reads well in
+  // both light and dark NLDD palettes; revisit when @nldd/design-system
+  // exposes a "current theme" signal we can subscribe to.
   mermaid.initialize({ startOnLoad: false, theme: 'neutral' });
   mermaidReady.value = true;
 });
 
 watch(
   [html, mermaidReady],
-  async ([newHtml, ready]) => {
-    if (!ready || !rootEl.value) return;
+  async ([, ready]) => {
+    if (!ready || !richTextEl.value) return;
     await nextTick();
-    await processMermaidBlocks(rootEl.value);
+    await processMermaidBlocks(richTextEl.value);
   },
   { immediate: true },
 );
 
 /** Find `<pre><code class="language-mermaid">…</code></pre>` blocks inside
- * the rendered content and replace each with a `<div class="mermaid">` that
- * mermaid.run() can hydrate into an SVG. Skips already-processed blocks
- * (idempotent across re-renders).
+ * the rendered rich-text and replace each with a `<div class="mermaid">`
+ * that mermaid.run() can hydrate into an SVG. Idempotent across re-renders.
  */
 async function processMermaidBlocks(root) {
   const blocks = root.querySelectorAll('pre > code.language-mermaid');
@@ -63,73 +64,31 @@ async function processMermaidBlocks(root) {
   }
 
   try {
-    await mermaid.run({ querySelector: '.docs-content .mermaid' });
+    await mermaid.run({ querySelector: '.docs-content-rich .mermaid' });
   } catch (err) {
-    // Mermaid throws on syntactically invalid diagrams. We surface that
-    // inline rather than crashing the whole page; an editor reading the
-    // analysis should see WHERE the diagram broke.
+    // Mermaid throws on syntactically invalid diagrams. Surface inline
+    // rather than crashing the page — an analysis reader should see WHERE
+    // the diagram broke, not a blank pane.
     console.warn('[docs] mermaid render error', err);
   }
 }
 </script>
 
 <template>
-  <article ref="rootEl" class="docs-content" v-html="html"></article>
+  <nldd-rich-text ref="richTextEl" class="docs-content-rich" v-html="html"></nldd-rich-text>
 </template>
 
 <style scoped>
-.docs-content {
-  max-width: 80ch;
-  line-height: 1.55;
-}
-
-.docs-content :deep(h1),
-.docs-content :deep(h2),
-.docs-content :deep(h3) {
-  margin-top: 1.5em;
-  margin-bottom: 0.5em;
-}
-
-.docs-content :deep(p),
-.docs-content :deep(ul),
-.docs-content :deep(ol) {
-  margin: 0.6em 0;
-}
-
-.docs-content :deep(code) {
-  background: var(--nldd-color-surface-subtle, #f5f5f5);
-  padding: 0.1em 0.3em;
-  border-radius: 2px;
-  font-size: 0.92em;
-}
-
-.docs-content :deep(pre) {
-  background: var(--nldd-color-surface-subtle, #f5f5f5);
-  padding: 0.8em 1em;
-  border-radius: 4px;
-  overflow-x: auto;
-}
-
-.docs-content :deep(pre code) {
-  background: transparent;
-  padding: 0;
-}
-
-.docs-content :deep(blockquote) {
-  margin: 0.6em 0;
-  padding: 0.3em 1em;
-  border-left: 3px solid var(--nldd-color-border, #ccc);
-  color: var(--nldd-color-text-subtle, #555);
-  font-style: italic;
-}
-
-.docs-content :deep(.mermaid) {
+/* Center the rendered mermaid SVGs inside the rich-text slot. Everything
+ * else (headings, paragraphs, lists, code, blockquote) inherits from
+ * nldd-rich-text and intentionally has no local override. */
+.docs-content-rich :deep(.mermaid) {
   display: flex;
   justify-content: center;
   margin: 1.2em 0;
 }
 
-.docs-content :deep(.mermaid svg) {
+.docs-content-rich :deep(.mermaid svg) {
   max-width: 100%;
   height: auto;
 }

--- a/frontend/src/components/docs/DocsContent.vue
+++ b/frontend/src/components/docs/DocsContent.vue
@@ -1,0 +1,136 @@
+<script setup>
+// Read-only docs renderer for /trajects/:id/docs pages.
+//
+// Re-uses the shared marked + DOMPurify pipeline from useArticleMarkdown so
+// docs and law-text stay visually consistent (same list nesting, paragraph
+// breaks, link styling). On top of that, ```mermaid``` code blocks are
+// upgraded into rendered SVGs via a post-render pass on the DOM — kept here
+// rather than in the shared pipeline because mermaid is a docs-only concern
+// and the helper must stay generic.
+//
+// The post-render approach (replace <pre><code class="language-mermaid"> with
+// <div class="mermaid"> + mermaid.run()) avoids touching marked's renderer
+// or DOMPurify's allow-list, both of which are shared with other panes.
+
+import { computed, nextTick, onMounted, ref, useTemplateRef, watch } from 'vue';
+import mermaid from 'mermaid';
+
+import { renderArticleHtml } from '../../composables/useArticleMarkdown.js';
+
+const props = defineProps({
+  /** Raw markdown source. Empty string renders nothing. */
+  text: { type: String, default: '' },
+});
+
+const html = computed(() => renderArticleHtml(props.text));
+const rootEl = useTemplateRef('rootEl');
+const mermaidReady = ref(false);
+
+onMounted(() => {
+  // Initialize once per component lifecycle. Theme matches the editor's
+  // NLDD light scheme; revisit when dark-mode lands repo-wide.
+  mermaid.initialize({ startOnLoad: false, theme: 'neutral' });
+  mermaidReady.value = true;
+});
+
+watch(
+  [html, mermaidReady],
+  async ([newHtml, ready]) => {
+    if (!ready || !rootEl.value) return;
+    await nextTick();
+    await processMermaidBlocks(rootEl.value);
+  },
+  { immediate: true },
+);
+
+/** Find `<pre><code class="language-mermaid">…</code></pre>` blocks inside
+ * the rendered content and replace each with a `<div class="mermaid">` that
+ * mermaid.run() can hydrate into an SVG. Skips already-processed blocks
+ * (idempotent across re-renders).
+ */
+async function processMermaidBlocks(root) {
+  const blocks = root.querySelectorAll('pre > code.language-mermaid');
+  if (blocks.length === 0) return;
+
+  for (const code of blocks) {
+    const pre = code.parentElement;
+    if (!pre || pre.dataset.mermaidReplaced === 'true') continue;
+    const source = code.textContent || '';
+    const div = document.createElement('div');
+    div.className = 'mermaid';
+    div.textContent = source;
+    pre.replaceWith(div);
+  }
+
+  try {
+    await mermaid.run({ querySelector: '.docs-content .mermaid' });
+  } catch (err) {
+    // Mermaid throws on syntactically invalid diagrams. We surface that
+    // inline rather than crashing the whole page; an editor reading the
+    // analysis should see WHERE the diagram broke.
+    console.warn('[docs] mermaid render error', err);
+  }
+}
+</script>
+
+<template>
+  <article ref="rootEl" class="docs-content" v-html="html"></article>
+</template>
+
+<style scoped>
+.docs-content {
+  max-width: 80ch;
+  line-height: 1.55;
+}
+
+.docs-content :deep(h1),
+.docs-content :deep(h2),
+.docs-content :deep(h3) {
+  margin-top: 1.5em;
+  margin-bottom: 0.5em;
+}
+
+.docs-content :deep(p),
+.docs-content :deep(ul),
+.docs-content :deep(ol) {
+  margin: 0.6em 0;
+}
+
+.docs-content :deep(code) {
+  background: var(--nldd-color-surface-subtle, #f5f5f5);
+  padding: 0.1em 0.3em;
+  border-radius: 2px;
+  font-size: 0.92em;
+}
+
+.docs-content :deep(pre) {
+  background: var(--nldd-color-surface-subtle, #f5f5f5);
+  padding: 0.8em 1em;
+  border-radius: 4px;
+  overflow-x: auto;
+}
+
+.docs-content :deep(pre code) {
+  background: transparent;
+  padding: 0;
+}
+
+.docs-content :deep(blockquote) {
+  margin: 0.6em 0;
+  padding: 0.3em 1em;
+  border-left: 3px solid var(--nldd-color-border, #ccc);
+  color: var(--nldd-color-text-subtle, #555);
+  font-style: italic;
+}
+
+.docs-content :deep(.mermaid) {
+  display: flex;
+  justify-content: center;
+  margin: 1.2em 0;
+}
+
+.docs-content :deep(.mermaid svg) {
+  max-width: 100%;
+  height: auto;
+}
+</style>

--- a/frontend/src/components/docs/DocsSidebar.vue
+++ b/frontend/src/components/docs/DocsSidebar.vue
@@ -1,15 +1,17 @@
 <script setup>
-// Left-rail navigation for the docs view: one section per source attached
-// to the traject, each section listing the markdown files in that source's
-// docs/ tree. Clicking a file emits ['select', { sourceId, path }] so the
-// parent (TrajectDocsApp) can update its router state.
+// Left-rail navigation for the docs view. One `<nldd-simple-section>` per
+// source the user has access to (typically one per corpus repo attached
+// to the traject), with files grouped by their top-level directory
+// (analysis/, diagrams/, etc.) into separate `<nldd-list>` blocks. Mirrors
+// the LibraryApp law/article sidebar pattern: nldd-list-item type="button"
+// with :selected, click emits ['select', { sourceId, path }].
 
 import { computed } from 'vue';
 
 const props = defineProps({
   /** Shape: { sources: [{ source_id, name, tree: [{ path }] }] } */
   tree: { type: Object, default: () => ({ sources: [] }) },
-  /** Currently selected page (highlight in sidebar). */
+  /** Currently selected page (highlights one row). */
   selectedSource: { type: String, default: '' },
   selectedPath: { type: String, default: '' },
 });
@@ -17,7 +19,7 @@ const props = defineProps({
 defineEmits(['select']);
 
 /** Group tree entries by their top-level folder so analysis/, diagrams/,
- * issues/ etc. each become a collapsible section per source. */
+ * etc. each become a labelled sub-list inside the source's section. */
 function group(tree) {
   const groups = new Map();
   for (const entry of tree || []) {
@@ -41,7 +43,7 @@ function isSelected(sourceId, path) {
 }
 
 function prettify(path) {
-  // Drop the .md extension and the folder prefix for the label.
+  // Drop the .md extension and the folder prefix; capitalize-ish.
   const segments = path.replace(/\.md$/, '').split('/');
   const tail = segments[segments.length - 1];
   return tail.replace(/[-_]/g, ' ');
@@ -49,101 +51,38 @@ function prettify(path) {
 </script>
 
 <template>
-  <nav class="docs-sidebar" aria-label="Docs-navigatie">
-    <div v-if="groupedSources.length === 0" class="empty">
-      Geen documentatie beschikbaar voor dit traject.
-    </div>
-    <section
-      v-for="src in groupedSources"
-      :key="src.source_id"
-      class="source-section"
-    >
-      <h2 class="source-name">{{ src.name }}</h2>
-      <div v-for="grp in src.groups" :key="grp.name" class="group">
-        <h3 class="group-name">{{ grp.name }}</h3>
-        <ul>
-          <li v-for="entry in grp.items" :key="entry.path">
-            <button
-              type="button"
-              :class="{ active: isSelected(src.source_id, entry.path) }"
-              @click="$emit('select', { sourceId: src.source_id, path: entry.path })"
-            >
-              {{ prettify(entry.path) }}
-            </button>
-          </li>
-        </ul>
-      </div>
-    </section>
-  </nav>
+  <nldd-inline-dialog
+    v-if="groupedSources.length === 0"
+    text="Geen documentatie beschikbaar voor dit traject."
+  ></nldd-inline-dialog>
+
+  <nldd-simple-section
+    v-for="src in groupedSources"
+    :key="src.source_id"
+    :heading="src.name"
+  >
+    <template v-for="grp in src.groups" :key="grp.name">
+      <nldd-title :text="grp.name" size="sm" class="docs-group-title"></nldd-title>
+      <nldd-list variant="simple">
+        <nldd-list-item
+          v-for="entry in grp.items"
+          :key="entry.path"
+          size="md"
+          type="button"
+          :selected="isSelected(src.source_id, entry.path) || undefined"
+          @click="$emit('select', { sourceId: src.source_id, path: entry.path })"
+        >
+          <nldd-text-cell :text="prettify(entry.path)"></nldd-text-cell>
+        </nldd-list-item>
+      </nldd-list>
+    </template>
+  </nldd-simple-section>
 </template>
 
 <style scoped>
-.docs-sidebar {
-  padding: 1rem;
-  font-size: 0.9rem;
-  border-right: 1px solid var(--nldd-color-border, #e5e5e5);
-  overflow-y: auto;
-}
-
-.docs-sidebar .empty {
-  color: var(--nldd-color-text-subtle, #666);
-  font-style: italic;
-}
-
-.source-section + .source-section {
-  margin-top: 1.25rem;
-  padding-top: 0.75rem;
-  border-top: 1px solid var(--nldd-color-border, #e5e5e5);
-}
-
-.source-name {
-  font-size: 0.85rem;
-  font-weight: 600;
-  margin: 0 0 0.4rem;
-  color: var(--nldd-color-text-subtle, #555);
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-}
-
-.group-name {
-  font-size: 0.78rem;
-  font-weight: 600;
-  margin: 0.6rem 0 0.25rem;
-  color: var(--nldd-color-text, #333);
-}
-
-.docs-sidebar ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-
-.docs-sidebar li {
-  margin: 0.1rem 0;
-}
-
-.docs-sidebar button {
+.docs-group-title {
   display: block;
-  width: 100%;
-  padding: 0.3rem 0.5rem;
-  background: transparent;
-  border: none;
-  text-align: left;
-  font-size: inherit;
-  font-family: inherit;
-  color: inherit;
-  border-radius: 3px;
-  cursor: pointer;
   text-transform: capitalize;
-}
-
-.docs-sidebar button:hover {
-  background: var(--nldd-color-surface-subtle, #f0f0f0);
-}
-
-.docs-sidebar button.active {
-  background: var(--nldd-color-primary-subtle, #e6effe);
-  color: var(--nldd-color-primary, #0066cc);
-  font-weight: 500;
+  margin: 0.75rem 0 0.25rem;
 }
 </style>

--- a/frontend/src/components/docs/DocsSidebar.vue
+++ b/frontend/src/components/docs/DocsSidebar.vue
@@ -1,0 +1,149 @@
+<script setup>
+// Left-rail navigation for the docs view: one section per source attached
+// to the traject, each section listing the markdown files in that source's
+// docs/ tree. Clicking a file emits ['select', { sourceId, path }] so the
+// parent (TrajectDocsApp) can update its router state.
+
+import { computed } from 'vue';
+
+const props = defineProps({
+  /** Shape: { sources: [{ source_id, name, tree: [{ path }] }] } */
+  tree: { type: Object, default: () => ({ sources: [] }) },
+  /** Currently selected page (highlight in sidebar). */
+  selectedSource: { type: String, default: '' },
+  selectedPath: { type: String, default: '' },
+});
+
+defineEmits(['select']);
+
+/** Group tree entries by their top-level folder so analysis/, diagrams/,
+ * issues/ etc. each become a collapsible section per source. */
+function group(tree) {
+  const groups = new Map();
+  for (const entry of tree || []) {
+    const segments = entry.path.split('/');
+    const top = segments.length > 1 ? segments[0] : '(root)';
+    if (!groups.has(top)) groups.set(top, []);
+    groups.get(top).push(entry);
+  }
+  return Array.from(groups.entries()).map(([name, items]) => ({ name, items }));
+}
+
+const groupedSources = computed(() =>
+  (props.tree?.sources || []).map((s) => ({
+    ...s,
+    groups: group(s.tree),
+  })),
+);
+
+function isSelected(sourceId, path) {
+  return sourceId === props.selectedSource && path === props.selectedPath;
+}
+
+function prettify(path) {
+  // Drop the .md extension and the folder prefix for the label.
+  const segments = path.replace(/\.md$/, '').split('/');
+  const tail = segments[segments.length - 1];
+  return tail.replace(/[-_]/g, ' ');
+}
+</script>
+
+<template>
+  <nav class="docs-sidebar" aria-label="Docs-navigatie">
+    <div v-if="groupedSources.length === 0" class="empty">
+      Geen documentatie beschikbaar voor dit traject.
+    </div>
+    <section
+      v-for="src in groupedSources"
+      :key="src.source_id"
+      class="source-section"
+    >
+      <h2 class="source-name">{{ src.name }}</h2>
+      <div v-for="grp in src.groups" :key="grp.name" class="group">
+        <h3 class="group-name">{{ grp.name }}</h3>
+        <ul>
+          <li v-for="entry in grp.items" :key="entry.path">
+            <button
+              type="button"
+              :class="{ active: isSelected(src.source_id, entry.path) }"
+              @click="$emit('select', { sourceId: src.source_id, path: entry.path })"
+            >
+              {{ prettify(entry.path) }}
+            </button>
+          </li>
+        </ul>
+      </div>
+    </section>
+  </nav>
+</template>
+
+<style scoped>
+.docs-sidebar {
+  padding: 1rem;
+  font-size: 0.9rem;
+  border-right: 1px solid var(--nldd-color-border, #e5e5e5);
+  overflow-y: auto;
+}
+
+.docs-sidebar .empty {
+  color: var(--nldd-color-text-subtle, #666);
+  font-style: italic;
+}
+
+.source-section + .source-section {
+  margin-top: 1.25rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid var(--nldd-color-border, #e5e5e5);
+}
+
+.source-name {
+  font-size: 0.85rem;
+  font-weight: 600;
+  margin: 0 0 0.4rem;
+  color: var(--nldd-color-text-subtle, #555);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.group-name {
+  font-size: 0.78rem;
+  font-weight: 600;
+  margin: 0.6rem 0 0.25rem;
+  color: var(--nldd-color-text, #333);
+}
+
+.docs-sidebar ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.docs-sidebar li {
+  margin: 0.1rem 0;
+}
+
+.docs-sidebar button {
+  display: block;
+  width: 100%;
+  padding: 0.3rem 0.5rem;
+  background: transparent;
+  border: none;
+  text-align: left;
+  font-size: inherit;
+  font-family: inherit;
+  color: inherit;
+  border-radius: 3px;
+  cursor: pointer;
+  text-transform: capitalize;
+}
+
+.docs-sidebar button:hover {
+  background: var(--nldd-color-surface-subtle, #f0f0f0);
+}
+
+.docs-sidebar button.active {
+  background: var(--nldd-color-primary-subtle, #e6effe);
+  color: var(--nldd-color-primary, #0066cc);
+  font-weight: 500;
+}
+</style>

--- a/frontend/src/composables/useDocs.js
+++ b/frontend/src/composables/useDocs.js
@@ -1,0 +1,108 @@
+/**
+ * Composables for the per-traject docs view.
+ *
+ * Two backend endpoints, both will be served by editor-api once the
+ * traject_members / traject_corpus_sources tables exist (PR #632):
+ *   GET /api/trajects/:trajectId/docs/tree
+ *     -> { sources: [{ source_id, name, tree: [{ path, type }] }] }
+ *   GET /api/trajects/:trajectId/docs/page?source=:src&path=:p
+ *     -> raw markdown text/plain
+ *
+ * While the upstream PRs are still in review the backend returns canned
+ * data — see packages/editor-api/src/traject_docs.rs. The composables here
+ * stay shape-stable across the stub→real transition.
+ */
+import { ref, shallowRef, watch } from 'vue';
+
+function trajectsRoot(trajectId) {
+  return `/api/trajects/${encodeURIComponent(trajectId)}/docs`;
+}
+
+/**
+ * Reactive ref<{ sources: Array }> for the given traject's docs tree.
+ * Returns { tree, loading, error, reload }.
+ */
+export function useDocsTree(trajectIdRef) {
+  const tree = shallowRef({ sources: [] });
+  const loading = ref(false);
+  const error = ref(null);
+
+  async function load() {
+    const id = unwrap(trajectIdRef);
+    if (!id) {
+      tree.value = { sources: [] };
+      return;
+    }
+    loading.value = true;
+    error.value = null;
+    try {
+      const resp = await fetch(`${trajectsRoot(id)}/tree`, {
+        credentials: 'include',
+      });
+      if (!resp.ok) {
+        // 403 surfaces as "no access to this traject" upstream; we don't
+        // try to redirect — the parent view decides UX.
+        throw new Error(`tree fetch failed: ${resp.status}`);
+      }
+      tree.value = await resp.json();
+    } catch (err) {
+      error.value = err;
+      tree.value = { sources: [] };
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  watch(() => unwrap(trajectIdRef), load, { immediate: true });
+
+  return { tree, loading, error, reload: load };
+}
+
+/**
+ * Reactive ref<string> with the markdown source for a single page.
+ * Watches all three refs; refetches on any change.
+ */
+export function useDocsPage(trajectIdRef, sourceIdRef, pathRef) {
+  const text = ref('');
+  const loading = ref(false);
+  const error = ref(null);
+
+  async function load() {
+    const tid = unwrap(trajectIdRef);
+    const sid = unwrap(sourceIdRef);
+    const path = unwrap(pathRef);
+    if (!tid || !sid || !path) {
+      text.value = '';
+      return;
+    }
+    loading.value = true;
+    error.value = null;
+    try {
+      const url =
+        `${trajectsRoot(tid)}/page` +
+        `?source=${encodeURIComponent(sid)}&path=${encodeURIComponent(path)}`;
+      const resp = await fetch(url, { credentials: 'include' });
+      if (!resp.ok) throw new Error(`page fetch failed: ${resp.status}`);
+      text.value = await resp.text();
+    } catch (err) {
+      error.value = err;
+      text.value = '';
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  watch(
+    () => [unwrap(trajectIdRef), unwrap(sourceIdRef), unwrap(pathRef)],
+    load,
+    { immediate: true },
+  );
+
+  return { text, loading, error, reload: load };
+}
+
+function unwrap(maybeRef) {
+  return maybeRef && typeof maybeRef === 'object' && 'value' in maybeRef
+    ? maybeRef.value
+    : maybeRef;
+}

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -29,6 +29,21 @@ const router = createRouter({
         },
       }),
     },
+    {
+      // Docs view for a specific traject. URL shape:
+      //   /trajects/:trajectId/docs                       → landing (sidebar only)
+      //   /trajects/:trajectId/docs/:sourceId             → source root
+      //   /trajects/:trajectId/docs/:sourceId/<path>      → specific .md page
+      //
+      // The pathMatch wildcard captures multi-segment paths (analysis/foo,
+      // diagrams/bar/baz, ...) verbatim. requiresAuth follows the editor
+      // pattern; the per-traject membership check happens server-side in
+      // packages/editor-api/src/traject_docs.rs.
+      path: '/trajects/:trajectId/docs/:sourceId?/:pathMatch(.*)*',
+      name: 'traject-docs',
+      component: () => import('./TrajectDocsApp.vue'),
+      meta: { title: 'Docs', requiresAuth: true },
+    },
   ],
 });
 

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -23,6 +23,7 @@ mod feature_flags;
 mod harvest_proxy;
 mod middleware;
 mod state;
+mod traject_docs;
 mod user_settings;
 
 use state::{AppState, CorpusState};
@@ -175,6 +176,19 @@ async fn main() {
             "/api/user/settings/{key}",
             axum::routing::put(user_settings::set)
                 .layer(axum::extract::DefaultBodyLimit::max(4096)),
+        )
+        // Per-traject docs reader. Both endpoints serve canned data today
+        // (see traject_docs::tree / ::page). Real DB-backed implementation
+        // lands after PR #632 (trajects) and PR #626 (layered RBAC) merge —
+        // at that point we also raise the role gate from `editor-reader`
+        // (implicit via `require_session_auth`) to the explicit role check.
+        .route(
+            "/api/trajects/{traject_id}/docs/tree",
+            get(traject_docs::tree),
+        )
+        .route(
+            "/api/trajects/{traject_id}/docs/page",
+            get(traject_docs::page),
         )
         .route_layer(axum_middleware::from_fn_with_state(
             app_state.clone(),

--- a/packages/editor-api/src/traject_docs.rs
+++ b/packages/editor-api/src/traject_docs.rs
@@ -1,0 +1,193 @@
+//! Per-traject docs handlers.
+//!
+//! Two endpoints:
+//!   GET /api/trajects/{traject_id}/docs/tree
+//!     -> JSON: { sources: [ { source_id, name, tree: [ { path } ] } ] }
+//!   GET /api/trajects/{traject_id}/docs/page?source={src}&path={p}
+//!     -> text/markdown; charset=utf-8
+//!
+//! ## Current state: stub
+//!
+//! This module returns **canned data** while two upstream PRs are still in
+//! review:
+//!
+//! - PR #632 (tdjager/trajects) introduces the `trajects`, `traject_members`,
+//!   `accounts`, and `traject_corpus_sources` tables. Without those we can't
+//!   do the real authz check ("is this account a member of this traject?")
+//!   nor list the traject's sources.
+//! - PR #626 (tdjager/feat/layered-rbac) introduces the
+//!   `editor-reader/writer/admin` realm-role gating; the docs routes belong
+//!   on `editor-reader`.
+//!
+//! When both PRs land this module switches to:
+//!   1. Resolving `session.person_sub -> accounts.id` (one query).
+//!   2. Asserting membership in `traject_members` for `traject_id`. Not a
+//!      member → 403.
+//!   3. Selecting `traject_corpus_sources` rows for the traject and walking
+//!      each source's on-disk clone (the same clones #632's writable-own
+//!      handlers use). The `docs/` subdir of each clone is the docs tree.
+//!
+//! The handler signatures and response shapes here are stable across the
+//! stub→real transition — the frontend (`frontend/src/composables/useDocs.js`)
+//! does not need to change.
+
+use axum::extract::{Path, Query};
+use axum::http::{header, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize)]
+pub struct DocsTreeEntry {
+    pub path: String,
+}
+
+#[derive(Serialize)]
+pub struct DocsSourceTree {
+    pub source_id: String,
+    pub name: String,
+    pub tree: Vec<DocsTreeEntry>,
+}
+
+#[derive(Serialize)]
+pub struct DocsTreeResponse {
+    pub sources: Vec<DocsSourceTree>,
+}
+
+#[derive(Deserialize)]
+pub struct PageQuery {
+    pub source: String,
+    pub path: String,
+}
+
+/// GET /api/trajects/{traject_id}/docs/tree
+///
+/// Stub: returns a single fictive "dummy" source whose tree mirrors the
+/// `regelrecht-corpus-dummy` repo. Once PR #632 lands, this becomes a DB
+/// query over `traject_corpus_sources` + directory walks per clone.
+pub async fn tree(Path(_traject_id): Path<String>) -> Json<DocsTreeResponse> {
+    Json(DocsTreeResponse {
+        sources: vec![DocsSourceTree {
+            source_id: "dummy".to_string(),
+            name: "Gemeente Dummy — Verordening Fietsval-verbod".to_string(),
+            tree: stub_dummy_tree(),
+        }],
+    })
+}
+
+/// GET /api/trajects/{traject_id}/docs/page?source={src}&path={p}
+///
+/// Stub: returns canned markdown for known (source, path) pairs. For unknown
+/// paths returns 404 (so the frontend's error path renders). Once PR #632
+/// lands, this reads from `/opt/corpora/<clone-cache>/<source>/docs/<path>`
+/// after asserting the requester is a member of the traject.
+pub async fn page(Path(_traject_id): Path<String>, Query(q): Query<PageQuery>) -> Response {
+    let Some(body) = stub_page_body(&q.source, &q.path) else {
+        return (StatusCode::NOT_FOUND, "page not found").into_response();
+    };
+    (
+        [(header::CONTENT_TYPE, "text/markdown; charset=utf-8")],
+        body,
+    )
+        .into_response()
+}
+
+// ---------------------------------------------------------------------------
+// Stub fixtures — REMOVE these once the real DB-backed implementation lands.
+// ---------------------------------------------------------------------------
+
+fn stub_dummy_tree() -> Vec<DocsTreeEntry> {
+    [
+        "analysis/fietsval-verbod-context.md",
+        "analysis/handhavingsbevoegdheid.md",
+        "analysis/samenloop-rijksregels.md",
+        "diagrams/cross-law-gemeente-dummy.md",
+        "diagrams/fietsval-flow-2025-04-01.md",
+        "issues/issue-onduidelijkheid-definitie-fietsval.md",
+        "plans/2025-03-15-implementatie-traject.md",
+        "reviews/review-eerste-uitvoering.md",
+    ]
+    .iter()
+    .map(|p| DocsTreeEntry {
+        path: (*p).to_string(),
+    })
+    .collect()
+}
+
+fn stub_page_body(source: &str, path: &str) -> Option<String> {
+    if source != "dummy" {
+        return None;
+    }
+    let body = match path {
+        "analysis/fietsval-verbod-context.md" => STUB_FIETSVAL_CONTEXT,
+        "analysis/handhavingsbevoegdheid.md" => STUB_HANDHAVING,
+        "diagrams/fietsval-flow-2025-04-01.md" => STUB_FLOW_DIAGRAM,
+        "diagrams/cross-law-gemeente-dummy.md" => STUB_CROSS_LAW_DIAGRAM,
+        _ => STUB_PLACEHOLDER,
+    };
+    Some(body.to_string())
+}
+
+const STUB_FIETSVAL_CONTEXT: &str = r#"# Context: waarom een fietsval-verbod?
+
+> Stuk is **volledig fictief** en dient als demo-tekst voor de
+> docs-platform-ingest. Geen verwijzingen naar bestaande casuïstiek.
+
+De Gemeente Dummy worstelt sinds enkele jaren met een toename van
+fietsvalmeldingen in het centrum. Uit de (verzonnen) bestuurlijke
+inventarisatie volgt dat:
+
+1. Het aantal meldingen tussen 2022 en 2024 met circa 40% is gestegen.
+2. De directe oorzaak in meerderheid van de gevallen niet aan
+   wegonderhoud is te wijten, maar aan gedragsfactoren.
+3. Bestaande rijksregels (zoals de Wegenverkeerswet) onvoldoende
+   handvatten bieden om gemeentelijke prioriteiten te stellen.
+
+Tegen deze achtergrond is gekozen voor een lokale verordening die het
+verschijnsel als zelfstandige overtreding benoemt en handhavingsbeleid
+mogelijk maakt zonder afhankelijkheid van het Openbaar Ministerie.
+"#;
+
+const STUB_HANDHAVING: &str = r#"# Handhavingsbevoegdheid en rol BOA's
+
+De Verordening Handhaving Fietsval-verbod Gemeente Dummy 2025 wijst
+handhaving expliciet toe aan buitengewoon opsporingsambtenaren (BOA's)
+in dienst van — of aangewezen door — het college.
+
+Twee aspecten verdienen nadere aandacht: de **bevoegdheidsketen** en de
+**registratieplicht**. Beide worden hieronder besproken.
+"#;
+
+const STUB_FLOW_DIAGRAM: &str = r#"# Flow: constatering → registratie → sanctie
+
+```mermaid
+flowchart TD
+    A[Constatering fietsval door BOA] --> B{Valt onder uitzondering?}
+    B -- ja --> X[Geen sanctie<br/>geen registratie]
+    B -- nee --> C[Registratie in handhavingsregister<br/>binnen 24 uur]
+    C --> D{Recidive binnen 12 mnd?}
+    D -- nee --> F[Boete ≤ € 30]
+    D -- ja --> H[Boete ≤ € 90]
+```
+
+Bovenstaand diagram laat zien hoe een constatering door de BOA via
+registratie tot een sanctie kan leiden.
+"#;
+
+const STUB_CROSS_LAW_DIAGRAM: &str = r#"# Cross-law relaties binnen Gemeente Dummy
+
+```mermaid
+graph LR
+    V1[Verordening Fietsval-verbod] --> V2[Verordening Handhaving]
+    V2 --> B1[Beleidsregel Uitvoering]
+    B1 --> E1[Wegenverkeerswet]
+```
+
+Pijl-richting = juridische delegatie of verwijzing.
+"#;
+
+const STUB_PLACEHOLDER: &str = r#"# Stub
+
+Deze pagina is nog niet uitgewerkt. Dit is een platzhalter terwijl
+PR #632 (trajects) nog in review zit.
+"#;


### PR DESCRIPTION
## Summary

Adds a markdown-rendered, per-traject docs view to the editor. The route renders documentation files (`docs/*.md`) from the corpus-sources attached to a traject, behind the usual session-auth + an upcoming explicit `editor-reader` role gate.

```
/trajects/:trajectId/docs                       → landing (sidebar only)
/trajects/:trajectId/docs/:sourceId             → source root
/trajects/:trajectId/docs/:sourceId/<path>      → specific .md page
```

## :warning: Stub state — blocked on #632 + #626

The backend handlers in `packages/editor-api/src/traject_docs.rs` currently return **canned data** so the frontend can be reviewed end-to-end while two upstream PRs are still in flight:

- **#632 (@tdjager) — trajects.** Introduces the `trajects`, `traject_members`, `accounts`, and `traject_corpus_sources` tables. Without those we can't do the real authz check (\"is this account a member of this traject?\") nor list the traject's sources from the DB.
- **#626 (@tdjager) — layered RBAC.** Introduces `editor-reader / editor-writer / editor-admin` realm-roles. Our docs routes will be raised to `editor-reader` (explicit) instead of the implicit `require_session_auth` wired today.

Once both land, `traject_docs.rs` switches to:

1. Resolve `session.person_sub` → `accounts.id` via one query.
2. Assert membership in `traject_members` for the requested `:trajectId`. Not a member → 403.
3. Select `traject_corpus_sources` rows for the traject and walk each source's on-disk clone (the same clones #632 uses for the writable-own flow). The `docs/` subdir of each clone is the docs tree.

The handler signatures and response shapes are stable across the stub→real transition, so the frontend does not need to change when the backend is rewired.

## What's in this PR

### Frontend

- `frontend/src/TrajectDocsApp.vue` — root view (parallel to EditorApp / LibraryApp). Two-pane layout: DocsSidebar + DocsContent.
- `frontend/src/components/docs/DocsSidebar.vue` — lists each source attached to the traject, grouped by top-level directory.
- `frontend/src/components/docs/DocsContent.vue` — renders markdown via the shared `useArticleMarkdown` pipeline (marked + DOMPurify, identical to `ArticleText.vue`) and post-processes ` \`\`\`mermaid ` code blocks into SVG via `mermaid.run`.
- `frontend/src/composables/useDocs.js` — `useDocsTree` + `useDocsPage` composables with cookie-credentialed fetches. Route-driven so refresh/back/forward keep working.
- `frontend/src/router.js` — new `traject-docs` route, `meta.requiresAuth: true` identical to the editor route.
- `mermaid@^11.4.1` added to `frontend/package.json`. Lazy-loaded — only fetched when navigating to the docs route.

### Backend

- `packages/editor-api/src/traject_docs.rs` — `tree` + `page` handlers, stub-only for now.
- `packages/editor-api/src/main.rs` — module registered, two routes added inside the existing `protected_api_routes` block (which carries `require_session_auth`).

## Test plan

- [x] `just editor-api-fmt` — clean
- [x] `just editor-api-lint` (clippy) — clean
- [x] `just editor-api-check` (cargo check) — clean
- [x] `cd frontend && npm run build` — passes; mermaid + sub-renderers chunked separately, lazy-loaded into the TrajectDocsApp bundle
- [ ] Local interactive smoke against \`just editor-api\` + \`cd frontend && npm run dev\` — confirm \`/trajects/test/docs/dummy/diagrams/fietsval-flow-2025-04-01\` shows a rendered mermaid flow-chart
- [ ] After #632 + #626 merge: rebase, swap canned data for real DB queries + add membership-401, add explicit `editor-reader` route-layer

## Not in this PR (follow-ups)

- Real DB-backed handlers (blocked on #632)
- Explicit `editor-reader` realm-role gate (blocked on #626)
- Annotations on docs pages — RFC-018 covers law-text annotations; whether to extend that pattern to free-text markdown is a separate design decision once these merges land.
- Source-cross-link resolution (relative `.md` → in-app router-link)
- Wiring corpus sources into the editor image's build pipeline (depends on #632's clone-cache layout)

## Background

Replaces an earlier exploration of a standalone docs platform (`MinBZK/regelrecht-corpus-docs`, soon to be archived) that built its own auth-proxy + DB. Integrating into the editor instead reuses auth, session-management, deploy pipeline, and now per-traject permissions from #632 — drastically less infrastructure for the same user-facing capability.