### PR TITLE
feat(editor): overlap-aware notitie-rendering met hover-bridge

### DIFF
--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -262,11 +262,6 @@ const notesForArticle = computed(() => [
   ...draftNotesForArticle.value,
 ]);
 
-// (No longer needed: AnnotatedText now boundary-splits overlapping spans so
-// a draft overlapping a committed note renders layered, and an encapsulated
-// outer is only suppressed in the inner's segment but still renders in its
-// flanks. There is no "silently not highlighted" case to warn about.)
-
 function onCreateNote(note) {
   addDraft(note);
 }

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -262,27 +262,10 @@ const notesForArticle = computed(() => [
   ...draftNotesForArticle.value,
 ]);
 
-// AnnotatedText paints a flat partition: a draft whose span overlaps a
-// committed note's span resolves fine but is silently not highlighted (the
-// earlier note wins, RFC-018's documented overlapping-notes limitation).
-// Through the write path that is confusing — the count says "1 concept" but
-// nothing lights up — so detect it and tell the user explicitly.
-const hiddenDraftCount = computed(() => {
-  const committed = committedNotesForArticle.value.flatMap((n) => n.spans);
-  let hidden = 0;
-  for (const d of draftNotesForArticle.value) {
-    for (const s of d.spans) {
-      const overlaps = committed.some(
-        (c) => s.start < c.end && c.start < s.end,
-      );
-      if (overlaps) {
-        hidden++;
-        break;
-      }
-    }
-  }
-  return hidden;
-});
+// (No longer needed: AnnotatedText now boundary-splits overlapping spans so
+// a draft overlapping a committed note renders layered, and an encapsulated
+// outer is only suppressed in the inner's segment but still renders in its
+// flanks. There is no "silently not highlighted" case to warn about.)
 
 function onCreateNote(note) {
   addDraft(note);
@@ -1656,12 +1639,6 @@ async function handleActionSave() {
                       v-if="canCreateNotes && draftCount > 0"
                       data-testid="draft-notes-bar"
                       :text="`${draftCount} concept-notitie(s), nog niet opgeslagen`"
-                      :supporting-text="
-                        hiddenDraftCount > 0
-                          ? `${hiddenDraftCount} overlapt een bestaande notitie en wordt niet gemarkeerd.`
-                          : undefined
-                      "
-                      :icon-color="hiddenDraftCount > 0 ? 'warning' : undefined"
                     >
                       <nldd-button
                         slot="actions"

--- a/frontend/src/components/AnnotatedText.test.js
+++ b/frontend/src/components/AnnotatedText.test.js
@@ -14,10 +14,13 @@ beforeEach(() => {
 // The watcher awaits nextTick before applyHighlights, so the test must wait
 // two ticks: one for the watcher to fire, one for its inner nextTick.
 
-// Component-level tests for the two DOM-bound behaviours the pure
-// useNotesHighlight tests cannot cover: idempotent re-apply (clear before
-// re-wrap) and the deterministic overlap drop. The markdown render + offset
-// alignment themselves are covered by useNotesHighlight.test.js.
+// Component-level tests for the DOM-bound behaviours the pure
+// useNotesHighlight / useNotesSegments tests cannot cover: idempotent
+// re-apply (clear before re-wrap) and the boundary-segment overlap render
+// (partial overlap = layered, encapsulation = inner shown, outer suppressed
+// in the inner's segment). The markdown render + offset alignment are
+// covered by useNotesHighlight.test.js; the segment-planning rules
+// themselves by useNotesSegments.test.js.
 
 const nlddStubs = {
   'nldd-rich-text': { template: '<div><slot/></div>' },
@@ -87,19 +90,88 @@ describe('AnnotatedText markdown highlighting', () => {
     expect(wrapper.element.querySelectorAll('mark mark')).toHaveLength(0);
   });
 
-  it('drops a later note overlapping an earlier one (document order wins)', async () => {
+  it('splits a partial overlap into three marks; the middle one shows both notes layered', async () => {
+    // A on "verzekerde" (raw 7..17), B on "kerde heeft a" (raw 12..25):
+    // boundaries 7,12,17,25 -> three segments. The middle [12,17) has both
+    // notes visible (layered backgrounds); flanks have one each. Primary in
+    // the middle is the earlier-start note (A), so its popover opens on
+    // hover.
     const wrapper = mountWith(ART, [
-      // Earlier note (by raw start) wins; the overlapping one is dropped,
-      // matching markRanges()'s deterministic behaviour.
       { note: noteVerzekerde, spans: [{ start: 7, end: 17 }] },
       { note: noteZorgtoeslag, spans: [{ start: 12, end: 25 }] },
     ]);
     await nextTick();
     await nextTick();
-    const marks = wrapper.element.querySelectorAll('mark[data-note-idx]');
-    expect(marks).toHaveLength(1);
+    const marks = [
+      ...wrapper.element.querySelectorAll('mark[data-primary-idx]'),
+    ];
+    expect(marks).toHaveLength(3);
+    // [7,12) — only A.
+    expect(marks[0].textContent).toBe('verze');
     expect(marks[0].dataset.noteIdx).toBe('0');
-    expect(marks[0].textContent).toBe('verzekerde');
+    expect(marks[0].dataset.primaryIdx).toBe('0');
+    expect(marks[0].className).toContain('note-commenting');
+    // [12,17) — both, primary is A (earlier start), bg is the layered
+    // marker class (no class-background; inline backgroundImage stacks).
+    expect(marks[1].textContent).toBe('kerde');
+    expect(marks[1].dataset.noteIdx).toBe('0,1');
+    expect(marks[1].dataset.primaryIdx).toBe('0');
+    expect(marks[1].className).toContain('note-multi');
+    expect(marks[1].style.backgroundImage).toContain('linear-gradient');
+    // [17,25) — only B.
+    expect(marks[2].textContent).toBe(' heeft a');
+    expect(marks[2].dataset.noteIdx).toBe('1');
+    expect(marks[2].dataset.primaryIdx).toBe('1');
+  });
+
+  it('encapsulation: outer is suppressed inside the inner segment (inner shown cleanly)', async () => {
+    // Outer A on "een verzekerde heeft aanspraak " (raw 3..34) wraps inner
+    // B on "verzekerde" (raw 7..17). The inner segment [7,17) must show
+    // only B; the outer's segments [3,7) and [17,34) show only A. A stays
+    // in coveringIdx of the inner segment so a hover-bridge can reach it.
+    const wrapper = mountWith(ART, [
+      { note: noteVerzekerde, spans: [{ start: 3, end: 34 }] }, // outer
+      { note: noteZorgtoeslag, spans: [{ start: 7, end: 17 }] }, // inner
+    ]);
+    await nextTick();
+    await nextTick();
+    const marks = [
+      ...wrapper.element.querySelectorAll('mark[data-primary-idx]'),
+    ];
+    expect(marks).toHaveLength(3);
+    // Outer's left flank: A only.
+    expect(marks[0].textContent).toBe('een ');
+    expect(marks[0].dataset.noteIdx).toBe('0');
+    expect(marks[0].dataset.coverIdx).toBe('0');
+    // Inner: B shown, A suppressed but reachable via coverIdx.
+    expect(marks[1].textContent).toBe('verzekerde');
+    expect(marks[1].dataset.noteIdx).toBe('1');
+    expect(marks[1].dataset.coverIdx).toBe('0,1');
+    expect(marks[1].dataset.primaryIdx).toBe('1');
+    // Outer's right flank: A only.
+    expect(marks[2].dataset.noteIdx).toBe('0');
+  });
+
+  it('hovering the outer in encapsulation bridges .note-hovered across the inner segment', async () => {
+    // Same setup as the encapsulation test. Firing pointerover on the
+    // outer's left flank must add .note-hovered to all three marks — the
+    // inner segment too, even though it does not render the outer's
+    // background by default — so the outer's full extent reads as one
+    // continuous range.
+    const wrapper = mountWith(ART, [
+      { note: noteVerzekerde, spans: [{ start: 3, end: 34 }] },
+      { note: noteZorgtoeslag, spans: [{ start: 7, end: 17 }] },
+    ]);
+    await nextTick();
+    await nextTick();
+    const marks = [
+      ...wrapper.element.querySelectorAll('mark[data-primary-idx]'),
+    ];
+    marks[0].dispatchEvent(new Event('pointerover', { bubbles: true }));
+    await nextTick();
+    expect(marks[0].classList.contains('note-hovered')).toBe(true);
+    expect(marks[1].classList.contains('note-hovered')).toBe(true);
+    expect(marks[2].classList.contains('note-hovered')).toBe(true);
   });
 
   it('does not wrap the inter-<li> whitespace nodes when a span crosses leden', async () => {

--- a/frontend/src/components/AnnotatedText.vue
+++ b/frontend/src/components/AnnotatedText.vue
@@ -44,6 +44,13 @@ const noteByIdx = computed(() => props.notesForArticle.map((n) => n.note));
 // is encapsulated within — the inner segment renders the inner note only by
 // default, but hover should still show the outer's extent.
 const hoverBridge = new Map();
+// Currently hover-bridged note idx, so .note-hovered can be removed cleanly
+// when the cursor leaves the bridged region. Declared alongside hoverBridge
+// because clearHighlights resets both together — a re-render mid-hover (e.g.
+// a draft added while the cursor sits on a mark) must drop both the lookup
+// table and the tracker, or the next pointerover early-exits in
+// applyHoverBridge and .note-hovered never lands on the new marks.
+let hoveredIdx = null;
 
 function collectTextNodes(root) {
   const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
@@ -166,6 +173,12 @@ function clearHighlights(root) {
     parent.normalize(); // re-join the split text nodes so offsets are stable
   }
   hoverBridge.clear();
+  // The marks the bridge tracker pointed at are gone; clear it too. Without
+  // this, a re-render mid-hover (e.g. a draft added while the cursor sits on
+  // a mark) leaves hoveredIdx pointing at the same note, and the next
+  // pointerover early-exits in applyHoverBridge so .note-hovered never lands
+  // on the new marks until the user hovers a different note first.
+  hoveredIdx = null;
 }
 
 // Vue paints the sanitized markdown via v-html, then we layer the marks on
@@ -254,9 +267,6 @@ watch(
 const popoverEl = useTemplateRef('popoverEl');
 const activeNote = ref(null);
 let closeTimer = null;
-// Currently hover-bridged note idx, so .note-hovered can be removed cleanly
-// when the cursor leaves the bridged region.
-let hoveredIdx = null;
 
 function markFromEvent(event) {
   const el = event.target?.closest?.('mark[data-primary-idx]');

--- a/frontend/src/components/AnnotatedText.vue
+++ b/frontend/src/components/AnnotatedText.vue
@@ -74,8 +74,11 @@ function motivationClass(note) {
 }
 
 // Same scheme but as a CSS colour — used for the inline layered backgrounds
-// in segments with multiple visible notes. The values mirror the CSS rules
-// below; if either side changes, the other must follow.
+// in segments with multiple visible notes. The values mirror these CSS rules
+// (search the file for each selector if you change one side): `:deep(mark.
+// note-linking)`, `note-commenting`, `note-questioning`, `note-tagging`,
+// `note-other`. Note the `questioning` row is 0.30 by design — slightly more
+// opaque so orange reads against light text — keep both sides in sync.
 const MOTIVATION_COLOR = {
   linking: 'rgba(59, 130, 246, 0.28)',
   commenting: 'rgba(234, 179, 8, 0.28)',

--- a/frontend/src/components/AnnotatedText.vue
+++ b/frontend/src/components/AnnotatedText.vue
@@ -6,6 +6,7 @@ import {
   spanToNodeSlices,
   cpToUtf16,
 } from '../composables/useNotesHighlight.js';
+import { planSegments } from '../composables/useNotesSegments.js';
 import { selectionToRawRange } from '../composables/useTextSelection.js';
 import NoteCreator from './NoteCreator.vue';
 
@@ -33,9 +34,16 @@ const html = computed(() => renderArticleHtml(props.article?.text || ''));
 
 const richTextEl = useTemplateRef('richTextEl');
 
-// Index notes so a <mark> can carry data-note-idx and the delegated hover
+// Index notes so a <mark> can carry data-primary-idx and the delegated hover
 // handler can recover the note object without per-mark Vue bindings.
 const noteByIdx = computed(() => props.notesForArticle.map((n) => n.note));
+
+// noteIdx -> all marks whose segment is covered by that note (visible or
+// suppressed by encapsulation). Built fresh by applyHighlights and consumed by
+// the hover handler to "bridge" a hovered note's full span across the marks it
+// is encapsulated within — the inner segment renders the inner note only by
+// default, but hover should still show the outer's extent.
+const hoverBridge = new Map();
 
 function collectTextNodes(root) {
   const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
@@ -58,6 +66,21 @@ function motivationClass(note) {
   return 'note-other';
 }
 
+// Same scheme but as a CSS colour — used for the inline layered backgrounds
+// in segments with multiple visible notes. The values mirror the CSS rules
+// below; if either side changes, the other must follow.
+const MOTIVATION_COLOR = {
+  linking: 'rgba(59, 130, 246, 0.28)',
+  commenting: 'rgba(234, 179, 8, 0.28)',
+  questioning: 'rgba(249, 115, 22, 0.3)',
+  tagging: 'rgba(34, 197, 94, 0.28)',
+  other: 'rgba(148, 163, 184, 0.28)',
+};
+function motivationColor(note) {
+  const m = note?.motivation;
+  return MOTIVATION_COLOR[m] ?? MOTIVATION_COLOR.other;
+}
+
 // Authority -> border style. Derived from the creator (RFC-018 Decision 3):
 // a known tool creator => generated (dotted), anything else => default
 // (solid). Advisory (dashed) is reserved for when competent_authority wiring
@@ -70,10 +93,25 @@ function authorityClass(note) {
   return 'note-authoritative';
 }
 
-// Wrap one code-point slice of a text node in a <mark>. Splits the text node
-// so the Range covers exactly the slice, then surrounds it. Returns the
-// created <mark> (or null if the slice is degenerate after splitting).
-function wrapSlice(slice, noteIdx, note) {
+// Wrap one code-point slice of a text node in a <mark> for a planSegments
+// segment. The mark carries three index lists:
+//   - data-note-idx       comma-separated visible note indices (rendered
+//                         backgrounds; one for a single note, several for a
+//                         partial overlap, or just the inner one in an
+//                         encapsulation segment)
+//   - data-cover-idx      comma-separated covering note indices (visible
+//                         plus any encapsulating outer suppressed in this
+//                         segment) — used by the hover-bridge to highlight a
+//                         hovered note across regions where it is suppressed
+//   - data-primary-idx    the single note whose popover opens on hover
+//                         (earliest-start visible note in the segment)
+//
+// In multi-visible segments the motivation CSS class no longer paints the
+// background (multiple notes can't share one class), so an inline
+// background-image stacks one semi-transparent layer per visible note. The
+// authority class for the primary still drives the border style.
+// Returns the created <mark> (or null if the slice is degenerate).
+function wrapSegmentSlice(slice, seg, notes) {
   const textNode = slice.node;
   const full = textNode.textContent;
   const u1 = cpToUtf16(full, slice.startCp);
@@ -82,12 +120,26 @@ function wrapSlice(slice, noteIdx, note) {
   const range = document.createRange();
   range.setStart(textNode, u1);
   range.setEnd(textNode, u2);
+
   const mark = document.createElement('mark');
-  mark.dataset.noteIdx = String(noteIdx);
-  // Class instead of data attribute so the scoped :deep() rules below match;
-  // mirrors the colour/border scheme of the pre-#646 string renderer.
-  mark.className = `${motivationClass(note)} ${authorityClass(note)}`;
-  mark.setAttribute('aria-label', `Notitie: ${note?.motivation ?? ''}`);
+  const primary = notes[seg.primaryIdx]?.note;
+  const multi = seg.visibleIdx.length > 1;
+  // Single-note segments keep the pre-#647 colour-class background. Multi-
+  // note segments switch to `note-multi` (no class background) plus an
+  // inline layered background-image so semi-transparent colours composite.
+  const bgCls = multi ? 'note-multi' : motivationClass(primary);
+  mark.className = `${bgCls} ${authorityClass(primary)}`;
+  mark.dataset.noteIdx = seg.visibleIdx.join(',');
+  mark.dataset.coverIdx = seg.coveringIdx.join(',');
+  mark.dataset.primaryIdx = String(seg.primaryIdx);
+  if (multi) {
+    const layers = seg.visibleIdx
+      .map((i) => motivationColor(notes[i]?.note))
+      .map((c) => `linear-gradient(${c}, ${c})`)
+      .join(', ');
+    mark.style.backgroundImage = layers;
+  }
+  mark.setAttribute('aria-label', `Notitie: ${primary?.motivation ?? ''}`);
   mark.setAttribute('tabindex', '0');
   try {
     range.surroundContents(mark);
@@ -106,13 +158,14 @@ function wrapSlice(slice, noteIdx, note) {
 // unchanged — e.g. once notes become editable) leaves the prior marks in
 // place, so applyHighlights must be idempotent and clean up first.
 function clearHighlights(root) {
-  for (const mark of root.querySelectorAll('mark[data-note-idx]')) {
+  for (const mark of root.querySelectorAll('mark[data-primary-idx]')) {
     const parent = mark.parentNode;
     if (!parent) continue;
     while (mark.firstChild) parent.insertBefore(mark.firstChild, mark);
     parent.removeChild(mark);
     parent.normalize(); // re-join the split text nodes so offsets are stable
   }
+  hoverBridge.clear();
 }
 
 // Vue paints the sanitized markdown via v-html, then we layer the marks on
@@ -141,38 +194,39 @@ function applyHighlights() {
     domNodes.map(({ node, text }) => [node, Array.from(text).length]),
   );
 
-  // Flatten to (span, note) and wrap by descending raw start. surroundContents
-  // splits the text node, so processing the rightmost span first keeps every
-  // earlier span's node references and offsets valid. `wrapped` tracks the raw
-  // ranges already marked: a span that overlaps one is dropped, matching the
-  // deterministic drop in markRanges() (RFC-018's overlapping-notes case).
-  const flat = [];
+  // Flatten (idx, span) pairs and ask planSegments for an overlap-aware
+  // partition: every char that any note covers ends up in exactly one
+  // segment, partial overlaps render layered (both colours), and a note that
+  // encapsulates another is suppressed in the inner's segment so the inner
+  // shows cleanly. `coveringIdx` keeps the suppressed outer reachable for
+  // the hover-bridge below.
+  const items = [];
   notes.forEach((entry, idx) => {
-    for (const span of entry.spans) flat.push({ span, idx });
+    for (const span of entry.spans) {
+      items.push({ start: span.start, end: span.end, idx });
+    }
   });
-  // Drop decision must use document order (ascending), so the *earlier* note
-  // wins the overlap, same as markRanges. Wrapping order stays descending.
-  const ascending = [...flat].sort(
-    (a, b) => a.span.start - b.span.start || b.span.end - a.span.end,
-  );
-  const keep = new Set();
-  let cursor = 0;
-  for (const item of ascending) {
-    if (item.span.start < cursor) continue; // overlaps an earlier kept span
-    keep.add(item);
-    cursor = item.span.end;
-  }
+  const segments = planSegments(items);
 
-  const descending = flat
-    .filter((item) => keep.has(item))
-    .sort((a, b) => b.span.start - a.span.start);
+  // Wrap by descending raw start. surroundContents splits the text node, so
+  // processing the rightmost segment first keeps every earlier segment's
+  // node references and offsets valid.
+  const descending = [...segments].sort((a, b) => b.start - a.start);
 
-  for (const { span, idx } of descending) {
-    const note = noteByIdx.value[idx];
-    const slices = spanToNodeSlices(rawToDom, span, domNodeCpLen);
-    // Wrap right-to-left within the span too, same node-stability reason.
+  for (const seg of descending) {
+    const slices = spanToNodeSlices(rawToDom, seg, domNodeCpLen);
+    // Wrap right-to-left within the segment too, same node-stability reason.
     for (let i = slices.length - 1; i >= 0; i--) {
-      wrapSlice(slices[i], idx, note);
+      const mark = wrapSegmentSlice(slices[i], seg, notes);
+      if (!mark) continue;
+      for (const coverIdx of seg.coveringIdx) {
+        let arr = hoverBridge.get(coverIdx);
+        if (!arr) {
+          arr = [];
+          hoverBridge.set(coverIdx, arr);
+        }
+        arr.push(mark);
+      }
     }
   }
 }
@@ -200,20 +254,46 @@ watch(
 const popoverEl = useTemplateRef('popoverEl');
 const activeNote = ref(null);
 let closeTimer = null;
+// Currently hover-bridged note idx, so .note-hovered can be removed cleanly
+// when the cursor leaves the bridged region.
+let hoveredIdx = null;
 
 function markFromEvent(event) {
-  const el = event.target?.closest?.('mark[data-note-idx]');
+  const el = event.target?.closest?.('mark[data-primary-idx]');
   if (!el) return null;
-  const idx = Number(el.dataset.noteIdx);
-  return { el, note: noteByIdx.value[idx] || null };
+  const idx = Number(el.dataset.primaryIdx);
+  return { el, note: noteByIdx.value[idx] || null, idx };
 }
 
-function openFor(el, note) {
+// Add .note-hovered to every mark that covers `idx` (including segments
+// where idx is suppressed by encapsulation), so the hovered note's full
+// extent reads as one continuous span even though it is rendered in
+// multiple <mark> elements. Removing the class is the inverse.
+function applyHoverBridge(idx) {
+  if (hoveredIdx === idx) return;
+  clearHoverBridge();
+  if (idx == null) return;
+  const marks = hoverBridge.get(idx);
+  if (!marks) return;
+  for (const m of marks) m.classList.add('note-hovered');
+  hoveredIdx = idx;
+}
+function clearHoverBridge() {
+  if (hoveredIdx == null) return;
+  const marks = hoverBridge.get(hoveredIdx);
+  if (marks) {
+    for (const m of marks) m.classList.remove('note-hovered');
+  }
+  hoveredIdx = null;
+}
+
+function openFor(el, note, idx) {
   if (closeTimer) {
     clearTimeout(closeTimer);
     closeTimer = null;
   }
   activeNote.value = note;
+  applyHoverBridge(idx);
   const pop = popoverEl.value;
   if (!pop) return;
   pop.anchorElement = el;
@@ -226,14 +306,14 @@ function openFor(el, note) {
 
 function onPointerOver(event) {
   const hit = markFromEvent(event);
-  if (hit?.note) openFor(hit.el, hit.note);
+  if (hit?.note) openFor(hit.el, hit.note, hit.idx);
 }
 function onPointerOut(event) {
   if (markFromEvent(event)) scheduleClose();
 }
 function onFocusIn(event) {
   const hit = markFromEvent(event);
-  if (hit?.note) openFor(hit.el, hit.note);
+  if (hit?.note) openFor(hit.el, hit.note, hit.idx);
 }
 function onFocusOut(event) {
   if (markFromEvent(event)) scheduleClose();
@@ -244,6 +324,7 @@ function scheduleClose() {
   closeTimer = setTimeout(() => {
     popoverEl.value?.hidePopover?.();
     activeNote.value = null;
+    clearHoverBridge();
     closeTimer = null;
   }, 160);
 }
@@ -555,6 +636,22 @@ onBeforeUnmount(() => {
 }
 .annotated-wrap :deep(mark.note-other) {
   background: rgba(148, 163, 184, 0.28);
+}
+/* Multi-visible-note segments (partial overlap, layered backgrounds). The
+   class is a marker only; the inline style on the mark stacks one
+   linear-gradient layer per visible note so two 28%-opaque colours composite
+   into a third — see motivationColor() in the script. The single border-bottom
+   from the primary's authority class stays. */
+.annotated-wrap :deep(mark.note-multi) {
+  background: none;
+}
+/* Hover-bridge: every mark whose coverage includes the hovered note's idx
+   gets this class, so the note's full span reads as one continuous range
+   even when boundary-splitting placed it in multiple <mark> elements (and
+   even where it is suppressed by encapsulation). The signal is a stronger
+   underline that visually carries across the inline marks. */
+.annotated-wrap :deep(mark.note-hovered) {
+  box-shadow: inset 0 -3px 0 currentColor;
 }
 .annotated-wrap :deep(mark:focus-visible) {
   outline: 2px solid currentColor;

--- a/frontend/src/components/AnnotatedText.vue
+++ b/frontend/src/components/AnnotatedText.vue
@@ -149,7 +149,16 @@ function wrapSegmentSlice(slice, seg, notes) {
       .join(', ');
     mark.style.backgroundImage = layers;
   }
-  mark.setAttribute('aria-label', `Notitie: ${primary?.motivation ?? ''}`);
+  // Announce every visible note's motivation on a multi-note segment so a
+  // screen-reader user is not told only about the primary while a second
+  // note is silently layered underneath.
+  const motivations = seg.visibleIdx
+    .map((i) => notes[i]?.note?.motivation)
+    .filter(Boolean);
+  const ariaLabel = motivations.length > 1
+    ? `${motivations.length} notities: ${motivations.join(', ')}`
+    : `Notitie: ${primary?.motivation ?? ''}`;
+  mark.setAttribute('aria-label', ariaLabel);
   mark.setAttribute('tabindex', '0');
   try {
     range.surroundContents(mark);

--- a/frontend/src/composables/useNotesSegments.js
+++ b/frontend/src/composables/useNotesSegments.js
@@ -126,7 +126,7 @@ function uniqueIdx(items) {
   return out;
 }
 
-function sameSet(a, b) {
+function sameOrderedList(a, b) {
   if (a.length !== b.length) return false;
   for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
   return true;
@@ -141,8 +141,8 @@ function mergeAdjacent(segments) {
     if (
       prev.end === cur.start &&
       prev.primaryIdx === cur.primaryIdx &&
-      sameSet(prev.visibleIdx, cur.visibleIdx) &&
-      sameSet(prev.coveringIdx, cur.coveringIdx)
+      sameOrderedList(prev.visibleIdx, cur.visibleIdx) &&
+      sameOrderedList(prev.coveringIdx, cur.coveringIdx)
     ) {
       prev.end = cur.end;
     } else {

--- a/frontend/src/composables/useNotesSegments.js
+++ b/frontend/src/composables/useNotesSegments.js
@@ -1,0 +1,139 @@
+/**
+ * planSegments — overlap-aware render plan for note highlights.
+ *
+ * Replaces the flat-partition overlap drop that #647 inherited from
+ * markRanges. Given each note's resolved spans (with the note's index in
+ * notesForArticle), produces a disjoint ordered list of segments whose union
+ * is exactly the union of all input spans. Each segment carries enough
+ * information for the renderer to:
+ *
+ *   - paint the right backgrounds in default state (`visibleIdx`),
+ *   - bridge a hovered note across regions where it is suppressed
+ *     (`coveringIdx`),
+ *   - choose which note's popover opens on hover (`primaryIdx`).
+ *
+ * Encapsulation rule: if note X strictly contains note Y (X.start <= Y.start
+ * AND X.end >= Y.end AND at least one inequality is strict) and both cover
+ * the same segment, X is suppressed in that segment so the inner note shows
+ * cleanly. X stays in the `coveringIdx` so hovering it bridges back to its
+ * full span. Identical spans both render — neither strictly contains the
+ * other.
+ *
+ * Partial overlap (neither contains the other): both render layered.
+ *
+ * Boundary sweep: the segment endpoints are exactly the spans' own
+ * endpoints, so containment in a segment [a, b) reduces to
+ * `note.start <= a && note.end >= b`.
+ *
+ * @param {Array<{start:number, end:number, idx:number}>} items
+ *        Flattened (note, span) pairs; idx is the note's index in
+ *        notesForArticle. A note with multiple spans contributes multiple
+ *        items with the same idx.
+ * @returns {Array<{
+ *   start:number,
+ *   end:number,
+ *   visibleIdx:number[],
+ *   coveringIdx:number[],
+ *   primaryIdx:number,
+ * }>}
+ *   Segments in ascending start order. Visible/covering arrays are
+ *   deduplicated by idx (so a note with two spans crossing a segment counts
+ *   once); idx is preserved in the order it first appears.
+ */
+export function planSegments(items) {
+  const valid = items.filter((it) => it.end > it.start);
+  if (valid.length === 0) return [];
+
+  const points = new Set();
+  for (const it of valid) {
+    points.add(it.start);
+    points.add(it.end);
+  }
+  const boundaries = [...points].sort((a, b) => a - b);
+
+  const segments = [];
+  for (let i = 0; i < boundaries.length - 1; i++) {
+    const a = boundaries[i];
+    const b = boundaries[i + 1];
+    const covering = valid.filter((it) => it.start <= a && it.end >= b);
+    if (covering.length === 0) continue;
+
+    const visible = covering.filter(
+      (x) => !covering.some((y) => y !== x && strictlyContains(x, y)),
+    );
+    if (visible.length === 0) continue;
+
+    const primary = pickPrimary(visible);
+    segments.push({
+      start: a,
+      end: b,
+      visibleIdx: uniqueIdx(visible),
+      coveringIdx: uniqueIdx(covering),
+      primaryIdx: primary.idx,
+    });
+  }
+
+  // Merge adjacent segments with identical visible/covering/primary so the
+  // renderer wraps one <mark> for a run of equal-coverage chars instead of
+  // one per boundary. Span endpoints from other notes outside the covering
+  // set still create boundaries here; merging keeps the DOM tidy.
+  return mergeAdjacent(segments);
+}
+
+function strictlyContains(outer, inner) {
+  return (
+    outer.start <= inner.start &&
+    outer.end >= inner.end &&
+    (outer.start < inner.start || outer.end > inner.end)
+  );
+}
+
+function pickPrimary(visible) {
+  // Earliest span.start wins (the note that "starts first" in document
+  // order). On a tie, lowest idx — that is the order the note appears in
+  // notesForArticle, which is the YAML order for committed notes.
+  let best = visible[0];
+  for (let i = 1; i < visible.length; i++) {
+    const x = visible[i];
+    if (x.start < best.start) best = x;
+    else if (x.start === best.start && x.idx < best.idx) best = x;
+  }
+  return best;
+}
+
+function uniqueIdx(items) {
+  const seen = new Set();
+  const out = [];
+  for (const it of items) {
+    if (seen.has(it.idx)) continue;
+    seen.add(it.idx);
+    out.push(it.idx);
+  }
+  return out;
+}
+
+function sameSet(a, b) {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
+}
+
+function mergeAdjacent(segments) {
+  if (segments.length < 2) return segments;
+  const out = [segments[0]];
+  for (let i = 1; i < segments.length; i++) {
+    const prev = out[out.length - 1];
+    const cur = segments[i];
+    if (
+      prev.end === cur.start &&
+      prev.primaryIdx === cur.primaryIdx &&
+      sameSet(prev.visibleIdx, cur.visibleIdx) &&
+      sameSet(prev.coveringIdx, cur.coveringIdx)
+    ) {
+      prev.end = cur.end;
+    } else {
+      out.push(cur);
+    }
+  }
+  return out;
+}

--- a/frontend/src/composables/useNotesSegments.js
+++ b/frontend/src/composables/useNotesSegments.js
@@ -64,11 +64,17 @@ export function planSegments(items) {
     // Strict containment is asymmetric (A ⊃ B ∧ B ⊃ A would require both
     // boundaries equal, which violates the "at least one strict" clause), so
     // a non-empty covering set always has at least one minimal element that
-    // survives the filter. Surfacing the invariant as a throw, not a silent
-    // continue, means a future change to strictlyContains that breaks it
-    // fails loudly instead of producing empty render segments.
+    // survives the filter. A throw would surface a regression loudly but
+    // also become an unhandled rejection in AnnotatedText's async watcher
+    // and silently drop the whole render — so log loudly and skip just this
+    // segment, leaving the rest of the article highlighted.
     if (visible.length === 0) {
-      throw new Error('planSegments invariant: visible must be non-empty when covering is non-empty');
+      // eslint-disable-next-line no-console
+      console.error(
+        'planSegments invariant violated: visible empty for non-empty covering at',
+        { start: a, end: b, coveringIdx: covering.map((c) => c.idx) },
+      );
+      continue;
     }
 
     const primary = pickPrimary(visible);

--- a/frontend/src/composables/useNotesSegments.js
+++ b/frontend/src/composables/useNotesSegments.js
@@ -61,7 +61,15 @@ export function planSegments(items) {
     const visible = covering.filter(
       (x) => !covering.some((y) => y !== x && strictlyContains(x, y)),
     );
-    if (visible.length === 0) continue;
+    // Strict containment is asymmetric (A ⊃ B ∧ B ⊃ A would require both
+    // boundaries equal, which violates the "at least one strict" clause), so
+    // a non-empty covering set always has at least one minimal element that
+    // survives the filter. Surfacing the invariant as a throw, not a silent
+    // continue, means a future change to strictlyContains that breaks it
+    // fails loudly instead of producing empty render segments.
+    if (visible.length === 0) {
+      throw new Error('planSegments invariant: visible must be non-empty when covering is non-empty');
+    }
 
     const primary = pickPrimary(visible);
     segments.push({

--- a/frontend/src/composables/useNotesSegments.test.js
+++ b/frontend/src/composables/useNotesSegments.test.js
@@ -1,0 +1,250 @@
+import { describe, it, expect } from 'vitest';
+import { planSegments } from './useNotesSegments.js';
+
+// planSegments replaces the flat-partition overlap drop. These tests pin the
+// boundary-sweep, the encapsulation suppression rule, and the primary
+// tiebreak so the renderer can rely on the plan shape without re-checking.
+
+describe('planSegments', () => {
+  it('returns [] when there are no spans', () => {
+    expect(planSegments([])).toEqual([]);
+  });
+
+  it('skips zero-length spans', () => {
+    expect(
+      planSegments([{ start: 5, end: 5, idx: 0 }]),
+    ).toEqual([]);
+  });
+
+  it('passes a single span through as one segment', () => {
+    expect(
+      planSegments([{ start: 10, end: 20, idx: 0 }]),
+    ).toEqual([
+      {
+        start: 10,
+        end: 20,
+        visibleIdx: [0],
+        coveringIdx: [0],
+        primaryIdx: 0,
+      },
+    ]);
+  });
+
+  it('emits non-overlapping spans as two independent segments', () => {
+    expect(
+      planSegments([
+        { start: 10, end: 20, idx: 0 },
+        { start: 30, end: 40, idx: 1 },
+      ]),
+    ).toEqual([
+      { start: 10, end: 20, visibleIdx: [0], coveringIdx: [0], primaryIdx: 0 },
+      { start: 30, end: 40, visibleIdx: [1], coveringIdx: [1], primaryIdx: 1 },
+    ]);
+  });
+
+  it('splits a partial overlap into three segments, both visible in the middle', () => {
+    // A:[10,20) and B:[15,25) — neither contains the other, both render in
+    // the overlap. Primary in the overlap is A (earlier start).
+    expect(
+      planSegments([
+        { start: 10, end: 20, idx: 0 },
+        { start: 15, end: 25, idx: 1 },
+      ]),
+    ).toEqual([
+      { start: 10, end: 15, visibleIdx: [0], coveringIdx: [0], primaryIdx: 0 },
+      {
+        start: 15,
+        end: 20,
+        visibleIdx: [0, 1],
+        coveringIdx: [0, 1],
+        primaryIdx: 0,
+      },
+      { start: 20, end: 25, visibleIdx: [1], coveringIdx: [1], primaryIdx: 1 },
+    ]);
+  });
+
+  it('suppresses the outer note in the inner-only segment (encapsulation)', () => {
+    // A:[10,50) encapsulates B:[20,30). In [20,30) only B is visible, but A
+    // stays in coveringIdx so hovering A from [10,20) or [30,50) can bridge
+    // back over the inner segment.
+    expect(
+      planSegments([
+        { start: 10, end: 50, idx: 0 },
+        { start: 20, end: 30, idx: 1 },
+      ]),
+    ).toEqual([
+      { start: 10, end: 20, visibleIdx: [0], coveringIdx: [0], primaryIdx: 0 },
+      {
+        start: 20,
+        end: 30,
+        visibleIdx: [1],
+        coveringIdx: [0, 1],
+        primaryIdx: 1,
+      },
+      { start: 30, end: 50, visibleIdx: [0], coveringIdx: [0], primaryIdx: 0 },
+    ]);
+  });
+
+  it('renders identical spans layered — neither strictly contains the other', () => {
+    // Two notes on exactly the same span: both visible, primary by lowest idx.
+    expect(
+      planSegments([
+        { start: 10, end: 20, idx: 0 },
+        { start: 10, end: 20, idx: 1 },
+      ]),
+    ).toEqual([
+      {
+        start: 10,
+        end: 20,
+        visibleIdx: [0, 1],
+        coveringIdx: [0, 1],
+        primaryIdx: 0,
+      },
+    ]);
+  });
+
+  it('handles nested encapsulation (3 levels) with only the innermost visible at the core', () => {
+    // A:[1,100) wraps B:[10,90) wraps C:[20,30). Each outer is suppressed
+    // wherever an inner covers the same segment.
+    const plan = planSegments([
+      { start: 1, end: 100, idx: 0 },
+      { start: 10, end: 90, idx: 1 },
+      { start: 20, end: 30, idx: 2 },
+    ]);
+    expect(plan).toEqual([
+      { start: 1, end: 10, visibleIdx: [0], coveringIdx: [0], primaryIdx: 0 },
+      {
+        start: 10,
+        end: 20,
+        visibleIdx: [1],
+        coveringIdx: [0, 1],
+        primaryIdx: 1,
+      },
+      {
+        start: 20,
+        end: 30,
+        visibleIdx: [2],
+        coveringIdx: [0, 1, 2],
+        primaryIdx: 2,
+      },
+      {
+        start: 30,
+        end: 90,
+        visibleIdx: [1],
+        coveringIdx: [0, 1],
+        primaryIdx: 1,
+      },
+      {
+        start: 90,
+        end: 100,
+        visibleIdx: [0],
+        coveringIdx: [0],
+        primaryIdx: 0,
+      },
+    ]);
+  });
+
+  it('picks the earliest-start note as primary in an overlap', () => {
+    // A:[10,40), B:[20,30) (inside A): primary in the inner segment is B,
+    // because A is suppressed. In the outer A-only flanks, primary is A.
+    const plan = planSegments([
+      { start: 10, end: 40, idx: 5 },
+      { start: 20, end: 30, idx: 9 },
+    ]);
+    expect(plan.map((s) => s.primaryIdx)).toEqual([5, 9, 5]);
+  });
+
+  it('breaks ties on equal start by lowest idx', () => {
+    // Both span [10,20); both visible; primary should be the lower idx, not
+    // the array order. Test order is reversed to make this matter.
+    const plan = planSegments([
+      { start: 10, end: 20, idx: 7 },
+      { start: 10, end: 20, idx: 3 },
+    ]);
+    expect(plan).toHaveLength(1);
+    expect(plan[0].primaryIdx).toBe(3);
+  });
+
+  it('deduplicates a note that contributes two spans to one segment', () => {
+    // A single note (idx 0) has two spans that both cover [15,20) — could
+    // happen if a TextQuoteSelector matches two adjacent occurrences. The
+    // visibleIdx/coveringIdx lists must dedupe so the renderer paints one
+    // background layer, not two of the same colour.
+    const plan = planSegments([
+      { start: 10, end: 20, idx: 0 },
+      { start: 15, end: 25, idx: 0 },
+    ]);
+    // Boundaries 10, 15, 20, 25. Same note covers all three segments.
+    // After merging, every adjacent segment has the same {visible, covering,
+    // primary} so they collapse into one [10,25) segment.
+    expect(plan).toEqual([
+      { start: 10, end: 25, visibleIdx: [0], coveringIdx: [0], primaryIdx: 0 },
+    ]);
+  });
+
+  it('merges adjacent segments with identical coverage', () => {
+    // A:[10,40) and B:[20,30) inside A produce 3 segments, but if another
+    // unrelated note D:[50,60) is added it should NOT introduce extra
+    // boundaries in A's region — already true; this test guards against a
+    // regression where stray boundaries got injected.
+    const plan = planSegments([
+      { start: 10, end: 40, idx: 0 },
+      { start: 20, end: 30, idx: 1 },
+      { start: 50, end: 60, idx: 2 },
+    ]);
+    expect(plan).toEqual([
+      { start: 10, end: 20, visibleIdx: [0], coveringIdx: [0], primaryIdx: 0 },
+      {
+        start: 20,
+        end: 30,
+        visibleIdx: [1],
+        coveringIdx: [0, 1],
+        primaryIdx: 1,
+      },
+      { start: 30, end: 40, visibleIdx: [0], coveringIdx: [0], primaryIdx: 0 },
+      { start: 50, end: 60, visibleIdx: [2], coveringIdx: [2], primaryIdx: 2 },
+    ]);
+  });
+
+  it('handles a three-way partial+encapsulating mix', () => {
+    // A:[10,30), B:[20,40), C:[25,35). A and B partially overlap; B
+    // strictly contains C; C and A partially overlap. In [25,30) all three
+    // cover, but B contains C so B is suppressed there → visible {A, C}.
+    const plan = planSegments([
+      { start: 10, end: 30, idx: 0 },
+      { start: 20, end: 40, idx: 1 },
+      { start: 25, end: 35, idx: 2 },
+    ]);
+    expect(plan).toEqual([
+      { start: 10, end: 20, visibleIdx: [0], coveringIdx: [0], primaryIdx: 0 },
+      {
+        start: 20,
+        end: 25,
+        visibleIdx: [0, 1],
+        coveringIdx: [0, 1],
+        primaryIdx: 0,
+      },
+      {
+        start: 25,
+        end: 30,
+        visibleIdx: [0, 2],
+        coveringIdx: [0, 1, 2],
+        primaryIdx: 0,
+      },
+      {
+        start: 30,
+        end: 35,
+        visibleIdx: [2],
+        coveringIdx: [1, 2],
+        primaryIdx: 2,
+      },
+      {
+        start: 35,
+        end: 40,
+        visibleIdx: [1],
+        coveringIdx: [1],
+        primaryIdx: 1,
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Probleem

Bij twee notities die elkaars tekst overlappen werd er maar één gerenderd
(en niet altijd dezelfde). Een commentregel in \`useNotes.js\` markeerde dit
al als bewust uitgesteld:

> two *different* notes annotating overlapping spans is a legitimate
> RFC-018 case — the later one is silently not rendered here ... the
> note-editing phase will need layered rendering instead of a flat
> partition.

De note-editing phase is sinds #648 live; deze flat-partitie drop is nu
echt een bug — de gebruiker kon niet zien dat er een tweede notitie was,
en welke "won" hing af van de geometrie van de selector.

## Aanpak

Nieuwe pure functie \`planSegments\` (\`useNotesSegments.js\`) projecteert
de spans op een boundary-partitie:

* **Partial overlap** (A:[10,20), B:[15,25)) → drie segmenten; het
  middelste rendert beide noten layered via inline
  \`background-image\` met meerdere \`linear-gradient\`-lagen, dus de twee
  28%-opaque kleuren composite naar een derde tint.
* **Encapsulation** (A:[10,50), B:[20,30)) → de binnenste noot wordt
  schoon getoond in haar segment; de buitenste wordt daar onderdrukt
  maar rendert in haar flanken. \`coveringIdx\` houdt de onderdrukte
  buitenste bereikbaar.
* **Hover-bridge**: elke \`<mark>\` wiens coverage de gehoverde noot
  bevat krijgt \`.note-hovered\` (inset box-shadow underline), zodat de
  gehoverde noot leesbaar is over non-contiguous \`<mark>\`-elementen.
* **Popover** opent voor de earliest-start visible note in het segment.
  Andere overlappers bereik je via een segment waar zij alleen
  zichtbaar zijn.

Border-bottoms blijven single (van de primaire noot) — bewuste keuze
om de scope klein te houden.

## Bijproducten

* \`EditorApp.hiddenDraftCount\` + de "overlapt en wordt niet gemarkeerd"
  waarschuwing verdwijnen: met boundary-rendering is geen draft meer
  echt onzichtbaar, hooguit lokaal onderdrukt.

## Tests

* \`useNotesSegments.test.js\` — 13 tests op de pure functie: no-overlap,
  partial overlap, encapsulation (twee niveaus + drie niveaus),
  identieke spans, primary tiebreak, multi-span dedup, drie-weg mix
  van partial + encapsulating.
* \`AnnotatedText.test.js\` — drie nieuwe component-tests: partial
  overlap drie marks layered, encapsulation drie marks, hover-bridge
  voegt \`.note-hovered\` toe over alle dekkende marks (ook waar
  onderdrukt).
* Full frontend suite: 206/206 groen.

## Test plan

- [ ] Open een wet met twee deels overlappende notities → beide
      backgrounds zichtbaar, mix in het overlap-gebied
- [ ] Hover op een van de twee → continue underline over de volledige
      extent
- [ ] Encapsulation: outer notitie + inner notitie met span erbinnen →
      inner schoon zichtbaar, outer alleen in de flanken
- [ ] Hover op de outer → onderstreping ook in het inner-segment
- [ ] Identieke spans → beide layered, popover van earliest-start