### PR TITLE
fix(harvester): only commit when law content actually changed

### DIFF
--- a/packages/corpus/src/client.rs
+++ b/packages/corpus/src/client.rs
@@ -234,8 +234,13 @@ impl CorpusClient {
             .collect()
     }
 
-    /// Stage the given paths (`git add -- <paths>`). No-op when `paths` is empty.
+    /// Stage the given paths (`git add -- <paths>`). No-op when `paths` is
+    /// empty — running `git add --` with no pathspecs is a no-op on some git
+    /// versions but errors on others, so guard it.
     async fn stage_paths(&self, paths: &[PathBuf]) -> Result<()> {
+        if paths.is_empty() {
+            return Ok(());
+        }
         let path_strings = Self::path_strings(paths);
         let mut add_args = vec!["add", "--"];
         add_args.extend(path_strings.iter().map(String::as_str));

--- a/packages/corpus/src/client.rs
+++ b/packages/corpus/src/client.rs
@@ -140,16 +140,7 @@ impl CorpusClient {
     /// Uses a retry loop around rebase+push to handle concurrent push race
     /// conditions where multiple workers push to the same branch.
     pub async fn commit_and_push(&self, paths: &[PathBuf], message: &str) -> Result<()> {
-        // Stage the specific files
-        let mut add_args = vec!["add", "--"];
-        let path_strings: Vec<String> = paths
-            .iter()
-            .map(|p| p.to_string_lossy().to_string())
-            .collect();
-        for p in &path_strings {
-            add_args.push(p);
-        }
-        self.run_git(&add_args).await?;
+        self.stage_paths(paths).await?;
 
         // Check if there's anything to commit
         let status_output = self.run_git_output(&["status", "--porcelain"]).await?;
@@ -162,15 +153,105 @@ impl CorpusClient {
         // Commit
         self.run_git(&["commit", "-m", message]).await?;
 
-        // Retry loop: rebase on remote, then push. If push fails due to a
-        // concurrent update, fetch+rebase again and retry with backoff.
+        self.rebase_and_push(message).await
+    }
+
+    /// Commit and push, but treat `content_paths` as the only thing that
+    /// counts as a "real change". `metadata_paths` (e.g. a `status.yaml`
+    /// carrying a `last_harvested` timestamp that churns on every run) are
+    /// committed *alongside* content when content changed, but never *trigger*
+    /// a commit on their own.
+    ///
+    /// Returns `Ok(true)` if a commit was made and pushed, `Ok(false)` if the
+    /// content was unchanged (in which case the metadata files are restored to
+    /// HEAD so the working tree stays clean for the next run — this matters for
+    /// the long-lived corpus clone the harvest worker reuses).
+    pub async fn commit_and_push_content(
+        &self,
+        content_paths: &[PathBuf],
+        metadata_paths: &[PathBuf],
+        message: &str,
+    ) -> Result<bool> {
+        // Stage only the content so the porcelain check below reflects content
+        // changes alone, not the always-churning metadata files.
+        self.stage_paths(content_paths).await?;
+
+        let content_path_strings = Self::path_strings(content_paths);
+        let mut status_args = vec!["status", "--porcelain", "--"];
+        status_args.extend(content_path_strings.iter().map(String::as_str));
+        let status_output = self.run_git_output(&status_args).await?;
+
+        if status_output.trim().is_empty() {
+            tracing::debug!("no content changes, skipping commit");
+            // Discard the churned metadata (e.g. status.yaml timestamp) so the
+            // working tree matches HEAD again — critical for the long-lived
+            // corpus clone, where a leftover dirty/untracked file would break
+            // the next `pull --rebase`.
+            self.restore_metadata(metadata_paths).await;
+            return Ok(false);
+        }
+
+        // Content changed — stage the metadata files alongside it and commit both.
+        self.stage_paths(metadata_paths).await?;
+        self.run_git(&["commit", "-m", message]).await?;
+        self.rebase_and_push(message).await?;
+        Ok(true)
+    }
+
+    /// Reset the given metadata paths back to HEAD: restore tracked files and
+    /// remove any still-untracked ones, so the working tree is clean afterward.
+    /// Best-effort — failures are logged but not propagated, since the caller
+    /// is already returning the "no changes" success path.
+    async fn restore_metadata(&self, metadata_paths: &[PathBuf]) {
+        let path_strings = Self::path_strings(metadata_paths);
+        if path_strings.is_empty() {
+            return;
+        }
+        let pathspecs: Vec<&str> = path_strings.iter().map(String::as_str).collect();
+
+        // Tracked metadata: restore the committed contents (drops the churn).
+        let mut checkout_args = vec!["checkout", "--"];
+        checkout_args.extend(pathspecs.iter().copied());
+        if let Err(e) = self.run_git(&checkout_args).await {
+            // Expected when a metadata file was never tracked (nothing to
+            // restore); the `git clean` below removes those instead.
+            tracing::debug!(error = %e, "metadata checkout had nothing to restore");
+        }
+
+        // Untracked metadata: remove it so the tree is clean for the next run.
+        let mut clean_args = vec!["clean", "-fq", "--"];
+        clean_args.extend(pathspecs.iter().copied());
+        if let Err(e) = self.run_git(&clean_args).await {
+            tracing::warn!(error = %e, "failed to clean untracked metadata; working tree may be dirty");
+        }
+    }
+
+    /// Lossy UTF-8 path strings for use as git pathspec arguments.
+    fn path_strings(paths: &[PathBuf]) -> Vec<String> {
+        paths
+            .iter()
+            .map(|p| p.to_string_lossy().to_string())
+            .collect()
+    }
+
+    /// Stage the given paths (`git add -- <paths>`). No-op when `paths` is empty.
+    async fn stage_paths(&self, paths: &[PathBuf]) -> Result<()> {
+        let path_strings = Self::path_strings(paths);
+        let mut add_args = vec!["add", "--"];
+        add_args.extend(path_strings.iter().map(String::as_str));
+        self.run_git(&add_args).await
+    }
+
+    /// Rebase on the remote branch then push the local commit, retrying with
+    /// backoff to absorb concurrent pushes from other workers.
+    async fn rebase_and_push(&self, message: &str) -> Result<()> {
         let mut last_error = None;
         for attempt in 1..=Self::MAX_PUSH_ATTEMPTS {
             // Pull --rebase to incorporate any concurrent remote changes.
             // On shallow clones (--depth 1), rebase may fail if the remote
             // advanced by many commits. The error-recovery path below
             // restores the working tree (abort rebase + hard-reset to remote)
-            // and propagates the error for job-level retry. The enriched
+            // and propagates the error for job-level retry. The committed
             // files remain on disk so the next attempt can re-stage them.
             if let Err(e) = self
                 .run_git(&["pull", "--rebase", "origin", &self.config.branch])
@@ -820,6 +901,157 @@ mod tests {
             .unwrap();
         let log_str = String::from_utf8_lossy(&log.stdout);
         assert!(log_str.contains("add test file"));
+    }
+
+    #[tokio::test]
+    async fn test_commit_and_push_content_skips_metadata_only_change() {
+        let dir = tempfile::tempdir().unwrap();
+        let bare_path = setup_bare_repo(dir.path()).await;
+        let bare_url = format!("file://{}", bare_path.display());
+        let repo_path = dir.path().join("corpus");
+        clone_with_config(&bare_path, &repo_path).await;
+
+        let law = repo_path.join("law.yaml");
+        let status = repo_path.join("status.yaml");
+        tokio::fs::write(&law, "articles: 1\n").await.unwrap();
+        tokio::fs::write(&status, "last_harvested: T1\n")
+            .await
+            .unwrap();
+
+        let config = CorpusConfig::new(&bare_url, &repo_path);
+        let client = CorpusClient::new(config);
+
+        // First harvest: content is new → commit made.
+        let committed = client
+            .commit_and_push_content(
+                std::slice::from_ref(&law),
+                std::slice::from_ref(&status),
+                "harvest: initial",
+            )
+            .await
+            .unwrap();
+        assert!(committed, "first harvest should commit new content");
+
+        let count_commits = |path: PathBuf| async move {
+            let out = Command::new("git")
+                .args(["rev-list", "--count", "HEAD"])
+                .current_dir(&path)
+                .output()
+                .await
+                .unwrap();
+            String::from_utf8_lossy(&out.stdout).trim().to_string()
+        };
+        let commits_after_first = count_commits(bare_path.clone()).await;
+
+        // Re-harvest: identical law content, only the status timestamp churns.
+        tokio::fs::write(&status, "last_harvested: T2\n")
+            .await
+            .unwrap();
+        let committed = client
+            .commit_and_push_content(
+                std::slice::from_ref(&law),
+                std::slice::from_ref(&status),
+                "harvest: no change",
+            )
+            .await
+            .unwrap();
+        assert!(!committed, "metadata-only change must not commit");
+
+        // No new commit on the remote.
+        assert_eq!(
+            commits_after_first,
+            count_commits(bare_path.clone()).await,
+            "no new commit should be pushed for a metadata-only change"
+        );
+        // The churned metadata file was restored to HEAD (T1), keeping the
+        // working tree clean for the next run.
+        let restored = tokio::fs::read_to_string(&status).await.unwrap();
+        assert_eq!(restored, "last_harvested: T1\n");
+
+        // Real content change → commit again.
+        tokio::fs::write(&law, "articles: 2\n").await.unwrap();
+        tokio::fs::write(&status, "last_harvested: T3\n")
+            .await
+            .unwrap();
+        let committed = client
+            .commit_and_push_content(
+                std::slice::from_ref(&law),
+                std::slice::from_ref(&status),
+                "harvest: real change",
+            )
+            .await
+            .unwrap();
+        assert!(committed, "content change should commit");
+
+        let log = Command::new("git")
+            .args(["log", "--oneline"])
+            .current_dir(&bare_path)
+            .output()
+            .await
+            .unwrap();
+        let log_str = String::from_utf8_lossy(&log.stdout);
+        assert!(log_str.contains("harvest: initial"));
+        assert!(log_str.contains("harvest: real change"));
+        assert!(
+            !log_str.contains("harvest: no change"),
+            "no-change harvest must not appear in history: {log_str}"
+        );
+    }
+
+    /// When law content is unchanged (tracked) but the metadata file is
+    /// untracked, the no-change path must leave the working tree clean —
+    /// otherwise a leftover untracked status.yaml breaks the next pull --rebase.
+    #[tokio::test]
+    async fn test_commit_and_push_content_cleans_untracked_metadata() {
+        let dir = tempfile::tempdir().unwrap();
+        let bare_path = setup_bare_repo(dir.path()).await;
+        let bare_url = format!("file://{}", bare_path.display());
+        let repo_path = dir.path().join("corpus");
+        clone_with_config(&bare_path, &repo_path).await;
+
+        let law = repo_path.join("law.yaml");
+        let status = repo_path.join("status.yaml");
+        tokio::fs::write(&law, "articles: 1\n").await.unwrap();
+
+        let config = CorpusConfig::new(&bare_url, &repo_path);
+        let client = CorpusClient::new(config);
+
+        // Commit only the law YAML — status.yaml never gets tracked.
+        let committed = client
+            .commit_and_push_content(std::slice::from_ref(&law), &[], "harvest: law only")
+            .await
+            .unwrap();
+        assert!(committed);
+
+        // Now an untracked status.yaml appears next to unchanged law content.
+        tokio::fs::write(&status, "last_harvested: T1\n")
+            .await
+            .unwrap();
+        let committed = client
+            .commit_and_push_content(
+                std::slice::from_ref(&law),
+                std::slice::from_ref(&status),
+                "harvest: untracked metadata",
+            )
+            .await
+            .unwrap();
+        assert!(!committed, "unchanged content must not commit");
+
+        // The untracked metadata was cleaned and the tree is clean.
+        assert!(
+            !status.exists(),
+            "untracked status.yaml should have been removed"
+        );
+        let porcelain = Command::new("git")
+            .args(["status", "--porcelain"])
+            .current_dir(&repo_path)
+            .output()
+            .await
+            .unwrap();
+        assert!(
+            String::from_utf8_lossy(&porcelain.stdout).trim().is_empty(),
+            "working tree must be clean after no-change harvest"
+        );
     }
 
     /// Verify that a worker whose local repo is behind the remote can

--- a/packages/pipeline/src/harvest.rs
+++ b/packages/pipeline/src/harvest.rs
@@ -103,6 +103,21 @@ fn default_changed() -> bool {
     true
 }
 
+/// The files a harvest writes to disk, split by their role in the commit.
+///
+/// `content` (the law YAML) is what gates the commit: a re-harvest only
+/// produces a new version when this file changes. `metadata` (`status.yaml`)
+/// is committed alongside content but carries a `last_harvested` timestamp
+/// that churns every run, so it must never trigger a commit on its own. The
+/// split is a typed contract so the worker can pass the two roles to
+/// `CorpusClient::commit_and_push_content` without relying on positional
+/// ordering.
+#[derive(Debug, Clone)]
+pub struct HarvestFiles {
+    pub content: PathBuf,
+    pub metadata: PathBuf,
+}
+
 /// Status file written alongside the law YAML.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LawStatusFile {
@@ -129,14 +144,14 @@ pub struct LawStatusFile {
 /// depends on pipeline-level logic (manifest resolution) that lives outside
 /// the harvester crate.
 ///
-/// Returns the harvest result and a list of file paths that were written
-/// (for git staging).
+/// Returns the harvest result and the files that were written, split into the
+/// content (law YAML) and metadata (`status.yaml`) roles for git staging.
 pub async fn execute_harvest(
     payload: &HarvestPayload,
     repo_path: &Path,
     output_base: &str,
     http_client: &Client,
-) -> Result<(HarvestResult, Vec<PathBuf>)> {
+) -> Result<(HarvestResult, HarvestFiles)> {
     let law_id = payload.law_id().ok_or_else(|| {
         crate::error::PipelineError::InvalidInput(
             "harvest payload must have either bwb_id or cvdr_id".into(),
@@ -250,11 +265,11 @@ pub async fn execute_harvest(
         changed: true,
     };
 
-    // Order matters: [0] is the law YAML (content), [1] is status.yaml
-    // (metadata). The worker relies on this so it can gate the commit on
-    // content changes while ignoring the always-churning status timestamp.
-    let written_files = vec![yaml_path, status_file_path];
-    Ok((result, written_files))
+    let files = HarvestFiles {
+        content: yaml_path,
+        metadata: status_file_path,
+    };
+    Ok((result, files))
 }
 
 #[cfg(test)]

--- a/packages/pipeline/src/harvest.rs
+++ b/packages/pipeline/src/harvest.rs
@@ -86,10 +86,21 @@ pub struct HarvestResult {
     /// Source type: "bwb" or "cvdr".
     #[serde(default = "default_source_type")]
     pub source_type: String,
+    /// Whether this harvest actually changed the law content (and thus produced
+    /// a corpus commit). `false` means the re-harvest was byte-identical to the
+    /// existing version and only the harvest timestamp differed — no new version
+    /// was committed. Set by the worker after the corpus commit; defaults to
+    /// `true` so older serialized results deserialize unchanged.
+    #[serde(default = "default_changed")]
+    pub changed: bool,
 }
 
 fn default_source_type() -> String {
     "bwb".to_string()
+}
+
+fn default_changed() -> bool {
+    true
 }
 
 /// Status file written alongside the law YAML.
@@ -234,8 +245,14 @@ pub async fn execute_harvest(
         referenced_bwb_ids,
         harvest_date: effective_date,
         source_type,
+        // Optimistic default; the worker overwrites this based on whether the
+        // corpus commit actually changed the law content.
+        changed: true,
     };
 
+    // Order matters: [0] is the law YAML (content), [1] is status.yaml
+    // (metadata). The worker relies on this so it can gate the commit on
+    // content changes while ignoring the always-churning status timestamp.
     let written_files = vec![yaml_path, status_file_path];
     Ok((result, written_files))
 }
@@ -337,6 +354,7 @@ mod tests {
             referenced_bwb_ids: vec!["BWBR0002629".to_string(), "BWBR0018450".to_string()],
             harvest_date: "2025-01-01".to_string(),
             source_type: "bwb".to_string(),
+            changed: true,
         };
 
         let json = serde_json::to_value(&result).unwrap();
@@ -344,6 +362,7 @@ mod tests {
         assert_eq!(json["article_count"], 10);
         assert_eq!(json["harvest_date"], "2025-01-01");
         assert_eq!(json["source_type"], "bwb");
+        assert_eq!(json["changed"], true);
 
         let refs = json["referenced_bwb_ids"].as_array().unwrap();
         assert_eq!(refs.len(), 2);
@@ -357,6 +376,15 @@ mod tests {
         let json = r#"{"law_name":"test","slug":"test","layer":"WET","file_path":"test.yaml","article_count":0,"warning_count":0,"warnings":[],"referenced_bwb_ids":[],"harvest_date":"2025-01-01"}"#;
         let result: HarvestResult = serde_json::from_str(json).unwrap();
         assert_eq!(result.source_type, "bwb");
+    }
+
+    /// Backward compatibility: HarvestResult without `changed` defaults to true,
+    /// so job results stored before this field existed deserialize unchanged.
+    #[test]
+    fn test_harvest_result_default_changed() {
+        let json = r#"{"law_name":"test","slug":"test","layer":"WET","file_path":"test.yaml","article_count":0,"warning_count":0,"warnings":[],"referenced_bwb_ids":[],"harvest_date":"2025-01-01"}"#;
+        let result: HarvestResult = serde_json::from_str(json).unwrap();
+        assert!(result.changed);
     }
 
     #[test]

--- a/packages/pipeline/src/worker.rs
+++ b/packages/pipeline/src/worker.rs
@@ -300,6 +300,20 @@ async fn process_next_job(
                 tracing::warn!(error = %e, law_id = %job.law_id, "failed to upsert law name/slug");
             }
 
+            // When the re-harvest was byte-identical to the existing version
+            // (only the harvest timestamp differed), no new version was
+            // committed — skip the follow-up work that only makes sense for an
+            // actual content change (re-enriching identical content wastes LLM
+            // budget; referenced-law harvests were already queued on the run
+            // that first produced this content).
+            if !result.changed {
+                tracing::info!(
+                    law_id = %job.law_id,
+                    "no changes detected — law content unchanged; skipped commit, enrich, and follow-up harvests"
+                );
+                return Ok(JobOutcome::Processed);
+            }
+
             // Auto-create enrich jobs after successful harvest — one per provider.
             // Each provider writes to its own branch (`enrich/{provider}`)
             // so results can be compared side-by-side.
@@ -1149,9 +1163,14 @@ async fn poll_progress_file(
 ///
 /// The corpus push happens before the DB transaction that marks the job as
 /// completed. If the process crashes after a successful push but before the
-/// DB commit, the job will be retried on restart. This is safe because
-/// `commit_and_push` is idempotent: re-harvesting produces identical files,
-/// and git detects "no changes to commit" when the content matches.
+/// DB commit, the job will be retried on restart. This is safe because the
+/// commit is content-gated: re-harvesting unchanged law content produces no
+/// new commit (`commit_and_push_content` returns `false`), so retries are
+/// idempotent even though the `status.yaml` timestamp churns every run.
+///
+/// Sets `result.changed` to reflect whether a commit was actually made, so the
+/// caller can skip follow-up work (enrich, referenced-law harvests) when the
+/// re-harvest was a no-op.
 async fn execute_harvest_job(
     output_dir: &Path,
     config: &WorkerConfig,
@@ -1159,7 +1178,7 @@ async fn execute_harvest_job(
     corpus: Option<&CorpusClient>,
     http_client: &Client,
 ) -> Result<HarvestResult> {
-    let (result, written_files) = execute_harvest(
+    let (mut result, written_files) = execute_harvest(
         payload,
         output_dir,
         &config.regulation_output_base,
@@ -1169,7 +1188,13 @@ async fn execute_harvest_job(
 
     if let Some(corpus) = corpus {
         let message = format!("harvest: {} ({})", result.law_name, result.slug);
-        corpus.commit_and_push(&written_files, &message).await?;
+        // written_files is [law_yaml (content), status.yaml (metadata)]. Only a
+        // change to the law YAML counts as a real change; the status timestamp
+        // alone must not produce a new version. See harvest::execute_harvest.
+        let (content, metadata) = written_files.split_at(1);
+        result.changed = corpus
+            .commit_and_push_content(content, metadata, &message)
+            .await?;
     }
 
     Ok(result)

--- a/packages/pipeline/src/worker.rs
+++ b/packages/pipeline/src/worker.rs
@@ -1178,7 +1178,7 @@ async fn execute_harvest_job(
     corpus: Option<&CorpusClient>,
     http_client: &Client,
 ) -> Result<HarvestResult> {
-    let (mut result, written_files) = execute_harvest(
+    let (mut result, files) = execute_harvest(
         payload,
         output_dir,
         &config.regulation_output_base,
@@ -1188,12 +1188,14 @@ async fn execute_harvest_job(
 
     if let Some(corpus) = corpus {
         let message = format!("harvest: {} ({})", result.law_name, result.slug);
-        // written_files is [law_yaml (content), status.yaml (metadata)]. Only a
-        // change to the law YAML counts as a real change; the status timestamp
-        // alone must not produce a new version. See harvest::execute_harvest.
-        let (content, metadata) = written_files.split_at(1);
+        // Only a change to the law YAML (content) counts as a real change; the
+        // status.yaml timestamp (metadata) alone must not produce a new version.
         result.changed = corpus
-            .commit_and_push_content(content, metadata, &message)
+            .commit_and_push_content(
+                std::slice::from_ref(&files.content),
+                std::slice::from_ref(&files.metadata),
+                &message,
+            )
             .await?;
     }
 

--- a/packages/pipeline/tests/harvest_tests.rs
+++ b/packages/pipeline/tests/harvest_tests.rs
@@ -162,6 +162,7 @@ fn test_harvest_result_serialization() {
         referenced_bwb_ids: vec!["BWBR0002629".to_string()],
         harvest_date: "2025-01-01".to_string(),
         source_type: "bwb".to_string(),
+        changed: true,
     };
 
     let json = serde_json::to_value(&result).unwrap();
@@ -189,6 +190,7 @@ fn test_harvest_result_cvdr_source_type() {
         referenced_bwb_ids: vec![],
         harvest_date: "2025-01-01".to_string(),
         source_type: "cvdr".to_string(),
+        changed: true,
     };
 
     let json = serde_json::to_value(&result).unwrap();

--- a/packages/pipeline/tests/harvest_tests.rs
+++ b/packages/pipeline/tests/harvest_tests.rs
@@ -217,7 +217,7 @@ async fn test_execute_harvest_real_law() {
     };
 
     let client = regelrecht_harvester::http::create_client().unwrap();
-    let (result, written_files) = execute_harvest(&payload, repo_path, "regulation/nl", &client)
+    let (result, files) = execute_harvest(&payload, repo_path, "regulation/nl", &client)
         .await
         .unwrap();
 
@@ -225,8 +225,14 @@ async fn test_execute_harvest_real_law() {
     assert!(!result.slug.is_empty());
     assert!(result.article_count > 0);
     assert_eq!(result.source_type, "bwb");
-    assert_eq!(written_files.len(), 2);
-    for f in &written_files {
-        assert!(f.exists(), "expected file to exist: {}", f.display());
-    }
+    assert!(
+        files.content.exists(),
+        "expected content file to exist: {}",
+        files.content.display()
+    );
+    assert!(
+        files.metadata.exists(),
+        "expected metadata file to exist: {}",
+        files.metadata.display()
+    );
 }


### PR DESCRIPTION
## Problem

Re-harvesting a law produced a **new git commit (a "new version") on every run**, even when the harvested law was byte-for-byte identical to what was already in the corpus.

Root cause: `execute_harvest` writes a `status.yaml` next to each law YAML containing `last_harvested: Utc::now()` — a wall-clock timestamp that changes every run. The worker staged **both** the law YAML and `status.yaml` together and called `commit_and_push`, whose no-change guard (`git status --porcelain`) was therefore never empty → a spurious commit each time. (The old code comment even claimed "re-harvesting produces identical files" — which wasn't true.)

## Fix

Gate the commit on the **law content** alone:

- **`CorpusClient::commit_and_push_content(content_paths, metadata_paths, message) -> bool`** (new): stages only the content, checks `git status --porcelain -- <content>`. If unchanged, it restores the churned metadata and returns `false` (no commit); otherwise it stages the metadata alongside, commits, pushes, and returns `true`.
  - On the no-change path it **restores tracked metadata and cleans untracked metadata**, so the long-lived corpus clone's working tree stays clean for the next `pull --rebase`.
  - The existing rebase+push retry loop is extracted into a private `rebase_and_push` helper; `commit_and_push` keeps its exact current behavior.
- **`HarvestResult.changed: bool`** (new, serde-default `true` for backward compat): set by the worker from the commit outcome.
- The harvest worker now logs **"no changes detected"** and, when nothing changed, **skips auto-enrich and follow-up referenced-law harvest jobs** (re-enriching identical content wastes LLM budget; the law is still marked `Harvested` and the job `Completed`).

## Behaviour

| Scenario | Before | After |
|----------|--------|-------|
| Re-harvest, identical law content | new commit every run | no commit, job ends "no changes detected" |
| Re-harvest, law content changed | new commit | new commit (incl. updated `status.yaml`) |
| First harvest of a law | commit | commit |

## Tests

- `commit_and_push_content`: metadata-only change → no commit + metadata restored; real content change → commit; untracked-metadata no-change → tree left clean.
- `HarvestResult` deserializes with `changed` defaulting to `true` for results stored before this field existed.
- `cargo fmt`, `clippy`, corpus + pipeline (35 lib + harvest) tests all green.
