### PR TITLE
feat(editor): search the full traject corpus, grouped by source

### DIFF
--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -1882,7 +1882,6 @@ async function handleActionSave() {
   <TrajectDocuments />
   <SearchPopover
     ref="searchPopoverRef"
-    :laws="corpusLaws"
     @select-law="onSearchSelectLaw"
     @harvest-available="onSearchHarvestAvailable"
   />

--- a/frontend/src/LibraryApp.vue
+++ b/frontend/src/LibraryApp.vue
@@ -144,17 +144,19 @@ const detailView = computed({
 const activeAction = ref(null);
 
 // Curated sidebar sections (in render order). Each entry is
-// `{ key, title, laws }`; a `null` title renders a headerless list (the
-// no-favorites fallback). Empty sections are never pushed, so the template
+// `{ key, title, laws }`. Empty sections are never pushed, so the template
 // can iterate without per-section emptiness checks.
 //
 //   - "Bewerkt in dit traject" comes first: it's the small, high-signal,
-//     context-specific set, so it sits above the larger favorites/full list.
+//     context-specific set, so it sits above favorites.
 //     Only present when a traject is active and the diff is non-empty.
-//   - "Favorieten": the user's personal favorites. When the user has none we
-//     fall back to the full corpus (today's behavior) under no heading,
-//     rather than showing an empty panel — full browse otherwise lives in
-//     the search popover.
+//   - "Favorieten": the user's personal favorites.
+//
+// There is deliberately NO full-corpus fallback: the central corpus is the
+// full BWB corpus (thousands of laws), so dumping it into the sidebar isn't
+// useful and is exactly the "huge pile" we don't want loaded here. When
+// nothing is curated yet, the template shows a search CTA instead — full
+// browse lives in the search popover.
 const sidebarSections = computed(() => {
   const list = laws.value;
   const sections = [];
@@ -170,13 +172,9 @@ const sidebarSections = computed(() => {
     const favList = list.filter(law => favorites.value.has(law.law_id));
     if (favList.length > 0) {
       sections.push({ key: 'favorites', title: 'Favorieten', laws: favList });
-      return sections;
     }
   }
 
-  // No personal favorites: fall back to the full corpus (headerless),
-  // matching the pre-sections behavior. The curated sections layer on top.
-  sections.push({ key: 'all', title: null, laws: list });
   return sections;
 });
 
@@ -705,6 +703,15 @@ watch(activeTrajectRef, () => {
                 <nldd-title id="home-titel" size="3"><h3>{{ LIBRARY_HOME_TITLE }}</h3></nldd-title>
                 <nldd-spacer size="16"></nldd-spacer>
                 <nldd-inline-dialog v-if="loading" text="Laden..."></nldd-inline-dialog>
+                <!-- Nothing curated yet (no favorites, no traject edits): point
+                     the user at search rather than dumping the whole corpus. -->
+                <nldd-inline-dialog
+                  v-else-if="sidebarSections.length === 0"
+                  text="Nog niets in je bibliotheek"
+                  supporting-text="Zoek een wet om te openen, of markeer wetten als favoriet."
+                >
+                  <nldd-button slot="actions" variant="primary" start-icon="search" text="Zoeken" @click="openSearch"></nldd-button>
+                </nldd-inline-dialog>
                 <template v-else>
                   <template
                     v-for="(section, sectionIndex) in sidebarSections"

--- a/frontend/src/LibraryApp.vue
+++ b/frontend/src/LibraryApp.vue
@@ -329,7 +329,14 @@ async function toggleFavorite(lawId) {
   try {
     const method = isFav ? 'DELETE' : 'PUT';
     const res = await fetch(`/api/favorites/${encodeURIComponent(lawId)}`, { method });
-    if (!res.ok) revert();
+    if (!res.ok) {
+      revert();
+    } else {
+      // Re-resolve the sidebar's id-set so a newly-favorited law (whose
+      // metadata isn't loaded yet, since we only fetch favorites + edits by
+      // id) appears in the Favorieten section without a manual reload.
+      loadIndex();
+    }
   } catch {
     revert();
   } finally {
@@ -345,18 +352,34 @@ async function loadIndex() {
   // both refer to the scope this run started in.
   const trajectRef = activeTrajectRef.value;
   try {
-    const [corpusRes, , changedIds] = await Promise.all([
-      fetch(lawsListUrl(trajectRef, 'limit=1000')),
+    // Resolve the small id sets the sidebar actually needs: the user's
+    // personal favorites and (in a traject) the laws edited on the traject
+    // branch. Both `loadFavorites` and `fetchChangedLawIds` are id-only.
+    const [, changedIds] = await Promise.all([
       loadFavorites(),
       fetchChangedLawIds(trajectRef),
     ]);
-    if (!corpusRes.ok) throw new Error(`Failed to load corpus: ${corpusRes.status}`);
+    if (gen !== loadIndexGeneration) return;
+    changedLawIds.value = changedIds;
+
+    // Fetch metadata for just those ids via `?ids=` — never the whole corpus.
+    // The central corpus is the full BWB corpus (thousands of laws); loading
+    // it here only to filter out a handful would be wasteful and would miss
+    // any favorite/edit that sorts past a page cap. Full browse lives in the
+    // search popover instead.
+    const ids = new Set([...(favorites.value || []), ...(changedIds || [])]);
+    if (ids.size === 0) {
+      laws.value = [];
+      return;
+    }
+    const query = `ids=${encodeURIComponent([...ids].join(','))}&limit=1000`;
+    const res = await fetch(lawsListUrl(trajectRef, query));
+    if (!res.ok) throw new Error(`Failed to load corpus: ${res.status}`);
     // Gate before and after json(): skip parsing for stale 200s, and catch races during it.
     if (gen !== loadIndexGeneration) return;
-    const corpusLaws = await corpusRes.json();
+    const corpusLaws = await res.json();
     if (gen !== loadIndexGeneration) return;
     laws.value = corpusLaws.sort((a, b) => a.law_id.localeCompare(b.law_id));
-    changedLawIds.value = changedIds;
   } catch (e) {
     if (gen !== loadIndexGeneration) return;
     indexError.value = e;

--- a/frontend/src/LibraryApp.vue
+++ b/frontend/src/LibraryApp.vue
@@ -945,7 +945,6 @@ watch(activeTrajectRef, () => {
   <ActionSheet :action="activeAction" :article="selectedArticle" :editable="false" @close="activeAction = null" @save="activeAction = null" @edit="editInEditor" />
   <SearchPopover
     ref="searchPopoverRef"
-    :laws="laws"
     @select-law="(lawId) => selectLaw(lawId, true)"
     @harvest-available="onHarvestAvailable"
   />

--- a/frontend/src/components/SearchPopover.test.js
+++ b/frontend/src/components/SearchPopover.test.js
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { nextTick } from 'vue';
+import SearchPopover from './SearchPopover.vue';
+
+// `nldd-*` tags are registered as custom elements in vite.config.js, so they
+// render as raw HTMLElements here. We drive the component via `wrapper.vm`
+// and assert on the `groupedLaws` computed rather than the shadow DOM.
+//
+// useAuth()/useBwb* fire a `fetch` on setup; stub it so the shared
+// /auth/status probe resolves quietly instead of hitting the network.
+beforeEach(() => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(() => Promise.resolve({ ok: false, json: () => Promise.resolve({}) })),
+  );
+});
+
+function law(law_id, source_id, source_name, source_priority) {
+  return { law_id, source_id, source_name, source_priority };
+}
+
+// Two sources: the traject's own writable repo (priority 0) and the seeded
+// central corpus (priority 5). The central laws are listed first in the prop
+// to prove ordering comes from priority, not input order.
+const LAWS = [
+  law('kieswet', 'central', 'MinBZK Central', 5),
+  law('besluit_zorgverzekering_bes', 'traject-own-abc', 'MinBZK/regelrecht-corpus-BES', 0),
+  law('wet_inkomstenbelasting_bes', 'traject-own-abc', 'MinBZK/regelrecht-corpus-BES', 0),
+];
+
+function mountPopover() {
+  return mount(SearchPopover, { props: { laws: LAWS } });
+}
+
+describe('SearchPopover groupedLaws', () => {
+  it('groups matches by source, private repo (priority 0) before central', async () => {
+    const wrapper = mountPopover();
+    wrapper.vm.search = 'bes';
+    await nextTick();
+
+    const groups = wrapper.vm.groupedLaws;
+    expect(groups.map((g) => g.source_name)).toEqual([
+      'MinBZK/regelrecht-corpus-BES',
+      // central has no 'bes' match, so it drops out entirely
+    ]);
+    expect(groups[0].laws.map((l) => l.law_id)).toEqual([
+      'besluit_zorgverzekering_bes',
+      'wet_inkomstenbelasting_bes',
+    ]);
+  });
+
+  it('orders groups by source priority ascending when both match', async () => {
+    const wrapper = mountPopover();
+    wrapper.vm.search = 'wet';
+    await nextTick();
+
+    const groups = wrapper.vm.groupedLaws;
+    expect(groups.map((g) => g.source_name)).toEqual([
+      'MinBZK/regelrecht-corpus-BES', // priority 0
+      'MinBZK Central', // priority 5
+    ]);
+  });
+
+  it('returns no groups when nothing matches (external fallback territory)', async () => {
+    const wrapper = mountPopover();
+    wrapper.vm.search = 'zzzznomatch';
+    await nextTick();
+
+    expect(wrapper.vm.groupedLaws).toEqual([]);
+  });
+});

--- a/frontend/src/components/SearchPopover.test.js
+++ b/frontend/src/components/SearchPopover.test.js
@@ -124,4 +124,28 @@ describe('SearchPopover server-side search', () => {
       .filter((u) => u.includes('/harvest/search'));
     expect(bwbCalls).toHaveLength(0);
   });
+
+  it('a backend error surfaces as failed, not a cascade to the external fallback', async () => {
+    fetch.mockImplementation((url) => {
+      const u = String(url);
+      if (u.includes('/auth/status')) return Promise.resolve({ ok: false, json: async () => ({}) });
+      if (u.includes('/corpus/laws') && u.includes('q=')) {
+        return Promise.resolve({ ok: false, status: 500, json: async () => [] });
+      }
+      return Promise.resolve({ ok: true, json: async () => [] });
+    });
+
+    const wrapper = mount(SearchPopover);
+    wrapper.vm.search = 'zorg';
+    await nextTick();
+    await settle();
+    await nextTick();
+
+    expect(wrapper.vm.searchFailed).toBe(true);
+    expect(wrapper.vm.groupedLaws).toEqual([]);
+    const bwbCalls = fetch.mock.calls
+      .map((c) => String(c[0]))
+      .filter((u) => u.includes('/harvest/search'));
+    expect(bwbCalls).toHaveLength(0);
+  });
 });

--- a/frontend/src/components/SearchPopover.test.js
+++ b/frontend/src/components/SearchPopover.test.js
@@ -3,70 +3,90 @@ import { mount } from '@vue/test-utils';
 import { nextTick } from 'vue';
 import SearchPopover from './SearchPopover.vue';
 
-// `nldd-*` tags are registered as custom elements in vite.config.js, so they
-// render as raw HTMLElements here. We drive the component via `wrapper.vm`
-// and assert on the `groupedLaws` computed rather than the shadow DOM.
+// SearchPopover queries the corpus server-side (`/corpus/laws?q=`) and groups
+// the response by source. We drive it via `wrapper.vm` and assert on the
+// `groupedLaws` computed.
 //
-// useAuth()/useBwb* fire a `fetch` on setup; stub it so the shared
-// /auth/status probe resolves quietly instead of hitting the network.
+// useTrajects() calls vue-router's useRoute(); mock it so the component mounts
+// without a router (no active traject → global /api/corpus URL).
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ params: {} }),
+}));
+
+// Central corpus (priority 2) listed before the BES repo (priority 0) to prove
+// the grouping order comes from source_priority, not response order.
+const LAWS = [
+  {
+    law_id: 'besluit_zorgverzekering',
+    source_id: 'central',
+    source_name: 'Centrale Regelrecht Corpus',
+    source_priority: 2,
+  },
+  {
+    law_id: 'besluit_zorgverzekering_bes',
+    source_id: 'traject-own',
+    source_name: 'MinBZK/regelrecht-corpus-BES',
+    source_priority: 0,
+  },
+];
+
 beforeEach(() => {
   vi.stubGlobal(
     'fetch',
-    vi.fn(() => Promise.resolve({ ok: false, json: () => Promise.resolve({}) })),
+    vi.fn(async (url) => {
+      const u = String(url);
+      if (u.includes('/auth/status')) return { ok: false, json: async () => ({}) };
+      if (u.includes('/corpus/laws') && u.includes('q=')) {
+        return { ok: true, json: async () => LAWS };
+      }
+      return { ok: true, json: async () => [] };
+    }),
   );
 });
 
-function law(law_id, source_id, source_name, source_priority) {
-  return { law_id, source_id, source_name, source_priority };
-}
+// Wait past the 200ms input debounce plus the awaited fetch.
+const settle = () => new Promise((r) => setTimeout(r, 300));
 
-// Two sources: the traject's own writable repo (priority 0) and the seeded
-// central corpus (priority 5). The central laws are listed first in the prop
-// to prove ordering comes from priority, not input order.
-const LAWS = [
-  law('kieswet', 'central', 'MinBZK Central', 5),
-  law('besluit_zorgverzekering_bes', 'traject-own-abc', 'MinBZK/regelrecht-corpus-BES', 0),
-  law('wet_inkomstenbelasting_bes', 'traject-own-abc', 'MinBZK/regelrecht-corpus-BES', 0),
-];
-
-function mountPopover() {
-  return mount(SearchPopover, { props: { laws: LAWS } });
-}
-
-describe('SearchPopover groupedLaws', () => {
-  it('groups matches by source, private repo (priority 0) before central', async () => {
-    const wrapper = mountPopover();
-    wrapper.vm.search = 'bes';
+describe('SearchPopover server-side search', () => {
+  it('groups corpus matches by source, private repo (priority 0) first', async () => {
+    const wrapper = mount(SearchPopover);
+    wrapper.vm.search = 'zorgverzekering';
+    await nextTick();
+    await settle();
     await nextTick();
 
     const groups = wrapper.vm.groupedLaws;
     expect(groups.map((g) => g.source_name)).toEqual([
       'MinBZK/regelrecht-corpus-BES',
-      // central has no 'bes' match, so it drops out entirely
+      'Centrale Regelrecht Corpus',
     ]);
-    expect(groups[0].laws.map((l) => l.law_id)).toEqual([
-      'besluit_zorgverzekering_bes',
-      'wet_inkomstenbelasting_bes',
-    ]);
+    expect(groups[0].laws.map((l) => l.law_id)).toEqual(['besluit_zorgverzekering_bes']);
   });
 
-  it('orders groups by source priority ascending when both match', async () => {
-    const wrapper = mountPopover();
-    wrapper.vm.search = 'wet';
+  it('queries the backend with the q parameter (not a client-side filter)', async () => {
+    const wrapper = mount(SearchPopover);
+    wrapper.vm.search = 'kieswet';
     await nextTick();
+    await settle();
 
-    const groups = wrapper.vm.groupedLaws;
-    expect(groups.map((g) => g.source_name)).toEqual([
-      'MinBZK/regelrecht-corpus-BES', // priority 0
-      'MinBZK Central', // priority 5
-    ]);
+    const urls = fetch.mock.calls.map((c) => String(c[0]));
+    expect(urls.some((u) => u.includes('/corpus/laws') && u.includes('q=kieswet'))).toBe(true);
   });
 
-  it('returns no groups when nothing matches (external fallback territory)', async () => {
-    const wrapper = mountPopover();
-    wrapper.vm.search = 'zzzznomatch';
+  it('debounces: a single query fires one corpus request', async () => {
+    const wrapper = mount(SearchPopover);
+    wrapper.vm.search = 'z';
     await nextTick();
+    wrapper.vm.search = 'zo';
+    await nextTick();
+    wrapper.vm.search = 'zorg';
+    await nextTick();
+    await settle();
 
-    expect(wrapper.vm.groupedLaws).toEqual([]);
+    const corpusCalls = fetch.mock.calls
+      .map((c) => String(c[0]))
+      .filter((u) => u.includes('/corpus/laws') && u.includes('q='));
+    expect(corpusCalls).toHaveLength(1);
+    expect(corpusCalls[0]).toContain('q=zorg');
   });
 });

--- a/frontend/src/components/SearchPopover.test.js
+++ b/frontend/src/components/SearchPopover.test.js
@@ -89,4 +89,39 @@ describe('SearchPopover server-side search', () => {
     expect(corpusCalls).toHaveLength(1);
     expect(corpusCalls[0]).toContain('q=zorg');
   });
+
+  it('clearing the query discards an in-flight corpus fetch (no stale results)', async () => {
+    // Make the corpus fetch hang so we can clear the input mid-flight.
+    let resolveCorpus;
+    fetch.mockImplementation((url) => {
+      const u = String(url);
+      if (u.includes('/auth/status')) return Promise.resolve({ ok: false, json: async () => ({}) });
+      if (u.includes('/corpus/laws') && u.includes('q=')) {
+        return new Promise((r) => {
+          resolveCorpus = () => r({ ok: true, json: async () => LAWS });
+        });
+      }
+      return Promise.resolve({ ok: true, json: async () => [] });
+    });
+
+    const wrapper = mount(SearchPopover);
+    wrapper.vm.search = 'zorg';
+    await nextTick();
+    await settle(); // debounce fires; the corpus fetch is now pending
+
+    // Clear before the fetch resolves, then let the stale fetch settle.
+    wrapper.vm.search = '';
+    await nextTick();
+    resolveCorpus();
+    await settle();
+    await nextTick();
+
+    // The cleared term's response must not repopulate the list, and no
+    // wetten.overheid.nl search should have been fired for it.
+    expect(wrapper.vm.groupedLaws).toEqual([]);
+    const bwbCalls = fetch.mock.calls
+      .map((c) => String(c[0]))
+      .filter((u) => u.includes('/harvest/search'));
+    expect(bwbCalls).toHaveLength(0);
+  });
 });

--- a/frontend/src/components/SearchPopover.vue
+++ b/frontend/src/components/SearchPopover.vue
@@ -59,6 +59,10 @@ const serverLaws = ref([]);
 // of briefly flashing "no results" (which would wrongly trigger the external
 // fallback) before the response lands.
 const searching = ref(false);
+// True when the last corpus query failed (HTTP error or network error). Kept
+// distinct from "0 results" so a backend failure surfaces an error instead of
+// silently masquerading as "no match" and cascading to the external fallback.
+const searchFailed = ref(false);
 
 /**
  * Group the matched laws by their providing source, ordered by source
@@ -98,6 +102,7 @@ let debounceTimer = null;
 
 watch(search, (q) => {
   clearBwb();
+  searchFailed.value = false;
   if (debounceTimer) clearTimeout(debounceTimer);
   const term = q.trim();
   if (term.length < MIN_QUERY_LENGTH) {
@@ -119,14 +124,26 @@ async function runCorpusSearch(term) {
     const url = lawsListUrl(activeTrajectRef.value, `q=${encodeURIComponent(term)}&limit=60`);
     const res = await fetch(url);
     if (seq !== searchSeq) return; // a newer query superseded this one
-    const laws = res.ok ? await res.json() : [];
+    if (!res.ok) {
+      // Backend error (500/503/…). Surface it rather than letting the empty
+      // result cascade to the external wetten.overheid.nl fallback, which
+      // would mask the failure with unrelated results.
+      serverLaws.value = [];
+      searchFailed.value = true;
+      return;
+    }
+    const laws = await res.json();
     if (seq !== searchSeq) return;
     serverLaws.value = laws;
+    searchFailed.value = false;
     // No match anywhere in the corpus → offer the external wetten.overheid.nl
     // search (unless the user must log in first to reach it).
     if (laws.length === 0 && !needsLogin.value) searchBwb(term);
   } catch {
-    if (seq === searchSeq) serverLaws.value = [];
+    if (seq === searchSeq) {
+      serverLaws.value = [];
+      searchFailed.value = true;
+    }
   } finally {
     if (seq === searchSeq) searching.value = false;
   }
@@ -272,6 +289,14 @@ defineExpose({ show });
         <!-- Corpus query in flight: show a spinner instead of briefly
              flashing "no results" and wrongly tripping the external fallback. -->
         <nldd-inline-dialog v-if="searching" text="Zoeken in de wetten…"></nldd-inline-dialog>
+        <!-- Corpus query failed: surface the error instead of masking it as
+             "no results" (which would cascade to the external fallback). -->
+        <nldd-inline-dialog
+          v-else-if="searchFailed"
+          variant="alert"
+          text="Zoeken is mislukt"
+          supporting-text="De wetten konden niet worden doorzocht. Probeer het opnieuw."
+        ></nldd-inline-dialog>
         <!-- Internal corpus matches: one labelled section per source, private
              repo first (priority 0), then the central corpus. The source name
              doubles as the group header, so the per-item supporting-text is

--- a/frontend/src/components/SearchPopover.vue
+++ b/frontend/src/components/SearchPopover.vue
@@ -101,6 +101,10 @@ watch(search, (q) => {
   if (debounceTimer) clearTimeout(debounceTimer);
   const term = q.trim();
   if (term.length < MIN_QUERY_LENGTH) {
+    // Bump the sequence so any fetch already in flight (debounce fired before
+    // this clear) is discarded when it resolves — otherwise it would repopulate
+    // serverLaws for the cleared term and fire a spurious BWB search.
+    ++searchSeq;
     serverLaws.value = [];
     searching.value = false;
     return;

--- a/frontend/src/components/SearchPopover.vue
+++ b/frontend/src/components/SearchPopover.vue
@@ -3,12 +3,12 @@ import { ref, computed, watch, nextTick } from 'vue';
 import { useBwbSearch, MIN_QUERY_LENGTH } from '../composables/useBwbSearch.js';
 import { useBwbHarvest } from '../composables/useBwbHarvest.js';
 import { useAuth } from '../composables/useAuth.js';
-
-const props = defineProps({
-  laws: { type: Array, default: () => [] },
-});
+import { useTrajects } from '../composables/useTrajects.js';
+import { lawsListUrl } from '../composables/corpusUrls.js';
 
 const emit = defineEmits(['select-law', 'harvest-available']);
+
+const { activeTrajectRef } = useTrajects();
 
 const { results: bwbResults, loading: bwbLoading, search: searchBwb, clear: clearBwb } = useBwbSearch();
 const {
@@ -49,27 +49,29 @@ function displayName(law) {
   return law.law_id.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
 }
 
-const filteredLaws = computed(() => {
-  const q = search.value.toLowerCase();
-  if (!q) return props.laws;
-  return props.laws.filter(law =>
-    law.law_id.toLowerCase().includes(q) ||
-    displayName(law).toLowerCase().includes(q)
-  );
-});
+// Results of the server-side corpus search (`?q=`). The corpus index can
+// hold thousands of laws, so the popover queries the backend rather than
+// filtering a preloaded client-side list — that's the only way the search
+// can reach every law, not just the first page. Ordered private-repo-first
+// by the backend; `groupedLaws` sections them by source.
+const serverLaws = ref([]);
+// True while a corpus query is in flight, so the UI shows a spinner instead
+// of briefly flashing "no results" (which would wrongly trigger the external
+// fallback) before the response lands.
+const searching = ref(false);
 
 /**
- * Group the filtered laws by their providing source, ordered by source
+ * Group the matched laws by their providing source, ordered by source
  * priority (lower = higher priority, so the traject's own writable repo at
  * priority 0 sorts above the seeded central corpus) and then alphabetically.
  * The popover renders one labelled section per group so a search surfaces
  * matches from the private repo and the central corpus under their own
- * headers — the external wetten.overheid.nl fallback only kicks in when
- * every internal group is empty (see `filteredLaws.length === 0` below).
+ * headers — the external wetten.overheid.nl fallback only kicks in when the
+ * corpus has no match (see `serverLaws` handling below).
  */
 const groupedLaws = computed(() => {
   const groups = new Map();
-  for (const law of filteredLaws.value) {
+  for (const law of serverLaws.value) {
     let group = groups.get(law.source_id);
     if (!group) {
       group = {
@@ -89,12 +91,42 @@ const groupedLaws = computed(() => {
 
 const hasSearch = computed(() => search.value.length > 0);
 
-watch([search, filteredLaws], ([q, filtered]) => {
+// Debounce the corpus query so we don't fire a request per keystroke, and
+// guard against out-of-order responses with a sequence number.
+let searchSeq = 0;
+let debounceTimer = null;
+
+watch(search, (q) => {
   clearBwb();
-  if (!q || q.length < MIN_QUERY_LENGTH || filtered.length > 0) return;
-  if (needsLogin.value) return;
-  searchBwb(q);
+  if (debounceTimer) clearTimeout(debounceTimer);
+  const term = q.trim();
+  if (term.length < MIN_QUERY_LENGTH) {
+    serverLaws.value = [];
+    searching.value = false;
+    return;
+  }
+  searching.value = true;
+  debounceTimer = setTimeout(() => runCorpusSearch(term), 200);
 });
+
+async function runCorpusSearch(term) {
+  const seq = ++searchSeq;
+  try {
+    const url = lawsListUrl(activeTrajectRef.value, `q=${encodeURIComponent(term)}&limit=60`);
+    const res = await fetch(url);
+    if (seq !== searchSeq) return; // a newer query superseded this one
+    const laws = res.ok ? await res.json() : [];
+    if (seq !== searchSeq) return;
+    serverLaws.value = laws;
+    // No match anywhere in the corpus → offer the external wetten.overheid.nl
+    // search (unless the user must log in first to reach it).
+    if (laws.length === 0 && !needsLogin.value) searchBwb(term);
+  } catch {
+    if (seq === searchSeq) serverLaws.value = [];
+  } finally {
+    if (seq === searchSeq) searching.value = false;
+  }
+}
 
 function bwbItemClick(result) {
   if (needsLogin.value) {
@@ -233,14 +265,40 @@ defineExpose({ show });
 
       <template v-if="hasSearch">
         <nldd-spacer size="16"></nldd-spacer>
-        <div v-if="filteredLaws.length === 0 && needsLogin && search.length >= MIN_QUERY_LENGTH" class="search-popover-login-prompt">
+        <!-- Corpus query in flight: show a spinner instead of briefly
+             flashing "no results" and wrongly tripping the external fallback. -->
+        <nldd-inline-dialog v-if="searching" text="Zoeken in de wetten…"></nldd-inline-dialog>
+        <!-- Internal corpus matches: one labelled section per source, private
+             repo first (priority 0), then the central corpus. The source name
+             doubles as the group header, so the per-item supporting-text is
+             dropped to avoid repeating it on every row. -->
+        <template v-else-if="groupedLaws.length > 0">
+          <template v-for="(group, groupIndex) in groupedLaws" :key="group.source_id">
+            <nldd-spacer v-if="groupIndex > 0" size="16"></nldd-spacer>
+            <nldd-title size="5"><h5>{{ group.source_name }}</h5></nldd-title>
+            <nldd-spacer size="8"></nldd-spacer>
+            <nldd-list variant="simple">
+              <nldd-list-item
+                v-for="law in group.laws"
+                :key="law.law_id"
+                size="md"
+                type="button"
+                @click="selectLaw(law.law_id)"
+              >
+                <nldd-text-cell :text="displayName(law)"></nldd-text-cell>
+              </nldd-list-item>
+            </nldd-list>
+          </template>
+        </template>
+        <!-- No corpus match → log in / search wetten.overheid.nl / empty. -->
+        <div v-else-if="needsLogin && search.length >= MIN_QUERY_LENGTH" class="search-popover-login-prompt">
           <div class="search-popover-empty-title">Log in om externe bronnen te doorzoeken</div>
           <div class="search-popover-empty-subtitle">Inloggen is vereist om wetten op te halen van wetten.overheid.nl</div>
           <nldd-spacer size="12"></nldd-spacer>
           <nldd-button size="md" text="Inloggen" @click="login"></nldd-button>
         </div>
-        <nldd-inline-dialog v-else-if="filteredLaws.length === 0 && bwbLoading" text="Zoeken op wetten.overheid.nl..."></nldd-inline-dialog>
-        <template v-else-if="filteredLaws.length === 0 && bwbResults.length > 0">
+        <nldd-inline-dialog v-else-if="bwbLoading" text="Zoeken op wetten.overheid.nl..."></nldd-inline-dialog>
+        <template v-else-if="bwbResults.length > 0">
           <nldd-title size="5"><h5>Resultaten van wetten.overheid.nl</h5></nldd-title>
           <nldd-spacer size="8"></nldd-spacer>
           <nldd-list variant="simple">
@@ -266,34 +324,12 @@ defineExpose({ show });
             </nldd-list-item>
           </nldd-list>
         </template>
-        <template v-else-if="filteredLaws.length > 0 || search.length >= MIN_QUERY_LENGTH">
-          <!-- One labelled section per source, private repo first (priority
-               0), then the central corpus. The source name doubles as the
-               group header, so the per-item supporting-text is dropped to
-               avoid repeating it on every row. -->
-          <template v-for="(group, groupIndex) in groupedLaws" :key="group.source_id">
-            <nldd-spacer v-if="groupIndex > 0" size="16"></nldd-spacer>
-            <nldd-title size="5"><h5>{{ group.source_name }}</h5></nldd-title>
-            <nldd-spacer size="8"></nldd-spacer>
-            <nldd-list variant="simple">
-              <nldd-list-item
-                v-for="law in group.laws"
-                :key="law.law_id"
-                size="md"
-                type="button"
-                @click="selectLaw(law.law_id)"
-              >
-                <nldd-text-cell :text="displayName(law)"></nldd-text-cell>
-              </nldd-list-item>
-            </nldd-list>
-          </template>
-          <nldd-list
-            v-if="groupedLaws.length === 0"
-            variant="simple"
-            empty-text="Geen resultaten gevonden"
-            empty-supporting-text="Pas je zoektermen of voorkeuren aan"
-          ></nldd-list>
-        </template>
+        <nldd-list
+          v-else-if="search.length >= MIN_QUERY_LENGTH"
+          variant="simple"
+          empty-text="Geen resultaten gevonden"
+          empty-supporting-text="Pas je zoektermen of voorkeuren aan"
+        ></nldd-list>
       </template>
     </nldd-container>
   </nldd-popover>

--- a/frontend/src/components/SearchPopover.vue
+++ b/frontend/src/components/SearchPopover.vue
@@ -58,6 +58,35 @@ const filteredLaws = computed(() => {
   );
 });
 
+/**
+ * Group the filtered laws by their providing source, ordered by source
+ * priority (lower = higher priority, so the traject's own writable repo at
+ * priority 0 sorts above the seeded central corpus) and then alphabetically.
+ * The popover renders one labelled section per group so a search surfaces
+ * matches from the private repo and the central corpus under their own
+ * headers — the external wetten.overheid.nl fallback only kicks in when
+ * every internal group is empty (see `filteredLaws.length === 0` below).
+ */
+const groupedLaws = computed(() => {
+  const groups = new Map();
+  for (const law of filteredLaws.value) {
+    let group = groups.get(law.source_id);
+    if (!group) {
+      group = {
+        source_id: law.source_id,
+        source_name: law.source_name || '',
+        priority: law.source_priority ?? Number.MAX_SAFE_INTEGER,
+        laws: [],
+      };
+      groups.set(law.source_id, group);
+    }
+    group.laws.push(law);
+  }
+  return [...groups.values()].sort(
+    (a, b) => a.priority - b.priority || a.source_name.localeCompare(b.source_name),
+  );
+});
+
 const hasSearch = computed(() => search.value.length > 0);
 
 watch([search, filteredLaws], ([q, filtered]) => {
@@ -237,23 +266,34 @@ defineExpose({ show });
             </nldd-list-item>
           </nldd-list>
         </template>
-        <nldd-list
-          v-else-if="filteredLaws.length > 0 || search.length >= MIN_QUERY_LENGTH"
-          variant="simple"
-          empty-text="Geen resultaten gevonden"
-          empty-supporting-text="Pas je zoektermen of voorkeuren aan"
-        >
-          <nldd-list-item
-            v-for="law in filteredLaws"
-            :key="law.law_id"
-            size="md"
-            type="button"
-            @click="selectLaw(law.law_id)"
-          >
-            <nldd-text-cell :text="displayName(law)" :supporting-text="law.source_name">
-            </nldd-text-cell>
-          </nldd-list-item>
-        </nldd-list>
+        <template v-else-if="filteredLaws.length > 0 || search.length >= MIN_QUERY_LENGTH">
+          <!-- One labelled section per source, private repo first (priority
+               0), then the central corpus. The source name doubles as the
+               group header, so the per-item supporting-text is dropped to
+               avoid repeating it on every row. -->
+          <template v-for="(group, groupIndex) in groupedLaws" :key="group.source_id">
+            <nldd-spacer v-if="groupIndex > 0" size="16"></nldd-spacer>
+            <nldd-title size="5"><h5>{{ group.source_name }}</h5></nldd-title>
+            <nldd-spacer size="8"></nldd-spacer>
+            <nldd-list variant="simple">
+              <nldd-list-item
+                v-for="law in group.laws"
+                :key="law.law_id"
+                size="md"
+                type="button"
+                @click="selectLaw(law.law_id)"
+              >
+                <nldd-text-cell :text="displayName(law)"></nldd-text-cell>
+              </nldd-list-item>
+            </nldd-list>
+          </template>
+          <nldd-list
+            v-if="groupedLaws.length === 0"
+            variant="simple"
+            empty-text="Geen resultaten gevonden"
+            empty-supporting-text="Pas je zoektermen of voorkeuren aan"
+          ></nldd-list>
+        </template>
       </template>
     </nldd-container>
   </nldd-popover>

--- a/packages/corpus/src/dto.rs
+++ b/packages/corpus/src/dto.rs
@@ -34,6 +34,9 @@ pub struct PaginationParams {
     /// those laws are returned — so the library sidebar can resolve metadata
     /// for just the user's favorites and traject edits instead of fetching the
     /// whole corpus and filtering client-side.
+    ///
+    /// Takes precedence over [`q`](Self::q): if both are sent, `ids` wins and
+    /// `q` is ignored (they're not combined). Callers pick one or the other.
     #[serde(default)]
     pub ids: Option<String>,
 }

--- a/packages/corpus/src/dto.rs
+++ b/packages/corpus/src/dto.rs
@@ -24,6 +24,12 @@ pub struct PaginationParams {
     pub offset: usize,
     #[serde(default)]
     pub limit: Option<usize>,
+    /// Optional case-insensitive search term. When present, the law list is
+    /// filtered server-side to laws whose `law_id` or name contains it —
+    /// letting the editor search the full corpus index without shipping every
+    /// law to the browser.
+    #[serde(default)]
+    pub q: Option<String>,
 }
 
 impl PaginationParams {

--- a/packages/corpus/src/dto.rs
+++ b/packages/corpus/src/dto.rs
@@ -30,6 +30,12 @@ pub struct PaginationParams {
     /// law to the browser.
     #[serde(default)]
     pub q: Option<String>,
+    /// Optional comma-separated set of exact `law_id`s. When present, only
+    /// those laws are returned — so the library sidebar can resolve metadata
+    /// for just the user's favorites and traject edits instead of fetching the
+    /// whole corpus and filtering client-side.
+    #[serde(default)]
+    pub ids: Option<String>,
 }
 
 impl PaginationParams {

--- a/packages/corpus/src/github.rs
+++ b/packages/corpus/src/github.rs
@@ -248,55 +248,7 @@ mod inner {
                 None => return Ok(FetchResult::NotModified),
             };
 
-            // Group paths by law_id, keeping only those in the filter set.
-            // Path format: {base_path}/{layer}/{law_id}/{date}.yaml
-            let prefix = if base_path.is_empty() {
-                String::new()
-            } else {
-                format!("{}/", base_path)
-            };
-
-            let today = crate::source_map::today_str();
-            let mut best_per_law: HashMap<String, String> = HashMap::new();
-
-            for path in &all_paths {
-                let rel = if prefix.is_empty() {
-                    path.as_str()
-                } else {
-                    match path.strip_prefix(&prefix) {
-                        Some(r) => r,
-                        None => continue,
-                    }
-                };
-
-                let parts: Vec<&str> = rel.split('/').collect();
-                if parts.len() < 3 {
-                    continue;
-                }
-
-                let law_id = parts[parts.len() - 2];
-                if !law_ids.contains(law_id) {
-                    continue;
-                }
-
-                // Extract date from filename (YYYY-MM-DD.yaml)
-                let filename = parts[parts.len() - 1];
-                let new_date = filename.strip_suffix(".yaml");
-
-                if let Some(existing_path) = best_per_law.get(law_id) {
-                    let existing_filename = existing_path.rsplit('/').next().unwrap_or("");
-                    let existing_date = existing_filename.strip_suffix(".yaml");
-
-                    let new_wins =
-                        crate::source_map::pick_best_version(existing_date, new_date, &today);
-
-                    if new_wins {
-                        best_per_law.insert(law_id.to_string(), path.clone());
-                    }
-                } else {
-                    best_per_law.insert(law_id.to_string(), path.clone());
-                }
-            }
+            let best_per_law = Self::group_best_versions(&all_paths, base_path, Some(law_ids));
 
             tracing::info!(
                 matched = best_per_law.len(),
@@ -323,6 +275,96 @@ mod inner {
             }
 
             Ok(FetchResult::Fetched(files))
+        }
+
+        /// Enumerate every law in a source via the Trees API (1 call),
+        /// selecting the best version per law — WITHOUT fetching any file
+        /// content. Returns `(law_id, repo_path)` pairs. This is the cheap
+        /// enumeration the lightweight corpus index is built from: opening a
+        /// law fetches just that one file lazily via the backend.
+        pub async fn list_source_law_paths(
+            &mut self,
+            source: &GitHubSource,
+            token: Option<&str>,
+        ) -> Result<Vec<(String, String)>> {
+            let base_path = source.path.as_deref().unwrap_or("");
+            let all_paths = match self
+                .list_yaml_files(
+                    &source.full_repo(),
+                    source.effective_ref(),
+                    base_path,
+                    token,
+                )
+                .await?
+            {
+                Some(paths) => paths,
+                None => return Ok(Vec::new()),
+            };
+            Ok(Self::group_best_versions(&all_paths, base_path, None)
+                .into_iter()
+                .collect())
+        }
+
+        /// Group repo-relative YAML paths by `law_id` (the directory name),
+        /// keeping the best version per law (closest valid date ≤ today, else
+        /// latest). `filter`, when set, restricts to those law_ids. Path
+        /// format: `{base_path}/{layer}/{law_id}/{date}.yaml`. Returns a map
+        /// of `law_id → repo_path`.
+        fn group_best_versions(
+            all_paths: &[String],
+            base_path: &str,
+            filter: Option<&HashSet<String>>,
+        ) -> HashMap<String, String> {
+            let prefix = if base_path.is_empty() {
+                String::new()
+            } else {
+                format!("{}/", base_path)
+            };
+            let today = crate::source_map::today_str();
+            let mut best_per_law: HashMap<String, String> = HashMap::new();
+
+            for path in all_paths {
+                let rel = if prefix.is_empty() {
+                    path.as_str()
+                } else {
+                    match path.strip_prefix(&prefix) {
+                        Some(r) => r,
+                        None => continue,
+                    }
+                };
+
+                let parts: Vec<&str> = rel.split('/').collect();
+                if parts.len() < 3 {
+                    continue;
+                }
+
+                let law_id = parts[parts.len() - 2];
+                if let Some(f) = filter {
+                    if !f.contains(law_id) {
+                        continue;
+                    }
+                }
+
+                // Extract date from filename (YYYY-MM-DD.yaml)
+                let filename = parts[parts.len() - 1];
+                let new_date = filename.strip_suffix(".yaml");
+
+                if let Some(existing_path) = best_per_law.get(law_id) {
+                    let existing_filename = existing_path.rsplit('/').next().unwrap_or("");
+                    let existing_date = existing_filename.strip_suffix(".yaml");
+
+                    let new_wins =
+                        crate::source_map::pick_best_version(existing_date, new_date, &today);
+
+                    if new_wins {
+                        best_per_law.insert(law_id.to_string(), path.clone());
+                    }
+                } else {
+                    best_per_law.insert(law_id.to_string(), path.clone());
+                }
+            }
+
+            best_per_law
         }
 
         /// List all YAML files in a repo path using the Trees API.

--- a/packages/corpus/src/registry.rs
+++ b/packages/corpus/src/registry.rs
@@ -213,6 +213,10 @@ impl CorpusRegistry {
     /// Load all sources (local + GitHub) into a SourceMap.
     ///
     /// Fetches GitHub sources using the provided auth file for token lookup.
+    /// Returns the populated map together with the ids of any sources that
+    /// failed to load. A single source failing is non-fatal (it's logged and
+    /// skipped), but the failed-id list lets callers escalate when a source
+    /// they care about — e.g. a traject's writable-own repo — is among them.
     ///
     /// **Note:** A fresh `GitHubFetcher` is created on each call, so the
     /// `NotModified` branch is currently unreachable (no prior ETag exists).
@@ -220,49 +224,99 @@ impl CorpusRegistry {
     /// sources are merged from a previous `SourceMap` instead of silently
     /// dropped.
     #[cfg(feature = "github")]
-    pub async fn load_all_sources_async(&self, auth_file: Option<&Path>) -> Result<SourceMap> {
+    pub async fn load_all_sources_async(
+        &self,
+        auth_file: Option<&Path>,
+    ) -> Result<(SourceMap, Vec<String>)> {
         let mut map = SourceMap::new();
         let mut fetcher = crate::github::GitHubFetcher::new()?;
+        let mut failed: Vec<String> = Vec::new();
 
         for source in &self.sources {
-            match &source.source_type {
-                SourceType::Local { .. } => {
-                    map.load_source(source)?;
-                }
-                SourceType::GitHub { github } => {
-                    let token = crate::auth::resolve_token_for_source(
-                        &source.id,
-                        source.auth_ref.as_deref(),
-                        auth_file,
-                    )?;
-                    match fetcher.fetch_source(github, token.as_deref()).await? {
-                        crate::github::FetchResult::Fetched(files) => {
-                            for file in &files {
-                                map.load_fetched_file(
-                                    &file.content,
-                                    &file.path,
-                                    github.path.as_deref(),
-                                    &source.id,
-                                    &source.name,
-                                    source.priority,
-                                )?;
-                            }
+            // A single source failing — a missing per-repo token, a
+            // writable-own branch that hasn't been created yet, a transient
+            // GitHub error — must NOT wipe the whole corpus. Log it, record
+            // the id, and move on so the remaining sources still populate the
+            // map.
+            if let Err(e) = Self::load_one_source(&mut map, &mut fetcher, source, auth_file).await {
+                tracing::warn!(
+                    source_id = %source.id,
+                    error = %e,
+                    "failed to load corpus source, skipping"
+                );
+                failed.push(source.id.clone());
+            }
+        }
+
+        if !failed.is_empty() {
+            tracing::warn!(
+                failed = ?failed,
+                loaded = map.len(),
+                "some corpus sources failed to load"
+            );
+        }
+
+        // Validate scopes for parity with `load_local_sources` and
+        // `load_favorites_async`, which both surface scope warnings.
+        for w in crate::validation::validate_scopes(&map, &self.sources) {
+            tracing::warn!(
+                law_id = %w.law_id,
+                source_id = %w.source_id,
+                "{}",
+                w.message
+            );
+        }
+
+        Ok((map, failed))
+    }
+
+    /// Load a single source into `map`. Factored out of
+    /// [`load_all_sources_async`] so one source's failure can be caught and
+    /// skipped without aborting the whole load.
+    #[cfg(feature = "github")]
+    async fn load_one_source(
+        map: &mut SourceMap,
+        fetcher: &mut crate::github::GitHubFetcher,
+        source: &Source,
+        auth_file: Option<&Path>,
+    ) -> Result<()> {
+        match &source.source_type {
+            SourceType::Local { .. } => {
+                map.load_source(source)?;
+            }
+            SourceType::GitHub { github } => {
+                let token = crate::auth::resolve_token_for_source(
+                    &source.id,
+                    source.auth_ref.as_deref(),
+                    auth_file,
+                )?;
+                match fetcher.fetch_source(github, token.as_deref()).await? {
+                    crate::github::FetchResult::Fetched(files) => {
+                        for file in &files {
+                            map.load_fetched_file(
+                                &file.content,
+                                &file.path,
+                                github.path.as_deref(),
+                                &source.id,
+                                &source.name,
+                                source.priority,
+                            )?;
                         }
-                        crate::github::FetchResult::NotModified => {
-                            // INVARIANT: currently unreachable because GitHubFetcher
-                            // is created fresh (no prior ETag). When ETag persistence
-                            // is added, this branch must merge laws from the previous
-                            // SourceMap — otherwise unchanged sources lose their laws.
-                            tracing::debug!(
-                                source_id = %source.id,
-                                "GitHub source unchanged, skipping"
-                            );
-                        }
+                    }
+                    crate::github::FetchResult::NotModified => {
+                        // INVARIANT: currently unreachable because GitHubFetcher
+                        // is created fresh (no prior ETag). When ETag persistence
+                        // is added, this branch must merge laws from the previous
+                        // SourceMap — otherwise unchanged sources lose their laws.
+                        tracing::debug!(
+                            source_id = %source.id,
+                            "GitHub source unchanged, skipping"
+                        );
                     }
                 }
             }
         }
-        Ok(map)
+        Ok(())
     }
 }
 

--- a/packages/corpus/src/registry.rs
+++ b/packages/corpus/src/registry.rs
@@ -106,7 +106,8 @@ impl CorpusRegistry {
 
     /// Load all local sources into a SourceMap.
     ///
-    /// GitHub sources are skipped — use [`load_all_sources_async`] to include them.
+    /// GitHub sources are skipped — use [`index_all_sources_async`] or
+    /// [`load_favorites_async`] to include them.
     pub fn load_local_sources(&self) -> Result<SourceMap> {
         let mut map = SourceMap::new();
         for source in &self.sources {
@@ -210,21 +211,23 @@ impl CorpusRegistry {
         Ok(map)
     }
 
-    /// Load all sources (local + GitHub) into a SourceMap.
+    /// Build a lightweight **index** of every law across all sources without
+    /// fetching law bodies. Local sources are loaded eagerly (disk is cheap
+    /// and gives real names); GitHub sources are enumerated via the Trees API
+    /// (1 call per source) into metadata-only entries — `law_id`, source, and
+    /// `relative_path`, but no content. Bodies are fetched lazily on first
+    /// read via the source's backend.
     ///
-    /// Fetches GitHub sources using the provided auth file for token lookup.
-    /// Returns the populated map together with the ids of any sources that
-    /// failed to load. A single source failing is non-fatal (it's logged and
-    /// skipped), but the failed-id list lets callers escalate when a source
-    /// they care about — e.g. a traject's writable-own repo — is among them.
+    /// This replaces the eager [`load_all_sources_async`] on the traject path:
+    /// loading every law's full YAML up front meant N per-file Contents API
+    /// calls per traject build, which is slow and trips GitHub's secondary
+    /// rate limit. The library/search only needs the index; content is only
+    /// needed when a specific law is opened.
     ///
-    /// **Note:** A fresh `GitHubFetcher` is created on each call, so the
-    /// `NotModified` branch is currently unreachable (no prior ETag exists).
-    /// If caching is added later, callers must ensure that `NotModified`
-    /// sources are merged from a previous `SourceMap` instead of silently
-    /// dropped.
+    /// Returns the index plus the ids of any sources that failed to enumerate
+    /// (non-fatal, mirroring [`load_all_sources_async`]).
     #[cfg(feature = "github")]
-    pub async fn load_all_sources_async(
+    pub async fn index_all_sources_async(
         &self,
         auth_file: Option<&Path>,
     ) -> Result<(SourceMap, Vec<String>)> {
@@ -233,16 +236,12 @@ impl CorpusRegistry {
         let mut failed: Vec<String> = Vec::new();
 
         for source in &self.sources {
-            // A single source failing — a missing per-repo token, a
-            // writable-own branch that hasn't been created yet, a transient
-            // GitHub error — must NOT wipe the whole corpus. Log it, record
-            // the id, and move on so the remaining sources still populate the
-            // map.
-            if let Err(e) = Self::load_one_source(&mut map, &mut fetcher, source, auth_file).await {
+            if let Err(e) = Self::index_one_source(&mut map, &mut fetcher, source, auth_file).await
+            {
                 tracing::warn!(
                     source_id = %source.id,
                     error = %e,
-                    "failed to load corpus source, skipping"
+                    "failed to index corpus source, skipping"
                 );
                 failed.push(source.id.clone());
             }
@@ -251,13 +250,11 @@ impl CorpusRegistry {
         if !failed.is_empty() {
             tracing::warn!(
                 failed = ?failed,
-                loaded = map.len(),
-                "some corpus sources failed to load"
+                indexed = map.len(),
+                "some corpus sources failed to index"
             );
         }
 
-        // Validate scopes for parity with `load_local_sources` and
-        // `load_favorites_async`, which both surface scope warnings.
         for w in crate::validation::validate_scopes(&map, &self.sources) {
             tracing::warn!(
                 law_id = %w.law_id,
@@ -270,11 +267,11 @@ impl CorpusRegistry {
         Ok((map, failed))
     }
 
-    /// Load a single source into `map`. Factored out of
-    /// [`load_all_sources_async`] so one source's failure can be caught and
-    /// skipped without aborting the whole load.
+    /// Index a single source: load local content eagerly, but enumerate a
+    /// GitHub source's laws by path only (no body fetch). Factored out so one
+    /// source's failure is skipped, not fatal.
     #[cfg(feature = "github")]
-    async fn load_one_source(
+    async fn index_one_source(
         map: &mut SourceMap,
         fetcher: &mut crate::github::GitHubFetcher,
         source: &Source,
@@ -290,29 +287,18 @@ impl CorpusRegistry {
                     source.auth_ref.as_deref(),
                     auth_file,
                 )?;
-                match fetcher.fetch_source(github, token.as_deref()).await? {
-                    crate::github::FetchResult::Fetched(files) => {
-                        for file in &files {
-                            map.load_fetched_file(
-                                &file.content,
-                                &file.path,
-                                github.path.as_deref(),
-                                &source.id,
-                                &source.name,
-                                source.priority,
-                            )?;
-                        }
-                    }
-                    crate::github::FetchResult::NotModified => {
-                        // INVARIANT: currently unreachable because GitHubFetcher
-                        // is created fresh (no prior ETag). When ETag persistence
-                        // is added, this branch must merge laws from the previous
-                        // SourceMap — otherwise unchanged sources lose their laws.
-                        tracing::debug!(
-                            source_id = %source.id,
-                            "GitHub source unchanged, skipping"
-                        );
-                    }
+                for (law_id, path) in fetcher
+                    .list_source_law_paths(github, token.as_deref())
+                    .await?
+                {
+                    map.load_metadata_entry(
+                        &law_id,
+                        &path,
+                        github.path.as_deref(),
+                        &source.id,
+                        &source.name,
+                        source.priority,
+                    )?;
                 }
             }
         }

--- a/packages/corpus/src/source_map.rs
+++ b/packages/corpus/src/source_map.rs
@@ -35,6 +35,15 @@ pub struct LoadedLaw {
     pub source_priority: u32,
 }
 
+impl LoadedLaw {
+    /// Whether this law's body has been fetched. Metadata-only index entries
+    /// (from path enumeration) carry an empty `yaml_content` until the law is
+    /// opened and its content lazily fetched.
+    pub fn is_loaded(&self) -> bool {
+        !self.yaml_content.is_empty()
+    }
+}
+
 /// Aggregates laws from multiple sources with priority-based conflict resolution.
 ///
 /// When multiple sources provide a law with the same `$id`, the source with the
@@ -275,6 +284,47 @@ impl SourceMap {
 
         self.insert(loaded)?;
         Ok(true)
+    }
+
+    /// Insert a metadata-only entry for a law discovered by path enumeration,
+    /// without fetching its content. `yaml_content` is left empty as the
+    /// "not yet loaded" sentinel — callers lazily fetch the body on first read
+    /// via the source's backend, using the `relative_path` stored here.
+    ///
+    /// `law_id` comes from the directory name (the corpus convention is
+    /// `{base}/{layer}/{law_id}/{date}.yaml`, and the directory name equals
+    /// the law's `$id`). `file_path` is the in-repo path; `source_subpath` is
+    /// stripped to produce the source-root-relative path the backend reads.
+    pub fn load_metadata_entry(
+        &mut self,
+        law_id: &str,
+        file_path: &str,
+        source_subpath: Option<&str>,
+        source_id: &str,
+        source_name: &str,
+        source_priority: u32,
+    ) -> Result<()> {
+        let relative_path = match source_subpath {
+            Some(sub) if !sub.is_empty() => {
+                let trimmed = sub.trim_end_matches('/');
+                file_path
+                    .strip_prefix(&format!("{trimmed}/"))
+                    .unwrap_or(file_path)
+                    .to_string()
+            }
+            _ => file_path.to_string(),
+        };
+
+        self.insert(LoadedLaw {
+            law_id: law_id.to_string(),
+            name: None,
+            yaml_content: String::new(),
+            file_path: file_path.to_string(),
+            relative_path,
+            source_id: source_id.to_string(),
+            source_name: source_name.to_string(),
+            source_priority,
+        })
     }
 
     /// Get all loaded laws.
@@ -772,6 +822,34 @@ mod tests {
         let law = map.get_law("test_wet").unwrap();
         assert_eq!(law.source_id, "central");
         assert_eq!(law.source_priority, 1);
+        assert!(law.is_loaded(), "a content-loaded law reports loaded");
+    }
+
+    #[test]
+    fn test_metadata_entry_is_unloaded_with_stripped_path() {
+        let mut map = SourceMap::new();
+        // `file_path` is the in-repo path; the source is rooted at
+        // `regulation/nl`, so the stored relative_path drops that prefix.
+        map.load_metadata_entry(
+            "besluit_zorgverzekering_bes",
+            "regulation/nl/amvb/besluit_zorgverzekering_bes/2024-01-01.yaml",
+            Some("regulation/nl"),
+            "traject-own-abc",
+            "MinBZK/regelrecht-corpus-BES",
+            0,
+        )
+        .unwrap();
+
+        let law = map.get_law("besluit_zorgverzekering_bes").unwrap();
+        assert!(!law.is_loaded(), "metadata-only entry has no body yet");
+        assert_eq!(law.yaml_content, "");
+        assert_eq!(law.name, None);
+        assert_eq!(
+            law.relative_path,
+            "amvb/besluit_zorgverzekering_bes/2024-01-01.yaml"
+        );
+        assert_eq!(law.source_id, "traject-own-abc");
+        assert_eq!(law.source_priority, 0);
     }
 
     #[test]

--- a/packages/corpus/src/source_map.rs
+++ b/packages/corpus/src/source_map.rs
@@ -39,6 +39,13 @@ impl LoadedLaw {
     /// Whether this law's body has been fetched. Metadata-only index entries
     /// (from path enumeration) carry an empty `yaml_content` until the law is
     /// opened and its content lazily fetched.
+    ///
+    /// Empty `yaml_content` is a safe "not yet fetched" sentinel only because a
+    /// corpus YAML file is never legitimately empty — it always carries at
+    /// least a `$id`. A genuinely-empty file would report `false` here and be
+    /// re-fetched on each open until the read-your-writes overlay caches it
+    /// (one extra read per pod, then the overlay short-circuits — see
+    /// `TrajectCorpus::law_yaml`), so the contract is "non-empty == loaded".
     pub fn is_loaded(&self) -> bool {
         !self.yaml_content.is_empty()
     }

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -196,6 +196,21 @@ fn list_corpus_laws_in_scope(scope: &ReadScope, params: PaginationParams) -> Vec
     let corpus = scope.corpus();
     let limit = params.effective_limit();
 
+    // Exact-id filter (highest precedence). The library sidebar sends the
+    // user's favorites + traject edits as `?ids=a,b,c` so it resolves metadata
+    // for just those laws — it never has to load the whole corpus and filter
+    // client-side, and a favorite that sorts past any page cap still resolves.
+    let id_filter: Option<std::collections::HashSet<&str>> = params
+        .ids
+        .as_deref()
+        .map(|s| {
+            s.split(',')
+                .map(str::trim)
+                .filter(|x| !x.is_empty())
+                .collect()
+        })
+        .filter(|s: &std::collections::HashSet<&str>| !s.is_empty());
+
     // Optional server-side search. The corpus index can hold thousands of
     // laws, so the editor sends `?q=` and we filter here rather than shipping
     // every law to the browser to filter client-side. Underscores in the
@@ -210,14 +225,19 @@ fn list_corpus_laws_in_scope(scope: &ReadScope, params: PaginationParams) -> Vec
     let mut entries: Vec<CorpusLawEntry> = corpus
         .source_map
         .laws()
-        .filter(|law| match &needle {
-            None => true,
-            Some(n) => {
-                law.law_id.replace('_', " ").to_lowercase().contains(n)
-                    || law
-                        .name
-                        .as_deref()
-                        .is_some_and(|name| name.to_lowercase().contains(n))
+        .filter(|law| {
+            if let Some(ids) = &id_filter {
+                return ids.contains(law.law_id.as_str());
+            }
+            match &needle {
+                None => true,
+                Some(n) => {
+                    law.law_id.replace('_', " ").to_lowercase().contains(n)
+                        || law
+                            .name
+                            .as_deref()
+                            .is_some_and(|name| name.to_lowercase().contains(n))
+                }
             }
         })
         .map(|law| {
@@ -233,11 +253,11 @@ fn list_corpus_laws_in_scope(scope: &ReadScope, params: PaginationParams) -> Vec
         })
         .collect();
 
-    if needle.is_some() {
-        // Search mode: order so the grouped UI gets the highest-priority
-        // sources first (the traject's own repo before the central corpus),
-        // and the result cap can't starve a high-priority source. No offset
-        // paging — search returns the top matches.
+    if id_filter.is_some() || needle.is_some() {
+        // Filtered (by ids or search): order so the grouped UI gets the
+        // highest-priority sources first (the traject's own repo before the
+        // central corpus), and the result cap can't starve a high-priority
+        // source. No offset paging — return the matching set.
         entries.sort_by(|a, b| {
             a.source_priority
                 .cmp(&b.source_priority)

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -196,9 +196,30 @@ fn list_corpus_laws_in_scope(scope: &ReadScope, params: PaginationParams) -> Vec
     let corpus = scope.corpus();
     let limit = params.effective_limit();
 
+    // Optional server-side search. The corpus index can hold thousands of
+    // laws, so the editor sends `?q=` and we filter here rather than shipping
+    // every law to the browser to filter client-side. Underscores in the
+    // `law_id` are treated as spaces so "wet op de zorgtoeslag" matches
+    // `wet_op_de_zorgtoeslag`; loaded laws also match on their `name`.
+    let needle = params
+        .q
+        .as_deref()
+        .map(|s| s.trim().to_lowercase())
+        .filter(|s| !s.is_empty());
+
     let mut entries: Vec<CorpusLawEntry> = corpus
         .source_map
         .laws()
+        .filter(|law| match &needle {
+            None => true,
+            Some(n) => {
+                law.law_id.replace('_', " ").to_lowercase().contains(n)
+                    || law
+                        .name
+                        .as_deref()
+                        .is_some_and(|name| name.to_lowercase().contains(n))
+            }
+        })
         .map(|law| {
             let display_name = resolve_display_name(&law.yaml_content);
             CorpusLawEntry {
@@ -212,13 +233,25 @@ fn list_corpus_laws_in_scope(scope: &ReadScope, params: PaginationParams) -> Vec
         })
         .collect();
 
-    entries.sort_by(|a, b| a.law_id.cmp(&b.law_id));
-
-    entries
-        .into_iter()
-        .skip(params.offset)
-        .take(limit)
-        .collect()
+    if needle.is_some() {
+        // Search mode: order so the grouped UI gets the highest-priority
+        // sources first (the traject's own repo before the central corpus),
+        // and the result cap can't starve a high-priority source. No offset
+        // paging — search returns the top matches.
+        entries.sort_by(|a, b| {
+            a.source_priority
+                .cmp(&b.source_priority)
+                .then_with(|| a.law_id.cmp(&b.law_id))
+        });
+        entries.into_iter().take(limit).collect()
+    } else {
+        entries.sort_by(|a, b| a.law_id.cmp(&b.law_id));
+        entries
+            .into_iter()
+            .skip(params.offset)
+            .take(limit)
+            .collect()
+    }
 }
 
 /// GET /api/trajects/{traject_ref}/corpus/changed-laws — law ids that have

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -112,12 +112,36 @@ impl ReadScope {
     /// takes precedence over the source_map snapshot, so a save +
     /// re-open in the same traject returns the new content without a
     /// full source_map rebuild.
-    async fn law_yaml(&self, law_id: &str) -> Option<String> {
+    async fn law_yaml(
+        &self,
+        law_id: &str,
+    ) -> Result<Option<String>, regelrecht_corpus::error::CorpusError> {
         match self {
             ReadScope::Traject(t) => t.law_yaml(law_id).await,
-            ReadScope::Global(g) => g.source_map.get_law(law_id).map(|l| l.yaml_content.clone()),
+            // The global corpus is fully loaded up front, so there's no lazy
+            // fetch that could fail — a miss is always a genuine miss.
+            ReadScope::Global(g) => {
+                Ok(g.source_map.get_law(law_id).map(|l| l.yaml_content.clone()))
+            }
         }
     }
+}
+
+/// Read a law's YAML within a scope, mapping the outcome to an HTTP error:
+/// a backend failure (lazy fetch threw) becomes 502 "failed to load" so it's
+/// distinguishable from a genuine 404 miss; the error is logged for operators.
+async fn read_law_yaml(scope: &ReadScope, law_id: &str) -> Result<String, (StatusCode, String)> {
+    scope
+        .law_yaml(law_id)
+        .await
+        .map_err(|e| {
+            tracing::warn!(law_id = %law_id, error = %e, "failed to load law body");
+            (
+                StatusCode::BAD_GATEWAY,
+                format!("Kon wet '{law_id}' niet laden"),
+            )
+        })?
+        .ok_or_else(|| (StatusCode::NOT_FOUND, format!("Law '{law_id}' not found")))
 }
 
 /// Global read scope: no traject, no overlay. Used by every public
@@ -334,10 +358,7 @@ async fn get_corpus_law_in_scope(
     scope: &ReadScope,
     law_id: &str,
 ) -> Result<YamlResponse, (StatusCode, String)> {
-    let yaml = scope
-        .law_yaml(law_id)
-        .await
-        .ok_or_else(|| (StatusCode::NOT_FOUND, format!("Law '{}' not found", law_id)))?;
+    let yaml = read_law_yaml(scope, law_id).await?;
     Ok((
         StatusCode::OK,
         [(axum::http::header::CONTENT_TYPE, "text/yaml; charset=utf-8")],
@@ -369,10 +390,7 @@ async fn list_law_outputs_in_scope(
     scope: &ReadScope,
     law_id: &str,
 ) -> Result<Json<Vec<LawOutputEntry>>, (StatusCode, String)> {
-    let yaml = scope
-        .law_yaml(law_id)
-        .await
-        .ok_or_else(|| (StatusCode::NOT_FOUND, format!("Law '{}' not found", law_id)))?;
+    let yaml = read_law_yaml(scope, law_id).await?;
 
     let outputs: Vec<LawOutputEntry> = collect_law_outputs(&yaml)
         .into_iter()

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -62,6 +62,11 @@ pub struct CorpusLawEntry {
     pub display_name: Option<String>,
     pub source_id: String,
     pub source_name: String,
+    /// Priority of the providing source (lower = higher priority). The
+    /// search UI groups results by source and orders the groups by this
+    /// value, so the traject's own writable repo (priority 0) sorts above
+    /// the seeded central corpus.
+    pub source_priority: u32,
 }
 
 /// A parameter required by the execution block that declares an output.
@@ -202,6 +207,7 @@ fn list_corpus_laws_in_scope(scope: &ReadScope, params: PaginationParams) -> Vec
                 display_name,
                 source_id: law.source_id.clone(),
                 source_name: law.source_name.clone(),
+                source_priority: law.source_priority,
             }
         })
         .collect();
@@ -923,7 +929,7 @@ async fn require_traject_corpus_from_ref(
     };
     state
         .trajects
-        .get_or_build(pool, traject_id, auth_file, &state.favorites)
+        .get_or_build(pool, traject_id, auth_file)
         .await
         .map_err(traject_corpus_error)
 }

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -117,7 +117,6 @@ async fn main() {
         pipeline_api_url,
         reload_lock: Arc::new(tokio::sync::Mutex::new(())),
         trajects: Arc::new(traject_corpus::TrajectCorpusCache::new()),
-        favorites,
     };
 
     let index_file = PathBuf::from(&static_dir).join("index.html");

--- a/packages/editor-api/src/state.rs
+++ b/packages/editor-api/src/state.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -35,10 +35,6 @@ pub struct AppState {
     /// traject in the session, save handlers route through this cache
     /// instead of [`AppState::corpus`].
     pub trajects: Arc<TrajectCorpusCache>,
-    /// Favorites set used to limit which laws are loaded from GitHub
-    /// sources. Shared between the global corpus init and per-traject
-    /// corpus builds so trajects see the same law set.
-    pub favorites: Arc<HashSet<String>>,
 }
 
 impl OidcAppState for AppState {

--- a/packages/editor-api/src/traject_corpus.rs
+++ b/packages/editor-api/src/traject_corpus.rs
@@ -227,7 +227,6 @@ impl TrajectCorpusCache {
         pool: &PgPool,
         traject_id: Uuid,
         auth_file: Option<PathBuf>,
-        favorites: &std::collections::HashSet<String>,
     ) -> Result<Arc<TrajectCorpus>, TrajectCorpusError> {
         let cell = {
             let mut map = self.cells.write().await;
@@ -238,7 +237,7 @@ impl TrajectCorpusCache {
 
         let built = cell
             .get_or_try_init(|| async {
-                build_traject_corpus(pool, traject_id, auth_file.as_deref(), favorites).await
+                build_traject_corpus(pool, traject_id, auth_file.as_deref()).await
             })
             .await?;
         Ok(built.clone())
@@ -291,7 +290,6 @@ async fn build_traject_corpus(
     pool: &PgPool,
     traject_id: Uuid,
     auth_file: Option<&std::path::Path>,
-    favorites: &std::collections::HashSet<String>,
 ) -> Result<Arc<TrajectCorpus>, TrajectCorpusError> {
     let rows = sqlx::query_as::<_, TrajectSourceRow>(
         "SELECT source_id, name, source_type::text AS source_type,
@@ -456,16 +454,32 @@ async fn build_traject_corpus(
         }
     }
 
-    // Load laws from the same favorites set the global corpus uses, so the
-    // traject sees the same law set (minus any laws the traject's sources
-    // don't contain).
-    let source_map = match registry.load_favorites_async(favorites, auth_file).await {
-        Ok(map) => map,
+    // Load every law from all of the traject's sources — the private
+    // writable-own repo and the seeded central corpus — not just the
+    // favorites set. The bibliotheek search must be able to surface any law
+    // in the traject's corpus, so it needs the full set indexed. Per-source
+    // failures are tolerated inside `load_all_sources_async` (a bad seed
+    // source is skipped, not fatal), but a failure on the writable-own source
+    // is escalated below: its laws are the whole point of the traject, so a
+    // silent drop would reintroduce exactly the "my laws aren't searchable"
+    // bug this load path fixes.
+    let source_map = match registry.load_all_sources_async(auth_file).await {
+        Ok((map, failed)) => {
+            if failed.iter().any(|id| id == &writable_own_source_id) {
+                tracing::error!(
+                    traject = %traject_id,
+                    source_id = %writable_own_source_id,
+                    "traject writable-own source failed to load — the traject's own laws \
+                     will be missing from the bibliotheek until the corpus is rebuilt"
+                );
+            }
+            map
+        }
         Err(e) => {
             tracing::warn!(
                 traject = %traject_id,
                 error = %e,
-                "traject favorites load failed, falling back to local-only"
+                "traject corpus load failed, falling back to local-only"
             );
             registry
                 .load_local_sources()

--- a/packages/editor-api/src/traject_corpus.rs
+++ b/packages/editor-api/src/traject_corpus.rs
@@ -94,14 +94,34 @@ impl TrajectCorpus {
     /// Resolve the YAML content for a law in this traject, preferring the
     /// post-save overlay over the source_map snapshot built at traject
     /// activation time.
+    ///
+    /// The source_map is a lightweight **index** — for GitHub-backed sources
+    /// its entries carry only metadata (no body). When a metadata-only law is
+    /// read for the first time, its body is fetched lazily from the law's own
+    /// source backend (one Contents API call), rather than every law's content
+    /// being fetched up front at traject-activation time.
     pub async fn law_yaml(&self, law_id: &str) -> Option<String> {
         if let Some(text) = self.overlay.read().await.get(law_id) {
             return Some(text.clone());
         }
-        self.corpus
-            .source_map
-            .get_law(law_id)
-            .map(|l| l.yaml_content.clone())
+
+        // Pull the bits we need out of the index entry, then drop the borrow
+        // before the await below.
+        let (source_id, relative_path) = {
+            let law = self.corpus.source_map.get_law(law_id)?;
+            if law.is_loaded() {
+                return Some(law.yaml_content.clone());
+            }
+            (law.source_id.clone(), law.relative_path.clone())
+        };
+
+        let entry = self.corpus.backends.get(&source_id)?;
+        let backend = entry.backend.lock().await;
+        backend
+            .read_file(std::path::Path::new(&relative_path))
+            .await
+            .ok()
+            .flatten()
     }
 
     /// Mirror a freshly-saved law's content into the read-your-writes
@@ -454,16 +474,17 @@ async fn build_traject_corpus(
         }
     }
 
-    // Load every law from all of the traject's sources — the private
-    // writable-own repo and the seeded central corpus — not just the
-    // favorites set. The bibliotheek search must be able to surface any law
-    // in the traject's corpus, so it needs the full set indexed. Per-source
-    // failures are tolerated inside `load_all_sources_async` (a bad seed
-    // source is skipped, not fatal), but a failure on the writable-own source
-    // is escalated below: its laws are the whole point of the traject, so a
-    // silent drop would reintroduce exactly the "my laws aren't searchable"
-    // bug this load path fixes.
-    let source_map = match registry.load_all_sources_async(auth_file).await {
+    // Build a lightweight INDEX of every law across the traject's sources —
+    // the private writable-own repo and the seeded central corpus — so the
+    // bibliotheek search can surface any law without fetching every law's body
+    // up front (which meant N per-file GitHub Contents API calls per traject
+    // build — slow and rate-limited). Bodies are fetched lazily on first read
+    // (see `TrajectCorpus::law_yaml`). Per-source failures are tolerated
+    // inside `index_all_sources_async` (a bad seed source is skipped, not
+    // fatal), but a failure on the writable-own source is escalated below: its
+    // laws are the whole point of the traject, so a silent drop would
+    // reintroduce exactly the "my laws aren't searchable" bug this path fixes.
+    let source_map = match registry.index_all_sources_async(auth_file).await {
         Ok((map, failed)) => {
             if failed.iter().any(|id| id == &writable_own_source_id) {
                 tracing::error!(

--- a/packages/editor-api/src/traject_corpus.rs
+++ b/packages/editor-api/src/traject_corpus.rs
@@ -496,11 +496,15 @@ async fn build_traject_corpus(
     // bibliotheek search can surface any law without fetching every law's body
     // up front (which meant N per-file GitHub Contents API calls per traject
     // build — slow and rate-limited). Bodies are fetched lazily on first read
-    // (see `TrajectCorpus::law_yaml`). Per-source failures are tolerated
+    // (see `TrajectCorpus::law_yaml`). Per-source index failures are tolerated
     // inside `index_all_sources_async` (a bad seed source is skipped, not
-    // fatal), but a failure on the writable-own source is escalated below: its
-    // laws are the whole point of the traject, so a silent drop would
-    // reintroduce exactly the "my laws aren't searchable" bug this path fixes.
+    // fatal). A failure to enumerate the writable-own source is the one we care
+    // about most — its laws are the point of the traject — so it's logged at
+    // error level for operators. The traject still opens, though: it degrades
+    // (those laws missing from search until the next rebuild) rather than
+    // failing entirely on what is usually a transient GitHub hiccup. The hard
+    // failure path is the writable-own *backend* init above, which returns
+    // `Err` so a broken write target never opens silently.
     let source_map = match registry.index_all_sources_async(auth_file).await {
         Ok((map, failed)) => {
             if failed.iter().any(|id| id == &writable_own_source_id) {

--- a/packages/editor-api/src/traject_corpus.rs
+++ b/packages/editor-api/src/traject_corpus.rs
@@ -102,29 +102,47 @@ impl TrajectCorpus {
     /// read for the first time, its body is fetched lazily from the law's own
     /// source backend (one Contents API call), rather than every law's content
     /// being fetched up front at traject-activation time.
-    pub async fn law_yaml(&self, law_id: &str) -> Option<String> {
+    ///
+    /// `Ok(None)` is a genuine miss (the law isn't in this traject's corpus, or
+    /// its source's backend never initialised). A lazy-fetch failure (GitHub
+    /// throttling, token expiry, a network blip) is returned as `Err` so the
+    /// caller can answer "failed to load" instead of masking a transient error
+    /// as a 404 "not found".
+    pub async fn law_yaml(
+        &self,
+        law_id: &str,
+    ) -> Result<Option<String>, regelrecht_corpus::error::CorpusError> {
         if let Some(text) = self.overlay.read().await.get(law_id) {
-            return Some(text.clone());
+            return Ok(Some(text.clone()));
         }
 
         // Pull the bits we need out of the index entry, then drop the borrow
         // before the await below.
         let (source_id, relative_path) = {
-            let law = self.corpus.source_map.get_law(law_id)?;
+            let Some(law) = self.corpus.source_map.get_law(law_id) else {
+                return Ok(None);
+            };
             if law.is_loaded() {
-                return Some(law.yaml_content.clone());
+                return Ok(Some(law.yaml_content.clone()));
             }
             (law.source_id.clone(), law.relative_path.clone())
         };
 
+        // The source is indexed but its backend was skipped at build time
+        // (already logged then) — the law isn't readable. Treat as a miss.
+        let Some(entry) = self.corpus.backends.get(&source_id) else {
+            return Ok(None);
+        };
+
         let content = {
-            let entry = self.corpus.backends.get(&source_id)?;
             let backend = entry.backend.lock().await;
+            // `?` propagates a read error rather than collapsing it to None.
             backend
                 .read_file(std::path::Path::new(&relative_path))
-                .await
-                .ok()
-                .flatten()?
+                .await?
+        };
+        let Some(content) = content else {
+            return Ok(None);
         };
 
         // Cache the lazily-fetched body so re-reads of this unloaded law don't
@@ -138,7 +156,7 @@ impl TrajectCorpus {
             .write()
             .await
             .insert(law_id.to_string(), content.clone());
-        Some(content)
+        Ok(Some(content))
     }
 
     /// Mirror a freshly-saved law's content into the read-your-writes

--- a/packages/editor-api/src/traject_corpus.rs
+++ b/packages/editor-api/src/traject_corpus.rs
@@ -47,13 +47,15 @@ pub struct TrajectCorpus {
     /// endpoints) to address the traject's own branch directly without
     /// having to reverse-engineer it out of `write_target_for_source`.
     pub writable_own_source_id: String,
-    /// Read-your-writes overlay for law YAML content. After a successful
-    /// `save_law` we mirror the persisted body here so subsequent reads
-    /// in the same traject (any session, any user) see the new content
-    /// without forcing a full source_map rebuild against GitHub. The
-    /// overlay is content-only — `LoadedLaw` metadata
-    /// (source_id/relative_path) doesn't change with a content edit, so
-    /// backend resolution keeps using `corpus.source_map`.
+    /// Read-your-writes overlay + lazy-read cache for law YAML content. After
+    /// a successful `save_law` we mirror the persisted body here so subsequent
+    /// reads in the same traject (any session, any user) see the new content
+    /// without forcing a full source_map rebuild against GitHub. It also caches
+    /// bodies fetched lazily on first read (see `law_yaml`), so a re-read of an
+    /// unloaded law (read-only article view, reload, another tab) doesn't spend
+    /// another Contents API call. The overlay is content-only — `LoadedLaw`
+    /// metadata (source_id/relative_path) doesn't change with a content edit,
+    /// so backend resolution keeps using `corpus.source_map`.
     ///
     /// Unbounded growth is intentional: in practice the size is bounded
     /// by the number of distinct laws edited in this traject, with a
@@ -115,13 +117,28 @@ impl TrajectCorpus {
             (law.source_id.clone(), law.relative_path.clone())
         };
 
-        let entry = self.corpus.backends.get(&source_id)?;
-        let backend = entry.backend.lock().await;
-        backend
-            .read_file(std::path::Path::new(&relative_path))
+        let content = {
+            let entry = self.corpus.backends.get(&source_id)?;
+            let backend = entry.backend.lock().await;
+            backend
+                .read_file(std::path::Path::new(&relative_path))
+                .await
+                .ok()
+                .flatten()?
+        };
+
+        // Cache the lazily-fetched body so re-reads of this unloaded law don't
+        // each spend another Contents API call (read-only views, reloads, a
+        // second tab). Same staleness model as the post-save mirror: cleared
+        // when the traject's cache entry is invalidated. Also makes a
+        // genuinely-empty body a one-shot fetch rather than re-fetching every
+        // call (the empty-`yaml_content` "unloaded" sentinel can't tell them
+        // apart, but the overlay short-circuits before that check).
+        self.overlay
+            .write()
             .await
-            .ok()
-            .flatten()
+            .insert(law_id.to_string(), content.clone());
+        Some(content)
     }
 
     /// Mirror a freshly-saved law's content into the read-your-writes

--- a/packages/editor-api/tests/save_annotations_test.rs
+++ b/packages/editor-api/tests/save_annotations_test.rs
@@ -17,7 +17,6 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
-use std::collections::HashSet;
 use std::sync::Arc;
 
 use axum::extract::{Path, State};
@@ -59,7 +58,6 @@ fn empty_state(pool: PgPool) -> AppState {
         pipeline_api_url: None,
         reload_lock: Arc::new(Mutex::new(())),
         trajects: Arc::new(TrajectCorpusCache::new()),
-        favorites: Arc::new(HashSet::new()),
     }
 }
 

--- a/packages/editor-api/tests/traject_reads_test.rs
+++ b/packages/editor-api/tests/traject_reads_test.rs
@@ -9,7 +9,6 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
-use std::collections::HashSet;
 use std::sync::Arc;
 
 use axum::extract::{Path, State};
@@ -33,8 +32,6 @@ use regelrecht_pipeline::test_utils::TestDb;
 const LAW_ID: &str = "zorgtoeslagwet";
 
 fn empty_state(pool: PgPool) -> AppState {
-    let mut favorites = HashSet::new();
-    favorites.insert(LAW_ID.to_string());
     AppState {
         corpus: Arc::new(RwLock::new(CorpusState::empty())),
         oidc_client: None,
@@ -48,7 +45,6 @@ fn empty_state(pool: PgPool) -> AppState {
         pipeline_api_url: None,
         reload_lock: Arc::new(Mutex::new(())),
         trajects: Arc::new(TrajectCorpusCache::new()),
-        favorites: Arc::new(favorites),
     }
 }
 

--- a/packages/editor-api/tests/trajects_test.rs
+++ b/packages/editor-api/tests/trajects_test.rs
@@ -15,7 +15,6 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
-use std::collections::HashSet;
 use std::sync::Arc;
 
 use axum::extract::{Path, State};
@@ -57,7 +56,6 @@ fn empty_state(pool: PgPool) -> AppState {
         pipeline_api_url: None,
         reload_lock: Arc::new(Mutex::new(())),
         trajects: Arc::new(TrajectCorpusCache::new()),
-        favorites: Arc::new(HashSet::new()),
     }
 }
 


### PR DESCRIPTION
## What

The bibliotheek search box could only find the ~24 laws in a static favorites allowlist, because a traject loaded only those. Laws in a traject's **own private repo** (e.g. `MinBZK/regelrecht-corpus-BES`) or anywhere in the central corpus were unfindable. This makes the search reach **every** law across all of a traject's sources, grouped by source.

## How it works (final design)

The naive version (eagerly fetching every law's body) was too heavy — the central corpus is the full BWB corpus (thousands of laws), so per-file Contents API calls timed out and tripped GitHub's rate limit. Instead:

1. **Lazy index** — opening a traject enumerates every law via the **Trees API (1 call per source)**, building a metadata-only index (`law_id` from the directory name, source, path) with **no bodies fetched**. A law's YAML is fetched lazily on first open (`law_yaml` -> backend `read_file`, 1 call). Cold index build is about 2.6 s once per pod; warm reads are instant.
2. **Server-side search** — `/corpus/laws?q=<term>` filters the full index on the backend (matching `law_id`/name, underscores treated as spaces), orders by source priority (private repo first) then `law_id`, capped to the limit. The popover queries this (debounced, stale-response-guarded) instead of filtering a client-loaded page — so search reaches the whole corpus, not just the first 1000 rows.
3. **Grouped UI** — results render under one header per source, the traject's own repo (priority 0) first, then central. The wetten.overheid.nl (BWB) fallback fires only on a genuine corpus miss.

## Verified on the preview (pr746)

| Query | Result |
|---|---|
| `zorgverzekering` | BES group first (Besluit Zorgverzekering Bes, ...) then Centrale corpus — grouped, private on top |
| `bes` | BES (23) first, then Centrale (37) |
| `kieswet` | found (was invisible past the old client page cap) |
| `wegenverkeerswet` | found in Centrale — no false external fallback |
| `qzxqzx-not-a-law` | 0 internal -> wetten.overheid.nl fallback |

Index/search timing: ~2.6 s cold index build per pod, ~28 ms per query after.

## Notes

- UI uses only MinBZK design-system `nldd-*` components (`nldd-title`/`nldd-list`/`nldd-spacer`/`nldd-inline-dialog`). **No custom CSS.**
- Search list shows the humanized `law_id` until a law is opened (real names live in the body); fine for search-by-name.
- Three pre-existing editor-api integration test files are stale against the current trajects API (unrelated to this PR, not compiled by CI); only their reference to the removed `AppState.favorites` field was cleaned up.

## Tests
- Rust: build + clippy clean; corpus/editor unit tests green (incl. a new metadata-entry test).
- Frontend: vite build + `SearchPopover.test.js` (server-side query, grouping order, debounce).