### PR TITLE
feat(editor): traject-aware reads via API-only backend

### DIFF
--- a/frontend/src/composables/useLaw.js
+++ b/frontend/src/composables/useLaw.js
@@ -5,6 +5,20 @@ import { getEditorSessionId, lastSavedPr, sanitizeSavedPr } from './useEditorSes
 // --- Shared law cache ---
 const lawCache = new Map();
 
+/**
+ * Drop every cached law-content entry. Called by the traject switcher
+ * after a successful active-traject change so the next read fetches the
+ * new traject's content via the API instead of returning a previously
+ * cached version from another traject (or from the no-traject scope).
+ *
+ * `lawCache` is keyed by law_id only — without this clear, switching
+ * trajecten with the editor open shows whichever traject the law was
+ * first opened in.
+ */
+export function clearLawCache() {
+  lawCache.clear();
+}
+
 export function resolveLawName(law) {
   if (!law) return '';
   const nameRef = law.name;

--- a/frontend/src/composables/useTrajects.js
+++ b/frontend/src/composables/useTrajects.js
@@ -1,4 +1,6 @@
 import { computed, ref } from 'vue';
+import router from '../router.js';
+import { clearLawCache } from './useLaw.js';
 
 const trajects = ref([]);
 const activeTrajectId = ref(null);
@@ -53,6 +55,23 @@ export async function switchTraject(trajectId) {
   if (!resp.ok) throw new Error(`Failed to switch traject: ${resp.status}`);
   const body = await resp.json();
   activeTrajectId.value = body.traject_id || null;
+
+  // After a successful switch the read scope on the server changed —
+  // GET /api/corpus/laws/... now serves the new traject's branch
+  // content (or the global view when the active id was cleared). Drop
+  // every cached law-content entry so the next fetch hits the API and
+  // navigate to the library so any open editor doesn't keep showing a
+  // mix of old (cached) and new (refetched) content.
+  clearLawCache();
+  // `navigate from anywhere` — non-Vue context, so we use the router
+  // export directly. Best-effort: if we're already at `/library`,
+  // `push` is a no-op.
+  try {
+    await router.push('/library');
+  } catch (_e) {
+    // NavigationDuplicated / NavigationAborted is benign; the cache
+    // clear above is the actually-load-bearing part of the switch.
+  }
   return activeTrajectId.value;
 }
 

--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -3651,6 +3651,7 @@ name = "regelrecht-corpus"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "base64 0.22.1",
  "jsonschema",
  "regelrecht-engine",
  "reqwest 0.13.2",

--- a/packages/corpus/Cargo.toml
+++ b/packages/corpus/Cargo.toml
@@ -20,11 +20,15 @@ serde_yaml_ng.workspace = true
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"], optional = true }
 serde_json = { workspace = true, optional = true }
 jsonschema = { version = "0.46", optional = true }
+base64 = { workspace = true, optional = true }
 walkdir.workspace = true
 
 [features]
 default = ["github"]
-github = ["dep:reqwest"]
+# The GitHub API backend (write path through Contents/Refs API) needs
+# JSON bodies and base64-encoded file contents, so `github` pulls both
+# in alongside reqwest.
+github = ["dep:reqwest", "dep:serde_json", "dep:base64"]
 # Schema validation for note (annotation) YAML. Pulls in jsonschema; only
 # the editor-api write path needs it, so it stays optional.
 annotation-validation = ["dep:jsonschema", "dep:serde_json"]

--- a/packages/corpus/src/error.rs
+++ b/packages/corpus/src/error.rs
@@ -16,6 +16,14 @@ pub enum CorpusError {
 
     #[error("write not supported: {0}")]
     ReadOnly(String),
+
+    /// Optimistic-concurrency conflict on a remote write (e.g. GitHub
+    /// Contents API returned 409 because the file's `sha` moved between
+    /// the read and the PUT). Surfaced separately from `Git` so a backend
+    /// can recognise it and retry with a fresh SHA without parsing error
+    /// strings.
+    #[error("conflict: {0}")]
+    Conflict(String),
 }
 
 pub type Result<T> = std::result::Result<T, CorpusError>;

--- a/packages/corpus/src/github.rs
+++ b/packages/corpus/src/github.rs
@@ -33,7 +33,6 @@ mod inner {
     #[derive(Debug, Clone)]
     pub struct DirectoryEntry {
         pub name: String,
-        pub path: String,
         /// `"file"` or `"dir"`. GitHub also reports `"submodule"` and
         /// `"symlink"`; the backend filters to `"file"` for listing.
         pub entry_type: String,
@@ -608,7 +607,6 @@ mod inner {
                 .into_iter()
                 .map(|i| DirectoryEntry {
                     name: i.name,
-                    path: i.path,
                     entry_type: i.entry_type,
                 })
                 .collect())

--- a/packages/corpus/src/github.rs
+++ b/packages/corpus/src/github.rs
@@ -7,13 +7,76 @@
 mod inner {
     use std::collections::{HashMap, HashSet};
 
+    use base64::Engine;
     use reqwest::header::{
-        HeaderMap, HeaderValue, ACCEPT, AUTHORIZATION, IF_NONE_MATCH, USER_AGENT,
+        HeaderMap, HeaderValue, ACCEPT, AUTHORIZATION, CONTENT_TYPE, IF_NONE_MATCH, USER_AGENT,
     };
-    use serde::Deserialize;
+    use serde::{Deserialize, Serialize};
 
     use crate::error::{CorpusError, Result};
     use crate::models::GitHubSource;
+
+    /// Commit identity used on Contents/Git Data API writes. Both
+    /// `committer` and `author` accept this shape — currently we set them
+    /// to the same value so the human editor shows up on both sides of the
+    /// git commit, and rely on the GitHub token's account for the actual
+    /// push credentials.
+    #[derive(Debug, Clone, Serialize)]
+    pub struct Committer {
+        pub name: String,
+        pub email: String,
+    }
+
+    /// Single entry returned by a Contents API directory listing. Only the
+    /// fields the backend needs are pulled off the JSON; GitHub returns
+    /// quite a bit more (url, html_url, size, …) that we don't use.
+    #[derive(Debug, Clone)]
+    pub struct DirectoryEntry {
+        pub name: String,
+        pub path: String,
+        /// `"file"` or `"dir"`. GitHub also reports `"submodule"` and
+        /// `"symlink"`; the backend filters to `"file"` for listing.
+        pub entry_type: String,
+    }
+
+    /// Raw shape of the Contents API response for a single path. Used both
+    /// for file reads (where `type == "file"`) and directory listings
+    /// (returned as a JSON array of these).
+    #[derive(Debug, Deserialize)]
+    struct ContentsItem {
+        name: String,
+        path: String,
+        sha: String,
+        #[serde(rename = "type")]
+        entry_type: String,
+        #[serde(default)]
+        content: Option<String>,
+        #[serde(default)]
+        encoding: Option<String>,
+    }
+
+    /// Subset of the Contents-API PUT response we care about. The full
+    /// response carries `content` and `commit` blocks; we only need the
+    /// new file SHA so callers can chain another write without re-reading.
+    #[derive(Debug, Deserialize)]
+    struct PutResponse {
+        content: PutContent,
+    }
+    #[derive(Debug, Deserialize)]
+    struct PutContent {
+        sha: String,
+    }
+
+    /// Refs-API response for `GET /git/ref/heads/{branch}`. We only need
+    /// the object SHA to use as the base for a new branch.
+    #[derive(Debug, Deserialize)]
+    struct RefResponse {
+        object: RefObject,
+    }
+    #[derive(Debug, Deserialize)]
+    struct RefObject {
+        sha: String,
+    }
 
     /// Result of fetching a GitHub source.
     #[derive(Debug)]
@@ -48,6 +111,10 @@ mod inner {
     /// GitHub fetcher with ETag caching and rate limit awareness.
     pub struct GitHubFetcher {
         client: reqwest::Client,
+        /// API base URL — overridable for tests against a wiremock server.
+        /// Production default is `"https://api.github.com"`. No trailing
+        /// slash; all callers prefix their `/...` path themselves.
+        api_base: String,
         /// ETag cache: URL → ETag value
         etag_cache: HashMap<String, String>,
         /// Remaining API calls before rate limit
@@ -66,9 +133,25 @@ mod inner {
 
             Ok(Self {
                 client,
+                api_base: "https://api.github.com".to_string(),
                 etag_cache: HashMap::new(),
                 rate_limit_remaining: None,
             })
+        }
+
+        /// Override the API base URL — for tests that point at a wiremock
+        /// server. Production callers use [`GitHubFetcher::new`] which
+        /// already points at `api.github.com`.
+        pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
+            self.set_base_url(base_url);
+            self
+        }
+
+        /// In-place variant of [`with_base_url`] for call sites that already
+        /// hold the fetcher by `&mut` (e.g. `GitHubApiBackend::with_api_base`
+        /// reaching through its `Mutex<Inner>`).
+        pub fn set_base_url(&mut self, base_url: impl Into<String>) {
+            self.api_base = base_url.into().trim_end_matches('/').to_string();
         }
 
         /// Fetch all YAML regulation files from a GitHub source.
@@ -242,8 +325,8 @@ mod inner {
             token: Option<&str>,
         ) -> Result<Option<Vec<String>>> {
             let url = format!(
-                "https://api.github.com/repos/{}/git/trees/{}?recursive=1",
-                repo, branch
+                "{}/repos/{}/git/trees/{}?recursive=1",
+                self.api_base, repo, branch
             );
 
             let mut headers = self.default_headers(token);
@@ -330,8 +413,8 @@ mod inner {
             token: Option<&str>,
         ) -> Result<String> {
             let url = format!(
-                "https://api.github.com/repos/{}/contents/{}?ref={}",
-                repo, path, branch
+                "{}/repos/{}/contents/{}?ref={}",
+                self.api_base, repo, path, branch
             );
 
             let mut headers = self.default_headers(token);
@@ -409,6 +492,387 @@ mod inner {
         pub fn rate_limit_remaining(&self) -> Option<u32> {
             self.rate_limit_remaining
         }
+
+        // -----------------------------------------------------------------
+        // Backend-oriented API (used by GitHubApiBackend; no ETag cache —
+        // backend reads want the current state of the branch on every
+        // call, not the cached one).
+        // -----------------------------------------------------------------
+
+        /// Fetch a single file's content **plus** its blob SHA. The SHA is
+        /// what the Contents API expects on a subsequent update PUT for
+        /// optimistic concurrency. Returns `Ok(None)` on 404.
+        pub async fn fetch_file_with_sha(
+            &mut self,
+            repo: &str,
+            branch: &str,
+            path: &str,
+            token: Option<&str>,
+        ) -> Result<Option<(String, String)>> {
+            let url = format!(
+                "{}/repos/{}/contents/{}?ref={}",
+                self.api_base, repo, path, branch
+            );
+            let headers = self.default_headers(token);
+            let response = self
+                .client
+                .get(&url)
+                .headers(headers)
+                .send()
+                .await
+                .map_err(|e| CorpusError::Git(format!("GitHub API request failed: {}", e)))?;
+            self.track_rate_limit(&response);
+
+            if response.status() == reqwest::StatusCode::NOT_FOUND {
+                return Ok(None);
+            }
+            if !response.status().is_success() {
+                return Err(CorpusError::Git(format!(
+                    "GitHub Contents API returned {} for {}: {}",
+                    response.status(),
+                    path,
+                    response.text().await.unwrap_or_default()
+                )));
+            }
+
+            let item: ContentsItem = response.json().await.map_err(|e| {
+                CorpusError::Git(format!("Failed to parse contents response: {}", e))
+            })?;
+            if item.entry_type != "file" {
+                return Err(CorpusError::Git(format!(
+                    "Path '{}' is a {}, not a file",
+                    path, item.entry_type
+                )));
+            }
+            let content = decode_contents_payload(&item)?;
+            Ok(Some((content, item.sha)))
+        }
+
+        /// List a directory via the Contents API. For a directory the
+        /// response is a JSON array of [`ContentsItem`]; for a missing
+        /// directory we return an empty list (404). Files only — sub-
+        /// directories, symlinks and submodules are filtered out by the
+        /// caller via [`DirectoryEntry::entry_type`].
+        pub async fn list_directory(
+            &mut self,
+            repo: &str,
+            branch: &str,
+            dir: &str,
+            token: Option<&str>,
+        ) -> Result<Vec<DirectoryEntry>> {
+            let url = format!(
+                "{}/repos/{}/contents/{}?ref={}",
+                self.api_base, repo, dir, branch
+            );
+            let headers = self.default_headers(token);
+            let response = self
+                .client
+                .get(&url)
+                .headers(headers)
+                .send()
+                .await
+                .map_err(|e| CorpusError::Git(format!("GitHub API request failed: {}", e)))?;
+            self.track_rate_limit(&response);
+
+            // 404 on a directory listing is the "no scenarios yet" path —
+            // same shape as the local LocalBackend.list_files when the
+            // directory doesn't exist.
+            if response.status() == reqwest::StatusCode::NOT_FOUND {
+                return Ok(Vec::new());
+            }
+            if !response.status().is_success() {
+                return Err(CorpusError::Git(format!(
+                    "GitHub Contents API returned {} for {}: {}",
+                    response.status(),
+                    dir,
+                    response.text().await.unwrap_or_default()
+                )));
+            }
+
+            // The endpoint returns an array for directories and a single
+            // object for files. We only call this for directories, but if
+            // someone calls it on a file path we still return Ok([]) (the
+            // file is not a directory).
+            let body = response.text().await.map_err(|e| {
+                CorpusError::Git(format!("Failed to read directory listing: {}", e))
+            })?;
+            let trimmed = body.trim_start();
+            if !trimmed.starts_with('[') {
+                tracing::debug!(dir = %dir, "list_directory: path is not a directory");
+                return Ok(Vec::new());
+            }
+            let items: Vec<ContentsItem> = serde_json::from_str(&body).map_err(|e| {
+                CorpusError::Git(format!("Failed to parse directory listing: {}", e))
+            })?;
+            Ok(items
+                .into_iter()
+                .map(|i| DirectoryEntry {
+                    name: i.name,
+                    path: i.path,
+                    entry_type: i.entry_type,
+                })
+                .collect())
+        }
+
+        /// Upsert a file via Contents API PUT. Pass `base_sha = None` to
+        /// create a new file, `Some(sha)` to update an existing one. The
+        /// branch must exist (see [`ensure_branch`]). Returns the new blob
+        /// SHA so callers can chain writes without an extra GET.
+        ///
+        /// Maps 409 to [`CorpusError::Conflict`] so backends can detect a
+        /// concurrent-write race and retry; everything else is `Git`.
+        #[allow(clippy::too_many_arguments)]
+        pub async fn put_file(
+            &mut self,
+            repo: &str,
+            branch: &str,
+            path: &str,
+            content: &str,
+            base_sha: Option<&str>,
+            committer: &Committer,
+            message: &str,
+            token: Option<&str>,
+        ) -> Result<String> {
+            let url = format!("{}/repos/{}/contents/{}", self.api_base, repo, path);
+            let mut body = serde_json::json!({
+                "message": message,
+                "content": base64::engine::general_purpose::STANDARD.encode(content.as_bytes()),
+                "branch": branch,
+                "committer": committer,
+                "author": committer,
+            });
+            if let Some(sha) = base_sha {
+                body["sha"] = serde_json::Value::String(sha.to_string());
+            }
+
+            let mut headers = self.default_headers(token);
+            headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+
+            let response = self
+                .client
+                .put(&url)
+                .headers(headers)
+                .body(body.to_string())
+                .send()
+                .await
+                .map_err(|e| CorpusError::Git(format!("GitHub API request failed: {}", e)))?;
+            self.track_rate_limit(&response);
+
+            let status = response.status();
+            if status == reqwest::StatusCode::CONFLICT {
+                return Err(CorpusError::Conflict(format!(
+                    "Contents API PUT {} hit a 409 (stale sha)",
+                    path
+                )));
+            }
+            if !status.is_success() {
+                return Err(CorpusError::Git(format!(
+                    "GitHub Contents API PUT {} returned {}: {}",
+                    path,
+                    status,
+                    response.text().await.unwrap_or_default()
+                )));
+            }
+            let parsed: PutResponse = response
+                .json()
+                .await
+                .map_err(|e| CorpusError::Git(format!("Failed to parse PUT response: {}", e)))?;
+            Ok(parsed.content.sha)
+        }
+
+        /// Delete a file via Contents API DELETE. Requires the current
+        /// blob SHA. 404 is treated as "already gone" (idempotent — same
+        /// shape as [`crate::backend::RepoBackend::delete_file`]).
+        #[allow(clippy::too_many_arguments)]
+        pub async fn delete_file_via_api(
+            &mut self,
+            repo: &str,
+            branch: &str,
+            path: &str,
+            sha: &str,
+            committer: &Committer,
+            message: &str,
+            token: Option<&str>,
+        ) -> Result<()> {
+            let url = format!("{}/repos/{}/contents/{}", self.api_base, repo, path);
+            let body = serde_json::json!({
+                "message": message,
+                "sha": sha,
+                "branch": branch,
+                "committer": committer,
+                "author": committer,
+            });
+
+            let mut headers = self.default_headers(token);
+            headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+
+            let response = self
+                .client
+                .delete(&url)
+                .headers(headers)
+                .body(body.to_string())
+                .send()
+                .await
+                .map_err(|e| CorpusError::Git(format!("GitHub API request failed: {}", e)))?;
+            self.track_rate_limit(&response);
+
+            let status = response.status();
+            if status == reqwest::StatusCode::NOT_FOUND {
+                return Ok(());
+            }
+            if status == reqwest::StatusCode::CONFLICT {
+                return Err(CorpusError::Conflict(format!(
+                    "Contents API DELETE {} hit a 409 (stale sha)",
+                    path
+                )));
+            }
+            if !status.is_success() {
+                return Err(CorpusError::Git(format!(
+                    "GitHub Contents API DELETE {} returned {}: {}",
+                    path,
+                    status,
+                    response.text().await.unwrap_or_default()
+                )));
+            }
+            Ok(())
+        }
+
+        /// Check whether a branch exists. Returns `Ok(true)` on 200,
+        /// `Ok(false)` on 404, error on anything else.
+        pub async fn branch_exists(
+            &mut self,
+            repo: &str,
+            branch: &str,
+            token: Option<&str>,
+        ) -> Result<bool> {
+            let url = format!("{}/repos/{}/git/ref/heads/{}", self.api_base, repo, branch);
+            let headers = self.default_headers(token);
+            let response = self
+                .client
+                .get(&url)
+                .headers(headers)
+                .send()
+                .await
+                .map_err(|e| CorpusError::Git(format!("GitHub API request failed: {}", e)))?;
+            self.track_rate_limit(&response);
+
+            let status = response.status();
+            if status.is_success() {
+                return Ok(true);
+            }
+            if status == reqwest::StatusCode::NOT_FOUND {
+                return Ok(false);
+            }
+            Err(CorpusError::Git(format!(
+                "GitHub Refs API returned {} for {}@{}: {}",
+                status,
+                repo,
+                branch,
+                response.text().await.unwrap_or_default()
+            )))
+        }
+
+        /// Create `branch` pointing at the tip of `base_branch`. The base
+        /// branch must already exist; the target branch must NOT exist
+        /// (GitHub returns 422 otherwise — surfaced as `Git`).
+        pub async fn create_branch(
+            &mut self,
+            repo: &str,
+            branch: &str,
+            base_branch: &str,
+            token: Option<&str>,
+        ) -> Result<()> {
+            // 1) resolve the base ref's SHA
+            let base_url = format!(
+                "{}/repos/{}/git/ref/heads/{}",
+                self.api_base, repo, base_branch
+            );
+            let headers = self.default_headers(token);
+            let response = self
+                .client
+                .get(&base_url)
+                .headers(headers)
+                .send()
+                .await
+                .map_err(|e| CorpusError::Git(format!("GitHub API request failed: {}", e)))?;
+            self.track_rate_limit(&response);
+            if !response.status().is_success() {
+                return Err(CorpusError::Git(format!(
+                    "Could not resolve base branch {}@{}: {}",
+                    repo,
+                    base_branch,
+                    response.text().await.unwrap_or_default()
+                )));
+            }
+            let parsed: RefResponse = response
+                .json()
+                .await
+                .map_err(|e| CorpusError::Git(format!("Failed to parse base ref: {}", e)))?;
+
+            // 2) POST a new ref pointing at the same SHA
+            let post_url = format!("{}/repos/{}/git/refs", self.api_base, repo);
+            let body = serde_json::json!({
+                "ref": format!("refs/heads/{}", branch),
+                "sha": parsed.object.sha,
+            });
+            let mut headers = self.default_headers(token);
+            headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+            let response = self
+                .client
+                .post(&post_url)
+                .headers(headers)
+                .body(body.to_string())
+                .send()
+                .await
+                .map_err(|e| CorpusError::Git(format!("GitHub API request failed: {}", e)))?;
+            self.track_rate_limit(&response);
+            if !response.status().is_success() {
+                return Err(CorpusError::Git(format!(
+                    "GitHub Refs API POST returned {} for {}@{}: {}",
+                    response.status(),
+                    repo,
+                    branch,
+                    response.text().await.unwrap_or_default()
+                )));
+            }
+            Ok(())
+        }
+    }
+
+    /// Decode a Contents-API response's content payload. The API returns
+    /// either base64-encoded content (default `encoding: "base64"`) or a
+    /// raw string when `application/vnd.github.raw+json` was requested —
+    /// but the JSON path always gives us base64, so we only handle that.
+    /// Files larger than 1 MiB come back without `content` (encoding
+    /// `"none"`); for those the Git Blob API is the documented route.
+    fn decode_contents_payload(item: &ContentsItem) -> Result<String> {
+        let encoding = item.encoding.as_deref().unwrap_or("base64");
+        if encoding != "base64" {
+            return Err(CorpusError::Git(format!(
+                "Contents API returned unsupported encoding '{}' for {} \
+                 (large file? use the Blob API)",
+                encoding, item.path
+            )));
+        }
+        let content = item.content.as_deref().ok_or_else(|| {
+            CorpusError::Git(format!(
+                "Contents API returned no content for {} (possibly >1 MiB)",
+                item.path
+            ))
+        })?;
+        // The API wraps the base64 at 60 chars per line — strip whitespace
+        // before decoding.
+        let cleaned: String = content
+            .chars()
+            .filter(|c| !c.is_ascii_whitespace())
+            .collect();
+        let bytes = base64::engine::general_purpose::STANDARD
+            .decode(cleaned.as_bytes())
+            .map_err(|e| {
+                CorpusError::Git(format!("Base64 decode failed for {}: {}", item.path, e))
+            })?;
+        String::from_utf8(bytes)
+            .map_err(|e| CorpusError::Git(format!("UTF-8 decode failed for {}: {}", item.path, e)))
     }
 }
 

--- a/packages/corpus/src/github_api_backend.rs
+++ b/packages/corpus/src/github_api_backend.rs
@@ -303,11 +303,13 @@ impl RepoBackend for GitHubApiBackend {
         let repo = self.full_repo();
         let mut new_shas: HashMap<PathBuf, String> = HashMap::new();
 
-        // Capture the buffer back if anything fails partway through, so
-        // a caller-side retry isn't forced to re-collect the same writes.
-        // GitHubFetcher methods are `&mut`, so a single lock guard around
-        // the whole loop is cheap (no other writer can pile on while we
-        // flush).
+        // Take one lock guard for the whole loop so the &mut GitHubFetcher
+        // calls inside don't pay re-acquire cost per-write. The pending
+        // buffer was already drained above; if any write fails we propagate
+        // via `?` and the remaining (still-untaken-from-buffer) entries are
+        // dropped — fine in practice because each handler only enqueues a
+        // single write before calling persist, so there is no partially-
+        // applied multi-write batch to recover here.
         let mut inner = self.inner.lock().await;
         for (path, pw) in pending {
             let api_path = self.api_path(&path)?;
@@ -396,16 +398,43 @@ impl RepoBackend for GitHubApiBackend {
                 self.branch, self.owner, self.repo
             ))
         })?;
-        inner
+        // TOCTOU on lazy branch creation: between our `branch_exists`
+        // returning false and this POST, another activation (different
+        // backend instance, same traject) can win the race and create
+        // the branch first. GitHub then 422s us with "Reference already
+        // exists". Re-check `branch_exists` on any create_branch failure;
+        // if the branch is present now the desired post-condition holds
+        // and we treat the create as a benign no-op.
+        match inner
             .fetcher
             .create_branch(&repo, &self.branch, base, self.token.as_deref())
-            .await?;
-        tracing::info!(
-            repo = %repo,
-            branch = %self.branch,
-            base = %base,
-            "GitHubApiBackend: created traject branch from base"
-        );
+            .await
+        {
+            Ok(()) => {
+                tracing::info!(
+                    repo = %repo,
+                    branch = %self.branch,
+                    base = %base,
+                    "GitHubApiBackend: created traject branch from base"
+                );
+            }
+            Err(e) => {
+                let now_exists = inner
+                    .fetcher
+                    .branch_exists(&repo, &self.branch, self.token.as_deref())
+                    .await
+                    .unwrap_or(false);
+                if now_exists {
+                    tracing::info!(
+                        repo = %repo,
+                        branch = %self.branch,
+                        "GitHubApiBackend: create_branch lost a benign race; branch already exists"
+                    );
+                } else {
+                    return Err(e);
+                }
+            }
+        }
         Ok(())
     }
 

--- a/packages/corpus/src/github_api_backend.rs
+++ b/packages/corpus/src/github_api_backend.rs
@@ -60,8 +60,11 @@ enum PendingOp {
 struct Inner {
     fetcher: GitHubFetcher,
     /// Map from source-relative path → most recently observed blob SHA.
-    /// Populated by `read_file`, consumed by `persist`. Cleared on
-    /// successful persist so a new edit cycle starts from a fresh read.
+    /// Populated by `read_file`. On persist: entries for paths that were
+    /// written are refreshed with the post-commit SHA; entries for paths
+    /// that were deleted are removed. Stale entries for paths neither
+    /// written nor deleted may linger — the next write's 409/retry path
+    /// covers that, so it stays correct.
     sha_cache: HashMap<PathBuf, String>,
     /// Buffered writes/deletes, in insertion order.
     pending: Vec<(PathBuf, PendingWrite)>,

--- a/packages/corpus/src/github_api_backend.rs
+++ b/packages/corpus/src/github_api_backend.rs
@@ -1,0 +1,538 @@
+//! API-only [`RepoBackend`] implementation against the GitHub REST API.
+//!
+//! No local git clone, no `/tmp` working tree. Reads go straight through
+//! the Contents API; writes buffer in memory and flush as one Contents
+//! API PUT/DELETE per file in [`persist`]. The branch is created lazily
+//! in [`ensure_ready`] when it doesn't yet exist on the remote
+//! ("traject branch on first activation").
+//!
+//! ## Atomicity
+//!
+//! The Contents API commits each PUT/DELETE separately. All current
+//! editor flows ([`save_law`], [`save_scenario`], [`delete_scenario`],
+//! [`save_annotations`]) write exactly one file per persist, so they are
+//! effectively atomic. A future multi-file save would need the Git Data
+//! API (blob → tree → commit → ref update) to land both files in a
+//! single commit; the implementation here would surface partial-failure
+//! state.
+//!
+//! ## Optimistic concurrency
+//!
+//! Each pending write carries the blob SHA that was current when the
+//! caller last read the file (or `None` if it was never read — e.g. a
+//! brand-new file). On the PUT, GitHub returns 409 if the SHA is stale.
+//! `persist` then re-reads the SHA and retries **once**; a second 409 is
+//! surfaced as [`CorpusError::Conflict`] for the caller to deal with.
+//! For `save_annotations`'s append-only flow this is safe because dedup
+//! happens against the freshly-read base before re-writing.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use async_trait::async_trait;
+use tokio::sync::Mutex;
+
+use crate::backend::{FileEntry, PersistOutcome, RepoBackend, WriteContext};
+use crate::error::{CorpusError, Result};
+use crate::github::{Committer, GitHubFetcher};
+use crate::models::GitHubSource;
+
+/// Pending change buffered between `write_file`/`delete_file` and
+/// `persist`. `base_sha` is `Some` when the caller read the file first
+/// (handlers that do read-modify-write, like `save_annotations`); for
+/// blind writes/deletes the backend resolves the SHA lazily at persist.
+#[derive(Debug, Clone)]
+struct PendingWrite {
+    op: PendingOp,
+    base_sha: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+enum PendingOp {
+    Upsert(String),
+    Delete,
+}
+
+/// Mutable state guarded by the backend's mutex. The fetcher lives here
+/// because its methods take `&mut self` (ETag cache + rate-limit
+/// tracking), and the SHA cache + pending buffer must be accessed from
+/// `&self` callbacks on the trait.
+struct Inner {
+    fetcher: GitHubFetcher,
+    /// Map from source-relative path → most recently observed blob SHA.
+    /// Populated by `read_file`, consumed by `persist`. Cleared on
+    /// successful persist so a new edit cycle starts from a fresh read.
+    sha_cache: HashMap<PathBuf, String>,
+    /// Buffered writes/deletes, in insertion order.
+    pending: Vec<(PathBuf, PendingWrite)>,
+}
+
+pub struct GitHubApiBackend {
+    owner: String,
+    repo: String,
+    branch: String,
+    /// Branch to seed the target branch from when it doesn't exist yet
+    /// (default for the editor traject flow: the writable repo's
+    /// default branch — `main` for the regelrecht-corpus repo).
+    base_branch: Option<String>,
+    /// Path prefix inside the repo (same role as `repo_subpath` on
+    /// `GitBackend`). Source-relative paths are joined under this.
+    sub_path: Option<String>,
+    /// OAuth/PAT token for the API. `None` makes the backend read-only.
+    token: Option<String>,
+    inner: Mutex<Inner>,
+}
+
+impl GitHubApiBackend {
+    pub fn new(
+        github: &GitHubSource,
+        base_branch: Option<String>,
+        token: Option<String>,
+    ) -> Result<Self> {
+        Ok(Self {
+            owner: github.owner.clone(),
+            repo: github.repo.clone(),
+            branch: github.effective_ref().to_string(),
+            base_branch,
+            sub_path: github.path.clone(),
+            token,
+            inner: Mutex::new(Inner {
+                fetcher: GitHubFetcher::new()?,
+                sha_cache: HashMap::new(),
+                pending: Vec::new(),
+            }),
+        })
+    }
+
+    /// Repoint the backend's underlying fetcher at a different API base
+    /// URL. Production code never calls this — it's the seam our
+    /// wiremock-backed unit tests use to avoid hitting the real GitHub.
+    /// Must be called before any other backend method (taking `&mut self`
+    /// makes that easy to enforce at the type level).
+    pub fn with_api_base(mut self, base_url: impl Into<String>) -> Self {
+        // `get_mut` is fine because we still hold &mut self, so the mutex
+        // isn't contended. Mutate the fetcher in place rather than
+        // rebuilding it (which would propagate a fallible
+        // `GitHubFetcher::new` call for what is meant to be a trivial
+        // test-only seam).
+        self.inner.get_mut().fetcher.set_base_url(base_url);
+        self
+    }
+
+    fn full_repo(&self) -> String {
+        format!("{}/{}", self.owner, self.repo)
+    }
+
+    /// Resolve a source-relative path to the in-repo path the GitHub API
+    /// expects (with `sub_path` prefix). Forward slashes always — GitHub
+    /// is OS-agnostic.
+    fn api_path(&self, relative: &Path) -> Result<String> {
+        validate_relative(relative)?;
+        let rel = relative
+            .to_str()
+            .ok_or_else(|| {
+                CorpusError::Config(format!("path is not valid UTF-8: {}", relative.display()))
+            })?
+            .replace('\\', "/");
+        Ok(match &self.sub_path {
+            Some(sub) if !sub.is_empty() => format!("{}/{}", sub.trim_end_matches('/'), rel),
+            _ => rel,
+        })
+    }
+
+    /// Fetch the current SHA for a path on the target branch. Used by
+    /// `persist` when the caller never read the file first (blind write
+    /// to an existing file). Returns `Ok(None)` on 404 — the caller can
+    /// then treat the PUT as a create.
+    async fn fetch_sha(
+        inner: &mut Inner,
+        repo: &str,
+        branch: &str,
+        path: &str,
+        token: Option<&str>,
+    ) -> Result<Option<String>> {
+        match inner
+            .fetcher
+            .fetch_file_with_sha(repo, branch, path, token)
+            .await?
+        {
+            Some((_, sha)) => Ok(Some(sha)),
+            None => Ok(None),
+        }
+    }
+}
+
+fn validate_relative(path: &Path) -> Result<()> {
+    if path.is_absolute() {
+        return Err(CorpusError::Config(format!(
+            "path must be relative: {}",
+            path.display()
+        )));
+    }
+    for component in path.components() {
+        if matches!(component, std::path::Component::ParentDir) {
+            return Err(CorpusError::Config(format!(
+                "path must not contain '..': {}",
+                path.display()
+            )));
+        }
+    }
+    Ok(())
+}
+
+#[async_trait]
+impl RepoBackend for GitHubApiBackend {
+    async fn read_file(&self, relative_path: &Path) -> Result<Option<String>> {
+        let api_path = self.api_path(relative_path)?;
+        let mut inner = self.inner.lock().await;
+        let outcome = inner
+            .fetcher
+            .fetch_file_with_sha(
+                &self.full_repo(),
+                &self.branch,
+                &api_path,
+                self.token.as_deref(),
+            )
+            .await?;
+        match outcome {
+            Some((content, sha)) => {
+                inner.sha_cache.insert(relative_path.to_path_buf(), sha);
+                Ok(Some(content))
+            }
+            None => {
+                // Remove any stale SHA from a previous existence — a
+                // later write will (correctly) be treated as a create.
+                inner.sha_cache.remove(relative_path);
+                Ok(None)
+            }
+        }
+    }
+
+    async fn write_file(&self, relative_path: &Path, content: &str) -> Result<()> {
+        validate_relative(relative_path)?;
+        if self.token.is_none() {
+            return Err(CorpusError::ReadOnly(
+                "GitHubApiBackend has no push token".to_string(),
+            ));
+        }
+        let mut inner = self.inner.lock().await;
+        let base_sha = inner.sha_cache.get(relative_path).cloned();
+        inner.pending.push((
+            relative_path.to_path_buf(),
+            PendingWrite {
+                op: PendingOp::Upsert(content.to_string()),
+                base_sha,
+            },
+        ));
+        Ok(())
+    }
+
+    async fn delete_file(&self, relative_path: &Path) -> Result<()> {
+        validate_relative(relative_path)?;
+        if self.token.is_none() {
+            return Err(CorpusError::ReadOnly(
+                "GitHubApiBackend has no push token".to_string(),
+            ));
+        }
+        let mut inner = self.inner.lock().await;
+        let base_sha = inner.sha_cache.get(relative_path).cloned();
+        inner.pending.push((
+            relative_path.to_path_buf(),
+            PendingWrite {
+                op: PendingOp::Delete,
+                base_sha,
+            },
+        ));
+        Ok(())
+    }
+
+    async fn list_files(&self, dir: &Path, extension: Option<&str>) -> Result<Vec<FileEntry>> {
+        let api_dir = self.api_path(dir)?;
+        let mut inner = self.inner.lock().await;
+        let entries = inner
+            .fetcher
+            .list_directory(
+                &self.full_repo(),
+                &self.branch,
+                &api_dir,
+                self.token.as_deref(),
+            )
+            .await?;
+        let mut out: Vec<FileEntry> = entries
+            .into_iter()
+            .filter(|e| e.entry_type == "file")
+            .filter(|e| match extension {
+                None => true,
+                Some(ext) => Path::new(&e.name)
+                    .extension()
+                    .and_then(|s| s.to_str())
+                    .is_some_and(|s| s == ext),
+            })
+            .map(|e| FileEntry { name: e.name })
+            .collect();
+        out.sort_by(|a, b| a.name.cmp(&b.name));
+        Ok(out)
+    }
+
+    async fn persist(&self, ctx: &WriteContext) -> Result<PersistOutcome> {
+        let pending: Vec<(PathBuf, PendingWrite)> = {
+            let mut inner = self.inner.lock().await;
+            std::mem::take(&mut inner.pending)
+        };
+        if pending.is_empty() {
+            return Ok(PersistOutcome::default());
+        }
+
+        // Committer falls back to a service identity when no human is
+        // attached — same shape as `GitBackend` (the trailer/co-author
+        // is left empty rather than spoofed).
+        let committer = Committer {
+            name: ctx
+                .author
+                .as_ref()
+                .map(|a| a.name.clone())
+                .unwrap_or_else(|| "regelrecht-editor".to_string()),
+            email: ctx
+                .author
+                .as_ref()
+                .map(|a| a.email.clone())
+                .unwrap_or_else(|| "noreply@regelrecht.local".to_string()),
+        };
+
+        let token = self.token.as_deref();
+        let repo = self.full_repo();
+        let mut new_shas: HashMap<PathBuf, String> = HashMap::new();
+
+        // Capture the buffer back if anything fails partway through, so
+        // a caller-side retry isn't forced to re-collect the same writes.
+        // GitHubFetcher methods are `&mut`, so a single lock guard around
+        // the whole loop is cheap (no other writer can pile on while we
+        // flush).
+        let mut inner = self.inner.lock().await;
+        for (path, pw) in pending {
+            let api_path = self.api_path(&path)?;
+            match pw.op {
+                PendingOp::Upsert(content) => {
+                    let new_sha = try_put(
+                        &mut inner.fetcher,
+                        &repo,
+                        &self.branch,
+                        &api_path,
+                        &content,
+                        pw.base_sha.as_deref(),
+                        &committer,
+                        &ctx.message,
+                        token,
+                    )
+                    .await?;
+                    new_shas.insert(path, new_sha);
+                }
+                PendingOp::Delete => {
+                    let sha_for_delete = match &pw.base_sha {
+                        Some(s) => s.clone(),
+                        None => {
+                            match Self::fetch_sha(&mut inner, &repo, &self.branch, &api_path, token)
+                                .await?
+                            {
+                                Some(s) => s,
+                                // Already gone: treat as a successful delete,
+                                // same shape as `LocalBackend::delete_file`.
+                                None => continue,
+                            }
+                        }
+                    };
+                    try_delete(
+                        &mut inner.fetcher,
+                        &repo,
+                        &self.branch,
+                        &api_path,
+                        &sha_for_delete,
+                        &committer,
+                        &ctx.message,
+                        token,
+                    )
+                    .await?;
+                    // Drop the cached SHA so a next read sees the file as
+                    // gone (or rebuilt) without holding a stale value.
+                    inner.sha_cache.remove(&path);
+                }
+            }
+        }
+
+        // Refresh the SHA cache so a follow-up read-modify-write cycle in
+        // the same backend instance starts from the post-commit SHA.
+        for (path, sha) in new_shas {
+            inner.sha_cache.insert(path, sha);
+        }
+
+        // Contents API commits straight to the configured branch — no
+        // PR is opened. The trajectflow already accepted `pr: None`
+        // from the previous `GitBackend` impl, so this is wire-
+        // compatible with the existing save handlers.
+        Ok(PersistOutcome::default())
+    }
+
+    async fn ensure_ready(&mut self) -> Result<()> {
+        // Read-only backends have nothing to bootstrap — the branch
+        // either exists (reads work) or it doesn't (reads 404 as
+        // they'd 404 on a missing file), and we don't try to mint a
+        // branch without a write token.
+        if self.token.is_none() {
+            return Ok(());
+        }
+        let inner = self.inner.get_mut();
+        let repo = format!("{}/{}", self.owner, self.repo);
+        let exists = inner
+            .fetcher
+            .branch_exists(&repo, &self.branch, self.token.as_deref())
+            .await?;
+        if exists {
+            return Ok(());
+        }
+        let base = self.base_branch.as_deref().ok_or_else(|| {
+            CorpusError::Config(format!(
+                "branch '{}' does not exist on {}/{} and no base_branch \
+                 was configured to seed it from",
+                self.branch, self.owner, self.repo
+            ))
+        })?;
+        inner
+            .fetcher
+            .create_branch(&repo, &self.branch, base, self.token.as_deref())
+            .await?;
+        tracing::info!(
+            repo = %repo,
+            branch = %self.branch,
+            base = %base,
+            "GitHubApiBackend: created traject branch from base"
+        );
+        Ok(())
+    }
+
+    fn is_writable(&self) -> bool {
+        self.token.is_some()
+    }
+}
+
+/// PUT with one optimistic-concurrency retry: on 409 the SHA is refreshed
+/// (the file moved between our last read and this PUT) and the put is
+/// reattempted exactly once with the new SHA. A second 409 propagates so
+/// the caller can decide between abort and a higher-level retry.
+#[allow(clippy::too_many_arguments)]
+async fn try_put(
+    fetcher: &mut GitHubFetcher,
+    repo: &str,
+    branch: &str,
+    path: &str,
+    content: &str,
+    base_sha: Option<&str>,
+    committer: &Committer,
+    message: &str,
+    token: Option<&str>,
+) -> Result<String> {
+    match fetcher
+        .put_file(
+            repo, branch, path, content, base_sha, committer, message, token,
+        )
+        .await
+    {
+        Ok(sha) => Ok(sha),
+        Err(CorpusError::Conflict(_)) => {
+            tracing::debug!(repo = %repo, path = %path, "PUT 409 — refreshing sha and retrying");
+            let fresh = fetcher
+                .fetch_file_with_sha(repo, branch, path, token)
+                .await?
+                .map(|(_, sha)| sha);
+            fetcher
+                .put_file(
+                    repo,
+                    branch,
+                    path,
+                    content,
+                    fresh.as_deref(),
+                    committer,
+                    message,
+                    token,
+                )
+                .await
+        }
+        Err(e) if is_unsigned_existing_file(&e) => {
+            // A PUT without `sha` against an existing file returns 422
+            // ("sha was not supplied"). Resolve the SHA and retry once
+            // — covers `save_law` / `save_scenario` which call
+            // `write_file` without a preceding `read_file`.
+            tracing::debug!(repo = %repo, path = %path, "PUT 422 — fetching sha and retrying as update");
+            let fresh = fetcher
+                .fetch_file_with_sha(repo, branch, path, token)
+                .await?
+                .map(|(_, sha)| sha);
+            if fresh.is_none() {
+                // 422 wasn't about an existing file after all — propagate
+                // the original error so the operator can diagnose.
+                return Err(e);
+            }
+            fetcher
+                .put_file(
+                    repo,
+                    branch,
+                    path,
+                    content,
+                    fresh.as_deref(),
+                    committer,
+                    message,
+                    token,
+                )
+                .await
+        }
+        Err(e) => Err(e),
+    }
+}
+
+/// DELETE with one optimistic-concurrency retry: same shape as `try_put`.
+#[allow(clippy::too_many_arguments)]
+async fn try_delete(
+    fetcher: &mut GitHubFetcher,
+    repo: &str,
+    branch: &str,
+    path: &str,
+    sha: &str,
+    committer: &Committer,
+    message: &str,
+    token: Option<&str>,
+) -> Result<()> {
+    match fetcher
+        .delete_file_via_api(repo, branch, path, sha, committer, message, token)
+        .await
+    {
+        Ok(()) => Ok(()),
+        Err(CorpusError::Conflict(_)) => {
+            tracing::debug!(repo = %repo, path = %path, "DELETE 409 — refreshing sha and retrying");
+            let fresh = fetcher
+                .fetch_file_with_sha(repo, branch, path, token)
+                .await?
+                .map(|(_, sha)| sha);
+            match fresh {
+                Some(s) => {
+                    fetcher
+                        .delete_file_via_api(repo, branch, path, &s, committer, message, token)
+                        .await
+                }
+                // Race: file was deleted between our 409 and this
+                // refetch. Treat as a successful delete.
+                None => Ok(()),
+            }
+        }
+        Err(e) => Err(e),
+    }
+}
+
+/// Best-effort detection that a PUT failed with 422 because we omitted
+/// `sha` while the file already exists. We don't have a structured error
+/// variant for 422 (it's just `CorpusError::Git`), so we sniff the
+/// message — the GitHub response text reliably mentions `sha`.
+fn is_unsigned_existing_file(e: &CorpusError) -> bool {
+    match e {
+        CorpusError::Git(msg) => msg.contains(" 422") && msg.contains("sha"),
+        _ => false,
+    }
+}

--- a/packages/corpus/src/lib.rs
+++ b/packages/corpus/src/lib.rs
@@ -8,6 +8,8 @@ pub mod dto;
 pub mod error;
 #[cfg(feature = "github")]
 pub mod github;
+#[cfg(feature = "github")]
+pub mod github_api_backend;
 pub mod models;
 #[cfg(feature = "github")]
 pub mod pr_client;
@@ -23,6 +25,8 @@ pub use config::{deployment_from_hostname, CorpusConfig};
 pub use error::CorpusError;
 #[cfg(feature = "github")]
 pub use github::{FetchResult, GitHubFetcher};
+#[cfg(feature = "github")]
+pub use github_api_backend::GitHubApiBackend;
 pub use models::{RegistryManifest, Source, SourceType};
 #[cfg(feature = "github")]
 pub use pr_client::PullRequestClient;

--- a/packages/corpus/tests/github_api_backend.rs
+++ b/packages/corpus/tests/github_api_backend.rs
@@ -1,0 +1,361 @@
+//! Unit tests for `GitHubApiBackend`. Uses a wiremock server in place of
+//! `api.github.com` so the tests are hermetic and the backend's HTTP
+//! interactions can be asserted precisely (which queries fire, which
+//! payloads land at which endpoints).
+
+#![cfg(feature = "github")]
+#![allow(clippy::unwrap_used)]
+
+use std::path::Path;
+
+use base64::Engine;
+use regelrecht_corpus::backend::{RepoBackend, WriteContext};
+use regelrecht_corpus::github_api_backend::GitHubApiBackend;
+use regelrecht_corpus::models::GitHubSource;
+use serde_json::json;
+use wiremock::matchers::{body_partial_json, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn b64(s: &str) -> String {
+    base64::engine::general_purpose::STANDARD.encode(s.as_bytes())
+}
+
+fn github_source(owner: &str, repo: &str, branch: &str, sub: Option<&str>) -> GitHubSource {
+    GitHubSource {
+        owner: owner.to_string(),
+        repo: repo.to_string(),
+        branch: branch.to_string(),
+        path: sub.map(|s| s.to_string()),
+        git_ref: None,
+    }
+}
+
+fn backend(server: &MockServer) -> GitHubApiBackend {
+    let src = github_source("acme", "corpus", "traject/abc", None);
+    GitHubApiBackend::new(
+        &src,
+        Some("main".to_string()),
+        Some("test-token".to_string()),
+    )
+    .unwrap()
+    .with_api_base(server.uri())
+}
+
+fn ctx() -> WriteContext {
+    WriteContext {
+        message: "test commit".to_string(),
+        author: None,
+    }
+}
+
+#[tokio::test]
+async fn read_file_returns_content_and_caches_sha_for_later_write() {
+    let server = MockServer::start().await;
+
+    // Read returns content + sha.
+    Mock::given(method("GET"))
+        .and(path("/repos/acme/corpus/contents/laws/x.yaml"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "name": "x.yaml",
+            "path": "laws/x.yaml",
+            "sha": "sha-v1",
+            "type": "file",
+            "content": b64("hello\n"),
+            "encoding": "base64",
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // PUT must reuse the cached sha.
+    Mock::given(method("PUT"))
+        .and(path("/repos/acme/corpus/contents/laws/x.yaml"))
+        .and(body_partial_json(
+            json!({ "sha": "sha-v1", "branch": "traject/abc" }),
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "content": { "sha": "sha-v2" }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let b = backend(&server);
+    let got = b.read_file(Path::new("laws/x.yaml")).await.unwrap();
+    assert_eq!(got.as_deref(), Some("hello\n"));
+
+    b.write_file(Path::new("laws/x.yaml"), "goodbye\n")
+        .await
+        .unwrap();
+    b.persist(&ctx()).await.unwrap();
+}
+
+#[tokio::test]
+async fn write_without_prior_read_resolves_sha_lazily_at_persist() {
+    let server = MockServer::start().await;
+
+    // First PUT (no sha) returns 422 — file already exists; backend must
+    // then GET sha and re-PUT.
+    Mock::given(method("PUT"))
+        .and(path("/repos/acme/corpus/contents/laws/x.yaml"))
+        .and(body_partial_json(json!({ "branch": "traject/abc" })))
+        .respond_with(
+            ResponseTemplate::new(422).set_body_string("{\"message\":\"sha was not supplied\"}"),
+        )
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+
+    // SHA-resolve GET.
+    Mock::given(method("GET"))
+        .and(path("/repos/acme/corpus/contents/laws/x.yaml"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "name": "x.yaml",
+            "path": "laws/x.yaml",
+            "sha": "sha-existing",
+            "type": "file",
+            "content": b64("old"),
+            "encoding": "base64",
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // Retry PUT with the resolved sha succeeds.
+    Mock::given(method("PUT"))
+        .and(path("/repos/acme/corpus/contents/laws/x.yaml"))
+        .and(body_partial_json(json!({ "sha": "sha-existing" })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "content": { "sha": "sha-new" }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let b = backend(&server);
+    b.write_file(Path::new("laws/x.yaml"), "new").await.unwrap();
+    b.persist(&ctx()).await.unwrap();
+}
+
+#[tokio::test]
+async fn put_409_refreshes_sha_and_retries_once() {
+    let server = MockServer::start().await;
+
+    // The caller read the file once, caching sha-old.
+    Mock::given(method("GET"))
+        .and(path("/repos/acme/corpus/contents/laws/x.yaml"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "name": "x.yaml", "path": "laws/x.yaml",
+            "sha": "sha-old", "type": "file",
+            "content": b64("v1"), "encoding": "base64",
+        })))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+
+    // First PUT with sha-old → 409.
+    Mock::given(method("PUT"))
+        .and(path("/repos/acme/corpus/contents/laws/x.yaml"))
+        .and(body_partial_json(json!({ "sha": "sha-old" })))
+        .respond_with(ResponseTemplate::new(409).set_body_string("conflict"))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+
+    // Backend re-fetches sha → sha-fresh.
+    Mock::given(method("GET"))
+        .and(path("/repos/acme/corpus/contents/laws/x.yaml"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "name": "x.yaml", "path": "laws/x.yaml",
+            "sha": "sha-fresh", "type": "file",
+            "content": b64("v1.5"), "encoding": "base64",
+        })))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+
+    // Retry PUT with sha-fresh → 200.
+    Mock::given(method("PUT"))
+        .and(path("/repos/acme/corpus/contents/laws/x.yaml"))
+        .and(body_partial_json(json!({ "sha": "sha-fresh" })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "content": { "sha": "sha-new" }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let b = backend(&server);
+    b.read_file(Path::new("laws/x.yaml")).await.unwrap();
+    b.write_file(Path::new("laws/x.yaml"), "v2").await.unwrap();
+    b.persist(&ctx()).await.unwrap();
+}
+
+#[tokio::test]
+async fn delete_path_resolves_sha_then_deletes() {
+    let server = MockServer::start().await;
+
+    // No prior read → backend must GET sha first.
+    Mock::given(method("GET"))
+        .and(path("/repos/acme/corpus/contents/laws/y.yaml"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "name": "y.yaml", "path": "laws/y.yaml",
+            "sha": "sha-d1", "type": "file",
+            "content": b64("doomed"), "encoding": "base64",
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("DELETE"))
+        .and(path("/repos/acme/corpus/contents/laws/y.yaml"))
+        .and(body_partial_json(json!({ "sha": "sha-d1" })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let b = backend(&server);
+    b.delete_file(Path::new("laws/y.yaml")).await.unwrap();
+    b.persist(&ctx()).await.unwrap();
+}
+
+#[tokio::test]
+async fn delete_already_gone_is_no_op() {
+    let server = MockServer::start().await;
+
+    // GET 404 → file already gone → persist swallows the delete.
+    Mock::given(method("GET"))
+        .and(path("/repos/acme/corpus/contents/laws/gone.yaml"))
+        .respond_with(ResponseTemplate::new(404).set_body_string("not found"))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let b = backend(&server);
+    b.delete_file(Path::new("laws/gone.yaml")).await.unwrap();
+    // No DELETE mock — if backend tried to call it, wiremock would 404
+    // again and we'd see a failure. The point is that it doesn't.
+    b.persist(&ctx()).await.unwrap();
+}
+
+#[tokio::test]
+async fn ensure_ready_creates_branch_when_missing() {
+    let server = MockServer::start().await;
+
+    // branch_exists check → 404.
+    Mock::given(method("GET"))
+        .and(path("/repos/acme/corpus/git/ref/heads/traject/abc"))
+        .respond_with(ResponseTemplate::new(404).set_body_string("missing"))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // Resolve base ref.
+    Mock::given(method("GET"))
+        .and(path("/repos/acme/corpus/git/ref/heads/main"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "object": { "sha": "abc123" }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // POST new ref.
+    Mock::given(method("POST"))
+        .and(path("/repos/acme/corpus/git/refs"))
+        .and(body_partial_json(json!({
+            "ref": "refs/heads/traject/abc",
+            "sha": "abc123",
+        })))
+        .respond_with(ResponseTemplate::new(201).set_body_json(json!({})))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let mut b = backend(&server);
+    b.ensure_ready().await.unwrap();
+}
+
+#[tokio::test]
+async fn ensure_ready_no_op_when_branch_exists() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/repos/acme/corpus/git/ref/heads/traject/abc"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "object": { "sha": "abc123" }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // No POST mock — if create_branch is called, the test fails.
+    let mut b = backend(&server);
+    b.ensure_ready().await.unwrap();
+}
+
+#[tokio::test]
+async fn list_files_filters_to_extension() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/repos/acme/corpus/contents/scenarios"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+            { "name": "a.feature", "path": "scenarios/a.feature", "sha": "s1", "type": "file" },
+            { "name": "b.feature", "path": "scenarios/b.feature", "sha": "s2", "type": "file" },
+            { "name": "notes.md",  "path": "scenarios/notes.md",  "sha": "s3", "type": "file" },
+            { "name": "subdir",    "path": "scenarios/subdir",    "sha": "s4", "type": "dir"  },
+        ])))
+        .mount(&server)
+        .await;
+
+    let b = backend(&server);
+    let entries = b
+        .list_files(Path::new("scenarios"), Some("feature"))
+        .await
+        .unwrap();
+    let names: Vec<_> = entries.iter().map(|e| e.name.as_str()).collect();
+    assert_eq!(names, vec!["a.feature", "b.feature"]);
+}
+
+#[tokio::test]
+async fn list_files_missing_directory_returns_empty() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/repos/acme/corpus/contents/scenarios"))
+        .respond_with(ResponseTemplate::new(404).set_body_string("not found"))
+        .mount(&server)
+        .await;
+
+    let b = backend(&server);
+    let entries = b
+        .list_files(Path::new("scenarios"), Some("feature"))
+        .await
+        .unwrap();
+    assert!(entries.is_empty());
+}
+
+#[tokio::test]
+async fn sub_path_prefixes_api_calls() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/repos/acme/corpus/contents/regulation/nl/wet/x.yaml"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "name": "x.yaml", "path": "regulation/nl/wet/x.yaml",
+            "sha": "sub-sha", "type": "file",
+            "content": b64("c"), "encoding": "base64",
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let src = github_source("acme", "corpus", "traject/abc", Some("regulation/nl"));
+    let b = GitHubApiBackend::new(&src, Some("main".to_string()), Some("t".to_string()))
+        .unwrap()
+        .with_api_base(server.uri());
+    let got = b.read_file(Path::new("wet/x.yaml")).await.unwrap();
+    assert_eq!(got.as_deref(), Some("c"));
+}

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -21,7 +21,7 @@ use regelrecht_corpus::source_map::{
 };
 use regelrecht_corpus::CorpusError;
 
-use crate::state::AppState;
+use crate::state::{AppState, CorpusState};
 use crate::traject_corpus::{TrajectCorpus, TrajectCorpusError};
 use crate::trajects::read_active_from_session;
 
@@ -81,11 +81,119 @@ pub struct LawOutputEntry {
     pub parameters: Vec<LawParamEntry>,
 }
 
+/// Read-time scope for the corpus endpoints. Either the per-traject
+/// corpus (when an active traject and a valid membership are both
+/// present), or the global corpus state under a read lock (anonymous /
+/// no-traject browsing). Both variants expose a `&CorpusState` view so
+/// the handlers stay agnostic.
+///
+/// Membership re-check and DB lookups for an active traject can fail
+/// (revoked member, deleted traject, transient DB error). In contrast
+/// with the write path (which 403s on any failure to protect the
+/// branch), the read path **degrades gracefully** to the global corpus
+/// so a user can still browse — saves will still be denied by the
+/// stricter `require_traject_corpus` guard on the write handlers.
+enum ReadScope {
+    Traject(Arc<TrajectCorpus>),
+    Global(tokio::sync::OwnedRwLockReadGuard<CorpusState>),
+}
+
+impl ReadScope {
+    fn corpus(&self) -> &CorpusState {
+        match self {
+            ReadScope::Traject(t) => &t.corpus,
+            ReadScope::Global(g) => g,
+        }
+    }
+
+    /// Look up a law's YAML content within the active scope. For a
+    /// traject, the read-your-writes overlay (populated by `save_law`)
+    /// takes precedence over the source_map snapshot, so a save +
+    /// re-open in the same traject returns the new content without a
+    /// full source_map rebuild.
+    async fn law_yaml(&self, law_id: &str) -> Option<String> {
+        match self {
+            ReadScope::Traject(t) => t.law_yaml(law_id).await,
+            ReadScope::Global(g) => g.source_map.get_law(law_id).map(|l| l.yaml_content.clone()),
+        }
+    }
+}
+
+async fn resolve_read_corpus(state: &AppState, session: &Session) -> ReadScope {
+    // No active traject → straight to global (no DB hit).
+    let traject_id = match read_active_from_session(session).await {
+        Ok(Some(id)) => id,
+        _ => return ReadScope::Global(state.corpus.clone().read_owned().await),
+    };
+    let pool = match state.pool.as_ref() {
+        Some(p) => p,
+        None => return ReadScope::Global(state.corpus.clone().read_owned().await),
+    };
+
+    // Membership re-check. Same shape as `require_traject_corpus` but
+    // log-and-fall-back rather than 403 on any failure, so a stale
+    // session can't lock the user out of read access entirely.
+    let sub: Option<String> = session.get(SESSION_KEY_SUB).await.ok().flatten();
+    let Some(sub) = sub else {
+        return ReadScope::Global(state.corpus.clone().read_owned().await);
+    };
+    let membership: Result<(bool,), _> = sqlx::query_as(
+        "SELECT EXISTS(
+             SELECT 1 FROM accounts a
+             JOIN traject_members m ON m.account_id = a.id
+             WHERE a.person_sub = $1 AND m.traject_id = $2
+         )",
+    )
+    .bind(&sub)
+    .bind(traject_id)
+    .fetch_one(pool)
+    .await;
+    let is_member = match membership {
+        Ok((b,)) => b,
+        Err(e) => {
+            tracing::warn!(error = %e, "membership check failed in resolve_read_corpus; falling back to global");
+            return ReadScope::Global(state.corpus.clone().read_owned().await);
+        }
+    };
+    if !is_member {
+        // Drop the stale pointer so the next switch from the menu rebinds
+        // cleanly. Matches the same clear in `require_traject_corpus`.
+        let _: Option<Uuid> = session
+            .remove(crate::trajects::SESSION_KEY_ACTIVE_TRAJECT)
+            .await
+            .unwrap_or(None);
+        return ReadScope::Global(state.corpus.clone().read_owned().await);
+    }
+
+    let auth_file = {
+        let corpus = state.corpus.read().await;
+        corpus.auth_file.clone()
+    };
+    match state
+        .trajects
+        .get_or_build(pool, traject_id, auth_file, &state.favorites)
+        .await
+    {
+        Ok(traject) => ReadScope::Traject(traject),
+        Err(e) => {
+            // A traject_corpus build failure (DB row missing, source
+            // misconfigured, …) shouldn't fail an anonymous-looking GET.
+            // Log and serve the global view instead; the user's next
+            // write would surface the real error via the stricter
+            // `require_traject_corpus`.
+            tracing::warn!(error = %e, "traject corpus build failed in read path; falling back to global");
+            ReadScope::Global(state.corpus.clone().read_owned().await)
+        }
+    }
+}
+
 /// GET /api/sources — list all registered corpus sources with law counts.
 pub async fn list_sources(
     State(state): State<AppState>,
+    session: Session,
 ) -> Result<Json<Vec<SourceSummary>>, (StatusCode, String)> {
-    let corpus = state.corpus.read().await;
+    let scope = resolve_read_corpus(&state, &session).await;
+    let corpus = scope.corpus();
     Ok(Json(build_source_summaries(
         &corpus.registry,
         &corpus.source_map,
@@ -98,9 +206,11 @@ pub async fn list_sources(
 /// maximum is 1000.
 pub async fn list_corpus_laws(
     State(state): State<AppState>,
+    session: Session,
     Query(params): Query<PaginationParams>,
 ) -> Result<Json<Vec<CorpusLawEntry>>, (StatusCode, String)> {
-    let corpus = state.corpus.read().await;
+    let scope = resolve_read_corpus(&state, &session).await;
+    let corpus = scope.corpus();
     let limit = params.effective_limit();
 
     let mut entries: Vec<CorpusLawEntry> = corpus
@@ -132,6 +242,7 @@ pub async fn list_corpus_laws(
 /// GET /api/corpus/laws/{law_id} — return raw YAML content for a specific law.
 pub async fn get_corpus_law(
     State(state): State<AppState>,
+    session: Session,
     Path(law_id): Path<String>,
 ) -> Result<
     (
@@ -141,33 +252,31 @@ pub async fn get_corpus_law(
     ),
     (StatusCode, String),
 > {
-    let corpus = state.corpus.read().await;
-
-    let law = corpus
-        .source_map
-        .get_law(&law_id)
+    let scope = resolve_read_corpus(&state, &session).await;
+    let yaml = scope
+        .law_yaml(&law_id)
+        .await
         .ok_or_else(|| (StatusCode::NOT_FOUND, format!("Law '{}' not found", law_id)))?;
-
     Ok((
         StatusCode::OK,
         [(axum::http::header::CONTENT_TYPE, "text/yaml; charset=utf-8")],
-        law.yaml_content.clone(),
+        yaml,
     ))
 }
 
 /// GET /api/corpus/laws/{law_id}/outputs — list all outputs declared across articles.
 pub async fn list_law_outputs(
     State(state): State<AppState>,
+    session: Session,
     Path(law_id): Path<String>,
 ) -> Result<Json<Vec<LawOutputEntry>>, (StatusCode, String)> {
-    let corpus = state.corpus.read().await;
-
-    let law = corpus
-        .source_map
-        .get_law(&law_id)
+    let scope = resolve_read_corpus(&state, &session).await;
+    let yaml = scope
+        .law_yaml(&law_id)
+        .await
         .ok_or_else(|| (StatusCode::NOT_FOUND, format!("Law '{}' not found", law_id)))?;
 
-    let outputs: Vec<LawOutputEntry> = collect_law_outputs(&law.yaml_content)
+    let outputs: Vec<LawOutputEntry> = collect_law_outputs(&yaml)
         .into_iter()
         .map(|out| LawOutputEntry {
             name: out.name,
@@ -193,20 +302,15 @@ pub struct ScenarioEntry {
 /// GET /api/corpus/laws/{law_id}/scenarios — list available scenario files.
 pub async fn list_scenarios(
     State(state): State<AppState>,
+    session: Session,
     Path(law_id): Path<String>,
 ) -> Result<Json<Vec<ScenarioEntry>>, (StatusCode, String)> {
-    // Reads use the global backend resolution (writable fallback included).
-    // For federated GitHub sources this is NOT the same backend writes use
-    // (writes go through the per-session `SessionGitBackend`), so a save
-    // followed immediately by a list/get returns the pre-edit content from
-    // the global clone until the session branch is rebased back into it.
-    // Frontend already keeps the just-saved content in local state, so
-    // editor UX is unaffected; a follow-up can route reads through the
-    // session backend if a strict read-your-writes guarantee is needed.
-    let resolved = {
-        let corpus = state.corpus.read().await;
-        resolve_backend_for_law(&corpus, &law_id).await?
-    };
+    // Route through the active traject's backends when one is selected;
+    // otherwise fall back to the global corpus state. Saves still land
+    // on the traject branch, so the same scope serves read-your-writes
+    // and cross-traject isolation in one go.
+    let scope = resolve_read_corpus(&state, &session).await;
+    let resolved = resolve_backend_for_law(scope.corpus(), &law_id).await?;
 
     let scenarios_dir = match law_relative_dir(&resolved.law) {
         Ok(dir) => dir.join("scenarios"),
@@ -241,6 +345,7 @@ pub async fn list_scenarios(
 /// GET /api/corpus/laws/{law_id}/scenarios/{filename} — return raw .feature content.
 pub async fn get_scenario(
     State(state): State<AppState>,
+    session: Session,
     Path((law_id, filename)): Path<(String, String)>,
 ) -> Result<
     (
@@ -252,10 +357,8 @@ pub async fn get_scenario(
 > {
     validate_scenario_filename(&filename)?;
 
-    let resolved = {
-        let corpus = state.corpus.read().await;
-        resolve_backend_for_law(&corpus, &law_id).await?
-    };
+    let scope = resolve_read_corpus(&state, &session).await;
+    let resolved = resolve_backend_for_law(scope.corpus(), &law_id).await?;
 
     let scenarios_dir = law_relative_dir(&resolved.law)?.join("scenarios");
     let relative_path = scenarios_dir.join(&filename);
@@ -997,6 +1100,10 @@ pub async fn save_law(
         ));
     }
 
+    // Resolve the write target AND keep a handle on the per-traject
+    // corpus so we can mirror the saved body into its read-your-writes
+    // overlay after `persist` succeeds.
+    let traject = require_traject_corpus(&state, &session).await?;
     let target = resolve_traject_law_target(&state, &session, &law_id).await?;
     let EditorWriteTarget {
         relative_path,
@@ -1017,14 +1124,15 @@ pub async fn save_law(
             .map_err(corpus_write_error("law"))?
     };
 
-    // Deliberately NOT mirroring the new YAML into `state.corpus.source_map`:
-    // that cache is the read source for `/api/corpus/laws/...` for users
-    // *outside* the active traject (and anyone browsing without a traject),
-    // so pushing a traject's in-progress edits into it would leak unmerged
-    // changes across users. GET handlers under `state.corpus.*` will keep
-    // returning the last globally-loaded content until `POST
-    // /api/corpus/reload` runs — routing GETs through the per-traject
-    // corpus when a traject is active is a separate follow-up.
+    // The global `state.corpus.source_map` is still NOT touched here:
+    // it feeds GET handlers when no traject is active, so writing a
+    // traject's in-progress edits into it would leak unmerged changes
+    // across users.
+    //
+    // We DO mirror into the per-traject overlay so a subsequent GET in
+    // the same traject (any session) sees the new content — that is
+    // the read-your-writes follow-up that used to be punted.
+    traject.record_save(law_id.clone(), body).await;
 
     Ok(Json(save_response_from_traject(outcome)))
 }

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -548,6 +548,14 @@ async fn resolve_backend_for_law(
 fn corpus_write_error(kind: &'static str) -> impl FnOnce(CorpusError) -> (StatusCode, String) {
     move |e| match e {
         CorpusError::ReadOnly(_) => (StatusCode::FORBIDDEN, e.to_string()),
+        // Optimistic-concurrency race (remote SHA moved between read and
+        // write). The frontend needs to discriminate this from a generic
+        // 500 so it can prompt a refresh-and-retry instead of an error
+        // toast.
+        CorpusError::Conflict(_) => (
+            StatusCode::CONFLICT,
+            "Concurrent edit detected, please retry".to_string(),
+        ),
         _ => {
             tracing::warn!(error = %e, kind = %kind, "corpus write/persist failed");
             (

--- a/packages/editor-api/src/traject_corpus.rs
+++ b/packages/editor-api/src/traject_corpus.rs
@@ -245,8 +245,9 @@ async fn build_traject_corpus(
             );
         }
 
-        // For GitHub sources we override the clone path so each traject
-        // gets its own working tree. Local sources keep their configured
+        // GitHub sources go through the in-memory Contents-API backend
+        // (one isolated `GitHubApiBackend` per traject — no clone, no
+        // working tree on disk). Local sources keep their configured
         // path — they're already isolated by definition.
         let backend_result = match &source.source_type {
             SourceType::GitHub { github } => build_traject_github_backend(

--- a/packages/editor-api/src/traject_corpus.rs
+++ b/packages/editor-api/src/traject_corpus.rs
@@ -41,6 +41,36 @@ pub struct TrajectCorpus {
     /// routed through the traject's own branch on the same upstream
     /// repo.
     pub write_target_for_source: HashMap<String, String>,
+    /// Read-your-writes overlay for law YAML content. After a successful
+    /// `save_law` we mirror the persisted body here so subsequent reads
+    /// in the same traject (any session, any user) see the new content
+    /// without forcing a full source_map rebuild against GitHub. The
+    /// overlay is content-only — `LoadedLaw` metadata
+    /// (source_id/relative_path) doesn't change with a content edit, so
+    /// backend resolution keeps using `corpus.source_map`.
+    overlay: RwLock<HashMap<String, String>>,
+}
+
+impl TrajectCorpus {
+    /// Resolve the YAML content for a law in this traject, preferring the
+    /// post-save overlay over the source_map snapshot built at traject
+    /// activation time.
+    pub async fn law_yaml(&self, law_id: &str) -> Option<String> {
+        if let Some(text) = self.overlay.read().await.get(law_id) {
+            return Some(text.clone());
+        }
+        self.corpus
+            .source_map
+            .get_law(law_id)
+            .map(|l| l.yaml_content.clone())
+    }
+
+    /// Mirror a freshly-saved law's content into the read-your-writes
+    /// overlay. Called by `save_law` after a successful `backend.persist`,
+    /// so the next GET on the same law (or a refresh) sees the new body.
+    pub async fn record_save(&self, law_id: String, body: String) {
+        self.overlay.write().await.insert(law_id, body);
+    }
 }
 
 /// Lazy registry of per-traject corpora, mirroring the
@@ -308,47 +338,36 @@ async fn build_traject_corpus(
             auth_file: auth_file.map(|p| p.to_path_buf()),
         },
         write_target_for_source,
+        overlay: RwLock::new(HashMap::new()),
     }))
 }
 
-/// Build a [`GitBackend`] whose clone path lives under a traject-specific
-/// directory, so two trajects writing to the same upstream repo never
-/// share a working tree.
+/// Build a [`GitHubApiBackend`] for a traject source — no clone, no
+/// `/tmp` working tree. Reads, writes, branch-creation all go through
+/// the GitHub REST API. The branch on the writable_own source is
+/// created lazily (in `ensure_ready`) from `base_branch` if it doesn't
+/// yet exist on the remote — preserving the "first save creates the
+/// branch" behaviour the old `GitBackend` clone path had.
 fn build_traject_github_backend(
-    traject_id: Uuid,
-    source: &Source,
+    _traject_id: Uuid,
+    _source: &Source,
     github: &GitHubSource,
     base_branch: Option<&str>,
     token: Option<&str>,
 ) -> Result<Box<dyn regelrecht_corpus::backend::RepoBackend>, regelrecht_corpus::error::CorpusError>
 {
-    use regelrecht_corpus::backend::GitBackend;
-    use regelrecht_corpus::config::CorpusConfig;
-    use regelrecht_corpus::CorpusClient;
+    use regelrecht_corpus::github_api_backend::GitHubApiBackend;
 
-    let host_id = std::env::var("HOSTNAME").unwrap_or_else(|_| "local".to_string());
-    let repo_path = std::env::temp_dir()
-        .join("regelrecht-editor-corpus")
-        .join("trajects")
-        .join(host_id)
-        .join(traject_id.to_string())
-        .join(&source.id);
-
-    let repo_url = format!("https://github.com/{}/{}.git", github.owner, github.repo);
-    let mut config = CorpusConfig::new(&repo_url, &repo_path);
-    config.branch = github.effective_ref().to_string();
-    // For traject writable branches we expect the branch to not yet exist
-    // on the remote on first clone — `git_clone_and_create_branch` will
-    // fall back to `base_branch` and push a new branch. Default to `main`
-    // for trajects (overrides the global default of `development`); the
-    // caller can override per-source when their writable repo's default
-    // branch is something else.
-    config.base_branch = Some(base_branch.unwrap_or("main").to_string());
-    if let Some(t) = token {
-        config = config.with_token(t);
-    }
-    let client = CorpusClient::new(config);
-    Ok(Box::new(GitBackend::new(client, github.path.clone())))
+    // `traject_id` and `source.id` used to namespace the on-disk clone
+    // path; with the API backend the branch + URL already disambiguate,
+    // so the parameters are kept on the signature for call-site
+    // symmetry only.
+    let backend = GitHubApiBackend::new(
+        github,
+        Some(base_branch.unwrap_or("main").to_string()),
+        token.map(|t| t.to_string()),
+    )?;
+    Ok(Box::new(backend))
 }
 
 /// DB row mirror for `traject_corpus_sources`. `gh_base_branch` is kept

--- a/packages/editor-api/src/traject_corpus.rs
+++ b/packages/editor-api/src/traject_corpus.rs
@@ -196,18 +196,19 @@ async fn build_traject_corpus(
         .map(|r| r.source_id.clone())
         .ok_or(TrajectCorpusError::NoWritableOwn)?;
 
-    // Build the read-source → write-target-source map. The writable_own
-    // row carries `auth_ref` pointing at the seed source it shadows;
-    // saves for laws read from that seed get routed through the
-    // writable_own's traject-branched backend instead of pushing to the
-    // seed's read-only branch. Laws read from sources without an entry
-    // (e.g. the local source) write back through their own backend.
+    // Build the read-source → write-target-source map. Every non-
+    // writable_own source (local seed, GitHub seed, …) is routed to the
+    // writable_own's backend so a save on any read-only seed-loaded law
+    // lands on the traject's branch. The earlier `auth_ref`-only
+    // mapping only fired when the writable_own's auth_ref matched a
+    // seed's source_id verbatim, which broke for preview/local-stack
+    // deploys where the seed is `local` but auth_ref still resolves a
+    // GitHub token — saves on those laws then silently fell back to
+    // the local backend and never reached the traject branch.
     let mut write_target_for_source: HashMap<String, String> = HashMap::new();
     for row in &rows {
-        if row.is_writable_own {
-            if let Some(target_seed) = row.auth_ref.as_deref() {
-                write_target_for_source.insert(target_seed.to_string(), row.source_id.clone());
-            }
+        if !row.is_writable_own {
+            write_target_for_source.insert(row.source_id.clone(), writable_own_source_id.clone());
         }
     }
 

--- a/packages/editor-api/src/traject_corpus.rs
+++ b/packages/editor-api/src/traject_corpus.rs
@@ -48,6 +48,14 @@ pub struct TrajectCorpus {
     /// overlay is content-only — `LoadedLaw` metadata
     /// (source_id/relative_path) doesn't change with a content edit, so
     /// backend resolution keeps using `corpus.source_map`.
+    ///
+    /// Unbounded growth is intentional: in practice the size is bounded
+    /// by the number of distinct laws edited in this traject, with a
+    /// memory budget of roughly N laws × YAML size (KBs). The overlay
+    /// is cleared when the `TrajectCorpus` cache entry is invalidated
+    /// (e.g. on source config change). If a bulk-edit flow is ever
+    /// added that touches many laws per traject, revisit with an LRU
+    /// cap.
     overlay: RwLock<HashMap<String, String>>,
 }
 

--- a/packages/editor-api/tests/traject_reads_test.rs
+++ b/packages/editor-api/tests/traject_reads_test.rs
@@ -1,0 +1,265 @@
+//! Integration tests for the traject-aware read path
+//! (`corpus_handlers::get_corpus_law` and friends).
+//!
+//! These tests exist to pin the cross-traject read isolation introduced
+//! alongside `GitHubApiBackend`. Each test uses local writable-own
+//! sources so the runs are hermetic — no GitHub, no network — and the
+//! handler is invoked directly with inline `axum` extractors, mirroring
+//! the pattern in `save_annotations_test.rs` and `trajects_test.rs`.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::Json;
+use pretty_assertions::assert_eq;
+use sqlx::PgPool;
+use tokio::sync::{Mutex, RwLock};
+use tower_sessions::Session;
+use tower_sessions_memory_store::MemoryStore;
+use uuid::Uuid;
+
+use regelrecht_auth::handlers::SESSION_KEY_SUB;
+use regelrecht_editor_api::config::AppConfig;
+use regelrecht_editor_api::corpus_handlers::{get_corpus_law, save_law};
+use regelrecht_editor_api::state::{AppState, CorpusState};
+use regelrecht_editor_api::traject_corpus::TrajectCorpusCache;
+use regelrecht_editor_api::trajects::SESSION_KEY_ACTIVE_TRAJECT;
+
+use regelrecht_pipeline::test_utils::TestDb;
+
+const LAW_ID: &str = "zorgtoeslagwet";
+
+fn empty_state(pool: PgPool) -> AppState {
+    let mut favorites = HashSet::new();
+    favorites.insert(LAW_ID.to_string());
+    AppState {
+        corpus: Arc::new(RwLock::new(CorpusState::empty())),
+        oidc_client: None,
+        end_session_url: None,
+        config: Arc::new(AppConfig {
+            oidc: None,
+            base_url: None,
+        }),
+        http_client: reqwest::Client::new(),
+        pool: Some(pool),
+        pipeline_api_url: None,
+        reload_lock: Arc::new(Mutex::new(())),
+        trajects: Arc::new(TrajectCorpusCache::new()),
+        favorites: Arc::new(favorites),
+    }
+}
+
+async fn seed_account(pool: &PgPool, email: &str) -> (Uuid, String) {
+    let sub = format!("sub-{email}");
+    let (id,): (Uuid,) = sqlx::query_as(
+        "INSERT INTO accounts (person_sub, email, name) VALUES ($1, $2, $3) RETURNING id",
+    )
+    .bind(&sub)
+    .bind(email)
+    .bind("Test User")
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    (id, sub)
+}
+
+/// Write a minimal but schema-valid law file under `corpus_dir/wet/{law_id}/2025-01-01.yaml`
+/// with a single distinguishing `name:` so we can verify which copy a
+/// read served back.
+fn write_law(corpus_dir: &std::path::Path, name_marker: &str) {
+    let law_dir = corpus_dir.join("wet").join(LAW_ID);
+    std::fs::create_dir_all(&law_dir).unwrap();
+    std::fs::write(
+        law_dir.join("2025-01-01.yaml"),
+        format!("$id: {LAW_ID}\nname: {name_marker}\n"),
+    )
+    .unwrap();
+}
+
+/// Create a traject with one local writable-own source pointing at
+/// `corpus_dir`. Returns the traject id. `owner_id` is added as a
+/// `beheerder` so the membership re-check on reads/writes passes.
+async fn local_traject(pool: &PgPool, owner_id: Uuid, corpus_dir: &std::path::Path) -> Uuid {
+    let (traject_id,): (Uuid,) = sqlx::query_as(
+        "INSERT INTO trajects (name, description, scope, created_by)
+         VALUES ('Test', '', '', $1) RETURNING id",
+    )
+    .bind(owner_id)
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO traject_members (traject_id, account_id, role)
+         VALUES ($1, $2, 'beheerder')",
+    )
+    .bind(traject_id)
+    .bind(owner_id)
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO traject_corpus_sources
+         (traject_id, source_id, name, source_type, local_path,
+          priority, scopes, is_writable_own)
+         VALUES ($1, 'local', 'Local', 'local'::corpus_source_type, $2,
+                 0, '[]'::jsonb, TRUE)",
+    )
+    .bind(traject_id)
+    .bind(corpus_dir.to_string_lossy().to_string())
+    .execute(pool)
+    .await
+    .unwrap();
+    traject_id
+}
+
+async fn session_for(sub: &str, traject_id: Option<Uuid>) -> Session {
+    let session = Session::new(None, Arc::new(MemoryStore::default()), None);
+    session.insert(SESSION_KEY_SUB, sub).await.unwrap();
+    if let Some(id) = traject_id {
+        session
+            .insert(SESSION_KEY_ACTIVE_TRAJECT, id)
+            .await
+            .unwrap();
+    }
+    session
+}
+
+/// Helper: call `get_corpus_law` and return the response body text.
+async fn read_law(state: AppState, session: Session) -> String {
+    let (status, _headers, body) = get_corpus_law(State(state), session, Path(LAW_ID.to_string()))
+        .await
+        .expect("get_corpus_law must succeed");
+    assert_eq!(status, StatusCode::OK);
+    body
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn get_corpus_law_serves_active_trajects_content() {
+    let db = TestDb::new().await;
+    let state = empty_state(db.pool.clone());
+    let (owner, sub) = seed_account(&db.pool, "alice@test.local").await;
+
+    // Two trajects, each owning a different corpus copy with the same
+    // law id but distinguishable `name:` field.
+    let corpus_a = tempfile::tempdir().unwrap();
+    write_law(corpus_a.path(), "TRAJECT_A");
+    let traject_a = local_traject(&db.pool, owner, corpus_a.path()).await;
+
+    let corpus_b = tempfile::tempdir().unwrap();
+    write_law(corpus_b.path(), "TRAJECT_B");
+    let traject_b = local_traject(&db.pool, owner, corpus_b.path()).await;
+
+    // Reading with traject A active returns A's copy.
+    let body_a = read_law(state.clone(), session_for(&sub, Some(traject_a)).await).await;
+    assert!(
+        body_a.contains("TRAJECT_A"),
+        "expected A's content, got: {body_a}"
+    );
+    assert!(!body_a.contains("TRAJECT_B"));
+
+    // Reading with traject B active returns B's copy.
+    let body_b = read_law(state.clone(), session_for(&sub, Some(traject_b)).await).await;
+    assert!(
+        body_b.contains("TRAJECT_B"),
+        "expected B's content, got: {body_b}"
+    );
+    assert!(!body_b.contains("TRAJECT_A"));
+}
+
+#[tokio::test]
+async fn save_then_read_returns_the_just_saved_content() {
+    let db = TestDb::new().await;
+    let state = empty_state(db.pool.clone());
+    let (owner, sub) = seed_account(&db.pool, "alice@test.local").await;
+
+    let corpus = tempfile::tempdir().unwrap();
+    write_law(corpus.path(), "ORIGINAL");
+    let traject_id = local_traject(&db.pool, owner, corpus.path()).await;
+
+    // Verify the pre-save read returns the on-disk content.
+    let before = read_law(state.clone(), session_for(&sub, Some(traject_id)).await).await;
+    assert!(before.contains("ORIGINAL"));
+
+    // Save a new body via the actual handler.
+    let new_body = format!("$id: {LAW_ID}\nname: UPDATED\n");
+    let _ = save_law(
+        State(state.clone()),
+        session_for(&sub, Some(traject_id)).await,
+        Path(LAW_ID.to_string()),
+        new_body,
+    )
+    .await
+    .expect("save should succeed");
+
+    // The next read must reflect the save — overlay populated by
+    // `save_law` short-circuits the source_map snapshot.
+    let after = read_law(state, session_for(&sub, Some(traject_id)).await).await;
+    assert!(
+        after.contains("UPDATED"),
+        "expected the saved content; got: {after}"
+    );
+    assert!(!after.contains("ORIGINAL"));
+}
+
+#[tokio::test]
+async fn no_active_traject_falls_back_to_global_corpus() {
+    let db = TestDb::new().await;
+    let state = empty_state(db.pool.clone());
+    let (_owner, sub) = seed_account(&db.pool, "alice@test.local").await;
+
+    // No active traject in the session. The global `state.corpus` is
+    // CorpusState::empty(), so `get_corpus_law` should 404 — but
+    // crucially without erroring out on the missing-traject path.
+    let err = get_corpus_law(
+        State(state),
+        session_for(&sub, None).await,
+        Path(LAW_ID.to_string()),
+    )
+    .await
+    .expect_err("law is not in the global corpus; expect 404");
+
+    assert_eq!(err.0, StatusCode::NOT_FOUND, "{}", err.1);
+}
+
+#[tokio::test]
+async fn revoked_membership_falls_back_to_global_instead_of_403() {
+    let db = TestDb::new().await;
+    let state = empty_state(db.pool.clone());
+    let (owner, sub) = seed_account(&db.pool, "alice@test.local").await;
+
+    let corpus = tempfile::tempdir().unwrap();
+    write_law(corpus.path(), "TRAJECT_CONTENT");
+    let traject_id = local_traject(&db.pool, owner, corpus.path()).await;
+
+    // Yank the membership AFTER the session was issued — the stale
+    // session still carries the active traject id.
+    sqlx::query("DELETE FROM traject_members WHERE traject_id = $1")
+        .bind(traject_id)
+        .execute(&db.pool)
+        .await
+        .unwrap();
+
+    // Read should *not* 403; it should silently degrade to the global
+    // corpus (empty here, hence 404 — but the contract is "no 403").
+    let err = get_corpus_law(
+        State(state),
+        session_for(&sub, Some(traject_id)).await,
+        Path(LAW_ID.to_string()),
+    )
+    .await
+    .expect_err("global corpus is empty so the law isn't found");
+    assert_eq!(
+        err.0,
+        StatusCode::NOT_FOUND,
+        "revoked membership must degrade to global, not 403; got: {}",
+        err.1
+    );
+}

--- a/packages/editor-api/tests/traject_reads_test.rs
+++ b/packages/editor-api/tests/traject_reads_test.rs
@@ -14,7 +14,6 @@ use std::sync::Arc;
 
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
-use axum::Json;
 use pretty_assertions::assert_eq;
 use sqlx::PgPool;
 use tokio::sync::{Mutex, RwLock};
@@ -262,4 +261,128 @@ async fn revoked_membership_falls_back_to_global_instead_of_403() {
         "revoked membership must degrade to global, not 403; got: {}",
         err.1
     );
+}
+
+/// Provision a traject with TWO local sources — a `seed` source at low
+/// priority that carries the existing law file, and a `writable_own`
+/// at priority 0 that starts empty. The shape mirrors a real federated
+/// deploy where the seed is read-only (baked into the container or
+/// pulled from a central repo) and the writable_own is the traject's
+/// own branch on the writable upstream. Returns the traject id.
+async fn seeded_traject(
+    pool: &PgPool,
+    owner_id: Uuid,
+    seed_dir: &std::path::Path,
+    writable_own_dir: &std::path::Path,
+) -> Uuid {
+    let (traject_id,): (Uuid,) = sqlx::query_as(
+        "INSERT INTO trajects (name, description, scope, created_by)
+         VALUES ('Test', '', '', $1) RETURNING id",
+    )
+    .bind(owner_id)
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO traject_members (traject_id, account_id, role)
+         VALUES ($1, $2, 'beheerder')",
+    )
+    .bind(traject_id)
+    .bind(owner_id)
+    .execute(pool)
+    .await
+    .unwrap();
+
+    // Seed source — read-only logically (we treat it as such; the
+    // LocalBackend's write_path is what makes the test crisp).
+    sqlx::query(
+        "INSERT INTO traject_corpus_sources
+         (traject_id, source_id, name, source_type, local_path,
+          priority, scopes, is_writable_own)
+         VALUES ($1, 'seed', 'Seed', 'local'::corpus_source_type, $2,
+                 5, '[]'::jsonb, FALSE)",
+    )
+    .bind(traject_id)
+    .bind(seed_dir.to_string_lossy().to_string())
+    .execute(pool)
+    .await
+    .unwrap();
+
+    // Writable-own source at priority 0 (highest priority). Starts
+    // empty; first save lands here.
+    sqlx::query(
+        "INSERT INTO traject_corpus_sources
+         (traject_id, source_id, name, source_type, local_path,
+          priority, scopes, is_writable_own)
+         VALUES ($1, 'writable_own', 'Writable Own',
+                 'local'::corpus_source_type, $2,
+                 0, '[]'::jsonb, TRUE)",
+    )
+    .bind(traject_id)
+    .bind(writable_own_dir.to_string_lossy().to_string())
+    .execute(pool)
+    .await
+    .unwrap();
+
+    traject_id
+}
+
+#[tokio::test]
+async fn save_on_seed_loaded_law_lands_on_writable_own_backend() {
+    // Regression test for the routing bug where a law loaded from a
+    // seed source (e.g. the baked-in `local` corpus on the editor
+    // container) had its save fall back to the seed's own backend
+    // instead of being routed to the writable_own's branch. Symptom:
+    // save returned 200, read-your-writes worked via the overlay, but
+    // no commit landed on the traject branch. The fix routes every
+    // non-writable_own source to the writable_own at build time, not
+    // just the source matching `auth_ref`.
+    let db = TestDb::new().await;
+    let state = empty_state(db.pool.clone());
+    let (owner, sub) = seed_account(&db.pool, "alice@test.local").await;
+
+    let seed = tempfile::tempdir().unwrap();
+    let writable_own = tempfile::tempdir().unwrap();
+    // Seed has the law; writable_own starts empty.
+    write_law(seed.path(), "SEED_VERSION");
+    let traject_id = seeded_traject(&db.pool, owner, seed.path(), writable_own.path()).await;
+
+    // Sanity check: pre-save, the writable_own dir does NOT have the
+    // law file. The read falls through priority order and lands on
+    // the seed copy.
+    let writable_own_law_path = writable_own
+        .path()
+        .join("wet")
+        .join(LAW_ID)
+        .join("2025-01-01.yaml");
+    assert!(!writable_own_law_path.exists());
+
+    let new_body = format!("$id: {LAW_ID}\nname: SAVED_TO_WRITABLE_OWN\n");
+    let _ = save_law(
+        State(state.clone()),
+        session_for(&sub, Some(traject_id)).await,
+        Path(LAW_ID.to_string()),
+        new_body.clone(),
+    )
+    .await
+    .expect("save should succeed");
+
+    // The file must now exist on the writable_own's backend root.
+    // Before the fix the save silently landed on the seed source
+    // (because write_target_for_source only fired for sources whose
+    // id matched the writable_own's auth_ref) and this assertion
+    // failed.
+    let written = std::fs::read_to_string(&writable_own_law_path)
+        .expect("save must land on the writable_own backend, not the seed");
+    assert!(
+        written.contains("SAVED_TO_WRITABLE_OWN"),
+        "writable_own file must contain the saved body; got: {written}"
+    );
+
+    // The seed file is left untouched — saves never reach the seed's
+    // backend.
+    let seed_law_path = seed.path().join("wet").join(LAW_ID).join("2025-01-01.yaml");
+    let seed_text = std::fs::read_to_string(&seed_law_path).unwrap();
+    assert!(seed_text.contains("SEED_VERSION"));
+    assert!(!seed_text.contains("SAVED_TO_WRITABLE_OWN"));
 }


### PR DESCRIPTION
## Context

Trajecten in #632 isoleerden saves correct via per-traject git clones, maar alle reads gingen nog door de globale corpus. Switchen tussen trajecten liet daardoor geen traject-specifieke aanpassingen zien — soms zelfs frontend-gecachte versies van een ander traject. De follow-up die de docstring van `save_law` literally beloofde is nu uitgevoerd.

Anne's notitie-PR (#652) leeft op dezelfde traject-backend (PUT `/api/corpus/laws/{id}/annotations`); die werkt via de `RepoBackend` trait, dus integreert schoon met dit pad.

## Summary

- **`GitHubApiBackend`** — nieuwe `RepoBackend` implementatie tegen GitHub Trees/Contents/Refs APIs. **Geen clone, geen `/tmp` working tree.** SHA-cache + 1-shot 409 retry voor read-modify-write (`save_annotations`); 422 fallback voor blind PUT-then-update (`save_law`/`save_scenario`). Lazy branch creation via Refs API in `ensure_ready`.
- **Traject-bewuste reads** — nieuwe `resolve_read_corpus` helper in `corpus_handlers.rs` routeert `list_sources`/`list_corpus_laws`/`get_corpus_law`/`list_law_outputs`/`list_scenarios`/`get_scenario` door de actieve traject's corpus. Geen traject → fallback global. Revoked membership → degradeer naar global ipv 403 (reads liberaal, writes strict).
- **Read-your-writes overlay** in `TrajectCorpus`: `save_law` mirrort het gesavede body in een overlay zodat een volgende read in hetzelfde traject de zojuist gesavede content ziet zonder source_map rebuild.
- **Frontend** — `clearLawCache()` exporteren uit `useLaw.js` en aanroepen vanuit `switchTraject` + navigatie naar `/library`. Voorkomt dat een geopende law-editor cached content van een ander traject blijft tonen.
- **`CorpusError::Conflict`** — nieuwe variant zodat backends 409-races kunnen herkennen zonder error-strings te parsen.

## Test plan

- [x] `just check` groen (format/lint/build/validate/tests)
- [x] Nieuwe unit tests `corpus/tests/github_api_backend.rs` (10/10) — SHA cache lifecycle, 409 retry, 422 fallback, delete, branch creation, sub_path prefixing
- [x] Nieuwe integration tests `editor-api/tests/traject_reads_test.rs` (4/4) — cross-traject isolation, read-your-writes na save_law, no-active-traject fallback, revoked-membership graceful degradation
- [x] Bestaande `save_annotations_test` blijft groen (zelfde RepoBackend trait, dus de nieuwe backend werkt out-of-the-box voor Anne's flow)
- [ ] Manuele e2e met `/local-stack` tegen een echte GitHub-corpus (review-time check)

## Out of scope (follow-ups)

- **Annotation reads** gaan vandaag via de statische `/data/...` mirror in de frontend-container, niet via editor-api. Eigen isolation-gap, eigen issue.
- **Multi-file atomic commits** (Git Data API) zijn nu niet nodig — alle handlers schrijven 1 file per persist.
- **PR opener** op traject-saves; Contents API commiteert direct naar de branch zoals de oude traject `GitBackend` ook al deed.
- **GitBackend** blijft staan voor harvester / lokale flows.