### PR TITLE
chore(deps): migrate frontend to cucumber ESM (gherkin 40, messages 33) — browser-fixed

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,8 +8,8 @@
       "name": "regelrecht-ui-prototype",
       "version": "1.0.0",
       "dependencies": {
-        "@cucumber/gherkin": "^39.1.0",
-        "@cucumber/messages": "^32.3.1",
+        "@cucumber/gherkin": "^40.0.0",
+        "@cucumber/messages": "^33.0.2",
         "@nldd/design-system": "^0.8.62",
         "@tiptap/core": "^3.26.1",
         "@tiptap/starter-kit": "^3.26.1",
@@ -354,23 +354,19 @@
       }
     },
     "node_modules/@cucumber/gherkin": {
-      "version": "39.1.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-39.1.0.tgz",
-      "integrity": "sha512-pqmSO2bUWxJm3TbNrKXlDaHjL6c77+ez9kWmfCd9oRPeTRPEVH3spZvpAqdXYWOZYSNYwWFCAAeZ4RGpkauNoQ==",
+      "version": "40.0.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-40.0.0.tgz",
+      "integrity": "sha512-wMbF0TtNy2ELBJ8nls29eZQWL4XKfuWtMwqDaylUEAiv3qC0/ZAVU0LS2viQ6ZfXe5ROAC38penTOAdrjwYC9Q==",
       "license": "MIT",
       "dependencies": {
-        "@cucumber/messages": ">=31.0.0 <33"
+        "@cucumber/messages": ">=31.0.0 <34"
       }
     },
     "node_modules/@cucumber/messages": {
-      "version": "32.3.1",
-      "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-32.3.1.tgz",
-      "integrity": "sha512-yNQq1KoXRYaEKrWMFmpUQX7TdeQuU9jeGgJAZ3dArTsC/T4NpJ6DnqaJIIgwPnz/wtQIQTNX7/h0rOuF5xY4qQ==",
-      "license": "MIT",
-      "dependencies": {
-        "class-transformer": "0.5.1",
-        "reflect-metadata": "0.2.2"
-      }
+      "version": "33.0.2",
+      "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-33.0.2.tgz",
+      "integrity": "sha512-JxWlW9H7+SCuKBlqpD0Puhy+afXStE3qmMutmvJcdF+BWhl4jvFLexyK77uN0Xs+zLlJ+/B6T49nw4OO5BUZxg==",
+      "license": "MIT"
     },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
@@ -2361,12 +2357,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/class-transformer": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
-      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "license": "MIT"
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3996,12 +3986,6 @@
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
       }
-    },
-    "node_modules/reflect-metadata": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
-      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "license": "Apache-2.0"
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,8 +14,8 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
-    "@cucumber/gherkin": "^39.1.0",
-    "@cucumber/messages": "^32.3.1",
+    "@cucumber/gherkin": "^40.0.0",
+    "@cucumber/messages": "^33.0.2",
     "@nldd/design-system": "^0.8.62",
     "@tiptap/core": "^3.26.1",
     "@tiptap/starter-kit": "^3.26.1",

--- a/frontend/src/shims/node-module.js
+++ b/frontend/src/shims/node-module.js
@@ -1,0 +1,22 @@
+// Browser shim for Node's `node:module`.
+//
+// @cucumber/messages 33 (pure ESM) reads its own version at import time in
+// dist/version.js:
+//
+//   import { createRequire } from 'node:module';
+//   export const version = createRequire(import.meta.url)('../package.json').version;
+//
+// `createRequire` is a Node-only API; in the browser the bundler stubs
+// `node:module` to an empty object, so `createRequire` is undefined and the
+// call throws `TypeError: createRequire is not a function` at module load —
+// crashing every view that imports the gherkin parser (the whole editor).
+//
+// We never use that version string, so provide a minimal `createRequire` whose
+// returned require() yields an object with a `version` field. This alias is
+// applied to the browser build only (see vite.config.js); Node-based vitest
+// keeps the real `node:module`.
+export function createRequire() {
+  return () => ({ version: '0.0.0' });
+}
+
+export default { createRequire };

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,5 +1,16 @@
+import { fileURLToPath, URL } from 'node:url';
 import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
