### PR TITLE
feat(corpus): CJIB centrale rijksincasso — WAHV, Strafrecht, Awb titel 4.4, beslagvrije voet

### DIFF
--- a/corpus/regulation/nl/wet/algemene_wet_bestuursrecht/1994-01-01.yaml
+++ b/corpus/regulation/nl/wet/algemene_wet_bestuursrecht/1994-01-01.yaml
@@ -149,6 +149,23 @@ articles:
       tenzij de beschikking een later tijdstip vermeldt.
       2. Bij of krachtens wettelijk voorschrift kan een andere termijn voor de betaling worden vastgesteld.
     url: https://wetten.overheid.nl/BWBR0005537/2026-01-01#Artikel4:87
+    machine_readable:
+      execution:
+        parameters:
+          - name: bekendmaking_datum
+            type: date
+            required: true
+            description: Datum waarop de beschikking op de voorgeschreven wijze is bekendgemaakt
+        output:
+          - name: betaaltermijn_einddatum
+            type: date
+            description: De betaling geschiedt binnen zes weken na bekendmaking (lid 1)
+        actions:
+          - output: betaaltermijn_einddatum
+            value:
+              operation: DATE_ADD
+              date: $bekendmaking_datum
+              weeks: 6
   - number: 4:88
     text: |-
       1. Bij wettelijk voorschrift kan worden bepaald dat een geldsom moet worden betaald zonder dat dit bij
@@ -248,6 +265,22 @@ articles:
     text: |-
       De schuldenaar is in verzuim indien hij niet binnen de voorgeschreven termijn heeft betaald.
     url: https://wetten.overheid.nl/BWBR0005537/2026-01-01#Artikel4:97
+    machine_readable:
+      execution:
+        parameters:
+          - name: tijdig_betaald
+            type: boolean
+            required: true
+            description: Of binnen de voorgeschreven betalingstermijn is betaald
+        output:
+          - name: in_verzuim
+            type: boolean
+            description: De schuldenaar is in verzuim indien niet tijdig is betaald
+        actions:
+          - output: in_verzuim
+            value:
+              operation: NOT
+              value: $tijdig_betaald
   - number: 4:98
     text: |-
       1. Het verzuim heeft de verschuldigdheid van wettelijke rente tot gevolg overeenkomstig de artikelen 119,
@@ -257,6 +290,58 @@ articles:
       3. Indien na het intreden van het verzuim de koers van het geld waarin de geldschuld moet worden betaald zich
       heeft gewijzigd, is artikel 125 van Boek 6 van het Burgerlijk Wetboek van overeenkomstige toepassing.
     url: https://wetten.overheid.nl/BWBR0005537/2026-01-01#Artikel4:98
+    machine_readable:
+      definitions:
+        rentedrempel_schuldenaar:
+          value: 2000
+          description: Wettelijke rente is niet verschuldigd indien het bedrag minder dan EUR 20 is (lid 2)
+        rentedrempel_bestuursorgaan:
+          value: 1000
+          description: Drempel van EUR 10 indien het bestuursorgaan de schuldenaar is (lid 2)
+      execution:
+        parameters:
+          - name: tijdig_betaald
+            type: boolean
+            required: true
+            description: Of binnen de voorgeschreven betalingstermijn is betaald
+          - name: rentebedrag
+            type: number
+            required: true
+            description: Het berekende bedrag aan wettelijke rente in eurocent
+          - name: bestuursorgaan_is_schuldenaar
+            type: boolean
+            required: true
+            description: Of het bestuursorgaan zelf de schuldenaar van de geldschuld is
+        input:
+          - name: in_verzuim
+            type: boolean
+            source:
+              output: in_verzuim
+        output:
+          - name: wettelijke_rente_verschuldigd
+            type: boolean
+            description: Of wettelijke rente verschuldigd is (lid 1 en 2)
+        actions:
+          # Lid 1: het verzuim heeft de verschuldigdheid van wettelijke rente tot gevolg.
+          # Lid 2: niet verschuldigd indien het bedrag minder dan EUR 20 (of EUR 10) is.
+          - output: wettelijke_rente_verschuldigd
+            value:
+              operation: AND
+              conditions:
+                - operation: EQUALS
+                  subject: $in_verzuim
+                  value: true
+                - operation: GREATER_THAN_OR_EQUAL
+                  subject: $rentebedrag
+                  value:
+                    operation: IF
+                    cases:
+                      - when:
+                          operation: EQUALS
+                          subject: $bestuursorgaan_is_schuldenaar
+                          value: true
+                        then: $rentedrempel_bestuursorgaan
+                    default: $rentedrempel_schuldenaar
   - number: 4:99
     text: |-
       Het bestuursorgaan stelt het bedrag van de verschuldigde wettelijke rente bij beschikking vast.
@@ -300,6 +385,23 @@ articles:
       2. Na voltooiing van de verjaring kan het bestuursorgaan zijn bevoegdheden tot aanmaning en verrekening en tot
       uitvaardiging en tenuitvoerlegging van een dwangbevel niet meer uitoefenen.
     url: https://wetten.overheid.nl/BWBR0005537/2026-01-01#Artikel4:104
+    machine_readable:
+      execution:
+        parameters:
+          - name: betaaltermijn_einddatum
+            type: date
+            required: true
+            description: De dag waarop de voorgeschreven betalingstermijn is verstreken
+        output:
+          - name: verjaringsdatum
+            type: date
+            description: De rechtsvordering tot betaling verjaart vijf jaar na afloop van de betalingstermijn (lid 1)
+        actions:
+          - output: verjaringsdatum
+            value:
+              operation: DATE_ADD
+              date: $betaaltermijn_einddatum
+              years: 5
   - number: 4:105
     text: |-
       1. De verjaring wordt gestuit door een daad van rechtsvervolging overeenkomstig artikel 316, eerste lid, van
@@ -356,12 +458,64 @@ articles:
       3. De aanmaning vermeldt dat bij niet tijdige betaling deze kan worden afgedwongen door op kosten van de
       schuldenaar uit te voeren invorderingsmaatregelen.
     url: https://wetten.overheid.nl/BWBR0005537/2026-01-01#Artikel4:112
+    machine_readable:
+      execution:
+        parameters:
+          - name: aanmaning_datum
+            type: date
+            required: true
+            description: Datum waarop de aanmaning is toegezonden
+        output:
+          - name: aanmaning_betaaltermijn_einddatum
+            type: date
+            description: De schuldenaar wordt aangemaand binnen twee weken te betalen (lid 1)
+        actions:
+          # Lid 1: betaling binnen twee weken, gerekend vanaf de dag na toezending.
+          - output: aanmaning_betaaltermijn_einddatum
+            value:
+              operation: DATE_ADD
+              date: $aanmaning_datum
+              weeks: 2
   - number: 4:113
     text: |-
       1. Het bestuursorgaan kan voor de aanmaning een vergoeding in rekening brengen. De vergoeding bedraagt € 9
       indien de schuld minder dan € 454 bedraagt en € 20 indien de schuld € 454 of meer bedraagt.
       2. De aanmaning vermeldt de vergoeding die in rekening wordt gebracht.
     url: https://wetten.overheid.nl/BWBR0005537/2026-01-01#Artikel4:113
+    machine_readable:
+      definitions:
+        aanmaningsvergoeding_laag:
+          value: 900
+          description: Vergoeding van EUR 9 indien de schuld minder dan EUR 454 bedraagt (lid 1)
+        aanmaningsvergoeding_hoog:
+          value: 2000
+          description: Vergoeding van EUR 20 indien de schuld EUR 454 of meer bedraagt (lid 1)
+        schuldgrens_aanmaningsvergoeding:
+          value: 45400
+          description: Grensbedrag van EUR 454 (lid 1)
+      execution:
+        parameters:
+          - name: schuldbedrag
+            type: number
+            required: true
+            description: Het bedrag van de schuld in eurocent
+        output:
+          - name: aanmaningsvergoeding
+            type: amount
+            type_spec:
+              unit: eurocent
+            description: De vergoeding die voor de aanmaning in rekening kan worden gebracht (lid 1)
+        actions:
+          - output: aanmaningsvergoeding
+            value:
+              operation: IF
+              cases:
+                - when:
+                    operation: LESS_THAN
+                    subject: $schuldbedrag
+                    value: $schuldgrens_aanmaningsvergoeding
+                  then: $aanmaningsvergoeding_laag
+              default: $aanmaningsvergoeding_hoog
   - number: 4:114
     text: |-
       Onder dwangbevel wordt verstaan: een schriftelijk bevel van een bestuursorgaan dat ertoe strekt de betaling

--- a/corpus/regulation/nl/wet/algemene_wet_bestuursrecht/1994-01-01.yaml
+++ b/corpus/regulation/nl/wet/algemene_wet_bestuursrecht/1994-01-01.yaml
@@ -125,3 +125,314 @@ articles:
               operation: DATE_ADD
               date: $bekendmaking_datum
               weeks: $bezwaartermijn_weken
+  - number: 4:85
+    text: |-
+      1. Deze titel is van toepassing op geldschulden die voortvloeien uit:
+      a. een wettelijk voorschrift dat een verplichting tot betaling uitsluitend aan of door een bestuursorgaan
+      regelt, of
+      b. een besluit dat vatbaar is voor bezwaar of beroep.
+      2. Deze titel is niet van toepassing op verplichtingen tot betaling van een geldsom voor het in behandeling
+      nemen van een aanvraag.
+      3. Deze titel is niet van toepassing op verplichtingen tot betaling die bij uitspraak van de bestuursrechter
+      zijn opgelegd.
+    url: https://wetten.overheid.nl/BWBR0005537/2026-01-01#Artikel4:85
+  - number: 4:86
+    text: |-
+      1. De verplichting tot betaling van een geldsom wordt bij beschikking vastgesteld.
+      2. De beschikking vermeldt in ieder geval:
+      a. de te betalen geldsom;
+      b. de termijn waarbinnen de betaling moet plaatsvinden.
+    url: https://wetten.overheid.nl/BWBR0005537/2026-01-01#Artikel4:86
+  - number: 4:87
+    text: |-
+      1. De betaling geschiedt binnen zes weken nadat de beschikking op de voorgeschreven wijze is bekendgemaakt,
+      tenzij de beschikking een later tijdstip vermeldt.
+      2. Bij of krachtens wettelijk voorschrift kan een andere termijn voor de betaling worden vastgesteld.
+    url: https://wetten.overheid.nl/BWBR0005537/2026-01-01#Artikel4:87
+  - number: 4:88
+    text: |-
+      1. Bij wettelijk voorschrift kan worden bepaald dat een geldsom moet worden betaald zonder dat dit bij
+      beschikking is vastgesteld.
+      2. In dat geval wordt tevens bepaald binnen welke termijn de betaling moet plaatsvinden.
+      3. Indien de belanghebbende binnen redelijke termijn daarom verzoekt wordt de op het bestuursorgaan rustende
+      verplichting tot betaling zo spoedig mogelijk alsnog bij beschikking vastgesteld.
+    url: https://wetten.overheid.nl/BWBR0005537/2026-01-01#Artikel4:88
+  - number: 4:89
+    text: |-
+      1. Tenzij bij wettelijk voorschrift anders is bepaald, geschiedt betaling door bijschrijving op een daartoe
+      door de schuldeiser bestemde bankrekening.
+      2. Betaling geschiedt in euro, tenzij bij wettelijk voorschrift of bij besluit van het bestuursorgaan anders
+      is bepaald.
+      3. Betaling door bijschrijving op een bankrekening geschiedt op het tijdstip waarop de rekening van de
+      schuldeiser wordt gecrediteerd.
+      4. Bij wettelijk voorschrift kan worden bepaald dat betaling aan een ander dan de schuldeiser geschiedt.
+    url: https://wetten.overheid.nl/BWBR0005537/2026-01-01#Artikel4:89
+  - number: 4:90
+    text: |-
+      1. Indien girale betaling naar het oordeel van het bestuursorgaan bezwaarlijk is, kan het betaling in andere
+      vorm ontvangen of verrichten.
+      2. De schuldeiser is verplicht voor iedere contante betaling een kwitantie af te geven, tenzij bij wettelijk
+      voorschrift anders is bepaald.
+    url: https://wetten.overheid.nl/BWBR0005537/2026-01-01#Artikel4:90
+  - number: 4:91
+    text: |-
+      1. De kosten van betaling komen ten laste van de schuldenaar.
+      2. Indien een bestuursorgaan betaalt aan een schuldeiser buiten de Europese Unie, kunnen de daaraan verbonden
+      kosten op het te betalen bedrag in mindering worden gebracht, tenzij bij wettelijk voorschrift anders is
+      bepaald.
+    url: https://wetten.overheid.nl/BWBR0005537/2026-01-01#Artikel4:91
+  - number: 4:92
+    text: |-
+      1. Betaling ter voldoening van een bepaalde geldschuld strekt in de eerste plaats tot mindering van de kosten,
+      vervolgens tot mindering van de verschenen rente en ten slotte tot mindering van de hoofdsom en de lopende
+      rente.
+      2. Indien een schuldenaar verschillende geldschulden heeft bij dezelfde schuldeiser, kan de schuldenaar bij de
+      betaling de geldschuld aanwijzen waaraan de betaling moet worden toegerekend.
+    url: https://wetten.overheid.nl/BWBR0005537/2026-01-01#Artikel4:92
+  - number: 4:93
+    text: |-
+      1. Verrekening van een geldschuld met een bestaande vordering geschiedt slechts voor zover in de bevoegdheid
+      daartoe bij wettelijk voorschrift is voorzien.
+      2. Verrekening geschiedt onder vermelding van de vordering waarmee de geldschuld is verrekend alsmede de
+      hoogte van het bedrag van de verrekening.
+      3. De verrekening werkt terug overeenkomstig artikel 129, eerste en tweede lid, van Boek 6 van het Burgerlijk
+      Wetboek.
+      4. De schuldenaar is niet bevoegd tot verrekening voor zover beslag op de vordering van de schuldeiser nietig
+      zou zijn.
+      5. Uitstel van betaling staat aan verrekening niet in de weg.
+    url: https://wetten.overheid.nl/BWBR0005537/2026-01-01#Artikel4:93
+  - number: 4:94
+    text: |-
+      1. Het bestuursorgaan kan de wederpartij uitstel van betaling verlenen.
+      2. Gedurende het uitstel kan het bestuursorgaan niet aanmanen of invorderen.
+      3. De beschikking tot uitstel van betaling vermeldt de termijn waarvoor het uitstel geldt.
+      4. Het bestuursorgaan kan aan de beschikking tot uitstel van betaling voorschriften verbinden.
+    url: https://wetten.overheid.nl/BWBR0005537/2026-01-01#Artikel4:94
+  - number: 4:94a
+    text: |-
+      Tenzij bij wettelijk voorschrift anders is bepaald, kan een bestuursorgaan een geldschuld geheel of
+      gedeeltelijk kwijtschelden indien de nadelige gevolgen van de invordering onevenredig zijn in verhouding tot
+      de met de invordering te dienen doelen.
+    url: https://wetten.overheid.nl/BWBR0005537/2026-01-01#Artikel4:94a
+  - number: 4:95
+    text: |-
+      1. Het bestuursorgaan kan vooruitlopend op de vaststelling van een verplichting tot betaling van een geldsom
+      een voorschot verlenen indien redelijkerwijs kan worden aangenomen dat een verplichting tot betaling zal
+      worden vastgesteld, tenzij bij wettelijk voorschrift anders is bepaald.
+      2. In de beschikking tot verlening van een voorschot kan, in afwijking van artikel 4:86, tweede lid, onderdeel
+      a, worden volstaan met de vermelding van de wijze waarop het bedrag van het voorschot wordt bepaald.
+      3. Bij de beschikking tot verlening van een voorschot kan een van artikel 4:87, eerste lid, afwijkende termijn
+      voor de betaling van het voorschot worden vastgesteld.
+      4. Betaalde voorschotten worden verrekend met de te betalen geldsom. Onverschuldigd betaalde voorschotten
+      kunnen worden teruggevorderd.
+      5. Het bestuursorgaan kan het terug te vorderen voorschot bij dwangbevel invorderen voor zover deze
+      bevoegdheid ook ten aanzien van de terugvordering van de hoofdsom is toegekend.
+      6. Het bestuursorgaan kan aan de beschikking tot verlening van een voorschot voorschriften verbinden.
+    url: https://wetten.overheid.nl/BWBR0005537/2026-01-01#Artikel4:95
+  - number: 4:96
+    text: |-
+      1. Het bestuursorgaan kan de beschikking tot uitstel van betaling onderscheidenlijk tot verlening van een
+      voorschot intrekken of wijzigen:
+      a. indien de voorschriften niet worden nageleefd;
+      b. indien de wederpartij onjuiste of onvolledige gegevens heeft verstrekt en de verstrekking van juiste of
+      volledige gegevens tot een andere beschikking zou hebben geleid, of
+      c. voor zover veranderde omstandigheden zich verzetten tegen voortduring van het uitstel onderscheidenlijk
+      tegen de verlening van het voorschot.
+      2. De verplichting tot betaling van een voorschot wordt opgeschort met ingang van de dag waarop het
+      bestuursorgaan aan de wederpartij schriftelijk kennis geeft van het ernstige vermoeden dat er grond bestaat om
+      toepassing te geven aan het eerste lid, aanhef en onder a of b, tot en met de dag waarop de beschikking
+      omtrent intrekking of wijziging is bekendgemaakt of de dag waarop sedert de kennisgeving van het ernstige
+      vermoeden dertien weken zijn verstreken.
+    url: https://wetten.overheid.nl/BWBR0005537/2026-01-01#Artikel4:96
+  - number: 4:97
+    text: |-
+      De schuldenaar is in verzuim indien hij niet binnen de voorgeschreven termijn heeft betaald.
+    url: https://wetten.overheid.nl/BWBR0005537/2026-01-01#Artikel4:97
+  - number: 4:98
+    text: |-
+      1. Het verzuim heeft de verschuldigdheid van wettelijke rente tot gevolg overeenkomstig de artikelen 119,
+      eerste en tweede lid, en 120, eerste lid, van Boek 6 van het Burgerlijk Wetboek.
+      2. Wettelijke rente is niet verschuldigd indien het bedrag ervan bij enige of laatste betaling minder bedraagt
+      dan € 20, dan wel, indien het bestuursorgaan de schuldenaar is, € 10.
+      3. Indien na het intreden van het verzuim de koers van het geld waarin de geldschuld moet worden betaald zich
+      heeft gewijzigd, is artikel 125 van Boek 6 van het Burgerlijk Wetboek van overeenkomstige toepassing.
+    url: https://wetten.overheid.nl/BWBR0005537/2026-01-01#Artikel4:98
+  - number: 4:99
+    text: |-
+      Het bestuursorgaan stelt het bedrag van de verschuldigde wettelijke rente bij beschikking vast.
+    url: https://wetten.overheid.nl/BWBR0005537/2026-01-01#Artikel4:99
+  - number: 4:100
+    text: |-
+      Indien het bestuursorgaan de beschikking tot betaling van een door hem verschuldigde geldsom niet tijdig
+      geeft, is het wettelijke rente verschuldigd vanaf het tijdstip waarop het in verzuim zou zijn geweest indien
+      de beschikking op de laatste dag van de daarvoor gestelde termijn zou zijn gegeven.
+    url: https://wetten.overheid.nl/BWBR0005537/2026-01-01#Artikel4:100
+  - number: 4:101
+    text: |-
+      Voor zover het bestuursorgaan uitstel van betaling heeft verleend of de rechter de verplichting tot betaling
+      heeft geschorst, is de schuldenaar over de termijn van uitstel of schorsing wettelijke rente verschuldigd,
+      tenzij bij het uitstel of de schorsing anders is bepaald.
+    url: https://wetten.overheid.nl/BWBR0005537/2026-01-01#Artikel4:101
+  - number: 4:102
+    text: |-
+      1. Indien een betaling aan het bestuursorgaan is geschied op grond van een beschikking die in bezwaar of in
+      beroep is gewijzigd of vernietigd, is het bestuursorgaan over de termijn tussen de betaling en de
+      terugbetaling wettelijke rente verschuldigd over het te veel betaalde bedrag.
+      2. Indien een afwijzende beschikking tot betaling door het bestuursorgaan als gevolg van bezwaar of beroep
+      wordt vervangen door een beschikking tot betaling, is het bestuursorgaan wettelijke rente verschuldigd vanaf
+      het tijdstip waarop het in verzuim zou zijn geweest indien de beschikking op de laatste dag van de daarvoor
+      gestelde termijn zou zijn gegeven.
+      3. Wettelijke rente is niet verschuldigd voor zover de belanghebbende onjuiste of onvolledige gegevens heeft
+      verstrekt, dan wel aan de belanghebbende is toe te rekenen dat onjuiste of onvolledige gegevens zijn
+      verstrekt.
+      4. Dit artikel is van overeenkomstige toepassing indien het bestuursorgaan de beschikking tot betaling met
+      terugwerkende kracht wijzigt of intrekt.
+    url: https://wetten.overheid.nl/BWBR0005537/2026-01-01#Artikel4:102
+  - number: 4:103
+    text: |-
+      Deze afdeling is niet van toepassing indien bij de wet een andere regeling omtrent verzuim en de gevolgen
+      daarvan is getroffen.
+    url: https://wetten.overheid.nl/BWBR0005537/2026-01-01#Artikel4:103
+  - number: 4:104
+    text: |-
+      1. De rechtsvordering tot betaling van een geldsom verjaart vijf jaren nadat de voorgeschreven
+      betalingstermijn is verstreken.
+      2. Na voltooiing van de verjaring kan het bestuursorgaan zijn bevoegdheden tot aanmaning en verrekening en tot
+      uitvaardiging en tenuitvoerlegging van een dwangbevel niet meer uitoefenen.
+    url: https://wetten.overheid.nl/BWBR0005537/2026-01-01#Artikel4:104
+  - number: 4:105
+    text: |-
+      1. De verjaring wordt gestuit door een daad van rechtsvervolging overeenkomstig artikel 316, eerste lid, van
+      Boek 3 van het Burgerlijk Wetboek. Artikel 316, tweede lid, van Boek 3 van het Burgerlijk Wetboek is van
+      overeenkomstige toepassing.
+      2. Erkenning van het recht op betaling stuit de verjaring van de rechtsvordering tegen hem die het recht
+      erkent.
+    url: https://wetten.overheid.nl/BWBR0005537/2026-01-01#Artikel4:105
+  - number: 4:106
+    text: |-
+      Het bestuursorgaan kan de verjaring ook stuiten door een aanmaning als bedoeld in artikel 4:112, een
+      beschikking tot verrekening of een dwangbevel dan wel door een daad van tenuitvoerlegging van een dwangbevel.
+    url: https://wetten.overheid.nl/BWBR0005537/2026-01-01#Artikel4:106
+  - number: 4:107
+    text: |-
+      De schuldeiser van het bestuursorgaan kan de verjaring ook stuiten door een schriftelijke aanmaning of een
+      schriftelijke mededeling waarin hij zich ondubbelzinnig zijn recht op betaling voorbehoudt.
+    url: https://wetten.overheid.nl/BWBR0005537/2026-01-01#Artikel4:107
+  - number: 4:108
+    text: |-
+      Indien de schuldeiser van het bestuursorgaan een recht tot verrekening als bedoeld in artikel 4:93 heeft,
+      eindigt dit recht niet door verjaring van de rechtsvordering.
+    url: https://wetten.overheid.nl/BWBR0005537/2026-01-01#Artikel4:108
+  - number: 4:109
+    text: |-
+      Indien de schuldeiser van het bestuursorgaan zelf een bestuursorgaan is, zijn de artikelen 4:107 en 4:108 niet
+      van toepassing.
+    url: https://wetten.overheid.nl/BWBR0005537/2026-01-01#Artikel4:109
+  - number: 4:110
+    text: |-
+      1. Door stuiting van de verjaring begint een nieuwe verjaringstermijn te lopen met de aanvang van de volgende
+      dag.
+      2. De nieuwe termijn is gelijk aan de oorspronkelijke, doch niet langer dan vijf jaren.
+      3. Wordt de verjaring echter gestuit door het instellen van een eis die door toewijzing wordt gevolgd, dan is
+      artikel 324 van Boek 3 van het Burgerlijk Wetboek van overeenkomstige toepassing.
+    url: https://wetten.overheid.nl/BWBR0005537/2026-01-01#Artikel4:110
+  - number: 4:111
+    text: |-
+      1. De verjaringstermijn van de rechtsvordering tot betaling aan een bestuursorgaan wordt verlengd met de tijd
+      gedurende welke de schuldenaar na de aanvang van die termijn uitstel van betaling heeft.
+      2. Het eerste lid is van overeenkomstige toepassing indien:
+      a. de schuldenaar in surseance van betaling verkeert;
+      b. de schuldenaar in staat van faillissement verkeert;
+      c. ten aanzien van de schuldenaar de schuldsaneringsregeling natuurlijke personen van toepassing is;
+      d. de tenuitvoerlegging van een dwangbevel is geschorst ingevolge een lopend rechtsgeding, met dien verstande
+      dat de termijn waarmee de verjaringstermijn wordt verlengd een aanvang neemt op de dag waarop het rechtsgeding
+      door het instellen van een vordering bij de burgerlijke rechter aanhangig wordt gemaakt.
+    url: https://wetten.overheid.nl/BWBR0005537/2026-01-01#Artikel4:111
+  - number: 4:112
+    text: |-
+      1. Het bestuursorgaan maant de schuldenaar die in verzuim is schriftelijk aan tot betaling binnen twee weken,
+      gerekend vanaf de dag na die waarop de aanmaning is toegezonden.
+      2. Bij wettelijk voorschrift kan een andere termijn worden vastgesteld.
+      3. De aanmaning vermeldt dat bij niet tijdige betaling deze kan worden afgedwongen door op kosten van de
+      schuldenaar uit te voeren invorderingsmaatregelen.
+    url: https://wetten.overheid.nl/BWBR0005537/2026-01-01#Artikel4:112
+  - number: 4:113
+    text: |-
+      1. Het bestuursorgaan kan voor de aanmaning een vergoeding in rekening brengen. De vergoeding bedraagt € 9
+      indien de schuld minder dan € 454 bedraagt en € 20 indien de schuld € 454 of meer bedraagt.
+      2. De aanmaning vermeldt de vergoeding die in rekening wordt gebracht.
+    url: https://wetten.overheid.nl/BWBR0005537/2026-01-01#Artikel4:113
+  - number: 4:114
+    text: |-
+      Onder dwangbevel wordt verstaan: een schriftelijk bevel van een bestuursorgaan dat ertoe strekt de betaling
+      van een geldsom als bedoeld in artikel 4:85 af te dwingen.
+    url: https://wetten.overheid.nl/BWBR0005537/2026-01-01#Artikel4:114
+  - number: 4:115
+    text: |-
+      De bevoegdheid tot uitvaardiging van een dwangbevel bestaat slechts indien zij bij de wet is toegekend.
+    url: https://wetten.overheid.nl/BWBR0005537/2026-01-01#Artikel4:115
+  - number: 4:116
+    text: |-
+      Een dwangbevel levert een executoriale titel op, die met toepassing van de voorschriften van het Wetboek van
+      Burgerlijke Rechtsvordering kan worden tenuitvoergelegd.
+    url: https://wetten.overheid.nl/BWBR0005537/2026-01-01#Artikel4:116
+  - number: 4:117
+    text: |-
+      1. Een dwangbevel wordt slechts uitgevaardigd wanneer binnen de overeenkomstig artikel 4:112 gestelde
+      aanmaningstermijn niet volledig is betaald.
+      2. Bij de wet kan evenwel worden bepaald dat het dwangbevel zo nodig zonder aanmaning en voor het verstrijken
+      van bij wettelijk voorschrift gestelde of eerder gegunde betalings- of aanmaningstermijnen kan worden
+      uitgevaardigd of tenuitvoergelegd.
+    url: https://wetten.overheid.nl/BWBR0005537/2026-01-01#Artikel4:117
+  - number: 4:118
+    text: |-
+      Artikel 4:8 is niet van toepassing op de aanmaning en het dwangbevel.
+    url: https://wetten.overheid.nl/BWBR0005537/2026-01-01#Artikel4:118
+  - number: 4:119
+    text: |-
+      1. Bij het dwangbevel kunnen tevens de aanmaningsvergoeding, de wettelijke rente en de kosten van het
+      dwangbevel worden ingevorderd.
+      2. Het dwangbevel kan betrekking hebben op verschillende verplichtingen tot betaling van een geldsom door de
+      schuldenaar aan het bestuursorgaan.
+    url: https://wetten.overheid.nl/BWBR0005537/2026-01-01#Artikel4:119
+  - number: 4:120
+    text: |-
+      1. De betekening en de tenuitvoerlegging van het dwangbevel geschieden op kosten van degene tegen wie het is
+      uitgevaardigd.
+      2. De gerechtelijke kosten worden berekend met toepassing van de op grond van artikel 434a van het Wetboek van
+      Burgerlijke Rechtsvordering vastgestelde tarieven. De buitengerechtelijke kosten worden berekend met
+      toepassing van bij algemene maatregel van bestuur vast te stellen tarieven.
+      3. De kosten zijn ook verschuldigd indien het dwangbevel door betaling van verschuldigde bedragen niet of niet
+      volledig ten uitvoer is gelegd.
+    url: https://wetten.overheid.nl/BWBR0005537/2026-01-01#Artikel4:120
+  - number: 4:121
+    text: |-
+      Indien een dwangbevel dat is uitgevaardigd voor een gedeelte van een verplichting tot betaling van een geldsom
+      ten uitvoer wordt gelegd door beslaglegging, kunnen bij datzelfde dwangbevel alle tot het tijdstip van
+      beslaglegging vervallen termijnen van die verplichting worden ingevorderd, mits het op dat tijdstip
+      invorderbare bedrag uit het dwangbevel is op te maken.
+    url: https://wetten.overheid.nl/BWBR0005537/2026-01-01#Artikel4:121
+  - number: 4:122
+    text: |-
+      1. Het dwangbevel vermeldt in ieder geval:
+      a. aan het hoofd het woord «dwangbevel»;
+      b. het bedrag van de invorderbare hoofdsom;
+      c. de beschikking of het wettelijk voorschrift waaruit de geldschuld voortvloeit;
+      d. de kosten van het dwangbevel, en
+      e. dat het op kosten van de schuldenaar ten uitvoer kan worden gelegd.
+      2. Het dwangbevel vermeldt, indien van toepassing:
+      a. het bedrag van de aanmaningsvergoeding, en
+      b. de ingangsdatum van de wettelijke rente.
+    url: https://wetten.overheid.nl/BWBR0005537/2026-01-01#Artikel4:122
+  - number: 4:123
+    text: |-
+      1. De bekendmaking van een dwangbevel geschiedt door middel van de betekening van een exploot als bedoeld in
+      het Wetboek van Burgerlijke Rechtsvordering. De artikelen 3:41 tot en met 3:45 zijn niet van toepassing.
+      2. Het exploot vermeldt in ieder geval de rechtbank waarbij tegen het dwangbevel en de tenuitvoerlegging ervan
+      overeenkomstig de artikelen 438 en 438a van het Wetboek van Burgerlijke Rechtsvordering kan worden opgekomen.
+    url: https://wetten.overheid.nl/BWBR0005537/2026-01-01#Artikel4:123
+  - number: 4:124
+    text: |-
+      Het bestuursorgaan beschikt ten aanzien van de invordering ook over de bevoegdheden die een schuldeiser op
+      grond van het privaatrecht heeft.
+    url: https://wetten.overheid.nl/BWBR0005537/2026-01-01#Artikel4:124

