### PR TITLE
feat(editor): cover-depth signal voor overlap met gelijke motivatie

### DIFF
--- a/frontend/src/components/AnnotatedText.test.js
+++ b/frontend/src/components/AnnotatedText.test.js
@@ -162,6 +162,26 @@ describe('AnnotatedText markdown highlighting', () => {
     expect(marks[2].dataset.coverDepth).toBe('1');
   });
 
+  it('caps cover-depth at 3 even when four+ notes share a span', async () => {
+    // Four notes on identical spans — none strictly contains another, all
+    // four are visible. coveringIdx.length is 4 but data-cover-depth must
+    // clamp to '3' so the CSS rule set stays bounded.
+    const wrapper = mountWith(ART, [
+      { note: noteVerzekerde, spans: [{ start: 7, end: 17 }] },
+      { note: noteZorgtoeslag, spans: [{ start: 7, end: 17 }] },
+      { note: { motivation: 'questioning', creator: 'C' }, spans: [{ start: 7, end: 17 }] },
+      { note: { motivation: 'tagging', creator: 'D' }, spans: [{ start: 7, end: 17 }] },
+    ]);
+    await nextTick();
+    await nextTick();
+    const marks = [
+      ...wrapper.element.querySelectorAll('mark[data-primary-idx]'),
+    ];
+    expect(marks).toHaveLength(1);
+    expect(marks[0].dataset.noteIdx).toBe('0,1,2,3');
+    expect(marks[0].dataset.coverDepth).toBe('3');
+  });
+
   it('hovering the outer in encapsulation bridges .note-hovered across the inner segment', async () => {
     // Same setup as the encapsulation test. Firing pointerover on the
     // outer's left flank must add .note-hovered to all three marks — the

--- a/frontend/src/components/AnnotatedText.test.js
+++ b/frontend/src/components/AnnotatedText.test.js
@@ -110,18 +110,23 @@ describe('AnnotatedText markdown highlighting', () => {
     expect(marks[0].textContent).toBe('verze');
     expect(marks[0].dataset.noteIdx).toBe('0');
     expect(marks[0].dataset.primaryIdx).toBe('0');
+    expect(marks[0].dataset.coverDepth).toBe('1');
     expect(marks[0].className).toContain('note-commenting');
     // [12,17) — both, primary is A (earlier start), bg is the layered
     // marker class (no class-background; inline backgroundImage stacks).
+    // coverDepth=2 drives the top-edge underline that makes same-motivation
+    // overlap legible without depending on a colour shift.
     expect(marks[1].textContent).toBe('kerde');
     expect(marks[1].dataset.noteIdx).toBe('0,1');
     expect(marks[1].dataset.primaryIdx).toBe('0');
+    expect(marks[1].dataset.coverDepth).toBe('2');
     expect(marks[1].className).toContain('note-multi');
     expect(marks[1].style.backgroundImage).toContain('linear-gradient');
     // [17,25) — only B.
     expect(marks[2].textContent).toBe(' heeft a');
     expect(marks[2].dataset.noteIdx).toBe('1');
     expect(marks[2].dataset.primaryIdx).toBe('1');
+    expect(marks[2].dataset.coverDepth).toBe('1');
   });
 
   it('encapsulation: outer is suppressed inside the inner segment (inner shown cleanly)', async () => {
@@ -143,13 +148,18 @@ describe('AnnotatedText markdown highlighting', () => {
     expect(marks[0].textContent).toBe('een ');
     expect(marks[0].dataset.noteIdx).toBe('0');
     expect(marks[0].dataset.coverIdx).toBe('0');
-    // Inner: B shown, A suppressed but reachable via coverIdx.
+    expect(marks[0].dataset.coverDepth).toBe('1');
+    // Inner: B shown, A suppressed but reachable via coverIdx. coverDepth=2
+    // surfaces the nested boundary visually even if outer and inner share a
+    // motivation (suppressed outer would otherwise erase the colour shift).
     expect(marks[1].textContent).toBe('verzekerde');
     expect(marks[1].dataset.noteIdx).toBe('1');
     expect(marks[1].dataset.coverIdx).toBe('0,1');
     expect(marks[1].dataset.primaryIdx).toBe('1');
+    expect(marks[1].dataset.coverDepth).toBe('2');
     // Outer's right flank: A only.
     expect(marks[2].dataset.noteIdx).toBe('0');
+    expect(marks[2].dataset.coverDepth).toBe('1');
   });
 
   it('hovering the outer in encapsulation bridges .note-hovered across the inner segment', async () => {

--- a/frontend/src/components/AnnotatedText.vue
+++ b/frontend/src/components/AnnotatedText.vue
@@ -142,6 +142,17 @@ function wrapSegmentSlice(slice, seg, notes) {
   mark.dataset.noteIdx = seg.visibleIdx.join(',');
   mark.dataset.coverIdx = seg.coveringIdx.join(',');
   mark.dataset.primaryIdx = String(seg.primaryIdx);
+  // Cover-depth signal: how many notes (visible + suppressed) cover this
+  // segment. Painted as a stacked underline in CSS so that overlap is
+  // legible even when motivation colours match. Encapsulation's inner
+  // segment also picks up the outer here, so a same-motivation nesting
+  // reads as "two notes" without depending on a colour shift. Capped at 3
+  // so the styling stays in two CSS rules; deeper stacks fall into the
+  // "3+" bucket and are visually clamped (acceptable — overlapping more
+  // than three notes on one span is vanishingly rare in real corpus).
+  mark.dataset.coverDepth = String(
+    Math.min(seg.coveringIdx.length, 3),
+  );
   if (multi) {
     const layers = seg.visibleIdx
       .map((i) => motivationColor(notes[i]?.note))
@@ -767,6 +778,26 @@ onBeforeUnmount(() => {
    from the primary's authority class stays. */
 .annotated-wrap :deep(mark.note-multi) {
   background: none;
+}
+/* Cover-depth signal: a thin currentColor line along the TOP edge of any
+   mark whose segment is covered by 2+ notes (visible or suppressed by
+   encapsulation). Paired with the existing border-bottom (authority style)
+   so a same-motivation overlap reads as "bracketed" — two parallel lines
+   instead of one — without depending on a colour shift. The encapsulated
+   inner segment also picks this up because the suppressed outer counts in
+   coveringIdx, so a same-motivation nesting is visible without colour
+   difference. data-cover-depth is capped at 3 in the script; we use a 3px
+   line for the three-deep case so the stacks-getting-busier signal is
+   monotonic without needing an explicit depth-counting glyph. */
+.annotated-wrap :deep(mark[data-cover-depth="2"]) {
+  box-shadow: inset 0 2px 0 currentColor;
+  border-left: 1px solid currentColor;
+  border-right: 1px solid currentColor;
+}
+.annotated-wrap :deep(mark[data-cover-depth="3"]) {
+  box-shadow: inset 0 3px 0 currentColor;
+  border-left: 2px solid currentColor;
+  border-right: 2px solid currentColor;
 }
 /* Hover-bridge: every mark whose coverage includes the hovered note's idx
    gets this class, so the note's full span reads as one continuous range

--- a/frontend/src/components/AnnotatedText.vue
+++ b/frontend/src/components/AnnotatedText.vue
@@ -142,17 +142,8 @@ function wrapSegmentSlice(slice, seg, notes) {
   mark.dataset.noteIdx = seg.visibleIdx.join(',');
   mark.dataset.coverIdx = seg.coveringIdx.join(',');
   mark.dataset.primaryIdx = String(seg.primaryIdx);
-  // Cover-depth signal: how many notes (visible + suppressed) cover this
-  // segment. Painted as a stacked underline in CSS so that overlap is
-  // legible even when motivation colours match. Encapsulation's inner
-  // segment also picks up the outer here, so a same-motivation nesting
-  // reads as "two notes" without depending on a colour shift. Capped at 3
-  // so the styling stays in two CSS rules; deeper stacks fall into the
-  // "3+" bucket and are visually clamped (acceptable — overlapping more
-  // than three notes on one span is vanishingly rare in real corpus).
-  mark.dataset.coverDepth = String(
-    Math.min(seg.coveringIdx.length, 3),
-  );
+  // Includes notes suppressed by encapsulation; capped at 3.
+  mark.dataset.coverDepth = String(Math.min(seg.coveringIdx.length, 3));
   if (multi) {
     const layers = seg.visibleIdx
       .map((i) => motivationColor(notes[i]?.note))
@@ -779,16 +770,8 @@ onBeforeUnmount(() => {
 .annotated-wrap :deep(mark.note-multi) {
   background: none;
 }
-/* Cover-depth signal: a thin currentColor line along the TOP edge of any
-   mark whose segment is covered by 2+ notes (visible or suppressed by
-   encapsulation). Paired with the existing border-bottom (authority style)
-   so a same-motivation overlap reads as "bracketed" — two parallel lines
-   instead of one — without depending on a colour shift. The encapsulated
-   inner segment also picks this up because the suppressed outer counts in
-   coveringIdx, so a same-motivation nesting is visible without colour
-   difference. data-cover-depth is capped at 3 in the script; we use a 3px
-   line for the three-deep case so the stacks-getting-busier signal is
-   monotonic without needing an explicit depth-counting glyph. */
+/* Top-edge line + side brackets when 2+ notes cover a span (suppressed
+   outers in coveringIdx count). Hover stacking lives below. */
 .annotated-wrap :deep(mark[data-cover-depth="2"]) {
   box-shadow: inset 0 2px 0 currentColor;
   border-left: 1px solid currentColor;
@@ -807,11 +790,7 @@ onBeforeUnmount(() => {
 .annotated-wrap :deep(mark.note-hovered) {
   box-shadow: inset 0 -3px 0 currentColor;
 }
-/* Hover on a multi-cover mark stacks both signals: keep the cover-depth
-   top-edge line AND add the hover bottom-edge stripe. Without this rule
-   the equal-specificity `.note-hovered` would override the depth-2/3
-   single-shadow above and the top-edge bracket would vanish — exactly
-   while the user is asking "what's here?". */
+/* Stack both shadows so the cover-depth top bar survives hover. */
 .annotated-wrap :deep(mark[data-cover-depth="2"].note-hovered) {
   box-shadow:
     inset 0 2px 0 currentColor,

--- a/frontend/src/components/AnnotatedText.vue
+++ b/frontend/src/components/AnnotatedText.vue
@@ -807,6 +807,21 @@ onBeforeUnmount(() => {
 .annotated-wrap :deep(mark.note-hovered) {
   box-shadow: inset 0 -3px 0 currentColor;
 }
+/* Hover on a multi-cover mark stacks both signals: keep the cover-depth
+   top-edge line AND add the hover bottom-edge stripe. Without this rule
+   the equal-specificity `.note-hovered` would override the depth-2/3
+   single-shadow above and the top-edge bracket would vanish — exactly
+   while the user is asking "what's here?". */
+.annotated-wrap :deep(mark[data-cover-depth="2"].note-hovered) {
+  box-shadow:
+    inset 0 2px 0 currentColor,
+    inset 0 -3px 0 currentColor;
+}
+.annotated-wrap :deep(mark[data-cover-depth="3"].note-hovered) {
+  box-shadow:
+    inset 0 3px 0 currentColor,
+    inset 0 -3px 0 currentColor;
+}
 .annotated-wrap :deep(mark:focus-visible) {
   outline: 2px solid currentColor;
   outline-offset: 1px;


### PR DESCRIPTION
## Probleem

Twee notities met dezelfde motivatie (bv. twee `commenting` op overlappende ranges) leveren visueel niks bruikbaars op: 28% + 28% van dezelfde kleur leest als "iets donkerder" zonder dat duidelijk is dat er meerdere notities staan. Bij encapsulation is het nog onzichtbaarder, want de outer wordt onderdrukt in het inner segment — het hele bereik krijgt exact dezelfde kleur en de nested boundary verdwijnt.

## Aanpak

Elke `<mark>` krijgt `data-cover-depth = Math.min(coveringIdx.length, 3)`. CSS plakt op marks met depth ≥ 2 **drie aanvullende randen** — een top-edge `currentColor`-lijn via inset `box-shadow` plus `border-left` en `border-right` — naast de bestaande `border-bottom` (authority-stijl). Multi-cover segmenten zijn daardoor visueel een geboxte "frame" om de gewone single-cover stroom, ongeacht de kleur.

| scenario | resultaat |
|---|---|
| Eén noot per segment | Alleen bestaande border-bottom (ongewijzigd) |
| Partial overlap | Middelste segment volledig geboxt (top + bottom + zijbrackets), single-note flanken normaal |
| Encapsulation | Inner segment volledig geboxt; outer flanken normaal — nested boundary direct zichtbaar zelfs als outer en inner dezelfde motivatie hebben |
| 3+ overlappend | 3px top + 2px zijbrackets ipv 2px/1px voor monotoon groeiend signaal; capped op 3 omdat diepere stapels vrijwel niet voorkomen |

## Hover-interactie

`.note-hovered` heeft equal-specificity met `[data-cover-depth]`, dus zou de top-line normaal overschrijven. Twee per-depth stacked-shadow regels (`mark[data-cover-depth="N"].note-hovered`) zorgen dat **beide signalen tegelijk renderen** op hover: top-edge bracket bar blijft staan én er komt een hover bottom-edge stripe bij. De depth-indicator overleeft hover — precies wanneer de gebruiker vraagt "wat staat hier?".

## Tests

Bestaande partial-overlap en encapsulation tests asserten nu `data-cover-depth` op alle drie boundary segmenten; aanvullende test pin de cap op `'3'` voor 4 overlappende identieke noten. 22/22 groen.

## Test plan

- [ ] Twee `commenting` (geel) notities die elkaar overlappen — middelste segment is een duidelijk geboxte sub-regio
- [ ] Encapsulation met outer + inner van dezelfde motivatie — inner segment is een box-binnen-box
- [ ] Drie+ overlappende notities → dikkere randen
- [ ] Hover op een multi-cover mark: top-line + bottom-stripe stacken samen, brackets blijven