### PR TITLE
docs: add descriptive context to documentation overviews

### DIFF
--- a/docs/src/content/docs/auth-and-roles.md
+++ b/docs/src/content/docs/auth-and-roles.md
@@ -1,5 +1,6 @@
 ---
 title: "Authentication & Roles"
+description: "The layered role model that gates the editor and harvester-admin services, and how it maps to Keycloak."
 ---
 
 This page describes the role model that gates the editor and harvester-admin

--- a/docs/src/content/docs/components/admin.md
+++ b/docs/src/content/docs/components/admin.md
@@ -1,5 +1,6 @@
 ---
 title: "Admin Dashboard"
+description: "The web dashboard operators use to monitor and control the harvester pipeline."
 ---
 
 The admin dashboard is a web application for operators to monitor and control the harvester pipeline.

--- a/docs/src/content/docs/components/corpus.md
+++ b/docs/src/content/docs/components/corpus.md
@@ -1,5 +1,6 @@
 ---
 title: "Corpus Library"
+description: "The shared Rust crate for loading, parsing, and validating the YAML regulation corpus."
 ---
 
 The corpus library is a shared Rust crate for loading and managing the regulation corpus. It abstracts over multiple source types (local filesystem and GitHub repositories) and handles YAML parsing, registry management, and schema validation.

--- a/docs/src/content/docs/components/editor-api.md
+++ b/docs/src/content/docs/components/editor-api.md
@@ -1,5 +1,6 @@
 ---
 title: "Editor API"
+description: "The Rust backend behind the law editor, serving the frontend and corpus REST endpoints."
 ---
 
 The editor API is a lightweight HTTP server that backs the law editor frontend. It serves the compiled frontend and provides REST endpoints for corpus access.

--- a/docs/src/content/docs/components/engine.md
+++ b/docs/src/content/docs/components/engine.md
@@ -1,5 +1,6 @@
 ---
 title: "Execution Engine"
+description: "The deterministic Rust runtime at the core of RegelRecht that evaluates machine-readable law."
 ---
 
 The execution engine is the core of RegelRecht: a deterministic Rust runtime that evaluates machine-readable Dutch law.

--- a/docs/src/content/docs/components/frontend.md
+++ b/docs/src/content/docs/components/frontend.md
@@ -1,5 +1,6 @@
 ---
 title: "Frontend"
+description: "The Vue 3 law editor and library browser for working with machine-readable law."
 ---
 
 The frontend is a law editor and library browser built with Vue 3 and Vite.

--- a/docs/src/content/docs/components/grafana.md
+++ b/docs/src/content/docs/components/grafana.md
@@ -1,5 +1,6 @@
 ---
 title: "Grafana Monitoring"
+description: "Provisioned monitoring dashboards and alerting for the RegelRecht platform."
 ---
 
 Grafana provides monitoring dashboards and alerting for the RegelRecht platform.

--- a/docs/src/content/docs/components/harvester.md
+++ b/docs/src/content/docs/components/harvester.md
@@ -1,5 +1,6 @@
 ---
 title: "Harvester"
+description: "Downloads Dutch legislation from BWB and CVDR and converts it into the corpus YAML format."
 ---
 
 The harvester downloads Dutch legislation and converts it to the RegelRecht YAML format. It handles two sources: national law from the BWB (Basiswettenbestand / wetten.nl) and decentralized regulations from the CVDR (Centrale Voorziening Decentrale Regelgeving). The CLI picks the right source from the identifier, so `BWBR…` IDs are fetched from BWB and `CVDR…` IDs from the CVDR.

--- a/docs/src/content/docs/components/lawmaking.md
+++ b/docs/src/content/docs/components/lawmaking.md
@@ -1,5 +1,6 @@
 ---
 title: "Lawmaking Frontend"
+description: "Visualizes the Dutch legislative process as an interactive, step-through flow diagram."
 ---
 
 The lawmaking frontend visualizes the Dutch legislative process as an interactive flow diagram.

--- a/docs/src/content/docs/components/pipeline.md
+++ b/docs/src/content/docs/components/pipeline.md
@@ -1,5 +1,6 @@
 ---
 title: "Pipeline"
