### PR TITLE
fix(editor): optimistic concurrency (ETag/If-Match) for law and scenario saves

### DIFF
--- a/frontend/src/composables/useLaw.js
+++ b/frontend/src/composables/useLaw.js
@@ -143,14 +143,16 @@ export function useLaw(lawParam, articleParam, trajectRefParam) {
       currentEtag.value = res.headers.get('ETag');
       const resolvedId = law.value?.$id || lawParam;
       const key = lawCacheKey(currentTrajectRef, resolvedId);
-      if (!lawCache.has(key)) {
-        lawCache.set(key, {
-          law: law.value,
-          rawYaml: text,
-          lawName: resolveLawName(law.value),
-          etag: currentEtag.value,
-        });
-      }
+      // Always overwrite: `load()` just fetched fresh content, so any
+      // pre-existing entry is by definition stale (older body and/or
+      // ETag) — keeping it would hand `fetchLaw`/`switchLaw` callers
+      // outdated YAML and a precondition doomed to 412.
+      lawCache.set(key, {
+        law: law.value,
+        rawYaml: text,
+        lawName: resolveLawName(law.value),
+        etag: currentEtag.value,
+      });
       touchLawCache(key);
       if (articles.value.length > 0 && !selectedArticleNumber.value) {
         if (initialArticle && articles.value.some(a => String(a.number) === initialArticle)) {

--- a/frontend/src/composables/useLaw.js
+++ b/frontend/src/composables/useLaw.js
@@ -75,7 +75,15 @@ export async function fetchLaw(trajectRef, lawId) {
   if (!res.ok) throw lawFetchError(res.status);
   const text = await res.text();
   const law = yaml.load(text);
-  const entry = { law, rawYaml: text, lawName: resolveLawName(law) };
+  const entry = {
+    law,
+    rawYaml: text,
+    lawName: resolveLawName(law),
+    // Echoed back as `If-Match` on the next save so a concurrent edit
+    // by another traject member surfaces as a 412 instead of a silent
+    // overwrite (same chain as useTrajectDocuments).
+    etag: res.headers.get('ETag'),
+  };
   lawCache.set(key, entry);
   touchLawCache(key);
   return entry;
@@ -102,6 +110,9 @@ export function useLaw(lawParam, articleParam, trajectRefParam) {
   const error = ref(null);
   const saving = ref(false);
   const saveError = ref(null);
+  // ETag of the last loaded/saved law content; sent as `If-Match` on
+  // save so the backend can 412 when someone else edited in between.
+  const currentEtag = ref(null);
 
   const articles = computed(() => law.value?.articles ?? []);
 
@@ -129,10 +140,16 @@ export function useLaw(lawParam, articleParam, trajectRefParam) {
       if (version !== switchVersion) return;
       rawYaml.value = text;
       law.value = yaml.load(text);
+      currentEtag.value = res.headers.get('ETag');
       const resolvedId = law.value?.$id || lawParam;
       const key = lawCacheKey(currentTrajectRef, resolvedId);
       if (!lawCache.has(key)) {
-        lawCache.set(key, { law: law.value, rawYaml: text, lawName: resolveLawName(law.value) });
+        lawCache.set(key, {
+          law: law.value,
+          rawYaml: text,
+          lawName: resolveLawName(law.value),
+          etag: currentEtag.value,
+        });
       }
       touchLawCache(key);
       if (articles.value.length > 0 && !selectedArticleNumber.value) {
@@ -177,6 +194,7 @@ export function useLaw(lawParam, articleParam, trajectRefParam) {
       if (version !== switchVersion) return;
       law.value = entry.law;
       rawYaml.value = entry.rawYaml;
+      currentEtag.value = entry.etag ?? null;
       if (articleNumber) {
         selectedArticleNumber.value = String(articleNumber);
       } else if (articles.value.length > 0) {
@@ -221,16 +239,29 @@ export function useLaw(lawParam, articleParam, trajectRefParam) {
     saving.value = true;
     saveError.value = null;
     try {
+      const headers = {
+        'Content-Type': 'text/yaml; charset=utf-8',
+        // Required by editor-api on every write — scopes this save to
+        // a per-(session, source) feature branch + PR upstream.
+        'X-Editor-Session': getEditorSessionId(),
+      };
+      // Optimistic concurrency: echo the ETag of the version we loaded
+      // so a concurrent edit by another traject member 412s instead of
+      // being silently overwritten. Absent (older deployments, direct
+      // URLs without ETag) the save stays a permissive blind write.
+      if (currentEtag.value) headers['If-Match'] = currentEtag.value;
       const res = await fetch(lawUrl(savedTrajectRef, savedLawId), {
         method: 'PUT',
-        headers: {
-          'Content-Type': 'text/yaml; charset=utf-8',
-          // Required by editor-api on every write — scopes this save to
-          // a per-(session, source) feature branch + PR upstream.
-          'X-Editor-Session': getEditorSessionId(),
-        },
+        headers,
         body: yamlText,
       });
+      if (res.status === 412) {
+        throw new Error(
+          'De wet is intussen door iemand anders gewijzigd. ' +
+          'Herlaad de pagina om de nieuwste versie te zien en voer je ' +
+          'wijziging daarna opnieuw door.',
+        );
+      }
       if (!res.ok) {
         // Only surface the body when it's our editor-api speaking. The
         // editor-api returns plain `text/plain; charset=utf-8` for its
@@ -249,19 +280,25 @@ export function useLaw(lawParam, articleParam, trajectRefParam) {
         }
         throw new Error(text);
       }
-      // Backend returns `{ pr: { url, number, branch } | null }` on 200.
+      // Backend returns `{ pr: { url, number, branch } | null, etag }` on 200.
+      let json = null;
       try {
-        const json = await res.json();
+        json = await res.json();
         lastSavedPr.value = sanitizeSavedPr(json?.pr);
       } catch {
         // Older deployments return a bare 200 without JSON — keep the
         // existing PR (if any) and treat the save as successful.
       }
+      // Chain the new ETag for the next save. The header is
+      // authoritative; the body echo is the fallback (mirrors
+      // useTrajectDocuments).
+      const newEtag = res.headers.get('ETag') ?? json?.etag ?? null;
       const parsed = yaml.load(yamlText);
       // Bail on the success path if the user navigated away mid-flight.
       if (lawId.value === savedLawId && currentTrajectRef === savedTrajectRef) {
         rawYaml.value = yamlText;
         law.value = parsed;
+        currentEtag.value = newEtag;
       }
       const resolvedId = parsed?.$id || savedLawId;
       const savedKey = lawCacheKey(savedTrajectRef, resolvedId);
@@ -269,6 +306,7 @@ export function useLaw(lawParam, articleParam, trajectRefParam) {
         law: parsed,
         rawYaml: yamlText,
         lawName: resolveLawName(parsed),
+        etag: newEtag,
       });
       touchLawCache(savedKey);
     } catch (e) {
@@ -297,6 +335,7 @@ export function useLaw(lawParam, articleParam, trajectRefParam) {
     saving,
     saveError,
     saveLaw,
+    currentEtag,
     lastSavedPr,
   };
 }

--- a/frontend/src/composables/useLaw.test.js
+++ b/frontend/src/composables/useLaw.test.js
@@ -76,7 +76,7 @@ describe('useLaw optimistic concurrency', () => {
   });
 
   it('surfaces a 412 as a Dutch conflict error instead of overwriting silently', async () => {
-    globalThis.fetch = vi.fn().mockImplementation(async (url, opts) => {
+    globalThis.fetch = vi.fn().mockImplementation(async (_url, opts) => {
       if (opts?.method === 'PUT') return res({ ok: false, status: 412 });
       return res({ body: '$id: wet_conflict\nname: V1\n', etag: '"v1"' });
     });

--- a/frontend/src/composables/useLaw.test.js
+++ b/frontend/src/composables/useLaw.test.js
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useLaw } from './useLaw.js';
+
+// Helper: shape a Response-like object with headers + body + status.
+// Mirrors the harness in useTrajectDocuments.test.js.
+function res({ ok = true, status = 200, body = '', etag = null, json = null }) {
+  const headers = new Map();
+  if (etag) headers.set('etag', etag);
+  if (json) headers.set('content-type', 'application/json');
+  else if (typeof body === 'string') headers.set('content-type', 'text/plain');
+  return {
+    ok,
+    status,
+    headers: {
+      get: (k) => headers.get(k.toLowerCase()) ?? null,
+    },
+    async text() {
+      return typeof body === 'string' ? body : JSON.stringify(body);
+    },
+    async json() {
+      return json ?? body;
+    },
+  };
+}
+
+async function waitForLoaded(law) {
+  await vi.waitFor(() => {
+    expect(law.loading.value).toBe(false);
+  });
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('useLaw optimistic concurrency', () => {
+  it('captures the ETag on load and sends it back as If-Match on save', async () => {
+    const calls = [];
+    globalThis.fetch = vi.fn().mockImplementation(async (url, opts) => {
+      calls.push({ url, opts: opts ?? {} });
+      if (opts?.method === 'PUT') {
+        return res({ etag: '"new"', json: { pr: null, etag: '"new"' } });
+      }
+      return res({ body: '$id: wet_etag_chain\nname: V1\n', etag: '"v1"' });
+    });
+
+    const law = useLaw('wet_etag_chain', null, 'tr-12345678');
+    await waitForLoaded(law);
+    expect(law.currentEtag.value).toBe('"v1"');
+
+    await law.saveLaw('$id: wet_etag_chain\nname: V2\n');
+
+    const put = calls.find((c) => c.opts?.method === 'PUT');
+    expect(put).toBeTruthy();
+    expect(put.url).toBe('/api/trajects/tr-12345678/corpus/laws/wet_etag_chain');
+    expect(put.opts.headers['If-Match']).toBe('"v1"');
+    // The new ETag from the save response is chained for the next save.
+    expect(law.currentEtag.value).toBe('"new"');
+  });
+
+  it('omits If-Match when the load carried no ETag (older deployments)', async () => {
+    const calls = [];
+    globalThis.fetch = vi.fn().mockImplementation(async (url, opts) => {
+      calls.push({ url, opts: opts ?? {} });
+      if (opts?.method === 'PUT') return res({ json: { pr: null } });
+      return res({ body: '$id: wet_no_etag\nname: V1\n' });
+    });
+
+    const law = useLaw('wet_no_etag', null, 'tr-12345678');
+    await waitForLoaded(law);
+    expect(law.currentEtag.value).toBeNull();
+
+    await law.saveLaw('$id: wet_no_etag\nname: V2\n');
+    const put = calls.find((c) => c.opts?.method === 'PUT');
+    expect(put.opts.headers['If-Match']).toBeUndefined();
+  });
+
+  it('surfaces a 412 as a Dutch conflict error instead of overwriting silently', async () => {
+    globalThis.fetch = vi.fn().mockImplementation(async (url, opts) => {
+      if (opts?.method === 'PUT') return res({ ok: false, status: 412 });
+      return res({ body: '$id: wet_conflict\nname: V1\n', etag: '"v1"' });
+    });
+
+    const law = useLaw('wet_conflict', null, 'tr-12345678');
+    await waitForLoaded(law);
+
+    await expect(law.saveLaw('$id: wet_conflict\nname: V2\n')).rejects.toThrow(
+      /door iemand anders gewijzigd/i,
+    );
+    expect(law.saveError.value?.message).toMatch(/herlaad/i);
+    // The stale ETag is kept — the user reloads to pick up a fresh one.
+    expect(law.currentEtag.value).toBe('"v1"');
+  });
+});

--- a/frontend/src/composables/useScenarios.js
+++ b/frontend/src/composables/useScenarios.js
@@ -23,6 +23,11 @@ export function useScenarios(lawId, trajectRef = ref(null)) {
   const saving = ref(false);
   const error = ref(null);
   const saveError = ref(null);
+  // ETag per scenario filename, captured on read and echoed back as
+  // `If-Match` on save so a concurrent edit by another traject member
+  // surfaces as a 412 instead of a silent overwrite. A filename without
+  // an entry (e.g. a brand-new scenario) saves without a precondition.
+  const scenarioEtags = new Map();
   // `lastSavedPr` is imported as a module-shared ref from useEditorSession
   // so scenario saves and law-content saves both update the same value,
   // and EditorApp's "Bekijk op GitHub" badge stays in sync regardless of
@@ -65,6 +70,9 @@ export function useScenarios(lawId, trajectRef = ref(null)) {
       const res = await fetch(scenarioFileUrl(trajectRef.value, lawId.value, filename));
       if (!res.ok) throw new Error(`Failed to fetch scenario: ${res.status}`);
       featureText.value = await res.text();
+      const etag = res.headers.get('ETag');
+      if (etag) scenarioEtags.set(filename, etag);
+      else scenarioEtags.delete(filename);
     } catch (e) {
       error.value = e;
       featureText.value = '';
@@ -86,29 +94,47 @@ export function useScenarios(lawId, trajectRef = ref(null)) {
     saveError.value = null;
 
     try {
+      const headers = {
+        'Content-Type': 'text/plain; charset=utf-8',
+        'X-Editor-Session': getEditorSessionId(),
+      };
+      // Echo the ETag we read so the backend can detect a concurrent
+      // edit (412). New scenarios have no entry → permissive create.
+      const ifMatch = scenarioEtags.get(filename);
+      if (ifMatch) headers['If-Match'] = ifMatch;
       const res = await fetch(
         scenarioFileUrl(trajectRef.value, lawId.value, filename),
         {
           method: 'PUT',
-          headers: {
-            'Content-Type': 'text/plain; charset=utf-8',
-            'X-Editor-Session': getEditorSessionId(),
-          },
+          headers,
           body: content,
         },
       );
+      if (res.status === 412) {
+        throw new Error(
+          'Het scenario is intussen door iemand anders gewijzigd. ' +
+          'Herlaad het scenario om de nieuwste versie te zien en voer ' +
+          'je wijziging daarna opnieuw door.',
+        );
+      }
       if (!res.ok) {
         const text = await res.text();
         throw new Error(text || `Save failed: ${res.status}`);
       }
-      // Same `{ pr }` shape as the law-content save; capture for the
-      // shared "Bekijk op GitHub" badge in EditorApp.vue.
+      // Same `{ pr, etag }` shape as the law-content save; capture the
+      // PR for the shared "Bekijk op GitHub" badge in EditorApp.vue.
+      let json = null;
       try {
-        const json = await res.json();
+        json = await res.json();
         lastSavedPr.value = sanitizeSavedPr(json?.pr);
       } catch {
         // Older deployments returned a bare 200 — keep the prior PR.
       }
+      // Chain the new ETag for the next save of this scenario. Header
+      // is authoritative; body echo is the fallback.
+      const newEtag = res.headers.get('ETag') ?? json?.etag ?? null;
+      if (newEtag) scenarioEtags.set(filename, newEtag);
+      else scenarioEtags.delete(filename);
       // Update local state with saved content
       featureText.value = content;
     } catch (e) {
@@ -125,6 +151,9 @@ export function useScenarios(lawId, trajectRef = ref(null)) {
   watch([lawId, trajectRef], () => {
     selectedScenario.value = null;
     featureText.value = '';
+    // ETags belong to the previous law/traject's files — a save in the
+    // new scope must not carry a stale precondition.
+    scenarioEtags.clear();
     fetchScenarios().catch(() => {});
   }, { immediate: true });
 

--- a/frontend/src/composables/useScenarios.js
+++ b/frontend/src/composables/useScenarios.js
@@ -90,6 +90,16 @@ export function useScenarios(lawId, trajectRef = ref(null)) {
     if (!lawId.value) return;
     requireTraject(trajectRef.value, 'scenario save');
 
+    // Snapshot the scope before the await (mirrors useLaw.saveLaw): if
+    // the user switches law/traject while the PUT is in flight, the
+    // watch below clears `scenarioEtags` for the new scope — the stale
+    // completion must not re-insert its ETag (keys are bare filenames
+    // like `basis.feature`, which recur across laws, so the entry would
+    // poison the new law's same-named scenario with a foreign
+    // precondition) nor overwrite the new scope's featureText.
+    const savedLawId = lawId.value;
+    const savedTrajectRef = trajectRef.value;
+
     saving.value = true;
     saveError.value = null;
 
@@ -130,6 +140,9 @@ export function useScenarios(lawId, trajectRef = ref(null)) {
       } catch {
         // Older deployments returned a bare 200 — keep the prior PR.
       }
+      // Bail on the success path if the user switched law/traject
+      // mid-flight — the new scope's state must not absorb this save.
+      if (lawId.value !== savedLawId || trajectRef.value !== savedTrajectRef) return;
       // Chain the new ETag for the next save of this scenario. Header
       // is authoritative; body echo is the fallback.
       const newEtag = res.headers.get('ETag') ?? json?.etag ?? null;
@@ -138,7 +151,9 @@ export function useScenarios(lawId, trajectRef = ref(null)) {
       // Update local state with saved content
       featureText.value = content;
     } catch (e) {
-      saveError.value = e;
+      if (lawId.value === savedLawId && trajectRef.value === savedTrajectRef) {
+        saveError.value = e;
+      }
       throw e;
     } finally {
       saving.value = false;

--- a/frontend/src/composables/useScenarios.test.js
+++ b/frontend/src/composables/useScenarios.test.js
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ref } from 'vue';
+import { useScenarios } from './useScenarios.js';
+
+// Helper: shape a Response-like object with headers + body + status.
+// Mirrors the harness in useTrajectDocuments.test.js.
+function res({ ok = true, status = 200, body = '', etag = null, json = null }) {
+  const headers = new Map();
+  if (etag) headers.set('etag', etag);
+  if (json) headers.set('content-type', 'application/json');
+  else if (typeof body === 'string') headers.set('content-type', 'text/plain');
+  return {
+    ok,
+    status,
+    headers: {
+      get: (k) => headers.get(k.toLowerCase()) ?? null,
+    },
+    async text() {
+      return typeof body === 'string' ? body : JSON.stringify(body);
+    },
+    async json() {
+      return json ?? body;
+    },
+  };
+}
+
+async function waitForScenario(sc, filename) {
+  await vi.waitFor(() => {
+    expect(sc.selectedScenario.value).toBe(filename);
+    expect(sc.featureText.value).not.toBe('');
+  });
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('useScenarios optimistic concurrency', () => {
+  function mockFetch(onPut) {
+    const calls = [];
+    globalThis.fetch = vi.fn().mockImplementation(async (url, opts) => {
+      calls.push({ url, opts: opts ?? {} });
+      if (opts?.method === 'PUT') return onPut(url, opts);
+      if (url.endsWith('/scenarios')) {
+        return res({ json: [{ filename: 'basis.feature' }] });
+      }
+      return res({ body: 'Feature: v1\n', etag: '"v1"' });
+    });
+    return calls;
+  }
+
+  it('captures the ETag on read and sends it back as If-Match on save', async () => {
+    const calls = mockFetch(() =>
+      res({ etag: '"new"', json: { pr: null, etag: '"new"' } }),
+    );
+
+    const sc = useScenarios(ref('wet_a'), ref('tr-12345678'));
+    await waitForScenario(sc, 'basis.feature');
+
+    await sc.saveScenario('basis.feature', 'Feature: v2\n');
+
+    const put = calls.find((c) => c.opts?.method === 'PUT');
+    expect(put).toBeTruthy();
+    expect(put.url).toBe(
+      '/api/trajects/tr-12345678/corpus/laws/wet_a/scenarios/basis.feature',
+    );
+    expect(put.opts.headers['If-Match']).toBe('"v1"');
+
+    // The new ETag is chained: a follow-up save sends the updated value.
+    await sc.saveScenario('basis.feature', 'Feature: v3\n');
+    const puts = calls.filter((c) => c.opts?.method === 'PUT');
+    expect(puts[1].opts.headers['If-Match']).toBe('"new"');
+  });
+
+  it('saves a brand-new scenario without an If-Match precondition', async () => {
+    const calls = mockFetch(() =>
+      res({ etag: '"created"', json: { pr: null, etag: '"created"' } }),
+    );
+
+    const sc = useScenarios(ref('wet_a'), ref('tr-12345678'));
+    await waitForScenario(sc, 'basis.feature');
+
+    await sc.saveScenario('nieuw.feature', 'Feature: nieuw\n');
+    const put = calls.find(
+      (c) => c.opts?.method === 'PUT' && c.url.endsWith('nieuw.feature'),
+    );
+    expect(put.opts.headers['If-Match']).toBeUndefined();
+  });
+
+  it('surfaces a 412 as a Dutch conflict error instead of overwriting silently', async () => {
+    mockFetch(() => res({ ok: false, status: 412 }));
+
+    const sc = useScenarios(ref('wet_a'), ref('tr-12345678'));
+    await waitForScenario(sc, 'basis.feature');
+
+    await expect(
+      sc.saveScenario('basis.feature', 'Feature: v2\n'),
+    ).rejects.toThrow(/door iemand anders gewijzigd/i);
+    expect(sc.saveError.value?.message).toMatch(/herlaad/i);
+  });
+});

--- a/frontend/src/composables/useScenarios.test.js
+++ b/frontend/src/composables/useScenarios.test.js
@@ -98,4 +98,56 @@ describe('useScenarios optimistic concurrency', () => {
     ).rejects.toThrow(/door iemand anders gewijzigd/i);
     expect(sc.saveError.value?.message).toMatch(/herlaad/i);
   });
+
+  it('does not chain the etag or content across a law switch mid-save', async () => {
+    // Scenario filenames recur across laws (`basis.feature` exists for
+    // both wet_a and wet_b). An in-flight save of wet_a's copy must not
+    // re-insert its ETag into the map after the watch cleared it for
+    // wet_b, or wet_b's next save carries a foreign If-Match → 412.
+    let resolvePut;
+    const putGate = new Promise((resolve) => { resolvePut = resolve; });
+    const calls = [];
+    globalThis.fetch = vi.fn().mockImplementation(async (url, opts) => {
+      calls.push({ url, opts: opts ?? {} });
+      if (opts?.method === 'PUT') {
+        await putGate;
+        return res({ etag: '"a2"', json: { pr: null, etag: '"a2"' } });
+      }
+      if (url.endsWith('/scenarios')) {
+        return res({ json: [{ filename: 'basis.feature' }] });
+      }
+      if (url.includes('/laws/wet_b/')) {
+        return res({ body: 'Feature: b1\n', etag: '"b1"' });
+      }
+      return res({ body: 'Feature: a1\n', etag: '"a1"' });
+    });
+
+    const lawId = ref('wet_a');
+    const sc = useScenarios(lawId, ref('tr-12345678'));
+    await waitForScenario(sc, 'basis.feature');
+    expect(sc.featureText.value).toBe('Feature: a1\n');
+
+    // Kick off the save, then switch laws while the PUT is in flight.
+    const save = sc.saveScenario('basis.feature', 'Feature: a2\n');
+    lawId.value = 'wet_b';
+    await vi.waitFor(() => {
+      expect(sc.featureText.value).toBe('Feature: b1\n');
+    });
+
+    resolvePut();
+    await save;
+
+    // The stale completion must not overwrite the new law's content…
+    expect(sc.featureText.value).toBe('Feature: b1\n');
+
+    // …nor poison the new law's etag map: saving wet_b's same-named
+    // scenario sends the ETag wet_b's read returned, not the old
+    // save's chained one.
+    await sc.saveScenario('basis.feature', 'Feature: b2\n');
+    const puts = calls.filter((c) => c.opts?.method === 'PUT');
+    expect(puts[1].url).toBe(
+      '/api/trajects/tr-12345678/corpus/laws/wet_b/scenarios/basis.feature',
+    );
+    expect(puts[1].opts.headers['If-Match']).toBe('"b1"');
+  });
 });

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -2670,8 +2670,11 @@ mod tests {
 
     #[test]
     fn law_save_absent_if_match_is_permissive() {
-        // Backward compatibility: a client that never sent an `If-Match`
-        // (older frontend, curl) keeps the blind last-write-wins save.
+        // `check_if_match` with `if_match = None` is a no-op (that path is
+        // exercised in production by `enforce_if_match` on the document
+        // route); `save_law`/`save_scenario` skip the call entirely when the
+        // header is absent, which is what keeps older clients (frontend
+        // without etag plumbing, curl) on the blind last-write-wins save.
         let current = "$id: wet\nname: v1\n";
         let etag = check_if_match(Some(current), None, "Wet").unwrap();
         assert_eq!(etag.as_deref(), Some(document_etag(current).as_str()));

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -523,35 +523,75 @@ async fn list_scenarios_in_scope(
     scope: &ReadScope,
     law_id: &str,
 ) -> Result<Json<Vec<ScenarioEntry>>, (StatusCode, String)> {
-    let resolved = resolve_backend_for_law(scope.corpus(), law_id).await?;
-
-    let scenarios_dir = match law_relative_dir(&resolved.law) {
-        Ok(dir) => dir.join("scenarios"),
-        Err(_) => return Ok(Json(Vec::new())),
-    };
-
-    let backend = resolved.backend.lock().await;
     // Surface real backend errors (permissions, broken git checkout, …) as
     // 500 instead of swallowing them as "no scenarios". `list_files` itself
     // already returns `Ok(vec![])` for a missing directory, so anything that
     // does reach the error arm is a genuine fault worth telling the client.
-    let entries = backend
-        .list_files(&scenarios_dir, Some("feature"))
-        .await
-        .map_err(|e| {
-            tracing::warn!(law_id = %law_id, error = %e, "list_scenarios backend failure");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "Failed to list scenarios".to_string(),
-            )
-        })?;
-    drop(backend);
+    let list_error = |e: CorpusError| {
+        tracing::warn!(law_id = %law_id, error = %e, "list_scenarios backend failure");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Failed to list scenarios".to_string(),
+        )
+    };
 
-    let mut out: Vec<ScenarioEntry> = entries
+    let filenames: std::collections::BTreeSet<String> = match scope {
+        // Traject-scoped: the union of the write target's listing and
+        // the seed's, mirroring the per-file routing of the scenario GET
+        // / `If-Match` check (`read_traject_file_via_write_target`): a
+        // scenario saved on the traject branch is listed even when the
+        // law file itself was never saved there, AND seed scenarios that
+        // were never copied to the branch keep showing up (their GET
+        // falls back to the seed the same way).
+        ReadScope::Traject(traject) => {
+            let law = traject_law(traject, law_id)?;
+            let scenarios_dir = match law_relative_dir(law) {
+                Ok(dir) => dir.join("scenarios"),
+                Err(_) => return Ok(Json(Vec::new())),
+            };
+            let write_source_id = traject_write_source_id(traject, law);
+            let mut names = std::collections::BTreeSet::new();
+            // Lock order: write target first, released before the seed
+            // backend is touched (writable-own → seed, never the
+            // reverse — same invariant as the per-file reads).
+            let seed_source_id =
+                (law.source_id != write_source_id).then_some(law.source_id.as_str());
+            for source_id in std::iter::once(write_source_id.as_str()).chain(seed_source_id) {
+                let Some(entry) = traject.corpus.backends.get(source_id) else {
+                    continue;
+                };
+                let backend = entry.backend.lock().await;
+                let entries = backend
+                    .list_files(&scenarios_dir, Some("feature"))
+                    .await
+                    .map_err(list_error)?;
+                drop(backend);
+                names.extend(entries.into_iter().map(|e| e.name));
+            }
+            names
+        }
+        // Global: no write target exists; keep the read-only resolution.
+        ReadScope::Global(_) => {
+            let resolved = resolve_backend_for_law(scope.corpus(), law_id).await?;
+            let scenarios_dir = match law_relative_dir(&resolved.law) {
+                Ok(dir) => dir.join("scenarios"),
+                Err(_) => return Ok(Json(Vec::new())),
+            };
+            let backend = resolved.backend.lock().await;
+            let entries = backend
+                .list_files(&scenarios_dir, Some("feature"))
+                .await
+                .map_err(list_error)?;
+            drop(backend);
+            entries.into_iter().map(|e| e.name).collect()
+        }
+    };
+
+    // BTreeSet iteration is already sorted by filename.
+    let out: Vec<ScenarioEntry> = filenames
         .into_iter()
-        .map(|e| ScenarioEntry { filename: e.name })
+        .map(|filename| ScenarioEntry { filename })
         .collect();
-    out.sort_by(|a, b| a.filename.cmp(&b.filename));
     Ok(Json(out))
 }
 
@@ -582,23 +622,35 @@ async fn get_scenario_in_scope(
 ) -> Result<EtaggedContentResponse, (StatusCode, String)> {
     validate_scenario_filename(filename)?;
 
-    let resolved = resolve_backend_for_law(scope.corpus(), law_id).await?;
+    let content = match scope {
+        // Traject-scoped: read through the same write-target-with-seed-
+        // fallback routing the save's `If-Match` check uses, so the GET
+        // serves (and ETags) exactly the bytes a subsequent save is
+        // checked against. See `read_traject_file_via_write_target` for
+        // the 412-loop this prevents.
+        ReadScope::Traject(traject) => {
+            let law = traject_law(traject, law_id)?;
+            let relative_path = scenario_relative_path(law, filename)?;
+            read_traject_file_via_write_target(traject, law, &relative_path, "scenario").await?
+        }
+        // Global: no write target exists; keep the read-only resolution.
+        ReadScope::Global(_) => {
+            let resolved = resolve_backend_for_law(scope.corpus(), law_id).await?;
+            let relative_path = scenario_relative_path(&resolved.law, filename)?;
+            let backend = resolved.backend.lock().await;
+            backend
+                .read_file(&relative_path)
+                .await
+                .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        }
+    };
 
-    let scenarios_dir = law_relative_dir(&resolved.law)?.join("scenarios");
-    let relative_path = scenarios_dir.join(filename);
-
-    let backend = resolved.backend.lock().await;
-    let content = backend
-        .read_file(&relative_path)
-        .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                format!("Scenario '{}' not found", filename),
-            )
-        })?;
-    drop(backend);
+    let content = content.ok_or_else(|| {
+        (
+            StatusCode::NOT_FOUND,
+            format!("Scenario '{}' not found", filename),
+        )
+    })?;
 
     Ok(etagged_content_response(
         "text/plain; charset=utf-8",
@@ -632,19 +684,12 @@ fn resolve_annotation_read_backend(
 ) -> Result<SharedBackend, (StatusCode, String)> {
     match scope {
         ReadScope::Traject(traject) => {
-            let law =
-                traject.corpus.source_map.get_law(law_id).ok_or_else(|| {
-                    (StatusCode::NOT_FOUND, format!("Law '{}' not found", law_id))
-                })?;
+            let law = traject_law(traject, law_id)?;
             // Mirror `resolve_traject_law_write`: a law from a
             // non-writable_own source is routed to the writable_own
             // backend via `write_target_for_source`; a law from a
             // writable source goes to its own.
-            let target_source_id = traject
-                .write_target_for_source
-                .get(&law.source_id)
-                .cloned()
-                .unwrap_or_else(|| law.source_id.clone());
+            let target_source_id = traject_write_source_id(traject, law);
             let entry = traject
                 .corpus
                 .backends
@@ -1104,6 +1149,36 @@ fn traject_corpus_error(e: TrajectCorpusError) -> (StatusCode, String) {
     }
 }
 
+/// Look up a law in a traject's federated source map; 404 when absent.
+fn traject_law<'a>(
+    traject: &'a TrajectCorpus,
+    law_id: &str,
+) -> Result<&'a LoadedLaw, (StatusCode, String)> {
+    traject
+        .corpus
+        .source_map
+        .get_law(law_id)
+        .ok_or_else(|| (StatusCode::NOT_FOUND, format!("Law '{}' not found", law_id)))
+}
+
+/// Write-target source id for a law in a traject — the single routing
+/// rule shared by the write path (`resolve_traject_law_write`), the
+/// annotation read path and the traject-scoped scenario reads.
+///
+/// "Save back where the law came from": laws from a source that has an
+/// entry in `write_target_for_source` get routed through that mapped
+/// backend (typically the writable_own's traject-branched backend on
+/// the same upstream repo). Laws from a source without an entry — e.g.
+/// the local source, which is natively writable on its scratch dir —
+/// stay on their own source's backend.
+fn traject_write_source_id(traject: &TrajectCorpus, law: &LoadedLaw) -> String {
+    traject
+        .write_target_for_source
+        .get(&law.source_id)
+        .cloned()
+        .unwrap_or_else(|| law.source_id.clone())
+}
+
 /// Resolved write routing for a law in a traject: the law's index
 /// entry, the id of the source whose backend the write goes to, and an
 /// owned guard over that backend.
@@ -1124,24 +1199,9 @@ async fn resolve_traject_law_write(
     traject: &Arc<TrajectCorpus>,
     law_id: &str,
 ) -> Result<TrajectLawWrite, (StatusCode, String)> {
-    let law = traject
-        .corpus
-        .source_map
-        .get_law(law_id)
-        .ok_or_else(|| (StatusCode::NOT_FOUND, format!("Law '{}' not found", law_id)))?
-        .clone();
+    let law = traject_law(traject, law_id)?.clone();
 
-    // "Save back where the law came from": laws from a source that has
-    // an entry in `write_target_for_source` get routed through that
-    // mapped backend (typically the writable_own's traject-branched
-    // backend on the same upstream repo). Laws from a source without an
-    // entry — e.g. the local source, which is natively writable on its
-    // scratch dir — write directly through their own source's backend.
-    let write_target_source_id = traject
-        .write_target_for_source
-        .get(&law.source_id)
-        .cloned()
-        .unwrap_or_else(|| law.source_id.clone());
+    let write_target_source_id = traject_write_source_id(traject, &law);
     let entry = traject
         .corpus
         .backends
@@ -1183,10 +1243,7 @@ fn scenario_relative_path(
 /// *different* source (a federated law whose first traject edit hasn't
 /// landed on the writable-own branch), the client's ETag was computed
 /// from the upstream body the GET served — so fall back to reading the
-/// law's own source backend. The `law.source_id != write_source_id`
-/// guard guarantees the fallback locks a different mutex than the one
-/// the caller already holds; tokio's `Mutex` is not reentrant, so
-/// re-locking the held guard would deadlock.
+/// law's own source backend (see [`read_seed_fallback`]).
 async fn current_content_for_write(
     traject: &Arc<TrajectCorpus>,
     write: &TrajectLawWrite,
@@ -1201,10 +1258,39 @@ async fn current_content_for_write(
     {
         return Ok(Some(text));
     }
-    if write.law.source_id == write.write_source_id {
+    read_seed_fallback(
+        traject,
+        &write.law,
+        &write.write_source_id,
+        relative_path,
+        kind,
+    )
+    .await
+}
+
+/// Read `relative_path` from the law's own (seed) source backend — the
+/// fallback leg of the write-target routing, for laws federated from a
+/// non-writable source whose file was never saved on the writable-own
+/// branch. Returns `Ok(None)` when the law already writes to its own
+/// source (nothing to fall back to) or the seed backend is missing.
+///
+/// Lock-ordering invariant: callers must NOT hold the seed backend's
+/// lock. Holding the write-target lock while calling this is allowed —
+/// writable-own → seed is the one legal two-backend lock order (the
+/// `law.source_id != write_source_id` guard guarantees the fallback
+/// locks a *different* mutex than the write target's; tokio's `Mutex`
+/// is not reentrant, so re-locking a held guard would deadlock).
+async fn read_seed_fallback(
+    traject: &Arc<TrajectCorpus>,
+    law: &LoadedLaw,
+    write_source_id: &str,
+    relative_path: &std::path::Path,
+    kind: &'static str,
+) -> Result<Option<String>, (StatusCode, String)> {
+    if law.source_id == write_source_id {
         return Ok(None);
     }
-    let Some(entry) = traject.corpus.backends.get(&write.law.source_id) else {
+    let Some(entry) = traject.corpus.backends.get(&law.source_id) else {
         return Ok(None);
     };
     let backend = entry.backend.lock().await;
@@ -1212,6 +1298,47 @@ async fn current_content_for_write(
         .read_file(relative_path)
         .await
         .map_err(corpus_write_error(kind))
+}
+
+/// Read a law-scoped file for a traject GET through the **same routing
+/// the write path's `If-Match` check uses** ([`current_content_for_write`]):
+/// the write-target backend first, then the law's own seed source when
+/// the file doesn't exist on the target yet. GET, precondition check
+/// and write thereby agree on the authoritative replica.
+///
+/// Without this, a scenario saved before the law itself was ever saved
+/// in the traject (law file still absent on the writable-own branch)
+/// kept being served from the seed by `resolve_backend_for_law` —
+/// whose fallback rule verifies the *law* file — while the check
+/// compared against the writable-own copy: the user could never see
+/// their save and every If-Match retry 412'd against an ETag the GET
+/// never served (a permanent conflict loop).
+///
+/// Lock order: the write-target lock is released before the seed
+/// backend is locked (writable-own → seed, never the reverse — the
+/// same invariant `current_content_for_write` relies on).
+async fn read_traject_file_via_write_target(
+    traject: &Arc<TrajectCorpus>,
+    law: &LoadedLaw,
+    relative_path: &std::path::Path,
+    kind: &'static str,
+) -> Result<Option<String>, (StatusCode, String)> {
+    let write_source_id = traject_write_source_id(traject, law);
+    let entry = traject.corpus.backends.get(&write_source_id).ok_or((
+        StatusCode::SERVICE_UNAVAILABLE,
+        "Writable backend not initialised".to_string(),
+    ))?;
+    {
+        let backend = entry.backend.lock().await;
+        if let Some(text) = backend
+            .read_file(relative_path)
+            .await
+            .map_err(corpus_write_error(kind))?
+        {
+            return Ok(Some(text));
+        }
+    }
+    read_seed_fallback(traject, law, &write_source_id, relative_path, kind).await
 }
 
 async fn resolve_traject_scenario_target(

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -43,6 +43,13 @@ pub struct SaveResponse {
     /// finding NEW-2). Always `false` for law/scenario saves; those
     /// clients ignore it.
     pub no_change: bool,
+    /// The new ETag after a law/scenario save — clients keep it for the
+    /// next PUT's `If-Match` header (same optimistic-concurrency chain
+    /// as [`SaveDocumentResponse::etag`]). `None` for handlers that
+    /// don't participate in If-Match concurrency (annotations, deletes),
+    /// and omitted from the JSON in that case.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub etag: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -335,11 +342,31 @@ type YamlResponse = (
     String,
 );
 
+/// Raw-content response carrying an `ETag` next to the `Content-Type`.
+/// Used by the law and scenario GETs so clients can echo the ETag back
+/// as `If-Match` on the corresponding save (same optimistic-concurrency
+/// chain as the document endpoints).
+type EtaggedContentResponse = (StatusCode, [(axum::http::HeaderName, String); 2], String);
+
+/// Build a `200 OK` raw-content response with `Content-Type` and an
+/// `ETag` computed over the body (see [`document_etag`]).
+fn etagged_content_response(content_type: &'static str, content: String) -> EtaggedContentResponse {
+    let etag = document_etag(&content);
+    (
+        StatusCode::OK,
+        [
+            (axum::http::header::CONTENT_TYPE, content_type.to_string()),
+            (axum::http::header::ETAG, etag),
+        ],
+        content,
+    )
+}
+
 /// GET /api/corpus/laws/{law_id} — return raw YAML content for a specific law (global view).
 pub async fn get_corpus_law(
     State(state): State<AppState>,
     Path(law_id): Path<String>,
-) -> Result<YamlResponse, (StatusCode, String)> {
+) -> Result<EtaggedContentResponse, (StatusCode, String)> {
     let scope = global_scope(&state).await;
     get_corpus_law_in_scope(&scope, &law_id).await
 }
@@ -350,7 +377,7 @@ pub async fn get_traject_corpus_law(
     State(state): State<AppState>,
     session: Session,
     Path((traject_ref, law_id)): Path<(String, String)>,
-) -> Result<YamlResponse, (StatusCode, String)> {
+) -> Result<EtaggedContentResponse, (StatusCode, String)> {
     let scope = require_traject_scope(&state, &session, &traject_ref).await?;
     get_corpus_law_in_scope(&scope, &law_id).await
 }
@@ -358,13 +385,9 @@ pub async fn get_traject_corpus_law(
 async fn get_corpus_law_in_scope(
     scope: &ReadScope,
     law_id: &str,
-) -> Result<YamlResponse, (StatusCode, String)> {
+) -> Result<EtaggedContentResponse, (StatusCode, String)> {
     let yaml = read_law_yaml(scope, law_id).await?;
-    Ok((
-        StatusCode::OK,
-        [(axum::http::header::CONTENT_TYPE, "text/yaml; charset=utf-8")],
-        yaml,
-    ))
+    Ok(etagged_content_response("text/yaml; charset=utf-8", yaml))
 }
 
 /// GET /api/corpus/laws/{law_id}/outputs — list all outputs declared across articles (global view).
@@ -536,7 +559,7 @@ async fn list_scenarios_in_scope(
 pub async fn get_scenario(
     State(state): State<AppState>,
     Path((law_id, filename)): Path<(String, String)>,
-) -> Result<YamlResponse, (StatusCode, String)> {
+) -> Result<EtaggedContentResponse, (StatusCode, String)> {
     let scope = global_scope(&state).await;
     get_scenario_in_scope(&scope, &law_id, &filename).await
 }
@@ -547,7 +570,7 @@ pub async fn get_traject_scenario(
     State(state): State<AppState>,
     session: Session,
     Path((traject_ref, law_id, filename)): Path<(String, String, String)>,
-) -> Result<YamlResponse, (StatusCode, String)> {
+) -> Result<EtaggedContentResponse, (StatusCode, String)> {
     let scope = require_traject_scope(&state, &session, &traject_ref).await?;
     get_scenario_in_scope(&scope, &law_id, &filename).await
 }
@@ -556,7 +579,7 @@ async fn get_scenario_in_scope(
     scope: &ReadScope,
     law_id: &str,
     filename: &str,
-) -> Result<YamlResponse, (StatusCode, String)> {
+) -> Result<EtaggedContentResponse, (StatusCode, String)> {
     validate_scenario_filename(filename)?;
 
     let resolved = resolve_backend_for_law(scope.corpus(), law_id).await?;
@@ -577,12 +600,8 @@ async fn get_scenario_in_scope(
         })?;
     drop(backend);
 
-    Ok((
-        StatusCode::OK,
-        [(
-            axum::http::header::CONTENT_TYPE,
-            "text/plain; charset=utf-8",
-        )],
+    Ok(etagged_content_response(
+        "text/plain; charset=utf-8",
         content,
     ))
 }
@@ -1085,19 +1104,26 @@ fn traject_corpus_error(e: TrajectCorpusError) -> (StatusCode, String) {
     }
 }
 
+/// Resolved write routing for a law in a traject: the law's index
+/// entry, the id of the source whose backend the write goes to, and an
+/// owned guard over that backend.
+struct TrajectLawWrite {
+    law: LoadedLaw,
+    /// Source id of the backend behind `backend`. Differs from
+    /// `law.source_id` when the law comes from a federated read-only
+    /// source and its writes are routed to the traject's writable-own
+    /// backend (see `write_target_for_source`).
+    write_source_id: String,
+    backend: tokio::sync::OwnedMutexGuard<Box<dyn RepoBackend>>,
+}
+
 /// Resolve the writable-own backend within a traject's corpus. Returns
-/// the looked-up law (for its `relative_path`) and an owned guard over
-/// the traject's writable backend.
+/// the looked-up law (for its `relative_path`), the write-target source
+/// id, and an owned guard over the traject's writable backend.
 async fn resolve_traject_law_write(
     traject: &Arc<TrajectCorpus>,
     law_id: &str,
-) -> Result<
-    (
-        LoadedLaw,
-        tokio::sync::OwnedMutexGuard<Box<dyn RepoBackend>>,
-    ),
-    (StatusCode, String),
-> {
+) -> Result<TrajectLawWrite, (StatusCode, String)> {
     let law = traject
         .corpus
         .source_map
@@ -1128,18 +1154,64 @@ async fn resolve_traject_law_write(
         return Err((StatusCode::FORBIDDEN, "Source is read-only".to_string()));
     }
     let backend = entry.backend.clone().lock_owned().await;
-    Ok((law, backend))
-}
-
-async fn resolve_traject_law_target(
-    traject: &Arc<TrajectCorpus>,
-    law_id: &str,
-) -> Result<EditorWriteTarget, (StatusCode, String)> {
-    let (law, backend) = resolve_traject_law_write(traject, law_id).await?;
-    Ok(EditorWriteTarget {
-        relative_path: PathBuf::from(&law.relative_path),
+    Ok(TrajectLawWrite {
+        law,
+        write_source_id: write_target_source_id,
         backend,
     })
+}
+
+/// Source-relative path of a law's scenario file.
+fn scenario_relative_path(
+    law: &LoadedLaw,
+    filename: &str,
+) -> Result<PathBuf, (StatusCode, String)> {
+    Ok(law_relative_dir(law)?.join("scenarios").join(filename))
+}
+
+/// Read the bytes an `If-Match` check on a law/scenario save compares
+/// against, coherently with the write that follows.
+///
+/// The write-target file (the traject branch) is authoritative: it is
+/// read through the same mutex guard the caller holds for the upcoming
+/// write, so a concurrent save of the same law cannot slip in between
+/// the check and the write (saves of one law serialise on that mutex,
+/// and the loser then sees the winner's bytes — a stale `If-Match`
+/// 412s instead of silently overwriting).
+///
+/// When that file does not exist yet AND the law is routed from a
+/// *different* source (a federated law whose first traject edit hasn't
+/// landed on the writable-own branch), the client's ETag was computed
+/// from the upstream body the GET served — so fall back to reading the
+/// law's own source backend. The `law.source_id != write_source_id`
+/// guard guarantees the fallback locks a different mutex than the one
+/// the caller already holds; tokio's `Mutex` is not reentrant, so
+/// re-locking the held guard would deadlock.
+async fn current_content_for_write(
+    traject: &Arc<TrajectCorpus>,
+    write: &TrajectLawWrite,
+    relative_path: &std::path::Path,
+    kind: &'static str,
+) -> Result<Option<String>, (StatusCode, String)> {
+    if let Some(text) = write
+        .backend
+        .read_file(relative_path)
+        .await
+        .map_err(corpus_write_error(kind))?
+    {
+        return Ok(Some(text));
+    }
+    if write.law.source_id == write.write_source_id {
+        return Ok(None);
+    }
+    let Some(entry) = traject.corpus.backends.get(&write.law.source_id) else {
+        return Ok(None);
+    };
+    let backend = entry.backend.lock().await;
+    backend
+        .read_file(relative_path)
+        .await
+        .map_err(corpus_write_error(kind))
 }
 
 async fn resolve_traject_scenario_target(
@@ -1147,11 +1219,10 @@ async fn resolve_traject_scenario_target(
     law_id: &str,
     filename: &str,
 ) -> Result<EditorWriteTarget, (StatusCode, String)> {
-    let (law, backend) = resolve_traject_law_write(traject, law_id).await?;
-    let rel_dir = law_relative_dir(&law)?;
+    let write = resolve_traject_law_write(traject, law_id).await?;
     Ok(EditorWriteTarget {
-        relative_path: rel_dir.join("scenarios").join(filename),
-        backend,
+        relative_path: scenario_relative_path(&write.law, filename)?,
+        backend: write.backend,
     })
 }
 
@@ -1167,12 +1238,12 @@ async fn resolve_traject_annotation_target(
     traject: &Arc<TrajectCorpus>,
     law_id: &str,
 ) -> Result<EditorWriteTarget, (StatusCode, String)> {
-    let (_law, backend) = resolve_traject_law_write(traject, law_id).await?;
+    let write = resolve_traject_law_write(traject, law_id).await?;
     Ok(EditorWriteTarget {
         relative_path: PathBuf::from("annotations")
             .join(law_id)
             .join("annotations.yaml"),
-        backend,
+        backend: write.backend,
     })
 }
 
@@ -1188,6 +1259,7 @@ fn save_response_from_traject(outcome: PersistOutcome) -> SaveResponse {
             number: pr.number,
         }),
         no_change: false,
+        etag: None,
     }
 }
 
@@ -1197,28 +1269,44 @@ fn save_response_from_traject(outcome: PersistOutcome) -> SaveResponse {
 /// The traject id comes from the URL (per-tab SPA route), and the
 /// caller's membership is re-checked on every request. No traject id =
 /// no route, so this handler is unreachable without one.
+///
+/// Honors an optional `If-Match` header for optimistic concurrency
+/// (412 on mismatch; an absent header stays a permissive blind write
+/// for backward compatibility — same semantics as the document PUT).
+/// The new ETag is returned in both the `ETag` header and the response
+/// body's `etag` field.
 pub async fn save_scenario(
     State(state): State<AppState>,
     session: Session,
     Path((traject_ref, law_id, filename)): Path<(String, String, String)>,
+    headers: axum::http::HeaderMap,
     body: String,
-) -> Result<Json<SaveResponse>, (StatusCode, String)> {
+) -> Result<axum::response::Response, (StatusCode, String)> {
+    use axum::response::IntoResponse;
     validate_scenario_filename(&filename)?;
     let author = Some(require_editor_user(&session).await?);
 
     let traject = require_traject_corpus_from_ref(&state, &session, &traject_ref).await?;
-    let target = resolve_traject_scenario_target(&traject, &law_id, &filename).await?;
-    let EditorWriteTarget {
-        relative_path,
-        backend,
-    } = target;
+    let write = resolve_traject_law_write(&traject, &law_id).await?;
+    let relative_path = scenario_relative_path(&write.law, &filename)?;
 
-    backend
+    // Optimistic concurrency, same semantics as documents. Only read the
+    // current content when the client actually sent a precondition — a
+    // header-less save stays a single write, no extra backend read.
+    if let Some(if_match) = extract_if_match(&headers) {
+        let current =
+            current_content_for_write(&traject, &write, &relative_path, "scenario").await?;
+        check_if_match(current.as_deref(), Some(&if_match), "Scenario")?;
+    }
+
+    write
+        .backend
         .write_file(&relative_path, &body)
         .await
         .map_err(corpus_write_error("scenario"))?;
 
-    let outcome = backend
+    let outcome = write
+        .backend
         .persist(&WriteContext {
             message: format!("Update scenario {} for {}", filename, law_id),
             author,
@@ -1226,7 +1314,10 @@ pub async fn save_scenario(
         .await
         .map_err(corpus_write_error("scenario"))?;
 
-    Ok(Json(save_response_from_traject(outcome)))
+    let new_etag = document_etag(&body);
+    let mut response = save_response_from_traject(outcome);
+    response.etag = Some(new_etag.clone());
+    Ok(([(axum::http::header::ETAG, new_etag)], Json(response)).into_response())
 }
 
 /// Schema the produced notes document is validated against before it is
@@ -1340,6 +1431,7 @@ pub async fn save_annotations(
                 return Ok(Json(SaveResponse {
                     pr: None,
                     no_change: true,
+                    etag: None,
                 }));
             }
             AppendOutcome::Write(text) => text,
@@ -1422,8 +1514,10 @@ pub async fn save_law(
     State(state): State<AppState>,
     session: Session,
     Path((traject_ref, law_id)): Path<(String, String)>,
+    headers: axum::http::HeaderMap,
     body: String,
-) -> Result<Json<SaveResponse>, (StatusCode, String)> {
+) -> Result<axum::response::Response, (StatusCode, String)> {
+    use axum::response::IntoResponse;
     let author = Some(require_editor_user(&session).await?);
 
     // Validation:
@@ -1472,18 +1566,28 @@ pub async fn save_law(
     // corpus so we can mirror the saved body into its read-your-writes
     // overlay after `persist` succeeds.
     let traject = require_traject_corpus_from_ref(&state, &session, &traject_ref).await?;
-    let target = resolve_traject_law_target(&traject, &law_id).await?;
-    let EditorWriteTarget {
-        relative_path,
-        backend,
-    } = target;
+    let write = resolve_traject_law_write(&traject, &law_id).await?;
+    let relative_path = PathBuf::from(&write.law.relative_path);
+
+    // Optimistic concurrency, same semantics as the document PUT: a
+    // present `If-Match` must equal the current content's ETag (412 on
+    // mismatch), an absent header stays a permissive blind write for
+    // backward compatibility. Checked while holding the write backend's
+    // mutex (acquired by `resolve_traject_law_write` above), so a
+    // concurrent save cannot slip between the check and the write.
+    if let Some(if_match) = extract_if_match(&headers) {
+        let current = current_content_for_write(&traject, &write, &relative_path, "law").await?;
+        check_if_match(current.as_deref(), Some(&if_match), "Wet")?;
+    }
 
     let outcome = {
-        backend
+        write
+            .backend
             .write_file(&relative_path, &body)
             .await
             .map_err(corpus_write_error("law"))?;
-        backend
+        write
+            .backend
             .persist(&WriteContext {
                 message: format!("Update law {}", law_id),
                 author,
@@ -1491,6 +1595,10 @@ pub async fn save_law(
             .await
             .map_err(corpus_write_error("law"))?
     };
+
+    // ETag of what we just wrote — the client chains it into the next
+    // save's `If-Match`. Computed before `record_save` consumes `body`.
+    let new_etag = document_etag(&body);
 
     // The global `state.corpus.source_map` is still NOT touched here:
     // it feeds GET handlers when no traject is active, so writing a
@@ -1508,7 +1616,9 @@ pub async fn save_law(
     // instead of waiting out the TTL.
     traject.invalidate_changed_cache().await;
 
-    Ok(Json(save_response_from_traject(outcome)))
+    let mut response = save_response_from_traject(outcome);
+    response.etag = Some(new_etag.clone());
+    Ok(([(axum::http::header::ETAG, new_etag)], Json(response)).into_response())
 }
 
 /// DELETE /api/trajects/{traject_id}/corpus/laws/{law_id}/scenarios/{filename}
@@ -1808,21 +1918,37 @@ async fn enforce_if_match(
         .read_file(relative_path)
         .await
         .map_err(corpus_write_error("document"))?;
-    let current_etag = current.as_deref().map(document_etag);
+    check_if_match(current.as_deref(), if_match, "Document")
+}
+
+/// Pure core of the `If-Match` precondition shared by the document,
+/// law, and scenario save paths: compare a client-supplied `If-Match`
+/// against the ETag of the current content and return that ETag (or
+/// `None` when there is no current content). `noun` names the resource
+/// in the Dutch 412 messages ("Document", "Wet", "Scenario").
+///
+/// `if_match = None` is intentionally a no-op — see [`enforce_if_match`]
+/// for the backward-compatibility reasoning.
+fn check_if_match(
+    current: Option<&str>,
+    if_match: Option<&str>,
+    noun: &'static str,
+) -> Result<Option<String>, (StatusCode, String)> {
+    let current_etag = current.map(document_etag);
     if let Some(client) = if_match {
         match (client, &current_etag) {
             ("*", Some(_)) => {}
             ("*", None) => {
                 return Err((
                     StatusCode::PRECONDITION_FAILED,
-                    "Document bestaat (nog) niet".to_string(),
+                    format!("{noun} bestaat (nog) niet"),
                 ))
             }
             (val, Some(etag)) if val == etag.as_str() => {}
             _ => {
                 return Err((
                     StatusCode::PRECONDITION_FAILED,
-                    "Document is intussen door iemand anders gewijzigd".to_string(),
+                    format!("{noun} is intussen door iemand anders gewijzigd"),
                 ))
             }
         }
@@ -2066,6 +2192,8 @@ mod tests {
         assert!(body.pr.is_none());
         // Law/scenario saves are never a notes no-op.
         assert!(!body.no_change);
+        // The etag is filled in by the law/scenario handlers themselves.
+        assert!(body.etag.is_none());
     }
 
     // ---- editor_user_from_session: attribution invariants ----
@@ -2161,6 +2289,7 @@ mod tests {
             axum::extract::State<crate::state::AppState>,
             Session,
             axum::extract::Path<(String, String, String)>,
+            axum::http::HeaderMap,
             String,
         ) -> _ = save_scenario;
         let _: fn(
@@ -2173,6 +2302,7 @@ mod tests {
             axum::extract::State<crate::state::AppState>,
             Session,
             axum::extract::Path<(String, String)>,
+            axum::http::HeaderMap,
             String,
         ) -> _ = save_law;
         // delete_scenario takes no body at all — even stronger guarantee.
@@ -2403,5 +2533,55 @@ mod tests {
             returned.as_deref(),
             Some(document_etag("anything").as_str())
         );
+    }
+
+    // ---- check_if_match: the law/scenario save precondition ----
+    //
+    // `save_law` / `save_scenario` resolve the current bytes through the
+    // traject's write routing and run this pure check against them; the
+    // three cases below pin the contract those handlers rely on.
+
+    #[test]
+    fn law_save_absent_if_match_is_permissive() {
+        // Backward compatibility: a client that never sent an `If-Match`
+        // (older frontend, curl) keeps the blind last-write-wins save.
+        let current = "$id: wet\nname: v1\n";
+        let etag = check_if_match(Some(current), None, "Wet").unwrap();
+        assert_eq!(etag.as_deref(), Some(document_etag(current).as_str()));
+    }
+
+    #[test]
+    fn law_save_stale_if_match_is_412() {
+        // Someone else saved between this client's GET and PUT: the
+        // client's ETag no longer matches the stored YAML → 412, and the
+        // message names the law (not "Document").
+        let current = "$id: wet\nname: v2-van-iemand-anders\n";
+        let stale = document_etag("$id: wet\nname: v1\n");
+        let err = check_if_match(Some(current), Some(&stale), "Wet")
+            .expect_err("stale etag must be refused");
+        assert_eq!(err.0, StatusCode::PRECONDITION_FAILED);
+        assert!(
+            err.1.contains("Wet"),
+            "message should name the noun: {}",
+            err.1
+        );
+    }
+
+    #[test]
+    fn scenario_save_matching_if_match_passes() {
+        let current = "Feature: bestaand scenario\n";
+        let etag = document_etag(current);
+        let returned = check_if_match(Some(current), Some(&etag), "Scenario").unwrap();
+        assert_eq!(returned.as_deref(), Some(etag.as_str()));
+    }
+
+    #[test]
+    fn scenario_save_if_match_against_missing_file_is_412() {
+        // The scenario was deleted between the client's GET and PUT —
+        // a precondition can never match absent content.
+        let stale = document_etag("Feature: weg\n");
+        let err = check_if_match(None, Some(&stale), "Scenario")
+            .expect_err("etag against missing file must be refused");
+        assert_eq!(err.0, StatusCode::PRECONDITION_FAILED);
     }
 }

--- a/packages/editor-api/tests/save_annotations_test.rs
+++ b/packages/editor-api/tests/save_annotations_test.rs
@@ -181,7 +181,7 @@ async fn writes_a_note_to_the_traject_local_sidecar() {
     let session = session_for(&sub, Some(traject_id)).await;
 
     let body = serde_json::to_string(&[note(LAW_ID, "zorgtoeslag")]).unwrap();
-    let Json(SaveResponse { pr, no_change }) =
+    let Json(SaveResponse { pr, no_change, .. }) =
         save_annotations(State(state), session, Path(LAW_ID.to_string()), body)
             .await
             .expect("save should succeed");
@@ -266,7 +266,7 @@ async fn re_saving_an_already_committed_note_is_a_no_op() {
     // Second save of the SAME note: dedup leaves nothing, so no_change is
     // reported and the file is byte-identical (no empty commit / churn).
     let session2 = session_for(&sub, Some(traject_id)).await;
-    let Json(SaveResponse { pr, no_change }) =
+    let Json(SaveResponse { pr, no_change, .. }) =
         save_annotations(State(state), session2, Path(LAW_ID.to_string()), body)
             .await
             .expect("second save ok");

--- a/packages/editor-api/tests/traject_reads_test.rs
+++ b/packages/editor-api/tests/traject_reads_test.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 
 use axum::extract::{Path, State};
 use axum::http::{HeaderMap, HeaderValue, StatusCode};
+use axum::Json;
 use pretty_assertions::assert_eq;
 use sqlx::PgPool;
 use tokio::sync::{Mutex, RwLock};
@@ -28,7 +29,8 @@ use regelrecht_auth::handlers::{
 };
 use regelrecht_editor_api::config::AppConfig;
 use regelrecht_editor_api::corpus_handlers::{
-    get_corpus_law, get_traject_corpus_law, get_traject_scenario, save_law, save_scenario,
+    get_corpus_law, get_traject_corpus_law, get_traject_scenario, list_traject_scenarios, save_law,
+    save_scenario,
 };
 use regelrecht_editor_api::state::{AppState, CorpusState};
 use regelrecht_editor_api::traject_corpus::TrajectCorpusCache;
@@ -189,6 +191,53 @@ async fn save_law_with(
         Path((tref.to_string(), LAW_ID.to_string())),
         headers,
         body,
+    )
+    .await?;
+    let etag = response
+        .headers()
+        .get(axum::http::header::ETAG)
+        .map(|v| v.to_str().unwrap().to_string());
+    Ok((response.status(), etag))
+}
+
+/// Helper: call the traject-scoped scenario GET and return `(etag, body)`.
+async fn read_scenario(
+    state: AppState,
+    session: Session,
+    tref: &str,
+    filename: &str,
+) -> (String, String) {
+    let (status, headers, body) = get_traject_scenario(
+        State(state),
+        session,
+        Path((tref.to_string(), LAW_ID.to_string(), filename.to_string())),
+    )
+    .await
+    .expect("scenario GET must succeed");
+    assert_eq!(status, StatusCode::OK);
+    let etag = headers
+        .iter()
+        .find(|(name, _)| name == axum::http::header::ETAG)
+        .map(|(_, value)| value.clone())
+        .expect("scenario GET must carry an ETag header");
+    (etag, body)
+}
+
+/// Helper: call `save_scenario` and return the response (status + new ETag).
+async fn save_scenario_with(
+    state: AppState,
+    session: Session,
+    tref: &str,
+    filename: &str,
+    headers: HeaderMap,
+    body: &str,
+) -> Result<(StatusCode, Option<String>), (StatusCode, String)> {
+    let response = save_scenario(
+        State(state),
+        session,
+        Path((tref.to_string(), LAW_ID.to_string(), filename.to_string())),
+        headers,
+        body.to_string(),
     )
     .await?;
     let etag = response
@@ -560,52 +609,36 @@ async fn scenario_save_if_match_matrix() {
     let tref = traject_ref(traject_id);
 
     // GET the scenario → ETag.
-    let (status, headers, body) = get_traject_scenario(
-        State(state.clone()),
+    let (etag, body) = read_scenario(
+        state.clone(),
         session_for(&sub).await,
-        Path((
-            tref.clone(),
-            LAW_ID.to_string(),
-            "basis.feature".to_string(),
-        )),
+        &tref,
+        "basis.feature",
     )
-    .await
-    .expect("scenario GET must succeed");
-    assert_eq!(status, StatusCode::OK);
+    .await;
     assert_eq!(body, "Feature: v1\n");
-    let etag = headers
-        .iter()
-        .find(|(name, _)| name == axum::http::header::ETAG)
-        .map(|(_, value)| value.clone())
-        .expect("scenario GET must carry an ETag header");
 
     // Matching If-Match → success.
-    let response = save_scenario(
-        State(state.clone()),
+    let (status, _etag) = save_scenario_with(
+        state.clone(),
         session_for(&sub).await,
-        Path((
-            tref.clone(),
-            LAW_ID.to_string(),
-            "basis.feature".to_string(),
-        )),
+        &tref,
+        "basis.feature",
         if_match_headers(&etag),
-        "Feature: v2\n".to_string(),
+        "Feature: v2\n",
     )
     .await
     .expect("matching If-Match must succeed");
-    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(status, StatusCode::OK);
 
     // The same (now stale) ETag again → 412.
-    let err = save_scenario(
-        State(state.clone()),
+    let err = save_scenario_with(
+        state.clone(),
         session_for(&sub).await,
-        Path((
-            tref.clone(),
-            LAW_ID.to_string(),
-            "basis.feature".to_string(),
-        )),
+        &tref,
+        "basis.feature",
         if_match_headers(&etag),
-        "Feature: v3-overschrijft\n".to_string(),
+        "Feature: v3-overschrijft\n",
     )
     .await
     .expect_err("stale If-Match must be refused");
@@ -613,18 +646,150 @@ async fn scenario_save_if_match_matrix() {
 
     // No If-Match at all → permissive (backward compatibility, and the
     // create path for brand-new scenario files).
-    let response = save_scenario(
-        State(state.clone()),
+    let (status, _etag) = save_scenario_with(
+        state.clone(),
         session_for(&sub).await,
-        Path((
-            tref.clone(),
-            LAW_ID.to_string(),
-            "nieuw.feature".to_string(),
-        )),
+        &tref,
+        "nieuw.feature",
         HeaderMap::new(),
-        "Feature: nieuw\n".to_string(),
+        "Feature: nieuw\n",
     )
     .await
     .expect("save without If-Match must stay permissive");
-    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(status, StatusCode::OK);
+}
+
+#[tokio::test]
+async fn scenario_saved_before_law_is_readable_and_chains_etag() {
+    // Regression test for the permanent 412 loop on federated laws:
+    // the scenario GET used to route via `resolve_backend_for_law`,
+    // which only picks the writable backend when the *law* file exists
+    // there. For a seed-loaded law whose law file was never saved in
+    // the traject, a scenario save landed on the writable-own backend
+    // but subsequent GETs kept serving the seed's old copy + old ETag —
+    // while the save's If-Match check compared against the writable-own
+    // copy. The user could never see their save and every retry 412'd.
+    let db = TestDb::new().await;
+    let state = empty_state(db.pool.clone());
+    let (owner, sub) = seed_account(&db.pool, "alice@test.local").await;
+
+    let seed = tempfile::tempdir().unwrap();
+    let writable_own = tempfile::tempdir().unwrap();
+    // Seed has the law AND an existing scenario; writable_own starts empty.
+    write_law(seed.path(), "SEED_VERSION");
+    write_scenario(seed.path(), "basis.feature", "Feature: seed-versie\n");
+    let traject_id = seeded_traject(&db.pool, owner, seed.path(), writable_own.path()).await;
+    let tref = traject_ref(traject_id);
+
+    // Pre-save GET serves the seed copy (nothing on the branch yet).
+    let (etag, body) = read_scenario(
+        state.clone(),
+        session_for(&sub).await,
+        &tref,
+        "basis.feature",
+    )
+    .await;
+    assert_eq!(body, "Feature: seed-versie\n");
+
+    // First If-Match save succeeds (check falls back to the seed copy)
+    // and lands on the writable-own backend.
+    let (status, saved_etag) = save_scenario_with(
+        state.clone(),
+        session_for(&sub).await,
+        &tref,
+        "basis.feature",
+        if_match_headers(&etag),
+        "Feature: traject-versie\n",
+    )
+    .await
+    .expect("first If-Match save of a federated scenario must succeed");
+    assert_eq!(status, StatusCode::OK);
+    let saved_etag = saved_etag.expect("save response must carry an ETag header");
+
+    // The LAW file still does not exist on the writable-own backend —
+    // only the scenario does. This is the exact state that used to
+    // flip the GET back to the seed.
+    assert!(!writable_own
+        .path()
+        .join("wet")
+        .join(LAW_ID)
+        .join("2025-01-01.yaml")
+        .exists());
+
+    // GET now returns the just-saved content and its ETag.
+    let (get_etag, body) = read_scenario(
+        state.clone(),
+        session_for(&sub).await,
+        &tref,
+        "basis.feature",
+    )
+    .await;
+    assert_eq!(
+        body, "Feature: traject-versie\n",
+        "GET after save must serve the saved content, not the seed copy"
+    );
+    assert_eq!(
+        get_etag, saved_etag,
+        "GET must serve the ETag the save returned, or the chain breaks"
+    );
+
+    // And a follow-up If-Match save with that ETag succeeds — no 412 loop.
+    let (status, _etag) = save_scenario_with(
+        state.clone(),
+        session_for(&sub).await,
+        &tref,
+        "basis.feature",
+        if_match_headers(&get_etag),
+        "Feature: traject-versie-2\n",
+    )
+    .await
+    .expect("second If-Match save must succeed (no 412 loop)");
+    assert_eq!(status, StatusCode::OK);
+}
+
+#[tokio::test]
+async fn scenario_list_unions_write_target_and_seed() {
+    // The list must mirror the per-file routing: a scenario saved on the
+    // traject branch shows up even though the law file was never saved
+    // there, AND seed scenarios never copied to the branch keep showing
+    // up (their GET falls back to the seed the same way).
+    let db = TestDb::new().await;
+    let state = empty_state(db.pool.clone());
+    let (owner, sub) = seed_account(&db.pool, "alice@test.local").await;
+
+    let seed = tempfile::tempdir().unwrap();
+    let writable_own = tempfile::tempdir().unwrap();
+    write_law(seed.path(), "SEED_VERSION");
+    write_scenario(seed.path(), "basis.feature", "Feature: seed-versie\n");
+    write_scenario(seed.path(), "extra.feature", "Feature: extra\n");
+    let traject_id = seeded_traject(&db.pool, owner, seed.path(), writable_own.path()).await;
+    let tref = traject_ref(traject_id);
+
+    // Save only `basis.feature` — it lands on the writable-own backend;
+    // `extra.feature` stays seed-only.
+    let (status, _etag) = save_scenario_with(
+        state.clone(),
+        session_for(&sub).await,
+        &tref,
+        "basis.feature",
+        HeaderMap::new(),
+        "Feature: traject-versie\n",
+    )
+    .await
+    .expect("save must succeed");
+    assert_eq!(status, StatusCode::OK);
+
+    let Json(entries) = list_traject_scenarios(
+        State(state),
+        session_for(&sub).await,
+        Path((tref, LAW_ID.to_string())),
+    )
+    .await
+    .expect("list must succeed");
+    let filenames: Vec<&str> = entries.iter().map(|e| e.filename.as_str()).collect();
+    assert_eq!(
+        filenames,
+        vec!["basis.feature", "extra.feature"],
+        "list must union the branch's saves with the seed's remaining scenarios"
+    );
 }

--- a/packages/editor-api/tests/traject_reads_test.rs
+++ b/packages/editor-api/tests/traject_reads_test.rs
@@ -1,18 +1,21 @@
 //! Integration tests for the traject-aware read path
-//! (`corpus_handlers::get_corpus_law` and friends).
+//! (`corpus_handlers::get_corpus_law` and friends) and the optimistic
+//! concurrency (`ETag`/`If-Match`) on law and scenario saves.
 //!
 //! These tests exist to pin the cross-traject read isolation introduced
-//! alongside `GitHubApiBackend`. Each test uses local writable-own
-//! sources so the runs are hermetic — no GitHub, no network — and the
-//! handler is invoked directly with inline `axum` extractors, mirroring
-//! the pattern in `save_annotations_test.rs` and `trajects_test.rs`.
+//! alongside `GitHubApiBackend`, and the 412 semantics that stop two
+//! traject members from silently overwriting each other's law edits.
+//! Each test uses local writable-own sources so the runs are hermetic —
+//! no GitHub, no network — and the handlers are invoked directly with
+//! inline `axum` extractors, mirroring the pattern in
+//! `save_annotations_test.rs` and `trajects_test.rs`.
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use std::sync::Arc;
 
 use axum::extract::{Path, State};
-use axum::http::StatusCode;
+use axum::http::{HeaderMap, HeaderValue, StatusCode};
 use pretty_assertions::assert_eq;
 use sqlx::PgPool;
 use tokio::sync::{Mutex, RwLock};
@@ -20,12 +23,15 @@ use tower_sessions::Session;
 use tower_sessions_memory_store::MemoryStore;
 use uuid::Uuid;
 
-use regelrecht_auth::handlers::SESSION_KEY_SUB;
+use regelrecht_auth::handlers::{
+    SESSION_KEY_EMAIL, SESSION_KEY_EMAIL_VERIFIED, SESSION_KEY_NAME, SESSION_KEY_SUB,
+};
 use regelrecht_editor_api::config::AppConfig;
-use regelrecht_editor_api::corpus_handlers::{get_corpus_law, save_law};
+use regelrecht_editor_api::corpus_handlers::{
+    get_corpus_law, get_traject_corpus_law, get_traject_scenario, save_law, save_scenario,
+};
 use regelrecht_editor_api::state::{AppState, CorpusState};
 use regelrecht_editor_api::traject_corpus::TrajectCorpusCache;
-use regelrecht_editor_api::trajects::SESSION_KEY_ACTIVE_TRAJECT;
 
 use regelrecht_pipeline::test_utils::TestDb;
 
@@ -75,6 +81,14 @@ fn write_law(corpus_dir: &std::path::Path, name_marker: &str) {
     .unwrap();
 }
 
+/// Write a scenario file next to the law (the path `save_scenario`
+/// writes to / `get_traject_scenario` reads from).
+fn write_scenario(corpus_dir: &std::path::Path, filename: &str, content: &str) {
+    let dir = corpus_dir.join("wet").join(LAW_ID).join("scenarios");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join(filename), content).unwrap();
+}
+
 /// Create a traject with one local writable-own source pointing at
 /// `corpus_dir`. Returns the traject id. `owner_id` is added as an
 /// `owner` so the membership re-check on reads/writes passes.
@@ -111,33 +125,85 @@ async fn local_traject(pool: &PgPool, owner_id: Uuid, corpus_dir: &std::path::Pa
     traject_id
 }
 
-async fn session_for(sub: &str, traject_id: Option<Uuid>) -> Session {
+/// URL form of a traject reference: `{slug}-{first 8 hex of the UUID}`
+/// (see `trajects::resolve_traject_ref`).
+fn traject_ref(traject_id: Uuid) -> String {
+    format!("test-{}", &traject_id.to_string()[..8])
+}
+
+/// A session with a verified editor identity — the save handlers
+/// require name + email + `email_verified=true` for commit attribution.
+async fn session_for(sub: &str) -> Session {
     let session = Session::new(None, Arc::new(MemoryStore::default()), None);
     session.insert(SESSION_KEY_SUB, sub).await.unwrap();
-    if let Some(id) = traject_id {
-        session
-            .insert(SESSION_KEY_ACTIVE_TRAJECT, id)
-            .await
-            .unwrap();
-    }
+    session.insert(SESSION_KEY_NAME, "Test User").await.unwrap();
+    session
+        .insert(SESSION_KEY_EMAIL, "alice@test.local")
+        .await
+        .unwrap();
+    session
+        .insert(SESSION_KEY_EMAIL_VERIFIED, true)
+        .await
+        .unwrap();
     session
 }
 
-/// Helper: call `get_corpus_law` and return the response body text.
-async fn read_law(state: AppState, session: Session) -> String {
-    let (status, _headers, body) = get_corpus_law(State(state), session, Path(LAW_ID.to_string()))
-        .await
-        .expect("get_corpus_law must succeed");
+fn if_match_headers(etag: &str) -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        axum::http::header::IF_MATCH,
+        HeaderValue::from_str(etag).unwrap(),
+    );
+    headers
+}
+
+/// Helper: call the traject-scoped law GET and return `(etag, body)`.
+async fn read_law(state: AppState, session: Session, tref: &str) -> (String, String) {
+    let (status, headers, body) = get_traject_corpus_law(
+        State(state),
+        session,
+        Path((tref.to_string(), LAW_ID.to_string())),
+    )
+    .await
+    .expect("get_traject_corpus_law must succeed");
     assert_eq!(status, StatusCode::OK);
-    body
+    let etag = headers
+        .iter()
+        .find(|(name, _)| name == axum::http::header::ETAG)
+        .map(|(_, value)| value.clone())
+        .expect("law GET must carry an ETag header");
+    (etag, body)
+}
+
+/// Helper: call `save_law` and return the response (status + new ETag).
+async fn save_law_with(
+    state: AppState,
+    session: Session,
+    tref: &str,
+    headers: HeaderMap,
+    body: String,
+) -> Result<(StatusCode, Option<String>), (StatusCode, String)> {
+    let response = save_law(
+        State(state),
+        session,
+        Path((tref.to_string(), LAW_ID.to_string())),
+        headers,
+        body,
+    )
+    .await?;
+    let etag = response
+        .headers()
+        .get(axum::http::header::ETAG)
+        .map(|v| v.to_str().unwrap().to_string());
+    Ok((response.status(), etag))
 }
 
 // ---------------------------------------------------------------------------
-// Tests
+// Read-isolation tests
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
-async fn get_corpus_law_serves_active_trajects_content() {
+async fn get_corpus_law_serves_the_trajects_content() {
     let db = TestDb::new().await;
     let state = empty_state(db.pool.clone());
     let (owner, sub) = seed_account(&db.pool, "alice@test.local").await;
@@ -152,16 +218,26 @@ async fn get_corpus_law_serves_active_trajects_content() {
     write_law(corpus_b.path(), "TRAJECT_B");
     let traject_b = local_traject(&db.pool, owner, corpus_b.path()).await;
 
-    // Reading with traject A active returns A's copy.
-    let body_a = read_law(state.clone(), session_for(&sub, Some(traject_a)).await).await;
+    // Reading through traject A's URL returns A's copy.
+    let (_etag_a, body_a) = read_law(
+        state.clone(),
+        session_for(&sub).await,
+        &traject_ref(traject_a),
+    )
+    .await;
     assert!(
         body_a.contains("TRAJECT_A"),
         "expected A's content, got: {body_a}"
     );
     assert!(!body_a.contains("TRAJECT_B"));
 
-    // Reading with traject B active returns B's copy.
-    let body_b = read_law(state.clone(), session_for(&sub, Some(traject_b)).await).await;
+    // Reading through traject B's URL returns B's copy.
+    let (_etag_b, body_b) = read_law(
+        state.clone(),
+        session_for(&sub).await,
+        &traject_ref(traject_b),
+    )
+    .await;
     assert!(
         body_b.contains("TRAJECT_B"),
         "expected B's content, got: {body_b}"
@@ -178,25 +254,30 @@ async fn save_then_read_returns_the_just_saved_content() {
     let corpus = tempfile::tempdir().unwrap();
     write_law(corpus.path(), "ORIGINAL");
     let traject_id = local_traject(&db.pool, owner, corpus.path()).await;
+    let tref = traject_ref(traject_id);
 
     // Verify the pre-save read returns the on-disk content.
-    let before = read_law(state.clone(), session_for(&sub, Some(traject_id)).await).await;
+    let (_etag, before) = read_law(state.clone(), session_for(&sub).await, &tref).await;
     assert!(before.contains("ORIGINAL"));
 
-    // Save a new body via the actual handler.
+    // Save a new body via the actual handler — WITHOUT `If-Match`, so
+    // this also pins the backward-compatible permissive save (older
+    // clients that never send the precondition keep working).
     let new_body = format!("$id: {LAW_ID}\nname: UPDATED\n");
-    let _ = save_law(
-        State(state.clone()),
-        session_for(&sub, Some(traject_id)).await,
-        Path(LAW_ID.to_string()),
+    let (status, _etag) = save_law_with(
+        state.clone(),
+        session_for(&sub).await,
+        &tref,
+        HeaderMap::new(),
         new_body,
     )
     .await
-    .expect("save should succeed");
+    .expect("save without If-Match should succeed");
+    assert_eq!(status, StatusCode::OK);
 
     // The next read must reflect the save — overlay populated by
     // `save_law` short-circuits the source_map snapshot.
-    let after = read_law(state, session_for(&sub, Some(traject_id)).await).await;
+    let (_etag, after) = read_law(state, session_for(&sub).await, &tref).await;
     assert!(
         after.contains("UPDATED"),
         "expected the saved content; got: {after}"
@@ -205,27 +286,21 @@ async fn save_then_read_returns_the_just_saved_content() {
 }
 
 #[tokio::test]
-async fn no_active_traject_falls_back_to_global_corpus() {
+async fn global_get_404s_when_law_not_in_global_corpus() {
     let db = TestDb::new().await;
     let state = empty_state(db.pool.clone());
-    let (_owner, sub) = seed_account(&db.pool, "alice@test.local").await;
 
-    // No active traject in the session. The global `state.corpus` is
-    // CorpusState::empty(), so `get_corpus_law` should 404 — but
-    // crucially without erroring out on the missing-traject path.
-    let err = get_corpus_law(
-        State(state),
-        session_for(&sub, None).await,
-        Path(LAW_ID.to_string()),
-    )
-    .await
-    .expect_err("law is not in the global corpus; expect 404");
+    // The global `state.corpus` is `CorpusState::empty()`, so the
+    // non-traject GET should 404.
+    let err = get_corpus_law(State(state), Path(LAW_ID.to_string()))
+        .await
+        .expect_err("law is not in the global corpus; expect 404");
 
     assert_eq!(err.0, StatusCode::NOT_FOUND, "{}", err.1);
 }
 
 #[tokio::test]
-async fn revoked_membership_falls_back_to_global_instead_of_403() {
+async fn revoked_membership_is_403_on_traject_read() {
     let db = TestDb::new().await;
     let state = empty_state(db.pool.clone());
     let (owner, sub) = seed_account(&db.pool, "alice@test.local").await;
@@ -234,30 +309,27 @@ async fn revoked_membership_falls_back_to_global_instead_of_403() {
     write_law(corpus.path(), "TRAJECT_CONTENT");
     let traject_id = local_traject(&db.pool, owner, corpus.path()).await;
 
-    // Yank the membership AFTER the session was issued — the stale
-    // session still carries the active traject id.
+    // Yank the membership AFTER the account got the traject URL — the
+    // per-request membership re-check must refuse the read.
     sqlx::query("DELETE FROM traject_members WHERE traject_id = $1")
         .bind(traject_id)
         .execute(&db.pool)
         .await
         .unwrap();
 
-    // Read should *not* 403; it should silently degrade to the global
-    // corpus (empty here, hence 404 — but the contract is "no 403").
-    let err = get_corpus_law(
+    let err = get_traject_corpus_law(
         State(state),
-        session_for(&sub, Some(traject_id)).await,
-        Path(LAW_ID.to_string()),
+        session_for(&sub).await,
+        Path((traject_ref(traject_id), LAW_ID.to_string())),
     )
     .await
-    .expect_err("global corpus is empty so the law isn't found");
-    assert_eq!(
-        err.0,
-        StatusCode::NOT_FOUND,
-        "revoked membership must degrade to global, not 403; got: {}",
-        err.1
-    );
+    .expect_err("revoked membership must refuse the traject read");
+    assert_eq!(err.0, StatusCode::FORBIDDEN, "{}", err.1);
 }
+
+// ---------------------------------------------------------------------------
+// Write-routing tests
+// ---------------------------------------------------------------------------
 
 /// Provision a traject with TWO local sources — a `seed` source at low
 /// priority that carries the existing law file, and a `writable_own`
@@ -342,6 +414,7 @@ async fn save_on_seed_loaded_law_lands_on_writable_own_backend() {
     // Seed has the law; writable_own starts empty.
     write_law(seed.path(), "SEED_VERSION");
     let traject_id = seeded_traject(&db.pool, owner, seed.path(), writable_own.path()).await;
+    let tref = traject_ref(traject_id);
 
     // Sanity check: pre-save, the writable_own dir does NOT have the
     // law file. The read falls through priority order and lands on
@@ -353,15 +426,22 @@ async fn save_on_seed_loaded_law_lands_on_writable_own_backend() {
         .join("2025-01-01.yaml");
     assert!(!writable_own_law_path.exists());
 
+    // The first edit of a federated law sends the ETag the GET served
+    // (computed from the SEED copy — the file doesn't exist on the
+    // writable_own yet). The If-Match check must fall back to the
+    // law's own source and pass, NOT 412 on the absent branch file.
+    let (etag, _body) = read_law(state.clone(), session_for(&sub).await, &tref).await;
     let new_body = format!("$id: {LAW_ID}\nname: SAVED_TO_WRITABLE_OWN\n");
-    let _ = save_law(
-        State(state.clone()),
-        session_for(&sub, Some(traject_id)).await,
-        Path(LAW_ID.to_string()),
+    let (status, _new_etag) = save_law_with(
+        state.clone(),
+        session_for(&sub).await,
+        &tref,
+        if_match_headers(&etag),
         new_body.clone(),
     )
     .await
-    .expect("save should succeed");
+    .expect("first If-Match save of a federated law should succeed");
+    assert_eq!(status, StatusCode::OK);
 
     // The file must now exist on the writable_own's backend root.
     // Before the fix the save silently landed on the seed source
@@ -381,4 +461,170 @@ async fn save_on_seed_loaded_law_lands_on_writable_own_backend() {
     let seed_text = std::fs::read_to_string(&seed_law_path).unwrap();
     assert!(seed_text.contains("SEED_VERSION"));
     assert!(!seed_text.contains("SAVED_TO_WRITABLE_OWN"));
+}
+
+// ---------------------------------------------------------------------------
+// Optimistic concurrency (ETag / If-Match) on law and scenario saves
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn law_save_with_matching_if_match_succeeds_and_chains_etag() {
+    let db = TestDb::new().await;
+    let state = empty_state(db.pool.clone());
+    let (owner, sub) = seed_account(&db.pool, "alice@test.local").await;
+
+    let corpus = tempfile::tempdir().unwrap();
+    write_law(corpus.path(), "V1");
+    let traject_id = local_traject(&db.pool, owner, corpus.path()).await;
+    let tref = traject_ref(traject_id);
+
+    // GET → ETag of the current content.
+    let (etag, _body) = read_law(state.clone(), session_for(&sub).await, &tref).await;
+
+    // PUT with that ETag as If-Match → success, response carries the
+    // NEW etag (of the saved body) for the next save to chain on.
+    let new_body = format!("$id: {LAW_ID}\nname: V2\n");
+    let (status, new_etag) = save_law_with(
+        state.clone(),
+        session_for(&sub).await,
+        &tref,
+        if_match_headers(&etag),
+        new_body.clone(),
+    )
+    .await
+    .expect("matching If-Match must succeed");
+    assert_eq!(status, StatusCode::OK);
+    let new_etag = new_etag.expect("save response must carry an ETag header");
+    assert_ne!(new_etag, etag);
+
+    // The new ETag matches what a fresh GET serves, so the chain holds.
+    let (get_etag, _body) = read_law(state, session_for(&sub).await, &tref).await;
+    assert_eq!(get_etag, new_etag);
+}
+
+#[tokio::test]
+async fn law_save_with_stale_if_match_is_412() {
+    let db = TestDb::new().await;
+    let state = empty_state(db.pool.clone());
+    let (owner, sub) = seed_account(&db.pool, "alice@test.local").await;
+
+    let corpus = tempfile::tempdir().unwrap();
+    write_law(corpus.path(), "V1");
+    let traject_id = local_traject(&db.pool, owner, corpus.path()).await;
+    let tref = traject_ref(traject_id);
+
+    // Member A loads the law…
+    let (stale_etag, _body) = read_law(state.clone(), session_for(&sub).await, &tref).await;
+
+    // …member B saves a new version in the meantime…
+    let b_body = format!("$id: {LAW_ID}\nname: B_WAS_HERE\n");
+    save_law_with(
+        state.clone(),
+        session_for(&sub).await,
+        &tref,
+        HeaderMap::new(),
+        b_body,
+    )
+    .await
+    .expect("B's save should succeed");
+
+    // …and A's save with the now-stale ETag must be refused with 412
+    // instead of silently overwriting B's work (the old last-write-wins).
+    let a_body = format!("$id: {LAW_ID}\nname: A_OVERWRITES\n");
+    let err = save_law_with(
+        state.clone(),
+        session_for(&sub).await,
+        &tref,
+        if_match_headers(&stale_etag),
+        a_body,
+    )
+    .await
+    .expect_err("stale If-Match must be refused");
+    assert_eq!(err.0, StatusCode::PRECONDITION_FAILED, "{}", err.1);
+
+    // B's version is still what a read returns.
+    let (_etag, body) = read_law(state, session_for(&sub).await, &tref).await;
+    assert!(body.contains("B_WAS_HERE"), "got: {body}");
+}
+
+#[tokio::test]
+async fn scenario_save_if_match_matrix() {
+    let db = TestDb::new().await;
+    let state = empty_state(db.pool.clone());
+    let (owner, sub) = seed_account(&db.pool, "alice@test.local").await;
+
+    let corpus = tempfile::tempdir().unwrap();
+    write_law(corpus.path(), "V1");
+    write_scenario(corpus.path(), "basis.feature", "Feature: v1\n");
+    let traject_id = local_traject(&db.pool, owner, corpus.path()).await;
+    let tref = traject_ref(traject_id);
+
+    // GET the scenario → ETag.
+    let (status, headers, body) = get_traject_scenario(
+        State(state.clone()),
+        session_for(&sub).await,
+        Path((
+            tref.clone(),
+            LAW_ID.to_string(),
+            "basis.feature".to_string(),
+        )),
+    )
+    .await
+    .expect("scenario GET must succeed");
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body, "Feature: v1\n");
+    let etag = headers
+        .iter()
+        .find(|(name, _)| name == axum::http::header::ETAG)
+        .map(|(_, value)| value.clone())
+        .expect("scenario GET must carry an ETag header");
+
+    // Matching If-Match → success.
+    let response = save_scenario(
+        State(state.clone()),
+        session_for(&sub).await,
+        Path((
+            tref.clone(),
+            LAW_ID.to_string(),
+            "basis.feature".to_string(),
+        )),
+        if_match_headers(&etag),
+        "Feature: v2\n".to_string(),
+    )
+    .await
+    .expect("matching If-Match must succeed");
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // The same (now stale) ETag again → 412.
+    let err = save_scenario(
+        State(state.clone()),
+        session_for(&sub).await,
+        Path((
+            tref.clone(),
+            LAW_ID.to_string(),
+            "basis.feature".to_string(),
+        )),
+        if_match_headers(&etag),
+        "Feature: v3-overschrijft\n".to_string(),
+    )
+    .await
+    .expect_err("stale If-Match must be refused");
+    assert_eq!(err.0, StatusCode::PRECONDITION_FAILED, "{}", err.1);
+
+    // No If-Match at all → permissive (backward compatibility, and the
+    // create path for brand-new scenario files).
+    let response = save_scenario(
+        State(state.clone()),
+        session_for(&sub).await,
+        Path((
+            tref.clone(),
+            LAW_ID.to_string(),
+            "nieuw.feature".to_string(),
+        )),
+        HeaderMap::new(),
+        "Feature: nieuw\n".to_string(),
+    )
+    .await
+    .expect("save without If-Match must stay permissive");
+    assert_eq!(response.status(), StatusCode::OK);
 }


### PR DESCRIPTION
## Problem

Traject **documents** already have full optimistic concurrency (`document_etag`, `enforce_if_match`, ETag headers, frontend If-Match echo), but **law** and **scenario** saves had none of it: two traject members editing the same law silently overwrote each other — blind last-write-wins.

## Approach

Extend the existing documents ETag pattern to laws and scenarios, reusing the same helpers instead of duplicating them:

**Backend** (`packages/editor-api/src/corpus_handlers.rs`)
- Law and scenario GETs (global + traject-scoped) now return an `ETag` header computed over the raw content (same SHA-256 scheme as documents, via the shared `document_etag`/`etagged_content_response`).
- `save_law` / `save_scenario` honor an optional `If-Match`: **412 Precondition Failed** on mismatch. The comparison matrix is extracted from `enforce_if_match` into a pure `check_if_match` shared by documents, laws and scenarios.
- Coherence with the per-source backend mutex: the current-content read for the check happens **while holding the write target's lock** (acquired by `resolve_traject_law_write`), so concurrent saves of the same law serialise and the loser gets a 412. For a federated law whose first traject edit hasn't landed on the writable-own branch yet, the check falls back to the law's own source backend — guarded by `law.source_id != write_source_id`, which guarantees a *different* mutex (tokio's `Mutex` is not reentrant).
- The save response carries the new ETag in both the `ETag` header and the body's `etag` field, mirroring `SaveDocumentResponse`.

**Frontend** (`useLaw.js`, `useScenarios.js`)
- Capture the ETag on read, echo it as `If-Match` on save, chain the new ETag from the save response (header authoritative, body fallback) — same flow as `useTrajectDocuments`.
- A 412 surfaces as a clear Dutch error ("… is intussen door iemand anders gewijzigd. Herlaad …") instead of a silent overwrite. EditorView's YAML save goes through `useLaw.saveLaw`, so it is covered.

## Backward compatibility

An **absent `If-Match` stays permissive** (blind write), exactly like the documents PUT: older clients, curl, and reads that carried no ETag keep working unchanged. The `etag` body field is `skip_serializing_if = None`, so annotation/delete responses are byte-identical.

## Test plan

- `just format` / `just lint` — pass.
- `cargo test -p regelrecht-editor-api --lib` — 41 passed (incl. new `check_if_match` matrix: stale → 412, match → ok, absent → permissive).
- `cargo test -p regelrecht-editor-api --test traject_reads_test` (Docker/testcontainers) — 8 passed, incl. handler-level: stale etag → 412 (the two-members race), matching etag → success + chained etag, absent header → permissive, and the federated first-edit fallback.
- `npm --prefix frontend test` — 278 passed (25 files), incl. new `useLaw.test.js` / `useScenarios.test.js` covering If-Match echo, etag chaining, no-precondition saves and the 412 path.

**Note:** `traject_reads_test.rs` predated the traject-ref-in-URL change and no longer compiled; this PR brings it back in sync. `save_annotations_test.rs` and `trajects_test.rs` have the same pre-existing drift (CI only runs fmt/clippy/check for editor-api) — left for a follow-up to keep this PR scoped.

## Review fixes

- **[MAJOR] Permanent 412 loop on federated scenarios**: traject-scoped scenario GET/list routed via `resolve_backend_for_law` (writable-own only when the *law* file exists there), while the `If-Match` check routed via the write target — a scenario saved before the law was ever saved in the traject kept being served from the seed with a stale ETag, so every retry 412'd. Scenario GET now reads through the same write-target-with-seed-fallback resolution the check uses (`read_traject_file_via_write_target`), and the list unions the write target's and the seed's listings. Routing rule extracted (`traject_write_source_id`) and shared with `resolve_traject_law_write` / `resolve_annotation_read_backend` / `current_content_for_write`; lock order stays writable-own → seed. Two regression tests added (both fail on the old routing).
- **[MINOR] `useScenarios.saveScenario` chained the etag across a law/traject switch**: snapshot the scope before the PUT and skip etag-chaining/`featureText`/`saveError` on mismatch (mirrors `useLaw.saveLaw`); new vitest case fails without the guard.
- **[MINOR] `save_annotations_test.rs`**: added `..` to the two `SaveResponse` destructures so the new `etag` field doesn't add fresh E0027s (the file's pre-existing drift stays out of scope).
- **[NIT] `useLaw.load()`**: always overwrite the law-cache entry with the freshly fetched content+etag instead of only on a cache miss.

Verification: `just format` / `just lint` pass; `cargo test -p regelrecht-editor-api --lib` 41 passed; `--test traject_reads_test` 10 passed (testcontainers); `npm --prefix frontend test` 279 passed.
