### PR TITLE
perf(editor): ttl-refresh traject index snapshots, bound body cache, implements index

### DIFF
--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -751,6 +757,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "criterion"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1404,6 +1419,16 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fluent-uri"
@@ -2516,6 +2541,16 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -3719,12 +3754,14 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
+ "flate2",
  "jsonschema",
  "regelrecht-engine",
  "reqwest 0.13.2",
  "serde",
  "serde_json",
  "serde_yaml_ng",
+ "tar",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -4501,6 +4538,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4942,6 +4985,17 @@ checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]

--- a/packages/corpus/Cargo.toml
+++ b/packages/corpus/Cargo.toml
@@ -21,14 +21,17 @@ reqwest = { version = "0.13", default-features = false, features = ["json", "rus
 serde_json = { workspace = true, optional = true }
 jsonschema = { version = "0.46", optional = true }
 base64 = { workspace = true, optional = true }
+flate2 = { version = "1", optional = true }
+tar = { version = "0.4", optional = true }
 walkdir.workspace = true
 
 [features]
 default = ["github"]
 # The GitHub API backend (write path through Contents/Refs API) needs
 # JSON bodies and base64-encoded file contents, so `github` pulls both
-# in alongside reqwest.
-github = ["dep:reqwest", "dep:serde_json", "dep:base64"]
+# in alongside reqwest. The implements-index bulk read downloads the repo
+# archive (tarball) in one request, so it also needs gzip + tar.
+github = ["dep:reqwest", "dep:serde_json", "dep:base64", "dep:flate2", "dep:tar"]
 # Schema validation for note (annotation) YAML. Pulls in jsonschema; only
 # the editor-api write path needs it, so it stays optional.
 annotation-validation = ["dep:jsonschema", "dep:serde_json"]

--- a/packages/corpus/src/backend.rs
+++ b/packages/corpus/src/backend.rs
@@ -130,24 +130,31 @@ pub trait RepoBackend: Send + Sync {
             .collect())
     }
 
-    /// Read every file under the source in as few requests as possible,
-    /// optionally filtered by extension (without the dot). Returns
-    /// `(source-relative path, content)` pairs, forward-slashed.
+    /// Return every YAML law's `implements` list as `(source-relative
+    /// path, implements)` pairs — the input the implements/“who implements
+    /// me” index is built from — reading bodies in as few requests as
+    /// possible.
     ///
-    /// The default implementation degrades to one [`list_files_recursive`]
-    /// plus a [`read_file`] per entry — correct, but one request per file.
-    /// A backend that can fetch in bulk (the GitHub API backend downloads
-    /// the repo archive in a single request) should override this so a
-    /// corpus-wide scan does not fan out into thousands of calls.
+    /// Returns parsed `implements` lists, NOT bodies, on purpose: a
+    /// corpus-wide scan must never hold every law body in memory at once
+    /// (that OOMs on a large corpus). The default implementation reads one
+    /// file at a time via [`list_files_recursive`] + [`read_file`], parsing
+    /// and dropping each body as it goes. A backend that can fetch in bulk
+    /// (the GitHub API backend downloads the repo archive in a single
+    /// request) overrides this — but still streams bodies through the
+    /// parser one at a time.
     ///
     /// [`list_files_recursive`]: RepoBackend::list_files_recursive
     /// [`read_file`]: RepoBackend::read_file
-    async fn read_all_files(&self, extension: Option<&str>) -> Result<Vec<(String, String)>> {
-        let entries = self.list_files_recursive(Path::new(""), extension).await?;
+    async fn read_all_implements(&self) -> Result<Vec<(String, Vec<String>)>> {
+        let entries = self
+            .list_files_recursive(Path::new(""), Some("yaml"))
+            .await?;
         let mut out = Vec::with_capacity(entries.len());
         for entry in entries {
             if let Some(content) = self.read_file(Path::new(&entry.relative_path)).await? {
-                out.push((entry.relative_path, content));
+                let implements = crate::source_map::collect_law_implements(&content);
+                out.push((entry.relative_path, implements));
             }
         }
         Ok(out)

--- a/packages/corpus/src/backend.rs
+++ b/packages/corpus/src/backend.rs
@@ -130,6 +130,29 @@ pub trait RepoBackend: Send + Sync {
             .collect())
     }
 
+    /// Read every file under the source in as few requests as possible,
+    /// optionally filtered by extension (without the dot). Returns
+    /// `(source-relative path, content)` pairs, forward-slashed.
+    ///
+    /// The default implementation degrades to one [`list_files_recursive`]
+    /// plus a [`read_file`] per entry — correct, but one request per file.
+    /// A backend that can fetch in bulk (the GitHub API backend downloads
+    /// the repo archive in a single request) should override this so a
+    /// corpus-wide scan does not fan out into thousands of calls.
+    ///
+    /// [`list_files_recursive`]: RepoBackend::list_files_recursive
+    /// [`read_file`]: RepoBackend::read_file
+    async fn read_all_files(&self, extension: Option<&str>) -> Result<Vec<(String, String)>> {
+        let entries = self.list_files_recursive(Path::new(""), extension).await?;
+        let mut out = Vec::with_capacity(entries.len());
+        for entry in entries {
+            if let Some(content) = self.read_file(Path::new(&entry.relative_path)).await? {
+                out.push((entry.relative_path, content));
+            }
+        }
+        Ok(out)
+    }
+
     /// Persist pending changes.
     ///
     /// No-op for local backends. For git backends this commits dirty files

--- a/packages/corpus/src/github.rs
+++ b/packages/corpus/src/github.rs
@@ -649,6 +649,59 @@ mod inner {
             Ok(Some((content, item.sha)))
         }
 
+        /// Download every YAML file in the repo at `git_ref` in a SINGLE
+        /// request via the archive (tarball) endpoint, instead of one
+        /// Contents call per file. Returns `(repo-relative path, content)`
+        /// pairs for `.yaml`/`.yml` files; the archive's top-level
+        /// `{owner}-{repo}-{sha}/` directory component is stripped so the
+        /// paths line up with the Trees/Contents APIs.
+        ///
+        /// GitHub answers the tarball endpoint with a 302 to a short-lived
+        /// codeload URL (carrying its own token), which reqwest follows
+        /// automatically — so this works for private repos with just the
+        /// Bearer token on the initial request.
+        pub async fn fetch_archive(
+            &mut self,
+            repo: &str,
+            git_ref: &str,
+            token: Option<&str>,
+        ) -> Result<Vec<(String, String)>> {
+            let url = format!("{}/repos/{}/tarball/{}", self.api_base, repo, git_ref);
+            let headers = self.default_headers(token);
+            let response = self
+                .client
+                .get(&url)
+                .headers(headers)
+                .send()
+                .await
+                .map_err(|e| CorpusError::Git(format!("GitHub archive request failed: {}", e)))?;
+            self.track_rate_limit(&response);
+
+            if !response.status().is_success() {
+                return Err(CorpusError::Git(format!(
+                    "GitHub archive API returned {} for {}: {}",
+                    response.status(),
+                    repo,
+                    response.text().await.unwrap_or_default()
+                )));
+            }
+
+            let bytes = response
+                .bytes()
+                .await
+                .map_err(|e| CorpusError::Git(format!("Failed to read archive body: {}", e)))?;
+
+            // gunzip + untar are synchronous and CPU-bound: run them off the
+            // async runtime so a large corpus archive can't stall it.
+            let files =
+                tokio::task::spawn_blocking(move || extract_yaml_from_tar_gz(bytes.as_ref()))
+                    .await
+                    .map_err(|e| {
+                        CorpusError::Config(format!("archive extract task panicked: {e}"))
+                    })??;
+            Ok(files)
+        }
+
         /// List a directory via the Contents API. For a directory the
         /// response is a JSON array of [`ContentsItem`]; for a missing
         /// directory we return an empty list (404). Files only — sub-
@@ -1028,6 +1081,48 @@ mod inner {
             })?;
         String::from_utf8(bytes)
             .map_err(|e| CorpusError::Git(format!("UTF-8 decode failed for {}: {}", item.path, e)))
+    }
+
+    /// Extract `(repo-relative path, content)` for every `.yaml`/`.yml`
+    /// file in a gzipped tar produced by GitHub's tarball endpoint. The
+    /// archive nests everything under a single top-level
+    /// `{owner}-{repo}-{sha}/` directory; that first component is stripped.
+    /// Directories, non-YAML files, and non-UTF-8 bodies are skipped rather
+    /// than failing the whole scan.
+    fn extract_yaml_from_tar_gz(bytes: &[u8]) -> Result<Vec<(String, String)>> {
+        use std::io::Read;
+        let gz = flate2::read::GzDecoder::new(bytes);
+        let mut archive = tar::Archive::new(gz);
+        let mut out = Vec::new();
+        let entries = archive
+            .entries()
+            .map_err(|e| CorpusError::Git(format!("failed to read archive entries: {e}")))?;
+        for entry in entries {
+            let mut entry = entry
+                .map_err(|e| CorpusError::Git(format!("failed to read archive entry: {e}")))?;
+            if entry.header().entry_type() != tar::EntryType::Regular {
+                continue;
+            }
+            let path = entry
+                .path()
+                .map_err(|e| CorpusError::Git(format!("archive entry has no path: {e}")))?
+                .to_string_lossy()
+                .replace('\\', "/");
+            // Strip the archive's single top-level directory component.
+            let Some((_, rel)) = path.split_once('/') else {
+                continue;
+            };
+            if !(rel.ends_with(".yaml") || rel.ends_with(".yml")) {
+                continue;
+            }
+            let mut content = String::new();
+            if entry.read_to_string(&mut content).is_err() {
+                tracing::debug!(path = %rel, "archive entry is not valid UTF-8; skipping");
+                continue;
+            }
+            out.push((rel.to_string(), content));
+        }
+        Ok(out)
     }
 
     #[cfg(test)]

--- a/packages/corpus/src/github.rs
+++ b/packages/corpus/src/github.rs
@@ -106,6 +106,16 @@ mod inner {
         pub content: String,
     }
 
