### PR TITLE
fix(engine): load all law versions for date-aware cross-law resolution

### DIFF
--- a/frontend/src/components/ScenarioBuilder.vue
+++ b/frontend/src/components/ScenarioBuilder.vue
@@ -169,7 +169,11 @@ async function fetchLawVersions(lawId) {
     errorMessage: (status) => `Failed to fetch versions of law '${lawId}': ${status}`,
   });
   const list = Array.isArray(yamls) ? yamls : [];
-  versionsCache[lawId] = list;
+  // Only cache a non-empty result. An empty array (unknown/not-yet-harvested
+  // law) must stay uncached so a retry after harvest re-fetches rather than
+  // returning the stale `[]` — `[]` is truthy, so caching it would short-
+  // circuit the `if (versionsCache[lawId])` guard forever.
+  if (list.length > 0) versionsCache[lawId] = list;
   return list;
 }
 

--- a/frontend/src/components/ScenarioBuilder.vue
+++ b/frontend/src/components/ScenarioBuilder.vue
@@ -2,8 +2,8 @@
 import { ref, computed, watch, nextTick, onBeforeUnmount } from 'vue';
 import { useDependencies } from '../composables/useDependencies.js';
 import { useScenarios, isScenarioMismatch } from '../composables/useScenarios.js';
-import { lawUrl } from '../composables/corpusUrls.js';
-import { apiFetchText } from '../lib/apiFetch.js';
+import { lawVersionsUrl } from '../composables/corpusUrls.js';
+import { apiFetchJson } from '../lib/apiFetch.js';
 import { useLatest } from '../lib/useLatest.js';
 import { parseFeature } from '../gherkin/parser.js';
 import { mapFeatureToForm, getEffectiveSetup, formStateToGherkin, syncEditedValues } from '../gherkin/formMapper.js';
@@ -151,22 +151,25 @@ watch(featureText, (text) => {
   }
 });
 
-// Cache for fetched law YAML texts, scoped to the active traject so a
-// traject switch doesn't return the previous traject's body.
-const yamlCache = {};
-let yamlCacheTrajectRef = null;
+// Cache for fetched law version lists, scoped to the active traject so a
+// traject switch doesn't return the previous traject's bodies. The dependency
+// loader needs *every* version of a law (not just today's-best) so the engine
+// can pick the one in force on the scenario's calculation date.
+const versionsCache = {};
+let versionsCacheTrajectRef = null;
 
