### PR TITLE
feat(docs): regelrecht dossier-, desk- en workshop-skills

### DIFF
--- a/.claude/skills/law-generate/SKILL.md
+++ b/.claude/skills/law-generate/SKILL.md
@@ -400,6 +400,21 @@ to fall back to a plain param. That assumption is false: schema v0.5.2 supports 
 `source:` bindings per article, and they resolve fine. When in doubt, bind for real and
 prove it with a BDD scenario.
 
+**Section placement — a `source:` MUST live under `input:`, NEVER under `parameters:`.**
+This is the single most common way a binding looks real but silently does nothing. The
+engine has two distinct structs: `Parameter` (the items under `parameters:`) has **no
+`source` field**, while `Input` (the items under `input:`) is the only one that carries
+`source`. A `source:` block placed under `parameters:` is therefore **dropped at parse time**
+— the value degrades to a plain caller-supplied parameter and cross-law resolution never
+fires. It will still "pass" any BDD scenario that injects the value directly, which hides
+the defect. Rule of thumb:
+- The cross-law-resolved value (the thing the other law produces) → declare under `input:` with its `source:`.
+- The leaf parameters that FEED that binding's `source.parameters` mapping → stay under `parameters:` as direct inputs.
+
+A binding only truly resolves when its `input:` entry is reached AND no overriding parameter
+of the same name is supplied. Verify with a BDD scenario that loads the target law and sets
+the *leaf* inputs (not the bound value), then asserts the dependent output flips.
+
 **Name-mismatch rule:** if the local input name differs from the target output name, put
 the *target's* output name in `source.output` and the *local* name in `name`, and note the
 difference in the `description`:

--- a/.claude/skills/law-generate/SKILL.md
+++ b/.claude/skills/law-generate/SKILL.md
@@ -381,6 +381,40 @@ machine_readable:
         value: $verlaging_percentage
 ```
 
+#### Binding purity — NEVER leave a cross-law input as a plain-param placeholder
+
+Every `input` that references a concept owned by another legal provision MUST carry a
+real `source:` block. A description is documentation, not a binding — it does not make the
+engine resolve anything.
+
+**Forbidden pattern:** an `input` whose description names another regulation, or uses words
+like "conceptueel", "forward naar", or "tijdelijk als directe parameter", but has NO
+`source:` block. This is a *plain-param placeholder*: it silently turns a cross-law value
+into a free input the caller must supply by hand, and real cross-document resolution never
+happens. If the target law does not yet produce the needed output, FIRST add that output to
+the target law (a `machine_readable` action on the correct article), then bind to it — do
+not leave the reference stranded in a description.
+
+**Never** use "the engine cannot resolve multiple source bindings per article" as a reason
+to fall back to a plain param. That assumption is false: schema v0.5.2 supports multiple
+`source:` bindings per article, and they resolve fine. When in doubt, bind for real and
+prove it with a BDD scenario.
+
+**Name-mismatch rule:** if the local input name differs from the target output name, put
+the *target's* output name in `source.output` and the *local* name in `name`, and note the
+difference in the `description`:
+```yaml
+input:
+  - name: lokaal_inkomen           # local name used by this article's logic
+    type: amount
+    description: "bindt aan output 'toetsingsinkomen' van de andere regeling (naam wijkt af)"
+    source:
+      regulation: algemene_wet_inkomensafhankelijke_regelingen
+      output: toetsingsinkomen     # the name the TARGET law actually produces
+    type_spec:
+      unit: eurocent
+```
+
 ### Field Types
 
 | Context | Valid types |

--- a/.claude/skills/law-letter-fidelity-audit/SKILL.md
+++ b/.claude/skills/law-letter-fidelity-audit/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: law-letter-fidelity-audit
+description: >
+  Audits whether a machine-readable regelrecht law model is faithful to the LETTER of
+  the wettekst — and strictly separates the wettekst (leading) from the toelichting
+  (Nota/Memorie van Toelichting; explanatory, not a norm). Runs in critical passes per
+  article/lid and detects four deviation classes: toelichting-bleed (a modeled criterion
+  that the letter only states as an open norm, or not at all), missing verbatim elements
+  (a word/condition such as a "tenzij" or a qualifier dropped from the model), wrong
+  legal_basis anchoring (an endpoint hung on a "kapstok"-article while the operative norm
+  lives elsewhere), and verbatim-drift in text: (an ingetrokken/older redaction). Also
+  detects positief-lid vs uitsluitings-lid conflicts and checks the chapeau for an explicit
+  derogation rule ("zo nodig in afwijking van het eerste lid") before judging precedence.
+  Classifies every finding as modelfout (fix), wettekst-gevolg (report, do not fix), or
+  letter-vs-toelichting-question (jurist decides what is leading + revision signal). Use
+  when the user wants to know if a model is "dicht bij de letter", mentions letter vs
+  toelichting/bedoeling, fidelity, "natuurgetrouw", or before trusting feature outcomes.
+allowed-tools: Read, Write, Bash, Grep, Glob, WebFetch, WebSearch, AskUserQuestion
+user-invocable: true
+---
+
+# Law Letter-Fidelity Audit
+
+Audits whether a `machine_readable` model reflects the **letter of the wettekst**, not the
+*toelichting* and not the desired outcome. The aim is to separate three very different things:
+a genuine **modelfout** (the model deviates from the letter — fix it), a **wettekst-gevolg**
+(the model faithfully follows a letter that itself produces an odd or unintended result —
+report it, do not "fix" it in the model), and a **letter-vs-toelichting-question** (the letter
+and the toelichting diverge — a jurist must decide which is leading).
+
+## Core principle — wettekst leidend, toelichting is uitleg
+
+> De **artikeltekst** (het `text:`-veld, de feitelijk geldende wet) is leidend. De **toelichting**
+> (Nota / Memorie van Toelichting) legt de bedoeling uit maar is **geen norm**. Modelleer de open
+> norm zoals de wet die stelt; gebruik de toelichting als duiding, nooit als een verkapt criterium.
+
+Soll-normalisatie is verboden: het model spiegelt de wet inclusief haar onvolkomenheden. Modelleer
+nooit een "zuiver" (zoals-bedoeld) stelsel als vervanging van het verbatim-model; het verschil tussen
+letter en bedoeling is juist de te rapporteren bevinding.
+
+## Werkwijze — kritische passes, fideliteit vóór outcome
+
+Doe de fideliteit-audit **vóór** je het model tegen verwachte uitkomsten/scenario's afzet. Anders ga
+je het model reverse-engineeren om een test te laten slagen (outcome-bias). Volgorde: (1) letter ↔
+model per artikel/lid; (2) pas daarna toetsing tegen scenario's/uitvoeringsbeleid.
+
+Loop per artikel: lees het verbatim `text:`-veld naast de `machine_readable` (parameters/input/actions/
+operations) en zoek de vier afwijkingsklassen.
+
+### Klasse 1 — toelichting-bleed
+Een conditie of begrip in het model dat uit de **toelichting** komt terwijl de **letter** het slechts
+als open norm stelt (of helemaal niet noemt). Symptoom: een leaf/operatie genoemd naar een
+toelichtings-term, terwijl de wet alleen "naar de omstandigheden te beoordelen" o.i.d. zegt.
+→ Hernoem/herorden zodat het model de open norm van de letter draagt; verplaats de toelichtings-uitleg
+naar de `description`/comment, expliciet gelabeld als toelichting.
+
+### Klasse 2 — ontbrekend verbatim-bestanddeel
+Een woord of voorwaarde dat **in de letter staat** maar niet in het model zit: een kwalificatie
+("rechtmatig", "uitsluitend", "tijdelijk"), een "tenzij"-clausule, of een hele uitsluiting. Grep de
+verbatim `text:` op "tenzij", "behoudens", "voor zover", "niet ... dan wel", en controleer of elke
+voorwaarde in de `actions` terugkomt. → Voeg het ontbrekende bestanddeel toe (richting de letter).
+
+### Klasse 3 — verkeerde verankering (legal_basis)
+Een endpoint hangt aan een "kapstok"-artikel terwijl de dragende norm in een buurartikel of in een
+andere wet staat (bv. de beslislogica zit in art. N+1, of een leeftijds-/statuseis in een ander
+wetboek). De beslislogica kan correct zijn; de **herleidbaarheid** klopt niet. → Markeer als
+`legal_basis`-/architectuur-kwestie (jurist/architectuur), meestal geen logica-fix.
+
+### Klasse 4 — verbatim-drift in `text:`
+Het `text:`-veld draagt een **ingetrokken of oudere redactie** (verwijzing naar een ingetrokken wet,
+een oude instantienaam) terwijl de feitelijk geldende tekst anders luidt. Kruis-check verbatim tegen
+de bron op de claimed `valid_from` (zie de `law-version-drift-check`-skill). → Actualiseer het
+`text:`-veld naar de geldende verbatim redactie; corrigeer nooit een fout die in de geldende wet
+zélf staat (die rapporteer je).
+
+## Lid-conflict & afwijkings-precedence
+
+Wanneer een positieve grond (een toekennend lid) en een uitsluiting (een ontzeggend lid) elkaar lijken
+te weerspreken, **controleer eerst de chapeau** op een expliciete voorrangsregel vóór je een "conflict"
+of "lacune" rapporteert:
+- Een chapeau als *"zo nodig **in afwijking van** het [vorige lid], is niet ..."* betekent dat de
+  uitsluiting **dérogeert** aan de positieve grond — dan is de uitsluitende uitkomst de letter, geen
+  modelkeuze en geen lacune.
+- Een tegen-uitsluiting als *"[lid X] is niet van toepassing op ..."* schakelt (een deel van) de
+  uitsluiting weer uit; modelleer de exacte reikwijdte (welke onderdelen, welke subgroep).
+Modelleer de precedence **zoals de letter die stelt**. Als de letter zo een groep uitsluit die de
+bedoeling juist insluit, is dat een wettekst-gevolg (zie classificatie), geen modelfout.
+
+## Classificatie van elke bevinding
+
+| Bucket | Betekenis | Actie |
+|---|---|---|
+| **MODELFOUT** | het model wijkt af van de letter | aanpassen richting de letter |
+| **WETTEKST-GEVOLG** | model = letter, maar de letter zelf produceert een vreemde/onbedoelde uitkomst | **rapporteren**, niet "fixen" in het model |
+| **LETTER-vs-TOELICHTING** | letter en toelichting divergeren | jurist bepaalt wat leidend is; tevens **signaal voor herziening** (de bedoeling hoort dan in de wéttekst — primaat van de wetgever) |
+
+Voor elke WETTEKST-GEVOLG- en LETTER-vs-TOELICHTING-bevinding: formuleer een **jurist-vraag** en, waar
+toepasselijk, een wetgevings-signaal (de norm hoort kenbaar in de regelgeving, niet in toelichting of
+stilzwijgende uitvoeringscorrectie).
+
+## Verificatie (geen hunches)
+
+Toets uitkomsten via de engine (`evaluate`-binary, met `extra_laws` voor cross-law), met alleen
+upstream-leaf-feiten en anti-masking (flip een bron-feit, zie de uitkomst omklappen) — niet door de
+uitkomst direct te injecteren. Schema-validatie en cross-law-integriteit blijven groen.
+
+## Output
+
+Per artikel/lid: (verbatim passage) → (wat het model doet) → (afwijkingsklasse of "letter-getrouw") →
+(classificatie: modelfout/wettekst-gevolg/letter-vs-toelichting) → (jurist-vraag waar van toepassing).
+Sluit af met een prioriteitenlijst en, voor letter-vs-toelichting-bevindingen, een aparte paragraaf
+"Lezing: toelichting náást de letter" puur op de twee teksten (zonder de implementatie erbij).
+
+## Samenhang met andere skills
+- `law-version-drift-check` — dekt klasse 4 (verbatim-drift) in detail; draai die als Step 0.
+- `regelrecht-stelselanalyse` — cross-law-integriteit, cyclus-workflow en classificatie-taxonomie.
+- `law-generate` — de plaatsings-/bindingsregels (source onder `input:`, niet `parameters:`).

--- a/.claude/skills/law-reverse-validate/SKILL.md
+++ b/.claude/skills/law-reverse-validate/SKILL.md
@@ -59,6 +59,8 @@ circular, or inefficient. That is intentional — model it as the law writes it.
       - Every `action` and its `operation` — does the legal text describe this logic?
       - Every comparison value — does the legal text state this threshold/amount?
       - Every `source.regulation` reference — does the legal text reference that law?
+      - Every `source` binding — does the target law YAML exist in the corpus, and does
+        the named `output` actually occur in it? (see "Cross-Law Binding Check" below)
       - Every `endpoint` — is there a reason for external callability?
       - Every `hooks` entry — does the legal text describe a rule triggered by lifecycle events (e.g., "na bekendmaking", "bij bezwaar")?
       - Every `overrides` entry — does the legal text explicitly state "in afwijking van artikel X" or similar override language?
@@ -86,6 +88,26 @@ that look correct but cannot be traced back to the provision that claims to prod
    passes schema validation. Removing elements can break required field constraints
    or leave dangling `$variable` references. Fix any validation errors before
    completing the report.
+
+## Cross-Law Binding Check — dangling source detection
+
+A `source:` binding is a factual claim: "the target regulation produces this output." A
+binding to an output that does not exist is a hallucination of the same kind as a fabricated
+article reference — it just hides better, because the YAML is schema-valid and the binding
+looks plausible.
+
+For every `source: { regulation, output }` in the file:
+1. Confirm the **target law YAML exists** in the corpus (`corpus/regulation/nl/...`). A
+   binding to a regulation that has no file is a hallucinated dependency — flag it.
+2. Confirm the **named output actually occurs** in that target law (it appears as an
+   `- output:` in some article's `machine_readable`). A binding whose `output` is produced
+   nowhere in the target is a **dangling binding** — flag it.
+
+A dangling binding is a modelling error, never an "engine limitation". The fix is either to
+correct the `output` name to one the target law really produces, or to add that output to
+the target law first (on the article that should own it). Do not silently downgrade the
+binding to a plain `input` parameter to make the error disappear — that hides the gap, it
+does not close it.
 
 ## Operation Correctness Check
 

--- a/.claude/skills/law-version-drift-check/SKILL.md
+++ b/.claude/skills/law-version-drift-check/SKILL.md
@@ -1,0 +1,269 @@
+---
+name: law-version-drift-check
+description: >
+  Detects version drift between machine-readable law YAML files and the binding
+  geldende wettekst on wetten.overheid.nl at the YAML's claimed valid_from. Catches
+  the silent failure where authored content lags behind ingevoerde wijzigingen — a
+  YAML dated 2025-01-01 still carrying pre-Stb.-X text. Activate as Step 0 of every
+  regelrecht-stelselanalyse micro-cycle, before any YAML edit. Strict by design: no
+  bypass, no normalization beyond whitespace within a single paragraph; the geldende
+  wettekst is leading and is mirrored verbatim, including errata. Use proactively
+  when starting a stelselanalyse cycle, before harvest/migrate/extend, or when user
+  mentions "drift", "versie", "geldende tekst", or worries that a YAML may be stale
+  relative to wetten.overheid.nl.
+allowed-tools: Read, Write, Bash, Grep, Glob, WebFetch, WebSearch, AskUserQuestion
+user-invocable: true
+---
+
+# Law Version Drift Check — Step 0 of every micro-cycle
+
+Detects whether a YAML's `text:` blocks (and adjacent fields) match the binding
+geldende wettekst at the version the YAML claims to represent. The failure this
+skill catches is silent: a file passes schema-validation, hallucination-checks
+and BDD tests while its content is from an older version of the law. Every
+downstream review (wetgevings-fouten, modellering-fouten, untranslatables) then
+mis-classifies bevindingen until the drift is closed.
+
+This skill belongs in the desk-layer (`regelrecht-stelselanalyse`) and runs
+*before* every other review-as.
+
+## Core principle — verbatim spiegelregel
+
+> De feitelijk geldende wettekst is leidend. Fouten in de wet worden feitelijk
+> overgenomen. Geen "soll"-fietsen.
+
+The YAML's `text:` block must equal the geldende wettekst character-for-character.
+There is **one** allowed normalization, defined below; every other deviation is
+drift, regardless of who is "right". Errata, redactionele oddities, dode
+verwijzingen — all preserved verbatim in the YAML. If the wet contains a fout,
+the wet itself is the carrier; the YAML mirrors it. A wetgevings-fout (4-weg
+klasse 2) is reported to the wetgever separately; it is never silently "corrected"
+in the YAML.
+
+### The one allowed normalization
+
+`|-` block scalars in YAML wrap long sentences at ~N characters for editor
+readability; wetten.overheid.nl wraps based on its own rendering. Within a single
+paragraph, multiple whitespace and intra-paragraph line breaks collapse to a
+single space before comparison. **Between** paragraphs (between leden, between
+onderdelen, between verbatim-blocks) structure is preserved exactly.
+
+Anything else — diacritics, quote glyphs (`«»` vs `"`), capitalization, word
+order, punctuation — is part of the law's substance and any deviation is drift.
+
+## Position: Step 0 of `regelrecht-stelselanalyse`
+
+This skill is a **hard prerequisite** for every micro-cycle. Without a CLEAN (or
+scope-restricted) drift-report, no YAML edit may be made.
+
+Rationale: drift silently mis-classifies findings across the 4-weg-classificatie:
+- A claim "the YAML says X but the wet says Y" is a *wetgevings-fout* only if the
+  geldende wet truly says Y. If Y had already been changed by a Stb. that was not
+  ingeharvest, the same finding is in fact a *modellering-fout (drift)*. Confusing
+  the two breaks the 4-weg discipline that the cycle relies on.
+
+Strict by design: no bypass parameter, no "this cycle is just docs" escape. If a
+cycle is purely docs and not touching YAMLs, it doesn't reach Step 0 — the
+trigger is "about to edit a regulation YAML".
+
+## Verdict per article — two axes
+
+| Structural | Textual | Verdict |
+|------------|---------|---------|
+| match | match | **CLEAN** |
+| match | diff | **DRIFT-tekst** (with word-level sub-diff) |
+| mismatch | (skipped) | **DRIFT-structureel** (with the missing/extra item named) |
+| (any) | not fetchable | **NIET-VERIFIEERBAAR** (after retry + Staatsblad-fallback) |
+
+**Structural axis** (assessed first): count of leden, ordered list of onderdeel-
+letters per lid, alinea-count per lid. A mismatch here is decisive — skip textual,
+report the missing/extra element by name. This is the axis that catches the most
+costly drift type: an entire missing onderdeel or lid (a downstream wijziging
+that was never harvested).
+
+**Textual axis**: per-paragraph word-level diff after applying the single
+allowed whitespace normalization. The output is a unified diff at word
+granularity for every paragraph that differs.
+
+## Procedure
+
+### 1. Inventory the target file
+
+Extract from the YAML:
+- `bwb_id`, `valid_from`
+- per article: `number`, `text:` block (the literal string after `|-`), `url:`
+- corpus-level: every `competent_authority.name` referenced anywhere in the file
+
+### 2. Structural inventory from the geldende text
+
+For each article, fetch the structural skeleton at
+`https://wetten.overheid.nl/<bwb_id>/<valid_from>#Artikel<N>`.
+
+**Force enumeration in the prompt.** Summary-style prompts produce text that
+*looks* complete while quietly dropping the last onderdeel. Required form:
+
+> "List the structural skeleton of artikel N at this version: number of leden,
+> for each lid the ordered list of onderdeel-letters (a, b, c, …), and the last
+> letter present. Do not paraphrase, do not omit any onderdeel."
+
+Two independent calls per article (different phrasings) and compare; a
+disagreement is treated as a fetch reliability problem and triggers Staatsblad-
+fallback for that article.
+
+### 3. Calibration ijkpunten — verplicht
+
+Before any drift-report is emitted, the skill must independently re-find a set
+of pre-recorded **known drifts** for the corpus under review. The ijkpunten file
+lives **in the corpus** (`docs/drift-ijkpunten.md` or equivalent), **not in this
+skill**, so the skill stays dossier-agnostic.
+
+If calibration fails to recall ≥ 80% of known drifts: WebFetch is not reliable
+for this run. Retry with stricter prompts; on a second failure, fall back to
+Staatsblad-stack for the entire corpus. A drift-report **without** passing
+calibration is invalid and must be marked as such.
+
+### 4. Verbatim text fetch (textual axis)
+
+For articles that pass the structural axis, fetch the verbatim text per article
+with an enumeration-forcing prompt:
+
+> "Give the literal full text of artikel N at this version, lid by lid, onderdeel
+> by onderdeel, verbatim. State the last onderdeel letter explicitly so completeness
+> can be verified. Do not summarize, do not paraphrase, do not omit."
+
+### 5. Diff per article
+
+- Apply the single allowed whitespace normalization (collapse intra-paragraph
+  whitespace; preserve paragraph boundaries).
+- Word-level diff per paragraph. Output unified-diff at word granularity.
+- Diacritics differences count as DRIFT-tekst (per the verbatim principle).
+- Errata-style additions (e.g. parenthetical reading notes) present in the
+  geldende text must be present in the YAML; absence is drift.
+
+### 6. Adjacent fields (same file, same run)
+
+- `competent_authority.name` values across the file: check against the current
+  formal organ name at the geldende version. A historical name is drift.
+- `url:` anchors per article: must resolve to the artikel at the YAML's
+  `valid_from`. Anchors pointing at a different version (or a non-existent
+  article) are drift.
+
+### 7. Staatsblad fallback — five cases
+
+`wetten.overheid.nl` is primary. Fall back to the Staatsblad-stack
+(`zoek.officielebekendmakingen.nl`) **only** when:
+
+1. **Render lag** — a recent Stb. is published but not yet rendered in the
+   consolidation; the change exists in the publication of record.
+2. **Calibration fail** for a specific article: distrust the render, verify via
+   the Stb. that introduced the most recent change to that article.
+3. **Errata-style notations** (`[bedoeld zal zijn ...]` or equivalent): confirm
+   the notation is in the formal Stb. text, not a rendering artefact.
+4. **Version gap** — the YAML's `valid_from` falls between two consolidations
+   (deferred inwerkingtreding, retroactive effect): the Stb. clarifies the
+   inwerkingtredingsdatum.
+5. **Historical version reconstruction** — older `valid_from` where the current
+   render no longer shows the historical text cleanly.
+
+Local `pdftotext` is the final fallback for opaque PDFs; mark such articles as
+verified via local extraction.
+
+In the report, every article carries its verification mode:
+`primair: wetten.overheid.nl/<datum>` or `secundair: Stb. <jaartal>, <nr>` or
+`tertiair: local-pdf-extract`.
+
+### 8. Partial-failure handling — scope-restrictie
+
+After retry + Staatsblad-fallback, articles that remain NIET-VERIFIEERBAAR are
+**frozen** for the duration of the micro-cycle: any edit touching their text
+block, competent_authority value, or url anchor is blocked until the next drift
+pass. Other articles in the same file remain editable. The report lists frozen
+articles with the failure reason (TLS, rate-limit, persistent render issue) and
+a suggested retry timeframe.
+
+No bypass. The skill never permits "skip and continue".
+
+## Output
+
+### Drift-rapport (per file)
+
+```
+# Drift-rapport — <file path>
+bwb_id: ...
+valid_from: ...
+calibratie: ✅ (X/Y ijkpunten gerecalled) | ❌ (rapport invalide)
+
+| Artikel | Verdict | Bron-modus | Detail |
+|---------|---------|------------|--------|
+| 1       | CLEAN   | primair    | — |
+| 2       | DRIFT-structureel | primair | onderdeel z ontbreekt in YAML |
+| 3       | DRIFT-tekst | primair | lid 2: "<woord1>" → "<woord2>" |
+| ...     | ...     | ...        | ... |
+| N       | NIET-VERIFIEERBAAR | — | TLS-fout na 3 pogingen; bevroren |
+
+## Aggregaat
+- CLEAN: a
+- DRIFT-tekst: b
+- DRIFT-structureel: c
+- NIET-VERIFIEERBAAR (bevroren): d
+
+## Diakritiek-aggregaat (planning, geen excuus)
+Aantal artikelen waar diakritiek de enige driftbron is: e
+
+## Bevroren artikelen (scope-restrictie)
+- art. N — reden — suggested retry
+```
+
+### Resolutie-tracker entries
+
+Each DRIFT entry becomes a row in the corpus's `resolutie-tracker.md` with
+4-weg klasse 1 (Modellering-fout) and a link to the geldende wettekst. The
+fix lands in `modellering-fixes-plan.md` (corpus-side, not in this skill).
+
+### Sub-rapport diakritiek
+
+Aggregate list of articles whose only deviation is diacritics. This is NOT an
+exemption — diacritics-only drift still counts as DRIFT-tekst in the verdict
+table. The sub-rapport exists only to make a corpus-wide reconciliation
+plannable (one PR that restores accents corpus-wide, rather than per-article).
+
+## Integration with `regelrecht-stelselanalyse`
+
+- Inserted as Step 0 of every micro-cycle that may touch regulation YAMLs.
+- Findings → `resolutie-tracker.md` (status: `drift-gerapporteerd` /
+  `drift-opgelost`).
+- Fixes → `modellering-fixes-plan.md` as 4-weg klasse 1.
+- A micro-cycle may only collect findings on other axes (wetgevings-fouten,
+  untranslatables, coverage, source-refs) on articles that are CLEAN or whose
+  DRIFT-tekst is closed within the same cycle. Otherwise the finding is
+  mis-classified and rejected at synthesis time.
+
+## What this skill does NOT do
+
+- It does not edit YAMLs. It only reports.
+- It does not "fix" errata in the geldende wet. Errata are preserved verbatim
+  in the YAML; the wetgevings-fout is reported elsewhere.
+- It does not decide on diacritics policy. It reports the drift; a separate
+  corpus-wide reconciliation cycle decides whether to align the YAMLs to the
+  wet (verbatim) or to leave them — but the report is unambiguous.
+- It does not bypass under load. A flaky network produces scope-restrictie,
+  not a green report.
+
+## Files in this skill
+
+- `SKILL.md` — this document (process).
+- `reference.md` — URL patterns, the single allowed whitespace normalization
+  algorithm, prompt templates, verdict criteria, output format.
+
+## Hard rules
+
+- **Dossier-agnostisch.** No corpus content, no concrete drift examples, no
+  references to specific findings — those belong to the corpus the skill runs
+  against, not to the skill itself.
+- **Verbatim is wet.** No normalization beyond the single intra-paragraph
+  whitespace rule.
+- **Structure before text.** Always.
+- **Calibratie vóór rapport.** A report without passed calibration is invalid.
+- **Strict, no bypass.** Scope-restrictie handles partial failure; nothing
+  handles "skip this cycle's drift check".
+- **No push without permission.** Inherits the stelselanalyse protocol.

--- a/.claude/skills/law-version-drift-check/reference.md
+++ b/.claude/skills/law-version-drift-check/reference.md
@@ -1,0 +1,256 @@
+# Law Version Drift Check — Reference
+
+Operational reference for `law-version-drift-check`. Patterns, algorithms,
+prompt templates, output formats. Dossier-agnostisch.
+
+## 1. URL patterns
+
+### Primary: wetten.overheid.nl
+
+Per-version base URL:
+```
+https://wetten.overheid.nl/<BWB-id>/<YYYY-MM-DD>
+```
+
+Per-article anchor:
+```
+https://wetten.overheid.nl/<BWB-id>/<YYYY-MM-DD>#Artikel<N>
+```
+
+`<YYYY-MM-DD>` is the YAML's `valid_from`. Always supply the date explicitly —
+omitting it returns "current" and silently hides drift in older YAMLs.
+
+Information page (version history, change list):
+```
+https://wetten.overheid.nl/<BWB-id>/<YYYY-MM-DD>/0/informatie
+```
+
+### Secondary: Staatsblad / Staatscourant (officielebekendmakingen.nl)
+
+Publication of record:
+```
+https://zoek.officielebekendmakingen.nl/stb-<YYYY>-<NR>.html
+https://zoek.officielebekendmakingen.nl/stb-<YYYY>-<NR>.pdf
+https://zoek.officielebekendmakingen.nl/stcrt-<YYYY>-<NR>.html
+```
+
+Use the HTML form first; PDFs may need local extraction (see §4 fallback).
+
+## 2. The single allowed normalization
+
+Pseudocode for the intra-paragraph whitespace normalization. This is the **only**
+normalization permitted before diffing.
+
+```
+normalize(text):
+    paragraphs = split_on_blank_lines(text)
+    for each paragraph:
+        replace every run of whitespace (spaces, tabs, single line breaks)
+        with one space; trim leading/trailing whitespace.
+    rejoin paragraphs with a single blank line between them.
+```
+
+A paragraph boundary is a blank line in the rendered source. Paragraph
+boundaries between leden, between onderdelen, and between citation blocks are
+preserved exactly. Everything inside a paragraph — accents, quote glyphs,
+punctuation, capitalization — is preserved exactly.
+
+Apply the same normalization to both sides before diffing. Never apply it to
+only one side.
+
+## 3. Prompt templates
+
+### 3.1 Structural inventory prompt
+
+Use exactly this form (substitute `<N>` and the URL):
+
+> Visit `<URL>`. Return a structured skeleton of artikel `<N>`:
+>
+> - aantal leden
+> - voor elk lid: de geordende lijst van onderdeel-letters (a, b, c, …) en de
+>   laatste letter die in dit lid voorkomt
+> - of artikel `<N>` eindigt na een onderdeel of na een doorlopende alinea
+>
+> Do not paraphrase. Do not summarise. Do not omit the last onderdeel. If you
+> are uncertain about the last onderdeel, say so explicitly — do not guess.
+
+Run this prompt **twice with different surface phrasings**. Agreement → accept.
+Disagreement → escalate to Staatsblad-fallback for that article.
+
+### 3.2 Verbatim text prompt
+
+Use exactly this form:
+
+> Visit `<URL>`. Return the literal full text of artikel `<N>` at this version,
+> lid by lid and onderdeel by onderdeel, verbatim.
+>
+> - Begin each lid with its number followed by a period.
+> - Begin each onderdeel with its letter followed by a period.
+> - State the letter of the final onderdeel explicitly at the end.
+> - Preserve all punctuation, all accents, all parenthetical reading notes
+>   (e.g., bracketed editorial annotations within the text).
+> - Do not summarise. Do not paraphrase. Do not "clean up" obvious errors.
+
+### 3.3 Anchor / competent_authority verification prompt
+
+> At `<URL>`, what is the formal name of the orgaan that holds the function
+> referenced as `<role>` in artikel `<N>`? Return the name verbatim as it
+> appears in the geldende text on the indicated date.
+
+## 4. Fetch reliability ladder
+
+In order of precedence:
+
+1. WebFetch on `wetten.overheid.nl/<bwb>/<date>` with the structural prompt.
+2. Second WebFetch with rephrased structural prompt; require agreement with (1).
+3. WebFetch on the same URL with the verbatim prompt (only after structural pass).
+4. Fall back to Staatsblad (`zoek.officielebekendmakingen.nl/stb-...`) — HTML form.
+5. Local PDF extraction (`pdftotext` on the cached Stb. PDF) as final fallback.
+
+Mark each verification with its source mode in the report.
+
+## 5. Verdict assignment
+
+Given the two axes (structural, textual), assign verdict per article:
+
+```
+if structural_diff is not empty:
+    verdict = DRIFT-structureel
+    detail  = enumerate missing/extra elements by name
+elif textual_diff is not empty:
+    verdict = DRIFT-tekst
+    detail  = word-level unified diff per paragraph
+elif neither could be fetched after the ladder:
+    verdict = NIET-VERIFIEERBAAR
+    detail  = failure reason + suggested retry
+else:
+    verdict = CLEAN
+```
+
+Diacritics differences contribute to `textual_diff` and therefore to
+DRIFT-tekst. They are not exempt.
+
+A DRIFT-tekst entry whose **only** differences are diacritics is additionally
+counted in the diacritics-aggregate sub-table; its verdict remains DRIFT-tekst.
+
+## 6. Calibration ijkpunten
+
+The skill requires a corpus-local calibration file:
+```
+<corpus-root>/docs/drift-ijkpunten.md
+```
+
+Format (per ijkpunt):
+```
+- file: <relative path to YAML>
+  article: <number>
+  axis: structural | textual
+  expected: <one-line description of the known drift>
+```
+
+Before producing a drift-report, the skill independently re-finds each ijkpunt.
+Recall < 80% → run is invalid; produce no drift-report; report the calibration
+failure.
+
+The ijkpunten file lives in the corpus, not in this skill, so the skill stays
+dossier-agnostisch. Curate ijkpunten that exercise different failure modes:
+at least one DRIFT-structureel, one DRIFT-tekst, one diacritics-only.
+
+## 7. Output format
+
+### 7.1 Drift-rapport (one file)
+
+Markdown, written to `<corpus-root>/docs/drift-reports/<file-stem>-<run-date>.md`.
+
+```markdown
+# Drift-rapport — <relative-path-to-yaml>
+
+**Run-datum:** <YYYY-MM-DD HH:MM>
+**bwb_id:** <id>
+**valid_from (YAML):** <YYYY-MM-DD>
+**Calibratie:** ✅ (<recalled>/<total> ijkpunten) | ❌ <reason>
+
+## Verdict per artikel
+
+| Artikel | Verdict | Bron-modus | Detail |
+|---|---|---|---|
+| 1 | CLEAN | primair | — |
+| ... | ... | ... | ... |
+
+## Aggregaat
+- CLEAN: <n>
+- DRIFT-tekst: <n>
+- DRIFT-structureel: <n>
+- NIET-VERIFIEERBAAR (bevroren): <n>
+
+## Diakritiek-aggregaat (planning)
+Aantal artikelen waar diakritiek de enige driftbron is: <n>
+
+## Bevroren artikelen (scope-restrictie)
+- artikel <N> — <reason> — retry <suggested>
+
+## Adjacent fields
+- competent_authority: <verdict per name>
+- url anchors: <verdict per article>
+```
+
+### 7.2 Per-finding tracker entry
+
+Append to `<corpus-root>/docs/issues/drift-resolutie-tracker.md` (or equivalent
+location per stelselanalyse convention):
+
+```markdown
+| ID | File | Artikel | Verdict | Bron | Detail | Status |
+|---|---|---|---|---|---|---|
+| D-<seq> | <path> | <N> | DRIFT-tekst | primair | lid 2: "<a>" → "<b>" | drift-gerapporteerd |
+```
+
+Status vocabulary: `drift-gerapporteerd`, `drift-in-fix`, `drift-opgelost`,
+`drift-bevroren` (scope-restricted).
+
+### 7.3 Sub-report: diacritics aggregate
+
+A separate table in the same drift-rapport, listing the articles whose only
+deviation is diacritics. Used for planning a single corpus-wide reconciliation
+PR, not for excusing individual findings.
+
+## 8. Frozen-article semantics (scope-restrictie)
+
+A NIET-VERIFIEERBAAR article is frozen for the duration of the current
+micro-cycle. Concretely, the cycle's worker (Edit/Write tooling) must refuse:
+
+- any modification of the frozen article's `text:` block,
+- any modification of its `url:` anchor,
+- any modification of `competent_authority` values within the article's scope.
+
+The cycle may still touch other articles in the same file.
+
+The freeze lifts when the next drift-pass either gives the article a definitive
+verdict (CLEAN / DRIFT-*) or the cycle is closed (a new cycle starts with its
+own drift-pass).
+
+## 9. Pitfalls and forbidden shortcuts
+
+- **Open prompts.** "Summarise artikel N" produces text that *looks* complete
+  while losing the final onderdeel. Always force enumeration.
+- **Trusting a single fetch.** Two independent fetches with different phrasings;
+  disagreement → Staatsblad-fallback.
+- **One-sided normalization.** Never normalise only the geldende text and not
+  the YAML, or vice versa.
+- **Interpreting errata.** A bracketed editorial note in the geldende text
+  (e.g., a reading correction) belongs in the YAML verbatim. It is a
+  wetgevings-fout if reported separately to the wetgever; the YAML still
+  mirrors it.
+- **Skipping calibration.** A drift-report without passed calibration is not
+  a drift-report.
+- **Bypassing on load.** Flaky network → scope-restrictie. There is no
+  "skip" mode.
+
+## 10. Hand-off conventions
+
+- The skill writes its output to the corpus, never into itself.
+- The skill never edits regulation YAMLs. It produces reports and tracker
+  entries; the fix lands via the corpus's modellering-fixes-plan workflow
+  (see `regelrecht-stelselanalyse`).
+- The skill never pushes. Commits and PRs follow the corpus repo's protocol;
+  pushes require explicit user permission.

