### PR TITLE
docs: prose-opschoning rfc-003, 009, 012, 013, 014, 015

### DIFF
--- a/docs/src/content/rfcs/rfc-003.md
+++ b/docs/src/content/rfcs/rfc-003.md
@@ -10,7 +10,7 @@ title: "RFC-003: Inversion of Control for Delegated Legislation"
 
 Dutch legislation follows a hierarchical delegation pattern: a formal law (*wet*) delegates authority to lower regulatory layers. For example, the Wet op de zorgtoeslag, article 4, delegates the determination of the standard premium (*standaardpremie*) to the minister via a ministerial regulation.
 
-The engine previously supported this via a **top-down** `resolve` action: the higher law explicitly searches for matching lower regulations using `legal_basis` indexes and `select_on` criteria. This inverts the real legal relationship. In practice, a ministerial regulation opens with "In consideration of article 4 of the Wet op de zorgtoeslag" (*"Gelet op artikel 4 van de Wet op de zorgtoeslag"*) — it *registers itself* as filling in a delegated term.
+The engine previously supported this via a **top-down** `resolve` action: the higher law explicitly searches for matching lower regulations using `legal_basis` indexes and `select_on` criteria. This inverts the real legal relationship. In practice, a ministerial regulation opens with "In consideration of article 4 of the Wet op de zorgtoeslag" (*"Gelet op artikel 4 van de Wet op de zorgtoeslag"*). It *registers itself* as filling in a delegated term.
 
 The top-down approach has limitations:
 - The higher law must know how to find its implementations
@@ -54,18 +54,18 @@ machine_readable:
 2. When executing an article with `open_terms`, the engine looks up implementations
 3. **Temporal filtering**: for each candidate, the engine selects the version valid for the calculation date (`valid_from <= calculation_date`). Candidates with no valid version for the requested date are excluded. This ensures that e.g. the 2025 standard premium (*standaardpremie*) is used for a 2025 calculation, even if a 2026 version is also loaded
 4. **Scope filtering**: candidates are filtered against the execution scope (e.g., `gemeente_code`). A scoped regulation only matches when the execution parameters contain the same value. Unscoped (national) regulations always match
-5. **Priority resolution**: among remaining candidates, **lex superior** (higher regulatory layer wins) then **lex posterior** (newer `valid_from` wins). When candidates have the same layer and date, this is ambiguous — the engine returns an error rather than silently picking one. This is a law authoring error that needs fixing
+5. **Priority resolution**: among remaining candidates, **lex superior** (higher regulatory layer wins) then **lex posterior** (newer `valid_from` wins). When candidates have the same layer and date, this is ambiguous: the engine returns an error rather than silently picking one. This is a law authoring error that needs fixing
 6. If found: execute the implementing article to get the value
 7. If not found + has `default`: execute the default actions block
 8. If not found + `required: true` + no default: error
 9. If not found + `required: false` + no default: skip (traced)
-10. **Cycle detection**: if an open term is already being resolved (via `ResolutionContext.visited`), a `CircularReference` error is raised — circular dependencies are a law authoring problem, not something the engine should fix. The cycle detection key uses `\0` (null byte) as separator to prevent key collisions when law IDs or article numbers contain `#`
+10. **Cycle detection**: if an open term is already being resolved (via `ResolutionContext.visited`), a `CircularReference` error is raised. The engine treats circular dependencies as a law authoring problem and does not work around them. The cycle detection key uses `\0` (null byte) as separator to prevent key collisions when law IDs or article numbers contain `#`
 11. **Delegation type validation**: the engine validates that an implementing regulation's `regulatory_layer` matches the open term's `delegation_type`. If a municipal ordinance (*gemeentelijke verordening*) tries to implement a term delegated to a minister, the engine rejects it with a clear error
 12. **Array size validation**: `open_terms` and `implements` arrays are validated against `MAX_ARRAY_SIZE` at law load time, preventing resource exhaustion
 
 ### Temporal model for open term resolution
 
