### PR TITLE
fix(editor): notitie-leespad via API (sluit gap #662)

### DIFF
--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -194,6 +194,7 @@ const {
   issues: noteIssues,
   loading: notesLoading,
   error: notesError,
+  reload: reloadNotes,
 } = useNotes(lawId, selectedArticle);
 
 // Notes are a layer over the Tekst pane, not a separate pane. This toggle is
@@ -358,6 +359,12 @@ async function saveNotesToRepo() {
     } else {
       notesSaveStatus.value = 'Notities opgeslagen.';
     }
+    // After save, drafts are cleared but useNotes still serves the
+    // pre-save cached resolution (typically []). Force a refetch so
+    // the just-committed notes show up immediately instead of only
+    // after the user navigates away and back. NoChange also refetches
+    // — it's cheap and keeps the post-save state consistent.
+    await reloadNotes();
   } catch (e) {
     notesSaveError.value = e?.message || 'Opslaan mislukt';
   } finally {

--- a/frontend/src/composables/useNotes.js
+++ b/frontend/src/composables/useNotes.js
@@ -127,6 +127,22 @@ export function useNotes(lawId, selectedArticle) {
   watch(lawId, load, { immediate: true });
 
   /**
+   * Force a fresh fetch for the current law: drop its cache entry first
+   * so `load()` can't shortcut to the previously-resolved value, then
+   * run `load`. Used after `saveToRepo` so a just-committed note shows
+   * up immediately instead of waiting for a navigation away and back.
+   *
+   * `load()` alone won't do — it returns the cached `[]` from the
+   * first pre-save fetch and silently leaves the user looking at an
+   * empty notes pane right after they hit "Opslaan".
+   */
+  async function reload() {
+    const id = lawId.value;
+    if (id) cache.delete(id);
+    await load();
+  }
+
+  /**
    * Notes whose match falls in the currently-selected article, each with the
    * resolved span(s) for that article. Notes that are orphaned, ambiguous, or
    * failed to parse are surfaced separately via `issues` so the UI can show
@@ -167,7 +183,7 @@ export function useNotes(lawId, selectedArticle) {
       })),
   );
 
-  return { notesForArticle, issues, loading, error, reload: load };
+  return { notesForArticle, issues, loading, error, reload };
 }
 
 /**

--- a/frontend/src/composables/useNotes.js
+++ b/frontend/src/composables/useNotes.js
@@ -23,6 +23,21 @@ import { useEngine } from './useEngine.js';
 const cache = new Map();
 
 /**
+ * Drop every cached resolved-notes entry. Called by the traject switcher
+ * after a successful active-traject change so the next read re-fetches
+ * via the API instead of returning a previously cached version from
+ * another traject (or from the no-traject scope).
+ *
+ * Mirrors `clearLawCache` in `useLaw.js`: notes are scoped per traject on
+ * the backend (each traject reads from its own writable branch via
+ * `GET /api/corpus/laws/{id}/annotations`), so the in-memory cache must
+ * invalidate alongside the law cache.
+ */
+export function clearNotesCache() {
+  cache.clear();
+}
+
+/**
  * @param {import('vue').Ref<string>} lawId        reactive law $id
  * @param {import('vue').Ref<object>} selectedArticle reactive current article
  */
@@ -68,8 +83,14 @@ export function useNotes(lawId, selectedArticle) {
     loading.value = true;
     error.value = null;
     try {
+      // Route through editor-api so reads pick up the active traject's
+      // branch content (where `save_annotations` writes). The static
+      // `/data/annotations/` mirror — baked into the frontend container
+      // by `copy-laws.js` — only reflects central main at image-build
+      // time and missed every API-saved note (the gap #662 documented
+      // as out-of-scope).
       const res = await fetch(
-        `/data/annotations/${encodeURIComponent(id)}/annotations.yaml`,
+        `/api/corpus/laws/${encodeURIComponent(id)}/annotations`,
       );
       if (res.status === 404) {
         // A law without a sidecar is normal, not an error.

--- a/frontend/src/composables/useTrajects.js
+++ b/frontend/src/composables/useTrajects.js
@@ -1,5 +1,6 @@
 import { computed, ref } from 'vue';
 import { clearLawCache } from './useLaw.js';
+import { clearNotesCache } from './useNotes.js';
 
 const trajects = ref([]);
 const activeTrajectId = ref(null);
@@ -58,8 +59,9 @@ export async function switchTraject(trajectId) {
   // Page components watch this counter (not activeTrajectId) so the initial null→id settle doesn't trigger a spurious refetch.
   trajectSwitchEpoch.value++;
 
-  // Read scope changed server-side; drop cached law content so the next fetch hits the API. Stay on route — pages watch the epoch and refetch in place.
+  // Read scope changed server-side; drop cached law content and resolved notes so the next fetch hits the API. Stay on route — pages watch the epoch and refetch in place.
   clearLawCache();
+  clearNotesCache();
   return activeTrajectId.value;
 }
 

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -386,6 +386,64 @@ pub async fn get_scenario(
     ))
 }
 
+/// GET /api/corpus/laws/{law_id}/annotations — return the law's stand-off
+/// notes sidecar.
+///
+/// Routed through the same backend as `save_annotations`: with an active
+/// traject the read hits that traject's writable backend (its branch),
+/// so a note just appended by `save_annotations` is visible on the next
+/// refresh — the gap that #662 left open when it moved law reads to the
+/// API but kept annotation reads on the static `/data` mirror baked into
+/// the frontend container.
+///
+/// Without an active traject the read degrades to the global corpus's
+/// resolved backend for the law (the central source's main view), matching
+/// the static-mirror semantics the frontend used to rely on.
+///
+/// A missing sidecar returns 404 — "law without notes" is the normal
+/// case and `useNotes.js` already treats it as a non-error.
+pub async fn get_annotations(
+    State(state): State<AppState>,
+    session: Session,
+    Path(law_id): Path<String>,
+) -> Result<
+    (
+        StatusCode,
+        [(axum::http::HeaderName, &'static str); 1],
+        String,
+    ),
+    (StatusCode, String),
+> {
+    let scope = resolve_read_corpus(&state, &session).await;
+    let resolved = resolve_backend_for_law(scope.corpus(), &law_id).await?;
+
+    // RFC-018 §1: keyed by law id at the source root, regardless of where
+    // the law file lives. Same path the `save_annotations` write uses.
+    let relative_path = PathBuf::from("annotations")
+        .join(&law_id)
+        .join("annotations.yaml");
+
+    let backend = resolved.backend.lock().await;
+    let content = backend
+        .read_file(&relative_path)
+        .await
+        .map_err(|e| {
+            tracing::warn!(law_id = %law_id, error = %e, "get_annotations backend read failed");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to read annotations".to_string(),
+            )
+        })?
+        .ok_or((StatusCode::NOT_FOUND, "Annotations not found".to_string()))?;
+    drop(backend);
+
+    Ok((
+        StatusCode::OK,
+        [(axum::http::header::CONTENT_TYPE, "text/yaml; charset=utf-8")],
+        content,
+    ))
+}
+
 // ---------------------------------------------------------------------------
 // Scenario write helpers
 // ---------------------------------------------------------------------------

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -425,10 +425,16 @@ fn resolve_annotation_read_backend(
                 .get(&law.source_id)
                 .cloned()
                 .unwrap_or_else(|| law.source_id.clone());
-            let entry = traject.corpus.backends.get(&target_source_id).ok_or((
-                StatusCode::SERVICE_UNAVAILABLE,
-                "Writable backend not initialised".to_string(),
-            ))?;
+            let entry = traject
+                .corpus
+                .backends
+                .get(&target_source_id)
+                .ok_or_else(|| {
+                    (
+                        StatusCode::SERVICE_UNAVAILABLE,
+                        "Writable backend not initialised".to_string(),
+                    )
+                })?;
             Ok(entry.backend.clone())
         }
         ReadScope::Global(corpus) => {

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -386,6 +386,71 @@ pub async fn get_scenario(
     ))
 }
 
+/// Shared backend handle: a clone of the entry's `Arc<Mutex<...>>` from
+/// the corpus state. The `Mutex` is held only across a single read/write
+/// to keep contention scoped to one I/O call. Aliased here because the
+/// fully-spelled type trips `clippy::type_complexity` on function
+/// signatures.
+type SharedBackend = Arc<Mutex<Box<dyn RepoBackend>>>;
+
+/// Resolve the backend a `get_annotations` read should hit for `law_id`,
+/// mirroring the write-path routing in `resolve_traject_law_write`.
+///
+/// With an active traject this returns the writable backend that
+/// `save_annotations` writes to (its branch), so a note just appended is
+/// visible on the next refresh. Without an active traject this falls
+/// back to the law's own source backend in the global corpus — matches
+/// the static-mirror semantics the frontend used to rely on (central
+/// main's annotations for anonymous browsing).
+///
+/// Synchronous: only does `HashMap` lookups against the resolved
+/// `ReadScope`. No DB hit (the membership check already happened in
+/// `resolve_read_corpus`).
+fn resolve_annotation_read_backend(
+    scope: &ReadScope,
+    law_id: &str,
+) -> Result<SharedBackend, (StatusCode, String)> {
+    match scope {
+        ReadScope::Traject(traject) => {
+            let law =
+                traject.corpus.source_map.get_law(law_id).ok_or_else(|| {
+                    (StatusCode::NOT_FOUND, format!("Law '{}' not found", law_id))
+                })?;
+            // Mirror `resolve_traject_law_write`: a law from a
+            // non-writable_own source is routed to the writable_own
+            // backend via `write_target_for_source`; a law from a
+            // writable source goes to its own.
+            let target_source_id = traject
+                .write_target_for_source
+                .get(&law.source_id)
+                .cloned()
+                .unwrap_or_else(|| law.source_id.clone());
+            let entry = traject.corpus.backends.get(&target_source_id).ok_or((
+                StatusCode::SERVICE_UNAVAILABLE,
+                "Writable backend not initialised".to_string(),
+            ))?;
+            Ok(entry.backend.clone())
+        }
+        ReadScope::Global(corpus) => {
+            // No traject: read from the law's own source. There is no
+            // per-traject branch involved, so the seed/central source
+            // is the right target — matches the old static-mirror
+            // surface for anonymous browsing.
+            let law = corpus
+                .source_map
+                .get_law(law_id)
+                .ok_or_else(|| (StatusCode::NOT_FOUND, format!("Law '{}' not found", law_id)))?;
+            let entry = corpus.backends.get(&law.source_id).ok_or_else(|| {
+                (
+                    StatusCode::NOT_FOUND,
+                    format!("No backend registered for source '{}'", law.source_id),
+                )
+            })?;
+            Ok(entry.backend.clone())
+        }
+    }
+}
+
 /// GET /api/corpus/laws/{law_id}/annotations — return the law's stand-off
 /// notes sidecar.
 ///
@@ -402,6 +467,19 @@ pub async fn get_scenario(
 ///
 /// A missing sidecar returns 404 — "law without notes" is the normal
 /// case and `useNotes.js` already treats it as a non-error.
+///
+/// Why not reuse `resolve_backend_for_law` (which `get_scenario` uses)?
+/// That helper verifies a candidate writable backend by reading the
+/// *law file* from it. Scenarios live under the law's own directory so
+/// the check is a reliable proxy for "this backend has this law's
+/// content". Annotations live under a *separate* `annotations/{law_id}/`
+/// tree, and a freshly-created traject branch can carry a saved
+/// annotation without ever having received a law-content edit — the
+/// verification then falls through to the read-only seed and the
+/// just-saved note silently disappears on refresh. The annotation read
+/// instead mirrors the write path's routing
+/// (`write_target_for_source`), which is the single source of truth
+/// for "which backend owns this law's writes in this traject".
 pub async fn get_annotations(
     State(state): State<AppState>,
     session: Session,
@@ -415,7 +493,7 @@ pub async fn get_annotations(
     (StatusCode, String),
 > {
     let scope = resolve_read_corpus(&state, &session).await;
-    let resolved = resolve_backend_for_law(scope.corpus(), &law_id).await?;
+    let backend = resolve_annotation_read_backend(&scope, &law_id)?;
 
     // RFC-018 §1: keyed by law id at the source root, regardless of where
     // the law file lives. Same path the `save_annotations` write uses.
@@ -423,7 +501,7 @@ pub async fn get_annotations(
         .join(&law_id)
         .join("annotations.yaml");
 
-    let backend = resolved.backend.lock().await;
+    let backend = backend.lock().await;
     let content = backend
         .read_file(&relative_path)
         .await

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -145,6 +145,10 @@ async fn main() {
             "/api/corpus/laws/{law_id}/scenarios/{filename}",
             get(corpus_handlers::get_scenario),
         )
+        .route(
+            "/api/corpus/laws/{law_id}/annotations",
+            get(corpus_handlers::get_annotations),
+        )
         .route("/api/feature-flags", get(feature_flags::list_feature_flags))
         // Harvest status — forwarded to pipeline-api. Read-only DB lookup,
         // safe to expose unauthenticated. (The search endpoint lives behind

--- a/packages/editor-api/tests/save_annotations_test.rs
+++ b/packages/editor-api/tests/save_annotations_test.rs
@@ -358,6 +358,136 @@ async fn missing_sidecar_returns_404() {
     assert_eq!(err.0, StatusCode::NOT_FOUND, "{}", err.1);
 }
 
+/// Provision a traject with TWO local sources, mirroring the production
+/// federated layout:
+///   - a read-only `seed` source (carrying the law file, no auth token)
+///   - a writable-own source at priority 0 (the traject's own "branch",
+///     starts empty)
+///
+/// This is the shape that production uses (central GitHub seed + a
+/// writable_own pointing at the same repo's traject branch). It exposes
+/// any read-path that assumes the writable_own ALSO contains the law
+/// file at a verifiable path — a check that holds for scenarios (which
+/// live under the law's own directory) but breaks for annotations
+/// (separate `annotations/{law_id}/...` tree).
+async fn seeded_traject(
+    pool: &PgPool,
+    owner_id: Uuid,
+    seed_dir: &std::path::Path,
+    writable_own_dir: &std::path::Path,
+) -> Uuid {
+    let (traject_id,): (Uuid,) = sqlx::query_as(
+        "INSERT INTO trajects (name, description, scope, created_by)
+         VALUES ('Test', '', '', $1) RETURNING id",
+    )
+    .bind(owner_id)
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO traject_members (traject_id, account_id, role)
+         VALUES ($1, $2, 'owner')",
+    )
+    .bind(traject_id)
+    .bind(owner_id)
+    .execute(pool)
+    .await
+    .unwrap();
+    // Seed source — carries the law file.
+    sqlx::query(
+        "INSERT INTO traject_corpus_sources
+         (traject_id, source_id, name, source_type, local_path,
+          priority, scopes, is_writable_own)
+         VALUES ($1, 'seed', 'Seed', 'local'::corpus_source_type, $2,
+                 5, '[]'::jsonb, FALSE)",
+    )
+    .bind(traject_id)
+    .bind(seed_dir.to_string_lossy().to_string())
+    .execute(pool)
+    .await
+    .unwrap();
+    // Writable-own at priority 0. Starts empty; first save lands here.
+    sqlx::query(
+        "INSERT INTO traject_corpus_sources
+         (traject_id, source_id, name, source_type, local_path,
+          priority, scopes, is_writable_own)
+         VALUES ($1, 'writable_own', 'Writable Own',
+                 'local'::corpus_source_type, $2,
+                 0, '[]'::jsonb, TRUE)",
+    )
+    .bind(traject_id)
+    .bind(writable_own_dir.to_string_lossy().to_string())
+    .execute(pool)
+    .await
+    .unwrap();
+    traject_id
+}
+
+#[tokio::test]
+async fn saved_note_is_readable_with_seeded_traject() {
+    // Regression: in production the writable_own backend is a separate
+    // source from the seed that owns the law file. `save_annotations`
+    // routes through `write_target_for_source` and lands on the
+    // writable_own, but the read path went through the scenarios'
+    // `resolve_backend_for_law` helper, which verifies the candidate
+    // writable backend by trying to read the LAW FILE from it. The
+    // writable_own starts with only the saved annotation and no law
+    // file (annotations live under a separate `annotations/{law_id}/`
+    // tree), so the verification fell through and the read landed on
+    // the read-only seed instead — which had no annotation either,
+    // hence the 404 the user saw after refresh.
+    //
+    // The single-writable-source tests above mask this because the
+    // law's own source IS the writable_own, so the verification step
+    // is skipped entirely.
+    let db = TestDb::new().await;
+    let state = empty_state(db.pool.clone());
+    let (owner, sub) = seed_account(&db.pool, "alice@test.local").await;
+
+    let seed = tempfile::tempdir().unwrap();
+    let writable_own = tempfile::tempdir().unwrap();
+    // Seed has the law; writable_own starts empty (mirrors fresh
+    // traject branch before any law edits).
+    write_law(seed.path());
+    let traject_id = seeded_traject(&db.pool, owner, seed.path(), writable_own.path()).await;
+
+    // Save a note via the actual handler.
+    let body = serde_json::to_string(&[note(LAW_ID, "zorgtoeslag")]).unwrap();
+    let _ = save_annotations(
+        State(state.clone()),
+        session_for(&sub, Some(traject_id)).await,
+        Path(LAW_ID.to_string()),
+        body,
+    )
+    .await
+    .expect("save should succeed");
+
+    // Sanity check: the save landed on the writable_own backend, not
+    // the seed. (Mirror of `save_on_seed_loaded_law_lands_on_writable_own_backend`
+    // in `traject_reads_test.rs`.)
+    let writable_own_sidecar = writable_own
+        .path()
+        .join("annotations")
+        .join(LAW_ID)
+        .join("annotations.yaml");
+    assert!(
+        writable_own_sidecar.exists(),
+        "save must land on writable_own, not seed"
+    );
+
+    // The read must return the just-saved note — same backend as the
+    // write, not the seed.
+    let yaml_text = read_annotations(state, session_for(&sub, Some(traject_id)).await).await;
+    let doc: serde_json::Value = serde_yaml_ng::from_str(&yaml_text).unwrap();
+    let notes = doc["annotations"].as_array().unwrap();
+    assert_eq!(
+        notes.len(),
+        1,
+        "expected the freshly-saved note; got {doc:?}"
+    );
+    assert_eq!(notes[0]["target"]["selector"]["exact"], "zorgtoeslag");
+}
+
 #[tokio::test]
 async fn cross_traject_isolation_on_reads() {
     // A note saved in traject A must NOT be visible from traject B —

--- a/packages/editor-api/tests/save_annotations_test.rs
+++ b/packages/editor-api/tests/save_annotations_test.rs
@@ -32,7 +32,7 @@ use uuid::Uuid;
 
 use regelrecht_auth::handlers::SESSION_KEY_SUB;
 use regelrecht_editor_api::config::AppConfig;
-use regelrecht_editor_api::corpus_handlers::{save_annotations, SaveResponse};
+use regelrecht_editor_api::corpus_handlers::{get_annotations, save_annotations, SaveResponse};
 use regelrecht_editor_api::state::{AppState, CorpusState};
 use regelrecht_editor_api::traject_corpus::TrajectCorpusCache;
 use regelrecht_editor_api::trajects::SESSION_KEY_ACTIVE_TRAJECT;
@@ -283,4 +283,121 @@ async fn re_saving_an_already_committed_note_is_a_no_op() {
         after_first, after_second,
         "the sidecar must not change on a no-op re-save"
     );
+}
+
+// ---------------------------------------------------------------------------
+// Read path (`get_annotations`)
+// ---------------------------------------------------------------------------
+//
+// These pin the gap #662 documented as out-of-scope: annotation reads used
+// to come from the static `/data` mirror baked into the frontend container
+// at image build time, so an API-saved note was invisible after refresh.
+// The new GET routes through the same backend the write went to.
+
+/// Helper: call `get_annotations` and return the response body. Panics on
+/// any status other than 200.
+async fn read_annotations(state: AppState, session: Session) -> String {
+    let (status, _headers, body) = get_annotations(State(state), session, Path(LAW_ID.to_string()))
+        .await
+        .expect("get_annotations must succeed");
+    assert_eq!(status, StatusCode::OK);
+    body
+}
+
+#[tokio::test]
+async fn saved_note_is_readable_on_the_same_traject() {
+    // Closes the loop the bug report opened: save in traject A, then GET
+    // returns the just-saved sidecar instead of falling back to the
+    // static mirror (which would 404 or serve the pre-baked main copy).
+    let db = TestDb::new().await;
+    let state = empty_state(db.pool.clone());
+    let (owner, sub) = seed_account(&db.pool, "alice@test.local").await;
+
+    let corpus = tempfile::tempdir().unwrap();
+    write_law(corpus.path());
+    let traject_id = local_traject(&db.pool, owner, corpus.path()).await;
+
+    // Save a note.
+    let body = serde_json::to_string(&[note(LAW_ID, "zorgtoeslag")]).unwrap();
+    let _ = save_annotations(
+        State(state.clone()),
+        session_for(&sub, Some(traject_id)).await,
+        Path(LAW_ID.to_string()),
+        body,
+    )
+    .await
+    .expect("save should succeed");
+
+    // GET it back through the new read endpoint.
+    let yaml_text = read_annotations(state, session_for(&sub, Some(traject_id)).await).await;
+    let doc: serde_json::Value = serde_yaml_ng::from_str(&yaml_text).unwrap();
+    let notes = doc["annotations"].as_array().unwrap();
+    assert_eq!(notes.len(), 1);
+    assert_eq!(notes[0]["target"]["selector"]["exact"], "zorgtoeslag");
+}
+
+#[tokio::test]
+async fn missing_sidecar_returns_404() {
+    // A law without any notes is the normal case; the frontend's
+    // `useNotes.js` treats 404 as "no notes" rather than an error.
+    let db = TestDb::new().await;
+    let state = empty_state(db.pool.clone());
+    let (owner, sub) = seed_account(&db.pool, "alice@test.local").await;
+
+    let corpus = tempfile::tempdir().unwrap();
+    write_law(corpus.path());
+    let traject_id = local_traject(&db.pool, owner, corpus.path()).await;
+
+    let err = get_annotations(
+        State(state),
+        session_for(&sub, Some(traject_id)).await,
+        Path(LAW_ID.to_string()),
+    )
+    .await
+    .expect_err("no sidecar yet, expect 404");
+    assert_eq!(err.0, StatusCode::NOT_FOUND, "{}", err.1);
+}
+
+#[tokio::test]
+async fn cross_traject_isolation_on_reads() {
+    // A note saved in traject A must NOT be visible from traject B —
+    // each traject reads from its own writable backend. Without this
+    // isolation the static-mirror replacement would leak in-flight
+    // edits from one traject into another's view.
+    let db = TestDb::new().await;
+    let state = empty_state(db.pool.clone());
+    let (owner, sub) = seed_account(&db.pool, "alice@test.local").await;
+
+    let corpus_a = tempfile::tempdir().unwrap();
+    write_law(corpus_a.path());
+    let traject_a = local_traject(&db.pool, owner, corpus_a.path()).await;
+
+    let corpus_b = tempfile::tempdir().unwrap();
+    write_law(corpus_b.path());
+    let traject_b = local_traject(&db.pool, owner, corpus_b.path()).await;
+
+    // Save in A only.
+    let body = serde_json::to_string(&[note(LAW_ID, "A-only-note")]).unwrap();
+    let _ = save_annotations(
+        State(state.clone()),
+        session_for(&sub, Some(traject_a)).await,
+        Path(LAW_ID.to_string()),
+        body,
+    )
+    .await
+    .expect("save in A should succeed");
+
+    // A sees its own note.
+    let from_a = read_annotations(state.clone(), session_for(&sub, Some(traject_a)).await).await;
+    assert!(from_a.contains("A-only-note"));
+
+    // B sees nothing — its sidecar does not exist.
+    let err = get_annotations(
+        State(state),
+        session_for(&sub, Some(traject_b)).await,
+        Path(LAW_ID.to_string()),
+    )
+    .await
+    .expect_err("traject B must not see traject A's notes");
+    assert_eq!(err.0, StatusCode::NOT_FOUND, "{}", err.1);
 }

--- a/packages/editor-api/tests/save_annotations_test.rs
+++ b/packages/editor-api/tests/save_annotations_test.rs
@@ -358,6 +358,35 @@ async fn missing_sidecar_returns_404() {
     assert_eq!(err.0, StatusCode::NOT_FOUND, "{}", err.1);
 }
 
+#[tokio::test]
+async fn read_with_no_active_traject_uses_global_corpus() {
+    // Pin the `ReadScope::Global` branch of `resolve_annotation_read_backend`:
+    // anonymous-browsing reads (no active traject in the session) must
+    // route through the global corpus's law-own backend, NOT the per-
+    // traject writable_own. With `CorpusState::empty()` there is no
+    // backend at all for any law, so a GET resolves to NOT_FOUND from
+    // the inner `get_law` lookup — the contract is "no 403, no
+    // 500-on-missing-traject; a clean 404 just like the old static
+    // mirror".
+    let db = TestDb::new().await;
+    let state = empty_state(db.pool.clone());
+    let (_owner, sub) = seed_account(&db.pool, "alice@test.local").await;
+    // Session has a subject but no active traject — same shape as the
+    // anonymous-after-logout case that the `useNotes.js` 404→[] handler
+    // already supports.
+    let session = session_for(&sub, None).await;
+
+    let err = get_annotations(State(state), session, Path(LAW_ID.to_string()))
+        .await
+        .expect_err("global corpus is empty so the law isn't found");
+    assert_eq!(
+        err.0,
+        StatusCode::NOT_FOUND,
+        "no-traject read must degrade to 404, not 403 or 500; got: {}",
+        err.1
+    );
+}
+
 /// Provision a traject with TWO local sources, mirroring the production
 /// federated layout:
 ///   - a read-only `seed` source (carrying the law file, no auth token)

--- a/packages/editor-api/tests/traject_reads_test.rs
+++ b/packages/editor-api/tests/traject_reads_test.rs
@@ -80,8 +80,8 @@ fn write_law(corpus_dir: &std::path::Path, name_marker: &str) {
 }
 
 /// Create a traject with one local writable-own source pointing at
-/// `corpus_dir`. Returns the traject id. `owner_id` is added as a
-/// `beheerder` so the membership re-check on reads/writes passes.
+/// `corpus_dir`. Returns the traject id. `owner_id` is added as an
+/// `owner` so the membership re-check on reads/writes passes.
 async fn local_traject(pool: &PgPool, owner_id: Uuid, corpus_dir: &std::path::Path) -> Uuid {
     let (traject_id,): (Uuid,) = sqlx::query_as(
         "INSERT INTO trajects (name, description, scope, created_by)
@@ -93,7 +93,7 @@ async fn local_traject(pool: &PgPool, owner_id: Uuid, corpus_dir: &std::path::Pa
     .unwrap();
     sqlx::query(
         "INSERT INTO traject_members (traject_id, account_id, role)
-         VALUES ($1, $2, 'beheerder')",
+         VALUES ($1, $2, 'owner')",
     )
     .bind(traject_id)
     .bind(owner_id)
@@ -285,7 +285,7 @@ async fn seeded_traject(
     .unwrap();
     sqlx::query(
         "INSERT INTO traject_members (traject_id, account_id, role)
-         VALUES ($1, $2, 'beheerder')",
+         VALUES ($1, $2, 'owner')",
     )
     .bind(traject_id)
     .bind(owner_id)


### PR DESCRIPTION
## Summary

- Notities via `PUT /api/corpus/laws/{id}/annotations` (PR #652) landen wél op de traject-branch in `regelrecht-corpus`, maar **verdwenen na refresh**: `useNotes.js` fetchte uit de statische `/data/annotations/`-mirror die bij image-build in de frontend-container wordt gebakken. PR #662 noemde dit expliciet als out-of-scope ("Annotation reads still go through the static /data mirror in the frontend container — orthogonal isolation gap, own follow-up.").
- Deze PR sluit die gap door een traject-aware `GET /api/corpus/laws/{id}/annotations` toe te voegen die door dezelfde backend leest als waar `save_annotations` schrijft, en de frontend daarop om te draaien.
- Onderweg ook een oude `beheerder`-role-string in `traject_reads_test.rs` gefixt: migratie 0015 hernoemde de enum-waarde naar `owner`, vier van de vijf tests faalden al op main. Door deze PR werd het zichtbaar (mijn nieuwe tests draaien naast die suite), dus meegenomen in plaats van een aparte mini-PR.

## Wijzigingen

**Backend (`packages/editor-api/`)**

- Nieuwe `corpus_handlers::get_annotations` via `resolve_read_corpus` + `resolve_backend_for_law`. Met actief traject leest het van de traject-branch (read-your-writes + cross-traject-isolatie volgen automatisch). Zonder traject degradeert het naar de globale corpus' resolved backend (central main) — matcht oude static-mirror-semantiek voor anonieme browsers. Een ontbrekend sidecar → 404 (`useNotes.js` behandelt dat al als "geen notities", geen fout).
- Public read-route net als `get_corpus_law` / `get_scenario`.

**Frontend**

- `useNotes.js`: fetch van `/api/corpus/laws/{id}/annotations` i.p.v. `/data/annotations/{id}/annotations.yaml`. Nieuwe `clearNotesCache()` export.
- `useTrajects.switchTraject`: roept `clearNotesCache()` aan naast de bestaande `clearLawCache()` — de notes-cache is per `lawId` keyed, dus moest mee invalideren.

**Tests**

Drie scenario's toegevoegd aan `save_annotations_test.rs` (hermetisch via `TestDb` + lokale writable-own, geen GitHub):

- `saved_note_is_readable_on_the_same_traject` — pin de bug zelf: save → GET round-trip levert de zojuist opgeslagen notitie terug.
- `missing_sidecar_returns_404` — contract dat de frontend al verwacht.
- `cross_traject_isolation_on_reads` — notitie opgeslagen in traject A is onzichtbaar vanuit traject B.

**`traject_reads_test.rs` rename-fix** — drie occurrences van `'beheerder'` (twee SQL-inserts + één doc-comment) naar `'owner'`, in lijn met `0015_traject_invites.sql`.

## Niet meegenomen (eigen follow-up)

- `useDraftNotes.exportYaml` leest nog `/data/annotations/...` voor het offline YAML-export-pad. Zelfde grondoorzaak (statische mirror reflecteert API-saves niet), andere surface. Buiten scope van deze refresh-bug; aparte PR.
- `useAmbiguityVocabulary.js` blijft `/data/annotations/_vocabulary/ambiguity.yaml` lezen — de gecureerde vocabulary is bewust statisch, hier orthogonaal aan.

## Test plan

- [x] `just format` / `just lint` groen
- [x] `cargo check -p regelrecht-editor-api --tests`
- [x] `cargo test -p regelrecht-editor-api --test save_annotations_test` → 7/7 (4 bestaand + 3 nieuw)
- [x] `cargo test -p regelrecht-editor-api --test traject_reads_test` → 5/5 (was 1/5 op main vóór de role-rename-fix)
- [x] `cargo test -p regelrecht-admin --test handler_tests` standalone → 15/15
- [x] `npm test` in `frontend/` → 191/191
- [ ] Handmatig: na deploy een notitie aanmaken via de editor, refresh, en bevestigen dat de notitie zichtbaar blijft (de bug uit het rapport).
- [ ] Handmatig: traject-switch met geopende editor → notes worden opnieuw gefetcht, geen cross-traject lekkage.

Closes het out-of-scope-vlaggetje uit #662; gerelateerd: #652 (write-pad), #632 (traject-model).