### PR TITLE
feat(editor): scenario discovery keyed by declared law $id

### DIFF
--- a/frontend/src/components/ScenarioBuilder.vue
+++ b/frontend/src/components/ScenarioBuilder.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { ref, computed, watch, nextTick, onBeforeUnmount } from 'vue';
 import { useDependencies } from '../composables/useDependencies.js';
-import { useScenarios } from '../composables/useScenarios.js';
+import { useScenarios, isScenarioMismatch } from '../composables/useScenarios.js';
 import { lawUrl } from '../composables/corpusUrls.js';
 import { parseFeature } from '../gherkin/parser.js';
 import { mapFeatureToForm, getEffectiveSetup, formStateToGherkin, syncEditedValues } from '../gherkin/formMapper.js';
@@ -49,6 +49,23 @@ const {
   selectScenario: selectScenarioFile,
   saveScenario,
 } = useScenarios(lawIdRef, trajectRefRef);
+
+// Mismatch warning: the selected scenario file declares execution targets
+// that do not include the opened law. Running it would evaluate that other
+// law — surface this instead of letting the run fail confusingly.
+const selectedScenarioEntry = computed(
+  () => scenarioFiles.value.find((sf) => sf.filename === selectedScenarioFile.value) || null,
+);
+const selectedScenarioMismatchTargets = computed(() =>
+  selectedScenarioEntry.value && isScenarioMismatch(selectedScenarioEntry.value, props.lawId)
+    ? selectedScenarioEntry.value.target_law_ids
+    : null,
+);
+const mismatchSupportingText = computed(() =>
+  selectedScenarioMismatchTargets.value
+    ? `Dit scenario evalueert '${selectedScenarioMismatchTargets.value.join("', '")}', niet deze wet ('${props.lawId}'). Uitvoeren gebruikt die andere wet.`
+    : '',
+);
 
 const formState = ref(null);
 const saveSuccess = ref(false);
@@ -473,10 +490,17 @@ defineExpose({ save: onSave });
           @change="onScenarioFileSelect"
         >
           <option v-for="sf in scenarioFiles" :key="sf.filename" :value="sf.filename">
-            {{ sf.filename }}
+            {{ isScenarioMismatch(sf, lawId) ? '⚠ ' + sf.filename : sf.filename }}
           </option>
         </select>
       </nldd-dropdown>
+
+      <nldd-inline-dialog
+        v-if="selectedScenarioMismatchTargets"
+        variant="alert"
+        text="Scenario hoort bij een andere wet"
+        :supporting-text="mismatchSupportingText"
+      ></nldd-inline-dialog>
 
       <nldd-inline-dialog v-if="saveSuccess" text="Opgeslagen"></nldd-inline-dialog>
       <nldd-inline-dialog v-if="saveError" variant="alert" text="Opslaan mislukt" :supporting-text="saveError.message || String(saveError)"></nldd-inline-dialog>

--- a/frontend/src/composables/useScenarios.js
+++ b/frontend/src/composables/useScenarios.js
@@ -61,12 +61,14 @@ export function useScenarios(lawId, trajectRef = ref(null)) {
       }
       scenarios.value = await res.json();
 
