### PR TITLE
fix(editor): drag-selection laat los bij notitie-mark

### DIFF
--- a/frontend/src/components/AnnotatedText.test.js
+++ b/frontend/src/components/AnnotatedText.test.js
@@ -397,6 +397,23 @@ describe('AnnotatedText popover suppression during drag-selection', () => {
     expect(wrapper.vm.activeNote).toBeNull();
   });
 
+  it('click-to-pin on one instance does not open the popover on another mounted instance', async () => {
+    // Two AnnotatedText instances both register document-level pointerup
+    // listeners. Without a containment guard, a tap on instance B's mark
+    // would resolve to instance A's noteByIdx[idx] and pop A's popover
+    // with the wrong note attached to B's DOM. The guard inside
+    // markFromEvent rejects targets outside the instance's own
+    // richTextEl, so A stays untouched.
+    const { wrapper: wrapperA } = await mountedWithMark();
+    const { wrapper: wrapperB, mark: markB } = await mountedWithMark();
+    // Sanity: A's activeNote starts null.
+    expect(wrapperA.vm.activeNote).toBeNull();
+    fire(document, 'pointerdown', { button: 0, clientX: 20, clientY: 20 });
+    fire(markB, 'pointerup', { button: 0, clientX: 21, clientY: 22 });
+    expect(wrapperB.vm.activeNote).toBeTruthy(); // B's own click-to-pin
+    expect(wrapperA.vm.activeNote).toBeNull(); // A must not have opened
+  });
+
   it('closes an already-open popover immediately on a new pointerdown', async () => {
     const { wrapper, mark } = await mountedWithMark();
     fire(mark, 'pointerover');

--- a/frontend/src/components/AnnotatedText.test.js
+++ b/frontend/src/components/AnnotatedText.test.js
@@ -262,3 +262,127 @@ describe('AnnotatedText markdown highlighting', () => {
     expect(wrapper.vm.selectionRange).toBe(null);
   });
 });
