### PR TITLE
feat: AI-suggesties tijdens het editen van een wet

### DIFF
--- a/.claude/skills/law-aanwijzingen/SKILL.md
+++ b/.claude/skills/law-aanwijzingen/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: law-aanwijzingen
+description: >
+  Toetst de tekst van een Nederlandse wet (op artikelniveau) tegen de Aanwijzingen
+  voor de regelgeving (KCBR) en levert per bevinding een concrete suggestie. De
+  bevindingen worden als JSON naar een outputpad geschreven met een TextQuoteSelector
+  (exact/prefix/suffix) zodat ze als W3C-annotatie aan de wettekst verankerd kunnen
+  worden. Gebruik deze skill wanneer iemand een wet bewerkt en wetgevingskwaliteits-
+  feedback wil, of wanneer 'aanwijzingen', 'aanwijzingen voor de regelgeving',
+  'wetgevingskwaliteit' of 'KCBR' genoemd wordt in de context van een wet-YAML.
+allowed-tools: Read, Grep, Glob, Write
+user-invocable: true
+---
+
+# Law Aanwijzingen — Toets wettekst tegen de Aanwijzingen voor de regelgeving
+
+Deze skill leest de tekst van een wet-YAML en toetst die, **artikel voor artikel**,
+tegen de Aanwijzingen voor de regelgeving (de officiële wetgevingskwaliteits-
+richtlijnen van het KCBR). Per bevinding schrijf je een **suggestie** — je wijzigt de
+wet zelf NIET. De output is een JSON-bestand dat de aanroeper omzet naar verankerde
+annotaties in de editor, die de gebruiker per stuk accepteert of afwijst.
+
+**CRITICAL — alleen suggereren, niet bewerken.** Gebruik nooit Edit op de wet-YAML.
+Je enige schrijfactie is het JSON-outputbestand. De mens beslist.
+
+## Invoer
+
+De aanroeper geeft je:
+- `LAW_YAML` — pad naar de wet-YAML (article-based, conform `schema/latest/schema.json`).
+- `OUTPUT_PATH` — pad waar je het JSON-resultaat schrijft.
+- Optioneel `ARTICLE_NUMBER` — beperk je tot dit artikel. Ontbreekt dit, toets alle artikelen.
+
+## Setup
+
+1. Lees `LAW_YAML`. Voor elk artikel telt het `text`-veld als de te toetsen tekst.
+2. Lees `.claude/skills/law-aanwijzingen/reference.md` — de gecondenseerde kernset
+   aanwijzingen met nummers en toetsvragen.
+3. Beperk je tot `ARTICLE_NUMBER` als die is opgegeven.
+
+## Fundamentele regel: blijf binnen de tekst
+
+Toets uitsluitend wat er in het `text`-veld van het artikel staat. Beoordeel de
+**formulering en structuur van de wettekst**, niet of het beleid wenselijk is en niet
+de `machine_readable`-sectie (dat doet `law-reverse-validate`). Verzin geen bevindingen:
+elke suggestie moet wijzen naar een concrete, letterlijk in de tekst aanwezige passage.
+
+## Werkwijze
+
+Loop per artikel door `reference.md`. Voor elke aanwijzing die van toepassing kan zijn,
+stel de bijbehorende toetsvraag. Levert die een concreet probleem op in déze tekst, maak
+dan één bevinding. Geen probleem → geen bevinding (liever weinig, rake bevindingen dan
+veel ruis).
+
+Per bevinding bepaal je:
+- de **exacte passage** in de wettekst waar het over gaat (letterlijk overgenomen);
+- genoeg **prefix/suffix** eromheen om de passage uniek te maken binnen het artikel
+  (de tekst eromheen, niet verzonnen — kopieer het);
+- het **aanwijzingsnummer** (uit `reference.md`; gebruik `null` als je een algemeen
+  kwaliteitsprobleem signaleert dat niet aan één nummer hangt);
+- een **severity** (`info` | `suggestie` | `belangrijk`);
+- een **suggestietekst** in het Nederlands: wat is er aan de hand en wat is het advies;
+- optioneel een **proposed_replacement**: de letterlijke vervangende tekst voor `exact`,
+  alleen als je een concrete herformulering kunt geven die 1-op-1 de passage vervangt.
+
+## Outputformaat (CRITICAL — exact dit contract)
+
+Schrijf met de Write-tool naar `OUTPUT_PATH` één JSON-object:
+
+```json
+{
+  "law_id": "<het $id uit de YAML>",
+  "findings": [
+    {
+      "article_number": "2",
+      "exact_quote": "de belanghebbende",
+      "prefix": "aanspraak heeft ",
+      "suffix": ", bedoeld in",
+      "aanwijzing_nr": "3.56",
+      "severity": "suggestie",
+      "suggestion_text": "De term 'belanghebbende' is hier niet gedefinieerd terwijl elders 'aanvrager' wordt gebruikt. Aanwijzing 3.56 vraagt om consistente terminologie. Overweeg één term consequent te gebruiken.",
+      "proposed_replacement": "de aanvrager"
+    }
+  ]
+}
+```
+
+Regels voor het outputcontract:
+- `exact_quote` is de te markeren passage uit de artikeltekst, **met genormaliseerde
+  witruimte**: vervang elk regeleinde en elke reeks spaties/tabs door één spatie, en
+  trim begin/eind. De wettekst in de YAML bevat harde regelafbrekingen midden in zinnen;
+  normaliseer die weg zodat de quote één doorlopende zin is. De resolver verankert
+  whitespace-tolerant (fuzzy), dus een genormaliseerde quote matcht ook als het origineel
+  een `\n` op die plek had. Kopieer verder de woorden letterlijk — verzin of parafraseer niets.
+- `prefix`/`suffix` zijn de tekst direct vóór/na `exact_quote`, óók met genormaliseerde
+  witruimte. Mogen leeg ("") zijn, maar vul ze (een paar woorden) als de passage anders
+  meerdere keren in het artikel voorkomt, zodat de verankering ondubbelzinnig is.
+- `article_number` is een string en matcht het `number`-veld van het artikel.
+- `aanwijzing_nr` is een string of `null`.
+- `proposed_replacement` is optioneel; laat weg als je geen concrete vervanging hebt.
+- Schrijf **geen** Markdown of proza buiten het JSON-object. Het bestand is puur data.
+- Lege bevindingenlijst is een geldig en goed resultaat: `{"law_id": "...", "findings": []}`.
+
+## Afronding
+
+Schrijf het JSON-bestand. Rapporteer aan de aanroeper kort: aantal getoetste artikelen
+en aantal bevindingen per severity. Wijzig niets aan de wet.

--- a/.claude/skills/law-aanwijzingen/reference.md
+++ b/.claude/skills/law-aanwijzingen/reference.md
@@ -1,0 +1,99 @@
+# Reference — kernset Aanwijzingen voor de regelgeving
+
+Gecondenseerde, machine-bruikbare kernset van de Aanwijzingen voor de regelgeving
+(KCBR), toegespitst op de kwaliteit van **wetteksten op artikelniveau**. Dit is een
+werkbare startset, geen volledige weergave van alle aanwijzingen.
+
+> **Nummering:** de nummers hieronder volgen de hoofdstukindeling van de Aanwijzingen
+> (hfst. 3 vormgeving, hfst. 4 algemene bestanddelen, hfst. 5 bijzondere bestanddelen).
+> Behandel de exacte nummers als indicatief: noem het nummer als je zeker bent, gebruik
+> anders `aanwijzing_nr: null` en beschrijf het kwaliteitsprobleem inhoudelijk. De volledige,
+> actuele tekst staat op https://www.kcbr.nl/ontwikkelen-beleid-en-regelgeving/aanwijzingen-voor-de-regelgeving
+
+Per item: **kern** + **toetsvraag** (stel die op de artikeltekst; "ja" → mogelijke bevinding).
+
+## 1. Definities en begripsbepalingen
+
+- **3.x Begripsbepalingen vooraan.** Kern: definities horen geconcentreerd in een
+  begripsbepalingenartikel (meestal artikel 1), niet verspreid.
+  Toetsvraag: introduceert dit artikel een eigen definitie ("wordt verstaan onder…",
+  "in dit artikel wordt … aangeduid als…") die in het begripsbepalingenartikel thuishoort?
+- **3.x Definieer alleen wat afwijkt.** Kern: definieer geen term die in normaal
+  spraakgebruik al duidelijk is; definieer juist wel een term met een afwijkende betekenis.
+  Toetsvraag: wordt een alledaagse term overbodig gedefinieerd, óf wordt een vaktechnische
+  term zonder definitie gebruikt?
+- **3.x Gebruik gedefinieerde termen consequent.** Kern: gebruik een gedefinieerde term
+  overal in dezelfde betekenis; introduceer geen synoniemen.
+  Toetsvraag: wordt voor hetzelfde begrip nu eens term A, dan term B gebruikt?
+
+## 2. Terminologie en consistentie
+
+- **3.56 (e.o.) Consistent taalgebruik.** Kern: gebruik in de hele regeling dezelfde term
+  voor hetzelfde begrip en vermijd wisselende formuleringen.
+  Toetsvraag: duiken binnen dit artikel of t.o.v. eerdere artikelen verschillende termen op
+  voor wat hetzelfde lijkt (bv. "aanvrager" vs "belanghebbende" vs "verzoeker")?
+- **3.x Eenduidige werkwoordsvormen.** Kern: druk een verplichting/bevoegdheid eenduidig uit.
+  In NL-wetgeving: gebonden norm = tegenwoordige tijd ("De minister stelt vast"); bevoegdheid =
+  "kan". Vermijd "zal", "dient te", "moet" door elkaar.
+  Toetsvraag: worden normstellende werkwoordsvormen inconsistent of vaag gebruikt?
+
+## 3. Normstellende vs. beschrijvende/toelichtende tekst
+
+- **3.x Geen toelichtende of motiverende tekst in de regeling.** Kern: de regeling bevat
+  normen; toelichting hoort in de memorie van toelichting, niet in het artikel.
+  Toetsvraag: bevat de tekst uitleg, motivering of voorbeelden ("dit betekent dat…",
+  "met als doel…", "bijvoorbeeld") die in een MvT thuishoren?
+- **3.x Geen overbodige bepalingen.** Kern: neem niets op wat al uit hogere regeling of
+  algemeen recht volgt; herhaal geen wettelijke regel die elders al geldt.
+  Toetsvraag: herhaalt dit artikel iets wat al elders dwingend geregeld is?
+- **3.x Normen, geen intenties.** Kern: een artikel formuleert een rechtsgevolg, geen
+  beleidswens.
+  Toetsvraag: is de bepaling een streven/intentie ("streeft naar", "bevordert") zonder
+  concreet rechtsgevolg, waar een norm bedoeld is?
+
+## 4. Verwijzingen
+
+- **3.x Verwijs zo precies en stabiel mogelijk.** Kern: verwijs naar het specifieke
+  artikel/lid; vermijd vage of ketenverwijzingen ("het bepaalde in de vorige artikelen").
+  Toetsvraag: bevat de tekst een vage verwijzing, of een verwijzing die door wijziging snel
+  onjuist wordt?
+- **3.x Vermijd verwijzingen naar verwijzingen.** Kern: geen verwijzing naar een bepaling
+  die zelf alleen maar doorverwijst (cirkel/keten).
+  Toetsvraag: leidt de verwijzing de lezer via een omweg, in plaats van rechtstreeks naar de norm?
+
+## 5. Delegatie
+
+- **2.x / 5.x Delegatiegrondslag duidelijk en begrensd.** Kern: delegatie ("bij of
+  krachtens algemene maatregel van bestuur", "bij ministeriële regeling") moet onderwerp en
+  grenzen aangeven; delegeer geen hoofdelementen naar een te laag niveau.
+  Toetsvraag: delegeert dit artikel iets zonder de reikwijdte te begrenzen, of naar een lager
+  niveau dan past bij het gewicht van de norm?
+- **5.x Juiste delegatieterminologie.** Kern: "bij amvb" (gebonden), "bij of krachtens"
+  (subdelegatie mogelijk), "bij ministeriële regeling" (alleen voor details/uitvoering).
+  Toetsvraag: past de gekozen delegatieformulering bij wat gedelegeerd wordt?
+
+## 6. Artikelopbouw en leesbaarheid
+
+- **3.x Eén gedachte per artikel/lid.** Kern: splits samengestelde normen; gebruik leden en
+  onderdelen voor opsommingen.
+  Toetsvraag: propt dit artikel meerdere zelfstandige normen in één lange volzin die beter
+  in leden/onderdelen uiteenvalt?
+- **3.x Korte, enkelvoudige zinnen.** Kern: vermijd lange zinnen met veel ingebedde
+  voorwaarden; gebruik een opsomming.
+  Toetsvraag: is de zin zo lang/genest dat de norm moeilijk te volgen is?
+- **3.x Actieve, concrete formulering.** Kern: benoem wie wat moet/mag; vermijd onnodig
+  passief en nominalisaties.
+  Toetsvraag: verbergt een passieve constructie wie de normadressaat is ("er wordt vastgesteld"
+  zonder dat duidelijk is door wie)?
+- **3.x Geen dubbele ontkenningen / vermijdbare ambiguïteit.** Kern: formuleer ondubbelzinnig.
+  Toetsvraag: bevat de zin een dubbele ontkenning of een "en/of"-constructie die meerdere
+  lezingen toelaat?
+
+## Toepassing
+
+- Geef per echte bevinding precies één finding-object (zie SKILL.md outputcontract).
+- Citeer altijd de letterlijke passage (`exact_quote`) — nooit een parafrase.
+- Bij twijfel of iets echt fout is: laat het weg. Liever drie rake suggesties dan twintig vage.
+- Severity-richtlijn: `belangrijk` = juridisch risico (vage delegatie, overbodige bepaling die
+  conflicteert); `suggestie` = duidelijke kwaliteitswinst (terminologie, opbouw);
+  `info` = stilistisch detail.

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -3,13 +3,15 @@ import { ref, computed, reactive, watch, watchEffect, nextTick } from 'vue';
 import { useRoute, useRouter, onBeforeRouteUpdate } from 'vue-router';
 import yaml from 'js-yaml';
 import { useLaw, fetchLaw } from './composables/useLaw.js';
-import { lawsListUrl } from './composables/corpusUrls.js';
+import { lawsListUrl, annotationsUrl } from './composables/corpusUrls.js';
+import { getEditorSessionId } from './composables/useEditorSession.js';
 import { useEngine } from './composables/useEngine.js';
 import { useAuth } from './composables/useAuth.js';
 import { useTrajects } from './composables/useTrajects.js';
 import TrajectMenu from './components/TrajectMenu.vue';
 import { useFeatureFlags } from './composables/useFeatureFlags.js';
 import { useNotes, useResolvedDraftNotes } from './composables/useNotes.js';
+import { useSuggestions } from './composables/useSuggestions.js';
 import { useDraftNotes } from './composables/useDraftNotes.js';
 import { useColorScheme } from './composables/useColorScheme.js';
 import { lastLibraryPath, sectionTarget } from './composables/useLastVisitedRoute.js';
@@ -21,6 +23,7 @@ import ActionSheet from './components/ActionSheet.vue';
 import EditSheet from './components/EditSheet.vue';
 import SearchPopover from './components/SearchPopover.vue';
 import MachineReadable from './components/MachineReadable.vue';
+import SuggestionsPane from './components/SuggestionsPane.vue';
 import ScenarioBuilder from './components/ScenarioBuilder.vue';
 import ExecutionTraceView from './components/ExecutionTraceView.vue';
 import LawGraphView from './components/LawGraphView.vue';
@@ -48,6 +51,9 @@ const editorPanelFlags = [
   // notes can be shown read-only without exposing the (MVP, local-only)
   // creation + export flow.
   ['notes.create', 'Notities aanmaken'],
+  // AI-suggestiepane (aanwijzingen + machine_readable). A real pane, unlike
+  // panel.notes which is a layer over the Tekst pane.
+  ['panel.suggestions', 'Aanwijzingen'],
   ['editor.article_text_edit', 'Tekst bewerken'],
 ];
 
@@ -63,6 +69,7 @@ const VIEW_DEFINITIONS = [
   { id: 'machine', flag: 'panel.machine_readable', label: 'Machine' },
   { id: 'scenario', flag: 'panel.scenario_form', label: "Scenario's" },
   { id: 'yaml', flag: 'panel.yaml_editor', label: 'YAML' },
+  { id: 'suggestions', flag: 'panel.suggestions', label: 'Aanwijzingen' },
 ];
 
 const availableViews = computed(() => VIEW_DEFINITIONS.filter(v => isEnabled(v.flag)));
@@ -217,6 +224,17 @@ const {
   error: notesError,
   reload: reloadNotes,
 } = useNotes(lawId, selectedArticle, activeTrajectRef);
+
+// AI suggestions (aanwijzingen + machine_readable) for the current law,
+// resolved against its text the same way notes are. Polled after a save.
+const {
+  suggestionsForArticle,
+  issues: suggestionIssues,
+  loading: suggestionsLoading,
+  jobState: suggestionJobState,
+  reload: reloadSuggestions,
+  pollStatus: pollSuggestions,
+} = useSuggestions(lawId, selectedArticle, activeTrajectRef);
 
 // Notes are a layer over the Tekst pane, not a separate pane. This toggle is
 // the user's "show notes now" preference; panel.notes (a feature flag) is the
@@ -963,9 +981,53 @@ async function handleLawSave() {
     // Successful save — the dialog flags drop back to false.
     lastSaveTouchedText.value = false;
     lastSaveTouchedMachine.value = false;
+    // A save enqueues background AI-suggestion jobs on the traject branch.
+    // Start polling so the Aanwijzingen pane fills in when they finish. Only
+    // when the pane is enabled; fire-and-forget (poll self-cancels on switch).
+    if (isEnabled('panel.suggestions')) {
+      pollSuggestions();
+    }
   } catch (e) {
     // saveError is surfaced via lawSaveError; log for dev visibility.
     console.warn('saveLaw failed:', e);
+  }
+}
+
+// Accept a suggestion: apply its proposed change, then mark it resolved so the
+// span and list entry disappear. For an `editing` suggestion the replacement
+// text was appended to the body ("Voorgestelde tekst: …"); applying it to the
+// Tekst/Machine pane is the user's job for now — here we record the acceptance
+// by reloading after the resolve. (Full one-click apply is a follow-up; this
+// keeps the human in the loop, which the skill contract intends.)
+async function handleSuggestionAccept(note) {
+  await resolveSuggestion(note);
+}
+
+// Reject a suggestion: mark it resolved (workflow: resolved) via the
+// annotations write path so it stops being shown.
+async function handleSuggestionReject(note) {
+  await resolveSuggestion(note);
+}
+
+// Mark a suggestion annotation resolved by appending a resolved copy to the
+// law's annotations sidecar (the same write path notes use), then reload the
+// suggestions so the open one drops out of the list.
+async function resolveSuggestion(note) {
+  const tr = activeTrajectRef.value;
+  if (!tr || !note) return;
+  const resolved = { ...note, workflow: 'resolved' };
+  try {
+    await fetch(annotationsUrl(tr, lawId.value), {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Editor-Session': getEditorSessionId(),
+      },
+      body: JSON.stringify([resolved]),
+    });
+    await reloadSuggestions();
+  } catch (e) {
+    console.warn('resolveSuggestion failed:', e);
   }
 }
 