+description: "A PostgreSQL-backed job queue that orchestrates and tracks the law-processing workflow."
 ---
 
 The pipeline is a PostgreSQL-backed job queue and law status tracking system that orchestrates the law processing workflow.

--- a/docs/src/content/docs/components/tui.md
+++ b/docs/src/content/docs/components/tui.md
@@ -1,5 +1,6 @@
 ---
 title: "Terminal UI (TUI)"
+description: "An interactive terminal dashboard for browsing the corpus and running the engine."
 ---
 
 The TUI is an interactive terminal dashboard for developers working with the regulation corpus and engine.

--- a/docs/src/content/docs/concepts/branches-of-law.md
+++ b/docs/src/content/docs/concepts/branches-of-law.md
@@ -1,5 +1,6 @@
 ---
 title: "Branches of Law"
+description: "How well the major branches of Dutch law map to rule-based execution, and the research questions they raise."
 ---
 
 RegelRecht makes Dutch law machine-readable and executable. Some branches of law lend themselves to this better than others. This page surveys the major branches, how well they map to rule-based execution, and what research questions they raise.

--- a/docs/src/content/docs/concepts/cross-law-references.md
+++ b/docs/src/content/docs/concepts/cross-law-references.md
@@ -1,5 +1,6 @@
 ---
 title: "Cross-Law References"
+description: "How a law declares what it needs from other laws, and how the engine resolves those references automatically."
 ---
 
 Dutch laws reference each other constantly. The Healthcare Allowance Act (*Zorgtoeslagwet*) needs your income, which is defined by the Awir. It needs your insurance status, which comes from the Zorgverzekeringswet. It needs to know whether you have an allowance partner, which the Awir determines.

--- a/docs/src/content/docs/concepts/execution-provenance.md
+++ b/docs/src/content/docs/concepts/execution-provenance.md
@@ -1,5 +1,6 @@
 ---
 title: "Execution Provenance"
+description: "How every result can be reproduced later by pinning the regulation, schema, and engine version."
 ---
 
 Government agencies must be able to reproduce a specific decision months or years later, with the exact same result. Dutch administrative law requires this (Awb Art. 3:46, the AERIUS rulings), and the EU AI Act makes it mandatory for high-risk systems from August 2026.

--- a/docs/src/content/docs/concepts/federated-corpus.md
+++ b/docs/src/content/docs/concepts/federated-corpus.md
@@ -1,5 +1,6 @@
 ---
 title: "Federated Corpus"
+description: "How each authority can maintain its own regulations in its own repository, discovered through a registry."
 ---
 
 Dutch legislation is produced by many authorities: Parliament, ministers, 342 municipalities, 12 provinces, 21 water boards. Maintaining all regulations in a single repository does not match this reality.

--- a/docs/src/content/docs/concepts/hooks-and-reactive-execution.md
+++ b/docs/src/content/docs/concepts/hooks-and-reactive-execution.md
@@ -1,5 +1,6 @@
 ---
 title: "Hooks and Reactive Execution"
+description: "How cross-cutting laws like the Awb apply to decisions automatically, without being called explicitly."
 ---
 
 Some laws apply to every government decision without being called explicitly. The General Administrative Law Act (Algemene wet bestuursrecht, Awb) is the main example: whenever any government body issues a formal decision (*beschikking*), Awb rules about reasoning requirements, objection periods, and notification deadlines kick in automatically.

--- a/docs/src/content/docs/concepts/how-it-works.md
+++ b/docs/src/content/docs/concepts/how-it-works.md
@@ -1,5 +1,6 @@
 ---
 title: "How RegelRecht Works"
+description: "A plain-language walkthrough of the core ideas behind turning legislation into executable files."
 ---
 
 RegelRecht turns Dutch legislation into structured files that a computer can execute. This page explains the core ideas.

--- a/docs/src/content/docs/concepts/inversion-of-control.md
+++ b/docs/src/content/docs/concepts/inversion-of-control.md
@@ -1,5 +1,6 @@
 ---
 title: "Inversion of Control"
+description: "How legal delegation is modeled with open terms in higher laws and implementations in lower regulations."
 ---
 
 Dutch law has a hierarchy. Parliament passes a *wet* (formal law), which often delegates specifics to a minister or municipality. The Healthcare Allowance Act says the minister sets the standard premium. The Participation Act says municipalities set sanctions policy.

