### PR TITLE
feat(editor): curated library sidebar sections (favorites + edited-in-traject)

### DIFF
--- a/frontend/src/LibraryApp.vue
+++ b/frontend/src/LibraryApp.vue
@@ -14,7 +14,7 @@ import { lawFetchError } from './composables/useLaw.js';
 import { useFeatureFlags } from './composables/useFeatureFlags.js';
 import { useColorScheme } from './composables/useColorScheme.js';
 import { useTrajects } from './composables/useTrajects.js';
-import { lawsListUrl, lawUrl } from './composables/corpusUrls.js';
+import { lawsListUrl, lawUrl, changedLawsUrl } from './composables/corpusUrls.js';
 import { SUPPORT_EMAIL } from './constants.js';
 import { lastEditorPath, sectionTarget } from './composables/useLastVisitedRoute.js';
 
@@ -83,6 +83,9 @@ const editorTabHref = computed(() => router.resolve(editorTabTarget.value).href)
 
 const laws = ref([]);
 const favorites = ref(null);
+// Law ids edited in the active traject (branch-vs-base diff). `null` until
+// loaded / when no traject is active; a Set once the endpoint resolves.
+const changedLawIds = ref(null);
 const loading = ref(true);
 const indexError = ref(null);
 const searchPopoverRef = ref(null);
@@ -140,13 +143,41 @@ const detailView = computed({
 });
 const activeAction = ref(null);
 
