### PR TITLE
fix(frontend): restore Notitie button after note popover light-dismiss

### DIFF
--- a/frontend/src/components/NoteCreator.test.js
+++ b/frontend/src/components/NoteCreator.test.js
@@ -36,7 +36,7 @@ const stubs = {
 
 const RAW = 'Indien de normpremie voor een verzekerde';
 
-function mountCreator(extraProps = {}) {
+function mountCreator(extraProps = {}, extraStubs = {}) {
   const engine = {
     resolveNote: () => ({
       status: 'found',
@@ -58,7 +58,7 @@ function mountCreator(extraProps = {}) {
       anchor: document.createElement('span'),
       ...extraProps,
     },
-    global: { stubs },
+    global: { stubs: { ...stubs, ...extraStubs } },
   });
 }
 
@@ -175,7 +175,8 @@ describe('NoteCreator', () => {
   it('emits cancel when the popover closes via light-dismiss', async () => {
     const w = mountCreator();
     await nextTick();
-    w.element.dispatchEvent(new Event('close'));
+    // Same shape as the real nldd close event (bubbles + composed).
+    w.element.dispatchEvent(new Event('close', { bubbles: true, composed: true }));
     await nextTick();
     expect(w.emitted('cancel')).toHaveLength(1);
   });
@@ -184,9 +185,46 @@ describe('NoteCreator', () => {
     const w = mountCreator();
     await nextTick();
     await w.setProps({ range: null }); // parent already tore the flow down
-    w.element.dispatchEvent(new Event('close'));
+    w.element.dispatchEvent(new Event('close', { bubbles: true, composed: true }));
     await nextTick();
     expect(w.emitted('cancel')).toBeUndefined();
+  });
+
+  // A future nested nldd component in the form slot would dispatch its own
+  // bubbling `close`; that must not cancel the half-filled form.
+  it('ignores a close event bubbling up from inside the form', async () => {
+    const w = mountCreator();
+    await nextTick();
+    w.find('[data-testid="note-creator"]').element.dispatchEvent(
+      new Event('close', { bubbles: true, composed: true }),
+    );
+    await nextTick();
+    expect(w.emitted('cancel')).toBeUndefined();
+  });
+
+  // If an nldd-popover implementation ever dispatched close synchronously
+  // from hidePopover() (instead of the spec's queued toggle task), save()
+  // must still not read as a cancel. The stub simulates that regime.
+  it('does not emit cancel when save() itself hides the popover', async () => {
+    const w = mountCreator({}, {
+      'nldd-popover': {
+        template: '<div><slot/></div>',
+        methods: {
+          showPopover() {},
+          hidePopover() {
+            this.$el.dispatchEvent(new Event('close', { bubbles: true, composed: true }));
+          },
+          matches() { return false; },
+        },
+      },
+    });
+    await nextTick();
+    w.vm.commentText = 'uitleg';
+    await nextTick();
+    w.vm.save();
+    await nextTick();
+    expect(w.emitted('cancel')).toBeUndefined();
+    expect(w.emitted('create')).toHaveLength(1);
   });
 
   it('remembers the creator across mounts via localStorage', async () => {

--- a/frontend/src/components/NoteCreator.test.js
+++ b/frontend/src/components/NoteCreator.test.js
@@ -167,6 +167,28 @@ describe('NoteCreator', () => {
     expect(w.find('[data-testid="note-save"]').exists()).toBe(true);
   });
 
+  // nldd-popover is popover="auto": clicking outside (or Esc) light-dismisses
+  // it in the browser without going through cancel(). The component fires
+  // `close` on every dismissal; NoteCreator must treat a close while the form
+  // is still open as a cancel, or the parent keeps creatorOpen=true and the
+  // "Notitie" button never reappears on a new selection.
+  it('emits cancel when the popover closes via light-dismiss', async () => {
+    const w = mountCreator();
+    await nextTick();
+    w.element.dispatchEvent(new Event('close'));
+    await nextTick();
+    expect(w.emitted('cancel')).toHaveLength(1);
+  });
+
+  it('does not emit cancel for the close that follows its own teardown', async () => {
+    const w = mountCreator();
+    await nextTick();
+    await w.setProps({ range: null }); // parent already tore the flow down
+    w.element.dispatchEvent(new Event('close'));
+    await nextTick();
+    expect(w.emitted('cancel')).toBeUndefined();
+  });
+
   it('remembers the creator across mounts via localStorage', async () => {
     const w = mountCreator();
     await nextTick();

--- a/frontend/src/components/NoteCreator.vue
+++ b/frontend/src/components/NoteCreator.vue
@@ -179,7 +179,11 @@ function cancel() {
 // the parent keeps creatorOpen=true and suppresses the "Notitie" button for
 // every later selection. Closes from our own save()/cancel()/teardown land
 // after the parent already nulled the range, so the guard skips those.
-function onPopoverClose() {
+function onPopoverClose(event) {
+  // Only the popover's own close counts: nldd close events bubble+composed,
+  // so a future nested sheet/dialog in the form slot would land here too and
+  // silently cancel a half-filled form.
+  if (event.target !== event.currentTarget) return;
   if (!props.range) return;
   reset();
   emit('cancel');

--- a/frontend/src/components/NoteCreator.vue
+++ b/frontend/src/components/NoteCreator.vue
@@ -172,6 +172,19 @@ function cancel() {
   emit('cancel');
 }
 
+// nldd-popover is popover="auto": the browser light-dismisses it on an
+// outside click or Esc without going through cancel(). The component fires
+// `close` on every dismissal, so a close that arrives while the form is
+// still open (range set) is an external dismiss and must cancel — otherwise
+// the parent keeps creatorOpen=true and suppresses the "Notitie" button for
+// every later selection. Closes from our own save()/cancel()/teardown land
+// after the parent already nulled the range, so the guard skips those.
+function onPopoverClose() {
+  if (!props.range) return;
+  reset();
+  emit('cancel');
+}
+
 function save() {
   if (!canSave.value) return;
   const note = {
@@ -272,6 +285,7 @@ const statusInfo = computed(() => {
     accessible-label="Notitie aanmaken"
     placement="bottom-start"
     width="480px"
+    @close="onPopoverClose"
   >
     <div v-if="range" class="note-creator" data-testid="note-creator">
       <div class="nc-quote">

--- a/frontend/src/components/NoteCreator.vue
+++ b/frontend/src/components/NoteCreator.vue
@@ -166,8 +166,25 @@ function reset() {
   workflow.value = 'open';
 }
 
+// True while our own cancel()/save() is inside hidePopover(), so a `close`
+// dispatched synchronously from that call is recognized as self-inflicted.
+// The native popover spec queues toggle (and thus nldd's close) as a task,
+// which lands after the parent nulled `range` — the range guard below covers
+// that regime. This flag covers the synchronous regime, so onPopoverClose
+// stays correct regardless of how nldd-popover dispatches.
+let selfClosing = false;
+
+function hidePopoverSelf() {
+  selfClosing = true;
+  try {
+    popoverEl.value?.hidePopover?.();
+  } finally {
+    selfClosing = false;
+  }
+}
+
 function cancel() {
-  popoverEl.value?.hidePopover?.();
+  hidePopoverSelf();
   reset();
   emit('cancel');
 }
@@ -177,14 +194,15 @@ function cancel() {
 // `close` on every dismissal, so a close that arrives while the form is
 // still open (range set) is an external dismiss and must cancel — otherwise
 // the parent keeps creatorOpen=true and suppresses the "Notitie" button for
-// every later selection. Closes from our own save()/cancel()/teardown land
-// after the parent already nulled the range, so the guard skips those.
+// every later selection. Closes from our own save()/cancel()/teardown are
+// filtered by the selfClosing flag (synchronous dispatch) or arrive after
+// the parent already nulled the range (asynchronous dispatch).
 function onPopoverClose(event) {
   // Only the popover's own close counts: nldd close events bubble+composed,
   // so a future nested sheet/dialog in the form slot would land here too and
   // silently cancel a half-filled form.
   if (event.target !== event.currentTarget) return;
-  if (!props.range) return;
+  if (selfClosing || !props.range) return;
   reset();
   emit('cancel');
 }
@@ -209,7 +227,7 @@ function save() {
     note.workflow = workflow.value;
   }
   note.__draft = true;
-  popoverEl.value?.hidePopover?.();
+  hidePopoverSelf();
   reset();
   emit('create', note);
 }


### PR DESCRIPTION
## Problem

After opening the note-creator form on a text selection and then dismissing it by clicking next to it (or pressing Esc), selecting new text no longer shows the "Notitie" button. The only way out was switching articles.

## Root cause

`nldd-popover` is a native `popover="auto"` element: the browser light-dismisses it on an outside click without going through `NoteCreator.cancel()`. `AnnotatedText` therefore never received the `cancel` event, `creatorOpen` stayed `true`, and `onSelectionChange` kept early-returning — suppressing the selection button for every later selection.

## Fix

`nldd-popover` fires a `close` event on every dismissal, including light-dismiss. `NoteCreator` now listens for it and treats a close that arrives while the form is still open (`range` set) as a cancel. Closes triggered by our own `save()`/`cancel()`/teardown arrive after the parent already nulled the range, so the guard prevents double-emits.

## Testing

- New unit test: `close` event while the form is open emits `cancel`; a `close` after teardown does not.
- Full frontend suite: 270 tests pass.