### PR TITLE
fix(landing): FAQ-cards in twee uitgebalanceerde kolommen

### DIFF
--- a/docs/src/components/LandingSections.astro
+++ b/docs/src/components/LandingSections.astro
@@ -554,9 +554,9 @@ const toc = [
             <h2>{t.faq.title}</h2>
           </nldd-title>
           <nldd-spacer size="24" />
-          <nldd-collection layout="grid" item-width="480px">
+          <nldd-container layout="columns" column-count="1" md-column-count="2" lg-column-count="2" gap="40">
             {t.faq.items.map((item) => (
-              <nldd-card accessible-label={item.q}>
+              <nldd-card class="rr-faq-card" accessible-label={item.q}>
                 <nldd-container padding="20">
                   <nldd-title size="4">
                     <h3>{item.q}</h3>
@@ -576,7 +576,7 @@ const toc = [
                 </nldd-container>
               </nldd-card>
             ))}
-          </nldd-collection>
+          </nldd-container>
         </nldd-simple-section>
 
         <nldd-simple-section

--- a/docs/src/lib/landing-content.ts
+++ b/docs/src/lib/landing-content.ts
@@ -460,23 +460,21 @@ export const content: Record<'nl' | 'en', LandingContent> = {
     },
     faq: {
       title: 'Vragen bij deze verkenning',
+      // Item order is tuned so the two-column masonry layout (see
+      // LandingSections.astro) ends up with roughly equal column heights:
+      // the long answers are spread across both columns instead of stacking
+      // in the left one. The cards read column-by-column, not row-by-row, so
+      // this is a visual ordering, not a content priority. Reordering, adding
+      // or shortening an answer changes the balance — re-check the layout if
+      // you touch this list.
       items: [
-        {
-          q: 'Wat zou een digitaal rechtsstelsel kunnen betekenen?',
-          a: 'Juridische regels worden dan geschreven als uitvoerbare code die computers direct kunnen draaien en toepassen, zonder tussenkomst van menselijke interpretatie of programmeurs. Is dat realiseerbaar? En hoe verhoudt het zich tot traditioneel analoog recht?',
-        },
-        {
-          q: 'Betekent dit één centrale interpretatie?',
-          a: 'Nee. RegelRecht verkent of de manier waarop een wet wordt uitgevoerd publiek gepubliceerd kan worden, niet of er één partij is die bepaalt wat de waarheid is. Het bevoegd gezag publiceert zijn lezing als gezaghebbende interpretatie, maar andere organisaties, juristen en burgers kunnen hun lezing daarnaast publiceren. De executie wordt bovendien niet aan één engine opgehangen: meerdere onafhankelijke implementaties moeten op dezelfde regels en data dezelfde uitkomst geven. Wat centraal wordt is de publicatie en controleerbaarheid, niet de interpretatie zelf.',
-        },
         {
           q: 'Wat gebeurt er met open normen?',
           a: 'Wetten bevatten bewust ruimte voor interpretatie: termen die "bij ministeriële regeling" worden ingevuld, of begrippen die een afweging aan de uitvoerder laten. Bij gewone automatisering verdwijnt die ruimte stilzwijgend in code: de keuze die een programmeur maakt wordt feitelijk recht, zonder publicatie of toetsing. RegelRecht maakt zo\'n keuze juist expliciet: de hogere wet markeert een open norm, de lagere regeling vult hem in, en juristen kunnen aantekenen of een begrip volledig, deels of nog niet is ingevuld. Zo wordt zichtbaar waar de wet eindigt en de interpretatie begint. Echte menselijke beoordelingen in een besluitproces, zoals een hardheidsclausule of een individuele afweging door een ambtenaar, blijven gewoon menselijk werk; die proberen we niet weg te automatiseren.',
         },
         {
-          q: 'Waarom een eigen regelformaat?',
-          a: 'Het formaat is YAML met wettekst en machine-uitvoerbare regels naast elkaar in één bestand. Een versioned JSON Schema bewaakt de structuur, BDD-scenario’s leggen de bedoelde uitkomsten vast. Zo kunnen juristen meelezen, ontwikkelaars meebouwen, en verschillende overheidssystemen dezelfde regels gebruiken.',
-          link: { label: 'Lees RFC-011', href: '/rfcs/rfc-011' },
+          q: 'Wat zou een digitaal rechtsstelsel kunnen betekenen?',
+          a: 'Juridische regels worden dan geschreven als uitvoerbare code die computers direct kunnen draaien en toepassen, zonder tussenkomst van menselijke interpretatie of programmeurs. Is dat realiseerbaar? En hoe verhoudt het zich tot traditioneel analoog recht?',
         },
         {
           q: 'Hoe zou dit zich kunnen verhouden tot bestaande systemen?',
@@ -487,12 +485,21 @@ export const content: Record<'nl' | 'en', LandingContent> = {
           a: 'RegelRecht is een technisch hulpmiddel. De juridische geldigheid blijft bij de oorspronkelijke wetgeving. De vraag is of het kan helpen bij consistente interpretatie en toepassing.',
         },
         {
-          q: 'Hoe draagt dit bij aan transparantie?',
-          a: 'Door regels expliciet te maken in code kunnen burgers en organisaties exact zien hoe beslissingen tot stand komen, in plaats van te vertrouwen op ondoorzichtige systemen.',
+          q: 'Betekent dit één centrale interpretatie?',
+          a: 'Nee. RegelRecht verkent of de manier waarop een wet wordt uitgevoerd publiek gepubliceerd kan worden, niet of er één partij is die bepaalt wat de waarheid is. Het bevoegd gezag publiceert zijn lezing als gezaghebbende interpretatie, maar andere organisaties, juristen en burgers kunnen hun lezing daarnaast publiceren. De executie wordt bovendien niet aan één engine opgehangen: meerdere onafhankelijke implementaties moeten op dezelfde regels en data dezelfde uitkomst geven. Wat centraal wordt is de publicatie en controleerbaarheid, niet de interpretatie zelf.',
         },
         {
           q: 'Moet ik dan jullie Rust-engine in mijn landschap draaien?',
           a: 'Nee. RegelRecht legt het regelformaat en de bedoelde uitkomsten vast, niet de implementatie. De Rust-engine is de referentie-implementatie: hij laat zien wat de regels horen te doen en dient als ijkpunt waartegen andere implementaties zich kunnen meten. Een engine kan ook anders geïmplementeerd worden, in een andere taal of architectuur, zodat hij in jouw landschap past. Wat telt is dat elke implementatie op dezelfde regels en data dezelfde uitkomst geeft als de referentie.',
+        },
+        {
+          q: 'Waarom een eigen regelformaat?',
+          a: 'Het formaat is YAML met wettekst en machine-uitvoerbare regels naast elkaar in één bestand. Een versioned JSON Schema bewaakt de structuur, BDD-scenario’s leggen de bedoelde uitkomsten vast. Zo kunnen juristen meelezen, ontwikkelaars meebouwen, en verschillende overheidssystemen dezelfde regels gebruiken.',
+          link: { label: 'Lees RFC-011', href: '/rfcs/rfc-011' },
+        },
+        {
+          q: 'Hoe draagt dit bij aan transparantie?',
+          a: 'Door regels expliciet te maken in code kunnen burgers en organisaties exact zien hoe beslissingen tot stand komen, in plaats van te vertrouwen op ondoorzichtige systemen.',
         },
       ],
     },
@@ -910,23 +917,20 @@ export const content: Record<'nl' | 'en', LandingContent> = {
     },
     faq: {
       title: 'Questions about this exploration',
+      // Item order is tuned for the two-column masonry layout (see
+      // LandingSections.astro) so the columns end up roughly equal in height;
+      // the long answers are spread across both columns. Cards read
+      // column-by-column, not row-by-row, so this is a visual ordering, not a
+      // content priority. Mirrors the Dutch list; re-check the layout if you
+      // reorder, add or shorten an answer. Keep both lists in sync.
       items: [
-        {
-          q: 'What could a digital legal system mean?',
-          a: 'Legal rules are written as executable code that computers can run and apply directly, without human interpretation or programmers in between. Is that achievable? And how does it relate to traditional analogue law?',
-        },
-        {
-          q: 'Does this mean one central interpretation?',
-          a: 'No. RegelRecht explores whether the way a law is executed can be published, not whether one party decides what is true. The competent authority publishes its reading as the authoritative interpretation, but other organisations, lawyers and citizens can publish their reading alongside it. Execution is not tied to a single engine either: multiple independent implementations must produce the same outcome on the same rules and data. What becomes central is publication and verifiability, not interpretation itself.',
-        },
         {
           q: 'What happens to open norms?',
           a: 'Laws deliberately leave room for interpretation: terms that are filled in "by ministerial regulation", or concepts that leave a judgement to the implementing body. In ordinary automation that room quietly disappears into code: the choice the programmer makes effectively becomes law, with no publication or scrutiny. RegelRecht turns that choice into something explicit instead: the higher law marks an open norm, the lower regulation fills it in, and lawyers can record whether a concept is fully, partly or not yet filled in. That makes visible where the statute ends and interpretation begins. Genuinely human judgements inside a decision process, such as a hardship clause or a case-by-case assessment by an official, stay human work; we are not trying to automate those away.',
         },
         {
-          q: 'Why a dedicated rule format?',
-          a: 'The format is YAML, with legal text and machine-executable rules side by side in a single file. A versioned JSON Schema guards the structure, and BDD scenarios capture the intended outcomes. Legal experts can read along, developers can contribute, and different government systems can use the same rules.',
-          link: { label: 'Read RFC-011', href: '/rfcs/rfc-011' },
+          q: 'What could a digital legal system mean?',
+          a: 'Legal rules are written as executable code that computers can run and apply directly, without human interpretation or programmers in between. Is that achievable? And how does it relate to traditional analogue law?',
         },
         {
           q: 'How could this relate to existing systems?',
@@ -937,12 +941,21 @@ export const content: Record<'nl' | 'en', LandingContent> = {
           a: 'RegelRecht is a technical aid. Legal validity remains with the original legislation. The open question is whether it can help with consistent interpretation and application.',
         },
         {
-          q: 'How does this contribute to transparency?',
-          a: 'By making rules explicit in code, citizens and organisations can see exactly how decisions are reached, instead of relying on opaque systems.',
+          q: 'Does this mean one central interpretation?',
+          a: 'No. RegelRecht explores whether the way a law is executed can be published, not whether one party decides what is true. The competent authority publishes its reading as the authoritative interpretation, but other organisations, lawyers and citizens can publish their reading alongside it. Execution is not tied to a single engine either: multiple independent implementations must produce the same outcome on the same rules and data. What becomes central is publication and verifiability, not interpretation itself.',
         },
         {
           q: 'Do I have to run your Rust engine in my own landscape?',
           a: 'No. RegelRecht fixes the rule format and the intended outcomes, not the implementation. The Rust engine is the reference implementation: it shows what the rules are meant to do and serves as the benchmark other implementations can measure themselves against. An engine can also be implemented differently, in another language or architecture, so that it fits your landscape. What matters is that every implementation produces the same outcome on the same rules and data as the reference.',
+        },
+        {
+          q: 'Why a dedicated rule format?',
+          a: 'The format is YAML, with legal text and machine-executable rules side by side in a single file. A versioned JSON Schema guards the structure, and BDD scenarios capture the intended outcomes. Legal experts can read along, developers can contribute, and different government systems can use the same rules.',
+          link: { label: 'Read RFC-011', href: '/rfcs/rfc-011' },
+        },
+        {
+          q: 'How does this contribute to transparency?',
+          a: 'By making rules explicit in code, citizens and organisations can see exactly how decisions are reached, instead of relying on opaque systems.',
         },
       ],
     },

--- a/docs/src/styles/landing.css
+++ b/docs/src/styles/landing.css
@@ -61,3 +61,15 @@ html {
 .rr-min-width-0 {
   min-width: 0;
 }
+
+/* --- FAQ masonry spacing ---
+   The FAQ uses nldd-container layout="columns" (CSS multicol) so cards keep
+   their natural height instead of stretching to row height like layout="grid".
+   multicol's `gap` only sets the horizontal column-gap; it has no row-gap.
+   A stand-alone nldd-spacer between cards can't fix this: at a column break it
+   orphans to the top of the next column, leaving that column starting low. A
+   bottom margin belongs to the card itself, so it never breaks away. Horizontal
+   spacing stays owned by the container's `gap`. */
+.rr-faq-card {
+  margin-bottom: 40px;
+}


### PR DESCRIPTION
## Wat

De FAQ-sectie op de landingspagina (\"Vragen bij deze verkenning\") stond in een `nldd-collection` grid. In een grid rekken cards in een rij uit naar de hoogte van de langste card, wat rommelige witruimte en ongelijke hoogtes gaf.

Nu staat de sectie in een `nldd-container layout="columns"` (CSS multicol): elke card houdt zijn natuurlijke hoogte en de cards stromen in twee kolommen wanneer de ruimte het toelaat, en in één kolom op smalle schermen.

De FAQ-items zijn herordend zodat de lange antwoorden over beide kolommen verdeeld worden en de kolommen ongeveer even hoog uitkomen. Dit is gedaan voor zowel de Nederlandse als de Engelse versie, met een toelichtend commentaar bij beide lijsten zodat de balans niet onbedoeld breekt bij een tekstwijziging.

## Custom CSS (bewust gemeld)

Eén regel custom CSS toegevoegd in `landing.css`:

```css
.rr-faq-card { margin-bottom: 40px; }
```

CSS multicol kent geen row-gap; het `gap`-attribuut van de container zet alleen de horizontale `column-gap`. Een losse `nldd-spacer` tussen de cards lost dit niet op, want die verspringt bij een kolomovergang naar de top van de volgende kolom. Een bottom-margin hoort bij de card zelf en breekt daarom nooit los. De horizontale ruimte blijft van de container-`gap`.

## Getest

- `npm run build` in `docs/` slaagt schoon (71 pagina's).
- Visueel gecontroleerd in de browser: NL en EN, beide kolommen ongeveer even hoog, geen orphan bovenaan de rechterkolom.