### PR TITLE
fix(editor): allow Safari for local SSO dev

### DIFF
--- a/.env.sso-local.example
+++ b/.env.sso-local.example
@@ -6,8 +6,9 @@
 # including the Keycloak client configuration (localhost redirect URI, confidential
 # client, realm-roles ID-token mapper).
 #
-# Use Chrome or Firefox: the session cookie is marked `Secure` and only those
-# browsers send Secure cookies over http://localhost. Safari will not.
+# Works in any browser: when BASE_URL is an http localhost origin the editor
+# drops the session cookie's `Secure` flag, so Safari (which won't send Secure
+# cookies over http://localhost) logs in too. Production keeps Secure cookies.
 #
 # The values below are for a dev container backed by Docker Desktop (the common
 # setup here): the DB host is `host.docker.internal` and the frontend runs on a

--- a/docs/src/content/docs/auth-and-roles.md
+++ b/docs/src/content/docs/auth-and-roles.md
@@ -296,11 +296,12 @@ just editor-sso
 cd frontend && npx vite --port 7300
 ```
 
-Open `http://localhost:7300` in **Chrome or Firefox** and log in. The session
-cookie is marked `Secure`; Chrome 89+/Firefox send Secure cookies over
-`http://localhost`, but **Safari does not** — there the OIDC callback fails with
-a CSRF/nonce mismatch. For Safari, front the editor with an `https://localhost`
-TLS proxy instead.
+Open `http://localhost:7300` in any browser and log in. When `BASE_URL` is an
+http localhost origin the editor drops the session cookie's `Secure` flag, so
+Safari — which, unlike Chrome and Firefox, refuses Secure cookies over
+`http://localhost` — completes the OIDC handshake too. Outside localhost
+(production always serves over an `https://` `BASE_URL`) the cookie stays
+`Secure`.
 
 On a successful start the editor-api log shows
 `using OIDC_DISCOVERY_URL for issuer: …` and

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -402,14 +402,9 @@ async fn main() {
                 .continuously_delete_expired(tokio::time::Duration::from_secs(60)),
         );
 
