### PR TITLE
perf(corpus): partial-clone sparse checkouts

### DIFF
--- a/packages/corpus/src/client.rs
+++ b/packages/corpus/src/client.rs
@@ -455,6 +455,7 @@ impl CorpusClient {
             "--single-branch",
         ];
         if sparse {
+            // Partial clone — see `git_clone` for the rationale.
             args.push("--filter=blob:none");
             args.push("--no-checkout");
         }

--- a/packages/corpus/src/client.rs
+++ b/packages/corpus/src/client.rs
@@ -398,6 +398,12 @@ impl CorpusClient {
             "--single-branch",
         ];
         if sparse {
+            // Partial clone: don't ship blobs in the pack. Combined with the
+            // cone-mode sparse-checkout below, only blobs inside the sparse
+            // paths get fetched lazily when `git checkout` materialises the
+            // working tree — turning a full-corpus download into a few-files
+            // download for per-job enrichment checkouts.
+            args.push("--filter=blob:none");
             args.push("--no-checkout");
         }
         args.push(&url);
@@ -449,6 +455,7 @@ impl CorpusClient {
             "--single-branch",
         ];
         if sparse {
+            args.push("--filter=blob:none");
             args.push("--no-checkout");
         }
         args.push(&url);

--- a/packages/corpus/src/client.rs
+++ b/packages/corpus/src/client.rs
@@ -398,11 +398,7 @@ impl CorpusClient {
             "--single-branch",
         ];
         if sparse {
-            // Partial clone: don't ship blobs in the pack. Combined with the
-            // cone-mode sparse-checkout below, only blobs inside the sparse
-            // paths get fetched lazily when `git checkout` materialises the
-            // working tree — turning a full-corpus download into a few-files
-            // download for per-job enrichment checkouts.
+            // Partial clone: lazy-fetch blobs via sparse paths instead of shipping the full pack.
             args.push("--filter=blob:none");
             args.push("--no-checkout");
         }


### PR DESCRIPTION
## Summary

Add `--filter=blob:none` to the **sparse** branch of `git_clone` and `git_clone_and_create_branch` in `packages/corpus/src/client.rs`.

- **Why**: sparse-checkout filters the working tree but `git clone --no-checkout` still downloads the full pack from the server (every blob, every file). Combining with a partial clone makes git fetch only the blobs that fall inside the sparse paths when `git checkout` materialises the working tree.
- **Scope**: enrichment worker (`packages/pipeline/src/enrich.rs:438` — sets `sparse_paths`). Harvester clone is non-sparse and untouched. Editor traject-flow is being refactored to direct GitHub API separately, so it's not touched here.

## Benchmark

Against the real `MinBZK/regelrecht-corpus` `development` branch:

| | Wall-clock | `.git` size |
|---|---|---|
| Before (`--depth 1 --single-branch --no-checkout`) | **2m 25s** | **421 MB** |
| After (adds `--filter=blob:none`) | **2.3s** | **1.1 MB** |

~63× faster, ~99.7% smaller. Sparse-checkout then lazily pulls only the YAMLs in the law directory + `features/` over the wire.

## Test plan

- [x] `cargo test -p regelrecht-corpus --lib` — 104/104 passing (covers `git_clone` paths against local fixture repos)
- [x] Pre-commit hooks green (`format`, `clippy`)
- [ ] Watch CI

Caveat: lazy blob-fetch needs the remote reachable when missing blobs are accessed. The enrichment flow stays connected to GitHub throughout (clone → commit → push), so this is fine.