### PR TITLE
feat(dev): local SSO login against a Keycloak realm

### DIFF
--- a/.env.editor-local.example
+++ b/.env.editor-local.example
@@ -21,9 +21,9 @@
 OIDC_DISCOVERY_URL=https://<keycloak-host>/realms/<realm>/.well-known/openid-configuration
 
 # Confidential client (Client authentication = On) with the localhost redirect URI.
-# A dedicated dev client (e.g. `editor-local`) is recommended over reusing the
-# production client — see the docs for the trade-off.
-OIDC_CLIENT_ID=editor-local
+# A dedicated dev client (`regelrecht-local`, shared across all local apps) is
+# recommended over reusing the production client — see the docs for the trade-off.
+OIDC_CLIENT_ID=regelrecht-local
 # Quote the secret: this file is sourced by the shell (`just editor-sso`), so a
 # value containing spaces or shell metacharacters would otherwise break.
 OIDC_CLIENT_SECRET='<client-secret-from-keycloak>'

--- a/.env.editor-local.example
+++ b/.env.editor-local.example
@@ -21,8 +21,12 @@
 OIDC_DISCOVERY_URL=https://<keycloak-host>/realms/<realm>/.well-known/openid-configuration
 
 # Confidential client (Client authentication = On) with the localhost redirect URI.
-OIDC_CLIENT_ID=editor
-OIDC_CLIENT_SECRET=<client-secret-from-keycloak>
+# A dedicated dev client (e.g. `editor-local`) is recommended over reusing the
+# production client — see the docs for the trade-off.
+OIDC_CLIENT_ID=editor-local
+# Quote the secret: this file is sourced by the shell (`just editor-sso`), so a
+# value containing spaces or shell metacharacters would otherwise break.
+OIDC_CLIENT_SECRET='<client-secret-from-keycloak>'
 
 # Minimum realm role required to log in. Your account needs this role (or higher).
 OIDC_REQUIRED_ROLE=editor-reader

--- a/.env.editor-local.example
+++ b/.env.editor-local.example
@@ -1,0 +1,36 @@
+# Local SSO login for the editor (real SSO Rijk Keycloak over http://localhost).
+#
+# Copy to `.env.editor-local` (gitignored) and fill in the values from your
+# Keycloak realm. Then run `just editor-sso`. See
+# docs/src/content/docs/auth-and-roles.md → "Local SSO login" for the full guide,
+# including the Keycloak client configuration (localhost redirect URI, confidential
+# client, realm-roles ID-token mapper).
+#
+# Use Chrome or Firefox: the session cookie is marked `Secure` and only those
+# browsers send Secure cookies over http://localhost. Safari will not.
+#
+# Running inside a dev container (Docker Desktop host)? Two adjustments:
+#   - DATABASE_URL host: use `host.docker.internal` instead of `localhost`
+#     (published container ports live on the Docker host, not the container's
+#     localhost — same reason as TESTCONTAINERS_HOST_OVERRIDE).
+#   - BASE_URL / Vite port: use a host-mapped port (e.g. 7300) and start Vite
+#     with `--port 7300`, since only mapped ports are reachable from the browser.
+#     The Keycloak redirect URI must then be http://localhost:7300/auth/callback.
+
+# OIDC issuer discovery. Takes priority over KEYCLOAK_BASE_URL + KEYCLOAK_REALM.
+OIDC_DISCOVERY_URL=https://<keycloak-host>/realms/<realm>/.well-known/openid-configuration
+
+# Confidential client (Client authentication = On) with the localhost redirect URI.
+OIDC_CLIENT_ID=editor
+OIDC_CLIENT_SECRET=<client-secret-from-keycloak>
+
+# Minimum realm role required to log in. Your account needs this role (or higher).
+OIDC_REQUIRED_ROLE=editor-reader
+
+# Browser-facing origin of the editor frontend (Vite). The redirect URI becomes
+# ${BASE_URL}/auth/callback — this exact value must be a Valid redirect URI on the
+# Keycloak client.
+BASE_URL=http://localhost:3000
+
+# Session store (required whenever OIDC is enabled). Matches the `just dev` Postgres.
+DATABASE_URL=postgres://regelrecht:regelrecht_dev@localhost:5433/regelrecht_pipeline

--- a/.env.editor-local.example
+++ b/.env.editor-local.example
@@ -9,13 +9,10 @@
 # Use Chrome or Firefox: the session cookie is marked `Secure` and only those
 # browsers send Secure cookies over http://localhost. Safari will not.
 #