-Temporal filtering is critical for correctness when multiple versions of an implementing regulation are loaded (e.g., the 2024 and 2025 standard premium (*standaardpremie*)). The mechanism works at two levels:
+Temporal filtering is needed for correctness when multiple versions of an implementing regulation are loaded (e.g., the 2024 and 2025 standard premium (*standaardpremie*)). The mechanism works at two levels:
 
 **Same `$id`, multiple versions.** The resolver stores multiple versions of the same law (keyed by `$id`), sorted newest-first. `get_law_for_date` filters these by `valid_from <= calculation_date` and returns the most recent valid version. So for a 2025-01-15 calculation with both `regeling_standaardpremie` versions loaded, the 2025 version is selected. A 2026 version with `valid_from: 2026-01-01` would be excluded because `2026-01-01 <= 2025-01-15` is false.
 
@@ -73,7 +73,7 @@ Temporal filtering is critical for correctness when multiple versions of an impl
 
 **Invariant: `valid_from` must be present on implementing regulations.** The temporal filter uses `is_none_or`, meaning a regulation *without* `valid_from` passes the date check unconditionally — it matches every calculation date. This is by design for laws where the effective date is unknown, but for implementing regulations it undermines temporal correctness. Law authors must ensure that every regulation with an `implements` declaration has an explicit `valid_from` date. The schema does not enforce this (since `valid_from` is optional for other use cases), so this is a convention that must be maintained through review.
 
-**Why not filter in the index?** The `implements_index` is built at load time and is date-independent — it records *all* implementing relationships across all loaded versions. Temporal filtering happens at query time in `find_implementations`, which is the correct place because the calculation date is only known at execution time.
+**Why not filter in the index?** The `implements_index` is built at load time and is date-independent. It records *all* implementing relationships across all loaded versions. Temporal filtering happens at query time in `find_implementations`, which is the correct place because the calculation date is only known at execution time.
 
 ### Same-law routing via `source.output`
 
@@ -135,7 +135,7 @@ source:
   output: verlaging_percentage
 ```
 
-This is backwards. The Participatiewet doesn't know which municipalities (*gemeenten*) have ordinances (*verordeningen*) — it just delegates. The municipal ordinance (*gemeentelijke verordening*) knows which law (*wet*) it implements. IoC corrects this by letting the implementing regulation declare the relationship:
+This is backwards. The Participatiewet doesn't know which municipalities (*gemeenten*) have ordinances (*verordeningen*); it just delegates. The municipal ordinance (*gemeentelijke verordening*) knows which law (*wet*) it implements. IoC corrects this by letting the implementing regulation declare the relationship:
 
 ```yaml
 # New pattern: lower regulation registers itself
