### PR TITLE
docs: point schema references to schema/latest

### DIFF
--- a/.claude/skills/law-generate/SKILL.md
+++ b/.claude/skills/law-generate/SKILL.md
@@ -19,7 +19,7 @@ Generates `machine_readable` sections for Dutch law YAML files through an iterat
 cycle of creation, validation, and BDD testing.
 
 **CRITICAL**: All generated YAML MUST pass `just validate <file>`. The schema is the
-single source of truth. When in doubt, consult `schema/v0.5.1/schema.json` and study
+single source of truth. When in doubt, consult `schema/latest/schema.json` and study
 working examples in the corpus.
 
 ## Setup

--- a/.claude/skills/law-generate/examples.md
+++ b/.claude/skills/law-generate/examples.md
@@ -369,7 +369,7 @@ actions:
 ```
 
 **Key points:**
-- Use `IF` with `cases`/`default` for multi-branch conditionals (SWITCH was removed in v0.5.1)
+- Use `IF` with `cases`/`default` for multi-branch conditionals (SWITCH was removed in v0.5.0)
 - Cases are evaluated in order; the first matching case wins
 - Each case has `when` (condition) and `then` (result value)
 - `default` is the fallback if no case matches

--- a/.claude/skills/law-generate/examples.md
+++ b/.claude/skills/law-generate/examples.md
@@ -1,6 +1,6 @@
 # Law Generate - Usage Examples
 
-All examples below conform to schema v0.5.1 and pass `just validate`.
+All examples below pass `just validate` against the latest schema.
 
 ## Example 1: Simple Constant (direct value assignment)
 
@@ -369,7 +369,7 @@ actions:
 ```
 
 **Key points:**
-- Use `IF` with `cases`/`default` for multi-branch conditionals (SWITCH does not exist in v0.5.1)
+- Use `IF` with `cases`/`default` for multi-branch conditionals (SWITCH was removed in v0.5.1)
 - Cases are evaluated in order; the first matching case wins
 - Each case has `when` (condition) and `then` (result value)
 - `default` is the fallback if no case matches

--- a/.claude/skills/law-generate/reference.md
+++ b/.claude/skills/law-generate/reference.md
@@ -1,6 +1,6 @@
 # Law Generate - Technical Reference
 
-Based on schema v0.5.1 (`schema/v0.5.1/schema.json`). Validate with `just validate`.
+Based on the latest schema (`schema/latest/schema.json`). Validate with `just validate`.
 
 ## Complete Machine-Readable Section Structure
 
@@ -498,7 +498,7 @@ This is the opposite of English. So `€1.234,56` means one thousand two hundred
 
 ## External Resources
 
-- **Schema**: `schema/v0.5.1/schema.json` (v0.5.1)
+- **Schema**: `schema/latest/schema.json`
 - **Working examples**:
   - `corpus/regulation/nl/wet/wet_op_de_zorgtoeslag/2025-01-01.yaml` — basic patterns
   - `corpus/regulation/nl/wet/algemene_wet_bestuursrecht/2026-01-01.yaml` — hooks, procedures

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ git worktree add .worktrees/feature-branch feature-branch
 ### Law Format
 
 Laws are stored as article-based YAML files conforming to the official JSON schema:
-- Schema: `https://raw.githubusercontent.com/MinBZK/regelrecht/refs/heads/main/schema/latest/schema.json`
+- Schema: `schema/latest/schema.json` (symlink to the current version directory in this repo)
 
 ### Cross-Law References
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ git worktree add .worktrees/feature-branch feature-branch
 ### Law Format
 
 Laws are stored as article-based YAML files conforming to the official JSON schema:
-- Schema: `https://raw.githubusercontent.com/MinBZK/regelrecht/refs/heads/main/schema/v0.4.0/schema.json`
+- Schema: `https://raw.githubusercontent.com/MinBZK/regelrecht/refs/heads/main/schema/latest/schema.json`
 
 ### Cross-Law References
 


### PR DESCRIPTION
## Summary
- Replace `schema/v0.5.1/schema.json` references in the law-generate skill (used by both the claude and opencode enrichers) with `schema/latest/schema.json` so the LLMs always pick up the current schema.
- Update the stale `schema/v0.4.0` reference in `CLAUDE.md` to `schema/latest` for the same reason.
- Historical notes describing when operators were added/removed (e.g. "SWITCH was removed in v0.5.1") are kept as-is — they document change moments, not the current version.

## Why
The enricher (`packages/pipeline/src/enrich.rs`) instructs both providers to read `.claude/skills/law-generate/{SKILL.md,reference.md,examples.md}`. The schema version was hardcoded in those files at v0.5.1 while the corpus is at v0.5.2 (and `schema/latest -> v0.5.2`). Pointing at `schema/latest` avoids needing to bump the skill on every minor schema release.

## Test plan
- [ ] Trigger an enrichment run on a sample law and confirm the LLM picks up the latest schema operators / regulatory_layer values