### PR TITLE
feat(editor): datatype-driven scenario parameter inputs

### DIFF
--- a/frontend/e2e/scenario-param-inputs.spec.js
+++ b/frontend/e2e/scenario-param-inputs.spec.js
@@ -1,0 +1,75 @@
+/**
+ * Datatype-driven scenario parameter inputs.
+ *
+ * Verifies that a scenario parameter renders the control matching its
+ * declared datatype (ScenarioParameterInput): a boolean input becomes a
+ * switch, an amount/eurocent input a number-field showing euros, and a
+ * string a plain text-field. Drives the real editor with a mocked corpus
+ * (no editor-api / Postgres needed) and opens the scenario edit sheet.
+ */
+import { test, expect } from '@playwright/test';
+import { loadFixture } from './helpers.js';
+import { mockCorpusApi } from './helpers-corpus.js';
+
+// A minimal scenario that passes one parameter of each declared datatype:
+// bsn (string), is_verzekerde (boolean input), toetsingsinkomen (amount,
+// unit eurocent). Execution may not fully succeed without cross-law data,
+// but the scenario card and its edit sheet still render, which is what we
+// assert against.
+const SCENARIO = `Feature: Typed input controls
+
+  Scenario: Mixed parameter types
+    Given the calculation date is "2025-01-01"
+    Given parameter "bsn" is "999993653"
+    Given parameter "is_verzekerde" is "true"
+    Given parameter "toetsingsinkomen" is 150000
+    When I evaluate "heeft_recht_op_zorgtoeslag" of "zorgtoeslagwet"
+    Then the execution succeeds
+`;
+
+test.describe('Scenario parameter input controls', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      try { window.localStorage.removeItem('regelrecht-open-tabs'); } catch { /* ignore */ }
+    });
+
+    const fixture = loadFixture('zorgtoeslag-full.yaml');
+    const corpus = new Map([
+      ['zorgtoeslagwet', { content: fixture, path: '', pubDate: '2024-12-20' }],
+    ]);
+    await mockCorpusApi(
+      page,
+      corpus,
+      { id: 'zorgtoeslagwet', scenarioFilename: 'typed.feature' },
+      SCENARIO,
+    );
+  });
+
+  test('renders a switch for boolean, number-field for amount, text-field for string', async ({ page }) => {
+    await page.goto('/editor/zorgtoeslagwet/2');
+    await page.waitForSelector('nldd-document-tab-bar-item', { timeout: 15_000 });
+
+    // Open the scenario edit sheet via the card's "Bewerk" button.
+    const edit = page.getByRole('button', { name: 'Bewerk' }).first();
+    await edit.waitFor({ timeout: 30_000 });
+    await edit.click();
+
+    // Each parameter renders as a list-item: the name plus the typed control.
+    // Scope by the list-item carrying the parameter name. The sheet opening
+    // is implied by the controls becoming visible below.
+    const itemFor = (name) => page.locator('nldd-list-item').filter({ hasText: name });
+
+    // boolean -> switch (and the stored "true" reflects as checked)
+    const sw = itemFor('is_verzekerde').locator('nldd-switch-field');
+    await expect(sw).toBeVisible({ timeout: 10_000 });
+    expect(await sw.evaluate((el) => el.checked)).toBe(true);
+
+    // amount/eurocent -> number-field showing euros (150000 eurocent -> 1500)
+    const amount = itemFor('toetsingsinkomen').locator('nldd-number-field');
+    await expect(amount).toBeVisible();
+    expect(await amount.evaluate((el) => el.value)).toBe(1500);
+
+    // string -> plain text-field
+    await expect(itemFor('bsn').locator('nldd-text-field')).toBeVisible();
+  });
+});

--- a/frontend/src/components/EditSheet.vue
+++ b/frontend/src/components/EditSheet.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { ref, computed, watch, watchEffect, nextTick } from 'vue';
 import { collectAvailableVariables } from '../utils/operationTree.js';
+import { centsToEuros, eurosToCents } from '../utils/currency.js';
 import { lawsListUrl } from '../composables/corpusUrls.js';
 import { apiFetchJson } from '../lib/apiFetch.js';
 
