### PR TITLE
docs: vacaturesectie 'Werk mee aan RegelRecht' op landingspagina

### DIFF
--- a/docs/src/components/LandingSections.astro
+++ b/docs/src/components/LandingSections.astro
@@ -22,6 +22,7 @@ const home = lang === 'en' ? '/en/' : '/';
 // Hero ToC: every landing section's title rendered in the right column.
 const toc = [
   { text: t.whatIsIt.title, href: '#what-is-it' },
+  { text: t.jobs.title, href: '#jobs' },
   { text: t.whyImportant.title, href: '#why-important' },
   { text: t.howItWorks.title, href: '#how-it-works' },
   { text: t.tools.title, href: '#tools' },
@@ -149,6 +150,85 @@ const toc = [
                   <nldd-rich-text>
                     <p>{c.p}</p>
                   </nldd-rich-text>
+                </nldd-container>
+              </nldd-card>
+            ))}
+          </nldd-collection>
+        </nldd-simple-section>
+
+        <nldd-simple-section
+          id="jobs"
+          background="tinted"
+          sm-padding-block="32"
+          md-padding-block="64"
+          lg-padding-block="96"
+        >
+          <nldd-title size="2">
+            <h2>{t.jobs.title}</h2>
+          </nldd-title>
+          <nldd-spacer size="8" />
+          <nldd-rich-text>
+            <p>{t.jobs.lede}</p>
+          </nldd-rich-text>
+          <nldd-spacer size="24" />
+          <nldd-collection layout="grid" item-width="720px">
+            {t.jobs.items.map((job) => (
+              <nldd-card accessible-label={`${t.jobs.vacancyTag}: ${job.title}`}>
+                <nldd-container padding="20">
+                  <nldd-container layout="wrap" gap="6" horizontal-alignment="left">
+                    <nldd-tag color="accent" size="md">{t.jobs.vacancyTag}</nldd-tag>
+                    <nldd-tag color="brand" size="md">{job.organisation}</nldd-tag>
+                  </nldd-container>
+                  <nldd-spacer size="12" />
+                  <nldd-title size="3">
+                    <h3>{job.title}</h3>
+                  </nldd-title>
+                  <nldd-spacer size="12" />
+                  <nldd-rich-text>
+                    <p>{job.pitch}</p>
+                  </nldd-rich-text>
+                  <nldd-spacer size="16" />
+                  <nldd-container layout="wrap" gap="6" horizontal-alignment="left">
+                    {job.meta.map((m) => (
+                      <nldd-tag color="neutral" size="md">{m}</nldd-tag>
+                    ))}
+                  </nldd-container>
+                  <nldd-spacer size="20" />
+                  <nldd-button-group orientation="horizontal">
+                    <nldd-button
+                      variant="primary"
+                      href={job.ctaHref}
+                      end-icon="external-link"
+                      text={job.ctaLabel}
+                    />
+                  </nldd-button-group>
+                  {job.contacts.length > 0 && (
+                    <Fragment>
+                      <nldd-spacer size="16" />
+                      <nldd-rich-text>
+                        <p>
+                          {t.jobs.contactsLabel}{' '}
+                          {job.contacts.map((c, i, arr) => {
+                            const sep =
+                              i === 0
+                                ? ''
+                                : i === arr.length - 1
+                                  ? lang === 'en'
+                                    ? ' or '
+                                    : ' of '
+                                  : ', ';
+                            return (
+                              <Fragment>
+                                {sep}
+                                <a href={c.href}>{c.label}</a>
+                              </Fragment>
+                            );
+                          })}
+                          .
+                        </p>
+                      </nldd-rich-text>
+                    </Fragment>
+                  )}
                 </nldd-container>
               </nldd-card>
             ))}

--- a/docs/src/lib/landing-content.ts
+++ b/docs/src/lib/landing-content.ts
@@ -21,6 +21,7 @@ export interface LandingContent {
     tools: string
     example: string
     faq: string
+    jobs: string
     signup: string
     docs: string
   }
@@ -74,6 +75,21 @@ export interface LandingContent {
     }[]
   }
   faq: { title: string; items: { q: string; a: string }[] }
+  jobs: {
+    title: string
+    lede: string
+    vacancyTag: string
+    contactsLabel: string
+    items: {
+      title: string
+      organisation: string
+      pitch: string
+      meta: string[]
+      ctaLabel: string
+      ctaHref: string
+      contacts: { label: string; href: string }[]
+    }[]
+  }
   feedback: { title: string; body: string; cta: string; ctaHref: string }
   footer: {
     blurb: string
@@ -135,6 +151,7 @@ export const content: Record<'nl' | 'en', LandingContent> = {
       tools: 'Ecosysteem',
       example: 'Voorbeelden',
       faq: 'Vragen',
+      jobs: 'Werken bij',
       signup: 'Aanmelden',
       docs: 'Documentatie',
     },
@@ -443,6 +460,34 @@ export const content: Record<'nl' | 'en', LandingContent> = {
         },
       ],
     },