--- a/.claude/skills/reference-and-concept-hygiene/SKILL.md
+++ b/.claude/skills/reference-and-concept-hygiene/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: reference-and-concept-hygiene
+description: >
+  Builds and audits a concept-ontology for a regelrecht corpus to decide and verify reference
+  types — cross-law source-binding vs intra-law source-binding vs open-norm leaf vs external-fact
+  leaf — and to catch concept conflation across laws. Core principle: a value's reference type is
+  fixed by WHO derives it, and a binding is sound only when producer and consumer denote the SAME
+  concept; the lexical surface (the word in the text) is not the concept. Detects false friends
+  (one term, different concepts — e.g. a register-based vs a factual "naar de omstandigheden"-based
+  residence/ingezetene concept), orphan plain-params (a value a regulation actually derives, modeled
+  as a brute input), negation/complement re-entry (¬X modeled as an independent leaf next to X), and
+  duplication (one concept re-entered as several independent leafs, losing the single-source-of-truth
+  invariant). Produces a law-level glossary and a stelsel-level concept map with sound same-concept
+  binding edges and flagged lexical-match-but-concept-mismatch edges. Use when deciding whether a
+  value should be cross-law/intra-law/leaf, when the same term means different things across laws,
+  or when a binding might silently conflate concepts.
+allowed-tools: Read, Write, Bash, Grep, Glob, WebFetch, WebSearch, AskUserQuestion
+user-invocable: true
+---
+
+# Cross-law Concept & Binding Ontology
+
+Two recurring questions in a cross-law model: (1) what **reference type** should a value be —
+a cross-law source-binding, an intra-law source-binding, an open-norm leaf, or an external-fact
+leaf — and (2) is a given **binding sound**, given that the same term can denote a *different
+concept* in a different law. This skill answers both by building a concept-ontology and auditing
+references against it.
+
+## Core principle — type follows derivation, soundness follows concept identity
+
+> The reference type of a modeled value is fixed by **who derives it**. A source-binding is sound
+> only when the producer and the consumer denote the **same concept**. The lexical surface — the
+> word in the `text:` — is **not** the concept: two laws can use one word for different concepts
+> (false friends), or different words for one concept (synonyms). The engine runs a conflated
+> binding without complaint; only concept analysis catches it.
+
+## Reference-type decision procedure
+
+For each modeled value, ask in order:
+1. **Does another regulation derive it** (an endpoint computes it)? → **cross-law source-binding**.
+2. **Does the same regulation derive it** in another article? → **intra-law source-binding**.
+3. **Does the law delegate the determination** to a factual or discretionary judgment ("naar de
+   omstandigheden te beoordelen", "naar het oordeel van", "zo nodig geschat" — an open norm)? →
+   **open-norm leaf** (an injected judgment; the legislator opened the slot).
+4. **Brute fact** that no regulation derives and the law does not delegate as an open norm? →
+   **external-fact leaf**.
+
+Anti-patterns to flag:
+- **Orphan plain-param** — a value that a regulation actually derives (1 or 2) modeled as a brute
+  input. Smell: a leaf whose name matches an existing endpoint, or a value the text grounds in
+  "vastgesteld op grond van [andere regeling]".
+- **Negation/complement re-entry** — a value that is the logical complement of an existing
+  determination (¬X) modeled as an *independent* leaf, so the model permits X ∧ ¬X. Derive it from
+  the single determination instead.
+
+## The ontology — cluster by concept, not by word
+
+The discriminator is the **determination-mode**, not the lexeme. For each term the corpus reckons
+with, tag its mode:
+- **computed-rule** — derived by an endpoint;
+- **register/administrative** — an inschrijving in a register; a formal act;
+- **factual open-norm** — "naar de omstandigheden"; a weging of facts;
+- **composite** — a status = a factual core **+** a qualifier (e.g. *lawful*-X = factual-X + a
+  legality predicate);
+- **brute fact**.
+
+Then cluster surface forms into **canonical concepts** by mode + legal referent, not by spelling:
+- **False friends** — one lexeme, different concepts. A residence/ingezetene term that is
+  register-based in statute A but a factual "naar de omstandigheden"-weging in statute B is a
+  *different concept*. Binding A's predicate to B's endpoint is a conflation even though the words
+  match and the engine runs.
+- **Synonyms** — different lexemes, one concept → a binding is appropriate.
+- **Composites** — never bind a composite to one of its parts (lawful-resident ↛ factual-resident);
+  decompose into the part-bindings.
+
+## Binding-soundness audit
+
+For each existing source-binding `P (law A) ← E (law B)`:
+- **Same canonical concept** (mode + referent)? If not → **CONFLATION** (false friend); flag.
+- Is the consumer a **composite** and the producer one of its **parts** (or vice versa)? →
+  **PART/WHOLE mismatch**; decompose.
+
+Across the corpus:
+- Is one concept **re-entered as several independent leafs**? → **DUPLICATION**; lost
+  single-source-of-truth and lost mutual-exclusion invariant. Derive the rest from one determination.
+- Does a **plain-param** correspond to something a regulation derives? → **ORPHAN**; rebind.
+
+## Classification of each finding
+
+| Bucket | Meaning | Action |
+|---|---|---|
+| **structural-fix** | the reference type or binding is mechanically wrong vs the derivation/concept facts | rebind / derive from one source / decompose |
+| **concept-question (jurist)** | whether two concepts are *legally equivalent* is a normative call (e.g. "do we accept a register as proxy for a factual open norm?") | jurist decides; document the proxy-with-rationale or reject |
+| **accept-with-rationale** | a deliberate proxy (e.g. a register as best machine-readable indicator of a factual norm) | keep — but model the register as an **indicator that feeds** the open-norm weging, never as its silent **replacement**; annotate |
+
+**Cardinal rule:** a register may *inform* a factual open-norm determination but must not silently
+*replace* it — that substitution is the canonical conflation (mirrors the standard "naar de
+omstandigheden te beoordelen" + "een enkele inschrijving is niet voldoende"-doctrine). Keep the model
+**symmetric**: if one side of a stelsel models a concept factually, the mirror side must too, unless a
+documented decision says otherwise.
+
+## Output
+
+- **Law-level glossary** (per law): `term → canonical concept → determination-mode → reference-type →
+  endpoint/leaf id`.
+- **Stelsel-level concept map**: concepts as nodes; sound same-concept binding edges; and a flagged
+  list of false-friend edges (lexical match, concept mismatch), orphan plain-params, complement
+  re-entries, and duplications.
+- A **reference-hygiene report** classifying each finding (structural-fix / concept-question /
+  accept-with-rationale), with a jurist-question per concept-equivalence call.
+
+## Verification (no hunches)
+
+Confirm a "derived" claim by locating the producing endpoint; confirm a conflation by showing the
+**determination-modes differ**, not by the wording. After a rebind/derive/decompose: schema-validation
+and cross-law-integriteit stay green, and end-to-end outcomes are unchanged where the concept was
+already equivalent (anti-masking: flip a source fact, see the outcome move). A rebinding that changes
+outcomes means the concepts were genuinely different — that is a finding, not a regression.
+
+## Relation to other skills
+
+- `law-letter-fidelity-audit` — is the model faithful to the **letter** (vs toelichting / desired
+  outcome)? Orthogonal to this skill, which asks whether the **references** are the right type and
+  whether bindings respect **concept identity**. Run fidelity first (terms letter-true), then this
+  (terms wired and clustered right).
+- `law-generate` — the placement/binding mechanics (`source` under `input:`, not `parameters:`). This
+  skill decides *which* binding type and *whether* a binding is conceptually sound.
+- `regelrecht-stelselanalyse` — cross-law-integriteit (dangling / plain-param) is the **mechanical**
+  layer; this skill adds the **conceptual** layer on top (same-concept binding, false-friend
+  detection).

--- a/.claude/skills/regelrecht-audit-products/SKILL.md
+++ b/.claude/skills/regelrecht-audit-products/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: regelrecht-audit-products
+description: Bouwt de audit- en workshop-producten waarmee juridische experts een machine-leesbare (regelrecht-YAML) vertaling van wet- en regelgeving valideren in een live sessie. Gebruik dit bij het voorbereiden van een expert-workshop of validatie-sessie over een dossier, het maken van een scope-/stelselanalyse, per-artikel audit-checklists, facilitator-materiaal, testcase-scenario's, of sessie-verslagen (intern + extern). Dossier-agnostisch; de regelrecht-methode (YAML, formules, untranslatables, source/override, legal_basis, engine-trace) is de vaste taal. Voor analytische desk-review van een corpus zonder live sessie (wetgevings-/stelselfouten, coverage, multi-agent review): zie de zusterskill regelrecht-stelselanalyse.
+allowed-tools: Read, Write, Edit, Grep, Glob, Bash, AskUserQuestion
+---
+
+# Regelrecht audit- & workshop-producten
+
+Genereert de documenten waarmee een analist een machine-leesbare vertaling van
+regelgeving (regelrecht-YAML) laat valideren door domein-experts — voorbereiding,
+facilitatie, en nazorg van een **live validatie-sessie**.
+
+> **Twee skills + een router.** Dit is de live-sessie-familie. De analytische
+> **desk-review**-familie woont in **`regelrecht-stelselanalyse`**. Twijfel je waar te
+> beginnen of hoe ze samenhangen → **`regelrecht-dossier`** (front-door router).
+
+## Routing & handoff
+
+Feitelijke defecten routeren naar de desk (`regelrecht-stelselanalyse`); oordeels-/
+praktijkvragen naar de workshop (hier). Twee workshop-modi: **verkennend** (vroeg, geen
+gate — domeinkennis ontginnen op een ruwe scope-analyse) en **validerend** (gate: schema
+valide + tests groen + modellering-fouten gefixt + resterende open punten zijn judgment).
+Na de sessie gaan correctiepunten + bevestigde interpretaties terug de desk-cyclus in.
+Canonieke flow: zie `regelrecht-dossier/references/routing.md`.
+
+Deze skill bevat **geen casus-inhoud**. Hij is generiek over dossiers; alleen de
+regelrecht-*methode* ligt vast. Concrete casus-inhoud (welke wet, welke gronden,
+welke bedragen) komt uit de aangeleverde casus-map of uit de analist tijdens het
+opbouwen.
+
+## Wanneer gebruiken
+
+- "Ik ga een workshop / validatie-sessie voorbereiden over dossier X"
+- "Maak een scope-analyse / stelseloverzicht voor deze casus"
+- "Maak audit-documenten voor de artikelen die we gaan doornemen"
+- "Ik heb facilitator-materiaal nodig (draaiboek, spiekbriefje, jargon-uitleg)"
+- "Maak testcase-scenario's voor een vervolgsessie"
+- "Schrijf een verslag van de sessie (intern / voor de klant)"
+- "Doe een analytische review van de machine-readable correctheid van dit corpus"
+
+## Kernprincipe: hybride, modus per product
+
+Niet alles wordt automatisch gegenereerd, en niet alles is handwerk. **Per product
+de juiste modus** (zie `references/products.md` voor de volledige catalogus):
+
+- **Auto-uit-YAML** (hoog): stelsel/scope-overzicht en de analytische review zijn
+  grotendeels af te leiden uit het scope-manifest + de YAML's (legal_basis, source,
+  overrides, outputs, untranslatables).
+- **Semi-auto, analist legt focus** (midden): per-artikel audit-docs en het
+  draaiboek — de skill extraheert structuur uit de YAML, maar **welke kernartikelen
+  en welke focus** bepaal je samen met de analist. Vraag dit expliciet.
+- **Mens-gedreven, skill structureert** (laag): verslagen en testcase-uitkomsten
+  leunen op observaties/keuzes die alleen de analist heeft; de skill levert de
+  structuur en stelt gericht vragen.
+
+Forceer nooit volledige automatisering waar contextkennis van de analist nodig is.
+Bij twijfel: gebruik `AskUserQuestion` om focus, sessie-doel, deelnemers of
+beoordelings-paden op te halen voordat je schrijft.
+
+## Werkstroom
+
+1. **Oriënteer op de casus-map.** Verwacht een casus-map met een scope-manifest
+   (welke wetten/artikelen in scope) + verwijzingen naar de machine-readable
+   YAML's in het corpus. Lees `references/inputs.md` voor wat je nodig hebt en hoe
+   je het detecteert. Ontbreekt het scope-manifest, help het dan eerst opstellen.
+
+2. **Bepaal welke producten nodig zijn.** Vraag het, of leid het af uit de vraag.
+   Zie de productcatalogus in `references/products.md`. Veel producten bouwen op
+   elkaar voort (volgorde-afhankelijkheden staan daar).
+
+3. **Bouw per product in de juiste modus.** Start vanuit het bijbehorende sjabloon
+   in `templates/`. Vul uit de YAML wat automatisch kan; haal focus/keuzes op bij de
+   analist waar nodig. Houd je aan de regelrecht-terminologie uit
+   `references/method-glossary.md`.
+
+4. **Schrijf naar de casus-map, niet in de skill.** Output gaat naar de
+   werkomgeving van het dossier (bijv. een `audit/`- of `docs/`-map van de casus).
+   Wijzig nooit de sjablonen in deze skill met casus-inhoud.
+
+5. **Commit/push alleen op verzoek.** Nooit ongevraagd pushen.
+
+## Bestanden in deze skill
+
+- `references/products.md` — productcatalogus: per product het doel, de input, de
+  modus/automatiseringsgraad, hoe te bouwen, en de onderlinge volgorde.
+- `references/method-glossary.md` — de regelrecht-concepten (YAML, engine, output,
+  parameter, input, source, caller, action, definition, untranslatable, override,
+  legal_basis) in vaste, generieke bewoordingen. De gedeelde taal van alle producten.
+- `references/inputs.md` — wat de skill als input verwacht (casus-map, scope-manifest,
+  corpus-YAML's) en hoe je dat detecteert of helpt opstellen.
+- `references/facilitation-patterns.md` — herbruikbare werkvormen en facilitator-
+  technieken (walk-through-protocol A/B/C, 1-2-4-all, time-boxing, risico's +
+  back-pockets) die in draaiboek, brief en vervolgsessie terugkomen.
+- `templates/` — generieke skeletten per product (zie catalogus voor de mapping).
+
+## Belangrijke regels
+
+- **Dossier-agnostisch blijven.** Geen vaste wet-namen, bedragen, of casus-specifieke
+  voorbeelden in de skill-bestanden. In *output* mag casus-inhoud uiteraard wel.
+- **Vertrouwelijkheid.** Neem geen persoonsgegevens of vertrouwelijke casus-details op
+  in producten die voor verspreiding bedoeld zijn (bijv. extern verslag, scenario's).
+  Testcase-scenario's zijn fictief of sterk-gelijkend, nooit echte persoonsgegevens.
+- **Twee verslag-varianten gescheiden houden.** Intern (eerlijk, reflectief, voor het
+  eigen team) vs extern (hoogover, waarderend, voor de klant) — nooit vermengen.
+- **Engine-uitkomsten zijn feiten, geen oordeel.** In het Claude-orakel en in
+  scenario's: toon wat de YAML/engine zegt, laat het juridische oordeel bij de experts.
+</content>
+</invoke>

--- a/.claude/skills/regelrecht-audit-products/SKILL.md
+++ b/.claude/skills/regelrecht-audit-products/SKILL.md
@@ -104,5 +104,3 @@ beoordelings-paden op te halen voordat je schrijft.
   eigen team) vs extern (hoogover, waarderend, voor de klant) — nooit vermengen.
 - **Engine-uitkomsten zijn feiten, geen oordeel.** In het Claude-orakel en in
   scenario's: toon wat de YAML/engine zegt, laat het juridische oordeel bij de experts.
-</content>
-</invoke>

--- a/.claude/skills/regelrecht-audit-products/references/facilitation-patterns.md
+++ b/.claude/skills/regelrecht-audit-products/references/facilitation-patterns.md
@@ -1,0 +1,78 @@
+# Facilitatie-patronen
+
+Herbruikbare werkvormen en technieken die terugkomen in draaiboek, facilitator-brief
+en vervolgsessie. Generiek — vul casus-inhoud bij gebruik.
+
+## Walk-through-protocol per output (A/B/C)
+
+Per `machine_readable` output, in splitview (formules-doc links, sessie-notities rechts):
+
+- **A — Vertellen** (≈1 min): lees de wettekst-quote + de formule + één zin context.
+- **B — Toetsen** (2–8 min): drie micro-vragen —
+  1. *Dekt de formule de wettekst?*
+  2. *Klopt de bron-/source-verwijzing?*
+  3. *Kennen jullie een case die dit breekt?*
+  Klik checkbox of noteer.
+- **C — Fixeren** (≈30 s): *"Output X: 2 vinkjes, N open cases. Door."*
+
+Geef elke output een **harde time-box**; de zwaarste output krijgt het meeste budget.
+Zet een timer.
+
+## 1-2-4-all (voor beslispunten)
+
+Per beslispunt, max ~3 min:
+1. 30 s individueel: *"wat zou jij kiezen?"*
+2. 1 min in paren: *"match jullie?"*
+3. 1 min in viertallen (bij grotere groep): *"waar wijken we af?"*
+4. groepsoordeel + **noteer minderheidsstandpunt expliciet**.
+
+Per beslispunt vooraf voorbereiden: het punt in één zin, het **verwachte weerwoord**,
+en je **comeback**.
+
+## Scope bekrachtigen (Venn / dot-voting)
+
+- Fysiek Venn-/lagen-diagram op tafel; laat mensen er overheen wijzen.
+- Dot-voting: ieder N groene dots ("kennen we door-en-door") + N rode ("blinde vlek").
+- Dot-profiel stuurt scope-keuze: een blok met 0 groene dots is een veilig
+  "buiten scope" / "later".
+
+## Kennis-oogst (brown paper, 3 kleuren)
+
+Sticky-notes in drie kleuren: 🟨 kern van het onderwerp · 🟩 wat loopt goed ·
+🟥 wat loopt stroef / vragen. 5 min schrijven → 10 min plakken → 10 min clusteren.
+De 🟥-stack is het belangrijkst — foto maken. Doe zelf één gele sticky vooraf om de
+drempel te verlagen.
+
+## Time-management
+
+- Pauze inplannen en **niet skippen** bij sessies > ~75 min.
+- Harde stops per blok; bij oploop → **parkeren** in open-punten, niet doortrekken.
+- 5-minuten-regel bij verzanding in één edge-case.
+
+## Risico's + back-pocket-zinnen
+
+| Signaal | Back-pocket |
+|---|---|
+| Experts voelen zich getoetst | "Wij hebben een voorstel, jullie schieten het stuk — dat is het doel." |
+| Eén expert domineert | "Even een rondje — wat denk jij, [naam]?" |
+| Verzanding in één edge-case | "Na 5 min → parkeren in open-punten, verder." |
+| Te abstracte discussie | Case-based maken: "Stel [fictieve persoon], [bedrag], [situatie] — wat gebeurt er?" |
+| Niemand durft te besluiten | "Beslissingen zijn niet voor eeuwig — morgen kunnen we terugdraaien." |
+
+**Plan B als het volledig stroef loopt**: case-vertelling dóór de wettekst heen i.p.v.
+door de YAML; of de groep zelf een beslisboom laten tekenen.
+
+## De rol van Claude in de sessie
+
+Optioneel YAML-lookup-orakel (zie `templates/claude-orakel-prompt.md`). Alleen
+droog-feitelijk: *"wat zegt de YAML?"*, *"wat zou de engine doen bij case X?"*. Geen
+juridisch oordeel. Rode vlag: als Claude gaat adviseren i.p.v. opzoeken → corrigeer
+met *"Blijf bij de YAML-lookup. Wat zegt de YAML feitelijk?"*. In de praktijk niet
+altijd nodig — overweeg vooraf of de sessie het echt gebruikt.
+
+## Vertel-eerst-dan-uitleg-regel
+
+Als een deelnemer naar een term vraagt: **vertaal eerst, leg dan uit** (zie
+`jargon-spiekbriefje`). Zo blijft iedereen aangehaakt zonder dat de discussie in
+jargon verzandt.
+</content>

--- a/.claude/skills/regelrecht-audit-products/references/facilitation-patterns.md
+++ b/.claude/skills/regelrecht-audit-products/references/facilitation-patterns.md
@@ -75,4 +75,3 @@ altijd nodig — overweeg vooraf of de sessie het echt gebruikt.
 Als een deelnemer naar een term vraagt: **vertaal eerst, leg dan uit** (zie
 `jargon-spiekbriefje`). Zo blijft iedereen aangehaakt zonder dat de discussie in
 jargon verzandt.
-</content>

--- a/.claude/skills/regelrecht-audit-products/references/inputs.md
+++ b/.claude/skills/regelrecht-audit-products/references/inputs.md
@@ -42,4 +42,3 @@ het scope-analyse-product; lever het meteen in dat formaat op.
 Als alleen één wet/artikel + YAML beschikbaar is, kun je nog steeds een
 per-artikel audit-doc maken. Scope-analyse en de keten-producten vereisen meer dan
 één wet in beeld.
-</content>

--- a/.claude/skills/regelrecht-audit-products/references/inputs.md
+++ b/.claude/skills/regelrecht-audit-products/references/inputs.md
@@ -1,0 +1,45 @@
+# Input — wat de skill verwacht en hoe je het detecteert
+
+De skill start typisch vanaf een **casus-map met een scope-manifest + verwijzingen
+naar de machine-readable YAML's** in een corpus. Casussen verschillen per dossier;
+de structuur hieronder is het generieke patroon.
+
+## Wat je nodig hebt
+
+1. **Scope-manifest** — welke wetten/regelingen en welke artikelen in scope zijn,
+   met hun rol in de keten en het pad naar de YAML. Vaak een `scope.yaml` of een
+   tabel in een analyse-document. Bevat per wet minimaal: law-id, laag (A/B/C/D),
+   rol, YAML-pad.
+
+2. **Corpus-YAML's** — de machine-readable bestanden zelf (geversioneerd per
+   inwerkingtredingsdatum). Hieruit haal je: outputs, actions/formules, parameters,
+   inputs, `source:`-koppelingen, `definitions`, `untranslatables`, `overrides`,
+   `legal_basis` (incl. per-formule `explanation`-quotes).
+
+3. **Wettekst-bron-URL's** — de officiële publicatie per wet/artikel (voor
+   wettekst-excerpts en links in de audit-docs). Vaak afleidbaar uit de YAML-metadata.
+
+## Hoe je detecteert wat er is
+
+- Zoek in de casus-map naar een scope-manifest (`*scope*`, of een analyse-doc met
+  een wetten-tabel).
+- Zoek de genoemde YAML-paden op in het corpus; verifieer dat ze bestaan en lees de
+  relevante artikelen.
+- Als er al een formules-afgeleide (bijv. een gegenereerde `formules.md`) bestaat,
+  gebruik die als secundaire bron naast de YAML.
+- Controleer of de engine een trace kan produceren (voor scenario-uitkomsten en het
+  orakel) — zo niet, vraag de analist om uitkomsten of reken op de wettekst.
+
+## Wat als het scope-manifest ontbreekt
+
+Help het eerst opstellen. Loop het corpus af voor de wetten die de casus raken,
+classificeer ze in lagen (A/B/C/D — zie `method-glossary.md`), en leg de relaties
+vast (source-calls, legal_basis, overrides). Dit ís feitelijk de eerste helft van
+het scope-analyse-product; lever het meteen in dat formaat op.
+
+## Minimaal startpunt
+
+Als alleen één wet/artikel + YAML beschikbaar is, kun je nog steeds een
+per-artikel audit-doc maken. Scope-analyse en de keten-producten vereisen meer dan
+één wet in beeld.
+</content>

--- a/.claude/skills/regelrecht-audit-products/references/method-glossary.md
+++ b/.claude/skills/regelrecht-audit-products/references/method-glossary.md
@@ -1,0 +1,94 @@
+# Regelrecht-methode — vaste begrippen
+
+De gedeelde taal van alle audit- en workshop-producten. Generiek: vul de
+`{voorbeelden}` met casus-inhoud bij gebruik, maar de definities liggen vast.
+
+## Kern-metafoor (voor niet-technische deelnemers)
+
+> "Stel je een junior-medewerker voor die je wilt leren een beschikking te nemen.
+> Je geeft haar een stappenplan. De YAML is dat stappenplan. De engine is de
+> medewerker die het uitvoert. Alles wat we vandaag bespreken gaat over: klopt het
+> stappenplan?"
+
+## Snel-overzicht
+
+| Begrip | Mensentaal |
+|---|---|
+| **YAML** | Het regel-stappenplan als tekstbestand (mens + computer leesbaar) |
+| **Engine** | Het programma / de 'junior-medewerker' die het stappenplan uitvoert |
+| **Output** | Het eindantwoord van een (artikel in een) wet |
+| **Parameter** | Waarde die de *caller* aanlevert (bijv. BSN, een bedrag, een type) |
+| **Input** | Waarde die de engine zélf ergens ophaalt (uit een andere wet) |
+| **Source** | Het mechanisme waarmee een input uit een andere wet wordt opgehaald |
+| **Caller** | Het systeem dat de engine aanroept (het uitvoerings-systeem) |
+| **Action** | Eén formule die één output berekent |
+| **Definition** | Vaste waarde uit de wettekst (een drempel, een percentage) |
+| **Untranslatable** | Wettekst die bewust níet in een formule zit (menselijk oordeel) |
+| **Override** | Een andere regeling vervangt jouw formule/waarde |
+| **legal_basis** | De juridische grondslag onder een regel + per-formule wettekst-quote |
+
+## Definities
+
+### YAML — het stappenplan
+Tekstbestand met regels die zowel mens als computer kan lezen. Elke wet/regeling
+heeft een eigen YAML-bestand, geversioneerd per inwerkingtredingsdatum.
+
+### Engine — de uitvoerder
+Leest de YAML en komt tot een antwoord. Produceert een **trace**: stap-voor-stap
+welke parameters welke outputs voeden en in welke volgorde de actions draaien.
+
+### Output — het eindantwoord
+Wat een artikel teruggeeft. Een artikel kan meerdere outputs hebben (bijv. een
+ja/nee-gate én een bedrag).
+
+### De drie soorten invoer
+- **Parameter** — wat de caller aanlevert; verschilt per geval.
+- **Input** — wat de engine automatisch uit een andere wet haalt; de caller ziet
+  het niet.
+- **Source** — de koppeling die een input vult (`source:` → andere wet/output).
+
+Onderscheid parameter vs definition in één zin: *"Definition = een getal uit de
+wet zelf. Parameter = een getal dat de caller moet aanleveren."*
+
+### Action — één berekening
+Eén regel/formule die één output berekent. Noteer formules in wiskundige/natuurlijke
+notatie (AND/OR/IF/MAX/MULTIPLY), **niet** als YAML, in audit-documenten.
+
+### Untranslatable — bewust niet gemodelleerd
+Stuk wettekst dat menselijk oordeel vergt ("naar het oordeel van", "bijzondere
+omstandigheden", "aannemelijk maken") en daarom niet als formule is vertaald.
+
+Twee subtypes — belangrijk om te benoemen in een audit:
+- **Factual** (feitelijk vaststelbaar door een systeem): kán alsnog een
+  caller-parameter / gate worden.
+- **Judgment** (oordeelsvorming / prognose): blijft untranslatable zonder
+  waardeverlies.
+
+### Override — andere regeling wint
+Een andere regeling zegt "gebruik mijn waarde/formule voor jouw output". Markeer
+de grondslag-vraag expliciet: werkt de override mechanisch correct, maar klopt de
+juridische *grondslag-attributie*? (Een klassieke valkuil: de mechanische route is
+korter dan juridisch houdbaar.)
+
+### legal_basis — grondslag + quote
+Waar berust deze regel op (welke wet, welk artikel), en — per formule — de
+letterlijke wettekst-quote die de formule dekt (`legal_basis.explanation`). Dit is
+wat je voorleest tijdens een walk-through: *"De YAML zegt: '{quote}'. Klopt dat?"*
+
+## Stelsel-lagen (voor scope-analyse)
+
+Dossiers vallen vaak in lagen. Generiek patroon:
+- **Laag A — grondslag**: de formele wet die delegeert (vaak niet zelf
+  machine-leesbaar, alleen `legal_basis`-doel).
+- **Laag B — uitwerking**: lagere regeling(en) waar de kern-berekening leeft.
+- **Laag C — lokale/uitvoerende laag**: de orchestrator die scope kiest en
+  bovenliggende lagen inpakt via `source:`-calls.
+- **Laag D — databronnen**: wetten die alleen *data* leveren (persoonsgegevens,
+  normen), geen formules in de keten.
+
+Drie relatie-types in de wet-graph:
+- `==source==>` executie-tijd data-call (formule A haalt waarde uit wet B)
+- `-.grondslag.->` legal_basis (juridisch fundament, geen runtime-dependency)
+- `--overrides-->` B verandert de betekenis van A's output
+- `-.data.->` impliciete parameter-dependency (databron levert data, geen formule)
+</content>

--- a/.claude/skills/regelrecht-audit-products/references/method-glossary.md
+++ b/.claude/skills/regelrecht-audit-products/references/method-glossary.md
@@ -91,4 +91,3 @@ Drie relatie-types in de wet-graph:
 - `-.grondslag.->` legal_basis (juridisch fundament, geen runtime-dependency)
 - `--overrides-->` B verandert de betekenis van A's output
 - `-.data.->` impliciete parameter-dependency (databron levert data, geen formule)
-</content>

--- a/.claude/skills/regelrecht-audit-products/references/products.md
+++ b/.claude/skills/regelrecht-audit-products/references/products.md
@@ -117,4 +117,3 @@ stelselfouten-analyse, multi-agent review + synthese, resolutie-tracker met bron
 verificatie, eindrapport per cyclus) is **geen workshop-product** en woont in de
 zusterskill `regelrecht-stelselanalyse`. Gebruik die skill zodra het gaat om fouten in
 de *wet zelf* of de *engine* i.p.v. validatie van onze modellering met experts.