@@ -182,13 +183,13 @@ function inferControlType(value, unit) {
 }
 
 function toDisplay(value, controlType) {
-  if (controlType === 'currency') return +(value / 100).toFixed(2);
+  if (controlType === 'currency') return centsToEuros(value);
   if (controlType === 'percentage') return +(value * 100).toFixed(6);
   return value;
 }
 
 function fromDisplay(value, controlType) {
-  if (controlType === 'currency') return Math.round(value * 100);
+  if (controlType === 'currency') return eurosToCents(value);
   if (controlType === 'percentage') return parseFloat((value / 100).toPrecision(15));
   return value;
 }

--- a/frontend/src/components/ScenarioBuilder.vue
+++ b/frontend/src/components/ScenarioBuilder.vue
@@ -9,7 +9,7 @@ import { useLatest } from '../lib/useLatest.js';
 import { parseFeature } from '../gherkin/parser.js';
 import { mapFeatureToForm, getEffectiveSetup, formStateToGherkin, syncEditedValues } from '../gherkin/formMapper.js';
 import { matchStatus, humanize } from '../utils/outputFormat.js';
-import { buildArticleMap } from '../utils/articleMapping.js';
+import { buildArticleMap, buildTypeMap } from '../utils/articleMapping.js';
 import ScenarioForm from './ScenarioForm.vue';
 
 const props = defineProps({
@@ -29,6 +29,9 @@ const emit = defineEmits(['executed', 'dirty-change']);
 
 // --- Article mapping ---
 const articleMap = computed(() => buildArticleMap(props.articles));
+// Datatype mapping: drives the per-type scenario input controls (boolean ->
+// switch, amount -> currency field, etc.) in ScenarioForm.
+const typeMap = computed(() => buildTypeMap(props.articles));
 
 // --- Dependencies ---
 const {
@@ -630,6 +633,7 @@ defineExpose({ save: onSave });
             :ready="ready"
             :law-id="lawId"
             :article-map="articleMap"
+            :type-map="typeMap"
             @show-details="() => onShowDetails(i)"
             @executed="(data) => onScenarioResult(i, data)"
             @change="markDirty"

--- a/frontend/src/components/ScenarioForm.vue
+++ b/frontend/src/components/ScenarioForm.vue
@@ -3,6 +3,7 @@ import { ref, computed, watch, onBeforeUnmount, useId } from 'vue';
 import { parseValue } from '../gherkin/steps.js';
 import { formatValue, formatOutputValue, normalizeForCompare, matchStatus as _matchStatus, humanize } from '../utils/outputFormat.js';
 import DataSourceTable from './DataSourceTable.vue';
+import ScenarioParameterInput from './ScenarioParameterInput.vue';
 
 const props = defineProps({
   /** Scenario object from mapFeatureToForm() */
@@ -17,7 +18,16 @@ const props = defineProps({
   lawId: { type: String, required: true },
   /** Article mapping: { outputToArticle, inputToArticle, paramToArticle } */
   articleMap: { type: Object, default: null },
+  /** Datatype mapping from buildTypeMap(): name -> { type, unit } */
+  typeMap: { type: Object, default: null },
 });
+
+// Resolve a parameter's declared datatype/unit; default to a plain text field
+// for params not found in the map (background-only params, articles without
+// machine_readable).
+function paramMeta(name) {
+  return props.typeMap?.get(name) ?? { type: 'string', unit: null };
+}
 
 const emit = defineEmits(['show-details', 'executed', 'change', 'drill-change']);
 
@@ -315,7 +325,14 @@ const dateErrorId = useId();
           <nldd-text-cell text="Datum" min-width="120px" max-width="200px"></nldd-text-cell>
           <nldd-spacer-cell size="8"></nldd-spacer-cell>
           <nldd-cell width="full" min-width="120px">
-            <nldd-text-field size="md" type="date" :invalid="dateInvalid || undefined" :error-message-ids="dateInvalid ? dateErrorId : undefined" :value="calculationDate" @input="calculationDate = $event.target?.value ?? $event.detail?.value ?? calculationDate; emit('change')"></nldd-text-field>
+            <ScenarioParameterInput
+              type="date"
+              name="Datum"
+              :value="calculationDate"
+              :invalid="dateInvalid"
+              :error-message-ids="dateErrorId"
+              @update="calculationDate = $event; emit('change')"
+            />
             <span v-if="dateInvalid" :id="dateErrorId" class="sf-error">Datum is verplicht</span>
           </nldd-cell>
         </nldd-list-item>
@@ -323,12 +340,14 @@ const dateErrorId = useId();
           <nldd-text-cell :text="name" :supporting-text="articleMap?.paramToArticle?.get(name) ? `Artikel ${articleMap.paramToArticle.get(name)}` : undefined" min-width="120px" max-width="200px"></nldd-text-cell>
           <nldd-spacer-cell size="8"></nldd-spacer-cell>
           <nldd-cell width="full" min-width="120px">
-            <nldd-text-field
-              size="md"
-              :invalid="(!!error && (value === '' || value == null)) || undefined"
+            <ScenarioParameterInput
+              :type="paramMeta(name).type"
+              :unit="paramMeta(name).unit"
+              :name="name"
               :value="value"
-              @input="parameterValues = { ...parameterValues, [name]: $event.target?.value ?? $event.detail?.value ?? '' }; emit('change')"
-            ></nldd-text-field>
+              :invalid="!!error && (value === '' || value == null)"
+              @update="parameterValues = { ...parameterValues, [name]: $event }; emit('change')"
+            />
           </nldd-cell>
         </nldd-list-item>
       </nldd-list>

--- a/frontend/src/components/ScenarioParameterInput.test.js
+++ b/frontend/src/components/ScenarioParameterInput.test.js
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import ScenarioParameterInput from './ScenarioParameterInput.vue';
+
+// nldd-* tags render as raw custom elements (vite.config.js isCustomElement),
+// so we drive the component by dispatching the CustomEvents the real NDD
+// components emit (detail.checked / detail.value) and assert the typed value
+// the component emits via `update`.
+function mountInput(props) {
+  return mount(ScenarioParameterInput, { attachTo: document.body, props });
+}
+
+function lastUpdate(wrapper) {
+  const events = wrapper.emitted('update');
+  return events[events.length - 1][0];
+}
+
+describe('ScenarioParameterInput', () => {
+  describe('control selection per datatype', () => {
+    const cases = [
+      ['boolean', 'nldd-switch-field'],
+      ['number', 'nldd-number-field'],
+      ['amount', 'nldd-number-field'],
+      ['date', 'nldd-text-field'],
+      ['string', 'nldd-text-field'],
+    ];
+    for (const [type, tag] of cases) {
+      it(`renders ${tag} for type=${type}`, () => {
+        const wrapper = mountInput({ type, value: '' });
+        expect(wrapper.find(tag).exists()).toBe(true);
+      });
+    }
+
+    it('falls back to text-field for an unknown type', () => {
+      const wrapper = mountInput({ type: 'mystery', value: '' });
+      expect(wrapper.find('nldd-text-field').exists()).toBe(true);
+    });
+  });
+
+  describe('boolean', () => {
+    it('renders a string "true" value as checked', () => {
+      const wrapper = mountInput({ type: 'boolean', value: 'true' });
+      expect(wrapper.find('nldd-switch-field').attributes('checked')).toBeDefined();
+    });
+
+    it('renders a falsy value as unchecked', () => {
+      const wrapper = mountInput({ type: 'boolean', value: 'false' });
+      expect(wrapper.find('nldd-switch-field').attributes('checked')).toBeUndefined();
+    });
+
+    it('emits a real boolean on toggle', () => {
+      const wrapper = mountInput({ type: 'boolean', value: 'false' });
+      wrapper.find('nldd-switch-field').element.dispatchEvent(
+        new CustomEvent('change', { detail: { checked: true } }),
+      );
+      expect(lastUpdate(wrapper)).toBe(true);
+    });
+  });
+
+  describe('number', () => {
+    it('emits a real number', () => {
+      const wrapper = mountInput({ type: 'number', value: '' });
+      wrapper.find('nldd-number-field').element.dispatchEvent(
+        new CustomEvent('input', { detail: { value: '42' } }),
+      );
+      expect(lastUpdate(wrapper)).toBe(42);
+    });
+
+    it('emits empty string for a cleared field', () => {
+      const wrapper = mountInput({ type: 'number', value: '7' });
+      wrapper.find('nldd-number-field').element.dispatchEvent(
+        new CustomEvent('change', { detail: { value: '' } }),
+      );
+      expect(lastUpdate(wrapper)).toBe('');
+    });
+  });
+
+  describe('amount', () => {
+    it('displays eurocent values in euros', () => {
+      const wrapper = mountInput({ type: 'amount', unit: 'eurocent', value: 109171 });
+      expect(wrapper.find('nldd-number-field').attributes('value')).toBe('1091.71');
+    });
+
+    it('emits eurocents when the unit is eurocent', () => {
+      const wrapper = mountInput({ type: 'amount', unit: 'eurocent', value: '' });
+      wrapper.find('nldd-number-field').element.dispatchEvent(
+        new CustomEvent('change', { detail: { value: '1500' } }),
+      );
+      expect(lastUpdate(wrapper)).toBe(150000);
+    });
+
+    it('emits the raw number when no unit is declared', () => {
+      const wrapper = mountInput({ type: 'amount', unit: null, value: '' });
+      wrapper.find('nldd-number-field').element.dispatchEvent(
+        new CustomEvent('change', { detail: { value: '1500' } }),
+      );
+      expect(lastUpdate(wrapper)).toBe(1500);
+    });
+  });
+
+  describe('date / string', () => {
+    it('emits the date string', () => {
+      const wrapper = mountInput({ type: 'date', value: '' });
+      wrapper.find('nldd-text-field').element.dispatchEvent(
+        new CustomEvent('input', { detail: { value: '2025-01-01' } }),
+      );
+      expect(lastUpdate(wrapper)).toBe('2025-01-01');
+    });
+
+    it('emits the string value', () => {
+      const wrapper = mountInput({ type: 'string', value: '' });
+      wrapper.find('nldd-text-field').element.dispatchEvent(
+        new CustomEvent('input', { detail: { value: 'hello' } }),
+      );
+      expect(lastUpdate(wrapper)).toBe('hello');
+    });
+  });
+});

--- a/frontend/src/components/ScenarioParameterInput.vue
+++ b/frontend/src/components/ScenarioParameterInput.vue
@@ -1,0 +1,117 @@
+<script setup>
+import { computed } from 'vue';
+import { centsToEuros, eurosToCents } from '../utils/currency.js';
+
+// Generic, datatype-driven scenario input control. Given a declared datatype
+// (and optional unit), it renders the matching NDD component and emits a
+// correctly-typed JS value via `update`. It stays purely presentational: the
+// parent owns the value store and the `change`/auto-execute side effects.
+//
+// Round-trip is handled here: scenario values often arrive as strings parsed
+// from Gherkin ("true" / "1500" / "2025-01-01"), and downstream consumers
+// (engine execute + Gherkin re-serialisation) accept real JS types — so we
+// coerce to the right type on the way out. See ScenarioForm.execute() and
+// formMapper.syncEditedValues().
+const props = defineProps({
+  /** Declared datatype: string | number | boolean | amount | date */
+  type: { type: String, default: 'string' },
+  /** type_spec.unit for amounts (e.g. 'eurocent' | 'euro'); null when unannotated */
+  unit: { type: String, default: null },
+  /** Raw stored value (string or already-typed) */
+  value: { default: '' },
+  /** Parameter name (used as the boolean switch label) */
+  name: { type: String, default: '' },
+  /** Mark the field invalid */
+  invalid: { type: Boolean, default: false },
+  /** aria error-message id(s) to associate with the field when invalid */
+  errorMessageIds: { type: String, default: undefined },
+});
+
+const emit = defineEmits(['update']);
+
+// Amounts whose unit is eurocent are stored as integer cents but entered in
+// euros. Any other amount (unit 'euro' or unannotated) is entered raw, so we
+// never silently scale a value whose unit we don't actually know.
+const isEurocent = computed(() => props.type === 'amount' && props.unit === 'eurocent');
+
+// Interpret the incoming (possibly string) value for display per datatype.
+const displayValue = computed(() => {
+  const v = props.value;
+  switch (props.type) {
+    case 'boolean':
+      return v === true || v === 'true' || v === '1';
+    case 'number':
+      return v === '' || v == null ? '' : Number(v);
+    case 'amount':
+      if (v === '' || v == null) return '';
+      return isEurocent.value ? centsToEuros(v) : Number(v);
+    default:
+      // date + string
+      return String(v ?? '');
+  }
+});
+
+function emitNumber(detailValue) {
+  emit('update', detailValue === '' || detailValue == null ? '' : Number(detailValue));
+}
+
+function emitAmount(detailValue) {
+  if (detailValue === '' || detailValue == null) return emit('update', '');
+  emit('update', isEurocent.value ? eurosToCents(detailValue) : Number(detailValue));
+}
+</script>
+
+<template>
+  <!-- boolean -> switch (consistent with EditSheet's boolean control) -->
+  <nldd-switch-field
+    v-if="type === 'boolean'"
+    :checked="displayValue ? true : undefined"
+    @change="emit('update', Boolean($event.detail?.checked))"
+  >{{ name }}</nldd-switch-field>
+
+  <!-- amount -> number-field; enters euros (eurocent unit) or raw otherwise.
+       Both @input and @change are intentional: @input gives live updates,
+       @change delivers the locale-normalised value on commit/blur. -->
+  <nldd-number-field
+    v-else-if="type === 'amount'"
+    :value="displayValue"
+    :invalid="invalid || undefined"
+    step="0.01"
+    width="full"
+    hide-spin-buttons
+    @input="emitAmount($event.detail?.value)"
+    @change="emitAmount($event.detail?.value)"
+  ></nldd-number-field>
+
+  <!-- number -> number-field -->
+  <nldd-number-field
+    v-else-if="type === 'number'"
+    :value="displayValue"
+    :invalid="invalid || undefined"
+    width="full"
+    hide-spin-buttons
+    @input="emitNumber($event.detail?.value)"
+    @change="emitNumber($event.detail?.value)"
+  ></nldd-number-field>
+
+  <!-- date -> native date picker via text-field -->
+  <nldd-text-field
+    v-else-if="type === 'date'"
+    size="md"
+    type="date"
+    :invalid="invalid || undefined"
+    :error-message-ids="invalid ? errorMessageIds : undefined"
+    :value="displayValue"
+    @input="emit('update', $event.target?.value ?? $event.detail?.value ?? '')"
+  ></nldd-text-field>
+
+  <!-- string (fallback) -->
+  <nldd-text-field
+    v-else
+    size="md"
+    :invalid="invalid || undefined"
+    :error-message-ids="invalid ? errorMessageIds : undefined"
+    :value="displayValue"
+    @input="emit('update', $event.target?.value ?? $event.detail?.value ?? '')"
+  ></nldd-text-field>
+</template>

--- a/frontend/src/gherkin/formMapper.test.js
+++ b/frontend/src/gherkin/formMapper.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { parseFeature } from './parser.js';
 import { mapFeatureToForm, getEffectiveSetup, formStateToGherkin, syncEditedValues } from './formMapper.js';
+import { parseValue } from './steps.js';
 
 describe('mapFeatureToForm', () => {
   it('maps a simple scenario with date, evaluate, and assertions', () => {
@@ -365,5 +366,43 @@ Feature: No-op sync
 
     // No scenario-level override should be added
     expect(form.scenarios[0].setup.parameters).toHaveLength(0);
+  });
+});
+
+describe('typed scenario values round-trip', () => {
+  // ScenarioParameterInput now emits real JS types (boolean true, integer
+  // eurocents) instead of strings. Verify these serialize to valid Gherkin
+  // and parse back unchanged, so the new typed controls don't corrupt the
+  // .feature file. See ScenarioForm / ScenarioParameterInput.
+  it('serializes a real boolean and an eurocent amount, then parses back', () => {
+    const parsed = parseFeature(`
+Feature: Typed values
+
+  Scenario: Test
+    Given parameter "is_verzekerde" is "false"
+    Given parameter "inkomen" is 0
+    When I evaluate "result" of "law"
+`);
+
+    const form = mapFeatureToForm(parsed);
+    syncEditedValues(form, 0, {
+      parameterValues: { is_verzekerde: true, inkomen: 150000 },
+      calculationDate: null,
+    });
+
+    const gherkin = formStateToGherkin(form);
+    // boolean → quoted; integer eurocents → unquoted number
+    expect(gherkin).toContain('Given parameter "is_verzekerde" is "true"');
+    expect(gherkin).toContain('Given parameter "inkomen" is 150000');
+
+    // Re-parse. Quoted params (booleans/strings) reload as strings, which the
+    // engine and ScenarioParameterInput coerce via parseValue at use time;
+    // unquoted numbers reload as numbers directly.
+    const reform = mapFeatureToForm(parseFeature(gherkin));
+    const reparams = Object.fromEntries(
+      reform.scenarios[0].setup.parameters.map((p) => [p.name, p.value]),
+    );
+    expect(parseValue(reparams.is_verzekerde)).toBe(true);
+    expect(reparams.inkomen).toBe(150000);
   });
 });

--- a/frontend/src/utils/articleMapping.js
+++ b/frontend/src/utils/articleMapping.js
@@ -26,3 +26,36 @@ export function buildArticleMap(articles) {
 
   return { outputToArticle, inputToArticle, paramToArticle };
 }
+
+/**
+ * Builds a name -> datatype map for scenario parameter inputs, so each input
+ * can render the control matching its declared type (boolean -> switch,
+ * amount -> currency field, etc.). Merges execution.input and
+ * execution.parameters; parameter types win on name collision since a
+ * scenario `Given parameter` targets an execution parameter most directly.
+ * Captures `type_spec.unit` so the amount branch can convert eurocents<->euros.
+ *
+ * @param {Array} articles - Articles array from useLaw()
+ * @returns {Map<string, { type: string, unit: (string|null) }>}
+ */
+export function buildTypeMap(articles) {
+  const typeMap = new Map();
+  const add = (field) => {
+    if (field?.name && field.type) {
+      typeMap.set(field.name, { type: field.type, unit: field.type_spec?.unit ?? null });
+    }
+  };
+
+  // Two passes across all articles: collect every input first, then let
+  // parameters override on name collision (a scenario `Given parameter`
+  // targets an execution parameter most directly). A single per-article pass
+  // would let a later article's input clobber an earlier article's parameter.
+  for (const article of articles || []) {
+    for (const i of article.machine_readable?.execution?.input || []) add(i);
+  }
+  for (const article of articles || []) {
+    for (const p of article.machine_readable?.execution?.parameters || []) add(p);
+  }
+
+  return typeMap;
+}

--- a/frontend/src/utils/articleMapping.test.js
+++ b/frontend/src/utils/articleMapping.test.js
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { buildTypeMap } from './articleMapping.js';
+
+describe('buildTypeMap', () => {
+  it('maps parameter and input names to their declared type', () => {
+    const articles = [
+      {
+        number: '2',
+        machine_readable: {
+          execution: {
+            parameters: [{ name: 'bsn', type: 'string' }],
+            input: [{ name: 'is_verzekerde', type: 'boolean' }],
+          },
+        },
+      },
+    ];
+    const map = buildTypeMap(articles);
+    expect(map.get('bsn')).toEqual({ type: 'string', unit: null });
+    expect(map.get('is_verzekerde')).toEqual({ type: 'boolean', unit: null });
+  });
+
+  it('captures type_spec.unit for amounts', () => {
+    const articles = [
+      {
+        number: '3',
+        machine_readable: {
+          execution: {
+            parameters: [{ name: 'inkomen', type: 'amount', type_spec: { unit: 'eurocent' } }],
+          },
+        },
+      },
+    ];
+    expect(buildTypeMap(articles).get('inkomen')).toEqual({ type: 'amount', unit: 'eurocent' });
+  });
+
+  it('lets parameter types override input types on name collision', () => {
+    const articles = [
+      {
+        number: '1',
+        machine_readable: {
+          execution: {
+            input: [{ name: 'x', type: 'string' }],
+            parameters: [{ name: 'x', type: 'number' }],
+          },
+        },
+      },
+    ];
+    expect(buildTypeMap(articles).get('x')).toEqual({ type: 'number', unit: null });
+  });
+
+  it('ignores articles without machine_readable and returns a Map', () => {
+    const map = buildTypeMap([{ number: '1' }, {}]);
+    expect(map).toBeInstanceOf(Map);
+    expect(map.size).toBe(0);
+  });
+
+  it('handles empty / nullish input', () => {
+    expect(buildTypeMap(undefined).size).toBe(0);
+    expect(buildTypeMap([]).size).toBe(0);
+  });
+});

--- a/frontend/src/utils/currency.js
+++ b/frontend/src/utils/currency.js
@@ -1,0 +1,17 @@
+/**
+ * Amounts are stored as integer eurocents but displayed/entered as euros.
+ * These two pure helpers convert between the two; shared by EditSheet (law
+ * definition values) and ScenarioParameterInput (scenario amount inputs).
+ */
+
+/** Eurocents (int) -> euros (2-decimal number). Empty/nullish passes through. */
+export function centsToEuros(cents) {
+  if (cents === '' || cents == null) return '';
+  return +(Number(cents) / 100).toFixed(2);
+}
+
+/** Euros (number) -> eurocents (rounded int). Empty/nullish passes through. */
+export function eurosToCents(euros) {
+  if (euros === '' || euros == null) return '';
+  return Math.round(Number(euros) * 100);
+}

--- a/frontend/src/utils/currency.test.js
+++ b/frontend/src/utils/currency.test.js
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { centsToEuros, eurosToCents } from './currency.js';
+
+describe('currency', () => {
+  describe('centsToEuros', () => {
+    it('converts eurocents to a 2-decimal euro number', () => {
+      expect(centsToEuros(150000)).toBe(1500);
+      expect(centsToEuros(109171)).toBe(1091.71);
+      expect(centsToEuros(1)).toBe(0.01);
+    });
+
+    it('passes empty/nullish through unchanged', () => {
+      expect(centsToEuros('')).toBe('');
+      expect(centsToEuros(null)).toBe('');
+      expect(centsToEuros(undefined)).toBe('');
+    });
+
+    it('accepts numeric strings', () => {
+      expect(centsToEuros('109171')).toBe(1091.71);
+    });
+  });
+
+  describe('eurosToCents', () => {
+    it('converts euros to rounded eurocents', () => {
+      expect(eurosToCents(1500)).toBe(150000);
+      expect(eurosToCents(1091.71)).toBe(109171);
+      expect(eurosToCents(19.999)).toBe(2000);
+    });
+
+    it('passes empty/nullish through unchanged', () => {
+      expect(eurosToCents('')).toBe('');
+      expect(eurosToCents(null)).toBe('');
+      expect(eurosToCents(undefined)).toBe('');
+    });
+
+    it('round-trips with centsToEuros', () => {
+      expect(eurosToCents(centsToEuros(109171))).toBe(109171);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Scenario parameter inputs in the editor always rendered as a plain text field, regardless of the parameter's declared datatype — so a boolean was typed as the literal text `true`, an amount as a raw number, a date as a free-text string.

This adds a generic, datatype-driven control (`ScenarioParameterInput.vue`) that renders the NDD component matching each parameter's declared datatype:

| datatype | control |
|----------|---------|
| `boolean` | `nldd-switch-field` (consistent with EditSheet) |
| `number` | `nldd-number-field` |
| `amount` | `nldd-number-field`, **unit-aware** |
| `date` | `nldd-text-field type="date"` |
| `string` | `nldd-text-field` (fallback) |

![Scenario inputs per datatype](https://files.catbox.moe/g0f05b.png)

The "Datum" (calculation date) field reuses the same control.

## How it works

- `buildTypeMap(articles)` (new, sibling of `buildArticleMap`) resolves each parameter's `{ type, unit }` from the law's `execution.parameters` / `execution.input`. `ScenarioBuilder` threads it into `ScenarioForm`.
- The control coerces values to real JS types (boolean / number / string) on the way out; they round-trip cleanly through `formMapper` / `parseValue` (verified by test) — no `formMapper` change needed.
- **Amount is unit-aware.** With `type_spec.unit: eurocent`, the user enters euros and the value is stored as integer eurocents (e.g. `150000` ⇄ `1500`); with `unit: euro` or no declared unit it stays a raw number, so we never silently scale a value whose unit we don't know. The euro⇄eurocent math is extracted into `utils/currency.js` and reused by `EditSheet`.

## Stacked on #729

This builds on **#729 (RFC-019, units of measurement)**, which adds `type_spec.unit` to `parameterField` — that's what makes the amount control's unit-awareness real rather than dormant. Base this PR's merge on #729; once #729 lands, rebase onto `main`.

Parameters without a declared unit fall back to a raw number-field, so un-annotated laws keep working unchanged.

## Tests

- Unit: `currency`, `buildTypeMap`, `ScenarioParameterInput` (control selection + display/emit coercion per type), and a typed `formMapper` round-trip — all green (247 frontend tests pass).
- E2E: `e2e/scenario-param-inputs.spec.js` opens a scenario with a boolean / amount-eurocent / string parameter and asserts each renders the right control (switch checked, number-field showing `1500` euros, text-field).

## Custom CSS

None. Only NDD design-system components; no `<style>` added.
