### PR TITLE
chore(deps): stop Dependabot from updating @nldd/design-system

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,6 +39,9 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      # Our own design package — bump manually, not via Dependabot
+      - dependency-name: '@nldd/design-system'
 
   - package-ecosystem: docker
     directory: /frontend
@@ -71,6 +74,9 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      # Our own design package — bump manually, not via Dependabot
+      - dependency-name: '@nldd/design-system'
 
   - package-ecosystem: docker
     directory: /packages/admin
@@ -102,6 +108,9 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      # Our own design package — bump manually, not via Dependabot
+      - dependency-name: '@nldd/design-system'
 
   - package-ecosystem: npm
     directory: /frontend-lawmaking
@@ -116,6 +125,9 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      # Our own design package — bump manually, not via Dependabot
+      - dependency-name: '@nldd/design-system'
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
## What

Adds a Dependabot `ignore` rule for `@nldd/design-system` to all four npm ecosystems that depend on it: `/frontend`, `/packages/admin/frontend-src`, `/docs`, and `/frontend-lawmaking`.

## Why

`@nldd/design-system` is **our own design package**. Its version should be bumped deliberately, in lockstep with the corresponding UI work, rather than landing as automated Dependabot PRs. Auto-bumping it also keeps churning the `npm-minor-patch` group (e.g. it appeared in #753, #754, #756) and, in #756, an unrelated `marked` regression blocked the whole group anyway.

After this change Dependabot will leave `@nldd/design-system` alone in all four projects; we bump it manually when we pull in new design-system work. All other npm dependencies remain grouped and auto-updated as before.