### PR TITLE
chore(deps): migrate frontend to cucumber ESM (gherkin 40, messages 33)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,8 +8,8 @@
       "name": "regelrecht-ui-prototype",
       "version": "1.0.0",
       "dependencies": {
-        "@cucumber/gherkin": "^39.1.0",
-        "@cucumber/messages": "^32.3.1",
+        "@cucumber/gherkin": "^40.0.0",
+        "@cucumber/messages": "^33.0.2",
         "@nldd/design-system": "^0.8.53",
         "@tiptap/core": "^3.26.1",
         "@tiptap/starter-kit": "^3.26.1",
@@ -354,23 +354,19 @@
       }
     },
     "node_modules/@cucumber/gherkin": {
-      "version": "39.1.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-39.1.0.tgz",
-      "integrity": "sha512-pqmSO2bUWxJm3TbNrKXlDaHjL6c77+ez9kWmfCd9oRPeTRPEVH3spZvpAqdXYWOZYSNYwWFCAAeZ4RGpkauNoQ==",
+      "version": "40.0.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-40.0.0.tgz",
+      "integrity": "sha512-wMbF0TtNy2ELBJ8nls29eZQWL4XKfuWtMwqDaylUEAiv3qC0/ZAVU0LS2viQ6ZfXe5ROAC38penTOAdrjwYC9Q==",
       "license": "MIT",
       "dependencies": {
-        "@cucumber/messages": ">=31.0.0 <33"
+        "@cucumber/messages": ">=31.0.0 <34"
       }
     },
     "node_modules/@cucumber/messages": {
-      "version": "32.3.1",
-      "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-32.3.1.tgz",
-      "integrity": "sha512-yNQq1KoXRYaEKrWMFmpUQX7TdeQuU9jeGgJAZ3dArTsC/T4NpJ6DnqaJIIgwPnz/wtQIQTNX7/h0rOuF5xY4qQ==",
-      "license": "MIT",
-      "dependencies": {
-        "class-transformer": "0.5.1",
-        "reflect-metadata": "0.2.2"
-      }
+      "version": "33.0.2",
+      "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-33.0.2.tgz",
+      "integrity": "sha512-JxWlW9H7+SCuKBlqpD0Puhy+afXStE3qmMutmvJcdF+BWhl4jvFLexyK77uN0Xs+zLlJ+/B6T49nw4OO5BUZxg==",
+      "license": "MIT"
     },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
@@ -2361,12 +2357,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/class-transformer": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
-      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "license": "MIT"
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3996,12 +3986,6 @@
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
       }
-    },
-    "node_modules/reflect-metadata": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
-      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "license": "Apache-2.0"
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,8 +14,8 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
-    "@cucumber/gherkin": "^39.1.0",
-    "@cucumber/messages": "^32.3.1",
+    "@cucumber/gherkin": "^40.0.0",
+    "@cucumber/messages": "^33.0.2",
     "@nldd/design-system": "^0.8.53",
     "@tiptap/core": "^3.26.1",
     "@tiptap/starter-kit": "^3.26.1",

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -39,6 +39,15 @@ export default defineConfig({
     include: ['src/**/*.test.js'],
     pool: 'vmThreads',
     testTimeout: 10000,
+    server: {
+      // @cucumber/gherkin 40 and @cucumber/messages 33 ship as pure ESM.
+      // The vmThreads pool loads external ESM in a separate VM context, which
+      // throws "Linked modules must use the same context". Inlining lets vitest
+      // process them in the test context instead.
+      deps: {
+        inline: [/@cucumber\//],
+      },
+    },
   },
   build: {
     cssTarget: ['chrome123', 'edge123', 'firefox120', 'safari18'],


### PR DESCRIPTION
## What

Combined the two stalled Dependabot major bumps for the frontend cucumber packages into one ESM migration:

- `@cucumber/gherkin` 39.1.0 → **40.0.0**
- `@cucumber/messages` 32.3.1 → **33.0.2**

Both majors switch to **pure ESM**. They are coupled (gherkin 40 depends on messages 33), so they have to land together.

## Why the originals were blocked

#808 (gherkin 40) failed CI: the gherkin parser tests threw `Error: Linked modules must use the same context`. The frontend vitest config uses the `vmThreads` pool, which loads external ESM dependencies in a separate VM context — pure-ESM packages can't link across those contexts.

## Fix

Inline the `@cucumber/*` packages via `test.server.deps.inline` so vitest processes them in the test context instead of loading them as external ESM. No source changes were needed — the only API used (`Messages.IdGenerator.uuid()`, `Gherkin.AstBuilder`/`Parser`/`GherkinClassicTokenMatcher`, AST traversal in `src/gherkin/parser.js`) is unchanged across the major bumps.

## Verification

- `npx vitest run` — **309 tests / 28 files pass** locally
- `npm run build` — production build succeeds (gherkin chunk builds fine)

Supersedes #808 and #809.