### PR TITLE
chore(deps): upgrade @nldd/design-system naar 0.8.60 + loading-state adoptie

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@astrojs/mdx": "^6",
-        "@nldd/design-system": "^0.8.54",
+        "@nldd/design-system": "^0.8.60",
         "astro": "^6.4.7",
         "astro-pagefind": "^2.0.0",
         "rehype-mermaid": "^3",
@@ -1331,9 +1331,9 @@
       }
     },
     "node_modules/@nldd/design-system": {
-      "version": "0.8.56",
-      "resolved": "https://registry.npmjs.org/@nldd/design-system/-/design-system-0.8.56.tgz",
-      "integrity": "sha512-NDx2+I4jN+B5dR6mUayQQHmR0FhhXDloMom2Z59NO5KcPitrxXGopFYP4X4Vy/aLlL3EB1qwwm3fSzGeWwwRUw==",
+      "version": "0.8.60",
+      "resolved": "https://registry.npmjs.org/@nldd/design-system/-/design-system-0.8.60.tgz",
+      "integrity": "sha512-ckQ+KzVYrKLM+745HQ4HIGalNhqmwXuUR9uWOVbRB+FXvHQqntCB4StLXTsCB4GaOWGP0L8mEaUtmDx6TlHZPQ==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@floating-ui/dom": "^1.7.6",

--- a/docs/package.json
+++ b/docs/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@astrojs/mdx": "^6",
-    "@nldd/design-system": "^0.8.54",
+    "@nldd/design-system": "^0.8.60",
     "astro": "^6.4.7",
     "astro-pagefind": "^2.0.0",
     "rehype-mermaid": "^3",

--- a/frontend-lawmaking/package-lock.json
+++ b/frontend-lawmaking/package-lock.json
@@ -8,7 +8,7 @@
       "name": "regelrecht-frontend-lawmaking",
       "version": "1.0.0",
       "dependencies": {
-        "@nldd/design-system": "^0.8.56",
+        "@nldd/design-system": "^0.8.60",
         "vue": "^3.5.38"
       },
       "devDependencies": {
@@ -171,9 +171,9 @@
       }
     },
     "node_modules/@nldd/design-system": {
-      "version": "0.8.56",
-      "resolved": "https://registry.npmjs.org/@nldd/design-system/-/design-system-0.8.56.tgz",
-      "integrity": "sha512-NDx2+I4jN+B5dR6mUayQQHmR0FhhXDloMom2Z59NO5KcPitrxXGopFYP4X4Vy/aLlL3EB1qwwm3fSzGeWwwRUw==",
+      "version": "0.8.60",
+      "resolved": "https://registry.npmjs.org/@nldd/design-system/-/design-system-0.8.60.tgz",
+      "integrity": "sha512-ckQ+KzVYrKLM+745HQ4HIGalNhqmwXuUR9uWOVbRB+FXvHQqntCB4StLXTsCB4GaOWGP0L8mEaUtmDx6TlHZPQ==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@floating-ui/dom": "^1.7.6",

--- a/frontend-lawmaking/package.json
+++ b/frontend-lawmaking/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@nldd/design-system": "^0.8.56",
+    "@nldd/design-system": "^0.8.60",
     "vue": "^3.5.38"
   },
   "devDependencies": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@cucumber/gherkin": "^39.1.0",
         "@cucumber/messages": "^32.3.1",
-        "@nldd/design-system": "^0.8.53",
+        "@nldd/design-system": "^0.8.60",
         "@tiptap/core": "^3.26.1",
         "@tiptap/starter-kit": "^3.26.1",
         "@tiptap/vue-3": "^3.26.1",
