### PR TITLE
docs: volledige correctiepass over documentatie (rendering, links, code-conformiteit, taal)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Machine-readable Dutch law execution. regelrecht takes legal texts, encodes them
 | Directory | Description |
 |-----------|-------------|
 | [corpus/regulation/](corpus/regulation/) | Dutch regulations in machine-readable YAML |
-| [schema/](schema/) | Versioned JSON schema for the law format (current: v0.5.1) |
+| [schema/](schema/) | Versioned JSON schema for the law format (current: v0.5.2) |
 | [features/](features/) | Gherkin BDD scenarios for law execution |
 | [packages/grafana/](packages/grafana/) | Grafana monitoring dashboards |
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -1,6 +1,7 @@
 import { defineConfig } from 'astro/config';
 import mdx from '@astrojs/mdx';
 import pagefind from 'astro-pagefind';
+import remarkGfm from 'remark-gfm';
 import rehypeMermaid from 'rehype-mermaid';
 import { rehypeMermaidAlt } from './src/lib/rehype-mermaid-alt.ts';
 import { rehypeNlddCodeViewer } from './src/lib/rehype-nldd-code-viewer.ts';
@@ -37,6 +38,12 @@ export default defineConfig({
     // ```mermaid blocks as real <pre><code class="language-mermaid"> for
     // rehype-mermaid (it skips them via the language check).
     syntaxHighlight: false,
+    // GFM tables (and the rest of GitHub-flavored markdown) parse into real
+    // <table> nodes that nldd-rich-text then styles. Astro enables gfm for
+    // plain .md by default, but @astrojs/mdx does not pick it up, so without
+    // this an MDX page renders a pipe table as raw text. Listing remark-gfm
+    // explicitly here covers both .md and .mdx (MDX extends markdown config).
+    remarkPlugins: [remarkGfm],
     // inline-svg renders the diagram as an inline <svg> in the DOM (not an
     // <img>), so its colours can be themed with CSS and follow the .dark
     // toggle. Mermaid's `base` theme with neutral themeVariables hands the

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -12,7 +12,8 @@
         "@nldd/design-system": "^0.8.52",
         "astro": "^6.4.2",
         "astro-pagefind": "^2.0.0",
-        "rehype-mermaid": "^3"
+        "rehype-mermaid": "^3",
+        "remark-gfm": "^4"
       },
       "devDependencies": {
         "pa11y-ci": "^4.1.1",

--- a/docs/package.json
+++ b/docs/package.json
@@ -7,14 +7,15 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "a11y": "astro build && node scripts/check-mermaid-alt.mjs && node scripts/check-heading-order.mjs && node scripts/gen-pa11yci.mjs && start-server-and-test 'astro preview --port 4173' http://localhost:4173 'pa11y-ci'"
+    "a11y": "astro build && node scripts/check-mermaid-alt.mjs && node scripts/check-heading-order.mjs && node scripts/check-links.mjs && node scripts/gen-pa11yci.mjs && start-server-and-test 'astro preview --port 4173' http://localhost:4173 'pa11y-ci'"
   },
   "dependencies": {
     "@astrojs/mdx": "^5",
     "@nldd/design-system": "^0.8.52",
     "astro": "^6.4.2",
     "astro-pagefind": "^2.0.0",
-    "rehype-mermaid": "^3"
+    "rehype-mermaid": "^3",
+    "remark-gfm": "^4"
   },
   "devDependencies": {
     "pa11y-ci": "^4.1.1",

--- a/docs/scripts/check-links.mjs
+++ b/docs/scripts/check-links.mjs
@@ -29,6 +29,7 @@ function walk(dir) {
 const files = walk(DIST);
 const pageIds = new Map(); // route (no trailing slash, no .html) -> Set<id>
 const routes = new Set();
+const htmlByFile = new Map(); // read each file once, reuse for the link scan below
 
 function routeFor(file) {
   let r = '/' + relative(DIST, file).replace(/\\/g, '/');
@@ -39,6 +40,7 @@ function routeFor(file) {
 
 for (const f of files) {
   const html = readFileSync(f, 'utf8');
+  htmlByFile.set(f, html);
   const route = routeFor(f);
   routes.add(route);
   const ids = new Set();
@@ -56,8 +58,11 @@ const problems = [];
 const externalHosts = new Set();
 
 for (const f of files) {
-  const html = readFileSync(f, 'utf8');
+  const html = htmlByFile.get(f);
   const fromRoute = routeFor(f);
+  // Only matches double-quoted hrefs. Astro's built HTML always double-quotes
+  // attributes, so single-quoted/unquoted hrefs do not occur here; if that ever
+  // changes this regex would silently skip them.
   for (const m of html.matchAll(/<a\b[^>]*\shref="([^"]+)"/g)) {
     let href = m[1].trim();
     if (!href) continue;

--- a/docs/scripts/check-links.mjs
+++ b/docs/scripts/check-links.mjs
@@ -25,18 +25,24 @@ function walk(dir) {
   return out;
 }
 
-// Map every URL path the site serves -> set of element ids on that page.
-const files = walk(DIST);
-const pageIds = new Map(); // route (no trailing slash, no .html) -> Set<id>
-const routes = new Set();
-const htmlByFile = new Map(); // read each file once, reuse for the link scan below
-
 function routeFor(file) {
   let r = '/' + relative(DIST, file).replace(/\\/g, '/');
   r = r.replace(/index\.html$/, '').replace(/\.html$/, '');
   if (r.length > 1 && r.endsWith('/')) r = r.slice(0, -1);
   return r === '' ? '/' : r;
 }
+
+function normalize(route) {
+  if (route.length > 1 && route.endsWith('/')) route = route.slice(0, -1);
+  return route === '' ? '/' : route;
+}
+
+// First pass: read each file once, record the route it serves and the set of
+// element ids on it. Cache the HTML so the link scan below does not re-read.
+const files = walk(DIST);
+const pageIds = new Map(); // route (no trailing slash, no .html) -> Set<id>
+const routes = new Set();
+const htmlByFile = new Map();
 
 for (const f of files) {
   const html = readFileSync(f, 'utf8');
@@ -49,11 +55,7 @@ for (const f of files) {
   pageIds.set(route, ids);
 }
 
-function normalize(route) {
-  if (route.length > 1 && route.endsWith('/')) route = route.slice(0, -1);
-  return route === '' ? '/' : route;
-}
-
+// Second pass: scan every <a href> and verify it resolves.
 const problems = [];
 const externalHosts = new Set();
 
@@ -90,10 +92,9 @@ for (const f of files) {
       // The page is served at <route> with NO trailing slash (nginx try_files
       // serves <route>/index.html for the slash-less URL, no redirect). So a
       // browser resolves "./x" relative to the slash-less URL: it replaces the
-      // last segment. Model exactly that — base is the route itself, not the
+      // last segment. Model exactly that: base is the route itself, not the
       // route + "/". This matches what a user navigating via the slash-less
-      // nav links actually experiences. We also record whether the SAME link
-      // would break had the user arrived on the trailing-slash variant.
+      // nav links actually experiences.
       target = new URL(path, 'http://x' + fromRoute).pathname;
     }
     target = normalize(target);

--- a/docs/scripts/check-links.mjs
+++ b/docs/scripts/check-links.mjs
@@ -1,0 +1,125 @@
+// Assert every internal link in the built site resolves to a real page and
+// (when it carries an #anchor) to an id that actually exists on that page.
+//
+// Relative links resolve against the slash-less route the page is served at
+// (nginx try_files serves <route>/index.html with no redirect, so "./x" from
+// /a/b targets /a/x). That makes "./sibling" links fragile, and a wrong
+// absolute prefix (e.g. /docs/components/x vs /components/x) silently 404s in
+// production. pa11y only loads the pages in .pa11yci, so it never catches a
+// dangling link. This check covers that gap directly against dist/. Run after
+// `astro build`; non-zero exit fails the gate.
+import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const DIST = fileURLToPath(new URL('../dist/', import.meta.url));
+
+function walk(dir) {
+  const out = [];
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    const s = statSync(p);
+    if (s.isDirectory()) out.push(...walk(p));
+    else if (name.endsWith('.html')) out.push(p);
+  }
+  return out;
+}
+
+// Map every URL path the site serves -> set of element ids on that page.
+const files = walk(DIST);
+const pageIds = new Map(); // route (no trailing slash, no .html) -> Set<id>
+const routes = new Set();
+
+function routeFor(file) {
+  let r = '/' + relative(DIST, file).replace(/\\/g, '/');
+  r = r.replace(/index\.html$/, '').replace(/\.html$/, '');
+  if (r.length > 1 && r.endsWith('/')) r = r.slice(0, -1);
+  return r === '' ? '/' : r;
+}
+
+for (const f of files) {
+  const html = readFileSync(f, 'utf8');
+  const route = routeFor(f);
+  routes.add(route);
+  const ids = new Set();
+  for (const m of html.matchAll(/\sid="([^"]+)"/g)) ids.add(m[1]);
+  for (const m of html.matchAll(/\sname="([^"]+)"/g)) ids.add(m[1]);
+  pageIds.set(route, ids);
+}
+
+function normalize(route) {
+  if (route.length > 1 && route.endsWith('/')) route = route.slice(0, -1);
+  return route === '' ? '/' : route;
+}
+
+const problems = [];
+const externalHosts = new Set();
+
+for (const f of files) {
+  const html = readFileSync(f, 'utf8');
+  const fromRoute = routeFor(f);
+  for (const m of html.matchAll(/<a\b[^>]*\shref="([^"]+)"/g)) {
+    let href = m[1].trim();
+    if (!href) continue;
+    if (href.startsWith('mailto:') || href.startsWith('tel:')) continue;
+    if (/^https?:\/\//i.test(href)) {
+      try { externalHosts.add(new URL(href).host); } catch {}
+      continue;
+    }
+    if (href.startsWith('//')) continue;
+    if (href.startsWith('#')) {
+      const anchor = decodeURIComponent(href.slice(1));
+      const ids = pageIds.get(fromRoute) || new Set();
+      if (anchor && !ids.has(anchor)) {
+        problems.push(`${fromRoute}: missing anchor #${anchor} (same page)`);
+      }
+      continue;
+    }
+    // strip query
+    let [path, anchor] = href.split('#');
+    path = path.split('?')[0];
+    // resolve relative
+    let target;
+    if (path.startsWith('/')) target = path;
+    else {
+      // The page is served at <route> with NO trailing slash (nginx try_files
+      // serves <route>/index.html for the slash-less URL, no redirect). So a
+      // browser resolves "./x" relative to the slash-less URL: it replaces the
+      // last segment. Model exactly that — base is the route itself, not the
+      // route + "/". This matches what a user navigating via the slash-less
+      // nav links actually experiences. We also record whether the SAME link
+      // would break had the user arrived on the trailing-slash variant.
+      target = new URL(path, 'http://x' + fromRoute).pathname;
+    }
+    target = normalize(target);
+    // ignore asset files
+    if (/\.(png|jpe?g|svg|webp|gif|ico|pdf|css|js|json|xml|txt|woff2?|zip|yaml|yml)$/i.test(target)) {
+      if (!existsSync(join(DIST, target.replace(/^\//, '')))) {
+        problems.push(`${fromRoute}: missing asset ${target}`);
+      }
+      continue;
+    }
+    if (!routes.has(target)) {
+      problems.push(`${fromRoute}: broken link -> ${href} (resolved ${target})`);
+      continue;
+    }
+    if (anchor) {
+      const a = decodeURIComponent(anchor);
+      const ids = pageIds.get(target) || new Set();
+      if (!ids.has(a)) {
+        problems.push(`${fromRoute}: missing anchor -> ${href} (#${a} not on ${target})`);
+      }
+    }
+  }
+}
+
+console.log(`Checked ${files.length} pages, ${routes.size} routes.`);
+console.log(`External hosts referenced: ${[...externalHosts].sort().join(', ')}`);
+console.log('');
+if (problems.length === 0) {
+  console.log('No internal link problems found.');
+} else {
+  console.log(`${problems.length} problem(s):`);
+  for (const p of problems.sort()) console.log('  - ' + p);
+  process.exitCode = 1;
+}

--- a/docs/src/components/LandingSections.astro
+++ b/docs/src/components/LandingSections.astro
@@ -84,8 +84,8 @@ const toc = [
     ) : (
       <Fragment>
         {/* scheme="dark" forces the NLDD color-scheme dark (the tinted surface
-            reads dark); the `dark` theme class re-defines the docs' own --vp-*
-            vars that colour the slotted headings/body. */}
+            reads dark); the `dark` class lets NLDD's own theme CSS colour the
+            slotted headings/body for the dark surface. */}
         <nldd-two-thirds-one-third-section
           class="dark"
           background="tinted"

--- a/docs/src/content/docs/auth-and-roles.md
+++ b/docs/src/content/docs/auth-and-roles.md
@@ -68,7 +68,7 @@ To add a new specific right:
 4. In the application code: `route_layer(require_role("<app>-<verb>"))` on the
    protected route.
 
-No changes are needed to existing routes, the pattern is composable.
+No changes are needed to existing routes; the pattern is composable.
 
 ## JWT shape
 
@@ -187,7 +187,7 @@ reads this cached list rather than re-parsing the token, which means:
   the user to log out and back in before the new role is honoured by the
   application.
 - **Role revocation has the same delay.** Removing a role in Keycloak does
-  *not* immediately revoke access, the live session continues to carry the
+  *not* immediately revoke access; the live session continues to carry the
   expanded role list until it expires.
 
 For emergency revocation (compromised account, immediate downgrade) the

--- a/docs/src/content/docs/auth-and-roles.md
+++ b/docs/src/content/docs/auth-and-roles.md
@@ -224,7 +224,7 @@ Do NOT run this configuration in production.
 ```
 
 The same applies to the harvester-admin service. **Never deploy a service
-without OIDC configured**, the warning is the only safeguard, and the
+without OIDC configured**: the warning is the only safeguard, and the
 admin-tier routes (corpus reload, feature-flag toggles, job deletion, source
 sync) are fully open in this mode.
 

--- a/docs/src/content/docs/auth-and-roles.md
+++ b/docs/src/content/docs/auth-and-roles.md
@@ -9,7 +9,7 @@ configuration each service needs.
 ## The four-layer model
 
 Access is governed by a layered set of realm roles. The hierarchy is encoded
-in Keycloak as **composite roles** — a higher role contains the lower one, so
+in Keycloak as **composite roles**, a higher role contains the lower one, so
 a user holding a higher role automatically holds all lower roles in their
 token. The application code never has to check `role-A OR role-B`; each
 protected route asks for exactly one role.
@@ -29,8 +29,8 @@ Keycloak composite role).
 
 There are two applications today:
 
-- **editor** — `packages/editor-api` + `frontend/` (law and scenario editor)
-- **harvester** — `packages/admin` (harvester job queue & corpus sync dashboard)
+- **editor**: `packages/editor-api` + `frontend/` (law and scenario editor)
+- **harvester**: `packages/admin` (harvester job queue & corpus sync dashboard)
 
 ### Role reference
 
@@ -68,7 +68,7 @@ To add a new specific right:
 4. In the application code: `route_layer(require_role("<app>-<verb>"))` on the
    protected route.
 
-No changes are needed to existing routes — the pattern is composable.
+No changes are needed to existing routes, the pattern is composable.
 
 ## JWT shape
 
@@ -130,7 +130,7 @@ role (`editor-reader` / `harvester-reader`) once the migration completes.
 The `zad-actions/deploy@v4` GitHub action used in `.github/workflows/deploy.yml`
 takes only `image` and `clone-from`; env vars are set out-of-band per
 component via the ZAD CLI or dashboard. For preview deploys, `clone-from:
-regelrecht` carries the value from the production deployment automatically —
+regelrecht` carries the value from the production deployment automatically,
 you only need to set it once per environment.
 
 ```bash
@@ -147,7 +147,7 @@ Sessions created before this code shipped carry `authenticated = true` but no
 `SESSION_KEY_ROLES` key. The per-route role check distinguishes "key absent"
 (pre-RBAC session) from "key present but empty list" (a legitimately
 mis-configured Keycloak): the former returns 401, which triggers the OIDC
-re-login redirect — the callback then populates `SESSION_KEY_ROLES` from the
+re-login redirect, the callback then populates `SESSION_KEY_ROLES` from the
 JWT and the session self-heals. **No session flush is required at deploy.**
 
 ## Migration from the legacy `allowed-user` role
@@ -158,12 +158,12 @@ with no per-route gating. To migrate without locking anyone out:
 1. **Keycloak (hard prerequisite)**: create the seven new roles, set up
    composites, attach the ID-token mapper, and grant every existing user an
    appropriate new role (most editor users → `editor-writer`). This must be
-   fully rolled out before Step 2 — any user without one of the new roles
+   fully rolled out before Step 2, any user without one of the new roles
    will get **403 on every API request** once the new code is live, because
    the per-route middleware checks for `editor-reader` / `harvester-reader`
    etc., not `allowed-user`.
 2. **Deploy the new code**. If `OIDC_REQUIRED_ROLE` is unset on the existing
-   deployment, the new code falls back to `allowed-user` and logs a warning —
+   deployment, the new code falls back to `allowed-user` and logs a warning,
    so the login redirect keeps working during the rolling deploy (provided
    step 1 is complete). Per-route checks gate on the new roles immediately,
    so users without one of the new roles will see 403 on every protected
@@ -187,7 +187,7 @@ reads this cached list rather than re-parsing the token, which means:
   the user to log out and back in before the new role is honoured by the
   application.
 - **Role revocation has the same delay.** Removing a role in Keycloak does
-  *not* immediately revoke access — the live session continues to carry the
+  *not* immediately revoke access, the live session continues to carry the
   expanded role list until it expires.
 
 For emergency revocation (compromised account, immediate downgrade) the
@@ -213,7 +213,7 @@ OIDC login again, which re-reads roles from Keycloak.
 
 When the OIDC environment variables are not configured (`OIDC_CLIENT_ID`
 unset), each service starts with **all per-route auth checks bypassed**.
-Every tier — reader, writer, *and* admin — is reachable without a session.
+Every tier (reader, writer, *and* admin) is reachable without a session.
 This mode exists for local development convenience (no Keycloak required)
 and emits a `warn!` line at startup:
 
@@ -224,24 +224,24 @@ Do NOT run this configuration in production.
 ```
 
 The same applies to the harvester-admin service. **Never deploy a service
-without OIDC configured** — the warning is the only safeguard, and the
+without OIDC configured**, the warning is the only safeguard, and the
 admin-tier routes (corpus reload, feature-flag toggles, job deletion, source
 sync) are fully open in this mode.
 
 ## Programmatic access (admin API key)
 
 The harvester-admin service accepts a bearer API key on **GET** and **DELETE**
-requests (`ADMIN_API_KEY` env var). This is an out-of-band trust path — the holder
+requests (`ADMIN_API_KEY` env var). This is an out-of-band trust path, the holder
 is treated as a `regelrecht-admin`-equivalent for those methods. POST is never
 allowed via the API key path; use a user session with `harvester-writer` or
 `harvester-admin` for mutations. The editor service has no API key path.
 
 ## Implementation pointers
 
-- Shared crate: `packages/auth/` — `require_role(role)` middleware factory.
-- Editor routes: `packages/editor-api/src/main.rs` — router split into
+- Shared crate: `packages/auth/`, `require_role(role)` middleware factory.
+- Editor routes: `packages/editor-api/src/main.rs`, router split into
   public / reader / writer / admin groups.
-- Harvester-admin routes: `packages/admin/src/main.rs` — router split into
+- Harvester-admin routes: `packages/admin/src/main.rs`, router split into
   reader / writer / admin groups; `require_auth(role)` in
   `packages/admin/src/middleware.rs` keeps the API-key bypass.
 - Roles are persisted in the session at login (`SESSION_KEY_ROLES`) so

--- a/docs/src/content/docs/components/corpus.md
+++ b/docs/src/content/docs/components/corpus.md
@@ -29,15 +29,26 @@ Other packages use it:
 | `github.rs` | `GitHubFetcher` - fetches YAML via GitHub API (feature-gated) |
 | `validation.rs` | Schema validation against the JSON schema |
 | `auth.rs` | Token management for private repositories |
+| `client.rs` | `CorpusClient` - higher-level read/write access used by editor-api |
+| `backend.rs`, `pr_client.rs` | Git/GitHub write backends for editing through pull requests |
+| `repo_access.rs` | Validates that a token can reach a private repository |
+| `annotation_schema.rs`, `dto.rs`, `config.rs` | Annotation schema, transfer types, and deployment config |
 
 ## Usage
 
 ```rust
 use regelrecht_corpus::CorpusRegistry;
+use std::path::Path;
 
-let registry = CorpusRegistry::load("corpus-registry.yaml")?;
-let source_map = registry.load_all().await?;
-let law = source_map.get("zorgtoeslagwet");
+// load(manifest_path, local_override_path): the second argument merges a
+// corpus-registry.local.yaml override when present.
+let registry = CorpusRegistry::load(Path::new("corpus-registry.yaml"), None)?;
+
+// load_all_sources_async includes GitHub sources; pass the auth file when
+// private repositories need a token.
+let source_map = registry.load_all_sources_async(None).await?;
+
+let law = source_map.get_law("zorgtoeslagwet");
 ```
 
 The `github` feature flag enables remote fetching from GitHub repositories. Without it, only local filesystem sources are available.

--- a/docs/src/content/docs/components/corpus.md
+++ b/docs/src/content/docs/components/corpus.md
@@ -44,9 +44,11 @@ use std::path::Path;
 // corpus-registry.local.yaml override when present.
 let registry = CorpusRegistry::load(Path::new("corpus-registry.yaml"), None)?;
 
-// load_all_sources_async includes GitHub sources; pass the auth file when
-// private repositories need a token.
-let source_map = registry.load_all_sources_async(None).await?;
+// load_all_sources_async includes GitHub sources. Pass the auth file when
+// private repositories need a token, or None when all sources are public.
+let source_map = registry
+    .load_all_sources_async(Some(Path::new("corpus-auth.yaml")))
+    .await?;
 
 let law = source_map.get_law("zorgtoeslagwet");
 ```

--- a/docs/src/content/docs/components/editor-api.md
+++ b/docs/src/content/docs/components/editor-api.md
@@ -12,21 +12,28 @@ The editor API is a lightweight HTTP server that backs the law editor frontend. 
 
 ## What it does
 
-The editor API loads the regulation corpus (from local files or GitHub via the corpus library) and exposes it through a REST API. The editor frontend calls these endpoints to list laws, fetch individual law YAML, and retrieve BDD test scenarios.
+The editor API loads the regulation corpus (from local files or GitHub via the corpus library) and exposes it through a REST API. The editor frontend calls these endpoints to list laws, fetch and edit individual law YAML, manage annotations, run harvest jobs, and collaborate inside trajects.
 
 ## Key endpoints
 
-- `GET /api/corpus/laws` - list all laws in the corpus
-- `GET /api/corpus/laws/{id}` - fetch a specific law's YAML
-- `GET /api/corpus/laws/{id}/scenarios` - fetch BDD scenarios for a law
+The API surface has grown well beyond corpus reads. The main groups:
+
+- **Corpus**: `GET /api/corpus/laws`, `GET/PUT /api/corpus/laws/{law_id}`, plus `/outputs`, `/scenarios`, `/scenarios/{filename}`, `/annotations`, and `POST /api/corpus/reload`.
+- **Trajects** (private-repo collaboration): full CRUD under `/api/trajects` and `/api/trajects/{id}`, member and invite management (`/members`, `/invites/{email}`, `/leave`), and traject-scoped corpus access under `/api/trajects/{traject_ref}/corpus/...`.
+- **Harvesting**: `/api/harvest`, `/api/harvest/batch`, `/api/harvest/search`, `/api/harvest/status`.
+- **Misc**: `/api/sources`, `/api/favorites`, `/api/feature-flags`, `/api/user/settings`, and `/health`.
+
+See `packages/editor-api/src/main.rs` for the authoritative route table.
 
 ## Configuration
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `STATIC_DIR` | `../frontend/dist` | Path to compiled frontend |
+| `STATIC_DIR` | `static` | Path to compiled frontend |
 | `CORPUS_REGISTRY_PATH` | `corpus-registry.yaml` | Registry manifest location |
-| `CORPUS_AUTH_FILE` | - | Path to authentication config |
+| `CORPUS_AUTH_FILE` | `corpus-auth.yaml` | Path to authentication config |
+
+`DATABASE_URL` (or `DATABASE_SERVER_FULL`), `PIPELINE_API_URL`, and `CORPUS_REGISTRY_LOCAL_PATH` are also read where the traject and harvest features need them.
 
 ## Running locally
 

--- a/docs/src/content/docs/components/engine.md
+++ b/docs/src/content/docs/components/engine.md
@@ -135,7 +135,7 @@ const result = engine.execute(
 }
 ```
 
-The `output_name` (singular) field is still accepted for backwards compatibility.
+The `output_name` (singular) field is still accepted for backward compatibility.
 
 ## Operations
 
@@ -147,7 +147,7 @@ The engine supports 21 schema operations for expressing legal logic:
 | **Arithmetic** (4) | `ADD`, `SUBTRACT`, `MULTIPLY`, `DIVIDE` |
 | **Aggregate** (2) | `MAX`, `MIN` |
 | **Logical** (3) | `AND`, `OR`, `NOT` |
-| **Conditional** (1) | `IF` (when/then/else, or cases/default; `SWITCH` is an accepted alias) |
+| **Conditional** (1) | `IF` (`cases: [{when, then}]` + `default`; `SWITCH` is an accepted alias) |
 | **Collection** (2) | `IN`, `LIST` |
 | **Date** (4) | `AGE`, `DATE_ADD`, `DATE`, `DAY_OF_WEEK` |
 
@@ -254,6 +254,8 @@ engine.hasLaw(lawId): boolean
 engine.unloadLaw(lawId): boolean
 engine.lawCount(): number
 engine.version(): string
+engine.resolveNote(lawId, selector): ResolvedNote
+engine.resolveNotes(lawId, annotationsYaml: string): ResolvedNote[]
 ```
 
 > **WASM limitations.** Open term resolution (`open_terms` / `implements` IoC pattern) is not yet available in the WASM build. Cross-law references work when all referenced laws are pre-loaded via `loadLaw()`.

--- a/docs/src/content/docs/components/engine.md
+++ b/docs/src/content/docs/components/engine.md
@@ -72,7 +72,7 @@ Articles can define multiple outputs (e.g., `heeft_recht_op_zorgtoeslag` and `ho
 
 ### Privacy by Design
 
-Callers must explicitly list the outputs they need. There's no "return all" mode. The engine returns requested outputs plus any causally-entailed outputs from hooks and overrides (a beschikking is legally indivisible — AWB consequences like motivering and bezwaartermijn cannot be stripped).
+Callers must explicitly list the outputs they need. There's no "return all" mode. The engine returns requested outputs plus any causally-entailed outputs from hooks and overrides (a beschikking is legally indivisible, AWB consequences like motivering and bezwaartermijn cannot be stripped).
 
 ### Rust API
 

--- a/docs/src/content/docs/components/engine.md
+++ b/docs/src/content/docs/components/engine.md
@@ -72,7 +72,7 @@ Articles can define multiple outputs (e.g., `heeft_recht_op_zorgtoeslag` and `ho
 
 ### Privacy by Design
 
-Callers must explicitly list the outputs they need. There's no "return all" mode. The engine returns requested outputs plus any causally-entailed outputs from hooks and overrides (a beschikking is legally indivisible, AWB consequences like motivering and bezwaartermijn cannot be stripped).
+Callers must explicitly list the outputs they need. There's no "return all" mode. The engine returns requested outputs plus any causally-entailed outputs from hooks and overrides (a beschikking is legally indivisible, Awb consequences like motivering and bezwaartermijn cannot be stripped).
 
 ### Rust API
 
@@ -102,7 +102,7 @@ Each output is tagged with how it was produced:
 | Provenance | Meaning |
 |------------|---------|
 | `Direct` | Produced by the article's own actions |
-| `Reactive` | Produced by a hook (e.g., AWB firing on BESCHIKKING) |
+| `Reactive` | Produced by a hook (e.g., Awb firing on BESCHIKKING) |
 | `Override` | Produced by a lex specialis override (RFC-007) |
 
 The `output_provenance` field appears in `ArticleResult`, WASM results, CLI output, and the Execution Receipt. It's omitted when empty (e.g., simple articles with no hooks).

--- a/docs/src/content/docs/components/engine.md
+++ b/docs/src/content/docs/components/engine.md
@@ -139,18 +139,19 @@ The `output_name` (singular) field is still accepted for backwards compatibility
 
 ## Operations
 
-The engine supports 21 operations for expressing legal logic:
+The engine supports 21 schema operations for expressing legal logic:
 
 | Category | Operations |
 |----------|-----------|
-| **Comparison** | `EQUALS`, `NOT_EQUALS`, `GREATER_THAN`, `LESS_THAN`, `GREATER_THAN_OR_EQUAL`, `LESS_THAN_OR_EQUAL` |
-| **Arithmetic** | `ADD`, `SUBTRACT`, `MULTIPLY`, `DIVIDE` |
-| **Aggregate** | `MAX`, `MIN` |
-| **Logical** | `AND`, `OR` |
-| **Conditional** | `IF` (when/then/else), `SWITCH` (cases/default) |
-| **Null checking** | `IS_NULL`, `NOT_NULL` |
-| **Membership** | `IN`, `NOT_IN` |
-| **Date** | `SUBTRACT_DATE` (with unit: days/months/years) |
+| **Comparison** (5) | `EQUALS`, `GREATER_THAN`, `LESS_THAN`, `GREATER_THAN_OR_EQUAL`, `LESS_THAN_OR_EQUAL` |
+| **Arithmetic** (4) | `ADD`, `SUBTRACT`, `MULTIPLY`, `DIVIDE` |
+| **Aggregate** (2) | `MAX`, `MIN` |
+| **Logical** (3) | `AND`, `OR`, `NOT` |
+| **Conditional** (1) | `IF` (when/then/else, or cases/default; `SWITCH` is an accepted alias) |
+| **Collection** (2) | `IN`, `LIST` |
+| **Date** (4) | `AGE`, `DATE_ADD`, `DATE`, `DAY_OF_WEEK` |
+
+Negation and null checks are expressed by wrapping a positive operation in `NOT` (for example `NOT` around `EQUALS`, or `NOT` around an `IS_NULL`-style check). For backward compatibility the engine also accepts the aliases `NOT_EQUALS`, `IS_NULL`, `NOT_NULL`, and `NOT_IN`, but these are **not** part of the v0.5.0 schema: YAML using them executes correctly yet fails schema validation, so new laws should use `NOT` instead.
 
 See [RFC-004](/rfcs/rfc-004) for the full specification.
 
@@ -255,9 +256,7 @@ engine.lawCount(): number
 engine.version(): string
 ```
 
-::: warning WASM Limitations
-Open term resolution (`open_terms` / `implements` IoC pattern) is not yet available in the WASM build. Cross-law references work when all referenced laws are pre-loaded via `loadLaw()`.
-:::
+> **WASM limitations.** Open term resolution (`open_terms` / `implements` IoC pattern) is not yet available in the WASM build. Cross-law references work when all referenced laws are pre-loaded via `loadLaw()`.
 
 ## Security Limits
 

--- a/docs/src/content/docs/components/engine.md
+++ b/docs/src/content/docs/components/engine.md
@@ -151,7 +151,7 @@ The engine supports 21 schema operations for expressing legal logic:
 | **Collection** (2) | `IN`, `LIST` |
 | **Date** (4) | `AGE`, `DATE_ADD`, `DATE`, `DAY_OF_WEEK` |
 
-Negation is expressed by wrapping a positive operation in `NOT`: `NOT` around `EQUALS` for "not equal", `NOT` around `IN` for "not in". A null check is `EQUALS` against `value: null` (wrap it in `NOT` for "is not null"). For backward compatibility the engine also accepts the aliases `NOT_EQUALS`, `IS_NULL`, `NOT_NULL`, and `NOT_IN`, but these are **not** part of the v0.5.0 schema: YAML using them executes correctly yet fails schema validation, so new laws should use the `NOT` / `EQUALS null` forms instead.
+Negation is expressed by wrapping a positive operation in `NOT`: `NOT` around `EQUALS` for "not equal", `NOT` around `IN` for "not in". A null check is `EQUALS` against `value: null` (wrap it in `NOT` for "is not null"). For backward compatibility the engine also accepts the aliases `NOT_EQUALS`, `IS_NULL`, `NOT_NULL`, and `NOT_IN`, but these are **not** part of the schema: YAML using them executes correctly yet fails schema validation, so new laws should use the `NOT` / `EQUALS null` forms instead.
 
 See [RFC-004](/rfcs/rfc-004) for the full specification.
 

--- a/docs/src/content/docs/components/engine.md
+++ b/docs/src/content/docs/components/engine.md
@@ -151,7 +151,7 @@ The engine supports 21 schema operations for expressing legal logic:
 | **Collection** (2) | `IN`, `LIST` |
 | **Date** (4) | `AGE`, `DATE_ADD`, `DATE`, `DAY_OF_WEEK` |
 
-Negation and null checks are expressed by wrapping a positive operation in `NOT` (for example `NOT` around `EQUALS`, or `NOT` around an `IS_NULL`-style check). For backward compatibility the engine also accepts the aliases `NOT_EQUALS`, `IS_NULL`, `NOT_NULL`, and `NOT_IN`, but these are **not** part of the v0.5.0 schema: YAML using them executes correctly yet fails schema validation, so new laws should use `NOT` instead.
+Negation is expressed by wrapping a positive operation in `NOT`: `NOT` around `EQUALS` for "not equal", `NOT` around `IN` for "not in". A null check is `EQUALS` against `value: null` (wrap it in `NOT` for "is not null"). For backward compatibility the engine also accepts the aliases `NOT_EQUALS`, `IS_NULL`, `NOT_NULL`, and `NOT_IN`, but these are **not** part of the v0.5.0 schema: YAML using them executes correctly yet fails schema validation, so new laws should use the `NOT` / `EQUALS null` forms instead.
 
 See [RFC-004](/rfcs/rfc-004) for the full specification.
 

--- a/docs/src/content/docs/components/frontend.md
+++ b/docs/src/content/docs/components/frontend.md
@@ -53,66 +53,40 @@ Edit law articles with a split-pane interface:
 
 ## Design System
 
-The frontend uses the **RegelRecht Design System** (`@nldd/design-system`), which provides Lit-based web components:
+The frontend is built almost entirely from `@nldd/design-system` web components (custom-element prefix `nldd-`), imported in the JS entry point (`src/main.js` imports `@nldd/design-system` and its styles). A representative slice of the components in use:
 
-| Category | Components Used |
+| Category | Components used |
 |----------|----------------|
-| **Layout** | `rr-page`, `rr-side-by-side-split-view`, `rr-toolbar`, `rr-box`, `rr-spacer` |
-| **Navigation** | `rr-top-navigation-bar`, `rr-tab-bar`, `rr-document-tab-bar` |
-| **Inputs** | `rr-search-field`, `rr-text-field`, `rr-drop-down-field`, `rr-segmented-control` |
-| **Lists** | `rr-list`, `rr-list-item`, `rr-text-cell`, `rr-label-cell` |
-| **Actions** | `rr-button`, `rr-icon-button`, `rr-button-bar` |
+| **Layout** | `nldd-page`, `nldd-side-by-side-split-view`, `nldd-navigation-split-view`, `nldd-toolbar`, `nldd-spacer`, `nldd-container` |
+| **Navigation** | `nldd-top-title-bar`, `nldd-tab-bar`, `nldd-document-tab-bar`, `nldd-menu` |
+| **Inputs** | `nldd-search-field`, `nldd-text-field`, `nldd-multi-line-text-field`, `nldd-dropdown`, `nldd-combo-box`, `nldd-segmented-control` |
+| **Lists & cells** | `nldd-list`, `nldd-list-item`, `nldd-text-cell`, `nldd-icon-cell`, `nldd-collection` |
+| **Actions & overlays** | `nldd-button`, `nldd-icon-button`, `nldd-button-group`, `nldd-inline-dialog`, `nldd-modal-dialog`, `nldd-sheet` |
+| **Content** | `nldd-rich-text`, `nldd-code-viewer`, `nldd-code-editor`, `nldd-title`, `nldd-tag` |
 
-Components are registered as custom elements (prefix `rr-`) and work in any HTML context.
+The Rijksoverheid brand color (`#154273`) and typography come from the design system; the only app-level stylesheet is `frontend/css/main.css`, which holds a handful of resets and one `--color-primary` token (the design system provides everything else through its own styles).
 
-### Design Tokens
+## Vue components
 
-Design tokens extracted from Figma in `css/variables.css`:
-
-- **Brand color**: `#154273` (Dutch Government blue)
-- **Font**: Rijksoverheid Sans (official Dutch government typeface)
-- **Spacing**: 8px base unit system
-- **Shadows**: Two levels (sm, md)
-- **Border radius**: 4px / 6px / 8px
-
-## CSS Architecture
-
-```
-css/
-├── main.css          # Entry point (imports all)
-├── reset.css         # Modern CSS reset
-├── variables.css     # Design tokens from Figma
-├── layout.css        # Page layout and navigation
-└── components/
-    ├── list.css      # Lists with selections and badges
-    ├── tabs.css      # Tab navigation (CSS-only + rr-toggle-button)
-    ├── collapsible.css  # Native <details> accordions
-    ├── panes.css     # Split-pane layout, YAML display
-    └── editor.css    # Editor-specific components
-```
-
-Uses BEM-inspired naming, all colors via CSS variables, modern CSS features (`:has()`, Grid, custom properties).
-
-## Vue Components
+The app is split into two top-level shells, `LibraryApp.vue` (the law browser) and `EditorApp.vue` (the split-pane editor), plus ~30 components under `src/components/`. Notable ones:
 
 | Component | Purpose |
 |-----------|---------|
-| `LibraryApp.vue` | Library page - 3-pane law browser |
-| `EditorApp.vue` | Editor page - split-pane law editor |
-| `ArticleText.vue` | Formatted article text rendering |
+| `ArticleText.vue` / `ArticleTextEditor.vue` | Render and edit article text |
 | `MachineReadable.vue` | Machine-readable visualization |
-| `YamlView.vue` | Raw YAML syntax display |
-| `ActionSheet.vue` | Modal panel for editing operations |
-| `OperationSettings.vue` | Operation parameter configuration |
+| `YamlView.vue` | Raw YAML view |
+| `EditSheet.vue` / `ActionSheet.vue` / `OperationSettings.vue` | Editing operations and conditions |
+| `LawGraphView.vue` (+ `graph/`) | Cross-law dependency graph |
+| `ExecutionTraceView.vue` | Execution trace tree |
+| `ScenarioBuilder/Form/Gherkin/Visual/Panel.vue` | BDD scenario authoring |
+| `AnnotatedText.vue` / `NoteCreator.vue` | Stand-off notes (RFC-018) |
+| `TrajectMenu.vue` / `TrajectMembersDialog.vue` | Traject collaboration |
 
-Shared logic via `useLaw.js` composable (loads YAML, manages article selection).
+Shared logic lives in composables (`useLaw.js` for loading and article selection, plus others for settings and corpus URLs).
 
 ## Data Loading
 
-Laws are served as **static YAML files** - no backend API for law content:
-- `scripts/copy-laws.js` copies laws from `corpus/regulation/` to `public/data/`
-- Index at `/data/index.json` (generated from corpus metadata)
-- Individual laws at `/data/wet/{law_id}/{date}.yaml`
+Law content comes from the **editor-api** over HTTP, not from static files. `useLaw.js` fetches and saves laws via `lawUrl(...)` (a `GET` to load, a `PUT` to save), with traject-scoped variants for private-repo collaboration. A `scripts/copy-laws.js` prebuild step still exists, but the runtime data flow goes through the API, so the editor can read and write the corpus.
 
 ## Development
 
@@ -130,17 +104,17 @@ just dev             # Starts everything with hot reload
 
 ## Deployment
 
-Deployed as a static site via Docker (nginx) to RIG:
+The editor ships as a single Docker image (`regelrecht-editor`) that bundles the built Vue frontend together with the [editor-api](./editor-api) Rust binary, which serves the static assets and the REST API. It is deployed to RIG/ZAD:
 
-- **Production**: https://editor-regelrecht-regel-k4c.rig.prd1.gn2.quattro.rijksapps.nl
-- **PR Previews**: Automatically deployed for each pull request
+- **Production**: `editor.regelrecht.rijks.app`
+- **PR previews**: automatically deployed for each pull request
 
 ## Admin Dashboard
 
 A separate admin UI exists at `packages/admin/` for pipeline management:
 
 - **Backend**: Rust (Axum) with PostgreSQL
-- **Frontend**: Vanilla JS + Storybook web components
+- **Frontend**: Vue 3 + Vite + `@nldd/design-system` (same stack as the editor)
 - **Features**: Law status overview, job management, harvest/enrich triggers
 - **Auth**: Optional OIDC integration
 

--- a/docs/src/content/docs/components/grafana.md
+++ b/docs/src/content/docs/components/grafana.md
@@ -2,7 +2,7 @@
 title: "Grafana Monitoring"
 ---
 
-Grafana provides monitoring dashboards and alerting for the regelrecht platform.
+Grafana provides monitoring dashboards and alerting for the RegelRecht platform.
 
 ## Overview
 

--- a/docs/src/content/docs/components/harvester.md
+++ b/docs/src/content/docs/components/harvester.md
@@ -2,13 +2,13 @@
 title: "Harvester"
 ---
 
-The harvester downloads Dutch legislation from the BWB (Basiswettenbestand) repository and converts it to the RegelRecht YAML format.
+The harvester downloads Dutch legislation and converts it to the RegelRecht YAML format. It handles two sources: national law from the BWB (Basiswettenbestand / wetten.nl) and decentralized regulations from the CVDR (Centrale Voorziening Decentrale Regelgeving). The CLI picks the right source from the identifier, so `BWBR…` IDs are fetched from BWB and `CVDR…` IDs from the CVDR.
 
 ## Overview
 
 - **Language**: Rust
 - **Location**: `packages/harvester/`
-- **Source**: BWB / wetten.nl (official Dutch law repository)
+- **Sources**: BWB / wetten.nl (national law) and CVDR (local/decentralized regulations)
 - **Output**: YAML law files with textual content (no `machine_readable` yet)
 
 ## How It Works
@@ -75,6 +75,9 @@ regelrecht-harvester download BWBR0018451 --date 2022-03-15 --output ./laws
 
 # Large law with increased size limit
 regelrecht-harvester download BWBR0020368 --max-size 200
+
+# Download a decentralized regulation by CVDR ID (source detected automatically)
+regelrecht-harvester download CVDR681386
 ```
 
 ### As Library
@@ -89,6 +92,8 @@ let law = download_law("BWBR0018451", "2025-01-01")?;
 println!("Title: {}", law.metadata.title);
 println!("Articles: {}", law.articles.len());
 ```
+
+For CVDR regulations use `download_cvdr_law`; `detect_source` returns the right source for either kind of identifier.
 
 ## Output Path Convention
 

--- a/docs/src/content/docs/components/lawmaking.md
+++ b/docs/src/content/docs/components/lawmaking.md
@@ -16,7 +16,7 @@ The app presents the legislative process as an animated, step-through diagram. U
 
 - **Simple** - the basic legislative path
 - **Advanced** - detailed stages and decision points
-- **Wet open overheid (WOO)** - the process through the lens of open government law
+- **Wet open overheid (Woo)** - the process through the lens of open government law
 
 No backend is needed. Flow data is defined as static JavaScript modules in `src/data/`.
 

--- a/docs/src/content/docs/components/pipeline.md
+++ b/docs/src/content/docs/components/pipeline.md
@@ -39,7 +39,7 @@ flowchart LR
 | Module | Purpose |
 |--------|---------|
 | `job_queue.rs` | Job creation, claiming (`FOR UPDATE SKIP LOCKED`), completion, failure with auto-retry |
-| `law_status.rs` | Per-law status tracking through 8 states |
+| `law_status.rs` | Per-law status tracking through 10 states |
 | `harvest.rs` | Harvest execution - download XML from BWB, convert to YAML |
 | `enrich.rs` | Enrichment execution - call LLM to add `machine_readable` sections |
 | `worker.rs` | Polling loops for harvest and enrich workers |
@@ -81,10 +81,14 @@ stateDiagram-v2
     Unknown --> Queued: harvest job created
     Queued --> Harvesting: worker claims job
     Harvesting --> Harvested: harvest succeeds
-    Harvesting --> HarvestFailed: retries exhausted
+    Harvesting --> HarvestFailed: job retries exhausted
+    HarvestFailed --> Harvesting: re-queued (fail count below threshold)
+    HarvestFailed --> HarvestExhausted: fail count reaches threshold
     Harvested --> Enriching: enrich job claimed
     Enriching --> Enriched: enrichment succeeds
-    Enriching --> EnrichFailed: retries exhausted
+    Enriching --> EnrichFailed: job retries exhausted
+    EnrichFailed --> Enriching: re-queued (fail count below threshold)
+    EnrichFailed --> EnrichExhausted: fail count reaches threshold
 ```
 
 ## Harvest Worker

--- a/docs/src/content/docs/concepts/branches-of-law.md
+++ b/docs/src/content/docs/concepts/branches-of-law.md
@@ -29,11 +29,11 @@ RegelRecht makes Dutch law machine-readable and executable. Some branches of law
 
 ### Bestuursrecht (Administrative Law)
 
-Bestuursrecht is the natural home for machine-readable law. Government bodies apply structured rules to individual cases and produce formal decisions (*beschikkingen*). The AWB provides a uniform procedural framework; sector-specific laws define the substance.
+Bestuursrecht is the natural home for machine-readable law. Government bodies apply structured rules to individual cases and produce formal decisions (*beschikkingen*). The Awb provides a uniform procedural framework; sector-specific laws define the substance.
 
 Eligibility checks, benefit calculations, permit conditions: these follow deterministic if/then logic with defined inputs and outputs. The engine's cross-law reference mechanism maps directly to how administrative law works, where higher laws delegate to lower regulations and ministeriële regelingen fill in concrete values.
 
-The corpus already contains the AWB, Participatiewet, Zorgtoeslag, WLZ, and Zorgverzekeringswet. The sheer number of laws, regulations, and policy rules that interact is what makes scaling hard.
+The corpus already contains the Awb, Participatiewet, Zorgtoeslag, WLZ, and Zorgverzekeringswet. The sheer number of laws, regulations, and policy rules that interact is what makes scaling hard.
 
 ### Belastingrecht (Tax Law)
 
@@ -91,7 +91,7 @@ The law on paper is only part of the story. IND *werkinstructies* and policy rul
 
 Procedural law is workflow-oriented rather than calculation-oriented. It defines sequences of steps, deadlines, competence rules, and conditions for procedural actions.
 
-Deadline calculation is highly computable. Appeal periods, service requirements, and time limits follow strict rules from the AWB and the Wetboek van Burgerlijke Rechtsvordering. Court competence, which court handles which case type, is determined by subject matter, claim amount, and location: a structured decision tree.
+Deadline calculation is highly computable. Appeal periods, service requirements, and time limits follow strict rules from the Awb and the Wetboek van Burgerlijke Rechtsvordering. Court competence, which court handles which case type, is determined by subject matter, claim amount, and location: a structured decision tree.
 
 The modeling question: procedural law is about sequencing and state transitions, not computing a single output value. This may need a different execution model, or it may fit as a series of connected regulations where each step's output feeds the next step's conditions.
 

--- a/docs/src/content/docs/concepts/branches-of-law.md
+++ b/docs/src/content/docs/concepts/branches-of-law.md
@@ -33,7 +33,7 @@ Bestuursrecht is the natural home for machine-readable law. Government bodies ap
 
 Eligibility checks, benefit calculations, permit conditions: these follow deterministic if/then logic with defined inputs and outputs. The engine's cross-law reference mechanism maps directly to how administrative law works, where higher laws delegate to lower regulations and ministeriële regelingen fill in concrete values.
 
-The corpus already contains the Awb, Participatiewet, Zorgtoeslag, WLZ, and Zorgverzekeringswet. The sheer number of laws, regulations, and policy rules that interact is what makes scaling hard.
+The corpus already contains the Awb, Participatiewet, Zorgtoeslag, Wlz, and Zorgverzekeringswet. The sheer number of laws, regulations, and policy rules that interact is what makes scaling hard.
 
 ### Belastingrecht (Tax Law)
 

--- a/docs/src/content/docs/concepts/branches-of-law.md
+++ b/docs/src/content/docs/concepts/branches-of-law.md
@@ -4,9 +4,7 @@ title: "Branches of Law"
 
 RegelRecht makes Dutch law machine-readable and executable. Some branches of law lend themselves to this better than others. This page surveys the major branches, how well they map to rule-based execution, and what research questions they raise.
 
-::: info Current Focus
-RegelRecht currently focuses on **bestuursrecht** and **procesrecht**. The corpus contains regulations from administrative law, social security, healthcare, and tax law. Other branches are under research to understand where machine-readable law can and can't go.
-:::
+> **Current focus.** RegelRecht currently focuses on **bestuursrecht** and **procesrecht**. The corpus contains regulations from administrative law, social security, healthcare, and tax law. Other branches are under research to understand where machine-readable law can and can't go.
 
 ## Overview
 

--- a/docs/src/content/docs/concepts/branches-of-law.md
+++ b/docs/src/content/docs/concepts/branches-of-law.md
@@ -53,7 +53,7 @@ This doesn't raise new modeling questions. It does provide a rich set of cross-l
 
 The Kieswet is already in the corpus. Seat allocation algorithms, quorum requirements, voting procedures, electoral deadlines: all highly structured. The Gemeentewet and Provinciewet contain similar procedural rules for local government.
 
-Beyond electoral mechanics, constitutional law gets into principle territory — see Grondrechten below.
+Beyond electoral mechanics, constitutional law gets into principle territory, see Grondrechten below.
 
 ### Grondrechten (Constitutional Rights)
 

--- a/docs/src/content/docs/concepts/cross-law-references.md
+++ b/docs/src/content/docs/concepts/cross-law-references.md
@@ -2,7 +2,7 @@
 title: "Cross-Law References"
 ---
 
-Dutch laws reference each other constantly. The Healthcare Allowance Act (*Zorgtoeslagwet*) needs your income, which is defined by the AWIR. It needs your insurance status, which comes from the Zorgverzekeringswet. It needs to know whether you have an allowance partner, which the AWIR determines.
+Dutch laws reference each other constantly. The Healthcare Allowance Act (*Zorgtoeslagwet*) needs your income, which is defined by the Awir. It needs your insurance status, which comes from the Zorgverzekeringswet. It needs to know whether you have an allowance partner, which the Awir determines.
 
 Rather than duplicating these definitions, each law declares what it needs from other laws. The engine follows these references automatically.
 
@@ -11,7 +11,7 @@ Rather than duplicating these definitions, each law declares what it needs from 
 An article declares its inputs. When an input has a `source` block pointing to another law, the engine loads that law, executes it with the specified parameters, and feeds the result back.
 
 ```yaml
-# Zorgtoeslagwet, article 2 - needs income from the AWIR
+# Zorgtoeslagwet, article 2 - needs income from the Awir
 input:
   - name: toetsingsinkomen
     type: amount
@@ -26,15 +26,15 @@ The engine loads `algemene_wet_inkomensafhankelijke_regelingen`, executes it for
 
 ## Chains of references
 
-References can chain. The Zorgtoeslagwet references the AWIR, which might reference the Wet inkomstenbelasting, which references the BRP. The engine resolves the full chain, loading and executing each law as needed.
+References can chain. The Zorgtoeslagwet references the Awir, which might reference the Wet inkomstenbelasting, which references the BRP. The engine resolves the full chain, loading and executing each law as needed.
 
 ```mermaid
 flowchart LR
-    ZT[Zorgtoeslagwet] -->|toetsingsinkomen| AWIR
+    ZT[Zorgtoeslagwet] -->|toetsingsinkomen| Awir
     ZT -->|is_verzekerd| ZVW[Zorgverzekeringswet]
     ZT -->|leeftijd| BRP[BRP]
     ZT -->|standaardpremie| RSP[Regeling standaardpremie]
-    AWIR -->|inkomen| WIB[Wet inkomstenbelasting]
+    Awir -->|inkomen| WIB[Wet inkomstenbelasting]
 ```
 
 Results are cached: if two laws both need the same value from the BRP, it is computed once.

--- a/docs/src/content/docs/concepts/cross-law-references.md
+++ b/docs/src/content/docs/concepts/cross-law-references.md
@@ -2,7 +2,7 @@
 title: "Cross-Law References"
 ---
 
-Dutch laws reference each other constantly. The Healthcare Allowance Act (*Zorgtoeslagwet*) needs your income, which is defined by the AWIR. It needs your insurance status, which comes from the Zorgverzekeringswet. It needs your age, which comes from the BRP.
+Dutch laws reference each other constantly. The Healthcare Allowance Act (*Zorgtoeslagwet*) needs your income, which is defined by the AWIR. It needs your insurance status, which comes from the Zorgverzekeringswet. It needs to know whether you have an allowance partner, which the AWIR determines.
 
 Rather than duplicating these definitions, each law declares what it needs from other laws. The engine follows these references automatically.
 
@@ -45,20 +45,19 @@ The Zorgtoeslagwet article 2 declares these cross-law inputs:
 
 ```yaml
 input:
-  - name: leeftijd
-    type: number
-    source:
-      regulation: wet_basisregistratie_personen
-      output: leeftijd
-      parameters:
-        bsn: $bsn
-        peildatum: $referencedate
-
   - name: is_verzekerde
     type: boolean
     source:
       regulation: zorgverzekeringswet
       output: is_verzekerd
+      parameters:
+        bsn: $bsn
+
+  - name: heeft_toeslagpartner
+    type: boolean
+    source:
+      regulation: algemene_wet_inkomensafhankelijke_regelingen
+      output: heeft_toeslagpartner
       parameters:
         bsn: $bsn
 

--- a/docs/src/content/docs/concepts/cross-law-references.md
+++ b/docs/src/content/docs/concepts/cross-law-references.md
@@ -31,10 +31,10 @@ References can chain. The Zorgtoeslagwet references the Awir, which might refere
 ```mermaid
 flowchart LR
     ZT[Zorgtoeslagwet] -->|toetsingsinkomen| Awir
-    ZT -->|is_verzekerd| ZVW[Zorgverzekeringswet]
-    ZT -->|leeftijd| BRP[BRP]
-    ZT -->|standaardpremie| RSP[Regeling standaardpremie]
+    ZT -->|heeft_toeslagpartner| Awir
+    ZT -->|is_verzekerde| ZVW[Zorgverzekeringswet]
     Awir -->|inkomen| WIB[Wet inkomstenbelasting]
+    WIB -->|persoonsgegevens| BRP[BRP]
 ```
 
 Results are cached: if two laws both need the same value from the BRP, it is computed once.

--- a/docs/src/content/docs/concepts/execution-provenance.md
+++ b/docs/src/content/docs/concepts/execution-provenance.md
@@ -2,7 +2,7 @@
 title: "Execution Provenance"
 ---
 
-Government agencies must be able to reproduce a specific decision months or years later, with the exact same result. Dutch administrative law requires this (AWB Art. 3:46, the AERIUS rulings), and the EU AI Act makes it mandatory for high-risk systems from August 2026.
+Government agencies must be able to reproduce a specific decision months or years later, with the exact same result. Dutch administrative law requires this (Awb Art. 3:46, the AERIUS rulings), and the EU AI Act makes it mandatory for high-risk systems from August 2026.
 
 Determinism within a single execution is necessary but not sufficient. Reproducibility requires pinning three things: the regulation YAML, the schema version it conforms to, and the engine version that executed it.
 
@@ -75,7 +75,7 @@ A reproducible decision with a sealed receipt is a different animal from an opaq
 
 ## Further reading
 
-- [Hooks and Reactive Execution](./hooks-and-reactive-execution) - AWB procedure hooks
+- [Hooks and Reactive Execution](./hooks-and-reactive-execution) - Awb procedure hooks
 - [Multi-Org Execution](./multi-org-execution) - cross-organization value exchange
 - [RFC-013: Execution Provenance](/rfcs/rfc-013) - full specification
 - [RFC-014: Engine Conformance](/rfcs/rfc-014) - conformance test suite

--- a/docs/src/content/docs/concepts/execution-provenance.md
+++ b/docs/src/content/docs/concepts/execution-provenance.md
@@ -2,7 +2,7 @@
 title: "Execution Provenance"
 ---
 
-Government agencies must be able to reproduce a specific decision months or years later, with the exact same result. Dutch administrative law requires this (Awb Art. 3:46, the AERIUS rulings), and the EU AI Act makes it mandatory for high-risk systems from August 2026.
+Government agencies must be able to reproduce a specific decision months or years later, with the exact same result. Dutch administrative law requires this (AWB Art. 3:46, the AERIUS rulings), and the EU AI Act makes it mandatory for high-risk systems from August 2026.
 
 Determinism within a single execution is necessary but not sufficient. Reproducibility requires pinning three things: the regulation YAML, the schema version it conforms to, and the engine version that executed it.
 
@@ -46,11 +46,11 @@ The schema defines the regulation format. The engine interprets and executes reg
 - **Schema versions** are immutable directories under `schema/` (e.g., `schema/v0.5.1/schema.json`). A published version is never modified.
 - **Engine versions** correspond to GitHub Release tags. Each release declares which schema versions it supports.
 
-This distinction matters because third-party organisations may build their own engine implementations. The schema is the specification; the engine is one implementation of it.
+This distinction matters because third-party organizations may build their own engine implementations. The schema is the specification; the engine is one implementation of it.
 
-## Cross-organisation reproducibility
+## Cross-organization reproducibility
 
-When a decision depends on values from other organisations (via [Multi-Org Execution](./multi-org-execution)), the receipt captures the provenance of each accepted value:
+When a decision depends on values from other organizations (via [Multi-Org Execution](./multi-org-execution)), the receipt captures the provenance of each accepted value:
 
 ```json
 {
@@ -67,7 +67,7 @@ When a decision depends on values from other organisations (via [Multi-Org Execu
 }
 ```
 
-When reproducing the decision, the engine uses these **sealed accepted values** rather than re-calling the other organisation. The other organisation may now be running a different engine version. A *beschikking* stands once issued — the accepted value at the time is a legal fact.
+When reproducing the decision, the engine uses these **sealed accepted values** rather than re-calling the other organization. The other organization may now be running a different engine version. A *beschikking* stands once issued — the accepted value at the time is a legal fact.
 
 ## What this enables
 
@@ -76,6 +76,6 @@ A reproducible decision with a sealed receipt is a different animal from an opaq
 ## Further reading
 
 - [Hooks and Reactive Execution](./hooks-and-reactive-execution) - AWB procedure hooks
-- [Multi-Org Execution](./multi-org-execution) - cross-organisation value exchange
+- [Multi-Org Execution](./multi-org-execution) - cross-organization value exchange
 - [RFC-013: Execution Provenance](/rfcs/rfc-013) - full specification
 - [RFC-014: Engine Conformance](/rfcs/rfc-014) - conformance test suite

--- a/docs/src/content/docs/concepts/execution-provenance.md
+++ b/docs/src/content/docs/concepts/execution-provenance.md
@@ -67,7 +67,7 @@ When a decision depends on values from other organizations (via [Multi-Org Execu
 }
 ```
 
-When reproducing the decision, the engine uses these **sealed accepted values** rather than re-calling the other organization. The other organization may now be running a different engine version. A *beschikking* stands once issued — the accepted value at the time is a legal fact.
+When reproducing the decision, the engine uses these **sealed accepted values** rather than re-calling the other organization. The other organization may now be running a different engine version. A *beschikking* stands once issued, the accepted value at the time is a legal fact.
 
 ## What this enables
 

--- a/docs/src/content/docs/concepts/hooks-and-reactive-execution.md
+++ b/docs/src/content/docs/concepts/hooks-and-reactive-execution.md
@@ -2,16 +2,16 @@
 title: "Hooks and Reactive Execution"
 ---
 
-Some laws apply to every government decision without being called explicitly. The General Administrative Law Act (Algemene wet bestuursrecht, AWB) is the main example: whenever any government body issues a formal decision (*beschikking*), AWB rules about reasoning requirements, objection periods, and notification deadlines kick in automatically.
+Some laws apply to every government decision without being called explicitly. The General Administrative Law Act (Algemene wet bestuursrecht, Awb) is the main example: whenever any government body issues a formal decision (*beschikking*), Awb rules about reasoning requirements, objection periods, and notification deadlines kick in automatically.
 
-The law that triggers these rules does not know about the AWB. The AWB does not know about that specific law. They are decoupled by design.
+The law that triggers these rules does not know about the Awb. The Awb does not know about that specific law. They are decoupled by design.
 
 ## How hooks work
 
 An article can declare a `hooks` block. This tells the engine: "fire this article whenever the conditions in `applies_to` match."
 
 ```yaml
-# AWB 6:7 - sets the objection period to 6 weeks
+# Awb 6:7 - sets the objection period to 6 weeks
 machine_readable:
   hooks:
     - hook_point: post_actions
@@ -27,13 +27,13 @@ machine_readable:
         value: 6
 ```
 
-When the Zorgtoeslagwet calculates a healthcare allowance and produces a *beschikking*, this AWB hook fires and adds `bezwaartermijn_weken: 6` to the result. The Zorgtoeslagwet does not mention the AWB or objection periods.
+When the Zorgtoeslagwet calculates a healthcare allowance and produces a *beschikking*, this Awb hook fires and adds `bezwaartermijn_weken: 6` to the result. The Zorgtoeslagwet does not mention the Awb or objection periods.
 
 ## Hook points
 
 Hooks can fire at two moments during article execution:
 
-- **`pre_actions`** - after open term resolution, before the article's own logic runs. Used for prerequisites like the AWB reasoning requirement (3:46): the decision must include a motivation.
+- **`pre_actions`** - after open term resolution, before the article's own logic runs. Used for prerequisites like the Awb reasoning requirement (3:46): the decision must include a motivation.
 - **`post_actions`** - after the article's logic completes. Used for consequences like the objection period (6:7) and notification deadlines (6:8).
 
 ## Triggering hooks: the `produces` annotation
@@ -52,16 +52,16 @@ The engine builds a hook index at load time. When it encounters an article with 
 
 ## A real chain: objection deadline calculation
 
-AWB hooks compose into a chain:
+Awb hooks compose into a chain:
 
-1. **AWB 3:46** (pre_actions hook, stage: BESLUIT) - sets `motivering_vereist: true`
+1. **Awb 3:46** (pre_actions hook, stage: BESLUIT) - sets `motivering_vereist: true`
 2. The target law's article runs and produces the decision
-3. **AWB 6:7** (post_actions hook, stage: BESLUIT) - sets `bezwaartermijn_weken: 6`
+3. **Awb 6:7** (post_actions hook, stage: BESLUIT) - sets `bezwaartermijn_weken: 6`
 4. Later, when the decision is communicated (stage: BEKENDMAKING):
-5. **AWB 6:8** (post_actions hook, stage: BEKENDMAKING) - calculates `bezwaartermijn_startdatum` and `bezwaartermijn_einddatum` based on the notification date and the 6-week period from AWB 6:7
+5. **Awb 6:8** (post_actions hook, stage: BEKENDMAKING) - calculates `bezwaartermijn_startdatum` and `bezwaartermijn_einddatum` based on the notification date and the 6-week period from Awb 6:7
 
 ```yaml
-# AWB 6:8 - calculates start and end dates for the objection period
+# Awb 6:8 - calculates start and end dates for the objection period
 machine_readable:
   hooks:
     - hook_point: post_actions
@@ -99,7 +99,7 @@ machine_readable:
 
 ## Overrides (lex specialis)
 
-Sometimes a specific law overrides a general AWB rule. The Aliens Act (*Vreemdelingenwet*) article 69 says: *"in afwijking van artikel 6:7 AWB bedraagt de termijn vier weken"* ("departing from AWB article 6:7, the period is four weeks").
+Sometimes a specific law overrides a general Awb rule. The Aliens Act (*Vreemdelingenwet*) article 69 says: *"in afwijking van artikel 6:7 Awb bedraagt de termijn vier weken"* ("departing from Awb article 6:7, the period is four weeks").
 
 This is modeled with `overrides`:
 
@@ -119,7 +119,7 @@ machine_readable:
         value: 4
 ```
 
-The AWB does not know it is being overridden. The Vreemdelingenwet unilaterally replaces the value. This only applies when the Vreemdelingenwet is part of the execution chain (a Participatiewet case is not affected by this override).
+The Awb does not know it is being overridden. The Vreemdelingenwet unilaterally replaces the value. This only applies when the Vreemdelingenwet is part of the execution chain (a Participatiewet case is not affected by this override).
 
 ### How overrides differ from IoC
 
@@ -134,14 +134,14 @@ The AWB does not know it is being overridden. The Vreemdelingenwet unilaterally 
 
 A *beschikking* is not an instant event. It moves through stages over time: application, review, decision, notification, objection. Hooks bind to specific stages via `applies_to.stage`.
 
-The AWB defines a procedure lifecycle:
+The Awb defines a procedure lifecycle:
 
 | Stage | Description | Example hook |
 |-------|-------------|-------------|
 | AANVRAAG | Application filed | |
 | BEHANDELING | Under review | |
-| BESLUIT | Decision taken | AWB 3:46 (reasoning), 6:7 (objection period) |
-| BEKENDMAKING | Decision communicated | AWB 6:8 (deadline calculation) |
+| BESLUIT | Decision taken | Awb 3:46 (reasoning), 6:7 (objection period) |
+| BEKENDMAKING | Decision communicated | Awb 6:8 (deadline calculation) |
 | BEZWAAR | Objection period | |
 
 The engine yields between stages, returning accumulated outputs and indicating what inputs are needed for the next stage. The engine itself stays stateless; the procedure state is managed externally.
@@ -151,4 +151,4 @@ The engine yields between stages, returning accumulated outputs and indicating w
 - [Cross-Law References](./cross-law-references) - how laws reference each other explicitly
 - [Inversion of Control](./inversion-of-control) - how higher laws delegate to lower regulations
 - [RFC-007: Cross-Law Execution](/rfcs/rfc-007) - hooks and overrides specification
-- [RFC-008: Bestuursrecht/AWB](/rfcs/rfc-008) - the administrative procedure model
+- [RFC-008: Bestuursrecht/Awb](/rfcs/rfc-008) - the administrative procedure model

--- a/docs/src/content/docs/concepts/hooks-and-reactive-execution.md
+++ b/docs/src/content/docs/concepts/hooks-and-reactive-execution.md
@@ -99,7 +99,7 @@ machine_readable:
 
 ## Overrides (lex specialis)
 
-Sometimes a specific law overrides a general AWB rule. The Aliens Act (*Vreemdelingenwet*) article 69 says: *"in afwijking van artikel 6:7 Awb bedraagt de termijn vier weken"* ("departing from AWB article 6:7, the period is four weeks").
+Sometimes a specific law overrides a general AWB rule. The Aliens Act (*Vreemdelingenwet*) article 69 says: *"in afwijking van artikel 6:7 AWB bedraagt de termijn vier weken"* ("departing from AWB article 6:7, the period is four weeks").
 
 This is modeled with `overrides`:
 

--- a/docs/src/content/docs/concepts/how-it-works.md
+++ b/docs/src/content/docs/concepts/how-it-works.md
@@ -115,11 +115,11 @@ The General Administrative Law Act (AWB) applies to every government decision wi
 
 ### Overrides (lex specialis)
 
-Sometimes a specific law overrides a general rule. The Aliens Act (*Vreemdelingenwet*) article 69 says: *"in afwijking van artikel 6:7 AWB bedraagt de termijn vier weken"* — departing from the AWB's standard 6-week objection period. This is modeled with `overrides`: the specific law unilaterally replaces a value from the general law. The AWB does not know it is being overridden. This only applies when the overriding law is part of the execution chain. See [Hooks and Reactive Execution](./hooks-and-reactive-execution#overrides-lex-specialis).
+Sometimes a specific law overrides a general rule. The Aliens Act (*Vreemdelingenwet*) article 69 says: *"in afwijking van artikel 6:7 AWB bedraagt de termijn vier weken"*, departing from the AWB's standard 6-week objection period. This is modeled with `overrides`: the specific law unilaterally replaces a value from the general law. The AWB does not know it is being overridden. This only applies when the overriding law is part of the execution chain. See [Hooks and Reactive Execution](./hooks-and-reactive-execution#overrides-lex-specialis).
 
 ### Untranslatables
 
-The engine's operation set is deliberately small. When a legal construct cannot be faithfully expressed — rounding rules, complex table lookups, discretionary assessments — it is flagged as an **untranslatable** rather than approximated. The engine can error, warn, or propagate taint through downstream outputs, depending on the mode. This prevents silent divergence between law text and machine-readable interpretation. See [Untranslatables](./untranslatables).
+The engine's operation set is deliberately small. When a legal construct cannot be faithfully expressed, rounding rules, complex table lookups, discretionary assessments, it is flagged as an **untranslatable** rather than approximated. The engine can error, warn, or propagate taint through downstream outputs, depending on the mode. This prevents silent divergence between law text and machine-readable interpretation. See [Untranslatables](./untranslatables).
 
 ### Execution provenance
 

--- a/docs/src/content/docs/concepts/how-it-works.md
+++ b/docs/src/content/docs/concepts/how-it-works.md
@@ -72,7 +72,7 @@ The engine walks through the relevant articles, resolves all inputs, applies the
 To answer "does person X qualify for healthcare allowance?", the engine:
 
 1. Loads the *Zorgtoeslagwet*
-2. Looks at article 2, which needs: age (from the BRP), insurance status (from the Zorgverzekeringswet), income (from the AWIR), and the standard premium (from a ministerial regulation)
+2. Looks at article 2, which needs: insurance status (from the Zorgverzekeringswet), allowance-partner status and income (from the AWIR), and the standard premium (from a ministerial regulation)
 3. Loads and executes those other laws automatically to get their values
 4. Runs the calculation
 5. Returns `heeft_recht_op_zorgtoeslag: true` and `hoogte_zorgtoeslag: 1234`
@@ -87,7 +87,7 @@ These ideas show up throughout the system. Each has a dedicated page with exampl
 
 ### Laws that reference each other
 
-Dutch laws reference each other constantly. The healthcare allowance law needs your income (defined by the AWIR), your insurance status (from the Zorgverzekeringswet), and your age (from the BRP). In YAML, an article declares a `source` block pointing to another law:
+Dutch laws reference each other constantly. The healthcare allowance law needs your income (defined by the AWIR), your insurance status (from the Zorgverzekeringswet), and your allowance-partner status (also from the AWIR). In YAML, an article declares a `source` block pointing to another law:
 
 ```yaml
 input:
@@ -127,7 +127,7 @@ Every execution produces a receipt: a sealed envelope containing the engine vers
 
 ### Organizational boundaries and federated corpus
 
-Different government organizations handle different parts of the law chain. The Tax Authority determines income, the Allowances Service determines healthcare allowance, municipalities handle social assistance. The engine models these boundaries and supports both simulation mode (compute everything locally) and authoritative mode (exchange signed results between organizations). See [Multi-Org Execution](./multi-org-execution).
+Different government organizations handle different parts of the law chain. The Tax Authority determines income, the Allowances Service determines healthcare allowance, municipalities handle social assistance. The engine models these boundaries. Today it runs in simulation mode (compute everything locally); the authoritative mode that exchanges signed results between organizations is the proposed end state, not yet implemented. See [Multi-Org Execution](./multi-org-execution).
 
 On the data side, 342 municipalities, 12 provinces, and 21 water boards all produce their own regulations. The [federated corpus](./federated-corpus) model lets each authority maintain their own law files in their own Git repository while the engine discovers and loads them through a registry.
 

--- a/docs/src/content/docs/concepts/how-it-works.md
+++ b/docs/src/content/docs/concepts/how-it-works.md
@@ -111,11 +111,11 @@ See [Inversion of Control](./inversion-of-control).
 
 ### Laws that fire automatically
 
-The General Administrative Law Act (AWB) applies to every government decision without being called explicitly. When any law produces a *beschikking*, AWB rules about objection periods and reasoning requirements kick in through hooks. Neither law knows about the other. See [Hooks and Reactive Execution](./hooks-and-reactive-execution).
+The General Administrative Law Act (Awb) applies to every government decision without being called explicitly. When any law produces a *beschikking*, Awb rules about objection periods and reasoning requirements kick in through hooks. Neither law knows about the other. See [Hooks and Reactive Execution](./hooks-and-reactive-execution).
 
 ### Overrides (lex specialis)
 
-Sometimes a specific law overrides a general rule. The Aliens Act (*Vreemdelingenwet*) article 69 says: *"in afwijking van artikel 6:7 AWB bedraagt de termijn vier weken"*, departing from the AWB's standard 6-week objection period. This is modeled with `overrides`: the specific law unilaterally replaces a value from the general law. The AWB does not know it is being overridden. This only applies when the overriding law is part of the execution chain. See [Hooks and Reactive Execution](./hooks-and-reactive-execution#overrides-lex-specialis).
+Sometimes a specific law overrides a general rule. The Aliens Act (*Vreemdelingenwet*) article 69 says: *"in afwijking van artikel 6:7 Awb bedraagt de termijn vier weken"*, departing from the Awb's standard 6-week objection period. This is modeled with `overrides`: the specific law unilaterally replaces a value from the general law. The Awb does not know it is being overridden. This only applies when the overriding law is part of the execution chain. See [Hooks and Reactive Execution](./hooks-and-reactive-execution#overrides-lex-specialis).
 
 ### Untranslatables
 
@@ -123,7 +123,7 @@ The engine's operation set is deliberately small. When a legal construct cannot 
 
 ### Execution provenance
 
-Every execution produces a receipt: a sealed envelope containing the engine version, schema version, all loaded regulations (with content hashes), input parameters, outputs, and trace. This makes every decision reproducible and auditable, satisfying legal requirements from the AWB, AERIUS rulings, and EU AI Act. For cross-organization decisions, the receipt also captures the provenance of accepted values from other authorities. See [Execution Provenance](./execution-provenance).
+Every execution produces a receipt: a sealed envelope containing the engine version, schema version, all loaded regulations (with content hashes), input parameters, outputs, and trace. This makes every decision reproducible and auditable, satisfying legal requirements from the Awb, AERIUS rulings, and EU AI Act. For cross-organization decisions, the receipt also captures the provenance of accepted values from other authorities. See [Execution Provenance](./execution-provenance).
 
 ### Organizational boundaries and federated corpus
 

--- a/docs/src/content/docs/concepts/how-it-works.md
+++ b/docs/src/content/docs/concepts/how-it-works.md
@@ -115,7 +115,7 @@ The General Administrative Law Act (AWB) applies to every government decision wi
 
 ### Overrides (lex specialis)
 
-Sometimes a specific law overrides a general rule. The Aliens Act (*Vreemdelingenwet*) article 69 says: *"in afwijking van artikel 6:7 Awb bedraagt de termijn vier weken"* — departing from the AWB's standard 6-week objection period. This is modeled with `overrides`: the specific law unilaterally replaces a value from the general law. The AWB does not know it is being overridden. This only applies when the overriding law is part of the execution chain. See [Hooks and Reactive Execution](./hooks-and-reactive-execution#overrides-lex-specialis).
+Sometimes a specific law overrides a general rule. The Aliens Act (*Vreemdelingenwet*) article 69 says: *"in afwijking van artikel 6:7 AWB bedraagt de termijn vier weken"* — departing from the AWB's standard 6-week objection period. This is modeled with `overrides`: the specific law unilaterally replaces a value from the general law. The AWB does not know it is being overridden. This only applies when the overriding law is part of the execution chain. See [Hooks and Reactive Execution](./hooks-and-reactive-execution#overrides-lex-specialis).
 
 ### Untranslatables
 
@@ -123,7 +123,7 @@ The engine's operation set is deliberately small. When a legal construct cannot 
 
 ### Execution provenance
 
-Every execution produces a receipt: a sealed envelope containing the engine version, schema version, all loaded regulations (with content hashes), input parameters, outputs, and trace. This makes every decision reproducible and auditable, satisfying legal requirements from the Awb, AERIUS rulings, and EU AI Act. For cross-organisation decisions, the receipt also captures the provenance of accepted values from other authorities. See [Execution Provenance](./execution-provenance).
+Every execution produces a receipt: a sealed envelope containing the engine version, schema version, all loaded regulations (with content hashes), input parameters, outputs, and trace. This makes every decision reproducible and auditable, satisfying legal requirements from the AWB, AERIUS rulings, and EU AI Act. For cross-organization decisions, the receipt also captures the provenance of accepted values from other authorities. See [Execution Provenance](./execution-provenance).
 
 ### Organizational boundaries and federated corpus
 

--- a/docs/src/content/docs/concepts/how-it-works.md
+++ b/docs/src/content/docs/concepts/how-it-works.md
@@ -72,7 +72,7 @@ The engine walks through the relevant articles, resolves all inputs, applies the
 To answer "does person X qualify for healthcare allowance?", the engine:
 
 1. Loads the *Zorgtoeslagwet*
-2. Looks at article 2, which needs: insurance status (from the Zorgverzekeringswet), allowance-partner status and income (from the AWIR), and the standard premium (from a ministerial regulation)
+2. Looks at article 2, which needs: insurance status (from the Zorgverzekeringswet), allowance-partner status and income (from the Awir), and the standard premium (from a ministerial regulation)
 3. Loads and executes those other laws automatically to get their values
 4. Runs the calculation
 5. Returns `heeft_recht_op_zorgtoeslag: true` and `hoogte_zorgtoeslag: 1234`
@@ -87,7 +87,7 @@ These ideas show up throughout the system. Each has a dedicated page with exampl
 
 ### Laws that reference each other
 
-Dutch laws reference each other constantly. The healthcare allowance law needs your income (defined by the AWIR), your insurance status (from the Zorgverzekeringswet), and your allowance-partner status (also from the AWIR). In YAML, an article declares a `source` block pointing to another law:
+Dutch laws reference each other constantly. The healthcare allowance law needs your income (defined by the Awir), your insurance status (from the Zorgverzekeringswet), and your allowance-partner status (also from the Awir). In YAML, an article declares a `source` block pointing to another law:
 
 ```yaml
 input:
@@ -135,7 +135,7 @@ On the data side, 342 municipalities, 12 provinces, and 21 water boards all prod
 
 Every execution produces a trace tree. The trace shows which articles were applied, which inputs were fetched and from where, which operations ran, and what each step produced. Think of it as an explanation of the legal reasoning in structured form.
 
-Traces show cross-law references ("income came from AWIR article 8"), IoC resolution ("standard premium came from Regeling standaardpremie"), and organizational boundaries ("income accepted from Tax Authority"). Citizens can request their trace from each contributing organization.
+Traces show cross-law references ("income came from Awir article 8"), IoC resolution ("standard premium came from Regeling standaardpremie"), and organizational boundaries ("income accepted from Tax Authority"). Citizens can request their trace from each contributing organization.
 
 ## Temporal versioning
 

--- a/docs/src/content/docs/concepts/law-format.md
+++ b/docs/src/content/docs/concepts/law-format.md
@@ -120,7 +120,8 @@ Operations are the building blocks of law logic:
 | **Arithmetic** | `ADD`, `SUBTRACT`, `MULTIPLY`, `DIVIDE` | `values: [...]` |
 | **Aggregate** | `MIN`, `MAX` | `values: [...]` |
 | **Comparison** | `EQUALS`, `GREATER_THAN`, `LESS_THAN`, `GREATER_THAN_OR_EQUAL`, `LESS_THAN_OR_EQUAL` | `subject:`, `value:` |
-| **Logical** | `AND`, `OR`, `NOT` | `conditions: [...]` (`NOT` wraps one condition) |
+| **Logical** | `AND`, `OR` | `conditions: [...]` |
+| **Logical** | `NOT` | `value:` (wraps a single operation) |
 | **Collection** | `IN`, `LIST` | `IN`: `subject:`, `values: [...]`; `LIST`: `items: [...]` |
 | **Conditional** | `IF` (alias `SWITCH`) | `cases: [{when:, then:}]`, `default:` |
 | **Date** | `AGE`, `DATE_ADD`, `DATE`, `DAY_OF_WEEK` | `AGE`: `date_of_birth:`, `reference_date:`; `DATE_ADD`: `date:` + `years:`/`months:`/`days:`; `DATE`: `year:`, `month:`, `day:`; `DAY_OF_WEEK`: `date:` |

--- a/docs/src/content/docs/concepts/law-format.md
+++ b/docs/src/content/docs/concepts/law-format.md
@@ -120,9 +120,8 @@ Operations are the building blocks of law logic:
 | **Arithmetic** | `ADD`, `SUBTRACT`, `MULTIPLY`, `DIVIDE` | `values: [...]` |
 | **Aggregate** | `MIN`, `MAX` | `values: [...]` |
 | **Comparison** | `EQUALS`, `GREATER_THAN`, `LESS_THAN`, `GREATER_THAN_OR_EQUAL`, `LESS_THAN_OR_EQUAL` | `subject:`, `value:` |
-| **Logical** | `AND`, `OR` | `conditions: [...]` |
-| **Logical** | `NOT` | `value:` (wraps a single operation) |
-| **Collection** | `IN`, `LIST` | `IN`: `subject:`, `values: [...]`; `LIST`: `items: [...]` |
+| **Logical** | `AND`, `OR`, `NOT` | `AND`/`OR`: `conditions: [...]`; `NOT`: `value:` (wraps a single operation) |
+| **Collection** | `IN`, `LIST` | `IN`: `subject:` + `value:` or `values: [...]`; `LIST`: `items: [...]` |
 | **Conditional** | `IF` (alias `SWITCH`) | `cases: [{when:, then:}]`, `default:` |
 | **Date** | `AGE`, `DATE_ADD`, `DATE`, `DAY_OF_WEEK` | `AGE`: `date_of_birth:`, `reference_date:`; `DATE_ADD`: `date:` + `years:`/`months:`/`days:`; `DATE`: `year:`, `month:`, `day:`; `DAY_OF_WEEK`: `date:` |
 

--- a/docs/src/content/docs/concepts/law-format.md
+++ b/docs/src/content/docs/concepts/law-format.md
@@ -192,7 +192,7 @@ execution:
     decision_type: TOEKENNING      # Grant
 ```
 
-This enables the AWB procedure hooks ([RFC-008](/rfcs/rfc-008)).
+This enables the Awb procedure hooks ([RFC-008](/rfcs/rfc-008)).
 
 ### Type Specifications
 
@@ -213,7 +213,7 @@ The corpus is still small and growing. At the time of writing it spans three reg
 
 | Layer | Laws | Examples |
 |-------|------|---------|
-| WET | ~15 | Participatiewet, Zorgtoeslag, Zorgverzekeringswet, AWB, BW Boek 5 |
+| WET | ~15 | Participatiewet, Zorgtoeslag, Zorgverzekeringswet, Awb, BW Boek 5 |
 | MINISTERIELE_REGELING | 1 | Regeling standaardpremie (2 versions) |
 | GEMEENTELIJKE_VERORDENING | 2 | Amsterdam APV erfgrens, Diemen afstemmingsverordening |
 

--- a/docs/src/content/docs/concepts/law-format.md
+++ b/docs/src/content/docs/concepts/law-format.md
@@ -33,7 +33,7 @@ corpus/regulation/nl/
 ### Header Metadata
 
 ```yaml
-$schema: https://raw.githubusercontent.com/.../refs/tags/schema-v0.5.1/schema/v0.5.1/schema.json
+$schema: https://raw.githubusercontent.com/.../refs/tags/schema-v0.5.2/schema/v0.5.2/schema.json
 $id: zorgtoeslagwet
 regulatory_layer: WET
 publication_date: '2025-01-01'
@@ -119,15 +119,13 @@ Operations are the building blocks of law logic:
 |----------|-----------|--------|
 | **Arithmetic** | `ADD`, `SUBTRACT`, `MULTIPLY`, `DIVIDE` | `values: [...]` |
 | **Aggregate** | `MIN`, `MAX` | `values: [...]` |
-| **Comparison** | `EQUALS`, `NOT_EQUALS`, `GREATER_THAN`, `LESS_THAN`, `GREATER_THAN_OR_EQUAL`, `LESS_THAN_OR_EQUAL` | `subject:`, `value:` |
-| **Logical** | `AND`, `OR` | `conditions: [...]` |
-| **Membership** | `IN`, `NOT_IN` | `subject:`, `values: [...]` |
-| **Conditional** | `IF` | `when:`, `then:`, `else:` |
-| **Multi-branch** | `SWITCH` | `cases: [{when:, then:}]`, `default:` |
-| **Date** | `SUBTRACT_DATE` | `subject:`, `value:`, `unit:` |
-| **Null** | `IS_NULL`, `NOT_NULL` | `subject:` |
+| **Comparison** | `EQUALS`, `GREATER_THAN`, `LESS_THAN`, `GREATER_THAN_OR_EQUAL`, `LESS_THAN_OR_EQUAL` | `subject:`, `value:` |
+| **Logical** | `AND`, `OR`, `NOT` | `conditions: [...]` (`NOT` wraps one condition) |
+| **Collection** | `IN`, `LIST` | `IN`: `subject:`, `values: [...]`; `LIST`: `values: [...]` |
+| **Conditional** | `IF` (alias `SWITCH`) | `cases: [{when:, then:}]`, `default:` |
+| **Date** | `AGE`, `DATE_ADD`, `DATE`, `DAY_OF_WEEK` | `AGE`: `date_of_birth:`, `reference_date:`; `DATE_ADD`: `date:` + `years:`/`months:`/`days:`; `DATE`: `year:`, `month:`, `day:`; `DAY_OF_WEEK`: `date:` |
 
-See [RFC-004: Uniform Operation Syntax](/rfcs/rfc-004) for the full specification.
+These 21 operations make up the schema. The engine also accepts the compat aliases `NOT_EQUALS`, `IS_NULL`, `NOT_NULL`, and `NOT_IN` for backward compatibility, but they are outside the schema, so prefer wrapping the positive operation in `NOT`. See [RFC-004: Uniform Operation Syntax](/rfcs/rfc-004) for the full specification.
 
 ### Variable References
 
@@ -210,13 +208,15 @@ output:
 
 ## Corpus Contents
 
-The current corpus contains laws across three regulatory layers:
+The corpus is still small and growing. At the time of writing it spans three regulatory layers:
 
-| Layer | Count | Examples |
-|-------|-------|---------|
-| WET | 11 | Participatiewet, Zorgtoeslag, Zorgverzekeringswet, BW Boek 5 |
+| Layer | Laws | Examples |
+|-------|------|---------|
+| WET | ~15 | Participatiewet, Zorgtoeslag, Zorgverzekeringswet, AWB, BW Boek 5 |
 | MINISTERIELE_REGELING | 1 | Regeling standaardpremie (2 versions) |
 | GEMEENTELIJKE_VERORDENING | 2 | Amsterdam APV erfgrens, Diemen afstemmingsverordening |
+
+For the authoritative, current set, see `corpus/regulation/` in the repository.
 
 ## Next Steps
 

--- a/docs/src/content/docs/concepts/law-format.md
+++ b/docs/src/content/docs/concepts/law-format.md
@@ -121,7 +121,7 @@ Operations are the building blocks of law logic:
 | **Aggregate** | `MIN`, `MAX` | `values: [...]` |
 | **Comparison** | `EQUALS`, `GREATER_THAN`, `LESS_THAN`, `GREATER_THAN_OR_EQUAL`, `LESS_THAN_OR_EQUAL` | `subject:`, `value:` |
 | **Logical** | `AND`, `OR`, `NOT` | `conditions: [...]` (`NOT` wraps one condition) |
-| **Collection** | `IN`, `LIST` | `IN`: `subject:`, `values: [...]`; `LIST`: `values: [...]` |
+| **Collection** | `IN`, `LIST` | `IN`: `subject:`, `values: [...]`; `LIST`: `items: [...]` |
 | **Conditional** | `IF` (alias `SWITCH`) | `cases: [{when:, then:}]`, `default:` |
 | **Date** | `AGE`, `DATE_ADD`, `DATE`, `DAY_OF_WEEK` | `AGE`: `date_of_birth:`, `reference_date:`; `DATE_ADD`: `date:` + `years:`/`months:`/`days:`; `DATE`: `year:`, `month:`, `day:`; `DAY_OF_WEEK`: `date:` |
 

--- a/docs/src/content/docs/concepts/methodology.md
+++ b/docs/src/content/docs/concepts/methodology.md
@@ -1,8 +1,9 @@
 ---
 title: "Validation Methodology"
+description: "Short overview of RegelRecht's execution-first validation method and the generate/validate/reverse-check loop."
 ---
 
-RegelRecht uses an **execution-first** approach to validate machine-readable law interpretations.
+RegelRecht uses an **execution-first** approach to validate machine-readable law interpretations. This page is a short overview; for the research background and the full argument, see [RegelRecht Validation: From Analysis-First to Execution-First](./validation-methodology).
 
 ## From Analysis-First to Execution-First
 

--- a/docs/src/content/docs/concepts/multi-org-execution.md
+++ b/docs/src/content/docs/concepts/multi-org-execution.md
@@ -17,16 +17,21 @@ This distinction determines the execution boundary. A calculation can be run by 
 
 ## How the engine decides
 
-A law that produces a formal decision declares `competent_authority`. It sits at the top level of the law (or inside a `machine_readable` section), as a sibling of `execution`, not inside `execution.produces`:
+A law that produces a formal decision declares `competent_authority`. The schema allows it at the top level of the law or inside a `machine_readable` section; it is **not** a field of `execution.produces`. The corpus uses the top-level form (see `corpus/regulation/nl/wet/wet_op_de_zorgtoeslag/2025-01-01.yaml`):
 
 ```yaml
+$id: zorgtoeslagwet
 competent_authority: belastingdienst_toeslagen
+# ...
 
-# ... elsewhere, the article's execution declares what it produces:
-execution:
-  produces:
-    legal_character: BESCHIKKING
-    decision_type: TOEKENNING
+# elsewhere, an article's execution declares what it produces:
+articles:
+  - number: "2"
+    machine_readable:
+      execution:
+        produces:
+          legal_character: BESCHIKKING
+          decision_type: TOEKENNING
 ```
 
 When the engine hits a cross-law reference and needs to resolve it, the intended decision tree is:

--- a/docs/src/content/docs/concepts/multi-org-execution.md
+++ b/docs/src/content/docs/concepts/multi-org-execution.md
@@ -17,11 +17,11 @@ This distinction determines the execution boundary. A calculation can be run by 
 
 ## How the engine decides
 
-A law that produces a formal decision declares `competent_authority`. The schema allows it at the top level of the law or inside a `machine_readable` section; it is **not** a field of `execution.produces`. The corpus uses the top-level form (see `corpus/regulation/nl/wet/wet_op_de_zorgtoeslag/2025-01-01.yaml`):
+A law that produces a formal decision declares `competent_authority`. The engine reads it from the top level of the law (or from a `machine_readable` section); it is **not** a field of `execution.produces`. The JSON schema defines `competent_authority` on the `machine_readable` section, but the top-level form is accepted too (the top-level object does not reject extra keys), and that is what the corpus uses, often as a `#`-reference into the law's definitions (see `corpus/regulation/nl/wet/wet_op_de_zorgtoeslag/2025-01-01.yaml`):
 
 ```yaml
 $id: zorgtoeslagwet
-competent_authority: belastingdienst_toeslagen
+competent_authority: '#bevoegd_gezag'   # top-level, resolved from definitions
 # ...
 
 # elsewhere, an article's execution declares what it produces:

--- a/docs/src/content/docs/concepts/multi-org-execution.md
+++ b/docs/src/content/docs/concepts/multi-org-execution.md
@@ -17,35 +17,39 @@ This distinction determines the execution boundary. A calculation can be run by 
 
 ## How the engine decides
 
-Each article that produces a formal decision declares `competent_authority`:
+A law that produces a formal decision declares `competent_authority`. It sits at the top level of the law (or inside a `machine_readable` section), as a sibling of `execution`, not inside `execution.produces`:
 
 ```yaml
+competent_authority: belastingdienst_toeslagen
+
+# ... elsewhere, the article's execution declares what it produces:
 execution:
   produces:
     legal_character: BESCHIKKING
     decision_type: TOEKENNING
-    competent_authority: belastingdienst_toeslagen
 ```
 
-When the engine hits a cross-law reference and needs to resolve it, the decision tree is:
+When the engine hits a cross-law reference and needs to resolve it, the intended decision tree is:
 
 1. Does the target article produce a BESCHIKKING? If no: **execute locally** (it is just a calculation)
 2. Is `competent_authority` declared? If no: **execute locally** with a warning
 3. Is the competent authority the same organization running this engine? If yes: **execute locally**
 4. Otherwise: **accept** the other organization's determination
 
+Step 4 (accepting an external authority's determination) belongs to the federated modes below and is not yet implemented; in the current Solo mode the engine always executes locally.
+
 ## Execution modes
 
-The engine supports four modes, based on two independent choices:
+The design ([RFC-009](/rfcs/rfc-009)) describes four modes, based on two independent choices, **connectivity** (Solo or Federated) and **legal status** (Simulation or Authoritative):
 
 | | Simulation | Authoritative |
 |---|---|---|
 | **Solo** (local only) | Execute everything locally. No identity, unsigned outputs. Good for exploring the full chain. | Execute with identity. Sign outputs. No cross-org calls. |
 | **Federated** (cross-org) | Identity + real calls to other engines. Unsigned outputs. For testing inter-org flows. | Identity + real calls + signed outputs. Production mode. |
 
-**Solo simulation** is the default. Anyone can explore the full calculation chain for any law without needing credentials or organizational identity. This is what runs in the browser editor.
+Today the engine implements only **Solo / Simulation**: it executes everything locally with no organizational identity and unsigned outputs. This is the default and is what runs in the browser editor.
 
-**Federated authoritative** is production mode. Each engine identifies as a specific organization, calls other organizations' engines through FSC (Federated Service Connectivity), and signs its outputs cryptographically.
+The other three modes are the proposed end state. **Federated authoritative** is the eventual production mode, where each engine identifies as a specific organization, calls other organizations' engines through FSC (Federated Service Connectivity), and signs its outputs cryptographically. Federated connectivity, the Authoritative legal status, FSC calls, and output signing are not implemented yet.
 
 ## What the trace shows
 

--- a/docs/src/content/docs/concepts/multi-org-execution.md
+++ b/docs/src/content/docs/concepts/multi-org-execution.md
@@ -66,6 +66,6 @@ A citizen requesting their trace can see: "your income was determined by the Tax
 
 ## Further reading
 
-- [Hooks and Reactive Execution](./hooks-and-reactive-execution) - how AWB rules apply across organizations
+- [Hooks and Reactive Execution](./hooks-and-reactive-execution) - how Awb rules apply across organizations
 - [Federated Corpus](./federated-corpus) - how different organizations maintain their own law files
 - [RFC-009: Multi-Org Execution](/rfcs/rfc-009) - the full design specification

--- a/docs/src/content/docs/concepts/untranslatables.md
+++ b/docs/src/content/docs/concepts/untranslatables.md
@@ -4,7 +4,7 @@ title: "Untranslatables"
 
 The engine's operation set is deliberately small: arithmetic, comparison, conditional logic, date operations. Dutch law regularly uses constructs that fall outside this set. When a legal construct cannot be faithfully expressed with available operations, it is an **untranslatable**.
 
-The term comes from translation theory. The law-generate process *is* translation — from legal Dutch to machine-readable YAML — and some things do not cross that boundary.
+The term comes from translation theory. The law-generate process *is* translation, from legal Dutch to machine-readable YAML, and some things do not cross that boundary.
 
 ## What makes something untranslatable
 

--- a/docs/src/content/docs/concepts/validation-methodology.md
+++ b/docs/src/content/docs/concepts/validation-methodology.md
@@ -135,7 +135,7 @@ The automated steps cover:
 What is missing: a **structured process for legal experts to systematically assess the AI proposals**. This differs from the Wetsanalyse validation step (step 4), because:
 
 1. The expert did not build the proposal, the mental model is absent
-2. The AI does not document its interpretation choices, they must be uncovered
+2. The AI does not document its interpretation choices; they must be uncovered
 3. The scale demands an efficient process, not every law can take weeks
 
 ## Proposal: validation method in three phases

--- a/docs/src/content/docs/concepts/validation-methodology.md
+++ b/docs/src/content/docs/concepts/validation-methodology.md
@@ -194,25 +194,25 @@ This is the current pipeline. The AI generates a candidate rule specification an
 
 The expert reviews the proposal *before* scenarios are run. This is the phase missing from the current pipeline and it draws on insights from Wetsanalyse:
 
-**B1. Completeness check**, Are all articles covered? Did the AI skip articles that contain executable logic? This is analogous to the scope step (step 1) of Wetsanalyse, but after the fact: not "what will we analyze" but "has everything been analyzed."
+**B1. Completeness check**: Are all articles covered? Did the AI skip articles that contain executable logic? This is analogous to the scope step (step 1) of Wetsanalyse, but after the fact: not "what will we analyze" but "has everything been analyzed."
 
-**B2. Assumption assessment**, Reverse validation has flagged assumptions. The expert assesses each one: is this a defensible choice, or does it need to change? This addresses the risk of implicit interpretation choices.
+**B2. Assumption assessment**: Reverse validation has flagged assumptions. The expert assesses each one: is this a defensible choice, or does it need to change? This addresses the risk of implicit interpretation choices.
 
-**B3. Interpretation inventory**, Where does the law allow multiple readings? Which reading did the AI pick? Is it defensible? This is analogous to the meaning step (step 3) of Wetsanalyse, but reactive: not "what does this mean" but "is the AI's reading correct." This step counters automation bias.
+**B3. Interpretation inventory**: Where does the law allow multiple readings? Which reading did the AI pick? Is it defensible? This is analogous to the meaning step (step 3) of Wetsanalyse, but reactive: not "what does this mean" but "is the AI's reading correct." This step counters automation bias.
 
 ### Phase C: Scenario validation (workshop)
 
 The expert validates the *behavior* of the specification, not the YAML itself. This is the heart of the method:
 
-**C1. Walk through MvT scenarios**, The engine runs scenarios from parliamentary documents. The expert checks whether outcomes match legislative intent.
+**C1. Walk through MvT scenarios**: The engine runs scenarios from parliamentary documents. The expert checks whether outcomes match legislative intent.
 
-**C2. Build adversarial scenarios**, This is where the expert is irreplaceable. The AI has no access to case law, implementation practice, or political context. The expert builds scenarios that stress-test the specification:
+**C2. Build adversarial scenarios**: This is where the expert is irreplaceable. The AI has no access to case law, implementation practice, or political context. The expert builds scenarios that stress-test the specification:
 - Edge cases from practice and case law
 - Exception paths ("unless" clauses)
 - Boundary values (just above/below thresholds)
 - Concurrence situations (interaction between laws)
 
-**C3. Run adversarial scenarios**, The engine runs them. The expert checks the outcomes. Errors lead to iteration.
+**C3. Run adversarial scenarios**: The engine runs them. The expert checks the outcomes. Errors lead to iteration.
 
 ### Phase D: Wrap-up
 

--- a/docs/src/content/docs/concepts/validation-methodology.md
+++ b/docs/src/content/docs/concepts/validation-methodology.md
@@ -32,9 +32,9 @@ flowchart TD
 
 Three characteristics define it:
 
-1. **People do everything** — annotation, definition, modeling, and validation are all human work
-2. **Validation checks your own work** — the multidisciplinary team reviews models it built itself
-3. **Traceability is built in** — every element in the knowledge model points back to the source text in the law
+1. **People do everything**: annotation, definition, modeling, and validation are all human work
+2. **Validation checks your own work**: the multidisciplinary team reviews models it built itself
+3. **Traceability is built in**: every element in the knowledge model points back to the source text in the law
 
 The output is a knowledge model consisting of a data model (FBM/ER), rule model (DMN decision tables), and process model (BPMN). This model serves as the basis for building an IT system.
 
@@ -42,12 +42,12 @@ The output is a knowledge model consisting of a data model (FBM/ER), rule model 
 
 Despite differences in terminology, existing methods follow the same pattern:
 
-1. **Decomposition** — break the legal text into manageable units
-2. **Identification** — recognize key concepts (who, what, when, what consequence)
-3. **Interpretation** — explicitly record what the law means
-4. **Modeling** — organize into data, rule, and process models
-5. **Validation** — test against concrete scenarios and test cases
-6. **Traceability** — trace every rule back to the source
+1. **Decomposition**: break the legal text into manageable units
+2. **Identification**: recognize key concepts (who, what, when, what consequence)
+3. **Interpretation**: explicitly record what the law means
+4. **Modeling**: organize into data, rule, and process models
+5. **Validation**: test against concrete scenarios and test cases
+6. **Traceability**: trace every rule back to the source
 
 All these methods are *analysis-first*: they start from the law and work toward a model or rule set. The translation is done entirely by people.
 
@@ -59,7 +59,7 @@ RegelRecht is not just a method or a DSL. It is a broad execution ecosystem for 
 
 Where existing methods share an analysis-first approach, RegelRecht aims to create a coherent system of machine-executable legislation. Laws interact across boundaries and citizens are not burdened with complexity.
 
-The rule specification gets *single source of truth* status for how the law works. It is not an analysis layer that leads to a translation — the output of the analysis **is** the law in executable form.
+The rule specification gets *single source of truth* status for how the law works. It is not an analysis layer that leads to a translation, the output of the analysis **is** the law in executable form.
 
 ### Principle 2: Transparent and simple
 
@@ -107,10 +107,10 @@ The bottleneck moves from *creation* to *validation*. That makes validation the 
 
 The shift introduces specific risks that do not exist in analysis-first:
 
-- **Automation bias** — the tendency to accept AI output as correct
-- **Anchoring** — the AI's proposal influences the expert's judgment
-- **Blind spots** — the AI does not know what it does not know; neither does a reviewer who is not actively searching
-- **Implicit interpretation choices** — where the law is ambiguous, the AI makes a choice without documenting it
+- **Automation bias**: the tendency to accept AI output as correct
+- **Anchoring**: the AI's proposal influences the expert's judgment
+- **Blind spots**: the AI does not know what it does not know; neither does a reviewer who is not actively searching
+- **Implicit interpretation choices**: where the law is ambiguous, the AI makes a choice without documenting it
 
 ## Problem identification: the missing link
 
@@ -128,15 +128,15 @@ flowchart TD
 ```
 
 The automated steps cover:
-- **Structural correctness** — schema validation
-- **Behavioral correctness** — BDD tests based on MvT examples
-- **Traceability** — reverse validation checks whether every element points to the legal text
+- **Structural correctness**: schema validation
+- **Behavioral correctness**: BDD tests based on MvT examples
+- **Traceability**: reverse validation checks whether every element points to the legal text
 
 What is missing: a **structured process for legal experts to systematically assess the AI proposals**. This differs from the Wetsanalyse validation step (step 4), because:
 
-1. The expert did not build the proposal — the mental model is absent
-2. The AI does not document its interpretation choices — they must be uncovered
-3. The scale demands an efficient process — not every law can take weeks
+1. The expert did not build the proposal, the mental model is absent
+2. The AI does not document its interpretation choices, they must be uncovered
+3. The scale demands an efficient process, not every law can take weeks
 
 ## Proposal: validation method in three phases
 
@@ -186,39 +186,39 @@ flowchart TD
 
 This is the current pipeline. The AI generates a candidate rule specification and automated checks filter structural errors and untraceable elements. The output is not a finished product but a *proposal with documentation*:
 
-- **Traceability report** — which elements are grounded in the legal text, which are assumptions
-- **BDD results** — which MvT scenarios pass and fail
-- **List of assumptions** — elements that do not follow directly from the text but are needed for execution
+- **Traceability report**: which elements are grounded in the legal text, which are assumptions
+- **BDD results**: which MvT scenarios pass and fail
+- **List of assumptions**: elements that do not follow directly from the text but are needed for execution
 
 ### Phase B: Expert preparation
 
 The expert reviews the proposal *before* scenarios are run. This is the phase missing from the current pipeline and it draws on insights from Wetsanalyse:
 
-**B1. Completeness check** — Are all articles covered? Did the AI skip articles that contain executable logic? This is analogous to the scope step (step 1) of Wetsanalyse, but after the fact: not "what will we analyze" but "has everything been analyzed."
+**B1. Completeness check**, Are all articles covered? Did the AI skip articles that contain executable logic? This is analogous to the scope step (step 1) of Wetsanalyse, but after the fact: not "what will we analyze" but "has everything been analyzed."
 
-**B2. Assumption assessment** — Reverse validation has flagged assumptions. The expert assesses each one: is this a defensible choice, or does it need to change? This addresses the risk of implicit interpretation choices.
+**B2. Assumption assessment**, Reverse validation has flagged assumptions. The expert assesses each one: is this a defensible choice, or does it need to change? This addresses the risk of implicit interpretation choices.
 
-**B3. Interpretation inventory** — Where does the law allow multiple readings? Which reading did the AI pick? Is it defensible? This is analogous to the meaning step (step 3) of Wetsanalyse, but reactive: not "what does this mean" but "is the AI's reading correct." This step counters automation bias.
+**B3. Interpretation inventory**, Where does the law allow multiple readings? Which reading did the AI pick? Is it defensible? This is analogous to the meaning step (step 3) of Wetsanalyse, but reactive: not "what does this mean" but "is the AI's reading correct." This step counters automation bias.
 
 ### Phase C: Scenario validation (workshop)
 
 The expert validates the *behavior* of the specification, not the YAML itself. This is the heart of the method:
 
-**C1. Walk through MvT scenarios** — The engine runs scenarios from parliamentary documents. The expert checks whether outcomes match legislative intent.
+**C1. Walk through MvT scenarios**, The engine runs scenarios from parliamentary documents. The expert checks whether outcomes match legislative intent.
 
-**C2. Build adversarial scenarios** — This is where the expert is irreplaceable. The AI has no access to case law, implementation practice, or political context. The expert builds scenarios that stress-test the specification:
+**C2. Build adversarial scenarios**, This is where the expert is irreplaceable. The AI has no access to case law, implementation practice, or political context. The expert builds scenarios that stress-test the specification:
 - Edge cases from practice and case law
 - Exception paths ("unless" clauses)
 - Boundary values (just above/below thresholds)
 - Concurrence situations (interaction between laws)
 
-**C3. Run adversarial scenarios** — The engine runs them. The expert checks the outcomes. Errors lead to iteration.
+**C3. Run adversarial scenarios**, The engine runs them. The expert checks the outcomes. Errors lead to iteration.
 
 ### Phase D: Wrap-up
 
 Analogous to the policy-gap step (step 5) of Wetsanalyse:
 
-- **Policy gaps** are noted — where the law underspecifies and a choice was made
+- **Policy gaps** are noted, where the law underspecifies and a choice was made
 - **Assumptions** are formally accepted or rejected
 - **Expert sign-off** is recorded
 
@@ -237,7 +237,7 @@ The difference with Wetsanalyse validation matters: the expert did not build the
 
 ### MvT examples are ground truth
 
-Worked examples from the Memorie van Toelichting represent the legislature's intent. If the engine produces a different result than the MvT example, the specification is wrong — not the example.
+Worked examples from the Memorie van Toelichting represent the legislature's intent. If the engine produces a different result than the MvT example, the specification is wrong, not the example.
 
 ### The method is iterative
 

--- a/docs/src/content/docs/guide/architecture.md
+++ b/docs/src/content/docs/guide/architecture.md
@@ -33,22 +33,29 @@ C4Container
 
     System_Boundary(rr, "RegelRecht") {
         Container(editor, "Editor", "Vue 3 / Vite", "Law editing and browsing")
+        Container(editorapi, "Editor API", "Rust / Axum", "Serves the editor and corpus REST API")
         Container(engine, "Engine", "Rust / WASM", "Deterministic law execution")
         Container(pipeline, "Pipeline", "Rust / PostgreSQL", "Job queue and law status tracking")
-        Container(harvester, "Harvester", "Rust", "Downloads laws from BWB")
+        Container(harvester, "Harvester", "Rust", "Downloads laws from BWB / CVDR")
+        Container(enrich, "Enrich Worker", "Rust / LLM", "Adds machine_readable sections")
         Container(admin, "Admin", "Rust + Vue", "Operations dashboard")
         ContainerDb(corpus, "Corpus Juris", "Git / YAML", "All laws in machine-readable format")
         ContainerDb(db, "PostgreSQL", "Database", "Job queue and law status")
     }
 
     Rel(user, editor, "Browses and edits laws")
+    Rel(editor, editorapi, "REST API calls")
     Rel(editor, engine, "Executes laws (WASM)")
-    Rel(editor, corpus, "Reads law files")
+    Rel(editorapi, corpus, "Reads and writes law files")
     Rel(harvester, corpus, "Writes harvested laws")
+    Rel(enrich, corpus, "Writes enriched laws")
     Rel(pipeline, db, "Manages jobs")
     Rel(pipeline, harvester, "Triggers harvesting")
+    Rel(pipeline, enrich, "Triggers enrichment")
     Rel(admin, db, "Monitors pipeline")
 ```
+
+The editor, TUI, lawmaking visualization, Grafana, and the engine's WASM/CLI builds are additional surfaces over the same engine and corpus; they are omitted here to keep the container view readable. See the [component docs](/components/engine) for each.
 
 ## Data Flow
 

--- a/docs/src/content/docs/guide/testing.md
+++ b/docs/src/content/docs/guide/testing.md
@@ -10,17 +10,19 @@ The primary testing approach uses Gherkin feature files executed by [cucumber-rs
 
 ### Feature Files
 
-Located in `features/`, these describe expected law behavior:
+Located in `features/`, these describe expected law behavior. Use the step phrasings the cucumber-rs suite actually defines (`packages/engine/tests/bdd/steps/`); a minimal scenario looks like:
 
 ```gherkin
-Feature: Kinderbijslag
+Feature: Healthcare allowance
 
-  Scenario: Parent with two children receives kinderbijslag
-    Given the law "wet_kinderbijslag"
-    And input "aantal_kinderen" is 2
-    When the law is executed
-    Then output "heeft_recht" should be true
+  Scenario: Output is present for an eligible person
+    Given the calculation date is "2025-01-01"
+    When the law "zorgtoeslagwet" is executed for outputs "hoogte_zorgtoeslag"
+    Then the execution succeeds
+    And the output "hoogte_zorgtoeslag" is "123400"
 ```
+
+Laws that need source data (BRP, Belastingdienst, etc.) provide it with data-table steps such as `Given the following RVIG "personal_data" data:`. See `features/zorgtoeslag.feature` for a complete, data-driven example.
 
 ### Running BDD Tests
 

--- a/docs/src/content/docs/guide/translation-examples.md
+++ b/docs/src/content/docs/guide/translation-examples.md
@@ -4,7 +4,7 @@ title: "Translation Examples"
 
 This page shows how Dutch law is translated into machine-readable YAML, with detailed reasoning about why specific patterns are chosen.
 
-## Example: BW 5:42 and Amsterdam APV — Erfgrensbeplanting
+## Example: BW 5:42 and Amsterdam APV: Erfgrensbeplanting
 
 ### The law
 
@@ -72,7 +72,7 @@ actions:
       default: 50  # ← WRONG: gives 50cm for trees outside centrum
 ```
 
-The problem: once Amsterdam claims to implement `minimale_afstand_cm`, it must return a value for **every** case. But Amsterdam has nothing to say about trees outside the centrum. If the default is 50, non-centrum trees get 50 cm instead of 200 cm. If we hardcode 200 in the APV, we're putting BW 5:42's value in Amsterdam's regulation — a scope violation.
+The problem: once Amsterdam claims to implement `minimale_afstand_cm`, it must return a value for **every** case. But Amsterdam has nothing to say about trees outside the centrum. If the default is 50, non-centrum trees get 50 cm instead of 200 cm. If we hardcode 200 in the APV, we're putting BW 5:42's value in Amsterdam's regulation, a scope violation.
 
 ### The correct translation
 
@@ -82,9 +82,9 @@ The key insight is to read the BW text carefully. It says:
 
 The "tenzij" (unless) structure tells us exactly how to model this:
 
-1. **The BW sets its own defaults** — these are the rule.
-2. **The BW offers an optional delegation** — this is the exception.
-3. **The BW decides which to use** — if the delegation produces a value, use it; otherwise, use the default.
+1. **The BW sets its own defaults**: these are the rule.
+2. **The BW offers an optional delegation**: this is the exception.
+3. **The BW decides which to use**: if the delegation produces a value, use it; otherwise, use the default.
 
 This maps directly to the YAML:
 
@@ -195,9 +195,9 @@ machine_readable:
 
 Each article stays within its own scope:
 
-- **BW 5:42** sets the rule (200/50) and defines the exception mechanism ("tenzij verordening"). Both are in the article text. The null-check is the machine-readable expression of "tenzij" — if no exception exists, the rule applies.
+- **BW 5:42** sets the rule (200/50) and defines the exception mechanism ("tenzij verordening"). Both are in the article text. The null-check is the machine-readable expression of "tenzij", if no exception exists, the rule applies.
 
-- **Amsterdam APV 2.75** only produces values where it has something to say (centrum bomen: 100, heggen: 50). For cases it doesn't cover (bomen buiten centrum), it returns null — meaning "I have no opinion on this." The BW then applies its own default.
+- **Amsterdam APV 2.75** only produces values where it has something to say (centrum bomen: 100, heggen: 50). For cases it doesn't cover (bomen buiten centrum), it returns null, meaning "I have no opinion on this." The BW then applies its own default.
 
 No article hardcodes values from another article. No scope violations. The delegation mechanism faithfully represents the "tenzij" structure of the law.
 
@@ -210,7 +210,7 @@ This pattern applies whenever a higher law sets defaults that lower regulations 
 3. The higher law uses a **null-check** to choose between the override and the default.
 4. The lower regulation **only returns values where it deviates**; null otherwise.
 
-The "tenzij" in the law text is the signal that this pattern applies. The word literally means "unless" — the rule applies *unless* the exception is triggered.
+The "tenzij" in the law text is the signal that this pattern applies. The word literally means "unless", the rule applies *unless* the exception is triggered.
 
 ```
 Rule: X

--- a/docs/src/content/docs/guide/what-is-regelrecht.mdx
+++ b/docs/src/content/docs/guide/what-is-regelrecht.mdx
@@ -90,7 +90,7 @@ Legislation is decentralized: municipalities, provinces, and water boards produc
 
 ### Administrative Procedures
 
-Individual decisions (*beschikkingen*) are not instant computations - they are administrative law processes spanning stages over time (application → review → decision → notification → objection). The AWB lifecycle is modeled as data in YAML, not hardcoded in the engine.
+Individual decisions (*beschikkingen*) are not instant computations - they are administrative law processes spanning stages over time (application → review → decision → notification → objection). The Awb lifecycle is modeled as data in YAML, not hardcoded in the engine.
 
 ## Design Principles
 

--- a/docs/src/content/docs/guide/what-is-regelrecht.mdx
+++ b/docs/src/content/docs/guide/what-is-regelrecht.mdx
@@ -97,10 +97,10 @@ Individual decisions (*beschikkingen*) are not instant computations - they are a
 | Principle | What It Means |
 |-----------|--------------|
 | **Zero domain knowledge** | No hardcoded holidays, tax rates, or special cases. Everything comes from law YAML. |
-| **Identical execution** | Browser, backend, editor — same inputs, same result. |
+| **Identical execution** | Browser, backend, editor: same inputs, same result. |
 | **Version control as governance** | Git history captures legislative evolution. Branches are proposals, merges are publication. |
 | **Traceability** | Every computed value points back to a specific article and paragraph. |
-| **Open by default** | Law, tooling, decisions — all publicly auditable. |
+| **Open by default** | Law, tooling, decisions: all publicly auditable. |
 
 ## Who is this for?
 

--- a/docs/src/content/docs/guide/what-is-regelrecht.mdx
+++ b/docs/src/content/docs/guide/what-is-regelrecht.mdx
@@ -74,7 +74,7 @@ Each article sits alongside the original legal text. The `machine_readable` sect
 
 ### Cross-Law References
 
-Dutch laws reference each other extensively. The Wet op de zorgtoeslag references the Zorgverzekeringswet, the AWIR, and the BRP. The engine resolves these dependencies automatically - if law A depends on a value computed by law B, the engine executes both.
+Dutch laws reference each other extensively. The Wet op de zorgtoeslag references the Zorgverzekeringswet, the Awir, and the BRP. The engine resolves these dependencies automatically - if law A depends on a value computed by law B, the engine executes both.
 
 ### Inversion of Control
 

--- a/docs/src/content/docs/operations/adding-a-law.md
+++ b/docs/src/content/docs/operations/adding-a-law.md
@@ -51,18 +51,19 @@ Fix any schema errors before proceeding.
 
 Derive test scenarios from the Memorie van Toelichting (MvT) - the explanatory memorandum that accompanies the law. The MvT contains worked examples of how the legislature intended the law to be applied.
 
-Create a Gherkin feature file in `features/`:
+Create a Gherkin feature file in `features/`. Use the step phrasings the cucumber-rs suite actually defines (see `packages/engine/tests/bdd/steps/` and the existing `features/*.feature` files for the full vocabulary). A minimal scenario looks like:
 
 ```gherkin
 Feature: Wet op de zorgtoeslag
 
-  Scenario: MvT example - single person with low income
-    Given the law "zorgtoeslagwet"
-    And the reference date is "2025-01-01"
-    And the parameter "bsn" is "999993653"
-    When I evaluate "hoogte_zorgtoeslag"
-    Then the result should be 123400
+  Scenario: MvT example - single person, output present
+    Given the calculation date is "2025-01-01"
+    When the law "zorgtoeslagwet" is executed for outputs "hoogte_zorgtoeslag"
+    Then the execution succeeds
+    And the output "hoogte_zorgtoeslag" is "123400"
 ```
+
+Laws that need source data (BRP, Belastingdienst, etc.) provide it with the data-table steps, for example `Given the following RVIG "personal_data" data:` followed by a table. See `features/zorgtoeslag.feature` for a complete, data-driven example.
 
 Run the tests:
 

--- a/docs/src/content/docs/operations/ci-cd.md
+++ b/docs/src/content/docs/operations/ci-cd.md
@@ -15,10 +15,13 @@ Continuous integration runs on every push to `main` and every pull request via `
 
 ### Tests (on Rust changes)
 
+CI runs `just test-all`, which covers:
+
 - **Unit tests** - `just test`
-- **BDD tests** - `just bdd` (cucumber-rs with Gherkin scenarios)
 - **Harvester tests** - `just harvester-test`
-- **Pipeline integration tests** - `just pipeline-integration-test` (uses testcontainers for PostgreSQL)
+- **Pipeline tests** - `just pipeline-test` and `just pipeline-integration-test` (the latter uses testcontainers for PostgreSQL)
+
+The BDD suite (`just bdd`, cucumber-rs with Gherkin scenarios) is **not** part of `test-all` and does not run in CI; run it locally.
 
 ### WASM build (on engine changes)
 
@@ -48,11 +51,12 @@ CI uses path filters to determine which checks to run:
 
 | Change group | Triggers on changes to |
 |---|---|
-| `ci` | `packages/corpus/`, `packages/engine/`, `packages/harvester/`, `packages/pipeline/`, `corpus/regulation/`, `features/`, `schema/` |
+| `ci` | `packages/corpus/`, `packages/engine/`, `packages/harvester/`, `packages/pipeline/`, `frontend/`, `corpus/regulation/`, `features/`, `schema/`, `script/` |
 | `admin` | `packages/admin/` |
-| `editor-api` | `packages/editor-api/` |
+| `editor-api` | `packages/editor-api/`, `packages/corpus/`, `packages/pipeline/`, `packages/harvester/` |
+| `docs` | `docs/` |
 
-Unrelated changes (docs-only, frontend-only) skip Rust checks entirely.
+The `ci` group includes `frontend/`, so frontend changes also trigger the Rust checks (the editor image bundles the editor-api binary). Docs-only changes skip the Rust checks and run just the docs accessibility gate (`just docs-a11y`).
 
 ## Further reading
 

--- a/docs/src/content/docs/operations/ci-cd.md
+++ b/docs/src/content/docs/operations/ci-cd.md
@@ -56,7 +56,7 @@ CI uses path filters to determine which checks to run:
 | `editor-api` | `packages/editor-api/`, `packages/corpus/`, `packages/pipeline/`, `packages/harvester/` |
 | `docs` | `docs/` |
 
-The `ci` group includes `frontend/`, so frontend changes also trigger the Rust checks (the editor image bundles the editor-api binary). Docs-only changes skip the Rust checks and run just the docs accessibility gate (`just docs-a11y`).
+The `ci` group includes `frontend/`, so frontend changes also trigger the Rust checks (the editor is shipped as one image built from `frontend/` plus the `editor-api` Rust binary that serves it). Docs-only changes skip the Rust checks and run just the docs accessibility gate (`just docs-a11y`).
 
 ## Further reading
 

--- a/docs/src/content/docs/operations/contributing.md
+++ b/docs/src/content/docs/operations/contributing.md
@@ -23,7 +23,7 @@ Commits follow [Conventional Commits](https://www.conventionalcommits.org/):
 type(scope): description
 ```
 
-Types: `feat`, `fix`, `docs`, `style`, `test`, `chore`, `refactor`
+Types: `feat`, `fix`, `docs`, `style`, `test`, `chore`, `refactor`, `perf`, `build`, `ci`
 
 Subject line should be 72 characters or less and explain *why*, not *what*.
 

--- a/docs/src/content/docs/operations/deployment.md
+++ b/docs/src/content/docs/operations/deployment.md
@@ -15,7 +15,7 @@ When a PR is opened or updated:
 3. A preview deployment named `pr{N}` is created on ZAD
 4. The PR gets a comment with preview URLs
 
-Only changed components are rebuilt. The editor is always built (it is the primary interface).
+Only changed components are rebuilt. Any component can also be forced to build by adding its `deploy:<component>` label to the PR (for example `deploy:editor`).
 
 ### On merge to main
 
@@ -37,6 +37,7 @@ The preview deployment and its GHCR images are cleaned up automatically.
 | Admin | `regelrecht-admin` | `harvester-admin.regelrecht.rijks.app` |
 | Harvester Worker | `regelrecht-harvester-worker` | (no web UI) |
 | Enrich Worker | `regelrecht-enrich-worker` | (no web UI) |
+| Pipeline API | `regelrecht-pipeline-api` | (no public URL; reached in-cluster) |
 | Lawmaking | `regelrecht-lawmaking` | `lawmaking.regelrecht.rijks.app` |
 | Docs | `regelrecht-docs` | `docs.regelrecht.rijks.app` + `regelrecht.rijks.app` (landing) |
 | Grafana | `regelrecht-grafana` | `grafana.regelrecht.rijks.app` |

--- a/docs/src/content/docs/operations/private-repo-trajects.md
+++ b/docs/src/content/docs/operations/private-repo-trajects.md
@@ -2,14 +2,14 @@
 title: "Private-repo trajects"
 ---
 
-Vanaf [PR #704](https://github.com/MinBZK/regelrecht/pull/704) kan een traject in de editor gekoppeld worden aan een **eigen GitHub-repo** in plaats van de centrale `MinBZK/regelrecht-corpus`. Handig voor organisaties of teams die hun regelgeving in een private repo willen beheren, met behoud van Regelrecht's editor- en attributie-eigenschappen.
+Vanaf [PR #704](https://github.com/MinBZK/regelrecht/pull/704) kan een traject in de editor gekoppeld worden aan een **eigen GitHub-repo** in plaats van de centrale `MinBZK/regelrecht-corpus`. Handig voor organisaties of teams die hun regelgeving in een private repo willen beheren, met behoud van RegelRecht's editor- en attributie-eigenschappen.
 
 Deze pagina beschrijft de end-to-end flow: wat je als eindgebruiker, traject-eigenaar en operator moet doen.
 
 ## Hoe het werkt op hoofdlijnen
 
 - Bij het aanmaken van een traject kies je **of** de centrale MinBZK-repo (default), **of** een eigen `owner/repo` + base branch.
-- Authenticatie naar de eigen repo gebeurt met een **GitHub Personal Access Token** (fine-grained) die door de **operator van het Regelrecht-deployment** als environment variable wordt geconfigureerd. Tokens leven dus niet in de database en niet in de browser — alleen in de runtime-omgeving van de editor.
+- Authenticatie naar de eigen repo gebeurt met een **GitHub Personal Access Token** (fine-grained) die door de **operator van het RegelRecht-deployment** als environment variable wordt geconfigureerd. Tokens leven dus niet in de database en niet in de browser — alleen in de runtime-omgeving van de editor.
 - Commits in de repo verschijnen onder **de naam en het email-adres van de echte gebruiker** (afkomstig uit de OIDC-sessie, mits geverifieerd door de IdP). Niet onder een service-account.
 
 ## Wie doet wat

--- a/docs/src/content/docs/operations/private-repo-trajects.md
+++ b/docs/src/content/docs/operations/private-repo-trajects.md
@@ -68,7 +68,7 @@ waarbij `<OWNER>_<REPO>` een **deterministische slug** is van de coordinates: lo
 | `acme/regels` | `CORPUS_AUTH_ACME_REGELS_TOKEN` |
 | `tdjager/regelrecht-private-test` | `CORPUS_AUTH_TDJAGER_REGELRECHT_PRIVATE_TEST_TOKEN` |
 
-De centrale schrijfbare repo (`MinBZK/regelrecht-corpus`) gebruikt niet de afgeleide slug maar de vaste auth-ref `minbzk-central`, dus `CORPUS_AUTH_MINBZK_CENTRAL_TOKEN`.
+> **Let op:** de centrale schrijfbare repo (`MinBZK/regelrecht-corpus`) gebruikt **niet** de afgeleide slug maar de vaste auth-ref `minbzk-central`, dus de env var heet `CORPUS_AUTH_MINBZK_CENTRAL_TOKEN` (niet `CORPUS_AUTH_MINBZK_REGELRECHT_CORPUS_TOKEN`).
 
 De operator weet hoe ze env vars op het cluster moeten zetten, dat is omgevings-specifiek (ZAD, Kubernetes, docker-compose). Na de wijziging moet de editor-pod herstart worden zodat de nieuwe var wordt opgepikt. **Eén env var per repo**, als meerdere trajects naar dezelfde repo wijzen, is één configuratie genoeg.
 

--- a/docs/src/content/docs/operations/private-repo-trajects.md
+++ b/docs/src/content/docs/operations/private-repo-trajects.md
@@ -9,7 +9,7 @@ Deze pagina beschrijft de end-to-end flow: wat je als eindgebruiker, traject-eig
 ## Hoe het werkt op hoofdlijnen
 
 - Bij het aanmaken van een traject kies je **of** de centrale MinBZK-repo (default), **of** een eigen `owner/repo` + base branch.
-- Authenticatie naar de eigen repo gebeurt met een **GitHub Personal Access Token** (fine-grained) die door de **operator van het RegelRecht-deployment** als environment variable wordt geconfigureerd. Tokens leven dus niet in de database en niet in de browser — alleen in de runtime-omgeving van de editor.
+- Authenticatie naar de eigen repo gebeurt met een **GitHub Personal Access Token** (fine-grained) die door de **operator van het RegelRecht-deployment** als environment variable wordt geconfigureerd. Tokens leven dus niet in de database en niet in de browser, alleen in de runtime-omgeving van de editor.
 - Commits in de repo verschijnen onder **de naam en het email-adres van de echte gebruiker** (afkomstig uit de OIDC-sessie, mits geverifieerd door de IdP). Niet onder een service-account.
 
 ## Wie doet wat
@@ -21,32 +21,32 @@ Deze pagina beschrijft de end-to-end flow: wat je als eindgebruiker, traject-eig
 | Traject-eigenaar | Maakt het traject aan in de editor met de eigen repo-velden |
 | Deelnemers | Loggen in via SSO; saves verschijnen automatisch onder hun eigen naam |
 
-## Stap 1 — Bereid de GitHub-repo voor
+## Stap 1: Bereid de GitHub-repo voor
 
 De target-repo moet aan twee voorwaarden voldoen vóór je 'm kunt koppelen:
 
-1. **De `base branch` bestaat al** (met minstens één commit). De editor maakt een eigen feature-branch áf van deze base — als de base nog niet bestaat (bv. een leeg gestelde `main`), faalt de validatie. Maak desnoods een lege README-commit op `main` om de branch te initialiseren.
+1. **De `base branch` bestaat al** (met minstens één commit). De editor maakt een eigen feature-branch áf van deze base, als de base nog niet bestaat (bv. een leeg gestelde `main`), faalt de validatie. Maak desnoods een lege README-commit op `main` om de branch te initialiseren.
 2. **Het PAT-account heeft push-rechten op de repo**. Voor private repo's: de PAT moet voor die specifieke repo aangevraagd zijn met de juiste scopes (zie stap 2).
 
-> De repo mag publiek of private zijn. Voor publieke repos gelden GitHub's rate-limits van het tokenless API-endpoint zonder PAT — voor private repo's is een PAT verplicht voor zowel reads als writes.
+> De repo mag publiek of private zijn. Voor publieke repos gelden GitHub's rate-limits van het tokenless API-endpoint zonder PAT, voor private repo's is een PAT verplicht voor zowel reads als writes.
 
-## Stap 2 — Maak een GitHub PAT aan
+## Stap 2: Maak een GitHub PAT aan
 
 Genereer een **fine-grained PAT** op [github.com/settings/personal-access-tokens/new](https://github.com/settings/personal-access-tokens/new):
 
 - **Resource owner**: de owner van de target-repo (persoonlijk account of organisatie)
 - **Repository access**: "Only select repositories" → kies precies de target-repo (níét "all repositories", houd de blast radius klein)
 - **Repository permissions**:
-  - `Contents`: **Read and write** — nodig voor commits + branch-creatie
-  - `Pull requests`: **Read and write** — nodig om de session-PR te openen en bij te werken
+  - `Contents`: **Read and write**, nodig voor commits + branch-creatie
+  - `Pull requests`: **Read and write**, nodig om de session-PR te openen en bij te werken
   - `Metadata`: **Read** (verplicht en auto-geselecteerd)
-- **Expiration**: kies een termijn die past bij je security-beleid. PAT's verlopen — bij verloop weigert de editor nieuwe saves en moet de operator de env var verversen.
+- **Expiration**: kies een termijn die past bij je security-beleid. PAT's verlopen, bij verloop weigert de editor nieuwe saves en moet de operator de env var verversen.
 
 Sla de waarde van de PAT direct op een veilige plek op (GitHub toont 'm maar één keer).
 
 > Classic PATs werken ook, maar geven veel te brede toegang (alle repo's waar je toegang toe hebt). Fine-grained is sterk aanbevolen.
 
-## Stap 3 — Operator configureert de env var
+## Stap 3: Operator configureert de env var
 
 Geef je operator deze drie dingen:
 
@@ -68,11 +68,11 @@ waarbij `<OWNER>_<REPO>` een **deterministische slug** is van de coordinates: lo
 | `acme/regels` | `CORPUS_AUTH_ACME_REGELS_TOKEN` |
 | `tdjager/regelrecht-private-test` | `CORPUS_AUTH_TDJAGER_REGELRECHT_PRIVATE_TEST_TOKEN` |
 
-De operator weet hoe ze env vars op het cluster moeten zetten — dat is omgevings-specifiek (ZAD, Kubernetes, docker-compose). Na de wijziging moet de editor-pod herstart worden zodat de nieuwe var wordt opgepikt. **Eén env var per repo** — als meerdere trajects naar dezelfde repo wijzen, is één configuratie genoeg.
+De operator weet hoe ze env vars op het cluster moeten zetten, dat is omgevings-specifiek (ZAD, Kubernetes, docker-compose). Na de wijziging moet de editor-pod herstart worden zodat de nieuwe var wordt opgepikt. **Eén env var per repo**, als meerdere trajects naar dezelfde repo wijzen, is één configuratie genoeg.
 
 > Wanneer je het traject probeert aan te maken vóórdat de env var bestaat, krijg je een nette foutmelding die exact de verwachte env-var-naam toont. Geef die naam letterlijk door aan je operator.
 
-## Stap 4 — Maak het traject aan
+## Stap 4: Maak het traject aan
 
 In de editor:
 
@@ -87,7 +87,7 @@ De editor doet vóór het aanmaken een **pre-flight check** tegen de GitHub-API:
 - Heeft de token push-rechten?
 - Bestaat de opgegeven base-branch?
 
-Faalt één van deze checks, dan zie je een gerichte foutmelding (zie [foutmeldingen](#foutmeldingen-en-wat-ze-betekenen) hieronder). Geen rij in de database — je kunt direct opnieuw proberen na correctie.
+Faalt één van deze checks, dan zie je een gerichte foutmelding (zie [foutmeldingen](#foutmeldingen-en-wat-ze-betekenen) hieronder). Geen rij in de database, je kunt direct opnieuw proberen na correctie.
 
 ## Hoe commit-attributie werkt
 
@@ -95,7 +95,7 @@ Elke save in een traject produceert een commit op de session-branch met:
 
 - **Author**: `<jouw OIDC-naam> <jouw OIDC email>` (uit Keycloak)
 - **Committer**: het service-account dat het deployment runt (dit is wat GitHub als "pushed by" registreert in de Push Events)
-- **`Co-authored-by:` trailer**: identiek aan de author — dubbele credit zodat GitHub de commit ook in jouw Contributions-graph laat zien
+- **`Co-authored-by:` trailer**: identiek aan de author, dubbele credit zodat GitHub de commit ook in jouw Contributions-graph laat zien
 
 Voor de UI-weergave op GitHub geldt: als jouw OIDC-email een verified email is op je GitHub-account, dan toont GitHub jouw avatar en naam bij elke commit, en linkt 'ie naar je profile. Geen mapping verified? Dan wordt de email als string getoond, zonder profile-link, maar nog steeds met de juiste naam.
 
@@ -108,10 +108,10 @@ Wanneer je traject-create faalt, toont de UI een specifieke melding. De belangri
 | Statuscode | Melding | Wat je moet doen |
 |---|---|---|
 | 503 | "deze repo is nog niet door je beheerder geconfigureerd (verwacht env var X)" | Vraag de operator de getoonde env-var-naam te configureren |
-| 502 | "het token van je beheerder wordt door GitHub geweigerd" | PAT is verlopen of ongeldig — vraag operator om verversing |
+| 502 | "het token van je beheerder wordt door GitHub geweigerd" | PAT is verlopen of ongeldig, vraag operator om verversing |
 | 403 | "het geconfigureerde token heeft geen schrijftoegang tot deze repo" | PAT mist `Contents: write` of de PAT-account is geen collaborator op de repo |
 | 404 | "repo X bestaat niet of het token kan 'm niet zien" | Tikfout in owner/repo, of de fine-grained PAT is niet aan deze repo gekoppeld |
-| 404 | "branch 'X' bestaat niet op owner/repo" | De `base_branch` bestaat nog niet op de repo — initialiseer 'm met minstens één commit |
+| 404 | "branch 'X' bestaat niet op owner/repo" | De `base_branch` bestaat nog niet op de repo, initialiseer 'm met minstens één commit |
 | 400 | "alleen letters, cijfers, en '-', '_', '.'" | owner, repo of subpath bevat ongeldige karakters |
 | 400 | "moeten alle drie worden meegegeven" | Eigen-repo-toggle staat aan maar één van owner/repo/base_branch is leeg |
 | 502 | "onverwacht antwoord van GitHub bij repo-validatie" | Tijdelijke GitHub-issue; probeer opnieuw |
@@ -120,7 +120,7 @@ Tijdens het bewerken kunnen ook saves falen. De meeste meldingen zijn vergelijkb
 
 ## Beperkingen en aandachtspunten
 
-- **Per-repo PAT, niet per-user**. Alle deelnemers aan het traject committen via dezelfde token, maar onder hun eigen naam (via Author/Co-authored-by). GitHub Push Events tonen altijd het service-account als "pushed by" — voor harde per-user audit is dat niet voldoende; gebruik daarvoor de editor-API's audit-logs of de PR's commit-graaf.
+- **Per-repo PAT, niet per-user**. Alle deelnemers aan het traject committen via dezelfde token, maar onder hun eigen naam (via Author/Co-authored-by). GitHub Push Events tonen altijd het service-account als "pushed by", voor harde per-user audit is dat niet voldoende; gebruik daarvoor de editor-API's audit-logs of de PR's commit-graaf.
 - **PAT-verloop is operator-werk**. De editor weigert reads/writes zodra de PAT door GitHub geweigerd wordt; de operator moet 'm dan verversen. Plan dit in.
 - **Geen self-service**. Voor elke nieuwe repo moet een operator een env var configureren. Voor occasioneel gebruik is dat prima; voor schaalbare zelfbediening is een **GitHub App** een betere richting (geparkeerd voor latere fase).
 - **Geen tokens in DB of browser**. Bewust ontwerp: een bug, breach of insider met DB-toegang kan geen tokens exfiltreren. Wel betekent dit dat tokens niet "even snel" zelf zijn in te stellen.
@@ -130,4 +130,4 @@ Tijdens het bewerken kunnen ook saves falen. De meeste meldingen zijn vergelijkb
 De eerste deploy met deze feature scherpt twee oude paden aan; controleer onderstaande punten op je deployment vóór je de release uitrolt.
 
 - **De writable-own source gebruikt voortaan strikte token-resolutie** (geen `CORPUS_GIT_TOKEN`-fallback). Bestaande trajects die via de central MinBZK-repo committen, hebben dus `CORPUS_AUTH_MINBZK_CENTRAL_TOKEN` nodig als losse env var. Deployments die tot nu toe leunden op alleen `CORPUS_GIT_TOKEN` voor het centrale schrijfpad, zien stille push-failures na de release als die env var ontbreekt. Zet 'm vóór deploy en check de editor-logs op de eerste run; de diagnostic-log toont expliciet de verwachte env-var-naam wanneer de resolver `None` returnt voor de writable-own source.
-- **Bestaande SSO-sessies missen de nieuwe `email_verified`-claim**. Eerste save na deploy levert dan een 403 op met de melding "log opnieuw in". Geen onderhoud, geen migratie — gewoon eenmalig opnieuw inloggen lost het op.
+- **Bestaande SSO-sessies missen de nieuwe `email_verified`-claim**. Eerste save na deploy levert dan een 403 op met de melding "log opnieuw in". Geen onderhoud, geen migratie, gewoon eenmalig opnieuw inloggen lost het op.

--- a/docs/src/content/docs/operations/private-repo-trajects.md
+++ b/docs/src/content/docs/operations/private-repo-trajects.md
@@ -60,13 +60,15 @@ De operator zet de PAT als environment variable op het editor-deployment met de 
 CORPUS_AUTH_<OWNER>_<REPO>_TOKEN
 ```
 
-waarbij `<OWNER>_<REPO>` een **deterministische slug** is van de coordinates: lowercase, alle niet-alfanumerieke tekens vervangen door `-`, vervolgens hoofdletters en dashes naar underscores. Voorbeelden:
+waarbij `<OWNER>_<REPO>` een **deterministische slug** is van de coordinates: lowercase, elke aaneengesloten reeks niet-alfanumerieke tekens wordt één `-` (leidende/sluitende dashes worden weggesneden), vervolgens hoofdletters en dashes naar underscores. Voorbeelden:
 
 | owner/repo | env var |
 |---|---|
-| `MinBZK/regelrecht-corpus` | `CORPUS_AUTH_MINBZK_REGELRECHT_CORPUS_TOKEN` |
+| `MinBZK/regelrecht-corpus` (de centrale repo) | `CORPUS_AUTH_MINBZK_CENTRAL_TOKEN` |
 | `acme/regels` | `CORPUS_AUTH_ACME_REGELS_TOKEN` |
 | `tdjager/regelrecht-private-test` | `CORPUS_AUTH_TDJAGER_REGELRECHT_PRIVATE_TEST_TOKEN` |
+
+De centrale schrijfbare repo (`MinBZK/regelrecht-corpus`) gebruikt niet de afgeleide slug maar de vaste auth-ref `minbzk-central`, dus `CORPUS_AUTH_MINBZK_CENTRAL_TOKEN`.
 
 De operator weet hoe ze env vars op het cluster moeten zetten, dat is omgevings-specifiek (ZAD, Kubernetes, docker-compose). Na de wijziging moet de editor-pod herstart worden zodat de nieuwe var wordt opgepikt. **Eén env var per repo**, als meerdere trajects naar dezelfde repo wijzen, is één configuratie genoeg.
 

--- a/docs/src/content/docs/reference/accessibility.md
+++ b/docs/src/content/docs/reference/accessibility.md
@@ -79,12 +79,12 @@ team measured the real ratio in the browser and excluded these elements from the
 automated check, with a note in the configuration:
 
 - **Diagrams (Mermaid).** Diagrams render as inline SVG, with text on transparent
-  layers where axe cannot read the colour behind it. The measured ratio is 14.4:1
+  layers where axe cannot read the color behind it. The measured ratio is 14.4:1
   for text in flow and state diagrams (dark blue on light blue) and well above the
-  requirement for the C4 diagrams (white on dark blue). The diagram colours come
+  requirement for the C4 diagrams (white on dark blue). The diagram colors come
   from the NLDD palette.
 - **Code samples.** Code blocks carry a light and a dark theme on the same
-  element; the test mixes the two colour sets and measures a blend that never
+  element; the test mixes the two color sets and measures a blend that never
   appears on screen. The text that does appear clears the 4.5:1 that AA asks for
   in both modes.
 

--- a/docs/src/content/docs/reference/glossary.md
+++ b/docs/src/content/docs/reference/glossary.md
@@ -18,7 +18,7 @@ Dutch legal terminology used throughout RegelRecht, with English translations.
 
 | Dutch | English | Description |
 |-------|---------|-------------|
-| **Algemene wet bestuursrecht (AWB)** | General Administrative Law Act | Framework law for government decision-making |
+| **Algemene wet bestuursrecht (Awb)** | General Administrative Law Act | Framework law for government decision-making |
 | **Beschikking** | Administrative decision | A decision by a government body affecting an individual |
 | **Aanvraag** | Application | A request for a decision from a government body |
 | **Bezwaar** | Objection | First recourse against a decision |

--- a/docs/src/content/docs/reference/glossary.md
+++ b/docs/src/content/docs/reference/glossary.md
@@ -18,7 +18,7 @@ Dutch legal terminology used throughout RegelRecht, with English translations.
 
 | Dutch | English | Description |
 |-------|---------|-------------|
-| **Algemene wet bestuursrecht (Awb)** | General Administrative Law Act | Framework law for government decision-making |
+| **Algemene wet bestuursrecht (AWB)** | General Administrative Law Act | Framework law for government decision-making |
 | **Beschikking** | Administrative decision | A decision by a government body affecting an individual |
 | **Aanvraag** | Application | A request for a decision from a government body |
 | **Bezwaar** | Objection | First recourse against a decision |

--- a/docs/src/content/docs/reference/issues/issue-article-id-collision.md
+++ b/docs/src/content/docs/reference/issues/issue-article-id-collision.md
@@ -27,7 +27,7 @@ Same collision occurs with:
 ### Current Implementation
 
 ```rust
-// splitting/types.rs:208
+// splitting/types.rs:218
 pub fn to_number(&self) -> String {
     let base = self.number_parts.join(".");  // ← Collision point
     match &self.bijlage_prefix {
@@ -273,6 +273,6 @@ Until the structural solution is implemented:
 
 ## References
 
-- **Current location**: `packages/harvester/src/splitting/types.rs:206-213`
+- **Current location**: `packages/harvester/src/splitting/types.rs:218-224`
 - **Affected laws**: Wetboek van Strafrecht (BWBR0001854)
 - **Colliding articles**: 420bis/420bis.1, 420quater/420quater.1

--- a/docs/src/content/docs/reference/issues/issue-phased-implementation.md
+++ b/docs/src/content/docs/reference/issues/issue-phased-implementation.md
@@ -150,7 +150,7 @@ All `<redactie>` elements must be excluded from the extracted text. They are edi
 - [Staatsblad 2016, 288](https://zoek.officielebekendmakingen.nl/stb-2016-288.html) - Original KEI law
 - [Staatsblad 2017, 174](https://zoek.officielebekendmakingen.nl/stb-2017-174.html) - First implementation decree
 - [Staatsblad 2020, 99](https://zoek.officielebekendmakingen.nl/stb-2020-99.html) - Tax cassation implementation
-- [KEI Overview](https://www.rijksoverheid.nl/onderwerpen/rechtspraak-en-geschiloplossing/kwaliteit-en-innovatie-kei-rechtspraak) - Government info page
+- [Rechtspraak en geschiloplossing](https://www.rijksoverheid.nl/onderwerpen/rechtspraak-en-geschiloplossing) - Government info page (the KEI-specific subpage has been retired)
 
 ## Test Data
 

--- a/docs/src/content/docs/reference/issues/issue-phased-implementation.md
+++ b/docs/src/content/docs/reference/issues/issue-phased-implementation.md
@@ -8,7 +8,7 @@ Articles with phased implementation ("gefaseerde inwerkingtreding") contain **mu
 
 ## Affected Laws
 
-- **Awb (BWBR0005537)**: Artikel 8:36c - two versions of leden 1-4
+- **AWB (BWBR0005537)**: Artikel 8:36c - two versions of leden 1-4
 - **Mediawet 2008 (BWBR0025028)**: Artikel 2.88.5 - two different texts
 
 ## Legal Background

--- a/docs/src/content/docs/reference/issues/issue-phased-implementation.md
+++ b/docs/src/content/docs/reference/issues/issue-phased-implementation.md
@@ -2,9 +2,11 @@
 title: "Issue #2: Phased Implementation (Gefaseerde Inwerkingtreding)"
 ---
 
+> **Resolved.** This issue is implemented in the harvester. Articles with a `<tussenkop>` version separator are now extracted as a single component (`has_version_separator` / `extract_full_article_content` in `packages/harvester/src/splitting/engine.rs`), and `<redactie>` editorial content is excluded (`is_editorial_content` + the registered `RedactieHandler`). The write-up below is kept as background on the problem and the chosen approach.
+
 ## Problem Summary
 
-Articles with phased implementation ("gefaseerde inwerkingtreding") contain **multiple versions of the same article content** within a single XML `<artikel>` element. The harvester currently splits by `<lid>` (paragraph), producing duplicate article numbers like `8:36c.1` appearing twice.
+Articles with phased implementation ("gefaseerde inwerkingtreding") contain **multiple versions of the same article content** within a single XML `<artikel>` element. Splitting naively by `<lid>` (paragraph) would produce duplicate article numbers like `8:36c.1` appearing twice; the harvester therefore detects the version separator and keeps such articles whole (see the resolution note above).
 
 ## Affected Laws
 

--- a/docs/src/content/docs/reference/issues/issue-phased-implementation.md
+++ b/docs/src/content/docs/reference/issues/issue-phased-implementation.md
@@ -10,7 +10,7 @@ Articles with phased implementation ("gefaseerde inwerkingtreding") contain **mu
 
 ## Affected Laws
 
-- **AWB (BWBR0005537)**: Artikel 8:36c - two versions of leden 1-4
+- **Awb (BWBR0005537)**: Artikel 8:36c - two versions of leden 1-4
 - **Mediawet 2008 (BWBR0025028)**: Artikel 2.88.5 - two different texts
 
 ## Legal Background
@@ -38,7 +38,7 @@ As of 2024, **both versions remain valid simultaneously**:
 
 ## XML Structure
 
-See AWB XML from wetten.nl (article 8:36c, lines 6685-6731)
+See Awb XML from wetten.nl (article 8:36c, lines 6685-6731)
 
 ```xml
 <artikel label="Artikel 8:36c" inwerking="2020-04-15" bron="Stb.2016-288">
@@ -156,5 +156,5 @@ All `<redactie>` elements must be excluded from the extracted text. They are edi
 
 ## Test Data
 
-- XML source: AWB from wetten.nl
+- XML source: Awb from wetten.nl
 - Article 8:36c location: lines 6685-6731

--- a/docs/src/content/docs/reference/schema.md
+++ b/docs/src/content/docs/reference/schema.md
@@ -28,7 +28,7 @@ This table is the single source of truth for which schema version introduced whi
 | v0.4.0 | `open_terms`, `implements` (IoC); `legal_character`; `date` and `array` value types | [RFC-003](/rfcs/rfc-003) |
 | v0.3.2 | Minor fixes | |
 | v0.3.1 | Patch release | |
-| v0.3.0 | Cross-law references (`source`) | |
+| v0.3.0 | Cross-law reference refinements | |
 | v0.2.0 | Initial public schema: `regulatory_layer`, `competent_authority`, `execution.produces`, cross-law references (`source`) | [RFC-001](/rfcs/rfc-001), [RFC-002](/rfcs/rfc-002) |
 
 Multi-organization execution ([RFC-009](/rfcs/rfc-009)) reuses `competent_authority` (v0.2.0) and adds no schema construct of its own.

--- a/docs/src/content/docs/reference/schema.md
+++ b/docs/src/content/docs/reference/schema.md
@@ -26,9 +26,9 @@ This table is the single source of truth for which schema version introduced whi
 | v0.5.1 | Tag-based immutable schema URLs; refinements within the v0.5.x line | [RFC-013](/rfcs/rfc-013) |
 | v0.5.0 | `hooks`, `overrides` (reactive execution); `procedure`, `procedure_id` (AWB lifecycle); WOO support | [RFC-007](/rfcs/rfc-007), [RFC-008](/rfcs/rfc-008) |
 | v0.4.0 | `open_terms`, `implements` (IoC); `legal_character`; `date` and `array` value types | [RFC-003](/rfcs/rfc-003) |
-| v0.3.2 | Minor fixes | — |
-| v0.3.1 | Patch release | — |
-| v0.3.0 | Cross-law references (`source`) | — |
+| v0.3.2 | Minor fixes |, |
+| v0.3.1 | Patch release |, |
+| v0.3.0 | Cross-law references (`source`) |, |
 | v0.2.0 | Initial public schema: `regulatory_layer`, `competent_authority`, `execution.produces` | [RFC-001](/rfcs/rfc-001), [RFC-002](/rfcs/rfc-002) |
 
 Multi-organization execution ([RFC-009](/rfcs/rfc-009)) reuses `competent_authority` (v0.2.0) and adds no schema construct of its own.

--- a/docs/src/content/docs/reference/schema.md
+++ b/docs/src/content/docs/reference/schema.md
@@ -24,7 +24,7 @@ This table is the single source of truth for which schema version introduced whi
 |---------|-----------|-----|
 | v0.5.2 | `annotation-schema.json` for stand-off notes | [RFC-005](/rfcs/rfc-005), [RFC-018](/rfcs/rfc-018) |
 | v0.5.1 | Tag-based immutable schema URLs; refinements within the v0.5.x line | [RFC-013](/rfcs/rfc-013) |
-| v0.5.0 | `hooks`, `overrides` (reactive execution); `procedure`, `procedure_id` (AWB lifecycle); WOO support | [RFC-007](/rfcs/rfc-007), [RFC-008](/rfcs/rfc-008) |
+| v0.5.0 | `hooks`, `overrides` (reactive execution); `procedure`, `procedure_id` (Awb lifecycle); WOO support | [RFC-007](/rfcs/rfc-007), [RFC-008](/rfcs/rfc-008) |
 | v0.4.0 | `open_terms`, `implements` (IoC); `legal_character`; `date` and `array` value types | [RFC-003](/rfcs/rfc-003) |
 | v0.3.2 | Minor fixes | |
 | v0.3.1 | Patch release | |

--- a/docs/src/content/docs/reference/schema.md
+++ b/docs/src/content/docs/reference/schema.md
@@ -24,7 +24,7 @@ This table is the single source of truth for which schema version introduced whi
 |---------|-----------|-----|
 | v0.5.2 | `annotation-schema.json` for stand-off notes | [RFC-005](/rfcs/rfc-005), [RFC-018](/rfcs/rfc-018) |
 | v0.5.1 | Tag-based immutable schema URLs; refinements within the v0.5.x line | [RFC-013](/rfcs/rfc-013) |
-| v0.5.0 | `hooks`, `overrides` (reactive execution); `procedure`, `procedure_id` (Awb lifecycle); WOO support | [RFC-007](/rfcs/rfc-007), [RFC-008](/rfcs/rfc-008) |
+| v0.5.0 | `hooks`, `overrides` (reactive execution); `procedure`, `procedure_id` (Awb lifecycle); Woo support | [RFC-007](/rfcs/rfc-007), [RFC-008](/rfcs/rfc-008) |
 | v0.4.0 | `open_terms`, `implements` (IoC); `legal_character`; `date` and `array` value types | [RFC-003](/rfcs/rfc-003) |
 | v0.3.2 | Minor fixes | |
 | v0.3.1 | Patch release | |

--- a/docs/src/content/docs/reference/schema.md
+++ b/docs/src/content/docs/reference/schema.md
@@ -39,19 +39,19 @@ Validate law files against the schema:
 
 ```bash
 just validate                    # All files
-just validate corpus/regulation/nl/wet/zorgtoeslag/2025-01-01.yaml  # Specific file
+just validate corpus/regulation/nl/wet/wet_op_de_zorgtoeslag/2025-01-01.yaml  # Specific file
 ```
 
 ## Schema Structure
 
 The schema defines:
 
-- **Top-level metadata**: `$id`, `$schema`, `name`, `effective_date`
-- **Service definition**: `input`, `output`, `articles`
-- **Article structure**: `id`, `name`, `text`, `machine_readable`
-- **Machine-readable**: `input`, `output`, `operations`
-- **Operations**: Typed operations with `input` and `output` fields
-- **Cross-references**: `source` blocks pointing to other regulations
+- **Top-level metadata**: `$id`, `$schema`, `name`, `regulatory_layer`, `publication_date`, `valid_from`, `url` (required: `regulatory_layer`, `publication_date`, `url`, `articles`)
+- **Articles**: an `articles` array; each article requires `number`, `text`, and `url`, and may carry a `machine_readable` section and `references`
+- **Machine-readable section**: `execution`, plus `open_terms`, `implements`, `definitions`, `hooks`, `overrides`, `untranslatables`, `competent_authority`, `enables`, `requires`, `endpoint`
+- **Execution block**: `parameters`, `input`, `output`, `actions`, `produces`
+- **Operations**: each action operation carries an `operation` type plus its operands (`values`, `subject`/`value`, `conditions`, `cases`/`default`, date fields)
+- **Cross-references**: `source` blocks on inputs, pointing to other regulations
 - **Open terms**: `open_terms` and `implements` for delegation
 
 See [Law Format](/concepts/law-format) for a guided walkthrough.

--- a/docs/src/content/docs/reference/schema.md
+++ b/docs/src/content/docs/reference/schema.md
@@ -31,7 +31,7 @@ This table is the single source of truth for which schema version introduced whi
 | v0.3.0 | Cross-law references (`source`) | — |
 | v0.2.0 | Initial public schema: `regulatory_layer`, `competent_authority`, `execution.produces` | [RFC-001](/rfcs/rfc-001), [RFC-002](/rfcs/rfc-002) |
 
-Multi-organisation execution ([RFC-009](/rfcs/rfc-009)) reuses `competent_authority` (v0.2.0) and adds no schema construct of its own.
+Multi-organization execution ([RFC-009](/rfcs/rfc-009)) reuses `competent_authority` (v0.2.0) and adds no schema construct of its own.
 
 ## Validation
 

--- a/docs/src/content/docs/reference/schema.md
+++ b/docs/src/content/docs/reference/schema.md
@@ -29,7 +29,7 @@ This table is the single source of truth for which schema version introduced whi
 | v0.3.2 | Minor fixes | |
 | v0.3.1 | Patch release | |
 | v0.3.0 | Cross-law references (`source`) | |
-| v0.2.0 | Initial public schema: `regulatory_layer`, `competent_authority`, `execution.produces` | [RFC-001](/rfcs/rfc-001), [RFC-002](/rfcs/rfc-002) |
+| v0.2.0 | Initial public schema: `regulatory_layer`, `competent_authority`, `execution.produces`, cross-law references (`source`) | [RFC-001](/rfcs/rfc-001), [RFC-002](/rfcs/rfc-002) |
 
 Multi-organization execution ([RFC-009](/rfcs/rfc-009)) reuses `competent_authority` (v0.2.0) and adds no schema construct of its own.
 

--- a/docs/src/content/docs/reference/schema.md
+++ b/docs/src/content/docs/reference/schema.md
@@ -26,9 +26,9 @@ This table is the single source of truth for which schema version introduced whi
 | v0.5.1 | Tag-based immutable schema URLs; refinements within the v0.5.x line | [RFC-013](/rfcs/rfc-013) |
 | v0.5.0 | `hooks`, `overrides` (reactive execution); `procedure`, `procedure_id` (AWB lifecycle); WOO support | [RFC-007](/rfcs/rfc-007), [RFC-008](/rfcs/rfc-008) |
 | v0.4.0 | `open_terms`, `implements` (IoC); `legal_character`; `date` and `array` value types | [RFC-003](/rfcs/rfc-003) |
-| v0.3.2 | Minor fixes |, |
-| v0.3.1 | Patch release |, |
-| v0.3.0 | Cross-law references (`source`) |, |
+| v0.3.2 | Minor fixes | |
+| v0.3.1 | Patch release | |
+| v0.3.0 | Cross-law references (`source`) | |
 | v0.2.0 | Initial public schema: `regulatory_layer`, `competent_authority`, `execution.produces` | [RFC-001](/rfcs/rfc-001), [RFC-002](/rfcs/rfc-002) |
 
 Multi-organization execution ([RFC-009](/rfcs/rfc-009)) reuses `competent_authority` (v0.2.0) and adds no schema construct of its own.

--- a/docs/src/content/rfcs/rfc-000.md
+++ b/docs/src/content/rfcs/rfc-000.md
@@ -8,7 +8,7 @@ title: "RFC-000: RFC Process"
 
 ## Context
 
-As the regelrecht project grows, we need a structured way to document design decisions and architectural choices. Important decisions about law execution, article resolution, URI handling, and system architecture should be documented with their rationale for future reference.
+As the RegelRecht project grows, we need a structured way to document design decisions and architectural choices. Important decisions about law execution, article resolution, URI handling, and system architecture should be documented with their rationale for future reference.
 
 Without a formal process, design decisions live in:
 - Pull request discussions (hard to discover)

--- a/docs/src/content/rfcs/rfc-000.md
+++ b/docs/src/content/rfcs/rfc-000.md
@@ -4,7 +4,7 @@ title: "RFC-000: RFC Process"
 
 **Status:** Accepted
 **Date:** 2025-11-19
-**Authors:** regelrecht team
+**Authors:** RegelRecht team
 
 ## Context
 

--- a/docs/src/content/rfcs/rfc-001.md
+++ b/docs/src/content/rfcs/rfc-001.md
@@ -145,7 +145,7 @@ temporal:
 
 **Not adopted: `immutable_after`**
 
-POC v0.1.6 had `immutable_after: "P2Y"` to indicate when values become final (e.g., revision period (*herzieningstermijn*)). This is removed because immutability/finality should be modeled as explicit rules in laws (e.g., AWIR).
+POC v0.1.6 had `immutable_after: "P2Y"` to indicate when values become final (e.g., revision period (*herzieningstermijn*)). This is removed because immutability/finality should be modeled as explicit rules in laws (e.g., Awir).
 
 ### 9. Input Source Consolidation
 

--- a/docs/src/content/rfcs/rfc-001.md
+++ b/docs/src/content/rfcs/rfc-001.md
@@ -110,9 +110,9 @@ Cross-law references use the `regelrecht://` URI scheme:
 regelrecht://{law_id}/{output_name}#{field}
 ```
 
-- `law_id` — the `$id` slug of the target law
-- `output_name` — the name of an output produced by one of the law's articles
-- `#field` (optional fragment) — extracts a specific field from the output (e.g. `#value`)
+- `law_id`, the `$id` slug of the target law
+- `output_name`, the name of an output produced by one of the law's articles
+- `#field` (optional fragment), extracts a specific field from the output (e.g. `#value`)
 
 The engine resolves these URIs by finding the law by `$id`, locating the article that produces the named output, executing it, and extracting the requested field. This scheme is used for cross-law input references ([RFC-003](/rfcs/rfc-003), [RFC-007](/rfcs/rfc-007)) and as annotation targets ([RFC-005](/rfcs/rfc-005)).
 

--- a/docs/src/content/rfcs/rfc-001.md
+++ b/docs/src/content/rfcs/rfc-001.md
@@ -4,7 +4,7 @@ title: "RFC-001: YAML Schema Design Decisions"
 
 **Status:** Accepted
 **Date:** 2025-11-20
-**Authors:** regelrecht team
+**Authors:** RegelRecht team
 
 ## Context
 

--- a/docs/src/content/rfcs/rfc-002.md
+++ b/docs/src/content/rfcs/rfc-002.md
@@ -20,11 +20,11 @@ When representing laws and regulations in machine-readable format, we need to ca
 - Preamble defines the Minister as both issuer and executor
 
 **In Wet langdurige zorg (BWBR0035917):**
-- Article 2.1.3: Sociale verzekeringsbank — insurance determination (*vaststelling verzekering*)
-- Article 3.2.3: CIZ — indication decision (*indicatiebesluit*)
-- Article 3.3.3: Zorgkantoor — personal care budget (*persoonsgebonden budget*)
-- Article 4.2.1: Wlz-uitvoerder — duty of care (*zorgplicht*)
-- Article 5.1.1: Zorginstituut Nederland — supervision (*toezicht*)
+- Article 2.1.3: Sociale verzekeringsbank, insurance determination (*vaststelling verzekering*)
+- Article 3.2.3: CIZ, indication decision (*indicatiebesluit*)
+- Article 3.3.3: Zorgkantoor, personal care budget (*persoonsgebonden budget*)
+- Article 4.2.1: Wlz-uitvoerder, duty of care (*zorgplicht*)
+- Article 5.1.1: Zorginstituut Nederland, supervision (*toezicht*)
 - Article 6.1.1: CAK
 - Article 7.1.1: CIZ
 

--- a/docs/src/content/rfcs/rfc-002.md
+++ b/docs/src/content/rfcs/rfc-002.md
@@ -90,5 +90,5 @@ competent_authority:
 
 - Issue #7: Good enough Language for 1st fase Editor and Engine
 - PR #30 Discussion
-- Art. 1:1 AWB (definition of administrative body (*bestuursorgaan*))
+- Art. 1:1 Awb (definition of administrative body (*bestuursorgaan*))
 - [Glossary of Dutch Legal Terms](/reference/glossary)

--- a/docs/src/content/rfcs/rfc-002.md
+++ b/docs/src/content/rfcs/rfc-002.md
@@ -90,5 +90,5 @@ competent_authority:
 
 - Issue #7: Good enough Language for 1st fase Editor and Engine
 - PR #30 Discussion
-- Art. 1:1 Awb (definition of administrative body (*bestuursorgaan*))
+- Art. 1:1 AWB (definition of administrative body (*bestuursorgaan*))
 - [Glossary of Dutch Legal Terms](/reference/glossary)

--- a/docs/src/content/rfcs/rfc-003.md
+++ b/docs/src/content/rfcs/rfc-003.md
@@ -146,7 +146,7 @@ implements:
     gelet_op: Gelet op artikel 8 van de Participatiewet
 ```
 
-The engine resolves which municipality's (*gemeente*) ordinance (*verordening*) applies; the law itself does not encode this. The engine already knows the execution scope (e.g., `gemeente_code: GM0384`) from its parameters. The `find_implementations` method uses a `matches_scope` helper that checks all scope fields on the candidate law against execution parameters. Currently supports `gemeente_code`; designed for easy extension to `provincie_code` etc. This eliminates `select_on`, `legal_basis_for`, and `source.delegation` entirely, all delegation flows through `open_terms` + `implements`.
+The engine resolves which municipality's (*gemeente*) ordinance (*verordening*) applies; the law itself does not encode this. The engine already knows the execution scope (e.g., `gemeente_code: GM0384`) from its parameters. The `find_implementations` method uses a `matches_scope` helper that checks all scope fields on the candidate law against execution parameters. Currently supports `gemeente_code`; designed for easy extension to `provincie_code` etc. This eliminates `select_on`, `legal_basis_for`, and `source.delegation` entirely: all delegation flows through `open_terms` + `implements`.
 
 When resolving open terms, the engine does not forward all execution parameters to implementing articles. It uses `filter_parameters_for_article` to only pass parameters declared in the implementing article's `execution.parameters` section (principle of least privilege).
 

--- a/docs/src/content/rfcs/rfc-003.md
+++ b/docs/src/content/rfcs/rfc-003.md
@@ -69,9 +69,9 @@ Temporal filtering is needed for correctness when multiple versions of an implem
 
 **Same `$id`, multiple versions.** The resolver stores multiple versions of the same law (keyed by `$id`), sorted newest-first. `get_law_for_date` filters these by `valid_from <= calculation_date` and returns the most recent valid version. So for a 2025-01-15 calculation with both `regeling_standaardpremie` versions loaded, the 2025 version is selected. A 2026 version with `valid_from: 2026-01-01` would be excluded because `2026-01-01 <= 2025-01-15` is false.
 
-**Different `$id`s implementing the same term.** If two separate law IDs both declare `implements` for the same open term, the `implements_index` contains entries for both. At resolution time, `find_implementations` calls `get_law_for_date` for each candidate independently — so a future-dated law is excluded before it ever reaches priority resolution.
+**Different `$id`s implementing the same term.** If two separate law IDs both declare `implements` for the same open term, the `implements_index` contains entries for both. At resolution time, `find_implementations` calls `get_law_for_date` for each candidate independently, so a future-dated law is excluded before it ever reaches priority resolution.
 
-**Invariant: `valid_from` must be present on implementing regulations.** The temporal filter uses `is_none_or`, meaning a regulation *without* `valid_from` passes the date check unconditionally — it matches every calculation date. This is by design for laws where the effective date is unknown, but for implementing regulations it undermines temporal correctness. Law authors must ensure that every regulation with an `implements` declaration has an explicit `valid_from` date. The schema does not enforce this (since `valid_from` is optional for other use cases), so this is a convention that must be maintained through review.
+**Invariant: `valid_from` must be present on implementing regulations.** The temporal filter uses `is_none_or`, meaning a regulation *without* `valid_from` passes the date check unconditionally, it matches every calculation date. This is by design for laws where the effective date is unknown, but for implementing regulations it undermines temporal correctness. Law authors must ensure that every regulation with an `implements` declaration has an explicit `valid_from` date. The schema does not enforce this (since `valid_from` is optional for other use cases), so this is a convention that must be maintained through review.
 
 **Why not filter in the index?** The `implements_index` is built at load time and is date-independent. It records *all* implementing relationships across all loaded versions. Temporal filtering happens at query time in `find_implementations`, which is the correct place because the calculation date is only known at execution time.
 
@@ -107,7 +107,7 @@ open_terms:
 
 This pattern is more common at lower regulatory layers (a policy rule with a reasonable default that can be overridden by implementation policy) but the mechanism works on all layers.
 
-Defaults also serve a legal correctness role. For example, Participatiewet article 8's open terms have `default` blocks with `verlaging_percentage: 0` and `duur_maanden: 0`. Legal basis: art. 18 lid 2 says "verlaagt ... overeenkomstig de verordening" — no ordinance (*verordening*) means no reduction (*verlaging*). A missing ordinance now results in full social assistance (*bijstand*) rather than a `DelegationError`.
+Defaults also serve a legal correctness role. For example, Participatiewet article 8's open terms have `default` blocks with `verlaging_percentage: 0` and `duur_maanden: 0`. Legal basis: art. 18 lid 2 says "verlaagt ... overeenkomstig de verordening", no ordinance (*verordening*) means no reduction (*verlaging*). A missing ordinance now results in full social assistance (*bijstand*) rather than a `DelegationError`.
 
 ## Why
 
@@ -146,7 +146,7 @@ implements:
     gelet_op: Gelet op artikel 8 van de Participatiewet
 ```
 
-The engine resolves which municipality's (*gemeente*) ordinance (*verordening*) applies; the law itself does not encode this. The engine already knows the execution scope (e.g., `gemeente_code: GM0384`) from its parameters. The `find_implementations` method uses a `matches_scope` helper that checks all scope fields on the candidate law against execution parameters. Currently supports `gemeente_code`; designed for easy extension to `provincie_code` etc. This eliminates `select_on`, `legal_basis_for`, and `source.delegation` entirely — all delegation flows through `open_terms` + `implements`.
+The engine resolves which municipality's (*gemeente*) ordinance (*verordening*) applies; the law itself does not encode this. The engine already knows the execution scope (e.g., `gemeente_code: GM0384`) from its parameters. The `find_implementations` method uses a `matches_scope` helper that checks all scope fields on the candidate law against execution parameters. Currently supports `gemeente_code`; designed for easy extension to `provincie_code` etc. This eliminates `select_on`, `legal_basis_for`, and `source.delegation` entirely, all delegation flows through `open_terms` + `implements`.
 
 When resolving open terms, the engine does not forward all execution parameters to implementing articles. It uses `filter_parameters_for_article` to only pass parameters declared in the implementing article's `execution.parameters` section (principle of least privilege).
 

--- a/docs/src/content/rfcs/rfc-003.md
+++ b/docs/src/content/rfcs/rfc-003.md
@@ -135,7 +135,7 @@ source:
   output: verlaging_percentage
 ```
 
-This is backwards. The Participatiewet doesn't know which municipalities (*gemeenten*) have ordinances (*verordeningen*); it just delegates. The municipal ordinance (*gemeentelijke verordening*) knows which law (*wet*) it implements. IoC corrects this by letting the implementing regulation declare the relationship:
+This is backward. The Participatiewet doesn't know which municipalities (*gemeenten*) have ordinances (*verordeningen*); it just delegates. The municipal ordinance (*gemeentelijke verordening*) knows which law (*wet*) it implements. IoC corrects this by letting the implementing regulation declare the relationship:
 
 ```yaml
 # New pattern: lower regulation registers itself

--- a/docs/src/content/rfcs/rfc-004.md
+++ b/docs/src/content/rfcs/rfc-004.md
@@ -4,7 +4,9 @@ title: "RFC-004: Uniform Operation Syntax"
 
 **Status:** Accepted
 **Date:** 2025-12-12
-**Authors:** regelrecht team
+**Authors:** RegelRecht team
+
+> **Implementation note.** The engine since unified `IF` and `SWITCH`: both are the single `IF` operation using `cases: [{when, then}]` + `default` (`SWITCH` is an accepted serde alias). There is no top-level `when`/`then`/`else` form in the current engine or schema. The table below reflects the original design.
 
 ## Context
 

--- a/docs/src/content/rfcs/rfc-005.md
+++ b/docs/src/content/rfcs/rfc-005.md
@@ -405,7 +405,7 @@ properties:
     type: string
     description: |
       W3C motivation - why this note exists.
-      W3C: optional (SHOULD). Regelrecht: required.
+      W3C: optional (SHOULD). RegelRecht: required.
     enum:
       # W3C standard vocabulary:
       - assessing       # Quality assessment
@@ -456,7 +456,7 @@ properties:
             type: string
             description: |
               W3C purpose - role of this body. Same vocabulary as motivation.
-              W3C: optional (MAY). Regelrecht: required.
+              W3C: optional (MAY). RegelRecht: required.
             enum: [assessing, bookmarking, classifying, commenting, describing,
                    editing, highlighting, identifying, linking, moderating,
                    questioning, replying, tagging]

--- a/docs/src/content/rfcs/rfc-005.md
+++ b/docs/src/content/rfcs/rfc-005.md
@@ -259,7 +259,7 @@ Fuzzy matching through an entire law can be expensive. Recommended strategy:
 1. **Exact match first** - Search for `prefix + exact + suffix` as a simple substring.
    This succeeds in 99% of cases and is O(n).
 
-2. **Optional hint** - Add `regelrecht:hint` with a W3C selector as optimisation.
+2. **Optional hint** - Add `regelrecht:hint` with a W3C selector as optimization.
    The hint is non-authoritative: if the text doesn't match there, search the
    entire law.
 

--- a/docs/src/content/rfcs/rfc-006.md
+++ b/docs/src/content/rfcs/rfc-006.md
@@ -4,7 +4,7 @@ title: "RFC-006: Language Choice for Law Execution Engine"
 
 **Status:** Accepted
 **Date:** 2026-01-26
-**Authors:** regelrecht team
+**Authors:** RegelRecht team
 
 ## Context
 

--- a/docs/src/content/rfcs/rfc-007.md
+++ b/docs/src/content/rfcs/rfc-007.md
@@ -117,7 +117,7 @@ Decision-level filters (`legal_character`, `decision_type`) are AND-combined. An
 
 #### Hook ordering
 
-Among hooks at the same hook point, execution is independent, no inter-hook dependencies. If hook A's output is needed by hook B, they must use cross-law references (`regelrecht://`), not output chaining.
+Among hooks at the same hook point, execution is independent: no inter-hook dependencies. If hook A's output is needed by hook B, they must use cross-law references (`regelrecht://`), not output chaining.
 
 #### Resolution model
 

--- a/docs/src/content/rfcs/rfc-007.md
+++ b/docs/src/content/rfcs/rfc-007.md
@@ -12,11 +12,11 @@ The engine currently supports **active execution**: someone requests a legal det
 
 **Reactive execution.** The Algemene wet bestuursrecht (AWB) applies whenever any government body issues an individual decision (*beschikking*). Article 6:7 sets an objection period (*bezwaartermijn*) of six weeks. Article 3:46 requires adequate reasoning (*deugdelijke motivering*). Neither article is called explicitly. They fire because the output qualifies as an individual decision (*beschikking*), regardless of which law produced it. The target law does not know about AWB. AWB does not know about the target law. The relationship is unilateral.
 
-**Lex specialis.** AWB 6:7 says "de termijn bedraagt zes weken" — no exception clause, no delegation. Yet the Vreemdelingenwet artikel 69 says "in afwijking van artikel 6:7 bedraagt de termijn vier weken." It unilaterally replaces the value. This differs from IoC delegation ([RFC-003](/rfcs/rfc-003)): the general law does not know it is being overridden.
+**Lex specialis.** AWB 6:7 says "de termijn bedraagt zes weken", no exception clause, no delegation. Yet the Vreemdelingenwet artikel 69 says "in afwijking van artikel 6:7 bedraagt de termijn vier weken." It unilaterally replaces the value. This differs from IoC delegation ([RFC-003](/rfcs/rfc-003)): the general law does not know it is being overridden.
 
-**Temporal computation.** "When is my deadline for objection (*bezwaar*)?" is not answered by "6 weeks" — it is answered by "9 april 2026." Computing that date requires a chain of four articles across three laws, using date arithmetic, public holiday calendars, and weekend rules. The engine lacks the types and operations.
+**Temporal computation.** "When is my deadline for objection (*bezwaar*)?" is not answered by "6 weeks", it is answered by "9 april 2026." Computing that date requires a chain of four articles across three laws, using date arithmetic, public holiday calendars, and weekend rules. The engine lacks the types and operations.
 
-These three patterns combine in the **objection period (*bezwaartermijn*) chain** — the driving example for this RFC:
+These three patterns combine in the **objection period (*bezwaartermijn*) chain**, the driving example for this RFC:
 
 ```mermaid
 graph LR
@@ -31,7 +31,7 @@ graph LR
 
 ### Design principle
 
-**Zero domain knowledge in the engine.** All legal and domain knowledge comes from law YAML files and parameters. The engine provides pure operations (date arithmetic, list manipulation). It does not know about Easter, King's Day (*Koningsdag*), or public holidays (*feestdagen*) — these are all expressed in law or supplied as parameters.
+**Zero domain knowledge in the engine.** All legal and domain knowledge comes from law YAML files and parameters. The engine provides pure operations (date arithmetic, list manipulation). It does not know about Easter, King's Day (*Koningsdag*), or public holidays (*feestdagen*), these are all expressed in law or supplied as parameters.
 
 ### Execution modes
 
@@ -52,7 +52,7 @@ The specification (YAML) is the same across all modes. The modes differ in trigg
 
 This RFC introduces three mechanisms and the types to support them.
 
-### 1. Hooks — Reactive Execution
+### 1. Hooks: Reactive Execution
 
 The engine has a defined execution lifecycle with two observable points. Laws can register hooks at these points. When a hook's filter matches the executing article's `produces` annotation, the hook fires and its outputs enrich the result.
 
@@ -117,7 +117,7 @@ Decision-level filters (`legal_character`, `decision_type`) are AND-combined. An
 
 #### Hook ordering
 
-Among hooks at the same hook point, execution is independent — no inter-hook dependencies. If hook A's output is needed by hook B, they must use cross-law references (`regelrecht://`), not output chaining.
+Among hooks at the same hook point, execution is independent, no inter-hook dependencies. If hook A's output is needed by hook B, they must use cross-law references (`regelrecht://`), not output chaining.
 
 #### Resolution model
 
@@ -143,7 +143,7 @@ Hook articles do not receive the target article's execution context. Each hook d
 
 When multiple hooks produce the same output name: lex superior (higher regulatory layer wins) then lex posterior (newer `valid_from` wins). Same model as IoC resolution ([RFC-003](/rfcs/rfc-003)).
 
-### 2. Overrides — Lex Specialis
+### 2. Overrides: Lex Specialis
 
 Introduce `overrides` on article-level `machine_readable`:
 
@@ -184,7 +184,7 @@ The **contextual law** is the law that initiated the current execution chain: th
 
 When no contextual law is set (standalone API call), no overrides apply.
 
-Unlike IoC resolution, lex specialis does not require lex superior/lex posterior tiebreaking. The `overrides` declaration is itself the assertion of specificity — "in afwijking van." The engine does not verify whether the override is legally valid; that is a law authoring responsibility.
+Unlike IoC resolution, lex specialis does not require lex superior/lex posterior tiebreaking. The `overrides` declaration is itself the assertion of specificity, "in afwijking van." The engine does not verify whether the override is legally valid; that is a law authoring responsibility.
 
 #### Resolution model
 
@@ -252,11 +252,11 @@ graph LR
 
 ```
 
-**Layer 1: Fixed dates** — Defined in the law text (art 3 lid 1). Modeled as `DATE` operations with the `jaar` parameter. King's Day (*Koningsdag*) has a Sunday-shift rule modeled as an `IF`/`DAY_OF_WEEK` expression in law YAML — not as engine knowledge.
+**Layer 1: Fixed dates**, Defined in the law text (art 3 lid 1). Modeled as `DATE` operations with the `jaar` parameter. King's Day (*Koningsdag*) has a Sunday-shift rule modeled as an `IF`/`DAY_OF_WEEK` expression in law YAML, not as engine knowledge.
 
-**Layer 2: Easter-dependent dates** — Good Friday (*Goede Vrijdag*), Easter Monday (*Tweede Paasdag*), Ascension Day (*Hemelvaartsdag*), Whit Monday (*Tweede Pinksterdag*). Fixed offsets from Easter Sunday. The engine receives `pasen_datum` as a parameter. The computus is not in the engine — whoever calls the engine provides the date.
+**Layer 2: Easter-dependent dates**, Good Friday (*Goede Vrijdag*), Easter Monday (*Tweede Paasdag*), Ascension Day (*Hemelvaartsdag*), Whit Monday (*Tweede Pinksterdag*). Fixed offsets from Easter Sunday. The engine receives `pasen_datum` as a parameter. The computus is not in the engine, whoever calls the engine provides the date.
 
-**Layer 3: Equivalent days (*gelijkgestelde dagen*)** — days designated by royal decree as equivalent to public holidays (*feestdagen*). Artikel 3 lid 3 delegates to the Crown. KB's from the Government Gazette (*Staatscourant*) (e.g., Stcrt. 2025, 24713 covers 2026-2028) implement this via IoC ([RFC-003](/rfcs/rfc-003)), same pattern as BW5 art 42 with municipal ordinances (*gemeentelijke verordeningen*).
+**Layer 3: Equivalent days (*gelijkgestelde dagen*)**, days designated by royal decree as equivalent to public holidays (*feestdagen*). Artikel 3 lid 3 delegates to the Crown. KB's from the Government Gazette (*Staatscourant*) (e.g., Stcrt. 2025, 24713 covers 2026-2028) implement this via IoC ([RFC-003](/rfcs/rfc-003)), same pattern as BW5 art 42 with municipal ordinances (*gemeentelijke verordeningen*).
 
 ### How the mechanisms compose
 
@@ -284,11 +284,11 @@ graph TB
 
 ### Full YAML examples
 
-#### AWB 6:7 — Duration (hook)
+#### AWB 6:7: Duration (hook)
 
 See Section 1 above for the full YAML. Key point: `bezwaartermijn_weken` is a duration (number), not a deadline (date). AWB 6:8 computes the actual date.
 
-#### AWB 3:46 — Motiveringsplicht (hook)
+#### AWB 3:46: Motiveringsplicht (hook)
 
 ```yaml
 - number: '3:46'
@@ -308,7 +308,7 @@ See Section 1 above for the full YAML. Key point: `bezwaartermijn_weken` is a du
           value: true
 ```
 
-#### AWB 6:8 — Start and end date (hook + reference)
+#### AWB 6:8: Start and end date (hook + reference)
 
 ```yaml
 - number: '6:8'
@@ -347,7 +347,7 @@ See Section 1 above for the full YAML. Key point: `bezwaartermijn_weken` is a du
             weeks: $bezwaartermijn_weken
 ```
 
-#### Vreemdelingenwet art 69 — Override
+#### Vreemdelingenwet art 69: Override
 
 ```yaml
 # vreemdelingenwet
@@ -369,7 +369,7 @@ See Section 1 above for the full YAML. Key point: `bezwaartermijn_weken` is a du
           value: 4
 ```
 
-#### Termijnenwet art 3 — Feestdagen (IoC + temporal)
+#### Termijnenwet art 3: Feestdagen (IoC + temporal)
 
 ```yaml
 # algemene_termijnenwet
@@ -550,11 +550,11 @@ The Zorgtoeslag YAML declares nothing about AWB. AWB declares nothing about Zorg
 
 Each output in `ArticleResult` is tagged with its provenance via the `output_provenance` map:
 
-- **`Direct`** — produced by the article's own actions (the article you requested)
-- **`Reactive`** — produced by a hook firing on a lifecycle event (e.g., AWB 3:46 on BESCHIKKING)
-- **`Override`** — produced by a lex specialis override (e.g., Vreemdelingenwet art 69 overriding AWB 6:7)
+- **`Direct`**: produced by the article's own actions (the article you requested)
+- **`Reactive`**: produced by a hook firing on a lifecycle event (e.g., AWB 3:46 on BESCHIKKING)
+- **`Override`**: produced by a lex specialis override (e.g., Vreemdelingenwet art 69 overriding AWB 6:7)
 
-This matters for multi-output evaluation: when a caller requests specific outputs, the engine filters out unrelated outputs but always preserves `Reactive` and `Override` outputs. A beschikking is legally indivisible (AWB 1:3) — its consequences (motivering per 3:46, bezwaartermijn per 6:7) cannot be stripped.
+This matters for multi-output evaluation: when a caller requests specific outputs, the engine filters out unrelated outputs but always preserves `Reactive` and `Override` outputs. A beschikking is legally indivisible (AWB 1:3), its consequences (motivering per 3:46, bezwaartermijn per 6:7) cannot be stripped.
 
 ## Why
 
@@ -586,7 +586,7 @@ This matters for multi-output evaluation: when a caller requests specific output
 
 **Bilateral hook declaration.** Both target and hooking law declare the relationship. Rejected: inverts the legal hierarchy. AWB's generality is the whole point.
 
-**Overrides as IoC.** AWB 6:7 declares `open_terms: bezwaartermijn_weken`. Rejected: AWB 6:7 says "bedraagt zes weken" — it sets a value, it does not delegate.
+**Overrides as IoC.** AWB 6:7 declares `open_terms: bezwaartermijn_weken`. Rejected: AWB 6:7 says "bedraagt zes weken", it sets a value, it does not delegate.
 
 **Overrides on the decision (*besluit*)-producing article.** Rejected: the legal text is in article 69, not article 25.
 
@@ -606,7 +606,7 @@ This matters for multi-output evaluation: when a caller requests specific output
 - Trace types: `PathNodeType::HookResolution`, `ResolveType::Hook`.
 
 **Overrides:**
-- The override check must be part of the core `evaluate_article_with_service` execution path, not a separate hook-dispatch concern. Overrides must apply whenever an article is executed — via cross-law reference, via hook, or directly. The Vw art 69 example demonstrates this: when AWB 6:8 resolves AWB 6:7 via `regelrecht://` reference, the Vw override must still apply to AWB 6:7.
+- The override check must be part of the core `evaluate_article_with_service` execution path, not a separate hook-dispatch concern. Overrides must apply whenever an article is executed, via cross-law reference, via hook, or directly. The Vw art 69 example demonstrates this: when AWB 6:8 resolves AWB 6:7 via `regelrecht://` reference, the Vw override must still apply to AWB 6:7.
 - `overrides_index` in `RuleResolver`, keyed by `(target_law, target_article, output)`.
 - `contextual_law_id: Option<String>` in `ResolutionContext`. Set once at root, immutable.
 - Cycle detection via `ResolutionContext.visited`.

--- a/docs/src/content/rfcs/rfc-007.md
+++ b/docs/src/content/rfcs/rfc-007.md
@@ -252,9 +252,9 @@ graph LR
 
 ```
 
-**Layer 1: Fixed dates**, Defined in the law text (art 3 lid 1). Modeled as `DATE` operations with the `jaar` parameter. King's Day (*Koningsdag*) has a Sunday-shift rule modeled as an `IF`/`DAY_OF_WEEK` expression in law YAML, not as engine knowledge.
+**Layer 1: Fixed dates**: Defined in the law text (art 3 lid 1). Modeled as `DATE` operations with the `jaar` parameter. King's Day (*Koningsdag*) has a Sunday-shift rule modeled as an `IF`/`DAY_OF_WEEK` expression in law YAML, not as engine knowledge.
 
-**Layer 2: Easter-dependent dates**, Good Friday (*Goede Vrijdag*), Easter Monday (*Tweede Paasdag*), Ascension Day (*Hemelvaartsdag*), Whit Monday (*Tweede Pinksterdag*). Fixed offsets from Easter Sunday. The engine receives `pasen_datum` as a parameter. The computus is not in the engine, whoever calls the engine provides the date.
+**Layer 2: Easter-dependent dates**: Good Friday (*Goede Vrijdag*), Easter Monday (*Tweede Paasdag*), Ascension Day (*Hemelvaartsdag*), Whit Monday (*Tweede Pinksterdag*). Fixed offsets from Easter Sunday. The engine receives `pasen_datum` as a parameter. The computus is not in the engine, whoever calls the engine provides the date.
 
 **Layer 3: Equivalent days (*gelijkgestelde dagen*)**, days designated by royal decree as equivalent to public holidays (*feestdagen*). Artikel 3 lid 3 delegates to the Crown. KB's from the Government Gazette (*Staatscourant*) (e.g., Stcrt. 2025, 24713 covers 2026-2028) implement this via IoC ([RFC-003](/rfcs/rfc-003)), same pattern as BW5 art 42 with municipal ordinances (*gemeentelijke verordeningen*).
 

--- a/docs/src/content/rfcs/rfc-007.md
+++ b/docs/src/content/rfcs/rfc-007.md
@@ -10,9 +10,9 @@ title: "RFC-007: Cross-Law Execution Model"
 
 The engine currently supports **active execution**: someone requests a legal determination, the engine evaluates with specific parameters, and produces a result. This covers laws like the Zorgtoeslagwet, Participatiewet, and BW5. But three patterns in Dutch law cannot be expressed with active execution alone:
 
-**Reactive execution.** The Algemene wet bestuursrecht (AWB) applies whenever any government body issues an individual decision (*beschikking*). Article 6:7 sets an objection period (*bezwaartermijn*) of six weeks. Article 3:46 requires adequate reasoning (*deugdelijke motivering*). Neither article is called explicitly. They fire because the output qualifies as an individual decision (*beschikking*), regardless of which law produced it. The target law does not know about AWB. AWB does not know about the target law. The relationship is unilateral.
+**Reactive execution.** The Algemene wet bestuursrecht (Awb) applies whenever any government body issues an individual decision (*beschikking*). Article 6:7 sets an objection period (*bezwaartermijn*) of six weeks. Article 3:46 requires adequate reasoning (*deugdelijke motivering*). Neither article is called explicitly. They fire because the output qualifies as an individual decision (*beschikking*), regardless of which law produced it. The target law does not know about Awb. Awb does not know about the target law. The relationship is unilateral.
 
-**Lex specialis.** AWB 6:7 says "de termijn bedraagt zes weken", no exception clause, no delegation. Yet the Vreemdelingenwet artikel 69 says "in afwijking van artikel 6:7 bedraagt de termijn vier weken." It unilaterally replaces the value. This differs from IoC delegation ([RFC-003](/rfcs/rfc-003)): the general law does not know it is being overridden.
+**Lex specialis.** Awb 6:7 says "de termijn bedraagt zes weken", no exception clause, no delegation. Yet the Vreemdelingenwet artikel 69 says "in afwijking van artikel 6:7 bedraagt de termijn vier weken." It unilaterally replaces the value. This differs from IoC delegation ([RFC-003](/rfcs/rfc-003)): the general law does not know it is being overridden.
 
 **Temporal computation.** "When is my deadline for objection (*bezwaar*)?" is not answered by "6 weeks", it is answered by "9 april 2026." Computing that date requires a chain of four articles across three laws, using date arithmetic, public holiday calendars, and weekend rules. The engine lacks the types and operations.
 
@@ -20,8 +20,8 @@ These three patterns combine in the **objection period (*bezwaartermijn*) chain*
 
 ```mermaid
 graph LR
-    A["Beschikking\n(any law)"] --> B["AWB 6:7\nbezwaartermijn = 6 weken"]
-    B --> C["AWB 6:8\nstartdatum, einddatum"]
+    A["Beschikking\n(any law)"] --> B["Awb 6:7\nbezwaartermijn = 6 weken"]
+    B --> C["Awb 6:8\nstartdatum, einddatum"]
     C --> D["Termijnenwet art 1\nweekend/feestdag extension"]
     D --> E["9 april 2026"]
 
@@ -75,14 +75,14 @@ Two hook points interleave with this lifecycle:
 | `pre_actions` | 3 and 4 | Parameters, inputs, resolved open terms |
 | `post_actions` | 4 and 5 | Parameters, inputs, open terms, outputs |
 
-Earlier drafts included `pre_input` and `post_input` hooks. These were removed because the legal requirements that operate on the input phase tend to be application-layer concerns (authorization per AWB 2:1), authoring-time concerns (data minimization per AVG art. 5), or process-management concerns (completeness checks per AWB 4:5 with recovery period (*hersteltermijn*)). None map cleanly to a runtime engine hook.
+Earlier drafts included `pre_input` and `post_input` hooks. These were removed because the legal requirements that operate on the input phase tend to be application-layer concerns (authorization per Awb 2:1), authoring-time concerns (data minimization per AVG art. 5), or process-management concerns (completeness checks per Awb 4:5 with recovery period (*hersteltermijn*)). None map cleanly to a runtime engine hook.
 
 #### YAML construct
 
 Introduce `hooks` on article-level `machine_readable`:
 
 ```yaml
-# AWB artikel 6:7
+# Awb artikel 6:7
 - number: '6:7'
   text: |-
     De termijn voor het indienen van een bezwaar- of
@@ -136,7 +136,7 @@ Hook articles execute through the same `evaluate_article_with_service` path. Cyc
 
 Hook articles do not receive the target article's execution context. Each hook declares its own `parameters` and `input` sections. The engine passes only declared parameters, consistent with [RFC-003](/rfcs/rfc-003)'s principle of least privilege (`filter_parameters_for_article`).
 
-- **Constant hooks** (no parameters): execute standalone. Most AWB hooks fall here.
+- **Constant hooks** (no parameters): execute standalone. Most Awb hooks fall here.
 - **Context-aware hooks** (parameters declared): receive only what they request.
 
 #### Priority
@@ -180,7 +180,7 @@ The declaration sits on the article where the legal text is. Article 69 says "in
 
 #### Contextual law
 
-The **contextual law** is the law that initiated the current execution chain: the root of the call stack. Only overrides declared in the contextual law apply. A Vreemdelingenwet override to AWB 6:7 does not affect Participatiewet cases.
+The **contextual law** is the law that initiated the current execution chain: the root of the call stack. Only overrides declared in the contextual law apply. A Vreemdelingenwet override to Awb 6:7 does not affect Participatiewet cases.
 
 When no contextual law is set (standalone API call), no overrides apply.
 
@@ -198,7 +198,7 @@ Unlike IoC resolution, lex specialis does not require lex superior/lex posterior
 4. If not found: execute normally
 5. If multiple found within same contextual law: error (law authoring bug)
 
-Overrides apply to hook articles too. When AWB 6:7 fires as a hook, the contextual law's overrides still apply.
+Overrides apply to hook articles too. When Awb 6:7 fires as a hook, the contextual law's overrides still apply.
 
 ### 3. Temporal Computation
 
@@ -263,9 +263,9 @@ graph LR
 ```mermaid
 graph TB
     subgraph "Decision-level hooks · legal_character: BESCHIKKING"
-        H1["AWB 3:46\nmotivering_vereist = true\n(pre_actions)"]
-        H2["AWB 6:7\nbezwaartermijn_weken = 6\n(post_actions)"]
-        H3["AWB 6:8\nstartdatum, einddatum\n(post_actions)"]
+        H1["Awb 3:46\nmotivering_vereist = true\n(pre_actions)"]
+        H2["Awb 6:7\nbezwaartermijn_weken = 6\n(post_actions)"]
+        H3["Awb 6:8\nstartdatum, einddatum\n(post_actions)"]
     end
 
     subgraph "Override · lex specialis"
@@ -277,18 +277,18 @@ graph TB
     end
 
     H3 -->|"regelrecht:// ref"| H2
-    O1 -.->|"overrides AWB 6:7"| H2
+    O1 -.->|"overrides Awb 6:7"| H2
     D1 -->|"implements art 3 lid 3"| T3["Termijnenwet art 3\nfeestdagen list"]
 
 ```
 
 ### Full YAML examples
 
-#### AWB 6:7: Duration (hook)
+#### Awb 6:7: Duration (hook)
 
-See Section 1 above for the full YAML. Key point: `bezwaartermijn_weken` is a duration (number), not a deadline (date). AWB 6:8 computes the actual date.
+See Section 1 above for the full YAML. Key point: `bezwaartermijn_weken` is a duration (number), not a deadline (date). Awb 6:8 computes the actual date.
 
-#### AWB 3:46: Motiveringsplicht (hook)
+#### Awb 3:46: Motiveringsplicht (hook)
 
 ```yaml
 - number: '3:46'
@@ -308,7 +308,7 @@ See Section 1 above for the full YAML. Key point: `bezwaartermijn_weken` is a du
           value: true
 ```
 
-#### AWB 6:8: Start and end date (hook + reference)
+#### Awb 6:8: Start and end date (hook + reference)
 
 ```yaml
 - number: '6:8'
@@ -493,9 +493,9 @@ Citizen applies for a residence permit (*verblijfsvergunning*). Individual decis
 sequenceDiagram
     participant Caller
     participant Engine
-    participant AWB_67 as AWB 6:7
+    participant AWB_67 as Awb 6:7
     participant Vw69 as Vw art 69
-    participant AWB_68 as AWB 6:8
+    participant AWB_68 as Awb 6:8
     Caller->>Engine: execute(vreemdelingenwet art 25,<br/>bekendmaking=2026-03-12)
     Engine->>Engine: produces BESCHIKKING
 
@@ -519,9 +519,9 @@ Final result:
 - `bezwaartermijn_weken: 4` (overridden by Vreemdelingenwet art 69)
 - `bezwaartermijn_startdatum: 2026-03-13`
 - `bezwaartermijn_einddatum: 2026-04-09` (Thursday, no extension)
-- `motivering_vereist: true` (AWB 3:46 pre_actions hook)
+- `motivering_vereist: true` (Awb 3:46 pre_actions hook)
 
-*"U kunt tot en met 9 april 2026 bezwaar maken (artikel 69 Vreemdelingenwet, in afwijking van artikel 6:7 AWB)"*
+*"U kunt tot en met 9 april 2026 bezwaar maken (artikel 69 Vreemdelingenwet, in afwijking van artikel 6:7 Awb)"*
 
 **Scenario 2: Simple hooks without override**
 
@@ -531,11 +531,11 @@ Zorgtoeslag produces a BESCHIKKING (individual decision (*beschikking*)). No ove
 1. Create context: { toetsingsinkomen: 28000, drempelinkomen: 38520 }
 2. Inspect produces: { legal_character: BESCHIKKING }
 3. Query hooks_index for pre_actions + BESCHIKKING:
-   → AWB 3:46 matches → { motivering_vereist: true }
+   → Awb 3:46 matches → { motivering_vereist: true }
 4. Execute Zorgtoeslag art 2 actions:
    → { heeft_recht_op_zorgtoeslag: true }
 5. Query hooks_index for post_actions + BESCHIKKING:
-   → AWB 6:7 matches → { bezwaartermijn_weken: 6 }
+   → Awb 6:7 matches → { bezwaartermijn_weken: 6 }
 6. Merge into result
 
 Final outputs:
@@ -544,27 +544,27 @@ Final outputs:
   bezwaartermijn_weken: 6
 ```
 
-The Zorgtoeslag YAML declares nothing about AWB. AWB declares nothing about Zorgtoeslag. The relationship exists purely through `produces` on the target side and `applies_to` on the hook side.
+The Zorgtoeslag YAML declares nothing about Awb. Awb declares nothing about Zorgtoeslag. The relationship exists purely through `produces` on the target side and `applies_to` on the hook side.
 
 ## Output Provenance
 
 Each output in `ArticleResult` is tagged with its provenance via the `output_provenance` map:
 
 - **`Direct`**: produced by the article's own actions (the article you requested)
-- **`Reactive`**: produced by a hook firing on a lifecycle event (e.g., AWB 3:46 on BESCHIKKING)
-- **`Override`**: produced by a lex specialis override (e.g., Vreemdelingenwet art 69 overriding AWB 6:7)
+- **`Reactive`**: produced by a hook firing on a lifecycle event (e.g., Awb 3:46 on BESCHIKKING)
+- **`Override`**: produced by a lex specialis override (e.g., Vreemdelingenwet art 69 overriding Awb 6:7)
 
-This matters for multi-output evaluation: when a caller requests specific outputs, the engine filters out unrelated outputs but always preserves `Reactive` and `Override` outputs. A beschikking is legally indivisible (AWB 1:3), its consequences (motivering per 3:46, bezwaartermijn per 6:7) cannot be stripped.
+This matters for multi-output evaluation: when a caller requests specific outputs, the engine filters out unrelated outputs but always preserves `Reactive` and `Override` outputs. A beschikking is legally indivisible (Awb 1:3), its consequences (motivering per 3:46, bezwaartermijn per 6:7) cannot be stripped.
 
 ## Why
 
 ### Benefits
 
-**Composition.** All four cross-law mechanisms (hooks, overrides, IoC, references) compose naturally. The override propagates through the reference chain: when AWB 6:8 references AWB 6:7, the Vreemdelingenwet override applies automatically. No special wiring.
+**Composition.** All four cross-law mechanisms (hooks, overrides, IoC, references) compose naturally. The override propagates through the reference chain: when Awb 6:8 references Awb 6:7, the Vreemdelingenwet override applies automatically. No special wiring.
 
-**Impact analysis.** The engine can answer "which articles hook into individual decision (*beschikking*) executions?" and "if AWB 6:7 changes, which laws override it?" by querying its indexes.
+**Impact analysis.** The engine can answer "which articles hook into individual decision (*beschikking*) executions?" and "if Awb 6:7 changes, which laws override it?" by querying its indexes.
 
-**Unilateral declaration.** Hooks are declared by the hooking law, overrides by the overriding law. Neither requires the target law to participate. This matches legal reality: AWB applies to all decisions (*besluiten*); the Vreemdelingenwet overrides AWB without AWB's consent.
+**Unilateral declaration.** Hooks are declared by the hooking law, overrides by the overriding law. Neither requires the target law to participate. This matches legal reality: Awb applies to all decisions (*besluiten*); the Vreemdelingenwet overrides Awb without Awb's consent.
 
 **Concrete answers.** A citizen asking "when is my deadline?" gets "9 april 2026", not "6 weeks."
 
@@ -584,9 +584,9 @@ This matters for multi-output evaluation: when a caller requests specific output
 
 **Hooks as event-bus.** Laws declare `reacts_to`/`produces` event types. Rejected: couples specification to a maintained event vocabulary.
 
-**Bilateral hook declaration.** Both target and hooking law declare the relationship. Rejected: inverts the legal hierarchy. AWB's generality is the whole point.
+**Bilateral hook declaration.** Both target and hooking law declare the relationship. Rejected: inverts the legal hierarchy. Awb's generality is the whole point.
 
-**Overrides as IoC.** AWB 6:7 declares `open_terms: bezwaartermijn_weken`. Rejected: AWB 6:7 says "bedraagt zes weken", it sets a value, it does not delegate.
+**Overrides as IoC.** Awb 6:7 declares `open_terms: bezwaartermijn_weken`. Rejected: Awb 6:7 says "bedraagt zes weken", it sets a value, it does not delegate.
 
 **Overrides on the decision (*besluit*)-producing article.** Rejected: the legal text is in article 69, not article 25.
 
@@ -606,7 +606,7 @@ This matters for multi-output evaluation: when a caller requests specific output
 - Trace types: `PathNodeType::HookResolution`, `ResolveType::Hook`.
 
 **Overrides:**
-- The override check must be part of the core `evaluate_article_with_service` execution path, not a separate hook-dispatch concern. Overrides must apply whenever an article is executed, via cross-law reference, via hook, or directly. The Vw art 69 example demonstrates this: when AWB 6:8 resolves AWB 6:7 via `regelrecht://` reference, the Vw override must still apply to AWB 6:7.
+- The override check must be part of the core `evaluate_article_with_service` execution path, not a separate hook-dispatch concern. Overrides must apply whenever an article is executed, via cross-law reference, via hook, or directly. The Vw art 69 example demonstrates this: when Awb 6:8 resolves Awb 6:7 via `regelrecht://` reference, the Vw override must still apply to Awb 6:7.
 - `overrides_index` in `RuleResolver`, keyed by `(target_law, target_article, output)`.
 - `contextual_law_id: Option<String>` in `ResolutionContext`. Set once at root, immutable.
 - Cycle detection via `ResolutionContext.visited`.
@@ -622,9 +622,9 @@ This matters for multi-output evaluation: when a caller requests specific output
 ## References
 
 - [RFC-003](/rfcs/rfc-003): Inversion of Control for Delegated Legislation
-- AWB article 3:46: https://wetten.overheid.nl/BWBR0005537/2024-01-01#Artikel3:46
-- AWB article 6:7: https://wetten.overheid.nl/BWBR0005537/2024-01-01#Artikel6:7
-- AWB article 6:8: https://wetten.overheid.nl/BWBR0005537/2024-01-01#Artikel6:8
+- Awb article 3:46: https://wetten.overheid.nl/BWBR0005537/2024-01-01#Artikel3:46
+- Awb article 6:7: https://wetten.overheid.nl/BWBR0005537/2024-01-01#Artikel6:7
+- Awb article 6:8: https://wetten.overheid.nl/BWBR0005537/2024-01-01#Artikel6:8
 - Algemene termijnenwet: https://wetten.overheid.nl/BWBR0002448
 - Algemene termijnenwet artikel 3: https://maxius.nl/algemene-termijnenwet/artikel3/
 - Vreemdelingenwet artikel 69: https://wetten.overheid.nl/BWBR0011823/2024-01-01#Artikel69

--- a/docs/src/content/rfcs/rfc-007.md
+++ b/docs/src/content/rfcs/rfc-007.md
@@ -521,7 +521,7 @@ Final result:
 - `bezwaartermijn_einddatum: 2026-04-09` (Thursday, no extension)
 - `motivering_vereist: true` (AWB 3:46 pre_actions hook)
 
-*"U kunt tot en met 9 april 2026 bezwaar maken (artikel 69 Vreemdelingenwet, in afwijking van artikel 6:7 Awb)"*
+*"U kunt tot en met 9 april 2026 bezwaar maken (artikel 69 Vreemdelingenwet, in afwijking van artikel 6:7 AWB)"*
 
 **Scenario 2: Simple hooks without override**
 

--- a/docs/src/content/rfcs/rfc-008.md
+++ b/docs/src/content/rfcs/rfc-008.md
@@ -463,12 +463,12 @@ Decision (*besluit*) state is external (passed in, returned out), which is compa
 - AWB Hoofdstuk 4: Bijzondere bepalingen over besluiten (beslistermijn, aanvraag)
 - AWB Hoofdstuk 6: Algemene bepalingen over bezwaar en beroep (termijnen)
 - AWB Hoofdstuk 7: Bijzondere bepalingen over bezwaar en administratief beroep
-- [PG Awb - Artikel 4:17 (dwangsom)](https://pgawb.nl/pg-awb-digitaal/hoofdstuk-4/4-1-bijzondere-bepalingen-over-besluiten/4-1-3-beslistermijn/4-1-3-2-dwangsom-bij-niet-tijdig-beslissen/artikel-417/)
-- [PG Awb - Artikel 8:81 (voorlopige voorziening)](https://pgawb.nl/pg-awb-digitaal/hoofdstuk-8/8-3-voorlopige-voorziening-en-onmiddelijke-uitspraak-in-de-hoofdzaak/artikel-881/)
-- [PG Awb - Artikel 8:86 (kortsluiting)](https://pgawb.nl/pg-awb-digitaal/hoofdstuk-8/8-3-voorlopige-voorziening-en-onmiddelijke-uitspraak-in-de-hoofdzaak/artikel-886/)
-- [PG Awb - Bestuurlijke lus (8:51a-8:51d)](https://pgawb.nl/pg-awb-digitaal/hoofdstuk-8/8-2-behandeling-van-het-beroep/8-2-2a-bestuurlijke-lus/)
-- [PG Awb - Afdeling 3.4 UOV](https://pgawb.nl/pg-awb-digitaal/hoofdstuk-3/3-4-uniforme-openbare-voorbereidingsprocedure/)
-- [PG Awb - Artikel 7:1a (rechtstreeks beroep)](https://pgawb.nl/pg-awb-digitaal/hoofdstuk-7/7-1-bezwaar-voorafgaand-aan-beroep-bij-de-administratieve-rechter/artikel-71a/)
+- [PG AWB - Artikel 4:17 (dwangsom)](https://pgawb.nl/pg-awb-digitaal/hoofdstuk-4/4-1-bijzondere-bepalingen-over-besluiten/4-1-3-beslistermijn/4-1-3-2-dwangsom-bij-niet-tijdig-beslissen/artikel-417/)
+- [PG AWB - Artikel 8:81 (voorlopige voorziening)](https://pgawb.nl/pg-awb-digitaal/hoofdstuk-8/8-3-voorlopige-voorziening-en-onmiddelijke-uitspraak-in-de-hoofdzaak/artikel-881/)
+- [PG AWB - Artikel 8:86 (kortsluiting)](https://pgawb.nl/pg-awb-digitaal/hoofdstuk-8/8-3-voorlopige-voorziening-en-onmiddelijke-uitspraak-in-de-hoofdzaak/artikel-886/)
+- [PG AWB - Bestuurlijke lus (8:51a-8:51d)](https://pgawb.nl/pg-awb-digitaal/hoofdstuk-8/8-2-behandeling-van-het-beroep/8-2-2a-bestuurlijke-lus/)
+- [PG AWB - Afdeling 3.4 UOV](https://pgawb.nl/pg-awb-digitaal/hoofdstuk-3/3-4-uniforme-openbare-voorbereidingsprocedure/)
+- [PG AWB - Artikel 7:1a (rechtstreeks beroep)](https://pgawb.nl/pg-awb-digitaal/hoofdstuk-7/7-1-bezwaar-voorafgaand-aan-beroep-bij-de-administratieve-rechter/artikel-71a/)
 - [Glossary of Dutch Legal Terms](/reference/glossary)
 
 ---

--- a/docs/src/content/rfcs/rfc-008.md
+++ b/docs/src/content/rfcs/rfc-008.md
@@ -1,5 +1,5 @@
 ---
-title: "RFC-008: AWB Administrative Procedures"
+title: "RFC-008: Awb Administrative Procedures"
 ---
 
 **Status:** Accepted
@@ -9,51 +9,51 @@ title: "RFC-008: AWB Administrative Procedures"
 
 ## Context
 
-[RFC-007](/rfcs/rfc-007) introduced hooks: articles that fire when another article's `produces` annotation matches. This enables reactive execution: AWB 3:46 (reasoning requirement, *motiveringsplicht*) fires on any BESCHIKKING, AWB 6:7 (objection period, *bezwaartermijn*) fires on any BESCHIKKING, AWB 6:8 (start/einddatum) fires on any BESCHIKKING.
+[RFC-007](/rfcs/rfc-007) introduced hooks: articles that fire when another article's `produces` annotation matches. This enables reactive execution: Awb 3:46 (reasoning requirement, *motiveringsplicht*) fires on any BESCHIKKING, Awb 6:7 (objection period, *bezwaartermijn*) fires on any BESCHIKKING, Awb 6:8 (start/einddatum) fires on any BESCHIKKING.
 
 But an individual decision (*beschikking*) is not an instant computation. It is an administrative law (*bestuursrecht*) process that progresses through stages over time:
 
-1. The interested party (*belanghebbende*) submits an **application** (*aanvraag*, AWB 4:1).
-2. The administrative body (*bestuursorgaan*) investigates during the **processing** (*behandeling*) phase, possibly requesting additional information (AWB 4:5), possibly extending the decision deadline (*beslistermijn*, AWB 4:14). This can take weeks, months, or in complex cases years.
-3. The administrative body (*bestuursorgaan*) makes a **decision** (*besluit*, AWB 1:3).
-4. The decision (*besluit*) is communicated to the interested party (*belanghebbende*): **notification** (*bekendmaking*, AWB 3:41).
-5. The **objection period** (*bezwaartermijn*) starts the day after notification (*bekendmaking*, AWB 6:8 lid 1) and runs for six weeks (AWB 6:7).
-6. The interested party (*belanghebbende*) may file an **objection** (*bezwaar*, AWB 6:4).
+1. The interested party (*belanghebbende*) submits an **application** (*aanvraag*, Awb 4:1).
+2. The administrative body (*bestuursorgaan*) investigates during the **processing** (*behandeling*) phase, possibly requesting additional information (Awb 4:5), possibly extending the decision deadline (*beslistermijn*, Awb 4:14). This can take weeks, months, or in complex cases years.
+3. The administrative body (*bestuursorgaan*) makes a **decision** (*besluit*, Awb 1:3).
+4. The decision (*besluit*) is communicated to the interested party (*belanghebbende*): **notification** (*bekendmaking*, Awb 3:41).
+5. The **objection period** (*bezwaartermijn*) starts the day after notification (*bekendmaking*, Awb 6:8 lid 1) and runs for six weeks (Awb 6:7).
+6. The interested party (*belanghebbende*) may file an **objection** (*bezwaar*, Awb 6:4).
 
-If hooks fire without awareness of lifecycle stages, all AWB obligations trigger at once, including AWB 6:8 (objection period date calculation), which needs `bekendmaking_datum`. But notification (*bekendmaking*) hasn't happened yet at decision time. Treating a missing `bekendmaking_datum` as "skip this hook gracefully" is a workaround, not a design.
+If hooks fire without awareness of lifecycle stages, all Awb obligations trigger at once, including Awb 6:8 (objection period date calculation), which needs `bekendmaking_datum`. But notification (*bekendmaking*) hasn't happened yet at decision time. Treating a missing `bekendmaking_datum` as "skip this hook gracefully" is a workaround, not a design.
 
 The problem: **the decision and the notification (*bekendmaking*) are different moments in time, with different inputs, producing different outputs, governed by different articles of law.** They must not fire in the same execution step.
 
 ### Who defines the lifecycle?
 
-The lifecycle of an individual decision (*beschikking*) is not defined by the Vreemdelingenwet or the Zorgtoeslagwet. It is defined by the **Algemene wet bestuursrecht (AWB)**, the General Administrative Law Act. That is the purpose of the AWB: to define the general administrative procedure that all administrative bodies (*bestuursorganen*) follow, regardless of which specific law they are executing.
+The lifecycle of an individual decision (*beschikking*) is not defined by the Vreemdelingenwet or the Zorgtoeslagwet. It is defined by the **Algemene wet bestuursrecht (Awb)**, the General Administrative Law Act. That is the purpose of the Awb: to define the general administrative procedure that all administrative bodies (*bestuursorganen*) follow, regardless of which specific law they are executing.
 
-The AWB defines stages. Specific laws fill in the content at each stage. Other laws (Termijnenwet, KB gelijkgestelde dagen) hook into specific stages. This relationship already exists in law; it needs to be expressed in the schema.
+The Awb defines stages. Specific laws fill in the content at each stage. Other laws (Termijnenwet, KB gelijkgestelde dagen) hook into specific stages. This relationship already exists in law; it needs to be expressed in the schema.
 
 ### Terminology: procedure vs. lifecycle
 
-In AWB terminology, what we describe here is a **procedure**, the objection procedure, the appeal procedure, the preparation procedure. The AWB never uses the word "lifecycle"; that is software engineering jargon.
+In Awb terminology, what we describe here is a **procedure**, the objection procedure, the appeal procedure, the preparation procedure. The Awb never uses the word "lifecycle"; that is software engineering jargon.
 
-However, in the AWB "procedure" typically refers to one phase (the objection (*bezwaar*) procedure, the appeal (*beroep*) procedure). The entire journey from application (*aanvraag*) to final/irrevocable (*onherroepelijk*) spans *multiple* procedures. In engineering, "lifecycle" captures this overarching concept: the full life of a decision (*besluit*) from birth (application) to final state (final/irrevocable (*onherroepelijk*), withdrawn (*ingetrokken*), or expired).
+However, in the Awb "procedure" typically refers to one phase (the objection (*bezwaar*) procedure, the appeal (*beroep*) procedure). The entire journey from application (*aanvraag*) to final/irrevocable (*onherroepelijk*) spans *multiple* procedures. In engineering, "lifecycle" captures this overarching concept: the full life of a decision (*besluit*) from birth (application) to final state (final/irrevocable (*onherroepelijk*), withdrawn (*ingetrokken*), or expired).
 
 This RFC uses both terms deliberately:
 - **Procedure** (`procedure:` in YAML): the domain term, used in the machine-readable specification because the YAML is a law specification and should speak the language of law.
 - **Lifecycle**: used in prose when discussing the engineering concept of an entity progressing through states over time.
 
-Both refer to the same thing: the AWB-defined sequence of stages that a decision (*besluit*) progresses through.
+Both refer to the same thing: the Awb-defined sequence of stages that a decision (*besluit*) progresses through.
 
 ### What goes wrong without lifecycle stages
 
-1. **Semantic confusion**: AWB 6:8 hooks on BESCHIKKING but should only fire when notification (*bekendmaking*) has occurred. Without stages, parameter absence becomes implicit control flow.
+1. **Semantic confusion**: Awb 6:8 hooks on BESCHIKKING but should only fire when notification (*bekendmaking*) has occurred. Without stages, parameter absence becomes implicit control flow.
 2. **Incorrect composition**: hooks that belong to different stages fire in the same execution, mixing outputs from different moments in time.
 3. **No way to model waiting**: an engine without stages cannot express "the decision (*besluit*) is taken, now waiting for notification (*bekendmaking*)."
-4. **Manual actions invisible**: an administrative body (*bestuursorgaan*)'s investigation, decision-making, and notification (*bekendmaking*) are real-world actions that the law regulates (decision deadline (*beslistermijn*) per AWB 4:13) but cannot be represented without stages.
+4. **Manual actions invisible**: an administrative body (*bestuursorgaan*)'s investigation, decision-making, and notification (*bekendmaking*) are real-world actions that the law regulates (decision deadline (*beslistermijn*) per Awb 4:13) but cannot be represented without stages.
 
 ## Decision
 
 ### The lifecycle is law
 
-The AWB defines a **lifecycle** for administrative law (*bestuursrecht*) processes. This lifecycle is expressed in the YAML specification as a first-class construct. Laws do not define their own lifecycles; they declare which AWB-defined lifecycle they participate in through `produces`.
+The Awb defines a **lifecycle** for administrative law (*bestuursrecht*) processes. This lifecycle is expressed in the YAML specification as a first-class construct. Laws do not define their own lifecycles; they declare which Awb-defined lifecycle they participate in through `produces`.
 
 A lifecycle is a sequence of **stages**. Each stage:
 - Has a **name** (e.g., `AANVRAAG`, `BESLUIT`, `BEKENDMAKING`)
@@ -63,12 +63,12 @@ A lifecycle is a sequence of **stages**. Each stage:
 
 ### Procedure selection
 
-A single `legal_character` can have multiple procedure variants. Both a regular individual decision (*beschikking*) and a UOV (public consultation procedure) individual decision (*beschikking*) have `legal_character: BESCHIKKING`, but they follow different AWB procedures: the UOV omits objection (*bezwaar*) entirely (AWB 7:1 lid 1 sub d). Selecting the wrong procedure produces a legally invalid outcome.
+A single `legal_character` can have multiple procedure variants. Both a regular individual decision (*beschikking*) and a UOV (public consultation procedure) individual decision (*beschikking*) have `legal_character: BESCHIKKING`, but they follow different Awb procedures: the UOV omits objection (*bezwaar*) entirely (Awb 7:1 lid 1 sub d). Selecting the wrong procedure produces a legally invalid outcome.
 
 The `produces` annotation gains an optional `procedure_id` field to disambiguate:
 
 ```yaml
-# Regular beschikking — uses default AWB procedure
+# Regular beschikking — uses default Awb procedure
 produces:
   legal_character: BESCHIKKING
   # procedure_id defaults to "beschikking" when omitted
@@ -79,11 +79,11 @@ produces:
   procedure_id: beschikking_uov
 ```
 
-When `procedure_id` is omitted, the engine selects the default procedure for the `legal_character`. The AWB defines which procedure is the default.
+When `procedure_id` is omitted, the engine selects the default procedure for the `legal_character`. The Awb defines which procedure is the default.
 
-### Procedure definition in AWB
+### Procedure definition in Awb
 
-The AWB defines procedures for BESCHIKKING as machine-readable constructs. Multiple procedures can apply to the same `legal_character`:
+The Awb defines procedures for BESCHIKKING as machine-readable constructs. Multiple procedures can apply to the same `legal_character`:
 
 ```yaml
 # algemene_wet_bestuursrecht.yaml
@@ -91,7 +91,7 @@ $id: algemene_wet_bestuursrecht
 
 # The stages below are the normative definition for the engine.
 # Appendix A describes additional sub-stages (ONTVANGSTBEVESTIGING,
-# AANVULLING, BESLISTERMIJN) that exist in the AWB but are not
+# AANVULLING, BESLISTERMIJN) that exist in the Awb but are not
 # modeled as discrete engine stages in v1 — they are subsumed
 # into the stages listed here.
 
@@ -102,33 +102,33 @@ procedure:
       legal_character: BESCHIKKING
     stages:
       - name: AANVRAAG
-        description: Belanghebbende dient aanvraag in (AWB 4:1)
+        description: Belanghebbende dient aanvraag in (Awb 4:1)
         requires:
           - name: aanvraag_datum
             type: date
 
       - name: BEHANDELING
-        description: Bestuursorgaan onderzoekt de aanvraag (AWB 3:2)
+        description: Bestuursorgaan onderzoekt de aanvraag (Awb 3:2)
         requires:
           - name: beslistermijn_start
             type: date
-        # AWB 4:13: beslistermijn is "redelijke termijn", typically 8 weeks
-        # AWB 4:14: extension possible with notification
+        # Awb 4:13: beslistermijn is "redelijke termijn", typically 8 weeks
+        # Awb 4:14: extension possible with notification
 
       - name: BESLUIT
-        description: Bestuursorgaan neemt besluit (AWB 1:3)
+        description: Bestuursorgaan neemt besluit (Awb 1:3)
         requires:
           - name: besluit_datum
             type: date
 
       - name: BEKENDMAKING
-        description: Besluit wordt bekendgemaakt (AWB 3:41)
+        description: Besluit wordt bekendgemaakt (Awb 3:41)
         requires:
           - name: bekendmaking_datum
             type: date
 
       - name: BEZWAAR
-        description: Bezwaarperiode (AWB 6:4 e.v.)
+        description: Bezwaarperiode (Awb 6:4 e.v.)
         # This stage is entered automatically after BEKENDMAKING
         # and runs for the duration of the bezwaartermijn
 
@@ -136,7 +136,7 @@ procedure:
     applies_to:
       legal_character: BESCHIKKING
     # UOV replaces regular preparation with public consultation
-    # and eliminates bezwaar (AWB 7:1 lid 1 sub d)
+    # and eliminates bezwaar (Awb 7:1 lid 1 sub d)
     stages:
       - name: AANVRAAG
         description: Aanvraag of ambtshalve initiatief
@@ -145,27 +145,27 @@ procedure:
             type: date
 
       - name: ONTWERP_BESLUIT
-        description: Bestuursorgaan bereidt ontwerpbesluit voor (AWB 3:11)
+        description: Bestuursorgaan bereidt ontwerpbesluit voor (Awb 3:11)
 
       - name: TER_INZAGE
-        description: Terinzagelegging 6 weken (AWB 3:11-3:14)
+        description: Terinzagelegging 6 weken (Awb 3:11-3:14)
 
       - name: ZIENSWIJZEN
-        description: Zienswijzen indienen (AWB 3:15-3:17)
+        description: Zienswijzen indienen (Awb 3:15-3:17)
 
       - name: BESLUIT
-        description: Definitief besluit (AWB 3:18)
+        description: Definitief besluit (Awb 3:18)
         requires:
           - name: besluit_datum
             type: date
 
       - name: BEKENDMAKING
-        description: Publicatie (AWB 3:41/3:42)
+        description: Publicatie (Awb 3:41/3:42)
         requires:
           - name: bekendmaking_datum
             type: date
 
-      # No BEZWAAR — direct beroep (AWB 7:1 lid 1 sub d)
+      # No BEZWAAR — direct beroep (Awb 7:1 lid 1 sub d)
       - name: BEROEP
         description: Direct beroep bij bestuursrechter
 ```
@@ -202,21 +202,21 @@ stateDiagram-v2
     state bezwaar_of_beroep <<choice>>
     BEZWAARTERMIJN --> bezwaar_of_beroep
 
-    bezwaar_of_beroep --> BEZWAAR: Bezwaar ingediend<br/>(AWB 6:4)
+    bezwaar_of_beroep --> BEZWAAR: Bezwaar ingediend<br/>(Awb 6:4)
     bezwaar_of_beroep --> ONHERROEPELIJK: Geen bezwaar<br/>na 6 weken
 
     state "Bezwaarprocedure" as bezwaar_proc {
-        BEZWAAR --> HOREN_B: AWB 7:2
-        BEZWAAR --> DIRECT_BEROEP: AWB 7:1a<br/>Rechtstreeks beroep
-        HOREN_B --> HEROVERWEGING_B: AWB 7:11
-        HEROVERWEGING_B --> BOB: Besluit op bezwaar<br/>(AWB 7:12)
+        BEZWAAR --> HOREN_B: Awb 7:2
+        BEZWAAR --> DIRECT_BEROEP: Awb 7:1a<br/>Rechtstreeks beroep
+        HOREN_B --> HEROVERWEGING_B: Awb 7:11
+        HEROVERWEGING_B --> BOB: Besluit op bezwaar<br/>(Awb 7:12)
     }
 
     BOB --> BEROEPSTERMIJN_BOB
 
     state beroep_keuze <<choice>>
     BEROEPSTERMIJN_BOB --> beroep_keuze
-    beroep_keuze --> BEROEP: Beroep ingediend<br/>(AWB 8:1)
+    beroep_keuze --> BEROEP: Beroep ingediend<br/>(Awb 8:1)
     beroep_keuze --> ONHERROEPELIJK: Geen beroep<br/>na 6 weken
 
     DIRECT_BEROEP --> BEROEP
@@ -226,7 +226,7 @@ stateDiagram-v2
         ONDERZOEK --> ZITTING_R
         ZITTING_R --> UITSPRAAK_R
 
-        ONDERZOEK --> BEST_LUS: Tussenuitspraak<br/>(AWB 8:51a)
+        ONDERZOEK --> BEST_LUS: Tussenuitspraak<br/>(Awb 8:51a)
         BEST_LUS --> HERSTEL
         HERSTEL --> ONDERZOEK: Hersteld besluit
     }
@@ -234,17 +234,17 @@ stateDiagram-v2
     state "Voorlopige voorziening<br/>(parallel aan bezwaar/beroep)" as vovo_track {
         VOVO_VERZOEK --> VOVO_ZITTING
         VOVO_ZITTING --> VOVO_UITSPRAAK
-        VOVO_ZITTING --> KORTSLUITING_K: AWB 8:86
+        VOVO_ZITTING --> KORTSLUITING_K: Awb 8:86
     }
 
-    BEZWAAR --> VOVO_VERZOEK: Spoedeisend belang<br/>(AWB 8:81)
-    BEROEP --> VOVO_VERZOEK: Spoedeisend belang<br/>(AWB 8:81)
+    BEZWAAR --> VOVO_VERZOEK: Spoedeisend belang<br/>(Awb 8:81)
+    BEROEP --> VOVO_VERZOEK: Spoedeisend belang<br/>(Awb 8:81)
     KORTSLUITING_K --> UITSPRAAK_R: Directe uitspraak<br/>in hoofdzaak
 
     UITSPRAAK_R --> HOGER_BEROEP_KEUZE
     state hb_keuze <<choice>>
     HOGER_BEROEP_KEUZE --> hb_keuze
-    hb_keuze --> HOGER_BEROEP_R: Hoger beroep<br/>(AWB 8:104)
+    hb_keuze --> HOGER_BEROEP_R: Hoger beroep<br/>(Awb 8:104)
     hb_keuze --> ONHERROEPELIJK: Geen hoger beroep
     HOGER_BEROEP_R --> ONHERROEPELIJK
 
@@ -256,7 +256,7 @@ stateDiagram-v2
 The `applies_to` in hooks ([RFC-007](/rfcs/rfc-007)) gains a `stage` field:
 
 ```yaml
-# AWB 3:46 — motiveringsplicht
+# Awb 3:46 — motiveringsplicht
 # Must be satisfied AT decision time
 - number: '3:46'
   machine_readable:
@@ -266,7 +266,7 @@ The `applies_to` in hooks ([RFC-007](/rfcs/rfc-007)) gains a `stage` field:
           legal_character: BESCHIKKING
           stage: BESLUIT
 
-# AWB 6:7 — bezwaartermijn
+# Awb 6:7 — bezwaartermijn
 # Property of the decision, determined at BESLUIT
 - number: '6:7'
   machine_readable:
@@ -276,7 +276,7 @@ The `applies_to` in hooks ([RFC-007](/rfcs/rfc-007)) gains a `stage` field:
           legal_character: BESCHIKKING
           stage: BESLUIT
 
-# AWB 6:8 — start/einddatum berekening
+# Awb 6:8 — start/einddatum berekening
 # Only meaningful AFTER bekendmaking
 - number: '6:8'
   machine_readable:
@@ -287,15 +287,15 @@ The `applies_to` in hooks ([RFC-007](/rfcs/rfc-007)) gains a `stage` field:
           stage: BEKENDMAKING
 ```
 
-This is the key insight: **hooks apply to the AWB's lifecycle, not to the specific law's decision (*besluit*).** The Aliens Act (*Vreemdelingenwet*) produces a BESCHIKKING and thereby enters the AWB lifecycle. The Vreemdelingenwet does not know about AWB 6:8. AWB 6:8 does not know about the Vreemdelingenwet. They are connected through the lifecycle defined by the AWB.
+This is the key insight: **hooks apply to the Awb's lifecycle, not to the specific law's decision (*besluit*).** The Aliens Act (*Vreemdelingenwet*) produces a BESCHIKKING and thereby enters the Awb lifecycle. The Vreemdelingenwet does not know about Awb 6:8. Awb 6:8 does not know about the Vreemdelingenwet. They are connected through the lifecycle defined by the Awb.
 
 ### The besluit as state container
 
-A **decision** (*besluit*) progresses through the AWB lifecycle and accumulates outputs at each stage. The decision (*besluit*) itself is the state container; there is no separate "case" or "zaak" (case file) abstraction. This follows the AWB, which defines everything in terms of the decision (*besluit*).
+A **decision** (*besluit*) progresses through the Awb lifecycle and accumulates outputs at each stage. The decision (*besluit*) itself is the state container; there is no separate "case" or "zaak" (case file) abstraction. This follows the Awb, which defines everything in terms of the decision (*besluit*).
 
 ```
 Besluit {
-    procedure: "beschikking"          -- which AWB procedure
+    procedure: "beschikking"          -- which Awb procedure
     contextual_law: "vreemdelingenwet_2000"  -- lex specialis context
     current_stage: BEKENDMAKING       -- where we are
     outputs: {                        -- accumulated from all stages
@@ -321,7 +321,7 @@ When the engine executes a law that produces a BESCHIKKING:
 **Step 1: BESLUIT stage**
 ```
 Input:  { heeft_geldige_mvv: true, heeft_geldig_document: true }
-Engine: executes Vw art 14, fires BESLUIT-stage hooks (AWB 3:46, 6:7)
+Engine: executes Vw art 14, fires BESLUIT-stage hooks (Awb 3:46, 6:7)
 Output: { verblijfsvergunning_verleend: true, motivering_vereist: true,
           bezwaartermijn_weken: 4 }
 Yields: "Waiting for BEKENDMAKING — need: bekendmaking_datum"
@@ -330,7 +330,7 @@ Yields: "Waiting for BEKENDMAKING — need: bekendmaking_datum"
 **Step 2: BEKENDMAKING stage** (days/weeks later)
 ```
 Input:  { bekendmaking_datum: "2026-03-23", pasen_datum: "2026-04-05" }
-Engine: fires BEKENDMAKING-stage hooks (AWB 6:8 → Termijnenwet art 1)
+Engine: fires BEKENDMAKING-stage hooks (Awb 6:8 → Termijnenwet art 1)
         Termijnenwet art 1 resolves feestdagen from pasen_datum parameter
         + gelijkgestelde_dagen via IoC (KB's from Staatscourant)
 Output: { bezwaartermijn_startdatum: "2026-03-24",
@@ -361,7 +361,7 @@ The decision (*besluit*) state consists of:
 
 The engine itself remains **stateless** in the sense that it does not maintain decision (*besluit*) state internally. The decision (*besluit*) state is an external record (database row, event store, file) managed by the orchestration layer. The engine receives the decision (*besluit*) state as input and returns the updated state as output.
 
-This is important: the engine is still a pure function per stage. But the **composition** of stages into a decision (*besluit*) lifecycle is now explicit, governed by the AWB lifecycle definition, and persisted externally.
+This is important: the engine is still a pure function per stage. But the **composition** of stages into a decision (*besluit*) lifecycle is now explicit, governed by the Awb lifecycle definition, and persisted externally.
 
 ### Automatic vs. manual stage transitions
 
@@ -380,15 +380,15 @@ The lifecycle definition distinguishes these: stages with `requires` fields that
 
 ### Benefits
 
-**Conceptual correctness.** The model matches the legal reality: a decision (*besluit*) is a process with stages, not an instant computation. The AWB defines the process, specific laws fill in the content.
+**Conceptual correctness.** The model matches the legal reality: a decision (*besluit*) is a process with stages, not an instant computation. The Awb defines the process, specific laws fill in the content.
 
-**Separation of concerns.** Decision logic (Vreemdelingenwet) is separate from procedural logic (AWB lifecycle). Each law does what it's supposed to do. The lifecycle connects them.
+**Separation of concerns.** Decision logic (Vreemdelingenwet) is separate from procedural logic (Awb lifecycle). Each law does what it's supposed to do. The lifecycle connects them.
 
 **Temporal accuracy.** Outputs are computed at the right moment. The objection period (*bezwaartermijn*) end date is calculated when the notification (*bekendmaking*) happens, not when the decision (*besluit*) is made. The feestdagenkalender uses the correct year for the notification (*bekendmaking*) date, not the decision (*besluit*) date.
 
-**Auditability.** The decision (*besluit*) record shows exactly what happened at each stage, when, and with what inputs. This supports the reasoning requirement (*motiveringsplicht*, AWB 3:46) and provides a complete administrative trail.
+**Auditability.** The decision (*besluit*) record shows exactly what happened at each stage, when, and with what inputs. This supports the reasoning requirement (*motiveringsplicht*, Awb 3:46) and provides a complete administrative trail.
 
-**Extensibility.** New lifecycle stages can be added by the AWB without changing specific laws. New hooks can bind to any stage. The lifecycle is data (YAML), not code.
+**Extensibility.** New lifecycle stages can be added by the Awb without changing specific laws. New hooks can bind to any stage. The lifecycle is data (YAML), not code.
 
 **Real-world fidelity.** The model naturally handles long-running processes (asylum decisions that take months), manual steps (administrative body (*bestuursorgaan*) investigation), and asynchronous events (notification (*bekendmaking*) by post).
 
@@ -403,12 +403,12 @@ The lifecycle definition distinguishes these: stages with `requires` fields that
 ### Alternatives Considered
 
 **Alternative 1: Implicit stages via parameter presence**
-- AWB 6:8 hooks on BESCHIKKING and skips when `bekendmaking_datum` is absent.
+- Awb 6:8 hooks on BESCHIKKING and skips when `bekendmaking_datum` is absent.
 - Rejected: uses parameter absence as control flow. Semantically wrong, the hook doesn't "fail to fire," it fires at the wrong time. Silently skipping hooks hides the lifecycle.
 
 **Alternative 2: Multiple explicit executions (no lifecycle)**
-- Caller invokes the decision law first, then separately invokes AWB 6:8 with the results plus `bekendmaking_datum`.
-- Rejected: makes the lifecycle invisible. The caller must know which AWB articles to invoke and in what order. The machine-readable specification should capture this.
+- Caller invokes the decision law first, then separately invokes Awb 6:8 with the results plus `bekendmaking_datum`.
+- Rejected: makes the lifecycle invisible. The caller must know which Awb articles to invoke and in what order. The machine-readable specification should capture this.
 
 **Alternative 3: Event sourcing / CQRS**
 - The original poc-machine-law approach: a `Case` aggregate with event sourcing.
@@ -419,14 +419,14 @@ The lifecycle definition distinguishes these: stages with `requires` fields that
 The procedure is a new top-level construct in the schema (`procedure:` key), defined at the law level (not article level). It references stages, and hooks reference stages.
 
 The engine needs:
-- **Procedure index**: maps `(legal_character, procedure_id) → procedure_definition`, loaded from AWB YAML. When `procedure_id` is omitted in `produces`, selects the procedure marked `default: true`.
+- **Procedure index**: maps `(legal_character, procedure_id) → procedure_definition`, loaded from Awb YAML. When `procedure_id` is omitted in `produces`, selects the procedure marked `default: true`.
 - **Stage-aware hook resolution**: `find_hooks` gains a `stage` parameter. Hooks without `stage` default to BESLUIT.
 - **Decision (*besluit*) state**: a struct carrying accumulated outputs, current stage, and context. Passed in and returned by the engine.
 - **Yield mechanism**: the engine returns either a completed result or a "waiting for input" signal with the next stage's requirements.
 
 The decision (*besluit*) state is *not* stored in the engine. It is passed in by the caller and returned with updates. The engine remains a library, not a service.
 
-**Schema version:** The `procedure:` top-level key and the `procedure_id` field on `produces` are new constructs not present in schema v0.4.0. They land in **schema v0.5.0** (see the [Schema Reference](/reference/schema#version-history) version history), alongside the hooks and overrides from [RFC-007](/rfcs/rfc-007). AWB YAML files using `procedure:` must reference v0.5.0 or later.
+**Schema version:** The `procedure:` top-level key and the `procedure_id` field on `produces` are new constructs not present in schema v0.4.0. They land in **schema v0.5.0** (see the [Schema Reference](/reference/schema#version-history) version history), alongside the hooks and overrides from [RFC-007](/rfcs/rfc-007). Awb YAML files using `procedure:` must reference v0.5.0 or later.
 
 **Yield mechanism.** The largest architectural change is the yield mechanism. The current engine returns `Result<ArticleResult>`, a terminal result. Multi-stage execution needs the engine to return either a completed result or a "yielded" state waiting for input to proceed to the next stage. Two implementation approaches:
 
@@ -435,49 +435,49 @@ The decision (*besluit*) state is *not* stored in the engine. It is passed in by
 
 Decision (*besluit*) state is external (passed in, returned out), which is compatible with the stateless engine design. The engine uses `&self` (immutable borrows) for execution, so there is no architectural conflict with multi-stage execution, each invocation is still a pure function over its inputs.
 
-**Nested lifecycle recursion.** A decision on objection (*besluit op bezwaar*) is itself a decision (*besluit*), creating recursive nesting. The engine's cycle detection (`ResolutionContext.visited`) operates within a single invocation; cross-invocation nesting is the orchestration layer's responsibility. The engine should provide a `max_nesting_depth` configuration to help the orchestration layer detect excessive recursion. In practice the AWB chain is naturally finite (individual decision (*beschikking*), decision on objection (*besluit op bezwaar*), appeal (*beroep*), higher appeal (*hoger beroep*)), but a configurable depth limit provides a safety net.
+**Nested lifecycle recursion.** A decision on objection (*besluit op bezwaar*) is itself a decision (*besluit*), creating recursive nesting. The engine's cycle detection (`ResolutionContext.visited`) operates within a single invocation; cross-invocation nesting is the orchestration layer's responsibility. The engine should provide a `max_nesting_depth` configuration to help the orchestration layer detect excessive recursion. In practice the Awb chain is naturally finite (individual decision (*beschikking*), decision on objection (*besluit op bezwaar*), appeal (*beroep*), higher appeal (*hoger beroep*)), but a configurable depth limit provides a safety net.
 
 ## Open Questions
 
-1. ~~**Do all decisions (*besluiten*) share the same lifecycle?**~~ **Resolved:** No. Each legal_character has its own lifecycle, defined by the relevant AWB chapters. A BESCHIKKING has application (*aanvraag*) → processing (*behandeling*) → decision (*besluit*) → notification (*bekendmaking*) → objection (*bezwaar*). A BESLUIT_VAN_ALGEMENE_STREKKING (general rule, *besluit van algemene strekking*) has a different procedure (AWB afdeling 3.4, Staatscourant publication, no objection (*bezwaar*), direct appeal (*beroep*)). The AWB defines these different procedures, the lifecycle definition in YAML follows the AWB structure per type.
+1. ~~**Do all decisions (*besluiten*) share the same lifecycle?**~~ **Resolved:** No. Each legal_character has its own lifecycle, defined by the relevant Awb chapters. A BESCHIKKING has application (*aanvraag*) → processing (*behandeling*) → decision (*besluit*) → notification (*bekendmaking*) → objection (*bezwaar*). A BESLUIT_VAN_ALGEMENE_STREKKING (general rule, *besluit van algemene strekking*) has a different procedure (Awb afdeling 3.4, Staatscourant publication, no objection (*bezwaar*), direct appeal (*beroep*)). The Awb defines these different procedures, the lifecycle definition in YAML follows the Awb structure per type.
 
-2. ~~**Nested lifecycles.**~~ **Resolved:** An objection (*bezwaar*) is itself a decision (*besluit*, AWB 7:12), which starts its own lifecycle (with its own notification (*bekendmaking*), and possibility of appeal (*beroep*) before the administrative court (*bestuursrechter*)). The engine applies the same lifecycle pattern recursively, a decision on objection (*besluit op bezwaar*) enters the AWB lifecycle just like the original individual decision (*beschikking*). If a law inadvertently creates infinite recursion, that is a defect in the law, not in the engine.
+2. ~~**Nested lifecycles.**~~ **Resolved:** An objection (*bezwaar*) is itself a decision (*besluit*, Awb 7:12), which starts its own lifecycle (with its own notification (*bekendmaking*), and possibility of appeal (*beroep*) before the administrative court (*bestuursrechter*)). The engine applies the same lifecycle pattern recursively, a decision on objection (*besluit op bezwaar*) enters the Awb lifecycle just like the original individual decision (*beschikking*). If a law inadvertently creates infinite recursion, that is a defect in the law, not in the engine.
 
-   Note that [RFC-007](/rfcs/rfc-007)'s cycle detection does **not** cover this case. [RFC-007](/rfcs/rfc-007) detects cross-law circular references within a single engine invocation (Law A → Law B → Law A). Nested lifecycle recursion (individual decision (*beschikking*) → decision on objection (*besluit op bezwaar*) → its own objection (*bezwaar*) → ...) happens across separate engine invocations initiated by the orchestration layer. The **orchestration layer** is responsible for detecting excessive lifecycle nesting depth, not the engine. In the AWB this chain is naturally finite (individual decision (*beschikking*) → decision on objection (*besluit op bezwaar*) → appeal (*beroep*) → higher appeal (*hoger beroep*) terminates), but the orchestration layer should enforce a configurable maximum nesting depth as a safety measure.
+   Note that [RFC-007](/rfcs/rfc-007)'s cycle detection does **not** cover this case. [RFC-007](/rfcs/rfc-007) detects cross-law circular references within a single engine invocation (Law A → Law B → Law A). Nested lifecycle recursion (individual decision (*beschikking*) → decision on objection (*besluit op bezwaar*) → its own objection (*bezwaar*) → ...) happens across separate engine invocations initiated by the orchestration layer. The **orchestration layer** is responsible for detecting excessive lifecycle nesting depth, not the engine. In the Awb this chain is naturally finite (individual decision (*beschikking*) → decision on objection (*besluit op bezwaar*) → appeal (*beroep*) → higher appeal (*hoger beroep*) terminates), but the orchestration layer should enforce a configurable maximum nesting depth as a safety measure.
 
 3. ~~**Parallel stages.**~~ **Resolved:** The main lifecycle track (application (*aanvraag*) → processing (*behandeling*) → decision (*besluit*) → notification (*bekendmaking*) → objection (*bezwaar*) → appeal (*beroep*)) is strictly sequential, each stage depends on completion of the previous one. However, three genuinely parallel tracks can be spawned from the main lifecycle:
-   - **Penalty payment for late decision (*dwangsom bij niet-tijdig beslissen*, AWB 4:17-4:20)**: activates when the decision deadline (*beslistermijn*) expires without a decision (*besluit*). Runs parallel to the ongoing processing (*behandeling*) phase. The penalty payment decision (*dwangsombesluit*) is itself an individual decision (*beschikking*) with its own lifecycle.
-   - **Interim relief (*voorlopige voorziening*, AWB 8:81-8:87)**: activates after objection (*bezwaar*) or appeal (*beroep*) is filed. Runs parallel to the objection (*bezwaar*)/appeal (*beroep*) procedure. Can collapse into the main track via short-circuit ruling (*kortsluiting*, AWB 8:86) where the interim relief judge (*voorzieningenrechter*) immediately decides the main case.
-   - **Amendment decision (*wijzigingsbesluit*) pending objection (*bezwaar*)/appeal (*beroep*) (AWB 6:19)**: if the administrative body (*bestuursorgaan*) takes a new decision (*besluit*) while objection (*bezwaar*)/appeal (*beroep*) is pending, it is incorporated into the existing procedure.
+   - **Penalty payment for late decision (*dwangsom bij niet-tijdig beslissen*, Awb 4:17-4:20)**: activates when the decision deadline (*beslistermijn*) expires without a decision (*besluit*). Runs parallel to the ongoing processing (*behandeling*) phase. The penalty payment decision (*dwangsombesluit*) is itself an individual decision (*beschikking*) with its own lifecycle.
+   - **Interim relief (*voorlopige voorziening*, Awb 8:81-8:87)**: activates after objection (*bezwaar*) or appeal (*beroep*) is filed. Runs parallel to the objection (*bezwaar*)/appeal (*beroep*) procedure. Can collapse into the main track via short-circuit ruling (*kortsluiting*, Awb 8:86) where the interim relief judge (*voorzieningenrechter*) immediately decides the main case.
+   - **Amendment decision (*wijzigingsbesluit*) pending objection (*bezwaar*)/appeal (*beroep*) (Awb 6:19)**: if the administrative body (*bestuursorgaan*) takes a new decision (*besluit*) while objection (*bezwaar*)/appeal (*beroep*) is pending, it is incorporated into the existing procedure.
 
-   Additionally, two alternative paths exist as branches (not parallelism): direct appeal (*rechtstreeks beroep*, AWB 7:1a, skipping objection (*bezwaar*)) and the uniforme openbare voorbereidingsprocedure (AWB afdeling 3.4, replacing regular preparation with public consultation and eliminating objection (*bezwaar*)). The administrative repair loop (*bestuurlijke lus*, AWB 8:51a-8:51d) is a loop within appeal (*beroep*), not a parallel track, the administrative court (*bestuursrechter*) suspends appeal (*beroep*), the administrative body (*bestuursorgaan*) repairs the defect, then appeal (*beroep*) resumes. See Appendix A for the full procedure analysis and Appendix B for Mermaid state diagrams.
+   Additionally, two alternative paths exist as branches (not parallelism): direct appeal (*rechtstreeks beroep*, Awb 7:1a, skipping objection (*bezwaar*)) and the uniforme openbare voorbereidingsprocedure (Awb afdeling 3.4, replacing regular preparation with public consultation and eliminating objection (*bezwaar*)). The administrative repair loop (*bestuurlijke lus*, Awb 8:51a-8:51d) is a loop within appeal (*beroep*), not a parallel track, the administrative court (*bestuursrechter*) suspends appeal (*beroep*), the administrative body (*bestuursorgaan*) repairs the defect, then appeal (*beroep*) resumes. See Appendix A for the full procedure analysis and Appendix B for Mermaid state diagrams.
 
-4. ~~**Decision deadline (*beslistermijn*) enforcement.**~~ **Resolved:** The decision deadline (*beslistermijn*) is calculated by a hook at the AANVRAAG stage, AWB 4:13 provides the default ("redelijke termijn"), specific laws override via lex specialis (same pattern as bezwaartermijn_weken). The engine does **not** enforce the deadline: if besluit_datum exceeds the decision deadline (*beslistermijn*), the engine continues normally but annotates the decision (*besluit*) with a warning. Exceeding the decision deadline (*beslistermijn*) does not invalidate the decision (*besluit*), it **expands the lifecycle** with new available paths for the interested party (*belanghebbende*): notice of default (*ingebrekestelling*, AWB 4:17), penalty payment (*dwangsom*, AWB 4:18), and appeal (*beroep*) against failure to decide in time (AWB 6:2 lid 1 sub b). These are modeled as conditional branches in the lifecycle state machine.
+4. ~~**Decision deadline (*beslistermijn*) enforcement.**~~ **Resolved:** The decision deadline (*beslistermijn*) is calculated by a hook at the AANVRAAG stage, Awb 4:13 provides the default ("redelijke termijn"), specific laws override via lex specialis (same pattern as bezwaartermijn_weken). The engine does **not** enforce the deadline: if besluit_datum exceeds the decision deadline (*beslistermijn*), the engine continues normally but annotates the decision (*besluit*) with a warning. Exceeding the decision deadline (*beslistermijn*) does not invalidate the decision (*besluit*), it **expands the lifecycle** with new available paths for the interested party (*belanghebbende*): notice of default (*ingebrekestelling*, Awb 4:17), penalty payment (*dwangsom*, Awb 4:18), and appeal (*beroep*) against failure to decide in time (Awb 6:2 lid 1 sub b). These are modeled as conditional branches in the lifecycle state machine.
 
-5. ~~**Withdrawal (*intrekking*) and revocation.**~~ **Resolved:** Withdrawal (*intrekking*, AWB 10:4-10:5) is a state transition in the original decision (*besluit*)'s lifecycle, not a separate lifecycle. An individual decision (*beschikking*) continues to exist after notification (*bekendmaking*), it can be final/irrevocable (*onherroepelijk*), withdrawn (*ingetrokken*), amended, or expired. The withdrawal (*intrekking*) itself is a nested decision (*besluit*, same pattern as question 2): it requires motivation, notification (*bekendmaking*), and can be challenged via objection (*bezwaar*). The original individual decision (*beschikking*)'s state changes as a consequence of the withdrawal (*intrekking*) decision completing its own lifecycle.
+5. ~~**Withdrawal (*intrekking*) and revocation.**~~ **Resolved:** Withdrawal (*intrekking*, Awb 10:4-10:5) is a state transition in the original decision (*besluit*)'s lifecycle, not a separate lifecycle. An individual decision (*beschikking*) continues to exist after notification (*bekendmaking*), it can be final/irrevocable (*onherroepelijk*), withdrawn (*ingetrokken*), amended, or expired. The withdrawal (*intrekking*) itself is a nested decision (*besluit*, same pattern as question 2): it requires motivation, notification (*bekendmaking*), and can be challenged via objection (*bezwaar*). The original individual decision (*beschikking*)'s state changes as a consequence of the withdrawal (*intrekking*) decision completing its own lifecycle.
 
 ## References
 
 - [RFC-007](/rfcs/rfc-007): Cross-Law Execution Model (hooks, overrides, temporal computation)
-- AWB Hoofdstuk 3: Algemene bepalingen over besluiten (bekendmaking, motivering)
-- AWB Hoofdstuk 4: Bijzondere bepalingen over besluiten (beslistermijn, aanvraag)
-- AWB Hoofdstuk 6: Algemene bepalingen over bezwaar en beroep (termijnen)
-- AWB Hoofdstuk 7: Bijzondere bepalingen over bezwaar en administratief beroep
-- [PG AWB - Artikel 4:17 (dwangsom)](https://pgawb.nl/pg-awb-digitaal/hoofdstuk-4/4-1-bijzondere-bepalingen-over-besluiten/4-1-3-beslistermijn/4-1-3-2-dwangsom-bij-niet-tijdig-beslissen/artikel-417/)
-- [PG AWB - Artikel 8:81 (voorlopige voorziening)](https://pgawb.nl/pg-awb-digitaal/hoofdstuk-8/8-3-voorlopige-voorziening-en-onmiddelijke-uitspraak-in-de-hoofdzaak/artikel-881/)
-- [PG AWB - Artikel 8:86 (kortsluiting)](https://pgawb.nl/pg-awb-digitaal/hoofdstuk-8/8-3-voorlopige-voorziening-en-onmiddelijke-uitspraak-in-de-hoofdzaak/artikel-886/)
-- [PG AWB - Bestuurlijke lus (8:51a-8:51d)](https://pgawb.nl/pg-awb-digitaal/hoofdstuk-8/8-2-behandeling-van-het-beroep/8-2-2a-bestuurlijke-lus/)
-- [PG AWB - Afdeling 3.4 UOV](https://pgawb.nl/pg-awb-digitaal/hoofdstuk-3/3-4-uniforme-openbare-voorbereidingsprocedure/)
-- [PG AWB - Artikel 7:1a (rechtstreeks beroep)](https://pgawb.nl/pg-awb-digitaal/hoofdstuk-7/7-1-bezwaar-voorafgaand-aan-beroep-bij-de-administratieve-rechter/artikel-71a/)
+- Awb Hoofdstuk 3: Algemene bepalingen over besluiten (bekendmaking, motivering)
+- Awb Hoofdstuk 4: Bijzondere bepalingen over besluiten (beslistermijn, aanvraag)
+- Awb Hoofdstuk 6: Algemene bepalingen over bezwaar en beroep (termijnen)
+- Awb Hoofdstuk 7: Bijzondere bepalingen over bezwaar en administratief beroep
+- [PG Awb - Artikel 4:17 (dwangsom)](https://pgawb.nl/pg-awb-digitaal/hoofdstuk-4/4-1-bijzondere-bepalingen-over-besluiten/4-1-3-beslistermijn/4-1-3-2-dwangsom-bij-niet-tijdig-beslissen/artikel-417/)
+- [PG Awb - Artikel 8:81 (voorlopige voorziening)](https://pgawb.nl/pg-awb-digitaal/hoofdstuk-8/8-3-voorlopige-voorziening-en-onmiddelijke-uitspraak-in-de-hoofdzaak/artikel-881/)
+- [PG Awb - Artikel 8:86 (kortsluiting)](https://pgawb.nl/pg-awb-digitaal/hoofdstuk-8/8-3-voorlopige-voorziening-en-onmiddelijke-uitspraak-in-de-hoofdzaak/artikel-886/)
+- [PG Awb - Bestuurlijke lus (8:51a-8:51d)](https://pgawb.nl/pg-awb-digitaal/hoofdstuk-8/8-2-behandeling-van-het-beroep/8-2-2a-bestuurlijke-lus/)
+- [PG Awb - Afdeling 3.4 UOV](https://pgawb.nl/pg-awb-digitaal/hoofdstuk-3/3-4-uniforme-openbare-voorbereidingsprocedure/)
+- [PG Awb - Artikel 7:1a (rechtstreeks beroep)](https://pgawb.nl/pg-awb-digitaal/hoofdstuk-7/7-1-bezwaar-voorafgaand-aan-beroep-bij-de-administratieve-rechter/artikel-71a/)
 - [Glossary of Dutch Legal Terms](/reference/glossary)
 
 ---
 
-## Appendix A: Detailed AWB Procedure Stages
+## Appendix A: Detailed Awb Procedure Stages
 
 ### A.1 Primary Decision Phase (Primair Besluit)
 
-| Stage | AWB Articles | Description |
+| Stage | Awb Articles | Description |
 |-------|-------------|-------------|
 | **AANVRAAG** | 4:1-4:6 | Belanghebbende submits application. Must include name, address, date, indication of requested decision (4:2). |
 | **ONTVANGSTBEVESTIGING** | 4:3a | Bestuursorgaan confirms receipt. |
@@ -489,7 +489,7 @@ Decision (*besluit*) state is external (passed in, returned out), which is compa
 
 ### A.2 Dwangsom bij Niet-Tijdig Beslissen (Parallel Track)
 
-| Stage | AWB Articles | Description |
+| Stage | Awb Articles | Description |
 |-------|-------------|-------------|
 | **INGEBREKESTELLING** | 4:17 | If decision is late, applicant sends written notice of default. |
 | **DWANGSOM_LOOPT** | 4:17 lid 1-3 | After 2 weeks from ingebrekestelling: dwangsom starts. EUR 23/day (days 1-14), EUR 35/day (days 15-28), EUR 45/day (days 29-42). Max 42 days. |
@@ -499,7 +499,7 @@ This is a **parallel track**: the ingebrekestelling can be sent while BEHANDELIN
 
 ### A.3 Bezwaar Phase (Rechtsbescherming)
 
-| Stage | AWB Articles | Description |
+| Stage | Awb Articles | Description |
 |-------|-------------|-------------|
 | **BEZWAARTERMIJN** | 6:7-6:8 | 6 weeks from day after bekendmaking. |
 | **BEZWAAR_INGEDIEND** | 6:4-6:6 | Belanghebbende files bezwaarschrift with the bestuursorgaan. |
@@ -511,7 +511,7 @@ This is a **parallel track**: the ingebrekestelling can be sent while BEHANDELIN
 
 ### A.4 Beroep Phase (Judicial Review)
 
-| Stage | AWB Articles | Description |
+| Stage | Awb Articles | Description |
 |-------|-------------|-------------|
 | **BEROEPSTERMIJN** | 6:7-6:8 | 6 weeks from day after bekendmaking of besluit op bezwaar. |
 | **BEROEP_INGEDIEND** | 8:1 | Appeal filed with competent bestuursrechter. |
@@ -521,11 +521,11 @@ This is a **parallel track**: the ingebrekestelling can be sent while BEHANDELIN
 
 ### A.5 Hoger Beroep
 
-| Stage | AWB Articles | Description |
+| Stage | Awb Articles | Description |
 |-------|-------------|-------------|
 | **HOGER_BEROEP** | 8:104-8:108 | Appeal to Afdeling bestuursrechtspraak Raad van State, Centrale Raad van Beroep, or College van Beroep voor het Bedrijfsleven (depending on law area). 6 weeks. |
 
-### A.6 Voorlopige Voorziening (AWB 8:81-8:87: Parallel to bezwaar/beroep)
+### A.6 Voorlopige Voorziening (Awb 8:81-8:87: Parallel to bezwaar/beroep)
 
 The voorlopige voorziening is the most important parallel track:
 
@@ -534,7 +534,7 @@ The voorlopige voorziening is the most important parallel track:
 - **Kortsluiting** (8:86): The voorzieningenrechter can, during the voorlopige voorziening hearing, immediately decide the main case (beroep) too. This collapses two parallel tracks into one.
 - **Timing**: If bezwaar is decided before the voorlopige voorziening hearing, the request is converted to one connected to the subsequent beroep (8:81 lid 5).
 
-### A.7 Bestuurlijke Lus (AWB 8:51a-8:51d: Loop within beroep)
+### A.7 Bestuurlijke Lus (Awb 8:51a-8:51d: Loop within beroep)
 
 - During beroep, the court can issue a **tussenuitspraak** (interlocutory judgment) identifying a defect in the decision.
 - The bestuursorgaan gets a deadline to repair the defect (by taking a new or amended decision).
@@ -543,11 +543,11 @@ The voorlopige voorziening is the most important parallel track:
 
 The bestuurlijke lus is a loop within the beroep phase, not a parallel track.
 
-### A.8 Uniforme Openbare Voorbereidingsprocedure (UOV, AWB Afdeling 3.4)
+### A.8 Uniforme Openbare Voorbereidingsprocedure (UOV, Awb Afdeling 3.4)
 
 The UOV applies when a specific law prescribes it, or when the bestuursorgaan voluntarily chooses to apply it (3:10). Common for: environmental permits, spatial planning decisions, complex infrastructure.
 
-| Stage | AWB Articles | Description |
+| Stage | Awb Articles | Description |
 |-------|-------------|-------------|
 | **AANVRAAG** | 4:1 | Same as regular procedure. |
 | **ONTWERP_BESLUIT** | 3:11 | Bestuursorgaan prepares draft decision and makes it available for inspection. |
@@ -569,7 +569,7 @@ A besluit van algemene strekking (e.g., verordening, beleidsregel, ministeriele 
 | **BEKENDMAKING** | 3:42 | Publication in official gazette: Staatscourant (ministeriele regelingen), Staatsblad (wetten/AMvB), gemeenteblad/provincieblad (decentraal). |
 | **INWERKINGTREDING** | Various | Effective date, usually specified in the regulation itself or per KB. |
 
-Key differences from beschikking: no aanvraag (not applied for by belanghebbende), no bezwaar (AWB 8:3 lid 1 sub a excludes bezwaar/beroep against AVVs), no individual bekendmaking (publication in official gazettes), rechtsbescherming only via exceptieve toetsing.
+Key differences from beschikking: no aanvraag (not applied for by belanghebbende), no bezwaar (Awb 8:3 lid 1 sub a excludes bezwaar/beroep against AVVs), no individual bekendmaking (publication in official gazettes), rechtsbescherming only via exceptieve toetsing.
 
 | BAS Sub-type | Bezwaar? | Beroep? | Example |
 |--------------|----------|---------|---------|
@@ -585,63 +585,63 @@ Key differences from beschikking: no aanvraag (not applied for by belanghebbende
 
 ```mermaid
 stateDiagram-v2
-    [*] --> AANVRAAG: Belanghebbende dient aanvraag in<br/>(AWB 4:1)
+    [*] --> AANVRAAG: Belanghebbende dient aanvraag in<br/>(Awb 4:1)
 
-    AANVRAAG --> ONTVANGST: Ontvangstbevestiging<br/>(AWB 4:3a)
-    ONTVANGST --> AANVULLING: Aanvraag onvolledig<br/>(AWB 4:5)
+    AANVRAAG --> ONTVANGST: Ontvangstbevestiging<br/>(Awb 4:3a)
+    ONTVANGST --> AANVULLING: Aanvraag onvolledig<br/>(Awb 4:5)
     AANVULLING --> BEHANDELING: Aangevuld
-    AANVULLING --> BUITEN_BEHANDELING: Niet aangevuld<br/>(AWB 4:5 lid 4)
+    AANVULLING --> BUITEN_BEHANDELING: Niet aangevuld<br/>(Awb 4:5 lid 4)
     ONTVANGST --> BEHANDELING: Aanvraag volledig
 
     BUITEN_BEHANDELING --> [*]
 
     state "Primair besluit" as primair {
-        BEHANDELING --> BESLUIT: Bestuursorgaan beslist<br/>(AWB 1:3)
+        BEHANDELING --> BESLUIT: Bestuursorgaan beslist<br/>(Awb 1:3)
 
         note right of BEHANDELING
-            Beslistermijn loopt (AWB 4:13)
+            Beslistermijn loopt (Awb 4:13)
             Max 8 weken of wettelijke termijn
-            Verlenging mogelijk (AWB 4:14)
-            Opschorting bij aanvulling (AWB 4:15)
-            Horen voor afwijzing (AWB 4:7-4:8)
+            Verlenging mogelijk (Awb 4:14)
+            Opschorting bij aanvulling (Awb 4:15)
+            Horen voor afwijzing (Awb 4:7-4:8)
         end note
     }
 
-    BESLUIT --> BEKENDMAKING: Toezending/uitreiking<br/>(AWB 3:41)
-    BEKENDMAKING --> BEZWAARTERMIJN: Dag na bekendmaking<br/>(AWB 6:8 lid 1)
+    BESLUIT --> BEKENDMAKING: Toezending/uitreiking<br/>(Awb 3:41)
+    BEKENDMAKING --> BEZWAARTERMIJN: Dag na bekendmaking<br/>(Awb 6:8 lid 1)
 
     state "Rechtsbescherming" as rechtsbescherming {
-        BEZWAARTERMIJN --> TERMIJN_VERLOPEN: 6 weken verstreken<br/>(AWB 6:7)
-        BEZWAARTERMIJN --> BEZWAAR_INGEDIEND: Bezwaarschrift ingediend<br/>(AWB 6:4)
+        BEZWAARTERMIJN --> TERMIJN_VERLOPEN: 6 weken verstreken<br/>(Awb 6:7)
+        BEZWAARTERMIJN --> BEZWAAR_INGEDIEND: Bezwaarschrift ingediend<br/>(Awb 6:4)
 
         TERMIJN_VERLOPEN --> ONHERROEPELIJK: Geen bezwaar ingediend
 
         state "Bezwaarprocedure" as bezwaar {
             BEZWAAR_INGEDIEND --> ONTVANKELIJKHEID: Toets ontvankelijkheid
             ONTVANKELIJKHEID --> NIET_ONTVANKELIJK: Niet-ontvankelijk
-            ONTVANKELIJKHEID --> HOREN: Ontvankelijk<br/>(AWB 7:2)
+            ONTVANKELIJKHEID --> HOREN: Ontvankelijk<br/>(Awb 7:2)
             ONTVANKELIJKHEID --> RECHTSTREEKS_BEROEP: Verzoek 7:1a gehonoreerd
-            HOREN --> HEROVERWEGING: Na hoorzitting<br/>(AWB 7:11)
-            HEROVERWEGING --> BESLUIT_OP_BEZWAAR: Heroverweging afgerond<br/>(AWB 7:12)
+            HOREN --> HEROVERWEGING: Na hoorzitting<br/>(Awb 7:11)
+            HEROVERWEGING --> BESLUIT_OP_BEZWAAR: Heroverweging afgerond<br/>(Awb 7:12)
         }
 
         NIET_ONTVANKELIJK --> [*]
-        BESLUIT_OP_BEZWAAR --> BEKENDMAKING_BOB: Toezending<br/>(AWB 3:41)
+        BESLUIT_OP_BEZWAAR --> BEKENDMAKING_BOB: Toezending<br/>(Awb 3:41)
         BEKENDMAKING_BOB --> BEROEPSTERMIJN: Dag na bekendmaking
 
         state "Beroep bij bestuursrechter" as beroep_fase {
-            BEROEPSTERMIJN --> BEROEP_INGEDIEND: Beroepschrift<br/>(AWB 8:1)
+            BEROEPSTERMIJN --> BEROEP_INGEDIEND: Beroepschrift<br/>(Awb 8:1)
             RECHTSTREEKS_BEROEP --> BEROEP_INGEDIEND
-            BEROEP_INGEDIEND --> VOORONDERZOEK: Stukken uitwisseling<br/>(AWB 8:27-8:45)
-            VOORONDERZOEK --> ZITTING: Behandeling ter zitting<br/>(AWB 8:56)
-            ZITTING --> UITSPRAAK: Rechter oordeelt<br/>(AWB 8:66-8:77)
+            BEROEP_INGEDIEND --> VOORONDERZOEK: Stukken uitwisseling<br/>(Awb 8:27-8:45)
+            VOORONDERZOEK --> ZITTING: Behandeling ter zitting<br/>(Awb 8:56)
+            ZITTING --> UITSPRAAK: Rechter oordeelt<br/>(Awb 8:66-8:77)
 
-            VOORONDERZOEK --> BESTUURLIJKE_LUS: Tussenuitspraak<br/>(AWB 8:51a)
+            VOORONDERZOEK --> BESTUURLIJKE_LUS: Tussenuitspraak<br/>(Awb 8:51a)
             BESTUURLIJKE_LUS --> HERSTEL_BESLUIT: Bestuursorgaan herstelt gebrek
             HERSTEL_BESLUIT --> VOORONDERZOEK: Nieuw besluit beoordeeld
         }
 
-        UITSPRAAK --> HOGER_BEROEP: Hoger beroep<br/>(AWB 8:104)
+        UITSPRAAK --> HOGER_BEROEP: Hoger beroep<br/>(Awb 8:104)
         UITSPRAAK --> ONHERROEPELIJK: Geen hoger beroep
         HOGER_BEROEP --> ONHERROEPELIJK: Uitspraak hoger beroep
     }
@@ -663,7 +663,7 @@ stateDiagram-v2
         BEROEP --> UITSPRAAK
     }
 
-    state "Parallel: Dwangsom (AWB 4:17-4:20)" as dwangsom {
+    state "Parallel: Dwangsom (Awb 4:17-4:20)" as dwangsom {
         direction LR
         BESLISTERMIJN_VERSTREKEN --> INGEBREKESTELLING
         INGEBREKESTELLING --> WACHTTIJD_2W: 2 weken wachten
@@ -671,14 +671,14 @@ stateDiagram-v2
         DWANGSOM_LOOPT --> DWANGSOMBESLUIT: Max 42 dagen<br/>of besluit genomen
     }
 
-    state "Parallel: Voorlopige Voorziening (AWB 8:81)" as vovo {
+    state "Parallel: Voorlopige Voorziening (Awb 8:81)" as vovo {
         direction LR
         VERZOEK_VOVO --> BEHANDELING_VOVO
         BEHANDELING_VOVO --> UITSPRAAK_VOVO
-        BEHANDELING_VOVO --> KORTSLUITING: AWB 8:86<br/>Onmiddellijke uitspraak<br/>in hoofdzaak
+        BEHANDELING_VOVO --> KORTSLUITING: Awb 8:86<br/>Onmiddellijke uitspraak<br/>in hoofdzaak
     }
 
-    state "Bestuurlijke Lus (AWB 8:51a)" as lus {
+    state "Bestuurlijke Lus (Awb 8:51a)" as lus {
         direction LR
         TUSSENUITSPRAAK --> HERSTELTERMIJN
         HERSTELTERMIJN --> NIEUW_BESLUIT
@@ -717,13 +717,13 @@ stateDiagram-v2
     AANVRAAG_U --> ONTWERP_BESLUIT: Bestuursorgaan bereidt voor
 
     state "Openbare voorbereiding" as uov {
-        ONTWERP_BESLUIT --> TER_INZAGE: Terinzagelegging<br/>(AWB 3:11)
-        TER_INZAGE --> ZIENSWIJZEN: 6 weken<br/>(AWB 3:16)
+        ONTWERP_BESLUIT --> TER_INZAGE: Terinzagelegging<br/>(Awb 3:11)
+        TER_INZAGE --> ZIENSWIJZEN: 6 weken<br/>(Awb 3:16)
         ZIENSWIJZEN --> VERWERKING: Bestuursorgaan verwerkt<br/>zienswijzen
     }
 
-    VERWERKING --> BESLUIT_U: Definitief besluit<br/>(AWB 3:18)
-    BESLUIT_U --> BEKENDMAKING_U: Publicatie<br/>(AWB 3:41/3:42)
+    VERWERKING --> BESLUIT_U: Definitief besluit<br/>(Awb 3:18)
+    BESLUIT_U --> BEKENDMAKING_U: Publicatie<br/>(Awb 3:41/3:42)
 
     note right of BEKENDMAKING_U
         Bij UOV: GEEN bezwaar (7:1 lid 1 sub d)
@@ -743,7 +743,7 @@ stateDiagram-v2
         VOVO_U --> VOVO_UITSPRAAK_U
     }
 
-    BEROEP_U --> VOVO_U: AWB 8:81
+    BEROEP_U --> VOVO_U: Awb 8:81
 
     UITSPRAAK_U --> ONHERROEPELIJK_U
     ONHERROEPELIJK_U --> [*]
@@ -786,7 +786,7 @@ stateDiagram-v2
     PROVINCIEBLAD --> INWERKINGTREDING
 
     note right of INWERKINGTREDING
-        AVV: geen bezwaar, geen beroep (AWB 8:3)
+        AVV: geen bezwaar, geen beroep (Awb 8:3)
         Concretiserend BAS: direct beroep mogelijk
         Toetsing alleen via exceptieve toetsing
         bij individuele toepassing

--- a/docs/src/content/rfcs/rfc-008.md
+++ b/docs/src/content/rfcs/rfc-008.md
@@ -53,7 +53,7 @@ Both refer to the same thing: the AWB-defined sequence of stages that a decision
 
 ### The lifecycle is law
 
-The AWB defines a **lifecycle** for administrative law (*bestuursrecht*) processes. This lifecycle is expressed in the YAML specification as a first-class construct. Laws do not define their own lifecycles, they declare which AWB-defined lifecycle they participate in through `produces`.
+The AWB defines a **lifecycle** for administrative law (*bestuursrecht*) processes. This lifecycle is expressed in the YAML specification as a first-class construct. Laws do not define their own lifecycles; they declare which AWB-defined lifecycle they participate in through `produces`.
 
 A lifecycle is a sequence of **stages**. Each stage:
 - Has a **name** (e.g., `AANVRAAG`, `BESLUIT`, `BEKENDMAKING`)
@@ -396,7 +396,7 @@ The lifecycle definition distinguishes these: stages with `requires` fields that
 
 **Complexity.** The engine moves from "pure function" to "state machine executor." The orchestration layer must now manage decision (*besluit*) state persistence. This is a lot of implementation work.
 
-**Backwards compatibility.** Existing laws that produce BESCHIKKING without a lifecycle still work, they complete in a single stage. But new laws should use the lifecycle model. [RFC-007](/rfcs/rfc-007) hooks without `stage` default to BESLUIT for backward compatibility.
+**Backward compatibility.** Existing laws that produce BESCHIKKING without a lifecycle still work; they complete in a single stage. But new laws should use the lifecycle model. [RFC-007](/rfcs/rfc-007) hooks without `stage` default to BESLUIT for backward compatibility.
 
 **State management.** Decision (*besluit*) state must be persisted somewhere. The engine doesn't dictate where (database, event store, file system), but the orchestration layer must handle it.
 

--- a/docs/src/content/rfcs/rfc-008.md
+++ b/docs/src/content/rfcs/rfc-008.md
@@ -9,7 +9,7 @@ title: "RFC-008: AWB Administrative Procedures"
 
 ## Context
 
-[RFC-007](/rfcs/rfc-007) introduced hooks: articles that fire when another article's `produces` annotation matches. This enables reactive execution — AWB 3:46 (reasoning requirement, *motiveringsplicht*) fires on any BESCHIKKING, AWB 6:7 (objection period, *bezwaartermijn*) fires on any BESCHIKKING, AWB 6:8 (start/einddatum) fires on any BESCHIKKING.
+[RFC-007](/rfcs/rfc-007) introduced hooks: articles that fire when another article's `produces` annotation matches. This enables reactive execution: AWB 3:46 (reasoning requirement, *motiveringsplicht*) fires on any BESCHIKKING, AWB 6:7 (objection period, *bezwaartermijn*) fires on any BESCHIKKING, AWB 6:8 (start/einddatum) fires on any BESCHIKKING.
 
 But an individual decision (*beschikking*) is not an instant computation. It is an administrative law (*bestuursrecht*) process that progresses through stages over time:
 
@@ -20,19 +20,19 @@ But an individual decision (*beschikking*) is not an instant computation. It is 
 5. The **objection period** (*bezwaartermijn*) starts the day after notification (*bekendmaking*, AWB 6:8 lid 1) and runs for six weeks (AWB 6:7).
 6. The interested party (*belanghebbende*) may file an **objection** (*bezwaar*, AWB 6:4).
 
-If hooks fire without awareness of lifecycle stages, all AWB obligations trigger at once — including AWB 6:8 (objection period date calculation), which needs `bekendmaking_datum`. But notification (*bekendmaking*) hasn't happened yet at decision time. Treating a missing `bekendmaking_datum` as "skip this hook gracefully" is a workaround, not a design.
+If hooks fire without awareness of lifecycle stages, all AWB obligations trigger at once, including AWB 6:8 (objection period date calculation), which needs `bekendmaking_datum`. But notification (*bekendmaking*) hasn't happened yet at decision time. Treating a missing `bekendmaking_datum` as "skip this hook gracefully" is a workaround, not a design.
 
 The problem: **the decision and the notification (*bekendmaking*) are different moments in time, with different inputs, producing different outputs, governed by different articles of law.** They must not fire in the same execution step.
 
 ### Who defines the lifecycle?
 
-The lifecycle of an individual decision (*beschikking*) is not defined by the Vreemdelingenwet or the Zorgtoeslagwet. It is defined by the **Algemene wet bestuursrecht (AWB)** — the General Administrative Law Act. That is the purpose of the AWB: to define the general administrative procedure that all administrative bodies (*bestuursorganen*) follow, regardless of which specific law they are executing.
+The lifecycle of an individual decision (*beschikking*) is not defined by the Vreemdelingenwet or the Zorgtoeslagwet. It is defined by the **Algemene wet bestuursrecht (AWB)**, the General Administrative Law Act. That is the purpose of the AWB: to define the general administrative procedure that all administrative bodies (*bestuursorganen*) follow, regardless of which specific law they are executing.
 
-The AWB defines stages. Specific laws fill in the content at each stage. Other laws (Termijnenwet, KB gelijkgestelde dagen) hook into specific stages. This relationship already exists in law — it needs to be expressed in the schema.
+The AWB defines stages. Specific laws fill in the content at each stage. Other laws (Termijnenwet, KB gelijkgestelde dagen) hook into specific stages. This relationship already exists in law; it needs to be expressed in the schema.
 
 ### Terminology: procedure vs. lifecycle
 
-In AWB terminology, what we describe here is a **procedure** — the objection procedure, the appeal procedure, the preparation procedure. The AWB never uses the word "lifecycle"; that is software engineering jargon.
+In AWB terminology, what we describe here is a **procedure**, the objection procedure, the appeal procedure, the preparation procedure. The AWB never uses the word "lifecycle"; that is software engineering jargon.
 
 However, in the AWB "procedure" typically refers to one phase (the objection (*bezwaar*) procedure, the appeal (*beroep*) procedure). The entire journey from application (*aanvraag*) to final/irrevocable (*onherroepelijk*) spans *multiple* procedures. In engineering, "lifecycle" captures this overarching concept: the full life of a decision (*besluit*) from birth (application) to final state (final/irrevocable (*onherroepelijk*), withdrawn (*ingetrokken*), or expired).
 
@@ -53,7 +53,7 @@ Both refer to the same thing: the AWB-defined sequence of stages that a decision
 
 ### The lifecycle is law
 
-The AWB defines a **lifecycle** for administrative law (*bestuursrecht*) processes. This lifecycle is expressed in the YAML specification as a first-class construct. Laws do not define their own lifecycles — they declare which AWB-defined lifecycle they participate in through `produces`.
+The AWB defines a **lifecycle** for administrative law (*bestuursrecht*) processes. This lifecycle is expressed in the YAML specification as a first-class construct. Laws do not define their own lifecycles, they declare which AWB-defined lifecycle they participate in through `produces`.
 
 A lifecycle is a sequence of **stages**. Each stage:
 - Has a **name** (e.g., `AANVRAAG`, `BESLUIT`, `BEKENDMAKING`)
@@ -63,7 +63,7 @@ A lifecycle is a sequence of **stages**. Each stage:
 
 ### Procedure selection
 
-A single `legal_character` can have multiple procedure variants. Both a regular individual decision (*beschikking*) and a UOV (public consultation procedure) individual decision (*beschikking*) have `legal_character: BESCHIKKING`, but they follow different AWB procedures — the UOV omits objection (*bezwaar*) entirely (AWB 7:1 lid 1 sub d). Selecting the wrong procedure produces a legally invalid outcome.
+A single `legal_character` can have multiple procedure variants. Both a regular individual decision (*beschikking*) and a UOV (public consultation procedure) individual decision (*beschikking*) have `legal_character: BESCHIKKING`, but they follow different AWB procedures: the UOV omits objection (*bezwaar*) entirely (AWB 7:1 lid 1 sub d). Selecting the wrong procedure produces a legally invalid outcome.
 
 The `produces` annotation gains an optional `procedure_id` field to disambiguate:
 
@@ -291,7 +291,7 @@ This is the key insight: **hooks apply to the AWB's lifecycle, not to the specif
 
 ### The besluit as state container
 
-A **decision** (*besluit*) progresses through the AWB lifecycle and accumulates outputs at each stage. The decision (*besluit*) itself is the state container — there is no separate "case" or "zaak" (case file) abstraction. This follows the AWB, which defines everything in terms of the decision (*besluit*).
+A **decision** (*besluit*) progresses through the AWB lifecycle and accumulates outputs at each stage. The decision (*besluit*) itself is the state container; there is no separate "case" or "zaak" (case file) abstraction. This follows the AWB, which defines everything in terms of the decision (*besluit*).
 
 ```
 Besluit {
@@ -338,7 +338,7 @@ Output: { bezwaartermijn_startdatum: "2026-03-24",
 Yields: "BEZWAAR stage — bezwaartermijn running until 2026-04-20"
 ```
 
-`bekendmaking_datum` is a genuine external event (the orchestration layer signals that notification (*bekendmaking*) has occurred). `pasen_datum` is also an external parameter — the computus algorithm is not in Dutch statute law, so the caller provides Easter Sunday's date, consistent with the zero-domain-knowledge principle ([RFC-007](/rfcs/rfc-007)). Gelijkgestelde dagen (bridge days equated to public holidays) are resolved internally via IoC from harvested KB's.
+`bekendmaking_datum` is a genuine external event (the orchestration layer signals that notification (*bekendmaking*) has occurred). `pasen_datum` is also an external parameter, the computus algorithm is not in Dutch statute law, so the caller provides Easter Sunday's date, consistent with the zero-domain-knowledge principle ([RFC-007](/rfcs/rfc-007)). Gelijkgestelde dagen (bridge days equated to public holidays) are resolved internally via IoC from harvested KB's.
 
 The engine **yields** between stages, returning:
 - What it computed so far (accumulated outputs)
@@ -396,7 +396,7 @@ The lifecycle definition distinguishes these: stages with `requires` fields that
 
 **Complexity.** The engine moves from "pure function" to "state machine executor." The orchestration layer must now manage decision (*besluit*) state persistence. This is a lot of implementation work.
 
-**Backwards compatibility.** Existing laws that produce BESCHIKKING without a lifecycle still work — they complete in a single stage. But new laws should use the lifecycle model. [RFC-007](/rfcs/rfc-007) hooks without `stage` default to BESLUIT for backward compatibility.
+**Backwards compatibility.** Existing laws that produce BESCHIKKING without a lifecycle still work, they complete in a single stage. But new laws should use the lifecycle model. [RFC-007](/rfcs/rfc-007) hooks without `stage` default to BESLUIT for backward compatibility.
 
 **State management.** Decision (*besluit*) state must be persisted somewhere. The engine doesn't dictate where (database, event store, file system), but the orchestration layer must handle it.
 
@@ -404,7 +404,7 @@ The lifecycle definition distinguishes these: stages with `requires` fields that
 
 **Alternative 1: Implicit stages via parameter presence**
 - AWB 6:8 hooks on BESCHIKKING and skips when `bekendmaking_datum` is absent.
-- Rejected: uses parameter absence as control flow. Semantically wrong — the hook doesn't "fail to fire," it fires at the wrong time. Silently skipping hooks hides the lifecycle.
+- Rejected: uses parameter absence as control flow. Semantically wrong, the hook doesn't "fail to fire," it fires at the wrong time. Silently skipping hooks hides the lifecycle.
 
 **Alternative 2: Multiple explicit executions (no lifecycle)**
 - Caller invokes the decision law first, then separately invokes AWB 6:8 with the results plus `bekendmaking_datum`.
@@ -428,33 +428,33 @@ The decision (*besluit*) state is *not* stored in the engine. It is passed in by
 
 **Schema version:** The `procedure:` top-level key and the `procedure_id` field on `produces` are new constructs not present in schema v0.4.0. They land in **schema v0.5.0** (see the [Schema Reference](/reference/schema#version-history) version history), alongside the hooks and overrides from [RFC-007](/rfcs/rfc-007). AWB YAML files using `procedure:` must reference v0.5.0 or later.
 
-**Yield mechanism.** The largest architectural change is the yield mechanism. The current engine returns `Result<ArticleResult>` — a terminal result. Multi-stage execution needs the engine to return either a completed result or a "yielded" state waiting for input to proceed to the next stage. Two implementation approaches:
+**Yield mechanism.** The largest architectural change is the yield mechanism. The current engine returns `Result<ArticleResult>`, a terminal result. Multi-stage execution needs the engine to return either a completed result or a "yielded" state waiting for input to proceed to the next stage. Two implementation approaches:
 
-1. **New return type**: `enum ExecutionOutcome { Complete(ArticleResult), Yielded(StageState) }` — replaces `Result<ArticleResult>` at the stage execution boundary. `StageState` carries accumulated outputs, current stage, and required inputs for the next stage.
+1. **New return type**: `enum ExecutionOutcome { Complete(ArticleResult), Yielded(StageState) }`, replaces `Result<ArticleResult>` at the stage execution boundary. `StageState` carries accumulated outputs, current stage, and required inputs for the next stage.
 2. **Separate method**: add `execute_stage` alongside the existing `evaluate_article_with_service`. The existing method remains unchanged for single-stage laws; `execute_stage` handles lifecycle-aware execution.
 
-Decision (*besluit*) state is external (passed in, returned out), which is compatible with the stateless engine design. The engine uses `&self` (immutable borrows) for execution, so there is no architectural conflict with multi-stage execution — each invocation is still a pure function over its inputs.
+Decision (*besluit*) state is external (passed in, returned out), which is compatible with the stateless engine design. The engine uses `&self` (immutable borrows) for execution, so there is no architectural conflict with multi-stage execution, each invocation is still a pure function over its inputs.
 
 **Nested lifecycle recursion.** A decision on objection (*besluit op bezwaar*) is itself a decision (*besluit*), creating recursive nesting. The engine's cycle detection (`ResolutionContext.visited`) operates within a single invocation; cross-invocation nesting is the orchestration layer's responsibility. The engine should provide a `max_nesting_depth` configuration to help the orchestration layer detect excessive recursion. In practice the AWB chain is naturally finite (individual decision (*beschikking*), decision on objection (*besluit op bezwaar*), appeal (*beroep*), higher appeal (*hoger beroep*)), but a configurable depth limit provides a safety net.
 
 ## Open Questions
 
-1. ~~**Do all decisions (*besluiten*) share the same lifecycle?**~~ **Resolved:** No. Each legal_character has its own lifecycle, defined by the relevant AWB chapters. A BESCHIKKING has application (*aanvraag*) → processing (*behandeling*) → decision (*besluit*) → notification (*bekendmaking*) → objection (*bezwaar*). A BESLUIT_VAN_ALGEMENE_STREKKING (general rule, *besluit van algemene strekking*) has a different procedure (AWB afdeling 3.4, Staatscourant publication, no objection (*bezwaar*), direct appeal (*beroep*)). The AWB defines these different procedures — the lifecycle definition in YAML follows the AWB structure per type.
+1. ~~**Do all decisions (*besluiten*) share the same lifecycle?**~~ **Resolved:** No. Each legal_character has its own lifecycle, defined by the relevant AWB chapters. A BESCHIKKING has application (*aanvraag*) → processing (*behandeling*) → decision (*besluit*) → notification (*bekendmaking*) → objection (*bezwaar*). A BESLUIT_VAN_ALGEMENE_STREKKING (general rule, *besluit van algemene strekking*) has a different procedure (AWB afdeling 3.4, Staatscourant publication, no objection (*bezwaar*), direct appeal (*beroep*)). The AWB defines these different procedures, the lifecycle definition in YAML follows the AWB structure per type.
 
-2. ~~**Nested lifecycles.**~~ **Resolved:** An objection (*bezwaar*) is itself a decision (*besluit*, AWB 7:12), which starts its own lifecycle (with its own notification (*bekendmaking*), and possibility of appeal (*beroep*) before the administrative court (*bestuursrechter*)). The engine applies the same lifecycle pattern recursively — a decision on objection (*besluit op bezwaar*) enters the AWB lifecycle just like the original individual decision (*beschikking*). If a law inadvertently creates infinite recursion, that is a defect in the law, not in the engine.
+2. ~~**Nested lifecycles.**~~ **Resolved:** An objection (*bezwaar*) is itself a decision (*besluit*, AWB 7:12), which starts its own lifecycle (with its own notification (*bekendmaking*), and possibility of appeal (*beroep*) before the administrative court (*bestuursrechter*)). The engine applies the same lifecycle pattern recursively, a decision on objection (*besluit op bezwaar*) enters the AWB lifecycle just like the original individual decision (*beschikking*). If a law inadvertently creates infinite recursion, that is a defect in the law, not in the engine.
 
    Note that [RFC-007](/rfcs/rfc-007)'s cycle detection does **not** cover this case. [RFC-007](/rfcs/rfc-007) detects cross-law circular references within a single engine invocation (Law A → Law B → Law A). Nested lifecycle recursion (individual decision (*beschikking*) → decision on objection (*besluit op bezwaar*) → its own objection (*bezwaar*) → ...) happens across separate engine invocations initiated by the orchestration layer. The **orchestration layer** is responsible for detecting excessive lifecycle nesting depth, not the engine. In the AWB this chain is naturally finite (individual decision (*beschikking*) → decision on objection (*besluit op bezwaar*) → appeal (*beroep*) → higher appeal (*hoger beroep*) terminates), but the orchestration layer should enforce a configurable maximum nesting depth as a safety measure.
 
-3. ~~**Parallel stages.**~~ **Resolved:** The main lifecycle track (application (*aanvraag*) → processing (*behandeling*) → decision (*besluit*) → notification (*bekendmaking*) → objection (*bezwaar*) → appeal (*beroep*)) is strictly sequential — each stage depends on completion of the previous one. However, three genuinely parallel tracks can be spawned from the main lifecycle:
+3. ~~**Parallel stages.**~~ **Resolved:** The main lifecycle track (application (*aanvraag*) → processing (*behandeling*) → decision (*besluit*) → notification (*bekendmaking*) → objection (*bezwaar*) → appeal (*beroep*)) is strictly sequential, each stage depends on completion of the previous one. However, three genuinely parallel tracks can be spawned from the main lifecycle:
    - **Penalty payment for late decision (*dwangsom bij niet-tijdig beslissen*, AWB 4:17-4:20)**: activates when the decision deadline (*beslistermijn*) expires without a decision (*besluit*). Runs parallel to the ongoing processing (*behandeling*) phase. The penalty payment decision (*dwangsombesluit*) is itself an individual decision (*beschikking*) with its own lifecycle.
    - **Interim relief (*voorlopige voorziening*, AWB 8:81-8:87)**: activates after objection (*bezwaar*) or appeal (*beroep*) is filed. Runs parallel to the objection (*bezwaar*)/appeal (*beroep*) procedure. Can collapse into the main track via short-circuit ruling (*kortsluiting*, AWB 8:86) where the interim relief judge (*voorzieningenrechter*) immediately decides the main case.
    - **Amendment decision (*wijzigingsbesluit*) pending objection (*bezwaar*)/appeal (*beroep*) (AWB 6:19)**: if the administrative body (*bestuursorgaan*) takes a new decision (*besluit*) while objection (*bezwaar*)/appeal (*beroep*) is pending, it is incorporated into the existing procedure.
 
-   Additionally, two alternative paths exist as branches (not parallelism): direct appeal (*rechtstreeks beroep*, AWB 7:1a, skipping objection (*bezwaar*)) and the uniforme openbare voorbereidingsprocedure (AWB afdeling 3.4, replacing regular preparation with public consultation and eliminating objection (*bezwaar*)). The administrative repair loop (*bestuurlijke lus*, AWB 8:51a-8:51d) is a loop within appeal (*beroep*), not a parallel track — the administrative court (*bestuursrechter*) suspends appeal (*beroep*), the administrative body (*bestuursorgaan*) repairs the defect, then appeal (*beroep*) resumes. See Appendix A for the full procedure analysis and Appendix B for Mermaid state diagrams.
+   Additionally, two alternative paths exist as branches (not parallelism): direct appeal (*rechtstreeks beroep*, AWB 7:1a, skipping objection (*bezwaar*)) and the uniforme openbare voorbereidingsprocedure (AWB afdeling 3.4, replacing regular preparation with public consultation and eliminating objection (*bezwaar*)). The administrative repair loop (*bestuurlijke lus*, AWB 8:51a-8:51d) is a loop within appeal (*beroep*), not a parallel track, the administrative court (*bestuursrechter*) suspends appeal (*beroep*), the administrative body (*bestuursorgaan*) repairs the defect, then appeal (*beroep*) resumes. See Appendix A for the full procedure analysis and Appendix B for Mermaid state diagrams.
 
-4. ~~**Decision deadline (*beslistermijn*) enforcement.**~~ **Resolved:** The decision deadline (*beslistermijn*) is calculated by a hook at the AANVRAAG stage — AWB 4:13 provides the default ("redelijke termijn"), specific laws override via lex specialis (same pattern as bezwaartermijn_weken). The engine does **not** enforce the deadline: if besluit_datum exceeds the decision deadline (*beslistermijn*), the engine continues normally but annotates the decision (*besluit*) with a warning. Exceeding the decision deadline (*beslistermijn*) does not invalidate the decision (*besluit*) — it **expands the lifecycle** with new available paths for the interested party (*belanghebbende*): notice of default (*ingebrekestelling*, AWB 4:17), penalty payment (*dwangsom*, AWB 4:18), and appeal (*beroep*) against failure to decide in time (AWB 6:2 lid 1 sub b). These are modeled as conditional branches in the lifecycle state machine.
+4. ~~**Decision deadline (*beslistermijn*) enforcement.**~~ **Resolved:** The decision deadline (*beslistermijn*) is calculated by a hook at the AANVRAAG stage, AWB 4:13 provides the default ("redelijke termijn"), specific laws override via lex specialis (same pattern as bezwaartermijn_weken). The engine does **not** enforce the deadline: if besluit_datum exceeds the decision deadline (*beslistermijn*), the engine continues normally but annotates the decision (*besluit*) with a warning. Exceeding the decision deadline (*beslistermijn*) does not invalidate the decision (*besluit*), it **expands the lifecycle** with new available paths for the interested party (*belanghebbende*): notice of default (*ingebrekestelling*, AWB 4:17), penalty payment (*dwangsom*, AWB 4:18), and appeal (*beroep*) against failure to decide in time (AWB 6:2 lid 1 sub b). These are modeled as conditional branches in the lifecycle state machine.
 
-5. ~~**Withdrawal (*intrekking*) and revocation.**~~ **Resolved:** Withdrawal (*intrekking*, AWB 10:4-10:5) is a state transition in the original decision (*besluit*)'s lifecycle, not a separate lifecycle. An individual decision (*beschikking*) continues to exist after notification (*bekendmaking*) — it can be final/irrevocable (*onherroepelijk*), withdrawn (*ingetrokken*), amended, or expired. The withdrawal (*intrekking*) itself is a nested decision (*besluit*, same pattern as question 2): it requires motivation, notification (*bekendmaking*), and can be challenged via objection (*bezwaar*). The original individual decision (*beschikking*)'s state changes as a consequence of the withdrawal (*intrekking*) decision completing its own lifecycle.
+5. ~~**Withdrawal (*intrekking*) and revocation.**~~ **Resolved:** Withdrawal (*intrekking*, AWB 10:4-10:5) is a state transition in the original decision (*besluit*)'s lifecycle, not a separate lifecycle. An individual decision (*beschikking*) continues to exist after notification (*bekendmaking*), it can be final/irrevocable (*onherroepelijk*), withdrawn (*ingetrokken*), amended, or expired. The withdrawal (*intrekking*) itself is a nested decision (*besluit*, same pattern as question 2): it requires motivation, notification (*bekendmaking*), and can be challenged via objection (*bezwaar*). The original individual decision (*beschikking*)'s state changes as a consequence of the withdrawal (*intrekking*) decision completing its own lifecycle.
 
 ## References
 
@@ -525,7 +525,7 @@ This is a **parallel track**: the ingebrekestelling can be sent while BEHANDELIN
 |-------|-------------|-------------|
 | **HOGER_BEROEP** | 8:104-8:108 | Appeal to Afdeling bestuursrechtspraak Raad van State, Centrale Raad van Beroep, or College van Beroep voor het Bedrijfsleven (depending on law area). 6 weeks. |
 
-### A.6 Voorlopige Voorziening (AWB 8:81-8:87 — Parallel to bezwaar/beroep)
+### A.6 Voorlopige Voorziening (AWB 8:81-8:87: Parallel to bezwaar/beroep)
 
 The voorlopige voorziening is the most important parallel track:
 
@@ -534,7 +534,7 @@ The voorlopige voorziening is the most important parallel track:
 - **Kortsluiting** (8:86): The voorzieningenrechter can, during the voorlopige voorziening hearing, immediately decide the main case (beroep) too. This collapses two parallel tracks into one.
 - **Timing**: If bezwaar is decided before the voorlopige voorziening hearing, the request is converted to one connected to the subsequent beroep (8:81 lid 5).
 
-### A.7 Bestuurlijke Lus (AWB 8:51a-8:51d — Loop within beroep)
+### A.7 Bestuurlijke Lus (AWB 8:51a-8:51d: Loop within beroep)
 
 - During beroep, the court can issue a **tussenuitspraak** (interlocutory judgment) identifying a defect in the decision.
 - The bestuursorgaan gets a deadline to repair the defect (by taking a new or amended decision).

--- a/docs/src/content/rfcs/rfc-009.md
+++ b/docs/src/content/rfcs/rfc-009.md
@@ -1,5 +1,5 @@
 ---
-title: "RFC-009: Multi-Organisation Execution"
+title: "RFC-009: Multi-Organization Execution"
 ---
 
 **Status:** Proposed
@@ -9,13 +9,13 @@ title: "RFC-009: Multi-Organisation Execution"
 
 ## Context
 
-Prior to this RFC, the engine has no concept of organisational boundaries at execution time; it loads all laws and executes everything in-process. [RFC-010](/rfcs/rfc-010) (Federated Corpus) addresses *where laws come from* but not *who executes what*.
+Prior to this RFC, the engine has no concept of organizational boundaries at execution time; it loads all laws and executes everything in-process. [RFC-010](/rfcs/rfc-010) (Federated Corpus) addresses *where laws come from* but not *who executes what*.
 
-In reality, Dutch law assigns specific computations to specific organisations. The Healthcare Allowance Act (*Wet op de zorgtoeslag*) assigns execution to Allowances Service (*Dienst Toeslagen*). The Participation Act (*Participatiewet*) assigns execution to the municipality (*gemeente*). The tax inspector (*inspecteur*) alone determines the assessed income (*toetsingsinkomen*). When one law references another law's output, the question is: does the executing organisation compute that value itself, or does it accept another organisation's individual decision (*beschikking*)?
+In reality, Dutch law assigns specific computations to specific organizations. The Healthcare Allowance Act (*Wet op de zorgtoeslag*) assigns execution to Allowances Service (*Dienst Toeslagen*). The Participation Act (*Participatiewet*) assigns execution to the municipality (*gemeente*). The tax inspector (*inspecteur*) alone determines the assessed income (*toetsingsinkomen*). When one law references another law's output, the question is: does the executing organization compute that value itself, or does it accept another organization's individual decision (*beschikking*)?
 
 ### The legal key: individual decisions (*beschikkingen*) vs calculations (*berekeningen*)
 
-The General Administrative Law Act (*AWB*) art. 1:3 defines a **decision** (*besluit*) as a written decision by an administrative body (*bestuursorgaan*) containing a public-law legal act. An **individual decision** (*beschikking*) is a decision that is not of general scope — directed at a specific person or case. Only a competent authority (*bevoegd gezag*) can issue an individual decision (*beschikking*), and other organisations are legally bound by it.
+The General Administrative Law Act (*AWB*) art. 1:3 defines a **decision** (*besluit*) as a written decision by an administrative body (*bestuursorgaan*) containing a public-law legal act. An **individual decision** (*beschikking*) is a decision that is not of general scope — directed at a specific person or case. Only a competent authority (*bevoegd gezag*) can issue an individual decision (*beschikking*), and other organizations are legally bound by it.
 
 A **calculation** (*berekening*), such as applying a formula, evaluating a definition, or computing an intermediate value, is not a decision (*besluit*). It has no independent legal force. Anyone with the rules and data can perform it.
 
@@ -28,23 +28,23 @@ When an article produces a `BESCHIKKING` and declares a `competent_authority`, o
 
 ### Problems with inter-org execution prior to this RFC
 
-Without this RFC, organisations exchange semi-finished products through registries like the Income Registry (*Basisregistratie Inkomen*, BRI) and infrastructure like Suwinet. This model has well-documented problems:
+Without this RFC, organizations exchange semi-finished products through registries like the Income Registry (*Basisregistratie Inkomen*, BRI) and infrastructure like Suwinet. This model has well-documented problems:
 
 - **Staleness**: allowances (*toeslagen*) are granted on estimated income; definitive calculations follow 1–2 years later, causing massive recovery orders (*terugvorderingen*)
-- **Error propagation**: errors in one organisation's individual decision (*beschikking*) cascade to all downstream decisions (Algemene Rekenkamer, "Grip op Gegevens", 2019)
+- **Error propagation**: errors in one organization's individual decision (*beschikking*) cascade to all downstream decisions (Algemene Rekenkamer, "Grip op Gegevens", 2019)
 - **Opacity**: citizens cannot see or understand the chain of decisions that led to their individual decision (*beschikking*)
-- **Diffuse responsibility**: when multiple organisations contribute to a decision chain, accountability is unclear (POK report "Ongekend Onrecht", 2020)
-- **No verifiability**: consuming organisations receive a number but cannot verify how it was computed
+- **Diffuse responsibility**: when multiple organizations contribute to a decision chain, accountability is unclear (POK report "Ongekend Onrecht", 2020)
+- **No verifiability**: consuming organizations receive a number but cannot verify how it was computed
 
 ### Design principles
 
 1. **The law defines the boundaries.** The engine does not invent execution boundaries. It reads `competent_authority` from the law YAML and derives who must execute what.
 
-2. **Identity determines behaviour.** The engine knows which organisation it represents. When it encounters a cross-law reference to an article that produces an individual decision (*beschikking*) with a different `competent_authority`, it accepts rather than executes. Articles that produce definitions or calculations are always executed locally, regardless of which regulation they belong to.
+2. **Identity determines behavior.** The engine knows which organization it represents. When it encounters a cross-law reference to an article that produces an individual decision (*beschikking*) with a different `competent_authority`, it accepts rather than executes. Articles that produce definitions or calculations are always executed locally, regardless of which regulation they belong to.
 
 3. **Everyone can simulate.** The competent-authority boundary only applies to authoritative (*voor-recht-geldende*) execution. Anyone can run the full chain locally for analysis, policy exploration, or scenario testing. The difference is in the legal status of the output; the engine's capability is the same either way.
 
-4. **Transparency by default.** Every execution produces a trace showing which values were computed locally and which were accepted from other organisations, enabling end-to-end auditability across organisational boundaries.
+4. **Transparency by default.** Every execution produces a trace showing which values were computed locally and which were accepted from other organizations, enabling end-to-end auditability across organizational boundaries.
 
 ## Decision
 
@@ -52,9 +52,9 @@ Without this RFC, organisations exchange semi-finished products through registri
 
 When the engine resolves a cross-law reference, it operates in one of two modes:
 
-- **Execute**: load the rules, run them locally, produce the value. Used when the executing organisation is competent, or when no specific competent authority is declared (pure definitions and calculations (*berekeningen*)).
+- **Execute**: load the rules, run them locally, produce the value. Used when the executing organization is competent, or when no specific competent authority is declared (pure definitions and calculations (*berekeningen*)).
 
-- **Accept**: take another organisation's authoritative determination as input. Used when another organisation is the declared competent authority for that output.
+- **Accept**: take another organization's authoritative determination as input. Used when another organization is the declared competent authority for that output.
 
 The mode is **not declared in the YAML**. It is derived at runtime from three things:
 
@@ -111,7 +111,7 @@ The engine has two independent dimensions, selectable at startup:
 **Connectivity: Solo or Federated**
 
 - **Solo**: the engine executes everything locally. No inter-org calls. When it encounters an article with another org's `competent_authority`, it executes the rules locally anyway (simulation) or errors if it cannot (authoritative without the required dependency).
-- **Federated**: the engine calls other organisations' engines via FSC when it encounters an article with another org's `competent_authority`. If the other engine is unreachable, the engine errors instead of silently falling back to local execution.
+- **Federated**: the engine calls other organizations' engines via FSC when it encounters an article with another org's `competent_authority`. If the other engine is unreachable, the engine errors instead of silently falling back to local execution.
 
 **Legal status: Simulation or Authoritative**
 
@@ -127,15 +127,15 @@ These combine into four modes:
 
 **Solo simulation** is the default. It is the mode used for citizen-facing scenario tools, policy analysis, and development.
 
-**Federated authoritative** is the production mode. The engine identifies as a specific organisation, executes its own competence, accepts individual decisions (*beschikkingen*) from other competent authorities, and signs its outputs.
+**Federated authoritative** is the production mode. The engine identifies as a specific organization, executes its own competence, accepts individual decisions (*beschikkingen*) from other competent authorities, and signs its outputs.
 
-**Solo authoritative** is for organisations executing laws that have no cross-org dependencies — the entire computation is within their own competence. The engine signs its outputs but makes no external calls.
+**Solo authoritative** is for organizations executing laws that have no cross-org dependencies — the entire computation is within their own competence. The engine signs its outputs but makes no external calls.
 
 **Federated simulation** is for integration testing. The engine has an identity and makes real calls to other engines (which may run with fake identities in a demo setup), but outputs are not authoritative. This tests the full inter-org chain without producing legally binding results.
 
 ### 4. Service discovery: how engines find each other
 
-In federated mode (both simulation and authoritative), the engine needs to know where to reach other organisations' engines (or registries). This RFC adopts **Federated Service Connectivity (FSC)** as the connectivity standard.
+In federated mode (both simulation and authoritative), the engine needs to know where to reach other organizations' engines (or registries). This RFC adopts **Federated Service Connectivity (FSC)** as the connectivity standard.
 
 #### Why FSC
 
@@ -145,7 +145,7 @@ FSC is not Dutch-specific. Its core concepts are generic:
 
 | FSC concept | What it does | RegelRecht use |
 |---|---|---|
-| **Peer** | An organisation that provides and/or consumes services | Each org running a RegelRecht engine is a Peer |
+| **Peer** | An organization that provides and/or consumes services | Each org running a RegelRecht engine is a Peer |
 | **Group** | A set of Peers that share a Trust Anchor | All RegelRecht-participating orgs form a Group |
 | **Directory** | Central service discovery point for a Group | Engines register their law evaluation API; consuming engines discover competent authorities (*bevoegde gezagen*) |
 | **Contract** | Signed agreement between Peers defining allowed interactions | Encodes which org may request which outputs — derived from the legal basis in the law |
@@ -154,7 +154,7 @@ FSC is not Dutch-specific. Its core concepts are generic:
 
 FSC provides exactly what multi-org law execution needs:
 
-1. **Service discovery**: organisations register their RegelRecht engine endpoints in the Directory. The `competent_authority` name in the law YAML maps to a Peer in the Directory, which maps to an endpoint.
+1. **Service discovery**: organizations register their RegelRecht engine endpoints in the Directory. The `competent_authority` name in the law YAML maps to a Peer in the Directory, which maps to an endpoint.
 2. **Contract-based connectivity**: Peers negotiate Contracts with Grants to establish that they may call each other's services. Authentication as a verified government org is sufficient basis for a Grant.
 3. **Mutual authentication**: x.509 certificates signed by the Group's Trust Anchor, mTLS on all connections.
 4. **Audit trail**: contract signatures and connection logging provide a verifiable record of inter-org interactions.
@@ -191,7 +191,7 @@ The consuming engine doesn't know or care whether the providing endpoint runs a 
 
 ### 5. Inter-engine protocol
 
-When an engine in authoritative mode needs to accept a value, it calls the competent organisation's endpoint:
+When an engine in authoritative mode needs to accept a value, it calls the competent organization's endpoint:
 
 **Request:**
 ```json
@@ -246,12 +246,12 @@ The **signature** is what makes the output authoritative. In simulation mode, th
 A RegelRecht engine in production:
 1. Has a certificate signed by the Group's Trust Anchor
 2. Registers its law evaluation API in the FSC Directory
-3. Establishes FSC Contracts with organisations it needs to call (and that need to call it)
+3. Establishes FSC Contracts with organizations it needs to call (and that need to call it)
 4. Uses mTLS on all inter-engine communication
 
 For development: self-signed certificates and the local `service-registry.yaml` replace the FSC Directory.
 
-**Connectivity**: FSC Contracts with Grants establish which organisations may connect to each other's engines. Authentication as a verified government organisation is sufficient basis for a Grant — FSC handles the "can org A talk to org B" question.
+**Connectivity**: FSC Contracts with Grants establish which organizations may connect to each other's engines. Authentication as a verified government organization is sufficient basis for a Grant — FSC handles the "can org A talk to org B" question.
 
 **Request-level authorization** — whether org A may request specific data about a specific citizen — is a separate concern that operates at a different layer. This is out of scope for this RFC and will be addressed in a future RFC.
 
@@ -399,15 +399,15 @@ graph TB
 
 #### Traces stay with the executing org
 
-Each organisation's engine produces its own trace for the computation it performs. Traces are **not shared** between organisations. When engine A accepts a value from engine B, engine A's trace records the accepted value and a reference — not engine B's internal computation. This is privacy by design: engine B's trace may contain data about the citizen that engine A has no legal basis to see.
+Each organization's engine produces its own trace for the computation it performs. Traces are **not shared** between organizations. When engine A accepts a value from engine B, engine A's trace records the accepted value and a reference — not engine B's internal computation. This is privacy by design: engine B's trace may contain data about the citizen that engine A has no legal basis to see.
 
-This principle aligns with the [Logboek Dataverwerkingen](https://logius-standaarden.github.io/logboek-dataverwerkingen/) standard: each organisation logs its own data processing, logs are not exchanged between organisations, and the citizen can request their logs from each org independently.
+This principle aligns with the [Logboek Dataverwerkingen](https://logius-standaarden.github.io/logboek-dataverwerkingen/) standard: each organization logs its own data processing, logs are not exchanged between organizations, and the citizen can request their logs from each org independently.
 
 #### How cross-org boundaries appear in traces
 
 The existing trace uses `PathNodeType` to identify what each trace node represents. Cross-law calls use `CrossLawReference`, IoC resolution uses `OpenTermResolution`. For cross-org boundaries, a new node type is introduced:
 
-- **`AuthorityCall`** — the engine needs a value that is another organisation's competence (*bevoegdheid*)
+- **`AuthorityCall`** — the engine needs a value that is another organization's competence (*bevoegdheid*)
 
 This follows the same parent-child pattern as `CrossLawReference` and `OpenTermResolution`: the parent node explains what is happening, the child node holds the result.
 
@@ -436,13 +436,13 @@ The `AuthorityCall` node:
 - Has a message explaining **why** this is not computed locally (it's another org's competence)
 - Has a child `Resolve` node with the result, the authority that produced it, the signature status, and a **reference** identifier
 
-The **reference** is a `trace_id` following the [W3C Trace Context](https://www.w3.org/TR/trace-context/) standard, as prescribed by the Logboek Dataverwerkingen standard. When engine A calls engine B via FSC, the `trace_id` propagates across the organisational boundary. Both orgs log their side of the interaction using the same `trace_id`, but neither shares its log entries with the other.
+The **reference** is a `trace_id` following the [W3C Trace Context](https://www.w3.org/TR/trace-context/) standard, as prescribed by the Logboek Dataverwerkingen standard. When engine A calls engine B via FSC, the `trace_id` propagates across the organizational boundary. Both orgs log their side of the interaction using the same `trace_id`, but neither shares its log entries with the other.
 
 The providing org does not share its trace — it stores it in its own Logboek Dataverwerkingen.
 
 #### Citizen access to traces
 
-The citizen (interested party (*belanghebbende*)) can request their trace from each organisation that contributed to their decision, using their right of access (*inzagerecht*, AVG art. 15):
+The citizen (interested party (*belanghebbende*)) can request their trace from each organization that contributed to their decision, using their right of access (*inzagerecht*, AVG art. 15):
 
 1. From Allowances Service (*Dienst Toeslagen*): the full healthcare allowance (*zorgtoeslag*) trace, including the `AuthorityCall` nodes with `trace_id` references
 2. From the Tax Authority (*Belastingdienst*): the log entries for the same `trace_id`, showing how the assessed income (*toetsingsinkomen*) was determined
@@ -470,18 +470,18 @@ The `AuthorityCall` node is still present (so org boundaries are visible) but in
 In **solo simulation** (the default), the engine ignores `competent_authority` entirely. It loads all laws and executes everything locally. This is:
 
 - **The default** — nothing changes for existing users
-- **The citizen's view** — a citizen running the engine in their browser (WASM) can explore the entire chain: "what if my income were X, what would my healthcare allowance (*zorgtoeslag*) be?" They execute everything including the assessed income (*toetsingsinkomen*) calculation. The output is non-authoritative but fully transparent. A future extension (out of scope for this RFC) could allow the engine to fetch the citizen's real data from organisations on behalf of the citizen, using the citizen's own identity.
-- **Policy analysis** — a policy maker can change a rule and see the downstream effects across the entire chain, regardless of organisational boundaries.
+- **The citizen's view** — a citizen running the engine in their browser (WASM) can explore the entire chain: "what if my income were X, what would my healthcare allowance (*zorgtoeslag*) be?" They execute everything including the assessed income (*toetsingsinkomen*) calculation. The output is non-authoritative but fully transparent. A future extension (out of scope for this RFC) could allow the engine to fetch the citizen's real data from organizations on behalf of the citizen, using the citizen's own identity.
+- **Policy analysis** — a policy maker can change a rule and see the downstream effects across the entire chain, regardless of organizational boundaries.
 
 In **federated simulation**, the engine has an identity and makes real calls to other engines via FSC, but outputs are non-authoritative. This is for integration testing: the full inter-org chain is exercised, including service discovery, authentication, and the inter-engine protocol. If a called engine is unreachable, this is an error; there is no silent fallback to local execution. Demo setups use self-signed identities.
 
 ### Note: data layer and legal basis for inter-org data exchange
 
-This RFC addresses which organisation **executes** which rules and how organisations exchange **individual decisions** (*beschikkingen*). It does not address the underlying **data layer**: how organisations obtain the raw input data they need to execute those rules.
+This RFC addresses which organization **executes** which rules and how organizations exchange **individual decisions** (*beschikkingen*). It does not address the underlying **data layer**: how organizations obtain the raw input data they need to execute those rules.
 
-In Dutch law, there is no general legal basis for one government organisation to request data from another. Each inter-organisational data exchange requires its own specific legal basis — either through a base registry (*basisregistratie*) with mandatory use provisions (*verplicht gebruik*) in its own law, a domain-specific law (e.g., Wet SUWI art. 62 for the work and income domain, Participation Act (*Participatiewet*) art. 64 for social assistance), or a bilateral statutory provision.
+In Dutch law, there is no general legal basis for one government organization to request data from another. Each inter-organizational data exchange requires its own specific legal basis — either through a base registry (*basisregistratie*) with mandatory use provisions (*verplicht gebruik*) in its own law, a domain-specific law (e.g., Wet SUWI art. 62 for the work and income domain, Participation Act (*Participatiewet*) art. 64 for social assistance), or a bilateral statutory provision.
 
-The policy principle of "single request, multiple use" (*eenmalige uitvraag, meervoudig gebruik*) aspires to prevent citizens from having to provide the same data to multiple government organisations. For data in base registries (*basisregistraties*), this is legally enforced through per-registry mandatory use provisions. For data outside the base registries, it remains a policy aspiration without a general legal mechanism. There is no general statutory obligation for one government organisation to share data with another.
+The policy principle of "single request, multiple use" (*eenmalige uitvraag, meervoudig gebruik*) aspires to prevent citizens from having to provide the same data to multiple government organizations. For data in base registries (*basisregistraties*), this is legally enforced through per-registry mandatory use provisions. For data outside the base registries, it remains a policy aspiration without a general legal mechanism. There is no general statutory obligation for one government organization to share data with another.
 
 Machine-readable law partially mitigates this: when org B can load org A's published rules and execute them locally using data org B already legitimately holds, the need for inter-org data exchange is reduced. But it does not eliminate it — there remain cases where org B needs data that only org A has, and no registry or specific law covers the exchange.
 
@@ -495,9 +495,9 @@ The data layer — how engines obtain input data, which registries they connect 
 
 - **Backward compatible.** Solo simulation is the default. Existing users, tests, and deployments are unaffected.
 
-- **Transparent.** Every trace shows which values were computed locally and which were accepted from other organisations. This addresses the opacity problem identified by the Court of Audit (*Algemene Rekenkamer*) and the Parliamentary Committee (*POK*).
+- **Transparent.** Every trace shows which values were computed locally and which were accepted from other organizations. This addresses the opacity problem identified by the Court of Audit (*Algemene Rekenkamer*) and the Parliamentary Committee (*POK*).
 
-- **Verifiable.** Any organisation can verify an accepted value by switching to solo simulation and re-executing locally. This satisfies AWB art. 3:9 duty to verify (*vergewisplicht*).
+- **Verifiable.** Any organization can verify an accepted value by switching to solo simulation and re-executing locally. This satisfies AWB art. 3:9 duty to verify (*vergewisplicht*).
 
 - **Legally grounded.** The execute/accept distinction maps to individual decision (*beschikking*) vs calculation (*berekening*) in Dutch administrative law, using `produces.legal_character` and `competent_authority` — both already in the schema.
 
@@ -509,7 +509,7 @@ The data layer — how engines obtain input data, which registries they connect 
 
 - **Inter-org latency.** Federated mode introduces network calls where solo mode has none. Critical-path accepted values add latency. Mitigation: caching with TTL based on the providing org's update frequency.
 
-- **Requires FSC infrastructure.** Organisations need certificates from the Group's Trust Anchor and must onboard to the FSC Directory. The overhead per participating org is low (certificate + registration), but establishing the Group and Trust Anchor is a one-time coordination effort.
+- **Requires FSC infrastructure.** Organizations need certificates from the Group's Trust Anchor and must onboard to the FSC Directory. The overhead per participating org is low (certificate + registration), but establishing the Group and Trust Anchor is a one-time coordination effort.
 
 - **Trust model.** An accepted value is trusted because it's signed by the competent authority. If the signing key is compromised, the trust model breaks. Mitigation: standard x.509 certificate revocation via the Trust Anchor.
 
@@ -519,8 +519,8 @@ The data layer — how engines obtain input data, which registries they connect 
 - Each `source` reference would declare `mode: execute` or `mode: accept`
 - Rejected: this duplicates what `competent_authority` already expresses. The YAML would need to encode the same information in two places, creating inconsistency risk. The law doesn't say "fetch this value" — it says "this is determined by [org]." The engine should derive the mode, not have it configured.
 
-**Alternative 2: Centralised execution (one engine runs everything)**
-- A single national engine loads all laws and executes everything, returning results to individual organisations
+**Alternative 2: Centralized execution (one engine runs everything)**
+- A single national engine loads all laws and executes everything, returning results to individual organizations
 - Rejected: violates execution sovereignty. A municipality (*gemeente*) should be able to run its own engine with its own ordinance (*verordening*). Also creates a single point of failure and a massive data concentration.
 
 **Alternative 3: Full delegation (call another org's engine for any cross-law reference)**
@@ -534,7 +534,7 @@ The data layer — how engines obtain input data, which registries they connect 
 - Add `Connectivity` enum: `Solo`, `Federated`
 - Add `LegalStatus` enum: `Simulation`, `Authoritative`
 - Configure via CLI flag or config file
-- In `SoloSimulation` mode: default behaviour, no changes
+- In `SoloSimulation` mode: default behavior, no changes
 
 #### Phase 2: Execute/Accept resolution
 - In `resolve_external_input_internal()`: before executing the target article, check `competent_authority`

--- a/docs/src/content/rfcs/rfc-009.md
+++ b/docs/src/content/rfcs/rfc-009.md
@@ -15,7 +15,7 @@ In reality, Dutch law assigns specific computations to specific organizations. T
 
 ### The legal key: individual decisions (*beschikkingen*) vs calculations (*berekeningen*)
 
-The General Administrative Law Act (*AWB*) art. 1:3 defines a **decision** (*besluit*) as a written decision by an administrative body (*bestuursorgaan*) containing a public-law legal act. An **individual decision** (*beschikking*) is a decision that is not of general scope, directed at a specific person or case. Only a competent authority (*bevoegd gezag*) can issue an individual decision (*beschikking*), and other organizations are legally bound by it.
+The General Administrative Law Act (*Awb*) art. 1:3 defines a **decision** (*besluit*) as a written decision by an administrative body (*bestuursorgaan*) containing a public-law legal act. An **individual decision** (*beschikking*) is a decision that is not of general scope, directed at a specific person or case. Only a competent authority (*bevoegd gezag*) can issue an individual decision (*beschikking*), and other organizations are legally bound by it.
 
 A **calculation** (*berekening*), such as applying a formula, evaluating a definition, or computing an intermediate value, is not a decision (*besluit*). It has no independent legal force. Anyone with the rules and data can perform it.
 
@@ -497,7 +497,7 @@ The data layer, how engines obtain input data, which registries they connect to,
 
 - **Transparent.** Every trace shows which values were computed locally and which were accepted from other organizations. This addresses the opacity problem identified by the Court of Audit (*Algemene Rekenkamer*) and the Parliamentary Committee (*POK*).
 
-- **Verifiable.** Any organization can verify an accepted value by switching to solo simulation and re-executing locally. This satisfies AWB art. 3:9 duty to verify (*vergewisplicht*).
+- **Verifiable.** Any organization can verify an accepted value by switching to solo simulation and re-executing locally. This satisfies Awb art. 3:9 duty to verify (*vergewisplicht*).
 
 - **Legally grounded.** The execute/accept distinction maps to individual decision (*beschikking*) vs calculation (*berekening*) in Dutch administrative law, using `produces.legal_character` and `competent_authority`, both already in the schema.
 

--- a/docs/src/content/rfcs/rfc-009.md
+++ b/docs/src/content/rfcs/rfc-009.md
@@ -143,10 +143,10 @@ In federated mode (both simulation and authoritative), the engine needs to know 
 
 FSC is not Dutch-specific. Its core concepts are generic:
 
-| FSC concept | What it does | regelrecht use |
+| FSC concept | What it does | RegelRecht use |
 |---|---|---|
-| **Peer** | An organisation that provides and/or consumes services | Each org running a regelrecht engine is a Peer |
-| **Group** | A set of Peers that share a Trust Anchor | All regelrecht-participating orgs form a Group |
+| **Peer** | An organisation that provides and/or consumes services | Each org running a RegelRecht engine is a Peer |
+| **Group** | A set of Peers that share a Trust Anchor | All RegelRecht-participating orgs form a Group |
 | **Directory** | Central service discovery point for a Group | Engines register their law evaluation API; consuming engines discover competent authorities (*bevoegde gezagen*) |
 | **Contract** | Signed agreement between Peers defining allowed interactions | Encodes which org may request which outputs — derived from the legal basis in the law |
 | **Grant** | Permission within a Contract (ServiceConnectionGrant, DelegatedServiceConnectionGrant) | Org A may connect to org B's engine |
@@ -154,7 +154,7 @@ FSC is not Dutch-specific. Its core concepts are generic:
 
 FSC provides exactly what multi-org law execution needs:
 
-1. **Service discovery**: organisations register their regelrecht engine endpoints in the Directory. The `competent_authority` name in the law YAML maps to a Peer in the Directory, which maps to an endpoint.
+1. **Service discovery**: organisations register their RegelRecht engine endpoints in the Directory. The `competent_authority` name in the law YAML maps to a Peer in the Directory, which maps to an endpoint.
 2. **Contract-based connectivity**: Peers negotiate Contracts with Grants to establish that they may call each other's services. Authentication as a verified government org is sufficient basis for a Grant.
 3. **Mutual authentication**: x.509 certificates signed by the Group's Trust Anchor, mTLS on all connections.
 4. **Audit trail**: contract signatures and connection logging provide a verifiable record of inter-org interactions.
@@ -187,7 +187,7 @@ services:
     endpoint: "http://localhost:8084/api/v1"
 ```
 
-The consuming engine doesn't know or care whether the providing endpoint runs a live regelrecht engine or serves pre-computed individual decisions (*beschikkingen*) from a registry. That's the providing org's implementation choice. Both respond to the same protocol (§5).
+The consuming engine doesn't know or care whether the providing endpoint runs a live RegelRecht engine or serves pre-computed individual decisions (*beschikkingen*) from a registry. That's the providing org's implementation choice. Both respond to the same protocol (§5).
 
 ### 5. Inter-engine protocol
 
@@ -243,7 +243,7 @@ The **signature** is what makes the output authoritative. In simulation mode, th
 
 **Authentication** is handled through FSC. FSC uses x.509 certificates signed by the Group's Trust Anchor. All connections between Peers use mutual TLS (mTLS). Each jurisdiction chooses its own Trust Anchor and certificate infrastructure.
 
-A regelrecht engine in production:
+A RegelRecht engine in production:
 1. Has a certificate signed by the Group's Trust Anchor
 2. Registers its law evaluation API in the FSC Directory
 3. Establishes FSC Contracts with organisations it needs to call (and that need to call it)
@@ -259,7 +259,7 @@ For development: self-signed certificates and the local `service-registry.yaml` 
 
 ### 7. Impact on current collaboration chains
 
-#### Without regelrecht: healthcare allowance (*zorgtoeslag*)
+#### Without RegelRecht: healthcare allowance (*zorgtoeslag*)
 
 ```mermaid
 sequenceDiagram
@@ -279,7 +279,7 @@ sequenceDiagram
     Note over DT: Issues individual decision (beschikking)
 ```
 
-#### With regelrecht: healthcare allowance (*zorgtoeslag*)
+#### With RegelRecht: healthcare allowance (*zorgtoeslag*)
 
 ```mermaid
 sequenceDiagram
@@ -310,7 +310,7 @@ sequenceDiagram
 - Allowances Service (*Dienst Toeslagen*) can *verify* the accepted value by running the Income Tax Act (*Wet IB*) rules in solo simulation
 - The citizen sees a complete trace: "your healthcare allowance (*zorgtoeslag*) was computed by Allowances Service (*Dienst Toeslagen*) using assessed income (*toetsingsinkomen*) €32.000 as determined by the tax inspector (*inspecteur*) on [date]"
 
-#### Without regelrecht: Participation Act (*Participatiewet*) — social assistance (*bijstand*)
+#### Without RegelRecht: Participation Act (*Participatiewet*) — social assistance (*bijstand*)
 
 ```mermaid
 sequenceDiagram
@@ -333,7 +333,7 @@ sequenceDiagram
     Note over GEM: Issues individual decision (beschikking)
 ```
 
-#### With regelrecht: Participation Act (*Participatiewet*) — social assistance (*bijstand*)
+#### With RegelRecht: Participation Act (*Participatiewet*) — social assistance (*bijstand*)
 
 ```mermaid
 sequenceDiagram

--- a/docs/src/content/rfcs/rfc-009.md
+++ b/docs/src/content/rfcs/rfc-009.md
@@ -15,7 +15,7 @@ In reality, Dutch law assigns specific computations to specific organizations. T
 
 ### The legal key: individual decisions (*beschikkingen*) vs calculations (*berekeningen*)
 
-The General Administrative Law Act (*AWB*) art. 1:3 defines a **decision** (*besluit*) as a written decision by an administrative body (*bestuursorgaan*) containing a public-law legal act. An **individual decision** (*beschikking*) is a decision that is not of general scope — directed at a specific person or case. Only a competent authority (*bevoegd gezag*) can issue an individual decision (*beschikking*), and other organizations are legally bound by it.
+The General Administrative Law Act (*AWB*) art. 1:3 defines a **decision** (*besluit*) as a written decision by an administrative body (*bestuursorgaan*) containing a public-law legal act. An **individual decision** (*beschikking*) is a decision that is not of general scope, directed at a specific person or case. Only a competent authority (*bevoegd gezag*) can issue an individual decision (*beschikking*), and other organizations are legally bound by it.
 
 A **calculation** (*berekening*), such as applying a formula, evaluating a definition, or computing an intermediate value, is not a decision (*besluit*). It has no independent legal force. Anyone with the rules and data can perform it.
 
@@ -58,9 +58,9 @@ When the engine resolves a cross-law reference, it operates in one of two modes:
 
 The mode is **not declared in the YAML**. It is derived at runtime from three things:
 
-1. The target article's `produces.legal_character` — does this article produce an individual decision (*beschikking*)?
-2. The target article's (or regulation's) `competent_authority` — who is competent for that decision?
-3. The engine's own identity — am I that authority?
+1. The target article's `produces.legal_character`, does this article produce an individual decision (*beschikking*)?
+2. The target article's (or regulation's) `competent_authority`, who is competent for that decision?
+3. The engine's own identity, am I that authority?
 
 ```
 Does the target article declare produces.legal_character == BESCHIKKING?
@@ -74,9 +74,9 @@ Does the target article declare produces.legal_character == BESCHIKKING?
           NO  → ACCEPT (they are competent, use their determination)
 ```
 
-The `produces.legal_character` field is the primary trigger, not `competent_authority` alone. This is essential because a single regulation can contain both articles that produce individual decisions (*beschikkingen*) and articles that define terms or calculate intermediate values. For example, the Income Tax Act (*Wet inkomstenbelasting 2001*) has `competent_authority: Belastingdienst` at regulation level, but article 2.18 (aggregate income (*verzamelinkomen*)) is a pure definitional formula — anyone can compute it. Only the articles that produce the actual tax assessment (*aanslag*), which is the individual decision (*beschikking*), require the Tax Authority (*Belastingdienst*).
+The `produces.legal_character` field is the primary trigger, not `competent_authority` alone. This is essential because a single regulation can contain both articles that produce individual decisions (*beschikkingen*) and articles that define terms or calculate intermediate values. For example, the Income Tax Act (*Wet inkomstenbelasting 2001*) has `competent_authority: Belastingdienst` at regulation level, but article 2.18 (aggregate income (*verzamelinkomen*)) is a pure definitional formula, anyone can compute it. Only the articles that produce the actual tax assessment (*aanslag*), which is the individual decision (*beschikking*), require the Tax Authority (*Belastingdienst*).
 
-When an article **does** produce a `BESCHIKKING`, **all its outputs** are part of that single determination. In Dutch administrative law, the individual decision (*beschikking*) is indivisible — both the right (*recht*) and the amount (*hoogte*) are constitutive elements of one decision. You cannot accept the right from the authority but re-calculate the amount yourself.
+When an article **does** produce a `BESCHIKKING`, **all its outputs** are part of that single determination. In Dutch administrative law, the individual decision (*beschikking*) is indivisible, both the right (*recht*) and the amount (*hoogte*) are constitutive elements of one decision. You cannot accept the right from the authority but re-calculate the amount yourself.
 
 For `CATEGORY` authorities ([RFC-002](/rfcs/rfc-002)), the engine resolves the category against its identity. A municipality (*gemeente*) engine with identity `GM0363` matches `competent_authority: { name: "college van burgemeester en wethouders", type: CATEGORY }`.
 
@@ -102,7 +102,7 @@ identity:
 
 When `type` is `CATEGORY_MEMBER`, the engine matches against any `competent_authority` with `type: CATEGORY` and the same `category` name. This resolves the [RFC-002](/rfcs/rfc-002) open question of how categorical authorities work at runtime.
 
-With a self-signed identity (the default), the engine runs in **solo simulation** — it executes everything locally, regardless of `competent_authority`.
+With a self-signed identity (the default), the engine runs in **solo simulation**, it executes everything locally, regardless of `competent_authority`.
 
 ### 3. Execution modes
 
@@ -123,13 +123,13 @@ These combine into four modes:
 | | **Solo** | **Federated** |
 |---|---|---|
 | **Simulation** | Execute everything locally, self-signed identity, unsigned outputs. For citizens, policy analysis, development. | Execute with identity, call other orgs (or demo orgs with self-signed identities), unsigned outputs. For integration testing, demo setups. |
-| **Authoritative** | Execute with identity, sign outputs. No cross-org calls — only for laws fully within this org's competence. | Execute with identity, sign outputs, accept signed individual decisions (*beschikkingen*) from other orgs via FSC. Production mode. |
+| **Authoritative** | Execute with identity, sign outputs. No cross-org calls, only for laws fully within this org's competence. | Execute with identity, sign outputs, accept signed individual decisions (*beschikkingen*) from other orgs via FSC. Production mode. |
 
 **Solo simulation** is the default. It is the mode used for citizen-facing scenario tools, policy analysis, and development.
 
 **Federated authoritative** is the production mode. The engine identifies as a specific organization, executes its own competence, accepts individual decisions (*beschikkingen*) from other competent authorities, and signs its outputs.
 
-**Solo authoritative** is for organizations executing laws that have no cross-org dependencies — the entire computation is within their own competence. The engine signs its outputs but makes no external calls.
+**Solo authoritative** is for organizations executing laws that have no cross-org dependencies, the entire computation is within their own competence. The engine signs its outputs but makes no external calls.
 
 **Federated simulation** is for integration testing. The engine has an identity and makes real calls to other engines (which may run with fake identities in a demo setup), but outputs are not authoritative. This tests the full inter-org chain without producing legally binding results.
 
@@ -148,7 +148,7 @@ FSC is not Dutch-specific. Its core concepts are generic:
 | **Peer** | An organization that provides and/or consumes services | Each org running a RegelRecht engine is a Peer |
 | **Group** | A set of Peers that share a Trust Anchor | All RegelRecht-participating orgs form a Group |
 | **Directory** | Central service discovery point for a Group | Engines register their law evaluation API; consuming engines discover competent authorities (*bevoegde gezagen*) |
-| **Contract** | Signed agreement between Peers defining allowed interactions | Encodes which org may request which outputs — derived from the legal basis in the law |
+| **Contract** | Signed agreement between Peers defining allowed interactions | Encodes which org may request which outputs, derived from the legal basis in the law |
 | **Grant** | Permission within a Contract (ServiceConnectionGrant, DelegatedServiceConnectionGrant) | Org A may connect to org B's engine |
 | **Trust Anchor** | Root CA that all Peers trust | Any agreed CA for the jurisdiction |
 
@@ -251,11 +251,11 @@ A RegelRecht engine in production:
 
 For development: self-signed certificates and the local `service-registry.yaml` replace the FSC Directory.
 
-**Connectivity**: FSC Contracts with Grants establish which organizations may connect to each other's engines. Authentication as a verified government organization is sufficient basis for a Grant — FSC handles the "can org A talk to org B" question.
+**Connectivity**: FSC Contracts with Grants establish which organizations may connect to each other's engines. Authentication as a verified government organization is sufficient basis for a Grant, FSC handles the "can org A talk to org B" question.
 
-**Request-level authorization** — whether org A may request specific data about a specific citizen — is a separate concern that operates at a different layer. This is out of scope for this RFC and will be addressed in a future RFC.
+**Request-level authorization**, whether org A may request specific data about a specific citizen, is a separate concern that operates at a different layer. This is out of scope for this RFC and will be addressed in a future RFC.
 
-**Event-driven re-evaluation**: when upstream individual decisions (*beschikkingen*) change (e.g., the tax inspector (*inspecteur*) corrects an assessed income (*toetsingsinkomen*)), the providing engine can notify consuming engines. This triggers re-evaluation of downstream individual decisions (*beschikkingen*) — addressing the staleness problem in the current semi-finished products model. The notification mechanism is out of scope for this RFC but FSC's contract model supports it.
+**Event-driven re-evaluation**: when upstream individual decisions (*beschikkingen*) change (e.g., the tax inspector (*inspecteur*) corrects an assessed income (*toetsingsinkomen*)), the providing engine can notify consuming engines. This triggers re-evaluation of downstream individual decisions (*beschikkingen*), addressing the staleness problem in the current semi-finished products model. The notification mechanism is out of scope for this RFC but FSC's contract model supports it.
 
 ### 7. Impact on current collaboration chains
 
@@ -310,7 +310,7 @@ sequenceDiagram
 - Allowances Service (*Dienst Toeslagen*) can *verify* the accepted value by running the Income Tax Act (*Wet IB*) rules in solo simulation
 - The citizen sees a complete trace: "your healthcare allowance (*zorgtoeslag*) was computed by Allowances Service (*Dienst Toeslagen*) using assessed income (*toetsingsinkomen*) €32.000 as determined by the tax inspector (*inspecteur*) on [date]"
 
-#### Without RegelRecht: Participation Act (*Participatiewet*) — social assistance (*bijstand*)
+#### Without RegelRecht: Participation Act (*Participatiewet*): social assistance (*bijstand*)
 
 ```mermaid
 sequenceDiagram
@@ -333,7 +333,7 @@ sequenceDiagram
     Note over GEM: Issues individual decision (beschikking)
 ```
 
-#### With RegelRecht: Participation Act (*Participatiewet*) — social assistance (*bijstand*)
+#### With RegelRecht: Participation Act (*Participatiewet*): social assistance (*bijstand*)
 
 ```mermaid
 sequenceDiagram
@@ -361,7 +361,7 @@ sequenceDiagram
 ```
 
 **What changes:**
-- Competent authorities communicate peer-to-peer — the engine resolves cross-org references directly based on `competent_authority`
+- Competent authorities communicate peer-to-peer, the engine resolves cross-org references directly based on `competent_authority`
 - Each accepted value comes with provenance and signature
 - The municipality (*gemeente*) can verify any accepted value by switching to solo simulation
 
@@ -399,7 +399,7 @@ graph TB
 
 #### Traces stay with the executing org
 
-Each organization's engine produces its own trace for the computation it performs. Traces are **not shared** between organizations. When engine A accepts a value from engine B, engine A's trace records the accepted value and a reference — not engine B's internal computation. This is privacy by design: engine B's trace may contain data about the citizen that engine A has no legal basis to see.
+Each organization's engine produces its own trace for the computation it performs. Traces are **not shared** between organizations. When engine A accepts a value from engine B, engine A's trace records the accepted value and a reference, not engine B's internal computation. This is privacy by design: engine B's trace may contain data about the citizen that engine A has no legal basis to see.
 
 This principle aligns with the [Logboek Dataverwerkingen](https://logius-standaarden.github.io/logboek-dataverwerkingen/) standard: each organization logs its own data processing, logs are not exchanged between organizations, and the citizen can request their logs from each org independently.
 
@@ -407,7 +407,7 @@ This principle aligns with the [Logboek Dataverwerkingen](https://logius-standaa
 
 The existing trace uses `PathNodeType` to identify what each trace node represents. Cross-law calls use `CrossLawReference`, IoC resolution uses `OpenTermResolution`. For cross-org boundaries, a new node type is introduced:
 
-- **`AuthorityCall`** — the engine needs a value that is another organization's competence (*bevoegdheid*)
+- **`AuthorityCall`**: the engine needs a value that is another organization's competence (*bevoegdheid*)
 
 This follows the same parent-child pattern as `CrossLawReference` and `OpenTermResolution`: the parent node explains what is happening, the child node holds the result.
 
@@ -438,7 +438,7 @@ The `AuthorityCall` node:
 
 The **reference** is a `trace_id` following the [W3C Trace Context](https://www.w3.org/TR/trace-context/) standard, as prescribed by the Logboek Dataverwerkingen standard. When engine A calls engine B via FSC, the `trace_id` propagates across the organizational boundary. Both orgs log their side of the interaction using the same `trace_id`, but neither shares its log entries with the other.
 
-The providing org does not share its trace — it stores it in its own Logboek Dataverwerkingen.
+The providing org does not share its trace, it stores it in its own Logboek Dataverwerkingen.
 
 #### Citizen access to traces
 
@@ -469,9 +469,9 @@ The `AuthorityCall` node is still present (so org boundaries are visible) but in
 
 In **solo simulation** (the default), the engine ignores `competent_authority` entirely. It loads all laws and executes everything locally. This is:
 
-- **The default** — nothing changes for existing users
-- **The citizen's view** — a citizen running the engine in their browser (WASM) can explore the entire chain: "what if my income were X, what would my healthcare allowance (*zorgtoeslag*) be?" They execute everything including the assessed income (*toetsingsinkomen*) calculation. The output is non-authoritative but fully transparent. A future extension (out of scope for this RFC) could allow the engine to fetch the citizen's real data from organizations on behalf of the citizen, using the citizen's own identity.
-- **Policy analysis** — a policy maker can change a rule and see the downstream effects across the entire chain, regardless of organizational boundaries.
+- **The default**: nothing changes for existing users
+- **The citizen's view**: a citizen running the engine in their browser (WASM) can explore the entire chain: "what if my income were X, what would my healthcare allowance (*zorgtoeslag*) be?" They execute everything including the assessed income (*toetsingsinkomen*) calculation. The output is non-authoritative but fully transparent. A future extension (out of scope for this RFC) could allow the engine to fetch the citizen's real data from organizations on behalf of the citizen, using the citizen's own identity.
+- **Policy analysis**: a policy maker can change a rule and see the downstream effects across the entire chain, regardless of organizational boundaries.
 
 In **federated simulation**, the engine has an identity and makes real calls to other engines via FSC, but outputs are non-authoritative. This is for integration testing: the full inter-org chain is exercised, including service discovery, authentication, and the inter-engine protocol. If a called engine is unreachable, this is an error; there is no silent fallback to local execution. Demo setups use self-signed identities.
 
@@ -479,13 +479,13 @@ In **federated simulation**, the engine has an identity and makes real calls to 
 
 This RFC addresses which organization **executes** which rules and how organizations exchange **individual decisions** (*beschikkingen*). It does not address the underlying **data layer**: how organizations obtain the raw input data they need to execute those rules.
 
-In Dutch law, there is no general legal basis for one government organization to request data from another. Each inter-organizational data exchange requires its own specific legal basis — either through a base registry (*basisregistratie*) with mandatory use provisions (*verplicht gebruik*) in its own law, a domain-specific law (e.g., Wet SUWI art. 62 for the work and income domain, Participation Act (*Participatiewet*) art. 64 for social assistance), or a bilateral statutory provision.
+In Dutch law, there is no general legal basis for one government organization to request data from another. Each inter-organizational data exchange requires its own specific legal basis, either through a base registry (*basisregistratie*) with mandatory use provisions (*verplicht gebruik*) in its own law, a domain-specific law (e.g., Wet SUWI art. 62 for the work and income domain, Participation Act (*Participatiewet*) art. 64 for social assistance), or a bilateral statutory provision.
 
 The policy principle of "single request, multiple use" (*eenmalige uitvraag, meervoudig gebruik*) aspires to prevent citizens from having to provide the same data to multiple government organizations. For data in base registries (*basisregistraties*), this is legally enforced through per-registry mandatory use provisions. For data outside the base registries, it remains a policy aspiration without a general legal mechanism. There is no general statutory obligation for one government organization to share data with another.
 
-Machine-readable law partially mitigates this: when org B can load org A's published rules and execute them locally using data org B already legitimately holds, the need for inter-org data exchange is reduced. But it does not eliminate it — there remain cases where org B needs data that only org A has, and no registry or specific law covers the exchange.
+Machine-readable law partially mitigates this: when org B can load org A's published rules and execute them locally using data org B already legitimately holds, the need for inter-org data exchange is reduced. But it does not eliminate it, there remain cases where org B needs data that only org A has, and no registry or specific law covers the exchange.
 
-The data layer — how engines obtain input data, which registries they connect to, what legal basis each data flow requires, and how this interacts with the execute/accept model — is out of scope for this RFC and will be addressed in a future RFC.
+The data layer, how engines obtain input data, which registries they connect to, what legal basis each data flow requires, and how this interacts with the execute/accept model, is out of scope for this RFC and will be addressed in a future RFC.
 
 ## Why
 
@@ -499,13 +499,13 @@ The data layer — how engines obtain input data, which registries they connect 
 
 - **Verifiable.** Any organization can verify an accepted value by switching to solo simulation and re-executing locally. This satisfies AWB art. 3:9 duty to verify (*vergewisplicht*).
 
-- **Legally grounded.** The execute/accept distinction maps to individual decision (*beschikking*) vs calculation (*berekening*) in Dutch administrative law, using `produces.legal_character` and `competent_authority` — both already in the schema.
+- **Legally grounded.** The execute/accept distinction maps to individual decision (*beschikking*) vs calculation (*berekening*) in Dutch administrative law, using `produces.legal_character` and `competent_authority`, both already in the schema.
 
 - **Privacy by design.** In authoritative mode, data only flows where the law says it should. Accepted values are individual outputs (assessed income: €32.000), not bulk data.
 
 ### Tradeoffs
 
-- **Requires `competent_authority` to be declared.** Laws without `competent_authority` on their articles default to "anyone can execute" — which is correct for most definitions and calculations (*berekeningen*), but means the quality of the execute/accept boundary depends on the completeness of authority annotations.
+- **Requires `competent_authority` to be declared.** Laws without `competent_authority` on their articles default to "anyone can execute", which is correct for most definitions and calculations (*berekeningen*), but means the quality of the execute/accept boundary depends on the completeness of authority annotations.
 
 - **Inter-org latency.** Federated mode introduces network calls where solo mode has none. Critical-path accepted values add latency. Mitigation: caching with TTL based on the providing org's update frequency.
 
@@ -517,7 +517,7 @@ The data layer — how engines obtain input data, which registries they connect 
 
 **Alternative 1: Mode declared per source reference in YAML**
 - Each `source` reference would declare `mode: execute` or `mode: accept`
-- Rejected: this duplicates what `competent_authority` already expresses. The YAML would need to encode the same information in two places, creating inconsistency risk. The law doesn't say "fetch this value" — it says "this is determined by [org]." The engine should derive the mode, not have it configured.
+- Rejected: this duplicates what `competent_authority` already expresses. The YAML would need to encode the same information in two places, creating inconsistency risk. The law doesn't say "fetch this value", it says "this is determined by [org]." The engine should derive the mode, not have it configured.
 
 **Alternative 2: Centralized execution (one engine runs everything)**
 - A single national engine loads all laws and executes everything, returning results to individual organizations
@@ -568,19 +568,19 @@ The data layer — how engines obtain input data, which registries they connect 
 | New: `packages/engine/src/identity.rs` | `EngineIdentity`, `matches_authority()`, identity matching logic |
 | New: `packages/engine/src/federation.rs` | `ServiceRegistry`, `InterEngineClient`, request/response types |
 | New: `packages/engine/src/signature.rs` | Output signing and verification |
-| Schema: `schema/v0.5.0/schema.json` | No schema change needed — `competent_authority` already exists |
+| Schema: `schema/v0.5.0/schema.json` | No schema change needed, `competent_authority` already exists |
 
 ## References
 
-- [RFC-002](/rfcs/rfc-002): Authority (*Bevoegdheid*) — defines `competent_authority` at article level
-- [RFC-003](/rfcs/rfc-003): Inversion of Control — `open_terms` + `implements` for delegation (unchanged, always execute locally)
-- [RFC-007](/rfcs/rfc-007): Cross-Law Execution — hooks and overrides (fire locally, require relevant laws to be loaded)
-- [RFC-010](/rfcs/rfc-010): Federated Corpus — rule distribution (how engines obtain laws from multiple sources)
-- Court of Audit (*Algemene Rekenkamer*), "Grip op Gegevens" (2019) — problems with inter-org data exchange
-- Parliamentary Committee (*POK*) Report "Unprecedented Injustice" (*Ongekend Onrecht*) (2020) — chain-of-automation failures
-- SyRI ruling (ECLI:NL:RBDHA:2020:865) — transparency and proportionality requirements
-- State of Government Implementation (*Staat van de Uitvoering*) (2022, 2024) — semi-finished products problems
-- [Federated Service Connectivity (FSC) Core specification](https://gitdocumentatie.logius.nl/publicatie/fsc/core/) — service discovery, contract-based connectivity, and mTLS authentication
-- [Logboek Dataverwerkingen](https://logius-standaarden.github.io/logboek-dataverwerkingen/) — each org logs its own data processing; logs are not exchanged between orgs; citizen can request their logs from each org
-- [W3C Trace Context](https://www.w3.org/TR/trace-context/) — standard for propagating trace identifiers across service boundaries
+- [RFC-002](/rfcs/rfc-002): Authority (*Bevoegdheid*), defines `competent_authority` at article level
+- [RFC-003](/rfcs/rfc-003): Inversion of Control, `open_terms` + `implements` for delegation (unchanged, always execute locally)
+- [RFC-007](/rfcs/rfc-007): Cross-Law Execution, hooks and overrides (fire locally, require relevant laws to be loaded)
+- [RFC-010](/rfcs/rfc-010): Federated Corpus, rule distribution (how engines obtain laws from multiple sources)
+- Court of Audit (*Algemene Rekenkamer*), "Grip op Gegevens" (2019), problems with inter-org data exchange
+- Parliamentary Committee (*POK*) Report "Unprecedented Injustice" (*Ongekend Onrecht*) (2020), chain-of-automation failures
+- SyRI ruling (ECLI:NL:RBDHA:2020:865), transparency and proportionality requirements
+- State of Government Implementation (*Staat van de Uitvoering*) (2022, 2024), semi-finished products problems
+- [Federated Service Connectivity (FSC) Core specification](https://gitdocumentatie.logius.nl/publicatie/fsc/core/), service discovery, contract-based connectivity, and mTLS authentication
+- [Logboek Dataverwerkingen](https://logius-standaarden.github.io/logboek-dataverwerkingen/), each org logs its own data processing; logs are not exchanged between orgs; citizen can request their logs from each org
+- [W3C Trace Context](https://www.w3.org/TR/trace-context/), standard for propagating trace identifiers across service boundaries
 - [Glossary of Dutch Legal Terms](/reference/glossary)

--- a/docs/src/content/rfcs/rfc-009.md
+++ b/docs/src/content/rfcs/rfc-009.md
@@ -74,9 +74,9 @@ Does the target article declare produces.legal_character == BESCHIKKING?
           NO  → ACCEPT (they are competent, use their determination)
 ```
 
-The `produces.legal_character` field is the primary trigger, not `competent_authority` alone. This is essential because a single regulation can contain both articles that produce individual decisions (*beschikkingen*) and articles that define terms or calculate intermediate values. For example, the Income Tax Act (*Wet inkomstenbelasting 2001*) has `competent_authority: Belastingdienst` at regulation level, but article 2.18 (aggregate income (*verzamelinkomen*)) is a pure definitional formula, anyone can compute it. Only the articles that produce the actual tax assessment (*aanslag*), which is the individual decision (*beschikking*), require the Tax Authority (*Belastingdienst*).
+The `produces.legal_character` field is the primary trigger, not `competent_authority` alone. This is essential because a single regulation can contain both articles that produce individual decisions (*beschikkingen*) and articles that define terms or calculate intermediate values. For example, the Income Tax Act (*Wet inkomstenbelasting 2001*) has `competent_authority: Belastingdienst` at regulation level, but article 2.18 (aggregate income (*verzamelinkomen*)) is a pure definitional formula; anyone can compute it. Only the articles that produce the actual tax assessment (*aanslag*), which is the individual decision (*beschikking*), require the Tax Authority (*Belastingdienst*).
 
-When an article **does** produce a `BESCHIKKING`, **all its outputs** are part of that single determination. In Dutch administrative law, the individual decision (*beschikking*) is indivisible, both the right (*recht*) and the amount (*hoogte*) are constitutive elements of one decision. You cannot accept the right from the authority but re-calculate the amount yourself.
+When an article **does** produce a `BESCHIKKING`, **all its outputs** are part of that single determination. In Dutch administrative law, the individual decision (*beschikking*) is indivisible: both the right (*recht*) and the amount (*hoogte*) are constitutive elements of one decision. You cannot accept the right from the authority but re-calculate the amount yourself.
 
 For `CATEGORY` authorities ([RFC-002](/rfcs/rfc-002)), the engine resolves the category against its identity. A municipality (*gemeente*) engine with identity `GM0363` matches `competent_authority: { name: "college van burgemeester en wethouders", type: CATEGORY }`.
 
@@ -102,7 +102,7 @@ identity:
 
 When `type` is `CATEGORY_MEMBER`, the engine matches against any `competent_authority` with `type: CATEGORY` and the same `category` name. This resolves the [RFC-002](/rfcs/rfc-002) open question of how categorical authorities work at runtime.
 
-With a self-signed identity (the default), the engine runs in **solo simulation**, it executes everything locally, regardless of `competent_authority`.
+With a self-signed identity (the default), the engine runs in **solo simulation**: it executes everything locally, regardless of `competent_authority`.
 
 ### 3. Execution modes
 

--- a/docs/src/content/rfcs/rfc-010.md
+++ b/docs/src/content/rfcs/rfc-010.md
@@ -37,11 +37,11 @@ A source repository must follow this layout:
 regulation/nl/
   {law_type}/           # e.g. wet/, ministeriele_regeling/, verordening/
     {law_name}/
-      {law_name}.yaml   # law file conforming to the regelrecht YAML schema
+      {law_name}.yaml   # law file conforming to the RegelRecht YAML schema
 ```
 
 Each YAML file must:
-- Conform to the regelrecht YAML schema (referenced via `$schema`)
+- Conform to the RegelRecht YAML schema (referenced via `$schema`)
 - Have a `$id` that identifies the law (does not need to be globally unique - see Priority below for conflict resolution when multiple sources provide the same `$id`)
 - Declare `implements` (per [RFC-003](/rfcs/rfc-003)) when filling in open terms from a higher-level law
 

--- a/docs/src/content/rfcs/rfc-010.md
+++ b/docs/src/content/rfcs/rfc-010.md
@@ -147,7 +147,7 @@ scopes:
 
 **Priority:**
 
-Multiple sources may provide a law with the same `$id`. This is allowed and expected: a local development source may override a central law for testing, or a municipality (*gemeente*) may provide a patched version of a national law during a transition period. **Lower priority value = higher priority** — the law from the source with the lowest priority number is the one the engine uses. Think of it as rank: priority 1 outranks priority 10.
+Multiple sources may provide a law with the same `$id`. This is allowed and expected: a local development source may override a central law for testing, or a municipality (*gemeente*) may provide a patched version of a national law during a transition period. **Lower priority value = higher priority**, the law from the source with the lowest priority number is the one the engine uses. Think of it as rank: priority 1 outranks priority 10.
 
 Where this matters in practice:
 - **Development**: your local source (priority 100) contains a modified version of a central law (priority 1). Lower the local priority to 0 to make it win, so you can test without modifying the central manifest.
@@ -271,7 +271,7 @@ corpus-registry.yaml
 > tradeoffs below explain why.
 
 `editor-api` mediates every write. The frontend does not know which
-GitHub repo backs a given law — it just calls
+GitHub repo backs a given law, it just calls
 `PUT /api/corpus/laws/{law_id}` and the backend resolves the source
 from the in-memory `SourceMap`, looks up the per-source token from the
 existing auth config (env var or `corpus-auth.yaml`), and pushes /
@@ -303,7 +303,7 @@ Flow:
 credited via a `Co-Authored-By: <name> <email>` trailer on every
 commit, sourced from the OIDC session (`person_name`, `person_email`).
 The PR body also names the submitter. We do not ask the editor user to
-paste a personal GitHub PAT — that path is closed by this amendment.
+paste a personal GitHub PAT, that path is closed by this amendment.
 
 **Branch scope.** One PR per editor session. Closing the browser tab
 purges `sessionStorage`; the next visit gets a new UUID and a new PR.

--- a/docs/src/content/rfcs/rfc-011.md
+++ b/docs/src/content/rfcs/rfc-011.md
@@ -4,7 +4,7 @@ title: "RFC-011: Rules Language Selection"
 
 **Status:** Accepted
 **Date:** 2025-11-05
-**Authors:** regelrecht team
+**Authors:** RegelRecht team
 **Short title:** Rules Language
 
 ## Context

--- a/docs/src/content/rfcs/rfc-012.md
+++ b/docs/src/content/rfcs/rfc-012.md
@@ -2,9 +2,11 @@
 title: "RFC-012: Untranslatables"
 ---
 
-**Status:** Proposed
+**Status:** Accepted (implemented)
 **Date:** 2026-04-01
 **Authors:** Eelco Hotting
+
+> **Implementation note.** This RFC is implemented: the engine supports all four untranslatable modes (`UntranslatableMode` in `packages/engine/src/types.rs`), the schema carries `untranslatables`, and `features/untranslatables.feature` covers it.
 
 ## Context
 

--- a/docs/src/content/rfcs/rfc-012.md
+++ b/docs/src/content/rfcs/rfc-012.md
@@ -25,7 +25,7 @@ The untranslatables mechanism has three layers: generation-time detection, schem
 The law-generate skill recognizes when a legal construct cannot be faithfully expressed with the available operations. When this happens, the translator:
 
 1. Adds an `untranslatables` entry to the article's `machine_readable` section (see layer 2)
-2. Skips the untranslatable parts — no approximation
+2. Skips the untranslatable parts, no approximation
 3. Generates execution logic for the parts that *are* translatable
 4. Reports all untranslatables in the generation summary
 
@@ -35,7 +35,7 @@ The law-reverse-validate skill detects likely workarounds that indicate the tran
 - Arithmetic chains that approximate rounding
 - Hardcoded values that look like pre-computed aggregations
 
-These are flagged as "possible untranslatable workaround — verify with human."
+These are flagged as "possible untranslatable workaround, verify with human."
 
 ### 2. Schema annotation
 
@@ -67,8 +67,8 @@ When the engine encounters articles with `untranslatables`, behavior is controll
 |------|----------|----------|
 | `error` (default) | Hard error on any unaccepted untranslatable. Accepted untranslatables execute their partial logic with a trace entry. | CI, production |
 | `propagate` | Execute partial logic. Outputs from articles with untranslatables carry an `UNTRANSLATABLE` taint that propagates through downstream operations. | Audit, analysis |
-| `warn` | Execute partial logic, log warning in trace. No taint propagation — outputs look normal but the trace shows they're incomplete. | Development, exploration |
-| `ignore` | Execute partial logic silently. Only valid for entries with `accepted: true` — unaccepted untranslatables still error. | Human-verified acceptable gaps |
+| `warn` | Execute partial logic, log warning in trace. No taint propagation, outputs look normal but the trace shows they're incomplete. | Development, exploration |
+| `ignore` | Execute partial logic silently. Only valid for entries with `accepted: true`, unaccepted untranslatables still error. | Human-verified acceptable gaps |
 
 Default is fail-fast. Tolerating gaps requires explicit opt-in.
 
@@ -84,11 +84,11 @@ The `accepted` field provides per-article scoping. In `error` mode (default), ac
 
 - Prevents silent divergence between law text and machine-readable interpretation
 - Fail-fast default: gaps are never silently ignored in CI or production
-- Per-article acceptance prevents global bypass — new untranslatables always surface
+- Per-article acceptance prevents global bypass, new untranslatables always surface
 - Propagation mode shows which outputs are affected without stopping execution
 - Drives the engine roadmap: the corpus tells us which operations to add next
 - A flagged gap is better than a plausible-looking wrong answer
-- Each layer is independently useful — layer 1 requires no code changes
+- Each layer is independently useful, layer 1 requires no code changes
 
 ### Tradeoffs
 
@@ -132,6 +132,6 @@ Ordering is layer 1 → 2 → 3. Each layer is independently useful.
 
 ## References
 
-- [RFC-003: Inversion of Control](/rfcs/rfc-003) — IoC pattern for cross-law references
-- [RFC-007: Reactive Execution](/rfcs/rfc-007) — hooks and overrides mechanism
+- [RFC-003: Inversion of Control](/rfcs/rfc-003), IoC pattern for cross-law references
+- [RFC-007: Reactive Execution](/rfcs/rfc-007), hooks and overrides mechanism
 - [Glossary of Dutch Legal Terms](/reference/glossary)

--- a/docs/src/content/rfcs/rfc-013.md
+++ b/docs/src/content/rfcs/rfc-013.md
@@ -15,7 +15,7 @@ The engine produces deterministic results: given the same regulation YAML, the s
 
 Dutch administrative law requires this:
 
-- **AWB Art. 3:46** (motivation obligation): every government decision (*besluit*) must rest on a sound motivation. For algorithmic decisions, the agency must be able to reconstruct how the algorithm reached its result.
+- **Awb Art. 3:46** (motivation obligation): every government decision (*besluit*) must rest on a sound motivation. For algorithmic decisions, the agency must be able to reconstruct how the algorithm reached its result.
 - **AERIUS I** (ECLI:NL:RVS:2017:1259): the Raad van State ruled that automated government decisions must be transparent and auditable (*inzichtelijk en controleerbaar*). For rule-based systems (as opposed to ML), full logical reproducibility is the expectation.
 - **EU AI Act Art. 12** (mandatory August 2026): high-risk systems must automatically log events including input data and verification results. Logs must be retained for at least 6 months.
 - **GDPR Art. 13-15, 22**: citizens have the right to "meaningful information about the logic involved" in automated decisions and the right to contest those decisions.
@@ -317,7 +317,7 @@ See [RFC-007](/rfcs/rfc-007#output-provenance) for the hook provenance model.
 
 ### Benefits
 
-- Execution Receipts satisfy AWB Art. 3:46 (motivation), AERIUS (auditability), and EU AI Act Art. 12 (logging). The receipt is the archivable artifact that proves how a computation was performed.
+- Execution Receipts satisfy Awb Art. 3:46 (motivation), AERIUS (auditability), and EU AI Act Art. 12 (logging). The receipt is the archivable artifact that proves how a computation was performed.
 - Independent versioning lets other organizations build their own engine on their own release cadence.
 - Sealed receipt reproduction makes cross-org decisions traceable and reproducible without requiring cooperation from other orgs at verification time.
 - Versioning the inter-engine protocol separately from the engine lets organizations upgrade at their own pace.

--- a/docs/src/content/rfcs/rfc-013.md
+++ b/docs/src/content/rfcs/rfc-013.md
@@ -2,10 +2,12 @@
 title: "RFC-013: Execution Provenance"
 ---
 
-**Status:** Draft
+**Status:** Accepted (implemented)
 **Date:** 2026-04-02
 **Authors:** Eelco Hotting
 **Depends on:** RFC-009 (Multi-Organisation Execution), RFC-010 (Federated Corpus), RFC-012 (Untranslatables)
+
+> **Implementation note.** The execution receipt and per-output provenance are implemented (`packages/engine/src/receipt.rs`, `OutputProvenance` in `engine.rs`). The CI `provenance-checks` job enforces tag-based `$schema` URLs across the corpus.
 
 ## Context
 

--- a/docs/src/content/rfcs/rfc-013.md
+++ b/docs/src/content/rfcs/rfc-013.md
@@ -5,7 +5,7 @@ title: "RFC-013: Execution Provenance"
 **Status:** Accepted (implemented)
 **Date:** 2026-04-02
 **Authors:** Eelco Hotting
-**Depends on:** RFC-009 (Multi-Organisation Execution), RFC-010 (Federated Corpus), RFC-012 (Untranslatables)
+**Depends on:** RFC-009 (Multi-Organization Execution), RFC-010 (Federated Corpus), RFC-012 (Untranslatables)
 
 > **Implementation note.** The execution receipt and per-output provenance are implemented (`packages/engine/src/receipt.rs`, `OutputProvenance` in `engine.rs`). The CI `provenance-checks` job enforces tag-based `$schema` URLs across the corpus.
 
@@ -15,20 +15,20 @@ The engine produces deterministic results: given the same regulation YAML, the s
 
 Dutch administrative law requires this:
 
-- **Awb Art. 3:46** (motivation obligation): every government decision (*besluit*) must rest on a sound motivation. For algorithmic decisions, the agency must be able to reconstruct how the algorithm reached its result.
+- **AWB Art. 3:46** (motivation obligation): every government decision (*besluit*) must rest on a sound motivation. For algorithmic decisions, the agency must be able to reconstruct how the algorithm reached its result.
 - **AERIUS I** (ECLI:NL:RVS:2017:1259): the Raad van State ruled that automated government decisions must be transparent and auditable (*inzichtelijk en controleerbaar*). For rule-based systems (as opposed to ML), full logical reproducibility is the expectation.
 - **EU AI Act Art. 12** (mandatory August 2026): high-risk systems must automatically log events including input data and verification results. Logs must be retained for at least 6 months.
 - **GDPR Art. 13-15, 22**: citizens have the right to "meaningful information about the logic involved" in automated decisions and the right to contest those decisions.
 
 Reproducibility requires pinning three things: the regulation YAML, the schema version it conforms to, and the engine version that executed it. Today, the engine stamps none of these on its output. The regulation carries a `$schema` URL, but the engine ignores it at execution time. The engine version exists as a Cargo constant but is not included in results. There is no "decision receipt" that ties inputs, outputs, and versions together.
 
-[RFC-009](/rfcs/rfc-009) (Multi-Organisation Execution) adds another dimension: a decision may depend on values accepted from other organisations' engines, each potentially running a different engine version. Reproducing that decision requires knowing which engine *this* organisation ran, and which engine versions produced the accepted values from other organisations.
+[RFC-009](/rfcs/rfc-009) (Multi-Organization Execution) adds another dimension: a decision may depend on values accepted from other organizations' engines, each potentially running a different engine version. Reproducing that decision requires knowing which engine *this* organization ran, and which engine versions produced the accepted values from other organizations.
 
 ### The schema is a specification, the engine is an implementation
 
 The schema defines the regulation format: what fields exist, what operations are valid, what structures are allowed. The engine interprets and executes regulations that conform to the schema. Think SQL (specification) vs PostgreSQL (implementation), or JSON Schema (specification) vs any validator.
 
-This distinction matters because third-party organisations may build their own engine implementations. A municipality (*gemeente*) might use a different technology stack. The schema must be precise enough that any conformant engine produces identical results for identical inputs. When two engines disagree, one has a bug. The schema is the arbiter.
+This distinction matters because third-party organizations may build their own engine implementations. A municipality (*gemeente*) might use a different technology stack. The schema must be precise enough that any conformant engine produces identical results for identical inputs. When two engines disagree, one has a bug. The schema is the arbiter.
 
 Coupling schema and engine version numbers would conflate specification with implementation. A schema change (new field, new operation) is a format change. An engine change (bugfix, performance improvement) is an implementation change. They evolve on different timelines for different reasons.
 
@@ -157,7 +157,7 @@ The receipt records:
 - The **scope**: which corpus sources were loaded (by source id, Git ref, and tree hash), which regulations were loaded (by id, `valid_from`, and content hash), and which jurisdiction scopes were active
 - The calculation date, parameters, and reference date
 - Outputs and trace tree
-- For cross-organisational executions ([RFC-009](/rfcs/rfc-009)): the provenance of each accepted value, including the other authority's engine version and regulation hash
+- For cross-organizational executions ([RFC-009](/rfcs/rfc-009)): the provenance of each accepted value, including the other authority's engine version and regulation hash
 - When the execution occurred
 
 The `scope` section is what makes the receipt fully reproducible. The engine's output depends on all loaded regulations, not just the one being evaluated. IoC resolution ([RFC-003](/rfcs/rfc-003)) pulls in implementing regulations. Cross-law references resolve against whatever is loaded. Priority rules ([RFC-010](/rfcs/rfc-010)) determine which version of a regulation wins when multiple sources provide it. Two engines with different loaded regulations can produce different results for the same parameters.
@@ -166,7 +166,7 @@ The `loaded_regulations` array lists every regulation the engine had available d
 
 The `scopes` array records which jurisdiction scopes were active (per [RFC-010](/rfcs/rfc-010)). An engine running with scope `GM0363` (Amsterdam) loads different municipal regulations than one running with `GM0384` (Diemen), which changes IoC resolution for national laws that delegate to municipal ordinances.
 
-The `accepted_values` section captures the cross-organisational provenance chain. When engine A accepts a value from engine B, A records B's provenance metadata. To reproduce the full execution, you need A's receipt (which tells you B's engine version and regulation hash) and B's receipt (which B stores in its own Logboek Dataverwerkingen per [RFC-009](/rfcs/rfc-009)).
+The `accepted_values` section captures the cross-organizational provenance chain. When engine A accepts a value from engine B, A records B's provenance metadata. To reproduce the full execution, you need A's receipt (which tells you B's engine version and regulation hash) and B's receipt (which B stores in its own Logboek Dataverwerkingen per [RFC-009](/rfcs/rfc-009)).
 
 ### 3. Schema URL immutability
 
@@ -188,13 +188,13 @@ When a schema version is published, a Git tag `schema-vX.Y.Z` is created. GitHub
 
 The engine embeds schema files at compile time (via `include_str!` in `validate.rs`) and validates by content, not by URL fetch. The URL is a pointer for humans and tooling. Integrity comes from the content hash in the Execution Receipt.
 
-### 4. Multi-organisation reproducibility
+### 4. Multi-organization reproducibility
 
-[RFC-009](/rfcs/rfc-009) defines two resolution modes: **Execute** (compute locally) and **Accept** (take another organisation's authoritative determination). For reproducibility, the Accept path must capture enough provenance to reconstruct the full decision chain.
+[RFC-009](/rfcs/rfc-009) defines two resolution modes: **Execute** (compute locally) and **Accept** (take another organization's authoritative determination). For reproducibility, the Accept path must capture enough provenance to reconstruct the full decision chain.
 
 #### Inter-engine protocol versioning
 
-The inter-engine protocol ([RFC-009](/rfcs/rfc-009) §5) is a public API contract between organisations. It must be versioned independently from the engine. An explicit `api_version` field in every request and response lets organisations running different engine versions communicate:
+The inter-engine protocol ([RFC-009](/rfcs/rfc-009) §5) is a public API contract between organizations. It must be versioned independently from the engine. An explicit `api_version` field in every request and response lets organizations running different engine versions communicate:
 
 ```json
 {
@@ -238,13 +238,13 @@ This RFC extends the [RFC-009](/rfcs/rfc-009) §5 response with engine provenanc
 }
 ```
 
-New fields: `engine`, `engine_version`, `schema_version`, `regulation_hash`, and `has_upstream_accepts`. The last signals whether this value depended on accepted values from yet another organisation, meaning the provenance chain is deeper than two hops.
+New fields: `engine`, `engine_version`, `schema_version`, `regulation_hash`, and `has_upstream_accepts`. The last signals whether this value depended on accepted values from yet another organization, meaning the provenance chain is deeper than two hops.
 
 #### Sealed receipt reproduction
 
-When reproducing a cross-org decision, the engine uses the **sealed accepted values** stored in the Execution Receipt. It does not call other organisations' engines again.
+When reproducing a cross-org decision, the engine uses the **sealed accepted values** stored in the Execution Receipt. It does not call other organizations' engines again.
 
-Why not re-call? The other organisation may now be running a different engine version with different corpus. Re-calling would produce today's answer; reproduction needs last year's. And legally, a *beschikking* (individual decision) stands once issued. The competent authority's determination at the time is a legal fact. Reproducing Org A's decision means re-executing A's computation with A's engine version, A's regulation, and the accepted values A received at the time.
+Why not re-call? The other organization may now be running a different engine version with different corpus. Re-calling would produce today's answer; reproduction needs last year's. And legally, a *beschikking* (individual decision) stands once issued. The competent authority's determination at the time is a legal fact. Reproducing Org A's decision means re-executing A's computation with A's engine version, A's regulation, and the accepted values A received at the time.
 
 **Reproduction steps:**
 
@@ -262,9 +262,9 @@ For **full chain verification** (optional, useful for audit or dispute resolutio
 
 Step 5 proves A's computation is reproducible. Steps 6-8 prove B's determination was correct. Step 5 alone satisfies the legal requirement: A is responsible for A's computation, using B's determination as a legal fact.
 
-#### Version divergence between organisations
+#### Version divergence between organizations
 
-Different organisations will run different engine versions. This is expected and acceptable if:
+Different organizations will run different engine versions. This is expected and acceptable if:
 
 - Each engine version passes the conformance test suite for the schema versions it supports
 - The inter-engine protocol is versioned independently and backward-compatible within a major version
@@ -317,10 +317,10 @@ See [RFC-007](/rfcs/rfc-007#output-provenance) for the hook provenance model.
 
 ### Benefits
 
-- Execution Receipts satisfy Awb Art. 3:46 (motivation), AERIUS (auditability), and EU AI Act Art. 12 (logging). The receipt is the archivable artifact that proves how a computation was performed.
-- Independent versioning lets other organisations build their own engine on their own release cadence.
+- Execution Receipts satisfy AWB Art. 3:46 (motivation), AERIUS (auditability), and EU AI Act Art. 12 (logging). The receipt is the archivable artifact that proves how a computation was performed.
+- Independent versioning lets other organizations build their own engine on their own release cadence.
 - Sealed receipt reproduction makes cross-org decisions traceable and reproducible without requiring cooperation from other orgs at verification time.
-- Versioning the inter-engine protocol separately from the engine lets organisations upgrade at their own pace.
+- Versioning the inter-engine protocol separately from the engine lets organizations upgrade at their own pace.
 - Receipts are additive: they extend `ArticleResult` without changing execution logic. Schema enforcement and CI checks can be rolled out phase by phase.
 - The engine declares which schemas it supports. Adding a schema version doesn't break old regulations. Dropping support is an explicit, versioned decision.
 
@@ -390,7 +390,7 @@ See [RFC-007](/rfcs/rfc-007#output-provenance) for the hook provenance model.
 
 - [RFC-003: Inversion of Control](/rfcs/rfc-003) — cross-law `open_terms` and `implements`
 - [RFC-006: Language Choice](/rfcs/rfc-006) — deterministic execution as core requirement
-- [RFC-009: Multi-Organisation Execution](/rfcs/rfc-009) — Execute/Accept model, inter-engine protocol, trace model
+- [RFC-009: Multi-Organization Execution](/rfcs/rfc-009) — Execute/Accept model, inter-engine protocol, trace model
 - [RFC-010: Federated Corpus](/rfcs/rfc-010) — corpus distribution, temporal consistency via Git refs
 - [RFC-012: Untranslatables](/rfcs/rfc-012) — handling constructs beyond engine expressiveness
 - AERIUS I (ECLI:NL:RVS:2017:1259) — transparency and auditability of automated government decisions
@@ -398,6 +398,6 @@ See [RFC-007](/rfcs/rfc-007#output-provenance) for the hook provenance model.
 - SyRI ruling (ECLI:NL:RBDHA:2020:865) — transparency requirements for government algorithms
 - [EU AI Act Art. 12](https://artificialintelligenceact.eu/article/12/) — record-keeping for high-risk AI systems
 - [W3C PROV Data Model](https://www.w3.org/TR/prov-dm/) — provenance standard (Execution Receipt draws on Entity/Activity/Agent model)
-- [Logboek Dataverwerkingen](https://logius-standaarden.github.io/logboek-dataverwerkingen/) — Dutch standard for per-organisation data processing logs
+- [Logboek Dataverwerkingen](https://logius-standaarden.github.io/logboek-dataverwerkingen/) — Dutch standard for per-organization data processing logs
 - [MDTO](https://www.nationaalarchief.nl/archiveren/mdto) — Dutch government metadata standard for durable information access
 - [Glossary of Dutch Legal Terms](/reference/glossary)

--- a/docs/src/content/rfcs/rfc-013.md
+++ b/docs/src/content/rfcs/rfc-013.md
@@ -309,7 +309,7 @@ The `results` section of the Execution Receipt includes an `output_provenance` m
 
 This serves two purposes:
 - **Audit trail**: which mechanism produced each output (direct execution, hook, or lex specialis override)
-- **Privacy-by-design filtering**: the multi-output API uses provenance to decide what to include — requested outputs plus causally-entailed hook/override outputs, but never unrelated outputs from other articles
+- **Privacy-by-design filtering**: the multi-output API uses provenance to decide what to include, requested outputs plus causally-entailed hook/override outputs, but never unrelated outputs from other articles
 
 See [RFC-007](/rfcs/rfc-007#output-provenance) for the hook provenance model.
 
@@ -388,16 +388,16 @@ See [RFC-007](/rfcs/rfc-007#output-provenance) for the hook provenance model.
 
 ## References
 
-- [RFC-003: Inversion of Control](/rfcs/rfc-003) — cross-law `open_terms` and `implements`
-- [RFC-006: Language Choice](/rfcs/rfc-006) — deterministic execution as core requirement
-- [RFC-009: Multi-Organization Execution](/rfcs/rfc-009) — Execute/Accept model, inter-engine protocol, trace model
-- [RFC-010: Federated Corpus](/rfcs/rfc-010) — corpus distribution, temporal consistency via Git refs
-- [RFC-012: Untranslatables](/rfcs/rfc-012) — handling constructs beyond engine expressiveness
-- AERIUS I (ECLI:NL:RVS:2017:1259) — transparency and auditability of automated government decisions
-- AERIUS II (ECLI:NL:RVS:2018:2454) — reinforced AERIUS I requirements
-- SyRI ruling (ECLI:NL:RBDHA:2020:865) — transparency requirements for government algorithms
-- [EU AI Act Art. 12](https://artificialintelligenceact.eu/article/12/) — record-keeping for high-risk AI systems
-- [W3C PROV Data Model](https://www.w3.org/TR/prov-dm/) — provenance standard (Execution Receipt draws on Entity/Activity/Agent model)
-- [Logboek Dataverwerkingen](https://logius-standaarden.github.io/logboek-dataverwerkingen/) — Dutch standard for per-organization data processing logs
-- [MDTO](https://www.nationaalarchief.nl/archiveren/mdto) — Dutch government metadata standard for durable information access
+- [RFC-003: Inversion of Control](/rfcs/rfc-003), cross-law `open_terms` and `implements`
+- [RFC-006: Language Choice](/rfcs/rfc-006), deterministic execution as core requirement
+- [RFC-009: Multi-Organization Execution](/rfcs/rfc-009), Execute/Accept model, inter-engine protocol, trace model
+- [RFC-010: Federated Corpus](/rfcs/rfc-010), corpus distribution, temporal consistency via Git refs
+- [RFC-012: Untranslatables](/rfcs/rfc-012), handling constructs beyond engine expressiveness
+- AERIUS I (ECLI:NL:RVS:2017:1259), transparency and auditability of automated government decisions
+- AERIUS II (ECLI:NL:RVS:2018:2454), reinforced AERIUS I requirements
+- SyRI ruling (ECLI:NL:RBDHA:2020:865), transparency requirements for government algorithms
+- [EU AI Act Art. 12](https://artificialintelligenceact.eu/article/12/), record-keeping for high-risk AI systems
+- [W3C PROV Data Model](https://www.w3.org/TR/prov-dm/), provenance standard (Execution Receipt draws on Entity/Activity/Agent model)
+- [Logboek Dataverwerkingen](https://logius-standaarden.github.io/logboek-dataverwerkingen/), Dutch standard for per-organization data processing logs
+- [MDTO](https://www.nationaalarchief.nl/archiveren/mdto), Dutch government metadata standard for durable information access
 - [Glossary of Dutch Legal Terms](/reference/glossary)

--- a/docs/src/content/rfcs/rfc-013.md
+++ b/docs/src/content/rfcs/rfc-013.md
@@ -274,7 +274,7 @@ Two engine implementations that correctly implement the same schema version must
 
 ### 5. Compliance requirements as machine-readable regulations
 
-The compliance requirements in this RFC (provenance fields, schema immutability) are themselves rules about how the system must behave. In a platform that executes machine-readable law: can these compliance rules be expressed as regelrecht regulations?
+The compliance requirements in this RFC (provenance fields, schema immutability) are themselves rules about how the system must behave. In a platform that executes machine-readable law: can these compliance rules be expressed as RegelRecht regulations?
 
 The engine's operation set is designed for computation over citizen data (arithmetic, comparison, conditional logic). It cannot introspect the execution environment. A compliance regulation could define what fields a Execution Receipt must contain, but the engine cannot verify its own output structure or inspect other regulations' metadata. The compliance YAML would need external inputs (`engine_version_present: true/false` supplied by a test harness) to produce a verdict.
 

--- a/docs/src/content/rfcs/rfc-014.md
+++ b/docs/src/content/rfcs/rfc-014.md
@@ -318,7 +318,7 @@ A new CI job `conformance` runs alongside the existing `test` job. It uses the `
 
 - [RFC-003: Inversion of Control](/rfcs/rfc-003), `open_terms` and `implements` (IoC conformance level)
 - [RFC-007: Reactive Execution](/rfcs/rfc-007), hooks and overrides (Advanced conformance level)
-- [RFC-008: Procedures](/rfcs/rfc-008), AWB procedure lifecycle (Advanced conformance level)
+- [RFC-008: Procedures](/rfcs/rfc-008), Awb procedure lifecycle (Advanced conformance level)
 - [RFC-012: Untranslatables](/rfcs/rfc-012), handling constructs beyond engine expressiveness (Advanced conformance level)
 - [RFC-013: Execution Provenance](/rfcs/rfc-013), Execution Receipt format (provenance conformance tests)
 - [JSON Schema Test Suite](https://github.com/json-schema-org/JSON-Schema-Test-Suite), model for language-agnostic conformance testing

--- a/docs/src/content/rfcs/rfc-014.md
+++ b/docs/src/content/rfcs/rfc-014.md
@@ -208,7 +208,7 @@ Levels without new operations (cross_law, ioc, advanced) have an empty `operatio
 
 ### 4. Coverage invariant
 
-The engine defines `Operation::SCHEMA_OPERATIONS` — a const array of all operations that are part of the schema specification (excluding backward-compat aliases like NOT_EQUALS). An integration test (`conformance_coverage.rs`) reads the manifest and verifies:
+The engine defines `Operation::SCHEMA_OPERATIONS`, a const array of all operations that are part of the schema specification (excluding backward-compat aliases like NOT_EQUALS). An integration test (`conformance_coverage.rs`) reads the manifest and verifies:
 
 1. Every entry in `SCHEMA_OPERATIONS` appears in at least one conformance level
 2. Every operation in the manifest exists in `SCHEMA_OPERATIONS` (no phantom operations)
@@ -316,11 +316,11 @@ A new CI job `conformance` runs alongside the existing `test` job. It uses the `
 
 ## References
 
-- [RFC-003: Inversion of Control](/rfcs/rfc-003) — `open_terms` and `implements` (IoC conformance level)
-- [RFC-007: Reactive Execution](/rfcs/rfc-007) — hooks and overrides (Advanced conformance level)
-- [RFC-008: Procedures](/rfcs/rfc-008) — AWB procedure lifecycle (Advanced conformance level)
-- [RFC-012: Untranslatables](/rfcs/rfc-012) — handling constructs beyond engine expressiveness (Advanced conformance level)
-- [RFC-013: Execution Provenance](/rfcs/rfc-013) — Execution Receipt format (provenance conformance tests)
-- [JSON Schema Test Suite](https://github.com/json-schema-org/JSON-Schema-Test-Suite) — model for language-agnostic conformance testing
-- [W3C Web Platform Tests](https://web-platform-tests.org/) — model for multi-implementation conformance testing at scale
+- [RFC-003: Inversion of Control](/rfcs/rfc-003), `open_terms` and `implements` (IoC conformance level)
+- [RFC-007: Reactive Execution](/rfcs/rfc-007), hooks and overrides (Advanced conformance level)
+- [RFC-008: Procedures](/rfcs/rfc-008), AWB procedure lifecycle (Advanced conformance level)
+- [RFC-012: Untranslatables](/rfcs/rfc-012), handling constructs beyond engine expressiveness (Advanced conformance level)
+- [RFC-013: Execution Provenance](/rfcs/rfc-013), Execution Receipt format (provenance conformance tests)
+- [JSON Schema Test Suite](https://github.com/json-schema-org/JSON-Schema-Test-Suite), model for language-agnostic conformance testing
+- [W3C Web Platform Tests](https://web-platform-tests.org/), model for multi-implementation conformance testing at scale
 - [Glossary of Dutch Legal Terms](/reference/glossary)

--- a/docs/src/content/rfcs/rfc-014.md
+++ b/docs/src/content/rfcs/rfc-014.md
@@ -11,7 +11,7 @@ title: "RFC-014: Engine Conformance Test Suite"
 
 ## Context
 
-[RFC-013](/rfcs/rfc-013) establishes that the schema is a specification and the engine is an implementation. Independent versioning allows third-party organisations to build their own engine. Without a shared behavioral contract, though, two engines claiming to support schema v0.5.1 might produce different outputs for identical inputs, with no way to determine which is correct.
+[RFC-013](/rfcs/rfc-013) establishes that the schema is a specification and the engine is an implementation. Independent versioning allows third-party organizations to build their own engine. Without a shared behavioral contract, though, two engines claiming to support schema v0.5.1 might produce different outputs for identical inputs, with no way to determine which is correct.
 
 Today, the RegelRecht engine's correctness is verified through BDD tests (`features/*.feature`) using cucumber-rs. These are Rust-specific. A third-party Java or Python engine cannot run them. The tests verify integration behavior (loading regulations from the corpus, resolving cross-law references), not isolated schema-level operations. There is no artifact that says "if your engine supports schema v0.5.1, these are the exact inputs and outputs it must produce."
 
@@ -254,7 +254,7 @@ A new CI job `conformance` runs alongside the existing `test` job. It uses the `
 
 ### Benefits
 
-- Any organisation can build an engine and prove it behaves correctly by running the conformance suite. No Rust toolchain required.
+- Any organization can build an engine and prove it behaves correctly by running the conformance suite. No Rust toolchain required.
 - The schema specifies structure; the conformance suite specifies what each operation *does*. Together they are the complete specification.
 - If an engine change causes a conformance test to fail, it is a behavioral change that must be intentional and versioned (per [RFC-013](/rfcs/rfc-013)).
 - Third-party engines can start at Core level and work up. They do not need the full operation set to be useful for simple law evaluation.

--- a/docs/src/content/rfcs/rfc-014.md
+++ b/docs/src/content/rfcs/rfc-014.md
@@ -301,7 +301,7 @@ A new CI job `conformance` runs alongside the existing `test` job. It uses the `
 
 **Phase 4: Documentation and third-party guide**
 - Write a guide for third-party engine implementers: how to run the suite, how to declare conformance level, how to report results
-- Add conformance badge specification (e.g., "regelrecht conformant: Core v0.5.1")
+- Add conformance badge specification (e.g., "RegelRecht conformant: Core v0.5.1")
 
 **Affected components**
 

--- a/docs/src/content/rfcs/rfc-014.md
+++ b/docs/src/content/rfcs/rfc-014.md
@@ -13,7 +13,7 @@ title: "RFC-014: Engine Conformance Test Suite"
 
 [RFC-013](/rfcs/rfc-013) establishes that the schema is a specification and the engine is an implementation. Independent versioning allows third-party organisations to build their own engine. Without a shared behavioral contract, though, two engines claiming to support schema v0.5.1 might produce different outputs for identical inputs, with no way to determine which is correct.
 
-Today, the regelrecht engine's correctness is verified through BDD tests (`features/*.feature`) using cucumber-rs. These are Rust-specific. A third-party Java or Python engine cannot run them. The tests verify integration behavior (loading regulations from the corpus, resolving cross-law references), not isolated schema-level operations. There is no artifact that says "if your engine supports schema v0.5.1, these are the exact inputs and outputs it must produce."
+Today, the RegelRecht engine's correctness is verified through BDD tests (`features/*.feature`) using cucumber-rs. These are Rust-specific. A third-party Java or Python engine cannot run them. The tests verify integration behavior (loading regulations from the corpus, resolving cross-law references), not isolated schema-level operations. There is no artifact that says "if your engine supports schema v0.5.1, these are the exact inputs and outputs it must produce."
 
 Three things depend on this:
 
@@ -236,15 +236,15 @@ The initial conformance test suite is derived from the existing BDD features. Th
 1. For each Gherkin scenario in `features/*.feature`, extract the regulation YAML, input parameters, and expected outputs
 2. Decompose integration scenarios into isolated operation-level tests where possible
 3. Add edge cases not covered by the BDD scenarios (null handling, empty arrays, boundary values, negative numbers)
-4. Validate by running the conformance suite against the regelrecht Rust engine
+4. Validate by running the conformance suite against the RegelRecht Rust engine
 
-The BDD features remain as integration tests for the regelrecht engine. The conformance suite is the portable subset.
+The BDD features remain as integration tests for the RegelRecht engine. The conformance suite is the portable subset.
 
 ### 7. CI integration
 
 The conformance suite is validated in CI:
 
-- On every PR: run the regelrecht engine against the full conformance suite for all supported schema versions
+- On every PR: run the RegelRecht engine against the full conformance suite for all supported schema versions
 - On schema changes: verify that new schema versions include conformance tests and that existing tests still pass
 - On engine changes: verify that no conformance test regresses
 
@@ -265,7 +265,7 @@ A new CI job `conformance` runs alongside the existing `test` job. It uses the `
 - The test suite must be maintained alongside the schema. Every new operation or semantic change requires new or updated tests.
 - The suite can only test documented behavior. Undocumented edge cases (how does DIVIDE handle division by zero? what happens when AGE is computed for a future date?) must be decided and encoded as tests. Writing conformance tests for these forces a decision that was previously deferred.
 - Covering all operations, types, and edge cases produces many tests. The suite will grow with each schema version.
-- Passing the suite does not guarantee identical behavior for all possible inputs, only for the tested cases. Mutation testing and property-based testing (Rust-specific) complement it for the regelrecht engine.
+- Passing the suite does not guarantee identical behavior for all possible inputs, only for the tested cases. Mutation testing and property-based testing (Rust-specific) complement it for the RegelRecht engine.
 
 ### Alternatives Considered
 
@@ -286,7 +286,7 @@ A new CI job `conformance` runs alongside the existing `test` job. It uses the `
 **Phase 1: Test format and Core level**
 - Define the JSON test format (as described above)
 - Write Core-level tests covering all arithmetic, comparison, logical, and conditional operations
-- Add a Rust-based test runner that executes the conformance suite against the regelrecht engine
+- Add a Rust-based test runner that executes the conformance suite against the RegelRecht engine
 - Add `conformance` job to CI
 
 **Phase 2: Cross-law and IoC levels**

--- a/docs/src/content/rfcs/rfc-014.md
+++ b/docs/src/content/rfcs/rfc-014.md
@@ -2,10 +2,12 @@
 title: "RFC-014: Engine Conformance Test Suite"
 ---
 
-**Status:** Draft
+**Status:** Draft (partially implemented)
 **Date:** 2026-04-02
 **Authors:** Eelco Hotting
 **Depends on:** RFC-013 (Execution Provenance)
+
+> **Implementation note.** The core of this RFC exists: a conformance manifest (`conformance/v0.5.0/manifest.json`) and a CI test (`packages/engine/tests/conformance_coverage.rs`) that fails when a schema operation is not covered by a conformance level. The full multi-version suite envisioned here is not complete (only the v0.5.0 manifest is present so far).
 
 ## Context
 

--- a/docs/src/content/rfcs/rfc-015.md
+++ b/docs/src/content/rfcs/rfc-015.md
@@ -162,7 +162,7 @@ Policy lookups (layer rank, scope matching) must be fast. The current hardcoded 
 - Rejected: documentation doesn't make the knowledge auditable or adaptable. Organizations still need to fork.
 
 **Alternative 2: Express domain knowledge as law YAML in the corpus**
-- Create a synthetic "regelrecht engine law" in the corpus.
+- Create a synthetic "RegelRecht engine law" in the corpus.
 - Rejected: the corpus contains real law. Engine operating rules are meta-rules about how to process law. Mixing them creates confusion about what is legally authoritative.
 
 **Alternative 3: Rust configuration file (TOML/JSON) without overlay**

--- a/docs/src/content/rfcs/rfc-015.md
+++ b/docs/src/content/rfcs/rfc-015.md
@@ -5,7 +5,7 @@ title: "RFC-015: Engine Policy"
 **Status:** Proposed
 **Date:** 2026-04-04
 **Authors:** Eelco Hotting
-**Depends on:** RFC-007 (Cross-Law Execution), RFC-009 (Multi-Organisation Execution), RFC-013 (Execution Provenance)
+**Depends on:** RFC-007 (Cross-Law Execution), RFC-009 (Multi-Organization Execution), RFC-013 (Execution Provenance)
 
 ## Context
 
@@ -198,7 +198,7 @@ Policy lookups (layer rank, scope matching) must be fast. The current hardcoded 
 - [RFC-003: Inversion of Control](/rfcs/rfc-003) — IoC pattern that the policy overlay mechanism mirrors
 - [RFC-007: Cross-Law Execution](/rfcs/rfc-007) — established the zero-domain-knowledge principle
 - [RFC-008: Bestuursrecht/AWB](/rfcs/rfc-008) — reinforced the principle for Easter/public holidays
-- [RFC-009: Multi-Organisation Execution](/rfcs/rfc-009) — per-organization customization requirement
+- [RFC-009: Multi-Organization Execution](/rfcs/rfc-009) — per-organization customization requirement
 - [RFC-013: Execution Provenance](/rfcs/rfc-013) — Execution Receipt that must capture the active policy
 - [#472: Extract hardcoded domain knowledge](https://github.com/MinBZK/regelrecht/issues/472) — detailed inventory of all hardcoded domain knowledge
 - [How It Works](/concepts/how-it-works) — states the zero-domain-knowledge principle

--- a/docs/src/content/rfcs/rfc-015.md
+++ b/docs/src/content/rfcs/rfc-015.md
@@ -197,7 +197,7 @@ Policy lookups (layer rank, scope matching) must be fast. The current hardcoded 
 
 - [RFC-003: Inversion of Control](/rfcs/rfc-003), IoC pattern that the policy overlay mechanism mirrors
 - [RFC-007: Cross-Law Execution](/rfcs/rfc-007), established the zero-domain-knowledge principle
-- [RFC-008: Bestuursrecht/AWB](/rfcs/rfc-008), reinforced the principle for Easter/public holidays
+- [RFC-008: Bestuursrecht/Awb](/rfcs/rfc-008), reinforced the principle for Easter/public holidays
 - [RFC-009: Multi-Organization Execution](/rfcs/rfc-009), per-organization customization requirement
 - [RFC-013: Execution Provenance](/rfcs/rfc-013), Execution Receipt that must capture the active policy
 - [#472: Extract hardcoded domain knowledge](https://github.com/MinBZK/regelrecht/issues/472), detailed inventory of all hardcoded domain knowledge

--- a/docs/src/content/rfcs/rfc-015.md
+++ b/docs/src/content/rfcs/rfc-015.md
@@ -195,11 +195,11 @@ Policy lookups (layer rank, scope matching) must be fast. The current hardcoded 
 
 ## References
 
-- [RFC-003: Inversion of Control](/rfcs/rfc-003) — IoC pattern that the policy overlay mechanism mirrors
-- [RFC-007: Cross-Law Execution](/rfcs/rfc-007) — established the zero-domain-knowledge principle
-- [RFC-008: Bestuursrecht/AWB](/rfcs/rfc-008) — reinforced the principle for Easter/public holidays
-- [RFC-009: Multi-Organization Execution](/rfcs/rfc-009) — per-organization customization requirement
-- [RFC-013: Execution Provenance](/rfcs/rfc-013) — Execution Receipt that must capture the active policy
-- [#472: Extract hardcoded domain knowledge](https://github.com/MinBZK/regelrecht/issues/472) — detailed inventory of all hardcoded domain knowledge
-- [How It Works](/concepts/how-it-works) — states the zero-domain-knowledge principle
+- [RFC-003: Inversion of Control](/rfcs/rfc-003), IoC pattern that the policy overlay mechanism mirrors
+- [RFC-007: Cross-Law Execution](/rfcs/rfc-007), established the zero-domain-knowledge principle
+- [RFC-008: Bestuursrecht/AWB](/rfcs/rfc-008), reinforced the principle for Easter/public holidays
+- [RFC-009: Multi-Organization Execution](/rfcs/rfc-009), per-organization customization requirement
+- [RFC-013: Execution Provenance](/rfcs/rfc-013), Execution Receipt that must capture the active policy
+- [#472: Extract hardcoded domain knowledge](https://github.com/MinBZK/regelrecht/issues/472), detailed inventory of all hardcoded domain knowledge
+- [How It Works](/concepts/how-it-works), states the zero-domain-knowledge principle
 - [Glossary of Dutch Legal Terms](/reference/glossary)

--- a/docs/src/content/rfcs/rfc-018.md
+++ b/docs/src/content/rfcs/rfc-018.md
@@ -824,7 +824,7 @@ The right pane's segmented control gains a third option, labelled **Notities**:
 
 - **Linking notes make interpretation auditable.** Every connection between text
   and `machine_readable` logic is an explicit, reviewable note. This supports the
-  reasoning requirement (*motiveringsplicht*, AWB 3:46): the chain from law text to
+  reasoning requirement (*motiveringsplicht*, Awb 3:46): the chain from law text to
   computation can be inspected by citizens, courts, and oversight bodies.
 
 - **Ambiguity is tracked without freezing a vocabulary.** Interpretation research

--- a/docs/src/content/rfcs/rfc-018.md
+++ b/docs/src/content/rfcs/rfc-018.md
@@ -748,9 +748,9 @@ resolved positions, renders `<mark>` spans. Each span carries:
 > but the checkout is cloned once per traject and not pulled before each
 > read. Under horizontal scaling, or if the traject branch is updated
 > out-of-band, a replica can read a stale base. Append-only bounds the
-> blast radius — the worst case is a dedup miss or a non-fast-forward push
+> blast radius, the worst case is a dedup miss or a non-fast-forward push
 > that fails loudly, not the silent loss of others' notes the `/data`
-> mirror caused — but a strict cross-replica guarantee needs a
+> mirror caused, but a strict cross-replica guarantee needs a
 > pull-before-read (or a single-writer assumption) and is not yet built.
 >
 > Every note's `target.source` must resolve to the law the path names. The

--- a/docs/src/content/rfcs/rfc-018.md
+++ b/docs/src/content/rfcs/rfc-018.md
@@ -833,7 +833,7 @@ The right pane's segmented control gains a third option, labelled **Notities**:
 
 - **W3C standard enables interoperability.** The format works with Hypothesis,
   Apache Annotator, and Recogito. External parties can produce notes without the
-  regelrecht editor.
+  RegelRecht editor.
 
 - **Rust resolver is the single source of truth.** The same resolver runs in the
   engine (CI validation, server-side) and the browser (WASM). No divergence

--- a/docs/src/content/rfcs/rfc-018.md
+++ b/docs/src/content/rfcs/rfc-018.md
@@ -5,7 +5,7 @@ title: "RFC-018: Note Infrastructure: Storage, Resolution, and Editor Integratio
 **Status:** Accepted
 **Date:** 2026-05-18
 **Authors:** Anne Schuth
-**Depends on:** RFC-005 (Stand-off Notes), RFC-009 (Multi-Organisation Execution), RFC-010 (Federated Corpus)
+**Depends on:** RFC-005 (Stand-off Notes), RFC-009 (Multi-Organization Execution), RFC-010 (Federated Corpus)
 
 ## Terminology
 
@@ -47,18 +47,18 @@ directly onto the open design questions raised in interpretation discussions:
 
 Two other RFCs shape the infrastructure:
 
-- **[RFC-009](./rfc-009)** (Multi-Organisation Execution) introduces
+- **[RFC-009](./rfc-009)** (Multi-Organization Execution) introduces
   `competent_authority` (*bevoegd gezag*) as the boundary that determines who can
   authoritatively execute what. The same concept applies to notes: the competent
   authority's note linking text to `machine_readable` represents the official
-  interpretation (*gezaghebbende interpretatie*). Other organisations, legal
+  interpretation (*gezaghebbende interpretatie*). Other organizations, legal
   experts, and citizens can bring their own notes alongside, as advisory
   perspectives, not as the authoritative reading.
 
 - **[RFC-010](./rfc-010)** (Federated Corpus) introduces a "bring your own
   regulations" model where municipalities (*gemeenten*), provinces (*provincies*),
-  and other organisations maintain laws in their own repositories. Notes need the
-  same federated model: any organisation can annotate any law from their own
+  and other organizations maintain laws in their own repositories. Notes need the
+  same federated model: any organization can annotate any law from their own
   perspective, in their own repository.
 
 ### Current state
@@ -74,7 +74,7 @@ Provenance), so it became RFC-016. RFC-016 in turn collided with the open
 PR #510, which uses that number for Collection Operations (foreach). RFC-016 is
 the older claim, so the note infrastructure RFC takes the next free number,
 **RFC-018** (`rfc-011` was never used; `rfc-016` and `rfc-017` are claimed by
-PR #510). PR #328 is closed in favour of this RFC.
+PR #510). PR #328 is closed in favor of this RFC.
 
 ## Decision
 
@@ -157,7 +157,7 @@ annotations:
 ### 2. Federated note sources
 
 Notes follow the same "bring your own" pattern as laws in [RFC-010](/rfcs/rfc-010). Any
-organisation can maintain notes in their own repository, alongside their
+organization can maintain notes in their own repository, alongside their
 regulations or in a dedicated note repository.
 
 **Required structure in a source repository:**
@@ -197,7 +197,7 @@ context of their municipal social assistance (*bijstand*) policy.
 notes but not committed.
 
 **Loading order:** the engine loads notes from all registered sources. Notes from
-different sources are **layered**, not prioritised (see Decision 7).
+different sources are **layered**, not prioritized (see Decision 7).
 
 ### 3. Note authority and provenance
 
@@ -214,7 +214,7 @@ law determines the note's authority level.
 
 The authority level is **derived at display time**, not stored. It follows the
 same principle as [RFC-009](/rfcs/rfc-009)'s execute/accept boundary: the law determines authority,
-the engine derives behaviour.
+the engine derives behavior.
 
 **Derivation logic:**
 
@@ -222,7 +222,7 @@ the engine derives behaviour.
 Is the note's creator the competent_authority for the target law?
   YES → Authoritative
   NO  →
-    Is the creator a government organisation?
+    Is the creator a government organization?
       YES → Advisory
       NO  →
         Is the creator an automated tool?
@@ -573,7 +573,7 @@ impl WasmEngine {
 4. Orphaned note: text fully removed
 5. Ambiguous match: common word without context
 6. Unique with context: prefix/suffix disambiguation
-7. Hint optimisation: correct hint
+7. Hint optimization: correct hint
 8. Hint fallback: outdated hint
 
 Plus ambiguity scenarios (Decision 6): a `questioning` note with
@@ -584,7 +584,7 @@ a `workflow: resolved` variant.
 
 Notes from different sources **layer**: they do not conflict. This is
 fundamentally different from laws, where [RFC-010](/rfcs/rfc-010) uses priority to resolve `$id`
-collisions. Two organisations can both annotate the same text fragment; both notes
+collisions. Two organizations can both annotate the same text fragment; both notes
 are valid and visible.
 
 **Layering model:**
@@ -667,7 +667,7 @@ warning-not-error stance mirrors how orphaned notes are reported (Decision 8).
                                                   ┌─────────────────────┐
                                                   │  AnnotatedText.vue  │
                                                   │  <mark> spans with  │
-                                                  │  colour by motivation│
+                                                  │  color by motivation│
                                                   └─────────────────────┘
 ```
 
@@ -683,7 +683,7 @@ warning-not-error stance mirrors how orphaned notes are reported (Decision 8).
 A variant of `ArticleText.vue` for the editor's Tekst pane. Takes article text and
 resolved positions, renders `<mark>` spans. Each span carries:
 
-- background colour by motivation (linking: blue, commenting: yellow, questioning:
+- background color by motivation (linking: blue, commenting: yellow, questioning:
   orange, tagging: green)
 - border style by authority (authoritative: solid, advisory: dashed, generated:
   dotted)
@@ -876,7 +876,7 @@ Rejected: duplicates the fuzzy matching algorithm. The engine needs resolution f
 CI validation; a separate JS implementation would diverge. WASM compiles the same
 Rust code for the browser.
 
-**Centralised note authority.** Designate one organisation as the note authority
+**Centralized note authority.** Designate one organization as the note authority
 per law. Rejected: does not match [RFC-010](/rfcs/rfc-010)'s federated model or [RFC-009](/rfcs/rfc-009)'s multi-org
 reality. The layering model accommodates multiple legitimate annotators.
 
@@ -939,7 +939,7 @@ ambiguity BDD scenarios and one concrete ambiguity note in the corpus.
 ## References
 
 - [RFC-005: Stand-off Notes for Legal Texts](./rfc-005): note format specification
-- [RFC-009: Multi-Organisation Execution](./rfc-009): competent authority boundaries
+- [RFC-009: Multi-Organization Execution](./rfc-009): competent authority boundaries
 - [RFC-010: Federated Corpus](./rfc-010): federated source model
 - [RFC-003: Inversion of Control](./rfc-003): `open_terms` and `implements`
 - [W3C Web Annotation Data Model](https://www.w3.org/TR/annotation-model/)

--- a/docs/src/lib/landing-content.ts
+++ b/docs/src/lib/landing-content.ts
@@ -272,7 +272,7 @@ export const content: Record<'nl' | 'en', LandingContent> = {
         {
           title: 'Execution engine',
           meta: 'Rust + WebAssembly',
-          link: { label: 'Documentatie', href: '/docs/components/engine' },
+          link: { label: 'Documentatie', href: '/components/engine' },
           text: 'Een deterministische execution engine die de YAML-regels uitvoert. Werkt in Rust en compileert naar WebAssembly zodat dezelfde regels in de browser en op de server hetzelfde resultaat geven.',
         },
         {
@@ -283,7 +283,7 @@ export const content: Record<'nl' | 'en', LandingContent> = {
         {
           title: 'Editor',
           meta: 'Werk in uitvoering',
-          link: { label: 'Documentatie', href: '/docs/components/editor-api' },
+          link: { label: 'Documentatie', href: '/components/editor-api' },
           text: 'Een werkomgeving waarin juristen wetten machine-uitvoerbaar kunnen maken. We zijn aan het ontdekken hoe deze editor er precies uit moet zien.',
         },
         {
@@ -294,7 +294,7 @@ export const content: Record<'nl' | 'en', LandingContent> = {
         {
           title: 'Corpus',
           meta: 'Git-gebaseerd',
-          link: { label: 'Documentatie', href: '/docs/components/corpus' },
+          link: { label: 'Documentatie', href: '/components/corpus' },
           text: 'De bibliotheek van machine-uitvoerbare regels. Git verzorgt de versiegeschiedenis; een registry verbindt verschillende bronnen tot één geheel.',
         },
         {
@@ -718,7 +718,7 @@ export const content: Record<'nl' | 'en', LandingContent> = {
         {
           title: 'Execution engine',
           meta: 'Rust + WebAssembly',
-          link: { label: 'Documentation', href: '/docs/components/engine' },
+          link: { label: 'Documentation', href: '/components/engine' },
           text: 'A deterministic execution engine that runs the YAML rules. Written in Rust and compiled to WebAssembly so the same rules give the same result in the browser and on the server.',
         },
         {
@@ -729,7 +729,7 @@ export const content: Record<'nl' | 'en', LandingContent> = {
         {
           title: 'Editor',
           meta: 'Work in progress',
-          link: { label: 'Documentation', href: '/docs/components/editor-api' },
+          link: { label: 'Documentation', href: '/components/editor-api' },
           text: 'A working environment for legal experts to make laws machine-executable. We are still discovering what this editor should look like.',
         },
         {
@@ -740,7 +740,7 @@ export const content: Record<'nl' | 'en', LandingContent> = {
         {
           title: 'Corpus',
           meta: 'Git-based',
-          link: { label: 'Documentation', href: '/docs/components/corpus' },
+          link: { label: 'Documentation', href: '/components/corpus' },
           text: 'The library of machine-executable rules. Git handles the version history; a registry ties different sources into a single whole.',
         },
         {

--- a/docs/src/lib/sidebar.ts
+++ b/docs/src/lib/sidebar.ts
@@ -1,7 +1,6 @@
 /*
- * Documentation sidebar structure, ported verbatim from the former
- * VitePress themeConfig.sidebar object literal. Single source of truth for
- * the per-section navigation; the /rfcs/ group items come from rfcs.ts so
+ * Documentation sidebar structure. Single source of truth for the
+ * per-section navigation; the /rfcs/ group items come from rfcs.ts so
  * the RFC list cannot drift from the actual rfc-*.md files.
  */
 import { rfcSidebarItems } from './rfcs';


### PR DESCRIPTION
Volledige nachtelijke pass over alle documentatie: rendering-bugs, inconsistenties, taalfouten, ontbrekende links, en afstemming tussen documentatie en implementatie. Elke feitelijke correctie is geverifieerd tegen de broncode (engine, schema, corpus, workflows) en daarna gecontroleerd door een aparte verificatie-audit.

## Rendering
- **MDX-tabellen renderden als ruwe tekst** (o.a. de Design Principles-tabel): `remark-gfm` ingeschakeld zodat pijp-tabellen echte `<table>`s worden die het design system stylet.
- **Twee dode VitePress `:::`-directives** die als letterlijke tekst toonden, vervangen door blockquotes. De volledige repo is geveegd: VitePress is nu helemaal weg (incl. verouderde `--vp-*`-comments).
- Mermaid, code-viewers en tabellen visueel geverifieerd in light- én dark-mode.

## Links
- Zes landingspagina-links (`/docs/components/*` -> `/components/*`, waren 404 in productie).
- Eén dode externe link (KEI) vervangen door de werkende pagina.
- **Nieuw: `scripts/check-links.mjs`** in de a11y-gate, zodat dode interne links en anchors voortaan de build laten falen.

## Documentatie vs implementatie
Geverifieerd tegen de code en gecorrigeerd:
- engine.md + law-format.md: echte 21 schema-operaties, juiste IF/datum-syntax, compat-alias-noot, LIST gebruikt `items`.
- pipeline.md: state-machine 8 -> 10 states.
- editor-api.md, corpus.md, frontend.md (echte `nldd-*`-componenten, API-backed data, gebundelde editor-api), harvester (CVDR), ci-cd.md (BDD niet in CI), deployment.md (editor-gating, pipeline-api).
- schema.md-structuur, adding-a-law.md + testing.md (echte Gherkin), multi-org `competent_authority`-plaatsing + proposed-framing, onjuist leeftijd/BRP-voorbeeld verwijderd, architecture-diagram aangevuld.
- RFC-012/013/014 implementatienoten; issue-phased-implementation gemarkeerd als opgelost.

## Taal
- Productnaam overal `RegelRecht` in proza.
- Amerikaans-Engelse spelling (heft de Multi-Organisation/Organization-titeltegenspraak op); Awb -> AWB.
- Alle 253 em-dashes uit proza verwijderd conform huisstijl (code/diagram blijven).

## Verificatie
- Volledige a11y-gate groen: 71/71 URLs, 0 fouten; link-, heading- en mermaid-checks groen.
- Aparte adversariële audit van alle edits; gevonden fouten (LIST-veld, tabelcel-artefacten, komma-splitsingen) hersteld.