### PR TITLE
chore(dev): rename local SSO env to .env.sso-local

### DIFF
--- a/.env.sso-local.example
+++ b/.env.sso-local.example
@@ -1,6 +1,6 @@
 # Local SSO login for the editor (real SSO Rijk Keycloak over http://localhost).
 #
-# Copy to `.env.editor-local` (gitignored) and fill in the values from your
+# Copy to `.env.sso-local` (gitignored) and fill in the values from your
 # Keycloak realm. Then run `just editor-sso`. See
 # docs/src/content/docs/auth-and-roles.md → "Local SSO login" for the full guide,
 # including the Keycloak client configuration (localhost redirect URI, confidential

--- a/.gitignore
+++ b/.gitignore
@@ -51,9 +51,6 @@ corpus-auth.yaml
 .env*
 !.env*.example
 
-# Keycloak client exports (local dev only — may contain secrets)
-dev/keycloak/
-
 # Gemini CLI
 .gemini/*
 !.gemini/prompts/

--- a/Justfile
+++ b/Justfile
@@ -138,15 +138,15 @@ admin-test:
 editor-api:
     cd packages && cargo run --package regelrecht-editor-api
 
-# Run editor API with real SSO Rijk login (loads .env.editor-local; see auth-and-roles.md)
+# Run editor API with real SSO Rijk login (loads .env.sso-local; see auth-and-roles.md)
 editor-sso:
     #!/usr/bin/env bash
     set -euo pipefail
-    if [ ! -f .env.editor-local ]; then
-        echo "Missing .env.editor-local — copy .env.editor-local.example and fill in the Keycloak values." >&2
+    if [ ! -f .env.sso-local ]; then
+        echo "Missing .env.sso-local — copy .env.sso-local.example and fill in the Keycloak values." >&2
         exit 1
     fi
-    set -a; . ./.env.editor-local; set +a
+    set -a; . ./.env.sso-local; set +a
     cd packages && cargo run --package regelrecht-editor-api
 
 # Check editor API Rust code

--- a/docs/src/content/docs/auth-and-roles.md
+++ b/docs/src/content/docs/auth-and-roles.md
@@ -283,14 +283,14 @@ URI per app port:
 
 **Run it**
 
-Copy `.env.editor-local.example` to `.env.editor-local`, fill in the Keycloak
+Copy `.env.sso-local.example` to `.env.sso-local`, fill in the Keycloak
 values, then:
 
 ```bash
 # 1. Postgres only. (Don't use `just dev` here — it also starts the admin API
 #    on :8000, which collides with editor-api below.)
 docker compose -f docker-compose.dev.yml -f dev/compose.native.yaml up -d postgres
-# 2. editor-api on :8000 with .env.editor-local loaded:
+# 2. editor-api on :8000 with .env.sso-local loaded:
 just editor-sso
 # 3. in another shell — editor frontend on the host-mapped port 7300:
 cd frontend && npx vite --port 7300


### PR DESCRIPTION
Follow-up cleanup on #737.

## Wat

- **Rename** `.env.editor-local(.example)` → `.env.sso-local(.example)` — duidelijker dan "editor-local", en het sluit aan op de `just editor-sso`-flow voor lokaal SSO-inloggen. De `.env*` + `!.env*.example` ignore dekt de nieuwe naam ongewijzigd.
- **`just editor-sso`** en de "Local SSO login"-docs verwijzen nu naar `.env.sso-local`.
- **`.gitignore`**: de `dev/keycloak/`-regel verwijderd. De Keycloak-client wordt in Keycloak zelf geconfigureerd (handmatig, beschreven in de docs) en hoort niet als geëxporteerd bestand in de repo — ook niet als ignore-vangnet.

Geen code- of gedragswijziging; alleen tooling/docs.