-</content>

--- a/.claude/skills/regelrecht-audit-products/references/products.md
+++ b/.claude/skills/regelrecht-audit-products/references/products.md
@@ -1,0 +1,120 @@
+# Productcatalogus
+
+Per product: doel, input, modus + automatiseringsgraad, hoe te bouwen, en het
+bijbehorende sjabloon. **Modus** volgt het hybride principe uit SKILL.md:
+`auto` (uit YAML), `semi-auto` (analist legt focus), `mens-gedreven` (skill
+structureert observaties van de analist).
+
+## Onderlinge volgorde
+
+```
+1. Scope-analyse + wet-graph        (auto)            ── fundament
+2. Per-artikel audit-doc            (semi-auto)       ── per kernartikel
+        │
+        ├─► 3. Workshop-draaiboek   (semi-auto)
+        │       ├─► 4. Facilitator-brief    (auto, condenseert 3)
+        │       ├─► 5. Jargon-spiekbriefje  (auto + casus-voorbeelden)
+        │       └─► 6. Claude-orakel-prompt (semi-auto)
+        │
+        └─► 7. Testcase-scenario's  (semi-auto, vereist engine-uitkomsten)
+                └─► vervolgsessie-werkvorm (in zelfde sjabloon)
+
+na de sessie:
+   8. Verslag intern   (mens-gedreven)
+   9. Verslag extern   (mens-gedreven, afgeleid van 8)
+
+alternatief spoor (geen live sessie):
+   → zie de zusterskill `regelrecht-stelselanalyse` (desk-review & corpus-completion)
+```
+
+Bouw 1 en 2 altijd eerst; de facilitatie-producten leunen erop.
+
+---
+
+## 1. Scope-analyse + wet-graph — `templates/scope-analyse.md`
+**Doel.** Het wettelijk stelsel rond de casus in kaart: welke wetten, in welke laag,
+hoe ze samenhangen (source / legal_basis / override / data), en welke scope-keuzes
+de experts moeten bekrachtigen.
+**Input.** Scope-manifest + YAML's (legal_basis, source, overrides).
+**Modus.** `auto` — leid de lagen, relaties en de mermaid-graph af uit de YAML's.
+Laat de analist de laag-indeling en de scope-beslispunten bevestigen.
+**Bouw.** (a) Wetten-tabel met laag + rol + YAML-pad. (b) Mermaid-graph met de vier
+relatie-types. (c) Runtime-afhankelijkheden (source-calls). (d) legal_basis-keten.
+(e) Override-relaties. (f) Scope-beslispunten (S1..Sn) als checkboxes.
+
+## 2. Per-artikel audit-doc — `templates/audit-doc.md`
+**Doel.** Kern-validatiedocument: koppelt elke `machine_readable` output aan de
+wettekst, zodat een jurist rij-voor-rij kan controleren. Bevat untranslatables en
+open punten.
+**Input.** De YAML van het artikel + de wettekst-bron.
+**Modus.** `semi-auto` — extraheer outputs/formules/untranslatables uit de YAML,
+maar **bepaal samen met de analist welke artikelen kernartikelen zijn** en waar de
+focus ligt. Vraag dit met `AskUserQuestion` voordat je alle artikelen uitwerkt.
+**Bouw.** Per output: wettekst-excerpt (letterlijk, met subsectie + link), formule
+(natuurlijke notatie), interpretatie, YAML-locatie, en review-checkboxes (punten die
+de jurist apart bevestigt). Daarna: untranslatables-tabel (factual vs judgment),
+externe overrides met grondslag-nuance, en open punten voor de sessie.
+
+## 3. Workshop-draaiboek — `templates/workshop-draaiboek.md`
+**Doel.** Inhoudelijk draaiboek voor de facilitator: agenda, walk-through per output,
+beslispunten, werkvormen. Niet bedoeld om op scherm te tonen.
+**Input.** Audit-docs (2) + scope-analyse (1) + sessie-doel + deelnemers.
+**Modus.** `semi-auto` — skelet en walk-through-volgorde uit de audit-docs; tijden,
+werkvormen en beslispunten samen met de analist (sessie-duur, aantal deelnemers,
+zwaartepunten). Vraag doel/duur/deelnemers op.
+**Bouw.** Gebruik de patronen uit `facilitation-patterns.md` (protocol A/B/C,
+1-2-4-all, time-boxing). Per output een time-box en key-reminders; beslispunten met
+verwacht weerwoord + comeback.
+
+## 4. Facilitator-brief — `templates/facilitator-brief.md`
+**Doel.** 1-A4 spiekbriefje voor tijdens de sessie (klaarzetten, blok-voor-blok
+reminders, risico's + back-pockets, checklist).
+**Input.** Het draaiboek (3).
+**Modus.** `auto` — condenseer het draaiboek naar het korte format. Voeg niets nieuws
+toe; dit is een afgeleide.
+
+## 5. Jargon-spiekbriefje — `templates/jargon-spiekbriefje.md`
+**Doel.** Schema-/engine-termen in mensentaal, met één concreet casus-voorbeeld per
+term, plus back-pocket-antwoorden op lastige vragen.
+**Input.** `method-glossary.md` + casus-voorbeelden.
+**Modus.** `auto` voor de generieke uitleg; de analist levert de concrete
+casus-voorbeelden per term aan (of je leidt ze af uit de YAML).
+
+## 6. Claude-orakel-prompt — `templates/claude-orakel-prompt.md`
+**Doel.** Systeem-prompt die Claude in een YAML-lookup-rol zet tijdens de sessie:
+citeert de YAML, simuleert de engine, signaleert gaps — geeft **geen** juridisch
+oordeel.
+**Input.** De casus-keten (welke YAML's, welke outputs, welke source-calls).
+**Modus.** `semi-auto` — vul de context-sectie (casus, bronnen, scope, outputs,
+delegaties) uit de YAML's; de rol-instructies zijn generiek.
+
+## 7. Testcase-scenario's (+ vervolgsessie-werkvorm) — `templates/testcase-scenarios.md`
+**Doel.** Een set scenario's die elk een ander beoordelings-pad raken, met de
+engine-uitkomst per scenario; plus een draaiboek voor een testcase-sessie ("komen
+jullie op hetzelfde uit als de engine, en hoe rekenen jullie?").
+**Input.** De engine (voor uitkomsten) + de hoofdpaden uit de audit-docs.
+**Modus.** `semi-auto` — de analist kiest welke beoordelings-paden de scenario's
+moeten raken; de skill stelt scenario's voor en haalt engine-uitkomsten op (of
+vraagt ze). **Scenario's zijn fictief of sterk-gelijkend — nooit persoonsgegevens.**
+
+## 8. Verslag intern — `templates/verslag-intern.md`
+**Doel.** Eerlijk, reflectief verslag voor het eigen team: wat is werkelijk gedaan,
+onderzoek-/correctiepunten, sessie-dynamiek, tooling-leerpunten, way forward.
+**Input.** Sessie-notities/observaties van de analist.
+**Modus.** `mens-gedreven` — de skill structureert; de inhoud (observaties,
+correctiepunten) komt van de analist. Stel gerichte vragen om de secties te vullen.
+
+## 9. Verslag extern — `templates/verslag-extern.md`
+**Doel.** Hoogover, waarderende terugkoppeling voor de klant: wat we samen deden,
+wat het opleverde (op hoofdlijnen), vervolg.
+**Input.** Het interne verslag (8).
+**Modus.** `mens-gedreven` — afgeleid van het interne verslag, maar **abstraheer**:
+geen detail-bevindingen, geen interne reflecties, geen vertrouwelijke details.
+
+## 10. Analytische desk-review → **aparte skill `regelrecht-stelselanalyse`**
+Het analytische desk-spoor (corpus-review op correctheid/coverage, wetgevings-/
+stelselfouten-analyse, multi-agent review + synthese, resolutie-tracker met bronnen-
+verificatie, eindrapport per cyclus) is **geen workshop-product** en woont in de
+zusterskill `regelrecht-stelselanalyse`. Gebruik die skill zodra het gaat om fouten in
+de *wet zelf* of de *engine* i.p.v. validatie van onze modellering met experts.
+</content>

--- a/.claude/skills/regelrecht-audit-products/templates/audit-doc.md
+++ b/.claude/skills/regelrecht-audit-products/templates/audit-doc.md
@@ -1,0 +1,110 @@
+# Audit — {Wet/regeling} {artikel}
+
+**Wet**: {volledige naam + versie/jaar}
+**`$id`**: `{law_id}`
+**Type**: {wet / ministeriële regeling / beleidsregel / verordening / …}
+**Wet-URL**: {officiële publicatie-URL}
+**YAML-bestand**: `{pad naar YAML}`
+**Laatste review**: —
+**Reviewer(s)**: —
+
+---
+
+## Werkwijze
+
+{Eén of meer zinnen: hoe is dit artikel gestructureerd, en hoe is de
+machine_readable-vertaling opgezet (bijv. alles wat de beschikking bepaalt in één
+`machine_readable`-block; per output gekoppeld aan de wettekst).}
+
+Symbolische kortschriften die in formules worden gebruikt:
+
+- `{symbool}` = `{parameter/output-naam}` ({korte uitleg})
+- …
+
+---
+
+## (optioneel) Wijzigingen t.o.v. vorige versie
+
+*Alleen invullen als deze YAML een nieuwere versie van een eerdere is.*
+
+| Subartikel | Oude tekst | Nieuwe tekst | Impact op MR |
+|---|---|---|---|
+| {x} | {…} | {…} | {Geen / wel — toelichting} |
+
+**Totaal-impact op machine_readable**: {NIHIL / beperkt / substantieel — onderbouw}.
+
+---
+
+## Output {n} — `{output_naam}`
+
+**Wettekst-excerpt** — uit {wet} {subsectie} *"{kopje}"*:
+
+> "{letterlijk citaat uit de wettekst}"
+
+🔗 {wet-URL}#{anker} (subsectie {x})
+
+| | |
+|---|---|
+| **Formule** | `{formule in natuurlijke/wiskundige notatie — AND/OR/IF/MAX/...}` |
+| **Operanden / bron** | {korte uitleg van elke operand; `source:`-verwijzingen} |
+| **Interpretatie** | {wat de formule betekent en welke aannames erin zitten} |
+| **YAML-locatie** | `articles[…].machine_readable.execution.actions[{i}]` |
+
+**Review**:
+
+- [ ] {Punt dat de jurist apart moet bevestigen — bv. dekt de formule de wettekst?} Notitie: —
+- [ ] {Klopt de bron-/source-verwijzing?} Notitie: —
+- [ ] {Specifieke twijfel / interpretatie-keuze die bekrachtigd moet worden.} Notitie: —
+
+**Open** *(indien van toepassing)*:
+
+- {vraag of onduidelijkheid die nog beslist moet worden}
+
+---
+
+*(herhaal het Output-blok per `machine_readable` output)*
+
+---
+
+## Niet-getranslateerd (`untranslatables`)
+
+Wat in {artikel} staat maar bewust niet in een formule is vertaald. Per grond:
+**factual** (feitelijk vaststelbaar → kán alsnog gate worden) of **judgment**
+(oordeel/prognose → blijft untranslatable).
+
+| Subsectie | Wettekst-kern | Type | Reden | Review |
+|---|---|---|---|---|
+| {x} | {citaat-kern} | factual / judgment | {waarom niet gemodelleerd} | [ ] Accepteerbaar? |
+
+---
+
+## Externe override(s) — juridische nuance
+
+*Alleen invullen als een andere regeling een waarde/formule in deze keten override't.*
+
+| Override | Bron | Doel | Effect |
+|---|---|---|---|
+| {wat} | {bron-regeling art X} | `{output}` | {nieuwe waarde/gedrag} |
+
+### ⚠ Twijfel over grondslag *(indien van toepassing)*
+
+{Werkt de override mechanisch correct, maar klopt de juridische grondslag-attributie?
+Beschrijf de discrepantie YAML ↔ juridische werkelijkheid en de mogelijke opties.}
+
+- [ ] {Welke optie?} Notitie: —
+
+---
+
+## Open punten voor de sessie
+
+1. {open punt — formule-twijfel, missende grond, koppeling die ontbreekt, …}
+2. …
+
+---
+
+## Vervolg
+
+Na review: vink `[ ]` → `[x]` en schrijf afwijkingen op in een "Bevindingen"-blok
+onderaan. Bij *wijzigen* van een interpretatie: aparte commit met de YAML-update,
+testen groen, formules-doc opnieuw genereren.
+</content>

--- a/.claude/skills/regelrecht-audit-products/templates/audit-doc.md
+++ b/.claude/skills/regelrecht-audit-products/templates/audit-doc.md
@@ -107,4 +107,3 @@ Beschrijf de discrepantie YAML ↔ juridische werkelijkheid en de mogelijke opti
 Na review: vink `[ ]` → `[x]` en schrijf afwijkingen op in een "Bevindingen"-blok
 onderaan. Bij *wijzigen* van een interpretatie: aparte commit met de YAML-update,
 testen groen, formules-doc opnieuw genereren.
-</content>

--- a/.claude/skills/regelrecht-audit-products/templates/claude-orakel-prompt.md
+++ b/.claude/skills/regelrecht-audit-products/templates/claude-orakel-prompt.md
@@ -76,4 +76,3 @@ strict als je iets niet weet ("daar heb ik geen informatie over").
 2. Met file-access: noem de YAML-paden zodat Claude zelf leest. Anders: plak relevante
    YAML-snippets mee bij elke vraag.
 3. Als Claude buiten rol gaat: *"Blijf bij de YAML-lookup-rol. Wat zegt de YAML feitelijk?"*
-</content>

--- a/.claude/skills/regelrecht-audit-products/templates/claude-orakel-prompt.md
+++ b/.claude/skills/regelrecht-audit-products/templates/claude-orakel-prompt.md
@@ -1,0 +1,79 @@
+# Claude YAML-orakel — systeem-prompt voor {Dossier}-workshop {datum}
+
+*Kopieer de tekst hieronder als systeem-prompt (Claude Code, Claude Desktop, of
+bovenaan een nieuwe chat). Vul de `{...}`-context uit de casus-YAML's.*
+
+---
+
+## Prompt (kopieer vanaf hier)
+
+Je bent een **YAML-lookup-orakel** in een expert-workshop waarin domein-experts een
+machine-leesbare vertaling van {onderwerp} valideren. Jouw rol is **strikt
+adviserend en feitelijk** — nooit sturend of oordelend.
+
+### Context
+- **Casus**: {dossier + centrale beschikking}.
+- **Authentieke bron-tekst**: {wettekst-URL}.
+- **Machine-leesbare representatie**: YAML in `{pad}`.
+- **Gedelegeerde kern-berekening**: {welke wet/artikelen, in welk pad} *(indien van
+  toepassing)*.
+- **Override**: {welke override op welke output} *(indien van toepassing)*.
+- **Cross-law scope**: {N} wetten — zie `{scope-manifest}`.
+
+### Wat je WEL doet
+1. **YAML-citaten op verzoek** — citeer letterlijk uit de YAML (incl.
+   `legal_basis.explanation`) en de plek in de tekst (`art X, subart Y`).
+2. **Mentale engine-simulatie** — bij een concrete case: loop stap voor stap de
+   formules af en rapporteer het getal in trace-boom-formaat:
+   ```
+   {output} = IF {gate} THEN {waarde} ELSE 0
+            = ...
+   ```
+3. **Relatie-toelichting** — beschrijf `source:`-ketens en `legal_basis`-verwijzingen
+   feitelijk.
+4. **Gap-signalering** — bij een grond/case die níet in de MR zit: "Die zit niet in
+   de huidige YAML. Staat wel/niet als untranslatable. Willen jullie dat dat verandert?"
+
+### Wat je NIET doet
+- ❌ Geen juridisch oordeel ("Is deze formule correct?") → "Dat beslissen jullie. Ik
+  toon alleen wat er staat."
+- ❌ Geen beleidsadvies → "Dat is jullie keuze. Ik kan wel de consequenties van opties
+  laten zien."
+- ❌ Geen speculatie buiten scope → "De YAML dekt {casus} specifiek."
+- ❌ Geen conclusies uit onenigheid tussen experts → "Ik noteer dat jullie hier
+  verschillend in zitten." Wacht op de facilitator.
+- ❌ Geen verzonnen bedragen/formules/gronden.
+
+### Antwoord-template
+> **De YAML zegt** (of: **de berekening geeft**): *{quote of stap-voor-stap}.*
+>
+> **Klopt dat met jullie praktijk / verwachting?**
+
+Onzeker? → "De YAML bevat daar geen expliciete regel voor. Wil je dat ik in een andere
+wet in scope zoek?"
+
+### Concrete scope — wat je kent
+De orchestrator {artikel} heeft **{N} outputs**:
+- `{output_1}` = {korte formule}
+- `{output_2}` = {korte formule}
+- …
+
+**Gedelegeerd naar {wet}** *(indien van toepassing)*:
+- `{output}` ({formule/locatie})
+
+### Tone-of-voice
+Nederlands · zakelijk, droog, feitelijk · geen humor/metaforen/speculatie · kort ·
+strict als je iets niet weet ("daar heb ik geen informatie over").
+
+### Wanneer te stoppen
+- Debat tussen experts → trek je terug, noteer het verschil, wacht op de facilitator.
+- Vraag echt buiten scope → meld het, vraag of je in een andere wet in scope moet zoeken.
+
+---
+
+## Gebruik tijdens de workshop
+1. Open een Claude-sessie. Plak bovenstaande prompt.
+2. Met file-access: noem de YAML-paden zodat Claude zelf leest. Anders: plak relevante
+   YAML-snippets mee bij elke vraag.
+3. Als Claude buiten rol gaat: *"Blijf bij de YAML-lookup-rol. Wat zegt de YAML feitelijk?"*
+</content>

--- a/.claude/skills/regelrecht-audit-products/templates/facilitator-brief.md
+++ b/.claude/skills/regelrecht-audit-products/templates/facilitator-brief.md
@@ -63,4 +63,3 @@ wettekst.}
 1. Kennismaking: warm, persoonlijk · 2. Kennis-oogst: 3-kleur, hun model op tafel ·
 3. Scope: dot-vote, S1..Sn · 4. Pauze · 5. Walk-through: A/B/C, {zware output} ·
 6. Beslispunten: 1-2-4-all · 7. Afronding: rondje + action-items.
-</content>

--- a/.claude/skills/regelrecht-audit-products/templates/facilitator-brief.md
+++ b/.claude/skills/regelrecht-audit-products/templates/facilitator-brief.md
@@ -1,0 +1,66 @@
+# Workshop-draaiboek brief — {Dossier} {datum}
+
+*Kort-format spiekbriefje voor tijdens de sessie. 1 A4 print, of als aparte tab naast
+de inhoudelijke docs. Afgeleid van het volledige draaiboek — voeg niets nieuws toe.*
+
+**Doel sessie**: {één zin} — {duur}.
+
+---
+
+## Klaarzetten
+
+**Print per deelnemer**: {wet-graph} · {formules-doc} · {wettekst PDF}.
+**Materialen**: sticky-notes 3 kleuren · dot-stickers · markers · brown paper · pennen.
+**Laptop-tabs**: {draaiboek/notulen} · {audit-doc} · {scope-analyse} · {formules-doc} ·
+{jargon-spiekbriefje} · {orakel-prompt}.
+**Claude-orakel**: aparte tab met de systeem-prompt geladen *(indien gebruikt)*.
+
+---
+
+## Blok-voor-blok (tijd · doel · wat doe je · reminders)
+
+**{0:00–0:15} Kennismaking** — warm, persoonlijk, 1 domein-signaal per persoon.
+Reminder: jij luistert + typt namen/rollen; eigen opening; vermijd discussie.
+
+**{0:15–0:45} Kennis-oogst** — hun mentaal model op tafel. 3-kleur brown paper.
+Reminder: doe zelf 1 gele sticky vooraf; 🟥-stack belangrijkst → foto.
+
+**{0:45–1:15} Scope + graph** — scope-keuzes S1..Sn vastleggen via dot-voting.
+Reminder: graph fysiek, laat mensen wijzen; {de 2-3 dingen die experts vaak missen}.
+
+**{1:15–1:25} Pauze** — niet skippen.
+
+**{1:25–2:25} Walk-through** — {N} outputs afvinken via protocol A/B/C.
+Time-box per output: {O1 x min · O2 x min · …}. {Welke output is zwaar en waarom.}
+
+**{2:25–2:50} Beslispunten** — 1-2-4-all, B1..Bn. {Welke punten zijn zwaar / nooit
+skippen.}
+
+**{2:50–3:00} Afronding** — 1-zin-rondje, action-items, vervolgsessie-datum.
+
+---
+
+## Claude-orakel — wanneer
+{Goede momenten + rode vlag (corrigeer met "Blijf bij de YAML-lookup").}
+
+## Risico's + back-pockets
+{Compacte tabel uit `facilitation-patterns.md`. Plan B: case-vertelling door de
+wettekst.}
+
+---
+
+## Laatste check vóór de sessie
+- [ ] Wet-graph geprint
+- [ ] Formules-doc geprint per persoon
+- [ ] Wettekst geprint per persoon
+- [ ] Sticky-notes + dot-stickers + markers + brown paper
+- [ ] Laptop-tabs open
+- [ ] Claude-orakel-tab geladen *(indien gebruikt)*
+- [ ] Co-facilitator/notulist geregeld
+- [ ] Timer klaar voor time-box
+
+## Samenvatting — 1 zin per blok
+1. Kennismaking: warm, persoonlijk · 2. Kennis-oogst: 3-kleur, hun model op tafel ·
+3. Scope: dot-vote, S1..Sn · 4. Pauze · 5. Walk-through: A/B/C, {zware output} ·
+6. Beslispunten: 1-2-4-all · 7. Afronding: rondje + action-items.
+</content>

--- a/.claude/skills/regelrecht-audit-products/templates/jargon-spiekbriefje.md
+++ b/.claude/skills/regelrecht-audit-products/templates/jargon-spiekbriefje.md
@@ -1,0 +1,79 @@
+# Jargon-spiekbriefje — {Dossier}-workshop
+
+*Houd dit naast je. Alle schema-/engine-termen in mensentaal, met één concreet
+casus-voorbeeld per stuk. Generieke definities staan vast (zie method-glossary);
+vul de `{voorbeelden}` met casus-inhoud.*
+
+## Kern-metafoor (1 zin voor deelnemers)
+
+> "Stel je een junior-medewerker voor die je wilt leren {de beschikking} nemen. Je
+> geeft haar een stappenplan. De YAML is dat stappenplan. De engine is de medewerker
+> die het uitvoert. Alles wat we vandaag bespreken: klopt het stappenplan?"
+
+## Snel-overzicht
+
+| Jargon | Mensentaal |
+|---|---|
+| **YAML** | Het regel-stappenplan als tekstbestand |
+| **Engine** | De 'junior-medewerker' die het stappenplan uitvoert |
+| **Output** | Het eindantwoord van een wet |
+| **Parameter** | Getal dat de caller aanlevert ({voorbeeld}) |
+| **Input** | Getal dat de engine zelf ergens ophaalt ({voorbeeld}) |
+| **Source** | Mechanisme waarmee input uit een andere wet wordt opgehaald |
+| **Caller** | Systeem dat de engine aanroept ({het uitvoerings-systeem}) |
+| **Action** | Eén formule die één output berekent |
+| **Definition** | Vaste waarde uit de wet ({voorbeeld-drempel}) |
+| **Untranslatable** | Wettekst die bewust niet in een formule zit (handmatig oordeel) |
+| **Override** | Andere wet vervangt jouw formule/waarde |
+| **legal_basis** | Juridische grondslag onder een regel + wettekst-quote per formule |
+
+---
+
+## De drie soorten invoer — hier zit vaak een scope-vraag
+
+- **Parameter** — wat de caller aanlevert. *Voorbeeld*: {casus-parameter}.
+- **Input** — wat de engine automatisch uit een andere wet haalt. *Voorbeeld*:
+  {casus-input}.
+- **Source** — het ophaal-mechanisme. *"Deze input `{x}` heeft een source naar
+  {wet}. De engine belt {wet} met onze gegevens en gebruikt dat antwoord."*
+
+**Source vs caller in 2 zinnen voor deelnemers**:
+> "Een bedrag kan op twee manieren bij onze formule komen. Óf jullie systeem stopt
+> het getal erin (caller-parameter). Óf de engine gaat automatisch naar de
+> {bron}-YAML, leest daar de actuele waarde, en gebruikt die (source). Source is
+> mechanisch consistent — mits {bron} onderhouden wordt. Caller geeft jullie controle."
+
+---
+
+## Untranslatable — belangrijk concept
+
+> "Sommige stukken kunnen we niet in een formule gieten — '{voorbeeld open norm}',
+> 'bijzondere omstandigheden', 'aannemelijk maken' — dat vergt menselijk oordeel.
+> Die markeren we als 'untranslatable'. De engine doet die check niet; de behandelaar
+> doet 'm handmatig."
+
+## Override — *(indien van toepassing)*
+
+> "{Wet A} zegt: {waarde X}. {Wet B} zegt: nee, {waarde Y}. De engine weet dat —
+> zodra de betreffende waarde berekend wordt, pakt de engine automatisch {waarde Y}."
+
+---
+
+## Back-pocket-antwoorden op lastige vragen
+
+**"Wat als jullie formule een getal geeft dat ik in de praktijk niet zou geven?"**
+→ "Perfect — dat willen we weten. Geef een concrete case, dan laten we de engine die
+doorrekenen en zien we waar de afwijking zit." (gebruik het orakel voor de trace)
+
+**"Wet is niet mechanisch, je kan dit niet zomaar in formules gieten."**
+→ "Klopt. De formules dekken niet alle nuance. Daarom is een deel 'untranslatable' —
+bewust niet mechanisch. We willen van jullie horen waar die grens ligt."
+
+**"Waarom niet alles in formules?"**
+→ "Alleen wat mechanisch toetsbaar is. Alles wat discretie/oordeel vergt blijft
+menselijk. Vandaag bepalen we samen welke zin waar valt."
+
+**"Deze wet kan morgen veranderen!"**
+→ "Daarom is de YAML gelabeld per datum. Bij een wijziging maken we een nieuwe versie;
+de oude blijft beschikbaar voor zaken uit die periode."
+</content>

--- a/.claude/skills/regelrecht-audit-products/templates/jargon-spiekbriefje.md
+++ b/.claude/skills/regelrecht-audit-products/templates/jargon-spiekbriefje.md
@@ -76,4 +76,3 @@ menselijk. Vandaag bepalen we samen welke zin waar valt."
 **"Deze wet kan morgen veranderen!"**
 → "Daarom is de YAML gelabeld per datum. Bij een wijziging maken we een nieuwe versie;
 de oude blijft beschikbaar voor zaken uit die periode."
-</content>

--- a/.claude/skills/regelrecht-audit-products/templates/scope-analyse.md
+++ b/.claude/skills/regelrecht-audit-products/templates/scope-analyse.md
@@ -132,4 +132,3 @@ juridische grondslag-attributie? Markeer twijfel als beslispunt.}
 - [ ] **S1** — {vraag}? Notitie: —
 - [ ] **S2** — {vraag}? Notitie: —
 - [ ] **S3** — {vraag}? Notitie: —
-</content>

--- a/.claude/skills/regelrecht-audit-products/templates/scope-analyse.md
+++ b/.claude/skills/regelrecht-audit-products/templates/scope-analyse.md
@@ -1,0 +1,135 @@
+# {Dossier} — scope-analyse en wet-graph
+
+*Te gebruiken om de scope te bekrachtigen aan het begin van de sessie. Open in een
+viewer die `mermaid` en `[ ]`-checkboxes rendert.*
+
+**Casus**: {korte omschrijving van het dossier en de centrale beschikking/output}.
+**Scope-manifest**: `{pad naar scope-manifest}` — {N} wetten.
+
+---
+
+## Samenvatting in één oogopslag
+
+```mermaid
+graph TD
+    %% Laag A — grondslag
+    {A1}[{Wet A1}<br/><i>WET</i>]:::wet
+
+    %% Laag B — uitwerking
+    {B1}[{Regeling B1}<br/><i>MIN. REG. / BELEIDSREGEL</i>]:::mr
+
+    %% Laag C — lokaal/uitvoerend (orchestrator)
+    {C1}[{Orchestrator C1}<br/><i>...</i>]:::lokaal
+
+    %% Laag D — databronnen
+    {D1}[{Databron D1}<br/><i>WET</i>]:::data
+
+    %% Grondslagen (legal_basis)
+    {C1} -.grondslag.-> {A1}
+    {B1} -.grondslag.-> {A1}
+
+    %% Source-calls (data-flow bij executie)
+    {C1} ==source==> {B1}
+
+    %% Override
+    {Bx} -->|overrides {output}| {By}
+
+    %% Impliciete data-dependencies
+    {C1} -.data.-> {D1}
+
+    classDef wet fill:#e8f4f8,stroke:#2a6ca8,stroke-width:2px
+    classDef mr fill:#fff4e0,stroke:#c88a1e,stroke-width:2px
+    classDef lokaal fill:#d8f0d8,stroke:#2a7d2a,stroke-width:3px
+    classDef data fill:#f0e0ff,stroke:#7030a0,stroke-width:2px
+```
+
+**Legenda**
+- `==source==>` executie-tijd data-call (formule A haalt waarde uit wet B)
+- `-.grondslag.->` `legal_basis` (juridisch fundament, geen runtime-dep)
+- `--overrides-->` B verandert de betekenis van A's output
+- `-.data.->` impliciete parameter-dependency (databron levert data, geen formule)
+
+---
+
+## De wetten — tabel
+
+| # | Law-id | Laag | Rol in keten | YAML |
+|---|---|---|---|---|
+| 1 | `{law_id}` | {A/B/C/D} | {grondslag / kern-berekening / orchestrator / databron} | `{pad}` |
+| 2 | … | … | … | … |
+
+---
+
+## Runtime-afhankelijkheden (source-calls)
+
+Wie roept wie aan bij executie van de centrale beschikking:
+
+```
+[#{n}] {Orchestrator}
+  ├── source → #{m}  {wet/artikel}   ({welke output/waarde})
+  └── source → #{k}  {wet/artikel}   ({welke output/waarde})
+```
+
+**Niet-source, wel data-provider** (via caller-parameters):
+- #{x} {databron} → `{parameters}`
+
+---
+
+## Juridische afhankelijkheden (`legal_basis`)
+
+```
+{Orchestrator}   → {grondslag-wet art X}  +  {…}
+{Regeling}       → {grondslag-wet art X}
+```
+
+Iedereen berust direct of transitief op **{grondslag-wet art X}** — de delegatie-basis.
+
+---
+
+## Override-relaties
+
+| Override op | Output | Door | Nieuwe waarde |
+|---|---|---|---|
+| {wet art X waarde} | `{output}` | {andere regeling art Y} | **{nieuwe waarde}** |
+
+**Werking + grondslag-nuance**: {werkt de override mechanisch correct, en klopt de
+juridische grondslag-attributie? Markeer twijfel als beslispunt.}
+
+---
+
+## Clusters — de lagen
+
+### Laag A — grondslag
+{wet(ten); waarom (nog) niet zelf machine-leesbaar}
+
+### Laag B — uitwerking
+{regeling(en) waar de kern-berekening leeft}
+
+### Laag C — lokale/uitvoerende laag
+{de orchestrator; wat zijn eigen bijdrage smal/breed maakt}
+
+### Laag D — databronnen
+{wetten die alleen data leveren}
+
+---
+
+## Analyse — wat cruciaal is om te snappen
+
+1. {één entry-point? waar leeft de kern-berekening? hoe smal is de eigen bijdrage van
+   de orchestrator? welke databronnen zijn nog niet volledig gekoppeld? hoe ver
+   reikt de override? hoe transitief is de grondslag?}
+
+---
+
+## Scope-beslispunten (voor sessie-blok "scope")
+
+| # | Keuze | Opties | Implicatie |
+|---|---|---|---|
+| S1 | {scope volledig of ontbreekt er iets?} | compleet / aanvullen | {…} |
+| S2 | {databronnen via source of via caller-parameter?} | source / caller | {…} |
+| S3 | … | … | … |
+
+- [ ] **S1** — {vraag}? Notitie: —
+- [ ] **S2** — {vraag}? Notitie: —
+- [ ] **S3** — {vraag}? Notitie: —
+</content>