@@ -1794,6 +1856,17 @@ async function handleActionSave() {
                 ></nldd-code-editor>
                 <div v-if="parseError" class="editor-parse-error-detail">{{ parseError }}</div>
               </nldd-simple-section>
+
+              <!-- AI suggestions (aanwijzingen + machine_readable) -->
+              <SuggestionsPane
+                v-else-if="view === 'suggestions'"
+                :suggestions-for-article="suggestionsForArticle"
+                :issues="suggestionIssues"
+                :loading="suggestionsLoading"
+                :job-state="suggestionJobState"
+                @accept="handleSuggestionAccept"
+                @reject="handleSuggestionReject"
+              />
             </nldd-page>
           </nldd-split-view-pane>
         </nldd-side-by-side-split-view>

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -3,8 +3,7 @@ import { ref, computed, reactive, watch, watchEffect, nextTick } from 'vue';
 import { useRoute, useRouter, onBeforeRouteUpdate } from 'vue-router';
 import yaml from 'js-yaml';
 import { useLaw, fetchLaw } from './composables/useLaw.js';
-import { lawsListUrl, annotationsUrl } from './composables/corpusUrls.js';
-import { getEditorSessionId } from './composables/useEditorSession.js';
+import { lawsListUrl } from './composables/corpusUrls.js';
 import { useEngine } from './composables/useEngine.js';
 import { useAuth } from './composables/useAuth.js';
 import { useTrajects } from './composables/useTrajects.js';
@@ -232,8 +231,8 @@ const {
   issues: suggestionIssues,
   loading: suggestionsLoading,
   jobState: suggestionJobState,
-  reload: reloadSuggestions,
   pollStatus: pollSuggestions,
+  markResolved: markSuggestionResolved,
 } = useSuggestions(lawId, selectedArticle, activeTrajectRef);
 
 // Notes are a layer over the Tekst pane, not a separate pane. This toggle is
@@ -993,42 +992,27 @@ async function handleLawSave() {
   }
 }
 
-// Accept a suggestion: apply its proposed change, then mark it resolved so the
-// span and list entry disappear. For an `editing` suggestion the replacement
-// text was appended to the body ("Voorgestelde tekst: …"); applying it to the
-// Tekst/Machine pane is the user's job for now — here we record the acceptance
-// by reloading after the resolve. (Full one-click apply is a follow-up; this
-// keeps the human in the loop, which the skill contract intends.)
+// Accept a suggestion: copy the proposed text to the clipboard (so the user can
+// paste it where it belongs), then mark it resolved so the span and list entry
+// disappear. For an `editing` suggestion the body carries "Voorgestelde tekst:
+// …". One-click in-place apply is a deliberate follow-up — this keeps the human
+// in the loop, which the skill contract intends.
 async function handleSuggestionAccept(note) {
-  await resolveSuggestion(note);
-}
-
-// Reject a suggestion: mark it resolved (workflow: resolved) via the
-// annotations write path so it stops being shown.
-async function handleSuggestionReject(note) {
-  await resolveSuggestion(note);
-}
-
-// Mark a suggestion annotation resolved by appending a resolved copy to the
-// law's annotations sidecar (the same write path notes use), then reload the
-// suggestions so the open one drops out of the list.
-async function resolveSuggestion(note) {
-  const tr = activeTrajectRef.value;
-  if (!tr || !note) return;
-  const resolved = { ...note, workflow: 'resolved' };
-  try {
-    await fetch(annotationsUrl(tr, lawId.value), {
-      method: 'PUT',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Editor-Session': getEditorSessionId(),
-      },
-      body: JSON.stringify([resolved]),
-    });
-    await reloadSuggestions();
-  } catch (e) {
-    console.warn('resolveSuggestion failed:', e);
+  const body = Array.isArray(note?.body) ? note.body[0] : note?.body;
+  const text = body?.value ?? '';
+  if (text && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch {
+      /* clipboard blocked — still resolve below */
+    }
   }
+  markSuggestionResolved(note);
+}
+
+// Reject a suggestion: just mark it resolved so it stops being shown.
+function handleSuggestionReject(note) {
+  markSuggestionResolved(note);
 }
 
 // Per-pane scoped views of lawSaveError. The error is only visible in the

--- a/frontend/src/components/SuggestionsPane.vue
+++ b/frontend/src/components/SuggestionsPane.vue
@@ -1,0 +1,127 @@
+<script setup>
+/**
+ * SuggestionsPane — lists AI-generated suggestions (Aanwijzingen voor de
+ * regelgeving + machine_readable) for the selected article, with accept/reject
+ * per item. Suggestions are W3C annotations produced by the pipeline; the
+ * dotted-span highlighting in the Tekst pane is handled by AnnotatedText (it
+ * already styles `creator: Agent/llm` as generated). This pane is the list view.
+ *
+ * Built from NDD (`nldd-*`) components only. Accept/reject are emitted to the
+ * parent (EditorApp), which applies a text/YAML change or marks the suggestion
+ * resolved via the annotations write path.
+ */
+import { computed } from 'vue';
+
+const props = defineProps({
+  // [{ note, spans }] for the active article (from useSuggestions).
+  suggestionsForArticle: { type: Array, default: () => [] },
+  // [{ note, reason }] orphaned/ambiguous suggestions.
+  issues: { type: Array, default: () => [] },
+  loading: { type: Boolean, default: false },
+  // 'idle' | 'running' | 'done'
+  jobState: { type: String, default: 'idle' },
+});
+
+const emit = defineEmits(['accept', 'reject']);
+
+// Extract the plain suggestion text from a note's body (one body or a list).
+function bodyText(note) {
+  const body = note?.body;
+  if (!body) return '';
+  const first = Array.isArray(body) ? body[0] : body;
+  return first?.value ?? '';
+}
+
+// Creator name (Agent) for a subtle source label per item.
+function creatorName(note) {
+  const c = note?.creator;
+  if (!c) return 'AI';
+  return typeof c === 'string' ? c : (c.name ?? 'AI');
+}
+
+// `editing` motivation means a concrete replacement is offered → show "Toepassen".
+function hasReplacement(note) {
+  return note?.motivation === 'editing';
+}
+
+const items = computed(() =>
+  props.suggestionsForArticle.map((s, i) => ({
+    key: `${s.note?.target?.selector?.exact ?? 'sug'}-${i}`,
+    note: s.note,
+    text: bodyText(s.note),
+    creator: creatorName(s.note),
+    applicable: hasReplacement(s.note),
+  })),
+);
+</script>
+
+<template>
+  <nldd-simple-section width="full">
+    <!-- Status while suggestion jobs run in the background. -->
+    <nldd-inline-dialog
+      v-if="jobState === 'running'"
+      data-testid="suggestions-running"
+      text="Aanwijzingen worden gegenereerd…"
+      supporting-text="Dit kan een paar minuten duren. De suggesties verschijnen hier zodra ze klaar zijn."
+    ></nldd-inline-dialog>
+
+    <nldd-inline-dialog
+      v-else-if="loading"
+      data-testid="suggestions-loading"
+      text="Suggesties laden…"
+    ></nldd-inline-dialog>
+
+    <nldd-inline-dialog
+      v-else-if="items.length === 0 && issues.length === 0"
+      data-testid="suggestions-empty"
+      text="Geen suggesties voor dit artikel"
+      supporting-text="Sla de wet op om nieuwe suggesties te laten genereren."
+    ></nldd-inline-dialog>
+
+    <!-- The suggestions for the selected article. -->
+    <nldd-list v-if="items.length" variant="box" data-testid="suggestions-list">
+      <nldd-list-item
+        v-for="item in items"
+        :key="item.key"
+        size="md"
+        :data-testid="`suggestion-${item.key}`"
+      >
+        <nldd-cell width="full">
+          <nldd-text-cell :text="item.text" :supporting-text="item.creator"></nldd-text-cell>
+          <nldd-spacer size="8"></nldd-spacer>
+          <nldd-button-group>
+            <nldd-button
+              v-if="item.applicable"
+              variant="primary"
+              size="sm"
+              text="Toepassen"
+              :data-testid="`accept-${item.key}`"
+              @click="emit('accept', item.note)"
+            ></nldd-button>
+            <nldd-button
+              variant="subtle"
+              size="sm"
+              text="Afwijzen"
+              :data-testid="`reject-${item.key}`"
+              @click="emit('reject', item.note)"
+            ></nldd-button>
+          </nldd-button-group>
+        </nldd-cell>
+      </nldd-list-item>
+    </nldd-list>
+
+    <!-- Suggestions that couldn't be anchored, surfaced separately. -->
+    <template v-if="issues.length">
+      <nldd-spacer size="16"></nldd-spacer>
+      <nldd-title text="Niet verankerd" size="sm"></nldd-title>
+      <nldd-list variant="box" data-testid="suggestion-issues">
+        <nldd-list-item v-for="(issue, i) in issues" :key="`issue-${i}`" size="md">
+          <nldd-text-cell
+            :text="issue.note?.body?.[0]?.value ?? issue.note?.body?.value ?? 'Suggestie'"
+            :supporting-text="issue.reason"
+          ></nldd-text-cell>
+        </nldd-list-item>
+      </nldd-list>
+    </template>
+  </nldd-simple-section>
+</template>

--- a/frontend/src/composables/corpusUrls.js
+++ b/frontend/src/composables/corpusUrls.js
@@ -37,6 +37,17 @@ export function annotationsUrl(trajectRef, lawId) {
   return `${lawUrl(trajectRef, lawId)}/annotations`;
 }
 
+// AI-suggestion sidecar written by the pipeline to the traject branch
+// (separate from annotations.yaml). Read-only.
+export function suggestionsUrl(trajectRef, lawId) {
+  return `${lawUrl(trajectRef, lawId)}/suggestions`;
+}
+
+// Poll target for whether the suggestion jobs are still running.
+export function suggestionsStatusUrl(trajectRef, lawId) {
+  return `${lawUrl(trajectRef, lawId)}/suggestions/status`;
+}
+
 // Writes only exist under the traject prefix. Composables call this at
 // the top of their save function so the call-stack failure is "no
 // traject" instead of a malformed URL.

