### PR TITLE
feat(editor): traject op basis van eigen GitHub-repo + verified-email enforcement

### DIFF
--- a/docs/src/content/docs/operations/private-repo-trajects.md
+++ b/docs/src/content/docs/operations/private-repo-trajects.md
@@ -1,0 +1,126 @@
+---
+title: "Private-repo trajects"
+---
+
+Vanaf [PR #704](https://github.com/MinBZK/regelrecht/pull/704) kan een traject in de editor gekoppeld worden aan een **eigen GitHub-repo** in plaats van de centrale `MinBZK/regelrecht-corpus`. Handig voor organisaties of teams die hun regelgeving in een private repo willen beheren, met behoud van Regelrecht's editor- en attributie-eigenschappen.
+
+Deze pagina beschrijft de end-to-end flow: wat je als eindgebruiker, traject-eigenaar en operator moet doen.
+
+## Hoe het werkt op hoofdlijnen
+
+- Bij het aanmaken van een traject kies je **of** de centrale MinBZK-repo (default), **of** een eigen `owner/repo` + base branch.
+- Authenticatie naar de eigen repo gebeurt met een **GitHub Personal Access Token** (fine-grained) die door de **operator van het Regelrecht-deployment** als environment variable wordt geconfigureerd. Tokens leven dus niet in de database en niet in de browser — alleen in de runtime-omgeving van de editor.
+- Commits in de repo verschijnen onder **de naam en het email-adres van de echte gebruiker** (afkomstig uit de OIDC-sessie, mits geverifieerd door de IdP). Niet onder een service-account.
+
+## Wie doet wat
+
+| Rol | Actie |
+|---|---|
+| Repo-eigenaar (of admin) | Maakt een GitHub-PAT met schrijfrechten op de target-repo |
+| Operator | Configureert de PAT als env var op het editor-deployment (eenmalig per repo) |
+| Traject-eigenaar | Maakt het traject aan in de editor met de eigen repo-velden |
+| Deelnemers | Loggen in via SSO; saves verschijnen automatisch onder hun eigen naam |
+
+## Stap 1 — Bereid de GitHub-repo voor
+
+De target-repo moet aan twee voorwaarden voldoen vóór je 'm kunt koppelen:
+
+1. **De `base branch` bestaat al** (met minstens één commit). De editor maakt een eigen feature-branch áf van deze base — als de base nog niet bestaat (bv. een leeg gestelde `main`), faalt de validatie. Maak desnoods een lege README-commit op `main` om de branch te initialiseren.
+2. **Het PAT-account heeft push-rechten op de repo**. Voor private repo's: de PAT moet voor die specifieke repo aangevraagd zijn met de juiste scopes (zie stap 2).
+
+> De repo mag publiek of private zijn. Voor publieke repos gelden GitHub's rate-limits van het tokenless API-endpoint zonder PAT — voor private repo's is een PAT verplicht voor zowel reads als writes.
+
+## Stap 2 — Maak een GitHub PAT aan
+
+Genereer een **fine-grained PAT** op [github.com/settings/personal-access-tokens/new](https://github.com/settings/personal-access-tokens/new):
+
+- **Resource owner**: de owner van de target-repo (persoonlijk account of organisatie)
+- **Repository access**: "Only select repositories" → kies precies de target-repo (níét "all repositories", houd de blast radius klein)
+- **Repository permissions**:
+  - `Contents`: **Read and write** — nodig voor commits + branch-creatie
+  - `Pull requests`: **Read and write** — nodig om de session-PR te openen en bij te werken
+  - `Metadata`: **Read** (verplicht en auto-geselecteerd)
+- **Expiration**: kies een termijn die past bij je security-beleid. PAT's verlopen — bij verloop weigert de editor nieuwe saves en moet de operator de env var verversen.
+
+Sla de waarde van de PAT direct op een veilige plek op (GitHub toont 'm maar één keer).
+
+> Classic PATs werken ook, maar geven veel te brede toegang (alle repo's waar je toegang toe hebt). Fine-grained is sterk aanbevolen.
+
+## Stap 3 — Operator configureert de env var
+
+Geef je operator deze drie dingen:
+
+1. De `owner/repo` van de target-repo (bv. `acme/regelrecht-lokaal`)
+2. De gegenereerde PAT-waarde
+3. Een korte beschrijving van het doel (voor audit-doeleinden)
+
+De operator zet de PAT als environment variable op het editor-deployment met de naam:
+
+```
+CORPUS_AUTH_<OWNER>_<REPO>_TOKEN
+```
+
+waarbij `<OWNER>_<REPO>` een **deterministische slug** is van de coordinates: lowercase, alle niet-alfanumerieke tekens vervangen door `-`, vervolgens hoofdletters en dashes naar underscores. Voorbeelden:
+
+| owner/repo | env var |
+|---|---|
+| `MinBZK/regelrecht-corpus` | `CORPUS_AUTH_MINBZK_REGELRECHT_CORPUS_TOKEN` |
+| `acme/regels` | `CORPUS_AUTH_ACME_REGELS_TOKEN` |
+| `tdjager/regelrecht-private-test` | `CORPUS_AUTH_TDJAGER_REGELRECHT_PRIVATE_TEST_TOKEN` |
+
+De operator weet hoe ze env vars op het cluster moeten zetten — dat is omgevings-specifiek (ZAD, Kubernetes, docker-compose). Na de wijziging moet de editor-pod herstart worden zodat de nieuwe var wordt opgepikt. **Eén env var per repo** — als meerdere trajects naar dezelfde repo wijzen, is één configuratie genoeg.
+
+> Wanneer je het traject probeert aan te maken vóórdat de env var bestaat, krijg je een nette foutmelding die exact de verwachte env-var-naam toont. Geef die naam letterlijk door aan je operator.
+
+## Stap 4 — Maak het traject aan
+
+In de editor:
+
+1. Klik **"Nieuw traject"** in het traject-menu.
+2. Vul **naam**, **beschrijving** en **scope** in.
+3. Zet de schakelaar **"Eigen GitHub-repo gebruiken"** aan.
+4. Vul `repo_owner`, `repo_name` en `base_branch` in. Eventueel `repo_path` als je YAML-bestanden in een subdirectory zitten (default: repo root).
+5. Klik **"Aanmaken"**.
+
+De editor doet vóór het aanmaken een **pre-flight check** tegen de GitHub-API:
+- Bestaat de repo en is 'ie zichtbaar voor de geconfigureerde token?
+- Heeft de token push-rechten?
+- Bestaat de opgegeven base-branch?
+
+Faalt één van deze checks, dan zie je een gerichte foutmelding (zie [foutmeldingen](#foutmeldingen-en-wat-ze-betekenen) hieronder). Geen rij in de database — je kunt direct opnieuw proberen na correctie.
+
+## Hoe commit-attributie werkt
+
+Elke save in een traject produceert een commit op de session-branch met:
+
+- **Author**: `<jouw OIDC-naam> <jouw OIDC email>` (uit Keycloak)
+- **Committer**: het service-account dat het deployment runt (dit is wat GitHub als "pushed by" registreert in de Push Events)
+- **`Co-authored-by:` trailer**: identiek aan de author — dubbele credit zodat GitHub de commit ook in jouw Contributions-graph laat zien
+
+Voor de UI-weergave op GitHub geldt: als jouw OIDC-email een verified email is op je GitHub-account, dan toont GitHub jouw avatar en naam bij elke commit, en linkt 'ie naar je profile. Geen mapping verified? Dan wordt de email als string getoond, zonder profile-link, maar nog steeds met de juiste naam.
+
+> De editor weigert saves wanneer Keycloak's `email_verified` claim niet `true` is. Dit voorkomt dat een gebruiker met een ongeverifieerd email-claim onder die naam zou kunnen committen. Krijg je hiervan een 403, log dan opnieuw in (refresht de claim) of vraag je beheerder om je account-instellingen te controleren.
+
+## Foutmeldingen en wat ze betekenen
+
+Wanneer je traject-create faalt, toont de UI een specifieke melding. De belangrijkste:
+
+| Statuscode | Melding | Wat je moet doen |
+|---|---|---|
+| 503 | "deze repo is nog niet door je beheerder geconfigureerd (verwacht env var X)" | Vraag de operator de getoonde env-var-naam te configureren |
+| 401 | "het token van je beheerder wordt door GitHub geweigerd" | PAT is verlopen of ongeldig — vraag operator om verversing |
+| 403 | "het geconfigureerde token heeft geen schrijftoegang tot deze repo" | PAT mist `Contents: write` of de PAT-account is geen collaborator op de repo |
+| 404 | "repo X bestaat niet of het token kan 'm niet zien" | Tikfout in owner/repo, of de fine-grained PAT is niet aan deze repo gekoppeld |
+| 404 | "branch 'X' bestaat niet op owner/repo" | De `base_branch` bestaat nog niet op de repo — initialiseer 'm met minstens één commit |
+| 400 | "alleen letters, cijfers, en '-', '_', '.'" | owner, repo of subpath bevat ongeldige karakters |
+| 400 | "moeten alle drie worden meegegeven" | Eigen-repo-toggle staat aan maar één van owner/repo/base_branch is leeg |
+| 502 | "onverwacht antwoord van GitHub bij repo-validatie" | Tijdelijke GitHub-issue; probeer opnieuw |
+
+Tijdens het bewerken kunnen ook saves falen. De meeste meldingen zijn vergelijkbaar; bij een 403 over "geverifieerd e-mailadres" is opnieuw inloggen meestal de oplossing.
+
+## Beperkingen en aandachtspunten
+
+- **Per-repo PAT, niet per-user**. Alle deelnemers aan het traject committen via dezelfde token, maar onder hun eigen naam (via Author/Co-authored-by). GitHub Push Events tonen altijd het service-account als "pushed by" — voor harde per-user audit is dat niet voldoende; gebruik daarvoor de editor-API's audit-logs of de PR's commit-graaf.
+- **PAT-verloop is operator-werk**. De editor weigert reads/writes zodra de PAT door GitHub geweigerd wordt; de operator moet 'm dan verversen. Plan dit in.
+- **Geen self-service**. Voor elke nieuwe repo moet een operator een env var configureren. Voor occasioneel gebruik is dat prima; voor schaalbare zelfbediening is een **GitHub App** een betere richting (geparkeerd voor latere fase).
+- **Geen tokens in DB of browser**. Bewust ontwerp: een bug, breach of insider met DB-toegang kan geen tokens exfiltreren. Wel betekent dit dat tokens niet "even snel" zelf zijn in te stellen.

--- a/docs/src/content/docs/operations/private-repo-trajects.md
+++ b/docs/src/content/docs/operations/private-repo-trajects.md
@@ -108,7 +108,7 @@ Wanneer je traject-create faalt, toont de UI een specifieke melding. De belangri
 | Statuscode | Melding | Wat je moet doen |
 |---|---|---|
 | 503 | "deze repo is nog niet door je beheerder geconfigureerd (verwacht env var X)" | Vraag de operator de getoonde env-var-naam te configureren |
-| 401 | "het token van je beheerder wordt door GitHub geweigerd" | PAT is verlopen of ongeldig — vraag operator om verversing |
+| 502 | "het token van je beheerder wordt door GitHub geweigerd" | PAT is verlopen of ongeldig — vraag operator om verversing |
 | 403 | "het geconfigureerde token heeft geen schrijftoegang tot deze repo" | PAT mist `Contents: write` of de PAT-account is geen collaborator op de repo |
 | 404 | "repo X bestaat niet of het token kan 'm niet zien" | Tikfout in owner/repo, of de fine-grained PAT is niet aan deze repo gekoppeld |
 | 404 | "branch 'X' bestaat niet op owner/repo" | De `base_branch` bestaat nog niet op de repo — initialiseer 'm met minstens één commit |
@@ -124,3 +124,10 @@ Tijdens het bewerken kunnen ook saves falen. De meeste meldingen zijn vergelijkb
 - **PAT-verloop is operator-werk**. De editor weigert reads/writes zodra de PAT door GitHub geweigerd wordt; de operator moet 'm dan verversen. Plan dit in.
 - **Geen self-service**. Voor elke nieuwe repo moet een operator een env var configureren. Voor occasioneel gebruik is dat prima; voor schaalbare zelfbediening is een **GitHub App** een betere richting (geparkeerd voor latere fase).
 - **Geen tokens in DB of browser**. Bewust ontwerp: een bug, breach of insider met DB-toegang kan geen tokens exfiltreren. Wel betekent dit dat tokens niet "even snel" zelf zijn in te stellen.
+
+## Rollout-aandachtspunten (alleen relevant bij de eerste deploy)
+
+De eerste deploy met deze feature scherpt twee oude paden aan; controleer onderstaande punten op je deployment vóór je de release uitrolt.
+
+- **De writable-own source gebruikt voortaan strikte token-resolutie** (geen `CORPUS_GIT_TOKEN`-fallback). Bestaande trajects die via de central MinBZK-repo committen, hebben dus `CORPUS_AUTH_MINBZK_CENTRAL_TOKEN` nodig als losse env var. Deployments die tot nu toe leunden op alleen `CORPUS_GIT_TOKEN` voor het centrale schrijfpad, zien stille push-failures na de release als die env var ontbreekt. Zet 'm vóór deploy en check de editor-logs op de eerste run; de diagnostic-log toont expliciet de verwachte env-var-naam wanneer de resolver `None` returnt voor de writable-own source.
+- **Bestaande SSO-sessies missen de nieuwe `email_verified`-claim**. Eerste save na deploy levert dan een 403 op met de melding "log opnieuw in". Geen onderhoud, geen migratie — gewoon eenmalig opnieuw inloggen lost het op.

--- a/docs/src/lib/sidebar.ts
+++ b/docs/src/lib/sidebar.ts
@@ -114,6 +114,7 @@ export const sidebar: Record<string, SidebarGroup[]> = {
       text: 'Corpus Management',
       items: [
         { text: 'Adding a Law', link: '/operations/adding-a-law' },
+        { text: 'Private-repo trajects', link: '/operations/private-repo-trajects' },
       ],
     },
     {

--- a/frontend/src/components/TrajectMenu.vue
+++ b/frontend/src/components/TrajectMenu.vue
@@ -77,6 +77,11 @@ function emptyForm() {
     repo_owner: '',
     repo_name: '',
     base_branch: 'main',
+    // Sub-path within the repo where regulation YAML files live. Empty
+    // means "everything under repo root" — the right default for user
+    // repos dedicated to regulations. Set to e.g. `regulation/nl` when
+    // the YAMLs live in a sub-directory.
+    repo_path: '',
   };
 }
 
@@ -165,6 +170,13 @@ async function submitCreate() {
     payload.repo_owner = owner;
     payload.repo_name = repo;
     payload.base_branch = branch;
+    // `repo_path` is optional; only attach when the user filled it in
+    // so the backend keeps using its empty-string default ("repo root")
+    // for personal regulation repos.
+    const subpath = form.value.repo_path.trim();
+    if (subpath) {
+      payload.repo_path = subpath;
+    }
   }
 
   createBusy.value = true;
@@ -366,6 +378,21 @@ function bind(field) {
                   size="md"
                   :value="form.base_branch"
                   @input="bind('base_branch')($event)"
+                ></nldd-text-field>
+              </nldd-cell>
+            </nldd-list-item>
+            <nldd-list-item size="md">
+              <nldd-text-cell
+                text="Subpath (optioneel)"
+                supporting-text="Submap met regulation YAML-bestanden. Laat leeg voor repo-root."
+                max-width="180px"
+              ></nldd-text-cell>
+              <nldd-spacer-cell size="8"></nldd-spacer-cell>
+              <nldd-cell>
+                <nldd-text-field
+                  size="md"
+                  :value="form.repo_path"
+                  @input="bind('repo_path')($event)"
                 ></nldd-text-field>
               </nldd-cell>
             </nldd-list-item>

--- a/frontend/src/components/TrajectMenu.vue
+++ b/frontend/src/components/TrajectMenu.vue
@@ -70,6 +70,13 @@ function emptyForm() {
     name: '',
     description: '',
     scope: '',
+    // When `useCustomRepo` is false the create call omits the repo
+    // fields and the backend falls back to the default MinBZK repo —
+    // existing trajects keep their behaviour unchanged.
+    useCustomRepo: false,
+    repo_owner: '',
+    repo_name: '',
+    base_branch: 'main',
   };
 }
 
@@ -136,13 +143,33 @@ async function submitCreate() {
     createError.value = 'Naam is verplicht';
     return;
   }
+
+  // Build the request body. Only attach the repo fields when the toggle
+  // is on — leaving them out lets the backend pick the MinBZK default
+  // so existing flows are unchanged for users who don't need a custom
+  // repo.
+  const payload = {
+    name: form.value.name.trim(),
+    description: form.value.description,
+    scope: form.value.scope,
+  };
+  if (form.value.useCustomRepo) {
+    const owner = form.value.repo_owner.trim();
+    const repo = form.value.repo_name.trim();
+    const branch = form.value.base_branch.trim();
+    if (!owner || !repo || !branch) {
+      createError.value =
+        'Eigen repo: vul owner, repo en base-branch in (of zet de schakelaar uit).';
+      return;
+    }
+    payload.repo_owner = owner;
+    payload.repo_name = repo;
+    payload.base_branch = branch;
+  }
+
   createBusy.value = true;
   try {
-    const created = await createTraject({
-      name: form.value.name.trim(),
-      description: form.value.description,
-      scope: form.value.scope,
-    });
+    const created = await createTraject(payload);
     showCreate.value = false;
     // Jump straight into the new traject — same per-tab navigation as
     // selecting from the dropdown. Mirror the `selectTraject` guard:
@@ -288,10 +315,78 @@ function bind(field) {
             </nldd-list-item>
           </nldd-list>
 
+          <div class="traject-source-toggle">
+            <nldd-switch
+              :checked="form.useCustomRepo ? true : undefined"
+              @change="form.useCustomRepo = Boolean($event.detail?.checked)"
+            ></nldd-switch>
+            <label>Eigen GitHub-repo gebruiken (i.p.v. de standaard MinBZK-repo)</label>
+          </div>
+
+          <nldd-list v-if="form.useCustomRepo" variant="box" class="traject-form-list">
+            <nldd-list-item size="md">
+              <nldd-text-cell
+                text="Repo owner"
+                supporting-text="Organisatie of gebruiker op GitHub, bijv. 'MinBZK'."
+                max-width="180px"
+              ></nldd-text-cell>
+              <nldd-spacer-cell size="8"></nldd-spacer-cell>
+              <nldd-cell>
+                <nldd-text-field
+                  size="md"
+                  :value="form.repo_owner"
+                  @input="bind('repo_owner')($event)"
+                ></nldd-text-field>
+              </nldd-cell>
+            </nldd-list-item>
+            <nldd-list-item size="md">
+              <nldd-text-cell
+                text="Repo"
+                supporting-text="Naam van de repository."
+                max-width="180px"
+              ></nldd-text-cell>
+              <nldd-spacer-cell size="8"></nldd-spacer-cell>
+              <nldd-cell>
+                <nldd-text-field
+                  size="md"
+                  :value="form.repo_name"
+                  @input="bind('repo_name')($event)"
+                ></nldd-text-field>
+              </nldd-cell>
+            </nldd-list-item>
+            <nldd-list-item size="md">
+              <nldd-text-cell
+                text="Base branch"
+                supporting-text="Branch waarop het traject z'n PR opent (vaak 'main')."
+                max-width="180px"
+              ></nldd-text-cell>
+              <nldd-spacer-cell size="8"></nldd-spacer-cell>
+              <nldd-cell>
+                <nldd-text-field
+                  size="md"
+                  :value="form.base_branch"
+                  @input="bind('base_branch')($event)"
+                ></nldd-text-field>
+              </nldd-cell>
+            </nldd-list-item>
+          </nldd-list>
+
           <div class="traject-source-hint">
-            Edits in dit traject worden gepusht naar een aparte branch op
-            <code>MinBZK/regelrecht-corpus</code> (basis: <code>development</code>).
-            Per-gebruiker GitHub-auth komt later.
+            <template v-if="form.useCustomRepo">
+              Edits worden gepusht naar
+              <code>{{ form.repo_owner || '…' }}/{{ form.repo_name || '…' }}</code>
+              (basis: <code>{{ form.base_branch || 'main' }}</code>).
+              Je beheerder moet voor deze repo een <code>CORPUS_AUTH_*_TOKEN</code>
+              env-var hebben gezet — anders krijg je een foutmelding bij aanmaken.
+              Commits verschijnen onder je eigen naam (uit je SSO-account), niet
+              onder het service-account.
+            </template>
+            <template v-else>
+              Edits in dit traject worden gepusht naar een aparte branch op
+              <code>MinBZK/regelrecht-corpus</code> (basis:
+              <code>development</code>). Commits verschijnen onder je eigen naam
+              (uit je SSO-account).
+            </template>
           </div>
 
           <div v-if="createError" class="traject-error">{{ createError }}</div>
@@ -323,6 +418,17 @@ function bind(field) {
 }
 .traject-form-list nldd-text-field {
   width: 100%;
+}
+.traject-source-toggle {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 16px 0 8px;
+  font-size: 14px;
+}
+.traject-source-toggle label {
+  cursor: pointer;
+  user-select: none;
 }
 .traject-source-hint {
   margin-top: 16px;

--- a/frontend/src/components/TrajectMenu.vue
+++ b/frontend/src/components/TrajectMenu.vue
@@ -327,13 +327,17 @@ function bind(field) {
             </nldd-list-item>
           </nldd-list>
 
-          <div class="traject-source-toggle">
+          <!-- The `<label>` wraps the switch so clicking the label text
+               toggles the control and screen readers announce the two
+               together — `for=`/`id=` pairing is harder to keep stable
+               across NDD's slotted internals. -->
+          <label class="traject-source-toggle">
             <nldd-switch
               :checked="form.useCustomRepo ? true : undefined"
               @change="form.useCustomRepo = Boolean($event.detail?.checked)"
             ></nldd-switch>
-            <label>Eigen GitHub-repo gebruiken (i.p.v. de standaard MinBZK-repo)</label>
-          </div>
+            <span>Eigen GitHub-repo gebruiken (i.p.v. de standaard MinBZK-repo)</span>
+          </label>
 
           <nldd-list v-if="form.useCustomRepo" variant="box" class="traject-form-list">
             <nldd-list-item size="md">
@@ -452,8 +456,6 @@ function bind(field) {
   gap: 10px;
   margin: 16px 0 8px;
   font-size: 14px;
-}
-.traject-source-toggle label {
   cursor: pointer;
   user-select: none;
 }

--- a/packages/auth/src/handlers.rs
+++ b/packages/auth/src/handlers.rs
@@ -24,6 +24,13 @@ pub const SESSION_KEY_PKCE_VERIFIER: &str = "oidc_pkce_verifier";
 pub const SESSION_KEY_AUTHENTICATED: &str = "authenticated";
 pub const SESSION_KEY_SUB: &str = "person_sub";
 pub const SESSION_KEY_EMAIL: &str = "person_email";
+/// Whether the upstream IdP claims the email is verified
+/// (`email_verified=true` claim). Stored as a `bool`; absent or `false`
+/// means the email failed verification (or no claim was sent) and
+/// downstream code that attributes actions to the user should refuse
+/// rather than fall back to a service identity (see
+/// `editor_user_from_session` in editor-api).
+pub const SESSION_KEY_EMAIL_VERIFIED: &str = "person_email_verified";
 pub const SESSION_KEY_NAME: &str = "person_name";
 pub const SESSION_KEY_ID_TOKEN: &str = "id_token_hint";
 pub const SESSION_KEY_ROLES: &str = "person_roles";
@@ -304,6 +311,11 @@ pub async fn callback<S: OidcAppState>(
 
     let sub = claims.subject().as_str().to_string();
     let email = claims.email().map(|e| (**e).clone()).unwrap_or_default();
+    // Standard OIDC `email_verified` claim — `false`/missing is the
+    // safe default. Editor commit attribution refuses to use the email
+    // when this is `false`, so a misconfigured IdP fails closed instead
+    // of letting a spoofed email through.
+    let email_verified = claims.email_verified().unwrap_or(false);
     let name = claims
         .name()
         .and_then(|n| n.get(None).map(|v| (**v).clone()))
@@ -332,6 +344,15 @@ pub async fn callback<S: OidcAppState>(
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
     session_insert(&session, SESSION_KEY_SUB, sub.clone()).await?;
     session_insert(&session, SESSION_KEY_EMAIL, email.clone()).await?;
+    // `email_verified` is a bool, not a String — go through `insert`
+    // directly. Same error mapping as `session_insert` for consistency.
+    session
+        .insert(SESSION_KEY_EMAIL_VERIFIED, email_verified)
+        .await
+        .map_err(|e| {
+            tracing::error!(key = SESSION_KEY_EMAIL_VERIFIED, error = %e, "failed to insert into session");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
     session_insert(&session, SESSION_KEY_NAME, name.clone()).await?;
     session_insert(&session, SESSION_KEY_ID_TOKEN, id_token_jwt).await?;
     // Persist the realm roles so route-level `require_role` middleware can

--- a/packages/auth/src/lib.rs
+++ b/packages/auth/src/lib.rs
@@ -15,8 +15,8 @@ pub mod test_utils;
 
 pub use config::{parse_base_url, parse_oidc_from_env, OidcConfig};
 pub use handlers::{
-    AuthStatus, PersonInfo, SESSION_KEY_AUTHENTICATED, SESSION_KEY_EMAIL, SESSION_KEY_NAME,
-    SESSION_KEY_ROLES, SESSION_KEY_SUB,
+    AuthStatus, PersonInfo, SESSION_KEY_AUTHENTICATED, SESSION_KEY_EMAIL,
+    SESSION_KEY_EMAIL_VERIFIED, SESSION_KEY_NAME, SESSION_KEY_ROLES, SESSION_KEY_SUB,
 };
 pub use middleware::{
     check_session_role, require_role, require_session_auth, security_headers, RoleCheck,

--- a/packages/corpus/src/auth.rs
+++ b/packages/corpus/src/auth.rs
@@ -2,6 +2,22 @@ use std::path::Path;
 
 use crate::error::{CorpusError, Result};
 
+/// Construct the per-source token env-var name from a slug.
+///
+/// Single source of truth — used by the resolver and surfaced in
+/// operator-facing error messages so the name shown to the operator
+/// matches what the resolver actually looks up. Keeping it in one place
+/// guarantees that if the naming scheme ever changes (lowercase prefix,
+/// extra separator, etc.) the resolver and the diagnostic log can't
+/// silently drift apart and confuse an operator who follows the error
+/// message.
+pub fn token_env_name(auth_ref: &str) -> String {
+    format!(
+        "CORPUS_AUTH_{}_TOKEN",
+        auth_ref.to_uppercase().replace('-', "_")
+    )
+}
+
 /// Auth configuration for a corpus source, loaded from `corpus-auth.yaml`.
 #[derive(Debug, Clone, serde::Deserialize)]
 pub struct AuthConfig {
@@ -65,10 +81,7 @@ pub fn resolve_token_for_source(
 /// to a repo the attacker controls, a token-exfiltration vector.
 pub fn resolve_token_strict(auth_ref: &str, auth_file: Option<&Path>) -> Result<Option<String>> {
     // 1. Per-source environment variable
-    let env_key = format!(
-        "CORPUS_AUTH_{}_TOKEN",
-        auth_ref.to_uppercase().replace('-', "_")
-    );
+    let env_key = token_env_name(auth_ref);
     if let Ok(token) = std::env::var(&env_key) {
         if !token.is_empty() {
             return Ok(Some(token));
@@ -119,10 +132,7 @@ pub fn resolve_token_strict(auth_ref: &str, auth_file: Option<&Path>) -> Result<
 /// 4. None (unauthenticated, lower rate limits).
 pub fn resolve_token(source_id: &str, auth_file: Option<&Path>) -> Result<Option<String>> {
     // 1. Per-source environment variable
-    let env_key = format!(
-        "CORPUS_AUTH_{}_TOKEN",
-        source_id.to_uppercase().replace('-', "_")
-    );
+    let env_key = token_env_name(source_id);
     if let Ok(token) = std::env::var(&env_key) {
         if !token.is_empty() {
             return Ok(Some(token));

--- a/packages/corpus/src/auth.rs
+++ b/packages/corpus/src/auth.rs
@@ -88,31 +88,43 @@ pub fn resolve_token_strict(auth_ref: &str, auth_file: Option<&Path>) -> Result<
         }
     }
 
-    // 2. Auth file. Same parser as `resolve_token` below; we deliberately
-    // do NOT fall through to `CORPUS_GIT_TOKEN` afterwards.
-    if let Some(path) = auth_file {
-        if path.exists() {
-            let content = std::fs::read_to_string(path).map_err(|e| {
-                CorpusError::Config(format!(
-                    "Failed to read auth file {}: {}",
-                    path.display(),
-                    e
-                ))
-            })?;
-            let config: AuthConfig = serde_yaml_ng::from_str(&content).map_err(|e| {
-                CorpusError::Config(format!(
-                    "Failed to parse auth file {}: {}",
-                    path.display(),
-                    e
-                ))
-            })?;
-            if let Some(entry) = config.sources.iter().find(|s| s.id == auth_ref) {
-                return Ok(Some(entry.token.clone()));
-            }
-        }
-    }
+    // 2. Auth file. We deliberately do NOT fall through to
+    // `CORPUS_GIT_TOKEN` afterwards — see `resolve_token` for the legacy
+    // fallback path.
+    find_in_auth_file(auth_ref, auth_file)
+}
 
-    Ok(None)
+/// Read the auth file (if any) and look up `auth_ref` in it. Returns
+/// `None` when the file is absent or the ref isn't listed. Shared
+/// between [`resolve_token`] and [`resolve_token_strict`] so both
+/// parsers stay in lock-step — a future change to the auth-file shape
+/// only needs to land here.
+fn find_in_auth_file(auth_ref: &str, auth_file: Option<&Path>) -> Result<Option<String>> {
+    let Some(path) = auth_file else {
+        return Ok(None);
+    };
+    if !path.exists() {
+        return Ok(None);
+    }
+    let content = std::fs::read_to_string(path).map_err(|e| {
+        CorpusError::Config(format!(
+            "Failed to read auth file {}: {}",
+            path.display(),
+            e
+        ))
+    })?;
+    let config: AuthConfig = serde_yaml_ng::from_str(&content).map_err(|e| {
+        CorpusError::Config(format!(
+            "Failed to parse auth file {}: {}",
+            path.display(),
+            e
+        ))
+    })?;
+    Ok(config
+        .sources
+        .iter()
+        .find(|s| s.id == auth_ref)
+        .map(|entry| entry.token.clone()))
 }
 
 /// Look up a GitHub token by key.
@@ -140,28 +152,8 @@ pub fn resolve_token(source_id: &str, auth_file: Option<&Path>) -> Result<Option
     }
 
     // 2. Auth file
-    if let Some(path) = auth_file {
-        if path.exists() {
-            let content = std::fs::read_to_string(path).map_err(|e| {
-                CorpusError::Config(format!(
-                    "Failed to read auth file {}: {}",
-                    path.display(),
-                    e
-                ))
-            })?;
-
-            let config: AuthConfig = serde_yaml_ng::from_str(&content).map_err(|e| {
-                CorpusError::Config(format!(
-                    "Failed to parse auth file {}: {}",
-                    path.display(),
-                    e
-                ))
-            })?;
-
-            if let Some(entry) = config.sources.iter().find(|s| s.id == source_id) {
-                return Ok(Some(entry.token.clone()));
-            }
-        }
+    if let Some(token) = find_in_auth_file(source_id, auth_file)? {
+        return Ok(Some(token));
     }
 
     // 3. Legacy shared CORPUS_GIT_TOKEN (harvester-era single token)

--- a/packages/corpus/src/auth.rs
+++ b/packages/corpus/src/auth.rs
@@ -33,7 +33,16 @@ impl std::fmt::Debug for SourceAuth {
 /// Resolution order:
 /// 1. Environment variable `CORPUS_AUTH_{KEY}_TOKEN` (uppercased, hyphens → underscores)
 /// 2. `corpus-auth.yaml` file (if it exists)
-/// 3. None (unauthenticated, lower rate limits)
+/// 3. Legacy shared `CORPUS_GIT_TOKEN` (harvester-era fallback)
+/// 4. None (unauthenticated, lower rate limits)
+///
+/// **Security**: the legacy fallback at step 3 returns the same token
+/// for *any* `auth_ref`, which makes it unsafe whenever the `auth_ref`
+/// is derived from user input (e.g. a user picking which repo a
+/// traject points at). Use [`resolve_token_strict`] there instead —
+/// it omits the legacy fallback so an unknown `auth_ref` cleanly
+/// returns `None` rather than leaking the central token to a
+/// user-chosen repo on the outgoing API call.
 pub fn resolve_token_for_source(
     source_id: &str,
     auth_ref: Option<&str>,
@@ -41,6 +50,56 @@ pub fn resolve_token_for_source(
 ) -> Result<Option<String>> {
     let key = auth_ref.unwrap_or(source_id);
     resolve_token(key, auth_file)
+}
+
+/// Like [`resolve_token_for_source`] but only consults the per-source
+/// env var and the auth file. Returns `None` when neither yields a
+/// token — the legacy `CORPUS_GIT_TOKEN` fallback is intentionally
+/// skipped.
+///
+/// Use this for any code path where the lookup key is derived from
+/// untrusted input. Today that's the writable-own source of a traject
+/// whose repo coordinates came from the create-request — without this
+/// guard, an attacker-controlled `auth_ref` would fall through to the
+/// shared `CORPUS_GIT_TOKEN` and ship it (via `Authorization: Bearer`)
+/// to a repo the attacker controls, a token-exfiltration vector.
+pub fn resolve_token_strict(auth_ref: &str, auth_file: Option<&Path>) -> Result<Option<String>> {
+    // 1. Per-source environment variable
+    let env_key = format!(
+        "CORPUS_AUTH_{}_TOKEN",
+        auth_ref.to_uppercase().replace('-', "_")
+    );
+    if let Ok(token) = std::env::var(&env_key) {
+        if !token.is_empty() {
+            return Ok(Some(token));
+        }
+    }
+
+    // 2. Auth file. Same parser as `resolve_token` below; we deliberately
+    // do NOT fall through to `CORPUS_GIT_TOKEN` afterwards.
+    if let Some(path) = auth_file {
+        if path.exists() {
+            let content = std::fs::read_to_string(path).map_err(|e| {
+                CorpusError::Config(format!(
+                    "Failed to read auth file {}: {}",
+                    path.display(),
+                    e
+                ))
+            })?;
+            let config: AuthConfig = serde_yaml_ng::from_str(&content).map_err(|e| {
+                CorpusError::Config(format!(
+                    "Failed to parse auth file {}: {}",
+                    path.display(),
+                    e
+                ))
+            })?;
+            if let Some(entry) = config.sources.iter().find(|s| s.id == auth_ref) {
+                return Ok(Some(entry.token.clone()));
+            }
+        }
+    }
+
+    Ok(None)
 }
 
 /// Look up a GitHub token by key.
@@ -203,5 +262,39 @@ sources:
     fn test_resolve_token_missing_file_is_none() {
         let result = resolve_token("test", Some(Path::new("/nonexistent/auth.yaml"))).unwrap();
         assert_eq!(result, None);
+    }
+
+    #[test]
+    fn resolve_token_strict_skips_legacy_corpus_git_token() {
+        // The whole point of `resolve_token_strict`: an unknown auth_ref
+        // must NOT fall through to `CORPUS_GIT_TOKEN`. If it did, an
+        // attacker who can pick `auth_ref` (via repo coords on the
+        // create-traject endpoint) would harvest the operator's
+        // central token on the next outgoing GitHub call. This test
+        // pins the strict behaviour so a future refactor of the
+        // resolver can't silently regress it.
+        let _g = ENV_LOCK.lock().unwrap();
+        let prev = std::env::var("CORPUS_GIT_TOKEN").ok();
+        unsafe { std::env::set_var("CORPUS_GIT_TOKEN", "central-secret") };
+        let result = resolve_token_strict("attacker-supplied-key", None).unwrap();
+        match prev {
+            Some(v) => unsafe { std::env::set_var("CORPUS_GIT_TOKEN", v) },
+            None => unsafe { std::env::remove_var("CORPUS_GIT_TOKEN") },
+        }
+        assert_eq!(
+            result, None,
+            "strict resolver must NOT leak the legacy token"
+        );
+    }
+
+    #[test]
+    fn resolve_token_strict_still_uses_per_source_env() {
+        // The strict variant still honours the explicit per-source env
+        // var — that's the path operators are supposed to configure.
+        let key = "CORPUS_AUTH_STRICT_PER_SOURCE_OK_TOKEN";
+        unsafe { std::env::set_var(key, "per-source-value") };
+        let result = resolve_token_strict("strict-per-source-ok", None).unwrap();
+        unsafe { std::env::remove_var(key) };
+        assert_eq!(result, Some("per-source-value".to_string()));
     }
 }

--- a/packages/corpus/src/auth.rs
+++ b/packages/corpus/src/auth.rs
@@ -301,6 +301,11 @@ sources:
     fn resolve_token_strict_still_uses_per_source_env() {
         // The strict variant still honours the explicit per-source env
         // var — that's the path operators are supposed to configure.
+        // Holds `ENV_LOCK` like the sibling strict test: even though
+        // the key here is unique, env-mutating tests run serialised so
+        // a concurrent test holding the lock and mutating arbitrary
+        // env vars can't race with this one.
+        let _g = ENV_LOCK.lock().unwrap();
         let key = "CORPUS_AUTH_STRICT_PER_SOURCE_OK_TOKEN";
         unsafe { std::env::set_var(key, "per-source-value") };
         let result = resolve_token_strict("strict-per-source-ok", None).unwrap();

--- a/packages/corpus/src/lib.rs
+++ b/packages/corpus/src/lib.rs
@@ -14,6 +14,8 @@ pub mod models;
 #[cfg(feature = "github")]
 pub mod pr_client;
 pub mod registry;
+#[cfg(feature = "github")]
+pub mod repo_access;
 pub mod source_map;
 pub mod validation;
 
@@ -31,4 +33,6 @@ pub use models::{RegistryManifest, Source, SourceType};
 #[cfg(feature = "github")]
 pub use pr_client::PullRequestClient;
 pub use registry::CorpusRegistry;
+#[cfg(feature = "github")]
+pub use repo_access::{validate_repo_access, RepoAccessError, RepoInfo};
 pub use source_map::SourceMap;

--- a/packages/corpus/src/repo_access.rs
+++ b/packages/corpus/src/repo_access.rs
@@ -171,9 +171,17 @@ mod inner {
         base_branch: &str,
         token: &str,
     ) -> Result<(), RepoAccessError> {
+        // Branch names can legitimately contain `/` (e.g. `feature/foo`,
+        // `release/1.0`). Spliced raw into the path, the slash collapses
+        // into the URL router so GitHub matches `branch = "feature"` with
+        // a trailing path segment and returns 404. Percent-encode the
+        // segment so the branch reaches the API as-typed.
         let url = format!(
             "{}/repos/{}/{}/branches/{}",
-            base_url, owner, repo, base_branch
+            base_url,
+            owner,
+            repo,
+            percent_encode_path_segment(base_branch)
         );
         let headers = default_headers(token)?;
         let response = client
@@ -255,6 +263,30 @@ mod inner {
         format!("{}…", &s[..end])
     }
 
+    /// Percent-encode a single URL path segment per RFC 3986 §2.3:
+    /// unreserved chars (alphanumeric, `-._~`) pass through, everything
+    /// else becomes `%XX`. In particular `/`, `#`, `?`, and `%` are
+    /// encoded — without that, a branch like `feature/foo` collapses
+    /// into the URL path and GitHub matches `branch = "feature"` with a
+    /// trailing segment instead of looking up the real ref.
+    ///
+    /// Inline rather than via a crate dependency: the call is tiny,
+    /// the rule is fixed by the RFC, and the corpus crate already runs
+    /// without the `percent_encoding` / `url` crates as direct deps.
+    fn percent_encode_path_segment(s: &str) -> String {
+        use std::fmt::Write;
+        let mut out = String::with_capacity(s.len());
+        for &b in s.as_bytes() {
+            if b.is_ascii_alphanumeric() || matches!(b, b'-' | b'.' | b'_' | b'~') {
+                out.push(b as char);
+            } else {
+                // `write!` into a String can't fail; ignore the result.
+                let _ = write!(out, "%{:02X}", b);
+            }
+        }
+        out
+    }
+
     #[cfg(test)]
     #[allow(clippy::unwrap_used)]
     mod tests {
@@ -284,6 +316,7 @@ mod inner {
                 .await;
             Mock::given(method("GET"))
                 .and(path("/repos/acme/foo/branches/main"))
+                .and(header("Authorization", "Bearer t"))
                 .respond_with(
                     ResponseTemplate::new(200).set_body_json(serde_json::json!({"name":"main"})),
                 )
@@ -296,6 +329,72 @@ mod inner {
                 .unwrap();
             assert_eq!(info.default_branch, "main");
             assert!(info.is_private);
+        }
+
+        #[tokio::test]
+        async fn slashed_branch_is_percent_encoded() {
+            // `feature/foo` would collapse into the URL path if we spliced
+            // it raw: GitHub's router would match `branch = "feature"` with
+            // a trailing path segment and return 404. We must percent-
+            // encode the slash so the API sees `branches/feature%2Ffoo`.
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/repos/acme/foo"))
+                .respond_with(
+                    ResponseTemplate::new(200).set_body_json(ok_repo_body("main", true, true)),
+                )
+                .expect(1)
+                .mount(&server)
+                .await;
+            // wiremock matches against the raw (still-encoded) request
+            // path. Asserting on the literal `%2F` form proves the
+            // client is sending the encoded variant — without the
+            // percent-encoding fix, the request would go out as
+            // `branches/feature/foo` and the mock would not match.
+            Mock::given(method("GET"))
+                .and(path("/repos/acme/foo/branches/feature%2Ffoo"))
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        .set_body_json(serde_json::json!({"name":"feature/foo"})),
+                )
+                .expect(1)
+                .mount(&server)
+                .await;
+            // Negative-path catch-all: a regression that drops the
+            // encoding would hit this route, return 200 (with a body
+            // that does not match the route), and the positive mock's
+            // `.expect(1)` would still fail with "expected 1, got 0".
+            // The catch-all just makes the failure mode louder by
+            // letting the bogus route succeed visibly.
+            Mock::given(method("GET"))
+                .and(path("/repos/acme/foo/branches/feature"))
+                .respond_with(ResponseTemplate::new(404))
+                .expect(0)
+                .mount(&server)
+                .await;
+
+            validate_repo_access(&server.uri(), "acme", "foo", "feature/foo", "t")
+                .await
+                .expect("slashed branch should resolve");
+        }
+
+        #[test]
+        fn percent_encode_path_segment_examples() {
+            // Spot-checks for the inline encoder so a future refactor
+            // (e.g. swapping to a crate) is forced to preserve the
+            // contract.
+            assert_eq!(percent_encode_path_segment("main"), "main");
+            assert_eq!(percent_encode_path_segment("feature/foo"), "feature%2Ffoo");
+            assert_eq!(
+                percent_encode_path_segment("release-1.0_rc~final"),
+                "release-1.0_rc~final"
+            );
+            assert_eq!(percent_encode_path_segment("a b"), "a%20b");
+            assert_eq!(percent_encode_path_segment("a#b"), "a%23b");
+            assert_eq!(percent_encode_path_segment("a?b"), "a%3Fb");
+            // Multi-byte UTF-8: encoded as raw bytes per RFC 3986.
+            // `é` is 0xC3 0xA9 in UTF-8.
+            assert_eq!(percent_encode_path_segment("é"), "%C3%A9");
         }
 
         #[tokio::test]

--- a/packages/corpus/src/repo_access.rs
+++ b/packages/corpus/src/repo_access.rs
@@ -116,9 +116,10 @@ mod inner {
         token: &str,
     ) -> Result<RepoInfo, RepoAccessError> {
         let url = format!("{}/repos/{}/{}", base_url, owner, repo);
+        let headers = default_headers(token)?;
         let response = client
             .get(&url)
-            .headers(default_headers(token))
+            .headers(headers)
             .send()
             .await
             .map_err(|e| RepoAccessError::Transport(e.to_string()))?;
@@ -174,9 +175,10 @@ mod inner {
             "{}/repos/{}/{}/branches/{}",
             base_url, owner, repo, base_branch
         );
+        let headers = default_headers(token)?;
         let response = client
             .get(&url)
-            .headers(default_headers(token))
+            .headers(headers)
             .send()
             .await
             .map_err(|e| RepoAccessError::Transport(e.to_string()))?;
@@ -200,7 +202,14 @@ mod inner {
         }
     }
 
-    fn default_headers(token: &str) -> HeaderMap {
+    /// Build the default header set for every GitHub API call, including
+    /// the `Authorization` header. Returns `RepoAccessError::Other` when
+    /// the token contains bytes that aren't valid in an HTTP header value
+    /// (BOM, CR/LF, non-ASCII) — silently dropping the header would send
+    /// an unauthenticated request and surface as a misleading 401, which
+    /// the operator would chase as "GitHub rejected the token" while the
+    /// real cause is a malformed env var.
+    fn default_headers(token: &str) -> Result<HeaderMap, RepoAccessError> {
         let mut headers = HeaderMap::new();
         headers.insert(
             USER_AGENT,
@@ -214,10 +223,15 @@ mod inner {
             "X-GitHub-Api-Version",
             HeaderValue::from_static("2022-11-28"),
         );
-        if let Ok(val) = HeaderValue::from_str(&format!("Bearer {}", token)) {
-            headers.insert(AUTHORIZATION, val);
-        }
-        headers
+        let auth_value = HeaderValue::from_str(&format!("Bearer {}", token)).map_err(|_| {
+            RepoAccessError::Other(
+                "token contains characters not valid in an HTTP header value \
+                 — check the env var for whitespace/BOM/non-ASCII"
+                    .to_string(),
+            )
+        })?;
+        headers.insert(AUTHORIZATION, auth_value);
+        Ok(headers)
     }
 
     /// UTF-8-safe slice up to `max` *bytes*, walking back to the
@@ -356,6 +370,39 @@ mod inner {
                 .await
                 .expect_err("missing branch should error");
             assert!(matches!(err, RepoAccessError::BranchNotFound));
+        }
+
+        #[tokio::test]
+        async fn malformed_token_surfaces_as_other_not_silent_unauth() {
+            // A token with bytes that aren't valid in an HTTP header
+            // value (here: an embedded newline) used to silently drop
+            // the Authorization header and surface as 401, sending the
+            // operator on a wild "token rejected by GitHub" chase. Now
+            // it returns RepoAccessError::Other so the operator-facing
+            // message names the real cause (corrupt env var).
+            //
+            // No server interaction expected — the failure happens
+            // *before* we hit the network. We still spin one up so the
+            // signature is consistent with the other tests; assert that
+            // it isn't touched.
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/repos/acme/foo"))
+                .respond_with(ResponseTemplate::new(200))
+                .expect(0)
+                .mount(&server)
+                .await;
+
+            let err = validate_repo_access(&server.uri(), "acme", "foo", "main", "bad\ntoken")
+                .await
+                .expect_err("malformed token must error");
+            match err {
+                RepoAccessError::Other(msg) => assert!(
+                    msg.contains("not valid in an HTTP header value"),
+                    "unexpected Other body: {msg}"
+                ),
+                other => panic!("expected RepoAccessError::Other, got {other:?}"),
+            }
         }
 
         #[tokio::test]

--- a/packages/corpus/src/repo_access.rs
+++ b/packages/corpus/src/repo_access.rs
@@ -187,9 +187,12 @@ mod inner {
             StatusCode::OK => Ok(()),
             StatusCode::NOT_FOUND => Err(RepoAccessError::BranchNotFound),
             StatusCode::UNAUTHORIZED => Err(RepoAccessError::Unauthorized),
-            // Per-branch 403 = branch protection forbids reads with this
-            // token. Surface as "no push access" — protected branches
-            // require contents:write for read on the bypass list.
+            // Per-branch 403 = the token can resolve the repo (passed the
+            // `/repos/{owner}/{repo}` check above) but the fine-grained PAT
+            // scopes don't include `contents:read`. Surface as "no push
+            // access" since the operator's fix is identical: widen the
+            // token. Branch protection itself only governs writes, so it
+            // can't be the cause of a 403 on this GET.
             StatusCode::FORBIDDEN => Err(RepoAccessError::NoPushAccess),
             other => {
                 let body = response.text().await.unwrap_or_default();

--- a/packages/corpus/src/repo_access.rs
+++ b/packages/corpus/src/repo_access.rs
@@ -1,0 +1,385 @@
+//! Pre-flight checks for a GitHub repository before we commit a traject
+//! to use it as a write target.
+//!
+//! Two questions to answer:
+//! 1. Does the supplied token actually have push access to this repo?
+//!    (Without it, the very first save would fail at push time with a
+//!    cryptic "could not read Username" or a 403; checking up-front gives
+//!    a clean error at traject-create time.)
+//! 2. Does the configured `base_branch` exist? (We branch off this on
+//!    first persist — a missing base would also fail late.)
+
+#[cfg(feature = "github")]
+mod inner {
+    use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, AUTHORIZATION, USER_AGENT};
+    use reqwest::StatusCode;
+    use serde::Deserialize;
+
+    /// Distinct failure modes for repo access validation. The editor-api
+    /// caller maps each variant onto a specific HTTP status / user-facing
+    /// message — keep them disjoint so the matching is exhaustive.
+    #[derive(Debug)]
+    pub enum RepoAccessError {
+        /// 401 on either call. Token rejected by GitHub (revoked, expired,
+        /// or simply wrong).
+        Unauthorized,
+        /// 404 on `GET /repos/{owner}/{repo}`. Either the repo really
+        /// doesn't exist, or it's private and the token can't see it —
+        /// GitHub returns 404 in both cases to avoid leaking existence.
+        RepoNotFound,
+        /// 404 on `GET /repos/{owner}/{repo}/branches/{base}`. Repo is
+        /// reachable but the base branch the operator named is wrong.
+        BranchNotFound,
+        /// Repo reads fine, but the token's user/installation has
+        /// `permissions.push == false`. Pushing the traject branch later
+        /// would fail with 403 — better to refuse the traject now.
+        NoPushAccess,
+        /// Transport-level failure (DNS, TLS, timeout, connection reset).
+        /// Worth retrying or surfacing as 503.
+        Transport(String),
+        /// Any other response we can't classify (5xx, surprise 4xx, JSON
+        /// parse failure). Includes the status + a short error blurb for
+        /// diagnostics — never the token.
+        Other(String),
+    }
+
+    impl std::fmt::Display for RepoAccessError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Unauthorized => write!(f, "token is not authorised for this repo"),
+                Self::RepoNotFound => write!(f, "repository not found or token cannot see it"),
+                Self::BranchNotFound => write!(f, "base branch does not exist on the repo"),
+                Self::NoPushAccess => write!(f, "token has no push access to the repo"),
+                Self::Transport(msg) => write!(f, "transport error talking to GitHub: {}", msg),
+                Self::Other(msg) => write!(f, "unexpected GitHub response: {}", msg),
+            }
+        }
+    }
+
+    impl std::error::Error for RepoAccessError {}
+
+    /// Information we glean from a successful validation call. The
+    /// caller might surface `default_branch` (e.g. as a hint when the
+    /// operator typed the wrong base) or use `is_private` to drive
+    /// frontend hints later.
+    #[derive(Debug, Clone)]
+    pub struct RepoInfo {
+        pub default_branch: String,
+        pub is_private: bool,
+    }
+
+    /// Minimal subset of the `/repos/{owner}/{repo}` response we care
+    /// about. GitHub returns many more fields; ignore them.
+    #[derive(Debug, Deserialize)]
+    struct RepoResponse {
+        default_branch: String,
+        #[serde(default)]
+        private: bool,
+        permissions: Option<RepoPermissions>,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct RepoPermissions {
+        #[serde(default)]
+        push: bool,
+    }
+
+    /// Pre-flight check before letting a traject use this repo as its
+    /// write target. Performs two API calls in sequence: repo lookup
+    /// (also returns the permission bits) and branch existence.
+    ///
+    /// `base_url` is exposed for tests pointing at a wiremock server;
+    /// production callers pass `"https://api.github.com"`.
+    pub async fn validate_repo_access(
+        base_url: &str,
+        owner: &str,
+        repo: &str,
+        base_branch: &str,
+        token: &str,
+    ) -> Result<RepoInfo, RepoAccessError> {
+        let client = reqwest::Client::builder()
+            .connect_timeout(std::time::Duration::from_secs(10))
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .map_err(|e| RepoAccessError::Transport(e.to_string()))?;
+
+        let info = check_repo(&client, base_url, owner, repo, token).await?;
+        check_branch(&client, base_url, owner, repo, base_branch, token).await?;
+        Ok(info)
+    }
+
+    async fn check_repo(
+        client: &reqwest::Client,
+        base_url: &str,
+        owner: &str,
+        repo: &str,
+        token: &str,
+    ) -> Result<RepoInfo, RepoAccessError> {
+        let url = format!("{}/repos/{}/{}", base_url, owner, repo);
+        let response = client
+            .get(&url)
+            .headers(default_headers(token))
+            .send()
+            .await
+            .map_err(|e| RepoAccessError::Transport(e.to_string()))?;
+
+        match response.status() {
+            StatusCode::OK => {}
+            StatusCode::UNAUTHORIZED => return Err(RepoAccessError::Unauthorized),
+            StatusCode::NOT_FOUND => return Err(RepoAccessError::RepoNotFound),
+            // 403 from the repo lookup means the token can see the repo
+            // exists but isn't allowed to read it (rare; usually masks
+            // as 404). Treat as Unauthorized — the operator needs to fix
+            // the token either way.
+            StatusCode::FORBIDDEN => return Err(RepoAccessError::Unauthorized),
+            other => {
+                let body = response.text().await.unwrap_or_default();
+                return Err(RepoAccessError::Other(format!(
+                    "{}: {}",
+                    other,
+                    truncate(&body, 200)
+                )));
+            }
+        }
+
+        let parsed: RepoResponse = response
+            .json()
+            .await
+            .map_err(|e| RepoAccessError::Other(format!("parse repo response: {}", e)))?;
+
+        // No `permissions` block on the response usually means an
+        // unauthenticated request — we always send a token, so missing
+        // permissions here is a real "no access" signal, not a quirk to
+        // shrug off.
+        let pushable = parsed.permissions.as_ref().map(|p| p.push).unwrap_or(false);
+        if !pushable {
+            return Err(RepoAccessError::NoPushAccess);
+        }
+
+        Ok(RepoInfo {
+            default_branch: parsed.default_branch,
+            is_private: parsed.private,
+        })
+    }
+
+    async fn check_branch(
+        client: &reqwest::Client,
+        base_url: &str,
+        owner: &str,
+        repo: &str,
+        base_branch: &str,
+        token: &str,
+    ) -> Result<(), RepoAccessError> {
+        let url = format!(
+            "{}/repos/{}/{}/branches/{}",
+            base_url, owner, repo, base_branch
+        );
+        let response = client
+            .get(&url)
+            .headers(default_headers(token))
+            .send()
+            .await
+            .map_err(|e| RepoAccessError::Transport(e.to_string()))?;
+
+        match response.status() {
+            StatusCode::OK => Ok(()),
+            StatusCode::NOT_FOUND => Err(RepoAccessError::BranchNotFound),
+            StatusCode::UNAUTHORIZED => Err(RepoAccessError::Unauthorized),
+            // Per-branch 403 = branch protection forbids reads with this
+            // token. Surface as "no push access" — protected branches
+            // require contents:write for read on the bypass list.
+            StatusCode::FORBIDDEN => Err(RepoAccessError::NoPushAccess),
+            other => {
+                let body = response.text().await.unwrap_or_default();
+                Err(RepoAccessError::Other(format!(
+                    "{}: {}",
+                    other,
+                    truncate(&body, 200)
+                )))
+            }
+        }
+    }
+
+    fn default_headers(token: &str) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            USER_AGENT,
+            HeaderValue::from_static("regelrecht-corpus/0.1"),
+        );
+        headers.insert(
+            ACCEPT,
+            HeaderValue::from_static("application/vnd.github+json"),
+        );
+        headers.insert(
+            "X-GitHub-Api-Version",
+            HeaderValue::from_static("2022-11-28"),
+        );
+        if let Ok(val) = HeaderValue::from_str(&format!("Bearer {}", token)) {
+            headers.insert(AUTHORIZATION, val);
+        }
+        headers
+    }
+
+    /// UTF-8-safe slice up to `max` *bytes*, walking back to the
+    /// nearest char boundary so a non-ASCII body from GitHub (a 5xx
+    /// HTML page, say) doesn't panic the formatter on a multi-byte
+    /// split. `s[..max]` would panic in that case — only safe for pure
+    /// ASCII, which we can't assume on the unhappy path.
+    fn truncate(s: &str, max: usize) -> String {
+        if s.len() <= max {
+            return s.to_string();
+        }
+        // Walk back from `max` until we land on a char boundary. `str`
+        // guarantees that byte 0 is a boundary, so this terminates.
+        let mut end = max;
+        while !s.is_char_boundary(end) {
+            end -= 1;
+        }
+        format!("{}…", &s[..end])
+    }
+
+    #[cfg(test)]
+    #[allow(clippy::unwrap_used)]
+    mod tests {
+        use super::*;
+        use wiremock::matchers::{header, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        fn ok_repo_body(default_branch: &str, push: bool, private: bool) -> serde_json::Value {
+            serde_json::json!({
+                "default_branch": default_branch,
+                "private": private,
+                "permissions": { "push": push, "pull": true, "admin": false }
+            })
+        }
+
+        #[tokio::test]
+        async fn happy_path_returns_info() {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/repos/acme/foo"))
+                .and(header("Authorization", "Bearer t"))
+                .respond_with(
+                    ResponseTemplate::new(200).set_body_json(ok_repo_body("main", true, true)),
+                )
+                .expect(1)
+                .mount(&server)
+                .await;
+            Mock::given(method("GET"))
+                .and(path("/repos/acme/foo/branches/main"))
+                .respond_with(
+                    ResponseTemplate::new(200).set_body_json(serde_json::json!({"name":"main"})),
+                )
+                .expect(1)
+                .mount(&server)
+                .await;
+
+            let info = validate_repo_access(&server.uri(), "acme", "foo", "main", "t")
+                .await
+                .unwrap();
+            assert_eq!(info.default_branch, "main");
+            assert!(info.is_private);
+        }
+
+        #[tokio::test]
+        async fn missing_repo_is_not_found() {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/repos/acme/foo"))
+                .respond_with(ResponseTemplate::new(404))
+                .mount(&server)
+                .await;
+
+            let err = validate_repo_access(&server.uri(), "acme", "foo", "main", "t")
+                .await
+                .expect_err("404 should error");
+            assert!(matches!(err, RepoAccessError::RepoNotFound));
+        }
+
+        #[tokio::test]
+        async fn bad_token_is_unauthorized() {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/repos/acme/foo"))
+                .respond_with(ResponseTemplate::new(401))
+                .mount(&server)
+                .await;
+
+            let err = validate_repo_access(&server.uri(), "acme", "foo", "main", "t")
+                .await
+                .expect_err("401 should error");
+            assert!(matches!(err, RepoAccessError::Unauthorized));
+        }
+
+        #[tokio::test]
+        async fn read_only_token_has_no_push_access() {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/repos/acme/foo"))
+                .respond_with(
+                    ResponseTemplate::new(200).set_body_json(ok_repo_body("main", false, true)),
+                )
+                .expect(1)
+                .mount(&server)
+                .await;
+            // Branch call must NOT be made — fail-fast on no-push.
+            Mock::given(method("GET"))
+                .and(path("/repos/acme/foo/branches/main"))
+                .respond_with(ResponseTemplate::new(200))
+                .expect(0)
+                .mount(&server)
+                .await;
+
+            let err = validate_repo_access(&server.uri(), "acme", "foo", "main", "t")
+                .await
+                .expect_err("no push must error");
+            assert!(matches!(err, RepoAccessError::NoPushAccess));
+        }
+
+        #[tokio::test]
+        async fn missing_branch_is_branch_not_found() {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/repos/acme/foo"))
+                .respond_with(
+                    ResponseTemplate::new(200).set_body_json(ok_repo_body("main", true, false)),
+                )
+                .mount(&server)
+                .await;
+            Mock::given(method("GET"))
+                .and(path("/repos/acme/foo/branches/wibble"))
+                .respond_with(ResponseTemplate::new(404))
+                .mount(&server)
+                .await;
+
+            let err = validate_repo_access(&server.uri(), "acme", "foo", "wibble", "t")
+                .await
+                .expect_err("missing branch should error");
+            assert!(matches!(err, RepoAccessError::BranchNotFound));
+        }
+
+        #[tokio::test]
+        async fn missing_permissions_block_is_no_push_access() {
+            // We always send a token, so a response without a permissions
+            // block isn't an "unauth read shape" — it's an unusual one we
+            // should reject rather than fall through.
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/repos/acme/foo"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "default_branch": "main",
+                    "private": true
+                })))
+                .mount(&server)
+                .await;
+
+            let err = validate_repo_access(&server.uri(), "acme", "foo", "main", "t")
+                .await
+                .expect_err("missing perms should error");
+            assert!(matches!(err, RepoAccessError::NoPushAccess));
+        }
+    }
+}
+
+#[cfg(feature = "github")]
+pub use inner::*;

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -801,9 +801,12 @@ async fn require_editor_user(session: &Session) -> Result<EditorUser, (StatusCod
     editor_user_from_session(session).await.ok_or_else(|| {
         (
             StatusCode::FORBIDDEN,
-            "Je sessie mist een geverifieerd e-mailadres — log opnieuw in om de \
-             editor weer te kunnen gebruiken. (Als dit blijft optreden: vraag je \
-             beheerder om in Keycloak 'email_verified' aan te zetten voor je account.)"
+            "Je sessie heeft geen geverifieerd e-mailadres. \
+             Mogelijke oorzaken: (1) je sessie is van vóór de laatste deploy — \
+             log opnieuw in om de verificatie-status uit je organisatie-account \
+             in te lezen; (2) je e-mail is daadwerkelijk niet geverifieerd — \
+             vraag je beheerder om in Keycloak 'email_verified' aan te zetten \
+             voor je account."
                 .to_string(),
         )
     })

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -8,7 +8,9 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 use tower_sessions::Session;
 
-use regelrecht_auth::handlers::{SESSION_KEY_EMAIL, SESSION_KEY_NAME, SESSION_KEY_SUB};
+use regelrecht_auth::handlers::{
+    SESSION_KEY_EMAIL, SESSION_KEY_EMAIL_VERIFIED, SESSION_KEY_NAME, SESSION_KEY_SUB,
+};
 use regelrecht_corpus::annotation_schema::{
     append_notes_to_sidecar, first_note_not_targeting_law, parse_and_validate_annotation_yaml,
     validate_annotation_doc, AppendOutcome,
@@ -756,22 +758,55 @@ fn corpus_write_error(kind: &'static str) -> impl FnOnce(CorpusError) -> (Status
 // Save / Delete scenario endpoints
 // ---------------------------------------------------------------------------
 
-/// Pull the editor user identity out of the OIDC session, when both name
-/// and email are populated.
+/// Pull the editor user identity out of the OIDC session, but only
+/// when the IdP has marked the email as verified.
 ///
-/// Returns `None` when auth is disabled or the relevant session keys
-/// haven't been set — in those cases the resulting commit just has no
-/// `Co-Authored-By` trailer, which is harmless. We do NOT fail the save
-/// over a missing identity.
+/// Why the strict check: this identity ends up as the commit-author on
+/// every save. Without `email_verified=true` we can't claim the email
+/// is really the user's — GitHub will still happily render anyone's
+/// name+email on a commit, so without IdP verification an attacker
+/// could change their preferred email mid-session and impersonate
+/// someone else on the resulting commits. Returning `None` here makes
+/// the save-handler refuse the write with a 403, which is the right
+/// fail-closed behaviour for an attribution system.
+///
+/// Returns `None` also when the session keys aren't populated at all
+/// (auth disabled, or a session created before the verified-email
+/// claim was added); the caller distinguishes those cases via its own
+/// error message.
 async fn editor_user_from_session(session: &Session) -> Option<EditorUser> {
     let name: Option<String> = session.get(SESSION_KEY_NAME).await.ok().flatten();
     let email: Option<String> = session.get(SESSION_KEY_EMAIL).await.ok().flatten();
-    match (name, email) {
-        (Some(name), Some(email)) if !name.is_empty() && !email.is_empty() => {
+    let verified: Option<bool> = session.get(SESSION_KEY_EMAIL_VERIFIED).await.ok().flatten();
+    match (name, email, verified) {
+        (Some(name), Some(email), Some(true)) if !name.is_empty() && !email.is_empty() => {
             Some(EditorUser { name, email })
         }
         _ => None,
     }
+}
+
+/// Wrapper around [`editor_user_from_session`] for write paths that
+/// REQUIRE an attributable identity. Returns 403 with a user-facing
+/// message when the editor isn't fully authenticated — better than
+/// silently committing under the service account, which would let an
+/// unverified email leak into the git history.
+///
+/// Note for ops at rollout: any session that predates the deploy that
+/// introduced `SESSION_KEY_EMAIL_VERIFIED` lacks the claim entirely
+/// and will hit this 403 even when the user's email *is* verified at
+/// the IdP. The message therefore nudges towards a re-login, which
+/// re-runs the OIDC callback and populates the missing claim.
+async fn require_editor_user(session: &Session) -> Result<EditorUser, (StatusCode, String)> {
+    editor_user_from_session(session).await.ok_or_else(|| {
+        (
+            StatusCode::FORBIDDEN,
+            "Je sessie mist een geverifieerd e-mailadres — log opnieuw in om de \
+             editor weer te kunnen gebruiken. (Als dit blijft optreden: vraag je \
+             beheerder om in Keycloak 'email_verified' aan te zetten voor je account.)"
+                .to_string(),
+        )
+    })
 }
 
 /// Resolved write target for editor saves: a backend lock + the file
@@ -999,7 +1034,7 @@ pub async fn save_scenario(
     body: String,
 ) -> Result<Json<SaveResponse>, (StatusCode, String)> {
     validate_scenario_filename(&filename)?;
-    let author = editor_user_from_session(&session).await;
+    let author = Some(require_editor_user(&session).await?);
 
     let traject = require_traject_corpus_from_ref(&state, &session, &traject_ref).await?;
     let target = resolve_traject_scenario_target(&traject, &law_id, &filename).await?;
@@ -1052,7 +1087,7 @@ pub async fn save_annotations(
     Path((traject_ref, law_id)): Path<(String, String)>,
     body: String,
 ) -> Result<Json<SaveResponse>, (StatusCode, String)> {
-    let author = editor_user_from_session(&session).await;
+    let author = Some(require_editor_user(&session).await?);
 
     // Body is a JSON array of new notes. Parse + bound it before touching
     // the backend.
@@ -1219,7 +1254,7 @@ pub async fn save_law(
     Path((traject_ref, law_id)): Path<(String, String)>,
     body: String,
 ) -> Result<Json<SaveResponse>, (StatusCode, String)> {
-    let author = editor_user_from_session(&session).await;
+    let author = Some(require_editor_user(&session).await?);
 
     // Validation:
     //   1. Body must parse as well-formed YAML. extract_law_id below is a
@@ -1308,7 +1343,7 @@ pub async fn delete_scenario(
     Path((traject_ref, law_id, filename)): Path<(String, String, String)>,
 ) -> Result<Json<SaveResponse>, (StatusCode, String)> {
     validate_scenario_filename(&filename)?;
-    let author = editor_user_from_session(&session).await;
+    let author = Some(require_editor_user(&session).await?);
 
     let traject = require_traject_corpus_from_ref(&state, &session, &traject_ref).await?;
     let target = resolve_traject_scenario_target(&traject, &law_id, &filename).await?;
@@ -1432,5 +1467,120 @@ mod tests {
         assert!(body.pr.is_none());
         // Law/scenario saves are never a notes no-op.
         assert!(!body.no_change);
+    }
+
+    // ---- editor_user_from_session: attribution invariants ----
+
+    use std::sync::Arc;
+    use tower_sessions::{MemoryStore, Session};
+
+    fn empty_session() -> Session {
+        Session::new(None, Arc::new(MemoryStore::default()), None)
+    }
+
+    async fn session_with(
+        name: Option<&str>,
+        email: Option<&str>,
+        verified: Option<bool>,
+    ) -> Session {
+        let s = empty_session();
+        if let Some(n) = name {
+            s.insert(SESSION_KEY_NAME, n.to_string()).await.unwrap();
+        }
+        if let Some(e) = email {
+            s.insert(SESSION_KEY_EMAIL, e.to_string()).await.unwrap();
+        }
+        if let Some(v) = verified {
+            s.insert(SESSION_KEY_EMAIL_VERIFIED, v).await.unwrap();
+        }
+        s
+    }
+
+    #[tokio::test]
+    async fn editor_user_requires_verified_email() {
+        // verified=false must produce None even when name+email are
+        // present — otherwise an IdP that doesn't verify emails would
+        // let an attacker pick any email and have it land in the commit
+        // author field.
+        let s = session_with(Some("Alice"), Some("alice@example.com"), Some(false)).await;
+        assert!(editor_user_from_session(&s).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn editor_user_missing_verified_claim_is_rejected() {
+        // No verified key at all (older session created before the
+        // claim was added, or auth disabled) falls in the same bucket
+        // as `verified=false`: fail closed.
+        let s = session_with(Some("Alice"), Some("alice@example.com"), None).await;
+        assert!(editor_user_from_session(&s).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn editor_user_happy_path() {
+        let s = session_with(Some("Alice"), Some("alice@example.com"), Some(true)).await;
+        let user = editor_user_from_session(&s).await.unwrap();
+        assert_eq!(user.name, "Alice");
+        assert_eq!(user.email, "alice@example.com");
+    }
+
+    #[tokio::test]
+    async fn require_editor_user_returns_403_when_unverified() {
+        let s = session_with(Some("Alice"), Some("alice@example.com"), Some(false)).await;
+        let err = require_editor_user(&s).await.expect_err("must refuse");
+        assert_eq!(err.0, StatusCode::FORBIDDEN);
+        assert!(
+            err.1.contains("e-mailadres"),
+            "message should mention email verification: {}",
+            err.1
+        );
+    }
+
+    // ---- Spoofing-by-body invariant ----
+
+    /// The handler-input contract guarantees that no save handler exposes
+    /// a JSON field named `author` (or a structurally similar one) that
+    /// could overwrite the OIDC-derived attribution. This is enforced at
+    /// the type system level — `save_scenario` / `save_annotations` /
+    /// `save_law` all take `body: String` (raw scenario / raw JSON
+    /// notes array / raw YAML), never a `Json<SomeRequest>` struct that
+    /// might carry an `author` field.
+    ///
+    /// If a future refactor switches one of those handlers to take a
+    /// structured body, this test fails (the function signature no
+    /// longer matches) and the author has to come back and re-examine
+    /// the spoofing surface. Document the invariant via a compile-time
+    /// signature assertion rather than a runtime probe — the runtime
+    /// path is "session in → context out", with no body in between.
+    #[test]
+    fn save_handler_signatures_take_raw_body_no_author_field() {
+        // Compile-time assertions: the function pointer types include
+        // `body: String` as the last positional argument. If any handler
+        // changes to `Json<X>` for some struct `X`, this code won't
+        // compile — forcing a re-review of whether `X` can carry an
+        // `author`-shaped field.
+        let _: fn(
+            axum::extract::State<crate::state::AppState>,
+            Session,
+            axum::extract::Path<(String, String, String)>,
+            String,
+        ) -> _ = save_scenario;
+        let _: fn(
+            axum::extract::State<crate::state::AppState>,
+            Session,
+            axum::extract::Path<(String, String)>,
+            String,
+        ) -> _ = save_annotations;
+        let _: fn(
+            axum::extract::State<crate::state::AppState>,
+            Session,
+            axum::extract::Path<(String, String)>,
+            String,
+        ) -> _ = save_law;
+        // delete_scenario takes no body at all — even stronger guarantee.
+        let _: fn(
+            axum::extract::State<crate::state::AppState>,
+            Session,
+            axum::extract::Path<(String, String, String)>,
+        ) -> _ = delete_scenario;
     }
 }

--- a/packages/editor-api/src/traject_corpus.rs
+++ b/packages/editor-api/src/traject_corpus.rs
@@ -251,19 +251,16 @@ async fn build_traject_corpus(
         // operator can see whether the row carries the expected ref and
         // whether the env var matches.
         if token.is_none() && source.id == writable_own_source_id {
+            let expected_env = regelrecht_corpus::auth::token_env_name(
+                source.auth_ref.as_deref().unwrap_or(&source.id),
+            );
             tracing::error!(
                 traject = %traject_id,
                 source_id = %source.id,
                 auth_ref = ?source.auth_ref,
                 auth_file = ?auth_file,
-                "traject writable-own source resolved NO token — push will fail; \
-                 expected env var: CORPUS_AUTH_{}_TOKEN",
-                source
-                    .auth_ref
-                    .as_deref()
-                    .unwrap_or(&source.id)
-                    .to_uppercase()
-                    .replace('-', "_")
+                expected_env = %expected_env,
+                "traject writable-own source resolved NO token — push will fail"
             );
         }
 

--- a/packages/editor-api/src/traject_corpus.rs
+++ b/packages/editor-api/src/traject_corpus.rs
@@ -218,12 +218,25 @@ async fn build_traject_corpus(
     // Build a backend per source, scoped to a traject-specific clone path.
     let mut backends: HashMap<String, BackendEntry> = HashMap::new();
     for (row, source) in rows.iter().zip(sources.iter()) {
-        let token = regelrecht_corpus::auth::resolve_token_for_source(
-            &source.id,
-            source.auth_ref.as_deref(),
-            auth_file,
-        )
-        .unwrap_or_else(|e| {
+        // For the writable-own source we resolve strictly (no legacy
+        // `CORPUS_GIT_TOKEN` fallback). The `auth_ref` on this row was
+        // derived from the create-request's repo coords, so a missing
+        // per-repo token MUST fail closed — not transparently ship the
+        // central token to a user-chosen GitHub repo on the next push.
+        // Seeded (non-writable) sources keep the legacy fallback so
+        // pre-existing deployments that rely on a single global PAT for
+        // read-only mirrors keep working.
+        let token_result = if row.is_writable_own {
+            let key = source.auth_ref.as_deref().unwrap_or(&source.id);
+            regelrecht_corpus::auth::resolve_token_strict(key, auth_file)
+        } else {
+            regelrecht_corpus::auth::resolve_token_for_source(
+                &source.id,
+                source.auth_ref.as_deref(),
+                auth_file,
+            )
+        };
+        let token = token_result.unwrap_or_else(|e| {
             tracing::warn!(
                 traject = %traject_id,
                 source_id = %source.id,

--- a/packages/editor-api/src/trajects.rs
+++ b/packages/editor-api/src/trajects.rs
@@ -172,10 +172,14 @@ fn valid_branch_name(s: &str) -> bool {
     if s.contains("..") || s.contains("@{") || s.contains("//") {
         return false;
     }
-    // No path component may end with `.lock` — git treats `<ref>.lock`
-    // as a lockfile sentinel, so `main.lock` and `feature/foo.lock` are
-    // both refused as refnames.
-    if s.split('/').any(|c| c.ends_with(".lock")) {
+    // Per `git-check-ref-format`: no path component may start with `.`
+    // (so `.hidden` and `feature/.hidden` are both refused) and none may
+    // end with `.lock` (git treats `<ref>.lock` as a lockfile sentinel,
+    // so `main.lock` and `feature/foo.lock` are refused). Walk the
+    // components once for both rules.
+    if s.split('/')
+        .any(|c| c.starts_with('.') || c.ends_with(".lock"))
+    {
         return false;
     }
     s.chars().all(|c| {
@@ -1722,6 +1726,11 @@ mod tests {
         assert!(!valid_branch_name("@"));
         assert!(!valid_branch_name("main.lock"));
         assert!(!valid_branch_name("feat/foo.lock"));
+        // No path component may start with `.`. GitHub would accept
+        // these refs but git would refuse them downstream at push time.
+        assert!(!valid_branch_name(".hidden"));
+        assert!(!valid_branch_name("feature/.hidden"));
+        assert!(!valid_branch_name(".github"));
         // Sanity: dots / "lock" inside a name (not as a trailing
         // component / suffix) stay accepted.
         assert!(valid_branch_name("main.foo"));

--- a/packages/editor-api/src/trajects.rs
+++ b/packages/editor-api/src/trajects.rs
@@ -95,14 +95,50 @@ pub struct CreateTrajectRequest {
     pub description: String,
     #[serde(default)]
     pub scope: String,
+    /// GitHub `owner` for the writable-own source. When `None`, falls
+    /// back to the central MinBZK repo (phase-1 default). When set,
+    /// `repo_name` and `base_branch` must also be set; the server
+    /// derives `auth_ref` deterministically and looks up the matching
+    /// `CORPUS_AUTH_{AUTH_REF}_TOKEN` env var.
+    #[serde(default)]
+    pub repo_owner: Option<String>,
+    /// GitHub `repo`. Required when `repo_owner` is set.
+    #[serde(default)]
+    pub repo_name: Option<String>,
+    /// Branch to base the traject branch off of (and target with the
+    /// session PR). Required when `repo_owner` is set; the default
+    /// branch of the repo if you're unsure.
+    #[serde(default)]
+    pub base_branch: Option<String>,
+    /// Optional sub-path within the repo where regulation YAML files
+    /// live. Empty / omitted means "everything under repo root" — the
+    /// right default for user repos dedicated to regulations. Set this
+    /// when the YAML files sit in a subdirectory like `regulation/nl`
+    /// (which is the MinBZK default).
+    #[serde(default)]
+    pub repo_path: Option<String>,
 }
 
-// Phase-1: trajects always push to a single, app-wide writable source —
-// the central MinBZK corpus repo on its `development` branch, using the
-// app-wide CORPUS_AUTH_MINBZK_CENTRAL_TOKEN. No per-user / per-traject
-// auth yet; that's phase 2 (probably GitHub-App OAuth so we don't have
-// to store PATs in the database at all). When phase 2 lands these
-// constants become a fallback default for the request body.
+/// GitHub `owner` / `repo` segments end up in a URL path
+/// (`/repos/{owner}/{repo}`), in the on-disk session-branch name, and
+/// in the commit/PR body. Accept only the character set that GitHub
+/// itself allows for these identifiers — alphanumerics plus `-`, `_`,
+/// and `.`. Lets us refuse path-traversal-shaped input (`..`, `/`) at
+/// the API boundary rather than relying on GitHub to 404 it.
+fn valid_repo_segment(s: &str) -> bool {
+    !s.is_empty()
+        && s.len() <= 100
+        && s.chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
+}
+
+// Phase-1 default writable source — the central MinBZK corpus repo on
+// its `development` branch, using the app-wide
+// `CORPUS_AUTH_MINBZK_CENTRAL_TOKEN`. Used when the create-request omits
+// the repo_* fields entirely, so existing flows keep working unchanged.
+// When the request *does* supply repo coordinates, all four user-facing
+// fields (owner/repo/branch/path) are taken from the request and
+// `auth_ref` is derived from owner+repo (see `derive_auth_ref`).
 const CENTRAL_WRITABLE_OWNER: &str = "MinBZK";
 const CENTRAL_WRITABLE_REPO: &str = "regelrecht-corpus";
 const CENTRAL_WRITABLE_PATH: &str = "regulation/nl";
@@ -157,6 +193,28 @@ fn db_err<E: std::fmt::Display>(context: &'static str) -> impl FnOnce(E) -> Stat
     move |e| {
         tracing::error!(error = %e, "{context}");
         StatusCode::INTERNAL_SERVER_ERROR
+    }
+}
+
+/// Same as [`get_pool`] but for handlers that return `(StatusCode, String)`
+/// so the body can carry a user-facing message. Used by `create` where
+/// failure reasons (missing token, missing branch, …) need to reach the UI.
+fn get_pool_msg(state: &AppState) -> Result<&PgPool, (StatusCode, String)> {
+    state.pool.as_ref().ok_or((
+        StatusCode::SERVICE_UNAVAILABLE,
+        "database not configured".to_string(),
+    ))
+}
+
+/// Same as [`db_err`] but returning `(StatusCode, String)`. Empty body —
+/// 500s caused by a DB issue carry no information the caller can act on,
+/// so we just log on the server and let the client see a bare 500.
+fn db_err_msg<E: std::fmt::Display>(
+    context: &'static str,
+) -> impl FnOnce(E) -> (StatusCode, String) {
+    move |e| {
+        tracing::error!(error = %e, "{context}");
+        (StatusCode::INTERNAL_SERVER_ERROR, String::new())
     }
 }
 
@@ -226,6 +284,42 @@ pub fn short_id(traject_id: Uuid) -> String {
 /// existing URLs.
 pub fn traject_ref(name: &str, traject_id: Uuid) -> String {
     format!("{}-{}", slugify(name), short_id(traject_id))
+}
+
+/// Derive the `auth_ref` for a user-supplied `<owner>/<repo>` so the
+/// existing token-resolver picks up the right
+/// `CORPUS_AUTH_{AUTH_REF_UPPER}_TOKEN` env var without anyone having
+/// to hand-maintain the mapping. Operators see a deterministic env-var
+/// name derived from the repo coordinates.
+///
+/// Rule: lowercase, runs of non-alphanumeric characters collapse to a
+/// single `-`, leading/trailing dashes trimmed. This is a slug, not a
+/// hash — it's lossy and not injective (e.g. `("a-", "-b")` and
+/// `("a", "b")` both produce `"a-b"`), so two pathological repo
+/// names could share an env var. Acceptable trade-off for legibility;
+/// the env-var collision just means both repos use the same token.
+///
+/// Examples:
+///   ("Acme",   "Secret-Repo")        → "acme-secret-repo"
+///   ("MinBZK", "regelrecht-corpus")  → "minbzk-regelrecht-corpus"
+///   ("a.b",    "c_d")                → "a-b-c-d"
+pub fn derive_auth_ref(owner: &str, repo: &str) -> String {
+    let mut out = String::new();
+    let mut prev_dash = true; // suppress leading dashes
+    let combined = format!("{owner}/{repo}");
+    for ch in combined.chars() {
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch.to_ascii_lowercase());
+            prev_dash = false;
+        } else if !prev_dash {
+            out.push('-');
+            prev_dash = true;
+        }
+    }
+    while out.ends_with('-') {
+        out.pop();
+    }
+    out
 }
 
 /// Resolve a `{slug}-{8hex}` URL ref to a traject UUID. Returns 400 on
@@ -514,6 +608,210 @@ pub async fn get(
     }))
 }
 
+/// Resolved writable-own source coordinates for the create handler.
+/// Either the phase-1 MinBZK defaults or the user-supplied repo after
+/// validation. The handler picks once up-front and then threads this
+/// through the INSERT — no `Option` juggling in the SQL bind list.
+struct WritableTarget {
+    owner: String,
+    repo: String,
+    base_branch: String,
+    path: String,
+    auth_ref: String,
+    /// Display name used as the source label in the federation config.
+    /// `MinBZK/regelrecht-corpus` for the default, `<owner>/<repo>` for
+    /// user-supplied repos.
+    display_name: String,
+}
+
+/// Decide whether the create-request asks for the MinBZK default or a
+/// user-supplied repo, then validate the latter against the configured
+/// token before we open the DB transaction.
+///
+/// The three `repo_*` fields are all-or-nothing: any subset other than
+/// "none" or "all three" is a 400 — partial submissions almost always
+/// mean the frontend forgot to wire one field.
+async fn resolve_writable_target(
+    state: &AppState,
+    req: &CreateTrajectRequest,
+) -> Result<WritableTarget, (StatusCode, String)> {
+    let owner = req
+        .repo_owner
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    let repo = req
+        .repo_name
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    let base = req
+        .base_branch
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+
+    match (owner, repo, base) {
+        // No repo coords → phase-1 default.
+        (None, None, None) => Ok(WritableTarget {
+            owner: CENTRAL_WRITABLE_OWNER.to_string(),
+            repo: CENTRAL_WRITABLE_REPO.to_string(),
+            base_branch: CENTRAL_WRITABLE_BASE_BRANCH.to_string(),
+            path: CENTRAL_WRITABLE_PATH.to_string(),
+            auth_ref: CENTRAL_WRITABLE_AUTH_REF.to_string(),
+            display_name: CENTRAL_WRITABLE_NAME.to_string(),
+        }),
+        // All three filled → user-supplied repo path. Validate.
+        (Some(owner), Some(repo), Some(base_branch)) => {
+            if !valid_repo_segment(owner) || !valid_repo_segment(repo) {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    "repo_owner / repo_name mogen alleen letters, cijfers, en \
+                     de tekens '-', '_' en '.' bevatten"
+                        .to_string(),
+                ));
+            }
+            let auth_ref = derive_auth_ref(owner, repo);
+            if auth_ref.is_empty() {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    format!("owner/repo \"{owner}/{repo}\" produces an empty auth_ref"),
+                ));
+            }
+
+            // Resolve the token. Use the *strict* resolver here — the
+            // `auth_ref` is derived from user-supplied repo coords, so
+            // an unknown ref must NOT fall back to `CORPUS_GIT_TOKEN`
+            // (that would ship the central token to a repo the user
+            // picked, a token-exfiltration vector). The strict variant
+            // returns `None` when no per-repo env var or auth-file
+            // entry is configured, which we then surface as a clean
+            // 503 with the expected env-var name.
+            let auth_file = {
+                let corpus = state.corpus.read().await;
+                corpus.auth_file.clone()
+            };
+            let token =
+                regelrecht_corpus::auth::resolve_token_strict(&auth_ref, auth_file.as_deref())
+                    .map_err(|e| {
+                        tracing::error!(error = %e, "auth lookup failed for new traject repo");
+                        (
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            "auth lookup failed".to_string(),
+                        )
+                    })?
+                    .ok_or_else(|| {
+                        let env_name = format!(
+                            "CORPUS_AUTH_{}_TOKEN",
+                            auth_ref.to_uppercase().replace('-', "_")
+                        );
+                        tracing::warn!(
+                            auth_ref = %auth_ref,
+                            env_name = %env_name,
+                            "no token configured for user-supplied repo"
+                        );
+                        (
+                            StatusCode::SERVICE_UNAVAILABLE,
+                            format!(
+                                "deze repo is nog niet door je beheerder geconfigureerd \
+                         (verwacht env var {env_name})"
+                            ),
+                        )
+                    })?;
+
+            let info = regelrecht_corpus::repo_access::validate_repo_access(
+                "https://api.github.com",
+                owner,
+                repo,
+                base_branch,
+                &token,
+            )
+            .await
+            .map_err(|e| repo_access_error_to_status(&e, owner, repo, base_branch))?;
+
+            tracing::info!(
+                owner = %owner,
+                repo = %repo,
+                base_branch = %base_branch,
+                default_branch = %info.default_branch,
+                is_private = info.is_private,
+                "validated user-supplied repo for new traject"
+            );
+
+            Ok(WritableTarget {
+                owner: owner.to_string(),
+                repo: repo.to_string(),
+                base_branch: base_branch.to_string(),
+                // `repo_path` is optional — empty means "everything
+                // under repo root", which the corpus client already
+                // handles correctly. The MinBZK default explicitly sets
+                // "regulation/nl"; user repos dedicated to regulations
+                // typically don't need a subpath.
+                path: req
+                    .repo_path
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .unwrap_or("")
+                    .to_string(),
+                auth_ref,
+                display_name: format!("{owner}/{repo}"),
+            })
+        }
+        // Partial → caller error, refuse rather than guess.
+        _ => Err((
+            StatusCode::BAD_REQUEST,
+            "repo_owner, repo_name en base_branch moeten alle drie worden meegegeven \
+             (of alle drie weggelaten worden voor de standaard MinBZK repo)"
+                .to_string(),
+        )),
+    }
+}
+
+/// Map a `RepoAccessError` to the appropriate HTTP status + a NL message
+/// the create-sheet can show as-is. Kept verbose so each failure mode is
+/// distinguishable in the UI.
+fn repo_access_error_to_status(
+    err: &regelrecht_corpus::repo_access::RepoAccessError,
+    owner: &str,
+    repo: &str,
+    base_branch: &str,
+) -> (StatusCode, String) {
+    use regelrecht_corpus::repo_access::RepoAccessError as E;
+    match err {
+        E::Unauthorized => (
+            StatusCode::UNAUTHORIZED,
+            "het token van je beheerder wordt door GitHub geweigerd".to_string(),
+        ),
+        E::RepoNotFound => (
+            StatusCode::NOT_FOUND,
+            format!("repo {owner}/{repo} bestaat niet of het token kan 'm niet zien"),
+        ),
+        E::BranchNotFound => (
+            StatusCode::NOT_FOUND,
+            format!("branch '{base_branch}' bestaat niet op {owner}/{repo}"),
+        ),
+        E::NoPushAccess => (
+            StatusCode::FORBIDDEN,
+            "het geconfigureerde token heeft geen schrijftoegang tot deze repo".to_string(),
+        ),
+        E::Transport(msg) => {
+            tracing::warn!(error = %msg, "transport error validating repo");
+            (
+                StatusCode::SERVICE_UNAVAILABLE,
+                "kon GitHub niet bereiken om de repo te valideren".to_string(),
+            )
+        }
+        E::Other(msg) => {
+            tracing::warn!(error = %msg, "unexpected GitHub response validating repo");
+            (
+                StatusCode::BAD_GATEWAY,
+                "onverwacht antwoord van GitHub bij repo-validatie".to_string(),
+            )
+        }
+    }
+}
+
 /// POST /api/trajects — create a new traject.
 ///
 /// Seeds the federated config by copying the global registry's sources
@@ -521,18 +819,30 @@ pub async fn get(
 /// source at priority 0. Branch creation on the writable source is
 /// handled by `GitBackend` on first use, which falls back to the
 /// configured base branch when the traject branch doesn't yet exist.
+///
+/// When the request supplies `repo_owner`/`repo_name`/`base_branch`,
+/// the writable-own source points to that user repo and the
+/// pre-existing `CORPUS_AUTH_*_TOKEN` env var (named after a
+/// deterministic slug of `owner-repo` — see [`derive_auth_ref`])
+/// authenticates it. No request omitted → phase-1 MinBZK default.
 pub async fn create(
     State(state): State<AppState>,
     Extension(account): Extension<AccountRecord>,
     Json(req): Json<CreateTrajectRequest>,
-) -> Result<(StatusCode, Json<TrajectSummary>), StatusCode> {
+) -> Result<(StatusCode, Json<TrajectSummary>), (StatusCode, String)> {
     let name = req.name.trim();
     if name.is_empty() {
-        return Err(StatusCode::BAD_REQUEST);
+        return Err((StatusCode::BAD_REQUEST, "name is required".to_string()));
     }
 
-    let pool = get_pool(&state)?;
-    let mut tx = pool.begin().await.map_err(db_err("begin tx"))?;
+    // Resolve the writable-own target first — the validation may need to
+    // talk to GitHub (which can fail with a helpful 4xx); we want to do
+    // that *before* we open the DB transaction so a network blip doesn't
+    // leak a half-rolled row.
+    let target = resolve_writable_target(&state, &req).await?;
+
+    let pool = get_pool_msg(&state)?;
+    let mut tx = pool.begin().await.map_err(db_err_msg("begin tx"))?;
 
     let traject_id: Uuid = sqlx::query_scalar(
         "INSERT INTO trajects (name, description, scope, created_by)
@@ -544,7 +854,7 @@ pub async fn create(
     .bind(account.id)
     .fetch_one(&mut *tx)
     .await
-    .map_err(db_err("insert traject"))?;
+    .map_err(db_err_msg("insert traject"))?;
 
     sqlx::query(
         "INSERT INTO traject_members (traject_id, account_id, role)
@@ -554,7 +864,7 @@ pub async fn create(
     .bind(account.id)
     .execute(&mut *tx)
     .await
-    .map_err(db_err("insert member"))?;
+    .map_err(db_err_msg("insert member"))?;
 
     // Seed federated config from the global registry. The global corpus
     // read guard is dropped before the next await so we don't hold it
@@ -594,15 +904,14 @@ pub async fn create(
         .bind(seed.scopes)
         .execute(&mut *tx)
         .await
-        .map_err(db_err("seed traject source"))?;
+        .map_err(db_err_msg("seed traject source"))?;
     }
 
-    // Writable-own source: hardcoded to the central MinBZK corpus on
-    // `development` for phase 1. The branch name is derived from the
-    // traject name + id; auth flows through `CORPUS_AUTH_MINBZK_CENTRAL_TOKEN`
-    // via `auth_ref = "minbzk-central"`. Columns stay populated as a
-    // record — phase 2 (per-user auth, per-traject fork choice) can swap
-    // these constants for request-body fields without touching the DB.
+    // Writable-own source: either the phase-1 MinBZK default or the
+    // user-supplied repo (already validated up-front for push access).
+    // The branch name is derived from the traject name + id; auth flows
+    // through `CORPUS_AUTH_{AUTH_REF_UPPER}_TOKEN` via the `auth_ref`
+    // stored on this row.
     let writable_branch = derive_branch_name(name, traject_id);
     let writable_source_id = format!("traject-own-{}", traject_id.simple());
     sqlx::query(
@@ -616,18 +925,20 @@ pub async fn create(
     )
     .bind(traject_id)
     .bind(&writable_source_id)
-    .bind(CENTRAL_WRITABLE_NAME)
-    .bind(CENTRAL_WRITABLE_OWNER)
-    .bind(CENTRAL_WRITABLE_REPO)
+    .bind(&target.display_name)
+    .bind(&target.owner)
+    .bind(&target.repo)
     .bind(&writable_branch)
-    .bind(CENTRAL_WRITABLE_BASE_BRANCH)
-    .bind(CENTRAL_WRITABLE_PATH)
-    .bind(CENTRAL_WRITABLE_AUTH_REF)
+    .bind(&target.base_branch)
+    .bind(&target.path)
+    .bind(&target.auth_ref)
     .execute(&mut *tx)
     .await
-    .map_err(db_err("insert writable source"))?;
+    .map_err(db_err_msg("insert writable source"))?;
 
-    tx.commit().await.map_err(db_err("commit traject create"))?;
+    tx.commit()
+        .await
+        .map_err(db_err_msg("commit traject create"))?;
 
     state.trajects.invalidate(traject_id).await;
 
@@ -1108,5 +1419,41 @@ mod tests {
         let branch = derive_branch_name("Tarief", id);
         assert!(branch.starts_with("traject/tarief-"));
         assert_eq!(branch.len(), "traject/tarief-".len() + 8);
+    }
+
+    #[test]
+    fn auth_ref_lowercases_and_collapses_separators() {
+        // Owner + repo combined with `/`, all separators collapse to a
+        // single dash. Operators read this back as the env-var stem
+        // `CORPUS_AUTH_<UPPER>_TOKEN`.
+        assert_eq!(derive_auth_ref("Acme", "Secret-Repo"), "acme-secret-repo");
+        assert_eq!(
+            derive_auth_ref("MinBZK", "regelrecht-corpus"),
+            "minbzk-regelrecht-corpus"
+        );
+        assert_eq!(derive_auth_ref("a.b", "c_d"), "a-b-c-d");
+    }
+
+    #[test]
+    fn auth_ref_stable_under_already_normalised_input() {
+        // An already-normalised owner/repo (lowercase + dash-only) must
+        // come out byte-identical — operators read this back from the
+        // DB row to know the matching env-var name; any drift between
+        // create-time and read-time would mean "broken token resolution
+        // after a rename".
+        assert_eq!(derive_auth_ref("acme", "secret-repo"), "acme-secret-repo");
+        assert_eq!(
+            derive_auth_ref("minbzk", "regelrecht-corpus"),
+            "minbzk-regelrecht-corpus"
+        );
+    }
+
+    #[test]
+    fn auth_ref_trims_leading_and_trailing_dashes() {
+        // Garbage in/out: only-special-chars resolves to "" rather than
+        // a string of pure dashes. The caller should reject this before
+        // it reaches the INSERT.
+        assert_eq!(derive_auth_ref("...", "..."), "");
+        assert_eq!(derive_auth_ref(".foo.", ".bar."), "foo-bar");
     }
 }

--- a/packages/editor-api/src/trajects.rs
+++ b/packages/editor-api/src/trajects.rs
@@ -125,11 +125,58 @@ pub struct CreateTrajectRequest {
 /// itself allows for these identifiers — alphanumerics plus `-`, `_`,
 /// and `.`. Lets us refuse path-traversal-shaped input (`..`, `/`) at
 /// the API boundary rather than relying on GitHub to 404 it.
+///
+/// GitHub additionally disallows the literal segments `.` and `..` and
+/// names starting with a leading `.` (hidden/reserved). Reject those
+/// here so we don't store a row that GitHub will subsequently 404 on
+/// every contents/branches call.
 fn valid_repo_segment(s: &str) -> bool {
-    !s.is_empty()
-        && s.len() <= 100
-        && s.chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
+    if s.is_empty() || s.len() > 100 {
+        return false;
+    }
+    if s == "." || s == ".." || s.starts_with('.') {
+        return false;
+    }
+    s.chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
+}
+
+/// Reject branch names that git itself would refuse as refnames.
+///
+/// Mirrors the subset of `git-check-ref-format` rules that we can apply
+/// to a single component: no control chars, no whitespace, no
+/// `~^:?*[\` or `..`, no leading dash, no leading/trailing slash, no
+/// `@{` sequence. Bounded length so an oversized input can't bloat the
+/// on-disk branch name.
+///
+/// `base_branch` flows unencoded into a GitHub Contents-API URL
+/// (`/repos/{owner}/{repo}/branches/{base_branch}`) and is later
+/// persisted + used as a git refname in `commit_and_push_to_branch`.
+/// A non-empty trim check would let `"main?spoof=1"` through — GitHub
+/// strips the query, validates `main`, and the bogus suffix lands in
+/// the DB. This guard refuses any refname-illegal character at the API
+/// boundary so the persisted value is always a clean refname.
+fn valid_branch_name(s: &str) -> bool {
+    if s.is_empty() || s.len() > 200 {
+        return false;
+    }
+    if s.starts_with('-') || s.starts_with('/') || s.ends_with('/') {
+        return false;
+    }
+    if s.contains("..") || s.contains("@{") || s.contains("//") {
+        return false;
+    }
+    s.chars().all(|c| {
+        !c.is_control()
+            && c != ' '
+            && c != '~'
+            && c != '^'
+            && c != ':'
+            && c != '?'
+            && c != '*'
+            && c != '['
+            && c != '\\'
+    })
 }
 
 /// Validate a user-supplied `repo_path` (sub-directory within a repo).
@@ -655,7 +702,12 @@ struct WritableTarget {
     owner: String,
     repo: String,
     base_branch: String,
-    path: String,
+    /// Optional sub-path within the repo. `None` means "everything
+    /// under repo root" and is persisted as SQL `NULL` — consistent
+    /// with how seeded sources without a subpath are stored. `Some` is
+    /// always a non-empty, validated relative path (see
+    /// `valid_repo_path`).
+    path: Option<String>,
     auth_ref: String,
     /// Display name used as the source label in the federation config.
     /// `MinBZK/regelrecht-corpus` for the default, `<owner>/<repo>` for
@@ -696,7 +748,7 @@ async fn resolve_writable_target(
             owner: CENTRAL_WRITABLE_OWNER.to_string(),
             repo: CENTRAL_WRITABLE_REPO.to_string(),
             base_branch: CENTRAL_WRITABLE_BASE_BRANCH.to_string(),
-            path: CENTRAL_WRITABLE_PATH.to_string(),
+            path: Some(CENTRAL_WRITABLE_PATH.to_string()),
             auth_ref: CENTRAL_WRITABLE_AUTH_REF.to_string(),
             display_name: CENTRAL_WRITABLE_NAME.to_string(),
         }),
@@ -710,25 +762,43 @@ async fn resolve_writable_target(
                         .to_string(),
                 ));
             }
+            // `base_branch` flows unencoded into a GitHub URL and is
+            // later persisted + used as a git refname; reject any
+            // refname-illegal character at the boundary so neither
+            // GitHub nor git ever sees a malformed ref. See
+            // `valid_branch_name` for the exact rule set.
+            if !valid_branch_name(base_branch) {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    "base_branch bevat tekens die niet zijn toegestaan in een git branch-naam"
+                        .to_string(),
+                ));
+            }
             // Validate the optional repo sub-path at the API boundary.
             // `GitBackend::resolve` only validates the inner *relative*
             // path on each read/write; the base `gh_path` itself is
             // never re-checked downstream, so a traversal like
             // `../../etc` would let the backend read/write outside the
             // per-traject clone. Reject up-front.
-            let repo_path_input = req
+            //
+            // Trim + treat empty as "no subpath" → stored as SQL NULL
+            // (matches how seeded sources without a subpath are stored;
+            // avoids the "" vs NULL inconsistency on the row).
+            let repo_path: Option<String> = req
                 .repo_path
                 .as_deref()
                 .map(str::trim)
                 .filter(|s| !s.is_empty())
-                .unwrap_or("");
-            if !valid_repo_path(repo_path_input) {
-                return Err((
-                    StatusCode::BAD_REQUEST,
-                    "repo_path moet een relatief pad zijn zonder '..' segmenten en \
-                     mag alleen letters, cijfers, en '-', '_', '.' bevatten"
-                        .to_string(),
-                ));
+                .map(str::to_string);
+            if let Some(ref p) = repo_path {
+                if !valid_repo_path(p) {
+                    return Err((
+                        StatusCode::BAD_REQUEST,
+                        "repo_path moet een relatief pad zijn zonder '..' segmenten en \
+                         mag alleen letters, cijfers, en '-', '_', '.' bevatten"
+                            .to_string(),
+                    ));
+                }
             }
             let auth_ref = derive_auth_ref(owner, repo);
             if auth_ref.is_empty() {
@@ -818,13 +888,14 @@ async fn resolve_writable_target(
                 owner: owner.to_string(),
                 repo: repo.to_string(),
                 base_branch: base_branch.to_string(),
-                // `repo_path` is optional — empty means "everything
-                // under repo root", which the corpus client already
-                // handles correctly. The MinBZK default explicitly sets
-                // "regulation/nl"; user repos dedicated to regulations
-                // typically don't need a subpath. Already validated
-                // above as a clean relative path.
-                path: repo_path_input.to_string(),
+                // `repo_path` is optional — `None` means "everything
+                // under repo root" (persisted as NULL), which the
+                // corpus client already handles correctly. The MinBZK
+                // default explicitly sets "regulation/nl"; user repos
+                // dedicated to regulations typically don't need a
+                // subpath. Already validated above as a clean relative
+                // path.
+                path: repo_path,
                 auth_ref,
                 display_name: format!("{owner}/{repo}"),
             })
@@ -1551,6 +1622,65 @@ mod tests {
         assert!(!valid_repo_path(".."));
         assert!(!valid_repo_path("regulation/with space"));
         assert!(!valid_repo_path("regulation/with!bang"));
+    }
+
+    #[test]
+    fn valid_repo_segment_rejects_leading_dot_and_dots_only() {
+        // GitHub disallows segments that are literal `.` or `..` and
+        // names starting with a leading `.`. The previous validator
+        // permitted these because they're inside the `[A-Za-z0-9._-]`
+        // character class; this test pins the explicit rejection.
+        assert!(!valid_repo_segment("."));
+        assert!(!valid_repo_segment(".."));
+        assert!(!valid_repo_segment(".hidden"));
+        assert!(!valid_repo_segment(".github"));
+        // Dots in the middle of a segment remain valid (e.g. version
+        // suffixes like `repo.v2`).
+        assert!(valid_repo_segment("a.b"));
+        assert!(valid_repo_segment("regelrecht-corpus"));
+    }
+
+    #[test]
+    fn valid_branch_name_accepts_common_branches() {
+        // Real branch names that flow through `resolve_writable_target`
+        // every day: must not be rejected by the boundary guard.
+        assert!(valid_branch_name("main"));
+        assert!(valid_branch_name("develop"));
+        assert!(valid_branch_name("feature/foo"));
+        assert!(valid_branch_name("release-1.0"));
+        assert!(valid_branch_name("user/feature/sub-branch"));
+    }
+
+    #[test]
+    fn valid_branch_name_rejects_url_injection_and_refname_illegals() {
+        // `?` would let `main?spoof=1` pass the trim+non-empty check
+        // because GitHub strips the query before validating `main`;
+        // refuse it at the boundary so the persisted refname is clean.
+        assert!(!valid_branch_name("main?spoof=1"));
+        // Trailing/embedded whitespace and control chars.
+        assert!(!valid_branch_name("main "));
+        assert!(!valid_branch_name("ma in"));
+        assert!(!valid_branch_name("main\n"));
+        assert!(!valid_branch_name("main\t"));
+        // Refname-illegal characters from `git-check-ref-format`.
+        assert!(!valid_branch_name("feat~1"));
+        assert!(!valid_branch_name("feat^2"));
+        assert!(!valid_branch_name("a:b"));
+        assert!(!valid_branch_name("a*b"));
+        assert!(!valid_branch_name("a[b"));
+        assert!(!valid_branch_name("a\\b"));
+        assert!(!valid_branch_name("feat@{1}"));
+        // `..` (dot-dot), leading `-`, leading/trailing `/`, double `/`.
+        assert!(!valid_branch_name(".."));
+        assert!(!valid_branch_name("a..b"));
+        assert!(!valid_branch_name("-x"));
+        assert!(!valid_branch_name("/x"));
+        assert!(!valid_branch_name("x/"));
+        assert!(!valid_branch_name("feat//bar"));
+        // Empty + oversized.
+        assert!(!valid_branch_name(""));
+        let oversized: String = "a".repeat(201);
+        assert!(!valid_branch_name(&oversized));
     }
 
     #[test]

--- a/packages/editor-api/src/trajects.rs
+++ b/packages/editor-api/src/trajects.rs
@@ -160,10 +160,22 @@ fn valid_branch_name(s: &str) -> bool {
     if s.is_empty() || s.len() > 200 {
         return false;
     }
-    if s.starts_with('-') || s.starts_with('/') || s.ends_with('/') {
+    // `git-check-ref-format` rejects the bare `@` as a refname.
+    if s == "@" {
+        return false;
+    }
+    // Leading `-`/`/`, trailing `/`, and a trailing `.` are all rejected
+    // by `git-check-ref-format` (e.g. `main.` is refused).
+    if s.starts_with('-') || s.starts_with('/') || s.ends_with('/') || s.ends_with('.') {
         return false;
     }
     if s.contains("..") || s.contains("@{") || s.contains("//") {
+        return false;
+    }
+    // No path component may end with `.lock` — git treats `<ref>.lock`
+    // as a lockfile sentinel, so `main.lock` and `feature/foo.lock` are
+    // both refused as refnames.
+    if s.split('/').any(|c| c.ends_with(".lock")) {
         return false;
     }
     s.chars().all(|c| {
@@ -1681,6 +1693,21 @@ mod tests {
         assert!(!valid_branch_name(""));
         let oversized: String = "a".repeat(201);
         assert!(!valid_branch_name(&oversized));
+    }
+
+    #[test]
+    fn valid_branch_name_rejects_git_specific_corner_cases() {
+        // git-check-ref-format rejects refnames that end with `.`, the
+        // bare `@`, or any component ending in `.lock`. Mirror those
+        // here so the boundary check matches the refname grammar.
+        assert!(!valid_branch_name("main."));
+        assert!(!valid_branch_name("@"));
+        assert!(!valid_branch_name("main.lock"));
+        assert!(!valid_branch_name("feat/foo.lock"));
+        // Sanity: dots / "lock" inside a name (not as a trailing
+        // component / suffix) stay accepted.
+        assert!(valid_branch_name("main.foo"));
+        assert!(valid_branch_name("locked-down"));
     }
 
     #[test]

--- a/packages/editor-api/src/trajects.rs
+++ b/packages/editor-api/src/trajects.rs
@@ -188,6 +188,13 @@ fn valid_branch_name(s: &str) -> bool {
             && c != '*'
             && c != '['
             && c != '\\'
+            // `#` is a legal refname char in git but is the URL fragment
+            // delimiter. `format!(".../branches/{base_branch}")` followed
+            // by reqwest parsing would silently drop everything after
+            // `#`, so a branch name `main#spoof` would 200-pass the
+            // pre-flight (it matches `main`) but later git operations
+            // reference the non-existent `main#spoof`. Reject up front.
+            && c != '#'
     })
 }
 
@@ -1682,6 +1689,11 @@ mod tests {
         assert!(!valid_branch_name("a[b"));
         assert!(!valid_branch_name("a\\b"));
         assert!(!valid_branch_name("feat@{1}"));
+        // `#` is legal in git refnames but is the URL fragment delimiter,
+        // so `main#spoof` would 200-pass the pre-flight (matches `main`)
+        // and produce a non-existent refname downstream. Refuse it.
+        assert!(!valid_branch_name("main#spoof"));
+        assert!(!valid_branch_name("#"));
         // `..` (dot-dot), leading `-`, leading/trailing `/`, double `/`.
         assert!(!valid_branch_name(".."));
         assert!(!valid_branch_name("a..b"));

--- a/packages/editor-api/src/trajects.rs
+++ b/packages/editor-api/src/trajects.rs
@@ -132,6 +132,45 @@ fn valid_repo_segment(s: &str) -> bool {
             .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
 }
 
+/// Validate a user-supplied `repo_path` (sub-directory within a repo).
+///
+/// Empty is allowed and means "repo root". Otherwise the path must be
+/// relative (no leading `/`, no Windows prefix) and contain only
+/// "normal" components — no `..`, no `.`, no root. Each segment is
+/// further constrained to the same character set as `valid_repo_segment`
+/// so it can safely flow into a GitHub Contents-API URL without
+/// double-encoding or escaping surprises.
+///
+/// `validate_relative_path` inside `GitBackend::resolve` covers the
+/// inner per-file relative path, but the *base* `repo_subpath` (stored
+/// on the row as `gh_path`) never reaches that check. Without this
+/// guard a caller could ship `repo_path = "../../etc"` and the backend
+/// would read/write outside the per-traject clone.
+fn valid_repo_path(s: &str) -> bool {
+    if s.is_empty() {
+        return true;
+    }
+    let p = std::path::Path::new(s);
+    if p.is_absolute() {
+        return false;
+    }
+    for c in p.components() {
+        match c {
+            std::path::Component::Normal(seg) => {
+                let seg_str = seg.to_string_lossy();
+                if !valid_repo_segment(&seg_str) {
+                    return false;
+                }
+            }
+            // ParentDir (`..`), CurDir (`.`), RootDir, Prefix — all
+            // rejected so the stored gh_path is always a clean,
+            // forward-traversal-only relative path.
+            _ => return false,
+        }
+    }
+    true
+}
+
 // Phase-1 default writable source — the central MinBZK corpus repo on
 // its `development` branch, using the app-wide
 // `CORPUS_AUTH_MINBZK_CENTRAL_TOKEN`. Used when the create-request omits
@@ -671,11 +710,51 @@ async fn resolve_writable_target(
                         .to_string(),
                 ));
             }
+            // Validate the optional repo sub-path at the API boundary.
+            // `GitBackend::resolve` only validates the inner *relative*
+            // path on each read/write; the base `gh_path` itself is
+            // never re-checked downstream, so a traversal like
+            // `../../etc` would let the backend read/write outside the
+            // per-traject clone. Reject up-front.
+            let repo_path_input = req
+                .repo_path
+                .as_deref()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .unwrap_or("");
+            if !valid_repo_path(repo_path_input) {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    "repo_path moet een relatief pad zijn zonder '..' segmenten en \
+                     mag alleen letters, cijfers, en '-', '_', '.' bevatten"
+                        .to_string(),
+                ));
+            }
             let auth_ref = derive_auth_ref(owner, repo);
             if auth_ref.is_empty() {
                 return Err((
                     StatusCode::BAD_REQUEST,
                     format!("owner/repo \"{owner}/{repo}\" produces an empty auth_ref"),
+                ));
+            }
+            // Reject the rare collision where a user-supplied
+            // owner/repo combination derives to the same slug as the
+            // hardcoded central writable auth ref. Without this check,
+            // a user who happens to point a traject at
+            // `MinBZK/central` would silently get the central token
+            // routed to their repo, violating the design principle
+            // that the central token only ever reaches the central
+            // repo. Surface as a 400 so the operator picks a
+            // different slug (or omits the repo fields entirely to
+            // use the actual MinBZK default).
+            if auth_ref == CENTRAL_WRITABLE_AUTH_REF {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    format!(
+                        "repo \"{owner}/{repo}\" botst met de gereserveerde central auth ref; \
+                         gebruik een andere repo of laat de repo-velden weg om naar de centrale \
+                         MinBZK-repo te wijzen"
+                    ),
                 ));
             }
 
@@ -701,10 +780,7 @@ async fn resolve_writable_target(
                         )
                     })?
                     .ok_or_else(|| {
-                        let env_name = format!(
-                            "CORPUS_AUTH_{}_TOKEN",
-                            auth_ref.to_uppercase().replace('-', "_")
-                        );
+                        let env_name = regelrecht_corpus::auth::token_env_name(&auth_ref);
                         tracing::warn!(
                             auth_ref = %auth_ref,
                             env_name = %env_name,
@@ -746,14 +822,9 @@ async fn resolve_writable_target(
                 // under repo root", which the corpus client already
                 // handles correctly. The MinBZK default explicitly sets
                 // "regulation/nl"; user repos dedicated to regulations
-                // typically don't need a subpath.
-                path: req
-                    .repo_path
-                    .as_deref()
-                    .map(str::trim)
-                    .filter(|s| !s.is_empty())
-                    .unwrap_or("")
-                    .to_string(),
+                // typically don't need a subpath. Already validated
+                // above as a clean relative path.
+                path: repo_path_input.to_string(),
                 auth_ref,
                 display_name: format!("{owner}/{repo}"),
             })
@@ -1455,5 +1526,51 @@ mod tests {
         // it reaches the INSERT.
         assert_eq!(derive_auth_ref("...", "..."), "");
         assert_eq!(derive_auth_ref(".foo.", ".bar."), "foo-bar");
+    }
+
+    #[test]
+    fn valid_repo_path_accepts_empty_and_simple_subdirs() {
+        assert!(valid_repo_path(""));
+        assert!(valid_repo_path("regulation/nl"));
+        assert!(valid_repo_path("a"));
+        assert!(valid_repo_path("a/b/c"));
+        assert!(valid_repo_path("dir.with.dots/and_underscores"));
+    }
+
+    #[test]
+    fn valid_repo_path_rejects_traversal_and_absolute() {
+        // The whole point of this check: the base gh_path is never
+        // re-validated by GitBackend::resolve, so any traversal or
+        // absolute path that lands in the DB row will be honoured by
+        // the backend on subsequent reads/writes. Reject at the API
+        // boundary.
+        assert!(!valid_repo_path("../etc"));
+        assert!(!valid_repo_path("/etc"));
+        assert!(!valid_repo_path("regulation/../../etc"));
+        assert!(!valid_repo_path("./regulation"));
+        assert!(!valid_repo_path(".."));
+        assert!(!valid_repo_path("regulation/with space"));
+        assert!(!valid_repo_path("regulation/with!bang"));
+    }
+
+    #[test]
+    fn minbzk_central_collides_with_reserved_auth_ref() {
+        // Documents the collision the `resolve_writable_target` guard
+        // exists to prevent: a user-supplied owner=MinBZK, repo=central
+        // derives byte-for-byte to the hardcoded CENTRAL_WRITABLE_AUTH_REF.
+        // Without the guard, that traject would silently get the central
+        // token routed to a user-chosen repo. The guard rejects the
+        // request before INSERT; this test pins the precondition so a
+        // future rename of either constant or `derive_auth_ref` can't
+        // silently break the guard's premise.
+        assert_eq!(
+            derive_auth_ref("MinBZK", "central"),
+            CENTRAL_WRITABLE_AUTH_REF
+        );
+        // Sanity check: an unrelated repo doesn't collide.
+        assert_ne!(
+            derive_auth_ref("MinBZK", "regelrecht-corpus"),
+            CENTRAL_WRITABLE_AUTH_REF
+        );
     }
 }

--- a/packages/editor-api/src/trajects.rs
+++ b/packages/editor-api/src/trajects.rs
@@ -940,8 +940,14 @@ fn repo_access_error_to_status(
 ) -> (StatusCode, String) {
     use regelrecht_corpus::repo_access::RepoAccessError as E;
     match err {
+        // The *user* is fully authenticated (made it through OIDC + this
+        // handler's middleware). What failed is the *operator's*
+        // GitHub PAT — that is an upstream credential issue, not a
+        // missing user credential. Use BAD_GATEWAY rather than 401 so
+        // proxies / browsers don't try to inject WWW-Authenticate or
+        // pop a credential dialog at the editor's user.
         E::Unauthorized => (
-            StatusCode::UNAUTHORIZED,
+            StatusCode::BAD_GATEWAY,
             "het token van je beheerder wordt door GitHub geweigerd".to_string(),
         ),
         E::RepoNotFound => (


### PR DESCRIPTION
## Summary

- **Traject op eigen repo**: bij aanmaken kan een gebruiker nu een eigen `owner/repo/base_branch` (+ optionele `repo_path`) opgeven; de drie velden zijn een alles-of-niets-keuze. Lege velden = huidig MinBZK/regelrecht-corpus gedrag (backwards compat).
- **Per-repo token via env var**: voor elke repo moet de operator één env-var configureren (`CORPUS_AUTH_<owner-repo>_TOKEN`, slug deterministisch afgeleid). Geen tokens in DB, geen tokens in browser.
- **Verified-email afdwingen**: save-handlers eisen nu een geverifieerd e-mailadres uit de OIDC-sessie (Keycloak's `email_verified=true`). Zonder verified email weigert de handler met 403 — geen stille fallback naar service-identity, dat zou spoofing maskeren.

## Waarom?

Phase-1 hardcoded alle trajects op `MinBZK/regelrecht-corpus` met één central app-token. Voor teams die op een eigen private repo willen werken was er nog niets — die hebben nu een pad zonder dat we per-user tokens in DB hoeven op te slaan.

Bij commit-attributie was er een spoofing-risico: de OIDC name/email landde op de commit-author zonder verificatie, dus iemand met een crafted IdP-config kon onder andermans naam committen. Nu vereist de save-handler een geverifieerd email-claim en weigert anders.

## Belangrijkste files

- `packages/corpus/src/repo_access.rs` (nieuw) — pre-flight `validate_repo_access` via GitHub REST (push-permissions + base-branch bestaan), wiremock-tested (6 cases)
- `packages/corpus/src/auth.rs` — nieuwe `resolve_token_strict()` zonder legacy `CORPUS_GIT_TOKEN` fallback. Voor user-supplied auth_refs verplicht; voorkomt token-exfiltratie naar user-chosen repos
- `packages/auth/src/handlers.rs` + `lib.rs` — `SESSION_KEY_EMAIL_VERIFIED` ingevuld uit OIDC `email_verified` claim
- `packages/editor-api/src/trajects.rs` — `CreateTrajectRequest` uitgebreid, `create()` valideert repo voor de DB-tx opent, `derive_auth_ref()` helper, char-validation op owner/repo
- `packages/editor-api/src/corpus_handlers.rs` — `editor_user_from_session` strict, `require_editor_user` returnt 403 met re-login hint
- `packages/editor-api/src/traject_corpus.rs` — gebruikt strict resolver voor writable-own (legacy fallback alleen voor read-only seeds)
- `frontend/src/components/TrajectMenu.vue` — create-sheet toggle "Eigen repo" + drie velden + foutmeldingen

## Tests

- Corpus crate: 8 auth tests (incl. nieuwe `resolve_token_strict_skips_legacy_corpus_git_token` regression), 6 repo_access wiremock-tests
- Editor-api crate: 14 unit tests (incl. 4 editor_user/require_editor_user, 4 derive_auth_ref, en een compile-time spoof-invariant test)
- Frontend: 192 vitest tests groen
- `just lint`, `just build-check`, `just format` allen groen
- Integration-tests in `packages/editor-api/tests/*.rs` zijn al broken op origin/main (gebruiken `SESSION_KEY_ACTIVE_TRAJECT` die PR #695 verwijderd heeft) — niet in scope hier; CI doet alleen `cargo check`

## Rollout note

Bestaande sessies missen `SESSION_KEY_EMAIL_VERIFIED` en krijgen na deploy 403 op de eerste save. De 403-message stuurt expliciet aan op opnieuw inloggen — daarmee wordt de claim alsnog gevuld. Documentatie + UX hint zit in de NL foutmelding.

## Geparkeerd voor follow-up

- Eigen audit-log tabel in editor-api DB met `account_id` per save (harde attributie naast de zachte git-trailer)
- GitHub OAuth via Keycloak identity broker (phase 3)
- "Open repo direct" mode zonder DB-traject

## Test plan

- [ ] Operator zet `CORPUS_AUTH_<OWNER>_<REPO>_TOKEN` op een dev-deploy
- [ ] Editor → Nieuw traject → toggle "Eigen repo" → owner/repo/main invullen → submit
- [ ] Edit + save → commit op GitHub onder OIDC-naam, PR open op `<owner>/<repo>`
- [ ] Tweede browser/account → andere commits onder andere OIDC-naam
- [ ] Probeer create met onbekende repo → 503 met env-var-naam hint
- [ ] Probeer create met repo zonder push-rechten → 403 met duidelijke melding
- [ ] Probeer create met niet-bestaande branch → 404 met duidelijke melding
- [ ] Bestaande MinBZK-trajects ongewijzigd werken