### PR TITLE
fix(editor): traject blijft actief in de bibliotheek

### DIFF
--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -12,7 +12,7 @@ import { useFeatureFlags } from './composables/useFeatureFlags.js';
 import { useNotes, useResolvedDraftNotes } from './composables/useNotes.js';
 import { useDraftNotes } from './composables/useDraftNotes.js';
 import { useColorScheme } from './composables/useColorScheme.js';
-import { lastLibraryPath } from './composables/useLastVisitedRoute.js';
+import { lastLibraryPath, sectionTarget } from './composables/useLastVisitedRoute.js';
 import { SUPPORT_EMAIL } from './constants.js';
 import ArticleText from './components/ArticleText.vue';
 import AnnotatedText from './components/AnnotatedText.vue';
@@ -163,6 +163,14 @@ const canEditArticleText = computed(() => canEdit.value && isEnabled('editor.art
 
 const route = useRoute();
 const router = useRouter();
+
+// Bibliotheek tab / "naar bibliotheek" buttons: restore the last library
+// position but re-stamp it with the currently active traject, so the
+// traject survives the Editor→Bibliotheek switch (it lives in the URL).
+const libraryTabTarget = computed(() =>
+  sectionTarget(router, lastLibraryPath.value, activeTrajectRef.value),
+);
+const libraryTabHref = computed(() => router.resolve(libraryTabTarget.value).href);
 
 // --- Initial law load (from route params) ---
 const {
@@ -433,7 +441,7 @@ function onSearchSelectLaw(lawIdVal) {
   // Open in the library — search currently only matches law names. As
   // soon as article-level search lands, we can route directly into the
   // editor (with the chosen article as the active tab).
-  router.push(`/library/${encodeURIComponent(lawIdVal)}`);
+  router.push(libraryRouteFor(lawIdVal));
 }
 
 async function onSearchHarvestAvailable(slug) {
@@ -443,7 +451,7 @@ async function onSearchHarvestAvailable(slug) {
     body: JSON.stringify({ law_ids: [slug] }),
   }).catch(() => {});
   await loadCorpusLaws();
-  router.push(`/library/${encodeURIComponent(slug)}`);
+  router.push(libraryRouteFor(slug));
 }
 const resultSheetEl = ref(null);
 watch(resultSheetOpen, async (open) => {
@@ -506,6 +514,19 @@ function editorRouteFor(lawIdVal, articleNumber) {
     name: 'editor',
     params: { lawId: lawIdVal, articleNumber },
   };
+}
+
+/**
+ * Build a router target for the bibliotheek that preserves the current
+ * traject scope, mirroring editorRouteFor. Used when leaving the editor
+ * for the library (e.g. opening a search result) so the active traject
+ * follows the user instead of being dropped.
+ */
+function libraryRouteFor(lawIdVal) {
+  const trajectRef = route.params.trajectRef;
+  return trajectRef
+    ? { name: 'library-traject', params: { trajectRef, lawId: lawIdVal } }
+    : { name: 'library', params: { lawId: lawIdVal } };
 }
 
 // If the user lands on the editor without a lawId, restore the last
@@ -1262,7 +1283,7 @@ async function handleActionSave() {
           <nldd-toolbar size="md">
             <nldd-toolbar-item slot="start">
               <nldd-tab-bar size="md">
-                <nldd-tab-bar-item :href="lastLibraryPath" @click.prevent="router.push(lastLibraryPath)" text="Bibliotheek"></nldd-tab-bar-item>
+                <nldd-tab-bar-item :href="libraryTabHref" @click.prevent="router.push(libraryTabTarget)" text="Bibliotheek"></nldd-tab-bar-item>
                 <nldd-tab-bar-item selected text="Editor"></nldd-tab-bar-item>
               </nldd-tab-bar>
             </nldd-toolbar-item>
@@ -1324,7 +1345,7 @@ async function handleActionSave() {
           <nldd-toolbar size="md">
             <nldd-toolbar-item slot="start">
               <nldd-tab-bar size="md">
-                <nldd-tab-bar-item :href="lastLibraryPath" @click.prevent="router.push(lastLibraryPath)" text="Bibliotheek"></nldd-tab-bar-item>
+                <nldd-tab-bar-item :href="libraryTabHref" @click.prevent="router.push(libraryTabTarget)" text="Bibliotheek"></nldd-tab-bar-item>
                 <nldd-tab-bar-item selected text="Editor"></nldd-tab-bar-item>
               </nldd-tab-bar>
             </nldd-toolbar-item>
@@ -1413,7 +1434,7 @@ async function handleActionSave() {
         <nldd-page v-if="!activeTab">
           <nldd-simple-section width="full">
             <nldd-inline-dialog text="Open een artikel vanuit de tabbalk of de bibliotheek om te bewerken.">
-              <nldd-button slot="actions" variant="secondary" text="Ga naar bibliotheek" :href="lastLibraryPath" @click.prevent="router.push(lastLibraryPath)"></nldd-button>
+              <nldd-button slot="actions" variant="secondary" text="Ga naar bibliotheek" :href="libraryTabHref" @click.prevent="router.push(libraryTabTarget)"></nldd-button>
             </nldd-inline-dialog>
           </nldd-simple-section>
         </nldd-page>
@@ -1438,7 +1459,7 @@ async function handleActionSave() {
               :text="`${failedLawName} is niet beschikbaar in dit traject`"
               supporting-text="Wissel van traject via het menu rechtsboven of ga terug naar het overzicht."
             >
-              <nldd-button slot="actions" variant="primary" text="Naar bibliotheek" :href="lastLibraryPath" @click.prevent="router.push(lastLibraryPath)"></nldd-button>
+              <nldd-button slot="actions" variant="primary" text="Naar bibliotheek" :href="libraryTabHref" @click.prevent="router.push(libraryTabTarget)"></nldd-button>
               <nldd-button slot="actions" variant="secondary" text="Probeer opnieuw" @click="retryLoadLaw"></nldd-button>
             </nldd-inline-dialog>
             <nldd-inline-dialog
@@ -1784,7 +1805,7 @@ async function handleActionSave() {
           <nldd-toolbar size="md">
             <nldd-toolbar-item slot="start">
               <nldd-tab-bar variant="compact">
-                <nldd-tab-bar-item :href="lastLibraryPath" @click.prevent="router.push(lastLibraryPath)" icon="books" text="Bibliotheek"></nldd-tab-bar-item>
+                <nldd-tab-bar-item :href="libraryTabHref" @click.prevent="router.push(libraryTabTarget)" icon="books" text="Bibliotheek"></nldd-tab-bar-item>
                 <nldd-tab-bar-item selected icon="edit" text="Editor"></nldd-tab-bar-item>
               </nldd-tab-bar>
             </nldd-toolbar-item>

--- a/frontend/src/LibraryApp.vue
+++ b/frontend/src/LibraryApp.vue
@@ -12,8 +12,10 @@ import { useAuth } from './composables/useAuth.js';
 import { lawFetchError } from './composables/useLaw.js';
 import { useFeatureFlags } from './composables/useFeatureFlags.js';
 import { useColorScheme } from './composables/useColorScheme.js';
+import { useTrajects } from './composables/useTrajects.js';
+import { lawsListUrl, lawUrl } from './composables/corpusUrls.js';
 import { SUPPORT_EMAIL } from './constants.js';
-import { lastEditorPath } from './composables/useLastVisitedRoute.js';
+import { lastEditorPath, sectionTarget } from './composables/useLastVisitedRoute.js';
 
 const { authenticated, loading: authLoading, oidcConfigured, person, login, logout } = useAuth();
 const { isEnabled, toggle: toggleFlag } = useFeatureFlags();
@@ -43,6 +45,40 @@ const editorPanelFlags = [
 
 const route = useRoute();
 const router = useRouter();
+
+// Active traject (null = global browse). Derived from the URL via
+// `route.params.trajectRef`, so the new `library-traject` route makes the
+// bibliotheek traject-aware without any extra plumbing.
+const { activeTrajectRef } = useTrajects();
+
+// Keep the user's traject scope across in-app navigations. With a traject
+// in the URL we stay on `library-traject` / `editor-traject`; without one
+// on the plain `library` / `editor`. Mirrors EditorApp.editorRouteFor.
+function libraryRouteFor(params = {}) {
+  return activeTrajectRef.value
+    ? { name: 'library-traject', params: { ...params, trajectRef: activeTrajectRef.value } }
+    : { name: 'library', params };
+}
+function editorRouteFor(lawIdVal, articleNumber) {
+  return activeTrajectRef.value
+    ? { name: 'editor-traject', params: { trajectRef: activeTrajectRef.value, lawId: lawIdVal, articleNumber } }
+    : { name: 'editor', params: { lawId: lawIdVal, articleNumber } };
+}
+
+// Tab-bar state + cross-section navigation. The Bibliotheek/Editor tabs
+// must light up for both the plain and traject-scoped route variants, and
+// switching to the Editor tab must carry the active traject across (see
+// sectionTarget).
+const isLibraryRoute = computed(
+  () => route.name === 'library' || route.name === 'library-traject',
+);
+const isEditorRoute = computed(
+  () => route.name === 'editor' || route.name === 'editor-traject',
+);
+const editorTabTarget = computed(() =>
+  sectionTarget(router, lastEditorPath.value, activeTrajectRef.value),
+);
+const editorTabHref = computed(() => router.resolve(editorTabTarget.value).href);
 
 const laws = ref([]);
 const favorites = ref(null);
@@ -260,7 +296,7 @@ async function loadIndex() {
   const gen = ++loadIndexGeneration;
   try {
     const [corpusRes] = await Promise.all([
-      fetch('/api/corpus/laws?limit=1000'),
+      fetch(lawsListUrl(activeTrajectRef.value, 'limit=1000')),
       loadFavorites(),
     ]);
     if (!corpusRes.ok) throw new Error(`Failed to load corpus: ${corpusRes.status}`);
@@ -285,7 +321,7 @@ async function loadLaw(lawId) {
   const gen = ++loadLawGeneration;
   try {
     selectedLawLoading.value = true;
-    const res = await fetch(`/api/corpus/laws/${encodeURIComponent(lawId)}`);
+    const res = await fetch(lawUrl(activeTrajectRef.value, lawId));
     if (!res.ok) throw lawFetchError(res.status);
     // Gate before and after `res.text()`: skip the body read for stale 200s, and catch races during it.
     if (gen !== loadLawGeneration) return;
@@ -334,8 +370,18 @@ function retryLoadCorpus() {
 function editInEditor() {
   if (!selectedLawId.value || !selectedArticleNumber.value) return;
   activeAction.value = null;
-  router.push(`/editor/${encodeURIComponent(selectedLawId.value)}/${encodeURIComponent(selectedArticleNumber.value)}`);
+  // Carry the active traject so "Bewerken" opens the editable
+  // editor-traject view instead of the read-only editor.
+  router.push(editorRouteFor(selectedLawId.value, selectedArticleNumber.value));
 }
+
+// "Bewerken" button in the detail pane: same traject-aware target as
+// editInEditor, exposed as a location + href so the anchor is real (and
+// middle-click / open-in-new-tab works) while the click stays SPA.
+const editLawTarget = computed(() =>
+  editorRouteFor(selectedLawId.value, selectedArticleNumber.value || undefined),
+);
+const editLawHref = computed(() => router.resolve(editLawTarget.value).href);
 
 function selectLaw(lawId, focusAfter = false) {
   if (lawId !== selectedLawId.value || lawError.value) {
@@ -343,7 +389,7 @@ function selectLaw(lawId, focusAfter = false) {
     selectedArticleNumber.value = null;
     activeAction.value = null;
     lawError.value = null;
-    router.push({ name: 'library', params: { lawId } });
+    router.push(libraryRouteFor({ lawId }));
     loadLaw(lawId);
   }
 
@@ -367,7 +413,10 @@ function selectArticle(number) {
   if (articleStr === selectedArticleNumber.value) return;
   selectedArticleNumber.value = articleStr;
   activeAction.value = null;
-  router.replace({ name: 'library', params: { lawId: selectedLawId.value, articleNumber: articleStr }, hash: route.hash });
+  router.replace({
+    ...libraryRouteFor({ lawId: selectedLawId.value, articleNumber: articleStr }),
+    hash: route.hash,
+  });
 }
 
 /**
@@ -399,12 +448,12 @@ function onPaneBack(e) {
 
 function goToLawRoot() {
   if (selectedLawId.value) {
-    router.push({ name: 'library', params: { lawId: selectedLawId.value } });
+    router.push(libraryRouteFor({ lawId: selectedLawId.value }));
   }
 }
 
 function goToLibraryRoot() {
-  router.push({ name: 'library' });
+  router.push(libraryRouteFor());
 }
 
 // Handle browser back/forward navigation
@@ -461,10 +510,20 @@ if (route.params.lawId) {
 }
 loadIndex();
 
-// LibraryApp is the global, no-traject view: it always reads through
-// `/api/corpus/...`. Switching trajects in the TrajectMenu is a route
-// change to `/editor/{ref}/...`, which leaves LibraryApp behind — no
-// in-place refetch needed here.
+// The bibliotheek reads through the active traject's corpus
+// (`/api/trajects/{ref}/corpus/...`) or the global corpus (`/api/corpus/...`)
+// depending on `activeTrajectRef`. When the user switches traject in-place
+// (e.g. picking another traject from the TrajectMenu while staying in the
+// library, or "Geen traject"), the route param changes but the component
+// stays mounted — so refetch the index and the open law through the new
+// scope. Mirrors EditorApp's `watch(activeTrajectRef)`.
+watch(activeTrajectRef, () => {
+  loadIndex();
+  if (selectedLawId.value) {
+    lawError.value = null;
+    loadLaw(selectedLawId.value);
+  }
+});
 </script>
 
 <template>
@@ -476,8 +535,8 @@ loadIndex();
           <nldd-toolbar size="md">
             <nldd-toolbar-item slot="start">
               <nldd-tab-bar size="md" navigation>
-                <nldd-tab-bar-item :selected="route.name === 'library' || undefined" text="Bibliotheek"></nldd-tab-bar-item>
-                <nldd-tab-bar-item :selected="route.name === 'editor' || undefined" :href="lastEditorPath" @click.prevent="router.push(lastEditorPath)" text="Editor"></nldd-tab-bar-item>
+                <nldd-tab-bar-item :selected="isLibraryRoute || undefined" text="Bibliotheek"></nldd-tab-bar-item>
+                <nldd-tab-bar-item :selected="isEditorRoute || undefined" :href="editorTabHref" @click.prevent="router.push(editorTabTarget)" text="Editor"></nldd-tab-bar-item>
               </nldd-tab-bar>
             </nldd-toolbar-item>
             <nldd-toolbar-item slot="end">
@@ -525,8 +584,8 @@ loadIndex();
           <nldd-toolbar size="md">
             <nldd-toolbar-item slot="start">
               <nldd-tab-bar size="md" navigation>
-                <nldd-tab-bar-item :selected="route.name === 'library' || undefined" text="Bibliotheek"></nldd-tab-bar-item>
-                <nldd-tab-bar-item :selected="route.name === 'editor' || undefined" :href="lastEditorPath" @click.prevent="router.push(lastEditorPath)" text="Editor"></nldd-tab-bar-item>
+                <nldd-tab-bar-item :selected="isLibraryRoute || undefined" text="Bibliotheek"></nldd-tab-bar-item>
+                <nldd-tab-bar-item :selected="isEditorRoute || undefined" :href="editorTabHref" @click.prevent="router.push(editorTabTarget)" text="Editor"></nldd-tab-bar-item>
               </nldd-tab-bar>
             </nldd-toolbar-item>
             <nldd-toolbar-item slot="center" min-width="240px" width="33%">
@@ -725,7 +784,7 @@ loadIndex();
                       </nldd-tab-bar>
                     </nldd-toolbar-item>
                     <nldd-toolbar-item slot="end">
-                      <nldd-button v-if="selectedLawId" variant="secondary" text="Bewerken" :href="`/editor/${encodeURIComponent(selectedLawId)}/${encodeURIComponent(selectedArticleNumber)}`" @click.prevent="router.push(`/editor/${encodeURIComponent(selectedLawId)}/${encodeURIComponent(selectedArticleNumber)}`)"></nldd-button>
+                      <nldd-button v-if="selectedLawId" variant="secondary" text="Bewerken" :href="editLawHref" @click.prevent="router.push(editLawTarget)"></nldd-button>
                     </nldd-toolbar-item>
                   </nldd-toolbar>
                   <nldd-spacer size="24"></nldd-spacer>
@@ -748,8 +807,8 @@ loadIndex();
           <nldd-toolbar size="md">
             <nldd-toolbar-item slot="start">
               <nldd-tab-bar variant="compact" navigation>
-                <nldd-tab-bar-item :selected="route.name === 'library' || undefined" icon="books" text="Bibliotheek"></nldd-tab-bar-item>
-                <nldd-tab-bar-item :selected="route.name === 'editor' || undefined" :href="lastEditorPath" @click.prevent="router.push(lastEditorPath)" icon="edit" text="Editor"></nldd-tab-bar-item>
+                <nldd-tab-bar-item :selected="isLibraryRoute || undefined" icon="books" text="Bibliotheek"></nldd-tab-bar-item>
+                <nldd-tab-bar-item :selected="isEditorRoute || undefined" :href="editorTabHref" @click.prevent="router.push(editorTabTarget)" icon="edit" text="Editor"></nldd-tab-bar-item>
               </nldd-tab-bar>
             </nldd-toolbar-item>
             <nldd-toolbar-item slot="end">

--- a/frontend/src/LibraryApp.vue
+++ b/frontend/src/LibraryApp.vue
@@ -72,9 +72,9 @@ function editorRouteFor(lawIdVal, articleNumber) {
 const isLibraryRoute = computed(
   () => route.name === 'library' || route.name === 'library-traject',
 );
-const isEditorRoute = computed(
-  () => route.name === 'editor' || route.name === 'editor-traject',
-);
+// The Editor tab is never the active tab while LibraryApp is mounted
+// (this component only serves the library routes), so it needs no
+// `:selected` binding — only the cross-section target/href below.
 const editorTabTarget = computed(() =>
   sectionTarget(router, lastEditorPath.value, activeTrajectRef.value),
 );
@@ -536,7 +536,7 @@ watch(activeTrajectRef, () => {
             <nldd-toolbar-item slot="start">
               <nldd-tab-bar size="md" navigation>
                 <nldd-tab-bar-item :selected="isLibraryRoute || undefined" text="Bibliotheek"></nldd-tab-bar-item>
-                <nldd-tab-bar-item :selected="isEditorRoute || undefined" :href="editorTabHref" @click.prevent="router.push(editorTabTarget)" text="Editor"></nldd-tab-bar-item>
+                <nldd-tab-bar-item :href="editorTabHref" @click.prevent="router.push(editorTabTarget)" text="Editor"></nldd-tab-bar-item>
               </nldd-tab-bar>
             </nldd-toolbar-item>
             <nldd-toolbar-item slot="end">
@@ -585,7 +585,7 @@ watch(activeTrajectRef, () => {
             <nldd-toolbar-item slot="start">
               <nldd-tab-bar size="md" navigation>
                 <nldd-tab-bar-item :selected="isLibraryRoute || undefined" text="Bibliotheek"></nldd-tab-bar-item>
-                <nldd-tab-bar-item :selected="isEditorRoute || undefined" :href="editorTabHref" @click.prevent="router.push(editorTabTarget)" text="Editor"></nldd-tab-bar-item>
+                <nldd-tab-bar-item :href="editorTabHref" @click.prevent="router.push(editorTabTarget)" text="Editor"></nldd-tab-bar-item>
               </nldd-tab-bar>
             </nldd-toolbar-item>
             <nldd-toolbar-item slot="center" min-width="240px" width="33%">
@@ -808,7 +808,7 @@ watch(activeTrajectRef, () => {
             <nldd-toolbar-item slot="start">
               <nldd-tab-bar variant="compact" navigation>
                 <nldd-tab-bar-item :selected="isLibraryRoute || undefined" icon="books" text="Bibliotheek"></nldd-tab-bar-item>
-                <nldd-tab-bar-item :selected="isEditorRoute || undefined" :href="editorTabHref" @click.prevent="router.push(editorTabTarget)" icon="edit" text="Editor"></nldd-tab-bar-item>
+                <nldd-tab-bar-item :href="editorTabHref" @click.prevent="router.push(editorTabTarget)" icon="edit" text="Editor"></nldd-tab-bar-item>
               </nldd-tab-bar>
             </nldd-toolbar-item>
             <nldd-toolbar-item slot="end">

--- a/frontend/src/components/TrajectMenu.vue
+++ b/frontend/src/components/TrajectMenu.vue
@@ -23,15 +23,19 @@ const route = useRoute();
 const router = useRouter();
 
 /**
- * Navigate to a traject — push the user into the traject-scoped
- * editor at the same law they were viewing. Per-tab state: a switch
- * here only affects this tab, never other open editors.
+ * Navigate to a traject — push the user into the traject-scoped view of
+ * the section they are currently in (bibliotheek or editor), at the same
+ * law they were viewing. Picking a traject from the bibliotheek keeps you
+ * in the bibliotheek; from the editor it keeps you in the editor. Per-tab
+ * state: a switch here only affects this tab, never other open tabs.
  */
 async function goToTraject(trajectRef) {
   const lawId = route.params.lawId || undefined;
   const articleNumber = route.params.articleNumber || undefined;
+  const inLibrary =
+    route.name === 'library' || route.name === 'library-traject';
   await router.push({
-    name: 'editor-traject',
+    name: inLibrary ? 'library-traject' : 'editor-traject',
     params: { trajectRef, lawId, articleNumber },
   });
 }

--- a/frontend/src/composables/useLastVisitedRoute.js
+++ b/frontend/src/composables/useLastVisitedRoute.js
@@ -79,5 +79,14 @@ export function sectionTarget(router, storedPath, activeRef) {
     if (name === 'library-traject') name = 'library';
     else if (name === 'editor-traject') name = 'editor';
   }
+  // Defensive: a corrupted or extremely stale sessionStorage path can
+  // resolve to an unrecognised (or null) route name, which would make the
+  // downstream router.push throw. Fall back to the section root, deriving
+  // the section from the stored path's prefix so the correct tab is kept.
+  const KNOWN = ['library', 'library-traject', 'editor', 'editor-traject'];
+  if (!KNOWN.includes(name)) {
+    const section = storedPath.startsWith('/editor') ? 'editor' : 'library';
+    name = activeRef ? `${section}-traject` : section;
+  }
   return { name, params };
 }

--- a/frontend/src/composables/useLastVisitedRoute.js
+++ b/frontend/src/composables/useLastVisitedRoute.js
@@ -27,14 +27,17 @@ function save() {
   }
 }
 
-// Normalise the editor's two route names — `editor` (read-only, no
-// trajectRef) and `editor-traject` (full edit) — to a single
-// `editor` storage key. Either way it's "the editor tab" semantically;
-// keeping them separate would mean a `??` fallback chain has to pick a
-// winner regardless of which was visited more recently. With one
-// shared key, the last write wins by definition.
+// Normalise each section's traject / no-traject route names to a single
+// storage key per section: `editor`/`editor-traject` → `editor`,
+// `library`/`library-traject` → `library`. Either way it's "the editor
+// tab" / "the bibliotheek tab" semantically; keeping them separate would
+// mean a `??` fallback chain has to pick a winner regardless of which
+// was visited more recently. With one shared key, the last write wins by
+// definition.
 function storageKeyFor(routeName) {
-  return routeName === 'editor-traject' ? 'editor' : routeName;
+  if (routeName === 'editor-traject') return 'editor';
+  if (routeName === 'library-traject') return 'library';
+  return routeName;
 }
 
 export function recordLastVisited(routeName, fullPath) {
@@ -55,3 +58,26 @@ export const lastLibraryPath = computed(() => _lastVisited.value.library ?? '/li
 export const lastEditorPath = computed(
   () => _lastVisited.value.editor ?? '/editor',
 );
+
+// Build a router target for the *other* top-level section (Bibliotheek /
+// Editor) from its last-visited path, but re-stamp the trajectRef to the
+// CURRENTLY active traject. The stored path can carry a stale trajectRef
+// (or none) from an earlier visit; the active scope must win, otherwise a
+// tab-switch would either drop the traject (the bug this fixes) or
+// teleport the user into whatever traject they last had open in that
+// section. Returns a `{ name, params }` location for `router.push`.
+export function sectionTarget(router, storedPath, activeRef) {
+  const loc = router.resolve(storedPath);
+  const params = { ...loc.params };
+  let name = loc.name;
+  if (activeRef) {
+    params.trajectRef = activeRef;
+    if (name === 'library') name = 'library-traject';
+    else if (name === 'editor') name = 'editor-traject';
+  } else {
+    delete params.trajectRef;
+    if (name === 'library-traject') name = 'library';
+    else if (name === 'editor-traject') name = 'editor';
+  }
+  return { name, params };
+}

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -8,6 +8,26 @@ const router = createRouter({
   routes: [
     { path: '/', redirect: '/library' },
     {
+      // Traject-scoped bibliotheek: the same library UI, but reading
+      // through `/api/trajects/{trajectRef}/corpus/...` so the active
+      // traject survives a Bibliotheek↔Editor tab switch. Mirrors the
+      // `editor-traject` route below — the active traject lives in the
+      // URL (per-tab state), never a server session.
+      //
+      // The `:trajectRef` regex pins the param to `{slug}-{8hex}` so a
+      // plain law-id slug like `zorgtoeslagwet` does NOT match here — it
+      // falls through to the no-traject library below. Same invariant as
+      // `editor-traject`: law `$id` slugs must not end in `-{8hex}`.
+      //
+      // Reads of a traject's corpus require auth (the traject is tied to
+      // the user's repo), so this route is gated like `editor-traject`.
+      // The user only ever reaches it from an authenticated session.
+      path: '/library/:trajectRef([a-z0-9-]+-[0-9a-f]{8})/:lawId?/:articleNumber?',
+      name: 'library-traject',
+      component: LibraryApp,
+      meta: { title: 'Bibliotheek', requiresAuth: true },
+    },
+    {
       path: '/library/:lawId?/:articleNumber?',
       name: 'library',
       component: LibraryApp,

--- a/frontend/src/router.test.js
+++ b/frontend/src/router.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import router from './router.js';
+import { sectionTarget } from './composables/useLastVisitedRoute.js';
+
+// A valid traject ref is `{slug}-{8hex}` (see the route regex). A plain
+// law `$id` uses underscores and must NOT match the traject route.
+const REF = 'mijn-traject-1a2b3c4d';
+
+describe('route disambiguation (traject vs no-traject)', () => {
+  it('routes a {slug}-{8hex} library URL to library-traject', () => {
+    const r = router.resolve(`/library/${REF}/zorgtoeslagwet/3`);
+    expect(r.name).toBe('library-traject');
+    expect(r.params.trajectRef).toBe(REF);
+    expect(r.params.lawId).toBe('zorgtoeslagwet');
+    expect(r.params.articleNumber).toBe('3');
+  });
+
+  it('routes a plain law-id library URL to library (no traject)', () => {
+    const r = router.resolve('/library/wet_op_de_zorgtoeslag');
+    expect(r.name).toBe('library');
+    expect(r.params.lawId).toBe('wet_op_de_zorgtoeslag');
+    expect(r.params.trajectRef).toBeUndefined();
+  });
+
+  it('mirrors the same split for the editor routes', () => {
+    expect(router.resolve(`/editor/${REF}/foo`).name).toBe('editor-traject');
+    expect(router.resolve('/editor/wet_op_de_zorgtoeslag').name).toBe('editor');
+  });
+});
+
+describe('sectionTarget — traject preserved across tab switches', () => {
+  it('stamps the active traject when entering a section without one', () => {
+    const t = sectionTarget(router, '/library/wet_op_de_zorgtoeslag', REF);
+    expect(t.name).toBe('library-traject');
+    expect(t.params.trajectRef).toBe(REF);
+    expect(t.params.lawId).toBe('wet_op_de_zorgtoeslag');
+  });
+
+  it('re-stamps a stale stored traject with the currently active one', () => {
+    const t = sectionTarget(router, '/editor/old-deadbeef/foo', REF);
+    expect(t.name).toBe('editor-traject');
+    expect(t.params.trajectRef).toBe(REF);
+    expect(t.params.lawId).toBe('foo');
+  });
+
+  it('strips the traject when none is active (Geen traject)', () => {
+    const t = sectionTarget(router, `/library/${REF}/foo`, null);
+    expect(t.name).toBe('library');
+    expect(t.params.trajectRef).toBeUndefined();
+    expect(t.params.lawId).toBe('foo');
+  });
+});

--- a/frontend/src/router.test.js
+++ b/frontend/src/router.test.js
@@ -49,4 +49,12 @@ describe('sectionTarget — traject preserved across tab switches', () => {
     expect(t.params.trajectRef).toBeUndefined();
     expect(t.params.lawId).toBe('foo');
   });
+
+  it('falls back to the section root for an unresolvable stored path', () => {
+    // A corrupted/stale sessionStorage value must not crash router.push.
+    expect(sectionTarget(router, '/totally/unknown', REF).name).toBe('library-traject');
+    expect(sectionTarget(router, '/totally/unknown', null).name).toBe('library');
+    // Section is derived from the path prefix so the right tab is kept.
+    expect(sectionTarget(router, '/editor-bogus/x', null).name).toBe('editor');
+  });
 });


### PR DESCRIPTION
## Probleem

Gemeld: *"Als ik in de editor in een traject zit en dan naar de bibliotheek ga, is het traject weg. Als ik het dan opnieuw kies, ga ik weer naar de editor."*

Dit is een **regressie sinds #695** ("traject in URL i.p.v. server-sessie"). #670 maakte de bibliotheek traject-bewust via de server-sessie; #695 verplaatste het traject naar de URL (per-tab isolatie) maar gaf de bibliotheek-route nooit een `trajectRef`-segment. Daardoor:

1. Tab-wissel editor → bibliotheek gaat naar `/library/...` zonder `trajectRef` → `activeTrajectRef` wordt `null` → menu toont "Geen traject".
2. Traject opnieuw kiezen riep altijd `editor-traject` aan → je belandde weer in de editor.

## Oplossing

De bibliotheek wordt traject-bewust, in lijn met de bewuste keuze om het traject **per-tab in de URL** te houden (geen globale store):

- **Nieuwe `library-traject`-route** (`/library/{ref}/...`) naast de plain `library`, met dezelfde `{slug}-{8hex}`-regex als `editor-traject` (law-`$id`'s gebruiken underscores en matchen dus nooit).
- **LibraryApp** leest via de bestaande `lawsListUrl`/`lawUrl`-helpers door de actieve traject-corpus en herlaadt in-place bij traject-wissel (mirror van EditorApp's `watch(activeTrajectRef)`).
- **Tab-wissel** Bibliotheek↔Editor behoudt de scope via een gedeelde `sectionTarget`-helper die de `trajectRef` her-stempelt op het actieve traject.
- **Traject kiezen** (`TrajectMenu.goToTraject`) blijft in de huidige sectie: vanuit de bibliotheek → bibliotheek, vanuit de editor → editor.
- **"Bewerken"** en **zoekresultaten** dragen het traject mee i.p.v. naar de read-only/globale view te vallen.

## Tests / verificatie

- `npm run build` ✅
- `npm test` → 225 passed (incl. 6 nieuwe in `router.test.js` voor regex-disambiguatie en `sectionTarget`).
- Browser-rooktest volgt op de preview-deployment van deze PR.

## UI / styling

Geen custom CSS toegevoegd; uitsluitend `ndd-*` design-system componenten en routing/logica gewijzigd.