### PR TITLE
fix(deps): patch frontend npm advisories (undici, dompurify)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2594,9 +2594,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.10",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
-      "integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -4397,9 +4397,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
-      "integrity": "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Summary

The required **Security Audit** check started failing repo-wide (on every open PR and `main`) after two npm advisories were freshly published against existing frontend dependencies. `cargo deny` is clean; the failure is `frontend` `npm audit`:

- **high** — `undici` 7.0.0–7.27.2: TLS cert-validation bypass (GHSA-vmh5-mc38-953g) + cross-user cache disclosure (GHSA-pr7r-676h-xcf6)
- **moderate** — `dompurify` ≤3.4.10: permanent `ALLOWED_ATTR` pollution via `setConfig()` (GHSA-cmwh-pvxp-8882)

`npm audit fix` resolves both with **lockfile-only** bumps (no `package.json` range change):

- `dompurify` 3.4.10 → **3.4.11**
- `undici` 7.27.2 → **7.28.0**

`npm audit` now reports **0 vulnerabilities**.

## Why a separate PR

This is an unrelated, repo-wide security bump; keeping it out of the feature PR (#832) that it currently blocks. dompurify was recently pinned/unblocked at 3.4.8 for a happy-dom NodeIterator quirk (#773), so this is gated on the full frontend test suite to confirm the patch bump doesn't regress it.

## Test plan

- [x] `npm audit` → 0 vulnerabilities
- [x] `npm run build` (frontend) passes
- [x] `npm run test` (vitest) — 33 files, 354 tests pass (dompurify 3.4.11 does not reintroduce the happy-dom quirk)