--- a/corpus/regulation/nl/wet/wet_administratiefrechtelijke_handhaving_verkeersvoorschriften/2026-01-01.yaml
+++ b/corpus/regulation/nl/wet/wet_administratiefrechtelijke_handhaving_verkeersvoorschriften/2026-01-01.yaml
@@ -51,6 +51,54 @@ articles:
       6. Een algemene maatregel van bestuur, als bedoeld in het vijfde lid, wordt vastgesteld op voordracht van Onze
       Minister en Onze Minister van Infrastructuur en Milieu.
     url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel2
+    machine_readable:
+      execution:
+        parameters:
+          - name: basis_geldsom
+            type: number
+            required: true
+            description: De voor de gedraging in de bijlage bepaalde geldsom, in eurocent
+          - name: leeftijd_ten_tijde_gedraging
+            type: number
+            required: true
+            description: Leeftijd in jaren van de betrokkene ten tijde van de gedraging
+        input:
+          - name: bedrag_eerste_categorie
+            type: amount
+            source:
+              regulation: wetboek_van_strafrecht
+              output: bedrag_eerste_categorie
+              parameters:
+                boetecategorie: '1'
+            type_spec:
+              unit: eurocent
+        output:
+          - name: geldsom
+            type: amount
+            type_spec:
+              unit: eurocent
+            description: De aan de Staat te betalen geldsom voor de gedraging
+        actions:
+          # Lid 4: voor personen jonger dan 16 jaar wordt de geldsom gehalveerd.
+          # Lid 3: de geldsom kan niet meer zijn dan het bedrag van de geldboete
+          # van de eerste categorie (artikel 23 Wetboek van Strafrecht).
+          - output: geldsom
+            value:
+              operation: MIN
+              values:
+                - operation: IF
+                  cases:
+                    - when:
+                        operation: LESS_THAN
+                        subject: $leeftijd_ten_tijde_gedraging
+                        value: 16
+                      then:
+                        operation: DIVIDE
+                        values:
+                          - $basis_geldsom
+                          - 2
+                  default: $basis_geldsom
+                - $bedrag_eerste_categorie
   - number: 2a
     text: |-
       De titels 4.4, 5.1 en 5.4 van de Algemene wet bestuursrecht zijn niet van toepassing op het opleggen en de
@@ -99,6 +147,33 @@ articles:
       wijze waarop de sanctie, alsmede de verhogingen die krachtens artikel 23, derde lid, en artikel 25 op de
       administratieve sanctie vallen, indien deze niet tijdig wordt voldaan, dient te worden voldaan.
     url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel4
+    machine_readable:
+      execution:
+        parameters:
+          - name: gedraging_datum
+            type: date
+            required: true
+            description: Datum waarop de gedraging heeft plaatsgevonden
+        output:
+          - name: bekendmaking_termijn_datum
+            type: date
+            description: De beschikking wordt binnen vier maanden na de gedraging bekendgemaakt (lid 2)
+          - name: uiterste_bekendmaking_datum
+            type: date
+            description: Bekendmaking geschiedt uiterlijk vijf jaar na de gedraging (lid 2)
+        actions:
+          # Lid 2: bekendmaking binnen vier maanden na de gedraging; bij toezending
+          # aan de kentekenhouder uiterlijk binnen vijf jaar na de gedraging.
+          - output: bekendmaking_termijn_datum
+            value:
+              operation: DATE_ADD
+              date: $gedraging_datum
+              months: 4
+          - output: uiterste_bekendmaking_datum
+            value:
+              operation: DATE_ADD
+              date: $gedraging_datum
+              years: 5
   - number: '5'
     text: |-
       Indien is vastgesteld dat de gedraging heeft plaatsgevonden met of door middel van een motorrijtuig waarvoor
@@ -226,6 +301,64 @@ articles:
       gemachtigde in rekening te brengen vergoedingen is het ter zake bepaalde bij of krachtens de Wet
       griffierechten burgerlijke zaken van overeenkomstige toepassing.
     url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel11
+    machine_readable:
+      definitions:
+        zekerheidsbedrag_standaard:
+          value: 22500
+          description: Zekerheid wordt gesteld voor de betaling van EUR 225 (lid 2)
+      execution:
+        parameters:
+          - name: sanctiebedrag
+            type: number
+            required: true
+            description: Het bedrag van de opgelegde administratieve sanctie in eurocent
+          - name: jonger_dan_16
+            type: boolean
+            required: true
+            description: Of de betrokkene ten tijde van de gedraging jonger dan 16 jaar was
+        output:
+          - name: zekerheidstelling_vereist
+            type: boolean
+            description: Of zekerheid moet worden gesteld voor de betaling (lid 2)
+          - name: zekerheidsbedrag
+            type: amount
+            type_spec:
+              unit: eurocent
+            description: Bedrag waarvoor zekerheid wordt gesteld, exclusief administratiekosten (lid 2)
+        actions:
+          # Lid 2: zekerheidstelling indien de sanctie ten minste EUR 225 bedraagt;
+          # voor personen jonger dan 16 jaar gelden de helft van die bedragen.
+          - output: zekerheidstelling_vereist
+            value:
+              operation: GREATER_THAN_OR_EQUAL
+              subject: $sanctiebedrag
+              value:
+                operation: IF
+                cases:
+                  - when:
+                      operation: EQUALS
+                      subject: $jonger_dan_16
+                      value: true
+                    then:
+                      operation: DIVIDE
+                      values:
+                        - $zekerheidsbedrag_standaard
+                        - 2
+                default: $zekerheidsbedrag_standaard
+          - output: zekerheidsbedrag
+            value:
+              operation: IF
+              cases:
+                - when:
+                    operation: EQUALS
+                    subject: $jonger_dan_16
+                    value: true
+                  then:
+                    operation: DIVIDE
+                    values:
+                      - $zekerheidsbedrag_standaard
+                      - 2
+              default: $zekerheidsbedrag_standaard
   - number: '12'
     text: |-
       1. De kantonrechter stelt, alvorens te beslissen, partijen in de gelegenheid om op een door de kantonrechter
@@ -454,6 +587,55 @@ articles:
       3. De sanctie wordt van rechtswege met vijftig procent verhoogd indien het in de gestelde termijn of termijnen
       verschuldigde bedrag niet tijdig geheel wordt voldaan.
     url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel23
+    machine_readable:
+      definitions:
+        verhogingspercentage:
+          value: 0.5
+          description: De sanctie wordt van rechtswege met vijftig procent verhoogd (lid 3)
+      execution:
+        parameters:
+          - name: sanctiebedrag
+            type: number
+            required: true
+            description: Het bedrag van de opgelegde administratieve sanctie in eurocent
+          - name: tijdig_voldaan
+            type: boolean
+            required: true
+            description: Of het in de gestelde termijn verschuldigde bedrag tijdig geheel is voldaan
+        output:
+          - name: verhoging
+            type: amount
+            type_spec:
+              unit: eurocent
+            description: De verhoging van rechtswege bij niet-tijdige betaling (lid 3)
+          - name: bedrag_na_verhoging
+            type: amount
+            type_spec:
+              unit: eurocent
+            description: Het verschuldigde bedrag na de verhoging van vijftig procent
+        actions:
+          # Lid 3: van rechtswege +50% indien het verschuldigde bedrag niet tijdig
+          # geheel wordt voldaan.
+          - output: verhoging
+            value:
+              operation: IF
+              cases:
+                - when:
+                    operation: EQUALS
+                    subject: $tijdig_voldaan
+                    value: false
+                  then:
+                    operation: MULTIPLY
+                    values:
+                      - $sanctiebedrag
+                      - $verhogingspercentage
+              default: 0
+          - output: bedrag_na_verhoging
+            value:
+              operation: ADD
+              values:
+                - $sanctiebedrag
+                - $verhoging
   - number: '24'
     text: |-
       1. Degene aan wie een administratieve sanctie is opgelegd, is verplicht tot betaling van het ingevolge artikel
@@ -461,6 +643,23 @@ articles:
       2. Indien na de verhoging het verschuldigde bedrag behoudens de administratiekosten, ten minste € 225
       bedraagt, is artikel 23, tweede lid, van overeenkomstige toepassing.
     url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel24
+    machine_readable:
+      execution:
+        parameters:
+          - name: aanmaning_datum
+            type: date
+            required: true
+            description: Datum waarop Onze Minister de aanmaning heeft toegezonden
+        output:
+          - name: uiterste_betaaldatum_na_aanmaning
+            type: date
+            description: Betaling van het verhoogde bedrag binnen vier weken na de aanmaning (lid 1)
+        actions:
+          - output: uiterste_betaaldatum_na_aanmaning
+            value:
+              operation: DATE_ADD
+              date: $aanmaning_datum
+              weeks: 4
   - number: '25'
     text: |-
       1. Indien degene aan wie een administratieve sanctie is opgelegd, nalaat het in de op grond van artikel 24
@@ -480,6 +679,67 @@ articles:
       4. Het recht om verhaal te nemen vervalt door het overlijden van degene aan wie een administratieve sanctie is
       opgelegd.
     url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel25
+    machine_readable:
+      definitions:
+        tweede_verhogingspercentage:
+          value: 1.0
+          description: Verhoging met honderd procent (lid 1)
+      execution:
+        parameters:
+          - name: sanctiebedrag
+            type: number
+            required: true
+            description: Het bedrag van de opgelegde administratieve sanctie in eurocent
+          - name: tijdig_voldaan
+            type: boolean
+            required: true
+            description: Of het na artikel 23 verschuldigde bedrag tijdig geheel is voldaan
+          - name: tijdig_voldaan_na_aanmaning
+            type: boolean
+            required: true
+            description: Of het in de op grond van artikel 24 gestelde termijn verschuldigde bedrag tijdig is voldaan
+        input:
+          - name: bedrag_na_eerste_verhoging
+            type: amount
+            source:
+              output: bedrag_na_verhoging
+            type_spec:
+              unit: eurocent
+        output:
+          - name: tweede_verhoging
+            type: amount
+            type_spec:
+              unit: eurocent
+            description: De verhoging van rechtswege met honderd procent (lid 1)
+          - name: bedrag_na_tweede_verhoging
+            type: amount
+            type_spec:
+              unit: eurocent
+            description: Het verschuldigde bedrag na de verhoging van honderd procent
+        actions:
+          # Lid 1: indien betaling na artikel 24 uitblijft, +100% van het bedrag
+          # van de sanctie en de daarop inmiddels gevallen verhoging (= het na
+          # artikel 23 verschuldigde bedrag).
+          - output: tweede_verhoging
+            value:
+              operation: IF
+              cases:
+                - when:
+                    operation: EQUALS
+                    subject: $tijdig_voldaan_na_aanmaning
+                    value: false
+                  then:
+                    operation: MULTIPLY
+                    values:
+                      - $bedrag_na_eerste_verhoging
+                      - $tweede_verhogingspercentage
+              default: 0
+          - output: bedrag_na_tweede_verhoging
+            value:
+              operation: ADD
+              values:
+                - $bedrag_na_eerste_verhoging
+                - $tweede_verhoging
   - number: '26'
     text: |-
       1. Verhaal op de goederen van degene aan wie de administratieve sanctie is opgelegd geschiedt krachtens een

