### PR TITLE
feat(dev): frontend-focused `just dev-frontend` recipe

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -273,102 +273,32 @@ dev-setup:
 dev:
     #!/usr/bin/env bash
     set -euo pipefail
+    export COMPOSE="{{ compose-native }}"  PIDFILE="{{ pidfile }}"
+    source script/dev-lib.sh
 
-    bold="\033[1m"  dim="\033[2m"  reset="\033[0m"
-    green="\033[32m"  red="\033[31m"  cyan="\033[36m"  yellow="\033[33m"
+    dev_preflight --rust --node --watch
 
-    # -- preflight checks --
-    missing=()
-    command -v cargo >/dev/null || missing+=("cargo (rustup.rs)")
-    command -v node >/dev/null  || missing+=("node")
-    command -v docker >/dev/null || missing+=("docker")
-    if ! cargo watch --version >/dev/null 2>&1; then
-        printf "${yellow}=> Installing cargo-watch…${reset} "
-        if cargo install cargo-watch --quiet 2>/dev/null; then
-            printf "${green}done${reset}\n"
-        else
-            missing+=("cargo-watch (cargo install cargo-watch)")
-        fi
-    fi
-    # mold is the linker configured in packages/.cargo/config.toml; without it
-    # dev builds fail to link.
-    command -v mold >/dev/null 2>&1 || missing+=("mold (run 'just dev-setup')")
-    if [ ${#missing[@]} -gt 0 ]; then
-        printf "${red}Missing dependencies:${reset}\n"
-        for dep in "${missing[@]}"; do echo "  - $dep"; done
-        exit 1
-    fi
+    dev_compose_up postgres prometheus grafana
+    dev_wait_postgres
 
-    # -- start infra --
-    logfile=$(mktemp)
-    printf "${bold}=> Starting infra (postgres, prometheus, grafana)…${reset} "
-    if {{ compose-native }} up -d postgres prometheus grafana > "$logfile" 2>&1; then
-        printf "${green}done${reset}\n"
-    else
-        printf "${red}failed${reset}\n"
-        cat "$logfile"; rm -f "$logfile"; exit 1
-    fi
-    rm -f "$logfile"
+    if dev_ensure_deps packages/admin/frontend-src "admin frontend"; then admin_fe=true; else admin_fe=false; fi
+    if dev_ensure_deps frontend "editor frontend"; then editor_fe=true; else editor_fe=false; fi
 
-    # -- wait for postgres --
-    printf "${bold}=> Waiting for postgres…${reset} "
-    for i in $(seq 1 30); do
-        if {{ compose-native }} exec -T postgres pg_isready -U regelrecht -d regelrecht_pipeline >/dev/null 2>&1; then
-            printf "${green}ready${reset}\n"
-            break
-        fi
-        if [ "$i" -eq 30 ]; then
-            printf "${red}timeout${reset}\n"; exit 1
-        fi
-        sleep 1
-    done
+    rm -f "$PIDFILE"
 
-    # -- install frontend deps if needed --
-    admin_fe=true
-    editor_fe=true
-
-    if [ ! -d packages/admin/frontend-src/node_modules ]; then
-        printf "${bold}=> Installing admin frontend deps…${reset} "
-        if (cd packages/admin/frontend-src && npm ci --silent) > /dev/null 2>&1; then
-            printf "${green}done${reset}\n"
-        else
-            printf "${yellow}skipped${reset} (npm ci failed)\n"
-            admin_fe=false
-        fi
-    fi
-    if [ ! -d frontend/node_modules ]; then
-        printf "${bold}=> Installing editor frontend deps…${reset} "
-        if (cd frontend && npm ci --silent) > /dev/null 2>&1; then
-            printf "${green}done${reset}\n"
-        else
-            printf "${yellow}skipped${reset} (npm ci failed)\n"
-            editor_fe=false
-        fi
-    fi
-
-    # -- start native services in background --
-    rm -f {{ pidfile }}
-
-    printf "${bold}=> Starting admin API (cargo watch on :8000)…${reset}\n"
-    DATABASE_URL="postgres://regelrecht:regelrecht_dev@localhost:${POSTGRES_PORT:-5433}/regelrecht_pipeline" \
-    RUST_LOG="${RUST_LOG:-info}" \
-      cargo watch -C packages -x 'run --package regelrecht-admin' \
-      > .dev-admin.log 2>&1 &
-    echo "$!" >> {{ pidfile }}
+    db_url="postgres://regelrecht:regelrecht_dev@${DB_HOST:-localhost}:${POSTGRES_PORT:-5433}/regelrecht_pipeline"
+    dev_start "admin API (cargo watch on :8000)" .dev-admin.log \
+      "DATABASE_URL='$db_url' RUST_LOG='${RUST_LOG:-info}' cargo watch -C packages -x 'run --package regelrecht-admin'"
 
     if [ "$admin_fe" = true ]; then
-        printf "${bold}=> Starting admin frontend (vite on :3001)…${reset}\n"
-        (cd packages/admin/frontend-src && npx vite) > .dev-admin-frontend.log 2>&1 &
-        echo "$!" >> {{ pidfile }}
+        dev_start "admin frontend (vite on :3001)" .dev-admin-frontend.log \
+          "cd packages/admin/frontend-src && npx vite"
     fi
-
     if [ "$editor_fe" = true ]; then
-        printf "${bold}=> Starting editor frontend (vite on :3000)…${reset}\n"
-        (cd frontend && npx vite) > .dev-editor.log 2>&1 &
-        echo "$!" >> {{ pidfile }}
+        dev_start "editor frontend (vite on :3000)" .dev-editor.log \
+          "cd frontend && npx vite"
     fi
 
-    # -- wait for services to come up --
     printf "${bold}=> Waiting for services…${reset} "
     sleep 4
     printf "${green}done${reset}\n"
@@ -397,28 +327,120 @@ dev:
     printf "  ${dim}Database:${reset}           just dev-psql\n"
     printf "  ${dim}Stop everything:${reset}    just dev-down\n"
 
-# Stop dev: kill native processes and stop infra
+# Vite ports default to 7300/7400/7500 (the redirect URIs already registered on
+# the regelrecht-local Keycloak client); override via EDITOR_PORT / ADMIN_FE_PORT
+# / LAWMAKING_PORT. No grafana / prometheus / workers are started.
+#
+# Frontend-focused dev: start only what a frontend needs (backend, DB, WASM, vite). APP = editor (default) | admin | lawmaking | all
+dev-frontend APP="editor":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    export COMPOSE="{{ compose-native }}"  PIDFILE="{{ pidfile }}"
+    source script/dev-lib.sh
+
+    app="{{ APP }}"
+    case "$app" in
+        editor|admin|lawmaking|all) ;;
+        *) printf "${red}Unknown app '%s'${reset} — use: editor | admin | lawmaking | all\n" "$app"; exit 1 ;;
+    esac
+
+    run_editor=false; run_admin=false; run_lawmaking=false
+    case "$app" in
+        editor)    run_editor=true ;;
+        admin)     run_admin=true ;;
+        lawmaking) run_lawmaking=true ;;
+        all)       run_editor=true; run_admin=true; run_lawmaking=true ;;
+    esac
+
+    # Vite (browser-facing) ports — overridable. Editor stays 7300 unless you
+    # also update BASE_URL in .env.sso-local and the Keycloak redirect URI.
+    editor_port="${EDITOR_PORT:-7300}"
+    admin_fe_port="${ADMIN_FE_PORT:-7400}"
+    lawmaking_port="${LAWMAKING_PORT:-7500}"
+    # In 'all', editor-api keeps :8000 and admin moves to :8001 to avoid the clash.
+    admin_api_port=8000
+    if [ "$app" = all ]; then admin_api_port=8001; fi
+
+    if [ "$run_editor" = true ] || [ "$run_admin" = true ]; then
+        dev_preflight --rust --node
+    else
+        dev_preflight --node
+    fi
+
+    # editor / all run editor-api with OIDC against the central Keycloak.
+    if [ "$run_editor" = true ] && [ ! -f .env.sso-local ]; then
+        printf "${red}Missing .env.sso-local${reset} — copy .env.sso-local.example and fill in the Keycloak values (see auth-and-roles.md).\n"
+        exit 1
+    fi
+
+    # DB is needed by editor (session store) and admin; lawmaking has no backend.
+    if [ "$run_editor" = true ] || [ "$run_admin" = true ]; then
+        dev_compose_up postgres
+        dev_wait_postgres
+    fi
+
+    rm -f "$PIDFILE"
+
+    if [ "$run_editor" = true ]; then
+        dev_ensure_wasm
+        if dev_ensure_deps frontend "editor frontend"; then
+            # Plain `cargo run` (not cargo-watch): a frontend-dev loop doesn't
+            # rebuild the backend, and cargo-watch's recursive watch hangs on a
+            # 9p-mounted worktree. Matches the `editor-sso` recipe. Source
+            # .env.sso-local inside the backgrounded shell so the OIDC /
+            # DATABASE_URL / BASE_URL it sets scope to editor-api only.
+            dev_start "editor-api (:8000, OIDC)" .dev-editor-api.log \
+              "set -a; . ./.env.sso-local; set +a; cd packages && cargo run --package regelrecht-editor-api"
+            dev_start "editor vite (:${editor_port})" .dev-editor.log \
+              "cd frontend && API_PORT=8000 npx vite --port ${editor_port} --strictPort --host 0.0.0.0"
+        fi
+    fi
+
+    if [ "$run_admin" = true ]; then
+        if dev_ensure_deps packages/admin/frontend-src "admin frontend"; then
+            db_url="postgres://regelrecht:regelrecht_dev@${DB_HOST:-localhost}:${POSTGRES_PORT:-5433}/regelrecht_pipeline"
+            dev_start "admin API (:${admin_api_port})" .dev-admin.log \
+              "cd packages && DATABASE_URL='$db_url' RUST_LOG='${RUST_LOG:-info}' ADMIN_PORT=${admin_api_port} cargo run --package regelrecht-admin"
+            dev_start "admin vite (:${admin_fe_port})" .dev-admin-frontend.log \
+              "cd packages/admin/frontend-src && API_PORT=${admin_api_port} npx vite --port ${admin_fe_port} --strictPort --host 0.0.0.0"
+        fi
+    fi
+
+    if [ "$run_lawmaking" = true ]; then
+        if dev_ensure_deps frontend-lawmaking "lawmaking frontend"; then
+            dev_start "lawmaking vite (:${lawmaking_port})" .dev-lawmaking.log \
+              "cd frontend-lawmaking && npx vite --port ${lawmaking_port} --strictPort --host 0.0.0.0"
+        fi
+    fi
+
+    printf "${bold}=> Waiting for services…${reset} "
+    sleep 4
+    printf "${green}done${reset}\n\n"
+
+    printf "${bold}${green}  Frontend dev stack (%s) is running (vite HMR; backends run-once)${reset}\n\n" "$app"
+    if [ "$run_editor" = true ]; then
+        echo "  Editor:     http://localhost:${editor_port}     (vite HMR → editor-api :8000, SSO)"
+    fi
+    if [ "$run_admin" = true ]; then
+        echo "  Admin UI:   http://localhost:${admin_fe_port}     (vite HMR → admin API :${admin_api_port})"
+    fi
+    if [ "$run_lawmaking" = true ]; then
+        echo "  Lawmaking:  http://localhost:${lawmaking_port}     (vite HMR, no backend)"
+    fi
+    if [ "$run_editor" = true ] || [ "$run_admin" = true ]; then
+        echo "  PostgreSQL: localhost:${POSTGRES_PORT:-5433}"
+    fi
+    printf "\n"
+    printf "  ${dim}Logs:${reset}            tail -f .dev-*.log\n"
+    printf "  ${dim}Stop everything:${reset} just dev-down\n"
+
+# Stop dev: kill native processes and stop infra (works for dev and dev-frontend)
 dev-down:
     #!/usr/bin/env bash
     set -euo pipefail
