### PR TITLE
chore: nldd design-system plugin inschakelen voor de repo

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,5 +17,8 @@
         ]
       }
     ]
+  },
+  "enabledPlugins": {
+    "nldd@nldd-plugins": true
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,6 +18,14 @@
       }
     ]
   },
+  "extraKnownMarketplaces": {
+    "nldd-plugins": {
+      "source": {
+        "source": "github",
+        "repo": "MinBZK/storybook"
+      }
+    }
+  },
   "enabledPlugins": {
     "nldd@nldd-plugins": true
   }


### PR DESCRIPTION
Maakt de `nldd` plugin van het MinBZK design system standaard beschikbaar in deze repo, conform de `CLAUDE.md`-richtlijn dat alle UI met de NDD `ndd-*` componenten gebouwd wordt.

Twee delen, beide in `.claude/settings.json`:

- **`extraKnownMarketplaces`** — declareert waar de `nldd-plugins` marketplace vandaan komt (`github.com/MinBZK/storybook`). Zonder deze declaratie is de repo niet zelf-bevattend: die mapping stond alleen in de globale `~/.claude/plugins`-config van één machine, dus bij een collega zou de plugin stilletjes niet laden.
- **`enabledPlugins`** — zet de `nldd` plugin aan.

Zodra een collega de repo-map vertrouwt, biedt Claude Code aan om de marketplace toe te voegen en de plugin in te schakelen (geen automatische installatie; het blijft een prompt die ze accepteren).