-# Running inside a dev container (Docker Desktop host)? Two adjustments:
-#   - DATABASE_URL host: use `host.docker.internal` instead of `localhost`
-#     (published container ports live on the Docker host, not the container's
-#     localhost — same reason as TESTCONTAINERS_HOST_OVERRIDE).
-#   - BASE_URL / Vite port: use a host-mapped port (e.g. 7300) and start Vite
-#     with `--port 7300`, since only mapped ports are reachable from the browser.
-#     The Keycloak redirect URI must then be http://localhost:7300/auth/callback.
+# The values below are for a dev container backed by Docker Desktop (the common
+# setup here): the DB host is `host.docker.internal` and the frontend runs on a
+# host-mapped port (7300). On a plain Linux host instead, use `localhost` for the
+# DB host and any free port (e.g. 3000) for BASE_URL / Vite.
 
 # OIDC issuer discovery. Takes priority over KEYCLOAK_BASE_URL + KEYCLOAK_REALM.
 OIDC_DISCOVERY_URL=https://<keycloak-host>/realms/<realm>/.well-known/openid-configuration
@@ -31,10 +28,11 @@ OIDC_CLIENT_SECRET='<client-secret-from-keycloak>'
 # Minimum realm role required to log in. Your account needs this role (or higher).
 OIDC_REQUIRED_ROLE=editor-reader
 
-# Browser-facing origin of the editor frontend (Vite). The redirect URI becomes
-# ${BASE_URL}/auth/callback — this exact value must be a Valid redirect URI on the
-# Keycloak client.
-BASE_URL=http://localhost:3000
+# Browser-facing origin of the editor frontend (Vite, started with --port 7300).
+# The redirect URI becomes ${BASE_URL}/auth/callback — this exact value must be a
+# Valid redirect URI on the Keycloak client.
+BASE_URL=http://localhost:7300
 
-# Session store (required whenever OIDC is enabled). Matches the `just dev` Postgres.
-DATABASE_URL=postgres://regelrecht:regelrecht_dev@localhost:5433/regelrecht_pipeline
+# Session store (required whenever OIDC is enabled). The `just dev` Postgres is
+# published on :5433; from a dev container reach it via host.docker.internal.
+DATABASE_URL=postgres://regelrecht:regelrecht_dev@host.docker.internal:5433/regelrecht_pipeline

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -41,6 +41,7 @@ jobs:
             ci
             schema
             deps
+            dev
           requireScope: false
           subjectPattern: ^[a-z].*$
           subjectPatternError: |

--- a/.gitignore
+++ b/.gitignore
@@ -47,9 +47,9 @@ trace_output/
 corpus-registry.local.yaml
 corpus-auth.yaml
 
-# Environment
-.env
-.env.editor-local
+# Environment — ignore all .env files, keep the committed *.example templates
+.env*
+!.env*.example
 
 # Keycloak client exports (local dev only — may contain secrets)
 dev/keycloak/

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,10 @@ corpus-auth.yaml
 
 # Environment
 .env
