### PR TITLE
feat(editor): invite-by-email for trajects with pending invites

### DIFF
--- a/frontend/src/components/TrajectMembersDialog.vue
+++ b/frontend/src/components/TrajectMembersDialog.vue
@@ -1,0 +1,354 @@
+<script setup>
+import { computed, nextTick, ref, watch } from 'vue';
+import { useTrajectMembers } from '../composables/useTrajectMembers.js';
+import { refreshTrajects } from '../composables/useTrajects.js';
+
+const props = defineProps({
+  /** Whether the sheet is currently open. */
+  modelValue: { type: Boolean, default: false },
+  /** Traject to manage. */
+  trajectId: { type: String, default: null },
+  /** Traject display name, for the sheet header. */
+  trajectName: { type: String, default: '' },
+});
+
+const emit = defineEmits(['update:modelValue']);
+
+const sheetEl = ref(null);
+
+const {
+  members,
+  pendingInvites,
+  callerRole,
+  loading,
+  error: loadError,
+  load,
+  invite,
+  updateRole,
+  removeMember,
+  removeInvite,
+  leaveTraject,
+} = useTrajectMembers();
+
+const isOwner = computed(() => callerRole.value === 'owner');
+
+// Invite form
+const inviteEmail = ref('');
+const inviteRole = ref('contributor');
+const inviteBusy = ref(false);
+const inviteError = ref(null);
+const inviteResult = ref(null);
+
+// Row-level busy + error indicators keyed by member account_id / invite email.
+const rowBusy = ref(new Set());
+const rowError = ref(new Map());
+
+function markBusy(key, busy) {
+  const next = new Set(rowBusy.value);
+  if (busy) next.add(key);
+  else next.delete(key);
+  rowBusy.value = next;
+}
+
+function setRowError(key, message) {
+  const next = new Map(rowError.value);
+  if (message) next.set(key, message);
+  else next.delete(key);
+  rowError.value = next;
+}
+
+watch(
+  () => props.modelValue,
+  async (v) => {
+    await nextTick();
+    if (v) {
+      inviteEmail.value = '';
+      inviteRole.value = 'contributor';
+      inviteError.value = null;
+      inviteResult.value = null;
+      rowBusy.value = new Set();
+      rowError.value = new Map();
+      if (props.trajectId) {
+        await load(props.trajectId);
+      }
+      sheetEl.value?.show();
+    } else {
+      sheetEl.value?.hide();
+    }
+  },
+);
+
+function close() {
+  emit('update:modelValue', false);
+}
+
+function bindValue(target) {
+  return (event) =>
+    (target.value = event.target?.value ?? event.detail?.value ?? target.value);
+}
+
+async function submitInvite() {
+  inviteError.value = null;
+  inviteResult.value = null;
+  if (!inviteEmail.value.trim()) {
+    inviteError.value = 'E-mailadres is verplicht';
+    return;
+  }
+  inviteBusy.value = true;
+  try {
+    const body = await invite(props.trajectId, inviteEmail.value.trim(), inviteRole.value);
+    inviteEmail.value = '';
+    inviteResult.value =
+      body.status === 'pending'
+        ? `Uitnodiging klaargezet voor ${body.email}. Toegang wordt actief bij de eerste login.`
+        : `${body.email} is toegevoegd.`;
+  } catch (e) {
+    inviteError.value = e.message || 'Uitnodigen mislukt';
+  } finally {
+    inviteBusy.value = false;
+  }
+}
+
+async function changeMemberRole(member, newRole) {
+  if (member.role === newRole) return;
+  setRowError(member.account_id, null);
+  markBusy(member.account_id, true);
+  try {
+    await updateRole(props.trajectId, member.account_id, newRole);
+  } catch (e) {
+    setRowError(member.account_id, e.message || 'Wijzigen mislukt');
+  } finally {
+    markBusy(member.account_id, false);
+  }
+}
+
+async function clickRemoveMember(member) {
+  setRowError(member.account_id, null);
+  markBusy(member.account_id, true);
+  try {
+    await removeMember(props.trajectId, member.account_id);
+  } catch (e) {
+    setRowError(member.account_id, e.message || 'Verwijderen mislukt');
+  } finally {
+    markBusy(member.account_id, false);
+  }
+}
+
+async function clickRemoveInvite(inv) {
+  setRowError(inv.email, null);
+  markBusy(inv.email, true);
+  try {
+    await removeInvite(props.trajectId, inv.email);
+  } catch (e) {
+    setRowError(inv.email, e.message || 'Intrekken mislukt');
+  } finally {
+    markBusy(inv.email, false);
+  }
+}
+
+const leaveBusy = ref(false);
+const leaveError = ref(null);
+
+async function clickLeave() {
+  leaveError.value = null;
+  leaveBusy.value = true;
+  try {
+    await leaveTraject(props.trajectId);
+    await refreshTrajects();
+    close();
+  } catch (e) {
+    leaveError.value = e.message || 'Verlaten mislukt';
+  } finally {
+    leaveBusy.value = false;
+  }
+}
+</script>
+
+<template>
+  <Teleport to="body">
+    <nldd-sheet
+      ref="sheetEl"
+      placement="right"
+      width="520px"
+      full-height
+      @close="close"
+    >
+      <nldd-page sticky-header sticky-footer>
+        <nldd-top-title-bar
+          slot="header"
+          :text="`Leden — ${trajectName}`"
+          dismiss-text="Sluit"
+          @dismiss="close"
+        ></nldd-top-title-bar>
+
+        <nldd-simple-section v-if="loading">
+          <p class="members-status">Laden…</p>
+        </nldd-simple-section>
+
+        <nldd-simple-section v-else-if="loadError">
+          <p class="members-error">{{ loadError.message || 'Fout bij laden' }}</p>
+        </nldd-simple-section>
+
+        <template v-else>
+          <nldd-simple-section heading="Actieve leden">
+            <nldd-list variant="box">
+              <nldd-list-item v-for="m in members" :key="m.account_id" size="md">
+                <nldd-text-cell
+                  :text="m.name || m.email"
+                  :supporting-text="m.name ? m.email : null"
+                ></nldd-text-cell>
+                <nldd-spacer-cell size="8"></nldd-spacer-cell>
+                <nldd-cell>
+                  <select
+                    class="members-role-select"
+                    :value="m.role"
+                    :disabled="!isOwner || rowBusy.has(m.account_id) || undefined"
+                    @change="changeMemberRole(m, $event.target.value)"
+                  >
+                    <option value="owner">Owner</option>
+                    <option value="contributor">Contributor</option>
+                  </select>
+                </nldd-cell>
+                <nldd-spacer-cell size="8"></nldd-spacer-cell>
+                <nldd-cell v-if="isOwner">
+                  <nldd-button
+                    variant="ghost"
+                    size="sm"
+                    text="Verwijder"
+                    :disabled="rowBusy.has(m.account_id) || undefined"
+                    @click="clickRemoveMember(m)"
+                  ></nldd-button>
+                </nldd-cell>
+                <div v-if="rowError.get(m.account_id)" class="members-row-error">
+                  {{ rowError.get(m.account_id) }}
+                </div>
+              </nldd-list-item>
+            </nldd-list>
+          </nldd-simple-section>
+
+          <nldd-simple-section
+            v-if="pendingInvites.length > 0"
+            heading="Openstaande uitnodigingen"
+          >
+            <nldd-list variant="box">
+              <nldd-list-item v-for="inv in pendingInvites" :key="inv.email" size="md">
+                <nldd-text-cell
+                  :text="inv.email"
+                  supporting-text="Wacht op eerste login"
+                ></nldd-text-cell>
+                <nldd-spacer-cell size="8"></nldd-spacer-cell>
+                <nldd-cell>
+                  <span class="members-pending-role">{{ inv.role }}</span>
+                </nldd-cell>
+                <nldd-spacer-cell size="8"></nldd-spacer-cell>
+                <nldd-cell v-if="isOwner">
+                  <nldd-button
+                    variant="ghost"
+                    size="sm"
+                    text="Trek in"
+                    :disabled="rowBusy.has(inv.email) || undefined"
+                    @click="clickRemoveInvite(inv)"
+                  ></nldd-button>
+                </nldd-cell>
+                <div v-if="rowError.get(inv.email)" class="members-row-error">
+                  {{ rowError.get(inv.email) }}
+                </div>
+              </nldd-list-item>
+            </nldd-list>
+          </nldd-simple-section>
+
+          <nldd-simple-section v-if="isOwner" heading="Iemand uitnodigen">
+            <nldd-list variant="box">
+              <nldd-list-item size="md">
+                <nldd-text-cell
+                  text="E-mail"
+                  supporting-text="Toegang wordt actief bij de eerste login als er nog geen account bestaat."
+                  max-width="180px"
+                ></nldd-text-cell>
+                <nldd-spacer-cell size="8"></nldd-spacer-cell>
+                <nldd-cell>
+                  <nldd-text-field
+                    size="md"
+                    type="email"
+                    :value="inviteEmail"
+                    @input="bindValue(inviteEmail)($event)"
+                  ></nldd-text-field>
+                </nldd-cell>
+              </nldd-list-item>
+              <nldd-list-item size="md">
+                <nldd-text-cell text="Rol" max-width="180px"></nldd-text-cell>
+                <nldd-spacer-cell size="8"></nldd-spacer-cell>
+                <nldd-cell>
+                  <select
+                    class="members-role-select"
+                    :value="inviteRole"
+                    @change="inviteRole = $event.target.value"
+                  >
+                    <option value="contributor">Contributor</option>
+                    <option value="owner">Owner</option>
+                  </select>
+                </nldd-cell>
+              </nldd-list-item>
+            </nldd-list>
+            <div v-if="inviteResult" class="members-info">{{ inviteResult }}</div>
+            <div v-if="inviteError" class="members-error">{{ inviteError }}</div>
+            <nldd-button
+              variant="primary"
+              size="md"
+              :text="inviteBusy ? 'Bezig…' : 'Uitnodigen'"
+              :disabled="inviteBusy || undefined"
+              @click="submitInvite"
+            ></nldd-button>
+          </nldd-simple-section>
+
+          <nldd-simple-section v-if="!isOwner && callerRole" heading="Dit traject verlaten">
+            <p class="members-leave-hint">
+              Je verliest direct toegang tot dit traject. Een owner kan je later
+              opnieuw uitnodigen.
+            </p>
+            <div v-if="leaveError" class="members-error">{{ leaveError }}</div>
+            <nldd-button
+              variant="ghost"
+              size="md"
+              :text="leaveBusy ? 'Bezig…' : 'Verlaat traject'"
+              :disabled="leaveBusy || undefined"
+              @click="clickLeave"
+            ></nldd-button>
+          </nldd-simple-section>
+        </template>
+      </nldd-page>
+    </nldd-sheet>
+  </Teleport>
+</template>
+
+<style scoped>
+.members-status,
+.members-leave-hint {
+  font-size: 13px;
+  color: var(--semantics-content-secondary-color, #555);
+  margin: 8px 0;
+}
+.members-info {
+  font-size: 13px;
+  color: var(--semantics-content-secondary-color, #555);
+  margin: 12px 0 4px;
+}
+.members-error,
+.members-row-error {
+  color: var(--nldd-color-text-error, #c62828);
+  font-size: 13px;
+  margin-top: 8px;
+}
+.members-role-select {
+  padding: 4px 6px;
+  font-size: 13px;
+  border-radius: 4px;
+  border: 1px solid var(--nldd-color-border, #ccc);
+  background: var(--semantics-surfaces-background-color, #fff);
+}
+.members-pending-role {
+  font-size: 13px;
+  color: var(--semantics-content-secondary-color, #555);
+  text-transform: capitalize;
+}
+</style>

--- a/frontend/src/components/TrajectMembersDialog.vue
+++ b/frontend/src/components/TrajectMembersDialog.vue
@@ -82,11 +82,6 @@ function close() {
   emit('update:modelValue', false);
 }
 
-function bindValue(target) {
-  return (event) =>
-    (target.value = event.target?.value ?? event.detail?.value ?? target.value);
-}
-
 async function submitInvite() {
   inviteError.value = null;
   inviteResult.value = null;
@@ -200,15 +195,18 @@ async function clickLeave() {
                   ></nldd-text-cell>
                   <nldd-spacer-cell size="8"></nldd-spacer-cell>
                   <nldd-cell>
-                    <select
-                      class="members-role-select"
-                      :value="m.role"
-                      :disabled="!isOwner || rowBusy.has(m.account_id) || undefined"
-                      @change="changeMemberRole(m, $event.target.value)"
+                    <nldd-dropdown
+                      size="md"
+                      @change="changeMemberRole(m, $event.detail?.value ?? $event.target?.value ?? m.role)"
                     >
-                      <option value="owner">Owner</option>
-                      <option value="contributor">Contributor</option>
-                    </select>
+                      <select
+                        :value="m.role"
+                        :disabled="!isOwner || rowBusy.has(m.account_id) || undefined"
+                      >
+                        <option value="owner">Owner</option>
+                        <option value="contributor">Contributor</option>
+                      </select>
+                    </nldd-dropdown>
                   </nldd-cell>
                   <nldd-spacer-cell size="8"></nldd-spacer-cell>
                   <nldd-cell v-if="isOwner">
@@ -262,40 +260,33 @@ async function clickLeave() {
           </nldd-simple-section>
 
           <nldd-simple-section v-if="isOwner" heading="Iemand uitnodigen">
-            <nldd-list variant="box">
-              <nldd-list-item size="md">
-                <nldd-text-cell
-                  text="E-mail"
-                  supporting-text="Toegang wordt actief bij de eerste login als er nog geen account bestaat."
-                  max-width="180px"
-                ></nldd-text-cell>
-                <nldd-spacer-cell size="8"></nldd-spacer-cell>
-                <nldd-cell>
-                  <nldd-text-field
-                    size="md"
-                    type="email"
-                    :value="inviteEmail"
-                    @input="bindValue(inviteEmail)($event)"
-                  ></nldd-text-field>
-                </nldd-cell>
-              </nldd-list-item>
-              <nldd-list-item size="md">
-                <nldd-text-cell text="Rol" max-width="180px"></nldd-text-cell>
-                <nldd-spacer-cell size="8"></nldd-spacer-cell>
-                <nldd-cell>
-                  <select
-                    class="members-role-select"
-                    :value="inviteRole"
-                    @change="inviteRole = $event.target.value"
-                  >
-                    <option value="contributor">Contributor</option>
-                    <option value="owner">Owner</option>
-                  </select>
-                </nldd-cell>
-              </nldd-list-item>
-            </nldd-list>
+            <nldd-form-field label="E-mail" supporting-label="Toegang wordt actief bij de eerste login als er nog geen account bestaat.">
+              <nldd-text-field
+                size="md"
+                type="email"
+                :value="inviteEmail"
+                :invalid="inviteError ? true : undefined"
+                :error-message="inviteError ? 'invite-email-error' : undefined"
+                @input="inviteEmail = $event.target?.value ?? $event.detail?.value ?? inviteEmail"
+              ></nldd-text-field>
+              <nldd-form-field-error-text id="invite-email-error">
+                {{ inviteError }}
+              </nldd-form-field-error-text>
+            </nldd-form-field>
+
+            <nldd-form-field label="Rol">
+              <nldd-dropdown
+                size="md"
+                @change="inviteRole = $event.detail?.value ?? $event.target?.value ?? inviteRole"
+              >
+                <select :value="inviteRole">
+                  <option value="contributor">Contributor</option>
+                  <option value="owner">Owner</option>
+                </select>
+              </nldd-dropdown>
+            </nldd-form-field>
+
             <div v-if="inviteResult" class="members-info">{{ inviteResult }}</div>
-            <div v-if="inviteError" class="members-error">{{ inviteError }}</div>
             <nldd-button
               variant="primary"
               size="md"
@@ -342,13 +333,6 @@ async function clickLeave() {
   color: var(--nldd-color-text-error, #c62828);
   font-size: 13px;
   margin-top: 8px;
-}
-.members-role-select {
-  padding: 4px 6px;
-  font-size: 13px;
-  border-radius: 4px;
-  border: 1px solid var(--nldd-color-border, #ccc);
-  background: var(--semantics-surfaces-background-color, #fff);
 }
 .members-pending-role {
   font-size: 13px;

--- a/frontend/src/components/TrajectMembersDialog.vue
+++ b/frontend/src/components/TrajectMembersDialog.vue
@@ -192,37 +192,39 @@ async function clickLeave() {
         <template v-else>
           <nldd-simple-section heading="Actieve leden">
             <nldd-list variant="box">
-              <nldd-list-item v-for="m in members" :key="m.account_id" size="md">
-                <nldd-text-cell
-                  :text="m.name || m.email"
-                  :supporting-text="m.name ? m.email : null"
-                ></nldd-text-cell>
-                <nldd-spacer-cell size="8"></nldd-spacer-cell>
-                <nldd-cell>
-                  <select
-                    class="members-role-select"
-                    :value="m.role"
-                    :disabled="!isOwner || rowBusy.has(m.account_id) || undefined"
-                    @change="changeMemberRole(m, $event.target.value)"
-                  >
-                    <option value="owner">Owner</option>
-                    <option value="contributor">Contributor</option>
-                  </select>
-                </nldd-cell>
-                <nldd-spacer-cell size="8"></nldd-spacer-cell>
-                <nldd-cell v-if="isOwner">
-                  <nldd-button
-                    variant="ghost"
-                    size="sm"
-                    text="Verwijder"
-                    :disabled="rowBusy.has(m.account_id) || undefined"
-                    @click="clickRemoveMember(m)"
-                  ></nldd-button>
-                </nldd-cell>
+              <template v-for="m in members" :key="m.account_id">
+                <nldd-list-item size="md">
+                  <nldd-text-cell
+                    :text="m.name || m.email"
+                    :supporting-text="m.name ? m.email : null"
+                  ></nldd-text-cell>
+                  <nldd-spacer-cell size="8"></nldd-spacer-cell>
+                  <nldd-cell>
+                    <select
+                      class="members-role-select"
+                      :value="m.role"
+                      :disabled="!isOwner || rowBusy.has(m.account_id) || undefined"
+                      @change="changeMemberRole(m, $event.target.value)"
+                    >
+                      <option value="owner">Owner</option>
+                      <option value="contributor">Contributor</option>
+                    </select>
+                  </nldd-cell>
+                  <nldd-spacer-cell size="8"></nldd-spacer-cell>
+                  <nldd-cell v-if="isOwner">
+                    <nldd-button
+                      variant="ghost"
+                      size="sm"
+                      text="Verwijder"
+                      :disabled="rowBusy.has(m.account_id) || undefined"
+                      @click="clickRemoveMember(m)"
+                    ></nldd-button>
+                  </nldd-cell>
+                </nldd-list-item>
                 <div v-if="rowError.get(m.account_id)" class="members-row-error">
                   {{ rowError.get(m.account_id) }}
                 </div>
-              </nldd-list-item>
+              </template>
             </nldd-list>
           </nldd-simple-section>
 
@@ -231,29 +233,31 @@ async function clickLeave() {
             heading="Openstaande uitnodigingen"
           >
             <nldd-list variant="box">
-              <nldd-list-item v-for="inv in pendingInvites" :key="inv.email" size="md">
-                <nldd-text-cell
-                  :text="inv.email"
-                  supporting-text="Wacht op eerste login"
-                ></nldd-text-cell>
-                <nldd-spacer-cell size="8"></nldd-spacer-cell>
-                <nldd-cell>
-                  <span class="members-pending-role">{{ inv.role }}</span>
-                </nldd-cell>
-                <nldd-spacer-cell size="8"></nldd-spacer-cell>
-                <nldd-cell v-if="isOwner">
-                  <nldd-button
-                    variant="ghost"
-                    size="sm"
-                    text="Trek in"
-                    :disabled="rowBusy.has(inv.email) || undefined"
-                    @click="clickRemoveInvite(inv)"
-                  ></nldd-button>
-                </nldd-cell>
+              <template v-for="inv in pendingInvites" :key="inv.email">
+                <nldd-list-item size="md">
+                  <nldd-text-cell
+                    :text="inv.email"
+                    supporting-text="Wacht op eerste login"
+                  ></nldd-text-cell>
+                  <nldd-spacer-cell size="8"></nldd-spacer-cell>
+                  <nldd-cell>
+                    <span class="members-pending-role">{{ inv.role }}</span>
+                  </nldd-cell>
+                  <nldd-spacer-cell size="8"></nldd-spacer-cell>
+                  <nldd-cell v-if="isOwner">
+                    <nldd-button
+                      variant="ghost"
+                      size="sm"
+                      text="Trek in"
+                      :disabled="rowBusy.has(inv.email) || undefined"
+                      @click="clickRemoveInvite(inv)"
+                    ></nldd-button>
+                  </nldd-cell>
+                </nldd-list-item>
                 <div v-if="rowError.get(inv.email)" class="members-row-error">
                   {{ rowError.get(inv.email) }}
                 </div>
-              </nldd-list-item>
+              </template>
             </nldd-list>
           </nldd-simple-section>
 

--- a/frontend/src/components/TrajectMenu.vue
+++ b/frontend/src/components/TrajectMenu.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { computed, nextTick, ref, watch } from 'vue';
 import { useTrajects } from '../composables/useTrajects.js';
+import TrajectMembersDialog from './TrajectMembersDialog.vue';
 
 const props = defineProps({
   // Suffix to keep ids unique when this component is mounted in multiple
@@ -57,6 +58,18 @@ function openCreate() {
   createError.value = null;
   form.value = emptyForm();
   showCreate.value = true;
+}
+
+// --- Members dialog state ---
+const showMembers = ref(false);
+const membersTrajectId = ref(null);
+const membersTrajectName = ref('');
+
+function openMembersForActive() {
+  if (!activeTraject.value) return;
+  membersTrajectId.value = activeTraject.value.id;
+  membersTrajectName.value = activeTraject.value.name;
+  showMembers.value = true;
 }
 
 function closeCreate() {
@@ -133,11 +146,23 @@ function bind(field) {
     ></nldd-menu-item>
     <nldd-menu-divider></nldd-menu-divider>
     <nldd-menu-item
+      v-if="activeTraject"
+      text="Beheer leden…"
+      start-icon="users"
+      @click="openMembersForActive"
+    ></nldd-menu-item>
+    <nldd-menu-item
       text="Nieuw traject…"
       start-icon="plus"
       @click="openCreate"
     ></nldd-menu-item>
   </nldd-menu>
+
+  <TrajectMembersDialog
+    v-model="showMembers"
+    :traject-id="membersTrajectId"
+    :traject-name="membersTrajectName"
+  />
 
   <!-- Teleport the sheet out of the toolbar so it doesn't inherit the
        toolbar's positioning / clipping. Matches the ScenarioBuilder

--- a/frontend/src/composables/useTrajectMembers.js
+++ b/frontend/src/composables/useTrajectMembers.js
@@ -17,8 +17,13 @@ export function useTrajectMembers() {
   const error = ref(null);
 
   async function load(trajectId) {
+    // Reset state before the await so a reopen against a different
+    // traject can't briefly flash the previous traject's members.
     loading.value = true;
     error.value = null;
+    members.value = [];
+    pendingInvites.value = [];
+    callerRole.value = null;
     try {
       const resp = await fetch(`/api/trajects/${trajectId}`);
       if (!resp.ok) {

--- a/frontend/src/composables/useTrajectMembers.js
+++ b/frontend/src/composables/useTrajectMembers.js
@@ -1,0 +1,111 @@
+import { ref } from 'vue';
+
+/**
+ * Per-traject member + pending-invite state.
+ *
+ * Returns a fresh reactive state on every call so multiple dialogs (or
+ * the same dialog reopened) don't leak previous data between trajects.
+ * The component owning the dialog passes the traject id at load time;
+ * the composable handles fetching, invite, role change, removal, and
+ * leave.
+ */
+export function useTrajectMembers() {
+  const members = ref([]);
+  const pendingInvites = ref([]);
+  const callerRole = ref(null);
+  const loading = ref(false);
+  const error = ref(null);
+
+  async function load(trajectId) {
+    loading.value = true;
+    error.value = null;
+    try {
+      const resp = await fetch(`/api/trajects/${trajectId}`);
+      if (!resp.ok) {
+        throw new Error(`Kon traject niet laden: ${resp.status}`);
+      }
+      const body = await resp.json();
+      members.value = body.members || [];
+      pendingInvites.value = body.pending_invites || [];
+      callerRole.value = body.role || null;
+    } catch (e) {
+      error.value = e;
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  async function invite(trajectId, email, role) {
+    const resp = await fetch(`/api/trajects/${trajectId}/members`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ email, role }),
+    });
+    if (!resp.ok) {
+      throw new Error((await resp.text()) || `Uitnodigen mislukt: ${resp.status}`);
+    }
+    const body = await resp.json();
+    await load(trajectId);
+    return body;
+  }
+
+  async function updateRole(trajectId, accountId, role) {
+    const resp = await fetch(
+      `/api/trajects/${trajectId}/members/${accountId}`,
+      {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ role }),
+      },
+    );
+    if (!resp.ok) {
+      throw new Error((await resp.text()) || `Rol wijzigen mislukt: ${resp.status}`);
+    }
+    await load(trajectId);
+  }
+
+  async function removeMember(trajectId, accountId) {
+    const resp = await fetch(
+      `/api/trajects/${trajectId}/members/${accountId}`,
+      { method: 'DELETE' },
+    );
+    if (!resp.ok) {
+      throw new Error((await resp.text()) || `Verwijderen mislukt: ${resp.status}`);
+    }
+    await load(trajectId);
+  }
+
+  async function removeInvite(trajectId, email) {
+    const resp = await fetch(
+      `/api/trajects/${trajectId}/invites/${encodeURIComponent(email)}`,
+      { method: 'DELETE' },
+    );
+    if (!resp.ok) {
+      throw new Error((await resp.text()) || `Uitnodiging intrekken mislukt: ${resp.status}`);
+    }
+    await load(trajectId);
+  }
+
+  async function leaveTraject(trajectId) {
+    const resp = await fetch(`/api/trajects/${trajectId}/leave`, {
+      method: 'POST',
+    });
+    if (!resp.ok) {
+      throw new Error((await resp.text()) || `Verlaten mislukt: ${resp.status}`);
+    }
+  }
+
+  return {
+    members,
+    pendingInvites,
+    callerRole,
+    loading,
+    error,
+    load,
+    invite,
+    updateRole,
+    removeMember,
+    removeInvite,
+    leaveTraject,
+  };
+}

--- a/frontend/src/composables/useTrajectMembers.js
+++ b/frontend/src/composables/useTrajectMembers.js
@@ -47,7 +47,13 @@ export function useTrajectMembers() {
       body: JSON.stringify({ email, role }),
     });
     if (!resp.ok) {
-      throw new Error((await resp.text()) || `Uitnodigen mislukt: ${resp.status}`);
+      const reason = await resp.text();
+      // 400 from normalize_email/validate_role comes back with an empty
+      // body; surface a specific message instead of "Uitnodigen mislukt: 400".
+      if (resp.status === 400) {
+        throw new Error(reason || 'Ongeldig e-mailadres of rol');
+      }
+      throw new Error(reason || `Uitnodigen mislukt: ${resp.status}`);
     }
     const body = await resp.json();
     await load(trajectId);

--- a/packages/editor-api/src/accounts.rs
+++ b/packages/editor-api/src/accounts.rs
@@ -121,6 +121,53 @@ pub async fn ensure_account(
     }))
 }
 
+/// Promote any pending `traject_invites` rows matching the user's email
+/// into real `traject_members` rows, then clear those invites.
+///
+/// Called on every authenticated request after the account upsert. The
+/// happy path (no invites for this email) costs one indexed lookup that
+/// returns zero rows and a no-op DELETE — sub-millisecond.
+///
+/// The INSERT … SELECT uses `ON CONFLICT DO NOTHING` so a user who's
+/// somehow already a member of the matched traject (concurrent invite +
+/// direct add, account email change races) just keeps their existing
+/// row. The unconditional DELETE is intentional: after the INSERT runs,
+/// every invite for this email is by definition obsolete — the account
+/// exists and is now a member of each matching traject.
+///
+/// Failures are logged but not propagated to the caller: the user has
+/// already been authenticated and their account upserted, so a transient
+/// promotion failure just delays access to a freshly-invited traject
+/// until the next request. Failing the entire request would be worse UX
+/// than the lag.
+pub async fn promote_pending_invites(pool: &PgPool, account_id: Uuid, email: &str) {
+    let email_lower = email.trim().to_lowercase();
+    if email_lower.is_empty() {
+        return;
+    }
+    let result = sqlx::query(
+        "WITH _ins AS (
+             INSERT INTO traject_members (traject_id, account_id, role)
+             SELECT i.traject_id, $1, i.role
+               FROM traject_invites i
+              WHERE i.email = $2
+             ON CONFLICT (traject_id, account_id) DO NOTHING
+         )
+         DELETE FROM traject_invites WHERE email = $2",
+    )
+    .bind(account_id)
+    .bind(&email_lower)
+    .execute(pool)
+    .await;
+    if let Err(e) = result {
+        tracing::error!(
+            error = %e,
+            account_id = %account_id,
+            "promote_pending_invites failed; user will retry on next request"
+        );
+    }
+}
+
 /// Axum middleware that ensures the authenticated user has a row in
 /// `accounts` and exposes it to downstream handlers via
 /// `axum::Extension<AccountRecord>`.
@@ -151,6 +198,7 @@ pub async fn account_middleware(
         );
         StatusCode::SERVICE_UNAVAILABLE
     })?;
+    promote_pending_invites(pool, account.id, &account.email).await;
     request.extensions_mut().insert(account);
     Ok(next.run(request).await)
 }

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -257,6 +257,10 @@ async fn main() {
             axum::routing::patch(trajects::update_member).delete(trajects::remove_member),
         )
         .route(
+            "/api/trajects/{id}/invites/{email}",
+            axum::routing::delete(trajects::remove_invite),
+        )
+        .route(
             "/api/session/active-traject",
             get(trajects::get_active).put(trajects::set_active),
         )

--- a/packages/editor-api/src/trajects.rs
+++ b/packages/editor-api/src/trajects.rs
@@ -613,17 +613,15 @@ pub async fn add_member(
     let email = normalize_email(&req.email).ok_or(StatusCode::BAD_REQUEST)?;
 
     // `accounts.email` keeps the IdP-supplied casing, so the lookup
-    // lowercases on the DB side to match our normalised key.
-    // LIMIT 1 because the UNIQUE constraint is on raw `email`, not on
-    // `lower(email)`. The IdP should never produce two case-variants of
-    // the same address, but if it ever does we still want a deterministic
-    // pick instead of a runtime panic in `fetch_optional`.
-    let target: Option<(Uuid,)> =
-        sqlx::query_as("SELECT id FROM accounts WHERE lower(email) = $1 LIMIT 1")
-            .bind(&email)
-            .fetch_optional(pool)
-            .await
-            .map_err(db_err("lookup account"))?;
+    // lowercases on the DB side to match our normalised key. The
+    // functional unique index `idx_accounts_email_lower` (migration
+    // 0016) makes this index-only and case-insensitively unique, so
+    // `fetch_optional` is sound by construction.
+    let target: Option<(Uuid,)> = sqlx::query_as("SELECT id FROM accounts WHERE lower(email) = $1")
+        .bind(&email)
+        .fetch_optional(pool)
+        .await
+        .map_err(db_err("lookup account"))?;
 
     if let Some((target_id,)) = target {
         // Known account → write traject_members. Guard the "would demote

--- a/packages/editor-api/src/trajects.rs
+++ b/packages/editor-api/src/trajects.rs
@@ -591,11 +591,16 @@ pub async fn add_member(
 
     // `accounts.email` keeps the IdP-supplied casing, so the lookup
     // lowercases on the DB side to match our normalised key.
-    let target: Option<(Uuid,)> = sqlx::query_as("SELECT id FROM accounts WHERE lower(email) = $1")
-        .bind(&email)
-        .fetch_optional(pool)
-        .await
-        .map_err(db_err("lookup account"))?;
+    // LIMIT 1 because the UNIQUE constraint is on raw `email`, not on
+    // `lower(email)`. The IdP should never produce two case-variants of
+    // the same address, but if it ever does we still want a deterministic
+    // pick instead of a runtime panic in `fetch_optional`.
+    let target: Option<(Uuid,)> =
+        sqlx::query_as("SELECT id FROM accounts WHERE lower(email) = $1 LIMIT 1")
+            .bind(&email)
+            .fetch_optional(pool)
+            .await
+            .map_err(db_err("lookup account"))?;
 
     if let Some((target_id,)) = target {
         // Known account → write traject_members. Guard the "would demote

--- a/packages/editor-api/src/trajects.rs
+++ b/packages/editor-api/src/trajects.rs
@@ -56,11 +56,18 @@ pub struct TrajectSourceDto {
     pub is_writable_own: bool,
 }
 
+#[derive(Debug, Serialize, sqlx::FromRow)]
+pub struct TrajectInvite {
+    pub email: String,
+    pub role: String,
+}
+
 #[derive(Debug, Serialize)]
 pub struct TrajectDetail {
     #[serde(flatten)]
     pub summary: TrajectSummary,
     pub members: Vec<TrajectMember>,
+    pub pending_invites: Vec<TrajectInvite>,
     pub sources: Vec<TrajectSourceDto>,
 }
 
@@ -107,9 +114,11 @@ pub struct ActiveTrajectResponse {
 
 #[derive(Debug, Deserialize)]
 pub struct AddMemberRequest {
-    /// Email of an existing account to invite. Returns 404 when no
-    /// matching account exists — we deliberately do not create stub
-    /// accounts on invite so OIDC stays the only path that produces them.
+    /// Email of the user to invite. If an account already exists for
+    /// this email the row lands in `traject_members` (active). If not,
+    /// it goes into `traject_invites` (pending) and is promoted to a
+    /// real membership the next time someone with that email claim hits
+    /// any authenticated endpoint — see `accounts::ensure_account`.
     pub email: String,
     pub role: String,
 }
@@ -117,6 +126,16 @@ pub struct AddMemberRequest {
 #[derive(Debug, Deserialize)]
 pub struct UpdateMemberRequest {
     pub role: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AddMemberResponse {
+    /// `"active"` when a `traject_members` row was created (account
+    /// existed), `"pending"` when only a `traject_invites` row was
+    /// created (no account yet for this email).
+    pub status: &'static str,
+    /// Normalised (lowercased + trimmed) email used as the key.
+    pub email: String,
 }
 
 // ---------------------------------------------------------------------------
@@ -219,13 +238,13 @@ async fn require_membership(
         .ok_or(StatusCode::FORBIDDEN)
 }
 
-async fn require_beheerder(
+async fn require_owner(
     pool: &PgPool,
     traject_id: Uuid,
     account_id: Uuid,
 ) -> Result<(), StatusCode> {
     let role = require_membership(pool, traject_id, account_id).await?;
-    if role == "beheerder" {
+    if role == "owner" {
         Ok(())
     } else {
         Err(StatusCode::FORBIDDEN)
@@ -233,10 +252,22 @@ async fn require_beheerder(
 }
 
 fn validate_role(role: &str) -> Result<(), StatusCode> {
-    if role == "beheerder" || role == "lid" {
+    if role == "owner" || role == "contributor" {
         Ok(())
     } else {
         Err(StatusCode::BAD_REQUEST)
+    }
+}
+
+/// Normalise an email for storage and comparison: trim whitespace and
+/// lowercase. Empty results become `None` so callers can return 400
+/// instead of inserting an empty key.
+fn normalize_email(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_lowercase())
     }
 }
 
@@ -307,6 +338,17 @@ pub async fn get(
     .await
     .map_err(db_err("traject members fetch failed"))?;
 
+    let pending_invites: Vec<TrajectInvite> = sqlx::query_as(
+        "SELECT email, role::text AS role
+         FROM traject_invites
+         WHERE traject_id = $1
+         ORDER BY invited_at",
+    )
+    .bind(id)
+    .fetch_all(pool)
+    .await
+    .map_err(db_err("traject invites fetch failed"))?;
+
     let sources: Vec<TrajectSourceDto> = sqlx::query_as(
         "SELECT source_id, name, source_type::text AS source_type,
                 gh_owner, gh_repo, gh_branch, gh_base_branch, gh_path, gh_ref,
@@ -323,6 +365,7 @@ pub async fn get(
     Ok(Json(TrajectDetail {
         summary,
         members,
+        pending_invites,
         sources,
     }))
 }
@@ -361,7 +404,7 @@ pub async fn create(
 
     sqlx::query(
         "INSERT INTO traject_members (traject_id, account_id, role)
-         VALUES ($1, $2, 'beheerder')",
+         VALUES ($1, $2, 'owner')",
     )
     .bind(traject_id)
     .bind(account.id)
@@ -450,12 +493,12 @@ pub async fn create(
         description: req.description,
         scope: req.scope,
         status: "bezig".to_string(),
-        role: "beheerder".to_string(),
+        role: "owner".to_string(),
     };
     Ok((StatusCode::CREATED, Json(summary)))
 }
 
-/// PATCH /api/trajects/:id — beheerder-only update of metadata fields.
+/// PATCH /api/trajects/:id — owner-only update of metadata fields.
 pub async fn update(
     State(state): State<AppState>,
     Extension(account): Extension<AccountRecord>,
@@ -463,7 +506,7 @@ pub async fn update(
     Json(req): Json<UpdateTrajectRequest>,
 ) -> Result<StatusCode, StatusCode> {
     let pool = get_pool(&state)?;
-    require_beheerder(pool, id, account.id).await?;
+    require_owner(pool, id, account.id).await?;
     if let Some(ref s) = req.status {
         validate_status(s)?;
     }
@@ -495,7 +538,7 @@ pub async fn update(
     Ok(StatusCode::NO_CONTENT)
 }
 
-/// DELETE /api/trajects/:id — beheerder-only hard delete.
+/// DELETE /api/trajects/:id — owner-only hard delete.
 ///
 /// FK cascades on `traject_members` and `traject_corpus_sources` clean
 /// up the dependent rows. The cached `TrajectCorpus` is invalidated so
@@ -510,7 +553,7 @@ pub async fn delete(
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, StatusCode> {
     let pool = get_pool(&state)?;
-    require_beheerder(pool, id, account.id).await?;
+    require_owner(pool, id, account.id).await?;
 
     let affected = sqlx::query("DELETE FROM trajects WHERE id = $1")
         .bind(id)
@@ -527,71 +570,131 @@ pub async fn delete(
     Ok(StatusCode::NO_CONTENT)
 }
 
-/// POST /api/trajects/:id/members — invite an existing account by email.
+/// POST /api/trajects/:id/members — invite by email.
+///
+/// If the email already maps to an account, a `traject_members` row is
+/// created (or updated, idempotently) and the response status is
+/// `"active"`. If not, a `traject_invites` row is created and the
+/// response status is `"pending"`; that row is promoted to a real
+/// membership the next time someone with the matching email claim hits
+/// any authenticated endpoint (see `accounts::ensure_account`).
 pub async fn add_member(
     State(state): State<AppState>,
     Extension(account): Extension<AccountRecord>,
     Path(id): Path<Uuid>,
     Json(req): Json<AddMemberRequest>,
-) -> Result<StatusCode, StatusCode> {
+) -> Result<Json<AddMemberResponse>, StatusCode> {
     let pool = get_pool(&state)?;
-    require_beheerder(pool, id, account.id).await?;
+    require_owner(pool, id, account.id).await?;
     validate_role(&req.role)?;
+    let email = normalize_email(&req.email).ok_or(StatusCode::BAD_REQUEST)?;
 
-    let target: Option<(Uuid,)> = sqlx::query_as("SELECT id FROM accounts WHERE email = $1")
-        .bind(&req.email)
+    // `accounts.email` keeps the IdP-supplied casing, so the lookup
+    // lowercases on the DB side to match our normalised key.
+    let target: Option<(Uuid,)> = sqlx::query_as("SELECT id FROM accounts WHERE lower(email) = $1")
+        .bind(&email)
         .fetch_optional(pool)
         .await
         .map_err(db_err("lookup account"))?;
-    let target_id = target.ok_or(StatusCode::NOT_FOUND)?.0;
 
-    // Guard the "would demote the last beheerder" case atomically in the
-    // same statement so it can't race with a concurrent leave/remove.
-    // Without this, two concurrent calls each read the guard and see the
-    // other beheerder, then both writes commit, leaving the traject with
-    // zero beheerders. By embedding the guard in the INSERT … SELECT
-    // WHERE clause we tie the check to the same row-level lock the write
-    // takes.
-    //
-    // The WHERE evaluates to true when any of:
-    //   * the new role is `beheerder` (promotion/no-op, never reduces count)
-    //   * the target isn't currently a beheerder (no demotion happening)
-    //   * another beheerder exists for this traject (demotion is safe)
-    // When all three are false (target is the sole beheerder being demoted
-    // to lid) the SELECT returns no row, the INSERT runs zero times, no
-    // conflict triggers, and `rows_affected` is 0 → CONFLICT.
-    let affected = sqlx::query(
-        "INSERT INTO traject_members (traject_id, account_id, role)
-         SELECT $1, $2, $3::traject_role
-         WHERE
-             $3::traject_role = 'beheerder'
-             OR NOT EXISTS (
-                 SELECT 1 FROM traject_members tm
-                 WHERE tm.traject_id = $1
-                   AND tm.account_id = $2
-                   AND tm.role = 'beheerder'
-             )
-             OR EXISTS (
-                 SELECT 1 FROM traject_members tm2
-                 WHERE tm2.traject_id = $1
-                   AND tm2.role = 'beheerder'
-                   AND tm2.account_id <> $2
-             )
-         ON CONFLICT (traject_id, account_id) DO UPDATE
-             SET role = EXCLUDED.role",
-    )
-    .bind(id)
-    .bind(target_id)
-    .bind(&req.role)
-    .execute(pool)
-    .await
-    .map_err(db_err("add member"))?
-    .rows_affected();
+    if let Some((target_id,)) = target {
+        // Known account → write traject_members. Guard the "would demote
+        // the last owner" case atomically in the same statement so it
+        // can't race with a concurrent leave/remove.
+        //
+        // The WHERE evaluates to true when any of:
+        //   * the new role is `owner` (promotion/no-op, never reduces count)
+        //   * the target isn't currently an owner (no demotion happening)
+        //   * another owner exists for this traject (demotion is safe)
+        // When all three are false (target is the sole owner being
+        // demoted to contributor) the SELECT returns no row, the INSERT
+        // runs zero times, no conflict triggers, and `rows_affected` is
+        // 0 → CONFLICT.
+        let affected = sqlx::query(
+            "INSERT INTO traject_members (traject_id, account_id, role)
+             SELECT $1, $2, $3::traject_role
+             WHERE
+                 $3::traject_role = 'owner'
+                 OR NOT EXISTS (
+                     SELECT 1 FROM traject_members tm
+                     WHERE tm.traject_id = $1
+                       AND tm.account_id = $2
+                       AND tm.role = 'owner'
+                 )
+                 OR EXISTS (
+                     SELECT 1 FROM traject_members tm2
+                     WHERE tm2.traject_id = $1
+                       AND tm2.role = 'owner'
+                       AND tm2.account_id <> $2
+                 )
+             ON CONFLICT (traject_id, account_id) DO UPDATE
+                 SET role = EXCLUDED.role",
+        )
+        .bind(id)
+        .bind(target_id)
+        .bind(&req.role)
+        .execute(pool)
+        .await
+        .map_err(db_err("add member"))?
+        .rows_affected();
 
-    if affected == 0 {
-        return Err(StatusCode::CONFLICT);
+        if affected == 0 {
+            return Err(StatusCode::CONFLICT);
+        }
+        return Ok(Json(AddMemberResponse {
+            status: "active",
+            email,
+        }));
     }
 
+    // Unknown account → park the invite. Re-inviting the same email
+    // with a different role just updates the role (last write wins).
+    sqlx::query(
+        "INSERT INTO traject_invites (traject_id, email, role, invited_by)
+         VALUES ($1, $2, $3::traject_role, $4)
+         ON CONFLICT (traject_id, email) DO UPDATE
+             SET role = EXCLUDED.role,
+                 invited_by = EXCLUDED.invited_by,
+                 invited_at = now()",
+    )
+    .bind(id)
+    .bind(&email)
+    .bind(&req.role)
+    .bind(account.id)
+    .execute(pool)
+    .await
+    .map_err(db_err("add invite"))?;
+
+    Ok(Json(AddMemberResponse {
+        status: "pending",
+        email,
+    }))
+}
+
+/// DELETE /api/trajects/:id/invites/:email — owner-only removal of a
+/// pending invite. Returns 404 when no invite exists for the (traject,
+/// email) pair, so the operation is idempotent against repeated
+/// cancellations.
+pub async fn remove_invite(
+    State(state): State<AppState>,
+    Extension(account): Extension<AccountRecord>,
+    Path((id, email)): Path<(Uuid, String)>,
+) -> Result<StatusCode, StatusCode> {
+    let pool = get_pool(&state)?;
+    require_owner(pool, id, account.id).await?;
+    let email = normalize_email(&email).ok_or(StatusCode::BAD_REQUEST)?;
+
+    let affected = sqlx::query("DELETE FROM traject_invites WHERE traject_id = $1 AND email = $2")
+        .bind(id)
+        .bind(&email)
+        .execute(pool)
+        .await
+        .map_err(db_err("remove invite"))?
+        .rows_affected();
+
+    if affected == 0 {
+        return Err(StatusCode::NOT_FOUND);
+    }
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -603,14 +706,14 @@ pub async fn update_member(
     Json(req): Json<UpdateMemberRequest>,
 ) -> Result<StatusCode, StatusCode> {
     let pool = get_pool(&state)?;
-    require_beheerder(pool, id, account.id).await?;
+    require_owner(pool, id, account.id).await?;
     validate_role(&req.role)?;
 
-    // Atomic guard against demoting the last beheerder. The UPDATE only
+    // Atomic guard against demoting the last owner. The UPDATE only
     // fires when at least one of these holds:
-    //   * the new role is `beheerder` (no demote)
-    //   * the row's current role isn't `beheerder` (no demote)
-    //   * another beheerder exists for this traject (demote is safe)
+    //   * the new role is `owner` (no demote)
+    //   * the row's current role isn't `owner` (no demote)
+    //   * another owner exists for this traject (demote is safe)
     // Otherwise the row stays untouched, `rows_affected` is 0, and we
     // disambiguate "row missing" (NOT_FOUND) from "guard blocked"
     // (CONFLICT) via a follow-up read on the cold path.
@@ -618,12 +721,12 @@ pub async fn update_member(
         "UPDATE traject_members SET role = $3::traject_role
          WHERE traject_id = $1 AND account_id = $2
            AND (
-               $3::traject_role = 'beheerder'
-               OR role <> 'beheerder'
+               $3::traject_role = 'owner'
+               OR role <> 'owner'
                OR EXISTS (
                    SELECT 1 FROM traject_members tm2
                    WHERE tm2.traject_id = $1
-                     AND tm2.role = 'beheerder'
+                     AND tm2.role = 'owner'
                      AND tm2.account_id <> $2
                )
            )",
@@ -649,21 +752,21 @@ pub async fn remove_member(
     Path((id, account_id)): Path<(Uuid, Uuid)>,
 ) -> Result<StatusCode, StatusCode> {
     let pool = get_pool(&state)?;
-    require_beheerder(pool, id, account.id).await?;
+    require_owner(pool, id, account.id).await?;
 
     // Atomic guard: DELETE only succeeds when the target isn't the sole
-    // beheerder. The EXISTS condition is part of the same statement so
+    // owner. The EXISTS condition is part of the same statement so
     // two concurrent removes can't both pass the check and then both
     // commit a delete.
     let affected = sqlx::query(
         "DELETE FROM traject_members
          WHERE traject_id = $1 AND account_id = $2
            AND (
-               role <> 'beheerder'
+               role <> 'owner'
                OR EXISTS (
                    SELECT 1 FROM traject_members tm2
                    WHERE tm2.traject_id = $1
-                     AND tm2.role = 'beheerder'
+                     AND tm2.role = 'owner'
                      AND tm2.account_id <> $2
                )
            )",
@@ -684,8 +787,8 @@ pub async fn remove_member(
 /// POST /api/trajects/:id/leave — caller removes themselves from the
 /// traject.
 ///
-/// A `lid` can always leave. A `beheerder` cannot leave when they are
-/// the last beheerder — they must hand over the role or delete the
+/// A `contributor` can always leave. An `owner` cannot leave when they are
+/// the last owner — they must hand over the role or delete the
 /// traject. When the caller leaves the traject they currently have
 /// active in their session, that session pointer is cleared so the
 /// next save handler doesn't try to resolve a traject they no longer
@@ -700,8 +803,8 @@ pub async fn leave(
     require_membership(pool, id, account.id).await?;
 
     // Atomic guard, same shape as remove_member: the DELETE only runs
-    // when the caller is a lid or another beheerder remains. Two
-    // beheerders calling `leave` concurrently can't both pass a separate
+    // when the caller is a contributor or another owner remains. Two
+    // owners calling `leave` concurrently can't both pass a separate
     // count then both delete — the second one's DELETE re-evaluates the
     // EXISTS under Postgres' READ COMMITTED snapshot semantics and ends
     // up matching zero rows.
@@ -709,11 +812,11 @@ pub async fn leave(
         "DELETE FROM traject_members
          WHERE traject_id = $1 AND account_id = $2
            AND (
-               role <> 'beheerder'
+               role <> 'owner'
                OR EXISTS (
                    SELECT 1 FROM traject_members tm2
                    WHERE tm2.traject_id = $1
-                     AND tm2.role = 'beheerder'
+                     AND tm2.role = 'owner'
                      AND tm2.account_id <> $2
                )
            )",

--- a/packages/editor-api/src/trajects.rs
+++ b/packages/editor-api/src/trajects.rs
@@ -259,16 +259,30 @@ fn validate_role(role: &str) -> Result<(), StatusCode> {
     }
 }
 
-/// Normalise an email for storage and comparison: trim whitespace and
-/// lowercase. Empty results become `None` so callers can return 400
-/// instead of inserting an empty key.
+/// Normalise an email for storage and comparison: trim whitespace,
+/// lowercase, and reject obvious non-emails so junk addresses can't
+/// accumulate as pending invites that will never promote.
+///
+/// We intentionally avoid pulling in a full RFC 5322 parser: invite
+/// creation is owner-only behind OIDC, so this is correctness/data
+/// hygiene rather than a security boundary. The structural check is:
+/// exactly one `@`, non-empty local part, non-empty domain part, and a
+/// `.` in the domain. The IdP is the source of truth for whether an
+/// address is actually deliverable.
 fn normalize_email(raw: &str) -> Option<String> {
     let trimmed = raw.trim();
     if trimmed.is_empty() {
-        None
-    } else {
-        Some(trimmed.to_lowercase())
+        return None;
     }
+    let at_count = trimmed.bytes().filter(|b| *b == b'@').count();
+    if at_count != 1 {
+        return None;
+    }
+    let (local, domain) = trimmed.split_once('@')?;
+    if local.is_empty() || domain.is_empty() || !domain.contains('.') {
+        return None;
+    }
+    Some(trimmed.to_lowercase())
 }
 
 fn validate_status(status: &str) -> Result<(), StatusCode> {
@@ -338,16 +352,25 @@ pub async fn get(
     .await
     .map_err(db_err("traject members fetch failed"))?;
 
-    let pending_invites: Vec<TrajectInvite> = sqlx::query_as(
-        "SELECT email, role::text AS role
-         FROM traject_invites
-         WHERE traject_id = $1
-         ORDER BY invited_at",
-    )
-    .bind(id)
-    .fetch_all(pool)
-    .await
-    .map_err(db_err("traject invites fetch failed"))?;
+    // Pending invites carry the email addresses of people the owner has
+    // invited but who haven't yet logged in. Only owners — who can act
+    // on invites (cancel, re-invite, change role) — get to see them;
+    // contributors get an empty list. This keeps invitee emails out of
+    // a non-owner's view by default.
+    let pending_invites: Vec<TrajectInvite> = if role == "owner" {
+        sqlx::query_as(
+            "SELECT email, role::text AS role
+             FROM traject_invites
+             WHERE traject_id = $1
+             ORDER BY invited_at",
+        )
+        .bind(id)
+        .fetch_all(pool)
+        .await
+        .map_err(db_err("traject invites fetch failed"))?
+    } else {
+        Vec::new()
+    };
 
     let sources: Vec<TrajectSourceDto> = sqlx::query_as(
         "SELECT source_id, name, source_type::text AS source_type,
@@ -646,6 +669,18 @@ pub async fn add_member(
         if affected == 0 {
             return Err(StatusCode::CONFLICT);
         }
+        // Clean up any stale invite for this email on the same traject.
+        // Race: an account can be created between an earlier
+        // `add_member` that parked an invite and a later `add_member`
+        // that found the account — without this delete, GET would
+        // return the user in both `members` and `pending_invites` until
+        // their next request triggered `promote_pending_invites`.
+        sqlx::query("DELETE FROM traject_invites WHERE traject_id = $1 AND email = $2")
+            .bind(id)
+            .bind(&email)
+            .execute(pool)
+            .await
+            .map_err(db_err("clean up stale invite"))?;
         return Ok(Json(AddMemberResponse {
             status: "active",
             email,

--- a/packages/editor-api/src/trajects.rs
+++ b/packages/editor-api/src/trajects.rs
@@ -638,6 +638,12 @@ pub async fn add_member(
         // demoted to contributor) the SELECT returns no row, the INSERT
         // runs zero times, no conflict triggers, and `rows_affected` is
         // 0 → CONFLICT.
+        //
+        // Transaction: the INSERT and the stale-invite cleanup must
+        // commit together. If the cleanup failed mid-flight, GET would
+        // briefly return the user in both `members` and `pending_invites`
+        // until `promote_pending_invites` next ran.
+        let mut tx = pool.begin().await.map_err(db_err("begin add_member tx"))?;
         let affected = sqlx::query(
             "INSERT INTO traject_members (traject_id, account_id, role)
              SELECT $1, $2, $3::traject_role
@@ -661,7 +667,7 @@ pub async fn add_member(
         .bind(id)
         .bind(target_id)
         .bind(&req.role)
-        .execute(pool)
+        .execute(&mut *tx)
         .await
         .map_err(db_err("add member"))?
         .rows_affected();
@@ -669,18 +675,13 @@ pub async fn add_member(
         if affected == 0 {
             return Err(StatusCode::CONFLICT);
         }
-        // Clean up any stale invite for this email on the same traject.
-        // Race: an account can be created between an earlier
-        // `add_member` that parked an invite and a later `add_member`
-        // that found the account — without this delete, GET would
-        // return the user in both `members` and `pending_invites` until
-        // their next request triggered `promote_pending_invites`.
         sqlx::query("DELETE FROM traject_invites WHERE traject_id = $1 AND email = $2")
             .bind(id)
             .bind(&email)
-            .execute(pool)
+            .execute(&mut *tx)
             .await
             .map_err(db_err("clean up stale invite"))?;
+        tx.commit().await.map_err(db_err("commit add_member tx"))?;
         return Ok(Json(AddMemberResponse {
             status: "active",
             email,

--- a/packages/editor-api/tests/save_annotations_test.rs
+++ b/packages/editor-api/tests/save_annotations_test.rs
@@ -121,7 +121,7 @@ async fn local_traject(pool: &PgPool, owner_id: Uuid, corpus_dir: &std::path::Pa
 
     sqlx::query(
         "INSERT INTO traject_members (traject_id, account_id, role)
-         VALUES ($1, $2, 'beheerder')",
+         VALUES ($1, $2, 'owner')",
     )
     .bind(traject_id)
     .bind(owner_id)

--- a/packages/editor-api/tests/trajects_test.rs
+++ b/packages/editor-api/tests/trajects_test.rs
@@ -846,3 +846,114 @@ async fn remove_invite_requires_owner() {
     .unwrap_err();
     assert_eq!(err, StatusCode::FORBIDDEN);
 }
+
+#[tokio::test]
+async fn add_member_active_path_cleans_up_stale_invite() {
+    // Race window: invite an unknown email → ghost's account gets
+    // created later (e.g. they registered with the IdP but haven't
+    // hit any API yet, so promote_pending_invites hasn't run) → owner
+    // re-invites. The active path must clean up the stale invite so
+    // GET doesn't return ghost in both members and pending_invites.
+    let db = TestDb::new().await;
+    let state = empty_state(db.pool.clone());
+    let alice = seed_account(&db.pool, "alice@test.local", "Alice").await;
+    let traject_id = create_traject(&state, &alice, "Tarief").await;
+
+    assert_eq!(
+        add_member(
+            &state,
+            &alice,
+            traject_id,
+            "ghost@test.local",
+            "contributor"
+        )
+        .await,
+        Ok("pending")
+    );
+
+    // Ghost's account materialises (e.g. via OIDC login) but
+    // promote_pending_invites hasn't run yet.
+    let _ghost = seed_account(&db.pool, "ghost@test.local", "Ghost").await;
+
+    // Owner re-invites — now the active path is taken.
+    assert_eq!(
+        add_member(
+            &state,
+            &alice,
+            traject_id,
+            "ghost@test.local",
+            "contributor"
+        )
+        .await,
+        Ok("active")
+    );
+
+    let (invite_count,): (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM traject_invites WHERE traject_id = $1")
+            .bind(traject_id)
+            .fetch_one(&db.pool)
+            .await
+            .unwrap();
+    assert_eq!(invite_count, 0, "stale invite must be cleaned up");
+}
+
+#[tokio::test]
+async fn get_hides_pending_invites_from_contributors() {
+    let db = TestDb::new().await;
+    let state = empty_state(db.pool.clone());
+    let alice = seed_account(&db.pool, "alice@test.local", "Alice").await;
+    let bob = seed_account(&db.pool, "bob@test.local", "Bob").await;
+    let traject_id = create_traject(&state, &alice, "Tarief").await;
+    add_member(&state, &alice, traject_id, &bob.email, "contributor")
+        .await
+        .unwrap();
+    add_member(
+        &state,
+        &alice,
+        traject_id,
+        "ghost@test.local",
+        "contributor",
+    )
+    .await
+    .unwrap();
+
+    // Alice (owner) sees the pending invite.
+    let Json(owner_view) = trajects::get(State(state.clone()), Extension(alice), Path(traject_id))
+        .await
+        .unwrap();
+    assert_eq!(owner_view.pending_invites.len(), 1);
+
+    // Bob (contributor) does not.
+    let Json(contributor_view) = trajects::get(State(state), Extension(bob), Path(traject_id))
+        .await
+        .unwrap();
+    assert_eq!(contributor_view.pending_invites.len(), 0);
+    assert_eq!(
+        contributor_view.members.len(),
+        2,
+        "members list itself still visible to contributors"
+    );
+}
+
+#[tokio::test]
+async fn add_member_rejects_malformed_emails() {
+    let db = TestDb::new().await;
+    let state = empty_state(db.pool.clone());
+    let alice = seed_account(&db.pool, "alice@test.local", "Alice").await;
+    let traject_id = create_traject(&state, &alice, "Tarief").await;
+
+    for bad in [
+        "notanemail",
+        "@nolocal.com",
+        "nodomain@",
+        "no-dot-in-domain@localhost",
+        "two@@signs.com",
+        "   ",
+    ] {
+        assert_eq!(
+            add_member(&state, &alice, traject_id, bad, "contributor").await,
+            Err(StatusCode::BAD_REQUEST),
+            "expected 400 for {bad:?}",
+        );
+    }
+}

--- a/packages/editor-api/tests/trajects_test.rs
+++ b/packages/editor-api/tests/trajects_test.rs
@@ -101,16 +101,20 @@ async fn create_traject(state: &AppState, owner: &AccountRecord, name: &str) -> 
     summary.id
 }
 
+/// Test helper that calls `trajects::add_member` and returns either the
+/// resulting `(StatusCode::OK, "active" | "pending")` on success or the
+/// error status on failure. Tests that care about the response body call
+/// `trajects::add_member` directly.
 async fn add_member(
     state: &AppState,
-    beheerder: &AccountRecord,
+    owner: &AccountRecord,
     traject_id: Uuid,
     invitee_email: &str,
     role: &str,
-) -> StatusCode {
+) -> Result<&'static str, StatusCode> {
     trajects::add_member(
         State(state.clone()),
-        Extension(beheerder.clone()),
+        Extension(owner.clone()),
         Path(traject_id),
         Json(AddMemberRequest {
             email: invitee_email.to_string(),
@@ -118,7 +122,7 @@ async fn add_member(
         }),
     )
     .await
-    .unwrap_or_else(|s| s)
+    .map(|Json(body)| body.status)
 }
 
 fn make_session() -> Session {
@@ -130,7 +134,7 @@ fn make_session() -> Session {
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
-async fn create_inserts_traject_with_owner_as_beheerder_and_writable_own_source() {
+async fn create_inserts_traject_with_creator_as_owner_and_writable_own_source() {
     let db = TestDb::new().await;
     let state = empty_state(db.pool.clone());
     let alice = seed_account(&db.pool, "alice@test.local", "Alice").await;
@@ -146,7 +150,7 @@ async fn create_inserts_traject_with_owner_as_beheerder_and_writable_own_source(
     assert_eq!(status, StatusCode::CREATED);
     assert_eq!(summary.name, "Tarief");
     assert_eq!(summary.status, "bezig");
-    assert_eq!(summary.role, "beheerder");
+    assert_eq!(summary.role, "owner");
 
     let (role,): (String,) = sqlx::query_as(
         "SELECT role::text FROM traject_members WHERE traject_id = $1 AND account_id = $2",
@@ -156,7 +160,7 @@ async fn create_inserts_traject_with_owner_as_beheerder_and_writable_own_source(
     .fetch_one(&db.pool)
     .await
     .unwrap();
-    assert_eq!(role, "beheerder");
+    assert_eq!(role, "owner");
 
     let (priority, is_writable_own, gh_branch): (i32, bool, String) = sqlx::query_as(
         "SELECT priority, is_writable_own, gh_branch
@@ -241,7 +245,7 @@ async fn get_returns_detail_for_member() {
         .await
         .unwrap();
     assert_eq!(detail.summary.id, traject_id);
-    assert_eq!(detail.summary.role, "beheerder");
+    assert_eq!(detail.summary.role, "owner");
     assert_eq!(detail.members.len(), 1);
     assert_eq!(detail.members[0].account_id, alice.id);
     // Only the writable-own source is present because the empty CorpusState
@@ -255,15 +259,15 @@ async fn get_returns_detail_for_member() {
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
-async fn update_rejects_lid_and_accepts_beheerder() {
+async fn update_rejects_contributor_and_accepts_owner() {
     let db = TestDb::new().await;
     let state = empty_state(db.pool.clone());
     let alice = seed_account(&db.pool, "alice@test.local", "Alice").await;
     let bob = seed_account(&db.pool, "bob@test.local", "Bob").await;
     let traject_id = create_traject(&state, &alice, "Tarief").await;
     assert_eq!(
-        add_member(&state, &alice, traject_id, &bob.email, "lid").await,
-        StatusCode::NO_CONTENT
+        add_member(&state, &alice, traject_id, &bob.email, "contributor").await,
+        Ok("active")
     );
 
     let body = UpdateTrajectRequest {
@@ -273,7 +277,7 @@ async fn update_rejects_lid_and_accepts_beheerder() {
         status: None,
     };
 
-    // lid → 403
+    // contributor → 403
     let err = trajects::update(
         State(state.clone()),
         Extension(bob),
@@ -289,7 +293,7 @@ async fn update_rejects_lid_and_accepts_beheerder() {
     .unwrap_err();
     assert_eq!(err, StatusCode::FORBIDDEN);
 
-    // beheerder → 204
+    // owner → 204
     let ok = trajects::update(
         State(state.clone()),
         Extension(alice.clone()),
@@ -336,14 +340,75 @@ async fn update_validates_status_enum() {
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
-async fn add_member_returns_404_when_email_has_no_account() {
+async fn add_member_with_unknown_email_creates_pending_invite() {
     let db = TestDb::new().await;
     let state = empty_state(db.pool.clone());
     let alice = seed_account(&db.pool, "alice@test.local", "Alice").await;
     let traject_id = create_traject(&state, &alice, "Tarief").await;
 
-    let status = add_member(&state, &alice, traject_id, "ghost@test.local", "lid").await;
-    assert_eq!(status, StatusCode::NOT_FOUND);
+    let status = add_member(
+        &state,
+        &alice,
+        traject_id,
+        "ghost@test.local",
+        "contributor",
+    )
+    .await;
+    assert_eq!(status, Ok("pending"));
+
+    let (email, role): (String, String) =
+        sqlx::query_as("SELECT email, role::text FROM traject_invites WHERE traject_id = $1")
+            .bind(traject_id)
+            .fetch_one(&db.pool)
+            .await
+            .unwrap();
+    assert_eq!(email, "ghost@test.local");
+    assert_eq!(role, "contributor");
+
+    // No traject_members row was created — only the inviter.
+    let (member_count,): (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM traject_members WHERE traject_id = $1")
+            .bind(traject_id)
+            .fetch_one(&db.pool)
+            .await
+            .unwrap();
+    assert_eq!(member_count, 1);
+}
+
+#[tokio::test]
+async fn add_member_normalizes_email_case_for_pending_invites() {
+    let db = TestDb::new().await;
+    let state = empty_state(db.pool.clone());
+    let alice = seed_account(&db.pool, "alice@test.local", "Alice").await;
+    let traject_id = create_traject(&state, &alice, "Tarief").await;
+
+    assert_eq!(
+        add_member(
+            &state,
+            &alice,
+            traject_id,
+            "Mixed@Case.LOCAL",
+            "contributor"
+        )
+        .await,
+        Ok("pending")
+    );
+    // A re-invite using a different casing of the same email must
+    // collide on the (traject_id, email) primary key.
+    assert_eq!(
+        add_member(&state, &alice, traject_id, "mixed@case.local", "owner").await,
+        Ok("pending")
+    );
+
+    let rows: Vec<(String, String)> =
+        sqlx::query_as("SELECT email, role::text FROM traject_invites WHERE traject_id = $1")
+            .bind(traject_id)
+            .fetch_all(&db.pool)
+            .await
+            .unwrap();
+    assert_eq!(rows.len(), 1, "case variants must collide");
+    assert_eq!(rows[0].0, "mixed@case.local");
+    assert_eq!(rows[0].1, "owner", "re-invite updates the role");
 }
 
 #[tokio::test]
@@ -355,12 +420,12 @@ async fn add_member_upserts_role_on_conflict() {
     let traject_id = create_traject(&state, &alice, "Tarief").await;
 
     assert_eq!(
-        add_member(&state, &alice, traject_id, &bob.email, "lid").await,
-        StatusCode::NO_CONTENT
+        add_member(&state, &alice, traject_id, &bob.email, "contributor").await,
+        Ok("active")
     );
     assert_eq!(
-        add_member(&state, &alice, traject_id, &bob.email, "beheerder").await,
-        StatusCode::NO_CONTENT
+        add_member(&state, &alice, traject_id, &bob.email, "owner").await,
+        Ok("active")
     );
 
     let (role,): (String,) = sqlx::query_as(
@@ -371,24 +436,24 @@ async fn add_member_upserts_role_on_conflict() {
     .fetch_one(&db.pool)
     .await
     .unwrap();
-    assert_eq!(role, "beheerder");
+    assert_eq!(role, "owner");
 }
 
 #[tokio::test]
-async fn add_member_blocks_demoting_last_beheerder_via_upsert() {
+async fn add_member_blocks_demoting_last_owner_via_upsert() {
     // Without this guard, add_member would be a back-door around the
-    // last-beheerder check that update_member already enforces.
+    // last-owner check that update_member already enforces.
     let db = TestDb::new().await;
     let state = empty_state(db.pool.clone());
     let alice = seed_account(&db.pool, "alice@test.local", "Alice").await;
     let traject_id = create_traject(&state, &alice, "Tarief").await;
 
-    let status = add_member(&state, &alice, traject_id, &alice.email, "lid").await;
-    assert_eq!(status, StatusCode::CONFLICT);
+    let status = add_member(&state, &alice, traject_id, &alice.email, "contributor").await;
+    assert_eq!(status, Err(StatusCode::CONFLICT));
 }
 
 #[tokio::test]
-async fn update_member_blocks_demoting_last_beheerder() {
+async fn update_member_blocks_demoting_last_owner() {
     let db = TestDb::new().await;
     let state = empty_state(db.pool.clone());
     let alice = seed_account(&db.pool, "alice@test.local", "Alice").await;
@@ -399,7 +464,7 @@ async fn update_member_blocks_demoting_last_beheerder() {
         Extension(alice.clone()),
         Path((traject_id, alice.id)),
         Json(UpdateMemberRequest {
-            role: "lid".to_string(),
+            role: "contributor".to_string(),
         }),
     )
     .await
@@ -408,7 +473,7 @@ async fn update_member_blocks_demoting_last_beheerder() {
 }
 
 #[tokio::test]
-async fn remove_member_blocks_removing_last_beheerder() {
+async fn remove_member_blocks_removing_last_owner() {
     let db = TestDb::new().await;
     let state = empty_state(db.pool.clone());
     let alice = seed_account(&db.pool, "alice@test.local", "Alice").await;
@@ -429,24 +494,24 @@ async fn remove_member_blocks_removing_last_beheerder() {
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
-async fn delete_is_beheerder_only_and_cascades() {
+async fn delete_is_owner_only_and_cascades() {
     let db = TestDb::new().await;
     let state = empty_state(db.pool.clone());
     let alice = seed_account(&db.pool, "alice@test.local", "Alice").await;
     let bob = seed_account(&db.pool, "bob@test.local", "Bob").await;
     let traject_id = create_traject(&state, &alice, "Tarief").await;
     assert_eq!(
-        add_member(&state, &alice, traject_id, &bob.email, "lid").await,
-        StatusCode::NO_CONTENT
+        add_member(&state, &alice, traject_id, &bob.email, "contributor").await,
+        Ok("active")
     );
 
-    // lid cannot delete
+    // contributor cannot delete
     let err = trajects::delete(State(state.clone()), Extension(bob), Path(traject_id))
         .await
         .unwrap_err();
     assert_eq!(err, StatusCode::FORBIDDEN);
 
-    // beheerder can
+    // owner can
     let ok = trajects::delete(State(state.clone()), Extension(alice), Path(traject_id))
         .await
         .unwrap();
@@ -472,7 +537,7 @@ async fn delete_is_beheerder_only_and_cascades() {
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
-async fn leave_blocks_last_beheerder() {
+async fn leave_blocks_last_owner() {
     let db = TestDb::new().await;
     let state = empty_state(db.pool.clone());
     let alice = seed_account(&db.pool, "alice@test.local", "Alice").await;
@@ -486,15 +551,15 @@ async fn leave_blocks_last_beheerder() {
 }
 
 #[tokio::test]
-async fn leave_allows_lid_and_clears_active_session_when_leaving_active_traject() {
+async fn leave_allows_contributor_and_clears_active_session_when_leaving_active_traject() {
     let db = TestDb::new().await;
     let state = empty_state(db.pool.clone());
     let alice = seed_account(&db.pool, "alice@test.local", "Alice").await;
     let bob = seed_account(&db.pool, "bob@test.local", "Bob").await;
     let traject_id = create_traject(&state, &alice, "Tarief").await;
     assert_eq!(
-        add_member(&state, &alice, traject_id, &bob.email, "lid").await,
-        StatusCode::NO_CONTENT
+        add_member(&state, &alice, traject_id, &bob.email, "contributor").await,
+        Ok("active")
     );
 
     let session = make_session();
@@ -578,4 +643,206 @@ async fn set_active_clears_session_when_traject_id_is_null() {
 
     let active: Option<Uuid> = session.get(SESSION_KEY_ACTIVE_TRAJECT).await.unwrap();
     assert_eq!(active, None);
+}
+
+// ---------------------------------------------------------------------------
+// Pending invites + promotion
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn pending_invite_is_promoted_to_membership_on_login() {
+    // End-to-end: owner invites an unknown email, the invitee later logs
+    // in (their account is upserted), and the next time
+    // `account_middleware` runs the invite turns into a real membership.
+    let db = TestDb::new().await;
+    let state = empty_state(db.pool.clone());
+    let alice = seed_account(&db.pool, "alice@test.local", "Alice").await;
+    let traject_id = create_traject(&state, &alice, "Tarief").await;
+
+    assert_eq!(
+        add_member(
+            &state,
+            &alice,
+            traject_id,
+            "Ghost@Test.Local",
+            "contributor"
+        )
+        .await,
+        Ok("pending")
+    );
+
+    // Simulate the invitee logging in: a new accounts row is created.
+    let ghost = seed_account(&db.pool, "ghost@test.local", "Ghost").await;
+
+    // Simulate `account_middleware` post-upsert step.
+    regelrecht_editor_api::accounts::promote_pending_invites(&db.pool, ghost.id, &ghost.email)
+        .await;
+
+    let (invite_count,): (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM traject_invites WHERE traject_id = $1")
+            .bind(traject_id)
+            .fetch_one(&db.pool)
+            .await
+            .unwrap();
+    assert_eq!(invite_count, 0);
+
+    let (role,): (String,) = sqlx::query_as(
+        "SELECT role::text FROM traject_members WHERE traject_id = $1 AND account_id = $2",
+    )
+    .bind(traject_id)
+    .bind(ghost.id)
+    .fetch_one(&db.pool)
+    .await
+    .unwrap();
+    assert_eq!(role, "contributor");
+
+    let Json(list) = trajects::list(State(state.clone()), Extension(ghost.clone()))
+        .await
+        .unwrap();
+    assert_eq!(list.len(), 1);
+    assert_eq!(list[0].id, traject_id);
+    assert_eq!(list[0].role, "contributor");
+}
+
+#[tokio::test]
+async fn promotion_is_idempotent_when_user_is_already_a_member() {
+    // Defence-in-depth: even if an invite somehow co-exists with a
+    // membership for the same email + traject, promotion must not error
+    // and the invite must be cleaned up. Bob's existing role wins.
+    let db = TestDb::new().await;
+    let state = empty_state(db.pool.clone());
+    let alice = seed_account(&db.pool, "alice@test.local", "Alice").await;
+    let bob = seed_account(&db.pool, "bob@test.local", "Bob").await;
+    let traject_id = create_traject(&state, &alice, "Tarief").await;
+
+    add_member(&state, &alice, traject_id, &bob.email, "contributor")
+        .await
+        .unwrap();
+
+    sqlx::query(
+        "INSERT INTO traject_invites (traject_id, email, role, invited_by)
+         VALUES ($1, $2, 'owner', $3)",
+    )
+    .bind(traject_id)
+    .bind(&bob.email)
+    .bind(alice.id)
+    .execute(&db.pool)
+    .await
+    .unwrap();
+
+    regelrecht_editor_api::accounts::promote_pending_invites(&db.pool, bob.id, &bob.email).await;
+
+    let (invite_count,): (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM traject_invites WHERE email = $1")
+            .bind(&bob.email)
+            .fetch_one(&db.pool)
+            .await
+            .unwrap();
+    assert_eq!(invite_count, 0);
+
+    let (role,): (String,) = sqlx::query_as(
+        "SELECT role::text FROM traject_members WHERE traject_id = $1 AND account_id = $2",
+    )
+    .bind(traject_id)
+    .bind(bob.id)
+    .fetch_one(&db.pool)
+    .await
+    .unwrap();
+    assert_eq!(role, "contributor");
+}
+
+#[tokio::test]
+async fn get_returns_pending_invites_alongside_members() {
+    let db = TestDb::new().await;
+    let state = empty_state(db.pool.clone());
+    let alice = seed_account(&db.pool, "alice@test.local", "Alice").await;
+    let traject_id = create_traject(&state, &alice, "Tarief").await;
+
+    assert_eq!(
+        add_member(
+            &state,
+            &alice,
+            traject_id,
+            "ghost@test.local",
+            "contributor"
+        )
+        .await,
+        Ok("pending")
+    );
+
+    let Json(detail) = trajects::get(State(state), Extension(alice), Path(traject_id))
+        .await
+        .unwrap();
+    assert_eq!(detail.members.len(), 1, "alice is still the only member");
+    assert_eq!(detail.pending_invites.len(), 1);
+    assert_eq!(detail.pending_invites[0].email, "ghost@test.local");
+    assert_eq!(detail.pending_invites[0].role, "contributor");
+}
+
+#[tokio::test]
+async fn remove_invite_deletes_and_is_idempotent_404() {
+    let db = TestDb::new().await;
+    let state = empty_state(db.pool.clone());
+    let alice = seed_account(&db.pool, "alice@test.local", "Alice").await;
+    let traject_id = create_traject(&state, &alice, "Tarief").await;
+
+    assert_eq!(
+        add_member(
+            &state,
+            &alice,
+            traject_id,
+            "ghost@test.local",
+            "contributor"
+        )
+        .await,
+        Ok("pending")
+    );
+
+    let ok = trajects::remove_invite(
+        State(state.clone()),
+        Extension(alice.clone()),
+        Path((traject_id, "ghost@test.local".to_string())),
+    )
+    .await
+    .unwrap();
+    assert_eq!(ok, StatusCode::NO_CONTENT);
+
+    let err = trajects::remove_invite(
+        State(state),
+        Extension(alice),
+        Path((traject_id, "ghost@test.local".to_string())),
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(err, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn remove_invite_requires_owner() {
+    let db = TestDb::new().await;
+    let state = empty_state(db.pool.clone());
+    let alice = seed_account(&db.pool, "alice@test.local", "Alice").await;
+    let bob = seed_account(&db.pool, "bob@test.local", "Bob").await;
+    let traject_id = create_traject(&state, &alice, "Tarief").await;
+    add_member(&state, &alice, traject_id, &bob.email, "contributor")
+        .await
+        .unwrap();
+    add_member(
+        &state,
+        &alice,
+        traject_id,
+        "ghost@test.local",
+        "contributor",
+    )
+    .await
+    .unwrap();
+
+    let err = trajects::remove_invite(
+        State(state),
+        Extension(bob),
+        Path((traject_id, "ghost@test.local".to_string())),
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(err, StatusCode::FORBIDDEN);
 }

--- a/packages/pipeline/migrations/0015_traject_invites.sql
+++ b/packages/pipeline/migrations/0015_traject_invites.sql
@@ -1,0 +1,32 @@
+-- Traject user management — invite-by-email with pending invites.
+--
+-- Two changes:
+-- 1. Rename traject_role enum values from Dutch (beheerder/lid) to English
+--    (owner/contributor). Future roles (reviewer, …) will be added here.
+--    ALTER TYPE … RENAME VALUE is in-place: existing traject_members rows
+--    are not rewritten, only the label changes.
+-- 2. Add traject_invites to hold invitations for emails that don't yet
+--    have an accounts row. account_middleware promotes matching invites
+--    into traject_members on the next authenticated request from the
+--    invited email, so onboarding new collaborators no longer requires
+--    them to have logged in before being invited.
+
+ALTER TYPE traject_role RENAME VALUE 'beheerder'  TO 'owner';
+ALTER TYPE traject_role RENAME VALUE 'lid'        TO 'contributor';
+
+CREATE TABLE traject_invites (
+    traject_id  UUID         NOT NULL REFERENCES trajects(id) ON DELETE CASCADE,
+    -- Stored lowercase by the API so the (traject_id, email) PK collides
+    -- on case variants of the same address. The promotion query compares
+    -- against the user's lowercased email claim.
+    email       TEXT         NOT NULL,
+    role        traject_role NOT NULL,
+    invited_by  UUID         NOT NULL REFERENCES accounts(id),
+    invited_at  TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    PRIMARY KEY (traject_id, email)
+);
+
+-- account_middleware promotes invites by exact email match on every
+-- authenticated request; the index keeps the common (empty-result) path
+-- sub-millisecond.
+CREATE INDEX idx_traject_invites_email ON traject_invites(email);

--- a/packages/pipeline/migrations/0016_accounts_lower_email_unique.sql
+++ b/packages/pipeline/migrations/0016_accounts_lower_email_unique.sql
@@ -1,0 +1,13 @@
+-- Functional unique index on lower(accounts.email).
+--
+-- `add_member` (and any future call site that maps an external email to
+-- an account) looks the account up case-insensitively:
+--   SELECT id FROM accounts WHERE lower(email) = $1
+-- A B-tree index on `email` (from migration 0014) cannot satisfy this
+-- predicate, so the lookup degrades to a sequential scan as `accounts`
+-- grows. Adding a functional unique index makes the lookup index-only
+-- and tightens the schema: case-variants of the same address can no
+-- longer coexist as two rows (existing data already satisfies this — no
+-- way to create case-variants today since accounts are keyed on
+-- `person_sub` and OIDC emails don't bounce between casings).
+CREATE UNIQUE INDEX idx_accounts_email_lower ON accounts (lower(email));


### PR DESCRIPTION
## Summary
- Renames the traject role enum from `beheerder/lid` to `owner/contributor` (PR #632 had it in Dutch).
- Adds a `traject_invites` table so owners can invite **any** email — known or unknown. Migration 0014's "no stub accounts" principle is preserved; OIDC is still the only path that creates `accounts` rows.
- `account_middleware` now promotes any pending invites matching the user's email after the upsert, so a freshly-invited user sees the traject on the next page load (no logout/login required).
- New UI: a **Beheer leden…** entry in the `TrajectMenu` dropdown opens a side-sheet showing active members, pending invites, and an invite form. Owner-only role/remove controls; non-owners see a *Verlaat traject* affordance.

## Background
On `origin/main` after PR #632 the membership flow already exists, but `add_member` rejects any email without an existing account (404). That blocks the typical onboarding flow — "invite a colleague by email." This PR is the smallest cut that fixes that and gets us a real members UI, without disturbing the existing layered RBAC (`editor-writer` app role still gates the API surface).

## Key changes
- `packages/pipeline/migrations/0015_traject_invites.sql` — enum rename + new `traject_invites(traject_id, email, role, invited_by, invited_at)` keyed on `(traject_id, email)`.
- `packages/editor-api/src/trajects.rs` — `add_member` splits on known/unknown email and returns `{status: "active" | "pending", email}`; new `remove_invite` handler; `TrajectDetail.pending_invites` exposed via `GET /api/trajects/:id`; helpers renamed to `require_owner`; email normalisation centralised in `normalize_email`.
- `packages/editor-api/src/accounts.rs` — new `promote_pending_invites` runs in `account_middleware` after the account upsert; ON CONFLICT DO NOTHING + unconditional DELETE keeps the path idempotent. Failures log but don't 500 the request.
- `packages/editor-api/src/main.rs` — register `DELETE /api/trajects/:id/invites/:email` under the same `editor-writer` + `account_middleware` stack.
- `frontend/src/components/TrajectMembersDialog.vue` + `frontend/src/composables/useTrajectMembers.js` — new side-sheet and the composable that owns members/invites state.
- `frontend/src/components/TrajectMenu.vue` — *Beheer leden…* entry, teleports the dialog at the menu's level.

## Authz model (unchanged in shape)
Two-layer: **app role** (`editor-writer` realm role gates the route group) AND **traject role** (`owner` can manage members, `contributor` cannot). Inviting someone requires both. The `accounts.email` UNIQUE invariant is preserved; emails are lowercased on both sides of every comparison.

## Test plan
- [x] `just format` clean
- [x] `just lint` clean (clippy with `-Dwarnings`)
- [x] `just build-check` clean
- [x] `just test` — 191 unit tests pass
- [x] `just editor-api-integration-test` — **23 traject tests pass**, including 7 new ones:
  - `add_member_with_unknown_email_creates_pending_invite`
  - `add_member_normalizes_email_case_for_pending_invites`
  - `pending_invite_is_promoted_to_membership_on_login`
  - `promotion_is_idempotent_when_user_is_already_a_member`
  - `get_returns_pending_invites_alongside_members`
  - `remove_invite_deletes_and_is_idempotent_404`
  - `remove_invite_requires_owner`
- [x] `frontend` build clean; vitest: 191/191 passing
- [ ] Manual against Keycloak dev realm with two test users — verify the invite/promote round-trip end-to-end through the UI
- [ ] Verify ZAD `prN` preview deploy comes up green (migration 0015 applies cleanly)

## Out of scope (deliberate)
- Email notifications for invites (no mail server yet)
- Address book / "users from my org" suggestions — will hook in as a separate composable when organisations land
- Link-sharing or invite shortcodes
- `reviewer` and other future roles — start with `owner/contributor` only