### PR TITLE
chore(docs): nldd 0.8.54 zodat tabellen de nieuwe boxed-stijl krijgen

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@astrojs/mdx": "^6",
-        "@nldd/design-system": "^0.8.52",
+        "@nldd/design-system": "^0.8.54",
         "astro": "^6.4.2",
         "astro-pagefind": "^2.0.0",
         "rehype-mermaid": "^3",
@@ -1331,9 +1331,9 @@
       }
     },
     "node_modules/@nldd/design-system": {
-      "version": "0.8.52",
-      "resolved": "https://registry.npmjs.org/@nldd/design-system/-/design-system-0.8.52.tgz",
-      "integrity": "sha512-Hmc/IGOMOGOP1f08QCD+2F0BaAKvdtlgnLjBbXaInzmEsaOqNh8Two7f3dEEK1cM3N5oWXwJMwRmjLWBGNy2fA==",
+      "version": "0.8.56",
+      "resolved": "https://registry.npmjs.org/@nldd/design-system/-/design-system-0.8.56.tgz",
+      "integrity": "sha512-NDx2+I4jN+B5dR6mUayQQHmR0FhhXDloMom2Z59NO5KcPitrxXGopFYP4X4Vy/aLlL3EB1qwwm3fSzGeWwwRUw==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@floating-ui/dom": "^1.7.6",

--- a/docs/package.json
+++ b/docs/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@astrojs/mdx": "^6",
-    "@nldd/design-system": "^0.8.52",
+    "@nldd/design-system": "^0.8.54",
     "astro": "^6.4.2",
     "astro-pagefind": "^2.0.0",
     "rehype-mermaid": "^3",

--- a/docs/src/styles/tokens.css
+++ b/docs/src/styles/tokens.css
@@ -48,7 +48,7 @@
 }
 
 html {
-  background: var(--semantics-surfaces-background-color);
+  background: var(--semantics-surfaces-base-background-color);
   /* Sticky top nav offsets anchored scrolling (#anchor links land under the
      nav otherwise). Applies site-wide — landing + docs. */
   scroll-padding-top: 5rem;


### PR DESCRIPTION
Bumpt `@nldd/design-system` naar `^0.8.54` voor het `docs/`-pakket (dat zowel de docs als de landing serveert).

## Waarom

Vanaf 0.8.54 stylet `nldd-rich-text` de `<table>`-elementen als `nldd-table`: een afgeronde boxed frame, full-bleed scheidingslijnen en ingesprongen cellen. De markdown-tabellen in de docs renderen al als echte `<table>` binnen `nldd-rich-text`, dus ze krijgen de nieuwe look zonder dat er per tabel iets aan de markup verandert.

## Wat zit erin

- `docs/package.json`: `@nldd/design-system` van `^0.8.52` naar `^0.8.54` (resolved naar 0.8.56; 0.8.55 en 0.8.56 zijn plugin-only releases zonder component- of tokenwijzigingen).
- `docs/src/styles/tokens.css`: de breaking change uit 0.8.54 verwerkt. Surface-token hernoemd van `--semantics-surfaces-background-color` naar `--semantics-surfaces-base-background-color`. Zonder deze fix valt de pagina-achtergrond stil terug op de default.
- `docs/package-lock.json`: meegegaan met de install.

## Gecontroleerd

- Geen gebruik van de andere verwijderde API's (`nldd-progress`, `no-label`, `box-on-tinted`, `*-segment`) in de docs-scope.
- Geen extra CSS bovenop het design system; de tabelstijl komt volledig van NLDD.
- `npm run build` groen (71 pagina's), nieuwe boxed-tabel met header-divider en getinte rijen geverifieerd in de browser op `/operations/ci-cd/`.

## Buiten scope

`frontend/` (0.8.53), `frontend-lawmaking/` en `packages/admin/frontend-src/` (0.8.52) gebruiken hetzelfde hernoemde token. Bij een latere bump naar 0.8.54+ moeten die dezelfde tokenfix krijgen.