+.env.editor-local
+
+# Keycloak client exports (local dev only — may contain secrets)
+dev/keycloak/
 
 # Gemini CLI
 .gemini/*

--- a/Justfile
+++ b/Justfile
@@ -138,6 +138,17 @@ admin-test:
 editor-api:
     cd packages && cargo run --package regelrecht-editor-api
 
+# Run editor API with real SSO Rijk login (loads .env.editor-local; see auth-and-roles.md)
+editor-sso:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ ! -f .env.editor-local ]; then
+        echo "Missing .env.editor-local — copy .env.editor-local.example and fill in the Keycloak values." >&2
+        exit 1
+    fi
+    set -a; . ./.env.editor-local; set +a
+    cd packages && cargo run --package regelrecht-editor-api
+
 # Check editor API Rust code
 editor-api-check:
     cd packages && {{ci_flags}} cargo check --package regelrecht-editor-api

--- a/docs/src/content/docs/auth-and-roles.md
+++ b/docs/src/content/docs/auth-and-roles.md
@@ -238,14 +238,16 @@ layer is driven entirely by environment variables.
 
 **How the local flow fits together**
 
-- The editor frontend runs on Vite at `:3000` and proxies `/api`, `/auth`,
-  `/health` to the editor-api on `:8000`. The browser talks only to
-  `http://localhost:3000`.
+- The editor frontend runs on Vite (started with `--port 7300`) and proxies
+  `/api`, `/auth`, `/health` to the editor-api on `:8000`. The browser talks
+  only to `http://localhost:7300`. (Vite's config default is `:3000`; we use a
+  host-mapped port — see *Ports and DB host* below.)
 - The redirect URI is built as `${BASE_URL}/auth/callback`. With
-  `BASE_URL=http://localhost:3000` it becomes
-  `http://localhost:3000/auth/callback`, which Vite proxies to the backend.
+  `BASE_URL=http://localhost:7300` it becomes
+  `http://localhost:7300/auth/callback`, which Vite proxies to the backend.
 - When OIDC is enabled the session uses a **PostgreSQL** store, so
-  `DATABASE_URL` is required (the `just dev` Postgres works).
+  `DATABASE_URL` is required (the `just dev` Postgres works; from a dev
+  container reach it via `host.docker.internal`).
 
 **Keycloak configuration (one-time, realm admin)**
 
@@ -260,10 +262,12 @@ URI per app port:
    `OIDC_CLIENT_SECRET` is empty). Enable *Standard flow* (Authorization Code).
    PKCE (S256) is sent by the app and accepted by Keycloak out of the box; you
    may optionally enforce it under *Advanced → Proof Key for Code Exchange*.
-2. **Valid redirect URIs**: add exactly `http://localhost:3000/auth/callback`
-   (scheme + host + port + path must match the value the app sends).
-3. **Web origins**: add `http://localhost:3000` (or `+` to derive from the
-   redirect URIs) so the browser's CORS checks pass.
+2. **Valid redirect URIs**: add exactly `http://localhost:7300/auth/callback`
+   for the editor — and one per other local app, e.g.
+   `http://localhost:7400/auth/callback` for harvester-admin. Scheme + host +
+   port + path must match the value the app sends.
+3. **Web origins**: add `http://localhost:7300` (and `http://localhost:7400`),
+   or `+` to derive from the redirect URIs, so the browser's CORS checks pass.
 4. **Client scopes**: ensure `openid`, `email`, and `profile` are granted — the
    app requests these three scopes.
 5. **Realm-roles ID-token mapper**: add a *User Realm Role* mapper on the client
@@ -284,16 +288,15 @@ values, then:
 
 ```bash
 # 1. Postgres only. (Don't use `just dev` here — it also starts the admin API
-#    on :8000 and its own Vite on :3000, both of which collide with the steps
-#    below.)
+#    on :8000, which collides with editor-api below.)
 docker compose -f docker-compose.dev.yml -f dev/compose.native.yaml up -d postgres
 # 2. editor-api on :8000 with .env.editor-local loaded:
 just editor-sso
-# 3. in another shell — editor frontend on :3000:
-cd frontend && npx vite
+# 3. in another shell — editor frontend on the host-mapped port 7300:
+cd frontend && npx vite --port 7300
 ```
 
-Open `http://localhost:3000` in **Chrome or Firefox** and log in. The session
+Open `http://localhost:7300` in **Chrome or Firefox** and log in. The session
 cookie is marked `Secure`; Chrome 89+/Firefox send Secure cookies over
 `http://localhost`, but **Safari does not** — there the OIDC callback fails with
 a CSRF/nonce mismatch. For Safari, front the editor with an `https://localhost`
@@ -303,17 +306,20 @@ On a successful start the editor-api log shows
 `using OIDC_DISCOVERY_URL for issuer: …` and
 `session store ready (PostgreSQL-backed)` (not the "OIDC is DISABLED" warning).
 
-**Running inside a dev container** (Docker Desktop on the host): published
-container ports live on the Docker host, not the container's `localhost`, so
-two values change:
+**Ports and DB host.** The values above assume a dev container backed by Docker
+Desktop (the common setup here):
 
-- `DATABASE_URL` host → `host.docker.internal` (e.g.
-  `postgres://regelrecht:regelrecht_dev@host.docker.internal:5433/regelrecht_pipeline`),
-  the same reason `TESTCONTAINERS_HOST_OVERRIDE` is needed for tests.
-- Use a host-mapped port for the browser-facing frontend (e.g. `7300`):
-  `npx vite --port 7300`, `BASE_URL=http://localhost:7300`, and a matching
-  `http://localhost:7300/auth/callback` redirect URI in Keycloak. The editor-api
-  stays on `:8000` (container-internal; only Vite needs to be reachable).
+- `DATABASE_URL` uses `host.docker.internal` — published container ports live on
+  the Docker host, not the container's `localhost` (the same reason
+  `TESTCONTAINERS_HOST_OVERRIDE` is needed for tests).
+- The frontend uses a **host-mapped port** in the 7100–7300 range (`7300`)
+  because only mapped ports are reachable from the browser; `3000`/`8000` are
+  not forwarded. The editor-api stays on `:8000` (container-internal; only Vite
+  needs to be reachable).
+
+On a plain Linux host neither applies: use `localhost` for the DB and any free
+port (e.g. `3000`) for `BASE_URL` and Vite, with a matching redirect URI in
+Keycloak.
 
 ## Programmatic access (admin API key)
 

--- a/docs/src/content/docs/auth-and-roles.md
+++ b/docs/src/content/docs/auth-and-roles.md
@@ -229,6 +229,88 @@ without OIDC configured**: the warning is the only safeguard, and the
 admin-tier routes (corpus reload, feature-flag toggles, job deletion, source
 sync) are fully open in this mode.
 
+### Local SSO login (dev/local, real Keycloak)
+
+To test the *real* login + RBAC flow locally — instead of the auth-disabled
+bypass above — you can point the editor at a Keycloak realm and log in with a
+real account over `http://localhost`. No code change is required; the auth
+layer is driven entirely by environment variables.
+
+**How the local flow fits together**
+
+- The editor frontend runs on Vite at `:3000` and proxies `/api`, `/auth`,
+  `/health` to the editor-api on `:8000`. The browser talks only to
+  `http://localhost:3000`.
+- The redirect URI is built as `${BASE_URL}/auth/callback`. With
+  `BASE_URL=http://localhost:3000` it becomes
+  `http://localhost:3000/auth/callback`, which Vite proxies to the backend.
+- When OIDC is enabled the session uses a **PostgreSQL** store, so
+  `DATABASE_URL` is required (the `just dev` Postgres works).
+
+**Keycloak configuration (one-time, realm admin)**
+
+Configure the OIDC client the editor will use (re-use the existing `editor`
+client, or create a dedicated `editor-local` client — adding a `localhost`
+redirect to a production client is a minor token-leakage footgun, so a separate
+dev client is the cleaner choice):
+
+1. **Client type / capability**: *Client authentication* = **On** (a
+   confidential client — the editor sends a client secret, and startup fails if
+   `OIDC_CLIENT_SECRET` is empty). Enable *Standard flow* (Authorization Code).
+   PKCE (S256) is sent by the app and accepted by Keycloak out of the box; you
+   may optionally enforce it under *Advanced → Proof Key for Code Exchange*.
+2. **Valid redirect URIs**: add exactly `http://localhost:3000/auth/callback`
+   (scheme + host + port + path must match the value the app sends).
+3. **Web origins**: add `http://localhost:3000` (or `+` to derive from the
+   redirect URIs) so the browser's CORS checks pass.
+4. **Client scopes**: ensure `openid`, `email`, and `profile` are granted — the
+   app requests these three scopes.
+5. **Realm-roles ID-token mapper**: add a *User Realm Role* mapper on the client
+   (or its dedicated scope) with *Add to ID token* = On. Keycloak only puts
+   `realm_access.roles` in the access token by default; without this mapper the
+   app falls back to parsing the access token (noisier, but still works).
+6. **Roles on your account**: grant your user at least `editor-reader` (the
+   login gate set by `OIDC_REQUIRED_ROLE`). Without it you can authenticate but
+   get **403** on every API call. See the role hierarchy above for higher tiers.
+7. Note the **discovery URL**
+   (`https://<host>/realms/<realm>/.well-known/openid-configuration`), the
+   **client ID**, and the **client secret** (Credentials tab) for the env file.
+
+**Run it**
+
+Copy `.env.editor-local.example` to `.env.editor-local`, fill in the Keycloak
+values, then:
+
+```bash
+just dev            # brings up the dev Postgres (stop/skip the admin API — it
+                    # also binds :8000 and collides with editor-api)
+just editor-sso     # editor-api on :8000 with .env.editor-local loaded
+# in another shell:
+cd frontend && npx vite   # editor frontend on :3000
+```
+
+Open `http://localhost:3000` in **Chrome or Firefox** and log in. The session
+cookie is marked `Secure`; Chrome 89+/Firefox send Secure cookies over
+`http://localhost`, but **Safari does not** — there the OIDC callback fails with
+a CSRF/nonce mismatch. For Safari, front the editor with an `https://localhost`
+TLS proxy instead.
+
+On a successful start the editor-api log shows
+`using OIDC_DISCOVERY_URL for issuer: …` and
+`session store ready (PostgreSQL-backed)` (not the "OIDC is DISABLED" warning).
+
+**Running inside a dev container** (Docker Desktop on the host): published
+container ports live on the Docker host, not the container's `localhost`, so
+two values change:
+
+- `DATABASE_URL` host → `host.docker.internal` (e.g.
+  `postgres://regelrecht:regelrecht_dev@host.docker.internal:5433/regelrecht_pipeline`),
+  the same reason `TESTCONTAINERS_HOST_OVERRIDE` is needed for tests.
+- Use a host-mapped port for the browser-facing frontend (e.g. `7300`):
+  `npx vite --port 7300`, `BASE_URL=http://localhost:7300`, and a matching
+  `http://localhost:7300/auth/callback` redirect URI in Keycloak. The editor-api
+  stays on `:8000` (container-internal; only Vite needs to be reachable).
+
 ## Programmatic access (admin API key)
 
 The harvester-admin service accepts a bearer API key on **GET** and **DELETE**

--- a/docs/src/content/docs/auth-and-roles.md
+++ b/docs/src/content/docs/auth-and-roles.md
@@ -282,11 +282,14 @@ Copy `.env.editor-local.example` to `.env.editor-local`, fill in the Keycloak
 values, then:
 
 ```bash
-just dev            # brings up the dev Postgres (stop/skip the admin API — it
-                    # also binds :8000 and collides with editor-api)
-just editor-sso     # editor-api on :8000 with .env.editor-local loaded
-# in another shell:
-cd frontend && npx vite   # editor frontend on :3000
+# 1. Postgres only. (Don't use `just dev` here — it also starts the admin API
+#    on :8000 and its own Vite on :3000, both of which collide with the steps
+#    below.)
+docker compose -f docker-compose.dev.yml -f dev/compose.native.yaml up -d postgres
+# 2. editor-api on :8000 with .env.editor-local loaded:
+just editor-sso
+# 3. in another shell — editor frontend on :3000:
+cd frontend && npx vite
 ```
 
 Open `http://localhost:3000` in **Chrome or Firefox** and log in. The session

--- a/docs/src/content/docs/auth-and-roles.md
+++ b/docs/src/content/docs/auth-and-roles.md
@@ -249,10 +249,11 @@ layer is driven entirely by environment variables.
 
 **Keycloak configuration (one-time, realm admin)**
 
-Configure the OIDC client the editor will use (re-use the existing `editor`
-client, or create a dedicated `editor-local` client — adding a `localhost`
-redirect to a production client is a minor token-leakage footgun, so a separate
-dev client is the cleaner choice):
+Configure the OIDC client the editor will use. Re-using the production client
+and adding a `localhost` redirect to it is a minor token-leakage footgun, so the
+cleaner choice is a single dedicated dev client — `regelrecht-local`, shared
+across all local apps (editor, harvester-admin, …), with a `localhost` redirect
+URI per app port:
 
 1. **Client type / capability**: *Client authentication* = **On** (a
    confidential client — the editor sends a client secret, and startup fails if


### PR DESCRIPTION
## Wat & waarom

Tot nu toe draait de editor lokaal alleen in **auth-disabled mode** (geen `OIDC_CLIENT_ID` → alle auth-checks gebypassed). Daardoor kun je de echte SSO-/RBAC-flow (login-redirect, rollen uit het JWT, per-route gates) lokaal niet testen.

Deze PR documenteert en faciliteert lokaal inloggen tegen een echte Keycloak-realm (bijv. SSO Rijk) over `http://localhost`. **Geen code-wijziging nodig** — de auth-laag is volledig env-var-gestuurd; dit is puur tooling + docs.

## Wijzigingen

- **`just editor-sso`** — draait de editor-api op `:8000` met `.env.editor-local` geladen (hergebruikt de bestaande `editor-api`-recipe).
- **`.env.editor-local.example`** — template met alle benodigde vars; het echte `.env.editor-local` is gitignored.
- **`docs/auth-and-roles.md` → "Local SSO login"** — volledige handleiding:
  - Keycloak-client setup: confidential client, `localhost` redirect URI, realm-roles ID-token mapper, vereiste rol (`editor-reader`).
  - Browser-caveat: `Secure`-cookie werkt over `http://localhost` in Chrome/Firefox, niet Safari.
  - Dev-container caveat: `host.docker.internal` als DB-host + een host-gemapte Vite-poort.
- **`.gitignore`** — negeert `.env.editor-local` en `dev/keycloak/` (lokale exports met secrets).

## Getest

End-to-end gevalideerd tegen een echte realm: OIDC discovery + `/auth/login` 307 naar Keycloak met `client_id`, `S256` PKCE en de juiste `redirect_uri`, en een succesvolle interactieve login in de browser.