### PR TITLE
docs: koppel RFC-kruisverwijzingen en herstel inconsistenties

### DIFF
--- a/corpus/annotations/zorgtoeslagwet/annotations.yaml
+++ b/corpus/annotations/zorgtoeslagwet/annotations.yaml
@@ -1,7 +1,7 @@
 ---
 # Stand-off notes on the Healthcare Allowance Act (Wet op de zorgtoeslag).
 # Format: RFC-005. Infrastructure: RFC-018. Validated by `just validate-annotations`.
-$schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/heads/main/schema/v0.5.2/annotation-schema.json
+$schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/tags/schema-v0.5.2/schema/v0.5.2/annotation-schema.json
 annotations:
   # Linking note: connects the text granting the allowance to the
   # machine_readable element that computes its amount. This makes the
@@ -18,7 +18,7 @@ annotations:
         suffix: ' ter grootte van dat verschil'
     body:
       type: SpecificResource
-      source: regelrecht://zorgtoeslagwet/hoogte_zorgtoeslag#hoogte_zorgtoeslag
+      source: regelrecht://zorgtoeslagwet/hoogte_zorgtoeslag
       purpose: linking
     resolution: found
     workflow: resolved

--- a/docs/src/content/docs/reference/schema.md
+++ b/docs/src/content/docs/reference/schema.md
@@ -6,27 +6,32 @@ The law format is defined by a JSON Schema. All law YAML files in the corpus mus
 
 ## Current Version
 
-The current schema version is **v0.5.1**.
+The current schema version is **v0.5.2**.
 
 Schema URLs use immutable git tags to guarantee reproducibility. The format is:
 
 ```
-https://raw.githubusercontent.com/MinBZK/regelrecht/refs/tags/schema-v0.5.1/schema/v0.5.1/schema.json
+https://raw.githubusercontent.com/MinBZK/regelrecht/refs/tags/schema-v0.5.2/schema/v0.5.2/schema.json
 ```
 
 The tag `schema-vX.Y.Z` is created when a schema version is released. Using tags instead of `refs/heads/main` ensures that the schema a law file references can never change underneath it. See [RFC-013](/rfcs/rfc-013) for the rationale.
 
 ## Version History
 
-| Version | Description |
-|---------|-------------|
-| v0.5.1 | Current - tag-based immutable schema URLs |
-| v0.5.0 | Operation set with engine, corpus migration, and WOO support |
-| v0.4.0 | Open terms, implements, legal character, type specifications |
-| v0.3.2 | Minor fixes |
-| v0.3.1 | Patch release |
-| v0.3.0 | Added cross-law references |
-| v0.2.0 | Initial public schema |
+This table is the single source of truth for which schema version introduced which construct. RFCs that add a construct reference this table rather than asserting a version independently.
+
+| Version | Introduces | RFC |
+|---------|-----------|-----|
+| v0.5.2 | `annotation-schema.json` for stand-off notes | [RFC-005](/rfcs/rfc-005), [RFC-018](/rfcs/rfc-018) |
+| v0.5.1 | Tag-based immutable schema URLs; refinements within the v0.5.x line | [RFC-013](/rfcs/rfc-013) |
+| v0.5.0 | `hooks`, `overrides` (reactive execution); `procedure`, `procedure_id` (AWB lifecycle); WOO support | [RFC-007](/rfcs/rfc-007), [RFC-008](/rfcs/rfc-008) |
+| v0.4.0 | `open_terms`, `implements` (IoC); `legal_character`; `date` and `array` value types | [RFC-003](/rfcs/rfc-003) |
+| v0.3.2 | Minor fixes | — |
+| v0.3.1 | Patch release | — |
+| v0.3.0 | Cross-law references (`source`) | — |
+| v0.2.0 | Initial public schema: `regulatory_layer`, `competent_authority`, `execution.produces` | [RFC-001](/rfcs/rfc-001), [RFC-002](/rfcs/rfc-002) |
+
+Multi-organisation execution ([RFC-009](/rfcs/rfc-009)) reuses `competent_authority` (v0.2.0) and adds no schema construct of its own.
 
 ## Validation
 

--- a/docs/src/content/rfcs/index.md
+++ b/docs/src/content/rfcs/index.md
@@ -17,4 +17,4 @@ See [RFC-000](./rfc-000) for the process. RFCs are warranted for:
 - Cross-cutting design patterns
 - Integration patterns between components
 
-The template is at `docs/rfcs/template.md` in the repository.
+The template is at `docs/src/content/rfcs/template.md` in the repository.

--- a/docs/src/content/rfcs/rfc-000.md
+++ b/docs/src/content/rfcs/rfc-000.md
@@ -19,7 +19,7 @@ We need a lightweight but structured approach to capture these decisions.
 
 ## Decision
 
-We adopt an RFC (Request for Comments) process where significant design decisions are documented as markdown files in `docs/rfcs/`.
+We adopt an RFC (Request for Comments) process where significant design decisions are documented as markdown files in `docs/src/content/rfcs/`.
 
 ### RFC Template
 
@@ -29,6 +29,7 @@ We adopt an RFC (Request for Comments) process where significant design decision
 **Status:** [Draft | Proposed | Accepted | Rejected | Superseded]
 **Date:** YYYY-MM-DD
 **Authors:** Name(s)
+**Depends on:** RFC-NNN, RFC-MMM (optional; omit if none)
 
 ## Context
 Why is this decision necessary? What problem does it solve?
@@ -43,7 +44,7 @@ Benefits, tradeoffs, alternatives
 ### Numbering Convention
 
 - RFC-000 is reserved for this process document
-- Subsequent RFCs are numbered sequentially: RFC-001, RFC-002, etc.
+- Subsequent RFCs are numbered sequentially: [RFC-001](/rfcs/rfc-001), [RFC-002](/rfcs/rfc-002), etc.
 - Once a number is assigned, it is never reused (even for rejected RFCs)
 
 ### Status Values

--- a/docs/src/content/rfcs/rfc-001.md
+++ b/docs/src/content/rfcs/rfc-001.md
@@ -43,18 +43,18 @@ The POC v0.1.6 schema had several top-level "regulation discovery" fields. This 
 
 | POC v0.1.6 Field | v0.2.0 Status | Notes |
 |------------------|---------------|-------|
-| `law_type` | **Replaced** by `regulatory_layer` | More comprehensive: WET, AMVB, MINISTERIELE_REGELING, GRONDWET, EU_VERORDENING, etc. |
+| `law_type` | **Replaced** by `regulatory_layer` | More comprehensive: WET, AMVB, MINISTERIELE_REGELING, KONINKLIJK_BESLUIT, GRONDWET, EU_VERORDENING, etc. (see [RFC-015](/rfcs/rfc-015) for the full ranked layer list) |
 | `legal_character` | **Moved** to `execution.produces.legal_character` | Now per-article instead of per-service (BESCHIKKING, TOETS, etc.) |
 | `decision_type` | **Moved** to `execution.produces.decision_type` | Now per-article instead of per-service (TOEKENNING, GOEDKEURING, etc.) |
 | `discoverable` | **Removed** | No longer needed; all outputs are public endpoints (see Decision 1) |
-| `service` | **Replaced** by `competent_authority` | The "service" concept becomes the authority responsible for execution; see RFC-002 for detailed design |
+| `service` | **Replaced** by `competent_authority` | The "service" concept becomes the authority responsible for execution; see [RFC-002](/rfcs/rfc-002) for detailed design |
 
 **Why per-article instead of per-service?**
 - Laws contain multiple articles with different legal effects
 - Article 2 may produce a BESCHIKKING (toekenning) while Article 3 produces a TOETS (goedkeuring)
 - This matches the legal reality better than a single service-level classification
 
-The `produces` construct on an article's `execution` block declares what legal artifact the article produces when executed. `legal_character` (e.g. BESCHIKKING, VASTSTELLING) classifies the type of legal act; `decision_type` (e.g. TOEKENNING, AFWIJZING) classifies the outcome. These fields serve as filter targets for reactive hooks (see RFC-007) and lifecycle stages (see RFC-008).
+The `produces` construct on an article's `execution` block declares what legal artifact the article produces when executed. `legal_character` (e.g. BESCHIKKING, VASTSTELLING) classifies the type of legal act; `decision_type` (e.g. TOEKENNING, AFWIJZING) classifies the outcome. These fields serve as filter targets for reactive hooks (see [RFC-007](/rfcs/rfc-007)) and lifecycle stages (see [RFC-008](/rfcs/rfc-008)).
 
 **Open question: Single vs multiple executions per article?**
 
@@ -114,7 +114,7 @@ regelrecht://{law_id}/{output_name}#{field}
 - `output_name` — the name of an output produced by one of the law's articles
 - `#field` (optional fragment) — extracts a specific field from the output (e.g. `#value`)
 
-The engine resolves these URIs by finding the law by `$id`, locating the article that produces the named output, executing it, and extracting the requested field. This scheme is used for cross-law input references (RFC-003, RFC-007) and as annotation targets (RFC-005).
+The engine resolves these URIs by finding the law by `$id`, locating the article that produces the named output, executing it, and extracting the requested field. This scheme is used for cross-law input references ([RFC-003](/rfcs/rfc-003), [RFC-007](/rfcs/rfc-007)) and as annotation targets ([RFC-005](/rfcs/rfc-005)).
 
 ### 7. UUID Field: Removed
 

--- a/docs/src/content/rfcs/rfc-003.md
+++ b/docs/src/content/rfcs/rfc-003.md
@@ -77,7 +77,7 @@ Temporal filtering is needed for correctness when multiple versions of an implem
 
 ### Same-law routing via `source.output`
 