--- a/corpus/regulation/nl/wet/wet_administratiefrechtelijke_handhaving_verkeersvoorschriften/2026-01-01.yaml
+++ b/corpus/regulation/nl/wet/wet_administratiefrechtelijke_handhaving_verkeersvoorschriften/2026-01-01.yaml
@@ -1,0 +1,781 @@
+---
+$schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/heads/main/schema/v0.5.0/schema.json
+$id: wet_administratiefrechtelijke_handhaving_verkeersvoorschriften
+regulatory_layer: WET
+publication_date: '2026-01-01'
+valid_from: '2026-01-01'
+name: Wet administratiefrechtelijke handhaving verkeersvoorschriften
+bwb_id: BWBR0004581
+url: https://wetten.overheid.nl/BWBR0004581/2026-01-01
+
+articles:
+  - number: '1'
+    text: |-
+      1. In deze wet wordt verstaan onder:
+      *Onze Minister:* Onze Minister van Veiligheid en Justitie;
+      *aanhangwagen, motorrijtuig, kenteken en rijbewijs*: hetgeen daaronder wordt verstaan in artikel 1, eerste
+      lid, van de Wegenverkeerswet 1994;
+      *bestuurder*: alle weggebruikers behalve voetgangers;
+      *kentekenregister*: het register, bedoeld in artikel 42 van de Wegenverkeerswet 1994;
+      *gedraging:* een gedraging als bedoeld in artikel 2, eerste lid;
+      *administratieve sanctie:* de aan de Staat te betalen geldsom, bedoeld in artikel 2;
+      *adres:* aanduiding van straatnaam, huisnummer, plaatsnaam en postcode van het woonhuis van de betrokkene.
+      2. In deze wet wordt mede verstaan onder:
+      *bestuurder*: degene die wordt geacht een motorrijtuig onder zijn onmiddellijk toezicht te doen besturen;
+      *kenteken*: het kenteken waaronder een motorrijtuig in het buitenland is geregistreerd, het registratienummer,
+      vermeld op het registratiebewijs, afgegeven voor een motorrijtuig gebezigd ten behoeve van de strijdkrachten,
+      alsmede enig ander registratienummer waaronder een motorrijtuig in Nederland mag worden geregistreerd;
+      *kentekenregister*: een buitenlands register betreffende aldaar geregistreerde motorrijtuigen, de registratie
+      betreffende motorrijtuigen gebezigd ten behoeve van de strijdkrachten, bijgehouden door Onze Minister van
+      Defensie, alsmede enig andere registratie betreffende motorrijtuigen, waarvan de houder gerechtigd is deze in
+      Nederland te voeren;
+      *rijbewijs*: een door het bevoegde gezag in het buitenland afgegeven rijbewijs, alsmede een door het militaire
+      gezag afgegeven rijbewijs.
+    url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel1
+  - number: '2'
+    text: |-
+      1. Ter zake van de in de bijlage bij deze wet omschreven gedragingen die in strijd zijn met op het verkeer
+      betrekking hebbende voorschriften gesteld bij of krachtens de Wegenverkeerswet 1994, de Wet
+      aansprakelijkheidsverzekering motorrijtuigen, de Provinciewet of de Gemeentewet, kunnen op de wijze bij deze
+      wet bepaald administratieve sancties worden opgelegd. Ingeval een administratiefrechtelijke sanctie wordt
+      opgelegd zijn voorzieningen van strafrechtelijke of strafvorderlijke aard uitgesloten.
+      2. Als gedragingen in de zin van het eerste lid worden niet beschouwd die gedragingen waarbij letsel aan
+      personen is ontstaan of schade aan goederen is toegebracht.
+      3. Voor elke gedraging bepaalt de in het eerste lid bedoelde bijlage de aan de Staat te betalen geldsom. Deze
+      geldsom kan per gedraging niet meer zijn dan het bedrag van de geldboete van de eerste categorie.
+      4. De in het derde lid bedoelde geldsom wordt voor personen die ten tijde van de gedraging nog geen zestien
+      jaar oud waren, gehalveerd.
+      5. De in het eerste lid bedoelde bijlage kan bij algemene maatregel van bestuur worden gewijzigd. De
+      voordracht van deze algemene maatregel van bestuur wordt niet eerder gedaan dan vier weken nadat het ontwerp
+      aan beide kamers der Staten-Generaal is overgelegd.
+      6. Een algemene maatregel van bestuur, als bedoeld in het vijfde lid, wordt vastgesteld op voordracht van Onze
+      Minister en Onze Minister van Infrastructuur en Milieu.
+    url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel2
+  - number: 2a
+    text: |-
+      De titels 4.4, 5.1 en 5.4 van de Algemene wet bestuursrecht zijn niet van toepassing op het opleggen en de
+      inning van een administratieve sanctie en de administratiekosten op grond van deze wet.
+    url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel2a
+  - number: '3'
+    text: |-
+      1. Met het toezicht op de naleving van de in artikel 2, eerste lid, bedoelde voorschriften zijn belast de bij
+      algemene maatregel van bestuur aangewezen ambtenaren.
+      2. De in het eerste lid bedoelde ambtenaren zijn bevoegd tot het opleggen van een administratieve sanctie ter
+      zake van de door hen of op geautomatiseerde wijze vastgestelde gedragingen aan personen die de leeftijd van
+      twaalf jaren hebben bereikt.
+      3. De officier van justitie in het arrondissement waar de in het eerste lid bedoelde ambtenaren optreden,
+      houdt toezicht op de wijze waarop zij van de hun verleende bevoegdheid gebruik maken. Hij kan daaromtrent
+      beleidsregels vaststellen. Bij algemene maatregel van bestuur worden regels gesteld omtrent het toezicht op de
+      wijze waarop de in het eerste lid bedoelde ambtenaren van de hun verleende bevoegdheid gebruik maken en de
+      intrekking van die bevoegdheid.
+      4. Het College van procureurs-generaal houdt toezicht op de bij deze wet geregelde handhaving van
+      verkeersvoorschriften. Het geeft daartoe bevelen aan de hoofden van de arrondissementsparketten.
+    url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel3
+  - number: '4'
+    text: |-
+      1. De administratieve sanctie wordt opgelegd bij een gedagtekende beschikking. De beschikking bevat een korte
+      omschrijving, onder verwijzing naar de aanduiding in de bijlage, van de gedraging ter zake waarvan zij is
+      gegeven en het voor die gedraging bepaalde bedrag van de administratieve sanctie, de datum en het tijdstip
+      waarop, alsmede de plaats waar de gedraging is geconstateerd. Bij ministeriële regeling worden het model van
+      de beschikking en dat van de aankondiging van de beschikking vastgesteld, of de eisen waaraan het model moet
+      voldoen.
+      2. De bekendmaking van de beschikking geschiedt binnen vier maanden nadat de gedraging heeft plaatsgevonden,
+      door toezending van de beschikking aan het adres dat betrokkene heeft opgegeven. Indien dat niet mogelijk is
+      en de gedraging heeft plaatsgevonden met of door middel van een motorrijtuig waarvoor een kenteken is
+      opgegeven, dient de bekendmaking van de beschikking binnen vier maanden nadat de naam en het adres van de
+      kentekenhouder van dat motorrijtuig bekend zijn te geschieden, door toezending van de beschikking aan dat
+      adres, met dien verstande dat de bekendmaking van de beschikking geschiedt uiterlijk binnen vijf jaar nadat de
+      gedraging heeft plaatsgevonden. Indien de brief onbestelbaar blijkt te zijn, wordt de beschikking gezonden
+      naar het in de basisregistratie personen vermelde adres, tenzij dit hetzelfde is als hetgeen is opgenomen in
+      het kentekenregister. Indien de brief ook op het in de basisregistratie personen opgenomen adres onbestelbaar
+      blijkt te zijn, wordt de beschikking geacht aan de betrokkene bekend te zijn.
+      3. Een aankondiging van de beschikking kan worden uitgereikt aan degene tot wie zij zich richt of kan worden
+      achtergelaten in of aan het motorrijtuig.
+      4. In een geval als bedoeld in artikel 31, eerste lid, geschiedt de bekendmaking door uitreiking van de
+      beschikking aan betrokkene. De weigering de beschikking in ontvangst te nemen, schort de bekendmaking daarvan
+      niet op.
+      5. De beschikking vermeldt de dag waarop krachtens artikel 23 de sanctie en de administratiekosten uiterlijk
+      moet zijn voldaan. Tevens vermeldt de beschikking een beschikkingsnummer en de door Onze Minister bepaalde
+      wijze waarop de sanctie, alsmede de verhogingen die krachtens artikel 23, derde lid, en artikel 25 op de
+      administratieve sanctie vallen, indien deze niet tijdig wordt voldaan, dient te worden voldaan.
+    url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel4
+  - number: '5'
+    text: |-
+      Indien is vastgesteld dat de gedraging heeft plaatsgevonden met of door middel van een motorrijtuig waarvoor
+      een kenteken is opgegeven, en niet aanstonds is vastgesteld wie daarvan de bestuurder is, wordt, onverminderd
+      het bepaalde in artikel 31, tweede lid, de administratieve sanctie opgelegd aan degene op wiens naam het
+      kenteken ten tijde van de gedraging in het kentekenregister was ingeschreven. Daarbij wordt hij gewezen op het
+      bepaalde in artikel 8.
+    url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel5
+  - number: 5a
+    text: |-
+      Indien is vastgesteld dat de gedraging heeft plaatsgevonden met of door middel van een motorrijtuig, waarmee
+      een aanhangwagen waarvoor een kenteken is vereist, wordt voortbewogen, dan wel waaraan een aanhangwagen
+      waarvoor een kenteken is vereist, is gekoppeld, en niet aanstonds is vastgesteld wie daarvan de bestuurder is,
+      wordt, onverminderd het bepaalde in artikel 31, tweede lid, de administratieve sanctie opgelegd aan degene op
+      wiens naam het kenteken van het motorrijtuig ten tijde van de gedraging in het kentekenregister was
+      ingeschreven. Indien het kenteken van het motorrijtuig niet is vastgesteld, wordt, onverminderd het bepaalde
+      in artikel 31, tweede lid, de administratieve sanctie opgelegd aan degene op wiens naam het kenteken van de
+      aanhangwagen ten tijde van de gedraging in het kentekenregister was ingeschreven. In beide gevallen wordt hij
+      gewezen op het bepaalde in artikel 8.
+    url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel5a
+  - number: 5b
+    text: |-
+      1. Indien is vastgesteld dat de gedraging heeft plaatsgevonden met of door middel van een motorrijtuig waarmee
+      een niet-kentekenplichtige aanhangwagen wordt voortbewogen, dan wel waaraan een niet-kentekenplichtige
+      aanhangwagen is gekoppeld, en niet aanstonds is vastgesteld wie daarvan de bestuurder is, wordt, onverminderd
+      het bepaalde in artikel 31, tweede lid, de administratieve sanctie opgelegd aan degene op wiens naam het
+      kenteken van het trekkend motorrijtuig ten tijde van de gedraging in het kentekenregister was ingeschreven.
+      2. Indien is vastgesteld dat de gedraging heeft plaatsgevonden met of door middel van een kentekenplichtige
+      aanhangwagen, wordt de administratieve sanctie opgelegd aan degene op wiens naam het kenteken van de
+      aanhangwagen ten tijde van de gedraging in het kentekenregister was ingeschreven. Indien het kenteken van de
+      aanhangwagen niet is vastgesteld, dan wel indien de aanhangwagen niet kentekenplichtig is, wordt de
+      administratieve sanctie opgelegd aan degene die ten tijde van de gedraging eigenaar of houder was van de
+      aanhangwagen.
+      3. Indien sprake is van een geval als bedoeld in het eerste of tweede lid dan wordt daarbij gewezen op het
+      bepaalde in artikel 8.
+    url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel5b
+  - number: 5c
+    text: |-
+      Indien geen administratieve sanctie kan worden opgelegd, omdat degene die ten tijde van de geconstateerde
+      gedraging met of door middel van een motorrijtuig met een kenteken als bedoeld in artikel 4 van het
+      Kentekenreglement was ingeschreven in het kentekenregister immuniteit geniet op grond van het volkenrecht,
+      verstrekt de officier van justitie de gegevens, genoemd in artikel 4, eerste lid, tweede volzin aan Onze
+      Minister van Buitenlandse Zaken ten behoeve van het versturen van een notificatie aan deze kentekenhouder.
+    url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel5c
+  - number: '6'
+    text: |-
+      1. Tegen de oplegging van de administratieve sanctie kan degene tot wie de beschikking is gericht, beroep
+      instellen bij de officier van justitie.
+      2. Onverminderd artikel 6:5 van de Algemene wet bestuursrecht vermeldt het beroepschrift de geboortedatum, de
+      geboorteplaats en het geboortejaar van degene die het beroep heeft ingesteld, het nummer van zijn
+      bankrekening, indien degene die heeft, en het nummer van de beschikking, bedoeld in artikel 4, vierde lid.
+    url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel6
+  - number: '7'
+    text: |-
+      1. De artikelen 6:14, tweede lid, 7:16, tweede lid, 7:24, tweede en vijfde lid, en 7:26, vierde lid, van de
+      Algemene wet bestuursrecht zijn niet van toepassing.
+      2. In afwijking van artikel 7:16, eerste lid, van de Algemene wet bestuursrecht stelt de officier van justitie
+      slechts de indiener van het beroepschrift in de gelegenheid te worden gehoord.
+    url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel7
+  - number: '8'
+    text: |-
+      De officier van justitie vernietigt de beschikking indien, in het geval van artikel 5 onderscheidenlijk
+      artikel 5a, degene op wiens naam het kenteken in het kentekenregister is ingeschreven:
+      a. aannemelijk maakt dat tegen zijn wil door een ander van het motorrijtuig onderscheidenlijk de aanhangwagen
+      gebruik is gemaakt en dat hij dit gebruik redelijkerwijs niet heeft kunnen voorkomen,
+      b. een voor een termijn van ten hoogste drie maanden schriftelijk bedrijfsmatig aangegane huurovereenkomst
+      overlegt waaruit blijkt wie ten tijde van de gedraging de huurder van het motorrijtuig onderscheidenlijk de
+      aanhangwagen was, dan wel
+      c. een vrijwaringsbewijs, bedoeld in artikel 1, onderdeel *i*, van het Kentekenreglement, of een verklaring
+      als bedoeld in de artikelen 31 tot en met 33 van het Kentekenreglement, overlegt waaruit blijkt dat hij ten
+      tijde van de gedraging geen eigenaar of houder meer was van het betrokken motorrijtuig onderscheidenlijk de
+      betrokken aanhangwagen.
+      In de onder *a*, *b* en *c* bedoelde gevallen is de officier van justitie bevoegd tot het opleggen van een
+      administratieve sanctie aan degene die de gedraging heeft verricht of aan degene die de huurder van het
+      motorrijtuig onderscheidenlijk de aanhangwagen was, dan wel aan degene aan wie het motorrijtuig
+      onderscheidenlijk de aanhangwagen werd overgedragen. De artikelen 4, 6 en 7 zijn alsdan van overeenkomstige
+      toepassing, met dien verstande dat de beschikking uiterlijk binnen acht maanden nadat de gedraging heeft
+      plaatsgevonden wordt bekendgemaakt.
+    url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel8
+  - number: '9'
+    text: |-
+      1. Tegen de beslissing van de officier van justitie kan degene die administratief beroep heeft ingesteld,
+      beroep instellen bij de rechtbank; het beroep wordt behandeld en beslist door de kantonrechter. In afwijking
+      van artikel 6:4, derde lid, van de Algemene wet bestuursrecht, wordt het beroepschrift ingediend bij de
+      officier van justitie die ingevolge artikel 6, eerste lid, op het administratief beroep heeft beslist.
+      Hoofdstuk 8 van de Algemene wet bestuursrecht is niet van toepassing.
+      2. Het beroep kan worden ingesteld ter zake dat:
+      a. de gedraging niet is verricht of dat, buiten het geval van artikel 5, degene tot wie de beschikking is
+      gericht, de gestelde gedraging niet heeft verricht;
+      b. de officier van justitie had moeten beslissen dat de omstandigheden waaronder de gedraging heeft
+      plaatsgevonden, het opleggen van een administratieve sanctie niet billijken dan wel dat hij, gelet op de
+      omstandigheden waarin de betrokkene verkeert, een lager bedrag van de administratieve sanctie had moeten
+      vaststellen;
+      c. de officier van justitie ten onrechte de beschikking niet op grond van artikel 8 heeft vernietigd.
+      3. Artikel 6, tweede lid, is van overeenkomstige toepassing.
+    url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel9
+  - number: '10'
+    text: |-
+      De officier van justitie brengt het beroepschrift en de op de zaak betrekking hebbende stukken ter kennis van
+      de rechtbank van het arrondissement waarin de gedraging is verricht, dan wel bij de rechtbank van het
+      arrondissement waarin de woonplaats van de betrokkene is gelegen.
+    url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel10
+  - number: '11'
+    text: |-
+      1. Het beroepschrift en de op de zaak betrekking hebbende stukken worden door de officier van justitie aan de
+      rechtbank ter kennis gebracht binnen zes weken nadat de indiener zekerheid heeft gesteld voor de betaling van
+      de sanctie en de administratiekosten, dan wel nadat de termijn daarvoor is verstreken.
+      2. Indien de administratieve sanctie ten minste € 225 bedraagt, dient zekerheid te worden gesteld voor de
+      betaling van € 225 en de administratiekosten. Voor personen die ten tijde van de gedraging nog geen 16 jaar
+      oud waren, geldt de helft van de in de eerste volzin genoemde bedragen.
+      3. Indien de officier van justitie geheel of gedeeltelijk aan de indiener van het beroepschrift
+      tegemoetgekomen is, kan de in het eerste lid bedoelde termijn zonodig met vier weken worden verlengd.
+      4. De zekerheid wordt door de indiener gesteld bij Onze Minister, hetzij op de door Onze Minister
+      voorgeschreven wijze, hetzij anderszins door overboeking op de rekening van Onze Minister. De officier van
+      justitie wijst de indiener van het beroepschrift na de ontvangst ervan op de verplichting tot
+      zekerheidstelling en deelt hem mee dat de zekerheidstelling dient te geschieden binnen twee weken na de dag
+      van verzending van zijn mededeling. Indien de zekerheidstelling niet binnen deze termijn is geschied, wordt
+      het beroep door de kantonrechter niet-ontvankelijk verklaard, tenzij redelijkerwijs niet kan worden geoordeeld
+      dat de indiener in verzuim is geweest.
+      5. Alle op een beroepschrift betrekking hebbende stukken worden, indien zekerheidstelling heeft
+      plaatsgevonden, nedergelegd ter griffie van de rechtbank. Hiervan wordt door de griffier mededeling gedaan aan
+      degene die het beroep heeft ingesteld. De betrokkene of zijn gemachtigde kan binnen een door de kantonrechter
+      bepaalde en aan hem door de griffier medegedeelde termijn, deze stukken inzien en daarvan afschriften of
+      uittreksels vragen. Op de voor de verstrekking van afschriften en uittreksels aan de betrokkene of zijn
+      gemachtigde in rekening te brengen vergoedingen is het ter zake bepaalde bij of krachtens de Wet
+      griffierechten burgerlijke zaken van overeenkomstige toepassing.
+    url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel11
+  - number: '12'
+    text: |-
+      1. De kantonrechter stelt, alvorens te beslissen, partijen in de gelegenheid om op een door de kantonrechter
+      bepaalde dag en uur op een openbare zitting hun zienswijze nader toe te lichten. Zij worden daartoe door de
+      griffier opgeroepen. De oproep aan degene die het beroep heeft ingesteld wordt gericht aan het in het
+      beroepschrift vermelde adres.
+      2. Degene die het beroep heeft ingesteld, kan zich ter zitting doen bijstaan of doen vertegenwoordigen door
+      een advocaat of door een daartoe schriftelijk door hem gemachtigde.
+      3. Ter zitting kunnen getuigen en deskundigen worden meegebracht, ten einde door de kantonrechter te worden
+      gehoord. Deze kan ambtshalve of op verzoek ook andere personen als getuige of deskundige horen.
+      4. De kantonrechter kan bevelen, dat getuigen niet zullen worden gehoord en tolken niet tot de uitoefening van
+      hun taak zullen worden toegelaten dan na het afleggen van de eed of belofte.
+      5. Zij leggen in dat geval ten overstaan van hem de eed of belofte af; de getuigen: dat zij zullen zeggen de
+      gehele waarheid en niets dan de waarheid; de tolken: dat zij hun plichten als tolk met nauwkeurigheid zullen
+      vervullen. De deskundigen zijn verplicht hun taak onpartijdig en naar beste weten te verrichten.
+    url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel12
+  - number: 12a
+    text: |-
+      Titel IV van het Vierde Boek van het Wetboek van Strafvordering is van overeenkomstige toepassing.
+    url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel12a
+  - number: '13'
+    text: |-
+      1. Indien de kantonrechter bevindt dat het beroep ontvankelijk is en dat de beslissing van de officier van
+      justitie niet of niet ten volle gehandhaafd kan worden, verklaart de kantonrechter het beroep geheel of
+      gedeeltelijk gegrond en vernietigt of wijzigt het daarbij de bestreden beslissing.
+      2. De beslissing van de kantonrechter is met redenen omkleed en wordt hetzij terstond, hetzij uiterlijk
+      veertien dagen nadien, op een openbare zitting uitgesproken.
+      3. De beslissing wordt in het proces-verbaal der zitting aangetekend. De aantekening bevat de gronden waarop
+      de beslissing berust. Een afschrift van de aantekening van de beslissing wordt toegezonden aan partijen.
+    url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel13
+  - number: 13a
+    text: |-
+      1. De kantonrechter is bij uitsluiting bevoegd een partij te veroordelen in de kosten die een andere partij in
+      verband met de behandeling van het beroep bij de rechtbank, en van het bezwaar of van het administratief
+      beroep redelijkerwijs heeft moeten maken. De artikelen 7:15, tweede tot en met vierde lid, en 7:28, tweede,
+      vierde en vijfde lid, van de Algemene wet bestuursrecht zijn van toepassing. Een natuurlijke persoon kan
+      slechts in de kosten worden veroordeeld in geval van kennelijk onredelijk gebruik van procesrecht. Het Besluit
+      proceskosten bestuursrecht is van overeenkomstige toepassing.
+      2. Het bedrag dat strekt tot vergoeding van de kosten, bedoeld in het eerste lid, na toepassing van het
+      Besluit proceskosten bestuursrecht, wordt, voor zover die kosten betrekking hebben op door een derde
+      beroepsmatig verleende rechtsbijstand en geen sprake is van bijzondere omstandigheden als bedoeld in dat
+      besluit, vermenigvuldigd met:
+      a. 0,25 indien de kosten zijn gemaakt in verband met de behandeling van het administratief beroep dan wel het
+      beroep bij de rechtbank waarbij de bestreden administratieve sanctie wordt vernietigd of het sanctiebedrag
+      wordt gewijzigd;
+      b. 0,1 in alle overige gevallen.
+      3. Onverminderd het vijfde lid vinden uitbetalingen ingevolge een beslissing op het administratief beroep of
+      uitspraak op beroep op grond van deze wet uitsluitend plaats op een bankrekening die op naam staat van degene
+      tot wie de beschikking waarbij de administratieve sanctie is opgelegd, is gericht.
+      4. Vorderingen tot uitbetaling als bedoeld in het derde lid zijn niet vatbaar voor vervreemding of verpanding.
+      5. In geval van een veroordeling in de kosten ten behoeve van een partij aan wie ter zake van het beroep bij
+      de kantonrechter, het bezwaar of het administratief beroep een toevoeging is verleend krachtens de Wet op de
+      rechtsbijstand, wordt het bedrag van de kosten betaald aan de rechtsbijstandverlener. De
+      rechtsbijstandverlener stelt de belanghebbende zoveel mogelijk schadeloos voor de door deze voldane eigen
+      bijdrage. De rechtsbijstandverlener doet aan de Raad voor rechtsbijstand opgave van een kostenvergoeding door
+      het bestuursorgaan.
+      6. In geval van een veroordeling in de kosten ten behoeve van de indiener van het beroepschrift worden de
+      kosten door de Staat der Nederlanden vergoed.
+    url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel13a
+  - number: 13b
+    text: |-
+      1. In geval van intrekking van het beroep omdat de officier van justitie geheel of gedeeltelijk aan de
+      indiener van het beroepschrift is tegemoetgekomen, kan de officier van justitie op verzoek van de indiener bij
+      afzonderlijke uitspraak met toepassing van artikel 13a in de kosten worden veroordeeld. Het verzoek wordt
+      gedaan tegelijk met de intrekking van het beroep. Indien aan dit vereiste niet is voldaan, wordt het verzoek
+      niet-ontvankelijk verklaard. Het verzoek wordt bij de officier van justitie ingediend.
+      2. De kantonrechter stelt de verzoeker zo nodig in de gelegenheid het verzoek schriftelijk toe te lichten en
+      stelt de officier van justitie in de gelegenheid een verweerschrift in te dienen. Hij stelt hiervoor termijnen
+      vast. Indien het verzoek mondeling wordt gedaan, kan de kantonrechter bepalen dat het toelichten van het
+      verzoek en het voeren van verweer onmiddellijk mondeling geschieden.
+      3. Indien het toelichten van het verzoek en het voeren van verweer mondeling zijn geschied, sluit de
+      kantonrechter het onderzoek.
+      4. Indien het verzoek schriftelijk wordt toegelicht, nodigt de kantonrechter partijen uit ter zitting te
+      verschijnen. Indien partijen daarvoor toestemming hebben gegeven, kan de kantonrechter bepalen dat het
+      onderzoek ter zitting achterwege blijft. De kantonrechter kan ook ambtshalve besluiten het verzoek buiten
+      zitting af te doen. De kantonrechter sluit vervolgens het onderzoek.
+    url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel13b
+  - number: '14'
+    text: |-
+      1. Degene die bij de rechtbank beroep heeft ingesteld, alsmede de officier van justitie, kunnen tegen de
+      beslissing van de kantonrechter hoger beroep instellen bij het gerechtshof Arnhem-Leeuwarden, tenzij de
+      opgelegde administratieve sanctie bij die beslissing niet meer bedraagt dan € 110.
+      2. Eveneens kan degene die bij de rechtbank beroep heeft ingesteld doch daarin met toepassing van het bepaalde
+      in artikel 11, vierde lid, niet-ontvankelijk is verklaard, tegen die beslissing hoger beroep instellen op de
+      grond dat de kantonrechter ten onrechte heeft geoordeeld dat de zekerheid niet dan wel niet tijdig is gesteld
+      dan wel ten onrechte niet heeft geoordeeld dat de indiener redelijkerwijs niet geacht kan worden in verzuim te
+      zijn geweest.
+    url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel14
+  - number: '15'
+    text: |-
+      1. In afwijking van artikel 6:4 van de Algemene wet bestuursrecht geschiedt het instellen van hoger beroep
+      door het indienen van een beroepschrift bij de rechtbank van de kantonrechter tegen wiens beslissing het
+      beroep is gericht.
+      2. Nadat de termijn voor het instellen van hoger beroep is verstreken, zendt de griffier van de rechtbank het
+      ingekomen beroepschrift met de stukken van het geding en een afschrift van de beslissing onverwijld ter
+      griffie van het gerechtshof Arnhem-Leeuwarden in.
+    url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel15
+  - number: '16'
+    text: |-
+      1. Het gerechtshof beslist, behoudens het bepaalde in het tweede lid, in enkelvoudige kamers.
+      2. De oudste in rang van de voorzitters van de meervoudige kamers regelt de verdeling van de werkzaamheden
+      over de kamers. Indien de voorzitter de zaak niet vatbaar acht voor afdoening door een enkelvoudige kamer,
+      wijst hij voor de behandeling van de zaak de meervoudige kamer aan.
+      3. De voorzitter is bevoegd een reeds door een meervoudige kamer in behandeling genomen zaak op voordracht van
+      die kamer te verwijzen naar een enkelvoudige kamer.
+      4. Een enkelvoudige kamer kan een zaak in iedere stand van het geding naar een meervoudige kamer verwijzen.
+    url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel16
+  - number: '17'
+    text: |-
+      De artikelen 512 tot en met 518 van het Wetboek van Strafvordering zijn van overeenkomstige toepassing.
+    url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel17
+  - number: '18'
+    text: |-
+      1. Nadat het hoger beroep is ingesteld treedt de advocaat-generaal bij het ressortsparket als partij in de
+      plaats van de officier van justitie.
+      2. De officier van justitie verstrekt de advocaat-generaal bij het ressortsparket de nodige inlichtingen.
+    url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel18
+  - number: '19'
+    text: |-
+      1. De griffier van het gerechtshof zendt een door hem voor eensluidend getekend afschrift van het
+      beroepschrift onverwijld toe aan degene, die mede tot het instellen van hoger beroep gerechtigd was.
+      2. Deze kan binnen vier weken nadat het afschrift is verzonden, bij het gerechtshof een ondertekend
+      verweerschrift indienen.
+      3. De griffier van het gerechtshof zendt een door hem voor eensluidend getekend verweerschrift onverwijld aan
+      degene die hoger beroep heeft ingesteld. Deze kan binnen twee weken nadat het afschrift van het verweerschrift
+      is verzonden schriftelijk een nadere toelichting geven op zijn beroep. Indien een nadere toelichting gegeven
+      wordt, stelt het gerechtshof de in het eerste lid bedoelde persoon in de gelegenheid hierop eveneens binnen
+      twee weken te reageren.
+      4. Partijen kunnen afschriften van of uittreksels uit door hen omschreven stukken verkrijgen. Op de voor de
+      verstrekking van afschriften of uittreksels in rekening te brengen vergoedingen is het bij of krachtens de Wet
+      griffierechten burgerlijke zaken bepaalde van overeenkomstige toepassing.
+    url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel19
+  - number: '20'
+    text: |-
+      Het gerechtshof kan partijen en zonodig getuigen en deskundigen opdragen binnen een bepaalde termijn
+      schriftelijk inlichtingen te geven of onder hen berustende stukken in te zenden.
+    url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel20
+  - number: 20a
+    text: |-
+      1. Een partij kan schriftelijk verzoeken om een behandeling ter zitting. Zodanig verzoek wordt ingediend bij
+      het beroepschrift of, indien een verweerschrift is ingediend, uiterlijk binnen twee weken na verzending
+      daarvan door het gerechtshof aan de wederpartij.
+      2. De voorzitter van de kamer die de zaak in behandeling heeft bepaalt dag en uur van de behandeling ter
+      zitting.
+      3. De zitting is openbaar.
+    url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel20a
+  - number: 20b
+    text: |-
+      Indien de zaak op een zitting zal worden behandeld worden de stukken van het geding neergelegd ter griffie van
+      het gerechtshof. Hiervan wordt door de griffier mededeling gedaan aan partijen, onder vermelding van de
+      termijn waarbinnen deze stukken aldaar kunnen worden ingezien en dat daarvan afschriften of uittreksels kunnen
+      worden gevraagd. Op de voor de verstrekking van afschriften of uittreksels in rekening te brengen vergoedingen
+      is het bij of krachtens de Wet griffierechten burgerlijke zaken bepaalde van overeenkomstige toepassing.
+    url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel20b
+  - number: 20c
+    text: |-
+      1. Indien de zaak op een zitting zal worden behandeld worden partijen uitgenodigd ter zitting. De oproep aan
+      degene die hoger beroep heeft ingesteld wordt gericht aan het adres opgegeven in het beroepschrift in hoger
+      beroep dan wel, in geval de officier van justitie hoger beroep heeft ingesteld, aan het door de betrokkene in
+      het verweerschrift of in het beroepschrift bij de rechtbank opgegeven adres.
+      2. Degene aan wie de administratieve sanctie is opgelegd, kan zich ter zitting laten bijstaan of zich door een
+      gemachtigde laten vertegenwoordigen.
+      3. Ter zitting kunnen getuigen of deskundigen worden meegebracht ten einde door het gerechtshof te worden
+      gehoord. Het gerechtshof kan ambtshalve of op verzoek ook andere personen als getuige of deskundige horen.
+      4. Het gerechtshof kan bevelen dat getuigen niet zullen worden gehoord en tolken niet tot de uitoefening van
+      hun taak zullen worden toegelaten dan na het afleggen van de eed of belofte.
+      5. Ze leggen in dat geval ten overstaan van de voorzitter de eed of belofte af;
+      de getuigen: dat zij zullen zeggen de gehele waarheid en niets dan de waarheid;
+      de tolken: dat zij hun plichten als tolk met nauwkeurigheid zullen vervullen.
+      De deskundigen zijn verplicht hun taak onpartijdig en naar beste weten te vervullen.
+      6. Van het verhandelde ter zitting wordt proces-verbaal opgemaakt, hetwelk door de voorzitter en de griffier
+      wordt vastgesteld en ondertekend.
+    url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel20c
+  - number: 20d
+    text: |-
+      1. Indien het gerechtshof het beroepschrift ontvankelijk acht, bevestigt het gerechtshof de beslissing van de
+      kantonrechter, hetzij met overneming, hetzij met verbetering van de gronden, of doet het, met gehele of
+      gedeeltelijke vernietiging van de bestreden beslissing van de kantonrechter, hetgeen de kantonrechter zou
+      behoren te doen.
+      2. Indien de beslissing van de kantonrechter moet worden vernietigd op de in artikel 14, tweede lid, genoemde
+      grond wijst het gerechtshof de zaak terug naar de rechtbank, tenzij door betrokkene de behandeling van het
+      beroep door het gerechtshof zelf is verlangd. In geval van terugwijzing doet de kantonrechter recht met
+      inachtneming van het arrest van het gerechtshof.
+      3. Het arrest van het gerechtshof is met redenen omkleed. Het wordt op een openbare zitting uitgesproken.
+      Indien de zaak ter zitting is behandeld wordt het arrest aangetekend in het proces-verbaal van die zitting en
+      wordt het uiterlijk veertien dagen na de sluiting van het onderzoek ter zitting uitgesproken. Indien de zaak
+      niet ter zitting is behandeld wordt het arrest op een door de voorzitter te bepalen dag uiterlijk zes weken
+      nadat de laatste van de in artikel 19 bedoelde termijnen is verstreken uitgesproken.
+      4. De artikelen 13a en 13b zijn van overeenkomstige toepassing, met uitzondering van de laatste volzin van
+      artikel 13b, eerste lid.
+      5. Een afschrift van het arrest wordt toegezonden aan partijen.
+    url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel20d
+  - number: '21'
+    text: |-
+      1. De verplichting tot zekerheidstelling vervalt nadat ten aanzien van de opgelegde administratieve sanctie
+      een onherroepelijke beslissing is genomen.
+      2. Indien de in het eerste lid bedoelde beslissing inhoudt dat de opgelegde administratieve sanctie geheel of
+      gedeeltelijk blijft gehandhaafd, wordt de verschuldigde administratieve sanctie op de zekerheidstelling
+      verhaald.
+      3. Indien de verschuldigde administratieve sanctie vanwege toepassing van artikel 11, tweede lid, niet geheel
+      op de zekerheidstelling kan worden verhaald, is Hoofdstuk VIII van toepassing op de inning van het bedrag dat
+      nog niet is voldaan.
+    url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel21
+  - number: '22'
+    text: |-
+      1. Met de inning van de administratieve sanctie en de administratiekosten is Onze Minister belast.
+      2. Bij of krachtens algemene maatregel van bestuur worden omtrent de inning voorschriften gegeven. Deze
+      voorschriften hebben in ieder geval betrekking op de plaats en wijze van betaling van de administratieve
+      sanctie, de administratiekosten, de verantwoording van de ontvangen geldbedragen, alsmede op de kosten van
+      verhaal, de invorderingskosten daaronder begrepen.
+      3. Een ieder is verplicht desgevorderd onverwijld aan Onze Minister de inlichtingen te verstrekken welke naar
+      het redelijk oordeel van Onze Minister noodzakelijk zijn ten behoeve van de toepassing van het eerste lid van
+      dit artikel. De artikelen 217 tot en met 218a van het Wetboek van Strafvordering zijn van overeenkomstige
+      toepassing.
+      4. De officier van justitie kan de inning van een opgelegde administratieve sanctie laten eindigen, indien hij
+      van oordeel is dat met de voortzetting daarvan geen redelijk doel wordt gediend.
+    url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel22
+  - number: '23'
+    text: |-
+      1. Uiterlijk binnen twee weken nadat een beschikking waarbij een administratieve sanctie is opgelegd,
+      onherroepelijk is geworden, moeten de administratieve sanctie en de administratiekosten zijn voldaan.
+      2. Indien de administratieve sanctie ten minste € 225 bedraagt, kan Onze Minister uitstel van betaling of
+      betaling in termijnen toestaan. Voor personen die ten tijde van de gedraging nog geen 16 jaar oud waren, kan
+      Onze Minister uitstel van betaling of betaling in termijnen toestaan indien de administratieve sanctie ten
+      minste € 112,50 bedraagt.
+      3. De sanctie wordt van rechtswege met vijftig procent verhoogd indien het in de gestelde termijn of termijnen
+      verschuldigde bedrag niet tijdig geheel wordt voldaan.
+    url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel23
+  - number: '24'
+    text: |-
+      1. Degene aan wie een administratieve sanctie is opgelegd, is verplicht tot betaling van het ingevolge artikel
+      23, derde lid, verhoogde bedrag binnen vier weken nadat Onze Minister hem een aanmaning heeft toegezonden.
+      2. Indien na de verhoging het verschuldigde bedrag behoudens de administratiekosten, ten minste € 225
+      bedraagt, is artikel 23, tweede lid, van overeenkomstige toepassing.
+    url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel24
+  - number: '25'
+    text: |-
+      1. Indien degene aan wie een administratieve sanctie is opgelegd, nalaat het in de op grond van artikel 24
+      gestelde termijn of termijnen verschuldigde bedrag tijdig geheel te voldoen, wordt het inmiddels verschuldigde
+      bedrag van rechtswege verhoogd met honderd procent van het bedrag van de sanctie en de daarop inmiddels
+      gevallen verhoging. Ter inning van het verschuldigde bedrag kan Onze Minister verhaal nemen overeenkomstig het
+      bepaalde in de artikelen 26 en 27.
+      2. Indien het verschuldigde bedrag behoudens de administratiekosten, na de verhogingen op grond van artikel
+      23, derde lid, en van het eerste lid, ten minste € 225 bedraagt, is artikel 23, tweede lid, van
+      overeenkomstige toepassing. Indien betaling in termijnen door Onze Minister is toegestaan, vindt verhaal
+      overeenkomstig het bepaalde in de artikelen 26 en 27 enkel plaats indien degene aan wie een administratieve
+      sanctie is opgelegd nalatig blijft het in de gestelde termijn of termijnen verschuldigde bedrag tijdig geheel
+      te voldoen.
+      3. Onze Minister kan verhaal nemen gedurende drie jaar nadat ten aanzien van de administratieve sanctie een
+      onherroepelijke beslissing is genomen. Indien betaling in termijnen door Onze Minister is toegestaan, wordt de
+      termijn waarin verhaal kan worden genomen verlengd met één jaar.
+      4. Het recht om verhaal te nemen vervalt door het overlijden van degene aan wie een administratieve sanctie is
+      opgelegd.
+    url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel25
+  - number: '26'
+    text: |-
+      1. Verhaal op de goederen van degene aan wie de administratieve sanctie is opgelegd geschiedt krachtens een
+      dwangbevel, medebrengende het recht om die goederen zonder vonnis aan te tasten.
+      2. Het dwangbevel wordt in naam van de Koning uitgevaardigd door Onze Minister. Het wordt ten uitvoer gelegd
+      als een vonnis van de burgerlijke rechter.
+      3. Tegen de tenuitvoerlegging van het dwangbevel kan verzet worden gedaan, hetwelk niet gericht zal kunnen
+      zijn tegen de beslissing waarbij de administratieve sanctie werd opgelegd. Verzet wordt gedaan bij een met
+      redenen omkleed verzetschrift. Het verzetschrift wordt binnen twee weken na de betekening van het dwangbevel
+      ingediend bij de rechtbank van het arrondissement waar het adres is van degene aan wie de administratieve
+      sanctie is opgelegd. Wordt binnen twee weken na de betekening tot inbeslagneming overgegaan, dan wordt het
+      verzetschrift binnen een week na de dag van inbeslagneming ingediend. Bij het verzetschrift worden het
+      dwangbevel en een afschrift van het exploit van betekening van het dwangbevel overgelegd.
+      4. Degene aan wie de administratieve sanctie is opgelegd, is een griffierecht verschuldigd. De griffier wijst
+      de indiener van het verzetschrift op de verschuldigdheid van het griffierecht en deelt hem mee dat het
+      verschuldigde bedrag binnen twee weken na de dag van verzending van zijn mededeling dient te zijn
+      bijgeschreven op de rekening van de rechtbank dan wel ter griffie te zijn gestort. Indien het bedrag niet
+      binnen deze termijn is bijgeschreven of gestort, wordt het verzet niet-ontvankelijk verklaard, tenzij
+      redelijkerwijs niet kan worden geoordeeld dat de indiener in verzuim is geweest.
+      5. Indien de in het derde lid bedoelde stukken niet zijn overgelegd, deelt de griffier de indiener van het
+      verzetschrift mee dat deze stukken binnen twee weken na de dag van verzending van zijn mededeling ter griffie
+      dienen te zijn overgelegd. Indien dit laatste niet binnen deze termijn is geschied, wordt het verzet
+      niet-ontvankelijk verklaard, tenzij redelijkerwijs niet kan worden geoordeeld dat de indiener in verzuim is
+      geweest.
+      6. De griffier brengt het verzetschrift en de daarop betrekking hebbende stukken ter kennis van Onze Minister,
+      ten einde hem in de gelegenheid te stellen daarover de nodige opmerkingen te maken. Onze Minister stelt de
+      betrokken gerechtsdeurwaarder ervan in kennis dat verzet is gedaan. De kantonrechter geeft zo spoedig mogelijk
+      na afloop van deze termijn, na zo nodig degene aan wie de administratieve sanctie is opgelegd te hebben
+      gehoord, althans opgeroepen om te verschijnen, zijn met redenen omklede beschikking, welke onverwijld aan
+      degene die het verzet heeft gedaan en aan Onze Minister wordt medegedeeld. De artikelen 13a en 13b zijn van
+      overeenkomstige toepassing, met uitzondering van artikel 13a, tweede tot en met vierde lid, en de laatste
+      volzin van artikel 13b, eerste lid, en met dien verstande dat hetgeen in die artikelen met betrekking tot de
+      officier van justitie is bepaald, geldt voor Onze Minister.
+      7. Indien de kantonrechter het verzet gegrond oordeelt, houdt de beschikking tevens in dat aan de indiener van
+      het verzetschrift het door hem betaalde griffierecht wordt vergoed door de griffier. In de overige gevallen
+      kan de kantonrechter bepalen dat het betaalde griffierecht wordt vergoed.
+      8. Ten aanzien van derden die bij een inbeslagneming van goederen daarop geheel of gedeeltelijk recht menen te
+      hebben, zijn de bepalingen van het Wetboek van Burgerlijke Rechtsvordering van toepassing.
+      9. De kosten van het verhaal krachtens dit artikel worden op gelijke voet als de administratieve sanctie op
+      degene aan wie deze sanctie is opgelegd verhaald. Onder de kosten van het verhaal zijn begrepen de
+      invorderingskosten.
+    url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel26
+  - number: 26a
+    text: |-
+      1. Onze Minister, alsmede degene aan wie de administratieve sanctie is opgelegd, kunnen tegen de beschikking
+      van de kantonrechter binnen twee weken na de verzending van de mededeling van de beschikking van de
+      kantonrechter hoger beroep instellen bij het gerechtshof Arnhem-Leeuwarden. Het beroepschrift wordt ingediend
+      bij de griffie van de rechtbank die de beschikking heeft gegeven.
+      2. Degene aan wie de administratieve sanctie is opgelegd, is in zijn beroep slechts ontvankelijk na
+      voorafgaande zekerheidstelling van het nog verschuldigde bedrag en van al de kosten. De zekerheid wordt
+      gesteld bij Onze Minister, hetzij op de door Onze Minister voorgeschreven wijze, hetzij anderszins door
+      overboeking op de rekening van Onze Minister. De griffier van de rechtbank wijst de indiener van het
+      beroepschrift op de verplichting tot zekerheidstelling en deelt hem mee dat de zekerheidstelling dient te
+      geschieden binnen twee weken na de dag van verzending van zijn mededeling. Indien de zekerheidstelling niet
+      binnen deze termijn is geschied, wordt het beroep niet-ontvankelijk verklaard, tenzij redelijkerwijs niet kan
+      worden geoordeeld dat de indiener in verzuim is geweest.
+      3. Degene aan wie de administratieve sanctie is opgelegd, is eveneens een griffierecht verschuldigd. De
+      griffier van de rechtbank wijst de indiener van het beroepschrift op de verschuldigdheid van het griffierecht
+      en deelt hem mee dat het verschuldigde bedrag binnen twee weken na de dag van verzending van zijn mededeling
+      dient te zijn bijgeschreven op de rekening van de rechtbank dan wel ter griffie te zijn gestort. Indien het
+      griffierecht niet binnen deze termijn is bijgeschreven of gestort, wordt het beroep niet-ontvankelijk
+      verklaard, tenzij redelijkerwijs niet kan worden geoordeeld dat de indiener in verzuim is geweest.
+      4. Nadat de zekerheidstelling en de bijschrijving of de storting van het griffierecht hebben plaatsgevonden of
+      nadat de termijnen voor het stellen van de zekerheid en de betaling van het griffierecht ongebruikt zijn
+      verstreken, zendt de griffier van de rechtbank het beroepschrift met de daarop betrekking hebbende stukken en
+      een afschrift van de beschikking van de kantonrechter onverwijld ter griffie van het gerechtshof in.
+      5. Op de behandeling van het hoger beroep zijn de artikelen 16 tot en met 20c van overeenkomstige toepassing,
+      met dien verstande dat Onze Minister zich bij de behandeling van het hoger beroep door een gemachtigde laat
+      vertegenwoordigen.
+      6. Het gerechtshof beslist zo spoedig mogelijk. De artikelen 13a en 13b, met uitzondering van artikel 13a,
+      tweede tot en met vierde lid, en de laatste volzin van artikel 13b, eerste lid, en 20d, eerste en derde lid,
+      zijn op de beschikking van overeenkomstige toepassing, met dien verstande dat hetgeen in die artikelen met
+      betrekking tot de officier van justitie is bepaald, geldt voor Onze Minister.
+      7. Afschrift van de beschikking wordt door de griffier van het gerechtshof gezonden aan degenen die tot het
+      instellen van hoger beroep gerechtigd waren.
+    url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel26a
+  - number: '27'
+    text: |-
+      1. Verhaal kan zonder dwangbevel worden genomen op:
+      a. inkomsten in geld uit arbeid van degene aan wie een administratieve sanctie is opgelegd;
+      b. pensioenen, wachtgelden en andere uitkeringen waarop degene aan wie de administratieve sanctie is opgelegd,
+      aanspraak heeft;
+      c. het tegoed van een rekening bij een bank als bedoeld in artikel 1:1 van de Wet op het financieel toezicht,
+      waarover degene aan wie de administratieve sanctie is opgelegd te eigen bate mag beschikken, alsmede, indien
+      de bank en degene aan wie een administratieve sanctie is opgelegd in samenhang met die rekening een
+      overeenkomst inzake krediet zijn aangegaan, op uit het ingevolge die overeenkomst verstrekte krediet.
+      2. Verhaal met toepassing van het eerste lid geschiedt door middel van een schriftelijke kennisgeving van Onze
+      Minister. De kennisgeving bevat een voor de uitoefening van verhaal voldoende aanduiding van degene aan wie de
+      administratieve sanctie is opgelegd, en vermeldt welk bedrag uit hoofde van de beschikking nog verschuldigd
+      is, dan wel bij welke rechterlijke uitspraak de administratieve sanctie is opgelegd, alsmede de plaats waar de
+      betaling moet geschieden. Zij wordt verstrekt aan degene onder wie verhaal wordt genomen, en nadat verhaal is
+      genomen toegezonden aan het adres dat betrokkene heeft opgegeven of, indien dat niet mogelijk is en de
+      gedraging waarvoor de administratieve sanctie is opgelegd heeft plaatsgevonden met of door middel van een
+      motorrijtuig waarvoor een kenteken is opgegeven, aan het adres dat is opgenomen in het kentekenregister.
+      Indien de brief onbestelbaar blijkt te zijn, wordt de kennisgeving gezonden naar het in de basisregistratie
+      personen vermelde adres, tenzij dit hetzelfde is als hetgeen is opgenomen in het kentekenregister. Indien de
+      brief ook op het in de basisregistratie personen opgenomen adres onbestelbaar blijkt te zijn, wordt de
+      kennisgeving geacht aan de betrokkene bekend te zijn.
+      3. Door de verstrekking van de kennisgeving is degene onder wie verhaal wordt genomen, verplicht tot
+      onverwijlde betaling aan Onze Minister van het in de kennisgeving bedoelde bedrag voor zover degene aan wie de
+      administratieve sanctie is opgelegd op hem een opeisbare vordering heeft of verkrijgt. Onze Minister bepaalt
+      de termijn waarbinnen de betaling moet geschieden. De verplichting tot betaling vervalt zodra het uit hoofde
+      van de beschikking verschuldigde bedrag is betaald of verhaald en uiterlijk wanneer twee jaren na de dag van
+      verstrekking van de kennisgeving zijn verstreken.
+      4. Degene onder wie verhaal wordt genomen, kan zich niet tegenover Onze Minister beroepen op het tenietgaan of
+      de vermindering van zijn schuld aan degene aan wie de administratieve sanctie is opgelegd door betaling of
+      door verrekening met een tegenvordering dan in de gevallen waarin hij daartoe ook bevoegd zou zijn geweest bij
+      een op het tijdstip van de betekening overeenkomstig het Wetboek van Burgerlijke Rechtsvordering gelegd beslag
+      onder derden. Indien een andere schuldeiser op de vordering waarop het verhaal wordt genomen, beslag heeft
+      gelegd, is artikel 478 van het Wetboek van overeenkomstige toepassing. Het verhaal wordt voor de toepassing
+      van de artikelen 33 en 301 van de Faillissementswet met een beslag onder derden gelijkgesteld.
+      5. Indien verhaal is genomen op vordering van degene aan wie de administratieve sanctie is opgelegd als
+      bedoeld in het eerste lid, onder a en b, zijn de artikelen 475a tot en met 475g en 475i, tweede tot en met
+      vijfde lid, van het Wetboek van Burgerlijke Rechtsvordering van overeenkomstige toepassing.
+      6. Iedere belanghebbende kan binnen zes weken na de verzending van de in het tweede lid bedoelde kennisgeving
+      bij met redenen omkleed verzetschrift verzet doen tegen het verhaal. Artikel 26, derde tot en met negende lid,
+      en artikel 26a zijn van overeenkomstige toepassing.
+      7. De kosten van het verhaal krachtens dit artikel worden op gelijke voet als de administratieve sanctie op
+      degene aan wie deze sanctie is opgelegd verhaald. Onder de kosten van het verhaal zijn begrepen de
+      invorderingskosten.
+      8. Verhaal zonder dwangbevel kan niet worden genomen als degene aan wie de administratieve sanctie is
+      opgelegd, valt onder de schuldsaneringsregeling natuurlijke personen, bedoeld in Titel III van de
+      Faillissementswet.
+    url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel27
+  - number: 27a
+    text: |-
+      Bij algemene maatregel van bestuur kan worden bepaald dat de staat geldbedragen, verkregen uit de
+      tenuitvoerlegging van administratieve sancties, op een daarbij vast te stellen grondslag en naar daarbij vast
+      te stellen regelen ten goede laat komen aan een rechtspersoon die krachtens het publiekrecht is ingesteld.
+    url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel27a
+  - number: '28'
+    text: |-
+      1. De officier van justitie kan, indien niet of niet volledig verhaal overeenkomstig de artikelen 26 en 27
+      heeft plaatsgevonden, bij de kantonrechter van de rechtbank van het arrondissement waar het adres is van
+      degene aan wie de administratieve sanctie is opgelegd een vordering instellen om te worden gemachtigd om per
+      gedraging waarvoor een administratieve sanctie is opgelegd het dwangmiddel gijzeling toe te passen van degene
+      aan wie de administratieve sanctie is opgelegd, voor ten hoogste één week. Indien degene aan wie de
+      administratieve sanctie is opgelegd als ingezetene is ingeschreven in de basisregistratie personen, maar niet
+      op het daarin opgenomen adres woonachtig is, dan wel indien degene aan wie de administratieve sanctie is
+      opgelegd geen bekende woon- of verblijfplaats in Nederland heeft, geschiedt de instelling van de bovenbedoelde
+      vordering bij de rechtbank Noord-Nederland. Een verleende machtiging om gijzeling toe te passen kan tot
+      uiterlijk vijf jaar nadat de opgelegde administratieve sanctie onherroepelijk is geworden, worden uitgevoerd.
+      Indien betaling in termijnen door Onze Minister is toegestaan, wordt de termijn waarin een verleende
+      machtiging gijzeling toe te passen kan worden uitgevoerd, verlengd met één jaar.
+      2. Op de vordering wordt niet beslist dan nadat degene aan wie de sanctie is opgelegd door de kantonrechter is
+      gehoord, althans behoorlijk is opgeroepen. De oproeping van degene die als ingezetene is ingeschreven op een
+      in de basisregistratie personen opgenomen adres, maar niet op het daarin opgenomen adres woonachtig is, dan
+      wel geen bekende woon- of verblijfplaats in Nederland heeft, geschiedt in de Staatscourant. Tegen de
+      beslissing staat geen rechtsmiddel open.
+      3. De officier van justitie of de ambtenaar die door hem is belast met de toepassing van de gijzeling heeft
+      voor het in gijzeling stellen van de betrokkene toegang tot elke plaats.
+      4. De toepassing van het dwangmiddel wordt gestaakt, zodra het verschuldigde bedrag aan de instantie, belast
+      met deze toepassing, is betaald. De toepassing van het dwangmiddel heft de verschuldigdheid niet op.
+      5. Bij algemene maatregel van bestuur worden regels gesteld omtrent de tenuitvoerlegging van de gijzeling als
+      bedoeld in het eerste lid.
+    url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel28
+  - number: 28a
+    text: |-
+      Indien niet of niet volledig verhaal overeenkomstig de artikelen 26 en 27 heeft plaatsgevonden, kan Onze
+      Minister het rijbewijs innemen van degene aan wie de administratieve sanctie is opgelegd. Onze Minister kan
+      tot uiterlijk vijf jaar nadat de opgelegde administratieve sanctie onherroepelijk is geworden van zijn
+      bevoegdheid gebruik maken. Indien betaling in termijnen door Onze Minister is toegestaan, wordt de termijn
+      waarin van de bevoegdheid gebruik kan worden gemaakt, verlengd met één jaar. De inneming van het rijbewijs
+      duurt ten hoogste vier weken.
+    url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel28a
+  - number: 28b
+    text: |-
+      Indien niet of niet volledig verhaal overeenkomstig de artikelen 26 en 27 heeft plaatsgevonden, kan Onze
+      Minister het voertuig waarmee de gedraging heeft plaatsgevonden buiten gebruik stellen of, indien dit voertuig
+      niet wordt aangetroffen, een soortgelijk voertuig waarover degene aan wie de administratieve sanctie is
+      opgelegd, vermag te beschikken. Onze Minister kan tot uiterlijk vijf jaar nadat de opgelegde administratieve
+      sanctie onherroepelijk is geworden van zijn bevoegdheid gebruik maken. Indien betaling in termijnen door Onze
+      Minister is toegestaan, wordt de termijn waarin van de bevoegdheid gebruik kan worden gemaakt, verlengd met
+      één jaar. De buitengebruikstelling duurt ten hoogste vier weken.
+    url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel28b
+  - number: '29'
+    text: |-
+      1. Indien degene wiens voertuig buiten gebruik kan worden gesteld door Onze Minister niet terstond voldoet aan
+      het overeenkomstig artikel 23, derde lid, en artikel 25 verhoogde bedrag van de administratieve sanctie, is
+      Onze Minister bevoegd het voertuig op kosten van de betrokkene naar een door hem aangewezen plaats te doen
+      overbrengen en in bewaring te doen stellen. Het voertuig wordt tussentijds aan de rechthebbende teruggegeven
+      tegen betaling van het bedrag van de administratieve sanctie en de daarop gevallen verhogingen, alsmede van de
+      kosten van overbrenging en bewaring.
+      2. Onze Minister is tevens bevoegd om in het in het eerste lid bedoelde geval aan het voertuig een mechanisch
+      hulpmiddel te doen aanbrengen, waardoor wordt verhinderd dat het voertuig wordt weggereden. Het mechanisch
+      hulpmiddel wordt tussentijds niet verwijderd dan nadat het bedrag van de administratieve sanctie en de daarop
+      gevallen verhogingen, alsmede de kosten van het aanbrengen en van het verwijderen ervan zijn voldaan.
+      3. Indien twaalf weken na de aanvang van de buitengebruikstelling de rechthebbende zijn voertuig niet heeft
+      afgehaald, wordt hij geacht zijn recht op de zaak te hebben opgegeven en is Onze Minister bevoegd het voertuig
+      om niet aan een derde in eigendom te doen overdragen, te doen verkopen of te doen vernietigen. Gelijke
+      bevoegdheid bestaat ook binnen de bedoelde termijn, zodra het gezamenlijke bedrag van de opgelegde
+      administratieve sanctie, de daarop gevallen verhoging, de kosten van het aanbrengen en het verwijderen,
+      alsmede de kosten van overbrenging en bewaring, vermeerderd met de voor de verkoop, de eigendomsoverdracht om
+      niet of de vernietiging geraamde kosten, in verhouding tot de waarde van het voertuig naar zijn oordeel
+      onevenredig hoog zou worden.
+      4. Bij of krachtens algemene maatregel van bestuur kunnen nadere regels worden gesteld omtrent de
+      overbrenging, bewaring, eigendomsoverdracht om niet, verkoop, vernietiging, de berekening van de kosten van
+      overbrenging en bewaring, alsmede omtrent hetgeen verder voor de uitvoering van dit artikel noodzakelijk is.
+    url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel29
+  - number: '30'
+    text: |-
+      1. Degene wiens rijbewijs kan worden ingenomen door Onze Minister, is verplicht op eerste vordering van Onze
+      Minister het rijbewijs in te leveren op een door Onze Minister te bepalen tijdstip en aan te wijzen plaats.
+      2. De termijn, bedoeld in artikel 28a, vangt aan op het tijdstip waarop de inlevering van het rijbewijs heeft
+      plaatsgevonden.
+      3. Indien aan de verplichting tot inlevering van het rijbewijs niet wordt voldaan, is Onze Minister bevoegd
+      dat rijbewijs op kosten van de in het eerste lid bedoelde persoon te doen inleveren. Afdeling 5.3 van de
+      Algemene wet bestuursrecht is niet van toepassing.
+      4. Onze Minister doet van het tijdstip, bedoeld in het eerste en in het tweede lid, onverwijld mededeling aan
+      de beheerder van het rijbewijzenregister in de zin van de Wegenverkeerswet 1994. Onze Minister doet op gelijke
+      wijze mededeling van het tijdstip waarop het rijbewijs is teruggegeven.
+    url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel30
+  - number: '31'
+    text: |-
+      1. Indien de in artikel 3, eerste lid, bedoelde ambtenaren bij de uitoefening van de in artikel 3, eerste lid,
+      omschreven bevoegdheid bevinden dat de bestuurder geen bekende woon- of verblijfplaats in Nederland heeft, dan
+      wel geregistreerd staat voor het niet voldoen van een hem eerder overeenkomstig de bepalingen van deze wet
+      opgelegde administratieve sanctie, kunnen zij vorderen dat het bedrag van de opgelegde en van de reeds
+      verschuldigde administratieve sanctie en van de administratiekosten terstond geheel zal worden voldaan dan wel
+      dat zekerheid wordt gesteld dat het bedrag van de bedoelde sanctie tijdig geheel zal worden voldaan.
+      2. Indien de in artikel 3, eerste lid, bedoelde ambtenaren hebben vastgesteld dat de gedraging heeft
+      plaatsgevonden met of door middel van een motorrijtuig waarvoor een kenteken is opgegeven, en niet aanstonds
+      is vastgesteld wie daarvan de bestuurder is en waarvan aannemelijk is dat de kentekenhouder geen bekende woon-
+      of verblijfplaats in Nederland heeft, dan wel dat de kentekenhouder geregistreerd staat voor het niet voldoen
+      van een hem eerder overeenkomstig de bepalingen van deze wet opgelegde sanctie, zijn zij bevoegd bij wijze van
+      voorlopige maatregel het voertuig naar een door hen aangewezen plaats te doen overbrengen en in bewaring te
+      stellen, dan wel aan het voertuig een mechanisch hulpmiddel te doen aanbrengen, waardoor wordt verhinderd dat
+      het voertuig wordt weggereden. Zij kunnen vorderen dat, alvorens het voertuig aan de bestuurder wordt
+      teruggegeven, naast de kosten van overbrenging en bewaring, eveneens het bedrag van de opgelegde
+      administratieve sanctie en de administratiekosten en van de eerder overeenkomstig de bepalingen van deze wet
+      opgelegde en inmiddels verschuldigde administratieve sanctie en de administratiekosten zal worden voldaan.
+      3. Voldoening van het bedrag van de opgelegde administratieve sanctie en van de administratiekosten laat de
+      bevoegdheid tegen de beschikking van de ambtenaar beroep in te stellen als omschreven in de artikelen 6 en 9
+      onverlet. Wordt het beroep gegrond verklaard, dan wordt het bedrag van de administratieve sanctie en van de
+      administratiekosten teruggegeven. Artikel 29, derde en vierde lid, is van overeenkomstige toepassing.
+    url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel31
+  - number: '32'
+    text: |-
+      Indien aan de in artikel 31, eerste lid, bedoelde vordering niet wordt voldaan, is de ambtenaar bevoegd bij
+      wijze van voorlopige maatregel het voertuig in bewaring te stellen, totdat het bedrag van de opgelegde en van
+      de reeds verschuldigde administratieve sanctie en van de administratiekosten, alsmede de inmiddels daarop
+      gevallen kosten van de inbewaringstelling zijn voldaan. Daartoe kan hij op kosten van de bestuurder het
+      voertuig naar een door hem aangewezen nabijgelegen plaats overbrengen of doen overbrengen en aldaar in
+      bewaring doen stellen. Zo nodig roept hij hierbij de hulp van de sterke arm in. Artikel 29, derde en vierde
+      lid, is van overeenkomstige toepassing.
+    url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel32
+  - number: '33'
+    text: |-
+      1. Van iedere inbewaringstelling maakt de betrokken ambtenaar proces-verbaal op. Hij zendt dit proces-verbaal
+      binnen vierentwintig uur aan de officier van justitie in het arrondissement waar de inbewaringstelling is
+      geschied. Een afschrift van het proces-verbaal wordt gelijktijdig uitgereikt of toegezonden aan de bestuurder,
+      alsmede aan degene aan wie het kenteken van het motorrijtuig is opgegeven. Daarbij wordt hij gewezen op het
+      bepaalde in artikel 29, derde lid.
+      2. Tegen een inbewaringstelling kan elke belanghebbende beroep instellen bij de rechtbank op grond dat
+      a. de inbewaringstelling met een algemeen verbindend voorschrift strijdt;
+      b. de ambtenaar van zijn in artikel 32 omschreven bevoegdheid op een kennelijk onredelijke wijze heeft gebruik
+      gemaakt.
+      3. Het beroepschrift wordt ingediend bij de officier van justitie in het arrondissement waar de
+      inbewaringstelling is geschied. De officier van justitie brengt het beroepschrift en de op de zaak betrekking
+      hebbende stukken ter kennis van de rechtbank van het arrondissement waar de inbewaringstelling is geschied.
+      4. Het beroepschrift en de op de zaak betrekking hebbende stukken worden door de officier van justitie aan de
+      rechtbank ter kennis gebracht binnen vier dagen nadat de indiener zekerheid heeft gesteld voor de betaling van
+      de sanctie, dan wel nadat de termijn daarvoor is verstreken.
+      5. De kantonrechter beslist zo spoedig mogelijk, doch uiterlijk binnen vier weken na de dag waarop het
+      beroepschrift bij de officier van justitie is ingediend. Ten aanzien van de behandeling van het beroepschrift
+      en de uitspraak zijn de artikelen 11, derde, vierde lid en vijfde lid, 12, 13, 13a, met uitzondering van het
+      tweede tot en met vierde lid, en 13b van overeenkomstige toepassing.
+      6. Indien de kantonrechter het beroepschrift gegrond acht, gelast hij de onmiddellijke teruggave van het
+      voertuig.
+      7. Het instellen van beroep schorst de bevoegdheid van de officier van justitie, bedoeld in artikel 29, derde
+      lid, tot de dag na die waarop de kantonrechter zijn beslissing heeft gegeven.
+    url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel33
+  - number: '34'
+    text: |-
+      1. Met geldboete van de tweede categorie wordt gestraft:
+      a. hij die niet voldoet aan vordering van een krachtens artikel 3, eerste lid, aangewezen toezichthouder;
+      b. hij die de gegevens waarop de in het eerste lid bedoelde vordering betrekking heeft, onjuist opgeeft;
+      c. hij die niet voldoet aan de in artikel 30 omschreven verplichting.
+      2. Het strafbare feit is een overtreding.
+    url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel34
+  - number: '35'
+    text: |-
+      Bij algemene maatregel van bestuur kunnen voorschriften worden gegeven omtrent hetgeen verder ter uitvoering
+      van deze wet nodig is.
+    url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel35
+  - number: '36'
+    text: |-
+      1. Behoudens in geval van een verzetschrift als bedoeld in artikel 26, derde lid, een beroepschrift bedoeld in
+      artikel 26a en een verzetschrift als bedoeld in artikel 27, zesde lid, is op grond van deze wet geen recht
+      verschuldigd in de zin van de Wet griffierechten burgerlijke zaken.
+      2. Indien het verzetschrift wordt ingetrokken omdat Onze Minister geheel of gedeeltelijk aan de indiener van
+      het verzetschrift is tegemoetgekomen, wordt het door de indiener betaalde griffierecht aan hem vergoed door
+      Onze Minister. In de overige gevallen kan Onze Minister, indien het verzet wordt ingetrokken, het betaalde
+      griffierecht geheel of gedeeltelijk vergoeden.
+    url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel36
+  - number: '44'
+    text: |-
+      Deze wet kan worden aangehaald als: Wet administratiefrechtelijke handhaving verkeersvoorschriften.
+    url: https://wetten.overheid.nl/BWBR0004581/2026-01-01#Artikel44