--- a/docs/src/content/docs/concepts/law-format.md
+++ b/docs/src/content/docs/concepts/law-format.md
@@ -1,5 +1,6 @@
 ---
 title: "Law Format"
+description: "The article-based YAML format for machine-readable law, conforming to the official JSON schema."
 ---
 
 Laws in RegelRecht are stored as YAML files conforming to the [law schema](/reference/schema). Each file represents one law at a specific point in time.

--- a/docs/src/content/docs/concepts/multi-org-execution.md
+++ b/docs/src/content/docs/concepts/multi-org-execution.md
@@ -1,5 +1,6 @@
 ---
 title: "Multi-Organization Execution"
+description: "How the engine handles organizational boundaries, distinguishing formal decisions from calculations."
 ---
 
 In practice, different government organizations handle different parts of the law chain. The Tax Authority determines your income. The Allowances Service determines your healthcare allowance. A municipality determines your social assistance.

--- a/docs/src/content/docs/concepts/untranslatables.md
+++ b/docs/src/content/docs/concepts/untranslatables.md
@@ -1,5 +1,6 @@
 ---
 title: "Untranslatables"
+description: "The legal constructs that cannot be faithfully expressed with the engine's operations, and how they are handled."
 ---
 
 The engine's operation set is deliberately small: arithmetic, comparison, conditional logic, date operations. Dutch law regularly uses constructs that fall outside this set. When a legal construct cannot be faithfully expressed with available operations, it is an **untranslatable**.

--- a/docs/src/content/docs/concepts/validation-methodology.md
+++ b/docs/src/content/docs/concepts/validation-methodology.md
@@ -1,5 +1,6 @@
 ---
 title: "RegelRecht Validation: From Analysis-First to Execution-First"
+description: "The full research background for RegelRecht's execution-first validation method, fifteen years in the making."
 ---
 
 ## Problem statement

--- a/docs/src/content/docs/guide/architecture.md
+++ b/docs/src/content/docs/guide/architecture.md
@@ -1,6 +1,6 @@
 ---
 title: "System Overview"
-description: "A high-level tour of the two pillars — the Corpus Juris and the Execution Engine — and how the pieces fit."
+description: "A high-level tour of the two pillars, the Corpus Juris and the Execution Engine, and how the pieces fit."
 ---
 
 RegelRecht is built on two pillars: the **Corpus Juris** (a git-versioned body of all Dutch law) and the **Execution Engine** (a runtime that evaluates laws deterministically).

--- a/docs/src/content/docs/guide/architecture.md
+++ b/docs/src/content/docs/guide/architecture.md
@@ -1,5 +1,6 @@
 ---
 title: "System Overview"
+description: "A high-level tour of the two pillars — the Corpus Juris and the Execution Engine — and how the pieces fit."
 ---
 
 RegelRecht is built on two pillars: the **Corpus Juris** (a git-versioned body of all Dutch law) and the **Execution Engine** (a runtime that evaluates laws deterministically).

--- a/docs/src/content/docs/guide/dev-environment.md
+++ b/docs/src/content/docs/guide/dev-environment.md
@@ -1,5 +1,6 @@
 ---
 title: "Development Environment"
+description: "How the local stack runs — infrastructure in Docker and application services natively with hot reload."
 ---
 
 ## Architecture

--- a/docs/src/content/docs/guide/dev-environment.md
+++ b/docs/src/content/docs/guide/dev-environment.md
@@ -1,6 +1,6 @@
 ---
 title: "Development Environment"
-description: "How the local stack runs — infrastructure in Docker and application services natively with hot reload."
+description: "How the local stack runs: infrastructure in Docker and application services natively with hot reload."
 ---
 
 ## Architecture

--- a/docs/src/content/docs/guide/getting-started.md
+++ b/docs/src/content/docs/guide/getting-started.md
@@ -1,5 +1,6 @@
 ---
 title: "Getting Started"
+description: "From a fresh clone to a built engine and a passing test suite."
 ---
 
 ## Prerequisites

--- a/docs/src/content/docs/guide/testing.md
+++ b/docs/src/content/docs/guide/testing.md
@@ -1,5 +1,6 @@
 ---
 title: "Testing"
