### PR TITLE
fix(pipeline): don't let completed harvest jobs block re-harvest dedup

### DIFF
--- a/packages/pipeline/src/job_queue.rs
+++ b/packages/pipeline/src/job_queue.rs
@@ -228,7 +228,11 @@ where
     Ok(count)
 }
 
-/// Create a harvest job only if no active harvest job exists for this law.
+/// Create a harvest job only if no active (pending/processing) harvest job
+/// exists for this law.
+///
+/// Completed and failed jobs never block: a law that was harvested before
+/// must remain re-harvestable (e.g. via the editor's `POST /harvest`).
 ///
 /// The fast path uses `INSERT ... WHERE NOT EXISTS` (filtered by date) to
 /// avoid a round-trip for the common non-racing case. When two requests race
@@ -255,7 +259,7 @@ where
             WHERE job_type = 'harvest'
               AND law_id = $2
               AND (payload->>'date' = $6 OR payload->>'date' IS NULL)
-              AND status != 'failed'
+              AND status IN ('pending', 'processing')
         )
         RETURNING *
         "#,

--- a/packages/pipeline/tests/job_queue_tests.rs
+++ b/packages/pipeline/tests/job_queue_tests.rs
@@ -333,6 +333,35 @@ async fn test_create_harvest_job_if_not_exists_skips_dateless_job() {
 }
 
 #[tokio::test]
+async fn test_create_harvest_job_if_not_exists_ignores_completed_job() {
+    let db = TestDb::new().await;
+
+    // A previous harvest of this law ran to completion (editor-style payload
+    // without a date key).
+    let payload = json!({"bwb_id": "BWBR0001840"});
+    let req = CreateJobRequest::new(JobType::Harvest, "BWBR0001840").with_payload(payload.clone());
+    job_queue::create_job(&db.pool, req).await.unwrap();
+    let claimed = job_queue::claim_job(&db.pool, None).await.unwrap().unwrap();
+    job_queue::complete_job(&db.pool, claimed.id, None)
+        .await
+        .unwrap();
+
+    // A re-harvest request (editor uses an empty date) must create a new job:
+    // only pending/processing jobs may block, never completed ones.
+    let req2 = CreateJobRequest::new(JobType::Harvest, "BWBR0001840")
+        .with_priority(Priority::new(30))
+        .with_payload(payload);
+    let result = job_queue::create_harvest_job_if_not_exists(&db.pool, req2, "")
+        .await
+        .unwrap();
+    assert!(
+        result.is_some(),
+        "completed harvest job must not block a re-harvest"
+    );
+    assert_eq!(result.unwrap().status, JobStatus::Pending);
+}
+
+#[tokio::test]
 async fn test_concurrent_claim_safety() {
     let db = TestDb::new().await;
 


### PR DESCRIPTION
## Bug

`create_harvest_job_if_not_exists` (`packages/pipeline/src/job_queue.rs`) documents that it creates a harvest job "only if no **active** harvest job exists", but its `NOT EXISTS` subquery used `status != 'failed'` — which also matches **completed** jobs. Combined with the date filter (`payload->>'date' = $6 OR payload->>'date' IS NULL`), which matches editor-created jobs that have no `date` key in the payload, any old completed job for a law permanently blocked new ones.

## User impact

- After one successful harvest of a law, the editor endpoint `POST /harvest` (`packages/pipeline/src/api/harvest.rs`) always returned `already_queued` and never created a job — **re-harvesting from the editor was impossible**.
- The worker's law-level auto-retry (`packages/pipeline/src/worker.rs`) could be blocked the same way when an older completed job existed.

## Fix

Change the dedup condition to `status IN ('pending', 'processing')` and make the doc comment accurate. This matches the enrich variant (`create_enrich_job_if_not_exists`) and the partial unique index `idx_unique_active_harvest_job` (migration 0011), which already provides race safety and only covers pending/processing — so excluding completed jobs from the check loses nothing.

## Test plan

- New integration test `test_create_harvest_job_if_not_exists_ignores_completed_job`: with an existing **completed** harvest job (dateless editor-style payload), a re-harvest with empty date **does** create a new job.
- Existing `test_create_harvest_job_if_not_exists_skips_duplicate` covers the inverse: a **pending** job still blocks.
- `just pipeline-test`: 37 passed.
- `TESTCONTAINERS_HOST_OVERRIDE=host.docker.internal just pipeline-integration-test`: 31 passed (17 job_queue + 14 law_status), 0 failed.
- `just format` and `just lint`: clean.