--- a/corpus/regulation/nl/wet/wetboek_van_burgerlijke_rechtsvordering/2026-01-01.yaml
+++ b/corpus/regulation/nl/wet/wetboek_van_burgerlijke_rechtsvordering/2026-01-01.yaml
@@ -53,6 +53,23 @@ articles:
       tweede of derde lid, een executoriaal beslag heeft gelegd dat is vernietigd, heeft niettemin bevrijdend
       betaald.
     url: https://wetten.overheid.nl/BWBR0001827/2026-01-01#Artikel475c
+    machine_readable:
+      execution:
+        parameters:
+          - name: beslag_datum
+            type: date
+            required: true
+            description: Datum waarop het beslag is gelegd
+        output:
+          - name: vernietigingstermijn_einddatum
+            type: date
+            description: Een beslag in strijd met lid 2 of 3 kan binnen drie jaar worden vernietigd (lid 6)
+        actions:
+          - output: vernietigingstermijn_einddatum
+            value:
+              operation: DATE_ADD
+              date: $beslag_datum
+              years: 3
   - number: 475d
     text: |-
       1. Voor de vaststelling van de beslagvrije voet wordt gebruik gemaakt van het belastbaar inkomen van de
@@ -85,6 +102,23 @@ articles:
       7. Het tweede en derde lid zijn niet van toepassing bij opgave van de beslagvrije voet op de wijze, bedoeld in
       artikel 475dc, tweede lid.
     url: https://wetten.overheid.nl/BWBR0001827/2026-01-01#Artikel475d
