### PR TITLE
docs: add RFC-023 (quantities) and RFC-024 (precision & rounding) for law YAML

### DIFF
--- a/docs/src/content/rfcs/rfc-023.md
+++ b/docs/src/content/rfcs/rfc-023.md
@@ -1,0 +1,270 @@
+---
+title: "RFC-023: Quantities in Law YAML — Money, Percentages, and Dimensioned Values"
+status: Proposed
+implementation: Not implemented
+date: '2026-06-16'
+authors:
+- Tim de Jager
+depends_on:
+- RFC-001 (YAML Schema Design Decisions)
+short_title: Quantities in Law YAML
+---
+
+## Summary
+
+Today a law YAML stores money, ratios and percentages as bare numbers, so `3971900` or
+`0.01896` is indistinguishable from any other number — a factor-of-100 faithfulness risk. This RFC
+makes a value's *quantity-kind* an explicit label.
+
+**Decided (YAML/modeling layer):**
+
+1. Declare quantity-kind with `type` + `type_spec.unit` — on inputs, outputs, parameters **and**
+   `definitions` constants.
+2. Extend the `type_spec.unit` enum with `euro`, `ratio`, `percentage` (alongside existing
+   `eurocent`, `years`, `weeks`, `months`, `days`).
+3. `ratio` and `percentage` are distinct labels; any division by 100 is an explicit value operation,
+   never implied by the label.
+4. A unit is a label, not a computational constraint — tagging a value never changes it.
+5. `definitions` entries may be *optionally* structured to carry `type`/`type_spec`; the bare
+   `naam: 123` form stays valid.
+
+**Out of scope (deferred):** how the engine checks, infers or reconciles units across laws. Rounding
+is RFC-024. See [In practice](#in-practice) for worked YAML.
+
+## Context
+
+The question is narrow — **how does a law YAML say what a number *means*?** — and today it often
+can't. The situations below, all from the current corpus, are what the language must be able to express.
+
+**1. The corpus already encodes quantities, but ambiguously.** `wet_op_de_zorgtoeslag` stores, in one
+`definitions` block, both a money amount and a ratio as bare numbers:
+
+```yaml
+# corpus/regulation/nl/wet/wet_op_de_zorgtoeslag/2025-01-01.yaml (definitions, ~L56)
+drempelinkomen_alleenstaande:
+  value: 3971900        # eurocent — i.e. € 39.719,00. Nothing here says "eurocent".
+percentage_drempelinkomen_alleenstaande:
+  value: 0.01896        # a 0–1 ratio (1,896%). Nothing here says "ratio, not percent".
+```
+
+Guess wrong and you are off by a factor of 100 — in either direction.
+
+**2. The same legal concept is stored in two incompatible ways.** Where zorgtoeslag uses decimal
+ratios, the Diemen `afstemmingsverordening_participatiewet` stores percentages as whole integers — and
+crucially these are **bare, untyped constants** in the schema-free `definitions` block: no `type`, no
+unit, nothing to disambiguate them:
+
+```yaml
+# corpus/regulation/nl/gemeentelijke_verordening/diemen/
+#   afstemmingsverordening_participatiewet/2015-01-01.yaml (definitions, ~L69)
+definitions:                 # schema-free: `{ "type": "object", "additionalProperties": true }`
+  PERCENTAGE_CATEGORIE_1:
+    value: 5                 # 5 percent — a bare integer, no type, no unit
+  PERCENTAGE_CATEGORIE_2:
+    value: 30                # 30 percent — indistinguishable from a raw multiplier 30
+```
+
+There is no way today to tell "30 percent" from "raw multiplier 30." The `type: number` declarations
+that *do* appear elsewhere in this file sit on `parameters` and `input`/`output` fields — never on
+these constants, which by construction cannot carry a type (see situation 5).
+
+**3. Quantities cross law boundaries.** A consuming law pulls another law's output via
+`source.regulation` + `output` — e.g. zorgtoeslag consumes `toetsingsinkomen` from the AWIR
+(`algemene_wet_inkomensafhankelijke_regelingen`). Both ends are already labeled today: the AWIR output
+and the zorgtoeslag input each declare `type: amount` + `type_spec.unit: eurocent`. So the YAML can already
+*express* this; what is missing is *checking* that producer and consumer agree — an engine concern
+(see Implementation Notes), not a gap in the language.
+
+**4. Money is routinely sub-cent.** The corpus is social-domain today, but fiscal law is coming, and it
+is dense with sub-cent amounts — reached two different ways:
+
+- **A scaled base unit.** Excise duty (*accijns*) is denominated **per 1.000 liter** at two decimals —
+  e.g. € 844,69 / 1.000 L (enacted 2026). The printed figure is tidy, but the per-liter value it
+  implies is € 0,84469 = 84,469 eurocent per liter, *not* a whole number of cents.
+- **A tariff printed directly at sub-cent precision.** Energy tax (*energiebelasting*, first bracket
+  electricity) is € 0,09161 / kWh (2026, excl. VAT) — a five-decimal per-kWh rate set straight in the
+  legislation, no scaling trick involved.
+
+Different mechanisms, same modeling consequence: a money value is not always a whole number of cents.
+
+This forces a principle the rest of this RFC relies on: **a unit is a label, not a computational
+constraint.** The arithmetic and the literal values determine the sum, so tagging a value never
+changes it by itself. The one way a `unit: eurocent` tag *could* corrupt a correct sum is by
+triggering implicit rounding — which is why labeling and rounding are kept strictly separate (rounding
+lives in [RFC-024](/rfcs/rfc-024)).
+
+**5. The place where misreading originates cannot carry a label at all.** The `definitions` block — the
+home of every constant in points 1–2 — is schema-free: in the schema it is
+`{ "type": "object", "additionalProperties": true }`. Inputs and outputs can carry `type` /
+`type_spec`; constants cannot. That is precisely backwards, because constants are raw magic numbers
+with no surrounding context to disambiguate them.
+
+## Decision
+
+A value's *quantity-kind* becomes a first-class, explicit label in the law representation. The table
+maps each situation above to the YAML expressiveness it requires and the modeling primitive that
+provides it.
+
+| # | Situation in legislation (grounded) | What the YAML must express | Modeling primitive (YAML layer) |
+|---|---|---|---|
+| 1 | Money in whole cents (zorgtoeslag `3971900`) | "this is money, denominated in eurocent" | `type: amount` + `type_spec.unit: eurocent` (exists) |
+| 2 | Sub-cent tariffs (accijns, energiebelasting) | "this money value is not a whole number of cents; the label must not force whole cents" | a money label usable without implying integer cents (`euro` / `eurocent`), paired with `type_spec.precision` (in the schema; issue #444) to state decimal places. Rounding is out of scope — see RFC-024 |
+| 3 | Percentage stored as ratio (`0.01896`, `0.137`) | "this is a 0–1 ratio, not a 0–100 percent, not a bare multiplier" | `type_spec.unit: ratio` |
+| 4 | Percentage stored as whole percent (`5`, `30`) | "this is a 0–100 percent" | `type_spec.unit: percentage` |
+| 5 | Constants in `definitions` carry no type | "a constant can declare its quantity-kind" | make `definitions` entries *optionally* structured so a constant carries `type` + `type_spec`; the bare `naam: 123` form stays valid |
+
+(Durations and cross-law unit flow are *already* expressible with existing vocabulary and are not
+decisions of this RFC — see [Already expressible](#already-expressible) below.)
+
+Concretely, this RFC decides, at the YAML/modeling layer:
+
+1. **Quantity-kind is an explicit, first-class label**, declared with `type` + `type_spec.unit`,
+   available on inputs, outputs, parameters, **and definitions/constants** — closing the schema-free
+   `definitions` gap (situation 5).
+2. **Extend the `type_spec.unit` enum** with `euro`, `ratio`, and `percentage`, alongside the
+   existing `eurocent`, `years`, `weeks`, `months`, `days`. Adding `euro` does **not** deprecate
+   `eurocent`; both are valid money labels and the choice is the modeler's, reflecting how the law
+   denominates the value (cf. accijns per 1.000 L).
+3. **`ratio` and `percentage` are distinct labels for the same dimension**, and the corpus keeps both.
+   We do not force a single canonical form, because some texts state "1,896" as a ratio and others
+   state "30 procent" literally. Whether a `percentage` is divided by 100 is a *value* concern,
+   expressed by an explicit `DIVIDE … 100` in the YAML where the value is *applied* — never something
+   the label silently performs. The corpus already works this way, and across a law boundary: the
+   Diemen `afstemmingsverordening_participatiewet` stores the verlagingspercentages as whole percents
+   (`5`, `30`) and uses them directly in its `IF` cases, while the national `participatiewet` that
+   consumes that `verlaging_percentage` (via the art. 8 open term) performs the
+   `… * verlaging_percentage / 100` at the point of application (`participatiewet/2022-03-15.yaml:432`).
+4. **A unit is a label, not a computational constraint.** As a normative rule: tagging a value with a
+   unit must never, by itself, change its numeric value (no implicit rounding or scaling). This is the
+   deliberate repudiation of coupling a unit to a coercion (e.g. `unit: eurocent → round_to_integer`,
+   proposed in [RFC-015](/rfcs/rfc-015)); where rounding belongs is decided in
+   [RFC-024](/rfcs/rfc-024).
+5. **`definitions` entries become optionally structured.** The bare form `naam: 123` remains valid
+   (backward-compatible); the structured form lets a constant carry `type` and `type_spec`, reusing
+   the existing field shape so there is one way to describe a quantity everywhere.
+
+This RFC does not decide how the engine *checks*, *infers*, or *reconciles* units — only what the YAML
+may *say*. See Implementation Notes.
+
+### In practice
+
+The zorgtoeslag constants and a cross-law input, labeled per this RFC (compare the bare forms in
+Context situations 1–2):
+
+```yaml
+definitions:
+  # money constant — was a bare `3971900`
+  drempelinkomen_alleenstaande:
+    value: 3971900
+    type: amount
+    type_spec:
+      unit: eurocent
+  # a 0–1 ratio, explicitly not a percentage
+  percentage_drempelinkomen_alleenstaande:
+    value: 0.01896
+    type: number
+    type_spec:
+      unit: ratio
+  # a whole percent; the /100 happens where it is applied, never via the label
+  PERCENTAGE_CATEGORIE_2:
+    value: 30
+    type: number
+    type_spec:
+      unit: percentage
+
+input:
+  # an input states the unit it expects to receive from another law
+  - name: toetsingsinkomen
+    type: amount
+    source:
+      regulation: algemene_wet_inkomensafhankelijke_regelingen
+      output: toetsingsinkomen
+    type_spec:
+      unit: eurocent
+```
+
+The bare `naam: 123` form stays valid, so labeling is incremental — a constant is upgraded only when
+someone annotates it.
+
+### Already expressible
+
+Two situations the corpus raises are **already** covered by existing modeling vocabulary. They are not
+decisions of this RFC; they are recorded here so authors model them with the existing primitive instead
+of reaching for a bare `type: number`:
+
+- **Durations.** A value meant as months / years / days is modeled with the existing time units
+  `years`, `weeks`, `months`, `days` (RFC-001), not a bare `type: number`. No new unit is required.
+- **Cross-law unit flow.** The consuming `source` input already declares its expected
+  `type_spec.unit`, and producing laws label their outputs too (Context situation 3 — zorgtoeslag's
+  `toetsingsinkomen` and the AWIR output both carry `unit: eurocent`). Reconciling a producer/consumer
+  *mismatch* is an engine concern (see Implementation Notes), not a YAML-layer addition.
+
+## Why
+
+### Benefits
+
+- A labeled value states its quantity-kind explicitly, removing the factor-of-100 ambiguity at the
+  source. The label is not self-enforcing — at the YAML layer it is inert until a consumer acts on it
+  (engine unit-checks are deferred, see Implementation Notes) — but a reader, human or tool, no longer
+  has to *guess* whether `3971900` is euros or cents.
+- The label is consumed by more than the engine: the editor renders the correct input control from a
+  value's `type`/`type_spec` (a boolean switch, a euro field) — see PR #748 — so a single YAML-layer
+  decision pays off across the engine, the editor UI, and scenario inputs.
+- Cross-law flows become checkable once the engine reconciles units (deferred): the consuming law
+  states the unit it expects to receive.
+- It closes the `definitions` blind spot, where the factor-of-100 ambiguity actually originates.
+- It is opt-in and backward-compatible: bare constants and unlabeled values keep working, so adoption
+  is gradual and no corpus-wide rewrite is forced.
+
+### Tradeoffs
+
+- Opt-in labeling means un-annotated laws stay ambiguous until someone annotates them. Acceptable: the
+  alternative (mandatory labels) would force a corpus-wide rewrite and block on it.
+- Keeping both `ratio` and `percentage` preserves a known representational inconsistency. We accept it
+  deliberately: collapsing to one canonical form would distort faithful transcription of laws that
+  literally say "30 procent" versus those that state a ratio.
+
+### Alternatives Considered
+
+**Alternative 1: a single canonical percentage form (ratio only).**
+Force every percentage to a 0–1 ratio. Rejected: it distorts faithful modeling — a law that says "30
+procent" should be transcribable as `30` with a `percentage` label, not silently rewritten to `0.30`.
+
+**Alternative 2: drop `eurocent`, use `euro` floats everywhere.**
+Rejected: much of the corpus and Belastingdienst convention is cent-denominated, and forcing euro
+floats invites the very precision loss this work is trying to prevent.
+
+**Alternative 3: bundle rounding into the unit (the RFC-015 coercion).**
+Let `unit: eurocent` imply round-to-integer. Rejected: empirically false for sub-cent tariffs
+(accijns, energiebelasting), and it hides a legal decision inside a unit label. Rounding must be a
+law-modeled instruction — see RFC-024.
+
+**Alternative 4: leave `definitions` schema-free and rely on naming conventions.**
+Rejected: that is the status quo that produces the factor-of-100 ambiguity in situations 1–2.
+
+### Implementation Notes
+
+This RFC is intentionally silent on the engine. The unit *algebra* (which unit pairs are valid under
+each operation), unit *inference* over expression trees, the static-validation and runtime mismatch
+checks, the error type for a mismatch, and cross-law unit *reconciliation* are engine concerns,
+specified and implemented separately. A prototype of that engine machinery already exists in PR #729
+(*units of measurement on values*), which originally drafted itself as "RFC-019" — a number since
+assigned on `main` to an unrelated RFC (Law End Dates). This RFC **supersedes the modeling decisions**
+in that draft, reframed situation-first; the Rust code in PR #729 can serve as the implementation of
+this RFC's deferred engine track. The only concrete artifact this RFC implies is a future schema
+version that adds the `euro`/`ratio`/`percentage` units and the optional structured
+`definitions` form (schema versions are immutable; the current version is v0.5.3).
+
+## References
+
+- [RFC-001: YAML Schema Design Decisions](/rfcs/rfc-001) — the type system, `type_spec` and unit enum
+  this RFC extends (the `type_spec.precision` field lives in the schema; see issue #444)
+- [RFC-012: Untranslatables](/rfcs/rfc-012) — the "grow the vocabulary only when real legal texts
+  demand it" philosophy this RFC follows
+- [RFC-015: Engine Policy](/rfcs/rfc-015) — the `unit: eurocent → round_to_integer` coercion this RFC
+  declines to adopt at the label level
+- [RFC-024: Precision and Rounding in Law YAML](/rfcs/rfc-024) — where rounding is modeled
+- PR #729 — prototype units-of-measurement engine machinery (the deferred implementation track)
+- PR #748 — editor scenario inputs rendered from `type`/`type_spec` (a non-engine consumer)
+- Issue #444 — `type_spec.precision`/`min`/`max` parsed but not enforced
+- [Glossary of Dutch Legal Terms](/reference/glossary)

--- a/docs/src/content/rfcs/rfc-024.md
+++ b/docs/src/content/rfcs/rfc-024.md
@@ -1,0 +1,246 @@
+---
+title: "RFC-024: Precision and Rounding in Law YAML — Modeling Statutory Rounding"
+status: Proposed
+implementation: Not implemented
+date: '2026-06-16'
+authors:
+- Tim de Jager
+depends_on:
+- RFC-001 (YAML Schema Design Decisions)
+- RFC-004 (Uniform Operation Syntax)
+- RFC-012 (Untranslatables)
+- RFC-023 (Quantities in Law YAML)
+short_title: Precision & Rounding
+---
+
+## Context
+
+This RFC answers a modeling question: **how does a law YAML express the rounding and precision that
+the law text prescribes?** As with [RFC-023](/rfcs/rfc-023), the starting point is the legislative
+situation, not the engine. The catalog is drawn from the current corpus.
+
+**1. Rounding is written in the law text, and we currently cannot execute it.** The AWIR says *"Het
+bedrag van de tegemoetkoming wordt rekenkundig afgerond op hele euro's"*
+(`algemene_wet_inkomensafhankelijke_regelingen/2025-01-01.yaml:298`); the Zorgverzekeringswet says
+*"Het op grond van het eerste of tweede lid berekende bedrag wordt afgerond op hele euro's"*
+(`zorgverzekeringswet/2025-01-01.yaml:537`). Neither is executed. The clearest case is
+`test_untranslatables/2025-01-01.yaml`, where *"naar boven afgerond op hele euro's"* sits as an
+**unaccepted untranslatable**:
+
+```yaml
+# test_untranslatables/2025-01-01.yaml:34
+- construct: afronden op hele euro's
+  reason: Rounding is not available as an engine operation
+  legal_text_excerpt: Het bedrag wordt naar boven afgerond op hele euro's
+  accepted: false
+```
+
+[RFC-012](/rfcs/rfc-012) names rounding as *the* canonical untranslatable and suggests adding a
+rounding operation. This RFC is the situation-first mechanism that resolves it — in keeping with
+RFC-012's own rule that the vocabulary grows only when real legal texts demand it.
+
+**2. Rounding has both a direction and a target.** Directions seen in or expected from Dutch law:
+*rekenkundig* (half-up), *naar boven* (ceil), *naar beneden* / *afkapping* (floor / truncate).
+Targets: whole euro, whole cent, or a number of decimals. "Round to whole euros, half-up" and "round
+up to whole euros" are different instructions and must be distinguishable.
+
+**3. Thresholds and caps are rounding-adjacent and under-modeled.** The AWIR continues: *"Een
+tegemoetkoming wordt niet toegekend indien deze minder dan € 24 zou bedragen"* (`:299`) — a
+below-threshold-to-nothing rule that is not modeled today. Zero-floors (`MAX(0, …)` in zorgtoeslag)
+and wealth caps (vermogensgrens, via `LESS_THAN_OR_EQUAL`) *are* modeled with existing operations.
+
+**4. Intermediate precision matters, and intermediate values must not be rounded.** The
+Zorgverzekeringswet computes a day-based pro-rata fraction — *"vermenigvuldigd met een breuk waarvan de
+teller gelijk is aan het aantal dagen … en de noemer aan het aantal dagen in het … kalenderjaar"*
+(`:522`) — and only *then* rounds the result to whole euros (`:537`). Two distinct rules apply, from two
+distinct sources (researched in issue #299): **intermediate calculations are not rounded** — standing
+Belastingdienst/Toeslagen administrative policy, not a court ruling — and **rekenkundig (half-up) is the
+default rounding method unless a law says otherwise** — established by the Hoge Raad (HR 15 May 2009,
+ECLI:NL:HR:2009:BI1980, itself a VAT case). Double-rounding an intermediate value shifts a legally
+binding amount.
+
+**5. The engine currently rounds money implicitly, which is the wrong place for the decision.** Today
+the engine rounds eurocent outputs at the result boundary regardless of what the law says, and
+[RFC-015](/rfcs/rfc-015) proposes formalizing that as a `unit: eurocent → round_to_integer` coercion.
+But "currency must be whole cents" is empirically false (sub-cent accijns and energiebelasting tariffs
+— see RFC-023 §Context). **The law, not a unit-coercion policy, must decide whether and how a value is
+rounded.** This RFC supplies the law-level vocabulary that lets that implicit engine behavior become
+law-controlled (issue #304).
+
+## Decision
+
+Rounding becomes an explicit, modeled legal instruction. The table maps each situation to the YAML
+expressiveness it requires and the primitive that provides it.
+
+| # | Situation in legislation (grounded) | What the YAML must express | Modeling primitive |
+|---|---|---|---|
+| 1 | "rekenkundig afgerond op hele euro's" (AWIR, zvw) | round to nearest, half-up, at a named point | `ROUND` + `precision` (half-up is its default) |
+| 2 | "naar boven afgerond op hele euro's" (the open untranslatable) | round up | `CEIL` + `precision` — flips the `accepted: false` entry to expressible |
+| 3 | "naar beneden" / "afkapping" | round down / truncate toward zero | `FLOOR` resp. `TRUNCATE` + `precision` (they differ for negatives) |
+| 4 | Round to whole *cent* / to N decimals (sub-cent tariffs, e.g. 5 dp) | the granularity to round to | the `precision` field (decimal places) on any of these operations |
+| 5 | Pro-rata fraction then round (zvw art. 21) | full precision through the intermediate `DIVIDE`; round only at the named step | principle: **no implicit intermediate rounding** |
+
+(Below-threshold-to-nothing and zero-floor/cap need no new operation — they are existing patterns, see
+[Already expressible](#already-expressible) below. Banker's rounding / half-even is not in scope — see
+decision 2.)
+
+Concretely, this RFC decides, at the YAML/modeling layer:
+
+1. **Rounding is an explicit, modeled legal instruction — never an implicit side effect of a type or
+   unit.** This is the direct counter to the current boundary rounding and to RFC-015's unit coercion.
+2. **Introduce four distinct rounding operations** — `ROUND` (round to nearest), `CEIL` (round up),
+   `FLOOR` (round down), and `TRUNCATE` (round toward zero). Each is a **unary** operation: one operand
+   in `value:` (mirroring the unary `NOT`), plus a **`precision`** — the number of decimal places to
+   round to, in the value's own unit (RFC-023). `precision` is a field **on the operation itself**,
+   deliberately *not* read implicitly from the operand's `type_spec`, so the rounding instruction is
+   always visible where it applies. `precision: 0` rounds to whole units, `precision: 5` to five
+   decimals; rounding to whole euros is `precision: 0` on a euro-denominated value (and `precision: -2`
+   on one held in eurocent). This is the abstract granularity knob — no money-specific "whole euro"
+   keyword in the language.
+
+   Distinct functions get distinct names, consistent with RFC-004's `ADD`/`SUBTRACT` and `MIN`/`MAX`
+   and its stated philosophy that *"the operation name describes what happens."* `CEIL`, `FLOOR`,
+   `TRUNCATE` and round-to-nearest are genuinely different functions, not modes of one — so they are
+   not collapsed into a single `mode`-parametrised operation (see Alternatives Considered).
+
+   `ROUND` is round-to-nearest with **half-up** as its default tie-break (the HR-2009 default). A
+   different tie-break — banker's rounding / **half-even** — is *not* part of this RFC: no corpus text
+   demands it yet, so per RFC-012 it is left to a future optional `tie:` field on `ROUND` alone
+   (`CEIL`/`FLOOR`/`TRUNCATE` have no tie-break). [RFC-014](/rfcs/rfc-014) already anticipates rounding
+   joining the Core conformance level "when added."
+
+   Worked example — the AWIR's *"rekenkundig afgerond op hele euro's"* (`:298`), rounding the
+   full-precision result of an earlier `SUBTRACT` only at the named step:
+
+   ```yaml
+   - output: tegemoetkoming
+     value:
+       operation: ROUND        # round to nearest, half-up (the default)
+       precision: 0            # to whole units of the value's own unit (RFC-023)
+       value:                  # operand: the full-precision amount to round
+         operation: SUBTRACT
+         values:
+           - $normbedrag
+           - $eigen_bijdrage
+   ```
+
+   The open untranslatable *"naar boven afgerond op hele euro's"* (situation 2) is then a `CEIL`:
+
+   ```yaml
+   operation: CEIL
+   precision: 0               # naar boven, op hele eenheden
+   value: $berekend_bedrag
+   ```
+
+   And rounding to a number of decimals is just a non-zero `precision` — here an energiebelasting line
+   rounded half-up to whole cents (two decimals of a euro), or to five decimals for a sub-cent tariff:
+
+   ```yaml
+   operation: ROUND
+   precision: 2               # to whole cents (use precision: 5 for a sub-cent tariff)
+   value:
+     operation: MULTIPLY
+     values:
+       - $verbruik_kwh
+       - $tarief_per_kwh
+   ```
+
+3. **Half-up (rekenkundig) is `ROUND`'s documented default tie-break** (per the Hoge Raad's 2009 VAT
+   ruling; issue #299) — but rounding is **never applied implicitly**. A law that rounds must say so
+   with an explicit rounding operation. Where the law is silent, no rounding occurs (matching the
+   "don't round intermediates" policy).
+4. **Intermediate values carry full precision.** As a normative rule: nothing rounds a value between
+   steps; only an explicit rounding operation changes precision. (Grounded in zvw art. 21 and issue
+   #299.)
+5. **This resolves the rounding untranslatable.** Once these rounding operations exist, the
+   `test_untranslatables` "naar boven afgerond" entry (a `CEIL`) flips from `accepted: false` to
+   expressible — the concrete legal text that, per RFC-012, justifies growing the vocabulary.
+
+This RFC does not specify the rounding *algorithm* or its edge cases — only the modeling vocabulary and
+the legal-default policy. See Implementation Notes.
+
+### Already expressible
+
+These rounding-adjacent situations need **no new operation** — existing RFC-004 operations already
+cover them. They are not decisions of this RFC; they are recorded as patterns (with a worked example)
+so authors model them instead of leaving them implicit:
+
+- **Below-threshold-to-nothing.** *"niet toegekend indien minder dan € 24"* (AWIR `:299`) is an `IF`
+  with a `LESS_THAN` comparison. The AWIR € 24 floor is the worked example authors should follow.
+- **Zero-floor / cap.** Clamping to a minimum or maximum (`MAX(0, …)`, the vermogensgrens cap) uses
+  the existing `MIN` / `MAX` operations — no rounding primitive involved.
+
+## Why
+
+### Benefits
+
+- Rounding the law mandates becomes faithfully executable instead of silently dropped or marked
+  untranslatable.
+- Removes the canonical untranslatable and gives RFC-012's reverse-validate heuristic ("arithmetic
+  chains that approximate rounding") a real primitive to point authors toward.
+- Makes the currently-hardcoded money rounding law-controlled, so a law that needs sub-cent precision
+  (accijns) and one that rounds to whole euros (AWIR) can both be modeled truthfully.
+- The no-implicit-intermediate-rounding rule prevents systematic under-/over-payment from
+  double-rounding.
+
+### Tradeoffs
+
+- It grows the operation vocabulary, against the project's minimalism instinct. But RFC-012's own rule
+  sanctions growth when real texts demand it, and the corpus demands it (AWIR, zvw,
+  test_untranslatables).
+- Modelers must now *think about* rounding explicitly rather than relying on a silent default. That is
+  the point: the law's rounding becomes visible and auditable.
+
+### Alternatives Considered
+
+**Alternative 1: keep rounding as an untranslatable.**
+Rejected: rounding is pervasive and statutorily explicit; perpetual untranslatability blocks faithful
+execution of the most common money operation in the corpus.
+
+**Alternative 2: rounding via the unit-coercion policy (RFC-015) or the engine's boundary rounding.**
+Rejected: empirically wrong for sub-cent tariffs, and it hides a legal decision in engine
+configuration. The law text must control rounding.
+
+**Alternative 3: a single `ROUND` operation with a `mode` field** (`mode: half_up|ceil|floor|truncate`).
+Tempting, because the rounding direction becomes one comparable field and new variants slot in without
+new operations. Rejected: `ceil`, `floor`, `truncate` and round-to-nearest are genuinely *different
+functions*, not spellings of one — and RFC-004 already names different functions distinctly
+(`ADD`/`SUBTRACT`, `MIN`/`MAX`), with the stated philosophy that *"the operation name describes what
+happens."* A single `mode`-parametrised `ROUND` would be the only such special case in the vocabulary.
+(The IF/SWITCH unification is **not** a precedent here: those were two syntaxes of one control-flow
+operation, whereas the rounding directions are distinct functions. RFC-004 is also not a flat enum —
+it groups operations by purpose with distinct operand fields, so "matching the enum" argues nothing.)
+Keeping the operations distinct also keeps each schema trivial: only `ROUND` ever needs a tie-break
+field; `CEIL`/`FLOOR`/`TRUNCATE` need none.
+
+**Alternative 4: only round-to-nearest (`ROUND`), no `CEIL`/`FLOOR`/`TRUNCATE`.**
+Rejected: the corpus already needs ceil ("naar boven") and will need floor/truncate ("afkapping").
+
+**Alternative 5: encode rounding with arithmetic tricks (e.g. `FLOOR(x + 0.5)` via existing ops).**
+Rejected: RFC-012 explicitly flags "arithmetic chains that approximate rounding" as a workaround to be
+caught in review. An explicit primitive is auditable and self-documenting.
+
+### Implementation Notes
+
+This RFC is silent on engine internals. The rounding *algorithm*, the float-versus-decimal
+representation question, half-even tie-breaking, the floor-versus-truncate behavior for negative
+numbers, division-by-zero in pro-rata fractions, and the **removal or replacement of the engine's
+current boundary rounding** are engine concerns specified elsewhere: the conformance hooks in
+[RFC-014](/rfcs/rfc-014), the engine-policy track in [RFC-015](/rfcs/rfc-015), and the open PR #791
+(which moves boundary rounding to a once-only, precision-driven step). This RFC decides the modeling
+vocabulary and the legal-default policy; the engine track decides the computation.
+
+## References
+
+- [RFC-004: Uniform Operation Syntax](/rfcs/rfc-004) — the operation vocabulary `ROUND`/`CEIL`/`FLOOR`/`TRUNCATE` join
+- [RFC-012: Untranslatables](/rfcs/rfc-012) — the rounding untranslatable this RFC resolves
+- [RFC-023: Quantities in Law YAML](/rfcs/rfc-023) — the unit a rounded value's `precision` is relative to
+- [RFC-014: Engine Conformance Test Suite](/rfcs/rfc-014) — where rounding ops join the Core level
+- [RFC-015: Engine Policy](/rfcs/rfc-015) — the engine-policy rounding track this RFC constrains
+- [RFC-001: YAML Schema Design Decisions](/rfcs/rfc-001) — the type system and `type_spec` (the
+  `type_spec.precision` field a rounding result targets lives in the schema; see issue #444)
+- Issue #299 — research on rounding rules (Hoge Raad half-up default; don't round intermediates)
+- Issue #304 — "engine hardcodes eurocent rounding — should be law-controlled"
+- Issue #444 — `type_spec.precision` parsed but not enforced
+- PR #791 — engine boundary-rounding track
+- [Glossary of Dutch Legal Terms](/reference/glossary)


### PR DESCRIPTION
## Context

A discussion around PR #791 (the engine rounds eurocents "at the result boundary") surfaced a deeper
gap: there is **no situation-first specification of how our law YAML models quantities, precision, and
rounding.** Today rounding prescribed by law text is an untranslatable (RFC-012), `type_spec.precision`
is parsed but unenforced (#444), the engine rounds money implicitly, and the "currency is whole cents"
assumption is empirically false (excise/energy tariffs are routinely sub-cent). A prior attempt at
units (PR #729) was too engine-focused.

These two RFCs specify the **YAML / law-modeling layer**, organized first and foremost around *which
situations exist in legislation and what the YAML must express to model them*. Engine implementation is
explicitly deferred to a later, separate step (a future schema version + engine work).

## What's here

- **RFC-023 — Quantities in Law YAML** (`depends_on: RFC-001`)
  Labels *what a number means*: money (`euro`/`eurocent`), and `ratio` vs `percentage`; plus
  optionally-structured `definitions` so constants can carry a `type`/`type_spec`. Core principle:
  **a unit is a label, not a computational constraint** (tagging a value never changes it). Supersedes
  the units-of-measurement design drafted in PR #729 (whose Rust code can serve as the deferred engine
  track).

- **RFC-024 — Precision and Rounding in Law YAML** (`depends_on: RFC-001, RFC-004, RFC-012, RFC-023`)
  Four distinct rounding operations — `ROUND` / `CEIL` / `FLOOR` / `TRUNCATE` — each unary with a
  numeric `precision` (decimal places, in the value's own unit; no money-specific keyword). Distinct
  functions get distinct names, consistent with RFC-004's `ADD`/`SUBTRACT` and `MIN`/`MAX`.
  **Rounding is an explicit legal instruction, never implicit from a type/unit; intermediate values
  carry full precision; half-up is `ROUND`'s documented default tie-break but never auto-applied.**
  `half_even` is deferred (no corpus text yet). Resolves the canonical rounding untranslatable (RFC-012).

Each RFC opens with a decision-first **Summary**, then a `situation -> required YAML expressiveness ->
modeling primitive` table grounded in real corpus law (zorgtoeslag, AWIR, zorgverzekeringswet,
participatiewet, test_untranslatables), worked YAML examples, and an *Already expressible* section for
cases that need no new primitive.

## Scope

Docs only. No schema or engine changes here — the RFCs *describe* the intended direction and defer the
unit algebra, enforcement, and rounding algorithm (and the removal of the current boundary rounding) to
a separate follow-up PR (schema v0.5.4 + engine). Verified locally: the docs RFC discovery parses both
files; all internal cross-links resolve; frontmatter matches `template.md`.

## Note

Renumbered from RFC-022/023 to **RFC-023/024** and rebased onto latest `main` — `main` now uses RFC-022
for Anne Schuth's Chronolexogram RFC.
