### PR TITLE
fix(docs): toegankelijkheidsverklaring rechttrekken (WCAG 2.1 als norm) + EN-vertaling

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -386,6 +386,6 @@ docs-build:
 docs-preview:
     cd docs && npm run preview
 
-# Run the accessibility gate (build + mermaid-alt check + pa11y-ci htmlcs+axe, WCAG 2.2 AA)
+# Run the accessibility gate (build + mermaid-alt check + pa11y-ci htmlcs+axe, WCAG 2.1 AA)
 docs-a11y:
     cd docs && npm run a11y

--- a/Justfile
+++ b/Justfile
@@ -386,6 +386,6 @@ docs-build:
 docs-preview:
     cd docs && npm run preview
 
-# Run the accessibility gate (build + mermaid-alt check + pa11y-ci htmlcs+axe, WCAG 2.1 AA)
+# Run the accessibility gate (build + mermaid-alt check + pa11y-ci htmlcs+axe, WCAG 2.2 AA)
 docs-a11y:
     cd docs && npm run a11y

--- a/docs/.pa11yci
+++ b/docs/.pa11yci
@@ -55,6 +55,7 @@
     "http://localhost:4173/operations/ci-cd",
     "http://localhost:4173/operations/contributing",
     "http://localhost:4173/operations/deployment",
+    "http://localhost:4173/reference/accessibility",
     "http://localhost:4173/reference/glossary",
     "http://localhost:4173/reference/issues/issue-article-id-collision",
     "http://localhost:4173/reference/issues/issue-phased-implementation",

--- a/docs/.pa11yci
+++ b/docs/.pa11yci
@@ -27,7 +27,6 @@
     "http://localhost:4173/components/frontend",
     "http://localhost:4173/components/grafana",
     "http://localhost:4173/components/harvester",
-    "http://localhost:4173/components/landing",
     "http://localhost:4173/components/lawmaking",
     "http://localhost:4173/components/pipeline",
     "http://localhost:4173/components/tui",

