### PR TITLE
feat(dev): default `just dev-frontend` to all frontends + dev docs

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -331,8 +331,8 @@ dev:
 # the regelrecht-local Keycloak client); override via EDITOR_PORT / ADMIN_FE_PORT
 # / LAWMAKING_PORT. No grafana / prometheus / workers are started.
 #
-# Frontend-focused dev: start only what a frontend needs (backend, DB, WASM, vite). APP = editor (default) | admin | lawmaking | all
-dev-frontend APP="editor":
+# Frontend-focused dev: start only what a frontend needs (backend, DB, WASM, vite). No arg = all frontends; APP = editor | admin | lawmaking | all
+dev-frontend APP="all":
     #!/usr/bin/env bash
     set -euo pipefail
     export COMPOSE="{{ compose-native }}"  PIDFILE="{{ pidfile }}"

--- a/README.md
+++ b/README.md
@@ -100,15 +100,17 @@ CI uses both mold and sccache (see `.github/workflows/ci.yml`).
 
 ```bash
 just dev               # full native dev stack (admin + both frontends + grafana/prometheus)
-just dev-frontend      # frontend-focused: editor only (editor-api + editor UI + DB), no observability
-just dev-frontend admin      # admin API + admin UI + DB
-just dev-frontend lawmaking  # lawmaking UI only (no backend)
-just dev-frontend all        # all frontends on distinct ports (editor 7300, admin 7400, lawmaking 7500)
+just dev-frontend            # all frontends (editor 7300, admin 7400, lawmaking 7500), no observability
+just dev-frontend editor     # just the editor (editor-api + editor UI + DB)
+just dev-frontend admin      # just the admin API + admin UI + DB
+just dev-frontend lawmaking  # just the lawmaking UI (no backend)
 just dev-down          # stop whichever of the above is running
 ```
 
-`dev-frontend` starts only the components a given frontend needs — no grafana,
-prometheus, or workers. The editor runs with real SSO against the central
+`dev-frontend` with no argument starts every frontend; pass `editor`, `admin`,
+or `lawmaking` to start just one. Either way it starts only the components those
+frontends need — no grafana, prometheus, or workers. The editor runs with real
+SSO against the central
 Keycloak, so it needs `.env.sso-local` (copy `.env.sso-local.example`). It and
 `just dev` are mutually exclusive (they share `.dev-pids` and ports) — run one at
 a time.

--- a/docs/src/content/docs/guide/dev-environment.md
+++ b/docs/src/content/docs/guide/dev-environment.md
@@ -23,6 +23,24 @@ The development stack runs infrastructure in Docker and application services nat
 └─────────────────────────────────────────────────┘
 ```
 
+## One-Time Setup (build speed)
+
+Run once per machine after cloning:
+
+```bash
+just dev-setup
+```
+
+It installs the [mold](https://github.com/rui314/mold) linker (a hard
+requirement — the dev recipes won't link without it) plus `sccache`, and points
+every git worktree at a single shared cargo `target-dir` so a new worktree
+reuses the already-built dependency graph instead of cold-building from scratch.
+When the repo lives on a slow mount (9p/NFS/SMB — e.g. a WSL2 or Docker-Desktop
+dev container backed by a Windows drive), it relocates that target dir to fast
+local storage under `~/.cache/regelrecht/`, which is usually the single biggest
+build-time win. `sccache` is installed but left off locally (it disables
+incremental compilation, which hurts the hot-reload loop); CI uses both.
+
 ## Starting the Dev Stack
 
 ```bash
@@ -30,11 +48,49 @@ just dev
 ```
 
 This command:
-1. Checks prerequisites (cargo, node, docker, cargo-watch)
+1. Checks prerequisites (cargo, node, docker, cargo-watch, mold)
 2. Starts infrastructure containers (PostgreSQL, Prometheus, Grafana)
 3. Waits for PostgreSQL to be ready
 4. Installs frontend dependencies if needed
 5. Starts all application services with hot reload
+
+## Frontend-Focused Dev Stack
+
+When you only need to work on a frontend, `just dev-frontend` starts just the
+components that frontend needs — its backend, PostgreSQL, the engine WASM, and
+the Vite dev server with HMR — and skips Grafana, Prometheus, and the workers.
+
+```bash
+just dev-frontend            # all frontends at once (default)
+just dev-frontend editor     # just the editor
+just dev-frontend admin      # just the admin dashboard
+just dev-frontend lawmaking  # just the lawmaking UI (no backend)
+just dev-down                # stop it (shared with `just dev`)
+```
+
+| App | URL | Backend | DB | Notes |
+|-----|-----|---------|----|----|
+| editor | `http://localhost:7300` | editor-api `:8000` | yes | real SSO — needs `.env.sso-local` |
+| admin | `http://localhost:7400` | admin API `:8000` (`:8001` when all run together) | yes | — |
+| lawmaking | `http://localhost:7500` | none | no | static, no backend |
+
+Notes:
+
+- **Backends run once** via `cargo run` (not `cargo watch`); Vite keeps HMR for
+  the frontend. Restarts after the first build are near-instant because the
+  Rust artifacts are reused (see [One-Time Setup](#one-time-setup-build-speed)).
+- **The editor uses real SSO** against the central Keycloak, so it needs
+  `.env.sso-local` (copy `.env.sso-local.example` and fill in the values — see
+  [Auth and roles](/auth-and-roles/)). Use Chrome or Firefox: the session cookie
+  is `Secure` and only those send it over `http://localhost`. The default port
+  `7300` (and `7400`/`7500`) are the redirect URIs already registered on the
+  `regelrecht-local` Keycloak client. Override ports with `EDITOR_PORT` /
+  `ADMIN_FE_PORT` / `LAWMAKING_PORT`.
+- `just dev-frontend` and `just dev` are **mutually exclusive** — they share
+  `.dev-pids` and ports, so run one at a time. `just dev-down` stops either.
+- In a dev container where the native backend can't reach Postgres on
+  `localhost`, set `DB_HOST=host.docker.internal` in `.env` (admin / `just dev`
+  paths); the editor takes that host from `DATABASE_URL` in `.env.sso-local`.
 
 ## Stopping
 


### PR DESCRIPTION
## What

Two follow-ups to #783:

1. **`just dev-frontend` (no argument) now starts *all* frontends.** Pass
   `editor`, `admin`, or `lawmaking` to start just one. The explicit `all`
   keyword still works but is no longer needed.

   ```bash
   just dev-frontend            # all frontends (editor 7300, admin 7400, lawmaking 7500)
   just dev-frontend editor     # just the editor
   just dev-frontend admin      # just the admin dashboard
   just dev-frontend lawmaking  # just the lawmaking UI
   ```

2. **Documentation.** Documents the frontend-dev workflow and the one-time
   `just dev-setup` (from #779) in the docs site
   (`guide/dev-environment`), and updates the README to match the new default.

## Why

The previous default (`editor`) made `all` a separate, easy-to-miss keyword. "No
arg = everything, an arg = that one app" is the more intuitive model.

## Testing

Smoke-tested `just dev-frontend` (all) end-to-end on the dev container:

- editor `:7300` → 200, proxied `/health` and `/auth/status` → editor-api `:8000` → 200
- admin `:7400` → 200, proxied `/health` → admin API `:8001` → 200 (no port clash with editor-api)
- lawmaking `:7500` → 200 (first-run vite dep-optimize ~51s, then served)
- both backends listening on distinct ports (8000 / 8001); only the postgres container started
- `just dev-down` tore the whole stack down cleanly (all dev ports clear)

`just --list` parses and the Justfile evaluates.