+    machine_readable:
+      execution:
+        parameters:
+          - name: vaststelling_datum
+            type: date
+            required: true
+            description: Datum waarop de beslagvrije voet is vastgesteld
+        output:
+          - name: beslagvrije_voet_geldig_tot
+            type: date
+            description: De vaststelling van de beslagvrije voet geldt voor de duur van twaalf maanden (lid 2)
+        actions:
+          - output: beslagvrije_voet_geldig_tot
+            value:
+              operation: DATE_ADD
+              date: $vaststelling_datum
+              months: 12
   - number: 475da
     text: |-
       1. De beslagvrije voet bedraagt ten hoogste:
@@ -163,6 +197,270 @@ articles:
       eerste lid, onderdeel a, van die wet. De gewijzigde bedragen worden door of namens Onze Minister van Sociale
       Zaken en Werkgelegenheid medegedeeld in de Staatscourant.
     url: https://wetten.overheid.nl/BWBR0001827/2026-01-01#Artikel475da
+    machine_readable:
+      definitions:
+        max_alleenstaande:
+          value: 219142
+          description: Beslagvrije voet ten hoogste EUR 2.191,42 voor een alleenstaande (lid 1a)
+        max_alleenstaande_ouder:
+          value: 252669
+          description: Beslagvrije voet ten hoogste EUR 2.526,69 voor een alleenstaande ouder (lid 1b)
+        max_gehuwden_zonder_kinderen:
+          value: 288141
+          description: Beslagvrije voet ten hoogste EUR 2.881,41 voor gehuwden zonder kinderen (lid 1c)
+        max_gehuwden_met_kinderen:
+          value: 315531
+          description: Beslagvrije voet ten hoogste EUR 3.155,31 voor gehuwden met kinderen (lid 1d)
+        percentage_norm:
+          value: 0.95
+          description: De beslagvrije voet bevat 95 procent van de toepasselijke norm (lid 2)
+        percentage_geen_nl_adres:
+          value: 0.475
+          description: Zonder woonadres in Nederland bedraagt de beslagvrije voet 47,5 procent (lid 4)
+      execution:
+        parameters:
+          - name: leefsituatie
+            type: string
+            required: true
+            description: ALLEENSTAANDE, ALLEENSTAANDE_OUDER, GEHUWD_ZONDER_KINDEREN of GEHUWD_MET_KINDEREN
+          - name: norm_alleenstaande_pw
+            type: number
+            required: true
+            description: A — de norm genoemd in artikel 21 onderdeel a Participatiewet, in eurocent
+          - name: norm_gehuwden_pw
+            type: number
+            required: true
+            description: B — de norm genoemd in artikel 21 onderdeel b Participatiewet, in eurocent
+          - name: jaarinkomen
+            type: number
+            required: true
+            description: C — het tot een jaarinkomen herleide belastbaar inkomen (artikel 475d lid 1), in eurocent
+          - name: drempelbedrag_zorgtoeslag
+            type: number
+            required: true
+            description: Drempelbedrag artikel 1 lid 1 onderdeel f Wet op de zorgtoeslag, in eurocent
+          - name: percentage_zorgtoeslag
+            type: number
+            required: true
+            description: E — percentage artikel 2 lid 3 Wet op de zorgtoeslag
+          - name: afbouwpercentage_eenpersoons
+            type: number
+            required: true
+            description: F — afbouwpercentage eenpersoonshuishouden artikel 21 lid 2a Wet op de huurtoeslag
+          - name: afbouwpercentage_meerpersoons
+            type: number
+            required: true
+            description: G — afbouwpercentage meerpersoonshuishouden artikel 21 lid 2b Wet op de huurtoeslag
+          - name: maximale_rekenhuur
+            type: number
+            required: true
+            description: H — maximale rekenhuur artikel 13 lid 1a Wet op de huurtoeslag, in eurocent
+          - name: inkomen_boven_ijkpunt
+            type: number
+            required: true
+            description: I — belastbaar inkomen C verminderd met het minimum-inkomensijkpunt, in eurocent
+          - name: basishuur
+            type: number
+            required: true
+            description: J — de basishuur bedoeld in artikel 16 Wet op de huurtoeslag, in eurocent
+          - name: percentage_kindgebonden_budget
+            type: number
+            required: true
+            description: K — percentage artikel 2 lid 7 Wet op het kindgebonden budget
+          - name: verhoging_drempelinkomen_kgb
+            type: number
+            required: true
+            description: L — verhoging drempelinkomen artikel 2 lid 8 Wet op het kindgebonden budget, in eurocent
+          - name: maximum_zorgtoeslagcomponent
+            type: number
+            required: true
+            description: Bovengrens van de zorgtoeslagcomponent (lid 3), in eurocent
+        output:
+          - name: maximum_beslagvrije_voet
+            type: amount
+            type_spec:
+              unit: eurocent
+            description: De ten hoogste geldende beslagvrije voet bij de leefsituatie (lid 1)
+          - name: norm
+            type: amount
+            type_spec:
+              unit: eurocent
+            description: De toepasselijke Participatiewet-norm A of B (lid 2)
+          - name: drempelbedrag
+            type: amount
+            type_spec:
+              unit: eurocent
+            description: D — het drempelbedrag, of C indien C lager is (lid 2)
+          - name: zorgtoeslagcomponent
+            type: amount
+            type_spec:
+              unit: eurocent
+            description: De component ((C - D) / 12) x E, begrensd op grond van lid 3
+          - name: huurtoeslagcomponent
+            type: amount
+            type_spec:
+              unit: eurocent
+            description: De component I x (F of G / 12), of H - J als dat minder is (lid 2)
+          - name: kindgebondenbudgetcomponent
+            type: amount
+            type_spec:
+              unit: eurocent
+            description: De kindcomponent ((C - D) / 12) x K voor leefsituaties met kinderen (lid 2)
+          - name: beslagvrije_voet
+            type: amount
+            type_spec:
+              unit: eurocent
+            description: De beslagvrije voet volgens lid 2, met inachtneming van het maximum uit lid 1
+          - name: beslagvrije_voet_geen_nl_adres
+            type: amount
+            type_spec:
+              unit: eurocent
+            description: De beslagvrije voet zonder woonadres in Nederland (lid 4)
+        actions:
+          # Lid 1: het bij de leefsituatie horende maximum.
+          - output: maximum_beslagvrije_voet
+            value:
+              operation: IF
+              cases:
+                - when:
+                    operation: EQUALS
+                    subject: $leefsituatie
+                    value: ALLEENSTAANDE
+                  then: $max_alleenstaande
+                - when:
+                    operation: EQUALS
+                    subject: $leefsituatie
+                    value: ALLEENSTAANDE_OUDER
+                  then: $max_alleenstaande_ouder
+                - when:
+                    operation: EQUALS
+                    subject: $leefsituatie
+                    value: GEHUWD_ZONDER_KINDEREN
+                  then: $max_gehuwden_zonder_kinderen
+              default: $max_gehuwden_met_kinderen
+          # Lid 2: A voor alleenstaanden, B voor gehuwden.
+          - output: norm
+            value:
+              operation: IF
+              cases:
+                - when:
+                    operation: IN
+                    subject: $leefsituatie
+                    values:
+                      - ALLEENSTAANDE
+                      - ALLEENSTAANDE_OUDER
+                  then: $norm_alleenstaande_pw
+              default: $norm_gehuwden_pw
+          # Lid 2: D is het drempelbedrag, of C indien C lager is dan dat bedrag.
+          - output: drempelbedrag
+            value:
+              operation: MIN
+              values:
+                - $drempelbedrag_zorgtoeslag
+                - $jaarinkomen
+          # Lid 2 en 3: ((C - D) / 12) x E, ten hoogste de zorgtoeslagcomponent uit lid 3.
+          - output: zorgtoeslagcomponent
+            value:
+              operation: MIN
+              values:
+                - operation: MULTIPLY
+                  values:
+                    - operation: DIVIDE
+                      values:
+                        - operation: SUBTRACT
+                          values:
+                            - $jaarinkomen
+                            - $drempelbedrag
+                        - 12
+                    - $percentage_zorgtoeslag
+                - $maximum_zorgtoeslagcomponent
+          # Lid 2: I x (F / 12) voor een alleenstaande, anders I x (G / 12);
+          # of, als dat minder is, H - J.
+          - output: huurtoeslagcomponent
+            value:
+              operation: MIN
+              values:
+                - operation: MULTIPLY
+                  values:
+                    - $inkomen_boven_ijkpunt
+                    - operation: DIVIDE
+                      values:
+                        - operation: IF
+                          cases:
+                            - when:
+                                operation: EQUALS
+                                subject: $leefsituatie
+                                value: ALLEENSTAANDE
+                              then: $afbouwpercentage_eenpersoons
+                          default: $afbouwpercentage_meerpersoons
+                        - 12
+                - operation: SUBTRACT
+                  values:
+                    - $maximale_rekenhuur
+                    - $basishuur
+          # Lid 2: ((C - D) / 12) x K voor de alleenstaande ouder;
+          # ((C - (D + L)) / 12) x K voor gehuwden met kinderen; anders nihil.
+          - output: kindgebondenbudgetcomponent
+            value:
+              operation: IF
+              cases:
+                - when:
+                    operation: EQUALS
+                    subject: $leefsituatie
+                    value: ALLEENSTAANDE_OUDER
+                  then:
+                    operation: MULTIPLY
+                    values:
+                      - operation: DIVIDE
+                        values:
+                          - operation: SUBTRACT
+                            values:
+                              - $jaarinkomen
+                              - $drempelbedrag
+                          - 12
+                      - $percentage_kindgebonden_budget
+                - when:
+                    operation: EQUALS
+                    subject: $leefsituatie
+                    value: GEHUWD_MET_KINDEREN
+                  then:
+                    operation: MULTIPLY
+                    values:
+                      - operation: DIVIDE
+                        values:
+                          - operation: SUBTRACT
+                            values:
+                              - $jaarinkomen
+                              - operation: ADD
+                                values:
+                                  - $drempelbedrag
+                                  - $verhoging_drempelinkomen_kgb
+                          - 12
+                      - $percentage_kindgebonden_budget
+              default: 0
+          # Lid 2 met inachtneming van lid 1: de som van de componenten, ten hoogste
+          # het bij de leefsituatie horende maximum.
+          - output: beslagvrije_voet
+            value:
+              operation: MIN
+              values:
+                - operation: ADD
+                  values:
+                    - operation: MULTIPLY
+                      values:
+                        - $percentage_norm
+                        - $norm
+                    - $zorgtoeslagcomponent
+                    - $huurtoeslagcomponent
+                    - $kindgebondenbudgetcomponent
+                - $maximum_beslagvrije_voet
+          # Lid 4: zonder woonadres in Nederland 47,5% van de norm voor gehuwden.
+          - output: beslagvrije_voet_geen_nl_adres
+            value:
+              operation: MULTIPLY
+              values:
+                - $percentage_geen_nl_adres
+                - $norm_gehuwden_pw
   - number: 475db
     text: |-
       1. De beslagvrije voet, bedoeld in de artikelen 475da en 475e, tweede lid, wordt in de onderstaande volgorde
