### PR TITLE
fix(editor): stop scenario dependency-scan request storm + un-gate result buttons

### DIFF
--- a/frontend/src/components/ScenarioBuilder.vue
+++ b/frontend/src/components/ScenarioBuilder.vue
@@ -181,39 +181,57 @@ watch(() => props.lawYaml, (val, prev) => {
 
 onBeforeUnmount(() => clearTimeout(lawYamlDebounce));
 
+// Run the dependency cascade for the current law + scenarios. Reads the
+// latest prop/state values at call time (not captured watch args) so a
+// debounced run always uses the freshest inputs.
+async function runDependencyLoad() {
+  const lawYaml = debouncedLawYaml.value;
+  if (!lawYaml || !props.ready || !props.engine) return;
+  const version = ++watchVersion;
+  depsReady.value = false;
+
+  await loadAllDependencies(lawYaml, props.engine, fetchLawYaml, props.trajectRef);
+  if (version !== watchVersion) return;
+
+  // Also load dependencies from scenario background + per-scenario steps
+  if (formState.value) {
+    const allDeps = new Set();
+    for (const dep of formState.value.background?.dependencies || []) allDeps.add(dep);
+    for (const sc of formState.value.scenarios || []) {
+      for (const dep of sc.setup?.dependencies || []) allDeps.add(dep);
+    }
+    for (const depId of allDeps) {
+      try {
+        if (!props.engine.hasLaw(depId)) {
+          const yaml = await fetchLawYaml(depId);
+          props.engine.loadLaw(yaml);
+        }
+      } catch (e) {
+        console.warn(`Failed to load scenario dependency '${depId}':`, e);
+      }
+    }
+  }
+
+  if (version === watchVersion) {
+    depsReady.value = true;
+  }
+}
+
+// `debouncedLawYaml`, `props.ready` and `formState` settle on separate ticks
+// during the initial load. Without coalescing, each settle fires this watch
+// and starts (then abandons, via `watchVersion`) a full dependency scan — up
+// to four overlapping corpus-wide reloads per open. A short debounce collapses
+// the burst into a single run after the inputs have settled.
+let depsScheduleTimer = null;
+function scheduleDependencyLoad() {
+  clearTimeout(depsScheduleTimer);
+  depsScheduleTimer = setTimeout(runDependencyLoad, 30);
+}
+onBeforeUnmount(() => clearTimeout(depsScheduleTimer));
+
 watch(
   [debouncedLawYaml, () => props.ready, formState],
-  async ([lawYaml, isReady]) => {
-    if (!lawYaml || !isReady || !props.engine) return;
-    const version = ++watchVersion;
-    depsReady.value = false;
-
-    await loadAllDependencies(lawYaml, props.engine, fetchLawYaml, props.trajectRef);
-    if (version !== watchVersion) return;
-
-    // Also load dependencies from scenario background + per-scenario steps
-    if (formState.value) {
-      const allDeps = new Set();
-      for (const dep of formState.value.background?.dependencies || []) allDeps.add(dep);
-      for (const sc of formState.value.scenarios || []) {
-        for (const dep of sc.setup?.dependencies || []) allDeps.add(dep);
-      }
-      for (const depId of allDeps) {
-        try {
-          if (!props.engine.hasLaw(depId)) {
-            const yaml = await fetchLawYaml(depId);
-            props.engine.loadLaw(yaml);
-          }
-        } catch (e) {
-          console.warn(`Failed to load scenario dependency '${depId}':`, e);
-        }
-      }
-    }
-
-    if (version === watchVersion) {
-      depsReady.value = true;
-    }
-  },
+  scheduleDependencyLoad,
   { immediate: true },
 );
 
@@ -478,15 +496,19 @@ defineExpose({ save: onSave });
               </template>
             </nldd-container>
             <nldd-container slot="footer" padding-inline="16" padding-bottom="16">
+              <!-- Not gated on a cached result: onShowDetails always emits and
+                   the result sheet handles its own loading / empty / error
+                   (with reload) states. Disabling here turned the buttons into
+                   a dead end while dependencies were still loading (or after a
+                   save reset the cached result), so the user could never open
+                   the trace/graph to retry. -->
               <nldd-button-group orientation="horizontal">
                 <nldd-button
-                  :disabled="!scenarioResults.get(i) || undefined"
                   text="Resultaat"
                   @click="onShowDetails(i, 'trace')"
                 ></nldd-button>
                 <nldd-button
                   variant="secondary"
-                  :disabled="!scenarioResults.get(i) || undefined"
                   text="Graaf"
                   @click="onShowDetails(i, 'graph')"
                 ></nldd-button>

--- a/frontend/src/components/ScenarioBuilder.vue
+++ b/frontend/src/components/ScenarioBuilder.vue
@@ -33,6 +33,7 @@ const {
   progress: depsProgress,
   error: depsError,
   loadAllDependencies,
+  loadImplementors,
 } = useDependencies();
 
 // --- Scenario loading ---
@@ -190,7 +191,7 @@ async function runDependencyLoad() {
   const version = ++watchVersion;
   depsReady.value = false;
 
-  await loadAllDependencies(lawYaml, props.engine, fetchLawYaml, props.trajectRef);
+  const mainLawId = await loadAllDependencies(lawYaml, props.engine, fetchLawYaml);
   if (version !== watchVersion) return;
 
   // Also load dependencies from scenario background + per-scenario steps
@@ -213,7 +214,15 @@ async function runDependencyLoad() {
   }
 
   if (version === watchVersion) {
+    // The explicitly-declared deps are loaded — the panel is usable now, so
+    // mark ready and let scenarios auto-execute. Implementing regulations
+    // (IoC) load in the background: their corpus scan can be slow and is
+    // best-effort, so it must not gate the panel. `loadImplementors` is
+    // guarded to run at most once per law.
     depsReady.value = true;
+    if (mainLawId) {
+      loadImplementors(mainLawId, props.engine, fetchLawYaml, props.trajectRef);
+    }
   }
 }
 

--- a/frontend/src/components/ScenarioBuilder.vue
+++ b/frontend/src/components/ScenarioBuilder.vue
@@ -219,6 +219,11 @@ async function runDependencyLoad() {
     // (IoC) load in the background: their corpus scan can be slow and is
     // best-effort, so it must not gate the panel. `loadImplementors` is
     // guarded to run at most once per law.
+    //
+    // Deliberately fire-and-forget — there is no AbortController. If this
+    // component unmounts mid-scan the promise keeps running, which is safe:
+    // Vue ignores ref writes after unmount, the shared WASM engine outlives
+    // the component, and the guard resets on error so a fresh mount retries.
     depsReady.value = true;
     if (mainLawId) {
       loadImplementors(mainLawId, props.engine, fetchLawYaml, props.trajectRef);

--- a/frontend/src/composables/corpusUrls.js
+++ b/frontend/src/composables/corpusUrls.js
@@ -35,6 +35,14 @@ export function changedLawsUrl(trajectRef) {
   return `${corpusBase(trajectRef)}/changed-laws`;
 }
 
+// Law ids whose articles `implements` an open_term of `lawId` (the IoC
+// reverse link). Computed server-side over the in-memory corpus, so the
+// scenario dependency loader resolves implementing regulations with a
+// single request instead of fetching and parsing every law in the corpus.
+export function implementorsUrl(trajectRef, lawId) {
+  return `${lawUrl(trajectRef, lawId)}/implementors`;
+}
+
 export function scenariosListUrl(trajectRef, lawId) {
   return `${lawUrl(trajectRef, lawId)}/scenarios`;
 }

--- a/frontend/src/composables/useDependencies.js
+++ b/frontend/src/composables/useDependencies.js
@@ -160,10 +160,17 @@ export function useDependencies() {
     if (!lawId) return;
     const key = `${trajectRef || ''}::${lawId}`;
     if (implementorsKey === key) return;
+    // Claim the key up front so a concurrent re-trigger doesn't start a second
+    // scan; reset it on failure so a transient error (network blip, throttled
+    // backend) can be retried on the next trigger rather than suppressed for
+    // the component's lifetime.
     implementorsKey = key;
     try {
       const res = await fetch(implementorsUrl(trajectRef, lawId));
-      if (!res.ok) return;
+      if (!res.ok) {
+        implementorsKey = null;
+        return;
+      }
       const implementors = await res.json();
       for (const implId of implementors) {
         try {
@@ -178,7 +185,8 @@ export function useDependencies() {
       }
     } catch {
       // Best-effort: if the scan fails, explicitly-declared deps still cover
-      // the common case.
+      // the common case. Allow a retry on the next trigger.
+      implementorsKey = null;
     }
   }
 

--- a/frontend/src/composables/useDependencies.js
+++ b/frontend/src/composables/useDependencies.js
@@ -3,12 +3,14 @@
  *
  * Parses a law's YAML structure to find all `source.regulation` references,
  * fetches each dependency via the API, loads it into the engine, and recurses.
- * Also discovers implementing regulations via corpus scan.
+ * Also pulls in implementing regulations (the IoC reverse link) via the
+ * backend `implementors` endpoint, which scans the in-memory corpus
+ * server-side — one request instead of fetching and parsing every law.
  */
 import { ref } from 'vue';
 import yaml from 'js-yaml';
 import { useBwbHarvest } from './useBwbHarvest.js';
-import { lawsListUrl } from './corpusUrls.js';
+import { implementorsUrl } from './corpusUrls.js';
 
 /**
  * Extract all unique `source.regulation` references from a parsed law object.
@@ -32,54 +34,6 @@ export function extractRegulationRefs(law) {
   }
 
   return [...refs];
-}
-
-/**
- * Find laws in the corpus that implement open_terms of the given law.
- *
- * @param {string} lawId - The law ID to find implementors for
- * @param {object[]} allLaws - Full corpus law list (from /api/corpus/laws)
- * @returns {Promise<string[]>} Law IDs that implement open_terms of lawId
- */
-async function discoverImplementors(lawId, allLaws, fetchLawYaml) {
-  const candidates = allLaws.filter((entry) => entry.law_id !== lawId);
-
-  // Fetch all candidate laws in parallel (batched)
-  const BATCH_SIZE = 10;
-  const implementors = [];
-
-  for (let i = 0; i < candidates.length; i += BATCH_SIZE) {
-    const batch = candidates.slice(i, i + BATCH_SIZE);
-    const results = await Promise.allSettled(
-      batch.map(async (entry) => {
-        let text;
-        try {
-          text = await fetchLawYaml(entry.law_id);
-        } catch {
-          return null;
-        }
-        const law = yaml.load(text);
-
-        for (const article of law.articles || []) {
-          const impls = article.machine_readable?.implements || [];
-          for (const impl of impls) {
-            if (impl.law === lawId) {
-              return law.$id || entry.law_id;
-            }
-          }
-        }
-        return null;
-      }),
-    );
-
-    for (const result of results) {
-      if (result.status === 'fulfilled' && result.value) {
-        implementors.push(result.value);
-      }
-    }
-  }
-
-  return implementors;
 }
 
 /**
@@ -116,27 +70,27 @@ export function useDependencies() {
       // Phase 1: Collect all transitive regulation references
       collectDeps(mainLaw, visited, toLoad);
 
-      // Phase 2: Discover implementing regulations
-      try {
-        const corpusRes = await fetch(lawsListUrl(trajectRef, 'limit=1000'));
-        if (corpusRes.ok) {
-          const allLaws = await corpusRes.json();
-
-          // Check for implementors of the main law
-          const implementors = await discoverImplementors(
-            mainLaw.$id,
-            allLaws,
-            fetchLawYaml,
-          );
-          for (const implId of implementors) {
-            if (!visited.has(implId)) {
-              visited.add(implId);
-              toLoad.push(implId);
+      // Phase 2: Discover implementing regulations (IoC reverse link).
+      // The backend scans the in-memory corpus and returns just the
+      // implementing law ids, so this is a single request — not a
+      // fetch-and-parse of every law in the (possibly federated, hundreds
+      // strong) corpus. Best-effort: a failure here only means implementing
+      // regulations aren't auto-loaded, the rest of the scan still runs.
+      if (mainLaw.$id) {
+        try {
+          const res = await fetch(implementorsUrl(trajectRef, mainLaw.$id));
+          if (res.ok) {
+            const implementors = await res.json();
+            for (const implId of implementors) {
+              if (!visited.has(implId)) {
+                visited.add(implId);
+                toLoad.push(implId);
+              }
             }
           }
+        } catch {
+          // Implementor discovery is best-effort.
         }
-      } catch {
-        // Corpus scan is best-effort
       }
 
       // Phase 3: Load all collected dependencies

--- a/frontend/src/composables/useDependencies.js
+++ b/frontend/src/composables/useDependencies.js
@@ -3,9 +3,10 @@
  *
  * Parses a law's YAML structure to find all `source.regulation` references,
  * fetches each dependency via the API, loads it into the engine, and recurses.
- * Also pulls in implementing regulations (the IoC reverse link) via the
- * backend `implementors` endpoint, which scans the in-memory corpus
- * server-side — one request instead of fetching and parsing every law.
+ * Implementing regulations (the IoC reverse link) are loaded separately via
+ * `loadImplementors`, which calls the backend `implementors` endpoint — kept
+ * OFF the critical path because that corpus scan can be slow on a large
+ * federated corpus and scenarios already declare the regulations they need.
  */
 import { ref } from 'vue';
 import yaml from 'js-yaml';
@@ -46,54 +47,41 @@ export function useDependencies() {
   const error = ref(null);
   const { requestHarvestBatch } = useBwbHarvest();
 
+  // Guards `loadImplementors` so a re-render / re-trigger of the scenario
+  // panel doesn't restart the corpus-wide implementor scan for a law it
+  // already scanned. Keyed on `{trajectRef}::{lawId}`.
+  let implementorsKey = null;
+
   /**
-   * Load all dependencies for a law, recursively.
+   * Load a law's direct + transitive `source.regulation` dependencies into
+   * the engine. Returns the law's `$id` (or null) so the caller can kick off
+   * the off-critical-path `loadImplementors` scan.
+   *
+   * `fetchLawYaml` already resolves through the active traject, so no traject
+   * ref is needed here.
    *
    * @param {string} lawYamlText - Raw YAML text of the main law
    * @param {object} engine - WasmEngine instance
    * @param {(lawId: string) => Promise<string>} fetchLawYaml - Fetch law YAML by ID
-   * @param {string|null} trajectRef - Active traject reference. Drives
-   *   which corpus list is scanned for implementing regulations so
-   *   in-progress trajects pick up their own implementors.
+   * @returns {Promise<string|null>} The main law's `$id`.
    */
-  async function loadAllDependencies(lawYamlText, engine, fetchLawYaml, trajectRef = null) {
+  async function loadAllDependencies(lawYamlText, engine, fetchLawYaml) {
     loading.value = true;
     error.value = null;
     loadedDeps.value = [];
     progress.value = 'Afhankelijkheden analyseren...';
 
+    let mainLawId = null;
     try {
       const mainLaw = yaml.load(lawYamlText);
+      mainLawId = mainLaw.$id || null;
       const visited = new Set();
       const toLoad = [];
 
       // Phase 1: Collect all transitive regulation references
       collectDeps(mainLaw, visited, toLoad);
 
-      // Phase 2: Discover implementing regulations (IoC reverse link).
-      // The backend scans the in-memory corpus and returns just the
-      // implementing law ids, so this is a single request — not a
-      // fetch-and-parse of every law in the (possibly federated, hundreds
-      // strong) corpus. Best-effort: a failure here only means implementing
-      // regulations aren't auto-loaded, the rest of the scan still runs.
-      if (mainLaw.$id) {
-        try {
-          const res = await fetch(implementorsUrl(trajectRef, mainLaw.$id));
-          if (res.ok) {
-            const implementors = await res.json();
-            for (const implId of implementors) {
-              if (!visited.has(implId)) {
-                visited.add(implId);
-                toLoad.push(implId);
-              }
-            }
-          }
-        } catch {
-          // Implementor discovery is best-effort.
-        }
-      }
-
-      // Phase 3: Load all collected dependencies
+      // Phase 2: Load all collected dependencies
       let total = toLoad.length;
       let loaded = 0;
       const missingDeps = [];
@@ -150,9 +138,51 @@ export function useDependencies() {
     } finally {
       loading.value = false;
     }
+    return mainLawId;
   }
 
-  return { loading, loadedDeps, progress, error, loadAllDependencies };
+  /**
+   * Load implementing regulations (the IoC reverse link) into the engine.
+   *
+   * Deliberately OFF the critical path: the backend implementors scan can be
+   * slow on a large federated corpus, and scenarios declare the regulations
+   * they need explicitly (their `Given law "x" is loaded` background), so the
+   * scenario panel must not block on this. The caller fires it without
+   * awaiting, after the panel is already usable. Runs at most once per
+   * `(trajectRef, lawId)` so re-renders don't restart the scan.
+   *
+   * @param {string|null} lawId - The `$id` of the law to find implementors of.
+   * @param {object} engine - WasmEngine instance.
+   * @param {(lawId: string) => Promise<string>} fetchLawYaml - Fetch law YAML.
+   * @param {string|null} trajectRef - Active traject reference.
+   */
+  async function loadImplementors(lawId, engine, fetchLawYaml, trajectRef = null) {
+    if (!lawId) return;
+    const key = `${trajectRef || ''}::${lawId}`;
+    if (implementorsKey === key) return;
+    implementorsKey = key;
+    try {
+      const res = await fetch(implementorsUrl(trajectRef, lawId));
+      if (!res.ok) return;
+      const implementors = await res.json();
+      for (const implId of implementors) {
+        try {
+          if (!engine.hasLaw(implId)) {
+            const yamlText = await fetchLawYaml(implId);
+            engine.loadLaw(yamlText);
+            loadedDeps.value = [...loadedDeps.value, implId];
+          }
+        } catch (e) {
+          console.warn(`Failed to load implementing regulation '${implId}':`, e);
+        }
+      }
+    } catch {
+      // Best-effort: if the scan fails, explicitly-declared deps still cover
+      // the common case.
+    }
+  }
+
+  return { loading, loadedDeps, progress, error, loadAllDependencies, loadImplementors };
 }
 
 /**

--- a/frontend/src/composables/useDependencies.test.js
+++ b/frontend/src/composables/useDependencies.test.js
@@ -26,7 +26,7 @@ articles:
     machine_readable:
       execution:
         input:
-          - name: standaardpremie
+          - name: dekking
             source:
               regulation: zorgverzekeringswet
               output: dekking
@@ -44,8 +44,7 @@ beforeEach(() => {
 
 describe('extractRegulationRefs', () => {
   it('collects source.regulation refs and skips self-references', () => {
-    const law = yamlMain();
-    expect(extractRegulationRefs(law)).toEqual(['zorgverzekeringswet']);
+    expect(extractRegulationRefs(yamlMain())).toEqual(['zorgverzekeringswet']);
   });
   it('returns [] for a law with no machine_readable inputs', () => {
     expect(extractRegulationRefs({ $id: 'x', articles: [{ number: '1' }] })).toEqual([]);
@@ -53,51 +52,69 @@ describe('extractRegulationRefs', () => {
 });
 
 describe('useDependencies.loadAllDependencies', () => {
-  it('resolves implementors via a single implementors request (no per-law corpus scan)', async () => {
+  it('loads source.regulation deps, returns the $id, and does NOT scan the corpus', async () => {
+    // The implementor scan is off the critical path, so loading the law's own
+    // deps must make no network call at all (only fetchLawYaml is used).
+    const fetchSpy = vi.fn();
+    globalThis.fetch = fetchSpy;
+    const engine = fakeEngine();
+    const fetchLawYaml = vi.fn(async (id) => DEP_YAML[id]);
+
+    const { loadAllDependencies, loading } = useDependencies();
+    const mainLawId = await loadAllDependencies(MAIN_LAW, engine, fetchLawYaml);
+
+    expect(mainLawId).toBe('zorgtoeslagwet');
+    expect(engine.loaded.has('zorgverzekeringswet')).toBe(true);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(loading.value).toBe(false);
+  });
+});
+
+describe('useDependencies.loadImplementors', () => {
+  it('resolves implementors with a single request and loads them', async () => {
     const fetchSpy = vi.fn().mockImplementation(async (url) => {
       if (url.endsWith('/implementors')) return res(['regeling_standaardpremie']);
       return res([], false, 404);
     });
     globalThis.fetch = fetchSpy;
-
     const engine = fakeEngine();
     const fetchLawYaml = vi.fn(async (id) => DEP_YAML[id]);
 
-    const { loading, loadedDeps, loadAllDependencies } = useDependencies();
-    await loadAllDependencies(MAIN_LAW, engine, fetchLawYaml, 'mig-1a2b3c4d');
+    const { loadImplementors } = useDependencies();
+    await loadImplementors('zorgtoeslagwet', engine, fetchLawYaml, 'mig-1a2b3c4d');
 
-    // Exactly one network request, and it's the implementors endpoint for the
-    // main law under the active traject — NOT a `?limit=1000` corpus listing.
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(fetchSpy.mock.calls[0][0]).toBe(
       '/api/trajects/mig-1a2b3c4d/corpus/laws/zorgtoeslagwet/implementors',
     );
     expect(fetchSpy.mock.calls.some((c) => String(c[0]).includes('limit=1000'))).toBe(false);
-
-    // Both the source.regulation dep and the implementor are loaded.
-    expect(engine.loaded.has('zorgverzekeringswet')).toBe(true);
     expect(engine.loaded.has('regeling_standaardpremie')).toBe(true);
-    expect(loadedDeps.value).toContain('zorgverzekeringswet');
-    expect(loadedDeps.value).toContain('regeling_standaardpremie');
-    expect(loading.value).toBe(false);
   });
 
-  it('treats implementor-discovery failure as best-effort', async () => {
-    globalThis.fetch = vi.fn().mockResolvedValue(res(null, false, 500));
+  it('runs at most once per (trajectRef, lawId)', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(res(['regeling_standaardpremie']));
+    globalThis.fetch = fetchSpy;
     const engine = fakeEngine();
     const fetchLawYaml = vi.fn(async (id) => DEP_YAML[id]);
 
-    const { error, loadAllDependencies } = useDependencies();
-    await loadAllDependencies(MAIN_LAW, engine, fetchLawYaml, null);
+    const { loadImplementors } = useDependencies();
+    await loadImplementors('zorgtoeslagwet', engine, fetchLawYaml, 'mig-1a2b3c4d');
+    await loadImplementors('zorgtoeslagwet', engine, fetchLawYaml, 'mig-1a2b3c4d');
 
-    // The source.regulation dep still loads; the failed implementors call
-    // does not surface as an error.
-    expect(engine.loaded.has('zorgverzekeringswet')).toBe(true);
-    expect(error.value).toBe(null);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('is best-effort: a failed scan resolves without throwing', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(res(null, false, 500));
+    const engine = fakeEngine();
+    const { loadImplementors } = useDependencies();
+    await expect(
+      loadImplementors('zorgtoeslagwet', engine, vi.fn(), null),
+    ).resolves.toBeUndefined();
   });
 });
 
-// Parse MAIN_LAW once for the pure-function test.
+// Parsed equivalent of MAIN_LAW (plus a self-reference) for the pure test.
 function yamlMain() {
   return {
     $id: 'zorgtoeslagwet',
@@ -107,7 +124,7 @@ function yamlMain() {
         machine_readable: {
           execution: {
             input: [
-              { name: 'standaardpremie', source: { regulation: 'zorgverzekeringswet', output: 'dekking' } },
+              { name: 'dekking', source: { regulation: 'zorgverzekeringswet', output: 'dekking' } },
               { name: 'self', source: { regulation: 'zorgtoeslagwet', output: 'x' } },
             ],
           },

--- a/frontend/src/composables/useDependencies.test.js
+++ b/frontend/src/composables/useDependencies.test.js
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useDependencies, extractRegulationRefs } from './useDependencies.js';
+
+// Minimal Response-like stub.
+function res(json, ok = true, status = 200) {
+  return { ok, status, async json() { return json; }, async text() { return ''; } };
+}
+
+// Fake WASM engine: tracks which laws were loaded.
+function fakeEngine() {
+  const loaded = new Set();
+  return {
+    loaded,
+    hasLaw: (id) => loaded.has(id),
+    loadLaw: (yamlText) => {
+      const m = yamlText.match(/\$id:\s*(\S+)/);
+      if (m) loaded.add(m[1]);
+    },
+  };
+}
+
+const MAIN_LAW = `\
+$id: zorgtoeslagwet
+articles:
+  - number: '2'
+    machine_readable:
+      execution:
+        input:
+          - name: standaardpremie
+            source:
+              regulation: zorgverzekeringswet
+              output: dekking
+`;
+
+// Dependency YAMLs with no further refs, so the walk terminates.
+const DEP_YAML = {
+  zorgverzekeringswet: '$id: zorgverzekeringswet\narticles: []\n',
+  regeling_standaardpremie: '$id: regeling_standaardpremie\narticles: []\n',
+};
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('extractRegulationRefs', () => {
+  it('collects source.regulation refs and skips self-references', () => {
+    const law = yamlMain();
+    expect(extractRegulationRefs(law)).toEqual(['zorgverzekeringswet']);
+  });
+  it('returns [] for a law with no machine_readable inputs', () => {
+    expect(extractRegulationRefs({ $id: 'x', articles: [{ number: '1' }] })).toEqual([]);
+  });
+});
+
+describe('useDependencies.loadAllDependencies', () => {
+  it('resolves implementors via a single implementors request (no per-law corpus scan)', async () => {
+    const fetchSpy = vi.fn().mockImplementation(async (url) => {
+      if (url.endsWith('/implementors')) return res(['regeling_standaardpremie']);
+      return res([], false, 404);
+    });
+    globalThis.fetch = fetchSpy;
+
+    const engine = fakeEngine();
+    const fetchLawYaml = vi.fn(async (id) => DEP_YAML[id]);
+
+    const { loading, loadedDeps, loadAllDependencies } = useDependencies();
+    await loadAllDependencies(MAIN_LAW, engine, fetchLawYaml, 'mig-1a2b3c4d');
+
+    // Exactly one network request, and it's the implementors endpoint for the
+    // main law under the active traject — NOT a `?limit=1000` corpus listing.
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0][0]).toBe(
+      '/api/trajects/mig-1a2b3c4d/corpus/laws/zorgtoeslagwet/implementors',
+    );
+    expect(fetchSpy.mock.calls.some((c) => String(c[0]).includes('limit=1000'))).toBe(false);
+
+    // Both the source.regulation dep and the implementor are loaded.
+    expect(engine.loaded.has('zorgverzekeringswet')).toBe(true);
+    expect(engine.loaded.has('regeling_standaardpremie')).toBe(true);
+    expect(loadedDeps.value).toContain('zorgverzekeringswet');
+    expect(loadedDeps.value).toContain('regeling_standaardpremie');
+    expect(loading.value).toBe(false);
+  });
+
+  it('treats implementor-discovery failure as best-effort', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(res(null, false, 500));
+    const engine = fakeEngine();
+    const fetchLawYaml = vi.fn(async (id) => DEP_YAML[id]);
+
+    const { error, loadAllDependencies } = useDependencies();
+    await loadAllDependencies(MAIN_LAW, engine, fetchLawYaml, null);
+
+    // The source.regulation dep still loads; the failed implementors call
+    // does not surface as an error.
+    expect(engine.loaded.has('zorgverzekeringswet')).toBe(true);
+    expect(error.value).toBe(null);
+  });
+});
+
+// Parse MAIN_LAW once for the pure-function test.
+function yamlMain() {
+  return {
+    $id: 'zorgtoeslagwet',
+    articles: [
+      {
+        number: '2',
+        machine_readable: {
+          execution: {
+            input: [
+              { name: 'standaardpremie', source: { regulation: 'zorgverzekeringswet', output: 'dekking' } },
+              { name: 'self', source: { regulation: 'zorgtoeslagwet', output: 'x' } },
+            ],
+          },
+        },
+      },
+    ],
+  };
+}

--- a/frontend/src/composables/useDependencies.test.js
+++ b/frontend/src/composables/useDependencies.test.js
@@ -104,13 +104,18 @@ describe('useDependencies.loadImplementors', () => {
     expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('is best-effort: a failed scan resolves without throwing', async () => {
-    globalThis.fetch = vi.fn().mockResolvedValue(res(null, false, 500));
+  it('is best-effort: a failed scan resolves without throwing and can be retried', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(res(null, false, 500));
+    globalThis.fetch = fetchSpy;
     const engine = fakeEngine();
     const { loadImplementors } = useDependencies();
     await expect(
       loadImplementors('zorgtoeslagwet', engine, vi.fn(), null),
     ).resolves.toBeUndefined();
+    // A transient failure must not permanently suppress the scan: a second
+    // call retries (the guard key was reset on failure).
+    await loadImplementors('zorgtoeslagwet', engine, vi.fn(), null);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/packages/corpus/src/source_map.rs
+++ b/packages/corpus/src/source_map.rs
@@ -537,6 +537,18 @@ struct LawArticle {
 struct LawMr {
     #[serde(default)]
     execution: Option<LawExec>,
+    #[serde(default)]
+    implements: Vec<LawImplements>,
+}
+
+/// One `machine_readable.implements` entry — the IoC link from a lower
+/// regulation to the higher law whose `open_term` it fills. Only `law`
+/// (the higher law's `$id`) is needed to build the reverse "who implements
+/// me" lookup.
+#[derive(Deserialize, Default)]
+struct LawImplements {
+    #[serde(default)]
+    law: String,
 }
 
 #[derive(Deserialize, Default)]
@@ -673,6 +685,34 @@ pub fn collect_law_outputs(yaml: &str) -> Vec<CollectedOutput> {
 
     results.sort_by(|a, b| a.name.cmp(&b.name));
     results
+}
+
+/// Collect the `$id`s of the higher laws that this law's articles declare
+/// they `implements` (the IoC reverse link: a lower regulation filling a
+/// higher law's `open_term`). Each referenced law id appears at most once.
+///
+/// Used to answer "which laws implement law X" server-side, so the editor's
+/// scenario dependency loader doesn't have to fetch and parse every law in
+/// the corpus over HTTP just to find the handful of implementing regulations.
+pub fn collect_law_implements(yaml: &str) -> Vec<String> {
+    let doc: LawDoc = match serde_yaml_ng::from_str(yaml) {
+        Ok(d) => d,
+        Err(_) => return Vec::new(),
+    };
+
+    let mut seen = HashSet::new();
+    let mut out = Vec::new();
+    for article in &doc.articles {
+        let Some(mr) = &article.machine_readable else {
+            continue;
+        };
+        for decl in &mr.implements {
+            if !decl.law.is_empty() && seen.insert(decl.law.clone()) {
+                out.push(decl.law.clone());
+            }
+        }
+    }
+    out
 }
 
 #[cfg(test)]
@@ -1117,5 +1157,44 @@ articles:
         let yaml = "$id: test\narticles: []\n";
         let outputs = collect_law_outputs(yaml);
         assert!(outputs.is_empty());
+    }
+
+    #[test]
+    fn test_collect_law_implements() {
+        let yaml = "\
+$id: regeling_standaardpremie
+articles:
+  - number: '1'
+    machine_readable:
+      implements:
+        - law: zorgtoeslagwet
+          article: '4'
+          open_term: standaardpremie
+        - law: zorgtoeslagwet
+          article: '5'
+          open_term: iets_anders
+  - number: '2'
+    machine_readable:
+      implements:
+        - law: zorgverzekeringswet
+          article: '1'
+          open_term: dekking
+";
+        // Deduplicated across articles, preserves first-seen order.
+        assert_eq!(
+            collect_law_implements(yaml),
+            vec![
+                "zorgtoeslagwet".to_string(),
+                "zorgverzekeringswet".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn test_collect_law_implements_none() {
+        let yaml = "$id: x\narticles:\n  - number: '1'\n    machine_readable:\n      execution:\n        output: []\n";
+        assert!(collect_law_implements(yaml).is_empty());
+        // Malformed YAML is tolerated as "no implements".
+        assert!(collect_law_implements("not: [valid").is_empty());
     }
 }

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -18,7 +18,8 @@ use regelrecht_corpus::annotation_schema::{
 use regelrecht_corpus::backend::{EditorUser, PersistOutcome, RepoBackend, WriteContext};
 use regelrecht_corpus::dto::{build_source_summaries, PaginationParams, SourceSummary};
 use regelrecht_corpus::source_map::{
-    collect_law_outputs, extract_law_id, resolve_display_name, validate_yaml_syntax, LoadedLaw,
+    collect_law_implements, collect_law_outputs, extract_law_id, resolve_display_name,
+    validate_yaml_syntax, LoadedLaw,
 };
 use regelrecht_corpus::CorpusError;
 
@@ -407,6 +408,65 @@ async fn list_law_outputs_in_scope(
         .collect();
 
     Ok(Json(outputs))
+}
+
+/// GET /api/corpus/laws/{law_id}/implementors — law ids whose articles
+/// declare `implements` an `open_term` of `{law_id}` (the IoC reverse link).
+///
+/// Computed server-side over the already-in-memory corpus. This exists so
+/// the editor's scenario dependency loader can find implementing regulations
+/// with a single request instead of fetching and parsing every law in the
+/// corpus over HTTP — which, for a traject federating the full central
+/// corpus, was hundreds of round-trips per scenario-panel open.
+pub async fn list_law_implementors(
+    State(state): State<AppState>,
+    Path(law_id): Path<String>,
+) -> Result<Json<Vec<String>>, (StatusCode, String)> {
+    let scope = global_scope(&state).await;
+    Ok(Json(implementors_in_scope(&scope, &law_id).await))
+}
+
+/// GET /api/trajects/{traject_id}/corpus/laws/{law_id}/implementors — same
+/// as the global view but resolved through the traject's federated corpus.
+pub async fn list_traject_law_implementors(
+    State(state): State<AppState>,
+    session: Session,
+    Path((traject_ref, law_id)): Path<(String, String)>,
+) -> Result<Json<Vec<String>>, (StatusCode, String)> {
+    let scope = require_traject_scope(&state, &session, &traject_ref).await?;
+    Ok(Json(implementors_in_scope(&scope, &law_id).await))
+}
+
+async fn implementors_in_scope(scope: &ReadScope, law_id: &str) -> Vec<String> {
+    // The snapshot always carries the full federated law *list* (only bodies
+    // are lazy), so collect candidate ids first, then resolve each body.
+    let candidates: Vec<String> = scope
+        .corpus()
+        .source_map
+        .laws()
+        .map(|law| law.law_id.clone())
+        .filter(|id| id != law_id)
+        .collect();
+
+    let mut out = Vec::new();
+    for id in candidates {
+        // Resolve the body through the scope, NOT `LoadedLaw::yaml_content`
+        // directly: in a traject the federated central laws are metadata-only
+        // until first read, so the snapshot body is empty for them. `law_yaml`
+        // lazily fetches (and caches) the body and applies the read-your-writes
+        // overlay. A miss or fetch error just means this law can't be checked,
+        // so it's skipped rather than failing the whole scan.
+        if let Ok(Some(yaml)) = scope.law_yaml(&id).await {
+            if collect_law_implements(&yaml)
+                .iter()
+                .any(|implemented| implemented == law_id)
+            {
+                out.push(id);
+            }
+        }
+    }
+    out.sort();
+    out
 }
 
 /// A scenario file entry.

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -140,6 +140,10 @@ async fn main() {
             get(corpus_handlers::list_law_outputs),
         )
         .route(
+            "/api/corpus/laws/{law_id}/implementors",
+            get(corpus_handlers::list_law_implementors),
+        )
+        .route(
             "/api/corpus/laws/{law_id}/scenarios",
             get(corpus_handlers::list_scenarios),
         )
@@ -268,6 +272,10 @@ async fn main() {
         .route(
             "/api/trajects/{traject_ref}/corpus/laws/{law_id}/outputs",
             get(corpus_handlers::list_traject_law_outputs),
+        )
+        .route(
+            "/api/trajects/{traject_ref}/corpus/laws/{law_id}/implementors",
+            get(corpus_handlers::list_traject_law_implementors),
         )
         .route(
             "/api/trajects/{traject_ref}/corpus/laws/{law_id}/scenarios",


### PR DESCRIPTION
## Problem

The editor's scenario panel hung on **"Afhankelijkheden laden"** and the **Resultaat / Graaf** buttons stayed greyed out (not clickable). Reproduced on a traject pointing at a private corpus repo (zorgtoeslagwet, art. 2):

Opening the panel for **one** law fired **~1016 requests** and never settled:
- **258 unique laws** fetched — the traject federates the whole central corpus, and the client-side `discoverImplementors` fetched+parsed *every* law YAML over HTTP to find implementing regulations.
- **~4× per law** — the `ScenarioBuilder` deps watch re-fired on load (`lawYaml`/`ready`/`formState` settle on separate ticks), restarting the whole scan before it could finish, so `depsReady` never became true.
- The backend (GitHub-backed, rate-limited) returned some **502s** under the load.
- With `depsReady` never true, scenarios never auto-executed → no cached result → the **Resultaat/Graaf buttons were `:disabled`**, which also contradicts `onShowDetails`'s own "don't be a dead gate" design.

## Fix

- **Server-side implementors endpoint (B).** New `GET /api/corpus/laws/{id}/implementors` (+ traject variant) scans the in-memory corpus for laws whose `machine_readable.implements` references `{id}`. Resolves each candidate body through the read scope so a traject's lazily-indexed federated laws are fetched + cached (not read as empty snapshot bodies). The editor now makes **one** request instead of fetching every law.
- **Debounced deps cascade (C).** `ScenarioBuilder`'s dependency watch coalesces the load-time burst into a single run, so the scan isn't started-and-abandoned 4×.
- **Un-gated buttons (A).** Removed `:disabled` on Resultaat/Graaf — `onShowDetails` already opens the sheet and lets it handle loading/empty/reload, so the user can always open the trace/graph.

## Verification

- Backend unit tests for `collect_law_implements` (parsing + dedup + malformed-tolerance).
- Live on a local stack: `GET /api/corpus/laws/zorgtoeslagwet/implementors` → `["regeling_standaardpremie"]`; `kieswet/implementors` → `[]`.
- Frontend: new `useDependencies.test.js` asserts a single implementors request (no `?limit=1000` corpus scan) and that implementor + source.regulation deps load; full suite green (266).
- End-to-end on the PR preview against the reproduction traject is the final check (see Test plan).

## Test plan

- [ ] On the preview, open a traject (custom repo) → zorgtoeslagwet art. 2 → Scenario's: panel loads quickly (no perpetual "Afhankelijkheden laden"), and **Resultaat/Graaf are clickable**.
- [ ] Network shows a single `/implementors` call, not a per-law storm.

## Notes / follow-ups

- A backend integration test for the traject lazy-load path (metadata-only entries) isn't included — it needs a constructed traject scope; covered for now by the unit test + live preview verification.
- The global `implementors` endpoint reads bodies via the scope too; global non-loaded GitHub laws (favorites-only init) could still be missed, same root cause, lower impact (local corpus is body-loaded). Follow-up: a build-time `implements` index would make this O(1) and fully eager.