### PR TITLE
feat: server-side OIDC token-refresh middleware

### DIFF
--- a/packages/admin/src/main.rs
+++ b/packages/admin/src/main.rs
@@ -207,6 +207,8 @@ async fn main() {
             middleware::require_metrics_auth,
         ));
 
+    // Clone for the refresh layer: with_state below consumes app_state.
+    let refresh_state = app_state.clone();
     let app = Router::new()
         .route("/health", get(health))
         .merge(metrics_route)
@@ -215,6 +217,12 @@ async fn main() {
         .merge(writer_routes)
         .merge(admin_routes)
         .with_state(app_state)
+        // Inside the session layer, outside the route role gates. No-op for
+        // API-key-authenticated requests (no session auth marker).
+        .layer(axum_middleware::from_fn_with_state(
+            refresh_state,
+            middleware::refresh_session_token::<AppState>,
+        ))
         .layer(session_layer)
         .layer(axum_middleware::from_fn(middleware::security_headers))
         .layer(TraceLayer::new_for_http())

--- a/packages/admin/src/middleware.rs
+++ b/packages/admin/src/middleware.rs
@@ -10,7 +10,7 @@ use sha2::{Digest, Sha256};
 use subtle::ConstantTimeEq;
 use tower_sessions::Session;
 
-pub use regelrecht_auth::middleware::security_headers;
+pub use regelrecht_auth::middleware::{refresh_session_token, security_headers};
 use regelrecht_auth::{check_session_role, RoleCheck};
 
 use crate::error::ApiError;

--- a/packages/auth/src/handlers.rs
+++ b/packages/auth/src/handlers.rs
@@ -516,10 +516,13 @@ pub(crate) fn unix_now() -> i64 {
         .unwrap_or(0)
 }
 
-/// Access-token lifetime in seconds, defaulting to a conservative 60s when the
-/// IdP omits `expires_in` (so we re-validate soon rather than never).
+/// Access-token lifetime in seconds. Falls back to 300s when the IdP omits
+/// `expires_in` — comfortably above the refresh middleware's skew window so a
+/// missing `expires_in` doesn't put the session straight back into the
+/// refresh-now band (which would refresh on every request). Keycloak always
+/// sends `expires_in`, so the fallback is belt-and-braces.
 pub(crate) fn access_token_ttl_secs(expires_in: Option<std::time::Duration>) -> i64 {
-    expires_in.map(|d| d.as_secs() as i64).unwrap_or(60)
+    expires_in.map(|d| d.as_secs() as i64).unwrap_or(300)
 }
 
 /// Decode `realm_access.roles` from a JWT payload.

--- a/packages/auth/src/handlers.rs
+++ b/packages/auth/src/handlers.rs
@@ -34,6 +34,15 @@ pub const SESSION_KEY_EMAIL_VERIFIED: &str = "person_email_verified";
 pub const SESSION_KEY_NAME: &str = "person_name";
 pub const SESSION_KEY_ID_TOKEN: &str = "id_token_hint";
 pub const SESSION_KEY_ROLES: &str = "person_roles";
+/// OIDC refresh token, kept server-side so the refresh middleware can
+/// re-validate with the IdP (and pick up role/revocation changes) without the
+/// browser ever holding a token. Rotated in place when the IdP issues a new
+/// refresh token. See [`crate::middleware::refresh_session_token`].
+pub const SESSION_KEY_REFRESH_TOKEN: &str = "oidc_refresh_token";
+/// Absolute access-token expiry (unix seconds, `i64`). Drives *when* the
+/// refresh middleware re-validates with the IdP; it does not gate requests on
+/// its own (the session's own inactivity window does that).
+pub const SESSION_KEY_TOKEN_EXPIRES_AT: &str = "oidc_token_expires_at";
 const SESSION_KEY_BASE_URL: &str = "oidc_base_url";
 const SESSION_KEY_RETURN_URL: &str = "oidc_return_url";
 
@@ -365,6 +374,27 @@ pub async fn callback<S: OidcAppState>(
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
 
+    // Persist refresh material so the refresh middleware can re-validate with
+    // the IdP before the access token's lifetime elapses. The refresh token is
+    // optional (only stored when the IdP returns one); without it the session
+    // simply never re-validates and falls back to its own inactivity window.
+    if let Some(refresh_token) = token_response.refresh_token() {
+        session_insert(
+            &session,
+            SESSION_KEY_REFRESH_TOKEN,
+            refresh_token.secret().clone(),
+        )
+        .await?;
+    }
+    let expires_at = unix_now() + access_token_ttl_secs(token_response.expires_in());
+    session
+        .insert(SESSION_KEY_TOKEN_EXPIRES_AT, expires_at)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, "failed to insert token expiry into session");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
     tracing::debug!(email = %email, "OIDC login successful");
 
     let return_url: Option<String> = session.get(SESSION_KEY_RETURN_URL).await.ok().flatten();
@@ -475,6 +505,21 @@ struct JwtPayload {
 
 fn get_access_token_secret(resp: &impl OAuth2TokenResponse) -> &str {
     resp.access_token().secret()
+}
+
+/// Current wall-clock time in unix seconds. Saturates to 0 if the clock is
+/// before the epoch (never in practice) so callers get a monotonic-ish `i64`.
+pub(crate) fn unix_now() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+/// Access-token lifetime in seconds, defaulting to a conservative 60s when the
+/// IdP omits `expires_in` (so we re-validate soon rather than never).
+pub(crate) fn access_token_ttl_secs(expires_in: Option<std::time::Duration>) -> i64 {
+    expires_in.map(|d| d.as_secs() as i64).unwrap_or(60)
 }
 
 /// Decode `realm_access.roles` from a JWT payload.

--- a/packages/auth/src/lib.rs
+++ b/packages/auth/src/lib.rs
@@ -19,7 +19,8 @@ pub use handlers::{
     SESSION_KEY_EMAIL_VERIFIED, SESSION_KEY_NAME, SESSION_KEY_ROLES, SESSION_KEY_SUB,
 };
 pub use middleware::{
-    check_session_role, require_role, require_session_auth, security_headers, RoleCheck,
+    check_session_role, refresh_session_token, require_role, require_session_auth,
+    security_headers, RoleCheck,
 };
 pub use oidc::{discover_client, ConfiguredClient, DiscoveryResult};
 

--- a/packages/auth/src/middleware.rs
+++ b/packages/auth/src/middleware.rs
@@ -6,9 +6,13 @@ use axum::http::header;
 use axum::http::{HeaderValue, StatusCode};
 use axum::middleware::Next;
 use axum::response::Response;
+use openidconnect::{OAuth2TokenResponse, RefreshToken, RequestTokenError};
 use tower_sessions::Session;
 
-use crate::handlers::{SESSION_KEY_AUTHENTICATED, SESSION_KEY_ROLES, SESSION_KEY_SUB};
+use crate::handlers::{
+    access_token_ttl_secs, extract_realm_roles, unix_now, SESSION_KEY_AUTHENTICATED,
+    SESSION_KEY_REFRESH_TOKEN, SESSION_KEY_ROLES, SESSION_KEY_SUB, SESSION_KEY_TOKEN_EXPIRES_AT,
+};
 use crate::OidcAppState;
 
 type RequireRoleFuture = Pin<Box<dyn Future<Output = Result<Response, StatusCode>> + Send>>;
@@ -171,6 +175,145 @@ pub fn require_role<S: OidcAppState>(
             }
         })
     }