@@ -197,6 +495,39 @@ articles:
       geëxecuteerde geldende bijstandsnorm inclusief vakantiebijslag, verminderd met het inkomen, bedoeld in artikel
       32 van de Participatiewet.
     url: https://wetten.overheid.nl/BWBR0001827/2026-01-01#Artikel475dc
+    machine_readable:
+      definitions:
+        percentage_inkomen:
+          value: 0.95
+          description: De beslagvrije voet bedraagt ten hoogste 95 procent van het maandinkomen (lid 1)
+      execution:
+        parameters:
+          - name: beslagvrije_voet_475da_475db
+            type: number
+            required: true
+            description: De op grond van de artikelen 475da en 475db berekende beslagvrije voet, in eurocent
+          - name: maandinkomen
+            type: number
+            required: true
+            description: Het maandelijkse inkomen inclusief vakantiebijslag uit de vorderingen 475c lid 1 a-i
+        output:
+          - name: beslagvrije_voet_begrensd_op_inkomen
+            type: amount
+            type_spec:
+              unit: eurocent
+            description: De beslagvrije voet, ten hoogste 95 procent van het maandinkomen (lid 1)
+        actions:
+          # Lid 1: leidt toepassing van 475da en 475db tot een beslagvrije voet
+          # hoger dan 95% van het maandinkomen, dan geldt 95% van het maandinkomen.
+          - output: beslagvrije_voet_begrensd_op_inkomen
+            value:
+              operation: MIN
+              values:
+                - $beslagvrije_voet_475da_475db
+                - operation: MULTIPLY
+                  values:
+                    - $percentage_inkomen
+                    - $maandinkomen
   - number: 475e
     text: |-
       1. Indien de geëxecuteerde over een niet in de basisregistratie personen opgenomen vaste woon- of
@@ -208,6 +539,43 @@ articles:
       a. twee derde van de bijstandsnorm, genoemd in artikel 23, eerste lid, van de Participatiewet;
       b. het bedrag, genoemd in artikel 23, tweede lid, van de Participatiewet.
     url: https://wetten.overheid.nl/BWBR0001827/2026-01-01#Artikel475e
+    machine_readable:
+      execution:
+        parameters:
+          - name: verzorgingsprijs
+            type: number
+            required: true
+            description: De prijs verschuldigd voor verzorging of verpleging in de inrichting, in eurocent
+          - name: bijstandsnorm_artikel_23_lid_1
+            type: number
+            required: true
+            description: De bijstandsnorm genoemd in artikel 23 lid 1 Participatiewet, in eurocent
+          - name: bedrag_artikel_23_lid_2
+            type: number
+            required: true
+            description: Het bedrag genoemd in artikel 23 lid 2 Participatiewet, in eurocent
+        output:
+          - name: beslagvrije_voet_inrichting
+            type: amount
+            type_spec:
+              unit: eurocent
+            description: De beslagvrije voet bij opname ter verzorging of verpleging (lid 2)
+        actions:
+          # Lid 2: de verzorgingsprijs verhoogd met twee derde van de bijstandsnorm
+          # (artikel 23 lid 1 Participatiewet) en het bedrag uit artikel 23 lid 2.
+          - output: beslagvrije_voet_inrichting
+            value:
+              operation: ADD
+              values:
+                - $verzorgingsprijs
+                - operation: DIVIDE
+                  values:
+                    - operation: MULTIPLY
+                      values:
+                        - $bijstandsnorm_artikel_23_lid_1
+                        - 2
+                    - 3
+                - $bedrag_artikel_23_lid_2
   - number: 475fa
     text: |-
       Indien de toepassing van de artikelen 475da tot en met 475e leidt tot een kennelijk onevenredige hardheid als

