### PR TITLE
refactor(editor): remove local/test-corpus read-only traject sentinel

### DIFF
--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -1368,21 +1368,6 @@ fn traject_write_source_id(traject: &TrajectCorpus, law: &LoadedLaw) -> String {
         .unwrap_or_else(|| law.source_id.clone())
 }
 
-/// Reject writes against a read-only traject (local-test-corpus). All
-/// six traject write/delete handlers (`save_scenario`, `save_annotations`,
-/// `save_law`, `save_traject_document`, `delete_scenario`,
-/// `delete_traject_document`) call this right after resolving the
-/// `TrajectCorpus`, so a read-only traject never reaches a backend write.
-fn ensure_traject_writable(traject: &TrajectCorpus) -> Result<(), (StatusCode, String)> {
-    if traject.read_only {
-        return Err((
-            StatusCode::FORBIDDEN,
-            "Dit is een read-only lokale-testcorpus-traject; opslaan is uitgeschakeld.".to_string(),
-        ));
-    }
-    Ok(())
-}
-
 /// Resolved write routing for a law in a traject: the law's index
 /// entry, the id of the source whose backend the write goes to, and an
 /// owned guard over that backend.
@@ -1618,7 +1603,6 @@ pub async fn save_scenario(
     let author = Some(require_editor_user(&session).await?);
 
     let traject = require_traject_corpus_from_ref(&state, &session, &traject_ref).await?;
-    ensure_traject_writable(&traject)?;
     let write = resolve_traject_law_write(&traject, &law_id).await?;
     let relative_path = scenario_relative_path(&write.law, &filename)?;
 
@@ -1699,7 +1683,6 @@ pub async fn save_annotations(
     }
 
     let traject = require_traject_corpus_from_ref(&state, &session, &traject_ref).await?;
-    ensure_traject_writable(&traject)?;
     let target = resolve_traject_annotation_target(&traject, &law_id).await?;
     let EditorWriteTarget {
         relative_path,
@@ -1899,7 +1882,6 @@ pub async fn save_law(
     // corpus so we can mirror the saved body into its read-your-writes
     // overlay after `persist` succeeds.
     let traject = require_traject_corpus_from_ref(&state, &session, &traject_ref).await?;
-    ensure_traject_writable(&traject)?;
     let write = resolve_traject_law_write(&traject, &law_id).await?;
     let relative_path = PathBuf::from(&write.law.relative_path);
 
@@ -1966,7 +1948,6 @@ pub async fn delete_scenario(
     let author = Some(require_editor_user(&session).await?);
 
     let traject = require_traject_corpus_from_ref(&state, &session, &traject_ref).await?;
-    ensure_traject_writable(&traject)?;
     let target = resolve_traject_scenario_target(&traject, &law_id, &filename).await?;
     let EditorWriteTarget {
         relative_path,
@@ -2411,7 +2392,6 @@ pub async fn save_traject_document(
     }
 
     let traject = require_traject_corpus_from_ref(&state, &session, &traject_ref).await?;
-    ensure_traject_writable(&traject)?;
     let backend = resolve_traject_documents_writer(&traject).await?;
     let relative_path = traject_documents_base(&traject_ref).join(&doc_path);
 
@@ -2472,7 +2452,6 @@ pub async fn delete_traject_document(
     let author = Some(require_editor_user(&session).await?);
 
     let traject = require_traject_corpus_from_ref(&state, &session, &traject_ref).await?;
-    ensure_traject_writable(&traject)?;
     let backend = resolve_traject_documents_writer(&traject).await?;
     let relative_path = traject_documents_base(&traject_ref).join(&doc_path);
 
@@ -2507,19 +2486,6 @@ mod tests {
     //! sqlx + a real source map and live behind separate integration
     //! tests.
     use super::*;
-
-    #[test]
-    fn ensure_traject_writable_blocks_read_only() {
-        let traject = TrajectCorpus::for_test(true);
-        let err = ensure_traject_writable(&traject).expect_err("read-only must be rejected");
-        assert_eq!(err.0, StatusCode::FORBIDDEN);
-    }
-
-    #[test]
-    fn ensure_traject_writable_allows_writable() {
-        let traject = TrajectCorpus::for_test(false);
-        assert!(ensure_traject_writable(&traject).is_ok());
-    }
 
     #[test]
     fn save_response_from_traject_passes_through_pr_when_set() {

--- a/packages/editor-api/src/traject_corpus.rs
+++ b/packages/editor-api/src/traject_corpus.rs
@@ -59,9 +59,6 @@ pub struct TrajectCorpus {
     /// endpoints) to address the traject's own branch directly without
     /// having to reverse-engineer it out of `write_target_for_source`.
     pub writable_own_source_id: String,
-    /// True for a read-only traject (local-test-corpus). Save handlers
-    /// reject writes; `compute_changed_law_ids` short-circuits.
-    pub read_only: bool,
     /// Read-your-writes overlay for law YAML content: only bodies that
     /// went through a successful `save_law` (see [`record_save`]). After a
     /// save we mirror the persisted body here so subsequent reads in the
@@ -801,12 +798,6 @@ impl TrajectCorpus {
     async fn compute_changed_law_ids(
         &self,
     ) -> Result<Vec<String>, regelrecht_corpus::error::CorpusError> {
-        // A read-only traject never accumulates changes; skip the diff
-        // (its writable-own is the local corpus dir, where `changed_files`
-        // would otherwise surface unrelated working-tree noise).
-        if self.read_only {
-            return Ok(Vec::new());
-        }
         let Some(entry) = self.corpus.backends.get(&self.writable_own_source_id) else {
             return Ok(Vec::new());
         };
@@ -1078,14 +1069,6 @@ async fn build_traject_corpus(
         return Err(TrajectCorpusError::NotFound);
     }
 
-    // The traject exists (rows non-empty implies the FK row exists);
-    // default to writable if the column read ever returns nothing.
-    let read_only: bool = sqlx::query_scalar("SELECT read_only FROM trajects WHERE id = $1")
-        .bind(traject_id)
-        .fetch_optional(pool)
-        .await?
-        .unwrap_or(false);
-
     // Confirm the traject has a writable_own source — without one we
     // can't route saves on laws read from the seed sources. The actual
     // routing happens via `write_target_for_source` below; the local
@@ -1287,7 +1270,6 @@ async fn build_traject_corpus(
         },
         write_target_for_source,
         writable_own_source_id,
-        read_only,
         overlay: Arc::new(RwLock::new(HashMap::new())),
         body_cache: RwLock::new(BoundedBodyCache::default()),
         implements_index: RwLock::new(None),
@@ -1371,7 +1353,6 @@ async fn next_snapshot(old: &Arc<TrajectCorpus>, source_map: SourceMap) -> Arc<T
         },
         write_target_for_source: old.write_target_for_source.clone(),
         writable_own_source_id: old.writable_own_source_id.clone(),
-        read_only: old.read_only,
         overlay: old.overlay.clone(),
         body_cache: RwLock::new(BoundedBodyCache::default()),
         implements_index: RwLock::new(carried_index),
@@ -1542,34 +1523,6 @@ struct TrajectSourceRow {
 }
 
 #[cfg(test)]
-impl TrajectCorpus {
-    /// Bare `TrajectCorpus` with no sources/backends, parameterized on
-    /// `read_only`. Crate-visible so guard tests in other modules (e.g.
-    /// `corpus_handlers::ensure_traject_writable`) can build one without
-    /// a DB or a live source map.
-    pub(crate) fn for_test(read_only: bool) -> Self {
-        TrajectCorpus {
-            corpus: CorpusState {
-                registry: CorpusRegistry::empty(),
-                source_map: SourceMap::new(),
-                backends: HashMap::new(),
-                auth_file: None,
-            },
-            write_target_for_source: HashMap::new(),
-            writable_own_source_id: "own".to_string(),
-            read_only,
-            overlay: Arc::new(RwLock::new(HashMap::new())),
-            body_cache: RwLock::new(BoundedBodyCache::default()),
-            implements_index: RwLock::new(None),
-            implements_index_stale: AtomicBool::new(false),
-            implements_build_lock: Mutex::new(()),
-            implements_memo: Arc::new(RwLock::new(HashMap::new())),
-            changed_cache: Arc::new(RwLock::new(None)),
-        }
-    }
-}
-
-#[cfg(test)]
 mod tests {
     //! Unit tests for the snapshot caches: the bounded lazy-body cache,
     //! the TTL freshness rule, the per-snapshot implements index (incl.
@@ -1686,7 +1639,6 @@ mod tests {
             },
             write_target_for_source: HashMap::new(),
             writable_own_source_id: "own".to_string(),
-            read_only: false,
             overlay: Arc::new(RwLock::new(HashMap::new())),
             body_cache: RwLock::new(BoundedBodyCache::default()),
             implements_index: RwLock::new(None),
@@ -1695,25 +1647,6 @@ mod tests {
             implements_memo: Arc::new(RwLock::new(HashMap::new())),
             changed_cache: Arc::new(RwLock::new(None)),
         }
-    }
-
-    #[test]
-    fn read_only_flag_roundtrips() {
-        // Build two corpora differing only in read_only and assert the
-        // field is observable (the save-handler guard keys on this).
-        let writable = TrajectCorpus::for_test(false);
-        let read_only = TrajectCorpus::for_test(true);
-        assert!(!writable.read_only);
-        assert!(read_only.read_only);
-    }
-
-    #[tokio::test]
-    async fn read_only_traject_reports_no_changed_laws() {
-        // The short-circuit added for read-only trajecten returns an empty
-        // changed-set without touching the (here absent) writable-own
-        // backend — proving the guard, not just the field.
-        let corpus = TrajectCorpus::for_test(true);
-        assert!(corpus.compute_changed_law_ids().await.unwrap().is_empty());
     }
 
     fn metadata_entry(map: &mut SourceMap, law_id: &str, source_id: &str) {
@@ -2041,7 +1974,6 @@ mod tests {
             },
             write_target_for_source: HashMap::new(),
             writable_own_source_id: "own".to_string(),
-            read_only: false,
             overlay: Arc::new(RwLock::new(HashMap::new())),
             body_cache: RwLock::new(BoundedBodyCache::default()),
             implements_index: RwLock::new(None),

--- a/packages/editor-api/src/trajects.rs
+++ b/packages/editor-api/src/trajects.rs
@@ -23,11 +23,6 @@ pub struct TrajectSummary {
     pub scope: String,
     pub status: String,
     pub role: String,
-    /// True for read-only trajecten (e.g. a local-test-corpus traject).
-    /// The frontend uses this to surface a read-only notice; the backend
-    /// save handlers enforce it (see `ensure_traject_writable`).
-    #[serde(default)]
-    pub read_only: bool,
     /// URL-form reference: `{slug}-{8hex}`. Built from current `name`
     /// and `id`; the slug part is cosmetic, the trailing 8 hex chars of
     /// the uuid are the actual lookup key (see `resolve_traject_ref`).
@@ -259,24 +254,6 @@ const CENTRAL_WRITABLE_PATH: &str = "regulation/nl";
 const CENTRAL_WRITABLE_BASE_BRANCH: &str = "development";
 const CENTRAL_WRITABLE_AUTH_REF: &str = "minbzk-central";
 const CENTRAL_WRITABLE_NAME: &str = "MinBZK/regelrecht-corpus";
-
-/// Reserved custom-repo sentinel: a create request whose `repo_owner` /
-/// `repo_name` equal these (case-insensitive, trimmed) is interpreted as
-/// "make a local-test-corpus traject" instead of a user GitHub repo.
-const LOCAL_TEST_SENTINEL_OWNER: &str = "local";
-const LOCAL_TEST_SENTINEL_REPO: &str = "test-corpus";
-/// Synthesized local writable-own source for a local-test traject.
-const LOCAL_TEST_SOURCE_NAME: &str = "Local Test Corpus";
-const LOCAL_TEST_CORPUS_PATH: &str = "corpus/regulation/nl";
-
-/// True when the create request asks for a local-test-corpus traject via
-/// the reserved `local` / `test-corpus` repo sentinel.
-fn is_local_test_request(req: &CreateTrajectRequest) -> bool {
-    let owner = req.repo_owner.as_deref().map(str::trim).unwrap_or("");
-    let repo = req.repo_name.as_deref().map(str::trim).unwrap_or("");
-    owner.eq_ignore_ascii_case(LOCAL_TEST_SENTINEL_OWNER)
-        && repo.eq_ignore_ascii_case(LOCAL_TEST_SENTINEL_REPO)
-}
 
 #[derive(Debug, Deserialize)]
 pub struct UpdateTrajectRequest {
@@ -649,8 +626,7 @@ pub async fn list(
     let mut rows: Vec<TrajectSummary> = sqlx::query_as(
         "SELECT t.id, t.name, t.description, t.scope,
                 t.status::text AS status,
-                tm.role::text  AS role,
-                t.read_only
+                tm.role::text  AS role
          FROM trajects t
          JOIN traject_members tm ON tm.traject_id = t.id
          WHERE tm.account_id = $1
@@ -678,8 +654,7 @@ pub async fn get(
     let mut summary: TrajectSummary = sqlx::query_as(
         "SELECT id, name, description, scope,
                 status::text AS status,
-                $2           AS role,
-                read_only
+                $2           AS role
          FROM trajects WHERE id = $1",
     )
     .bind(id)
@@ -1031,32 +1006,23 @@ pub async fn create(
         return Err((StatusCode::BAD_REQUEST, "name is required".to_string()));
     }
 
-    let local_test = is_local_test_request(&req);
-
-    // Resolve the writable-own GitHub target only for normal trajecten.
-    // A local-test traject uses a synthesized local writable-own and
-    // never touches GitHub, so we skip resolution (and its token check).
-    // The validation may need to talk to GitHub (which can fail with a
-    // helpful 4xx); we want to do that *before* we open the DB
-    // transaction so a network blip doesn't leak a half-rolled row.
-    let target = if local_test {
-        None
-    } else {
-        Some(resolve_writable_target(&state, &req).await?)
-    };
+    // Resolve the writable-own GitHub target up-front. Validation may need
+    // to talk to GitHub (which can fail with a helpful 4xx); we do that
+    // *before* opening the DB transaction so a network blip doesn't leak a
+    // half-rolled row.
+    let target = resolve_writable_target(&state, &req).await?;
 
     let pool = get_pool_msg(&state)?;
     let mut tx = pool.begin().await.map_err(db_err_msg("begin tx"))?;
 
     let traject_id: Uuid = sqlx::query_scalar(
-        "INSERT INTO trajects (name, description, scope, created_by, read_only)
-         VALUES ($1, $2, $3, $4, $5) RETURNING id",
+        "INSERT INTO trajects (name, description, scope, created_by)
+         VALUES ($1, $2, $3, $4) RETURNING id",
     )
     .bind(name)
     .bind(&req.description)
     .bind(&req.scope)
     .bind(account.id)
-    .bind(local_test)
     .fetch_one(&mut *tx)
     .await
     .map_err(db_err_msg("insert traject"))?;
@@ -1073,10 +1039,7 @@ pub async fn create(
 
     // Seed federated read-config from the global registry. The global
     // corpus read guard is dropped before the next await so we don't hold
-    // it across the database transaction. For a local-test traject this
-    // seeds minbzk-central (so local laws that reference central laws
-    // resolve); the local source is no longer in the registry and is
-    // added below as the writable-own instead.
+    // it across the database transaction.
     let seeded: Vec<SeedSource> = {
         let corpus = state.corpus.read().await;
         corpus
@@ -1115,66 +1078,34 @@ pub async fn create(
         .map_err(db_err_msg("seed traject source"))?;
     }
 
-    // Writable-own source: either the phase-1 MinBZK default / the
-    // user-supplied repo (already validated up-front for push access),
-    // or a synthesized local source for a local-test traject. For the
-    // GitHub path the branch name is derived from the traject name + id;
-    // auth flows through `CORPUS_AUTH_{AUTH_REF_UPPER}_TOKEN` via the
-    // `auth_ref` stored on this row.
+    // Writable-own source: the phase-1 MinBZK default or the user-supplied
+    // repo (already validated up-front for push access). The branch name is
+    // derived from the traject name + id; auth flows through
+    // `CORPUS_AUTH_{AUTH_REF_UPPER}_TOKEN` via the `auth_ref` stored on this
+    // row.
     let writable_source_id = format!("traject-own-{}", traject_id.simple());
-    if local_test {
-        // Synthesized LOCAL writable-own. The local backend is natively
-        // writable on its path, but the traject is `read_only` so the
-        // save handlers reject writes (see `ensure_traject_writable`).
-        // Using a local source means the traject opens without a GitHub
-        // token — important for token-less local dev.
-        sqlx::query(
-            "INSERT INTO traject_corpus_sources
-             (traject_id, source_id, name, source_type,
-              local_path, priority, is_writable_own)
-             VALUES ($1, $2, $3, 'local', $4, 0, TRUE)",
-        )
-        .bind(traject_id)
-        .bind(&writable_source_id)
-        .bind(LOCAL_TEST_SOURCE_NAME)
-        .bind(LOCAL_TEST_CORPUS_PATH)
-        .execute(&mut *tx)
-        .await
-        .map_err(db_err_msg("insert local writable source"))?;
-    } else {
-        // Normal traject: `target` was resolved above (it is `None` only on
-        // the `local_test` path, which this `else` excludes). Treat an
-        // unexpected `None` as an internal error rather than panicking, to
-        // satisfy the workspace `expect_used` lint.
-        let Some(target) = target else {
-            return Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "writable target unexpectedly missing".to_string(),
-            ));
-        };
-        let writable_branch = derive_branch_name(name, traject_id);
-        sqlx::query(
-            "INSERT INTO traject_corpus_sources
-             (traject_id, source_id, name, source_type,
-              gh_owner, gh_repo, gh_branch, gh_base_branch, gh_path,
-              priority, auth_ref, is_writable_own)
-             VALUES ($1, $2, $3, 'github',
-                     $4, $5, $6, $7, $8,
-                     0, $9, TRUE)",
-        )
-        .bind(traject_id)
-        .bind(&writable_source_id)
-        .bind(&target.display_name)
-        .bind(&target.owner)
-        .bind(&target.repo)
-        .bind(&writable_branch)
-        .bind(&target.base_branch)
-        .bind(&target.path)
-        .bind(&target.auth_ref)
-        .execute(&mut *tx)
-        .await
-        .map_err(db_err_msg("insert writable source"))?;
-    }
+    let writable_branch = derive_branch_name(name, traject_id);
+    sqlx::query(
+        "INSERT INTO traject_corpus_sources
+         (traject_id, source_id, name, source_type,
+          gh_owner, gh_repo, gh_branch, gh_base_branch, gh_path,
+          priority, auth_ref, is_writable_own)
+         VALUES ($1, $2, $3, 'github',
+                 $4, $5, $6, $7, $8,
+                 0, $9, TRUE)",
+    )
+    .bind(traject_id)
+    .bind(&writable_source_id)
+    .bind(&target.display_name)
+    .bind(&target.owner)
+    .bind(&target.repo)
+    .bind(&writable_branch)
+    .bind(&target.base_branch)
+    .bind(&target.path)
+    .bind(&target.auth_ref)
+    .execute(&mut *tx)
+    .await
+    .map_err(db_err_msg("insert writable source"))?;
 
     tx.commit()
         .await
@@ -1190,7 +1121,6 @@ pub async fn create(
         status: "bezig".to_string(),
         role: "owner".to_string(),
         traject_ref: None,
-        read_only: local_test,
     };
     summary.fill_ref();
     Ok((StatusCode::CREATED, Json(summary)))

--- a/packages/editor-api/tests/trajects_test.rs
+++ b/packages/editor-api/tests/trajects_test.rs
@@ -183,70 +183,6 @@ async fn create_rejects_empty_name() {
     assert_eq!(status, StatusCode::BAD_REQUEST);
 }
 
-/// A request whose custom repo is the reserved `local` / `test-corpus`
-/// sentinel produces a read-only traject backed by a synthesized local
-/// writable-own source (no GitHub writable-own).
-fn local_test_req(name: &str) -> CreateTrajectRequest {
-    CreateTrajectRequest {
-        name: name.to_string(),
-        description: String::new(),
-        scope: String::new(),
-        repo_owner: Some("Local".to_string()), // case-insensitive
-        repo_name: Some("test-corpus".to_string()),
-        base_branch: None,
-        repo_path: None,
-    }
-}
-
-#[tokio::test]
-async fn local_test_sentinel_creates_read_only_local_traject() {
-    let db = TestDb::new().await;
-    let state = empty_state(db.pool.clone());
-    let owner = seed_account(&db.pool, "owner@example.com", "Owner").await;
-
-    let (status, Json(summary)) = trajects::create(
-        State(state.clone()),
-        Extension(owner.clone()),
-        Json(local_test_req("Lokale test")),
-    )
-    .await
-    .unwrap();
-    assert_eq!(status, StatusCode::CREATED);
-    assert!(summary.read_only, "sentinel traject must be read_only");
-
-    // trajects.read_only persisted
-    let read_only: bool = sqlx::query_scalar("SELECT read_only FROM trajects WHERE id = $1")
-        .bind(summary.id)
-        .fetch_one(&db.pool)
-        .await
-        .unwrap();
-    assert!(read_only);
-
-    // Exactly one writable-own, and it is a LOCAL source at the test path.
-    let (src_type, local_path): (String, Option<String>) = sqlx::query_as(
-        "SELECT source_type::text, local_path
-         FROM traject_corpus_sources
-         WHERE traject_id = $1 AND is_writable_own = TRUE",
-    )
-    .bind(summary.id)
-    .fetch_one(&db.pool)
-    .await
-    .unwrap();
-    assert_eq!(src_type, "local");
-    assert_eq!(local_path.as_deref(), Some("corpus/regulation/nl"));
-
-    // No GitHub writable-own row exists.
-    let gh_writable: i64 = sqlx::query_scalar(
-        "SELECT COUNT(*) FROM traject_corpus_sources
-         WHERE traject_id = $1 AND is_writable_own = TRUE AND source_type = 'github'",
-    )
-    .bind(summary.id)
-    .fetch_one(&db.pool)
-    .await
-    .unwrap();
-    assert_eq!(gh_writable, 0);
-}
-
 #[tokio::test]
 async fn normal_traject_is_writable_with_github_own() {
     let db = TestDb::new().await;
@@ -254,13 +190,6 @@ async fn normal_traject_is_writable_with_github_own() {
     let owner = seed_account(&db.pool, "owner2@example.com", "Owner2").await;
 
     let id = create_traject(&state, &owner, "Gewoon traject").await;
-
-    let read_only: bool = sqlx::query_scalar("SELECT read_only FROM trajects WHERE id = $1")
-        .bind(id)
-        .fetch_one(&db.pool)
-        .await
-        .unwrap();
-    assert!(!read_only, "normal traject must be writable");
 
     let src_type: String = sqlx::query_scalar(
         "SELECT source_type::text FROM traject_corpus_sources

--- a/packages/pipeline/migrations/0021_drop_traject_read_only.sql
+++ b/packages/pipeline/migrations/0021_drop_traject_read_only.sql
@@ -1,0 +1,8 @@
+-- Drop the `read_only` flag. The `local`/`test-corpus` read-only sentinel
+-- that introduced it (migration 0020) has been removed: editing the laws in
+-- the regelrecht monorepo now happens through a normal writable GitHub
+-- traject pointed at MinBZK/regelrecht (path corpus/regulation/nl), which
+-- saves via a session branch + PR. No traject is read-only anymore, so the
+-- column is dead.
+ALTER TABLE trajects
+    DROP COLUMN read_only;


### PR DESCRIPTION
## What

Removes the hardcoded `local` / `test-corpus` create sentinel and the entire `read_only` traject flag from editor-api.

The sentinel produced a **read-only, token-less** traject backed by the baked-in `corpus/regulation/nl` dir — useful only for viewing the monorepo's own laws. Editing those laws with full save + scenarios now goes through a **normal writable GitHub traject** pointed at `MinBZK/regelrecht` (path `corpus/regulation/nl`, base `main`), which the existing private-repo-traject flow already supports — saves land on a session branch + PR, so `main` stays static for the unit/BDD fixtures. With that in place, no traject is read-only anymore and the flag is dead.

This is the code half of a two-part change; the other half (pointing a traject at the monorepo) is purely operational (a fine-grained PAT + the `CORPUS_AUTH_MINBZK_REGELRECHT_TOKEN` env var on the editor deployments).

## Changes

- `trajects.rs`: drop `LOCAL_TEST_SENTINEL_*` / `LOCAL_TEST_*` consts + `is_local_test_request()`; `create()` always resolves a GitHub writable-own target (no more `Option` juggling); remove `read_only` from the `trajects` INSERT, the `TrajectSummary.read_only` field, and the `read_only` columns in the list/get SELECTs.
- `corpus_handlers.rs`: remove `ensure_traject_writable()` + its 6 save/delete call sites + 2 unit tests. The separate per-source "Source is read-only" writability guard is untouched.
- `traject_corpus.rs`: remove `TrajectCorpus.read_only`, the `compute_changed_law_ids` short-circuit, the `SELECT read_only` in build, the `for_test()` helper + 2 tests.
- `tests/trajects_test.rs`: remove the sentinel test + helper; trim a `read_only` assertion.
- `migrations/0021_drop_traject_read_only.sql`: `ALTER TABLE trajects DROP COLUMN read_only;`

## Notes for review

- **Rolling-deploy ordering**: after the migration, an *old* editor pod still running `SELECT read_only` would error against the new schema until it rotates out. The ZAD rollout runs the migration on the new image's startup and drains old pods, so the window is brief and self-healing — flagging it as a conscious accept.
- **Behavior**: all trajects are now writable. Verified nothing else gated on the flag; the `changed_law_ids` short-circuit was a noise guard for the *local dir* writable-own, and a normal GitHub session-branch diff is meaningful, so removing it is correct.
- **Out of scope**: `tests/save_annotations_test.rs` has a pre-existing compile break (a `get_annotations`/`session_for` signature drift; editor-api tests aren't in CI). It contains zero `read_only` references and is unrelated to this PR.

## Verification

- `cargo check --lib` + `cargo clippy --lib` clean; `cargo fmt --check` clean; `trajects_test` compiles. Repo-wide sweep: no surviving `read_only` / sentinel / `ensure_traject_writable` / `for_test` reference.