### PR TITLE
docs: herstel status/implementation-tags in RFC-kop

### DIFF
--- a/docs/src/pages/rfcs/[slug].astro
+++ b/docs/src/pages/rfcs/[slug].astro
@@ -20,10 +20,11 @@ const { Content, headings } = await render(entry);
 const pathname = '/rfcs/' + entry.id.replace(/\.md$/, '');
 
 // RFC metadata from frontmatter. Author(s) and date render as an nldd-byline
-// under the title; status and implementation render as nldd-tags (colour via
-// the shared rfcStatusColor so it cannot drift from the index), with the
-// cross-references as plain rich-text lines beneath. No bespoke CSS — the
-// tag row reuses the index's nldd-container wrap layout.
+// under the title; status and implementation render as side-by-side nldd-tags
+// (colour via the shared rfcStatusColor so it cannot drift from the index),
+// with the cross-references as a rich-text line beneath. No bespoke CSS — the
+// tag row reuses the index's nldd-container wrap layout, and it sits outside
+// the content rich-text so the wrap flow isn't flattened by prose typography.
 const { status, implementation, date, authors } = entry.data;
 // Forward (Depends on) and reverse (Required by) links, resolved against the
 // real RFC set in rfcs.ts so back-references cannot drift from the forward ones.
@@ -67,7 +68,7 @@ const title = pageTitle + ' · RegelRecht';
       <nldd-spacer size="24" sm-size="16" />
       <EditLink filePath={entry.filePath} />
     </div>
-    <nldd-rich-text slot="right" data-edit-base={editBase}>
+    <div slot="right">
       {status && (
         <>
           <nldd-container layout="wrap" gap="4">
@@ -77,27 +78,32 @@ const title = pageTitle + ' · RegelRecht';
             )}
           </nldd-container>
           {(relations.dependsOn.length > 0 || relations.requiredBy.length > 0) && (
-            <p>
-              {relations.dependsOn.length > 0 && (
-                <>
-                  Depends on: {relations.dependsOn.map((r, i) => (
-                    <span>{i > 0 ? ', ' : ''}<a href={r.link}>{r.id}</a> ({r.title})</span>
-                  ))}
-                </>
-              )}
-              {relations.dependsOn.length > 0 && relations.requiredBy.length > 0 && <br />}
-              {relations.requiredBy.length > 0 && (
-                <>
-                  Required by: {relations.requiredBy.map((r, i) => (
-                    <span>{i > 0 ? ', ' : ''}<a href={r.link}>{r.id}</a> ({r.title})</span>
-                  ))}
-                </>
-              )}
-            </p>
+            <nldd-rich-text spacing="flat">
+              <p>
+                {relations.dependsOn.length > 0 && (
+                  <>
+                    Depends on: {relations.dependsOn.map((r, i) => (
+                      <span>{i > 0 ? ', ' : ''}<a href={r.link}>{r.id}</a> ({r.title})</span>
+                    ))}
+                  </>
+                )}
+                {relations.dependsOn.length > 0 && relations.requiredBy.length > 0 && <br />}
+                {relations.requiredBy.length > 0 && (
+                  <>
+                    Required by: {relations.requiredBy.map((r, i) => (
+                      <span>{i > 0 ? ', ' : ''}<a href={r.link}>{r.id}</a> ({r.title})</span>
+                    ))}
+                  </>
+                )}
+              </p>
+            </nldd-rich-text>
           )}
+          <nldd-spacer size="16" />
         </>
       )}
-      <Content />
-    </nldd-rich-text>
+      <nldd-rich-text data-edit-base={editBase}>
+        <Content />
+      </nldd-rich-text>
+    </div>
   </nldd-one-third-two-thirds-section>
 </Base>

--- a/docs/src/pages/rfcs/[slug].astro
+++ b/docs/src/pages/rfcs/[slug].astro
@@ -3,7 +3,7 @@ import { getCollection, render } from 'astro:content';
 import Base from '~/layouts/Base.astro';
 import DocsOutline from '~/components/DocsOutline.astro';
 import EditLink from '~/components/EditLink.astro';
