### PR TITLE
docs: add RFC-020 date-aware reference resolution (as_of)

### DIFF
--- a/docs/src/content/rfcs/rfc-020.md
+++ b/docs/src/content/rfcs/rfc-020.md
@@ -5,7 +5,7 @@ title: "RFC-020: Date-Aware Reference Resolution (as_of)"
 **Status:** Draft
 **Date:** 2026-06-09
 **Authors:** Tim de Jager
-**Depends on:** RFC-019 (Law End Dates), RFC-007 (Cross-Law Execution Model), RFC-008 (Awb Administrative Procedures)
+**Depends on:** RFC-019 (Law End Dates), RFC-007 (Cross-Law Execution Model), RFC-008 (Awb Administrative Procedures), RFC-013 (Execution Provenance)
 
 ## Context
 
@@ -187,13 +187,13 @@ input:
     source:
       regulation: wet_x
       output: boetebedrag
-      as_of: $overtreding_datum
+      as_of: $overtreding_datum    # RFC-008 stage input, like $besluit_datum in Example A
   - name: boete_beschikkingsmoment
     type: amount
     source:
       regulation: wet_x
       output: boetebedrag
-      as_of: $beschikking_datum
+      as_of: $beschikking_datum    # RFC-008 stage input, like $besluit_datum in Example A
 actions:
   - output: boete
     value:
