### PR TITLE
chore: anonymize private corpus repo name in test fixtures

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,17 @@ This repository uses pre-commit hooks for code quality:
 
 **No branding in commits.** Do not add "Generated with Claude Code" or "Co-Authored-By: Claude" lines to commit messages.
 
+### Test Data
+
+**Never use real secret or private information in tests.** This is a public
+repository — anything in a test fixture is published. Do not put names of
+private repositories, internal hostnames, credentials, tokens, real BSNs/personal
+data, or any reference to a private working environment into test fixtures,
+assertions, comments, or sample data. Use clearly-fictional placeholders instead
+(e.g. `example-org/regelrecht-corpus-example`). When a test needs to model a
+private/traject-owned source, anonymize the identifiers — the test should prove
+the behavior, not leak where the real data lives.
+
 ### Git Worktrees
 
 When using git worktrees, create them **inside the project folder** (e.g., `.worktrees/`).

--- a/frontend/src/components/SearchPopover.test.js
+++ b/frontend/src/components/SearchPopover.test.js
@@ -13,8 +13,9 @@ vi.mock('vue-router', () => ({
   useRoute: () => ({ params: {} }),
 }));
 
-// Central corpus (priority 2) listed before the BES repo (priority 0) to prove
-// the grouping order comes from source_priority, not response order.
+// Central corpus (priority 2) listed before the private traject repo
+// (priority 0) to prove the grouping order comes from source_priority, not
+// response order. Source name/law id are anonymized fixtures, not real repos.
 const LAWS = [
   {
     law_id: 'besluit_zorgverzekering',
@@ -23,9 +24,9 @@ const LAWS = [
     source_priority: 2,
   },
   {
-    law_id: 'besluit_zorgverzekering_bes',
+    law_id: 'besluit_zorgverzekering_example',
     source_id: 'traject-own',
-    source_name: 'MinBZK/regelrecht-corpus-BES',
+    source_name: 'example-org/regelrecht-corpus-example',
     source_priority: 0,
   },
 ];
@@ -57,10 +58,10 @@ describe('SearchPopover server-side search', () => {
 
     const groups = wrapper.vm.groupedLaws;
     expect(groups.map((g) => g.source_name)).toEqual([
-      'MinBZK/regelrecht-corpus-BES',
+      'example-org/regelrecht-corpus-example',
       'Centrale Regelrecht Corpus',
     ]);
-    expect(groups[0].laws.map((l) => l.law_id)).toEqual(['besluit_zorgverzekering_bes']);
+    expect(groups[0].laws.map((l) => l.law_id)).toEqual(['besluit_zorgverzekering_example']);
   });
 
   it('queries the backend with the q parameter (not a client-side filter)', async () => {

--- a/packages/corpus/src/source_map.rs
+++ b/packages/corpus/src/source_map.rs
@@ -945,23 +945,23 @@ mod tests {
         // `file_path` is the in-repo path; the source is rooted at
         // `regulation/nl`, so the stored relative_path drops that prefix.
         map.load_metadata_entry(
-            "besluit_zorgverzekering_bes",
-            "regulation/nl/amvb/besluit_zorgverzekering_bes/2024-01-01.yaml",
+            "besluit_zorgverzekering_example",
+            "regulation/nl/amvb/besluit_zorgverzekering_example/2024-01-01.yaml",
             Some("regulation/nl"),
             "traject-own-abc",
-            "MinBZK/regelrecht-corpus-BES",
+            "example-org/regelrecht-corpus-example",
             0,
             Some("blob-sha-1"),
         )
         .unwrap();
 
-        let law = map.get_law("besluit_zorgverzekering_bes").unwrap();
+        let law = map.get_law("besluit_zorgverzekering_example").unwrap();
         assert!(!law.is_loaded(), "metadata-only entry has no body yet");
         assert_eq!(law.yaml_content, "");
         assert_eq!(law.name, None);
         assert_eq!(
             law.relative_path,
-            "amvb/besluit_zorgverzekering_bes/2024-01-01.yaml"
+            "amvb/besluit_zorgverzekering_example/2024-01-01.yaml"
         );
         assert_eq!(law.source_id, "traject-own-abc");
         assert_eq!(law.source_priority, 0);


### PR DESCRIPTION
## What

Replaces the hard-coded name of a private corpus repository (and a derived law id) in two test fixtures with clearly-fictional placeholders:

- `frontend/src/components/SearchPopover.test.js` — `source_name` fixture + assertion
- `packages/corpus/src/source_map.rs` — `load_metadata_entry` test (~line 948)

`MinBZK/regelrecht-corpus-<private>` → `example-org/regelrecht-corpus-example`, and the derived `besluit_zorgverzekering_<private>` law id → `besluit_zorgverzekering_example`.

## Why

This is a public repository, so anything in a test fixture is published. The fixtures referenced a private working environment (introduced in #746). No law content or secrets were involved — only the repo name and a law id — but the reference shouldn't live in the public repo. Flagged by @daanwijnhorst.

Also adds a **Test Data** rule to `CLAUDE.md`: never put secret/private information (private repo names, internal hostnames, credentials, real personal data) in tests; use fictional placeholders.

## Out of scope

This does **not** remove the name from git history (#746). A history rewrite on the public `main` would require a force-push that breaks every existing checkout, so it's deliberately left out.

## Verification

- `regelrecht-corpus` unit test `test_metadata_entry_is_unloaded_with_stripped_path` — passes
- `SearchPopover.test.js` — 5/5 pass