### PR TITLE
docs: corrigeer nrml-afkorting in rfc-011 naar normalized rule model language

### DIFF
--- a/docs/src/content/rfcs/rfc-011.md
+++ b/docs/src/content/rfcs/rfc-011.md
@@ -90,7 +90,7 @@ The alternatives split into two categories, assessed with different criteria. **
 
 **DMN with FEEL** (Adoption: High). The most widely adopted decision-modeling standard, with strong vendor support and a decision-table paradigm that suits eligibility rules. In practice ~80-90% of DMN usage is decision tables; FEEL expressions are used far less because of perceived complexity, and FEEL tool support is uneven outside Camunda/Trisotech. Decision tables handle simple eligibility checks well, but complex calculations (benefit amounts, tax formulas) need extensive FEEL. Temporal versioning is not native, service references between laws would need custom extensions, and external governance of the standard may conflict with our requirements.
 
-**NRML** (Nederlandse Regelgeving Markup Language). Developed within the same MinBZK effort as this project, not a market-driven standard, and currently with no external adoption beyond its development team. Purpose-built for Dutch regulation with domain-specific constructs, and a natural candidate for knowledge sharing since both efforts come from MinBZK's law-as-code work. Strong domain alignment, but a broader feature set than we need risks extra complexity, and its service-reference patterns would need validation against our use case.
+**NRML** (Normalized Rule Model Language). Developed within the same MinBZK effort as this project, not a market-driven standard, and currently with no external adoption beyond its development team. Purpose-built for Dutch regulation with domain-specific constructs, and a natural candidate for knowledge sharing since both efforts come from MinBZK's law-as-code work. Strong domain alignment, but a broader feature set than we need risks extra complexity, and its service-reference patterns would need validation against our use case.
 
 **Datalog** (Adoption: Low, growing). Declarative rules that read close to legal text, strong for legal reasoning and "why not eligible?" explanations, with temporal extensions, guaranteed termination (safer than Prolog), and predictable bottom-up evaluation. Open-source engines include Soufflé (C++), Flix (JVM), PyDatalog (Python), and Logica (compiles to SQL). A natural fit for legal rule representation, but less accessible to non-technical stakeholders without tooling, and it would need an extra layer for law metadata and service references.
 
@@ -120,7 +120,7 @@ ineligible_reason(Person, "te jong") :-
 - [RFC-003: Inversion of Control for Delegated Legislation](./rfc-003)
 - [RFC-006: Language Choice for Law Execution Engine](./rfc-006)
 - [DMN Specification](https://www.omg.org/spec/DMN/): Decision Model and Notation standard
-- [NRML](https://github.com/MinBZK/NRML): Nederlandse Regelgeving Markup Language
+- [NRML](https://github.com/MinBZK/NRML): Normalized Rule Model Language
 - [Datalog](https://en.wikipedia.org/wiki/Datalog): declarative logic programming
 - [Catala](https://catala-lang.org/): programming language for law
 - [Soufflé](https://souffle-lang.github.io/): high-performance Datalog engine


### PR DESCRIPTION
NRML stond in rfc-011 verkeerd uitgeschreven als "Nederlandse Regelgeving Markup Language". Volgens de bron (https://github.com/MinBZK/NRML) staat NRML voor **Normalized Rule Model Language**.

Aangepast op twee plekken in `docs/src/content/rfcs/rfc-011.md`:
- de alternatievenbeschrijving van NRML
- de referentielijst onderaan

Verder kwam de onjuiste uitschrijving nergens anders in de repo voor.