### PR TITLE
feat(editor): groepeer bibliotheek-artikellijst per artikel

### DIFF
--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -13,6 +13,7 @@ import { useNotes, useResolvedDraftNotes } from './composables/useNotes.js';
 import { useDraftNotes } from './composables/useDraftNotes.js';
 import { useColorScheme } from './composables/useColorScheme.js';
 import { lastLibraryPath, sectionTarget } from './composables/useLastVisitedRoute.js';
+import { groupArticles, findGroupForArticleNumber } from './utils/articleGroups.js';
 import { SUPPORT_EMAIL } from './constants.js';
 import ArticleText from './components/ArticleText.vue';
 import AnnotatedText from './components/AnnotatedText.vue';
@@ -189,6 +190,23 @@ const {
   saveLaw,
   lastSavedPr,
 } = useLaw(route.params.lawId, route.params.articleNumber, route.params.trajectRef);
+
+// Harvested laws can be split to leaf level (`1.e.1°`, `2.4.1.a.1°`), giving
+// many `articles[]` entries per actual article. The library groups these per
+// article; the editor mirrors that so an article is one tab and all its
+// segments stay reachable. Editing/saving still operates on the active leaf
+// segment (`selectedArticleNumber`) — grouping is a navigation layer only.
+const articleGroups = computed(() => groupArticles(articles.value));
+const currentGroup = computed(() =>
+  findGroupForArticleNumber(articleGroups.value, selectedArticleNumber.value) ?? null
+);
+// Segments of the article currently open — drives the segment selector.
+const segmentsInArticle = computed(() => currentGroup.value?.segments ?? []);
+// The article-level number for the open segment (e.g. `2.4` for `2.4.1.a.1°`),
+// used for the tab identity/label. Falls back to the raw number when ungrouped.
+const currentArticleNumber = computed(() =>
+  currentGroup.value?.number ?? (selectedArticleNumber.value != null ? String(selectedArticleNumber.value) : null)
+);
 
 // When the active traject changes (router.push to /editor/{otherRef}/…)
 // the URL stays on the same component; refresh the corpus index and