-        // Secure cookies require HTTPS in the browser — except production,
-        // which always serves the editor over an https BASE_URL, so the
-        // default is `Secure`. The one exception is local SSO dev
-        // (`just editor-sso`), which serves over http://localhost: Chrome and
-        // Firefox send Secure cookies over http://localhost as a special case,
-        // but Safari does not, so the OIDC handshake (CSRF/PKCE live in the
-        // session cookie) never completes there. Drop Secure only when BASE_URL
-        // is an http localhost origin, which Safari then accepts.
+        // Drop Secure only for http localhost origins so Safari completes the
+        // OIDC handshake; production (https BASE_URL) keeps it. See
+        // `is_http_localhost` for the full reasoning.
         let secure_cookie = !is_http_localhost(app_state.config.base_url.as_deref());
         if !secure_cookie {
             tracing::warn!(

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -700,26 +700,27 @@ fn resolve_pipeline_api_url(hostname: Option<&str>, env_url: Option<String>) -> 
 /// (`just editor-sso` over http://localhost) so Safari — which, unlike Chrome
 /// and Firefox, refuses Secure cookies over http://localhost — completes the
 /// OIDC handshake. Production always serves over an https BASE_URL, so this is
-/// false there and cookies stay Secure. A missing BASE_URL is treated as
-/// non-local (Secure stays on) — the safe default.
+/// false there and cookies stay Secure. A missing or unparseable BASE_URL is
+/// treated as non-local (Secure stays on) — the safe default.
+///
+/// Parses with `url::Url` (the same crate that validates `BASE_URL` at startup)
+/// so the scheme/host extraction matches WHATWG rules: the host is exact (a
+/// look-alike like `http://localhost.attacker.example` or userinfo like
+/// `http://localhost@evil.com` resolves to a non-loopback host and is rejected)
+/// and IPv6 loopback is handled via the typed `Host` enum.
 fn is_http_localhost(base_url: Option<&str>) -> bool {
-    let Some(url) = base_url else {
+    let Some(url) = base_url.and_then(|u| url::Url::parse(u).ok()) else {
         return false;
     };
-    let Some(rest) = url.strip_prefix("http://") else {
+    if url.scheme() != "http" {
         return false;
-    };
-    // Drop the path, then the `:port`, so we match the host exactly and don't
-    // treat e.g. `http://localhost.attacker.example` as local. A bracketed
-    // IPv6 host (`[::1]`) keeps its inner colons, so strip the port only after
-    // any closing bracket.
-    let authority = rest.split('/').next().unwrap_or("");
-    let host = match authority.rsplit_once(']') {
-        Some((bracketed, _port)) => format!("{bracketed}]"), // `[::1]:7300` -> `[::1]`
-        None => authority.split(':').next().unwrap_or("").to_string(),
     }
-    .to_ascii_lowercase();
-    host == "localhost" || host == "127.0.0.1" || host == "[::1]"
+    matches!(
+        url.host(),
+        Some(url::Host::Domain("localhost"))
+            | Some(url::Host::Ipv4(std::net::Ipv4Addr::LOCALHOST))
+            | Some(url::Host::Ipv6(std::net::Ipv6Addr::LOCALHOST))
+    )
 }
 
 #[cfg(test)]
@@ -833,5 +834,18 @@ mod http_localhost_tests {
         assert!(!is_http_localhost(Some(
             "http://localhost.attacker.example"
         )));
+    }
+
+    /// `localhost` in the userinfo position is not the host — the real host is
+    /// `evil.com`, so this must not be treated as local.
+    #[test]
+    fn localhost_in_userinfo_is_not_local() {
+        assert!(!is_http_localhost(Some("http://localhost@evil.com:7300")));
+    }
+
+    /// An unparseable BASE_URL fails closed (Secure stays on).
+    #[test]
+    fn unparseable_base_url_defaults_to_secure() {
+        assert!(!is_http_localhost(Some("not a url")));
     }
 }

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -402,11 +402,27 @@ async fn main() {
                 .continuously_delete_expired(tokio::time::Duration::from_secs(60)),
         );
 
+        // Secure cookies require HTTPS in the browser — except production,
+        // which always serves the editor over an https BASE_URL, so the
+        // default is `Secure`. The one exception is local SSO dev
+        // (`just editor-sso`), which serves over http://localhost: Chrome and
+        // Firefox send Secure cookies over http://localhost as a special case,
+        // but Safari does not, so the OIDC handshake (CSRF/PKCE live in the
+        // session cookie) never completes there. Drop Secure only when BASE_URL
+        // is an http localhost origin, which Safari then accepts.
+        let secure_cookie = !is_http_localhost(app_state.config.base_url.as_deref());
+        if !secure_cookie {
+            tracing::warn!(
+                "session cookie Secure flag is OFF — BASE_URL is an http localhost origin \
+                 (local SSO dev). This must never happen in production."
+            );
+        }
+
         let session_layer = SessionManagerLayer::new(session_store)
             .with_expiry(Expiry::OnInactivity(time::Duration::hours(8)))
             .with_same_site(tower_sessions::cookie::SameSite::Lax)
             .with_http_only(true)
-            .with_secure(true);
+            .with_secure(secure_cookie);
 
         // Clone for the refresh layer: `with_state` below consumes app_state,
         // and from_fn_with_state needs its own copy of the OIDC client/config.
@@ -679,6 +695,33 @@ fn resolve_pipeline_api_url(hostname: Option<&str>, env_url: Option<String>) -> 
         .or(env_url)
 }
 
+/// True when `base_url` is an http (not https) origin pointing at the local
+/// machine. Used to drop the session cookie's `Secure` flag for local SSO dev
+/// (`just editor-sso` over http://localhost) so Safari — which, unlike Chrome
+/// and Firefox, refuses Secure cookies over http://localhost — completes the
+/// OIDC handshake. Production always serves over an https BASE_URL, so this is
+/// false there and cookies stay Secure. A missing BASE_URL is treated as
+/// non-local (Secure stays on) — the safe default.
+fn is_http_localhost(base_url: Option<&str>) -> bool {
+    let Some(url) = base_url else {
+        return false;
+    };
+    let Some(rest) = url.strip_prefix("http://") else {
+        return false;
+    };
+    // Drop the path, then the `:port`, so we match the host exactly and don't
+    // treat e.g. `http://localhost.attacker.example` as local. A bracketed
+    // IPv6 host (`[::1]`) keeps its inner colons, so strip the port only after
+    // any closing bracket.
+    let authority = rest.split('/').next().unwrap_or("");
+    let host = match authority.rsplit_once(']') {
+        Some((bracketed, _port)) => format!("{bracketed}]"), // `[::1]:7300` -> `[::1]`
+        None => authority.split(':').next().unwrap_or("").to_string(),
+    }
+    .to_ascii_lowercase();
+    host == "localhost" || host == "127.0.0.1" || host == "[::1]"
+}
+
 #[cfg(test)]
 mod pipeline_api_url_tests {
     use super::resolve_pipeline_api_url;
@@ -738,5 +781,57 @@ mod pipeline_api_url_tests {
     fn no_hostname_uses_env_override() {
         let url = resolve_pipeline_api_url(None, Some("http://localhost:8001".to_string()));
         assert_eq!(url.as_deref(), Some("http://localhost:8001"));
+    }
+}
+
+#[cfg(test)]
+mod http_localhost_tests {
+    use super::is_http_localhost;
+
+    #[test]
+    fn http_localhost_with_port_is_local() {
+        assert!(is_http_localhost(Some("http://localhost:7300")));
+    }
+
+    #[test]
+    fn http_localhost_bare_is_local() {
+        assert!(is_http_localhost(Some("http://localhost")));
+    }
+
+    #[test]
+    fn http_loopback_ipv4_is_local() {
+        assert!(is_http_localhost(Some("http://127.0.0.1:7300")));
+    }
+
+    #[test]
+    fn http_loopback_ipv6_is_local() {
+        assert!(is_http_localhost(Some("http://[::1]:7300")));
+    }
+
+    #[test]
+    fn https_localhost_is_not_local() {
+        // https already lets Safari accept Secure cookies — keep them Secure.
+        assert!(!is_http_localhost(Some("https://localhost:7300")));
+    }
+
+    #[test]
+    fn production_https_origin_is_not_local() {
+        assert!(!is_http_localhost(Some(
+            "https://editor.regelrecht.rijks.app"
+        )));
+    }
+
+    #[test]
+    fn missing_base_url_defaults_to_secure() {
+        assert!(!is_http_localhost(None));
+    }
+
+    /// A hostname that merely starts with `localhost` must not be treated as
+    /// local — the host is matched exactly, not by prefix.
+    #[test]
+    fn localhost_lookalike_host_is_not_local() {
+        assert!(!is_http_localhost(Some(
+            "http://localhost.attacker.example"
+        )));
     }
 }


### PR DESCRIPTION
## Problem

The local SSO dev flow (`just editor-sso`) serves the editor over `http://localhost:7300` with OIDC enabled. In that branch the session cookie was set with `Secure` unconditionally (`packages/editor-api/src/main.rs`).

Chrome and Firefox send `Secure` cookies over `http://localhost` as a special case; **Safari does not**. The whole OIDC handshake (CSRF token + PKCE verifier) lives in that single session cookie, so in Safari the cookie was never stored → the callback failed with a CSRF/nonce mismatch and login never completed. This was a documented "use Chrome or Firefox" limitation.

## Fix

Derive the cookie's `Secure` flag from `BASE_URL` instead of hardcoding `true`:

- `Secure` is dropped **only** when `BASE_URL` is an http localhost origin (`localhost` / `127.0.0.1` / `[::1]`).
- Production always serves over an `https://` `BASE_URL`, so cookies stay `Secure` there.
- A missing `BASE_URL` defaults to `Secure` (safe default), and a startup `warn!` fires whenever Secure is off.

Zero-config: `just editor-sso` now works in Safari with no extra setup.

## Notes

- New `is_http_localhost` helper with unit tests (exact host match — `http://localhost.attacker.example` is correctly **not** treated as local; IPv6 bracket form handled).
- Host matching is exact (not prefix) to avoid look-alike hosts.
- Updated `.env.sso-local.example` and `docs/.../auth-and-roles.md` to drop the Safari caveat.