--- a/.claude/skills/regelrecht-audit-products/templates/testcase-scenarios.md
+++ b/.claude/skills/regelrecht-audit-products/templates/testcase-scenarios.md
@@ -94,4 +94,3 @@ brede behandeling van de kleinere open punten (alleen parkeren).
 
 ## Afronding
 1 zin per persoon. Actiepunten (max 3-4: wat/wie/wanneer).
-</content>

--- a/.claude/skills/regelrecht-audit-products/templates/testcase-scenarios.md
+++ b/.claude/skills/regelrecht-audit-products/templates/testcase-scenarios.md
@@ -1,0 +1,97 @@
+# {Dossier} — testcase-scenario's voor vervolg-sessie
+
+Scenario's om met experts door te lopen. Elk raakt een ander hoofdpad in de digitale
+beoordelings-keten. **Kernvraag per scenario**: *"komen jullie op hetzelfde uit als
+de engine? En hoe rekenen jullie eigenlijk?"*
+
+> **Vertrouwelijkheid**: scenario's zijn fictief of sterk-gelijkend op echte
+> casussen — **nooit echte persoonsgegevens**. De BDD-versie kan in een
+> `features/`-feature-file staan.
+
+---
+
+## 1. {Scenario-titel — kort beoordelings-pad}
+
+> {Fictieve persoon/situatie in 2-3 zinnen, met de relevante feiten en het bedrag.}
+
+**Wat de engine berekent**: {trace-conclusie in één regel — bijv. volledige
+toekenning €X / afwijzing / gedeeltelijk}.
+
+**Discussie**:
+- Komen jullie op hetzelfde uit?
+- Welke gegevens zien jullie wel die de digitale toets nu niet pakt?
+- {scenario-specifieke doorvraag die een open punt op tafel brengt}
+
+---
+
+*(herhaal per scenario; kies scenario's die samen verschillende hoofdpaden raken:
+het simpele/volle pad, een afwijzing via een gate, en een grond-met-nuance)*
+
+---
+
+## Wat ze samen aanraken
+
+| Scenario | Hoofdpad | Engine zegt |
+|---|---|---|
+| 1 | {pad} | {uitkomst} |
+| 2 | {pad} | {uitkomst} |
+| 3 | {pad} | {uitkomst} |
+
+**Overkoepelend open punt** *(indien van toepassing)*: {het ene punt dat over meerdere
+scenario's heen speelt en in het slot wordt teruggebracht}.
+
+---
+
+## Bonus — leeg scenario voor zelf-invullen
+
+> Optioneel. Als experts een eigen casus willen testen. **Niet verplicht alle
+> variabelen langs te lopen** — vul alleen wat relevant is; de engine pakt voor de
+> rest een standaardwaarde (0 of nee).
+
+### Mini-sjabloon
+
+```
+Casus: ____________________________
+Wie:       _____________________
+Inkomen:   € _____ / mnd  (+ partner € _____ indien van toepassing)
+Vermogen:  € _____ ( ____________ )
+Aanslag/bedrag: € _____ ( ____________ )
+Bijzonder: ________________________________________________
+```
+
+---
+
+# Vervolg-sessie — werkvorm en draaiboek
+
+**Vervolg op**: {eerste workshop-doc}
+**Doel**: drie testcases langs de experts halen — per case toetsen of de digitale
+beoordeling op hetzelfde uitkomt als de praktijk, en bij verschil helder krijgen hoe
+zij rekenen.
+**Deelnemers**: {2-4 experts} + facilitator. **Duur**: {±90 min}.
+
+## Werkvorm-protocol per scenario (≈20 min)
+
+1. **Lees voor + toon engine-uitkomst** (1 min) — direct de uitkomst noemen. Geen
+   discussie nu.
+2. **Stilte** (2 min) — ieder schrijft individueel op: *wat zou ik beslissen?* + *welk
+   gegeven vond ik doorslaggevend?* (voorkomt dat een dominante stem kleurt).
+3. **Pair-share** (3 min) — in tweetallen vergelijken.
+4. **Plenair** (9 min) — uitkomsten ophalen, vergelijken met engine; bij **verschil
+   doorvragen op de rekenmethode**, niet op de beslissing.
+5. **Verdiepingspunten** (5 min) — de 2-3 specifieke vragen onder het scenario.
+
+Time-box strak: bij oploop → parkeren naar het slot.
+
+## Facilitator-tips
+- **Stilte-eerst**; **engine-uitkomst vooraf delen** (anders dan blinde toets — hier
+  is de cijfer-vergelijking de kern); **bij verschil doorvragen op de rekenstap**
+  ("hoe komen jullie van A naar B?"); **niet over beleid argumenteren** — "anders
+  rekenen" is informatie, niet onze rol om te bevestigen of dat mag.
+
+## Wat NIET in deze sessie
+Code-/YAML-uitleg · diepte van de cross-law-keten · live demo's die nog niet werken ·
+brede behandeling van de kleinere open punten (alleen parkeren).
+
+## Afronding
+1 zin per persoon. Actiepunten (max 3-4: wat/wie/wanneer).
+</content>

--- a/.claude/skills/regelrecht-audit-products/templates/verslag-extern.md
+++ b/.claude/skills/regelrecht-audit-products/templates/verslag-extern.md
@@ -1,0 +1,49 @@
+# Terugkoppeling {onderwerp}-sessie — {datum}
+
+*Hoogover terugkoppeling voor de klant. Waarderend, op hoofdlijnen. Afgeleid van het
+interne verslag, maar geabstraheerd: geen detail-bevindingen, geen interne reflecties,
+geen vertrouwelijke details. Brief-vorm.*
+
+Beste {collega's van klant},
+
+Bedankt voor de tijd en openheid die jullie hebben geïnvesteerd in de sessie over de
+machine-leesbare vertaling van {onderwerp}. Hieronder een beknopt verslag van wat we
+samen hebben opgehaald en hoe we verder gaan.
+
+## Wat we samen hebben gedaan
+
+In ~{duur} hebben we:
+- {het wettelijk stelsel in kaart gebracht};
+- {het kernartikel variabele voor variabele doorgelopen, steeds met de wettekst ernaast};
+- {gezamenlijk getoetst of de vertaling klopt met de praktijk};
+- {een eerste beeld gekregen van hoe de regelingen samenhangen}.
+
+## Wat het heeft opgeleverd
+
+**Bevestiging van de hoofdlijnen**: {de opzet volgt de route die jullie in de praktijk
+hanteren}.
+
+**{Aantal} aanscherp-punten** waar we samen verder op gaan (op hoofdlijnen):
+1. {punt — abstract geformuleerd, geen interne details}
+2. …
+
+{Optioneel: een waarderende observatie — bijv. dat tijdens de doorloop ook bij jullie
+meer zicht ontstond op de eigen regeling.}
+
+## Vervolg
+
+- {concrete vervolgafspraak 1 — bijv. testcases vanuit de klant}
+- {concrete vervolgafspraak 2 — bijv. een data-inzicht-formulier}
+- {volgende sessie}
+
+## Waar vinden jullie de uitwerking terug
+
+{De inhoudelijke notities en de vertaling worden vastgelegd in een werkomgeving; per
+onderwerp delen we voor de volgende sessie een compact voorbereidend document.}
+
+Nogmaals dank voor jullie bijdrage.
+
+Met vriendelijke groet,
+
+{Naam}
+</content>

--- a/.claude/skills/regelrecht-audit-products/templates/verslag-extern.md
+++ b/.claude/skills/regelrecht-audit-products/templates/verslag-extern.md
@@ -46,4 +46,3 @@ Nogmaals dank voor jullie bijdrage.
 Met vriendelijke groet,
 
 {Naam}
-</content>

--- a/.claude/skills/regelrecht-audit-products/templates/verslag-intern.md
+++ b/.claude/skills/regelrecht-audit-products/templates/verslag-intern.md
@@ -1,0 +1,57 @@
+# Verslag {Dossier}-expert-sessie {datum} — intern
+
+*Voor het eigen team. Primair document voor reflectie + vervolgstappen. De hoogover-
+variant voor de klant staat apart. Eerlijk en volledig — ook wat niet goed liep.*
+
+## Samenvatting
+
+{Wanneer, met wie, hoe lang, wat het doel was, en het resultaat in 3-4 zinnen.
+Inclusief afwijking van de planning en de belangrijkste uitkomst.}
+
+## Deelnemers + duur
+
+- {rollen, niet per se namen}
+- Facilitator: {naam}
+- Duur: {werkelijke duur} (gepland: {geplande duur})
+
+## Wat we werkelijk hebben gedaan
+
+1. {chronologisch wat er feitelijk gebeurde — inclusief waar het anders liep dan
+   voorbereid}
+
+**Niet gedaan**: {geplande onderdelen die zijn overgeslagen}.
+
+## Onderzoek-/correctie-punten
+
+*Per punt: wat is het, status in de YAML, en wat moet worden uitgezocht.*
+
+### 1. {Titel van het punt}
+{Beschrijving — wat de YAML doet vs wat de praktijk/expert zegt.}
+**Status**: {wel/niet in de YAML verwerkt; gevolg}.
+**Onderzoek**: {concrete vraag/vragen die nog beantwoord moeten worden}.
+
+*(herhaal per punt)*
+
+## Observaties over sessie-dynamiek
+
+- {hoe stonden deelnemers erin; openheid; eventuele terughoudendheid + reden; toon van
+  de sessie; wat werkte als praatplaat}
+
+## Tooling-leerpunten
+
+- {wat bleek haalbaar/waardevol; wat was te technisch; werd het orakel gebruikt; welke
+  feature-kandidaten kwamen naar voren}
+
+## Way forward
+
+| # | Actie | Wie | Wanneer |
+|---|---|---|---|
+| 1 | | | |
+
+## Bijlagen
+
+- Workshop-notities: `{pad}`
+- Pre/post-diff: `{git ref range}`
+- Formules-doc: `{pad}`
+- Branch / tag: `{ref}`
+</content>

--- a/.claude/skills/regelrecht-audit-products/templates/verslag-intern.md
+++ b/.claude/skills/regelrecht-audit-products/templates/verslag-intern.md
@@ -54,4 +54,3 @@ Inclusief afwijking van de planning en de belangrijkste uitkomst.}
 - Pre/post-diff: `{git ref range}`
 - Formules-doc: `{pad}`
 - Branch / tag: `{ref}`
-</content>

--- a/.claude/skills/regelrecht-audit-products/templates/workshop-draaiboek.md
+++ b/.claude/skills/regelrecht-audit-products/templates/workshop-draaiboek.md
@@ -108,4 +108,3 @@ wettekst heen.
 3. Per beslispunt waar *wijzigen* is gekozen: aparte commit met YAML-update + testen
    groen + formules opnieuw genereren.
 4. Verslag intern + extern opstellen.
-</content>

--- a/.claude/skills/regelrecht-audit-products/templates/workshop-draaiboek.md
+++ b/.claude/skills/regelrecht-audit-products/templates/workshop-draaiboek.md
@@ -1,0 +1,111 @@
+# {Dossier}-expert-workshop — {artikel/onderwerp} — {datum} ({duur})
+
+**Doel**: {wat valideren we, met wie, in hoeveel tijd}.
+
+**Deelnemers**: —
+
+**Te auditen**:
+- YAML: `{pad}` — {artikel}
+- Wettekst: {URL}
+- Formules: `{pad naar formules-doc}`
+
+**Afbakening**: {wat valt binnen scope, wat raken we alleen waar direct gedelegeerd,
+wat is een aparte sessie}.
+
+---
+
+## Agenda
+
+| Tijd | Blok |
+|---|---|
+| {0:00–0:15} | Kennismaking |
+| {0:15–0:45} | Kennis-oogst |
+| {0:45–1:15} | Scope + wet-graph |
+| {1:15–1:25} | Pauze |
+| {1:25–2:25} | Walk-through {artikel} |
+| {2:25–2:50} | Beslispunten |
+| {2:50–3:00} | Afronding |
+
+*Dit draaiboek is voor de facilitator — niet bedoeld om tijdens de sessie op scherm te
+tonen.*
+
+---
+
+## Deel 1 — Kennismaking + kennis-oogst
+
+Rondje (naam + rol + 1 zin "recente case"). Daarna brown paper + sticky-notes
+(3 kleuren: 🟨 kern · 🟩 wat loopt goed · 🟥 wat loopt stroef/vragen).
+Zie `facilitation-patterns.md` → kennis-oogst.
+
+## Deel 2 — Scope + wet-graph
+
+Scope-/lagen-diagram op tafel. Dot-voting (🟢 kennen we / 🔴 blinde vlek). Loop de
+scope-beslispunten S1..Sn uit de scope-analyse door.
+
+## Pauze — **niet skippen**
+
+## Deel 3 — Walk-through {artikel}
+
+Protocol per output (zie `facilitation-patterns.md` → A/B/C). Splitview formules-doc
+links, sessie-notities rechts.
+
+**Time-box** (harde stops):
+- Output 1 → {x} min
+- Output 2 (de zware) → {x} min
+- …
+- Buffer → {x} min
+
+### Per output — key-reminder
+
+**Output 1 `{naam}`** ({simpel/zwaar}):
+- {korte karakterisering; verwacht weerwoord; je comeback}
+
+**Output 2 `{naam}`** (de zware):
+- {sub-gronden snel langs; eventuele splitsings-/interpretatie-discussie via 1-2-4-all}
+- {untranslatables: benoem factual vs judgment}
+
+*(per output herhalen)*
+
+## Deel 4 — Beslispunten ({tijd}) — werkvorm 1-2-4-all
+
+Per punt max ~3 min (zie `facilitation-patterns.md`). Noteer minderheidsstandpunten.
+
+| # | Punt | Verwacht + comeback |
+|---|---|---|
+| B1 | {punt in één zin} | {verwacht weerwoord → comeback} |
+| B2 | … | … |
+| … | … | … |
+
+Markeer de zwaarste juridische punten — daar minimaal {x} min discussie, nooit skippen.
+Als er geen conclusie komt → action-item met eigenaar.
+
+## Deel 5 — Afronding
+
+1 zin per persoon — *"wat neem ik mee?"*. Noteer elke zin.
+Daarna: action-items-tabel (wie/wat/deadline) + vervolgsessie-datum.
+
+| # | Wat | Wie | Deadline |
+|---|---|---|---|
+| 1 | | | |
+
+---
+
+## Claude-orakel — wanneer gebruiken
+
+{Goede momenten (case-simulatie bij "case die dit breekt?", feitelijke check bij een
+beslispunt). Rode vlag: als Claude gaat adviseren → "Blijf bij de YAML-lookup."
+Zie `templates/claude-orakel-prompt.md`.}
+
+## Risico's + back-pockets
+
+Zie `facilitation-patterns.md`. Plan B als het stroef loopt: case-vertelling dóór de
+wettekst heen.
+
+## Na afloop
+
+1. Deze file (alle vinkjes + notities) wordt het ruwe sessie-verslag.
+2. Audit-docs `[ ]` → `[x]` invullen + afwijkingen noteren.
+3. Per beslispunt waar *wijzigen* is gekozen: aparte commit met YAML-update + testen
+   groen + formules opnieuw genereren.
+4. Verslag intern + extern opstellen.
+</content>

--- a/.claude/skills/regelrecht-dossier/SKILL.md
+++ b/.claude/skills/regelrecht-dossier/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: regelrecht-dossier
+description: Front-door router voor het werken aan een regelrecht-dossier. Gebruik dit aan het begin van een dossier, of bij twijfel over waar te beginnen — het triageert de situatie en routeert naar de juiste skill (regelrecht-stelselanalyse voor desk-review/corpus-completion, regelrecht-audit-products voor live expert-validatie) en de juiste volgorde. Bevat het routeringsprincipe: feitelijke defecten routeren naar de desk, oordeels-/praktijkvragen naar de workshop. Dossier-agnostisch.
+allowed-tools: Read, Glob, Grep, AskUserQuestion
+---
+
+# Regelrecht dossier — router & flow
+
+De ingang voor het werken aan een regelrecht-dossier. Bepaalt **waar je begint** en
+**hoe de twee werk-skills in één flow samenhangen**. Dit is een dunne dispatcher: het
+eigenlijke werk gebeurt in de twee skills waarnaar het routeert.
+
+- **`regelrecht-stelselanalyse`** — de machinekamer (desk): harvest, modelleer, valideer,
+  classificeer, fix, documenteer, verifieer. Levert een corpus + geclassificeerde
+  bevindingen.
+- **`regelrecht-audit-products`** — de menselijke validatielaag (live): valideert met
+  domein-experts. Levert consensus + correctiepunten + testcases.
+
+De volledige flow, het gate-criterium en de handoff-lus staan in `references/routing.md`
+(de canonieke bron; beide werk-skills verwijzen hierheen). Voor het inwerken van nieuwe
+regelanalisten: `references/zakkaart.md` — een printbare één-A4 met de drie deuren, de
+flow, de 4-weg-classificatie en de beslis-kaart (methode bekend verondersteld).
+
+## Het routeringsprincipe in één regel
+
+**Feitelijke defecten routeren naar binnen (desk); oordeels-/praktijkvragen routeren naar
+buiten (workshop).** De vier-weg-classificatie van een bevinding bepaalt de bestemming:
+
+| Classificatie | Route |
+|---|---|
+| modellering-fout | desk → wij fixen de YAML |
+| engine-limitatie | desk trackt → engine-issue |
+| wetgevings-fout | desk documenteert → wetgevings-notitie (stakeholders, niet de validatieworkshop) |
+| acceptabele untranslatable / interpretatie- of praktijk-onzeker | **workshop** |
+
+## Triage: waar begin je?
+
+Stel (of leid af) een paar dingen vast, dan volgt de route:
+
+1. **Is er al een corpus?** Nee → desk: harvest eerst (`regelrecht-stelselanalyse`).
+2. **Is het corpus gemodelleerd en gevalideerd?** Nee → desk: valideer + classificeer + fix.
+3. **Wat is de openstaande vraag — feitelijk of oordeel/praktijk?**
+   - Feitelijk (klopt onze YAML / de wet / kan de engine het?) → **desk**.
+   - Oordeel/praktijk (open norm, formule-vs-praktijk, scope-keuze) → **workshop**.
+4. **Heb je domeinkennis of stakeholder-buy-in nodig die je nog niet hebt?** → een
+   **verkennende workshop** mag vroeg (zie de twee workshop-modi hieronder), ook vóór
+   het corpus volledig gefixt is.
+
+Bij twijfel: gebruik `AskUserQuestion` om de situatie scherp te krijgen voordat je routeert.
+
+## Twee workshop-modi (het gate-criterium is mode-afhankelijk)
+
+- **Verkennende / ontginnende workshop** — vroeg, zelfs op een ruwe scope-analyse. Doel:
+  domeinkennis ontginnen, praktijk boven tafel krijgen, scope bekrachtigen. **Geen
+  gate** — je hoeft het corpus niet eerst volledig te fixen. (Dit is hoe een eerste
+  sessie vaak nuttig is, ook al staat de modellering nog niet vast.)
+- **Validerende workshop** — later, om een gemodelleerd corpus te valideren. **Gate**:
+  schema valide + tests groen + modellering-fouten gefixt + de resterende open punten
+  zijn *judgment* (niet *factual*). Anders eerst nog een desk-cyclus — je wilt geen
+  experts laten valideren wat eigenlijk onze eigen modelleerfout is.
+
+## Handoff-lus (kort)
+
+- **Desk → workshop**: een rijp (of bewust-ruw, bij verkennen) corpus; de judgment-set
+  untranslatables wordt de beslispunten; de scope-analyse komt uit `cross-law-diagram` +
+  `corpus-status`.
+- **Workshop → desk**: correctiepunten + bevestigde interpretaties gaan terug de cyclus
+  in (implementeer modellering-fixes, verifieer claims tegen bronnen via de
+  resolutie-tracker, documenteer bevestigde wetgevings-fouten).
+
+Zie `references/routing.md` voor het volledige diagram en de gedeelde bruggen.
+</content>

--- a/.claude/skills/regelrecht-dossier/SKILL.md
+++ b/.claude/skills/regelrecht-dossier/SKILL.md
@@ -69,4 +69,3 @@ Bij twijfel: gebruik `AskUserQuestion` om de situatie scherp te krijgen voordat 
   resolutie-tracker, documenteer bevestigde wetgevings-fouten).
 
 Zie `references/routing.md` voor het volledige diagram en de gedeelde bruggen.
-</content>

--- a/.claude/skills/regelrecht-dossier/SKILL.md
+++ b/.claude/skills/regelrecht-dossier/SKILL.md
@@ -33,6 +33,9 @@ buiten (workshop).** De vier-weg-classificatie van een bevinding bepaalt de best
 | wetgevings-fout | desk documenteert → wetgevings-notitie (stakeholders, niet de validatieworkshop) |
 | acceptabele untranslatable / interpretatie- of praktijk-onzeker | **workshop** |
 
+Canonieke definities + de open-norm-beslisregel: `regelrecht-stelselanalyse/references/classification.md`
+(één bron van waarheid; deze tabel is de routing-samenvatting).
+
 ## Triage: waar begin je?
 
 Stel (of leid af) een paar dingen vast, dan volgt de route:

--- a/.claude/skills/regelrecht-dossier/references/routing.md
+++ b/.claude/skills/regelrecht-dossier/references/routing.md
@@ -87,4 +87,3 @@ wat eigenlijk onze modelleerfout is. Voor kennis-ontginning is een ruw corpus pr
 | Untranslatables | factual vs judgment geclassificeerd | judgment-set = beslispunten |
 | Scenario's | `engine-tests` (regressie) | `testcase-scenarios` (expert-validatie) |
 | Verslag/rapport | `eindrapport` (per cyclus) | `verslag-intern`/`-extern` (per sessie) |
-</content>

--- a/.claude/skills/regelrecht-dossier/references/routing.md
+++ b/.claude/skills/regelrecht-dossier/references/routing.md
@@ -13,20 +13,18 @@ Eén bron van waarheid voor hoe `regelrecht-stelselanalyse` (desk) en
 ## De flow (gesloten lus)
 
 ```
-        ┌────────────── DESK · regelrecht-stelselanalyse ──────────────┐
-        │  harvest → modelleer → valideer → 4-weg classificeer → fix   │◀──┐
-        └──────┬───────────────────────────────────────────────────────┘   │
-               │ modellering-fout → fix · engine-limitatie → engine        │
-               │ wetgevings-fout → notitie                                 │
-               │                                                           │
-   corpus workshop-rijp (validerend)                          correctiepunten +
-   of bewust ruw (verkennend)                                 bevestigde interpretaties
-               ▼                                                           │
-        ┌─────────── WORKSHOP · regelrecht-audit-products ─────────────┐   │
-        │  scope-analyse → audit-doc → sessie → correctiepunten +      │   │
-        │  consensus + testcase-scenario's                             │───┘
-        └──────────────────────────────────────────────────────────────┘
-                              terug de desk in: implementeer + verifieer
+   ┌────────────── DESK · regelrecht-stelselanalyse ──────────────┐
+   │  harvest → modelleer → valideer → 4-weg classificeer → fix   │ ◀──┐
+   └───┬──────────────────────────────────────────────────────────┘    │
+       │  modellering-fout → fix · engine-limitatie → engine           │
+       │  wetgevings-fout → notitie                                    │
+       ▼                                                               │
+   ┌──────────── WORKSHOP · regelrecht-audit-products ────────────┐    │
+   │  scope-analyse → audit-doc → sessie → correctiepunten +      │    │
+   │  consensus + testcase-scenario's                             │ ───┘
+   └──────────────────────────────────────────────────────────────┘
+       omlaag: corpus workshop-rijp (validerend) of bewust ruw (verkennend)
+       omhoog: correctiepunten + bevestigde interpretaties → implementeer + verifieer
 ```
 
 ## De router-taal: vier-weg-classificatie

--- a/.claude/skills/regelrecht-dossier/references/routing.md
+++ b/.claude/skills/regelrecht-dossier/references/routing.md
@@ -13,20 +13,19 @@ Eén bron van waarheid voor hoe `regelrecht-stelselanalyse` (desk) en
 ## De flow (gesloten lus)
 
 ```
-        ┌──────────────── DESK · regelrecht-stelselanalyse ────────────────┐
-        │  harvest → modelleer → valideer → 4-weg classificeer → documenteer │
-        └───┬────────────────────────────────────────────────────┬─────────┘
-            │ modellering-fout → fix    wetgevings-fout → notitie  │
-            │ engine-limitatie → engine                            │
-            │                                                       │
-   corpus workshop-rijp (validerend)                     correctiepunten +
-   of bewust ruw (verkennend)                            bevestigde interpretaties
-            ▼                                                       │
-        ┌──────────── WORKSHOP · regelrecht-audit-products ────────┐│
-        │  scope-analyse → audit-doc → sessie → correctiepunten +  ││
-        │  consensus + testcase-scenario's                         ││
-        └───────────────────────────────────────────────────────┬─┘│
-                                                                  └──┘
+        ┌────────────── DESK · regelrecht-stelselanalyse ──────────────┐
+        │  harvest → modelleer → valideer → 4-weg classificeer → fix   │◀──┐
+        └──────┬───────────────────────────────────────────────────────┘   │
+               │ modellering-fout → fix · engine-limitatie → engine        │
+               │ wetgevings-fout → notitie                                 │
+               │                                                           │
+   corpus workshop-rijp (validerend)                          correctiepunten +
+   of bewust ruw (verkennend)                                 bevestigde interpretaties
+               ▼                                                           │
+        ┌─────────── WORKSHOP · regelrecht-audit-products ─────────────┐   │
+        │  scope-analyse → audit-doc → sessie → correctiepunten +      │   │
+        │  consensus + testcase-scenario's                             │───┘
+        └──────────────────────────────────────────────────────────────┘
                               terug de desk in: implementeer + verifieer
 ```
 

--- a/.claude/skills/regelrecht-dossier/references/routing.md
+++ b/.claude/skills/regelrecht-dossier/references/routing.md
@@ -1,0 +1,91 @@
+# Routing — de regelrecht dossier-flow (canoniek)
+
+Eén bron van waarheid voor hoe `regelrecht-stelselanalyse` (desk) en
+`regelrecht-audit-products` (workshop) samenhangen. Beide werk-skills verwijzen hierheen.
+
+## Twee lagen, geen alternatieven
+
+- **Desk (machinekamer)** — `regelrecht-stelselanalyse`. Harvest → modelleer → valideer →
+  **4-weg classificeer** → fix → documenteer → verifieer. Draait eerst en continu.
+- **Workshop (validatielaag)** — `regelrecht-audit-products`. Valideert met domein-experts.
+  Levert consensus, correctiepunten en testcases.
+
+## De flow (gesloten lus)
+
+```
+        ┌──────────────── DESK · regelrecht-stelselanalyse ────────────────┐
+        │  harvest → modelleer → valideer → 4-weg classificeer → documenteer │
+        └───┬────────────────────────────────────────────────────┬─────────┘
+            │ modellering-fout → fix    wetgevings-fout → notitie  │
+            │ engine-limitatie → engine                            │
+            │                                                       │
+   corpus workshop-rijp (validerend)                     correctiepunten +
+   of bewust ruw (verkennend)                            bevestigde interpretaties
+            ▼                                                       │
+        ┌──────────── WORKSHOP · regelrecht-audit-products ────────┐│
+        │  scope-analyse → audit-doc → sessie → correctiepunten +  ││
+        │  consensus + testcase-scenario's                         ││
+        └───────────────────────────────────────────────────────┬─┘│
+                                                                  └──┘
+                              terug de desk in: implementeer + verifieer
+```
+
+## De router-taal: vier-weg-classificatie
+
+Het label van een bevinding bepaalt de bestemming (zie
+`regelrecht-stelselanalyse/references/classification.md` voor de definities):
+
+| Classificatie | Route | Landt in |
+|---|---|---|
+| **modellering-fout** | desk fixt de YAML | `modellering-fixes-plan` |
+| **engine-limitatie** | desk trackt; engine-issue | `engine-limitaties` |
+| **wetgevings-fout** | desk documenteert → wetgevings-notitie (stakeholders) | `wetgevingsfouten-analyse` |
+| **acceptabele untranslatable / interpretatie-/praktijk-onzeker** | **workshop** | beslispunten in `audit-doc`/`workshop-draaiboek` |
+
+In één regel: **feitelijke defecten naar binnen (desk), oordeels-/praktijkvragen naar
+buiten (workshop).**
+
+## Entry-router (waar begin je?)
+
+| Situatie | Start |
+|---|---|
+| Geen corpus, of ruw/onvolledig | desk — harvest + modelleer |
+| Corpus bestaat, modellering onzeker/ongevalideerd | desk — valideer + classificeer + fix |
+| Corpus intern consistent; open punten zijn judgment/praktijk | workshop — validerend |
+| Je hebt domeinkennis/buy-in nodig die je mist | workshop — verkennend (mag vroeg) |
+| Na een workshop | terug naar desk — implementeer + verifieer |
+
+## Twee workshop-modi (gate is mode-afhankelijk)
+
+- **Verkennend / ontginnend** — vroeg, zelfs op een ruwe scope-analyse. Doel:
+  domeinkennis ontginnen, praktijk ophalen, scope bekrachtigen. **Geen gate.**
+- **Validerend** — een gemodelleerd corpus toetsen. **Gate**: schema valide + tests
+  groen + modellering-fouten gefixt + resterende open punten zijn *judgment* (niet
+  *factual*).
+
+Het gate-criterium beschermt alleen de validerende modus: laat experts niet valideren
+wat eigenlijk onze modelleerfout is. Voor kennis-ontginning is een ruw corpus prima.
+
+## Handoff-lus — wat stroomt welke kant op
+
+**Desk → workshop**
+- een rijp (validerend) of bewust-ruw (verkennend) corpus;
+- de *judgment*-set untranslatables wordt de **beslispunten** van de workshop;
+- de scope-analyse/wet-graph komt uit de desk-producten `cross-law-diagram` +
+  `corpus-status`.
+
+**Workshop → desk**
+- correctiepunten → modellering-fixes (implementeren + valideren);
+- bevestigde/weerlegde interpretaties → resolutie-tracker (verifiëren tegen bronnen);
+- door experts bevestigde wet-tekortkomingen → wetgevings-fouten-analyse;
+- expert-bevestigde testcases → engine-tests (regressie).
+
+## Gedeelde bruggen
+
+| Brug | Desk-kant | Workshop-kant |
+|---|---|---|
+| Scope/relaties | `cross-law-diagram`, `corpus-status` | `scope-analyse` (hergebruikt) |
+| Untranslatables | factual vs judgment geclassificeerd | judgment-set = beslispunten |
+| Scenario's | `engine-tests` (regressie) | `testcase-scenarios` (expert-validatie) |
+| Verslag/rapport | `eindrapport` (per cyclus) | `verslag-intern`/`-extern` (per sessie) |
+</content>

--- a/.claude/skills/regelrecht-dossier/references/zakkaart.md
+++ b/.claude/skills/regelrecht-dossier/references/zakkaart.md
@@ -39,6 +39,8 @@ skill-namen te onthouden — zeg wat je wilt, de router triageert en dispatcht.
 > **Eén regel**: feitelijke defecten → naar binnen (desk); oordeels-/praktijkvragen → naar buiten (workshop).
 > Open norm = *acceptabele untranslatable* bij kenbare beslisser + kader, anders *wetgevings-fout*.
 
+Canonieke definities: `regelrecht-stelselanalyse/references/classification.md` — deze kaart is de spiekversie.
+
 ## Workshop: twee modi (gate is mode-afhankelijk)
 
 - **Verkennend** — vroeg, géén gate: domeinkennis ontginnen op een ruwe scope-analyse.

