### PR TITLE
chore: gitignore browser automation screenshots/snapshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,11 @@
 # Git worktrees
 .worktrees/
 
+# Browser automation artifacts (Playwright MCP / e2e smoke screenshots).
+# The MCP server writes snapshots/screenshots here; keep them out of git.
+.playwright-mcp/
+.screenshots/
+
 # Frontend
 node_modules/
 frontend/dist/


### PR DESCRIPTION
## What

Adds two directories to `.gitignore` so Playwright MCP / e2e smoke artifacts stop showing up as untracked noise:

```
.playwright-mcp/   # aria snapshots the MCP server auto-writes
.screenshots/      # screenshots (new dedicated output dir)
```

## Why

The Playwright MCP server was dropping screenshots loose in the repo root and ~400 aria snapshots in `.playwright-mcp/`. To make this reliable, the MCP server is now pointed at a dedicated `.screenshots/` output dir (local Claude config change, not in-repo), and both dirs are ignored here.

No blanket `*.png`/`*.jpeg` patterns — only the dedicated artifact dirs, so real images under `docs/`, `frontend/`, etc. are unaffected.