@@ -535,7 +553,10 @@ function libraryRouteFor(lawIdVal) {
 if (!route.params.lawId) {
   const last = loadSavedActiveTab();
   if (last?.lawId) {
-    router.replace(editorRouteFor(last.lawId, last.articleNumber || undefined));
+    // Route on the leaf segment so the editor lands on a real `articles[]`
+    // entry — the tab's `articleNumber` may be a group number (e.g. `2.4`)
+    // that isn't itself a segment. Old saved tabs lack `segment`; fall back.
+    router.replace(editorRouteFor(last.lawId, last.segment || last.articleNumber || undefined));
   }
 }
 
@@ -555,17 +576,28 @@ function findTab(lawIdVal, articleNumber) {
   return openTabs.value.find(t => t.lawId === lawIdVal && t.articleNumber === String(articleNumber));
 }
 
-// Add tab when initial law loads
+// Add/refresh the tab when an article loads. Tabs are keyed by the ARTICLE
+// (group) number so a split article is one tab; the tab remembers which
+// segment is active so the tab "follows" the segment selector instead of
+// spawning a tab per leaf.
 watch([() => lawId.value, selectedArticle], ([id, article]) => {
   if (!id || !article) return;
-  const num = String(article.number);
-  if (!findTab(id, num)) {
+  const seg = String(article.number);
+  const groupNum = currentArticleNumber.value ?? seg;
+  const existing = findTab(id, groupNum);
+  if (existing) {
+    if (existing.segment !== seg) {
+      openTabs.value = openTabs.value.map(t =>
+        (t.lawId === id && t.articleNumber === groupNum) ? { ...t, segment: seg } : t);
+      saveTabs(openTabs.value);
+    }
+  } else {
     const MAX_TABS = 20;
-    const tabs = [...openTabs.value, { lawId: id, articleNumber: num }];
+    const tabs = [...openTabs.value, { lawId: id, articleNumber: groupNum, segment: seg }];
     openTabs.value = tabs.length > MAX_TABS ? tabs.slice(-MAX_TABS) : tabs;
     saveTabs(openTabs.value);
   }
-  activeTab.value = { lawId: id, articleNumber: num };
+  activeTab.value = { lawId: id, articleNumber: groupNum, segment: seg };
   saveActiveTab(activeTab.value);
   if (lawName.value) lawNames.value = { ...lawNames.value, [id]: lawName.value };
 });
@@ -587,17 +619,32 @@ async function selectTab(tab) {
   if (activeAction.value) {
     handleActionClose();
   }
+  // Open the tab's remembered segment — a real `articles[]` entry. Old saved
+  // tabs lack `segment`, so fall back to `articleNumber`.
+  const seg = tab.segment ?? tab.articleNumber;
   if (tab.lawId === lawId.value) {
-    selectedArticleNumber.value = tab.articleNumber;
+    selectedArticleNumber.value = seg;
   } else {
-    await switchLaw(tab.lawId, tab.articleNumber);
+    await switchLaw(tab.lawId, seg);
     if (gen !== switchGeneration) return; // stale, another switch started
     lawNames.value = { ...lawNames.value, [tab.lawId]: lawName.value };
   }
   // Sync the URL so deep-linking and browser back/forward stay in step.
   // `replace` (not `push`) keeps history clean — a tab switch isn't
   // navigation the user wants to undo with the back button.
-  router.replace(editorRouteFor(tab.lawId, tab.articleNumber));
+  router.replace(editorRouteFor(tab.lawId, seg));
+}
+
+// Switch which segment of the open article is being edited. Same-article move,
+// so the tab is reused (the tab-watch updates its remembered segment) rather
+// than a new tab opening. Mirrors a tab switch otherwise (drop a mid-edit
+// action snapshot; existing per-article edit-state behaviour applies).
+function selectSegment(segNum) {
+  const num = String(segNum);
+  if (num === String(selectedArticleNumber.value)) return;
+  if (activeAction.value) handleActionClose();
+  selectedArticleNumber.value = num;
+  router.replace(editorRouteFor(lawId.value, num));
 }
 
 // Browser back/forward (or any external navigation) — pull state from
@@ -773,7 +820,7 @@ watch(selectedArticle, (article) => {
 // fallback but it raced with this effect on tab/article switches.
 watchEffect(() => {
   const detail = [];
-  if (selectedArticle.value) detail.push(`Art. ${selectedArticle.value.number}`);
+  if (currentArticleNumber.value) detail.push(`Art. ${currentArticleNumber.value}`);
   if (lawName.value) detail.push(lawName.value);
   document.title = detail.length > 0
     ? `Editor: ${detail.join(' · ')} · RegelRecht`
@@ -1422,6 +1469,31 @@ async function handleActionSave() {
             >
             </nldd-document-tab-bar-item>
           </nldd-document-tab-bar>
+          <!-- Segment selector — only for split articles (harvested to leaf
+               level). Lets the user reach/edit every onderdeel/lid of the open
+               article without each becoming its own tab. Editing still targets
+               the selected segment (selectedArticleNumber). -->
+          <template v-if="segmentsInArticle.length > 1">
+            <nldd-spacer size="8"></nldd-spacer>
+            <nldd-button
+              id="segment-select-btn"
+              size="md"
+              expandable
+              accessible-label="Kies een onderdeel van dit artikel"
+              :text="`Onderdeel ${selectedArticleNumber}`"
+              popovertarget="segment-select-menu"
+            ></nldd-button>
+            <nldd-menu id="segment-select-menu" anchor="segment-select-btn">
+              <nldd-menu-item
+                v-for="seg in segmentsInArticle"
+                :key="seg.number"
+                type="radio"
+                :selected="String(seg.number) === String(selectedArticleNumber) || undefined"
+                :text="String(seg.number)"
+                @select="selectSegment(seg.number)"
+              ></nldd-menu-item>
+            </nldd-menu>
+          </template>
         </nldd-container>
       </nldd-split-view-pane>
 

--- a/frontend/src/LibraryApp.vue
+++ b/frontend/src/LibraryApp.vue
@@ -2,9 +2,7 @@
 import { ref, computed, shallowRef, nextTick, watch, watchEffect } from 'vue';
 import { useRoute, useRouter, onBeforeRouteUpdate } from 'vue-router';
 import yaml from 'js-yaml';
-import ArticleText from './components/ArticleText.vue';
-import MachineReadable from './components/MachineReadable.vue';
-import YamlView from './components/YamlView.vue';
+import ArticleGroup from './components/ArticleGroup.vue';
 import ActionSheet from './components/ActionSheet.vue';
 import SearchPopover from './components/SearchPopover.vue';
 import TrajectMenu from './components/TrajectMenu.vue';
@@ -14,6 +12,7 @@ import { useFeatureFlags } from './composables/useFeatureFlags.js';
 import { useColorScheme } from './composables/useColorScheme.js';
 import { useTrajects } from './composables/useTrajects.js';
 import { lawsListUrl, lawUrl } from './composables/corpusUrls.js';
+import { groupArticles, findGroupForArticleNumber } from './utils/articleGroups.js';
 import { SUPPORT_EMAIL } from './constants.js';
 import { lastEditorPath, sectionTarget } from './composables/useLastVisitedRoute.js';
 
@@ -189,19 +188,40 @@ const indexedLawName = computed(() => {
   return law ? displayName(law) : humanizeLawId(selectedLawId.value);
 });
 
-const selectedArticle = computed(() => {
-  if (!selectedArticleNumber.value) return null;
-  return articles.value.find(
-    (a) => String(a.number) === String(selectedArticleNumber.value)
-  ) ?? null;
-});
+// Harvested laws can be split to leaf level (`1.e.1°`, `2.4.1.a.1°`), giving
+// many `articles[]` entries per actual article. The list and detail group those
+// segments per article (keyed on the `#Artikel…` url anchor); see articleGroups.js.
+const articleGroups = computed(() => groupArticles(articles.value));
+
+// The selected article as a group of its segments. Resolves both the canonical
+// article number (`2.4`) and legacy deep-links to a leaf segment (`2.4.1.a.1°`).
+const selectedGroup = computed(() =>
+  findGroupForArticleNumber(articleGroups.value, selectedArticleNumber.value) ?? null
+);
+
+// First segment of the selected group — the concrete `articles[]` entry to open
+// in the (still flat) editor, since a group number like `2.4` need not itself be
+// an entry.
+const firstSegment = computed(() => selectedGroup.value?.segments?.[0] ?? null);
+
+// Segment whose machine_readable owns the currently open action, so the
+// ActionSheet resolves variables against the right segment.
+const activeActionArticle = ref(null);
 
 // True when the URL points at an article that doesn't exist in the
 // loaded law. Distinct from "no article selected" (where no article
 // number is in the URL).
 const articleNotFound = computed(() =>
-  !!(selectedLaw.value && selectedArticleNumber.value && !selectedArticle.value)
+  !!(selectedLaw.value && selectedArticleNumber.value && !selectedGroup.value)
 );
+
+// Canonicalize a deep-linked leaf number (`1.e.1°`) to its grouped article
+// number (`1`) so the URL matches the highlighted list item. selectArticle
+// no-ops when already canonical, so this can't loop.
+watch([selectedGroup, selectedArticleNumber], ([group, number]) => {
+  if (!group || number == null) return;
+  if (String(group.number) !== String(number)) selectArticle(group.number);
+});
 
 // 404 means the law isn't in the active traject's corpus; the error UI shows a traject-specific message.
 const lawErrorIs404 = computed(() => lawError.value?.status === 404);
@@ -217,7 +237,7 @@ const lawErrorIs404 = computed(() => lawError.value?.status === 404);
 // fallback but it raced with this effect on tab/article switches.
 watchEffect(() => {
   const detail = [];
-  if (selectedArticle.value) detail.push(`Art. ${selectedArticle.value.number}`);
+  if (selectedGroup.value) detail.push(`Art. ${selectedGroup.value.number}`);
   // Fall back to indexedLawName so the title reflects the URL even when the
   // law itself failed to load.
   const name = lawName.value || indexedLawName.value;
@@ -367,19 +387,31 @@ function retryLoadCorpus() {
   loadIndex();
 }
 
+// ArticleGroup forwards the action plus the segment it belongs to, so the
+// ActionSheet resolves variables against the correct segment's machine_readable.
+function onOpenAction({ action, article }) {
+  activeAction.value = action;
+  activeActionArticle.value = article ?? null;
+}
+
 function editInEditor() {
-  if (!selectedLawId.value || !selectedArticleNumber.value) return;
+  // The editor is still per-segment, so open the segment that owns the action
+  // (falling back to the group's first segment) rather than the group number.
+  const target = activeActionArticle.value?.number ?? firstSegment.value?.number;
+  if (!selectedLawId.value || !target) return;
   activeAction.value = null;
   // Carry the active traject so "Bewerken" opens the editable
   // editor-traject view instead of the read-only editor.
-  router.push(editorRouteFor(selectedLawId.value, selectedArticleNumber.value));
+  router.push(editorRouteFor(selectedLawId.value, String(target)));
 }
 
 // "Bewerken" button in the detail pane: same traject-aware target as
 // editInEditor, exposed as a location + href so the anchor is real (and
 // middle-click / open-in-new-tab works) while the click stays SPA.
 const editLawTarget = computed(() =>
-  editorRouteFor(selectedLawId.value, selectedArticleNumber.value || undefined),
+  // Open the group's first concrete segment in the (flat) editor — the group
+  // number (`2.4`) need not be an `articles[]` entry on its own.
+  editorRouteFor(selectedLawId.value, firstSegment.value?.number ?? selectedArticleNumber.value ?? undefined),
 );
 const editLawHref = computed(() => router.resolve(editLawTarget.value).href);
 
@@ -687,14 +719,14 @@ watch(activeTrajectRef, () => {
                 <nldd-inline-dialog v-else-if="!selectedLaw" text="Selecteer een wet"></nldd-inline-dialog>
                 <nldd-list v-else variant="simple">
                   <nldd-list-item
-                    v-for="article in articles"
-                    :key="article.number"
+                    v-for="group in articleGroups"
+                    :key="group.key"
                     size="md"
                     type="button"
-                    :selected="String(article.number) === String(selectedArticleNumber) || undefined"
-                    @click="selectArticle(article.number)"
+                    :selected="selectedGroup && group.key === selectedGroup.key || undefined"
+                    @click="selectArticle(group.number)"
                   >
-                    <nldd-text-cell :text="`Artikel ${article.number}`" :supporting-text="articleDescription(article)">
+                    <nldd-text-cell :text="group.label" :supporting-text="articleDescription(group.segments[0])">
                     </nldd-text-cell>
                     <nldd-spacer-cell size="8"></nldd-spacer-cell>
                     <nldd-icon-cell size="20">
@@ -707,14 +739,14 @@ watch(activeTrajectRef, () => {
           </nldd-split-view-pane>
 
           <!-- Main: Artikel Detail -->
-          <nldd-split-view-pane slot="main" :has-content="selectedArticle || lawError || articleNotFound || indexError ? true : undefined">
+          <nldd-split-view-pane slot="main" :has-content="selectedGroup || lawError || articleNotFound || indexError ? true : undefined">
             <nldd-page sticky-header>
               <nldd-top-title-bar
                 slot="header"
-                :text="selectedArticle ? `Artikel ${selectedArticle.number}` : undefined"
-                :supporting-text="selectedArticle ? lawName : undefined"
+                :text="selectedGroup ? selectedGroup.label : undefined"
+                :supporting-text="selectedGroup ? lawName : undefined"
                 :back-text="indexError ? undefined : (lawError ? LIBRARY_HOME_BACK_TEXT : (lawName || 'Terug'))"
-                :collapse-anchor="selectedArticle ? 'article-titel' : undefined"
+                :collapse-anchor="selectedGroup ? 'article-titel' : undefined"
               ></nldd-top-title-bar>
 
               <nldd-simple-section width="full" v-if="indexError">
@@ -765,13 +797,13 @@ watch(activeTrajectRef, () => {
                   <nldd-button slot="actions" variant="secondary" text="Neem contact op via e-mail" :href="`mailto:${SUPPORT_EMAIL}`"></nldd-button>
                 </nldd-inline-dialog>
               </nldd-simple-section>
-              <nldd-simple-section width="full" v-else-if="!selectedArticle">
+              <nldd-simple-section width="full" v-else-if="!selectedGroup">
                 <nldd-inline-dialog text="Selecteer een artikel"></nldd-inline-dialog>
               </nldd-simple-section>
               <template v-else>
                 <nldd-simple-section width="full">
                   <nldd-title id="article-titel" size="3">
-                    <h3>Artikel {{ selectedArticle.number }}</h3>
+                    <h3>{{ selectedGroup.label }}</h3>
                     <span slot="subtitle">{{ lawName }}</span>
                   </nldd-title>
                   <nldd-spacer size="16"></nldd-spacer>
@@ -788,11 +820,13 @@ watch(activeTrajectRef, () => {
                     </nldd-toolbar-item>
                   </nldd-toolbar>
                   <nldd-spacer size="24"></nldd-spacer>
-                  <KeepAlive>
-                    <ArticleText v-if="detailView === 'tekst'" :article="selectedArticle" centered />
-                    <MachineReadable v-else-if="detailView === 'machine'" :article="selectedArticle" @open-action="activeAction = $event" />
-                    <YamlView v-else-if="detailView === 'yaml'" :article="selectedArticle" />
-                  </KeepAlive>
+                  <ArticleGroup
+                    :segments="selectedGroup.segments"
+                    :view="detailView"
+                    :traject-ref="activeTrajectRef"
+                    centered
+                    @open-action="onOpenAction"
+                  />
                 </nldd-simple-section>
               </template>
             </nldd-page>
@@ -858,7 +892,7 @@ watch(activeTrajectRef, () => {
 
   <!-- LibraryApp is a read-only browser; ActionSheet is mounted without editable
        so the output field is hidden and the footer button just closes the sheet. -->
-  <ActionSheet :action="activeAction" :article="selectedArticle" :editable="false" @close="activeAction = null" @save="activeAction = null" @edit="editInEditor" />
+  <ActionSheet :action="activeAction" :article="activeActionArticle || firstSegment" :editable="false" @close="activeAction = null" @save="activeAction = null" @edit="editInEditor" />
   <SearchPopover
     ref="searchPopoverRef"
     :laws="laws"

--- a/frontend/src/components/ArticleGroup.test.js
+++ b/frontend/src/components/ArticleGroup.test.js
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import ArticleGroup from './ArticleGroup.vue';
+
+// Stub the per-segment renderers so we test ArticleGroup's stacking/provenance
+// logic without pulling in their (network-touching) internals.
+const stubs = {
+  ArticleText: { props: ['article'], template: '<div class="stub-text">{{ article.number }}</div>' },
+  MachineReadable: { props: ['article'], template: '<div class="stub-mr">{{ article.number }}</div>' },
+  YamlView: { props: ['article'], template: '<div class="stub-yaml">{{ article.number }}</div>' },
+};
+
+const seg = (number, mr = false) => ({
+  number,
+  text: `tekst ${number}`,
+  ...(mr ? { machine_readable: { execution: {} } } : {}),
+});
+
+function mountGroup(segments, view) {
+  return mount(ArticleGroup, { props: { segments, view }, global: { stubs } });
+}
+
+describe('ArticleGroup — tekst view', () => {
+  it('renders one ArticleText per segment, in order, without provenance labels', () => {
+    const w = mountGroup([seg('1'), seg('1.a'), seg('1.e.1°')], 'tekst');
+    const texts = w.findAll('.stub-text');
+    expect(texts.map((t) => t.text())).toEqual(['1', '1.a', '1.e.1°']);
+    expect(w.findAll('nldd-title')).toHaveLength(0);
+  });
+});
+
+describe('ArticleGroup — machine view', () => {
+  it('renders only segments that carry machine_readable', () => {
+    const w = mountGroup([seg('1'), seg('1.a', true), seg('1.e', true)], 'machine');
+    expect(w.findAll('.stub-mr').map((m) => m.text())).toEqual(['1.a', '1.e']);
+  });
+
+  it('shows a provenance label per MR segment when the article is split', () => {
+    const w = mountGroup([seg('1'), seg('1.a', true), seg('1.e', true)], 'machine');
+    const labels = w.findAll('nldd-title').map((t) => t.text());
+    expect(labels).toEqual(['Artikel 1.a', 'Artikel 1.e']);
+  });
+
+  it('omits the provenance label for a single-segment article', () => {
+    const w = mountGroup([seg('3.1', true)], 'machine');
+    expect(w.findAll('nldd-title')).toHaveLength(0);
+    expect(w.findAll('.stub-mr')).toHaveLength(1);
+  });
+
+  it('shows an empty-state when no segment has machine_readable', () => {
+    const w = mountGroup([seg('1'), seg('1.a')], 'machine');
+    expect(w.find('nldd-inline-dialog').exists()).toBe(true);
+    expect(w.findAll('.stub-mr')).toHaveLength(0);
+  });
+});
+
+describe('ArticleGroup — yaml view', () => {
+  it('renders YamlView per MR segment with provenance when split', () => {
+    const w = mountGroup([seg('2.4.1', true), seg('2.4.1.a', true)], 'yaml');
+    expect(w.findAll('.stub-yaml').map((y) => y.text())).toEqual(['2.4.1', '2.4.1.a']);
+    expect(w.findAll('nldd-title').map((t) => t.text())).toEqual([
+      'Artikel 2.4.1',
+      'Artikel 2.4.1.a',
+    ]);
+  });
+});

--- a/frontend/src/components/ArticleGroup.vue
+++ b/frontend/src/components/ArticleGroup.vue
@@ -1,0 +1,90 @@
+<script setup>
+import { computed } from 'vue';
+import ArticleText from './ArticleText.vue';
+import MachineReadable from './MachineReadable.vue';
+import YamlView from './YamlView.vue';
+
+/**
+ * Read-only detail renderer for one *article* that may be stored as several
+ * `articles[]` segments (harvester leaf-splitting, e.g. `1.e.1°`, `2.4.1.a.1°`).
+ *
+ * The article reads as one continuous whole:
+ *  - Tekst: the segments' text stacked without separators — `1.a`, `1.e`, … just
+ *    flow on as the article's content.
+ *  - Machine / YAML: shown per segment that actually carries `machine_readable`,
+ *    each with its segment number as provenance so it's clear which lid/onderdeel
+ *    the logic belongs to. The label is only shown when the article is genuinely
+ *    split (more than one segment), so single-entry laws look exactly as before.
+ *
+ * Reuses the existing per-segment components (`ArticleText`, `MachineReadable`,
+ * `YamlView`) rather than re-implementing their rendering.
+ */
+const props = defineProps({
+  segments: { type: Array, default: () => [] },
+  // 'tekst' | 'machine' | 'yaml'
+  view: { type: String, default: 'tekst' },
+  // Passed through to MachineReadable for traject-scoped law-name resolution.
+  trajectRef: { type: String, default: null },
+  centered: { type: Boolean, default: false },
+});
+
+// `open-action` carries the owning segment alongside the action, so the
+// ActionSheet resolves variables/definitions against the right segment's
+// machine_readable (a split article's actions can live on any sub-segment).
+const emit = defineEmits(['open-action']);
+
+// Only segments that carry machine_readable matter for the Machine/YAML tabs;
+// rendering an empty "geen gegevens" block per leaf segment would be noise.
+const mrSegments = computed(() =>
+  props.segments.filter((s) => s.machine_readable),
+);
+
+// Show the per-segment provenance label only for genuinely split articles.
+const showProvenance = computed(() => props.segments.length > 1);
+</script>
+
+<template>
+  <!-- Tekst: one continuous article, segments flow on without separators. -->
+  <template v-if="view === 'tekst'">
+    <template v-for="(segment, i) in segments" :key="segment.number">
+      <nldd-spacer v-if="i > 0" size="16"></nldd-spacer>
+      <ArticleText :article="segment" :centered="centered || undefined" />
+    </template>
+  </template>
+
+  <!-- Machine: per segment that has machine_readable, with provenance. -->
+  <template v-else-if="view === 'machine'">
+    <nldd-inline-dialog
+      v-if="mrSegments.length === 0"
+      text="Geen machine-leesbare gegevens voor dit artikel"
+    ></nldd-inline-dialog>
+    <template v-else>
+      <template v-for="(segment, i) in mrSegments" :key="segment.number">
+        <nldd-spacer v-if="i > 0" size="24"></nldd-spacer>
+        <nldd-title v-if="showProvenance" size="6"><h4>Artikel {{ segment.number }}</h4></nldd-title>
+        <nldd-spacer v-if="showProvenance" size="8"></nldd-spacer>
+        <MachineReadable
+          :article="segment"
+          :traject-ref="trajectRef"
+          @open-action="emit('open-action', { action: $event, article: segment })"
+        />
+      </template>
+    </template>
+  </template>
+
+  <!-- YAML: per segment that has machine_readable, with provenance. -->
+  <template v-else-if="view === 'yaml'">
+    <nldd-inline-dialog
+      v-if="mrSegments.length === 0"
+      text="Geen machine-leesbare gegevens voor dit artikel"
+    ></nldd-inline-dialog>
+    <template v-else>
+      <template v-for="(segment, i) in mrSegments" :key="segment.number">
+        <nldd-spacer v-if="i > 0" size="24"></nldd-spacer>
+        <nldd-title v-if="showProvenance" size="6"><h4>Artikel {{ segment.number }}</h4></nldd-title>
+        <nldd-spacer v-if="showProvenance" size="8"></nldd-spacer>
+        <YamlView :article="segment" />
+      </template>
+    </template>
+  </template>
+</template>

--- a/frontend/src/utils/articleGroups.js
+++ b/frontend/src/utils/articleGroups.js
@@ -1,0 +1,88 @@
+/**
+ * Group a flat `articles[]` array into per-article groups.
+ *
+ * Harvested laws can be split down to leaf level (lid → onderdeel → sub),
+ * producing many `articles[]` entries for a single actual article — e.g.
+ * `besluit_zorgverzekering` yields separate entries `1.e.1°`, `2.4.1.a.1°`.
+ * The article list (library column 2) should show ONE item per article and
+ * load all underlying segments together when selected.
+ *
+ * The reliable grouping key is the `#…` fragment of each entry's `url`, which
+ * is the actual article anchor on wetten.overheid.nl. Every segment of an
+ * article shares it (`1.e.1°` and `1.f` both carry `#Artikel1`; `2.4.1` and
+ * `2.4.1.a.1°` both carry `#Artikel2.4`). This disambiguates dotted numbers
+ * that the number string alone cannot: `2.1.1` (article 2.1, lid 1) groups
+ * under `#Artikel2.1`, while a genuine dotted article `3.1` (`#Artikel3.1`)
+ * stays its own group instead of being folded into "article 3".
+ */
+
+/** Extract the article anchor (the part after `#`) from an entry's url. */
+export function articleAnchor(url) {
+  if (typeof url !== "string") return null;
+  const hash = url.indexOf("#");
+  if (hash < 0) return null;
+  const fragment = url.slice(hash + 1).trim();
+  return fragment.length > 0 ? fragment : null;
+}
+
+/**
+ * Derive the article number used in routes/labels from an anchor.
+ * `Artikel2.4` → `2.4`, `ArtikelAanhef` → `Aanhef`. Anchors that don't follow
+ * the `Artikel<n>` convention are returned as-is.
+ */
+function numberFromAnchor(anchor) {
+  const m = /^Artikel(.+)$/.exec(anchor);
+  return m ? m[1] : anchor;
+}
+
+/** Human label for the article list item. */
+function labelForNumber(number) {
+  // The "Aanhef" (preamble) reads oddly as "Artikel Aanhef"; show it bare.
+  return /^\d/.test(String(number)) ? `Artikel ${number}` : String(number);
+}
+
+/**
+ * Convert a flat articles array into ordered groups.
+ *
+ * @param {Array} articles - the law's `articles[]` (each: { number, text, url, machine_readable? })
+ * @returns {Array<{ key: string, number: string, label: string, segments: Array }>}
+ *          Groups in order of first appearance; segments in YAML order.
+ */
+export function groupArticles(articles) {
+  const groups = [];
+  const byKey = new Map();
+
+  for (const article of articles || []) {
+    const anchor = articleAnchor(article.url);
+    // Anchor-keyed groups share the anchor; fragmentless entries stand alone
+    // under a number-namespaced key so they can't collide with an anchor.
+    const number = anchor ? numberFromAnchor(anchor) : String(article.number);
+    const key = anchor ? `#${anchor}` : `n:${number}`;
+
+    let group = byKey.get(key);
+    if (!group) {
+      group = { key, number, label: labelForNumber(number), segments: [] };
+      byKey.set(key, group);
+      groups.push(group);
+    }
+    group.segments.push(article);
+  }
+
+  return groups;
+}
+
+/**
+ * Find the group a given article number belongs to. Matches the group's
+ * representative `number` first (new article-level routes), then falls back to
+ * any segment number it contains (legacy deep-links to a leaf like `1.e.1°`).
+ *
+ * @returns the matching group, or undefined.
+ */
+export function findGroupForArticleNumber(groups, number) {
+  if (number == null) return undefined;
+  const target = String(number);
+  return (
+    groups.find((g) => String(g.number) === target) ??
+    groups.find((g) => g.segments.some((s) => String(s.number) === target))
+  );
+}

--- a/frontend/src/utils/articleGroups.test.js
+++ b/frontend/src/utils/articleGroups.test.js
@@ -72,6 +72,14 @@ describe("groupArticles — besluit_zorgverzekering shape", () => {
     expect(groups.find((g) => g.number === "Aanhef").label).toBe("Aanhef");
     expect(groups.find((g) => g.number === "2.4").label).toBe("Artikel 2.4");
   });
+
+  it("keys anchor-grouped articles on the url fragment (drives list :selected)", () => {
+    const groups = groupArticles(articles);
+    // The list's selected-state compares group.key === selectedGroup.key, so
+    // the key shape is part of the contract.
+    expect(groups.find((g) => g.number === "2.4").key).toBe("#Artikel2.4");
+    expect(groups.find((g) => g.number === "Aanhef").key).toBe("#ArtikelAanhef");
+  });
 });
 
 describe("groupArticles — genuine dotted articles are not over-grouped", () => {

--- a/frontend/src/utils/articleGroups.test.js
+++ b/frontend/src/utils/articleGroups.test.js
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "vitest";
+import {
+  articleAnchor,
+  groupArticles,
+  findGroupForArticleNumber,
+} from "./articleGroups.js";
+
+const BASE = "https://wetten.overheid.nl/BWBR0018492/2026-01-01";
+const a = (number, anchor) => ({
+  number,
+  text: `tekst ${number}`,
+  url: anchor === null ? BASE : `${BASE}#${anchor}`,
+});
+
+describe("articleAnchor", () => {
+  it("extracts the fragment after #", () => {
+    expect(articleAnchor(`${BASE}#Artikel2.4`)).toBe("Artikel2.4");
+  });
+  it("returns null without a fragment", () => {
+    expect(articleAnchor(BASE)).toBe(null);
+    expect(articleAnchor(undefined)).toBe(null);
+  });
+});
+
+describe("groupArticles — besluit_zorgverzekering shape", () => {
+  // Over-split corpus: many leaf segments per article, all sharing an anchor.
+  const articles = [
+    a("Aanhef", "ArtikelAanhef"),
+    a("1", "Artikel1"),
+    a("1.a", "Artikel1"),
+    a("1.e", "Artikel1"),
+    a("1.e.1°", "Artikel1"),
+    a("1.e.2°", "Artikel1"),
+    a("1.f", "Artikel1"),
+    a("2.1.1", "Artikel2.1"),
+    a("2.1.2", "Artikel2.1"),
+    a("2.4.1", "Artikel2.4"),
+    a("2.4.1.a", "Artikel2.4"),
+    a("2.4.1.a.1°", "Artikel2.4"),
+  ];
+
+  it("collapses leaf segments into one group per article", () => {
+    const groups = groupArticles(articles);
+    expect(groups.map((g) => g.number)).toEqual([
+      "Aanhef",
+      "1",
+      "2.1",
+      "2.4",
+    ]);
+  });
+
+  it("does NOT show 1.e.1° as its own list item", () => {
+    const groups = groupArticles(articles);
+    expect(groups.some((g) => g.number === "1.e.1°")).toBe(false);
+  });
+
+  it("keeps all segments of an article, in YAML order", () => {
+    const groups = groupArticles(articles);
+    const art1 = groups.find((g) => g.number === "1");
+    expect(art1.segments.map((s) => s.number)).toEqual([
+      "1",
+      "1.a",
+      "1.e",
+      "1.e.1°",
+      "1.e.2°",
+      "1.f",
+    ]);
+  });
+
+  it("labels the preamble 'Aanhef' and numbered articles 'Artikel N'", () => {
+    const groups = groupArticles(articles);
+    expect(groups.find((g) => g.number === "Aanhef").label).toBe("Aanhef");
+    expect(groups.find((g) => g.number === "2.4").label).toBe("Artikel 2.4");
+  });
+});
+
+describe("groupArticles — genuine dotted articles are not over-grouped", () => {
+  // wet_inkomstenbelasting: each dotted number is a whole article with its own
+  // anchor, so they must stay separate groups.
+  const articles = [
+    a("3.1", "Artikel3.1"),
+    a("3.2", "Artikel3.2"),
+    a("4.12", "Artikel4.12"),
+  ];
+
+  it("keeps each dotted article as its own group", () => {
+    const groups = groupArticles(articles);
+    expect(groups.map((g) => g.number)).toEqual(["3.1", "3.2", "4.12"]);
+    expect(groups.every((g) => g.segments.length === 1)).toBe(true);
+  });
+});
+
+describe("groupArticles — fragmentless entries stand alone", () => {
+  it("groups entries without a url fragment by their own number", () => {
+    const groups = groupArticles([a("1", null), a("2", null)]);
+    expect(groups.map((g) => g.number)).toEqual(["1", "2"]);
+  });
+});
+
+describe("findGroupForArticleNumber", () => {
+  const groups = groupArticles([
+    a("1", "Artikel1"),
+    a("1.e.1°", "Artikel1"),
+    a("2.4.1.a.1°", "Artikel2.4"),
+  ]);
+
+  it("matches by the group's representative number", () => {
+    expect(findGroupForArticleNumber(groups, "2.4")?.number).toBe("2.4");
+  });
+
+  it("resolves a legacy leaf deep-link to its containing group", () => {
+    expect(findGroupForArticleNumber(groups, "1.e.1°")?.number).toBe("1");
+    expect(findGroupForArticleNumber(groups, "2.4.1.a.1°")?.number).toBe("2.4");
+  });
+
+  it("returns undefined for an unknown number", () => {
+    expect(findGroupForArticleNumber(groups, "99")).toBeUndefined();
+    expect(findGroupForArticleNumber(groups, null)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What & why

The library's second column (article list) was filled 1:1 from `articles[]`. For deeply split laws this rendered every segment as its own item — e.g. `Artikel 1.e.1°` as a separate menu entry for [`besluit_zorgverzekering`](https://editor.regelrecht.rijks.app/library/besluit_zorgverzekering). The list now groups **per article**: all segments of one article fold into a single item, and selecting it shows them together.

## Grouping key: the url anchor

Every entry has a required `url` with an `#Artikel…` anchor — the real article anchor (= the harvester's `number_parts[0]`). This is more reliable than the dotted number:

- `1.e.1°`, `1.f` → `#Artikel1`
- `2.4.1`, `2.4.1.a.1°` → `#Artikel2.4`
- a genuine dotted article like `3.1` → `#Artikel3.1` (its own group, **not** over-grouped)

No schema, harvester, or corpus changes needed.

## Part 1 — Library (read-only)

- `utils/articleGroups.js` — shared `groupArticles` + `findGroupForArticleNumber` (+ tests)
- `components/ArticleGroup.vue` — stacks the segments, reusing `ArticleText` / `MachineReadable` / `YamlView`; the text reads as one continuous article, `machine_readable` is shown per segment with its segment number as provenance (+ tests)
- `LibraryApp.vue` — column 2 groups, the detail renders the group, and deep-links to a leaf number normalize to the article number

## Part 2 — Editor

Without this, "Edit" landed on the first segment and the underlying parts (`1.a`, `1.b`, `2.4.1.a.1°`) became unreachable in the editor (which has no article list — only tabs + search).

- **Tabs are now per article** (group number) instead of per leaf segment: one tab per article, remembering which segment is active — no tab spam when switching parts.
- An **"Onderdeel" (part) selector** in the document-tab bar (only for split articles) makes every segment reachable and editable.
- Editing/saving still operates on the active segment (`selectedArticleNumber`) — grouping is purely a navigation layer; the splice/PUT logic is unchanged.

Fully seamless stacked text editing (all segments as one continuous editor) was deliberately left out: the editor's text/notes/toolbar machinery is per-article. Per-segment selection is the safe, reachable solution.

## Testing

- `npm --prefix frontend test` — 256 tests green (17 new)
- `npx vite build` — compiles
- Browser smoke (against the built `dist/` with the real `besluit_zorgverzekering`, since the preview host has a TLS mismatch that blocks the sandbox browser):
  - Library: 354 entries → 62 article items, no leaf items; `Artikel 1` shows 41 segments merged; deep-link `2.4.1.a.1°` → `2.4`.
  - Editor: `Artikel 1` / `Artikel 2.4` each one tab; part selector with 41 resp. 15 segments; switching parts reuses the tab (no spam).

No custom CSS — everything via `ndd-*` components.