### PR TITLE
feat(editor): traject in URL i.p.v. server-sessie

### DIFF
--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -186,7 +186,14 @@ const {
 // re-fetch the open law through the new traject's backends. `switchLaw`
 // crosses trajects too via its third argument so the law cache key
 // stays correct.
+//
+// Also flush the WASM engine: it caches loaded laws by id only, so
+// without this a scenario run after a traject switch would evaluate
+// the open law against the *previous* traject's dependencies. The
+// dependency walker re-loads on demand on the next run, so a single
+// `unloadAllLaws` is enough — no per-dep bookkeeping needed.
 watch(activeTrajectRef, (next) => {
+  unloadAllLaws();
   loadCorpusLaws();
   if (lawId.value) {
     switchLaw(lawId.value, selectedArticleNumber.value, next);
@@ -242,6 +249,7 @@ const { draftNotesForArticle } = useResolvedDraftNotes(
   draftNotes,
   lawId,
   selectedArticle,
+  activeTrajectRef,
 );
 const canCreateNotes = computed(
   () => isEnabled('notes.create') && notesActive.value,
@@ -634,7 +642,14 @@ Promise.all(uniqueLawIds.map(async (id) => {
 }));
 
 // --- Engine ---
-const { ready: engineReady, initError: engineInitError, initEngine, getEngine } = useEngine();
+const {
+  ready: engineReady,
+  initError: engineInitError,
+  initEngine,
+  getEngine,
+  loadLawYaml,
+  unloadAllLaws,
+} = useEngine();
 initEngine().catch(() => {});
 
 // The engine-loading watch lives below, next to `currentLawYaml`, so it
@@ -849,18 +864,18 @@ const currentLawYaml = computed(() => {
   }
 });
 
-// Load current law into engine. Reacts to currentLawYaml so in-memory edits
-// are immediately visible to scenarios.
+// Load current law into engine. Reacts to currentLawYaml so in-memory
+// edits are immediately visible to scenarios. Goes through
+// useEngine.loadLawYaml so the engine's scope-tracking map sees this
+// load under the right traject — otherwise a later loadDependency call
+// for the same law id would treat it as already-current and skip the
+// refetch on a traject switch.
 watch(
   [currentLawYaml, engineReady],
-  ([lawYaml, isReady]) => {
+  async ([lawYaml, isReady]) => {
     if (!isReady || !lawYaml) return;
-    const engine = getEngine();
     try {
-      if (engine.hasLaw(lawId.value)) {
-        engine.unloadLaw(lawId.value);
-      }
-      engine.loadLaw(lawYaml);
+      await loadLawYaml(lawYaml, lawId.value, activeTrajectRef.value);
     } catch (e) {
       console.warn(`Failed to load law '${lawId.value}' into engine:`, e);
     }

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -601,18 +601,22 @@ async function selectTab(tab) {
   router.replace(editorRouteFor(tab.lawId, tab.articleNumber));
 }
 
-// Browser back/forward (or any external navigation) — pull state from URL.
-// Local mutations from selectTab already match the destination, so the
-// guards below short-circuit; the work only happens for true URL changes.
-// trajectRef changes go through `watch(activeTrajectRef)` above, which
-// re-fetches the law via the new traject's backends; this guard handles
-// the law/article portion.
-onBeforeRouteUpdate(async (to, from) => {
+// Browser back/forward (or any external navigation) — pull state from
+// URL. Local mutations from selectTab already match the destination,
+// so the guards below short-circuit; the work only happens for true
+// URL changes.
+//
+// trajectRef-only changes are intentionally NOT handled here: the
+// `watch(activeTrajectRef)` above already does `unloadAllLaws` +
+// `loadCorpusLaws` + `switchLaw`, and triggering switchLaw twice in
+// the same tick would burn an extra fetch (the first await loses the
+// switchVersion race, but still hits the network). This guard handles
+// the law / article portion only.
+onBeforeRouteUpdate(async (to) => {
   const newLawId = to.params.lawId;
   const newArticle = to.params.articleNumber;
-  const trajectChanged = to.params.trajectRef !== from.params.trajectRef;
   if (!newLawId) return;
-  if (newLawId !== lawId.value || trajectChanged) {
+  if (newLawId !== lawId.value) {
     const gen = ++switchGeneration;
     await switchLaw(newLawId, newArticle, to.params.trajectRef || null);
     if (gen !== switchGeneration) return;

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -145,12 +145,13 @@ function setPaneView(idx, viewId) {
 }
 
 // All edit operations are gated behind SSO + an active traject. The
-// SPA route shape (`/editor/{trajectRef}/{lawId?}`) puts the traject
-// in the URL, so this component cannot mount without one (the router
-// `beforeEnter` redirects bookmark-shaped `/editor/{lawId}` URLs to
-// the library). `canEdit` is therefore effectively just the auth
-// check, but we keep the explicit `activeTrajectRef` guard so an
-// unexpectedly-empty param surfaces as read-only rather than a 500.
+// editor renders in two shapes:
+//   - `/editor/{lawId?}/{articleNumber?}`         → read-only view,
+//     `canEdit` is false; save buttons disabled.
+//   - `/editor/{trajectRef}/{lawId?}/{article?}`  → full edit mode,
+//     `canEdit` is true; writes land in that traject's branch.
+// Pick a traject in the TrajectMenu to flip from the first shape to
+// the second.
 const { activeTrajectRef } = useTrajects();
 const canEdit = computed(
   () => (!oidcConfigured.value || authenticated.value) && activeTrajectRef.value !== null,
@@ -507,20 +508,35 @@ function saveActiveTab(tab) {
   else localStorage.setItem(ACTIVE_TAB_STORAGE_KEY, JSON.stringify(tab));
 }
 
-// If the user lands on /editor/{trajectRef}/ without a lawId, restore
-// the last tab they had open before the refresh — keeping the same
-// trajectRef they navigated to.
+/**
+ * Build a router target for the editor that preserves the current
+ * traject scope. With a traject in the URL the user stays in
+ * `editor-traject` (full edit mode); without one they stay in `editor`
+ * (read-only). Vue Router requires the route name to match the
+ * presence/absence of the `:trajectRef` param, so a single literal
+ * `name: 'editor'` won't survive a no-traject ↔ with-traject switch.
+ */
+function editorRouteFor(lawIdVal, articleNumber) {
+  const trajectRef = route.params.trajectRef;
+  if (trajectRef) {
+    return {
+      name: 'editor-traject',
+      params: { trajectRef, lawId: lawIdVal, articleNumber },
+    };
+  }
+  return {
+    name: 'editor',
+    params: { lawId: lawIdVal, articleNumber },
+  };
+}
+
+// If the user lands on the editor without a lawId, restore the last
+// tab they had open before the refresh — keeping the same traject
+// scope (or lack of it).
 if (!route.params.lawId) {
   const last = loadSavedActiveTab();
   if (last?.lawId) {
-    router.replace({
-      name: 'editor',
-      params: {
-        trajectRef: route.params.trajectRef,
-        lawId: last.lawId,
-        articleNumber: last.articleNumber || undefined,
-      },
-    });
+    router.replace(editorRouteFor(last.lawId, last.articleNumber || undefined));
   }
 }
 
@@ -582,14 +598,7 @@ async function selectTab(tab) {
   // Sync the URL so deep-linking and browser back/forward stay in step.
   // `replace` (not `push`) keeps history clean — a tab switch isn't
   // navigation the user wants to undo with the back button.
-  router.replace({
-    name: 'editor',
-    params: {
-      trajectRef: route.params.trajectRef,
-      lawId: tab.lawId,
-      articleNumber: tab.articleNumber,
-    },
-  });
+  router.replace(editorRouteFor(tab.lawId, tab.articleNumber));
 }
 
 // Browser back/forward (or any external navigation) — pull state from URL.

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -3,6 +3,7 @@ import { ref, computed, reactive, watch, watchEffect, nextTick } from 'vue';
 import { useRoute, useRouter, onBeforeRouteUpdate } from 'vue-router';
 import yaml from 'js-yaml';
 import { useLaw, fetchLaw } from './composables/useLaw.js';
+import { lawsListUrl } from './composables/corpusUrls.js';
 import { useEngine } from './composables/useEngine.js';
 import { useAuth } from './composables/useAuth.js';
 import { useTrajects } from './composables/useTrajects.js';
@@ -143,16 +144,16 @@ function setPaneView(idx, viewId) {
   paneViews.value = next;
 }
 
-// All edit operations are gated behind SSO + an active traject. SSO gates
-// access to the editor as a whole; the active traject scopes writes to a
-// branch on a corpus source — without it the editor renders read-only and
-// the save handlers return 403. The `requiresAuth` router guard awaits
-// the auth-check before this component mounts so the SSO half of the
-// guard is in practice always true; the traject half can flip at runtime
-// when the user picks a different option from the TrajectMenu.
-const { activeTrajectId, trajectSwitchEpoch } = useTrajects();
+// All edit operations are gated behind SSO + an active traject. The
+// SPA route shape (`/editor/{trajectRef}/{lawId?}`) puts the traject
+// in the URL, so this component cannot mount without one (the router
+// `beforeEnter` redirects bookmark-shaped `/editor/{lawId}` URLs to
+// the library). `canEdit` is therefore effectively just the auth
+// check, but we keep the explicit `activeTrajectRef` guard so an
+// unexpectedly-empty param surfaces as read-only rather than a 500.
+const { activeTrajectRef } = useTrajects();
 const canEdit = computed(
-  () => (!oidcConfigured.value || authenticated.value) && activeTrajectId.value !== null,
+  () => (!oidcConfigured.value || authenticated.value) && activeTrajectRef.value !== null,
 );
 // Tekst-pane is only editable when the user has write access AND the
 // `editor.article_text_edit` flag is on. Visibility of the pane is
@@ -178,13 +179,17 @@ const {
   saveError: lawSaveError,
   saveLaw,
   lastSavedPr,
-} = useLaw(route.params.lawId, route.params.articleNumber);
+} = useLaw(route.params.lawId, route.params.articleNumber, route.params.trajectRef);
 
-// On user-driven traject switch (epoch bump): refresh corpus index and refetch the open law.
-watch(trajectSwitchEpoch, () => {
+// When the active traject changes (router.push to /editor/{otherRef}/…)
+// the URL stays on the same component; refresh the corpus index and
+// re-fetch the open law through the new traject's backends. `switchLaw`
+// crosses trajects too via its third argument so the law cache key
+// stays correct.
+watch(activeTrajectRef, (next) => {
   loadCorpusLaws();
   if (lawId.value) {
-    switchLaw(lawId.value, selectedArticleNumber.value);
+    switchLaw(lawId.value, selectedArticleNumber.value, next);
   }
 });
 
@@ -195,7 +200,7 @@ const {
   loading: notesLoading,
   error: notesError,
   reload: reloadNotes,
-} = useNotes(lawId, selectedArticle);
+} = useNotes(lawId, selectedArticle, activeTrajectRef);
 
 // Notes are a layer over the Tekst pane, not a separate pane. This toggle is
 // the user's "show notes now" preference; panel.notes (a feature flag) is the
@@ -232,7 +237,7 @@ const {
   clearDrafts,
   exportYaml,
   saveToRepo,
-} = useDraftNotes(lawId);
+} = useDraftNotes(lawId, activeTrajectRef);
 const { draftNotesForArticle } = useResolvedDraftNotes(
   draftNotes,
   lawId,
@@ -385,7 +390,7 @@ let corpusLawsGeneration = 0;
 async function loadCorpusLaws() {
   const gen = ++corpusLawsGeneration;
   try {
-    const res = await fetch('/api/corpus/laws?limit=1000');
+    const res = await fetch(lawsListUrl(activeTrajectRef.value, 'limit=1000'));
     if (!res.ok) return;
     if (gen !== corpusLawsGeneration) return; // stale response, discard
     const list = await res.json();
@@ -494,14 +499,19 @@ function saveActiveTab(tab) {
   else localStorage.setItem(ACTIVE_TAB_STORAGE_KEY, JSON.stringify(tab));
 }
 
-// If the user lands on /editor without a lawId, restore the last tab
-// they had open before the refresh.
+// If the user lands on /editor/{trajectRef}/ without a lawId, restore
+// the last tab they had open before the refresh — keeping the same
+// trajectRef they navigated to.
 if (!route.params.lawId) {
   const last = loadSavedActiveTab();
   if (last?.lawId) {
     router.replace({
       name: 'editor',
-      params: { lawId: last.lawId, articleNumber: last.articleNumber || undefined },
+      params: {
+        trajectRef: route.params.trajectRef,
+        lawId: last.lawId,
+        articleNumber: last.articleNumber || undefined,
+      },
     });
   }
 }
@@ -566,20 +576,28 @@ async function selectTab(tab) {
   // navigation the user wants to undo with the back button.
   router.replace({
     name: 'editor',
-    params: { lawId: tab.lawId, articleNumber: tab.articleNumber },
+    params: {
+      trajectRef: route.params.trajectRef,
+      lawId: tab.lawId,
+      articleNumber: tab.articleNumber,
+    },
   });
 }
 
 // Browser back/forward (or any external navigation) — pull state from URL.
 // Local mutations from selectTab already match the destination, so the
 // guards below short-circuit; the work only happens for true URL changes.
-onBeforeRouteUpdate(async (to) => {
+// trajectRef changes go through `watch(activeTrajectRef)` above, which
+// re-fetches the law via the new traject's backends; this guard handles
+// the law/article portion.
+onBeforeRouteUpdate(async (to, from) => {
   const newLawId = to.params.lawId;
   const newArticle = to.params.articleNumber;
+  const trajectChanged = to.params.trajectRef !== from.params.trajectRef;
   if (!newLawId) return;
-  if (newLawId !== lawId.value) {
+  if (newLawId !== lawId.value || trajectChanged) {
     const gen = ++switchGeneration;
-    await switchLaw(newLawId, newArticle);
+    await switchLaw(newLawId, newArticle, to.params.trajectRef || null);
     if (gen !== switchGeneration) return;
     lawNames.value = { ...lawNames.value, [newLawId]: lawName.value };
   } else if (newArticle && String(newArticle) !== String(selectedArticleNumber.value)) {
@@ -604,11 +622,13 @@ function tabDisplayName(tab) {
   return lawNames.value[tab.lawId] || tab.lawId;
 }
 
-// Load lawNames for persisted tabs on startup (parallel, deduplicated)
+// Load lawNames for persisted tabs on startup (parallel, deduplicated).
+// Reads go through the currently-active traject so tab labels match
+// what the editor pane shows after a save.
 const uniqueLawIds = [...new Set(openTabs.value.map(t => t.lawId))];
 Promise.all(uniqueLawIds.map(async (id) => {
   try {
-    const entry = await fetchLaw(id);
+    const entry = await fetchLaw(activeTrajectRef.value, id);
     lawNames.value = { ...lawNames.value, [id]: entry.lawName };
   } catch { /* ignore */ }
 }));
@@ -1690,6 +1710,7 @@ async function handleActionSave() {
                   :dirty="isMachineReadableDirty"
                   :saving="lawSaving"
                   :save-error="machineReadableSaveError"
+                  :traject-ref="activeTrajectRef"
                   @open-action="handleOpenAction"
                   @open-edit="activeEditItem = $event"
                   @init-mr="handleInitMr"
@@ -1737,6 +1758,7 @@ async function handleActionSave() {
                   :engine="getEngine()"
                   :ready="engineReady"
                   :articles="articles"
+                  :traject-ref="activeTrajectRef"
                   @executed="handleScenarioExecuted"
                 />
               </template>
@@ -1812,7 +1834,7 @@ async function handleActionSave() {
   </nldd-app-view>
 
   <ActionSheet :action="activeAction" :article="editedArticle" :editable="canEdit" :is-new="activeActionIsNew" @close="handleActionClose" @save="handleActionSave" />
-  <EditSheet :item="activeEditItem" :article="editedArticle" @save="handleSave" @close="activeEditItem = null" />
+  <EditSheet :item="activeEditItem" :article="editedArticle" :traject-ref="activeTrajectRef" @save="handleSave" @close="activeEditItem = null" />
   <SearchPopover
     ref="searchPopoverRef"
     :laws="corpusLaws"
@@ -1880,6 +1902,7 @@ async function handleActionSave() {
         :result="lastResult"
         :output-name="lastOutputName"
         :expectations="lastExpectations"
+        :traject-ref="activeTrajectRef"
       />
     </nldd-page>
   </nldd-sheet>

--- a/frontend/src/LibraryApp.vue
+++ b/frontend/src/LibraryApp.vue
@@ -9,7 +9,6 @@ import ActionSheet from './components/ActionSheet.vue';
 import SearchPopover from './components/SearchPopover.vue';
 import TrajectMenu from './components/TrajectMenu.vue';
 import { useAuth } from './composables/useAuth.js';
-import { useTrajects } from './composables/useTrajects.js';
 import { lawFetchError } from './composables/useLaw.js';
 import { useFeatureFlags } from './composables/useFeatureFlags.js';
 import { useColorScheme } from './composables/useColorScheme.js';
@@ -462,19 +461,10 @@ if (route.params.lawId) {
 }
 loadIndex();
 
-// On user-driven traject switch (epoch bump): refetch corpus index and the open law.
-const { trajectSwitchEpoch } = useTrajects();
-watch(trajectSwitchEpoch, () => {
-  // Reset error so the loading-gate kicks in before any new 404
-  // (e.g. when the open law isn't part of the new traject's corpus).
-  lawError.value = null;
-  indexError.value = null;
-  loading.value = true;
-  loadIndex();
-  if (selectedLawId.value) {
-    loadLaw(selectedLawId.value);
-  }
-});
+// LibraryApp is the global, no-traject view: it always reads through
+// `/api/corpus/...`. Switching trajects in the TrajectMenu is a route
+// change to `/editor/{ref}/...`, which leaves LibraryApp behind — no
+// in-place refetch needed here.
 </script>
 
 <template>

--- a/frontend/src/components/EditSheet.vue
+++ b/frontend/src/components/EditSheet.vue
@@ -1,10 +1,15 @@
 <script setup>
 import { ref, computed, watch, watchEffect, nextTick } from 'vue';
 import { collectAvailableVariables } from '../utils/operationTree.js';
+import { lawsListUrl } from '../composables/corpusUrls.js';
 
 const props = defineProps({
   item: { type: Object, default: null },
   article: { type: Object, default: null },
+  /** Active traject ref. When set the law search dropdown is scoped to
+   *  the traject's corpus so newly-added laws in this traject can be
+   *  selected as a source. */
+  trajectRef: { type: String, default: null },
 });
 
 const emit = defineEmits(['save', 'close']);
@@ -50,11 +55,19 @@ const paramValueGroups = computed(() => {
 });
 
 // --- Law search / output selection ---
+// Cache scoped per (traject, instance). Resetting on a traject change
+// keeps cross-traject content from leaking when the same sheet is
+// opened again under a different traject.
 let lawsCache = null;
+let lawsCacheTrajectRef = null;
 async function fetchLawsList() {
+  if (lawsCacheTrajectRef !== props.trajectRef) {
+    lawsCache = null;
+    lawsCacheTrajectRef = props.trajectRef;
+  }
   if (lawsCache) return lawsCache;
   try {
-    const res = await fetch('/api/corpus/laws?limit=1000');
+    const res = await fetch(lawsListUrl(props.trajectRef, 'limit=1000'));
     if (!res.ok) return [];
     lawsCache = await res.json();
   } catch {

--- a/frontend/src/components/LawGraphView.vue
+++ b/frontend/src/components/LawGraphView.vue
@@ -18,6 +18,7 @@ import { useLawGraph, rootOfId } from '../composables/useLawGraph.js';
 import { useTraceStepping } from '../composables/useTraceStepping.js';
 import { useColorScheme } from '../composables/useColorScheme.js';
 import { stepHasHighlights } from '../lib/traceEdges.js';
+import { lawUrl } from '../composables/corpusUrls.js';
 
 const props = defineProps({
   lawId: { type: String, default: null },
@@ -29,10 +30,13 @@ const props = defineProps({
   // matching output leaf on the root law.
   outputName: { type: String, default: null },
   expectations: { type: Object, default: () => ({}) },
+  /** Active traject ref — routes dependency reads through the
+   *  traject's backend so the graph mirrors what the editor pane shows. */
+  trajectRef: { type: String, default: null },
 });
 
 async function fetchLawYaml(lawId) {
-  const res = await fetch(`/api/corpus/laws/${encodeURIComponent(lawId)}`);
+  const res = await fetch(lawUrl(props.trajectRef, lawId));
   if (!res.ok) throw new Error(`Law '${lawId}' niet gevonden (${res.status})`);
   return await res.text();
 }

--- a/frontend/src/components/MachineReadable.vue
+++ b/frontend/src/components/MachineReadable.vue
@@ -1,11 +1,9 @@
 <script setup>
-import { computed, ref, watch, nextTick } from 'vue';
+import { computed, ref, toRef, watch, nextTick } from 'vue';
 import { humanize } from '../utils/outputFormat.js';
 import { useCorpusLaws } from '../composables/useCorpusLaws.js';
 import BreakableName from './BreakableName.vue';
 import RowActionsMenu from './RowActionsMenu.vue';
-
-const { displayName: lawDisplayName } = useCorpusLaws();
 
 const props = defineProps({
   article: { type: Object, default: null },
@@ -16,7 +14,12 @@ const props = defineProps({
   saving: { type: Boolean, default: false },
   /** Error from the most recent save attempt (Error instance or null) */
   saveError: { type: Object, default: null },
+  /** Active traject ref — scopes the corpus-laws lookup so display
+   *  names reflect the traject's view (including its in-progress edits). */
+  trajectRef: { type: String, default: null },
 });
+
+const { displayName: lawDisplayName } = useCorpusLaws(toRef(props, 'trajectRef'));
 
 const emit = defineEmits([
   'open-action',

--- a/frontend/src/components/ScenarioBuilder.vue
+++ b/frontend/src/components/ScenarioBuilder.vue
@@ -2,6 +2,7 @@
 import { ref, computed, watch, nextTick } from 'vue';
 import { useDependencies } from '../composables/useDependencies.js';
 import { useScenarios } from '../composables/useScenarios.js';
+import { lawUrl } from '../composables/corpusUrls.js';
 import { parseFeature } from '../gherkin/parser.js';
 import { mapFeatureToForm, getEffectiveSetup, formStateToGherkin, syncEditedValues } from '../gherkin/formMapper.js';
 import { matchStatus, humanize } from '../utils/outputFormat.js';
@@ -15,6 +16,10 @@ const props = defineProps({
   ready: { type: Boolean, default: false },
   /** Articles array from useLaw() for article mapping */
   articles: { type: Array, default: () => [] },
+  /** Active traject ref. Required for scenario writes; reads route
+   *  through the matching traject's backend so a save is visible
+   *  without a corpus reload. */
+  trajectRef: { type: String, default: null },
 });
 
 const emit = defineEmits(['executed', 'dirty-change']);
@@ -32,6 +37,7 @@ const {
 
 // --- Scenario loading ---
 const lawIdRef = computed(() => props.lawId);
+const trajectRefRef = computed(() => props.trajectRef);
 const {
   scenarios: scenarioFiles,
   selectedScenario: selectedScenarioFile,
@@ -41,7 +47,7 @@ const {
   saveError,
   selectScenario: selectScenarioFile,
   saveScenario,
-} = useScenarios(lawIdRef);
+} = useScenarios(lawIdRef, trajectRefRef);
 
 const formState = ref(null);
 const saveSuccess = ref(false);
@@ -125,12 +131,18 @@ watch(featureText, (text) => {
   }
 });
 
-// Cache for fetched law YAML texts
+// Cache for fetched law YAML texts, scoped to the active traject so a
+// traject switch doesn't return the previous traject's body.
 const yamlCache = {};
+let yamlCacheTrajectRef = null;
 
 async function fetchLawYaml(lawId) {
+  if (yamlCacheTrajectRef !== props.trajectRef) {
+    Object.keys(yamlCache).forEach((k) => delete yamlCache[k]);
+    yamlCacheTrajectRef = props.trajectRef;
+  }
   if (yamlCache[lawId]) return yamlCache[lawId];
-  const res = await fetch(`/api/corpus/laws/${encodeURIComponent(lawId)}`);
+  const res = await fetch(lawUrl(props.trajectRef, lawId));
   if (!res.ok) throw new Error(`Failed to fetch law '${lawId}': ${res.status}`);
   const text = await res.text();
   yamlCache[lawId] = text;
@@ -150,7 +162,7 @@ watch(
     const version = ++watchVersion;
     depsReady.value = false;
 
-    await loadAllDependencies(lawYaml, props.engine, fetchLawYaml);
+    await loadAllDependencies(lawYaml, props.engine, fetchLawYaml, props.trajectRef);
     if (version !== watchVersion) return;
 
     // Also load dependencies from scenario background + per-scenario steps

--- a/frontend/src/components/ScenarioGherkin.vue
+++ b/frontend/src/components/ScenarioGherkin.vue
@@ -11,9 +11,11 @@ const props = defineProps({
   engine: { type: Object, default: null },
   ready: { type: Boolean, default: false },
   loadDependency: { type: Function, required: true },
+  trajectRef: { type: String, default: null },
 });
 
 const lawIdRef = computed(() => props.lawId);
+const trajectRefRef = computed(() => props.trajectRef);
 
 const {
   scenarios,
@@ -24,7 +26,7 @@ const {
   saveError,
   selectScenario,
   saveScenario,
-} = useScenarios(lawIdRef);
+} = useScenarios(lawIdRef, trajectRefRef);
 
 const results = ref(null);
 const running = ref(false);

--- a/frontend/src/components/ScenarioPanel.vue
+++ b/frontend/src/components/ScenarioPanel.vue
@@ -7,10 +7,19 @@ import ScenarioGherkin from './ScenarioGherkin.vue';
 const props = defineProps({
   lawId: { type: String, required: true },
   lawYaml: { type: String, default: null },
+  trajectRef: { type: String, default: null },
 });
 
 const mode = ref('form');
 const { ready, initError, initEngine, loadDependency, getEngine } = useEngine();
+
+// Wrap loadDependency so scenario runs pull dependencies through the
+// same traject scope as the current law. Without this the engine
+// would fetch dependencies from the global view and miss any
+// in-progress edits within the traject.
+function loadDependencyInScope(lawId) {
+  return loadDependency(lawId, props.trajectRef || null);
+}
 
 // Initialize the engine on mount
 initEngine().catch(() => {});
@@ -63,6 +72,7 @@ function onModeChange(event) {
           :law-yaml="lawYaml"
           :engine="getEngine()"
           :ready="ready"
+          :traject-ref="trajectRef"
         />
       </KeepAlive>
 
@@ -73,7 +83,8 @@ function onModeChange(event) {
           :law-id="lawId"
           :engine="getEngine()"
           :ready="ready"
-          :load-dependency="loadDependency"
+          :load-dependency="loadDependencyInScope"
+          :traject-ref="trajectRef"
         />
       </KeepAlive>
     </template>

--- a/frontend/src/components/TrajectMenu.vue
+++ b/frontend/src/components/TrajectMenu.vue
@@ -23,28 +23,31 @@ const route = useRoute();
 const router = useRouter();
 
 /**
- * Navigate to a traject — push the user into `/editor/{ref}/{lawId?}`
- * preserving whichever law they were viewing. Per-tab state: a switch
+ * Navigate to a traject — push the user into the traject-scoped
+ * editor at the same law they were viewing. Per-tab state: a switch
  * here only affects this tab, never other open editors.
  */
 async function goToTraject(trajectRef) {
   const lawId = route.params.lawId || undefined;
   const articleNumber = route.params.articleNumber || undefined;
   await router.push({
-    name: 'editor',
+    name: 'editor-traject',
     params: { trajectRef, lawId, articleNumber },
   });
 }
 
 /**
- * Leave traject scope — go to the global library. Keeps the open law
- * in the URL so the user lands on the same law (read-only).
+ * Leave traject scope. Stays in the editor (read-only view) when the
+ * user is currently editing; goes to the library when they were
+ * browsing. Either way the open law is preserved.
  */
-async function goToLibrary() {
+async function leaveTraject() {
   const lawId = route.params.lawId || undefined;
   const articleNumber = route.params.articleNumber || undefined;
+  const inEditor =
+    route.name === 'editor' || route.name === 'editor-traject';
   await router.push({
-    name: 'library',
+    name: inEditor ? 'editor' : 'library',
     params: { lawId, articleNumber },
   });
 }
@@ -107,7 +110,7 @@ function closeCreate() {
 }
 
 async function selectNoTraject() {
-  await goToLibrary();
+  await leaveTraject();
   emit('switched', null);
 }
 

--- a/frontend/src/components/TrajectMenu.vue
+++ b/frontend/src/components/TrajectMenu.vue
@@ -145,7 +145,15 @@ async function submitCreate() {
     });
     showCreate.value = false;
     // Jump straight into the new traject — same per-tab navigation as
-    // selecting from the dropdown.
+    // selecting from the dropdown. Mirror the `selectTraject` guard:
+    // the backend's `create` handler always calls `fill_ref()` so this
+    // shouldn't fire today, but a future refactor that returns a
+    // half-filled `TrajectSummary` would otherwise navigate to
+    // `/editor/undefined/...` and silently no-op.
+    if (!created.ref) {
+      console.warn('TrajectMenu: created traject has no ref', created);
+      return;
+    }
     await goToTraject(created.ref);
     emit('switched', created.ref);
   } catch (e) {

--- a/frontend/src/components/TrajectMenu.vue
+++ b/frontend/src/components/TrajectMenu.vue
@@ -115,6 +115,16 @@ async function selectNoTraject() {
 }
 
 async function selectTraject(t) {
+  // `t.ref` is a server-supplied `Option<String>` and serialises to
+  // `null` when a `TrajectSummary` is built without calling
+  // `fill_ref()`. Refuse to navigate — silently routing to
+  // `/editor/null/...` would just bounce off the trajectRef regex
+  // and confuse the user. Treat as a programming error on the
+  // backend side, log and bail.
+  if (!t.ref) {
+    console.warn('TrajectMenu: traject has no ref', t);
+    return;
+  }
   if (t.ref === activeTrajectRef.value) return;
   await goToTraject(t.ref);
   emit('switched', t.ref);

--- a/frontend/src/components/TrajectMenu.vue
+++ b/frontend/src/components/TrajectMenu.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { computed, nextTick, ref, watch } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
 import { useTrajects } from '../composables/useTrajects.js';
 import TrajectMembersDialog from './TrajectMembersDialog.vue';
 
@@ -13,12 +14,40 @@ const emit = defineEmits(['switched']);
 
 const {
   trajects,
-  activeTrajectId,
+  activeTrajectRef,
   activeTraject,
   loading,
-  switchTraject,
   createTraject,
 } = useTrajects();
+const route = useRoute();
+const router = useRouter();
+
+/**
+ * Navigate to a traject — push the user into `/editor/{ref}/{lawId?}`
+ * preserving whichever law they were viewing. Per-tab state: a switch
+ * here only affects this tab, never other open editors.
+ */
+async function goToTraject(trajectRef) {
+  const lawId = route.params.lawId || undefined;
+  const articleNumber = route.params.articleNumber || undefined;
+  await router.push({
+    name: 'editor',
+    params: { trajectRef, lawId, articleNumber },
+  });
+}
+
+/**
+ * Leave traject scope — go to the global library. Keeps the open law
+ * in the URL so the user lands on the same law (read-only).
+ */
+async function goToLibrary() {
+  const lawId = route.params.lawId || undefined;
+  const articleNumber = route.params.articleNumber || undefined;
+  await router.push({
+    name: 'library',
+    params: { lawId, articleNumber },
+  });
+}
 
 const menuBtnId = computed(() => `traject-menu-btn-${props.idSuffix}`);
 const menuId = computed(() => `traject-menu-${props.idSuffix}`);
@@ -78,14 +107,14 @@ function closeCreate() {
 }
 
 async function selectNoTraject() {
-  await switchTraject(null);
+  await goToLibrary();
   emit('switched', null);
 }
 
-async function selectTraject(id) {
-  if (id === activeTrajectId.value) return;
-  await switchTraject(id);
-  emit('switched', id);
+async function selectTraject(t) {
+  if (t.ref === activeTrajectRef.value) return;
+  await goToTraject(t.ref);
+  emit('switched', t.ref);
 }
 
 async function submitCreate() {
@@ -102,7 +131,10 @@ async function submitCreate() {
       scope: form.value.scope,
     });
     showCreate.value = false;
-    emit('switched', created.id);
+    // Jump straight into the new traject — same per-tab navigation as
+    // selecting from the dropdown.
+    await goToTraject(created.ref);
+    emit('switched', created.ref);
   } catch (e) {
     createError.value = e.message || 'Aanmaken mislukt';
   } finally {
@@ -131,7 +163,7 @@ function bind(field) {
   <nldd-menu :id="menuId" :anchor="menuBtnId">
     <nldd-menu-item
       type="radio"
-      :selected="activeTrajectId === null || undefined"
+      :selected="activeTrajectRef === null || undefined"
       text="Geen traject"
       @select="selectNoTraject"
     ></nldd-menu-item>
@@ -140,9 +172,9 @@ function bind(field) {
       v-for="t in trajects"
       :key="t.id"
       type="radio"
-      :selected="t.id === activeTrajectId || undefined"
+      :selected="t.ref === activeTrajectRef || undefined"
       :text="`${t.name}${t.status === 'afgerond' ? ' (afgerond)' : ''}`"
-      @select="selectTraject(t.id)"
+      @select="selectTraject(t)"
     ></nldd-menu-item>
     <nldd-menu-divider></nldd-menu-divider>
     <nldd-menu-item

--- a/frontend/src/composables/corpusUrls.js
+++ b/frontend/src/composables/corpusUrls.js
@@ -37,12 +37,6 @@ export function annotationsUrl(trajectRef, lawId) {
   return `${lawUrl(trajectRef, lawId)}/annotations`;
 }
 
-export function sourcesUrl(trajectRef) {
-  return trajectRef
-    ? `/api/trajects/${encodeURIComponent(trajectRef)}/sources`
-    : `/api/sources`;
-}
-
 // Writes only exist under the traject prefix. Composables call this at
 // the top of their save function so the call-stack failure is "no
 // traject" instead of a malformed URL.

--- a/frontend/src/composables/corpusUrls.js
+++ b/frontend/src/composables/corpusUrls.js
@@ -1,0 +1,53 @@
+// Centralised URL builders for the editor's corpus endpoints. The two
+// shapes — global (`/api/corpus/...`, read-only) and traject-scoped
+// (`/api/trajects/{ref}/corpus/...`, read + write) — are picked by
+// whether a traject ref is present at call time. Putting the choice in
+// one place keeps composables aligned and prevents the pattern from
+// drifting per file.
+//
+// The `trajectRef` is the URL-form identifier `{slug}-{8hex}` returned
+// by the backend on `t.ref`. The backend resolves it back to a UUID via
+// `resolve_traject_ref` — frontend code never needs to know the UUID
+// shape, only the ref string.
+
+function corpusBase(trajectRef) {
+  return trajectRef
+    ? `/api/trajects/${encodeURIComponent(trajectRef)}/corpus`
+    : `/api/corpus`;
+}
+
+export function lawUrl(trajectRef, lawId) {
+  return `${corpusBase(trajectRef)}/laws/${encodeURIComponent(lawId)}`;
+}
+
+export function lawsListUrl(trajectRef, query = '') {
+  const q = query ? `?${query}` : '';
+  return `${corpusBase(trajectRef)}/laws${q}`;
+}
+
+export function scenariosListUrl(trajectRef, lawId) {
+  return `${lawUrl(trajectRef, lawId)}/scenarios`;
+}
+
+export function scenarioFileUrl(trajectRef, lawId, filename) {
+  return `${scenariosListUrl(trajectRef, lawId)}/${encodeURIComponent(filename)}`;
+}
+
+export function annotationsUrl(trajectRef, lawId) {
+  return `${lawUrl(trajectRef, lawId)}/annotations`;
+}
+
+export function sourcesUrl(trajectRef) {
+  return trajectRef
+    ? `/api/trajects/${encodeURIComponent(trajectRef)}/sources`
+    : `/api/sources`;
+}
+
+// Writes only exist under the traject prefix. Composables call this at
+// the top of their save function so the call-stack failure is "no
+// traject" instead of a malformed URL.
+export function requireTraject(trajectRef, op = 'this operation') {
+  if (!trajectRef) {
+    throw new Error(`Cannot perform ${op} without an active traject`);
+  }
+}

--- a/frontend/src/composables/useCorpusLaws.js
+++ b/frontend/src/composables/useCorpusLaws.js
@@ -19,6 +19,14 @@ import { lawsListUrl } from './corpusUrls.js';
 // so the gap is visible rather than silently broken.
 const FETCH_LIMIT = 1000;
 
+// LRU cap on the per-scope caches. Without one a long session that
+// hops between many trajects accumulates one entry per scope forever.
+// 5 is enough to cover the global view + a handful of recently-used
+// trajects without thrashing. `Map` preserves insertion order, so the
+// oldest key is always the first; touching a key (re-adding via
+// `delete` + `set`) bumps it to the most-recent position.
+const SCOPE_CACHE_MAX = 5;
+
 const lawsByScope = new Map(); // scopeKey -> Ref<Array>
 const fetchByScope = new Map(); // scopeKey -> Promise
 
@@ -26,10 +34,27 @@ function scopeKey(trajectRef) {
   return trajectRef || '';
 }
 
+function touchScope(key) {
+  // Re-insert to mark as most recently used, then evict the oldest if
+  // the cap is exceeded. The global scope (`''`) follows the same
+  // rules — that's fine because it just gets re-fetched on demand.
+  if (lawsByScope.has(key)) {
+    const v = lawsByScope.get(key);
+    lawsByScope.delete(key);
+    lawsByScope.set(key, v);
+  }
+  while (lawsByScope.size > SCOPE_CACHE_MAX) {
+    const oldest = lawsByScope.keys().next().value;
+    lawsByScope.delete(oldest);
+    fetchByScope.delete(oldest);
+  }
+}
+
 function ensureFetched(trajectRef) {
   const key = scopeKey(trajectRef);
   if (fetchByScope.has(key)) return fetchByScope.get(key);
   if (!lawsByScope.has(key)) lawsByScope.set(key, ref([]));
+  touchScope(key);
   const lawsRef = lawsByScope.get(key);
   const p = fetch(lawsListUrl(trajectRef, `limit=${FETCH_LIMIT}`))
     .then(r => {

--- a/frontend/src/composables/useCorpusLaws.js
+++ b/frontend/src/composables/useCorpusLaws.js
@@ -1,16 +1,15 @@
-import { ref, computed } from 'vue';
+import { ref, computed, watch } from 'vue';
+import { lawsListUrl } from './corpusUrls.js';
 
 /**
- * Shared corpus-laws list. The `/api/corpus/laws` payload is small (~kb) and
- * stable per page-load, so we fetch once and reuse across components that
- * need to resolve a law_id to its human name (Bron-regelgeving combo-box,
- * MachineReadable input rows, etc.).
+ * Shared corpus-laws list, scoped by the active traject. Each distinct
+ * traject (and the global view) gets its own cached payload — switching
+ * trajects routes through the corresponding `/api/trajects/{ref}/corpus/laws`
+ * endpoint without losing the previous traject's data on rebound.
  *
- * Module-level state — every consumer sees the same list/promise.
+ * Module-level state — every consumer for the same `trajectRef` shares
+ * the same list/promise.
  */
-
-const laws = ref([]);
-let fetchPromise = null;
 
 // Backend hard-caps `?limit` at 1000 (see editor-api/corpus_handlers.rs
 // MAX_LIMIT). With the current curated Test Corpus this is far above
@@ -20,34 +19,41 @@ let fetchPromise = null;
 // so the gap is visible rather than silently broken.
 const FETCH_LIMIT = 1000;
 
-function ensureFetched() {
-  if (fetchPromise) return fetchPromise;
-  fetchPromise = fetch(`/api/corpus/laws?limit=${FETCH_LIMIT}`)
+const lawsByScope = new Map(); // scopeKey -> Ref<Array>
+const fetchByScope = new Map(); // scopeKey -> Promise
+
+function scopeKey(trajectRef) {
+  return trajectRef || '';
+}
+
+function ensureFetched(trajectRef) {
+  const key = scopeKey(trajectRef);
+  if (fetchByScope.has(key)) return fetchByScope.get(key);
+  if (!lawsByScope.has(key)) lawsByScope.set(key, ref([]));
+  const lawsRef = lawsByScope.get(key);
+  const p = fetch(lawsListUrl(trajectRef, `limit=${FETCH_LIMIT}`))
     .then(r => {
-      // Throw on non-ok so the catch below resets fetchPromise — otherwise
-      // a transient 500/404 at first call would lock us into the empty-list
-      // fallback for the rest of the session, since later useCorpusLaws()
-      // calls would see the (already-resolved) promise and skip refetch.
       if (!r.ok) throw new Error(`HTTP ${r.status}`);
       return r.json();
     })
     .then(list => {
-      laws.value = Array.isArray(list) ? list : [];
-      if (laws.value.length >= FETCH_LIMIT) {
+      lawsRef.value = Array.isArray(list) ? list : [];
+      if (lawsRef.value.length >= FETCH_LIMIT) {
         console.warn(
           `useCorpusLaws: hit the ${FETCH_LIMIT}-law cap — laws beyond this won't resolve to display names. ` +
           `Pagination needs to be added if the corpus has grown past ${FETCH_LIMIT} entries.`,
         );
       }
-      return laws.value;
+      return lawsRef.value;
     })
     .catch(() => {
-      laws.value = [];
+      lawsRef.value = [];
       // Reset so the next consumer mount triggers a fresh fetch.
-      fetchPromise = null;
+      fetchByScope.delete(key);
       return [];
     });
-  return fetchPromise;
+  fetchByScope.set(key, p);
+  return p;
 }
 
 /**
@@ -59,8 +65,37 @@ function fallbackName(lawId) {
   return lawId.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
 }
 
-export function useCorpusLaws() {
-  ensureFetched();
+/**
+ * @param {import('vue').Ref<string|null>=} trajectRef Optional active
+ *   traject reference. Without it the global view is used.
+ */
+export function useCorpusLaws(trajectRef) {
+  const refSource = trajectRef && 'value' in trajectRef
+    ? trajectRef
+    : ref(trajectRef ?? null);
+  const laws = ref([]);
+
+  watch(
+    refSource,
+    (current) => {
+      const key = scopeKey(current);
+      ensureFetched(current);
+      laws.value = lawsByScope.get(key)?.value ?? [];
+      // Re-sync once the in-flight promise resolves: the initial
+      // assignment above only sees the cached value (empty on a miss).
+      const p = fetchByScope.get(key);
+      if (p) {
+        p.then(() => {
+          // Only commit if this is still the active scope by the time
+          // the fetch resolves — avoids a cross-scope late write.
+          if (scopeKey(refSource.value) === key) {
+            laws.value = lawsByScope.get(key)?.value ?? [];
+          }
+        });
+      }
+    },
+    { immediate: true },
+  );
 
   const lawsById = computed(() => {
     const map = new Map();

--- a/frontend/src/composables/useCorpusLaws.js
+++ b/frontend/src/composables/useCorpusLaws.js
@@ -125,16 +125,22 @@ export function useCorpusLaws(trajectRef) {
     (current) => {
       const key = scopeKey(current);
       ensureFetched(current);
-      laws.value = lawsByScope.get(key)?.value ?? [];
-      // Re-sync once the in-flight promise resolves: the initial
-      // assignment above only sees the cached value (empty on a miss).
+      // Capture the underlying Ref BEFORE attaching the .then. If
+      // the LRU evicts `key` while its fetch is still in flight
+      // (6+ distinct scopes hit during the window), a later
+      // `lawsByScope.get(key)?.value` would return `undefined` and
+      // we'd silently set `laws.value = []` instead of the
+      // fetched list. The closure over `capturedRef` keeps the
+      // populated ref reachable even after the map entry is gone.
+      const capturedRef = lawsByScope.get(key);
+      laws.value = capturedRef?.value ?? [];
       const p = fetchByScope.get(key);
-      if (p) {
+      if (p && capturedRef) {
         p.then(() => {
           // Only commit if this is still the active scope by the time
           // the fetch resolves — avoids a cross-scope late write.
           if (scopeKey(refSource.value) === key) {
-            laws.value = lawsByScope.get(key)?.value ?? [];
+            laws.value = capturedRef.value;
           }
         });
       }

--- a/frontend/src/composables/useCorpusLaws.js
+++ b/frontend/src/composables/useCorpusLaws.js
@@ -52,7 +52,15 @@ function touchScope(key) {
 
 function ensureFetched(trajectRef) {
   const key = scopeKey(trajectRef);
-  if (fetchByScope.has(key)) return fetchByScope.get(key);
+  if (fetchByScope.has(key)) {
+    // Cache hit: touch so the LRU treats this access as recent.
+    // Without this an often-accessed scope can be evicted before a
+    // genuinely-stale one that happened to be added more recently —
+    // the invariant "most recently used is kept" only holds if the
+    // touch runs on every access, not just on miss.
+    touchScope(key);
+    return fetchByScope.get(key);
+  }
   if (!lawsByScope.has(key)) lawsByScope.set(key, ref([]));
   touchScope(key);
   const lawsRef = lawsByScope.get(key);

--- a/frontend/src/composables/useCorpusLaws.js
+++ b/frontend/src/composables/useCorpusLaws.js
@@ -103,6 +103,18 @@ function fallbackName(lawId) {
  *   traject reference. Without it the global view is used.
  */
 export function useCorpusLaws(trajectRef) {
+  // A plain string passed here gets silently wrapped in a static
+  // `ref(value)` that never reacts to the caller's scope changes —
+  // which would look like "the corpus list is stuck" without any
+  // error. All current callers pass a `Ref` (via `toRef(props, ...)`
+  // or `computed`); a dev-mode warning catches future misuses before
+  // they ship as a silent regression.
+  if (trajectRef !== undefined && trajectRef !== null && !('value' in trajectRef)) {
+    console.warn(
+      'useCorpusLaws: trajectRef should be a Ref, got plain value — list will not react to scope changes',
+      trajectRef,
+    );
+  }
   const refSource = trajectRef && 'value' in trajectRef
     ? trajectRef
     : ref(trajectRef ?? null);

--- a/frontend/src/composables/useDependencies.js
+++ b/frontend/src/composables/useDependencies.js
@@ -8,6 +8,7 @@
 import { ref } from 'vue';
 import yaml from 'js-yaml';
 import { useBwbHarvest } from './useBwbHarvest.js';
+import { lawsListUrl } from './corpusUrls.js';
 
 /**
  * Extract all unique `source.regulation` references from a parsed law object.
@@ -97,8 +98,11 @@ export function useDependencies() {
    * @param {string} lawYamlText - Raw YAML text of the main law
    * @param {object} engine - WasmEngine instance
    * @param {(lawId: string) => Promise<string>} fetchLawYaml - Fetch law YAML by ID
+   * @param {string|null} trajectRef - Active traject reference. Drives
+   *   which corpus list is scanned for implementing regulations so
+   *   in-progress trajects pick up their own implementors.
    */
-  async function loadAllDependencies(lawYamlText, engine, fetchLawYaml) {
+  async function loadAllDependencies(lawYamlText, engine, fetchLawYaml, trajectRef = null) {
     loading.value = true;
     error.value = null;
     loadedDeps.value = [];
@@ -114,7 +118,7 @@ export function useDependencies() {
 
       // Phase 2: Discover implementing regulations
       try {
-        const corpusRes = await fetch('/api/corpus/laws?limit=1000');
+        const corpusRes = await fetch(lawsListUrl(trajectRef, 'limit=1000'));
         if (corpusRes.ok) {
           const allLaws = await corpusRes.json();
 

--- a/frontend/src/composables/useDraftNotes.js
+++ b/frontend/src/composables/useDraftNotes.js
@@ -15,6 +15,7 @@
 import { ref, computed, watch } from 'vue';
 import yaml from 'js-yaml';
 import { lastSavedPr, sanitizeSavedPr } from './useEditorSession.js';
+import { annotationsUrl, requireTraject } from './corpusUrls.js';
 
 const STORAGE_PREFIX = 'regelrecht-draft-notes:';
 
@@ -43,8 +44,11 @@ function persist(lawId, list) {
 
 /**
  * @param {import('vue').Ref<string>} lawId reactive law $id
+ * @param {import('vue').Ref<string|null>=} trajectRef active traject
+ *   reference. Required for `saveToRepo`; drafts themselves live in
+ *   localStorage and don't care about the scope.
  */
-export function useDraftNotes(lawId) {
+export function useDraftNotes(lawId, trajectRef) {
   const drafts = ref(loadFor(lawId.value));
 
   // Re-read from storage whenever the law changes. A real watch (not a lazy
@@ -167,11 +171,13 @@ export function useDraftNotes(lawId) {
    */
   async function saveToRepo() {
     const id = lawId.value;
+    const tr = trajectRef?.value ?? null;
+    requireTraject(tr, 'notes save');
     // Snapshot drafts BEFORE any await (watch(lawId) swaps drafts.value on
     // a law switch). Strip the internal __draft marker; the backend gets
     // clean W3C Annotation objects.
     const newNotes = drafts.value.map(stripDraftMarker);
-    const url = `/api/corpus/laws/${encodeURIComponent(id)}/annotations`;
+    const url = annotationsUrl(tr, id);
     const res = await fetch(url, {
       method: 'PUT',
       headers: {

--- a/frontend/src/composables/useDraftNotes.test.js
+++ b/frontend/src/composables/useDraftNotes.test.js
@@ -137,6 +137,12 @@ function stubSave(putResponse) {
 }
 
 describe('useDraftNotes.saveToRepo', () => {
+  // Traject ref used across these saveToRepo tests — must look like
+  // `{slug}-{8hex}` so the URL builder produces the canonical shape and
+  // the assertions stay stable.
+  const TRAJECT_REF = 'tarief-2026-3f4a8b2c';
+  const TRAJECT_ROUTE = `/api/trajects/${TRAJECT_REF}`;
+
   beforeEach(() => {
     lastSavedPr.value = null;
   });
@@ -148,18 +154,21 @@ describe('useDraftNotes.saveToRepo', () => {
         pr: { url: 'https://github.com/x/y/pull/7', number: 7, branch: 'b' },
       }),
     });
-    const { addDraft, saveToRepo, drafts } = useDraftNotes(ref('zorgtoeslagwet'));
+    const { addDraft, saveToRepo, drafts } = useDraftNotes(
+      ref('zorgtoeslagwet'),
+      ref(TRAJECT_REF),
+    );
     addDraft({ ...NOTE, __draft: true });
 
     await saveToRepo();
 
     expect(globalThis.fetch).toHaveBeenCalledTimes(1);
     const [url, opts] = globalThis.fetch.mock.calls[0];
-    expect(url).toBe('/api/corpus/laws/zorgtoeslagwet/annotations');
+    expect(url).toBe(`${TRAJECT_ROUTE}/corpus/laws/zorgtoeslagwet/annotations`);
     expect(opts.method).toBe('PUT');
     expect(opts.headers['Content-Type']).toBe('application/json');
-    // No X-Editor-Session: the traject is implicit in the session cookie
-    // (same as law/scenario saves since #632).
+    // No X-Editor-Session: the traject is explicit in the URL path, not
+    // a session header.
     expect(opts.headers['X-Editor-Session']).toBeUndefined();
     const sent = JSON.parse(opts.body);
     expect(Array.isArray(sent)).toBe(true);
@@ -174,18 +183,37 @@ describe('useDraftNotes.saveToRepo', () => {
     });
   });
 
-  it('never appends a ?source= query — the traject decides the target', async () => {
+  it('uses the traject path; ignores any spurious source argument', async () => {
     stubSave({ ok: true, json: async () => ({ pr: null }) });
-    const { addDraft, saveToRepo } = useDraftNotes(ref('zorgtoeslagwet'));
+    const { addDraft, saveToRepo } = useDraftNotes(
+      ref('zorgtoeslagwet'),
+      ref(TRAJECT_REF),
+    );
     addDraft({ ...NOTE, __draft: true });
 
-    // saveToRepo takes no source argument anymore; even if one is passed
-    // it must not leak into the URL.
+    // saveToRepo takes no source argument; passing one must not leak
+    // into the URL.
     await saveToRepo('amsterdam');
 
     expect(globalThis.fetch.mock.calls[0][0]).toBe(
-      '/api/corpus/laws/zorgtoeslagwet/annotations',
+      `${TRAJECT_ROUTE}/corpus/laws/zorgtoeslagwet/annotations`,
     );
+  });
+
+  it('throws "no active traject" when called without a traject ref', async () => {
+    // Per-tab traject lives in the URL; an editor session without one
+    // has no business calling saveToRepo. The thrown shape matches the
+    // requireTraject helper so the editor surfaces a clear error.
+    stubSave({ ok: true, json: async () => ({ pr: null }) });
+    const { addDraft, saveToRepo, drafts } = useDraftNotes(
+      ref('zorgtoeslagwet'),
+      ref(null),
+    );
+    addDraft({ ...NOTE, __draft: true });
+
+    await expect(saveToRepo()).rejects.toThrow(/active traject/);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(drafts.value).toHaveLength(1);
   });
 
   it('keeps the existing PR badge on a NoChange re-save', async () => {
@@ -194,7 +222,10 @@ describe('useDraftNotes.saveToRepo', () => {
     // so the UI can say "already saved" instead of looking like loss.
     lastSavedPr.value = { url: 'https://github.com/x/y/pull/3', number: 3, branch: 'b' };
     stubSave({ ok: true, json: async () => ({ pr: null, no_change: true }) });
-    const { addDraft, saveToRepo, drafts } = useDraftNotes(ref('w'));
+    const { addDraft, saveToRepo, drafts } = useDraftNotes(
+      ref('w'),
+      ref(TRAJECT_REF),
+    );
     addDraft({ ...NOTE, __draft: true });
 
     const result = await saveToRepo();
@@ -218,7 +249,10 @@ describe('useDraftNotes.saveToRepo', () => {
       headers: { get: () => 'text/plain; charset=utf-8' },
       text: async () => 'Notes are not valid against the annotation schema',
     });
-    const { addDraft, saveToRepo, drafts } = useDraftNotes(ref('w'));
+    const { addDraft, saveToRepo, drafts } = useDraftNotes(
+      ref('w'),
+      ref(TRAJECT_REF),
+    );
     addDraft({ ...NOTE, __draft: true });
 
     await expect(saveToRepo()).rejects.toThrow(/not valid against/);
@@ -233,7 +267,7 @@ describe('useDraftNotes.saveToRepo', () => {
       () => new Promise((r) => { resolvePut = r; }),
     );
     const lawId = ref('lawA');
-    const { addDraft, saveToRepo, drafts } = useDraftNotes(lawId);
+    const { addDraft, saveToRepo, drafts } = useDraftNotes(lawId, ref(TRAJECT_REF));
     addDraft({ ...NOTE, __draft: true }); // a draft on lawA
 
     const p = saveToRepo(); // snapshots id = 'lawA'

--- a/frontend/src/composables/useEngine.js
+++ b/frontend/src/composables/useEngine.js
@@ -14,7 +14,26 @@ let initPromise = null;
 // would see whichever copy happened to be loaded first — switching
 // trajects then runs scenarios against a stale dependency. Keyed by
 // `lawId`, value is the `trajectRef || ''` the load used.
+//
+// LRU-capped. In practice `unloadAllLaws()` already clears the map on
+// every traject switch, so the map only grows within one traject's
+// session. The cap is a safety net for any future code path that
+// loads a dependency without going through `unloadAllLaws` on scope
+// change. Cap mirrors `lawCache`'s order of magnitude (`useLaw.js`).
+const LOADED_SCOPES_MAX = 50;
 const loadedScopes = new Map();
+
+function touchLoadedScopes(lawId) {
+  if (loadedScopes.has(lawId)) {
+    const v = loadedScopes.get(lawId);
+    loadedScopes.delete(lawId);
+    loadedScopes.set(lawId, v);
+  }
+  while (loadedScopes.size > LOADED_SCOPES_MAX) {
+    const oldest = loadedScopes.keys().next().value;
+    loadedScopes.delete(oldest);
+  }
+}
 
 const ready = ref(false);
 const initError = ref(null);
@@ -71,6 +90,7 @@ async function loadDependency(lawId, trajectRef = null) {
   const yaml = await res.text();
   engine.loadLaw(yaml);
   loadedScopes.set(lawId, scope);
+  touchLoadedScopes(lawId);
 }
 
 /**
@@ -88,7 +108,10 @@ async function loadLawYaml(yaml, lawId = null, trajectRef = null) {
   const engine = await initEngine();
   if (lawId && engine.hasLaw(lawId)) engine.unloadLaw(lawId);
   const result = engine.loadLaw(yaml);
-  if (lawId) loadedScopes.set(lawId, trajectRef || '');
+  if (lawId) {
+    loadedScopes.set(lawId, trajectRef || '');
+    touchLoadedScopes(lawId);
+  }
   return result;
 }
 

--- a/frontend/src/composables/useEngine.js
+++ b/frontend/src/composables/useEngine.js
@@ -9,6 +9,13 @@ import { lawUrl } from './corpusUrls.js';
 let engineInstance = null;
 let initPromise = null;
 
+// Per-law tracking of which traject scope a YAML was loaded under. The
+// WASM engine itself only knows law id, so without this every scope
+// would see whichever copy happened to be loaded first — switching
+// trajects then runs scenarios against a stale dependency. Keyed by
+// `lawId`, value is the `trajectRef || ''` the load used.
+const loadedScopes = new Map();
+
 const ready = ref(false);
 const initError = ref(null);
 
@@ -46,23 +53,70 @@ async function initEngine() {
  * `trajectRef` is given the read goes through the traject's per-source
  * backends (read-your-writes for in-progress edits); omit it for the
  * global view.
+ *
+ * If the law was previously loaded under a *different* scope, unload
+ * the stale copy first — otherwise scenario runs after a traject
+ * switch would evaluate against the previous scope's dependencies.
  */
 async function loadDependency(lawId, trajectRef = null) {
   const engine = await initEngine();
-  if (engine.hasLaw(lawId)) return;
+  const scope = trajectRef || '';
+  if (engine.hasLaw(lawId)) {
+    if (loadedScopes.get(lawId) === scope) return;
+    engine.unloadLaw(lawId);
+  }
 
   const res = await fetch(lawUrl(trajectRef, lawId));
   if (!res.ok) throw new Error(`Failed to fetch law '${lawId}': ${res.status}`);
   const yaml = await res.text();
   engine.loadLaw(yaml);
+  loadedScopes.set(lawId, scope);
 }
 
 /**
- * Load a law YAML string into the engine.
+ * Load a law YAML string into the engine and remember which scope it
+ * came from. Callers that pass a raw YAML body (i.e. an edited law
+ * being saved through the editor) should pass the scope they fetched
+ * it under so a later `loadDependency` call doesn't think a copy from
+ * another scope is still valid.
+ *
+ * Re-loads (same `lawId`) unload the previous copy first so the
+ * engine sees the new YAML — `engine.loadLaw` on a known id is a no-op
+ * in the WASM binding.
  */
-async function loadLawYaml(yaml) {
+async function loadLawYaml(yaml, lawId = null, trajectRef = null) {
   const engine = await initEngine();
-  return engine.loadLaw(yaml);
+  if (lawId && engine.hasLaw(lawId)) engine.unloadLaw(lawId);
+  const result = engine.loadLaw(yaml);
+  if (lawId) loadedScopes.set(lawId, trajectRef || '');
+  return result;
+}
+
+/**
+ * Unload a law from the engine and forget its scope. Used when a
+ * traject switch needs to flush a known dependency so the next
+ * resolver call re-fetches from the new scope.
+ */
+function unloadLaw(lawId) {
+  if (!engineInstance) return;
+  if (engineInstance.hasLaw(lawId)) engineInstance.unloadLaw(lawId);
+  loadedScopes.delete(lawId);
+}
+
+/**
+ * Unload every law the engine has tracked. Cheaper than rebuilding
+ * the engine on every traject switch in the editor, and good enough
+ * because the dependency walker re-loads on demand.
+ */
+function unloadAllLaws() {
+  if (!engineInstance) {
+    loadedScopes.clear();
+    return;
+  }
+  for (const lawId of loadedScopes.keys()) {
+    if (engineInstance.hasLaw(lawId)) engineInstance.unloadLaw(lawId);
+  }
+  loadedScopes.clear();
 }
 
 export function useEngine() {
@@ -77,6 +131,10 @@ export function useEngine() {
     loadDependency,
     /** Load raw YAML into the engine */
     loadLawYaml,
+    /** Unload a single law from the engine */
+    unloadLaw,
+    /** Unload every tracked law — used on traject switch to flush stale deps */
+    unloadAllLaws,
     /** Get the engine instance (must be initialized first) */
     getEngine: () => engineInstance,
   };

--- a/frontend/src/composables/useEngine.js
+++ b/frontend/src/composables/useEngine.js
@@ -4,6 +4,7 @@
  * Provides the engine and helpers for loading laws and dependencies.
  */
 import { ref } from 'vue';
+import { lawUrl } from './corpusUrls.js';
 
 let engineInstance = null;
 let initPromise = null;
@@ -41,13 +42,16 @@ async function initEngine() {
 }
 
 /**
- * Fetch law YAML from the API and load it into the engine.
+ * Fetch law YAML from the API and load it into the engine. When
+ * `trajectRef` is given the read goes through the traject's per-source
+ * backends (read-your-writes for in-progress edits); omit it for the
+ * global view.
  */
-async function loadDependency(lawId) {
+async function loadDependency(lawId, trajectRef = null) {
   const engine = await initEngine();
   if (engine.hasLaw(lawId)) return;
 
-  const res = await fetch(`/api/corpus/laws/${encodeURIComponent(lawId)}`);
+  const res = await fetch(lawUrl(trajectRef, lawId));
   if (!res.ok) throw new Error(`Failed to fetch law '${lawId}': ${res.status}`);
   const yaml = await res.text();
   engine.loadLaw(yaml);

--- a/frontend/src/composables/useEngine.js
+++ b/frontend/src/composables/useEngine.js
@@ -31,6 +31,14 @@ function touchLoadedScopes(lawId) {
   }
   while (loadedScopes.size > LOADED_SCOPES_MAX) {
     const oldest = loadedScopes.keys().next().value;
+    // Drop the WASM-side copy alongside the tracking entry — without
+    // this the engine retains the law in memory even though our
+    // scope-tracking forgot it, defeating the whole "safety net" of
+    // the cap. `hasLaw` guards an unloadLaw call that the engine
+    // would otherwise panic on if the law is already gone.
+    if (engineInstance?.hasLaw(oldest)) {
+      engineInstance.unloadLaw(oldest);
+    }
     loadedScopes.delete(oldest);
   }
 }

--- a/frontend/src/composables/useLastVisitedRoute.js
+++ b/frontend/src/composables/useLastVisitedRoute.js
@@ -37,4 +37,10 @@ export function recordLastVisited(routeName, fullPath) {
 }
 
 export const lastLibraryPath = computed(() => _lastVisited.value.library ?? '/library');
-export const lastEditorPath = computed(() => _lastVisited.value.editor ?? '/editor');
+
+// `/editor` (no traject) is the read-only editor. The first visit
+// lands there; subsequent visits restore the last-seen editor URL,
+// which may include `:trajectRef` if the user picked a traject.
+export const lastEditorPath = computed(
+  () => _lastVisited.value.editor ?? _lastVisited.value['editor-traject'] ?? '/editor',
+);

--- a/frontend/src/composables/useLastVisitedRoute.js
+++ b/frontend/src/composables/useLastVisitedRoute.js
@@ -27,20 +27,31 @@ function save() {
   }
 }
 
+// Normalise the editor's two route names — `editor` (read-only, no
+// trajectRef) and `editor-traject` (full edit) — to a single
+// `editor` storage key. Either way it's "the editor tab" semantically;
+// keeping them separate would mean a `??` fallback chain has to pick a
+// winner regardless of which was visited more recently. With one
+// shared key, the last write wins by definition.
+function storageKeyFor(routeName) {
+  return routeName === 'editor-traject' ? 'editor' : routeName;
+}
+
 export function recordLastVisited(routeName, fullPath) {
   if (!routeName) return;
   // Mutate in place rather than re-spreading. The ref wraps a reactive
   // object so a property assignment still notifies the lastLibraryPath /
   // lastEditorPath computeds. Avoids GC churn if the section list grows.
-  _lastVisited.value[routeName] = fullPath;
+  _lastVisited.value[storageKeyFor(routeName)] = fullPath;
   save();
 }
 
 export const lastLibraryPath = computed(() => _lastVisited.value.library ?? '/library');
 
 // `/editor` (no traject) is the read-only editor. The first visit
-// lands there; subsequent visits restore the last-seen editor URL,
-// which may include `:trajectRef` if the user picked a traject.
+// lands there; subsequent visits restore the most-recently-seen
+// editor URL — read-only OR traject-scoped, whichever the user was on
+// last.
 export const lastEditorPath = computed(
-  () => _lastVisited.value.editor ?? _lastVisited.value['editor-traject'] ?? '/editor',
+  () => _lastVisited.value.editor ?? '/editor',
 );

--- a/frontend/src/composables/useLaw.js
+++ b/frontend/src/composables/useLaw.js
@@ -97,7 +97,7 @@ export function useLaw(lawParam, articleParam, trajectRefParam) {
     const version = ++switchVersion;
     try {
       loading.value = true;
-      const url = initialDirectUrl ?? lawUrl(currentTrajectRef,lawParam);
+      const url = initialDirectUrl ?? lawUrl(currentTrajectRef, lawParam);
       const res = await fetch(url);
       if (!res.ok) throw lawFetchError(res.status);
       if (version !== switchVersion) return;

--- a/frontend/src/composables/useLaw.js
+++ b/frontend/src/composables/useLaw.js
@@ -1,7 +1,7 @@
 import { computed, ref, shallowRef } from 'vue';
 import yaml from 'js-yaml';
 import { getEditorSessionId, lastSavedPr, sanitizeSavedPr } from './useEditorSession.js';
-import { lawUrl, requireTraject } from './corpusUrls.js';
+import { lawUrl } from './corpusUrls.js';
 
 // Shared law cache, keyed by `${trajectRef || ''}::${lawId}` so a law
 // opened in traject A and in traject B (or globally) returns the
@@ -221,7 +221,6 @@ export function useLaw(lawParam, articleParam, trajectRefParam) {
     saving.value = true;
     saveError.value = null;
     try {
-      requireTraject(savedTrajectRef, 'law save');
       const res = await fetch(lawUrl(savedTrajectRef, savedLawId), {
         method: 'PUT',
         headers: {

--- a/frontend/src/composables/useLaw.js
+++ b/frontend/src/composables/useLaw.js
@@ -1,22 +1,17 @@
 import { computed, ref, shallowRef } from 'vue';
 import yaml from 'js-yaml';
 import { getEditorSessionId, lastSavedPr, sanitizeSavedPr } from './useEditorSession.js';
+import { lawUrl, requireTraject } from './corpusUrls.js';
 
-// --- Shared law cache ---
+// Shared law cache, keyed by `${trajectRef || ''}::${lawId}` so a law
+// opened in traject A and in traject B (or globally) returns the
+// per-traject view rather than whichever was fetched first. The
+// trajectRef is part of the URL, so per-tab navigation never silently
+// mixes content across trajects.
 const lawCache = new Map();
 
-/**
- * Drop every cached law-content entry. Called by the traject switcher
- * after a successful active-traject change so the next read fetches the
- * new traject's content via the API instead of returning a previously
- * cached version from another traject (or from the no-traject scope).
- *
- * `lawCache` is keyed by law_id only — without this clear, switching
- * trajecten with the editor open shows whichever traject the law was
- * first opened in.
- */
-export function clearLawCache() {
-  lawCache.clear();
+function lawCacheKey(trajectRef, lawId) {
+  return `${trajectRef || ''}::${lawId}`;
 }
 
 export function resolveLawName(law) {
@@ -42,27 +37,40 @@ export function lawFetchError(status) {
   return err;
 }
 
-export async function fetchLaw(lawId) {
-  if (lawCache.has(lawId)) return lawCache.get(lawId);
-  const res = await fetch(`/api/corpus/laws/${encodeURIComponent(lawId)}`);
+/**
+ * Fetch a law's YAML, possibly from cache. The traject id is part of
+ * the cache key so this never returns content from a different traject
+ * than the caller asked for.
+ *
+ * @param {string|null} trajectRef - active traject (null = global read)
+ * @param {string} lawId
+ */
+export async function fetchLaw(trajectRef, lawId) {
+  const key = lawCacheKey(trajectRef, lawId);
+  if (lawCache.has(key)) return lawCache.get(key);
+  const res = await fetch(lawUrl(trajectRef, lawId));
   if (!res.ok) throw lawFetchError(res.status);
   const text = await res.text();
   const law = yaml.load(text);
   const entry = { law, rawYaml: text, lawName: resolveLawName(law) };
-  lawCache.set(lawId, entry);
+  lawCache.set(key, entry);
   return entry;
 }
 
-export function useLaw(lawParam, articleParam) {
+export function useLaw(lawParam, articleParam, trajectRefParam) {
   if (!lawParam) {
     const params = new URLSearchParams(window.location.search);
     lawParam = params.get('law') || 'zorgtoeslagwet';
   }
   const initialArticle = articleParam || null;
-  // If the parameter looks like a URL, fetch directly; otherwise use the API.
-  const yamlUrl = (lawParam.startsWith('/') || lawParam.startsWith('http'))
-    ? lawParam
-    : `/api/corpus/laws/${encodeURIComponent(lawParam)}`;
+  // Current traject id for this composable instance. `switchLaw` may
+  // update this when navigation crosses trajects, so URL builders read
+  // through the closure instead of capturing a snapshot.
+  let currentTrajectRef = trajectRefParam || null;
+  // If the parameter looks like a URL, fetch directly; otherwise build
+  // the API URL from the current trajectRef.
+  const initialDirectUrl =
+    lawParam.startsWith('/') || lawParam.startsWith('http') ? lawParam : null;
   const law = shallowRef(null);
   const rawYaml = ref('');
   const selectedArticleNumber = ref(null);
@@ -70,15 +78,6 @@ export function useLaw(lawParam, articleParam) {
   const error = ref(null);
   const saving = ref(false);
   const saveError = ref(null);
-  // PR opened or updated by the most recent successful save through the
-  // federated write-back path (RFC-010 phase 6). Imported as a
-  // module-shared ref from useEditorSession so the badge in EditorApp
-  // reflects the most recent save regardless of which composable issued
-  // it (law-content saves via useLaw, scenario saves via useScenarios).
-  // Stays populated across saves in the same editor session — every
-  // successful save returns the same PR info from the backend until the
-  // session ends or the PR is merged/closed. Null for local-source saves
-  // (no upstream PR).
 
   const articles = computed(() => law.value?.articles ?? []);
 
@@ -94,23 +93,22 @@ export function useLaw(lawParam, articleParam) {
   // Shared version counter for `load()` and `switchLaw()`; stale awaits compare and discard.
   let switchVersion = 0;
 
-  // Initial fetch; shares `switchVersion` with `switchLaw` so a mid-flight traject switch wins.
   async function load() {
     const version = ++switchVersion;
     try {
       loading.value = true;
-      const res = await fetch(yamlUrl);
+      const url = initialDirectUrl ?? lawUrl(currentTrajectRef,lawParam);
+      const res = await fetch(url);
       if (!res.ok) throw lawFetchError(res.status);
-      // Gate before and after `res.text()`: skip the body read for stale 200s, and catch races during it.
       if (version !== switchVersion) return;
       const text = await res.text();
       if (version !== switchVersion) return;
       rawYaml.value = text;
       law.value = yaml.load(text);
-      // Populate cache
       const resolvedId = law.value?.$id || lawParam;
-      if (!lawCache.has(resolvedId)) {
-        lawCache.set(resolvedId, { law: law.value, rawYaml: text, lawName: resolveLawName(law.value) });
+      const key = lawCacheKey(currentTrajectRef, resolvedId);
+      if (!lawCache.has(key)) {
+        lawCache.set(key, { law: law.value, rawYaml: text, lawName: resolveLawName(law.value) });
       }
       if (articles.value.length > 0 && !selectedArticleNumber.value) {
         if (initialArticle && articles.value.some(a => String(a.number) === initialArticle)) {
@@ -120,7 +118,7 @@ export function useLaw(lawParam, articleParam) {
         }
       }
     } catch (e) {
-      if (version !== switchVersion) return; // stale, discard
+      if (version !== switchVersion) return;
       error.value = e;
     } finally {
       if (version === switchVersion) {
@@ -134,21 +132,24 @@ export function useLaw(lawParam, articleParam) {
   // Derive the law ID from the parsed law or the original param
   const lawId = computed(() => law.value?.$id || lawParam);
 
-  async function switchLaw(newLawId, articleNumber) {
+  /**
+   * Re-load the open law's content, optionally switching law id /
+   * article / traject in one step. Passing `newTrajectRef` is how a
+   * cross-traject URL change drives a fresh fetch (and the cache key
+   * keeps the previous traject's copy untouched).
+   */
+  async function switchLaw(newLawId, articleNumber, newTrajectRef) {
     const version = ++switchVersion;
     try {
       loading.value = true;
       error.value = null;
-      // Reset save state too — a failed save on the previous law must not
-      // leak its error dialog (or spinner) into the new law's Machine
-      // panel. `saving` is cleared here alongside `saveError` because an
-      // in-flight PUT from the previous law will still set `saving = false`
-      // in its own `finally`, but until that stale response arrives the
-      // new law should not inherit the spinner.
       saveError.value = null;
       saving.value = false;
-      const entry = await fetchLaw(newLawId);
-      if (version !== switchVersion) return; // stale, discard
+      if (newTrajectRef !== undefined) {
+        currentTrajectRef = newTrajectRef || null;
+      }
+      const entry = await fetchLaw(currentTrajectRef, newLawId);
+      if (version !== switchVersion) return;
       law.value = entry.law;
       rawYaml.value = entry.rawYaml;
       if (articleNumber) {
@@ -157,7 +158,7 @@ export function useLaw(lawParam, articleParam) {
         selectedArticleNumber.value = String(articles.value[0].number);
       }
     } catch (e) {
-      if (version !== switchVersion) return; // stale, discard
+      if (version !== switchVersion) return;
       error.value = e;
     } finally {
       if (version === switchVersion) {
@@ -182,28 +183,30 @@ export function useLaw(lawParam, articleParam) {
     if (!lawId.value) {
       throw new Error('Cannot save law: no lawId');
     }
+    if (!currentTrajectRef) {
+      throw new Error('Cannot save law: no active traject');
+    }
     // Snapshot the law we're saving *before* the await. If the user
     // switches laws while the PUT is in flight, `switchLaw` will replace
     // `lawId` / `rawYaml` / `law` with the new law's state; when the stale
     // response eventually arrives, we must not overwrite the new law's
     // reactive state with the old law's YAML.
     const savedLawId = lawId.value;
+    const savedTrajectRef = currentTrajectRef;
     saving.value = true;
     saveError.value = null;
     try {
-      const res = await fetch(
-        `/api/corpus/laws/${encodeURIComponent(savedLawId)}`,
-        {
-          method: 'PUT',
-          headers: {
-            'Content-Type': 'text/yaml; charset=utf-8',
-            // Required by editor-api on every write — scopes this save to
-            // a per-(session, source) feature branch + PR upstream.
-            'X-Editor-Session': getEditorSessionId(),
-          },
-          body: yamlText,
+      requireTraject(savedTrajectRef, 'law save');
+      const res = await fetch(lawUrl(savedTrajectRef, savedLawId), {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'text/yaml; charset=utf-8',
+          // Required by editor-api on every write — scopes this save to
+          // a per-(session, source) feature branch + PR upstream.
+          'X-Editor-Session': getEditorSessionId(),
         },
-      );
+        body: yamlText,
+      });
       if (!res.ok) {
         // Only surface the body when it's our editor-api speaking. The
         // editor-api returns plain `text/plain; charset=utf-8` for its
@@ -223,11 +226,6 @@ export function useLaw(lawParam, articleParam) {
         throw new Error(text);
       }
       // Backend returns `{ pr: { url, number, branch } | null }` on 200.
-      // Update `lastSavedPr` unconditionally — the badge represents "last
-      // save's PR" not "current law's PR", and `useScenarios.saveScenario`
-      // applies the same rule. The reactive refs for `rawYaml`/`law` are
-      // still gated on `lawId.value === savedLawId` below because writing
-      // them after a law-switch would corrupt the new law's editor state.
       try {
         const json = await res.json();
         lastSavedPr.value = sanitizeSavedPr(json?.pr);
@@ -235,40 +233,25 @@ export function useLaw(lawParam, articleParam) {
         // Older deployments return a bare 200 without JSON — keep the
         // existing PR (if any) and treat the save as successful.
       }
-      // Parse once and reuse for both reactive state and the shared
-      // lawCache so they remain referentially consistent.
       const parsed = yaml.load(yamlText);
       // Bail on the success path if the user navigated away mid-flight.
-      // The write succeeded on the backend (so the cache update below is
-      // still worth doing), but we must not touch the now-foreign
-      // reactive refs.
-      if (lawId.value === savedLawId) {
+      if (lawId.value === savedLawId && currentTrajectRef === savedTrajectRef) {
         rawYaml.value = yamlText;
         law.value = parsed;
       }
-      // Keep the shared cache in sync so other tabs on the same law see
-      // the edited version on their next fetchLaw() call. The cache key
-      // is the saved law's ID, independent of the composable's current
-      // `lawId` ref, so this refresh is safe even if the user switched.
       const resolvedId = parsed?.$id || savedLawId;
-      lawCache.set(resolvedId, {
+      lawCache.set(lawCacheKey(savedTrajectRef, resolvedId), {
         law: parsed,
         rawYaml: yamlText,
         lawName: resolveLawName(parsed),
       });
     } catch (e) {
-      // Only surface the error on the originating law's state. If the user
-      // navigated away, the error belongs to law A and the new law's
-      // Machine panel must not inherit it.
-      if (lawId.value === savedLawId) {
+      if (lawId.value === savedLawId && currentTrajectRef === savedTrajectRef) {
         saveError.value = e;
       }
       throw e;
     } finally {
-      // Same story for the spinner: only clear it if we're still on the
-      // same law. If the user switched, switchLaw already reset `saving`
-      // and we don't want to fight that.
-      if (lawId.value === savedLawId) {
+      if (lawId.value === savedLawId && currentTrajectRef === savedTrajectRef) {
         saving.value = false;
       }
     }

--- a/frontend/src/composables/useLaw.js
+++ b/frontend/src/composables/useLaw.js
@@ -8,10 +8,30 @@ import { lawUrl, requireTraject } from './corpusUrls.js';
 // per-traject view rather than whichever was fetched first. The
 // trajectRef is part of the URL, so per-tab navigation never silently
 // mixes content across trajects.
+//
+// LRU-capped so a long session that hops across many trajects doesn't
+// grow the cache without bound. 50 entries comfortably covers global +
+// a handful of trajects × the laws a session realistically opens;
+// evictions are cheap (the next fetch re-populates from the API).
+// Insertion order on a Map IS the LRU order — `touchLawCache` bumps a
+// key by `delete` + `set`.
+const LAW_CACHE_MAX = 50;
 const lawCache = new Map();
 
 function lawCacheKey(trajectRef, lawId) {
   return `${trajectRef || ''}::${lawId}`;
+}
+
+function touchLawCache(key) {
+  if (lawCache.has(key)) {
+    const v = lawCache.get(key);
+    lawCache.delete(key);
+    lawCache.set(key, v);
+  }
+  while (lawCache.size > LAW_CACHE_MAX) {
+    const oldest = lawCache.keys().next().value;
+    lawCache.delete(oldest);
+  }
 }
 
 export function resolveLawName(law) {
@@ -47,13 +67,17 @@ export function lawFetchError(status) {
  */
 export async function fetchLaw(trajectRef, lawId) {
   const key = lawCacheKey(trajectRef, lawId);
-  if (lawCache.has(key)) return lawCache.get(key);
+  if (lawCache.has(key)) {
+    touchLawCache(key);
+    return lawCache.get(key);
+  }
   const res = await fetch(lawUrl(trajectRef, lawId));
   if (!res.ok) throw lawFetchError(res.status);
   const text = await res.text();
   const law = yaml.load(text);
   const entry = { law, rawYaml: text, lawName: resolveLawName(law) };
   lawCache.set(key, entry);
+  touchLawCache(key);
   return entry;
 }
 
@@ -110,6 +134,7 @@ export function useLaw(lawParam, articleParam, trajectRefParam) {
       if (!lawCache.has(key)) {
         lawCache.set(key, { law: law.value, rawYaml: text, lawName: resolveLawName(law.value) });
       }
+      touchLawCache(key);
       if (articles.value.length > 0 && !selectedArticleNumber.value) {
         if (initialArticle && articles.value.some(a => String(a.number) === initialArticle)) {
           selectedArticleNumber.value = initialArticle;
@@ -240,11 +265,13 @@ export function useLaw(lawParam, articleParam, trajectRefParam) {
         law.value = parsed;
       }
       const resolvedId = parsed?.$id || savedLawId;
-      lawCache.set(lawCacheKey(savedTrajectRef, resolvedId), {
+      const savedKey = lawCacheKey(savedTrajectRef, resolvedId);
+      lawCache.set(savedKey, {
         law: parsed,
         rawYaml: yamlText,
         lawName: resolveLawName(parsed),
       });
+      touchLawCache(savedKey);
     } catch (e) {
       if (lawId.value === savedLawId && currentTrajectRef === savedTrajectRef) {
         saveError.value = e;

--- a/frontend/src/composables/useNotes.js
+++ b/frontend/src/composables/useNotes.js
@@ -96,12 +96,14 @@ export function useNotes(lawId, selectedArticle, trajectRef) {
       const yamlText = await res.text();
 
       const engine = await initEngine();
-      // The resolver needs the law's articles loaded; mirror how the rest of
-      // the editor pulls a law into the engine. Pass the traject so the
-      // dependency fetch sees the same scope (read-your-writes parity).
-      if (!engine.hasLaw(id)) {
-        await loadDependency(id, tr);
-      }
+      // The resolver needs the law's articles loaded; mirror how the
+      // rest of the editor pulls a law into the engine. Call
+      // `loadDependency` unconditionally — it short-circuits when the
+      // engine already has the law under the same scope, and unloads +
+      // refetches when a previous load came from a different traject.
+      // A bare `if (!engine.hasLaw(id))` gate here would skip that scope
+      // check and resolve notes against stale-scope content.
+      await loadDependency(id, tr);
       const result = engine.resolveNotes(id, yamlText);
       const list = Array.isArray(result) ? result : [];
       cache.set(key, list);

--- a/frontend/src/composables/useNotes.js
+++ b/frontend/src/composables/useNotes.js
@@ -9,39 +9,33 @@
  */
 import { ref, computed, watch } from 'vue';
 import { useEngine } from './useEngine.js';
+import { annotationsUrl } from './corpusUrls.js';
 
-// Cache resolved notes per lawId for the session. The resolver result only
-// changes when the law text or the sidecar changes.
+// Cache resolved notes per `${trajectRef}::${lawId}` for the session.
+// The resolver result only changes when the law text or the sidecar
+// changes; scoping by trajectRef prevents cross-traject leakage when
+// the user switches between trajects.
 //
-// Caveat (acceptable for the display-only, default-off MVP; revisit in the
-// note-editing phase): the key is `lawId` (`law.$id`) alone, which does not
-// encode the law *version*. RFC-005 notes resolve per version, and a save
-// through the editor changes the text without changing `$id`. This cache is
-// not invalidated on save, so editing a law in-session and reopening its
-// Notities pane could show offsets resolved against the pre-save text. Once
-// notes become editable, key by `$id` + version and invalidate on save.
+// Caveat (acceptable for the display-only, default-off MVP; revisit in
+// the note-editing phase): the lawId key part is `law.$id`, which does
+// not encode the law *version*. A save through the editor changes the
+// text without changing `$id`, so the cache is not invalidated on save
+// — editing a law in-session and reopening its Notities pane could show
+// offsets resolved against the pre-save text. Once notes become
+// editable, key by `$id` + version and invalidate on save.
 const cache = new Map();
 
-/**
- * Drop every cached resolved-notes entry. Called by the traject switcher
- * after a successful active-traject change so the next read re-fetches
- * via the API instead of returning a previously cached version from
- * another traject (or from the no-traject scope).
- *
- * Mirrors `clearLawCache` in `useLaw.js`: notes are scoped per traject on
- * the backend (each traject reads from its own writable branch via
- * `GET /api/corpus/laws/{id}/annotations`), so the in-memory cache must
- * invalidate alongside the law cache.
- */
-export function clearNotesCache() {
-  cache.clear();
+function cacheKey(trajectRef, lawId) {
+  return `${trajectRef || ''}::${lawId}`;
 }
 
 /**
- * @param {import('vue').Ref<string>} lawId        reactive law $id
+ * @param {import('vue').Ref<string>} lawId reactive law $id
  * @param {import('vue').Ref<object>} selectedArticle reactive current article
+ * @param {import('vue').Ref<string|null>} trajectRef reactive traject ref
+ *   (`null` for global / no-traject reads)
  */
-export function useNotes(lawId, selectedArticle) {
+export function useNotes(lawId, selectedArticle, trajectRef) {
   const { initEngine, loadDependency } = useEngine();
   const resolved = ref([]); // [{ note, match, error }]
   const loading = ref(false);
@@ -57,6 +51,7 @@ export function useNotes(lawId, selectedArticle) {
 
   async function load() {
     const id = lawId.value;
+    const tr = trajectRef?.value ?? null;
     const gen = ++generation;
     const isStale = () => gen !== generation;
 
@@ -71,10 +66,11 @@ export function useNotes(lawId, selectedArticle) {
       loading.value = false;
       return;
     }
-    if (cache.has(id)) {
+    const key = cacheKey(tr, id);
+    if (cache.has(key)) {
       // Reset error too: a cached law (e.g. a 404 → []) must not keep showing
       // the previous law's "kon notities niet laden" alert.
-      resolved.value = cache.get(id);
+      resolved.value = cache.get(key);
       error.value = null;
       loading.value = false;
       return;
@@ -83,18 +79,14 @@ export function useNotes(lawId, selectedArticle) {
     loading.value = true;
     error.value = null;
     try {
-      // Route through editor-api so reads pick up the active traject's
-      // branch content (where `save_annotations` writes). The static
-      // `/data/annotations/` mirror — baked into the frontend container
-      // by `copy-laws.js` — only reflects central main at image-build
-      // time and missed every API-saved note (the gap #662 documented
-      // as out-of-scope).
-      const res = await fetch(
-        `/api/corpus/laws/${encodeURIComponent(id)}/annotations`,
-      );
+      // With an active traject the read goes through that traject's
+      // backend (where `save_annotations` writes) so a freshly-appended
+      // note is visible immediately. Without a traject this falls back
+      // to the global annotation route — the central source's main view.
+      const res = await fetch(annotationsUrl(tr, id));
       if (res.status === 404) {
         // A law without a sidecar is normal, not an error.
-        cache.set(id, []);
+        cache.set(key, []);
         if (!isStale()) resolved.value = [];
         return;
       }
@@ -105,13 +97,14 @@ export function useNotes(lawId, selectedArticle) {
 
       const engine = await initEngine();
       // The resolver needs the law's articles loaded; mirror how the rest of
-      // the editor pulls a law into the engine.
+      // the editor pulls a law into the engine. Pass the traject so the
+      // dependency fetch sees the same scope (read-your-writes parity).
       if (!engine.hasLaw(id)) {
-        await loadDependency(id);
+        await loadDependency(id, tr);
       }
       const result = engine.resolveNotes(id, yamlText);
       const list = Array.isArray(result) ? result : [];
-      cache.set(id, list);
+      cache.set(key, list);
       if (!isStale()) resolved.value = list;
     } catch (e) {
       if (!isStale()) {
@@ -124,7 +117,11 @@ export function useNotes(lawId, selectedArticle) {
     }
   }
 
-  watch(lawId, load, { immediate: true });
+  // Re-load on either the law or the active-traject changing — the
+  // sidecar lives per traject branch, so a switch needs a fresh fetch
+  // even if the law id stayed put.
+  const trackers = trajectRef ? [lawId, trajectRef] : [lawId];
+  watch(trackers, load, { immediate: true });
 
   /**
    * Force a fresh fetch for the current law: drop its cache entry first
@@ -138,7 +135,7 @@ export function useNotes(lawId, selectedArticle) {
    */
   async function reload() {
     const id = lawId.value;
-    if (id) cache.delete(id);
+    if (id) cache.delete(cacheKey(trajectRef?.value ?? null, id));
     await load();
   }
 

--- a/frontend/src/composables/useNotes.js
+++ b/frontend/src/composables/useNotes.js
@@ -193,8 +193,11 @@ export function useNotes(lawId, selectedArticle, trajectRef) {
  * @param {import('vue').Ref<Array>} draftNotes reactive list of W3C Annotation
  * @param {import('vue').Ref<string>} lawId
  * @param {import('vue').Ref<object>} selectedArticle
+ * @param {import('vue').Ref<string|null>=} trajectRef Active traject ref.
+ *   Routes the dependency load through the matching scope so a draft
+ *   resolves against the same law copy the editor shows.
  */
-export function useResolvedDraftNotes(draftNotes, lawId, selectedArticle) {
+export function useResolvedDraftNotes(draftNotes, lawId, selectedArticle, trajectRef) {
   const { initEngine, loadDependency } = useEngine();
   const resolvedDrafts = ref([]); // [{ note, match }]
 
@@ -209,6 +212,7 @@ export function useResolvedDraftNotes(draftNotes, lawId, selectedArticle) {
   async function resolve() {
     const id = lawId.value;
     const notes = draftNotes.value;
+    const tr = trajectRef?.value ?? null;
     const gen = ++generation;
     const isStale = () => gen !== generation;
     if (!id || !notes || notes.length === 0) {
@@ -217,7 +221,10 @@ export function useResolvedDraftNotes(draftNotes, lawId, selectedArticle) {
     }
     try {
       const engine = await initEngine();
-      if (!engine.hasLaw(id)) await loadDependency(id);
+      // Pass the scope so the engine cache can detect a stale copy
+      // from a previous traject and refetch — without this a switch
+      // would keep highlighting drafts against the old law content.
+      await loadDependency(id, tr);
       const out = [];
       for (const note of notes) {
         const selector = note?.target?.selector;
@@ -236,7 +243,8 @@ export function useResolvedDraftNotes(draftNotes, lawId, selectedArticle) {
     }
   }
 
-  watch([draftNotes, lawId], resolve, { immediate: true, deep: true });
+  const trackers = trajectRef ? [draftNotes, lawId, trajectRef] : [draftNotes, lawId];
+  watch(trackers, resolve, { immediate: true, deep: true });
 
   const draftNotesForArticle = computed(() => {
     const articleNr = selectedArticle.value?.number;

--- a/frontend/src/composables/useScenarios.js
+++ b/frontend/src/composables/useScenarios.js
@@ -6,14 +6,16 @@
  * that scenario writes live under `/api/trajects/{tid}/corpus/...`.
  *
  * @param {import('vue').Ref<string>} lawId
- * @param {import('vue').Ref<string|null>} trajectRef active traject id,
- *   `null` for a global read context (no edits possible)
+ * @param {import('vue').Ref<string|null>=} trajectRef Active traject
+ *   ref. Defaults to `ref(null)` so omitting the second arg gives a
+ *   read-only / global-scope view instead of a `TypeError: Cannot read
+ *   properties of undefined` deep inside the fetch.
  */
 import { ref, watch } from 'vue';
 import { getEditorSessionId, lastSavedPr, sanitizeSavedPr } from './useEditorSession.js';
 import { requireTraject, scenarioFileUrl, scenariosListUrl } from './corpusUrls.js';
 
-export function useScenarios(lawId, trajectRef) {
+export function useScenarios(lawId, trajectRef = ref(null)) {
   const scenarios = ref([]);
   const selectedScenario = ref(null);
   const featureText = ref('');

--- a/frontend/src/composables/useScenarios.js
+++ b/frontend/src/composables/useScenarios.js
@@ -1,10 +1,19 @@
 /**
  * useScenarios — fetch, manage, and save scenario files for a law.
+ *
+ * Reads pick the global or traject-scoped URL based on `trajectRef`;
+ * writes only succeed with a traject, matching the backend invariant
+ * that scenario writes live under `/api/trajects/{tid}/corpus/...`.
+ *
+ * @param {import('vue').Ref<string>} lawId
+ * @param {import('vue').Ref<string|null>} trajectRef active traject id,
+ *   `null` for a global read context (no edits possible)
  */
 import { ref, watch } from 'vue';
 import { getEditorSessionId, lastSavedPr, sanitizeSavedPr } from './useEditorSession.js';
+import { requireTraject, scenarioFileUrl, scenariosListUrl } from './corpusUrls.js';
 
-export function useScenarios(lawId) {
+export function useScenarios(lawId, trajectRef) {
   const scenarios = ref([]);
   const selectedScenario = ref(null);
   const featureText = ref('');
@@ -27,9 +36,7 @@ export function useScenarios(lawId) {
     saveError.value = null;
 
     try {
-      const res = await fetch(
-        `/api/corpus/laws/${encodeURIComponent(lawId.value)}/scenarios`,
-      );
+      const res = await fetch(scenariosListUrl(trajectRef.value, lawId.value));
       if (!res.ok) {
         scenarios.value = [];
         return;
@@ -53,9 +60,7 @@ export function useScenarios(lawId) {
     saveError.value = null;
 
     try {
-      const res = await fetch(
-        `/api/corpus/laws/${encodeURIComponent(lawId.value)}/scenarios/${encodeURIComponent(filename)}`,
-      );
+      const res = await fetch(scenarioFileUrl(trajectRef.value, lawId.value, filename));
       if (!res.ok) throw new Error(`Failed to fetch scenario: ${res.status}`);
       featureText.value = await res.text();
     } catch (e) {
@@ -73,13 +78,14 @@ export function useScenarios(lawId) {
    */
   async function saveScenario(filename, content) {
     if (!lawId.value) return;
+    requireTraject(trajectRef.value, 'scenario save');
 
     saving.value = true;
     saveError.value = null;
 
     try {
       const res = await fetch(
-        `/api/corpus/laws/${encodeURIComponent(lawId.value)}/scenarios/${encodeURIComponent(filename)}`,
+        scenarioFileUrl(trajectRef.value, lawId.value, filename),
         {
           method: 'PUT',
           headers: {
@@ -111,8 +117,10 @@ export function useScenarios(lawId) {
     }
   }
 
-  // Re-fetch when lawId changes
-  watch(lawId, () => {
+  // Re-fetch when the law id OR active traject changes. Switching
+  // traject (URL change) re-routes reads through the new traject's
+  // backends, so a refresh is needed even if the law id stayed the same.
+  watch([lawId, trajectRef], () => {
     selectedScenario.value = null;
     featureText.value = '';
     fetchScenarios().catch(() => {});

--- a/frontend/src/composables/useTrajects.js
+++ b/frontend/src/composables/useTrajects.js
@@ -62,8 +62,13 @@ export function useTrajects() {
   ensureTrajectsReady();
   const route = useRoute();
   const activeTrajectRef = computed(() => route.params.trajectRef || null);
+  // Guard against `t.ref` being null/undefined: the backend serialises
+  // it as `null` when a `TrajectSummary` is built without calling
+  // `fill_ref()` (defensive contract — see editor-api/trajects.rs).
+  // Skip those rather than risk a `null === null` match against a
+  // missing `activeTrajectRef`.
   const activeTraject = computed(
-    () => trajects.value.find((t) => t.ref === activeTrajectRef.value) || null,
+    () => trajects.value.find((t) => t.ref && t.ref === activeTrajectRef.value) || null,
   );
   return {
     trajects,

--- a/frontend/src/composables/useTrajects.js
+++ b/frontend/src/composables/useTrajects.js
@@ -1,12 +1,9 @@
 import { computed, ref } from 'vue';
-import { clearLawCache } from './useLaw.js';
-import { clearNotesCache } from './useNotes.js';
+import { useRoute } from 'vue-router';
 
 const trajects = ref([]);
-const activeTrajectId = ref(null);
 const loading = ref(true);
 const error = ref(null);
-const trajectSwitchEpoch = ref(0);
 
 let readyPromise = null;
 
@@ -17,16 +14,9 @@ async function loadTrajects() {
   // for the duration of the round-trip.
   loading.value = true;
   try {
-    const [listResp, activeResp] = await Promise.all([
-      fetch('/api/trajects'),
-      fetch('/api/session/active-traject'),
-    ]);
-    if (listResp.ok) {
-      trajects.value = await listResp.json();
-    }
-    if (activeResp.ok) {
-      const body = await activeResp.json();
-      activeTrajectId.value = body.traject_id || null;
+    const resp = await fetch('/api/trajects');
+    if (resp.ok) {
+      trajects.value = await resp.json();
     }
   } catch (e) {
     error.value = e;
@@ -47,24 +37,6 @@ export async function refreshTrajects() {
   return readyPromise;
 }
 
-export async function switchTraject(trajectId) {
-  const resp = await fetch('/api/session/active-traject', {
-    method: 'PUT',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ traject_id: trajectId }),
-  });
-  if (!resp.ok) throw new Error(`Failed to switch traject: ${resp.status}`);
-  const body = await resp.json();
-  activeTrajectId.value = body.traject_id || null;
-  // Page components watch this counter (not activeTrajectId) so the initial null→id settle doesn't trigger a spurious refetch.
-  trajectSwitchEpoch.value++;
-
-  // Read scope changed server-side; drop cached law content and resolved notes so the next fetch hits the API. Stay on route — pages watch the epoch and refetch in place.
-  clearLawCache();
-  clearNotesCache();
-  return activeTrajectId.value;
-}
-
 export async function createTraject(payload) {
   const resp = await fetch('/api/trajects', {
     method: 'POST',
@@ -77,23 +49,28 @@ export async function createTraject(payload) {
   }
   const created = await resp.json();
   await refreshTrajects();
-  await switchTraject(created.id);
   return created;
 }
 
+// Active traject lives in `route.params.trajectRef` (per-tab state),
+// derived here so consumers do not each repeat the lookup. Returns
+// `null` for any route without a traject param — that's the "global
+// browse" mode where edits are not available. The ref is the URL form
+// `{slug}-{8hex}` returned on `t.ref`; the backend resolver looks up
+// the matching traject by the trailing 8 hex chars of its UUID.
 export function useTrajects() {
   ensureTrajectsReady();
-  const activeTraject = computed(() =>
-    trajects.value.find((t) => t.id === activeTrajectId.value) || null,
+  const route = useRoute();
+  const activeTrajectRef = computed(() => route.params.trajectRef || null);
+  const activeTraject = computed(
+    () => trajects.value.find((t) => t.ref === activeTrajectRef.value) || null,
   );
   return {
     trajects,
-    activeTrajectId,
+    activeTrajectRef,
     activeTraject,
     loading,
     error,
-    trajectSwitchEpoch,
-    switchTraject,
     createTraject,
     refreshTrajects,
   };

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -3,6 +3,14 @@ import LibraryApp from './LibraryApp.vue';
 import { ensureAuthReady, useAuth } from './composables/useAuth.js';
 import { recordLastVisited } from './composables/useLastVisitedRoute.js';
 
+// Traject ref shape: `{slug}-{8hex}` where the trailing 8 hex chars are
+// the lookup key against the trajects table (slug is cosmetic — see
+// `resolve_traject_ref` in editor-api). Loose enough to accept the
+// runtime-generated slug, strict enough to disambiguate from a bare
+// law-id slug so an old-shape `/editor/{lawId}` bookmark falls through
+// to the legacy redirect below.
+const TRAJECT_REF_RE = /^[a-z0-9-]+-[0-9a-f]{8}$/i;
+
 const router = createRouter({
   history: createWebHistory(),
   routes: [
@@ -14,15 +22,36 @@ const router = createRouter({
       meta: { title: 'Bibliotheek' },
     },
     {
-      path: '/editor/:lawId?/:articleNumber?',
+      // Per-tab active traject lives in the URL: each open tab carries
+      // its own `trajectRef`, so a switch in one tab no longer leaks
+      // into another tab's saves. The matching API routes hang under
+      // `/api/trajects/{trajectRef}/corpus/...` (see editor-api main.rs).
+      path: '/editor/:trajectRef/:lawId?/:articleNumber?',
       name: 'editor',
       component: () => import('./EditorApp.vue'),
       meta: { title: 'Editor', requiresAuth: true },
+      beforeEnter: (to) => {
+        // Legacy bookmark `/editor/{lawId}` (no traject) — interpret
+        // `trajectRef` as the law id and redirect to the global library
+        // view. Users can re-open in a traject via the menu.
+        if (!TRAJECT_REF_RE.test(to.params.trajectRef)) {
+          return {
+            name: 'library',
+            params: {
+              lawId: to.params.trajectRef,
+              articleNumber: to.params.lawId,
+            },
+          };
+        }
+      },
     },
     {
       path: '/editor.html',
+      // Legacy query-string entry point — without a traject we can't
+      // land in the editor, so route to the library view of the
+      // requested law instead.
       redirect: (to) => ({
-        name: 'editor',
+        name: 'library',
         params: {
           lawId: to.query.law || undefined,
           articleNumber: to.query.article || undefined,

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -3,14 +3,6 @@ import LibraryApp from './LibraryApp.vue';
 import { ensureAuthReady, useAuth } from './composables/useAuth.js';
 import { recordLastVisited } from './composables/useLastVisitedRoute.js';
 
-// Traject ref shape: `{slug}-{8hex}` where the trailing 8 hex chars are
-// the lookup key against the trajects table (slug is cosmetic — see
-// `resolve_traject_ref` in editor-api). Loose enough to accept the
-// runtime-generated slug, strict enough to disambiguate from a bare
-// law-id slug so an old-shape `/editor/{lawId}` bookmark falls through
-// to the legacy redirect below.
-const TRAJECT_REF_RE = /^[a-z0-9-]+-[0-9a-f]{8}$/i;
-
 const router = createRouter({
   history: createWebHistory(),
   routes: [
@@ -22,36 +14,34 @@ const router = createRouter({
       meta: { title: 'Bibliotheek' },
     },
     {
-      // Per-tab active traject lives in the URL: each open tab carries
-      // its own `trajectRef`, so a switch in one tab no longer leaks
-      // into another tab's saves. The matching API routes hang under
-      // `/api/trajects/{trajectRef}/corpus/...` (see editor-api main.rs).
-      path: '/editor/:trajectRef/:lawId?/:articleNumber?',
+      // Traject-scoped editor: full read + write. Per-tab active
+      // traject lives in the URL; switching in one tab no longer
+      // leaks into another tab's saves. API hangs under
+      // `/api/trajects/{trajectRef}/corpus/...`.
+      //
+      // The `:trajectRef` regex pins the param to `{slug}-{8hex}` so a
+      // plain law-id slug like `zorgtoeslagwet` does NOT match this
+      // route — it falls through to the no-traject editor below.
+      path: '/editor/:trajectRef([a-z0-9-]+-[0-9a-f]{8})/:lawId?/:articleNumber?',
+      name: 'editor-traject',
+      component: () => import('./EditorApp.vue'),
+      meta: { title: 'Editor', requiresAuth: true },
+    },
+    {
+      // Editor without a traject: read-only view. Useful for browsing
+      // a law's editor UI (machine_readable, YAML, scenarios) without
+      // committing to a traject. Save actions are disabled (`canEdit`
+      // gates them); the user picks a traject via the TrajectMenu to
+      // unlock edits, which navigates to `editor-traject`.
+      path: '/editor/:lawId?/:articleNumber?',
       name: 'editor',
       component: () => import('./EditorApp.vue'),
       meta: { title: 'Editor', requiresAuth: true },
-      beforeEnter: (to) => {
-        // Legacy bookmark `/editor/{lawId}` (no traject) — interpret
-        // `trajectRef` as the law id and redirect to the global library
-        // view. Users can re-open in a traject via the menu.
-        if (!TRAJECT_REF_RE.test(to.params.trajectRef)) {
-          return {
-            name: 'library',
-            params: {
-              lawId: to.params.trajectRef,
-              articleNumber: to.params.lawId,
-            },
-          };
-        }
-      },
     },
     {
       path: '/editor.html',
-      // Legacy query-string entry point — without a traject we can't
-      // land in the editor, so route to the library view of the
-      // requested law instead.
       redirect: (to) => ({
-        name: 'library',
+        name: 'editor',
         params: {
           lawId: to.query.law || undefined,
           articleNumber: to.query.article || undefined,

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -22,6 +22,14 @@ const router = createRouter({
       // The `:trajectRef` regex pins the param to `{slug}-{8hex}` so a
       // plain law-id slug like `zorgtoeslagwet` does NOT match this
       // route — it falls through to the no-traject editor below.
+      //
+      // **Invariant**: law `$id` slugs must not match this regex (i.e.
+      // they must not end in `-{8hex}`). Today every harvested $id uses
+      // underscores (e.g. `wet_op_de_zorgtoeslag`) which are excluded
+      // from the character class, so the collision is structurally
+      // impossible. If a future harvester ever emits hyphenated ids, a
+      // schema check (or this regex tightened to require a leading
+      // word from the slug, not just hex chars) must be added.
       path: '/editor/:trajectRef([a-z0-9-]+-[0-9a-f]{8})/:lawId?/:articleNumber?',
       name: 'editor-traject',
       component: () => import('./EditorApp.vue'),

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -7,7 +7,6 @@ use axum::Json;
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 use tower_sessions::Session;
-use uuid::Uuid;
 
 use regelrecht_auth::handlers::{SESSION_KEY_EMAIL, SESSION_KEY_NAME, SESSION_KEY_SUB};
 use regelrecht_corpus::annotation_schema::{
@@ -23,7 +22,7 @@ use regelrecht_corpus::CorpusError;
 
 use crate::state::{AppState, CorpusState};
 use crate::traject_corpus::{TrajectCorpus, TrajectCorpusError};
-use crate::trajects::read_active_from_session;
+use crate::trajects::resolve_traject_ref;
 
 /// Response body for a successful save.
 ///
@@ -82,17 +81,12 @@ pub struct LawOutputEntry {
 }
 
 /// Read-time scope for the corpus endpoints. Either the per-traject
-/// corpus (when an active traject and a valid membership are both
-/// present), or the global corpus state under a read lock (anonymous /
-/// no-traject browsing). Both variants expose a `&CorpusState` view so
-/// the handlers stay agnostic.
-///
-/// Membership re-check and DB lookups for an active traject can fail
-/// (revoked member, deleted traject, transient DB error). In contrast
-/// with the write path (which 403s on any failure to protect the
-/// branch), the read path **degrades gracefully** to the global corpus
-/// so a user can still browse — saves will still be denied by the
-/// stricter `require_traject_corpus` guard on the write handlers.
+/// corpus (membership-checked) or the global corpus state under a read
+/// lock (anonymous / no-traject browsing). The variant is determined by
+/// the route — `/api/corpus/...` always lands in `Global`,
+/// `/api/trajects/{tid}/corpus/...` always lands in `Traject` — so a
+/// single handler body can serve both via the route-specific extractor
+/// that produced the scope.
 enum ReadScope {
     Traject(Arc<TrajectCorpus>),
     Global(tokio::sync::OwnedRwLockReadGuard<CorpusState>),
@@ -119,97 +113,79 @@ impl ReadScope {
     }
 }
 
-async fn resolve_read_corpus(state: &AppState, session: &Session) -> ReadScope {
-    // No active traject → straight to global (no DB hit).
-    let traject_id = match read_active_from_session(session).await {
-        Ok(Some(id)) => id,
-        _ => return ReadScope::Global(state.corpus.clone().read_owned().await),
-    };
-    let pool = match state.pool.as_ref() {
-        Some(p) => p,
-        None => return ReadScope::Global(state.corpus.clone().read_owned().await),
-    };
-
-    // Membership re-check. Same shape as `require_traject_corpus` but
-    // log-and-fall-back rather than 403 on any failure, so a stale
-    // session can't lock the user out of read access entirely.
-    let sub: Option<String> = session.get(SESSION_KEY_SUB).await.ok().flatten();
-    let Some(sub) = sub else {
-        return ReadScope::Global(state.corpus.clone().read_owned().await);
-    };
-    let membership: Result<(bool,), _> = sqlx::query_as(
-        "SELECT EXISTS(
-             SELECT 1 FROM accounts a
-             JOIN traject_members m ON m.account_id = a.id
-             WHERE a.person_sub = $1 AND m.traject_id = $2
-         )",
-    )
-    .bind(&sub)
-    .bind(traject_id)
-    .fetch_one(pool)
-    .await;
-    let is_member = match membership {
-        Ok((b,)) => b,
-        Err(e) => {
-            tracing::warn!(error = %e, "membership check failed in resolve_read_corpus; falling back to global");
-            return ReadScope::Global(state.corpus.clone().read_owned().await);
-        }
-    };
-    if !is_member {
-        // Drop the stale pointer so the next switch from the menu rebinds
-        // cleanly. Matches the same clear in `require_traject_corpus`.
-        let _: Option<Uuid> = session
-            .remove(crate::trajects::SESSION_KEY_ACTIVE_TRAJECT)
-            .await
-            .unwrap_or(None);
-        return ReadScope::Global(state.corpus.clone().read_owned().await);
-    }
-
-    let auth_file = {
-        let corpus = state.corpus.read().await;
-        corpus.auth_file.clone()
-    };
-    match state
-        .trajects
-        .get_or_build(pool, traject_id, auth_file, &state.favorites)
-        .await
-    {
-        Ok(traject) => ReadScope::Traject(traject),
-        Err(e) => {
-            // A traject_corpus build failure (DB row missing, source
-            // misconfigured, …) shouldn't fail an anonymous-looking GET.
-            // Log and serve the global view instead; the user's next
-            // write would surface the real error via the stricter
-            // `require_traject_corpus`.
-            tracing::warn!(error = %e, "traject corpus build failed in read path; falling back to global");
-            ReadScope::Global(state.corpus.clone().read_owned().await)
-        }
-    }
+/// Global read scope: no traject, no overlay. Used by every public
+/// `/api/corpus/...` GET — no membership check, no DB hit.
+async fn global_scope(state: &AppState) -> ReadScope {
+    ReadScope::Global(state.corpus.clone().read_owned().await)
 }
 
-/// GET /api/sources — list all registered corpus sources with law counts.
+/// Traject read scope: looks up the per-traject corpus, verifying the
+/// caller's membership against `traject_members`. Used by both
+/// `/api/trajects/{ref}/corpus/...` reads and the write handlers (writes
+/// also need the membership check before touching the branch).
+///
+/// The `traject_ref` is the URL form `{slug}-{8hex}` — resolved to a
+/// UUID before the membership query (see `resolve_traject_ref`). Returns
+/// 403 when the caller is not a member, 404 when the ref doesn't match
+/// any known traject, 400 when the ref is malformed.
+async fn require_traject_scope(
+    state: &AppState,
+    session: &Session,
+    traject_ref: &str,
+) -> Result<ReadScope, (StatusCode, String)> {
+    let traject = require_traject_corpus_from_ref(state, session, traject_ref).await?;
+    Ok(ReadScope::Traject(traject))
+}
+
+/// GET /api/sources — list all registered corpus sources (global).
 pub async fn list_sources(
     State(state): State<AppState>,
-    session: Session,
 ) -> Result<Json<Vec<SourceSummary>>, (StatusCode, String)> {
-    let scope = resolve_read_corpus(&state, &session).await;
-    let corpus = scope.corpus();
-    Ok(Json(build_source_summaries(
-        &corpus.registry,
-        &corpus.source_map,
-    )))
+    let scope = global_scope(&state).await;
+    Ok(Json(list_sources_in_scope(&scope)))
 }
 
-/// GET /api/corpus/laws — list loaded laws with source metadata.
+/// GET /api/trajects/{traject_id}/sources — same shape as `/api/sources`,
+/// but routed through the traject's per-source backends.
+pub async fn list_traject_sources(
+    State(state): State<AppState>,
+    session: Session,
+    Path(traject_ref): Path<String>,
+) -> Result<Json<Vec<SourceSummary>>, (StatusCode, String)> {
+    let scope = require_traject_scope(&state, &session, &traject_ref).await?;
+    Ok(Json(list_sources_in_scope(&scope)))
+}
+
+fn list_sources_in_scope(scope: &ReadScope) -> Vec<SourceSummary> {
+    let corpus = scope.corpus();
+    build_source_summaries(&corpus.registry, &corpus.source_map)
+}
+
+/// GET /api/corpus/laws — list loaded laws with source metadata (global view).
 ///
 /// Supports pagination via `?offset=0&limit=100`. Default limit is 100,
 /// maximum is 1000.
 pub async fn list_corpus_laws(
     State(state): State<AppState>,
-    session: Session,
     Query(params): Query<PaginationParams>,
 ) -> Result<Json<Vec<CorpusLawEntry>>, (StatusCode, String)> {
-    let scope = resolve_read_corpus(&state, &session).await;
+    let scope = global_scope(&state).await;
+    Ok(Json(list_corpus_laws_in_scope(&scope, params)))
+}
+
+/// GET /api/trajects/{traject_id}/corpus/laws — same as `/api/corpus/laws`
+/// but the source_map comes from the traject's per-source backends.
+pub async fn list_traject_corpus_laws(
+    State(state): State<AppState>,
+    session: Session,
+    Path(traject_ref): Path<String>,
+    Query(params): Query<PaginationParams>,
+) -> Result<Json<Vec<CorpusLawEntry>>, (StatusCode, String)> {
+    let scope = require_traject_scope(&state, &session, &traject_ref).await?;
+    Ok(Json(list_corpus_laws_in_scope(&scope, params)))
+}
+
+fn list_corpus_laws_in_scope(scope: &ReadScope, params: PaginationParams) -> Vec<CorpusLawEntry> {
     let corpus = scope.corpus();
     let limit = params.effective_limit();
 
@@ -230,31 +206,45 @@ pub async fn list_corpus_laws(
 
     entries.sort_by(|a, b| a.law_id.cmp(&b.law_id));
 
-    let paginated: Vec<CorpusLawEntry> = entries
+    entries
         .into_iter()
         .skip(params.offset)
         .take(limit)
-        .collect();
-
-    Ok(Json(paginated))
+        .collect()
 }
 
-/// GET /api/corpus/laws/{law_id} — return raw YAML content for a specific law.
+type YamlResponse = (
+    StatusCode,
+    [(axum::http::HeaderName, &'static str); 1],
+    String,
+);
+
+/// GET /api/corpus/laws/{law_id} — return raw YAML content for a specific law (global view).
 pub async fn get_corpus_law(
     State(state): State<AppState>,
-    session: Session,
     Path(law_id): Path<String>,
-) -> Result<
-    (
-        StatusCode,
-        [(axum::http::HeaderName, &'static str); 1],
-        String,
-    ),
-    (StatusCode, String),
-> {
-    let scope = resolve_read_corpus(&state, &session).await;
+) -> Result<YamlResponse, (StatusCode, String)> {
+    let scope = global_scope(&state).await;
+    get_corpus_law_in_scope(&scope, &law_id).await
+}
+
+/// GET /api/trajects/{traject_id}/corpus/laws/{law_id} — same as the
+/// global GET but with the traject's read-your-writes overlay applied.
+pub async fn get_traject_corpus_law(
+    State(state): State<AppState>,
+    session: Session,
+    Path((traject_ref, law_id)): Path<(String, String)>,
+) -> Result<YamlResponse, (StatusCode, String)> {
+    let scope = require_traject_scope(&state, &session, &traject_ref).await?;
+    get_corpus_law_in_scope(&scope, &law_id).await
+}
+
+async fn get_corpus_law_in_scope(
+    scope: &ReadScope,
+    law_id: &str,
+) -> Result<YamlResponse, (StatusCode, String)> {
     let yaml = scope
-        .law_yaml(&law_id)
+        .law_yaml(law_id)
         .await
         .ok_or_else(|| (StatusCode::NOT_FOUND, format!("Law '{}' not found", law_id)))?;
     Ok((
@@ -264,15 +254,32 @@ pub async fn get_corpus_law(
     ))
 }
 
-/// GET /api/corpus/laws/{law_id}/outputs — list all outputs declared across articles.
+/// GET /api/corpus/laws/{law_id}/outputs — list all outputs declared across articles (global view).
 pub async fn list_law_outputs(
     State(state): State<AppState>,
-    session: Session,
     Path(law_id): Path<String>,
 ) -> Result<Json<Vec<LawOutputEntry>>, (StatusCode, String)> {
-    let scope = resolve_read_corpus(&state, &session).await;
+    let scope = global_scope(&state).await;
+    list_law_outputs_in_scope(&scope, &law_id).await
+}
+
+/// GET /api/trajects/{traject_id}/corpus/laws/{law_id}/outputs — same as
+/// global but with the traject overlay.
+pub async fn list_traject_law_outputs(
+    State(state): State<AppState>,
+    session: Session,
+    Path((traject_ref, law_id)): Path<(String, String)>,
+) -> Result<Json<Vec<LawOutputEntry>>, (StatusCode, String)> {
+    let scope = require_traject_scope(&state, &session, &traject_ref).await?;
+    list_law_outputs_in_scope(&scope, &law_id).await
+}
+
+async fn list_law_outputs_in_scope(
+    scope: &ReadScope,
+    law_id: &str,
+) -> Result<Json<Vec<LawOutputEntry>>, (StatusCode, String)> {
     let yaml = scope
-        .law_yaml(&law_id)
+        .law_yaml(law_id)
         .await
         .ok_or_else(|| (StatusCode::NOT_FOUND, format!("Law '{}' not found", law_id)))?;
 
@@ -299,18 +306,32 @@ pub struct ScenarioEntry {
     pub filename: String,
 }
 
-/// GET /api/corpus/laws/{law_id}/scenarios — list available scenario files.
+/// GET /api/corpus/laws/{law_id}/scenarios — list available scenario files (global view).
 pub async fn list_scenarios(
     State(state): State<AppState>,
-    session: Session,
     Path(law_id): Path<String>,
 ) -> Result<Json<Vec<ScenarioEntry>>, (StatusCode, String)> {
-    // Route through the active traject's backends when one is selected;
-    // otherwise fall back to the global corpus state. Saves still land
-    // on the traject branch, so the same scope serves read-your-writes
-    // and cross-traject isolation in one go.
-    let scope = resolve_read_corpus(&state, &session).await;
-    let resolved = resolve_backend_for_law(scope.corpus(), &law_id).await?;
+    let scope = global_scope(&state).await;
+    list_scenarios_in_scope(&scope, &law_id).await
+}
+
+/// GET /api/trajects/{traject_id}/corpus/laws/{law_id}/scenarios — same as
+/// global but routed through the traject's backends, so a freshly saved
+/// scenario is visible without a corpus reload.
+pub async fn list_traject_scenarios(
+    State(state): State<AppState>,
+    session: Session,
+    Path((traject_ref, law_id)): Path<(String, String)>,
+) -> Result<Json<Vec<ScenarioEntry>>, (StatusCode, String)> {
+    let scope = require_traject_scope(&state, &session, &traject_ref).await?;
+    list_scenarios_in_scope(&scope, &law_id).await
+}
+
+async fn list_scenarios_in_scope(
+    scope: &ReadScope,
+    law_id: &str,
+) -> Result<Json<Vec<ScenarioEntry>>, (StatusCode, String)> {
+    let resolved = resolve_backend_for_law(scope.corpus(), law_id).await?;
 
     let scenarios_dir = match law_relative_dir(&resolved.law) {
         Ok(dir) => dir.join("scenarios"),
@@ -342,26 +363,37 @@ pub async fn list_scenarios(
     Ok(Json(out))
 }
 
-/// GET /api/corpus/laws/{law_id}/scenarios/{filename} — return raw .feature content.
+/// GET /api/corpus/laws/{law_id}/scenarios/{filename} — return raw .feature content (global view).
 pub async fn get_scenario(
     State(state): State<AppState>,
-    session: Session,
     Path((law_id, filename)): Path<(String, String)>,
-) -> Result<
-    (
-        StatusCode,
-        [(axum::http::HeaderName, &'static str); 1],
-        String,
-    ),
-    (StatusCode, String),
-> {
-    validate_scenario_filename(&filename)?;
+) -> Result<YamlResponse, (StatusCode, String)> {
+    let scope = global_scope(&state).await;
+    get_scenario_in_scope(&scope, &law_id, &filename).await
+}
 
-    let scope = resolve_read_corpus(&state, &session).await;
-    let resolved = resolve_backend_for_law(scope.corpus(), &law_id).await?;
+/// GET /api/trajects/{traject_id}/corpus/laws/{law_id}/scenarios/{filename}
+/// — traject-scoped scenario read.
+pub async fn get_traject_scenario(
+    State(state): State<AppState>,
+    session: Session,
+    Path((traject_ref, law_id, filename)): Path<(String, String, String)>,
+) -> Result<YamlResponse, (StatusCode, String)> {
+    let scope = require_traject_scope(&state, &session, &traject_ref).await?;
+    get_scenario_in_scope(&scope, &law_id, &filename).await
+}
+
+async fn get_scenario_in_scope(
+    scope: &ReadScope,
+    law_id: &str,
+    filename: &str,
+) -> Result<YamlResponse, (StatusCode, String)> {
+    validate_scenario_filename(filename)?;
+
+    let resolved = resolve_backend_for_law(scope.corpus(), law_id).await?;
 
     let scenarios_dir = law_relative_dir(&resolved.law)?.join("scenarios");
-    let relative_path = scenarios_dir.join(&filename);
+    let relative_path = scenarios_dir.join(filename);
 
     let backend = resolved.backend.lock().await;
     let content = backend
@@ -488,23 +520,35 @@ fn resolve_annotation_read_backend(
 /// for "which backend owns this law's writes in this traject".
 pub async fn get_annotations(
     State(state): State<AppState>,
-    session: Session,
     Path(law_id): Path<String>,
-) -> Result<
-    (
-        StatusCode,
-        [(axum::http::HeaderName, &'static str); 1],
-        String,
-    ),
-    (StatusCode, String),
-> {
-    let scope = resolve_read_corpus(&state, &session).await;
-    let backend = resolve_annotation_read_backend(&scope, &law_id)?;
+) -> Result<YamlResponse, (StatusCode, String)> {
+    let scope = global_scope(&state).await;
+    get_annotations_in_scope(&scope, &law_id).await
+}
+
+/// GET /api/trajects/{traject_id}/corpus/laws/{law_id}/annotations — same
+/// as the global GET but reads the sidecar from the traject's writable
+/// backend, matching the write path. A note just appended via
+/// `save_annotations` is therefore visible on the next refresh.
+pub async fn get_traject_annotations(
+    State(state): State<AppState>,
+    session: Session,
+    Path((traject_ref, law_id)): Path<(String, String)>,
+) -> Result<YamlResponse, (StatusCode, String)> {
+    let scope = require_traject_scope(&state, &session, &traject_ref).await?;
+    get_annotations_in_scope(&scope, &law_id).await
+}
+
+async fn get_annotations_in_scope(
+    scope: &ReadScope,
+    law_id: &str,
+) -> Result<YamlResponse, (StatusCode, String)> {
+    let backend = resolve_annotation_read_backend(scope, law_id)?;
 
     // RFC-018 §1: keyed by law id at the source root, regardless of where
     // the law file lives. Same path the `save_annotations` write uses.
     let relative_path = PathBuf::from("annotations")
-        .join(&law_id)
+        .join(law_id)
         .join("annotations.yaml");
 
     let backend = backend.lock().await;
@@ -738,42 +782,39 @@ struct EditorWriteTarget {
     backend: tokio::sync::OwnedMutexGuard<Box<dyn RepoBackend>>,
 }
 
-/// Resolve the per-traject corpus from session state, returning 403 when
-/// no traject is active. Bumps the cache on a miss; calls
-/// `ensure_ready` (i.e. `git clone`) for every source in the traject's
-/// federated config on first use.
+/// Resolve the per-traject corpus from the URL ref, re-checking the
+/// caller's membership on every call. Bumps the traject corpus cache on
+/// a miss; calls `ensure_ready` (i.e. `git clone`) for every source in
+/// the traject's federated config on first use.
 ///
-/// Re-verifies the caller's membership against `traject_members` on every
-/// call — `set_active` only checks once at the time the active id is
-/// stored, so without a re-check a member who has been removed (or whose
-/// traject has been deleted) since picking it active could keep writing
-/// to that traject's branch through their stale session.
-async fn require_traject_corpus(
+/// The `traject_ref` is the URL form `{slug}-{8hex}`. The slug part is
+/// cosmetic — `resolve_traject_ref` looks up the traject by the trailing
+/// 8 hex chars of the UUID. A renamed traject keeps working under the
+/// old URL because the suffix never changes.
+///
+/// The membership re-check catches drift since the SPA loaded the
+/// `/editor/{ref}/…` route — a member removed (or their traject deleted)
+/// mid-session must immediately stop being able to write to the branch
+/// instead of keeping a stale handle through their open tabs.
+async fn require_traject_corpus_from_ref(
     state: &AppState,
     session: &Session,
+    traject_ref: &str,
 ) -> Result<Arc<TrajectCorpus>, (StatusCode, String)> {
-    let traject_id = read_active_from_session(session)
-        .await
-        .map_err(|status| (status, "session read failed".to_string()))?
-        .ok_or_else(|| {
-            (
-                StatusCode::FORBIDDEN,
-                "Selecteer eerst een traject om te bewerken".to_string(),
-            )
-        })?;
     let pool = state.pool.as_ref().ok_or((
         StatusCode::SERVICE_UNAVAILABLE,
         "database not configured".to_string(),
     ))?;
+    let traject_id = resolve_traject_ref(pool, traject_ref).await?;
 
     // Membership re-check: a single EXISTS join keeps this on the hot
-    // path while catching session/state drift (membership revoked,
-    // traject deleted, account never linked to a sub).
+    // path while catching state drift (membership revoked, traject
+    // deleted, account never linked to a sub).
     let sub: String = session
         .get(SESSION_KEY_SUB)
         .await
         .map_err(|e| {
-            tracing::error!(error = %e, "session read sub in require_traject_corpus");
+            tracing::error!(error = %e, "session read sub in require_traject_corpus_from_path");
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "session read failed".to_string(),
@@ -802,13 +843,6 @@ async fn require_traject_corpus(
         )
     })?;
     if !is_member {
-        // Clear the stale pointer so the next request from this session
-        // hits the "no active traject" path and the user can rebind via
-        // the menu instead of seeing 403 on every save.
-        let _: Option<Uuid> = session
-            .remove(crate::trajects::SESSION_KEY_ACTIVE_TRAJECT)
-            .await
-            .unwrap_or(None);
         return Err((
             StatusCode::FORBIDDEN,
             "Je hebt geen toegang meer tot dit traject".to_string(),
@@ -819,27 +853,11 @@ async fn require_traject_corpus(
         let corpus = state.corpus.read().await;
         corpus.auth_file.clone()
     };
-    match state
+    state
         .trajects
         .get_or_build(pool, traject_id, auth_file, &state.favorites)
         .await
-    {
-        Ok(corpus) => Ok(corpus),
-        Err(e) => {
-            // Also clear the session on NotFound so the user isn't stuck
-            // 404-on-every-save after the traject was deleted. The clear
-            // must run inline (NOT via tokio::spawn) so SessionManagerLayer
-            // sees the mutation when it persists the session on the way
-            // out — a detached task wouldn't have run yet at save time.
-            if matches!(e, TrajectCorpusError::NotFound) {
-                let _: Option<Uuid> = session
-                    .remove(crate::trajects::SESSION_KEY_ACTIVE_TRAJECT)
-                    .await
-                    .unwrap_or(None);
-            }
-            Err(traject_corpus_error(e))
-        }
-    }
+        .map_err(traject_corpus_error)
 }
 
 fn traject_corpus_error(e: TrajectCorpusError) -> (StatusCode, String) {
@@ -862,12 +880,11 @@ fn traject_corpus_error(e: TrajectCorpusError) -> (StatusCode, String) {
     }
 }
 
-/// Resolve the writable-own backend within an active traject's corpus.
-/// Returns the looked-up law (for its `relative_path`) and an owned guard
-/// over the traject's writable backend.
+/// Resolve the writable-own backend within a traject's corpus. Returns
+/// the looked-up law (for its `relative_path`) and an owned guard over
+/// the traject's writable backend.
 async fn resolve_traject_law_write(
-    state: &AppState,
-    session: &Session,
+    traject: &Arc<TrajectCorpus>,
     law_id: &str,
 ) -> Result<
     (
@@ -876,7 +893,6 @@ async fn resolve_traject_law_write(
     ),
     (StatusCode, String),
 > {
-    let traject = require_traject_corpus(state, session).await?;
     let law = traject
         .corpus
         .source_map
@@ -911,11 +927,10 @@ async fn resolve_traject_law_write(
 }
 
 async fn resolve_traject_law_target(
-    state: &AppState,
-    session: &Session,
+    traject: &Arc<TrajectCorpus>,
     law_id: &str,
 ) -> Result<EditorWriteTarget, (StatusCode, String)> {
-    let (law, backend) = resolve_traject_law_write(state, session, law_id).await?;
+    let (law, backend) = resolve_traject_law_write(traject, law_id).await?;
     Ok(EditorWriteTarget {
         relative_path: PathBuf::from(&law.relative_path),
         backend,
@@ -923,12 +938,11 @@ async fn resolve_traject_law_target(
 }
 
 async fn resolve_traject_scenario_target(
-    state: &AppState,
-    session: &Session,
+    traject: &Arc<TrajectCorpus>,
     law_id: &str,
     filename: &str,
 ) -> Result<EditorWriteTarget, (StatusCode, String)> {
-    let (law, backend) = resolve_traject_law_write(state, session, law_id).await?;
+    let (law, backend) = resolve_traject_law_write(traject, law_id).await?;
     let rel_dir = law_relative_dir(&law)?;
     Ok(EditorWriteTarget {
         relative_path: rel_dir.join("scenarios").join(filename),
@@ -936,21 +950,19 @@ async fn resolve_traject_scenario_target(
     })
 }
 
-/// Resolve the write target for a law's stand-off notes sidecar within the
-/// active traject.
+/// Resolve the write target for a law's stand-off notes sidecar.
 ///
 /// The path is `annotations/{law_id}/annotations.yaml` at the source root,
 /// NOT under the law's own `regulation/...` directory: RFC-018 §1 keys the
-/// sidecar by law id, independent of where the law file lives. Routing,
-/// writability and membership checks all come from `resolve_traject_law_write`
-/// (same backend the law/scenario writes use), so notes land in the same
-/// traject branch/PR as the rest of the edits in the session.
+/// sidecar by law id, independent of where the law file lives. Routing
+/// and writability come from `resolve_traject_law_write` (same backend
+/// the law/scenario writes use), so notes land in the same traject
+/// branch/PR as the rest of the edits in the session.
 async fn resolve_traject_annotation_target(
-    state: &AppState,
-    session: &Session,
+    traject: &Arc<TrajectCorpus>,
     law_id: &str,
 ) -> Result<EditorWriteTarget, (StatusCode, String)> {
-    let (_law, backend) = resolve_traject_law_write(state, session, law_id).await?;
+    let (_law, backend) = resolve_traject_law_write(traject, law_id).await?;
     Ok(EditorWriteTarget {
         relative_path: PathBuf::from("annotations")
             .join(law_id)
@@ -974,21 +986,23 @@ fn save_response_from_traject(outcome: PersistOutcome) -> SaveResponse {
     }
 }
 
-/// PUT /api/corpus/laws/{law_id}/scenarios/{filename} — save a scenario file.
+/// PUT /api/trajects/{traject_id}/corpus/laws/{law_id}/scenarios/{filename}
+/// — save a scenario file in the traject's writable-own backend.
 ///
-/// Requires an active traject in the session; the save is routed through
-/// that traject's writable-own source (its branch on the writable repo).
-/// Without an active traject the handler returns 403.
+/// The traject id comes from the URL (per-tab SPA route), and the
+/// caller's membership is re-checked on every request. No traject id =
+/// no route, so this handler is unreachable without one.
 pub async fn save_scenario(
     State(state): State<AppState>,
     session: Session,
-    Path((law_id, filename)): Path<(String, String)>,
+    Path((traject_ref, law_id, filename)): Path<(String, String, String)>,
     body: String,
 ) -> Result<Json<SaveResponse>, (StatusCode, String)> {
     validate_scenario_filename(&filename)?;
     let author = editor_user_from_session(&session).await;
 
-    let target = resolve_traject_scenario_target(&state, &session, &law_id, &filename).await?;
+    let traject = require_traject_corpus_from_ref(&state, &session, &traject_ref).await?;
+    let target = resolve_traject_scenario_target(&traject, &law_id, &filename).await?;
     let EditorWriteTarget {
         relative_path,
         backend,
@@ -1020,12 +1034,10 @@ const ANNOTATION_SCHEMA_URL: &str = "https://raw.githubusercontent.com/MinBZK/re
 /// cannot append an unreasonable number of notes in one commit.
 const MAX_NOTES_PER_SAVE: usize = 500;
 
-/// PUT /api/corpus/laws/{law_id}/annotations — append stand-off notes.
-///
-/// Requires an active traject, exactly like `save_law`/`save_scenario`:
-/// the notes land in that traject's writable backend (its branch), so a
-/// note and a law edit made in the same session ride the same PR. Without
-/// an active traject the underlying `resolve_traject_law_write` returns 403.
+/// PUT /api/trajects/{traject_id}/corpus/laws/{law_id}/annotations —
+/// append stand-off notes. The notes land in the traject's writable
+/// backend (its branch), so a note and a law edit made in the same
+/// session ride the same PR.
 ///
 /// The body is a JSON array of *new* notes (drafts). The handler reads the
 /// sidecar as it stands on the traject branch and appends only the new,
@@ -1037,7 +1049,7 @@ const MAX_NOTES_PER_SAVE: usize = 500;
 pub async fn save_annotations(
     State(state): State<AppState>,
     session: Session,
-    Path(law_id): Path<String>,
+    Path((traject_ref, law_id)): Path<(String, String)>,
     body: String,
 ) -> Result<Json<SaveResponse>, (StatusCode, String)> {
     let author = editor_user_from_session(&session).await;
@@ -1058,7 +1070,8 @@ pub async fn save_annotations(
         ));
     }
 
-    let target = resolve_traject_annotation_target(&state, &session, &law_id).await?;
+    let traject = require_traject_corpus_from_ref(&state, &session, &traject_ref).await?;
+    let target = resolve_traject_annotation_target(&traject, &law_id).await?;
     let EditorWriteTarget {
         relative_path,
         backend,
@@ -1186,14 +1199,14 @@ pub async fn save_annotations(
     Ok(Json(save_response_from_traject(outcome)))
 }
 
-/// PUT /api/corpus/laws/{law_id} — save edited law YAML content.
-///
-/// Writes the new YAML to the active traject's writable-own backend (its
-/// branch on the writable repo). The save does NOT mirror the new content
-/// into `state.corpus.source_map`: that cache feeds GETs for users outside
-/// the traject, so pushing in-progress traject edits there would leak
-/// across users. Routing GETs through the per-traject corpus is a separate
-/// follow-up.
+/// PUT /api/trajects/{traject_id}/corpus/laws/{law_id} — save edited law
+/// YAML content to the traject's writable-own backend (its branch on the
+/// writable repo). The save does NOT mirror into
+/// `state.corpus.source_map`: that cache feeds GETs against
+/// `/api/corpus/...` (no traject), so pushing in-progress traject edits
+/// there would leak across users. The traject overlay populated below
+/// makes the new content visible to GETs under the same `/api/trajects/{tid}/...`
+/// prefix without a corpus reload.
 ///
 /// The `$id` in the body must match the path parameter: allowing them to
 /// diverge would either create a phantom law (new `$id` lands on an
@@ -1203,7 +1216,7 @@ pub async fn save_annotations(
 pub async fn save_law(
     State(state): State<AppState>,
     session: Session,
-    Path(law_id): Path<String>,
+    Path((traject_ref, law_id)): Path<(String, String)>,
     body: String,
 ) -> Result<Json<SaveResponse>, (StatusCode, String)> {
     let author = editor_user_from_session(&session).await;
@@ -1253,8 +1266,8 @@ pub async fn save_law(
     // Resolve the write target AND keep a handle on the per-traject
     // corpus so we can mirror the saved body into its read-your-writes
     // overlay after `persist` succeeds.
-    let traject = require_traject_corpus(&state, &session).await?;
-    let target = resolve_traject_law_target(&state, &session, &law_id).await?;
+    let traject = require_traject_corpus_from_ref(&state, &session, &traject_ref).await?;
+    let target = resolve_traject_law_target(&traject, &law_id).await?;
     let EditorWriteTarget {
         relative_path,
         backend,
@@ -1287,20 +1300,18 @@ pub async fn save_law(
     Ok(Json(save_response_from_traject(outcome)))
 }
 
-/// DELETE /api/corpus/laws/{law_id}/scenarios/{filename} — delete a scenario file.
-///
-/// Requires an active traject in the session, same as `save_scenario` /
-/// `save_law`: the deletion is routed through the traject's writable-own
-/// backend. Without an active traject the handler returns 403.
+/// DELETE /api/trajects/{traject_id}/corpus/laws/{law_id}/scenarios/{filename}
+/// — delete a scenario file in the traject's writable-own backend.
 pub async fn delete_scenario(
     State(state): State<AppState>,
     session: Session,
-    Path((law_id, filename)): Path<(String, String)>,
+    Path((traject_ref, law_id, filename)): Path<(String, String, String)>,
 ) -> Result<Json<SaveResponse>, (StatusCode, String)> {
     validate_scenario_filename(&filename)?;
     let author = editor_user_from_session(&session).await;
 
-    let target = resolve_traject_scenario_target(&state, &session, &law_id, &filename).await?;
+    let traject = require_traject_corpus_from_ref(&state, &session, &traject_ref).await?;
+    let target = resolve_traject_scenario_target(&traject, &law_id, &filename).await?;
     let EditorWriteTarget {
         relative_path,
         backend,

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -814,7 +814,7 @@ async fn require_traject_corpus_from_ref(
         .get(SESSION_KEY_SUB)
         .await
         .map_err(|e| {
-            tracing::error!(error = %e, "session read sub in require_traject_corpus_from_path");
+            tracing::error!(error = %e, "session read sub in require_traject_corpus_from_ref");
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "session read failed".to_string(),

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -237,33 +237,16 @@ async fn main() {
     // — the active traject is per-tab via the SPA route, not a server
     // session). All `/api/trajects/{id}/corpus/...` routes go through the
     // same membership re-check that `traject_routes` already use.
-    let traject_routes = Router::new()
-        .route("/api/trajects", get(trajects::list).post(trajects::create))
-        .route(
-            "/api/trajects/{id}",
-            get(trajects::get)
-                .patch(trajects::update)
-                .delete(trajects::delete),
-        )
-        .route(
-            "/api/trajects/{id}/leave",
-            axum::routing::post(trajects::leave),
-        )
-        .route(
-            "/api/trajects/{id}/members",
-            axum::routing::post(trajects::add_member),
-        )
-        .route(
-            "/api/trajects/{id}/members/{account_id}",
-            axum::routing::patch(trajects::update_member).delete(trajects::remove_member),
-        )
-        .route(
-            "/api/trajects/{id}/invites/{email}",
-            axum::routing::delete(trajects::remove_invite),
-        )
-        // Traject-scoped corpus reads — same content as `/api/corpus/...`
-        // but routed through the traject's per-source backends so a
-        // read-your-writes save is visible without a corpus reload.
+    // Traject-scoped reads (editor-reader tier). Listing/viewing the
+    // trajects you're a member of and reading the per-traject corpus
+    // overlay don't require write privilege — a Keycloak `editor-reader`
+    // who has been invited to a traject must be able to see in-progress
+    // edits. Membership is re-checked per request inside the handlers,
+    // so the role here is the broader "is this an authenticated reader
+    // at all" gate. Writes live in `traject_writer_routes` below.
+    let traject_reader_routes = Router::new()
+        .route("/api/trajects", get(trajects::list))
+        .route("/api/trajects/{id}", get(trajects::get))
         .route(
             "/api/trajects/{traject_ref}/sources",
             get(corpus_handlers::list_traject_sources),
@@ -286,26 +269,59 @@ async fn main() {
         )
         .route(
             "/api/trajects/{traject_ref}/corpus/laws/{law_id}/scenarios/{filename}",
-            // `DefaultBodyLimit` on a `MethodRouter` applies to every
-            // method on that route — including the GET handler. The
-            // GET is a no-op for body-reading so the limit is
-            // effectively a no-op there; the cap is the relevant
-            // guard for the PUT/DELETE handlers below. Restructuring
-            // to a per-method layer would require splitting the GET
-            // off into a separate `.route()` call, which we'd rather
-            // not do for one shared path.
-            get(corpus_handlers::get_traject_scenario)
-                .put(corpus_handlers::save_scenario)
+            get(corpus_handlers::get_traject_scenario),
+        )
+        .route(
+            "/api/trajects/{traject_ref}/corpus/laws/{law_id}/annotations",
+            get(corpus_handlers::get_traject_annotations),
+        )
+        .route_layer(axum_middleware::from_fn_with_state(
+            app_state.clone(),
+            accounts::account_middleware,
+        ))
+        .route_layer(axum_middleware::from_fn_with_state(
+            app_state.clone(),
+            middleware::require_role::<AppState>("editor-reader"),
+        ));
+
+    // Traject-scoped writes (editor-writer tier). Mutations to traject
+    // metadata + membership AND the traject-branch corpus content all
+    // require write privilege. Axum merges the reader and writer
+    // routers at the same path by method: a PUT against
+    // `/corpus/laws/{lid}/scenarios/{fn}` resolves to the writer
+    // handler, while a GET on the same path resolves to the reader
+    // handler above.
+    let traject_writer_routes = Router::new()
+        .route("/api/trajects", axum::routing::post(trajects::create))
+        .route(
+            "/api/trajects/{id}",
+            axum::routing::patch(trajects::update).delete(trajects::delete),
+        )
+        .route(
+            "/api/trajects/{id}/leave",
+            axum::routing::post(trajects::leave),
+        )
+        .route(
+            "/api/trajects/{id}/members",
+            axum::routing::post(trajects::add_member),
+        )
+        .route(
+            "/api/trajects/{id}/members/{account_id}",
+            axum::routing::patch(trajects::update_member).delete(trajects::remove_member),
+        )
+        .route(
+            "/api/trajects/{id}/invites/{email}",
+            axum::routing::delete(trajects::remove_invite),
+        )
+        .route(
+            "/api/trajects/{traject_ref}/corpus/laws/{law_id}/scenarios/{filename}",
+            axum::routing::put(corpus_handlers::save_scenario)
                 .delete(corpus_handlers::delete_scenario)
                 .layer(axum::extract::DefaultBodyLimit::max(MAX_SCENARIO_BODY)),
         )
         .route(
             "/api/trajects/{traject_ref}/corpus/laws/{law_id}/annotations",
-            // Same shape as the scenarios route above: the body limit
-            // covers the whole MethodRouter; only the PUT actually
-            // reads a body.
-            get(corpus_handlers::get_traject_annotations)
-                .put(corpus_handlers::save_annotations)
+            axum::routing::put(corpus_handlers::save_annotations)
                 .layer(axum::extract::DefaultBodyLimit::max(MAX_SCENARIO_BODY)),
         )
         .route(
@@ -371,7 +387,8 @@ async fn main() {
             .merge(reader_routes)
             .merge(writer_routes)
             .merge(admin_routes)
-            .merge(traject_routes)
+            .merge(traject_reader_routes)
+            .merge(traject_writer_routes)
             .with_state(app_state)
             .layer(session_layer)
             .layer(axum_middleware::from_fn(middleware::security_headers))
@@ -396,7 +413,8 @@ async fn main() {
             .merge(reader_routes)
             .merge(writer_routes)
             .merge(admin_routes)
-            .merge(traject_routes)
+            .merge(traject_reader_routes)
+            .merge(traject_writer_routes)
             .with_state(app_state)
             .layer(session_layer)
             .layer(axum_middleware::from_fn(middleware::security_headers))

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -286,6 +286,14 @@ async fn main() {
         )
         .route(
             "/api/trajects/{traject_ref}/corpus/laws/{law_id}/scenarios/{filename}",
+            // `DefaultBodyLimit` on a `MethodRouter` applies to every
+            // method on that route — including the GET handler. The
+            // GET is a no-op for body-reading so the limit is
+            // effectively a no-op there; the cap is the relevant
+            // guard for the PUT/DELETE handlers below. Restructuring
+            // to a per-method layer would require splitting the GET
+            // off into a separate `.route()` call, which we'd rather
+            // not do for one shared path.
             get(corpus_handlers::get_traject_scenario)
                 .put(corpus_handlers::save_scenario)
                 .delete(corpus_handlers::delete_scenario)
@@ -293,6 +301,9 @@ async fn main() {
         )
         .route(
             "/api/trajects/{traject_ref}/corpus/laws/{law_id}/annotations",
+            // Same shape as the scenarios route above: the body limit
+            // covers the whole MethodRouter; only the PUT actually
+            // reads a body.
             get(corpus_handlers::get_traject_annotations)
                 .put(corpus_handlers::save_annotations)
                 .layer(axum::extract::DefaultBodyLimit::max(MAX_SCENARIO_BODY)),

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -125,7 +125,10 @@ async fn main() {
     // --- Routes ---
     let auth_routes = regelrecht_auth::auth_routes::<AppState>();
 
-    // Public API routes — accessible without authentication
+    // Public API routes — accessible without authentication. The corpus
+    // reads under `/api/corpus/...` here serve the **global** view (no
+    // per-traject overlay). Edits and traject-scoped reads live under
+    // `/api/trajects/{tid}/corpus/...` (writer-tier, see `traject_routes`).
     let public_api_routes = Router::new()
         .route("/api/sources", get(corpus_handlers::list_sources))
         .route("/api/corpus/laws", get(corpus_handlers::list_corpus_laws))
@@ -175,26 +178,13 @@ async fn main() {
             middleware::require_role::<AppState>("editor-reader"),
         ));
 
-    // Writer routes — `editor-writer` covers wet- and scenario-edits plus
-    // user-scoped writes. Harvest POSTs (which trigger outbound requests) sit
-    // here so anonymous callers can never reach them.
+    // Writer routes — `editor-writer` covers user-scoped writes. Corpus
+    // edits live under `/api/trajects/{tid}/corpus/...` in `traject_routes`
+    // (membership + traject path on every request, making "no traject = no
+    // write" an URL-level invariant rather than a runtime check). Harvest
+    // POSTs (which trigger outbound requests) sit here so anonymous callers
+    // can never reach them.
     let writer_routes = Router::new()
-        .route(
-            "/api/corpus/laws/{law_id}/scenarios/{filename}",
-            axum::routing::put(corpus_handlers::save_scenario)
-                .delete(corpus_handlers::delete_scenario)
-                .layer(axum::extract::DefaultBodyLimit::max(MAX_SCENARIO_BODY)),
-        )
-        .route(
-            "/api/corpus/laws/{law_id}",
-            axum::routing::put(corpus_handlers::save_law)
-                .layer(axum::extract::DefaultBodyLimit::max(MAX_LAW_BODY)),
-        )
-        .route(
-            "/api/corpus/laws/{law_id}/annotations",
-            axum::routing::put(corpus_handlers::save_annotations)
-                .layer(axum::extract::DefaultBodyLimit::max(MAX_SCENARIO_BODY)),
-        )
         .route(
             "/api/favorites/{law_id}",
             axum::routing::put(favorites::add).delete(favorites::remove),
@@ -235,11 +225,18 @@ async fn main() {
             middleware::require_role::<AppState>("editor-admin"),
         ));
 
-    // Traject routes — user-scoped CRUD on shared editing sessions. Handlers
-    // extract `Extension<AccountRecord>`, so `account_middleware` must run
-    // before each request to load the account row from the DB. Writer-tier
+    // Traject routes — user-scoped CRUD on shared editing sessions plus
+    // the traject-scoped corpus endpoints (read + write). Handlers extract
+    // `Extension<AccountRecord>`, so `account_middleware` must run before
+    // each request to load the account row from the DB. Writer-tier
     // because users manage their own trajects; the per-traject membership
     // model handles finer-grained access within each handler.
+    //
+    // Why the corpus routes live here too: writes against a traject's
+    // branch require the traject id to be in the URL (per RFC discussion
+    // — the active traject is per-tab via the SPA route, not a server
+    // session). All `/api/trajects/{id}/corpus/...` routes go through the
+    // same membership re-check that `traject_routes` already use.
     let traject_routes = Router::new()
         .route("/api/trajects", get(trajects::list).post(trajects::create))
         .route(
@@ -264,9 +261,46 @@ async fn main() {
             "/api/trajects/{id}/invites/{email}",
             axum::routing::delete(trajects::remove_invite),
         )
+        // Traject-scoped corpus reads — same content as `/api/corpus/...`
+        // but routed through the traject's per-source backends so a
+        // read-your-writes save is visible without a corpus reload.
         .route(
-            "/api/session/active-traject",
-            get(trajects::get_active).put(trajects::set_active),
+            "/api/trajects/{traject_ref}/sources",
+            get(corpus_handlers::list_traject_sources),
+        )
+        .route(
+            "/api/trajects/{traject_ref}/corpus/laws",
+            get(corpus_handlers::list_traject_corpus_laws),
+        )
+        .route(
+            "/api/trajects/{traject_ref}/corpus/laws/{law_id}",
+            get(corpus_handlers::get_traject_corpus_law),
+        )
+        .route(
+            "/api/trajects/{traject_ref}/corpus/laws/{law_id}/outputs",
+            get(corpus_handlers::list_traject_law_outputs),
+        )
+        .route(
+            "/api/trajects/{traject_ref}/corpus/laws/{law_id}/scenarios",
+            get(corpus_handlers::list_traject_scenarios),
+        )
+        .route(
+            "/api/trajects/{traject_ref}/corpus/laws/{law_id}/scenarios/{filename}",
+            get(corpus_handlers::get_traject_scenario)
+                .put(corpus_handlers::save_scenario)
+                .delete(corpus_handlers::delete_scenario)
+                .layer(axum::extract::DefaultBodyLimit::max(MAX_SCENARIO_BODY)),
+        )
+        .route(
+            "/api/trajects/{traject_ref}/corpus/laws/{law_id}/annotations",
+            get(corpus_handlers::get_traject_annotations)
+                .put(corpus_handlers::save_annotations)
+                .layer(axum::extract::DefaultBodyLimit::max(MAX_SCENARIO_BODY)),
+        )
+        .route(
+            "/api/trajects/{traject_ref}/corpus/laws/{law_id}",
+            axum::routing::put(corpus_handlers::save_law)
+                .layer(axum::extract::DefaultBodyLimit::max(MAX_LAW_BODY)),
         )
         .route_layer(axum_middleware::from_fn_with_state(
             app_state.clone(),

--- a/packages/editor-api/src/trajects.rs
+++ b/packages/editor-api/src/trajects.rs
@@ -10,16 +10,10 @@ use axum::http::StatusCode;
 use axum::{Extension, Json};
 use serde::{Deserialize, Serialize};
 use sqlx::PgPool;
-use tower_sessions::Session;
 use uuid::Uuid;
 
 use crate::accounts::AccountRecord;
 use crate::state::AppState;
-
-/// Session key for the active traject id. The editor stores this in the
-/// user's session so save handlers can resolve the traject without a
-/// round-trip to the frontend.
-pub const SESSION_KEY_ACTIVE_TRAJECT: &str = "active_traject_id";
 
 #[derive(Debug, Serialize, sqlx::FromRow)]
 pub struct TrajectSummary {
@@ -29,6 +23,22 @@ pub struct TrajectSummary {
     pub scope: String,
     pub status: String,
     pub role: String,
+    /// URL-form reference: `{slug}-{8hex}`. Built from current `name`
+    /// and `id`; the slug part is cosmetic, the trailing 8 hex chars of
+    /// the uuid are the actual lookup key (see `resolve_traject_ref`).
+    /// Populated post-fetch — sqlx::FromRow doesn't see it in the SELECT.
+    #[serde(rename = "ref")]
+    #[sqlx(default)]
+    pub traject_ref: String,
+}
+
+impl TrajectSummary {
+    /// Recompute `traject_ref` from the current `name` and `id`. Called
+    /// right after a sqlx fetch and after any in-memory mutation that
+    /// might change the slug.
+    pub fn fill_ref(&mut self) {
+        self.traject_ref = traject_ref(&self.name, self.id);
+    }
 }
 
 #[derive(Debug, Serialize, sqlx::FromRow)]
@@ -103,16 +113,6 @@ pub struct UpdateTrajectRequest {
 }
 
 #[derive(Debug, Deserialize)]
-pub struct SetActiveTrajectRequest {
-    pub traject_id: Option<Uuid>,
-}
-
-#[derive(Debug, Serialize)]
-pub struct ActiveTrajectResponse {
-    pub traject_id: Option<Uuid>,
-}
-
-#[derive(Debug, Deserialize)]
 pub struct AddMemberRequest {
     /// Email of the user to invite. If an account already exists for
     /// this email the row lands in `traject_members` (active). If not,
@@ -147,16 +147,6 @@ fn get_pool(state: &AppState) -> Result<&PgPool, StatusCode> {
 }
 
 fn db_err<E: std::fmt::Display>(context: &'static str) -> impl FnOnce(E) -> StatusCode {
-    move |e| {
-        tracing::error!(error = %e, "{context}");
-        StatusCode::INTERNAL_SERVER_ERROR
-    }
-}
-
-/// Builds a session-error mapper that logs the underlying error with the
-/// key being read/written so operators can diagnose tower-sessions /
-/// session-store failures from logs instead of seeing a bare 500.
-fn session_err(context: &'static str) -> impl FnOnce(tower_sessions::session::Error) -> StatusCode {
     move |e| {
         tracing::error!(error = %e, "{context}");
         StatusCode::INTERNAL_SERVER_ERROR
@@ -207,6 +197,97 @@ fn derive_branch_name(name: &str, traject_id: Uuid) -> String {
     let slug = slugify(name);
     let short = traject_id.simple().to_string()[..8].to_string();
     format!("traject/{slug}-{short}")
+}
+
+/// First 8 hex characters of a traject UUID — the suffix used in the
+/// URL ref (`{slug}-{short}`). Same length as the branch-name short id so
+/// users see one identifier across URL and branch.
+pub fn short_id(traject_id: Uuid) -> String {
+    traject_id.simple().to_string()[..8].to_string()
+}
+
+/// Build the URL-form ref for a traject from its current name and id.
+/// `{slug}-{8hex}`. The slug part is cosmetic — the resolver only cares
+/// about the trailing 8-hex chunk, so renaming a traject does not break
+/// existing URLs.
+pub fn traject_ref(name: &str, traject_id: Uuid) -> String {
+    format!("{}-{}", slugify(name), short_id(traject_id))
+}
+
+/// Resolve a `{slug}-{8hex}` URL ref to a traject UUID. Returns 400 on
+/// a malformed ref, 404 when no traject has a uuid starting with the
+/// suffix.
+///
+/// The UUID prefix is uniformly distributed across 32 bits — with 1k
+/// trajects the collision probability is ~10^-5; we accept that for the
+/// readability gain and treat any ambiguous prefix as 404 (caller can
+/// pick a different ref). A monitoring counter on the duplicate branch
+/// catches the case in production before it bites a user.
+pub async fn resolve_traject_ref(
+    pool: &PgPool,
+    traject_ref: &str,
+) -> Result<Uuid, (StatusCode, String)> {
+    // 8-hex suffix preceded by a dash. Anything else (bare UUID, raw
+    // slug without suffix, garbage) is a 400 — we don't try to fall
+    // back to a bare-uuid lookup because that path no longer exists in
+    // the URL contract.
+    let suffix_start = traject_ref.len().checked_sub(8).ok_or_else(|| {
+        (
+            StatusCode::BAD_REQUEST,
+            "Malformed traject reference".to_string(),
+        )
+    })?;
+    if suffix_start == 0 || !traject_ref.is_char_boundary(suffix_start - 1) {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "Malformed traject reference".to_string(),
+        ));
+    }
+    let separator = &traject_ref[suffix_start - 1..suffix_start];
+    let suffix = &traject_ref[suffix_start..];
+    if separator != "-" || !suffix.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "Malformed traject reference".to_string(),
+        ));
+    }
+    let suffix_lower = suffix.to_ascii_lowercase();
+
+    // UUID text format starts with the first 8 hex chars (`xxxxxxxx-...`),
+    // so a LIKE on the textual representation matches our short id
+    // exactly. For 1k trajects the sequential scan is irrelevant; an
+    // index on `(left(id::text, 8))` is the obvious next step if the
+    // table grows.
+    let pattern = format!("{suffix_lower}-%");
+    let rows: Vec<(Uuid,)> = sqlx::query_as("SELECT id FROM trajects WHERE id::text LIKE $1")
+        .bind(&pattern)
+        .fetch_all(pool)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, "resolve traject ref query failed");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to resolve traject reference".to_string(),
+            )
+        })?;
+    match rows.len() {
+        1 => Ok(rows[0].0),
+        0 => Err((StatusCode::NOT_FOUND, "Traject not found".to_string())),
+        _ => {
+            // Two trajects whose UUIDs share the same first 8 hex
+            // chars — astronomical odds, but if it happens the URL is
+            // ambiguous. Log loudly and refuse rather than guess.
+            tracing::error!(
+                suffix = %suffix_lower,
+                count = rows.len(),
+                "traject ref short id collides; refusing to guess"
+            );
+            Err((
+                StatusCode::CONFLICT,
+                "Traject reference is ambiguous (id-suffix collision); contact support".to_string(),
+            ))
+        }
+    }
 }
 
 /// Look up the role of an account in a traject. Returns `None` when the
@@ -303,7 +384,7 @@ pub async fn list(
     Extension(account): Extension<AccountRecord>,
 ) -> Result<Json<Vec<TrajectSummary>>, StatusCode> {
     let pool = get_pool(&state)?;
-    let rows: Vec<TrajectSummary> = sqlx::query_as(
+    let mut rows: Vec<TrajectSummary> = sqlx::query_as(
         "SELECT t.id, t.name, t.description, t.scope,
                 t.status::text AS status,
                 tm.role::text  AS role
@@ -316,6 +397,9 @@ pub async fn list(
     .fetch_all(pool)
     .await
     .map_err(db_err("list trajects failed"))?;
+    for row in &mut rows {
+        row.fill_ref();
+    }
     Ok(Json(rows))
 }
 
@@ -328,7 +412,7 @@ pub async fn get(
     let pool = get_pool(&state)?;
     let role = require_membership(pool, id, account.id).await?;
 
-    let summary: TrajectSummary = sqlx::query_as(
+    let mut summary: TrajectSummary = sqlx::query_as(
         "SELECT id, name, description, scope,
                 status::text AS status,
                 $2           AS role
@@ -339,6 +423,7 @@ pub async fn get(
     .fetch_one(pool)
     .await
     .map_err(db_err("traject summary fetch failed"))?;
+    summary.fill_ref();
 
     let members: Vec<TrajectMember> = sqlx::query_as(
         "SELECT a.id AS account_id, a.email, a.name, tm.role::text AS role
@@ -510,14 +595,16 @@ pub async fn create(
 
     state.trajects.invalidate(traject_id).await;
 
-    let summary = TrajectSummary {
+    let mut summary = TrajectSummary {
         id: traject_id,
         name: name.to_string(),
         description: req.description,
         scope: req.scope,
         status: "bezig".to_string(),
         role: "owner".to_string(),
+        traject_ref: String::new(),
     };
+    summary.fill_ref();
     Ok((StatusCode::CREATED, Json(summary)))
 }
 
@@ -828,14 +915,12 @@ pub async fn remove_member(
 ///
 /// A `contributor` can always leave. An `owner` cannot leave when they are
 /// the last owner — they must hand over the role or delete the
-/// traject. When the caller leaves the traject they currently have
-/// active in their session, that session pointer is cleared so the
-/// next save handler doesn't try to resolve a traject they no longer
-/// belong to.
+/// traject. The next write request the caller makes against this
+/// traject's URL will 403 on the membership re-check in
+/// `require_traject_corpus_from_path`.
 pub async fn leave(
     State(state): State<AppState>,
     Extension(account): Extension<AccountRecord>,
-    session: Session,
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, StatusCode> {
     let pool = get_pool(&state)?;
@@ -875,17 +960,6 @@ pub async fn leave(
         return distinguish_member_missing_or_conflict(pool, id, account.id).await;
     }
 
-    let active: Option<Uuid> = session
-        .get(SESSION_KEY_ACTIVE_TRAJECT)
-        .await
-        .map_err(session_err("session read active-traject in leave"))?;
-    if active == Some(id) {
-        let _: Option<Uuid> = session
-            .remove(SESSION_KEY_ACTIVE_TRAJECT)
-            .await
-            .map_err(session_err("session clear active-traject in leave"))?;
-    }
-
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -907,48 +981,6 @@ async fn distinguish_member_missing_or_conflict(
         Err(StatusCode::NOT_FOUND)
     } else {
         Err(StatusCode::CONFLICT)
-    }
-}
-
-/// GET /api/session/active-traject — return the current active traject id
-/// from the session (or `null` when none).
-pub async fn get_active(session: Session) -> Result<Json<ActiveTrajectResponse>, StatusCode> {
-    let traject_id: Option<Uuid> = session
-        .get(SESSION_KEY_ACTIVE_TRAJECT)
-        .await
-        .map_err(session_err("session read active-traject"))?;
-    Ok(Json(ActiveTrajectResponse { traject_id }))
-}
-
-/// PUT /api/session/active-traject — set or clear the active traject for
-/// this session. Membership is verified against `traject_members` before
-/// persisting so a user cannot point themselves at a traject they don't
-/// belong to.
-pub async fn set_active(
-    State(state): State<AppState>,
-    Extension(account): Extension<AccountRecord>,
-    session: Session,
-    Json(req): Json<SetActiveTrajectRequest>,
-) -> Result<Json<ActiveTrajectResponse>, StatusCode> {
-    let pool = get_pool(&state)?;
-    match req.traject_id {
-        Some(id) => {
-            let _role = require_membership(pool, id, account.id).await?;
-            session
-                .insert(SESSION_KEY_ACTIVE_TRAJECT, id)
-                .await
-                .map_err(session_err("session set active-traject"))?;
-            Ok(Json(ActiveTrajectResponse {
-                traject_id: Some(id),
-            }))
-        }
-        None => {
-            let _: Option<Uuid> = session
-                .remove(SESSION_KEY_ACTIVE_TRAJECT)
-                .await
-                .map_err(session_err("session clear active-traject"))?;
-            Ok(Json(ActiveTrajectResponse { traject_id: None }))
-        }
     }
 }
 
@@ -1009,15 +1041,6 @@ impl SeedSource {
             scopes,
         }
     }
-}
-
-/// Read the active traject id from a session — used by save handlers in
-/// `corpus_handlers.rs`. Returns `Ok(None)` when no traject is selected.
-pub async fn read_active_from_session(session: &Session) -> Result<Option<Uuid>, StatusCode> {
-    session
-        .get::<Uuid>(SESSION_KEY_ACTIVE_TRAJECT)
-        .await
-        .map_err(session_err("session read active-traject in save"))
 }
 
 #[cfg(test)]

--- a/packages/editor-api/src/trajects.rs
+++ b/packages/editor-api/src/trajects.rs
@@ -220,9 +220,11 @@ pub fn traject_ref(name: &str, traject_id: Uuid) -> String {
 ///
 /// The UUID prefix is uniformly distributed across 32 bits — with 1k
 /// trajects the collision probability is ~10^-5; we accept that for the
-/// readability gain and treat any ambiguous prefix as 404 (caller can
-/// pick a different ref). A monitoring counter on the duplicate branch
-/// catches the case in production before it bites a user.
+/// readability gain and surface any ambiguous prefix as 409 Conflict
+/// (the URL is genuinely ambiguous; we refuse to guess and the caller
+/// must rebuild the ref against a fresh traject). A tracing error on
+/// the duplicate branch catches the case in production before it bites
+/// a user.
 pub async fn resolve_traject_ref(
     pool: &PgPool,
     traject_ref: &str,
@@ -265,14 +267,14 @@ pub async fn resolve_traject_ref(
     }
     let suffix_lower = suffix.to_ascii_lowercase();
 
-    // UUID text format starts with the first 8 hex chars (`xxxxxxxx-...`),
-    // so a LIKE on the textual representation matches our short id
-    // exactly. For 1k trajects the sequential scan is irrelevant; an
-    // index on `(left(id::text, 8))` is the obvious next step if the
+    // UUID text format starts with the first 8 hex chars (`xxxxxxxx-...`).
+    // Equality on `left(id::text, 8)` matches our short id exactly and
+    // uses the functional index from migration 0017
+    // (`trajects_short_id_idx`) — every traject-scoped request runs this
+    // lookup, so the index avoids a seq scan on every save once the
     // table grows.
-    let pattern = format!("{suffix_lower}-%");
-    let rows: Vec<(Uuid,)> = sqlx::query_as("SELECT id FROM trajects WHERE id::text LIKE $1")
-        .bind(&pattern)
+    let rows: Vec<(Uuid,)> = sqlx::query_as("SELECT id FROM trajects WHERE left(id::text, 8) = $1")
+        .bind(&suffix_lower)
         .fetch_all(pool)
         .await
         .map_err(|e| {

--- a/packages/editor-api/src/trajects.rs
+++ b/packages/editor-api/src/trajects.rs
@@ -917,7 +917,7 @@ pub async fn remove_member(
 /// the last owner — they must hand over the role or delete the
 /// traject. The next write request the caller makes against this
 /// traject's URL will 403 on the membership re-check in
-/// `require_traject_corpus_from_path`.
+/// `require_traject_corpus_from_ref`.
 pub async fn leave(
     State(state): State<AppState>,
     Extension(account): Extension<AccountRecord>,

--- a/packages/editor-api/src/trajects.rs
+++ b/packages/editor-api/src/trajects.rs
@@ -251,7 +251,14 @@ pub async fn resolve_traject_ref(
             "Malformed traject reference".to_string(),
         )
     })?;
-    if suffix_start == 0 {
+    // Reject empty- and missing-slug refs in one go:
+    //   suffix_start == 0  → ref is exactly 8 hex chars (no dash, no slug)
+    //   suffix_start == 1  → ref is `-{8hex}` (the slug part is empty)
+    // The SPA router regex requires at least one alphanumeric char
+    // before the dash, so the frontend can never produce these; a
+    // direct HTTP request still hits the DB lookup if we don't gate
+    // here. Aligns both layers on the same minimum shape.
+    if suffix_start <= 1 {
         return Err((
             StatusCode::BAD_REQUEST,
             "Malformed traject reference".to_string(),

--- a/packages/editor-api/src/trajects.rs
+++ b/packages/editor-api/src/trajects.rs
@@ -231,13 +231,25 @@ pub async fn resolve_traject_ref(
     // slug without suffix, garbage) is a 400 — we don't try to fall
     // back to a bare-uuid lookup because that path no longer exists in
     // the URL contract.
+    //
+    // Reject non-ASCII up front. Valid refs are slug + 8 hex chars,
+    // both ASCII by construction; without this guard a crafted
+    // multi-byte sequence like `abcé1234567` passes the length check
+    // and then panics on the byte-index slicing below (a multi-byte
+    // char straddling `suffix_start` is a char-boundary mid-slice).
+    if !traject_ref.is_ascii() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "Malformed traject reference".to_string(),
+        ));
+    }
     let suffix_start = traject_ref.len().checked_sub(8).ok_or_else(|| {
         (
             StatusCode::BAD_REQUEST,
             "Malformed traject reference".to_string(),
         )
     })?;
-    if suffix_start == 0 || !traject_ref.is_char_boundary(suffix_start - 1) {
+    if suffix_start == 0 {
         return Err((
             StatusCode::BAD_REQUEST,
             "Malformed traject reference".to_string(),

--- a/packages/editor-api/src/trajects.rs
+++ b/packages/editor-api/src/trajects.rs
@@ -209,6 +209,13 @@ fn derive_branch_name(name: &str, traject_id: Uuid) -> String {
 /// First 8 hex characters of a traject UUID — the suffix used in the
 /// URL ref (`{slug}-{short}`). Same length as the branch-name short id so
 /// users see one identifier across URL and branch.
+///
+/// `simple()` emits the 32-char hyphen-less form (`3f4a8b2c…`), and the
+/// canonical hyphenated form (`3f4a8b2c-…`) used by Postgres `id::text`
+/// places its first hyphen at position 8 — so `left(id::text, 8)` in
+/// SQL and `traject_id.simple()[..8]` in Rust produce the SAME first-8
+/// hex chars. `resolve_traject_ref`'s DB lookup
+/// (`WHERE left(id::text, 8) = $1`) relies on this alignment.
 pub fn short_id(traject_id: Uuid) -> String {
     traject_id.simple().to_string()[..8].to_string()
 }
@@ -225,9 +232,10 @@ pub fn traject_ref(name: &str, traject_id: Uuid) -> String {
 /// a malformed ref, 404 when no traject has a uuid starting with the
 /// suffix.
 ///
-/// The UUID prefix is uniformly distributed across 32 bits — with 1k
-/// trajects the collision probability is ~10^-5; we accept that for the
-/// readability gain and surface any ambiguous prefix as 409 Conflict
+/// The UUID prefix is uniformly distributed across 32 bits — for N=1k
+/// trajects the birthday-bound collision probability is
+/// N·(N−1)/(2·2³²) ≈ 1.16×10⁻⁴, which we accept for the readability
+/// gain. Ambiguous prefixes surface as 409 Conflict
 /// (the URL is genuinely ambiguous; we refuse to guess and the caller
 /// must rebuild the ref against a fresh traject). A tracing error on
 /// the duplicate branch catches the case in production before it bites

--- a/packages/editor-api/src/trajects.rs
+++ b/packages/editor-api/src/trajects.rs
@@ -27,9 +27,16 @@ pub struct TrajectSummary {
     /// and `id`; the slug part is cosmetic, the trailing 8 hex chars of
     /// the uuid are the actual lookup key (see `resolve_traject_ref`).
     /// Populated post-fetch — sqlx::FromRow doesn't see it in the SELECT.
+    ///
+    /// `Option<String>` (not `String` with a default of `""`) so a future
+    /// code path that fetches a `TrajectSummary` and forgets to call
+    /// `fill_ref()` serializes to `"ref": null` instead of `"ref": ""`.
+    /// The frontend's `t.ref === activeTrajectRef.value` comparison then
+    /// fails loudly (never matches) instead of silently equating two
+    /// empty strings against a missing trajectRef.
     #[serde(rename = "ref")]
     #[sqlx(default)]
-    pub traject_ref: String,
+    pub traject_ref: Option<String>,
 }
 
 impl TrajectSummary {
@@ -37,7 +44,7 @@ impl TrajectSummary {
     /// right after a sqlx fetch and after any in-memory mutation that
     /// might change the slug.
     pub fn fill_ref(&mut self) {
-        self.traject_ref = traject_ref(&self.name, self.id);
+        self.traject_ref = Some(traject_ref(&self.name, self.id));
     }
 }
 
@@ -623,7 +630,7 @@ pub async fn create(
         scope: req.scope,
         status: "bezig".to_string(),
         role: "owner".to_string(),
-        traject_ref: String::new(),
+        traject_ref: None,
     };
     summary.fill_ref();
     Ok((StatusCode::CREATED, Json(summary)))

--- a/packages/pipeline/migrations/0017_traject_short_id_index.sql
+++ b/packages/pipeline/migrations/0017_traject_short_id_index.sql
@@ -1,0 +1,11 @@
+-- Index the first 8 hex chars of `trajects.id` so `resolve_traject_ref`
+-- in editor-api can look up trajects by their URL-form short id without
+-- a sequential scan.
+--
+-- Every request to `/api/trajects/{ref}/corpus/...` runs the lookup —
+-- without this index the planner falls back to a seq scan because the
+-- comparison is on a derived expression (`left(id::text, 8)`) and can't
+-- use the primary-key btree on `id`. A regular btree on the function
+-- expression covers the equality lookup `resolve_traject_ref` uses.
+CREATE INDEX IF NOT EXISTS trajects_short_id_idx
+    ON trajects (left(id::text, 8));


### PR DESCRIPTION
## Summary

- **Probleem**: het actieve traject leefde in de server-side sessie, dus alle browser tabs deelden hetzelfde traject — switchen in tab A veranderde silent de write-target voor tab B's volgende save (write naar verkeerd traject mogelijk).
- **Oplossing**: traject leeft nu in de SPA route (\`/editor/{trajectRef}/{lawId?}\`), per tab. Geen cross-tab sync nodig, links zijn shareable, refresh werkt.
- **API-vorm**: twee parallelle route-families — \`/api/corpus/...\` (global read-only) en \`/api/trajects/{ref}/corpus/...\` (read + write). Writes bestaan **alleen** onder de traject prefix; "no traject = no write" is een URL-level invariant geworden i.p.v. een runtime 403.

## Traject ref

Format: \`{slug}-{8hex}\` (bv \`tarief-2026-3f4a8b2c\`).
- De 8 hex chars zijn de eerste 8 van de UUID — \`resolve_traject_ref()\` doet de DB-lookup op alleen die suffix.
- Slug is cosmetisch; renames breken oude URLs niet (alleen het label klopt niet meer).
- Zelfde short-id als de branch naam (\`derive_branch_name\`), zodat URL en branch consistent zijn.

## Wat veranderde concreet

**Backend** (\`packages/editor-api\`):
- Verwijderd: \`SESSION_KEY_ACTIVE_TRAJECT\`, \`GET/PUT /api/session/active-traject\`, \`read_active_from_session\`, sessie-cleanup in \`leave\`/membership-revoke.
- Toegevoegd: \`resolve_traject_ref\`, \`require_traject_corpus_from_ref\`, traject-scoped routes onder \`traject_routes\`. \`TrajectSummary\` draagt nu een \`ref\` veld.
- Read handlers gesplitst in global + \`_in_traject\` variant met gedeelde inner logic.

**Frontend** (\`frontend/src\`):
- \`/editor\` route accepteert \`:trajectRef\` (regex validatie + redirect voor legacy \`/editor/{lawId}\` bookmarks).
- \`useTrajects\` levert \`activeTrajectRef\` + \`activeTraject\` computeds, afgeleid uit \`route.params.trajectRef\` (geen lokale state meer).
- \`TrajectMenu\` switcht via \`router.push\` (sub-route behouden — zelfde wet, ander traject).
- Nieuwe \`corpusUrls.js\` helper bouwt global of traject-scoped URL's. Alle composables (\`useLaw\`, \`useScenarios\`, \`useNotes\`, \`useDraftNotes\`, \`useDependencies\`, \`useEngine\`, \`useCorpusLaws\`) zijn traject-bewust en cachen per scope om cross-traject leakage te voorkomen.

## Test plan

- [ ] **Multi-tab smoke**: open \`/editor/A/zorgtoeslagwet\` in tab A en \`/editor/B/zorgtoeslagwet\` in tab B; edit + save in beide; verifieer dat saves in de juiste branch landen.
- [ ] **Tab refresh**: F5 op een editor-URL houdt het traject vast (uit URL).
- [ ] **Switch in menu**: vanuit \`/editor/A/wet-X\` op een ander traject klikken → \`/editor/B/wet-X\` (zelfde wet, andere scope).
- [ ] **Legacy redirect**: \`/editor/zorgtoeslagwet\` (oude shape, geen UUID) → redirect naar \`/library/zorgtoeslagwet\`.
- [ ] **Geen traject**: \`/library/...\` blijft werken (global read), TrajectMenu's "Geen traject" navigeert daarheen.
- [ ] **Membership revoke**: revoke een lid van traject X, doe save in hun open tab → 403 met "geen toegang meer".
- [ ] **Rename**: rename traject "Tarief 2026" → "Tarief 2027" en open een oude link \`/editor/tarief-2026-3f4a8b2c/...\` → resolver vindt 'm via de UUID-staart, label in menu klopt weer.
- [ ] **Just check**: \`just check\` groen (incl. cucumber BDD, frontend unit tests).