@@ -146,7 +146,7 @@ implements:
     gelet_op: Gelet op artikel 8 van de Participatiewet
 ```
 
-The scoping question (which municipality's (*gemeente*) ordinance (*verordening*) applies?) is an engine concern, not a law-encoding concern. The engine already knows the execution scope (e.g., `gemeente_code: GM0384`) from its parameters. The `find_implementations` method uses a `matches_scope` helper that checks all scope fields on the candidate law against execution parameters. Currently supports `gemeente_code`; designed for easy extension to `provincie_code` etc. This eliminates `select_on`, `legal_basis_for`, and `source.delegation` entirely — all delegation flows through `open_terms` + `implements`.
+The engine resolves which municipality's (*gemeente*) ordinance (*verordening*) applies; the law itself does not encode this. The engine already knows the execution scope (e.g., `gemeente_code: GM0384`) from its parameters. The `find_implementations` method uses a `matches_scope` helper that checks all scope fields on the candidate law against execution parameters. Currently supports `gemeente_code`; designed for easy extension to `provincie_code` etc. This eliminates `select_on`, `legal_basis_for`, and `source.delegation` entirely — all delegation flows through `open_terms` + `implements`.
 
 When resolving open terms, the engine does not forward all execution parameters to implementing articles. It uses `filter_parameters_for_article` to only pass parameters declared in the implementing article's `execution.parameters` section (principle of least privilege).
 

--- a/docs/src/content/rfcs/rfc-009.md
+++ b/docs/src/content/rfcs/rfc-009.md
@@ -8,7 +8,7 @@ title: "RFC-009: Multi-Organisation Execution"
 
 ## Context
 
-Prior to this RFC, the engine has no concept of organisational boundaries at execution time — it loads all laws and executes everything in-process. RFC-010 (Federated Corpus) addresses *where laws come from* but not *who executes what*.
+Prior to this RFC, the engine has no concept of organisational boundaries at execution time; it loads all laws and executes everything in-process. RFC-010 (Federated Corpus) addresses *where laws come from* but not *who executes what*.
 
 In reality, Dutch law assigns specific computations to specific organisations. The Healthcare Allowance Act (*Wet op de zorgtoeslag*) assigns execution to Allowances Service (*Dienst Toeslagen*). The Participation Act (*Participatiewet*) assigns execution to the municipality (*gemeente*). The tax inspector (*inspecteur*) alone determines the assessed income (*toetsingsinkomen*). When one law references another law's output, the question is: does the executing organisation compute that value itself, or does it accept another organisation's individual decision (*beschikking*)?
 
@@ -16,14 +16,14 @@ In reality, Dutch law assigns specific computations to specific organisations. T
 
 The General Administrative Law Act (*AWB*) art. 1:3 defines a **decision** (*besluit*) as a written decision by an administrative body (*bestuursorgaan*) containing a public-law legal act. An **individual decision** (*beschikking*) is a decision that is not of general scope — directed at a specific person or case. Only a competent authority (*bevoegd gezag*) can issue an individual decision (*beschikking*), and other organisations are legally bound by it.
 
-A **calculation** (*berekening*) — applying a formula, evaluating a definition, computing an intermediate value — is not a decision (*besluit*). It has no independent legal force. Anyone with the rules and data can perform it.
+A **calculation** (*berekening*), such as applying a formula, evaluating a definition, or computing an intermediate value, is not a decision (*besluit*). It has no independent legal force. Anyone with the rules and data can perform it.
 
 This distinction determines the execution boundary. The schema already captures it through two fields:
 
 - `competent_authority` (RFC-002): which authority is competent to issue the decision
 - `produces.legal_character`: whether the article's output constitutes an individual decision (`BESCHIKKING`), assessment (`TOETS`), or informational output (`INFORMATIEF`)
 
-When an article produces a `BESCHIKKING` and declares a `competent_authority`, only that authority can produce it authoritatively. All other articles — definitions, formulas, sub-checks — can be executed by anyone.
+When an article produces a `BESCHIKKING` and declares a `competent_authority`, only that authority can produce it authoritatively. All other articles (definitions, formulas, sub-checks) can be executed by anyone.
 
 ### Problems with inter-org execution prior to this RFC
 
@@ -41,7 +41,7 @@ Without this RFC, organisations exchange semi-finished products through registri
 
 2. **Identity determines behaviour.** The engine knows which organisation it represents. When it encounters a cross-law reference to an article that produces an individual decision (*beschikking*) with a different `competent_authority`, it accepts rather than executes. Articles that produce definitions or calculations are always executed locally, regardless of which regulation they belong to.
 
-3. **Everyone can simulate.** The competent-authority boundary only applies to authoritative (*voor-recht-geldende*) execution. Anyone can run the full chain locally for analysis, policy exploration, or scenario testing. The difference is in the legal status of the output, not in the engine's capability.
+3. **Everyone can simulate.** The competent-authority boundary only applies to authoritative (*voor-recht-geldende*) execution. Anyone can run the full chain locally for analysis, policy exploration, or scenario testing. The difference is in the legal status of the output; the engine's capability is the same either way.
 
 4. **Transparency by default.** Every execution produces a trace showing which values were computed locally and which were accepted from other organisations, enabling end-to-end auditability across organisational boundaries.
 
@@ -110,7 +110,7 @@ The engine has two independent dimensions, selectable at startup:
 **Connectivity: Solo or Federated**
 
 - **Solo**: the engine executes everything locally. No inter-org calls. When it encounters an article with another org's `competent_authority`, it executes the rules locally anyway (simulation) or errors if it cannot (authoritative without the required dependency).
-- **Federated**: the engine calls other organisations' engines via FSC when it encounters an article with another org's `competent_authority`. If the other engine is unreachable, this is an error — not a silent fallback to local execution.
+- **Federated**: the engine calls other organisations' engines via FSC when it encounters an article with another org's `competent_authority`. If the other engine is unreachable, the engine errors instead of silently falling back to local execution.
 
 **Legal status: Simulation or Authoritative**
 
@@ -304,7 +304,7 @@ sequenceDiagram
 ```
 
 **What changes:**
