### PR TITLE
fix(pipeline): reap zombie git children and add resource-exhaustion breaker

### DIFF
--- a/packages/pipeline/Dockerfile.enrich-worker
+++ b/packages/pipeline/Dockerfile.enrich-worker
@@ -45,8 +45,12 @@ RUN find . -name '*.rs' -exec touch {} + && \
     cargo build --release --bin regelrecht-enrich-worker
 
 # Stage 4: Runtime
+# tini runs as PID 1 so reparented subprocesses are reaped instead of leaking as
+# zombies. The enrich worker kills the LLM CLI (claude/opencode) on timeout,
+# which orphans its child processes — without an init those accumulate against
+# the container's low pids limit and eventually cause fork()/EAGAIN failures.
 FROM alpine:3.23@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
-RUN apk add --no-cache ca-certificates git nodejs npm && \
+RUN apk add --no-cache ca-certificates git nodejs npm tini && \
     addgroup -S app && adduser -S app -G app
 
 # Install opencode and claude CLI globally (pinned versions for reproducibility)
@@ -79,4 +83,4 @@ EXPOSE 8000
 ENV REGULATION_REPO_PATH=/tmp/regulation-repo
 ENV REGULATION_OUTPUT_BASE=regulation/nl
 
-ENTRYPOINT ["entrypoint-enrich.sh"]
+ENTRYPOINT ["/sbin/tini", "--", "entrypoint-enrich.sh"]

--- a/packages/pipeline/Dockerfile.harvester-worker
+++ b/packages/pipeline/Dockerfile.harvester-worker
@@ -45,8 +45,13 @@ RUN find . -name '*.rs' -exec touch {} + && \
     cargo build --release --bin regelrecht-harvest-worker
 
 # Stage 4: Runtime
+# tini runs as PID 1 so reparented git grandchildren (merge-base,
+# git-remote-https, the askpass helper) get reaped instead of piling up as
+# zombies against the container's low pids limit — the accumulation that wedges
+# the worker into a "cannot fork() / Resource temporarily unavailable" loop on
+# long harvest runs.
 FROM alpine:3.23@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
-RUN apk add --no-cache ca-certificates git && \
+RUN apk add --no-cache ca-certificates git tini && \
     addgroup -S app && adduser -S app -G app
 
 COPY --from=builder /build/target/release/regelrecht-harvest-worker /usr/local/bin/
@@ -59,4 +64,4 @@ EXPOSE 8000
 ENV REGULATION_REPO_PATH=/tmp/regulation-repo
 ENV REGULATION_OUTPUT_BASE=regulation/nl
 
-ENTRYPOINT ["entrypoint.sh"]
+ENTRYPOINT ["/sbin/tini", "--", "entrypoint.sh"]

--- a/packages/pipeline/src/config.rs
+++ b/packages/pipeline/src/config.rs
@@ -72,6 +72,12 @@ pub struct WorkerConfig {
     /// Number of consecutive failures before a law is marked as exhausted.
     /// Default: 10. Configurable via `EXHAUSTED_THRESHOLD`.
     pub exhausted_threshold: i32,
+    /// Number of consecutive *resource-exhaustion* failures (fork()/EAGAIN/OOM)
+    /// before the worker exits so the orchestrator restarts it with a clean
+    /// process table. These faults are environmental and only clear on restart,
+    /// so retrying in-process just burns job retry budget in a tight loop.
+    /// Default: 5. Configurable via `WORKER_MAX_CONSECUTIVE_RESOURCE_FAILURES`.
+    pub max_consecutive_resource_failures: u32,
 }
 
 impl std::fmt::Debug for WorkerConfig {
@@ -87,6 +93,10 @@ impl std::fmt::Debug for WorkerConfig {
             .field("job_timeout", &self.job_timeout)
             .field("orphan_timeout", &self.orphan_timeout)
             .field("exhausted_threshold", &self.exhausted_threshold)
+            .field(
+                "max_consecutive_resource_failures",
+                &self.max_consecutive_resource_failures,
+            )
             .finish()
     }
 }