-    bold="\033[1m"  reset="\033[0m"  green="\033[32m"
-
-    printf "${bold}=> Stopping native services…${reset} "
-    if [ -f {{ pidfile }} ]; then
-        while read -r pid; do
-            # Kill children first (node, cargo, etc.), then the parent
-            pkill -P "$pid" 2>/dev/null || true
-            kill "$pid" 2>/dev/null || true
-        done < {{ pidfile }}
-        rm -f {{ pidfile }}
-        sleep 1
-    fi
-    rm -f .dev-admin.log .dev-admin-frontend.log .dev-editor.log
-    printf "${green}done${reset}\n"
-
-    printf "${bold}=> Stopping infra…${reset} "
-    {{ compose-native }} down > /dev/null 2>&1
-    printf "${green}done${reset}\n"
+    export COMPOSE="{{ compose-native }}"  PIDFILE="{{ pidfile }}"
+    source script/dev-lib.sh
+    dev_stop
 
 # Follow infra logs in dev mode
 dev-logs *ARGS:

--- a/README.md
+++ b/README.md
@@ -96,6 +96,28 @@ export RUSTC_WRAPPER=sccache CARGO_INCREMENTAL=0
 
 CI uses both mold and sccache (see `.github/workflows/ci.yml`).
 
+### Running a dev stack
+
+```bash
+just dev               # full native dev stack (admin + both frontends + grafana/prometheus)
+just dev-frontend      # frontend-focused: editor only (editor-api + editor UI + DB), no observability
+just dev-frontend admin      # admin API + admin UI + DB
+just dev-frontend lawmaking  # lawmaking UI only (no backend)
+just dev-frontend all        # all frontends on distinct ports (editor 7300, admin 7400, lawmaking 7500)
+just dev-down          # stop whichever of the above is running
+```
+
+`dev-frontend` starts only the components a given frontend needs — no grafana,
+prometheus, or workers. The editor runs with real SSO against the central
+Keycloak, so it needs `.env.sso-local` (copy `.env.sso-local.example`). It and
+`just dev` are mutually exclusive (they share `.dev-pids` and ports) — run one at
+a time.
+
+Vite ports default to `7300/7400/7500` (overridable via `EDITOR_PORT` /
+`ADMIN_FE_PORT` / `LAWMAKING_PORT`). When the native backend can't reach Postgres
+on `localhost` (e.g. a WSL2/Docker-Desktop dev container, where Postgres is
+published on the Docker host), set `DB_HOST=host.docker.internal` in `.env`.
+
 See the [docs site](https://docs.regelrecht.rijks.app) for full development instructions.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -114,9 +114,12 @@ Keycloak, so it needs `.env.sso-local` (copy `.env.sso-local.example`). It and
 a time.
 
 Vite ports default to `7300/7400/7500` (overridable via `EDITOR_PORT` /
-`ADMIN_FE_PORT` / `LAWMAKING_PORT`). When the native backend can't reach Postgres
+`ADMIN_FE_PORT` / `LAWMAKING_PORT`). When a native backend can't reach Postgres
 on `localhost` (e.g. a WSL2/Docker-Desktop dev container, where Postgres is
-published on the Docker host), set `DB_HOST=host.docker.internal` in `.env`.
+published on the Docker host), point it at `host.docker.internal`: for the
+admin / `just dev` paths set `DB_HOST=host.docker.internal` in `.env`; for the
+editor that host comes from `DATABASE_URL` in `.env.sso-local` (the
+`.env.sso-local.example` already uses `host.docker.internal`).
 
 See the [docs site](https://docs.regelrecht.rijks.app) for full development instructions.
 

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,6 +1,11 @@
 import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
 
+// Backend port the dev proxy forwards /api, /auth and /health to. Defaults to
+// 8000 (editor-api); `just dev-frontend` sets API_PORT so multiple backends can
+// coexist on distinct ports.
+const apiTarget = `http://localhost:${process.env.API_PORT || '8000'}`;
+
 export default defineConfig({
   root: '.',
   plugins: [
@@ -42,9 +47,9 @@ export default defineConfig({
   server: {
     port: 3000,
     proxy: {
-      '/api': 'http://localhost:8000',
-      '/auth': 'http://localhost:8000',
-      '/health': 'http://localhost:8000',
+      '/api': apiTarget,
+      '/auth': apiTarget,
+      '/health': apiTarget,
     },
   },
 });

--- a/packages/admin/frontend-src/vite.config.js
+++ b/packages/admin/frontend-src/vite.config.js
@@ -1,6 +1,11 @@
 import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
 
+// Backend port the dev proxy forwards /api, /auth and /health to. Defaults to
+// 8000 (admin API); `just dev-frontend all` sets API_PORT=8001 so the admin API
+// can move aside for editor-api on :8000.
+const apiTarget = `http://localhost:${process.env.API_PORT || '8000'}`;
+
 export default defineConfig({
   root: '.',
   // Vite's built-in SPA history-fallback (the default for appType 'spa')
@@ -28,9 +33,9 @@ export default defineConfig({
   server: {
     port: 3001,
     proxy: {
-      '/api': 'http://localhost:8000',
-      '/auth': 'http://localhost:8000',
-      '/health': 'http://localhost:8000',
+      '/api': apiTarget,
+      '/auth': apiTarget,
+      '/health': apiTarget,
     },
   },
 });

--- a/script/dev-lib.sh
+++ b/script/dev-lib.sh
@@ -11,7 +11,7 @@
 
 # ANSI colors. Stored as literal escapes and expanded by printf's format string.
 bold="\033[1m"  dim="\033[2m"  reset="\033[0m"
-green="\033[32m"  red="\033[31m"  cyan="\033[36m"  yellow="\033[33m"
+green="\033[32m"  red="\033[31m"  yellow="\033[33m"
 
 # dev_preflight [--rust] [--node] [--watch]
 # Verify the tools the recipe needs. Always checks docker. --node also checks

--- a/script/dev-lib.sh
+++ b/script/dev-lib.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Shared helpers for the `just dev` and `just dev-frontend` recipes.
+#
+# This file is *sourced* (not executed) by those recipes, so they can share one
+# implementation of preflight checks, infra start-up, dependency installation,
+# backgrounded service launching, and teardown. Before sourcing, the caller must
+# export:
+#   COMPOSE  - the `docker compose -f … -f …` invocation (i.e. compose-native)
+#   PIDFILE  - path to the file tracking backgrounded native-service PIDs
+# All functions assume the repo root as CWD (just runs recipe bodies from there).
+
+# ANSI colors. Stored as literal escapes and expanded by printf's format string.
+bold="\033[1m"  dim="\033[2m"  reset="\033[0m"
+green="\033[32m"  red="\033[31m"  cyan="\033[36m"  yellow="\033[33m"
+
+# dev_preflight [--rust] [--node] [--watch]
+# Verify the tools the recipe needs. Always checks docker. --node also checks
+# node; --rust also checks cargo and requires mold (the linker configured in
+# packages/.cargo/config.toml); --watch additionally auto-installs cargo-watch
+# (only `just dev` hot-reloads the backend). Exits 1 listing every missing dep.
+dev_preflight() {
+    local want_rust=false want_node=false want_watch=false arg
+    for arg in "$@"; do
+        case "$arg" in
+            --rust)  want_rust=true ;;
+            --node)  want_node=true ;;
+            --watch) want_watch=true ;;
+        esac
+    done
+
+    local missing=()
+    command -v docker >/dev/null || missing+=("docker")
+    [ "$want_node" = true ] && { command -v node >/dev/null || missing+=("node"); }
+
+    if [ "$want_rust" = true ]; then
+        command -v cargo >/dev/null || missing+=("cargo (rustup.rs)")
+        # mold is the linker in packages/.cargo/config.toml; without it dev
+        # builds fail to link.
+        command -v mold >/dev/null 2>&1 || missing+=("mold (run 'just dev-setup')")
+    fi
+
+    if [ "$want_watch" = true ] && ! cargo watch --version >/dev/null 2>&1; then
+        printf "${yellow}=> Installing cargo-watch…${reset} "
+        if cargo install cargo-watch --quiet 2>/dev/null; then
+            printf "${green}done${reset}\n"
+        else
+            missing+=("cargo-watch (cargo install cargo-watch)")
+        fi
+    fi
+
+    if [ ${#missing[@]} -gt 0 ]; then
+        printf "${red}Missing dependencies:${reset}\n"
+        local dep
+        for dep in "${missing[@]}"; do echo "  - $dep"; done
+        exit 1
+    fi
+}
+
+# dev_compose_up <service…> — start the given infra services, failing loudly
+# (with captured logs) if compose errors.
+dev_compose_up() {
+    local logfile
+    logfile=$(mktemp)
+    printf "${bold}=> Starting infra (%s)…${reset} " "$*"
+    if $COMPOSE up -d "$@" > "$logfile" 2>&1; then
+        printf "${green}done${reset}\n"
+    else
+        printf "${red}failed${reset}\n"
+        cat "$logfile"; rm -f "$logfile"; exit 1
+    fi
+    rm -f "$logfile"
+}
+
+# dev_wait_postgres — block (up to 30s) until postgres accepts connections.
+dev_wait_postgres() {
+    printf "${bold}=> Waiting for postgres…${reset} "
+    local i
+    for i in $(seq 1 30); do
+        if $COMPOSE exec -T postgres pg_isready -U regelrecht -d regelrecht_pipeline >/dev/null 2>&1; then
+            printf "${green}ready${reset}\n"
+            return 0
+        fi
+        if [ "$i" -eq 30 ]; then
+            printf "${red}timeout${reset}\n"; exit 1
+        fi
+        sleep 1
+    done
+}
+
+# dev_ensure_deps <dir> <label> — run `npm ci` in <dir> if node_modules is
+# absent. Returns non-zero (with a warning) on failure so the caller can skip
+# that frontend instead of aborting the whole stack.
+dev_ensure_deps() {
+    local dir="$1" label="$2"
+    [ -d "$dir/node_modules" ] && return 0
+    printf "${bold}=> Installing %s deps…${reset} " "$label"
+    if (cd "$dir" && npm ci --silent) > /dev/null 2>&1; then
+        printf "${green}done${reset}\n"
+        return 0
+    fi
+    printf "${yellow}skipped${reset} (npm ci failed)\n"
+    return 1
+}
+
+# dev_ensure_wasm — build the engine WASM the editor frontend loads at runtime,
+# if it isn't built yet. (frontend/src/composables/useEngine.js fetches it.)
+dev_ensure_wasm() {
+    [ -f frontend/public/wasm/pkg/regelrecht_engine.js ] && return 0
+    printf "${bold}=> Building engine WASM (just wasm-build)…${reset}\n"
+    just wasm-build
+}
+
+# dev_start <label> <logfile> <cmd-string> — run <cmd-string> in the background
+# via `setsid bash -c`, redirect its output to <logfile>, and record its PID in
+# $PIDFILE for `just dev-down`. The command is a string so callers can inline
+# per-service env vars and `cd` without leaking them into the recipe shell.
+# `setsid` makes the process its own session/group leader (PID == PGID), so
+# dev_stop can kill the whole subtree — npm → node, cargo → child — in one shot.
+dev_start() {
+    local label="$1" logfile="$2" cmd="$3"
+    printf "${bold}=> Starting %s…${reset}\n" "$label"
+    setsid bash -c "$cmd" > "$logfile" 2>&1 &
+    echo "$!" >> "$PIDFILE"
+}
+
+# dev_stop — kill everything recorded in $PIDFILE, remove dev logs, stop infra.
+# Shared by `just dev-down`; works for whichever of dev / dev-frontend ran.
+dev_stop() {
+    printf "${bold}=> Stopping native services…${reset} "
+    if [ -f "$PIDFILE" ]; then
+        local pid
+        while read -r pid; do
+            # Each recorded PID is a setsid session leader (PID == PGID), so the
+            # negative-PID kill takes out the whole process tree (vite's node
+            # grandchild, cargo's child, …). Fall back to a plain kill.
+            kill -- -"$pid" 2>/dev/null || kill "$pid" 2>/dev/null || true
+        done < "$PIDFILE"
+        rm -f "$PIDFILE"
+        sleep 1
+    fi
+    rm -f .dev-*.log
+    printf "${green}done${reset}\n"
+
+    printf "${bold}=> Stopping infra…${reset} "
+    $COMPOSE down > /dev/null 2>&1
+    printf "${green}done${reset}\n"
+}


### PR DESCRIPTION
## What

Adds `just dev-frontend [editor|admin|lawmaking|all]` — a frontend-focused dev
recipe that starts **only** the components a given frontend needs (its backend,
DB, WASM, and vite dev server) and skips grafana, prometheus, and the workers.

Builds on PR #779 (merged).

## Why

`just dev` always boots the full observability stack (postgres + prometheus +
grafana) and wires a single backend on `:8000`. For frontend iteration that's
both too much and subtly wrong: `just dev` runs the **admin** API on `:8000`, but
the editor frontend's vite proxy also points at `:8000`, so the editor UI talks
to the admin API instead of `editor-api`.

## What's in it

| `just dev-frontend …` | vite (browser) | backend | postgres | WASM | SSO |
|---|---|---|---|---|---|
| `editor` (default) | 7300 | editor-api :8000 (OIDC) | ✅ | ✅ | central Keycloak via `.env.sso-local` |
| `admin` | 7400 | admin API :8000 (`ADMIN_PORT`) | ✅ | — | — |
| `lawmaking` | 7500 | none | — | — | — |
| `all` | 7300 / 7400 / 7500 | editor-api :8000 + admin :8001 | ✅ | ✅ (editor) | editor only |

- **DRY refactor:** the shared dev orchestration (preflight, infra start,
  postgres-wait, npm-dep install, WASM build, backgrounded service start,
  teardown) is extracted into `script/dev-lib.sh`; both `dev` and `dev-down` are
  rebuilt on it. `dev`'s behaviour is unchanged.
- Vite ports default to `7300/7400/7500` — the redirect URIs already registered
  on the `regelrecht-local` Keycloak client, so any app can use SSO with **zero
  Keycloak changes**. Overridable via `EDITOR_PORT` / `ADMIN_FE_PORT` /
  `LAWMAKING_PORT`.
- The editor and admin **vite proxy targets** now honour an `API_PORT` env var,
  so `all` can run editor-api on `:8000` and admin on `:8001` simultaneously.
  No Rust change (admin already honours `ADMIN_PORT`; editor-api stays on `:8000`).
- `DB_HOST` knob (default `localhost`; set `host.docker.internal` in a
  WSL2/Docker-Desktop dev container) for Postgres reachability.

## Notes / things to know

- `dev` and `dev-frontend` are **mutually exclusive** (shared `.dev-pids` +
  overlapping ports) — `just dev-down` stops whichever is running.
- Vite servers bind `0.0.0.0` so they're reachable from the host. Backends stay
  in-container (reached only via the vite proxy), so they're irrelevant to
  Keycloak.

## Files

- `script/dev-lib.sh` — new shared library.
- `Justfile` — add `dev-frontend`; rebuild `dev` / `dev-down` on the library.
- `frontend/vite.config.js`, `packages/admin/frontend-src/vite.config.js` —
  `API_PORT`-configurable proxy target.
- `README.md` — document the recipe.

## Testing

Verified end-to-end in the dev container: `just dev-frontend editor` brings up
postgres + editor-api (SSO against the central Keycloak, DB-backed sessions) +
editor vite on `:7300` with the engine WASM built. Probes:

- vite `:7300` → 200; editor-api `:8000/health` → 200
- proxied `:7300/health` and `:7300/auth/status` → 200 (editor UI talks to
  **editor-api**, not admin)
- `:7300/wasm/pkg/regelrecht_engine.js` → 200
- `:7300/auth/login` → 307 to `keycloak.rijksapp.nl/.../regelrecht-local` with
  `redirect_uri=http://localhost:7300/auth/callback` (a registered URI — zero
  Keycloak changes)
- `just dev-down` tears the whole stack down cleanly (no leaked vite/editor-api).

Note: backends run once via plain `cargo run` (matching `editor-sso`), not
cargo-watch — a frontend-dev loop doesn't rebuild the backend, and cargo-watch's
recursive watch hangs on a 9p-mounted worktree. vite keeps HMR for the frontend.