### PR TITLE
feat: regelrecht-uitvoeringstoets skill (dienstverlening-validatie)

### DIFF
--- a/.claude/skills/regelrecht-uitvoeringstoets/PLAN.md
+++ b/.claude/skills/regelrecht-uitvoeringstoets/PLAN.md
@@ -1,0 +1,285 @@
+# Planningsdocument — Skill `regelrecht-uitvoeringstoets`
+
+> Status: **plan / nog niet gebouwd**. Datum: 2026-06-16.
+> Basis voor een toekomstige skill-PR (engine-repo `.claude/skills`). Niets hiervan is
+> gepusht of geïmplementeerd; dit document is bedoeld om aan te scherpen.
+
+## 1. In één zin
+
+Een **workshop-format-skill** die uit een (semi-)gevalideerd corpus een geloofwaardige
+**service-PoC** genereert (burger- + behandelaar-portaal, of een headless beslis-service),
+en die PoC inzet als **validatie-instrument** om met uitvoeringsexperts inzichtelijk te
+maken wat nodig is om een wet **rechtvaardig in de praktijk** te brengen — gezien vanuit de
+betrokkene.
+
+## 2. These
+
+Een echt voelbare dienstverlening-demo maakt — beter dan een tekstanalyse — zichtbaar wat
+een wet *betekent als dienst*: welke last bij de burger ligt, waar menselijk oordeel zit,
+welke termijnen gelden, en waar de wet hard of onduidelijk is. Dat is precies het materiaal
+dat uitvoeringsexperts, juristen/beleid en ontwerpers nodig hebben om de uitvoering
+rechtvaardig in te richten. De PoC is dus **middel, geen doel** — maar moet zó goed zijn dat
+het "echt had kunnen zijn", anders valideert het niet eerlijk.
+
+## 3. Rol & plek in de skill-familie
+
+Een **vierde, zelfstandige skill** die als **fase 2** in de validatiereis zit — ná de
+logica-/scenario-validatie, niet in plaats daarvan:
+
+```
+regelrecht-stelselanalyse (desk)        → corpus correct & compleet
+        ↓
+regelrecht-audit-products (workshop A)  → logica + eerste scenario's/persona's gevalideerd, open vragen
+        ↓
+regelrecht-uitvoeringstoets (WORKSHOP B) → service-PoC + dienstverlening-validatie
+        ↓
+terug naar de desk / volgende corpus-ronde
+```
+
+- **Consumeert**: output van `regelrecht-stelselanalyse` (het corpus) en
+  `regelrecht-scenario-traces` (gevalideerde persona's/scenario's + keten-checkpoints).
+- **Levert aan**: de workshop-cyclus van `regelrecht-audit-products` (de PoC ís het
+  sessie-materiaal voor workshop B) en de bevindingen terug de cyclus in.
+- **Router**: `regelrecht-dossier` moet deze fase-2-plek leren kennen (routeert
+  service-/dienstverleningsvragen hierheen).
+
+Woont in de engine-repo `.claude/skills` (zelfde plek/PR-lijn als de andere, met de
+bestaande leak-guard).
+
+## 4. Naam
+
+`regelrecht-uitvoeringstoets` — sluit aan op de gevestigde overheidsterm "uitvoeringstoets".
+**Let op:** dit is *niet* de formele uitvoeringstoets-procedure; de skill levert materiaal
+dát een uitvoeringstoets-achtige validatie ondersteunt. Dat onderscheid expliciet benoemen
+in de skill-omschrijving.
+
+## 5. Eenheid van waarde
+
+Primair het **validatie-inzicht** (wat de demo blootlegt over rechtvaardige uitvoering),
+maar met een PoC die **production-credible** is. Een dun/clickable artefact volstaat
+daarom niet.
+
+## 6. Intellectuele kern — corpus-afleiding (signaal → service-spec → vorm)
+
+Geen vaste archetype-lijst die je kiest; de skill **leidt af wat de YAML's impliceren**. Het
+"archetype" is een *emergente samenvatting* van de gevonden dimensies, geen schakelaar. Dit
+maakt het echt casus-agnostisch: een nieuwe wet hoeft niet in een voorgebakken hokje te passen.
+
+| Corpus-signaal | Wat het impliceert voor de dienst |
+|---|---|
+| `hooks` (AANVRAAG / BEHANDELING / BESLUIT / BEKENDMAKING / BEZWAAR) | welke **levenscyclus-fasen** bestaan → procesflow + schermen |
+| `legal_character: BESCHIKKING` + `produces` | er is een **besluit** → motiveringsplicht, bekendmaking, bezwaar/beroep |
+| `untranslatables` | waar **menselijk oordeel** zit → de mens-taken-wachtrij |
+| caller-params (leaf-inputs), per leaf geclassificeerd naar *herkomst* | welke **gegevens** nodig zijn en *van wie* (burger / ander systeem / oordeel ambtenaar) → de last, en of een portaal zin heeft vs. vooraf-invullen |
+| `source:` / `implements:` | **ketensamenwerking** → andere partijen/systemen, data-herkomst |
+| `type_spec` (days / weeks / eurocent) | **termijnen & bedragen** in de dienst |
+| verzoek-param + AANVRAAG-hook (aan/afwezig) | **initiatie**: burger-geïnitieerd vs. ambtshalve vs. melding |
+
+Uit deze **service-spec** assembleert de skill de PoC: welke lenzen (burger / behandelaar /
+headless), welke schermen, welke taken-wachtrij, welke wat-als-schakelaars (de open vragen).
+
+**Afwezigheid is een bevinding.** Waar een signaal ontbreekt of dubbelzinnig is, zet de skill
+dat op de agenda voor workshop B:
+- geen BEZWAAR-hook → "is er echt geen bezwaarweg, of is het corpus incompleet?"
+- een leaf-param die niemand kan leveren → last-/uitvoerbaarheidsvraag
+- een untranslatable zonder duidelijke eigenaar → wie doet dit oordeel, en hoe?
+
+De afleiding produceert dus meteen het validatie-materiaal.
+
+## 7. Uitvoeringstoets-gereedheid — contract op het corpus
+
+De skill definieert de **minimale metadata** die een corpus nodig heeft om zinvol te
+genereren (bv. hooks aanwezig, legal_character gezet, caller-params met herkomst-hints,
+type_spec-units). Ontbreekt die: **soepel bouwen met markeringen** (zie §9) en het gat op de
+bevindingenlijst zetten — niet weigeren.
+
+## 8. De vijf stappen van de skill
+
+1. **Ingangscheck** — is de logica + ≥1 gevalideerd scenario/persona + open-vragen-register
+   aanwezig? Zo niet: waarschuwen en markeren, niet weigeren.
+2. **Afleiden** — service-spec uit corpus-signalen (§6) → tonen → bevestigen met de gebruiker.
+3. **Genereren** — PoC uit de **referentie-template-repo** + corpus-config, gevuld met de
+   gevalideerde persona's. Privacy-guards worden meegescaffold (§12).
+4. **Instrumenteren** — per scherm: artikel-herkomst, open vragen zichtbaar, wat-als-
+   schakelaars (een open beleidskeuze: variant A vs B), feedback-vangst, en eerlijkheid over
+   de grenzen (§13).
+5. **Faciliteren & oogsten** — sessie-draaiboek + facilitator-materiaal; verslag dat twee
+   kanalen voedt (§11).
+
+## 9. Ingangscontract — soepel met markeringen
+
+Draait ook op semi-gevalideerd corpus, maar markeert overal expliciet wat nog niet
+gevalideerd is. Die markeringen *zijn* validatie-materiaal. (Configureerbare strengheid is
+een mogelijk groeipad, niet v1.)
+
+## 10. Deelnemers van workshop B
+
+- **Uitvoeringsexperts** (beslisambtenaren / behandelaars) — de kern.
+- **Juristen / beleid** — voor de open beleidsvragen die de PoC blootlegt.
+- **Ontwerpers / dienstverlening** — voor begrijpelijkheid, last, toegankelijkheid.
+- **Groeipad (niet v1):** ervaringsdeskundigen / burgers — interessant, maar vraagt
+  zorgvuldige opzet; eerst de PoC's testen met bovenstaande rollen.
+
+## 11. Oogst — twee kanalen
+
+- **Wets-/logica-bevindingen** → terug naar `regelrecht-stelselanalyse` (desk-cyclus).
+- **Dienstverlening-bevindingen** → een apart **service-backlog** (last, begrijpelijkheid,
+  toegankelijkheid, proces-/interactiekeuzes).
+
+## 12. Verpakking — skill + referentie-template-repo
+
+- De **skill** orkestreert (afleiden, genereren, instrumenteren, faciliteren) en bevat het
+  sessie-format.
+- Een **casus-agnostische referentie-template-repo** levert de échte architectuur (engine =
+  rekenmeester, wet = procesflow, lenzen, RFC-013 receipts, append-only audit). Zo blijft het
+  "had kunnen zijn"-niveau hoog én het onderhoud voorspelbaar; §14 vat de onderhoudbaarheids-
+  eisen samen.
+- **Privacy-guards meegescaffold:** privé-repo-vereiste, fail-closed pre-push hook
+  (`check-remote-private.sh`-equivalent), fictieve data (fictieve test-BSN's), corpus-by-reference.
+
+## 12b. Hoe de referentie-template eruitziet
+
+**Kern-truc:** alles wat in een handgebouwde PoC hardcoded zou zitten, komt in de template uit
+een **gegenereerde service-spec**. De app-code is 100% casus-agnostisch; per wet verschilt
+alleen één gegenereerd configbestand + de redactionele B1-teksten. Het corpus blijft
+by-reference.
+
+**Drie lagen:**
+
+| Laag | Inhoud | Per casus? |
+|---|---|---|
+| Referentie-architectuur (de app) | engine=rekenmeester, levenscyclus-statemachine, lenzen/views, componenten, dialoog-flow, auth-adapter, receipts, guards, testharnas | nee — nooit |
+| Service-spec (`service.config.yaml`) | params/labels, lenzen, levenscyclus, keten, termijnen, mens-taken-bron, wat-als, open vragen | ja — **gegenereerd door de skill** |
+| Corpus | de wet-YAML's | by-reference (`CORPUS_DIR`) |
+
+**Repo-structuur (schets):**
+
+```
+regelrecht-service-template/
+├── Cargo.toml                # engine gePIND op release (geen path-dep)
+├── service.config.yaml       # ← gegenereerd: de enige casus-specifieke waarheid
+├── backend/src/
+│   ├── config.rs             # service-spec model
+│   ├── engine.rs             # generiek: law-id/outputs/keten uit config
+│   ├── lifecycle.rs          # fasen/termijnen/taken gedreven door hooks + config
+│   ├── db.rs + migrations/   # sqlx migrate (geen CREATE IF NOT EXISTS)
+│   ├── api.rs                # getypeerde DTO's (geen losse row→json)
+│   ├── dialoog.rs            # meedenk-flow (generiek)
+│   └── auth.rs               # IdP-adapter: mock ⇄ echte OIDC, pluggable
+│   └── tests/                # round-trip · contract · lifecycle
+├── frontend/src/
+│   ├── views/                # generieke intake/dossier/werkvoorraad/detail
+│   ├── components/           # stepper, live-trace, wet-uitleg, thread
+│   └── service-spec.js       # laadt de config
+├── scaffold/                 # privacy-guards die meegescaffold worden
+└── docs/service-spec.schema.md
+```
+
+**Service-spec — NEUTRAAL voorbeeld** (de template bevat géén echte casus-waarden;
+voorbeelden draaien tegen `regelrecht-corpus-dummy`):
+
+```yaml
+casus: <voorbeeld-casus>
+orchestrator_law: <hoofdregeling-id>
+
+lenzen: [proef, burger, behandelaar, meekijken]   # of [headless] bij ambtshalve/plugin
+levenscyclus:                                       # uit hooks
+  - { fase: AANVRAAG }
+  - { fase: BESLUIT, produceert_beschikking: true } # uit legal_character
+  - { fase: BEZWAAR }
+
+formulier:                                          # uit caller-params + type_spec
+  outputs: [<uitkomst-a>, <bedrag-b>]
+  groepen:
+    - kort: <groep>
+      velden:
+        - key: <leaf_param>
+          type: euro
+          herkomst: burger            # burger | ander_systeem | oordeel_ambtenaar
+          label: "<B1-label — redactie, te reviewen>"
+  gates: [...]                          # poortvragen
+  escalaties: [...]                     # toon_als-regels
+
+keten:                                  # uit source/implements
+  - { knoop: <tussenresultaat>, artikel: <regeling>_<art> }
+
+termijnen:                              # uit type_spec days/weeks
+  herstel: { output: <termijn-output>, unit: weeks }
+
+mens_taken_bron: { law: <regeling>, article: "<nr>" }   # uit untranslatables
+
+wat_als:                                # uit het open-vragen-register
+  - naam: "<open beleidskeuze>"
+    varianten: [{ label: "Variant A (corpus)" }, { label: "Variant B (praktijk)" }]
+open_vragen: [...]
+herkomst_annotaties: true
+```
+
+**Casus-neutraliteit / leak-preventie (expliciet):**
+- De template-repo én de skill-tekst bevatten **geen** casus-specifieke waarden en **geen
+  domein-vocabulaire** (geen organisatie-, belasting- of keten-termen die naar één casus
+  wijzen). Ook impliciete vingerafdrukken vermijden.
+- Voorbeelden en de "template draait"-demo gebruiken **`regelrecht-corpus-dummy`**.
+- Een **ingevulde** service-spec (voor een echte casus) wordt at-runtime gegenereerd en leeft
+  **alléén bij de gegenereerde (privé) PoC**, nooit in de publieke template of skill.
+- Dit document is zélf casus-agnostisch: geen organisatie-, repo-, belasting- of domeinnamen,
+  en geen verwijzing naar een specifieke eerdere build. Concrete waarden (law-ids, param- en
+  output-namen, bedragen) leven uitsluitend bij de gegenereerde (privé) PoC en de
+  service-spec — nooit in dit plan, de template of de skill.
+
+## 13. Eerlijkheid over de grenzen (ethisch, kern van "rechtvaardig")
+
+Een gelikte demo mag geen schijnzekerheid wekken. De PoC toont altijd expliciet:
+- fictieve data, geen productie, geen rechten te ontlenen;
+- **corpus-correct ≠ beleids-correct** (de wat-als-schakelaars maken openstaande
+  beleidskeuzes zichtbaar i.p.v. ze te verbergen);
+- waar menselijk oordeel onmisbaar is (de untranslatables), niet weggeautomatiseerd.
+
+## 14. Onderhoudbaarheids-eisen aan de template
+
+De template moet deze eisen inbakken, zodat de skill onderhoudbaar genereert (een naïef
+handgebouwde PoC schendt ze typisch):
+
+1. **Formulier-metadata uit corpus/engine** i.p.v. hardcoded veldgroepen/labels/param-namen
+   (tientallen hardcoded params → drift-risico).
+2. **Getypeerd API-contract** (gedeelde types / OpenAPI) i.p.v. ongetypeerde row→json-respons.
+3. **Regressienet als onderdeel van de template**: round-trip-tests op de conversies,
+   keten-checkpoint-waarden, en een **corpus-contracttest** (faalt zodra app en corpus
+   uiteenlopen).
+4. **Beslis-/mapping-logica uit de backend richting corpus** waar mogelijk (in een
+   handgebouwde PoC zit nog business-logica in de backend, bv. beslis-type-bepaling en
+   input-mappings — die hoort idealiter in het corpus/de engine).
+5. **Engine gepind op release** (niet path-dep naar lokale checkout) + corpus-versie in de
+   receipt; **migratieframework** i.p.v. ad-hoc tabel-creatie; echte DB/sessiestore.
+6. **Echte design-system-componenten** + geverifieerde toegankelijkheid (niet alleen
+   look-alike CSS).
+
+## 15. v1-scope
+
+- Ondersteunt in v1 eerst het archetype **aanvraag→beschikking**, maar de motor is de
+  afleiding (§6), niet het archetype — andere vormen emergeren naarmate meer wetten
+  erdoorheen gaan.
+- Headless beslis-service (plugin op een ander systeem) als strategisch interessantste tweede
+  vorm om de afleiding te testen — als snel groeipad, niet noodzakelijk in v1.
+
+## 16. Open punten / nog te beslissen
+
+1. Precieze afbakening van het **uitvoeringstoets-gereedheid-contract** (§7) — welke
+   metadata strikt vereist, welke optioneel.
+2. **Herkomst-classificatie van caller-params** (burger / ander systeem / oordeel): hoe
+   gecodeerd in het corpus? Nieuwe metadata, of af te leiden?
+3. **Naamgeving & locatie referentie-template-repo** (publiek-leeg-template vs. privé).
+4. Aansluiting op de bestaande **skills-PR (#785)**: zelfde PR of opvolger.
+5. Of de skill ook de **wat-als-schakelaars** automatisch uit het open-vragen-register
+   genereert, of dat de facilitator ze kiest.
+
+## 17. Beslist (samenvatting)
+
+- Naam: **`regelrecht-uitvoeringstoets`**.
+- Rol: **fase-2 workshop-format**, ná logica-/scenario-validatie.
+- Waarde: **validatie-inzicht**, met production-credible PoC.
+- Kern: **corpus-afleiding** (signaal → service-spec → vorm), archetype emergent.
+- Ingang: **soepel met markeringen**.
+- Deelnemers: **uitvoeringsexperts + juristen/beleid + ontwerpers**; burgers = groeipad.
+- Oogst: **twee kanalen** (desk + service-backlog).
+- Verpakking: **skill + referentie-template-repo**.

--- a/.claude/skills/regelrecht-uitvoeringstoets/SKILL.md
+++ b/.claude/skills/regelrecht-uitvoeringstoets/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: regelrecht-uitvoeringstoets
+description: Genereert uit een (semi-)gevalideerd regelrecht-corpus een geloofwaardige service-PoC (burger- + behandelaar-portaal, of een headless beslis-service) en zet die in als validatie-instrument met uitvoeringsexperts — om tastbaar te maken wat nodig is om een wet rechtvaardig in de praktijk te brengen, gezien vanuit de betrokkene. Gebruik dit als workshop-fase ná de logica-/scenariovalidatie (audit-products) om de dienstverlening-kant te valideren: welke service impliceert de wet, waar zit menselijk oordeel, welke last ligt bij de burger, welke termijnen, waar is de wet hard of onduidelijk. Dossier-agnostisch; de regelrecht-methode (hooks, legal_character, untranslatables, source/implements, type_spec, receipts) is de vaste taal. Voor de logica-/scenariovalidatie zelf: zie de zusterskill regelrecht-audit-products.
+allowed-tools: Read, Write, Edit, Grep, Glob, Bash, AskUserQuestion
+---
+
+# Regelrecht uitvoeringstoets — dienstverlening-validatie via een service-PoC
+
+Genereert uit een corpus een geloofwaardige **service-PoC** en zet die in als
+**validatie-instrument**: niet om een app op te leveren, maar om met uitvoeringsexperts
+inzichtelijk te maken wat nodig is om de wet **rechtvaardig in de praktijk** te brengen.
+De PoC is het middel; het **validatie-inzicht** is de uitkomst — maar de PoC moet zó goed
+zijn dat het "echt had kunnen zijn", anders valideert het niet eerlijk.
+
+> **Niet de formele uitvoeringstoets.** De naam sluit aan op de overheidsterm, maar deze
+> skill levert *materiaal dat een uitvoeringstoets-achtige validatie ondersteunt* — geen
+> formele toets-procedure.
+
+> **De familie + router.** Dit is **workshop-fase 2 (dienstverlening)**, ná de logica-/
+> scenariovalidatie. Logica valideren = `regelrecht-audit-products`. Desk-review/corpus-
+> completion = `regelrecht-stelselanalyse`. Casussen/persona's/traces = `regelrecht-
+> scenario-traces`. Twijfel je waar te beginnen → `regelrecht-dossier` (front-door router).
+
+## Geen casus-inhoud
+
+Deze skill is **dossier-agnostisch**. Hij bevat geen organisatie-, persoons-, functie-,
+of domeinnamen, geen concrete law-ids/param-namen/bedragen, en geen onderbouwingen uit een
+specifieke casus. Concrete waarden leven **uitsluitend** in het (privé) corpus en in de
+at-runtime gegenereerde service-spec van de (privé) PoC — nooit in deze skill of de
+referentie-template. Zie `references/definition-of-clean.md` (de leak-discipline) en houd je
+eraan bij élk gegenereerd of toegevoegd bestand.
+
+## Wanneer gebruiken
+
+- "De logica/scenario's zijn gevalideerd — laten we de **dienstverlening** valideren."
+- "Maak een service-PoC waarmee uitvoeringsexperts kunnen ervaren wat de wet voor betrokkenen betekent."
+- "Wat voor service impliceert deze wet — een zaaksysteem, een melding, een ambtshalve flow, of een headless beslis-service?"
+- "Maak workshop-materiaal (draaiboek) voor een dienstverlening-validatiesessie."
+- "Oogst de bevindingen van zo'n sessie en route ze terug de cyclus in."
+
+## Routing & handoff
+
+- **Instroom**: een corpus op minstens "logica-/scenario-gevalideerd of semi-gevalideerd"
+  niveau, plus ≥1 gevalideerd scenario/persona (uit `regelrecht-scenario-traces`) en het
+  open-vragen-register (uit `regelrecht-audit-products`/`-stelselanalyse`).
+- **Uitstroom (twee kanalen)**: wets-/logica-bevindingen → terug naar de desk
+  (`regelrecht-stelselanalyse`); dienstverlening-bevindingen (last, begrijpelijkheid,
+  toegankelijkheid, proces-/interactiekeuzes) → een apart service-backlog.
+
+## De methode — vijf stappen
+
+1. **Ingangscheck** — is de logica + ≥1 gevalideerd scenario/persona + open-vragen-register
+   aanwezig? Soepel: bij gaten **waarschuwen en markeren**, niet weigeren. De markeringen
+   zíjn validatie-materiaal. Het gereedheid-contract staat in `references/service-spec.md`.
+2. **Afleiden** — leid de **service-spec** af uit corpus-signalen (zie de afleidingstabel in
+   `references/service-spec.md`): hooks → levenscyclus; legal_character/produces → besluit
+   + bezwaar/beroep; untranslatables → mens-taken; caller-params + herkomst → de last en of
+   een portaal zinvol is; source/implements → ketensamenwerking; type_spec → termijnen.
+   Het **archetype** (aanvraag→beschikking, melding, ambtshalve, headless beslis-service) is
+   een *emergente samenvatting* van de gevonden dimensies, geen keuze vooraf. Toon → bevestig.
+3. **Genereren** — bouw de PoC uit de **referentie-template-repo** (de casus-agnostische
+   architectuur) + de gegenereerde service-spec, gevuld met de gevalideerde persona's. Scaffold
+   de privacy-guards mee (privé-repo-vereiste, fail-closed pre-push, fictieve data). Zie
+   `references/service-spec.md` voor het contract en de verpakking.
+4. **Instrumenteren** — maak de PoC tot validatie-instrument: per scherm artikel-herkomst,
+   open vragen zichtbaar, **wat-als-schakelaars** (een open beleidskeuze: variant A vs B),
+   feedback-vangst, en **eerlijkheid over de grenzen** (fictieve data; corpus-correct ≠
+   beleids-correct; menselijk oordeel niet wegautomatiseren).
+5. **Faciliteren & oogsten** — draai de sessie met `templates/workshop-draaiboek.md`
+   (deelnemers: uitvoeringsexperts + juristen/beleid + ontwerpers/dienstverlening; burgers/
+   ervaringsdeskundigen = bewust groeipad, niet standaard). Leg de uitkomst vast met
+   `templates/bevindingen-verslag.md` en route ze via de twee kanalen.
+
+## Afwezigheid is een bevinding
+
+Waar een corpus-signaal ontbreekt of dubbelzinnig is, genereer je geen aanname maar een
+**bevinding**: geen bezwaar-hook → "is er echt geen bezwaarweg, of is het corpus incompleet?";
+een param die niemand kan leveren → last-/uitvoerbaarheidsvraag; een untranslatable zonder
+eigenaar → wie doet dit oordeel, en hoe? De afleiding levert zo meteen de agenda voor de sessie.
+
+## Verpakking
+
+- **Deze skill** orkestreert (afleiden, genereren, instrumenteren, faciliteren).
+- De **referentie-template-repo** levert de échte, casus-agnostische architectuur (engine =
+  rekenmeester, wet = procesflow, lenzen, receipts, append-only audit). Casus-specifieke
+  waarden komen uit de gegenereerde service-spec, niet uit de template. Zie
+  `references/service-spec.md`.
+
+## Ontwerp & rationale
+
+De volledige ontwerpredenering (waarom fase-2, de eenheid-van-waarde, de afleiding als kern,
+de onderhoudbaarheids-eisen aan de template) staat in `PLAN.md` naast dit bestand.

--- a/.claude/skills/regelrecht-uitvoeringstoets/references/definition-of-clean.md
+++ b/.claude/skills/regelrecht-uitvoeringstoets/references/definition-of-clean.md
@@ -1,0 +1,47 @@
+# Definition-of-clean — de leak-discipline
+
+Alles wat deze skill genereert of toevoegt aan een publiek-bestemde laag (deze skill, de
+referentie-template) moet **casus-agnostisch** zijn. De gegenereerde PoC en zijn ingevulde
+service-spec zijn casus-specifiek en horen **uitsluitend** in privé-ruimte (privé-repo,
+fictieve data).
+
+## De vier categorieën die nooit in een publieke laag mogen
+
+1. **Casus-onderbouwingen** — domein-vocabulaire of voorbeelden die naar één casus wijzen,
+   ook geparafraseerd.
+2. **Casus-namen** — namen van wetten/regelingen/dossiers die een specifieke casus aanduiden.
+3. **Persoonsnamen** — inclusief persona-aanduidingen.
+4. **Organisatie-/functienamen** — organisaties, bestuursorganen, functietitels.
+
+Generieke methode-/rollentermen mogen wél (bv. *behandelaar, jurist, ontwerper,
+uitvoeringsexpert, corpus, engine, untranslatable, PoC als concept*) — mits ze geen
+specifieke casus verraden.
+
+## Gelaagde borging (van sterk naar aanvullend)
+
+1. **Structurele scheiding (primair)** — casus-specifieke waarden (law-ids, param-/output-
+   namen, bedragen, onderbouwingen) bestaan alleen in het privé-corpus + de gegenereerde
+   (privé) PoC. De publieke lagen hebben er **geen slot** voor: alleen placeholders/config-
+   sleutels, at-runtime gevuld. Dan is er categorisch niets te lekken.
+2. **Vorm-heuristiek** — scan op de *vorm* van casus-inhoud, ongeacht welke casus:
+   identifier-achtige nummerreeksen, code-patronen, law-id-vormen, bedragen in
+   voorbeeldposities, "aanhef + Hoofdletternaam" voor personen.
+3. **Allowlist van placeholders** — definieer wat in voorbeeld-/configposities wél mag
+   (`<law-id>`, `<param>`, een dummy-corpus, de generieke rollen); vlag de rest.
+4. **Semantisch vangnet** — een adversariële review (mens of LLM) die geparafraseerde/
+   impliciete verwijzingen vangt die regex mist.
+
+## Enforcement
+
+- Plaats publieke artefacten zo dat de repo-leak-guard ze scant (`.claude/skills/…`).
+- De guard is een **denylist** (snelle eerste filter) en draait in **pre-commit én CI** —
+  dus de PR wordt server-side gecontroleerd, niet alleen lokaal.
+- Een denylist is reactief; combineer 'm daarom met laag 1–4 hierboven. Voeg per nieuw
+  dossier de concrete markers toe aan de denylist.
+
+## Checklist vóór publiceren
+
+- [ ] Geen treffers op de vier categorieën (handmatig + guard).
+- [ ] Voorbeelden gebruiken placeholders / een dummy-corpus, geen echte waarden.
+- [ ] Geen verwijzing naar een specifieke build, sessie of traject.
+- [ ] Semantische review uitgevoerd (laag 4) bij twijfel.

--- a/.claude/skills/regelrecht-uitvoeringstoets/references/service-spec.md
+++ b/.claude/skills/regelrecht-uitvoeringstoets/references/service-spec.md
@@ -33,7 +33,7 @@ zetten (afwezigheid is een bevinding). Niet weigeren.
 
 ## 3. Het contract (neutraal voorbeeld)
 
-Zie `templates/service-spec.example.yaml` voor een volledig, **neutraal** voorbeeld met
+Zie `templates/service-spec.example.md` voor een volledig, **neutraal** voorbeeld met
 placeholders. De spec bevat o.a.: `lenzen`, `levenscyclus`, `formulier` (groepen/velden met
 `herkomst` + B1-`label`, gates, escalaties), `keten` (knoop → artikel), `termijnen`,
 `mens_taken_bron`, `wat_als`, `open_vragen`, `herkomst_annotaties`.

--- a/.claude/skills/regelrecht-uitvoeringstoets/references/service-spec.md
+++ b/.claude/skills/regelrecht-uitvoeringstoets/references/service-spec.md
@@ -1,0 +1,60 @@
+# Service-spec — afleiding, contract & verpakking
+
+De **service-spec** is het enige casus-specifieke bestand: één gegenereerde configuratie die
+de PoC stuurt. De referentie-architectuur (app-code) is 100% casus-agnostisch; per wet
+verschilt alleen deze spec + de redactionele B1-teksten. Het corpus blijft by-reference.
+
+## 1. Afleiding — corpus-signaal → service-spec
+
+Geen vaste archetype-lijst; leid de dienst af uit wat de YAML's impliceren. Het archetype is
+een *emergente samenvatting*, geen schakelaar.
+
+| Corpus-signaal | Implicatie voor de dienst |
+|---|---|
+| `hooks` (AANVRAAG / BEHANDELING / BESLUIT / BEKENDMAKING / BEZWAAR) | de levenscyclus-fasen → procesflow + schermen |
+| `legal_character` (besluit) + `produces` | er is een besluit → motiveringsplicht, bekendmaking, bezwaar/beroep |
+| `untranslatables` | waar menselijk oordeel zit → de mens-taken-wachtrij |
+| caller-params (leaf-inputs) + herkomst-classificatie | welke gegevens nodig zijn en *van wie* (burger / ander systeem / oordeel) → de last, en of een burgerportaal zinvol is vs. vooraf-invullen |
+| `source:` / `implements:` | ketensamenwerking → andere partijen/systemen, data-herkomst |
+| `type_spec` (days / weeks / bedrag-eenheden) | termijnen & bedragen in de dienst |
+| aanwezigheid initiatie-param + AANVRAAG-hook | initiatie: burger-geïnitieerd vs. ambtshalve vs. melding |
+
+**Emergente archetypen** (samenvattingen, geen invoer): aanvraag→beschikking · melding/
+registratie · ambtshalve oplegging · **headless beslis-service** (geen eigen portaal — een
+beslis-/uitleg-/trace-API als formele plugin op een ander systeem). Vindt de afleiding geen
+burger-initiatie → `lenzen: [headless]`.
+
+## 2. Gereedheid-contract op het corpus
+
+Minimaal nodig om zinvol te genereren: hooks aanwezig, besluit-karakter gezet waar van
+toepassing, caller-params met herkomst-hint, type_spec-eenheden op termijn-/bedrag-outputs.
+Ontbreekt iets → **soepel genereren met markeringen** en het gat op de bevindingenlijst
+zetten (afwezigheid is een bevinding). Niet weigeren.
+
+## 3. Het contract (neutraal voorbeeld)
+
+Zie `templates/service-spec.example.yaml` voor een volledig, **neutraal** voorbeeld met
+placeholders. De spec bevat o.a.: `lenzen`, `levenscyclus`, `formulier` (groepen/velden met
+`herkomst` + B1-`label`, gates, escalaties), `keten` (knoop → artikel), `termijnen`,
+`mens_taken_bron`, `wat_als`, `open_vragen`, `herkomst_annotaties`.
+
+## 4. Verpakking — drie lagen
+
+| Laag | Inhoud | Per casus? |
+|---|---|---|
+| Referentie-architectuur (de app) | engine=rekenmeester, levenscyclus-statemachine, lenzen/views, componenten, dialoog-flow, auth-adapter, receipts, guards, testharnas | nee — nooit |
+| Service-spec (`service.config.yaml`) | params/labels, lenzen, levenscyclus, keten, termijnen, mens-taken-bron, wat-als | ja — gegenereerd |
+| Corpus | de wet-YAML's | by-reference |
+
+## 5. Onderhoudbaarheids-eisen aan de template
+
+De template moet deze inbakken (een naïef handgebouwde PoC schendt ze typisch):
+
+1. **Formulier-metadata uit corpus/engine** i.p.v. hardcoded veldgroepen/labels/param-namen.
+2. **Getypeerd API-contract** (gedeelde types / OpenAPI) i.p.v. ongetypeerde respons.
+3. **Regressienet**: round-trip-tests op de conversies, keten-checkpoint-waarden, en een
+   **corpus-contracttest** (faalt zodra app en corpus uiteenlopen).
+4. **Beslis-/mapping-logica richting corpus** waar mogelijk (niet in de backend hardcoden).
+5. **Engine gepind op release** + corpus-versie in de receipt; **migratieframework**; echte
+   DB/sessiestore.
+6. **Echte design-system-componenten** + geverifieerde toegankelijkheid.

--- a/.claude/skills/regelrecht-uitvoeringstoets/templates/bevindingen-verslag.md
+++ b/.claude/skills/regelrecht-uitvoeringstoets/templates/bevindingen-verslag.md
@@ -1,0 +1,43 @@
+# Bevindingen — dienstverlening-validatiesessie (workshop B)
+
+> Casus-agnostisch sjabloon. Vul casus-context in vanuit de casus-map.
+
+## Samenvatting
+- **Sessie / deelnemers (rollen):** …
+- **Corpus-stand:** … (gevalideerd / semi-gevalideerd; welke markeringen stonden aan)
+- **Kernconclusie:** wat is nodig om dit rechtvaardig in de praktijk te brengen?
+
+## Bevindingen — twee kanalen
+
+De oogst splitst naar twee kanalen, zodat elk in de juiste cyclus landt.
+
+### A. Wets-/logica-bevindingen → desk (`regelrecht-stelselanalyse`)
+Feitelijke onjuistheden, ontbrekende paden, of corpus-gaten die de afleiding blootlegde.
+
+| # | Bevinding | Bron (artikel/signaal) | Soort (modelfout / corpus-gat / open beleidskeuze) | Actie |
+|---|---|---|---|---|
+| 1 | … | … | … | … |
+
+### B. Dienstverlening-bevindingen → service-backlog
+Last bij de burger, begrijpelijkheid, toegankelijkheid, proces-/interactiekeuzes,
+plekken waar de wet hard/onduidelijk uitpakt voor betrokkenen.
+
+| # | Bevinding | Scherm/stap | Impact op betrokkene | Voorstel |
+|---|---|---|---|---|
+| 1 | … | … | … | … |
+
+## Open beleidskeuzes (wat-als)
+Per getoonde variant: het effect op de uitkomst, het standpunt van de experts, en de
+grondslag-/beslisvraag die nog openstaat.
+
+| Keuze | Variant A | Variant B | Effect | Wie beslist / grondslag |
+|---|---|---|---|---|
+| … | … | … | … | … |
+
+## Mens-in-de-lus
+Per untranslatable: wie het oordeel doet, waarop, en hoe het richting de betrokkene wordt
+uitgelegd. Knelpunten en benodigde ondersteuning.
+
+## Vervolg
+- Terug de cyclus in (kanaal A → desk; kanaal B → service-backlog).
+- Eventuele volgende PoC-iteratie of vervolgsessie.

--- a/.claude/skills/regelrecht-uitvoeringstoets/templates/service-spec.example.md
+++ b/.claude/skills/regelrecht-uitvoeringstoets/templates/service-spec.example.md
@@ -1,8 +1,11 @@
-# NEUTRAAL voorbeeld van een service-spec (geen echte casus-waarden).
-# De skill genereert een ingevulde versie hiervan uit het corpus; die ingevulde
-# versie leeft uitsluitend bij de (privé) PoC, nooit in deze skill of de template.
-# Voorbeelden/demo's draaien tegen een dummy-corpus.
+# Service-spec — neutraal voorbeeld
 
+Illustratief voorbeeld met **placeholders** (geen echte casus-waarden). De skill genereert
+een ingevulde versie hiervan uit het corpus; die ingevulde versie leeft uitsluitend bij de
+(privé) PoC, nooit in deze skill of de template. Voorbeelden/demo's draaien tegen een
+dummy-corpus. Zie `references/service-spec.md` voor het contract en de afleiding.
+
+```yaml
 casus: <voorbeeld-casus>
 orchestrator_law: <hoofdregeling-id>
 
@@ -39,3 +42,4 @@ wat_als:                                            # uit het open-vragen-regist
     varianten: [{ label: "Variant A (corpus)" }, { label: "Variant B (praktijk)" }]
 open_vragen: []
 herkomst_annotaties: true
+```

--- a/.claude/skills/regelrecht-uitvoeringstoets/templates/service-spec.example.yaml
+++ b/.claude/skills/regelrecht-uitvoeringstoets/templates/service-spec.example.yaml
@@ -1,0 +1,41 @@
+# NEUTRAAL voorbeeld van een service-spec (geen echte casus-waarden).
+# De skill genereert een ingevulde versie hiervan uit het corpus; die ingevulde
+# versie leeft uitsluitend bij de (privé) PoC, nooit in deze skill of de template.
+# Voorbeelden/demo's draaien tegen een dummy-corpus.
+
+casus: <voorbeeld-casus>
+orchestrator_law: <hoofdregeling-id>
+
+lenzen: [proef, burger, behandelaar, meekijken]   # of [headless] bij ambtshalve/plugin
+
+levenscyclus:                                       # uit hooks
+  - { fase: AANVRAAG }
+  - { fase: BESLUIT, produceert_beschikking: true } # uit legal_character
+  - { fase: BEZWAAR }
+
+formulier:                                          # uit caller-params + type_spec
+  outputs: [<uitkomst-a>, <bedrag-b>]
+  groepen:
+    - kort: <groep>
+      velden:
+        - key: <leaf_param>
+          type: euro                                # of: getal | keuze | ja_nee
+          herkomst: burger                          # burger | ander_systeem | oordeel
+          label: "<B1-label — redactie, te reviewen>"
+  gates: []                                         # poortvragen (progressive disclosure)
+  escalaties: []                                    # toon_als-regels (regel-escalatie)
+
+keten:                                              # uit source/implements
+  - { knoop: <tussenresultaat>, artikel: <regeling>_<art> }
+
+termijnen:                                          # uit type_spec days/weeks
+  herstel: { output: <termijn-output>, unit: weeks }
+
+mens_taken_bron: { law: <regeling>, article: "<nr>" }   # uit untranslatables
+
+# validatie-instrumentatie
+wat_als:                                            # uit het open-vragen-register
+  - naam: "<open beleidskeuze>"
+    varianten: [{ label: "Variant A (corpus)" }, { label: "Variant B (praktijk)" }]
+open_vragen: []
+herkomst_annotaties: true

--- a/.claude/skills/regelrecht-uitvoeringstoets/templates/workshop-draaiboek.md
+++ b/.claude/skills/regelrecht-uitvoeringstoets/templates/workshop-draaiboek.md
@@ -1,0 +1,41 @@
+# Draaiboek — dienstverlening-validatiesessie (workshop B)
+
+> Vul de casus-context in vanuit de aangeleverde casus-map; dit draaiboek zelf blijft
+> casus-agnostisch.
+
+## Doel
+Met de service-PoC tastbaar maken wat de wet als **dienst** betekent, en vaststellen wat
+nodig is om 'm **rechtvaardig in de praktijk** te brengen — gezien vanuit de betrokkene.
+Niet de logica valideren (dat is workshop A), maar de dienstverlening.
+
+## Wanneer
+Ná de logica-/scenariovalidatie, op een (semi-)gevalideerd corpus.
+
+## Deelnemers
+- **Uitvoeringsexperts** (behandelaars / beslissers) — de kern.
+- **Juristen / beleid** — voor de open beleidsvragen die de PoC blootlegt.
+- **Ontwerpers / dienstverlening** — voor begrijpelijkheid, last, toegankelijkheid.
+- *Groeipad (niet standaard):* ervaringsdeskundigen/burgers — vraagt zorgvuldige opzet.
+
+## Voorbereiding
+- [ ] Service-PoC gegenereerd en draaiend (gevuld met gevalideerde persona's).
+- [ ] Wat-als-schakelaars klaargezet voor de open beleidskeuzes.
+- [ ] Per scherm artikel-herkomst + open vragen zichtbaar.
+- [ ] Feedback-vangst aan (zodat opmerkingen per scherm gevangen worden).
+- [ ] Eerlijkheids-banner zichtbaar (fictieve data; corpus-correct ≠ beleids-correct).
+
+## Programma (indicatief, ~2 uur)
+1. **Kader (10 min)** — doel, wat we wél/niet valideren, eerlijkheid over de grenzen.
+2. **Doorloop per persona (3×20 min)** — laat de dienst doorlopen door de ogen van de
+   betrokkene. Per stap: *klopt dit als dienst? wat vragen we de burger? is dat redelijk?
+   waar zou iemand vastlopen?* Noteer per scherm.
+3. **Mens-in-de-lus (20 min)** — bij elke untranslatable: *wie doet dit oordeel, waarop, en
+   hoe leg je het uit?*
+4. **Wat-als (20 min)** — toon de open beleidskeuzes (variant A vs B) en het effect op de
+   uitkomst. Wat is rechtvaardig, en wat is de grondslag?
+5. **Oogst (15 min)** — clusteren naar twee kanalen (zie `bevindingen-verslag.md`).
+
+## Facilitatie-principes
+- De PoC is gespreksmateriaal, geen eindproduct — nodig uit tot kritiek.
+- "Afwezigheid is een bevinding": ontbrekende paden/velden zijn juist gespreksstof.
+- Houd de betrokkene centraal: last, begrijpelijkheid, en rechtvaardigheid boven volledigheid.


### PR DESCRIPTION
Nieuwe dossier-agnostische skill **regelrecht-uitvoeringstoets**: genereert uit een (semi-)gevalideerd corpus een geloofwaardige service-PoC en zet die in als validatie-instrument met uitvoeringsexperts — een workshop-fase ná de logica-/scenariovalidatie, om de dienstverlening-kant te valideren.

**Inhoud** (`.claude/skills/regelrecht-uitvoeringstoets/`):
- `SKILL.md` — de methode (5 stappen: ingangscheck → afleiden → genereren → instrumenteren → faciliteren/oogsten).
- `references/service-spec.md` — corpus-signaal → service-spec-afleiding, contract, verpakking, onderhoudbaarheids-eisen.
- `references/definition-of-clean.md` — de leak-discipline (vier categorieën + gelaagde borging).
- `templates/` — neutraal service-spec-voorbeeld, workshop-draaiboek, bevindingen-verslag.
- `PLAN.md` — ontwerp & rationale.

**Borging:** volledig casus-agnostisch; passeert de casus-leak-guard (lokaal + CI), brede scan en semantische review schoon.

**Draft:** bedoeld om te lezen/aanscherpen. De referentie-template-repo (de echte generatie-backend) is een apart vervolgspoor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)