-const sidebarLaws = computed(() => {
+// Curated sidebar sections (in render order). Each entry is
+// `{ key, title, laws }`; a `null` title renders a headerless list (the
+// no-favorites fallback). Empty sections are never pushed, so the template
+// can iterate without per-section emptiness checks.
+//
+//   - "Bewerkt in dit traject" comes first: it's the small, high-signal,
+//     context-specific set, so it sits above the larger favorites/full list.
+//     Only present when a traject is active and the diff is non-empty.
+//   - "Favorieten": the user's personal favorites. When the user has none we
+//     fall back to the full corpus (today's behavior) under no heading,
+//     rather than showing an empty panel — full browse otherwise lives in
+//     the search popover.
+const sidebarSections = computed(() => {
   const list = laws.value;
+  const sections = [];
+
+  if (activeTrajectRef.value && changedLawIds.value?.size) {
+    const changed = list.filter(law => changedLawIds.value.has(law.law_id));
+    if (changed.length > 0) {
+      sections.push({ key: 'changed', title: 'Bewerkt in dit traject', laws: changed });
+    }
+  }
+
   if (favorites.value) {
     const favList = list.filter(law => favorites.value.has(law.law_id));
-    if (favList.length > 0) return favList;
+    if (favList.length > 0) {
+      sections.push({ key: 'favorites', title: 'Favorieten', laws: favList });
+      return sections;
+    }
   }
-  return list;
+
+  // No personal favorites: fall back to the full corpus (headerless),
+  // matching the pre-sections behavior. The curated sections layer on top.
+  sections.push({ key: 'all', title: null, laws: list });
+  return sections;
 });
 
 const articles = computed(() => selectedLaw.value?.articles ?? []);
@@ -258,6 +289,23 @@ async function loadFavorites() {
   }
 }
 
+// Fetch the set of law ids edited in the active traject. Returns `null`
+// when there's no traject (global browse has no "changed" notion) or on
+// any failure — the "Bewerkt in dit traject" section then simply stays
+// hidden instead of surfacing an error in the sidebar. The backend returns
+// an empty array (not an error) when nothing has been saved yet, which maps
+// to an empty Set and a hidden section all the same.
+async function fetchChangedLawIds(trajectRef) {
+  if (!trajectRef) return null;
+  try {
+    const res = await fetch(changedLawsUrl(trajectRef));
+    if (!res.ok) return null;
+    return new Set(await res.json());
+  } catch {
+    return null;
+  }
+}
+
 const togglingFavorites = ref(new Set());
 
 async function toggleFavorite(lawId) {
@@ -295,10 +343,14 @@ let loadIndexGeneration = 0;
 
 async function loadIndex() {
   const gen = ++loadIndexGeneration;
+  // Snapshot the traject so the changed-laws fetch and its assignment below
+  // both refer to the scope this run started in.
+  const trajectRef = activeTrajectRef.value;
   try {
-    const [corpusRes] = await Promise.all([
-      fetch(lawsListUrl(activeTrajectRef.value, 'limit=1000')),
+    const [corpusRes, , changedIds] = await Promise.all([
+      fetch(lawsListUrl(trajectRef, 'limit=1000')),
       loadFavorites(),
+      fetchChangedLawIds(trajectRef),
     ]);
     if (!corpusRes.ok) throw new Error(`Failed to load corpus: ${corpusRes.status}`);
     // Gate before and after json(): skip parsing for stale 200s, and catch races during it.
@@ -306,6 +358,7 @@ async function loadIndex() {
     const corpusLaws = await corpusRes.json();
     if (gen !== loadIndexGeneration) return;
     laws.value = corpusLaws.sort((a, b) => a.law_id.localeCompare(b.law_id));
+    changedLawIds.value = changedIds;
   } catch (e) {
     if (gen !== loadIndexGeneration) return;
     indexError.value = e;
@@ -519,6 +572,12 @@ loadIndex();
 // stays mounted — so refetch the index and the open law through the new
 // scope. Mirrors EditorApp's `watch(activeTrajectRef)`.
 watch(activeTrajectRef, () => {
+  // Drop the previous traject's changed-set immediately so the
+  // "Bewerkt in dit traject" section doesn't briefly show stale entries
+  // (filtered against the also-stale corpus) while the new index loads.
+  // `loadIndex` repopulates it for the new scope, or leaves it null in
+  // global browse.
+  changedLawIds.value = null;
   loadIndex();
   if (selectedLawId.value) {
     lawError.value = null;
@@ -646,24 +705,38 @@ watch(activeTrajectRef, () => {
                 <nldd-title id="home-titel" size="3"><h3>{{ LIBRARY_HOME_TITLE }}</h3></nldd-title>
                 <nldd-spacer size="16"></nldd-spacer>
                 <nldd-inline-dialog v-if="loading" text="Laden..."></nldd-inline-dialog>
-                <nldd-list v-else variant="simple">
-                  <nldd-list-item
-                    v-for="law in sidebarLaws"
-                    :key="law.law_id"
-                    size="md"
-                    type="button"
-                    :data-law-id="law.law_id"
-                    :selected="law.law_id === selectedLawId || undefined"
-                    @click="selectLaw(law.law_id)"
+                <template v-else>
+                  <template
+                    v-for="(section, sectionIndex) in sidebarSections"
+                    :key="section.key"
                   >
-                    <nldd-text-cell :text="displayName(law)" :supporting-text="law.source_name">
-                    </nldd-text-cell>
-                    <nldd-spacer-cell size="8"></nldd-spacer-cell>
-                    <nldd-icon-cell size="20">
-                      <nldd-icon name="chevron-right"></nldd-icon>
-                    </nldd-icon-cell>
-                  </nldd-list-item>
-                </nldd-list>
+                    <!-- Gap above every section after the first, so the
+                         curated groups read as distinct blocks. -->
+                    <nldd-spacer v-if="sectionIndex > 0" size="24"></nldd-spacer>
+                    <template v-if="section.title">
+                      <nldd-title size="5"><h4>{{ section.title }}</h4></nldd-title>
+                      <nldd-spacer size="8"></nldd-spacer>
+                    </template>
+                    <nldd-list variant="simple">
+                      <nldd-list-item
+                        v-for="law in section.laws"
+                        :key="`${section.key}-${law.law_id}`"
+                        size="md"
+                        type="button"
+                        :data-law-id="law.law_id"
+                        :selected="law.law_id === selectedLawId || undefined"
+                        @click="selectLaw(law.law_id)"
+                      >
+                        <nldd-text-cell :text="displayName(law)" :supporting-text="law.source_name">
+                        </nldd-text-cell>
+                        <nldd-spacer-cell size="8"></nldd-spacer-cell>
+                        <nldd-icon-cell size="20">
+                          <nldd-icon name="chevron-right"></nldd-icon>
+                        </nldd-icon-cell>
+                      </nldd-list-item>
+                    </nldd-list>
+                  </template>
+                </template>
               </nldd-simple-section>
             </nldd-page>
           </nldd-split-view-pane>

--- a/frontend/src/composables/corpusUrls.js
+++ b/frontend/src/composables/corpusUrls.js
@@ -25,6 +25,16 @@ export function lawsListUrl(trajectRef, query = '') {
   return `${corpusBase(trajectRef)}/laws${q}`;
 }
 
+// Law ids edited in a traject (branch-vs-base diff). Only exists under the
+// traject prefix — there is no global "changed laws" notion — so this is
+// traject-only, like the documents builders. Callers already short-circuit
+// the no-traject case (see `fetchChangedLawIds`); the guard here documents
+// that contract and fails loudly if a future caller forgets it.
+export function changedLawsUrl(trajectRef) {
+  requireTraject(trajectRef, 'changed-laws listing');
+  return `${corpusBase(trajectRef)}/changed-laws`;
+}
+
 export function scenariosListUrl(trajectRef, lawId) {
   return `${lawUrl(trajectRef, lawId)}/scenarios`;
 }

--- a/packages/corpus/src/backend.rs
+++ b/packages/corpus/src/backend.rs
@@ -143,6 +143,18 @@ pub trait RepoBackend: Send + Sync {
 
     /// Whether this backend supports write operations.
     fn is_writable(&self) -> bool;
+
+    /// Source-relative paths of files that differ between this backend's
+    /// branch and its configured base branch.
+    ///
+    /// Only meaningful for backends that track a branch against a base
+    /// (the GitHub API backend used by the traject flow). The default
+    /// returns an empty list, so local- and clone-based backends — which
+    /// have no "base vs head" notion in this context — simply report
+    /// "nothing changed".
+    async fn changed_files(&self) -> Result<Vec<String>> {
+        Ok(Vec::new())
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/corpus/src/github.rs
+++ b/packages/corpus/src/github.rs
@@ -77,6 +77,19 @@ mod inner {
         sha: String,
     }
 
+    /// Compare-API response for `GET /repos/{repo}/compare/{base}...{head}`.
+    /// We only need the per-file `filename`s to map changed files back to
+    /// law ids.
+    #[derive(Debug, Deserialize)]
+    struct CompareResponse {
+        #[serde(default)]
+        files: Vec<CompareFile>,
+    }
+    #[derive(Debug, Deserialize)]
+    struct CompareFile {
+        filename: String,
+    }
+
     /// Result of fetching a GitHub source.
     #[derive(Debug)]
     pub enum FetchResult {
@@ -834,6 +847,61 @@ mod inner {
                 )));
             }
             Ok(())
+        }
+
+        /// In-repo paths of files that differ between `base` and `head`,
+        /// via the Compare API (`{base}...{head}` — three-dot, so the
+        /// result is the set of changes `head` introduced since the merge
+        /// base, which is exactly "what this branch changed").
+        ///
+        /// A 404 (base or head ref missing — e.g. the traject branch was
+        /// never created because no edits have been saved yet) maps to an
+        /// empty list rather than an error: "no branch yet" is the normal
+        /// pre-edit state and the caller treats it as "nothing changed".
+        ///
+        /// NOTE: the Compare API caps `files` at 300 entries and paginates
+        /// beyond that. A traject realistically edits a handful of laws, so
+        /// we read the first page only; a diff larger than 300 files would
+        /// be under-reported (acceptable for the curated-sidebar use case).
+        pub async fn compare_files(
+            &mut self,
+            repo: &str,
+            base: &str,
+            head: &str,
+            token: Option<&str>,
+        ) -> Result<Vec<String>> {
+            let url = format!(
+                "{}/repos/{}/compare/{}...{}",
+                self.api_base, repo, base, head
+            );
+            let headers = self.default_headers(token);
+            let response = self
+                .client
+                .get(&url)
+                .headers(headers)
+                .send()
+                .await
+                .map_err(|e| CorpusError::Git(format!("GitHub API request failed: {}", e)))?;
+            self.track_rate_limit(&response);
+
+            let status = response.status();
+            if status == reqwest::StatusCode::NOT_FOUND {
+                return Ok(Vec::new());
+            }
+            if !status.is_success() {
+                return Err(CorpusError::Git(format!(
+                    "GitHub Compare API {}...{} on {} returned {}: {}",
+                    base,
+                    head,
+                    repo,
+                    status,
+                    response.text().await.unwrap_or_default()
+                )));
+            }
+            let parsed: CompareResponse = response.json().await.map_err(|e| {
+                CorpusError::Git(format!("Failed to parse compare response: {}", e))
+            })?;
+            Ok(parsed.files.into_iter().map(|f| f.filename).collect())
         }
     }
 

--- a/packages/corpus/src/github_api_backend.rs
+++ b/packages/corpus/src/github_api_backend.rs
@@ -143,6 +143,21 @@ impl GitHubApiBackend {
         })
     }
 
+    /// Inverse of [`api_path`]: strip the `sub_path` prefix from an in-repo
+    /// path to recover the source-relative path used by `SourceMap` /
+    /// `LoadedLaw`. Returns `None` for paths outside `sub_path` (files that
+    /// aren't part of this source's corpus subtree — e.g. repo-root config
+    /// when the corpus lives under `regulation/nl`).
+    fn to_source_relative(&self, in_repo_path: &str) -> Option<String> {
+        match &self.sub_path {
+            Some(sub) if !sub.is_empty() => {
+                let prefix = format!("{}/", sub.trim_end_matches('/'));
+                in_repo_path.strip_prefix(&prefix).map(str::to_string)
+            }
+            _ => Some(in_repo_path.to_string()),
+        }
+    }
+
     /// Fetch the current SHA for a path on the target branch. Used by
     /// `persist` when the caller never read the file first (blind write
     /// to an existing file). Returns `Ok(None)` on 404 — the caller can
@@ -527,6 +542,31 @@ impl RepoBackend for GitHubApiBackend {
 
     fn is_writable(&self) -> bool {
         self.token.is_some()
+    }
+
+    async fn changed_files(&self) -> Result<Vec<String>> {
+        // The diff is branch-against-base. Without a base to compare to,
+        // or a token to read the (typically private) repo, there's nothing
+        // meaningful to report — return empty rather than erroring.
+        let Some(base) = self.base_branch.as_deref() else {
+            return Ok(Vec::new());
+        };
+        if self.token.is_none() {
+            return Ok(Vec::new());
+        }
+        let in_repo_paths = {
+            let mut inner = self.inner.lock().await;
+            inner
+                .fetcher
+                .compare_files(&self.full_repo(), base, &self.branch, self.token.as_deref())
+                .await?
+        };
+        // Map in-repo paths back to source-relative paths, dropping any
+        // that fall outside this source's `sub_path` subtree.
+        Ok(in_repo_paths
+            .into_iter()
+            .filter_map(|p| self.to_source_relative(&p))
+            .collect())
     }
 }
 

--- a/packages/corpus/tests/github_api_backend.rs
+++ b/packages/corpus/tests/github_api_backend.rs
@@ -359,3 +359,69 @@ async fn sub_path_prefixes_api_calls() {
     let got = b.read_file(Path::new("wet/x.yaml")).await.unwrap();
     assert_eq!(got.as_deref(), Some("c"));
 }
+
+#[tokio::test]
+async fn changed_files_maps_compare_to_source_relative_paths() {
+    let server = MockServer::start().await;
+
+    // Compare base...head returns two changed law files plus one file
+    // outside the source's sub_path (repo-root config) that must be dropped.
+    Mock::given(method("GET"))
+        .and(path("/repos/acme/corpus/compare/main...traject/abc"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "files": [
+                { "filename": "regulation/nl/wet/a/2025-01-01.yaml" },
+                { "filename": "regulation/nl/wet/b/2025-01-01.yaml" },
+                { "filename": "README.md" },
+            ]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let src = github_source("acme", "corpus", "traject/abc", Some("regulation/nl"));
+    let b = GitHubApiBackend::new(&src, Some("main".to_string()), Some("t".to_string()))
+        .unwrap()
+        .with_api_base(server.uri());
+
+    let mut changed = b.changed_files().await.unwrap();
+    changed.sort();
+    assert_eq!(
+        changed,
+        vec![
+            "wet/a/2025-01-01.yaml".to_string(),
+            "wet/b/2025-01-01.yaml".to_string(),
+        ],
+        "sub_path prefix must be stripped and out-of-subtree files dropped"
+    );
+}
+
+#[tokio::test]
+async fn changed_files_missing_branch_returns_empty() {
+    let server = MockServer::start().await;
+
+    // No traject branch yet (nothing saved) → Compare API 404 → empty list.
+    Mock::given(method("GET"))
+        .and(path("/repos/acme/corpus/compare/main...traject/abc"))
+        .respond_with(ResponseTemplate::new(404).set_body_json(json!({
+            "message": "Not Found"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let b = backend(&server);
+    assert!(b.changed_files().await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn changed_files_without_token_is_empty_and_makes_no_request() {
+    let server = MockServer::start().await;
+    // No mounted mock: any HTTP call would 404 from wiremock. A read-only
+    // backend (no token) must short-circuit before hitting the network.
+    let src = github_source("acme", "corpus", "traject/abc", None);
+    let b = GitHubApiBackend::new(&src, Some("main".to_string()), None)
+        .unwrap()
+        .with_api_base(server.uri());
+    assert!(b.changed_files().await.unwrap().is_empty());
+}

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -1365,6 +1365,12 @@ pub async fn save_law(
     // the read-your-writes follow-up that used to be punted.
     traject.record_save(law_id.clone(), body).await;
 
+    // This save added (or kept) this law on the traject branch, so the
+    // cached changed-laws diff is now stale — drop it so the sidebar's
+    // "Bewerkt in dit traject" section reflects the edit on the next load
+    // instead of waiting out the TTL.
+    traject.invalidate_changed_cache().await;
+
     Ok(Json(save_response_from_traject(outcome)))
 }
 

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -215,6 +215,36 @@ fn list_corpus_laws_in_scope(scope: &ReadScope, params: PaginationParams) -> Vec
         .collect()
 }
 
+/// GET /api/trajects/{traject_ref}/corpus/changed-laws — law ids that have
+/// been edited in this traject (the diff of the traject branch against its
+/// base on the writable-own source, mapped back to law ids).
+///
+/// Feeds the library sidebar's "Bewerkt in dit traject" section. Returns an
+/// empty array — not an error — when nothing has been saved yet (the
+/// traject branch doesn't exist), so the frontend simply hides the section.
+///
+/// Goes through `require_traject_corpus_from_ref` (not `require_traject_scope`)
+/// because it needs the `TrajectCorpus` directly to reach the writable-own
+/// backend; the membership re-check is identical either way.
+pub async fn list_traject_changed_laws(
+    State(state): State<AppState>,
+    session: Session,
+    Path(traject_ref): Path<String>,
+) -> Result<Json<Vec<String>>, (StatusCode, String)> {
+    let traject = require_traject_corpus_from_ref(&state, &session, &traject_ref).await?;
+    let ids = traject.changed_law_ids().await.map_err(|e| {
+        // A GitHub round-trip failure (token, transport, unexpected status)
+        // is upstream — surface it as 502 with a generic message; details
+        // are logged for operators.
+        tracing::warn!(traject_ref = %traject_ref, error = %e, "changed-laws diff failed");
+        (
+            StatusCode::BAD_GATEWAY,
+            "Kon de gewijzigde wetten van dit traject niet ophalen".to_string(),
+        )
+    })?;
+    Ok(Json(ids))
+}
+
 type YamlResponse = (
     StatusCode,
     [(axum::http::HeaderName, &'static str); 1],

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -259,6 +259,10 @@ async fn main() {
             get(corpus_handlers::list_traject_corpus_laws),
         )
         .route(
+            "/api/trajects/{traject_ref}/corpus/changed-laws",
+            get(corpus_handlers::list_traject_changed_laws),
+        )
+        .route(
             "/api/trajects/{traject_ref}/corpus/laws/{law_id}",
             get(corpus_handlers::get_traject_corpus_law),
         )

--- a/packages/editor-api/src/traject_corpus.rs
+++ b/packages/editor-api/src/traject_corpus.rs
@@ -84,6 +84,47 @@ impl TrajectCorpus {
     pub async fn record_save(&self, law_id: String, body: String) {
         self.overlay.write().await.insert(law_id, body);
     }
+
+    /// Law ids that have been edited in this traject: the diff between the
+    /// writable-own source's traject branch and its base branch, mapped
+    /// back to law ids via the source map.
+    ///
+    /// This is the durable source of truth for "what changed in this
+    /// traject" — every save commits to the branch, so the branch-vs-base
+    /// diff survives process restarts and is shared across all members
+    /// (unlike the in-memory `overlay`, which is only a read-your-writes
+    /// cache). Returns an empty list when nothing has been saved yet (the
+    /// traject branch doesn't exist → the Compare API 404s → empty) or the
+    /// writable-own backend isn't initialised.
+    pub async fn changed_law_ids(
+        &self,
+    ) -> Result<Vec<String>, regelrecht_corpus::error::CorpusError> {
+        let Some(entry) = self.corpus.backends.get(&self.writable_own_source_id) else {
+            return Ok(Vec::new());
+        };
+        let changed = {
+            let backend = entry.backend.lock().await;
+            backend.changed_files().await?
+        };
+        if changed.is_empty() {
+            return Ok(Vec::new());
+        }
+        // Match changed source-relative paths against loaded laws. Normalise
+        // separators so a relative_path computed on a non-Unix host still
+        // matches the forward-slash paths GitHub returns.
+        let changed: std::collections::HashSet<String> =
+            changed.into_iter().map(|p| p.replace('\\', "/")).collect();
+        let mut ids: Vec<String> = self
+            .corpus
+            .source_map
+            .laws()
+            .filter(|law| changed.contains(&law.relative_path.replace('\\', "/")))
+            .map(|law| law.law_id.clone())
+            .collect();
+        ids.sort();
+        ids.dedup();
+        Ok(ids)
+    }
 }
 
 /// Lazy registry of per-traject corpora, mirroring the

--- a/packages/editor-api/src/traject_corpus.rs
+++ b/packages/editor-api/src/traject_corpus.rs
@@ -14,6 +14,7 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use regelrecht_corpus::backend::create_backend;
 use regelrecht_corpus::models::{GitHubSource, LocalSource, Source, SourceType};
@@ -62,7 +63,32 @@ pub struct TrajectCorpus {
     /// added that touches many laws per traject, revisit with an LRU
     /// cap.
     overlay: RwLock<HashMap<String, String>>,
+    /// Short-lived cache of the "edited in this traject" diff
+    /// ([`changed_law_ids`]). Each `changed-laws` request would otherwise
+    /// fire a GitHub Compare API call, and the library sidebar re-requests
+    /// it on every load / traject switch — on a shared, rate-limited token
+    /// that adds up fast. The cache collapses a burst of library loads into
+    /// one Compare call per [`CHANGED_LAWS_TTL`] window. `save_law`
+    /// invalidates it so the saving user sees their own edit appear
+    /// immediately (read-your-writes, like `overlay`); other members /
+    /// replicas converge within the TTL. A stale entry is also served as a
+    /// fallback when a fresh Compare call fails (e.g. token throttled), so
+    /// the section degrades to slightly-stale rather than vanishing.
+    changed_cache: RwLock<Option<ChangedLawsCache>>,
 }
+
+/// Cached result of [`TrajectCorpus::changed_law_ids`] with the instant it
+/// was computed, for TTL expiry.
+struct ChangedLawsCache {
+    computed_at: Instant,
+    law_ids: Vec<String>,
+}
+
+/// How long a cached changed-laws diff is served before a fresh GitHub
+/// Compare call is made. Short enough that another member's save shows up
+/// promptly in the sidebar, long enough to collapse a burst of library
+/// loads (mount + tab switches + retries) into a single Compare call.
+const CHANGED_LAWS_TTL: Duration = Duration::from_secs(60);
 
 impl TrajectCorpus {
     /// Resolve the YAML content for a law in this traject, preferring the
@@ -96,7 +122,58 @@ impl TrajectCorpus {
     /// cache). Returns an empty list when nothing has been saved yet (the
     /// traject branch doesn't exist → the Compare API 404s → empty) or the
     /// writable-own backend isn't initialised.
+    ///
+    /// Cached for [`CHANGED_LAWS_TTL`] (see `changed_cache`) so the library
+    /// sidebar's repeated loads don't each spend a GitHub Compare call. On a
+    /// fresh-compute failure (e.g. token throttled) a stale cached value, if
+    /// any, is served rather than propagating the error — the sidebar keeps
+    /// showing the last-known edit set instead of dropping the section.
     pub async fn changed_law_ids(
+        &self,
+    ) -> Result<Vec<String>, regelrecht_corpus::error::CorpusError> {
+        // Fast path: a fresh cache entry serves without any GitHub call.
+        if let Some(cached) = self.changed_cache.read().await.as_ref() {
+            if cached.computed_at.elapsed() < CHANGED_LAWS_TTL {
+                return Ok(cached.law_ids.clone());
+            }
+        }
+
+        match self.compute_changed_law_ids().await {
+            Ok(ids) => {
+                *self.changed_cache.write().await = Some(ChangedLawsCache {
+                    computed_at: Instant::now(),
+                    law_ids: ids.clone(),
+                });
+                Ok(ids)
+            }
+            Err(e) => {
+                // Serve a stale entry (if we have one) rather than dropping
+                // the section when GitHub is momentarily unavailable /
+                // rate-limited. Only propagate when there's nothing cached.
+                if let Some(cached) = self.changed_cache.read().await.as_ref() {
+                    tracing::warn!(
+                        error = %e,
+                        "changed-laws compute failed; serving stale cached value"
+                    );
+                    return Ok(cached.law_ids.clone());
+                }
+                Err(e)
+            }
+        }
+    }
+
+    /// Drop the cached changed-laws diff so the next [`changed_law_ids`]
+    /// call recomputes against GitHub. Called by `save_law` so the saving
+    /// user's new edit shows up in the sidebar immediately instead of after
+    /// the TTL — the changed-laws analogue of [`record_save`].
+    pub async fn invalidate_changed_cache(&self) {
+        *self.changed_cache.write().await = None;
+    }
+
+    /// Uncached computation behind [`changed_law_ids`]: ask the writable-own
+    /// backend for its branch-vs-base diff and map the changed paths to law
+    /// ids via the source map.
+    async fn compute_changed_law_ids(
         &self,
     ) -> Result<Vec<String>, regelrecht_corpus::error::CorpusError> {
         let Some(entry) = self.corpus.backends.get(&self.writable_own_source_id) else {
@@ -406,6 +483,7 @@ async fn build_traject_corpus(
         write_target_for_source,
         writable_own_source_id,
         overlay: RwLock::new(HashMap::new()),
+        changed_cache: RwLock::new(None),
     }))
 }
 


### PR DESCRIPTION
## What

PR 1 of a series that turns the editor library's left sidebar (`LibraryApp.vue`) into curated sections with their own headings, instead of one flat list.

- **Favorieten** — the user's personal favorites (`/api/favorites`, unchanged toggle logic).
- **Bewerkt in dit traject** — laws edited in the active traject. Shown only when a traject is active **and** the diff is non-empty.

Iteration 1 scope. "Recent geopende wetten" is deliberately **not** in this PR (iteration 2 — needs client-side / `user_settings` storage).

## Why the branch diff, not the overlay

The in-memory `overlay` in `traject_corpus.rs` is **not** durable (it's a per-process read-your-writes cache, cleared on cache invalidation). The durable source of truth for "what changed in this traject" is the diff between the traject branch (`gh_branch`) and its base (`gh_base_branch`) on GitHub — every save commits to that branch.

So this adds a reader-tier endpoint that computes that diff:

`GET /api/trajects/{ref}/corpus/changed-laws` -> `["law_id", ...]`

- `GitHubFetcher::compare_files` calls the GitHub Compare API (`{base}...{head}`, three-dot = "what this branch introduced since the merge base"). A 404 (branch not created yet — nothing saved) and a missing token both map to an empty list.
- `GitHubApiBackend::changed_files` strips `sub_path` back to source-relative paths (inverse of the existing `api_path`).
- `TrajectCorpus::changed_law_ids` maps those paths to law ids via the source map.
- `RepoBackend::changed_files` has a default empty impl, so local/clone backends are a no-op.

Reuses the existing `GitHubFetcher` / token / membership-recheck plumbing (DRY).

## Behavior

| State | Sidebar |
|---|---|
| Has favorites, no traject | **Favorieten** only |
| Has favorites, traject active | **Bewerkt in dit traject** (if non-empty) + **Favorieten** |
| No favorites | Full corpus list (headerless, prior behavior), + **Bewerkt in dit traject** when applicable |

Empty sections are hidden. Full-corpus browse otherwise lives in the search popover (curated-only panel, per product decision).

## UI

Built entirely from existing MinBZK/NDD design-system components (`nldd-title` sub-headings + `nldd-list`, separated by `nldd-spacer`). **No custom CSS added.**

## Auth

The endpoint sits under `traject_reader_routes` (`editor-reader` role) and re-checks membership per request via `require_traject_corpus_from_ref` — reading in-progress traject edits is an explicit reader-tier capability.

## Tests / checks

- 3 new wiremock tests on `GitHubApiBackend::changed_files` (path mapping + sub_path strip, 404->empty, no-token->no-request).
- `just format`, `just lint` clean; corpus (117) + editor-api (37) unit tests pass; frontend vitest (243) pass; vite build OK.

## Known limitations (documented inline)

- The Compare API caps `files` at 300 (first page only). A traject editing >300 laws under-reports — fine for the curated sidebar.
- Unsaved (dirty) editor drafts are **not** shown: that state is UI-only, single-article, and doesn't survive navigation, so it isn't a meaningful durable source.