### PR TITLE
docs: rfc-011 rules language selection en codeblok-rendering

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -4,6 +4,7 @@ import pagefind from 'astro-pagefind';
 import rehypeMermaid from 'rehype-mermaid';
 import { rehypeMermaidAlt } from './src/lib/rehype-mermaid-alt.ts';
 import { rehypeNlddCodeViewer } from './src/lib/rehype-nldd-code-viewer.ts';
+import { rehypeRfcMeta } from './src/lib/rehype-rfc-meta.ts';
 
 export default defineConfig({
   site: 'https://docs.regelrecht.rijks.app',
@@ -30,7 +31,7 @@ export default defineConfig({
     pagefind({ indexConfig: { forceLanguage: 'en' } }),
   ],
   markdown: {
-    // No Shiki: rehype-nldd-code-viewer turns every fenced block into <nldd-code-viewer>,
+    // No Shiki: rehype-nldd-code-viewer turns every fenced block into <nldd-code>,
     // which owns styling + (Prism) highlighting. Disabling Shiki also leaves
     // ```mermaid blocks as real <pre><code class="language-mermaid"> for
     // rehype-mermaid (it skips them via the language check).
@@ -58,6 +59,7 @@ export default defineConfig({
       ],
       rehypeMermaidAlt,
       rehypeNlddCodeViewer,
+      rehypeRfcMeta,
     ],
   },
   vite: {

--- a/docs/src/content/rfcs/rfc-011.md
+++ b/docs/src/content/rfcs/rfc-011.md
@@ -1,0 +1,129 @@
+---
+title: "RFC-011: Rules Language Selection"
+---
+
+**Status:** Proposed
+**Date:** 2026-05-29
+**Authors:** Tim, Anne
+**Short title:** Rules Language
+
+## Context
+
+RegelRecht needs a rules language to represent Dutch legislation in machine-readable form. Several rules languages already exist (DMN with FEEL, Datalog, NRML, and others), each with different characteristics and levels of adoption. The choice shapes what the system can express, how maintainable it stays, and how well it fits its specific mission.
+
+During the proof-of-concept we built and tested a custom YAML-based language. That language now backs the corpus (`corpus/regulation/nl/`), which holds machine-readable implementations of over 30 Dutch laws, including the *Wet op de zorgtoeslag*, the *Algemene Ouderdomswet*, and the *Participatiewet*. The POC validated that the approach can model real legislation.
+
+This RFC records why we continue with the custom YAML language rather than adopting an existing one, and how conversion from other formats fits into that choice.
+
+> **Note on provenance:** This RFC originates as RFC-001 in `MinBZK/poc-machine-law`. It is renumbered to RFC-011 here to avoid colliding with [RFC-001](./rfc-001) (*YAML Schema Design Decisions*), and retranslated into this repo's house style. The substance of the decision is unchanged.
+
+## Decision
+
+**Continue with and formalize the custom YAML-based rules language ("RegelRecht YAML"), with conversion from existing rules languages as an optional, stakeholder-driven future capability.**
+
+The language:
+
+- uses YAML for structure and human readability
+- defines domain-specific constructs tailored to Dutch legislation
+- has been validated through POC implementations of actual laws
+- provides precise semantics matching our computational requirements
+
+## Why
+
+The decision turns on getting the best possible fit between language capabilities and mission requirements. After evaluating the alternatives, the central trade-off is this:
+
+**Existing rules languages** offer varying degrees of market adoption, ecosystem, tooling, and cross-organization compatibility. Market-driven standards bring interoperability; NRML brings Dutch government domain alignment.
+
+**Custom YAML** offers freedom and ownership: full control over semantics, versioning, and evolution, with no external dependencies. We can keep the feature set to exactly what we need, without external models arriving with expectations of feature support we don't provide, and without pressure to absorb breaking changes from upstream.
+
+Because we are doing something new and complex, a language that is a 100% fit for our requirements pays off. Custom YAML addresses four specific needs:
+
+1. **Novel combination of concerns.** Temporal versioning, complex calculations, multi-law interaction, service references between laws, and explanation generation, in one integrated system.
+2. **Evolving understanding.** As a research-oriented project, requirements keep clarifying through implementation. A custom language can adapt without external constraints.
+3. **Precise semantics.** Government decisions demand unambiguous interpretation. A custom language gives exact semantics without vendor-specific ambiguity.
+4. **Proven viability.** A POC with 30+ laws demonstrates that the YAML approach successfully models real legislation.
+
+### Benefits
+
+- Complete ownership of semantics, versioning, and language evolution
+- No external governance forcing breaking changes or unwanted features
+- An intentionally minimal feature set: only what the mission requires
+- A single canonical representation with precise, unambiguous semantics
+- Validated against 30+ real Dutch laws
+
+### Tradeoffs
+
+- We build and maintain the language infrastructure ourselves
+- We write the documentation and examples
+- Users must learn a new syntax, or we build tooling to ease that
+- Risk of bugs or design oversights unique to a homegrown language
+
+Mitigations:
+
+- Start with a minimal feature set; expand only on proven need
+- Borrow design patterns from existing languages
+- Keep a comprehensive test suite
+- Document design decisions via RFCs
+- Support conversion from other formats to reuse existing work, when stakeholders need it
+
+### Conversion strategy
+
+Conversion from established formats into RegelRecht YAML is technically feasible for features that fall within our YAML's scope. The evaluated formats (DMN, NRML, Datalog) share the core decision-modeling concepts (inputs, rules, outputs, conditions, temporal aspects) that map onto our constructs. Features outside our intentionally limited scope are simply not converted.
+
+```
+┌─────────┐      ┌──────────┐      ┌──────────────┐
+│   DMN   │─────>│          │      │              │
+├─────────┤      │          │      │  RegelRecht  │
+│  NRML   │─────>│Converters│─────>│     YAML     │
+├─────────┤      │(feasible,│      │  (canonical) │
+│ Datalog │─────>│ optional)│      │              │
+└─────────┘      └──────────┘      └──────────────┘
+```
+
+When stakeholders need it, conversion would let practitioners familiar with other formats contribute, would allow evaluation of existing law models, and would provide a migration path from legacy systems, all while keeping clear internal semantics through the canonical YAML.
+
+**Implementation decision:** converters are built when stakeholders demonstrate need, not preemptively.
+
+### Alternatives Considered
+
+The alternatives split into two categories, assessed with different criteria. **Market-driven standards** (DMN, Datalog, Prolog, OWL/RDF, Catala) are judged on worldwide adoption, ecosystem maturity, cross-organization compatibility, and vendor support. The **Dutch government-specific initiative** (NRML) is judged on fit with Dutch legislation and its relationship to this project. Adoption levels (Low/Medium/High) below indicate worldwide usage and ecosystem maturity.
+
+**DMN with FEEL** (Adoption: High). The most widely adopted decision-modeling standard, with strong vendor support and a decision-table paradigm that suits eligibility rules. In practice ~80-90% of DMN usage is decision tables; FEEL expressions are used far less because of perceived complexity, and FEEL tool support is uneven outside Camunda/Trisotech. Decision tables handle simple eligibility checks well, but complex calculations (benefit amounts, tax formulas) need extensive FEEL. Temporal versioning is not native, service references between laws would need custom extensions, and external governance of the standard may conflict with our requirements.
+
+**NRML** (Nederlandse Regelgeving Markup Language). Developed within the same MinBZK effort as this project, not a market-driven standard, and currently with no external adoption beyond its development team. Purpose-built for Dutch regulation with domain-specific constructs, and a natural candidate for knowledge sharing since both efforts come from MinBZK's law-as-code work. Strong domain alignment, but a broader feature set than we need risks extra complexity, and its service-reference patterns would need validation against our use case.
+
+**Datalog** (Adoption: Low, growing). Declarative rules that read close to legal text, strong for legal reasoning and "why not eligible?" explanations, with temporal extensions, guaranteed termination (safer than Prolog), and predictable bottom-up evaluation. Open-source engines include Soufflé (C++), Flix (JVM), PyDatalog (Python), and Logica (compiles to SQL). A natural fit for legal rule representation, but less accessible to non-technical stakeholders without tooling, and it would need an extra layer for law metadata and service references.
+
+```datalog
+% Temporal versioning built in
+income_limit("single", 35000, "2024-01-01", "2024-12-31").
+income_limit("single", 37000, "2025-01-01", "2025-12-31").
+
+% Reason tracking for explanations
+ineligible_reason(Person, "te jong") :-
+    person(Person), age(Person, Age), Age < 18.
+```
+
+**Prolog** (Adoption: Medium). Powerful logical inference and backtracking, established in legal expert systems, with natural querying that finds all solutions automatically. But it has maintenance challenges at scale, less predictable performance than Datalog, and accessibility challenges for non-technical reviewers.
+
+**OWL/RDF with SHACL** (Adoption: High in semantic web). Excellent for knowledge representation, ontologies, semantic reasoning, and linked-data interoperability, with SHACL for constraint validation and SPARQL for queries. Strong for representing law structures and relationships, but calculations and procedural logic are awkward to express, and it is complex for non-technical users. Better as a complement than as the primary language; service references could map to linked-data patterns.
+
+**Catala** (Adoption: Low). A programming language designed specifically for law, with strong formal foundations, proof capabilities, and direct code generation from legal text. New (2020), with French pilot projects but limited production use. Theoretically appealing, but early-stage maturity, limited tooling, and significant adoption cost outweigh its formal-verification benefits for our immediate needs.
+
+**Regelspraak / RuleSpeak** (Adoption: Low). A controlled-natural-language approach: rules in structured Dutch/English sentences that legal experts can read and validate, lowering the barrier to review. Strong for documentation and stakeholder communication, but it needs a translation layer to executable code and has less precise semantics than a formal language. Complementary, and could inform human-readable documentation alongside the YAML, rather than serve as the execution language.
+
+**Other logic-programming options.** Answer Set Programming (Low) handles the non-monotonic reasoning common in legal rules but is mostly research-focused. Production rules engines such as Drools and JENA (High) are established in enterprise but more procedural than declarative. LegalRuleML (Low) is an OASIS standard for legal rules, more expressive than DMN but with limited production use.
+
+## References
+
+- [RFC-001: YAML Schema Design Decisions](./rfc-001)
+- [RFC-003: Inversion of Control](./rfc-003)
+- [DMN Specification](https://www.omg.org/spec/DMN/): Decision Model and Notation standard
+- [NRML](https://github.com/MinBZK/NRML): Nederlandse Regelgeving Markup Language
+- [Datalog](https://en.wikipedia.org/wiki/Datalog): declarative logic programming
+- [Catala](https://catala-lang.org/): programming language for law
+- [Soufflé](https://souffle-lang.github.io/): high-performance Datalog engine
+- [PyDatalog](https://github.com/pcarbonn/pyDatalog): Python Datalog implementation
+- [RuleSpeak](http://www.rulespeak.com/): controlled natural language for business rules
+- [SBVR](https://www.omg.org/spec/SBVR/): Semantics of Business Vocabulary and Rules
+- [Glossary of Dutch Legal Terms](/reference/glossary)

--- a/docs/src/content/rfcs/rfc-011.md
+++ b/docs/src/content/rfcs/rfc-011.md
@@ -2,18 +2,20 @@
 title: "RFC-011: Rules Language Selection"
 ---
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-05-29
-**Authors:** Tim, Anne
+**Authors:** regelrecht team
 **Short title:** Rules Language
 
 ## Context
 
-RegelRecht needs a rules language to represent Dutch legislation in machine-readable form. Several rules languages already exist (DMN with FEEL, Datalog, NRML, and others), each with different characteristics and levels of adoption. The choice shapes what the system can express, how maintainable it stays, and how well it fits its specific mission.
+RegelRecht needs a rules language to represent Dutch legislation in machine-readable form. Several already exist (DMN with FEEL, Datalog, NRML, and others), varying in expressive power and in how widely they are adopted. The choice sets the ceiling on what the system can express and how maintainable it stays over time.
 
 During the proof-of-concept we built and tested a custom YAML-based language. That language now backs the corpus (`corpus/regulation/nl/`), which holds machine-readable implementations of over 30 Dutch laws, including the *Wet op de zorgtoeslag*, the *Algemene Ouderdomswet*, and the *Participatiewet*. The POC validated that the approach can model real legislation.
 
-This RFC records why we continue with the custom YAML language rather than adopting an existing one, and how conversion from other formats fits into that choice.
+This RFC ratifies that choice. The custom YAML language is already in production: [RFC-001](./rfc-001) through [RFC-010](./rfc-010) build on it, and the corpus runs on it today. This RFC does not reopen the decision; it records why we made it and how conversion from other formats fits in, so the rationale lives somewhere durable rather than implied across a dozen downstream RFCs.
+
+This is a different question from [RFC-006](./rfc-006) (*Language Choice for Law Execution Engine*), which chose the engine's *implementation* language (Rust). The question here is the *rules* language in which legislation itself is expressed (RegelRecht YAML), an orthogonal concern.
 
 > **Note on provenance:** This RFC originates as RFC-001 in `MinBZK/poc-machine-law`. It is renumbered to RFC-011 here to avoid colliding with [RFC-001](./rfc-001) (*YAML Schema Design Decisions*), and retranslated into this repo's house style. The substance of the decision is unchanged.
 
@@ -30,25 +32,25 @@ The language:
 
 ## Why
 
-The decision turns on getting the best possible fit between language capabilities and mission requirements. After evaluating the alternatives, the central trade-off is this:
+The decision comes down to fit between what a language can express and what this project needs. After evaluating the alternatives, the central trade-off is this:
 
 **Existing rules languages** offer varying degrees of market adoption, ecosystem, tooling, and cross-organization compatibility. Market-driven standards bring interoperability; NRML brings Dutch government domain alignment.
 
 **Custom YAML** offers freedom and ownership: full control over semantics, versioning, and evolution, with no external dependencies. We can keep the feature set to exactly what we need, without external models arriving with expectations of feature support we don't provide, and without pressure to absorb breaking changes from upstream.
 
-Because we are doing something new and complex, a language that is a 100% fit for our requirements pays off. Custom YAML addresses four specific needs:
+For work this novel, a language that fits our requirements exactly pays off. Custom YAML addresses four specific needs:
 
-1. **Novel combination of concerns.** Temporal versioning, complex calculations, multi-law interaction, service references between laws, and explanation generation, in one integrated system.
+1. **Novel combination of concerns.** One system that has to handle temporal versioning, complex calculations, multi-law interaction, service references between laws, and explanation generation at once.
 2. **Evolving understanding.** As a research-oriented project, requirements keep clarifying through implementation. A custom language can adapt without external constraints.
-3. **Precise semantics.** Government decisions demand unambiguous interpretation. A custom language gives exact semantics without vendor-specific ambiguity.
+3. **Precise semantics.** Government decisions demand unambiguous interpretation, which a custom language can guarantee without inheriting vendor-specific ambiguity.
 4. **Proven viability.** A POC with 30+ laws demonstrates that the YAML approach successfully models real legislation.
 
 ### Benefits
 
-- Complete ownership of semantics, versioning, and language evolution
+- We own the language outright: how it is versioned and how it evolves are ours to decide
 - No external governance forcing breaking changes or unwanted features
 - An intentionally minimal feature set: only what the mission requires
-- A single canonical representation with precise, unambiguous semantics
+- One canonical representation, with semantics precise enough for government decisions
 - Validated against 30+ real Dutch laws
 
 ### Tradeoffs
@@ -70,14 +72,12 @@ Mitigations:
 
 Conversion from established formats into RegelRecht YAML is technically feasible for features that fall within our YAML's scope. The evaluated formats (DMN, NRML, Datalog) share the core decision-modeling concepts (inputs, rules, outputs, conditions, temporal aspects) that map onto our constructs. Features outside our intentionally limited scope are simply not converted.
 
-```
-┌─────────┐      ┌──────────┐      ┌──────────────┐
-│   DMN   │─────>│          │      │              │
-├─────────┤      │          │      │  RegelRecht  │
-│  NRML   │─────>│Converters│─────>│     YAML     │
-├─────────┤      │(feasible,│      │  (canonical) │
-│ Datalog │─────>│ optional)│      │              │
-└─────────┘      └──────────┘      └──────────────┘
+```mermaid
+flowchart LR
+    DMN --> C["Converters<br/>(feasible, optional)"]
+    NRML --> C
+    Datalog --> C
+    C --> Y["RegelRecht YAML<br/>(canonical)"]
 ```
 
 When stakeholders need it, conversion would let practitioners familiar with other formats contribute, would allow evaluation of existing law models, and would provide a migration path from legacy systems, all while keeping clear internal semantics through the canonical YAML.
@@ -94,7 +94,7 @@ The alternatives split into two categories, assessed with different criteria. **
 
 **Datalog** (Adoption: Low, growing). Declarative rules that read close to legal text, strong for legal reasoning and "why not eligible?" explanations, with temporal extensions, guaranteed termination (safer than Prolog), and predictable bottom-up evaluation. Open-source engines include Soufflé (C++), Flix (JVM), PyDatalog (Python), and Logica (compiles to SQL). A natural fit for legal rule representation, but less accessible to non-technical stakeholders without tooling, and it would need an extra layer for law metadata and service references.
 
-```datalog
+```
 % Temporal versioning built in
 income_limit("single", 35000, "2024-01-01", "2024-12-31").
 income_limit("single", 37000, "2025-01-01", "2025-12-31").
@@ -117,7 +117,8 @@ ineligible_reason(Person, "te jong") :-
 ## References
 
 - [RFC-001: YAML Schema Design Decisions](./rfc-001)
-- [RFC-003: Inversion of Control](./rfc-003)
+- [RFC-003: Inversion of Control for Delegated Legislation](./rfc-003)
+- [RFC-006: Language Choice for Law Execution Engine](./rfc-006)
 - [DMN Specification](https://www.omg.org/spec/DMN/): Decision Model and Notation standard
 - [NRML](https://github.com/MinBZK/NRML): Nederlandse Regelgeving Markup Language
 - [Datalog](https://en.wikipedia.org/wiki/Datalog): declarative logic programming

--- a/docs/src/content/rfcs/rfc-011.md
+++ b/docs/src/content/rfcs/rfc-011.md
@@ -3,7 +3,7 @@ title: "RFC-011: Rules Language Selection"
 ---
 
 **Status:** Accepted
-**Date:** 2026-05-29
+**Date:** 2025-11-05
 **Authors:** regelrecht team
 **Short title:** Rules Language
 

--- a/docs/src/lib/landing-content.ts
+++ b/docs/src/lib/landing-content.ts
@@ -472,7 +472,7 @@ export const content: Record<'nl' | 'en', LandingContent> = {
         {
           q: 'Waarom een eigen regelformaat?',
           a: 'Het formaat is YAML met wettekst en machine-uitvoerbare regels naast elkaar in één bestand. Een versioned JSON Schema bewaakt de structuur, BDD-scenario’s leggen de bedoelde uitkomsten vast. Zo kunnen juristen meelezen, ontwikkelaars meebouwen, en verschillende overheidssystemen dezelfde regels gebruiken.',
-          link: { label: 'Lees RFC-001', href: '/rfcs/rfc-001' },
+          link: { label: 'Lees RFC-011', href: '/rfcs/rfc-011' },
         },
         {
           q: 'Hoe zou dit zich kunnen verhouden tot bestaande systemen?',
@@ -914,7 +914,7 @@ export const content: Record<'nl' | 'en', LandingContent> = {
         {
           q: 'Why a dedicated rule format?',
           a: 'The format is YAML, with legal text and machine-executable rules side by side in a single file. A versioned JSON Schema guards the structure, and BDD scenarios capture the intended outcomes. Legal experts can read along, developers can contribute, and different government systems can use the same rules.',
-          link: { label: 'Read RFC-001', href: '/rfcs/rfc-001' },
+          link: { label: 'Read RFC-011', href: '/rfcs/rfc-011' },
         },
         {
           q: 'How could this relate to existing systems?',

--- a/docs/src/lib/rehype-nldd-code-viewer.ts
+++ b/docs/src/lib/rehype-nldd-code-viewer.ts
@@ -13,13 +13,15 @@ function textContent(node: RootContent): string {
 
 /**
  * Replace fenced code blocks (<pre><code class="language-X">…) with
- * <nldd-code-viewer language="X">…</nldd-code-viewer> so the design-system code component
+ * <nldd-code language="X">…</nldd-code> so the design-system code component
  * owns the styling and (Prism) highlighting.
  *
  * Mermaid blocks are skipped — rehype-mermaid has already turned them into an
- * <svg> by the time this runs. Languages nldd-code-viewer doesn't (yet) support
- * render as plain code; the real language is still passed so highlighting
- * starts working automatically once the grammar is added upstream.
+ * <svg> by the time this runs. The component only highlights its supported
+ * grammars (yaml, json, javascript, typescript, css, html, bash, markdown);
+ * any other language renders as raw monospaced text with whitespace preserved.
+ * The real language is still passed so highlighting starts working
+ * automatically once the grammar is added upstream.
  */
 export function rehypeNlddCodeViewer() {
   return (tree: Root) => {
@@ -43,7 +45,7 @@ export function rehypeNlddCodeViewer() {
 
       parent.children[index] = {
         type: 'element',
-        tagName: 'nldd-code-viewer',
+        tagName: 'nldd-code',
         properties: language ? { language } : {},
         children: [{ type: 'text', value: raw }],
       };

--- a/docs/src/lib/rehype-rfc-meta.ts
+++ b/docs/src/lib/rehype-rfc-meta.ts
@@ -1,0 +1,119 @@
+import type { Root, Element, RootContent, ElementContent, Text } from 'hast';
+
+/**
+ * RFC preamble styling.
+ *
+ * Every RFC body opens with a paragraph of bold-labelled metadata:
+ *
+ *   <p><strong>Status:</strong> Accepted
+ *      <strong>Date:</strong> 2026-05-29
+ *      <strong>Authors:</strong> regelrecht team</p>
+ *
+ * Rendered as-is that is one grey run-on line. This plugin recognises that
+ * first paragraph and rebuilds it as a small metadata header: the Status
+ * value becomes an <nldd-tag> coloured by status (same mapping as the RFC
+ * index), and the remaining fields render as a muted line beneath it.
+ *
+ * It only fires on a paragraph whose first child is <strong>Status:</strong>,
+ * so ordinary prose is never touched. RFCs that omit the preamble render
+ * unchanged.
+ */
+
+const STATUS_COLOR: Record<string, string> = {
+  accept: 'success',
+  propos: 'accent',
+  reject: 'critical',
+  supersed: 'warning',
+};
+
+function statusColor(status: string): string {
+  const k = status.toLowerCase();
+  for (const key of Object.keys(STATUS_COLOR)) {
+    if (k.includes(key)) return STATUS_COLOR[key];
+  }
+  return 'neutral';
+}
+
+function textOf(node: RootContent): string {
+  if (node.type === 'text') return node.value;
+  if ('children' in node) {
+    return (node.children as RootContent[]).map(textOf).join('');
+  }
+  return '';
+}
+
+/** Read a paragraph of `<strong>Label:</strong> value` pairs into a map. */
+function parseFields(p: Element): Record<string, string> | null {
+  const fields: Record<string, string> = {};
+  let currentLabel: string | null = null;
+  for (const child of p.children) {
+    if (child.type === 'element' && child.tagName === 'strong') {
+      currentLabel = textOf(child).replace(/:\s*$/, '').trim();
+    } else if (child.type === 'text' && currentLabel) {
+      const value = child.value.trim();
+      if (value) {
+        fields[currentLabel] = value;
+        currentLabel = null;
+      }
+    }
+  }
+  return Object.keys(fields).length ? fields : null;
+}
+
+function tag(color: string, label: string): Element {
+  return {
+    type: 'element',
+    tagName: 'nldd-tag',
+    properties: { color, size: 'md' },
+    children: [{ type: 'text', value: label } as Text],
+  };
+}
+
+function mutedLine(text: string): Element {
+  return {
+    type: 'element',
+    tagName: 'span',
+    properties: { className: ['rr-rfc-meta-fields'] },
+    children: [{ type: 'text', value: text } as Text],
+  };
+}
+
+export function rehypeRfcMeta() {
+  return (tree: Root) => {
+    const firstP = tree.children.find(
+      (n): n is Element => n.type === 'element' && n.tagName === 'p',
+    );
+    if (!firstP) return;
+    const first = firstP.children[0];
+    const startsWithStatus =
+      first?.type === 'element' &&
+      first.tagName === 'strong' &&
+      /^Status:/.test(textOf(first));
+    if (!startsWithStatus) return;
+
+    const fields = parseFields(firstP);
+    if (!fields || !fields.Status) return;
+
+    // Status as a coloured tag; the rest (Date, Authors, …) as a muted line,
+    // skipping Short title which is sidebar-only metadata.
+    const rest = Object.entries(fields)
+      .filter(([k]) => k !== 'Status' && k !== 'Short title')
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('  ·  ');
+
+    const children: ElementContent[] = [tag(statusColor(fields.Status), fields.Status)];
+    if (rest) children.push(mutedLine(rest));
+
+    const replacement: Element = {
+      type: 'element',
+      tagName: 'div',
+      properties: { className: ['rr-rfc-meta'] },
+      children,
+    };
+
+    const idx = tree.children.indexOf(firstP);
+    tree.children[idx] = replacement;
+  };
+}
+
+export default rehypeRfcMeta;

--- a/docs/src/styles/docs.css
+++ b/docs/src/styles/docs.css
@@ -136,3 +136,18 @@ svg[id^='mermaid-'] .labelBkg {
   fill: transparent !important;
   background: transparent !important;
 }
+
+/* RFC preamble metadata header (rehype-rfc-meta).
+   Status renders as an <nldd-tag>; the remaining fields sit beneath it as a
+   muted line. Spacing matches the gap rich-text leaves between blocks. */
+.rr-rfc-meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.5rem;
+  margin-block: 0 1.5rem;
+}
+.rr-rfc-meta-fields {
+  color: var(--semantics-content-secondary-color);
+  font-size: 0.875rem;
+}


### PR DESCRIPTION
## Wat

Haalt [RFC-001: Rules Language Selection](https://github.com/MinBZK/poc-machine-law/blob/main/doc/rfcs/RFC-001-rules-language-selection.md) uit `MinBZK/poc-machine-law` binnen als RFC-011, hertaald naar de huisstijl en ingepast in de RFC-structuur. Onderweg bleek de docs-rendering van codeblokken sitebreed stuk; die fix zit in deze PR.

## RFC-011

- **Nummer**: bronnummer 001 was hier al bezet (*YAML Schema Design Decisions*); 011 is het laagste vrije gat. Een provenance-noot legt herkomst en hernummering vast.
- **Status Accepted, ratificatie-framing**: de keuze voor custom YAML draait al in productie (RFC-001 t/m 010 bouwen erop). De RFC heropent de keuze niet, hij legt de rationale vast.
- **Onderscheid met RFC-006** expliciet: RFC-006 koos de engine-*implementatietaal* (Rust), RFC-011 de *regeltaal* (RegelRecht YAML).
- Hertaald: geen em-dashes, rule-of-three-ritmes en herhaalde formuleringen eruit, Nederlandse domeintermen geïtaliceerd, corpus-pad gecorrigeerd t.o.v. de foute `regelrecht-laws`-submodule in de bron.
- ASCII-conversiediagram vervangen door een Mermaid-flowchart (krijgt automatisch een toegankelijke naam via `rehype-mermaid-alt`).

## Sitebrede rendering-fixes

- **Codeblokken**: `rehype-nldd-code-viewer` emitte `<nldd-code-viewer>`, een tag die het design system niet kent (de component heet `nldd-code`). Elk codeblok bleef daardoor ongehydrateerd met `white-space: normal`, waardoor de browser de newlines pletste. Nu `nldd-code`; 200 codeblokken op de docs-site renderen weer correct. Geverifieerd in de production build (preview), niet alleen `astro dev`.
- **RFC-metadata**: de `**Status:** ... **Date:** ... **Authors:** ...` preamble rendered als grijze run-on regel. Nieuwe `rehype-rfc-meta`-plugin zet de status om in een gekleurde `nldd-tag` (zelfde kleurmapping als de index: groen/blauw/grijs/rood) met datum en auteurs als subtiele regel eronder. Werkt voor alle 16 RFC's en alle statussen.

## Verificatie

- `astro build` slaagt (schone build, 70 pagina's).
- a11y-checks groen: mermaid-alt (31 diagrammen gelabeld), heading-order (geen rank-skips).
- TS-plugins type-clean (`tsc --noEmit`).
- Visueel gecontroleerd in de browser op de production preview: RFC-011, codeblokken op rfc-008, en de status-tag op rfc-009/013/018.