### PR TITLE
refactor(pipeline): canonical request-harvest path shared by editor and admin

### DIFF
--- a/packages/admin/src/handlers.rs
+++ b/packages/admin/src/handlers.rs
@@ -1,11 +1,12 @@
 use axum::extract::{Query, State};
 use axum::http::StatusCode;
 use axum::Json;
-use regelrecht_pipeline::job_queue::{
-    create_enrich_job_if_not_exists, create_job, CreateJobRequest,
+use regelrecht_pipeline::harvest_request::{
+    request_harvest, HarvestRequestOptions, HarvestRequestOutcome,
 };
-use regelrecht_pipeline::law_status::{set_enrich_job, set_harvest_job};
-use regelrecht_pipeline::{EnrichPayload, HarvestPayload, JobType, Priority, ENRICH_PROVIDERS};
+use regelrecht_pipeline::job_queue::{create_enrich_job_if_not_exists, CreateJobRequest};
+use regelrecht_pipeline::law_status::set_enrich_job;
+use regelrecht_pipeline::{EnrichPayload, JobType, Priority, ENRICH_PROVIDERS};
 use serde::{Deserialize, Serialize};
 
 use crate::error::ApiError;
@@ -162,7 +163,7 @@ pub async fn list_law_entries(
     // interpolating it into the query string is safe.
     let query_str = if params.status.is_some() {
         format!(
-            "SELECT law_id, law_name, status, coverage_score, \
+            "SELECT law_id, law_name, slug, status, coverage_score, \
              harvest_job_id, enrich_job_id, harvest_fail_count, enrich_fail_count, \
              created_at, updated_at \
              FROM law_entries WHERE status::text = $1 \
@@ -170,7 +171,7 @@ pub async fn list_law_entries(
         )
     } else {
         format!(
-            "SELECT law_id, law_name, status, coverage_score, \
+            "SELECT law_id, law_name, slug, status, coverage_score, \
              harvest_job_id, enrich_job_id, harvest_fail_count, enrich_fail_count, \
              created_at, updated_at \
              FROM law_entries \
@@ -324,7 +325,7 @@ pub async fn list_jobs(
     let sort_expr = job_sort_expression(sort_column);
     let data_sql = format!(
         "SELECT id, job_type, law_id, status, \
-         priority, payload, result, progress, attempts, max_attempts, created_at, updated_at, started_at, completed_at \
+         priority, payload, result, progress, attempts, max_attempts, created_at, updated_at, started_at, completed_at, scheduled_at \
          FROM jobs {where_sql} \
          ORDER BY {sort_expr} {order} LIMIT ${limit_idx} OFFSET ${offset_idx}"
     );
@@ -513,122 +514,43 @@ pub async fn create_harvest_job(
 
     let law_id = raw_id;
 
-    if let Some(ref date) = body.date {
-        // Use harvester's validator so admin and harvester agree on what
-        // counts as valid: format check, real date, and not in the future.
-        // Previously admin only checked format, so it accepted dates the
-        // harvester would later reject.
-        regelrecht_harvester::validate_date(date).map_err(|e| {
-            tracing::debug!(date, error = %e, "rejected invalid date");
-            ApiError::BadRequest(format!("invalid date: {e}"))
-        })?;
-    }
+    // All harvest-request semantics (advisory lock, dedup, exhausted check,
+    // date validation, law upsert + status + job link) live in the canonical
+    // pipeline function; this handler only parses input and maps the outcome.
+    let opts = HarvestRequestOptions {
+        priority: Priority::new(body.priority.unwrap_or(50)),
+        date: body.date,
+        law_name: None,
+        slug: None,
+    };
 
-    let pool = &state.pool;
-
-    let mut tx = pool
-        .begin()
-        .await
-        .map_err(db_err("failed to begin transaction"))?;
-
-    // Acquire an advisory lock keyed on the law_id to serialize concurrent requests
-    // for the same law. This prevents the TOCTOU race where two requests both see
-    // no existing job and both create one. The lock is released when the transaction
-    // commits or rolls back.
-    sqlx::query("SELECT pg_advisory_xact_lock(hashtext($1))")
-        .bind(&law_id)
-        .execute(&mut *tx)
-        .await
-        .map_err(|e| {
-            tracing::error!(error = %e, law_id = %law_id, "failed to acquire advisory lock");
-            ApiError::Internal("internal server error".to_string())
-        })?;
-
-    // Check for existing pending or processing harvest job to prevent duplicates.
-    let existing: Option<(sqlx::types::Uuid,)> = sqlx::query_as(
-        "SELECT id FROM jobs \
-         WHERE law_id = $1 AND job_type = 'harvest' AND status IN ('pending', 'processing') \
-         LIMIT 1",
-    )
-    .bind(&law_id)
-    .fetch_optional(&mut *tx)
-    .await
-    .map_err(|e| {
-        tracing::error!(error = %e, law_id = %law_id, "failed to check for existing jobs");
-        ApiError::Internal("failed to check for existing jobs".to_string())
-    })?;
-
-    if let Some((existing_id,)) = existing {
-        return Err(ApiError::Conflict(format!(
-            "a pending or processing harvest job already exists: {existing_id}"
-        )));
-    }
-
-    // Check if law is exhausted for harvest.
-    // RowNotFound is fine (new law, can't be exhausted); other errors should propagate.
-    match regelrecht_pipeline::law_status::get_law(&mut *tx, &law_id).await {
-        Ok(law) if law.status == regelrecht_pipeline::LawStatusValue::HarvestExhausted => {
-            return Err(ApiError::Conflict(format!("{law_id} is harvest_exhausted — reset via /api/law_entries/{law_id}/reset-exhausted first")));
+    match request_harvest(&state.pool, &law_id, opts).await {
+        Ok(HarvestRequestOutcome::Created(job)) => {
+            tracing::info!(job_id = %job.id, law_id = %law_id, "created harvest job");
+            Ok((
+                StatusCode::CREATED,
+                Json(CreateJobResponse {
+                    job_id: job.id.to_string(),
+                    law_id,
+                }),
+            ))
         }
-        Err(regelrecht_pipeline::PipelineError::LawNotFound(_)) => {}
+        Ok(HarvestRequestOutcome::AlreadyQueued { existing_job_id }) => {
+            Err(ApiError::Conflict(format!(
+                "a pending or processing harvest job already exists: {existing_job_id}"
+            )))
+        }
+        Ok(HarvestRequestOutcome::Exhausted) => Err(ApiError::Conflict(format!(
+            "{law_id} is harvest_exhausted — reset via /api/law_entries/{law_id}/reset-exhausted first"
+        ))),
+        Ok(HarvestRequestOutcome::InvalidDate { reason }) => {
+            Err(ApiError::BadRequest(format!("invalid date: {reason}")))
+        }
         Err(e) => {
-            tracing::error!(error = %e, "failed to check exhausted status");
-            return Err(ApiError::Internal(
-                "failed to check exhausted status".to_string(),
-            ));
+            tracing::error!(error = %e, law_id = %law_id, "failed to create harvest job");
+            Err(ApiError::Internal("failed to create harvest job".to_string()))
         }
-        Ok(_) => {}
     }
-
-    sqlx::query(
-        "INSERT INTO law_entries (law_id, status) \
-         VALUES ($1, 'queued') \
-         ON CONFLICT (law_id) DO UPDATE SET status = 'queued', updated_at = NOW() \
-         WHERE law_entries.status NOT IN ('harvesting', 'enriching')",
-    )
-    .bind(&law_id)
-    .execute(&mut *tx)
-    .await
-    .map_err(|e| {
-        tracing::error!(error = %e, law_id = %law_id, "failed to upsert law entry");
-        ApiError::Internal("failed to upsert law entry".to_string())
-    })?;
-
-    let payload = HarvestPayload::for_law(&law_id, body.date);
-
-    let priority = Priority::new(body.priority.unwrap_or(50));
-
-    let req = CreateJobRequest::new(JobType::Harvest, &law_id)
-        .with_priority(priority)
-        .with_payload(serde_json::to_value(&payload).map_err(|e| {
-            tracing::error!(error = %e, "failed to serialize payload");
-            ApiError::Internal("failed to serialize payload".to_string())
-        })?);
-
-    let job = create_job(&mut *tx, req).await.map_err(|e| {
-        tracing::error!(error = %e, law_id = %law_id, "failed to create harvest job");
-        ApiError::Internal("failed to create harvest job".to_string())
-    })?;
-
-    // Link the harvest job to the law entry.
-    set_harvest_job(&mut *tx, &law_id, job.id).await.map_err(|e| {
-        tracing::error!(error = %e, law_id = %law_id, job_id = %job.id, "failed to link harvest job to law entry");
-        ApiError::Internal("failed to link harvest job to law entry".to_string())
-    })?;
-
-    tx.commit()
-        .await
-        .map_err(db_err("failed to commit transaction"))?;
-
-    tracing::info!(job_id = %job.id, law_id = %law_id, "created harvest job");
-
-    Ok((
-        StatusCode::CREATED,
-        Json(CreateJobResponse {
-            job_id: job.id.to_string(),
-            law_id,
-        }),
-    ))
 }
 
 // --- Enrich Jobs ---
@@ -805,7 +727,7 @@ pub async fn get_job(
     let job = sqlx::query_as::<_, Job>(
         "SELECT id, job_type, law_id, status, \
          priority, payload, result, progress, attempts, max_attempts, \
-         created_at, updated_at, started_at, completed_at \
+         created_at, updated_at, started_at, completed_at, scheduled_at \
          FROM jobs WHERE id = $1",
     )
     .bind(uuid)

--- a/packages/admin/src/models.rs
+++ b/packages/admin/src/models.rs
@@ -1,7 +1,12 @@
-use chrono::{DateTime, Utc};
 use serde::Serialize;
 
-pub use regelrecht_pipeline::{JobStatus, JobType, LawStatusValue};
+// Row types come straight from the pipeline crate — admin reads the same
+// tables, so re-declaring them here only created drift (every migration had
+// to be mirrored by hand). Note the pipeline types carry two fields the old
+// admin copies dropped (`LawEntry.slug`, `Job.scheduled_at`); they now appear
+// in API responses, which is additive — the Vue frontend ignores unknown
+// fields.
+pub use regelrecht_pipeline::{Job, LawEntry};
 
 #[derive(Serialize)]
 pub struct PaginatedResponse<T: Serialize> {
@@ -9,36 +14,4 @@ pub struct PaginatedResponse<T: Serialize> {
     pub total: i64,
     pub limit: i64,
     pub offset: i64,
-}
-
-#[derive(Serialize, sqlx::FromRow)]
-pub struct LawEntry {
-    pub law_id: String,
-    pub law_name: Option<String>,
-    pub status: LawStatusValue,
-    pub coverage_score: Option<f64>,
-    pub harvest_job_id: Option<sqlx::types::Uuid>,
-    pub enrich_job_id: Option<sqlx::types::Uuid>,
-    pub harvest_fail_count: i32,
-    pub enrich_fail_count: i32,
-    pub created_at: DateTime<Utc>,
-    pub updated_at: DateTime<Utc>,
-}
-
-#[derive(Serialize, sqlx::FromRow)]
-pub struct Job {
-    pub id: sqlx::types::Uuid,
-    pub job_type: JobType,
-    pub law_id: String,
-    pub status: JobStatus,
-    pub priority: i32,
-    pub payload: Option<serde_json::Value>,
-    pub result: Option<serde_json::Value>,
-    pub progress: Option<serde_json::Value>,
-    pub attempts: i32,
-    pub max_attempts: i32,
-    pub created_at: DateTime<Utc>,
-    pub updated_at: DateTime<Utc>,
-    pub started_at: Option<DateTime<Utc>>,
-    pub completed_at: Option<DateTime<Utc>>,
 }

--- a/packages/admin/tests/handler_tests.rs
+++ b/packages/admin/tests/handler_tests.rs
@@ -308,6 +308,37 @@ async fn create_harvest_job_rejects_impossible_date() {
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 }
 
+#[tokio::test]
+async fn create_harvest_job_rejects_exhausted_law() {
+    let db = TestDb::new().await;
+    let app = test_app(db.pool.clone());
+
+    regelrecht_pipeline::law_status::upsert_law(&db.pool, "BWBR0018451", None, None)
+        .await
+        .unwrap();
+    regelrecht_pipeline::law_status::update_status(
+        &db.pool,
+        "BWBR0018451",
+        regelrecht_pipeline::LawStatusValue::HarvestExhausted,
+    )
+    .await
+    .unwrap();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/harvest-jobs")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"bwb_id": "BWBR0018451"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+}
+
 // --- list endpoints ---
 
 #[tokio::test]

--- a/packages/pipeline/src/api/harvest.rs
+++ b/packages/pipeline/src/api/harvest.rs
@@ -3,9 +3,8 @@ use axum::http::StatusCode;
 use axum::Json;
 use serde::{Deserialize, Serialize};
 
-use crate::job_queue::{self, CreateJobRequest};
-use crate::law_status;
-use crate::models::{JobType, LawStatusValue, Priority};
+use crate::harvest_request::{self, HarvestRequestOptions, HarvestRequestOutcome};
+use crate::models::Priority;
 
 use crate::ApiState;
 
@@ -169,19 +168,20 @@ async fn find_bwb_id_by_slug(
     Ok(row.map(|(law_id,)| law_id))
 }
 
-/// Create a high-priority harvest job, using the pipeline's existing job queue.
+/// Create a high-priority harvest job via the canonical pipeline entry point
+/// ([`harvest_request::request_harvest`]) and map the outcome onto the
+/// editor's status-string response shape.
 async fn create_harvest_job(state: &ApiState, bwb_id: &str, slug: Option<&str>) -> HarvestResponse {
-    let payload = serde_json::json!({ "bwb_id": bwb_id });
+    let opts = HarvestRequestOptions {
+        priority: Priority::new(EDITOR_HARVEST_PRIORITY),
+        // Editor harvests always want the latest consolidation.
+        date: None,
+        law_name: None,
+        slug: slug.map(|s| s.to_string()),
+    };
 
-    let req = CreateJobRequest::new(JobType::Harvest, bwb_id)
-        .with_priority(Priority::new(EDITOR_HARVEST_PRIORITY))
-        .with_payload(payload);
-
-    // Use the deduplicating variant — returns None if a pending/processing job
-    // already exists for this law. The `date` parameter is empty string to match
-    // any date (editor harvests always want the latest consolidation).
-    match job_queue::create_harvest_job_if_not_exists(&state.pool, req, "").await {
-        Ok(Some(job)) => {
+    let status = match harvest_request::request_harvest(&state.pool, bwb_id, opts).await {
+        Ok(HarvestRequestOutcome::Created(job)) => {
             tracing::info!(
                 job_id = %job.id,
                 bwb_id = %bwb_id,
@@ -189,48 +189,27 @@ async fn create_harvest_job(state: &ApiState, bwb_id: &str, slug: Option<&str>) 
                 priority = EDITOR_HARVEST_PRIORITY,
                 "created editor-requested harvest job"
             );
-
-            // Best-effort: upsert law_entry to 'queued' status and link job
-            let _ = law_status::upsert_law(&state.pool, bwb_id, None, slug).await;
-            // Don't downgrade a law that's already progressing or complete —
-            // protect in-progress states (Harvesting, Enriching) and finished
-            // states (Harvested, Enriched). Only Unknown / failed / queued
-            // laws get reset to Queued here.
-            let _ = law_status::update_status_unless_any(
-                &state.pool,
-                bwb_id,
-                &[
-                    LawStatusValue::Harvesting,
-                    LawStatusValue::Harvested,
-                    LawStatusValue::Enriching,
-                    LawStatusValue::Enriched,
-                ],
-                LawStatusValue::Queued,
-            )
-            .await;
-            let _ = law_status::set_harvest_job(&state.pool, bwb_id, job.id).await;
-
-            HarvestResponse {
-                bwb_id: bwb_id.to_string(),
-                status: "queued".to_string(),
-                slug: slug.map(|s| s.to_string()),
-            }
+            "queued"
         }
-        Ok(None) => {
-            // An active job already exists
-            HarvestResponse {
-                bwb_id: bwb_id.to_string(),
-                status: "already_queued".to_string(),
-                slug: slug.map(|s| s.to_string()),
-            }
+        Ok(HarvestRequestOutcome::AlreadyQueued { .. }) => "already_queued",
+        // The law is exhausted and must be reset via the admin UI first. The
+        // frontend already treats `harvest_exhausted` as a terminal status.
+        Ok(HarvestRequestOutcome::Exhausted) => "harvest_exhausted",
+        // Unreachable: the editor never sends a date. Treated as an error so
+        // it can't silently pass as "queued" if that ever changes.
+        Ok(HarvestRequestOutcome::InvalidDate { reason }) => {
+            tracing::error!(bwb_id = %bwb_id, reason = %reason, "unexpected invalid date on editor harvest path");
+            "error"
         }
         Err(e) => {
             tracing::error!(error = %e, bwb_id = %bwb_id, "failed to create harvest job");
-            HarvestResponse {
-                bwb_id: bwb_id.to_string(),
-                status: "error".to_string(),
-                slug: slug.map(|s| s.to_string()),
-            }
+            "error"
         }
+    };
+
+    HarvestResponse {
+        bwb_id: bwb_id.to_string(),
+        status: status.to_string(),
+        slug: slug.map(|s| s.to_string()),
     }
 }

--- a/packages/pipeline/src/harvest_request.rs
+++ b/packages/pipeline/src/harvest_request.rs
@@ -1,0 +1,173 @@
+//! Canonical "request a harvest" entry point.
+//!
+//! Both HTTP layers that accept harvest requests (the editor-facing pipeline
+//! API and the admin API) used to own divergent copies of this logic, with
+//! different dedup, exhausted-law and bookkeeping semantics. This module is
+//! the single implementation: advisory lock, dedup against active jobs, the
+//! `harvest_exhausted` check, date validation, and law-entry bookkeeping
+//! (upsert + status + job link) — all in one transaction, with every error
+//! propagated instead of discarded.
+//!
+//! The worker's follow-up path (re-harvesting laws referenced by a completed
+//! harvest) deliberately stays on
+//! [`crate::job_queue::create_harvest_job_if_not_exists`]: it runs in a hot
+//! loop over many laws and intentionally does no per-law status bookkeeping.
+
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use crate::error::{PipelineError, Result};
+use crate::harvest::HarvestPayload;
+use crate::job_queue::{self, CreateJobRequest};
+use crate::law_status;
+use crate::models::{Job, JobType, LawStatusValue, Priority};
+
+/// Options for a harvest request. `Default` gives the standard pipeline
+/// priority (50) and no date/name/slug.
+#[derive(Debug, Default)]
+pub struct HarvestRequestOptions {
+    /// Job priority (higher = processed first).
+    pub priority: Priority,
+    /// Requested consolidation date (`YYYY-MM-DD`). `None` means the
+    /// harvester resolves the latest consolidation itself.
+    pub date: Option<String>,
+    /// Human-readable law name to store on the law entry, if known.
+    pub law_name: Option<String>,
+    /// Law slug to store on the law entry, if known.
+    pub slug: Option<String>,
+}
+
+/// Outcome of a harvest request. Designed so each HTTP layer can map it onto
+/// its existing response shape (created / already queued / exhausted /
+/// invalid date) without re-implementing any of the decision logic.
+#[derive(Debug)]
+pub enum HarvestRequestOutcome {
+    /// A new harvest job was created and linked to the law entry.
+    Created(Job),
+    /// A pending or processing harvest job already exists for this law.
+    AlreadyQueued { existing_job_id: Uuid },
+    /// The law is `harvest_exhausted`; it must be reset before re-queueing.
+    Exhausted,
+    /// The requested date failed validation (format, impossible, or future).
+    InvalidDate { reason: String },
+}
+
+/// Request a harvest for `law_id`, creating a job plus the law-status
+/// bookkeeping in a single transaction.
+///
+/// Semantics (the union of what the editor and admin paths used to do):
+/// - the requested `date` is validated up front ([`HarvestRequestOutcome::InvalidDate`]);
+/// - a transaction-scoped advisory lock on the law id serialises concurrent
+///   requests (no TOCTOU between the dedup check and the insert);
+/// - an existing pending/processing harvest job short-circuits to
+///   [`HarvestRequestOutcome::AlreadyQueued`];
+/// - a `harvest_exhausted` law is refused ([`HarvestRequestOutcome::Exhausted`]);
+/// - the law entry is upserted (name/slug) and its status set to `queued`
+///   unless it is currently in an in-progress state (`harvesting`/`enriching`),
+///   and the new job is linked via `harvest_job_id`.
+///
+/// All bookkeeping failures roll back the transaction and propagate — they
+/// are never silently discarded.
+///
+/// The caller is responsible for validating the *shape* of `law_id` (BWB vs
+/// CVDR prefix, slug resolution); this function treats it as an opaque key.
+#[tracing::instrument(skip(pool, opts), fields(priority = opts.priority.value(), date = opts.date.as_deref()))]
+pub async fn request_harvest(
+    pool: &PgPool,
+    law_id: &str,
+    opts: HarvestRequestOptions,
+) -> Result<HarvestRequestOutcome> {
+    if let Some(ref date) = opts.date {
+        if let Err(e) = regelrecht_harvester::validate_date(date) {
+            tracing::debug!(law_id = %law_id, date = %date, error = %e, "rejected harvest request: invalid date");
+            return Ok(HarvestRequestOutcome::InvalidDate {
+                reason: e.to_string(),
+            });
+        }
+    }
+
+    let mut tx = pool.begin().await?;
+
+    // Serialize concurrent requests for the same law. This prevents the
+    // TOCTOU race where two requests both see no existing job and both
+    // create one. Released on commit/rollback.
+    sqlx::query("SELECT pg_advisory_xact_lock(hashtext($1))")
+        .bind(law_id)
+        .execute(&mut *tx)
+        .await?;
+
+    // Dedup: an active (pending/processing) harvest job means there is
+    // nothing to do.
+    let existing: Option<(Uuid,)> = sqlx::query_as(
+        "SELECT id FROM jobs \
+         WHERE law_id = $1 AND job_type = 'harvest' AND status IN ('pending', 'processing') \
+         LIMIT 1",
+    )
+    .bind(law_id)
+    .fetch_optional(&mut *tx)
+    .await?;
+
+    if let Some((existing_job_id,)) = existing {
+        tracing::info!(law_id = %law_id, existing_job_id = %existing_job_id, "harvest request deduplicated: active job exists");
+        return Ok(HarvestRequestOutcome::AlreadyQueued { existing_job_id });
+    }
+
+    // Refuse exhausted laws. LawNotFound is fine (a new law cannot be
+    // exhausted); other errors propagate.
+    match law_status::get_law(&mut *tx, law_id).await {
+        Ok(law) if law.status == LawStatusValue::HarvestExhausted => {
+            tracing::info!(law_id = %law_id, "harvest request refused: law is harvest_exhausted");
+            return Ok(HarvestRequestOutcome::Exhausted);
+        }
+        Ok(_) | Err(PipelineError::LawNotFound(_)) => {}
+        Err(e) => return Err(e),
+    }
+
+    // Bookkeeping: upsert the entry (name/slug) and mark it queued unless an
+    // in-progress state would be overwritten. Errors roll the whole request
+    // back — job creation and status must stay consistent.
+    law_status::upsert_law(
+        &mut *tx,
+        law_id,
+        opts.law_name.as_deref(),
+        opts.slug.as_deref(),
+    )
+    .await?;
+    law_status::update_status_unless_any(
+        &mut *tx,
+        law_id,
+        &[LawStatusValue::Harvesting, LawStatusValue::Enriching],
+        LawStatusValue::Queued,
+    )
+    .await?;
+
+    let payload = HarvestPayload::for_law(law_id, opts.date.clone());
+    let req = CreateJobRequest::new(JobType::Harvest, law_id)
+        .with_priority(opts.priority)
+        .with_payload(serde_json::to_value(&payload).map_err(|e| {
+            PipelineError::InvalidInput(format!("failed to serialize harvest payload: {e}"))
+        })?);
+
+    let job = job_queue::create_job(&mut *tx, req).await?;
+
+    law_status::set_harvest_job(&mut *tx, law_id, job.id).await?;
+
+    tx.commit().await?;
+
+    tracing::info!(job_id = %job.id, law_id = %law_id, "harvest job created");
+    Ok(HarvestRequestOutcome::Created(job))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn options_default_uses_standard_priority() {
+        let opts = HarvestRequestOptions::default();
+        assert_eq!(opts.priority.value(), Priority::default().value());
+        assert!(opts.date.is_none());
+        assert!(opts.law_name.is_none());
+        assert!(opts.slug.is_none());
+    }
+}

--- a/packages/pipeline/src/harvest_request.rs
+++ b/packages/pipeline/src/harvest_request.rs
@@ -148,7 +148,42 @@ pub async fn request_harvest(
             PipelineError::InvalidInput(format!("failed to serialize harvest payload: {e}"))
         })?);
 
-    let job = job_queue::create_job(&mut *tx, req).await?;
+    let job = match job_queue::create_job(&mut *tx, req).await {
+        Ok(job) => job,
+        // The worker's follow-up path deliberately skips the advisory lock,
+        // so its insert can land between our dedup SELECT and this one; the
+        // partial unique index then rejects ours (23505). Report that as
+        // AlreadyQueued — the translation `create_harvest_job_if_not_exists`
+        // already applies — instead of surfacing an error.
+        Err(PipelineError::Database(sqlx::Error::Database(ref db_err)))
+            if db_err.code().as_deref() == Some("23505") =>
+        {
+            // The transaction is aborted after the constraint violation; drop
+            // it (rollback) to release the advisory lock, then look up the
+            // winning job outside the transaction.
+            drop(tx);
+            let existing: Option<(Uuid,)> = sqlx::query_as(
+                "SELECT id FROM jobs \
+                 WHERE law_id = $1 AND job_type = 'harvest' AND status IN ('pending', 'processing') \
+                 LIMIT 1",
+            )
+            .bind(law_id)
+            .fetch_optional(pool)
+            .await?;
+            return match existing {
+                Some((existing_job_id,)) => {
+                    tracing::info!(law_id = %law_id, existing_job_id = %existing_job_id, "harvest request lost insert race: active job exists");
+                    Ok(HarvestRequestOutcome::AlreadyQueued { existing_job_id })
+                }
+                // The racing job left pending/processing in the same instant —
+                // vanishingly rare; surface as a retryable error.
+                None => Err(PipelineError::Worker(format!(
+                    "harvest job insert for {law_id} lost a race and the winning job is already gone; retry"
+                ))),
+            };
+        }
+        Err(e) => return Err(e),
+    };
 
     law_status::set_harvest_job(&mut *tx, law_id, job.id).await?;
 

--- a/packages/pipeline/src/job_queue.rs
+++ b/packages/pipeline/src/job_queue.rs
@@ -303,8 +303,12 @@ where
 /// Create a harvest job only if no active (pending/processing) harvest job
 /// exists for this law.
 ///
+/// Used by the worker's follow-up path (re-harvesting referenced laws). HTTP
+/// harvest requests go through [`crate::harvest_request::request_harvest`]
+/// instead, which adds the exhausted check and law-status bookkeeping.
+///
 /// Completed and failed jobs never block: a law that was harvested before
-/// must remain re-harvestable (e.g. via the editor's `POST /harvest`).
+/// must remain re-harvestable.
 ///
 /// The fast path uses `INSERT ... WHERE NOT EXISTS` (filtered by date) to
 /// avoid a round-trip for the common non-racing case. When two requests race

--- a/packages/pipeline/src/lib.rs
+++ b/packages/pipeline/src/lib.rs
@@ -6,6 +6,7 @@ pub mod enrich;
 pub mod error;
 pub mod feature_flags;
 pub mod harvest;
+pub mod harvest_request;
 pub mod health;
 pub mod job_queue;
 pub mod law_status;
@@ -24,4 +25,5 @@ pub use enrich::{
 };
 pub use error::PipelineError;
 pub use harvest::{HarvestPayload, HarvestResult, MAX_HARVEST_DEPTH};
+pub use harvest_request::{request_harvest, HarvestRequestOptions, HarvestRequestOutcome};
 pub use models::{FeatureFlag, Job, JobStatus, JobType, LawEntry, LawStatusValue, Priority};

--- a/packages/pipeline/src/lib.rs
+++ b/packages/pipeline/src/lib.rs
@@ -25,5 +25,8 @@ pub use enrich::{
 };
 pub use error::PipelineError;
 pub use harvest::{HarvestPayload, HarvestResult, MAX_HARVEST_DEPTH};
-pub use harvest_request::{request_harvest, HarvestRequestOptions, HarvestRequestOutcome};
+// Deliberately no crate-root re-export of the `request_harvest` fn: the axum
+// handler `api::harvest::request_harvest` shares that name, so callers import
+// it path-qualified via the module.
+pub use harvest_request::{HarvestRequestOptions, HarvestRequestOutcome};
 pub use models::{FeatureFlag, Job, JobStatus, JobType, LawEntry, LawStatusValue, Priority};

--- a/packages/pipeline/tests/harvest_request_tests.rs
+++ b/packages/pipeline/tests/harvest_request_tests.rs
@@ -1,0 +1,238 @@
+use pretty_assertions::assert_eq;
+
+use regelrecht_pipeline::harvest_request::{
+    request_harvest, HarvestRequestOptions, HarvestRequestOutcome,
+};
+use regelrecht_pipeline::law_status;
+use regelrecht_pipeline::models::{JobStatus, JobType, LawStatusValue, Priority};
+use regelrecht_pipeline::test_utils::TestDb;
+use regelrecht_pipeline::{job_queue, HarvestPayload};
+
+const LAW_ID: &str = "BWBR0018451";
+
+fn opts() -> HarvestRequestOptions {
+    HarvestRequestOptions::default()
+}
+
+#[tokio::test]
+async fn creates_job_and_bookkeeping() {
+    let db = TestDb::new().await;
+
+    let outcome = request_harvest(&db.pool, LAW_ID, opts()).await.unwrap();
+
+    let HarvestRequestOutcome::Created(job) = outcome else {
+        panic!("expected Created, got {outcome:?}");
+    };
+    assert_eq!(job.law_id, LAW_ID);
+    assert_eq!(job.job_type, JobType::Harvest);
+    assert_eq!(job.status, JobStatus::Pending);
+    assert_eq!(job.priority, 50);
+
+    // Payload uses the canonical HarvestPayload shape.
+    let payload: HarvestPayload = serde_json::from_value(job.payload.clone().unwrap()).unwrap();
+    assert_eq!(payload.bwb_id.as_deref(), Some(LAW_ID));
+    assert!(payload.date.is_none());
+
+    // Law entry was upserted, queued, and linked to the job.
+    let entry = law_status::get_law(&db.pool, LAW_ID).await.unwrap();
+    assert_eq!(entry.status, LawStatusValue::Queued);
+    assert_eq!(entry.harvest_job_id, Some(job.id));
+}
+
+#[tokio::test]
+async fn stores_priority_date_and_slug() {
+    let db = TestDb::new().await;
+
+    let outcome = request_harvest(
+        &db.pool,
+        LAW_ID,
+        HarvestRequestOptions {
+            priority: Priority::new(80),
+            date: Some("2024-01-01".to_string()),
+            law_name: Some("Zorgtoeslagwet".to_string()),
+            slug: Some("wet_op_de_zorgtoeslag".to_string()),
+        },
+    )
+    .await
+    .unwrap();
+
+    let HarvestRequestOutcome::Created(job) = outcome else {
+        panic!("expected Created, got {outcome:?}");
+    };
+    assert_eq!(job.priority, 80);
+
+    let payload: HarvestPayload = serde_json::from_value(job.payload.clone().unwrap()).unwrap();
+    assert_eq!(payload.date.as_deref(), Some("2024-01-01"));
+
+    let entry = law_status::get_law(&db.pool, LAW_ID).await.unwrap();
+    assert_eq!(entry.law_name.as_deref(), Some("Zorgtoeslagwet"));
+    assert_eq!(entry.slug.as_deref(), Some("wet_op_de_zorgtoeslag"));
+}
+
+#[tokio::test]
+async fn cvdr_id_produces_cvdr_payload() {
+    let db = TestDb::new().await;
+
+    let outcome = request_harvest(&db.pool, "CVDR681386", opts())
+        .await
+        .unwrap();
+
+    let HarvestRequestOutcome::Created(job) = outcome else {
+        panic!("expected Created, got {outcome:?}");
+    };
+    let payload: HarvestPayload = serde_json::from_value(job.payload.clone().unwrap()).unwrap();
+    assert!(payload.bwb_id.is_none());
+    assert_eq!(payload.cvdr_id.as_deref(), Some("CVDR681386"));
+}
+
+#[tokio::test]
+async fn dedups_against_active_job() {
+    let db = TestDb::new().await;
+
+    let first = request_harvest(&db.pool, LAW_ID, opts()).await.unwrap();
+    let HarvestRequestOutcome::Created(first_job) = first else {
+        panic!("expected Created, got {first:?}");
+    };
+
+    let second = request_harvest(&db.pool, LAW_ID, opts()).await.unwrap();
+    let HarvestRequestOutcome::AlreadyQueued { existing_job_id } = second else {
+        panic!("expected AlreadyQueued, got {second:?}");
+    };
+    assert_eq!(existing_job_id, first_job.id);
+}
+
+#[tokio::test]
+async fn dedups_against_dated_job() {
+    let db = TestDb::new().await;
+
+    // A pending job WITH a date must also block an undated request — the old
+    // editor path missed this (it only deduped against undated jobs).
+    let dated = request_harvest(
+        &db.pool,
+        LAW_ID,
+        HarvestRequestOptions {
+            date: Some("2024-01-01".to_string()),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    assert!(matches!(dated, HarvestRequestOutcome::Created(_)));
+
+    let undated = request_harvest(&db.pool, LAW_ID, opts()).await.unwrap();
+    assert!(matches!(
+        undated,
+        HarvestRequestOutcome::AlreadyQueued { .. }
+    ));
+}
+
+#[tokio::test]
+async fn allows_requeue_after_completion() {
+    let db = TestDb::new().await;
+
+    let first = request_harvest(&db.pool, LAW_ID, opts()).await.unwrap();
+    let HarvestRequestOutcome::Created(first_job) = first else {
+        panic!("expected Created, got {first:?}");
+    };
+
+    let claimed = job_queue::claim_job(&db.pool, Some(JobType::Harvest))
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(claimed.id, first_job.id);
+    job_queue::complete_job(&db.pool, claimed.id, None)
+        .await
+        .unwrap();
+
+    let second = request_harvest(&db.pool, LAW_ID, opts()).await.unwrap();
+    assert!(matches!(second, HarvestRequestOutcome::Created(_)));
+}
+
+#[tokio::test]
+async fn refuses_exhausted_law() {
+    let db = TestDb::new().await;
+
+    law_status::upsert_law(&db.pool, LAW_ID, None, None)
+        .await
+        .unwrap();
+    law_status::update_status(&db.pool, LAW_ID, LawStatusValue::HarvestExhausted)
+        .await
+        .unwrap();
+
+    let outcome = request_harvest(&db.pool, LAW_ID, opts()).await.unwrap();
+    assert!(matches!(outcome, HarvestRequestOutcome::Exhausted));
+
+    // No job was created and the status was left untouched.
+    let jobs = job_queue::list_jobs(&db.pool, None).await.unwrap();
+    assert!(jobs.is_empty());
+    let entry = law_status::get_law(&db.pool, LAW_ID).await.unwrap();
+    assert_eq!(entry.status, LawStatusValue::HarvestExhausted);
+}
+
+#[tokio::test]
+async fn rejects_invalid_date_before_touching_db() {
+    let db = TestDb::new().await;
+
+    for bad_date in ["not-a-date", "2025-13-01", "9999-01-01"] {
+        let outcome = request_harvest(
+            &db.pool,
+            LAW_ID,
+            HarvestRequestOptions {
+                date: Some(bad_date.to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert!(
+            matches!(outcome, HarvestRequestOutcome::InvalidDate { .. }),
+            "expected InvalidDate for {bad_date}, got {outcome:?}"
+        );
+    }
+
+    // Nothing was written.
+    let jobs = job_queue::list_jobs(&db.pool, None).await.unwrap();
+    assert!(jobs.is_empty());
+    assert!(law_status::get_law(&db.pool, LAW_ID).await.is_err());
+}
+
+#[tokio::test]
+async fn does_not_downgrade_in_progress_status() {
+    let db = TestDb::new().await;
+
+    // A law stuck in 'harvesting' without an active job (e.g. its job was
+    // deleted) can be re-queued, but the in-progress status must not be
+    // overwritten by the bookkeeping.
+    law_status::upsert_law(&db.pool, LAW_ID, None, None)
+        .await
+        .unwrap();
+    law_status::update_status(&db.pool, LAW_ID, LawStatusValue::Harvesting)
+        .await
+        .unwrap();
+
+    let outcome = request_harvest(&db.pool, LAW_ID, opts()).await.unwrap();
+    assert!(matches!(outcome, HarvestRequestOutcome::Created(_)));
+
+    let entry = law_status::get_law(&db.pool, LAW_ID).await.unwrap();
+    assert_eq!(entry.status, LawStatusValue::Harvesting);
+}
+
+#[tokio::test]
+async fn resets_completed_status_to_queued() {
+    let db = TestDb::new().await;
+
+    // Re-harvesting an already-harvested law marks it queued again — the new
+    // pending job is the source of truth (admin semantics, now canonical).
+    law_status::upsert_law(&db.pool, LAW_ID, None, None)
+        .await
+        .unwrap();
+    law_status::update_status(&db.pool, LAW_ID, LawStatusValue::Harvested)
+        .await
+        .unwrap();
+
+    let outcome = request_harvest(&db.pool, LAW_ID, opts()).await.unwrap();
+    assert!(matches!(outcome, HarvestRequestOutcome::Created(_)));
+
+    let entry = law_status::get_law(&db.pool, LAW_ID).await.unwrap();
+    assert_eq!(entry.status, LawStatusValue::Queued);
+}


### PR DESCRIPTION
## Problem

Three components owned divergent "create a harvest job" logic against the same tables:

1. **Editor-facing pipeline API** (`packages/pipeline/src/api/harvest.rs`) — no `harvest_exhausted` check, and three bare `let _ =` silently swallowing law-status bookkeeping errors (upsert, status update, job link).
2. **Admin API** (`packages/admin/src/handlers.rs`) — advisory lock + pending/processing dedup + `harvest_exhausted` check + date validation, all inline in the handler.
3. **Worker auto-retry/follow-up** (`packages/pipeline/src/worker.rs`) — its own dedup via `create_harvest_job_if_not_exists`.

Consequences: a `harvest_exhausted` law could be re-queued via the editor but was refused by admin; date validation existed only on the admin path; bookkeeping failures on the editor path were invisible. On top of that, `packages/admin/src/models.rs` re-declared `Job` and `LawEntry` field-for-field from the pipeline crate, so every migration had to be mirrored by hand.

## Change

### Canonical function

New `regelrecht_pipeline::harvest_request::request_harvest(pool, law_id, opts) -> Result<HarvestRequestOutcome>`:

- validates the requested date up front (harvester's validator: format, real date, not in the future);
- takes a transaction-scoped advisory lock on the law id (no TOCTOU between dedup and insert);
- dedups against any pending/processing harvest job;
- refuses `harvest_exhausted` laws;
- upserts the law entry (name/slug), sets status to `queued` unless the law is in an in-progress state (`harvesting`/`enriching`), creates the job and links `harvest_job_id` — all in one transaction, with every error propagated instead of discarded.

The `HarvestRequestOutcome` enum (`Created` / `AlreadyQueued` / `Exhausted` / `InvalidDate`) lets both HTTP layers stay thin: parse/validate input, call the function, map the outcome onto their existing response shapes. Admin keeps its exact status codes and messages (201, 409 with job id, 409 exhausted hint, 400 invalid date); the editor keeps its status-string JSON shape.

### Deliberate behavior changes (editor path, adopting admin semantics)

- **Exhausted laws are now refused**: the editor endpoint returns status `"harvest_exhausted"` instead of happily re-queueing. The editor frontend already treats `harvest_exhausted` as a terminal status (same string the status-poll endpoint emits), so no frontend change is needed.
- **Dedup covers dated jobs**: previously the editor only deduped against undated active jobs, so a pending admin job with a date let the editor create a duplicate. Now any active harvest job short-circuits to `already_queued`.
- **Bookkeeping errors are no longer silent**: a failed upsert/status/link now rolls back the whole request and surfaces as `"error"` (previously the job was created and the failures vanished).
- **Re-harvesting a harvested/enriched law resets its status to `queued`**: the new pending job is the source of truth — this is what admin always did; the editor used to keep `harvested`/`enriched` in place.

### Worker follow-up path

Deliberately left on `create_harvest_job_if_not_exists`: it runs in a hot loop over referenced laws, intentionally does no per-law status bookkeeping, and keeps its own depth/exhausted handling. Folding it in would add a transaction + advisory lock + law-entry writes per referenced law for no behavioral gain. Its doc comment now points HTTP callers at the canonical function.

### Row-type dedup

`packages/admin/src/models.rs` now re-exports `regelrecht_pipeline::{Job, LawEntry}` instead of re-declaring them; only the admin-specific `PaginatedResponse` remains. Admin queries select the two columns the old copies dropped (`law_entries.slug`, `jobs.scheduled_at`), so those fields now appear in admin API responses. This is purely additive JSON — the Vue frontend reads only the fields it knows (verified: no `.slug`/`scheduled_at` consumers in `packages/admin/frontend-src`) — and removes the last reason to hand-mirror migrations.

## Tests

- New `packages/pipeline/tests/harvest_request_tests.rs` (10 tests): created (+payload/bookkeeping/link), priority/date/slug propagation, CVDR payload, dedup (incl. dated-job case), re-queue after completion, exhausted refusal, invalid-date rejection without DB writes, in-progress status protection, harvested→queued reset.
- New admin handler test: POST `/api/harvest-jobs` on an exhausted law → 409.
- All existing admin handler tests (created/duplicate/invalid-date/impossible-date/after-completion) pass unchanged, pinning the external behavior.

`just format`, `just lint`, `just build-check`, `just pipeline-test` (41 passed), `just pipeline-integration-test` (10+12+19+14 passed), `just admin-test` (64+64 unit, 16 integration passed) — all green locally.