### PR TITLE
fix(corpus): align zorgtoeslag law $id with folder/harvester convention

### DIFF
--- a/.claude/skills/law-generate/SKILL.md
+++ b/.claude/skills/law-generate/SKILL.md
@@ -133,7 +133,7 @@ The lower regulation registers as implementing it:
 # In the lower regulation (e.g., regeling_standaardpremie article 1)
 machine_readable:
   implements:
-    - law: zorgtoeslagwet
+    - law: wet_op_de_zorgtoeslag
       article: '4'
       open_term: standaardpremie
       gelet_op: Gelet op artikel 4 van de Wet op de zorgtoeslag

--- a/.claude/skills/law-generate/examples.md
+++ b/.claude/skills/law-generate/examples.md
@@ -310,7 +310,7 @@ The lower regulation registers as implementing the open term:
 # regeling_standaardpremie article 1
 machine_readable:
   implements:
-    - law: zorgtoeslagwet
+    - law: wet_op_de_zorgtoeslag
       article: '4'
       open_term: standaardpremie
       gelet_op: Gelet op artikel 4 van de Wet op de zorgtoeslag

--- a/.claude/skills/law-generate/reference.md
+++ b/.claude/skills/law-generate/reference.md
@@ -34,7 +34,7 @@ machine_readable:
       legal_basis: artikel 4 Wet op de zorgtoeslag
 
   implements:                   # IoC fulfillment (optional)
-    - law: zorgtoeslagwet
+    - law: wet_op_de_zorgtoeslag
       article: '4'
       open_term: standaardpremie
       gelet_op: Gelet op artikel 4 van de Wet op de zorgtoeslag
@@ -330,7 +330,7 @@ machine_readable:
 ```yaml
 machine_readable:
   implements:
-    - law: zorgtoeslagwet
+    - law: wet_op_de_zorgtoeslag
       article: '4'
       open_term: standaardpremie
       gelet_op: Gelet op artikel 4 van de Wet op de zorgtoeslag

--- a/corpus/annotations/wet_op_de_zorgtoeslag/annotations.yaml
+++ b/corpus/annotations/wet_op_de_zorgtoeslag/annotations.yaml
@@ -10,7 +10,7 @@ annotations:
     motivation: linking
     creator: Dienst Toeslagen
     target:
-      source: regelrecht://zorgtoeslagwet
+      source: regelrecht://wet_op_de_zorgtoeslag
       selector:
         type: TextQuoteSelector
         exact: zorgtoeslag
@@ -18,7 +18,7 @@ annotations:
         suffix: ' ter grootte van dat verschil'
     body:
       type: SpecificResource
-      source: regelrecht://zorgtoeslagwet/hoogte_zorgtoeslag
+      source: regelrecht://wet_op_de_zorgtoeslag/hoogte_zorgtoeslag
       purpose: linking
     resolution: found
     workflow: resolved
@@ -28,7 +28,7 @@ annotations:
     motivation: commenting
     creator: J. de Vries
     target:
-      source: regelrecht://zorgtoeslagwet
+      source: regelrecht://wet_op_de_zorgtoeslag
       selector:
         type: TextQuoteSelector
         exact: normpremie
@@ -52,7 +52,7 @@ annotations:
     motivation: questioning
     creator: interpreter-team
     target:
-      source: regelrecht://zorgtoeslagwet
+      source: regelrecht://wet_op_de_zorgtoeslag
       selector:
         type: TextQuoteSelector
         exact: ministeriële regeling
@@ -81,7 +81,7 @@ annotations:
     motivation: questioning
     creator: interpreter-team
     target:
-      source: regelrecht://zorgtoeslagwet
+      source: regelrecht://wet_op_de_zorgtoeslag
       selector:
         type: TextQuoteSelector
         exact: 4,273 procent

--- a/corpus/regulation/nl/ministeriele_regeling/regeling_standaardpremie/2024-01-01.yaml
+++ b/corpus/regulation/nl/ministeriele_regeling/regeling_standaardpremie/2024-01-01.yaml
@@ -10,7 +10,7 @@ name: '#wet_naam'
 competent_authority:
   name: Minister van Volksgezondheid, Welzijn en Sport
 legal_basis:
-  - law_id: zorgtoeslagwet
+  - law_id: wet_op_de_zorgtoeslag
     article: '4'
   - law_id: zorgverzekeringswet
     article: 18d
@@ -25,7 +25,7 @@ articles:
     url: https://wetten.overheid.nl/BWBR0049005/2024-01-01#Artikel1
     machine_readable:
       implements:
-        - law: zorgtoeslagwet
+        - law: wet_op_de_zorgtoeslag
           article: '4'
           open_term: standaardpremie
           gelet_op: Gelet op artikel 4 van de Wet op de zorgtoeslag

--- a/corpus/regulation/nl/ministeriele_regeling/regeling_standaardpremie/2025-01-01.yaml
+++ b/corpus/regulation/nl/ministeriele_regeling/regeling_standaardpremie/2025-01-01.yaml
@@ -10,7 +10,7 @@ name: '#wet_naam'
 competent_authority:
   name: Minister van Volksgezondheid, Welzijn en Sport
 legal_basis:
-  - law_id: zorgtoeslagwet
+  - law_id: wet_op_de_zorgtoeslag
     article: '4'
   - law_id: zorgverzekeringswet
     article: 18d
@@ -25,7 +25,7 @@ articles:
     url: https://wetten.overheid.nl/BWBR0050536/2025-01-01#Artikel1
     machine_readable:
       implements:
-        - law: zorgtoeslagwet
+        - law: wet_op_de_zorgtoeslag
           article: '4'
           open_term: standaardpremie
           gelet_op: Gelet op artikel 4 van de Wet op de zorgtoeslag

--- a/corpus/regulation/nl/wet/wet_op_de_zorgtoeslag/2024-01-01.yaml
+++ b/corpus/regulation/nl/wet/wet_op_de_zorgtoeslag/2024-01-01.yaml
@@ -1,6 +1,6 @@
 ---
 $schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/tags/schema-v0.5.0/schema/v0.5.0/schema.json
-$id: zorgtoeslagwet
+$id: wet_op_de_zorgtoeslag
 regulatory_layer: WET
 publication_date: '2023-12-20'
 valid_from: '2024-01-01'

--- a/corpus/regulation/nl/wet/wet_op_de_zorgtoeslag/2025-01-01.yaml
+++ b/corpus/regulation/nl/wet/wet_op_de_zorgtoeslag/2025-01-01.yaml
@@ -1,6 +1,6 @@
 ---
 $schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/tags/schema-v0.5.0/schema/v0.5.0/schema.json
-$id: zorgtoeslagwet
+$id: wet_op_de_zorgtoeslag
 regulatory_layer: WET
 publication_date: '2024-12-20'
 valid_from: '2025-01-01'

--- a/corpus/regulation/nl/wet/wet_op_de_zorgtoeslag/scenarios/eligibility.feature
+++ b/corpus/regulation/nl/wet/wet_op_de_zorgtoeslag/scenarios/eligibility.feature
@@ -33,7 +33,7 @@ Feature: Zorgtoeslag eligibility
       | bsn       | detentiestatus | inrichting_type | zorgtype | juridische_grondslag |
       | 999993653 | null           | null            | null     | null                 |
     Given parameter "bsn" is "999993653"
-    When I evaluate "heeft_recht_op_zorgtoeslag" of "zorgtoeslagwet"
+    When I evaluate "heeft_recht_op_zorgtoeslag" of "wet_op_de_zorgtoeslag"
     Then the execution succeeds
     Then output "heeft_recht_op_zorgtoeslag" is true
     Then output "hoogte_zorgtoeslag" equals 209692
@@ -64,7 +64,7 @@ Feature: Zorgtoeslag eligibility
       | bsn       | detentiestatus | inrichting_type | zorgtype | juridische_grondslag |
       | 999993653 | null           | null            | null     | null                 |
     Given parameter "bsn" is "999993653"
-    When I evaluate "heeft_recht_op_zorgtoeslag" of "zorgtoeslagwet"
+    When I evaluate "heeft_recht_op_zorgtoeslag" of "wet_op_de_zorgtoeslag"
     Then the execution succeeds
     Then output "heeft_recht_op_zorgtoeslag" is false
 
@@ -91,7 +91,7 @@ Feature: Zorgtoeslag eligibility
       | bsn       | detentiestatus | inrichting_type | zorgtype | juridische_grondslag |
       | 999993653 | null           | null            | null     | null                 |
     Given parameter "bsn" is "999993653"
-    When I evaluate "heeft_recht_op_zorgtoeslag" of "zorgtoeslagwet"
+    When I evaluate "heeft_recht_op_zorgtoeslag" of "wet_op_de_zorgtoeslag"
     Then the execution succeeds
     Then output "heeft_recht_op_zorgtoeslag" is true
     Then output "hoogte_zorgtoeslag" equals 210821
@@ -125,7 +125,7 @@ Feature: Zorgtoeslag eligibility
       | bsn       | aantal_studerend_gezin |
       | 999993653 | 0                      |
     Given parameter "bsn" is "999993653"
-    When I evaluate "heeft_recht_op_zorgtoeslag" of "zorgtoeslagwet"
+    When I evaluate "heeft_recht_op_zorgtoeslag" of "wet_op_de_zorgtoeslag"
     Then the execution succeeds
     Then output "heeft_recht_op_zorgtoeslag" is true
     Then output "hoogte_zorgtoeslag" equals 210916
@@ -159,7 +159,7 @@ Feature: Zorgtoeslag eligibility
       | bsn       | detentiestatus | inrichting_type | zorgtype | juridische_grondslag |
       | 999993653 | null           | null            | null     | null                 |
     Given parameter "bsn" is "999993653"
-    When I evaluate "heeft_recht_op_zorgtoeslag" of "zorgtoeslagwet"
+    When I evaluate "heeft_recht_op_zorgtoeslag" of "wet_op_de_zorgtoeslag"
     Then the execution succeeds
     Then output "heeft_recht_op_zorgtoeslag" is true
     Then output "hoogte_zorgtoeslag" equals 272845
@@ -189,7 +189,7 @@ Feature: Zorgtoeslag eligibility
       | bsn       | detentiestatus | inrichting_type | zorgtype | juridische_grondslag |
       | 999993653 | null           | null            | null     | null                 |
     Given parameter "bsn" is "999993653"
-    When I evaluate "heeft_recht_op_zorgtoeslag" of "zorgtoeslagwet"
+    When I evaluate "heeft_recht_op_zorgtoeslag" of "wet_op_de_zorgtoeslag"
     Then the execution succeeds
     Then output "heeft_recht_op_zorgtoeslag" is true
     Then output "hoogte_zorgtoeslag" equals 173280
@@ -217,7 +217,7 @@ Feature: Zorgtoeslag eligibility
       | bsn       | detentiestatus | inrichting_type | zorgtype | juridische_grondslag |
       | 999993653 | null           | null            | null     | null                 |
     Given parameter "bsn" is "999993653"
-    When I evaluate "heeft_recht_op_zorgtoeslag" of "zorgtoeslagwet"
+    When I evaluate "heeft_recht_op_zorgtoeslag" of "wet_op_de_zorgtoeslag"
     Then the execution succeeds
     Then output "heeft_recht_op_zorgtoeslag" is true
     Then output "hoogte_zorgtoeslag" equals 210726
@@ -247,7 +247,7 @@ Feature: Zorgtoeslag eligibility
       | bsn       | detentiestatus | inrichting_type | zorgtype | juridische_grondslag |
       | 999993653 | null           | null            | GGZ      | TBS                  |
     Given parameter "bsn" is "999993653"
-    When I evaluate "heeft_recht_op_zorgtoeslag" of "zorgtoeslagwet"
+    When I evaluate "heeft_recht_op_zorgtoeslag" of "wet_op_de_zorgtoeslag"
     Then the execution succeeds
     Then output "heeft_recht_op_zorgtoeslag" is true
     Then output "hoogte_zorgtoeslag" equals 210726

--- a/docs/src/content/docs/components/corpus.md
+++ b/docs/src/content/docs/components/corpus.md
@@ -51,7 +51,7 @@ let source_map = registry
     .load_all_sources_async(Some(Path::new("corpus-auth.yaml")))
     .await?;
 
-let law = source_map.get_law("zorgtoeslagwet");
+let law = source_map.get_law("wet_op_de_zorgtoeslag");
 ```
 
 The `github` feature flag enables remote fetching from GitHub repositories. Without it, only local filesystem sources are available.