-      // Auto-select the first scenario that actually targets this law;
-      // fall back to the first file when none match (or targets are
-      // unknown). Folder placement is no longer the source of truth for
-      // the law↔scenario binding — the file's execution steps are.
+      // Auto-select the first scenario that explicitly targets this law;
+      // then prefer files whose targets are unknown (no parseable
+      // execution step) over known mismatches; finally fall back to the
+      // first file. Folder placement is no longer the source of truth
+      // for the law↔scenario binding — the file's execution steps are.
       if (scenarios.value.length > 0 && !selectedScenario.value) {
         const preferred =
+          scenarios.value.find((s) => s.target_law_ids?.includes(lawId.value)) ||
           scenarios.value.find((s) => !isScenarioMismatch(s, lawId.value)) ||
           scenarios.value[0];
         await selectScenario(preferred.filename);

--- a/frontend/src/composables/useScenarios.js
+++ b/frontend/src/composables/useScenarios.js
@@ -15,6 +15,17 @@ import { ref, watch } from 'vue';
 import { getEditorSessionId, lastSavedPr, sanitizeSavedPr } from './useEditorSession.js';
 import { requireTraject, scenarioFileUrl, scenariosListUrl } from './corpusUrls.js';
 
+/**
+ * True when the scenario file declares execution targets and none of
+ * them is the opened law — running it would evaluate a different law.
+ * Files without a parseable execution step (`target_law_ids` empty)
+ * count as "unknown", not as a mismatch.
+ */
+export function isScenarioMismatch(entry, lawId) {
+  const targets = entry?.target_law_ids || [];
+  return targets.length > 0 && !targets.includes(lawId);
+}
+
 export function useScenarios(lawId, trajectRef = ref(null)) {
   const scenarios = ref([]);
   const selectedScenario = ref(null);
@@ -50,9 +61,15 @@ export function useScenarios(lawId, trajectRef = ref(null)) {
       }
       scenarios.value = await res.json();
 
-      // Auto-select first scenario
+      // Auto-select the first scenario that actually targets this law;
+      // fall back to the first file when none match (or targets are
+      // unknown). Folder placement is no longer the source of truth for
+      // the law↔scenario binding — the file's execution steps are.
       if (scenarios.value.length > 0 && !selectedScenario.value) {
-        await selectScenario(scenarios.value[0].filename);
+        const preferred =
+          scenarios.value.find((s) => !isScenarioMismatch(s, lawId.value)) ||
+          scenarios.value[0];
+        await selectScenario(preferred.filename);
       }
     } catch (e) {
       error.value = e;

--- a/frontend/src/composables/useScenarios.test.js
+++ b/frontend/src/composables/useScenarios.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { ref } from 'vue';
-import { useScenarios } from './useScenarios.js';
+import { useScenarios, isScenarioMismatch } from './useScenarios.js';
 
 // Helper: shape a Response-like object with headers + body + status.
 // Mirrors the harness in useTrajectDocuments.test.js.
@@ -149,5 +149,49 @@ describe('useScenarios optimistic concurrency', () => {
       '/api/trajects/tr-12345678/corpus/laws/wet_b/scenarios/basis.feature',
     );
     expect(puts[1].opts.headers['If-Match']).toBe('"b1"');
+  });
+});
+
+describe('isScenarioMismatch', () => {
+  it('is false when the file targets the opened law', () => {
+    expect(isScenarioMismatch({ target_law_ids: ['wet_a'] }, 'wet_a')).toBe(false);
+  });
+  it('is false when targets are unknown (no execution step yet)', () => {
+    expect(isScenarioMismatch({ target_law_ids: [] }, 'wet_a')).toBe(false);
+    expect(isScenarioMismatch({}, 'wet_a')).toBe(false);
+  });
+  it('is true when the file only targets other laws', () => {
+    expect(isScenarioMismatch({ target_law_ids: ['wet_b', 'wet_c'] }, 'wet_a')).toBe(true);
+  });
+});
+
+describe('useScenarios auto-select', () => {
+  function mockList(entries) {
+    globalThis.fetch = vi.fn().mockImplementation(async (url) => {
+      if (String(url).endsWith('/scenarios')) return res({ json: entries });
+      return res({ body: 'Feature: x\n', etag: '"v1"' });
+    });
+  }
+
+  it('prefers the first file that targets the opened law', async () => {
+    mockList([
+      { filename: 'other.feature', target_law_ids: ['andere_wet'] },
+      { filename: 'matching.feature', target_law_ids: ['wet_a'] },
+    ]);
+
+    const s = useScenarios(ref('wet_a'));
+    await s.fetchScenarios();
+    expect(s.selectedScenario.value).toBe('matching.feature');
+  });
+
+  it('falls back to the first file when none match', async () => {
+    mockList([
+      { filename: 'a.feature', target_law_ids: ['andere_wet'] },
+      { filename: 'b.feature', target_law_ids: ['nog_een_wet'] },
+    ]);
+
+    const s = useScenarios(ref('wet_a'));
+    await s.fetchScenarios();
+    expect(s.selectedScenario.value).toBe('a.feature');
   });
 });

--- a/frontend/src/composables/useScenarios.test.js
+++ b/frontend/src/composables/useScenarios.test.js
@@ -184,6 +184,28 @@ describe('useScenarios auto-select', () => {
     expect(s.selectedScenario.value).toBe('matching.feature');
   });
 
