### PR TITLE
fix(editor): debounce law-reload so scenarios don't flicker on every keystroke

### DIFF
--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed, reactive, watch, watchEffect, nextTick } from 'vue';
+import { ref, computed, reactive, watch, watchEffect, nextTick, onBeforeUnmount } from 'vue';
 import { useRoute, useRouter, onBeforeRouteUpdate } from 'vue-router';
 import yaml from 'js-yaml';
 import { useLaw, fetchLaw } from './composables/useLaw.js';
@@ -883,18 +883,37 @@ const currentLawYaml = computed(() => {
 // load under the right traject — otherwise a later loadDependency call
 // for the same law id would treat it as already-current and skip the
 // refetch on a traject switch.
+// `currentLawYaml` re-dumps on every keystroke, so reacting directly would
+// reload the WASM engine per keystroke. Debounce the reload ~300ms after the
+// last edit; keep the first load (no previous yaml) synchronous so opening an
+// article isn't delayed.
+let engineLoadDebounce = null;
+
+async function reloadEngineLaw(lawYaml, isReady) {
+  if (!isReady || !lawYaml) return;
+  try {
+    await loadLawYaml(lawYaml, lawId.value, activeTrajectRef.value);
+  } catch (e) {
+    console.warn(`Failed to load law '${lawId.value}' into engine:`, e);
+  }
+}
+
 watch(
   [currentLawYaml, engineReady],
-  async ([lawYaml, isReady]) => {
-    if (!isReady || !lawYaml) return;
-    try {
-      await loadLawYaml(lawYaml, lawId.value, activeTrajectRef.value);
-    } catch (e) {
-      console.warn(`Failed to load law '${lawId.value}' into engine:`, e);
+  ([lawYaml, isReady], prev) => {
+    clearTimeout(engineLoadDebounce);
+    // First load (no previous yaml): run immediately so scenarios see the law
+    // without delay. Subsequent in-memory edits debounce.
+    if (!prev || !prev[0]) {
+      reloadEngineLaw(lawYaml, isReady);
+      return;
     }
+    engineLoadDebounce = setTimeout(() => reloadEngineLaw(lawYaml, isReady), 300);
   },
   { immediate: true },
 );
+
+onBeforeUnmount(() => clearTimeout(engineLoadDebounce));
 
 // Dirty state: the selected article's in-memory machine_readable differs
 // from the article's saved copy. `machineReadable.value` starts as a deep

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -885,8 +885,9 @@ const currentLawYaml = computed(() => {
 // refetch on a traject switch.
 // `currentLawYaml` re-dumps on every keystroke, so reacting directly would
 // reload the WASM engine per keystroke. Debounce the reload ~300ms after the
-// last edit; keep the first load (no previous yaml) synchronous so opening an
-// article isn't delayed.
+// last edit; keep the first load (no previous yaml) synchronous so the initial
+// load isn't delayed. Subsequent transitions from an existing yaml — keystroke
+// edits, article switches, traject switches — debounce.
 let engineLoadDebounce = null;
 
 async function reloadEngineLaw(lawYaml, isReady) {
@@ -903,7 +904,7 @@ watch(
   ([lawYaml, isReady], prev) => {
     clearTimeout(engineLoadDebounce);
     // First load (no previous yaml): run immediately so scenarios see the law
-    // without delay. Subsequent in-memory edits debounce.
+    // without delay. Any change from an existing yaml debounces.
     if (!prev || !prev[0]) {
       reloadEngineLaw(lawYaml, isReady);
       return;

--- a/frontend/src/components/ScenarioBuilder.vue
+++ b/frontend/src/components/ScenarioBuilder.vue
@@ -165,8 +165,10 @@ const debouncedLawYaml = ref(props.lawYaml);
 let lawYamlDebounce = null;
 
 watch(() => props.lawYaml, (val, prev) => {
-  // First population or cleared→set (opening an article): apply immediately so
-  // initial load isn't delayed by 300ms. Subsequent edits debounce.
+  // First population or cleared→set (no prior law loaded): apply immediately so
+  // the initial dependency load isn't delayed by 300ms. Any change from an
+  // existing value — keystroke edits, but also switching to another article of
+  // the already-open law — debounces.
   clearTimeout(lawYamlDebounce);
   if (!prev) {
     debouncedLawYaml.value = val;

--- a/frontend/src/components/ScenarioBuilder.vue
+++ b/frontend/src/components/ScenarioBuilder.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed, watch, nextTick } from 'vue';
+import { ref, computed, watch, nextTick, onBeforeUnmount } from 'vue';
 import { useDependencies } from '../composables/useDependencies.js';
 import { useScenarios } from '../composables/useScenarios.js';
 import { lawUrl } from '../composables/corpusUrls.js';
@@ -155,8 +155,32 @@ const depsReady = ref(false);
 // --- Load dependencies when law YAML changes ---
 let watchVersion = 0;
 
+// Debounced mirror of props.lawYaml. While the user types in the text or
+// machine pane, `lawYaml` changes on every keystroke (currentLawYaml re-dumps
+// the whole doc), which would re-run the expensive dependency reload + corpus
+// scan and toggle depsReady — making the scenario panel flicker. We only let
+// the cascade below fire ~300ms after the last edit. Same setTimeout debounce
+// pattern as ScenarioForm.vue's execute.
+const debouncedLawYaml = ref(props.lawYaml);
+let lawYamlDebounce = null;
+
+watch(() => props.lawYaml, (val, prev) => {
+  // First population or cleared→set (opening an article): apply immediately so
+  // initial load isn't delayed by 300ms. Subsequent edits debounce.
+  clearTimeout(lawYamlDebounce);
+  if (!prev) {
+    debouncedLawYaml.value = val;
+    return;
+  }
+  lawYamlDebounce = setTimeout(() => {
+    debouncedLawYaml.value = val;
+  }, 300);
+});
+
+onBeforeUnmount(() => clearTimeout(lawYamlDebounce));
+
 watch(
-  [() => props.lawYaml, () => props.ready, formState],
+  [debouncedLawYaml, () => props.ready, formState],
   async ([lawYaml, isReady]) => {
     if (!lawYaml || !isReady || !props.engine) return;
     const version = ++watchVersion;


### PR DESCRIPTION
## Problem

Typing in the article-text editor made the **scenario panel flicker on every keystroke**.

Root cause: `editedText` updates per keystroke → `currentLawYaml` (computed) re-runs `yaml.dump` and produces a new string each time. That new string:
- retriggers `ScenarioBuilder`'s dependency `watch`, which sets `depsLoading=true` (the *"Afhankelijkheden laden"* block flashes in + layout-shifts) and runs a **full corpus scan** (`/laws?limit=1000` + fetching every candidate law) — on *every* key;
- toggles `depsReady` false→true, re-running the auto-execute watch so all scenario result badges flicker;
- reloads the WASM engine via `EditorApp`'s `currentLawYaml` watch per keystroke.

Editing article *text* doesn't change scenario execution, so all of this is wasted per keystroke.

## Fix

Debounce ~300ms after the last edit (reusing the existing `setTimeout` pattern from `ScenarioForm.vue`):
- **`ScenarioBuilder.vue`** — a debounced mirror of `props.lawYaml` drives the dependency/auto-execute cascade. First population/article-open applies immediately; subsequent edits debounce.
- **`EditorApp.vue`** — the engine reload is debounced the same way, first load stays synchronous.

Result: no per-keystroke flicker or corpus rescans; after a short pause the panel refreshes once. Live-preview of `machine_readable` edits still works (just ~300ms later).

The `:key="i"` index keys were considered but are **not** the cause and were left unchanged.

## Verification

- `vitest run` — all 243 tests pass; SFCs compile.
- Manual (recommended): open an article with scenarios, type fast in the text editor → no *"Afhankelijkheden laden"* flashing, no layout shift, no corpus scan per key (check Network tab); edit `machine_readable` and pause → results still update.