### PR TITLE
fix(frontend): bump markdown-it to 14.2.0 (GHSA-6v5v-wf23-fmfq)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3282,9 +3282,19 @@
       }
     },
     "node_modules/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"
@@ -3378,14 +3388,24 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
-      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
+      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
+        "linkify-it": "^5.0.1",
         "mdurl": "^2.0.0",
         "punycode.js": "^2.3.1",
         "uc.micro": "^2.1.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,7 +29,8 @@
     "tiptap-markdown": "^0.9.0"
   },
   "overrides": {
-    "brace-expansion": "^5.0.5"
+    "brace-expansion": "^5.0.5",
+    "markdown-it": "^14.2.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.61.0",


### PR DESCRIPTION
## What

Adds an npm override forcing `markdown-it` to `^14.2.0` in `frontend/`.

## Why

`markdown-it <=14.1.1` has a moderate **quadratic-complexity DoS** in the smartquotes rule ([GHSA-6v5v-wf23-fmfq](https://github.com/advisories/GHSA-6v5v-wf23-fmfq)). It is pulled transitively via `tiptap-markdown@0.9.0` (and `prosemirror-markdown`). The advisory was published today and now makes the **required `Security Audit` check (`npm audit`) fail on every open PR and on `main`** — it is unrelated to any specific PR's changes.

`14.2.0` is the patched release; the override pins it without touching `tiptap-markdown`.

## Verification

- `npm audit` → **0 vulnerabilities**
- `npm run build` → succeeds
- `npx vitest run` on the tiptap/markdown component tests → **29 pass**

Unblocks #818 (cucumber ESM migration) and any other open PR.