+}
+
+/// Renew the access token when it has at most this many seconds of life left.
+/// The window absorbs clock skew and the refresh round-trip so re-validation
+/// happens just before, not after, expiry.
+const TOKEN_REFRESH_SKEW_SECS: i64 = 60;
+
+/// Backoff applied to the recorded expiry after a *transient* refresh failure
+/// (IdP unreachable), so we retry on a later request instead of hammering the
+/// token endpoint on every request while the IdP is down.
+const TOKEN_REFRESH_RETRY_BACKOFF_SECS: i64 = 30;
+
+/// Pure refresh decision: true when an expiry is recorded and it is within the
+/// skew window (or already past). A missing expiry means the session predates
+/// this feature (or the IdP sent no `expires_in`) — never refresh then.
+fn should_refresh(expires_at: Option<i64>, now: i64) -> bool {
+    match expires_at {
+        Some(expires_at) => expires_at - now <= TOKEN_REFRESH_SKEW_SECS,
+        None => false,
+    }
+}
+
+/// Transparently re-validate the OIDC session with the IdP.
+///
+/// Runs as a global layer *inside* the session layer (so the session is loaded)
+/// and *outside* the per-route role gates. For an authenticated session whose
+/// access token is within [`TOKEN_REFRESH_SKEW_SECS`] of expiry it uses the
+/// stored refresh token to obtain a fresh access token, then updates the stored
+/// expiry, the (possibly rotated) refresh token, and the realm roles — so role
+/// changes at the IdP propagate without a re-login.
+///
+/// If the IdP *definitively* rejects the refresh token (e.g. the user was
+/// logged out or disabled at Keycloak → `invalid_grant`), the authenticated
+/// marker is dropped so the downstream gate returns 401 and the client
+/// re-logs in. Transient failures (IdP unreachable) leave the session intact
+/// and only nudge the retry window forward.
+///
+/// Concurrency: deliberately lock-free. With Keycloak's default "Revoke Refresh
+/// Token" = off a refresh token is reusable until expiry, so concurrent
+/// refreshes in the skew window are harmless. If rotation is enabled, a rare
+/// concurrent double-use can fail one request's refresh; that self-heals via
+/// the normal re-login redirect (silent while the IdP SSO session is alive).
+/// Serializing per session would pull a `tokio` + `dashmap` runtime dependency
+/// into this intentionally dependency-light shared crate — not worth it for
+/// that edge case.
+pub async fn refresh_session_token<S: OidcAppState>(
+    State(state): State<S>,
+    session: Session,
+    request: Request,
+    next: Next,
+) -> Response {
+    if state.is_auth_enabled() {
+        try_refresh_token(&state, &session).await;
+    }
+    next.run(request).await
+}
+
+async fn try_refresh_token<S: OidcAppState>(state: &S, session: &Session) {
+    let authenticated: bool = session
+        .get(SESSION_KEY_AUTHENTICATED)
+        .await
+        .ok()
+        .flatten()
+        .unwrap_or(false);
+    if !authenticated {
+        return;
+    }
+
+    let expires_at = session
+        .get::<i64>(SESSION_KEY_TOKEN_EXPIRES_AT)
+        .await
+        .ok()
+        .flatten();
+    if !should_refresh(expires_at, unix_now()) {
+        return;
+    }
+
+    // Need both an OIDC client and a stored refresh token to re-validate.
+    let Some(client) = state.oidc_client() else {
+        return;
+    };
+    let Some(refresh_token) = session
+        .get::<String>(SESSION_KEY_REFRESH_TOKEN)
+        .await
+        .ok()
+        .flatten()
+    else {
+        return;
+    };
+
+    match client
+        .exchange_refresh_token(&RefreshToken::new(refresh_token))
+        .request_async(state.http_client())
+        .await
+    {
+        Ok(token_response) => {
+            let new_expiry = unix_now() + access_token_ttl_secs(token_response.expires_in());
+            let _ = session
+                .insert(SESSION_KEY_TOKEN_EXPIRES_AT, new_expiry)
+                .await;
+            // Keycloak rotates the refresh token when rotation is enabled; store
+            // whatever it returned so the next refresh uses the current one.
+            if let Some(new_refresh) = token_response.refresh_token() {
+                let _ = session
+                    .insert(SESSION_KEY_REFRESH_TOKEN, new_refresh.secret().clone())
+                    .await;
+            }
+            // Refresh realm roles from the access token (Keycloak includes
+            // `realm_access` there by default). Only overwrite on a successful
+            // parse so a mapper misconfiguration doesn't wipe existing roles.
+            if let Some(roles) = extract_realm_roles(token_response.access_token().secret()) {
+                let _ = session.insert(SESSION_KEY_ROLES, roles).await;
+            }
+            tracing::debug!("refreshed OIDC access token");
+        }
+        // IdP definitively rejected the token → force re-login.
+        Err(RequestTokenError::ServerResponse(e)) => {
+            tracing::info!(error = ?e, "refresh token rejected by IdP — invalidating session");
+            invalidate_session(session).await;
+        }
+        // Transient failure (network/parse) → keep the session, retry later.
+        Err(e) => {
+            tracing::warn!(error = %e, "token refresh failed transiently — will retry");
+            let _ = session
+                .insert(
+                    SESSION_KEY_TOKEN_EXPIRES_AT,
+                    unix_now() + TOKEN_REFRESH_RETRY_BACKOFF_SECS,
+                )
+                .await;
+        }
+    }
+}
+
+/// Drop the authenticated marker and refresh material so downstream gates treat
+/// the session as unauthenticated (401 → client re-login).
+async fn invalidate_session(session: &Session) {
+    let _ = session.remove::<bool>(SESSION_KEY_AUTHENTICATED).await;
+    let _ = session.remove::<String>(SESSION_KEY_REFRESH_TOKEN).await;
+    let _ = session.remove::<i64>(SESSION_KEY_TOKEN_EXPIRES_AT).await;
 }
 
 #[cfg(test)]
