### PR TITLE
fix(corpus): stop indexing traject annotation files as laws

### DIFF
--- a/packages/corpus/src/github.rs
+++ b/packages/corpus/src/github.rs
@@ -338,6 +338,18 @@ mod inner {
                     continue;
                 }
 
+                // Annotations are persisted at the reserved
+                // `annotations/{law_id}/annotations.yaml` path in a traject's
+                // own repo (see editor-api `save_annotations`). That shape
+                // collides with the law-file convention
+                // `{layer}/{law_id}/{date}.yaml`, so without this guard the
+                // annotation file is indexed as a phantom law whose body is
+                // the annotation YAML — the law then opens to an empty editor
+                // ("Geen items"). Skip the annotations subtree entirely.
+                if parts[0] == "annotations" {
+                    continue;
+                }
+
                 let law_id = parts[parts.len() - 2];
                 if let Some(f) = filter {
                     if !f.contains(law_id) {
@@ -981,6 +993,55 @@ mod inner {
             })?;
         String::from_utf8(bytes)
             .map_err(|e| CorpusError::Git(format!("UTF-8 decode failed for {}: {}", item.path, e)))
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::GitHubFetcher;
+        use std::collections::HashMap;
+
+        fn sorted_ids(map: &HashMap<String, String>) -> Vec<String> {
+            let mut ids: Vec<String> = map.keys().cloned().collect();
+            ids.sort();
+            ids
+        }
+
+        // A saved annotation lives at `annotations/{law_id}/annotations.yaml`
+        // in the traject's own repo. That path shape collides with the
+        // law-file convention `{layer}/{law_id}/{date}.yaml`, so without an
+        // explicit guard the indexer registers the annotation file as a
+        // phantom law whose "content" is the annotation YAML — the law then
+        // opens to an empty editor ("Geen items"). Annotations must never be
+        // indexed as laws.
+        #[test]
+        fn annotation_files_are_not_indexed_as_laws() {
+            let paths = vec![
+                "regulation/nl/wet/wet_op_de_zorgtoeslag/2026-01-01.yaml".to_string(),
+                "annotations/zorgtoeslagwet/annotations.yaml".to_string(),
+            ];
+            let best = GitHubFetcher::group_best_versions(&paths, "", None);
+            assert_eq!(sorted_ids(&best), vec!["wet_op_de_zorgtoeslag".to_string()]);
+            assert!(
+                !best.contains_key("zorgtoeslagwet"),
+                "annotation file was mis-indexed as law 'zorgtoeslagwet'"
+            );
+        }
+
+        // When an annotation's law_id matches a real law present in the same
+        // repo, the annotation file must not shadow the actual law content.
+        #[test]
+        fn annotation_does_not_shadow_real_law_with_same_id() {
+            let paths = vec![
+                "regulation/nl/wet/zorgtoeslagwet/2026-01-01.yaml".to_string(),
+                "annotations/zorgtoeslagwet/annotations.yaml".to_string(),
+            ];
+            let best = GitHubFetcher::group_best_versions(&paths, "", None);
+            assert_eq!(
+                best.get("zorgtoeslagwet").map(String::as_str),
+                Some("regulation/nl/wet/zorgtoeslagwet/2026-01-01.yaml"),
+                "annotation file shadowed the real law content"
+            );
+        }
     }
 }
 

--- a/packages/corpus/src/github.rs
+++ b/packages/corpus/src/github.rs
@@ -1026,22 +1026,6 @@ mod inner {
                 "annotation file was mis-indexed as law 'zorgtoeslagwet'"
             );
         }
-
-        // When an annotation's law_id matches a real law present in the same
-        // repo, the annotation file must not shadow the actual law content.
-        #[test]
-        fn annotation_does_not_shadow_real_law_with_same_id() {
-            let paths = vec![
-                "regulation/nl/wet/zorgtoeslagwet/2026-01-01.yaml".to_string(),
-                "annotations/zorgtoeslagwet/annotations.yaml".to_string(),
-            ];
-            let best = GitHubFetcher::group_best_versions(&paths, "", None);
-            assert_eq!(
-                best.get("zorgtoeslagwet").map(String::as_str),
-                Some("regulation/nl/wet/zorgtoeslagwet/2026-01-01.yaml"),
-                "annotation file shadowed the real law content"
-            );
-        }
     }
 }
 


### PR DESCRIPTION
## Problem

In the editor library, opening a law that exists in a traject (e.g. the *Zorgtoeslagwet* tile under "Bewerkt in dit traject" in the `tdjager/regelrecht-private-test` traject) showed **"Geen items"** in the middle panel instead of the law's content.

## Root cause

The GitHub corpus indexer derives a law id from the **directory name** of each `.yaml` path it discovers, assuming the law-file convention `{layer}/{law_id}/{date}.yaml`:

```rust
let parts: Vec<&str> = rel.split('/').collect();
if parts.len() < 3 { continue; }
let law_id = parts[parts.len() - 2];   // directory name
```

Saved annotations are persisted at the reserved path `annotations/{law_id}/annotations.yaml` (editor-api `save_annotations`). That path has the same three-segment shape, so the annotation file was registered as a **phantom law** whose body is the annotation YAML. Opening it parsed an annotation document (no `articles`/`segments`) and rendered "Geen items". The phantom also surfaced in the sidebar's "Bewerkt in dit traject" section via `changed-laws`.

The local-directory loader is unaffected — it reads each file and requires a `$id:` line, which annotation files lack. Only the GitHub index path (which reconstructs the id from the path without fetching the body) needed the guard.

## Fix

Skip the reserved `annotations/` subtree in `group_best_versions`, the single choke point that maps discovered paths to law ids — covering both `list_source_law_paths` (full traject indexing) and `fetch_source_filtered` (favorites).

## Tests

- `annotation_files_are_not_indexed_as_laws` — the production scenario: an `annotations/zorgtoeslagwet/annotations.yaml` next to a real `wet_op_de_zorgtoeslag` law must not produce a `zorgtoeslagwet` law entry. Fails without the fix.

The same-id case (an annotation whose id matches a real law in the same repo) is also handled by the guard — `parts[0] == "annotations"` skips the subtree unconditionally — but it is **not** separately tested: `pick_best_version` already discards the annotation file (its `annotations` filename is not a valid date and loses the date tiebreak to the real dated law), so such a test passes with or without the guard and would give false confidence. The guard's only observable effect — annotation paths never producing a law entry — is covered by the test above.

Full `regelrecht-corpus` suite, `just format`, and `just lint` all green.
