### PR TITLE
chore(deps): bump @nldd/design-system naar 0.8.50

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@astrojs/mdx": "^5",
         "@nldd/design-system": "^0.8.50",
-        "astro": "^6.3.8",
+        "astro": "^6.4.2",
         "astro-pagefind": "^2.0.0",
         "rehype-mermaid": "^3"
       },
@@ -2792,14 +2792,14 @@
       }
     },
     "node_modules/astro": {
-      "version": "6.3.8",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-6.3.8.tgz",
-      "integrity": "sha512-xH2UA8Z17IS+JaqSlSkBor7jO6gd7zXTLdmu06nKpfpDDJFbi/7KZEy3NDmWxmier+6XrCZ9Z4aitO8jhC9oiA==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-6.4.2.tgz",
+      "integrity": "sha512-8H89CH2dKL5SCU99OCqdU9BGjmPkSJqaPurywj5XMo7eMFGUFD3vsNhdEKnEh4mK4LgGje3/QDTTSIIGst0G0Q==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler": "^4.0.0",
-        "@astrojs/internal-helpers": "0.9.1",
-        "@astrojs/markdown-remark": "7.1.2",
+        "@astrojs/internal-helpers": "0.10.0",
+        "@astrojs/markdown-remark": "7.2.0",
         "@astrojs/telemetry": "3.3.2",
         "@capsizecss/unpack": "^4.0.0",
         "@clack/prompts": "^1.1.0",
@@ -2881,6 +2881,47 @@
       },
       "peerDependencies": {
         "astro": "^2.0.4 || ^3 || ^4 || ^5 || ^6"
+      }
+    },
+    "node_modules/astro/node_modules/@astrojs/internal-helpers": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.10.0.tgz",
+      "integrity": "sha512-Ry2R3VPeIN4uPCSA4xQc+e+vsJXkalKpEbDc07hV+a/o5Bs2N/s/uDcPJH/05L19DKh9tAy7e6JM3YZ6Cxfezw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.4",
+        "@types/mdast": "^4.0.4",
+        "js-yaml": "^4.1.1",
+        "picomatch": "^4.0.4",
+        "retext-smartypants": "^6.2.0",
+        "shiki": "^4.0.2",
+        "smol-toml": "^1.6.0",
+        "unified": "^11.0.5"
+      }
+    },
+    "node_modules/astro/node_modules/@astrojs/markdown-remark": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.2.0.tgz",
+      "integrity": "sha512-+YxmVQu1Bd+MFfSzjq1rOJvD9+nIOJzz5YIIhdIH01RrxRkKbyKoEgyIqP3yv51MhzMDgd79QaPv+kCVPT8vHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/internal-helpers": "0.10.0",
+        "@astrojs/prism": "4.0.2",
+        "github-slugger": "^2.0.0",
+        "hast-util-from-html": "^2.0.3",
+        "hast-util-to-text": "^4.0.2",
+        "mdast-util-definitions": "^6.0.0",
+        "rehype-raw": "^7.0.0",
+        "rehype-stringify": "^10.0.1",
+        "remark-gfm": "^4.0.1",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.1.2",
+        "remark-smartypants": "^3.0.2",
+        "unified": "^11.0.5",
+        "unist-util-remove-position": "^5.0.0",
+        "unist-util-visit": "^5.1.0",
+        "unist-util-visit-parents": "^6.0.2",
+        "vfile": "^6.0.3"
       }
     },
     "node_modules/async": {

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@astrojs/mdx": "^5",
-        "@nldd/design-system": "^0.8.49",
+        "@nldd/design-system": "^0.8.50",
         "astro": "^6.3.8",
         "astro-pagefind": "^2.0.0",
         "rehype-mermaid": "^3"
@@ -1320,9 +1320,9 @@
       }
     },
     "node_modules/@nldd/design-system": {
-      "version": "0.8.49",
-      "resolved": "https://registry.npmjs.org/@nldd/design-system/-/design-system-0.8.49.tgz",
-      "integrity": "sha512-p6VU3aQzzjK+3OJtIJPnfw/zePaAzs6LegdpBZf87GgCnTFTxsRRnc32QVeyc0NC4AMZ5J0KYPqwHCAw2yYhGg==",
+      "version": "0.8.50",
+      "resolved": "https://registry.npmjs.org/@nldd/design-system/-/design-system-0.8.50.tgz",
+      "integrity": "sha512-5oCd4a3D6RTWIAhRR2cDsRix8GltKpKQ93bNniF9qM3q4NVr53q7zFC831eT7mcVJOV+/LrzSUmp56W97kQyow==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@floating-ui/dom": "^1.7.6",

--- a/docs/package.json
+++ b/docs/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@astrojs/mdx": "^5",
     "@nldd/design-system": "^0.8.50",
-    "astro": "^6.3.8",
+    "astro": "^6.4.2",
     "astro-pagefind": "^2.0.0",
     "rehype-mermaid": "^3"
   },

