### PR TITLE
fix(pipeline): harvest job timeout, independent reaper, exponential retry backoff

### DIFF
--- a/packages/corpus/src/client.rs
+++ b/packages/corpus/src/client.rs
@@ -162,10 +162,12 @@ impl CorpusClient {
     /// committed *alongside* content when content changed, but never *trigger*
     /// a commit on their own.
     ///
-    /// Returns `Ok(true)` if a commit was made and pushed, `Ok(false)` if the
-    /// content was unchanged (in which case the metadata files are restored to
-    /// HEAD so the working tree stays clean for the next run — this matters for
-    /// the long-lived corpus clone the harvest worker reuses).
+    /// Returns `Ok(true)` if a commit was pushed (either freshly made, or a
+    /// stranded local commit from an interrupted earlier attempt), `Ok(false)`
+    /// if the content was unchanged and the remote already has it (in which
+    /// case the metadata files are restored to HEAD so the working tree stays
+    /// clean for the next run — this matters for the long-lived corpus clone
+    /// the harvest worker reuses).
     pub async fn commit_and_push_content(
         &self,
         content_paths: &[PathBuf],
@@ -188,6 +190,22 @@ impl CorpusClient {
             // corpus clone, where a leftover dirty/untracked file would break
             // the next `pull --rebase`.
             self.restore_metadata(metadata_paths).await;
+
+            // The porcelain check above compares against the LOCAL HEAD. A
+            // previous attempt may have committed this exact content and then
+            // been interrupted (e.g. the worker's job timeout) before its push
+            // completed — the stranded commit makes the re-harvest look like
+            // "no change" even though the remote never received the content.
+            // If we returned `Ok(false)` here, the job would complete while
+            // the next `reset --hard origin/<branch>` (or pod restart)
+            // silently discards the commit. Push it instead.
+            if self.local_commits_ahead_of_remote().await? > 0 {
+                tracing::info!(
+                    "local HEAD ahead of remote tracking branch, pushing stranded commit(s)"
+                );
+                self.rebase_and_push(message).await?;
+                return Ok(true);
+            }
             return Ok(false);
         }
 
@@ -224,6 +242,20 @@ impl CorpusClient {
         if let Err(e) = self.run_git(&clean_args).await {
             tracing::warn!(error = %e, "failed to clean untracked metadata; working tree may be dirty");
         }
+    }
+
+    /// Number of commits the local HEAD is ahead of the remote tracking
+    /// branch (`origin/<branch>..HEAD`). Non-zero means an earlier
+    /// commit-and-push was interrupted between the commit and the push.
+    async fn local_commits_ahead_of_remote(&self) -> Result<u64> {
+        let range = format!("origin/{}..HEAD", self.config.branch);
+        let output = self
+            .run_git_output(&["rev-list", "--count", &range])
+            .await?;
+        let count = output.trim();
+        count
+            .parse::<u64>()
+            .map_err(|e| CorpusError::Git(format!("could not parse rev-list count {count:?}: {e}")))
     }
 
     /// Lossy UTF-8 path strings for use as git pathspec arguments.
@@ -491,11 +523,7 @@ impl CorpusClient {
         args.push(&url);
         args.push(&path_str);
 
-        let output = Command::new("git")
-            .args(&args)
-            .envs(self.git_env())
-            .output()
-            .await?;
+        let output = self.git_command(&args).output().await?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -544,11 +572,7 @@ impl CorpusClient {
         args.push(&url);
         args.push(&path_str);
 
-        let output = Command::new("git")
-            .args(&args)
-            .envs(self.git_env())
-            .output()
-            .await?;
+        let output = self.git_command(&args).output().await?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -667,12 +691,24 @@ impl CorpusClient {
         Ok(!output.trim().is_empty())
     }
 
+    /// Build a git `Command` with the shared environment and `kill_on_drop`.
+    ///
+    /// `kill_on_drop` matters because callers may be wrapped in a timeout
+    /// (e.g. the harvest worker's job timeout): when the timed-out future is
+    /// dropped, the subprocess must be killed too — otherwise a hung
+    /// `git pull --rebase` keeps running and races the next job in the same
+    /// checkout (index.lock contention).
+    fn git_command(&self, args: &[&str]) -> Command {
+        let mut cmd = Command::new("git");
+        cmd.args(args).envs(self.git_env()).kill_on_drop(true);
+        cmd
+    }
+
     /// Run a git command in the repo directory and check for success.
     async fn run_git(&self, args: &[&str]) -> Result<()> {
-        let output = Command::new("git")
-            .args(args)
+        let output = self
+            .git_command(args)
             .current_dir(&self.config.repo_path)
-            .envs(self.git_env())
             .output()
             .await?;
 
@@ -691,10 +727,9 @@ impl CorpusClient {
 
     /// Run a git command and return stdout.
     async fn run_git_output(&self, args: &[&str]) -> Result<String> {
-        let output = Command::new("git")
-            .args(args)
+        let output = self
+            .git_command(args)
             .current_dir(&self.config.repo_path)
-            .envs(self.git_env())
             .output()
             .await?;
 
@@ -1056,6 +1091,101 @@ mod tests {
         assert!(
             String::from_utf8_lossy(&porcelain.stdout).trim().is_empty(),
             "working tree must be clean after no-change harvest"
+        );
+    }
+
+    /// Regression: a harvest job can be interrupted (worker job timeout, pod
+    /// restart) after `git commit` but before the push completes. The retry
+    /// then re-harvests identical content, the porcelain check against the
+    /// LOCAL HEAD (which already contains the stranded commit) is empty, and
+    /// the old code returned `Ok(false)` without ever pushing — the law was
+    /// marked harvested while the remote corpus lacked the commit, and the
+    /// next `reset --hard origin/<branch>` discarded it permanently.
+    /// `commit_and_push_content` must detect the stranded commit and push it.
+    #[tokio::test]
+    async fn test_commit_and_push_content_pushes_stranded_local_commit() {
+        let dir = tempfile::tempdir().unwrap();
+        let bare_path = setup_bare_repo(dir.path()).await;
+        let bare_url = format!("file://{}", bare_path.display());
+        let repo_path = dir.path().join("corpus");
+        clone_with_config(&bare_path, &repo_path).await;
+
+        // Simulate the interrupted first attempt: the harvested content was
+        // committed locally but the push never happened (timeout fired
+        // mid-push and the future was dropped).
+        let law = repo_path.join("law.yaml");
+        tokio::fs::write(&law, "articles: 1\n").await.unwrap();
+        for args in [
+            vec!["add", "--", "law.yaml"],
+            vec!["commit", "-m", "harvest: interrupted before push"],
+        ] {
+            Command::new("git")
+                .args(&args)
+                .current_dir(&repo_path)
+                .output()
+                .await
+                .unwrap();
+        }
+
+        // Sanity-check the precondition: the remote does NOT have the commit.
+        let remote_log = Command::new("git")
+            .args(["log", "--oneline", "--all"])
+            .current_dir(&bare_path)
+            .output()
+            .await
+            .unwrap();
+        assert!(
+            !String::from_utf8_lossy(&remote_log.stdout).contains("interrupted before push"),
+            "precondition: stranded commit must not be on the remote yet"
+        );
+
+        let config = CorpusConfig::new(&bare_url, &repo_path);
+        let client = CorpusClient::new(config);
+
+        // The retry re-harvests identical content: the working tree already
+        // matches the (stranded) local HEAD, only the metadata churns.
+        let status = repo_path.join("status.yaml");
+        tokio::fs::write(&law, "articles: 1\n").await.unwrap();
+        tokio::fs::write(&status, "last_harvested: T2\n")
+            .await
+            .unwrap();
+        let committed = client
+            .commit_and_push_content(
+                std::slice::from_ref(&law),
+                std::slice::from_ref(&status),
+                "harvest: retry",
+            )
+            .await
+            .unwrap();
+        assert!(
+            committed,
+            "retry must report a change when it pushes a stranded commit"
+        );
+
+        // The stranded commit is now on the remote.
+        let remote_log = Command::new("git")
+            .args(["log", "--oneline", "--all"])
+            .current_dir(&bare_path)
+            .output()
+            .await
+            .unwrap();
+        let log_str = String::from_utf8_lossy(&remote_log.stdout);
+        assert!(
+            log_str.contains("interrupted before push"),
+            "stranded local commit must have been pushed to the remote: {log_str}"
+        );
+
+        // And the working tree is clean (metadata churn restored), so the
+        // next run's `pull --rebase` won't trip over a dirty file.
+        let porcelain = Command::new("git")
+            .args(["status", "--porcelain"])
+            .current_dir(&repo_path)
+            .output()
+            .await
+            .unwrap();
+        assert!(
+            String::from_utf8_lossy(&porcelain.stdout).trim().is_empty(),
+            "working tree must be clean after pushing the stranded commit"
         );
     }
 

--- a/packages/corpus/src/client.rs
+++ b/packages/corpus/src/client.rs
@@ -203,7 +203,14 @@ impl CorpusClient {
                 tracing::info!(
                     "local HEAD ahead of remote tracking branch, pushing stranded commit(s)"
                 );
-                self.rebase_and_push(message).await?;
+                // Log the stranded commit's own subject, not this retry's
+                // `message` — the stranded commit is what lands on the remote.
+                let stranded_subject = self
+                    .run_git_output(&["log", "-1", "--format=%s"])
+                    .await
+                    .map(|s| s.trim().to_string())
+                    .unwrap_or_else(|_| "<unknown stranded commit>".to_string());
+                self.rebase_and_push(&stranded_subject).await?;
                 return Ok(true);
             }
             return Ok(false);

--- a/packages/pipeline/migrations/0019_add_job_scheduled_at.sql
+++ b/packages/pipeline/migrations/0019_add_job_scheduled_at.sql
@@ -1,0 +1,13 @@
+-- Retry backoff: scheduled_at delays when a pending job becomes claimable.
+-- NULL means the job is claimable immediately (the default for new jobs).
+-- fail_job sets it to now() + exponential backoff when re-queueing a job
+-- for retry, so transient outages (e.g. BWB downtime) no longer burn all
+-- attempts within seconds.
+ALTER TABLE jobs ADD COLUMN scheduled_at TIMESTAMPTZ;
+
+-- Recreate the claim index with scheduled_at as a trailing key so the claim
+-- query's due-filter (scheduled_at IS NULL OR scheduled_at <= now()) can be
+-- evaluated from the index without heap fetches.
+DROP INDEX idx_jobs_queue;
+CREATE INDEX idx_jobs_queue ON jobs (priority DESC, created_at ASC, scheduled_at)
+    WHERE status = 'pending';

--- a/packages/pipeline/migrations/0019_add_job_scheduled_at.sql
+++ b/packages/pipeline/migrations/0019_add_job_scheduled_at.sql
@@ -5,9 +5,11 @@
 -- attempts within seconds.
 ALTER TABLE jobs ADD COLUMN scheduled_at TIMESTAMPTZ;
 
--- Recreate the claim index with scheduled_at as a trailing key so the claim
--- query's due-filter (scheduled_at IS NULL OR scheduled_at <= now()) can be
--- evaluated from the index without heap fetches.
-DROP INDEX idx_jobs_queue;
+-- Recreate the claim index with scheduled_at as a trailing key. The claim
+-- query's due-filter (scheduled_at IS NULL OR scheduled_at <= now()) is an
+-- OR on a non-leading column, so it is applied as a heap filter rather than
+-- an index qual (and FOR UPDATE visits the heap regardless); the partial
+-- predicate and the (priority, created_at) ordering are still index-served.
+DROP INDEX IF EXISTS idx_jobs_queue;
 CREATE INDEX idx_jobs_queue ON jobs (priority DESC, created_at ASC, scheduled_at)
     WHERE status = 'pending';

--- a/packages/pipeline/src/job_queue.rs
+++ b/packages/pipeline/src/job_queue.rs
@@ -6,7 +6,9 @@ use uuid::Uuid;
 use crate::error::{PipelineError, Result};
 use crate::models::{Job, JobStatus, JobType, Priority};
 
-/// Base delay before the first retry of a failed job.
+/// Base delay before the first retry of a failed job. Effective retry latency
+/// is this backoff plus up to the worker's max poll interval (the poll loop
+/// only discovers due jobs on its next tick) — by design, not a bug.
 pub const RETRY_BACKOFF_BASE: Duration = Duration::from_secs(30);
 
 /// Maximum delay between retries of a failed job.
@@ -14,10 +16,13 @@ pub const RETRY_BACKOFF_CAP: Duration = Duration::from_secs(15 * 60);
 
 /// Exponential backoff for retry `attempts`: `30s * 2^(attempts-1)`, capped
 /// at 15 minutes. `attempts` is the number of attempts already spent (>= 1
-/// when a job fails); values below 1 are treated as 1.
+/// when a job fails); values below 1 are treated as 1. The exponent is
+/// clamped at 30 so the multiplication cannot overflow before the cap
+/// applies.
 ///
 /// `fail_job` applies the same formula in SQL (with [`RETRY_BACKOFF_BASE`] and
-/// [`RETRY_BACKOFF_CAP`] bound as parameters) — keep the two in sync.
+/// [`RETRY_BACKOFF_CAP`] bound as parameters, and the same exponent clamp) —
+/// keep the two in sync.
 pub fn retry_backoff(attempts: i32) -> Duration {
     let exponent = attempts.saturating_sub(1).clamp(0, 30) as u32;
     RETRY_BACKOFF_BASE
@@ -209,8 +214,12 @@ where
             END,
             scheduled_at = CASE
                 WHEN attempts < max_attempts THEN
+                    -- Clamp the exponent at 30 (like retry_backoff in Rust):
+                    -- the product is computed BEFORE the LEAST cap, so an
+                    -- unclamped exponent overflows the interval for large
+                    -- attempt counts and the whole UPDATE errors.
                     now() + LEAST(
-                        $3::interval * power(2, GREATEST(attempts - 1, 0)),
+                        $3::interval * power(2, LEAST(GREATEST(attempts - 1, 0), 30)),
                         $4::interval
                     )
                 ELSE NULL

--- a/packages/pipeline/src/job_queue.rs
+++ b/packages/pipeline/src/job_queue.rs
@@ -1,7 +1,35 @@
+use std::time::Duration;
+
+use sqlx::postgres::types::PgInterval;
 use uuid::Uuid;
 
 use crate::error::{PipelineError, Result};
 use crate::models::{Job, JobStatus, JobType, Priority};
+
+/// Base delay before the first retry of a failed job.
+pub const RETRY_BACKOFF_BASE: Duration = Duration::from_secs(30);
+
+/// Maximum delay between retries of a failed job.
+pub const RETRY_BACKOFF_CAP: Duration = Duration::from_secs(15 * 60);
+
+/// Exponential backoff for retry `attempts`: `30s * 2^(attempts-1)`, capped
+/// at 15 minutes. `attempts` is the number of attempts already spent (>= 1
+/// when a job fails); values below 1 are treated as 1.
+///
+/// `fail_job` applies the same formula in SQL (with [`RETRY_BACKOFF_BASE`] and
+/// [`RETRY_BACKOFF_CAP`] bound as parameters) — keep the two in sync.
+pub fn retry_backoff(attempts: i32) -> Duration {
+    let exponent = attempts.saturating_sub(1).clamp(0, 30) as u32;
+    RETRY_BACKOFF_BASE
+        .saturating_mul(2u32.saturating_pow(exponent))
+        .min(RETRY_BACKOFF_CAP)
+}
+
+/// Convert a `Duration` to a Postgres interval bind parameter.
+fn to_pg_interval(duration: Duration) -> Result<PgInterval> {
+    PgInterval::try_from(duration)
+        .map_err(|_| PipelineError::InvalidInput(format!("invalid interval: {duration:?}")))
+}
 
 /// Internal row type for the reaper CTE result.
 #[derive(sqlx::FromRow)]
@@ -22,6 +50,9 @@ pub struct CreateJobRequest {
     pub priority: Priority,
     pub payload: Option<serde_json::Value>,
     pub max_attempts: i32,
+    /// Delay before the job becomes claimable (sets `scheduled_at` to
+    /// `now() + delay`). `None` means claimable immediately.
+    pub initial_delay: Option<Duration>,
 }
 
 impl CreateJobRequest {
@@ -32,6 +63,7 @@ impl CreateJobRequest {
             priority: Priority::default(),
             payload: None,
             max_attempts: 3,
+            initial_delay: None,
         }
     }
 
@@ -49,6 +81,11 @@ impl CreateJobRequest {
         self.max_attempts = max_attempts.max(1);
         self
     }
+
+    pub fn with_initial_delay(mut self, delay: Duration) -> Self {
+        self.initial_delay = Some(delay);
+        self
+    }
 }
 
 /// Create a new job in the queue.
@@ -57,10 +94,11 @@ pub async fn create_job<'e, E>(executor: E, req: CreateJobRequest) -> Result<Job
 where
     E: sqlx::PgExecutor<'e>,
 {
+    let initial_delay = req.initial_delay.map(to_pg_interval).transpose()?;
     let job = sqlx::query_as::<_, Job>(
         r#"
-        INSERT INTO jobs (job_type, law_id, priority, payload, max_attempts)
-        VALUES ($1, $2, $3, $4, $5)
+        INSERT INTO jobs (job_type, law_id, priority, payload, max_attempts, scheduled_at)
+        VALUES ($1, $2, $3, $4, $5, now() + $6::interval)
         RETURNING *
         "#,
     )
@@ -69,6 +107,7 @@ where
     .bind(req.priority.value())
     .bind(&req.payload)
     .bind(req.max_attempts)
+    .bind(initial_delay)
     .fetch_one(executor)
     .await?;
 
@@ -77,6 +116,8 @@ where
 }
 
 /// Claim the highest-priority pending job using FOR UPDATE SKIP LOCKED.
+/// Jobs scheduled in the future (`scheduled_at > now()`, set by the retry
+/// backoff) are skipped until they become due.
 /// Returns None if no jobs are available.
 #[tracing::instrument(skip(executor))]
 pub async fn claim_job<'e, E>(executor: E, job_type: Option<JobType>) -> Result<Option<Job>>
@@ -92,7 +133,9 @@ where
         SET status = 'processing', started_at = now(), attempts = attempts + 1
         WHERE id = (
             SELECT id FROM jobs
-            WHERE status = 'pending' AND ($1::job_type IS NULL OR job_type = $1)
+            WHERE status = 'pending'
+              AND ($1::job_type IS NULL OR job_type = $1)
+              AND (scheduled_at IS NULL OR scheduled_at <= now())
             ORDER BY priority DESC, created_at ASC
             LIMIT 1
             FOR UPDATE SKIP LOCKED
@@ -138,7 +181,11 @@ where
     Ok(job)
 }
 
-/// Mark a job as failed. If attempts < max_attempts, reset to pending for retry.
+/// Mark a job as failed. If attempts < max_attempts, reset to pending for
+/// retry with an exponential backoff: `scheduled_at` is set to
+/// `now() + 30s * 2^(attempts-1)`, capped at 15 minutes (see
+/// [`retry_backoff`] — the SQL below implements the same formula), so a
+/// transient outage doesn't burn all attempts within one poll interval.
 #[tracing::instrument(skip(executor, error_result))]
 pub async fn fail_job<'e, E>(
     executor: E,
@@ -159,6 +206,14 @@ where
             completed_at = CASE
                 WHEN attempts >= max_attempts THEN now()
                 ELSE NULL
+            END,
+            scheduled_at = CASE
+                WHEN attempts < max_attempts THEN
+                    now() + LEAST(
+                        $3::interval * power(2, GREATEST(attempts - 1, 0)),
+                        $4::interval
+                    )
+                ELSE NULL
             END
         WHERE id = $1 AND status = 'processing'
         RETURNING *
@@ -166,13 +221,21 @@ where
     )
     .bind(job_id)
     .bind(&error_result)
+    .bind(to_pg_interval(RETRY_BACKOFF_BASE)?)
+    .bind(to_pg_interval(RETRY_BACKOFF_CAP)?)
     .fetch_optional(executor)
     .await?
     .ok_or(PipelineError::JobNotProcessing(job_id))?;
 
     match job.status {
         JobStatus::Pending => {
-            tracing::info!(job_id = %job.id, attempt = job.attempts, max = job.max_attempts, "job failed, will retry");
+            tracing::info!(
+                job_id = %job.id,
+                attempt = job.attempts,
+                max = job.max_attempts,
+                retry_at = ?job.scheduled_at,
+                "job failed, will retry after backoff"
+            );
         }
         JobStatus::Failed => {
             tracing::warn!(job_id = %job.id, attempts = job.attempts, "job permanently failed after exhausting retries");
@@ -250,10 +313,11 @@ pub async fn create_harvest_job_if_not_exists<'e, E>(
 where
     E: sqlx::PgExecutor<'e>,
 {
+    let initial_delay = req.initial_delay.map(to_pg_interval).transpose()?;
     let result = sqlx::query_as::<_, Job>(
         r#"
-        INSERT INTO jobs (job_type, law_id, priority, payload, max_attempts)
-        SELECT $1, $2, $3, $4, $5
+        INSERT INTO jobs (job_type, law_id, priority, payload, max_attempts, scheduled_at)
+        SELECT $1, $2, $3, $4, $5, now() + $7::interval
         WHERE NOT EXISTS (
             SELECT 1 FROM jobs
             WHERE job_type = 'harvest'
@@ -270,6 +334,7 @@ where
     .bind(&req.payload)
     .bind(req.max_attempts)
     .bind(date)
+    .bind(initial_delay)
     .fetch_optional(executor)
     .await;
 
@@ -337,10 +402,11 @@ pub async fn create_enrich_job_if_not_exists<'e, E>(
 where
     E: sqlx::PgExecutor<'e>,
 {
+    let initial_delay = req.initial_delay.map(to_pg_interval).transpose()?;
     let job = sqlx::query_as::<_, Job>(
         r#"
-        INSERT INTO jobs (job_type, law_id, priority, payload, max_attempts)
-        VALUES ($1, $2, $3, $4, $5)
+        INSERT INTO jobs (job_type, law_id, priority, payload, max_attempts, scheduled_at)
+        VALUES ($1, $2, $3, $4, $5, now() + $6::interval)
         ON CONFLICT (law_id, job_type, (payload->>'provider'))
             WHERE job_type = 'enrich' AND status IN ('pending', 'processing')
         DO NOTHING
@@ -352,6 +418,7 @@ where
     .bind(req.priority.value())
     .bind(&req.payload)
     .bind(req.max_attempts)
+    .bind(initial_delay)
     .fetch_optional(executor)
     .await?;
 
@@ -383,4 +450,30 @@ where
     };
 
     Ok(jobs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn retry_backoff_doubles_per_attempt() {
+        assert_eq!(retry_backoff(1), Duration::from_secs(30));
+        assert_eq!(retry_backoff(2), Duration::from_secs(60));
+        assert_eq!(retry_backoff(3), Duration::from_secs(120));
+        assert_eq!(retry_backoff(4), Duration::from_secs(240));
+    }
+
+    #[test]
+    fn retry_backoff_is_capped_at_fifteen_minutes() {
+        assert_eq!(retry_backoff(6), Duration::from_secs(15 * 60));
+        assert_eq!(retry_backoff(10), RETRY_BACKOFF_CAP);
+        assert_eq!(retry_backoff(i32::MAX), RETRY_BACKOFF_CAP);
+    }
+
+    #[test]
+    fn retry_backoff_treats_non_positive_attempts_as_first() {
+        assert_eq!(retry_backoff(0), RETRY_BACKOFF_BASE);
+        assert_eq!(retry_backoff(-5), RETRY_BACKOFF_BASE);
+    }
 }

--- a/packages/pipeline/src/models.rs
+++ b/packages/pipeline/src/models.rs
@@ -110,6 +110,9 @@ pub struct Job {
     pub updated_at: DateTime<Utc>,
     pub started_at: Option<DateTime<Utc>>,
     pub completed_at: Option<DateTime<Utc>>,
+    /// Earliest moment the job may be claimed. `None` means claimable
+    /// immediately; set by the retry-backoff logic in `fail_job`.
+    pub scheduled_at: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]

--- a/packages/pipeline/src/worker.rs
+++ b/packages/pipeline/src/worker.rs
@@ -201,7 +201,9 @@ pub async fn run_harvest_worker(config: WorkerConfig) -> Result<()> {
     }
 
     reaper_cancel.cancel();
-    let _ = reaper_handle.await;
+    if let Err(e) = reaper_handle.await {
+        tracing::error!(error = %e, "reaper task panicked");
+    }
 
     Ok(())
 }
@@ -778,7 +780,9 @@ pub async fn run_enrich_worker(config: WorkerConfig) -> Result<()> {
     }
 
     reaper_cancel.cancel();
-    let _ = reaper_handle.await;
+    if let Err(e) = reaper_handle.await {
+        tracing::error!(error = %e, "reaper task panicked");
+    }
 
     Ok(())
 }

--- a/packages/pipeline/src/worker.rs
+++ b/packages/pipeline/src/worker.rs
@@ -70,6 +70,36 @@ fn is_resource_exhaustion(err: &str) -> bool {
     MARKERS.iter().any(|m| e.contains(m))
 }
 
+/// Interval between orphaned-job reaper runs.
+const REAPER_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Spawn the orphaned-job reaper as an independent interval task.
+///
+/// Running the reaper inside the worker loop meant a wedged job stopped
+/// reaping too, freezing the whole queue until a pod restart. As its own
+/// task (with its own pool handle) it keeps resetting jobs stuck in
+/// 'processing' even when the main loop is blocked on a job. The reaper
+/// query is idempotent, so multiple workers running it concurrently is safe.
+///
+/// The task runs until the cancellation token fires (on worker shutdown).
+fn spawn_reaper(
+    pool: PgPool,
+    orphan_timeout: Duration,
+    cancel: tokio_util::sync::CancellationToken,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            if let Err(e) = job_queue::reap_orphaned_jobs(&pool, orphan_timeout).await {
+                tracing::warn!(error = %e, "failed to reap orphaned jobs");
+            }
+            tokio::select! {
+                _ = cancel.cancelled() => break,
+                _ = tokio::time::sleep(REAPER_INTERVAL) => {}
+            }
+        }
+    })
+}
+
 /// Run the harvest worker loop.
 ///
 /// Polls the job queue for harvest jobs and executes them.
@@ -105,12 +135,19 @@ pub async fn run_harvest_worker(config: WorkerConfig) -> Result<()> {
         output_dir = %output_dir.display(),
         output_base = %config.regulation_output_base,
         poll_interval = ?config.poll_interval,
+        job_timeout = ?config.job_timeout,
+        orphan_timeout = ?config.orphan_timeout,
         "starting harvest worker"
     );
 
     let mut sigterm = signal(SignalKind::terminate()).map_err(|e| {
         crate::error::PipelineError::Worker(format!("failed to register SIGTERM handler: {e}"))
     })?;
+
+    // Reap orphaned jobs on an independent task so a wedged job in the main
+    // loop can't also stop the reaper (which would freeze the whole queue).
+    let reaper_cancel = tokio_util::sync::CancellationToken::new();
+    let reaper_handle = spawn_reaper(pool.clone(), config.orphan_timeout, reaper_cancel.clone());
 
     let mut current_interval = std::time::Duration::ZERO; // poll immediately on startup
     let mut consecutive_resource_failures: u32 = 0;
@@ -131,11 +168,6 @@ pub async fn run_harvest_worker(config: WorkerConfig) -> Result<()> {
             _ = tokio::time::sleep(current_interval) => {
                 // Ready to process next job
             }
-        }
-
-        // Reap orphaned jobs stuck in 'processing' (cheap single-query check)
-        if let Err(e) = job_queue::reap_orphaned_jobs(&pool, config.orphan_timeout).await {
-            tracing::warn!(error = %e, "failed to reap orphaned jobs");
         }
 
         // Process job outside of select! — runs to completion without cancellation
@@ -167,6 +199,9 @@ pub async fn run_harvest_worker(config: WorkerConfig) -> Result<()> {
             }
         }
     }
+
+    reaper_cancel.cancel();
+    let _ = reaper_handle.await;
 
     Ok(())
 }
@@ -256,7 +291,33 @@ async fn process_next_job(
         tracing::warn!(error = %e, law_id = %job.law_id, "failed to set status to harvesting");
     }
 
-    match execute_harvest_job(output_dir, config, &payload, corpus, http_client).await {
+    // Bound the harvest with the job timeout (mirrors the enrich path): the
+    // BWB HTTP fetches and corpus git operations (fetch/pull/push) have no
+    // internal deadline, so a hung remote would otherwise stall this
+    // sequential worker loop forever. On timeout the error feeds the normal
+    // failure path below (retry with backoff / exhausted threshold).
+    let harvest_outcome = match tokio::time::timeout(
+        config.job_timeout,
+        execute_harvest_job(output_dir, config, &payload, corpus, http_client),
+    )
+    .await
+    {
+        Ok(outcome) => outcome,
+        Err(_elapsed) => {
+            tracing::error!(
+                job_id = %job.id,
+                law_id = %job.law_id,
+                timeout = ?config.job_timeout,
+                "harvest job timed out"
+            );
+            Err(PipelineError::Worker(format!(
+                "harvest job timed out after {}s",
+                config.job_timeout.as_secs()
+            )))
+        }
+    };
+
+    match harvest_outcome {
         Ok(result) => {
             tracing::info!(
                 job_id = %job.id,
@@ -540,11 +601,16 @@ async fn process_next_job(
                     }
                     Ok(count) => {
                         // Not yet exhausted — queue a new harvest job so the
-                        // fail_count can accumulate toward the threshold.
+                        // fail_count can accumulate toward the threshold. The
+                        // job starts with a backoff delay that grows with the
+                        // law's fail count, so a transient BWB outage doesn't
+                        // mass-exhaust laws within minutes.
+                        let retry_delay = job_queue::retry_backoff(count);
                         tracing::info!(
                             law_id = %job.law_id,
                             fail_count = count,
                             threshold = config.exhausted_threshold,
+                            delay = ?retry_delay,
                             "scheduling auto-retry harvest job"
                         );
                         match serde_json::to_value(&payload) {
@@ -552,7 +618,8 @@ async fn process_next_job(
                                 let date = payload.date.as_deref().unwrap_or("");
                                 let req = CreateJobRequest::new(JobType::Harvest, &job.law_id)
                                     .with_priority(Priority::new(job.priority))
-                                    .with_payload(payload_json);
+                                    .with_payload(payload_json)
+                                    .with_initial_delay(retry_delay);
                                 match job_queue::create_harvest_job_if_not_exists(pool, req, date)
                                     .await
                                 {
@@ -647,6 +714,11 @@ pub async fn run_enrich_worker(config: WorkerConfig) -> Result<()> {
         crate::error::PipelineError::Worker(format!("failed to register SIGTERM handler: {e}"))
     })?;
 
+    // Reap orphaned jobs on an independent task so a wedged job in the main
+    // loop can't also stop the reaper (which would freeze the whole queue).
+    let reaper_cancel = tokio_util::sync::CancellationToken::new();
+    let reaper_handle = spawn_reaper(pool.clone(), config.orphan_timeout, reaper_cancel.clone());
+
     let mut current_interval = std::time::Duration::ZERO;
     let mut consecutive_resource_failures: u32 = 0;
 
@@ -667,10 +739,6 @@ pub async fn run_enrich_worker(config: WorkerConfig) -> Result<()> {
             }
         }
 
-        if let Err(e) = job_queue::reap_orphaned_jobs(&pool, config.orphan_timeout).await {
-            tracing::warn!(error = %e, "failed to reap orphaned jobs");
-        }
-
         match process_next_enrich_job(
             &pool,
             &repo_path,
@@ -683,7 +751,6 @@ pub async fn run_enrich_worker(config: WorkerConfig) -> Result<()> {
         {
             Ok(JobOutcome::Processed) => {
                 consecutive_resource_failures = 0;
-                // Use poll_interval (not zero) to avoid tight-looping reap_orphaned_jobs.
                 current_interval = config.poll_interval;
             }
             Ok(JobOutcome::Idle) => {
@@ -709,6 +776,9 @@ pub async fn run_enrich_worker(config: WorkerConfig) -> Result<()> {
             }
         }
     }
+
+    reaper_cancel.cancel();
+    let _ = reaper_handle.await;
 
     Ok(())
 }
@@ -1219,18 +1289,22 @@ async fn handle_enrich_exhausted_or_retry(
         }
         Ok(count) => {
             // Not yet exhausted — queue a new enrich job so the
-            // fail_count can accumulate toward the threshold.
+            // fail_count can accumulate toward the threshold. The job starts
+            // with a backoff delay that grows with the law's fail count.
+            let retry_delay = job_queue::retry_backoff(count);
             tracing::info!(
                 law_id = %law_id,
                 fail_count = count,
                 threshold = exhausted_threshold,
+                delay = ?retry_delay,
                 "scheduling auto-retry enrich job"
             );
             match serde_json::to_value(payload) {
                 Ok(payload_json) => {
                     let req = CreateJobRequest::new(JobType::Enrich, law_id)
                         .with_priority(Priority::new(priority))
-                        .with_payload(payload_json);
+                        .with_payload(payload_json)
+                        .with_initial_delay(retry_delay);
                     match job_queue::create_enrich_job_if_not_exists(pool, req).await {
                         Ok(Some(new_job)) => {
                             tracing::info!(

--- a/packages/pipeline/tests/job_queue_tests.rs
+++ b/packages/pipeline/tests/job_queue_tests.rs
@@ -136,6 +136,16 @@ async fn test_complete_job_not_processing() {
     assert!(matches!(result, Err(PipelineError::JobNotProcessing(_))));
 }
 
+/// Backdate a job's scheduled_at so it becomes claimable immediately
+/// (simulates the retry backoff having elapsed).
+async fn make_due(pool: &sqlx::PgPool, job_id: uuid::Uuid) {
+    sqlx::query("UPDATE jobs SET scheduled_at = now() - interval '1 second' WHERE id = $1")
+        .bind(job_id)
+        .execute(pool)
+        .await
+        .unwrap();
+}
+
 #[tokio::test]
 async fn test_fail_job_with_retry() {
     let db = TestDb::new().await;
@@ -150,12 +160,18 @@ async fn test_fail_job_with_retry() {
         .unwrap();
     assert_eq!(failed.status, JobStatus::Pending);
 
+    // The retry backoff makes the job not immediately claimable.
+    let none = job_queue::claim_job(&db.pool, None).await.unwrap();
+    assert!(none.is_none(), "job must not be claimable during backoff");
+    make_due(&db.pool, job.id).await;
+
     let claimed = job_queue::claim_job(&db.pool, None).await.unwrap().unwrap();
     assert_eq!(claimed.attempts, 2);
     let failed = job_queue::fail_job(&db.pool, job.id, Some(json!({"error": "timeout again"})))
         .await
         .unwrap();
     assert_eq!(failed.status, JobStatus::Pending);
+    make_due(&db.pool, job.id).await;
 
     let claimed = job_queue::claim_job(&db.pool, None).await.unwrap().unwrap();
     assert_eq!(claimed.attempts, 3);
@@ -164,9 +180,80 @@ async fn test_fail_job_with_retry() {
         .unwrap();
     assert_eq!(failed.status, JobStatus::Failed);
     assert!(failed.completed_at.is_some());
+    assert!(
+        failed.scheduled_at.is_none(),
+        "permanently failed job must not carry a retry schedule"
+    );
 
     let none = job_queue::claim_job(&db.pool, None).await.unwrap();
     assert!(none.is_none());
+}
+
+#[tokio::test]
+async fn test_fail_job_sets_exponential_backoff_schedule() {
+    let db = TestDb::new().await;
+
+    let req = CreateJobRequest::new(JobType::Harvest, "BWBR0001840").with_max_attempts(5);
+    let job = job_queue::create_job(&db.pool, req).await.unwrap();
+    assert!(
+        job.scheduled_at.is_none(),
+        "new job is claimable immediately"
+    );
+
+    // First failure: backoff = 30s * 2^0 = 30s.
+    job_queue::claim_job(&db.pool, None).await.unwrap().unwrap();
+    let failed = job_queue::fail_job(&db.pool, job.id, None).await.unwrap();
+    let now = chrono::Utc::now();
+    let scheduled = failed.scheduled_at.expect("retrying job has scheduled_at");
+    let delay = (scheduled - now).num_seconds();
+    assert!(
+        (20..=40).contains(&delay),
+        "first retry should be ~30s out, got {delay}s"
+    );
+
+    // Second failure: backoff = 30s * 2^1 = 60s.
+    make_due(&db.pool, job.id).await;
+    job_queue::claim_job(&db.pool, None).await.unwrap().unwrap();
+    let failed = job_queue::fail_job(&db.pool, job.id, None).await.unwrap();
+    let now = chrono::Utc::now();
+    let delay = (failed.scheduled_at.unwrap() - now).num_seconds();
+    assert!(
+        (50..=70).contains(&delay),
+        "second retry should be ~60s out, got {delay}s"
+    );
+
+    // SQL formula must match the Rust reference implementation.
+    assert_eq!(job_queue::retry_backoff(1).as_secs(), 30);
+    assert_eq!(job_queue::retry_backoff(2).as_secs(), 60);
+}
+
+#[tokio::test]
+async fn test_claim_job_skips_future_scheduled_and_claims_due() {
+    let db = TestDb::new().await;
+
+    let future = CreateJobRequest::new(JobType::Harvest, "future")
+        .with_priority(Priority::new(90))
+        .with_initial_delay(Duration::from_secs(3600));
+    let due = CreateJobRequest::new(JobType::Harvest, "due").with_priority(Priority::new(10));
+    let future_job = job_queue::create_job(&db.pool, future).await.unwrap();
+    job_queue::create_job(&db.pool, due).await.unwrap();
+
+    assert!(
+        future_job.scheduled_at.is_some(),
+        "initial delay must set scheduled_at"
+    );
+
+    // Despite its higher priority, the future-scheduled job is skipped.
+    let claimed = job_queue::claim_job(&db.pool, None).await.unwrap().unwrap();
+    assert_eq!(claimed.law_id, "due");
+
+    let none = job_queue::claim_job(&db.pool, None).await.unwrap();
+    assert!(none.is_none(), "future job must not be claimable yet");
+
+    // Once due, the job becomes claimable.
+    make_due(&db.pool, future_job.id).await;
+    let claimed = job_queue::claim_job(&db.pool, None).await.unwrap().unwrap();
+    assert_eq!(claimed.law_id, "future");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Problem

A verified audit of `packages/pipeline/` found three failure modes that together can freeze the queue or mass-exhaust laws:

1. **No per-job timeout for harvest jobs.** `worker.rs` awaited `execute_harvest_job` without `tokio::time::timeout`, unlike the enrich path. The BWB HTTP fetches and corpus git operations (`ensure_repo`, `commit_and_push_content`) have no internal deadline, so a single hung git fetch/push stalled the sequential worker loop forever.
2. **Reaper ran inside the worker loop.** `reap_orphaned_jobs` was only called from the worker loops, so a wedged worker also stopped reaping — the whole queue froze until a pod restart.
3. **No backoff anywhere in the retry chain.** `fail_job` reset failed jobs to `pending` immediately (re-claimed within the 5s poll interval, 3 attempts burned in ~15s), and the law-level auto-retry spawned a fresh job immediately. A transient BWB outage could drive laws to `harvest_exhausted` (threshold 10) in minutes.

## Fixes

- **Harvest timeout**: `execute_harvest_job` is now wrapped in `tokio::time::timeout(config.job_timeout, ...)`, analogous to the enrich path. On timeout the job fails with a clear `harvest job timed out after Xs` error and goes through the normal retry/backoff/exhausted path. The existing `WORKER_JOB_TIMEOUT_SECS` (default 20 min) applies; since harvest and enrich workers are separate deployments, they can already be tuned independently via env — no new config knob needed.
- **Independent reaper**: `reap_orphaned_jobs` now runs in its own `tokio::spawn`-ed task (own pool clone, 60s interval) for both the harvest and enrich workers, and was removed from the loops. The reaper query is idempotent, so concurrent reapers are safe. The task is cancelled via a `CancellationToken` and awaited on worker shutdown, consistent with the existing SIGTERM/SIGINT handling.
- **Exponential retry backoff**: new nullable `jobs.scheduled_at` column (`NULL` = claimable now).
  - `claim_job` only claims jobs `WHERE scheduled_at IS NULL OR scheduled_at <= now()` (still `FOR UPDATE SKIP LOCKED`).
  - `fail_job`, when re-queueing (attempts < max), sets `scheduled_at = now() + 30s * 2^(attempts-1)`, capped at 15 minutes. Constants live in `job_queue.rs` (`RETRY_BACKOFF_BASE`/`RETRY_BACKOFF_CAP`) with a Rust reference implementation `retry_backoff()`; the SQL applies the same formula with the constants bound as parameters.
  - The law-level auto-retry jobs (harvest and enrich) are created with `with_initial_delay(retry_backoff(fail_count))`, so the delay grows with the law's fail count.

## Migration

New migration `0019_add_job_scheduled_at.sql` (no existing migrations touched): adds `scheduled_at TIMESTAMPTZ` and recreates the partial claim index `idx_jobs_queue` with `scheduled_at` as a trailing key so the due-filter is evaluated from the index.

`packages/admin` re-declares its own `Job` struct with explicit column lists, so the added column is transparent there (verified: admin compiles and its testcontainer suite passes). `packages/tui` does not read the jobs table.

## Test plan

- [x] `just pipeline-test` — 40 passed (includes new `retry_backoff` unit tests: doubling, cap, non-positive attempts)
- [x] `TESTCONTAINERS_HOST_OVERRIDE=host.docker.internal just pipeline-integration-test` — all passed, including new tests:
  - `test_fail_job_sets_exponential_backoff_schedule` (~30s after 1st failure, ~60s after 2nd; SQL matches the Rust formula)
  - `test_claim_job_skips_future_scheduled_and_claims_due` (future-scheduled job skipped despite higher priority, claimable once due; `with_initial_delay` sets `scheduled_at`)
  - `test_fail_job_with_retry` extended: not claimable during backoff; permanently failed job carries no retry schedule
- [x] `TESTCONTAINERS_HOST_OVERRIDE=host.docker.internal just admin-test` — all passed
- [x] `just format`, `just lint`, `just build-check` — clean

## Caveats

- On harvest timeout the future is dropped; a git subprocess spawned by the corpus client may linger until it finishes or the pod restarts — same trade-off as the enrich path's outer timeout. The worker loop itself is unblocked, which is the goal.
- Jobs reset by the reaper become claimable immediately (no extra backoff) — the reaper already waited `orphan_timeout` (30 min default).