--- a/docs/src/content/docs/components/engine.md
+++ b/docs/src/content/docs/components/engine.md
@@ -80,7 +80,7 @@ Callers must explicitly list the outputs they need. There's no "return all" mode
 ```rust
 // Request multiple outputs
 let result = service.evaluate_law(
-    "zorgtoeslagwet",
+    "wet_op_de_zorgtoeslag",
     &["heeft_recht_op_zorgtoeslag", "hoogte_zorgtoeslag"],
     params,
     "2025-01-01",
@@ -90,7 +90,7 @@ let result = service.evaluate_law(
 
 // Single-output convenience (equivalent to evaluate_law with one output)
 let result = service.evaluate_law_output(
-    "zorgtoeslagwet", "hoogte_zorgtoeslag", params, "2025-01-01",
+    "wet_op_de_zorgtoeslag", "hoogte_zorgtoeslag", params, "2025-01-01",
 )?;
 ```
 
@@ -113,7 +113,7 @@ The `output_provenance` field appears in `ArticleResult`, WASM results, CLI outp
 ```javascript
 // Multiple outputs
 const result = engine.executeMultiple(
-    'zorgtoeslagwet',
+    'wet_op_de_zorgtoeslag',
     ['heeft_recht_op_zorgtoeslag', 'hoogte_zorgtoeslag'],
     { bsn: '999993653' },
     '2025-01-01'
@@ -121,7 +121,7 @@ const result = engine.executeMultiple(
 
 // Single output (unchanged)
 const result = engine.execute(
-    'zorgtoeslagwet', 'hoogte_zorgtoeslag', params, '2025-01-01'
+    'wet_op_de_zorgtoeslag', 'hoogte_zorgtoeslag', params, '2025-01-01'
 );
 ```
 
@@ -190,7 +190,7 @@ Every execution can produce a full trace tree showing how each value was compute
 
 ```rust
 let result = service.evaluate_law_with_trace(
-    "zorgtoeslagwet",
+    "wet_op_de_zorgtoeslag",
     &["hoogte_zorgtoeslag"],
     params,
     "2025-01-01",
@@ -287,21 +287,21 @@ See [RFC-013](/rfcs/rfc-013) for the design rationale.
 ```bash
 # Execute a law
 cargo run --bin evaluate -- \
-    corpus/regulation/nl/wet/zorgtoeslagwet/2025-01-01.yaml \
+    corpus/regulation/nl/wet/wet_op_de_zorgtoeslag/2025-01-01.yaml \
     heeft_recht_op_zorgtoeslag \
     --param bsn 999993653 \
     --param vermogen 50000
 
 # Execute and output a full Execution Receipt as JSON
 cargo run --bin evaluate -- \
-    corpus/regulation/nl/wet/zorgtoeslagwet/2025-01-01.yaml \
+    corpus/regulation/nl/wet/wet_op_de_zorgtoeslag/2025-01-01.yaml \
     heeft_recht_op_zorgtoeslag \
     --param bsn 999993653 \
     --receipt
 
 # Validate a YAML file against schema
 cargo run --bin validate --features validate -- \
-    corpus/regulation/nl/wet/zorgtoeslagwet/2025-01-01.yaml
+    corpus/regulation/nl/wet/wet_op_de_zorgtoeslag/2025-01-01.yaml
 ```
 
 ## Performance

--- a/docs/src/content/docs/concepts/how-it-works.md
+++ b/docs/src/content/docs/concepts/how-it-works.md
@@ -22,7 +22,7 @@ The YAML specification *is* the law in executable form. Every article in the fil
 Each Dutch law is stored as a YAML file. The file mirrors the legal structure:
 
 ```yaml
-$id: zorgtoeslagwet
+$id: wet_op_de_zorgtoeslag
 name: Wet op de zorgtoeslag
 regulatory_layer: WET
 valid_from: '2025-01-01'

--- a/docs/src/content/docs/concepts/inversion-of-control.md
+++ b/docs/src/content/docs/concepts/inversion-of-control.md
@@ -43,7 +43,7 @@ This says: "I need a value called `standaardpremie`. The minister should set it 
 # valid_from: 2025-01-01
 machine_readable:
   implements:
-    - law: zorgtoeslagwet
+    - law: wet_op_de_zorgtoeslag
       article: '4'
       open_term: standaardpremie
       gelet_op: Gelet op artikel 4 van de Wet op de zorgtoeslag

--- a/docs/src/content/docs/concepts/law-format.md
+++ b/docs/src/content/docs/concepts/law-format.md
@@ -35,7 +35,7 @@ corpus/regulation/nl/
 
 ```yaml
 $schema: https://raw.githubusercontent.com/.../refs/tags/schema-v0.5.2/schema/v0.5.2/schema.json
-$id: zorgtoeslagwet
+$id: wet_op_de_zorgtoeslag
 regulatory_layer: WET
 publication_date: '2025-01-01'
 valid_from: '2025-01-01'
@@ -171,7 +171,7 @@ open_terms:
 
 # In the ministerial regulation (lower law)
 implements:
-  - law: zorgtoeslagwet
+  - law: wet_op_de_zorgtoeslag
     article: '4'
     open_term: standaardpremie
     gelet_op: Gelet op artikel 4 van de Wet op de zorgtoeslag

--- a/docs/src/content/docs/concepts/multi-org-execution.md
+++ b/docs/src/content/docs/concepts/multi-org-execution.md
@@ -21,7 +21,7 @@ This distinction determines the execution boundary. A calculation can be run by 
 A law that produces a formal decision declares `competent_authority`. The engine reads it from the top level of the law (or from a `machine_readable` section); it is **not** a field of `execution.produces`. The JSON schema defines `competent_authority` on the `machine_readable` section, but the top-level form is accepted too (the top-level object does not reject extra keys), and that is what the corpus uses, often as a `#`-reference into the law's definitions (see `corpus/regulation/nl/wet/wet_op_de_zorgtoeslag/2025-01-01.yaml`):
 
 ```yaml
-$id: zorgtoeslagwet
+$id: wet_op_de_zorgtoeslag
 competent_authority: '#bevoegd_gezag'   # top-level, resolved from definitions
 # ...
 

--- a/docs/src/content/docs/guide/testing.md
+++ b/docs/src/content/docs/guide/testing.md
@@ -18,7 +18,7 @@ Feature: Healthcare allowance
 
   Scenario: Output is present for an eligible person
     Given the calculation date is "2025-01-01"
-    When the law "zorgtoeslagwet" is executed for outputs "hoogte_zorgtoeslag"
+    When the law "wet_op_de_zorgtoeslag" is executed for outputs "hoogte_zorgtoeslag"
     Then the execution succeeds
     And the output "hoogte_zorgtoeslag" is "123400"
 ```

--- a/docs/src/content/docs/operations/adding-a-law.md
+++ b/docs/src/content/docs/operations/adding-a-law.md
@@ -59,7 +59,7 @@ Feature: Wet op de zorgtoeslag
 
   Scenario: MvT example - single person, output present
     Given the calculation date is "2025-01-01"
-    When the law "zorgtoeslagwet" is executed for outputs "hoogte_zorgtoeslag"
+    When the law "wet_op_de_zorgtoeslag" is executed for outputs "hoogte_zorgtoeslag"
     Then the execution succeeds
     And the output "hoogte_zorgtoeslag" is "123400"
 ```

--- a/docs/src/content/rfcs/rfc-003.md
+++ b/docs/src/content/rfcs/rfc-003.md
@@ -42,7 +42,7 @@ Declares that an article fills an open term from a higher-level law:
 ```yaml
 machine_readable:
   implements:
-    - law: zorgtoeslagwet
+    - law: wet_op_de_zorgtoeslag
       article: '4'
       open_term: standaardpremie
       gelet_op: "Gelet op artikel 4 van de Wet op de zorgtoeslag"

--- a/docs/src/content/rfcs/rfc-005.md
+++ b/docs/src/content/rfcs/rfc-005.md
@@ -107,7 +107,7 @@ A legal expert explains what "zorgtoeslag" means:
 type: Annotation
 motivation: commenting
 target:
-  source: regelrecht://zorgtoeslagwet
+  source: regelrecht://wet_op_de_zorgtoeslag
   selector:
     type: TextQuoteSelector
     exact: zorgtoeslag
@@ -129,7 +129,7 @@ The interpreter links text to the calculation:
 type: Annotation
 motivation: linking
 target:
-  source: regelrecht://zorgtoeslagwet
+  source: regelrecht://wet_op_de_zorgtoeslag
   selector:
     type: TextQuoteSelector
     exact: zorgtoeslag ter grootte van dat verschil
@@ -137,7 +137,7 @@ target:
     suffix: ". Voor een verzekerde"
 body:
   type: SpecificResource
-  source: regelrecht://zorgtoeslagwet/bereken_zorgtoeslag#hoogte_zorgtoeslag
+  source: regelrecht://wet_op_de_zorgtoeslag/bereken_zorgtoeslag#hoogte_zorgtoeslag
   purpose: linking
 ```
 
@@ -149,7 +149,7 @@ An analyst classifies legal concepts:
 type: Annotation
 motivation: tagging
 target:
-  source: regelrecht://zorgtoeslagwet
+  source: regelrecht://wet_op_de_zorgtoeslag
   selector:
     type: TextQuoteSelector
     exact: verzekerde
@@ -442,7 +442,7 @@ properties:
       source:
         type: string
         format: uri
-        description: URI of the law (e.g., regelrecht://zorgtoeslagwet)
+        description: URI of the law (e.g., regelrecht://wet_op_de_zorgtoeslag)
       selector:
         $ref: "#/TextQuoteSelector"
   body:

--- a/docs/src/content/rfcs/rfc-018.md
+++ b/docs/src/content/rfcs/rfc-018.md
@@ -93,16 +93,16 @@ corpus/
   regulation/nl/
     wet/
       wet_op_de_zorgtoeslag/                     # filesystem path
-        2025-01-01.yaml                          # law text, $id: zorgtoeslagwet
+        2025-01-01.yaml                          # law text, $id: wet_op_de_zorgtoeslag
   annotations/
-    zorgtoeslagwet/                              # keyed by the law's $id
+    wet_op_de_zorgtoeslag/                              # keyed by the law's $id
       annotations.yaml                           # law-level notes (all versions)
       2025-01-01.annotations.yaml                # version-specific notes (optional)
     _vocabulary/
       ambiguity.yaml                             # controlled vocabulary (Decision 9)
 ```
 
-The annotation directory is keyed by the law's `$id` (e.g. `zorgtoeslagwet`),
+The annotation directory is keyed by the law's `$id` (e.g. `wet_op_de_zorgtoeslag`),
 not by its filesystem path under `regulation/` (e.g. `wet_op_de_zorgtoeslag`).
 The `$id` is the stable identifier laws reference each other by.
 
@@ -116,8 +116,8 @@ The directory is named `annotations/` (not `notes/`) because it stores W3C
 `Annotation` objects; the storage path follows the data model, the feature name
 follows [RFC-005](/rfcs/rfc-005).
 
-**Discovery:** convention-based. Given a law with `$id: zorgtoeslagwet`, the
-engine looks for notes at `corpus/annotations/zorgtoeslagwet/annotations.yaml`. No
+**Discovery:** convention-based. Given a law with `$id: wet_op_de_zorgtoeslag`, the
+engine looks for notes at `corpus/annotations/wet_op_de_zorgtoeslag/annotations.yaml`. No
 registry manifest is needed for local notes.
 
 **Validation:** note files conform to `schema/v0.5.2/annotation-schema.json`,
@@ -126,14 +126,14 @@ validated by `just validate-annotations`.
 **Example note file:**
 
 ```yaml
-# corpus/annotations/zorgtoeslagwet/annotations.yaml
+# corpus/annotations/wet_op_de_zorgtoeslag/annotations.yaml
 $schema: "https://raw.githubusercontent.com/MinBZK/regelrecht/refs/tags/schema-v0.5.2/schema/v0.5.2/annotation-schema.json"
 annotations:
   - type: Annotation
     motivation: linking
     creator: "Dienst Toeslagen"
     target:
-      source: "regelrecht://zorgtoeslagwet"
+      source: "regelrecht://wet_op_de_zorgtoeslag"
       selector:
         type: TextQuoteSelector
         exact: "zorgtoeslag ter grootte van dat verschil"
@@ -148,7 +148,7 @@ annotations:
             end: 152
     body:
       type: SpecificResource
-      source: "regelrecht://zorgtoeslagwet/hoogte_zorgtoeslag"
+      source: "regelrecht://wet_op_de_zorgtoeslag/hoogte_zorgtoeslag"
       purpose: linking
     resolution: found
     workflow: resolved
@@ -181,7 +181,7 @@ regulation/nl/
     afstemmingsverordening/
       2025-01-01.yaml                           # Amsterdam's ordinance
 annotations/
-  zorgtoeslagwet/
+  wet_op_de_zorgtoeslag/
     annotations.yaml                             # Amsterdam's perspective on national law
   afstemmingsverordening/
     annotations.yaml                             # notes on their own ordinance
@@ -277,7 +277,7 @@ auditable.
   motivation: linking
   creator: "Dienst Toeslagen"
   target:
-    source: "regelrecht://zorgtoeslagwet"
+    source: "regelrecht://wet_op_de_zorgtoeslag"
     selector:
       type: TextQuoteSelector
       exact: "zorgtoeslag ter grootte van dat verschil"
@@ -285,7 +285,7 @@ auditable.
       suffix: ". Voor een verzekerde met een toeslagpartner"
   body:
     type: SpecificResource
-    source: "regelrecht://zorgtoeslagwet/hoogte_zorgtoeslag"
+    source: "regelrecht://wet_op_de_zorgtoeslag/hoogte_zorgtoeslag"
     purpose: linking
 ```
 