--- a/corpus/regulation/nl/wet/wetboek_van_burgerlijke_rechtsvordering/2026-01-01.yaml
+++ b/corpus/regulation/nl/wet/wetboek_van_burgerlijke_rechtsvordering/2026-01-01.yaml
@@ -1,0 +1,217 @@
+---
+$schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/heads/main/schema/v0.5.0/schema.json
+$id: wetboek_van_burgerlijke_rechtsvordering
+regulatory_layer: WET
+publication_date: '2026-01-01'
+valid_from: '2026-01-01'
+name: Wetboek van Burgerlijke Rechtsvordering
+bwb_id: BWBR0001827
+url: https://wetten.overheid.nl/BWBR0001827/2026-01-01
+
+articles:
+  - number: 475c
+    text: |-
+      1. Een beslagvrije voet is verbonden aan vorderingen tot periodieke betaling van:
+      a. uitkeringen op grond van de Participatiewet;
+      b. uitkeringen op grond van overige sociale zekerheidswetten, uitgezonderd kinderbijslag onder welke benaming
+      ook;
+      c. uitkeringen of buitengewone pensioenen op grond van een wettelijke regeling voor oorlogsgetroffenen;
+      d. de bedragen – onder de naam bezoldiging of welke benaming ook – waarop een ambtenaar als bedoeld in artikel
+      3 van de Ambtenarenwet 2017 als zodanig uit hoofde van zijn dienstbetrekking aanspraak heeft alsmede de
+      bedragen – onder de benaming pensioen, wachtgeld, uitkering of welke benaming ook – waarop een gewezen
+      ambtenaar als zodanig uit hoofde van zijn vroegere dienstbetrekking aanspraak heeft of waarop zijn nagelaten
+      betrekkingen uit hoofde van zijn overlijden aanspraak hebben;
+      e. loon;
+      f. uitkeringen uit levens-, invaliditeits-, ongevallen- of ziekengeldverzekering;
+      g. pensioen en lijfrente, waaronder mede worden verstaan uitkeringen ten laste van een lijfrenterekening of
+      ten laste van de waarde van een lijfrentebeleggingsrecht als bedoeld in artikel 3.126a, vierde en zesde lid,
+      van de Wet inkomstenbelasting 2001;
+      h. inkomstenbelasting begrepen in een voorlopige teruggaaf als bedoeld in artikel 13, tweede lid, van de
+      Algemene wet inzake rijksbelastingen;
+      i. uitkeringen tot levensonderhoud, verschuldigd krachtens Boek 1 van het Burgerlijk Wetboek, of tot
+      vergoeding van schade door het derven van levensonderhoud;
+      j. een tegemoetkoming als bedoeld in artikel 2, eerste lid, onderdeel h, van de Algemene wet
+      inkomensafhankelijke regelingen, met uitzondering van de kinderopvangtoeslag, bedoeld in artikel 1.5 van de
+      Wet kinderopvang en kwaliteitseisen peuterspeelzalen.
+      2. De beslaglegger legt beslag op de vorderingen tot periodieke betaling, bedoeld in het eerste lid, in de
+      volgorde van de onderdelen in dit lid. Indien sprake is van meerdere vorderingen tot periodieke betaling
+      binnen een onderdeel gaat de hoogste vordering voor.
+      3. In afwijking van het tweede lid kan de beslaglegger beslag leggen op een vordering tot periodieke betaling
+      die later is opgenomen in de volgorde van de onderdelen in het eerste lid, indien hij ter invordering van zijn
+      vordering tot aan de vastgestelde beslagvrije voet bij deze periodieke betaling kan volstaan met een beslag
+      onder één derde en hij bij toepassing van het tweede lid genoodzaakt is onder meerdere derden beslag te
+      leggen.
+      4. Indien reeds beslag ligt op een andere vordering tot periodieke betaling houdt de beslaglegger die het
+      latere beslag legt bij de vaststelling van de hoogte van de beslagvrije voet rekening met dit beslag.
+      5. Bij meerdere beslagen op vorderingen tot periodieke betaling als bedoeld in het eerste lid, onderdelen a
+      tot en met i, wordt de beslagvrije voet omgeslagen in verhouding tot de hoogte van deze betalingen voor zover
+      toepassing van het tweede of derde lid ertoe leidt dat een opvolgend beslaglegger beslag legt op een andere
+      vordering dan de vordering waarop reeds beslag is gelegd.
+      6. Een beslag dat in strijd met het tweede of derde lid wordt gelegd, kan binnen drie jaar na het leggen van
+      het beslag worden vernietigd door de geëxecuteerde of door een andere beslaglegger.
+      7. Een derde-beslagene die een betaling heeft gedaan aan een deurwaarder die in strijd met artikel 475c,
+      tweede of derde lid, een executoriaal beslag heeft gelegd dat is vernietigd, heeft niettemin bevrijdend
+      betaald.
+    url: https://wetten.overheid.nl/BWBR0001827/2026-01-01#Artikel475c
+  - number: 475d
+    text: |-
+      1. Voor de vaststelling van de beslagvrije voet wordt gebruik gemaakt van het belastbaar inkomen van de
+      schuldenaar en, indien de schuldenaar gehuwd is, de echtgenoot. De hoogte van het belastbaar inkomen wordt
+      berekend op basis van het meest recente maandinkomen zoals dat blijkt uit de polisadministratie, tenzij dit
+      maandinkomen geen reële afspiegeling vormt van het belastbaar inkomen omdat het maandinkomen fluctueert of er
+      sprake is van een incidentele betaling. Of het meest recente maandinkomen een reële afspiegeling van het
+      belastbaar inkomen vormt, wordt beoordeeld aan de hand van in de polisadministratie opgenomen gegevens over de
+      vier meest recente maanden gerekend vanaf het moment van verstrekking, bedoeld in artikel 475ga, eerste lid.
+      Bij of krachtens algemene maatregel van bestuur worden regels gesteld over de wijze waarop in het geval dat
+      het meest recente maandinkomen geen reële afspiegeling van het belastbaar inkomen vormt, het belastbaar
+      inkomen wordt berekend.
+      2. De vaststelling van de beslagvrije voet geldt voor de duur van twaalf maanden. Bij algemene maatregel van
+      bestuur kan voor bepaalde categorieën periodieke betalingen een kortere termijn worden bepaald.
+      3. De deurwaarder of, in geval van samenloop van beslagen als bedoeld in artikel 478 de coördinerende
+      deurwaarder, stelt de beslagvrije voet opnieuw vast, indien:
+      a. de termijn, bedoeld in het tweede lid, verstrijkt;
+      b. hij met redenen omkleed wordt geïnformeerd over een structurele wijziging van omstandigheden die van belang
+      is voor de vaststelling van de beslagvrije voet.
+      4. De deurwaarder of, in geval van samenloop van beslagen als bedoeld in artikel 478 de coördinerende
+      deurwaarder, is bevoegd de beslagvrije voet opnieuw vast te stellen indien hij op andere wijze dan bedoeld in
+      het derde lid, onderdeel b, bekend raakt met feiten of omstandigheden die van invloed kunnen zijn op de hoogte
+      van de beslagvrije voet.
+      5. Indien toepassing van het derde of vierde lid leidt tot een verhoging van de beslagvrije voet, past de
+      deurwaarder of, in geval van samenloop van beslagen als bedoeld in artikel 478 de coördinerende deurwaarder,
+      deze verhoging onverwijld toe vanaf het moment dat de verplichting tot het opnieuw vaststellen van de
+      beslagvrije voet is ontstaan, onderscheidenlijk vanaf het moment dat hij bekend is geraakt met de feiten of
+      omstandigheden die van invloed zijn op de hoogte van de beslagvrije voet.
+      6. De beslagvrije voet wordt vastgesteld op basis van maandbedragen.
+      7. Het tweede en derde lid zijn niet van toepassing bij opgave van de beslagvrije voet op de wijze, bedoeld in
+      artikel 475dc, tweede lid.
+    url: https://wetten.overheid.nl/BWBR0001827/2026-01-01#Artikel475d
+  - number: 475da
+    text: |-
+      1. De beslagvrije voet bedraagt ten hoogste:
+      a. voor een alleenstaande: € 2.191,42;
+      b. voor een alleenstaande ouder: € 2.526,69;
+      c. voor gehuwden zonder kinderen: € 2.881,41;
+      d. voor gehuwden met een of meer kinderen: € 3.155,31.
+      2. Met inachtneming van het eerste lid bedraagt de beslagvrije voet:
+      a. voor een alleenstaande (95% x A) + (((C - D) / 12) x E) + (I x (F / 12), of, als dat minder is, H-J);
+      b. voor een alleenstaande ouder: (95% x A) + (((C - D) / 12) x E) + (I x (G / 12), of, als dat minder is, H-J)
+      + (((C - D) / 12) x K);
+      c. voor gehuwden zonder kinderen: (95% x B) + (((C - D) / 12) x E) + (I x (G / 12), of, als dat minder is,
+      H-J);
+      d. voor gehuwden met een of meer kinderen: (95% x B) + (((C - D) / 12) x E) + (I x (G / 12), of, als dat
+      minder is, H-J) + (((C - (D + L)) / 12) x K).
+      Hierbij staat
+      • A voor de norm, genoemd in artikel 21, onderdeel a, van de Participatiewet;
+      • B voor de norm, genoemd in artikel 21, onderdeel b, van de Participatiewet;
+      • C voor het tot een jaarinkomen herleide belastbaar inkomen zoals dit is vastgesteld op basis van artikel
+      475d, eerste lid, van de geëxecuteerde, en, indien van toepassing, zijn echtgenoot;
+      • D voor het drempelbedrag, bedoeld in artikel 1, eerste lid, onderdeel f, van de Wet op de zorgtoeslag, of
+      voor C, indien C lager is dan dit drempelbedrag;
+      • E voor het percentage van het toetsingsinkomen waarmee het drempelinkomen wordt vermeerderd, bedoeld in
+      artikel 2, derde lid, van de Wet op de zorgtoeslag;
+      • F voor het afbouwpercentage voor een eenpersoonshuishouden, bedoeld in artikel 21, tweede lid, onderdeel a,
+      van de Wet op de huurtoeslag;
+      • G voor het afbouwpercentage voor een meerpersoonshuishouden, bedoeld in artikel 21, tweede lid, onderdeel b,
+      van de Wet op de huurtoeslag;
+      • H voor de maximale rekenhuur, bedoeld in artikel 13, eerste lid, onderdeel a, van de Wet op de huurtoeslag;
+      • I voor het belastbaar inkomen C verminderd met het minimum-inkomensijkpunt, bedoeld in artikel 17, eerste
+      lid, van de Wet op de huurtoeslag;
+      • J voor de basishuur, bedoeld in artikel 16 van de Wet op de huurtoeslag;
+      • K voor het percentage, bedoeld in artikel 2, zevende lid, van de Wet op het kindgebonden budget;
+      • L voor het bedrag waarmee het drempelinkomen van de ouder en diens partner op basis van artikel 2, achtste
+      lid, van de Wet op het kindgebonden budget wordt verhoogd.
+      3. De uitkomst van het onderdeel (C – D) / 12) x E) in het tweede lid bedraagt ten hoogste een bedrag gelijk
+      aan de standaardpremie, bedoeld in artikel 2, eerste lid, van de Wet op de zorgtoeslag herleid naar een
+      maandbedrag onder aftrek van het bij de desbetreffende leefsituatie horende bedrag genoemd in artikel 23,
+      tweede lid, van de Participatiewet.
+      4. Indien de geëxecuteerde op grond van de basisregistratie personen geen woonadres in Nederland heeft,
+      bedraagt de beslagvrije voet 47,5% van de norm, genoemd in artikel 21, onderdeel b, van de Participatiewet.
+      Indien de geëxecuteerde buiten Nederland een vaste woon- of verblijfplaats heeft, wordt de beslagvrije voet
+      vermenigvuldigd met een bij of krachtens algemene maatregel van bestuur vastgestelde factor.
+      5. Indien de geëxecuteerde woonkosten heeft die ten minste 10% meer bedragen dan de in artikel 13, eerste lid,
+      onderdeel a, van de Wet op de huurtoeslag opgenomen rekenhuur, wordt de beslagvrije voet op verzoek van de
+      geëxecuteerde voor de duur dat de geëxecuteerde deze woonkosten heeft, doch ten hoogste gedurende een bij
+      ministeriële regeling van Onze Minister van Sociale Zaken en Werkgelegenheid te bepalen termijn, verhoogd met
+      het bedrag waarmee de woonkosten de eerder genoemde rekenhuur vermeerderd met 10% ophoging overstijgen. Indien
+      de geëxecuteerde gehuwd is, wordt dit verzoek gehonoreerd, voor zover de niet onder beslag liggende inkomsten
+      van de echtgenoot onvoldoende zijn om de hogere woonkosten te betalen.
+      6. Op verzoek van de geëxecuteerde kan de op grond van het vijfde lid verhoogde beslagvrije voet voor ten
+      hoogste zes maanden worden verlengd, indien binnen die termijn de vordering waarvoor het beslag is gelegd
+      volledig kan worden voldaan.
+      7. Indien de geëxecuteerde eigenaar is van een door hemzelf bewoonde woning of huurder van een door hemzelf
+      bewoonde woning die niet voldoet aan artikel 11 van de Wet op de huurtoeslag en hij een belastbaar inkomen
+      heeft dat lager is dan € 55.682,78, indien de geëxecuteerde alleenstaand is, of € 71.089,09, indien de
+      geëxecuteerde een meerpersoonshuishouden heeft, wordt de beslagvrije voet op verzoek van de geëxecuteerde
+      verhoogd met een bedrag waarvan de wijze van vaststelling bij of krachtens algemene maatregel van bestuur
+      wordt vastgesteld. Indien de geëxecuteerde gehuwd is, wordt onder belastbaar inkomen als bedoeld in de vorige
+      zin tevens verstaan het belastbaar inkomen van de echtgenoot. In geval een huurder verzoekt om verhoging van
+      de beslagvrije voet kan de beslaglegger van de geëxecuteerde verlangen dat een bij of krachtens algemene
+      maatregel van bestuur te bepalen bewijsstuk overgelegd wordt.
+      8. De bedragen, genoemd in het eerste lid, zijn gelijk aan de beslagvrije voet die bij de desbetreffende
+      leefsituatie hoort, indien de uitkomst van (I x (F / 12)) respectievelijk (I x (G / 12)) gelijk is aan het
+      bedrag, genoemd in artikel 13, eerste lid, onderdeel a, van de Wet op de huurtoeslag. De bedragen worden met
+      ingang van 1 januari en 1 juli van ieder jaar gewijzigd en door of namens Onze Minister van Sociale Zaken en
+      Werkgelegenheid medegedeeld in de Staatscourant.
+      9. De bedragen, genoemd in het zevende lid, worden jaarlijks met ingang van 1 januari gewijzigd door (I x (F /
+      12)) en (I x (G / 12)) gelijk te stellen aan de maximale normhuur. Daarbij staan F, G en I voor de normen,
+      bedoeld in het tweede lid, en wordt de maximale normhuur berekend door het bedrag van de
+      kwaliteitskortingsgrens, genoemd in artikel 20, eerste lid, van de Wet op de huurtoeslag, te vermeerderen met
+      het in artikel 21, eerste lid, onderdeel b, van die wet bedoelde percentage van het verschil tussen het bedrag
+      van de kwaliteitskortingsgrens en de aftoppingsgrens, genoemd in artikel 20, tweede lid, onderdeel a, van die
+      wet, vermeerderd met het in artikel 21, eerste lid, onderdeel c, van die wet bedoelde percentage van het
+      verschil tussen het bedrag van de aftoppingsgrens en het bedrag van de rekenhuur, genoemd in artikel 13,
+      eerste lid, onderdeel a, van die wet. De gewijzigde bedragen worden door of namens Onze Minister van Sociale
+      Zaken en Werkgelegenheid medegedeeld in de Staatscourant.
+    url: https://wetten.overheid.nl/BWBR0001827/2026-01-01#Artikel475da
+  - number: 475db
+    text: |-
+      1. De beslagvrije voet, bedoeld in de artikelen 475da en 475e, tweede lid, wordt in de onderstaande volgorde
+      verminderd met:
+      a. de in artikel 475c, eerste lid, onderdelen a tot en met i, genoemde niet onder beslag liggende vorderingen
+      tot periodieke betaling inclusief vakantiebijslag van de echtgenoot van de geëxecuteerde, tot ten hoogste de
+      helft van de beslagvrije voet, bedoeld in de artikelen 475da en 475e, tweede lid;
+      b. de in artikel 475c, eerste lid, onderdelen a tot en met i, genoemde niet onder beslag liggende vorderingen
+      tot periodieke betaling inclusief vakantiebijslag van de geëxecuteerde;
+      c. de over het voordeel bedoeld in artikel 13bis van de Wet op de loonbelasting 1964 verschuldigde
+      loonbelasting ten gevolge van het voor privédoeleinden aan de geëxecuteerde ter beschikking gestelde
+      vervoermiddel, indien de geëxecuteerde heeft nagelaten om de inhouding bij aanvang van het eerste kalenderjaar
+      volgend op het kalenderjaar waarin het beslag is gelegd te doen eindigen.
+      2. De hoogte van het op basis van het eerste lid, onderdelen a en b, in mindering te brengen bedrag wordt
+      berekend op basis van het meest recente maandinkomen zoals dat blijkt uit de polisadministratie op het moment
+      van beslaglegging, tenzij dit maandinkomen geen reële afspiegeling vormt van het belastbaar inkomen op het
+      moment van beslaglegging omdat het maandinkomen fluctueert of er sprake is van een incidentele betaling. Bij
+      of krachtens algemene maatregel van bestuur worden regels gesteld over de wijze waarop de hoogte van het in
+      mindering te brengen bedrag wordt berekend. Artikel 475d, eerste lid, derde en vierde zin, is van
+      overeenkomstige toepassing.
+    url: https://wetten.overheid.nl/BWBR0001827/2026-01-01#Artikel475db
+  - number: 475dc
+    text: |-
+      1. In afwijking van de artikelen 475da en 475db bedraagt de beslagvrije voet 95% van het maandelijkse inkomen
+      inclusief vakantiebijslag dat de geëxecuteerde op basis van zijn vorderingen tot periodieke betaling, genoemd
+      in artikel 475c, eerste lid, onderdelen a tot en met i, ontvangt, indien toepassing van de artikelen 475da en
+      475db leidt tot een beslagvrije voet die hoger is dan 95% van het maandelijkse inkomen inclusief
+      vakantiebijslag.
+      2. Indien sprake is van beslag op bij algemene maatregel van bestuur aan te wijzen uitkeringen geeft de
+      deurwaarder of, in geval van samenloop van beslagen als bedoeld in artikel 478 de coördinerende deurwaarder,
+      bij toepassing van het eerste lid aan de derde-beslagene op dat de beslagvrijevoet 95% bedraagt van de voor de
+      geëxecuteerde geldende bijstandsnorm inclusief vakantiebijslag, verminderd met het inkomen, bedoeld in artikel
+      32 van de Participatiewet.
+    url: https://wetten.overheid.nl/BWBR0001827/2026-01-01#Artikel475dc
+  - number: 475e
+    text: |-
+      1. Indien de geëxecuteerde over een niet in de basisregistratie personen opgenomen vaste woon- of
+      verblijfplaats beschikt en hij de deurwaarder die gerechtigd is ten laste van hem binnen Nederland beslag te
+      leggen, inzicht geeft in zijn leefsituatie en zijn bronnen van inkomsten, blijft het bepaalde in artikel
+      475da, vierde lid, eerste zin, buiten toepassing.
+      2. Indien de geëxecuteerde ter verzorging of verpleging in een daartoe bestemde inrichting is opgenomen,
+      bedraagt de beslagvrije voet de prijs die is verschuldigd voor verzorging dan wel verpleging, verhoogd met:
+      a. twee derde van de bijstandsnorm, genoemd in artikel 23, eerste lid, van de Participatiewet;
+      b. het bedrag, genoemd in artikel 23, tweede lid, van de Participatiewet.
+    url: https://wetten.overheid.nl/BWBR0001827/2026-01-01#Artikel475e
+  - number: 475fa
+    text: |-
+      Indien de toepassing van de artikelen 475da tot en met 475e leidt tot een kennelijk onevenredige hardheid als
+      gevolg van een omstandigheid waarmee geen rekening is gehouden bij de vaststelling van de beslagvrije voet,
+      kan de kantonrechter op verzoek van de geëxecuteerde de beslagvrije voet voor een door hem te bepalen termijn
+      verhogen.
+    url: https://wetten.overheid.nl/BWBR0001827/2026-01-01#Artikel475fa