+description: "The testing strategies RegelRecht uses, led by Gherkin BDD scenarios run with cucumber-rs."
 ---
 
 RegelRecht uses multiple testing strategies to ensure correctness.

--- a/docs/src/content/docs/guide/translation-examples.md
+++ b/docs/src/content/docs/guide/translation-examples.md
@@ -1,5 +1,6 @@
 ---
 title: "Translation Examples"
+description: "Worked examples of translating Dutch law into machine-readable YAML, with the reasoning behind each choice."
 ---
 
 This page shows how Dutch law is translated into machine-readable YAML, with detailed reasoning about why specific patterns are chosen.

--- a/docs/src/content/docs/guide/what-is-regelrecht.mdx
+++ b/docs/src/content/docs/guide/what-is-regelrecht.mdx
@@ -1,5 +1,6 @@
 ---
 title: What is RegelRecht?
+description: An introduction to RegelRecht and its goal — making Dutch law executable as machine-readable files.
 ---
 
 import DocsFeatureCards from '~/components/DocsFeatureCards.astro';

--- a/docs/src/content/docs/guide/what-is-regelrecht.mdx
+++ b/docs/src/content/docs/guide/what-is-regelrecht.mdx
@@ -1,6 +1,6 @@
 ---
 title: What is RegelRecht?
-description: An introduction to RegelRecht and its goal — making Dutch law executable as machine-readable files.
+description: An introduction to RegelRecht and its goal of making Dutch law executable as machine-readable files.
 ---
 
 import DocsFeatureCards from '~/components/DocsFeatureCards.astro';

--- a/docs/src/content/docs/operations/adding-a-law.md
+++ b/docs/src/content/docs/operations/adding-a-law.md
@@ -1,5 +1,6 @@
 ---
 title: "Adding a Law"
+description: "A step-by-step walkthrough from downloading a law's text to running tests against it."
 ---
 
 This guide walks through adding a new law to the corpus, from downloading the legal text to running tests against it.

--- a/docs/src/content/docs/operations/ci-cd.md
+++ b/docs/src/content/docs/operations/ci-cd.md
@@ -1,5 +1,6 @@
 ---
 title: "CI/CD Pipeline"
+description: "What runs on every push and pull request, and how only the checks relevant to changed files run."
 ---
 
 Continuous integration runs on every push to `main` and every pull request via `.github/workflows/ci.yml`. Only checks relevant to changed files run, keeping CI fast.

--- a/docs/src/content/docs/operations/contributing.md
+++ b/docs/src/content/docs/operations/contributing.md
@@ -1,5 +1,6 @@
 ---
 title: "Contributing"
+description: "The branching model, quality checks, and workflow for contributing to RegelRecht."
 ---
 
 RegelRecht is open source and welcomes contributions. This page covers the workflow.

--- a/docs/src/content/docs/operations/deployment.md
+++ b/docs/src/content/docs/operations/deployment.md
@@ -1,5 +1,6 @@
 ---
 title: "Deployment"
+description: "How components are built and deployed to ZAD (RIG/Quattro/rijksapps) through GitHub Actions."
 ---
 
 All components are deployed to ZAD (RIG/Quattro/rijksapps) via GitHub Actions. Docker images are pushed to GitHub Container Registry (GHCR).

--- a/docs/src/content/docs/operations/private-repo-trajects.md
+++ b/docs/src/content/docs/operations/private-repo-trajects.md
@@ -1,5 +1,6 @@
 ---
 title: "Private-repo trajects"