@@ -305,7 +305,7 @@ Human explanation of a legal concept or provision.
   motivation: commenting
   creator: "J. de Vries"
   target:
-    source: "regelrecht://zorgtoeslagwet"
+    source: "regelrecht://wet_op_de_zorgtoeslag"
     selector:
       type: TextQuoteSelector
       exact: "normpremie"
@@ -332,7 +332,7 @@ the carrier for ambiguity state (Decision 9).
   motivation: tagging
   creator: "regelrecht-tooling"
   target:
-    source: "regelrecht://zorgtoeslagwet"
+    source: "regelrecht://wet_op_de_zorgtoeslag"
     selector:
       type: TextQuoteSelector
       exact: "verzekerde"
@@ -354,7 +354,7 @@ type carries the ambiguity-tracking use case (Decision 9).
   motivation: questioning
   creator: "interpreter-team"
   target:
-    source: "regelrecht://zorgtoeslagwet"
+    source: "regelrecht://wet_op_de_zorgtoeslag"
     selector:
       type: TextQuoteSelector
       exact: "drempelinkomen"
@@ -400,7 +400,7 @@ body (the machine-readable state). The W3C model permits multiple bodies.
   motivation: questioning
   creator: "interpreter-team"
   target:
-    source: "regelrecht://zorgtoeslagwet"
+    source: "regelrecht://wet_op_de_zorgtoeslag"
     selector:
       type: TextQuoteSelector
       exact: "bij ministeriële regeling"
@@ -431,7 +431,7 @@ we still looking for" a queryable property of the corpus, not tribal knowledge.
   motivation: questioning
   creator: "interpreter-team"
   target:
-    source: "regelrecht://zorgtoeslagwet"
+    source: "regelrecht://wet_op_de_zorgtoeslag"
     selector:
       type: TextQuoteSelector
       exact: "beleidsregels van de Belastingdienst"

