### PR TITLE
fix(frontend): use design-system fonts instead of hardcoded OS fonts

### DIFF
--- a/frontend-lawmaking/css/variables.css
+++ b/frontend-lawmaking/css/variables.css
@@ -31,6 +31,7 @@
 
   /* Typography - aligned with @nldd/design-system design tokens */
   --font-family: var(--primitives-font-family-body, var(--rr-font-family-sans, 'RijksSansVF', system-ui, sans-serif));
+  --font-family-mono: var(--primitives-font-family-monospace, var(--rr-font-family-mono, 'JetBrains Mono', monospace));
 
   --font-size-xs: 12px;
   --font-size-sm: 14px;

--- a/frontend-lawmaking/fonts/fonts.css
+++ b/frontend-lawmaking/fonts/fonts.css
@@ -56,8 +56,12 @@
   font-display: swap;
 }
 
-/* CSS Custom Properties - aligned with @nldd/design-system design tokens */
+/* CSS Custom Properties - aligned with @nldd/design-system design tokens.
+   The mono fallback names 'JetBrains Mono' (the design-system monospace face,
+   already registered + loaded via the `@nldd/design-system/styles` import in
+   main.js); it only applies if the primitives token is ever absent. */
 :root {
   --rr-font-family-sans: 'RijksSansVF', system-ui, sans-serif;
   --rr-font-family-serif: 'RijksoverheidSerif', Georgia, serif;
+  --rr-font-family-mono: 'JetBrains Mono', monospace;
 }

--- a/frontend-lawmaking/src/components/FlowDiagram.vue
+++ b/frontend-lawmaking/src/components/FlowDiagram.vue
@@ -284,7 +284,7 @@ function isConnectionActive(conn) {
 }
 
 .flow-diagram__branch-label {
-  font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+  font-family: var(--font-family-mono);
   transition: opacity 0.5s ease;
 }
 
@@ -295,7 +295,7 @@ function isConnectionActive(conn) {
 }
 
 .flow-diagram__timeline-label {
-  font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+  font-family: var(--font-family-mono);
   font-variant-numeric: tabular-nums;
 }
 </style>

--- a/frontend-lawmaking/src/components/FlowNode.vue
+++ b/frontend-lawmaking/src/components/FlowNode.vue
@@ -139,7 +139,7 @@ const fillColor = computed(() =>
 }
 
 .flow-node__git-label {
-  font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+  font-family: var(--font-family-mono);
   letter-spacing: 0.02em;
 }
 
@@ -152,12 +152,12 @@ const fillColor = computed(() =>
 }
 
 .flow-node__date {
-  font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+  font-family: var(--font-family-mono);
   font-variant-numeric: tabular-nums;
 }
 
 .flow-node__tag-label {
-  font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+  font-family: var(--font-family-mono);
   letter-spacing: 0.02em;
 }
 

