### PR TITLE
docs: documentatie-coverage voor accepted RFC's en engine-features

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -7,7 +7,8 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "a11y": "astro build && node scripts/check-mermaid-alt.mjs && node scripts/check-heading-order.mjs && node scripts/check-links.mjs && node scripts/gen-pa11yci.mjs && start-server-and-test 'astro preview --port 4173' http://localhost:4173 'pa11y-ci'"
+    "check:rfc-coverage": "node scripts/check-rfc-coverage.mjs",
+    "a11y": "astro build && node scripts/check-rfc-coverage.mjs && node scripts/check-mermaid-alt.mjs && node scripts/check-heading-order.mjs && node scripts/check-links.mjs && node scripts/gen-pa11yci.mjs && start-server-and-test 'astro preview --port 4173' http://localhost:4173 'pa11y-ci'"
   },
   "dependencies": {
     "@astrojs/mdx": "^6",

--- a/docs/scripts/check-rfc-coverage.mjs
+++ b/docs/scripts/check-rfc-coverage.mjs
@@ -1,0 +1,67 @@
+// Assert the documentation-coverage matrix lists every Accepted RFC.
+//
+// `reference/documentation-coverage.md` is a hand-maintained table claiming,
+// per Accepted RFC, where its prose coverage lives (or that it is on the
+// backlog). A hand-maintained coverage claim rots the moment a new RFC is
+// accepted and nobody updates the table: it then asserts coverage that does
+// not exist while looking authoritative. This check makes the table fail CI
+// when an Accepted RFC is missing from it, so the matrix stays honest as the
+// RFC set grows. It reads source files (frontmatter + the markdown table),
+// not the build, so it runs without `astro build`. Non-zero exit fails the gate.
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const RFC_DIR = fileURLToPath(new URL('../src/content/rfcs', import.meta.url));
+const COVERAGE = fileURLToPath(
+  new URL('../src/content/docs/reference/documentation-coverage.md', import.meta.url),
+);
+
+// RFC-000 is the process itself; it documents itself and the coverage page says
+// so in prose rather than the table. Any other Accepted RFC must appear.
+const EXEMPT = new Set(['RFC-000']);
+
+// Pull the `status:` value out of YAML frontmatter (first --- ... --- block).
+function frontmatterStatus(src) {
+  const fm = src.match(/^---\n([\s\S]*?)\n---/);
+  if (!fm) return null;
+  const line = fm[1].match(/^status:\s*(.+)$/m);
+  if (!line) return null;
+  return line[1].trim().replace(/^['"]|['"]$/g, '');
+}
+
+// Every Accepted RFC id, from frontmatter — the source of truth, not a list to
+// keep in sync by hand.
+const acceptedRfcs = [];
+for (const entry of readdirSync(RFC_DIR)) {
+  const m = entry.match(/^(rfc-\d+)\.md$/);
+  if (!m) continue;
+  const status = frontmatterStatus(readFileSync(join(RFC_DIR, entry), 'utf8'));
+  if (status === 'Accepted') acceptedRfcs.push(m[1].toUpperCase());
+}
+acceptedRfcs.sort();
+
+// Every RFC id mentioned anywhere in the coverage page (table rows or the
+// Backlog prose both count as "tracked").
+const coverageSrc = readFileSync(COVERAGE, 'utf8');
+const tracked = new Set(coverageSrc.match(/RFC-\d+/g) ?? []);
+
+const missing = acceptedRfcs.filter((id) => !EXEMPT.has(id) && !tracked.has(id));
+
+if (missing.length) {
+  console.error(
+    `RFC coverage check FAILED: ${missing.length} Accepted RFC(s) absent from ` +
+      `documentation-coverage.md:`,
+  );
+  for (const id of missing) console.error('  ' + id);
+  console.error(
+    'Add a row to the coverage table (or a Backlog entry) for each, then re-run.',
+  );
+  process.exit(1);
+}
+
+console.log(
+  `RFC coverage check passed: all ${acceptedRfcs.length - acceptedRfcs.filter((id) => EXEMPT.has(id)).length} ` +
+    `Accepted RFC(s) (excluding ${[...EXEMPT].join(', ')}) are tracked.`,
+);

--- a/docs/src/content/docs/concepts/competent-authority.md
+++ b/docs/src/content/docs/concepts/competent-authority.md
@@ -1,0 +1,43 @@
+---
+title: "Competent Authority"
+description: "How an article records the bevoegd gezag: the authority whose execution produces a binding decision, as a named organization or a category resolved per context."
+---
+
+A *beschikking* is only binding when the right body issues it. The Tax Authority assesses income; the CIZ decides on long-term care indications; a municipal college grants social assistance. An article records which body that is in `competent_authority`, the *bevoegd gezag*. This is what lets the engine tell a binding decision apart from a calculation anyone may run (see [Multi-Org Execution](./multi-org-execution)), and it is the anchor for deriving who may authoritatively annotate a law (see [Notes and Annotations](./notes-and-annotations)).
+
+## The two forms
+
+`competent_authority` sits in an article's `machine_readable` section and takes one of two shapes.
+
+A named authority, when the body is fixed:
+
+```yaml
+machine_readable:
+  competent_authority:
+    name: Belastingdienst
+    type: INSTANCE
+```
+
+`type` is either `INSTANCE` or `CATEGORY`, defaulting to `INSTANCE`:
+
+- **`INSTANCE`** is one specific organization, named outright. Belastingdienst, CIZ, Minister van Volksgezondheid, Welzijn en Sport.
+- **`CATEGORY`** is a categorical role that resolves to a different concrete body depending on context. "College van burgemeester en wethouders" names a kind of authority; which of the 342 colleges is meant depends on the municipality in scope. The distinction tells the engine whether the authority is settled by the article alone or still needs a contextual fact to pin down.
+
+A reference to a computed output, when the authority itself depends on the case:
+
+```yaml
+machine_readable:
+  competent_authority: '#bevoegd_gezag'
+```
+
+The `#` form points at an output computed elsewhere in the same law. The Wet langdurige zorg uses this: which body is competent (`2_1_3_bevoegd_gezag`) is itself a rule, so the article references the output rather than hard-coding a name.
+
+## One law, several authorities
+
+A single law can name a different authority per article, because different articles describe different acts. In the Wet langdurige zorg the indication decision is the CIZ's, while later articles assign other steps to the Zorgkantoor and the Wlz-uitvoerder. Each carries its own `competent_authority`. The authority is a property of the act in the article, not of the law as a whole.
+
+## Further reading
+
+- [Multi-Org Execution](./multi-org-execution) - how the competent authority decides execute-vs-accept
+- [Notes and Annotations](./notes-and-annotations) - how note authority is derived from the competent authority
+- [RFC-002: Bevoegdheid](/rfcs/rfc-002) - full specification

--- a/docs/src/content/docs/concepts/competent-authority.md
+++ b/docs/src/content/docs/concepts/competent-authority.md
@@ -3,7 +3,7 @@ title: "Competent Authority"
 description: "How an article records the bevoegd gezag: the authority whose execution produces a binding decision, as a named organization or a category resolved per context."
 ---
 
-A *beschikking* is only binding when the right body issues it. The Tax Authority assesses income; the CIZ decides on long-term care indications; a municipal college grants social assistance. An article records which body that is in `competent_authority`, the *bevoegd gezag*. This is what lets the engine tell a binding decision apart from a calculation anyone may run (see [Multi-Org Execution](./multi-org-execution)), and it is the anchor for deriving who may authoritatively annotate a law (see [Notes and Annotations](./notes-and-annotations)).
+A *beschikking* is only binding when the right body issues it. Income is assessed by the Tax Authority, but a long-term care indication is the CIZ's to decide, and social assistance is granted by a municipal college. An article records which body that is in `competent_authority`, the *bevoegd gezag*. This is what lets the engine tell a binding decision apart from a calculation anyone may run (see [Multi-Org Execution](./multi-org-execution)), and it is the anchor for deriving who may authoritatively annotate a law (see [Notes and Annotations](./notes-and-annotations)).
 
 ## The two forms
 
@@ -21,7 +21,7 @@ machine_readable:
 `type` is either `INSTANCE` or `CATEGORY`, defaulting to `INSTANCE`:
 
 - **`INSTANCE`** is one specific organization, named outright. Belastingdienst, CIZ, Minister van Volksgezondheid, Welzijn en Sport.
-- **`CATEGORY`** is a categorical role that resolves to a different concrete body depending on context. "College van burgemeester en wethouders" names a kind of authority; which of the 342 colleges is meant depends on the municipality in scope. The distinction tells the engine whether the authority is settled by the article alone or still needs a contextual fact to pin down.
+- **`CATEGORY`** is a categorical role that resolves to a different concrete body depending on context. "College van burgemeester en wethouders" names a kind of authority; which municipal college is meant depends on the municipality in scope. The distinction tells the engine whether the authority is settled by the article alone or still needs a contextual fact to pin down.
 
 A reference to a computed output, when the authority itself depends on the case:
 

--- a/docs/src/content/docs/concepts/cross-law-references.md
+++ b/docs/src/content/docs/concepts/cross-law-references.md
@@ -94,4 +94,6 @@ The engine detects circular references (law A needs law B which needs law A) and
 
 - [Law Format](./law-format) - full structure of a law YAML file
 - [Inversion of Control](./inversion-of-control) - a different pattern for cross-law values: delegation
+- [Temporal Validity and Dates](./temporal-and-dates) - what happens when a reference points at a law that has ended
+- [Traceability](./traceability) - a real cross-law chain shown in an execution trace
 - [RFC-007: Cross-Law Execution](/rfcs/rfc-007) - the full design specification

--- a/docs/src/content/docs/concepts/hooks-and-reactive-execution.md
+++ b/docs/src/content/docs/concepts/hooks-and-reactive-execution.md
@@ -151,5 +151,7 @@ The engine yields between stages, returning accumulated outputs and indicating w
 
 - [Cross-Law References](./cross-law-references) - how laws reference each other explicitly
 - [Inversion of Control](./inversion-of-control) - how higher laws delegate to lower regulations
+- [Traceability](./traceability) - how hook and override nodes appear in an execution trace
+- [Temporal Validity and Dates](./temporal-and-dates) - the date arithmetic behind the objection-deadline chain
 - [RFC-007: Cross-Law Execution](/rfcs/rfc-007) - hooks and overrides specification
 - [RFC-008: Bestuursrecht/Awb](/rfcs/rfc-008) - the administrative procedure model

--- a/docs/src/content/docs/concepts/how-it-works.md
+++ b/docs/src/content/docs/concepts/how-it-works.md
@@ -134,9 +134,7 @@ On the data side, 342 municipalities, 12 provinces, and 21 water boards all prod
 
 ## Traceability
 
-Every execution produces a trace tree. The trace shows which articles were applied, which inputs were fetched and from where, which operations ran, and what each step produced. Think of it as an explanation of the legal reasoning in structured form.
-
-Traces show cross-law references ("income came from Awir article 8"), IoC resolution ("standard premium came from Regeling standaardpremie"), and organizational boundaries ("income accepted from Tax Authority"). Citizens can request their trace from each contributing organization.
+Every execution can produce a trace tree showing which articles applied, which inputs were fetched and from where, which operations ran, and what each step produced: the legal reasoning behind a number, in structured form. A trace makes a cross-law chain, an IoC resolution, and the Awb hooks that fired on a *beschikking* all visible in one tree. See [Traceability](./traceability) for how to read one, with a real worked example.
 
 ## Temporal versioning
 

--- a/docs/src/content/docs/concepts/how-it-works.md
+++ b/docs/src/content/docs/concepts/how-it-works.md
@@ -140,4 +140,4 @@ Every execution can produce a trace tree showing which articles applied, which i
 
 Laws change over time. The standard premium was different in 2024 than in 2025. A calculation for January 2025 must use the rules and values in effect on that date. The engine selects the law version where `valid_from <= reference_date`.
 
-The corpus contains both `regeling_standaardpremie/2024-01-01.yaml` and `regeling_standaardpremie/2025-01-01.yaml`. A calculation with `reference_date: 2024-06-15` automatically uses the 2024 value.
+The corpus contains both `regeling_standaardpremie/2024-01-01.yaml` and `regeling_standaardpremie/2025-01-01.yaml`. A calculation with `reference_date: 2024-06-15` automatically uses the 2024 value. See [Temporal Validity and Dates](./temporal-and-dates) for how a law expires with `valid_to`, what happens to a reference into an ended law, and how dates are compared and subtracted inside the rules.

--- a/docs/src/content/docs/concepts/inversion-of-control.md
+++ b/docs/src/content/docs/concepts/inversion-of-control.md
@@ -128,4 +128,5 @@ Cross-law references and IoC both let laws use values from other laws, but they 
 
 - [Cross-Law References](./cross-law-references) - the other pattern for inter-law values
 - [Hooks and Reactive Execution](./hooks-and-reactive-execution) - yet another pattern: laws that fire automatically
+- [Traceability](./traceability) - how an open-term delegation appears in an execution trace
 - [RFC-003: Inversion of Control](/rfcs/rfc-003) - the full design specification

--- a/docs/src/content/docs/concepts/multi-org-execution.md
+++ b/docs/src/content/docs/concepts/multi-org-execution.md
@@ -67,6 +67,8 @@ A citizen requesting their trace can see: "your income was determined by the Tax
 
 ## Further reading
 
+- [Competent Authority](./competent-authority) - the `competent_authority` field that decides execute-vs-accept
+- [Traceability](./traceability) - how the organizational boundary appears in a real trace
 - [Hooks and Reactive Execution](./hooks-and-reactive-execution) - how Awb rules apply across organizations
 - [Federated Corpus](./federated-corpus) - how different organizations maintain their own law files
 - [RFC-009: Multi-Org Execution](/rfcs/rfc-009) - the full design specification

--- a/docs/src/content/docs/concepts/notes-and-annotations.md
+++ b/docs/src/content/docs/concepts/notes-and-annotations.md
@@ -1,0 +1,68 @@
+---
+title: "Notes and Annotations"
+description: "Stand-off notes that anchor to legal text by quote rather than position, so they survive renumbering and minor edits, and how their authority is derived."
+---
+
+People need to write things about a law: a comment explaining a term, a link from a sentence to the rule that executes it, a flag on an ambiguous norm. The hard part is that law text changes. Articles get renumbered, sentences get reworded, and a note pinned to "article 2, character 140" breaks the moment an article is inserted above it.
+
+RegelRecht keeps notes **stand-off**: stored separately from the law, never embedded in it, so the verbatim source text stays untouched. A note anchors to the text by quoting it, following the W3C Web Annotation Data Model.
+
+## Anchoring by quote
+
+A note targets text through a `TextQuoteSelector`: the exact quote, plus a little prefix and suffix for context. From a real note on the Wet op de zorgtoeslag (`corpus/annotations/wet_op_de_zorgtoeslag/annotations.yaml`):
+
+```yaml
+- type: Annotation
+  motivation: linking
+  creator: Dienst Toeslagen
+  target:
+    source: regelrecht://wet_op_de_zorgtoeslag
+    selector:
+      type: TextQuoteSelector
+      exact: zorgtoeslag
+      prefix: 'heeft de verzekerde aanspraak op een '
+      suffix: ' ter grootte van dat verschil'
+  body:
+    type: SpecificResource
+    source: regelrecht://wet_op_de_zorgtoeslag/hoogte_zorgtoeslag
+    purpose: linking
+```
+
+Because the anchor is the content, not a line number, the note follows its text. Insert a new article 1a and renumber the target to 4a, and the note still lands on 4a. The resolver (`packages/engine/src/annotation/`) reports one of three outcomes (`MatchStatus`):
+
+- **Found**: exactly one location matches.
+- **Ambiguous**: the quote occurs more than once with no context to separate the hits (the common word "verzekerde" three times in a sentence). Adding a prefix or suffix disambiguates.
+- **Orphaned**: the text is gone. The note is not silently dropped; it is marked orphaned so a human can re-anchor it.
+
+When wording drifts slightly (a Staatsblad amendment swaps a few words), exact matching fails but **fuzzy matching** recovers it: normalized Levenshtein similarity above 0.7 resolves as a fuzzy match with a confidence below 1.0; a wholesale rewrite falls below the threshold and orphans rather than mis-anchoring. A note may also carry an optional article hint to try first; an outdated hint falls back to a full search. The behavior is pinned by `features/notes.feature`.
+
+## What a note says
+
+The `motivation` field is the kind of note. The W3C model defines thirteen; four matter for law work, and three of those are in use in the corpus today:
+
+- **linking** ties a sentence to the `machine_readable` element that executes it, making the chain from text to logic auditable.
+- **commenting** is a plain explanation for readers.
+- **questioning** flags an open or ambiguous norm. These draw their term from a controlled vocabulary (`corpus/annotations/_vocabulary/ambiguity.yaml`) and move through a small workflow: an open question becomes `resolved` once the implementing regulation is found and modelled.
+
+The fourth, **tagging** (classification), is available but not yet used in the corpus.
+
+## Storage, federation, and authority
+
+Notes live in sidecar YAML keyed by the law's `$id`, not its file path (`corpus/annotations/{law_id}/annotations.yaml`). They follow the same [federated](./federated-corpus) model as the corpus: any organization can keep notes on a law in its own repository, and the editor's write path is append-only so parallel edits do not clobber each other.
+
+A note's **authority is derived at display time**, not declared. The resolver compares the note's `creator` against the article's [competent authority](./competent-authority):
+
+- **authoritative** when the creator is the competent body itself (Dienst Toeslagen on its own act).
+- **advisory** when the creator is another government organization.
+- **generated** when tooling produced it.
+- **personal** when an individual wrote it.
+
+The same note text means something different depending on who wrote it, and the model makes that explicit instead of treating every note as equal.
+
+The engine exposes resolution to the browser through the WASM bindings `resolveNote` and `resolveNotes` (`packages/engine/src/wasm.rs`), so the editor anchors notes against the live text on screen.
+
+## Further reading
+
+- [Competent Authority](./competent-authority) - the basis for a note's derived authority
+- [Federated Corpus](./federated-corpus) - how notes are distributed
+- [RFC-005: Stand-off Notes](/rfcs/rfc-005) and [RFC-018: Note Infrastructure](/rfcs/rfc-018) - full specifications

--- a/docs/src/content/docs/concepts/notes-and-annotations.md
+++ b/docs/src/content/docs/concepts/notes-and-annotations.md
@@ -34,11 +34,11 @@ Because the anchor is the content, not a line number, the note follows its text.
 - **Ambiguous**: the quote occurs more than once with no context to separate the hits (the common word "verzekerde" three times in a sentence). Adding a prefix or suffix disambiguates.
 - **Orphaned**: the text is gone. The note is not silently dropped; it is marked orphaned so a human can re-anchor it.
 
-When wording drifts slightly (a Staatsblad amendment swaps a few words), exact matching fails but **fuzzy matching** recovers it: normalized Levenshtein similarity above 0.7 resolves as a fuzzy match with a confidence below 1.0; a wholesale rewrite falls below the threshold and orphans rather than mis-anchoring. A note may also carry an optional article hint to try first; an outdated hint falls back to a full search. The behavior is pinned by `features/notes.feature`.
+When wording drifts slightly (a Staatsblad amendment swaps a few words), exact matching fails but **fuzzy matching** recovers it: normalized Levenshtein similarity above a threshold (currently 0.7) resolves as a fuzzy match with a confidence below 1.0; a wholesale rewrite falls below the threshold and orphans rather than mis-anchoring. A note may also carry an optional article hint to try first; an outdated hint falls back to a full search. The behavior is pinned by `features/notes.feature`.
 
 ## What a note says
 
-The `motivation` field is the kind of note. The W3C model defines thirteen; four matter for law work, and three of those are in use in the corpus today:
+The `motivation` field is the kind of note. The W3C model defines thirteen motivation values (Web Annotation Data Model, §3.3.5); four matter for law work, and three of those are in use in the corpus today:
 
 - **linking** ties a sentence to the `machine_readable` element that executes it, making the chain from text to logic auditable.
 - **commenting** is a plain explanation for readers.

--- a/docs/src/content/docs/concepts/temporal-and-dates.md
+++ b/docs/src/content/docs/concepts/temporal-and-dates.md
@@ -27,7 +27,7 @@ Then the execution fails with
   "No version of law 'test_einddatum' in force on 2025-06-01; last in force until 2024-12-31"
 ```
 
-The same honesty holds across a cross-law reference: a law that reads an ended law reports which law ended and when, instead of silently computing on no-longer-valid rules. The selection outcome is one of in force, not yet in force, or ended on a date (`SelectionReason` in `packages/engine/src/resolver.rs`), and both `valid_from` and `valid_to` are recorded in the [Execution Receipt](./execution-provenance) so the choice is reproducible. The scenarios above come from `features/einddatum.feature`.
+The same applies across a cross-law reference: a law that reads an ended law reports which law ended and when, instead of computing on no-longer-valid rules. The selection outcome is one of in force, not yet in force, or ended on a date (`SelectionReason` in `packages/engine/src/resolver.rs`), and both `valid_from` and `valid_to` are recorded in the [Execution Receipt](./execution-provenance) so the choice is reproducible. The scenarios above come from `features/einddatum.feature`.
 
 ## Comparing and subtracting dates
 

--- a/docs/src/content/docs/concepts/temporal-and-dates.md
+++ b/docs/src/content/docs/concepts/temporal-and-dates.md
@@ -1,0 +1,62 @@
+---
+title: "Temporal Validity and Dates"
+description: "How the engine selects the law version in force on a date, how it reports references to expired laws, and how dates are compared and subtracted."
+---
+
+A calculation always happens *as of* a date. The rules and amounts in force on 15 June 2024 are not the ones in force on 15 June 2025, and a faithful answer uses the version that applied on the day in question. Two mechanisms make this work: version selection by date, and date operations inside the rules.
+
+## Which version is in force
+
+A law version carries `valid_from`, and optionally `valid_to`: the first and last calendar days on which it is in force, both inclusive. The engine selects the version where `valid_from <= reference_date <= valid_to`, where the reference date is the calculation date supplied by the caller.
+
+`valid_to` is what lets a law expire without a successor. A version with `valid_to: 2024-12-31` resolves on its last day:
+
+```gherkin
+Given the calculation date is "2024-12-31"
+When the law "test_einddatum" is executed for outputs "normbedrag"
+Then the output "normbedrag" is "500"
+```
+
+and the day after, it is gone. Selection does **not** fall through to an older version once the in-force one has ended; an expired law is expired, not replaced by its predecessor. A reference to a law that has ended fails with the data fact rather than a vague "no rule found":
+
+```gherkin
+Given the calculation date is "2025-06-01"
+When the law "test_einddatum" is executed for outputs "normbedrag"
+Then the execution fails with
+  "No version of law 'test_einddatum' in force on 2025-06-01; last in force until 2024-12-31"
+```
+
+The same honesty holds across a cross-law reference: a law that reads an ended law reports which law ended and when, instead of silently computing on no-longer-valid rules. The selection outcome is one of in force, not yet in force, or ended on a date (`SelectionReason` in `packages/engine/src/resolver.rs`), and both `valid_from` and `valid_to` are recorded in the [Execution Receipt](./execution-provenance) so the choice is reproducible. The scenarios above come from `features/einddatum.feature`.
+
+## Comparing and subtracting dates
+
+Deadlines and durations need arithmetic on dates, not just on numbers. Two routes cover it.
+
+**Comparison operators dispatch on operand type.** `GREATER_THAN`, `LESS_THAN`, `LESS_THAN_OR_EQUAL` and the rest compare numbers when both operands are numeric, and compare chronologically when both are ISO 8601 dates. So `$indieningsdatum <= $peildatum` works directly, with no detour through `AGE`. `EQUALS` gains a date fallback for the mixed case (a date string against the `{iso, year, month, day}` object form of `referencedate`).
+
+**`DATE_DIFF` measures the span between two dates** with an explicit unit:
+
+```yaml
+operation: DATE_DIFF
+from: $indieningsdatum
+to: $referencedate
+in: days        # or: months, years
+```
+
+It is signed: positive when `to` is on or after `from`, negative otherwise. For a request filed on 2025-01-01 against a peildatum of 2025-07-01, the span is `181` days; flip the two dates and it is `-181`. Months and years count whole calendar units, reusing the same arithmetic as `AGE` (BW art. 1:2), so end-of-month and leap-year cases stay consistent: 31 January to 28 February is one whole month, because January has no 31st counterpart in February.
+
+```gherkin
+Given the calculation date is "2025-02-28"
+And a query with the following data:
+  | indieningsdatum | 2025-01-31 |
+When the law "test_date_operations" is executed for outputs "doorlooptijd_maanden"
+Then the output "doorlooptijd_maanden" is "1"
+```
+
+Dates must be in canonical `YYYY-MM-DD` form, zero-padded; `2025-1-1` is rejected rather than guessed. These scenarios come from `features/date_operations.feature`, and the related operations `AGE`, `DATE_ADD`, `DATE`, and `DAY_OF_WEEK` are listed in the [Law Format](./law-format) operation table.
+
+## Further reading
+
+- [Cross-Law References](./cross-law-references) - how an expired reference surfaces in a chain
+- [Execution Provenance](./execution-provenance) - validity windows in the receipt
+- [RFC-019: Law End Dates](/rfcs/rfc-019) and [RFC-021: Date Comparison](/rfcs/rfc-021) - full specifications

--- a/docs/src/content/docs/concepts/temporal-and-dates.md
+++ b/docs/src/content/docs/concepts/temporal-and-dates.md
@@ -14,7 +14,8 @@ A law version carries `valid_from`, and optionally `valid_to`: the first and las
 ```gherkin
 Given the calculation date is "2024-12-31"
 When the law "test_einddatum" is executed for outputs "normbedrag"
-Then the output "normbedrag" is "500"
+Then the execution succeeds
+And the output "normbedrag" is "500"
 ```
 
 and the day after, it is gone. Selection does **not** fall through to an older version once the in-force one has ended; an expired law is expired, not replaced by its predecessor. A reference to a law that has ended fails with the data fact rather than a vague "no rule found":

--- a/docs/src/content/docs/concepts/traceability.md
+++ b/docs/src/content/docs/concepts/traceability.md
@@ -5,7 +5,7 @@ description: "How to read an execution trace: the node types, the box-drawing tr
 
 When the engine computes an output, it can record every step it took to get there: which articles applied, which inputs it fetched and from where, which operations ran, and what each one produced. That record is the **trace**. It is the legal reasoning behind a number, in a form you can read top to bottom.
 
-A trace is opt-in. The plain evaluation path produces no trace at all (and pays nothing for it); you ask for one explicitly. This page explains how to read a trace, then walks through a real one. For how a trace fits into a reproducible, signed [Execution Receipt](./execution-provenance), see that page.
+A trace is opt-in. The plain evaluation path builds no trace at all; you ask for one explicitly through a separate entry point (`evaluate_law_output_with_trace`, not `evaluate_law_output`). This page explains how to read a trace, then walks through a real one. For how a trace fits into a reproducible, signed [Execution Receipt](./execution-provenance), see that page.
 
 ## Anatomy of a node
 

--- a/docs/src/content/docs/concepts/traceability.md
+++ b/docs/src/content/docs/concepts/traceability.md
@@ -1,0 +1,120 @@
+---
+title: "Traceability"
+description: "How to read an execution trace: the node types, the box-drawing tree, and a real zorgtoeslag trace with a cross-law chain, IoC delegation, and Awb hooks."
+---
+
+When the engine computes an output, it can record every step it took to get there: which articles applied, which inputs it fetched and from where, which operations ran, and what each one produced. That record is the **trace**. It is the legal reasoning behind a number, in a form you can read top to bottom.
+
+A trace is opt-in. The plain evaluation path produces no trace at all (and pays nothing for it); you ask for one explicitly. This page explains how to read a trace, then walks through a real one. For how a trace fits into a reproducible, signed [Execution Receipt](./execution-provenance), see that page.
+
+## Anatomy of a node
+
+A trace is a tree of nodes. Each node has a type (what kind of step it was), a name, an optional result, and children. The type is one of:
+
+| Node type | What it marks |
+|-----------|---------------|
+| `Article` | An article being evaluated |
+| `Action` | An action within an article |
+| `Resolve` | Resolving a variable to a value |
+| `Operation` | An operation running (`ADD`, `EQUALS`, `MAX`, …) |
+| `Requirement` | A requirement (eligibility) check |
+| `CrossLawReference` | A `source` lookup into another law |
+| `Cached` | A cross-law result reused from earlier in the same execution |
+| `OpenTermResolution` | An open term filled by an `implements` regulation (IoC) |
+| `HookResolution` | A hook firing on another article's output (RFC-007) |
+| `OverrideResolution` | A value replaced by lex specialis (RFC-007) |
+
+A `Resolve` node also carries a **resolve type** saying where the value came from: `Parameter` (caller input), `Definition` (an article constant), `Output` (a value computed earlier), `DataSource` (an external register), `ResolvedInput` (a cached cross-law result), `OpenTerm`, `Hook`, `Override`, `Context` (the `referencedate`), `Local` (a loop variable), `Input`, or `Uri`. The resolve type is the difference between "this number is a hard-coded constant in the law" and "this number came from the Tax Authority". The full set lives in `PathNodeType` and `ResolveType` in `packages/engine/src/types.rs`.
+
+## How to read the tree
+
+The default rendering uses box-drawing characters, and the connector tells you whether a step crossed a law boundary:
+
+- **Double lines** (`║`, `╟──`, `╙──`) wrap a cross-law scope. Everything indented under a double line is being computed inside a different law than its parent.
+- **Single lines** (`│`, `├──`, `└──`) are steps within one law: operations, variable resolutions, nested calculations.
+
+So the shape of the left margin is a map of which law you are in at any depth, without reading a single label.
+
+## A real trace
+
+Here is the engine computing `hoogte_zorgtoeslag` (the healthcare allowance amount) for one person on 2025-01-01. The full rendering is checked in at `packages/engine/tests/expected_zorgtoeslag_trace.txt` and pinned by a snapshot test, so it stays in step with the engine. The interesting parts:
+
+### A cross-law chain
+
+```text
+║   ╟──Reference: algemene_wet_inkomensafhankelijke_regelingen#toetsingsinkomen
+║   ║   ╟──Resolving from PARAMETERS: $BSN = '999993653'
+║   ║   ╟──Reference: wet_inkomstenbelasting_2001#toetsingsinkomen
+║   ║   ║   ╟──Resolving from PARAMETERS: $BSN = '999993653'
+║   ║   ║   ╟──Reference: wet_inkomstenbelasting_2001#box1_inkomen
+║   ║   ║   ║   ╟──Resolving from DATA_SOURCE: $LOON_UIT_DIENSTBETREKKING = 79547
+```
+
+The zorgtoeslag law needs `toetsingsinkomen`. The Awir provides it, but to do so the Awir itself calls the Wet inkomstenbelasting 2001, which in turn reads `loon_uit_dienstbetrekking` from a data source. Each new `║` column is one law deeper. The zorgtoeslag YAML asks only the Awir for this value; the step into the income-tax law is the Awir's own reference, which the engine follows transitively.
+
+### IoC delegation
+
+```text
+║   ╟──Resolving $WET_OP_DE_ZORGTOESLAG#STANDAARDPREMIE
+║   ║   ├──Resolving from RESOLVED_INPUT: 211200
+║   ║   ├──Delegation: Open term 'standaardpremie' implemented by regeling_standaardpremie article 1: 211200
+```
+
+The zorgtoeslag law leaves `standaardpremie` open; it does not state the number. A ministerial regulation, `regeling_standaardpremie`, declares that it implements that open term, and the trace records which regulation and article filled the blank. This is the [Inversion of Control](./inversion-of-control) pattern made visible.
+
+### A reused result
+
+```text
+║   ║   ├──Reference: algemene_wet_inkomensafhankelijke_regelingen#heeft_toeslagpartner
+║   ║   │   ╟──Resolving from PARAMETERS: $BSN = '999993653'
+║   ║   │   ╙──Cached: algemene_wet_inkomensafhankelijke_regelingen#heeft_toeslagpartner: False
+```
+
+`heeft_toeslagpartner` was already computed earlier in this execution. The second time it is needed, the engine reuses the result instead of recomputing the whole subtree. The `Cached` node is how you spot memoization: same law, same output, same parameters, computed once.
+
+### Awb hooks firing
+
+```text
+║   ╟──HOOK: Hook PreActions on BESCHIKKING stage BESLUIT → algemene_wet_bestuursrecht:3:46
+║   ║   ╙──Computing motivering_vereist
+...
+║   ╙──HOOK: Hook PostActions on BESCHIKKING stage BESLUIT → algemene_wet_bestuursrecht:6:7
+║       ╙──Computing bezwaartermijn_weken
+║           └──Result: bezwaartermijn_weken = 6
+```
+
+Neither the zorgtoeslag law nor the Awb references the other. Because the zorgtoeslag decision is a *beschikking*, two Awb articles fire on it: 3:46 adds the duty to give reasons (`motivering_vereist`), and 6:7 adds the six-week objection period (`bezwaartermijn_weken`). These are [reactive](./hooks-and-reactive-execution) outputs, and in the receipt they carry a `Reactive` provenance tag rather than `Direct`. (Where a more specific law shortens that period, an `Override` node appears instead; the Vreemdelingenwet's four-week term is the worked example on the hooks page.)
+
+### Operation branches
+
+Inside a single law the tree is just the calculation. An `IF` records which branch it took:
+
+```text
+║   ║       ├──Compute LESS_THAN_OR_EQUAL(...) = True
+║   ║       │   ├──Resolving from PARAMETERS: $VERMOGEN = 0
+║   ║       │   └──IF(took default) = 14189600
+║   ║       │       ├──CASE 0: False
+║   ║       │       │   └──Compute EQUALS(...) = False
+║   ║       │       │       └──Resolving from PARAMETERS: $HEEFT_TOESLAGPARTNER = False
+║   ║       │       └──DEFAULT: 14189600
+```
+
+`CASE 0: False` means the first case condition did not hold, so the operation `took default`. The asset limit applied here (14189600 eurocent) is the single-person limit, because the partner check returned `False`.
+
+## Generating a trace
+
+The quickest way to see one is the bundled example, which loads the local corpus and prints the rendered tree:
+
+```bash
+cargo run --example trace -- wet_op_de_zorgtoeslag hoogte_zorgtoeslag 2025-01-01 bsn=999993653
+```
+
+(See `packages/engine/examples/trace.rs`.) For a simpler starting point, `packages/engine/tests/expected_standaardpremie_trace.txt` is a seven-line trace of a single law with no cross-law calls.
+
+In Rust, call `evaluate_law_output_with_trace(...)` and render the `trace` field with `render_box_drawing()`. In the browser, the WASM engine exposes `executeWithTrace(...)` (and `executeMultipleWithTrace(...)` for several outputs at once); both return the trace as a structured tree you can render in the UI. The editor's execution view and the [TUI](../components/tui)'s trace screen both build on this.
+
+## Further reading
+
+- [Hooks and Reactive Execution](./hooks-and-reactive-execution) - where the hook and override nodes come from
+- [Inversion of Control](./inversion-of-control) - the open-term delegation a trace shows
+- [Execution Provenance](./execution-provenance) - the receipt that wraps a trace for reproducibility

--- a/docs/src/content/docs/reference/conformance.md
+++ b/docs/src/content/docs/reference/conformance.md
@@ -1,11 +1,13 @@
 ---
 title: "Conformance"
-description: "The language-agnostic conformance suite that lets a third-party engine prove it executes RegelRecht law correctly, organized into conformance levels per schema version."
+description: "The language-agnostic conformance suite that would let a third-party engine prove it executes RegelRecht law correctly: its level structure is specified, the JSON test cases are not yet written."
 ---
 
-The schema is the specification; the Rust engine is one implementation of it. Nothing stops another organization from building its own engine, and for a government decision system that independence is the point. The conformance suite is how a second implementation proves it produces the right answers, without depending on the RegelRecht codebase.
+The schema is the specification; the Rust engine is one implementation of it. Nothing stops another organization from building its own engine, and for a government decision system that independence is the point. The conformance suite is how a second implementation would prove it produces the right answers, without depending on the RegelRecht codebase.
 
-Tests are plain JSON, not Rust. Each one gives a regulation, parameters, and the expected outputs; an engine passes by producing those outputs. Trace assertions are optional, so an engine that does not emit traces can still demonstrate correctness on everything else.
+The suite is **specified but not yet populated**: the manifests that define its structure are checked in, but the JSON test cases themselves have not been written. This page describes the design and states plainly what is enforced today (the [next section](#what-is-enforced-today) has the details). Read the test format below as the intended shape, not as files you can open and run right now.
+
+Tests are designed to be plain JSON, not Rust. Each one will give a regulation, parameters, and the expected outputs; an engine passes by producing those outputs. Trace assertions are optional, so an engine that does not emit traces can still demonstrate correctness on everything else.
 
 ## Structure
 
@@ -21,19 +23,19 @@ The manifest groups work into **conformance levels**, from a minimal core outwar
 | `temporal` | Date operations: `AGE`, `DATE_ADD`, `DATE`, `DAY_OF_WEEK`, `DATE_DIFF` |
 | `advanced` | Hooks, overrides, untranslatables, data sources, and Awb procedures |
 
-Each level names its test files and the operations it is responsible for. An engine can claim a level once it passes every test in it, which gives a precise vocabulary for partial support: an engine might be core-and-cross-law conformant without yet handling the advanced level.
+Each level names the test files it will contain and the operations it is responsible for. Once the cases exist, an engine could claim a level by passing every test in it, which gives a precise vocabulary for partial support: an engine might be core-and-cross-law conformant without yet handling the advanced level. The `test_files` entries in the manifests are the planned filenames; the files themselves are not written yet.
 
 ## What is enforced today
 
-The suite is partially built. Two manifests are checked in (`v0.5.0` and `v0.5.4`); the v0.5.4 manifest added `DATE_DIFF` to the temporal level alongside the [date operations](../concepts/temporal-and-dates) it belongs with.
+Only the manifests exist. Two are checked in (`v0.5.0` and `v0.5.4`), and they declare the level structure and operation assignments above; the v0.5.4 manifest added `DATE_DIFF` to the temporal level alongside the [date operations](../concepts/temporal-and-dates) it belongs with. The JSON test cases the manifests reference have not been authored, and there is no runner that executes them against an engine. So the cross-implementation guarantee the suite is designed to provide does **not** hold today.
 
-The guarantee that holds right now is operation coverage. Three integration tests in `packages/engine/tests/conformance_coverage.rs` check the manifest against the engine's own operation list:
+What *is* enforced is narrower: operation coverage of the manifest itself. Three integration tests in `packages/engine/tests/conformance_coverage.rs` check each manifest's `operations` lists against the engine's own operation list:
 
 - every operation the engine supports appears in some level,
 - no level lists an operation the engine does not have,
 - no operation lands in two levels.
 
-So a new operation cannot be added to the engine without being classified into exactly one conformance level; CI fails otherwise. The cross-engine test corpus and a runner that executes the JSON cases against an arbitrary implementation are the remaining work (see [RFC-014](/rfcs/rfc-014)).
+So a new operation cannot be added to the engine without being classified into exactly one conformance level; CI fails otherwise. This keeps the manifest honest as the engine grows, but it tests the manifest, not any law execution. Writing the JSON test corpus and a runner that executes the cases against an arbitrary implementation is the remaining work (see [RFC-014](/rfcs/rfc-014)).
 
 ## Further reading
 

--- a/docs/src/content/docs/reference/conformance.md
+++ b/docs/src/content/docs/reference/conformance.md
@@ -1,0 +1,42 @@
+---
+title: "Conformance"
+description: "The language-agnostic conformance suite that lets a third-party engine prove it executes RegelRecht law correctly, organized into conformance levels per schema version."
+---
+
+The schema is the specification; the Rust engine is one implementation of it. Nothing stops another organization from building its own engine, and for a government decision system that independence is the point. The conformance suite is how a second implementation proves it produces the right answers, without depending on the RegelRecht codebase.
+
+Tests are plain JSON, not Rust. Each one gives a regulation, parameters, and the expected outputs; an engine passes by producing those outputs. Trace assertions are optional, so an engine that does not emit traces can still demonstrate correctness on everything else.
+
+## Structure
+
+Tests live under `conformance/v<schema>/`, one directory per schema version, each with a `manifest.json`. A test written against schema v0.5.4 belongs under `conformance/v0.5.4/`, because what counts as correct can change between schema versions.
+
+The manifest groups work into **conformance levels**, from a minimal core outward:
+
+| Level | Covers |
+|-------|--------|
+| `core` | Arithmetic, comparison, logical, conditional, and collection operations, plus variable resolution |
+| `cross_law` | Resolving a `source` reference into another law |
+| `ioc` | Open terms filled by `implements` regulations |
+| `temporal` | Date operations: `AGE`, `DATE_ADD`, `DATE`, `DAY_OF_WEEK`, `DATE_DIFF` |
+| `advanced` | Hooks, overrides, untranslatables, data sources, and Awb procedures |
+
+Each level names its test files and the operations it is responsible for. An engine can claim a level once it passes every test in it, which gives a precise vocabulary for partial support: an engine might be core-and-cross-law conformant without yet handling the advanced level.
+
+## What is enforced today
+
+The suite is partially built. Two manifests are checked in (`v0.5.0` and `v0.5.4`); the v0.5.4 manifest added `DATE_DIFF` to the temporal level alongside the [date operations](../concepts/temporal-and-dates) it belongs with.
+
+The guarantee that holds right now is operation coverage. Three integration tests in `packages/engine/tests/conformance_coverage.rs` check the manifest against the engine's own operation list:
+
+- every operation the engine supports appears in some level,
+- no level lists an operation the engine does not have,
+- no operation lands in two levels.
+
+So a new operation cannot be added to the engine without being classified into exactly one conformance level; CI fails otherwise. The cross-engine test corpus and a runner that executes the JSON cases against an arbitrary implementation are the remaining work (see [RFC-014](/rfcs/rfc-014)).
+
+## Further reading
+
+- [Execution Provenance](../concepts/execution-provenance) - the receipt format a conformant engine produces
+- [Schema](./schema) - the versioned specification under test
+- [RFC-014: Engine Conformance Test Suite](/rfcs/rfc-014) - full specification

--- a/docs/src/content/docs/reference/conformance.md
+++ b/docs/src/content/docs/reference/conformance.md
@@ -1,19 +1,38 @@
 ---
 title: "Conformance"
-description: "The language-agnostic conformance suite that would let a third-party engine prove it executes RegelRecht law correctly: its level structure is specified, the JSON test cases are not yet written."
+description: "What conformance enforces today (manifest operation-coverage in CI) and the language-agnostic test suite it is the foundation for. The level structure is checked in; the JSON test cases are not yet written. Design lives in RFC-014."
 ---
 
-The schema is the specification; the Rust engine is one implementation of it. Nothing stops another organization from building its own engine, and for a government decision system that independence is the point. The conformance suite is how a second implementation would prove it produces the right answers, without depending on the RegelRecht codebase.
+The schema is the specification; the Rust engine is one implementation of it. Nothing stops another organization from building its own engine, and for a government decision system that independence is the point. A conformance suite is how a second implementation would prove it produces the right answers, without depending on the RegelRecht codebase.
 
-The suite is **specified but not yet populated**: the manifests that define its structure are checked in, but the JSON test cases themselves have not been written. This page describes the design and states plainly what is enforced today (the [next section](#what-is-enforced-today) has the details). Read the test format below as the intended shape, not as files you can open and run right now.
+That suite is **designed but not built**. This page is therefore in two halves, in order of how real they are:
 
-Tests are designed to be plain JSON, not Rust. Each one will give a regulation, parameters, and the expected outputs; an engine passes by producing those outputs. Trace assertions are optional, so an engine that does not emit traces can still demonstrate correctness on everything else.
+1. [What is enforced today](#what-is-enforced-today) - a CI check that keeps the conformance manifest in step with the engine's operations. This exists and runs.
+2. [The intended suite](#the-intended-suite) - the cross-implementation test format the manifests are structured for. The manifests are checked in; the JSON test cases and the runner are not written yet. The full design is [RFC-014](/rfcs/rfc-014).
 
-## Structure
+If you came here expecting test cases you can run against your own engine, there are none yet. Read the second half as the target, not as files on disk.
 
-Tests live under `conformance/v<schema>/`, one directory per schema version, each with a `manifest.json`. A test written against schema v0.5.4 belongs under `conformance/v0.5.4/`, because what counts as correct can change between schema versions.
+## What is enforced today
 
-The manifest groups work into **conformance levels**, from a minimal core outward:
+Two manifests are checked in, `conformance/v0.5.0/manifest.json` and `conformance/v0.5.4/manifest.json`. Each declares a set of conformance levels and, per level, the operations that level is responsible for. The v0.5.4 manifest added `DATE_DIFF` to the temporal level alongside the [date operations](../concepts/temporal-and-dates) it belongs with.
+
+What runs in CI is **operation coverage of the manifest itself**, nothing more. Three integration tests in `packages/engine/tests/conformance_coverage.rs` check each manifest's `operations` lists against the engine's own operation list:
+
+- every operation the engine supports appears in some level,
+- no level lists an operation the engine does not have,
+- no operation lands in two levels.
+
+So a new operation cannot be added to the engine without being classified into exactly one conformance level; CI fails otherwise. This keeps the manifest honest as the engine grows. But it tests the *manifest*, not any law execution: it never runs a regulation, never checks an output. The cross-implementation guarantee a conformance suite is meant to provide does **not** hold today.
+
+## The intended suite
+
+The manifests are shaped for a test format that does not exist yet. Documented here so the structure already in the repo is legible, and so the gap is explicit.
+
+Tests are designed to be plain JSON, not Rust, so any engine can consume them. Each case would give a regulation, parameters, and the expected outputs; an engine passes by producing those outputs. Trace assertions would be optional, so an engine that does not emit traces can still demonstrate correctness on everything else.
+
+Tests live under `conformance/v<schema>/`, one directory per schema version, because what counts as correct can change between schema versions. A case written against schema v0.5.4 belongs under `conformance/v0.5.4/`.
+
+The manifest groups work into conformance levels, from a minimal core outward:
 
 | Level | Covers |
 |-------|--------|
@@ -23,22 +42,12 @@ The manifest groups work into **conformance levels**, from a minimal core outwar
 | `temporal` | Date operations: `AGE`, `DATE_ADD`, `DATE`, `DAY_OF_WEEK`, `DATE_DIFF` |
 | `advanced` | Hooks, overrides, untranslatables, data sources, and Awb procedures |
 
-Each level names the test files it will contain and the operations it is responsible for. Once the cases exist, an engine could claim a level by passing every test in it, which gives a precise vocabulary for partial support: an engine might be core-and-cross-law conformant without yet handling the advanced level. The `test_files` entries in the manifests are the planned filenames; the files themselves are not written yet.
+Once the cases exist, an engine could claim a level by passing every test in it, which gives a precise vocabulary for partial support: an engine might be core-and-cross-law conformant without yet handling the advanced level. The `test_files` entries in the manifests are the planned filenames; those files are not written yet, and there is no runner that executes them against an engine.
 
-## What is enforced today
-
-Only the manifests exist. Two are checked in (`v0.5.0` and `v0.5.4`), and they declare the level structure and operation assignments above; the v0.5.4 manifest added `DATE_DIFF` to the temporal level alongside the [date operations](../concepts/temporal-and-dates) it belongs with. The JSON test cases the manifests reference have not been authored, and there is no runner that executes them against an engine. So the cross-implementation guarantee the suite is designed to provide does **not** hold today.
-
-What *is* enforced is narrower: operation coverage of the manifest itself. Three integration tests in `packages/engine/tests/conformance_coverage.rs` check each manifest's `operations` lists against the engine's own operation list:
-
-- every operation the engine supports appears in some level,
-- no level lists an operation the engine does not have,
-- no operation lands in two levels.
-
-So a new operation cannot be added to the engine without being classified into exactly one conformance level; CI fails otherwise. This keeps the manifest honest as the engine grows, but it tests the manifest, not any law execution. Writing the JSON test corpus and a runner that executes the cases against an arbitrary implementation is the remaining work (see [RFC-014](/rfcs/rfc-014)).
+Writing the JSON test corpus and a runner that executes the cases against an arbitrary implementation is the remaining work. [RFC-014](/rfcs/rfc-014) is the full design and tracks that status.
 
 ## Further reading
 
 - [Execution Provenance](../concepts/execution-provenance) - the receipt format a conformant engine produces
 - [Schema](./schema) - the versioned specification under test
-- [RFC-014: Engine Conformance Test Suite](/rfcs/rfc-014) - full specification
+- [RFC-014: Engine Conformance Test Suite](/rfcs/rfc-014) - full specification and current status

--- a/docs/src/content/docs/reference/documentation-coverage.md
+++ b/docs/src/content/docs/reference/documentation-coverage.md
@@ -5,6 +5,8 @@ description: "Which accepted RFCs and built features have prose documentation ou
 
 This page tracks how well the prose docs cover the accepted RFCs and the implemented engine and platform features. It exists so coverage gaps are visible and tracked, rather than discovered by accident. RFCs that are still Draft or Proposed are out of scope here; their own pages under [RFCs](/rfcs/) are the source of truth until they are accepted.
 
+The table below is **enforced**: `docs/scripts/check-rfc-coverage.mjs` reads the `status` frontmatter of every RFC and fails CI when an Accepted RFC has no row here (or Backlog mention). So the matrix cannot silently fall behind the RFC set: accept a new RFC without adding it, and the docs build breaks. The check guarantees a *row exists* for each Accepted RFC; it does not, and cannot, judge whether the coverage that row points at is good. That judgement stays with whoever accepts the RFC, who owns adding an honest entry as part of acceptance.
+
 ## Accepted RFCs
 
 | RFC | Topic | Prose coverage |

--- a/docs/src/content/docs/reference/documentation-coverage.md
+++ b/docs/src/content/docs/reference/documentation-coverage.md
@@ -1,0 +1,45 @@
+---
+title: "Documentation Coverage"
+description: "Which accepted RFCs and built features have prose documentation outside the RFCs, and what is still on the backlog."
+---
+
+This page tracks how well the prose docs cover the accepted RFCs and the implemented engine and platform features. It exists so coverage gaps are visible and tracked, rather than discovered by accident. RFCs that are still Draft or Proposed are out of scope here; their own pages under [RFCs](/rfcs/) are the source of truth until they are accepted.
+
+## Accepted RFCs
+
+| RFC | Topic | Prose coverage |
+|-----|-------|----------------|
+| RFC-001 | YAML schema design | [Law Format](../concepts/law-format), [Schema](./schema) |
+| RFC-002 | Competent authority | [Competent Authority](../concepts/competent-authority) |
+| RFC-003 | Inversion of control | [Inversion of Control](../concepts/inversion-of-control) |
+| RFC-004 | Uniform operation syntax | [Law Format](../concepts/law-format) |
+| RFC-005 | Stand-off notes | [Notes and Annotations](../concepts/notes-and-annotations) |
+| RFC-006 | Language choice (Rust) | Backlog: the "why Rust" rationale has no prose page |
+| RFC-007 | Cross-law execution | [Hooks and Reactive Execution](../concepts/hooks-and-reactive-execution), [Traceability](../concepts/traceability) |
+| RFC-008 | Awb procedures | [Hooks and Reactive Execution](../concepts/hooks-and-reactive-execution) |
+| RFC-010 | Federated corpus | [Federated Corpus](../concepts/federated-corpus) |
+| RFC-011 | Rules language selection | Backlog: the "why custom YAML" rationale has no prose page |
+| RFC-012 | Untranslatables | [Untranslatables](../concepts/untranslatables) |
+| RFC-013 | Execution provenance | [Execution Provenance](../concepts/execution-provenance) |
+| RFC-014 | Conformance suite | [Conformance](./conformance) |
+| RFC-018 | Note infrastructure | [Notes and Annotations](../concepts/notes-and-annotations) |
+| RFC-019 | Law end dates | [Temporal Validity and Dates](../concepts/temporal-and-dates) |
+| RFC-021 | Date comparison | [Temporal Validity and Dates](../concepts/temporal-and-dates) |
+
+RFC-000 (the RFC process) is documented by [rfc-000](/rfcs/rfc-000) itself; the contributing guide links to it.
+
+## Backlog
+
+Accepted RFCs whose design rationale is not yet written up as prose:
+
+- **RFC-006 (why Rust)** and **RFC-011 (why custom YAML)** are both ratifications of language choices. A single "Design rationale" page covering both, drawing on the alternatives each RFC weighed, would close them together.
+
+Built features that work but are thin or absent in the docs, roughly in priority order:
+
+- **Editor collaboration**: trajects (create, invite members, roles, session branches) have a full backend and UI but no user-facing guide.
+- **Editor views**: the law-graph visualization with trace stepping, and the AI-suggestion panel, are gated behind feature flags and undocumented.
+- **WASM API surface**: the JavaScript bindings (`execute`, `executeWithTrace`, `executeMultiple`, `resolveNote`, `registerDataSource`, …) are an integration point with no reference page.
+- **Data sources**: registering tabular external data for execution is implemented but unexplained.
+- **TUI screens**, the **`evaluate`/`validate` CLI binaries**, the harvester's **CVDR** source, and the pipeline's **LLM-provider** selection are each implemented and lightly or never documented.
+
+When one of these gets a page, move it up into the table above.

--- a/docs/src/lib/sidebar.ts
+++ b/docs/src/lib/sidebar.ts
@@ -49,10 +49,14 @@ export const sidebar: Record<string, SidebarGroup[]> = {
         { text: 'Cross-Law References', link: '/concepts/cross-law-references' },
         { text: 'Inversion of Control', link: '/concepts/inversion-of-control' },
         { text: 'Hooks and Reactive Execution', link: '/concepts/hooks-and-reactive-execution' },
+        { text: 'Competent Authority', link: '/concepts/competent-authority' },
         { text: 'Multi-Org Execution', link: '/concepts/multi-org-execution' },
         { text: 'Federated Corpus', link: '/concepts/federated-corpus' },
+        { text: 'Notes and Annotations', link: '/concepts/notes-and-annotations' },
+        { text: 'Temporal Validity and Dates', link: '/concepts/temporal-and-dates' },
         { text: 'Untranslatables', link: '/concepts/untranslatables' },
         { text: 'Execution Provenance', link: '/concepts/execution-provenance' },
+        { text: 'Traceability', link: '/concepts/traceability' },
       ],
     },
     {
@@ -135,6 +139,8 @@ export const sidebar: Record<string, SidebarGroup[]> = {
       items: [
         { text: 'Glossary', link: '/reference/glossary' },
         { text: 'Schema', link: '/reference/schema' },
+        { text: 'Conformance', link: '/reference/conformance' },
+        { text: 'Documentation Coverage', link: '/reference/documentation-coverage' },
         { text: 'Accessibility', link: '/reference/accessibility' },
       ],
     },


### PR DESCRIPTION
## Waarom

Een audit van alle RFC's tegenover de prose-documentatie liet zien dat de **accepted** RFC's en een aantal gebouwde engine-features dun of niet gedekt waren buiten de RFC's zelf. Aanleiding was traceability: dat concept had vijf regels in `how-it-works` en geen eigen pagina, terwijl de engine een rijk trace-mechanisme heeft met echte voorbeelden.

Deze PR dicht de grootste gaten en zet de rest op een getrackte backlog. Draft- en proposed-RFC's blijven buiten scope; hun eigen pagina's zijn daarvoor de bron.

## Wat

Vijf nieuwe concept-/referentiepagina's plus een coveragematrix:

| Pagina | RFC('s) | Inhoud |
|--------|---------|--------|
| `concepts/traceability` | engine / RFC-007 | Hoe je een trace leest: node-types, de box-drawing-boom, en een echte zorgtoeslag-trace met cross-law-keten, IoC-delegatie, gecachet resultaat en twee Awb-hooks. Plus hoe je er zelf een genereert. |
| `concepts/competent-authority` | RFC-002 | Bevoegd gezag op artikelniveau: `name` + `type` (INSTANCE/CATEGORY) en de `#`-referentievorm. |
| `concepts/temporal-and-dates` | RFC-019, RFC-021 | Versieselectie met `valid_to` en eerlijke afhandeling van verlopen referenties; datumvergelijking en `DATE_DIFF`. |
| `concepts/notes-and-annotations` | RFC-005, RFC-018 | Stand-off notes, TextQuoteSelector, fuzzy matching en afgeleide autoriteit. |
| `reference/conformance` | RFC-014 | De taal-agnostische conformance-suite en wat er vandaag wordt afgedwongen. |
| `reference/documentation-coverage` | alle accepted | Per-RFC coveragematrix en de backlog. |

Daarnaast: de Traceability-sectie in `how-it-works` ingekort tot een verwijzing, en de nieuwe pagina's in de sidebar gezet.

## Grondslag van de voorbeelden

Alle voorbeelden komen uit artefacten die in deze repo staan en via tests in sync blijven, niet uit de externe corpus-repo:

- de trace-snapshot `packages/engine/tests/expected_zorgtoeslag_trace.txt` (gepind door een snapshot-test);
- de BDD-features `features/einddatum.feature`, `features/date_operations.feature`, `features/notes.feature`;
- de conformance-manifests onder `conformance/`;
- een echte annotatie in `corpus/annotations/wet_op_de_zorgtoeslag/annotations.yaml`.

De geciteerde trace- en gherkin-fragmenten zijn karakter-voor-karakter tegen de bron geverifieerd.

## Checks

- `npm run build` bouwt schoon (82 pagina's).
- `check-links.mjs`: geen kapotte interne links.
- `check-heading-order.mjs`: geen rang-sprongen.
- Pre-commit hooks groen.

## Backlog (apart, niet in deze PR)

`reference/documentation-coverage` legt vast wat nog mist: de "waarom Rust" (RFC-006) en "waarom YAML" (RFC-011) rationale, en kleinere ongedocumenteerde features (traject-samenwerking, law-graph, WASM-API, data-sources, TUI, CLI-binaries, CVDR-harvesting, LLM-provider).