+    /// A YAML file discovered via the Trees API: its repo-relative path
+    /// plus the blob sha the tree listing reported for it. The sha is the
+    /// file's content identity — two listings reporting the same sha are
+    /// guaranteed to have byte-identical content.
+    #[derive(Debug, Clone)]
+    struct TreeFile {
+        path: String,
+        sha: Option<String>,
+    }
+
     /// GitHub API response for the Trees endpoint.
     #[derive(Debug, Deserialize)]
     struct TreeResponse {
@@ -118,6 +128,11 @@ mod inner {
         path: String,
         #[serde(rename = "type")]
         entry_type: String,
+        /// Blob sha of the entry. GitHub always sends it; kept optional so
+        /// a missing field degrades to "no content identity" instead of
+        /// failing the whole tree parse.
+        #[serde(default)]
+        sha: Option<String>,
     }
 
     /// GitHub fetcher with ETag caching and rate limit awareness.
@@ -197,19 +212,24 @@ mod inner {
 
             // Step 2: Fetch each YAML file's content
             let mut files = Vec::new();
-            for path in &yaml_paths {
+            for file in &yaml_paths {
                 match self
-                    .fetch_file_content(&source.full_repo(), source.effective_ref(), path, token)
+                    .fetch_file_content(
+                        &source.full_repo(),
+                        source.effective_ref(),
+                        &file.path,
+                        token,
+                    )
                     .await
                 {
                     Ok(content) => {
                         files.push(FetchedFile {
-                            path: path.clone(),
+                            path: file.path.clone(),
                             content,
                         });
                     }
                     Err(e) => {
-                        tracing::warn!(path = %path, error = %e, "Failed to fetch file, skipping");
+                        tracing::warn!(path = %file.path, error = %e, "Failed to fetch file, skipping");
                     }
                 }
             }
@@ -257,19 +277,24 @@ mod inner {
             );
 
             let mut files = Vec::new();
-            for path in best_per_law.values() {
+            for file in best_per_law.values() {
                 match self
-                    .fetch_file_content(&source.full_repo(), source.effective_ref(), path, token)
+                    .fetch_file_content(
+                        &source.full_repo(),
+                        source.effective_ref(),
+                        &file.path,
+                        token,
+                    )
                     .await
                 {
                     Ok(content) => {
                         files.push(FetchedFile {
-                            path: path.clone(),
+                            path: file.path.clone(),
                             content,
                         });
                     }
                     Err(e) => {
-                        tracing::warn!(path = %path, error = %e, "Failed to fetch file, skipping");
+                        tracing::warn!(path = %file.path, error = %e, "Failed to fetch file, skipping");
                     }
                 }
             }
@@ -279,14 +304,17 @@ mod inner {
 
         /// Enumerate every law in a source via the Trees API (1 call),
         /// selecting the best version per law — WITHOUT fetching any file
-        /// content. Returns `(law_id, repo_path)` pairs. This is the cheap
-        /// enumeration the lightweight corpus index is built from: opening a
-        /// law fetches just that one file lazily via the backend.
+        /// content. Returns `(law_id, repo_path, blob_sha)` triples; the
+        /// sha is the file's content identity from the tree listing, so
+        /// callers can detect content change across enumerations without
+        /// fetching bodies. This is the cheap enumeration the lightweight
+        /// corpus index is built from: opening a law fetches just that one
+        /// file lazily via the backend.
         pub async fn list_source_law_paths(
             &mut self,
             source: &GitHubSource,
             token: Option<&str>,
-        ) -> Result<Vec<(String, String)>> {
+        ) -> Result<Vec<(String, String, Option<String>)>> {
             let base_path = source.path.as_deref().unwrap_or("");
             let all_paths = match self
                 .list_yaml_files(
@@ -302,28 +330,30 @@ mod inner {
             };
             Ok(Self::group_best_versions(&all_paths, base_path, None)
                 .into_iter()
+                .map(|(law_id, file)| (law_id, file.path, file.sha))
                 .collect())
         }
 
-        /// Group repo-relative YAML paths by `law_id` (the directory name),
+        /// Group repo-relative YAML files by `law_id` (the directory name),
         /// keeping the best version per law (closest valid date ≤ today, else
         /// latest). `filter`, when set, restricts to those law_ids. Path
         /// format: `{base_path}/{layer}/{law_id}/{date}.yaml`. Returns a map
-        /// of `law_id → repo_path`.
+        /// of `law_id → tree file (repo path + blob sha)`.
         fn group_best_versions(
-            all_paths: &[String],
+            all_paths: &[TreeFile],
             base_path: &str,
             filter: Option<&HashSet<String>>,
-        ) -> HashMap<String, String> {
+        ) -> HashMap<String, TreeFile> {
             let prefix = if base_path.is_empty() {
                 String::new()
             } else {
                 format!("{}/", base_path)
             };
             let today = crate::source_map::today_str();
-            let mut best_per_law: HashMap<String, String> = HashMap::new();
+            let mut best_per_law: HashMap<String, TreeFile> = HashMap::new();
 
-            for path in all_paths {
+            for file in all_paths {
+                let path = &file.path;
                 let rel = if prefix.is_empty() {
                     path.as_str()
                 } else {
@@ -361,25 +391,27 @@ mod inner {
                 let filename = parts[parts.len() - 1];
                 let new_date = filename.strip_suffix(".yaml");
 
-                if let Some(existing_path) = best_per_law.get(law_id) {
-                    let existing_filename = existing_path.rsplit('/').next().unwrap_or("");
+                if let Some(existing) = best_per_law.get(law_id) {
+                    let existing_filename = existing.path.rsplit('/').next().unwrap_or("");
                     let existing_date = existing_filename.strip_suffix(".yaml");
 
                     let new_wins =
                         crate::source_map::pick_best_version(existing_date, new_date, &today);
 
                     if new_wins {
-                        best_per_law.insert(law_id.to_string(), path.clone());
+                        best_per_law.insert(law_id.to_string(), file.clone());
                     }
                 } else {
-                    best_per_law.insert(law_id.to_string(), path.clone());
+                    best_per_law.insert(law_id.to_string(), file.clone());
                 }
             }
 
             best_per_law
         }
 
-        /// List all YAML files in a repo path using the Trees API.
+        /// List all YAML files in a repo path using the Trees API, with the
+        /// blob sha the tree reported for each file (the content identity
+        /// callers can use to detect change without fetching the body).
         ///
         /// Returns `None` when the server responds with 304 Not Modified,
         /// indicating the tree has not changed since the last fetch.
@@ -389,7 +421,7 @@ mod inner {
             branch: &str,
             base_path: &str,
             token: Option<&str>,
-        ) -> Result<Option<Vec<String>>> {
+        ) -> Result<Option<Vec<TreeFile>>> {
             let url = format!(
                 "{}/repos/{}/git/trees/{}?recursive=1",
                 self.api_base, repo, branch
@@ -448,7 +480,7 @@ mod inner {
                 )));
             }
 
-            let yaml_files: Vec<String> = tree
+            let yaml_files: Vec<TreeFile> = tree
                 .tree
                 .into_iter()
                 .filter(|e| {
@@ -458,7 +490,10 @@ mod inner {
                             || e.path == base_path
                             || e.path.starts_with(&format!("{}/", base_path)))
                 })
-                .map(|e| e.path)
+                .map(|e| TreeFile {
+                    path: e.path,
+                    sha: e.sha,
+                })
                 .collect();
 
             tracing::debug!(
@@ -997,10 +1032,10 @@ mod inner {
 
     #[cfg(test)]
     mod tests {
-        use super::GitHubFetcher;
+        use super::{GitHubFetcher, TreeFile};
         use std::collections::HashMap;
 
-        fn sorted_ids(map: &HashMap<String, String>) -> Vec<String> {
+        fn sorted_ids(map: &HashMap<String, TreeFile>) -> Vec<String> {
             let mut ids: Vec<String> = map.keys().cloned().collect();
             ids.sort();
             ids
@@ -1016,8 +1051,14 @@ mod inner {
         #[test]
         fn annotation_files_are_not_indexed_as_laws() {
             let paths = vec![
-                "regulation/nl/wet/wet_op_de_zorgtoeslag/2026-01-01.yaml".to_string(),
-                "annotations/zorgtoeslagwet/annotations.yaml".to_string(),
+                TreeFile {
+                    path: "regulation/nl/wet/wet_op_de_zorgtoeslag/2026-01-01.yaml".to_string(),
+                    sha: Some("abc123".to_string()),
+                },
+                TreeFile {
+                    path: "annotations/zorgtoeslagwet/annotations.yaml".to_string(),
+                    sha: Some("def456".to_string()),
+                },
             ];
             let best = GitHubFetcher::group_best_versions(&paths, "", None);
             assert_eq!(sorted_ids(&best), vec!["wet_op_de_zorgtoeslag".to_string()]);

--- a/packages/corpus/src/github.rs
+++ b/packages/corpus/src/github.rs
@@ -649,23 +649,28 @@ mod inner {
             Ok(Some((content, item.sha)))
         }
 
-        /// Download every YAML file in the repo at `git_ref` in a SINGLE
-        /// request via the archive (tarball) endpoint, instead of one
-        /// Contents call per file. Returns `(repo-relative path, content)`
-        /// pairs for `.yaml`/`.yml` files; the archive's top-level
-        /// `{owner}-{repo}-{sha}/` directory component is stripped so the
-        /// paths line up with the Trees/Contents APIs.
+        /// Download the repo at `git_ref` in a SINGLE request via the
+        /// archive (tarball) endpoint and return each YAML law's
+        /// `implements` list — `(repo-relative path, implements)` pairs for
+        /// `.yaml`/`.yml` files, the archive's top-level
+        /// `{owner}-{repo}-{sha}/` directory component stripped so the paths
+        /// line up with the Trees/Contents APIs.
+        ///
+        /// Crucially, bodies are parsed and DISCARDED one at a time during
+        /// extraction — only the (tiny) implements lists are kept — so a
+        /// large corpus archive does not materialise every law body in
+        /// memory at once (which would OOM the process).
         ///
         /// GitHub answers the tarball endpoint with a 302 to a short-lived
         /// codeload URL (carrying its own token), which reqwest follows
         /// automatically — so this works for private repos with just the
         /// Bearer token on the initial request.
-        pub async fn fetch_archive(
+        pub async fn fetch_archive_implements(
             &mut self,
             repo: &str,
             git_ref: &str,
             token: Option<&str>,
-        ) -> Result<Vec<(String, String)>> {
+        ) -> Result<Vec<(String, Vec<String>)>> {
             let url = format!("{}/repos/{}/tarball/{}", self.api_base, repo, git_ref);
             let headers = self.default_headers(token);
             let response = self
@@ -691,10 +696,10 @@ mod inner {
                 .await
                 .map_err(|e| CorpusError::Git(format!("Failed to read archive body: {}", e)))?;
 
-            // gunzip + untar are synchronous and CPU-bound: run them off the
-            // async runtime so a large corpus archive can't stall it.
+            // gunzip + untar + parse are synchronous and CPU-bound: run them
+            // off the async runtime so a large corpus archive can't stall it.
             let files =
-                tokio::task::spawn_blocking(move || extract_yaml_from_tar_gz(bytes.as_ref()))
+                tokio::task::spawn_blocking(move || extract_implements_from_tar_gz(bytes.as_ref()))
                     .await
                     .map_err(|e| {
                         CorpusError::Config(format!("archive extract task panicked: {e}"))
@@ -1083,13 +1088,19 @@ mod inner {
             .map_err(|e| CorpusError::Git(format!("UTF-8 decode failed for {}: {}", item.path, e)))
     }
 
-    /// Extract `(repo-relative path, content)` for every `.yaml`/`.yml`
-    /// file in a gzipped tar produced by GitHub's tarball endpoint. The
-    /// archive nests everything under a single top-level
-    /// `{owner}-{repo}-{sha}/` directory; that first component is stripped.
-    /// Directories, non-YAML files, and non-UTF-8 bodies are skipped rather
-    /// than failing the whole scan.
-    fn extract_yaml_from_tar_gz(bytes: &[u8]) -> Result<Vec<(String, String)>> {
+    /// Stream a gzipped tar produced by GitHub's tarball endpoint and
+    /// return `(repo-relative path, implements list)` for every
+    /// `.yaml`/`.yml` file. The archive nests everything under a single
+    /// top-level `{owner}-{repo}-{sha}/` directory; that first component is
+    /// stripped. Directories, non-YAML files, and non-UTF-8 bodies are
+    /// skipped rather than failing the whole scan.
+    ///
+    /// Each body is read into a scratch `String`, parsed for `implements`,
+    /// and dropped before the next entry — so peak memory is one law body
+    /// plus the (tiny) implements result, never the whole decompressed
+    /// corpus. This is what keeps the one-request bulk scan from OOMing on
+    /// a large corpus.
+    fn extract_implements_from_tar_gz(bytes: &[u8]) -> Result<Vec<(String, Vec<String>)>> {
         use std::io::Read;
         let gz = flate2::read::GzDecoder::new(bytes);
         let mut archive = tar::Archive::new(gz);
@@ -1120,7 +1131,9 @@ mod inner {
                 tracing::debug!(path = %rel, "archive entry is not valid UTF-8; skipping");
                 continue;
             }
-            out.push((rel.to_string(), content));
+            let implements = crate::source_map::collect_law_implements(&content);
+            out.push((rel.to_string(), implements));
+            // `content` dropped here — bodies never accumulate.
         }
         Ok(out)
     }

--- a/packages/corpus/src/github_api_backend.rs
+++ b/packages/corpus/src/github_api_backend.rs
@@ -231,7 +231,15 @@ impl RepoBackend for GitHubApiBackend {
     /// repo-relative; map them back through [`to_source_relative`] (drops
     /// files outside `sub_path`) so they match the `SourceMap`.
     ///
+    /// Holds the `inner` lock for the whole archive download + extraction
+    /// (seconds for a large corpus), same as [`read_file`] holds it for its
+    /// Contents call — the fetcher's `&mut self` (ETag cache, rate-limit
+    /// tracking) requires exclusive access. A concurrent read on the same
+    /// backend stalls for the duration, but in practice this only fires on
+    /// the cold implements-index build, which is single-flighted anyway.
+    ///
     /// [`to_source_relative`]: GitHubApiBackend::to_source_relative
+    /// [`read_file`]: GitHubApiBackend::read_file
     async fn read_all_files(&self, extension: Option<&str>) -> Result<Vec<(String, String)>> {
         let files = {
             let mut inner = self.inner.lock().await;

--- a/packages/corpus/src/github_api_backend.rs
+++ b/packages/corpus/src/github_api_backend.rs
@@ -226,6 +226,35 @@ impl RepoBackend for GitHubApiBackend {
         }
     }
 
+    /// Bulk read via the repo archive: one tarball download for the whole
+    /// source instead of a Contents call per file. Archive paths are
+    /// repo-relative; map them back through [`to_source_relative`] (drops
+    /// files outside `sub_path`) so they match the `SourceMap`.
+    ///
+    /// [`to_source_relative`]: GitHubApiBackend::to_source_relative
+    async fn read_all_files(&self, extension: Option<&str>) -> Result<Vec<(String, String)>> {
+        let files = {
+            let mut inner = self.inner.lock().await;
+            inner
+                .fetcher
+                .fetch_archive(&self.full_repo(), &self.branch, self.token.as_deref())
+                .await?
+        };
+        let suffix = extension.map(|ext| format!(".{ext}"));
+        Ok(files
+            .into_iter()
+            .filter_map(|(repo_path, content)| {
+                let rel = self.to_source_relative(&repo_path)?;
+                if let Some(suffix) = &suffix {
+                    if !rel.ends_with(suffix) {
+                        return None;
+                    }
+                }
+                Some((rel, content))
+            })
+            .collect())
+    }
+
     async fn write_file(&self, relative_path: &Path, content: &str) -> Result<()> {
         validate_relative(relative_path)?;
         if self.token.is_none() {
@@ -690,5 +719,89 @@ fn is_unsigned_existing_file(e: &CorpusError) -> bool {
     match e {
         CorpusError::Git(msg) => msg.contains(" 422") && msg.contains("sha"),
         _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+
+    use flate2::write::GzEncoder;
+    use flate2::Compression;
+    use wiremock::matchers::{method, path as path_matcher};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use super::GitHubApiBackend;
+    use crate::backend::RepoBackend;
+    use crate::models::GitHubSource;
+
+    /// Build a gzipped tar laid out like GitHub's tarball endpoint: every
+    /// entry nested under a single top-level `{owner}-{repo}-{sha}/` dir.
+    fn make_repo_tar_gz(top: &str, files: &[(&str, &str)]) -> Vec<u8> {
+        let mut builder = tar::Builder::new(GzEncoder::new(Vec::new(), Compression::default()));
+        for (rel, content) in files {
+            let mut header = tar::Header::new_gnu();
+            header.set_size(content.len() as u64);
+            header.set_entry_type(tar::EntryType::Regular);
+            header.set_mode(0o644);
+            header.set_cksum();
+            builder
+                .append_data(&mut header, format!("{top}/{rel}"), content.as_bytes())
+                .unwrap();
+        }
+        builder.into_inner().unwrap().finish().unwrap()
+    }
+
+    #[tokio::test]
+    async fn read_all_files_bulk_downloads_archive_and_maps_to_source_relative() {
+        let server = MockServer::start().await;
+
+        let tar_gz = make_repo_tar_gz(
+            "acme-corpus-deadbeef",
+            &[
+                ("regulation/nl/wet/foo/2025-01-01.yaml", "$id: foo\n"),
+                ("regulation/nl/wet/bar/2025-01-01.yaml", "$id: bar\n"),
+                // Non-YAML under the corpus subtree: dropped by the extract.
+                ("regulation/nl/README.md", "docs\n"),
+                // YAML outside the source sub_path: dropped by to_source_relative.
+                ("tools/gen.yaml", "noise\n"),
+            ],
+        );
+
+        // One request to the tarball endpoint serves the whole source.
+        Mock::given(method("GET"))
+            .and(path_matcher("/repos/acme/corpus/tarball/main"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(tar_gz, "application/gzip"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let src = GitHubSource {
+            owner: "acme".to_string(),
+            repo: "corpus".to_string(),
+            branch: "main".to_string(),
+            path: Some("regulation/nl".to_string()),
+            git_ref: None,
+        };
+        let backend =
+            GitHubApiBackend::new(&src, Some("main".to_string()), Some("tok".to_string()))
+                .unwrap()
+                .with_api_base(server.uri());
+
+        let mut got = backend.read_all_files(Some("yaml")).await.unwrap();
+        got.sort();
+        assert_eq!(
+            got,
+            vec![
+                (
+                    "wet/bar/2025-01-01.yaml".to_string(),
+                    "$id: bar\n".to_string()
+                ),
+                (
+                    "wet/foo/2025-01-01.yaml".to_string(),
+                    "$id: foo\n".to_string()
+                ),
+            ]
+        );
     }
 }

--- a/packages/corpus/src/github_api_backend.rs
+++ b/packages/corpus/src/github_api_backend.rs
@@ -226,10 +226,13 @@ impl RepoBackend for GitHubApiBackend {
         }
     }
 
-    /// Bulk read via the repo archive: one tarball download for the whole
-    /// source instead of a Contents call per file. Archive paths are
-    /// repo-relative; map them back through [`to_source_relative`] (drops
-    /// files outside `sub_path`) so they match the `SourceMap`.
+    /// Bulk implements scan via the repo archive: one tarball download for
+    /// the whole source instead of a Contents call per file. Bodies are
+    /// parsed for `implements` and discarded during extraction (see
+    /// [`fetch_archive_implements`]), so this never materialises the whole
+    /// corpus in memory. Archive paths are repo-relative; map them back
+    /// through [`to_source_relative`] (drops files outside `sub_path`) so
+    /// they match the `SourceMap`.
     ///
     /// Holds the `inner` lock for the whole archive download + extraction
     /// (seconds for a large corpus), same as [`read_file`] holds it for its
@@ -238,27 +241,22 @@ impl RepoBackend for GitHubApiBackend {
     /// backend stalls for the duration, but in practice this only fires on
     /// the cold implements-index build, which is single-flighted anyway.
     ///
+    /// [`fetch_archive_implements`]: crate::github::GitHubFetcher::fetch_archive_implements
     /// [`to_source_relative`]: GitHubApiBackend::to_source_relative
     /// [`read_file`]: GitHubApiBackend::read_file
-    async fn read_all_files(&self, extension: Option<&str>) -> Result<Vec<(String, String)>> {
+    async fn read_all_implements(&self) -> Result<Vec<(String, Vec<String>)>> {
         let files = {
             let mut inner = self.inner.lock().await;
             inner
                 .fetcher
-                .fetch_archive(&self.full_repo(), &self.branch, self.token.as_deref())
+                .fetch_archive_implements(&self.full_repo(), &self.branch, self.token.as_deref())
                 .await?
         };
-        let suffix = extension.map(|ext| format!(".{ext}"));
         Ok(files
             .into_iter()
-            .filter_map(|(repo_path, content)| {
+            .filter_map(|(repo_path, implements)| {
                 let rel = self.to_source_relative(&repo_path)?;
-                if let Some(suffix) = &suffix {
-                    if !rel.ends_with(suffix) {
-                        return None;
-                    }
-                }
-                Some((rel, content))
+                Some((rel, implements))
             })
             .collect())
     }
@@ -760,19 +758,31 @@ mod tests {
         builder.into_inner().unwrap().finish().unwrap()
     }
 
+    /// A law body whose `machine_readable.implements` references `higher`.
+    fn law_with_implements(id: &str, higher: &str) -> String {
+        format!(
+            "$id: {id}\narticles:\n  - number: '1'\n    machine_readable:\n      implements:\n        - law: {higher}\n"
+        )
+    }
+
     #[tokio::test]
-    async fn read_all_files_bulk_downloads_archive_and_maps_to_source_relative() {
+    async fn read_all_implements_bulk_downloads_archive_and_maps_to_source_relative() {
         let server = MockServer::start().await;
 
+        let foo = law_with_implements("foo", "wet_target");
         let tar_gz = make_repo_tar_gz(
             "acme-corpus-deadbeef",
             &[
-                ("regulation/nl/wet/foo/2025-01-01.yaml", "$id: foo\n"),
-                ("regulation/nl/wet/bar/2025-01-01.yaml", "$id: bar\n"),
+                ("regulation/nl/wet/foo/2025-01-01.yaml", foo.as_str()),
+                // No implements → empty list, but still reported.
+                (
+                    "regulation/nl/wet/bar/2025-01-01.yaml",
+                    "$id: bar\narticles: []\n",
+                ),
                 // Non-YAML under the corpus subtree: dropped by the extract.
                 ("regulation/nl/README.md", "docs\n"),
                 // YAML outside the source sub_path: dropped by to_source_relative.
-                ("tools/gen.yaml", "noise\n"),
+                ("tools/gen.yaml", "$id: noise\n"),
             ],
         );
 
@@ -796,18 +806,15 @@ mod tests {
                 .unwrap()
                 .with_api_base(server.uri());
 
-        let mut got = backend.read_all_files(Some("yaml")).await.unwrap();
+        let mut got = backend.read_all_implements().await.unwrap();
         got.sort();
         assert_eq!(
             got,
             vec![
-                (
-                    "wet/bar/2025-01-01.yaml".to_string(),
-                    "$id: bar\n".to_string()
-                ),
+                ("wet/bar/2025-01-01.yaml".to_string(), Vec::<String>::new()),
                 (
                     "wet/foo/2025-01-01.yaml".to_string(),
-                    "$id: foo\n".to_string()
+                    vec!["wet_target".to_string()]
                 ),
             ]
         );

--- a/packages/corpus/src/registry.rs
+++ b/packages/corpus/src/registry.rs
@@ -287,7 +287,7 @@ impl CorpusRegistry {
                     source.auth_ref.as_deref(),
                     auth_file,
                 )?;
-                for (law_id, path) in fetcher
+                for (law_id, path, sha) in fetcher
                     .list_source_law_paths(github, token.as_deref())
                     .await?
                 {
@@ -298,6 +298,7 @@ impl CorpusRegistry {
                         &source.id,
                         &source.name,
                         source.priority,
+                        sha.as_deref(),
                     )?;
                 }
             }

--- a/packages/corpus/src/source_map.rs
+++ b/packages/corpus/src/source_map.rs
@@ -41,6 +41,16 @@ pub struct LoadedLaw {
     /// and friends, and avoids the structural-depth heuristic that breaks
     /// when a source root is configured at an unusual location.
     pub relative_path: String,
+    /// Blob sha of the law file as reported by the source's enumeration
+    /// (the GitHub Trees API listing), for metadata-only entries. This is
+    /// the file's content identity: two enumerations reporting the same
+    /// sha are guaranteed to have byte-identical content, so callers can
+    /// reuse content-derived data across index snapshots without
+    /// re-fetching the body. `None` for eagerly-loaded entries (local
+    /// sources — the content is already present and parsed) and after
+    /// [`SourceMap::update_yaml_content`] (the in-memory content no
+    /// longer matches the enumerated blob).
+    pub content_sha: Option<String>,
     /// ID of the source that provided this law.
     pub source_id: String,
     /// Name of the source that provided this law.
@@ -174,6 +184,7 @@ impl SourceMap {
                 yaml_content: content,
                 file_path: path.display().to_string(),
                 relative_path,
+                content_sha: None,
                 source_id: source.id.clone(),
                 source_name: source.name.clone(),
                 source_priority: source.priority,
@@ -304,6 +315,7 @@ impl SourceMap {
             yaml_content: content.to_string(),
             file_path: file_path.to_string(),
             relative_path,
+            content_sha: None,
             source_id: source_id.to_string(),
             source_name: source_name.to_string(),
             source_priority,
@@ -322,6 +334,9 @@ impl SourceMap {
     /// `{base}/{layer}/{law_id}/{date}.yaml`, and the directory name equals
     /// the law's `$id`). `file_path` is the in-repo path; `source_subpath` is
     /// stripped to produce the source-root-relative path the backend reads.
+    /// `content_sha` is the blob sha the enumeration reported for the file
+    /// (see [`LoadedLaw::content_sha`]), when available.
+    #[allow(clippy::too_many_arguments)]
     pub fn load_metadata_entry(
         &mut self,
         law_id: &str,
@@ -330,6 +345,7 @@ impl SourceMap {
         source_id: &str,
         source_name: &str,
         source_priority: u32,
+        content_sha: Option<&str>,
     ) -> Result<()> {
         let relative_path = match source_subpath {
             Some(sub) if !sub.is_empty() => {
@@ -350,6 +366,7 @@ impl SourceMap {
             yaml_content: String::new(),
             file_path: file_path.to_string(),
             relative_path,
+            content_sha: content_sha.map(|s| s.to_string()),
             source_id: source_id.to_string(),
             source_name: source_name.to_string(),
             source_priority,
@@ -386,6 +403,9 @@ impl SourceMap {
         law.display_name = display_name;
         law.implements = implements;
         law.yaml_content = new_content;
+        // The in-memory content no longer matches the blob the source
+        // enumeration reported — drop the stale content identity.
+        law.content_sha = None;
         true
     }
 
@@ -941,6 +961,7 @@ mod tests {
             "traject-own-abc",
             "MinBZK/regelrecht-corpus-BES",
             0,
+            Some("blob-sha-1"),
         )
         .unwrap();
 
@@ -954,6 +975,7 @@ mod tests {
         );
         assert_eq!(law.source_id, "traject-own-abc");
         assert_eq!(law.source_priority, 0);
+        assert_eq!(law.content_sha.as_deref(), Some("blob-sha-1"));
     }
 
     #[test]
@@ -1223,6 +1245,7 @@ articles:
             "central",
             "Central",
             1,
+            None,
         )
         .unwrap();
         let law = map.get_law("some_wet").unwrap();

--- a/packages/corpus/src/source_map.rs
+++ b/packages/corpus/src/source_map.rs
@@ -566,6 +566,11 @@ fn extract_raw_name(yaml: &str) -> Option<String> {
 
 #[derive(Deserialize, Default)]
 struct LawDoc {
+    /// Top-level `name:` — a literal (`Kieswet`) or an output reference
+    /// (`#wet_naam`). Read straight off the shared parse so the loaded-field
+    /// derivation doesn't re-scan the raw string.
+    #[serde(default)]
+    name: Option<String>,
     #[serde(default)]
     articles: Vec<LawArticle>,
 }
@@ -688,10 +693,16 @@ fn derive_loaded_fields(yaml: &str) -> (Option<String>, Vec<String>) {
         Ok(d) => d,
         Err(_) => return (extract_law_name(yaml), Vec::new()),
     };
-    let display_name = extract_law_name(yaml).or_else(|| {
-        let raw = extract_raw_name(yaml)?;
-        let reference = raw.strip_prefix('#')?;
-        resolve_name_reference(&doc, reference)
+    // Resolve the display name from the already-parsed `name` field rather
+    // than re-scanning the raw string: a literal name is used as-is, a
+    // `#ref` is resolved against this doc's actions.
+    let display_name = doc.name.as_deref().and_then(|raw| {
+        let raw = raw.trim();
+        match raw.strip_prefix('#') {
+            Some(reference) => resolve_name_reference(&doc, reference),
+            None if !raw.is_empty() => Some(raw.to_string()),
+            None => None,
+        }
     });
     (display_name, collect_implements_from_doc(&doc))
 }

--- a/packages/corpus/src/source_map.rs
+++ b/packages/corpus/src/source_map.rs
@@ -14,6 +14,20 @@ pub struct LoadedLaw {
     pub law_id: String,
     /// The law's `name` field (human-readable title), if present.
     pub name: Option<String>,
+    /// Resolved human-readable display name, computed once at load time.
+    /// Equals [`name`](Self::name) for laws with a literal `name:` field;
+    /// for `name: '#output_ref'` laws this is the referenced action's
+    /// scalar value (see [`resolve_display_name`]). `None` when nothing
+    /// resolves, or for metadata-only entries whose body hasn't been
+    /// fetched. Precomputed so list endpoints don't re-scan (or fully
+    /// re-parse) every law body on every request.
+    pub display_name: Option<String>,
+    /// `$id`s of the higher laws this law's articles declare they
+    /// `implements` (the IoC link), computed once at load time (see
+    /// [`collect_law_implements`]). Empty for metadata-only entries.
+    /// Precomputed so "who implements law X" reverse lookups don't
+    /// re-parse every law body per request.
+    pub implements: Vec<String>,
     /// The raw YAML content.
     pub yaml_content: String,
     /// Path to the source file. For local sources this is the absolute path
@@ -142,6 +156,7 @@ impl SourceMap {
             };
 
             let name = extract_law_name(&content);
+            let (display_name, implements) = derive_loaded_fields(&content);
 
             // Compute the path relative to the source root so that writes
             // can address the file via the backend without re-deriving the
@@ -154,6 +169,8 @@ impl SourceMap {
             let loaded = LoadedLaw {
                 law_id: law_id.clone(),
                 name,
+                display_name,
+                implements,
                 yaml_content: content,
                 file_path: path.display().to_string(),
                 relative_path,
@@ -263,6 +280,7 @@ impl SourceMap {
         };
 
         let name = extract_law_name(content);
+        let (display_name, implements) = derive_loaded_fields(content);
 
         // Strip the source's in-repo subpath so the stored relative path is
         // relative to the source root, matching the on-disk layout the
@@ -281,6 +299,8 @@ impl SourceMap {
         let loaded = LoadedLaw {
             law_id: law_id.clone(),
             name,
+            display_name,
+            implements,
             yaml_content: content.to_string(),
             file_path: file_path.to_string(),
             relative_path,
@@ -325,6 +345,8 @@ impl SourceMap {
         self.insert(LoadedLaw {
             law_id: law_id.to_string(),
             name: None,
+            display_name: None,
+            implements: Vec::new(),
             yaml_content: String::new(),
             file_path: file_path.to_string(),
             relative_path,
@@ -350,16 +372,19 @@ impl SourceMap {
     /// waiting for a full corpus reload. Returns `true` if the law was
     /// present and updated, `false` otherwise.
     ///
-    /// Only `yaml_content` (and the optional human-readable `name`, which is
-    /// derived from the YAML) is updated — `$id`, `file_path`, source
-    /// provenance, and priority are stable across an edit and are left
-    /// untouched. If the caller writes a new file under a different `$id`
-    /// that's a different operation (unsupported via this hook).
+    /// Only `yaml_content` (and the content-derived fields `name`,
+    /// `display_name` and `implements`) is updated — `$id`, `file_path`,
+    /// source provenance, and priority are stable across an edit and are
+    /// left untouched. If the caller writes a new file under a different
+    /// `$id` that's a different operation (unsupported via this hook).
     pub fn update_yaml_content(&mut self, law_id: &str, new_content: String) -> bool {
         let Some(law) = self.laws.get_mut(law_id) else {
             return false;
         };
         law.name = extract_law_name(&new_content);
+        let (display_name, implements) = derive_loaded_fields(&new_content);
+        law.display_name = display_name;
+        law.implements = implements;
         law.yaml_content = new_content;
         true
     }
@@ -605,6 +630,12 @@ pub fn resolve_display_name(yaml: &str) -> Option<String> {
 
     // Parse YAML to find the action that resolves this reference
     let doc: LawDoc = serde_yaml_ng::from_str(yaml).ok()?;
+    resolve_name_reference(&doc, reference)
+}
+
+/// Find the action whose `output` matches `reference` and return its
+/// scalar string value — the resolution behind `name: '#output_ref'`.
+fn resolve_name_reference(doc: &LawDoc, reference: &str) -> Option<String> {
     for article in &doc.articles {
         let Some(mr) = &article.machine_readable else {
             continue;
@@ -622,6 +653,27 @@ pub fn resolve_display_name(yaml: &str) -> Option<String> {
     }
 
     None
+}
+
+/// Compute the content-derived [`LoadedLaw`] fields (`display_name`,
+/// `implements`) with a single YAML parse. Called once per law at load /
+/// update time so the read paths never have to re-parse bodies per
+/// request. Returns `(None, vec![])` for unparseable content — the same
+/// degraded result the per-request resolvers used to produce.
+fn derive_loaded_fields(yaml: &str) -> (Option<String>, Vec<String>) {
+    // `implements` always needs the parsed doc; the display name only
+    // does for `name: '#ref'` laws, but sharing one parse keeps this a
+    // single pass either way.
+    let doc: LawDoc = match serde_yaml_ng::from_str(yaml) {
+        Ok(d) => d,
+        Err(_) => return (extract_law_name(yaml), Vec::new()),
+    };
+    let display_name = extract_law_name(yaml).or_else(|| {
+        let raw = extract_raw_name(yaml)?;
+        let reference = raw.strip_prefix('#')?;
+        resolve_name_reference(&doc, reference)
+    });
+    (display_name, collect_implements_from_doc(&doc))
 }
 
 /// A collected output with the parameters required by its article's execution block.
@@ -699,7 +751,12 @@ pub fn collect_law_implements(yaml: &str) -> Vec<String> {
         Ok(d) => d,
         Err(_) => return Vec::new(),
     };
+    collect_implements_from_doc(&doc)
+}
 
+/// Doc-based core of [`collect_law_implements`], shared with the
+/// parse-once load path ([`derive_loaded_fields`]).
+fn collect_implements_from_doc(doc: &LawDoc) -> Vec<String> {
     let mut seen = HashSet::new();
     let mut out = Vec::new();
     for article in &doc.articles {
@@ -1076,6 +1133,125 @@ articles:
     fn test_resolve_display_name_no_name_field() {
         let yaml = "$id: test\narticles: []\n";
         assert_eq!(resolve_display_name(yaml), None);
+    }
+
+    /// A law body with a `name: '#ref'` display name and an `implements`
+    /// declaration, for the precompute tests below.
+    const DERIVED_FIELDS_YAML: &str = r#"$id: regeling_zorgtoeslag
+name: '#regeling_naam'
+articles:
+  - number: '1'
+    machine_readable:
+      execution:
+        actions:
+          - output: regeling_naam
+            value: Regeling zorgtoeslag
+      implements:
+        - law: wet_op_de_zorgtoeslag
+          open_term: standaardpremie
+"#;
+
+    #[test]
+    fn test_load_precomputes_display_name_and_implements() {
+        // The list/implementors endpoints read these fields straight off
+        // the loaded law instead of re-parsing every body per request, so
+        // load time MUST populate them.
+        let dir = TempDir::new().unwrap();
+        let path = dir
+            .path()
+            .join("regeling/regeling_zorgtoeslag/2025-01-01.yaml");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, DERIVED_FIELDS_YAML).unwrap();
+
+        let source = make_source("central", "Central", dir.path(), 1);
+        let mut map = SourceMap::new();
+        map.load_source(&source).unwrap();
+
+        let law = map.get_law("regeling_zorgtoeslag").unwrap();
+        // `name` only carries literal names; the resolved `#ref` lands in
+        // `display_name`.
+        assert_eq!(law.name, None);
+        assert_eq!(law.display_name.as_deref(), Some("Regeling zorgtoeslag"));
+        assert_eq!(law.implements, vec!["wet_op_de_zorgtoeslag".to_string()]);
+    }
+
+    #[test]
+    fn test_load_fetched_file_precomputes_display_name_and_implements() {
+        let mut map = SourceMap::new();
+        map.load_fetched_file(
+            DERIVED_FIELDS_YAML,
+            "regulation/nl/regeling/regeling_zorgtoeslag/2025-01-01.yaml",
+            Some("regulation/nl"),
+            "central",
+            "Central",
+            1,
+        )
+        .unwrap();
+
+        let law = map.get_law("regeling_zorgtoeslag").unwrap();
+        assert_eq!(law.display_name.as_deref(), Some("Regeling zorgtoeslag"));
+        assert_eq!(law.implements, vec!["wet_op_de_zorgtoeslag".to_string()]);
+    }
+
+    #[test]
+    fn test_load_literal_name_display_name_matches_name() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("wet/kieswet/2025-01-01.yaml");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, "$id: kieswet\nname: Kieswet\narticles: []\n").unwrap();
+
+        let source = make_source("central", "Central", dir.path(), 1);
+        let mut map = SourceMap::new();
+        map.load_source(&source).unwrap();
+
+        let law = map.get_law("kieswet").unwrap();
+        assert_eq!(law.name.as_deref(), Some("Kieswet"));
+        assert_eq!(law.display_name.as_deref(), Some("Kieswet"));
+        assert!(law.implements.is_empty());
+    }
+
+    #[test]
+    fn test_metadata_entry_has_no_derived_fields() {
+        // Metadata-only entries have no body to derive from — the fields
+        // stay empty until the body is fetched and (in the editor flow)
+        // a snapshot rebuild or `update_yaml_content` recomputes them.
+        let mut map = SourceMap::new();
+        map.load_metadata_entry(
+            "some_wet",
+            "regulation/nl/wet/some_wet/2025-01-01.yaml",
+            Some("regulation/nl"),
+            "central",
+            "Central",
+            1,
+        )
+        .unwrap();
+        let law = map.get_law("some_wet").unwrap();
+        assert_eq!(law.display_name, None);
+        assert!(law.implements.is_empty());
+    }
+
+    #[test]
+    fn test_update_yaml_content_recomputes_derived_fields() {
+        let dir = TempDir::new().unwrap();
+        let path = dir
+            .path()
+            .join("regeling/regeling_zorgtoeslag/2025-01-01.yaml");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, DERIVED_FIELDS_YAML).unwrap();
+
+        let source = make_source("central", "Central", dir.path(), 1);
+        let mut map = SourceMap::new();
+        map.load_source(&source).unwrap();
+
+        // Edit drops the implements block and switches to a literal name:
+        // both derived fields must follow the new content.
+        let new_content =
+            "$id: regeling_zorgtoeslag\nname: Nieuwe naam\narticles: []\n".to_string();
+        assert!(map.update_yaml_content("regeling_zorgtoeslag", new_content));
+
+        let law = map.get_law("regeling_zorgtoeslag").unwrap();
+        assert_eq!(law.display_name.as_deref(), Some("Nieuwe naam"));
+        assert!(law.implements.is_empty());
     }
 
     #[test]

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -18,8 +18,7 @@ use regelrecht_corpus::annotation_schema::{
 use regelrecht_corpus::backend::{EditorUser, PersistOutcome, RepoBackend, WriteContext};
 use regelrecht_corpus::dto::{build_source_summaries, PaginationParams, SourceSummary};
 use regelrecht_corpus::source_map::{
-    collect_law_implements, collect_law_outputs, extract_law_id, resolve_display_name,
-    validate_yaml_syntax, LoadedLaw,
+    collect_law_outputs, extract_law_id, validate_yaml_syntax, LoadedLaw,
 };
 use regelrecht_corpus::CorpusError;
 
@@ -272,16 +271,16 @@ fn list_corpus_laws_in_scope(scope: &ReadScope, params: PaginationParams) -> Vec
                 }
             }
         })
-        .map(|law| {
-            let display_name = resolve_display_name(&law.yaml_content);
-            CorpusLawEntry {
-                law_id: law.law_id.clone(),
-                name: law.name.clone(),
-                display_name,
-                source_id: law.source_id.clone(),
-                source_name: law.source_name.clone(),
-                source_priority: law.source_priority,
-            }
+        .map(|law| CorpusLawEntry {
+            law_id: law.law_id.clone(),
+            name: law.name.clone(),
+            // Precomputed at index/load time (see `LoadedLaw::display_name`)
+            // so the unfiltered list doesn't re-scan every law body — let
+            // alone fully re-parse the `name: '#ref'` ones — per page load.
+            display_name: law.display_name.clone(),
+            source_id: law.source_id.clone(),
+            source_name: law.source_name.clone(),
+            source_priority: law.source_priority,
         })
         .collect();
 
@@ -461,35 +460,42 @@ pub async fn list_traject_law_implementors(
 }
 
 async fn implementors_in_scope(scope: &ReadScope, law_id: &str) -> Vec<String> {
-    // The snapshot always carries the full federated law *list* (only bodies
-    // are lazy), so collect candidate ids first, then resolve each body.
-    let candidates: Vec<String> = scope
-        .corpus()
-        .source_map
-        .laws()
-        .map(|law| law.law_id.clone())
-        .filter(|id| id != law_id)
-        .collect();
-
-    let mut out = Vec::new();
-    for id in candidates {
-        // Resolve the body through the scope, NOT `LoadedLaw::yaml_content`
-        // directly: in a traject the federated central laws are metadata-only
-        // until first read, so the snapshot body is empty for them. `law_yaml`
-        // lazily fetches (and caches) the body and applies the read-your-writes
-        // overlay. A miss or fetch error just means this law can't be checked,
-        // so it's skipped rather than failing the whole scan.
-        if let Ok(Some(yaml)) = scope.law_yaml(&id).await {
-            if collect_law_implements(&yaml)
-                .iter()
-                .any(|implemented| implemented == law_id)
-            {
-                out.push(id);
+    match scope {
+        // Traject: federated laws are metadata-only until first read, so
+        // the lookup goes through the per-snapshot implements index
+        // (built once per snapshot — the only O(corpus) body scan — and
+        // invalidated with it; see `TrajectCorpus::implementors_of`).
+        // Laws whose body fetch failed during the scan are *reported*
+        // rather than silently passed off as "no implementors"; the
+        // response shape (a bare id array) has no room for a non-breaking
+        // partiality flag, so the signal is a warn for operators and the
+        // failed set self-heals at the next snapshot.
+        ReadScope::Traject(traject) => {
+            let result = traject.implementors_of(law_id).await;
+            if !result.skipped_law_ids.is_empty() {
+                tracing::warn!(
+                    law_id = %law_id,
+                    skipped = result.skipped_law_ids.len(),
+                    found = result.implementors.len(),
+                    "implementors lookup is incomplete: some law bodies could not be fetched when the implements index was built"
+                );
             }
+            result.implementors
+        }
+        // Global: bodies are fully loaded up front and each law's
+        // `implements` list was parsed once at load time, so this is an
+        // in-memory reverse scan — no per-request YAML parsing.
+        ReadScope::Global(corpus) => {
+            let mut out: Vec<String> = corpus
+                .source_map
+                .laws()
+                .filter(|law| law.law_id != law_id && law.implements.iter().any(|i| i == law_id))
+                .map(|law| law.law_id.clone())
+                .collect();
+            out.sort();
+            out
         }
     }
-    out.sort();
-    out
 }
 
 /// Law ids a scenario file evaluates, extracted from its execution steps.
@@ -738,10 +744,16 @@ async fn get_scenario_in_scope(
             let resolved = resolve_backend_for_law(scope.corpus(), law_id).await?;
             let relative_path = scenario_relative_path(&resolved.law, filename)?;
             let backend = resolved.backend.lock().await;
-            backend
-                .read_file(&relative_path)
-                .await
-                .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+            // Generic message + logged details, like `corpus_write_error`:
+            // the raw error can carry backend internals (paths, git/remote
+            // detail) that must not reach the client.
+            backend.read_file(&relative_path).await.map_err(|e| {
+                tracing::warn!(law_id = %law_id, filename = %filename, error = %e, "scenario read failed");
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Failed to read scenario".to_string(),
+                )
+            })?
         }
     };
 

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -480,7 +480,7 @@ async fn implementors_in_scope(scope: &ReadScope, law_id: &str) -> Vec<String> {
                     law_id = %law_id,
                     skipped = result.skipped_count,
                     found = result.implementors.len(),
-                    "implementors lookup is incomplete: some law bodies could not be fetched when the implements index was built"
+                    "implements index was built with unreadable law bodies (index-wide count, not specific to this law); this lookup may therefore be incomplete"
                 );
             }
             result.implementors

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -475,10 +475,10 @@ async fn implementors_in_scope(scope: &ReadScope, law_id: &str) -> Vec<String> {
         // rebuild self-heals it.
         ReadScope::Traject(traject) => {
             let result = traject.implementors_of(law_id).await;
-            if !result.skipped_law_ids.is_empty() {
+            if result.skipped_count > 0 {
                 tracing::debug!(
                     law_id = %law_id,
-                    skipped = result.skipped_law_ids.len(),
+                    skipped = result.skipped_count,
                     found = result.implementors.len(),
                     "implementors lookup is incomplete: some law bodies could not be fetched when the implements index was built"
                 );

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -468,12 +468,15 @@ async fn implementors_in_scope(scope: &ReadScope, law_id: &str) -> Vec<String> {
         // Laws whose body fetch failed during the scan are *reported*
         // rather than silently passed off as "no implementors"; the
         // response shape (a bare id array) has no room for a non-breaking
-        // partiality flag, so the signal is a warn for operators and the
-        // failed set self-heals at the next snapshot.
+        // partiality flag. The index build already warns once (with the
+        // skipped/indexed counts) when it records fetch failures, so the
+        // per-request signal here is debug-only — a warn per lookup would
+        // re-log the same incident on every panel open until the next
+        // rebuild self-heals it.
         ReadScope::Traject(traject) => {
             let result = traject.implementors_of(law_id).await;
             if !result.skipped_law_ids.is_empty() {
-                tracing::warn!(
+                tracing::debug!(
                     law_id = %law_id,
                     skipped = result.skipped_law_ids.len(),
                     found = result.implementors.len(),

--- a/packages/editor-api/src/state.rs
+++ b/packages/editor-api/src/state.rs
@@ -61,6 +61,11 @@ impl OidcAppState for AppState {
 /// A registered backend along with its writability flag, captured at init
 /// time after [`RepoBackend::ensure_ready`] (so a local source on a
 /// read-only filesystem is recorded as `writable: false`).
+///
+/// `Clone` is shallow: the clone shares the same backend mutex, which is
+/// exactly what the traject index refresh needs (in-flight saves keep
+/// serialising on the same lock across a snapshot swap).
+#[derive(Clone)]
 pub struct BackendEntry {
     pub backend: Arc<Mutex<Box<dyn RepoBackend>>>,
     pub writable: bool,

--- a/packages/editor-api/src/traject_corpus.rs
+++ b/packages/editor-api/src/traject_corpus.rs
@@ -177,6 +177,16 @@ const TRAJECT_INDEX_TTL: Duration = Duration::from_secs(60);
 /// instead of growing without bound.
 const BODY_CACHE_MAX_ENTRIES: usize = 1024;
 
+/// When an implements-index build would otherwise fetch at least this many
+/// law bodies one-by-one from a *single* source, pull the whole source in
+/// one archive request instead (see [`RepoBackend::read_all_files`]). Below
+/// the threshold the per-law lazy fetch is cheaper than downloading the
+/// archive. This is what turns the cold build over a large GitHub-backed
+/// traject from O(corpus) Contents calls (a 504) into one download.
+///
+/// [`RepoBackend::read_all_files`]: regelrecht_corpus::backend::RepoBackend::read_all_files
+const BULK_FETCH_THRESHOLD: usize = 16;
+
 /// Lazily-fetched law bodies with a FIFO size cap. FIFO (not LRU) keeps
 /// reads lock-cheap: a cache hit only needs the outer `RwLock`'s read
 /// guard, no per-hit reordering under a write lock. Eviction order only
@@ -453,6 +463,7 @@ impl TrajectCorpus {
         struct ScanEntry {
             law_id: String,
             source_id: String,
+            relative_path: String,
             content_sha: Option<String>,
             loaded_implements: Option<Vec<String>>,
         }
@@ -463,10 +474,66 @@ impl TrajectCorpus {
             .map(|law| ScanEntry {
                 law_id: law.law_id.clone(),
                 source_id: law.source_id.clone(),
+                relative_path: law.relative_path.clone(),
                 content_sha: law.content_sha.clone(),
                 loaded_implements: law.is_loaded().then(|| law.implements.clone()),
             })
             .collect();
+
+        // Cold builds would fetch every metadata-only body. One Contents
+        // call per law is O(corpus) and times out on large GitHub-backed
+        // trajects, so when a single source has many bodies to fetch, pull
+        // the whole source in one archive request and serve the scan from
+        // memory. Keyed by (source_id, source-relative path) to match the
+        // loop's per-entry lookup; deliberately NOT poured into the bounded
+        // body_cache, so a huge corpus can't thrash it.
+        let mut bulk: HashMap<(String, String), String> = HashMap::new();
+        {
+            let mut misses: HashMap<&str, usize> = HashMap::new();
+            for entry in &entries {
+                if overlay.contains_key(&entry.law_id) || entry.loaded_implements.is_some() {
+                    continue;
+                }
+                let memo_hit = entry
+                    .content_sha
+                    .as_ref()
+                    .is_some_and(|sha| memo.contains_key(&(entry.source_id.clone(), sha.clone())));
+                if !memo_hit {
+                    *misses.entry(entry.source_id.as_str()).or_default() += 1;
+                }
+            }
+            for (source_id, count) in misses {
+                if count < BULK_FETCH_THRESHOLD {
+                    continue;
+                }
+                let Some(backend_entry) = self.corpus.backends.get(source_id) else {
+                    continue;
+                };
+                let result = {
+                    let backend = backend_entry.backend.lock().await;
+                    backend.read_all_files(Some("yaml")).await
+                };
+                match result {
+                    Ok(files) => {
+                        tracing::info!(
+                            source_id,
+                            files = files.len(),
+                            "implements scan: bulk-loaded source bodies in one request"
+                        );
+                        for (rel_path, content) in files {
+                            bulk.insert((source_id.to_string(), rel_path), content);
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            source_id,
+                            error = %e,
+                            "implements scan: bulk source load failed; falling back to per-law fetch"
+                        );
+                    }
+                }
+            }
+        }
 
         let mut implements_by_law = HashMap::new();
         let mut failed_law_ids = Vec::new();
@@ -482,6 +549,15 @@ impl TrajectCorpus {
                 let memo_key = entry.content_sha.map(|sha| (entry.source_id.clone(), sha));
                 if let Some(hit) = memo_key.as_ref().and_then(|key| memo.get(key)) {
                     let implements = hit.clone();
+                    if let Some(key) = memo_key {
+                        new_memo.insert(key, implements.clone());
+                    }
+                    implements
+                } else if let Some(yaml) =
+                    bulk.get(&(entry.source_id.clone(), entry.relative_path.clone()))
+                {
+                    // Body came from the one-shot archive download above.
+                    let implements = collect_law_implements(yaml);
                     if let Some(key) = memo_key {
                         new_memo.insert(key, implements.clone());
                     }
@@ -1330,6 +1406,9 @@ mod tests {
         files: HashMap<String, String>,
         fail_reads: bool,
         reads: Arc<AtomicUsize>,
+        /// Counts `read_all_files` (bulk) calls so a test can assert the
+        /// scan pulled a source in one request instead of per-law.
+        bulk_reads: Arc<AtomicUsize>,
     }
 
     impl StubBackend {
@@ -1341,6 +1420,7 @@ mod tests {
                     .collect(),
                 fail_reads: false,
                 reads: Arc::new(AtomicUsize::new(0)),
+                bulk_reads: Arc::new(AtomicUsize::new(0)),
             }
         }
 
@@ -1349,6 +1429,7 @@ mod tests {
                 files: HashMap::new(),
                 fail_reads: true,
                 reads: Arc::new(AtomicUsize::new(0)),
+                bulk_reads: Arc::new(AtomicUsize::new(0)),
             }
         }
     }
@@ -1361,6 +1442,22 @@ mod tests {
                 return Err(CorpusError::Git("simulated throttle".to_string()));
             }
             Ok(self.files.get(path.to_str().unwrap()).cloned())
+        }
+        async fn read_all_files(
+            &self,
+            extension: Option<&str>,
+        ) -> CorpusResult<Vec<(String, String)>> {
+            self.bulk_reads.fetch_add(1, Ordering::SeqCst);
+            if self.fail_reads {
+                return Err(CorpusError::Git("simulated throttle".to_string()));
+            }
+            let suffix = extension.map(|e| format!(".{e}"));
+            Ok(self
+                .files
+                .iter()
+                .filter(|(p, _)| suffix.as_ref().is_none_or(|s| p.ends_with(s)))
+                .map(|(p, c)| (p.clone(), c.clone()))
+                .collect())
         }
         async fn write_file(&self, _: &Path, _: &str) -> CorpusResult<()> {
             Ok(())
@@ -1605,6 +1702,46 @@ mod tests {
         // still found.
         assert_eq!(result.implementors, vec!["regeling_a".to_string()]);
         assert_eq!(result.skipped_count, 1);
+    }
+
+    #[tokio::test]
+    async fn implements_index_bulk_loads_large_source_in_one_request() {
+        // A source with many metadata-only laws (≥ BULK_FETCH_THRESHOLD)
+        // must be pulled in ONE bulk request, not one fetch per law — this
+        // is what stops the cold build 504-ing on large GitHub trajects.
+        let n = BULK_FETCH_THRESHOLD;
+        let mut map = SourceMap::new();
+        let mut files: Vec<(String, String)> = Vec::new();
+        for i in 0..n {
+            let law_id = format!("reg_{i}");
+            metadata_entry(&mut map, &law_id, "seed");
+            files.push((
+                format!("wet/{law_id}/2025-01-01.yaml"),
+                law_body(&law_id, Some("wet_target")),
+            ));
+        }
+        let file_refs: Vec<(&str, &str)> = files
+            .iter()
+            .map(|(p, c)| (p.as_str(), c.as_str()))
+            .collect();
+        let stub = StubBackend::with_files(&file_refs);
+        let reads = stub.reads.clone();
+        let bulk_reads = stub.bulk_reads.clone();
+        let corpus = test_corpus(
+            map,
+            HashMap::from([("seed".to_string(), backend_entry(stub))]),
+        );
+
+        let result = corpus.implementors_of("wet_target").await;
+
+        // Every law is found as an implementor…
+        let mut expected: Vec<String> = (0..n).map(|i| format!("reg_{i}")).collect();
+        expected.sort();
+        assert_eq!(result.implementors, expected);
+        assert_eq!(result.skipped_count, 0);
+        // …via exactly one bulk request and zero per-law fetches.
+        assert_eq!(bulk_reads.load(Ordering::SeqCst), 1);
+        assert_eq!(reads.load(Ordering::SeqCst), 0);
     }
 
     #[tokio::test]

--- a/packages/editor-api/src/traject_corpus.rs
+++ b/packages/editor-api/src/traject_corpus.rs
@@ -6,21 +6,30 @@
 //! routes reads and writes through that traject's [`TrajectCorpus`] instead
 //! of the globally configured [`crate::state::CorpusState`].
 //!
-//! Construction is lazy: the cache holds a [`OnceCell`] per traject, and
-//! the first request that needs the traject pays the clone cost. The cell
-//! pattern means concurrent first-touches on the same traject share one
-//! clone; first-touches on *different* trajects never block each other.
+//! Construction is lazy: the cache holds a slot per traject, and the
+//! first request that needs the traject pays the clone cost. The slot's
+//! build lock means concurrent first-touches on the same traject share
+//! one clone; first-touches on *different* trajects never block each
+//! other.
+//!
+//! The cached index snapshot expires after [`TRAJECT_INDEX_TTL`]: the
+//! first request past the TTL re-enumerates the sources and swaps in a
+//! fresh [`SourceMap`] (new laws merged upstream, re-harvests, saves on
+//! another replica become visible without a process restart), while the
+//! backends, the post-save overlay and the changed-laws cache carry over
+//! so in-flight saves and read-your-writes semantics are unaffected.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use regelrecht_corpus::backend::create_backend;
 use regelrecht_corpus::models::{GitHubSource, LocalSource, Source, SourceType};
+use regelrecht_corpus::source_map::collect_law_implements;
 use regelrecht_corpus::{CorpusRegistry, SourceMap};
 use sqlx::PgPool;
-use tokio::sync::{Mutex, OnceCell, RwLock};
+use tokio::sync::{Mutex, RwLock};
 use uuid::Uuid;
 
 use crate::state::{BackendEntry, CorpusState};
@@ -47,24 +56,51 @@ pub struct TrajectCorpus {
     /// endpoints) to address the traject's own branch directly without
     /// having to reverse-engineer it out of `write_target_for_source`.
     pub writable_own_source_id: String,
-    /// Read-your-writes overlay + lazy-read cache for law YAML content. After
-    /// a successful `save_law` we mirror the persisted body here so subsequent
-    /// reads in the same traject (any session, any user) see the new content
-    /// without forcing a full source_map rebuild against GitHub. It also caches
-    /// bodies fetched lazily on first read (see `law_yaml`), so a re-read of an
-    /// unloaded law (read-only article view, reload, another tab) doesn't spend
-    /// another Contents API call. The overlay is content-only — `LoadedLaw`
-    /// metadata (source_id/relative_path) doesn't change with a content edit,
-    /// so backend resolution keeps using `corpus.source_map`.
+    /// Read-your-writes overlay for law YAML content: only bodies that
+    /// went through a successful `save_law` (see [`record_save`]). After a
+    /// save we mirror the persisted body here so subsequent reads in the
+    /// same traject (any session, any user) see the new content without
+    /// forcing a full source_map rebuild against GitHub. The overlay is
+    /// content-only — `LoadedLaw` metadata (source_id/relative_path)
+    /// doesn't change with a content edit, so backend resolution keeps
+    /// using `corpus.source_map`.
+    ///
+    /// Shared (via the `Arc`) across TTL index refreshes: a refreshed
+    /// snapshot must never resurrect pre-save content, and an in-flight
+    /// save that calls `record_save` on the pre-refresh instance must be
+    /// visible on the post-refresh one. It is only dropped when the whole
+    /// traject cache entry is invalidated (source config change).
     ///
     /// Unbounded growth is intentional: in practice the size is bounded
     /// by the number of distinct laws edited in this traject, with a
-    /// memory budget of roughly N laws × YAML size (KBs). The overlay
-    /// is cleared when the `TrajectCorpus` cache entry is invalidated
-    /// (e.g. on source config change). If a bulk-edit flow is ever
-    /// added that touches many laws per traject, revisit with an LRU
-    /// cap.
-    overlay: RwLock<HashMap<String, String>>,
+    /// memory budget of roughly N laws × YAML size (KBs). If a bulk-edit
+    /// flow is ever added that touches many laws per traject, revisit
+    /// with an LRU cap. (Lazily-fetched read bodies live in the bounded
+    /// `body_cache` below, not here.)
+    overlay: Arc<RwLock<HashMap<String, String>>>,
+    /// Cache of law bodies fetched lazily on first read (see `law_yaml`),
+    /// so a re-read of an unloaded law (read-only article view, reload,
+    /// another tab) doesn't spend another Contents API call.
+    ///
+    /// Unlike `overlay` this is per-snapshot: a TTL index refresh starts
+    /// with an empty cache, so upstream content changes become visible
+    /// within [`TRAJECT_INDEX_TTL`] instead of being served stale until
+    /// process restart. Bounded at [`BODY_CACHE_MAX_ENTRIES`] with FIFO
+    /// eviction so a crawl across a large federated corpus can't grow it
+    /// without limit.
+    body_cache: RwLock<BoundedBodyCache>,
+    /// Per-snapshot "law → laws it `implements`" index, built on demand by
+    /// [`implementors_of`] and discarded with the snapshot (a TTL refresh
+    /// or invalidation starts from `None`). Building it is the one
+    /// O(corpus) body scan; afterwards every implementors lookup is an
+    /// in-memory reverse scan over the parsed lists.
+    implements_index: RwLock<Option<Arc<ImplementsIndex>>>,
+    /// Single-flight gate for building `implements_index`. Held across
+    /// the (potentially long) body-fetching scan WITHOUT holding
+    /// `implements_index` itself, so `record_save` — which runs while the
+    /// writable-own backend mutex is held — can update the index without
+    /// any lock cycle against the scan's backend fetches.
+    implements_build_lock: Mutex<()>,
     /// Short-lived cache of the "edited in this traject" diff
     /// ([`changed_law_ids`]). Each `changed-laws` request would otherwise
     /// fire a GitHub Compare API call, and the library sidebar re-requests
@@ -76,7 +112,9 @@ pub struct TrajectCorpus {
     /// replicas converge within the TTL. A stale entry is also served as a
     /// fallback when a fresh Compare call fails (e.g. token throttled), so
     /// the section degrades to slightly-stale rather than vanishing.
-    changed_cache: RwLock<Option<ChangedLawsCache>>,
+    /// Shared (via the `Arc`) across TTL index refreshes, like `overlay`:
+    /// a refresh must not undo `save_law`'s invalidation of this cache.
+    changed_cache: Arc<RwLock<Option<ChangedLawsCache>>>,
 }
 
 /// Cached result of [`TrajectCorpus::changed_law_ids`] with the instant it
@@ -91,6 +129,82 @@ struct ChangedLawsCache {
 /// promptly in the sidebar, long enough to collapse a burst of library
 /// loads (mount + tab switches + retries) into a single Compare call.
 const CHANGED_LAWS_TTL: Duration = Duration::from_secs(60);
+
+/// How long a traject's cached index snapshot (its [`SourceMap`] plus the
+/// derived body / implements caches) is served before the first request
+/// past the deadline re-enumerates the sources. Same convergence target
+/// as [`CHANGED_LAWS_TTL`]: upstream changes (new laws merged, re-harvests,
+/// saves on another replica) show up within a minute instead of requiring
+/// a process restart, while a burst of library loads still hits the
+/// snapshot. The refresh keeps backends, the post-save overlay and the
+/// changed-laws cache (see [`TrajectCorpusCache::get_or_build`]).
+const TRAJECT_INDEX_TTL: Duration = Duration::from_secs(60);
+
+/// Upper bound on lazily-fetched law bodies cached per traject snapshot
+/// (see [`TrajectCorpus::body_cache`]). At a typical body size of a few
+/// tens of KB this caps the cache at low tens of MB per traject — enough
+/// to cover an implements-index scan over a mid-sized federated corpus
+/// without refetching, while a full-corpus crawl merely evicts FIFO
+/// instead of growing without bound.
+const BODY_CACHE_MAX_ENTRIES: usize = 1024;
+
+/// Lazily-fetched law bodies with a FIFO size cap. FIFO (not LRU) keeps
+/// reads lock-cheap: a cache hit only needs the outer `RwLock`'s read
+/// guard, no per-hit reordering under a write lock. Eviction order only
+/// matters once a traject's read set exceeds [`BODY_CACHE_MAX_ENTRIES`],
+/// which is already crawl territory.
+#[derive(Default)]
+struct BoundedBodyCache {
+    map: HashMap<String, String>,
+    /// Insertion order of the keys in `map`, oldest first.
+    order: VecDeque<String>,
+}
+
+impl BoundedBodyCache {
+    fn get(&self, law_id: &str) -> Option<&String> {
+        self.map.get(law_id)
+    }
+
+    fn insert(&mut self, law_id: String, body: String) {
+        if !self.map.contains_key(&law_id) {
+            while self.map.len() >= BODY_CACHE_MAX_ENTRIES {
+                let Some(oldest) = self.order.pop_front() else {
+                    break;
+                };
+                self.map.remove(&oldest);
+            }
+            self.order.push_back(law_id.clone());
+        }
+        self.map.insert(law_id, body);
+    }
+}
+
+/// Per-snapshot forward index: each law's parsed `implements` list, plus
+/// the laws whose body couldn't be fetched during the scan (throttling,
+/// token expiry, …) and therefore couldn't be checked.
+///
+/// `Clone` exists for `Arc::make_mut` in [`TrajectCorpus::record_save`]:
+/// a post-save entry update copy-on-writes when a lookup still holds the
+/// previous `Arc`.
+#[derive(Clone)]
+struct ImplementsIndex {
+    /// `law_id` → `$id`s of the higher laws it declares it implements.
+    /// Laws with an empty list are omitted.
+    implements_by_law: HashMap<String, Vec<String>>,
+    /// Laws skipped because their body fetch failed. Kept so lookups can
+    /// report partiality instead of silently passing off an incomplete
+    /// scan as "no implementors". Self-heals at the next snapshot
+    /// (TTL refresh / invalidation), which rebuilds the index.
+    failed_law_ids: Vec<String>,
+}
+
+/// Result of [`TrajectCorpus::implementors_of`]: the implementing law ids
+/// plus the ids that could not be checked because their body fetch failed
+/// when the index was built.
+pub struct ImplementorsResult {
+    pub implementors: Vec<String>,
+    pub skipped_law_ids: Vec<String>,
+}
 
 impl TrajectCorpus {
     /// Resolve the YAML content for a law in this traject, preferring the
@@ -113,6 +227,9 @@ impl TrajectCorpus {
         law_id: &str,
     ) -> Result<Option<String>, regelrecht_corpus::error::CorpusError> {
         if let Some(text) = self.overlay.read().await.get(law_id) {
+            return Ok(Some(text.clone()));
+        }
+        if let Some(text) = self.body_cache.read().await.get(law_id) {
             return Ok(Some(text.clone()));
         }
 
@@ -147,12 +264,13 @@ impl TrajectCorpus {
 
         // Cache the lazily-fetched body so re-reads of this unloaded law don't
         // each spend another Contents API call (read-only views, reloads, a
-        // second tab). Same staleness model as the post-save mirror: cleared
-        // when the traject's cache entry is invalidated. Also makes a
-        // genuinely-empty body a one-shot fetch rather than re-fetching every
-        // call (the empty-`yaml_content` "unloaded" sentinel can't tell them
-        // apart, but the overlay short-circuits before that check).
-        self.overlay
+        // second tab). Per-snapshot: discarded on a TTL index refresh so
+        // upstream content changes converge, and bounded so a corpus-wide
+        // crawl can't grow it without limit. Also makes a genuinely-empty
+        // body a one-shot fetch rather than re-fetching every call (the
+        // empty-`yaml_content` "unloaded" sentinel can't tell them apart,
+        // but this cache short-circuits before that check).
+        self.body_cache
             .write()
             .await
             .insert(law_id.to_string(), content.clone());
@@ -162,8 +280,119 @@ impl TrajectCorpus {
     /// Mirror a freshly-saved law's content into the read-your-writes
     /// overlay. Called by `save_law` after a successful `backend.persist`,
     /// so the next GET on the same law (or a refresh) sees the new body.
+    ///
+    /// Also keeps the per-snapshot implements index coherent: a save can
+    /// add or drop `implements` declarations, so when the index has been
+    /// built its entry for this law is replaced with the new body's list.
+    /// (When a save races an in-flight index build the scan may have read
+    /// the pre-save body after this update ran; the entry is then stale
+    /// until the next snapshot — bounded by [`TRAJECT_INDEX_TTL`].)
     pub async fn record_save(&self, law_id: String, body: String) {
-        self.overlay.write().await.insert(law_id, body);
+        let implements = collect_law_implements(&body);
+        self.overlay.write().await.insert(law_id.clone(), body);
+        if let Some(index) = self.implements_index.write().await.as_mut() {
+            let index = Arc::make_mut(index);
+            // The law's body is now known, so it can no longer count as
+            // "skipped due to fetch failure" from an earlier scan.
+            index.failed_law_ids.retain(|id| id != &law_id);
+            if implements.is_empty() {
+                index.implements_by_law.remove(&law_id);
+            } else {
+                index.implements_by_law.insert(law_id, implements);
+            }
+        }
+    }
+
+    /// Law ids whose articles declare `implements` for `law_id` (the IoC
+    /// reverse link), resolved against this snapshot's federated corpus.
+    ///
+    /// The first call builds the per-snapshot [`ImplementsIndex`] — the
+    /// one O(corpus) scan that lazily fetches the body of every
+    /// metadata-only law — and every later call (any target law) is an
+    /// in-memory reverse lookup. Bodies fetched by the scan land in
+    /// `body_cache`, so opening one of the scanned laws afterwards is
+    /// also free. Laws whose body fetch failed are reported in
+    /// [`ImplementorsResult::skipped_law_ids`] instead of being silently
+    /// indistinguishable from "doesn't implement anything"; the failed
+    /// set is retried when the snapshot rolls over (TTL refresh).
+    pub async fn implementors_of(&self, law_id: &str) -> ImplementorsResult {
+        let index = self.implements_index_get_or_build().await;
+        let mut implementors: Vec<String> = index
+            .implements_by_law
+            .iter()
+            .filter(|(id, implemented)| {
+                id.as_str() != law_id && implemented.iter().any(|i| i == law_id)
+            })
+            .map(|(id, _)| id.clone())
+            .collect();
+        implementors.sort();
+        ImplementorsResult {
+            implementors,
+            skipped_law_ids: index.failed_law_ids.clone(),
+        }
+    }
+
+    /// Get the snapshot's implements index, building it on first use.
+    ///
+    /// Single-flighted on `implements_build_lock`; the (long, fetching)
+    /// build never holds the `implements_index` RwLock itself, so a
+    /// concurrent `record_save` — which runs under the writable-own
+    /// backend mutex that the scan may also need — can always complete.
+    async fn implements_index_get_or_build(&self) -> Arc<ImplementsIndex> {
+        if let Some(index) = self.implements_index.read().await.as_ref() {
+            return index.clone();
+        }
+        let _build = self.implements_build_lock.lock().await;
+        // Re-check: another task may have built it while we waited.
+        if let Some(index) = self.implements_index.read().await.as_ref() {
+            return index.clone();
+        }
+
+        let mut implements_by_law = HashMap::new();
+        let mut failed_law_ids = Vec::new();
+        // Collect ids first so the source_map borrow doesn't live across
+        // the awaits below.
+        let law_ids: Vec<String> = self
+            .corpus
+            .source_map
+            .laws()
+            .map(|law| law.law_id.clone())
+            .collect();
+        for law_id in law_ids {
+            // Resolve through `law_yaml`, NOT `LoadedLaw::yaml_content`:
+            // federated laws are metadata-only until first read. The
+            // overlay/body_cache make repeat scans cheap.
+            match self.law_yaml(&law_id).await {
+                Ok(Some(yaml)) => {
+                    let implements = collect_law_implements(&yaml);
+                    if !implements.is_empty() {
+                        implements_by_law.insert(law_id, implements);
+                    }
+                }
+                // A genuine miss (no backend / file vanished) has nothing
+                // to index and nothing to retry.
+                Ok(None) => {}
+                Err(e) => {
+                    tracing::debug!(law_id = %law_id, error = %e, "implements scan: body fetch failed");
+                    failed_law_ids.push(law_id);
+                }
+            }
+        }
+        if !failed_law_ids.is_empty() {
+            tracing::warn!(
+                failed = failed_law_ids.len(),
+                indexed = implements_by_law.len(),
+                "implements index built with fetch failures; implementor lists may be incomplete until the next snapshot"
+            );
+        }
+        failed_law_ids.sort();
+
+        let index = Arc::new(ImplementsIndex {
+            implements_by_law,
+            failed_law_ids,
+        });
+        *self.implements_index.write().await = Some(index.clone());
+        index
     }
 
     /// Law ids that have been edited in this traject: the diff between the
@@ -259,17 +488,61 @@ impl TrajectCorpus {
     }
 }
 
-/// Lazy registry of per-traject corpora, mirroring the
-/// `CorpusState`-per-traject design. Each cell is initialised exactly
-/// once; concurrent first-touches on the same traject share the clone.
+/// A built traject corpus plus the instant its index snapshot was
+/// (re)built, for TTL expiry.
+struct CachedCorpus {
+    corpus: Arc<TrajectCorpus>,
+    built_at: Instant,
+}
+
+impl CachedCorpus {
+    fn is_fresh(&self, ttl: Duration) -> bool {
+        self.built_at.elapsed() < ttl
+    }
+}
+
+/// Per-traject cache slot. `state` holds the current snapshot (None until
+/// first build); `build_lock` single-flights both the initial build and
+/// TTL refreshes so concurrent first-touches share one clone and a
+/// refresh herd collapses to one source enumeration.
 #[derive(Default)]
+struct TrajectSlot {
+    state: RwLock<Option<CachedCorpus>>,
+    build_lock: Mutex<()>,
+}
+
+/// Lazy registry of per-traject corpora, mirroring the
+/// `CorpusState`-per-traject design. Concurrent first-touches on the same
+/// traject share one build; first-touches on *different* trajects never
+/// block each other. A built snapshot is served for `index_ttl` and then
+/// refreshed in place (see [`Self::get_or_build`]).
 pub struct TrajectCorpusCache {
-    cells: RwLock<HashMap<Uuid, Arc<OnceCell<Arc<TrajectCorpus>>>>>,
+    cells: RwLock<HashMap<Uuid, Arc<TrajectSlot>>>,
+    /// How long an index snapshot is served before it is refreshed.
+    /// [`TRAJECT_INDEX_TTL`] in production; tests inject shorter values
+    /// via [`Self::with_index_ttl`].
+    index_ttl: Duration,
+}
+
+impl Default for TrajectCorpusCache {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl TrajectCorpusCache {
     pub fn new() -> Self {
-        Self::default()
+        Self::with_index_ttl(TRAJECT_INDEX_TTL)
+    }
+
+    /// Cache with a caller-chosen snapshot TTL — the injection point for
+    /// tests that need to force (or rule out) a refresh without waiting
+    /// out the production TTL.
+    pub fn with_index_ttl(index_ttl: Duration) -> Self {
+        Self {
+            cells: RwLock::new(HashMap::new()),
+            index_ttl,
+        }
     }
 
     /// Get-or-build the corpus state for a traject.
@@ -277,25 +550,94 @@ impl TrajectCorpusCache {
     /// On a cache miss the slow path queries `traject_corpus_sources`,
     /// instantiates a backend per source (cloning when needed via
     /// `ensure_ready`), and stitches them into a [`CorpusState`].
+    ///
+    /// When the cached snapshot is older than the index TTL, the first
+    /// request past the deadline re-enumerates the sources and swaps in a
+    /// refreshed [`TrajectCorpus`] (see [`refresh_traject_corpus`] for
+    /// what carries over); concurrent requests keep being served the
+    /// stale snapshot while one refresh is in flight, and a failed
+    /// refresh extends the stale snapshot for another TTL window instead
+    /// of erroring reads (same degrade-to-stale stance as
+    /// [`TrajectCorpus::changed_law_ids`]).
     pub async fn get_or_build(
         &self,
         pool: &PgPool,
         traject_id: Uuid,
         auth_file: Option<PathBuf>,
     ) -> Result<Arc<TrajectCorpus>, TrajectCorpusError> {
-        let cell = {
+        let slot = {
             let mut map = self.cells.write().await;
             map.entry(traject_id)
-                .or_insert_with(|| Arc::new(OnceCell::new()))
+                .or_insert_with(|| Arc::new(TrajectSlot::default()))
                 .clone()
         };
 
-        let built = cell
-            .get_or_try_init(|| async {
-                build_traject_corpus(pool, traject_id, auth_file.as_deref()).await
-            })
-            .await?;
-        Ok(built.clone())
+        // Fast path: a fresh snapshot serves without touching the build
+        // lock. A stale-but-present snapshot is remembered so it can be
+        // served when another task is already refreshing.
+        let stale = {
+            let state = slot.state.read().await;
+            match state.as_ref() {
+                Some(cached) if cached.is_fresh(self.index_ttl) => {
+                    return Ok(cached.corpus.clone())
+                }
+                Some(cached) => Some(cached.corpus.clone()),
+                None => None,
+            }
+        };
+
+        let _build = match &stale {
+            // Nothing cached: every caller must wait for the one build.
+            None => slot.build_lock.lock().await,
+            // Stale: only one task refreshes; the rest serve stale rather
+            // than queueing up behind a network round-trip.
+            Some(stale_corpus) => match slot.build_lock.try_lock() {
+                Ok(guard) => guard,
+                Err(_) => return Ok(stale_corpus.clone()),
+            },
+        };
+
+        // Re-check under the build lock: the previous holder may have
+        // built/refreshed while we waited.
+        let stale = {
+            let state = slot.state.read().await;
+            match state.as_ref() {
+                Some(cached) if cached.is_fresh(self.index_ttl) => {
+                    return Ok(cached.corpus.clone())
+                }
+                Some(cached) => Some(cached.corpus.clone()),
+                None => None,
+            }
+        };
+
+        let corpus = match stale {
+            None => build_traject_corpus(pool, traject_id, auth_file.as_deref()).await?,
+            Some(old) => match refresh_traject_corpus(&old, traject_id).await {
+                Ok(refreshed) => refreshed,
+                Err(e) => {
+                    // Serve (and re-arm) the stale snapshot rather than
+                    // failing reads on a transient enumeration error; the
+                    // re-armed `built_at` stops every subsequent request
+                    // from re-attempting against a throttled upstream.
+                    tracing::warn!(
+                        traject = %traject_id,
+                        error = %e,
+                        "traject index refresh failed; serving stale snapshot for another TTL"
+                    );
+                    *slot.state.write().await = Some(CachedCorpus {
+                        corpus: old.clone(),
+                        built_at: Instant::now(),
+                    });
+                    return Ok(old);
+                }
+            },
+        };
+
+        *slot.state.write().await = Some(CachedCorpus {
+            corpus: corpus.clone(),
+            built_at: Instant::now(),
+        });
+        Ok(corpus)
     }
 
     /// Drop the cached entry for a traject so the next request rebuilds.
@@ -556,8 +898,70 @@ async fn build_traject_corpus(
         },
         write_target_for_source,
         writable_own_source_id,
-        overlay: RwLock::new(HashMap::new()),
-        changed_cache: RwLock::new(None),
+        overlay: Arc::new(RwLock::new(HashMap::new())),
+        body_cache: RwLock::new(BoundedBodyCache::default()),
+        implements_index: RwLock::new(None),
+        implements_build_lock: Mutex::new(()),
+        changed_cache: Arc::new(RwLock::new(None)),
+    }))
+}
+
+/// Build a TTL-refreshed [`TrajectCorpus`] from an existing one: a fresh
+/// index snapshot over the *same* sources and backends.
+///
+/// Carried over from `old` (so a refresh can never break in-flight save
+/// semantics):
+/// - the **backends map** — the same `Arc<Mutex<…>>` instances, so a save
+///   holding a backend mutex across the refresh keeps excluding writers
+///   and the writable-own → seed lock-ordering invariant is unaffected;
+/// - the **post-save `overlay`** (shared `Arc`) — refreshed reads keep
+///   seeing saved bodies (never resurrect pre-save content), and a save
+///   that lands on the pre-refresh instance is visible post-refresh;
+/// - the **changed-laws cache** (shared `Arc`) — same reasoning for
+///   `save_law`'s invalidation;
+/// - the **write routing** (`write_target_for_source`,
+///   `writable_own_source_id`) and the registry/auth config, which only
+///   change through traject create/delete → [`TrajectCorpusCache::invalidate`].
+///
+/// Fresh in the new instance:
+/// - the **`source_map` index snapshot** — the point of the refresh;
+/// - the **`body_cache`** — so upstream body changes become visible;
+/// - the **implements index** — rebuilt on demand against the new snapshot.
+///
+/// Any source failing to enumerate fails the whole refresh: the caller
+/// then serves the previous (complete) snapshot for another TTL, which
+/// strictly beats swapping in a snapshot with thousands of laws missing.
+async fn refresh_traject_corpus(
+    old: &Arc<TrajectCorpus>,
+    traject_id: Uuid,
+) -> Result<Arc<TrajectCorpus>, TrajectCorpusError> {
+    let registry = old.corpus.registry.clone();
+    let auth_file = old.corpus.auth_file.clone();
+    let (source_map, failed) = registry
+        .index_all_sources_async(auth_file.as_deref())
+        .await?;
+    if !failed.is_empty() {
+        return Err(TrajectCorpusError::Corpus(
+            regelrecht_corpus::error::CorpusError::Config(format!(
+                "index refresh for traject {traject_id} failed to enumerate sources: {failed:?}"
+            )),
+        ));
+    }
+
+    Ok(Arc::new(TrajectCorpus {
+        corpus: CorpusState {
+            registry,
+            source_map,
+            backends: old.corpus.backends.clone(),
+            auth_file,
+        },
+        write_target_for_source: old.write_target_for_source.clone(),
+        writable_own_source_id: old.writable_own_source_id.clone(),
+        overlay: old.overlay.clone(),
+        body_cache: RwLock::new(BoundedBodyCache::default()),
+        implements_index: RwLock::new(None),
+        implements_build_lock: Mutex::new(()),
+        changed_cache: old.changed_cache.clone(),
     }))
 }
 
@@ -608,6 +1012,456 @@ struct TrajectSourceRow {
     auth_ref: Option<String>,
     scopes: serde_json::Value,
     is_writable_own: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    //! Unit tests for the snapshot caches: the bounded lazy-body cache,
+    //! the TTL freshness rule, the per-snapshot implements index (incl.
+    //! the fetch-failure path) and the carry-over semantics of a TTL
+    //! index refresh. The DB-backed `get_or_build` flow is covered by
+    //! the `traject_reads_test` integration tests.
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+
+    use super::*;
+
+    use std::path::Path;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use async_trait::async_trait;
+    use regelrecht_corpus::backend::{
+        FileEntry, PersistOutcome, RepoBackend, WriteContext as CorpusWriteContext,
+    };
+    use regelrecht_corpus::error::{CorpusError, Result as CorpusResult};
+
+    /// In-memory backend stub: serves a fixed file set, optionally
+    /// failing every read (the throttled-fetch path), and counts reads
+    /// so tests can assert a cache hit skipped the backend.
+    struct StubBackend {
+        files: HashMap<String, String>,
+        fail_reads: bool,
+        reads: Arc<AtomicUsize>,
+    }
+
+    impl StubBackend {
+        fn with_files(files: &[(&str, &str)]) -> Self {
+            Self {
+                files: files
+                    .iter()
+                    .map(|(p, c)| (p.to_string(), c.to_string()))
+                    .collect(),
+                fail_reads: false,
+                reads: Arc::new(AtomicUsize::new(0)),
+            }
+        }
+
+        fn failing() -> Self {
+            Self {
+                files: HashMap::new(),
+                fail_reads: true,
+                reads: Arc::new(AtomicUsize::new(0)),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl RepoBackend for StubBackend {
+        async fn read_file(&self, path: &Path) -> CorpusResult<Option<String>> {
+            self.reads.fetch_add(1, Ordering::SeqCst);
+            if self.fail_reads {
+                return Err(CorpusError::Git("simulated throttle".to_string()));
+            }
+            Ok(self.files.get(path.to_str().unwrap()).cloned())
+        }
+        async fn write_file(&self, _: &Path, _: &str) -> CorpusResult<()> {
+            Ok(())
+        }
+        async fn delete_file(&self, _: &Path) -> CorpusResult<()> {
+            Ok(())
+        }
+        async fn list_files(&self, _: &Path, _: Option<&str>) -> CorpusResult<Vec<FileEntry>> {
+            Ok(Vec::new())
+        }
+        async fn persist(&self, _: &CorpusWriteContext) -> CorpusResult<PersistOutcome> {
+            Ok(PersistOutcome::default())
+        }
+        async fn ensure_ready(&mut self) -> CorpusResult<()> {
+            Ok(())
+        }
+        fn is_writable(&self) -> bool {
+            true
+        }
+    }
+
+    fn backend_entry(backend: StubBackend) -> BackendEntry {
+        BackendEntry {
+            backend: Arc::new(Mutex::new(Box::new(backend) as Box<dyn RepoBackend>)),
+            writable: true,
+        }
+    }
+
+    /// Bare `TrajectCorpus` over the given index + backends; no DB, no
+    /// network.
+    fn test_corpus(
+        source_map: SourceMap,
+        backends: HashMap<String, BackendEntry>,
+    ) -> TrajectCorpus {
+        TrajectCorpus {
+            corpus: CorpusState {
+                registry: CorpusRegistry::empty(),
+                source_map,
+                backends,
+                auth_file: None,
+            },
+            write_target_for_source: HashMap::new(),
+            writable_own_source_id: "own".to_string(),
+            overlay: Arc::new(RwLock::new(HashMap::new())),
+            body_cache: RwLock::new(BoundedBodyCache::default()),
+            implements_index: RwLock::new(None),
+            implements_build_lock: Mutex::new(()),
+            changed_cache: Arc::new(RwLock::new(None)),
+        }
+    }
+
+    fn metadata_entry(map: &mut SourceMap, law_id: &str, source_id: &str) {
+        map.load_metadata_entry(
+            law_id,
+            &format!("wet/{law_id}/2025-01-01.yaml"),
+            None,
+            source_id,
+            source_id,
+            // Distinct priorities per source: equal-priority conflicts
+            // across sources are a hard SourceMap error.
+            if source_id == "own" { 0 } else { 1 },
+        )
+        .unwrap();
+    }
+
+    fn law_body(law_id: &str, implements: Option<&str>) -> String {
+        match implements {
+            Some(higher) => format!(
+                "$id: {law_id}\narticles:\n  - number: '1'\n    machine_readable:\n      implements:\n        - law: {higher}\n"
+            ),
+            None => format!("$id: {law_id}\narticles: []\n"),
+        }
+    }
+
+    // ---- BoundedBodyCache ----
+
+    #[test]
+    fn body_cache_evicts_oldest_at_cap() {
+        let mut cache = BoundedBodyCache::default();
+        for i in 0..BODY_CACHE_MAX_ENTRIES + 10 {
+            cache.insert(format!("law_{i}"), "body".to_string());
+        }
+        assert_eq!(cache.map.len(), BODY_CACHE_MAX_ENTRIES);
+        // The 10 oldest entries were evicted FIFO; the newest survive.
+        assert!(cache.get("law_0").is_none());
+        assert!(cache.get("law_9").is_none());
+        assert!(cache.get("law_10").is_some());
+        assert!(cache
+            .get(&format!("law_{}", BODY_CACHE_MAX_ENTRIES + 9))
+            .is_some());
+    }
+
+    #[test]
+    fn body_cache_overwrite_does_not_grow_or_evict() {
+        let mut cache = BoundedBodyCache::default();
+        cache.insert("a".to_string(), "v1".to_string());
+        cache.insert("b".to_string(), "v1".to_string());
+        cache.insert("a".to_string(), "v2".to_string());
+        assert_eq!(cache.map.len(), 2);
+        assert_eq!(cache.order.len(), 2);
+        assert_eq!(cache.get("a").map(String::as_str), Some("v2"));
+    }
+
+    // ---- TTL freshness ----
+
+    #[test]
+    fn cached_corpus_freshness_respects_ttl() {
+        let cached = CachedCorpus {
+            corpus: Arc::new(test_corpus(SourceMap::new(), HashMap::new())),
+            built_at: Instant::now(),
+        };
+        // A just-built snapshot is fresh under the production TTL…
+        assert!(cached.is_fresh(TRAJECT_INDEX_TTL));
+        // …and stale under a zero TTL (the injection tests use).
+        assert!(!cached.is_fresh(Duration::ZERO));
+    }
+
+    // ---- law_yaml / body cache interplay ----
+
+    #[tokio::test]
+    async fn law_yaml_caches_lazy_fetch_and_prefers_overlay() {
+        let mut map = SourceMap::new();
+        metadata_entry(&mut map, "wet_a", "seed");
+        let stub = StubBackend::with_files(&[("wet/wet_a/2025-01-01.yaml", "$id: wet_a\n")]);
+        let reads = stub.reads.clone();
+        let corpus = test_corpus(
+            map,
+            HashMap::from([("seed".to_string(), backend_entry(stub))]),
+        );
+
+        // First read fetches and caches…
+        assert_eq!(
+            corpus.law_yaml("wet_a").await.unwrap().as_deref(),
+            Some("$id: wet_a\n")
+        );
+        assert_eq!(reads.load(Ordering::SeqCst), 1);
+        // …second read is a body-cache hit, no backend round-trip.
+        assert_eq!(
+            corpus.law_yaml("wet_a").await.unwrap().as_deref(),
+            Some("$id: wet_a\n")
+        );
+        assert_eq!(reads.load(Ordering::SeqCst), 1);
+
+        // A save wins over the cached body (read-your-writes).
+        corpus
+            .record_save("wet_a".to_string(), "$id: wet_a\nname: saved\n".to_string())
+            .await;
+        assert_eq!(
+            corpus.law_yaml("wet_a").await.unwrap().as_deref(),
+            Some("$id: wet_a\nname: saved\n")
+        );
+    }
+
+    // ---- implements index ----
+
+    #[tokio::test]
+    async fn implementors_of_builds_index_once_and_reverse_looks_up() {
+        let mut map = SourceMap::new();
+        metadata_entry(&mut map, "regeling_a", "seed");
+        metadata_entry(&mut map, "wet_hoger", "seed");
+        let stub = StubBackend::with_files(&[
+            (
+                "wet/regeling_a/2025-01-01.yaml",
+                &law_body("regeling_a", Some("wet_hoger")),
+            ),
+            (
+                "wet/wet_hoger/2025-01-01.yaml",
+                &law_body("wet_hoger", None),
+            ),
+        ]);
+        let reads = stub.reads.clone();
+        let corpus = test_corpus(
+            map,
+            HashMap::from([("seed".to_string(), backend_entry(stub))]),
+        );
+
+        let result = corpus.implementors_of("wet_hoger").await;
+        assert_eq!(result.implementors, vec!["regeling_a".to_string()]);
+        assert!(result.skipped_law_ids.is_empty());
+        let reads_after_build = reads.load(Ordering::SeqCst);
+        assert_eq!(reads_after_build, 2, "index build fetches each body once");
+
+        // A second lookup — different target — reuses the index without
+        // re-fetching anything.
+        let result = corpus.implementors_of("regeling_a").await;
+        assert!(result.implementors.is_empty());
+        assert_eq!(reads.load(Ordering::SeqCst), reads_after_build);
+    }
+
+    #[tokio::test]
+    async fn implementors_of_reports_fetch_failures_as_skipped() {
+        let mut map = SourceMap::new();
+        metadata_entry(&mut map, "regeling_a", "seed");
+        metadata_entry(&mut map, "wet_kapot", "broken");
+        let stub = StubBackend::with_files(&[(
+            "wet/regeling_a/2025-01-01.yaml",
+            &law_body("regeling_a", Some("wet_hoger")),
+        )]);
+        let corpus = test_corpus(
+            map,
+            HashMap::from([
+                ("seed".to_string(), backend_entry(stub)),
+                ("broken".to_string(), backend_entry(StubBackend::failing())),
+            ]),
+        );
+
+        let result = corpus.implementors_of("wet_hoger").await;
+        // The throttled law is reported as skipped — distinguishable from
+        // "checked and implements nothing" — while the healthy law is
+        // still found.
+        assert_eq!(result.implementors, vec!["regeling_a".to_string()]);
+        assert_eq!(result.skipped_law_ids, vec!["wet_kapot".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn record_save_updates_built_implements_index_in_place() {
+        let mut map = SourceMap::new();
+        metadata_entry(&mut map, "regeling_a", "seed");
+        let stub = StubBackend::with_files(&[(
+            "wet/regeling_a/2025-01-01.yaml",
+            &law_body("regeling_a", None),
+        )]);
+        let corpus = test_corpus(
+            map,
+            HashMap::from([("seed".to_string(), backend_entry(stub))]),
+        );
+
+        // Build the index against the pre-save body: no implementors.
+        assert!(corpus
+            .implementors_of("wet_hoger")
+            .await
+            .implementors
+            .is_empty());
+
+        // The save adds an `implements` declaration; the lookup must see
+        // it immediately — no snapshot rollover needed.
+        corpus
+            .record_save(
+                "regeling_a".to_string(),
+                law_body("regeling_a", Some("wet_hoger")),
+            )
+            .await;
+        assert_eq!(
+            corpus.implementors_of("wet_hoger").await.implementors,
+            vec!["regeling_a".to_string()]
+        );
+
+        // And the reverse: a save dropping the declaration removes it.
+        corpus
+            .record_save("regeling_a".to_string(), law_body("regeling_a", None))
+            .await;
+        assert!(corpus
+            .implementors_of("wet_hoger")
+            .await
+            .implementors
+            .is_empty());
+    }
+
+    // ---- TTL index refresh ----
+
+    /// Build a real local-source `TrajectCorpus` over `dir`, the manual
+    /// equivalent of `build_traject_corpus` without the DB round-trip.
+    async fn local_corpus(dir: &Path) -> Arc<TrajectCorpus> {
+        let source = Source {
+            id: "own".to_string(),
+            name: "Own".to_string(),
+            source_type: SourceType::Local {
+                local: LocalSource {
+                    path: dir.to_path_buf(),
+                },
+            },
+            scopes: vec![],
+            priority: 0,
+            auth_ref: None,
+        };
+        let registry = CorpusRegistry::from_sources(vec![source.clone()]);
+        let source_map = registry.load_local_sources().unwrap();
+        let mut backend = create_backend(&source, None).unwrap();
+        backend.ensure_ready().await.unwrap();
+        let writable = backend.is_writable();
+        let backends = HashMap::from([(
+            "own".to_string(),
+            BackendEntry {
+                backend: Arc::new(Mutex::new(backend)),
+                writable,
+            },
+        )]);
+        Arc::new(TrajectCorpus {
+            corpus: CorpusState {
+                registry,
+                source_map,
+                backends,
+                auth_file: None,
+            },
+            write_target_for_source: HashMap::new(),
+            writable_own_source_id: "own".to_string(),
+            overlay: Arc::new(RwLock::new(HashMap::new())),
+            body_cache: RwLock::new(BoundedBodyCache::default()),
+            implements_index: RwLock::new(None),
+            implements_build_lock: Mutex::new(()),
+            changed_cache: Arc::new(RwLock::new(None)),
+        })
+    }
+
+    fn write_law_file(dir: &Path, law_id: &str, body: &str) {
+        let law_dir = dir.join("wet").join(law_id);
+        std::fs::create_dir_all(&law_dir).unwrap();
+        std::fs::write(law_dir.join("2025-01-01.yaml"), body).unwrap();
+    }
+
+    #[tokio::test]
+    async fn refresh_swaps_index_but_carries_backends_overlay_and_changed_cache() {
+        let dir = tempfile::tempdir().unwrap();
+        write_law_file(dir.path(), "wet_a", "$id: wet_a\nname: v1\n");
+        let old = local_corpus(dir.path()).await;
+
+        // A save lands in the overlay before the refresh…
+        old.record_save("wet_a".to_string(), "$id: wet_a\nname: saved\n".to_string())
+            .await;
+        // …and upstream gains a brand-new law the old snapshot misses.
+        write_law_file(dir.path(), "wet_b", "$id: wet_b\nname: nieuw\n");
+        assert!(old.corpus.source_map.get_law("wet_b").is_none());
+
+        let refreshed = refresh_traject_corpus(&old, Uuid::new_v4())
+            .await
+            .expect("local refresh must succeed");
+
+        // Fresh snapshot: the new upstream law is now indexed.
+        assert!(refreshed.corpus.source_map.get_law("wet_b").is_some());
+        // The backends are the *same* mutexes — an in-flight save keeps
+        // excluding writers across the swap.
+        assert!(Arc::ptr_eq(
+            &old.corpus.backends["own"].backend,
+            &refreshed.corpus.backends["own"].backend
+        ));
+        // The overlay carried over: the refresh must never resurrect
+        // pre-save content.
+        assert_eq!(
+            refreshed.law_yaml("wet_a").await.unwrap().as_deref(),
+            Some("$id: wet_a\nname: saved\n")
+        );
+        // A save recorded on the OLD instance after the swap is visible
+        // through the refreshed one (shared overlay, not a copy).
+        old.record_save(
+            "wet_a".to_string(),
+            "$id: wet_a\nname: saved2\n".to_string(),
+        )
+        .await;
+        assert_eq!(
+            refreshed.law_yaml("wet_a").await.unwrap().as_deref(),
+            Some("$id: wet_a\nname: saved2\n")
+        );
+        // The changed-laws cache is shared for the same reason.
+        assert!(Arc::ptr_eq(&old.changed_cache, &refreshed.changed_cache));
+    }
+
+    #[tokio::test]
+    async fn refresh_resets_the_implements_index_with_the_snapshot() {
+        let dir = tempfile::tempdir().unwrap();
+        write_law_file(dir.path(), "wet_hoger", &law_body("wet_hoger", None));
+        let old = local_corpus(dir.path()).await;
+        assert!(old
+            .implementors_of("wet_hoger")
+            .await
+            .implementors
+            .is_empty());
+
+        // A new implementing regulation lands upstream (e.g. merged on
+        // the central corpus / saved on another replica).
+        write_law_file(
+            dir.path(),
+            "regeling_a",
+            &law_body("regeling_a", Some("wet_hoger")),
+        );
+        let refreshed = refresh_traject_corpus(&old, Uuid::new_v4())
+            .await
+            .expect("local refresh must succeed");
+
+        // The refreshed snapshot rebuilds its own index and finds it; the
+        // old instance's cached index is untouched (per-snapshot).
+        assert_eq!(
+            refreshed.implementors_of("wet_hoger").await.implementors,
+            vec!["regeling_a".to_string()]
+        );
+        assert!(old
+            .implementors_of("wet_hoger")
+            .await
+            .implementors
+            .is_empty());
+    }
 }
 
 impl TrajectSourceRow {

--- a/packages/editor-api/src/traject_corpus.rs
+++ b/packages/editor-api/src/traject_corpus.rs
@@ -1249,6 +1249,14 @@ async fn next_snapshot(old: &Arc<TrajectCorpus>, source_map: SourceMap) -> Arc<T
 /// network blip). The removal itself is compare-and-remove: an entry
 /// replaced by a concurrent `record_save` after this pass snapshotted it
 /// is left alone.
+///
+/// Note the drop also fires on a *version rollover*, not just a direct
+/// push: the path comes from the new `source_map`, which already picked
+/// `best_per_law`. If a corpus update publishes a newer valid-from date
+/// file for the same `law_id` (e.g. `2026-01-01.yaml` superseding the
+/// user's `2025-01-01.yaml` save), the branch read returns the new
+/// version, it differs from the saved body, and the overlay entry is
+/// dropped — the newer version correctly supersedes the pinned save.
 async fn reconcile_overlay(old: &Arc<TrajectCorpus>, source_map: &SourceMap) {
     let entries: Vec<(String, String)> = old
         .overlay

--- a/packages/editor-api/src/traject_corpus.rs
+++ b/packages/editor-api/src/traject_corpus.rs
@@ -220,6 +220,15 @@ impl BoundedBodyCache {
 
 /// Content-addressed memo behind [`TrajectCorpus::implements_memo`]:
 /// `(source_id, blob sha) → parsed implements list`.
+///
+/// The sha is the one the Trees enumeration reported at source-map build
+/// time, while the body is fetched separately (clone read or, for the
+/// writable-own API backend, the tarball). A branch push between those two
+/// steps can key an entry under sha A while the body parsed was sha B — a
+/// bounded staleness, the same TOCTOU the per-law fetch path has always
+/// had. It is harmless: the implements index only drives the editor's
+/// implementor panel (never legal calculations), and it self-heals once
+/// the law's sha changes again and a rebuild overwrites the memo wholesale.
 type ImplementsMemo = HashMap<(String, String), Vec<String>>;
 
 /// Per-snapshot forward index: each law's parsed `implements` list, plus
@@ -246,9 +255,13 @@ struct ImplementsIndex {
 /// when the index was built.
 pub struct ImplementorsResult {
     pub implementors: Vec<String>,
-    /// Count of laws skipped because their body fetch failed when the index
-    /// was built — reported so callers can surface partiality instead of
-    /// passing off an incomplete scan as "no implementors".
+    /// Number of laws whose body could not be read **anywhere in the index
+    /// build** — this is an index-wide count, NOT scoped to the queried
+    /// law. It signals that the index (and therefore *any* implementor
+    /// lookup against it) may be incomplete, not that these specific
+    /// failures implement the queried law. Reported so callers can surface
+    /// partiality instead of passing an incomplete scan off as "no
+    /// implementors". Self-heals at the next snapshot rebuild.
     pub skipped_count: usize,
 }
 

--- a/packages/editor-api/src/traject_corpus.rs
+++ b/packages/editor-api/src/traject_corpus.rs
@@ -16,11 +16,14 @@
 //! first request past the TTL re-enumerates the sources and swaps in a
 //! fresh [`SourceMap`] (new laws merged upstream, re-harvests, saves on
 //! another replica become visible without a process restart), while the
-//! backends, the post-save overlay and the changed-laws cache carry over
-//! so in-flight saves and read-your-writes semantics are unaffected.
+//! backends, the post-save overlay (reconciled against the branch — see
+//! [`reconcile_overlay`]), the implements index/memo and the
+//! changed-laws cache carry over so in-flight saves, read-your-writes
+//! semantics and implementor lookups are unaffected.
 
 use std::collections::{HashMap, VecDeque};
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -68,8 +71,14 @@ pub struct TrajectCorpus {
     /// Shared (via the `Arc`) across TTL index refreshes: a refreshed
     /// snapshot must never resurrect pre-save content, and an in-flight
     /// save that calls `record_save` on the pre-refresh instance must be
-    /// visible on the post-refresh one. It is only dropped when the whole
-    /// traject cache entry is invalidated (source config change).
+    /// visible on the post-refresh one. Each refresh *reconciles* the
+    /// entries against the write-target branch (see [`reconcile_overlay`]):
+    /// an entry whose branch file no longer matches the saved body was
+    /// overwritten by someone else (another replica, a direct push) and is
+    /// dropped, so reads converge to the branch instead of pinning this
+    /// process's save forever — read-your-writes-or-newer, not
+    /// read-your-writes-forever. The whole map is dropped when the traject
+    /// cache entry is invalidated (source config change).
     ///
     /// Unbounded growth is intentional: in practice the size is bounded
     /// by the number of distinct laws edited in this traject, with a
@@ -89,18 +98,38 @@ pub struct TrajectCorpus {
     /// eviction so a crawl across a large federated corpus can't grow it
     /// without limit.
     body_cache: RwLock<BoundedBodyCache>,
-    /// Per-snapshot "law → laws it `implements`" index, built on demand by
-    /// [`implementors_of`] and discarded with the snapshot (a TTL refresh
-    /// or invalidation starts from `None`). Building it is the one
-    /// O(corpus) body scan; afterwards every implementors lookup is an
-    /// in-memory reverse scan over the parsed lists.
+    /// "Law → laws it `implements`" index, built on demand by
+    /// [`implementors_of`]. A TTL refresh carries the previous snapshot's
+    /// index over as a *stale* value (see `implements_index_stale`) and
+    /// rebuilds it lazily against the new snapshot — stale-while-
+    /// revalidate, like the snapshot itself: a lookup is never blocked on
+    /// a corpus rescan when a previous index exists. The rebuild itself
+    /// is cheap thanks to `implements_memo`.
     implements_index: RwLock<Option<Arc<ImplementsIndex>>>,
+    /// Whether the value in `implements_index` was built against a
+    /// *previous* snapshot (carried over by a TTL refresh). While true,
+    /// the first lookup to win `implements_build_lock` rebuilds against
+    /// this snapshot; concurrent lookups keep serving the carried index.
+    implements_index_stale: AtomicBool,
     /// Single-flight gate for building `implements_index`. Held across
-    /// the (potentially long) body-fetching scan WITHOUT holding
-    /// `implements_index` itself, so `record_save` — which runs while the
-    /// writable-own backend mutex is held — can update the index without
-    /// any lock cycle against the scan's backend fetches.
+    /// the (potentially fetching) scan WITHOUT holding `implements_index`
+    /// itself, so `record_save` — which runs while the writable-own
+    /// backend mutex is held — can update the index without any lock
+    /// cycle against the scan's backend fetches.
     implements_build_lock: Mutex<()>,
+    /// Cross-snapshot content-addressed memo for the implements scan:
+    /// `(source_id, blob sha) → parsed implements list`. The blob sha
+    /// comes from the Trees enumeration that built the index snapshot
+    /// ([`regelrecht_corpus::source_map::LoadedLaw::content_sha`]), so a
+    /// rebuild after a TTL refresh only fetches/parses bodies whose
+    /// content actually changed — without it the first implementors
+    /// lookup after EVERY refresh would re-fetch the entire federated
+    /// corpus over the Contents API (the scan cost PR #762 removed from
+    /// the request path). Shared (via the `Arc`) across refreshes like
+    /// the overlay; each rebuild swaps in a map containing only the
+    /// entries of the current snapshot, so it cannot grow beyond
+    /// O(corpus) across content churn.
+    implements_memo: Arc<RwLock<ImplementsMemo>>,
     /// Short-lived cache of the "edited in this traject" diff
     /// ([`changed_law_ids`]). Each `changed-laws` request would otherwise
     /// fire a GitHub Compare API call, and the library sidebar re-requests
@@ -178,6 +207,10 @@ impl BoundedBodyCache {
         self.map.insert(law_id, body);
     }
 }
+
+/// Content-addressed memo behind [`TrajectCorpus::implements_memo`]:
+/// `(source_id, blob sha) → parsed implements list`.
+type ImplementsMemo = HashMap<(String, String), Vec<String>>;
 
 /// Per-snapshot forward index: each law's parsed `implements` list, plus
 /// the laws whose body couldn't be fetched during the scan (throttling,
@@ -306,15 +339,20 @@ impl TrajectCorpus {
     /// Law ids whose articles declare `implements` for `law_id` (the IoC
     /// reverse link), resolved against this snapshot's federated corpus.
     ///
-    /// The first call builds the per-snapshot [`ImplementsIndex`] — the
+    /// The first call of the process builds the [`ImplementsIndex`] — the
     /// one O(corpus) scan that lazily fetches the body of every
     /// metadata-only law — and every later call (any target law) is an
-    /// in-memory reverse lookup. Bodies fetched by the scan land in
-    /// `body_cache`, so opening one of the scanned laws afterwards is
-    /// also free. Laws whose body fetch failed are reported in
-    /// [`ImplementorsResult::skipped_law_ids`] instead of being silently
-    /// indistinguishable from "doesn't implement anything"; the failed
-    /// set is retried when the snapshot rolls over (TTL refresh).
+    /// in-memory reverse lookup. A TTL refresh does NOT repeat that scan:
+    /// the previous index is served stale while the first post-refresh
+    /// lookup rebuilds it, and the rebuild resolves unchanged bodies
+    /// through the content-addressed `implements_memo` (blob shas from
+    /// the Trees enumeration), fetching only what actually changed.
+    /// Bodies fetched by a scan land in `body_cache`, so opening one of
+    /// the scanned laws afterwards is also free. Laws whose body fetch
+    /// failed are reported in [`ImplementorsResult::skipped_law_ids`]
+    /// instead of being silently indistinguishable from "doesn't
+    /// implement anything"; the failed set is retried at the next
+    /// rebuild.
     pub async fn implementors_of(&self, law_id: &str) -> ImplementorsResult {
         let index = self.implements_index_get_or_build().await;
         let mut implementors: Vec<String> = index
@@ -334,48 +372,142 @@ impl TrajectCorpus {
 
     /// Get the snapshot's implements index, building it on first use.
     ///
-    /// Single-flighted on `implements_build_lock`; the (long, fetching)
-    /// build never holds the `implements_index` RwLock itself, so a
-    /// concurrent `record_save` — which runs under the writable-own
+    /// Single-flighted on `implements_build_lock`; the (potentially
+    /// fetching) build never holds the `implements_index` RwLock itself,
+    /// so a concurrent `record_save` — which runs under the writable-own
     /// backend mutex that the scan may also need — can always complete.
+    ///
+    /// Stale-while-revalidate across snapshots: a TTL refresh carries the
+    /// previous index over flagged stale. The first lookup to win the
+    /// build lock rebuilds against this snapshot (cheap — the
+    /// content-addressed `implements_memo` means only *changed* bodies
+    /// are fetched/parsed); every other lookup keeps serving the carried
+    /// index instead of queueing behind the rebuild. Only a traject that
+    /// has never built an index at all (first lookup of the process)
+    /// blocks all callers on the one initial scan.
     async fn implements_index_get_or_build(&self) -> Arc<ImplementsIndex> {
-        if let Some(index) = self.implements_index.read().await.as_ref() {
-            return index.clone();
-        }
-        let _build = self.implements_build_lock.lock().await;
-        // Re-check: another task may have built it while we waited.
-        if let Some(index) = self.implements_index.read().await.as_ref() {
-            return index.clone();
+        let carried = {
+            let guard = self.implements_index.read().await;
+            match guard.as_ref() {
+                Some(index) if !self.implements_index_stale.load(Ordering::SeqCst) => {
+                    return index.clone();
+                }
+                other => other.cloned(),
+            }
+        };
+
+        let _build = match &carried {
+            // Nothing to serve: every caller waits for the one build.
+            None => self.implements_build_lock.lock().await,
+            // Stale index available: only one task rebuilds; the rest
+            // serve the carried index rather than queueing up.
+            Some(stale) => match self.implements_build_lock.try_lock() {
+                Ok(guard) => guard,
+                Err(_) => return stale.clone(),
+            },
+        };
+
+        // Re-check under the build lock: the previous holder may have
+        // (re)built while we waited.
+        {
+            let guard = self.implements_index.read().await;
+            if let Some(index) = guard.as_ref() {
+                if !self.implements_index_stale.load(Ordering::SeqCst) {
+                    return index.clone();
+                }
+            }
         }
 
-        let mut implements_by_law = HashMap::new();
-        let mut failed_law_ids = Vec::new();
-        // Collect ids first so the source_map borrow doesn't live across
-        // the awaits below.
-        let law_ids: Vec<String> = self
+        let index = self.build_implements_index().await;
+        *self.implements_index.write().await = Some(index.clone());
+        self.implements_index_stale.store(false, Ordering::SeqCst);
+        index
+    }
+
+    /// One pass over the snapshot's laws producing the implements index.
+    /// Per law, in cost order:
+    /// - **overlay** entries (saved in this traject) are parsed from the
+    ///   overlay body — no fetch, O(locally saved laws);
+    /// - **loaded** entries (local sources) reuse the `implements` list
+    ///   the corpus parsed at load time — no fetch, no parse;
+    /// - **metadata-only** entries hit the cross-snapshot
+    ///   `implements_memo` by `(source_id, blob sha)` — only bodies whose
+    ///   sha changed since the last build (or were never seen) are
+    ///   fetched via [`law_yaml`] (which also feeds the body cache) and
+    ///   parsed.
+    ///
+    /// The memo is swapped wholesale at the end so it only ever holds the
+    /// current snapshot's entries (bounded by corpus size, and a build
+    /// cancelled mid-flight — client disconnect — leaves the old memo
+    /// intact).
+    async fn build_implements_index(&self) -> Arc<ImplementsIndex> {
+        let overlay = self.overlay.read().await.clone();
+        let memo = self.implements_memo.read().await.clone();
+        let mut new_memo: ImplementsMemo = HashMap::new();
+
+        // Collect what we need first so the source_map borrow doesn't
+        // live across the awaits below.
+        struct ScanEntry {
+            law_id: String,
+            source_id: String,
+            content_sha: Option<String>,
+            loaded_implements: Option<Vec<String>>,
+        }
+        let entries: Vec<ScanEntry> = self
             .corpus
             .source_map
             .laws()
-            .map(|law| law.law_id.clone())
+            .map(|law| ScanEntry {
+                law_id: law.law_id.clone(),
+                source_id: law.source_id.clone(),
+                content_sha: law.content_sha.clone(),
+                loaded_implements: law.is_loaded().then(|| law.implements.clone()),
+            })
             .collect();
-        for law_id in law_ids {
-            // Resolve through `law_yaml`, NOT `LoadedLaw::yaml_content`:
-            // federated laws are metadata-only until first read. The
-            // overlay/body_cache make repeat scans cheap.
-            match self.law_yaml(&law_id).await {
-                Ok(Some(yaml)) => {
-                    let implements = collect_law_implements(&yaml);
-                    if !implements.is_empty() {
-                        implements_by_law.insert(law_id, implements);
+
+        let mut implements_by_law = HashMap::new();
+        let mut failed_law_ids = Vec::new();
+        for entry in entries {
+            let implements = if let Some(body) = overlay.get(&entry.law_id) {
+                // A body saved in this traject supersedes both the loaded
+                // content and the enumerated blob; never memo it under the
+                // (pre-save) snapshot sha.
+                collect_law_implements(body)
+            } else if let Some(implements) = entry.loaded_implements {
+                implements
+            } else {
+                let memo_key = entry.content_sha.map(|sha| (entry.source_id.clone(), sha));
+                if let Some(hit) = memo_key.as_ref().and_then(|key| memo.get(key)) {
+                    let implements = hit.clone();
+                    if let Some(key) = memo_key {
+                        new_memo.insert(key, implements.clone());
+                    }
+                    implements
+                } else {
+                    // Resolve through `law_yaml`, NOT `LoadedLaw::yaml_content`:
+                    // metadata-only bodies are fetched lazily (and cached in
+                    // `body_cache` for subsequent opens).
+                    match self.law_yaml(&entry.law_id).await {
+                        Ok(Some(yaml)) => {
+                            let implements = collect_law_implements(&yaml);
+                            if let Some(key) = memo_key {
+                                new_memo.insert(key, implements.clone());
+                            }
+                            implements
+                        }
+                        // A genuine miss (no backend / file vanished) has
+                        // nothing to index and nothing to retry.
+                        Ok(None) => continue,
+                        Err(e) => {
+                            tracing::debug!(law_id = %entry.law_id, error = %e, "implements scan: body fetch failed");
+                            failed_law_ids.push(entry.law_id);
+                            continue;
+                        }
                     }
                 }
-                // A genuine miss (no backend / file vanished) has nothing
-                // to index and nothing to retry.
-                Ok(None) => {}
-                Err(e) => {
-                    tracing::debug!(law_id = %law_id, error = %e, "implements scan: body fetch failed");
-                    failed_law_ids.push(law_id);
-                }
+            };
+            if !implements.is_empty() {
+                implements_by_law.insert(entry.law_id, implements);
             }
         }
         if !failed_law_ids.is_empty() {
@@ -387,12 +519,11 @@ impl TrajectCorpus {
         }
         failed_law_ids.sort();
 
-        let index = Arc::new(ImplementsIndex {
+        *self.implements_memo.write().await = new_memo;
+        Arc::new(ImplementsIndex {
             implements_by_law,
             failed_law_ids,
-        });
-        *self.implements_index.write().await = Some(index.clone());
-        index
+        })
     }
 
     /// Law ids that have been edited in this traject: the diff between the
@@ -509,7 +640,19 @@ impl CachedCorpus {
 struct TrajectSlot {
     state: RwLock<Option<CachedCorpus>>,
     build_lock: Mutex<()>,
+    /// Consecutive failed TTL refreshes. Serving stale stays correct
+    /// indefinitely, but a permanently broken source would otherwise
+    /// re-warn every TTL window — the count rate-limits the warn to the
+    /// first failure and every [`FAILED_REFRESH_WARN_EVERY`]th after
+    /// that (the rest log at debug). Reset on any successful
+    /// build/refresh.
+    refresh_failures: AtomicU32,
 }
+
+/// Every how many consecutive refresh failures the full warn is repeated
+/// (between repeats the failure logs at debug). At the 60s TTL this is
+/// one warn per ~10 minutes for a permanently broken source.
+const FAILED_REFRESH_WARN_EVERY: u32 = 10;
 
 /// Lazy registry of per-traject corpora, mirroring the
 /// `CorpusState`-per-traject design. Concurrent first-touches on the same
@@ -619,11 +762,25 @@ impl TrajectCorpusCache {
                     // failing reads on a transient enumeration error; the
                     // re-armed `built_at` stops every subsequent request
                     // from re-attempting against a throttled upstream.
-                    tracing::warn!(
-                        traject = %traject_id,
-                        error = %e,
-                        "traject index refresh failed; serving stale snapshot for another TTL"
-                    );
+                    // Rate-limit the warn: a permanently broken source
+                    // fails every TTL window, and repeating the same warn
+                    // each minute drowns the log without new signal.
+                    let failures = slot.refresh_failures.fetch_add(1, Ordering::SeqCst) + 1;
+                    if failures == 1 || failures % FAILED_REFRESH_WARN_EVERY == 0 {
+                        tracing::warn!(
+                            traject = %traject_id,
+                            error = %e,
+                            consecutive_failures = failures,
+                            "traject index refresh failed; serving stale snapshot for another TTL"
+                        );
+                    } else {
+                        tracing::debug!(
+                            traject = %traject_id,
+                            error = %e,
+                            consecutive_failures = failures,
+                            "traject index refresh failed again; serving stale snapshot for another TTL"
+                        );
+                    }
                     *slot.state.write().await = Some(CachedCorpus {
                         corpus: old.clone(),
                         built_at: Instant::now(),
@@ -633,6 +790,7 @@ impl TrajectCorpusCache {
             },
         };
 
+        slot.refresh_failures.store(0, Ordering::SeqCst);
         *slot.state.write().await = Some(CachedCorpus {
             corpus: corpus.clone(),
             built_at: Instant::now(),
@@ -901,7 +1059,9 @@ async fn build_traject_corpus(
         overlay: Arc::new(RwLock::new(HashMap::new())),
         body_cache: RwLock::new(BoundedBodyCache::default()),
         implements_index: RwLock::new(None),
+        implements_index_stale: AtomicBool::new(false),
         implements_build_lock: Mutex::new(()),
+        implements_memo: Arc::new(RwLock::new(HashMap::new())),
         changed_cache: Arc::new(RwLock::new(None)),
     }))
 }
@@ -916,17 +1076,23 @@ async fn build_traject_corpus(
 ///   and the writable-own → seed lock-ordering invariant is unaffected;
 /// - the **post-save `overlay`** (shared `Arc`) — refreshed reads keep
 ///   seeing saved bodies (never resurrect pre-save content), and a save
-///   that lands on the pre-refresh instance is visible post-refresh;
+///   that lands on the pre-refresh instance is visible post-refresh. The
+///   entries are *reconciled* against the write-target branch first (see
+///   [`reconcile_overlay`]) so a save overwritten externally stops being
+///   pinned by this process;
 /// - the **changed-laws cache** (shared `Arc`) — same reasoning for
 ///   `save_law`'s invalidation;
+/// - the **implements index** (flagged stale) and the content-addressed
+///   **implements memo** (shared `Arc`) — lookups keep serving the
+///   previous index while the first post-refresh lookup rebuilds it, and
+///   the rebuild only fetches bodies whose blob sha changed;
 /// - the **write routing** (`write_target_for_source`,
 ///   `writable_own_source_id`) and the registry/auth config, which only
 ///   change through traject create/delete → [`TrajectCorpusCache::invalidate`].
 ///
 /// Fresh in the new instance:
 /// - the **`source_map` index snapshot** — the point of the refresh;
-/// - the **`body_cache`** — so upstream body changes become visible;
-/// - the **implements index** — rebuilt on demand against the new snapshot.
+/// - the **`body_cache`** — so upstream body changes become visible.
 ///
 /// Any source failing to enumerate fails the whole refresh: the caller
 /// then serves the previous (complete) snapshot for another TTL, which
@@ -948,21 +1114,122 @@ async fn refresh_traject_corpus(
         ));
     }
 
-    Ok(Arc::new(TrajectCorpus {
+    // Only after a *successful* enumeration: a failed refresh must not
+    // touch the overlay either.
+    reconcile_overlay(old, &source_map).await;
+
+    Ok(next_snapshot(old, source_map).await)
+}
+
+/// Assemble the next-snapshot [`TrajectCorpus`] over `source_map`,
+/// carrying over everything [`refresh_traject_corpus`] documents.
+/// Factored out of the refresh so tests can drive the carry-over
+/// semantics with a hand-built source map (no registry enumeration).
+async fn next_snapshot(old: &Arc<TrajectCorpus>, source_map: SourceMap) -> Arc<TrajectCorpus> {
+    // Carry the previous implements index (even one this snapshot itself
+    // inherited and never rebuilt) so implementor lookups keep being
+    // served during the post-refresh rebuild.
+    let carried_index = old.implements_index.read().await.clone();
+    Arc::new(TrajectCorpus {
         corpus: CorpusState {
-            registry,
+            registry: old.corpus.registry.clone(),
             source_map,
             backends: old.corpus.backends.clone(),
-            auth_file,
+            auth_file: old.corpus.auth_file.clone(),
         },
         write_target_for_source: old.write_target_for_source.clone(),
         writable_own_source_id: old.writable_own_source_id.clone(),
         overlay: old.overlay.clone(),
         body_cache: RwLock::new(BoundedBodyCache::default()),
-        implements_index: RwLock::new(None),
+        implements_index: RwLock::new(carried_index),
+        implements_index_stale: AtomicBool::new(true),
         implements_build_lock: Mutex::new(()),
+        implements_memo: old.implements_memo.clone(),
         changed_cache: old.changed_cache.clone(),
-    }))
+    })
+}
+
+/// Reconcile the read-your-writes overlay against the write-target
+/// branch at refresh time: for every overlaid law, read the file the
+/// save wrote (the writable-own branch for federated laws, the law's own
+/// backend otherwise) and DROP the entry when the branch content no
+/// longer equals the saved body — someone else (another replica, a
+/// direct push) wrote after us, and serving their newer content restores
+/// convergence. Without this, a law once saved on this process would
+/// serve this process's body forever and every cross-replica save would
+/// 412 against content the loser can never see.
+///
+/// Cost: O(locally saved laws), one backend read per entry, every TTL
+/// window. Each backend lock is taken per entry — never across the loop
+/// — and only the write-target backend is locked (no seed lock), so the
+/// writable-own → seed lock-order invariant cannot be violated and an
+/// in-flight save is never starved.
+///
+/// Failure stance: a read error keeps the entry (can't tell whether the
+/// branch moved — keeping read-your-writes beats dropping a save on a
+/// network blip). The removal itself is compare-and-remove: an entry
+/// replaced by a concurrent `record_save` after this pass snapshotted it
+/// is left alone.
+async fn reconcile_overlay(old: &Arc<TrajectCorpus>, source_map: &SourceMap) {
+    let entries: Vec<(String, String)> = old
+        .overlay
+        .read()
+        .await
+        .iter()
+        .map(|(law_id, body)| (law_id.clone(), body.clone()))
+        .collect();
+
+    for (law_id, overlay_body) in entries {
+        // Resolve the write-target file in the NEW snapshot. A law that
+        // vanished from the index entirely gets its entry dropped too:
+        // the overlay is checked before the index, so a stale entry
+        // would otherwise keep serving a law that no longer exists.
+        let branch_body = match source_map.get_law(&law_id) {
+            None => None,
+            Some(law) => {
+                let write_source_id = old
+                    .write_target_for_source
+                    .get(&law.source_id)
+                    .cloned()
+                    .unwrap_or_else(|| law.source_id.clone());
+                let Some(entry) = old.corpus.backends.get(&write_source_id) else {
+                    // Write backend gone (shouldn't happen outside config
+                    // churn): nothing to compare against, keep the entry.
+                    continue;
+                };
+                let read = {
+                    let backend = entry.backend.lock().await;
+                    backend
+                        .read_file(std::path::Path::new(&law.relative_path))
+                        .await
+                };
+                match read {
+                    Ok(body) => body,
+                    Err(e) => {
+                        tracing::debug!(
+                            law_id = %law_id,
+                            error = %e,
+                            "overlay reconcile: branch read failed; keeping overlay entry"
+                        );
+                        continue;
+                    }
+                }
+            }
+        };
+
+        if branch_body.as_deref() == Some(overlay_body.as_str()) {
+            // Our save is still what the branch holds — keep serving it.
+            continue;
+        }
+        let mut overlay = old.overlay.write().await;
+        if overlay.get(&law_id).map(String::as_str) == Some(overlay_body.as_str()) {
+            overlay.remove(&law_id);
+            tracing::info!(
+                law_id = %law_id,
+                "overlay entry superseded by branch content; dropping so reads converge"
+            );
+        }
+    }
 }
 
 /// Build a [`GitHubApiBackend`] for a traject source — no clone, no
@@ -1118,12 +1385,23 @@ mod tests {
             overlay: Arc::new(RwLock::new(HashMap::new())),
             body_cache: RwLock::new(BoundedBodyCache::default()),
             implements_index: RwLock::new(None),
+            implements_index_stale: AtomicBool::new(false),
             implements_build_lock: Mutex::new(()),
+            implements_memo: Arc::new(RwLock::new(HashMap::new())),
             changed_cache: Arc::new(RwLock::new(None)),
         }
     }
 
     fn metadata_entry(map: &mut SourceMap, law_id: &str, source_id: &str) {
+        metadata_entry_with_sha(map, law_id, source_id, Some(&format!("sha-{law_id}-v1")));
+    }
+
+    fn metadata_entry_with_sha(
+        map: &mut SourceMap,
+        law_id: &str,
+        source_id: &str,
+        sha: Option<&str>,
+    ) {
         map.load_metadata_entry(
             law_id,
             &format!("wet/{law_id}/2025-01-01.yaml"),
@@ -1133,6 +1411,7 @@ mod tests {
             // Distinct priorities per source: equal-priority conflicts
             // across sources are a hard SourceMap error.
             if source_id == "own" { 0 } else { 1 },
+            sha,
         )
         .unwrap();
     }
@@ -1371,7 +1650,9 @@ mod tests {
             overlay: Arc::new(RwLock::new(HashMap::new())),
             body_cache: RwLock::new(BoundedBodyCache::default()),
             implements_index: RwLock::new(None),
+            implements_index_stale: AtomicBool::new(false),
             implements_build_lock: Mutex::new(()),
+            implements_memo: Arc::new(RwLock::new(HashMap::new())),
             changed_cache: Arc::new(RwLock::new(None)),
         })
     }
@@ -1388,7 +1669,11 @@ mod tests {
         write_law_file(dir.path(), "wet_a", "$id: wet_a\nname: v1\n");
         let old = local_corpus(dir.path()).await;
 
-        // A save lands in the overlay before the refresh…
+        // A save lands before the refresh: like the real `save_law`, the
+        // body is persisted to the backend AND mirrored into the overlay
+        // (the refresh's reconcile pass keeps an entry only while the
+        // branch still holds the saved body).
+        write_law_file(dir.path(), "wet_a", "$id: wet_a\nname: saved\n");
         old.record_save("wet_a".to_string(), "$id: wet_a\nname: saved\n".to_string())
             .await;
         // …and upstream gains a brand-new law the old snapshot misses.
@@ -1429,7 +1714,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn refresh_resets_the_implements_index_with_the_snapshot() {
+    async fn refresh_marks_implements_index_stale_and_rebuild_sees_new_laws() {
         let dir = tempfile::tempdir().unwrap();
         write_law_file(dir.path(), "wet_hoger", &law_body("wet_hoger", None));
         let old = local_corpus(dir.path()).await;
@@ -1450,17 +1735,187 @@ mod tests {
             .await
             .expect("local refresh must succeed");
 
-        // The refreshed snapshot rebuilds its own index and finds it; the
-        // old instance's cached index is untouched (per-snapshot).
+        // The refreshed snapshot carries the old index as stale; the
+        // first lookup rebuilds against the new snapshot and finds the
+        // new regulation. The old instance's own (fresh) index is
+        // untouched.
+        assert!(refreshed.implements_index_stale.load(Ordering::SeqCst));
         assert_eq!(
             refreshed.implementors_of("wet_hoger").await.implementors,
             vec!["regeling_a".to_string()]
         );
+        assert!(!refreshed.implements_index_stale.load(Ordering::SeqCst));
         assert!(old
             .implementors_of("wet_hoger")
             .await
             .implementors
             .is_empty());
+    }
+
+    // ---- stale-while-revalidate on the implements index ----
+
+    #[tokio::test]
+    async fn carried_stale_index_is_served_while_a_rebuild_is_in_flight() {
+        // A snapshot whose (carried) index is stale must keep answering
+        // implementor lookups from it while another task holds the build
+        // lock — the post-refresh lookup herd must never queue behind the
+        // rescan (the federated-panel hang of PR #762).
+        let mut map = SourceMap::new();
+        metadata_entry(&mut map, "regeling_a", "seed");
+        let corpus = Arc::new(test_corpus(
+            map,
+            HashMap::from([(
+                "seed".to_string(),
+                backend_entry(StubBackend::with_files(&[(
+                    "wet/regeling_a/2025-01-01.yaml",
+                    &law_body("regeling_a", Some("wet_hoger")),
+                )])),
+            )]),
+        ));
+        // Simulate the carried-over state a TTL refresh produces.
+        *corpus.implements_index.write().await = Some(Arc::new(ImplementsIndex {
+            implements_by_law: HashMap::from([(
+                "carried_regeling".to_string(),
+                vec!["wet_hoger".to_string()],
+            )]),
+            failed_law_ids: Vec::new(),
+        }));
+        corpus.implements_index_stale.store(true, Ordering::SeqCst);
+
+        // Another task is rebuilding (holds the build lock)…
+        let build_guard = corpus.implements_build_lock.lock().await;
+        // …so the lookup must serve the carried index immediately, not
+        // block on the lock.
+        let result = corpus.implementors_of("wet_hoger").await;
+        assert_eq!(result.implementors, vec!["carried_regeling".to_string()]);
+        drop(build_guard);
+
+        // With the lock free, the next lookup rebuilds from the snapshot.
+        let result = corpus.implementors_of("wet_hoger").await;
+        assert_eq!(result.implementors, vec!["regeling_a".to_string()]);
+    }
+
+    // ---- cross-snapshot implements memo ----
+
+    #[tokio::test]
+    async fn rebuild_after_refresh_skips_unchanged_bodies_via_memo() {
+        let mut map = SourceMap::new();
+        metadata_entry(&mut map, "regeling_a", "seed");
+        metadata_entry(&mut map, "wet_hoger", "seed");
+        let stub = StubBackend::with_files(&[
+            (
+                "wet/regeling_a/2025-01-01.yaml",
+                &law_body("regeling_a", Some("wet_hoger")),
+            ),
+            (
+                "wet/wet_hoger/2025-01-01.yaml",
+                &law_body("wet_hoger", None),
+            ),
+        ]);
+        let reads = stub.reads.clone();
+        let old = Arc::new(test_corpus(
+            map,
+            HashMap::from([("seed".to_string(), backend_entry(stub))]),
+        ));
+
+        // First build of the process: every body is fetched once.
+        assert_eq!(
+            old.implementors_of("wet_hoger").await.implementors,
+            vec!["regeling_a".to_string()]
+        );
+        assert_eq!(reads.load(Ordering::SeqCst), 2);
+
+        // TTL refresh with an UNCHANGED enumeration (same blob shas):
+        // the post-refresh rebuild must answer entirely from the memo —
+        // zero body fetches.
+        let mut same_map = SourceMap::new();
+        metadata_entry(&mut same_map, "regeling_a", "seed");
+        metadata_entry(&mut same_map, "wet_hoger", "seed");
+        let refreshed = next_snapshot(&old, same_map).await;
+        assert_eq!(
+            refreshed.implementors_of("wet_hoger").await.implementors,
+            vec!["regeling_a".to_string()]
+        );
+        assert_eq!(
+            reads.load(Ordering::SeqCst),
+            2,
+            "an unchanged corpus must rebuild without refetching any body"
+        );
+
+        // Next refresh where ONE law's sha moved: only that body is
+        // refetched.
+        let mut changed_map = SourceMap::new();
+        metadata_entry_with_sha(
+            &mut changed_map,
+            "regeling_a",
+            "seed",
+            Some("sha-regeling_a-v2"),
+        );
+        metadata_entry(&mut changed_map, "wet_hoger", "seed");
+        let refreshed2 = next_snapshot(&refreshed, changed_map).await;
+        assert_eq!(
+            refreshed2.implementors_of("wet_hoger").await.implementors,
+            vec!["regeling_a".to_string()]
+        );
+        assert_eq!(
+            reads.load(Ordering::SeqCst),
+            3,
+            "only the changed body may be refetched"
+        );
+    }
+
+    // ---- overlay reconciliation at refresh ----
+
+    #[tokio::test]
+    async fn refresh_drops_overlay_entry_when_branch_moved_past_the_save() {
+        let dir = tempfile::tempdir().unwrap();
+        write_law_file(dir.path(), "wet_a", "$id: wet_a\nname: v1\n");
+        let old = local_corpus(dir.path()).await;
+
+        // Save through this process: persisted + overlaid.
+        write_law_file(dir.path(), "wet_a", "$id: wet_a\nname: saved\n");
+        old.record_save("wet_a".to_string(), "$id: wet_a\nname: saved\n".to_string())
+            .await;
+
+        // Another replica / a direct push moves the branch past our save.
+        write_law_file(dir.path(), "wet_a", "$id: wet_a\nname: extern\n");
+
+        let refreshed = refresh_traject_corpus(&old, Uuid::new_v4())
+            .await
+            .expect("local refresh must succeed");
+
+        // The overlay entry was dropped (branch content differs from the
+        // saved body), so reads converge to the external content instead
+        // of pinning our stale save forever — and the next If-Match save
+        // can 412 against bytes the user can actually see.
+        assert!(!refreshed.overlay.read().await.contains_key("wet_a"));
+        assert_eq!(
+            refreshed.law_yaml("wet_a").await.unwrap().as_deref(),
+            Some("$id: wet_a\nname: extern\n")
+        );
+    }
+
+    #[tokio::test]
+    async fn refresh_keeps_overlay_entry_while_branch_matches_the_save() {
+        let dir = tempfile::tempdir().unwrap();
+        write_law_file(dir.path(), "wet_a", "$id: wet_a\nname: v1\n");
+        let old = local_corpus(dir.path()).await;
+
+        // A fresh local save: branch == overlay.
+        write_law_file(dir.path(), "wet_a", "$id: wet_a\nname: saved\n");
+        old.record_save("wet_a".to_string(), "$id: wet_a\nname: saved\n".to_string())
+            .await;
+
+        let refreshed = refresh_traject_corpus(&old, Uuid::new_v4())
+            .await
+            .expect("local refresh must succeed");
+
+        // No external write happened: read-your-writes keeps holding.
+        assert!(refreshed.overlay.read().await.contains_key("wet_a"));
+        assert_eq!(
+            refreshed.law_yaml("wet_a").await.unwrap().as_deref(),
+            Some("$id: wet_a\nname: saved\n")
+        );
     }
 }
 

--- a/packages/editor-api/src/traject_corpus.rs
+++ b/packages/editor-api/src/traject_corpus.rs
@@ -1022,22 +1022,29 @@ async fn build_traject_corpus(
             );
         }
 
-        // GitHub sources go through the in-memory Contents-API backend
-        // (one isolated `GitHubApiBackend` per traject — no clone, no
-        // working tree on disk). Local sources keep their configured
-        // path — they're already isolated by definition.
+        let is_writable_own = source.id == writable_own_source_id;
+
+        // The writable-own GitHub source goes through the in-memory
+        // Contents-API backend (no clone, no working tree) so saves are
+        // committed via the API. Read-only base/seed GitHub sources
+        // (minbzk-central, …) instead read from a local git clone: body
+        // reads (`law_yaml`, the implements scan) then hit local disk
+        // rather than the REST Contents API, which avoids exhausting the
+        // GitHub REST quota on an O(corpus) implements scan and reuses the
+        // clone the global corpus already maintains (shared by source id).
+        // Local sources keep their configured path — already isolated.
         let backend_result = match &source.source_type {
-            SourceType::GitHub { github } => build_traject_github_backend(
+            SourceType::GitHub { github } if is_writable_own => build_traject_github_backend(
                 traject_id,
                 source,
                 github,
                 row.gh_base_branch.as_deref(),
                 token.as_deref(),
             ),
-            SourceType::Local { .. } => create_backend(source, token.as_deref()),
+            SourceType::GitHub { .. } | SourceType::Local { .. } => {
+                create_backend(source, token.as_deref())
+            }
         };
-
-        let is_writable_own = source.id == writable_own_source_id;
         match backend_result {
             Ok(mut backend) => {
                 if let Err(e) = backend.ensure_ready().await {

--- a/packages/editor-api/src/traject_corpus.rs
+++ b/packages/editor-api/src/traject_corpus.rs
@@ -1214,7 +1214,19 @@ async fn reconcile_overlay(old: &Arc<TrajectCorpus>, source_map: &SourceMap) {
                         .await
                 };
                 match read {
-                    Ok(body) => body,
+                    Ok(Some(body)) => body,
+                    Ok(None) => {
+                        // Trees enumeration found the law but the Contents
+                        // read says it's gone — a TOCTOU gap symmetric with
+                        // the Err arm below. We cannot tell a genuine delete
+                        // from transient propagation lag, so keep the save
+                        // (same "can't tell → keep" stance).
+                        tracing::debug!(
+                            law_id = %law_id,
+                            "overlay reconcile: file not found on branch; keeping overlay entry"
+                        );
+                        continue;
+                    }
                     Err(e) => {
                         tracing::debug!(
                             law_id = %law_id,
@@ -1227,7 +1239,7 @@ async fn reconcile_overlay(old: &Arc<TrajectCorpus>, source_map: &SourceMap) {
             }
         };
 
-        if branch_body.as_deref() == Some(overlay_body.as_str()) {
+        if branch_body == overlay_body {
             // Our save is still what the branch holds — keep serving it.
             continue;
         }
@@ -1462,6 +1474,26 @@ mod tests {
         assert_eq!(cache.map.len(), 2);
         assert_eq!(cache.order.len(), 2);
         assert_eq!(cache.get("a").map(String::as_str), Some("v2"));
+    }
+
+    #[test]
+    fn body_cache_overwrite_at_cap_does_not_evict() {
+        let mut cache = BoundedBodyCache::default();
+        // Fill exactly to capacity.
+        for i in 0..BODY_CACHE_MAX_ENTRIES {
+            cache.insert(format!("law_{i}"), "v1".to_string());
+        }
+        assert_eq!(cache.map.len(), BODY_CACHE_MAX_ENTRIES);
+        // Re-inserting an existing key at cap must NOT evict: the
+        // `contains_key` guard skips the eviction loop and leaves `order`
+        // untouched, so the size invariant holds and no live entry is lost.
+        cache.insert("law_0".to_string(), "v2".to_string());
+        assert_eq!(cache.map.len(), BODY_CACHE_MAX_ENTRIES);
+        assert_eq!(cache.order.len(), BODY_CACHE_MAX_ENTRIES);
+        // The next-oldest, untouched entry survives (no spurious eviction)…
+        assert!(cache.get("law_1").is_some());
+        // …and the overwritten value is updated in place.
+        assert_eq!(cache.get("law_0").map(String::as_str), Some("v2"));
     }
 
     // ---- TTL freshness ----

--- a/packages/editor-api/src/traject_corpus.rs
+++ b/packages/editor-api/src/traject_corpus.rs
@@ -1617,6 +1617,16 @@ mod tests {
         assert!(cache.get("law_1").is_some());
         // …and the overwritten value is updated in place.
         assert_eq!(cache.get("law_0").map(String::as_str), Some("v2"));
+
+        // FIFO, not LRU: the overwrite did NOT refresh law_0's age, so it's
+        // still the oldest. The next genuinely-new insert at cap evicts it.
+        cache.insert("law_new".to_string(), "v1".to_string());
+        assert_eq!(cache.map.len(), BODY_CACHE_MAX_ENTRIES);
+        assert!(
+            cache.get("law_0").is_none(),
+            "an overwrite must not refresh age — law_0 stays first out"
+        );
+        assert!(cache.get("law_new").is_some());
     }
 
     // ---- TTL freshness ----

--- a/packages/editor-api/src/traject_corpus.rs
+++ b/packages/editor-api/src/traject_corpus.rs
@@ -236,7 +236,10 @@ struct ImplementsIndex {
 /// when the index was built.
 pub struct ImplementorsResult {
     pub implementors: Vec<String>,
-    pub skipped_law_ids: Vec<String>,
+    /// Count of laws skipped because their body fetch failed when the index
+    /// was built — reported so callers can surface partiality instead of
+    /// passing off an incomplete scan as "no implementors".
+    pub skipped_count: usize,
 }
 
 impl TrajectCorpus {
@@ -349,7 +352,7 @@ impl TrajectCorpus {
     /// the Trees enumeration), fetching only what actually changed.
     /// Bodies fetched by a scan land in `body_cache`, so opening one of
     /// the scanned laws afterwards is also free. Laws whose body fetch
-    /// failed are reported in [`ImplementorsResult::skipped_law_ids`]
+    /// failed are counted in [`ImplementorsResult::skipped_count`]
     /// instead of being silently indistinguishable from "doesn't
     /// implement anything"; the failed set is retried at the next
     /// rebuild.
@@ -366,7 +369,7 @@ impl TrajectCorpus {
         implementors.sort();
         ImplementorsResult {
             implementors,
-            skipped_law_ids: index.failed_law_ids.clone(),
+            skipped_count: index.failed_law_ids.len(),
         }
     }
 
@@ -1180,12 +1183,19 @@ async fn reconcile_overlay(old: &Arc<TrajectCorpus>, source_map: &SourceMap) {
         .collect();
 
     for (law_id, overlay_body) in entries {
-        // Resolve the write-target file in the NEW snapshot. A law that
-        // vanished from the index entirely gets its entry dropped too:
-        // the overlay is checked before the index, so a stale entry
-        // would otherwise keep serving a law that no longer exists.
+        // Resolve the write-target file in the NEW snapshot. If the law is
+        // absent from this snapshot we KEEP the overlay entry rather than
+        // dropping it: absence is ambiguous. A just-saved law can be missing
+        // from a snapshot whose source enumeration ran between our branch
+        // push and `record_save` returning (the GitHub Trees listing
+        // predates the push) — dropping here would break read-your-writes for
+        // a TTL window even though the save is safely on the branch. This
+        // matches the read-error failure stance below: when we cannot read
+        // the branch to compare, keep serving our save. A law genuinely
+        // removed from the branch keeps its overlay entry until a later save
+        // overwrites it — the read-your-writes trade-off this function makes.
         let branch_body = match source_map.get_law(&law_id) {
-            None => None,
+            None => continue,
             Some(law) => {
                 let write_source_id = old
                     .write_target_for_source
@@ -1529,7 +1539,7 @@ mod tests {
 
         let result = corpus.implementors_of("wet_hoger").await;
         assert_eq!(result.implementors, vec!["regeling_a".to_string()]);
-        assert!(result.skipped_law_ids.is_empty());
+        assert_eq!(result.skipped_count, 0);
         let reads_after_build = reads.load(Ordering::SeqCst);
         assert_eq!(reads_after_build, 2, "index build fetches each body once");
 
@@ -1562,7 +1572,7 @@ mod tests {
         // "checked and implements nothing" — while the healthy law is
         // still found.
         assert_eq!(result.implementors, vec!["regeling_a".to_string()]);
-        assert_eq!(result.skipped_law_ids, vec!["wet_kapot".to_string()]);
+        assert_eq!(result.skipped_count, 1);
     }
 
     #[tokio::test]

--- a/packages/editor-api/src/traject_corpus.rs
+++ b/packages/editor-api/src/traject_corpus.rs
@@ -179,12 +179,12 @@ const BODY_CACHE_MAX_ENTRIES: usize = 1024;
 
 /// When an implements-index build would otherwise fetch at least this many
 /// law bodies one-by-one from a *single* source, pull the whole source in
-/// one archive request instead (see [`RepoBackend::read_all_files`]). Below
-/// the threshold the per-law lazy fetch is cheaper than downloading the
-/// archive. This is what turns the cold build over a large GitHub-backed
+/// one archive request instead (see [`RepoBackend::read_all_implements`]).
+/// Below the threshold the per-law lazy fetch is cheaper than downloading
+/// the archive. This is what turns the cold build over a large GitHub-backed
 /// traject from O(corpus) Contents calls (a 504) into one download.
 ///
-/// [`RepoBackend::read_all_files`]: regelrecht_corpus::backend::RepoBackend::read_all_files
+/// [`RepoBackend::read_all_implements`]: regelrecht_corpus::backend::RepoBackend::read_all_implements
 const BULK_FETCH_THRESHOLD: usize = 16;
 
 /// Lazily-fetched law bodies with a FIFO size cap. FIFO (not LRU) keeps
@@ -484,10 +484,12 @@ impl TrajectCorpus {
         // call per law is O(corpus) and times out on large GitHub-backed
         // trajects, so when a single source has many bodies to fetch, pull
         // the whole source in one archive request and serve the scan from
-        // memory. Keyed by (source_id, source-relative path) to match the
-        // loop's per-entry lookup; deliberately NOT poured into the bounded
-        // body_cache, so a huge corpus can't thrash it.
-        let mut bulk: HashMap<(String, String), String> = HashMap::new();
+        // memory. Holds parsed `implements` lists (NOT bodies — the backend
+        // parses and discards bodies during the streamed archive extraction,
+        // so neither side ever materialises the whole corpus), keyed by
+        // (source_id, source-relative path) to match the loop's per-entry
+        // lookup.
+        let mut bulk: HashMap<(String, String), Vec<String>> = HashMap::new();
         {
             let mut misses: HashMap<&str, usize> = HashMap::new();
             for entry in &entries {
@@ -511,17 +513,17 @@ impl TrajectCorpus {
                 };
                 let result = {
                     let backend = backend_entry.backend.lock().await;
-                    backend.read_all_files(Some("yaml")).await
+                    backend.read_all_implements().await
                 };
                 match result {
                     Ok(files) => {
                         tracing::info!(
                             source_id,
                             files = files.len(),
-                            "implements scan: bulk-loaded source bodies in one request"
+                            "implements scan: bulk-loaded source in one request"
                         );
-                        for (rel_path, content) in files {
-                            bulk.insert((source_id.to_string(), rel_path), content);
+                        for (rel_path, implements) in files {
+                            bulk.insert((source_id.to_string(), rel_path), implements);
                         }
                     }
                     Err(e) => {
@@ -553,11 +555,12 @@ impl TrajectCorpus {
                         new_memo.insert(key, implements.clone());
                     }
                     implements
-                } else if let Some(yaml) =
+                } else if let Some(implements) =
                     bulk.get(&(entry.source_id.clone(), entry.relative_path.clone()))
                 {
-                    // Body came from the one-shot archive download above.
-                    let implements = collect_law_implements(yaml);
+                    // Implements list came (already parsed) from the one-shot
+                    // archive scan above.
+                    let implements = implements.clone();
                     if let Some(key) = memo_key {
                         new_memo.insert(key, implements.clone());
                     }
@@ -1451,20 +1454,15 @@ mod tests {
             }
             Ok(self.files.get(path.to_str().unwrap()).cloned())
         }
-        async fn read_all_files(
-            &self,
-            extension: Option<&str>,
-        ) -> CorpusResult<Vec<(String, String)>> {
+        async fn read_all_implements(&self) -> CorpusResult<Vec<(String, Vec<String>)>> {
             self.bulk_reads.fetch_add(1, Ordering::SeqCst);
             if self.fail_reads {
                 return Err(CorpusError::Git("simulated throttle".to_string()));
             }
-            let suffix = extension.map(|e| format!(".{e}"));
             Ok(self
                 .files
                 .iter()
-                .filter(|(p, _)| suffix.as_ref().is_none_or(|s| p.ends_with(s)))
-                .map(|(p, c)| (p.clone(), c.clone()))
+                .map(|(p, c)| (p.clone(), collect_law_implements(c)))
                 .collect())
         }
         async fn write_file(&self, _: &Path, _: &str) -> CorpusResult<()> {

--- a/packages/editor-api/tests/traject_reads_test.rs
+++ b/packages/editor-api/tests/traject_reads_test.rs
@@ -335,7 +335,7 @@ async fn save_then_read_returns_the_just_saved_content() {
 }
 
 #[tokio::test]
-async fn ttl_refresh_picks_up_upstream_laws_and_keeps_saves() {
+async fn ttl_refresh_picks_up_upstream_laws_and_reconciles_saves() {
     use axum::extract::Query;
     use regelrecht_corpus::dto::PaginationParams;
 
@@ -371,9 +371,19 @@ async fn ttl_refresh_picks_up_upstream_laws_and_keeps_saves() {
     .expect("save must succeed");
     assert_eq!(status, StatusCode::OK);
 
+    // A fresh local save survives a refresh: the branch still holds
+    // exactly the saved body, so the reconcile pass keeps the overlay
+    // entry and reads keep returning the save (read-your-writes).
+    let (_etag, after_save) = read_law(state.clone(), session_for(&sub).await, &tref).await;
+    assert!(
+        after_save.contains("SAVED"),
+        "a fresh save must survive the TTL refresh; got: {after_save}"
+    );
+
     // Upstream changes behind the snapshot's back: a brand-new law lands
     // in the source (think: merged on the central corpus, a re-harvest)
-    // and the just-saved law's file is clobbered by an external writer.
+    // and the just-saved law's file is overwritten by an external writer
+    // (another replica, a direct push to the branch).
     let other_dir = corpus.path().join("wet").join("andere_wet");
     std::fs::create_dir_all(&other_dir).unwrap();
     std::fs::write(
@@ -403,15 +413,18 @@ async fn ttl_refresh_picks_up_upstream_laws_and_keeps_saves() {
         "refreshed snapshot must index the upstream-added law"
     );
 
-    // …while the law saved through the editor keeps serving the saved
-    // body: the refresh carries the read-your-writes overlay over and
-    // must never resurrect pre-save (or externally clobbered) content.
+    // …and the externally overwritten law CONVERGES to the branch
+    // content: the refresh's reconcile pass sees the branch no longer
+    // matches the overlaid save and drops the entry, so this process
+    // stops pinning its own stale save (which would otherwise turn every
+    // cross-replica edit into a permanent 412 loop — the user could
+    // never fetch the conflicting content their If-Match fails against).
     let (_etag, after) = read_law(state, session_for(&sub).await, &tref).await;
     assert!(
-        after.contains("SAVED"),
-        "expected the saved content to survive the TTL refresh; got: {after}"
+        after.contains("EXTERNAL"),
+        "expected reads to converge to the externally written content; got: {after}"
     );
-    assert!(!after.contains("EXTERNAL"));
+    assert!(!after.contains("SAVED"));
 }
 
 #[tokio::test]

--- a/packages/editor-api/tests/traject_reads_test.rs
+++ b/packages/editor-api/tests/traject_reads_test.rs
@@ -29,8 +29,8 @@ use regelrecht_auth::handlers::{
 };
 use regelrecht_editor_api::config::AppConfig;
 use regelrecht_editor_api::corpus_handlers::{
-    get_corpus_law, get_traject_corpus_law, get_traject_scenario, list_traject_scenarios, save_law,
-    save_scenario,
+    get_corpus_law, get_traject_corpus_law, get_traject_scenario, list_traject_corpus_laws,
+    list_traject_scenarios, save_law, save_scenario,
 };
 use regelrecht_editor_api::state::{AppState, CorpusState};
 use regelrecht_editor_api::traject_corpus::TrajectCorpusCache;
@@ -332,6 +332,86 @@ async fn save_then_read_returns_the_just_saved_content() {
         "expected the saved content; got: {after}"
     );
     assert!(!after.contains("ORIGINAL"));
+}
+
+#[tokio::test]
+async fn ttl_refresh_picks_up_upstream_laws_and_keeps_saves() {
+    use axum::extract::Query;
+    use regelrecht_corpus::dto::PaginationParams;
+
+    let db = TestDb::new().await;
+    let mut state = empty_state(db.pool.clone());
+    // Zero TTL: every request rolls the index snapshot over — the
+    // production refresh behaviour, accelerated so the test doesn't wait
+    // out the real TTL.
+    state.trajects = Arc::new(TrajectCorpusCache::with_index_ttl(
+        std::time::Duration::ZERO,
+    ));
+    let (owner, sub) = seed_account(&db.pool, "alice@test.local").await;
+
+    let corpus = tempfile::tempdir().unwrap();
+    write_law(corpus.path(), "ORIGINAL");
+    let traject_id = local_traject(&db.pool, owner, corpus.path()).await;
+    let tref = traject_ref(traject_id);
+
+    // First read builds the traject corpus.
+    let (_etag, before) = read_law(state.clone(), session_for(&sub).await, &tref).await;
+    assert!(before.contains("ORIGINAL"));
+
+    // Save through the editor — the overlay records the new body.
+    let saved_body = format!("$id: {LAW_ID}\nname: SAVED\n");
+    let (status, _etag) = save_law_with(
+        state.clone(),
+        session_for(&sub).await,
+        &tref,
+        HeaderMap::new(),
+        saved_body,
+    )
+    .await
+    .expect("save must succeed");
+    assert_eq!(status, StatusCode::OK);
+
+    // Upstream changes behind the snapshot's back: a brand-new law lands
+    // in the source (think: merged on the central corpus, a re-harvest)
+    // and the just-saved law's file is clobbered by an external writer.
+    let other_dir = corpus.path().join("wet").join("andere_wet");
+    std::fs::create_dir_all(&other_dir).unwrap();
+    std::fs::write(
+        other_dir.join("2025-01-01.yaml"),
+        "$id: andere_wet\nname: Nieuw\n",
+    )
+    .unwrap();
+    write_law(corpus.path(), "EXTERNAL");
+
+    // The next request refreshes the snapshot (TTL expired): the new law
+    // is indexed without a traject delete/recreate or process restart…
+    let Json(entries) = list_traject_corpus_laws(
+        State(state.clone()),
+        session_for(&sub).await,
+        Path(tref.clone()),
+        Query(PaginationParams {
+            offset: 0,
+            limit: None,
+            q: None,
+            ids: None,
+        }),
+    )
+    .await
+    .expect("law list must succeed");
+    assert!(
+        entries.iter().any(|e| e.law_id == "andere_wet"),
+        "refreshed snapshot must index the upstream-added law"
+    );
+
+    // …while the law saved through the editor keeps serving the saved
+    // body: the refresh carries the read-your-writes overlay over and
+    // must never resurrect pre-save (or externally clobbered) content.
+    let (_etag, after) = read_law(state, session_for(&sub).await, &tref).await;
+    assert!(
+        after.contains("SAVED"),
+        "expected the saved content to survive the TTL refresh; got: {after}"
+    );
+    assert!(!after.contains("EXTERNAL"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Problem (audit advice #9)

Three staleness/perf problems on the editor-api read paths:

1. **Stale-forever traject caches** — `TrajectCorpusCache` entries were only invalidated on traject create/delete. The per-traject source-map index snapshot never picked up upstream changes (new laws merged, re-harvests, saves on another replica) until process restart, and the lazily-fetched body cache was unbounded and never refreshed either.
2. **O(corpus) display names per request** — `GET /corpus/laws` called `resolve_display_name` per law per request: a line scan of every body, plus a full `serde_yaml_ng` parse for `name: '#ref'` laws. For the unfiltered list that is O(total corpus bytes) per page load.
3. **O(corpus) implementor discovery with serialized fetches** — `implementors_in_scope` lazily fetched every metadata-only law's body sequentially under the per-source mutex on *every* request, and silently skipped fetch failures, so a throttled scan returned a silently incomplete list.

## Changes

### TTL + refresh on the per-traject index snapshot (`TRAJECT_INDEX_TTL = 60s`)
Follows the existing `CHANGED_LAWS_TTL` precedent (same 60s convergence target). The first request past the deadline re-enumerates the sources and swaps in a fresh `SourceMap`; concurrent requests keep serving the stale snapshot while one refresh is in flight (single-flighted per traject), and a failed refresh re-arms the stale snapshot for another TTL window instead of erroring reads. A refresh where *any* source fails to enumerate is treated as failed — serving the previous complete snapshot beats swapping in one with thousands of laws missing. The failed-refresh warn is rate-limited (first failure and every 10th consecutive one; the rest log at debug) so a permanently broken source doesn't re-warn every minute.

**Why this is safe w.r.t. saves:** the refreshed instance carries over
- the **backend map** (same `Arc<Mutex<…>>` instances — an in-flight save keeps excluding writers across the swap, and the writable-own → seed lock-ordering invariant from #790 is untouched);
- the **post-save overlay** (shared `Arc`) — a refresh never resurrects pre-save content, and a `record_save` racing the swap on the old instance is visible through the new one;
- the **changed-laws cache** (shared `Arc`) — a refresh cannot undo `save_law`'s invalidation;
- the **implements index** (served stale while rebuilt) and its cross-snapshot memo — see below.

### Overlay reconciliation at refresh (read-your-writes-or-newer)
The overlay is carried across refreshes, but no longer unconditionally: each refresh compares every overlay entry against its write-target branch file (one per-entry backend lock — never held across the loop, and no seed lock, so the writable-own → seed lock order can't be violated) and **drops the entry when the branch content no longer equals the saved body**. That is the cross-replica convergence story: a law saved on this process serves the saved body until someone else (another replica, a direct push) overwrites it on the branch, after which reads converge to the newer branch content within a TTL window — instead of this process pinning its own save forever, which made every cross-replica `If-Match` save 412 against content the loser could never fetch. A read error keeps the entry (a network blip must not drop a save), and removal is compare-and-remove so a save landing concurrently with the reconcile pass is never dropped.

### Bounded, per-snapshot body cache (`BODY_CACHE_MAX_ENTRIES = 1024`)
The save overlay and the lazy-read cache used to share one unbounded map. They are now split: saves stay in the overlay (bounded by laws edited in the traject, survives refreshes), lazily fetched bodies live in a FIFO-bounded per-snapshot cache that the refresh discards — that is how upstream *content* changes (not just index changes) converge within the TTL. FIFO instead of LRU keeps cache hits on the cheap read guard; at ~tens of KB per body the cap bounds the cache at low tens of MB per traject.

### Implements index: stale-while-revalidate + content-addressed memo
- `LoadedLaw` now carries `display_name` and `implements`, derived once (one shared YAML parse) at load / `update_yaml_content` time in `regelrecht-corpus`. The law list reads `display_name` straight off the entry; the global implementors lookup is an in-memory reverse scan.
- Traject scopes build an implements index on the first lookup of the process — the one O(corpus) body scan. A TTL refresh does **not** repeat it: the previous index is carried over flagged stale, the first post-refresh lookup rebuilds it under a `try_lock` (same single-flight pattern as the snapshot refresh) while concurrent lookups keep serving the carried index — the federated implementors hot path (#762) never queues behind a rescan again.
- The rebuild itself is content-addressed: the GitHub Trees enumeration's **blob shas** are now plumbed through `regelrecht-corpus` onto metadata-only `LoadedLaw` entries (`content_sha`), and the editor keeps a cross-snapshot `(source_id, blob_sha) → implements` memo (shared `Arc`, like the overlay). A rebuild fetches/parses only bodies whose blob changed; an unchanged corpus rebuilds with **zero** Contents API calls. Overlay-saved laws are parsed from the overlay body (never memoized under the pre-save sha), loaded (local) laws reuse the corpus-parsed list, and each rebuild swaps the memo wholesale so it stays bounded by the current corpus size. `record_save` still updates the live index in place.
- Fetch failures during a scan are recorded and reported (the build warns once with skipped/indexed counts; the per-request signal is debug) instead of being indistinguishable from "no implementors"; the failed set is retried at the next rebuild. The response is a bare id array, so there was no non-breaking field for a partiality flag — left as a possible follow-up if the frontend wants to surface it.

### Small fix
The global scenario GET leaked raw backend error text via `e.to_string()`; it now uses the same generic-message/log-details pattern as `corpus_write_error`.

## Possible follow-up
A *partial* refresh (keep healthy sources' fresh enumeration when one source fails, instead of all-or-nothing serve-stale) would tighten convergence further for multi-source trajects with one flaky seed; deliberately out of scope here.

## Tests
- corpus: display-name/implements precompute on local load, fetched files, metadata-only entries (incl. `content_sha`), and `update_yaml_content` recompute.
- editor-api lib: body-cache FIFO bound, TTL freshness rule, lazy-fetch caching + overlay precedence, implements-index build/reuse, fetch-failure reporting, `record_save` in-place index updates, refresh carry-over semantics (shared backends/overlay/changed-cache), SWR (carried index served while a rebuild holds the build lock), memo (unchanged corpus rebuilds with zero fetches; a changed sha refetches only that body), and overlay reconciliation (entry kept while branch == saved body, dropped when the branch moved past the save).
- editor-api integration (`traject_reads_test`, testcontainers): end-to-end TTL refresh through the real handlers — an upstream-added law appears after the refresh, a fresh save survives it (read-your-writes), and an external overwrite of a saved law converges to the external content instead of being pinned. All 11 tests green.

Note: `save_annotations_test` and `trajects_test` do not compile on `origin/main` either (stale imports like `SESSION_KEY_ACTIVE_TRAJECT`); untouched here.

`just format`, `just lint`, `just build-check` all green.
