### PR TITLE
feat(editor): library traject-bewust + same-page switch + loading state

### DIFF
--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -180,6 +180,17 @@ const {
   lastSavedPr,
 } = useLaw(route.params.lawId, route.params.articleNumber);
 
+// React to traject switches: switchTraject now stays on the current
+// route (URL preserved), so the URL alone won't trigger a refetch.
+// Re-run `switchLaw` against the same lawId/article to pick up the
+// new traject's content (or surface a 404 when the law isn't part
+// of the new traject — handled by the error-state UI below).
+watch(activeTrajectId, () => {
+  if (lawId.value) {
+    switchLaw(lawId.value, selectedArticleNumber.value);
+  }
+});
+
 // Notes (RFC-005/RFC-018) for the current law, resolved against its text.
 const {
   notesForArticle: committedNotesForArticle,
@@ -388,6 +399,14 @@ const failedLawName = computed(() => {
   if (!id) return '';
   return corpusLaws.value.find(l => l.law_id === id)?.name || id;
 });
+
+/**
+ * Whether the current `error` is a 404 from the law fetch — i.e. the
+ * law does not exist (or is not part of the active traject's corpus).
+ * `useLaw.load` / `fetchLaw` decorate the thrown Error with `.status`
+ * so we can branch the error UI without re-parsing the message.
+ */
+const lawErrorIs404 = computed(() => error.value?.status === 404);
 
 /**
  * Retry the failed law fetch. switchLaw clears `error` and re-runs the
@@ -1368,10 +1387,35 @@ async function handleActionSave() {
           </nldd-simple-section>
         </nldd-page>
 
-        <!-- Error state — mirrors the library's law-load failure pattern. -->
+        <!-- Loading state — has priority over the error pane below, so a
+             stale `error` from the previous law/traject doesn't briefly
+             flash "Wet is niet geladen" while the new fetch is still in
+             flight. The design system has no dedicated spinner, so we
+             reuse the inline-dialog pattern. -->
+        <nldd-page v-else-if="loading">
+          <nldd-simple-section width="full">
+            <nldd-inline-dialog text="Wet laden…"></nldd-inline-dialog>
+          </nldd-simple-section>
+        </nldd-page>
+
+        <!-- Error state — mirrors the library's law-load failure pattern.
+             404s typically mean "the law isn't part of the active traject"
+             (e.g. after a traject switch); we surface a traject-specific
+             message and a quick "Naar bibliotheek" exit. Other failures
+             keep the generic copy + retry. -->
         <nldd-page v-else-if="error">
           <nldd-simple-section width="full">
             <nldd-inline-dialog
+              v-if="lawErrorIs404"
+              variant="alert"
+              :text="`${failedLawName} is niet beschikbaar in dit traject`"
+              supporting-text="Wissel van traject via het menu rechtsboven of ga terug naar het overzicht."
+            >
+              <nldd-button slot="actions" variant="primary" text="Naar bibliotheek" :href="lastLibraryPath" @click.prevent="router.push(lastLibraryPath)"></nldd-button>
+              <nldd-button slot="actions" variant="secondary" text="Probeer opnieuw" @click="retryLoadLaw"></nldd-button>
+            </nldd-inline-dialog>
+            <nldd-inline-dialog
+              v-else
               variant="alert"
               :text="`${failedLawName} is niet geladen`"
               supporting-text="De gegevens konden niet worden opgehaald."

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -150,7 +150,7 @@ function setPaneView(idx, viewId) {
 // the auth-check before this component mounts so the SSO half of the
 // guard is in practice always true; the traject half can flip at runtime
 // when the user picks a different option from the TrajectMenu.
-const { activeTrajectId } = useTrajects();
+const { activeTrajectId, trajectsReady } = useTrajects();
 const canEdit = computed(
   () => (!oidcConfigured.value || authenticated.value) && activeTrajectId.value !== null,
 );
@@ -185,7 +185,12 @@ const {
 // Re-run `switchLaw` against the same lawId/article to pick up the
 // new traject's content (or surface a 404 when the law isn't part
 // of the new traject — handled by the error-state UI below).
+// Gated on `trajectsReady` so the initial null → session-traject-id
+// transition done by `loadTrajects` (which runs asynchronously after
+// mount) doesn't spuriously trigger a duplicate `switchLaw` on cold
+// load. Only user-driven `switchTraject` calls fire the watcher.
 watch(activeTrajectId, () => {
+  if (!trajectsReady.value) return;
   if (lawId.value) {
     switchLaw(lawId.value, selectedArticleNumber.value);
   }

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -387,11 +387,20 @@ const graphSheetOpen = ref(false);
 const corpusLaws = ref([]);
 const searchPopoverRef = ref(null);
 
+// Guard against stale responses when the user switches trajects in quick
+// succession: a slower A-fetch resolving after a faster B-fetch would
+// otherwise overwrite B's list, briefly flashing A's display name in the
+// search popover and the 404 inline-dialog. Mirrors the loadIndex /
+// loadLaw generation pattern in LibraryApp.vue.
+let corpusLawsGeneration = 0;
+
 async function loadCorpusLaws() {
+  const gen = ++corpusLawsGeneration;
   try {
     const res = await fetch('/api/corpus/laws?limit=1000');
     if (!res.ok) return;
     const list = await res.json();
+    if (gen !== corpusLawsGeneration) return; // stale response, discard
     corpusLaws.value = list.sort((a, b) => a.law_id.localeCompare(b.law_id));
   } catch { /* ignore — search is a convenience */ }
 }

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -380,6 +380,7 @@ async function loadCorpusLaws() {
   try {
     const res = await fetch('/api/corpus/laws?limit=1000');
     if (!res.ok) return;
+    if (gen !== corpusLawsGeneration) return; // stale response, discard
     const list = await res.json();
     if (gen !== corpusLawsGeneration) return; // stale response, discard
     corpusLaws.value = list.sort((a, b) => a.law_id.localeCompare(b.law_id));
@@ -402,12 +403,7 @@ const failedLawName = computed(() => {
   return corpusLaws.value.find(l => l.law_id === id)?.name || id;
 });
 
-/**
- * Whether the current `error` is a 404 from the law fetch — i.e. the
- * law does not exist (or is not part of the active traject's corpus).
- * `useLaw.load` / `fetchLaw` decorate the thrown Error with `.status`
- * so we can branch the error UI without re-parsing the message.
- */
+// True when the law fetch errored with 404 (law missing or not in active traject's corpus).
 const lawErrorIs404 = computed(() => error.value?.status === 404);
 
 /**

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -180,22 +180,7 @@ const {
   lastSavedPr,
 } = useLaw(route.params.lawId, route.params.articleNumber);
 
-// React to traject switches: switchTraject now stays on the current
-// route (URL preserved), so the URL alone won't trigger a refetch.
-// Re-run `switchLaw` against the same lawId/article to pick up the
-// new traject's content (or surface a 404 when the law isn't part
-// of the new traject — handled by the error-state UI below).
-// Watch `trajectSwitchEpoch` (bumped only by user-driven
-// `switchTraject` calls) rather than `activeTrajectId` itself: the
-// initial null → session-traject-id settle done by `loadTrajects`
-// does not touch the counter, so the cold-load transition is ignored.
-// Using a counter (instead of a one-shot `trajectsReady` gate) also
-// closes the race where a user click lands in the same microtask as
-// the settle — both writes go to `activeTrajectId`, but only the
-// user-driven one bumps the epoch and triggers the refetch.
-// We also refresh the corpus index so the search popover AND the
-// `failedLawName` lookup (used by the 404 inline-dialog) reflect the
-// new traject's law set instead of the previous traject's names.
+// On user-driven traject switch (epoch bump): refresh corpus index and refetch the open law.
 watch(trajectSwitchEpoch, () => {
   loadCorpusLaws();
   if (lawId.value) {
@@ -387,11 +372,7 @@ const graphSheetOpen = ref(false);
 const corpusLaws = ref([]);
 const searchPopoverRef = ref(null);
 
-// Guard against stale responses when the user switches trajects in quick
-// succession: a slower A-fetch resolving after a faster B-fetch would
-// otherwise overwrite B's list, briefly flashing A's display name in the
-// search popover and the 404 inline-dialog. Mirrors the loadIndex /
-// loadLaw generation pattern in LibraryApp.vue.
+// Generation counter to discard stale responses across rapid traject switches.
 let corpusLawsGeneration = 0;
 
 async function loadCorpusLaws() {
@@ -1408,11 +1389,7 @@ async function handleActionSave() {
           </nldd-simple-section>
         </nldd-page>
 
-        <!-- Loading state — has priority over the error pane below, so a
-             stale `error` from the previous law/traject doesn't briefly
-             flash "Wet is niet geladen" while the new fetch is still in
-             flight. The design system has no dedicated spinner, so we
-             reuse the inline-dialog pattern. -->
+        <!-- Loading takes precedence over `error` to avoid flashing a stale error during a refetch. -->
         <nldd-page v-else-if="loading">
           <nldd-simple-section width="full">
             <nldd-inline-dialog text="Wet laden…"></nldd-inline-dialog>

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -150,7 +150,7 @@ function setPaneView(idx, viewId) {
 // the auth-check before this component mounts so the SSO half of the
 // guard is in practice always true; the traject half can flip at runtime
 // when the user picks a different option from the TrajectMenu.
-const { activeTrajectId, trajectsReady } = useTrajects();
+const { activeTrajectId, trajectSwitchEpoch } = useTrajects();
 const canEdit = computed(
   () => (!oidcConfigured.value || authenticated.value) && activeTrajectId.value !== null,
 );
@@ -185,12 +185,15 @@ const {
 // Re-run `switchLaw` against the same lawId/article to pick up the
 // new traject's content (or surface a 404 when the law isn't part
 // of the new traject — handled by the error-state UI below).
-// Gated on `trajectsReady` so the initial null → session-traject-id
-// transition done by `loadTrajects` (which runs asynchronously after
-// mount) doesn't spuriously trigger a duplicate `switchLaw` on cold
-// load. Only user-driven `switchTraject` calls fire the watcher.
-watch(activeTrajectId, () => {
-  if (!trajectsReady.value) return;
+// Watch `trajectSwitchEpoch` (bumped only by user-driven
+// `switchTraject` calls) rather than `activeTrajectId` itself: the
+// initial null → session-traject-id settle done by `loadTrajects`
+// does not touch the counter, so the cold-load transition is ignored.
+// Using a counter (instead of a one-shot `trajectsReady` gate) also
+// closes the race where a user click lands in the same microtask as
+// the settle — both writes go to `activeTrajectId`, but only the
+// user-driven one bumps the epoch and triggers the refetch.
+watch(trajectSwitchEpoch, () => {
   if (lawId.value) {
     switchLaw(lawId.value, selectedArticleNumber.value);
   }

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -193,7 +193,11 @@ const {
 // closes the race where a user click lands in the same microtask as
 // the settle — both writes go to `activeTrajectId`, but only the
 // user-driven one bumps the epoch and triggers the refetch.
+// We also refresh the corpus index so the search popover AND the
+// `failedLawName` lookup (used by the 404 inline-dialog) reflect the
+// new traject's law set instead of the previous traject's names.
 watch(trajectSwitchEpoch, () => {
+  loadCorpusLaws();
   if (lawId.value) {
     switchLaw(lawId.value, selectedArticleNumber.value);
   }

--- a/frontend/src/LibraryApp.vue
+++ b/frontend/src/LibraryApp.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed, shallowRef, nextTick, watchEffect } from 'vue';
+import { ref, computed, shallowRef, nextTick, watch, watchEffect } from 'vue';
 import { useRoute, useRouter, onBeforeRouteUpdate } from 'vue-router';
 import yaml from 'js-yaml';
 import ArticleText from './components/ArticleText.vue';
@@ -7,7 +7,9 @@ import MachineReadable from './components/MachineReadable.vue';
 import YamlView from './components/YamlView.vue';
 import ActionSheet from './components/ActionSheet.vue';
 import SearchPopover from './components/SearchPopover.vue';
+import TrajectMenu from './components/TrajectMenu.vue';
 import { useAuth } from './composables/useAuth.js';
+import { useTrajects } from './composables/useTrajects.js';
 import { useFeatureFlags } from './composables/useFeatureFlags.js';
 import { useColorScheme } from './composables/useColorScheme.js';
 import { SUPPORT_EMAIL } from './constants.js';
@@ -165,6 +167,12 @@ const articleNotFound = computed(() =>
   !!(selectedLaw.value && selectedArticleNumber.value && !selectedArticle.value)
 );
 
+// 404 from `loadLaw` typically means the law isn't part of the active
+// traject's corpus (e.g. after switching to a traject that doesn't
+// include this law); the error UI branches on this to render a
+// traject-specific message instead of a generic "niet geladen".
+const lawErrorIs404 = computed(() => lawError.value?.status === 404);
+
 // Reflect navigation depth in the document title:
 //   "Art. 5 · Wet op de zorgtoeslag · RegelRecht"
 // Most-specific first so browser tab truncation preserves the article number.
@@ -273,7 +281,14 @@ async function loadLaw(lawId) {
   try {
     selectedLawLoading.value = true;
     const res = await fetch(`/api/corpus/laws/${encodeURIComponent(lawId)}`);
-    if (!res.ok) throw new Error(`Failed to fetch: ${res.status}`);
+    if (!res.ok) {
+      // Attach the HTTP status so the error UI can render a 404
+      // ("niet beschikbaar in dit traject") differently from a 5xx
+      // without re-parsing the message.
+      const err = new Error(`Failed to fetch: ${res.status}`);
+      err.status = res.status;
+      throw err;
+    }
     if (gen !== loadLawGeneration) return; // stale response, discard
     const text = await res.text();
     selectedLaw.value = yaml.load(text);
@@ -445,6 +460,24 @@ if (route.params.lawId) {
   loadLaw(route.params.lawId);
 }
 loadIndex();
+
+// React to traject switches: the URL stays put (no router.push in
+// `switchTraject`), but the server-side read scope changes — so the
+// law index and the currently-open law need to be refetched. Skip
+// the initial fire when the ref settles to its starting value; only
+// real switches should trigger a reload.
+const { activeTrajectId } = useTrajects();
+watch(activeTrajectId, () => {
+  // Reset error so the loading-gate kicks in before any new 404
+  // (e.g. when the open law isn't part of the new traject's corpus).
+  lawError.value = null;
+  indexError.value = null;
+  loading.value = true;
+  loadIndex();
+  if (selectedLawId.value) {
+    loadLaw(selectedLawId.value);
+  }
+});
 </script>
 
 <template>
@@ -462,6 +495,9 @@ loadIndex();
             </nldd-toolbar-item>
             <nldd-toolbar-item slot="end">
               <nldd-button size="md" start-icon="search" text="Zoeken" @click="openSearch"></nldd-button>
+            </nldd-toolbar-item>
+            <nldd-toolbar-item slot="end">
+              <TrajectMenu id-suffix="lib-md" />
             </nldd-toolbar-item>
             <nldd-toolbar-item slot="end">
               <nldd-button id="settings-menu-btn-md" size="md" start-icon="global-settings" text="Instellingen" expandable popovertarget="settings-menu-md"></nldd-button>
@@ -513,6 +549,9 @@ loadIndex();
                 @click="openSearch"
                 @keydown="onBarSearchKeydown"
               ></nldd-search-field>
+            </nldd-toolbar-item>
+            <nldd-toolbar-item slot="end">
+              <TrajectMenu id-suffix="lib-lg" />
             </nldd-toolbar-item>
             <nldd-toolbar-item slot="end">
               <nldd-button id="settings-menu-btn-lg" size="md" start-icon="global-settings" text="Instellingen" expandable popovertarget="settings-menu-lg"></nldd-button>
@@ -647,8 +686,30 @@ loadIndex();
               <nldd-simple-section width="full" v-else-if="!selectedLawId">
                 <nldd-inline-dialog text="Selecteer een wet"></nldd-inline-dialog>
               </nldd-simple-section>
+              <nldd-simple-section width="full" v-else-if="selectedLawLoading">
+                <!-- Show the loading dialog before any error so a stale
+                     `lawError` from the previous fetch (or a 404 from
+                     before a traject switch) doesn't flash in front of
+                     the user while the new request is still on the
+                     wire. -->
+                <nldd-inline-dialog text="Wet laden…"></nldd-inline-dialog>
+              </nldd-simple-section>
               <nldd-simple-section width="full" v-else-if="lawError">
+                <!-- 404 typically means "law isn't part of the active
+                     traject" (the most common path after a traject
+                     switch on /library/:lawId). Give the user a way
+                     out without leading with a generic error. -->
                 <nldd-inline-dialog
+                  v-if="lawErrorIs404"
+                  variant="alert"
+                  :text="`${indexedLawName} is niet beschikbaar in dit traject`"
+                  supporting-text="Wissel van traject via het menu rechtsboven of ga terug naar het overzicht."
+                >
+                  <nldd-button slot="actions" variant="primary" text="Naar overzicht" @click="goToLibraryRoot"></nldd-button>
+                  <nldd-button slot="actions" variant="secondary" text="Probeer opnieuw" @click="retryLoadLaw"></nldd-button>
+                </nldd-inline-dialog>
+                <nldd-inline-dialog
+                  v-else
                   variant="alert"
                   :text="`${indexedLawName} is niet geladen`"
                   supporting-text="De gegevens konden niet worden opgehaald."
@@ -717,6 +778,9 @@ loadIndex();
               <span>
                 <nldd-icon-button size="lg" icon="search" text="Zoeken" @click="openSearch"></nldd-icon-button>
               </span>
+            </nldd-toolbar-item>
+            <nldd-toolbar-item slot="end">
+              <TrajectMenu id-suffix="lib-sm" />
             </nldd-toolbar-item>
             <nldd-toolbar-item slot="end">
               <span>

--- a/frontend/src/LibraryApp.vue
+++ b/frontend/src/LibraryApp.vue
@@ -587,9 +587,7 @@ watch(trajectSwitchEpoch, () => {
       <nldd-split-view-pane slot="main">
         <nldd-navigation-split-view @back="onPaneBack">
 
-          <!-- Sidebar: Wetten Browser. Hidden on corpus load failure so the
-               navigation-split-view collapses and the main pane carries the
-               error state on its own (mirrors the law-load failure pattern). -->
+          <!-- Sidebar hidden on corpus load failure so the main pane carries the error alone (mirrors law-load failure pattern). -->
           <nldd-split-view-pane v-if="!indexError" slot="sidebar" has-content>
             <nldd-page sticky-header>
               <nldd-top-title-bar slot="header" :text="LIBRARY_HOME_TITLE" collapse-anchor="home-titel"></nldd-top-title-bar>

--- a/frontend/src/LibraryApp.vue
+++ b/frontend/src/LibraryApp.vue
@@ -257,7 +257,10 @@ async function toggleFavorite(lawId) {
   }
 }
 
+let loadIndexGeneration = 0;
+
 async function loadIndex() {
+  const gen = ++loadIndexGeneration;
   try {
     const [corpusRes] = await Promise.all([
       fetch('/api/corpus/laws?limit=1000'),
@@ -266,11 +269,15 @@ async function loadIndex() {
     if (!corpusRes.ok) throw new Error(`Failed to load corpus: ${corpusRes.status}`);
     const corpusLaws = await corpusRes.json();
 
+    if (gen !== loadIndexGeneration) return; // stale response, discard
     laws.value = corpusLaws.sort((a, b) => a.law_id.localeCompare(b.law_id));
   } catch (e) {
+    if (gen !== loadIndexGeneration) return;
     indexError.value = e;
   } finally {
-    loading.value = false;
+    if (gen === loadIndexGeneration) {
+      loading.value = false;
+    }
   }
 }
 
@@ -463,15 +470,17 @@ loadIndex();
 
 // React to traject switches: the URL stays put (no router.push in
 // `switchTraject`), but the server-side read scope changes — so the
-// law index and the currently-open law need to be refetched. Skip
-// the initial fire by gating on `trajectsReady`: that flag flips on
-// only *after* `loadTrajects` has settled `activeTrajectId` from
-// null → session-traject-id and Vue has flushed the resulting watch
-// callbacks. So the cold-load transition is ignored and only real
-// user-driven `switchTraject` calls trigger a reload.
-const { activeTrajectId, trajectsReady } = useTrajects();
-watch(activeTrajectId, () => {
-  if (!trajectsReady.value) return;
+// law index and the currently-open law need to be refetched. Watch
+// `trajectSwitchEpoch` (bumped only by user-driven `switchTraject`
+// calls) rather than `activeTrajectId` itself: the initial null →
+// session-traject-id settle done by `loadTrajects` does not touch
+// the counter, so the cold-load transition is ignored. Using a
+// counter (instead of a one-shot `trajectsReady` gate) also closes
+// the race where a user click lands in the same microtask as the
+// settle — both writes go to `activeTrajectId`, but only the
+// user-driven one bumps the epoch and triggers the refetch.
+const { trajectSwitchEpoch } = useTrajects();
+watch(trajectSwitchEpoch, () => {
   // Reset error so the loading-gate kicks in before any new 404
   // (e.g. when the open law isn't part of the new traject's corpus).
   lawError.value = null;

--- a/frontend/src/LibraryApp.vue
+++ b/frontend/src/LibraryApp.vue
@@ -296,8 +296,14 @@ async function loadLaw(lawId) {
       err.status = res.status;
       throw err;
     }
+    // Two staleness checks: the first short-circuits a stale 200
+    // BEFORE we await the response body (saves the body read), the
+    // second catches a newer `loadLaw` call that landed *during*
+    // `res.text()` — the body-read await is a real race window that
+    // a single before-body check would miss.
+    if (gen !== loadLawGeneration) return;
     const text = await res.text();
-    if (gen !== loadLawGeneration) return; // stale response, discard
+    if (gen !== loadLawGeneration) return;
     selectedLaw.value = yaml.load(text);
     // selectedArticleNumber is set from the route on initial mount and via
     // onBeforeRouteUpdate; we don't validate here so an invalid number

--- a/frontend/src/LibraryApp.vue
+++ b/frontend/src/LibraryApp.vue
@@ -464,10 +464,14 @@ loadIndex();
 // React to traject switches: the URL stays put (no router.push in
 // `switchTraject`), but the server-side read scope changes — so the
 // law index and the currently-open law need to be refetched. Skip
-// the initial fire when the ref settles to its starting value; only
-// real switches should trigger a reload.
-const { activeTrajectId } = useTrajects();
+// the initial fire by gating on `trajectsReady`: that flag flips on
+// only *after* `loadTrajects` has settled `activeTrajectId` from
+// null → session-traject-id and Vue has flushed the resulting watch
+// callbacks. So the cold-load transition is ignored and only real
+// user-driven `switchTraject` calls trigger a reload.
+const { activeTrajectId, trajectsReady } = useTrajects();
 watch(activeTrajectId, () => {
+  if (!trajectsReady.value) return;
   // Reset error so the loading-gate kicks in before any new 404
   // (e.g. when the open law isn't part of the new traject's corpus).
   lawError.value = null;

--- a/frontend/src/LibraryApp.vue
+++ b/frontend/src/LibraryApp.vue
@@ -296,8 +296,8 @@ async function loadLaw(lawId) {
       err.status = res.status;
       throw err;
     }
-    if (gen !== loadLawGeneration) return; // stale response, discard
     const text = await res.text();
+    if (gen !== loadLawGeneration) return; // stale response, discard
     selectedLaw.value = yaml.load(text);
     // selectedArticleNumber is set from the route on initial mount and via
     // onBeforeRouteUpdate; we don't validate here so an invalid number

--- a/frontend/src/LibraryApp.vue
+++ b/frontend/src/LibraryApp.vue
@@ -10,6 +10,7 @@ import SearchPopover from './components/SearchPopover.vue';
 import TrajectMenu from './components/TrajectMenu.vue';
 import { useAuth } from './composables/useAuth.js';
 import { useTrajects } from './composables/useTrajects.js';
+import { lawFetchError } from './composables/useLaw.js';
 import { useFeatureFlags } from './composables/useFeatureFlags.js';
 import { useColorScheme } from './composables/useColorScheme.js';
 import { SUPPORT_EMAIL } from './constants.js';
@@ -167,10 +168,7 @@ const articleNotFound = computed(() =>
   !!(selectedLaw.value && selectedArticleNumber.value && !selectedArticle.value)
 );
 
-// 404 from `loadLaw` typically means the law isn't part of the active
-// traject's corpus (e.g. after switching to a traject that doesn't
-// include this law); the error UI branches on this to render a
-// traject-specific message instead of a generic "niet geladen".
+// 404 means the law isn't in the active traject's corpus; the error UI shows a traject-specific message.
 const lawErrorIs404 = computed(() => lawError.value?.status === 404);
 
 // Reflect navigation depth in the document title:
@@ -288,19 +286,8 @@ async function loadLaw(lawId) {
   try {
     selectedLawLoading.value = true;
     const res = await fetch(`/api/corpus/laws/${encodeURIComponent(lawId)}`);
-    if (!res.ok) {
-      // Attach the HTTP status so the error UI can render a 404
-      // ("niet beschikbaar in dit traject") differently from a 5xx
-      // without re-parsing the message.
-      const err = new Error(`Failed to fetch: ${res.status}`);
-      err.status = res.status;
-      throw err;
-    }
-    // Two staleness checks: the first short-circuits a stale 200
-    // BEFORE we await the response body (saves the body read), the
-    // second catches a newer `loadLaw` call that landed *during*
-    // `res.text()` — the body-read await is a real race window that
-    // a single before-body check would miss.
+    if (!res.ok) throw lawFetchError(res.status);
+    // Gate before and after `res.text()`: skip the body read for stale 200s, and catch races during it.
     if (gen !== loadLawGeneration) return;
     const text = await res.text();
     if (gen !== loadLawGeneration) return;
@@ -474,17 +461,7 @@ if (route.params.lawId) {
 }
 loadIndex();
 
-// React to traject switches: the URL stays put (no router.push in
-// `switchTraject`), but the server-side read scope changes — so the
-// law index and the currently-open law need to be refetched. Watch
-// `trajectSwitchEpoch` (bumped only by user-driven `switchTraject`
-// calls) rather than `activeTrajectId` itself: the initial null →
-// session-traject-id settle done by `loadTrajects` does not touch
-// the counter, so the cold-load transition is ignored. Using a
-// counter (instead of a one-shot `trajectsReady` gate) also closes
-// the race where a user click lands in the same microtask as the
-// settle — both writes go to `activeTrajectId`, but only the
-// user-driven one bumps the epoch and triggers the refetch.
+// On user-driven traject switch (epoch bump): refetch corpus index and the open law.
 const { trajectSwitchEpoch } = useTrajects();
 watch(trajectSwitchEpoch, () => {
   // Reset error so the loading-gate kicks in before any new 404
@@ -706,18 +683,11 @@ watch(trajectSwitchEpoch, () => {
                 <nldd-inline-dialog text="Selecteer een wet"></nldd-inline-dialog>
               </nldd-simple-section>
               <nldd-simple-section width="full" v-else-if="selectedLawLoading">
-                <!-- Show the loading dialog before any error so a stale
-                     `lawError` from the previous fetch (or a 404 from
-                     before a traject switch) doesn't flash in front of
-                     the user while the new request is still on the
-                     wire. -->
+                <!-- Loading takes precedence over `lawError` to avoid flashing a stale error during a refetch. -->
                 <nldd-inline-dialog text="Wet laden…"></nldd-inline-dialog>
               </nldd-simple-section>
               <nldd-simple-section width="full" v-else-if="lawError">
-                <!-- 404 typically means "law isn't part of the active
-                     traject" (the most common path after a traject
-                     switch on /library/:lawId). Give the user a way
-                     out without leading with a generic error. -->
+                <!-- 404 = law not in active traject; give the user an exit instead of a generic error. -->
                 <nldd-inline-dialog
                   v-if="lawErrorIs404"
                   variant="alert"

--- a/frontend/src/LibraryApp.vue
+++ b/frontend/src/LibraryApp.vue
@@ -265,9 +265,10 @@ async function loadIndex() {
       loadFavorites(),
     ]);
     if (!corpusRes.ok) throw new Error(`Failed to load corpus: ${corpusRes.status}`);
+    // Gate before and after json(): skip parsing for stale 200s, and catch races during it.
+    if (gen !== loadIndexGeneration) return;
     const corpusLaws = await corpusRes.json();
-
-    if (gen !== loadIndexGeneration) return; // stale response, discard
+    if (gen !== loadIndexGeneration) return;
     laws.value = corpusLaws.sort((a, b) => a.law_id.localeCompare(b.law_id));
   } catch (e) {
     if (gen !== loadIndexGeneration) return;

--- a/frontend/src/composables/useLaw.js
+++ b/frontend/src/composables/useLaw.js
@@ -171,9 +171,12 @@ export function useLaw(lawParam, articleParam) {
         selectedArticleNumber.value = String(articles.value[0].number);
       }
     } catch (e) {
+      if (version !== switchVersion) return; // stale, discard
       error.value = e;
     } finally {
-      loading.value = false;
+      if (version === switchVersion) {
+        loading.value = false;
+      }
     }
   }
 

--- a/frontend/src/composables/useLaw.js
+++ b/frontend/src/composables/useLaw.js
@@ -117,8 +117,13 @@ export function useLaw(lawParam, articleParam) {
       loading.value = true;
       const res = await fetch(yamlUrl);
       if (!res.ok) throw lawFetchError(res.status);
+      // Two staleness checks: before the body-read await to short-
+      // circuit a stale 200 without paying for `res.text()`, and after
+      // it to catch a `switchLaw` (or a follow-up `load`) that started
+      // *during* the body read.
+      if (version !== switchVersion) return;
       const text = await res.text();
-      if (version !== switchVersion) return; // stale, discard
+      if (version !== switchVersion) return;
       rawYaml.value = text;
       law.value = yaml.load(text);
       // Populate cache

--- a/frontend/src/composables/useLaw.js
+++ b/frontend/src/composables/useLaw.js
@@ -35,10 +35,22 @@ export function resolveLawName(law) {
   return nameRef || law.$id || '';
 }
 
+/**
+ * Build an `Error` carrying the HTTP status of a failed law fetch so
+ * call-site error UI can distinguish "law isn't there" (404 — typically
+ * surfaces as a traject-specific "niet beschikbaar in dit traject"
+ * message) from generic transport/server failures.
+ */
+function lawFetchError(status) {
+  const err = new Error(`Failed to fetch: ${status}`);
+  err.status = status;
+  return err;
+}
+
 export async function fetchLaw(lawId) {
   if (lawCache.has(lawId)) return lawCache.get(lawId);
   const res = await fetch(`/api/corpus/laws/${encodeURIComponent(lawId)}`);
-  if (!res.ok) throw new Error(`Failed to fetch: ${res.status}`);
+  if (!res.ok) throw lawFetchError(res.status);
   const text = await res.text();
   const law = yaml.load(text);
   const entry = { law, rawYaml: text, lawName: resolveLawName(law) };
@@ -88,7 +100,7 @@ export function useLaw(lawParam, articleParam) {
     try {
       loading.value = true;
       const res = await fetch(yamlUrl);
-      if (!res.ok) throw new Error(`Failed to fetch: ${res.status}`);
+      if (!res.ok) throw lawFetchError(res.status);
       const text = await res.text();
       rawYaml.value = text;
       law.value = yaml.load(text);

--- a/frontend/src/composables/useLaw.js
+++ b/frontend/src/composables/useLaw.js
@@ -96,12 +96,29 @@ export function useLaw(lawParam, articleParam) {
     ) ?? null;
   });
 
+  // Shared discriminator for the initial `load()` and every subsequent
+  // `switchLaw()`. Bumped at the start of each operation; awaits compare
+  // their captured version against the latest one before writing reactive
+  // state, so an in-flight load that's been superseded by a traject switch
+  // (or a follow-up switchLaw) cannot clobber the new law's content.
+  let switchVersion = 0;
+
+  /**
+   * Initial fetch for the law passed to `useLaw`. Shares the
+   * `switchVersion` discriminator with `switchLaw` so a traject switch
+   * fired while this XHR is in flight (the traject watcher in
+   * `EditorApp.vue` calls `switchLaw` on epoch change) cannot have its
+   * fresh content overwritten by the stale initial load's late
+   * resolution.
+   */
   async function load() {
+    const version = ++switchVersion;
     try {
       loading.value = true;
       const res = await fetch(yamlUrl);
       if (!res.ok) throw lawFetchError(res.status);
       const text = await res.text();
+      if (version !== switchVersion) return; // stale, discard
       rawYaml.value = text;
       law.value = yaml.load(text);
       // Populate cache
@@ -117,9 +134,12 @@ export function useLaw(lawParam, articleParam) {
         }
       }
     } catch (e) {
+      if (version !== switchVersion) return; // stale, discard
       error.value = e;
     } finally {
-      loading.value = false;
+      if (version === switchVersion) {
+        loading.value = false;
+      }
     }
   }
 
@@ -127,8 +147,6 @@ export function useLaw(lawParam, articleParam) {
 
   // Derive the law ID from the parsed law or the original param
   const lawId = computed(() => law.value?.$id || lawParam);
-
-  let switchVersion = 0;
 
   async function switchLaw(newLawId, articleNumber) {
     const version = ++switchVersion;

--- a/frontend/src/composables/useLaw.js
+++ b/frontend/src/composables/useLaw.js
@@ -35,13 +35,8 @@ export function resolveLawName(law) {
   return nameRef || law.$id || '';
 }
 
-/**
- * Build an `Error` carrying the HTTP status of a failed law fetch so
- * call-site error UI can distinguish "law isn't there" (404 — typically
- * surfaces as a traject-specific "niet beschikbaar in dit traject"
- * message) from generic transport/server failures.
- */
-function lawFetchError(status) {
+// Carry HTTP status on the Error so callers can branch on `.status === 404`.
+export function lawFetchError(status) {
   const err = new Error(`Failed to fetch: ${status}`);
   err.status = status;
   return err;
@@ -96,31 +91,17 @@ export function useLaw(lawParam, articleParam) {
     ) ?? null;
   });
 
-  // Shared discriminator for the initial `load()` and every subsequent
-  // `switchLaw()`. Bumped at the start of each operation; awaits compare
-  // their captured version against the latest one before writing reactive
-  // state, so an in-flight load that's been superseded by a traject switch
-  // (or a follow-up switchLaw) cannot clobber the new law's content.
+  // Shared version counter for `load()` and `switchLaw()`; stale awaits compare and discard.
   let switchVersion = 0;
 
-  /**
-   * Initial fetch for the law passed to `useLaw`. Shares the
-   * `switchVersion` discriminator with `switchLaw` so a traject switch
-   * fired while this XHR is in flight (the traject watcher in
-   * `EditorApp.vue` calls `switchLaw` on epoch change) cannot have its
-   * fresh content overwritten by the stale initial load's late
-   * resolution.
-   */
+  // Initial fetch; shares `switchVersion` with `switchLaw` so a mid-flight traject switch wins.
   async function load() {
     const version = ++switchVersion;
     try {
       loading.value = true;
       const res = await fetch(yamlUrl);
       if (!res.ok) throw lawFetchError(res.status);
-      // Two staleness checks: before the body-read await to short-
-      // circuit a stale 200 without paying for `res.text()`, and after
-      // it to catch a `switchLaw` (or a follow-up `load`) that started
-      // *during* the body read.
+      // Gate before and after `res.text()`: skip the body read for stale 200s, and catch races during it.
       if (version !== switchVersion) return;
       const text = await res.text();
       if (version !== switchVersion) return;

--- a/frontend/src/composables/useTrajects.js
+++ b/frontend/src/composables/useTrajects.js
@@ -1,11 +1,11 @@
-import { computed, nextTick, ref } from 'vue';
+import { computed, ref } from 'vue';
 import { clearLawCache } from './useLaw.js';
 
 const trajects = ref([]);
 const activeTrajectId = ref(null);
 const loading = ref(true);
 const error = ref(null);
-const trajectsReady = ref(false);
+const trajectSwitchEpoch = ref(0);
 
 let readyPromise = null;
 
@@ -32,13 +32,6 @@ async function loadTrajects() {
   } finally {
     loading.value = false;
   }
-  // Mark trajects ready *after* Vue has flushed the watchers on
-  // `activeTrajectId` for the initial settle. Page-component
-  // watchers gate on `trajectsReady.value` so they skip the
-  // null → session-id transition done by this loader, and only
-  // react to user-driven `switchTraject` calls after that.
-  await nextTick();
-  trajectsReady.value = true;
 }
 
 export function ensureTrajectsReady() {
@@ -62,6 +55,12 @@ export async function switchTraject(trajectId) {
   if (!resp.ok) throw new Error(`Failed to switch traject: ${resp.status}`);
   const body = await resp.json();
   activeTrajectId.value = body.traject_id || null;
+  // Bump on every user-driven switch. Page components watch this
+  // counter instead of `activeTrajectId` for refetch triggers, so
+  // `loadTrajects`'s null → session-id settle (which does NOT touch
+  // this counter) never causes a spurious reload, and a user click
+  // arriving in the same microtask as the settle is still observed.
+  trajectSwitchEpoch.value++;
 
   // After a successful switch the read scope on the server changed —
   // GET /api/corpus/laws/... now serves the new traject's branch
@@ -104,7 +103,7 @@ export function useTrajects() {
     activeTraject,
     loading,
     error,
-    trajectsReady,
+    trajectSwitchEpoch,
     switchTraject,
     createTraject,
     refreshTrajects,

--- a/frontend/src/composables/useTrajects.js
+++ b/frontend/src/composables/useTrajects.js
@@ -1,5 +1,4 @@
 import { computed, ref } from 'vue';
-import router from '../router.js';
 import { clearLawCache } from './useLaw.js';
 
 const trajects = ref([]);
@@ -59,19 +58,14 @@ export async function switchTraject(trajectId) {
   // After a successful switch the read scope on the server changed —
   // GET /api/corpus/laws/... now serves the new traject's branch
   // content (or the global view when the active id was cleared). Drop
-  // every cached law-content entry so the next fetch hits the API and
-  // navigate to the library so any open editor doesn't keep showing a
-  // mix of old (cached) and new (refetched) content.
+  // every cached law-content entry so the next fetch hits the API.
+  //
+  // Stay on the current route: LibraryApp and EditorApp watch
+  // `activeTrajectId` and re-fetch the open law (or surface a 404 when
+  // the law isn't part of the new traject). Navigating away on every
+  // switch destroyed that context — the user landed on the library
+  // overview even when they were halfway through editing.
   clearLawCache();
-  // `navigate from anywhere` — non-Vue context, so we use the router
-  // export directly. Best-effort: if we're already at `/library`,
-  // `push` is a no-op.
-  try {
-    await router.push('/library');
-  } catch (_e) {
-    // NavigationDuplicated / NavigationAborted is benign; the cache
-    // clear above is the actually-load-bearing part of the switch.
-  }
   return activeTrajectId.value;
 }
 

--- a/frontend/src/composables/useTrajects.js
+++ b/frontend/src/composables/useTrajects.js
@@ -55,24 +55,10 @@ export async function switchTraject(trajectId) {
   if (!resp.ok) throw new Error(`Failed to switch traject: ${resp.status}`);
   const body = await resp.json();
   activeTrajectId.value = body.traject_id || null;
-  // Bump on every user-driven switch. Page components watch this
-  // counter instead of `activeTrajectId` for refetch triggers, so
-  // `loadTrajects`'s null → session-id settle (which does NOT touch
-  // this counter) never causes a spurious reload, and a user click
-  // arriving in the same microtask as the settle is still observed.
+  // Page components watch this counter (not activeTrajectId) so the initial null→id settle doesn't trigger a spurious refetch.
   trajectSwitchEpoch.value++;
 
-  // After a successful switch the read scope on the server changed —
-  // GET /api/corpus/laws/... now serves the new traject's branch
-  // content (or the global view when the active id was cleared). Drop
-  // every cached law-content entry so the next fetch hits the API.
-  //
-  // Stay on the current route: LibraryApp and EditorApp watch
-  // `trajectSwitchEpoch` (bumped just above) and re-fetch the open law
-  // (or surface a 404 when the law isn't part of the new traject).
-  // Navigating away on every switch destroyed that context — the user
-  // landed on the library overview even when they were halfway through
-  // editing.
+  // Read scope changed server-side; drop cached law content so the next fetch hits the API. Stay on route — pages watch the epoch and refetch in place.
   clearLawCache();
   return activeTrajectId.value;
 }

--- a/frontend/src/composables/useTrajects.js
+++ b/frontend/src/composables/useTrajects.js
@@ -1,10 +1,11 @@
-import { computed, ref } from 'vue';
+import { computed, nextTick, ref } from 'vue';
 import { clearLawCache } from './useLaw.js';
 
 const trajects = ref([]);
 const activeTrajectId = ref(null);
 const loading = ref(true);
 const error = ref(null);
+const trajectsReady = ref(false);
 
 let readyPromise = null;
 
@@ -31,6 +32,13 @@ async function loadTrajects() {
   } finally {
     loading.value = false;
   }
+  // Mark trajects ready *after* Vue has flushed the watchers on
+  // `activeTrajectId` for the initial settle. Page-component
+  // watchers gate on `trajectsReady.value` so they skip the
+  // null → session-id transition done by this loader, and only
+  // react to user-driven `switchTraject` calls after that.
+  await nextTick();
+  trajectsReady.value = true;
 }
 
 export function ensureTrajectsReady() {
@@ -96,6 +104,7 @@ export function useTrajects() {
     activeTraject,
     loading,
     error,
+    trajectsReady,
     switchTraject,
     createTraject,
     refreshTrajects,

--- a/frontend/src/composables/useTrajects.js
+++ b/frontend/src/composables/useTrajects.js
@@ -68,10 +68,11 @@ export async function switchTraject(trajectId) {
   // every cached law-content entry so the next fetch hits the API.
   //
   // Stay on the current route: LibraryApp and EditorApp watch
-  // `activeTrajectId` and re-fetch the open law (or surface a 404 when
-  // the law isn't part of the new traject). Navigating away on every
-  // switch destroyed that context — the user landed on the library
-  // overview even when they were halfway through editing.
+  // `trajectSwitchEpoch` (bumped just above) and re-fetch the open law
+  // (or surface a 404 when the law isn't part of the new traject).
+  // Navigating away on every switch destroyed that context — the user
+  // landed on the library overview even when they were halfway through
+  // editing.
   clearLawCache();
   return activeTrajectId.value;
 }


### PR DESCRIPTION
## Context

Drie UX-gaten op de frontend kant van trajecten, doortrekkend op #662. De backend is na #662 al traject-aware op alle read-endpoints — dit is een pure UI-PR.

## Summary

1. **Library traject-aware UI** — `TrajectMenu` zit nu in de library-toolbar (md / lg / sm responsive slots). Geen aparte logica nodig: het component leunt al op `useTrajects()`. De backend serveert `/api/corpus/laws*` al via `resolve_read_corpus`, dus het was puur de UI die ontbrak.

2. **Switch blijft op huidige pagina** — `useTrajects.switchTraject` doet geen `router.push('/library')` meer. URL blijft staan, `LibraryApp` en `EditorApp` watchen `activeTrajectId` en refetchen de openstaande wet in het nieuwe traject. Is die wet niet beschikbaar in het nieuwe traject → 404-flow met traject-specifieke melding ("is niet beschikbaar in dit traject") en een `Naar overzicht`-knop.

3. **Loading-gate vóór error** — beide apps tonen `Wet laden…` (inline-dialog, want het design system heeft geen spinner) zolang de fetch loopt. Pas wanneer `loading=false` valt de UI eventueel door naar de error/404-pagina. Voorkomt de \"wet niet beschikbaar\"-flash die je zag op switch- en initial-load.

Klein bijproduct: `useLaw.fetchLaw` / `useLaw.load` decoreren de gegooide `Error` nu met `.status`, zodat de UI kan matchen op 404 zonder de message-string te parsen. Zelfde patroon in `LibraryApp.loadLaw`.

## Test plan

- [x] `npm run build` (frontend bouwt schoon)
- [x] `npm test` (vitest: 191/191 groen)
- [ ] Manuele verificatie via PR-preview:
  - Open `/library/zorgtoeslagwet/1`, switch traject → URL blijft, content laadt opnieuw
  - Open `/editor/zorgtoeslagwet/1`, switch naar een traject waar die wet niet in zit → \"niet beschikbaar in dit traject\"-melding (geen flash)
  - Laad een willekeurige editor-pagina cold → eerst `Wet laden…`, dan content / error (niet meer direct \"niet geladen\")

## Out of scope

- Backend-wijzigingen — `resolve_read_corpus` is na #662 klaar
- Annotation-reads via `/data/...`-mirror (orthogonale isolation-gap; eigen follow-up)
- Een dedicated `<Spinner>`-component in het design system (gebruik het bestaande `nldd-inline-dialog`-patroon)