### PR TITLE
feat(editor): redirect naar login bij 401 op api-calls

### DIFF
--- a/frontend/src/composables/useBwbHarvest.js
+++ b/frontend/src/composables/useBwbHarvest.js
@@ -114,6 +114,9 @@ export function useBwbHarvest() {
           startPolling();
         }
       } else if (res.status === 401) {
+        // The global apiAuthGuard (src/lib/apiAuthGuard.js) already redirects to
+        // login on a 401, so this branch rarely renders before navigation; kept
+        // as a graceful fallback for the brief window before the page unloads.
         harvestStatus.value = { ...harvestStatus.value, [bwbId]: 'unauthorized' };
       } else {
         harvestStatus.value = { ...harvestStatus.value, [bwbId]: 'error' };

--- a/frontend/src/lib/apiAuthGuard.js
+++ b/frontend/src/lib/apiAuthGuard.js
@@ -1,4 +1,4 @@
-import { useAuth } from '../composables/useAuth.js';
+import { ensureAuthReady, useAuth } from '../composables/useAuth.js';
 
 // Global 401 interceptor for the editor SPA.
 //
@@ -18,6 +18,12 @@ import { useAuth } from '../composables/useAuth.js';
 //   would loop. Call sites show their own "no access" message.
 // - Only same-origin `/api/*` responses are intercepted, so `/auth/*` (incl.
 //   `/auth/status`), `/data/*`, `/wasm/*` and cross-origin fetches pass through.
+// - 401s on sessions that were never authenticated. Public pages legitimately
+//   call `/api/*` endpoints that 401 without a session (e.g. `/library` loads
+//   `/api/favorites`, which the editor tolerates as "no favorites"), and local
+//   dev runs with OIDC disabled. We only redirect a session that loaded
+//   authenticated against a configured IdP and then got a 401 — i.e. its
+//   session expired. This mirrors the router guard's `oidcConfigured` gate.
 
 /**
  * True when the fetch target is a same-origin `/api/...` URL.
@@ -50,11 +56,19 @@ export function installApiAuthGuard() {
   window.fetch = async (input, init) => {
     const response = await originalFetch(input, init);
     if (response.status === 401 && !redirecting && isApiUrl(input)) {
-      redirecting = true;
-      // No explicit returnUrl: the navigation has already committed, so
-      // window.location reflects the page the user is actually on — exactly
-      // where they should return after re-auth.
-      useAuth().login();
+      // Resolve auth status before deciding: an early `/api/*` 401 can race the
+      // `/auth/status` check, leaving the refs at their defaults otherwise.
+      await ensureAuthReady();
+      const { authenticated, oidcConfigured, login } = useAuth();
+      // Only an expired session (loaded authenticated, IdP configured) redirects.
+      // Anonymous visitors on public pages and OIDC-off dev fall through.
+      if (oidcConfigured.value && authenticated.value && !redirecting) {
+        redirecting = true;
+        // No explicit returnUrl: the navigation has already committed, so
+        // window.location reflects the page the user is actually on — exactly
+        // where they should return after re-auth.
+        login();
+      }
     }
     return response;
   };

--- a/frontend/src/lib/apiAuthGuard.js
+++ b/frontend/src/lib/apiAuthGuard.js
@@ -1,0 +1,61 @@
+import { useAuth } from '../composables/useAuth.js';
+
+// Global 401 interceptor for the editor SPA.
+//
+// The backend runs a BFF/session model: the browser holds an opaque HttpOnly
+// session cookie, never a token. When the session expires the backend answers
+// API calls with 401. Without this guard each call site surfaces a raw "401"
+// error; with it, a 401 on an `/api/*` call bounces the user through
+// `/auth/login?return_url=<current path>` so they re-authenticate (silently if
+// the Keycloak SSO session is still alive) and land back where they were.
+//
+// The router already does this for *navigation* (router.js `beforeEach`); this
+// closes the gap for fetch calls fired while a page is open. We reuse the same
+// `useAuth().login()` redirect so there is one auth path, not two.
+//
+// Deliberately NOT handled here:
+// - 403 (authenticated but missing role) is not a re-login case — redirecting
+//   would loop. Call sites show their own "no access" message.
+// - Only same-origin `/api/*` responses are intercepted, so `/auth/*` (incl.
+//   `/auth/status`), `/data/*`, `/wasm/*` and cross-origin fetches pass through.
+
+/**
+ * True when the fetch target is a same-origin `/api/...` URL.
+ * Accepts the same input shapes as `fetch`: string, URL, or Request.
+ * @param {RequestInfo | URL} input
+ * @returns {boolean}
+ */
+export function isApiUrl(input) {
+  const raw = input instanceof Request ? input.url : input;
+  let url;
+  try {
+    url = new URL(raw, window.location.origin);
+  } catch {
+    return false;
+  }
+  return url.origin === window.location.origin && url.pathname.startsWith('/api/');
+}
+
+// Module-level latch: once a 401 triggers the login redirect we are leaving the
+// page, so further 401s from in-flight calls must not fire a second redirect.
+let redirecting = false;
+
+/**
+ * Wrap `window.fetch` so a 401 on a same-origin `/api/*` call redirects to the
+ * OIDC login. Idempotent-safe to call once at app start (before mount).
+ */
+export function installApiAuthGuard() {
+  const originalFetch = window.fetch.bind(window);
+
+  window.fetch = async (input, init) => {
+    const response = await originalFetch(input, init);
+    if (response.status === 401 && !redirecting && isApiUrl(input)) {
+      redirecting = true;
+      // No explicit returnUrl: the navigation has already committed, so
+      // window.location reflects the page the user is actually on — exactly
+      // where they should return after re-auth.
+      useAuth().login();
+    }
+    return response;
+  };
+}

--- a/frontend/src/lib/apiAuthGuard.js
+++ b/frontend/src/lib/apiAuthGuard.js
@@ -35,7 +35,10 @@ export function isApiUrl(input) {
   const raw = input instanceof Request ? input.url : input;
   let url;
   try {
-    url = new URL(raw, window.location.origin);
+    // Resolve against the full current URL (not just the origin) so bare
+    // relative paths resolve exactly as the browser's fetch does — e.g. on
+    // `/trajects/123`, `fetch('api/x')` hits `/trajects/api/x`, not `/api/x`.
+    url = new URL(raw, window.location.href);
   } catch {
     return false;
   }

--- a/frontend/src/lib/apiAuthGuard.test.js
+++ b/frontend/src/lib/apiAuthGuard.test.js
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Spy for useAuth().login — the guard must call it exactly once on a relevant 401.
+const loginSpy = vi.fn();
+vi.mock('../composables/useAuth.js', () => ({
+  useAuth: () => ({ login: loginSpy }),
+}));
+
+import { isApiUrl } from './apiAuthGuard.js';
+
+// happy-dom serves window.location.origin === 'http://localhost' by default.
+const ORIGIN = window.location.origin;
+
+/**
+ * Install the guard over a stubbed original fetch that resolves to `status`,
+ * then return the wrapped window.fetch. Each call resets the module's redirect
+ * latch by re-importing a fresh module instance.
+ */
+async function freshGuard(status) {
+  vi.resetModules();
+  loginSpy.mockClear();
+  const original = vi.fn().mockResolvedValue({ status });
+  window.fetch = original;
+  const { installApiAuthGuard: install } = await import('./apiAuthGuard.js');
+  install();
+  return { wrapped: window.fetch, original };
+}
+
+describe('isApiUrl', () => {
+  it('matches same-origin /api/ paths (string, URL, Request)', () => {
+    expect(isApiUrl('/api/trajects')).toBe(true);
+    expect(isApiUrl(`${ORIGIN}/api/trajects`)).toBe(true);
+    expect(isApiUrl(new URL('/api/foo', ORIGIN))).toBe(true);
+    expect(isApiUrl(new Request(`${ORIGIN}/api/foo`))).toBe(true);
+  });
+
+  it('rejects /auth/*, /data/*, /wasm/* and other same-origin paths', () => {
+    expect(isApiUrl('/auth/status')).toBe(false);
+    expect(isApiUrl('/auth/login')).toBe(false);
+    expect(isApiUrl('/data/annotations/x.yaml')).toBe(false);
+    expect(isApiUrl('/wasm/pkg/engine.js')).toBe(false);
+    expect(isApiUrl('/library')).toBe(false);
+  });
+
+  it('rejects cross-origin /api/ paths', () => {
+    expect(isApiUrl('https://evil.example/api/x')).toBe(false);
+  });
+});
+
+describe('installApiAuthGuard', () => {
+  beforeEach(() => {
+    loginSpy.mockClear();
+  });
+
+  it('redirects to login on a 401 from an /api/ call', async () => {
+    const { wrapped } = await freshGuard(401);
+    await wrapped('/api/trajects');
+    expect(loginSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT redirect on a 403 (missing role, not a re-login case)', async () => {
+    const { wrapped } = await freshGuard(403);
+    await wrapped('/api/trajects');
+    expect(loginSpy).not.toHaveBeenCalled();
+  });
+
+  it('does NOT redirect on a 401 from /auth/status', async () => {
+    const { wrapped } = await freshGuard(401);
+    await wrapped('/auth/status');
+    expect(loginSpy).not.toHaveBeenCalled();
+  });
+
+  it('does NOT redirect on a 401 from a cross-origin /api/ call', async () => {
+    const { wrapped } = await freshGuard(401);
+    await wrapped('https://other.example/api/x');
+    expect(loginSpy).not.toHaveBeenCalled();
+  });
+
+  it('redirects only once for multiple concurrent 401s (loop guard)', async () => {
+    const { wrapped } = await freshGuard(401);
+    await Promise.all([wrapped('/api/a'), wrapped('/api/b'), wrapped('/api/c')]);
+    expect(loginSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes the original response through unchanged on success', async () => {
+    const { wrapped, original } = await freshGuard(200);
+    const res = await wrapped('/api/trajects', { method: 'POST' });
+    expect(res.status).toBe(200);
+    expect(original).toHaveBeenCalledWith('/api/trajects', { method: 'POST' });
+    expect(loginSpy).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/apiAuthGuard.test.js
+++ b/frontend/src/lib/apiAuthGuard.test.js
@@ -1,9 +1,19 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
-// Spy for useAuth().login — the guard must call it exactly once on a relevant 401.
-const loginSpy = vi.fn();
+// Hoisted shared state: the login spy and the mutable auth refs the guard reads.
+const { loginSpy, authState } = vi.hoisted(() => ({
+  loginSpy: vi.fn(),
+  authState: { authenticated: true, oidcConfigured: true },
+}));
+
 vi.mock('../composables/useAuth.js', () => ({
-  useAuth: () => ({ login: loginSpy }),
+  ensureAuthReady: vi.fn().mockResolvedValue(undefined),
+  useAuth: () => ({
+    // Read authState at call time so a test can set it before the 401 fires.
+    authenticated: { value: authState.authenticated },
+    oidcConfigured: { value: authState.oidcConfigured },
+    login: loginSpy,
+  }),
 }));
 
 import { isApiUrl } from './apiAuthGuard.js';
@@ -12,13 +22,16 @@ import { isApiUrl } from './apiAuthGuard.js';
 const ORIGIN = window.location.origin;
 
 /**
- * Install the guard over a stubbed original fetch that resolves to `status`,
- * then return the wrapped window.fetch. Each call resets the module's redirect
- * latch by re-importing a fresh module instance.
+ * Install the guard over a stubbed original fetch that resolves to `status`.
+ * `auth` overrides the mocked authenticated/oidcConfigured refs (default: an
+ * authenticated session against a configured IdP). A fresh module instance per
+ * call resets the redirect latch.
  */
-async function freshGuard(status) {
+async function freshGuard(status, auth = {}) {
   vi.resetModules();
   loginSpy.mockClear();
+  authState.authenticated = auth.authenticated ?? true;
+  authState.oidcConfigured = auth.oidcConfigured ?? true;
   const original = vi.fn().mockResolvedValue({ status });
   window.fetch = original;
   const { installApiAuthGuard: install } = await import('./apiAuthGuard.js');
@@ -52,10 +65,23 @@ describe('installApiAuthGuard', () => {
     loginSpy.mockClear();
   });
 
-  it('redirects to login on a 401 from an /api/ call', async () => {
+  it('redirects on a 401 from an /api/ call for an authenticated session', async () => {
     const { wrapped } = await freshGuard(401);
     await wrapped('/api/trajects');
     expect(loginSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT redirect an unauthenticated session (anonymous public-page 401)', async () => {
+    // e.g. /library loading /api/favorites without a session — tolerated, no bounce.
+    const { wrapped } = await freshGuard(401, { authenticated: false });
+    await wrapped('/api/favorites');
+    expect(loginSpy).not.toHaveBeenCalled();
+  });
+
+  it('does NOT redirect when OIDC is disabled (local dev)', async () => {
+    const { wrapped } = await freshGuard(401, { oidcConfigured: false, authenticated: false });
+    await wrapped('/api/trajects');
+    expect(loginSpy).not.toHaveBeenCalled();
   });
 
   it('does NOT redirect on a 403 (missing role, not a re-login case)', async () => {

--- a/frontend/src/lib/apiAuthGuard.test.js
+++ b/frontend/src/lib/apiAuthGuard.test.js
@@ -58,6 +58,18 @@ describe('isApiUrl', () => {
   it('rejects cross-origin /api/ paths', () => {
     expect(isApiUrl('https://evil.example/api/x')).toBe(false);
   });
+
+  it('resolves bare relative paths against the document path, like fetch', () => {
+    // On /trajects/123, fetch('api/x') hits /trajects/api/x — NOT an API call.
+    window.history.pushState({}, '', '/trajects/123');
+    try {
+      expect(isApiUrl('api/trajects')).toBe(false);
+      // Absolute paths still match regardless of the document path.
+      expect(isApiUrl('/api/trajects')).toBe(true);
+    } finally {
+      window.history.pushState({}, '', '/');
+    }
+  });
 });
 
 describe('installApiAuthGuard', () => {

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -3,6 +3,11 @@ import '@nldd/design-system/styles';
 import { createApp } from 'vue';
 import App from './App.vue';
 import router from './router.js';
+import { installApiAuthGuard } from './lib/apiAuthGuard.js';
+
+// Catch 401s on /api/* calls fired while a page is open and redirect to login,
+// mirroring the router's navigation guard. Must run before any fetch.
+installApiAuthGuard();
 
 const app = createApp(App);
 app.use(router);


### PR DESCRIPTION
## Probleem

Na sessie-expiry beantwoordt de backend API-calls met **401**, maar de editor-frontend doet daar niets mee: de gebruiker ziet rauwe foutmeldingen ("nieuw traject geeft 401", "Lijst ophalen mislukt: 401"). De router-guard (`router.js` `beforeEach`) vangt 401 alleen bij **navigatie** af, niet bij fetch-calls die op een open pagina worden afgevuurd.

## Oplossing

Eén globale `window.fetch`-wrapper (`src/lib/apiAuthGuard.js`), geïnstalleerd in `main.js` vóór mount. Bij een **401 op een same-origin `/api/*`-call** stuurt hij de gebruiker via het bestaande `useAuth().login()` naar `/auth/login?return_url=<huidig pad>` — her-auth (stil als de Keycloak-SSO nog leeft) en terugkeer op dezelfde plek. Eén auth-pad, geen tweede mechanisme naast de router-guard.

### Bewust afgebakend
- **403** (ingelogd maar mist rol) triggert **géén** redirect — geen re-login-geval, anders ontstaat een loop. Call-sites tonen hun eigen melding.
- Alleen same-origin `/api/*` wordt afgevangen → `/auth/*` (incl. `/auth/status`), `/data/*`, `/wasm/*` en cross-origin blijven ongemoeid.
- **Loop-guard**: meerdere gelijktijdige 401's geven precies één redirect.

## Context

Auth is een BFF-model (`packages/auth`, `tower_sessions`): de browser heeft alleen een HttpOnly session-cookie, geen token. Een client-side 401-redirect is in dit model het juiste gedrag, onafhankelijk van eventuele latere server-side token-refresh.

## Tests

`src/lib/apiAuthGuard.test.js` (vitest): 401→redirect, 403→geen redirect, `/auth/status` 401→geen redirect, cross-origin→geen redirect, loop-guard (1 redirect), 200→response ongewijzigd. Volledige suite groen (228 tests).

## Verificatie (volgt op preview)
Inloggen → session-cookie wissen → `/api`-actie → bevestigen redirect naar `/auth/login` i.p.v. rauwe 401, en terugkeer op dezelfde pagina.