-- The intermediate BRI registry step is replaced by a direct engine-to-engine call (or engine-to-registry call — the Belastingdienst chooses its implementation)
+- The intermediate BRI registry step is replaced by a direct engine-to-engine call (or an engine-to-registry call; the Belastingdienst chooses its implementation)
 - The assessed income (*toetsingsinkomen*) comes with provenance: which law version, when computed
 - Allowances Service (*Dienst Toeslagen*) can *verify* the accepted value by running the Income Tax Act (*Wet IB*) rules in solo simulation
 - The citizen sees a complete trace: "your healthcare allowance (*zorgtoeslag*) was computed by Allowances Service (*Dienst Toeslagen*) using assessed income (*toetsingsinkomen*) €32.000 as determined by the tax inspector (*inspecteur*) on [date]"
@@ -472,7 +472,7 @@ In **solo simulation** (the default), the engine ignores `competent_authority` e
 - **The citizen's view** — a citizen running the engine in their browser (WASM) can explore the entire chain: "what if my income were X, what would my healthcare allowance (*zorgtoeslag*) be?" They execute everything including the assessed income (*toetsingsinkomen*) calculation. The output is non-authoritative but fully transparent. A future extension (out of scope for this RFC) could allow the engine to fetch the citizen's real data from organisations on behalf of the citizen, using the citizen's own identity.
 - **Policy analysis** — a policy maker can change a rule and see the downstream effects across the entire chain, regardless of organisational boundaries.
 
-In **federated simulation**, the engine has an identity and makes real calls to other engines via FSC, but outputs are non-authoritative. This is for integration testing: the full inter-org chain is exercised, including service discovery, authentication, and the inter-engine protocol. If a called engine is unreachable, this is an error — not a silent fallback to local execution. Demo setups use self-signed identities.
+In **federated simulation**, the engine has an identity and makes real calls to other engines via FSC, but outputs are non-authoritative. This is for integration testing: the full inter-org chain is exercised, including service discovery, authentication, and the inter-engine protocol. If a called engine is unreachable, this is an error; there is no silent fallback to local execution. Demo setups use self-signed identities.
 
 ### Note: data layer and legal basis for inter-org data exchange
 