+
+// nldd-popover uses the native HTML popover API: showPopover() puts the
+// element in the top layer and steals focus. Opening it from a pointerover
+// while the user is mid-drag therefore lands the drag's pointermove on the
+// popover instead of the underlying text — selection cannot extend past the
+// first mark it touches. These tests pin the drag-aware gate that closes
+// the hover-popover path during a selection drag, while keeping hover and
+// keyboard discoverability intact.
+//
+// The signal under test is `wrapper.vm.activeNote`, not a spy on the
+// popover stub. openFor sets activeNote BEFORE calling pop.showPopover,
+// so observing activeNote tells us whether the gate let openFor through.
+// This sidesteps quirks in how Vue Test Utils stubs expose setup() returns
+// via useTemplateRef + optional-chained calls.
+describe('AnnotatedText popover suppression during drag-selection', () => {
+  function fire(target, type, init = {}) {
+    // MouseEvent matches the type names Vue listens to for pointer events
+    // (pointerover/pointerdown/pointerup/pointercancel) and gives us
+    // clientX/clientY/button without depending on PointerEvent constructor
+    // support in happy-dom.
+    target.dispatchEvent(new MouseEvent(type, { bubbles: true, ...init }));
+  }
+
+  // Attach to document.body so events dispatched on marks bubble up to the
+  // document-level pointerdown/pointerup listeners the gate registers. The
+  // default mount is detached and pointer events would never reach document.
+  async function mountedWithMark() {
+    const wrapper = mount(AnnotatedText, {
+      props: {
+        article: ART,
+        notesForArticle: [
+          { note: noteVerzekerde, spans: [{ start: 7, end: 17 }] },
+        ],
+      },
+      attachTo: document.body,
+      global: { stubs: nlddStubs },
+    });
+    await nextTick();
+    await nextTick();
+    return {
+      wrapper,
+      mark: wrapper.element.querySelector('mark[data-primary-idx]'),
+    };
+  }
+
+  it('opens the popover on a hover without any prior pointerdown', async () => {
+    const { wrapper, mark } = await mountedWithMark();
+    fire(mark, 'pointerover');
+    expect(wrapper.vm.activeNote).toBeTruthy();
+  });
+
+  it('does not open the popover when pointerover hits a mark mid-drag', async () => {
+    const { wrapper, mark } = await mountedWithMark();
+    fire(document, 'pointerdown', { button: 0, clientX: 10, clientY: 10 });
+    fire(mark, 'pointerover');
+    expect(wrapper.vm.activeNote).toBeNull();
+  });
+
+  it('does not open the popover on focusin during a drag', async () => {
+    const { wrapper, mark } = await mountedWithMark();
+    fire(document, 'pointerdown', { button: 0, clientX: 10, clientY: 10 });
+    mark.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+    expect(wrapper.vm.activeNote).toBeNull();
+  });
+
+  it('opens the popover on focusin via keyboard (no prior pointerdown)', async () => {
+    const { wrapper, mark } = await mountedWithMark();
+    mark.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+    expect(wrapper.vm.activeNote).toBeTruthy();
+  });
+
+  it('does not pin the popover on pointerup when the pointer moved (real drag)', async () => {
+    const { wrapper, mark } = await mountedWithMark();
+    fire(document, 'pointerdown', { button: 0, clientX: 10, clientY: 10 });
+    fire(mark, 'pointerup', { button: 0, clientX: 80, clientY: 50 });
+    expect(wrapper.vm.activeNote).toBeNull();
+  });
+
+  it('pins the popover on pointerup when the pointer did not move (tap on mark)', async () => {
+    const { wrapper, mark } = await mountedWithMark();
+    fire(document, 'pointerdown', { button: 0, clientX: 20, clientY: 20 });
+    fire(mark, 'pointerup', { button: 0, clientX: 21, clientY: 22 });
+    expect(wrapper.vm.activeNote).toBeTruthy();
+  });
+
+  it('releases the drag flag on pointercancel so later hovers open again', async () => {
+    const { wrapper, mark } = await mountedWithMark();
+    fire(document, 'pointerdown', { button: 0, clientX: 10, clientY: 10 });
+    fire(document, 'pointercancel');
+    fire(mark, 'pointerover');
+    expect(wrapper.vm.activeNote).toBeTruthy();
+  });
+
+  it('does not open the popover when a non-collapsed selection lives inside the rich-text root', async () => {
+    const { wrapper, mark } = await mountedWithMark();
+    // Stub getSelection to return a non-collapsed Selection anchored inside
+    // the rich-text root — covers the post-mouseup path where the drag is
+    // done but the selection is still standing.
+    const fakeSel = {
+      rangeCount: 1,
+      isCollapsed: false,
+      anchorNode: mark.firstChild ?? mark,
+    };
+    const orig = window.getSelection;
+    window.getSelection = () => fakeSel;
+    try {
+      fire(mark, 'pointerover');
+      expect(wrapper.vm.activeNote).toBeNull();
+    } finally {
+      window.getSelection = orig;
+    }
+  });
+
+  it('closes an already-open popover immediately on a new pointerdown', async () => {
+    const { wrapper, mark } = await mountedWithMark();
+    fire(mark, 'pointerover');
+    expect(wrapper.vm.activeNote).toBeTruthy();
+    // Starting a drag while the hover-popover is up must drop the popover
+    // straight away so the in-flight drag-select is not anchored over the
+    // mark the popover is attached to.
+    fire(document, 'pointerdown', { button: 0, clientX: 10, clientY: 10 });
+    expect(wrapper.vm.activeNote).toBeNull();
+  });
+});

--- a/frontend/src/components/AnnotatedText.test.js
+++ b/frontend/src/components/AnnotatedText.test.js
@@ -384,6 +384,19 @@ describe('AnnotatedText popover suppression during drag-selection', () => {
     }
   });
 
