### PR TITLE
chore(deps): bump opentelemetry 0.31 → 0.32

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,16 @@ updates:
       - dependencies
       - rust
     groups:
+      opentelemetry:
+        patterns:
+          - opentelemetry
+          - opentelemetry-*
+          - opentelemetry_*
+          - tracing-opentelemetry
+        update-types:
+          - minor
+          - patch
+          - major
       rust-minor-patch:
         update-types:
           - minor

--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -2752,9 +2752,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "opentelemetry"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2766,22 +2766,22 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
 dependencies = [
  "async-trait",
  "bytes",
  "http",
  "opentelemetry",
- "reqwest 0.12.28",
+ "reqwest 0.13.2",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
  "http",
  "opentelemetry",
@@ -2789,35 +2789,33 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest 0.12.28",
+ "reqwest 0.13.2",
  "thiserror 2.0.18",
- "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
  "prost",
- "tonic",
- "tonic-prost",
 ]
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+checksum = "368afaed344110f40b179bb8fbe54bc52d98f9bd2b281799ef32487c2650c956"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
  "opentelemetry",
  "percent-encoding",
+ "portable-atomic",
  "rand 0.9.2",
  "thiserror 2.0.18",
 ]
@@ -3839,9 +3837,7 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "futures-channel",
  "futures-core",
- "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -5438,9 +5434,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.32.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
 dependencies = [
  "js-sys",
  "opentelemetry",

--- a/packages/engine/Cargo.toml
+++ b/packages/engine/Cargo.toml
@@ -69,19 +69,19 @@ features = ["env-filter", "fmt", "registry"]
 optional = true
 
 [dependencies.tracing-opentelemetry]
-version = "0.32"
+version = "0.33"
 optional = true
 
 [dependencies.opentelemetry]
-version = "0.31"
+version = "0.32"
 optional = true
 
 [dependencies.opentelemetry_sdk]
-version = "0.31"
+version = "0.32"
 optional = true
 
 [dependencies.opentelemetry-otlp]
-version = "0.31"
+version = "0.32"
 optional = true
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary

Bumps the four opentelemetry-ecosystem crates together so the dependency graph stays on a single major:

- `opentelemetry` 0.31 → 0.32
- `opentelemetry_sdk` 0.31 → 0.32
- `opentelemetry-otlp` 0.31 → 0.32
- `tracing-opentelemetry` 0.32 → 0.33 (pinned to opentelemetry ^0.32)

No source changes needed — `packages/engine/src/telemetry.rs` already imports `opentelemetry::trace::TracerProvider` correctly; the `.tracer()` call resolves once all four crates are on the matching major.

Also adds an explicit `opentelemetry` group to `.github/dependabot.yml` so future bumps ship as one PR. The existing `rust-minor-patch` group excluded `major` updates, and cargo treats `0.x → 0.(x+1)` as major — which is why Dependabot split the bump into #621/#622/#623, each breaking compilation on its own.

## Background

The individual Dependabot PRs failed with:

```
error[E0599]: no method named `tracer` found for struct
  opentelemetry_sdk::trace::SdkTracerProvider
```

That looks like an API break but isn't. `tracer()` is a provided method on the `TracerProvider` trait. The problem is version skew: with one crate at 0.32 and the rest at 0.31, two `opentelemetry` majors land in the graph, and the trait import resolves to a different major than the one `SdkTracerProvider` implements.

Closes #621
Closes #622
Closes #623

## Test plan

- [x] `cargo check --features otel` — green
- [x] `cargo build --bin evaluate --features otel` — green
- [x] `cargo tree -i opentelemetry --features otel` — single 0.32 in the graph (no duplicate majors)
- [x] `just format`, `just lint`, `just build-check`, `just validate` — all pass
- [x] `just test` — engine unit + integration tests pass (admin testcontainers tests skipped locally; CI will run them)
- [ ] CI green on this PR (Test, Pre-commit, Security Audit, WASM Build)