-async function fetchLawYaml(lawId) {
-  if (yamlCacheTrajectRef !== props.trajectRef) {
-    Object.keys(yamlCache).forEach((k) => delete yamlCache[k]);
-    yamlCacheTrajectRef = props.trajectRef;
+async function fetchLawVersions(lawId) {
+  if (versionsCacheTrajectRef !== props.trajectRef) {
+    Object.keys(versionsCache).forEach((k) => delete versionsCache[k]);
+    versionsCacheTrajectRef = props.trajectRef;
   }
-  if (yamlCache[lawId]) return yamlCache[lawId];
-  const text = await apiFetchText(lawUrl(props.trajectRef, lawId), {
-    errorMessage: (status) => `Failed to fetch law '${lawId}': ${status}`,
+  if (versionsCache[lawId]) return versionsCache[lawId];
+  const yamls = await apiFetchJson(lawVersionsUrl(props.trajectRef, lawId), {
+    errorMessage: (status) => `Failed to fetch versions of law '${lawId}': ${status}`,
   });
-  yamlCache[lawId] = text;
-  return text;
+  const list = Array.isArray(yamls) ? yamls : [];
+  versionsCache[lawId] = list;
+  return list;
 }
 
 // --- Dependencies ready tracking ---
@@ -210,7 +213,7 @@ async function runDependencyLoad() {
   const isCurrent = claimDependencyLoad();
   depsReady.value = false;
 
-  const mainLawId = await loadAllDependencies(lawYaml, props.engine, fetchLawYaml);
+  const mainLawId = await loadAllDependencies(lawYaml, props.engine, fetchLawVersions);
   if (!isCurrent()) return;
 
   // Also load dependencies from scenario background + per-scenario steps
@@ -223,8 +226,8 @@ async function runDependencyLoad() {
     for (const depId of allDeps) {
       try {
         if (!props.engine.hasLaw(depId)) {
-          const yaml = await fetchLawYaml(depId);
-          props.engine.loadLaw(yaml);
+          const yamls = await fetchLawVersions(depId);
+          for (const versionYaml of yamls) props.engine.loadLaw(versionYaml);
         }
       } catch (e) {
         console.warn(`Failed to load scenario dependency '${depId}':`, e);
@@ -245,7 +248,7 @@ async function runDependencyLoad() {
     // the component, and the guard resets on error so a fresh mount retries.
     depsReady.value = true;
     if (mainLawId) {
-      loadImplementors(mainLawId, props.engine, fetchLawYaml, props.trajectRef);
+      loadImplementors(mainLawId, props.engine, fetchLawVersions, props.trajectRef);
     }
   }
 }

--- a/frontend/src/components/ScenarioBuilder.vue
+++ b/frontend/src/components/ScenarioBuilder.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { ref, computed, watch, nextTick, onBeforeUnmount } from 'vue';
 import { useDependencies } from '../composables/useDependencies.js';
+import { loadLawVersions } from '../composables/useEngine.js';
 import { useScenarios, isScenarioMismatch } from '../composables/useScenarios.js';
 import { lawVersionsUrl } from '../composables/corpusUrls.js';
 import { apiFetchJson } from '../lib/apiFetch.js';
@@ -227,7 +228,7 @@ async function runDependencyLoad() {
       try {
         if (!props.engine.hasLaw(depId)) {
           const yamls = await fetchLawVersions(depId);
-          for (const versionYaml of yamls) props.engine.loadLaw(versionYaml);
+          loadLawVersions(props.engine, yamls, depId);
         }
       } catch (e) {
         console.warn(`Failed to load scenario dependency '${depId}':`, e);

--- a/frontend/src/composables/corpusUrls.js
+++ b/frontend/src/composables/corpusUrls.js
@@ -20,6 +20,16 @@ export function lawUrl(trajectRef, lawId) {
   return `${corpusBase(trajectRef)}/laws/${encodeURIComponent(lawId)}`;
 }
 
+// All versions of a law (newest-first), as a JSON array of YAML strings.
+// Unlike `lawUrl` (one "best for today" body), the scenario dependency loader
+// feeds every version to the engine so its date-aware version selection can
+// pick the one in force on the scenario's calculation date — otherwise a
+// referenced law that has a future-dated version would load only that future
+// version and fail "not yet in force" for a past-dated scenario.
+export function lawVersionsUrl(trajectRef, lawId) {
+  return `${lawUrl(trajectRef, lawId)}/versions`;
+}
+
 export function lawsListUrl(trajectRef, query = '') {
   const q = query ? `?${query}` : '';
   return `${corpusBase(trajectRef)}/laws${q}`;

--- a/frontend/src/composables/useDependencies.js
+++ b/frontend/src/composables/useDependencies.js
@@ -123,7 +123,14 @@ export function useDependencies() {
           // not-yet-in-force version.
           const newDeps = [];
           for (const versionYaml of yamls) {
-            collectDeps(yaml.load(versionYaml), visited, newDeps);
+            // Isolate the ref scan per version too: a version that loaded into
+            // the engine but is malformed for `js-yaml` must not throw here and
+            // get the (already-loaded) law spuriously marked missing + harvested.
+            try {
+              collectDeps(yaml.load(versionYaml), visited, newDeps);
+            } catch (e) {
+              console.warn(`Skipped transitive-ref scan of an unparseable version of '${lawId}':`, e);
+            }
           }
           if (newDeps.length > 0) {
             toLoad.push(...newDeps);

--- a/frontend/src/composables/useDependencies.js
+++ b/frontend/src/composables/useDependencies.js
@@ -11,6 +11,7 @@
 import { ref } from 'vue';
 import yaml from 'js-yaml';
 import { useBwbHarvest } from './useBwbHarvest.js';
+import { loadLawVersions } from './useEngine.js';
 import { implementorsUrl } from './corpusUrls.js';
 import { apiFetchJson } from '../lib/apiFetch.js';
 
@@ -101,14 +102,13 @@ export function useDependencies() {
 
         try {
           const yamls = await fetchLawVersions(lawId);
-          if (!yamls || yamls.length === 0) {
-            // No version of this law is available — treat as a missing
-            // dependency (harvest is requested below), same as a fetch error.
-            throw new Error(`no versions returned for '${lawId}'`);
+          // Load every version (isolating each) so the engine's date-aware
+          // selection can pick the one in force on the scenario's calculation
+          // date. No version loading — empty list or every version unloadable —
+          // is treated as a missing dependency (harvest requested below).
+          if (!loadLawVersions(engine, yamls, lawId)) {
+            throw new Error(`no loadable version for '${lawId}'`);
           }
-          // Load every version so the engine's date-aware selection can pick
-          // the one in force on the scenario's calculation date.
-          for (const versionYaml of yamls) engine.loadLaw(versionYaml);
           loaded++;
           loadedDeps.value = [...loadedDeps.value, lawId];
           progress.value = `${loaded}/${total} wetten geladen`;
@@ -205,8 +205,7 @@ export function useDependencies() {
       try {
         if (!engine.hasLaw(implId)) {
           const yamls = await fetchLawVersions(implId);
-          if (yamls && yamls.length > 0) {
-            for (const versionYaml of yamls) engine.loadLaw(versionYaml);
+          if (loadLawVersions(engine, yamls, implId)) {
             loadedDeps.value = [...loadedDeps.value, implId];
           }
         }

--- a/frontend/src/composables/useDependencies.js
+++ b/frontend/src/composables/useDependencies.js
@@ -114,8 +114,13 @@ export function useDependencies() {
           progress.value = `${loaded}/${total} wetten geladen`;
 
           // Recurse for transitive deps. Collect from every version — a
-          // `source.regulation` reference can appear in one version's articles
-          // and not another's.
+          // `source.regulation` reference can appear in one version and not
+          // another, and a scenario may be evaluated at any calculation date
+          // (including a future one), so a reference introduced only by a
+          // future version must still be loadable. This can over-fetch a
+          // transitive law that no in-force version needs; that's an accepted,
+          // bounded cost — the engine's `select_in` simply never selects a
+          // not-yet-in-force version.
           const newDeps = [];
           for (const versionYaml of yamls) {
             collectDeps(yaml.load(versionYaml), visited, newDeps);

--- a/frontend/src/composables/useDependencies.js
+++ b/frontend/src/composables/useDependencies.js
@@ -58,15 +58,19 @@ export function useDependencies() {
    * the engine. Returns the law's `$id` (or null) so the caller can kick off
    * the off-critical-path `loadImplementors` scan.
    *
-   * `fetchLawYaml` already resolves through the active traject, so no traject
-   * ref is needed here.
+   * `fetchLawVersions` already resolves through the active traject, so no
+   * traject ref is needed here. It returns **all** versions of a law (the
+   * engine keys versions by `($id, valid_from)`, so several bodies of one law
+   * coexist), and the engine picks the version in force on the scenario's
+   * calculation date — a referenced law that has a future-dated version would
+   * otherwise load only that future version and fail "not yet in force".
    *
    * @param {string} lawYamlText - Raw YAML text of the main law
    * @param {object} engine - WasmEngine instance
-   * @param {(lawId: string) => Promise<string>} fetchLawYaml - Fetch law YAML by ID
+   * @param {(lawId: string) => Promise<string[]>} fetchLawVersions - Fetch all version YAMLs by ID
    * @returns {Promise<string|null>} The main law's `$id`.
    */
-  async function loadAllDependencies(lawYamlText, engine, fetchLawYaml) {
+  async function loadAllDependencies(lawYamlText, engine, fetchLawVersions) {
     loading.value = true;
     error.value = null;
     loadedDeps.value = [];
@@ -96,16 +100,26 @@ export function useDependencies() {
         }
 
         try {
-          const yamlText = await fetchLawYaml(lawId);
-          engine.loadLaw(yamlText);
+          const yamls = await fetchLawVersions(lawId);
+          if (!yamls || yamls.length === 0) {
+            // No version of this law is available — treat as a missing
+            // dependency (harvest is requested below), same as a fetch error.
+            throw new Error(`no versions returned for '${lawId}'`);
+          }
+          // Load every version so the engine's date-aware selection can pick
+          // the one in force on the scenario's calculation date.
+          for (const versionYaml of yamls) engine.loadLaw(versionYaml);
           loaded++;
           loadedDeps.value = [...loadedDeps.value, lawId];
           progress.value = `${loaded}/${total} wetten geladen`;
 
-          // Recurse into newly loaded law for transitive deps
-          const depLaw = yaml.load(yamlText);
+          // Recurse for transitive deps. Collect from every version — a
+          // `source.regulation` reference can appear in one version's articles
+          // and not another's.
           const newDeps = [];
-          collectDeps(depLaw, visited, newDeps);
+          for (const versionYaml of yamls) {
+            collectDeps(yaml.load(versionYaml), visited, newDeps);
+          }
           if (newDeps.length > 0) {
             toLoad.push(...newDeps);
             total = toLoad.length;
@@ -154,10 +168,10 @@ export function useDependencies() {
    *
    * @param {string|null} lawId - The `$id` of the law to find implementors of.
    * @param {object} engine - WasmEngine instance.
-   * @param {(lawId: string) => Promise<string>} fetchLawYaml - Fetch law YAML.
+   * @param {(lawId: string) => Promise<string[]>} fetchLawVersions - Fetch all version YAMLs.
    * @param {string|null} trajectRef - Active traject reference.
    */
-  async function loadImplementors(lawId, engine, fetchLawYaml, trajectRef = null) {
+  async function loadImplementors(lawId, engine, fetchLawVersions, trajectRef = null) {
     if (!lawId) return;
     const key = `${trajectRef || ''}::${lawId}`;
     if (implementorsKey === key) return;
@@ -185,9 +199,11 @@ export function useDependencies() {
     for (const implId of implementors) {
       try {
         if (!engine.hasLaw(implId)) {
-          const yamlText = await fetchLawYaml(implId);
-          engine.loadLaw(yamlText);
-          loadedDeps.value = [...loadedDeps.value, implId];
+          const yamls = await fetchLawVersions(implId);
+          if (yamls && yamls.length > 0) {
+            for (const versionYaml of yamls) engine.loadLaw(versionYaml);
+            loadedDeps.value = [...loadedDeps.value, implId];
+          }
         }
       } catch (e) {
         console.warn(`Failed to load implementing regulation '${implId}':`, e);

--- a/frontend/src/composables/useDependencies.test.js
+++ b/frontend/src/composables/useDependencies.test.js
@@ -6,13 +6,18 @@ function res(json, ok = true, status = 200) {
   return { ok, status, async json() { return json; }, async text() { return ''; } };
 }
 
-// Fake WASM engine: tracks which laws were loaded.
+// Fake WASM engine: tracks which law ids are loaded, plus every body handed to
+// `loadLaw` so multi-version loading can be asserted (the real engine keys
+// versions by ($id, valid_from), so several bodies of one id coexist).
 function fakeEngine() {
   const loaded = new Set();
+  const bodies = [];
   return {
     loaded,
+    bodies,
     hasLaw: (id) => loaded.has(id),
     loadLaw: (yamlText) => {
+      bodies.push(yamlText);
       const m = yamlText.match(/\$id:\s*(\S+)/);
       if (m) loaded.add(m[1]);
     },
@@ -32,10 +37,11 @@ articles:
               output: dekking
 `;
 
-// Dependency YAMLs with no further refs, so the walk terminates.
-const DEP_YAML = {
-  zorgverzekeringswet: '$id: zorgverzekeringswet\narticles: []\n',
-  regeling_standaardpremie: '$id: regeling_standaardpremie\narticles: []\n',
+// Version lists per law id (the `fetchLawVersions` contract). No further refs,
+// so the walk terminates.
+const DEP_VERSIONS = {
+  zorgverzekeringswet: ['$id: zorgverzekeringswet\narticles: []\n'],
+  regeling_standaardpremie: ['$id: regeling_standaardpremie\narticles: []\n'],
 };
 
 beforeEach(() => {
@@ -54,19 +60,61 @@ describe('extractRegulationRefs', () => {
 describe('useDependencies.loadAllDependencies', () => {
   it('loads source.regulation deps, returns the $id, and does NOT scan the corpus', async () => {
     // The implementor scan is off the critical path, so loading the law's own
-    // deps must make no network call at all (only fetchLawYaml is used).
+    // deps must make no network call at all (only fetchLawVersions is used).
     const fetchSpy = vi.fn();
     globalThis.fetch = fetchSpy;
     const engine = fakeEngine();
-    const fetchLawYaml = vi.fn(async (id) => DEP_YAML[id]);
+    const fetchLawVersions = vi.fn(async (id) => DEP_VERSIONS[id]);
 
     const { loadAllDependencies, loading } = useDependencies();
-    const mainLawId = await loadAllDependencies(MAIN_LAW, engine, fetchLawYaml);
+    const mainLawId = await loadAllDependencies(MAIN_LAW, engine, fetchLawVersions);
 
     expect(mainLawId).toBe('wet_op_de_zorgtoeslag');
     expect(engine.loaded.has('zorgverzekeringswet')).toBe(true);
     expect(fetchSpy).not.toHaveBeenCalled();
     expect(loading.value).toBe(false);
+  });
+
+  it('loads EVERY version of a dependency (in-force + future), not just one', async () => {
+    // Regression for the temporal-federation bug: a referenced law that has a
+    // future-dated version must have *all* its versions loaded so the engine
+    // can pick the one in force on the scenario date — loading only the future
+    // version would fail "not yet in force" for a past-dated scenario.
+    const inForce = '$id: zorgverzekeringswet\nvalid_from: \'2025-01-01\'\narticles: []\n';
+    const future = '$id: zorgverzekeringswet\nvalid_from: \'2099-01-01\'\narticles: []\n';
+    const engine = fakeEngine();
+    const fetchLawVersions = vi.fn(async (id) =>
+      id === 'zorgverzekeringswet' ? [future, inForce] : DEP_VERSIONS[id],
+    );
+
+    const { loadAllDependencies } = useDependencies();
+    await loadAllDependencies(MAIN_LAW, engine, fetchLawVersions);
+
+    const zvwBodies = engine.bodies.filter((b) => b.includes('$id: zorgverzekeringswet'));
+    expect(zvwBodies).toHaveLength(2);
+    expect(zvwBodies).toContain(inForce);
+    expect(zvwBodies).toContain(future);
+  });
+
+  it('treats an empty version list as a missing dependency (requests harvest)', async () => {
+    // /versions returning [] means no version is available — the loader must
+    // not silently succeed; it routes the id to the harvest request like a
+    // fetch failure. The harvest call is the only network request.
+    const fetchSpy = vi.fn(async (url) => {
+      if (String(url).includes('/harvest')) return res({ results: [] });
+      return res([], false, 404);
+    });
+    globalThis.fetch = fetchSpy;
+    const engine = fakeEngine();
+    const fetchLawVersions = vi.fn(async () => []);
+
+    const { loadAllDependencies } = useDependencies();
+    await loadAllDependencies(MAIN_LAW, engine, fetchLawVersions);
+
+    expect(engine.loaded.has('zorgverzekeringswet')).toBe(false);
+    // The missing dep is routed to harvest, not silently dropped.
+    const harvestCalls = fetchSpy.mock.calls.filter((c) => String(c[0]).includes('/harvest'));
+    expect(harvestCalls.length).toBeGreaterThan(0);
   });
 });
 
@@ -78,10 +126,10 @@ describe('useDependencies.loadImplementors', () => {
     });
     globalThis.fetch = fetchSpy;
     const engine = fakeEngine();
-    const fetchLawYaml = vi.fn(async (id) => DEP_YAML[id]);
+    const fetchLawVersions = vi.fn(async (id) => DEP_VERSIONS[id]);
 
     const { loadImplementors } = useDependencies();
-    await loadImplementors('wet_op_de_zorgtoeslag', engine, fetchLawYaml, 'mig-1a2b3c4d');
+    await loadImplementors('wet_op_de_zorgtoeslag', engine, fetchLawVersions, 'mig-1a2b3c4d');
 
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(fetchSpy.mock.calls[0][0]).toBe(
@@ -95,11 +143,11 @@ describe('useDependencies.loadImplementors', () => {
     const fetchSpy = vi.fn().mockResolvedValue(res(['regeling_standaardpremie']));
     globalThis.fetch = fetchSpy;
     const engine = fakeEngine();
-    const fetchLawYaml = vi.fn(async (id) => DEP_YAML[id]);
+    const fetchLawVersions = vi.fn(async (id) => DEP_VERSIONS[id]);
 
     const { loadImplementors } = useDependencies();
-    await loadImplementors('wet_op_de_zorgtoeslag', engine, fetchLawYaml, 'mig-1a2b3c4d');
-    await loadImplementors('wet_op_de_zorgtoeslag', engine, fetchLawYaml, 'mig-1a2b3c4d');
+    await loadImplementors('wet_op_de_zorgtoeslag', engine, fetchLawVersions, 'mig-1a2b3c4d');
+    await loadImplementors('wet_op_de_zorgtoeslag', engine, fetchLawVersions, 'mig-1a2b3c4d');
 
     expect(fetchSpy).toHaveBeenCalledTimes(1);
   });

--- a/frontend/src/composables/useDependencies.test.js
+++ b/frontend/src/composables/useDependencies.test.js
@@ -17,6 +17,10 @@ function fakeEngine() {
     bodies,
     hasLaw: (id) => loaded.has(id),
     loadLaw: (yamlText) => {
+      // Model the real WASM engine rejecting an unparseable version (e.g. an
+      // old-schema or text-only harvested version): a body marked UNLOADABLE
+      // throws, and must not register the law.
+      if (yamlText.includes('UNLOADABLE')) throw new Error('unparseable version');
       bodies.push(yamlText);
       const m = yamlText.match(/\$id:\s*(\S+)/);
       if (m) loaded.add(m[1]);
@@ -94,6 +98,26 @@ describe('useDependencies.loadAllDependencies', () => {
     expect(zvwBodies).toHaveLength(2);
     expect(zvwBodies).toContain(inForce);
     expect(zvwBodies).toContain(future);
+  });
+
+  it('isolates an unloadable version: a bad version does not drop the good ones', async () => {
+    // Regression for the federated-corpus case where a law has an executable
+    // version AND an old-schema / text-only harvested version the engine can't
+    // parse. The harvested version must not abort the whole law — the engine
+    // must still hold the executable one so select_in can resolve it.
+    const bad = '$id: zorgverzekeringswet\nvalid_from: \'2026-02-21\'\nUNLOADABLE: true\n';
+    const good = '$id: zorgverzekeringswet\nvalid_from: \'2025-01-01\'\narticles: []\n';
+    const engine = fakeEngine();
+    const fetchLawVersions = vi.fn(async (id) =>
+      id === 'zorgverzekeringswet' ? [bad, good] : DEP_VERSIONS[id],
+    );
+
+    const { loadAllDependencies } = useDependencies();
+    await loadAllDependencies(MAIN_LAW, engine, fetchLawVersions);
+
+    expect(engine.loaded.has('zorgverzekeringswet')).toBe(true);
+    expect(engine.bodies).toContain(good);
+    expect(engine.bodies).not.toContain(bad);
   });
 
   it('treats an empty version list as a missing dependency (requests harvest)', async () => {

--- a/frontend/src/composables/useEngine.js
+++ b/frontend/src/composables/useEngine.js
@@ -4,8 +4,8 @@
  * Provides the engine and helpers for loading laws and dependencies.
  */
 import { ref } from 'vue';
-import { lawUrl } from './corpusUrls.js';
-import { apiFetchText } from '../lib/apiFetch.js';
+import { lawVersionsUrl } from './corpusUrls.js';
+import { apiFetchJson } from '../lib/apiFetch.js';
 import { createLruMap } from '../lib/lruMap.js';
 
 let engineInstance = null;
@@ -68,14 +68,23 @@ async function initEngine() {
 }
 
 /**
- * Fetch law YAML from the API and load it into the engine. When
+ * Fetch a law's YAML from the API and load it into the engine. When
  * `trajectRef` is given the read goes through the traject's per-source
  * backends (read-your-writes for in-progress edits); omit it for the
  * global view.
  *
- * If the law was previously loaded under a *different* scope, unload
- * the stale copy first — otherwise scenario runs after a traject
- * switch would evaluate against the previous scope's dependencies.
+ * Loads **every** version of the law (not just today's-best) so the
+ * engine's date-aware resolution can pick the one in force on a given
+ * calculation date — the same contract the scenario dependency walker
+ * uses. This keeps a single "load a law into the engine" semantic: any
+ * caller (notes, gherkin steps) that brings a law into the shared engine
+ * brings its full version set, so the `engine.hasLaw` skip guard never
+ * leaves a law with only one (possibly future-dated) version loaded.
+ *
+ * If the law was previously loaded under a *different* scope, unload the
+ * stale copy first (`unloadLaw` drops all of its versions) — otherwise
+ * scenario runs after a traject switch would evaluate against the
+ * previous scope's dependencies.
  */
 async function loadDependency(lawId, trajectRef = null) {
   const engine = await initEngine();
@@ -85,11 +94,15 @@ async function loadDependency(lawId, trajectRef = null) {
     engine.unloadLaw(lawId);
   }
 
-  const yaml = await apiFetchText(lawUrl(trajectRef, lawId), {
-    errorMessage: (status) => `Failed to fetch law '${lawId}': ${status}`,
+  const yamls = await apiFetchJson(lawVersionsUrl(trajectRef, lawId), {
+    errorMessage: (status) => `Failed to fetch versions of law '${lawId}': ${status}`,
   });
-  engine.loadLaw(yaml);
-  loadedScopes.set(lawId, scope);
+  const versions = Array.isArray(yamls) ? yamls : [];
+  for (const versionYaml of versions) engine.loadLaw(versionYaml);
+  // Only record the scope once a body is actually loaded, so an empty
+  // result (unknown law) stays retryable rather than masking the law as
+  // "loaded under this scope".
+  if (versions.length > 0) loadedScopes.set(lawId, scope);
 }
 
 /**

--- a/frontend/src/composables/useEngine.js
+++ b/frontend/src/composables/useEngine.js
@@ -5,7 +5,7 @@
  */
 import { ref } from 'vue';
 import { lawVersionsUrl } from './corpusUrls.js';
-import { apiFetchJson } from '../lib/apiFetch.js';
+import { apiFetchJson, apiFetchText } from '../lib/apiFetch.js';
 import { createLruMap } from '../lib/lruMap.js';
 
 let engineInstance = null;

--- a/frontend/src/composables/useEngine.js
+++ b/frontend/src/composables/useEngine.js
@@ -97,12 +97,42 @@ async function loadDependency(lawId, trajectRef = null) {
   const yamls = await apiFetchJson(lawVersionsUrl(trajectRef, lawId), {
     errorMessage: (status) => `Failed to fetch versions of law '${lawId}': ${status}`,
   });
-  const versions = Array.isArray(yamls) ? yamls : [];
-  for (const versionYaml of versions) engine.loadLaw(versionYaml);
-  // Only record the scope once a body is actually loaded, so an empty
-  // result (unknown law) stays retryable rather than masking the law as
-  // "loaded under this scope".
-  if (versions.length > 0) loadedScopes.set(lawId, scope);
+  // Only record the scope once a body actually loaded, so an empty result
+  // (unknown law) — or one whose every version was unloadable — stays
+  // retryable rather than masking the law as "loaded under this scope".
+  if (loadLawVersions(engine, yamls, lawId)) {
+    loadedScopes.set(lawId, scope);
+  }
+}
+
+/**
+ * Load a law's full version set into the engine, **isolating each version**.
+ *
+ * A single unloadable version must not prevent the engine from loading the
+ * law's other, executable versions: a federated corpus routinely carries
+ * versions the WASM engine can't parse (an older-schema or text-only
+ * *harvested* version alongside a small executable one). Without isolation,
+ * `engine.loadLaw` throwing on one version would abort the whole law and the
+ * resolver would report "Law not found" even though a usable version existed.
+ * The engine's date-aware `select_in` then picks the in-force version among
+ * whatever loaded.
+ *
+ * @param {object} engine - WasmEngine instance
+ * @param {string[]} yamls - version YAMLs (any/empty tolerated)
+ * @param {string} lawId - for diagnostics
+ * @returns {boolean} true if at least one version loaded
+ */
+export function loadLawVersions(engine, yamls, lawId) {
+  let anyLoaded = false;
+  for (const versionYaml of yamls || []) {
+    try {
+      engine.loadLaw(versionYaml);
+      anyLoaded = true;
+    } catch (e) {
+      console.warn(`Skipped an unloadable version of '${lawId}':`, e);
+    }
+  }
+  return anyLoaded;
 }
 
 /**

--- a/frontend/src/composables/useEngine.js
+++ b/frontend/src/composables/useEngine.js
@@ -124,7 +124,7 @@ async function loadDependency(lawId, trajectRef = null) {
  */
 export function loadLawVersions(engine, yamls, lawId) {
   let anyLoaded = false;
-  for (const versionYaml of yamls || []) {
+  for (const versionYaml of Array.isArray(yamls) ? yamls : []) {
     try {
       engine.loadLaw(versionYaml);
       anyLoaded = true;

--- a/frontend/src/composables/useEngine.test.js
+++ b/frontend/src/composables/useEngine.test.js
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock the API layer so `initEngine` never does a real network/WASM load.
+// `apiFetchText` rejects with a sentinel: the test asserts that sentinel
+// surfaces, which only happens if `apiFetchText` is actually imported and
+// called. A regression that dropped the import (it's used only on the WASM-
+// init path, which the dependency-loader tests mock past) would instead make
+// `initEngine` throw `ReferenceError: apiFetchText is not defined` — caught here.
+vi.mock('../lib/apiFetch.js', () => ({
+  apiFetchText: vi.fn().mockRejectedValue(new Error('SENTINEL_GLUE_FETCH')),
+  apiFetchJson: vi.fn().mockResolvedValue([]),
+}));
+
+import { useEngine } from './useEngine.js';
+
+describe('useEngine.initEngine', () => {
+  it('uses apiFetchText to fetch the WASM glue (regression: import must exist)', async () => {
+    const { initEngine, initError } = useEngine();
+    await expect(initEngine()).rejects.toThrow('SENTINEL_GLUE_FETCH');
+    // It reached the glue fetch and failed there — not a ReferenceError from a
+    // missing import.
+    expect(initError.value).toBeInstanceOf(Error);
+    expect(initError.value.message).toBe('SENTINEL_GLUE_FETCH');
+  });
+});

--- a/packages/corpus/src/source_map.rs
+++ b/packages/corpus/src/source_map.rs
@@ -81,8 +81,16 @@ impl LoadedLaw {
 /// lowest priority value wins. Equal priority with the same `$id` is an error.
 #[derive(Debug)]
 pub struct SourceMap {
-    /// Laws indexed by `$id`, with provenance metadata.
+    /// Laws indexed by `$id`, with provenance metadata. Holds the single
+    /// "best for today" version per id (see [`SourceMap::insert`]) — the
+    /// shape every existing single-version caller expects.
     laws: HashMap<String, LoadedLaw>,
+    /// *All* versions of each law, indexed by `$id`. Where [`laws`](Self::laws)
+    /// collapses an id to one entry, this keeps every version so the scenario
+    /// dependency loader can hand the engine the full set and let it pick the
+    /// version in force on the scenario's calculation date — not just today's.
+    /// See [`SourceMap::get_law_versions`].
+    versions: HashMap<String, Vec<LoadedLaw>>,
     /// Conflicts that were resolved (for reporting).
     resolved_conflicts: Vec<ConflictResolution>,
 }
@@ -102,6 +110,7 @@ impl SourceMap {
     pub fn new() -> Self {
         Self {
             laws: HashMap::new(),
+            versions: HashMap::new(),
             resolved_conflicts: Vec::new(),
         }
     }
@@ -207,6 +216,10 @@ impl SourceMap {
     fn insert(&mut self, law: LoadedLaw) -> Result<()> {
         let law_id = law.law_id.clone();
 
+        // Record every version (independent of the single-best collapse below)
+        // so the scenario loader can feed the engine the full set.
+        self.insert_version(law.clone());
+
         if let Some(existing) = self.laws.get(&law_id) {
             if existing.source_priority == law.source_priority {
                 // Same source with multiple versions → pick best version
@@ -268,6 +281,46 @@ impl SourceMap {
         }
 
         Ok(())
+    }
+
+    /// Record one version of a law in the per-id version set ([`Self::versions`]).
+    ///
+    /// Versions are keyed by their filename date (`…/{id}/{date}.yaml`). Two
+    /// sources providing the same `$id` for the *same* date collapse to the
+    /// higher-priority source's body (lower `source_priority` wins; ties keep
+    /// the incumbent, mirroring the single-best map's "existing wins on equal
+    /// priority"). A date present in only one source is always kept — so the
+    /// engine sees, e.g., a local always-in-force version *and* central's
+    /// future-dated one, and `select_in` can pick the one in force on the
+    /// scenario date. Undated files share a single slot, resolved the same way.
+    /// Order-independent: the outcome is the same whichever source is indexed
+    /// first. Entries are kept sorted newest-first (undated last) for
+    /// deterministic output; the engine re-sorts on load regardless.
+    ///
+    /// The filename date is a proxy for the body's `valid_from` (the corpus
+    /// convention is `{id}/{valid_from}.yaml`). The engine ultimately re-dedups
+    /// the loaded set by the body `valid_from` field, so a filename/body
+    /// mismatch can at worst pass a redundant body the engine collapses — it
+    /// never drops a genuinely distinct `valid_from`.
+    fn insert_version(&mut self, law: LoadedLaw) {
+        let new_date = extract_date_from_path(&law.file_path);
+        let entries = self.versions.entry(law.law_id.clone()).or_default();
+
+        if let Some(slot) = entries
+            .iter_mut()
+            .find(|e| extract_date_from_path(&e.file_path) == new_date)
+        {
+            if law.source_priority < slot.source_priority {
+                *slot = law;
+            }
+        } else {
+            entries.push(law);
+        }
+
+        entries.sort_by(|a, b| {
+            // Newest date first; undated entries (None) sort last.
+            extract_date_from_path(&b.file_path).cmp(&extract_date_from_path(&a.file_path))
+        });
     }
 
     /// Load a single fetched file (from GitHub or other remote) into the map.
@@ -383,6 +436,18 @@ impl SourceMap {
         self.laws.get(law_id)
     }
 
+    /// Get *all* versions of a law by ID, newest-first (undated last).
+    ///
+    /// Unlike [`Self::get_law`] (one "best for today" entry), this returns the
+    /// full version set across sources so the scenario dependency loader can
+    /// hand the engine every version and let `select_in` pick the one in force
+    /// on the scenario's calculation date. Returns `None` only when no version
+    /// of the id is indexed. Bodies of metadata-only (GitHub) entries are empty
+    /// until lazily fetched via each entry's `relative_path`.
+    pub fn get_law_versions(&self, law_id: &str) -> Option<&[LoadedLaw]> {
+        self.versions.get(law_id).map(Vec::as_slice)
+    }
+
     /// Update the cached YAML content for an existing law. Used after the
     /// editor persists an edit through [`crate::backend::RepoBackend`], so
     /// subsequent GETs (and dependency walks) see the new text without
@@ -395,17 +460,32 @@ impl SourceMap {
     /// left untouched. If the caller writes a new file under a different
     /// `$id` that's a different operation (unsupported via this hook).
     pub fn update_yaml_content(&mut self, law_id: &str, new_content: String) -> bool {
+        let name = extract_law_name(&new_content);
+        let (display_name, implements) = derive_loaded_fields(&new_content);
+
         let Some(law) = self.laws.get_mut(law_id) else {
             return false;
         };
-        law.name = extract_law_name(&new_content);
-        let (display_name, implements) = derive_loaded_fields(&new_content);
-        law.display_name = display_name;
-        law.implements = implements;
-        law.yaml_content = new_content;
+        law.name = name.clone();
+        law.display_name = display_name.clone();
+        law.implements = implements.clone();
+        law.yaml_content = new_content.clone();
         // The in-memory content no longer matches the blob the source
         // enumeration reported — drop the stale content identity.
         law.content_sha = None;
+        let file_path = law.file_path.clone();
+
+        // Keep the matching version entry coherent with the edited body so the
+        // version-set loader (`get_law_versions`) reflects read-your-writes too.
+        if let Some(entries) = self.versions.get_mut(law_id) {
+            if let Some(v) = entries.iter_mut().find(|v| v.file_path == file_path) {
+                v.name = name;
+                v.display_name = display_name;
+                v.implements = implements;
+                v.yaml_content = new_content;
+                v.content_sha = None;
+            }
+        }
         true
     }
 
@@ -1068,6 +1148,87 @@ mod tests {
         let law = map.get_law("my_law").unwrap();
         // 2024 is currently valid, 2099 is future → 2024 wins
         assert!(law.file_path.contains("2024-01-01"));
+    }
+
+    #[test]
+    fn test_get_law_versions_keeps_all_versions_same_source() {
+        let dir = TempDir::new().unwrap();
+
+        write_yaml(dir.path(), "wet/my_law/2024-01-01.yaml", "my_law");
+        write_yaml(dir.path(), "wet/my_law/2025-01-01.yaml", "my_law");
+
+        let source = make_source("local", "Local", dir.path(), 1);
+        let mut map = SourceMap::new();
+        map.load_source(&source).unwrap();
+
+        // `get_law` still collapses to one (the today's-best entry)...
+        assert_eq!(map.len(), 1);
+        // ...but `get_law_versions` exposes the full set, newest-first.
+        let versions = map.get_law_versions("my_law").unwrap();
+        assert_eq!(versions.len(), 2);
+        assert!(versions[0].file_path.contains("2025-01-01"));
+        assert!(versions[1].file_path.contains("2024-01-01"));
+        assert!(map.get_law_versions("nonexistent").is_none());
+    }
+
+    #[test]
+    fn test_get_law_versions_unions_across_sources_keeping_future() {
+        // The federation bug shape: a higher-priority source has only an
+        // in-force version, a lower-priority source additionally has a
+        // future-dated one. `get_law` returns the priority winner (the
+        // in-force local copy), but the engine must *also* see the future
+        // version so a scenario as-of a later date can resolve it — and the
+        // future version must NOT shadow the in-force one for earlier dates.
+        let local_dir = TempDir::new().unwrap();
+        let central_dir = TempDir::new().unwrap();
+
+        write_yaml(local_dir.path(), "wet/my_law/2025-01-01.yaml", "my_law");
+        write_yaml(central_dir.path(), "wet/my_law/2025-01-01.yaml", "my_law");
+        write_yaml(central_dir.path(), "wet/my_law/2099-01-01.yaml", "my_law");
+
+        let local = make_source("local", "Local", local_dir.path(), 1);
+        let central = make_source("central", "Central", central_dir.path(), 2);
+
+        let mut map = SourceMap::new();
+        map.load_source(&local).unwrap();
+        map.load_source(&central).unwrap();
+
+        // Single-best collapse: local (priority 1) wins the contested 2025 date.
+        assert_eq!(map.get_law("my_law").unwrap().source_id, "local");
+
+        // Version set: the union across sources — one entry per date, with the
+        // 2025 date resolved to the higher-priority (local) body.
+        let versions = map.get_law_versions("my_law").unwrap();
+        assert_eq!(versions.len(), 2, "expected the 2025 + 2099 union");
+        let v2025 = versions
+            .iter()
+            .find(|v| v.file_path.contains("2025-01-01"))
+            .unwrap();
+        assert_eq!(v2025.source_id, "local", "2025 date won by priority");
+        assert!(
+            versions.iter().any(|v| v.file_path.contains("2099-01-01")),
+            "central's future version must be kept, not dropped"
+        );
+    }
+
+    #[test]
+    fn test_get_law_versions_priority_order_independent() {
+        // Same as above but indexing central first — outcome must be identical.
+        let local_dir = TempDir::new().unwrap();
+        let central_dir = TempDir::new().unwrap();
+        write_yaml(local_dir.path(), "wet/my_law/2025-01-01.yaml", "my_law");
+        write_yaml(central_dir.path(), "wet/my_law/2025-01-01.yaml", "my_law");
+
+        let local = make_source("local", "Local", local_dir.path(), 1);
+        let central = make_source("central", "Central", central_dir.path(), 2);
+
+        let mut map = SourceMap::new();
+        map.load_source(&central).unwrap();
+        map.load_source(&local).unwrap();
+
+        let versions = map.get_law_versions("my_law").unwrap();
+        assert_eq!(versions.len(), 1);
+        assert_eq!(versions[0].source_id, "local");
     }
 
     #[test]

--- a/packages/corpus/src/source_map.rs
+++ b/packages/corpus/src/source_map.rs
@@ -460,20 +460,25 @@ impl SourceMap {
     /// left untouched. If the caller writes a new file under a different
     /// `$id` that's a different operation (unsupported via this hook).
     pub fn update_yaml_content(&mut self, law_id: &str, new_content: String) -> bool {
-        let name = extract_law_name(&new_content);
-        let (display_name, implements) = derive_loaded_fields(&new_content);
-
-        let Some(law) = self.laws.get_mut(law_id) else {
-            return false;
+        // Parse only once the law is known to be present — an unknown id is a
+        // no-op, so don't pay for header parsing on that path. The borrow on
+        // `laws` is released at the end of the block so the `versions` entry
+        // (which reuses the derived fields) can be updated next.
+        let (file_path, name, display_name, implements) = {
+            let Some(law) = self.laws.get_mut(law_id) else {
+                return false;
+            };
+            let name = extract_law_name(&new_content);
+            let (display_name, implements) = derive_loaded_fields(&new_content);
+            law.name = name.clone();
+            law.display_name = display_name.clone();
+            law.implements = implements.clone();
+            law.yaml_content = new_content.clone();
+            // The in-memory content no longer matches the blob the source
+            // enumeration reported — drop the stale content identity.
+            law.content_sha = None;
+            (law.file_path.clone(), name, display_name, implements)
         };
-        law.name = name.clone();
-        law.display_name = display_name.clone();
-        law.implements = implements.clone();
-        law.yaml_content = new_content.clone();
-        // The in-memory content no longer matches the blob the source
-        // enumeration reported — drop the stale content identity.
-        law.content_sha = None;
-        let file_path = law.file_path.clone();
 
         // Keep the matching version entry coherent with the edited body so the
         // version-set loader (`get_law_versions`) reflects read-your-writes too.
@@ -1213,11 +1218,16 @@ mod tests {
 
     #[test]
     fn test_get_law_versions_priority_order_independent() {
-        // Same as above but indexing central first — outcome must be identical.
+        // Mirrors `..._unions_across_sources_keeping_future` (local 2025 +
+        // central 2025 + central 2099) but indexes central FIRST, so this
+        // exercises both order-independent behaviours at once: the contested
+        // 2025 date still resolves to the higher-priority local body, and
+        // central's future 2099 version is still kept in the union.
         let local_dir = TempDir::new().unwrap();
         let central_dir = TempDir::new().unwrap();
         write_yaml(local_dir.path(), "wet/my_law/2025-01-01.yaml", "my_law");
         write_yaml(central_dir.path(), "wet/my_law/2025-01-01.yaml", "my_law");
+        write_yaml(central_dir.path(), "wet/my_law/2099-01-01.yaml", "my_law");
 
         let local = make_source("local", "Local", local_dir.path(), 1);
         let central = make_source("central", "Central", central_dir.path(), 2);
@@ -1227,8 +1237,16 @@ mod tests {
         map.load_source(&local).unwrap();
 
         let versions = map.get_law_versions("my_law").unwrap();
-        assert_eq!(versions.len(), 1);
-        assert_eq!(versions[0].source_id, "local");
+        assert_eq!(versions.len(), 2, "expected the 2025 + 2099 union");
+        let v2025 = versions
+            .iter()
+            .find(|v| v.file_path.contains("2025-01-01"))
+            .unwrap();
+        assert_eq!(v2025.source_id, "local", "2025 date won by priority");
+        assert!(
+            versions.iter().any(|v| v.file_path.contains("2099-01-01")),
+            "central's future version must be kept regardless of index order"
+        );
     }
 
     #[test]

--- a/packages/corpus/src/source_map.rs
+++ b/packages/corpus/src/source_map.rs
@@ -317,9 +317,11 @@ impl SourceMap {
             entries.push(law);
         }
 
-        // Newest date first; undated entries (None) sort last. `cached_key`
-        // parses each path once (the key allocates a String), mirroring the
-        // version sort in `resolver.rs`.
+        // Newest date first; undated entries (None) sort last. This re-sorts on
+        // every insertion — O(N) key allocations per insert, O(N²) to build a
+        // law's set one version at a time — negligible at the corpus's 1–5
+        // versions per law. If version counts ever grow large, prefer a single
+        // deferred sort in `get_law_versions` instead.
         entries.sort_by_cached_key(|e| std::cmp::Reverse(extract_date_from_path(&e.file_path)));
     }
 

--- a/packages/corpus/src/source_map.rs
+++ b/packages/corpus/src/source_map.rs
@@ -317,10 +317,10 @@ impl SourceMap {
             entries.push(law);
         }
 
-        entries.sort_by(|a, b| {
-            // Newest date first; undated entries (None) sort last.
-            extract_date_from_path(&b.file_path).cmp(&extract_date_from_path(&a.file_path))
-        });
+        // Newest date first; undated entries (None) sort last. `cached_key`
+        // parses each path once (the key allocates a String), mirroring the
+        // version sort in `resolver.rs`.
+        entries.sort_by_cached_key(|e| std::cmp::Reverse(extract_date_from_path(&e.file_path)));
     }
 
     /// Load a single fetched file (from GitHub or other remote) into the map.

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -144,8 +144,14 @@ impl ReadScope {
         match self {
             ReadScope::Traject(t) => t.law_yaml_versions(law_id).await,
             // The global corpus is fully loaded up front (like `law_yaml`), so
-            // bodies are present; filter any metadata-only sentinel so the
-            // loader never receives an empty YAML string.
+            // eagerly-loaded (local-source) bodies are present; filter any
+            // metadata-only sentinel so the loader never receives an empty YAML
+            // string. Asymmetry to note: GitHub-backed versions are metadata-
+            // only in the global view (never lazily fetched here, just as
+            // `law_yaml`'s Global branch can't fetch them), so they are omitted
+            // from the global endpoint. The traject-scoped path *does* lazily
+            // fetch them — and scenario execution always runs under a traject,
+            // so the omission never affects the dependency loader.
             ReadScope::Global(g) => Ok(g
                 .source_map
                 .get_law_versions(law_id)

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -132,6 +132,32 @@ impl ReadScope {
             }
         }
     }
+
+    /// Look up *all* versions of a law's YAML content within the active scope.
+    /// Mirrors [`Self::law_yaml`] but returns the full version set (newest-first)
+    /// so the scenario loader can hand them all to the engine. An unknown law is
+    /// an empty vec, not an error.
+    async fn law_yaml_versions(
+        &self,
+        law_id: &str,
+    ) -> Result<Vec<String>, regelrecht_corpus::error::CorpusError> {
+        match self {
+            ReadScope::Traject(t) => t.law_yaml_versions(law_id).await,
+            // The global corpus is fully loaded up front (like `law_yaml`), so
+            // bodies are present; filter any metadata-only sentinel so the
+            // loader never receives an empty YAML string.
+            ReadScope::Global(g) => Ok(g
+                .source_map
+                .get_law_versions(law_id)
+                .map(|vs| {
+                    vs.iter()
+                        .map(|l| l.yaml_content.clone())
+                        .filter(|y| !y.is_empty())
+                        .collect()
+                })
+                .unwrap_or_default()),
+        }
+    }
 }
 
 /// Read a law's YAML within a scope, mapping the outcome to an HTTP error:
@@ -387,6 +413,48 @@ async fn get_corpus_law_in_scope(
 ) -> Result<EtaggedContentResponse, (StatusCode, String)> {
     let yaml = read_law_yaml(scope, law_id).await?;
     Ok(etagged_content_response("text/yaml; charset=utf-8", yaml))
+}
+
+/// GET /api/corpus/laws/{law_id}/versions — every version's raw YAML, newest
+/// first (global view). The scenario dependency loader feeds all of these to
+/// the engine so its date-aware `select_in` can pick the version in force on
+/// the scenario's calculation date (rather than the single "best for today"
+/// entry that the plain `/laws/{id}` GET returns). An unknown law is an empty
+/// array, not a 404 — the loader treats that as a missing dependency.
+pub async fn get_corpus_law_versions(
+    State(state): State<AppState>,
+    Path(law_id): Path<String>,
+) -> Result<Json<Vec<String>>, (StatusCode, String)> {
+    let scope = global_scope(&state).await;
+    get_corpus_law_versions_in_scope(&scope, &law_id).await
+}
+
+/// GET /api/trajects/{traject_id}/corpus/laws/{law_id}/versions — same as the
+/// global GET but routed through the traject's per-source backends and
+/// read-your-writes overlay.
+pub async fn get_traject_corpus_law_versions(
+    State(state): State<AppState>,
+    session: Session,
+    Path((traject_ref, law_id)): Path<(String, String)>,
+) -> Result<Json<Vec<String>>, (StatusCode, String)> {
+    let scope = require_traject_scope(&state, &session, &traject_ref).await?;
+    get_corpus_law_versions_in_scope(&scope, &law_id).await
+}
+
+async fn get_corpus_law_versions_in_scope(
+    scope: &ReadScope,
+    law_id: &str,
+) -> Result<Json<Vec<String>>, (StatusCode, String)> {
+    let versions = scope.law_yaml_versions(law_id).await.map_err(|e| {
+        // A backend failure (lazy fetch threw) is a 502, distinguishable from
+        // a genuine "no such law" empty array; logged for operators.
+        tracing::warn!(law_id = %law_id, error = %e, "failed to load law versions");
+        (
+            StatusCode::BAD_GATEWAY,
+            format!("Kon versies van wet '{law_id}' niet laden"),
+        )
+    })?;
+    Ok(Json(versions))
 }
 
 /// GET /api/corpus/laws/{law_id}/outputs — list all outputs declared across articles (global view).

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -136,6 +136,10 @@ async fn main() {
             get(corpus_handlers::get_corpus_law),
         )
         .route(
+            "/api/corpus/laws/{law_id}/versions",
+            get(corpus_handlers::get_corpus_law_versions),
+        )
+        .route(
             "/api/corpus/laws/{law_id}/outputs",
             get(corpus_handlers::list_law_outputs),
         )
@@ -268,6 +272,10 @@ async fn main() {
         .route(
             "/api/trajects/{traject_ref}/corpus/laws/{law_id}",
             get(corpus_handlers::get_traject_corpus_law),
+        )
+        .route(
+            "/api/trajects/{traject_ref}/corpus/laws/{law_id}/versions",
+            get(corpus_handlers::get_traject_corpus_law_versions),
         )
         .route(
             "/api/trajects/{traject_ref}/corpus/laws/{law_id}/outputs",

--- a/packages/editor-api/src/traject_corpus.rs
+++ b/packages/editor-api/src/traject_corpus.rs
@@ -339,6 +339,86 @@ impl TrajectCorpus {
         Ok(Some(content))
     }
 
+    /// Like [`Self::law_yaml`], but returns **every** version of the law
+    /// rather than the single "best for today" one.
+    ///
+    /// The scenario dependency loader feeds all of these to the engine so its
+    /// `select_in` can pick the version in force on the scenario's calculation
+    /// date — fixing the case where a referenced law has a future-dated version
+    /// that would otherwise be the only one loaded (and so "not yet in force").
+    ///
+    /// Read-your-writes: the overlay / body cache hold the single saved (branch)
+    /// body, keyed by `law_id`; it is applied to the version whose source +
+    /// source-relative path matches the saved entry (`get_law`'s winner). Other
+    /// versions are served from the index body (local sources) or lazily fetched
+    /// via their own backend + `relative_path` (GitHub sources). Returns an empty
+    /// vec when no version of the id is indexed.
+    pub async fn law_yaml_versions(
+        &self,
+        law_id: &str,
+    ) -> Result<Vec<String>, regelrecht_corpus::error::CorpusError> {
+        // Snapshot the per-version index metadata, then drop the borrow before
+        // any await below.
+        let entries: Vec<(String, String, Option<String>)> = {
+            let Some(versions) = self.corpus.source_map.get_law_versions(law_id) else {
+                return Ok(Vec::new());
+            };
+            versions
+                .iter()
+                .map(|v| {
+                    let body = v.is_loaded().then(|| v.yaml_content.clone());
+                    (v.source_id.clone(), v.relative_path.clone(), body)
+                })
+                .collect()
+        };
+
+        // The overlay / body cache hold the saved body for the single best
+        // version (`get_law`'s winner); identify it so it's applied to the
+        // right version entry rather than all of them.
+        let saved_key = self
+            .corpus
+            .source_map
+            .get_law(law_id)
+            .map(|l| (l.source_id.clone(), l.relative_path.clone()));
+        let saved_body: Option<String> = if let Some(text) = self.overlay.read().await.get(law_id) {
+            Some(text.clone())
+        } else {
+            self.body_cache.read().await.get(law_id).cloned()
+        };
+
+        let mut out = Vec::with_capacity(entries.len());
+        for (source_id, relative_path, body) in entries {
+            // Read-your-writes for the saved/branch version.
+            if saved_key.as_ref() == Some(&(source_id.clone(), relative_path.clone())) {
+                if let Some(body) = &saved_body {
+                    out.push(body.clone());
+                    continue;
+                }
+            }
+            // Eagerly-loaded (local) version body is already in the index.
+            if let Some(body) = body {
+                out.push(body);
+                continue;
+            }
+            // Metadata-only (GitHub) version — lazily fetch its body. A source
+            // whose backend was skipped at build time is treated as a missing
+            // version rather than failing the whole set.
+            let Some(entry) = self.corpus.backends.get(&source_id) else {
+                continue;
+            };
+            let content = {
+                let backend = entry.backend.lock().await;
+                backend
+                    .read_file(std::path::Path::new(&relative_path))
+                    .await?
+            };
+            if let Some(content) = content {
+                out.push(content);
+            }
+        }
+        Ok(out)
+    }
+
     /// Mirror a freshly-saved law's content into the read-your-writes
     /// overlay. Called by `save_law` after a successful `backend.persist`,
     /// so the next GET on the same law (or a refresh) sees the new body.

--- a/packages/editor-api/src/traject_corpus.rs
+++ b/packages/editor-api/src/traject_corpus.rs
@@ -406,11 +406,30 @@ impl TrajectCorpus {
             let Some(entry) = self.corpus.backends.get(&source_id) else {
                 continue;
             };
+            // Isolate per-version fetch failures: a transient backend error for
+            // one version (e.g. a central GitHub blip on a future-dated version)
+            // must not fail the whole set and take down a law whose in-force
+            // version is locally available. Skip + log, mirroring the frontend's
+            // per-version `loadLawVersions` isolation. A law that ends up with no
+            // fetchable version surfaces to the loader as a missing dependency
+            // (retried on the next run), not a hard 502.
             let content = {
                 let backend = entry.backend.lock().await;
-                backend
+                match backend
                     .read_file(std::path::Path::new(&relative_path))
-                    .await?
+                    .await
+                {
+                    Ok(content) => content,
+                    Err(e) => {
+                        tracing::warn!(
+                            law_id = %law_id,
+                            source_id = %source_id,
+                            error = %e,
+                            "skipping a law version that failed to fetch"
+                        );
+                        continue;
+                    }
+                }
             };
             if let Some(content) = content {
                 out.push(content);

--- a/packages/editor-api/src/traject_corpus.rs
+++ b/packages/editor-api/src/traject_corpus.rs
@@ -388,8 +388,12 @@ impl TrajectCorpus {
 
         let mut out = Vec::with_capacity(entries.len());
         for (source_id, relative_path, body) in entries {
-            // Read-your-writes for the saved/branch version.
-            if saved_key.as_ref() == Some(&(source_id.clone(), relative_path.clone())) {
+            // Read-your-writes for the saved/branch version. Compare by
+            // reference (no per-iteration clone of the two owned Strings).
+            if saved_key
+                .as_ref()
+                .is_some_and(|(s, r)| s == &source_id && r == &relative_path)
+            {
                 if let Some(body) = &saved_body {
                     out.push(body.clone());
                     continue;
@@ -431,8 +435,17 @@ impl TrajectCorpus {
                     }
                 }
             };
-            if let Some(content) = content {
-                out.push(content);
+            match content {
+                Some(content) => out.push(content),
+                // Enumerated in the index but the blob is gone — an index/backend
+                // inconsistency. Skip like the Err path, but log it: same
+                // diagnosability concern, and this path is new.
+                None => tracing::warn!(
+                    law_id = %law_id,
+                    source_id = %source_id,
+                    relative_path = %relative_path,
+                    "skipping a law version whose blob was not found on the backend"
+                ),
             }
         }
         Ok(out)

--- a/packages/engine/src/service.rs
+++ b/packages/engine/src/service.rs
@@ -2530,6 +2530,33 @@ articles:
 "#
     }
 
+    /// A `base_law` version stamped with `valid_from` and a distinguishing
+    /// `base_value`, so a test can assert *which* version the resolver picked.
+    fn base_law_version(valid_from: &str, value: i32) -> String {
+        format!(
+            r#"
+$id: base_law
+regulatory_layer: WET
+publication_date: '2025-01-01'
+valid_from: '{valid_from}'
+articles:
+  - number: '1'
+    text: Provides a base value
+    machine_readable:
+      definitions:
+        BASE_VALUE:
+          value: {value}
+      execution:
+        output:
+          - name: base_value
+            type: number
+        actions:
+          - output: base_value
+            value: $BASE_VALUE
+"#
+        )
+    }
+
     // -------------------------------------------------------------------------
     // Basic Tests
     // -------------------------------------------------------------------------
@@ -2580,6 +2607,62 @@ articles:
 
         // doubled_value = base_value (100) * 2 = 200
         assert_eq!(result.outputs.get("doubled_value"), Some(&Value::Int(200)));
+    }
+
+    #[test]
+    fn test_service_cross_law_resolution_picks_in_force_version_over_future() {
+        // Regression for the temporal-federation bug: a referenced law that has
+        // BOTH an in-force and a future-dated version must resolve the in-force
+        // one when executed as-of a date before the future version. This is the
+        // version *set* the scenario loader now hands the engine; before the
+        // fix the loader fed only the single "best for today" version (the
+        // future one in a federated corpus) and execution failed NotYetInForce.
+        let mut service = LawExecutionService::new();
+        // Load future first to prove order doesn't matter (resolver sorts).
+        service
+            .load_law(&base_law_version("2099-01-01", 999))
+            .unwrap();
+        service
+            .load_law(&base_law_version("2025-01-01", 100))
+            .unwrap();
+        service.load_law(make_dependent_law()).unwrap();
+
+        let result = service
+            .evaluate_law_output(
+                "dependent_law",
+                "doubled_value",
+                BTreeMap::new(),
+                "2025-06-01",
+            )
+            .unwrap();
+
+        // Uses the in-force base_value (100 * 2), NOT the future one (999 * 2).
+        assert_eq!(result.outputs.get("doubled_value"), Some(&Value::Int(200)));
+    }
+
+    #[test]
+    fn test_service_cross_law_only_future_version_is_not_yet_in_force() {
+        // Control: with ONLY the future version loaded — the pre-fix behaviour
+        // where the loader handed the engine a single future-dated version —
+        // the same as-of-2025 execution fails NotYetInForce. This proves the
+        // fix is the version *set* reaching the engine, not `select_in` itself.
+        let mut service = LawExecutionService::new();
+        service
+            .load_law(&base_law_version("2099-01-01", 999))
+            .unwrap();
+        service.load_law(make_dependent_law()).unwrap();
+
+        let result = service.evaluate_law_output(
+            "dependent_law",
+            "doubled_value",
+            BTreeMap::new(),
+            "2025-06-01",
+        );
+
+        assert!(
+            matches!(result, Err(EngineError::LawNotYetInForce { .. })),
+            "expected LawNotYetInForce, got: {result:?}",
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Running a `wet_op_de_zorgtoeslag` scenario as of `2025-01-01` in a federated
(local + minbzk-central) test-corpus traject fails:

```
Execution failed: No version of law 'zorgverzekeringswet' in force on 2025-01-01 (not yet in force)
```

## Root cause

Scenario execution runs in-browser via WASM. The dependency walker fetched
**one** YAML per law id via `/api/.../corpus/laws/{id}`, and the backend
`SourceMap` collapses each `$id` to a single **"best for today"** version
(`pick_best_version` uses *today's* date, not the scenario's `calculation_date`).
So when a referenced law (`zorgverzekeringswet`) has a future-dated version
(central harvested a `2026-01-01`), the engine received only that future version
and a past-dated scenario failed `NotYetInForce`.

The engine's `select_in` is correct *given all versions* (a `valid_from`-less or
in-force version is matched); it simply never saw more than one version.

## Fix

Feed **every** version of each referenced law to the engine and let its
date-aware `select_in` pick the one in force on the scenario's calculation date.

- **corpus** (`source_map.rs`): `SourceMap` now also retains all versions per
  `$id` (`versions` map, populated in `insert`), unioned across sources with
  per-date priority resolution; new `get_law_versions`. The single-best `laws`
  map / `get_law` are unchanged, so existing single-version callers are
  untouched.
- **editor-api** (`traject_corpus.rs`, `corpus_handlers.rs`, `main.rs`): new
  `GET /api/corpus/laws/{id}/versions` and the traject-scoped variant returning
  a JSON array of every version body (lazy fetch + read-your-writes overlay for
  the saved version).
- **frontend** (`corpusUrls.js`, `useDependencies.js`, `useEngine.js`,
  `ScenarioBuilder.vue`): the dependency walker, scenario-step loader,
  implementors loader and `loadDependency` now load every version into the WASM
  engine (it keys versions by `($id, valid_from)`, so they coexist).

## Tests (target the execution version-loading path, not `select_in` alone)

- **engine** (`service.rs`): execute a law referencing another that has both an
  in-force and a future-dated version, as of a date before the future one →
  resolves the in-force version; plus a **control** asserting that with *only*
  the future version loaded the same execution fails `NotYetInForce` (proving
  the fix is the version *set* reaching the engine).
- **corpus** (`source_map.rs`): `get_law_versions` returns the cross-source
  union (in-force + future), order-independent.
- **frontend** (`useDependencies.test.js`): loads *every* version of a
  dependency; empty version list is routed to harvest (not silently dropped).

All green: `just check` (format + lint + build-check + validate + test) and the
full frontend vitest suite (356 tests).

## Corpus-data note (investigated, intentionally not changed)

The data oddities are legitimate, not bugs: local `zorgverzekeringswet/2025-01-01.yaml`
has **no** `valid_from` (always in force — one of a few such local laws), and
central legitimately harvested a future `2026-01-01` version. Editing one law's
YAML would only mask the general defect; the fix makes execution date-aware
regardless of which source/version wins.