@@ -131,6 +141,13 @@ impl WorkerConfig {
             .unwrap_or(10)
             .max(1);
 
+        let max_consecutive_resource_failures: u32 =
+            std::env::var("WORKER_MAX_CONSECUTIVE_RESOURCE_FAILURES")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(5)
+                .max(1);
+
         Ok(Self {
             database_url,
             max_connections,
@@ -142,6 +159,7 @@ impl WorkerConfig {
             job_timeout: Duration::from_secs(job_timeout_secs),
             orphan_timeout: Duration::from_secs(orphan_timeout_secs),
             exhausted_threshold,
+            max_consecutive_resource_failures,
         })
     }
 

--- a/packages/pipeline/src/worker.rs
+++ b/packages/pipeline/src/worker.rs
@@ -468,7 +468,16 @@ async fn process_next_job(
             );
 
             let error_json = serde_json::json!({ "error": e.to_string() });
-            let failed_job = job_queue::fail_job(pool, job.id, Some(error_json)).await?;
+            // Don't `?` here: a failure while recording the failure must still
+            // report `outcome` so the breaker counts a resource-exhaustion fault
+            // (matches how the enrich paths handle fail_job errors).
+            let failed_job = match job_queue::fail_job(pool, job.id, Some(error_json)).await {
+                Ok(j) => j,
+                Err(fail_err) => {
+                    tracing::error!(job_id = %job.id, error = %fail_err, "failed to mark harvest job as failed");
+                    return Ok(outcome);
+                }
+            };
 
             // Only mark law as failed when retries are exhausted
             if failed_job.status == crate::models::JobStatus::Failed {

--- a/packages/pipeline/src/worker.rs
+++ b/packages/pipeline/src/worker.rs
@@ -18,6 +18,58 @@ use crate::job_queue::{self, CreateJobRequest};
 use crate::law_status;
 use crate::models::{JobType, LawStatusValue, Priority};
 
+/// Outcome of attempting to process a single job, used to drive the
+/// resource-exhaustion circuit breaker in the worker loops.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum JobOutcome {
+    /// A job was claimed and handled — either completed, or failed for a
+    /// reason specific to that job/law (bad data, LLM error, etc.).
+    Processed,
+    /// No job was available to claim.
+    Idle,
+    /// The job failed because the container ran out of the OS resources needed
+    /// to spawn processes/threads (fork() EAGAIN / OOM). This is environmental,
+    /// not the job's fault, and only clears on restart. The job is failed and
+    /// requeued through the normal failure path (so its law status is reset and
+    /// it isn't left dangling); the loop additionally counts these and exits the
+    /// process once too many happen in a row, so the orchestrator restarts the
+    /// worker with a clean process table.
+    ResourceExhausted,
+}
+
+/// Map a job error to the [`JobOutcome`] reported after normal failure handling:
+/// `ResourceExhausted` for environmental fork()/EAGAIN/OOM faults (drives the
+/// breaker), `Processed` for ordinary per-law failures.
+fn outcome_for_error(err: &str) -> JobOutcome {
+    if is_resource_exhaustion(err) {
+        JobOutcome::ResourceExhausted
+    } else {
+        JobOutcome::Processed
+    }
+}
+
+/// Returns true when an error indicates the container has exhausted the OS
+/// resources needed to spawn processes or threads — `fork()` returning EAGAIN
+/// ("cannot fork() ... Resource temporarily unavailable"), thread-create
+/// failures, or OOM. These faults are environmental: a long-running worker can
+/// accumulate them (e.g. un-reaped child processes against a low pids limit)
+/// and they only clear when the process restarts. Distinguishing them from
+/// per-law failures lets the worker bail out for a restart instead of
+/// fast-failing every queued job in a tight loop.
+fn is_resource_exhaustion(err: &str) -> bool {
+    let e = err.to_ascii_lowercase();
+    const MARKERS: &[&str] = &[
+        "cannot fork",
+        "resource temporarily unavailable", // EAGAIN, human-readable form
+        "os error 11",                      // EAGAIN
+        "cannot allocate memory",
+        "os error 12", // ENOMEM
+        "unable to create thread",
+        "event loop thread panicked",
+    ];
+    MARKERS.iter().any(|m| e.contains(m))
+}
+
 /// Run the harvest worker loop.
 ///
 /// Polls the job queue for harvest jobs and executes them.
@@ -61,6 +113,7 @@ pub async fn run_harvest_worker(config: WorkerConfig) -> Result<()> {
     })?;
 
     let mut current_interval = std::time::Duration::ZERO; // poll immediately on startup