@@ -560,9 +560,9 @@
       }
     },
     "node_modules/@nldd/design-system": {
-      "version": "0.8.53",
-      "resolved": "https://registry.npmjs.org/@nldd/design-system/-/design-system-0.8.53.tgz",
-      "integrity": "sha512-jxBrkl2WqcLps70jgOBB9d5ZohxpGLRTTSTld0cLpC6tNJqsYXlIy/oN45e0Ta7CGF0HAcSMVImSEsJxuag26w==",
+      "version": "0.8.60",
+      "resolved": "https://registry.npmjs.org/@nldd/design-system/-/design-system-0.8.60.tgz",
+      "integrity": "sha512-ckQ+KzVYrKLM+745HQ4HIGalNhqmwXuUR9uWOVbRB+FXvHQqntCB4StLXTsCB4GaOWGP0L8mEaUtmDx6TlHZPQ==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@floating-ui/dom": "^1.7.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@cucumber/gherkin": "^39.1.0",
     "@cucumber/messages": "^32.3.1",
-    "@nldd/design-system": "^0.8.53",
+    "@nldd/design-system": "^0.8.60",
     "@tiptap/core": "^3.26.1",
     "@tiptap/starter-kit": "^3.26.1",
     "@tiptap/vue-3": "^3.26.1",

--- a/frontend/src/AppShell.vue
+++ b/frontend/src/AppShell.vue
@@ -222,7 +222,7 @@ const { lastSavedPr, documentTabs, activeDocumentTab, tabActions } = useAppChrom
         <nldd-container padding="8">
           <nldd-toolbar size="md">
             <nldd-toolbar-item slot="start">
-              <nldd-tab-bar variant="compact" navigation>
+              <nldd-tab-bar size="lg" navigation>
                 <nldd-tab-bar-item :selected="isLibraryRoute || undefined" :href="isLibraryRoute ? undefined : libraryTabHref" @click.prevent="isLibraryRoute || router.push(libraryTabTarget)" icon="books" text="Bibliotheek"></nldd-tab-bar-item>
                 <nldd-tab-bar-item :selected="!isLibraryRoute || undefined" :href="isLibraryRoute ? editorTabHref : undefined" @click.prevent="isLibraryRoute && router.push(editorTabTarget)" icon="edit" text="Editor"></nldd-tab-bar-item>
               </nldd-tab-bar>

--- a/frontend/src/EditorView.vue
+++ b/frontend/src/EditorView.vue
@@ -1516,8 +1516,9 @@ async function handleActionSave() {
                         slot="actions"
                         size="md"
                         variant="primary"
-                        :text="savingNotes ? 'Opslaan…' : 'Opslaan naar repo'"
-                        :disabled="savingNotes || !canEdit || null"
+                        text="Opslaan naar repo"
+                        :loading="savingNotes || undefined"
+                        :disabled="!canEdit || null"
                         data-testid="save-notes-btn"
                         @click="saveNotesToRepo"
                       ></nldd-button>
@@ -1573,8 +1574,8 @@ async function handleActionSave() {
                   size="md"
                   width="full"
                   data-testid="save-text-btn"
-                  :disabled="lawSaving || undefined"
-                  :text="lawSaving ? 'Opslaan…' : 'Opslaan'"
+                  :loading="lawSaving || undefined"
+                  text="Opslaan"
                   @click="handleLawSave"
                 ></nldd-button>
               </nldd-container>
@@ -1613,8 +1614,8 @@ async function handleActionSave() {
                   size="md"
                   width="full"
                   data-testid="save-mr-btn"
-                  :disabled="lawSaving || undefined"
-                  :text="lawSaving ? 'Opslaan…' : 'Opslaan'"
+                  :loading="lawSaving || undefined"
+                  text="Opslaan"
                   @click="handleMachineReadableSave"
                 ></nldd-button>
               </nldd-container>

--- a/frontend/src/LibraryView.vue
+++ b/frontend/src/LibraryView.vue
@@ -594,7 +594,7 @@ watch(activeTrajectRef, () => {
                         v-for="law in section.laws"
                         :key="`${section.key}-${law.law_id}`"
                         size="md"
-                        type="button"
+                        button
                         :data-law-id="law.law_id"
                         :selected="law.law_id === selectedLawId || undefined"
                         @click="selectLaw(law.law_id)"
@@ -646,7 +646,7 @@ watch(activeTrajectRef, () => {
                     v-for="article in articles"
                     :key="article.number"
                     size="md"
-                    type="button"
+                    button
                     :selected="String(article.number) === String(selectedArticleNumber) || undefined"
                     @click="selectArticle(article.number)"
                   >

--- a/frontend/src/components/ActionSheet.vue
+++ b/frontend/src/components/ActionSheet.vue
@@ -139,7 +139,7 @@ onUnmounted(() => {
               :key="op.number"
               size="md"
               :data-testid="`parent-op-${op.number}`"
-              type="button"
+              button
               @click="selectOperation(op)"
             >
               <nldd-icon-cell size="20">

--- a/frontend/src/components/LawGraphView.vue
+++ b/frontend/src/components/LawGraphView.vue
@@ -366,7 +366,7 @@ const currentStep = computed(() =>
   flex: 0 0 40vh;
   min-height: 220px;
   border-top: 2px solid var(--primitives-color-donkergeel-500);
-  background: var(--semantics-surfaces-background-color);
+  background: var(--semantics-surfaces-base-background-color);
   color: var(--semantics-content-color);
   font-size: 13px;
 }
@@ -384,7 +384,7 @@ const currentStep = computed(() =>
 .law-graph-trace__btn,
 .law-graph-trace__toggle {
   border: 1px solid var(--primitives-color-coolgray-400);
-  background: var(--semantics-surfaces-background-color);
+  background: var(--semantics-surfaces-base-background-color);
   color: var(--semantics-content-color);
   border-radius: 4px;
   padding: 2px 8px;

--- a/frontend/src/components/MachineReadable.test.js
+++ b/frontend/src/components/MachineReadable.test.js
@@ -297,7 +297,7 @@ describe('MachineReadable', () => {
       });
       // No Bewerk/Bekijk buttons in read-only mode; list-item itself is the trigger.
       expect(findBekijkButtons(wrapper).length).toBe(0);
-      const actionItems = wrapper.findAll('nldd-list-item[type="button"]');
+      const actionItems = wrapper.findAll('nldd-list-item[button]');
       expect(actionItems.length).toBeGreaterThan(0);
     });
 
@@ -305,7 +305,7 @@ describe('MachineReadable', () => {
       const wrapper = mount(MachineReadable, {
         props: { article: createArticle(), editable: false },
       });
-      const actionItems = wrapper.findAll('nldd-list-item[type="button"]');
+      const actionItems = wrapper.findAll('nldd-list-item[button]');
       await actionItems[0].trigger('click');
       expect(wrapper.emitted('open-action')).toHaveLength(1);
       expect(wrapper.emitted('open-edit')).toBeUndefined();

--- a/frontend/src/components/MachineReadable.vue
+++ b/frontend/src/components/MachineReadable.vue
@@ -461,7 +461,7 @@ function addOutput() {
           v-for="(action, index) in actions"
           :key="index"
           size="md"
-          :type="editable ? undefined : 'button'"
+          :button="!editable"
           @click="!editable && emit('open-action', action)"
         >
           <nldd-text-cell :text="action.output"></nldd-text-cell>

--- a/frontend/src/components/OperationSettings.vue
+++ b/frontend/src/components/OperationSettings.vue
@@ -559,7 +559,7 @@ function addValue() {
         :key="i"
         size="md"
         :data-testid="`op-value-${i}`"
-        :type="!editable && isNestedOperation(val._value) ? 'button' : undefined"
+        :button="!editable && isNestedOperation(val._value)"
         @click="!editable && isNestedOperation(val._value) && emit('select-operation', val._value)"
       >
         <nldd-text-cell :text="val._label" :width="editable ? '120px' : 'fit-content'"></nldd-text-cell>

--- a/frontend/src/components/ScenarioBuilder.vue
+++ b/frontend/src/components/ScenarioBuilder.vue
@@ -627,8 +627,8 @@ defineExpose({ save: onSave });
               variant="primary"
               size="md"
               data-testid="save-scenarios-btn"
-              :disabled="saving || undefined"
-              :text="saving ? 'Opslaan…' : 'Opslaan'"
+              :loading="saving || undefined"
+              text="Opslaan"
               @click="onSave"
             ></nldd-button>
             <nldd-button

--- a/frontend/src/components/ScenarioForm.vue
+++ b/frontend/src/components/ScenarioForm.vue
@@ -342,7 +342,7 @@ const dateErrorId = useId();
           v-for="(ds, i) in dataSources"
           :key="ds.sourceName"
           size="md"
-          type="button"
+          button
           :data-testid="`ds-row-${i}`"
           @click="selectedSource = i"
         >

--- a/frontend/src/components/SearchPopover.vue
+++ b/frontend/src/components/SearchPopover.vue
@@ -307,7 +307,7 @@ defineExpose({ show });
                 v-for="law in group.laws"
                 :key="law.law_id"
                 size="md"
-                type="button"
+                button
                 @click="selectLaw(law.law_id)"
               >
                 <nldd-text-cell :text="displayName(law)"></nldd-text-cell>
@@ -331,7 +331,7 @@ defineExpose({ show });
               v-for="result in bwbResults"
               :key="result.bwb_id"
               size="md"
-              type="button"
+              button
               :disabled="harvestStatus[result.bwb_id] === 'loading'
                 || isPolling(harvestStatus[result.bwb_id])
                 || undefined"

--- a/frontend/src/components/TrajectDocuments.vue
+++ b/frontend/src/components/TrajectDocuments.vue
@@ -284,8 +284,8 @@ function handleKeydown(e) {
             variant="primary"
             size="md"
             width="full"
-            :text="submittingCreate ? 'Bezig…' : '+ Nieuw document'"
-            :disabled="submittingCreate || undefined"
+            text="+ Nieuw document"
+            :loading="submittingCreate || undefined"
             @click="submitCreate"
           ></nldd-button>
         </nldd-container>
@@ -376,8 +376,9 @@ function handleKeydown(e) {
             variant="primary"
             size="md"
             width="full"
-            :text="saving ? 'Opslaan…' : 'Opslaan'"
-            :disabled="saving || !currentPath || undefined"
+            text="Opslaan"
+            :loading="saving || undefined"
+            :disabled="!currentPath || undefined"
             @click="handleSave"
           ></nldd-button>
         </nldd-container>

--- a/frontend/src/components/TrajectMembersDialog.vue
+++ b/frontend/src/components/TrajectMembersDialog.vue
@@ -290,8 +290,8 @@ async function clickLeave() {
             <nldd-button
               variant="primary"
               size="md"
-              :text="inviteBusy ? 'Bezig…' : 'Uitnodigen'"
-              :disabled="inviteBusy || undefined"
+              text="Uitnodigen"
+              :loading="inviteBusy || undefined"
               @click="submitInvite"
             ></nldd-button>
           </nldd-simple-section>
@@ -305,8 +305,8 @@ async function clickLeave() {
             <nldd-button
               variant="ghost"
               size="md"
-              :text="leaveBusy ? 'Bezig…' : 'Verlaat traject'"
-              :disabled="leaveBusy || undefined"
+              text="Verlaat traject"
+              :loading="leaveBusy || undefined"
               @click="clickLeave"
             ></nldd-button>
           </nldd-simple-section>

--- a/frontend/src/components/TrajectMenu.vue
+++ b/frontend/src/components/TrajectMenu.vue
@@ -462,15 +462,15 @@ function bind(field) {
 
         <nldd-container slot="footer" padding="16">
           <div v-if="createBusy" class="traject-busy" role="status">
-            <span class="traject-spinner" aria-hidden="true"></span>
-            <span>Traject wordt aangemaakt en branch wordt op de remote gezet — dit kan even duren.</span>
+            <nldd-activity-indicator size="14"></nldd-activity-indicator>
+            <span>Traject wordt aangemaakt en branch wordt op de remote gezet. Dit kan even duren.</span>
           </div>
           <nldd-button
             variant="primary"
             size="md"
             full-width
-            :text="createBusy ? 'Bezig…' : 'Aanmaken'"
-            :disabled="createBusy || undefined"
+            text="Aanmaken"
+            :loading="createBusy || undefined"
             @click="submitCreate"
           ></nldd-button>
         </nldd-container>
@@ -508,7 +508,7 @@ function bind(field) {
 .traject-source-hint code {
   font-size: 12px;
   padding: 1px 4px;
-  background: var(--semantics-surfaces-background-color, #fff);
+  background: var(--semantics-surfaces-base-background-color, #fff);
   border-radius: 3px;
 }
 .traject-error {
@@ -523,19 +523,5 @@ function bind(field) {
   font-size: 13px;
   color: var(--semantics-content-secondary-color, #555);
   margin-bottom: 12px;
-}
-.traject-spinner {
-  width: 14px;
-  height: 14px;
-  border: 2px solid currentColor;
-  border-top-color: transparent;
-  border-radius: 50%;
-  animation: traject-spin 0.8s linear infinite;
-  flex-shrink: 0;
-}
-@keyframes traject-spin {
-  to {
-    transform: rotate(360deg);
-  }
 }
 </style>

--- a/frontend/src/components/graph/LawNode.vue
+++ b/frontend/src/components/graph/LawNode.vue
@@ -44,7 +44,7 @@ defineProps({
   background: var(--semantics-content-color);
   background: color-mix(in oklch, var(--semantics-content-color), transparent 35%);
   padding: 4px;
-  color: var(--semantics-surfaces-background-color);
+  color: var(--semantics-surfaces-base-background-color);
   border: 0;
   line-height: 0;
 }

--- a/packages/admin/frontend-src/package-lock.json
+++ b/packages/admin/frontend-src/package-lock.json
@@ -8,7 +8,7 @@
       "name": "regelrecht-admin-ui",
       "version": "1.0.0",
       "dependencies": {
-        "@nldd/design-system": "^0.8.56",
+        "@nldd/design-system": "^0.8.60",
         "vue": "^3.5.38",
         "vue-router": "^5.1.0"
       },
@@ -270,9 +270,9 @@
       }
     },
     "node_modules/@nldd/design-system": {
-      "version": "0.8.56",
-      "resolved": "https://registry.npmjs.org/@nldd/design-system/-/design-system-0.8.56.tgz",
-      "integrity": "sha512-NDx2+I4jN+B5dR6mUayQQHmR0FhhXDloMom2Z59NO5KcPitrxXGopFYP4X4Vy/aLlL3EB1qwwm3fSzGeWwwRUw==",
+      "version": "0.8.60",
+      "resolved": "https://registry.npmjs.org/@nldd/design-system/-/design-system-0.8.60.tgz",
+      "integrity": "sha512-ckQ+KzVYrKLM+745HQ4HIGalNhqmwXuUR9uWOVbRB+FXvHQqntCB4StLXTsCB4GaOWGP0L8mEaUtmDx6TlHZPQ==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@floating-ui/dom": "^1.7.6",

--- a/packages/admin/frontend-src/package.json
+++ b/packages/admin/frontend-src/package.json
@@ -8,7 +8,7 @@
     "build": "vite build"
   },
   "dependencies": {
-    "@nldd/design-system": "^0.8.56",
+    "@nldd/design-system": "^0.8.60",
     "vue": "^3.5.38",
     "vue-router": "^5.1.0"
   },

--- a/packages/admin/frontend-src/src/components/DataTable.vue
+++ b/packages/admin/frontend-src/src/components/DataTable.vue
@@ -73,7 +73,7 @@ function formatCellValue(value, key) {
           v-for="row in data"
           :key="row.id || row.law_id"
           size="md"
-          :type="clickableRows ? 'button' : undefined"
+          :button="clickableRows"
           @click="clickableRows && emit('row-click', row)"
         >
           <template v-for="(col, idx) in columns" :key="col.key">

--- a/packages/admin/frontend-src/src/components/GroupedTable.vue
+++ b/packages/admin/frontend-src/src/components/GroupedTable.vue
@@ -82,7 +82,7 @@ function statusBarTitle(group) {
         v-for="group in data"
         :key="group.law_id"
         size="md"
-        type="button"
+        button
         @click="emit('view-jobs', group.law_id)"
       >
         <template v-for="(col, idx) in columns" :key="col.key">

--- a/packages/admin/frontend-src/src/components/LawJobsSheet.vue
+++ b/packages/admin/frontend-src/src/components/LawJobsSheet.vue
@@ -161,7 +161,7 @@ const codeSections = computed(() => {
               v-for="job in jobs"
               :key="job.id"
               size="md"
-              type="button"
+              button
               @click="selectedJob = job"
             >
               <nldd-text-cell


### PR DESCRIPTION
Verhoogt `@nldd/design-system` naar **0.8.60** in alle vier de frontends en past de breaking changes toe, plus een kleine adoptie van twee nieuwe API's die handgerolde UI vervangen.

## Upgrade + breaking changes (commit 1)

Alle vier de consumers gaan naar `^0.8.60` (frontend, docs, frontend-lawmaking, admin). Elke changelog-entry van 0.8.54 t/m 0.8.60 is gelezen en geverifieerd tegen het geleverde pakket.

- **`nldd-tab-bar`**: `variant="compact"` is verwijderd (0.8.57) → `size="lg"`.
- **`nldd-list-item`**: `type="button"` is vervangen door de boolean `button`-attribuut (0.8.58). 11 plekken in de editor- en admin-frontend omgezet, inclusief de testselector.
- **CSS-token**: `--semantics-surfaces-background-color` → `--semantics-surfaces-base-background-color` (0.8.54). De oude naam wordt niet meer geleverd, dus zonder fix een stille terugval op de default.

Gecontroleerd en bewust ongemoeid gelaten: de `--primitives-color-coolgray-*` tokens bestaan nog (alleen de *categorie*-waarde `coolgray` is weg), en de breadcrumbs in docs zijn maar 2 niveaus diep, dus de nieuwe 4+-niveau-inklap raakt ze niet.

## Loading-state adoptie (commit 2)

Vervangt het handmatige "`disabled` + tekstwissel naar Bezig…/Opslaan…" patroon door de `loading`-state op `nldd-button` (uit 0.8.54): die overlayt zelf een `nldd-activity-indicator`, zet `aria-busy` en houdt de knop focusbaar.

- Handgemaakte CSS-spinner in `TrajectMenu` (`.traject-spinner` + keyframes) verwijderd ten gunste van `nldd-activity-indicator`. Dit was een design-system-bypass.
- 7 opslaan-/verzendknoppen omgezet naar `loading`. Waar een knop een tweede uitschakelreden had (`!canEdit`, `!currentPath`) blijft die als `disabled` staan naast `loading`.

## Bewust niet gedaan

`nldd-table` adoptie in de admin-frontend is overwogen maar **niet** opgenomen: `DataTable.vue` is een volwassen, slot-gedreven abstractie (kolom-widths, named cell-slots, status/mono/supporting-text varianten, toolbar met sorteren/filteren). Migreren betekent het kolom-track/subgrid-model herbouwen over `DataTable`, `GroupedTable`, `JobsView` en `LawEntriesView` — een eigen PR waard, geen drive-by.

## Verificatie

- frontend: 323/323 unit tests groen
- frontend, docs, frontend-lawmaking, admin: builds allemaal schoon