@@ -227,8 +227,9 @@ Extends the cucumber-rs harness (`features/bezwaartermijn.feature`, `features/ei
 
 1. *ex nunc vs ex tunc*: the same reference resolves to different versions for
    `as_of: $besluit_datum` vs the default, with two versions of the target loaded.
-2. *statische verwijzing*: a fixed-date `as_of` keeps resolving an earlier version after the
-   target's `valid_to` (interaction with [RFC-019](/rfcs/rfc-019)).
+2. *statische verwijzing*: a fixed-date `as_of` resolves correctly when `calculation_date` is past
+   the target's `valid_to` but `as_of` is within the validity window (interaction with
+   [RFC-019](/rfcs/rfc-019)).
 3. *lex mitior*: a boete computed at two `as_of` dates yields the favourable (lower) result.
 4. *propagation*: an inner reference without `as_of` inherits the outer one; an inner `as_of`
    overrides for its subtree.

--- a/docs/src/content/rfcs/rfc-020.md
+++ b/docs/src/content/rfcs/rfc-020.md
@@ -198,7 +198,9 @@ actions:
   - output: boete
     value:
       operation: MIN          # gunstigste (= laagste) van twee momenten - art. 5:46 lid 4 Awb
-      values: [$boete_overtredingsmoment, $boete_besluitmoment]
+      values:
+        - $boete_overtredingsmoment
+        - $boete_besluitmoment
 ```
 
 *(`$besluit_datum` is the existing [RFC-008](/rfcs/rfc-008) BEHANDELING stage input.
@@ -247,6 +249,9 @@ Extends the cucumber-rs harness (`features/bezwaartermijn.feature`, `features/ei
    reported against the resolved date - never a silent miss.
 6. *failure path, symmetric*: `as_of` *before* the target's `valid_from` (law not yet in force -
    e.g. an `overtreding_datum` predating the law) yields the same `SelectionReason` error.
+7. *IoC propagation*: with an outer `as_of`, implementing regulations (`open_terms`/`implements`,
+   [RFC-003](/rfcs/rfc-003)) are selected at the propagated date, not at `calculation_date` -
+   the §5 rule, with two versions of an implementing regulation loaded.
 
 Plus `as_of` cases in the **Temporal** conformance level ([RFC-014](/rfcs/rfc-014)).
 

--- a/docs/src/content/rfcs/rfc-020.md
+++ b/docs/src/content/rfcs/rfc-020.md
@@ -9,52 +9,58 @@ title: "RFC-020: Date-Aware Reference Resolution (as_of)"
 
 ## Context
 
-[RFC-019](/rfcs/rfc-019) added an end date (`valid_to`) and made version selection drop a law once it
-has ended - all relative to a **single global `calculation_date`** ([RFC-003](/rfcs/rfc-003)). That
-is enough for "is this law still in force today?", but it cannot express a fact that pervades Dutch
-law: *which version of a referenced law applies is itself a legal question, and the answer is often a
-date other than the global one.*
+**Problem.** [RFC-019](/rfcs/rfc-019) selects law versions against a **single global
+`calculation_date`**. That answers "is this law in force today?", but Dutch law routinely requires
+resolving a referenced law **as it stood on a different date** - and that date must **propagate** to
+everything resolved beneath the reference:
 
-Three codified/established mechanisms require resolving a referenced law **as it stood on a specific
-date**, and that date must **propagate** to everything resolved beneath the reference:
+- **Eerbiedigende werking / overgangsrecht** - the old law stays applicable to existing cases
+  (Aanwijzing 5.64). Real corpus case: CEK23's staartzin, "*met dien verstande dat zij van
+  toepassing blijft op subsidies die voor die datum zijn verstrekt*" ([RFC-019](/rfcs/rfc-019)
+  example A).
+- **Statische vs. dynamische verwijzing** (Aanwijzing 3.47) - a static reference freezes the text
+  on a date and survives later change/repeal. Statutory formula: "*zoals dat luidde op <datum>*"
+  (e.g. Wet IB 2001 art. 10bis.1: "*zoals dat luidde op 31 december 2012*"); Aanwijzing 3.47 itself:
+  "*zoals zij op een gegeven tijdstip luidden*".
+- **Ex nunc / ex tunc** - the heroverweging in bezwaar (Awb art. 7:11) is in beginsel ex nunc, with
+  exceptions; which event date governs is Awb + jurisprudence.
+- **Lex mitior** (Awb art. 5:46 lid 4) even requires **two dates in one decision**: a bestuurlijke
+  boete compares the rule at the *overtreding* and at the *beschikking* and must apply the one most
+  favourable to the offender.
 
-- **Eerbiedigende werking / overgangsrecht** - the old law stays applicable to existing cases and
-  pending procedures ([Aanwijzing 5.64](https://www.kcbr.nl/beleid-en-regelgeving-ontwikkelen/aanwijzingen-voor-de-regelgeving/hoofdstuk-5-bijzondere-bestanddelen-van-regelingen/ss-514-overgangsrecht/aanwijzing-564-eerbiedigende-en-uitgestelde-werking)).
-- **Statische vs. dynamische verwijzing** - a *static* reference points to the text as it read on a
-  given date and survives later change/repeal; a *dynamic* reference follows the current text
-  ([Aanwijzing 3.47](https://www.kcbr.nl/beleid-en-regelgeving-ontwikkelen/aanwijzingen-voor-de-regelgeving/hoofdstuk-3-aspecten-van-vormgeving-31-364/ss-33-aanhaling-en-verwijzing-327-351/aanwijzing-347-dynamische-en-statische-verwijzing)).
-  In statutes the recurring static formula is "*zoals dat luidde op <datum>*" (e.g. Wet IB 2001
-  art. 10bis.1: "*zoals dat luidde op 31 december 2012*"); Aanwijzing 3.47 itself speaks of
-  referring to norms "*zoals zij op een gegeven tijdstip luidden*".
-- **ex nunc / ex tunc** - in bezwaar the heroverweging is in beginsel ex nunc, with ex tunc
-  exceptions; which event date governs is a matter of the Awb and jurisprudence (below).
-
-[RFC-008](/rfcs/rfc-008) already establishes the legal source of these dates: "the lifecycle is law",
-and a besluit carries several event dates (`aanvraag_datum`, `besluit_datum`, `bekendmaking_datum`)
-as stage inputs. What is missing is the ability for a **reference** to be resolved at one of those
-dates rather than the global `calculation_date`. This RFC adds exactly that.
-
-> **Aanwijzingen status.** The Aanwijzingen voor de regelgeving (official text
-> [BWBR0005730](https://wetten.overheid.nl/BWBR0005730)) are a *besluit van de Minister-President*:
-> drafting guidelines binding on the wetgever, **not** substantive law on citizens. The substantive
-> temporal effects rest on the laws themselves and on jurisprudence; the Aanwijzingen are cited here
-> as the authoritative statement of the drafting conventions.
+The event dates already exist: [RFC-008](/rfcs/rfc-008) ("the lifecycle is law") carries
+`aanvraag_datum`, `besluit_datum`, `bekendmaking_datum` as stage inputs. What is missing is a way
+for a **reference** to be resolved at one of those dates instead of the global `calculation_date`.
 
 ## Decision
 
+Add an optional **`as_of`** to a cross-law reference / open-term resolution: the referenced law -
+and everything beneath it - is resolved at that date, using [RFC-019](/rfcs/rfc-019)'s
+`valid_from`/`valid_to` selection.
+
+### Grounding - the law and jurisprudence this RFC is built on
+
+| Source | Vindplaats | Role in this RFC |
+|---|---|---|
+| Awb art. 7:11 (heroverweging) | [BWBR0005537](https://wetten.overheid.nl/BWBR0005537) | lid 1: "*Indien het bezwaar ontvankelijk is, vindt op grondslag daarvan een heroverweging van het bestreden besluit plaats.*" - example A |
+| Awb art. 5:46 lid 4 + art. 1 lid 2 Sr | [BWBR0005537](https://wetten.overheid.nl/BWBR0005537) · [BWBR0001854](https://wetten.overheid.nl/BWBR0001854) | lex mitior codified: "*Artikel 1, tweede lid, van het Wetboek van Strafrecht is van overeenkomstige toepassing.*" - §4, example C |
+| Ex-nunc jurisprudence | ABRvS *Greenpeace* 28-10-2020 ([ECLI:NL:RVS:2020:2571](https://uitspraken.rechtspraak.nl/details?id=ECLI:NL:RVS:2020:2571), standard arrest, r.o. 6.2.3-6.2.9) · *Steenwijkerland* 21-12-2016 ([ECLI:NL:RVS:2016:3388](https://uitspraken.rechtspraak.nl/details?id=ECLI:NL:RVS:2016:3388)) · *Berg en Dal* 21-02-2018 ([ECLI:NL:RVS:2018:610](https://uitspraken.rechtspraak.nl/details?id=ECLI:NL:RVS:2018:610), exception-side anchor) | the ex-nunc default is jurisprudential, not statutory - §3 |
+| Lex-mitior jurisprudence | ABRvS 21-05-2025 ([ECLI:NL:RVS:2025:2223](https://uitspraken.rechtspraak.nl/details?id=ECLI:NL:RVS:2025:2223)) · ABRvS 30-08-2023 ([ECLI:NL:RVS:2023:3291](https://uitspraken.rechtspraak.nl/details?id=ECLI:NL:RVS:2023:3291)) · CBb 06-07-2021 ([ECLI:NL:CBB:2021:700](https://uitspraken.rechtspraak.nl/details?id=ECLI:NL:CBB:2021:700)) | mandatory favourable-provision duty confirmed through beroep - §4 |
+| Aanwijzingen 3.47 / 5.60 / 5.61 / 5.64 | [BWBR0005730](https://wetten.overheid.nl/BWBR0005730), deep links via [kcbr.nl](https://www.kcbr.nl) | drafting conventions: statische/dynamische verwijzing, plaats overgangsrecht, onmiddellijke werking, eerbiedigende werking (besluit van de Minister-President, not substantive law) |
+| Wet IB 2001 art. 10bis.1 | [BWBR0011353](https://wetten.overheid.nl/BWBR0011353) | the "*zoals dat luidde op <datum>*" static-reference formula in live legislation |
+| Awb bezwaartermijn chain | `corpus/.../algemene_wet_bestuursrecht/1994-01-01.yaml`, `features/bezwaartermijn.feature` | existing modeled lifecycle this RFC builds on |
+
 ### 1. Three temporal axes
 
-Conflating these is the root confusion. Named explicitly:
+Conflating these is the root confusion:
 
 | Axis | Question | Where it lives |
 |---|---|---|
 | **Instrument validity** | When is this *text* in force? | `valid_from` / `valid_to` ([RFC-019](/rfcs/rfc-019)) |
-| **Substantive scope** | Which period/facts does the norm *govern*? | the rule's conditions/parameters + field `temporal` metadata ([RFC-001](/rfcs/rfc-001) §8) |
-| **Applicable-date selection** | *Which version-date* do we evaluate a reference against? | **this RFC** - computed by law (Awb/overgangsrecht), carried per reference |
+| **Substantive scope** | Which period/facts does the norm *govern*? | the rule's conditions + `temporal` metadata ([RFC-001](/rfcs/rfc-001) §8) |
+| **Applicable-date selection** | *Which version-date* do we evaluate a reference against? | **this RFC** - computed by law, carried per reference |
 
 ### 2. `as_of` on a reference, propagating down the subtree
-
-Add an optional `as_of` to a cross-law reference / open-term resolution:
 
 ```yaml
 input:
@@ -65,85 +71,65 @@ input:
       as_of: $besluit_datum        # resolve the referenced law as it stood on this date
 ```
 
-- **Default = dynamic** (no `as_of`): follows the global `calculation_date`. This is the hoofdregel
-  ([Aanwijzing 3.47](https://www.kcbr.nl/beleid-en-regelgeving-ontwikkelen/aanwijzingen-voor-de-regelgeving/hoofdstuk-3-aspecten-van-vormgeving-31-364/ss-33-aanhaling-en-verwijzing-327-351/aanwijzing-347-dynamische-en-statische-verwijzing))
-  and matches current behaviour.
-- **`as_of: <date or $param>`** resolves the referenced law (and everything resolved beneath it) at
-  the given date. A literal date models a *statische verwijzing*; a parameter (e.g. `$besluit_datum`)
-  models ex tunc / eerbiedigende werking.
-- **Propagation: inherited down the subtree, innermost wins.** A reference's `as_of` is inherited by
-  everything resolved beneath it, until a nested reference sets its own `as_of` (most-specific wins)
-  - so a statische verwijzing inside a dynamic context freezes only its own subtree.
-- **Recorded per reference.** The resolved date of every reference (explicit or inherited `as_of`,
-  default `calculation_date`) is recorded in the trace and execution receipt
-  ([RFC-013](/rfcs/rfc-013)) next to the version actually selected - the audit answer to "which
-  version of which law was used, and on what date basis", mirroring how [RFC-019](/rfcs/rfc-019) §4
-  records the validity window.
+- **Default = dynamic** (no `as_of`): follows the global `calculation_date` - the hoofdregel
+  (Aanwijzing 3.47) and current behaviour.
+- **`as_of: <date | $param>`**: a literal date models a *statische verwijzing*; a parameter (e.g.
+  `$besluit_datum`) models ex tunc / eerbiedigende werking.
+- **Propagation: inherited down the subtree, innermost wins** - a statische verwijzing inside a
+  dynamic context freezes only its own subtree.
+- **Recorded per reference**: the resolved date and selected version go into trace and receipt
+  ([RFC-013](/rfcs/rfc-013)), mirroring [RFC-019](/rfcs/rfc-019) §4 - the audit answer to "which
+  version of which law was used, on what date basis".
 
 ### 3. The applicable date is computed by law, not by engine heuristic
 
-The engine does not hard-code ex nunc/ex tunc/eerbiedigende-werking rules
-([RFC-015](/rfcs/rfc-015): zero domain knowledge). The applicable date is produced by executing the
-relevant rule - the **Awb** (heroverweging, art. 7:11) and/or the target law's own **overgangsrecht**
-- and passed as a reference's `as_of`. [RFC-008](/rfcs/rfc-008) already carries the event dates as
-stage inputs and date arithmetic exists ([RFC-007](/rfcs/rfc-007) §3).
-
-**There is no single statutory "applicable-date" article.** The ex-nunc reading of art. 7:11 is
-*jurisprudential*: the standard arrest is ABRvS *Greenpeace* 28-10-2020 (ECLI:NL:RVS:2020:2571,
-r.o. 6.2.3: heroverweging "op basis van de feiten en omstandigheden ten tijde van de heroverweging
-en op basis van het op dat moment geldende recht en beleid", with the exception framework in
-r.o. 6.2.4-6.2.9), building on ABRvS *Steenwijkerland* 21-12-2016 (ECLI:NL:RVS:2016:3388); ABRvS
-*Berg en Dal* 21-02-2018 (ECLI:NL:RVS:2018:610) anchors the exception side (ending the violation
-yourself does not make the sanction decision herroepbaar). The overgangsrecht default is
-**onmiddellijke werking**
-([Aanwijzing 5.61](https://www.kcbr.nl/beleid-en-regelgeving-ontwikkelen/aanwijzingen-voor-de-regelgeving/hoofdstuk-5-bijzondere-bestanddelen-van-regelingen-51-575/ss-514-overgangsrecht-559-566/aanwijzing-561-onmiddellijke-werking));
-its exceptions live in the *specific law's* overgangsbepalingen
-([Aanwijzing 5.60](https://www.kcbr.nl/beleid-en-regelgeving-ontwikkelen/aanwijzingen-voor-de-regelgeving/hoofdstuk-5-bijzondere-bestanddelen-van-regelingen/ss-514-overgangsrecht/aanwijzing-560-plaats-overgangsrecht)).
-So: **codified** date rules are modeled as machine_readable and computed like any other output; the
-**jurisprudential defaults** (ex nunc; onmiddellijke werking) are a documented **Engine Policy**
-default ([RFC-015](/rfcs/rfc-015)) annotated with their basis, overridable per reference via `as_of`.
-RFC-020 refines [RFC-008](/rfcs/rfc-008)'s ex-nunc default; it does not contradict it.
+- The engine hard-codes no ex nunc/ex tunc/eerbiedigende-werking rules
+  ([RFC-015](/rfcs/rfc-015): zero domain knowledge). The applicable date is *produced* by executing
+  the relevant rule - Awb 7:11 and/or the target law's own overgangsrecht - and passed as `as_of`.
+  Event dates and date arithmetic exist ([RFC-008](/rfcs/rfc-008), [RFC-007](/rfcs/rfc-007) §3).
+- **There is no single statutory "applicable-date" article**:
+  - the ex-nunc reading of art. 7:11 is *jurisprudential* - standard arrest *Greenpeace*
+    (heroverweging "*op basis van de feiten en omstandigheden ten tijde van de heroverweging en op
+    basis van het op dat moment geldende recht en beleid*", r.o. 6.2.3; exceptions in 6.2.4-6.2.9);
+    *Berg en Dal* anchors the exception side;
+  - the overgangsrecht default is **onmiddellijke werking** (Aanwijzing 5.61); its exceptions live
+    in the specific law's overgangsbepalingen (Aanwijzing 5.60).
+- Therefore: **codified** date rules are modeled as machine_readable and computed like any output;
+  the **jurisprudential defaults** (ex nunc; onmiddellijke werking) are a documented **Engine
+  Policy** default ([RFC-015](/rfcs/rfc-015)) annotated with their basis, overridable per reference
+  via `as_of`. This refines [RFC-008](/rfcs/rfc-008)'s ex-nunc default; it does not contradict it.
 
 ### 4. Multiple dates in one beoordeling - lex mitior
 
-Multiple event dates can legitimately govern *one* decision, and this is **codified**: art. 5:46 lid
-4 Awb declares the **lex-mitior** principle (art. 1 lid 2 Sr) van overeenkomstige toepassing - for a
-bestuurlijke boete, if the law changes in the offender's favour between the *overtreding* and the
-*beschikking*, the most favourable provision **must** be applied (confirmed through beroep: ABRvS
-21-05-2025, ECLI:NL:RVS:2025:2223; ABRvS 30-08-2023, ECLI:NL:RVS:2023:3291; CBb 06-07-2021,
-ECLI:NL:CBB:2021:700). So one besluit op bezwaar can be ex nunc on the merits (7:11) while the boete
+Art. 5:46 lid 4 Awb makes the lex-mitior principle (art. 1 lid 2 Sr) van overeenkomstige toepassing
+on bestuurlijke boetes - so one besluit op bezwaar can be ex nunc on the merits while the boete
 compares two dates. This **proves `as_of` must be per-reference**, not one global date.
 
 Four boundaries keep it faithful and out of the engine:
-- **Mandatory, not a free choice**: the favourable provision is obligatory, and "favourable" means
-  favourable to the *offender* - never to the administration, and not "best result" in general.
-- **Punitive sanctions only** (afd. 5.4.1 Awb). Not a general best-of-dates rule; a begunstigende
-  beschikking has a single applicable version chosen by ex nunc/ex tunc + overgangsrecht.
-- **Only on gewijzigd inzicht.** The duty presupposes that the change in sanction rules rests on the
-  legislature's altered judgment of the punishability or severity of the conduct (ABRvS 21-05-2025,
-  ECLI:NL:RVS:2025:2223, derived there from the Nota van Toelichting); a merely technical or
-  temporary change does not trigger it.
-- **The selector lives in the law.** The engine provides per-reference `as_of` + a selection
-  operation; *which* is favourable is domain knowledge in the rule (a fixed fine → `MIN`; conduct no
-  longer punishable → `IF`, not `MIN`). The engine never "tries all dates and optimizes".
+
+- **Mandatory, not a free choice** - and "favourable" means favourable to the *offender*, never
+  "best result" in general.
+- **Punitive sanctions only** (afd. 5.4.1 Awb); a begunstigende beschikking has a single applicable
+  version via ex nunc/ex tunc + overgangsrecht.
+- **Only on gewijzigd inzicht**: the change must rest on the legislature's altered judgment of
+  punishability or severity (ABRvS 21-05-2025); a technical or temporary change does not trigger it.
+- **The selector lives in the law**: the engine provides per-reference `as_of` + an operation;
+  *which* is favourable is domain knowledge in the rule (fixed fine → `MIN`; conduct no longer
+  punishable → `IF`). The engine never "tries all dates and optimizes".
 
 ### 5. Interaction with hooks/overrides
 
-Hook and override candidates are already temporally filtered by `valid_from` (lex posterior,
-[RFC-007](/rfcs/rfc-007)); [RFC-019](/rfcs/rfc-019)'s `valid_to` and this RFC's `as_of` apply
-identically - an ended candidate drops out, and `as_of` selects the applicable version. A conformance
-case ([RFC-014](/rfcs/rfc-014)) locks this in.
+Hook and override candidates are already filtered by `valid_from` ([RFC-007](/rfcs/rfc-007));
+[RFC-019](/rfcs/rfc-019)'s `valid_to` and this RFC's `as_of` apply identically: an ended candidate
+drops out, `as_of` selects the applicable version. A conformance case ([RFC-014](/rfcs/rfc-014))
+locks this in.
 
 ## Worked examples
 
-### A. Ex nunc vs. ex tunc - Awb 7:11 heroverweging (builds on RFC-008)
+### A. Ex nunc vs. ex tunc - Awb 7:11 heroverweging
 
-The `bezwaartermijn` chain is already modeled and tested
-(`corpus/.../algemene_wet_bestuursrecht/1994-01-01.yaml`, `features/bezwaartermijn.feature`). The
-heroverweging (Awb 7:11 lid 1: *"Indien het bezwaar ontvankelijk is, vindt op grondslag daarvan een
-heroverweging van het bestreden besluit plaats."*) re-evaluates the original decision. Whether it
-applies the law of the *besluit* moment (ex tunc) or of the *beslissing op bezwaar* moment (ex nunc)
-is selected by which event date is passed as `as_of`:
+Whether the heroverweging applies the law of the *beslissing op bezwaar* moment (ex nunc) or of the
+original *besluit* moment (ex tunc) is selected by which event date is passed as `as_of`:
 
 ```yaml
 # Default (ex nunc): heroverweging follows current law - no as_of, uses calculation_date
@@ -160,10 +146,10 @@ input:
       as_of: $besluit_datum     # RFC-008 stage input; propagates through the referenced subtree
 ```
 
-*(Illustrative: the corpus `vreemdelingenwet_2000` does not yet expose a
-`verblijfsvergunning_verleend` output - today it has `minister_is_bevoegd` and
-`bezwaartermijn_weken` - and Awb art. 7:11 itself is not yet in the corpus AWB. The example shows
-the mechanism; modeling the heroverweging chain is implementation work.)*
+*(Illustrative: the corpus `vreemdelingenwet_2000` does not yet expose
+`verblijfsvergunning_verleend`, and Awb 7:11 is not yet in the corpus AWB - the modeled chain today
+is the bezwaartermijn. The example shows the mechanism; modeling the heroverweging is
+implementation work.)*
 
 ### B. Statische verwijzing - frozen text by date
 
@@ -180,8 +166,8 @@ input:
 ### C. Lex mitior - two dates, take the favourable one (art. 5:46 lid 4 Awb)
 
 Two inputs resolve the *same* output at the two legally relevant moments; the selector (`MIN` - for
-a fixed fine, lower is favourable) lives in the law. This stays within the existing operation
-grammar: only `as_of` is new, no new operation-value shapes are needed.
+a fixed fine, lower is favourable) lives in the law. Stays within the existing operation grammar:
+only `as_of` is new.
 
 ```yaml
 input:
@@ -198,118 +184,81 @@ actions:
       values: [$boete_overtredingsmoment, $boete_beschikkingsmoment]
 ```
 
-## Findings on the open questions
-
-These were investigated against the law and jurisprudence; the answers shaped the decisions above.
-
-1. **Where does the applicable-date rule live?** → Layered; partly jurisprudential (ex nunc reading
-   of art. 7:11), partly in the specific law's overgangsrecht (Aanwijzing 5.60/5.61). Not a single
-   Awb article. → codified parts modeled as machine_readable; jurisprudential defaults in Engine
-   Policy, overridable per reference (§3).
-2. **Can multiple dates coexist in one beoordeling?** → Yes, codified (lex mitior, art. 5:46 lid 4
-   Awb). → `as_of` is per reference (§4).
-3. **How far does `as_of` propagate?** → Inherited down the subtree; innermost wins (§2).
-4. **Substantive scope vs instrument validity** → engine enforces instrument validity
-   ([RFC-019](/rfcs/rfc-019)); substantive scope is expressed in-law, not inferred ([RFC-015](/rfcs/rfc-015)).
-5. **Hooks/overrides** → same temporal treatment (§5).
-
-### Still open
+## Still open
 
 - The precise *form* of the Engine Policy default for ex nunc / onmiddellijke werking (one policy
-  flag vs. per-procedure defaults in the Awb lifecycle of [RFC-008](/rfcs/rfc-008)), and how it
-  carries its jurisprudential basis.
-- Whether lex mitior warrants a reusable library pattern rather than a hand-written
-  MIN/IF-over-two-`as_of` per boete-law.
-- **Cross-law-derived validity (extrinsic termination).** [RFC-019](/rfcs/rfc-019) treats `valid_to`
-  as static version-selection metadata and notes that when a law is *terminated by another
-  instrument* (an intrekkingswet/ministeriële regeling), the authoritative end date lives in that
-  instrument and should be **derived** from it - making in-force status an *executed* property rather
-  than static metadata. That is the same cross-law, execution-time territory as this RFC's `as_of`
-  (and lex-specialis `overrides`, [RFC-007](/rfcs/rfc-007)); a future "terminates" mechanism that
-  derives a law's `valid_to` from the terminating instrument belongs alongside the date-aware
-  resolution model here.
+  flag vs. per-procedure defaults in the [RFC-008](/rfcs/rfc-008) lifecycle), and how it carries
+  its jurisprudential basis.
+- Whether lex mitior warrants a reusable library pattern rather than hand-written
+  `MIN`/`IF`-over-two-`as_of` per boete-law.
+- **Cross-law-derived validity (extrinsic termination)**: [RFC-019](/rfcs/rfc-019) keeps `valid_to`
+  static and defers a "terminates" mechanism that *derives* a law's end from the terminating
+  instrument. That is the same cross-law, date-aware territory as `as_of` and belongs alongside
+  this model.
 
 ## Testing
 
-Extends the existing cucumber-rs harness (`features/bezwaartermijn.feature`):
-1. *ex nunc vs ex tunc*: the same heroverweging reference resolves to different versions for
-   `as_of: $besluit_datum` vs the default, when two versions of the target law are loaded.
-2. *statische verwijzing*: `as_of: '<fixed date>'` keeps resolving an earlier version after the
+Extends the cucumber-rs harness (`features/bezwaartermijn.feature`, `features/einddatum.feature`):
+
+1. *ex nunc vs ex tunc*: the same reference resolves to different versions for
+   `as_of: $besluit_datum` vs the default, with two versions of the target loaded.
+2. *statische verwijzing*: a fixed-date `as_of` keeps resolving an earlier version after the
    target's `valid_to` (interaction with [RFC-019](/rfcs/rfc-019)).
 3. *lex mitior*: a boete computed at two `as_of` dates yields the favourable (lower) result.
 4. *propagation*: an inner reference without `as_of` inherits the outer one; an inner `as_of`
    overrides for its subtree.
 
-Plus `as_of` resolution cases in the **Temporal** conformance level ([RFC-014](/rfcs/rfc-014)).
+Plus `as_of` cases in the **Temporal** conformance level ([RFC-014](/rfcs/rfc-014)).
 
 ## Why
 
 ### Benefits
 
-- **Legally faithful references.** ex nunc/ex tunc, statische verwijzing and eerbiedigende werking
-  are modeled by *which date* a reference resolves at - grounded in the Aanwijzingen and Awb, not in
-  engine heuristics.
-- **Composes with RFC-019.** A static `as_of` can resolve an earlier version even after the target's
-  `valid_to`; an ended reference at the default date still surfaces honestly ([RFC-019](/rfcs/rfc-019) §3,
-  with the diagnostic stated relative to the resolved `as_of` date).
-- **Reuses existing machinery.** Event dates ([RFC-008](/rfcs/rfc-008)), date arithmetic
-  ([RFC-007](/rfcs/rfc-007)), priority and provenance - only `as_of` and its propagation are new.
+- **Legally faithful references**: ex nunc/ex tunc, statische verwijzing and eerbiedigende werking
+  are modeled by *which date* a reference resolves at - grounded in Awb, Aanwijzingen and
+  jurisprudence, not in engine heuristics.
+- **Composes with [RFC-019](/rfcs/rfc-019)**: a static `as_of` can resolve an earlier version even
+  after the target's `valid_to`; an ended reference at the default date still fails honestly
+  (RFC-019 §3, stated relative to the resolved date).
+- **Reuses existing machinery**: event dates ([RFC-008](/rfcs/rfc-008)), date arithmetic
+  ([RFC-007](/rfcs/rfc-007)), version selection ([RFC-019](/rfcs/rfc-019)) - only `as_of` and its
+  propagation are new.
 
 ### Tradeoffs
 
-- **Second date dimension.** The engine must thread an `as_of` (defaulting to `calculation_date`)
-  through cross-law resolution, the reference subtree, cycle detection **and the per-execution
-  memoization cache** - the cache key must include the resolution date, or the two lex-mitior
-  lookups of the same output (example C) would collide.
-- **Policy surface.** The jurisprudential ex-nunc / onmiddellijke-werking default must be expressed
-  and audited as Engine Policy rather than code.
+- **Second date dimension**: `as_of` must thread through cross-law resolution, the reference
+  subtree, cycle detection **and the memoization cache** (the key must include the resolution date,
+  or example C's two lookups of the same output would collide).
+- **Policy surface**: the jurisprudential defaults must be expressed and audited as Engine Policy
+  rather than code.
 
 ### Alternatives Considered
 
-**A single global date for all version selection (status quo + RFC-019).** Rejected: cannot express
-ex tunc, statische verwijzing, or eerbiedigende werking, all of which resolve a referenced law at a
-date other than the global one.
-
-**Engine "tries all dates and picks the best" for lex mitior.** Rejected: lets the engine decide what
-counts as favourable - domain knowledge. The two moments and the favourable-selector belong in the
-law (§4).
-
-**Dates computed outside the engine.** Rejected for the same reason [RFC-007](/rfcs/rfc-007) rejected
-it: the date rules (Awb, overgangsrecht) are themselves law and should be executed.
+- **One global date for all version selection (status quo + RFC-019).** Rejected: cannot express ex
+  tunc, statische verwijzing or eerbiedigende werking - each resolves a reference at a non-global
+  date.
+- **Engine "tries all dates and picks the best" for lex mitior.** Rejected: deciding what counts as
+  favourable is domain knowledge; the two moments and the selector belong in the law (§4).
+- **Dates computed outside the engine.** Rejected for the reason [RFC-007](/rfcs/rfc-007) rejected
+  it: the date rules (Awb, overgangsrecht) are themselves law and should be executed.
 
 ### Implementation Notes
 
-- Schema: additive `as_of` on `source` (a literal date or `$`-parameter reference). The `source`
-  object is `additionalProperties: false`, so this needs a new minor schema version - additive,
-  non-breaking, like [RFC-019](/rfcs/rfc-019)'s `valid_to`.
-- Engine: thread an `as_of` (default `calculation_date`) through `get_article_by_output` and the
-  cross-law resolution path; inherit down the subtree with innermost-wins; reuse
-  [RFC-019](/rfcs/rfc-019)'s `valid_from`/`valid_to` selection at the resolved `as_of`; include the
-  resolved date in the memoization and cycle-detection keys; report selection failures
-  ([RFC-019](/rfcs/rfc-019) §3 `SelectionReason`) relative to the resolved date.
-- Receipt/trace: record the resolved date per reference ([RFC-013](/rfcs/rfc-013)).
-- Policy: an Engine Policy entry for the ex-nunc / onmiddellijke-werking default, annotated with its
-  jurisprudential basis.
+- **Schema**: additive `as_of` on `source` (literal date or `$`-parameter). `source` is
+  `additionalProperties: false`, so this needs a new minor schema version - additive, non-breaking.
+- **Engine**: thread `as_of` (default `calculation_date`) through the cross-law resolution path;
+  inherit down the subtree, innermost wins; reuse [RFC-019](/rfcs/rfc-019)'s selection at the
+  resolved date; include the resolved date in memoization and cycle-detection keys; report
+  selection failures ([RFC-019](/rfcs/rfc-019) §3 `SelectionReason`) relative to the resolved date.
+- **Receipt/trace**: record the resolved date per reference ([RFC-013](/rfcs/rfc-013)).
+- **Policy**: an Engine Policy entry for the ex-nunc / onmiddellijke-werking default, annotated
+  with its jurisprudential basis.
 
 ## References
 
-- [RFC-019](/rfcs/rfc-019): Law End Dates (`valid_to`, selection upper bound, expired-reference handling)
-- [RFC-001](/rfcs/rfc-001): YAML Schema (temporal metadata, `regelrecht://`)
-- [RFC-003](/rfcs/rfc-003): IoC for Delegated Legislation (temporal filter, priority)
-- [RFC-007](/rfcs/rfc-007): Cross-Law Execution Model (references, date types, lifecycle)
-- [RFC-008](/rfcs/rfc-008): Awb Administrative Procedures (lifecycle is law, stage dates, heroverweging)
-- [RFC-013](/rfcs/rfc-013): Execution Provenance (receipt scope, per-output provenance)
-- [RFC-014](/rfcs/rfc-014): Engine Conformance Test Suite (Temporal level)
-- [RFC-015](/rfcs/rfc-015): Engine Policy (zero domain knowledge)
-- Aanwijzingen voor de regelgeving - official text [BWBR0005730](https://wetten.overheid.nl/BWBR0005730)
-  (a *besluit van de Minister-President*; not substantive law): 3.47 (statische/dynamische
-  verwijzing), 5.60 (plaats overgangsrecht), 5.61 (onmiddellijke werking), 5.64 (eerbiedigende werking)
-- Algemene wet bestuursrecht art. 7:11 (heroverweging) en art. 5:46 lid 4 (lex mitior, art. 1 lid 2
-  Sr van overeenkomstige toepassing): https://wetten.overheid.nl/BWBR0005537
-- ex-nunc/ex-tunc jurisprudentie: ABRvS *Greenpeace* 28-10-2020 (ECLI:NL:RVS:2020:2571, standaardarrest,
-  r.o. 6.2.3-6.2.9); *Steenwijkerland* 21-12-2016 (ECLI:NL:RVS:2016:3388); *Berg en Dal* 21-02-2018
-  (ECLI:NL:RVS:2018:610, uitzonderings-anker). Lex mitior: ABRvS 21-05-2025 (ECLI:NL:RVS:2025:2223),
-  ABRvS 30-08-2023 (ECLI:NL:RVS:2023:3291), CBb 06-07-2021 (ECLI:NL:CBB:2021:700)
-- Statische-verwijzing-formule in wetgeving: Wet IB 2001 art. 10bis.1 ("zoals dat luidde op
-  31 december 2012"): https://wetten.overheid.nl/BWBR0011353
+- [RFC-019](/rfcs/rfc-019) Law End Dates · [RFC-001](/rfcs/rfc-001) YAML Schema ·
+  [RFC-003](/rfcs/rfc-003) IoC/temporal filter · [RFC-007](/rfcs/rfc-007) Cross-Law Execution ·
+  [RFC-008](/rfcs/rfc-008) Awb Administrative Procedures · [RFC-013](/rfcs/rfc-013) Execution
+  Provenance · [RFC-014](/rfcs/rfc-014) Conformance · [RFC-015](/rfcs/rfc-015) Engine Policy
+- Law, jurisprudence and drafting conventions: see the Grounding table above.
 - [Glossary of Dutch Legal Terms](/reference/glossary)

--- a/docs/src/content/rfcs/rfc-020.md
+++ b/docs/src/content/rfcs/rfc-020.md
@@ -1,0 +1,315 @@
+---
+title: "RFC-020: Date-Aware Reference Resolution (as_of)"
+---
+
+**Status:** Draft
+**Date:** 2026-06-09
+**Authors:** Tim de Jager
+**Depends on:** RFC-019 (Law End Dates), RFC-007 (Cross-Law Execution Model), RFC-008 (Awb Administrative Procedures)
+
+## Context
+
+[RFC-019](/rfcs/rfc-019) added an end date (`valid_to`) and made version selection drop a law once it
+has ended - all relative to a **single global `calculation_date`** ([RFC-003](/rfcs/rfc-003)). That
+is enough for "is this law still in force today?", but it cannot express a fact that pervades Dutch
+law: *which version of a referenced law applies is itself a legal question, and the answer is often a
+date other than the global one.*
+
+Three codified/established mechanisms require resolving a referenced law **as it stood on a specific
+date**, and that date must **propagate** to everything resolved beneath the reference:
+
+- **Eerbiedigende werking / overgangsrecht** - the old law stays applicable to existing cases and
+  pending procedures ([Aanwijzing 5.64](https://www.kcbr.nl/beleid-en-regelgeving-ontwikkelen/aanwijzingen-voor-de-regelgeving/hoofdstuk-5-bijzondere-bestanddelen-van-regelingen/ss-514-overgangsrecht/aanwijzing-564-eerbiedigende-en-uitgestelde-werking)).
+- **Statische vs. dynamische verwijzing** - a *static* reference points to the text as it read on a
+  given date and survives later change/repeal; a *dynamic* reference follows the current text
+  ([Aanwijzing 3.47](https://www.kcbr.nl/beleid-en-regelgeving-ontwikkelen/aanwijzingen-voor-de-regelgeving/hoofdstuk-3-aspecten-van-vormgeving-31-364/ss-33-aanhaling-en-verwijzing-327-351/aanwijzing-347-dynamische-en-statische-verwijzing)).
+  In statutes the recurring static formula is "*zoals dat luidde op <datum>*" (e.g. Wet IB 2001
+  art. 10bis.1: "*zoals dat luidde op 31 december 2012*"); Aanwijzing 3.47 itself speaks of
+  referring to norms "*zoals zij op een gegeven tijdstip luidden*".
+- **ex nunc / ex tunc** - in bezwaar the heroverweging is in beginsel ex nunc, with ex tunc
+  exceptions; which event date governs is a matter of the Awb and jurisprudence (below).
+
+[RFC-008](/rfcs/rfc-008) already establishes the legal source of these dates: "the lifecycle is law",
+and a besluit carries several event dates (`aanvraag_datum`, `besluit_datum`, `bekendmaking_datum`)
+as stage inputs. What is missing is the ability for a **reference** to be resolved at one of those
+dates rather than the global `calculation_date`. This RFC adds exactly that.
+
+> **Aanwijzingen status.** The Aanwijzingen voor de regelgeving (official text
+> [BWBR0005730](https://wetten.overheid.nl/BWBR0005730)) are a *besluit van de Minister-President*:
+> drafting guidelines binding on the wetgever, **not** substantive law on citizens. The substantive
+> temporal effects rest on the laws themselves and on jurisprudence; the Aanwijzingen are cited here
+> as the authoritative statement of the drafting conventions.
+
+## Decision
+
+### 1. Three temporal axes
+
+Conflating these is the root confusion. Named explicitly:
+
+| Axis | Question | Where it lives |
+|---|---|---|
+| **Instrument validity** | When is this *text* in force? | `valid_from` / `valid_to` ([RFC-019](/rfcs/rfc-019)) |
+| **Substantive scope** | Which period/facts does the norm *govern*? | the rule's conditions/parameters + field `temporal` metadata ([RFC-001](/rfcs/rfc-001) §8) |
+| **Applicable-date selection** | *Which version-date* do we evaluate a reference against? | **this RFC** - computed by law (Awb/overgangsrecht), carried per reference |
+
+### 2. `as_of` on a reference, propagating down the subtree
+
+Add an optional `as_of` to a cross-law reference / open-term resolution:
+
+```yaml
+input:
+  - name: standaardpremie
+    source:
+      regulation: regeling_standaardpremie
+      output: standaardpremie
+      as_of: $besluit_datum        # resolve the referenced law as it stood on this date
+```
+
+- **Default = dynamic** (no `as_of`): follows the global `calculation_date`. This is the hoofdregel
+  ([Aanwijzing 3.47](https://www.kcbr.nl/beleid-en-regelgeving-ontwikkelen/aanwijzingen-voor-de-regelgeving/hoofdstuk-3-aspecten-van-vormgeving-31-364/ss-33-aanhaling-en-verwijzing-327-351/aanwijzing-347-dynamische-en-statische-verwijzing))
+  and matches current behaviour.
+- **`as_of: <date or $param>`** resolves the referenced law (and everything resolved beneath it) at
+  the given date. A literal date models a *statische verwijzing*; a parameter (e.g. `$besluit_datum`)
+  models ex tunc / eerbiedigende werking.
+- **Propagation: inherited down the subtree, innermost wins.** A reference's `as_of` is inherited by
+  everything resolved beneath it, until a nested reference sets its own `as_of` (most-specific wins)
+  - so a statische verwijzing inside a dynamic context freezes only its own subtree.
+- **Recorded per reference.** The resolved date of every reference (explicit or inherited `as_of`,
+  default `calculation_date`) is recorded in the trace and execution receipt
+  ([RFC-013](/rfcs/rfc-013)) next to the version actually selected - the audit answer to "which
+  version of which law was used, and on what date basis", mirroring how [RFC-019](/rfcs/rfc-019) §4
+  records the validity window.
+
+### 3. The applicable date is computed by law, not by engine heuristic
+
+The engine does not hard-code ex nunc/ex tunc/eerbiedigende-werking rules
+([RFC-015](/rfcs/rfc-015): zero domain knowledge). The applicable date is produced by executing the
+relevant rule - the **Awb** (heroverweging, art. 7:11) and/or the target law's own **overgangsrecht**
+- and passed as a reference's `as_of`. [RFC-008](/rfcs/rfc-008) already carries the event dates as
+stage inputs and date arithmetic exists ([RFC-007](/rfcs/rfc-007) §3).
+
+**There is no single statutory "applicable-date" article.** The ex-nunc reading of art. 7:11 is
+*jurisprudential*: the standard arrest is ABRvS *Greenpeace* 28-10-2020 (ECLI:NL:RVS:2020:2571,
+r.o. 6.2.3: heroverweging "op basis van de feiten en omstandigheden ten tijde van de heroverweging
+en op basis van het op dat moment geldende recht en beleid", with the exception framework in
+r.o. 6.2.4-6.2.9), building on ABRvS *Steenwijkerland* 21-12-2016 (ECLI:NL:RVS:2016:3388); ABRvS
+*Berg en Dal* 21-02-2018 (ECLI:NL:RVS:2018:610) anchors the exception side (ending the violation
+yourself does not make the sanction decision herroepbaar). The overgangsrecht default is
+**onmiddellijke werking**
+([Aanwijzing 5.61](https://www.kcbr.nl/beleid-en-regelgeving-ontwikkelen/aanwijzingen-voor-de-regelgeving/hoofdstuk-5-bijzondere-bestanddelen-van-regelingen-51-575/ss-514-overgangsrecht-559-566/aanwijzing-561-onmiddellijke-werking));
+its exceptions live in the *specific law's* overgangsbepalingen
+([Aanwijzing 5.60](https://www.kcbr.nl/beleid-en-regelgeving-ontwikkelen/aanwijzingen-voor-de-regelgeving/hoofdstuk-5-bijzondere-bestanddelen-van-regelingen/ss-514-overgangsrecht/aanwijzing-560-plaats-overgangsrecht)).
+So: **codified** date rules are modeled as machine_readable and computed like any other output; the
+**jurisprudential defaults** (ex nunc; onmiddellijke werking) are a documented **Engine Policy**
+default ([RFC-015](/rfcs/rfc-015)) annotated with their basis, overridable per reference via `as_of`.
+RFC-020 refines [RFC-008](/rfcs/rfc-008)'s ex-nunc default; it does not contradict it.
+
+### 4. Multiple dates in one beoordeling - lex mitior
+
+Multiple event dates can legitimately govern *one* decision, and this is **codified**: art. 5:46 lid
+4 Awb declares the **lex-mitior** principle (art. 1 lid 2 Sr) van overeenkomstige toepassing - for a
+bestuurlijke boete, if the law changes in the offender's favour between the *overtreding* and the
+*beschikking*, the most favourable provision **must** be applied (confirmed through beroep: ABRvS
+21-05-2025, ECLI:NL:RVS:2025:2223; ABRvS 30-08-2023, ECLI:NL:RVS:2023:3291; CBb 06-07-2021,
+ECLI:NL:CBB:2021:700). So one besluit op bezwaar can be ex nunc on the merits (7:11) while the boete
+compares two dates. This **proves `as_of` must be per-reference**, not one global date.
+
+Four boundaries keep it faithful and out of the engine:
+- **Mandatory, not a free choice**: the favourable provision is obligatory, and "favourable" means
+  favourable to the *offender* - never to the administration, and not "best result" in general.
+- **Punitive sanctions only** (afd. 5.4.1 Awb). Not a general best-of-dates rule; a begunstigende
+  beschikking has a single applicable version chosen by ex nunc/ex tunc + overgangsrecht.
+- **Only on gewijzigd inzicht.** The duty presupposes that the change in sanction rules rests on the
+  legislature's altered judgment of the punishability or severity of the conduct (ABRvS 21-05-2025,
+  ECLI:NL:RVS:2025:2223, derived there from the Nota van Toelichting); a merely technical or
+  temporary change does not trigger it.
+- **The selector lives in the law.** The engine provides per-reference `as_of` + a selection
+  operation; *which* is favourable is domain knowledge in the rule (a fixed fine → `MIN`; conduct no
+  longer punishable → `IF`, not `MIN`). The engine never "tries all dates and optimizes".
+
+### 5. Interaction with hooks/overrides
+
+Hook and override candidates are already temporally filtered by `valid_from` (lex posterior,
+[RFC-007](/rfcs/rfc-007)); [RFC-019](/rfcs/rfc-019)'s `valid_to` and this RFC's `as_of` apply
+identically - an ended candidate drops out, and `as_of` selects the applicable version. A conformance
+case ([RFC-014](/rfcs/rfc-014)) locks this in.
+
+## Worked examples
+
+### A. Ex nunc vs. ex tunc - Awb 7:11 heroverweging (builds on RFC-008)
+
+The `bezwaartermijn` chain is already modeled and tested
+(`corpus/.../algemene_wet_bestuursrecht/1994-01-01.yaml`, `features/bezwaartermijn.feature`). The
+heroverweging (Awb 7:11 lid 1: *"Indien het bezwaar ontvankelijk is, vindt op grondslag daarvan een
+heroverweging van het bestreden besluit plaats."*) re-evaluates the original decision. Whether it
+applies the law of the *besluit* moment (ex tunc) or of the *beslissing op bezwaar* moment (ex nunc)
+is selected by which event date is passed as `as_of`:
+
+```yaml
+# Default (ex nunc): heroverweging follows current law - no as_of, uses calculation_date
+input:
+  - name: oorspronkelijk_recht
+    source: { regulation: vreemdelingenwet_2000, output: verblijfsvergunning_verleend }
+
+# Exception (ex tunc / eerbiedigende werking): evaluate the law as at the besluit moment
+input:
+  - name: oorspronkelijk_recht
+    source:
+      regulation: vreemdelingenwet_2000
+      output: verblijfsvergunning_verleend
+      as_of: $besluit_datum     # RFC-008 stage input; propagates through the referenced subtree
+```
+
+*(Illustrative: the corpus `vreemdelingenwet_2000` does not yet expose a
+`verblijfsvergunning_verleend` output - today it has `minister_is_bevoegd` and
+`bezwaartermijn_weken` - and Awb art. 7:11 itself is not yet in the corpus AWB. The example shows
+the mechanism; modeling the heroverweging chain is implementation work.)*
+
+### B. Statische verwijzing - frozen text by date
+
+```yaml
+# "... de Wet X, zoals die luidde op 31 december 2000 ..."
+input:
+  - name: oude_definitie
+    source:
+      regulation: wet_x
+      output: definitie
+      as_of: '2000-12-31'   # static: survives later repeal of wet_x; date propagates down
+```
+
+### C. Lex mitior - two dates, take the favourable one (art. 5:46 lid 4 Awb)
+
+Two inputs resolve the *same* output at the two legally relevant moments; the selector (`MIN` - for
+a fixed fine, lower is favourable) lives in the law. This stays within the existing operation
+grammar: only `as_of` is new, no new operation-value shapes are needed.
+
+```yaml
+input:
+  - name: boete_overtredingsmoment
+    type: amount
+    source: { regulation: wet_x, output: boetebedrag, as_of: $overtreding_datum }
+  - name: boete_beschikkingsmoment
+    type: amount
+    source: { regulation: wet_x, output: boetebedrag, as_of: $beschikking_datum }
+actions:
+  - output: boete
+    value:
+      operation: MIN          # gunstigste (= laagste) van twee momenten - art. 5:46 lid 4 Awb
+      values: [$boete_overtredingsmoment, $boete_beschikkingsmoment]
+```
+
+## Findings on the open questions
+
+These were investigated against the law and jurisprudence; the answers shaped the decisions above.
+
+1. **Where does the applicable-date rule live?** → Layered; partly jurisprudential (ex nunc reading
+   of art. 7:11), partly in the specific law's overgangsrecht (Aanwijzing 5.60/5.61). Not a single
+   Awb article. → codified parts modeled as machine_readable; jurisprudential defaults in Engine
+   Policy, overridable per reference (§3).
+2. **Can multiple dates coexist in one beoordeling?** → Yes, codified (lex mitior, art. 5:46 lid 4
+   Awb). → `as_of` is per reference (§4).
+3. **How far does `as_of` propagate?** → Inherited down the subtree; innermost wins (§2).
+4. **Substantive scope vs instrument validity** → engine enforces instrument validity
+   ([RFC-019](/rfcs/rfc-019)); substantive scope is expressed in-law, not inferred ([RFC-015](/rfcs/rfc-015)).
+5. **Hooks/overrides** → same temporal treatment (§5).
+
+### Still open
+
+- The precise *form* of the Engine Policy default for ex nunc / onmiddellijke werking (one policy
+  flag vs. per-procedure defaults in the Awb lifecycle of [RFC-008](/rfcs/rfc-008)), and how it
+  carries its jurisprudential basis.
+- Whether lex mitior warrants a reusable library pattern rather than a hand-written
+  MIN/IF-over-two-`as_of` per boete-law.
+- **Cross-law-derived validity (extrinsic termination).** [RFC-019](/rfcs/rfc-019) treats `valid_to`
+  as static version-selection metadata and notes that when a law is *terminated by another
+  instrument* (an intrekkingswet/ministeriële regeling), the authoritative end date lives in that
+  instrument and should be **derived** from it - making in-force status an *executed* property rather
+  than static metadata. That is the same cross-law, execution-time territory as this RFC's `as_of`
+  (and lex-specialis `overrides`, [RFC-007](/rfcs/rfc-007)); a future "terminates" mechanism that
+  derives a law's `valid_to` from the terminating instrument belongs alongside the date-aware
+  resolution model here.
+
+## Testing
+
+Extends the existing cucumber-rs harness (`features/bezwaartermijn.feature`):
+1. *ex nunc vs ex tunc*: the same heroverweging reference resolves to different versions for
+   `as_of: $besluit_datum` vs the default, when two versions of the target law are loaded.
+2. *statische verwijzing*: `as_of: '<fixed date>'` keeps resolving an earlier version after the
+   target's `valid_to` (interaction with [RFC-019](/rfcs/rfc-019)).
+3. *lex mitior*: a boete computed at two `as_of` dates yields the favourable (lower) result.
+4. *propagation*: an inner reference without `as_of` inherits the outer one; an inner `as_of`
+   overrides for its subtree.
+
+Plus `as_of` resolution cases in the **Temporal** conformance level ([RFC-014](/rfcs/rfc-014)).
+
+## Why
+
+### Benefits
+
+- **Legally faithful references.** ex nunc/ex tunc, statische verwijzing and eerbiedigende werking
+  are modeled by *which date* a reference resolves at - grounded in the Aanwijzingen and Awb, not in
+  engine heuristics.
+- **Composes with RFC-019.** A static `as_of` can resolve an earlier version even after the target's
+  `valid_to`; an ended reference at the default date still surfaces honestly ([RFC-019](/rfcs/rfc-019) §3,
+  with the diagnostic stated relative to the resolved `as_of` date).
+- **Reuses existing machinery.** Event dates ([RFC-008](/rfcs/rfc-008)), date arithmetic
+  ([RFC-007](/rfcs/rfc-007)), priority and provenance - only `as_of` and its propagation are new.
+
+### Tradeoffs
+
+- **Second date dimension.** The engine must thread an `as_of` (defaulting to `calculation_date`)
+  through cross-law resolution, the reference subtree, cycle detection **and the per-execution
+  memoization cache** - the cache key must include the resolution date, or the two lex-mitior
+  lookups of the same output (example C) would collide.
+- **Policy surface.** The jurisprudential ex-nunc / onmiddellijke-werking default must be expressed
+  and audited as Engine Policy rather than code.
+
+### Alternatives Considered
+
+**A single global date for all version selection (status quo + RFC-019).** Rejected: cannot express
+ex tunc, statische verwijzing, or eerbiedigende werking, all of which resolve a referenced law at a
+date other than the global one.
+
+**Engine "tries all dates and picks the best" for lex mitior.** Rejected: lets the engine decide what
+counts as favourable - domain knowledge. The two moments and the favourable-selector belong in the
+law (§4).
+
+**Dates computed outside the engine.** Rejected for the same reason [RFC-007](/rfcs/rfc-007) rejected
+it: the date rules (Awb, overgangsrecht) are themselves law and should be executed.
+
+### Implementation Notes
+
+- Schema: additive `as_of` on `source` (a literal date or `$`-parameter reference). The `source`
+  object is `additionalProperties: false`, so this needs a new minor schema version - additive,
+  non-breaking, like [RFC-019](/rfcs/rfc-019)'s `valid_to`.
+- Engine: thread an `as_of` (default `calculation_date`) through `get_article_by_output` and the
+  cross-law resolution path; inherit down the subtree with innermost-wins; reuse
+  [RFC-019](/rfcs/rfc-019)'s `valid_from`/`valid_to` selection at the resolved `as_of`; include the
+  resolved date in the memoization and cycle-detection keys; report selection failures
+  ([RFC-019](/rfcs/rfc-019) §3 `SelectionReason`) relative to the resolved date.
+- Receipt/trace: record the resolved date per reference ([RFC-013](/rfcs/rfc-013)).
+- Policy: an Engine Policy entry for the ex-nunc / onmiddellijke-werking default, annotated with its
+  jurisprudential basis.
+
+## References
+
+- [RFC-019](/rfcs/rfc-019): Law End Dates (`valid_to`, selection upper bound, expired-reference handling)
+- [RFC-001](/rfcs/rfc-001): YAML Schema (temporal metadata, `regelrecht://`)
+- [RFC-003](/rfcs/rfc-003): IoC for Delegated Legislation (temporal filter, priority)
+- [RFC-007](/rfcs/rfc-007): Cross-Law Execution Model (references, date types, lifecycle)
+- [RFC-008](/rfcs/rfc-008): Awb Administrative Procedures (lifecycle is law, stage dates, heroverweging)
+- [RFC-013](/rfcs/rfc-013): Execution Provenance (receipt scope, per-output provenance)
+- [RFC-014](/rfcs/rfc-014): Engine Conformance Test Suite (Temporal level)
+- [RFC-015](/rfcs/rfc-015): Engine Policy (zero domain knowledge)
+- Aanwijzingen voor de regelgeving - official text [BWBR0005730](https://wetten.overheid.nl/BWBR0005730)
+  (a *besluit van de Minister-President*; not substantive law): 3.47 (statische/dynamische
+  verwijzing), 5.60 (plaats overgangsrecht), 5.61 (onmiddellijke werking), 5.64 (eerbiedigende werking)
+- Algemene wet bestuursrecht art. 7:11 (heroverweging) en art. 5:46 lid 4 (lex mitior, art. 1 lid 2
+  Sr van overeenkomstige toepassing): https://wetten.overheid.nl/BWBR0005537
+- ex-nunc/ex-tunc jurisprudentie: ABRvS *Greenpeace* 28-10-2020 (ECLI:NL:RVS:2020:2571, standaardarrest,
+  r.o. 6.2.3-6.2.9); *Steenwijkerland* 21-12-2016 (ECLI:NL:RVS:2016:3388); *Berg en Dal* 21-02-2018
+  (ECLI:NL:RVS:2018:610, uitzonderings-anker). Lex mitior: ABRvS 21-05-2025 (ECLI:NL:RVS:2025:2223),
+  ABRvS 30-08-2023 (ECLI:NL:RVS:2023:3291), CBb 06-07-2021 (ECLI:NL:CBB:2021:700)
+- Statische-verwijzing-formule in wetgeving: Wet IB 2001 art. 10bis.1 ("zoals dat luidde op
+  31 december 2012"): https://wetten.overheid.nl/BWBR0011353
+- [Glossary of Dutch Legal Terms](/reference/glossary)

--- a/docs/src/content/rfcs/rfc-020.md
+++ b/docs/src/content/rfcs/rfc-020.md
@@ -245,10 +245,11 @@ Extends the cucumber-rs harness (`features/bezwaartermijn.feature`, `features/ei
 4. *propagation*: an inner reference without `as_of` inherits the outer one; an inner `as_of`
    overrides for its subtree.
 5. *failure path*: `as_of` *past* the target's `valid_to` (e.g. `as_of: '2027-01-01'` on a law
-   with `valid_to: '2026-12-31'`) yields a [RFC-019](/rfcs/rfc-019) `SelectionReason` error
-   reported against the resolved date - never a silent miss.
+   with `valid_to: '2026-12-31'`) yields a [RFC-019](/rfcs/rfc-019) §3 `SelectionReason` error
+   (`EndedOn`) reported against the resolved date - never a silent miss.
 6. *failure path, symmetric*: `as_of` *before* the target's `valid_from` (law not yet in force -
-   e.g. an `overtreding_datum` predating the law) yields the same `SelectionReason` error.
+   e.g. an `overtreding_datum` predating the law) yields the corresponding `SelectionReason`
+   error (`NotYetInForce`).
 7. *IoC propagation*: with an outer `as_of`, implementing regulations (`open_terms`/`implements`,
    [RFC-003](/rfcs/rfc-003)) are selected at the propagated date, not at `calculation_date` -
    the §5 rule, with two versions of an implementing regulation loaded.
@@ -289,12 +290,20 @@ Plus `as_of` cases in the **Temporal** conformance level ([RFC-014](/rfcs/rfc-01
 
 ### Implementation Notes
 
-- **Schema**: additive `as_of` on `source` (literal date or `$`-parameter). `source` is
+- **Schema**: additive `as_of` on `source` (literal date or `$`-parameter), encoded as the
+  existing union pattern `oneOf: [variableReference, {type: string, format: date}]` so malformed
+  dates and unprefixed parameter names fail validation. `as_of` is only meaningful when
+  `regulation` is present (there is no law to version-select otherwise) - the schema must make
+  that conditional (e.g. `if: {required: [regulation]}`), not silently ignore it. `source` is
   `additionalProperties: false`, so this needs a new minor schema version - additive, non-breaking.
 - **Engine**: thread `as_of` (default `calculation_date`) through the cross-law resolution path;
   inherit down the subtree, innermost wins; reuse [RFC-019](/rfcs/rfc-019)'s selection at the
   resolved date; include the resolved date in memoization and cycle-detection keys; report
   selection failures ([RFC-019](/rfcs/rfc-019) §3 `SelectionReason`) relative to the resolved date.
+  Date-keyed cycle detection catches same-date self-reference; a regressive chain (A at *D*
+  referencing A at *D−1*, and so on) has a unique key per step and is backstopped by the engine's
+  existing cross-law depth limit (`MAX_CROSS_LAW_DEPTH`) - a deliberate constraint, since static
+  corpus YAML cannot generate ever-older `as_of` values itself.
 - **Receipt/trace**: record the resolved date per reference ([RFC-013](/rfcs/rfc-013)).
 - **Policy**: an Engine Policy entry for the ex-nunc / onmiddellijke-werking default, annotated
   with its jurisprudential basis.

--- a/docs/src/content/rfcs/rfc-020.md
+++ b/docs/src/content/rfcs/rfc-020.md
@@ -117,12 +117,19 @@ Four boundaries keep it faithful and out of the engine:
   *which* is favourable is domain knowledge in the rule (fixed fine → `MIN`; conduct no longer
   punishable → `IF`). The engine never "tries all dates and optimizes".
 
-### 5. Interaction with hooks/overrides
+### 5. Interaction with hooks/overrides and IoC
 
 Hook and override candidates are already filtered by `valid_from` ([RFC-007](/rfcs/rfc-007));
 [RFC-019](/rfcs/rfc-019)'s `valid_to` and this RFC's `as_of` apply identically: an ended candidate
 drops out, `as_of` selects the applicable version. A conformance case ([RFC-014](/rfcs/rfc-014))
 locks this in.
+
+The IoC pattern (`open_terms`/`implements`, [RFC-003](/rfcs/rfc-003)) follows the **same
+propagation rule**: when a reference carries `as_of`, implementing regulations for the referenced
+subtree are selected at the propagated date, not at `calculation_date`. A statische verwijzing to
+an older version of a law therefore uses the implementing regulations *that were in force on that
+date* - the legally correct reading, and the only one consistent with "inherited down the subtree".
+Selecting implementations at `calculation_date` would be an undocumented exception to that rule.
 
 ## Worked examples
 
@@ -135,7 +142,9 @@ original *besluit* moment (ex tunc) is selected by which event date is passed as
 # Default (ex nunc): heroverweging follows current law - no as_of, uses calculation_date
 input:
   - name: oorspronkelijk_recht
-    source: { regulation: vreemdelingenwet_2000, output: verblijfsvergunning_verleend }
+    source:
+      regulation: vreemdelingenwet_2000
+      output: verblijfsvergunning_verleend
 ```
 
 ```yaml
@@ -175,10 +184,16 @@ only `as_of` is new.
 input:
   - name: boete_overtredingsmoment
     type: amount
-    source: { regulation: wet_x, output: boetebedrag, as_of: $overtreding_datum }
+    source:
+      regulation: wet_x
+      output: boetebedrag
+      as_of: $overtreding_datum
   - name: boete_beschikkingsmoment
     type: amount
-    source: { regulation: wet_x, output: boetebedrag, as_of: $beschikking_datum }
+    source:
+      regulation: wet_x
+      output: boetebedrag
+      as_of: $beschikking_datum
 actions:
   - output: boete
     value:
@@ -200,9 +215,11 @@ actions:
 - **No reset to `calculation_date` inside an inherited `as_of` context**: propagation (§2) is
   "inherited down the subtree, innermost wins", and `calculation_date` is an engine-level value
   that is not addressable as a `$`-parameter in law YAML - so a referenced law cannot declare
-  "always resolve my sub-references at the current date" (e.g. a dynamic rate table). Deliberate
-  for temporal consistency, but if a real corpus case needs it, an explicit escape
-  (e.g. `as_of: $calculation_date`) would be a schema addition.
+  "always resolve my sub-references at the current date" (e.g. a dynamic rate table). This is a
+  deliberate constraint for temporal consistency. An explicit escape would need an **engine
+  change** (injecting `calculation_date` as a reserved parameter, with name-collision and
+  nested-subtree semantics to settle), not just a schema addition - so it stays out of scope until
+  a real corpus case demands it.
 
 ## Testing
 
@@ -215,6 +232,9 @@ Extends the cucumber-rs harness (`features/bezwaartermijn.feature`, `features/ei
 3. *lex mitior*: a boete computed at two `as_of` dates yields the favourable (lower) result.
 4. *propagation*: an inner reference without `as_of` inherits the outer one; an inner `as_of`
    overrides for its subtree.
+5. *failure path*: `as_of` *past* the target's `valid_to` (e.g. `as_of: '2027-01-01'` on a law
+   with `valid_to: '2026-12-31'`) yields a [RFC-019](/rfcs/rfc-019) `SelectionReason` error
+   reported against the resolved date - never a silent miss.
 
 Plus `as_of` cases in the **Temporal** conformance level ([RFC-014](/rfcs/rfc-014)).
 

--- a/docs/src/content/rfcs/rfc-020.md
+++ b/docs/src/content/rfcs/rfc-020.md
@@ -158,7 +158,7 @@ input:
 ```
 
 *(Illustrative: the corpus `vreemdelingenwet_2000` does not yet expose
-`verblijfsvergunning_verleend`, and Awb 7:11 is not yet in the corpus AWB - the modeled chain today
+`verblijfsvergunning_verleend`, and Awb 7:11 is not yet in the corpus Awb - the modeled chain today
 is the bezwaartermijn. The example shows the mechanism; modeling the heroverweging is
 implementation work.)*
 
@@ -187,19 +187,23 @@ input:
     source:
       regulation: wet_x
       output: boetebedrag
-      as_of: $overtreding_datum    # RFC-008 stage input, like $besluit_datum in Example A
-  - name: boete_beschikkingsmoment
+      as_of: $overtreding_datum    # new stage input - see note below
+  - name: boete_besluitmoment
     type: amount
     source:
       regulation: wet_x
       output: boetebedrag
-      as_of: $beschikking_datum    # RFC-008 stage input, like $besluit_datum in Example A
+      as_of: $besluit_datum        # RFC-008 stage input, as in Example A
 actions:
   - output: boete
     value:
       operation: MIN          # gunstigste (= laagste) van twee momenten - art. 5:46 lid 4 Awb
-      values: [$boete_overtredingsmoment, $boete_beschikkingsmoment]
+      values: [$boete_overtredingsmoment, $boete_besluitmoment]
 ```
+
+*(`$besluit_datum` is the existing [RFC-008](/rfcs/rfc-008) BEHANDELING stage input.
+`$overtreding_datum` is not: a boete procedure needs its own lifecycle that adds it as a stage
+input - that lifecycle is future RFC-008 extension work, alongside modeling this pattern.)*
 
 ## Still open
 
@@ -220,6 +224,11 @@ actions:
   change** (injecting `calculation_date` as a reserved parameter, with name-collision and
   nested-subtree semantics to settle), not just a schema addition - so it stays out of scope until
   a real corpus case demands it.
+- **`as_of: $param` with the parameter absent at runtime**: silently falling back to
+  `calculation_date` would hide a caller error and contradict [RFC-015](/rfcs/rfc-015)'s
+  zero-domain-knowledge policy - the engine cannot know whether the date was optional. The
+  expected resolution is a strict resolution error (mirroring how missing required inputs already
+  fail), but this must be settled in the implementation.
 
 ## Testing
 
@@ -236,6 +245,8 @@ Extends the cucumber-rs harness (`features/bezwaartermijn.feature`, `features/ei
 5. *failure path*: `as_of` *past* the target's `valid_to` (e.g. `as_of: '2027-01-01'` on a law
    with `valid_to: '2026-12-31'`) yields a [RFC-019](/rfcs/rfc-019) `SelectionReason` error
    reported against the resolved date - never a silent miss.
+6. *failure path, symmetric*: `as_of` *before* the target's `valid_from` (law not yet in force -
+   e.g. an `overtreding_datum` predating the law) yields the same `SelectionReason` error.
 
 Plus `as_of` cases in the **Temporal** conformance level ([RFC-014](/rfcs/rfc-014)).
 

--- a/docs/src/content/rfcs/rfc-020.md
+++ b/docs/src/content/rfcs/rfc-020.md
@@ -136,7 +136,9 @@ original *besluit* moment (ex tunc) is selected by which event date is passed as
 input:
   - name: oorspronkelijk_recht
     source: { regulation: vreemdelingenwet_2000, output: verblijfsvergunning_verleend }
+```
 
+```yaml
 # Exception (ex tunc / eerbiedigende werking): evaluate the law as at the besluit moment
 input:
   - name: oorspronkelijk_recht
@@ -195,6 +197,12 @@ actions:
   static and defers a "terminates" mechanism that *derives* a law's end from the terminating
   instrument. That is the same cross-law, date-aware territory as `as_of` and belongs alongside
   this model.
+- **No reset to `calculation_date` inside an inherited `as_of` context**: propagation (§2) is
+  "inherited down the subtree, innermost wins", and `calculation_date` is an engine-level value
+  that is not addressable as a `$`-parameter in law YAML - so a referenced law cannot declare
+  "always resolve my sub-references at the current date" (e.g. a dynamic rate table). Deliberate
+  for temporal consistency, but if a real corpus case needs it, an explicit escape
+  (e.g. `as_of: $calculation_date`) would be a schema addition.
 
 ## Testing
 


### PR DESCRIPTION
## Summary

**RFC-020** — concept 2 of the temporal-validity split. Where [RFC-019 (#766)](https://github.com/MinBZK/regelrecht/pull/766) adds a law **end date** relative to the global `calculation_date`, RFC-020 lets a **reference** be resolved at a *different* date and have that date **propagate** down its subtree.

> **Stacked on #766.** Base branch is `docs/rfc-019-temporal-validity` so RFC-020's `[RFC-019]` links resolve in the docs link-check. The diff here is only `rfc-020.md`. When #766 merges, GitHub retargets this PR to `main`.

## What it proposes

- **`as_of`** on a cross-law reference / open-term resolution. Default = dynamic (follows `calculation_date`, the hoofdregel). `as_of: <date|$param>` resolves the referenced law (and its subtree) at that date — modeling **statische verwijzing**, **ex tunc**, and **eerbiedigende werking**. Propagation: inherited down the subtree, innermost wins. The resolved date is recorded per reference in trace/receipt (RFC-013).
- **Applicable date is computed by law**, not engine heuristic: the Awb (heroverweging art. 7:11) and/or the specific law's overgangsrecht. The ex-nunc reading is *jurisprudential* (standard arrest ABRvS Greenpeace 28-10-2020, ECLI:NL:RVS:2020:2571; Steenwijkerland ECLI:NL:RVS:2016:3388; exception-side anchor Berg en Dal ECLI:NL:RVS:2018:610) and the overgangsrecht default is **onmiddellijke werking** (Aanwijzing 5.61) — so those defaults live in **Engine Policy**, overridable per reference.
- **Multiple dates per beoordeling are codified**: lex mitior (art. 5:46 lid 4 Awb; ABRvS 21-05-2025 ECLI:NL:RVS:2025:2223; ABRvS 30-08-2023 ECLI:NL:RVS:2023:3291; CBb 06-07-2021 ECLI:NL:CBB:2021:700) — proving `as_of` must be **per-reference**. With four faithfulness boundaries: mandatory & offender-favourable, punitive-only, only on gewijzigd inzicht van de wetgever, selector-in-law (`MIN`/`IF`, the engine never optimizes over dates).
- Three temporal axes named: instrument validity (RFC-019) vs substantive scope vs applicable-date selection.

## Grounding

Every claim verified against the official sources: Awb art. 7:11 lid 1 and 5:46 lid 4 quoted verbatim (wetten.overheid.nl), Aanwijzingen 3.47 / 5.60 / 5.61 / 5.64 (BWBR0005730, status as drafting guidelines noted), and all six jurisprudence anchors pinned to their ECLIs on rechtspraak.nl. Worked YAML per mechanism (ex nunc/ex tunc, statische verwijzing, lex mitior) — all examples stay within the existing operation grammar; only `as_of` itself is new.

## Review round processed

- Example C (lex mitior) rewritten to two inputs + `MIN` over variables (the earlier shape put `source`-objects inside operation values, which the schema does not allow).
- ECLIs added for all six anchors; CBb date corrected to 6 juli 2021; ABRvS 30-08-2023 disambiguated to ECLI:NL:RVS:2023:3291 (a same-day lex-certa ruling exists).
- Fourth lex-mitior boundary (gewijzigd inzicht van de wetgever, per ABRvS 21-05-2025).
- "zoals dat luidde op <datum>" attributed to the statutory formula (Wet IB 2001 art. 10bis.1), not to Aanwijzing 3.47's own wording.
- Example A marked illustrative (`vreemdelingenwet_2000` has no `verblijfsvergunning_verleend` output yet; Awb 7:11 not yet in the corpus).
- Implementation notes: `as_of` in memoization/cycle-detection keys; `source` is `additionalProperties: false` so a new minor schema version is needed; selection failures reported relative to the resolved date.

## Status

**Draft** — design discussion. Implementation follows once the open points (form of the Engine Policy default; reusable lex-mitior pattern) are settled, after RFC-019 lands.