+description: "Hoe een traject aan een eigen (private) GitHub-repo gekoppeld wordt in plaats van de centrale corpus-repo."
 ---
 
 Vanaf [PR #704](https://github.com/MinBZK/regelrecht/pull/704) kan een traject in de editor gekoppeld worden aan een **eigen GitHub-repo** in plaats van de centrale `MinBZK/regelrecht-corpus`. Handig voor organisaties of teams die hun regelgeving in een private repo willen beheren, met behoud van RegelRecht's editor- en attributie-eigenschappen.

--- a/docs/src/content/docs/reference/glossary.md
+++ b/docs/src/content/docs/reference/glossary.md
@@ -1,5 +1,6 @@
 ---
 title: "Glossary"
+description: "Dutch legal and technical terms used across RegelRecht, with English translations."
 ---
 
 Dutch legal terminology used throughout RegelRecht, with English translations.

--- a/docs/src/content/docs/reference/issues/issue-article-id-collision.md
+++ b/docs/src/content/docs/reference/issues/issue-article-id-collision.md
@@ -1,5 +1,6 @@
 ---
 title: "Issue: Article ID Collision (420bis.1)"
+description: "When article numbering produces the same identifier for two different articles, and the proposed fix."
 ---
 
 **Status**: Open

--- a/docs/src/content/docs/reference/issues/issue-phased-implementation.md
+++ b/docs/src/content/docs/reference/issues/issue-phased-implementation.md
@@ -1,5 +1,6 @@
 ---
 title: "Issue #2: Phased Implementation (Gefaseerde Inwerkingtreding)"
+description: "How laws that come into force in phases were handled in the harvester (resolved), kept as background."
 ---
 
 > **Resolved.** This issue is implemented in the harvester. Articles with a `<tussenkop>` version separator are now extracted as a single component (`has_version_separator` / `extract_full_article_content` in `packages/harvester/src/splitting/engine.rs`), and `<redactie>` editorial content is excluded (`is_editorial_content` + the registered `RedactieHandler`). The write-up below is kept as background on the problem and the chosen approach.

--- a/docs/src/content/docs/reference/schema.md
+++ b/docs/src/content/docs/reference/schema.md
@@ -1,5 +1,6 @@
 ---
 title: "Schema Reference"
+description: "The JSON schema every law YAML file must conform to, and how versioned schema URLs work."
 ---
 
 The law format is defined by a JSON Schema. All law YAML files in the corpus must conform to this schema.

--- a/docs/src/lib/navLinks.ts
+++ b/docs/src/lib/navLinks.ts
@@ -33,7 +33,7 @@ export const docsNav: DocsNavItem[] = [
     link: '/concepts/how-it-works',
     match: '/concepts/',
     summary:
-      'The core ideas — how law becomes executable code, references, delegation, and provenance.',
+      'The core ideas: how law becomes executable code, references, delegation, and provenance.',
     intro:
       'The ideas behind RegelRecht: how Dutch legislation is turned into executable code, how laws reference and delegate to one another, and how every result traces back to its legal source.',
   },
@@ -44,7 +44,7 @@ export const docsNav: DocsNavItem[] = [
     summary:
       'The building blocks: engine, corpus, pipeline, harvester, and the user-facing tools.',
     intro:
-      'A tour of the parts that make up RegelRecht — the execution engine and corpus at the core, the processing pipeline and harvester, and the editors and dashboards on top.',
+      'A tour of the parts that make up RegelRecht: the execution engine and corpus at the core, the processing pipeline and harvester, and the editors and dashboards on top.',
   },
   {
     text: 'Operations',
@@ -59,7 +59,7 @@ export const docsNav: DocsNavItem[] = [
     text: 'Auth & Roles',
     link: '/auth-and-roles',
     match: '/auth-and-roles',
-    summary: 'Who can do what — the authorization and role model.',
+    summary: 'Who can do what: the authorization and role model.',
   },
   {
     text: 'RFCs',

--- a/docs/src/lib/navLinks.ts
+++ b/docs/src/lib/navLinks.ts
@@ -11,15 +11,69 @@ export interface DocsNavItem {
   /** Optional NLDD icon name; when set the item shows the icon (text stays
    *  as the accessible label). */
   icon?: string
+  /** One-line summary, shown as supporting text on the /docs overview cards. */
+  summary?: string
+  /** Short intro paragraph, shown in the left column of the category page. */
+  intro?: string
 }
 
 export const docsNav: DocsNavItem[] = [
   { text: 'Home', link: '/en/', match: '/en/' },
-  { text: 'Guide', link: '/guide/what-is-regelrecht', match: '/guide/' },
-  { text: 'Concepts', link: '/concepts/how-it-works', match: '/concepts/' },
-  { text: 'Components', link: '/components/engine', match: '/components/' },
-  { text: 'Operations', link: '/operations/deployment', match: '/operations/' },
-  { text: 'Auth & Roles', link: '/auth-and-roles', match: '/auth-and-roles' },
-  { text: 'RFCs', link: '/rfcs/', match: '/rfcs/' },
-  { text: 'Reference', link: '/reference/glossary', match: '/reference/' },
+  {
+    text: 'Guide',
+    link: '/guide/what-is-regelrecht',
+    match: '/guide/',
+    summary:
+      "Get oriented: what RegelRecht is, how it's built, and how to run it locally.",
+    intro:
+      'Start here. The guide introduces RegelRecht, sketches the architecture, and walks you through getting a development environment running.',
+  },
+  {
+    text: 'Concepts',
+    link: '/concepts/how-it-works',
+    match: '/concepts/',
+    summary:
+      'The core ideas — how law becomes executable code, references, delegation, and provenance.',
+    intro:
+      'The ideas behind RegelRecht: how Dutch legislation is turned into executable code, how laws reference and delegate to one another, and how every result traces back to its legal source.',
+  },
+  {
+    text: 'Components',
+    link: '/components/engine',
+    match: '/components/',
+    summary:
+      'The building blocks: engine, corpus, pipeline, harvester, and the user-facing tools.',
+    intro:
+      'A tour of the parts that make up RegelRecht — the execution engine and corpus at the core, the processing pipeline and harvester, and the editors and dashboards on top.',
+  },
+  {
+    text: 'Operations',
+    link: '/operations/deployment',
+    match: '/operations/',
+    summary:
+      'Running RegelRecht: deployment, CI/CD, and adding laws to the corpus.',
+    intro:
+      'Running RegelRecht in practice: how it is deployed and built through CI/CD, how laws are added to the corpus, and how to contribute changes.',
+  },
+  {
+    text: 'Auth & Roles',
+    link: '/auth-and-roles',
+    match: '/auth-and-roles',
+    summary: 'Who can do what — the authorization and role model.',
+  },
+  {
+    text: 'RFCs',
+    link: '/rfcs/',
+    match: '/rfcs/',
+    summary:
+      'Design decisions, documented: the problem, the alternatives, and the chosen approach.',
+  },
+  {
+    text: 'Reference',
+    link: '/reference/glossary',
+    match: '/reference/',
+    summary: 'Look-ups: glossary, schema, accessibility, and known issues.',
+    intro:
+      'Reference material to look things up: a glossary of terms, the law schema, the accessibility statement, and a record of known issues.',
+  },
 ]

--- a/docs/src/lib/sidebar.ts
+++ b/docs/src/lib/sidebar.ts
@@ -176,6 +176,10 @@ export interface DocsCategory {
   prefix: string;
   /** Display title, from the matching docsNav item. */
   title: string;
+  /** One-line summary, from the matching docsNav item. */
+  summary?: string;
+  /** Intro paragraph for the category page, from the matching docsNav item. */
+  intro?: string;
 }
 
 /**
@@ -184,10 +188,15 @@ export interface DocsCategory {
  * which has its own hand-built index page under src/pages/rfcs/.
  */
 export const docsCategories: DocsCategory[] = Object.keys(sidebar).map(
-  (prefix) => ({
-    prefix,
-    title: docsNav.find((n) => n.match === prefix)?.text ?? prefix,
-  }),
+  (prefix) => {
+    const nav = docsNav.find((n) => n.match === prefix);
+    return {
+      prefix,
+      title: nav?.text ?? prefix,
+      summary: nav?.summary,
+      intro: nav?.intro,
+    };
+  },
 );
 
 /** The category that owns a pathname (article or category page), or null. */

--- a/docs/src/pages/[category]/index.astro
+++ b/docs/src/pages/[category]/index.astro
@@ -1,4 +1,5 @@
 ---
+import { getCollection } from 'astro:content';
 import Base from '~/layouts/Base.astro';
 import { docsCategories, sidebarForPath } from '~/lib/sidebar';
 
@@ -16,6 +17,13 @@ export function getStaticPaths() {
 const { category } = Astro.props;
 const groups = sidebarForPath(category.prefix) ?? [];
 const title = category.title + ' · RegelRecht';
+
+// Per-article descriptions come from each page's frontmatter (the same field
+// shown as the page subtitle), keyed by URL so we can look one up per item.
+// '/' + entry.id matches the link format used throughout the sidebar.
+const descByLink = new Map(
+  (await getCollection('docs')).map((e) => ['/' + e.id, e.data.description]),
+);
 ---
 
 <Base lang="en" kind="docs" pathname={category.prefix} title={title}>
@@ -28,6 +36,16 @@ const title = category.title + ' · RegelRecht';
       <nldd-title size="2">
         <h1>{category.title}</h1>
       </nldd-title>
+      {
+        category.intro && (
+          <Fragment>
+            <nldd-spacer />
+            <nldd-rich-text>
+              <p>{category.intro}</p>
+            </nldd-rich-text>
+          </Fragment>
+        )
+      }
     </div>
     <div slot="right">
       {
@@ -47,7 +65,11 @@ const title = category.title + ' · RegelRecht';
                 .filter((it) => it.link)
                 .map((it) => (
                   <nldd-list-item href={it.link}>
-                    <nldd-text-cell text={it.text} width="full" />
+                    <nldd-text-cell
+                      text={it.text}
+                      supporting-text={descByLink.get(it.link)}
+                      width="full"
+                    />
                     <nldd-spacer-cell />
                     <nldd-icon-cell icon="chevron-right" />
                   </nldd-list-item>

--- a/docs/src/pages/docs/index.astro
+++ b/docs/src/pages/docs/index.astro
@@ -24,7 +24,11 @@ const title = 'Documentation · RegelRecht';
         {
           categories.map((c) => (
             <nldd-list-item href={c.match ?? c.link}>
-              <nldd-text-cell text={c.text} width="full" />
+              <nldd-text-cell
+                text={c.text}
+                supporting-text={c.summary}
+                width="full"
+              />
               <nldd-spacer-cell />
               <nldd-icon-cell icon="chevron-right" />
             </nldd-list-item>


### PR DESCRIPTION
## Why

On the docs site the `/docs` overview and the category pages (`/guide/`, `/concepts/`, …) listed only bare titles with a chevron. It was hard to tell what each section or article contained before clicking. This adds two levels of descriptive context so readers can orient themselves at a glance.

## What

- **`/docs` overview**: each category card now shows a one-line summary under its title.
- **Category pages** (`/guide/`, `/concepts/`, `/components/`, `/operations/`, `/reference/`): an intro paragraph in the left column, plus a one-line description under each article in the list.
- **Article descriptions** come from each page's frontmatter `description` field — the same field already rendered as the page subtitle on article pages. One source of truth: the same text appears as the subtitle and as the overview supporting-text. Filled in for the ~37 articles that lacked one (3 already had it).
- Category `summary`/`intro` copy lives in `navLinks.ts` and is threaded through `sidebar.ts` (`docsCategories`).

## Design system

No new components or custom CSS. Reuses existing NLDD props already used elsewhere in the docs:
- `nldd-text-cell` `supporting-text` (as in `DocsFeatureCards.astro`)
- `nldd-rich-text` + `nldd-spacer` for the intro (as on the RFC overview page)

So the changes inherit NLDD tokens and work in light/dark and on mobile with no styling work.

## Files

- `docs/src/lib/navLinks.ts` — category `summary` + `intro` fields and copy
- `docs/src/lib/sidebar.ts` — thread `summary`/`intro` into `docsCategories`
- `docs/src/pages/docs/index.astro` — supporting-text on category cards
- `docs/src/pages/[category]/index.astro` — intro paragraph + per-article descriptions via a `descByLink` map
- 37 files under `docs/src/content/docs/**` — `description` frontmatter added

## Verification

- `astro sync` runs clean (content collection synced, types generated) — confirms all frontmatter is valid YAML and the page logic type-checks.
- Note: a full `astro build` could not finish locally due to an environmental Playwright/Chromium mismatch needed by the mermaid renderer (`what-is-regelrecht.mdx`), unrelated to these changes. It builds in CI.

## Note for reviewers

*Auth & Roles* is a standalone page rather than a category with sub-pages. Its card on `/docs` gets a summary, but there is no intermediate overview/intro page — the card links straight to the article. This matches the current structure; happy to add an overview page for it if preferred.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X3k34CGrb8U9EjYg7Au1Zh)_