+  it('ignores a secondary-button pointerup while a primary drag is in flight', async () => {
+    // Right-button release mid-left-drag must not consume the left-drag's
+    // start coords or clear isDragging — otherwise the remaining drag would
+    // fall back to only the selection-based guard for the rest of the
+    // gesture and a pointerover on a mark could re-open the popover before
+    // the actual left release.
+    const { wrapper, mark } = await mountedWithMark();
+    fire(document, 'pointerdown', { button: 0, clientX: 10, clientY: 10 });
+    fire(mark, 'pointerup', { button: 2, clientX: 12, clientY: 11 }); // secondary
+    fire(mark, 'pointerover');
+    expect(wrapper.vm.activeNote).toBeNull();
+  });
+
   it('closes an already-open popover immediately on a new pointerdown', async () => {
     const { wrapper, mark } = await mountedWithMark();
     fire(mark, 'pointerover');

--- a/frontend/src/components/AnnotatedText.test.js
+++ b/frontend/src/components/AnnotatedText.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
 import { nextTick } from 'vue';
 import AnnotatedText from './AnnotatedText.vue';
@@ -288,6 +288,14 @@ describe('AnnotatedText popover suppression during drag-selection', () => {
   // Attach to document.body so events dispatched on marks bubble up to the
   // document-level pointerdown/pointerup listeners the gate registers. The
   // default mount is detached and pointer events would never reach document.
+  // Each wrapper goes on the `wrappers` list and is unmounted in afterEach
+  // so its document-level listeners are removed before the next test; without
+  // this, stale wrappers across tests would all see each other's pointer
+  // events and a future regression test could observe spurious state changes.
+  const wrappers = [];
+  afterEach(() => {
+    while (wrappers.length) wrappers.pop().unmount();
+  });
   async function mountedWithMark() {
     const wrapper = mount(AnnotatedText, {
       props: {
@@ -299,6 +307,7 @@ describe('AnnotatedText popover suppression during drag-selection', () => {
       attachTo: document.body,
       global: { stubs: nlddStubs },
     });
+    wrappers.push(wrapper);
     await nextTick();
     await nextTick();
     return {

--- a/frontend/src/components/AnnotatedText.vue
+++ b/frontend/src/components/AnnotatedText.vue
@@ -372,6 +372,13 @@ onBeforeUnmount(() => {
 function markFromEvent(event) {
   const el = event.target?.closest?.('mark[data-primary-idx]');
   if (!el) return null;
+  // Document-level handlers (onDocPointerUp) can see events targeted at any
+  // mark on the page, including another AnnotatedText instance's marks in a
+  // multi-article view. Reject anything outside this instance's rich-text
+  // root so the click-to-pin path never resolves noteByIdx against the wrong
+  // notes array. Component-scoped callers (@pointerover/@focusin on the
+  // wrap) are already in-scope so this is a no-op for them.
+  if (!richTextEl.value?.contains(el)) return null;
   const idx = Number(el.dataset.primaryIdx);
   return { el, note: noteByIdx.value[idx] || null, idx };
 }
@@ -724,9 +731,7 @@ onBeforeUnmount(() => {
 .annotated-wrap :deep(mark) {
   padding: 0 0.1em;
   border-radius: 2px;
-  /* `text` not `help`: drag-selection is the primary affordance here; the
-     popover stays discoverable via hover/Tab. The drag-gate in the script
-     also makes selecting across a mark work without losing the selection. */
+  /* text, not help: drag-selection is the primary affordance */
   cursor: text;
 }
 .annotated-wrap :deep(mark.note-authoritative) {

--- a/frontend/src/components/AnnotatedText.vue
+++ b/frontend/src/components/AnnotatedText.vue
@@ -329,6 +329,13 @@ function onDocPointerDown(event) {
 }
 
 function onDocPointerUp(event) {
+  // Match the button filter from onDocPointerDown: a secondary-button
+  // pointerup while the primary-button drag is still in flight must not
+  // consume the drag's start coords or clear isDragging — otherwise the
+  // remaining drag falls through to only the isSelectingInRoot() guard.
+  // pointercancel is exempt: any cancel aborts the whole gesture, primary
+  // or not.
+  if (event.type !== 'pointercancel' && event.button !== 0) return;
   const start = pointerDownAt;
   pointerDownAt = null;
   isDragging = false;

--- a/frontend/src/components/AnnotatedText.vue
+++ b/frontend/src/components/AnnotatedText.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, ref, watch, nextTick, useTemplateRef, onBeforeUnmount } from 'vue';
+import { computed, ref, watch, nextTick, useTemplateRef, onMounted, onBeforeUnmount } from 'vue';
 import { renderArticleHtml } from '../composables/useArticleMarkdown.js';
 import {
   buildAlignment,
@@ -280,6 +280,80 @@ const popoverEl = useTemplateRef('popoverEl');
 const activeNote = ref(null);
 let closeTimer = null;
 
+// Drag-aware popover gating. nldd-popover is the native HTML Popover API:
+// showPopover() puts the element into the top layer and steals focus via
+// _manageFocus(). If that runs while the user is mid-drag selecting text,
+// the pointermove from the drag lands on the popover instead of the
+// underlying text run and the Selection cannot extend past the first mark
+// the pointer touches. The gate below shuts the hover-popover path during
+// any in-flight drag (and any standing non-collapsed selection rooted in
+// our rich-text element), and reopens via a click-to-pin on tap-without-
+// move so touch users still have a way to surface a note.
+const isDragging = ref(false);
+let pointerDownAt = null; // { x, y } at most recent primary-button pointerdown
+const PIN_MAX_MOVE = 4; // px; below this on pointerup is treated as a tap
+
+function isSelectingInRoot() {
+  const root = richTextEl.value;
+  const sel = typeof window !== 'undefined' ? window.getSelection?.() : null;
+  if (!root || !sel || sel.rangeCount === 0 || sel.isCollapsed) return false;
+  return root.contains(sel.anchorNode);
+}
+
+// Hard-close path used by the pointerdown handler: bypasses the scheduleClose
+// debounce because a fresh drag must not be anchored over the just-pressed
+// mark for even one frame.
+function closePopoverNow() {
+  if (closeTimer) {
+    clearTimeout(closeTimer);
+    closeTimer = null;
+  }
+  popoverEl.value?.hidePopover?.();
+  activeNote.value = null;
+  clearHoverBridge();
+}
+
+function onDocPointerDown(event) {
+  if (event.button !== 0) return; // only primary-button drags select text
+  isDragging.value = true;
+  pointerDownAt = { x: event.clientX, y: event.clientY };
+  closePopoverNow();
+}
+
+function onDocPointerUp(event) {
+  const start = pointerDownAt;
+  pointerDownAt = null;
+  isDragging.value = false;
+  if (!start) return;
+  // Click-to-pin: a tap that did not move (mouse click without drag, or a
+  // touch tap) on a mark with no resulting selection opens the popover
+  // for that mark. Preserves the pre-fix mousedown-pins behaviour for the
+  // non-drag case so touch users still have a way in.
+  if (event.type === 'pointercancel') return;
+  const dx = (event.clientX ?? start.x) - start.x;
+  const dy = (event.clientY ?? start.y) - start.y;
+  if (Math.hypot(dx, dy) >= PIN_MAX_MOVE) return;
+  if (isSelectingInRoot()) return;
+  const hit = markFromEvent({ target: event.target });
+  if (hit?.note) openFor(hit.el, hit.note, hit.idx);
+}
+
+onMounted(() => {
+  // Capture-phase pointerdown so the gate flips before nldd-popover's own
+  // focus-management runs on the next frame. pointerup/pointercancel stay
+  // in bubble phase: the click-to-pin path reads `event.target` to find the
+  // mark under release, and we want the natural bubble path (which is what
+  // happy-dom and real browsers route reliably).
+  document.addEventListener('pointerdown', onDocPointerDown, true);
+  document.addEventListener('pointerup', onDocPointerUp);
+  document.addEventListener('pointercancel', onDocPointerUp);
+});
+onBeforeUnmount(() => {
+  document.removeEventListener('pointerdown', onDocPointerDown, true);
+  document.removeEventListener('pointerup', onDocPointerUp);
+  document.removeEventListener('pointercancel', onDocPointerUp);
+});
+
 function markFromEvent(event) {
   const el = event.target?.closest?.('mark[data-primary-idx]');
   if (!el) return null;
@@ -310,6 +384,10 @@ function clearHoverBridge() {
 }
 
 function openFor(el, note, idx) {
+  // Hover gate: skip while a drag is in flight, or while a non-collapsed
+  // selection is standing inside this rich-text root (post-mouseup but
+  // before the user clears it). See the comment block on isDragging above.
+  if (isDragging.value || isSelectingInRoot()) return;
   if (closeTimer) {
     clearTimeout(closeTimer);
     closeTimer = null;
@@ -631,7 +709,10 @@ onBeforeUnmount(() => {
 .annotated-wrap :deep(mark) {
   padding: 0 0.1em;
   border-radius: 2px;
-  cursor: help;
+  /* `text` not `help`: drag-selection is the primary affordance here; the
+     popover stays discoverable via hover/Tab. The drag-gate in the script
+     also makes selecting across a mark work without losing the selection. */
+  cursor: text;
 }
 .annotated-wrap :deep(mark.note-authoritative) {
   border-bottom: 2px solid currentColor;

--- a/frontend/src/components/AnnotatedText.vue
+++ b/frontend/src/components/AnnotatedText.vue
@@ -289,7 +289,9 @@ let closeTimer = null;
 // any in-flight drag (and any standing non-collapsed selection rooted in
 // our rich-text element), and reopens via a click-to-pin on tap-without-
 // move so touch users still have a way to surface a note.
-const isDragging = ref(false);
+// Plain `let` (not a ref): isDragging is read imperatively by openFor and
+// the document-level handlers, never bound to a template/watcher/computed.
+let isDragging = false;
 let pointerDownAt = null; // { x, y } at most recent primary-button pointerdown
 const PIN_MAX_MOVE = 4; // px; below this on pointerup is treated as a tap
 
@@ -315,7 +317,13 @@ function closePopoverNow() {
 
 function onDocPointerDown(event) {
   if (event.button !== 0) return; // only primary-button drags select text
-  isDragging.value = true;
+  // A press inside the popover panel itself is interacting with the
+  // popover, not starting a new selection — closing it on its own mousedown
+  // would swallow any click inside (currently moot, the popover holds only
+  // a `@click.prevent` link, but cheap insurance for any future control).
+  const pop = popoverEl.value;
+  if (pop?.contains?.(event.target)) return;
+  isDragging = true;
   pointerDownAt = { x: event.clientX, y: event.clientY };
   closePopoverNow();
 }
@@ -323,7 +331,7 @@ function onDocPointerDown(event) {
 function onDocPointerUp(event) {
   const start = pointerDownAt;
   pointerDownAt = null;
-  isDragging.value = false;
+  isDragging = false;
   if (!start) return;
   // Click-to-pin: a tap that did not move (mouse click without drag, or a
   // touch tap) on a mark with no resulting selection opens the popover
@@ -387,7 +395,7 @@ function openFor(el, note, idx) {
   // Hover gate: skip while a drag is in flight, or while a non-collapsed
   // selection is standing inside this rich-text root (post-mouseup but
   // before the user clears it). See the comment block on isDragging above.
-  if (isDragging.value || isSelectingInRoot()) return;
+  if (isDragging || isSelectingInRoot()) return;
   if (closeTimer) {
     clearTimeout(closeTimer);
     closeTimer = null;


### PR DESCRIPTION
## Probleem

Bij een drag-select brak de selectie zodra de muis een \`<mark>\`-element raakte. De Selection kon niet verder uitbreiden voorbij de eerste notitie die de pointer kruiste.

## Oorzaak

\`pointerover\` op een mark → \`openFor\` → \`pop.showPopover()\`. \`<nldd-popover>\` is de native HTML Popover API: \`showPopover()\` legt het paneel in de **top layer** en steelt focus via \`_manageFocus()\` → \`this.focus()\`. De lopende \`pointermove\` van de drag belandt daardoor op het popover-paneel (geen \`pointer-events: none\`) i.p.v. de tekst eronder; de Selection kan niet verder uitbreiden en de focus-shift breekt de afdruk visueel.

Hetzelfde pad via \`tabindex="0"\` + \`focusin\`.

De DOM→raw offset-mapping in \`useTextSelection.js\` is prima — \`endpointToRaw\` loopt netjes door text nodes binnen \`<mark>\` heen. **De popover-side-effect tijdens een drag was de enige oorzaak.**

## Fix

Drie-staps gate die het popover-open-pad sluit tijdens drag/selectie:

* **document-level \`pointerdown\` (capture-fase)** zet \`isDragging = true\`, registreert de start-coords, en sluit een open popover direct. Capture-fase zodat we de event zien vóór \`nldd-popover\`'s eigen focus-management draait.
* **document-level \`pointerup\`/\`pointercancel\`** zet \`isDragging = false\`. Bij een korte tap (<4px verplaatsing) op een mark zonder lopende selectie wordt de popover opnieuw geopend — **click-to-pin path**, vooral belangrijk voor touch-users die niet kunnen hoveren.
* **\`openFor\` valt vroeg uit** bij \`isDragging\` of bij een non-collapsed Selection met anchor in de rich-text root. Dekt ook de cross-wrap drag (start buiten, drag in) en het post-mouseup-met-actieve-selectie geval.

Synchrone \`pointerdown → focusin\` ordering (UI Events spec, Chromium/WebKit/Firefox) maakt dat de bestaande \`onFocusIn\` automatisch dezelfde gate krijgt zonder extra check; keyboard-Tab heeft geen voorafgaande \`pointerdown\` en blijft de popover openen.

CSS: \`cursor: help\` → \`cursor: text\` op marks; drag-selectie is nu de primaire affordance, popover blijft via hover/Tab te ontdekken.

## Tests

10 nieuwe component-tests in \`AnnotatedText.test.js\` die alle paden pinnen:

| # | scenario | gedrag |
|---|----------|--------|
| 1 | hover zonder drag | popover opent |
| 2 | pointerover tijdens drag | popover blijft dicht |
| 3 | focusin tijdens drag | popover blijft dicht |
| 4 | focusin via keyboard | popover opent |
| 5 | drag met >4px verplaatsing | geen click-to-pin op release |
| 6 | tap <4px op mark | click-to-pin opent popover |
| 7 | pointercancel reset | volgende hover opent weer |
| 8 | selection in root | popover blijft dicht |
| 9 | pointerdown sluit open popover meteen | activeNote → null |

Test-setup gebruikt \`attachTo: document.body\` zodat events van marks naar de document-listeners bubbelen; \`wrapper.vm.activeNote\` als observable signaal i.p.v. een stub-spy op \`showPopover\` (robuuster tegen quirks van Vue Test Utils stub-exposure).

Volledige frontend suite: **216/216 groen**.

## Test plan

- [ ] Drag-select over \`verzekerde aanspraak op een zorgtoeslag\` op \`/editor/zorgtoeslagwet/2\` (Chromium) → selectie volledig, geen interrupt op de mark.
- [ ] Hover op een mark zonder drag → popover opent zoals voorheen.
- [ ] Tap op een mark (mobile viewport, touch emulation) → popover opent via click-to-pin.
- [ ] Tab naar een mark → popover opent (keyboard-discoverability).
- [ ] Esc → popover sluit.