--- a/.claude/skills/regelrecht-dossier/references/zakkaart.md
+++ b/.claude/skills/regelrecht-dossier/references/zakkaart.md
@@ -1,0 +1,67 @@
+# Regelrecht — zakkaart voor regelanalisten
+
+*Eén A4. Waar begin ik · welke skill · hoe loopt een casus. (Methode bekend verondersteld.)*
+
+## Bij twijfel: de voordeur
+**Beschrijf je casus → `regelrecht-dossier` (router) wijst de weg.** Je hoeft geen
+skill-namen te onthouden — zeg wat je wilt, de router triageert en dispatcht.
+
+## Drie deuren (op intentie)
+
+| Je wilt… | Deur |
+|---|---|
+| nieuwe casus · waar begin ik · welke producten heb ik nodig | **router** — `regelrecht-dossier` |
+| wet machine-leesbaar maken · corpus reviewen · fouten in de wet vinden | **desk** — `regelrecht-stelselanalyse` |
+| expert-/validatiesessie voorbereiden | **workshop** — `regelrecht-audit-products` |
+
+## De flow (gesloten lus)
+
+```
+ NIEUWE CASUS → [router] → feitelijk? ┐        ┌ oordeel/praktijk?
+                                      ▼        ▼
+   ┌──────────── DESK (machinekamer) ────────────┐  handoff  ┌──── WORKSHOP (live) ────┐
+   │ plan → harvest → modelleer → valideer →      │ ◄───────► │ scope-analyse → audit-  │
+   │ CLASSIFICEER (4-weg) → fix → documenteer →   │           │ doc → sessie → consensus│
+   │ verifieer (bronnen/tracker) → eindrapport    │           │ + correctiepunten +     │
+   └──────────────────────────────────────────────┘           │ testcases               │
+        └─ correctiepunten + bevestigde interpretaties ◄────────┘ terug de desk in
+```
+
+## Router-taal: 4-weg-classificatie — waar gaat een bevinding heen?
+
+| Label | Betekenis | Route |
+|---|---|---|
+| **modellering-fout** | onze YAML ≠ (correcte) wet | desk fixt de YAML |
+| **wetgevings-fout** | de wet zelf fout/achterhaald/onuitvoerbaar | → wetgevings-notitie |
+| **engine-limitatie** | wet + modellering kloppen, engine kan 't niet | → engine-issue |
+| **untranslatable / praktijk** | open norm, oordeel nodig | → **workshop** |
+
+> **Eén regel**: feitelijke defecten → naar binnen (desk); oordeels-/praktijkvragen → naar buiten (workshop).
+> Open norm = *acceptabele untranslatable* bij kenbare beslisser + kader, anders *wetgevings-fout*.
+
+## Workshop: twee modi (gate is mode-afhankelijk)
+
+- **Verkennend** — vroeg, géén gate: domeinkennis ontginnen op een ruwe scope-analyse.
+- **Validerend** — gate: schema valide + tests groen + modellering-fouten gefixt + resterende punten zijn *judgment*.
+
+## Beslis-kaart
+
+| Situatie | Ga naar |
+|---|---|
+| Geen/ruw corpus | desk — harvest + modelleer |
+| Modellering onzeker/ongevalideerd | desk — valideer + classificeer + fix |
+| Open punt is **feitelijk** (YAML/wet/engine) | desk — fixes / wetgevings-analyse / engine-issues |
+| Open punt is **oordeel/praktijk** | workshop — validerend |
+| Domeinkennis/buy-in nodig die je mist | workshop — verkennend (mag vroeg) |
+| Na een workshop | desk — implementeer + verifieer |
+| Repetitief batchwerk / terugkerende controle | `/loop` (lokaal) · `/schedule` (cloud) |
+
+## Autonomie & veiligheid
+
+`/loop` = lokale batch (zichzelf afmakend) · `/schedule` = cloud-routine (onbeheerd, cron).
+Commits door routines gaan **alleen naar private repos** (push-guard); bewust publiek
+pushen: `ALLOW_PUBLIC_PUSH=1`.
+
+---
+Canonieke flow & details: `regelrecht-dossier/references/routing.md`
+</content>

--- a/.claude/skills/regelrecht-dossier/references/zakkaart.md
+++ b/.claude/skills/regelrecht-dossier/references/zakkaart.md
@@ -64,4 +64,3 @@ pushen: `ALLOW_PUBLIC_PUSH=1`.
 
 ---
 Canonieke flow & details: `regelrecht-dossier/references/routing.md`
-</content>

--- a/.claude/skills/regelrecht-stelselanalyse/SKILL.md
+++ b/.claude/skills/regelrecht-stelselanalyse/SKILL.md
@@ -177,6 +177,8 @@ voor polling, `/schedule`-routine voor onbeheerd terugkerend werk): zie
 **scripts/** — `assert-private-repo.sh`: fail-closed guard die alleen doorlaat als de
 push-target een **private** GitHub-repo is (autonome routines mogen committen/pushen, maar
 alleen naar private repos). Draai als preflight vóór elke push; PUBLIC/INTERNAL → geweigerd.
+`test-assert-private-repo.sh` borgt de invarianten van die guard met gestubde `git`/`gh`
+(gitlab/enterprise/bitbucket → block, github-private → pass, onbereikbaar → block).
 
 **Zustersskills** (apart geïnstalleerd, geen bestand in deze skill):
 - `law-version-drift-check` — **Step 0** van elke micro-cyclus: spiegelt YAML-tekst tegen

--- a/.claude/skills/regelrecht-stelselanalyse/SKILL.md
+++ b/.claude/skills/regelrecht-stelselanalyse/SKILL.md
@@ -86,17 +86,26 @@ over juridische correctheid.
    is geen losse steekproef maar een volledig algoritme over het hele corpus:
    1. Bouw een map `regulation → set(action-outputs)` over het hele corpus (welke output
       produceert elke wet feitelijk).
-   2. Voor elke `source: { regulation, output }`: verifieer `output ∈ outputs[regulation]`.
-      Zo niet → **DANGLING**-bevinding (classificatie: **modellering-fout**).
-   3. Scan elke input-`description` op tokens als "conceptueel", "forward naar",
-      "tijdelijk als directe parameter", plus een regulation-naam-patroon; heeft zo'n input
-      géén `source:`-blok → **PLAIN-PARAM**-bevinding (**modellering-fout**).
-   4. Rapporteer een telling `clean / dangling / plain-param`. Een corpus is pas
-      **source-clean** als `dangling = 0` én `plain-param = 0`.
+   2. **MISPLACED** — een `source:`-blok onder `parameters:` (i.p.v. `input:`). De engine
+      heeft twee aparte structs: `Parameter` (onder `parameters:`) kent **geen** `source`-veld,
+      alleen `Input` (onder `input:`) wel. Een source onder `parameters:` wordt dus bij het
+      parsen **stil weggegooid** — de binding lijkt echt maar vuurt nooit; scenario's die de
+      waarde direct injecteren maskeren het. Detecteer per `source` of de omsluitende lijst
+      `input:` is; zo niet → **MISPLACED** (**modellering-fout**). Dit is de meest
+      voorkomende verborgen vorm.
+   3. **DANGLING** — voor elke `source: { regulation, output }` onder `input:`: verifieer
+      `output ∈ outputs[regulation]`. Zo niet → **DANGLING** (**modellering-fout**).
+   4. **PLAIN-PARAM** — een `parameters:`-item waarvan de `description` "conceptueel" of
+      "tijdelijk als directe parameter" bevat maar dat géén binding is. (Let op: woorden als
+      "forward naar" op een leaf-parameter die een binding-mapping vóédt zijn legitiem — niet
+      flaggen.)
+   5. Rapporteer `clean / misplaced / dangling / plain-param`. Een corpus is pas
+      **source-clean** als `misplaced = 0`, `dangling = 0` én `plain-param = 0`.
 
-   **DANGLING en PLAIN-PARAM zijn in de vier-weg-classificatie ALTIJD modellering-fout —
-   nooit "engine-limitatie".** Het "de engine kan geen meerdere bindingen per artikel"-
-   excuus is ongeldig (schema v0.5.2 ondersteunt dit); bind echt en test.
+   **MISPLACED, DANGLING en PLAIN-PARAM zijn in de vier-weg-classificatie ALTIJD
+   modellering-fout — nooit "engine-limitatie".** Het "de engine kan geen meerdere bindingen
+   per artikel"-excuus is ongeldig (schema v0.5.2 ondersteunt dit); bind echt — onder
+   `input:` — en bewijs met een BDD-scenario dat de bron-wet laadt en de leaf-inputs zet.
 
    Draai de scan reproduceerbaar met
    `python3 .claude/skills/regelrecht-stelselanalyse/references/cross-law-integriteit.py <corpus-root>`

--- a/.claude/skills/regelrecht-stelselanalyse/SKILL.md
+++ b/.claude/skills/regelrecht-stelselanalyse/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: regelrecht-stelselanalyse
+description: Voert de iteratieve desk-review-&-completion-cyclus uit op een regelrecht-corpus — plannen, harvesten/migreren/uitbreiden, multi-agent valideren, bevindingen 4-weg classificeren (modellering-fout / wetgevings-fout / engine-limitatie / acceptabele untranslatable), synthese + heroverweging, documenteren (wetgevings-/stelselfouten-analyse, fixes-plan, engine-limitaties, diagrammen, corpus-status), verifiëren tegen externe bronnen (resolutie-tracker + bronnen-dossier), en een eindrapport per cyclus. Gebruik dit bij corpus-review op correctheid/coverage zonder live expert-sessie, het opstellen van een wetgevings-notitie-bron, schema-migratie, het harvesten van nieuwe wetten, of het aansturen van een autonome completion-loop. Dossier-agnostisch; de regelrecht-methode is de vaste taal. Voor live-validatie met experts: zie regelrecht-audit-products.
+allowed-tools: Read, Write, Edit, Grep, Glob, Bash, WebFetch, WebSearch, Agent, AskUserQuestion, ScheduleWakeup, Monitor
+---
+
+# Regelrecht stelselanalyse — desk-review & corpus-completion
+
+De analytische desk-tegenhanger van `regelrecht-audit-products` (live-validatie met
+experts). Deze skill drijft de **iteratieve cyclus** waarmee een machine-leesbaar
+corpus stap voor stap correcter en completer wordt, en levert de bijbehorende
+producten op.
+
+Het verschil met een audit-doc: een audit-doc vraagt *"klopt ons stappenplan?"*. Deze
+skill vraagt óók *"klopt de wet zelf, is hij uitvoerbaar, en hoe ver komt de engine?"*.
+Zie `references/classification.md`.
+
+Geen casus-inhoud in de skill; concrete inhoud komt uit het corpus en de externe
+bronnen tijdens de cyclus.
+
+## Routing & handoff
+
+Dit is de desk-laag. Oordeels-/praktijkvragen (acceptabele untranslatables, formule-vs-
+praktijk, scope-keuzes) routeren naar de workshop-skill **`regelrecht-audit-products`**;
+feitelijke defecten blijven hier. De *judgment*-set untranslatables wordt de beslispunten
+van een workshop; de scope-analyse daar komt uit de desk-producten `cross-law-diagram` +
+`corpus-status`. Workshop-correctiepunten komen terug de cyclus in (fixes + verificatie).
+Twijfel je waar te beginnen → **`regelrecht-dossier`** (router). Canonieke flow:
+`regelrecht-dossier/references/routing.md`.
+
+## De cyclus
+
+```
+plan ─► (harvest / migreer / breid uit) ─► valideer (multi-agent, per as)
+   ▲                                              │
+   │                                              ▼
+eindrapport ◄─ verifieer (bronnen + tracker) ◄─ classificeer (4-weg)
+                                                  │
+                                                  ▼
+                                        synthese + heroverweging
+                                                  │
+                                                  ▼
+                              documenteer (fouten / fixes / limitaties / diagrammen / status)
+```
+
+Eén cyclus pakt één **thema/scope** (niet alles tegelijk). Werk in micro-cycli.
+
+## Kernprincipe: vier-weg-classificatie
+
+Elke bevinding krijgt precies één label. Dit bepaalt waar hij landt en welke actie
+volgt — verkeerd labelen = verkeerde actie. Zie `references/classification.md`:
+
+1. **Modellering-fout** — onze YAML/feature wijkt af van de (correcte) wettekst →
+   wij fixen het (`modellering-fixes-plan`).
+2. **Wetgevings-fout** — de wet zelf is onjuist/achterhaald/onuitvoerbaar, niet door
+   interpretatie te repareren → aanbevolen wetgevings-actie (`wetgevingsfouten-analyse`).
+3. **Engine-limitatie** — wet + modellering kloppen, engine kan het (nog) niet →
+   engine-issue (`engine-limitaties`).
+4. **Acceptabele untranslatable** — open norm die bewust niet gemodelleerd wordt en
+   dat ook niet hoeft → markeren, geen actie.
+
+De grens tussen (2) en (4) is de subtielste en belangrijkste: een open norm is
+*acceptabel untranslatable* bij een kenbare beslisser + toetsbaar kader, en een
+*wetgevings-fout* als beslisser/kader/grond ontbreekt.
+
+**Meta-check, altijd uitvoeren**: maken de features en de YAML dezelfde fout? Zo ja,
+dan valideert de BDD-suite de YAML en niet de wet — groene tests bewijzen dan niets
+over juridische correctheid.
+
+## Werkstroom
+
+1. **Plan de cyclus.** Bepaal thema/scope en deel op in micro-cycli
+   (`templates/cyclus-plan.md`). Voor autonome uitvoering: schrijf een self-driving
+   loop-prompt (`templates/loop-prompt.md`). Zie `references/cycle-workflow.md`.
+
+2. **Doe het corpus-werk.** Harvest een nieuwe wet, migreer naar een nieuwe
+   schemaversie, of breid MR-logica uit — elk met een rapport
+   (`harvest`/`mr`/`schema-migratie`-sjablonen).
+
+3. **Valideer, eventueel multi-agent.** Verdeel over review-assen (correctheid,
+   untranslatables, coverage, source-refs, diagrammen, wetgevings-fouten). Bij
+   parallel werk: één sub-agent per as via de `Agent`-tool. Zie
+   `references/review-orchestration.md`.
+
+4. **Classificeer** elke bevinding 4-weg (zie boven). Voer de meta-check uit.
+
+5. **Synthese + heroverweging.** Voeg parallelle reviews samen; markeer twijfel-claims;
+   schrap weerlegde claims (doorgestreept + reden) en pas tellingen aan.
+
+6. **Documenteer** vanuit de sjablonen: wetgevings-fouten, fixes-plan, engine-limitaties,
+   cross-law-diagrammen, corpus-status, engine-tests.
+
+7. **Verifieer met externe bronnen.** Ontgin Staatsbladen / nota's van toelichting /
+   rekenregels via WebFetch; leg status vast in `resolutie-tracker.md`
+   (vocabulaire: verifieerd / weerlegd / gedeeltelijk / onverifieerbaar / out-of-scope)
+   en in het bronnen-dossier. Zie `references/verification-cycle.md`.
+
+8. **Eindrapport** per cyclus (`templates/eindrapport.md`): doel vs resultaat, geleverd,
+   discoveries, open punten voor de volgende cyclus.
+
+9. **Schrijf naar het corpus/dossier, niet in de skill. Commit/push alleen op verzoek.**
+
+## Bestanden in deze skill
+
+**references/**
+- `classification.md` — vier-weg-classificatie + onderscheid met de audit-doc + de
+  beslisregel open-norm-vs-wetgevingsfout. Het conceptuele hart.
+- `review-orchestration.md` — multi-agent review: assen, sub-agent-verdeling, synthese,
+  heroverweging, telling, de features-vs-YAML meta-check.
+- `defect-taxonomy.md` — categorieën wetgevings-fouten, ernst-niveaus, per-fout format.
+- `verification-cycle.md` — resolutie-tracker, status-vocabulaire, scope-markering,
+  bronnen-dossier + INDEX, WebFetch-ontginning.
+- `cycle-workflow.md` — de cyclus-motor: planning, loop-prompts, harvest, schema-migratie,
+  eindrapport, micro-cycli.
+
+**templates/** — `cyclus-plan`, `loop-prompt`, `scheduled-routine`, `schema-migratie`,
+`harvest-rapport`, `mr-uitbreiding-rapport`, `validatie-review`, `synthese`,
+`wetgevingsfouten-analyse`, `modellering-fixes-plan`, `engine-limitaties`,
+`resolutie-tracker`, `bronnen-INDEX`, `cross-law-diagram`, `corpus-status`,
+`engine-tests`, `eindrapport`.
+
+Autonome uitvoering (`/loop` self-paced voor een afgebakende batch, `/loop <interval>`
+voor polling, `/schedule`-routine voor onbeheerd terugkerend werk): zie
+`references/cycle-workflow.md` en de sjablonen `loop-prompt` + `scheduled-routine`.
+
+**scripts/** — `assert-private-repo.sh`: fail-closed guard die alleen doorlaat als de
+push-target een **private** GitHub-repo is (autonome routines mogen committen/pushen, maar
+alleen naar private repos). Draai als preflight vóór elke push; PUBLIC/INTERNAL → geweigerd.
+
+## Belangrijke regels
+
+- **Classificeer vóór je documenteert.** Het label bepaalt het product en de actie.
+- **Wetgevings-fouten zijn een formeel product** (bron voor een wetgevings-notitie):
+  feitelijk, met wettekst-citaat, implicatie en concrete reparatie — geen losse meningen.
+- **Bewaar de redeneerketen bij heroverweging**: geschrapte claims blijven zichtbaar
+  (doorgestreept + reden), tellingen aangepast — geen stille verwijdering.
+- **Scheid corpus- en engine-issues**: een engine-limitatie is geen wetgevings- of
+  modellering-fout; track 'm apart zodat het corpus niet onterecht "fout" lijkt.
+- **Dossier-agnostisch blijven**; niets pushen zonder toestemming.
+</content>

--- a/.claude/skills/regelrecht-stelselanalyse/SKILL.md
+++ b/.claude/skills/regelrecht-stelselanalyse/SKILL.md
@@ -159,10 +159,14 @@ over juridische correctheid.
   bronnen-dossier + INDEX, WebFetch-ontginning.
 - `cycle-workflow.md` — de cyclus-motor: planning, loop-prompts, harvest, schema-migratie,
   eindrapport, micro-cycli.
+- `check-keten.md` — overzicht van alle checks op wets-zuiverheid & cross-law, met per
+  check het *orakel* (waartegen) en of het een CI-gate of methodologisch is.
 - `cross-law-integriteit.py` — herbruikbaar script voor de source-refs-integriteitsscan:
-  bouwt `regulation → outputs`, detecteert dangling source-bindingen en plain-param-
-  placeholders, en print de telling `clean / dangling / plain-param` (exit 1 bij
-  bevindingen). Corpus-agnostisch; draai als preflight in de `Valideer`-stap.
+  bouwt `regulation → outputs`, detecteert MISPLACED/DANGLING/PLAIN-PARAM source-bindingen
+  én IMPL-DANGLING (`implements` naar een niet-gedeclareerde open_term) / IMPL-NO-DATE
+  (implementing-regeling zonder `valid_from`), en print de telling (exit 1 bij bevindingen).
+  Corpus-agnostisch; draait ook als CI-gate (`cross-law-integrity` job) en als preflight
+  in de `Valideer`-stap.
 
 **templates/** — `cyclus-plan`, `loop-prompt`, `scheduled-routine`, `schema-migratie`,
 `harvest-rapport`, `mr-uitbreiding-rapport`, `validatie-review`, `synthese`,

--- a/.claude/skills/regelrecht-stelselanalyse/SKILL.md
+++ b/.claude/skills/regelrecht-stelselanalyse/SKILL.md
@@ -45,6 +45,20 @@ eindrapport ◄─ verifieer (bronnen + tracker) ◄─ classificeer (4-weg)
 
 Eén cyclus pakt één **thema/scope** (niet alles tegelijk). Werk in micro-cycli.
 
+## Step 0 — drift-check (verplicht, vóór elke YAML-edit)
+
+Elke micro-cyclus die een regulation-YAML kán aanraken begint met de zustersskill
+**`law-version-drift-check`**: spiegel elk `text:`-blok tegen de geldende wettekst op
+wetten.overheid.nl bij de `valid_from` van de YAML. Géén bypass, geen "deze cyclus is
+maar docs"-escape — de trigger is "ik ga zo een regulation-YAML bewerken".
+
+Waarom een harde voorwaarde: drift mis-classificeert bevindingen over de hele 4-weg-as.
+Een claim "de YAML zegt X maar de wet zegt Y" is alleen een **wetgevings-fout** als de
+geldende wet écht Y zegt; was Y al gewijzigd door een niet-ingeharvest Stb., dan is
+diezelfde bevinding in werkelijkheid een **modellering-fout (drift)**. Zonder een CLEANE
+(of scope-gerestricteerde) drift-rapport mag geen YAML-edit gemaakt worden, en bevindingen
+op artikelen met open DRIFT-tekst worden bij de synthese (stap 5) verworpen.
+
 ## Kernprincipe: vier-weg-classificatie
 
 Elke bevinding krijgt precies één label. Dit bepaalt waar hij landt en welke actie
@@ -68,6 +82,10 @@ dan valideert de BDD-suite de YAML en niet de wet — groene tests bewijzen dan 
 over juridische correctheid.
 
 ## Werkstroom
+
+0. **Drift-check (Step 0).** Vóór élke YAML-edit: draai de zustersskill
+   `law-version-drift-check` per file. Geen CLEANE/scope-gerestricteerde drift-rapport →
+   geen edit. Zie de sectie *Step 0* hierboven; bevindingen → resolutie-tracker (klasse 1).
 
 1. **Plan de cyclus.** Bepaal thema/scope en deel op in micro-cycli
    (`templates/cyclus-plan.md`). Voor autonome uitvoering: schrijf een self-driving
@@ -160,6 +178,14 @@ voor polling, `/schedule`-routine voor onbeheerd terugkerend werk): zie
 push-target een **private** GitHub-repo is (autonome routines mogen committen/pushen, maar
 alleen naar private repos). Draai als preflight vóór elke push; PUBLIC/INTERNAL → geweigerd.
 
+**Zustersskills** (apart geïnstalleerd, geen bestand in deze skill):
+- `law-version-drift-check` — **Step 0** van elke micro-cyclus: spiegelt YAML-tekst tegen
+  de geldende wettekst vóór elke edit (zie de sectie *Step 0*). Bevindingen → resolutie-
+  tracker als 4-weg klasse 1 (modellering-fout), fixes → `modellering-fixes-plan`.
+- `regelrecht-audit-products` — live expert-validatie (workshop-laag); ontvangt de
+  judgment-untranslatables en scope-analyse uit deze desk-laag.
+- `regelrecht-dossier` — front-door router (`references/routing.md` = canonieke flow).
+
 ## Belangrijke regels
 
 - **Classificeer vóór je documenteert.** Het label bepaalt het product en de actie.
@@ -170,4 +196,3 @@ alleen naar private repos). Draai als preflight vóór elke push; PUBLIC/INTERNA
 - **Scheid corpus- en engine-issues**: een engine-limitatie is geen wetgevings- of
   modellering-fout; track 'm apart zodat het corpus niet onterecht "fout" lijkt.
 - **Dossier-agnostisch blijven**; niets pushen zonder toestemming.
-</content>

--- a/.claude/skills/regelrecht-stelselanalyse/SKILL.md
+++ b/.claude/skills/regelrecht-stelselanalyse/SKILL.md
@@ -82,6 +82,26 @@ over juridische correctheid.
    parallel werk: één sub-agent per as via de `Agent`-tool. Zie
    `references/review-orchestration.md`.
 
+   **Source-refs — verplichte, niet-overslaanbare integriteitsscan.** De `source-refs`-as
+   is geen losse steekproef maar een volledig algoritme over het hele corpus:
+   1. Bouw een map `regulation → set(action-outputs)` over het hele corpus (welke output
+      produceert elke wet feitelijk).
+   2. Voor elke `source: { regulation, output }`: verifieer `output ∈ outputs[regulation]`.
+      Zo niet → **DANGLING**-bevinding (classificatie: **modellering-fout**).
+   3. Scan elke input-`description` op tokens als "conceptueel", "forward naar",
+      "tijdelijk als directe parameter", plus een regulation-naam-patroon; heeft zo'n input
+      géén `source:`-blok → **PLAIN-PARAM**-bevinding (**modellering-fout**).
+   4. Rapporteer een telling `clean / dangling / plain-param`. Een corpus is pas
+      **source-clean** als `dangling = 0` én `plain-param = 0`.
+
+   **DANGLING en PLAIN-PARAM zijn in de vier-weg-classificatie ALTIJD modellering-fout —
+   nooit "engine-limitatie".** Het "de engine kan geen meerdere bindingen per artikel"-
+   excuus is ongeldig (schema v0.5.2 ondersteunt dit); bind echt en test.
+
+   Draai de scan reproduceerbaar met
+   `python3 .claude/skills/regelrecht-stelselanalyse/references/cross-law-integriteit.py <corpus-root>`
+   (exit-code 0 = source-clean, 1 = bevindingen).
+
 4. **Classificeer** elke bevinding 4-weg (zie boven). Voer de meta-check uit.
 
 5. **Synthese + heroverweging.** Voeg parallelle reviews samen; markeer twijfel-claims;
@@ -112,6 +132,10 @@ over juridische correctheid.
   bronnen-dossier + INDEX, WebFetch-ontginning.
 - `cycle-workflow.md` — de cyclus-motor: planning, loop-prompts, harvest, schema-migratie,
   eindrapport, micro-cycli.
+- `cross-law-integriteit.py` — herbruikbaar script voor de source-refs-integriteitsscan:
+  bouwt `regulation → outputs`, detecteert dangling source-bindingen en plain-param-
+  placeholders, en print de telling `clean / dangling / plain-param` (exit 1 bij
+  bevindingen). Corpus-agnostisch; draai als preflight in de `Valideer`-stap.
 
 **templates/** — `cyclus-plan`, `loop-prompt`, `scheduled-routine`, `schema-migratie`,
 `harvest-rapport`, `mr-uitbreiding-rapport`, `validatie-review`, `synthese`,

--- a/.claude/skills/regelrecht-stelselanalyse/references/check-keten.md
+++ b/.claude/skills/regelrecht-stelselanalyse/references/check-keten.md
@@ -1,0 +1,91 @@
+# Check-keten — waartegen wordt wets-zuiverheid & cross-law getoetst
+
+Overzicht van álle checks op de correctheid van een machine-leesbare wet en op
+cross-law-koppelingen, gerangschikt van puur-syntactisch (volledig geautomatiseerd)
+naar juridisch-inhoudelijk (mens/agent-gedreven). Per check: **waartegen** wordt
+afgemeten (het *orakel*), en of het een harde CI-gate is of methodologisch.
+
+Een **orakel** is de bron van waarheid waaraan een check het verdict afleest. Een
+CI-gate kan alleen op een *hermetisch* orakel draaien: stabiel, lokaal in de repo,
+reproduceerbaar. Een orakel dat op afstand staat en kan veranderen (de live
+wettekst) is niet gateable en hoort in de methodologische laag.
+
+## De vijf lagen
+
+```
+SCHEMA ──► ENGINE ──► CROSS-LAW ──► METHODOLOGIE ──► EXTERNE BRON
+└──── geautomatiseerd (CI) ────┴──── mens/agent-gedreven ────┘
+```
+
+De kern-spanning: **CI bewaakt vorm (formele correctheid), niet betekenis
+(juridische getrouwheid).** Dat laatste leeft in de drift-check (Step 0) en de
+expert-workshop.
+
+## Orakel-catalogus
+
+| Check | Toetst | Orakel | Type |
+|---|---|---|---|
+| Schema-validatie (`just validate`) | structuur/velden/types | `schema/vX.Y.Z/schema.json` (Draft-07) | CI-gate |
+| Serde-deserialisatie | type-integriteit | Rust-structs (`ArticleBasedLaw`) | CI-gate |
+| yamllint | YAML-stijl | `.yamllint` | CI-gate |
+| `protect-schema` | onveranderlijkheid releasede schema's | git diff vs `origin/main` | CI-gate (PR) |
+| `provenance-checks` (RFC-013) | schema-registratie, `$schema`-refs, symlink | repo-structuur | CI-gate (PR) |
+| Engine-resolver (runtime) | bestaan wet/artikel/output, cycles, types | de geladen corpus zelf | alleen bij uitvoering (BDD) |
+| **cross-law-integriteit** | MISPLACED/DANGLING/PLAIN-PARAM/IMPL-DANGLING/IMPL-NO-DATE | `regulation → outputs` + `open_terms`-index uit de corpus | **CI-gate** (`cross-law-integrity` job) |
+| BDD-features | end-to-end reken-uitkomsten incl. IoC | verwachte waarden in `features/*.feature` | CI-gate — *let op meta-check* |
+| RFC-013 execution receipt | reproduceerbaarheid | engine+schema+regulation-hash+scope | runtime |
+| **drift-check** (Step 0) | `text:` ≡ geldende wettekst (structureel + tekstueel) | **wetten.overheid.nl/`<bwb>`/`<valid_from>`** (+ Staatsblad) | methodologisch (WebFetch + kalibratie) |
+| 4-weg-classificatie | oorzaak/route van een bevinding | wet + jurisprudentie + schema/engine | methodologisch |
+| defect-taxonomie | type/ernst wetgevings-fout | Staatsblad, nota van toelichting, ECLI | methodologisch |
+| verificatie-cyclus | houdt een claim stand | externe bronnen via WebFetch | semi-automatisch |
+
+## Cross-law specifiek
+
+Twee mechanismen:
+- **Directe sourcing** — `source: {regulation, output, parameters}` op een `input:`-veld;
+  engine resolt via een `output_index`. Faalt pas bij uitvoering als de output ontbreekt.
+- **IoC / delegatie** — `open_terms` (hogere wet) ↔ `implements` (lagere regeling), met
+  temporele (`valid_from`) en scope-filtering (`gemeente_code`) en *lex superior > lex
+  posterior*.
+
+De statische gate is `cross-law-integriteit.py` (zie de skill-bestandenlijst). Sinds de
+uitbreiding dekt hij ook de IoC-kant: `implements` moet naar een echt gedeclareerd
+`open_term` wijzen (IMPL-DANGLING) en implementing-regelingen moeten `valid_from` dragen
+(IMPL-NO-DATE; anders matcht de RFC-003-temporele filter elke datum). Draait nu als
+CI-gate over `corpus/regulation`.
+
+## De meta-check (scharnierpunt)
+
+*"Maken de features en de YAML dezelfde fout?"* Zo ja, dan valideert de groene BDD-suite
+de YAML tegen zichzelf, niet tegen de wet — groen bewijst dan niets over juridische
+correctheid. Daarom bestaat de drift-check als gatekeeper vóór elke YAML-edit.
+
+## De gaten — en hoe ze geadresseerd zijn
+
+| Gap | Aard | Status |
+|---|---|---|
+| **1. cross-law niet in CI** | echte automatiseerbare gate | ✅ opgelost — `cross-law-integrity` CI-job |
+| **2. `implements` niet gevalideerd** | echte automatiseerbare gate | ✅ opgelost — IMPL-DANGLING + IMPL-NO-DATE in het script |
+| **3. tekst-getrouwheid niet in CI** | *orakel is de live wet → niet hermetisch* | ⏳ golden-text-subsysteem (aparte PR), zie hieronder |
+| **4. `coverage_score` ≠ correctheid** | semantiek/duidelijkheid, geen gate | ✅ verhelderd — doc-comment op het veld + deze notitie |
+
+### Waarom gap 3 anders is (en hoe het tóch kan)
+
+De *vergelijking* `text:` vs referentietekst is triviaal deterministisch. Het
+niet-deterministische zit in het **orakel**: de drift-check meet tegen de **live**
+geldende tekst op wetten.overheid.nl — een remote, mutabele, te-interpreteren bron
+(render-lag, rate-limiting, HTML-extractie). Daarom gebruikt de drift-check twee
+onafhankelijke fetches die moeten overeenkomen, kalibratie ≥80% op ijkpunten, en
+Staatsblad-fallback. Dat is statistisch, geen schone `==` — en dus geen CI-gate.
+
+**Deterministisch kan wél via een gecommitte snapshot (golden-text):**
+1. **Capture & bless** (methodologisch, drift-check, periodiek): haal per chunk de
+   geldende tekst op, normaliseer volgens de verbatim-spiegelregel (zie
+   `law-version-drift-check/reference.md` §2), en commit hash + tekst + herkomst.
+2. **Gate** (deterministisch, CI, per-commit): herbereken de genormaliseerde hash van
+   elk YAML-`text:`-chunk en vergelijk met de fixture. Mismatch → faal.
+
+De eerlijke grens: de gate bewaakt *"YAML ≡ laatst geverifieerde tekst"*, niet *"YAML ≡
+huidige live wet"*. Stille YAML-edits → CI faalt direct. Verandert de wet in de wereld →
+alleen de periodieke drift-check (laag 1) vangt het. Dit is "approval-testing" + per-chunk
+provenance (verwant aan RFC-013's `regulation_hash`, maar per lid i.p.v. per bestand).

--- a/.claude/skills/regelrecht-stelselanalyse/references/classification.md
+++ b/.claude/skills/regelrecht-stelselanalyse/references/classification.md
@@ -1,0 +1,58 @@
+# Vier-weg-classificatie — het conceptuele hart
+
+Elke bevinding in een desk-review krijgt **precies één** van vier labels. Het label
+bepaalt waar de bevinding landt en welke actie volgt. Verkeerd labelen leidt tot de
+verkeerde actie (een wet "fixen" die we niet kunnen wijzigen, of onze YAML niet
+corrigeren omdat we de fout bij de wet legden).
+
+| Label | Wat | Waar het landt | Actie |
+|---|---|---|---|
+| **Modellering-fout** | Onze YAML/feature wijkt af van de (correcte) wettekst | `modellering-fixes-plan` | Wij fixen de YAML |
+| **Wetgevings-fout** | De wet zelf is onjuist/achterhaald/onuitvoerbaar; niet door interpretatie te repareren | `wetgevingsfouten-analyse` | Aanbevolen wetgevings-actie |
+| **Engine-limitatie** | Wet + modellering kloppen, maar de engine kan het (nog) niet uitvoeren | `engine-limitaties` | Engine-issue / engine-PR |
+| **Acceptabele untranslatable** | Open norm die bewust niet gemodelleerd wordt en dat ook niet hoeft | gemarkeerd in de YAML | Geen actie |
+
+## Beslisboom
+
+1. Wijkt onze YAML/feature af van wat de wettekst feitelijk zegt? → **modellering-fout**.
+2. Klopt onze modellering met de wet, maar is de *wet zelf* fout/achterhaald/onuitvoerbaar?
+   → **wetgevings-fout**.
+3. Kloppen wet én modellering, maar faalt de *engine* op de uitvoering? → **engine-limitatie**.
+4. Is het een open norm die we bewust niet modelleren? → ga naar het onderscheid hieronder.
+
+## Het subtielste onderscheid: open norm — untranslatable of wetgevings-fout?
+
+Dezelfde clausule (*"naar het oordeel van"*, *"redelijkerwijs"*, *"onbillijkheid van
+overwegende aard"*) kan beide zijn. De stance bepaalt het label:
+
+- **Acceptabele untranslatable** wanneer er een **kenbare beslisser** is én een
+  **toetsbaar kader** (wie beslist, wanneer, op welke grond, met welk rechtsmiddel).
+  De norm vergt menselijk oordeel, maar is wel uitvoerbaar en toetsbaar.
+- **Wetgevings-fout** ("open norm zonder beslisser") wanneer beslisser, kader, of
+  grond **ontbreekt**: niet duidelijk wie toetst, geen criterium, geen rechtsmiddel,
+  of een circulair criterium. Dan is de norm niet kenbaar uitvoerbaar.
+
+Toets daarom bij elke open norm: *wie* beslist, *wanneer*, op welk *dossier/grond*, en
+met welk *rechtsmiddel*. Ontbreekt een van deze → kandidaat wetgevings-fout.
+
+## Onderscheid met de audit-doc (workshop-skill)
+
+| | Audit-doc (`regelrecht-audit-products`) | Desk-classificatie (deze skill) |
+|---|---|---|
+| Vraag | "Klopt ons stappenplan?" | "Klopt de wet zelf, en is hij uitvoerbaar?" |
+| Aanname | De wet is correct; fout zit in onze modellering | Fout kan in modellering, wet, of engine zitten |
+| Open norm | Geaccepteerde untranslatable | Untranslatable **of** wetgevings-fout (zie boven) |
+| Uitkomst | Bevestigde/gecorrigeerde YAML | Wetgevings-notitie + fixes + engine-issues + status |
+| Publiek | Domein-experts in een sessie | Wetgevingsjuristen / ministerie / eigen team |
+
+Een audit-doc kent maar één richting (de fout zit bij ons). Deze skill voegt de andere
+drie richtingen toe. Dat is het hele verschil — en de reden dat de producten op elkaar
+lijken maar niet hetzelfde zijn.
+
+## De features-vs-YAML meta-check
+
+Voer bij elke validatie uit: *maken de features en de YAML dezelfde fout?* Zo ja, dan
+valideert de BDD-suite de YAML in plaats van de wet — groene tests bewijzen dan niets
+over juridische correctheid. Dit is een veelvoorkomende valkuil en hoort als expliciete
+meta-bevinding in de synthese.
+</content>

--- a/.claude/skills/regelrecht-stelselanalyse/references/classification.md
+++ b/.claude/skills/regelrecht-stelselanalyse/references/classification.md
@@ -55,4 +55,3 @@ Voer bij elke validatie uit: *maken de features en de YAML dezelfde fout?* Zo ja
 valideert de BDD-suite de YAML in plaats van de wet — groene tests bewijzen dan niets
 over juridische correctheid. Dit is een veelvoorkomende valkuil en hoort als expliciete
 meta-bevinding in de synthese.
-</content>

--- a/.claude/skills/regelrecht-stelselanalyse/references/cross-law-integriteit.py
+++ b/.claude/skills/regelrecht-stelselanalyse/references/cross-law-integriteit.py
@@ -1,0 +1,27 @@
+import re, glob, sys
+root = sys.argv[1] if len(sys.argv) > 1 else 'regulation'
+law_outputs = {}
+for path in glob.glob(f'{root}/**/*.yaml', recursive=True):
+    txt = open(path).read()
+    m = re.search(r'\$id:\s*(\S+)', txt)
+    if not m: continue
+    law_outputs[m.group(1)] = set(re.findall(r'- output: (\S+)', txt))
+dangling, plain, ok = [], [], 0
+for path in glob.glob(f'{root}/**/*.yaml', recursive=True):
+    txt = open(path).read()
+    m = re.search(r'\$id:\s*(\S+)', txt)
+    if not m: continue
+    fl = m.group(1)
+    for sm in re.finditer(r'source:\s*\n\s+regulation:\s*(\S+)\s*\n\s+output:\s*(\S+)', txt):
+        tl, to = sm.group(1), sm.group(2)
+        if tl not in law_outputs or to not in law_outputs[tl]:
+            dangling.append(f'{fl} -> {tl}.{to}')
+        else:
+            ok += 1
+    for cm in re.finditer(r'conceptueel:', txt):
+        if 'source:' not in txt[cm.start():cm.start()+300]:
+            plain.append(fl)
+print(f'clean={ok} dangling={len(dangling)} plain-param={len(plain)}')
+for d in dangling: print('  DANGLING', d)
+for p in plain: print('  PLAIN', p)
+sys.exit(1 if (dangling or plain) else 0)

