### PR TITLE
docs(untranslatables): herframe als 'nog niet' en als signaal voor de engine-roadmap

### DIFF
--- a/docs/src/content/docs/concepts/how-it-works.md
+++ b/docs/src/content/docs/concepts/how-it-works.md
@@ -120,7 +120,7 @@ Sometimes a specific law overrides a general rule. The Aliens Act (*Vreemdelinge
 
 ### Untranslatables
 
-The engine's operation set is deliberately small. When a legal construct cannot be faithfully expressed, rounding rules, complex table lookups, discretionary assessments, it is flagged as an **untranslatable** rather than approximated. The engine can error, warn, or propagate taint through downstream outputs, depending on the mode. This prevents silent divergence between law text and machine-readable interpretation. See [Untranslatables](./untranslatables).
+The engine's operation set is deliberately small. When a legal construct cannot yet be faithfully expressed, rounding rules, complex table lookups, discretionary assessments, it is flagged as an **untranslatable** rather than approximated. "Untranslatable" means "not yet", not "never": each flag is a named gap in the engine and a tracked signal for what operation to build next. The engine can error, warn, or propagate taint through downstream outputs, depending on the mode. This prevents silent divergence between law text and machine-readable interpretation. See [Untranslatables](./untranslatables).
 
 ### Execution provenance
 

--- a/docs/src/content/docs/concepts/untranslatables.md
+++ b/docs/src/content/docs/concepts/untranslatables.md
@@ -1,22 +1,24 @@
 ---
 title: "Untranslatables"
-description: "The legal constructs that cannot be faithfully expressed with the engine's operations, and how they are handled."
+description: "Legal constructs the engine cannot express yet, why each one is a feature request against the engine, and how they are handled at runtime."
 ---
 
-The engine's operation set is deliberately small: arithmetic, comparison, conditional logic, date operations. Dutch law regularly uses constructs that fall outside this set. When a legal construct cannot be faithfully expressed with available operations, it is an **untranslatable**.
+The engine's operation set is deliberately small: arithmetic, comparison, conditional logic, date operations. Dutch law regularly uses constructs that fall outside this set. When a legal construct cannot yet be faithfully expressed with available operations, it is an **untranslatable**.
 
-The term comes from translation theory. The law-generate process *is* translation, from legal Dutch to machine-readable YAML, and some things do not cross that boundary.
+"Untranslatable" means "not yet", not "never". It is not a verdict that the law is beyond machines. It is a named gap in the engine: a specific operation or schema feature we have not built yet. Every untranslatable is therefore a concrete feature request against the engine, recorded at the exact article that needs it.
+
+The term comes from translation theory. The law-generate process *is* translation, from legal Dutch to machine-readable YAML, and some things do not cross that boundary yet.
 
 ## What makes something untranslatable
 
-A construct is untranslatable when the engine cannot express it without approximation. Examples:
+A construct is untranslatable when the engine cannot yet express it without approximation. Examples:
 
 - **Rounding rules** ("afgerond op hele euro's") when no ROUND operation exists
 - **Table lookups** (bracket tables with many rows) that would require fragile chains of IF cases
 - **Calendar logic** ("the next working day") when the engine has no holiday calendar
 - **Discretionary assessments** ("naar het oordeel van de minister") that are inherently human
 
-The key distinction: the law is clear about what it means, but the engine's formal language cannot yet express it.
+The key distinction: the law is clear about what it means, but the engine's formal language cannot express it yet. The gap is the engine's, not the law's, and we expect to close it.
 
 ## How they are flagged
 
@@ -35,6 +37,8 @@ machine_readable:
 ```
 
 Articles with untranslatables can still have partial execution logic for the parts that are expressible. The untranslatable annotation marks what is missing, not what is wrong.
+
+The `suggestion` field names the engine operation or schema feature that would close the gap (for example `Add ROUND/CEIL/FLOOR operation to engine`). This is what turns an untranslatable from a complaint into a feature request: it points directly at what to build next.
 
 The `accepted` field indicates whether a human has reviewed and acknowledged the gap. This controls per-article runtime behavior.
 
@@ -55,7 +59,7 @@ In `propagate` mode, `UNTRANSLATABLE` behaves like `NaN` in floating point: any 
 
 ## Driving the engine roadmap
 
-Untranslatables tell us which operations to add next. When enough laws need rounding, we add ROUND. When enough laws need table lookups, we add TABLE. The corpus drives the engine roadmap.
+This is the point of the feature, not a side effect. Untranslatables tell us which operations to add next. When enough laws need rounding, we add ROUND. When enough laws need table lookups, we add TABLE. Each `suggestion` is a vote, weighted by how many articles depend on it, and the corpus drives the engine roadmap. As the engine grows, today's untranslatables become tomorrow's ordinary execution logic.
 
 ## Further reading
 


### PR DESCRIPTION
De documentatie over untranslatables (docs.regelrecht.rijks.app) las als een categorische beperking: "een construct dat niet getrouw kan worden uitgedrukt". Dat suggereert dat zo'n stuk wet buiten het bereik van machines valt. Dat klopt niet. Het betekent dat de engine het *nog niet* kan.

Deze PR maakt twee dingen prominent op de concept-pagina en in de how-it-works-samenvatting:

1. **"Nog niet", niet "nooit".** Een untranslatable is een present-tense gat in de operatieset / het schema van de engine, geen permanente eigenschap van de wet. De wet is duidelijk; de engine kan het vandaag alleen niet uitdrukken.
2. **Het is een signaal.** Elke untranslatable is een concrete feature request tegen de engine, vastgelegd op het artikel dat het nodig heeft. Het `suggestion`-veld wijst direct aan wat er gebouwd moet worden, en stuurt zo de roadmap.

## Wijzigingen

- `concepts/untranslatables.md`: nieuwe alinea vooraan ("'nog niet', niet 'nooit'"), "yet" door de definities heen, `suggestion`-veld beschreven als de feature-request-haak, en de roadmap-sectie versterkt.
- `concepts/how-it-works.md`: de samenvattende teaser benoemt nu expliciet "nog niet, niet nooit" en het signaal-karakter.

Buiten scope: RFC-012/013/014 (geaccepteerde, gedateerde ontwerp-records) en het schema zelf (het datamodel ondersteunt de intentie al via `suggestion`/`accepted`).

## Verificatie

`cd docs && npm run build` draait schoon (71 pagina's, frontmatter en interne links intact).