### PR TITLE
fix(docs): rendert nldd-code-viewer in plaats van hernoemde nldd-code

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -31,7 +31,7 @@ export default defineConfig({
     pagefind({ indexConfig: { forceLanguage: 'en' } }),
   ],
   markdown: {
-    // No Shiki: rehype-nldd-code-viewer turns every fenced block into <nldd-code>,
+    // No Shiki: rehype-nldd-code-viewer turns every fenced block into <nldd-code-viewer>,
     // which owns styling + (Prism) highlighting. Disabling Shiki also leaves
     // ```mermaid blocks as real <pre><code class="language-mermaid"> for
     // rehype-mermaid (it skips them via the language check).

--- a/docs/src/lib/rehype-nldd-code-viewer.ts
+++ b/docs/src/lib/rehype-nldd-code-viewer.ts
@@ -13,8 +13,8 @@ function textContent(node: RootContent): string {
 
 /**
  * Replace fenced code blocks (<pre><code class="language-X">…) with
- * <nldd-code language="X">…</nldd-code> so the design-system code component
- * owns the styling and (Prism) highlighting.
+ * <nldd-code-viewer language="X">…</nldd-code-viewer> so the design-system
+ * code component owns the styling and (Prism) highlighting.
  *
  * Mermaid blocks are skipped — rehype-mermaid has already turned them into an
  * <svg> by the time this runs. The component only highlights its supported
@@ -45,7 +45,7 @@ export function rehypeNlddCodeViewer() {
 
       parent.children[index] = {
         type: 'element',
-        tagName: 'nldd-code',
+        tagName: 'nldd-code-viewer',
         properties: language ? { language } : {},
         children: [{ type: 'text', value: raw }],
       };


### PR DESCRIPTION
## Probleem

De docs-rehype-plugin zette elk fenced code block om naar een `<nldd-code>`-element. Die component is in `@nldd/design-system` 0.8.45 hernoemd naar `nldd-code-viewer` (ter onderscheid van de `nldd-code-editor` input-component). De docs draaien op `^0.8.50`, dus `nldd-code` bestaat daar niet meer als custom element.

Gevolg: codeblokken in de docs verloren hun styling, Prism-highlighting en de nieuwe copy-to-clipboard-knop uit 0.8.51.

## Fix

`rehype-nldd-code-viewer.ts` rendert nu `<nldd-code-viewer>` in plaats van `<nldd-code>`. De pa11y-config (`.pa11yci` / `gen-pa11yci.mjs`) mikte al op `nldd-code-viewer`, dus die sluit nu weer aan op wat de plugin produceert. Comment in `astro.config.mjs` meegetrokken.

## Wijzigingen

- `docs/src/lib/rehype-nldd-code-viewer.ts`: `tagName` + doc-comment
- `docs/astro.config.mjs`: comment