### PR TITLE
fix(frontend): restore favorites heart button in law sidebar

### DIFF
--- a/frontend/src/LibraryApp.vue
+++ b/frontend/src/LibraryApp.vue
@@ -684,6 +684,16 @@ watch(activeTrajectRef, () => {
               <nldd-simple-section width="full">
                 <nldd-title id="wet-titel" size="3"><h3>{{ lawName || 'Selecteer een wet' }}</h3></nldd-title>
                 <nldd-spacer size="16"></nldd-spacer>
+                <nldd-toolbar v-if="authenticated && selectedLaw">
+                  <nldd-toolbar-item slot="start">
+                    <nldd-icon-button
+                      :icon="favorites?.has(selectedLawId) ? 'heart-filled' : 'heart'"
+                      :text="favorites?.has(selectedLawId) ? 'Verwijder uit favorieten' : 'Voeg toe aan favorieten'"
+                      @click="toggleFavorite(selectedLawId)"
+                    ></nldd-icon-button>
+                  </nldd-toolbar-item>
+                </nldd-toolbar>
+                <nldd-spacer v-if="authenticated && selectedLaw" size="16"></nldd-spacer>
                 <nldd-inline-dialog v-if="selectedLawLoading" text="Laden..."></nldd-inline-dialog>
                 <nldd-inline-dialog v-else-if="!selectedLaw" text="Selecteer een wet"></nldd-inline-dialog>
                 <nldd-list v-else variant="simple">

--- a/frontend/src/LibraryApp.vue
+++ b/frontend/src/LibraryApp.vue
@@ -684,7 +684,7 @@ watch(activeTrajectRef, () => {
               <nldd-simple-section width="full">
                 <nldd-title id="wet-titel" size="3"><h3>{{ lawName || 'Selecteer een wet' }}</h3></nldd-title>
                 <nldd-spacer size="16"></nldd-spacer>
-                <nldd-toolbar v-if="authenticated && selectedLaw">
+                <nldd-toolbar v-if="authenticated && selectedLaw" label="Favorieten">
                   <nldd-toolbar-item slot="start">
                     <nldd-icon-button
                       :icon="favorites?.has(selectedLawId) ? 'heart-filled' : 'heart'"


### PR DESCRIPTION
## What

Restores the favorites (heart) toggle button in the law-detail sidebar so users can mark laws as favorite again.

## Why

The per-user favorites feature (#553) is still fully functional on the backend (`GET/PUT/DELETE /api/favorites`) and in the frontend logic (`loadFavorites`, `toggleFavorite`, favorites filtering). However, the heart toggle button was dropped from the `LibraryApp.vue` template during the nldd UX overhaul (ed93ddb), which rebuilt the sidebar from `ndd-*` to `nldd-*` components. This left the feature present but inaccessible from the UI.

## Changes

- Add an `nldd-icon-button` in the law-detail sidebar toolbar, shown only to authenticated users with a law selected.
- Icon toggles between `heart` and `heart-filled` based on favorite state (the old `ndd-*` set used `heart-fill`; the new nldd icon set registers `heart-filled`).
- Reuses the existing `toggleFavorite` / `favorites` logic — no backend or logic changes.

No custom CSS added; built entirely from design-system components.

## Verification

- `npm run build` passes.
- Visual/login verification on the preview deployment (button only appears when authenticated).