### PR TITLE
feat: zelfstandige trajectkeuze-pagina + pijltjesnavigatie op de lijsten

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@cucumber/gherkin": "^40.0.0",
         "@cucumber/messages": "^33.0.2",
-        "@nldd/design-system": "^0.8.62",
+        "@nldd/design-system": "^0.8.63",
         "@tiptap/core": "^3.26.1",
         "@tiptap/starter-kit": "^3.26.1",
         "@tiptap/vue-3": "^3.26.1",
@@ -556,9 +556,9 @@
       }
     },
     "node_modules/@nldd/design-system": {
-      "version": "0.8.62",
-      "resolved": "https://registry.npmjs.org/@nldd/design-system/-/design-system-0.8.62.tgz",
-      "integrity": "sha512-1roLjgSWvz6+lJg8ILYMXEysXVk/VrJAeHr0Oor6bbM4PTGcU4Ape8nhqXZIOw23dlqH2hWxjX4pfIRD8inkZQ==",
+      "version": "0.8.63",
+      "resolved": "https://registry.npmjs.org/@nldd/design-system/-/design-system-0.8.63.tgz",
+      "integrity": "sha512-iTqZZtfcDt42vVP2dkNbrUi/U+vuGRkLL7LGgnJULm4Hl9XxIHEOR1CpvW3DnOE+nLRyally/mEhhQopfglubg==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@floating-ui/dom": "^1.7.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@cucumber/gherkin": "^40.0.0",
     "@cucumber/messages": "^33.0.2",
-    "@nldd/design-system": "^0.8.62",
+    "@nldd/design-system": "^0.8.63",
     "@tiptap/core": "^3.26.1",
     "@tiptap/starter-kit": "^3.26.1",
     "@tiptap/vue-3": "^3.26.1",

--- a/frontend/src/AppShell.vue
+++ b/frontend/src/AppShell.vue
@@ -95,12 +95,18 @@ const { lastSavedPr, documentTabs, activeDocumentTab, tabActions, editorChanges,
 const viewport = ref('lg'); // 'sm' | 'md' | 'lg', aligned with the DS bar breakpoints
 let mdQuery = null;
 let lgQuery = null;
+// DS bar breakpoints, mirrored here for matchMedia. Keep in sync with
+// @nldd/design-system (src/assets/styles/breakpoints.ts): md >= 641px, lg >= 1008px.
+// If the DS shifts these thresholds, update them here too — otherwise the
+// coach-mark can anchor to a control that is hidden at the current breakpoint.
+const DS_MD_MIN = '(min-width: 641px)';
+const DS_LG_MIN = '(min-width: 1008px)';
 function updateViewport() {
   viewport.value = lgQuery?.matches ? 'lg' : mdQuery?.matches ? 'md' : 'sm';
 }
 onMounted(() => {
-  mdQuery = window.matchMedia?.('(min-width: 641px)') || null;
-  lgQuery = window.matchMedia?.('(min-width: 1008px)') || null;
+  mdQuery = window.matchMedia?.(DS_MD_MIN) || null;
+  lgQuery = window.matchMedia?.(DS_LG_MIN) || null;
   updateViewport();
   mdQuery?.addEventListener?.('change', updateViewport);
   lgQuery?.addEventListener?.('change', updateViewport);

--- a/frontend/src/AppShell.vue
+++ b/frontend/src/AppShell.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed } from 'vue';
+import { computed, ref, onMounted, onBeforeUnmount } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import TrajectMenu from './components/TrajectMenu.vue';
 import TrajectDocuments from './components/TrajectDocuments.vue';
@@ -66,8 +66,52 @@ const editorTabTarget = computed(() =>
 const libraryTabHref = computed(() => router.resolve(libraryTabTarget.value).href);
 const editorTabHref = computed(() => router.resolve(editorTabTarget.value).href);
 
+// The editor requires login. Rather than letting the route guard bounce an
+// unauthenticated user straight to the SSO screen (an unannounced surprise),
+// intercept the Editor tab and first show a small login-warning popover anchored
+// to the clicked tab. Authenticated users navigate as before.
+const loginWarning = ref(null);
+function onEditorTab(e) {
+  if (!authenticated.value) {
+    if (loginWarning.value) {
+      loginWarning.value.anchorElement = e.currentTarget;
+      loginWarning.value.show();
+    }
+    return;
+  }
+  if (isLibraryRoute.value) router.push(editorTabTarget.value);
+}
+
 // View-specific toolbar bits published by the active view.
-const { lastSavedPr, documentTabs, activeDocumentTab, tabActions, editorChanges, editorActions } = useAppChrome();
+const { lastSavedPr, documentTabs, activeDocumentTab, tabActions, editorChanges, editorActions, libraryEmpty } = useAppChrome();
+
+// Just-in-time coach-mark on the toolbar search affordance: shown only while the
+// library is empty (nothing curated yet) and never dismissable — the app drives
+// it, and it disappears by itself once the library has content. Each breakpoint
+// renders its search control in a different bar (sm icon-button, md text button,
+// lg search field), each in a pane that is display:none off-breakpoint. So we
+// resolve the active breakpoint and activate only the coach-mark whose control
+// is actually visible, never anchoring a popover to a hidden control.
+const viewport = ref('lg'); // 'sm' | 'md' | 'lg', aligned with the DS bar breakpoints
+let mdQuery = null;
+let lgQuery = null;
+function updateViewport() {
+  viewport.value = lgQuery?.matches ? 'lg' : mdQuery?.matches ? 'md' : 'sm';
+}
+onMounted(() => {
+  mdQuery = window.matchMedia?.('(min-width: 641px)') || null;
+  lgQuery = window.matchMedia?.('(min-width: 1008px)') || null;
+  updateViewport();
+  mdQuery?.addEventListener?.('change', updateViewport);
+  lgQuery?.addEventListener?.('change', updateViewport);
+});
+onBeforeUnmount(() => {
+  mdQuery?.removeEventListener?.('change', updateViewport);
+  lgQuery?.removeEventListener?.('change', updateViewport);
+});
+const showSearchHintSm = computed(() => libraryEmpty.value && viewport.value === 'sm');
+const showSearchHintMd = computed(() => libraryEmpty.value && viewport.value === 'md');
+const showSearchHintLg = computed(() => libraryEmpty.value && viewport.value === 'lg');
 
 // Editor with open tabs → the mobile traject row splits 50/50 to fit a tabs
 // button next to the traject menu, and the md+ document-tab-bar shows. The
@@ -92,7 +136,7 @@ const hasDocumentTabs = computed(
             <nldd-toolbar-item slot="start">
               <nldd-tab-bar size="md" navigation>
                 <nldd-tab-bar-item :selected="isLibraryRoute || undefined" :href="isLibraryRoute ? undefined : libraryTabHref" @click.prevent="isLibraryRoute || router.push(libraryTabTarget)" text="Bibliotheek"></nldd-tab-bar-item>
-                <nldd-tab-bar-item :selected="!isLibraryRoute || undefined" :href="isLibraryRoute ? editorTabHref : undefined" @click.prevent="isLibraryRoute && router.push(editorTabTarget)" text="Editor"></nldd-tab-bar-item>
+                <nldd-tab-bar-item :selected="!isLibraryRoute || undefined" :href="authenticated && isLibraryRoute ? editorTabHref : undefined" @click.prevent="onEditorTab" text="Editor"></nldd-tab-bar-item>
               </nldd-tab-bar>
             </nldd-toolbar-item>
             <nldd-toolbar-item v-if="lastSavedPr" slot="end">
@@ -101,7 +145,15 @@ const hasDocumentTabs = computed(
               <nldd-button size="md" start-icon="external-link" :text="`PR #${lastSavedPr.number}`" :href="lastSavedPr.url" target="_blank" rel="noopener"></nldd-button>
             </nldd-toolbar-item>
             <nldd-toolbar-item slot="end">
-              <nldd-button size="md" start-icon="search" text="Zoeken" @click="openSearch"></nldd-button>
+              <nldd-just-in-time-education
+                placement="bottom"
+                arrow-length="160px"
+                text="Zoek een wet om te openen"
+                supporting-text="Markeer een wet als favoriet om die later snel terug te vinden."
+                :active="showSearchHintMd || undefined"
+              >
+                <nldd-button size="md" start-icon="search" text="Zoeken" @click="openSearch"></nldd-button>
+              </nldd-just-in-time-education>
             </nldd-toolbar-item>
             <nldd-toolbar-item slot="end">
               <TrajectMenu id-suffix="md" />
@@ -132,7 +184,7 @@ const hasDocumentTabs = computed(
                 </nldd-menu-group>
                 <nldd-menu-divider></nldd-menu-divider>
                 <nldd-menu-item v-if="!authLoading && authenticated" text="Uitloggen" icon="logout" @click="logout"></nldd-menu-item>
-                <nldd-menu-item v-else-if="!authLoading && oidcConfigured" text="Inloggen" @click="login()"></nldd-menu-item>
+                <nldd-menu-item v-else-if="!authLoading && oidcConfigured" text="Inloggen" icon="login" @click="login()"></nldd-menu-item>
               </nldd-menu>
             </nldd-toolbar-item>
           </nldd-toolbar>
@@ -146,16 +198,24 @@ const hasDocumentTabs = computed(
             <nldd-toolbar-item slot="start">
               <nldd-tab-bar size="md" navigation>
                 <nldd-tab-bar-item :selected="isLibraryRoute || undefined" :href="isLibraryRoute ? undefined : libraryTabHref" @click.prevent="isLibraryRoute || router.push(libraryTabTarget)" text="Bibliotheek"></nldd-tab-bar-item>
-                <nldd-tab-bar-item :selected="!isLibraryRoute || undefined" :href="isLibraryRoute ? editorTabHref : undefined" @click.prevent="isLibraryRoute && router.push(editorTabTarget)" text="Editor"></nldd-tab-bar-item>
+                <nldd-tab-bar-item :selected="!isLibraryRoute || undefined" :href="authenticated && isLibraryRoute ? editorTabHref : undefined" @click.prevent="onEditorTab" text="Editor"></nldd-tab-bar-item>
               </nldd-tab-bar>
             </nldd-toolbar-item>
             <nldd-toolbar-item slot="center" min-width="240px" width="33%" max-width="480px">
-              <nldd-search-field
-                size="md"
-                placeholder="Zoeken"
-                @click="openSearch"
-                @keydown="onBarSearchKeydown"
-              ></nldd-search-field>
+              <nldd-just-in-time-education
+                placement="bottom"
+                arrow-length="160px"
+                text="Zoek een wet om te openen"
+                supporting-text="Markeer een wet als favoriet om die later snel terug te vinden."
+                :active="showSearchHintLg || undefined"
+              >
+                <nldd-search-field
+                  size="md"
+                  placeholder="Zoeken"
+                  @click="openSearch"
+                  @keydown="onBarSearchKeydown"
+                ></nldd-search-field>
+              </nldd-just-in-time-education>
             </nldd-toolbar-item>
             <nldd-toolbar-item v-if="lastSavedPr" slot="end">
               <nldd-button size="md" start-icon="external-link" :text="`PR #${lastSavedPr.number}`" :href="lastSavedPr.url" target="_blank" rel="noopener"></nldd-button>
@@ -189,7 +249,7 @@ const hasDocumentTabs = computed(
                 </nldd-menu-group>
                 <nldd-menu-divider></nldd-menu-divider>
                 <nldd-menu-item v-if="!authLoading && authenticated" text="Uitloggen" icon="logout" @click="logout"></nldd-menu-item>
-                <nldd-menu-item v-else-if="!authLoading && oidcConfigured" text="Inloggen" @click="login()"></nldd-menu-item>
+                <nldd-menu-item v-else-if="!authLoading && oidcConfigured" text="Inloggen" icon="login" @click="login()"></nldd-menu-item>
               </nldd-menu>
             </nldd-toolbar-item>
           </nldd-toolbar>
@@ -326,18 +386,22 @@ const hasDocumentTabs = computed(
             <nldd-toolbar-item slot="start">
               <nldd-tab-bar navigation>
                 <nldd-tab-bar-item :selected="isLibraryRoute || undefined" :href="isLibraryRoute ? undefined : libraryTabHref" @click.prevent="isLibraryRoute || router.push(libraryTabTarget)" icon="books" text="Bibliotheek"></nldd-tab-bar-item>
-                <nldd-tab-bar-item :selected="!isLibraryRoute || undefined" :href="isLibraryRoute ? editorTabHref : undefined" @click.prevent="isLibraryRoute && router.push(editorTabTarget)" icon="edit" text="Editor"></nldd-tab-bar-item>
+                <nldd-tab-bar-item :selected="!isLibraryRoute || undefined" :href="authenticated && isLibraryRoute ? editorTabHref : undefined" @click.prevent="onEditorTab" icon="edit" text="Editor"></nldd-tab-bar-item>
               </nldd-tab-bar>
             </nldd-toolbar-item>
             <nldd-toolbar-item slot="end">
-              <span>
+              <nldd-just-in-time-education
+                placement="top"
+                arrow-length="160px"
+                text="Zoek een wet om te openen"
+                supporting-text="Markeer een wet als favoriet om die later snel terug te vinden."
+                :active="showSearchHintSm || undefined"
+              >
                 <nldd-icon-button size="lg" icon="search" text="Zoeken" @click="openSearch"></nldd-icon-button>
-              </span>
+              </nldd-just-in-time-education>
             </nldd-toolbar-item>
             <nldd-toolbar-item slot="end">
-              <span>
-                <nldd-icon-button id="settings-menu-btn-sm" size="lg" icon="account" text="Account" tooltip-timing="never" popovertarget="settings-menu-sm"></nldd-icon-button>
-              </span>
+              <nldd-icon-button id="settings-menu-btn-sm" size="lg" icon="account" text="Account" tooltip-timing="never" popovertarget="settings-menu-sm"></nldd-icon-button>
               <nldd-menu id="settings-menu-sm" anchor="settings-menu-btn-sm">
                 <nldd-menu-item v-if="!authLoading && authenticated" :text="person?.name || person?.email" disabled></nldd-menu-item>
                 <nldd-menu-group text="Functies">
@@ -362,7 +426,7 @@ const hasDocumentTabs = computed(
                 </nldd-menu-group>
                 <nldd-menu-divider></nldd-menu-divider>
                 <nldd-menu-item v-if="!authLoading && authenticated" text="Uitloggen" icon="logout" @click="logout"></nldd-menu-item>
-                <nldd-menu-item v-else-if="!authLoading && oidcConfigured" text="Inloggen" @click="login()"></nldd-menu-item>
+                <nldd-menu-item v-else-if="!authLoading && oidcConfigured" text="Inloggen" icon="login" @click="login()"></nldd-menu-item>
               </nldd-menu>
             </nldd-toolbar-item>
           </nldd-toolbar>
@@ -374,4 +438,18 @@ const hasDocumentTabs = computed(
   <!-- Traject-documents browser sheet + edit window, opened from TrajectMenu.
        Shared by both sections, so it lives in the shell (mounted once). -->
   <TrajectDocuments />
+
+  <!-- Editor requires login: a heads-up popover anchored to the clicked Editor
+       tab (sm/md/lg) so the SSO screen never appears unannounced. -->
+  <nldd-popover ref="loginWarning" accessible-label="Inloggen" width="320px">
+    <nldd-container padding="16">
+      <nldd-inline-dialog
+        icon="login"
+        text="Log in om de editor te gebruiken"
+        supporting-text="Zodra je bent ingelogd kies je een traject en kun je aan de slag."
+      >
+        <nldd-button slot="actions" variant="primary" text="Inloggen" @click="login(editorTabHref)"></nldd-button>
+      </nldd-inline-dialog>
+    </nldd-container>
+  </nldd-popover>
 </template>

--- a/frontend/src/EditorView.vue
+++ b/frontend/src/EditorView.vue
@@ -1841,7 +1841,7 @@ async function handleActionSave() {
                   :value="yamlSource"
                   @input="onYamlInput"
                 ></nldd-code-editor>
-                <div v-if="parseError" class="editor-parse-error-detail">{{ parseError }}</div>
+                <nldd-banner v-if="parseError" variant="critical" :text="parseError"></nldd-banner>
               </nldd-simple-section>
             </nldd-page>
           </nldd-split-view-pane>

--- a/frontend/src/EditorView.vue
+++ b/frontend/src/EditorView.vue
@@ -506,16 +506,6 @@ function libraryRouteFor(lawIdVal) {
     : { name: 'library', params: { lawId: lawIdVal } };
 }
 
-// If the user lands on the editor without a lawId, restore the last
-// tab they had open before the refresh — keeping the same traject
-// scope (or lack of it).
-if (!route.params.lawId) {
-  const last = loadSavedActiveTab();
-  if (last?.lawId) {
-    router.replace(editorRouteFor(last.lawId, last.articleNumber || undefined));
-  }
-}
-
 const openTabs = ref(loadSavedTabs());
 
 // Cache for law names (populated on fetch)
@@ -577,6 +567,21 @@ async function selectTab(tab) {
   // `replace` (not `push`) keeps history clean — a tab switch isn't
   // navigation the user wants to undo with the back button.
   router.replace(editorRouteFor(tab.lawId, tab.articleNumber));
+}
+
+// On load there may be no article to edit yet — the URL carries no article
+// (just a traject, or a law without an article number). Rather than show the
+// empty state while tabs are still open, open one right away: the last active
+// tab when the URL has no law at all (so a refresh returns the user where they
+// were), otherwise simply the first open tab. selectTab sets activeTab
+// synchronously, so the empty state never flashes. With no open tabs we fall
+// through to it — the only case it should appear.
+if (!route.params.articleNumber && openTabs.value.length > 0) {
+  const lastActive = loadSavedActiveTab();
+  const restored = !route.params.lawId && lastActive?.lawId
+    ? findTab(lastActive.lawId, lastActive.articleNumber)
+    : null;
+  selectTab(restored || openTabs.value[0]).catch(console.warn);
 }
 
 // Browser back/forward (or any external navigation) — pull state from

--- a/frontend/src/EditorView.vue
+++ b/frontend/src/EditorView.vue
@@ -751,6 +751,16 @@ const activeEditItem = ref(null);
 const parseError = ref(null);
 
 const machineReadable = ref(null);
+
+// The YAML pane edits the machine-readable as text. There is something to edit
+// when the article carries machine_readable, or one was created/edited this
+// session (the live ref). With neither, the empty code editor is replaced by a
+// message — like the Machine pane and the read-only YAML view. Deliberately not
+// keyed on the live ref alone: clearing or mid-typing invalid YAML nulls it, and
+// that must not yank the editor out from under the user.
+const hasMachineReadable = computed(
+  () => !!machineReadable.value || !!selectedArticle.value?.machine_readable,
+);
 const yamlSource = ref('');
 // In-memory markdown for the currently selected article's `text` field.
 // Seeded on article switch alongside machineReadable so the Tekst and Machine
@@ -1715,10 +1725,11 @@ async function handleActionSave() {
                   text="Notities niet geladen"
                   :supporting-text="notesError.message"
                 ></nldd-inline-dialog>
-                <nldd-inline-dialog
+                <nldd-activity-indicator
                   v-else-if="notesLoading"
-                  text="Notities laden…"
-                ></nldd-inline-dialog>
+                  text="Notities laden"
+                  show-text
+                ></nldd-activity-indicator>
                 <template v-else>
                   <AnnotatedText
                     :article="selectedArticle"
@@ -1840,13 +1851,19 @@ async function handleActionSave() {
 
               <!-- YAML -->
               <nldd-simple-section v-else-if="view === 'yaml'" width="full">
-                <nldd-code-editor
-                  resize="none"
-                  accessible-label="YAML"
-                  :value="yamlSource"
-                  @input="onYamlInput"
-                ></nldd-code-editor>
-                <nldd-banner v-if="parseError" variant="critical" :text="parseError"></nldd-banner>
+                <nldd-inline-dialog
+                  v-if="!hasMachineReadable"
+                  text="Geen machine-leesbare gegevens voor dit artikel"
+                ></nldd-inline-dialog>
+                <template v-else>
+                  <nldd-code-editor
+                    resize="none"
+                    accessible-label="YAML"
+                    :value="yamlSource"
+                    @input="onYamlInput"
+                  ></nldd-code-editor>
+                  <nldd-banner v-if="parseError" variant="critical" :text="parseError"></nldd-banner>
+                </template>
               </nldd-simple-section>
             </nldd-page>
           </nldd-split-view-pane>

--- a/frontend/src/LibraryView.vue
+++ b/frontend/src/LibraryView.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed, shallowRef, nextTick, watch, watchEffect } from 'vue';
+import { ref, computed, shallowRef, nextTick, watch, watchEffect, onBeforeUnmount } from 'vue';
 import { useRoute, useRouter, onBeforeRouteUpdate } from 'vue-router';
 import yaml from 'js-yaml';
 import ArticleText from './components/ArticleText.vue';
@@ -12,12 +12,12 @@ import { lawFetchInit } from './composables/useLaw.js';
 import { useTrajects } from './composables/useTrajects.js';
 import { lawsListUrl, lawUrl, changedLawsUrl } from './composables/corpusUrls.js';
 import { SUPPORT_EMAIL } from './constants.js';
-import { openSearch, registerSearchPopover } from './composables/useAppChrome.js';
+import { registerSearchPopover, setLibraryEmpty } from './composables/useAppChrome.js';
 import { humanizeLawId } from './lib/lawName.js';
 import { apiFetch, apiFetchJson, ApiError } from './lib/apiFetch.js';
 import { useLatest } from './lib/useLatest.js';
 
-const { authenticated } = useAuth();
+const { authenticated, login } = useAuth();
 
 // Library home title (sidebar header + home heading) and the label of
 // the back-button that returns to it from underlying pages. They differ
@@ -60,8 +60,7 @@ const loading = ref(true);
 const indexError = ref(null);
 const searchPopoverRef = ref(null);
 // The toolbar search control lives in the AppShell; register our popover so
-// the shell's search button/field opens it. `openSearch` is imported from the
-// chrome store for the in-body "Zoeken" button below.
+// the shell's search button/field opens it.
 registerSearchPopover(searchPopoverRef);
 
 const selectedLawId = ref(null);
@@ -185,6 +184,12 @@ const isEmptyLibrary = computed(
   () => !loading.value && !indexError.value && !selectedLawId.value && sidebarSections.value.length === 0,
 );
 
+// Tell the shell whether the library is empty so it can show the just-in-time
+// search coach-mark on the toolbar field; reset on unmount so it doesn't linger
+// on the editor route.
+watchEffect(() => setLibraryEmpty(isEmptyLibrary.value));
+onBeforeUnmount(() => setLibraryEmpty(false));
+
 const articles = computed(() => selectedLaw.value?.articles ?? []);
 
 const lawName = computed(() => {
@@ -306,6 +311,21 @@ async function fetchChangedLawIds(trajectRef) {
 }
 
 const togglingFavorites = ref(new Set());
+
+const favoriteLoginWarning = ref(null);
+// Heart button when not logged in: nudge to log in via a popover anchored to the
+// button (same pattern as the Editor tab + Trajecten button) instead of silently
+// doing nothing.
+function onFavoriteClick(e) {
+  if (!authenticated.value) {
+    if (favoriteLoginWarning.value) {
+      favoriteLoginWarning.value.anchorElement = e.currentTarget;
+      favoriteLoginWarning.value.show();
+    }
+    return;
+  }
+  toggleFavorite(selectedLawId.value);
+}
 
 async function toggleFavorite(lawId) {
   if (!authenticated.value || !lawId) return;
@@ -669,27 +689,19 @@ watch(activeTrajectRef, () => {
         </nldd-page>
 
         <!-- Nothing curated yet (no favorites, no traject edits, no open law):
-             point the user at search rather than dumping the whole corpus. -->
-        <nldd-page v-else-if="isEmptyLibrary">
-          <nldd-simple-section width="full">
-            <nldd-inline-dialog
-              text="Nog niets in je bibliotheek"
-              supporting-text="Zoek een wet om te openen, of markeer wetten als favoriet."
-            >
-              <nldd-button slot="actions" variant="primary" start-icon="search" text="Zoeken" @click="openSearch"></nldd-button>
-            </nldd-inline-dialog>
-          </nldd-simple-section>
-        </nldd-page>
+             leave the canvas blank — the just-in-time coach-mark on the toolbar
+             search field (AppShell) points the user at search. -->
+        <nldd-page v-else-if="isEmptyLibrary"></nldd-page>
 
         <nldd-navigation-split-view v-else @back="onPaneBack">
 
           <nldd-split-view-pane slot="sidebar" has-content>
             <nldd-page sticky-header>
-              <nldd-top-title-bar slot="header" :text="LIBRARY_HOME_TITLE" collapse-anchor="home-titel"></nldd-top-title-bar>
+              <nldd-top-title-bar v-if="!loading" slot="header" :text="LIBRARY_HOME_TITLE" collapse-anchor="home-titel"></nldd-top-title-bar>
 
               <nldd-simple-section width="full">
-                <nldd-title id="home-titel" size="3"><h3>{{ LIBRARY_HOME_TITLE }}</h3></nldd-title>
-                <nldd-spacer size="16"></nldd-spacer>
+                <nldd-title v-if="!loading" id="home-titel" size="3"><h3>{{ LIBRARY_HOME_TITLE }}</h3></nldd-title>
+                <nldd-spacer v-if="!loading" size="16"></nldd-spacer>
                 <nldd-activity-indicator v-if="loading" text="Laden" show-text></nldd-activity-indicator>
                 <template v-else>
                   <template
@@ -745,25 +757,37 @@ watch(activeTrajectRef, () => {
           <nldd-split-view-pane v-if="selectedLawId && !lawError" slot="secondary-sidebar" has-content>
             <nldd-page sticky-header>
               <nldd-top-title-bar
+                v-if="!selectedLawLoading"
                 slot="header"
-                :text="lawName || indexedLawName || 'Selecteer een wet'"
+                :text="lawName || indexedLawName"
                 :back-text="LIBRARY_HOME_BACK_TEXT"
                 collapse-anchor="wet-titel"
               ></nldd-top-title-bar>
 
               <nldd-simple-section width="full">
-                <nldd-title id="wet-titel" size="3"><h3>{{ lawName || 'Selecteer een wet' }}</h3></nldd-title>
-                <nldd-spacer size="16"></nldd-spacer>
-                <nldd-toolbar v-if="authenticated && selectedLaw" label="Favorieten">
+                <nldd-title v-if="!selectedLawLoading" id="wet-titel" size="3"><h3>{{ lawName }}</h3></nldd-title>
+                <nldd-spacer v-if="!selectedLawLoading" size="16"></nldd-spacer>
+                <nldd-toolbar v-if="selectedLaw" label="Favorieten">
                   <nldd-toolbar-item slot="start">
                     <nldd-icon-button
                       :icon="favorites?.has(selectedLawId) ? 'heart-filled' : 'heart'"
                       :text="favorites?.has(selectedLawId) ? 'Verwijder uit favorieten' : 'Voeg toe aan favorieten'"
-                      @click="toggleFavorite(selectedLawId)"
+                      @click="onFavoriteClick"
                     ></nldd-icon-button>
                   </nldd-toolbar-item>
                 </nldd-toolbar>
-                <nldd-spacer v-if="authenticated && selectedLaw" size="16"></nldd-spacer>
+                <nldd-spacer v-if="selectedLaw" size="16"></nldd-spacer>
+                <nldd-popover ref="favoriteLoginWarning" accessible-label="Inloggen" width="320px">
+                  <nldd-container padding="16">
+                    <nldd-inline-dialog
+                      icon="login"
+                      text="Log in om wetten als favoriet te markeren"
+                      supporting-text="Zodra je bent ingelogd kun je wetten bewaren en snel terugvinden."
+                    >
+                      <nldd-button slot="actions" variant="primary" text="Inloggen" @click="login()"></nldd-button>
+                    </nldd-inline-dialog>
+                  </nldd-container>
+                </nldd-popover>
                 <nldd-activity-indicator v-if="selectedLawLoading" text="Wet laden" show-text></nldd-activity-indicator>
                 <nldd-inline-dialog v-else-if="!selectedLaw" text="Selecteer een wet"></nldd-inline-dialog>
                 <nldd-list v-else variant="simple">
@@ -803,7 +827,7 @@ watch(activeTrajectRef, () => {
               </nldd-simple-section>
               <nldd-simple-section width="full" v-else-if="selectedLawLoading">
                 <!-- Loading takes precedence over `lawError` to avoid flashing a stale error during a refetch. -->
-                <nldd-activity-indicator text="Wet laden" show-text></nldd-activity-indicator>
+                <nldd-activity-indicator text="Artikel laden" show-text></nldd-activity-indicator>
               </nldd-simple-section>
               <nldd-simple-section width="full" v-else-if="lawError">
                 <!-- 404 = law not in active traject; give the user an exit instead of a generic error. -->

--- a/frontend/src/LibraryView.vue
+++ b/frontend/src/LibraryView.vue
@@ -730,7 +730,7 @@ watch(activeTrajectRef, () => {
                       </nldd-title>
                       <nldd-spacer size="8"></nldd-spacer>
                     </template>
-                    <nldd-list variant="simple">
+                    <nldd-list variant="simple" arrow-navigation>
                       <nldd-list-item
                         v-for="law in section.laws"
                         :key="`${section.key}-${law.law_id}`"
@@ -795,7 +795,7 @@ watch(activeTrajectRef, () => {
                 </nldd-popover>
                 <nldd-activity-indicator v-if="selectedLawLoading" text="Wet laden" show-text></nldd-activity-indicator>
                 <nldd-inline-dialog v-else-if="!selectedLaw" text="Selecteer een wet"></nldd-inline-dialog>
-                <nldd-list v-else variant="simple">
+                <nldd-list v-else variant="simple" arrow-navigation>
                   <nldd-list-item
                     v-for="article in articles"
                     :key="article.number"

--- a/frontend/src/LibraryView.vue
+++ b/frontend/src/LibraryView.vue
@@ -32,7 +32,7 @@ const router = useRouter();
 // Active traject (null = global browse). Derived from the URL via
 // `route.params.trajectRef`, so the new `library-traject` route makes the
 // bibliotheek traject-aware without any extra plumbing.
-const { activeTrajectRef } = useTrajects();
+const { activeTrajectRef, activeTraject } = useTrajects();
 
 // Keep the user's traject scope across in-app navigations. With a traject
 // in the URL we stay on `library-traject` / `editor-traject`; without one
@@ -245,7 +245,9 @@ const articleNotFound = computed(() =>
 const lawErrorIs404 = computed(() => lawError.value?.status === 404);
 
 // Reflect navigation depth in the document title:
-//   "Art. 5 · Wet op de zorgtoeslag · RegelRecht"
+//   "Art. 5 · Wet op de zorgtoeslag · 15 juni test · RegelRecht"
+// On a traject-scoped browse the active traject name is appended (like the
+// editor) so the browser tab and history show which traject you are viewing.
 // Most-specific first so browser tab truncation preserves the article number.
 // We deliberately omit the "Bibliotheek:" prefix here (unlike the editor) —
 // browsing laws is the implicit default, and the law name carries enough
@@ -260,6 +262,9 @@ watchEffect(() => {
   // law itself failed to load.
   const name = lawName.value || indexedLawName.value;
   if (name) detail.push(name);
+  // Traject-scoped browse: append the traject name (resolves once the trajects
+  // list loads). Null on the public no-traject library, so it drops out there.
+  if (activeTraject.value?.name) detail.push(activeTraject.value.name);
   document.title = detail.length > 0
     ? `${detail.join(' · ')} · RegelRecht`
     : 'Bibliotheek · RegelRecht';

--- a/frontend/src/TrajectChooserView.vue
+++ b/frontend/src/TrajectChooserView.vue
@@ -1,24 +1,19 @@
 <script setup>
-import { onMounted, ref, watchEffect } from 'vue';
+import { onMounted, watchEffect } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
-import SearchPopover from './components/SearchPopover.vue';
 import { useTrajects, refreshTrajects } from './composables/useTrajects.js';
-import { registerSearchPopover } from './composables/useAppChrome.js';
+import { lastLibraryPath } from './composables/useLastVisitedRoute.js';
 
-// Trajectkeuze-pagina — de landing van de kale /editor. De editor vereist
-// een traject; hier kies je een bestaand traject of ga je door naar de
-// aanmaakpagina. Een meegekregen wet (query `law`/`article`, gezet door de
-// redirect van oude no-traject editor-links) opent na de keuze direct.
+// Trajectkeuze-pagina — de landing wanneer de editor (of een traject-scoped
+// bibliotheek) een traject vereist. Hier kies je een bestaand traject of ga je
+// door naar de aanmaakpagina. Een meegekregen wet (query `law`/`article`, gezet
+// door de redirect van oude no-traject editor-links) opent na de keuze direct.
 //
-// Content-only: de chrome (tabs, zoeken, account, traject-menu) leeft in de
-// persistente AppShell. Deze view registreert wel een eigen SearchPopover
-// zodat de zoekknop in de balk hier ook werkt.
+// Top-level route (geen AppShell-child): geen app-chrome. De pagina draagt z'n
+// eigen top-title-bar met terugknop naar de bibliotheek.
 const route = useRoute();
 const router = useRouter();
 const { trajects, loading, error } = useTrajects();
-
-const searchPopoverRef = ref(null);
-registerSearchPopover(searchPopoverRef);
 
 // Always refetch on entry: the landing page should reflect trajects
 // created elsewhere (other tab, other device) since the cached
@@ -28,18 +23,23 @@ onMounted(() => {
 });
 
 watchEffect(() => {
-  document.title = 'Kies een traject · RegelRecht';
+  document.title = 'Trajecten · RegelRecht';
 });
 
-// Deze pagina heeft zelf geen wetweergave — een zoekresultaat opent in de
-// bibliotheek.
-function openLawFromSearch(lawId) {
-  router.push({ name: 'library', params: { lawId } });
+// Terug naar waar de user vandaan kwam vóór de trajectkeuze: de bibliotheek, via
+// z'n in sessionStorage bewaarde last-visited-pad. Dat pad overleeft de full-
+// page SSO-redirect die een uitgelogde user naar deze auth-only pagina bracht;
+// een history-pop zou op de login-redirect landen.
+function goBack() {
+  router.push(lastLibraryPath.value);
 }
 
-function editorTarget(trajectRef) {
+// Where picking a traject takes you, from `sectie` (default editor): the
+// library or editor traject-scoped route, carrying the law/article the user was
+// heading for so they land on their intended destination.
+function trajectTarget(trajectRef) {
   return {
-    name: 'editor-traject',
+    name: route.query.sectie === 'library' ? 'library-traject' : 'editor-traject',
     params: {
       trajectRef,
       lawId: route.query.law || undefined,
@@ -55,7 +55,7 @@ function selectTraject(t) {
     console.warn('TrajectChooser: traject has no ref', t);
     return;
   }
-  router.push(editorTarget(t.ref));
+  router.push(trajectTarget(t.ref));
 }
 
 function openCreate() {
@@ -72,58 +72,63 @@ function trajectSupportingText(t) {
 </script>
 
 <template>
-  <nldd-page sticky-header>
-    <nldd-top-title-bar
-      slot="header"
-      text="Kies een traject"
-      collapse-anchor="kies-traject-titel"
-    ></nldd-top-title-bar>
+  <nldd-app-view>
+    <nldd-page sticky-header>
+      <nldd-top-title-bar
+        slot="header"
+        text="Trajecten"
+        back-text="Bibliotheek"
+        collapse-anchor="kies-traject-titel"
+        @back="goBack"
+      ></nldd-top-title-bar>
 
-    <nldd-simple-section width="800px">
-      <nldd-title id="kies-traject-titel" size="3"><h3>Kies een traject</h3></nldd-title>
-      <nldd-spacer size="16"></nldd-spacer>
-      <nldd-activity-indicator v-if="loading" text="Trajecten laden" show-text></nldd-activity-indicator>
-      <nldd-inline-dialog
-        v-else-if="error"
-        variant="alert"
-        text="Trajecten zijn niet geladen"
-        supporting-text="De gegevens konden niet worden opgehaald."
-      >
-        <nldd-button slot="actions" variant="primary" text="Probeer opnieuw" @click="refreshTrajects()"></nldd-button>
-      </nldd-inline-dialog>
-      <!-- "Nieuw traject" is een gewoon list item onderaan, zodat de
-           interactie identiek is mét bestaande trajecten (onderaan de
-           lijst) en zonder (als enige item). -->
-      <nldd-list v-else variant="box">
-        <nldd-list-item
-          v-for="t in trajects"
-          :key="t.id"
-          size="md"
-          button
-          @click="selectTraject(t)"
+      <nldd-simple-section width="800px">
+        <nldd-title id="kies-traject-titel" size="3"><h3>Trajecten</h3></nldd-title>
+        <nldd-spacer size="16"></nldd-spacer>
+        <nldd-activity-indicator v-if="loading" text="Trajecten laden" show-text></nldd-activity-indicator>
+        <nldd-inline-dialog
+          v-else-if="error"
+          variant="alert"
+          text="Trajecten zijn niet geladen"
+          supporting-text="De gegevens konden niet worden opgehaald."
         >
-          <nldd-text-cell :text="t.name" :supporting-text="trajectSupportingText(t)"></nldd-text-cell>
-          <nldd-spacer-cell size="8"></nldd-spacer-cell>
-          <nldd-icon-cell size="20">
-            <nldd-icon name="chevron-right"></nldd-icon>
-          </nldd-icon-cell>
-        </nldd-list-item>
-        <nldd-list-item size="md"
-          button
-          @click="openCreate"
-        >
-          <nldd-text-cell text="Nieuw traject"></nldd-text-cell>
-          <nldd-spacer-cell size="8"></nldd-spacer-cell>
-          <nldd-icon-cell size="20">
-            <nldd-icon name="chevron-right"></nldd-icon>
-          </nldd-icon-cell>
-        </nldd-list-item>
-      </nldd-list>
-    </nldd-simple-section>
-  </nldd-page>
-
-  <SearchPopover
-    ref="searchPopoverRef"
-    @select-law="openLawFromSearch"
-  />
+          <nldd-button slot="actions" variant="primary" text="Probeer opnieuw" @click="refreshTrajects()"></nldd-button>
+        </nldd-inline-dialog>
+        <!-- "Nieuw traject" is een gewoon list item onderaan, zodat de
+             interactie identiek is mét bestaande trajecten (onderaan de
+             lijst) en zonder (als enige item). -->
+        <nldd-list v-else variant="box">
+          <nldd-list-item
+            v-for="t in trajects"
+            :key="t.id"
+            size="md"
+            button
+            @click="selectTraject(t)"
+          >
+            <nldd-spacer-cell slot="start" size="12"></nldd-spacer-cell>
+            <nldd-icon-cell slot="start" size="20"><nldd-icon name="traject"></nldd-icon></nldd-icon-cell>
+            <nldd-spacer-cell slot="start" size="8"></nldd-spacer-cell>
+            <nldd-text-cell :text="t.name" :supporting-text="trajectSupportingText(t)"></nldd-text-cell>
+            <nldd-spacer-cell size="8"></nldd-spacer-cell>
+            <nldd-icon-cell size="20">
+              <nldd-icon name="chevron-right"></nldd-icon>
+            </nldd-icon-cell>
+          </nldd-list-item>
+          <nldd-list-item size="md"
+            button
+            @click="openCreate"
+          >
+            <nldd-spacer-cell slot="start" size="12"></nldd-spacer-cell>
+            <nldd-icon-cell slot="start" size="20"><nldd-icon name="plus"></nldd-icon></nldd-icon-cell>
+            <nldd-spacer-cell slot="start" size="8"></nldd-spacer-cell>
+            <nldd-text-cell text="Nieuw traject"></nldd-text-cell>
+            <nldd-spacer-cell size="8"></nldd-spacer-cell>
+            <nldd-icon-cell size="20">
+              <nldd-icon name="chevron-right"></nldd-icon>
+            </nldd-icon-cell>
+          </nldd-list-item>
+        </nldd-list>
+      </nldd-simple-section>
+    </nldd-page>
+  </nldd-app-view>
 </template>

--- a/frontend/src/TrajectChooserView.vue
+++ b/frontend/src/TrajectChooserView.vue
@@ -97,7 +97,7 @@ function trajectSupportingText(t) {
         <!-- "Nieuw traject" is een gewoon list item onderaan, zodat de
              interactie identiek is mét bestaande trajecten (onderaan de
              lijst) en zonder (als enige item). -->
-        <nldd-list v-else variant="box">
+        <nldd-list v-else variant="box" arrow-navigation>
           <nldd-list-item
             v-for="t in trajects"
             :key="t.id"

--- a/frontend/src/TrajectChooserView.vue
+++ b/frontend/src/TrajectChooserView.vue
@@ -129,6 +129,8 @@ function trajectSupportingText(t) {
           </nldd-list-item>
         </nldd-list>
       </nldd-simple-section>
+
+      <nldd-page-footer slot="footer"></nldd-page-footer>
     </nldd-page>
   </nldd-app-view>
 </template>

--- a/frontend/src/TrajectCreateView.vue
+++ b/frontend/src/TrajectCreateView.vue
@@ -82,6 +82,8 @@ async function submitCreate() {
           @submit="submitCreate"
         />
       </nldd-simple-section>
+
+      <nldd-page-footer slot="footer"></nldd-page-footer>
     </nldd-page>
   </nldd-app-view>
 </template>

--- a/frontend/src/TrajectCreateView.vue
+++ b/frontend/src/TrajectCreateView.vue
@@ -1,24 +1,18 @@
 <script setup>
-import { computed, ref, watchEffect } from 'vue';
+import { ref, watchEffect } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
-import SearchPopover from './components/SearchPopover.vue';
 import TrajectCreateForm from './components/TrajectCreateForm.vue';
 import { createTraject } from './composables/useTrajects.js';
-import { registerSearchPopover } from './composables/useAppChrome.js';
 
-// Nieuw-traject-pagina — bereikbaar vanaf de trajectkeuze-pagina
-// (/editor). Gebruikt hetzelfde gedeelde formulier als de
-// TrajectMenu-sheet; na het aanmaken ga je direct de editor in op het
-// nieuwe traject, met een eventueel meegekregen wet (query
-// `law`/`article`) voorgeselecteerd.
+// Nieuw-traject-pagina — bereikbaar vanaf de trajectkeuze-pagina. Gebruikt
+// hetzelfde gedeelde formulier als de TrajectMenu-sheet; na het aanmaken ga je
+// direct de editor (of traject-scoped bibliotheek) in op het nieuwe traject,
+// met een eventueel meegekregen wet (query `law`/`article`) voorgeselecteerd.
 //
-// Content-only: de chrome komt uit de persistente AppShell; de terugknop
-// naar de keuzepagina zit in de page-header.
+// Top-level route (geen AppShell-child): geen app-chrome. De pagina draagt z'n
+// eigen top-title-bar met terugknop naar de trajectkeuze.
 const route = useRoute();
 const router = useRouter();
-
-const searchPopoverRef = ref(null);
-registerSearchPopover(searchPopoverRef);
 
 const formEl = ref(null);
 const createBusy = ref(false);
@@ -28,13 +22,9 @@ watchEffect(() => {
   document.title = 'Nieuw traject · RegelRecht';
 });
 
-// Terug naar de keuzepagina, met behoud van een meegekregen wet.
-const backTarget = computed(() => ({ name: 'editor', query: route.query }));
-
-// Deze pagina heeft zelf geen wetweergave — een zoekresultaat opent in de
-// bibliotheek.
-function openLawFromSearch(lawId) {
-  router.push({ name: 'library', params: { lawId } });
+// Terug naar de chooser, met behoud van sectie + meegekregen wet.
+function goBack() {
+  router.push({ name: 'trajecten', query: route.query });
 }
 
 async function submitCreate() {
@@ -57,7 +47,7 @@ async function submitCreate() {
       return;
     }
     await router.push({
-      name: 'editor-traject',
+      name: route.query.sectie === 'library' ? 'library-traject' : 'editor-traject',
       params: {
         trajectRef: created.ref,
         lawId: route.query.law || undefined,
@@ -73,28 +63,25 @@ async function submitCreate() {
 </script>
 
 <template>
-  <nldd-page sticky-header>
-    <nldd-top-title-bar
-      slot="header"
-      text="Nieuw traject"
-      :back-text="createBusy ? undefined : 'Kies een traject'"
-      collapse-anchor="nieuw-traject-titel"
-      @back="router.push(backTarget)"
-    ></nldd-top-title-bar>
+  <nldd-app-view>
+    <nldd-page sticky-header>
+      <nldd-top-title-bar
+        slot="header"
+        text="Nieuw traject"
+        :back-text="createBusy ? undefined : 'Trajecten'"
+        collapse-anchor="nieuw-traject-titel"
+        @back="goBack"
+      ></nldd-top-title-bar>
 
-    <nldd-simple-section width="800px">
-      <nldd-title id="nieuw-traject-titel" size="3"><h3>Nieuw traject</h3></nldd-title>
-      <nldd-spacer size="16"></nldd-spacer>
-      <TrajectCreateForm ref="formEl"
-        :busy="createBusy"
-        :error="createError"
-        @submit="submitCreate"
-      />
-    </nldd-simple-section>
-  </nldd-page>
-
-  <SearchPopover
-    ref="searchPopoverRef"
-    @select-law="openLawFromSearch"
-  />
+      <nldd-simple-section width="800px">
+        <nldd-title id="nieuw-traject-titel" size="3"><h3>Nieuw traject</h3></nldd-title>
+        <nldd-spacer size="16"></nldd-spacer>
+        <TrajectCreateForm ref="formEl"
+          :busy="createBusy"
+          :error="createError"
+          @submit="submitCreate"
+        />
+      </nldd-simple-section>
+    </nldd-page>
+  </nldd-app-view>
 </template>

--- a/frontend/src/components/ActionSheet.vue
+++ b/frontend/src/components/ActionSheet.vue
@@ -130,7 +130,7 @@ onUnmounted(() => {
 
         <!-- Section A: Bovenliggende operaties -->
         <template v-if="parentOperations.length">
-          <nldd-list variant="box">
+          <nldd-list variant="box" arrow-navigation>
             <!-- Back/up navigation — clickable parent rows with a
                  chevron-left, identical in view and edit: click any
                  ancestor to jump up one or more levels. -->

--- a/frontend/src/components/ArticleTextEditor.test.js
+++ b/frontend/src/components/ArticleTextEditor.test.js
@@ -41,9 +41,9 @@ describe('ArticleTextEditor', () => {
     const wrapper = mount(ArticleTextEditor, {
       props: { article: null, editable: true, modelValue: '' },
     });
-    const empty = wrapper.find('.article-text-editor__empty');
+    const empty = wrapper.find('nldd-inline-dialog');
     expect(empty.exists()).toBe(true);
-    expect(empty.find('nldd-inline-dialog').attributes('text')).toContain('Geen artikel geselecteerd');
+    expect(empty.attributes('text')).toContain('Geen artikel geselecteerd');
   });
 
   it('renders the save error dialog when saveError is set and editable', () => {
@@ -68,7 +68,7 @@ describe('ArticleTextEditor', () => {
       props: { article: null, editable: true, saveError: err, modelValue: '' },
     });
     expect(wrapper.find('[data-testid="save-text-error"]').exists()).toBe(false);
-    expect(wrapper.find('.article-text-editor__empty').exists()).toBe(true);
+    expect(wrapper.find('nldd-inline-dialog').attributes('text')).toContain('Geen artikel geselecteerd');
   });
 
   // The remaining tests exercise tiptap under happy-dom. If the editor instance

--- a/frontend/src/components/ArticleTextEditor.vue
+++ b/frontend/src/components/ArticleTextEditor.vue
@@ -186,9 +186,14 @@ defineExpose({
 </script>
 
 <template>
-  <div class="article-text-editor" data-testid="article-text-editor">
+  <!-- Empty state as the component root (no wrappers), so it lands as a direct
+       child of the pane's nldd-simple-section and centers like the other panes
+       (AnnotatedText/ArticleText do the same). Wrapping it in the editor's flex
+       layout would top-align it instead. -->
+  <nldd-inline-dialog v-if="!article" text="Geen artikel geselecteerd"></nldd-inline-dialog>
+  <div v-else class="article-text-editor" data-testid="article-text-editor">
     <div class="article-text-editor__body-wrap">
-      <template v-if="article && editable && saveError">
+      <template v-if="editable && saveError">
         <nldd-inline-dialog
           variant="alert"
           text="Opslaan mislukt"
@@ -197,11 +202,7 @@ defineExpose({
         ></nldd-inline-dialog>
         <nldd-spacer size="12"></nldd-spacer>
       </template>
-
-      <div v-if="!article" class="article-text-editor__empty">
-        <nldd-inline-dialog text="Geen artikel geselecteerd"></nldd-inline-dialog>
-      </div>
-      <editor-content v-else :editor="editor" class="article-text-editor__body" />
+      <editor-content :editor="editor" class="article-text-editor__body" />
     </div>
   </div>
 </template>
@@ -211,11 +212,6 @@ defineExpose({
   display: flex;
   flex-direction: column;
   min-height: 0;
-}
-
-.article-text-editor__empty {
-  padding: 32px 16px;
-  text-align: center;
 }
 
 .article-text-editor__body {

--- a/frontend/src/components/DocumentEditor.vue
+++ b/frontend/src/components/DocumentEditor.vue
@@ -8,7 +8,7 @@
  * Replaces the old draggable nldd-window: no window, no movable dialog — it
  * renders inline in whatever container the host gives it.
  */
-import { nextTick, ref, watch } from 'vue';
+import { computed, nextTick, ref, watch } from 'vue';
 
 const props = defineProps({
   manager: { type: Object, required: true },
@@ -47,6 +47,19 @@ const {
   cancelDelete,
   confirmDelete,
 } = m;
+
+// One blocking error at a time, and it replaces the editor body rather than
+// stacking above it: there is nothing useful to edit behind a fetch/save
+// failure. The latest action error (saveError) outranks an earlier load error
+// (docError) that produced no document. Actionable notices (conflict,
+// draft-present, …) and title validation stay inline with the editor instead.
+const blockingError = computed(() => {
+  if (saveError.value) return { text: 'Actie mislukt', supporting: saveError.value.message };
+  if (docError.value && docError.value.kind !== 'draft-present') {
+    return { text: docError.value.message, supporting: null };
+  }
+  return null;
+});
 
 // Ctrl/Cmd+S = opslaan.
 function handleKeydown(e) {
@@ -107,19 +120,26 @@ watch(pendingDeletePath, async (path) => {
 
   <nldd-simple-section padding-top="8" @keydown="handleKeydown">
     <nldd-activity-indicator v-if="docLoading || creating" text="Document laden" show-text></nldd-activity-indicator>
+    <!-- A blocking failure replaces the whole editor body: just this one
+         message, nothing useful sits behind it. -->
+    <nldd-inline-dialog
+      v-else-if="blockingError"
+      variant="alert"
+      :text="blockingError.text"
+      :supporting-text="blockingError.supporting || undefined"
+    ></nldd-inline-dialog>
     <template v-else>
-      <nldd-inline-dialog v-if="deleteNotice" variant="warning" :text="deleteNotice"></nldd-inline-dialog>
+      <!-- Actionable notices keep the editor in view; at most one at a time. -->
       <nldd-inline-dialog v-if="conflict" variant="warning" :text="conflict">
         <nldd-button slot="actions" size="md" text="Server-versie laden" @click="reloadCurrent"></nldd-button>
         <nldd-button slot="actions" size="md" text="Lokaal overschrijven" @click="overwriteServer"></nldd-button>
       </nldd-inline-dialog>
-      <nldd-inline-dialog v-if="deletedRemotely" variant="warning" :text="deletedRemotely"></nldd-inline-dialog>
-      <nldd-inline-dialog v-if="docError && docError.kind === 'draft-present'" :text="docError.message">
+      <nldd-inline-dialog v-else-if="deletedRemotely" variant="warning" :text="deletedRemotely"></nldd-inline-dialog>
+      <nldd-inline-dialog v-else-if="deleteNotice" variant="warning" :text="deleteNotice"></nldd-inline-dialog>
+      <nldd-inline-dialog v-else-if="docError && docError.kind === 'draft-present'" :text="docError.message">
         <nldd-button slot="actions" size="md" text="Draft verwerpen" @click="dropDraft"></nldd-button>
       </nldd-inline-dialog>
-      <nldd-inline-dialog v-if="docError && docError.kind !== 'draft-present'" variant="alert" :text="docError.message"></nldd-inline-dialog>
-      <nldd-inline-dialog v-if="saveError" variant="alert" text="Actie mislukt" :supporting-text="saveError.message"></nldd-inline-dialog>
-      <nldd-inline-dialog v-if="titleError" variant="alert" :text="titleError"></nldd-inline-dialog>
+      <nldd-inline-dialog v-else-if="titleError" variant="alert" :text="titleError"></nldd-inline-dialog>
 
       <template v-if="viewMode === 'editor'">
         <nldd-text-field

--- a/frontend/src/components/DocumentEditor.vue
+++ b/frontend/src/components/DocumentEditor.vue
@@ -49,12 +49,12 @@ const {
 } = m;
 
 // One blocking error at a time, and it replaces the editor body rather than
-// stacking above it: there is nothing useful to edit behind a fetch/save
-// failure. The latest action error (saveError) outranks an earlier load error
-// (docError) that produced no document. Actionable notices (conflict,
-// draft-present, …) and title validation stay inline with the editor instead.
+// stacking above it: a load failure (docError) that produced no document leaves
+// nothing useful to edit, so it replaces the editor body. A save failure does
+// NOT block — the content is still in openTabs, so it stays an inline notice
+// above the editor (below) and the save can be retried in place. Actionable
+// notices (conflict, draft-present, …) and title validation also stay inline.
 const blockingError = computed(() => {
-  if (saveError.value) return { text: 'Actie mislukt', supporting: saveError.value.message };
   if (docError.value && docError.value.kind !== 'draft-present') {
     return { text: docError.value.message, supporting: null };
   }
@@ -129,6 +129,10 @@ watch(pendingDeletePath, async (path) => {
       :supporting-text="blockingError.supporting || undefined"
     ></nldd-inline-dialog>
     <template v-else>
+      <!-- A save failure is an action error, not a reason to hide the document:
+           surface it but keep the editor (content lives in openTabs) so the user
+           can fix and retry the save in place. -->
+      <nldd-inline-dialog v-if="saveError" variant="alert" text="Opslaan mislukt" :supporting-text="saveError.message"></nldd-inline-dialog>
       <!-- Actionable notices keep the editor in view; at most one at a time. -->
       <nldd-inline-dialog v-if="conflict" variant="warning" :text="conflict">
         <nldd-button slot="actions" size="md" text="Server-versie laden" @click="reloadCurrent"></nldd-button>

--- a/frontend/src/components/DocumentList.vue
+++ b/frontend/src/components/DocumentList.vue
@@ -39,15 +39,17 @@ function onRowClick(path) {
       :selected="doc.path === selectedPath || undefined"
       @click="onRowClick(doc.path)"
     >
-      <nldd-icon-cell size="20"><nldd-icon name="document"></nldd-icon></nldd-icon-cell>
-      <nldd-spacer-cell size="8"></nldd-spacer-cell>
+      <nldd-spacer-cell slot="start" size="12"></nldd-spacer-cell>
+      <nldd-icon-cell slot="start" size="20"><nldd-icon name="document"></nldd-icon></nldd-icon-cell>
+      <nldd-spacer-cell slot="start" size="8"></nldd-spacer-cell>
       <nldd-text-cell :text="title(doc.path)"></nldd-text-cell>
       <nldd-spacer-cell size="8"></nldd-spacer-cell>
       <nldd-icon-cell size="20"><nldd-icon :name="hrefFor ? 'open-new-page' : 'chevron-right'"></nldd-icon></nldd-icon-cell>
     </nldd-list-item>
     <nldd-list-item size="md" button @click="$emit('new')">
-      <nldd-icon-cell size="20"><nldd-icon name="plus"></nldd-icon></nldd-icon-cell>
-      <nldd-spacer-cell size="8"></nldd-spacer-cell>
+      <nldd-spacer-cell slot="start" size="12"></nldd-spacer-cell>
+      <nldd-icon-cell slot="start" size="20"><nldd-icon name="plus"></nldd-icon></nldd-icon-cell>
+      <nldd-spacer-cell slot="start" size="8"></nldd-spacer-cell>
       <nldd-text-cell text="Nieuw document"></nldd-text-cell>
       <nldd-spacer-cell size="8"></nldd-spacer-cell>
       <nldd-icon-cell size="20"><nldd-icon :name="hrefFor ? 'open-new-page' : 'chevron-right'"></nldd-icon></nldd-icon-cell>

--- a/frontend/src/components/DocumentList.vue
+++ b/frontend/src/components/DocumentList.vue
@@ -27,7 +27,7 @@ function onRowClick(path) {
 </script>
 
 <template>
-  <nldd-list :variant="variant">
+  <nldd-list :variant="variant" arrow-navigation>
     <nldd-list-item
       v-for="doc in documents"
       :key="doc.path"

--- a/frontend/src/components/MobileTrajectSheet.vue
+++ b/frontend/src/components/MobileTrajectSheet.vue
@@ -21,6 +21,22 @@ const { documentTabs, activeDocumentTab, tabActions } = useAppChrome();
 const route = useRoute();
 const router = useRouter();
 
+// Not logged in: log in, then land on the trajectchooser carrying the current
+// section + law/article, so picking a traject returns the user to where they
+// were — now traject-scoped.
+function loginToChooser() {
+  const inLibrary = route.name === 'library' || route.name === 'library-traject';
+  const target = router.resolve({
+    name: 'trajecten',
+    query: {
+      sectie: inLibrary ? 'library' : 'editor',
+      law: route.params.lawId || undefined,
+      article: route.params.articleNumber || undefined,
+    },
+  });
+  login(target.fullPath);
+}
+
 const sheetEl = ref(null);
 const sheetMode = ref('list'); // 'list' | 'create'
 
@@ -194,7 +210,7 @@ onBeforeUnmount(() => {
   <nldd-button
     size="md"
     expandable
-    start-icon="document"
+    start-icon="traject"
     width="full"
     horizontal-alignment="left"
     single-line
@@ -218,11 +234,11 @@ onBeforeUnmount(() => {
         <!-- Niet ingelogd -->
         <nldd-simple-section v-if="!authenticated">
           <nldd-inline-dialog
-            icon="traject"
+            icon="login"
             text="Log in om een traject te kiezen of aan te maken"
             supporting-text="Zodra je bent ingelogd zie je hier je lopende trajecten en kun je gemakkelijk wisselen."
           >
-            <nldd-button slot="actions" variant="primary" text="Inloggen" @click="login()"></nldd-button>
+            <nldd-button slot="actions" variant="primary" text="Inloggen" @click="loginToChooser"></nldd-button>
           </nldd-inline-dialog>
         </nldd-simple-section>
 

--- a/frontend/src/components/MobileTrajectSheet.vue
+++ b/frontend/src/components/MobileTrajectSheet.vue
@@ -347,5 +347,6 @@ onBeforeUnmount(() => {
     :traject-id="infoTrajectId"
     :traject-name="infoTrajectName"
     @deleted="onTrajectDeleted"
+    @left="onTrajectDeleted"
   />
 </template>

--- a/frontend/src/components/MobileTrajectSheet.vue
+++ b/frontend/src/components/MobileTrajectSheet.vue
@@ -3,6 +3,7 @@ import { computed, nextTick, onBeforeUnmount, onMounted, ref } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { useTrajects } from '../composables/useTrajects.js';
 import { useAuth } from '../composables/useAuth.js';
+import { useLoginToChooser } from '../composables/useLoginToChooser.js';
 import { useDocumentsSheet } from '../composables/useDocumentsSheet.js';
 import { useAppChrome } from '../composables/useAppChrome.js';
 import TrajectMembersDialog from './TrajectMembersDialog.vue';
@@ -15,27 +16,15 @@ import TrajectCreateForm from './TrajectCreateForm.vue';
 // "Artikelen"-lijst (de open tabbladen). md/lg houden TrajectMenu + de
 // document-tab-bar. Hergebruikt dezelfde composables/handlers als TrajectMenu.
 const { trajects, activeTrajectRef, activeTraject, loading, createTraject } = useTrajects();
-const { authenticated, login } = useAuth();
+const { authenticated } = useAuth();
 const documentsSheet = useDocumentsSheet();
 const { documentTabs, activeDocumentTab, tabActions } = useAppChrome();
 const route = useRoute();
 const router = useRouter();
 
 // Not logged in: log in, then land on the trajectchooser carrying the current
-// section + law/article, so picking a traject returns the user to where they
-// were — now traject-scoped.
-function loginToChooser() {
-  const inLibrary = route.name === 'library' || route.name === 'library-traject';
-  const target = router.resolve({
-    name: 'trajecten',
-    query: {
-      sectie: inLibrary ? 'library' : 'editor',
-      law: route.params.lawId || undefined,
-      article: route.params.articleNumber || undefined,
-    },
-  });
-  login(target.fullPath);
-}
+// section + law/article (shared composable, see also TrajectMenu).
+const loginToChooser = useLoginToChooser();
 
 const sheetEl = ref(null);
 const sheetMode = ref('list'); // 'list' | 'create'

--- a/frontend/src/components/MobileTrajectSheet.vue
+++ b/frontend/src/components/MobileTrajectSheet.vue
@@ -256,7 +256,7 @@ onBeforeUnmount(() => {
         <nldd-simple-section v-else>
           <!-- Acties van het actieve traject — bovenaan, zonder titel (de
                sheet-titel dekt dit al). -->
-          <nldd-list v-if="activeTraject" variant="box">
+          <nldd-list v-if="activeTraject" variant="box" arrow-navigation>
             <nldd-list-item size="md" button @click="openDocuments">
               <nldd-icon-cell size="20"><nldd-icon name="documents"></nldd-icon></nldd-icon-cell>
               <nldd-spacer-cell size="8"></nldd-spacer-cell>
@@ -278,7 +278,7 @@ onBeforeUnmount(() => {
           <nldd-spacer v-if="activeTraject" size="24"></nldd-spacer>
           <nldd-title size="5"><h2>Trajecten</h2></nldd-title>
           <nldd-spacer size="8"></nldd-spacer>
-          <nldd-list variant="box">
+          <nldd-list variant="box" arrow-navigation>
             <nldd-list-item
               v-for="t in trajects"
               :key="t.id"

--- a/frontend/src/components/ScenarioForm.vue
+++ b/frontend/src/components/ScenarioForm.vue
@@ -337,7 +337,7 @@ const dateErrorId = useId();
       <nldd-spacer size="16"></nldd-spacer>
       <nldd-title size="5"><h2>Bronnen</h2></nldd-title>
       <nldd-spacer size="8"></nldd-spacer>
-      <nldd-list variant="box">
+      <nldd-list variant="box" arrow-navigation>
         <nldd-list-item
           v-for="(ds, i) in dataSources"
           :key="ds.sourceName"

--- a/frontend/src/components/SearchPopover.vue
+++ b/frontend/src/components/SearchPopover.vue
@@ -302,7 +302,7 @@ defineExpose({ show });
             <nldd-spacer v-if="groupIndex > 0" size="16"></nldd-spacer>
             <nldd-title size="5"><h5>{{ group.source_name }}</h5></nldd-title>
             <nldd-spacer size="8"></nldd-spacer>
-            <nldd-list variant="simple">
+            <nldd-list variant="simple" arrow-navigation>
               <nldd-list-item
                 v-for="law in group.laws"
                 :key="law.law_id"
@@ -326,7 +326,7 @@ defineExpose({ show });
         <template v-else-if="bwbResults.length > 0">
           <nldd-title size="5"><h5>Resultaten van wetten.overheid.nl</h5></nldd-title>
           <nldd-spacer size="8"></nldd-spacer>
-          <nldd-list variant="simple">
+          <nldd-list variant="simple" arrow-navigation>
             <nldd-list-item
               v-for="result in bwbResults"
               :key="result.bwb_id"

--- a/frontend/src/components/TrajectInfoDialog.vue
+++ b/frontend/src/components/TrajectInfoDialog.vue
@@ -5,7 +5,7 @@ import {
   writableSource,
   branchTreeUrl,
 } from '../composables/useTrajectDetail.js';
-import { deleteTraject } from '../composables/useTrajects.js';
+import { deleteTraject, leaveTraject } from '../composables/useTrajects.js';
 
 const props = defineProps({
   /** Whether the sheet is currently open. */
@@ -16,7 +16,7 @@ const props = defineProps({
   trajectName: { type: String, default: '' },
 });
 
-const emit = defineEmits(['update:modelValue', 'deleted']);
+const emit = defineEmits(['update:modelValue', 'deleted', 'left']);
 
 const sheetEl = ref(null);
 const { detail, loading, error: loadError, load } = useTrajectDetail();
@@ -52,6 +52,8 @@ watch(
       // attempt must not greet the user on reopen.
       confirmingDelete.value = false;
       deleteError.value = null;
+      confirmingLeave.value = false;
+      leaveError.value = null;
       // Kick off the fetch before awaiting nextTick so the request settles
       // promptly (the test drives this with a couple of nextTick flushes).
       const loaded = props.trajectId ? load(props.trajectId) : Promise.resolve();
@@ -113,6 +115,47 @@ async function confirmDelete() {
     deleteError.value = e.message || 'Verwijderen mislukt';
   } finally {
     deleteBusy.value = false;
+  }
+}
+
+// --- Verlaten (bijdrager) — zelfde bevestigingsmodal als verwijderen. ---
+const leaveModalEl = ref(null);
+const confirmingLeave = ref(false);
+const leaveBusy = ref(false);
+const leaveError = ref(null);
+
+watch(confirmingLeave, async (open) => {
+  await nextTick();
+  const el = leaveModalEl.value;
+  if (!el) return;
+  if (open) el.show?.();
+  else el.hide?.();
+});
+
+function askLeave() {
+  leaveError.value = null;
+  confirmingLeave.value = true;
+}
+
+function cancelLeave() {
+  if (!confirmingLeave.value || leaveBusy.value) return; // idempotent: @close + button
+  confirmingLeave.value = false;
+}
+
+async function confirmLeave() {
+  if (leaveBusy.value) return;
+  leaveBusy.value = true;
+  leaveError.value = null;
+  try {
+    await leaveTraject(props.trajectId);
+    confirmingLeave.value = false;
+    emit('left', props.trajectId);
+    close();
+  } catch (e) {
+    confirmingLeave.value = false;
+    leaveError.value = e.message || 'Verlaten mislukt';
+  } finally {
+    leaveBusy.value = false;
   }
 }
 </script>
@@ -229,6 +272,22 @@ async function confirmDelete() {
               <nldd-inline-dialog variant="alert" :text="deleteError"></nldd-inline-dialog>
             </template>
           </template>
+
+          <!-- Bijdrager: traject verlaten, zelfde bevestigingspatroon als delete. -->
+          <template v-else-if="detail.role">
+            <nldd-spacer size="24"></nldd-spacer>
+            <nldd-button
+              variant="destructive"
+              size="md"
+              width="full"
+              text="Traject verlaten"
+              @click="askLeave"
+            ></nldd-button>
+            <template v-if="leaveError">
+              <nldd-spacer size="16"></nldd-spacer>
+              <nldd-inline-dialog variant="alert" :text="leaveError"></nldd-inline-dialog>
+            </template>
+          </template>
         </nldd-simple-section>
       </nldd-page>
     </nldd-sheet>
@@ -248,9 +307,30 @@ async function confirmDelete() {
       <nldd-button
         slot="actions"
         variant="destructive"
-        :text="deleteBusy ? 'Bezig…' : 'Verwijder'"
+        :text="deleteBusy ? 'Bezig…' : 'Verwijder traject'"
         :disabled="deleteBusy || undefined"
         @click="confirmDelete"
+      ></nldd-button>
+    </nldd-modal-dialog>
+  </Teleport>
+
+  <!-- Leave confirmation — same NLDD modal pattern as delete, from the
+       contributor's side. -->
+  <Teleport to="body">
+    <nldd-modal-dialog
+      ref="leaveModalEl"
+      variant="alert"
+      :text="`Traject ${trajectName} verlaten?`"
+      supporting-text="Je verlaat dit traject definitief en verliest meteen je toegang. Wil je later weer bijdragen, dan moet een eigenaar je opnieuw uitnodigen."
+      @close="cancelLeave"
+    >
+      <nldd-button slot="actions" variant="primary" text="Blijf in traject" @click="cancelLeave"></nldd-button>
+      <nldd-button
+        slot="actions"
+        variant="destructive"
+        :text="leaveBusy ? 'Bezig…' : 'Verlaat traject'"
+        :disabled="leaveBusy || undefined"
+        @click="confirmLeave"
       ></nldd-button>
     </nldd-modal-dialog>
   </Teleport>

--- a/frontend/src/components/TrajectInfoDialog.vue
+++ b/frontend/src/components/TrajectInfoDialog.vue
@@ -111,7 +111,7 @@ async function confirmDelete() {
     emit('deleted', props.trajectId);
     close();
   } catch (e) {
-    confirmingDelete.value = false;
+    // Keep the modal open so the user can read the error and retry in place.
     deleteError.value = e.message || 'Verwijderen mislukt';
   } finally {
     deleteBusy.value = false;
@@ -152,7 +152,7 @@ async function confirmLeave() {
     emit('left', props.trajectId);
     close();
   } catch (e) {
-    confirmingLeave.value = false;
+    // Keep the modal open so the user can read the error and retry in place.
     leaveError.value = e.message || 'Verlaten mislukt';
   } finally {
     leaveBusy.value = false;
@@ -267,10 +267,6 @@ async function confirmLeave() {
               text="Traject verwijderen"
               @click="askDelete"
             ></nldd-button>
-            <template v-if="deleteError">
-              <nldd-spacer size="16"></nldd-spacer>
-              <nldd-inline-dialog variant="alert" :text="deleteError"></nldd-inline-dialog>
-            </template>
           </template>
 
           <!-- Bijdrager: traject verlaten, zelfde bevestigingspatroon als delete. -->
@@ -283,10 +279,6 @@ async function confirmLeave() {
               text="Traject verlaten"
               @click="askLeave"
             ></nldd-button>
-            <template v-if="leaveError">
-              <nldd-spacer size="16"></nldd-spacer>
-              <nldd-inline-dialog variant="alert" :text="leaveError"></nldd-inline-dialog>
-            </template>
           </template>
         </nldd-simple-section>
       </nldd-page>
@@ -303,6 +295,7 @@ async function confirmLeave() {
       supporting-text="Het traject wordt definitief verwijderd, inclusief leden en uitnodigingen. De traject-branch op GitHub blijft bestaan. Dit kan niet ongedaan worden gemaakt."
       @close="cancelDelete"
     >
+      <nldd-inline-dialog v-if="deleteError" variant="alert" :text="deleteError"></nldd-inline-dialog>
       <nldd-button slot="actions" variant="primary" text="Behoud traject" @click="cancelDelete"></nldd-button>
       <nldd-button
         slot="actions"
@@ -324,6 +317,7 @@ async function confirmLeave() {
       supporting-text="Je verlaat dit traject definitief en verliest meteen je toegang. Wil je later weer bijdragen, dan moet een eigenaar je opnieuw uitnodigen."
       @close="cancelLeave"
     >
+      <nldd-inline-dialog v-if="leaveError" variant="alert" :text="leaveError"></nldd-inline-dialog>
       <nldd-button slot="actions" variant="primary" text="Blijf in traject" @click="cancelLeave"></nldd-button>
       <nldd-button
         slot="actions"

--- a/frontend/src/components/TrajectInfoDialog.vue
+++ b/frontend/src/components/TrajectInfoDialog.vue
@@ -169,11 +169,6 @@ async function confirmDelete() {
               <nldd-spacer-cell size="8"></nldd-spacer-cell>
               <nldd-text-cell :text="detail.role"></nldd-text-cell>
             </nldd-list-item>
-          </nldd-list>
-
-          <nldd-spacer size="24"></nldd-spacer>
-
-          <nldd-list variant="box">
             <nldd-list-item size="md">
               <nldd-text-cell
                 text="Repo"

--- a/frontend/src/components/TrajectMembersDialog.vue
+++ b/frontend/src/components/TrajectMembersDialog.vue
@@ -213,11 +213,15 @@ async function clickLeave() {
         ></nldd-top-title-bar>
 
         <nldd-simple-section v-if="loading">
-          <p class="members-status">Laden…</p>
+          <nldd-activity-indicator text="Leden laden" show-text></nldd-activity-indicator>
         </nldd-simple-section>
 
         <nldd-simple-section v-else-if="loadError">
-          <p class="members-error">{{ loadError.message || 'Fout bij laden' }}</p>
+          <nldd-inline-dialog
+            variant="alert"
+            text="Leden niet geladen"
+            :supporting-text="loadError.message"
+          ></nldd-inline-dialog>
         </nldd-simple-section>
 
         <template v-else>
@@ -225,6 +229,9 @@ async function clickLeave() {
             <nldd-list variant="box">
               <template v-for="m in members" :key="m.account_id">
                 <nldd-list-item size="md">
+                  <nldd-spacer-cell slot="start" size="12"></nldd-spacer-cell>
+                  <nldd-icon-cell slot="start" size="20"><nldd-icon name="user"></nldd-icon></nldd-icon-cell>
+                  <nldd-spacer-cell slot="start" size="8"></nldd-spacer-cell>
                   <nldd-text-cell :supporting-text="m.name ? m.email : null">
                     <span class="member-name">
                       <span>{{ m.name || m.email }}</span>
@@ -269,8 +276,9 @@ async function clickLeave() {
                 </div>
               </template>
               <nldd-list-item v-if="isOwner" size="md" button @click="openInvite">
-                <nldd-icon-cell size="20"><nldd-icon name="plus"></nldd-icon></nldd-icon-cell>
-                <nldd-spacer-cell size="8"></nldd-spacer-cell>
+                <nldd-spacer-cell slot="start" size="12"></nldd-spacer-cell>
+                <nldd-icon-cell slot="start" size="20"><nldd-icon name="plus"></nldd-icon></nldd-icon-cell>
+                <nldd-spacer-cell slot="start" size="8"></nldd-spacer-cell>
                 <nldd-text-cell text="Lid uitnodigen"></nldd-text-cell>
                 <nldd-spacer-cell size="8"></nldd-spacer-cell>
                 <nldd-icon-cell size="20"><nldd-icon name="chevron-right"></nldd-icon></nldd-icon-cell>
@@ -284,6 +292,9 @@ async function clickLeave() {
               <nldd-list variant="box">
                 <template v-for="inv in pendingInvites" :key="inv.email">
                   <nldd-list-item size="md">
+                    <nldd-spacer-cell slot="start" size="12"></nldd-spacer-cell>
+                    <nldd-icon-cell slot="start" size="20"><nldd-icon name="user"></nldd-icon></nldd-icon-cell>
+                    <nldd-spacer-cell slot="start" size="8"></nldd-spacer-cell>
                     <nldd-text-cell
                       :text="inv.email"
                       supporting-text="Wacht op eerste login"
@@ -318,7 +329,8 @@ async function clickLeave() {
                 Je verliest direct toegang tot dit traject. Een owner kan je later
                 opnieuw uitnodigen.
               </p>
-              <div v-if="leaveError" class="members-error">{{ leaveError }}</div>
+              <nldd-banner v-if="leaveError" variant="critical" :text="leaveError"></nldd-banner>
+              <nldd-spacer v-if="leaveError" size="16"></nldd-spacer>
               <nldd-button
                 variant="ghost"
                 size="md"
@@ -395,7 +407,6 @@ async function clickLeave() {
   align-items: center;
   gap: 8px;
 }
-.members-status,
 .members-leave-hint {
   font-size: 13px;
   color: var(--semantics-content-secondary-color, #555);

--- a/frontend/src/components/TrajectMembersDialog.vue
+++ b/frontend/src/components/TrajectMembersDialog.vue
@@ -1,7 +1,6 @@
 <script setup>
 import { computed, nextTick, ref, watch } from 'vue';
 import { useTrajectMembers } from '../composables/useTrajectMembers.js';
-import { refreshTrajects } from '../composables/useTrajects.js';
 
 const props = defineProps({
   /** Whether the sheet is currently open. */
@@ -27,7 +26,6 @@ const {
   updateRole,
   removeMember,
   removeInvite,
-  leaveTraject,
 } = useTrajectMembers();
 
 const isOwner = computed(() => callerRole.value === 'owner');
@@ -175,22 +173,6 @@ async function clickRemoveInvite(inv) {
   }
 }
 
-const leaveBusy = ref(false);
-const leaveError = ref(null);
-
-async function clickLeave() {
-  leaveError.value = null;
-  leaveBusy.value = true;
-  try {
-    await leaveTraject(props.trajectId);
-    await refreshTrajects();
-    close();
-  } catch (e) {
-    leaveError.value = e.message || 'Verlaten mislukt';
-  } finally {
-    leaveBusy.value = false;
-  }
-}
 </script>
 
 <template>
@@ -321,24 +303,6 @@ async function clickLeave() {
               </nldd-list>
             </template>
 
-            <template v-if="!isOwner && callerRole">
-              <nldd-spacer size="24"></nldd-spacer>
-              <nldd-title size="4"><h2>Dit traject verlaten</h2></nldd-title>
-              <nldd-spacer size="8"></nldd-spacer>
-              <p class="members-leave-hint">
-                Je verliest direct toegang tot dit traject. Een owner kan je later
-                opnieuw uitnodigen.
-              </p>
-              <nldd-banner v-if="leaveError" variant="critical" :text="leaveError"></nldd-banner>
-              <nldd-spacer v-if="leaveError" size="16"></nldd-spacer>
-              <nldd-button
-                variant="ghost"
-                size="md"
-                :text="leaveBusy ? 'Bezig…' : 'Verlaat traject'"
-                :disabled="leaveBusy || undefined"
-                @click="clickLeave"
-              ></nldd-button>
-            </template>
           </nldd-simple-section>
 
           <!-- Detail: invite form, one level deeper (reached via the
@@ -406,11 +370,6 @@ async function clickLeave() {
   display: inline-flex;
   align-items: center;
   gap: 8px;
-}
-.members-leave-hint {
-  font-size: 13px;
-  color: var(--semantics-content-secondary-color, #555);
-  margin: 8px 0;
 }
 .members-info {
   font-size: 13px;

--- a/frontend/src/components/TrajectMenu.vue
+++ b/frontend/src/components/TrajectMenu.vue
@@ -33,6 +33,22 @@ const route = useRoute();
 const router = useRouter();
 const documentsSheet = useDocumentsSheet();
 
+// Not logged in: log in, then land on the trajectchooser carrying the current
+// section + law/article, so picking a traject returns the user to where they
+// were — now traject-scoped.
+function loginToChooser() {
+  const inLibrary = route.name === 'library' || route.name === 'library-traject';
+  const target = router.resolve({
+    name: 'trajecten',
+    query: {
+      sectie: inLibrary ? 'library' : 'editor',
+      law: route.params.lawId || undefined,
+      article: route.params.articleNumber || undefined,
+    },
+  });
+  login(target.fullPath);
+}
+
 /**
  * Navigate to a traject — push the user into the traject-scoped view of
  * the section they are currently in (bibliotheek or editor), at the same
@@ -239,7 +255,7 @@ async function submitCreate() {
   >
     <nldd-container padding="16">
       <nldd-inline-dialog
-        icon="traject"
+        icon="login"
         text="Log in om een traject te kiezen of aan te maken"
         supporting-text="Zodra je bent ingelogd zie je hier je lopende trajecten en kun je gemakkelijk wisselen."
       >
@@ -247,7 +263,7 @@ async function submitCreate() {
           slot="actions"
           variant="primary"
           text="Inloggen"
-          @click="login()"
+          @click="loginToChooser"
         ></nldd-button>
       </nldd-inline-dialog>
     </nldd-container>

--- a/frontend/src/components/TrajectMenu.vue
+++ b/frontend/src/components/TrajectMenu.vue
@@ -280,6 +280,7 @@ async function submitCreate() {
     :traject-id="infoTrajectId"
     :traject-name="infoTrajectName"
     @deleted="onTrajectDeleted"
+    @left="onTrajectDeleted"
   />
 
   <!-- Teleport the sheet out of the toolbar so it doesn't inherit the

--- a/frontend/src/components/TrajectMenu.vue
+++ b/frontend/src/components/TrajectMenu.vue
@@ -4,6 +4,7 @@ import { useRoute, useRouter } from 'vue-router';
 import { useTrajects } from '../composables/useTrajects.js';
 import { useDocumentsSheet } from '../composables/useDocumentsSheet.js';
 import { useAuth } from '../composables/useAuth.js';
+import { useLoginToChooser } from '../composables/useLoginToChooser.js';
 import TrajectMembersDialog from './TrajectMembersDialog.vue';
 import TrajectInfoDialog from './TrajectInfoDialog.vue';
 import TrajectCreateForm from './TrajectCreateForm.vue';
@@ -28,26 +29,14 @@ const {
 } = useTrajects();
 // Auth gates the menu: logged-in users get the traject switcher; everyone
 // else gets a popover explaining that trajecten unlock after login.
-const { authenticated, login } = useAuth();
+const { authenticated } = useAuth();
 const route = useRoute();
 const router = useRouter();
 const documentsSheet = useDocumentsSheet();
 
 // Not logged in: log in, then land on the trajectchooser carrying the current
-// section + law/article, so picking a traject returns the user to where they
-// were — now traject-scoped.
-function loginToChooser() {
-  const inLibrary = route.name === 'library' || route.name === 'library-traject';
-  const target = router.resolve({
-    name: 'trajecten',
-    query: {
-      sectie: inLibrary ? 'library' : 'editor',
-      law: route.params.lawId || undefined,
-      article: route.params.articleNumber || undefined,
-    },
-  });
-  login(target.fullPath);
-}
+// section + law/article (shared composable, see also MobileTrajectSheet).
+const loginToChooser = useLoginToChooser();
 
 /**
  * Navigate to a traject — push the user into the traject-scoped view of

--- a/frontend/src/composables/useAppChrome.js
+++ b/frontend/src/composables/useAppChrome.js
@@ -63,6 +63,12 @@ const tabActions = shallowRef(null); // { key, displayName, select, close, reord
 const editorChanges = shallowRef(null); // { dirty, saving, canUndo, canRedo } | null
 const editorActions = shallowRef(null); // { save, discard, undo, redo } | null
 
+// --- Library-only chrome ---
+// Whether the library has nothing curated yet (no favorites, no traject edits,
+// no open law). While true, the shell shows the just-in-time search coach-mark
+// on the toolbar search field; the library body itself stays blank.
+const libraryEmpty = shallowRef(false);
+
 export function useAppChrome() {
   return {
     lastSavedPr,
@@ -71,7 +77,14 @@ export function useAppChrome() {
     tabActions,
     editorChanges,
     editorActions,
+    libraryEmpty,
   };
+}
+
+// Published reactively by the library view (and reset when it unmounts) so the
+// shell can gate the search coach-mark on an empty library.
+export function setLibraryEmpty(empty) {
+  libraryEmpty.value = !!empty;
 }
 
 export function setEditorChrome({ pr, tabs, activeTab }) {

--- a/frontend/src/composables/useLoginToChooser.js
+++ b/frontend/src/composables/useLoginToChooser.js
@@ -1,0 +1,24 @@
+import { useRoute, useRouter } from 'vue-router';
+import { useAuth } from './useAuth.js';
+
+// Shared "log in, then land on the traject chooser" redirect. Used by TrajectMenu
+// and MobileTrajectSheet so the return target (scoped to library vs editor, and
+// carrying the open law/article) stays in sync between the two entry points.
+export function useLoginToChooser() {
+  const route = useRoute();
+  const router = useRouter();
+  const { login } = useAuth();
+
+  return function loginToChooser() {
+    const inLibrary = route.name === 'library' || route.name === 'library-traject';
+    const target = router.resolve({
+      name: 'trajecten',
+      query: {
+        sectie: inLibrary ? 'library' : 'editor',
+        law: route.params.lawId || undefined,
+        article: route.params.articleNumber || undefined,
+      },
+    });
+    login(target.fullPath);
+  };
+}

--- a/frontend/src/composables/useTrajectMembers.js
+++ b/frontend/src/composables/useTrajectMembers.js
@@ -88,13 +88,6 @@ export function useTrajectMembers() {
     await load(trajectId);
   }
 
-  async function leaveTraject(trajectId) {
-    await apiFetch(`/api/trajects/${trajectId}/leave`, {
-      method: 'POST',
-      errorMessage: (status, body) => body || `Verlaten mislukt: ${status}`,
-    });
-  }
-
   return {
     members,
     pendingInvites,
@@ -106,6 +99,5 @@ export function useTrajectMembers() {
     updateRole,
     removeMember,
     removeInvite,
-    leaveTraject,
   };
 }

--- a/frontend/src/composables/useTrajects.js
+++ b/frontend/src/composables/useTrajects.js
@@ -62,6 +62,17 @@ export async function deleteTraject(trajectId) {
   await refreshTrajects();
 }
 
+// A contributor leaves a traject (backend: POST /api/trajects/:id/leave). Mirror
+// of deleteTraject from the member's side: refresh the list so the traject they
+// just left drops out immediately.
+export async function leaveTraject(trajectId) {
+  await apiFetch(`/api/trajects/${encodeURIComponent(trajectId)}/leave`, {
+    method: 'POST',
+    errorMessage: (status, body) => body || `Verlaten mislukt: ${status}`,
+  });
+  await refreshTrajects();
+}
+
 // Active traject lives in `route.params.trajectRef` (per-tab state),
 // derived here so consumers do not each repeat the lookup. Returns
 // `null` for any route without a traject param — that's the "global

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -51,24 +51,14 @@ const router = createRouter({
           meta: { title: 'Editor', requiresAuth: true },
         },
         {
-          // Nieuw traject aanmaken — eigen pagina met het gedeelde
-          // aanmaakformulier (TrajectCreateForm). Statisch segment, dus
-          // vue-router rankt dit boven de param-routes hieronder.
-          path: 'editor/nieuw-traject',
-          name: 'editor-nieuw-traject',
-          component: () => import('./TrajectCreateView.vue'),
-          meta: { title: 'Nieuw traject', requiresAuth: true },
-        },
-        {
-          // De editor vereist een traject. De kale /editor is de
-          // trajectkeuze-pagina: kies een bestaand traject of maak er een
-          // aan; daarna ga je door naar `editor-traject`. Een meegegeven wet
-          // (query `law`/`article`, gezet door de redirect hieronder) opent
-          // na de keuze direct in de editor.
+          // De kale /editor vereist nog steeds een traject: door naar de
+          // chooser met sectie=editor (meegegeven query blijft behouden). De
+          // naam 'editor' blijft bestaan zodat alle bestaande
+          // `{ name: 'editor' }`-navigaties (Editor-tab, sectionTarget,
+          // redirects) hier doorheen naar de chooser lopen.
           path: 'editor',
           name: 'editor',
-          component: () => import('./TrajectChooserView.vue'),
-          meta: { title: 'Kies een traject', requiresAuth: true },
+          redirect: (to) => ({ name: 'trajecten', query: { sectie: 'editor', ...to.query } }),
         },
         {
           // Editor-links zonder traject (de vroegere read-only editor): er is
@@ -80,14 +70,36 @@ const router = createRouter({
           // De declaratievolgorde is hier de scheidsrechter.
           path: 'editor/:lawId/:articleNumber?',
           redirect: (to) => ({
-            name: 'editor',
+            name: 'trajecten',
             query: {
+              sectie: 'editor',
               law: to.params.lawId,
               article: to.params.articleNumber || undefined,
             },
           }),
         },
       ],
+    },
+    {
+      // Trajectchooser — sectie-neutrale URL (library|editor via `sectie`,
+      // default editor) zodat zowel de bibliotheek als de editor 'm gebruiken;
+      // `law`/`article` dragen de beoogde bestemming mee. Top-level route (geen
+      // AppShell-child), zoals werkdocumenten: geen app-chrome, de pagina draagt
+      // z'n eigen top-title-bar met terugknop naar de bibliotheek.
+      path: '/trajecten',
+      name: 'trajecten',
+      component: () => import('./TrajectChooserView.vue'),
+      meta: { title: 'Trajecten', requiresAuth: true },
+    },
+    {
+      // Nieuw traject aanmaken — eigen pagina met het gedeelde aanmaakformulier
+      // (TrajectCreateForm). Ook top-level (geen app-chrome). Het statische pad
+      // `/editor/nieuw-traject` scoort boven de dynamische `/editor/...`-routes
+      // in de AppShell, dus een traject-ref of wet-id matcht deze nooit.
+      path: '/editor/nieuw-traject',
+      name: 'editor-nieuw-traject',
+      component: () => import('./TrajectCreateView.vue'),
+      meta: { title: 'Nieuw traject', requiresAuth: true },
     },
     {
       // Standalone full-page werkdocumenten editor, opened in a new tab from
@@ -105,8 +117,9 @@ const router = createRouter({
     {
       path: '/editor.html',
       redirect: (to) => ({
-        name: 'editor',
+        name: 'trajecten',
         query: {
+          sectie: 'editor',
           law: to.query.law || undefined,
           article: to.query.article || undefined,
         },

--- a/frontend/src/router.test.js
+++ b/frontend/src/router.test.js
@@ -24,19 +24,20 @@ describe('route disambiguation (traject vs no-traject)', () => {
 
   it('mirrors the same split for the editor routes', () => {
     expect(router.resolve(`/editor/${REF}/foo`).name).toBe('editor-traject');
-    // The bare /editor is the traject chooser; a law URL without a
-    // traject redirects onto it (the law travels along as query).
-    expect(router.resolve('/editor').name).toBe('editor');
+    // The chooser lives at its own section-neutral URL (/trajecten); the bare
+    // /editor redirects onto it with sectie=editor, and a no-traject law URL
+    // does the same with the law carried as query.
+    expect(router.resolve('/trajecten').name).toBe('trajecten');
     expect(router.resolve('/editor/nieuw-traject').name).toBe('editor-nieuw-traject');
     // A no-traject law URL hits a redirect route (router.resolve returns the
     // redirect record without following it). Assert it redirects onto the
-    // chooser, carrying the law as query.
+    // chooser, carrying the section + law as query.
     const matched = router.resolve('/editor/wet_op_de_zorgtoeslag').matched;
     const redirect = matched[matched.length - 1].redirect;
     expect(redirect).toBeTruthy();
     expect(redirect({ params: { lawId: 'wet_op_de_zorgtoeslag' } })).toMatchObject({
-      name: 'editor',
-      query: { law: 'wet_op_de_zorgtoeslag' },
+      name: 'trajecten',
+      query: { sectie: 'editor', law: 'wet_op_de_zorgtoeslag' },
     });
   });
 });


### PR DESCRIPTION
## Wat

Maakt de trajectkeuze een zelfstandige pagina, voegt toetsenbord-pijltjesnavigatie
toe aan de lijsten, en bevat diverse library/editor-polish. Draait nu op de
gepubliceerde `@nldd/design-system` 0.8.63 (geen lokale overlay meer).

## Highlights

### Zelfstandige trajectkeuze
- Nieuwe `/trajecten`-chooser zonder app-chrome, met aanmaak-flow.
- Page-footer op de keuze- en aanmaakpagina.
- "Verlaat traject"-flow naar de traject-details.

### Pijltjesnavigatie op lijsten
- `arrow-navigation` op alle simpele button/link-lijsten: bibliotheek
  (wetten-secties + artikelen), werkdocumenten (sidebar + launcher-sheet),
  trajectkeuze, mobiele traject-sheet, zoekresultaten, actie-sheet en
  scenario-bronnen.
- Tab springt tussen lijsten; ↑/↓ navigeert binnen een lijst (wrap-around,
  Home/End). Lijsten met losse controls of read-only rijen zijn bewust overgeslagen.

### Library & editor polish
- Trajectnaam in de document-titel (browsertab).
- Nette lege-, laad- en foutstates in library en editor: notities/yaml-panes,
  "geen artikel"-melding gecentreerd, eerste tab open bij laden, één blokkerende
  foutmelding in werkdocumenten.
- Consistente leading-icons in lijsten.

### Dependencies
- `@nldd/design-system` → 0.8.63 (npm release; vervangt de tarball-overlay).

## Verificatie
- Dev-server draait schoon op de nieuwe DS-release.