+
+// @cucumber/messages 33 runs `createRequire(import.meta.url)('../package.json')`
+// at import time (a Node-only API). In the browser build that throws and
+// crashes every view importing the gherkin parser, so alias `node:module` to a
+// browser shim that provides a harmless `createRequire`. Scope it to the build
+// only — under vitest (Node) the real `node:module` works, so we leave it.
+const isVitest = !!process.env.VITEST;
+const nodeModuleShim = fileURLToPath(
+  new URL('./src/shims/node-module.js', import.meta.url),
+);
 
 // Backend port the dev proxy forwards /api, /auth and /health to. Defaults to
 // 8000 (editor-api); `just dev-frontend` sets API_PORT so multiple backends can
@@ -34,11 +45,23 @@ export default defineConfig({
       },
     },
   ],
+  resolve: {
+    alias: isVitest ? {} : { 'node:module': nodeModuleShim },
+  },
   test: {
     environment: 'happy-dom',
     include: ['src/**/*.test.js'],
     pool: 'vmThreads',
     testTimeout: 10000,
+    server: {
+      // @cucumber/gherkin 40 and @cucumber/messages 33 ship as pure ESM. The
+      // vmThreads pool loads external ESM in a separate VM context, which throws
+      // "Linked modules must use the same context". Inlining lets vitest process
+      // them in the test context instead.
+      deps: {
+        inline: [/@cucumber\//],
+      },
+    },
   },
   build: {
     cssTarget: ['chrome123', 'edge123', 'firefox120', 'safari18'],


### PR DESCRIPTION
## What

Re-applies the cucumber major bump reverted in #820, this time with the browser-runtime fix:

- `@cucumber/gherkin` 39.1.0 → **40.0.0**
- `@cucumber/messages` 32.3.1 → **33.0.2**

## The bug that took down the editor (and how this fixes it)

`@cucumber/messages` 33 (pure ESM) runs this at **import time** (`dist/version.js`):

```js
import { createRequire } from 'node:module';
export const version = createRequire(import.meta.url)('../package.json').version;
```

`createRequire` is a **Node-only** API. In the browser the bundler stubs `node:module` to an empty object, so the call threw `TypeError: createRequire is not a function` — crashing every view that imports the gherkin parser (`src/gherkin/parser.js`), i.e. the entire editor (blank `/editor/*`). The first attempt (#818) shipped this because the only verification was Node-based vitest, where `createRequire` exists.

**Fix:** alias `node:module` to a tiny browser shim (`src/shims/node-module.js`) that provides a harmless `createRequire` (we don't use the version string). Scoped to the **build only** via `process.env.VITEST`, so Node-based vitest keeps the real module. Also re-adds `test.server.deps.inline: [/@cucumber\//]` for the `vmThreads` pool ("Linked modules must use the same context").

## Verification — in a real browser this time

- `vite build` succeeds; `createRequire` no longer present in any built asset.
- Served the built `dist` via `vite preview` → `/editor` **mounts** (was blank `<!---->`), **zero `createRequire` errors**.
- Dev server + `import('/src/gherkin/parser.js')` → `parseFeature(...)` parses feature name, scenario, and all 4 steps correctly under gherkin 40 / messages 33.
- `npx vitest run src/gherkin/` → 30 pass. `npm audit` → 0 vulnerabilities. markdown-it 14.2.0 override retained.

## Custom config reported (per CLAUDE.md)

No custom CSS. Two build-config additions: the `node:module` resolve alias (browser shim) and the vitest `deps.inline` for `@cucumber/*`. Both are dependency-compat shims, not UI changes.

## Note

Draft — not auto-merging. Given the prior incident, I'd suggest a browser smoke-test on the PR preview deployment before merge.