--- a/docs/src/content/rfcs/rfc-018.md
+++ b/docs/src/content/rfcs/rfc-018.md
@@ -102,8 +102,9 @@ corpus/
       ambiguity.yaml                             # controlled vocabulary (Decision 9)
 ```
 
-The annotation directory is keyed by the law's `$id` (e.g. `wet_op_de_zorgtoeslag`),
-not by its filesystem path under `regulation/` (e.g. `wet_op_de_zorgtoeslag`).
+The annotation directory is keyed by the law's `$id`, not by its filesystem
+path under `regulation/`. For `wet_op_de_zorgtoeslag` the two coincide, but
+when they differ the `$id` determines the annotation directory.
 The `$id` is the stable identifier laws reference each other by.
 
 - `annotations.yaml`: law-level notes that apply across all versions. The

--- a/frontend/e2e/action-crud.spec.js
+++ b/frontend/e2e/action-crud.spec.js
@@ -3,7 +3,7 @@ import { interceptLaw, gotoEditor, selectArticle, readYamlPane } from './helpers
 
 test.describe('Action CRUD', () => {
   test.beforeEach(async ({ page }) => {
-    await interceptLaw(page, 'zorgtoeslagwet', 'zorgtoeslag-stripped.yaml');
+    await interceptLaw(page, 'wet_op_de_zorgtoeslag', 'zorgtoeslag-stripped.yaml');
     await gotoEditor(page);
   });
 

--- a/frontend/e2e/complex-actions.spec.js
+++ b/frontend/e2e/complex-actions.spec.js
@@ -38,10 +38,10 @@ test.describe('Complex actions', () => {
   test('add action with AND operation containing comparison conditions', async ({ page }) => {
     const fixtureYaml = createFixtureWithMetadata();
 
-    await page.route('**/api/corpus/laws/zorgtoeslagwet', route =>
+    await page.route('**/api/corpus/laws/wet_op_de_zorgtoeslag', route =>
       route.fulfill({ status: 200, contentType: 'text/yaml', body: fixtureYaml })
     );
-    await page.goto('/editor/zorgtoeslagwet');
+    await page.goto('/editor/wet_op_de_zorgtoeslag');
     await page.waitForSelector('nldd-document-tab-bar-item', { timeout: 10_000 });
 
     await selectArticle(page, '2');
@@ -130,10 +130,10 @@ test.describe('Complex actions', () => {
   test('add nested operation via button and verify in YAML', async ({ page }) => {
     const fixtureYaml = createFixtureWithMetadata();
 
-    await page.route('**/api/corpus/laws/zorgtoeslagwet', route =>
+    await page.route('**/api/corpus/laws/wet_op_de_zorgtoeslag', route =>
       route.fulfill({ status: 200, contentType: 'text/yaml', body: fixtureYaml })
     );
-    await page.goto('/editor/zorgtoeslagwet');
+    await page.goto('/editor/wet_op_de_zorgtoeslag');
     await page.waitForSelector('nldd-document-tab-bar-item', { timeout: 10_000 });
 
     await selectArticle(page, '2');

--- a/frontend/e2e/definitions.spec.js
+++ b/frontend/e2e/definitions.spec.js
@@ -3,7 +3,7 @@ import { interceptLaw, gotoEditor, selectArticle, readYamlPane, waitForSheet, fi
 
 test.describe('Definitions', () => {
   test.beforeEach(async ({ page }) => {
-    await interceptLaw(page, 'zorgtoeslagwet', 'zorgtoeslag-stripped.yaml');
+    await interceptLaw(page, 'wet_op_de_zorgtoeslag', 'zorgtoeslag-stripped.yaml');
     await gotoEditor(page);
   });
 

--- a/frontend/e2e/edit-test-loop.spec.js
+++ b/frontend/e2e/edit-test-loop.spec.js
@@ -2,7 +2,7 @@
  * Edit → re-execute loop end-to-end.
  *
  * Verifies the demo flow the editor was built for:
- *   1. Open zorgtoeslagwet in the editor.
+ *   1. Open wet_op_de_zorgtoeslag in the editor.
  *   2. Observe the *Minderjarige heeft geen recht op zorgtoeslag* scenario is
  *      red (badge = ✗) — age check isn't in the law's machine_readable.
  *   3. Edit article 2's machine_readable via the middle-pane YAML editor to
@@ -35,8 +35,8 @@ test.describe('Edit → re-execute loop', () => {
 
   test('Minderjarige scenario goes red → green after adding age check', async ({ page }) => {
     const corpus = loadCorpus();
-    const zorgtoeslag = corpus.get('zorgtoeslagwet');
-    expect(zorgtoeslag, 'zorgtoeslagwet must exist in the test corpus').toBeTruthy();
+    const zorgtoeslag = corpus.get('wet_op_de_zorgtoeslag');
+    expect(zorgtoeslag, 'wet_op_de_zorgtoeslag must exist in the test corpus').toBeTruthy();
 
     const scenarioFilename = 'eligibility.feature';
     const scenarioText = loadScenario(zorgtoeslag.path, scenarioFilename);
@@ -45,13 +45,13 @@ test.describe('Edit → re-execute loop', () => {
     await mockCorpusApi(
       page,
       corpus,
-      { id: 'zorgtoeslagwet', scenarioFilename },
+      { id: 'wet_op_de_zorgtoeslag', scenarioFilename },
       scenarioText,
     );
 
     // Navigate directly to article 2 via the route param — that's where
     // heeft_recht_op_zorgtoeslag lives and where we need to edit.
-    await page.goto('/editor/zorgtoeslagwet/2');
+    await page.goto('/editor/wet_op_de_zorgtoeslag/2');
 
     // Wait for the document tab bar to render — articles loaded.
     await page.waitForSelector('nldd-document-tab-bar-item', { timeout: 15_000 });

--- a/frontend/e2e/fixtures/zorgtoeslag-full.yaml
+++ b/frontend/e2e/fixtures/zorgtoeslag-full.yaml
@@ -1,6 +1,6 @@
 ---
 $schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/tags/schema-v0.5.1/schema/v0.5.1/schema.json
-$id: zorgtoeslagwet
+$id: wet_op_de_zorgtoeslag
 regulatory_layer: WET
 publication_date: '2024-12-20'
 valid_from: '2025-01-01'

--- a/frontend/e2e/fixtures/zorgtoeslag-stripped.yaml
+++ b/frontend/e2e/fixtures/zorgtoeslag-stripped.yaml
@@ -1,6 +1,6 @@
 ---
 $schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/tags/schema-v0.5.1/schema/v0.5.1/schema.json
-$id: zorgtoeslagwet
+$id: wet_op_de_zorgtoeslag
 regulatory_layer: WET
 publication_date: '2024-12-20'
 valid_from: '2025-01-01'

--- a/frontend/e2e/full-roundtrip.spec.js
+++ b/frontend/e2e/full-roundtrip.spec.js
@@ -16,10 +16,10 @@ test.describe('Full round-trip', () => {
     const original = loadOriginal();
     const fullYaml = loadFixture('zorgtoeslag-full.yaml');
 
-    await page.route('**/api/corpus/laws/zorgtoeslagwet', route =>
+    await page.route('**/api/corpus/laws/wet_op_de_zorgtoeslag', route =>
       route.fulfill({ status: 200, contentType: 'text/yaml', body: fullYaml })
     );
-    await page.goto('/editor/zorgtoeslagwet');
+    await page.goto('/editor/wet_op_de_zorgtoeslag');
     await page.waitForSelector('nldd-document-tab-bar-item', { timeout: 10_000 });
 
     // Article 1a: simple definition
@@ -86,7 +86,7 @@ test.describe('Full round-trip', () => {
   });
 
   test('YAML editing creates valid structure that displays correctly', async ({ page }) => {
-    await interceptLaw(page, 'zorgtoeslagwet', 'zorgtoeslag-stripped.yaml');
+    await interceptLaw(page, 'wet_op_de_zorgtoeslag', 'zorgtoeslag-stripped.yaml');
     await gotoEditor(page);
 
     await selectArticle(page, '2');

--- a/frontend/e2e/helpers-corpus.js
+++ b/frontend/e2e/helpers-corpus.js
@@ -30,7 +30,7 @@ export const CORPUS_ROOT = resolve(__dirname, '../../corpus/regulation/nl');
  * whereas the editor-api's `SourceMap::pick_best_version` selects by
  * `valid_from` against today's date. The two will agree as long as
  * each law in the test corpus has only one dated file (the case for
- * zorgtoeslagwet today). If a future test fixture introduces multiple
+ * wet_op_de_zorgtoeslag today). If a future test fixture introduces multiple
  * dated files for the same `$id`, align this with the server logic
  * to avoid the spec serving a different version than the editor would
  * see in production.

--- a/frontend/e2e/helpers.js
+++ b/frontend/e2e/helpers.js
@@ -14,7 +14,7 @@ export function loadFixture(name) {
 /**
  * Intercept the law API and serve a local YAML fixture instead.
  * @param {import('@playwright/test').Page} page
- * @param {string} lawId - e.g. 'wet_op_de_zorgtoeslag' or 'zorgtoeslagwet'
+ * @param {string} lawId - e.g. 'wet_op_de_zorgtoeslag' or 'wet_op_de_zorgtoeslag'
  * @param {string} fixtureName - e.g. 'zorgtoeslag-stripped.yaml'
  */
 export async function interceptLaw(page, lawId, fixtureName) {
@@ -27,8 +27,8 @@ export async function interceptLaw(page, lawId, fixtureName) {
     }),
   );
   // Also intercept the default law id from the fixture itself
-  if (lawId !== 'zorgtoeslagwet') {
-    await page.route('**/api/corpus/laws/zorgtoeslagwet', (route) =>
+  if (lawId !== 'wet_op_de_zorgtoeslag') {
+    await page.route('**/api/corpus/laws/wet_op_de_zorgtoeslag', (route) =>
       route.fulfill({
         status: 200,
         contentType: 'text/yaml',
@@ -43,7 +43,7 @@ export async function interceptLaw(page, lawId, fixtureName) {
  * @param {import('@playwright/test').Page} page
  * @param {string} [lawId] - law query param
  */
-export async function gotoEditor(page, lawId = 'zorgtoeslagwet') {
+export async function gotoEditor(page, lawId = 'wet_op_de_zorgtoeslag') {
   await page.goto(`/editor/${lawId}`);
   // Wait for the document tab bar to appear (articles loaded)
   await page.waitForSelector('nldd-document-tab-bar-item', { timeout: 10_000 });

--- a/frontend/e2e/helpers.js
+++ b/frontend/e2e/helpers.js
@@ -14,7 +14,7 @@ export function loadFixture(name) {
 /**
  * Intercept the law API and serve a local YAML fixture instead.
  * @param {import('@playwright/test').Page} page
- * @param {string} lawId - e.g. 'wet_op_de_zorgtoeslag' or 'wet_op_de_zorgtoeslag'
+ * @param {string} lawId - e.g. 'wet_op_de_zorgtoeslag'
  * @param {string} fixtureName - e.g. 'zorgtoeslag-stripped.yaml'
  */
 export async function interceptLaw(page, lawId, fixtureName) {

--- a/frontend/e2e/init-machine-readable.spec.js
+++ b/frontend/e2e/init-machine-readable.spec.js
@@ -3,7 +3,7 @@ import { interceptLaw, gotoEditor, selectArticle, readYamlPane } from './helpers
 
 test.describe('Init machine_readable', () => {
   test.beforeEach(async ({ page }) => {
-    await interceptLaw(page, 'zorgtoeslagwet', 'zorgtoeslag-stripped.yaml');
+    await interceptLaw(page, 'wet_op_de_zorgtoeslag', 'zorgtoeslag-stripped.yaml');
     await gotoEditor(page);
   });
 

--- a/frontend/e2e/inputs.spec.js
+++ b/frontend/e2e/inputs.spec.js
@@ -3,7 +3,7 @@ import { interceptLaw, gotoEditor, selectArticle, readYamlPane, waitForSheet, fi
 
 test.describe('Inputs with sources', () => {
   test.beforeEach(async ({ page }) => {
-    await interceptLaw(page, 'zorgtoeslagwet', 'zorgtoeslag-stripped.yaml');
+    await interceptLaw(page, 'wet_op_de_zorgtoeslag', 'zorgtoeslag-stripped.yaml');
     await gotoEditor(page);
   });
 

--- a/frontend/e2e/machine-panel-edit-loop.spec.js
+++ b/frontend/e2e/machine-panel-edit-loop.spec.js
@@ -59,7 +59,7 @@ test.describe('Edit → re-execute loop via Machine panel', () => {
 
   test('add leeftijd input + AND condition via Machine panel turns scenario green', async ({ page }) => {
     const corpus = loadCorpus();
-    const zorgtoeslag = corpus.get('zorgtoeslagwet');
+    const zorgtoeslag = corpus.get('wet_op_de_zorgtoeslag');
     expect(zorgtoeslag).toBeTruthy();
 
     const scenarioFilename = 'eligibility.feature';
@@ -69,13 +69,13 @@ test.describe('Edit → re-execute loop via Machine panel', () => {
     await mockCorpusApi(
       page,
       corpus,
-      { id: 'zorgtoeslagwet', scenarioFilename },
+      { id: 'wet_op_de_zorgtoeslag', scenarioFilename },
       scenarioText,
     );
 
     // Open article 2 directly via the route param (avoids the
     // selectArticle helper bug noted in the previous PR).
-    await page.goto('/editor/zorgtoeslagwet/2');
+    await page.goto('/editor/wet_op_de_zorgtoeslag/2');
     await page.waitForSelector('nldd-document-tab-bar-item', { timeout: 15_000 });
 
     // --- Initial state: Minderjarige scenario is red ---

--- a/frontend/e2e/metadata-params-outputs.spec.js
+++ b/frontend/e2e/metadata-params-outputs.spec.js
@@ -3,7 +3,7 @@ import { interceptLaw, gotoEditor, selectArticle, readYamlPane, waitForSheet, fi
 
 test.describe('Parameters and Outputs', () => {
   test.beforeEach(async ({ page }) => {
-    await interceptLaw(page, 'zorgtoeslagwet', 'zorgtoeslag-stripped.yaml');
+    await interceptLaw(page, 'wet_op_de_zorgtoeslag', 'zorgtoeslag-stripped.yaml');
     await gotoEditor(page);
   });
 

--- a/frontend/e2e/operation-binding.spec.js
+++ b/frontend/e2e/operation-binding.spec.js
@@ -42,10 +42,10 @@ test.describe('Operation binding', () => {
   test('changing operation type updates YAML', async ({ page }) => {
     const fixtureYaml = createFixtureWithAction();
 
-    await page.route('**/api/corpus/laws/zorgtoeslagwet', route =>
+    await page.route('**/api/corpus/laws/wet_op_de_zorgtoeslag', route =>
       route.fulfill({ status: 200, contentType: 'text/yaml', body: fixtureYaml })
     );
-    await page.goto('/editor/zorgtoeslagwet');
+    await page.goto('/editor/wet_op_de_zorgtoeslag');
     await page.waitForSelector('nldd-document-tab-bar-item', { timeout: 10_000 });
 
     await selectArticle(page, '2');
@@ -84,10 +84,10 @@ test.describe('Operation binding', () => {
   test('changing literal value updates YAML', async ({ page }) => {
     const fixtureYaml = createFixtureWithAction();
 
-    await page.route('**/api/corpus/laws/zorgtoeslagwet', route =>
+    await page.route('**/api/corpus/laws/wet_op_de_zorgtoeslag', route =>
       route.fulfill({ status: 200, contentType: 'text/yaml', body: fixtureYaml })
     );
-    await page.goto('/editor/zorgtoeslagwet');
+    await page.goto('/editor/wet_op_de_zorgtoeslag');
     await page.waitForSelector('nldd-document-tab-bar-item', { timeout: 10_000 });
 
     await selectArticle(page, '2');
@@ -121,10 +121,10 @@ test.describe('Operation binding', () => {
   test('adding a value via button updates YAML', async ({ page }) => {
     const fixtureYaml = createFixtureWithAction();
 
-    await page.route('**/api/corpus/laws/zorgtoeslagwet', route =>
+    await page.route('**/api/corpus/laws/wet_op_de_zorgtoeslag', route =>
       route.fulfill({ status: 200, contentType: 'text/yaml', body: fixtureYaml })
     );
-    await page.goto('/editor/zorgtoeslagwet');
+    await page.goto('/editor/wet_op_de_zorgtoeslag');
     await page.waitForSelector('nldd-document-tab-bar-item', { timeout: 10_000 });
 
     await selectArticle(page, '2');
@@ -154,10 +154,10 @@ test.describe('Operation binding', () => {
   test('removing a value via minus button updates YAML', async ({ page }) => {
     const fixtureYaml = createFixtureWithAction();
 
-    await page.route('**/api/corpus/laws/zorgtoeslagwet', route =>
+    await page.route('**/api/corpus/laws/wet_op_de_zorgtoeslag', route =>
       route.fulfill({ status: 200, contentType: 'text/yaml', body: fixtureYaml })
     );
-    await page.goto('/editor/zorgtoeslagwet');
+    await page.goto('/editor/wet_op_de_zorgtoeslag');
     await page.waitForSelector('nldd-document-tab-bar-item', { timeout: 10_000 });
 
     await selectArticle(page, '2');

--- a/frontend/public/favorites.json
+++ b/frontend/public/favorites.json
@@ -1,5 +1,5 @@
 [
-  "zorgtoeslagwet",
+  "wet_op_de_zorgtoeslag",
   "regeling_standaardpremie",
   "zorgverzekeringswet",
   "algemene_wet_inkomensafhankelijke_regelingen",

--- a/frontend/src/components/AnnotatedText.test.js
+++ b/frontend/src/components/AnnotatedText.test.js
@@ -272,7 +272,7 @@ describe('AnnotatedText markdown highlighting', () => {
   it('mounts the authoring path without disturbing the highlight render', async () => {
     const wrapper = mountWith(ART, [{ note: noteVerzekerde, spans: [] }], {
       canCreate: true,
-      lawId: 'zorgtoeslagwet',
+      lawId: 'wet_op_de_zorgtoeslag',
       engine: { resolveNote: () => ({ status: 'orphaned', matches: [] }) },
     });
     await nextTick();
@@ -286,7 +286,7 @@ describe('AnnotatedText markdown highlighting', () => {
   it('tears down an open creator when the article changes', async () => {
     const wrapper = mountWith(ART, [], {
       canCreate: true,
-      lawId: 'zorgtoeslagwet',
+      lawId: 'wet_op_de_zorgtoeslag',
       engine: { resolveNote: () => ({ status: 'found', matches: [] }) },
     });
     await nextTick();

--- a/frontend/src/components/EditSheet.test.js
+++ b/frontend/src/components/EditSheet.test.js
@@ -428,7 +428,7 @@ describe('EditSheet', () => {
   describe('input — law combo-box flow', () => {
     const mockLaws = [
       { law_id: 'wet_basisregistratie_personen', name: null, display_name: 'Wet basisregistratie personen', source_id: 'local', source_name: 'Local' },
-      { law_id: 'zorgtoeslagwet', name: null, display_name: 'Wet op de zorgtoeslag', source_id: 'local', source_name: 'Local' },
+      { law_id: 'wet_op_de_zorgtoeslag', name: null, display_name: 'Wet op de zorgtoeslag', source_id: 'local', source_name: 'Local' },
       { law_id: 'kieswet', name: 'Kieswet', display_name: 'Kieswet', source_id: 'local', source_name: 'Local' },
     ];
     const mockOutputs = [
@@ -533,7 +533,7 @@ describe('EditSheet', () => {
       await vi.waitFor(() => expect(wrapper.vm.allLaws.length).toBeGreaterThan(0));
 
       const ids = wrapper.vm.allLaws.map((l) => l.law_id);
-      expect(ids).toEqual(['wet_basisregistratie_personen', 'zorgtoeslagwet', 'kieswet']);
+      expect(ids).toEqual(['wet_basisregistratie_personen', 'wet_op_de_zorgtoeslag', 'kieswet']);
     });
 
     it('save emits correct data after combo-box select flow', async () => {

--- a/frontend/src/components/NoteCreator.test.js
+++ b/frontend/src/components/NoteCreator.test.js
@@ -47,7 +47,7 @@ function mountCreator(extraProps = {}, extraStubs = {}) {
     props: {
       range: { start: 10, end: 20 }, // "normpremie"
       rawText: RAW,
-      lawId: 'zorgtoeslagwet',
+      lawId: 'wet_op_de_zorgtoeslag',
       article: {
         number: '1',
         machine_readable: {
@@ -93,7 +93,7 @@ describe('NoteCreator', () => {
     expect(note.motivation).toBe('linking');
     expect(note.body).toEqual({
       type: 'SpecificResource',
-      source: 'regelrecht://zorgtoeslagwet/hoogte_zorgtoeslag#hoogte_zorgtoeslag',
+      source: 'regelrecht://wet_op_de_zorgtoeslag/hoogte_zorgtoeslag#hoogte_zorgtoeslag',
       purpose: 'linking',
     });
   });

--- a/frontend/src/composables/useDependencies.test.js
+++ b/frontend/src/composables/useDependencies.test.js
@@ -20,7 +20,7 @@ function fakeEngine() {
 }
 
 const MAIN_LAW = `\
-$id: zorgtoeslagwet
+$id: wet_op_de_zorgtoeslag
 articles:
   - number: '2'
     machine_readable:
@@ -63,7 +63,7 @@ describe('useDependencies.loadAllDependencies', () => {
     const { loadAllDependencies, loading } = useDependencies();
     const mainLawId = await loadAllDependencies(MAIN_LAW, engine, fetchLawYaml);
 
-    expect(mainLawId).toBe('zorgtoeslagwet');
+    expect(mainLawId).toBe('wet_op_de_zorgtoeslag');
     expect(engine.loaded.has('zorgverzekeringswet')).toBe(true);
     expect(fetchSpy).not.toHaveBeenCalled();
     expect(loading.value).toBe(false);
@@ -81,11 +81,11 @@ describe('useDependencies.loadImplementors', () => {
     const fetchLawYaml = vi.fn(async (id) => DEP_YAML[id]);
 
     const { loadImplementors } = useDependencies();
-    await loadImplementors('zorgtoeslagwet', engine, fetchLawYaml, 'mig-1a2b3c4d');
+    await loadImplementors('wet_op_de_zorgtoeslag', engine, fetchLawYaml, 'mig-1a2b3c4d');
 
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(fetchSpy.mock.calls[0][0]).toBe(
-      '/api/trajects/mig-1a2b3c4d/corpus/laws/zorgtoeslagwet/implementors',
+      '/api/trajects/mig-1a2b3c4d/corpus/laws/wet_op_de_zorgtoeslag/implementors',
     );
     expect(fetchSpy.mock.calls.some((c) => String(c[0]).includes('limit=1000'))).toBe(false);
     expect(engine.loaded.has('regeling_standaardpremie')).toBe(true);
@@ -98,8 +98,8 @@ describe('useDependencies.loadImplementors', () => {
     const fetchLawYaml = vi.fn(async (id) => DEP_YAML[id]);
 
     const { loadImplementors } = useDependencies();
-    await loadImplementors('zorgtoeslagwet', engine, fetchLawYaml, 'mig-1a2b3c4d');
-    await loadImplementors('zorgtoeslagwet', engine, fetchLawYaml, 'mig-1a2b3c4d');
+    await loadImplementors('wet_op_de_zorgtoeslag', engine, fetchLawYaml, 'mig-1a2b3c4d');
+    await loadImplementors('wet_op_de_zorgtoeslag', engine, fetchLawYaml, 'mig-1a2b3c4d');
 
     expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
@@ -110,11 +110,11 @@ describe('useDependencies.loadImplementors', () => {
     const engine = fakeEngine();
     const { loadImplementors } = useDependencies();
     await expect(
-      loadImplementors('zorgtoeslagwet', engine, vi.fn(), null),
+      loadImplementors('wet_op_de_zorgtoeslag', engine, vi.fn(), null),
     ).resolves.toBeUndefined();
     // A transient failure must not permanently suppress the scan: a second
     // call retries (the guard key was reset on failure).
-    await loadImplementors('zorgtoeslagwet', engine, vi.fn(), null);
+    await loadImplementors('wet_op_de_zorgtoeslag', engine, vi.fn(), null);
     expect(fetchSpy).toHaveBeenCalledTimes(2);
   });
 });
@@ -122,7 +122,7 @@ describe('useDependencies.loadImplementors', () => {
 // Parsed equivalent of MAIN_LAW (plus a self-reference) for the pure test.
 function yamlMain() {
   return {
-    $id: 'zorgtoeslagwet',
+    $id: 'wet_op_de_zorgtoeslag',
     articles: [
       {
         number: '2',
@@ -130,7 +130,7 @@ function yamlMain() {
           execution: {
             input: [
               { name: 'dekking', source: { regulation: 'zorgverzekeringswet', output: 'dekking' } },
-              { name: 'self', source: { regulation: 'zorgtoeslagwet', output: 'x' } },
+              { name: 'self', source: { regulation: 'wet_op_de_zorgtoeslag', output: 'x' } },
             ],
           },
         },

--- a/frontend/src/composables/useDraftNotes.test.js
+++ b/frontend/src/composables/useDraftNotes.test.js
@@ -25,7 +25,7 @@ const NOTE = {
   type: 'Annotation',
   motivation: 'commenting',
   target: {
-    source: 'regelrecht://zorgtoeslagwet',
+    source: 'regelrecht://wet_op_de_zorgtoeslag',
     selector: { type: 'TextQuoteSelector', exact: 'normpremie' },
   },
   body: { type: 'TextualBody', value: 'uitleg', purpose: 'commenting' },
@@ -37,11 +37,11 @@ beforeEach(() => {
 
 describe('useDraftNotes', () => {
   it('appends a draft and persists it under a per-law key', () => {
-    const lawId = ref('zorgtoeslagwet');
+    const lawId = ref('wet_op_de_zorgtoeslag');
     const { addDraft, drafts } = useDraftNotes(lawId);
     addDraft(NOTE);
     expect(drafts.value).toHaveLength(1);
-    const raw = localStorage.getItem('regelrecht-draft-notes:zorgtoeslagwet');
+    const raw = localStorage.getItem('regelrecht-draft-notes:wet_op_de_zorgtoeslag');
     expect(JSON.parse(raw)).toHaveLength(1);
   });
 
@@ -155,7 +155,7 @@ describe('useDraftNotes.saveToRepo', () => {
       }),
     });
     const { addDraft, saveToRepo, drafts } = useDraftNotes(
-      ref('zorgtoeslagwet'),
+      ref('wet_op_de_zorgtoeslag'),
       ref(TRAJECT_REF),
     );
     addDraft({ ...NOTE, __draft: true });
@@ -164,7 +164,7 @@ describe('useDraftNotes.saveToRepo', () => {
 
     expect(globalThis.fetch).toHaveBeenCalledTimes(1);
     const [url, opts] = globalThis.fetch.mock.calls[0];
-    expect(url).toBe(`${TRAJECT_ROUTE}/corpus/laws/zorgtoeslagwet/annotations`);
+    expect(url).toBe(`${TRAJECT_ROUTE}/corpus/laws/wet_op_de_zorgtoeslag/annotations`);
     expect(opts.method).toBe('PUT');
     expect(opts.headers['Content-Type']).toBe('application/json');
     // No X-Editor-Session: the traject is explicit in the URL path, not
@@ -186,7 +186,7 @@ describe('useDraftNotes.saveToRepo', () => {
   it('uses the traject path; ignores any spurious source argument', async () => {
     stubSave({ ok: true, json: async () => ({ pr: null }) });
     const { addDraft, saveToRepo } = useDraftNotes(
-      ref('zorgtoeslagwet'),
+      ref('wet_op_de_zorgtoeslag'),
       ref(TRAJECT_REF),
     );
     addDraft({ ...NOTE, __draft: true });
@@ -196,7 +196,7 @@ describe('useDraftNotes.saveToRepo', () => {
     await saveToRepo('amsterdam');
 
     expect(globalThis.fetch.mock.calls[0][0]).toBe(
-      `${TRAJECT_ROUTE}/corpus/laws/zorgtoeslagwet/annotations`,
+      `${TRAJECT_ROUTE}/corpus/laws/wet_op_de_zorgtoeslag/annotations`,
     );
   });
 
@@ -206,7 +206,7 @@ describe('useDraftNotes.saveToRepo', () => {
     // requireTraject helper so the editor surfaces a clear error.
     stubSave({ ok: true, json: async () => ({ pr: null }) });
     const { addDraft, saveToRepo, drafts } = useDraftNotes(
-      ref('zorgtoeslagwet'),
+      ref('wet_op_de_zorgtoeslag'),
       ref(null),
     );
     addDraft({ ...NOTE, __draft: true });

--- a/frontend/src/composables/useLaw.js
+++ b/frontend/src/composables/useLaw.js
@@ -84,7 +84,7 @@ export async function fetchLaw(trajectRef, lawId) {
 export function useLaw(lawParam, articleParam, trajectRefParam) {
   if (!lawParam) {
     const params = new URLSearchParams(window.location.search);
-    lawParam = params.get('law') || 'zorgtoeslagwet';
+    lawParam = params.get('law') || 'wet_op_de_zorgtoeslag';
   }
   const initialArticle = articleParam || null;
   // Current traject id for this composable instance. `switchLaw` may

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -27,7 +27,7 @@ const router = createRouter({
           // URL (per-tab state), never a server session.
           //
           // The `:trajectRef` regex pins the param to `{slug}-{8hex}` so a
-          // plain law-id slug like `zorgtoeslagwet` does NOT match here — it
+          // plain law-id slug like `wet_op_de_zorgtoeslag` does NOT match here — it
           // falls through to the no-traject library below. Same invariant as
           // `editor-traject`: law `$id` slugs must not end in `-{8hex}`.
           //
@@ -52,7 +52,7 @@ const router = createRouter({
           // `/api/trajects/{trajectRef}/corpus/...`.
           //
           // The `:trajectRef` regex pins the param to `{slug}-{8hex}` so a
-          // plain law-id slug like `zorgtoeslagwet` does NOT match this
+          // plain law-id slug like `wet_op_de_zorgtoeslag` does NOT match this
           // route — it falls through to the no-traject editor below.
           //
           // **Invariant**: law `$id` slugs must not match this regex (i.e.

--- a/frontend/src/router.test.js
+++ b/frontend/src/router.test.js
@@ -8,10 +8,10 @@ const REF = 'mijn-traject-1a2b3c4d';
 
 describe('route disambiguation (traject vs no-traject)', () => {
   it('routes a {slug}-{8hex} library URL to library-traject', () => {
-    const r = router.resolve(`/library/${REF}/zorgtoeslagwet/3`);
+    const r = router.resolve(`/library/${REF}/wet_op_de_zorgtoeslag/3`);
     expect(r.name).toBe('library-traject');
     expect(r.params.trajectRef).toBe(REF);
-    expect(r.params.lawId).toBe('zorgtoeslagwet');
+    expect(r.params.lawId).toBe('wet_op_de_zorgtoeslag');
     expect(r.params.articleNumber).toBe('3');
   });
 

--- a/packages/corpus/src/annotation_schema.rs
+++ b/packages/corpus/src/annotation_schema.rs
@@ -424,7 +424,7 @@ annotations:
     motivation: commenting
     creator: tester
     target:
-      source: "regelrecht://zorgtoeslagwet"
+      source: "regelrecht://wet_op_de_zorgtoeslag"
       selector:
         type: TextQuoteSelector
         exact: zorgtoeslag
@@ -462,12 +462,12 @@ annotations:
     #[test]
     fn law_id_from_source_takes_the_host_segment() {
         assert_eq!(
-            law_id_from_source("regelrecht://zorgtoeslagwet"),
-            Some("zorgtoeslagwet")
+            law_id_from_source("regelrecht://wet_op_de_zorgtoeslag"),
+            Some("wet_op_de_zorgtoeslag")
         );
         assert_eq!(
-            law_id_from_source("regelrecht://zorgtoeslagwet/hoogte#out"),
-            Some("zorgtoeslagwet")
+            law_id_from_source("regelrecht://wet_op_de_zorgtoeslag/hoogte#out"),
+            Some("wet_op_de_zorgtoeslag")
         );
         assert_eq!(law_id_from_source("https://example.com/x"), None);
     }
@@ -475,16 +475,16 @@ annotations:
     #[test]
     fn parse_regelrecht_uri_recognises_laws() {
         assert_eq!(
-            parse_regelrecht_uri("regelrecht://zorgtoeslagwet"),
+            parse_regelrecht_uri("regelrecht://wet_op_de_zorgtoeslag"),
             Some(RegelrechtRef::Law {
-                law_id: "zorgtoeslagwet".to_string(),
+                law_id: "wet_op_de_zorgtoeslag".to_string(),
                 rest: "".to_string(),
             })
         );
         assert_eq!(
-            parse_regelrecht_uri("regelrecht://zorgtoeslagwet/hoogte#out"),
+            parse_regelrecht_uri("regelrecht://wet_op_de_zorgtoeslag/hoogte#out"),
             Some(RegelrechtRef::Law {
-                law_id: "zorgtoeslagwet".to_string(),
+                law_id: "wet_op_de_zorgtoeslag".to_string(),
                 rest: "hoogte#out".to_string(),
             })
         );
@@ -543,35 +543,38 @@ annotations:
     fn first_note_not_targeting_law_is_an_allowlist() {
         // All on-law → None.
         let ok = serde_json::json!({"annotations": [
-            {"target": {"source": "regelrecht://zorgtoeslagwet"}},
-            {"target": {"source": "regelrecht://zorgtoeslagwet/hoogte#x"}},
+            {"target": {"source": "regelrecht://wet_op_de_zorgtoeslag"}},
+            {"target": {"source": "regelrecht://wet_op_de_zorgtoeslag/hoogte#x"}},
         ]});
-        assert_eq!(first_note_not_targeting_law(&ok, "zorgtoeslagwet"), None);
+        assert_eq!(
+            first_note_not_targeting_law(&ok, "wet_op_de_zorgtoeslag"),
+            None
+        );
 
         // A different law → WrongLaw at its index.
         let wrong = serde_json::json!({"annotations": [
-            {"target": {"source": "regelrecht://zorgtoeslagwet"}},
+            {"target": {"source": "regelrecht://wet_op_de_zorgtoeslag"}},
             {"target": {"source": "regelrecht://andere_wet"}},
         ]});
         assert_eq!(
-            first_note_not_targeting_law(&wrong, "zorgtoeslagwet"),
+            first_note_not_targeting_law(&wrong, "wet_op_de_zorgtoeslag"),
             Some((1, NoteTargetError::WrongLaw("andere_wet".to_string())))
         );
 
         // Non-regelrecht:// source must be REJECTED, not silently skipped
         // (the bypass the hostile review found).
         let evil = serde_json::json!({"annotations": [
-            {"target": {"source": "https://evil/zorgtoeslagwet"}},
+            {"target": {"source": "https://evil/wet_op_de_zorgtoeslag"}},
         ]});
         assert_eq!(
-            first_note_not_targeting_law(&evil, "zorgtoeslagwet"),
+            first_note_not_targeting_law(&evil, "wet_op_de_zorgtoeslag"),
             Some((0, NoteTargetError::NotRegelrechtUri))
         );
 
         // Absent target.source → Unparseable, also rejected.
         let bare = serde_json::json!({"annotations": [{"target": {}}]});
         assert_eq!(
-            first_note_not_targeting_law(&bare, "zorgtoeslagwet"),
+            first_note_not_targeting_law(&bare, "wet_op_de_zorgtoeslag"),
             Some((0, NoteTargetError::Unparseable))
         );
 
@@ -601,13 +604,13 @@ annotations:
     motivation: linking
     creator: Dienst Toeslagen
     target:
-      source: regelrecht://zorgtoeslagwet
+      source: regelrecht://wet_op_de_zorgtoeslag
       selector:
         type: TextQuoteSelector
         exact: zorgtoeslag
     body:
       type: SpecificResource
-      source: regelrecht://zorgtoeslagwet/x#y
+      source: regelrecht://wet_op_de_zorgtoeslag/x#y
       purpose: linking
 ";
 
@@ -617,7 +620,7 @@ annotations:
             "motivation": "commenting",
             "creator": "tester",
             "target": {
-                "source": "regelrecht://zorgtoeslagwet",
+                "source": "regelrecht://wet_op_de_zorgtoeslag",
                 "selector": { "type": "TextQuoteSelector", "exact": exact }
             },
             "body": { "type": "TextualBody", "value": "x", "purpose": "commenting" }

--- a/packages/corpus/src/source_map.rs
+++ b/packages/corpus/src/source_map.rs
@@ -1050,7 +1050,7 @@ mod tests {
 
     #[test]
     fn test_resolve_display_name_output_reference() {
-        let yaml = r#"$id: zorgtoeslagwet
+        let yaml = r#"$id: wet_op_de_zorgtoeslag
 name: '#wet_naam'
 articles:
   - number: '8'
@@ -1167,10 +1167,10 @@ articles:
   - number: '1'
     machine_readable:
       implements:
-        - law: zorgtoeslagwet
+        - law: wet_op_de_zorgtoeslag
           article: '4'
           open_term: standaardpremie
-        - law: zorgtoeslagwet
+        - law: wet_op_de_zorgtoeslag
           article: '5'
           open_term: iets_anders
   - number: '2'
@@ -1184,7 +1184,7 @@ articles:
         assert_eq!(
             collect_law_implements(yaml),
             vec![
-                "zorgtoeslagwet".to_string(),
+                "wet_op_de_zorgtoeslag".to_string(),
                 "zorgverzekeringswet".to_string()
             ]
         );

--- a/packages/editor-api/tests/save_annotations_test.rs
+++ b/packages/editor-api/tests/save_annotations_test.rs
@@ -42,7 +42,7 @@ use regelrecht_pipeline::test_utils::TestDb;
 // Helpers
 // ---------------------------------------------------------------------------
 
-const LAW_ID: &str = "zorgtoeslagwet";
+const LAW_ID: &str = "wet_op_de_zorgtoeslag";
 
 fn empty_state(pool: PgPool) -> AppState {
     AppState {

--- a/packages/editor-api/tests/traject_reads_test.rs
+++ b/packages/editor-api/tests/traject_reads_test.rs
@@ -29,7 +29,7 @@ use regelrecht_editor_api::trajects::SESSION_KEY_ACTIVE_TRAJECT;
 
 use regelrecht_pipeline::test_utils::TestDb;
 
-const LAW_ID: &str = "zorgtoeslagwet";
+const LAW_ID: &str = "wet_op_de_zorgtoeslag";
 
 fn empty_state(pool: PgPool) -> AppState {
     AppState {

--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -22,15 +22,15 @@ await init();
 const engine = new WasmEngine();
 
 // Load a law from YAML
-const response = await fetch('/laws/zorgtoeslagwet.yaml');
+const response = await fetch('/laws/wet_op_de_zorgtoeslag.yaml');
 const yaml = await response.text();
-const lawId = engine.loadLaw(yaml);  // Returns "zorgtoeslagwet"
+const lawId = engine.loadLaw(yaml);  // Returns "wet_op_de_zorgtoeslag"
 
 // Execute an article output
 // NOTE: External dependencies (source.regulation) must be pre-resolved
 // and passed as parameters - see Limitations section
 const result = engine.execute(
-    'zorgtoeslagwet',
+    'wet_op_de_zorgtoeslag',
     'heeft_recht_op_zorgtoeslag',
     {
         BSN: '123456789',

--- a/packages/engine/benches/service_e2e.rs
+++ b/packages/engine/benches/service_e2e.rs
@@ -193,7 +193,7 @@ fn bench_complex_law(c: &mut Criterion) {
 
     // Verify the execution actually succeeds before benchmarking
     let verify = service.evaluate_law_output(
-        "zorgtoeslagwet",
+        "wet_op_de_zorgtoeslag",
         "hoogte_zorgtoeslag",
         params.clone(),
         "2025-01-01",
@@ -208,7 +208,7 @@ fn bench_complex_law(c: &mut Criterion) {
         b.iter(|| {
             service
                 .evaluate_law_output(
-                    black_box("zorgtoeslagwet"),
+                    black_box("wet_op_de_zorgtoeslag"),
                     black_box("hoogte_zorgtoeslag"),
                     params.clone(),
                     "2025-01-01",
@@ -221,7 +221,7 @@ fn bench_complex_law(c: &mut Criterion) {
         b.iter(|| {
             service
                 .evaluate_law_output_with_trace(
-                    black_box("zorgtoeslagwet"),
+                    black_box("wet_op_de_zorgtoeslag"),
                     black_box("hoogte_zorgtoeslag"),
                     params.clone(),
                     "2025-01-01",

--- a/packages/engine/benches/uri_parsing.rs
+++ b/packages/engine/benches/uri_parsing.rs
@@ -11,7 +11,7 @@ fn bench_parse_regelrecht_uri(c: &mut Criterion) {
     group.bench_function("regelrecht_uri_with_field", |b| {
         b.iter(|| {
             RegelrechtUri::parse(black_box(
-                "regelrecht://zorgtoeslagwet/bereken_zorgtoeslag#heeft_recht_op_zorgtoeslag",
+                "regelrecht://wet_op_de_zorgtoeslag/bereken_zorgtoeslag#heeft_recht_op_zorgtoeslag",
             ))
         })
     });
@@ -36,7 +36,7 @@ fn bench_uri_builder(c: &mut Criterion) {
 
     group.bench_function("build_string", |b| {
         b.iter(|| {
-            RegelrechtUriBuilder::new("zorgtoeslagwet", "bereken_zorgtoeslag")
+            RegelrechtUriBuilder::new("wet_op_de_zorgtoeslag", "bereken_zorgtoeslag")
                 .with_field("heeft_recht_op_zorgtoeslag")
                 .build()
         })
@@ -44,7 +44,7 @@ fn bench_uri_builder(c: &mut Criterion) {
 
     group.bench_function("build_parsed", |b| {
         b.iter(|| {
-            RegelrechtUriBuilder::new("zorgtoeslagwet", "bereken_zorgtoeslag")
+            RegelrechtUriBuilder::new("wet_op_de_zorgtoeslag", "bereken_zorgtoeslag")
                 .with_field("heeft_recht_op_zorgtoeslag")
                 .build_parsed()
         })

--- a/packages/engine/examples/trace.rs
+++ b/packages/engine/examples/trace.rs
@@ -4,7 +4,7 @@
 //!   cargo run --example trace -- <law_id> <output_name> <date> [key=value ...]
 //!
 //! Example:
-//!   cargo run --example trace -- zorgtoeslagwet hoogte_zorgtoeslag 2025-01-01 bsn=999993653
+//!   cargo run --example trace -- wet_op_de_zorgtoeslag hoogte_zorgtoeslag 2025-01-01 bsn=999993653
 
 use regelrecht_engine::{LawExecutionService, Value};
 use std::collections::BTreeMap;
@@ -15,7 +15,9 @@ fn main() {
     let args: Vec<String> = std::env::args().skip(1).collect();
     if args.len() < 3 {
         eprintln!("Usage: trace <law_id> <output_name> <date> [key=value ...]");
-        eprintln!("Example: trace zorgtoeslagwet hoogte_zorgtoeslag 2025-01-01 bsn=999993653");
+        eprintln!(
+            "Example: trace wet_op_de_zorgtoeslag hoogte_zorgtoeslag 2025-01-01 bsn=999993653"
+        );
         std::process::exit(1);
     }
 

--- a/packages/engine/src/annotation/mod.rs
+++ b/packages/engine/src/annotation/mod.rs
@@ -15,9 +15,9 @@ pub use types::{MatchResult, MatchStatus, SelectorHint, TextMatch, TextQuoteSele
 
 /// Extract the law `$id` from a note's `target.source` URI.
 ///
-/// `regelrecht://zorgtoeslagwet` and
-/// `regelrecht://zorgtoeslagwet/hoogte_zorgtoeslag#field` both yield
-/// `"zorgtoeslagwet"`. Returns `None` if the URI is not a `regelrecht://`
+/// `regelrecht://wet_op_de_zorgtoeslag` and
+/// `regelrecht://wet_op_de_zorgtoeslag/hoogte_zorgtoeslag#field` both yield
+/// `"wet_op_de_zorgtoeslag"`. Returns `None` if the URI is not a `regelrecht://`
 /// reference. Shared by the WASM bindings and `validate-annotations` so the
 /// two cannot drift.
 pub fn law_id_from_source(source: &str) -> Option<&str> {

--- a/packages/engine/src/article.rs
+++ b/packages/engine/src/article.rs
@@ -1520,12 +1520,12 @@ articles:
         }
 
         #[test]
-        fn test_load_zorgtoeslagwet() {
+        fn test_load_wet_op_de_zorgtoeslag() {
             let path = get_regulation_path().join("nl/wet/wet_op_de_zorgtoeslag/2025-01-01.yaml");
             let law = ArticleBasedLaw::from_yaml_file(&path)
-                .unwrap_or_else(|e| panic!("Failed to load zorgtoeslagwet: {}", e));
+                .unwrap_or_else(|e| panic!("Failed to load wet_op_de_zorgtoeslag: {}", e));
 
-            assert_eq!(law.id, "zorgtoeslagwet");
+            assert_eq!(law.id, "wet_op_de_zorgtoeslag");
             assert_eq!(law.regulatory_layer, RegulatoryLayer::Wet);
             assert!(!law.articles.is_empty());
 
@@ -1693,7 +1693,7 @@ articles:
         }
 
         #[test]
-        fn test_zorgtoeslagwet_find_article_by_output_works() {
+        fn test_wet_op_de_zorgtoeslag_find_article_by_output_works() {
             let path = get_regulation_path().join("nl/wet/wet_op_de_zorgtoeslag/2025-01-01.yaml");
             let law = ArticleBasedLaw::from_yaml_file(&path).unwrap();
 

--- a/packages/engine/src/engine.rs
+++ b/packages/engine/src/engine.rs
@@ -1363,7 +1363,7 @@ articles:
         use super::*;
 
         #[test]
-        fn test_execute_zorgtoeslagwet_vermogen_check() {
+        fn test_execute_wet_op_de_zorgtoeslag_vermogen_check() {
             let path = get_regulation_path().join("nl/wet/wet_op_de_zorgtoeslag/2025-01-01.yaml");
             let law = ArticleBasedLaw::from_yaml_file(&path).unwrap();
 

--- a/packages/engine/src/error.rs
+++ b/packages/engine/src/error.rs
@@ -316,9 +316,9 @@ mod tests {
         assert_eq!(external.to_string(), "Variable not found: user_age");
 
         // Law IDs are safe to expose
-        let internal = EngineError::LawNotFound("zorgtoeslagwet".to_string());
+        let internal = EngineError::LawNotFound("wet_op_de_zorgtoeslag".to_string());
         let external: ExternalError = internal.into();
-        assert_eq!(external.to_string(), "Law not found: zorgtoeslagwet");
+        assert_eq!(external.to_string(), "Law not found: wet_op_de_zorgtoeslag");
     }
 
     #[test]

--- a/packages/engine/src/lib.rs
+++ b/packages/engine/src/lib.rs
@@ -19,7 +19,7 @@
 //! params.insert("BSN".to_string(), Value::String("123456789".to_string()));
 //!
 //! let result = service.evaluate_law_output(
-//!     "zorgtoeslagwet",
+//!     "wet_op_de_zorgtoeslag",
 //!     "heeft_recht_op_zorgtoeslag",
 //!     params,
 //!     "2024-01-01",

--- a/packages/engine/src/resolver.rs
+++ b/packages/engine/src/resolver.rs
@@ -73,7 +73,7 @@ pub(crate) struct HookEntry {
 /// resolver.load_from_yaml(yaml_str)?;
 ///
 /// // Find article by output
-/// let article = resolver.get_article_by_output("zorgtoeslagwet", "standaardpremie", None);
+/// let article = resolver.get_article_by_output("wet_op_de_zorgtoeslag", "standaardpremie", None);
 /// ```
 pub struct RuleResolver {
     /// Registry of loaded laws by ID, supporting multiple versions per law ID.
@@ -1295,7 +1295,7 @@ articles:
 
     fn make_law_with_open_term() -> &'static str {
         r#"
-$id: zorgtoeslagwet
+$id: wet_op_de_zorgtoeslag
 regulatory_layer: WET
 publication_date: '2025-01-01'
 articles:
@@ -1329,7 +1329,7 @@ articles:
     text: De standaardpremie bedraagt 1928
     machine_readable:
       implements:
-        - law: zorgtoeslagwet
+        - law: wet_op_de_zorgtoeslag
           article: '4'
           open_term: standaardpremie
           gelet_op: "Gelet op artikel 4 van de Wet op de zorgtoeslag"
@@ -1354,7 +1354,7 @@ articles:
     text: De standaardpremie bedraagt 1889
     machine_readable:
       implements:
-        - law: zorgtoeslagwet
+        - law: wet_op_de_zorgtoeslag
           article: '4'
           open_term: standaardpremie
           gelet_op: "Gelet op artikel 4 van de Wet op de zorgtoeslag"
@@ -1383,7 +1383,7 @@ articles:
         // Look up
         let results = resolver
             .find_implementations(
-                "zorgtoeslagwet",
+                "wet_op_de_zorgtoeslag",
                 "4",
                 "standaardpremie",
                 None,
@@ -1404,7 +1404,7 @@ articles:
 
         let results = resolver
             .find_implementations(
-                "zorgtoeslagwet",
+                "wet_op_de_zorgtoeslag",
                 "4",
                 "standaardpremie",
                 None,
@@ -1430,7 +1430,7 @@ articles:
 
         let results = resolver
             .find_implementations(
-                "zorgtoeslagwet",
+                "wet_op_de_zorgtoeslag",
                 "4",
                 "standaardpremie",
                 None,
@@ -1459,7 +1459,7 @@ articles:
 
         let results = resolver
             .find_implementations(
-                "zorgtoeslagwet",
+                "wet_op_de_zorgtoeslag",
                 "4",
                 "standaardpremie",
                 None,
@@ -1504,7 +1504,7 @@ articles:
             "Expected at least 10 laws from corpus/regulation/nl, got {}",
             count
         );
-        assert!(resolver.has_law("zorgtoeslagwet"));
+        assert!(resolver.has_law("wet_op_de_zorgtoeslag"));
         assert!(resolver.has_law("regeling_standaardpremie"));
         assert!(resolver.has_law("participatiewet"));
     }

--- a/packages/engine/src/service.rs
+++ b/packages/engine/src/service.rs
@@ -10,7 +10,7 @@
 //! use std::collections::BTreeMap;
 //!
 //! let mut service = LawExecutionService::new();
-//! service.load_law(zorgtoeslagwet_yaml)?;
+//! service.load_law(wet_op_de_zorgtoeslag_yaml)?;
 //! service.load_law(regeling_standaardpremie_yaml)?;
 //!
 //! let mut params = BTreeMap::new();
@@ -2737,27 +2737,27 @@ articles:
 
         #[test]
         fn test_service_resolve_with_real_files() {
-            // Integration test: load real zorgtoeslagwet + regeling_standaardpremie
+            // Integration test: load real wet_op_de_zorgtoeslag + regeling_standaardpremie
             // and verify resolve action works end-to-end
             let regulation_path = get_regulation_path();
 
-            let zorgtoeslagwet_path =
+            let wet_op_de_zorgtoeslag_path =
                 regulation_path.join("nl/wet/wet_op_de_zorgtoeslag/2025-01-01.yaml");
             let regeling_path = regulation_path
                 .join("nl/ministeriele_regeling/regeling_standaardpremie/2025-01-01.yaml");
 
-            let zt_law = ArticleBasedLaw::from_yaml_file(&zorgtoeslagwet_path).unwrap();
+            let zt_law = ArticleBasedLaw::from_yaml_file(&wet_op_de_zorgtoeslag_path).unwrap();
             let rsp_law = ArticleBasedLaw::from_yaml_file(&regeling_path).unwrap();
 
             let mut service = LawExecutionService::new();
             service.load_law_struct(zt_law).unwrap();
             service.load_law_struct(rsp_law).unwrap();
 
-            // Execute zorgtoeslagwet standaardpremie output
+            // Execute wet_op_de_zorgtoeslag standaardpremie output
             // This should resolve the regeling_standaardpremie via legal_basis
             let result = service
                 .evaluate_law_output(
-                    "zorgtoeslagwet",
+                    "wet_op_de_zorgtoeslag",
                     "standaardpremie",
                     BTreeMap::new(),
                     "2025-01-01",
@@ -2787,7 +2787,7 @@ articles:
             );
 
             // Verify known laws are loaded
-            assert!(resolver.has_law("zorgtoeslagwet"));
+            assert!(resolver.has_law("wet_op_de_zorgtoeslag"));
             assert!(resolver.has_law("regeling_standaardpremie"));
             assert!(resolver.has_law("participatiewet"));
         }
@@ -2801,8 +2801,8 @@ articles:
             let mut service = LawExecutionService::new();
             service.load_law_struct(law).unwrap();
 
-            let info = service.get_law_info("zorgtoeslagwet").unwrap();
-            assert_eq!(info.id, "zorgtoeslagwet");
+            let info = service.get_law_info("wet_op_de_zorgtoeslag").unwrap();
+            assert_eq!(info.id, "wet_op_de_zorgtoeslag");
             assert_eq!(info.regulatory_layer, RegulatoryLayer::Wet);
             assert!(info.article_count > 0);
             assert!(!info.outputs.is_empty());

--- a/packages/engine/src/service.rs
+++ b/packages/engine/src/service.rs
@@ -2746,11 +2746,12 @@ articles:
             let regeling_path = regulation_path
                 .join("nl/ministeriele_regeling/regeling_standaardpremie/2025-01-01.yaml");
 
-            let zt_law = ArticleBasedLaw::from_yaml_file(&wet_op_de_zorgtoeslag_path).unwrap();
+            let wet_op_de_zorgtoeslag_law =
+                ArticleBasedLaw::from_yaml_file(&wet_op_de_zorgtoeslag_path).unwrap();
             let rsp_law = ArticleBasedLaw::from_yaml_file(&regeling_path).unwrap();
 
             let mut service = LawExecutionService::new();
-            service.load_law_struct(zt_law).unwrap();
+            service.load_law_struct(wet_op_de_zorgtoeslag_law).unwrap();
             service.load_law_struct(rsp_law).unwrap();
 
             // Execute wet_op_de_zorgtoeslag standaardpremie output

--- a/packages/engine/src/uri.rs
+++ b/packages/engine/src/uri.rs
@@ -20,10 +20,10 @@
 //! assert_eq!(uri.field(), Some("is_verzekerd"));
 //!
 //! // Build a URI
-//! let uri = RegelrechtUriBuilder::new("zorgtoeslagwet", "bereken_zorgtoeslag")
+//! let uri = RegelrechtUriBuilder::new("wet_op_de_zorgtoeslag", "bereken_zorgtoeslag")
 //!     .with_field("heeft_recht_op_zorgtoeslag")
 //!     .build();
-//! assert_eq!(uri, "regelrecht://zorgtoeslagwet/bereken_zorgtoeslag#heeft_recht_op_zorgtoeslag");
+//! assert_eq!(uri, "regelrecht://wet_op_de_zorgtoeslag/bereken_zorgtoeslag#heeft_recht_op_zorgtoeslag");
 //!
 //! // Internal reference
 //! let uri = RegelrechtUri::parse("#standaardpremie").unwrap();
@@ -47,7 +47,7 @@ pub enum ReferenceType {
 pub struct RegelrechtUri {
     /// Original URI string
     uri: String,
-    /// Law identifier (e.g., "zorgtoeslagwet")
+    /// Law identifier (e.g., "wet_op_de_zorgtoeslag")
     law_id: String,
     /// Output name (e.g., "bereken_zorgtoeslag")
     output: String,
@@ -228,7 +228,7 @@ impl RegelrechtUriBuilder {
     /// Create a new URI builder
     ///
     /// # Arguments
-    /// * `law_id` - Law identifier (e.g., "zorgtoeslagwet")
+    /// * `law_id` - Law identifier (e.g., "wet_op_de_zorgtoeslag")
     /// * `output` - Output name (e.g., "bereken_zorgtoeslag")
     ///
     /// # Panics
@@ -353,10 +353,10 @@ mod tests {
         #[test]
         fn test_parse_regelrecht_uri_long_ids() {
             let uri = RegelrechtUri::parse(
-                "regelrecht://zorgtoeslagwet/bereken_zorgtoeslag#heeft_recht_op_zorgtoeslag",
+                "regelrecht://wet_op_de_zorgtoeslag/bereken_zorgtoeslag#heeft_recht_op_zorgtoeslag",
             )
             .unwrap();
-            assert_eq!(uri.law_id(), "zorgtoeslagwet");
+            assert_eq!(uri.law_id(), "wet_op_de_zorgtoeslag");
             assert_eq!(uri.output(), "bereken_zorgtoeslag");
             assert_eq!(uri.field(), Some("heeft_recht_op_zorgtoeslag"));
         }
@@ -375,10 +375,10 @@ mod tests {
 
         #[test]
         fn test_parse_file_path_without_field() {
-            let uri = RegelrechtUri::parse("regulation/nl/wet/zorgtoeslagwet").unwrap();
-            assert_eq!(uri.law_id(), "zorgtoeslagwet");
+            let uri = RegelrechtUri::parse("regulation/nl/wet/wet_op_de_zorgtoeslag").unwrap();
+            assert_eq!(uri.law_id(), "wet_op_de_zorgtoeslag");
             // Output defaults to law_id when no field
-            assert_eq!(uri.output(), "zorgtoeslagwet");
+            assert_eq!(uri.output(), "wet_op_de_zorgtoeslag");
             assert_eq!(uri.field(), None);
         }
 
@@ -439,8 +439,12 @@ mod tests {
 
         #[test]
         fn test_build_basic() {
-            let uri = RegelrechtUriBuilder::new("zorgtoeslagwet", "bereken_zorgtoeslag").build();
-            assert_eq!(uri, "regelrecht://zorgtoeslagwet/bereken_zorgtoeslag");
+            let uri =
+                RegelrechtUriBuilder::new("wet_op_de_zorgtoeslag", "bereken_zorgtoeslag").build();
+            assert_eq!(
+                uri,
+                "regelrecht://wet_op_de_zorgtoeslag/bereken_zorgtoeslag"
+            );
         }
 
         #[test]

--- a/packages/engine/src/wasm.rs
+++ b/packages/engine/src/wasm.rs
@@ -17,7 +17,7 @@
 //!
 //! ```javascript
 //! const engine = new WasmEngine();
-//! engine.loadLaw(wet_op_de_zorgtoeslagYaml);
+//! engine.loadLaw(wetOpDeZorgtoeslagYaml);
 //! engine.loadLaw(regelingStandaardpremieYaml);
 //! engine.loadLaw(awirYaml);
 //!

--- a/packages/engine/src/wasm.rs
+++ b/packages/engine/src/wasm.rs
@@ -17,13 +17,13 @@
 //!
 //! ```javascript
 //! const engine = new WasmEngine();
-//! engine.loadLaw(zorgtoeslagwetYaml);
+//! engine.loadLaw(wet_op_de_zorgtoeslagYaml);
 //! engine.loadLaw(regelingStandaardpremieYaml);
 //! engine.loadLaw(awirYaml);
 //!
 //! // Cross-law references are resolved automatically
 //! const result = engine.execute(
-//!     'zorgtoeslagwet',
+//!     'wet_op_de_zorgtoeslag',
 //!     'heeft_recht_op_zorgtoeslag',
 //!     { bsn: '999993653' },
 //!     '2025-01-01'

--- a/packages/engine/tests/bdd/steps/when.rs
+++ b/packages/engine/tests/bdd/steps/when.rs
@@ -123,7 +123,7 @@ fn execute_healthcare_allowance(world: &mut RegelrechtWorld) {
 
     // Execute — engine resolves through cross-law references automatically.
     // BSN stays in parameters (set by set_rvig_personal_data in given.rs).
-    world.execute_law("zorgtoeslagwet", "hoogte_zorgtoeslag");
+    world.execute_law("wet_op_de_zorgtoeslag", "hoogte_zorgtoeslag");
 }
 
 fn register_if_present(

--- a/packages/engine/tests/expected_zorgtoeslag_trace.txt
+++ b/packages/engine/tests/expected_zorgtoeslag_trace.txt
@@ -1,5 +1,5 @@
-zorgtoeslagwet (2025-01-01 {bsn: 999993653} hoogte_zorgtoeslag)
-╟──Evaluating rules for zorgtoeslagwet (hoogte_zorgtoeslag)
+wet_op_de_zorgtoeslag (2025-01-01 {bsn: 999993653} hoogte_zorgtoeslag)
+╟──Evaluating rules for wet_op_de_zorgtoeslag (hoogte_zorgtoeslag)
 ║   ╟──Reference: zorgverzekeringswet#is_verzekerd
 ║   ║   ╟──Resolving from PARAMETERS: $BSN = '999993653'
 ║   ║   ╟──Resolving from DATA_SOURCE: $POLIS_STATUS = 'ACTIEF'
@@ -57,7 +57,7 @@ zorgtoeslagwet (2025-01-01 {bsn: 999993653} hoogte_zorgtoeslag)
 ║   ║       │   ├──Resolving from PARAMETERS: $VERZAMELINKOMEN = 79547
 ║   ║       │   └──Resolving from PARAMETERS: $BUITENLANDS_INKOMEN = 0
 ║   ║       └──Result: toetsingsinkomen = 79547
-║   ╟──Resolving $ZORGTOESLAGWET#STANDAARDPREMIE
+║   ╟──Resolving $WET_OP_DE_ZORGTOESLAG#STANDAARDPREMIE
 ║   ║   ├──Resolving from RESOLVED_INPUT: 211200
 ║   ║   ├──Delegation: Open term 'standaardpremie' implemented by regeling_standaardpremie article 1: 211200
 ║   ║   │   ╟──Computing standaardpremie
@@ -67,7 +67,7 @@ zorgtoeslagwet (2025-01-01 {bsn: 999993653} hoogte_zorgtoeslag)
 ║   ║   └──Computing standaardpremie
 ║   ║       ├──Resolving from PARAMETERS: $STANDAARDPREMIE = 211200
 ║   ║       └──Result: standaardpremie = 211200
-║   ╟──Resolving $ZORGTOESLAGWET#VERMOGEN_ONDER_GRENS
+║   ╟──Resolving $WET_OP_DE_ZORGTOESLAG#VERMOGEN_ONDER_GRENS
 ║   ║   ├──Resolving from RESOLVED_INPUT: True
 ║   ║   ├──Reference: wet_inkomstenbelasting_2001#rendementsgrondslag
 ║   ║   │   ╟──Resolving from PARAMETERS: $BSN = '999993653'

--- a/packages/engine/tests/trace_integration.rs
+++ b/packages/engine/tests/trace_integration.rs
@@ -129,7 +129,7 @@ fn test_zorgtoeslag_trace_output_format() {
 
     let result = service
         .evaluate_law_output_with_trace(
-            "zorgtoeslagwet",
+            "wet_op_de_zorgtoeslag",
             "hoogte_zorgtoeslag",
             params,
             "2025-01-01",
@@ -173,7 +173,7 @@ fn test_zorgtoeslag_trace_result_matches_non_trace() {
     // Execute with trace
     let traced_result = service
         .evaluate_law_output_with_trace(
-            "zorgtoeslagwet",
+            "wet_op_de_zorgtoeslag",
             "hoogte_zorgtoeslag",
             params.clone(),
             "2025-01-01",
@@ -182,7 +182,12 @@ fn test_zorgtoeslag_trace_result_matches_non_trace() {
 
     // Execute without trace
     let normal_result = service
-        .evaluate_law_output("zorgtoeslagwet", "hoogte_zorgtoeslag", params, "2025-01-01")
+        .evaluate_law_output(
+            "wet_op_de_zorgtoeslag",
+            "hoogte_zorgtoeslag",
+            params,
+            "2025-01-01",
+        )
         .expect("Normal evaluation should succeed");
 
     // Results should be identical
@@ -201,7 +206,12 @@ fn test_trace_disabled_by_default() {
 
     // Normal evaluation should not have a trace
     let result = service
-        .evaluate_law_output("zorgtoeslagwet", "hoogte_zorgtoeslag", params, "2025-01-01")
+        .evaluate_law_output(
+            "wet_op_de_zorgtoeslag",
+            "hoogte_zorgtoeslag",
+            params,
+            "2025-01-01",
+        )
         .expect("Evaluation should succeed");
 
     assert!(

--- a/packages/pipeline/README.md
+++ b/packages/pipeline/README.md
@@ -87,7 +87,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create a harvest job
     let job = job_queue::create_job(
         &pool,
-        CreateJobRequest::new(JobType::Harvest, "zorgtoeslagwet")
+        CreateJobRequest::new(JobType::Harvest, "wet_op_de_zorgtoeslag")
             .with_priority(Priority::new(80))
             .with_payload(serde_json::json!({
                 "bwb_id": "BWBR0018451",
@@ -96,9 +96,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     ).await?;
 
     // Track the law's status
-    law_status::upsert_law(&pool, "zorgtoeslagwet", Some("Zorgtoeslagwet")).await?;
-    law_status::update_status(&pool, "zorgtoeslagwet", LawStatusValue::Queued).await?;
-    law_status::set_harvest_job(&pool, "zorgtoeslagwet", job.id).await?;
+    law_status::upsert_law(&pool, "wet_op_de_zorgtoeslag", Some("Zorgtoeslagwet")).await?;
+    law_status::update_status(&pool, "wet_op_de_zorgtoeslag", LawStatusValue::Queued).await?;
+    law_status::set_harvest_job(&pool, "wet_op_de_zorgtoeslag", job.id).await?;
 
     Ok(())
 }

--- a/packages/pipeline/tests/harvest_tests.rs
+++ b/packages/pipeline/tests/harvest_tests.rs
@@ -149,9 +149,9 @@ fn test_harvest_payload_empty_json() {
 fn test_harvest_result_serialization() {
     let result = HarvestResult {
         law_name: "Zorgtoeslagwet".to_string(),
-        slug: "zorgtoeslagwet".to_string(),
+        slug: "wet_op_de_zorgtoeslag".to_string(),
         layer: "WET".to_string(),
-        file_path: "/tmp/regulation/nl/wet/zorgtoeslagwet/2025-01-01.yaml".to_string(),
+        file_path: "/tmp/regulation/nl/wet/wet_op_de_zorgtoeslag/2025-01-01.yaml".to_string(),
         article_count: 15,
         warning_count: 3,
         warnings: vec![
@@ -167,7 +167,7 @@ fn test_harvest_result_serialization() {
 
     let json = serde_json::to_value(&result).unwrap();
     assert_eq!(json["law_name"], "Zorgtoeslagwet");
-    assert_eq!(json["slug"], "zorgtoeslagwet");
+    assert_eq!(json["slug"], "wet_op_de_zorgtoeslag");
     assert_eq!(json["layer"], "WET");
     assert_eq!(json["article_count"], 15);
     assert_eq!(json["warning_count"], 3);

--- a/packages/pipeline/tests/law_status_tests.rs
+++ b/packages/pipeline/tests/law_status_tests.rs
@@ -9,19 +9,28 @@ use regelrecht_pipeline::test_utils::TestDb;
 async fn test_upsert_law() {
     let db = TestDb::new().await;
 
-    let entry = law_status::upsert_law(&db.pool, "zorgtoeslagwet", Some("Zorgtoeslagwet"), None)
-        .await
-        .unwrap();
+    let entry = law_status::upsert_law(
+        &db.pool,
+        "wet_op_de_zorgtoeslag",
+        Some("Zorgtoeslagwet"),
+        None,
+    )
+    .await
+    .unwrap();
 
-    assert_eq!(entry.law_id, "zorgtoeslagwet");
+    assert_eq!(entry.law_id, "wet_op_de_zorgtoeslag");
     assert_eq!(entry.law_name, Some("Zorgtoeslagwet".to_string()));
     assert_eq!(entry.status, LawStatusValue::Unknown);
     assert!(entry.coverage_score.is_none());
 
-    let updated =
-        law_status::upsert_law(&db.pool, "zorgtoeslagwet", Some("Zorgtoeslagwet v2"), None)
-            .await
-            .unwrap();
+    let updated = law_status::upsert_law(
+        &db.pool,
+        "wet_op_de_zorgtoeslag",
+        Some("Zorgtoeslagwet v2"),
+        None,
+    )
+    .await
+    .unwrap();
     assert_eq!(updated.law_name, Some("Zorgtoeslagwet v2".to_string()));
 }
 
@@ -171,14 +180,19 @@ async fn test_set_coverage_score_validation() {
 async fn test_get_law() {
     let db = TestDb::new().await;
 
-    law_status::upsert_law(&db.pool, "zorgtoeslagwet", Some("Zorgtoeslagwet"), None)
-        .await
-        .unwrap();
+    law_status::upsert_law(
+        &db.pool,
+        "wet_op_de_zorgtoeslag",
+        Some("Zorgtoeslagwet"),
+        None,
+    )
+    .await
+    .unwrap();
 
-    let entry = law_status::get_law(&db.pool, "zorgtoeslagwet")
+    let entry = law_status::get_law(&db.pool, "wet_op_de_zorgtoeslag")
         .await
         .unwrap();
-    assert_eq!(entry.law_id, "zorgtoeslagwet");
+    assert_eq!(entry.law_id, "wet_op_de_zorgtoeslag");
 }
 
 #[tokio::test]

--- a/script/validate-annotations.sh
+++ b/script/validate-annotations.sh
@@ -6,7 +6,7 @@
 #
 # Usage:
 #   script/validate-annotations.sh                       # all note files
-#   script/validate-annotations.sh corpus/annotations/zorgtoeslagwet/annotations.yaml
+#   script/validate-annotations.sh corpus/annotations/wet_op_de_zorgtoeslag/annotations.yaml
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"


### PR DESCRIPTION
## Problem

In a federated traject (reproduced live on `bes-e8ced166`), running the *Meerderjarige met actieve polis* scenario on the zorgtoeslag law failed with:

```
Execution failed: Law not found: wet_op_de_zorgtoeslag
╟──Evaluating rules for wet_op_de_zorgtoeslag (heeft_recht_op_zorgtoeslag)
```

Root cause: the same real-world law (`BWBR0018451`) was carried by two federated sources under **two different `$id`s**:

| source | priority | `$id` | state |
|---|---|---|---|
| `local` (hand-curated) | 1 | `zorgtoeslagwet` | executable (`machine_readable`), `valid_from 2025-01-01` |
| `minbzk-central` (harvested) | 2 | `wet_op_de_zorgtoeslag` | raw text, no logic, `valid_from 2026-01-01` |

RFC-010 priority shadowing only dedups laws that share a `$id`, so the two never merged — both surfaced as separate laws. Opening the harvested twin (`wet_op_de_zorgtoeslag`) and running its folder-shared scenarios (which evaluate at `2025-01-01`) hit a law whose only version is `valid_from 2026-01-01` ⇒ no valid version ⇒ "Law not found".

The harvester derives `$id` from the official title slug (`Wet op de zorgtoeslag` → `wet_op_de_zorgtoeslag`), matching the folder==`$id` convention nearly every law follows. `zorgtoeslagwet` was the hand-authored outlier.

## Fix

Rename the hand-authored law's `$id` `zorgtoeslagwet` → `wet_op_de_zorgtoeslag` (matching its folder and the harvester). Both sources now share the `$id`, so the **existing** RFC-010 priority shadowing engages: the priority-1 executable law shadows the priority-2 harvested one. No harvester change, no registry.

Updates every reference:
- the two law versions + its `scenarios/eligibility.feature`
- the `regeling_standaardpremie` cross-law dependency
- the annotations directory (keyed by `$id`): `corpus/annotations/zorgtoeslagwet/` → `wet_op_de_zorgtoeslag/`
- engine fixtures + `expected_zorgtoeslag_trace.txt`
- frontend default/tests/e2e fixtures
- docs + RFC examples

The human-readable name *Zorgtoeslagwet* (display/prose) is intentionally left untouched — only the machine `$id` is aligned.

## Verification

- `just validate` ✅  · `just test` ✅  · `just bdd` ✅ (66 scenarios / 390 steps) · `just format` ✅ · `just lint` ✅
- Frontend JS unit/e2e suites left to CI.