+    let mut consecutive_resource_failures: u32 = 0;
 
     loop {
         // Check for shutdown signals between jobs
@@ -87,14 +140,24 @@ pub async fn run_harvest_worker(config: WorkerConfig) -> Result<()> {
 
         // Process job outside of select! — runs to completion without cancellation
         match process_next_job(&pool, &config, &output_dir, corpus.as_ref(), &http_client).await {
-            Ok(true) => {
+            Ok(JobOutcome::Processed) => {
+                consecutive_resource_failures = 0;
                 current_interval = config.poll_interval;
             }
-            Ok(false) => {
+            Ok(JobOutcome::Idle) => {
+                consecutive_resource_failures = 0;
                 current_interval = (current_interval * 2)
                     .max(config.poll_interval)
                     .min(config.max_poll_interval);
                 tracing::info!(next_poll = ?current_interval, "no jobs available, backing off");
+            }
+            Ok(JobOutcome::ResourceExhausted) => {
+                handle_resource_exhaustion(
+                    &mut consecutive_resource_failures,
+                    config.max_consecutive_resource_failures,
+                    "harvest",
+                );
+                current_interval = config.poll_interval;
             }
             Err(e) => {
                 tracing::error!(error = %e, "error processing job");
@@ -108,19 +171,44 @@ pub async fn run_harvest_worker(config: WorkerConfig) -> Result<()> {
     Ok(())
 }
 
+/// Increment the consecutive resource-exhaustion counter and, once it crosses
+/// the configured threshold, exit the process so the orchestrator (RIG) restarts
+/// the worker with a fresh process table. fork()/EAGAIN faults are environmental
+/// and only clear on restart, so bailing out beats fast-failing the whole queue.
+fn handle_resource_exhaustion(counter: &mut u32, threshold: u32, worker: &str) {
+    *counter += 1;
+    tracing::error!(
+        worker,
+        consecutive = *counter,
+        threshold,
+        "resource exhaustion (cannot fork / EAGAIN) while processing job"
+    );
+    if *counter >= threshold {
+        tracing::error!(
+            worker,
+            threshold,
+            "resource-exhaustion breaker tripped; exiting so the orchestrator \
+             restarts the worker with a clean process table"
+        );
+        std::process::exit(1);
+    }
+}
+
 /// Process the next available harvest job.
 ///
-/// Returns `Ok(true)` if a job was processed, `Ok(false)` if no job was available.
+/// Returns the [`JobOutcome`]: `Processed` when a job was handled, `Idle` when
+/// none was available, or `ResourceExhausted` when the job failed because the
+/// container could not spawn processes/threads (fork()/EAGAIN).
 async fn process_next_job(
     pool: &PgPool,
     config: &WorkerConfig,
     output_dir: &Path,
     corpus: Option<&CorpusClient>,
     http_client: &Client,
-) -> Result<bool> {
+) -> Result<JobOutcome> {
     let job = match job_queue::claim_job(pool, Some(JobType::Harvest)).await? {
         Some(job) => job,
-        None => return Ok(false),
+        None => return Ok(JobOutcome::Idle),
     };
 
     tracing::info!(
@@ -141,7 +229,7 @@ async fn process_next_job(
                 if let Err(fail_err) = job_queue::fail_job(pool, job.id, Some(error_json)).await {
                     tracing::error!(job_id = %job.id, error = %fail_err, "failed to mark job as failed");
                 }
-                return Ok(true);
+                return Ok(JobOutcome::Processed);
             }
         },
         None => {
@@ -361,9 +449,17 @@ async fn process_next_job(
                 );
             }
 
-            Ok(true)
+            Ok(JobOutcome::Processed)
         }
         Err(e) => {
+            // Container resource exhaustion (fork()/EAGAIN) is environmental, not
+            // the law's fault, but the attempt was already spent at claim time, so
+            // we still run the normal failure/requeue path (which resets law
+            // status). We additionally report it via the outcome so the loop's
+            // breaker can exit the worker for a clean restart — the only thing
+            // that actually clears the condition.
+            let outcome = outcome_for_error(&e.to_string());
+
             tracing::error!(
                 job_id = %job.id,
                 law_id = %job.law_id,
@@ -454,7 +550,7 @@ async fn process_next_job(
                 }
             }
 
-            Ok(true)
+            Ok(outcome)
         }
     }
 }
@@ -502,6 +598,7 @@ pub async fn run_enrich_worker(config: WorkerConfig) -> Result<()> {
     })?;
 
     let mut current_interval = std::time::Duration::ZERO;
+    let mut consecutive_resource_failures: u32 = 0;
 
     loop {
         tokio::select! {
@@ -534,15 +631,25 @@ pub async fn run_enrich_worker(config: WorkerConfig) -> Result<()> {
         )
         .await
         {
-            Ok(true) => {
+            Ok(JobOutcome::Processed) => {
+                consecutive_resource_failures = 0;
                 // Use poll_interval (not zero) to avoid tight-looping reap_orphaned_jobs.
                 current_interval = config.poll_interval;
             }
-            Ok(false) => {
+            Ok(JobOutcome::Idle) => {
+                consecutive_resource_failures = 0;
                 current_interval = (current_interval * 2)
                     .max(config.poll_interval)
                     .min(config.max_poll_interval);
                 tracing::info!(next_poll = ?current_interval, "no enrich jobs available, backing off");
+            }
+            Ok(JobOutcome::ResourceExhausted) => {
+                handle_resource_exhaustion(
+                    &mut consecutive_resource_failures,
+                    config.max_consecutive_resource_failures,
+                    "enrich",
+                );
+                current_interval = config.poll_interval;
             }
             Err(e) => {
                 tracing::error!(error = %e, "error processing enrich job");
@@ -558,7 +665,9 @@ pub async fn run_enrich_worker(config: WorkerConfig) -> Result<()> {
 
 /// Process the next available enrich job.
 ///
-/// Returns `Ok(true)` if a job was processed, `Ok(false)` if no job was available.
+/// Returns the [`JobOutcome`]: `Processed` when a job was handled, `Idle` when
+/// none was available, or `ResourceExhausted` when the job failed because the
+/// container could not spawn processes/threads (fork()/EAGAIN).
 ///
 /// Each enrichment creates a separate branch (`enrich/{provider}`)
 /// so results can be reviewed before merging. A dedicated `CorpusClient` is
@@ -570,10 +679,10 @@ async fn process_next_enrich_job(
     corpus_config: Option<&CorpusConfig>,
     job_timeout: Duration,
     exhausted_threshold: i32,
-) -> Result<bool> {
+) -> Result<JobOutcome> {
     let job = match job_queue::claim_job(pool, Some(JobType::Enrich)).await? {
         Some(job) => job,
-        None => return Ok(false),
+        None => return Ok(JobOutcome::Idle),
     };
 
     let payload: EnrichPayload = match &job.payload {
@@ -586,7 +695,7 @@ async fn process_next_enrich_job(
                 if let Err(fail_err) = job_queue::fail_job(pool, job.id, Some(error_json)).await {
                     tracing::error!(job_id = %job.id, error = %fail_err, "failed to mark job as failed");
                 }
-                return Ok(true);
+                return Ok(JobOutcome::Processed);
             }
         },
         None => {
@@ -595,7 +704,7 @@ async fn process_next_enrich_job(
             if let Err(fail_err) = job_queue::fail_job(pool, job.id, Some(error_json)).await {
                 tracing::error!(job_id = %job.id, error = %fail_err, "failed to mark job as failed");
             }
-            return Ok(true);
+            return Ok(JobOutcome::Processed);
         }
     };
 
@@ -752,7 +861,7 @@ async fn process_next_enrich_job(
                 }
             }
 
-            Ok(true)
+            Ok(JobOutcome::Processed)
         }
         Ok(Ok((result, written_files))) => {
             tracing::info!(
@@ -798,6 +907,7 @@ async fn process_next_enrich_job(
 
             match commit_result {
                 Err(e) => {
+                    let outcome = outcome_for_error(&e.to_string());
                     tracing::error!(
                         job_id = %job.id,
                         error = %e,
@@ -843,6 +953,7 @@ async fn process_next_enrich_job(
                             tracing::error!(job_id = %job.id, error = %fail_err, "failed to mark job as failed");
                         }
                     }
+                    Ok(outcome)
                 }
                 Ok(()) => {
                     if let Err(e) =
@@ -866,12 +977,12 @@ async fn process_next_enrich_job(
                             "coverage score updated"
                         );
                     }
+                    Ok(JobOutcome::Processed)
                 }
             }
-
-            Ok(true)
         }
         Ok(Err(e)) => {
+            let outcome = outcome_for_error(&e.to_string());
             tracing::error!(
                 job_id = %job.id,
                 law_id = %job.law_id,
@@ -923,7 +1034,7 @@ async fn process_next_enrich_job(
                 }
             }
 
-            Ok(true)
+            Ok(outcome)
         }
     };
 
@@ -1092,5 +1203,61 @@ async fn handle_enrich_exhausted_or_retry(
         Err(e) => {
             tracing::warn!(error = %e, law_id = %law_id, "failed to increment enrich fail count");
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classifies_fork_eagain_errors_as_resource_exhaustion() {
+        // Real strings observed from failed harvest jobs.
+        assert!(is_resource_exhaustion(
+            "corpus error: git command failed: git pull failed: error: cannot fork() for \
+             merge-base: Resource temporarily unavailable"
+        ));
+        assert!(is_resource_exhaustion(
+            "corpus error: IO error: Resource temporarily unavailable (os error 11)"
+        ));
+        assert!(is_resource_exhaustion(
+            "task join error: task 5 panicked with message \"event loop thread panicked\""
+        ));
+        assert!(is_resource_exhaustion(
+            "Cannot allocate memory (os error 12)"
+        ));
+        assert!(is_resource_exhaustion(
+            "fatal: unable to create thread: Resource temporarily unavailable"
+        ));
+    }
+
+    #[test]
+    fn does_not_classify_per_law_failures_as_resource_exhaustion() {
+        // These are real per-law failures that must still burn the retry budget.
+        assert!(!is_resource_exhaustion(
+            "harvester error: Missing required XML element: _latestItem attribute in manifest"
+        ));
+        assert!(!is_resource_exhaustion(
+            "harvester error: CVDR SRU search failed for CVDR756485: No records found"
+        ));
+        assert!(!is_resource_exhaustion(
+            "enrichment error: claude exited with exit status: 1"
+        ));
+        assert!(!is_resource_exhaustion(
+            "enrichment error: opencode timed out after 600s"
+        ));
+        assert!(!is_resource_exhaustion(
+            "YAML error: did not find expected key at line 5 column 3"
+        ));
+    }
+
+    #[test]
+    fn handle_resource_exhaustion_increments_until_threshold() {
+        // Below the threshold it must not exit (test would abort if it did).
+        let mut counter = 0u32;
+        handle_resource_exhaustion(&mut counter, 3, "test");
+        assert_eq!(counter, 1);
+        handle_resource_exhaustion(&mut counter, 3, "test");
+        assert_eq!(counter, 2);
     }
 }

--- a/packages/pipeline/src/worker.rs
+++ b/packages/pipeline/src/worker.rs
@@ -470,7 +470,10 @@ async fn process_next_job(
             let error_json = serde_json::json!({ "error": e.to_string() });
             // Don't `?` here: a failure while recording the failure must still
             // report `outcome` so the breaker counts a resource-exhaustion fault
-            // (matches how the enrich paths handle fail_job errors).
+            // (matches how the enrich paths handle fail_job errors). For a
+            // non-resource error `outcome` is `Processed`, so the loop just moves
+            // on — a genuine DB outage resurfaces at the next claim_job and backs
+            // off there, so this can't tight-loop.
             let failed_job = match job_queue::fail_job(pool, job.id, Some(error_json)).await {
                 Ok(j) => j,
                 Err(fail_err) => {


### PR DESCRIPTION
## Problem

A corpus-wide harvest+enrich run queued on 2026-06-05 fell over: **~4,800 harvest jobs across ~2,460 laws failed**, 99% of them with `cannot fork() ... Resource temporarily unavailable` / `IO error (os error 11)` — i.e. `EAGAIN`. The single-threaded worker then **fast-failed every queued job for ~21 hours** (06-05 18:00 → 06-06 15:20, median 0.8s/job) without recovering. Only a redeploy/restart cleared it.

### Root cause

The worker binary runs as **PID 1 with no init**. Git shells out to subprocesses (`merge-base`, `git-remote-https`, the `GIT_ASKPASS` helper); when git terminates abnormally those grandchildren are **reparented to PID 1**, and with no reaper they become **zombies** that hold pid slots. They ratchet up against the container's already-low pids limit (the team had previously hit this — see `index.threads=1` in `corpus/src/client.rs::git_env`) until `fork()` returns `EAGAIN`. Nothing detected the degraded state, so it ran broken for 21h.

## Fix

**1. Reap zombies — add `tini` as PID 1** (`Dockerfile.harvester-worker`, `Dockerfile.enrich-worker`). The enrich worker kills the LLM CLI on timeout, orphaning its children, so it needs reaping too.

**2. Resource-exhaustion circuit breaker** (`worker.rs`, both loops):
- `is_resource_exhaustion()` classifies `fork()`/EAGAIN/OOM/thread-create errors as environmental (vs. per-law failures like bad XML, LLM timeouts).
- A `JobOutcome` enum threads the classification out of both process functions.
- After `WORKER_MAX_CONSECUTIVE_RESOURCE_FAILURES` (default 5) consecutive environmental failures, the worker `exit(1)`s so the orchestrator restarts it with a clean process table — turning a 21h outage into a ~1 minute blip.
- Resource-exhausted jobs still go through the **normal failure/requeue path** (law status reset, no dangling jobs); the breaker is purely additive.

## Not in this PR (ops follow-ups)
- Raise the worker pod's `pids`/memory limits for headroom.
- A liveness probe that reflects worker job-health (today `/health` only checks `SELECT 1`, which is why nothing restarted the degraded worker).
- Re-queue the ~2,460 failed laws once the workers are healthy.

## Testing
- New unit tests: classifier (real observed error strings, positive + negative) and breaker counting.
- `just pipeline-test` → 34/34 pass. `just lint` clean. `just format` clean.