### PR TITLE
docs: vacature Redesign Analist op de landingspagina

### DIFF
--- a/docs/src/components/LandingSections.astro
+++ b/docs/src/components/LandingSections.astro
@@ -211,36 +211,36 @@ const toc = [
             <p>{t.jobs.lede}</p>
           </nldd-rich-text>
           <nldd-spacer size="24" />
-          <nldd-collection layout="grid" item-width="720px">
+          <nldd-collection layout="horizontal-scroll" item-width="480px">
             {t.jobs.items.map((job) => (
               <nldd-card accessible-label={`${t.jobs.vacancyTag}: ${job.title}`}>
                 <nldd-container padding="20">
-                  <nldd-container layout="wrap" gap="6" horizontal-alignment="left">
+                  <nldd-container layout="wrap" gap="8" horizontal-alignment="left">
                     <nldd-tag color="accent" size="md">{t.jobs.vacancyTag}</nldd-tag>
                     <nldd-tag color="brand" size="md">{job.organisation}</nldd-tag>
                   </nldd-container>
-                  <nldd-spacer size="12" />
+                  <nldd-spacer size="16" />
                   <nldd-title size="3">
                     <h3>{job.title}</h3>
                   </nldd-title>
-                  <nldd-spacer size="12" />
+                  <nldd-spacer size="16" />
                   <nldd-rich-text>
                     <p>{job.pitch}</p>
                   </nldd-rich-text>
-                  <nldd-spacer size="16" />
-                  <nldd-container layout="wrap" gap="6" horizontal-alignment="left">
+                  <nldd-spacer size="20" />
+                  <nldd-container layout="wrap" gap="8" horizontal-alignment="left">
                     {job.meta.map((m) => (
                       <nldd-tag color="neutral" size="md">{m}</nldd-tag>
                     ))}
                     <nldd-tag
-                      color="neutral"
+                      color="warning"
                       size="md"
                       data-closes={job.closes}
                       data-closes-open={t.jobs.closesLabel.open}
                       data-closes-closed={t.jobs.closesLabel.closed}
                     >{t.jobs.closesLabel.open} {closesDate.format(parseIsoDate(job.closes))}</nldd-tag>
                   </nldd-container>
-                  <nldd-spacer size="20" />
+                  <nldd-spacer size="24" />
                   <nldd-button-group orientation="horizontal">
                     <nldd-button
                       variant="primary"
@@ -251,7 +251,7 @@ const toc = [
                   </nldd-button-group>
                   {job.contacts.length > 0 && (
                     <Fragment>
-                      <nldd-spacer size="16" />
+                      <nldd-spacer size="20" />
                       <nldd-rich-text>
                         <p>
                           {t.jobs.contactsLabel}{' '}
@@ -645,6 +645,7 @@ const toc = [
       const label =
         days >= 0 ? tag.dataset.closesOpen : tag.dataset.closesClosed;
       tag.textContent = `${label} ${rtf.format(days, 'day')}`;
+      if (days < 0) tag.setAttribute('color', 'critical');
     }
   }
 </script>

--- a/docs/src/components/LandingSections.astro
+++ b/docs/src/components/LandingSections.astro
@@ -20,6 +20,20 @@ const { lang, showSignup } = Astro.props;
 const t = content[lang];
 const home = lang === 'en' ? '/en/' : '/';
 
+// Vacancy closing dates render as an absolute date at build time (also the
+// no-JS text); the script at the bottom rewrites them relative to the
+// visitor's clock ("Sluit vandaag", "Gesloten gisteren"), which a static
+// build can't know.
+const closesDate = new Intl.DateTimeFormat(lang === 'en' ? 'en-GB' : 'nl-NL', {
+  day: 'numeric',
+  month: 'long',
+  year: 'numeric',
+});
+function parseIsoDate(iso: string): Date {
+  const [y, m, d] = iso.split('-').map(Number);
+  return new Date(y, m - 1, d);
+}
+
 // The example screenshots live in src/assets so Astro's <Image> generates
 // responsive, optimised variants (the originals are ~3390px wide for a ~600px
 // column) and sets intrinsic width/height to avoid layout shift. They are
@@ -218,6 +232,13 @@ const toc = [
                     {job.meta.map((m) => (
                       <nldd-tag color="neutral" size="md">{m}</nldd-tag>
                     ))}
+                    <nldd-tag
+                      color="neutral"
+                      size="md"
+                      data-closes={job.closes}
+                      data-closes-open={t.jobs.closesLabel.open}
+                      data-closes-closed={t.jobs.closesLabel.closed}
+                    >{t.jobs.closesLabel.open} {closesDate.format(parseIsoDate(job.closes))}</nldd-tag>
                   </nldd-container>
                   <nldd-spacer size="20" />
                   <nldd-button-group orientation="horizontal">
@@ -603,3 +624,27 @@ const toc = [
       </Fragment>
     )
   }
+
+<script>
+  // The build bakes in absolute closing dates; the visitor's "today" is only
+  // known here. A closing date is inclusive: on the date itself the vacancy
+  // is still open ("sluit vandaag").
+  const closesTags = document.querySelectorAll<HTMLElement>('[data-closes]');
+  if (closesTags.length > 0) {
+    const rtf = new Intl.RelativeTimeFormat(
+      document.documentElement.lang || 'nl',
+      { numeric: 'auto' },
+    );
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    for (const tag of closesTags) {
+      const [y, m, d] = (tag.dataset.closes ?? '').split('-').map(Number);
+      const days = Math.round(
+        (new Date(y, m - 1, d).getTime() - today.getTime()) / 86_400_000,
+      );
+      const label =
+        days >= 0 ? tag.dataset.closesOpen : tag.dataset.closesClosed;
+      tag.textContent = `${label} ${rtf.format(days, 'day')}`;
+    }
+  }
+</script>

--- a/docs/src/components/LandingSections.astro
+++ b/docs/src/components/LandingSections.astro
@@ -215,10 +215,10 @@ const toc = [
             {t.jobs.items.map((job) => (
               <nldd-card accessible-label={`${t.jobs.vacancyTag}: ${job.title}`}>
                 <nldd-container padding="20">
-                  <nldd-container layout="wrap" gap="8" horizontal-alignment="left">
+                  <div class="rr-tag-row">
                     <nldd-tag color="accent" size="md">{t.jobs.vacancyTag}</nldd-tag>
                     <nldd-tag color="brand" size="md">{job.organisation}</nldd-tag>
-                  </nldd-container>
+                  </div>
                   <nldd-spacer size="16" />
                   <nldd-title size="3">
                     <h3>{job.title}</h3>
@@ -228,7 +228,7 @@ const toc = [
                     <p>{job.pitch}</p>
                   </nldd-rich-text>
                   <nldd-spacer size="20" />
-                  <nldd-container layout="wrap" gap="8" horizontal-alignment="left">
+                  <div class="rr-tag-row">
                     {job.meta.map((m) => (
                       <nldd-tag color="neutral" size="md">{m}</nldd-tag>
                     ))}
@@ -239,7 +239,7 @@ const toc = [
                       data-closes-open={t.jobs.closesLabel.open}
                       data-closes-closed={t.jobs.closesLabel.closed}
                     >{t.jobs.closesLabel.open} {closesDate.format(parseIsoDate(job.closes))}</nldd-tag>
-                  </nldd-container>
+                  </div>
                   <nldd-spacer size="24" />
                   <nldd-button-group orientation="horizontal">
                     <nldd-button
@@ -399,17 +399,13 @@ const toc = [
                   {tool.meta && (
                     <Fragment>
                       <nldd-spacer size="8" />
-                      <nldd-container
-                        layout="wrap"
-                        gap="6"
-                        horizontal-alignment="left"
-                      >
+                      <div class="rr-tag-row">
                         {tool.meta.split('•').map((tag) => (
                           <nldd-tag color="accent" size="md">
                             {tag.trim()}
                           </nldd-tag>
                         ))}
-                      </nldd-container>
+                      </div>
                     </Fragment>
                   )}
                   <nldd-spacer size="8" />
@@ -638,7 +634,9 @@ const toc = [
     const today = new Date();
     today.setHours(0, 0, 0, 0);
     for (const tag of closesTags) {
-      const [y, m, d] = (tag.dataset.closes ?? '').split('-').map(Number);
+      const raw = tag.dataset.closes;
+      if (!raw) continue;
+      const [y, m, d] = raw.split('-').map(Number);
       const days = Math.round(
         (new Date(y, m - 1, d).getTime() - today.getTime()) / 86_400_000,
       );

--- a/docs/src/lib/landing-content.ts
+++ b/docs/src/lib/landing-content.ts
@@ -529,6 +529,29 @@ export const content: Record<'nl' | 'en', LandingContent> = {
             { label: 'Dian Hoppen (recruiter)', href: 'tel:+31650062738' },
           ],
         },
+        {
+          title: 'Redesign Analist',
+          organisation: 'Rijksorganisatie ODI · Ministerie van BZK',
+          pitch:
+            'Analyseer wet- en regelgeving en vertaal die naar machine-uitvoerbare specificaties. Je ontleedt complexe uitvoeringsprocessen en werkt in multidisciplinaire teams samen met engineers die de regels in code omzetten.',
+          meta: [
+            'Schaal 12',
+            '€4.691 – €6.907',
+            '32 – 36 uur',
+            'Den Haag',
+            'Sluit 24 juni 2026',
+          ],
+          ctaLabel: 'Bekijk de vacature',
+          ctaHref:
+            'https://www.werkenvoornederland.nl/vacatures/redesign-analist-BZK-2026-9806',
+          contacts: [
+            { label: 'Abram Klop (opgavemanager)', href: 'tel:+31650035732' },
+            {
+              label: 'Suzanne de Jager (recruiter)',
+              href: 'tel:+31627295317',
+            },
+          ],
+        },
       ],
     },
     feedback: {
@@ -983,6 +1006,29 @@ export const content: Record<'nl' | 'en', LandingContent> = {
           contacts: [
             { label: 'Abram Klop (opgavemanager)', href: 'tel:+31650035732' },
             { label: 'Dian Hoppen (recruiter)', href: 'tel:+31650062738' },
+          ],
+        },
+        {
+          title: 'Redesign Analyst',
+          organisation: 'Rijksorganisatie ODI · Ministry of the Interior',
+          pitch:
+            'Analyse Dutch legislation and translate it into machine-executable specifications. You dissect complex government processes and work in multidisciplinary teams alongside the engineers who turn the rules into code. In Dutch (fluency required).',
+          meta: [
+            'Scale 12',
+            '€4,691 – €6,907',
+            '32 – 36 hours',
+            'The Hague',
+            'Closes 24 June 2026',
+          ],
+          ctaLabel: 'View the vacancy (Dutch)',
+          ctaHref:
+            'https://www.werkenvoornederland.nl/vacatures/redesign-analist-BZK-2026-9806',
+          contacts: [
+            { label: 'Abram Klop (opgavemanager)', href: 'tel:+31650035732' },
+            {
+              label: 'Suzanne de Jager (recruiter)',
+              href: 'tel:+31627295317',
+            },
           ],
         },
       ],

--- a/docs/src/lib/landing-content.ts
+++ b/docs/src/lib/landing-content.ts
@@ -80,11 +80,13 @@ export interface LandingContent {
     lede: string
     vacancyTag: string
     contactsLabel: string
+    closesLabel: { open: string; closed: string }
     items: {
       title: string
       organisation: string
       pitch: string
       meta: string[]
+      closes: string
       ctaLabel: string
       ctaHref: string
       contacts: { label: string; href: string }[]
@@ -508,19 +510,15 @@ export const content: Record<'nl' | 'en', LandingContent> = {
       lede: 'Het team rond RegelRecht groeit. Bouw mee aan een open infrastructuur waarin Nederlandse wetgeving machine-uitvoerbaar wordt, en zie je werk landen bij uitvoeringsorganisaties die er dagelijks beslissingen op nemen.',
       vacancyTag: 'Vacature',
       contactsLabel: 'Vragen? Neem contact op met',
+      closesLabel: { open: 'Sluit', closed: 'Gesloten' },
       items: [
         {
           title: 'Software Engineer',
           organisation: 'Rijksorganisatie ODI · Ministerie van BZK',
           pitch:
             'Werk aan de Rust-engine en de tooling waarmee wetten machine-uitvoerbaar worden. Je adviseert opdrachtgevers binnen het Rijk, ontwerpt en programmeert, en werkt naast juristen die de regels in machineleesbare vorm gieten.',
-          meta: [
-            'Schaal 13',
-            '€5.212 – €7.747',
-            '32 – 36 uur',
-            'Den Haag',
-            'Sluit 11 juni 2026',
-          ],
+          meta: ['Schaal 13', '€5.212 – €7.747', '32 – 36 uur', 'Den Haag'],
+          closes: '2026-06-11',
           ctaLabel: 'Bekijk de vacature',
           ctaHref:
             'https://www.werkenvoornederland.nl/vacatures/software-engineer-BZK-2026-8544',
@@ -534,13 +532,8 @@ export const content: Record<'nl' | 'en', LandingContent> = {
           organisation: 'Rijksorganisatie ODI · Ministerie van BZK',
           pitch:
             'Analyseer wet- en regelgeving en vertaal die naar machine-uitvoerbare specificaties. Je ontleedt complexe uitvoeringsprocessen en werkt in multidisciplinaire teams samen met engineers die de regels in code omzetten.',
-          meta: [
-            'Schaal 12',
-            '€4.691 – €6.907',
-            '32 – 36 uur',
-            'Den Haag',
-            'Sluit 24 juni 2026',
-          ],
+          meta: ['Schaal 12', '€4.691 – €6.907', '32 – 36 uur', 'Den Haag'],
+          closes: '2026-06-24',
           ctaLabel: 'Bekijk de vacature',
           ctaHref:
             'https://www.werkenvoornederland.nl/vacatures/redesign-analist-BZK-2026-9806',
@@ -987,19 +980,15 @@ export const content: Record<'nl' | 'en', LandingContent> = {
       lede: 'The team behind RegelRecht is growing. Help build an open infrastructure that turns Dutch legislation into something computers can execute, and see your work land at the public-sector organisations that act on it every day.',
       vacancyTag: 'Vacancy',
       contactsLabel: 'Questions? Get in touch with',
+      closesLabel: { open: 'Closes', closed: 'Closed' },
       items: [
         {
           title: 'Software Engineer',
           organisation: 'Rijksorganisatie ODI · Ministry of the Interior',
           pitch:
             'Work on the Rust engine and the tooling that turns Dutch statutes into something computers can run. You advise teams across the Dutch government, design and write code, and work side by side with lawyers who translate rules into machine-readable form. Senior role, in Dutch (fluency required).',
-          meta: [
-            'Scale 13',
-            '€5,212 – €7,747',
-            '32 – 36 hours',
-            'The Hague',
-            'Closes 11 June 2026',
-          ],
+          meta: ['Scale 13', '€5,212 – €7,747', '32 – 36 hours', 'The Hague'],
+          closes: '2026-06-11',
           ctaLabel: 'View the vacancy (Dutch)',
           ctaHref:
             'https://www.werkenvoornederland.nl/vacatures/software-engineer-BZK-2026-8544',
@@ -1013,13 +1002,8 @@ export const content: Record<'nl' | 'en', LandingContent> = {
           organisation: 'Rijksorganisatie ODI · Ministry of the Interior',
           pitch:
             'Analyse Dutch legislation and translate it into machine-executable specifications. You dissect complex government processes and work in multidisciplinary teams alongside the engineers who turn the rules into code. In Dutch (fluency required).',
-          meta: [
-            'Scale 12',
-            '€4,691 – €6,907',
-            '32 – 36 hours',
-            'The Hague',
-            'Closes 24 June 2026',
-          ],
+          meta: ['Scale 12', '€4,691 – €6,907', '32 – 36 hours', 'The Hague'],
+          closes: '2026-06-24',
           ctaLabel: 'View the vacancy (Dutch)',
           ctaHref:
             'https://www.werkenvoornederland.nl/vacatures/redesign-analist-BZK-2026-9806',

--- a/docs/src/styles/landing.css
+++ b/docs/src/styles/landing.css
@@ -73,3 +73,13 @@ html {
 .rr-faq-card {
   margin-bottom: 40px;
 }
+
+/* --- Tag row ---
+   NLDD has no wrap-row layout component (nldd-container only does padding),
+   so a row of nldd-tags renders inline with bare word-spacing between them.
+   Gap uses the design-system space token so it tracks the token scale. */
+.rr-tag-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--primitives-space-8);
+}


### PR DESCRIPTION
Voegt de vacature Redesign Analist (BZK-2026-9806) toe aan de jobs-sectie van de landingspagina, naast de bestaande Software Engineer-vacature. Beide kaarten tonen de sluitingsdatum (Software Engineer sluit 11 juni, Redesign Analist sluit 24 juni).

Toegevoegd in beide taalversies (NL en EN), met schaal 12, salarisbereik, standplaats en de contactpersonen uit de vacaturetekst (Abram Klop, Suzanne de Jager).

Vacature: https://www.werkenvoornederland.nl/vacatures/redesign-analist-BZK-2026-9806