+    jobs: {
+      title: 'Werk mee aan RegelRecht',
+      lede: 'Het team rond RegelRecht groeit. Bouw mee aan een open infrastructuur waarin Nederlandse wetgeving machine-uitvoerbaar wordt, en zie je werk landen bij uitvoeringsorganisaties die er dagelijks beslissingen op nemen.',
+      vacancyTag: 'Vacature',
+      contactsLabel: 'Vragen? Neem contact op met',
+      items: [
+        {
+          title: 'Software Engineer',
+          organisation: 'Rijksorganisatie ODI · Ministerie van BZK',
+          pitch:
+            'Werk aan de Rust-engine en de tooling waarmee wetten machine-uitvoerbaar worden. Je adviseert opdrachtgevers binnen het Rijk, ontwerpt en programmeert, en werkt naast juristen die de regels in machineleesbare vorm gieten. Senior rol met directe maatschappelijke impact.',
+          meta: [
+            'Schaal 13',
+            '€5.212 – €7.747',
+            '32 – 36 uur',
+            'Den Haag',
+            'Sluit 11 juni 2026',
+          ],
+          ctaLabel: 'Bekijk de vacature',
+          ctaHref:
+            'https://www.werkenvoornederland.nl/vacatures/software-engineer-BZK-2026-8544',
+          contacts: [
+            { label: 'Abram Klop (opgavemanager)', href: 'tel:+31650035732' },
+            { label: 'Dian Hoppen (recruiter)', href: 'tel:+31650062738' },
+          ],
+        },
+      ],
+    },
     feedback: {
       title: 'Wat denk jij?',
       body: 'Deze verkenning van machine-uitvoerbare wetgeving roept veel vragen op. Hoe zie jij de toekomst van de digitale overheid? Wat zijn je zorgen en verwachtingen bij deze ontwikkelingen? Jouw input helpt ons deze verkenning verder vorm te geven.',
@@ -516,6 +561,7 @@ export const content: Record<'nl' | 'en', LandingContent> = {
       tools: 'Ecosystem',
       example: 'Examples',
       faq: 'Questions',
+      jobs: 'Join us',
       signup: 'Sign up',
       docs: 'Documentation',
     },
@@ -821,6 +867,34 @@ export const content: Record<'nl' | 'en', LandingContent> = {
         {
           q: 'How does this contribute to transparency?',
           a: 'By making rules explicit in code, citizens and organisations can see exactly how decisions are reached, instead of relying on opaque systems.',
+        },
+      ],
+    },
+    jobs: {
+      title: 'Join the RegelRecht team',
+      lede: 'The team behind RegelRecht is growing. Help build an open infrastructure that turns Dutch legislation into something computers can execute, and see your work land at the public-sector organisations that act on it every day.',
+      vacancyTag: 'Vacancy',
+      contactsLabel: 'Questions? Get in touch with',
+      items: [
+        {
+          title: 'Software Engineer',
+          organisation: 'Rijksorganisatie ODI · Ministry of the Interior',
+          pitch:
+            'Work on the Rust engine and the tooling that turns Dutch statutes into something computers can run. You advise teams across the Dutch government, design and write code, and work side by side with lawyers who translate rules into machine-readable form. Senior role, in Dutch (fluency required).',
+          meta: [
+            'Scale 13',
+            '€5,212 – €7,747',
+            '32 – 36 hours',
+            'The Hague',
+            'Closes 11 June 2026',
+          ],
+          ctaLabel: 'View the vacancy (Dutch)',
+          ctaHref:
+            'https://www.werkenvoornederland.nl/vacatures/software-engineer-BZK-2026-8544',
+          contacts: [
+            { label: 'Abram Klop (opgavemanager)', href: 'tel:+31650035732' },
+            { label: 'Dian Hoppen (recruiter)', href: 'tel:+31650062738' },
+          ],
         },
       ],
     },


### PR DESCRIPTION
## Samenvatting

- Nieuwe sectie **#jobs** ('Werk mee aan RegelRecht') op de landingspagina, vlak na 'Wat is RegelRecht?'
- Eerste vacature: [Software Engineer (Rijksorganisatie ODI · BZK)](https://www.werkenvoornederland.nl/vacatures/software-engineer-BZK-2026-8544), sluit 11 juni 2026
- Structuur in `landing-content.ts` ondersteunt meerdere vacatures (`jobs.items[]`); volgende vacature is straks alleen contentwerk
- NL + EN content; ToC in de hero-rechterkolom mee bijgewerkt

## Ontwerpkeuzes

- NLDD-componenten consistent met de rest: `nldd-simple-section` met `background="tinted"`, `nldd-card`, `nldd-tag` (accent voor 'Vacature', brand voor organisatie, neutral voor meta zoals schaal/salaris/uren/locatie/sluitdatum), `nldd-button` met `end-icon="external-link"`
- Contactregel met `tel:`-links voor de opgavemanager en recruiter
- Engelse versie noteert dat de rol Nederlandstalig is

## Testplan

- [x] Lokaal gedraaid op `http://localhost:4321/#jobs` en `http://localhost:4321/en/#jobs`
- [x] Sectie-volgorde geverifieerd via DOM: `what-is-it → jobs → why-important → …`
- [x] Primary CTA verwijst naar werkenvoornederland.nl
- [ ] Visuele review na deploy-preview