### PR TITLE
fix(landing): ruimte onder de tag-labels

### DIFF
--- a/docs/src/styles/landing.css
+++ b/docs/src/styles/landing.css
@@ -365,6 +365,17 @@ nldd-card.rr-card:defined .rr-card-inner {
 .rr-card-link:hover {
   text-decoration: underline;
 }
+/* NLDD components carry no margins of their own (whitespace is meant to come
+   from <nldd-spacer>, which only exists once JS upgrades the element). This
+   site renders without JS, so the gap between a tag and the heading below it
+   is set here instead, matching the .rr-card-link spacing above. Covers both
+   the cards (.rr-card-inner) and the problem/solution pairs (.rr-ps-*). */
+.rr-card-inner nldd-tag,
+.rr-ps-problem nldd-tag,
+.rr-ps-solution nldd-tag {
+  display: inline-block;
+  margin-bottom: 0.75rem;
+}
 
 /* --- Problem / solution pairs --- */
 .rr-ps-list {


### PR DESCRIPTION
De lichtblauwe/rode tag-labels op de landingspagina plakten tegen de kop eronder, zowel op de Innovatiebudget-kaarten als in de probleem/oplossing-blokken.

NLDD-componenten dragen bewust geen eigen marges — witruimte hoort van een `<nldd-spacer>` te komen. Maar dat is een Lit web component die alleen ruimte maakt zodra JS de boel upgradet, en deze site rendert op nul hydratie (no-JS-fundament, NLDD als enhancement). Een spacer zou de ruimte dus laten wegvallen zonder JS.

Daarom de marge in onze eigen `landing.css`, op de tags binnen `.rr-card-inner` en de `.rr-ps-*`-blokken, gelijk aan de bestaande `.rr-card-link`-spacing.

Visueel geverifieerd in de productie-build (Chrome): tag en kop staan nu los op de Innovatiebudget-kaarten, de ecosystem-kaarten en alle zes probleem/oplossing-blokken.