--- a/.claude/skills/regelrecht-stelselanalyse/references/cross-law-integriteit.py
+++ b/.claude/skills/regelrecht-stelselanalyse/references/cross-law-integriteit.py
@@ -1,27 +1,107 @@
-import re, glob, sys
+#!/usr/bin/env python3
+"""Cross-law binding integrity check (corpus-agnostic).
+
+Verifies that every cross-law source binding is REAL and RESOLVABLE:
+
+  MISPLACED  - a `source:` block under `parameters:` (or anywhere other than the
+               `input:` list). The engine's Parameter struct has no `source`
+               field, so the binding is silently dropped at parse time and the
+               value is treated as a plain direct parameter. Cross-law never fires.
+  DANGLING   - a `source: {regulation, output}` whose target law does not produce
+               that output (engine fails at resolution: "variable not found").
+  PLAIN-PARAM- an input whose description references another regulation
+               ("conceptueel", "forward naar", "tijdelijk als directe parameter")
+               but has no `source:` block at all.
+
+All three are MODELLING ERRORS, never engine limitations. Exit code != 0 if any
+are found (usable as a CI gate).
+
+Usage:  python3 cross-law-integriteit.py [corpus_root]   (default: regulation)
+"""
+import sys, glob
+
+try:
+    import yaml
+except ImportError:
+    sys.stderr.write("cross-law-integriteit.py requires pyyaml (pip install pyyaml)\n")
+    sys.exit(2)
+
 root = sys.argv[1] if len(sys.argv) > 1 else 'regulation'
-law_outputs = {}
+
+laws = {}
 for path in glob.glob(f'{root}/**/*.yaml', recursive=True):
-    txt = open(path).read()
-    m = re.search(r'\$id:\s*(\S+)', txt)
-    if not m: continue
-    law_outputs[m.group(1)] = set(re.findall(r'- output: (\S+)', txt))
-dangling, plain, ok = [], [], 0
-for path in glob.glob(f'{root}/**/*.yaml', recursive=True):
-    txt = open(path).read()
-    m = re.search(r'\$id:\s*(\S+)', txt)
-    if not m: continue
-    fl = m.group(1)
-    for sm in re.finditer(r'source:\s*\n\s+regulation:\s*(\S+)\s*\n\s+output:\s*(\S+)', txt):
-        tl, to = sm.group(1), sm.group(2)
-        if tl not in law_outputs or to not in law_outputs[tl]:
-            dangling.append(f'{fl} -> {tl}.{to}')
-        else:
-            ok += 1
-    for cm in re.finditer(r'conceptueel:', txt):
-        if 'source:' not in txt[cm.start():cm.start()+300]:
-            plain.append(fl)
-print(f'clean={ok} dangling={len(dangling)} plain-param={len(plain)}')
-for d in dangling: print('  DANGLING', d)
-for p in plain: print('  PLAIN', p)
-sys.exit(1 if (dangling or plain) else 0)
+    try:
+        doc = yaml.safe_load(open(path))
+    except Exception:
+        continue
+    if isinstance(doc, dict) and '$id' in doc:
+        laws[doc['$id']] = doc
+
+
+def action_outputs(doc):
+    outs = set()
+    for art in doc.get('articles', []) or []:
+        ex = (art.get('machine_readable') or {}).get('execution') or {}
+        for a in ex.get('actions', []) or []:
+            if isinstance(a, dict) and 'output' in a:
+                outs.add(a['output'])
+        for o in ex.get('output', []) or []:
+            if isinstance(o, dict) and 'name' in o:
+                outs.add(o['name'])
+    return outs
+
+
+law_outputs = {lid: action_outputs(doc) for lid, doc in laws.items()}
+
+# Markers that signal "this SHOULD be a cross-law binding but isn't". Note: do NOT
+# include generic words like "forward naar" — those legitimately describe leaf
+# parameters that FEED a binding's parameters-mapping (e.g. an upstream data field).
+PLAIN_MARKERS = ('conceptueel', 'tijdelijk als directe parameter')
+misplaced, dangling, plain, ok = [], [], [], 0
+
+for lid, doc in laws.items():
+    for art in doc.get('articles', []) or []:
+        num = art.get('number', '?')
+        ex = (art.get('machine_readable') or {}).get('execution') or {}
+
+        # MISPLACED: any source under parameters: (engine ignores it).
+        # Also flag plain-param placeholders (description names another law, no source).
+        for p in ex.get('parameters', []) or []:
+            if not isinstance(p, dict):
+                continue
+            if p.get('source'):
+                misplaced.append(f'{lid} art {num}: {p.get("name")} (source onder parameters: -> genegeerd; verplaats naar input:)')
+            else:
+                d = (p.get('description') or '').lower()
+                if any(mk in d for mk in PLAIN_MARKERS):
+                    plain.append(f'{lid} art {num}: {p.get("name")}')
+
+        # input: real cross-law bindings -> resolvability (dangling) check
+        for inp in ex.get('input', []) or []:
+            if not isinstance(inp, dict):
+                continue
+            src = inp.get('source')
+            if not isinstance(src, dict):
+                continue
+            reg, out = src.get('regulation'), src.get('output')
+            if reg is None and out is None:
+                continue  # data-registry binding (source: {})
+            if reg is None:  # intra-law reference
+                if out not in law_outputs.get(lid, set()):
+                    dangling.append(f'{lid} art {num}: intra-law {out} bestaat niet')
+                else:
+                    ok += 1
+            else:
+                if reg not in law_outputs or (out is not None and out not in law_outputs[reg]):
+                    dangling.append(f'{lid} art {num}: {reg}.{out} bestaat niet in doelwet')
+                else:
+                    ok += 1
+
+print(f'clean={ok} misplaced={len(misplaced)} dangling={len(dangling)} plain-param={len(plain)}')
+for x in misplaced:
+    print('  MISPLACED', x)
+for x in dangling:
+    print('  DANGLING', x)
+for x in plain:
+    print('  PLAIN', x)
+sys.exit(1 if (misplaced or dangling or plain) else 0)

--- a/.claude/skills/regelrecht-stelselanalyse/references/cross-law-integriteit.py
+++ b/.claude/skills/regelrecht-stelselanalyse/references/cross-law-integriteit.py
@@ -13,8 +13,16 @@ Verifies that every cross-law source binding is REAL and RESOLVABLE:
                ("conceptueel", "forward naar", "tijdelijk als directe parameter")
                but has no `source:` block at all.
 
