### PR TITLE
fix(docs): repareer github-edit-links en voeg regelselectie toe

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -5,6 +5,7 @@ import rehypeMermaid from 'rehype-mermaid';
 import { rehypeMermaidAlt } from './src/lib/rehype-mermaid-alt.ts';
 import { rehypeNlddCodeViewer } from './src/lib/rehype-nldd-code-viewer.ts';
 import { rehypeRfcMeta } from './src/lib/rehype-rfc-meta.ts';
+import { rehypeSourceLines } from './src/lib/rehype-source-lines.ts';
 
 export default defineConfig({
   site: 'https://docs.regelrecht.rijks.app',
@@ -42,6 +43,9 @@ export default defineConfig({
     // colouring to docs.css (.mermaid svg rules), keyed off currentColor and
     // NLDD tokens, light and dark.
     rehypePlugins: [
+      // Stamp source-line data attributes first, before the plugins below
+      // restructure nodes and lose the original markdown positions.
+      rehypeSourceLines,
       [
         rehypeMermaid,
         {

--- a/docs/src/components/EditLink.astro
+++ b/docs/src/components/EditLink.astro
@@ -1,24 +1,36 @@
 ---
 /*
- * "Edit this page on GitHub" link. The relanding editLink pattern was
- * https://github.com/MinBZK/regelrecht/edit/main/docs/:path . After the
- * content move the markdown lives under docs/src/content/docs/ (and
- * docs/src/content/rfcs/ for RFCs), so the base path is updated to match
- * the real file location and the links stay valid.
+ * "Edit this page on GitHub" link.
+ *
+ * The source path is taken straight from the content entry's `filePath`
+ * (e.g. "src/content/rfcs/rfc-011.md"), so the link always points at the
+ * real file, extension and all. Earlier this component rebuilt the path from
+ * the collection name + entry id, but Astro's glob loader strips the
+ * extension from `entry.id` ("rfc-011", not "rfc-011.md"), which produced
+ * extension-less URLs that GitHub's /edit/ view rejects — and the docs
+ * collection mixes .md and .mdx, so the extension can't be assumed.
+ *
+ * `lines` optionally narrows the link to a source range (#L<a>-L<b>); the
+ * select-lines-to-edit affordance uses this at runtime, but the static
+ * sidebar link omits it and edits the whole file.
  */
 interface Props {
-  /** Collection entry id, e.g. "guide/what-is-regelrecht.md" */
-  entryId: string;
-  /** Which collection the entry belongs to. */
-  collection: 'docs' | 'rfcs';
+  /** Repo-root relative source path, e.g. "src/content/rfcs/rfc-011.md". */
+  filePath?: string;
+  /** Optional 1-based [start, end] source line range. */
+  lines?: [number, number];
+  /** Link label; defaults to the whole-page wording. */
+  text?: string;
 }
-const { entryId, collection } = Astro.props;
+const { filePath, lines, text = 'Edit page on GitHub' } = Astro.props;
 
-const base =
-  collection === 'rfcs'
-    ? 'https://github.com/MinBZK/regelrecht/edit/main/docs/src/content/rfcs/'
-    : 'https://github.com/MinBZK/regelrecht/edit/main/docs/src/content/docs/';
-const editUrl = base + entryId;
+const fragment = lines ? `#L${lines[0]}-L${lines[1]}` : '';
+const editUrl = filePath
+  ? `https://github.com/MinBZK/regelrecht/edit/main/docs/${filePath}${fragment}`
+  : undefined;
 ---
-
-<nldd-link size="sm" href={editUrl} target="_blank" text="Edit page on GitHub" />
+{
+  editUrl && (
+    <nldd-link size="sm" href={editUrl} target="_blank" text={text} />
+  )
+}

--- a/docs/src/layouts/Base.astro
+++ b/docs/src/layouts/Base.astro
@@ -828,6 +828,119 @@ const legalLinks = [
       });
     </script>
 
+    <!-- Select lines in a doc/RFC, jump to GitHub edit at that source range.
+         Pure chrome, no hydration: one floating nldd-button wired to the
+         current text selection. Active only on pages whose content wrapper
+         carries data-edit-base (doc + RFC templates); the source line numbers
+         come from rehype-source-lines (data-line / data-line-end). -->
+    <script>
+      // Bound once for the document lifetime: the global listeners
+      // (selectionchange, scroll, keydown) survive ClientRouter swaps, and the
+      // button + content wrapper are re-resolved live on each selection.
+      function setupEditSelection() {
+        if (window.__rrEditSelectionWired) return;
+        window.__rrEditSelectionWired = true;
+
+        // Positioned wrapper (plain div) holding an nldd-button. The wrapper
+        // owns absolute positioning + show/hide; the design-system button owns
+        // appearance and the link, so it matches the rest of the site.
+        let wrap = document.getElementById('rr-edit-selection');
+        let btn;
+        if (!wrap) {
+          wrap = document.createElement('div');
+          wrap.id = 'rr-edit-selection';
+          wrap.hidden = true;
+          btn = document.createElement('nldd-button');
+          btn.setAttribute('size', 'sm');
+          btn.setAttribute('variant', 'primary');
+          btn.setAttribute('start-icon', 'pencil');
+          btn.setAttribute('text', 'Edit these lines on GitHub');
+          btn.setAttribute('target', '_blank');
+          btn.setAttribute('rel', 'noopener');
+          wrap.appendChild(btn);
+          document.body.appendChild(wrap);
+        } else {
+          btn = wrap.querySelector('nldd-button');
+        }
+
+        const hide = () => {
+          wrap.hidden = true;
+        };
+
+        const update = () => {
+          // Content wrapper is re-resolved every time: it lives in the swapped
+          // <body>, so it changes on each ClientRouter navigation.
+          const content = document.querySelector('[data-edit-base]');
+          const editBase = content && content.getAttribute('data-edit-base');
+          if (!content || !editBase) return hide();
+
+          const sel = window.getSelection();
+          if (!sel || sel.isCollapsed || sel.rangeCount === 0) return hide();
+          const range = sel.getRangeAt(0);
+          if (!content.contains(range.commonAncestorContainer)) return hide();
+
+          // Every data-line element the selection touches; min start / max end
+          // gives the source range even across multiple blocks.
+          let min = Infinity;
+          let max = -Infinity;
+          content.querySelectorAll('[data-line]').forEach((el) => {
+            if (!range.intersectsNode(el)) return;
+            const a = Number(el.getAttribute('data-line'));
+            const b = Number(el.getAttribute('data-line-end')) || a;
+            if (a && a < min) min = a;
+            if (b && b > max) max = b;
+          });
+          if (min === Infinity || max === -Infinity) return hide();
+
+          btn.setAttribute('href', `${editBase}#L${min}-L${max}`);
+          const rect = range.getBoundingClientRect();
+          if (!rect.width && !rect.height) return hide();
+          // Anchor just above the selection start, clamped into the viewport.
+          const top = window.scrollY + rect.top - 44;
+          const left = Math.max(8, window.scrollX + rect.left);
+          wrap.style.top = `${Math.max(window.scrollY + 8, top)}px`;
+          wrap.style.left = `${left}px`;
+          wrap.hidden = false;
+        };
+
+        document.addEventListener('selectionchange', update);
+        // Reposition while the page scrolls under a held selection.
+        window.addEventListener('scroll', () => {
+          if (!wrap.hidden) update();
+        });
+        document.addEventListener('keydown', (e) => {
+          if (e.key === 'Escape') hide();
+        });
+        // Clicking the button must not clear the selection before navigating.
+        wrap.addEventListener('mousedown', (e) => e.preventDefault());
+      }
+
+      // Run now if the DOM is already parsed (script is at end of body), and
+      // again on every ClientRouter navigation; the guard makes it idempotent.
+      setupEditSelection();
+      document.addEventListener('astro:page-load', setupEditSelection);
+    </script>
+
+    <!-- Global (unscoped) so it matches the button, which is created in plain
+         JS via document.createElement and therefore never carries Astro's
+         scoped data-astro-cid attribute that a scoped <style> would require. -->
+    <style is:global>
+      /* Floating wrapper for the "edit these lines on GitHub" button shown on
+         text selection. Only the wrapper is positioned here; the nldd-button
+         inside owns its appearance (and is keyboard/AT-reachable as a link).
+         The wrapper carries the soft drop shadow so it reads as a floating
+         toolbar above the prose. */
+      #rr-edit-selection {
+        position: absolute;
+        z-index: 50;
+        border-radius: 6px;
+        box-shadow: 0 2px 8px rgb(0 0 0 / 0.25);
+      }
+      #rr-edit-selection[hidden] {
+        display: none;
+      }
+    </style>
+
     <style>
       /* nldd-page owns the scroll: it is the scroll container (height: 100%,
          overflow-y: auto) and also provides the layout-container so page

--- a/docs/src/lib/rehype-source-lines.ts
+++ b/docs/src/lib/rehype-source-lines.ts
@@ -1,0 +1,112 @@
+import type { Root, Element, ElementContent } from 'hast';
+import type { VFile } from 'vfile';
+import { readFileSync } from 'node:fs';
+
+/**
+ * Source-line provenance for the select-lines-to-edit affordance.
+ *
+ * Markdown positions survive into the hast tree (Astro's remark pipeline
+ * keeps `node.position`). This plugin stamps the source line range of each
+ * block onto its rendered element as `data-line` / `data-line-end`, so a
+ * client script can map a text selection back to source lines and build a
+ * GitHub edit URL with a `#L<a>-L<b>` fragment.
+ *
+ * Frontmatter offset: Astro strips the YAML frontmatter ("remove" mode)
+ * before remark parses the body, so `node.position` counts from the body, not
+ * from line 1 of the file. How many lines the body is shifted depends on the
+ * frontmatter length AND on how the tokenizer treats the blank line(s) after
+ * the closing delimiter, so we don't compute it analytically. Instead we
+ * anchor: read the raw file, find the file line of the first real body line,
+ * and subtract the first stamped node's own (body-relative) start line. That
+ * difference is the offset, self-correcting regardless of blank-line handling.
+ *
+ * Must run BEFORE the plugins that reshape nodes (rehype-nldd-code-viewer,
+ * rehype-rfc-meta): those replace elements and drop the original positions.
+ *
+ * Scope: top-level blocks (headings, paragraphs, lists, blockquotes, tables,
+ * code) plus list items, the granularity a reader selects at.
+ */
+
+// Same shape Astro uses to detect/strip frontmatter (frontmatter.js).
+const FRONTMATTER_RE = /(?:^﻿?|^\s*\n)(?:---|\+\+\+)([\s\S]*?\n)(?:---|\+\+\+)/;
+
+/**
+ * File line (1-based) of the first non-frontmatter, non-blank line. Lines
+ * after the closing delimiter that are blank are skipped; the first content
+ * line is what remark's first node maps to.
+ */
+function firstBodyFileLine(text: string): number | null {
+  const match = FRONTMATTER_RE.exec(text);
+  const lines = text.split('\n');
+  // 0-based index of the line just past the frontmatter block (0 if none).
+  let start = 0;
+  if (match) {
+    const blockEnd = (match.index ?? 0) + match[0].length;
+    let nl = 0;
+    for (let i = 0; i < blockEnd; i++) if (text[i] === '\n') nl++;
+    // `nl` is the 0-based index of the closing delimiter line itself; the
+    // body begins on the next line, so start scanning past it.
+    start = nl + 1;
+  }
+  for (let i = start; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (line === '') continue;
+    // .mdx: top-of-file import/export statements are consumed as ESM, not
+    // rendered, so the first stamped block is the first prose line after them.
+    // Skip them so the anchor pairs with the right line.
+    if (/^(import|export)\b/.test(line)) continue;
+    return i + 1; // 1-based file line
+  }
+  return null;
+}
+
+function computeOffset(filePath: string | undefined, firstNodeLine: number): number {
+  if (!filePath) return 0;
+  try {
+    // file.path may be a file:// URL or a plain path depending on the loader.
+    const target = filePath.startsWith('file:') ? new URL(filePath) : filePath;
+    const text = readFileSync(target).toString('utf8');
+    const bodyLine = firstBodyFileLine(text);
+    if (bodyLine == null) return 0;
+    // The first stamped node sits on `firstNodeLine` in the body; the same
+    // content is `bodyLine` in the file. Their difference shifts everything.
+    return bodyLine - firstNodeLine;
+  } catch {
+    return 0;
+  }
+}
+
+function stamp(node: Element, offset: number): void {
+  const pos = node.position;
+  if (!pos?.start?.line || !pos?.end?.line) return;
+  node.properties = node.properties ?? {};
+  node.properties['data-line'] = pos.start.line + offset;
+  node.properties['data-line-end'] = pos.end.line + offset;
+}
+
+function walkListItems(children: ElementContent[], offset: number): void {
+  for (const child of children) {
+    if (child.type !== 'element') continue;
+    if (child.tagName === 'li') stamp(child, offset);
+    if (child.children) walkListItems(child.children, offset);
+  }
+}
+
+export function rehypeSourceLines() {
+  return (tree: Root, file: VFile) => {
+    const blocks = tree.children.filter(
+      (n): n is Element => n.type === 'element' && !!n.position?.start?.line,
+    );
+    if (blocks.length === 0) return;
+    const offset = computeOffset(file?.path, blocks[0].position!.start.line);
+    for (const node of blocks) {
+      stamp(node, offset);
+      // List items are the natural selection unit inside ul/ol; stamp them too.
+      if ((node.tagName === 'ul' || node.tagName === 'ol') && node.children) {
+        walkListItems(node.children, offset);
+      }
+    }
+  };
+}
+
+export default rehypeSourceLines;

--- a/docs/src/pages/[...slug].astro
+++ b/docs/src/pages/[...slug].astro
@@ -8,7 +8,8 @@ import DocsFooter from '~/components/DocsFooter.astro';
 export async function getStaticPaths() {
   const docs = await getCollection('docs');
   return docs.map((entry) => ({
-    // Collection id keeps the .md suffix; strip it for the site path.
+    // The glob loader already strips the extension from entry.id; the replace
+    // is a harmless guard. Use entry.filePath (below) for the real source path.
     params: { slug: entry.id.replace(/\.mdx?$/, '') },
     props: { entry },
   }));
@@ -18,6 +19,11 @@ const { entry } = Astro.props;
 const { Content, headings } = await render(entry);
 
 const pathname = '/' + entry.id.replace(/\.mdx?$/, '');
+// Edit-link base for this page (whole-file sidebar link + the per-selection
+// line-range affordance both build off it).
+const editBase = entry.filePath
+  ? `https://github.com/MinBZK/regelrecht/edit/main/docs/${entry.filePath}`
+  : undefined;
 
 // Frontmatter strings may use `&shy;` as a readable marker for U+00AD
 // (soft hyphen); the browser only renders the hyphen when the word needs
@@ -51,13 +57,13 @@ const description = shy(entry.data.description);
     <div slot="left">
       <DocsOutline headings={headings} />
       <nldd-spacer size="24" sm-size="16" />
-      <EditLink entryId={entry.id} collection="docs" />
+      <EditLink filePath={entry.filePath} />
     </div>
     {/* The markdown body stays light-DOM (SSR/no-JS safe) inside nldd-rich-text
         for NLDD prose typography. .rr-min-width-0 prevents long content (wide
         tables, code blocks) from forcing the 2/3 column wider than its share. */}
     <div slot="right" class="rr-min-width-0">
-      <nldd-rich-text>
+      <nldd-rich-text data-edit-base={editBase}>
         <Content />
       </nldd-rich-text>
       <DocsFooter pathname={pathname} />

--- a/docs/src/pages/rfcs/[slug].astro
+++ b/docs/src/pages/rfcs/[slug].astro
@@ -18,6 +18,11 @@ const { entry } = Astro.props;
 const { Content, headings } = await render(entry);
 
 const pathname = '/rfcs/' + entry.id.replace(/\.md$/, '');
+// Edit-link base for this page (whole-file sidebar link + the per-selection
+// line-range affordance both build off it).
+const editBase = entry.filePath
+  ? `https://github.com/MinBZK/regelrecht/edit/main/docs/${entry.filePath}`
+  : undefined;
 // Frontmatter strings may use `&shy;` as a readable marker for U+00AD
 // (soft hyphen); the browser only renders the hyphen when the word needs
 // to break.
@@ -41,10 +46,10 @@ const title = pageTitle + ' · RegelRecht';
     <div slot="left">
       <DocsOutline headings={headings} />
       <nldd-spacer size="24" sm-size="16" />
-      <EditLink entryId={entry.id} collection="rfcs" />
+      <EditLink filePath={entry.filePath} />
     </div>
     <div slot="right" class="rr-min-width-0">
-      <nldd-rich-text>
+      <nldd-rich-text data-edit-base={editBase}>
         <Content />
       </nldd-rich-text>
       <DocsFooter pathname={pathname} />

--- a/docs/src/pages/rfcs/index.astro
+++ b/docs/src/pages/rfcs/index.astro
@@ -4,6 +4,7 @@
  * listed as a boxed navigation list; getRfcs() runs at build time.
  */
 import Base from '~/layouts/Base.astro';
+import EditLink from '~/components/EditLink.astro';
 import { getRfcs } from '~/lib/rfcs';
 
 const pathname = '/rfcs/';
@@ -46,6 +47,8 @@ const statusColor = (s: string) => {
           See <a href="/rfcs/rfc-000">RFC-000</a> for the process and template.
         </p>
       </nldd-rich-text>
+      <nldd-spacer size="24" sm-size="16" />
+      <EditLink filePath="src/content/rfcs/index.md" />
     </div>
     <div slot="right">
       <nldd-list type="navigation" variant="box">


### PR DESCRIPTION
## Waarom

De "Edit page on GitHub"-links waren kapot: ze wezen naar een pad zonder bestandsextensie (bijv. `.../docs/src/content/rfcs/rfc-011`). GitHub's `/edit/`-weergave verwacht een echt bestand en toont anders de mapinhoud in plaats van een editor.

Oorzaak: `EditLink` reconstrueerde het pad uit collectienaam + `entry.id`, maar de glob-loader haalt de extensie van `entry.id` af (`rfc-011`, niet `rfc-011.md`). De docs-collectie mengt bovendien `.md` en `.mdx`, dus de extensie valt niet aan te nemen.

## Wat

**Edit-links gerepareerd.** `EditLink` gebruikt nu `entry.filePath` (het echte bronpad, inclusief extensie). Edit-link toegevoegd op de RFC-index (`src/content/rfcs/index.md`). De docs- en categorie-indexpagina's krijgen er bewust geen, want die worden uit navigatiedata gegenereerd en hebben geen enkel bronbestand.

**Regelselectie → GitHub-edit.** Selecteer regels in een RFC of doc en een zwevende knop "Edit these lines on GitHub" springt naar de editor met precies die regels geselecteerd (`#L<a>-L<b>`):
- Nieuwe rehype-plugin `rehype-source-lines` stempelt het bronregelbereik als `data-line` / `data-line-end` op elk blok, gecorrigeerd voor de door Astro verwijderde frontmatter (md, mdx en RFC's met preamble geverifieerd).
- Eén zwevende `nldd-button` in `Base.astro`, zonder extra hydratie; toetsenbord-/AT-bereikbaar als link. Werkt over ClientRouter-navigaties heen.

## Test
- `npm run build` slaagt; `data-line`-waarden in de output komen 1-op-1 overeen met de bronregels (RFC `.md`, doc `.md`, `.mdx`).
- Browser: enkel- en meerblokselectie openen de juiste `#L<a>-L<b>`-range op GitHub.

Let op: de `docs-a11y`-gate faalt al op `main` (bestaande `nldd-code`-axe-melding, los van deze wijziging) en is geen verplichte merge-check. Deze PR voegt geen nieuwe a11y-fouten toe.