-import { rfcRelations } from '~/lib/rfcs';
+import { rfcStatusColor, rfcRelations } from '~/lib/rfcs';
 
 export async function getStaticPaths() {
   const rfcs = await getCollection('rfcs');
@@ -20,8 +20,10 @@ const { Content, headings } = await render(entry);
 const pathname = '/rfcs/' + entry.id.replace(/\.md$/, '');
 
 // RFC metadata from frontmatter. Author(s) and date render as an nldd-byline
-// under the title; status, implementation and the cross-references render as
-// plain rich-text lines at the top of the article body.
+// under the title; status and implementation render as nldd-tags (colour via
+// the shared rfcStatusColor so it cannot drift from the index), with the
+// cross-references as plain rich-text lines beneath. No bespoke CSS — the
+// tag row reuses the index's nldd-container wrap layout.
 const { status, implementation, date, authors } = entry.data;
 // Forward (Depends on) and reverse (Required by) links, resolved against the
 // real RFC set in rfcs.ts so back-references cannot drift from the forward ones.
@@ -67,23 +69,33 @@ const title = pageTitle + ' · RegelRecht';
     </div>
     <nldd-rich-text slot="right" data-edit-base={editBase}>
       {status && (
-        <p>
-          Status: {status}{implementation && `, ${implementation}`}
-          {relations.dependsOn.length > 0 && (
-            <>
-              <br />Depends on: {relations.dependsOn.map((r, i) => (
-                <span>{i > 0 ? ', ' : ''}<a href={r.link}>{r.id}</a> ({r.title})</span>
-              ))}
-            </>
+        <>
+          <nldd-container layout="wrap" gap="4">
+            <nldd-tag color={rfcStatusColor(status)} size="md">{status}</nldd-tag>
+            {implementation && (
+              <nldd-tag color="neutral" size="md">{implementation}</nldd-tag>
+            )}
+          </nldd-container>
+          {(relations.dependsOn.length > 0 || relations.requiredBy.length > 0) && (
+            <p>
+              {relations.dependsOn.length > 0 && (
+                <>
+                  Depends on: {relations.dependsOn.map((r, i) => (
+                    <span>{i > 0 ? ', ' : ''}<a href={r.link}>{r.id}</a> ({r.title})</span>
+                  ))}
+                </>
+              )}
+              {relations.dependsOn.length > 0 && relations.requiredBy.length > 0 && <br />}
+              {relations.requiredBy.length > 0 && (
+                <>
+                  Required by: {relations.requiredBy.map((r, i) => (
+                    <span>{i > 0 ? ', ' : ''}<a href={r.link}>{r.id}</a> ({r.title})</span>
+                  ))}
+                </>
+              )}
+            </p>
           )}
-          {relations.requiredBy.length > 0 && (
-            <>
-              <br />Required by: {relations.requiredBy.map((r, i) => (
-                <span>{i > 0 ? ', ' : ''}<a href={r.link}>{r.id}</a> ({r.title})</span>
-              ))}
-            </>
-          )}
-        </p>
+        </>
       )}
       <Content />
     </nldd-rich-text>


### PR DESCRIPTION
## Wat

De RFC-detailkop toonde status en implementation weer als één platte `Status: ...`-regel in plaats van de nldd-tag-badges. Deze PR herstelt de tag-rendering.

## Waarom het weg was

Een stille regressie. PR #826 (RFC-metadata naar frontmatter) zette status en implementation als `nldd-tag`-badges en de cross-references als een gestructureerde lijst. PR #827 (traject-flow) was vertakt vóór #826 en draaide bij de merge de hele kop-rendering terug naar de oude platte preamble-regel. De data zelf bleef intact in de frontmatter; alleen de presentatie viel terug.

## Wat deze PR doet

- Status en implementation renderen weer als `nldd-tag`, met de kleur via de gedeelde `rfcStatusColor` uit `rfcs.ts` zodat ze niet uit elkaar lopen met de RFC-index.
- Depends-on en Required-by staan als prozaregels met gelinkte RFC's eronder.
- **Geen maatwerk-CSS.** De vorige herstelpoging (#826) gebruikte een `<dl>` met een eigen grid; dat is bewust niet teruggehaald. De tag-rij hergebruikt de `nldd-container layout="wrap"`-aanpak van de RFC-index.

## Verificatie

`npm run build` in `docs/` is schoon (84 pagina's). De gegenereerde `dist/rfcs/rfc-009/index.html` toont de twee tags (`Proposed` / `Partially implemented`) plus de gelinkte Depends-on/Required-by-regels.