-When multiple articles in the same law need an open term value, only one article should declare the `open_terms` and serve as the single point of delegation. Other articles reference it via `source.output` (see RFC-001, Section 9: Input Source Consolidation) without `source.regulation`:
+When multiple articles in the same law need an open term value, only one article should declare the `open_terms` and serve as the single point of delegation. Other articles reference it via `source.output` (see [RFC-001](/rfcs/rfc-001), Section 9: Input Source Consolidation) without `source.regulation`:
 
 ```yaml
 # Article 2 gets standaardpremie from article 4 (same law)
@@ -182,8 +182,8 @@ When resolving open terms, the engine does not forward all execution parameters 
 | Pattern | Use when |
 |---------|----------|
 | **IoC** (`open_terms` + `implements`) | Any delegation: a higher law delegates a value to a lower regulation (with or without scope) |
-| **Same-law reference** (`source.output`) | Internal: one article needs a value produced by another article in the same law (see RFC-001 §9) |
-| **External reference** (`source.regulation`) | Direct reference: one law needs a specific value from another law (see RFC-001 §9) |
+| **Same-law reference** (`source.output`) | Internal: one article needs a value produced by another article in the same law (see [RFC-001](/rfcs/rfc-001) §9) |
+| **External reference** (`source.regulation`) | Direct reference: one law needs a specific value from another law (see [RFC-001](/rfcs/rfc-001) §9) |
 
 The old `source.delegation` + `select_on` + `legal_basis_for` pattern is superseded by IoC and will be phased out.
 

--- a/docs/src/content/rfcs/rfc-005.md
+++ b/docs/src/content/rfcs/rfc-005.md
@@ -347,7 +347,7 @@ to be unique, even for common words.
 
 The blocks below are illustrative. The authoritative, machine-checked schema is
 `schema/v0.5.2/annotation-schema.json`, which additionally defines `creator`,
-`created`, and `modified` (see RFC-018 Decision 3 for the authority model that
+`created`, and `modified` (see [RFC-018](/rfcs/rfc-018) Decision 3 for the authority model that
 relies on `creator`). Validate note files against that file via
 `just validate-annotations`, not against the excerpts here.
 
@@ -492,7 +492,7 @@ in work-in-progress laws (a known need from interpretation research: "open norm
 partially filled", "needs explanation by implementation policy", a reference to a
 document we are still searching for). The specific ambiguity state is carried as a
 `tagging` body, not as a new schema field, so the vocabulary can grow without a
-schema change. RFC-018 details this and the controlled vocabulary that backs it.
+schema change. [RFC-018](/rfcs/rfc-018) details this and the controlled vocabulary that backs it.
 
 ## References
 

--- a/docs/src/content/rfcs/rfc-006.md
+++ b/docs/src/content/rfcs/rfc-006.md
@@ -3,7 +3,7 @@ title: "RFC-006: Language Choice for Law Execution Engine"
 ---
 
 **Status:** Accepted
-**Date:** 2025-01-26
+**Date:** 2026-01-26
 **Authors:** regelrecht team
 
 ## Context

--- a/docs/src/content/rfcs/rfc-007.md
+++ b/docs/src/content/rfcs/rfc-007.md
@@ -12,7 +12,7 @@ The engine currently supports **active execution**: someone requests a legal det
 
 **Reactive execution.** The Algemene wet bestuursrecht (AWB) applies whenever any government body issues an individual decision (*beschikking*). Article 6:7 sets an objection period (*bezwaartermijn*) of six weeks. Article 3:46 requires adequate reasoning (*deugdelijke motivering*). Neither article is called explicitly. They fire because the output qualifies as an individual decision (*beschikking*), regardless of which law produced it. The target law does not know about AWB. AWB does not know about the target law. The relationship is unilateral.
 
-**Lex specialis.** AWB 6:7 says "de termijn bedraagt zes weken" — no exception clause, no delegation. Yet the Vreemdelingenwet artikel 69 says "in afwijking van artikel 6:7 bedraagt de termijn vier weken." It unilaterally replaces the value. This differs from IoC delegation (RFC-003): the general law does not know it is being overridden.
+**Lex specialis.** AWB 6:7 says "de termijn bedraagt zes weken" — no exception clause, no delegation. Yet the Vreemdelingenwet artikel 69 says "in afwijking van artikel 6:7 bedraagt de termijn vier weken." It unilaterally replaces the value. This differs from IoC delegation ([RFC-003](/rfcs/rfc-003)): the general law does not know it is being overridden.
 
 **Temporal computation.** "When is my deadline for objection (*bezwaar*)?" is not answered by "6 weeks" — it is answered by "9 april 2026." Computing that date requires a chain of four articles across three laws, using date arithmetic, public holiday calendars, and weekend rules. The engine lacks the types and operations.
 
@@ -37,7 +37,7 @@ graph LR
 
 This RFC introduces two new execution modes alongside the existing one:
 
-1. **Active execution**: request-response (current engine, RFC-003 IoC)
+1. **Active execution**: request-response (current engine, [RFC-003](/rfcs/rfc-003) IoC)
 2. **Reactive execution**: hooks (this RFC)
 3. **Lex specialis**: overrides (this RFC)
 
@@ -62,7 +62,7 @@ The engine evaluates an article in five stages:
 
 1. **Create context** with parameters and calculation_date
 2. **Resolve inputs** from cross-law references and data sources
-3. **Resolve open terms** via IoC (RFC-003, `implements` index)
+3. **Resolve open terms** via IoC ([RFC-003](/rfcs/rfc-003), `implements` index)
 4. **Execute actions** that evaluate conditions and set outputs
 5. **Return result** with outputs
 
@@ -121,7 +121,7 @@ Among hooks at the same hook point, execution is independent — no inter-hook d
 
 #### Resolution model
 
-**At load time:** the engine builds a `hooks_index` when loading laws. For each article with a `hooks` declaration, it indexes the hook by `(hook_point, legal_character)`, mapping to `(law_id, article_number, HookFilter)` entries. This parallels `implements_index` (RFC-003) in `RuleResolver`.
+**At load time:** the engine builds a `hooks_index` when loading laws. For each article with a `hooks` declaration, it indexes the hook by `(hook_point, legal_character)`, mapping to `(law_id, article_number, HookFilter)` entries. This parallels `implements_index` ([RFC-003](/rfcs/rfc-003)) in `RuleResolver`.
 
 **At execution time:** when an article has a `produces` annotation:
 
@@ -134,14 +134,14 @@ Hook articles execute through the same `evaluate_article_with_service` path. Cyc
 
 #### Parameter passing
 
-Hook articles do not receive the target article's execution context. Each hook declares its own `parameters` and `input` sections. The engine passes only declared parameters, consistent with RFC-003's principle of least privilege (`filter_parameters_for_article`).
+Hook articles do not receive the target article's execution context. Each hook declares its own `parameters` and `input` sections. The engine passes only declared parameters, consistent with [RFC-003](/rfcs/rfc-003)'s principle of least privilege (`filter_parameters_for_article`).
 
 - **Constant hooks** (no parameters): execute standalone. Most AWB hooks fall here.
 - **Context-aware hooks** (parameters declared): receive only what they request.
 
 #### Priority
 
-When multiple hooks produce the same output name: lex superior (higher regulatory layer wins) then lex posterior (newer `valid_from` wins). Same model as IoC resolution (RFC-003).
+When multiple hooks produce the same output name: lex superior (higher regulatory layer wins) then lex posterior (newer `valid_from` wins). Same model as IoC resolution ([RFC-003](/rfcs/rfc-003)).
 
 ### 2. Overrides — Lex Specialis
 
@@ -171,7 +171,7 @@ The declaration sits on the article where the legal text is. Article 69 says "in
 
 #### Overrides vs. IoC
 
-| | IoC (RFC-003) | Lex specialis (this RFC) |
+| | IoC ([RFC-003](/rfcs/rfc-003)) | Lex specialis (this RFC) |
 |---|---|---|
 | General law | Declares `open_terms`, knows it is delegating | Declares nothing, unaware of overrides |
 | Specific law | Declares `implements`, fills in a value left open | Declares `overrides`, replaces a value already set |
@@ -220,7 +220,7 @@ output:
 
 #### Date arithmetic operations
 
-All operations are pure functions. No domain knowledge. These operations extend the operation set defined in RFC-004 (Uniform Operation Syntax). Date operations use named parameters (`date`, `years`, `months`, `weeks`, `days`) rather than RFC-004's positional `values` array, because their operands are heterogeneous (a date and a duration are not interchangeable list items).
+All operations are pure functions. No domain knowledge. These operations extend the operation set defined in [RFC-004](/rfcs/rfc-004) (Uniform Operation Syntax). Date operations use named parameters (`date`, `years`, `months`, `weeks`, `days`) rather than [RFC-004](/rfcs/rfc-004)'s positional `values` array, because their operands are heterogeneous (a date and a duration are not interchangeable list items).
 
 | Operation | Input | Output | Example | Status |
 |-----------|-------|--------|---------|--------|
@@ -256,7 +256,7 @@ graph LR
 
 **Layer 2: Easter-dependent dates** — Good Friday (*Goede Vrijdag*), Easter Monday (*Tweede Paasdag*), Ascension Day (*Hemelvaartsdag*), Whit Monday (*Tweede Pinksterdag*). Fixed offsets from Easter Sunday. The engine receives `pasen_datum` as a parameter. The computus is not in the engine — whoever calls the engine provides the date.
 
-**Layer 3: Equivalent days (*gelijkgestelde dagen*)** — days designated by royal decree as equivalent to public holidays (*feestdagen*). Artikel 3 lid 3 delegates to the Crown. KB's from the Government Gazette (*Staatscourant*) (e.g., Stcrt. 2025, 24713 covers 2026-2028) implement this via IoC (RFC-003), same pattern as BW5 art 42 with municipal ordinances (*gemeentelijke verordeningen*).
+**Layer 3: Equivalent days (*gelijkgestelde dagen*)** — days designated by royal decree as equivalent to public holidays (*feestdagen*). Artikel 3 lid 3 delegates to the Crown. KB's from the Government Gazette (*Staatscourant*) (e.g., Stcrt. 2025, 24713 covers 2026-2028) implement this via IoC ([RFC-003](/rfcs/rfc-003)), same pattern as BW5 art 42 with municipal ordinances (*gemeentelijke verordeningen*).
 
 ### How the mechanisms compose
 
@@ -601,7 +601,7 @@ This matters for multi-output evaluation: when a caller requests specific output
 **Hooks:**
 - New structs: `HookDeclaration { hook_point, applies_to }`, `HookPoint { PreActions, PostActions }`, `HookFilter { legal_character, decision_type }`.
 - `hooks_index` in `RuleResolver`, keyed by `(HookPoint, String)`.
-- The `hooks_index` key should include `stage: Option<String>` from the start. RFC-008 (Bestuursrecht) will add stage-aware filtering; designing the index with this field avoids reworking the data structure later. Hooks without `stage` default to matching any stage.
+- The `hooks_index` key should include `stage: Option<String>` from the start. [RFC-008](/rfcs/rfc-008) (Bestuursrecht) will add stage-aware filtering; designing the index with this field avoids reworking the data structure later. Hooks without `stage` default to matching any stage.
 - Hook firing in `LawExecutionService::evaluate_article_with_service()`.
 - Trace types: `PathNodeType::HookResolution`, `ResolveType::Hook`.
 
@@ -621,7 +621,7 @@ This matters for multi-output evaluation: when a caller requests specific output
 
 ## References
 
-- RFC-003: Inversion of Control for Delegated Legislation
+- [RFC-003](/rfcs/rfc-003): Inversion of Control for Delegated Legislation
 - AWB article 3:46: https://wetten.overheid.nl/BWBR0005537/2024-01-01#Artikel3:46
 - AWB article 6:7: https://wetten.overheid.nl/BWBR0005537/2024-01-01#Artikel6:7
 - AWB article 6:8: https://wetten.overheid.nl/BWBR0005537/2024-01-01#Artikel6:8

--- a/docs/src/content/rfcs/rfc-008.md
+++ b/docs/src/content/rfcs/rfc-008.md
@@ -9,7 +9,7 @@ title: "RFC-008: AWB Administrative Procedures"
 
 ## Context
 
-RFC-007 introduced hooks: articles that fire when another article's `produces` annotation matches. This enables reactive execution — AWB 3:46 (reasoning requirement, *motiveringsplicht*) fires on any BESCHIKKING, AWB 6:7 (objection period, *bezwaartermijn*) fires on any BESCHIKKING, AWB 6:8 (start/einddatum) fires on any BESCHIKKING.
+[RFC-007](/rfcs/rfc-007) introduced hooks: articles that fire when another article's `produces` annotation matches. This enables reactive execution — AWB 3:46 (reasoning requirement, *motiveringsplicht*) fires on any BESCHIKKING, AWB 6:7 (objection period, *bezwaartermijn*) fires on any BESCHIKKING, AWB 6:8 (start/einddatum) fires on any BESCHIKKING.
 
 But an individual decision (*beschikking*) is not an instant computation. It is an administrative law (*bestuursrecht*) process that progresses through stages over time:
 
@@ -253,7 +253,7 @@ stateDiagram-v2
 
 ### Hooks bind to stages, not just legal_character
 
-The `applies_to` in hooks (RFC-007) gains a `stage` field:
+The `applies_to` in hooks ([RFC-007](/rfcs/rfc-007)) gains a `stage` field:
 
 ```yaml
 # AWB 3:46 — motiveringsplicht