+  it('prefers an explicit match over a file with unknown targets', async () => {
+    mockList([
+      { filename: 'wip.feature', target_law_ids: [] },
+      { filename: 'matching.feature', target_law_ids: ['wet_a'] },
+    ]);
+
+    const s = useScenarios(ref('wet_a'));
+    await s.fetchScenarios();
+    expect(s.selectedScenario.value).toBe('matching.feature');
+  });
+
+  it('prefers unknown targets over a known mismatch', async () => {
+    mockList([
+      { filename: 'other.feature', target_law_ids: ['andere_wet'] },
+      { filename: 'wip.feature', target_law_ids: [] },
+    ]);
+
+    const s = useScenarios(ref('wet_a'));
+    await s.fetchScenarios();
+    expect(s.selectedScenario.value).toBe('wip.feature');
+  });
+
   it('falls back to the first file when none match', async () => {
     mockList([
       { filename: 'a.feature', target_law_ids: ['andere_wet'] },

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -615,7 +615,11 @@ async fn list_scenarios_in_scope(
             }
             // Content goes through the same write-target-with-seed-fallback
             // per-file routing as the scenario GET, so the extracted targets
-            // reflect exactly the bytes the editor serves.
+            // reflect exactly the bytes the editor serves. Cost: one
+            // sequential read per file in this law's `scenarios/` dir —
+            // O(folder), typically 1-3 files, NOT the O(corpus) scan that
+            // hung federated trajects before (#762). Revisit with a batch
+            // read or index only if per-law scenario counts grow.
             let mut out = Vec::with_capacity(names.len());
             for filename in names {
                 let relative_path = scenarios_dir.join(&filename);

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -495,16 +495,16 @@ async fn implementors_in_scope(scope: &ReadScope, law_id: &str) -> Vec<String> {
 /// Law ids a scenario file evaluates, extracted from its execution steps.
 ///
 /// A target is the law named in an `I evaluate "<output>" of "<law_id>"`
-/// step. The Gherkin keyword may be `When`, `And`, `But` or `*` — the
-/// frontend step matcher (`frontend/src/gherkin/steps.js`) matches step text
-/// without its keyword, so continuations are valid execution steps too.
+/// step. The Gherkin keyword may be `When`, `Then`, `And`, `But` or `*` —
+/// the frontend step matcher (`frontend/src/gherkin/steps.js`) matches step
+/// text without its keyword, so all of these run as execution steps.
 /// `Given law "…" is loaded` lines are dependencies, not targets.
 /// Deduplicated, order of first occurrence preserved.
 fn extract_target_law_ids(content: &str) -> Vec<String> {
     let mut out: Vec<String> = Vec::new();
     for line in content.lines() {
         let trimmed = line.trim_start();
-        let Some(step) = ["When ", "And ", "But ", "* "]
+        let Some(step) = ["When ", "Then ", "And ", "But ", "* "]
             .iter()
             .find_map(|kw| trimmed.strip_prefix(kw))
         else {
@@ -658,6 +658,10 @@ async fn list_scenarios_in_scope(
                 Ok(dir) => dir.join("scenarios"),
                 Err(_) => return Ok(Json(Vec::new())),
             };
+            // Unlike the Traject branch there is only one backend here, so
+            // holding its lock across the listing and the per-file reads is
+            // fine: no second lock is ever taken (no ordering hazard) and
+            // re-acquiring per file would only add churn.
             let backend = resolved.backend.lock().await;
             let entries = backend
                 .list_files(&scenarios_dir, Some("feature"))
@@ -2836,18 +2840,19 @@ mod tests {
     }
 
     #[test]
-    fn extract_targets_accepts_and_but_continuations() {
+    fn extract_targets_accepts_then_and_but_continuations() {
         // The frontend step matcher strips the Gherkin keyword before
-        // matching, so And/But/`*` continuations are valid execution steps.
+        // matching, so Then/And/But/`*` lines are valid execution steps.
         let content = r#"
     When I evaluate "a" of "law_a"
-    And I evaluate "b" of "law_b"
-    But I evaluate "c" of "law_c"
-    * I evaluate "d" of "law_d"
+    Then I evaluate "b" of "law_b"
+    And I evaluate "c" of "law_c"
+    But I evaluate "d" of "law_d"
+    * I evaluate "e" of "law_e"
 "#;
         assert_eq!(
             extract_target_law_ids(content),
-            vec!["law_a", "law_b", "law_c", "law_d"]
+            vec!["law_a", "law_b", "law_c", "law_d", "law_e"]
         );
     }
 

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -495,18 +495,16 @@ async fn implementors_in_scope(scope: &ReadScope, law_id: &str) -> Vec<String> {
 /// Law ids a scenario file evaluates, extracted from its execution steps.
 ///
 /// A target is the law named in an `I evaluate "<output>" of "<law_id>"`
-/// step. The Gherkin keyword may be `When`, `And` or `But` — the frontend
-/// step matcher (`frontend/src/gherkin/steps.js`) matches step text without
-/// its keyword, so continuations are valid execution steps too.
+/// step. The Gherkin keyword may be `When`, `And`, `But` or `*` — the
+/// frontend step matcher (`frontend/src/gherkin/steps.js`) matches step text
+/// without its keyword, so continuations are valid execution steps too.
 /// `Given law "…" is loaded` lines are dependencies, not targets.
 /// Deduplicated, order of first occurrence preserved.
-// wired into list_scenarios in the next commit
-#[allow(dead_code)]
 fn extract_target_law_ids(content: &str) -> Vec<String> {
     let mut out: Vec<String> = Vec::new();
     for line in content.lines() {
         let trimmed = line.trim_start();
-        let Some(step) = ["When ", "And ", "But "]
+        let Some(step) = ["When ", "And ", "But ", "* "]
             .iter()
             .find_map(|kw| trimmed.strip_prefix(kw))
         else {
@@ -536,6 +534,10 @@ fn extract_target_law_ids(content: &str) -> Vec<String> {
 #[derive(Debug, Serialize)]
 pub struct ScenarioEntry {
     pub filename: String,
+    /// Law ids this scenario file evaluates (from its
+    /// `I evaluate … of "…"` steps). Empty when the file has no parseable
+    /// execution step yet (work in progress) or could not be read.
+    pub target_law_ids: Vec<String>,
 }
 
 /// GET /api/corpus/laws/{law_id}/scenarios — list available scenario files (global view).
@@ -575,7 +577,10 @@ async fn list_scenarios_in_scope(
         )
     };
 
-    let filenames: std::collections::BTreeSet<String> = match scope {
+    // Each listed file is also read to extract which law ids it evaluates
+    // (`target_law_ids`). One failed read must not take down the whole
+    // listing: that entry stays listed with unknown (empty) targets.
+    let out: Vec<ScenarioEntry> = match scope {
         // Traject-scoped: the union of the write target's listing and
         // the seed's, mirroring the per-file routing of the scenario GET
         // / `If-Match` check (`read_traject_file_via_write_target`): a
@@ -608,7 +613,39 @@ async fn list_scenarios_in_scope(
                 drop(backend);
                 names.extend(entries.into_iter().map(|e| e.name));
             }
-            names
+            // Content goes through the same write-target-with-seed-fallback
+            // per-file routing as the scenario GET, so the extracted targets
+            // reflect exactly the bytes the editor serves.
+            let mut out = Vec::with_capacity(names.len());
+            for filename in names {
+                let relative_path = scenarios_dir.join(&filename);
+                let target_law_ids = match read_traject_file_via_write_target(
+                    traject,
+                    law,
+                    &relative_path,
+                    "scenario",
+                )
+                .await
+                {
+                    Ok(Some(content)) => extract_target_law_ids(&content),
+                    Ok(None) => Vec::new(),
+                    Err((_, err)) => {
+                        tracing::warn!(
+                            law_id = %law_id,
+                            file = %filename,
+                            error = %err,
+                            "scenario read failed during listing"
+                        );
+                        Vec::new()
+                    }
+                };
+                out.push(ScenarioEntry {
+                    filename,
+                    target_law_ids,
+                });
+            }
+            // BTreeSet iteration is already sorted by filename.
+            out
         }
         // Global: no write target exists; keep the read-only resolution.
         ReadScope::Global(_) => {
@@ -622,16 +659,31 @@ async fn list_scenarios_in_scope(
                 .list_files(&scenarios_dir, Some("feature"))
                 .await
                 .map_err(list_error)?;
+            let mut out = Vec::with_capacity(entries.len());
+            for e in entries {
+                let target_law_ids = match backend.read_file(&scenarios_dir.join(&e.name)).await {
+                    Ok(Some(content)) => extract_target_law_ids(&content),
+                    Ok(None) => Vec::new(),
+                    Err(err) => {
+                        tracing::warn!(
+                            law_id = %law_id,
+                            file = %e.name,
+                            error = %err,
+                            "scenario read failed during listing"
+                        );
+                        Vec::new()
+                    }
+                };
+                out.push(ScenarioEntry {
+                    filename: e.name,
+                    target_law_ids,
+                });
+            }
             drop(backend);
-            entries.into_iter().map(|e| e.name).collect()
+            out.sort_by(|a, b| a.filename.cmp(&b.filename));
+            out
         }
     };
-
-    // BTreeSet iteration is already sorted by filename.
-    let out: Vec<ScenarioEntry> = filenames
-        .into_iter()
-        .map(|filename| ScenarioEntry { filename })
-        .collect();
     Ok(Json(out))
 }
 
@@ -2782,15 +2834,16 @@ mod tests {
     #[test]
     fn extract_targets_accepts_and_but_continuations() {
         // The frontend step matcher strips the Gherkin keyword before
-        // matching, so And/But continuations are valid execution steps.
+        // matching, so And/But/`*` continuations are valid execution steps.
         let content = r#"
     When I evaluate "a" of "law_a"
     And I evaluate "b" of "law_b"
     But I evaluate "c" of "law_c"
+    * I evaluate "d" of "law_d"
 "#;
         assert_eq!(
             extract_target_law_ids(content),
-            vec!["law_a", "law_b", "law_c"]
+            vec!["law_a", "law_b", "law_c", "law_d"]
         );
     }
 

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -492,6 +492,46 @@ async fn implementors_in_scope(scope: &ReadScope, law_id: &str) -> Vec<String> {
     out
 }
 
+/// Law ids a scenario file evaluates, extracted from its execution steps.
+///
+/// A target is the law named in an `I evaluate "<output>" of "<law_id>"`
+/// step. The Gherkin keyword may be `When`, `And` or `But` — the frontend
+/// step matcher (`frontend/src/gherkin/steps.js`) matches step text without
+/// its keyword, so continuations are valid execution steps too.
+/// `Given law "…" is loaded` lines are dependencies, not targets.
+/// Deduplicated, order of first occurrence preserved.
+// wired into list_scenarios in the next commit
+#[allow(dead_code)]
+fn extract_target_law_ids(content: &str) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    for line in content.lines() {
+        let trimmed = line.trim_start();
+        let Some(step) = ["When ", "And ", "But "]
+            .iter()
+            .find_map(|kw| trimmed.strip_prefix(kw))
+        else {
+            continue;
+        };
+        let Some(rest) = step.trim_start().strip_prefix("I evaluate \"") else {
+            continue;
+        };
+        // rest = `<output>" of "<law_id>"…`
+        let Some((_, after_output)) = rest.split_once('"') else {
+            continue;
+        };
+        let Some(rest) = after_output.strip_prefix(" of \"") else {
+            continue;
+        };
+        let Some((law_id, _)) = rest.split_once('"') else {
+            continue;
+        };
+        if !law_id.is_empty() && !out.iter().any(|l| l == law_id) {
+            out.push(law_id.to_string());
+        }
+    }
+    out
+}
+
 /// A scenario file entry.
 #[derive(Debug, Serialize)]
 pub struct ScenarioEntry {
@@ -2713,5 +2753,74 @@ mod tests {
         let err = check_if_match(None, Some(&stale), "Scenario")
             .expect_err("etag against missing file must be refused");
         assert_eq!(err.0, StatusCode::PRECONDITION_FAILED);
+    }
+
+    // --- extract_target_law_ids ---
+
+    #[test]
+    fn extract_targets_single_when_step() {
+        let content = r#"Feature: X
+  Scenario: a
+    When I evaluate "heeft_recht_op_zorgtoeslag" of "wet_op_de_zorgtoeslag"
+"#;
+        assert_eq!(
+            extract_target_law_ids(content),
+            vec!["wet_op_de_zorgtoeslag".to_string()]
+        );
+    }
+
+    #[test]
+    fn extract_targets_dedups_and_preserves_order() {
+        let content = r#"
+    When I evaluate "a" of "law_b"
+    When I evaluate "b" of "law_a"
+    When I evaluate "c" of "law_b"
+"#;
+        assert_eq!(extract_target_law_ids(content), vec!["law_b", "law_a"]);
+    }
+
+    #[test]
+    fn extract_targets_accepts_and_but_continuations() {
+        // The frontend step matcher strips the Gherkin keyword before
+        // matching, so And/But continuations are valid execution steps.
+        let content = r#"
+    When I evaluate "a" of "law_a"
+    And I evaluate "b" of "law_b"
+    But I evaluate "c" of "law_c"
+"#;
+        assert_eq!(
+            extract_target_law_ids(content),
+            vec!["law_a", "law_b", "law_c"]
+        );
+    }
+
+    #[test]
+    fn extract_targets_ignores_given_law_loaded_dependencies() {
+        let content = r#"
+    Given law "zorgverzekeringswet" is loaded
+    Given law "wet_inkomstenbelasting_2001" is loaded
+    When I evaluate "x" of "wet_op_de_zorgtoeslag"
+"#;
+        assert_eq!(
+            extract_target_law_ids(content),
+            vec!["wet_op_de_zorgtoeslag"]
+        );
+    }
+
+    #[test]
+    fn extract_targets_empty_for_file_without_execution_step() {
+        let content =
+            "Feature: WIP\n  Scenario: later\n    Given the calculation date is \"2025-01-01\"\n";
+        assert_eq!(extract_target_law_ids(content), Vec::<String>::new());
+    }
+
+    #[test]
+    fn extract_targets_ignores_malformed_lines() {
+        let content = r#"
+    When I evaluate "no closing quote of "x
+    When I evaluate "a" of ""
+    When something else entirely
+"#;
+        assert_eq!(extract_target_law_ids(content), Vec::<String>::new());
     }
 }

--- a/packages/editor-api/tests/list_scenarios_test.rs
+++ b/packages/editor-api/tests/list_scenarios_test.rs
@@ -1,0 +1,180 @@
+//! Integration test for `corpus_handlers::list_traject_scenarios` —
+//! verifies that `ScenarioEntry::target_law_ids` is populated from the
+//! feature file content.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::Arc;
+
+use axum::extract::{Path, State};
+use sqlx::PgPool;
+use tokio::sync::{Mutex, RwLock};
+use tower_sessions::Session;
+use tower_sessions_memory_store::MemoryStore;
+use uuid::Uuid;
+
+use regelrecht_auth::handlers::SESSION_KEY_SUB;
+use regelrecht_editor_api::config::AppConfig;
+use regelrecht_editor_api::corpus_handlers::list_traject_scenarios;
+use regelrecht_editor_api::state::{AppState, CorpusState};
+use regelrecht_editor_api::traject_corpus::TrajectCorpusCache;
+
+use regelrecht_pipeline::test_utils::TestDb;
+
+const LAW_ID: &str = "wet_op_de_zorgtoeslag";
+
+// ---------------------------------------------------------------------------
+// Helpers — deliberately duplicated per test file (suite convention)
+// ---------------------------------------------------------------------------
+
+fn empty_state(pool: PgPool) -> AppState {
+    AppState {
+        corpus: Arc::new(RwLock::new(CorpusState::empty())),
+        oidc_client: None,
+        end_session_url: None,
+        config: Arc::new(AppConfig {
+            oidc: None,
+            base_url: None,
+        }),
+        http_client: reqwest::Client::new(),
+        pool: Some(pool),
+        pipeline_api_url: None,
+        reload_lock: Arc::new(Mutex::new(())),
+        trajects: Arc::new(TrajectCorpusCache::new()),
+    }
+}
+
+async fn seed_account(pool: &PgPool, email: &str) -> (Uuid, String) {
+    let sub = format!("sub-{email}");
+    let (id,): (Uuid,) = sqlx::query_as(
+        "INSERT INTO accounts (person_sub, email, name) VALUES ($1, $2, $3) RETURNING id",
+    )
+    .bind(&sub)
+    .bind(email)
+    .bind("Test User")
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    (id, sub)
+}
+
+/// Write a minimal but schema-valid law file and a `scenarios/` directory
+/// under `corpus_dir/wet/{LAW_ID}/`.
+fn write_corpus(corpus_dir: &std::path::Path) {
+    let law_dir = corpus_dir.join("wet").join(LAW_ID);
+    std::fs::create_dir_all(&law_dir).unwrap();
+    std::fs::write(
+        law_dir.join("2025-01-01.yaml"),
+        format!("$id: {LAW_ID}\nname: Zorgtoeslagwet\n"),
+    )
+    .unwrap();
+
+    let scenarios_dir = law_dir.join("scenarios");
+    std::fs::create_dir_all(&scenarios_dir).unwrap();
+
+    // A scenario that evaluates the law under test.
+    std::fs::write(
+        scenarios_dir.join("matching.feature"),
+        format!("Feature: m\n  Scenario: a\n    When I evaluate \"recht\" of \"{LAW_ID}\"\n"),
+    )
+    .unwrap();
+
+    // A scenario that evaluates a different law.
+    std::fs::write(
+        scenarios_dir.join("other.feature"),
+        "Feature: o\n  Scenario: b\n    When I evaluate \"x\" of \"andere_wet\"\n",
+    )
+    .unwrap();
+
+    // A work-in-progress scenario with no execution step.
+    std::fs::write(scenarios_dir.join("wip.feature"), "Feature: wip\n").unwrap();
+}
+
+/// Create a traject with a single local writable-own source at `corpus_dir`.
+/// Returns the traject id; `owner_id` is added as an owner so the membership
+/// re-check inside the handler passes.
+async fn local_traject(pool: &PgPool, owner_id: Uuid, corpus_dir: &std::path::Path) -> Uuid {
+    let (traject_id,): (Uuid,) = sqlx::query_as(
+        "INSERT INTO trajects (name, description, scope, created_by)
+         VALUES ('Test', '', '', $1) RETURNING id",
+    )
+    .bind(owner_id)
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO traject_members (traject_id, account_id, role)
+         VALUES ($1, $2, 'owner')",
+    )
+    .bind(traject_id)
+    .bind(owner_id)
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO traject_corpus_sources
+         (traject_id, source_id, name, source_type, local_path,
+          priority, scopes, is_writable_own)
+         VALUES ($1, 'local', 'Local', 'local'::corpus_source_type, $2,
+                 0, '[]'::jsonb, TRUE)",
+    )
+    .bind(traject_id)
+    .bind(corpus_dir.to_string_lossy().to_string())
+    .execute(pool)
+    .await
+    .unwrap();
+    traject_id
+}
+
+/// Build a session that carries `sub` as the authenticated user identity.
+/// The active traject is passed in the URL path (traject_ref), not in the
+/// session — so no `SESSION_KEY_ACTIVE_TRAJECT` insertion needed.
+async fn session_for(sub: &str) -> Session {
+    let session = Session::new(None, Arc::new(MemoryStore::default()), None);
+    session.insert(SESSION_KEY_SUB, sub).await.unwrap();
+    session
+}
+
+/// Build the URL-form traject ref used in path parameters.
+/// The resolver matches on `left(id::text, 8)` (first 8 hex chars of the
+/// hyphenated UUID), so `t-{8hex}` is a valid ref (slug="t", suffix=8hex).
+fn traject_ref(id: Uuid) -> String {
+    format!("t-{}", &id.to_string()[..8])
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn list_traject_scenarios_returns_target_law_ids() {
+    let db = TestDb::new().await;
+    let state = empty_state(db.pool.clone());
+    let (owner, sub) = seed_account(&db.pool, "alice@test.local").await;
+
+    let corpus = tempfile::tempdir().unwrap();
+    write_corpus(corpus.path());
+    let traject = local_traject(&db.pool, owner, corpus.path()).await;
+
+    let axum::Json(entries) = list_traject_scenarios(
+        State(state),
+        session_for(&sub).await,
+        Path((traject_ref(traject), LAW_ID.to_string())),
+    )
+    .await
+    .expect("list_traject_scenarios must succeed");
+
+    let summary: Vec<(String, Vec<String>)> = entries
+        .into_iter()
+        .map(|e| (e.filename, e.target_law_ids))
+        .collect();
+
+    assert_eq!(
+        summary,
+        vec![
+            ("matching.feature".to_string(), vec![LAW_ID.to_string()]),
+            ("other.feature".to_string(), vec!["andere_wet".to_string()]),
+            ("wip.feature".to_string(), Vec::new()),
+        ]
+    );
+}

--- a/packages/editor-api/tests/list_scenarios_test.rs
+++ b/packages/editor-api/tests/list_scenarios_test.rs
@@ -1,9 +1,11 @@
-//! Integration test for `corpus_handlers::list_traject_scenarios` —
-//! verifies that `ScenarioEntry::target_law_ids` is populated from the
-//! feature file content.
+//! Integration tests for `corpus_handlers::list_traject_scenarios` and
+//! `corpus_handlers::list_scenarios` (global) — verify that
+//! `ScenarioEntry::target_law_ids` is populated from the feature file
+//! content on both read paths.
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use axum::extract::{Path, State};
@@ -15,8 +17,8 @@ use uuid::Uuid;
 
 use regelrecht_auth::handlers::SESSION_KEY_SUB;
 use regelrecht_editor_api::config::AppConfig;
-use regelrecht_editor_api::corpus_handlers::list_traject_scenarios;
-use regelrecht_editor_api::state::{AppState, CorpusState};
+use regelrecht_editor_api::corpus_handlers::{list_scenarios, list_traject_scenarios};
+use regelrecht_editor_api::state::{AppState, BackendEntry, CorpusState};
 use regelrecht_editor_api::traject_corpus::TrajectCorpusCache;
 
 use regelrecht_pipeline::test_utils::TestDb;
@@ -163,6 +165,80 @@ async fn list_traject_scenarios_returns_target_law_ids() {
     )
     .await
     .expect("list_traject_scenarios must succeed");
+
+    let summary: Vec<(String, Vec<String>)> = entries
+        .into_iter()
+        .map(|e| (e.filename, e.target_law_ids))
+        .collect();
+
+    assert_eq!(
+        summary,
+        vec![
+            ("matching.feature".to_string(), vec![LAW_ID.to_string()]),
+            ("other.feature".to_string(), vec!["andere_wet".to_string()]),
+            ("wip.feature".to_string(), Vec::new()),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn list_scenarios_global_returns_target_law_ids() {
+    let corpus = tempfile::tempdir().unwrap();
+    write_corpus(corpus.path());
+
+    // Registry with a single local source rooted at the temp corpus, the
+    // same shape `init_corpus` builds from corpus-registry.yaml.
+    let manifest_dir = tempfile::tempdir().unwrap();
+    let manifest = manifest_dir.path().join("corpus-registry.yaml");
+    std::fs::write(
+        &manifest,
+        format!(
+            "---\nschema_version: '1.0'\nsources:\n  - id: local\n    name: Local\n    \
+             type: local\n    local:\n      path: {}\n    scopes: []\n    priority: 1\n",
+            corpus.path().display()
+        ),
+    )
+    .unwrap();
+    let registry = regelrecht_corpus::CorpusRegistry::load(&manifest, None).unwrap();
+    let source_map = registry.load_local_sources().unwrap();
+
+    let mut backends = HashMap::new();
+    for source in registry.sources() {
+        let mut backend = regelrecht_corpus::backend::create_backend(source, None).unwrap();
+        backend.ensure_ready().await.unwrap();
+        let writable = backend.is_writable();
+        backends.insert(
+            source.id.clone(),
+            BackendEntry {
+                backend: Arc::new(Mutex::new(backend)),
+                writable,
+            },
+        );
+    }
+
+    let state = AppState {
+        corpus: Arc::new(RwLock::new(CorpusState {
+            registry,
+            source_map,
+            backends,
+            auth_file: None,
+        })),
+        oidc_client: None,
+        end_session_url: None,
+        config: Arc::new(AppConfig {
+            oidc: None,
+            base_url: None,
+        }),
+        http_client: reqwest::Client::new(),
+        pool: None,
+        pipeline_api_url: None,
+        reload_lock: Arc::new(Mutex::new(())),
+        trajects: Arc::new(TrajectCorpusCache::new()),
+    };
+
+    let axum::Json(entries) = list_scenarios(State(state), Path(LAW_ID.to_string()))
+        .await
+        .expect("list_scenarios must succeed");
 
     let summary: Vec<(String, Vec<String>)> = entries
         .into_iter()


### PR DESCRIPTION
## Problem

Scenario *execution* is id-based — each `.feature` file names its target law in `When I evaluate "<output>" of "<law_id>"` — but scenario *discovery* is path-based: the editor lists whatever `.feature` files sit next to the opened law's YAML. When those keys disagree (the pre-#778 `zorgtoeslagwet`/`wet_op_de_zorgtoeslag` federated twin), the panel lists scenarios that then fail at run time with a misleading `Law not found`.

## Change

Unify both on the key the scenario file already declares:

- **editor-api**: `list_scenarios` now reads each feature file and returns `target_law_ids` (extracted from its execution steps; `When`/`And`/`But`/`*` keywords; `Given law "…" is loaded` dependency lines ignored; a single unreadable file degrades to `[]` + warn instead of failing the listing).
- **frontend**: a file whose targets don't include the opened law is marked `⚠` in the file dropdown, selecting it shows an `nldd-inline-dialog` alert naming the law it *would* evaluate, and auto-select prefers the first matching file.

Warn, don't hide: hiding mismatching files would mask exactly the drift this surfaces. Storage convention (scenarios next to their law) and the execution path are unchanged; no law YAML or `.feature` files were modified. The new field is additive, so existing consumers (incl. e2e mocks) are unaffected.

Design: `docs/superpowers/specs/2026-06-11-scenario-id-discovery-design.md` (follow-up to #778).

## Verification

- New Rust unit tests for the extractor (7 cases) + hermetic integration test `list_scenarios_test.rs` (TestDb + tempdir corpus, 1 passed)
- New vitest suite for `isScenarioMismatch` + auto-select preference (5 passed)
- `just check` ✅ · `npm --prefix frontend test` ✅ (277 passed)

## Note for reviewers

The three pre-existing editor-api integration test files (`traject_reads_test.rs`, `save_annotations_test.rs`, `trajects_test.rs`) do not compile on main — CI's Editor API job runs `cargo check`/`clippy` without `--tests`, so this is invisible in CI. Not touched here; worth a separate fix.