-All three are MODELLING ERRORS, never engine limitations. Exit code != 0 if any
-are found (usable as a CI gate).
+  IMPL-DANGLING - an `implements: {law, article, open_term}` whose target does
+               not declare that open_term on that law+article (the IoC binding
+               points at nothing; the delegation never resolves).
+  IMPL-NO-DATE - a regulation that carries an `implements:` block but has no
+               top-level `valid_from`. RFC-003's temporal filter then matches it
+               for EVERY calculation date, silently overriding the correct
+               version. Implementing regulations must be dated.
+
+All findings are MODELLING ERRORS, never engine limitations. Exit code != 0 if
+any are found (usable as a CI gate).
 
 Usage:  python3 cross-law-integriteit.py [corpus_root]   (default: regulation)
 """
@@ -53,16 +61,53 @@ def action_outputs(doc):
 
 law_outputs = {lid: action_outputs(doc) for lid, doc in laws.items()}
 
+
+def declared_open_terms(doc):
+    # law_id -> {article_number(str) -> set(open_term ids)}
+    idx = {}
+    for art in doc.get('articles', []) or []:
+        num = str(art.get('number', '?'))
+        mr = art.get('machine_readable') or {}
+        ids = {o.get('id') for o in (mr.get('open_terms') or []) if isinstance(o, dict)}
+        if ids:
+            idx.setdefault(num, set()).update(ids)
+    return idx
+
+
+open_terms_idx = {lid: declared_open_terms(doc) for lid, doc in laws.items()}
+
 # Markers that signal "this SHOULD be a cross-law binding but isn't". Note: do NOT
 # include generic words like "forward naar" — those legitimately describe leaf
 # parameters that FEED a binding's parameters-mapping (e.g. an upstream data field).
 PLAIN_MARKERS = ('conceptueel', 'tijdelijk als directe parameter')
 misplaced, dangling, plain, ok = [], [], [], 0
+impl_dangling, impl_nodate = [], []
 
 for lid, doc in laws.items():
+    # IMPL-NO-DATE: any implements block in a regulation without a valid_from.
+    has_implements = any(
+        (a.get('machine_readable') or {}).get('implements')
+        for a in doc.get('articles', []) or []
+    )
+    if has_implements and not doc.get('valid_from'):
+        impl_nodate.append(f'{lid}: implements zonder valid_from (matcht elke datum)')
+
     for art in doc.get('articles', []) or []:
         num = art.get('number', '?')
-        ex = (art.get('machine_readable') or {}).get('execution') or {}
+        mr = art.get('machine_readable') or {}
+        ex = mr.get('execution') or {}
+
+        # IMPL-DANGLING: implements must point at a declared open_term.
+        for im in mr.get('implements', []) or []:
+            if not isinstance(im, dict):
+                continue
+            tlaw, tart, term = im.get('law'), str(im.get('article')), im.get('open_term')
+            if tlaw not in open_terms_idx:
+                impl_dangling.append(f'{lid} art {num}: implements onbekende wet {tlaw}')
+            elif term not in open_terms_idx[tlaw].get(tart, set()):
+                impl_dangling.append(f'{lid} art {num}: {tlaw} art {tart} declareert open_term "{term}" niet')
+            else:
+                ok += 1
 
         # MISPLACED: any source under parameters: (engine ignores it).
         # Also flag plain-param placeholders (description names another law, no source).
@@ -97,11 +142,16 @@ for lid, doc in laws.items():
                 else:
                     ok += 1
 
-print(f'clean={ok} misplaced={len(misplaced)} dangling={len(dangling)} plain-param={len(plain)}')
+print(f'clean={ok} misplaced={len(misplaced)} dangling={len(dangling)} '
+      f'plain-param={len(plain)} impl-dangling={len(impl_dangling)} impl-no-date={len(impl_nodate)}')
 for x in misplaced:
     print('  MISPLACED', x)
 for x in dangling:
     print('  DANGLING', x)
 for x in plain:
     print('  PLAIN', x)
-sys.exit(1 if (misplaced or dangling or plain) else 0)
+for x in impl_dangling:
+    print('  IMPL-DANGLING', x)
+for x in impl_nodate:
+    print('  IMPL-NO-DATE', x)
+sys.exit(1 if (misplaced or dangling or plain or impl_dangling or impl_nodate) else 0)

--- a/.claude/skills/regelrecht-stelselanalyse/references/cycle-workflow.md
+++ b/.claude/skills/regelrecht-stelselanalyse/references/cycle-workflow.md
@@ -1,0 +1,80 @@
+# Cyclus-workflow — de motor
+
+Hoe je een cyclus plant, autonoom laat draaien, en afsluit. De producten hier zijn de
+"workflow-motor": ze sturen het corpus-werk aan in plaats van bevindingen te documenteren.
+
+## Micro-cycli
+
+Eén cyclus pakt één thema/scope; deel hem op in **micro-cycli** met elk een eigen,
+afgebakend doel (bijv. "harvest wet X", "migreer naar schema vN", "review-as Y +
+synthese"). Dit houdt elke stap toetsbaar en maakt een eindrapport per cyclus mogelijk.
+
+## Cyclus-plan
+
+`templates/cyclus-plan.md`: legt het thema vast, de micro-cycli, de doelen per micro-
+cyclus, de scope-afbakening (wat wél/niet), en de relatie tot de tracker. Verwijst naar
+het bronnen-dossier en de vorige eindrapporten.
+
+## Autonome uitvoering: loop vs schedule
+
+Drie manieren om werk autonoom te draaien. Kies op situatie:
+
+| Situatie | Mechanisme | Sjabloon |
+|---|---|---|
+| Afgebakende batch die zichzelf afmaakt, jij bij de sessie | **`/loop` self-paced** (geen interval; Claude bepaalt cadans en stopt zelf) | `loop-prompt.md` |
+| Wachten op een externe run (validatie/CI) binnen je sessie | **`/loop <interval>`** (vaste polling) | `loop-prompt.md` |
+| Terugkerend toezicht dat terminal-sluiting moet overleven | **routine (`/schedule`)** — cloud, onbeheerd, cron, min. 1 uur, géén permission-prompts | `scheduled-routine.md` |
+| Eén run op een toekomstig moment | éénmalig: `/schedule <tijd> <prompt>` | `scheduled-routine.md` |
+
+Vuistregels:
+- **`/loop` is lokaal + sessie-gebonden** (stopt bij terminal-sluiting, max 7 dagen). Voor
+  een corpus-completion-microcyclus is self-paced de beste fit: elke iteratie doet echt
+  werk en de loop eindigt zodra de werklijst leeg is.
+- **Routines draaien onbeheerd zónder bevestiging.** Committen/pushen mag, maar **alleen
+  naar private repos**: draai `scripts/assert-private-repo.sh` als fail-closed preflight
+  vóór elke push (PUBLIC/INTERNAL → geweigerd). Escape-hatch voor een bewuste publieke
+  push: `ALLOW_PUBLIC_PUSH=1`.
+- **Harde afdwinging lokaal**: een globale PreToolUse-hook
+  (`~/.claude/hooks/git-push-private-guard.sh`) blokkeert elke `git push` naar een
+  niet-private repo in lokale sessies en `/loop`-runs. **Cloud-`/schedule`-routines**
+  draaien in een aparte omgeving en gebruiken die lokale hook niet — daar is de
+  guard-in-de-routine-prompt de primaire beveiliging. Zie `templates/scheduled-routine.md`.
+- Cadans-wijsheid voor self-paced loops: werk-iteratie → direct door; wachten op een run →
+  poll ~270s (cache warm); idle-fallback ~1200s+. Vermijd precies 300s.
+
+Gebruik autonomie alleen voor repetitief, goed-afgebakend werk; voor verkennend/oordeels-
+werk niet automatiseren — markeer twijfel als `NEEDS_HUMAN_REVIEW` en ga door.
+
+## Harvest (nieuwe wet)
+
+`templates/harvest-rapport.md`: een nieuwe wet/regeling uit de officiële tekst het corpus
+in brengen. Het rapport legt vast: bron-id + versie, welke artikelen zijn opgenomen, de
+gemaakte interpretatie-keuzes, cross-law-koppelingen, en wat (nog) niet is opgenomen.
+
+## Schema-migratie
+
+`templates/schema-migratie.md`: het corpus naar een nieuwe schemaversie brengen. Werk in
+twee passes:
+- **Mechanische pass** — URL-bumps, hernoemde operaties, gewijzigde syntax (zoek-en-
+  vervang-achtig, per file).
+- **Semantische pass** — nieuwe schema-features benutten (nieuwe velden, nieuwe
+  structuren), per artikel beoordeeld.
+Noteer **discoveries** over het schema (welke aannames klopten/niet) — die zijn vaak het
+waardevolst voor de volgende cyclus.
+
+## Eindrapport
+
+`templates/eindrapport.md` sluit elke cyclus af: doel vs resultaat (tabel), wat is
+geleverd, discoveries (schema + wetgeving), commits, wat bewust níet is geleverd, en open
+punten voor de volgende cyclus. Verwijst naar alle producten die de cyclus opleverde.
+
+## Volgorde binnen een cyclus
+
+```
+cyclus-plan ─► [loop-prompt] ─► corpus-werk (harvest / schema-migratie / mr-uitbreiding)
+   ─► validatie-review(s) ─► synthese + heroverweging
+   ─► documentatie (wetgevings-fouten / fixes-plan / engine-limitaties / diagrammen / corpus-status / engine-tests)
+   ─► verificatie (bronnen + resolutie-tracker)
+   ─► eindrapport
+```
+</content>

--- a/.claude/skills/regelrecht-stelselanalyse/references/cycle-workflow.md
+++ b/.claude/skills/regelrecht-stelselanalyse/references/cycle-workflow.md
@@ -9,6 +9,13 @@ Eén cyclus pakt één thema/scope; deel hem op in **micro-cycli** met elk een e
 afgebakend doel (bijv. "harvest wet X", "migreer naar schema vN", "review-as Y +
 synthese"). Dit houdt elke stap toetsbaar en maakt een eindrapport per cyclus mogelijk.
 
+## Step 0 — drift-check (verplicht)
+
+Elke micro-cyclus die een regulation-YAML kán aanraken begint met de zustersskill
+`law-version-drift-check` (zie `../SKILL.md`, sectie *Step 0*): spiegel elk `text:`-blok
+tegen de geldende wettekst vóór de eerste edit. Geen CLEANE/scope-gerestricteerde
+drift-rapport → geen corpus-werk. Strikt, geen bypass.
+
 ## Cyclus-plan
 
 `templates/cyclus-plan.md`: legt het thema vast, de micro-cycli, de doelen per micro-
@@ -71,10 +78,9 @@ punten voor de volgende cyclus. Verwijst naar alle producten die de cyclus oplev
 ## Volgorde binnen een cyclus
 
 ```
-cyclus-plan ─► [loop-prompt] ─► corpus-werk (harvest / schema-migratie / mr-uitbreiding)
+cyclus-plan ─► drift-check (Step 0, per file) ─► [loop-prompt] ─► corpus-werk (harvest / schema-migratie / mr-uitbreiding)
    ─► validatie-review(s) ─► synthese + heroverweging
    ─► documentatie (wetgevings-fouten / fixes-plan / engine-limitaties / diagrammen / corpus-status / engine-tests)
    ─► verificatie (bronnen + resolutie-tracker)
    ─► eindrapport
 ```
-</content>

--- a/.claude/skills/regelrecht-stelselanalyse/references/defect-taxonomy.md
+++ b/.claude/skills/regelrecht-stelselanalyse/references/defect-taxonomy.md
@@ -49,4 +49,3 @@ Elke fout volgt dezelfde structuur (zie `templates/wetgevingsfouten-analyse.md`)
 - **Aanbevolen acties** in prioriteits-volgorde — eerst de kleine onbetwiste technische
   reparaties, dan het beleidsinhoudelijke werk.
 - **Adressering** — aan wie de notitie is gericht (wetgevings-eigenaar + uitvoerder).
-</content>

--- a/.claude/skills/regelrecht-stelselanalyse/references/defect-taxonomy.md
+++ b/.claude/skills/regelrecht-stelselanalyse/references/defect-taxonomy.md
@@ -1,0 +1,52 @@
+# Taxonomie van wetgevings-fouten
+
+Categorieën, ernst-niveaus en het per-fout entry-format voor de
+`wetgevingsfouten-analyse`. Generiek; de categorieën zijn algemene typen
+wetgevings-defecten (geen casus-inhoud).
+
+## Categorieën
+
+| Categorie | Wat | Typische ernst |
+|---|---|---|
+| **Lege delegaties** | Verplichte uitvoeringsregel ("bij ministeriële regeling / AMvB …") nooit afgekondigd → de concrete norm die de wet vooronderstelt ontbreekt | KRITIEK |
+| **Achterhaalde institutionele referenties** | Verwijzing naar een orgaan/wet die door reorganisatie of wetsvervanging niet meer bestaat; nooit formeel bijgewerkt | KRITIEK |
+| **Wettekst-fouten** | Feitelijke schrijffouten in de geldende tekst (verkeerd begrip, verkeerd lid-/hoofdstuk-nummer, errata-haakjes in de wet zelf) | KRITIEK |
+| **Inconsistenties met andere wetten** | Begrip/grondslag verschilt tussen wetten die naar elkaar verwijzen; verschillende namen voor dezelfde wet | ZORG |
+| **Onuitvoerbare voorwaarden zonder beslisser** | Open norm zonder kenbare beslisser, kader of grond (zie `classification.md`) — circulair of niet-toetsbaar | ZORG |
+| **Onuitgewerkte regelingen** | Wel grondslag, geen invulling (bv. een aangekondigde tabel/schaal die ontbreekt) | ZORG |
+| **Procedurele inconsistenties** | Procedure (bezwaar/beroep/termijn) strijdig met een algemene procesregel of intern inconsistent | ZORG/KRITIEK |
+| **Impliciete koppelingen** | Eén bedrag/artikel met dubbelfunctie, zodat een wijziging elders onbedoeld doorwerkt | ZORG |
+| **Geografisch-territoriale lacunes** | Aanspraak/bevoegdheid buiten het gebied waar de uitvoerder bevoegd is, zonder procedure | ZORG/KRITIEK |
+
+## Ernst-niveaus
+
+- **KRITIEK** — het stelsel is op dit punt niet uitvoerbaar zoals het er staat; een
+  geautomatiseerde uitvoering vindt geen kenbare regel.
+- **ZORG** — uitvoerbaar in de praktijk, maar juridisch onzeker, onbillijk, of
+  kwetsbaar voor toekomstige wijzigingen.
+
+## Per-fout entry-format
+
+Elke fout volgt dezelfde structuur (zie `templates/wetgevingsfouten-analyse.md`):
+
+1. **Titel + locatie** — categorie-nummer + wet + artikel/lid.
+2. **Wettekst** — letterlijk citaat van de geldende tekst (met bron-id).
+3. **Probleem** — waarom dit fout/achterhaald/onuitvoerbaar is.
+4. **Implicatie** — gevolg voor de uitvoering en/of de burger (kan hij zijn recht
+   kennen/berekenen/betwisten?). Hier ligt de scherpte: maak concreet wat onuitvoerbaar
+   wordt.
+5. **Wat zou moeten gebeuren** — concrete reparatie (technisch wijzigingsbesluit, AMvB
+   afkondigen, term vervangen, criterium toevoegen). Onderscheid "klein technisch" van
+   "vergt beleidsinhoudelijk werk".
+6. *(optioneel)* **Mermaid-diagram** dat het probleem visualiseert (circulair criterium,
+   dubbelfunctie, mismatch, territoriale lacune) — zeer effectief voor lezers.
+7. *(optioneel)* **COMMENT** — ruimte voor menselijke reviewer-nuance/weerlegging.
+
+## Closing-secties van de analyse
+
+- **"Wat is precies uitvoeren van dit stelsel?"** — concrete opsomming van wat een
+  burger vandaag *niet* geautomatiseerd kan vaststellen. Maakt de optelsom voelbaar.
+- **Aanbevolen acties** in prioriteits-volgorde — eerst de kleine onbetwiste technische
+  reparaties, dan het beleidsinhoudelijke werk.
+- **Adressering** — aan wie de notitie is gericht (wetgevings-eigenaar + uitvoerder).
+</content>

--- a/.claude/skills/regelrecht-stelselanalyse/references/review-orchestration.md
+++ b/.claude/skills/regelrecht-stelselanalyse/references/review-orchestration.md
@@ -1,0 +1,59 @@
+# Multi-agent review-orkestratie
+
+Hoe je een corpus-review verdeelt over parallelle assen, de uitkomsten samenvoegt, en
+twijfel heroverweegt. Generiek — pas de assen aan op de cyclus-scope.
+
+## Review-assen
+
+Verdeel de review over onafhankelijke assen. Eén as = één reviewer/sub-agent. Typische
+assen:
+
+1. **Machine-readable correctheid** — kloppen de formules/actions met de wettekst?
+2. **Untranslatables-correctheid** — zijn open normen correct gemarkeerd (factual vs
+   judgment), en ontbreken er untranslatables?
+3. **Wetten-coverage** — welke wetten in de keten ontbreken nog in het corpus?
+4. **machine_readable-coverage** — welke artikelen/leden hebben nog geen MR-logica?
+5. **Cross-law source-refs** — zijn verwijzingen als echte `source:` gelegd of staan ze
+   alleen in `description`?
+6. **Diagrammen** — kloppen de relatie-/flow-diagrammen met de YAML's?
+7. **Wetgevings-fouten** — fouten in de bron-regelgeving zelf (zie `defect-taxonomy.md`).
+
+## Parallelle uitvoering met sub-agents
+
+Bij een brede review: start één `Agent` per as (bij voorkeur in één bericht, zodat ze
+parallel lopen). Geef elke sub-agent:
+- de scope (welke wetten/artikelen),
+- de as + wat als bevinding telt,
+- de **vier-weg-classificatie** (zie `classification.md`) met de opdracht elke
+  bevinding te labelen,
+- een vast bevindingen-format (classificatie + ernst + locatie + korte omschrijving).
+
+Elke sub-agent levert een per-as review-doc op (`templates/validatie-review.md`).
+
+## Synthese
+
+Voeg de per-as reviews samen tot één synthese (`templates/synthese.md`):
+- **Wat is gefixt deze ronde** (met commit-verwijzing; bevestig dat tests groen blijven).
+- **Wat is gedocumenteerd, niet gefixt** — tabel per as/agent met aantal + classificatie.
+- **Discoveries uitgelicht** — de belangrijkste, met bron en gevolg.
+- **Meta-bevindingen** — bijv. de features-vs-YAML-check.
+- **Engine-correctheid behouden** — validatie- en scenario-commando's met N/N-uitslag.
+
+## Telling & ernst
+
+Houd expliciete tellingen bij (aantal wetgevings-fouten per categorie, per ernst). Deze
+tellingen komen terug in de samenvatting van de fouten-analyse en het eindrapport — dus
+houd ze consistent over documenten heen.
+
+## Heroverweging van twijfel-claims
+
+Markeer onzekere bevindingen expliciet (bijv. een `TWIJFEL`- of `NEEDS_HUMAN_REVIEW`-
+status). In een aparte heroverwegings-pass:
+- verifieer of de claim standhoudt;
+- bij **weerlegging**: schrap de claim **zichtbaar** (doorgestreept + reden + verwijzing
+  naar de heroverwegings-notitie), en pas de tellingen aan met -1;
+- bij **verplaatsing** naar een andere categorie: noteer de verplaatsing, telling
+  ongewijzigd.
+
+Nooit stilzwijgend verwijderen — de redeneerketen moet traceerbaar blijven.
+</content>

--- a/.claude/skills/regelrecht-stelselanalyse/references/review-orchestration.md
+++ b/.claude/skills/regelrecht-stelselanalyse/references/review-orchestration.md
@@ -14,7 +14,12 @@ assen:
 3. **Wetten-coverage** — welke wetten in de keten ontbreken nog in het corpus?
 4. **machine_readable-coverage** — welke artikelen/leden hebben nog geen MR-logica?
 5. **Cross-law source-refs** — zijn verwijzingen als echte `source:` gelegd of staan ze
-   alleen in `description`?
+   alleen in `description`? Dit is een verplichte, niet-overslaanbare integriteitsscan
+   (zie SKILL.md stap 3): bouw `regulation → outputs`, vlag elke `source`-binding naar een
+   niet-bestaande output (**DANGLING**) en elke "conceptueel/forward/tijdelijk"-input zonder
+   `source:`-blok (**PLAIN-PARAM**). Beide zijn altijd **modellering-fout**, nooit engine-
+   limitatie. Rapporteer `clean / dangling / plain-param`; source-clean = beide 0. Draai
+   `references/cross-law-integriteit.py <corpus-root>` als reproduceerbare preflight.
 6. **Diagrammen** — kloppen de relatie-/flow-diagrammen met de YAML's?
 7. **Wetgevings-fouten** — fouten in de bron-regelgeving zelf (zie `defect-taxonomy.md`).
 

--- a/.claude/skills/regelrecht-stelselanalyse/references/review-orchestration.md
+++ b/.claude/skills/regelrecht-stelselanalyse/references/review-orchestration.md
@@ -61,4 +61,3 @@ status). In een aparte heroverwegings-pass:
   ongewijzigd.
 
 Nooit stilzwijgend verwijderen — de redeneerketen moet traceerbaar blijven.
-</content>

--- a/.claude/skills/regelrecht-stelselanalyse/references/verification-cycle.md
+++ b/.claude/skills/regelrecht-stelselanalyse/references/verification-cycle.md
@@ -58,4 +58,3 @@ Verificatie kan een bevinding van categorie doen wisselen: een vermeende wetgevi
 die door een recent wijzigingsbesluit al is gerepareerd, wordt `weerlegd`/`verouderd` en
 verdwijnt uit de wetgevings-analyse. Houd de vier-weg-classificatie en de tracker
 synchroon.
-</content>

--- a/.claude/skills/regelrecht-stelselanalyse/references/verification-cycle.md
+++ b/.claude/skills/regelrecht-stelselanalyse/references/verification-cycle.md
@@ -1,0 +1,61 @@
+# Verificatie-cyclus — tracker, bronnen, status
+
+Hoe je claims (eigen bevindingen én menselijke reviewer-comments) toetst tegen externe
+bronnen en de status traceerbaar vastlegt.
+
+## Resolutie-tracker
+
+De leidende status-administratie per cyclus (`templates/resolutie-tracker.md`). Per
+comment en per wetgevings-fout: scope, status, gevonden bron, en het voorlopige gevolg.
+
+### Status-vocabulaire
+
+| Status | Betekenis |
+|---|---|
+| `open` | Niets ondernomen deze cyclus |
+| `in-progress` | Bron-onderzoek loopt of resolutie wordt geschreven |
+| `verifieerd` | Externe bron bevestigt de claim (referentie in bron-kolom) |
+| `weerlegd` | Externe bron weerlegt de claim |
+| `gedeeltelijk` | Bron resolveert deel van de claim; rest blijft open |
+| `onverifieerbaar` | Via beschikbare bronnen geen uitspraak mogelijk; menselijke/dossier-actie nodig |
+| `out-of-scope` | Bewust niet behandeld deze cyclus |
+
+### Scope-markering
+
+Markeer elk item met de cyclus-scope (bijv. een korte code per thema), zodat duidelijk
+is wat deze ronde wel/niet wordt opgepakt. Items buiten scope blijven `open`/`out-of-scope`
+en wachten op een volgende cyclus.
+
+## Bronnen-dossier
+
+Externe bronnen die je ontgint (Staatsbladen, nota's van toelichting, vaststellings-
+besluiten, rekenregels, nieuwsberichten van de uitvoerder) krijgen elk een eigen
+extract-bestand + een `bronnen-INDEX.md` die comments terugkoppelt aan bronnen.
+
+### WebFetch-ontginning
+
+- Haal officiële publicaties op via WebFetch (Staatsblad-HTML, wetten.overheid.nl,
+  uitvoerder-publicaties). Voor PDF's: lokaal extraheren (bijv. `pdftotext`) als WebFetch
+  de inhoud niet geeft.
+- Per bron: noteer wat het is, de exacte vindplaats, en de **kern** die het oplost of
+  onderbouwt (één regel). Zie het INDEX-sjabloon.
+- Onderscheid wat Claude wél kan ophalen van wat **alleen mens/dossier** kan leveren
+  (interne mandaat-stukken, niet-publieke nota's) → die worden `onverifieerbaar`.
+
+## Comment-resolutie
+
+Menselijke reviewers laten vaak inline `COMMENT`-blokken achter in de fouten-analyse die
+een claim nuanceren of weerleggen. Verwerk die expliciet:
+1. Verzamel alle comments en koppel ze aan de betreffende fout/sectie.
+2. Geef elk een scope + status in de tracker.
+3. Zoek de onderbouwende bron.
+4. Werk de fouten-analyse bij (claim afzwakken/intrekken bij weerlegging — zichtbaar,
+   zie heroverweging in `review-orchestration.md`).
+
+## Koppeling met de classificatie
+
+Verificatie kan een bevinding van categorie doen wisselen: een vermeende wetgevings-fout
+die door een recent wijzigingsbesluit al is gerepareerd, wordt `weerlegd`/`verouderd` en
+verdwijnt uit de wetgevings-analyse. Houd de vier-weg-classificatie en de tracker
+synchroon.
+</content>

--- a/.claude/skills/regelrecht-stelselanalyse/scripts/assert-private-repo.sh
+++ b/.claude/skills/regelrecht-stelselanalyse/scripts/assert-private-repo.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# assert-private-repo.sh — fail-closed guard: exit 0 alleen als de push-target
+# van de huidige git-repo aantoonbaar een PRIVATE GitHub-repo is.
+#
+# Gebruik (preflight vóór elke commit/push in een autonome routine):
+#   bash assert-private-repo.sh [remote]      # remote default: origin
+#   bash assert-private-repo.sh && git push   # push alleen als de guard slaagt
+#
+# Fail-closed: elke onzekerheid (geen repo / geen remote / geen gh / niet te bepalen /
+# niet-GitHub / INTERNAL / PUBLIC) → non-zero exit. Lokale commits zijn altijd veilig;
+# deze guard bewaakt het PUBLICEREN (push), want daar zit de blootstelling.
+set -euo pipefail
+
+fail() { echo "GUARD BLOCK: $*" >&2; exit 1; }
+
+# 1. Binnen een git-repo?
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || fail "geen git-repo (cwd=$(pwd))"
+
+# 2. Remote bepalen
+remote="${1:-origin}"
+url="$(git remote get-url "$remote" 2>/dev/null)" || fail "geen remote '$remote'"
+
+# 3. gh aanwezig + geauthenticeerd? (autoritatieve bron voor zichtbaarheid)
+command -v gh >/dev/null 2>&1 || fail "gh niet geïnstalleerd — zichtbaarheid niet te verifiëren"
+
+# 4. owner/repo afleiden uit ssh- of https-URL
+slug="$(printf '%s' "$url" \
+  | sed -E 's#^git@[^:]+:##; s#^https://[^/]+/##; s#^ssh://git@[^/]+/##; s#\.git$##')"
+case "$slug" in
+  github.com/*) slug="${slug#github.com/}" ;;
+esac
+case "$slug" in
+  */*) : ;;
+  *) fail "kan GitHub owner/repo niet uit '$url' halen (niet-GitHub remote?)" ;;
+esac
+
+# 5. Zichtbaarheid opvragen; alleen PRIVATE laat door (INTERNAL/PUBLIC = block).
+#    Korte retry tegen transiënte gh-haperingen — blijft fail-closed.
+vis=""
+for _attempt in 1 2 3; do
+  if vis="$(gh repo view "$slug" --json visibility --jq .visibility 2>/dev/null)" && [ -n "$vis" ]; then
+    break
+  fi
+  vis=""
+done
+[ -n "$vis" ] || fail "kan zichtbaarheid van '$slug' niet opvragen na 3 pogingen (auth/netwerk?)"
+
+if [ "$vis" = "PRIVATE" ]; then
+  echo "GUARD OK: $slug is PRIVATE — push toegestaan"
+  exit 0
+fi
+fail "$slug visibility=$vis (niet PRIVATE) — push geweigerd"

--- a/.claude/skills/regelrecht-stelselanalyse/scripts/assert-private-repo.sh
+++ b/.claude/skills/regelrecht-stelselanalyse/scripts/assert-private-repo.sh
@@ -20,28 +20,34 @@ git rev-parse --is-inside-work-tree >/dev/null 2>&1 || fail "geen git-repo (cwd=
 remote="${1:-origin}"
 url="$(git remote get-url "$remote" 2>/dev/null)" || fail "geen remote '$remote'"
 
-# 3. gh aanwezig + geauthenticeerd? (autoritatieve bron voor zichtbaarheid)
+# 3. Host strikt github.com (bewust geen GHE, geen GitLab/Bitbucket). Anders zou de
+#    slug-extractie de host blind strippen en de naam alsnog op github.com queriën —
+#    een match daar zegt niets over de werkelijke push-target. Fail-closed.
+case "$url" in
+  git@github.com:*|https://github.com/*|ssh://git@github.com/*) : ;;
+  *) fail "remote '$url' is geen github.com — guard alleen geldig voor github.com" ;;
+esac
+
+# 4. gh aanwezig + geauthenticeerd? (autoritatieve bron voor zichtbaarheid)
 command -v gh >/dev/null 2>&1 || fail "gh niet geïnstalleerd — zichtbaarheid niet te verifiëren"
 
-# 4. owner/repo afleiden uit ssh- of https-URL
+# 5. owner/repo afleiden uit ssh- of https-URL
 slug="$(printf '%s' "$url" \
-  | sed -E 's#^git@[^:]+:##; s#^https://[^/]+/##; s#^ssh://git@[^/]+/##; s#\.git$##')"
-case "$slug" in
-  github.com/*) slug="${slug#github.com/}" ;;
-esac
+  | sed -E 's#^git@github\.com:##; s#^https://github\.com/##; s#^ssh://git@github\.com/##; s#\.git$##')"
 case "$slug" in
   */*) : ;;
-  *) fail "kan GitHub owner/repo niet uit '$url' halen (niet-GitHub remote?)" ;;
+  *) fail "kan GitHub owner/repo niet uit '$url' halen" ;;
 esac
 
-# 5. Zichtbaarheid opvragen; alleen PRIVATE laat door (INTERNAL/PUBLIC = block).
-#    Korte retry tegen transiënte gh-haperingen — blijft fail-closed.
+# 6. Zichtbaarheid opvragen; alleen PRIVATE laat door (INTERNAL/PUBLIC = block).
+#    Korte retry mét pauze tegen transiënte gh-haperingen — blijft fail-closed.
 vis=""
 for _attempt in 1 2 3; do
   if vis="$(gh repo view "$slug" --json visibility --jq .visibility 2>/dev/null)" && [ -n "$vis" ]; then
     break
   fi
   vis=""
+  sleep 1
 done
 [ -n "$vis" ] || fail "kan zichtbaarheid van '$slug' niet opvragen na 3 pogingen (auth/netwerk?)"
 

--- a/.claude/skills/regelrecht-stelselanalyse/scripts/test-assert-private-repo.sh
+++ b/.claude/skills/regelrecht-stelselanalyse/scripts/test-assert-private-repo.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# test-assert-private-repo.sh — smoke-test voor de fail-closed push-guard.
+#
+# Stubt `git`, `gh` en `sleep` via een tijdelijke PATH-dir, zodat de guard zonder
+# echte repo of netwerk te testen is. Houdt de invariant vast:
+#   - github.com PRIVATE                  → exit 0  (push toegestaan)
+#   - github.com PUBLIC / INTERNAL        → exit 1  (geblokkeerd)
+#   - GitLab / GitHub-Enterprise / overig → exit 1  (host-check, fail-closed)
+#   - geen remote / gh onbereikbaar / geen repo → exit 1
+#
+# Gebruik: bash test-assert-private-repo.sh   (exit 0 = alle cases groen)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GUARD="$SCRIPT_DIR/assert-private-repo.sh"
+[ -f "$GUARD" ] || { echo "FAIL: guard niet gevonden op $GUARD" >&2; exit 1; }
+
+BIN="$(mktemp -d)"
+trap 'rm -rf "$BIN"' EXIT
+
+# --- stubs: lezen scenario uit env (TEST_REMOTE_URL, TEST_VISIBILITY, TEST_IS_REPO) ---
+cat >"$BIN/git" <<'STUB'
+#!/usr/bin/env bash
+case "$1 $2" in
+  "rev-parse --is-inside-work-tree")
+    [ "${TEST_IS_REPO:-1}" = "1" ] && exit 0 || exit 128 ;;
+  "remote get-url")
+    [ -n "${TEST_REMOTE_URL:-}" ] && { printf '%s\n' "$TEST_REMOTE_URL"; exit 0; } || exit 2 ;;
+esac
+exit 0
+STUB
+
+cat >"$BIN/gh" <<'STUB'
+#!/usr/bin/env bash
+if [ "$1" = "repo" ] && [ "$2" = "view" ]; then
+  [ -n "${TEST_VISIBILITY:-}" ] && { printf '%s\n' "$TEST_VISIBILITY"; exit 0; } || exit 1
+fi
+exit 0
+STUB
+
+# no-op sleep zodat de retry-loop de test niet vertraagt
+printf '#!/usr/bin/env bash\nexit 0\n' >"$BIN/sleep"
+chmod +x "$BIN/git" "$BIN/gh" "$BIN/sleep"
+
+PATH="$BIN:$PATH"
+
+pass=0; fail=0
+run_case() {
+  # $1 naam  $2 verwachte-exit  $3 verwachte-substring (of "")  [env via globals]
+  local name="$1" want_code="$2" want_sub="$3" out code
+  set +e
+  out="$(TEST_REMOTE_URL="${REMOTE_URL:-}" TEST_VISIBILITY="${VIS:-}" TEST_IS_REPO="${IS_REPO:-1}" \
+        bash "$GUARD" 2>&1)"
+  code=$?
+  set -e
+  local ok=1
+  [ "$code" = "$want_code" ] || ok=0
+  if [ -n "$want_sub" ]; then case "$out" in *"$want_sub"*) : ;; *) ok=0 ;; esac; fi
+  if [ "$ok" = 1 ]; then
+    printf '  ✓ %s\n' "$name"; pass=$((pass+1))
+  else
+    printf '  ✗ %s — exit=%s (verwacht %s), output: %s\n' "$name" "$code" "$want_code" "$out"; fail=$((fail+1))
+  fi
+}
+
+echo "Smoke-test push-guard:"
+REMOTE_URL="git@github.com:MinBZK/regelrecht-private.git" VIS="PRIVATE"  IS_REPO=1 run_case "github.com SSH private → pass"        0 "GUARD OK"
+REMOTE_URL="https://github.com/MinBZK/regelrecht-private.git" VIS="PRIVATE" IS_REPO=1 run_case "github.com HTTPS private → pass"  0 "GUARD OK"
+REMOTE_URL="ssh://git@github.com/MinBZK/x.git" VIS="PRIVATE"  IS_REPO=1 run_case "github.com ssh:// private → pass"        0 "GUARD OK"
+REMOTE_URL="git@github.com:MinBZK/regelrecht.git" VIS="PUBLIC" IS_REPO=1 run_case "github.com public → block"             1 "niet PRIVATE"
+REMOTE_URL="git@github.com:MinBZK/regelrecht.git" VIS="INTERNAL" IS_REPO=1 run_case "github.com internal → block"         1 "niet PRIVATE"
+REMOTE_URL="git@gitlab.com:MinBZK/regelrecht.git" VIS="PRIVATE" IS_REPO=1 run_case "gitlab.com → block (host-check)"      1 "geen github.com"
+REMOTE_URL="git@github.example.com:org/repo.git"  VIS="PRIVATE" IS_REPO=1 run_case "GitHub-Enterprise → block (host-check)" 1 "geen github.com"
+REMOTE_URL="git@bitbucket.org:org/repo.git"       VIS="PRIVATE" IS_REPO=1 run_case "bitbucket → block (host-check)"       1 "geen github.com"
+REMOTE_URL=""                                     VIS="PRIVATE" IS_REPO=1 run_case "geen remote → block"                  1 "geen remote"
+REMOTE_URL="git@github.com:MinBZK/x.git"          VIS=""        IS_REPO=1 run_case "gh onbereikbaar → block"              1 "na 3 pogingen"
+REMOTE_URL="git@github.com:MinBZK/x.git"          VIS="PRIVATE" IS_REPO=0 run_case "geen git-repo → block"                1 "geen git-repo"
+
+echo "----"
+printf '%d geslaagd, %d gefaald\n' "$pass" "$fail"
+[ "$fail" = 0 ]

--- a/.claude/skills/regelrecht-stelselanalyse/templates/bronnen-INDEX.md
+++ b/.claude/skills/regelrecht-stelselanalyse/templates/bronnen-INDEX.md
@@ -25,4 +25,3 @@ extract-bestand; deze INDEX koppelt comments/fouten terug aan bronnen.
 Per bron: WebFetch van de officiële publicatie (Staatsblad/wetten.overheid.nl/uitvoerder);
 PDF's lokaal extraheren indien nodig. Noteer per bron: wat het is, exacte vindplaats, en
 de kern in één regel.
-</content>

--- a/.claude/skills/regelrecht-stelselanalyse/templates/bronnen-INDEX.md
+++ b/.claude/skills/regelrecht-stelselanalyse/templates/bronnen-INDEX.md
@@ -1,0 +1,28 @@
+# Bronnen-dossier — INDEX ({cyclus})
+
+Externe bronnen ontgonnen t.b.v. comment-/fout-resolutie. Per bron een eigen
+extract-bestand; deze INDEX koppelt comments/fouten terug aan bronnen.
+
+## Bestanden
+
+| Bestand | Bron | Kern (wat het oplost/onderbouwt) |
+|---|---|---|
+| `INDEX.md` | — | Deze reverse-map |
+| `{bestand}.md` | {officiële titel + bron-id} | {één regel: welke claim het raakt} |
+
+## Reverse-map: comment/fout → bron
+
+| Comment/fout | Bron(nen) | Status-richting |
+|---|---|---|
+| {#n / §n.m} | {bestand(en)} | {verifieert / weerlegt / deels} |
+
+## Niet via Claude ontginbaar (mens/dossier nodig)
+
+- {welke onderbouwing alleen intern/niet-publiek beschikbaar is → wordt `onverifieerbaar`}
+
+## Methode
+
+Per bron: WebFetch van de officiële publicatie (Staatsblad/wetten.overheid.nl/uitvoerder);
+PDF's lokaal extraheren indien nodig. Noteer per bron: wat het is, exacte vindplaats, en
+de kern in één regel.
+</content>

--- a/.claude/skills/regelrecht-stelselanalyse/templates/corpus-status.md
+++ b/.claude/skills/regelrecht-stelselanalyse/templates/corpus-status.md
@@ -1,0 +1,26 @@
+# {Corpus/dossier} — overzicht, structuur en machine-readable status
+
+**Datum**: {datum}
+
+## Wetten in het corpus
+
+| # | Law-id | Laag | Schemaversie | MR-status | YAML |
+|---|---|---|---|---|---|
+| 1 | `{law_id}` | {A/B/C/D} | {versie} | {volledig / gedeeltelijk / alleen tekst / stub} | `{pad}` |
+
+**MR-status-legenda**: volledig = alle relevante artikelen machine_readable · gedeeltelijk
+= kern wel, randen niet · alleen tekst = geharvest zonder logica · stub = placeholder.
+
+## Structurele aandachtspunten
+
+- {duplicaten, verkeerde mappen, inconsistente schema-URL's, placeholders — verwijs naar
+  het modellering-fixes-plan}
+
+## Reviewstatus
+
+{Wat is door mensen gereviewd, welke aannames staan nog open (verwijs naar de tracker).}
+
+## Volgende stappen
+
+- {per wet/cluster: wat de volgende cyclus oppakt}
+</content>

--- a/.claude/skills/regelrecht-stelselanalyse/templates/corpus-status.md
+++ b/.claude/skills/regelrecht-stelselanalyse/templates/corpus-status.md
@@ -23,4 +23,3 @@
 ## Volgende stappen
 
 - {per wet/cluster: wat de volgende cyclus oppakt}
-</content>

--- a/.claude/skills/regelrecht-stelselanalyse/templates/cross-law-diagram.md
+++ b/.claude/skills/regelrecht-stelselanalyse/templates/cross-law-diagram.md
@@ -45,4 +45,3 @@ sequenceDiagram
 {Wat het diagram laat zien, welke YAML-elementen het weergeeft, en wat een lezer eruit
 moet halen. Houd het diagram synchroon met de YAML's — bij wijziging: update of markeer
 als verouderd.}
-</content>

--- a/.claude/skills/regelrecht-stelselanalyse/templates/cross-law-diagram.md
+++ b/.claude/skills/regelrecht-stelselanalyse/templates/cross-law-diagram.md
@@ -1,0 +1,48 @@
+# {Titel} — cross-law diagram
+
+*Mermaid-diagram dat een aspect van het corpus visualiseert. Kies het type dat past:
+relatie-graph, cross-law-flow, procedure-lifecycle, of hook-leverancier.*
+
+**Scope**: {welke wetten/artikelen} · **Datum**: {datum}
+
+## Relatie-graph
+
+```mermaid
+graph TD
+    {A}[{Wet A}]:::laag
+    {B}[{Wet B}]:::laag
+    {A} ==source==> {B}
+    {A} -.grondslag.-> {B}
+    {A} -->|overrides {output}| {B}
+    {A} -.data.-> {B}
+    classDef laag fill:#e8f4f8,stroke:#2a6ca8
+```
+
+**Legenda**: `==source==>` runtime data-call · `-.grondslag.->` legal_basis ·
+`--overrides-->` betekenis-override · `-.data.->` impliciete data-dependency.
+
+## Cross-law-flow (per scenario)
+
+```mermaid
+graph TD
+    A[{startvraag}] --> B{ {beslis} }
+    B -->|ja| C[{uitkomst}]
+    B -->|nee| D[{andere uitkomst}]
+```
+
+## Procedure-lifecycle
+
+```mermaid
+sequenceDiagram
+    participant Burger
+    participant Uitvoerder
+    Burger->>Uitvoerder: {aanvraag}
+    Uitvoerder->>Burger: {beschikking}
+```
+
+## Toelichting
+
+{Wat het diagram laat zien, welke YAML-elementen het weergeeft, en wat een lezer eruit
+moet halen. Houd het diagram synchroon met de YAML's — bij wijziging: update of markeer
+als verouderd.}
+</content>

--- a/.claude/skills/regelrecht-stelselanalyse/templates/cyclus-plan.md
+++ b/.claude/skills/regelrecht-stelselanalyse/templates/cyclus-plan.md
@@ -34,4 +34,3 @@ verschuiven.}
 ## Risico's / aannames
 
 - {aanname die kan omvallen; wat dan}
-</content>

--- a/.claude/skills/regelrecht-stelselanalyse/templates/cyclus-plan.md
+++ b/.claude/skills/regelrecht-stelselanalyse/templates/cyclus-plan.md
@@ -1,0 +1,37 @@
+# Iteratieplan — Cyclus {N} ({thema})
+
+**Datum start**: {datum}
+**Thema/scope**: {het ene thema dat deze cyclus pakt}
+**Bron-dossier**: `{pad}` · **Tracker**: `{pad}` · **Vorige eindrapport**: `{pad}`
+
+## Doel van de cyclus
+
+{Eén alinea: wat moet er aan het eind van deze cyclus af zijn.}
+
+## Micro-cycli
+
+| Micro-cyclus | Doel | Klaar als | Levert op |
+|---|---|---|---|
+| {N}a | {afgebakend doel} | {stop-conditie} | {product(en)} |
+| {N}b | … | … | … |
+| {N}c | … | … | … |
+
+## Scope-afbakening
+
+**Wél deze cyclus**: {expliciet}.
+**Niet deze cyclus** (volgende ronde): {expliciet — blijft `open`/`out-of-scope` in de tracker}.
+
+## Aanpak
+
+{Per micro-cyclus kort de werkwijze. Verwijs naar de relevante sjablonen: harvest /
+schema-migratie / mr-uitbreiding / validatie-review / synthese / verificatie.}
+
+## Relatie tot de tracker
+
+{Welke comments/fouten uit de tracker vallen in scope; welke statussen verwacht je te
+verschuiven.}
+
+## Risico's / aannames
+
+- {aanname die kan omvallen; wat dan}
+</content>

--- a/.claude/skills/regelrecht-stelselanalyse/templates/eindrapport.md
+++ b/.claude/skills/regelrecht-stelselanalyse/templates/eindrapport.md
@@ -53,4 +53,3 @@
 
 {Wat de cyclus heeft aangetoond; de stand van het corpus; wat verdere actie behoeft
 buiten dit corpus.}
-</content>

--- a/.claude/skills/regelrecht-stelselanalyse/templates/eindrapport.md
+++ b/.claude/skills/regelrecht-stelselanalyse/templates/eindrapport.md
@@ -1,0 +1,56 @@
+# Eindrapport — cyclus {N} ({datum})
+
+**Branch**: `{branch}` · **Cyclus**: {thema} · **Plan**: `{pad}`
+**Status**: {voltooid lokaal / gepusht}
+
+## Doel vs resultaat
+
+| Doel (uit plan) | Status |
+|---|---|
+| {doel} | ✅ / ⏭️ (scope-reductie) / ❌ |
+
+## Wat is geleverd
+
+### {Categorie, bv. tooling / migratie / reviews}
+- {opsomming met verwijzing naar de opgeleverde producten}
+
+## Discoveries
+
+### Schema / techniek
+1. {bevinding over het schema/de engine}
+
+### Wetgeving
+- {nieuwe wetgevings-fout-discovery, met verwijzing naar de fouten-analyse-sectie}
+
+## Bevindingen-telling (4-weg)
+
+| Classificatie | Aantal deze cyclus |
+|---|---|
+| Modellering-fout (gefixt) | {n} |
+| Wetgevings-fout (gedocumenteerd) | {n} |
+| Engine-limitatie | {n} |
+| Acceptabele untranslatable | {n} |
+
+## Commits
+
+```
+{git log --oneline van deze cyclus}
+```
+
+## Wat is NIET geleverd (bewust)
+
+- {onderdeel + reden (scope-reductie / aparte cyclus / hoort in engine)}
+
+## Open punten voor de volgende cyclus
+
+1. {punt + waar het landt (engine-PR / schema-PR / wetgevings-actie / feature-cyclus)}
+
+## Verhouding tot bestaande documenten
+
+- `{doc}` — {wat erin moet worden bijgewerkt n.a.v. deze cyclus}
+
+## Conclusie
+
+{Wat de cyclus heeft aangetoond; de stand van het corpus; wat verdere actie behoeft
+buiten dit corpus.}
+</content>

--- a/.claude/skills/regelrecht-stelselanalyse/templates/engine-limitaties.md
+++ b/.claude/skills/regelrecht-stelselanalyse/templates/engine-limitaties.md
@@ -33,4 +33,3 @@ niet in het corpus}.
 | Limitatie | Geraakte outputs | Engine-actie |
 |---|---|---|
 | {nr} | {n} | {PR-voorstel} |
-</content>

--- a/.claude/skills/regelrecht-stelselanalyse/templates/engine-limitaties.md
+++ b/.claude/skills/regelrecht-stelselanalyse/templates/engine-limitaties.md
@@ -1,0 +1,27 @@
+# Engine-executie-limitaties — {engine + versie}
+
+**Datum**: {datum}
+
+> Dit document bevat **engine-limitaties**: gevallen waar wet én onze modellering
+> kloppen, maar de engine de uitvoering (nog) niet ondersteunt. Géén wetgevings- of
+> modellering-fout — track apart zodat het corpus niet onterecht "fout" lijkt.
+
+## Limitaties
+
+### {nr} — {korte titel}
+**Geraakt**: {welke outputs / wetten / artikelen} ({aantal}).
+**Wat de engine niet kan**: {concrete beschrijving — bijv. een operatie/vergelijking die
+ontbreekt}.
+**Bewijs**: {het scenario/commando dat faalt + de foutuitkomst}.
+**Workaround** *(indien)*: {tijdelijke modellering-omweg, en de prijs daarvan}.
+**Voorgestelde engine-actie**: {engine-PR / feature die dit oplost — hoort in de engine,
+niet in het corpus}.
+
+*(herhaal per limitatie)*
+
+## Samenvatting
+
+| Limitatie | Geraakte outputs | Engine-actie |
+|---|---|---|
+| {nr} | {n} | {PR-voorstel} |
+</content>

--- a/.claude/skills/regelrecht-stelselanalyse/templates/engine-limitaties.md
+++ b/.claude/skills/regelrecht-stelselanalyse/templates/engine-limitaties.md
@@ -6,6 +6,15 @@
 > kloppen, maar de engine de uitvoering (nog) niet ondersteunt. Géén wetgevings- of
 > modellering-fout — track apart zodat het corpus niet onterecht "fout" lijkt.
 
+> **Bewijs-poort (verplicht).** Een limitatie mag pas hier worden opgenomen ná een
+> **reproduceerbare engine-run die het falen aantoont** — met het scenario/commando en de
+> foutuitkomst in het veld **Bewijs**. Een *onbewezen aanname* ("de engine kan vast geen
+> X") is géén limitatie: noteer die als **open vraag** in de cyclus (of weerleg hem door
+> het juist wél te binden en te testen). Veelgemaakte foute aanname: "de engine kan niet
+> meerdere `source:`-bindingen per artikel resolveren" — dat is onjuist (schema v0.5.2
+> ondersteunt dit); zo'n geval is een modellering-fout, geen limitatie. Zonder Bewijs-veld
+> hoort een regel niet in dit document.
+
 ## Limitaties
 
 ### {nr} — {korte titel}

--- a/.claude/skills/regelrecht-stelselanalyse/templates/engine-tests.md
+++ b/.claude/skills/regelrecht-stelselanalyse/templates/engine-tests.md
@@ -30,4 +30,3 @@ corpus-fout.}
 
 {Valideren deze scenario's de wet of de YAML? Als ze uit dezelfde (mogelijk foute)
 interpretatie komen als de YAML, bewijzen ze geen juridische correctheid.}
-</content>

--- a/.claude/skills/regelrecht-stelselanalyse/templates/engine-tests.md
+++ b/.claude/skills/regelrecht-stelselanalyse/templates/engine-tests.md
@@ -1,0 +1,33 @@
+# Engine-executie-tests — {datum}
+
+**Scope**: {welke wetten/keten} · **Engine**: {versie}
+
+## Persona-scenario's
+
+Scenario's die elk een ander kern-pad door de keten raken (cross-law indien van
+toepassing). Elk scenario = invoer + verwachte output.
+
+| Scenario | Persona / casus (fictief) | Invoer (kern) | Verwachte output |
+|---|---|---|---|
+| 1 | {korte beschrijving} | {parameters} | {output = waarde} |
+
+## Resultaten
+
+| Wet / artikel | Output | Engine-resultaat | Oordeel |
+|---|---|---|---|
+| {wet art X} | `{output}` | {waarde} | PASS / **FAIL** |
+
+{Bij FAIL: classificeer — engine-limitatie (→ `engine-limitaties`), modellering-fout
+(→ fixes-plan), of wetgevings-fout (→ fouten-analyse). Een FAIL is niet automatisch een
+corpus-fout.}
+
+## Hoe gedraaid
+
+- `{scenario-runner-commando}` ({N/N} PASS)
+- {verwijzing naar de scenario-bestanden / feature-files}
+
+## Meta-check
+
+{Valideren deze scenario's de wet of de YAML? Als ze uit dezelfde (mogelijk foute)
+interpretatie komen als de YAML, bewijzen ze geen juridische correctheid.}
+</content>

--- a/.claude/skills/regelrecht-stelselanalyse/templates/harvest-rapport.md
+++ b/.claude/skills/regelrecht-stelselanalyse/templates/harvest-rapport.md
@@ -1,0 +1,37 @@
+# Harvest {wet/regeling} ({schemaversie})
+
+**Bron**: {officiële titel + bron-id (BWBR/CVDR) + versie/datum} · **URL**: {wettekst-URL}
+**YAML**: `{pad}` · **Datum**: {datum}
+
+## Doel
+
+{Wet} uit de officiële tekst het corpus in brengen, conform schema {versie}.
+
+## Opgenomen artikelen
+
+| Artikel | Onderwerp | MR-status | Output(s) |
+|---|---|---|---|
+| {art X} | {…} | volledig / gedeeltelijk / alleen tekst | `{output}` |
+
+## Interpretatie-keuzes
+
+- {keuze + reden — bv. hoe een open term is behandeld, welke eenheid, welke aanname}
+
+## Cross-law-koppelingen
+
+- `source:` → {wet/output} voor {welke waarde}
+- `legal_basis` → {grondslag-wet/artikel}
+
+## Niet opgenomen (en waarom)
+
+- {artikel/lid} — {reden: untranslatable / proces / buiten scope / engine-limitatie}
+
+## Validatie
+
+- `{validatie-commando}` → {OK}
+- {eventuele engine-executie / scenario}
+
+## Bevindingen (4-weg geclassificeerd)
+
+- {bevinding} → {modellering-fout / wetgevings-fout / engine-limitatie / untranslatable}
+</content>

--- a/.claude/skills/regelrecht-stelselanalyse/templates/harvest-rapport.md
+++ b/.claude/skills/regelrecht-stelselanalyse/templates/harvest-rapport.md
@@ -34,4 +34,3 @@
 ## Bevindingen (4-weg geclassificeerd)
 
 - {bevinding} → {modellering-fout / wetgevings-fout / engine-limitatie / untranslatable}
-</content>

--- a/.claude/skills/regelrecht-stelselanalyse/templates/loop-prompt.md
+++ b/.claude/skills/regelrecht-stelselanalyse/templates/loop-prompt.md
@@ -1,0 +1,70 @@
+# Completion-loop — {taak}
+
+*Een self-driving prompt voor een afgebakende, repetitieve batch (bv. een werklijst
+wet-voor-wet harvesten/migreren/reviewen tot alles klaar is). Alleen voor repetitief,
+goed-afgebakend werk — niet voor verkennend/oordeels-werk.*
+
+## Hoe starten
+
+Kies de modus (zie `references/cycle-workflow.md` → loop vs schedule):
+
+- **Batch tot klaar (aanbevolen)** — self-paced `/loop`, Claude bepaalt zelf de cadans
+  en stopt zodra de stop-conditie is bereikt. Plak alles onder "PROMPT" achter:
+  ```
+  /loop <PROMPT>
+  ```
+- **Vaste polling** — als je op een externe run wacht (validatie/CI): `/loop 10m <PROMPT>`.
+- **Onbeheerd / terugkerend** — overleeft terminal-sluiting: gebruik géén `/loop` maar
+  een routine, zie `templates/scheduled-routine.md`.
+
+Self-paced loops zijn sessie-gebonden (stoppen als de terminal sluit) en lopen max 7
+dagen. Druk `Esc` om te stoppen; `--resume`/`--continue` herstelt een niet-verlopen loop.
+
+---
+
+## PROMPT (alles hieronder is de loop-prompt)
+
+Je werkt aan **{taak}** voor het corpus `{pad}`, cyclus-scope **{thema}**. Werk één
+item per iteratie af tot de stop-conditie is bereikt.
+
+**Stop-conditie**: {expliciet en controleerbaar — bv. alle items in de werklijst staan
+op `done`}. Als dit waar is: rapporteer de eindstand en **plan geen volgende wake** (de
+loop is klaar).
+
+**Per iteratie**:
+1. Lees het voortgangslog (onderaan dit document `{pad}`) + de werklijst; bepaal het
+   eerstvolgende niet-`done`-item.
+2. Doe het werk voor dat item ({concreet: harvest / migreer / breid MR uit / review-as}).
+   Houd je aan de regelrecht-methode en classificeer elke bevinding **4-weg**
+   (modellering-fout / wetgevings-fout / engine-limitatie / acceptabele untranslatable).
+3. Valideer: `{validatie-commando}` groen + `{scenario/BDD-commando}` groen. Rood? →
+   herstel binnen deze iteratie of markeer het item `geblokkeerd` met reden.
+4. Commit met een beschrijvende message (geen branding, nooit `--no-verify`).
+5. Werk de werklijst bij (`done`/`geblokkeerd`) en schrijf één regel in het voortgangslog:
+   item + uitkomst + eventuele discovery + classificatie.
+6. Bepaal de wake-cadans:
+   - werk-iteratie die echt werk deed → ga direct door (korte/geen wachttijd);
+   - wachtend op een externe run → poll rond ~270s (cache blijft warm);
+   - niets te doen maar nog niet klaar → fallback ~1200s.
+
+**Invarianten (nooit schenden)**:
+- Schema blijft valide; nooit rode tests pushen.
+- Blijf binnen scope **{thema}**; nieuwe scope → noteren in het log, niet zelf oppakken.
+- **Niets pushen zonder toestemming** (de loop draait lokaal met sessie-permissies).
+- Bij twijfel over een interpretatie → markeer `NEEDS_HUMAN_REVIEW` en ga door; forceer
+  geen oordeel.
+
+---
+
+## Werklijst
+
+| # | Item | Status |
+|---|---|---|
+| 1 | {item} | open |
+
+## Voortgangslog
+
+*(de loop vult dit per iteratie aan)*
+
+- **Iteratie 1** — {item}: {uitkomst}. Classificatie: {—}. Discovery: {—}.
+</content>

--- a/.claude/skills/regelrecht-stelselanalyse/templates/loop-prompt.md
+++ b/.claude/skills/regelrecht-stelselanalyse/templates/loop-prompt.md
@@ -67,4 +67,3 @@ loop is klaar).
 *(de loop vult dit per iteratie aan)*
 
 - **Iteratie 1** — {item}: {uitkomst}. Classificatie: {—}. Discovery: {—}.
-</content>

--- a/.claude/skills/regelrecht-stelselanalyse/templates/modellering-fixes-plan.md
+++ b/.claude/skills/regelrecht-stelselanalyse/templates/modellering-fixes-plan.md
@@ -36,4 +36,3 @@
 ## Open vraag (te verifiëren)
 
 - {bijv. komt een waarde uit een nog-niet-geharveste cross-law-bron? → naar tracker}
-</content>

--- a/.claude/skills/regelrecht-stelselanalyse/templates/modellering-fixes-plan.md
+++ b/.claude/skills/regelrecht-stelselanalyse/templates/modellering-fixes-plan.md
@@ -1,0 +1,39 @@
+# Modellering-fixes-plan — wat onze YAML moet aanpassen om bij de wet te kloppen
+
+**Datum**: {datum} · **Scope**: {welke wetten} · **Bron**: {validatie-review(s)}
+
+> Dit document bevat **modellering-fouten**: gevallen waar onze YAML/feature afwijkt van
+> de (correcte) wettekst. Voor fouten in de wet zelf, zie `{pad naar wetgevingsfouten-analyse}`.
+
+## Bevindingen die NIET opnieuw onderzocht hoeven worden
+
+*Vastgesteld in de validatie-review; direct fixbaar.*
+
+### Kritieke fouten in YAML + features
+| # | Wet / artikel | Fout | Bron-bevestiging |
+|---|---|---|---|
+| 1 | {wet art X} | {wat klopt niet t.o.v. wettekst} | {YAML-regels / feature-regels} |
+
+### Kritieke fouten alleen in YAML
+| # | Wet / artikel | Fout |
+|---|---|---|
+| {n} | {wet art X} | {ontbrekend lid / verkeerde operator / verkeerde eenheid} |
+
+### Structurele problemen
+| Probleem | Bestanden |
+|---|---|
+| {duplicaat-`$id` / verkeerde map / inconsistente schema-URL / lege placeholder} | {paden} |
+
+### Wél getrouw (niet aanraken)
+- {wat correct is — expliciet, om dubbel werk te voorkomen}
+
+## Fix-plan
+
+| Fix | Wet/artikel | Wat | Validatie na fix |
+|---|---|---|---|
+| F1 | {…} | {concrete YAML-wijziging} | {commando → verwacht resultaat} |
+
+## Open vraag (te verifiëren)
+
+- {bijv. komt een waarde uit een nog-niet-geharveste cross-law-bron? → naar tracker}
+</content>

--- a/.claude/skills/regelrecht-stelselanalyse/templates/mr-uitbreiding-rapport.md
+++ b/.claude/skills/regelrecht-stelselanalyse/templates/mr-uitbreiding-rapport.md
@@ -30,4 +30,3 @@
 ## Niet gedaan (bewust)
 
 - {wat buiten deze pass viel + reden (ROI / aparte cyclus / engine-limitatie)}
-</content>

--- a/.claude/skills/regelrecht-stelselanalyse/templates/mr-uitbreiding-rapport.md
+++ b/.claude/skills/regelrecht-stelselanalyse/templates/mr-uitbreiding-rapport.md
@@ -1,0 +1,33 @@
+# {Wet} — machine_readable uitbreiding/vervollediging ({datum})
+
+**YAML**: `{pad}` · **Artikelen**: {bereik, bv. art 6–17}
+**Doel**: {welke MR-logica wordt toegevoegd/gecompleteerd en waarom}
+
+## Wat is toegevoegd
+
+| Artikel/lid | Output | Formule (natuurlijke notatie) | Bron-quote (`legal_basis`) |
+|---|---|---|---|
+| {art X} | `{output}` | `{formule}` | {kort citaat} |
+
+## Untranslatables toegevoegd
+
+| Artikel/lid | Open norm | Type (factual/judgment) | Reden |
+|---|---|---|---|
+| {art X} | {citaat-kern} | {…} | {…} |
+
+## Cross-law / source-refs
+
+- {source-ref gelegd: van `description` naar echte `source:` → {wet/output}}
+
+## Validatie
+
+- `{validatie-commando}` → {OK} · {engine-executie indien van toepassing}
+
+## Bevindingen (4-weg)
+
+- {bevinding} → {classificatie}. {Indien wetgevings-fout: door naar de fouten-analyse.}
+
+## Niet gedaan (bewust)
+
+- {wat buiten deze pass viel + reden (ROI / aparte cyclus / engine-limitatie)}
+</content>

--- a/.claude/skills/regelrecht-stelselanalyse/templates/resolutie-tracker.md
+++ b/.claude/skills/regelrecht-stelselanalyse/templates/resolutie-tracker.md
@@ -42,4 +42,3 @@ of nog open staat. Leidende status-administratie voor de cyclus.
 - **In scope, open te resolveren**: {lijst ID's}
 - **Out-of-scope** (volgende cyclus): {aantal} comments + {aantal} fouten
 - **Verwacht patroon**: {welke worden weerlegd/verifieerd/onverifieerbaar}
-</content>

--- a/.claude/skills/regelrecht-stelselanalyse/templates/resolutie-tracker.md
+++ b/.claude/skills/regelrecht-stelselanalyse/templates/resolutie-tracker.md
@@ -1,0 +1,45 @@
+# Cyclus {N} — Resolutie-tracker (comments + wetgevings-fouten)
+
+**Datum start**: {datum} · **Plan**: `{pad}` · **Bron-dossier**: `{pad}`
+**Laatste update**: {datum} ({wat is bijgewerkt})
+
+## Doel
+
+Per inline-comment en per wetgevings-fout vastleggen of die deze cyclus is geresolveerd
+of nog open staat. Leidende status-administratie voor de cyclus.
+
+## Legenda — status
+
+| Status | Betekenis |
+|---|---|
+| `open` | Niets ondernomen deze cyclus |
+| `in-progress` | Bron-onderzoek loopt of resolutie wordt geschreven |
+| `verifieerd` | Externe bron bevestigt de claim (referentie in bron-kolom) |
+| `weerlegd` | Externe bron weerlegt de claim |
+| `gedeeltelijk` | Bron resolveert deel; rest blijft open |
+| `onverifieerbaar` | Geen uitspraak mogelijk via bronnen; mens/dossier nodig |
+| `out-of-scope` | Bewust niet behandeld deze cyclus |
+
+## Legenda — scope
+
+{Codes voor de thema's van deze cyclus, bijv.} **{X}** = {thema} · **{Y}** = {thema} ·
+**—** = buiten scope.
+
+## A. Inline-comments ({aantal})
+
+| # | Locatie | Scope | Kern | Status | Bron | Voorlopig gevolg |
+|---|---|---|---|---|---|---|
+| 1 | §{x} | {X/Y/—} | {kern van de comment} | {status} | {bron-bestand(en)} | {wat het betekent} |
+
+## B. Wetgevings-fouten ({aantal})
+
+| ID | Titel | Scope | Status | Bron | Voorlopig gevolg |
+|---|---|---|---|---|---|
+| §{n.m} | {titel} | {X/Y/—} | {status} | {bron} | {gevolg} |
+
+## Stand {datum} — einde {micro-cyclus}
+
+- **In scope, open te resolveren**: {lijst ID's}
+- **Out-of-scope** (volgende cyclus): {aantal} comments + {aantal} fouten
+- **Verwacht patroon**: {welke worden weerlegd/verifieerd/onverifieerbaar}
+</content>

--- a/.claude/skills/regelrecht-stelselanalyse/templates/scheduled-routine.md
+++ b/.claude/skills/regelrecht-stelselanalyse/templates/scheduled-routine.md
@@ -57,12 +57,13 @@ Push nooit naar een publieke repo."}
 - `/schedule list` — overzicht · `/schedule update` — wijzigen · `/schedule run` — nu draaien
 - Web-UI: claude.ai/code/routines (triggers, omgeving, connectors)
 
-### Harness-afdwinging (geïnstalleerd)
+### Harness-afdwinging (lokaal instellen)
 
-Er staat een globale PreToolUse-hook in `~/.claude/settings.json`
+Installeer een globale PreToolUse-hook in `~/.claude/settings.json`
 (`~/.claude/hooks/git-push-private-guard.sh`) die **elke** `git push` blokkeert tenzij de
-target een private GitHub-repo is. Escape-hatch voor een bewuste publieke push:
-`ALLOW_PUBLIC_PUSH=1 git push`.
+target een private GitHub-repo is. Deze hook is **machine-lokaal** en reist niet mee met
+de repo — registreer 'm zelf in je eigen `~/.claude/`. Escape-hatch voor een bewuste
+publieke push: `ALLOW_PUBLIC_PUSH=1 git push`.
 
 > ⚠ **Lokaal vs cloud.** Deze hook beschermt **lokale** sessies en `/loop`-runs (die op
 > jouw machine draaien). `/schedule`-routines draaien in een **aparte cloud-omgeving** en

--- a/.claude/skills/regelrecht-stelselanalyse/templates/scheduled-routine.md
+++ b/.claude/skills/regelrecht-stelselanalyse/templates/scheduled-routine.md
@@ -79,4 +79,3 @@ publieke push: `ALLOW_PUBLIC_PUSH=1 git push`.
 
 `min uur dag-vd-maand maand dag-vd-week` · `*/15 * * * *` elke 15 min ·
 `0 9 * * *` dagelijks 09:00 · `0 6 * * 1` maandag 06:00 · `0 0 1 * *` 1e v/d maand.
-</content>

--- a/.claude/skills/regelrecht-stelselanalyse/templates/scheduled-routine.md
+++ b/.claude/skills/regelrecht-stelselanalyse/templates/scheduled-routine.md
@@ -1,0 +1,81 @@
+# Geplande routine — {naam}
+
+*Een terugkerende, **onbeheerde** taak via `/schedule` (cloud-routine). Draait door als
+de terminal dicht is, op een cron-schema, **zonder permission-prompts**. Min. interval
+1 uur. Voor sessie-gebonden batchwerk: gebruik `/loop` (zie `loop-prompt.md`).*
+
+## ⚠ Veiligheid: committen mag, maar alleen naar private repos
+
+Routines draaien autonoom zónder bevestiging. Committen + pushen is toegestaan, mits de
+push-target **aantoonbaar private** is. Gebruik de fail-closed guard
+`scripts/assert-private-repo.sh` als **preflight vóór elke push**:
+
+```bash
+# in de routine, vóór publiceren:
+bash {pad-naar-skill}/scripts/assert-private-repo.sh && git push
+# of expliciet per remote:  assert-private-repo.sh upstream && git push upstream HEAD
+```
+
+De guard vraagt de GitHub-zichtbaarheid op en laat alleen `PRIVATE` door (PUBLIC en
+INTERNAL → block). Hij faalt **closed**: geen repo / geen remote / geen `gh` / niet te
+bepalen → push geweigerd. Lokale commits zijn altijd veilig (geen blootstelling); de
+guard bewaakt het *publiceren*.
+
+> **Echte afdwinging.** Een routine volgt deze invariant uit discipline. Voor
+> harness-afdwinging (zodat ook een ontspoorde autonome run niet naar een publieke repo
+> kan pushen) is een PreToolUse-hook op `git push` nodig die de guard draait — zie de
+> noot onder "Beheer". Zonder hook leunt het op de routine-instructies.
+
+## Wanneer een routine i.p.v. een loop
+
+| Situatie | Gebruik |
+|---|---|
+| Afgebakende batch die zichzelf afmaakt, jij erbij | `/loop` self-paced |
+| Wachten op een externe run binnen je sessie | `/loop <interval>` |
+| Terugkerend toezicht dat terminal-sluiting overleeft | **routine (`/schedule`)** |
+| Eén run op een toekomstig moment | éénmalig: `/schedule tomorrow at 9am <prompt>` |
+
+## Voorbeeld-routines voor desk-review
+
+| Naam | Cron | Doel (report-only) |
+|---|---|---|
+| Nachtelijke corpus-validatie | `0 2 * * *` | Valideer hele corpus tegen schema + engine; schrijf regressies naar een status-log + meld afwijkingen t.o.v. gisteren |
+| Wekelijkse coverage-sweep | `0 6 * * 1` | MR-coverage + untranslatables-coverage per wet; werk `corpus-status` bij en concept-eindrapport |
+| Bron-watch | (API/GitHub-trigger via web-UI) | Bij nieuwe publicatie van een wet in scope: signaleer dat een harvest nodig is |
+
+## Routine-prompt
+
+```
+{Beschrijf de taak voor de routine. Begin met de scope + het corpus-pad. Sluit af met de
+invariant: "Vóór elke push: draai `bash {pad}/scripts/assert-private-repo.sh` en push
+alleen als die slaagt; bij block commit je lokaal en rapporteer je dat niet gepusht is.
+Push nooit naar een publieke repo."}
+```
+
+## Beheer
+
+- `/schedule list` — overzicht · `/schedule update` — wijzigen · `/schedule run` — nu draaien
+- Web-UI: claude.ai/code/routines (triggers, omgeving, connectors)
+
+### Harness-afdwinging (geïnstalleerd)
+
+Er staat een globale PreToolUse-hook in `~/.claude/settings.json`
+(`~/.claude/hooks/git-push-private-guard.sh`) die **elke** `git push` blokkeert tenzij de
+target een private GitHub-repo is. Escape-hatch voor een bewuste publieke push:
+`ALLOW_PUBLIC_PUSH=1 git push`.
+
+> ⚠ **Lokaal vs cloud.** Deze hook beschermt **lokale** sessies en `/loop`-runs (die op
+> jouw machine draaien). `/schedule`-routines draaien in een **aparte cloud-omgeving** en
+> gebruiken deze lokale hook niet noodzakelijk. Voor cloud-routines geldt daarom:
+> - laat de routine-prompt de guard expliciet aanroepen vóór elke push, **en**
+> - zorg dat de guard (of een equivalent) in die omgeving beschikbaar is, **en**
+> - houd commit-routines bij voorkeur report-only of push naar een aantoonbaar private
+>   remote.
+> De fail-closed guard in de routine-prompt is dus de primaire beveiliging voor cloud;
+> de hook is de extra net voor lokaal werk.
+
+## Cron-spiekbriefje
+
+`min uur dag-vd-maand maand dag-vd-week` · `*/15 * * * *` elke 15 min ·
+`0 9 * * *` dagelijks 09:00 · `0 6 * * 1` maandag 06:00 · `0 0 1 * *` 1e v/d maand.
+</content>

--- a/.claude/skills/regelrecht-stelselanalyse/templates/schema-migratie.md
+++ b/.claude/skills/regelrecht-stelselanalyse/templates/schema-migratie.md
@@ -1,0 +1,42 @@
+# Schema-migratie {oude versie} → {nieuwe versie}
+
+**Datum**: {datum} · **Scope**: {welke wetten/bestanden}
+**Status**: {voltooid lokaal / gepusht}
+
+## Doel
+
+Alle {N} bestanden van schema {oud} naar {nieuw}, validerend onder het nieuwe schema +
+de engine.
+
+## Mechanische pass
+
+Zoek-en-vervang-achtige wijzigingen, per bestand:
+
+- {schema-URL bump: `{oud}` → `{nieuw}`}
+- {hernoemde operaties: `{A}` → `{B}`}
+- {gewijzigde syntax: `{oude vorm}` → `{nieuwe vorm}`}
+- {ontbrekende headers toevoegen aan serde-only bestanden}
+
+## Semantische pass
+
+Nieuwe schema-features benutten, per artikel beoordeeld:
+
+- {nieuw veld/structuur} toegepast op {welke artikelen} omdat {reden}
+- …
+
+## Discoveries — schema
+
+*Het waardevolste deel: welke aannames over het schema klopten of niet.*
+
+1. {bevinding — bijv. een enum bleek gesloten, een veld zit op een andere plek dan gedacht}
+2. …
+
+## Validatie
+
+- `{validatie-commando}` → {N/N OK}
+- `{engine-scenario-commando}` → {N/N PASS}
+
+## Open punten
+
+- {wat een vervolg vereist — bijv. een engine-PR voor een ontbrekende operatie}
+</content>

--- a/.claude/skills/regelrecht-stelselanalyse/templates/schema-migratie.md
+++ b/.claude/skills/regelrecht-stelselanalyse/templates/schema-migratie.md
@@ -39,4 +39,3 @@ Nieuwe schema-features benutten, per artikel beoordeeld:
 ## Open punten
 
 - {wat een vervolg vereist — bijv. een engine-PR voor een ontbrekende operatie}
-</content>

--- a/.claude/skills/regelrecht-stelselanalyse/templates/synthese.md
+++ b/.claude/skills/regelrecht-stelselanalyse/templates/synthese.md
@@ -1,0 +1,49 @@
+# Synthese expert-review — {datum}
+
+**Reviewers**: {N parallelle assen/agents} · **Scope**: {assen}
+**Resultaat in één zin**: {bijv. X gefixt + Y gedocumenteerd, rest naar volgende cyclus}
+
+## Wat is gefixt deze ronde
+
+- **{KRITIEK/MINOR} — {titel}** (as {x}): {bug + fix in één alinea}. Commit `{ref}`.
+  Tests blijven groen ({N/N}).
+
+## Wat is gedocumenteerd, niet gefixt
+
+| As / agent | Aantal | Classificatie | Discovery |
+|---|---|---|---|
+| {as} | {n} | {classificatie} | {korte omschrijving} |
+
+## Discoveries uitgelicht
+
+### D1 — {titel}
+{Wat, op basis waarvan, en het gevolg.}
+
+## Meta-bevindingen
+
+- **Features vs YAML**: {maken ze dezelfde fout? consequentie voor de BDD-suite}.
+- {andere stelsel-brede observatie}
+
+## Telling (geactualiseerd)
+
+{Aantal wetgevings-fouten per categorie/ernst na deze ronde. Consistent houden met de
+fouten-analyse en het eindrapport.}
+
+## Engine-correctheid behouden
+
+- `{validatie-commando}` → {N/N OK}
+- `{scenario-commando}` → {N/N PASS}
+
+---
+
+# Heroverweging twijfel-claims *(zelfde of apart document)*
+
+Per onzekere bevinding: houdt de claim stand?
+
+| Claim | Oordeel | Gevolg |
+|---|---|---|
+| {claim} | {gehandhaafd / weerlegd / verplaatst} | {telling −1 / categorie gewijzigd / —} |
+
+**Geschrapte claims** blijven zichtbaar in de bronnen-documenten (doorgestreept + reden);
+tellingen aangepast. Geen stille verwijdering.
+</content>

--- a/.claude/skills/regelrecht-stelselanalyse/templates/synthese.md
+++ b/.claude/skills/regelrecht-stelselanalyse/templates/synthese.md
@@ -46,4 +46,3 @@ Per onzekere bevinding: houdt de claim stand?
 
 **Geschrapte claims** blijven zichtbaar in de bronnen-documenten (doorgestreept + reden);
 tellingen aangepast. Geen stille verwijdering.
-</content>

--- a/.claude/skills/regelrecht-stelselanalyse/templates/validatie-review.md
+++ b/.claude/skills/regelrecht-stelselanalyse/templates/validatie-review.md
@@ -28,4 +28,3 @@ fouten-analyse met de juiste categorie.}
 ## Telling
 
 {Aantal bevindingen per classificatie/ernst — input voor de synthese.}
-</content>

--- a/.claude/skills/regelrecht-stelselanalyse/templates/validatie-review.md
+++ b/.claude/skills/regelrecht-stelselanalyse/templates/validatie-review.md
@@ -1,0 +1,31 @@
+# Review — {as} ({datum})
+
+**As**: {machine-readable correctheid / untranslatables / coverage / source-refs / diagrammen / wetgevings-fouten}
+**Scope**: {welke wetten/artikelen} · **Reviewer**: {mens / sub-agent}
+
+## Wat als bevinding telt
+
+{Korte definitie van wat op deze as een bevinding is.}
+
+## Bevindingen
+
+Per bevinding: classificatie (4-weg) + ernst + locatie + omschrijving.
+
+| # | Classificatie | Ernst | Locatie | Bevinding |
+|---|---|---|---|---|
+| 1 | {modellering / wetgeving / engine / untranslatable} | {KRITIEK/ZORG/—} | {wet art X} | {korte omschrijving} |
+
+## Uitgelichte bevindingen
+
+### {nr} — {titel}
+{Wat, wettekst vs YAML/praktijk, en het gevolg. Bij wetgevings-fout: door naar de
+fouten-analyse met de juiste categorie.}
+
+## Meta-check
+
+{Maken features en YAML dezelfde fout op deze as? Zo ja: noteer expliciet.}
+
+## Telling
+
+{Aantal bevindingen per classificatie/ernst — input voor de synthese.}
+</content>

--- a/.claude/skills/regelrecht-stelselanalyse/templates/wetgevingsfouten-analyse.md
+++ b/.claude/skills/regelrecht-stelselanalyse/templates/wetgevingsfouten-analyse.md
@@ -1,0 +1,76 @@
+# Wetgevings-fouten in het {stelsel/dossier}
+
+**Datum**: {datum} · **Bron**: {review-synthese / cyclus}
+**Onderwerp**: fouten en gaten in de wetgeving die **niet door interpretatie te
+repareren** zijn.
+
+> Dit document beschrijft **wetgevings-bugs** — gevallen waarin de wet zelf onjuist,
+> achterhaald of onuitvoerbaar is. Voor modellering-fouten die wij kunnen fixen, zie
+> `{pad naar modellering-fixes-plan}`.
+>
+> Geadresseerd aan: {wetgevings-eigenaar} (eigenaar), {uitvoerder/medewetgever}.
+> Bedoeld als bron voor een formele wetgevings-notitie.
+
+## Samenvatting
+
+| Categorie | Aantal | Ernst |
+|---|---|---|
+| Lege delegaties | {n} | KRITIEK |
+| Achterhaalde institutionele referenties | {n} | KRITIEK |
+| Wettekst-fouten | {n} | KRITIEK |
+| Inconsistenties met andere wetten | {n} | ZORG |
+| Onuitvoerbare voorwaarden zonder beslisser | {n} | ZORG |
+| Onuitgewerkte regelingen | {n} | ZORG |
+| {…overige categorieën} | {n} | {…} |
+
+**Conclusie**: {is het stelsel uitvoerbaar zoals het er staat? Waar functioneert de
+praktijk op gewoonterecht zonder formele basis? Wat betekent dat voor geautomatiseerde
+uitvoering?}
+
+---
+
+## §{n}. {Categorie}
+
+### {n.m} {Titel — wet + artikel/lid}
+COMMENT: {ruimte voor menselijke reviewer-nuance — leeg laten bij eerste opstelling}
+
+**Wettekst ({bron-id} {artikel})**:
+> "{letterlijk citaat van de geldende tekst}"
+
+**Probleem**: {waarom dit fout/achterhaald/onuitvoerbaar is}.
+
+**Implicatie**: {gevolg voor uitvoering en burger — kan hij zijn recht
+kennen/berekenen/betwisten? Maak concreet wat onuitvoerbaar wordt.}
+
+```mermaid
+%% optioneel: visualiseer het probleem (circulair criterium / dubbelfunctie / mismatch)
+```
+
+**Wat zou moeten gebeuren**: {concrete reparatie — technisch wijzigingsbesluit / AMvB
+afkondigen / term vervangen / criterium toevoegen. Geef aan: klein technisch vs
+beleidsinhoudelijk.}
+
+*(herhaal per fout; geschrapte fouten doorstrepen met ~~…~~ + reden + telling-correctie)*
+
+---
+
+## §{n}. Wat is precies "uitvoeren" van dit stelsel?
+
+Een burger kan vandaag **geen geautomatiseerd kenbare regel** vinden voor:
+1. {…}
+2. {…}
+
+{Conclusie: de machine_readable is zo correct als de wet toelaat, maar de wet laat te
+veel open om als geautomatiseerd uitvoerbaar stelsel te functioneren — tenzij
+wetgevings-onderhoud volgt.}
+
+---
+
+## §{n}. Aanbevolen acties (prioriteits-volgorde)
+
+1. **Reparatie wettekst-fouten** — technisch, onbetwist, zonder beleidsruimte.
+2. **Afkondigen ontbrekende MR's/AMvB's** — juridisch noodzakelijk, beleidsinhoudelijk.
+3. **Naam-modernisering institutionele referenties** — klein technisch.
+4. **Beslisser-aanwijzing voor open normen** — beleidsinhoudelijke keuze.
+5. {…}
+</content>

--- a/.claude/skills/regelrecht-stelselanalyse/templates/wetgevingsfouten-analyse.md
+++ b/.claude/skills/regelrecht-stelselanalyse/templates/wetgevingsfouten-analyse.md
@@ -73,4 +73,3 @@ wetgevings-onderhoud volgt.}
 3. **Naam-modernisering institutionele referenties** — klein technisch.
 4. **Beslisser-aanwijzing voor open normen** — beleidsinhoudelijke keuze.
 5. {…}
-</content>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
               - corpus/regulation/**
               - schema/**
               - script/**
+              - .claude/skills/regelrecht-stelselanalyse/references/cross-law-integriteit.py
               - Justfile
               - .pre-commit-config.yaml
               - .yamllint
@@ -230,6 +231,29 @@ jobs:
       - name: Skip (no relevant changes)
         if: needs.changes.outputs.ci != 'true'
         run: echo "No relevant changes, skipping provenance checks"
+
+  cross-law-integrity:
+    name: Cross-law integrity
+    needs: changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: needs.changes.outputs.ci == 'true'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
+        with:
+          python-version: '3.x'
+
+      - name: Install pyyaml
+        run: pip install pyyaml
+
+      # Fail-closed gate over the corpus: MISPLACED / DANGLING / PLAIN-PARAM
+      # source bindings and IMPL-DANGLING / IMPL-NO-DATE implements declarations
+      # are all modelling errors. The script exits non-zero on any finding.
+      - name: Check cross-law binding integrity
+        run: |
+          python3 .claude/skills/regelrecht-stelselanalyse/references/cross-law-integriteit.py corpus/regulation
 
   pre-commit:
     name: Pre-commit

--- a/packages/pipeline/src/models.rs
+++ b/packages/pipeline/src/models.rs
@@ -113,6 +113,11 @@ pub struct LawEntry {
     pub status: LawStatusValue,
     pub harvest_job_id: Option<Uuid>,
     pub enrich_job_id: Option<Uuid>,
+    /// Completeness metric: fraction of articles that received a
+    /// `machine_readable` section during enrichment. This measures COVERAGE,
+    /// not CORRECTNESS — a score of 1.0 means every article was modelled, not
+    /// that the modelling is legally faithful. Correctness is checked elsewhere
+    /// (schema/cross-law gates, BDD, and the methodological drift/desk-review).
     pub coverage_score: Option<f64>,
     pub harvest_fail_count: i32,
     pub enrich_fail_count: i32,


### PR DESCRIPTION
## Wat
Drie samenhangende Claude-skills onder `.claude/skills/` voor het werken aan een regelrecht-dossier:

- **regelrecht-dossier** — front-door router: triageert een binnenkomende casus en routeert (feitelijke defecten → desk, oordeels-/praktijkvragen → workshop). Bevat `routing.md` (canonieke flow) en `zakkaart.md` (onboarding-A4 voor regelanalisten).
- **regelrecht-stelselanalyse** — desk-review & corpus-completion-cyclus: 4-weg-classificatie (modellering-/wetgevings-fout, engine-limitatie, untranslatable), multi-agent review, externe bronnen-verificatie, `/loop`- en `/schedule`-ondersteuning, en een fail-closed private-only push-guard (`scripts/assert-private-repo.sh`).
- **regelrecht-audit-products** — producten voor live expert-validatie: scope-analyse, per-artikel audit-doc, facilitatiekit, testcase-scenario's, verslagen.

## Eigenschappen
- **Dossier-agnostisch**: geen casus-specifieke referenties; de regelrecht-methode is de vaste taal.
- Alleen toevoegingen onder `.claude/skills/` (41 bestanden), geen wijzigingen aan bestaande bestanden.

## Let op
- De `scheduled-routine` verwijst naar een machine-lokale push-guard hook (`~/.claude/hooks/…` + `~/.claude/settings.json`); die hook reist niet mee met de repo en moet lokaal worden geregistreerd. Het guard-script zelf zit wél in de skill.