@@ -338,7 +338,7 @@ Output: { bezwaartermijn_startdatum: "2026-03-24",
 Yields: "BEZWAAR stage — bezwaartermijn running until 2026-04-20"
 ```
 
-`bekendmaking_datum` is a genuine external event (the orchestration layer signals that notification (*bekendmaking*) has occurred). `pasen_datum` is also an external parameter — the computus algorithm is not in Dutch statute law, so the caller provides Easter Sunday's date, consistent with the zero-domain-knowledge principle (RFC-007). Gelijkgestelde dagen (bridge days equated to public holidays) are resolved internally via IoC from harvested KB's.
+`bekendmaking_datum` is a genuine external event (the orchestration layer signals that notification (*bekendmaking*) has occurred). `pasen_datum` is also an external parameter — the computus algorithm is not in Dutch statute law, so the caller provides Easter Sunday's date, consistent with the zero-domain-knowledge principle ([RFC-007](/rfcs/rfc-007)). Gelijkgestelde dagen (bridge days equated to public holidays) are resolved internally via IoC from harvested KB's.
 
 The engine **yields** between stages, returning:
 - What it computed so far (accumulated outputs)
@@ -396,7 +396,7 @@ The lifecycle definition distinguishes these: stages with `requires` fields that
 
 **Complexity.** The engine moves from "pure function" to "state machine executor." The orchestration layer must now manage decision (*besluit*) state persistence. This is a lot of implementation work.
 
-**Backwards compatibility.** Existing laws that produce BESCHIKKING without a lifecycle still work — they complete in a single stage. But new laws should use the lifecycle model. RFC-007 hooks without `stage` default to BESLUIT for backward compatibility.
+**Backwards compatibility.** Existing laws that produce BESCHIKKING without a lifecycle still work — they complete in a single stage. But new laws should use the lifecycle model. [RFC-007](/rfcs/rfc-007) hooks without `stage` default to BESLUIT for backward compatibility.
 
 **State management.** Decision (*besluit*) state must be persisted somewhere. The engine doesn't dictate where (database, event store, file system), but the orchestration layer must handle it.
 
@@ -426,7 +426,7 @@ The engine needs:
 
 The decision (*besluit*) state is *not* stored in the engine. It is passed in by the caller and returned with updates. The engine remains a library, not a service.
 
-**Schema version:** The `procedure:` top-level key and the `procedure_id` field on `produces` are new constructs not present in schema v0.4.0. Implementation requires a schema version bump (v0.5.0 or later). AWB YAML files using `procedure:` will fail validation against the current schema until the schema is extended.
+**Schema version:** The `procedure:` top-level key and the `procedure_id` field on `produces` are new constructs not present in schema v0.4.0. They land in **schema v0.5.0** (see the schema version history in [RFC-013](/rfcs/rfc-013)), alongside the hooks and overrides from [RFC-007](/rfcs/rfc-007). AWB YAML files using `procedure:` must reference v0.5.0 or later.
 
 **Yield mechanism.** The largest architectural change is the yield mechanism. The current engine returns `Result<ArticleResult>` — a terminal result. Multi-stage execution needs the engine to return either a completed result or a "yielded" state waiting for input to proceed to the next stage. Two implementation approaches:
 
@@ -443,7 +443,7 @@ Decision (*besluit*) state is external (passed in, returned out), which is compa
 
 2. ~~**Nested lifecycles.**~~ **Resolved:** An objection (*bezwaar*) is itself a decision (*besluit*, AWB 7:12), which starts its own lifecycle (with its own notification (*bekendmaking*), and possibility of appeal (*beroep*) before the administrative court (*bestuursrechter*)). The engine applies the same lifecycle pattern recursively — a decision on objection (*besluit op bezwaar*) enters the AWB lifecycle just like the original individual decision (*beschikking*). If a law inadvertently creates infinite recursion, that is a defect in the law, not in the engine.
 
-   Note that RFC-007's cycle detection does **not** cover this case. RFC-007 detects cross-law circular references within a single engine invocation (Law A → Law B → Law A). Nested lifecycle recursion (individual decision (*beschikking*) → decision on objection (*besluit op bezwaar*) → its own objection (*bezwaar*) → ...) happens across separate engine invocations initiated by the orchestration layer. The **orchestration layer** is responsible for detecting excessive lifecycle nesting depth, not the engine. In the AWB this chain is naturally finite (individual decision (*beschikking*) → decision on objection (*besluit op bezwaar*) → appeal (*beroep*) → higher appeal (*hoger beroep*) terminates), but the orchestration layer should enforce a configurable maximum nesting depth as a safety measure.
+   Note that [RFC-007](/rfcs/rfc-007)'s cycle detection does **not** cover this case. [RFC-007](/rfcs/rfc-007) detects cross-law circular references within a single engine invocation (Law A → Law B → Law A). Nested lifecycle recursion (individual decision (*beschikking*) → decision on objection (*besluit op bezwaar*) → its own objection (*bezwaar*) → ...) happens across separate engine invocations initiated by the orchestration layer. The **orchestration layer** is responsible for detecting excessive lifecycle nesting depth, not the engine. In the AWB this chain is naturally finite (individual decision (*beschikking*) → decision on objection (*besluit op bezwaar*) → appeal (*beroep*) → higher appeal (*hoger beroep*) terminates), but the orchestration layer should enforce a configurable maximum nesting depth as a safety measure.
 
 3. ~~**Parallel stages.**~~ **Resolved:** The main lifecycle track (application (*aanvraag*) → processing (*behandeling*) → decision (*besluit*) → notification (*bekendmaking*) → objection (*bezwaar*) → appeal (*beroep*)) is strictly sequential — each stage depends on completion of the previous one. However, three genuinely parallel tracks can be spawned from the main lifecycle:
    - **Penalty payment for late decision (*dwangsom bij niet-tijdig beslissen*, AWB 4:17-4:20)**: activates when the decision deadline (*beslistermijn*) expires without a decision (*besluit*). Runs parallel to the ongoing processing (*behandeling*) phase. The penalty payment decision (*dwangsombesluit*) is itself an individual decision (*beschikking*) with its own lifecycle.
@@ -458,7 +458,7 @@ Decision (*besluit*) state is external (passed in, returned out), which is compa
 
 ## References
 
-- RFC-007: Cross-Law Execution Model (hooks, overrides, temporal computation)
+- [RFC-007](/rfcs/rfc-007): Cross-Law Execution Model (hooks, overrides, temporal computation)
 - AWB Hoofdstuk 3: Algemene bepalingen over besluiten (bekendmaking, motivering)
 - AWB Hoofdstuk 4: Bijzondere bepalingen over besluiten (beslistermijn, aanvraag)
 - AWB Hoofdstuk 6: Algemene bepalingen over bezwaar en beroep (termijnen)

--- a/docs/src/content/rfcs/rfc-008.md
+++ b/docs/src/content/rfcs/rfc-008.md
@@ -426,7 +426,7 @@ The engine needs:
 
 The decision (*besluit*) state is *not* stored in the engine. It is passed in by the caller and returned with updates. The engine remains a library, not a service.
 
-**Schema version:** The `procedure:` top-level key and the `procedure_id` field on `produces` are new constructs not present in schema v0.4.0. They land in **schema v0.5.0** (see the schema version history in [RFC-013](/rfcs/rfc-013)), alongside the hooks and overrides from [RFC-007](/rfcs/rfc-007). AWB YAML files using `procedure:` must reference v0.5.0 or later.
+**Schema version:** The `procedure:` top-level key and the `procedure_id` field on `produces` are new constructs not present in schema v0.4.0. They land in **schema v0.5.0** (see the [Schema Reference](/reference/schema#version-history) version history), alongside the hooks and overrides from [RFC-007](/rfcs/rfc-007). AWB YAML files using `procedure:` must reference v0.5.0 or later.
 
 **Yield mechanism.** The largest architectural change is the yield mechanism. The current engine returns `Result<ArticleResult>` — a terminal result. Multi-stage execution needs the engine to return either a completed result or a "yielded" state waiting for input to proceed to the next stage. Two implementation approaches:
 

--- a/docs/src/content/rfcs/rfc-009.md
+++ b/docs/src/content/rfcs/rfc-009.md
@@ -5,10 +5,11 @@ title: "RFC-009: Multi-Organisation Execution"
 **Status:** Proposed
 **Date:** 2026-03-22
 **Authors:** Eelco Hotting
+**Depends on:** RFC-002 (Authority), RFC-010 (Federated Corpus)
 
 ## Context
 
-Prior to this RFC, the engine has no concept of organisational boundaries at execution time; it loads all laws and executes everything in-process. RFC-010 (Federated Corpus) addresses *where laws come from* but not *who executes what*.
+Prior to this RFC, the engine has no concept of organisational boundaries at execution time; it loads all laws and executes everything in-process. [RFC-010](/rfcs/rfc-010) (Federated Corpus) addresses *where laws come from* but not *who executes what*.
 
 In reality, Dutch law assigns specific computations to specific organisations. The Healthcare Allowance Act (*Wet op de zorgtoeslag*) assigns execution to Allowances Service (*Dienst Toeslagen*). The Participation Act (*Participatiewet*) assigns execution to the municipality (*gemeente*). The tax inspector (*inspecteur*) alone determines the assessed income (*toetsingsinkomen*). When one law references another law's output, the question is: does the executing organisation compute that value itself, or does it accept another organisation's individual decision (*beschikking*)?
 
@@ -20,7 +21,7 @@ A **calculation** (*berekening*), such as applying a formula, evaluating a defin
 
 This distinction determines the execution boundary. The schema already captures it through two fields:
 
-- `competent_authority` (RFC-002): which authority is competent to issue the decision
+- `competent_authority` ([RFC-002](/rfcs/rfc-002)): which authority is competent to issue the decision
 - `produces.legal_character`: whether the article's output constitutes an individual decision (`BESCHIKKING`), assessment (`TOETS`), or informational output (`INFORMATIEF`)
 
 When an article produces a `BESCHIKKING` and declares a `competent_authority`, only that authority can produce it authoritatively. All other articles (definitions, formulas, sub-checks) can be executed by anyone.
@@ -77,7 +78,7 @@ The `produces.legal_character` field is the primary trigger, not `competent_auth
 
 When an article **does** produce a `BESCHIKKING`, **all its outputs** are part of that single determination. In Dutch administrative law, the individual decision (*beschikking*) is indivisible — both the right (*recht*) and the amount (*hoogte*) are constitutive elements of one decision. You cannot accept the right from the authority but re-calculate the amount yourself.
 
-For `CATEGORY` authorities (RFC-002), the engine resolves the category against its identity. A municipality (*gemeente*) engine with identity `GM0363` matches `competent_authority: { name: "college van burgemeester en wethouders", type: CATEGORY }`.
+For `CATEGORY` authorities ([RFC-002](/rfcs/rfc-002)), the engine resolves the category against its identity. A municipality (*gemeente*) engine with identity `GM0363` matches `competent_authority: { name: "college van burgemeester en wethouders", type: CATEGORY }`.
 
 ### 2. Engine identity
 
@@ -99,7 +100,7 @@ identity:
   category: "college van burgemeester en wethouders"
 ```
 
-When `type` is `CATEGORY_MEMBER`, the engine matches against any `competent_authority` with `type: CATEGORY` and the same `category` name. This resolves the RFC-002 open question of how categorical authorities work at runtime.
+When `type` is `CATEGORY_MEMBER`, the engine matches against any `competent_authority` with `type: CATEGORY` and the same `category` name. This resolves the [RFC-002](/rfcs/rfc-002) open question of how categorical authorities work at runtime.
 
 With a self-signed identity (the default), the engine runs in **solo simulation** — it executes everything locally, regardless of `competent_authority`.
 
@@ -571,10 +572,10 @@ The data layer — how engines obtain input data, which registries they connect 
 
 ## References
 
-- RFC-002: Authority (*Bevoegdheid*) — defines `competent_authority` at article level
-- RFC-003: Inversion of Control — `open_terms` + `implements` for delegation (unchanged, always execute locally)
-- RFC-007: Cross-Law Execution — hooks and overrides (fire locally, require relevant laws to be loaded)
-- RFC-010: Federated Corpus — rule distribution (how engines obtain laws from multiple sources)
+- [RFC-002](/rfcs/rfc-002): Authority (*Bevoegdheid*) — defines `competent_authority` at article level
+- [RFC-003](/rfcs/rfc-003): Inversion of Control — `open_terms` + `implements` for delegation (unchanged, always execute locally)
+- [RFC-007](/rfcs/rfc-007): Cross-Law Execution — hooks and overrides (fire locally, require relevant laws to be loaded)
+- [RFC-010](/rfcs/rfc-010): Federated Corpus — rule distribution (how engines obtain laws from multiple sources)
 - Court of Audit (*Algemene Rekenkamer*), "Grip op Gegevens" (2019) — problems with inter-org data exchange
 - Parliamentary Committee (*POK*) Report "Unprecedented Injustice" (*Ongekend Onrecht*) (2020) — chain-of-automation failures
 - SyRI ruling (ECLI:NL:RBDHA:2020:865) — transparency and proportionality requirements

--- a/docs/src/content/rfcs/rfc-010.md
+++ b/docs/src/content/rfcs/rfc-010.md
@@ -10,14 +10,14 @@ title: "RFC-010: Federated Corpus"
 
 The corpus (`regulation/nl/`) lives in the regelrecht repo alongside the engine, pipeline, admin, and editor. That works for an MVP, but doesn't match the legislative reality: regulation is decentralized. Municipalities (*gemeenten*), provinces (*provincies*), water boards (*waterschappen*), and ministries each produce their own regulations, often filling in details delegated by higher-level laws.
 
-RFC-003 (Inversion of Control) introduces IoC with `open_terms` and `implements`. This lets a municipality (*gemeente*) fill in a national law without modifying that law. Technically this already works cross-repo, as long as the engine loads all relevant laws. What's missing is the infrastructure for that:
+[RFC-003](/rfcs/rfc-003) (Inversion of Control) introduces IoC with `open_terms` and `implements`. This lets a municipality (*gemeente*) fill in a national law without modifying that law. Technically this already works cross-repo, as long as the engine loads all relevant laws. What's missing is the infrastructure for that:
 
 - **Discovery**: how does the engine find municipal regulations?
 - **Loading**: how does the engine fetch laws from multiple sources?
 - **Scope validation**: how does the engine detect that a source claims to represent a jurisdiction it shouldn't?
 - **Write-back**: how can a municipality (*gemeente*) maintain regulations in their own repo via the editor?
 
-The old delegation approach (originally described in a previous version of RFC-003) has been superseded by RFC-003's IoC mechanism. This RFC builds on RFC-003 by adding the infrastructure for multiple sources, each with their own ownership.
+The old delegation approach (originally described in a previous version of [RFC-003](/rfcs/rfc-003)) has been superseded by [RFC-003](/rfcs/rfc-003)'s IoC mechanism. This RFC builds on [RFC-003](/rfcs/rfc-003) by adding the infrastructure for multiple sources, each with their own ownership.
 
 ## Decision
 
@@ -43,7 +43,7 @@ regulation/nl/
 Each YAML file must:
 - Conform to the regelrecht YAML schema (referenced via `$schema`)
 - Have a `$id` that identifies the law (does not need to be globally unique - see Priority below for conflict resolution when multiple sources provide the same `$id`)
-- Declare `implements` (per RFC-003) when filling in open terms from a higher-level law
+- Declare `implements` (per [RFC-003](/rfcs/rfc-003)) when filling in open terms from a higher-level law
 
 The `path` field in the registry manifest points to the root of this structure within the repo. This allows repos to keep regulations in a subdirectory (e.g. `regulation/nl/`) or at the root.
 
@@ -346,7 +346,7 @@ New endpoints on the admin service:
 
 ### Benefits
 
-- **Fits IoC**: the `implements` mechanism from RFC-003 works cross-repo as long as the laws are loaded. The registry makes that loading explicit and configurable.
+- **Fits IoC**: the `implements` mechanism from [RFC-003](/rfcs/rfc-003) works cross-repo as long as the laws are loaded. The registry makes that loading explicit and configurable.
 - **Decentralized ownership**: municipalities (*gemeenten*), provinces (*provincies*), and water boards (*waterschappen*) manage their regulations in their own repo. No PR to a central repo needed to change a municipal ordinance (*verordening*).
 - **Transparent**: the registry manifest is a YAML file in Git. Anyone who wants to see which sources the engine loads can look at the manifest.
 - **Scope validation as trust boundary**: without complex PKI infrastructure, the engine can validate via scopes that a source doesn't deliver laws outside its jurisdiction.
@@ -418,7 +418,7 @@ Scope validation, schema version compatibility checks, collision reporting, and 
 
 ## References
 
-- RFC-003: Inversion of Control with `open_terms` and `implements`
+- [RFC-003](/rfcs/rfc-003): Inversion of Control with `open_terms` and `implements`
 - GitHub Trees API: `GET /repos/{owner}/{repo}/git/trees/{tree_sha}?recursive=1`
 - GitHub Contents API: `GET /repos/{owner}/{repo}/contents/{path}`, `PUT /repos/{owner}/{repo}/contents/{path}`
 - [Glossary of Dutch Legal Terms](/reference/glossary)

--- a/docs/src/content/rfcs/rfc-011.md
+++ b/docs/src/content/rfcs/rfc-011.md
@@ -17,7 +17,7 @@ This RFC ratifies that choice. The custom YAML language is already in production
 
 This is a different question from [RFC-006](./rfc-006) (*Language Choice for Law Execution Engine*), which chose the engine's *implementation* language (Rust). The question here is the *rules* language in which legislation itself is expressed (RegelRecht YAML), an orthogonal concern.
 
-> **Note on provenance:** This RFC originates as [RFC-001](/rfcs/rfc-001) in `MinBZK/poc-machine-law`. It is renumbered to RFC-011 here to avoid colliding with [RFC-001](./rfc-001) (*YAML Schema Design Decisions*), and retranslated into this repo's house style. The substance of the decision is unchanged. The **Date** above (2025-11-05) is carried over from the original POC RFC; it records when the rules-language choice was first made, not when this renumbered document was written. That is why it predates RFC-000 and the RFCs this one references.
+> **Note on provenance:** This RFC originates as RFC-001 in `MinBZK/poc-machine-law`. It is renumbered to RFC-011 here to avoid colliding with [RFC-001](./rfc-001) (*YAML Schema Design Decisions*), and retranslated into this repo's house style. The substance of the decision is unchanged. The **Date** above (2025-11-05) is carried over from the original POC RFC; it records when the rules-language choice was first made, not when this renumbered document was written. That is why it predates RFC-000 and the RFCs this one references.
 
 ## Decision
 

--- a/docs/src/content/rfcs/rfc-011.md
+++ b/docs/src/content/rfcs/rfc-011.md
@@ -17,7 +17,7 @@ This RFC ratifies that choice. The custom YAML language is already in production
 
 This is a different question from [RFC-006](./rfc-006) (*Language Choice for Law Execution Engine*), which chose the engine's *implementation* language (Rust). The question here is the *rules* language in which legislation itself is expressed (RegelRecht YAML), an orthogonal concern.
 
-> **Note on provenance:** This RFC originates as RFC-001 in `MinBZK/poc-machine-law`. It is renumbered to RFC-011 here to avoid colliding with [RFC-001](./rfc-001) (*YAML Schema Design Decisions*), and retranslated into this repo's house style. The substance of the decision is unchanged.
+> **Note on provenance:** This RFC originates as [RFC-001](/rfcs/rfc-001) in `MinBZK/poc-machine-law`. It is renumbered to RFC-011 here to avoid colliding with [RFC-001](./rfc-001) (*YAML Schema Design Decisions*), and retranslated into this repo's house style. The substance of the decision is unchanged. The **Date** above (2025-11-05) is carried over from the original POC RFC; it records when the rules-language choice was first made, not when this renumbered document was written. That is why it predates RFC-000 and the RFCs this one references.
 
 ## Decision
 

--- a/docs/src/content/rfcs/rfc-013.md
+++ b/docs/src/content/rfcs/rfc-013.md
@@ -56,23 +56,7 @@ supported-schemas = ["v0.5.0", "v0.5.1", "v0.6.0"]
 
 The engine validates at startup that loaded regulations reference a supported schema version. A regulation referencing an unsupported schema version is a hard error; the engine does not silently fall back to serde-only validation.
 
-#### Schema version history
-
-This table is the single source of truth for which schema version introduced
-which construct. Other RFCs that add a construct reference this table rather than
-asserting a version independently. It reflects the published directories under
-`schema/`.
-
-| Version | Introduces | RFC |
-|---------|-----------|-----|
-| v0.2.0  | `regulatory_layer`, `competent_authority`, `execution.produces` (`legal_character`, `decision_type`) | [RFC-001](/rfcs/rfc-001), [RFC-002](/rfcs/rfc-002) |
-| v0.4.0  | `open_terms`, `implements` (IoC); `date` and `array` value types | [RFC-003](/rfcs/rfc-003) |
-| v0.5.0  | `hooks`, `overrides` (reactive execution); `procedure`, `procedure_id` (AWB lifecycle) | [RFC-007](/rfcs/rfc-007), [RFC-008](/rfcs/rfc-008) |
-| v0.5.1  | Refinements within the v0.5.x line | — |
-| v0.5.2  | `annotation-schema.json` for stand-off notes | [RFC-005](/rfcs/rfc-005), [RFC-018](/rfcs/rfc-018) |
-
-Multi-organisation execution ([RFC-009](/rfcs/rfc-009)) reuses `competent_authority`
-(v0.2.0) and adds no schema construct of its own.
+The mapping of which schema version introduced which construct is maintained in the [Schema Reference](/reference/schema#version-history) version history, which is the single source of truth. RFCs that add a construct reference that table rather than asserting a version independently.
 
 ### 2. Execution Receipt
 

--- a/docs/src/content/rfcs/rfc-013.md
+++ b/docs/src/content/rfcs/rfc-013.md
@@ -5,10 +5,11 @@ title: "RFC-013: Execution Provenance"
 **Status:** Draft
 **Date:** 2026-04-02
 **Authors:** Eelco Hotting
+**Depends on:** RFC-009 (Multi-Organisation Execution), RFC-010 (Federated Corpus), RFC-012 (Untranslatables)
 
 ## Context
 
-The engine produces deterministic results: given the same regulation YAML, the same inputs, and the same calculation date, it always produces the same outputs. RFC-006 chose Rust precisely for this guarantee. Determinism within a single execution is not enough. Government agencies must be able to reproduce a specific decision months or years later, with the exact same result.
+The engine produces deterministic results: given the same regulation YAML, the same inputs, and the same calculation date, it always produces the same outputs. [RFC-006](/rfcs/rfc-006) chose Rust precisely for this guarantee. Determinism within a single execution is not enough. Government agencies must be able to reproduce a specific decision months or years later, with the exact same result.
 
 Dutch administrative law requires this:
 
@@ -19,7 +20,7 @@ Dutch administrative law requires this:
 
 Reproducibility requires pinning three things: the regulation YAML, the schema version it conforms to, and the engine version that executed it. Today, the engine stamps none of these on its output. The regulation carries a `$schema` URL, but the engine ignores it at execution time. The engine version exists as a Cargo constant but is not included in results. There is no "decision receipt" that ties inputs, outputs, and versions together.
 
-RFC-009 (Multi-Organisation Execution) adds another dimension: a decision may depend on values accepted from other organisations' engines, each potentially running a different engine version. Reproducing that decision requires knowing which engine *this* organisation ran, and which engine versions produced the accepted values from other organisations.
+[RFC-009](/rfcs/rfc-009) (Multi-Organisation Execution) adds another dimension: a decision may depend on values accepted from other organisations' engines, each potentially running a different engine version. Reproducing that decision requires knowing which engine *this* organisation ran, and which engine versions produced the accepted values from other organisations.
 
 ### The schema is a specification, the engine is an implementation
 
@@ -54,6 +55,24 @@ supported-schemas = ["v0.5.0", "v0.5.1", "v0.6.0"]
 ```
 
 The engine validates at startup that loaded regulations reference a supported schema version. A regulation referencing an unsupported schema version is a hard error; the engine does not silently fall back to serde-only validation.
+
+#### Schema version history
+
+This table is the single source of truth for which schema version introduced
+which construct. Other RFCs that add a construct reference this table rather than
+asserting a version independently. It reflects the published directories under
+`schema/`.
+
+| Version | Introduces | RFC |
+|---------|-----------|-----|
+| v0.2.0  | `regulatory_layer`, `competent_authority`, `execution.produces` (`legal_character`, `decision_type`) | [RFC-001](/rfcs/rfc-001), [RFC-002](/rfcs/rfc-002) |
+| v0.4.0  | `open_terms`, `implements` (IoC); `date` and `array` value types | [RFC-003](/rfcs/rfc-003) |
+| v0.5.0  | `hooks`, `overrides` (reactive execution); `procedure`, `procedure_id` (AWB lifecycle) | [RFC-007](/rfcs/rfc-007), [RFC-008](/rfcs/rfc-008) |
+| v0.5.1  | Refinements within the v0.5.x line | — |
+| v0.5.2  | `annotation-schema.json` for stand-off notes | [RFC-005](/rfcs/rfc-005), [RFC-018](/rfcs/rfc-018) |
+
+Multi-organisation execution ([RFC-009](/rfcs/rfc-009)) reuses `competent_authority`
+(v0.2.0) and adds no schema construct of its own.
 
 ### 2. Execution Receipt
 
@@ -148,20 +167,20 @@ Every execution produces an **Execution Receipt**: an output envelope that conta
 The receipt records:
 
 - Which engine, version, and schema produced the result
-- The **engine configuration**: connectivity mode (solo/federated), legal status (simulation/authoritative), untranslatable mode (RFC-012), and engine identity (RFC-009). These determine execution behavior: whether cross-org calls are made, whether outputs carry legal weight, and how untranslatable constructs are handled
+- The **engine configuration**: connectivity mode (solo/federated), legal status (simulation/authoritative), untranslatable mode ([RFC-012](/rfcs/rfc-012)), and engine identity ([RFC-009](/rfcs/rfc-009)). These determine execution behavior: whether cross-org calls are made, whether outputs carry legal weight, and how untranslatable constructs are handled
 - The **scope**: which corpus sources were loaded (by source id, Git ref, and tree hash), which regulations were loaded (by id, `valid_from`, and content hash), and which jurisdiction scopes were active
 - The calculation date, parameters, and reference date
 - Outputs and trace tree
-- For cross-organisational executions (RFC-009): the provenance of each accepted value, including the other authority's engine version and regulation hash
+- For cross-organisational executions ([RFC-009](/rfcs/rfc-009)): the provenance of each accepted value, including the other authority's engine version and regulation hash
 - When the execution occurred
 
-The `scope` section is what makes the receipt fully reproducible. The engine's output depends on all loaded regulations, not just the one being evaluated. IoC resolution (RFC-003) pulls in implementing regulations. Cross-law references resolve against whatever is loaded. Priority rules (RFC-010) determine which version of a regulation wins when multiple sources provide it. Two engines with different loaded regulations can produce different results for the same parameters.
+The `scope` section is what makes the receipt fully reproducible. The engine's output depends on all loaded regulations, not just the one being evaluated. IoC resolution ([RFC-003](/rfcs/rfc-003)) pulls in implementing regulations. Cross-law references resolve against whatever is loaded. Priority rules ([RFC-010](/rfcs/rfc-010)) determine which version of a regulation wins when multiple sources provide it. Two engines with different loaded regulations can produce different results for the same parameters.
 
 The `loaded_regulations` array lists every regulation the engine had available during execution, each with a SHA-256 content hash. The `sources` array lists each corpus source with its Git ref and tree hash. Together, these allow exact reconstruction of the execution environment.
 
-The `scopes` array records which jurisdiction scopes were active (per RFC-010). An engine running with scope `GM0363` (Amsterdam) loads different municipal regulations than one running with `GM0384` (Diemen), which changes IoC resolution for national laws that delegate to municipal ordinances.
+The `scopes` array records which jurisdiction scopes were active (per [RFC-010](/rfcs/rfc-010)). An engine running with scope `GM0363` (Amsterdam) loads different municipal regulations than one running with `GM0384` (Diemen), which changes IoC resolution for national laws that delegate to municipal ordinances.
 
-The `accepted_values` section captures the cross-organisational provenance chain. When engine A accepts a value from engine B, A records B's provenance metadata. To reproduce the full execution, you need A's receipt (which tells you B's engine version and regulation hash) and B's receipt (which B stores in its own Logboek Dataverwerkingen per RFC-009).
+The `accepted_values` section captures the cross-organisational provenance chain. When engine A accepts a value from engine B, A records B's provenance metadata. To reproduce the full execution, you need A's receipt (which tells you B's engine version and regulation hash) and B's receipt (which B stores in its own Logboek Dataverwerkingen per [RFC-009](/rfcs/rfc-009)).
 
 ### 3. Schema URL immutability
 
@@ -185,11 +204,11 @@ The engine embeds schema files at compile time (via `include_str!` in `validate.
 
 ### 4. Multi-organisation reproducibility
 
-RFC-009 defines two resolution modes: **Execute** (compute locally) and **Accept** (take another organisation's authoritative determination). For reproducibility, the Accept path must capture enough provenance to reconstruct the full decision chain.
+[RFC-009](/rfcs/rfc-009) defines two resolution modes: **Execute** (compute locally) and **Accept** (take another organisation's authoritative determination). For reproducibility, the Accept path must capture enough provenance to reconstruct the full decision chain.
 
 #### Inter-engine protocol versioning
 
-The inter-engine protocol (RFC-009 §5) is a public API contract between organisations. It must be versioned independently from the engine. An explicit `api_version` field in every request and response lets organisations running different engine versions communicate:
+The inter-engine protocol ([RFC-009](/rfcs/rfc-009) §5) is a public API contract between organisations. It must be versioned independently from the engine. An explicit `api_version` field in every request and response lets organisations running different engine versions communicate:
 
 ```json
 {
@@ -207,7 +226,7 @@ Value representation on the wire is pinned: currency values are integers in cent
 
 #### Extended provenance in the inter-engine response
 
-This RFC extends the RFC-009 §5 response with engine provenance:
+This RFC extends the [RFC-009](/rfcs/rfc-009) §5 response with engine provenance:
 
 ```json
 {
@@ -345,7 +364,7 @@ See [RFC-007](/rfcs/rfc-007#output-provenance) for the hook provenance model.
 **Phase 1: Execution Receipt and engine version stamping**
 - Add `engine_version` (from `CARGO_PKG_VERSION`) and `schema_version` (from the regulation's `$schema` field) to `ArticleResult`
 - Add `regulation_hash` (SHA-256 of YAML content) to `ArticleResult`
-- Extend the inter-engine protocol response (RFC-009 §5) with `engine_version`, `schema_version`, `regulation_hash`, `has_upstream_accepts`, and `api_version`
+- Extend the inter-engine protocol response ([RFC-009](/rfcs/rfc-009) §5) with `engine_version`, `schema_version`, `regulation_hash`, `has_upstream_accepts`, and `api_version`
 - Define the `ExecutionReceipt` struct as the top-level output envelope
 - Add replay mode: engine can re-execute from sealed accepted values in a receipt
 
@@ -355,7 +374,7 @@ See [RFC-007](/rfcs/rfc-007#output-provenance) for the hook provenance model.
 - Error on unknown schema versions in `validate.rs` (fix the current silent fallback)
 - Migrate corpus `$schema` URLs from `refs/heads/main` to `refs/tags/schema-vX.Y.Z`
 - Create `schema-vX.Y.Z` Git tags for all published schema versions
-- Update `schema/latest` symlink (currently stale: points to v0.5.0, should be v0.5.1)
+- Keep the `schema/latest` symlink pointing at the highest released schema version (currently v0.5.2)
 
 **Phase 3: CI enforcement**
 - CI check: engine source changes require version bump (compare `Cargo.toml` version between PR and main)
@@ -377,7 +396,7 @@ See [RFC-007](/rfcs/rfc-007#output-provenance) for the hook provenance model.
 | `packages/engine/Cargo.toml` | `supported-schemas` metadata, version bump |
 | `packages/shared/src/provenance.rs` | New: `ExecutionReceipt`, `ExecutionReceiptProvenance` types |
 | `corpus/regulation/**/*.yaml` | `$schema` URL migration to tag-based refs |
-| `schema/latest` | Fix symlink: v0.5.0 to v0.5.1 |
+| `schema/latest` | Symlink tracks the highest released schema version (now v0.5.2) |
 | `.github/workflows/ci.yml` | Version bump check, schema registration check, `--locked` |
 | `rust-toolchain.toml` | New: pinned Rust toolchain version |
 

--- a/docs/src/content/rfcs/rfc-014.md
+++ b/docs/src/content/rfcs/rfc-014.md
@@ -5,18 +5,19 @@ title: "RFC-014: Engine Conformance Test Suite"
 **Status:** Draft
 **Date:** 2026-04-02
 **Authors:** Eelco Hotting
+**Depends on:** RFC-013 (Execution Provenance)
 
 ## Context
 
-RFC-013 establishes that the schema is a specification and the engine is an implementation. Independent versioning allows third-party organisations to build their own engine. Without a shared behavioral contract, though, two engines claiming to support schema v0.5.1 might produce different outputs for identical inputs, with no way to determine which is correct.
+[RFC-013](/rfcs/rfc-013) establishes that the schema is a specification and the engine is an implementation. Independent versioning allows third-party organisations to build their own engine. Without a shared behavioral contract, though, two engines claiming to support schema v0.5.1 might produce different outputs for identical inputs, with no way to determine which is correct.
 
 Today, the regelrecht engine's correctness is verified through BDD tests (`features/*.feature`) using cucumber-rs. These are Rust-specific. A third-party Java or Python engine cannot run them. The tests verify integration behavior (loading regulations from the corpus, resolving cross-law references), not isolated schema-level operations. There is no artifact that says "if your engine supports schema v0.5.1, these are the exact inputs and outputs it must produce."
 
 Three things depend on this:
 
-1. **Multi-org execution (RFC-009)**: when Org A accepts a value from Org B's engine, both engines must agree on what the law means. If they disagree, one has a bug. The conformance suite defines "correct."
+1. **Multi-org execution ([RFC-009](/rfcs/rfc-009))**: when Org A accepts a value from Org B's engine, both engines must agree on what the law means. If they disagree, one has a bug. The conformance suite defines "correct."
 
-2. **Reproducibility (RFC-013)**: an Execution Receipt records which engine version produced a result. If a different engine (or engine version) re-executes the same regulation with the same inputs, it must produce the same outputs. The conformance suite makes this testable.
+2. **Reproducibility ([RFC-013](/rfcs/rfc-013))**: an Execution Receipt records which engine version produced a result. If a different engine (or engine version) re-executes the same regulation with the same inputs, it must produce the same outputs. The conformance suite makes this testable.
 
 3. **Schema as execution specification**: without conformance tests, the schema only validates structure (does the YAML have the right fields?). It does not specify computation (what should the engine produce?). The conformance suite encodes the intended semantics of each operation.
 
@@ -167,13 +168,13 @@ Tests are tagged with a conformance level. An engine declares which levels it su
 |-------|-------|--------------------|
 | **Core** | Single-article evaluation with basic operations | ADD, SUBTRACT, MULTIPLY, DIVIDE, EQUALS, GREATER_THAN, LESS_THAN, GREATER_THAN_OR_EQUAL, LESS_THAN_OR_EQUAL, AND, OR, NOT, IF, IN, LIST, MAX, MIN |
 | **Cross-law** | Multi-regulation evaluation with source references | All Core operations + `source.regulation` resolution, parameter passing |
-| **IoC** | Delegated legislation via open terms | All Cross-law operations + `open_terms`, `implements` (RFC-003) |
+| **IoC** | Delegated legislation via open terms | All Cross-law operations + `open_terms`, `implements` ([RFC-003](/rfcs/rfc-003)) |
 | **Temporal** | Date operations and multi-version law selection | All Core operations + AGE, DATE_ADD, DATE, DAY_OF_WEEK, `valid_from` filtering, `reference_date` |
-| **Advanced** | Full engine features | All above + hooks (RFC-007), overrides, procedures (RFC-008), untranslatables (RFC-012), data sources |
+| **Advanced** | Full engine features | All above + hooks ([RFC-007](/rfcs/rfc-007)), overrides, procedures ([RFC-008](/rfcs/rfc-008)), untranslatables ([RFC-012](/rfcs/rfc-012)), data sources |
 
-Each level includes all operations from previous levels. A Core-level engine can execute simple single-law computations. An Advanced-level engine can participate in the full multi-org execution model (RFC-009).
+Each level includes all operations from previous levels. A Core-level engine can execute simple single-law computations. An Advanced-level engine can participate in the full multi-org execution model ([RFC-009](/rfcs/rfc-009)).
 
-Note: the engine's ADD operation handles numeric addition, array concatenation, and string concatenation. String concatenation tests are in `arithmetic.json` alongside numeric ADD tests. Rounding operations (ROUND, CEIL, FLOOR) are not in the operation set yet (RFC-012 lists rounding as an untranslatable). When added, they join the Core level and get their own conformance tests.
+Note: the engine's ADD operation handles numeric addition, array concatenation, and string concatenation. String concatenation tests are in `arithmetic.json` alongside numeric ADD tests. Rounding operations (ROUND, CEIL, FLOOR) are not in the operation set yet ([RFC-012](/rfcs/rfc-012) lists rounding as an untranslatable). When added, they join the Core level and get their own conformance tests.
 
 The manifest file declares the level structure. Each level lists its test files and which operations it covers:
 
@@ -215,9 +216,9 @@ A separate unit test in `types.rs` verifies that `SCHEMA_OPERATIONS` + `COMPAT_A
 
 The chain of invariants: add an `Operation` variant → compiler forces a `name()` match arm → unit test forces adding it to `SCHEMA_OPERATIONS` or `COMPAT_ALIASES` → integration test forces adding schema operations to a conformance level in the manifest.
 
-### 5. Provenance conformance (RFC-013 integration)
+### 5. Provenance conformance ([RFC-013](/rfcs/rfc-013) integration)
 
-A dedicated `provenance.json` verifies that the engine produces correct Execution Receipts (RFC-013):
+A dedicated `provenance.json` verifies that the engine produces correct Execution Receipts ([RFC-013](/rfcs/rfc-013)):
 
 - Output includes `engine_version` field
 - Output includes `schema_version` matching the regulation's `$schema`
@@ -253,7 +254,7 @@ A new CI job `conformance` runs alongside the existing `test` job. It uses the `
 
 - Any organisation can build an engine and prove it behaves correctly by running the conformance suite. No Rust toolchain required.
 - The schema specifies structure; the conformance suite specifies what each operation *does*. Together they are the complete specification.
-- If an engine change causes a conformance test to fail, it is a behavioral change that must be intentional and versioned (per RFC-013).
+- If an engine change causes a conformance test to fail, it is a behavioral change that must be intentional and versioned (per [RFC-013](/rfcs/rfc-013)).
 - Third-party engines can start at Core level and work up. They do not need the full operation set to be useful for simple law evaluation.
 - The test format is plain JSON. A test runner is around 50 lines in any language.
 
@@ -293,7 +294,7 @@ A new CI job `conformance` runs alongside the existing `test` job. It uses the `
 
 **Phase 3: Advanced level and provenance**
 - Add tests for hooks, overrides, untranslatables, procedures
-- Add `provenance.json` testing Execution Receipt fields (RFC-013)
+- Add `provenance.json` testing Execution Receipt fields ([RFC-013](/rfcs/rfc-013))
 - Publish the suite as a standalone downloadable artifact (GitHub Release or npm package)
 
 **Phase 4: Documentation and third-party guide**

--- a/docs/src/content/rfcs/rfc-015.md
+++ b/docs/src/content/rfcs/rfc-015.md
@@ -5,10 +5,11 @@ title: "RFC-015: Engine Policy"
 **Status:** Proposed
 **Date:** 2026-04-04
 **Authors:** Eelco Hotting
+**Depends on:** RFC-007 (Cross-Law Execution), RFC-009 (Multi-Organisation Execution), RFC-013 (Execution Provenance)
 
 ## Context
 
-The engine's founding principle is **zero built-in domain knowledge** (RFC-007): all legal and domain knowledge comes from law YAML files and parameters. The engine provides pure operations (arithmetic, comparison, date math) and a resolution framework. It does not know about Easter, King's Day, public holidays, tax rates, or government structure.
+The engine's founding principle is **zero built-in domain knowledge** ([RFC-007](/rfcs/rfc-007)): all legal and domain knowledge comes from law YAML files and parameters. The engine provides pure operations (arithmetic, comparison, date math) and a resolution framework. It does not know about Easter, King's Day, public holidays, tax rates, or government structure.
 
 The engine does need certain knowledge to function that no specific law declares: the regulatory layer hierarchy (constitutional doctrine), territorial scoping dimensions (gemeente_code, provincie_code), type coercion rules (eurocent rounding), and delegation validation rules. This is the meta-knowledge *about* how to process law, distinct from the law itself. It belongs in configuration, separate from both the corpus where real law lives and the engine binary.
 
@@ -109,7 +110,7 @@ The `extends` field references the base policy. The engine loads the base first,
 
 ### 3. Policy in the Execution Receipt
 
-The active Engine Policy (after overlay resolution) is recorded in the Execution Receipt (RFC-013). A reviewer can see which hierarchy, coercion rules, and scope dimensions were active for any given decision.
+The active Engine Policy (after overlay resolution) is recorded in the Execution Receipt ([RFC-013](/rfcs/rfc-013)). A reviewer can see which hierarchy, coercion rules, and scope dimensions were active for any given decision.
 
 ```json
 {
@@ -132,7 +133,7 @@ Pure operations stay in the engine. The line is:
 - **In the engine:** arithmetic, comparison, logical, date, and aggregate operations. Pure math, no legal meaning.
 - **In the policy:** anything that requires knowledge of the Dutch legal system, government structure, or financial conventions.
 
-Date arithmetic (RFC-007) stays in the engine. The clamping rule (Jan 31 + 1 month = Feb 28) is standard calendar math confirmed by the Hoge Raad (HR 1 September 2017, ECLI:NL:HR:2017:2225). Age calculation stays. Day-of-week numbering stays (ISO 8601). These are the same in any jurisdiction.
+Date arithmetic ([RFC-007](/rfcs/rfc-007)) stays in the engine. The clamping rule (Jan 31 + 1 month = Feb 28) is standard calendar math confirmed by the Hoge Raad (HR 1 September 2017, ECLI:NL:HR:2017:2225). Age calculation stays. Day-of-week numbering stays (ISO 8601). These are the same in any jurisdiction.
 
 ## Why
 
@@ -166,7 +167,7 @@ Policy lookups (layer rank, scope matching) must be fast. The current hardcoded 
 
 **Alternative 3: Rust configuration file (TOML/JSON) without overlay**
 - Single configuration file, no organization-level override.
-- Rejected: the multi-organization model (RFC-009) requires per-org customization. A single policy file forces all organizations to agree on every rule.
+- Rejected: the multi-organization model ([RFC-009](/rfcs/rfc-009)) requires per-org customization. A single policy file forces all organizations to agree on every rule.
 
 **Alternative 4: Deep merge for overrides**
 - Organization policies merge at the field level rather than section level.

--- a/docs/src/content/rfcs/rfc-018.md
+++ b/docs/src/content/rfcs/rfc-018.md
@@ -5,6 +5,7 @@ title: "RFC-018: Note Infrastructure: Storage, Resolution, and Editor Integratio
 **Status:** Accepted
 **Date:** 2026-05-18
 **Authors:** Anne Schuth
+**Depends on:** RFC-005 (Stand-off Notes), RFC-009 (Multi-Organisation Execution), RFC-010 (Federated Corpus)
 
 ## Terminology
 
@@ -15,13 +16,13 @@ where it refers to the data model itself. "Annotation" as a Dutch legal genre
 
 ## Context
 
-RFC-005 defines the note *format*: the W3C Web Annotation Data Model with
+[RFC-005](/rfcs/rfc-005) defines the note *format*: the W3C Web Annotation Data Model with
 TextQuoteSelector for version-resilient text anchoring. It specifies what a note
 looks like (selector, motivation, body, resolution states) but is explicitly
 storage-agnostic. It does not say where notes live, how they are loaded, who
 creates them, or how they are displayed.
 
-This RFC addresses the implementation questions RFC-005 leaves open. They map
+This RFC addresses the implementation questions [RFC-005](/rfcs/rfc-005) leaves open. They map
 directly onto the open design questions raised in interpretation discussions:
 
 1. **Working notes**: needed for the editor to bridge the gap between law text
@@ -82,7 +83,7 @@ Ten interconnected decisions form the note infrastructure.
 ### 1. Storage: Sidecar YAML files
 
 Notes are stored in separate YAML files alongside law files, not embedded in the
-law YAML. This preserves the verbatim legal text (RFC-005 requirement: notes must
+law YAML. This preserves the verbatim legal text ([RFC-005](/rfcs/rfc-005) requirement: notes must
 not modify the source) and enables independent versioning.
 
 **Directory convention:**
@@ -113,7 +114,7 @@ The `$id` is the stable identifier laws reference each other by.
 
 The directory is named `annotations/` (not `notes/`) because it stores W3C
 `Annotation` objects; the storage path follows the data model, the feature name
-follows RFC-005.
+follows [RFC-005](/rfcs/rfc-005).
 
 **Discovery:** convention-based. Given a law with `$id: zorgtoeslagwet`, the
 engine looks for notes at `corpus/annotations/zorgtoeslagwet/annotations.yaml`. No
@@ -126,7 +127,7 @@ validated by `just validate-annotations`.
 
 ```yaml
 # corpus/annotations/zorgtoeslagwet/annotations.yaml
-$schema: "https://raw.githubusercontent.com/MinBZK/regelrecht/refs/heads/main/schema/v0.5.2/annotation-schema.json"
+$schema: "https://raw.githubusercontent.com/MinBZK/regelrecht/refs/tags/schema-v0.5.2/schema/v0.5.2/annotation-schema.json"
 annotations:
   - type: Annotation
     motivation: linking
@@ -147,7 +148,7 @@ annotations:
             end: 152
     body:
       type: SpecificResource
-      source: "regelrecht://zorgtoeslagwet/hoogte_zorgtoeslag#hoogte_zorgtoeslag"
+      source: "regelrecht://zorgtoeslagwet/hoogte_zorgtoeslag"
       purpose: linking
     resolution: found
     workflow: resolved
@@ -155,7 +156,7 @@ annotations:
 
 ### 2. Federated note sources
 
-Notes follow the same "bring your own" pattern as laws in RFC-010. Any
+Notes follow the same "bring your own" pattern as laws in [RFC-010](/rfcs/rfc-010). Any
 organisation can maintain notes in their own repository, alongside their
 regulations or in a dedicated note repository.
 
@@ -167,7 +168,7 @@ annotations/
     annotations.yaml
 ```
 
-When a source in `corpus-registry.yaml` (RFC-010) includes an `annotations/`
+When a source in `corpus-registry.yaml` ([RFC-010](/rfcs/rfc-010)) includes an `annotations/`
 directory, the engine discovers and loads those notes alongside the source's
 regulations.
 
@@ -192,7 +193,7 @@ check, or add a comment explaining how Amsterdam interprets a provision in the
 context of their municipal social assistance (*bijstand*) policy.
 
 **Personal notes:** a `.local.annotations.yaml` file (gitignored) follows the
-RFC-010 `.local.yaml` override pattern. Personal notes are loaded alongside public
+[RFC-010](/rfcs/rfc-010) `.local.yaml` override pattern. Personal notes are loaded alongside public
 notes but not committed.
 
 **Loading order:** the engine loads notes from all registered sources. Notes from
@@ -212,7 +213,7 @@ law determines the note's authority level.
 | Automated tooling | Generated | Generated (*gegenereerd*) | LLM-produced linking note |
 
 The authority level is **derived at display time**, not stored. It follows the
-same principle as RFC-009's execute/accept boundary: the law determines authority,
+same principle as [RFC-009](/rfcs/rfc-009)'s execute/accept boundary: the law determines authority,
 the engine derives behaviour.
 
 **Derivation logic:**
@@ -230,7 +231,7 @@ Is the note's creator the competent_authority for the target law?
 ```
 
 For the MVP, `creator` is a string field (e.g., `"Dienst Toeslagen"`,
-`"LLM-generated"`, `"J. de Vries"`). When RFC-009's identity model
+`"LLM-generated"`, `"J. de Vries"`). When [RFC-009](/rfcs/rfc-009)'s identity model
 (`EngineIdentity` with OIN) is implemented, `creator` can carry a structured
 identity with signature verification. The schema accommodates both:
 
@@ -284,13 +285,16 @@ auditable.
       suffix: ". Voor een verzekerde met een toeslagpartner"
   body:
     type: SpecificResource
-    source: "regelrecht://zorgtoeslagwet/hoogte_zorgtoeslag#hoogte_zorgtoeslag"
+    source: "regelrecht://zorgtoeslagwet/hoogte_zorgtoeslag"
     purpose: linking
 ```
 
 The `body.source` uses a `regelrecht://` URI (as defined in
-`packages/engine/src/uri.rs`) pointing to the specific execution element. The
-fragment (`#hoogte_zorgtoeslag`) identifies the output name.
+`packages/engine/src/uri.rs`, grammar `regelrecht://{law_id}/{output}#{field}`)
+pointing to the specific execution element. The path segment after the law id
+(`hoogte_zorgtoeslag`) names the output. An optional `#{field}` fragment extracts
+a single field from that output (for example `#value`); omit it to target the
+whole output, as here.
 
 #### Commenting (*toelichting*)
 
@@ -375,7 +379,7 @@ partially filled", "open norm not yet filled", "needs explanation by
 implementation policy", "document still being searched for"); the set will grow as
 the interpretation process matures. Freezing it into a validated schema enum would
 mean every new state is a schema version bump plus a migration of existing note
-files plus an RFC amendment. That is exactly the brittleness RFC-005 avoids for
+files plus an RFC amendment. That is exactly the brittleness [RFC-005](/rfcs/rfc-005) avoids for
 text anchoring; we avoid it here too.
 
 **Model.** Ambiguity is expressed with the existing W3C dimensions, no schema
@@ -579,7 +583,7 @@ a `workflow: resolved` variant.
 ### 8. Conflict resolution and layering
 
 Notes from different sources **layer**: they do not conflict. This is
-fundamentally different from laws, where RFC-010 uses priority to resolve `$id`
+fundamentally different from laws, where [RFC-010](/rfcs/rfc-010) uses priority to resolve `$id`
 collisions. Two organisations can both annotate the same text fragment; both notes
 are valid and visible.
 
@@ -807,16 +811,16 @@ The right pane's segmented control gains a third option, labelled **Notities**:
   timestamp, and diff. `git blame` shows who added each note and when.
 
 - **Sidecar files preserve verbatim legal text.** The law YAML is never modified
-  (RFC-005 requirement). Essential for legal integrity: the source must be
+  ([RFC-005](/rfcs/rfc-005) requirement). Essential for legal integrity: the source must be
   identical to the official publication.
 
 - **Federated model lets every org bring their own notes.** A municipality can
   annotate national laws from their perspective without touching the central
-  corpus. This mirrors RFC-010.
+  corpus. This mirrors [RFC-010](/rfcs/rfc-010).
 
 - **Authority model reflects legal reality.** The competent authority's
   interpretation carries more weight, as in administrative law. Authority is
-  derived from existing schema fields (`competent_authority`), following RFC-009.
+  derived from existing schema fields (`competent_authority`), following [RFC-009](/rfcs/rfc-009).
 
 - **Linking notes make interpretation auditable.** Every connection between text
   and `machine_readable` logic is an explicit, reviewable note. This supports the
@@ -850,7 +854,7 @@ The right pane's segmented control gains a third option, labelled **Notities**:
 
 - **Authority derivation requires `competent_authority` in the law.** Laws without
   a declared `competent_authority` cannot distinguish authoritative from advisory
-  notes. This is an existing gap (RFC-009 also depends on it).
+  notes. This is an existing gap ([RFC-009](/rfcs/rfc-009) also depends on it).
 
 - **Tag vocabulary is soft-validated.** A typo in a tagging value produces a
   warning, not a hard failure. Deliberate: it keeps the vocabulary growable
@@ -859,7 +863,7 @@ The right pane's segmented control gains a third option, labelled **Notities**:
 ### Alternatives Considered
 
 **Notes inside law YAML.** Embed an `annotations` array in the law file. Rejected:
-modifies the verbatim source (RFC-005 forbids this) and creates noisy Git diffs
+modifies the verbatim source ([RFC-005](/rfcs/rfc-005) forbids this) and creates noisy Git diffs
 where note changes obscure law changes.
 
 **Database storage.** Store notes in PostgreSQL (the pipeline already uses it).
@@ -873,7 +877,7 @@ CI validation; a separate JS implementation would diverge. WASM compiles the sam
 Rust code for the browser.
 
 **Centralised note authority.** Designate one organisation as the note authority
-per law. Rejected: does not match RFC-010's federated model or RFC-009's multi-org
+per law. Rejected: does not match [RFC-010](/rfcs/rfc-010)'s federated model or [RFC-009](/rfcs/rfc-009)'s multi-org
 reality. The layering model accommodates multiple legitimate annotators.
 
 **Dedicated `regelrecht:ambiguity` enum field.** Add a validated enum to the
@@ -887,7 +891,7 @@ detection without forking the W3C model.
 Implementation is planned in six phases, each delivering a working whole.
 
 **Phase 0: RFC review**
-RFC-005 and this RFC accepted and merged before code lands.
+[RFC-005](/rfcs/rfc-005) and this RFC accepted and merged before code lands.
 
 **Phase 1: Rust resolver + BDD tests**
 Implement the `annotation` module (`types.rs`, `resolver.rs`). Port the 8 BDD

--- a/docs/src/content/rfcs/template.md
+++ b/docs/src/content/rfcs/template.md
@@ -5,6 +5,7 @@ title: "RFC-NNN: Title"
 **Status:** Proposed
 **Date:** YYYY-MM-DD
 **Authors:** Your Name
+**Depends on:** RFC-NNN, RFC-MMM (optional; omit this line if the RFC has no hard dependencies)
 
 ## Context
 


### PR DESCRIPTION
## Wat

Een opschoning van alle RFCs: losse RFC-vermeldingen worden echte links, en een reeks inhoudelijke inconsistenties tussen de RFCs is rechtgezet.

## Links tussen RFCs

Bare `RFC-NNN`-vermeldingen in de tekst zijn omgezet naar links (`/rfcs/rfc-NNN`). Bewuste uitzonderingen blijven platte tekst:

- `RFC-016`/`RFC-017` hebben geen pagina (zouden gebroken links worden).
- De nummerhistorie in RFC-018 (over welk nummer dit RFC eerder droeg) verwijst niet naar de echte pagina's.
- "Originates as RFC-001 in `MinBZK/poc-machine-law`" in RFC-011 verwijst naar de RFC-001 van een andere repo, niet die van deze repo.

## Inhoudelijke inconsistenties

| RFC | Wijziging |
|-----|-----------|
| RFC-006 | Datum `2025-01-26` → `2026-01-26` (lag tien maanden vóór RFC-000). |
| RFC-011 | Datum `2025-11-05` behouden; toelichting toegevoegd dat die is overgenomen uit de oorspronkelijke `poc-machine-law`-RFC en dus vóór RFC-000 valt. |
| Schema Reference + RFC-013 | **Schema-versietabel** is nu de enige bron van waarheid voor welke schemaversie welk construct introduceert. De tabel staat op de [Schema Reference](https://docs.regelrecht.rijks.app/reference/schema#version-history) (waar al een Version History stond), bijgewerkt naar v0.5.2 en uitgebreid met per-versie constructs en RFC-verwijzingen. RFC-013 en RFC-008 verwijzen ernaar i.p.v. zelf een versie te claimen. |
| RFC-013 | Verouderde claim over de `schema/latest`-symlink hersteld (v0.5.0 → v0.5.2). |
| RFC-008 | Noemt schema v0.5.0 expliciet i.p.v. "v0.5.0 of later". |
| RFC-001 | `KONINKLIJK_BESLUIT` toegevoegd aan de `regulatory_layer`-opsomming. |
| RFC-018 + corpus | `regelrecht://`-URI volgt nu de engine-grammatica uit `packages/engine/src/uri.rs` (`{law_id}/{output}#{field}`): het fragment is een veld, niet de outputnaam. |
| RFC-018 + corpus | Annotation-`$schema`-URL naar `refs/tags/schema-v0.5.2` (immutable tag i.p.v. `refs/heads/main`), conform RFC-013. |
| Template + RFC-009/013/014/015/018 | `Depends on:`-veld gestandaardiseerd (platte tekst, zodat de preamble-render klopt). RFC-008 had het al. |
| RFC-000 + index.md | Verouderd pad `docs/rfcs/` → `docs/src/content/rfcs/`. |

## ⚠️ Actie vereist vóór merge naar main

De annotation-`$schema` wijst nu naar `refs/tags/schema-v0.5.2`, maar die tag bestaat nog niet (tags lopen tot `schema-v0.5.1`). Cut de tag vóór dit landt, anders is de URL dood:

```
git tag schema-v0.5.2 && git push origin schema-v0.5.2
```

## Niet meegenomen

De voorbeeld-URI in de `description` van `schema/v0.5.2/annotation-schema.json` heeft dezelfde verwarring, maar die schemaversie is bevroren op main (CI `protect-schema`). Die nit gaat mee met de volgende schemaversie.

## Validatie

- `just validate-annotations` slaagt met de gewijzigde URI en `$schema`.
- Alle tabellen en code-fences gecontroleerd op rendering; alle preambles parsen nog voor de sidebar/index.
- pre-commit hooks (yamllint, trailing-whitespace) groen.