### PR TITLE
fix(frontend): revert cucumber ESM bump (#818) that blanks the editor in the browser

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,8 +8,8 @@
       "name": "regelrecht-ui-prototype",
       "version": "1.0.0",
       "dependencies": {
-        "@cucumber/gherkin": "^40.0.0",
-        "@cucumber/messages": "^33.0.2",
+        "@cucumber/gherkin": "^39.1.0",
+        "@cucumber/messages": "^32.3.1",
         "@nldd/design-system": "^0.8.53",
         "@tiptap/core": "^3.26.1",
         "@tiptap/starter-kit": "^3.26.1",
@@ -354,19 +354,23 @@
       }
     },
     "node_modules/@cucumber/gherkin": {
-      "version": "40.0.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-40.0.0.tgz",
-      "integrity": "sha512-wMbF0TtNy2ELBJ8nls29eZQWL4XKfuWtMwqDaylUEAiv3qC0/ZAVU0LS2viQ6ZfXe5ROAC38penTOAdrjwYC9Q==",
+      "version": "39.1.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-39.1.0.tgz",
+      "integrity": "sha512-pqmSO2bUWxJm3TbNrKXlDaHjL6c77+ez9kWmfCd9oRPeTRPEVH3spZvpAqdXYWOZYSNYwWFCAAeZ4RGpkauNoQ==",
       "license": "MIT",
       "dependencies": {
-        "@cucumber/messages": ">=31.0.0 <34"
+        "@cucumber/messages": ">=31.0.0 <33"
       }
     },
     "node_modules/@cucumber/messages": {
-      "version": "33.0.2",
-      "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-33.0.2.tgz",
-      "integrity": "sha512-JxWlW9H7+SCuKBlqpD0Puhy+afXStE3qmMutmvJcdF+BWhl4jvFLexyK77uN0Xs+zLlJ+/B6T49nw4OO5BUZxg==",
-      "license": "MIT"
+      "version": "32.3.1",
+      "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-32.3.1.tgz",
+      "integrity": "sha512-yNQq1KoXRYaEKrWMFmpUQX7TdeQuU9jeGgJAZ3dArTsC/T4NpJ6DnqaJIIgwPnz/wtQIQTNX7/h0rOuF5xY4qQ==",
+      "license": "MIT",
+      "dependencies": {
+        "class-transformer": "0.5.1",
+        "reflect-metadata": "0.2.2"
+      }
     },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
@@ -2357,6 +2361,12 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/class-transformer": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
+      "license": "MIT"
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3986,6 +3996,12 @@
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "license": "Apache-2.0"
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,8 +14,8 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
-    "@cucumber/gherkin": "^40.0.0",
-    "@cucumber/messages": "^33.0.2",
+    "@cucumber/gherkin": "^39.1.0",
+    "@cucumber/messages": "^32.3.1",
     "@nldd/design-system": "^0.8.53",
     "@tiptap/core": "^3.26.1",
     "@tiptap/starter-kit": "^3.26.1",

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -39,15 +39,6 @@ export default defineConfig({
     include: ['src/**/*.test.js'],
     pool: 'vmThreads',
     testTimeout: 10000,
-    server: {
-      // @cucumber/gherkin 40 and @cucumber/messages 33 ship as pure ESM.
-      // The vmThreads pool loads external ESM in a separate VM context, which
-      // throws "Linked modules must use the same context". Inlining lets vitest
-      // process them in the test context instead.
-      deps: {
-        inline: [/@cucumber\//],
-      },
-    },
   },
   build: {
     cssTarget: ['chrome123', 'edge123', 'firefox120', 'safari18'],


### PR DESCRIPTION
## ⚠️ Production incident — editor is down

`editor.regelrecht.rijks.app` renders a **blank page on every `/editor/*` route** (`#app` = `<!---->`). The read-only `/library` viewer still works; the editing UI — the core of the app — is fully down.

## Root cause: #818 (cucumber ESM migration)

`@cucumber/messages` 33 (pure ESM) runs this at module import time:

```js
createRequire(import.meta.url)('../package.json').version
```

`createRequire` is a **Node-only API** — it doesn't exist in the browser, so it throws `TypeError: createRequire is not a function` at import. `EditorView` imports the gherkin parser (`ScenarioForm`/`ScenarioBuilder` → `src/gherkin/parser.js` → `@cucumber/messages`), so the whole view crashes before mounting.

**Why CI/tests missed it:** vitest runs in Node (where `createRequire` exists), so the 309 unit tests + the production build all passed. The failure only manifests in a real browser. Lesson logged.

## This change

Reverts #818 (restores `@cucumber/gherkin` 39.1.0 / `@cucumber/messages` 32.3.1 and drops the now-unneeded vitest `deps.inline`). **Keeps #819** (markdown-it 14.2.0 security fix — unrelated and good).

## Verification (in a real browser this time)

- Built `dist` and served via `vite preview`; loaded `/editor` → `#app` renders (17 KB HTML), **no `createRequire` error** (only expected 502s from the absent local backend).
- `createRequire` no longer present in any built asset (`grep dist/assets` → 0).
- `npm audit` → 0 vulnerabilities; gherkin 39.1.0 / messages 32.3.1 / markdown-it 14.2.0.

## Follow-up

Redo the cucumber 40/33 migration properly with a browser-runtime fix for the `createRequire` version-probe (e.g. neutralize it via build config / alias), validated in a real browser before merge — not just Node tests.