--- a/docs/package.json
+++ b/docs/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@astrojs/mdx": "^5",
-    "@nldd/design-system": "^0.8.49",
+    "@nldd/design-system": "^0.8.50",
     "astro": "^6.3.8",
     "astro-pagefind": "^2.0.0",
     "rehype-mermaid": "^3"

--- a/frontend-lawmaking/package-lock.json
+++ b/frontend-lawmaking/package-lock.json
@@ -8,7 +8,7 @@
       "name": "regelrecht-frontend-lawmaking",
       "version": "1.0.0",
       "dependencies": {
-        "@nldd/design-system": "^0.8.49",
+        "@nldd/design-system": "^0.8.50",
         "vue": "^3.5.35"
       },
       "devDependencies": {
@@ -171,9 +171,9 @@
       }
     },
     "node_modules/@nldd/design-system": {
-      "version": "0.8.49",
-      "resolved": "https://registry.npmjs.org/@nldd/design-system/-/design-system-0.8.49.tgz",
-      "integrity": "sha512-p6VU3aQzzjK+3OJtIJPnfw/zePaAzs6LegdpBZf87GgCnTFTxsRRnc32QVeyc0NC4AMZ5J0KYPqwHCAw2yYhGg==",
+      "version": "0.8.50",
+      "resolved": "https://registry.npmjs.org/@nldd/design-system/-/design-system-0.8.50.tgz",
+      "integrity": "sha512-5oCd4a3D6RTWIAhRR2cDsRix8GltKpKQ93bNniF9qM3q4NVr53q7zFC831eT7mcVJOV+/LrzSUmp56W97kQyow==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@floating-ui/dom": "^1.7.6",

--- a/frontend-lawmaking/package.json
+++ b/frontend-lawmaking/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@nldd/design-system": "^0.8.49",
+    "@nldd/design-system": "^0.8.50",
     "vue": "^3.5.35"
   },
   "devDependencies": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@cucumber/gherkin": "^39.1.0",
         "@cucumber/messages": "^32.3.1",
-        "@nldd/design-system": "^0.8.49",
+        "@nldd/design-system": "^0.8.50",
         "@tiptap/core": "^3.23.6",
         "@tiptap/starter-kit": "^3.23.6",
         "@tiptap/vue-3": "^3.23.6",
@@ -337,9 +337,9 @@
       }
     },
     "node_modules/@nldd/design-system": {
-      "version": "0.8.49",
-      "resolved": "https://registry.npmjs.org/@nldd/design-system/-/design-system-0.8.49.tgz",
-      "integrity": "sha512-p6VU3aQzzjK+3OJtIJPnfw/zePaAzs6LegdpBZf87GgCnTFTxsRRnc32QVeyc0NC4AMZ5J0KYPqwHCAw2yYhGg==",
+      "version": "0.8.50",
+      "resolved": "https://registry.npmjs.org/@nldd/design-system/-/design-system-0.8.50.tgz",
+      "integrity": "sha512-5oCd4a3D6RTWIAhRR2cDsRix8GltKpKQ93bNniF9qM3q4NVr53q7zFC831eT7mcVJOV+/LrzSUmp56W97kQyow==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@floating-ui/dom": "^1.7.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@cucumber/gherkin": "^39.1.0",
     "@cucumber/messages": "^32.3.1",
-    "@nldd/design-system": "^0.8.49",
+    "@nldd/design-system": "^0.8.50",
     "@tiptap/core": "^3.23.6",
     "@tiptap/starter-kit": "^3.23.6",
     "@tiptap/vue-3": "^3.23.6",


### PR DESCRIPTION
## Dependency-bumps

- `@nldd/design-system` 0.8.49 → 0.8.50 in `frontend`, `docs` en `frontend-lawmaking` (`packages/admin/frontend-src` stond al op 0.8.50).
- `astro` 6.3.8 → 6.4.2 in `docs`. `@astrojs/mdx` v5 accepteert astro `^6.0.0`, dus die blijft ongemoeid.

Manifests en lockfiles bijgewerkt, lokaal opnieuw geïnstalleerd (geen kwetsbaarheden). Docs-build geverifieerd: 71 pagina's, geen fouten.