--- a/corpus/regulation/nl/wet/wetboek_van_strafrecht/2026-01-01.yaml
+++ b/corpus/regulation/nl/wet/wetboek_van_strafrecht/2026-01-01.yaml
@@ -1,0 +1,147 @@
+---
+$schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/heads/main/schema/v0.5.0/schema.json
+$id: wetboek_van_strafrecht
+regulatory_layer: WET
+publication_date: '2026-01-01'
+valid_from: '2026-01-01'
+name: Wetboek van Strafrecht
+bwb_id: BWBR0001854
+url: https://wetten.overheid.nl/BWBR0001854/2026-01-01
+
+articles:
+  - number: '23'
+    text: |-
+      1. Hij die tot een geldboete is veroordeeld, betaalt het vastgestelde bedrag binnen de door Onze Minister van
+      Justitie en Veiligheid te stellen termijn aan de staat.
+      2. Het bedrag van de geldboete is ten minste € 3.
+      3. De geldboete die voor een strafbaar feit ten hoogste kan worden opgelegd, is gelijk aan het bedrag van de
+      categorie die voor dat feit is bepaald.
+      4. Er zijn zes categorieën:
+      de eerste categorie, € 335 ;
+      de tweede categorie, € 3 350 ;
+      de derde categorie, € 6 700 ;
+      de vierde categorie, € 16 750 ;
+      de vijfde categorie, € 67 000 ;
+      de zesde categorie, € 670 000 .
+      5. Voor een overtreding, onderscheidenlijk een misdrijf, waarop geen geldboete is gesteld, kan een geldboete
+      worden opgelegd tot ten hoogste het bedrag van de eerste, onderscheidenlijk de derde categorie.
+      6. Voor een overtreding, onderscheidenlijk een misdrijf, waarop een geldboete is gesteld, maar waarvoor geen
+      boetecategorie is bepaald, kan een geldboete worden opgelegd tot ten hoogste het bedrag van de eerste,
+      onderscheidenlijk de derde categorie, indien dit bedrag hoger is dan het bedrag van de op het betrokken
+      strafbare feit gestelde geldboete.
+      7. Bij veroordeling van een rechtspersoon kan, indien de voor het feit bepaalde boetecategorie geen passende
+      bestraffing toelaat, een geldboete worden opgelegd tot ten hoogste het bedrag van de naast hogere categorie.
+      Indien voor het feit een geldboete van de zesde categorie kan worden opgelegd en die boetecategorie geen
+      passende bestraffing toelaat, kan een geldboete worden opgelegd tot ten hoogste tien procent van de jaaromzet
+      van de rechtspersoon in het boekjaar voorafgaande aan de uitspraak of strafbeschikking.
+      8. Het voorgaande lid is van overeenkomstige toepassing bij veroordeling van een vennootschap zonder
+      rechtspersoonlijkheid, maatschap, rederij of doelvermogen.
+      9. De in het vierde lid genoemde bedragen worden elke twee jaar, met ingang van 1 januari van een jaar, bij
+      algemene maatregel van bestuur aangepast aan de ontwikkeling van de consumentenprijsindex sinds de vorige
+      aanpassing van deze bedragen. Bij deze aanpassing wordt het geldbedrag van de eerste categorie op een veelvoud
+      van € 5 naar beneden afgerond en worden, uitgaande van het geldbedrag van deze eerste categorie en onder
+      instandhouding van de onderlinge verhouding tussen de bedragen van de geldboetecategorieën, de bedragen van de
+      tweede tot en met de zesde geldboetecategorie bepaald.
+    url: https://wetten.overheid.nl/BWBR0001854/2026-01-01#Artikel23
+  - number: '24'
+    text: |-
+      Bij de vaststelling van de geldboete wordt rekening gehouden met de draagkracht van de verdachte in de mate
+      waarin dat nodig is met het oog op een passende bestraffing van de verdachte zonder dat deze in zijn inkomen
+      en vermogen onevenredig wordt getroffen.
+    url: https://wetten.overheid.nl/BWBR0001854/2026-01-01#Artikel24
+  - number: 24a
+    text: |-
+      1. Indien een of meer geldboeten worden opgelegd tot een bedrag van ten minste € 225, kan in de uitspraak dan
+      wel de strafbeschikking worden bepaald dat degene aan wie de geldboete is opgelegd het bedrag in gedeelten mag
+      voldoen. Elk van die gedeelten wordt daarbij op ten minste € 45 bepaald.
+      2. In geval van toepassing van het eerste lid worden in de uitspraak of strafbeschikking tevens termijnen
+      vastgesteld voor de betaling van het tweede en - zo de geldboete in meer gedeelten mag worden voldaan - de
+      volgende gedeelten.
+      3. Deze termijnen worden op ten minste één en ten hoogste drie maanden gesteld. Zij mogen in het geval van een
+      uitspraak tezamen een tijdvak van twee jaar niet overschrijden; in het geval van een strafbeschikking mogen
+      zij een tijdvak van een jaar niet overschrijden.
+    url: https://wetten.overheid.nl/BWBR0001854/2026-01-01#Artikel24a
+  - number: 24c
+    text: |-
+      1. Bij de uitspraak waarbij geldboete wordt opgelegd, beveelt de rechter voor het geval dat noch volledige
+      betaling noch volledig verhaal van het verschuldigde bedrag volgt, dat vervangende hechtenis zal worden
+      toegepast. Indien de veroordeelde een rechtspersoon is, blijft dit bevel achterwege. Artikel 51, laatste lid,
+      is van overeenkomstige toepassing.
+      2. De duur van de vervangende hechtenis wordt in gehele dagen, weken of maanden vastgesteld.
+      3. De vervangende hechtenis beloopt ten minste één dag en ten hoogste een jaar. Voor elke volle € 25 van de
+      geldboete wordt niet meer dan één dag opgelegd.
+    url: https://wetten.overheid.nl/BWBR0001854/2026-01-01#Artikel24c
+  - number: 36e
+    text: |-
+      1. Op vordering van het openbaar ministerie kan bij een afzonderlijke rechterlijke beslissing aan degene die
+      is veroordeeld wegens een strafbaar feit de verplichting worden opgelegd tot betaling van een geldbedrag aan
+      de staat ter ontneming van wederrechtelijk verkregen voordeel.
+      2. De verplichting kan worden opgelegd aan de in het eerste lid bedoelde persoon die voordeel heeft verkregen
+      door middel van of uit de baten van het daar bedoelde feit of andere strafbare feiten, waaromtrent voldoende
+      aanwijzingen bestaan dat zij door de veroordeelde zijn begaan.
+      3. Op vordering van het openbaar ministerie kan bij een afzonderlijke rechterlijke beslissing aan degene die
+      is veroordeeld wegens een misdrijf dat naar de wettelijke omschrijving wordt bedreigd met een geldboete van de
+      vijfde categorie, de verplichting worden opgelegd tot betaling van een geldbedrag aan de staat ter ontneming
+      van wederrechtelijk verkregen voordeel, indien aannemelijk is dat of dat misdrijf of andere strafbare feiten
+      op enigerlei wijze ertoe hebben geleid dat de veroordeelde wederrechtelijk voordeel heeft verkregen. In dat
+      geval kan ook worden vermoed dat:
+      a. uitgaven die de veroordeelde heeft gedaan in een periode van zes jaren voorafgaand aan het plegen van dat
+      misdrijf, wederrechtelijk verkregen voordeel belichamen, tenzij aannemelijk is dat deze uitgaven zijn gedaan
+      uit een legale bron van inkomsten, of;
+      b. voorwerpen die in een periode van zes jaren voorafgaand aan het plegen van dat misdrijf aan de veroordeelde
+      zijn gaan toebehoren voordeel belichamen als bedoeld in het eerste lid, tenzij aannemelijk is dat aan de
+      verkrijging van die voorwerpen een legale bron van herkomst ten grondslag ligt.
+      4. De rechter kan ambtshalve, op vordering van het openbaar ministerie of op het verzoek van de veroordeelde
+      afwijken van de in het derde lid genoemde periode van zes jaren en een kortere periode in aanmerking nemen.
+      5. De rechter stelt het bedrag vast waarop het wederrechtelijk verkregen voordeel wordt geschat. Onder
+      voordeel is de besparing van kosten begrepen. De waarde van voorwerpen die door de rechter tot het
+      wederrechtelijk verkregen voordeel worden gerekend, kan worden geschat op de marktwaarde op het tijdstip van
+      de beslissing of door verwijzing naar de bij openbare verkoop te behalen opbrengst, indien verhaal moet worden
+      genomen. De rechter kan het te betalen bedrag lager vaststellen dan het geschatte voordeel. Op het
+      gemotiveerde verzoek van de verdachte of veroordeelde kan de rechter, indien de huidige en de redelijkerwijs
+      te verwachten toekomstige draagkracht van de verdachte of veroordeelde niet toereikend zullen zijn om het te
+      betalen bedrag te voldoen, bij de vaststelling van het te betalen bedrag daarmee rekening houden. Bij het
+      ontbreken van zodanig verzoek kan de rechter ambtshalve of op vordering van de officier van justitie deze
+      bevoegdheid toepassen.
+      6. Onder voorwerpen worden verstaan alle zaken en alle vermogensrechten.
+      7. Bij het vaststellen van het bedrag van het wederrechtelijk verkregen voordeel op grond van het eerste,
+      tweede en derde lid ter zake van strafbare feiten die door twee of meer personen zijn gepleegd, kan de rechter
+      bepalen dat deze hoofdelijk dan wel voor een door hem te bepalen deel aansprakelijk zijn voor de gezamenlijke
+      betalingsverplichting. Bij het vaststellen van het bedrag van het wederrechtelijk verkregen voordeel op grond
+      van het derde lid moet voor de toepassing van de vorige zin tevens aannemelijk zijn dat de veroordeelden een
+      economische eenheid vormden die het wederrechtelijk verkregen voordeel heeft genoten.
+      8. De rechter kan bij de bepaling van de hoogte van het voordeel kosten in mindering brengen die rechtstreeks
+      in verband staan met het begaan van strafbare feiten, bedoeld in het eerste tot en met derde lid, en die
+      redelijkerwijs voor aftrek in aanmerking komen.
+      9. Bij de bepaling van de omvang van het bedrag waarop het wederrechtelijk verkregen voordeel wordt geschat,
+      worden aan benadeelde derden in rechte toegekende vorderingen alsmede de verplichting tot betaling aan de
+      staat van een som gelds ten behoeve van het slachtoffer als bedoeld in artikel 36f voor zover die zijn
+      voldaan, in mindering gebracht.
+      10. Bij de oplegging van de maatregel wordt rekening gehouden met uit hoofde van eerdere beslissingen
+      opgelegde verplichtingen tot betaling van een geldbedrag ter ontneming van wederrechtelijk verkregen voordeel.
+      11. De rechter bepaalt bij de oplegging van de maatregel de duur van de gijzeling die met toepassing van
+      artikel 6:6:25 van het Wetboek van Strafvordering ten hoogste kan worden gevorderd. Bij het bepalen van de
+      duur wordt voor elke volle € 25 van het opgelegde bedrag niet meer dan één dag gerekend. De duur beloopt ten
+      hoogste drie jaar.
+    url: https://wetten.overheid.nl/BWBR0001854/2026-01-01#Artikel36e
+  - number: 36f
+    text: |-
+      1. Aan degene die bij rechterlijke uitspraak wegens een strafbaar feit wordt veroordeeld tot een straf of aan
+      wie bij rechterlijke uitspraak een maatregel wordt opgelegd dan wel ten aanzien van wie met toepassing van
+      artikel 2.3 van de Wet forensische zorg een zorgmachtiging of rechterlijke machtiging is afgegeven op de
+      gronden, genoemd in artikel 2.3, eerste lid, onderdeel 1°, 2° of 4°, van de Wet forensische zorg, of waarbij
+      door de rechter bij de strafoplegging rekening is gehouden met een strafbaar feit, waarvan in de dagvaarding
+      is meegedeeld dat het door de verdachte is erkend en ter kennis van de rechtbank wordt gebracht dan wel jegens
+      wie een strafbeschikking wordt uitgevaardigd, kan de verplichting worden opgelegd tot betaling aan de staat
+      van een som gelds ten behoeve van het slachtoffer of de personen genoemd in artikel 51f, tweede lid, van het
+      Wetboek van Strafvordering. De staat keert een ontvangen bedrag onverwijld uit aan het slachtoffer of de
+      personen genoemd in artikel 51f, tweede lid, van het Wetboek van Strafvordering.
+      2. De maatregel kan worden opgelegd indien en voor zover de verdachte jegens het slachtoffer naar burgerlijk
+      recht aansprakelijk is voor de schade die door het strafbare feit is toegebracht.
+      3. De maatregel kan te zamen met straffen en andere maatregelen worden opgelegd.
+      4. Artikel 24a is van overeenkomstige toepassing.
+      5. De rechter bepaalt bij de oplegging van de maatregel de duur volgens welke met toepassing van artikel
+      6:4:20 van het Wetboek van Strafvordering gijzeling kan worden toegepast. Bij het bepalen van de duur wordt
+      voor elke volle € 25 van het opgelegde bedrag niet meer dan één dag gerekend. De duur beloopt ten hoogste één
+      jaar.
+    url: https://wetten.overheid.nl/BWBR0001854/2026-01-01#Artikel36f

--- a/corpus/regulation/nl/wet/wetboek_van_strafrecht/2026-01-01.yaml
+++ b/corpus/regulation/nl/wet/wetboek_van_strafrecht/2026-01-01.yaml
@@ -1,5 +1,5 @@
 ---
-$schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/heads/main/schema/v0.5.0/schema.json
+$schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/heads/main/schema/v0.5.1/schema.json
 $id: wetboek_van_strafrecht
 regulatory_layer: WET
 publication_date: '2026-01-01'
@@ -43,6 +43,97 @@ articles:
       instandhouding van de onderlinge verhouding tussen de bedragen van de geldboetecategorieën, de bedragen van de
       tweede tot en met de zesde geldboetecategorie bepaald.
     url: https://wetten.overheid.nl/BWBR0001854/2026-01-01#Artikel23
+    machine_readable:
+      definitions:
+        boetecategorie_1:
+          value: 33500
+          description: Eerste categorie, het bedrag van EUR 335 (lid 4)
+        boetecategorie_2:
+          value: 335000
+          description: Tweede categorie, het bedrag van EUR 3.350 (lid 4)
+        boetecategorie_3:
+          value: 670000
+          description: Derde categorie, het bedrag van EUR 6.700 (lid 4)
+        boetecategorie_4:
+          value: 1675000
+          description: Vierde categorie, het bedrag van EUR 16.750 (lid 4)
+        boetecategorie_5:
+          value: 6700000
+          description: Vijfde categorie, het bedrag van EUR 67.000 (lid 4)
+        boetecategorie_6:
+          value: 67000000
+          description: Zesde categorie, het bedrag van EUR 670.000 (lid 4)
+        minimum_geldboete_bedrag:
+          value: 300
+          description: Het bedrag van de geldboete is ten minste EUR 3 (lid 2)
+      execution:
+        parameters:
+          - name: boetecategorie
+            type: number
+            required: true
+            description: De geldboetecategorie (1 t/m 6) die voor het strafbare feit is bepaald
+        output:
+          - name: minimum_geldboete
+            type: amount
+            type_spec:
+              unit: eurocent
+            description: Ondergrens van de geldboete (lid 2)
+          - name: maximum_geldboete
+            type: amount
+            type_spec:
+              unit: eurocent
+            description: Ten hoogste op te leggen geldboete, gelijk aan het bedrag van de categorie (lid 3)
+          - name: bedrag_eerste_categorie
+            type: amount
+            type_spec:
+              unit: eurocent
+            description: Het bedrag van de geldboete van de eerste categorie (lid 4)
+        actions:
+          - output: minimum_geldboete
+            value: $minimum_geldboete_bedrag
+            legal_basis:
+              law: Wetboek van Strafrecht
+              article: '23'
+          - output: bedrag_eerste_categorie
+            value: $boetecategorie_1
+            legal_basis:
+              law: Wetboek van Strafrecht
+              article: '23'
+          # Lid 3: de ten hoogste op te leggen geldboete is gelijk aan het bedrag
+          # van de categorie die voor dat feit is bepaald (lid 4 noemt de zes bedragen).
+          - output: maximum_geldboete
+            value:
+              operation: IF
+              cases:
+                - when:
+                    operation: EQUALS
+                    subject: $boetecategorie
+                    value: 1
+                  then: $boetecategorie_1
+                - when:
+                    operation: EQUALS
+                    subject: $boetecategorie
+                    value: 2
+                  then: $boetecategorie_2
+                - when:
+                    operation: EQUALS
+                    subject: $boetecategorie
+                    value: 3
+                  then: $boetecategorie_3
+                - when:
+                    operation: EQUALS
+                    subject: $boetecategorie
+                    value: 4
+                  then: $boetecategorie_4
+                - when:
+                    operation: EQUALS
+                    subject: $boetecategorie
+                    value: 5
+                  then: $boetecategorie_5
+              default: $boetecategorie_6
+            legal_basis:
+              law: Wetboek van Strafrecht
+              article: '23'
   - number: '24'
     text: |-
       Bij de vaststelling van de geldboete wordt rekening gehouden met de draagkracht van de verdachte in de mate
@@ -61,6 +152,52 @@ articles:
       uitspraak tezamen een tijdvak van twee jaar niet overschrijden; in het geval van een strafbeschikking mogen
       zij een tijdvak van een jaar niet overschrijden.
     url: https://wetten.overheid.nl/BWBR0001854/2026-01-01#Artikel24a
+    machine_readable:
+      definitions:
+        drempel_gespreide_betaling:
+          value: 22500
+          description: Vanaf EUR 225 kan betaling in gedeelten worden bepaald (lid 1)
+        minimum_gedeelte_bedrag:
+          value: 4500
+          description: Elk gedeelte bedraagt ten minste EUR 45 (lid 1)
+      execution:
+        parameters:
+          - name: geldboete_bedrag
+            type: number
+            required: true
+            description: Het opgelegde geldboetebedrag in eurocent
+        output:
+          - name: gespreide_betaling_mogelijk
+            type: boolean
+            description: Of betaling in gedeelten kan worden bepaald (lid 1)
+          - name: minimum_gedeelte
+            type: amount
+            type_spec:
+              unit: eurocent
+            description: Ondergrens van elk gedeelte (lid 1)
+          - name: minimum_termijn_maanden
+            type: number
+            description: Ondergrens van elke betalingstermijn (lid 3)
+          - name: maximum_termijn_maanden
+            type: number
+            description: Bovengrens van elke betalingstermijn (lid 3)
+        actions:
+          # Lid 1: betaling in gedeelten kan worden bepaald indien de geldboete
+          # ten minste EUR 225 bedraagt.
+          - output: gespreide_betaling_mogelijk
+            value:
+              operation: GREATER_THAN_OR_EQUAL
+              subject: $geldboete_bedrag
+              value: $drempel_gespreide_betaling
+            legal_basis:
+              law: Wetboek van Strafrecht
+              article: 24a
+          - output: minimum_gedeelte
+            value: $minimum_gedeelte_bedrag
+          - output: minimum_termijn_maanden
+            value: 1
+          - output: maximum_termijn_maanden
+            value: 3
   - number: 24c
     text: |-
       1. Bij de uitspraak waarbij geldboete wordt opgelegd, beveelt de rechter voor het geval dat noch volledige
@@ -71,6 +208,31 @@ articles:
       3. De vervangende hechtenis beloopt ten minste één dag en ten hoogste een jaar. Voor elke volle € 25 van de
       geldboete wordt niet meer dan één dag opgelegd.
     url: https://wetten.overheid.nl/BWBR0001854/2026-01-01#Artikel24c
+    machine_readable:
+      untranslatables:
+        - construct: voor elke volle EUR 25 van de geldboete niet meer dan een dag
+          reason: >-
+            Het maximum aantal dagen vergt gehele deling (floor) van het
+            geldboetebedrag door 25; de engine kent geen FLOOR- of
+            geheeltallige-deling-operatie.
+          suggestion: Voeg een FLOOR- of geheeltallige-deling-operatie toe aan de engine.
+          legal_text_excerpt: >-
+            Voor elke volle EUR 25 van de geldboete wordt niet meer dan een dag
+            opgelegd.
+          accepted: false
+      execution:
+        output:
+          - name: minimum_vervangende_hechtenis_dagen
+            type: number
+            description: De vervangende hechtenis beloopt ten minste een dag (lid 3)
+          - name: maximum_vervangende_hechtenis_jaren
+            type: number
+            description: De vervangende hechtenis beloopt ten hoogste een jaar (lid 3)
+        actions:
+          - output: minimum_vervangende_hechtenis_dagen
+            value: 1
+          - output: maximum_vervangende_hechtenis_jaren
+            value: 1
   - number: 36e
     text: |-
       1. Op vordering van het openbaar ministerie kan bij een afzonderlijke rechterlijke beslissing aan degene die
@@ -124,6 +286,25 @@ articles:
       duur wordt voor elke volle € 25 van het opgelegde bedrag niet meer dan één dag gerekend. De duur beloopt ten
       hoogste drie jaar.
     url: https://wetten.overheid.nl/BWBR0001854/2026-01-01#Artikel36e
+    machine_readable:
+      untranslatables:
+        - construct: voor elke volle EUR 25 van het opgelegde bedrag niet meer dan een dag gijzeling
+          reason: >-
+            De duur van de gijzeling vergt gehele deling (floor) van het
+            opgelegde bedrag door 25; de engine kent geen FLOOR-operatie.
+          suggestion: Voeg een FLOOR- of geheeltallige-deling-operatie toe aan de engine.
+          legal_text_excerpt: >-
+            Bij het bepalen van de duur wordt voor elke volle EUR 25 van het
+            opgelegde bedrag niet meer dan een dag gerekend.
+          accepted: false
+      execution:
+        output:
+          - name: maximum_gijzeling_jaren
+            type: number
+            description: De duur van de gijzeling beloopt ten hoogste drie jaar (lid 11)
+        actions:
+          - output: maximum_gijzeling_jaren
+            value: 3
   - number: 36f
     text: |-
       1. Aan degene die bij rechterlijke uitspraak wegens een strafbaar feit wordt veroordeeld tot een straf of aan
@@ -145,3 +326,22 @@ articles:
       voor elke volle € 25 van het opgelegde bedrag niet meer dan één dag gerekend. De duur beloopt ten hoogste één
       jaar.
     url: https://wetten.overheid.nl/BWBR0001854/2026-01-01#Artikel36f
+    machine_readable:
+      untranslatables:
+        - construct: voor elke volle EUR 25 van het opgelegde bedrag niet meer dan een dag gijzeling
+          reason: >-
+            De duur van de gijzeling vergt gehele deling (floor) van het
+            opgelegde bedrag door 25; de engine kent geen FLOOR-operatie.
+          suggestion: Voeg een FLOOR- of geheeltallige-deling-operatie toe aan de engine.
+          legal_text_excerpt: >-
+            Bij het bepalen van de duur wordt voor elke volle EUR 25 van het
+            opgelegde bedrag niet meer dan een dag gerekend.
+          accepted: false
+      execution:
+        output:
+          - name: maximum_gijzeling_jaren
+            type: number
+            description: De duur van de gijzeling beloopt ten hoogste een jaar (lid 5)
+        actions:
+          - output: maximum_gijzeling_jaren
+            value: 1


### PR DESCRIPTION
## CJIB centrale rijksincasso — wettelijke kern

Voegt de wetten toe die de juridische kern vormen van wat het CJIB uitvoert
voor de **centrale rijksincasso**. Gedownload via `/law-download` en uitvoerbaar
gemaakt via `/law-interpret` (machine_readable + ad-hoc BDD).

### Wetten

| Wet | Artikelen | Kern |
|-----|-----------|------|
| **WAHV** (Wet Mulder) | 52 (6 uitvoerbaar) | geldsom + halvering <16 jaar, cap op de eerste boetecategorie, verhoging +50%/+100%, zekerheidstelling, termijnen |
| **Wetboek van Strafrecht** | 6 (rijksincasso-scope) | geldboetecategorieën, gespreide betaling, vervangende hechtenis/gijzeling |
| **Awb titel 4.4** | +41 (6 uitvoerbaar) | betalingstermijn, verzuim, wettelijke rente, verjaring, aanmaning(svergoeding) — uitbreiding van het bestaande Awb-bestand |
| **Beslagvrije voet** (Rv 475c–475fa) | 7 (5 uitvoerbaar) | de volledige beslagvrije-voet-formule (475da lid 1–4), geldigheidsduur, 95%-inkomensgrens, beslagvrije voet bij opname |

### Resultaten

- **45 ad-hoc evaluatietests** slagen (Strafrecht 7, WAHV 14, Awb 12, Rv 12).
- Alle bestanden valideren tegen het schema; `just bdd` blijft groen (66 scenario's).
- Cross-law: WAHV art. 2 verwijst naar de eerste boetecategorie in Strafrecht art. 23.
- **Untranslatables**: Strafrecht 24c/36e/36f markeren de floor-deling "elke volle € 25" — de engine kent geen FLOOR-operatie.

### Bewust buiten scope

- **Wet stroomlijning keten voor derdenbeslag** — de meest CRI-specifieke *aankomende* wetgeving (centraal beslagregister), maar nog niet in de BWB-database; kan niet via `/law-download`.
- **Wetboek van Strafvordering Boek 6** (tenuitvoerlegging) — procedureel, weinig rekenlogica.
- De beslagvrije-voet-formule gebruikt variabelen uit de **Wet op de huurtoeslag** en de **Wet op het kindgebonden budget** (nog niet in de corpus); deze zijn nu parameters. Volledige cross-referencing vergt download van die twee wetten.

CRI zelf kent geen eigen wet — het is een beleids-/programmaconstruct (Rijksincassovisie 2016, Clustering Rijksincasso) bovenop deze generieke instrumenten.