--- a/docs/scripts/gen-pa11yci.mjs
+++ b/docs/scripts/gen-pa11yci.mjs
@@ -65,8 +65,9 @@ const config = {
     //    carry inline fill="…" attributes. axe's color-contrast algorithm can't
     //    resolve the effective background through that structure and flags every
     //    label, even though the rendered contrast is fine (state/flowchart text
-    //    is donkerblauw-900 on lichtblauw-50 ≈ 13:1; C4 keeps its native white
-    //    on #08427B ≈ 10:1 — both verified manually in the browser). The
+    //    is donkerblauw-900 on lichtblauw-50 ≈ 14.4:1; C4 keeps its native white
+    //    on dark blue, well above the requirement — both measured in the
+    //    browser). The
     //    diagrams' accessible name (role=img + aria-label) is asserted by
     //    scripts/check-mermaid-alt.mjs, which the a11y npm script runs against
     //    the build before this gate, so hiding the SVG here does not lose that
@@ -75,15 +76,16 @@ const config = {
     //    (color:<light>;--shiki-dark:<dark>, same for bg). axe evaluates the
     //    static light color against a background it samples inconsistently and
     //    reports phantom contrast failures on box-drawing/whitespace tokens,
-    //    while the actually-rendered text is 18.9:1 in light and 17.6:1 in dark
-    //    (both verified in the browser, both themes). The high-contrast GitHub
-    //    themes are deliberately chosen for this; the gate can't see it.
+    //    while the actually-rendered text clears the 4.5:1 AA requirement in
+    //    both themes. The high-contrast GitHub themes are deliberately chosen
+    //    for this; the gate can't see it.
     //  - hero text over the gradient (#rr-hero-title and the intro paragraph):
     //    the hero keeps a decorative donkerblauw gradient on top of a solid
     //    donkerblauw-900 fallback. axe cannot evaluate text contrast over a
     //    gradient and flags these, but both gradient stops are deep blue (white
-    //    text ≈ 9:1 on the lighter stop, ≈ 15:1 on the darker / solid fallback —
-    //    verified in the browser). Only the gradient TEXT is hidden, NOT the
+    //    text ≈ 11.4:1 on the lighter stop, ≈ 15.5:1 on the darker / solid
+    //    fallback — measured in the browser). Only the gradient TEXT is hidden,
+    //    NOT the
     //    whole .rr-hero: the CTA button/link inside it stays in the evaluation.
     hideElements:
       '.pagefind-ui, svg[id^="mermaid-"], pre.astro-code, #rr-hero-title, .rr-hero nldd-rich-text p',

--- a/docs/src/content/docs/reference/accessibility.md
+++ b/docs/src/content/docs/reference/accessibility.md
@@ -1,0 +1,109 @@
+---
+title: Accessibility
+description: Accessibility statement for RegelRecht (WCAG 2.2 AA, draft).
+lang: en
+---
+
+# Accessibility statement
+
+This is an English translation, provided for readers of the English
+documentation. The [Dutch version](/reference/toegankelijkheid) is the binding
+one: it is the legally required form for a Dutch government site, and where the
+two differ, the Dutch text prevails.
+
+The statement describes how far RegelRecht meets the accessibility requirements
+for government websites. The standard is WCAG 2.2 level AA, which has applied
+through EN 301 549 since October 2024 and is mandatory in the Netherlands under
+the Tijdelijk besluit digitale toegankelijkheid overheid. It covers the site
+served at `regelrecht.rijks.app` and at `docs.regelrecht.rijks.app`, so the
+landing page, the sign-up form, and the documentation.
+
+**This is a draft.** The status below rests on an automated test in the build
+pipeline and a manual review by the team. No independent party has audited the
+site, and the statement is not yet listed in the DigiToegankelijk register.
+Until both of those are done, this is not a legally valid statement and
+RegelRecht carries no accessibility label.
+
+## Compliance status
+
+Partial. The automated test finds no errors on the criteria it measures, and the
+manual review covers the criteria no tool tests reliably. A few known limitations
+remain, listed below. Without an external audit, RegelRecht claims no full
+compliance.
+
+## Language of the site
+
+The documentation is mostly English; the landing page and the sign-up form are
+Dutch. Every page carries a `lang` attribute that matches the language of its
+content (`en` for the docs, `nl` for the landing and the Dutch statement), so a
+screen reader picks the right pronunciation. Where a single term in the other
+language appears within a page, that fragment gets its own `lang`. This covers
+WCAG 3.1.1 (language of page) and 3.1.2 (language of parts).
+
+## How this was tested
+
+**Automated, on every change.** An accessibility test runs in CI on every change
+that touches the documentation. It builds the site and runs
+[pa11y-ci](https://github.com/pa11y/pa11y-ci) with two independent engines,
+HTML_CodeSniffer and axe-core 4.11, against every generated page (61 at the
+moment). The URL list comes from the build, so a new page is tested
+automatically and does not slip past the check. The test runs locally with
+`just docs-a11y`.
+
+Those two engines cover a large part of WCAG 2.2 that can be measured by machine:
+contrast, form labels, heading structure, landmarks, alt text, and some of the
+criteria added in 2.2. What a tool does not see reliably was checked by hand.
+
+**Manual, for the rest of 2.2.** The team went through the nine success criteria
+that WCAG 2.2 adds: focus not obscured (minimum and enhanced), focus appearance,
+dragging movements, target size, consistent help, redundant entry, and accessible
+authentication (minimum and enhanced). Beyond that, hand-tested:
+
+- keyboard-only operation, including the skip link and the focus order;
+- dark mode, for contrast and legibility;
+- rendering at 200% zoom and at 400% reflow.
+
+## Known limitations
+
+The automated contrast test flags a few elements whose contrast actually passes
+comfortably. The engines cannot read the ratio of these elements reliably. The
+team measured the real ratio in the browser and excluded these elements from the
+automated check, with a note in the configuration:
+
+- **Diagrams (Mermaid).** Diagrams render as inline SVG, with text on transparent
+  layers where axe cannot read the colour behind it. The measured ratio is 14.4:1
+  for text in flow and state diagrams (dark blue on light blue) and well above the
+  requirement for the C4 diagrams (white on dark blue). The diagram colours come
+  from the NLDD palette.
+- **Code samples.** Code blocks carry a light and a dark theme on the same
+  element; the test mixes the two colour sets and measures a blend that never
+  appears on screen. The text that does appear clears the 4.5:1 that AA asks for
+  in both modes.
+- **The hero on the landing page.** The title text is white on a dark-blue
+  gradient. axe cannot judge a gradient. The weakest point of the gradient, its
+  lightest stop, gives white-on-dark-blue a ratio of 11.4:1; towards the dark end
+  it rises to 15.5:1.
+
+The accessible name of each diagram (`role="img"` with an `aria-label`) is checked
+separately against the build output in the same gate, apart from the excluded
+contrast measurement.
+
+## Not yet covered
+
+- There has been **no independent audit**. Everything above rests on the team's
+  own test and review.
+- The interface uses web components from the NLDD design system that render their
+  content in a shadow DOM. Their own focus indication and internal accessibility
+  fall outside the site's control and depend on the design system.
+
+## Reporting a problem
+
+Run into an accessibility problem, or something does not work? Email
+[regelrecht@minbzk.nl](mailto:regelrecht@minbzk.nl). Describe what went wrong and
+on which page, and we will pick it up.
+
+## Drawn up
+
+This draft statement was drawn up on 21 May 2026, based on the test and review of
+that moment. RegelRecht is an exploration and still under development; the
+statement is updated when the site changes or after a formal audit.

--- a/docs/src/content/docs/reference/accessibility.md
+++ b/docs/src/content/docs/reference/accessibility.md
@@ -1,6 +1,6 @@
 ---
 title: Accessibility
-description: Accessibility statement for RegelRecht (WCAG 2.2 AA, draft).
+description: Accessibility statement for RegelRecht (WCAG 2.1 AA, draft).
 lang: en
 ---
 
@@ -12,11 +12,14 @@ one: it is the legally required form for a Dutch government site, and where the
 two differ, the Dutch text prevails.
 
 The statement describes how far RegelRecht meets the accessibility requirements
-for government websites. The standard is WCAG 2.2 level AA, which has applied
-through EN 301 549 since October 2024 and is mandatory in the Netherlands under
-the Tijdelijk besluit digitale toegankelijkheid overheid. It covers the site
-served at `regelrecht.rijks.app` and at `docs.regelrecht.rijks.app`, so the
-landing page, the sign-up form, and the documentation.
+for government websites. The legal standard right now is WCAG 2.1 level AA, via
+EN 301 549 and mandatory in the Netherlands under the Besluit digitale
+toegankelijkheid overheid. WCAG 2.2 has been published by the W3C but is not yet
+part of EN 301 549; once the European standard moves to 2.2, the Netherlands
+follows. RegelRecht has therefore already tested against the nine new 2.2
+criteria, ahead of that transition. The statement covers the site served at
+`regelrecht.rijks.app` and at `docs.regelrecht.rijks.app`, so the landing page,
+the sign-up form, and the documentation.
 
 **This is a draft.** The status below rests on an automated test in the build
 pipeline and a manual review by the team. No independent party has audited the
@@ -45,19 +48,19 @@ WCAG 3.1.1 (language of page) and 3.1.2 (language of parts).
 **Automated, on every change.** An accessibility test runs in CI on every change
 that touches the documentation. It builds the site and runs
 [pa11y-ci](https://github.com/pa11y/pa11y-ci) with two independent engines,
-HTML_CodeSniffer and axe-core 4.11, against every generated page (61 at the
-moment). The URL list comes from the build, so a new page is tested
-automatically and does not slip past the check. The test runs locally with
-`just docs-a11y`.
+HTML_CodeSniffer and axe-core 4.11, against every generated page. The URL list
+comes from the build, so a new page is tested automatically and does not slip
+past the check. The test runs locally with `just docs-a11y`.
 
-Those two engines cover a large part of WCAG 2.2 that can be measured by machine:
-contrast, form labels, heading structure, landmarks, alt text, and some of the
-criteria added in 2.2. What a tool does not see reliably was checked by hand.
+Those two engines cover a large part of what can be measured by machine:
+contrast, form labels, heading structure, landmarks, and alt text. What a tool
+does not see reliably was checked by hand.
 
-**Manual, for the rest of 2.2.** The team went through the nine success criteria
-that WCAG 2.2 adds: focus not obscured (minimum and enhanced), focus appearance,
-dragging movements, target size, consistent help, redundant entry, and accessible
-authentication (minimum and enhanced). Beyond that, hand-tested:
+**Manual, including a head start on 2.2.** The team went through the nine success
+criteria that WCAG 2.2 adds, although they are not yet a legal requirement: focus
+not obscured (minimum and enhanced), focus appearance, dragging movements, target
+size, consistent help, redundant entry, and accessible authentication (minimum
+and enhanced). Beyond that, hand-tested:
 
 - keyboard-only operation, including the skip link and the focus order;
 - dark mode, for contrast and legibility;

--- a/docs/src/content/docs/reference/toegankelijkheid.md
+++ b/docs/src/content/docs/reference/toegankelijkheid.md
@@ -1,30 +1,44 @@
 ---
 title: Toegankelijkheid
-description: Toegankelijkheidsverklaring voor de RegelRecht-documentatiesite (WCAG 2.1 AA, concept).
+description: Toegankelijkheidsverklaring voor RegelRecht (WCAG 2.2 AA, concept).
 lang: nl
 ---
 
 # Toegankelijkheidsverklaring
 
-Deze verklaring beschrijft in hoeverre de documentatiesite van RegelRecht
-voldoet aan de toegankelijkheidseisen voor overheidswebsites: WCAG 2.1
-niveau AA, zoals vastgelegd in EN 301 549 en de verplichting onder het
-Tijdelijk besluit digitale toegankelijkheid overheid. De verklaring geldt voor
-de site die zowel op `regelrecht.rijks.app` als op `docs.regelrecht.rijks.app`
-wordt aangeboden, inclusief de landingspagina en het aanmeldformulier.
+Deze verklaring is in het Nederlands en geldt als de bindende versie. Er is ook
+een [Engelse vertaling](/reference/accessibility) voor lezers van de
+Engelstalige documentatie; bij verschil tussen beide is deze Nederlandse tekst
+leidend.
 
-**Dit is een concept.** De status hieronder is gebaseerd op een geautomatiseerde
-toets in de bouwstraat en een handmatige controle door het team, niet op een
-onderzoek door een onafhankelijke partij. Een formele audit en publicatie in het
-register van DigiToegankelijk moeten nog plaatsvinden voordat dit een
-rechtsgeldige verklaring is.
+De verklaring beschrijft in hoeverre RegelRecht voldoet aan de
+toegankelijkheidseisen voor overheidswebsites. De norm is WCAG 2.2 niveau AA,
+zoals die sinds oktober 2024 via EN 301 549 geldt en in Nederland verplicht is
+onder het Tijdelijk besluit digitale toegankelijkheid overheid. Ze geldt voor de
+site die op `regelrecht.rijks.app` en op `docs.regelrecht.rijks.app` wordt
+aangeboden, dus voor de landingspagina, het aanmeldformulier en de documentatie.
+
+**Dit is een concept.** De status hieronder berust op een geautomatiseerde toets
+in de bouwstraat en een handmatige controle door het team. Een onderzoek door een
+onafhankelijke partij heeft niet plaatsgevonden, en de verklaring staat nog niet
+in het register van DigiToegankelijk. Tot dat allebei rond is, is dit geen
+rechtsgeldige verklaring en draagt RegelRecht geen toegankelijkheidslabel.
 
 ## Nalevingsstatus
 
 Gedeeltelijk. De geautomatiseerde toets vindt geen fouten op de criteria die zij
-kan meten, en de handmatige controle dekt de criteria die geen tool betrouwbaar
-test. Er resteren bekende beperkingen, hieronder benoemd. Zolang er geen externe
-audit is geweest, claimt RegelRecht geen volledige naleving.
+meet, en de handmatige controle dekt de criteria die geen tool betrouwbaar test.
+Een paar bekende beperkingen blijven over; die staan hieronder. Zonder externe
+audit claimt RegelRecht geen volledige naleving.
+
+## Taal van de site
+
+De documentatie is grotendeels Engels, de landingspagina en het aanmeldformulier
+zijn Nederlands. Elke pagina draagt een `lang`-attribuut dat overeenkomt met de
+taal van de inhoud (`en` voor de docs, `nl` voor deze verklaring en de landing),
+zodat een schermlezer de juiste uitspraak kiest. Waar binnen een pagina een
+losse term in de andere taal staat, krijgt dat fragment een eigen `lang`. Dit
+dekt WCAG 3.1.1 (taal van de pagina) en 3.1.2 (taal van onderdelen).
 
 ## Hoe dit getoetst is
 
@@ -32,69 +46,68 @@ audit is geweest, claimt RegelRecht geen volledige naleving.
 op elke wijziging die de documentatie raakt. De toets bouwt de site en draait
 [pa11y-ci](https://github.com/pa11y/pa11y-ci) met twee onafhankelijke engines,
 HTML_CodeSniffer en axe-core 4.11, tegen elke gegenereerde pagina (op dit moment
-61). De URL-lijst wordt uit de build afgeleid, zodat een nieuwe pagina
-automatisch meegetoetst wordt en niet stilletjes buiten de controle valt.
-Dezelfde toets is lokaal te draaien met `just docs-a11y`.
+61). De URL-lijst komt uit de build, zodat een nieuwe pagina automatisch
+meegetoetst wordt en niet buiten de controle valt. De toets is lokaal te draaien
+met `just docs-a11y`.
 
-**Handmatig, voor wat tools niet zien.** HTML_CodeSniffer en axe dekken de
-klassieke criteria (contrast, labels, koppenstructuur, landmarks, alt-teksten),
-maar niet alles. Het team controleerde daarnaast met de hand:
+Die twee engines dekken een groot deel van WCAG 2.2 dat machinaal te meten is:
+contrast, formulierlabels, koppenstructuur, landmarks, alt-teksten, en een deel
+van de in 2.2 toegevoegde criteria. Wat een tool niet betrouwbaar ziet, is met de
+hand gecontroleerd.
 
-- alle nieuwe WCAG 2.2-succescriteria, over deze thema's: focus niet afgedekt
-  (minimum en uitgebreid), focusverschijning, sleepbewegingen, klikdoelgrootte,
-  consistente hulp, herhaalde invoer en toegankelijke authenticatie (minimum en
-  uitgebreid);
-- de werking met alleen toetsenbord, inclusief de sla-over-link en de
+**Handmatig, voor de rest van 2.2.** Het team liep de negen succescriteria na die
+WCAG 2.2 toevoegt: focus niet afgedekt (minimum en uitgebreid), focusverschijning,
+sleepbewegingen, klikdoelgrootte, consistente hulp, herhaalde invoer, en
+toegankelijke authenticatie (minimum en uitgebreid). Daarnaast is met de hand
+getest:
+
+- de werking met alleen een toetsenbord, inclusief de sla-over-link en de
   focusvolgorde;
 - de donkere modus, op contrast en leesbaarheid;
-- weergave bij 200% zoom en 400% herschaling.
+- weergave bij 200% zoom en bij 400% herschaling.
 
 ## Bekende beperkingen
 
-Drie groepen elementen worden door de geautomatiseerde contrasttoets gemeld,
-maar voldoen feitelijk wel. De engines kunnen het contrast er niet betrouwbaar
-meten; het team heeft de werkelijke verhouding in de browser nagemeten en
-gecontroleerd dat die ruim boven de eis ligt. Deze elementen zijn daarom
-uitgesloten van de geautomatiseerde meting, met een toelichting in de
-configuratie:
+Een aantal elementen wordt door de geautomatiseerde contrasttoets gemeld, terwijl
+het contrast feitelijk ruim voldoet. De engines kunnen de verhouding bij deze
+elementen niet betrouwbaar bepalen. Het team heeft de werkelijke verhouding in de
+browser gemeten en deze elementen daarom uitgesloten van de geautomatiseerde
+meting, met een toelichting in de configuratie:
 
-- **Diagrammen (Mermaid).** Diagrammen worden als inline-SVG getekend, met
-  tekst in transparante lagen. axe kan de achtergrond achter die tekst niet
-  bepalen. De werkelijke verhouding is ongeveer 13:1 (donkerblauw op lichtblauw)
-  voor stroom- en toestanddiagrammen en ongeveer 10:1 (wit op donkerblauw) voor
-  de C4-diagrammen. De diagramkleuren komen uit het NLDD-palet.
-- **Codevoorbeelden.** Codeblokken dragen een licht- én een donker thema in
-  hetzelfde element; de toets verwart de twee kleurensets. De werkelijke tekst
-  haalt 18,9:1 in de lichte modus en 17,6:1 in de donkere.
-- **De hero op de landingspagina.** De titeltekst staat op een
-  donkerblauwe verloopachtergrond. axe kan contrast over een verloop niet
-  beoordelen; beide uiteinden van het verloop zijn donker genoeg (wit op de
-  lichtste stop ongeveer 9:1).
+- **Diagrammen (Mermaid).** Diagrammen worden als inline-SVG getekend, met tekst
+  in transparante lagen waar axe de achterliggende kleur niet van kan aflezen. De
+  gemeten verhouding is 14,4:1 voor de tekst in stroom- en toestanddiagrammen
+  (donkerblauw op lichtblauw) en ruim boven de eis voor de C4-diagrammen (wit op
+  donkerblauw). De diagramkleuren komen uit het NLDD-palet.
+- **Codevoorbeelden.** Codeblokken dragen een licht- en een donker thema in
+  hetzelfde element; de toets verwart de twee kleurensets en meet een mengsel dat
+  niet op het scherm verschijnt. De werkelijke tekst haalt in beide modi ruim de
+  4,5:1 die AA vraagt.
+- **De hero op de landingspagina.** De titeltekst staat in wit op een donkerblauwe
+  verloopachtergrond. axe kan een verloop niet beoordelen. De zwakste plek van het
+  verloop, de lichtste stop, geeft wit-op-donkerblauw een verhouding van 11,4:1;
+  naar de donkere kant loopt dat op tot 15,5:1.
 
-De toegankelijke naam van elk diagram (`role="img"` plus een `aria-label`) wordt
-in dezelfde gate apart tegen de bouwoutput gecontroleerd, los van de uitgesloten
+De toegankelijke naam van elk diagram (`role="img"` met een `aria-label`) wordt in
+dezelfde gate apart tegen de bouwoutput gecontroleerd, los van de uitgesloten
 contrastmeting.
 
 ## Wat nog niet gedekt is
 
-- Er is **geen onafhankelijke audit** geweest. De claims hierboven berusten op
-  de eigen toets en controle van het team.
-- De geautomatiseerde toets dekt **WCAG 2.1**; de negen 2.2-criteria zijn
-  handmatig beoordeeld, niet door een tool.
-- De interface bevat web-componenten van het NLDD-designsysteem die hun
-  inhoud in een schaduw-DOM tekenen. Hun eigen focusindicatie en interne
-  toegankelijkheid vallen buiten de site-eigen controle en zijn afhankelijk van
-  het designsysteem.
+- Er is **geen onafhankelijke audit** geweest. Alles hierboven berust op de eigen
+  toets en controle van het team.
+- De interface gebruikt web-componenten uit het NLDD-designsysteem die hun inhoud
+  in een schaduw-DOM tekenen. Hun eigen focusindicatie en interne toegankelijkheid
+  vallen buiten de site-eigen controle en hangen af van het designsysteem.
 
 ## Probleem melden
 
 Kom je een toegankelijkheidsprobleem tegen, of lukt iets niet? Mail naar
 [regelrecht@minbzk.nl](mailto:regelrecht@minbzk.nl). Beschrijf wat er misging en
-op welke pagina, dan pakken we het op.
+op welke pagina; dan pakken we het op.
 
 ## Opgesteld
 
-Deze conceptverklaring is opgesteld op 20 mei 2026, op basis van de toets en
-controle van datzelfde moment. RegelRecht is een verkenning en wordt nog
-ontwikkeld; de verklaring wordt bijgewerkt als de site verandert of na een
-formele audit.
+Deze conceptverklaring is opgesteld op 21 mei 2026, op basis van de toets en
+controle van dat moment. RegelRecht is een verkenning en wordt nog ontwikkeld; de
+verklaring wordt bijgewerkt als de site verandert of na een formele audit.

--- a/docs/src/content/docs/reference/toegankelijkheid.md
+++ b/docs/src/content/docs/reference/toegankelijkheid.md
@@ -1,6 +1,6 @@
 ---
 title: Toegankelijkheid
-description: Toegankelijkheidsverklaring voor RegelRecht (WCAG 2.2 AA, concept).
+description: Toegankelijkheidsverklaring voor RegelRecht (WCAG 2.1 AA, concept).
 lang: nl
 ---
 
@@ -12,11 +12,14 @@ Engelstalige documentatie; bij verschil tussen beide is deze Nederlandse tekst
 leidend.
 
 De verklaring beschrijft in hoeverre RegelRecht voldoet aan de
-toegankelijkheidseisen voor overheidswebsites. De norm is WCAG 2.2 niveau AA,
-zoals die sinds oktober 2024 via EN 301 549 geldt en in Nederland verplicht is
-onder het Tijdelijk besluit digitale toegankelijkheid overheid. Ze geldt voor de
-site die op `regelrecht.rijks.app` en op `docs.regelrecht.rijks.app` wordt
-aangeboden, dus voor de landingspagina, het aanmeldformulier en de documentatie.
+toegankelijkheidseisen voor overheidswebsites. De wettelijke norm is op dit
+moment WCAG 2.1 niveau AA, via EN 301 549 en verplicht onder het Besluit
+digitale toegankelijkheid overheid. WCAG 2.2 is door W3C gepubliceerd maar nog
+niet in EN 301 549 opgenomen; zodra de Europese norm naar 2.2 gaat, volgt
+Nederland. RegelRecht heeft daarom ook al tegen de negen nieuwe 2.2-criteria
+getoetst, vooruitlopend op die overgang. De verklaring geldt voor de site die op
+`regelrecht.rijks.app` en op `docs.regelrecht.rijks.app` wordt aangeboden, dus
+voor de landingspagina, het aanmeldformulier en de documentatie.
 
 **Dit is een concept.** De status hieronder berust op een geautomatiseerde toets
 in de bouwstraat en een handmatige controle door het team. Een onderzoek door een
@@ -45,21 +48,19 @@ dekt WCAG 3.1.1 (taal van de pagina) en 3.1.2 (taal van onderdelen).
 **Geautomatiseerd, bij elke wijziging.** Een toegankelijkheidstoets draait in CI
 op elke wijziging die de documentatie raakt. De toets bouwt de site en draait
 [pa11y-ci](https://github.com/pa11y/pa11y-ci) met twee onafhankelijke engines,
-HTML_CodeSniffer en axe-core 4.11, tegen elke gegenereerde pagina (op dit moment
-61). De URL-lijst komt uit de build, zodat een nieuwe pagina automatisch
-meegetoetst wordt en niet buiten de controle valt. De toets is lokaal te draaien
-met `just docs-a11y`.
+HTML_CodeSniffer en axe-core 4.11, tegen elke gegenereerde pagina. De URL-lijst
+komt uit de build, zodat een nieuwe pagina automatisch meegetoetst wordt en niet
+buiten de controle valt. De toets is lokaal te draaien met `just docs-a11y`.
 
-Die twee engines dekken een groot deel van WCAG 2.2 dat machinaal te meten is:
-contrast, formulierlabels, koppenstructuur, landmarks, alt-teksten, en een deel
-van de in 2.2 toegevoegde criteria. Wat een tool niet betrouwbaar ziet, is met de
-hand gecontroleerd.
+Die twee engines dekken een groot deel van wat machinaal te meten is: contrast,
+formulierlabels, koppenstructuur, landmarks en alt-teksten. Wat een tool niet
+betrouwbaar ziet, is met de hand gecontroleerd.
 
-**Handmatig, voor de rest van 2.2.** Het team liep de negen succescriteria na die
-WCAG 2.2 toevoegt: focus niet afgedekt (minimum en uitgebreid), focusverschijning,
-sleepbewegingen, klikdoelgrootte, consistente hulp, herhaalde invoer, en
-toegankelijke authenticatie (minimum en uitgebreid). Daarnaast is met de hand
-getest:
+**Handmatig, inclusief vooruitlopen op 2.2.** Het team liep de negen
+succescriteria na die WCAG 2.2 toevoegt, hoewel die nog geen wettelijke eis zijn:
+focus niet afgedekt (minimum en uitgebreid), focusverschijning, sleepbewegingen,
+klikdoelgrootte, consistente hulp, herhaalde invoer, en toegankelijke
+authenticatie (minimum en uitgebreid). Daarnaast is met de hand getest:
 
 - de werking met alleen een toetsenbord, inclusief de sla-over-link en de
   focusvolgorde;

--- a/docs/src/lib/landing-content.ts
+++ b/docs/src/lib/landing-content.ts
@@ -843,7 +843,7 @@ export const content: Record<'nl' | 'en', LandingContent> = {
         { label: 'How it works', href: '/en/#how-it-works' },
         { label: 'Stay informed', href: SIGNUP_EN_PATH },
         { label: 'Documentation', href: GUIDE_PATH },
-        { label: 'Accessibility (Dutch)', href: '/reference/toegankelijkheid' },
+        { label: 'Accessibility', href: '/reference/accessibility' },
       ],
       partOf: [
         'Bureau Architectuur',

--- a/docs/src/lib/sidebar.ts
+++ b/docs/src/lib/sidebar.ts
@@ -134,7 +134,7 @@ export const sidebar: Record<string, SidebarGroup[]> = {
       items: [
         { text: 'Glossary', link: '/reference/glossary' },
         { text: 'Schema', link: '/reference/schema' },
-        { text: 'Toegankelijkheid', link: '/reference/toegankelijkheid' },
+        { text: 'Accessibility', link: '/reference/accessibility' },
       ],
     },
     {


### PR DESCRIPTION
## Wat & waarom

Kritische review van de toegankelijkheidsverklaring legde een aantal dingen bloot. De PR begon als "norm naar 2.2", maar de feitencheck draaide dat om.

### Norm: 2.1 is de wettelijke lat, 2.2 vooruitlopend getoetst
Per mei 2026 is **WCAG 2.1 AA** nog steeds de wettelijke norm (EN 301 549 v3.2.1, geharmoniseerd 2021). WCAG 2.2 is door W3C gepubliceerd maar **nog niet in EN 301 549 opgenomen**; de EU-overgang wordt in 2026 verwacht. De verklaring claimde ten onrechte dat 2.2 "sinds oktober 2024" de norm is. Nu: 2.1 is de norm, en de negen nieuwe 2.2-criteria zijn al handmatig getoetst vooruitlopend op de overgang. Correct én sterker dan puur 2.1.

De instrumentnaam is ook geactualiseerd: **Besluit digitale toegankelijkheid overheid** (zonder "Tijdelijk", vervallen na de Wet digitale overheid).

### NL canoniek + EN vertaling
Er stond één Nederlandse pagina midden in de Engelse docs. Nu een Engelse vertaling op `/reference/accessibility` (`lang=en`); de NL-versie blijft canoniek en bindend. Beide pagina's verwijzen naar elkaar, NL leidend bij verschil.

### Contrastcijfers opnieuw gemeten
Hero **11,4:1** (wit op de lichtste verloopstop, was te conservatief op "9:1"), Mermaid **14,4:1**. De niet-reproduceerbare codeblok-getallen ("18,9:1 / 17,6:1") vervangen door een kwalitatieve claim. De comments in `gen-pa11yci.mjs` zijn met dezelfde waarden in lijn gebracht.

### Verder
- Taalsectie toegevoegd (WCAG 3.1.1 en 3.1.2): docs Engels, landing NL, `lang` per pagina.
- Hardcoded paginatelling uit de tekst gehaald (de lijst komt uit de build).
- Sidebar en EN-footer wijzen naar de EN-pagina; NL-footer naar de NL-pagina.

## Verificatie

- `just docs-a11y`: 61/61 pagina's groen (htmlcs + axe), 30 Mermaid-diagrammen gelabeld.
- `lang=en` / `lang=nl` per pagina geverifieerd in de build.
- Cross-links tussen beide pagina's resolven.
- Geen em-dashes, geen verboden frases.