--- a/frontend-lawmaking/src/components/StageDetail.vue
+++ b/frontend-lawmaking/src/components/StageDetail.vue
@@ -142,7 +142,7 @@ const badgeColor = computed(() => {
 }
 
 .stage-detail__mapping-value--git {
-  font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+  font-family: var(--font-family-mono);
   font-weight: 400;
 }
 

--- a/frontend/css/main.css
+++ b/frontend/css/main.css
@@ -15,6 +15,11 @@ body {
 
 body {
   margin: 0;
+  /* Base UI font for plain text not rendered inside an nldd component (e.g.
+     slotted spans in sheets/lists). @nldd/design-system only defines the
+     token + @font-face; it does not set a global body font, so without this
+     such text falls back to the browser default instead of RijksSans. */
+  font-family: var(--primitives-font-family-body);
 }
 
 *,

--- a/frontend/src/EditorApp.vue
+++ b/frontend/src/EditorApp.vue
@@ -2026,7 +2026,7 @@ async function handleActionSave() {
   margin-top: 8px;
   background: #fef2f2;
   color: #b91c1c;
-  font-family: 'SF Mono', monospace;
+  font-family: var(--primitives-font-family-monospace);
   font-size: 12px;
   padding: 8px 12px;
   border: 1px solid #fecaca;

--- a/frontend/src/components/AnnotatedText.vue
+++ b/frontend/src/components/AnnotatedText.vue
@@ -811,10 +811,10 @@ onBeforeUnmount(() => {
 }
 
 /* Popover card content. nldd-popover does not pad slotted content, nor
-   inherit the editor UI font, so the card sets both (RijksSansVF is the
-   design-system UI face). Border-left echoes the highlight colour. */
+   inherit the editor UI font, so the card sets both (the design-system body
+   token resolves to RijksSans). Border-left echoes the highlight colour. */
 .note-pop {
-  font-family: 'RijksSansVF', system-ui, sans-serif;
+  font-family: var(--primitives-font-family-body);
   padding: 14px 16px;
   border-left: 3px solid transparent;
 }

--- a/frontend/src/components/NoteCreator.vue
+++ b/frontend/src/components/NoteCreator.vue
@@ -432,7 +432,7 @@ const statusInfo = computed(() => {
 
 <style scoped>
 .note-creator {
-  font-family: 'RijksSansVF', system-ui, sans-serif;
+  font-family: var(--primitives-font-family-body);
   padding: 16px;
   /* The popover host owns the width (set via the `width="480px"` attribute on
      <nldd-popover>, which it reflects to --components-popover-default-width;

--- a/frontend/src/components/graph/TraceStepDetail.vue
+++ b/frontend/src/components/graph/TraceStepDetail.vue
@@ -118,7 +118,7 @@ const expectationEntries = computed(() => Object.entries(props.expectations || {
   letter-spacing: 0.04em;
 }
 .step-detail__name {
-  font-family: 'SF Mono', 'Fira Code', monospace;
+  font-family: var(--primitives-font-family-monospace);
   font-size: 12px;
   font-weight: 600;
 }
@@ -128,7 +128,7 @@ const expectationEntries = computed(() => Object.entries(props.expectations || {
   display: flex;
   flex-direction: column;
   gap: 2px;
-  font-family: 'SF Mono', 'Fira Code', monospace;
+  font-family: var(--primitives-font-family-monospace);
   font-size: 11px;
   margin: 0;
 }
@@ -149,7 +149,7 @@ const expectationEntries = computed(() => Object.entries(props.expectations || {
   word-break: break-word;
 }
 
-.mono { font-family: 'SF Mono', 'Fira Code', monospace; }
+.mono { font-family: var(--primitives-font-family-monospace); }
 .indigo { color: var(--primitives-color-paars-700); }
 .emerald { color: var(--primitives-color-mintgroen-700); }
 .italic { font-style: italic; color: var(--semantics-content-secondary-color); }
@@ -171,7 +171,7 @@ const expectationEntries = computed(() => Object.entries(props.expectations || {
   list-style: none;
   padding: 0;
   margin: 0;
-  font-family: 'SF Mono', 'Fira Code', monospace;
+  font-family: var(--primitives-font-family-monospace);
   font-size: 11px;
   display: flex;
   flex-direction: column;

--- a/frontend/src/components/graph/TraceStepList.vue
+++ b/frontend/src/components/graph/TraceStepList.vue
@@ -84,7 +84,7 @@ watch(
 <style scoped>
 .step-list {
   overflow-y: auto;
-  font-family: 'SF Mono', 'Fira Code', monospace;
+  font-family: var(--primitives-font-family-monospace);
 }
 
 .step-row {


### PR DESCRIPTION
## What

UI text must use the MinBZK/storybook (`@nldd/design-system`) faces only. Several spots hardcoded non-design-system fonts. This replaces them with the design-system tokens.

The trigger was the **Traject-info sheet** rendering in a different font than the rest of the editor: its plain slotted `<span>`s fell back to the **browser default font**, because the editor never set a global `body` font and the design system ships only the token + `@font-face`, not a global `body` rule.

## Incorrect fonts found

- `'SF Mono'` / `'Fira Code'` / `'Cascadia Code'` (IDE/macOS) instead of the design-system monospace (**JetBrains Mono**)
- `'RijksSansVF'` in the editor — not registered as an `@font-face` there, so it silently fell back to `system-ui`

## Changes

**Editor (`frontend/`, imports the design system):**
- `css/main.css`: set `body` font-family to `var(--primitives-font-family-body)` — root-cause fix for the Traject-info panel
- `AnnotatedText.vue`, `NoteCreator.vue`: `'RijksSansVF'` → `var(--primitives-font-family-body)`
- `EditorApp.vue`, `graph/TraceStepDetail.vue`, `graph/TraceStepList.vue`: `'SF Mono'…` → `var(--primitives-font-family-monospace)`

**Lawmaking (`frontend-lawmaking/`, also imports the design system):**
- `css/variables.css` + `fonts/fonts.css`: add `--font-family-mono` resolving to `--primitives-font-family-monospace` (JetBrains Mono), mirroring the existing `--font-family` fallback structure
- `FlowNode.vue`, `FlowDiagram.vue`, `StageDetail.vue`: `'SF Mono'…` → `var(--font-family-mono)`

## Custom CSS report (per CLAUDE.md)

One addition on top of the design-system components: a global `body { font-family: var(--primitives-font-family-body) }` in `frontend/css/main.css`. It sets the design-system token as the base font (no custom value), but it is a global rule the design system itself does not ship — possibly a signal the design system should provide a base body-font rule.

## Verification

- `frontend` build ✓ and `npm run test` → **262/262 passing**
- `frontend-lawmaking` build ✓ (JetBrains Mono served via the design-system import; no redundant self-hosted copy)