--- a/frontend/src/composables/useFeatureFlags.js
+++ b/frontend/src/composables/useFeatureFlags.js
@@ -14,6 +14,9 @@ const DEFAULTS = {
   // Notes pane (RFC-005/RFC-018). Off by default until the feature is past
   // the display-only MVP and the corpus has notes for more than one law.
   'panel.notes': false,
+  // AI-suggestiepane (aanwijzingen + machine_readable). Off by default:
+  // dark-launch tot de suggest-pipeline op productie draait.
+  'panel.suggestions': false,
   // Note authoring (RFC-018 write path, MVP: localStorage + manual export).
   // Off by default: it is a separate, opt-in capability on top of viewing.
   'notes.create': false,

--- a/frontend/src/composables/useSuggestions.js
+++ b/frontend/src/composables/useSuggestions.js
@@ -1,0 +1,199 @@
+/**
+ * useSuggestions — fetch a law's AI-suggestion sidecar and resolve it against
+ * the loaded law, plus poll the pipeline for in-flight suggestion jobs.
+ *
+ * Suggestions are just W3C Web Annotations (creator = an Agent), written by the
+ * pipeline to `suggestions.yaml` on the traject branch. They resolve through the
+ * same WASM resolver as notes (`engine.resolveNotes`) and render with the same
+ * `markRanges` helper — the editor highlights them with the `.note-generated`
+ * dotted style `AnnotatedText` already applies to `creator: llm/tool/generated`.
+ *
+ * Differs from useNotes in two ways:
+ *  - read-only of a different sidecar (`suggestionsUrl`), and
+ *  - a `pollStatus()` that watches `/suggestions/status` until both suggestion
+ *    kinds reach a terminal state, then reloads the sidecar once.
+ */
+import { ref, computed, watch } from 'vue';
+import { useEngine } from './useEngine.js';
+import { suggestionsUrl, suggestionsStatusUrl } from './corpusUrls.js';
+
+// Cache resolved suggestions per `${trajectRef}::${lawId}`, like useNotes. The
+// same save-doesn't-bump-$id caveat applies; `reload()` drops the entry so a
+// freshly-generated sidecar shows up without a navigation round-trip.
+const cache = new Map();
+
+function cacheKey(trajectRef, lawId) {
+  return `${trajectRef || ''}::${lawId}`;
+}
+
+const TERMINAL = new Set(['completed', 'failed']);
+
+/**
+ * @param {import('vue').Ref<string>} lawId reactive law $id
+ * @param {import('vue').Ref<object>} selectedArticle reactive current article
+ * @param {import('vue').Ref<string|null>} trajectRef reactive traject ref
+ */
+export function useSuggestions(lawId, selectedArticle, trajectRef) {
+  const { initEngine, loadDependency } = useEngine();
+  const resolved = ref([]); // [{ note, match, error }]
+  const loading = ref(false);
+  const error = ref(null);
+  // 'idle' | 'running' | 'done' — whether suggestion jobs are in flight.
+  const jobState = ref('idle');
+
+  // Generation guard: only the latest load()/poll() may write reactive state,
+  // mirroring useNotes — article numbers collide across laws, so a stale
+  // response could otherwise highlight the wrong spans.
+  let generation = 0;
+
+  async function load() {
+    const id = lawId.value;
+    const tr = trajectRef?.value ?? null;
+    const gen = ++generation;
+    const isStale = () => gen !== generation;
+
+    if (!id) {
+      resolved.value = [];
+      error.value = null;
+      loading.value = false;
+      return;
+    }
+    const key = cacheKey(tr, id);
+    if (cache.has(key)) {
+      resolved.value = cache.get(key);
+      error.value = null;
+      loading.value = false;
+      return;
+    }
+
+    loading.value = true;
+    error.value = null;
+    try {
+      const res = await fetch(suggestionsUrl(tr, id));
+      if (res.status === 404) {
+        // No sidecar yet is normal (no suggestions generated), not an error.
+        cache.set(key, []);
+        if (!isStale()) resolved.value = [];
+        return;
+      }
+      if (!res.ok) {
+        throw new Error(`Kon suggesties niet laden: ${res.status}`);
+      }
+      const yamlText = await res.text();
+
+      const engine = await initEngine();
+      await loadDependency(id, tr);
+      const result = engine.resolveNotes(id, yamlText);
+      const list = Array.isArray(result) ? result : [];
+      cache.set(key, list);
+      if (!isStale()) resolved.value = list;
+    } catch (e) {
+      if (!isStale()) {
+        error.value = e;
+        resolved.value = [];
+      }
+    } finally {
+      if (!isStale()) loading.value = false;
+    }
+  }
+
+  // Re-load when the law or active traject changes.
+  const trackers = trajectRef ? [lawId, trajectRef] : [lawId];
+  watch(trackers, load, { immediate: true });
+
+  /** Drop the cache entry for the current law, then reload. */
+  async function reload() {
+    const id = lawId.value;
+    if (id) cache.delete(cacheKey(trajectRef?.value ?? null, id));
+    await load();
+  }
+
+  /**
+   * Poll `/suggestions/status` until both suggestion kinds are terminal (or the
+   * timeout elapses), then reload the sidecar once. Called by the editor right
+   * after a save. Self-cancels if the law/traject changes mid-poll.
+   *
+   * The pipeline runs `claude -p` (up to ~10 min), so we poll every 4s with a
+   * generous cap rather than a tight loop.
+   */
+  async function pollStatus({ intervalMs = 4000, timeoutMs = 12 * 60 * 1000 } = {}) {
+    const id = lawId.value;
+    const tr = trajectRef?.value ?? null;
+    if (!id || !tr) return;
+    const gen = ++generation;
+    const isStale = () => gen !== generation;
+
+    jobState.value = 'running';
+    const deadline = Date.now() + timeoutMs;
+
+    while (!isStale() && Date.now() < deadline) {
+      let entries = [];
+      try {
+        const res = await fetch(suggestionsStatusUrl(tr, id));
+        if (res.ok) {
+          const body = await res.json();
+          entries = Array.isArray(body?.results) ? body.results : [];
+        }
+      } catch {
+        // Transient; keep polling until the deadline.
+      }
+      if (isStale()) return;
+
+      // Done when there is at least one job and every reported job is terminal.
+      const allTerminal =
+        entries.length > 0 && entries.every((e) => TERMINAL.has(e.status));
+      if (allTerminal) {
+        await reload();
+        if (!isStale()) jobState.value = 'done';
+        return;
+      }
+      await new Promise((r) => setTimeout(r, intervalMs));
+    }
+    if (!isStale()) jobState.value = 'idle';
+  }
+
+  /**
+   * Suggestions whose match falls in the currently-selected article, each with
+   * the resolved span(s). Same shape and filtering as useNotes.notesForArticle
+   * so the editor can render them through the same `markRanges` path.
+   */
+  const suggestionsForArticle = computed(() => {
+    const articleNr = selectedArticle.value?.number;
+    if (articleNr == null || articleNr === '') return [];
+    const target = String(articleNr);
+    const out = [];
+    for (const entry of resolved.value) {
+      if (entry.error || !entry.match) continue;
+      if (entry.match.status !== 'found') continue;
+      const spans = entry.match.matches.filter(
+        (m) => String(m.article_number) === target,
+      );
+      if (spans.length > 0) out.push({ note: entry.note, spans });
+    }
+    return out;
+  });
+
+  /** Orphaned / ambiguous / parse-failed suggestions, for a status list. */
+  const issues = computed(() =>
+    resolved.value
+      .filter((e) => e.error || (e.match && e.match.status !== 'found'))
+      .map((e) => ({
+        note: e.note,
+        reason: e.error
+          ? `parsefout: ${e.error}`
+          : e.match.status === 'orphaned'
+            ? 'niet gevonden in de wettekst (orphaned)'
+            : 'meerdere matches (ambigu)',
+      })),
+  );
+
+  return {
+    suggestionsForArticle,
+    issues,
+    loading,
+    error,
+    jobState,
+    reload,
+    pollStatus,
+  };
+}

--- a/frontend/src/composables/useSuggestions.js
+++ b/frontend/src/composables/useSuggestions.js
@@ -17,6 +17,42 @@ import { ref, computed, watch } from 'vue';
 import { useEngine } from './useEngine.js';
 import { suggestionsUrl, suggestionsStatusUrl } from './corpusUrls.js';
 
+// Resolved (accepted/rejected) suggestions are remembered locally so they drop
+// out of the pane. There is no server write path for the suggestions sidecar
+// (it is pipeline-owned), and the sidecar is regenerated each save anyway, so a
+// per-(traject,law) localStorage set of resolved keys is the right granularity:
+// it survives refresh, and a fresh save that re-raises the same finding will
+// re-key identically and stay hidden (which is the desired "I already handled
+// this" behaviour) until the user clears it.
+const RESOLVED_KEY = 'regelrecht-resolved-suggestions';
+
+function loadResolved() {
+  try {
+    return new Set(JSON.parse(localStorage.getItem(RESOLVED_KEY) || '[]'));
+  } catch {
+    return new Set();
+  }
+}
+
+function saveResolved(set) {
+  try {
+    localStorage.setItem(RESOLVED_KEY, JSON.stringify([...set]));
+  } catch {
+    /* ignore quota / private-mode failures */
+  }
+}
+
+/**
+ * Stable identity for a suggestion: traject + law + anchor + body text. Used to
+ * remember which suggestions the user already accepted/rejected.
+ */
+export function suggestionKey(trajectRef, lawId, note) {
+  const exact = note?.target?.selector?.exact ?? '';
+  const body = note?.body;
+  const value = (Array.isArray(body) ? body[0] : body)?.value ?? '';
+  return `${trajectRef || ''}::${lawId}::${exact}::${value}`;
+}
+
 // Cache resolved suggestions per `${trajectRef}::${lawId}`, like useNotes. The
 // same save-doesn't-bump-$id caveat applies; `reload()` drops the entry so a
 // freshly-generated sidecar shows up without a navigation round-trip.
@@ -40,6 +76,19 @@ export function useSuggestions(lawId, selectedArticle, trajectRef) {
   const error = ref(null);
   // 'idle' | 'running' | 'done' — whether suggestion jobs are in flight.
   const jobState = ref('idle');
+  // Reactive set of locally-resolved suggestion keys; accepted/rejected items
+  // are filtered out of the pane. Reactivity via a bumped counter (a plain Set
+  // is not deeply reactive).
+  const resolvedKeys = ref(loadResolved());
+  const resolvedTick = ref(0);
+
+  /** Mark a suggestion resolved (accepted or rejected) and persist it. */
+  function markResolved(note) {
+    const key = suggestionKey(trajectRef?.value ?? null, lawId.value, note);
+    resolvedKeys.value.add(key);
+    saveResolved(resolvedKeys.value);
+    resolvedTick.value++;
+  }
 
   // Generation guard: only the latest load()/poll() may write reactive state,
   // mirroring useNotes — article numbers collide across laws, so a stale
@@ -157,6 +206,15 @@ export function useSuggestions(lawId, selectedArticle, trajectRef) {
    * the resolved span(s). Same shape and filtering as useNotes.notesForArticle
    * so the editor can render them through the same `markRanges` path.
    */
+  // True when this note has been accepted/rejected this session. Reading
+  // resolvedTick makes the computeds re-run when markResolved fires.
+  function isResolved(note) {
+    void resolvedTick.value;
+    return resolvedKeys.value.has(
+      suggestionKey(trajectRef?.value ?? null, lawId.value, note),
+    );
+  }
+
   const suggestionsForArticle = computed(() => {
     const articleNr = selectedArticle.value?.number;
     if (articleNr == null || articleNr === '') return [];
@@ -165,6 +223,7 @@ export function useSuggestions(lawId, selectedArticle, trajectRef) {
     for (const entry of resolved.value) {
       if (entry.error || !entry.match) continue;
       if (entry.match.status !== 'found') continue;
+      if (isResolved(entry.note)) continue;
       const spans = entry.match.matches.filter(
         (m) => String(m.article_number) === target,
       );
@@ -177,6 +236,7 @@ export function useSuggestions(lawId, selectedArticle, trajectRef) {
   const issues = computed(() =>
     resolved.value
       .filter((e) => e.error || (e.match && e.match.status !== 'found'))
+      .filter((e) => !isResolved(e.note))
       .map((e) => ({
         note: e.note,
         reason: e.error
@@ -195,5 +255,6 @@ export function useSuggestions(lawId, selectedArticle, trajectRef) {
     jobState,
     reload,
     pollStatus,
+    markResolved,
   };
 }

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -541,6 +541,44 @@ pub async fn get_traject_annotations(
     get_annotations_in_scope(&scope, &law_id).await
 }
 
+/// GET /api/trajects/{traject_id}/corpus/laws/{law_id}/suggestions — read the
+/// AI-suggestion sidecar the pipeline wrote to this traject's branch. Same shape
+/// as the annotations read, but reads `suggestions.yaml` (kept separate from the
+/// human `annotations.yaml` so AI output never pollutes curated notes). 404 when
+/// no suggestions have been generated yet, which the editor treats as "none".
+pub async fn get_traject_suggestions(
+    State(state): State<AppState>,
+    session: Session,
+    Path((traject_ref, law_id)): Path<(String, String)>,
+) -> Result<YamlResponse, (StatusCode, String)> {
+    let scope = require_traject_scope(&state, &session, &traject_ref).await?;
+    let backend = resolve_annotation_read_backend(&scope, &law_id)?;
+
+    let relative_path = PathBuf::from("annotations")
+        .join(&law_id)
+        .join("suggestions.yaml");
+
+    let backend = backend.lock().await;
+    let content = backend
+        .read_file(&relative_path)
+        .await
+        .map_err(|e| {
+            tracing::warn!(law_id = %law_id, error = %e, "get_suggestions backend read failed");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to read suggestions".to_string(),
+            )
+        })?
+        .ok_or((StatusCode::NOT_FOUND, "Suggestions not found".to_string()))?;
+    drop(backend);
+
+    Ok((
+        StatusCode::OK,
+        [(axum::http::header::CONTENT_TYPE, "text/yaml; charset=utf-8")],
+        content,
+    ))
+}
+
 async fn get_annotations_in_scope(
     scope: &ReadScope,
     law_id: &str,
@@ -1335,7 +1373,55 @@ pub async fn save_law(
     // the read-your-writes follow-up that used to be punted.
     traject.record_save(law_id.clone(), body).await;
 
+    // Fire-and-forget: ask the pipeline to generate AI suggestions for the
+    // just-saved law on this traject's branch. Advisory — any failure here must
+    // never affect the save, so we only log. Skipped when the pipeline isn't
+    // configured or when the traject has no GitHub branch (a local writable
+    // source the worker can't check out).
+    if let (Some(pipeline_url), Some(branch)) = (
+        state.pipeline_api_url.clone(),
+        traject.writable_branch().map(str::to_string),
+    ) {
+        let http = state.http_client.clone();
+        let yaml_path = relative_path.to_string_lossy().to_string();
+        let law = law_id.clone();
+        let tref = traject_ref.clone();
+        tokio::spawn(async move {
+            enqueue_suggestions(&http, &pipeline_url, &law, &yaml_path, &tref, &branch).await;
+        });
+    }
+
     Ok(Json(save_response_from_traject(outcome)))
+}
+
+/// POST the pipeline `/suggest` enqueue for a saved law. Best-effort: logs and
+/// swallows all errors so it can run detached from the save response.
+async fn enqueue_suggestions(
+    http: &reqwest::Client,
+    pipeline_url: &str,
+    law_id: &str,
+    yaml_path: &str,
+    traject_ref: &str,
+    traject_branch: &str,
+) {
+    let url = format!("{pipeline_url}/suggest");
+    let body = serde_json::json!({
+        "law_id": law_id,
+        "yaml_path": yaml_path,
+        "traject_ref": traject_ref,
+        "traject_branch": traject_branch,
+    });
+    match http.post(&url).json(&body).send().await {
+        Ok(resp) if resp.status().is_success() => {
+            tracing::debug!(law_id, traject_ref, "queued AI suggestions");
+        }
+        Ok(resp) => {
+            tracing::warn!(law_id, status = %resp.status(), "suggest enqueue returned non-success");
+        }
+        Err(e) => {
+            tracing::warn!(law_id, error = %e, "failed to enqueue suggestions");
+        }
+    }
 }
 
 /// DELETE /api/trajects/{traject_id}/corpus/laws/{law_id}/scenarios/{filename}

--- a/packages/editor-api/src/feature_flags.rs
+++ b/packages/editor-api/src/feature_flags.rs
@@ -21,6 +21,11 @@ static DEFAULTS: LazyLock<HashMap<String, bool>> = LazyLock::new(|| {
         // 400s and the frontend silently reverts it (see the editor.* note
         // below — same allow-list mechanism).
         ("panel.notes".into(), false),
+        // AI-suggestiepane: toont de door de pipeline gegenereerde suggesties
+        // (aanwijzingen + machine_readable) als annotaties met accept/reject.
+        // Default off: dark-launch tot de suggest-pipeline op productie draait.
+        // Moet hier staan of de toggle-PUT 400't (allow-list).
+        ("panel.suggestions".into(), false),
         // Note authoring (RFC-018 write path, MVP: localStorage + manual
         // export). Separate gate from panel.notes so notes can be shown
         // read-only without exposing creation. Same allow-list rule: without

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -24,6 +24,7 @@ mod feature_flags;
 mod harvest_proxy;
 mod middleware;
 mod state;
+mod suggest_proxy;
 mod traject_corpus;
 mod trajects;
 mod user_settings;
@@ -274,6 +275,14 @@ async fn main() {
         .route(
             "/api/trajects/{traject_ref}/corpus/laws/{law_id}/annotations",
             get(corpus_handlers::get_traject_annotations),
+        )
+        .route(
+            "/api/trajects/{traject_ref}/corpus/laws/{law_id}/suggestions",
+            get(corpus_handlers::get_traject_suggestions),
+        )
+        .route(
+            "/api/trajects/{traject_ref}/corpus/laws/{law_id}/suggestions/status",
+            get(suggest_proxy::proxy_suggest_status),
         )
         .route_layer(axum_middleware::from_fn_with_state(
             app_state.clone(),

--- a/packages/editor-api/src/suggest_proxy.rs
+++ b/packages/editor-api/src/suggest_proxy.rs
@@ -1,0 +1,51 @@
+//! Proxy for the editor's suggestion-status polling.
+//!
+//! The editor polls `/api/trajects/{ref}/corpus/laws/{law_id}/suggestions/status`
+//! after a save; this forwards it to the pipeline-api `/suggest/status` endpoint
+//! (in-cluster) and returns the per-kind job state. Mirrors `harvest_proxy` but
+//! maps the traject-scoped path to the pipeline's flat query interface.
+
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+
+use crate::state::AppState;
+
+/// GET /api/trajects/{traject_ref}/corpus/laws/{law_id}/suggestions/status
+pub async fn proxy_suggest_status(
+    State(state): State<AppState>,
+    Path((traject_ref, law_id)): Path<(String, String)>,
+) -> Result<Response, (StatusCode, String)> {
+    let pipeline_url = state.pipeline_api_url.as_deref().ok_or((
+        StatusCode::SERVICE_UNAVAILABLE,
+        "Pipeline API not configured".to_string(),
+    ))?;
+
+    let resp = state
+        .http_client
+        .get(format!("{pipeline_url}/suggest/status"))
+        .query(&[
+            ("law_id", law_id.as_str()),
+            ("traject_ref", traject_ref.as_str()),
+        ])
+        .send()
+        .await
+        .map_err(|e| {
+            tracing::warn!(error = %e, "suggest status proxy request failed");
+            (
+                StatusCode::BAD_GATEWAY,
+                "Failed to reach pipeline API".to_string(),
+            )
+        })?;
+
+    let status =
+        StatusCode::from_u16(resp.status().as_u16()).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+    let body = resp.text().await.unwrap_or_default();
+
+    Ok((
+        status,
+        [(axum::http::header::CONTENT_TYPE, "application/json")],
+        body,
+    )
+        .into_response())
+}

--- a/packages/editor-api/src/traject_corpus.rs
+++ b/packages/editor-api/src/traject_corpus.rs
@@ -57,6 +57,11 @@ pub struct TrajectCorpus {
     /// added that touches many laws per traject, revisit with an LRU
     /// cap.
     overlay: RwLock<HashMap<String, String>>,
+    /// Git branch the traject's writable-own source pushes to
+    /// (`traject/{slug}-{8hex}`). `None` for trajects whose writable source is
+    /// local (no branch). Used by the suggest-on-save flow to tell the pipeline
+    /// which branch to read the saved law from and write the sidecar to.
+    writable_branch: Option<String>,
 }
 
 impl TrajectCorpus {
@@ -78,6 +83,12 @@ impl TrajectCorpus {
     /// so the next GET on the same law (or a refresh) sees the new body.
     pub async fn record_save(&self, law_id: String, body: String) {
         self.overlay.write().await.insert(law_id, body);
+    }
+
+    /// The git branch the traject's saves land on, if the writable source is a
+    /// GitHub branch. `None` for local writable sources.
+    pub fn writable_branch(&self) -> Option<&str> {
+        self.writable_branch.as_deref()
     }
 }
 
@@ -190,11 +201,15 @@ async fn build_traject_corpus(
     // can't route saves on laws read from the seed sources. The actual
     // routing happens via `write_target_for_source` below; the local
     // here is just the guard against a misconfigured traject.
-    let writable_own_source_id = rows
+    let writable_own_row = rows
         .iter()
         .find(|r| r.is_writable_own)
-        .map(|r| r.source_id.clone())
         .ok_or(TrajectCorpusError::NoWritableOwn)?;
+    let writable_own_source_id = writable_own_row.source_id.clone();
+    // The git branch the traject's saves land on (`traject/{slug}-{8hex}`).
+    // Captured here so the suggest-on-save flow can tell the pipeline which
+    // branch to read the saved law from and commit the suggestion sidecar to.
+    let writable_branch = writable_own_row.gh_branch.clone();
 
     // Build the read-source → write-target-source map. Every non-
     // writable_own source (local seed, GitHub seed, …) is routed to the
@@ -359,6 +374,7 @@ async fn build_traject_corpus(
         },
         write_target_for_source,
         overlay: RwLock::new(HashMap::new()),
+        writable_branch,
     }))
 }
 

--- a/packages/pipeline/migrations/0018_suggest_job_types.sql
+++ b/packages/pipeline/migrations/0018_suggest_job_types.sql
@@ -1,0 +1,34 @@
+-- Add suggest_guidelines and suggest_machine_readable job types for the
+-- editor's background AI-suggestion pipeline (suggestions on save).
+--
+-- Cannot use ALTER TYPE ADD VALUE inside a transaction (sqlx wraps each
+-- migration in one), so recreate the enum type with the new values — the
+-- same pattern as 0007 for law_status.
+
+-- 1. Rename the existing type to a temporary name. The jobs.job_type column
+--    has no default, so no default-drop dance is needed (unlike 0007).
+ALTER TYPE job_type RENAME TO job_type_old;
+
+-- 2. Create the new type with the suggest variants added.
+CREATE TYPE job_type AS ENUM (
+    'harvest',
+    'enrich',
+    'suggest_guidelines',
+    'suggest_machine_readable'
+);
+
+-- 3. Move the column to the new type (cast via text).
+ALTER TABLE jobs
+    ALTER COLUMN job_type TYPE job_type USING job_type::text::job_type;
+
+-- 4. Drop the old type.
+DROP TYPE job_type_old;
+
+-- 5. Prevent duplicate active suggest jobs per law + traject + kind. A save
+--    enqueues at most one job of each suggest kind per (law, traject); this
+--    closes the race where rapid saves pile up redundant suggestion runs
+--    while one is still pending/processing. Mirrors idx_unique_active_enrich_job.
+CREATE UNIQUE INDEX idx_unique_active_suggest_job
+    ON jobs (law_id, job_type, (payload->>'traject_ref'))
+    WHERE job_type IN ('suggest_guidelines', 'suggest_machine_readable')
+      AND status IN ('pending', 'processing');

--- a/packages/pipeline/src/api/mod.rs
+++ b/packages/pipeline/src/api/mod.rs
@@ -1,3 +1,4 @@
 pub mod bwb_search;
 pub mod harvest;
 pub mod status;
+pub mod suggest;

--- a/packages/pipeline/src/api/suggest.rs
+++ b/packages/pipeline/src/api/suggest.rs
@@ -1,0 +1,171 @@
+//! Pipeline-API endpoints for the editor-suggestion pipeline.
+//!
+//! `POST /suggest` enqueues one job per kind for a saved law on its traject
+//! branch; the editor-api calls this fire-and-forget after a successful save.
+//! `GET /suggest/status` reports the latest suggest-job state per kind so the
+//! editor can poll until the suggestions are ready.
+
+use axum::extract::{Query, State};
+use axum::http::StatusCode;
+use axum::Json;
+use serde::{Deserialize, Serialize};
+
+use crate::job_queue::{self, CreateJobRequest};
+use crate::models::{JobType, Priority};
+use crate::suggest::{SuggestKind, SuggestPayload};
+use crate::ApiState;
+
+/// Editor suggestions run at a higher priority than batch enrich (50) so a user
+/// waiting in the editor isn't stuck behind bulk enrichment, but below
+/// editor-requested harvest (80).
+const SUGGEST_PRIORITY: i32 = 70;
+
+/// Suggest jobs are advisory; a single attempt is enough (the user can re-save
+/// to retry). Avoids spending repeated LLM runs on a flaky law.
+const SUGGEST_MAX_ATTEMPTS: i32 = 1;
+
+#[derive(Deserialize)]
+pub struct SuggestRequest {
+    pub law_id: String,
+    pub yaml_path: String,
+    pub traject_ref: String,
+    pub traject_branch: String,
+    /// Optional single article to scope to. None = whole law.
+    #[serde(default)]
+    pub article_number: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct SuggestResponse {
+    /// Which kinds were enqueued this call (a kind already pending/processing
+    /// for this law+traject is skipped, so it won't appear here).
+    pub enqueued: Vec<String>,
+}
+
+/// POST /suggest
+///
+/// Enqueues a guidelines job and a machine_readable job for the saved law. A
+/// kind that already has an active (pending/processing) job for this
+/// law+traject is skipped (the partial unique index makes this atomic).
+pub async fn request_suggest(
+    State(state): State<ApiState>,
+    Json(body): Json<SuggestRequest>,
+) -> Result<Json<SuggestResponse>, (StatusCode, String)> {
+    if body.law_id.is_empty() || body.yaml_path.is_empty() || body.traject_branch.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "law_id, yaml_path and traject_branch are required".to_string(),
+        ));
+    }
+
+    let mut enqueued = Vec::new();
+    for kind in [SuggestKind::Guidelines, SuggestKind::MachineReadable] {
+        let payload = SuggestPayload {
+            law_id: body.law_id.clone(),
+            yaml_path: body.yaml_path.clone(),
+            traject_ref: body.traject_ref.clone(),
+            traject_branch: body.traject_branch.clone(),
+            kind,
+            article_number: body.article_number.clone(),
+        };
+        let payload_json = match serde_json::to_value(&payload) {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::error!(error = %e, "failed to serialize suggest payload");
+                continue;
+            }
+        };
+        let job_type = match kind {
+            SuggestKind::Guidelines => JobType::SuggestGuidelines,
+            SuggestKind::MachineReadable => JobType::SuggestMachineReadable,
+        };
+        let req = CreateJobRequest::new(job_type, body.law_id.clone())
+            .with_priority(Priority::new(SUGGEST_PRIORITY))
+            .with_payload(payload_json)
+            .with_max_attempts(SUGGEST_MAX_ATTEMPTS);
+
+        match job_queue::create_suggest_job_if_not_exists(&state.pool, req, &body.traject_ref).await
+        {
+            Ok(Some(_job)) => enqueued.push(kind.slug().to_string()),
+            Ok(None) => {
+                tracing::debug!(law_id = %body.law_id, kind = kind.slug(), "suggest job already active, skipped");
+            }
+            Err(e) => {
+                tracing::error!(error = %e, kind = kind.slug(), "failed to enqueue suggest job");
+            }
+        }
+    }
+
+    Ok(Json(SuggestResponse { enqueued }))
+}
+
+#[derive(Deserialize)]
+pub struct SuggestStatusQuery {
+    pub law_id: String,
+    pub traject_ref: String,
+}
+
+#[derive(Serialize)]
+pub struct SuggestStatusEntry {
+    pub kind: String,
+    pub status: String,
+}
+
+#[derive(Serialize)]
+pub struct SuggestStatusResponse {
+    /// Latest job state per kind for this law+traject. Absent kinds have never
+    /// been requested.
+    pub results: Vec<SuggestStatusEntry>,
+}
+
+/// GET /suggest/status?law_id=...&traject_ref=...
+///
+/// Returns the latest job status per suggest kind for a law within a traject,
+/// so the editor can poll until both runs reach a terminal state.
+pub async fn suggest_status(
+    State(state): State<ApiState>,
+    Query(query): Query<SuggestStatusQuery>,
+) -> Result<Json<SuggestStatusResponse>, (StatusCode, String)> {
+    if query.law_id.is_empty() {
+        return Err((StatusCode::BAD_REQUEST, "law_id is required".to_string()));
+    }
+
+    // Latest job per suggest kind for this law + traject (matched on the
+    // payload's traject_ref). DISTINCT ON keeps the most recent per job_type.
+    let rows: Vec<(String, String)> = sqlx::query_as(
+        r#"
+        SELECT DISTINCT ON (job_type) job_type::text, status::text
+        FROM jobs
+        WHERE law_id = $1
+          AND job_type IN ('suggest_guidelines', 'suggest_machine_readable')
+          AND payload->>'traject_ref' = $2
+        ORDER BY job_type, created_at DESC
+        "#,
+    )
+    .bind(&query.law_id)
+    .bind(&query.traject_ref)
+    .fetch_all(&state.pool)
+    .await
+    .map_err(|e| {
+        tracing::error!(error = %e, "failed to query suggest status");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Failed to query suggest status".to_string(),
+        )
+    })?;
+
+    let results = rows
+        .into_iter()
+        .map(|(job_type, status)| SuggestStatusEntry {
+            // Map the DB job_type back to the editor-facing kind slug.
+            kind: match job_type.as_str() {
+                "suggest_guidelines" => "guidelines".to_string(),
+                "suggest_machine_readable" => "machine_readable".to_string(),
+                other => other.to_string(),
+            },
+            status,
+        })
+        .collect();
+
+    Ok(Json(SuggestStatusResponse { results }))
+}

--- a/packages/pipeline/src/bin/enrich_worker.rs
+++ b/packages/pipeline/src/bin/enrich_worker.rs
@@ -1,7 +1,7 @@
 use regelrecht_pipeline::config::WorkerConfig;
 use regelrecht_pipeline::db;
 use regelrecht_pipeline::health::spawn_health_server;
-use regelrecht_pipeline::worker::run_enrich_worker;
+use regelrecht_pipeline::worker::{run_enrich_worker, run_suggest_worker};
 
 #[tokio::main]
 async fn main() {
@@ -31,10 +31,21 @@ async fn main() {
         }
     };
 
+    // Run the editor-suggestion worker alongside enrich in the same binary, so
+    // suggestions share this component's deployment, secrets, and baked-in
+    // skills without a separate ZAD component.
+    let suggest_config = config.clone();
+
     tokio::select! {
         result = run_enrich_worker(config) => {
             if let Err(e) = result {
                 tracing::error!(error = %e, "enrich worker exited with error");
+                std::process::exit(1);
+            }
+        }
+        result = run_suggest_worker(suggest_config) => {
+            if let Err(e) = result {
+                tracing::error!(error = %e, "suggest worker exited with error");
                 std::process::exit(1);
             }
         }

--- a/packages/pipeline/src/bin/pipeline_api.rs
+++ b/packages/pipeline/src/bin/pipeline_api.rs
@@ -2,7 +2,7 @@ use axum::routing::{get, post};
 use axum::Router;
 use tower_http::trace::TraceLayer;
 
-use regelrecht_pipeline::api::{bwb_search, harvest, status};
+use regelrecht_pipeline::api::{bwb_search, harvest, status, suggest};
 use regelrecht_pipeline::ApiState;
 
 #[tokio::main]
@@ -50,6 +50,8 @@ async fn main() {
         .route("/harvest", post(harvest::request_harvest))
         .route("/harvest/batch", post(harvest::request_harvest_batch))
         .route("/harvest/status", get(status::harvest_status))
+        .route("/suggest", post(suggest::request_suggest))
+        .route("/suggest/status", get(suggest::suggest_status))
         .route("/health", get(health))
         .layer(TraceLayer::new_for_http())
         .with_state(state);

--- a/packages/pipeline/src/error.rs
+++ b/packages/pipeline/src/error.rs
@@ -35,6 +35,12 @@ pub enum PipelineError {
     #[error("enrichment error: {0}")]
     Enrich(String),
 
+    #[error("suggestion error: {0}")]
+    Suggest(String),
+
+    #[error("LLM error: {0}")]
+    Llm(#[from] crate::llm::LlmError),
+
     #[error("worker error: {0}")]
     Worker(String),
 

--- a/packages/pipeline/src/job_queue.rs
+++ b/packages/pipeline/src/job_queue.rs
@@ -284,6 +284,53 @@ where
     Ok(job)
 }
 
+/// Create a suggest job only if no active one exists for this law + traject +
+/// kind. The partial unique index `idx_unique_active_suggest_job` (migration
+/// 0018) makes this atomic: a duplicate insert while one is pending/processing
+/// raises a 23505 unique-violation, which we translate into `Ok(None)`.
+///
+/// `traject_ref` must match `req.payload`'s `traject_ref` (the index keys on the
+/// payload field); it is passed separately only for the log line.
+///
+/// Returns `Some(Job)` if created, `None` if an active job already exists.
+pub async fn create_suggest_job_if_not_exists<'e, E>(
+    executor: E,
+    req: CreateJobRequest,
+    traject_ref: &str,
+) -> Result<Option<Job>>
+where
+    E: sqlx::PgExecutor<'e>,
+{
+    let result = sqlx::query_as::<_, Job>(
+        r#"
+        INSERT INTO jobs (job_type, law_id, priority, payload, max_attempts)
+        VALUES ($1, $2, $3, $4, $5)
+        RETURNING *
+        "#,
+    )
+    .bind(req.job_type)
+    .bind(&req.law_id)
+    .bind(req.priority.value())
+    .bind(&req.payload)
+    .bind(req.max_attempts)
+    .fetch_optional(executor)
+    .await;
+
+    let job = match result {
+        Ok(job) => job,
+        Err(sqlx::Error::Database(ref db_err)) if db_err.code().as_deref() == Some("23505") => {
+            return Ok(None);
+        }
+        Err(e) => return Err(e.into()),
+    };
+
+    if let Some(ref j) = job {
+        tracing::info!(job_id = %j.id, law_id = %j.law_id, traject = %traject_ref, "suggest job created");
+    }
+
+    Ok(job)
+}
+
 /// Update the progress field of a running job.
 ///
 /// Used by the enrich worker to report live phase information

--- a/packages/pipeline/src/law_status.rs
+++ b/packages/pipeline/src/law_status.rs
@@ -290,10 +290,17 @@ where
 }
 
 /// Column name on `law_entries` holding the consecutive fail counter for a job type.
-fn fail_count_column(job_type: crate::models::JobType) -> &'static str {
+///
+/// Returns `None` for suggest job types: editor suggestions are advisory and per
+/// traject, not part of the harvest/enrich law lifecycle, so they have no
+/// `law_entries` fail counter. The suggest worker never calls the fail-count or
+/// exhaustion helpers — this guard keeps that invariant explicit.
+fn fail_count_column(job_type: crate::models::JobType) -> Option<&'static str> {
     match job_type {
-        crate::models::JobType::Harvest => "harvest_fail_count",
-        crate::models::JobType::Enrich => "enrich_fail_count",
+        crate::models::JobType::Harvest => Some("harvest_fail_count"),
+        crate::models::JobType::Enrich => Some("enrich_fail_count"),
+        crate::models::JobType::SuggestGuidelines
+        | crate::models::JobType::SuggestMachineReadable => None,
     }
 }
 
@@ -307,7 +314,10 @@ pub async fn increment_fail_count<'e, E>(
 where
     E: sqlx::PgExecutor<'e>,
 {
-    let column = fail_count_column(job_type);
+    let Some(column) = fail_count_column(job_type) else {
+        // Suggest jobs have no law_entries fail counter; nothing to increment.
+        return Ok(0);
+    };
     // Column name is from a match on an enum, not user input — safe to interpolate.
     let sql = format!(
         "UPDATE law_entries SET {column} = {column} + 1, updated_at = now() \
@@ -332,7 +342,10 @@ pub async fn reset_fail_count<'e, E>(
 where
     E: sqlx::PgExecutor<'e>,
 {
-    let column = fail_count_column(job_type);
+    let Some(column) = fail_count_column(job_type) else {
+        // Suggest jobs have no law_entries fail counter; nothing to reset.
+        return Ok(());
+    };
     let sql = format!("UPDATE law_entries SET {column} = 0, updated_at = now() WHERE law_id = $1");
     sqlx::query(&sql).bind(law_id).execute(executor).await?;
 
@@ -359,6 +372,10 @@ where
             LawStatusValue::EnrichFailed,
             LawStatusValue::EnrichExhausted,
         ),
+        // Suggest jobs are advisory and per-traject; they have no exhausted
+        // law-lifecycle state. The suggest worker never calls this.
+        crate::models::JobType::SuggestGuidelines
+        | crate::models::JobType::SuggestMachineReadable => return Ok(()),
     };
     // Only exhaust if status is still the corresponding failed state,
     // preventing a race with admin reset.

--- a/packages/pipeline/src/lib.rs
+++ b/packages/pipeline/src/lib.rs
@@ -9,7 +9,9 @@ pub mod harvest;
 pub mod health;
 pub mod job_queue;
 pub mod law_status;
+pub mod llm;
 pub mod models;
+pub mod suggest;
 #[cfg(feature = "test-utils")]
 pub mod test_utils;
 pub mod worker;

--- a/packages/pipeline/src/llm.rs
+++ b/packages/pipeline/src/llm.rs
@@ -1,0 +1,226 @@
+//! Shared LLM invocation primitives.
+//!
+//! Both the enrich pipeline (`enrich.rs`) and the editor-suggestion pipeline
+//! (`suggest.rs`) spawn a headless LLM CLI (`claude -p` / `opencode run`) on a
+//! checked-out corpus repo. This module holds the provider selection, the
+//! environment allowlist, and the process runner so neither pipeline duplicates
+//! the subprocess/timeout/kill handling.
+//!
+//! The runner is deliberately prompt-based: callers build the prompt themselves
+//! and hand it to [`LlmRunner::run`] together with the working directory. It
+//! knows nothing about enrich payloads or suggestion kinds.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+/// A headless LLM provider plus where its CLI lives.
+///
+/// Both providers manage their own authentication:
+/// - **OpenCode/VLAM**: reads `~/.local/share/opencode/auth.json` (set via `opencode auth`)
+/// - **Claude**: reads `~/.claude/.credentials` or `ANTHROPIC_API_KEY` env var
+///
+/// In Docker, mount the appropriate auth files or set env vars.
+#[derive(Debug, Clone)]
+pub enum LlmProvider {
+    OpenCode {
+        path: PathBuf,
+        model: Option<String>,
+    },
+    Claude {
+        path: PathBuf,
+        model: Option<String>,
+    },
+}
+
+impl LlmProvider {
+    /// Short name used in branch names and metadata.
+    pub fn name(&self) -> &str {
+        match self {
+            LlmProvider::OpenCode { .. } => "opencode",
+            LlmProvider::Claude { .. } => "claude",
+        }
+    }
+
+    /// Model string for metadata (provider-specific default if not set).
+    pub fn model_str(&self) -> String {
+        match self {
+            LlmProvider::OpenCode { model, .. } => {
+                model.clone().unwrap_or_else(|| "default".into())
+            }
+            LlmProvider::Claude { model, .. } => model.clone().unwrap_or_else(|| "default".into()),
+        }
+    }
+}
+
+/// What an LLM run needs: a fully-built prompt, the repo working directory, the
+/// provider, the timeout, and the tools the agent may use. Kept provider- and
+/// pipeline-agnostic so enrich and suggest share one runner.
+pub struct LlmInvocation<'a> {
+    pub prompt: &'a str,
+    pub repo_path: &'a Path,
+    pub provider: &'a LlmProvider,
+    pub timeout: Duration,
+    /// Comma-separated allowed tools for the Claude CLI (`--allowedTools`).
+    /// OpenCode ignores this. Example: "Read,Edit,Write,Grep,Glob".
+    pub allowed_tools: &'a str,
+}
+
+/// Trait abstracting the LLM invocation so callers can test with a fake
+/// provider that doesn't spawn real processes.
+#[async_trait::async_trait]
+pub trait LlmRunner: Send + Sync {
+    /// Run the LLM with the given invocation. Implementations respect the timeout.
+    async fn run(&self, inv: &LlmInvocation<'_>) -> Result<(), LlmError>;
+}
+
+/// Error from spawning or running the LLM subprocess.
+#[derive(Debug, thiserror::Error)]
+pub enum LlmError {
+    #[error("{0}")]
+    Process(String),
+}
+
+/// Default runner that spawns a real CLI process.
+pub struct ProcessLlmRunner;
+
+#[async_trait::async_trait]
+impl LlmRunner for ProcessLlmRunner {
+    async fn run(&self, inv: &LlmInvocation<'_>) -> Result<(), LlmError> {
+        let provider_name = inv.provider.name().to_string();
+        let mut cmd = build_command(inv);
+
+        // stderr is inherited so the LLM's logging goes to the worker's stderr.
+        // This avoids a deadlock: if stderr were piped, a verbose LLM (e.g. Claude CLI)
+        // could fill the OS pipe buffer (64 KB) and block indefinitely.
+        cmd.stderr(std::process::Stdio::inherit());
+        let mut child = cmd
+            .spawn()
+            .map_err(|e| LlmError::Process(format!("failed to spawn {provider_name}: {e}")))?;
+
+        let status = tokio::select! {
+            result = child.wait() => {
+                result.map_err(|e| {
+                    LlmError::Process(format!("failed to wait for {provider_name}: {e}"))
+                })?
+            }
+            _ = tokio::time::sleep(inv.timeout) => {
+                if let Err(e) = child.kill().await {
+                    tracing::warn!(error = %e, "failed to kill timed-out LLM process");
+                }
+                let _ = child.wait().await;
+                return Err(LlmError::Process(format!(
+                    "{provider_name} timed out after {:?}",
+                    inv.timeout
+                )));
+            }
+        };
+
+        if !status.success() {
+            return Err(LlmError::Process(format!(
+                "{provider_name} exited with {status}"
+            )));
+        }
+
+        Ok(())
+    }
+}
+
+/// Allowlisted environment variable prefixes/names that are safe to pass to the
+/// LLM subprocess. Everything else (DATABASE_URL, etc.) is stripped.
+const LLM_ENV_ALLOWLIST: &[&str] = &[
+    "HOME",
+    "PATH",
+    "TERM",
+    "LANG",
+    "USER",
+    "SHELL",
+    "TMPDIR",
+    "XDG_",
+    // Provider-specific auth
+    "ANTHROPIC_API_KEY",
+    "VLAM_API_KEY",
+    "OPENCODE_",
+];
+
+/// Check whether an environment variable name is on the allowlist.
+fn env_allowed(key: &str) -> bool {
+    LLM_ENV_ALLOWLIST
+        .iter()
+        .any(|prefix| key == *prefix || key.starts_with(prefix))
+}
+
+/// Build the command for the configured LLM provider.
+///
+/// The subprocess gets a stripped environment: only variables on
+/// `LLM_ENV_ALLOWLIST` are forwarded. This prevents leaking DATABASE_URL
+/// and other secrets to the LLM process (which may have shell access).
+fn build_command(inv: &LlmInvocation<'_>) -> tokio::process::Command {
+    // Collect allowed env vars before creating the command.
+    let safe_env: Vec<(String, String)> =
+        std::env::vars().filter(|(k, _)| env_allowed(k)).collect();
+
+    match inv.provider {
+        LlmProvider::OpenCode { path, model } => {
+            let mut cmd = tokio::process::Command::new(path);
+            cmd.env_clear();
+            cmd.envs(safe_env);
+            cmd.env("NODE_OPTIONS", "--max-old-space-size=512");
+            cmd.arg("run")
+                .arg(inv.prompt)
+                .arg("--format")
+                .arg("json")
+                .arg("--dir")
+                .arg(inv.repo_path);
+            if let Some(m) = model {
+                cmd.arg("-m").arg(m);
+            }
+            cmd
+        }
+        LlmProvider::Claude { path, model } => {
+            let mut cmd = tokio::process::Command::new(path);
+            cmd.env_clear();
+            cmd.envs(safe_env);
+            cmd.env("NODE_OPTIONS", "--max-old-space-size=512");
+            cmd.arg("-p")
+                .arg(inv.prompt)
+                .arg("--allowedTools")
+                .arg(inv.allowed_tools)
+                .current_dir(inv.repo_path);
+            if let Some(m) = model {
+                cmd.arg("--model").arg(m);
+            }
+            cmd
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn env_allowlist_passes_auth_and_blocks_secrets() {
+        assert!(env_allowed("ANTHROPIC_API_KEY"));
+        assert!(env_allowed("OPENCODE_AUTH"));
+        assert!(env_allowed("PATH"));
+        assert!(!env_allowed("DATABASE_URL"));
+        assert!(!env_allowed("RIG_API_KEY"));
+    }
+
+    #[test]
+    fn provider_name_and_model() {
+        let p = LlmProvider::Claude {
+            path: "claude".into(),
+            model: Some("opus".into()),
+        };
+        assert_eq!(p.name(), "claude");
+        assert_eq!(p.model_str(), "opus");
+
+        let o = LlmProvider::OpenCode {
+            path: "opencode".into(),
+            model: None,
+        };
+        assert_eq!(o.name(), "opencode");
+        assert_eq!(o.model_str(), "default");
+    }
+}

--- a/packages/pipeline/src/models.rs
+++ b/packages/pipeline/src/models.rs
@@ -8,6 +8,17 @@ use uuid::Uuid;
 pub enum JobType {
     Harvest,
     Enrich,
+    /// Editor suggestion: check article text against the Aanwijzingen voor de
+    /// regelgeving and emit suggestions as an annotation sidecar. Advisory; it
+    /// never commits to the law itself.
+    #[sqlx(rename = "suggest_guidelines")]
+    #[serde(rename = "suggest_guidelines")]
+    SuggestGuidelines,
+    /// Editor suggestion: generate proposed `machine_readable` sections as an
+    /// annotation sidecar, for the user to review and apply. Advisory.
+    #[sqlx(rename = "suggest_machine_readable")]
+    #[serde(rename = "suggest_machine_readable")]
+    SuggestMachineReadable,
 }
 
 #[derive(

--- a/packages/pipeline/src/suggest.rs
+++ b/packages/pipeline/src/suggest.rs
@@ -1,0 +1,716 @@
+//! Editor-suggestion pipeline.
+//!
+//! When a user saves a law in the editor, the editor-api enqueues one suggest
+//! job per kind. A worker spawns a headless LLM (`claude -p`) that runs a skill
+//! against the saved law on the traject's own branch and produces *suggestions*
+//! — it never commits to the law itself. The skill writes findings as JSON; we
+//! convert those to a W3C Web Annotation sidecar (`creator: { name: "claude-…" }`)
+//! anchored to the law text via a `TextQuoteSelector`, and commit that sidecar
+//! to the traject branch. The editor reads it back and renders accept/reject UI.
+//!
+//! Two kinds:
+//! - [`SuggestKind::Guidelines`] — check article text against the Aanwijzingen
+//!   voor de regelgeving (the `law-aanwijzingen` skill).
+//! - [`SuggestKind::MachineReadable`] — propose `machine_readable` sections (the
+//!   `law-generate` pipeline), surfaced as suggestions instead of a direct commit.
+//!
+//! The subprocess/timeout/kill handling and provider selection live in
+//! [`crate::llm`]; this module only builds the prompt, parses the skill output,
+//! and shapes the annotation sidecar.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{PipelineError, Result};
+use crate::llm::{LlmInvocation, LlmProvider, LlmRunner};
+
+/// Which suggestion to generate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SuggestKind {
+    /// Toets de wettekst tegen de Aanwijzingen voor de regelgeving.
+    Guidelines,
+    /// Genereer voorgestelde machine_readable-secties.
+    MachineReadable,
+}
+
+impl SuggestKind {
+    /// Short slug for log lines, branch hints, and sidecar naming.
+    pub fn slug(self) -> &'static str {
+        match self {
+            SuggestKind::Guidelines => "guidelines",
+            SuggestKind::MachineReadable => "machine_readable",
+        }
+    }
+
+    /// W3C annotation `creator.name` for findings of this kind.
+    fn creator_name(self) -> &'static str {
+        match self {
+            SuggestKind::Guidelines => "claude-aanwijzingen",
+            SuggestKind::MachineReadable => "claude-machine-readable",
+        }
+    }
+}
+
+/// Payload for a suggest job, stored as JSON in the job queue.
+///
+/// `traject_branch` is the *resolved* git branch the editor-api saved the law
+/// to (`traject/{slug}-{8hex}`). The worker cannot derive it from `traject_ref`
+/// alone (it needs the traject name + id), so the editor-api passes it in.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SuggestPayload {
+    pub law_id: String,
+    /// Relative path to the law YAML within the repo.
+    pub yaml_path: String,
+    /// Traject reference (short id) the save belongs to. Used for the
+    /// unique-active-job index and sidecar scoping.
+    pub traject_ref: String,
+    /// Resolved traject git branch to check out and commit the sidecar to.
+    pub traject_branch: String,
+    pub kind: SuggestKind,
+    /// Optional single article to scope the suggestion to. None = whole law.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub article_number: Option<String>,
+}
+
+/// Configuration for suggestion execution. Editor suggestions use Claude
+/// (`claude -p`) by default; the env vars mirror the enrich worker's.
+#[derive(Debug, Clone)]
+pub struct SuggestConfig {
+    pub provider: LlmProvider,
+    pub timeout: Duration,
+}
+
+impl SuggestConfig {
+    pub fn from_env() -> Self {
+        let timeout = std::env::var("SUGGEST_TIMEOUT_SECS")
+            .or_else(|_| std::env::var("LLM_TIMEOUT_SECS"))
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .unwrap_or(600);
+
+        let provider = LlmProvider::Claude {
+            path: std::env::var("CLAUDE_PATH")
+                .or_else(|_| std::env::var("LLM_PATH"))
+                .unwrap_or_else(|_| "claude".into())
+                .into(),
+            model: std::env::var("CLAUDE_MODEL")
+                .or_else(|_| std::env::var("LLM_MODEL"))
+                .ok(),
+        };
+
+        Self {
+            provider,
+            timeout: Duration::from_secs(timeout),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Skill output contract (matches .claude/skills/law-aanwijzingen/SKILL.md)
+// ---------------------------------------------------------------------------
+
+/// One finding as written by the skill to its JSON output file.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SkillFinding {
+    pub article_number: String,
+    pub exact_quote: String,
+    #[serde(default)]
+    pub prefix: String,
+    #[serde(default)]
+    pub suffix: String,
+    #[serde(default)]
+    pub aanwijzing_nr: Option<String>,
+    #[serde(default)]
+    pub severity: Option<String>,
+    pub suggestion_text: String,
+    #[serde(default)]
+    pub proposed_replacement: Option<String>,
+}
+
+/// The skill's JSON output document.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SkillOutput {
+    #[serde(default)]
+    pub law_id: String,
+    #[serde(default)]
+    pub findings: Vec<SkillFinding>,
+}
+
+// ---------------------------------------------------------------------------
+// W3C Web Annotation sidecar (matches schema/v0.5.2/annotation-schema.json)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AnnotationSidecar {
+    pub annotations: Vec<Annotation>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Annotation {
+    #[serde(rename = "type")]
+    pub type_: String,
+    pub motivation: String,
+    pub creator: Creator,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub created: Option<String>,
+    pub workflow: String,
+    pub target: Target,
+    pub body: Vec<Body>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Creator {
+    #[serde(rename = "type")]
+    pub type_: String,
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Target {
+    pub source: String,
+    pub selector: TextQuoteSelector,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TextQuoteSelector {
+    #[serde(rename = "type")]
+    pub type_: String,
+    pub exact: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub prefix: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub suffix: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Body {
+    #[serde(rename = "type")]
+    pub type_: String,
+    pub value: String,
+    pub purpose: String,
+}
+
+/// Convert skill findings into a W3C annotation sidecar.
+///
+/// Quotes with empty `exact` are dropped: a selector with no `exact` cannot
+/// anchor and the schema requires a non-empty value. The skill emits
+/// whitespace-normalised quotes; the engine's fuzzy resolver tier anchors them
+/// despite the hard line-wraps in block-scalar law text (see the plan's
+/// "Verankering" note), so no normalisation is needed here.
+pub fn findings_to_sidecar(
+    law_id: &str,
+    kind: SuggestKind,
+    findings: &[SkillFinding],
+    created: Option<String>,
+) -> AnnotationSidecar {
+    // `editing` when there's a concrete replacement to apply, else `commenting`.
+    let annotations = findings
+        .iter()
+        .filter(|f| !f.exact_quote.trim().is_empty())
+        .map(|f| {
+            let has_replacement = f
+                .proposed_replacement
+                .as_ref()
+                .is_some_and(|r| !r.trim().is_empty());
+            let motivation = if has_replacement {
+                "editing"
+            } else {
+                "commenting"
+            };
+
+            // The body carries the human-readable suggestion. For machine_readable
+            // suggestions the proposed YAML lives in suggestion_text already; for a
+            // guideline finding with a replacement we append it so the editor can
+            // offer "apply" without a second field.
+            let mut value = f.suggestion_text.clone();
+            if let Some(rep) = &f.proposed_replacement {
+                if !rep.trim().is_empty() {
+                    value.push_str("\n\nVoorgestelde tekst: ");
+                    value.push_str(rep);
+                }
+            }
+            if let Some(nr) = &f.aanwijzing_nr {
+                if !nr.trim().is_empty() {
+                    value = format!("[Aanwijzing {nr}] {value}");
+                }
+            }
+
+            Annotation {
+                type_: "Annotation".into(),
+                motivation: motivation.into(),
+                creator: Creator {
+                    type_: "Agent".into(),
+                    name: kind.creator_name().into(),
+                },
+                created: created.clone(),
+                workflow: "open".into(),
+                target: Target {
+                    source: format!("regelrecht://{law_id}"),
+                    selector: TextQuoteSelector {
+                        type_: "TextQuoteSelector".into(),
+                        exact: f.exact_quote.clone(),
+                        prefix: f.prefix.clone(),
+                        suffix: f.suffix.clone(),
+                    },
+                },
+                body: vec![Body {
+                    type_: "TextualBody".into(),
+                    value,
+                    purpose: motivation.into(),
+                }],
+            }
+        })
+        .collect();
+
+    AnnotationSidecar { annotations }
+}
+
+/// Repo-relative path of the AI-suggestion sidecar for a law. Kept separate
+/// from the human `annotations/{law_id}/annotations.yaml` so AI suggestions
+/// never pollute curated notes and can be cleaned up independently.
+pub fn suggestions_sidecar_path(law_id: &str) -> String {
+    format!("annotations/{law_id}/suggestions.yaml")
+}
+
+/// Path the skill writes its JSON findings to, inside the repo checkout.
+fn skill_output_path(repo_path: &Path, law_id: &str, kind: SuggestKind) -> PathBuf {
+    repo_path.join(format!(".suggest-{}-{}.json", kind.slug(), law_id))
+}
+
+/// Build the prompt that drives the skill for a given kind.
+fn build_prompt(
+    yaml_path: &str,
+    output_path: &str,
+    kind: SuggestKind,
+    article_number: Option<&str>,
+) -> String {
+    let article_clause = match article_number {
+        Some(nr) => format!("ARTICLE_NUMBER={nr}. "),
+        None => String::new(),
+    };
+    match kind {
+        SuggestKind::Guidelines => format!(
+            r#"Voer de law-aanwijzingen skill uit. Lees .claude/skills/law-aanwijzingen/SKILL.md
+en .claude/skills/law-aanwijzingen/reference.md en volg de instructies volledig.
+
+LAW_YAML={yaml_path}. {article_clause}OUTPUT_PATH={output_path}.
+
+Schrijf het JSON-resultaat met bevindingen naar OUTPUT_PATH. Wijzig de wet-YAML NIET.
+Werk autonoom; stel geen vragen."#
+        ),
+        SuggestKind::MachineReadable => format!(
+            r#"Je stelt machine_readable-secties VOOR voor een Nederlandse wet — je commit NIETS
+en je wijzigt de wet-YAML NIET.
+
+LAW_YAML={yaml_path}. {article_clause}
+
+Lees .claude/skills/law-generate/SKILL.md, reference.md en examples.md. Bepaal voor elk
+uitvoerbaar artikel de machine_readable-logica zoals de skill voorschrijft, maar schrijf
+de YAML NIET naar de wet. Lever in plaats daarvan per artikel een voorstel als JSON naar
+OUTPUT_PATH={output_path}, met exact dit contract:
+
+{{"law_id": "<$id>", "findings": [
+  {{"article_number": "<nr>", "exact_quote": "<eerste ~8 woorden van de artikeltekst, genormaliseerde witruimte>",
+    "prefix": "", "suffix": "", "aanwijzing_nr": null, "severity": "suggestie",
+    "suggestion_text": "Voorgestelde machine_readable (YAML):\n<de voorgestelde yaml>",
+    "proposed_replacement": null}}
+]}}
+
+`exact_quote` is een letterlijke (witruimte-genormaliseerde) passage uit de artikeltekst
+om de suggestie aan te verankeren. Werk autonoom; stel geen vragen."#
+        ),
+    }
+}
+
+/// Allowed tools for the suggestion run. Guidelines is read-only plus the
+/// single Write for its JSON output; machine_readable needs the generate
+/// skill's full toolset (it validates with Bash) but still must not commit.
+fn allowed_tools(kind: SuggestKind) -> &'static str {
+    match kind {
+        SuggestKind::Guidelines => "Read,Grep,Glob,Write",
+        SuggestKind::MachineReadable => "Read,Grep,Glob,Write,Bash",
+    }
+}
+
+/// Result of a successful suggestion run.
+#[derive(Debug, Clone, Serialize)]
+pub struct SuggestResult {
+    pub law_id: String,
+    pub kind: SuggestKind,
+    pub findings_count: usize,
+    /// Repo-relative path of the sidecar that was written.
+    pub sidecar_path: String,
+}
+
+/// Execute a suggestion using the default process-based LLM runner.
+pub async fn execute_suggest(
+    payload: &SuggestPayload,
+    repo_path: &Path,
+    config: &SuggestConfig,
+    created: Option<String>,
+) -> Result<(SuggestResult, PathBuf)> {
+    execute_suggest_with_runner(
+        payload,
+        repo_path,
+        config,
+        created,
+        &crate::llm::ProcessLlmRunner,
+    )
+    .await
+}
+
+/// Execute a suggestion: run the LLM skill, read its JSON findings, convert them
+/// to an annotation sidecar, and write the sidecar into the repo checkout.
+///
+/// Returns the result summary and the absolute path of the written sidecar (for
+/// the caller to stage + commit to the traject branch). Accepts a `runner` so
+/// tests can avoid spawning real processes.
+pub async fn execute_suggest_with_runner(
+    payload: &SuggestPayload,
+    repo_path: &Path,
+    config: &SuggestConfig,
+    created: Option<String>,
+    runner: &dyn LlmRunner,
+) -> Result<(SuggestResult, PathBuf)> {
+    let yaml_abs = repo_path.join(&payload.yaml_path);
+    if !yaml_abs.exists() {
+        return Err(PipelineError::Suggest(format!(
+            "law YAML file not found: {}",
+            yaml_abs.display()
+        )));
+    }
+
+    let output_path = skill_output_path(repo_path, &payload.law_id, payload.kind);
+    // Remove a stale output from a previous attempt so a silent LLM failure
+    // can't make us read old findings.
+    let _ = tokio::fs::remove_file(&output_path).await;
+
+    let prompt = build_prompt(
+        &payload.yaml_path,
+        &output_path.to_string_lossy(),
+        payload.kind,
+        payload.article_number.as_deref(),
+    );
+
+    tracing::info!(
+        law_id = %payload.law_id,
+        kind = payload.kind.slug(),
+        traject = %payload.traject_ref,
+        "starting suggestion run"
+    );
+
+    runner
+        .run(&LlmInvocation {
+            prompt: &prompt,
+            repo_path,
+            provider: &config.provider,
+            timeout: config.timeout,
+            allowed_tools: allowed_tools(payload.kind),
+        })
+        .await?;
+
+    // Read and parse the skill's JSON output.
+    let raw = tokio::fs::read_to_string(&output_path).await.map_err(|e| {
+        PipelineError::Suggest(format!(
+            "skill produced no output at {}: {e}",
+            output_path.display()
+        ))
+    })?;
+    let skill_output: SkillOutput = serde_json::from_str(&raw)
+        .map_err(|e| PipelineError::Suggest(format!("skill output is not valid JSON: {e}")))?;
+
+    let law_id = if skill_output.law_id.is_empty() {
+        payload.law_id.clone()
+    } else {
+        skill_output.law_id.clone()
+    };
+
+    let sidecar = findings_to_sidecar(&law_id, payload.kind, &skill_output.findings, created);
+    let findings_count = sidecar.annotations.len();
+
+    // Write the sidecar into the repo checkout for the caller to commit.
+    let sidecar_rel = suggestions_sidecar_path(&payload.law_id);
+    let sidecar_abs = repo_path.join(&sidecar_rel);
+    if let Some(parent) = sidecar_abs.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+    let sidecar_yaml = serde_yaml_ng::to_string(&sidecar)?;
+    tokio::fs::write(&sidecar_abs, &sidecar_yaml).await?;
+
+    tracing::info!(
+        law_id = %payload.law_id,
+        kind = payload.kind.slug(),
+        findings = findings_count,
+        "suggestion run completed"
+    );
+
+    let result = SuggestResult {
+        law_id: payload.law_id.clone(),
+        kind: payload.kind,
+        findings_count,
+        sidecar_path: sidecar_rel,
+    };
+
+    // Clean up the transient skill output so it never gets staged.
+    let _ = tokio::fs::remove_file(&output_path).await;
+
+    Ok((result, sidecar_abs))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn suggest_payload_serde_roundtrip() {
+        let payload = SuggestPayload {
+            law_id: "zorgtoeslagwet".into(),
+            yaml_path: "regulation/nl/wet/zorgtoeslag/2025-01-01.yaml".into(),
+            traject_ref: "abc123".into(),
+            traject_branch: "traject/tarief-2025-3f4a8b2c".into(),
+            kind: SuggestKind::Guidelines,
+            article_number: Some("2".into()),
+        };
+        let json = serde_json::to_string(&payload).unwrap();
+        assert!(json.contains("\"kind\":\"guidelines\""));
+        let back: SuggestPayload = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.kind, SuggestKind::Guidelines);
+        assert_eq!(back.traject_branch, "traject/tarief-2025-3f4a8b2c");
+    }
+
+    #[test]
+    fn payload_omits_none_article() {
+        let payload = SuggestPayload {
+            law_id: "x".into(),
+            yaml_path: "y.yaml".into(),
+            traject_ref: "t".into(),
+            traject_branch: "traject/x".into(),
+            kind: SuggestKind::MachineReadable,
+            article_number: None,
+        };
+        let json = serde_json::to_string(&payload).unwrap();
+        assert!(!json.contains("article_number"));
+        assert!(json.contains("\"kind\":\"machine_readable\""));
+    }
+
+    #[test]
+    fn findings_become_annotations_with_agent_creator() {
+        let findings = vec![SkillFinding {
+            article_number: "2".into(),
+            exact_quote: "de verzekerde".into(),
+            prefix: "heeft ".into(),
+            suffix: " aanspraak".into(),
+            aanwijzing_nr: Some("3.56".into()),
+            severity: Some("suggestie".into()),
+            suggestion_text: "Gebruik consistente terminologie.".into(),
+            proposed_replacement: Some("de aanvrager".into()),
+        }];
+        let sidecar = findings_to_sidecar(
+            "zorgtoeslagwet",
+            SuggestKind::Guidelines,
+            &findings,
+            Some("2026-06-03T00:00:00Z".into()),
+        );
+        assert_eq!(sidecar.annotations.len(), 1);
+        let a = &sidecar.annotations[0];
+        assert_eq!(a.creator.name, "claude-aanwijzingen");
+        assert_eq!(a.creator.type_, "Agent");
+        // Has a replacement -> editing motivation.
+        assert_eq!(a.motivation, "editing");
+        assert_eq!(a.target.source, "regelrecht://zorgtoeslagwet");
+        assert_eq!(a.target.selector.exact, "de verzekerde");
+        assert_eq!(a.workflow, "open");
+        // Body carries aanwijzing nr + replacement.
+        assert!(a.body[0].value.contains("Aanwijzing 3.56"));
+        assert!(a.body[0].value.contains("de aanvrager"));
+    }
+
+    #[test]
+    fn finding_without_replacement_is_commenting() {
+        let findings = vec![SkillFinding {
+            article_number: "1".into(),
+            exact_quote: "iets".into(),
+            prefix: String::new(),
+            suffix: String::new(),
+            aanwijzing_nr: None,
+            severity: None,
+            suggestion_text: "Let op.".into(),
+            proposed_replacement: None,
+        }];
+        let sidecar = findings_to_sidecar("x", SuggestKind::Guidelines, &findings, None);
+        assert_eq!(sidecar.annotations[0].motivation, "commenting");
+    }
+
+    #[test]
+    fn empty_exact_quote_is_dropped() {
+        let findings = vec![SkillFinding {
+            article_number: "1".into(),
+            exact_quote: "   ".into(),
+            prefix: String::new(),
+            suffix: String::new(),
+            aanwijzing_nr: None,
+            severity: None,
+            suggestion_text: "x".into(),
+            proposed_replacement: None,
+        }];
+        let sidecar = findings_to_sidecar("x", SuggestKind::Guidelines, &findings, None);
+        assert!(sidecar.annotations.is_empty());
+    }
+
+    #[test]
+    fn sidecar_serializes_to_valid_w3c_shape() {
+        let findings = vec![SkillFinding {
+            article_number: "2".into(),
+            exact_quote: "de verzekerde".into(),
+            prefix: String::new(),
+            suffix: String::new(),
+            aanwijzing_nr: None,
+            severity: None,
+            suggestion_text: "x".into(),
+            proposed_replacement: None,
+        }];
+        let sidecar = findings_to_sidecar("law", SuggestKind::Guidelines, &findings, None);
+        let yaml = serde_yaml_ng::to_string(&sidecar).unwrap();
+        assert!(yaml.contains("type: Annotation"));
+        assert!(yaml.contains("type: TextQuoteSelector"));
+        assert!(yaml.contains("exact: de verzekerde"));
+        // Empty prefix/suffix are skipped.
+        assert!(!yaml.contains("prefix:"));
+    }
+
+    #[test]
+    fn suggestions_sidecar_path_is_separate_from_notes() {
+        assert_eq!(
+            suggestions_sidecar_path("zorgtoeslagwet"),
+            "annotations/zorgtoeslagwet/suggestions.yaml"
+        );
+    }
+
+    #[test]
+    fn build_prompt_references_skill_and_output() {
+        let p = build_prompt(
+            "law.yaml",
+            "/tmp/out.json",
+            SuggestKind::Guidelines,
+            Some("2"),
+        );
+        assert!(p.contains("law-aanwijzingen/SKILL.md"));
+        assert!(p.contains("ARTICLE_NUMBER=2"));
+        assert!(p.contains("/tmp/out.json"));
+        assert!(p.contains("LAW_YAML=law.yaml"));
+
+        let m = build_prompt(
+            "law.yaml",
+            "/tmp/out.json",
+            SuggestKind::MachineReadable,
+            None,
+        );
+        assert!(m.contains("law-generate/SKILL.md"));
+        assert!(!m.contains("ARTICLE_NUMBER="));
+    }
+
+    /// Fake runner that writes a fixed skill output JSON, simulating the LLM.
+    struct FakeSkillRunner {
+        json: String,
+    }
+
+    #[async_trait::async_trait]
+    impl LlmRunner for FakeSkillRunner {
+        async fn run(
+            &self,
+            inv: &LlmInvocation<'_>,
+        ) -> std::result::Result<(), crate::llm::LlmError> {
+            // The prompt contains `OUTPUT_PATH=<path>`; pull out the path and write
+            // the fixed findings there, mimicking what the real skill would do.
+            let marker = "OUTPUT_PATH=";
+            let start = inv.prompt.find(marker).unwrap() + marker.len();
+            let path = inv.prompt[start..]
+                .split_whitespace()
+                .next()
+                .unwrap()
+                .trim_end_matches('.');
+            std::fs::write(path, &self.json).unwrap();
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn execute_suggest_writes_sidecar_from_findings() {
+        let dir = tempfile::tempdir().unwrap();
+        let law_rel = "regulation/nl/wet/test/2025-01-01.yaml";
+        let law_abs = dir.path().join(law_rel);
+        tokio::fs::create_dir_all(law_abs.parent().unwrap())
+            .await
+            .unwrap();
+        tokio::fs::write(&law_abs, "articles: []\n").await.unwrap();
+
+        let json = r#"{"law_id":"testwet","findings":[
+            {"article_number":"2","exact_quote":"de verzekerde","prefix":"","suffix":"",
+             "aanwijzing_nr":null,"severity":"suggestie","suggestion_text":"Let op."}
+        ]}"#;
+
+        let payload = SuggestPayload {
+            law_id: "testwet".into(),
+            yaml_path: law_rel.into(),
+            traject_ref: "t1".into(),
+            traject_branch: "traject/test".into(),
+            kind: SuggestKind::Guidelines,
+            article_number: Some("2".into()),
+        };
+        let config = SuggestConfig {
+            provider: LlmProvider::Claude {
+                path: "fake".into(),
+                model: None,
+            },
+            timeout: Duration::from_secs(60),
+        };
+
+        let runner = FakeSkillRunner {
+            json: json.to_string(),
+        };
+        let (result, sidecar_abs) =
+            execute_suggest_with_runner(&payload, dir.path(), &config, None, &runner)
+                .await
+                .unwrap();
+
+        assert_eq!(result.findings_count, 1);
+        assert_eq!(result.sidecar_path, "annotations/testwet/suggestions.yaml");
+        assert!(sidecar_abs.exists());
+
+        let written = tokio::fs::read_to_string(&sidecar_abs).await.unwrap();
+        assert!(written.contains("claude-aanwijzingen"));
+        assert!(written.contains("regelrecht://testwet"));
+
+        // The transient skill output JSON must be cleaned up.
+        let out = skill_output_path(dir.path(), "testwet", SuggestKind::Guidelines);
+        assert!(!out.exists());
+    }
+
+    #[tokio::test]
+    async fn execute_suggest_errors_when_law_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let payload = SuggestPayload {
+            law_id: "x".into(),
+            yaml_path: "nope.yaml".into(),
+            traject_ref: "t".into(),
+            traject_branch: "traject/x".into(),
+            kind: SuggestKind::Guidelines,
+            article_number: None,
+        };
+        let config = SuggestConfig {
+            provider: LlmProvider::Claude {
+                path: "fake".into(),
+                model: None,
+            },
+            timeout: Duration::from_secs(60),
+        };
+        let runner = FakeSkillRunner { json: "{}".into() };
+        let err = execute_suggest_with_runner(&payload, dir.path(), &config, None, &runner)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("law YAML file not found"));
+    }
+}

--- a/packages/pipeline/src/suggest.rs
+++ b/packages/pipeline/src/suggest.rs
@@ -21,7 +21,9 @@
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+use regelrecht_corpus::{CorpusClient, CorpusConfig};
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 use crate::error::{PipelineError, Result};
 use crate::llm::{LlmInvocation, LlmProvider, LlmRunner};
@@ -278,6 +280,52 @@ pub fn suggestions_sidecar_path(law_id: &str) -> String {
 /// Path the skill writes its JSON findings to, inside the repo checkout.
 fn skill_output_path(repo_path: &Path, law_id: &str, kind: SuggestKind) -> PathBuf {
     repo_path.join(format!(".suggest-{}-{}.json", kind.slug(), law_id))
+}
+
+/// Create a `CorpusClient` checked out on the traject branch for a suggest job.
+///
+/// Unlike enrich (which works on `enrich/{provider}` and falls back to
+/// `development`), suggestions run on the traject's own branch — the editor just
+/// saved the law there, so the branch is guaranteed to exist. Sparse-checks out
+/// the law directory, `features/` (the skills read example features), and the
+/// law's `annotations/` directory so an existing sidecar can be overwritten in
+/// place. A per-job checkout dir keeps concurrent suggest jobs isolated.
+pub async fn create_suggest_corpus(
+    base_config: &CorpusConfig,
+    branch: &str,
+    job_id: Uuid,
+    yaml_path: &str,
+    law_id: &str,
+) -> Result<CorpusClient> {
+    let mut config = base_config.clone();
+    config.branch = branch.into();
+
+    let law_dir = Path::new(yaml_path)
+        .parent()
+        .map(|p| p.to_string_lossy().to_string())
+        .filter(|d| !d.is_empty());
+
+    let mut sparse = vec!["features".to_string(), format!("annotations/{law_id}")];
+    if let Some(dir) = law_dir {
+        sparse.push(dir);
+    }
+    config.sparse_paths = Some(sparse);
+
+    // Separate checkout dir per branch + job so concurrent suggest jobs (and the
+    // enrich worker) never clobber each other's working tree.
+    let dir_name = format!("suggest-{}-{}", branch.replace('/', "-"), job_id);
+    let base_dir = config
+        .repo_path
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .unwrap_or(Path::new("/tmp"));
+    config.repo_path = base_dir.join(dir_name);
+
+    let mut client = CorpusClient::new(config);
+    client.ensure_repo().await?;
+    client.checkout_from_branch(branch, &[yaml_path]).await?;
+
+    Ok(client)
 }
 
 /// Build the prompt that drives the skill for a given kind.

--- a/packages/pipeline/src/suggest.rs
+++ b/packages/pipeline/src/suggest.rs
@@ -300,7 +300,13 @@ pub async fn create_suggest_corpus(
     let mut config = base_config.clone();
     config.branch = branch.into();
 
-    let law_dir = Path::new(yaml_path)
+    // Validate + strip legacy absolute prefixes before the path touches git,
+    // exactly as the enrich path does (rejects `..`, absolute paths, and shell
+    // metacharacters). Defense-in-depth: the value is server-derived today, but
+    // the pipeline `/suggest` endpoint trusts the field blind.
+    let normalized = crate::enrich::normalize_yaml_path(yaml_path)?;
+
+    let law_dir = Path::new(&normalized)
         .parent()
         .map(|p| p.to_string_lossy().to_string())
         .filter(|d| !d.is_empty());
@@ -323,7 +329,9 @@ pub async fn create_suggest_corpus(
 
     let mut client = CorpusClient::new(config);
     client.ensure_repo().await?;
-    client.checkout_from_branch(branch, &[yaml_path]).await?;
+    client
+        .checkout_from_branch(branch, &[normalized.as_str()])
+        .await?;
 
     Ok(client)
 }
@@ -423,7 +431,10 @@ pub async fn execute_suggest_with_runner(
     created: Option<String>,
     runner: &dyn LlmRunner,
 ) -> Result<(SuggestResult, PathBuf)> {
-    let yaml_abs = repo_path.join(&payload.yaml_path);
+    // Normalize the same way the checkout did, so we look for the law at the
+    // path that was actually materialized (and reject traversal/absolute paths).
+    let normalized_path = crate::enrich::normalize_yaml_path(&payload.yaml_path)?;
+    let yaml_abs = repo_path.join(&normalized_path);
     if !yaml_abs.exists() {
         return Err(PipelineError::Suggest(format!(
             "law YAML file not found: {}",
@@ -437,7 +448,7 @@ pub async fn execute_suggest_with_runner(
     let _ = tokio::fs::remove_file(&output_path).await;
 
     let prompt = build_prompt(
-        &payload.yaml_path,
+        &normalized_path,
         &output_path.to_string_lossy(),
         payload.kind,
         payload.article_number.as_deref(),

--- a/packages/pipeline/src/worker.rs
+++ b/packages/pipeline/src/worker.rs
@@ -17,6 +17,7 @@ use crate::harvest::{execute_harvest, HarvestPayload, HarvestResult, MAX_HARVEST
 use crate::job_queue::{self, CreateJobRequest};
 use crate::law_status;
 use crate::models::{JobType, LawStatusValue, Priority};
+use crate::suggest::{create_suggest_corpus, execute_suggest, SuggestConfig, SuggestPayload};
 
 /// Run the harvest worker loop.
 ///
@@ -1091,6 +1092,233 @@ async fn handle_enrich_exhausted_or_retry(
         }
         Err(e) => {
             tracing::warn!(error = %e, law_id = %law_id, "failed to increment enrich fail count");
+        }
+    }
+}
+
+/// Run the suggest worker loop.
+///
+/// Polls the job queue for editor-suggestion jobs (both kinds) and runs them.
+/// Designed to run alongside the enrich worker in the same binary so no new ZAD
+/// component is needed. Suggestions are advisory: they write an annotation
+/// sidecar to the traject branch and never touch the law lifecycle. Graceful
+/// shutdown via SIGTERM/SIGINT; an in-flight job runs to completion.
+pub async fn run_suggest_worker(config: WorkerConfig) -> Result<()> {
+    let pipeline_config = config.pipeline_config();
+    let pool = db::create_pool(&pipeline_config).await?;
+    db::ensure_schema(&pool).await?;
+
+    let suggest_config = SuggestConfig::from_env();
+
+    let repo_path = config
+        .corpus_config
+        .as_ref()
+        .map(|c| c.repo_path.clone())
+        .unwrap_or_else(|| config.output_dir.clone());
+
+    tracing::info!(
+        repo_path = %repo_path.display(),
+        provider = %suggest_config.provider.name(),
+        poll_interval = ?config.poll_interval,
+        job_timeout = ?config.job_timeout,
+        "starting suggest worker"
+    );
+
+    let mut sigterm = signal(SignalKind::terminate())
+        .map_err(|e| PipelineError::Worker(format!("failed to register SIGTERM handler: {e}")))?;
+
+    let mut current_interval = std::time::Duration::ZERO;
+
+    loop {
+        tokio::select! {
+            biased;
+
+            _ = tokio::signal::ctrl_c() => {
+                tracing::info!("received SIGINT, stopping suggest worker");
+                break;
+            }
+            _ = sigterm.recv() => {
+                tracing::info!("received SIGTERM, stopping suggest worker");
+                break;
+            }
+            _ = tokio::time::sleep(current_interval) => {}
+        }
+
+        if let Err(e) = job_queue::reap_orphaned_jobs(&pool, config.orphan_timeout).await {
+            tracing::warn!(error = %e, "failed to reap orphaned jobs");
+        }
+
+        match process_next_suggest_job(
+            &pool,
+            &repo_path,
+            &suggest_config,
+            config.corpus_config.as_ref(),
+            config.job_timeout,
+        )
+        .await
+        {
+            Ok(true) => {
+                current_interval = config.poll_interval;
+            }
+            Ok(false) => {
+                current_interval = (current_interval * 2)
+                    .max(config.poll_interval)
+                    .min(config.max_poll_interval);
+            }
+            Err(e) => {
+                tracing::error!(error = %e, "error processing suggest job");
+                current_interval = (current_interval * 2)
+                    .max(config.poll_interval)
+                    .min(config.max_poll_interval);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Claim and process the next available suggest job of either kind.
+///
+/// Returns `Ok(true)` if a job was processed, `Ok(false)` if none was available.
+async fn process_next_suggest_job(
+    pool: &PgPool,
+    repo_path: &Path,
+    suggest_config: &SuggestConfig,
+    corpus_config: Option<&CorpusConfig>,
+    job_timeout: Duration,
+) -> Result<bool> {
+    // Try both suggest kinds; guidelines first (cheaper, read-only).
+    let job = match job_queue::claim_job(pool, Some(JobType::SuggestGuidelines)).await? {
+        Some(job) => job,
+        None => match job_queue::claim_job(pool, Some(JobType::SuggestMachineReadable)).await? {
+            Some(job) => job,
+            None => return Ok(false),
+        },
+    };
+
+    let payload: SuggestPayload = match &job.payload {
+        Some(p) => match serde_json::from_value(p.clone()) {
+            Ok(parsed) => parsed,
+            Err(e) => {
+                tracing::error!(job_id = %job.id, error = %e, "invalid suggest payload");
+                let error_json =
+                    serde_json::json!({ "error": format!("invalid suggest payload: {e}") });
+                let _ = job_queue::fail_job(pool, job.id, Some(error_json)).await;
+                return Ok(true);
+            }
+        },
+        None => {
+            tracing::error!(job_id = %job.id, "suggest job has no payload");
+            let error_json = serde_json::json!({ "error": "suggest job requires a payload" });
+            let _ = job_queue::fail_job(pool, job.id, Some(error_json)).await;
+            return Ok(true);
+        }
+    };
+
+    tracing::info!(
+        job_id = %job.id,
+        law_id = %job.law_id,
+        kind = payload.kind.slug(),
+        traject = %payload.traject_ref,
+        "processing suggest job"
+    );
+
+    // Check out the traject branch (where the editor just saved the law).
+    let suggest_corpus = if let Some(base_config) = corpus_config {
+        match create_suggest_corpus(
+            base_config,
+            &payload.traject_branch,
+            job.id,
+            &payload.yaml_path,
+            &payload.law_id,
+        )
+        .await
+        {
+            Ok(client) => Some(client),
+            Err(e) => {
+                tracing::error!(error = %e, branch = %payload.traject_branch, "failed to check out traject branch for suggestions");
+                let error_json = serde_json::json!({ "error": format!("checkout failed: {e}") });
+                let _ = job_queue::fail_job(pool, job.id, Some(error_json)).await;
+                return Ok(true);
+            }
+        }
+    } else {
+        None
+    };
+
+    let effective_repo = suggest_corpus
+        .as_ref()
+        .map(|c| c.repo_path().to_path_buf())
+        .unwrap_or_else(|| repo_path.to_path_buf());
+
+    // Make the baked-in skills available to the LLM (same mechanism as enrich).
+    if let Err(e) = crate::enrich::ensure_skills(&effective_repo).await {
+        tracing::warn!(error = %e, "failed to set up skill symlinks");
+    }
+
+    // Keep the LLM timeout inside the job timeout so the child is killed cleanly.
+    let mut bounded_config = suggest_config.clone();
+    if bounded_config.timeout >= job_timeout {
+        bounded_config.timeout = job_timeout.saturating_sub(Duration::from_secs(30));
+    }
+
+    let created = chrono::Utc::now().to_rfc3339();
+    let outcome = tokio::time::timeout(
+        job_timeout,
+        execute_suggest(&payload, &effective_repo, &bounded_config, Some(created)),
+    )
+    .await;
+
+    match outcome {
+        Err(_elapsed) => {
+            tracing::error!(job_id = %job.id, timeout = ?job_timeout, "suggest job timed out");
+            let error_json = serde_json::json!({
+                "error": format!("job timed out after {}s", job_timeout.as_secs())
+            });
+            let _ = job_queue::fail_job(pool, job.id, Some(error_json)).await;
+            Ok(true)
+        }
+        Ok(Err(e)) => {
+            tracing::error!(job_id = %job.id, error = %e, "suggest job failed");
+            let error_json = serde_json::json!({ "error": e.to_string() });
+            let _ = job_queue::fail_job(pool, job.id, Some(error_json)).await;
+            Ok(true)
+        }
+        Ok(Ok((result, sidecar_abs))) => {
+            tracing::info!(
+                job_id = %job.id,
+                law_id = %result.law_id,
+                kind = result.kind.slug(),
+                findings = result.findings_count,
+                "suggestion run completed"
+            );
+
+            let commit_result: std::result::Result<(), PipelineError> = async {
+                if let Some(ref corpus) = suggest_corpus {
+                    let message = format!(
+                        "suggesties({}): {} ({})",
+                        result.kind.slug(),
+                        result.law_id,
+                        result.findings_count
+                    );
+                    corpus
+                        .commit_and_push(std::slice::from_ref(&sidecar_abs), &message)
+                        .await
+                        .map_err(|e| PipelineError::Suggest(format!("corpus push failed: {e}")))?;
+                }
+
+                let result_json = serde_json::to_value(&result).ok();
+                job_queue::complete_job(pool, job.id, result_json).await?;
+                Ok(())
+            }
+            .await;
+
+            if let Err(e) = commit_result {
+                tracing::error!(job_id = %job.id, error = %e, "post-suggestion commit failed, marking job failed for retry");
+                let error_json = serde_json::json!({ "error": e.to_string() });
+                let _ = job_queue::fail_job(pool, job.id, Some(error_json)).await;
+            }
+            Ok(true)
         }
     }
 }

--- a/packages/pipeline/src/worker.rs
+++ b/packages/pipeline/src/worker.rs
@@ -1251,6 +1251,11 @@ async fn process_next_suggest_job(
         .map(|c| c.repo_path().to_path_buf())
         .unwrap_or_else(|| repo_path.to_path_buf());
 
+    // Per-job checkout path, captured for cleanup after the job completes.
+    // Each suggest job makes a full git clone; without cleanup these accumulate
+    // and fill the worker's disk (mirrors the enrich worker's cleanup).
+    let checkout_path = suggest_corpus.as_ref().map(|c| c.repo_path().to_path_buf());
+
     // Make the baked-in skills available to the LLM (same mechanism as enrich).
     if let Err(e) = crate::enrich::ensure_skills(&effective_repo).await {
         tracing::warn!(error = %e, "failed to set up skill symlinks");
@@ -1276,13 +1281,11 @@ async fn process_next_suggest_job(
                 "error": format!("job timed out after {}s", job_timeout.as_secs())
             });
             let _ = job_queue::fail_job(pool, job.id, Some(error_json)).await;
-            Ok(true)
         }
         Ok(Err(e)) => {
             tracing::error!(job_id = %job.id, error = %e, "suggest job failed");
             let error_json = serde_json::json!({ "error": e.to_string() });
             let _ = job_queue::fail_job(pool, job.id, Some(error_json)).await;
-            Ok(true)
         }
         Ok(Ok((result, sidecar_abs))) => {
             tracing::info!(
@@ -1318,7 +1321,15 @@ async fn process_next_suggest_job(
                 let error_json = serde_json::json!({ "error": e.to_string() });
                 let _ = job_queue::fail_job(pool, job.id, Some(error_json)).await;
             }
-            Ok(true)
         }
     }
+
+    // Clean up the per-job corpus checkout directory (regardless of outcome).
+    if let Some(path) = checkout_path {
+        if let Err(e) = tokio::fs::remove_dir_all(&path).await {
+            tracing::warn!(path = %path.display(), error = %e, "failed to clean up suggest checkout");
+        }
+    }
+
+    Ok(true)
 }


### PR DESCRIPTION
## Doel

Tijdens het bewerken van een wet in de editor op de achtergrond met `claude -p`
(headless Claude Code) suggesties genereren, op twee sporen:

1. **Aanwijzingen voor de regelgeving** — toets de wettekst tegen de KCBR-richtlijnen en lever concrete edit-suggesties.
2. **Machine-uitvoerbare YAML** — genereer concept-`machine_readable`-secties terwijl je schrijft.

Suggesties verschijnen als **annotaties** (RFC-018): gestippelde spans in de wettekst
plus een "Aanwijzingen"-pane met accepteren/afwijzen. De trigger is **opslaan**.

## Aanpak

Vooral bestaande, geteste onderdelen aan elkaar knopen:

- De **enrichworker** (`packages/pipeline/src/enrich.rs`) draait al `claude -p` via de
  PostgreSQL job-queue. De suggestie-tak hergebruikt dat patroon via een gedeelde
  `llm.rs`, met job-types `SuggestGuidelines` / `SuggestMachineReadable`, op de
  traject-branch i.p.v. `enrich/*`.
- Het **notes/annotatie-systeem** (W3C Web Annotations, `TextQuoteSelector`,
  WASM-resolver, `creator: Agent` → gestippeld in `AnnotatedText.vue`) is de sink.
- Transport = **polling** (zoals harvest-status), geïsoleerd in `useSuggestions.js`.

## Fasen (alle gemerged in deze branch)

- [x] **Skill + contract** — `law-aanwijzingen` skill (SKILL.md + reference.md). Solo
      gevalideerd met `claude -p` op de zorgtoeslagwet: valide JSON met verankerbare quotes.
- [x] **Pipeline kern** — `JobType`-varianten (migratie 0018), gedeelde `llm.rs`,
      `suggest.rs` (skill-output → W3C-annotatie-sidecar), 12 unit-tests.
- [x] **Worker + API** — `run_suggest_worker` (draait mee in de enrich-binary),
      pipeline-api `/suggest` + `/suggest/status`, dedup-helper.
- [x] **Editor-api** — enqueue-na-save (fire-and-forget), `/suggestions` lees-route,
      `/suggestions/status` proxy, traject-branch resolutie.
- [x] **Frontend** — `panel.suggestions` flag (off, dark-launch), `useSuggestions.js`,
      `SuggestionsPane.vue` (nldd-componenten), poll-na-save, accept/reject.
- [x] **machine_readable-tak** — zelfde infra, `kind=machine_readable` + law-generate-prompt.

## Verankering (geverifieerd)

Wetteksten zijn block scalars met harde regelafbrekingen midden in zinnen. De skill
levert quotes met genormaliseerde witruimte; de fuzzy resolver-tier (threshold 0.7)
verankert ze betrouwbaar (~0.97 similarity). Geen engine-wijziging nodig.

## Wat is geverifieerd

- Skill solo via `claude -p` → valide JSON, exacte quotes.
- `cargo test -p regelrecht-pipeline`: 43 tests groen (incl. 12 suggest/llm).
- `cargo check`/`clippy` op pipeline + editor-api lib: groen.
- Frontend `vite build` + 238 vitest tests: groen.

## Wat nog een live stack nodig heeft

End-to-end op een draaiende stack (editor + pipeline + DB + `ANTHROPIC_API_KEY` in de
worker): save → job enqueued → worker draait claude -p → sidecar op traject-branch →
pane vult. Vereist `ANTHROPIC_API_KEY` in de enrich/suggest-worker en `SKILLS_DIR`
met de nieuwe skill in het container-image.

## Bewust uit scope (follow-ups)

- One-click *apply* van een machine_readable-suggestie patcht nu nog niet automatisch
  `machineReadable.value`; accept zet de suggestie op resolved (human-in-the-loop).
- Gedeelde `llm.rs` wordt door `suggest.rs` gebruikt; `enrich.rs` houdt voorlopig zijn
  eigen runner (geen risicovolle refactor van productiecode in deze PR).