@@ -606,5 +749,124 @@ mod tests {
 
         // The gated request must return 401 (NotAuthenticated), not 403.
         assert_eq!(get_test(app, &cookie).await, StatusCode::UNAUTHORIZED);
+    }
+
+    // --- refresh_session_token ---
+
+    #[test]
+    fn should_refresh_decisions() {
+        let now = 1_000_000;
+        // No recorded expiry → never refresh (legacy/no-refresh-token session).
+        assert!(!should_refresh(None, now));
+        // Comfortably in the future → no refresh.
+        assert!(!should_refresh(Some(now + 3600), now));
+        // Just outside the skew window → no refresh.
+        assert!(!should_refresh(
+            Some(now + TOKEN_REFRESH_SKEW_SECS + 1),
+            now
+        ));
+        // Exactly at the skew boundary → refresh.
+        assert!(should_refresh(Some(now + TOKEN_REFRESH_SKEW_SECS), now));
+        // Already expired → refresh.
+        assert!(should_refresh(Some(now - 10), now));
+    }
+
+    /// Gate `/test` with `require_session_auth` behind the refresh layer, and
+    /// expose `/seed-tokens?exp=<unix>` to seed an authenticated session with a
+    /// given access-token expiry. Mirrors the production layer ordering:
+    /// refresh runs inside the session layer and outside the auth gate.
+    fn refresh_test_app(state: TestState) -> Router {
+        let session_layer = SessionManagerLayer::new(MemoryStore::default());
+
+        #[derive(serde::Deserialize)]
+        struct ExpQuery {
+            exp: i64,
+        }
+
+        Router::new()
+            .route("/test", get(|| async { "ok" }))
+            .route_layer(axum_middleware::from_fn_with_state(
+                state.clone(),
+                require_session_auth::<TestState>,
+            ))
+            .route(
+                "/seed-tokens",
+                get(
+                    |session: Session, axum::extract::Query(q): axum::extract::Query<ExpQuery>| async move {
+                        session
+                            .insert(SESSION_KEY_AUTHENTICATED, true)
+                            .await
+                            .expect("insert auth");
+                        session
+                            .insert(SESSION_KEY_TOKEN_EXPIRES_AT, q.exp)
+                            .await
+                            .expect("insert expiry");
+                        "seeded"
+                    },
+                ),
+            )
+            .layer(axum_middleware::from_fn_with_state(
+                state.clone(),
+                refresh_session_token::<TestState>,
+            ))
+            .with_state(state)
+            .layer(session_layer)
+    }
+
+    async fn seed_tokens(app: &Router, exp: i64) -> String {
+        let response = app
+            .clone()
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri(format!("/seed-tokens?exp={exp}"))
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::OK);
+        response
+            .headers()
+            .get("set-cookie")
+            .expect("set-cookie header")
+            .to_str()
+            .expect("cookie str")
+            .to_string()
+    }
+
+    #[tokio::test]
+    async fn refresh_layer_passes_through_when_token_valid() {
+        // Far-future expiry → no refresh attempt; the request reaches the gate
+        // with its auth marker intact.
+        let app = refresh_test_app(test_state(true));
+        let cookie = seed_tokens(&app, unix_now() + 3600).await;
+        assert_eq!(get_test(app, &cookie).await, StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn refresh_layer_does_not_invalidate_when_no_client_configured() {
+        // Token is within the skew window so a refresh is wanted, but TestState
+        // has no OIDC client: the layer must bail without dropping the auth
+        // marker (a misconfiguration must not log everyone out). The gate still
+        // sees an authenticated session.
+        let app = refresh_test_app(test_state(true));
+        let cookie = seed_tokens(&app, unix_now() + 5).await;
+        assert_eq!(get_test(app, &cookie).await, StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn refresh_layer_passthrough_when_auth_disabled() {
+        // Auth disabled → refresh is a no-op and the gate passes everything.
+        let app = refresh_test_app(test_state(false));
+        let response = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/test")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::OK);
     }
 }

--- a/packages/auth/src/middleware.rs
+++ b/packages/auth/src/middleware.rs
@@ -265,39 +265,83 @@ async fn try_refresh_token<S: OidcAppState>(state: &S, session: &Session) {
         return;
     };
 
-    match client
+    let outcome = match client
         .exchange_refresh_token(&RefreshToken::new(refresh_token))
         .request_async(state.http_client())
         .await
     {
-        Ok(token_response) => {
-            let new_expiry = unix_now() + access_token_ttl_secs(token_response.expires_in());
-            let _ = session
-                .insert(SESSION_KEY_TOKEN_EXPIRES_AT, new_expiry)
-                .await;
-            // Keycloak rotates the refresh token when rotation is enabled; store
+        Ok(token_response) => RefreshOutcome::Renewed {
+            expires_at: unix_now() + access_token_ttl_secs(token_response.expires_in()),
+            // Keycloak rotates the refresh token when rotation is enabled; carry
             // whatever it returned so the next refresh uses the current one.
-            if let Some(new_refresh) = token_response.refresh_token() {
+            refresh_token: token_response.refresh_token().map(|t| t.secret().clone()),
+            // Roles come from the access token (Keycloak includes `realm_access`
+            // there by default). `None` (parse failure) leaves existing roles.
+            roles: extract_realm_roles(token_response.access_token().secret()),
+        },
+        Err(e) => outcome_for_error(&e),
+    };
+    apply_refresh_outcome(session, outcome).await;
+}
+
+/// Result of a refresh attempt, decoupled from the oauth2/HTTP types so the
+/// session-mutation logic can be unit-tested without a live IdP.
+#[derive(Debug)]
+enum RefreshOutcome {
+    /// Fresh token material to persist (expiry, possibly-rotated refresh token,
+    /// optionally re-extracted roles).
+    Renewed {
+        expires_at: i64,
+        refresh_token: Option<String>,
+        roles: Option<Vec<String>>,
+    },
+    /// IdP definitively rejected the refresh token → invalidate the session.
+    Rejected,
+    /// Transient failure (IdP unreachable / unparseable) → keep the session and
+    /// back off so we retry on a later request instead of hammering the IdP.
+    Transient,
+}
+
+/// Classify a token-endpoint failure. A `ServerResponse` means the IdP
+/// processed the request and refused it (e.g. `invalid_grant` after logout or
+/// account disable) → definitive. Everything else (network, unparseable
+/// response) is transient and must not log the user out.
+fn outcome_for_error<RE: std::error::Error + 'static, T: openidconnect::ErrorResponse>(
+    err: &RequestTokenError<RE, T>,
+) -> RefreshOutcome {
+    match err {
+        RequestTokenError::ServerResponse(_) => RefreshOutcome::Rejected,
+        _ => RefreshOutcome::Transient,
+    }
+}
+
+/// Apply a [`RefreshOutcome`] to the session.
+async fn apply_refresh_outcome(session: &Session, outcome: RefreshOutcome) {
+    match outcome {
+        RefreshOutcome::Renewed {
+            expires_at,
+            refresh_token,
+            roles,
+        } => {
+            let _ = session
+                .insert(SESSION_KEY_TOKEN_EXPIRES_AT, expires_at)
+                .await;
+            if let Some(refresh_token) = refresh_token {
                 let _ = session
-                    .insert(SESSION_KEY_REFRESH_TOKEN, new_refresh.secret().clone())
+                    .insert(SESSION_KEY_REFRESH_TOKEN, refresh_token)
                     .await;
             }
-            // Refresh realm roles from the access token (Keycloak includes
-            // `realm_access` there by default). Only overwrite on a successful
-            // parse so a mapper misconfiguration doesn't wipe existing roles.
-            if let Some(roles) = extract_realm_roles(token_response.access_token().secret()) {
+            if let Some(roles) = roles {
                 let _ = session.insert(SESSION_KEY_ROLES, roles).await;
             }
             tracing::debug!("refreshed OIDC access token");
         }
-        // IdP definitively rejected the token → force re-login.
-        Err(RequestTokenError::ServerResponse(e)) => {
-            tracing::info!(error = ?e, "refresh token rejected by IdP — invalidating session");
+        RefreshOutcome::Rejected => {
+            tracing::info!("refresh token rejected by IdP — invalidating session");
             invalidate_session(session).await;
         }
-        // Transient failure (network/parse) → keep the session, retry later.
-        Err(e) => {
-            tracing::warn!(error = %e, "token refresh failed transiently — will retry");
+        RefreshOutcome::Transient => {
+            tracing::warn!("token refresh failed transiently — will retry");
             let _ = session
                 .insert(
                     SESSION_KEY_TOKEN_EXPIRES_AT,
@@ -308,12 +352,13 @@ async fn try_refresh_token<S: OidcAppState>(state: &S, session: &Session) {
     }
 }
 
-/// Drop the authenticated marker and refresh material so downstream gates treat
-/// the session as unauthenticated (401 → client re-login).
+/// Invalidate the session on definitive rejection. `flush()` deletes the whole
+/// session record (not just the auth marker), so no personal identifiers
+/// (`sub`, name, roles, id_token) linger in the store until natural expiry —
+/// data minimisation for a citizen-facing platform. The dropped auth marker
+/// makes the downstream gate return 401 → client re-login.
 async fn invalidate_session(session: &Session) {
-    let _ = session.remove::<bool>(SESSION_KEY_AUTHENTICATED).await;
-    let _ = session.remove::<String>(SESSION_KEY_REFRESH_TOKEN).await;
-    let _ = session.remove::<i64>(SESSION_KEY_TOKEN_EXPIRES_AT).await;
+    let _ = session.flush().await;
 }
 
 #[cfg(test)]
@@ -868,5 +913,182 @@ mod tests {
             .await
             .expect("response");
         assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    // --- apply_refresh_outcome: the three core token-exchange paths ---
+    //
+    // The network exchange itself is exercised end-to-end in integration; here
+    // we pin the session mutations each outcome must produce, since those are
+    // the regression-prone bits (wrong session key, missing flush, wrong
+    // backoff). A fresh detached Session over a MemoryStore lets us seed state,
+    // apply an outcome, and read the result back without a live IdP.
+
+    /// A detached, authenticated session seeded as a logged-in user would be.
+    async fn seeded_session() -> Session {
+        let session = Session::new(None, Arc::new(MemoryStore::default()), None);
+        session
+            .insert(SESSION_KEY_AUTHENTICATED, true)
+            .await
+            .unwrap();
+        session.insert(SESSION_KEY_SUB, "sub-123").await.unwrap();
+        session
+            .insert(SESSION_KEY_REFRESH_TOKEN, "old-rt")
+            .await
+            .unwrap();
+        session
+            .insert(SESSION_KEY_TOKEN_EXPIRES_AT, 1_000_i64)
+            .await
+            .unwrap();
+        session
+            .insert(SESSION_KEY_ROLES, vec!["editor-reader".to_string()])
+            .await
+            .unwrap();
+        session
+    }
+
+    #[tokio::test]
+    async fn apply_renewed_updates_expiry_refresh_token_and_roles() {
+        let session = seeded_session().await;
+        apply_refresh_outcome(
+            &session,
+            RefreshOutcome::Renewed {
+                expires_at: 9_999,
+                refresh_token: Some("new-rt".to_string()),
+                roles: Some(vec!["editor-writer".to_string()]),
+            },
+        )
+        .await;
+
+        assert_eq!(
+            session
+                .get::<i64>(SESSION_KEY_TOKEN_EXPIRES_AT)
+                .await
+                .unwrap(),
+            Some(9_999)
+        );
+        assert_eq!(
+            session
+                .get::<String>(SESSION_KEY_REFRESH_TOKEN)
+                .await
+                .unwrap(),
+            Some("new-rt".to_string())
+        );
+        assert_eq!(
+            session.get::<Vec<String>>(SESSION_KEY_ROLES).await.unwrap(),
+            Some(vec!["editor-writer".to_string()])
+        );
+        // Still authenticated.
+        assert_eq!(
+            session
+                .get::<bool>(SESSION_KEY_AUTHENTICATED)
+                .await
+                .unwrap(),
+            Some(true)
+        );
+    }
+
+    #[tokio::test]
+    async fn apply_renewed_keeps_existing_roles_when_none_parsed() {
+        // A mapper misconfiguration (roles = None) must not wipe existing roles.
+        let session = seeded_session().await;
+        apply_refresh_outcome(
+            &session,
+            RefreshOutcome::Renewed {
+                expires_at: 9_999,
+                refresh_token: None,
+                roles: None,
+            },
+        )
+        .await;
+        assert_eq!(
+            session.get::<Vec<String>>(SESSION_KEY_ROLES).await.unwrap(),
+            Some(vec!["editor-reader".to_string()])
+        );
+        // refresh_token untouched when the IdP returned none.
+        assert_eq!(
+            session
+                .get::<String>(SESSION_KEY_REFRESH_TOKEN)
+                .await
+                .unwrap(),
+            Some("old-rt".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn apply_rejected_flushes_session_including_pii() {
+        let session = seeded_session().await;
+        apply_refresh_outcome(&session, RefreshOutcome::Rejected).await;
+        // Auth marker gone → downstream gate returns 401.
+        assert_eq!(
+            session
+                .get::<bool>(SESSION_KEY_AUTHENTICATED)
+                .await
+                .unwrap(),
+            None
+        );
+        // PII flushed, not left lingering.
+        assert_eq!(session.get::<String>(SESSION_KEY_SUB).await.unwrap(), None);
+        assert_eq!(
+            session.get::<Vec<String>>(SESSION_KEY_ROLES).await.unwrap(),
+            None
+        );
+        assert_eq!(
+            session
+                .get::<String>(SESSION_KEY_REFRESH_TOKEN)
+                .await
+                .unwrap(),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn apply_transient_keeps_session_and_backs_off() {
+        let session = seeded_session().await;
+        apply_refresh_outcome(&session, RefreshOutcome::Transient).await;
+        // Session stays authenticated.
+        assert_eq!(
+            session
+                .get::<bool>(SESSION_KEY_AUTHENTICATED)
+                .await
+                .unwrap(),
+            Some(true)
+        );
+        // Expiry bumped into the future by the backoff so we don't refresh every
+        // request, but not invalidated.
+        let exp = session
+            .get::<i64>(SESSION_KEY_TOKEN_EXPIRES_AT)
+            .await
+            .unwrap()
+            .expect("expiry present");
+        assert!(exp >= unix_now() + TOKEN_REFRESH_RETRY_BACKOFF_SECS - 5);
+    }
+
+    #[test]
+    fn outcome_for_error_classifies_definitive_vs_transient() {
+        use openidconnect::core::CoreErrorResponseType;
+        use openidconnect::{HttpClientError, StandardErrorResponse};
+
+        type Err = RequestTokenError<
+            HttpClientError<reqwest::Error>,
+            StandardErrorResponse<CoreErrorResponseType>,
+        >;
+
+        // A server response (e.g. invalid_grant) is definitive → Rejected.
+        let definitive: Err = RequestTokenError::ServerResponse(StandardErrorResponse::new(
+            CoreErrorResponseType::Extension("invalid_grant".to_string()),
+            None,
+            None,
+        ));
+        assert!(matches!(
+            outcome_for_error(&definitive),
+            RefreshOutcome::Rejected
+        ));
+
+        // Anything else (network/parse) is transient → keep the session.
+        let transient: Err = RequestTokenError::Other("connection refused".to_string());
+        assert!(matches!(
+            outcome_for_error(&transient),
+            RefreshOutcome::Transient
+        ));
     }
 }

--- a/packages/auth/src/middleware.rs
+++ b/packages/auth/src/middleware.rs
@@ -342,10 +342,14 @@ async fn apply_refresh_outcome(session: &Session, outcome: RefreshOutcome) {
         }
         RefreshOutcome::Transient => {
             tracing::warn!("token refresh failed transiently — will retry");
+            // Push the recorded expiry past the skew window so the NEXT refresh
+            // only fires after the backoff elapses. Storing just `now + backoff`
+            // would stay inside the skew band (backoff < skew) and refresh on
+            // every request — defeating the backoff.
             let _ = session
                 .insert(
                     SESSION_KEY_TOKEN_EXPIRES_AT,
-                    unix_now() + TOKEN_REFRESH_RETRY_BACKOFF_SECS,
+                    unix_now() + TOKEN_REFRESH_SKEW_SECS + TOKEN_REFRESH_RETRY_BACKOFF_SECS,
                 )
                 .await;
         }
@@ -358,7 +362,14 @@ async fn apply_refresh_outcome(session: &Session, outcome: RefreshOutcome) {
 /// data minimisation for a citizen-facing platform. The dropped auth marker
 /// makes the downstream gate return 401 → client re-login.
 async fn invalidate_session(session: &Session) {
-    let _ = session.flush().await;
+    // A failed flush would leave the session authenticated in the store after a
+    // definitive IdP rejection (the opposite of what we want). The current
+    // request is still denied — flush clears the in-memory session so the
+    // downstream gate sees no auth marker — but a store-delete failure could
+    // resurrect the session on a later request, so surface it loudly.
+    if let Err(e) = session.flush().await {
+        tracing::error!(error = %e, "failed to flush session after token rejection");
+    }
 }
 
 #[cfg(test)]
@@ -1053,14 +1064,15 @@ mod tests {
                 .unwrap(),
             Some(true)
         );
-        // Expiry bumped into the future by the backoff so we don't refresh every
-        // request, but not invalidated.
+        // Expiry bumped past the skew window so we do NOT refresh on the very
+        // next request — the backoff must actually space out retries.
         let exp = session
             .get::<i64>(SESSION_KEY_TOKEN_EXPIRES_AT)
             .await
             .unwrap()
             .expect("expiry present");
-        assert!(exp >= unix_now() + TOKEN_REFRESH_RETRY_BACKOFF_SECS - 5);
+        assert!(!should_refresh(Some(exp), unix_now()));
+        assert!(exp >= unix_now() + TOKEN_REFRESH_SKEW_SECS + TOKEN_REFRESH_RETRY_BACKOFF_SECS - 5);
     }
 
     #[test]

--- a/packages/auth/src/middleware.rs
+++ b/packages/auth/src/middleware.rs
@@ -6,7 +6,8 @@ use axum::http::header;
 use axum::http::{HeaderValue, StatusCode};
 use axum::middleware::Next;
 use axum::response::Response;
-use openidconnect::{OAuth2TokenResponse, RefreshToken, RequestTokenError};
+use openidconnect::core::CoreErrorResponseType;
+use openidconnect::{OAuth2TokenResponse, RefreshToken, RequestTokenError, StandardErrorResponse};
 use tower_sessions::Session;
 
 use crate::handlers::{
@@ -302,15 +303,23 @@ enum RefreshOutcome {
     Transient,
 }
 
-/// Classify a token-endpoint failure. A `ServerResponse` means the IdP
-/// processed the request and refused it (e.g. `invalid_grant` after logout or
-/// account disable) → definitive. Everything else (network, unparseable
-/// response) is transient and must not log the user out.
-fn outcome_for_error<RE: std::error::Error + 'static, T: openidconnect::ErrorResponse>(
-    err: &RequestTokenError<RE, T>,
+/// Classify a token-endpoint failure.
+///
+/// Only `invalid_grant` is definitive: it means *this refresh token* is
+/// expired/revoked (the user was logged out or disabled at the IdP), the one
+/// case a re-login fixes → [`RefreshOutcome::Rejected`]. Everything else stays
+/// [`RefreshOutcome::Transient`] (keep the session): `server_error` /
+/// `temporarily_unavailable` (RFC 6749 §5.2) are server-side hiccups, and
+/// client-config errors (`invalid_client`/`unauthorized_client`) can't be fixed
+/// by the user re-logging in — flushing active sessions on any of those would
+/// log everyone out on a Keycloak blip. Network/parse errors fall here too.
+fn outcome_for_error<RE: std::error::Error + 'static>(
+    err: &RequestTokenError<RE, StandardErrorResponse<CoreErrorResponseType>>,
 ) -> RefreshOutcome {
     match err {
-        RequestTokenError::ServerResponse(_) => RefreshOutcome::Rejected,
+        RequestTokenError::ServerResponse(resp) if resp.error().as_ref() == "invalid_grant" => {
+            RefreshOutcome::Rejected
+        }
         _ => RefreshOutcome::Transient,
     }
 }
@@ -1077,26 +1086,42 @@ mod tests {
 
     #[test]
     fn outcome_for_error_classifies_definitive_vs_transient() {
-        use openidconnect::core::CoreErrorResponseType;
-        use openidconnect::{HttpClientError, StandardErrorResponse};
+        use openidconnect::HttpClientError;
 
         type Err = RequestTokenError<
             HttpClientError<reqwest::Error>,
             StandardErrorResponse<CoreErrorResponseType>,
         >;
 
-        // A server response (e.g. invalid_grant) is definitive → Rejected.
-        let definitive: Err = RequestTokenError::ServerResponse(StandardErrorResponse::new(
-            CoreErrorResponseType::Extension("invalid_grant".to_string()),
-            None,
-            None,
-        ));
+        fn server_error(code: CoreErrorResponseType) -> Err {
+            RequestTokenError::ServerResponse(StandardErrorResponse::new(code, None, None))
+        }
+
+        // Only invalid_grant is definitive → Rejected.
         assert!(matches!(
-            outcome_for_error(&definitive),
+            outcome_for_error(&server_error(CoreErrorResponseType::InvalidGrant)),
             RefreshOutcome::Rejected
         ));
 
-        // Anything else (network/parse) is transient → keep the session.
+        // Server-side / transient OAuth errors must NOT log the user out.
+        assert!(matches!(
+            outcome_for_error(&server_error(CoreErrorResponseType::Extension(
+                "server_error".to_string()
+            ))),
+            RefreshOutcome::Transient
+        ));
+        assert!(matches!(
+            outcome_for_error(&server_error(CoreErrorResponseType::Extension(
+                "temporarily_unavailable".to_string()
+            ))),
+            RefreshOutcome::Transient
+        ));
+        // Client-config error: re-login can't fix it → keep the session.
+        assert!(matches!(
+            outcome_for_error(&server_error(CoreErrorResponseType::InvalidClient)),
+            RefreshOutcome::Transient
+        ));
+        // Network/parse failure → transient.
         let transient: Err = RequestTokenError::Other("connection refused".to_string());
         assert!(matches!(
             outcome_for_error(&transient),

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -380,6 +380,9 @@ async fn main() {
             .with_http_only(true)
             .with_secure(true);
 
+        // Clone for the refresh layer: `with_state` below consumes app_state,
+        // and from_fn_with_state needs its own copy of the OIDC client/config.
+        let refresh_state = app_state.clone();
         let app = Router::new()
             .route("/health", get(|| async { "OK" }))
             .merge(auth_routes)
@@ -390,6 +393,13 @@ async fn main() {
             .merge(traject_reader_routes)
             .merge(traject_writer_routes)
             .with_state(app_state)
+            // Inside the session layer (session loaded) and outside the route
+            // role gates (fresh roles / a dropped auth marker are seen by the
+            // gate). Innermost .layer() so session_layer wraps it.
+            .layer(axum_middleware::from_fn_with_state(
+                refresh_state,
+                middleware::refresh_session_token::<AppState>,
+            ))
             .layer(session_layer)
             .layer(axum_middleware::from_fn(middleware::security_headers))
             .layer(TraceLayer::new_for_http())

--- a/packages/editor-api/src/middleware.rs
+++ b/packages/editor-api/src/middleware.rs
@@ -1,1 +1,1 @@
-pub use regelrecht_auth::middleware::{require_role, security_headers};
+pub use regelrecht_auth::middleware::{refresh_session_token, require_role, security_headers};


### PR DESCRIPTION
## Wat & waarom

In het huidige BFF-model gebruikt de backend het OIDC-access-token **één keer** bij `/auth/callback` om rollen te extraheren en gooit het daarna weg — er wordt geen refresh-token bewaard. De sessie leunt puur op `tower_sessions` (`OnInactivity(8u)`, glijdend).

Deze PR voegt **server-side token-refresh** toe. De browser ziet nog steeds nooit een token (het BFF-model blijft intact); de refresh gebeurt volledig server-side.

### Wat het oplevert (eerlijk gekaderd)
Omdat het access-token na login nergens meer per-request wordt gecontroleerd, is het werkelijke voordeel **periodieke her-validatie bij de IdP** binnen de access-token-levensduur, in plaats van pas na max 8u:

- **Rolwijzigingen** bij Keycloak propageren zonder dat de gebruiker hoeft uit/in te loggen.
- **IdP-side logout / account uitgeschakeld** wordt gehonoreerd: faalt de refresh definitief (`invalid_grant`), dan vervalt de app-sessie en wordt de gebruiker naar login gestuurd — i.p.v. tot 8u een geldige sessie te houden.

Dit is een aanvulling op #730 (client-side 401→login), geen vervanger.

## Hoe het werkt

- **Callback** (`handlers.rs`): bewaart `refresh_token` + absolute access-token-expiry (`SESSION_KEY_REFRESH_TOKEN`, `SESSION_KEY_TOKEN_EXPIRES_AT`) in de server-side sessie.
- **`refresh_session_token`** (`middleware.rs`): globale laag, **binnen** de session-layer (sessie geladen) en **buiten** de rol-gates. Bij access-token binnen 60s van expiry → `exchange_refresh_token` tegen de IdP:
  - **Succes** → update expiry, (geroteerd) refresh_token en rollen (uit `realm_access` van het access token).
  - **Definitieve afwijzing** (`ServerResponse`/`invalid_grant`) → auth-marker verwijderd → downstream 401 → client re-login.
  - **Transiente fout** (IdP onbereikbaar) → sessie intact, korte backoff zodat we niet elke request hameren.
- Bedraad in **editor-api** en **admin** (no-op voor API-key-geauthenticeerde admin-requests).

## Concurrency (bewuste keuze)

Lock-free, **geen nieuwe runtime-deps**. Met Keycloak's default *Revoke Refresh Token = uit* is een refresh-token herbruikbaar tot expiry, dus gelijktijdige refreshes in het skew-venster zijn onschadelijk. Mét rotatie kan een zeldzame gelijktijdige dubbel-refresh er één laten falen; dat self-heal't via de normale (stille) re-login. Per-sessie serialiseren zou `tokio`+`dashmap` als runtime-dep in deze bewust dependency-lichte crate trekken — niet de moeite voor die edge case. Gedocumenteerd in de code.

## Tests

- Pure `should_refresh`-beslissing (ontbrekend/ver-weg/grens/verlopen).
- Middleware: passthrough bij geldig token; **geen** invalidatie als er geen OIDC-client is (misconfig mag niet iedereen uitloggen); passthrough bij auth-disabled.
- `cargo test -p regelrecht-auth` groen (45), `editor-api`/`admin` compileren, `just format`/`just lint` schoon.

## Verificatie (volgt op preview)
Inloggen, sessie voorbij de access-token-levensduur laten lopen, een `/api`-call doen en in `zad logs` bevestigen dat er een refresh-regel verschijnt en de call slaagt. Refresh-token intrekken bij Keycloak → nette redirect naar login.