@@ -524,7 +524,7 @@ The data layer — how engines obtain input data, which registries they connect 
 
 **Alternative 3: Full delegation (call another org's engine for any cross-law reference)**
 - Every cross-law `source.regulation` triggers a remote call to the org that authored the referenced law
-- Rejected: most cross-law references are definitional references (*begripsverwijzingen*) or IoC delegations. Delegating these would mean calling the national government (*Rijksoverheid*) engine for every law that defines a term. The legal reality is that anyone can apply a definition — delegation is only needed for individual decisions (*beschikkingen*).
+- Rejected: most cross-law references are definitional references (*begripsverwijzingen*) or IoC delegations. Delegating these would mean calling the national government (*Rijksoverheid*) engine for every law that defines a term. The legal reality is that anyone can apply a definition; delegation is only needed for individual decisions (*beschikkingen*).
 
 ### Implementation Notes
 

--- a/docs/src/content/rfcs/rfc-012.md
+++ b/docs/src/content/rfcs/rfc-012.md
@@ -8,11 +8,11 @@ title: "RFC-012: Untranslatables"
 
 ## Context
 
-The engine's operation set is deliberately small — arithmetic, comparison, logical, conditional, and a handful of date operations. It only grows when real legal texts demand a new construct. This RFC is about streamlining what happens at that moment of discovery.
+The engine's operation set is deliberately small: arithmetic, comparison, logical, conditional, and a handful of date operations. It only grows when real legal texts demand a new construct. This RFC is about what should happen at that moment of discovery.
 
 Dutch law regularly uses constructs that fall outside the current operation set. The law-generate process (LLM-driven translation from legal Dutch to machine-readable YAML) has no structured way to handle this. Without an explicit "I can't express this" path, the translator will approximate: flattening tables into fragile IF/cases trees, pre-computing dynamic values, silently omitting inexpressible conditions, or inventing creative encodings that pass validation but misrepresent the law.
 
-We call these constructs **untranslatables**: the law is clear about what it means, but the engine's formal language cannot yet express it. The term is borrowed from translation theory — the law-generate process *is* translation, and some things don't cross the boundary between natural language and the engine's operation set.
+We call these constructs **untranslatables**: the law is clear about what it means, but the engine's formal language cannot yet express it. The term is borrowed from translation theory: the law-generate process *is* translation, and some things don't cross the boundary between natural language and the engine's operation set.
 
 ## Decision
 
@@ -51,7 +51,7 @@ machine_readable:
     # ... execution logic for the parts that ARE translatable
 ```
 
-Untranslatables are structured (queryable by tooling), persistent (survive across generate/validate cycles), visible (surfaced in admin dashboard and pipeline), and co-located (next to the article they apply to).
+Untranslatables are stored as structured data, so tooling can query them. They survive across generate/validate cycles, show up in the admin dashboard and pipeline, and sit next to the article they apply to.
 
 The `accepted` field (default `false`) indicates whether a human has reviewed and acknowledged the gap. This enables per-article scoping of runtime behavior (see layer 3).
 
@@ -74,7 +74,7 @@ The trace records untranslatables regardless of mode. The flag controls what the
 
 In `propagate` mode, `UNTRANSLATABLE` behaves like `NaN` in floating point: any operation involving an untranslatable input produces an untranslatable output. The result shows exactly which outputs are tainted and which are trustworthy. The trace captures the origin point.
 
-The `accepted` field provides per-article scoping. In `error` mode (default), accepted untranslatables are allowed to execute their partial logic — a human has verified the gap is tolerable. Unaccepted untranslatables always error in `error` and `ignore` modes. This prevents a global bypass: teams cannot set `--untranslatable=ignore` and accidentally suppress newly-discovered gaps.
+The `accepted` field provides per-article scoping. In `error` mode (default), accepted untranslatables are allowed to execute their partial logic: a human has verified the gap is tolerable. Unaccepted untranslatables always error in `error` and `ignore` modes. This prevents a global bypass: teams cannot set `--untranslatable=ignore` and accidentally suppress newly-discovered gaps.
 
 ## Why
 
@@ -91,10 +91,10 @@ The `accepted` field provides per-article scoping. In `error` mode (default), ac
 ### Tradeoffs
 
 - **More articles will be incomplete** in the short term, because the translator can no longer paper over gaps
-- **Schema change** for layer 2 — all tooling must handle `untranslatables` gracefully
-- **Heuristic detection has false positives** — a legitimate 10-case IF is not necessarily a workaround
-- **LLM compliance is imperfect** — even with explicit instructions, models may still improvise; the reverse-validate heuristics are a safety net, not a guarantee
-- **Propagation adds engine complexity** — a new value type handled in every operation
+- **Schema change** for layer 2: all tooling must handle `untranslatables` gracefully
+- **Heuristic detection has false positives**: a legitimate 10-case IF is not necessarily a workaround
+- **LLM compliance is imperfect**: even with explicit instructions, models may still improvise. The reverse-validate heuristics catch some of this but cannot guarantee detection
+- **Propagation adds engine complexity**: a new value type handled in every operation
 
 ### Alternatives Considered
 

--- a/docs/src/content/rfcs/rfc-013.md
+++ b/docs/src/content/rfcs/rfc-013.md
@@ -8,7 +8,7 @@ title: "RFC-013: Execution Provenance"
 
 ## Context
 
-The engine produces deterministic results: given the same regulation YAML, the same inputs, and the same calculation date, it always produces the same outputs. RFC-006 chose Rust precisely for this guarantee. Determinism within a single execution is necessary but not sufficient. Government agencies must be able to reproduce a specific decision months or years later, with the exact same result.
+The engine produces deterministic results: given the same regulation YAML, the same inputs, and the same calculation date, it always produces the same outputs. RFC-006 chose Rust precisely for this guarantee. Determinism within a single execution is not enough. Government agencies must be able to reproduce a specific decision months or years later, with the exact same result.
 
 Dutch administrative law requires this:
 
@@ -53,7 +53,7 @@ version = "0.6.0"
 supported-schemas = ["v0.5.0", "v0.5.1", "v0.6.0"]
 ```
 
-The engine validates at startup that loaded regulations reference a supported schema version. A regulation referencing an unsupported schema version is a hard error, not a silent fallback to serde-only validation.
+The engine validates at startup that loaded regulations reference a supported schema version. A regulation referencing an unsupported schema version is a hard error; the engine does not silently fall back to serde-only validation.
 
 ### 2. Execution Receipt
 
@@ -181,7 +181,7 @@ $schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/tags/schema-v0
 
 When a schema version is published, a Git tag `schema-vX.Y.Z` is created. GitHub tag protection rules prevent deletion or modification.
 
-The engine embeds schema files at compile time (via `include_str!` in `validate.rs`) and validates by content, not by URL fetch. The URL is a pointer for humans and tooling. The content hash in the Execution Receipt is the integrity anchor.
+The engine embeds schema files at compile time (via `include_str!` in `validate.rs`) and validates by content, not by URL fetch. The URL is a pointer for humans and tooling. Integrity comes from the content hash in the Execution Receipt.
 
 ### 4. Multi-organisation reproducibility
 
@@ -239,7 +239,7 @@ New fields: `engine`, `engine_version`, `schema_version`, `regulation_hash`, and
 
 When reproducing a cross-org decision, the engine uses the **sealed accepted values** stored in the Execution Receipt. It does not call other organisations' engines again.
 
-Why not re-call? The other organisation may now be running a different engine version with different corpus. Re-calling would produce today's answer, not last year's. And legally, a *beschikking* (individual decision) stands once issued. The competent authority's determination at the time is a legal fact. Reproducing Org A's decision means re-executing A's computation with A's engine version, A's regulation, and the accepted values A received at the time.
+Why not re-call? The other organisation may now be running a different engine version with different corpus. Re-calling would produce today's answer; reproduction needs last year's. And legally, a *beschikking* (individual decision) stands once issued. The competent authority's determination at the time is a legal fact. Reproducing Org A's decision means re-executing A's computation with A's engine version, A's regulation, and the accepted values A received at the time.
 
 **Reproduction steps:**
 
@@ -265,7 +265,7 @@ Different organisations will run different engine versions. This is expected and
 - The inter-engine protocol is versioned independently and backward-compatible within a major version
 - Accepted values include engine provenance in their response
 
-Two engine implementations that correctly implement the same schema version must produce identical outputs for identical inputs. When they diverge, one has a bug. A future RFC will define a language-agnostic conformance test suite that formalizes this contract, providing a shared set of input/output test cases any engine implementation can run to prove correctness per schema version.
+Two engine implementations that correctly implement the same schema version must produce identical outputs for identical inputs. When they diverge, one of them has misimplemented the schema. A future RFC will define a language-agnostic conformance test suite that formalizes this contract, providing a shared set of input/output test cases any engine implementation can run to prove correctness per schema version.
 
 ### 5. Compliance requirements as machine-readable regulations
 
@@ -316,7 +316,7 @@ See [RFC-007](/rfcs/rfc-007#output-provenance) for the hook provenance model.
 - Independent versioning lets other organisations build their own engine on their own release cadence.
 - Sealed receipt reproduction makes cross-org decisions traceable and reproducible without requiring cooperation from other orgs at verification time.
 - Versioning the inter-engine protocol separately from the engine lets organisations upgrade at their own pace.
-- Receipts are additive — they extend `ArticleResult` without changing execution logic. Schema enforcement and CI checks can be rolled out phase by phase.
+- Receipts are additive: they extend `ArticleResult` without changing execution logic. Schema enforcement and CI checks can be rolled out phase by phase.
 - The engine declares which schemas it supports. Adding a schema version doesn't break old regulations. Dropping support is an explicit, versioned decision.
 
 ### Tradeoffs

--- a/docs/src/content/rfcs/rfc-014.md
+++ b/docs/src/content/rfcs/rfc-014.md
@@ -201,7 +201,7 @@ The manifest file declares the level structure. Each level lists its test files 
 }
 ```
 
-Levels without new operations (cross_law, ioc, advanced) have an empty `operations` array — they test resolution patterns and features, not additional operation types.
+Levels without new operations (cross_law, ioc, advanced) have an empty `operations` array. They test resolution patterns and features rather than new operation types.
 
 ### 4. Coverage invariant
 
@@ -252,7 +252,7 @@ A new CI job `conformance` runs alongside the existing `test` job. It uses the `
 ### Benefits
 
 - Any organisation can build an engine and prove it behaves correctly by running the conformance suite. No Rust toolchain required.
-- The conformance tests define what each operation *does*. The schema specifies structure; the conformance suite specifies computation. Together they form the complete specification.
+- The schema specifies structure; the conformance suite specifies what each operation *does*. Together they are the complete specification.
 - If an engine change causes a conformance test to fail, it is a behavioral change that must be intentional and versioned (per RFC-013).
 - Third-party engines can start at Core level and work up. They do not need the full operation set to be useful for simple law evaluation.
 - The test format is plain JSON. A test runner is around 50 lines in any language.

--- a/docs/src/content/rfcs/rfc-015.md
+++ b/docs/src/content/rfcs/rfc-015.md
@@ -10,15 +10,13 @@ title: "RFC-015: Engine Policy"
 
 The engine's founding principle is **zero built-in domain knowledge** (RFC-007): all legal and domain knowledge comes from law YAML files and parameters. The engine provides pure operations (arithmetic, comparison, date math) and a resolution framework. It does not know about Easter, King's Day, public holidays, tax rates, or government structure.
 
-The engine does need certain knowledge to function that no specific law declares: the regulatory layer hierarchy (constitutional doctrine), territorial scoping dimensions (gemeente_code, provincie_code), type coercion rules (eurocent rounding), and delegation validation rules. This is the meta-knowledge *about* how to process law, distinct from the law itself. It belongs in configuration, not in the corpus alongside real law, and not compiled into the engine binary.
+The engine does need certain knowledge to function that no specific law declares: the regulatory layer hierarchy (constitutional doctrine), territorial scoping dimensions (gemeente_code, provincie_code), type coercion rules (eurocent rounding), and delegation validation rules. This is the meta-knowledge *about* how to process law, distinct from the law itself. It belongs in configuration, separate from both the corpus where real law lives and the engine binary.
 
 ## Decision
 
 ### 1. Engine Policy as structured configuration
 
-The engine reads its domain knowledge from an **Engine Policy** file at startup: a YAML configuration file that defines the meta-rules for law execution.
-
-The Engine Policy is engine configuration expressed in structured YAML, separate from the corpus.
+The engine reads its domain knowledge from an **Engine Policy** file at startup: a YAML configuration file, separate from the corpus, that defines the meta-rules for law execution.
 
 ```yaml
 # engine-policy.yaml
@@ -144,7 +142,7 @@ The engine binary contains no Dutch legal knowledge. Everything comes from law Y
 
 The policy is in the Execution Receipt, so an auditor can see which hierarchy and scoping rules were active for any decision. Policy changes are tracked in version control like any other configuration.
 
-Organizations can customize without forking. A water board adds `waterschap_code` as a scope dimension. A test harness uses a simplified hierarchy. A future non-Dutch deployment replaces the entire policy.
+Organizations can customize without forking. A water board can add `waterschap_code` as a scope dimension. A test harness might use a simplified hierarchy, and a non-Dutch deployment would replace the policy entirely.
 
 ### Tradeoffs
 


### PR DESCRIPTION
Leesbaarheid-verbeteringen in zes RFC's: em-streepjes vervangen door dubbele punt/punt/haakjes waar passend, negatieve parallellen ("X, niet Y") positief herformuleerd, één gedupliceerde definitie samengevoegd, opgeblazen woordkeuze (*critical*, *streamline*) vervangen door gewone termen.

Geen structurele of inhoudelijke wijzigingen — alleen prose.