### PR TITLE
docs: verwijzingen naar RFC's in RFC-teksten automatisch linken

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -6,6 +6,7 @@ import rehypeMermaid from 'rehype-mermaid';
 import { rehypeMermaidAlt } from './src/lib/rehype-mermaid-alt.ts';
 import { rehypeNlddCodeViewer } from './src/lib/rehype-nldd-code-viewer.ts';
 import { rehypeSourceLines } from './src/lib/rehype-source-lines.ts';
+import { rehypeRfcLinks } from './src/lib/rehype-rfc-links.ts';
 
 export default defineConfig({
   site: 'https://docs.regelrecht.rijks.app',
@@ -52,6 +53,12 @@ export default defineConfig({
       // Stamp source-line data attributes first, before the plugins below
       // restructure nodes and lose the original markdown positions.
       rehypeSourceLines,
+      // Auto-link bare RFC cross-references ("RFC-008", "RFC-001 §9") in RFC
+      // bodies. Runs after source-lines (it inserts <a> nodes, which would
+      // otherwise perturb the line stamping) and before the code-viewer
+      // reshape; it skips <a>/<code>/<pre> so existing links and code examples
+      // are left untouched.
+      rehypeRfcLinks,
       [
         rehypeMermaid,
         {

--- a/docs/src/lib/rehype-rfc-links.ts
+++ b/docs/src/lib/rehype-rfc-links.ts
@@ -1,0 +1,158 @@
+import type { Root, Element, ElementContent, Text } from 'hast'
+import type { VFile } from 'vfile'
+import { rfcTargets, type RfcTarget } from './rfcs.ts'
+
+/**
+ * Auto-link RFC cross-references in rendered RFC bodies.
+ *
+ * RFCs mention each other constantly ("RFC-008", "RFC-001 §9", "RFC-008 §A.8"),
+ * but most mentions are plain prose, not markdown links. Hand-linking each one
+ * would be hundreds of edits across the corpus and would rot the moment a
+ * heading is renumbered. This plugin instead scans the rendered text at build
+ * time and wraps every bare reference in an <a>:
+ *
+ *   - "RFC-008"        → /rfcs/rfc-008
+ *   - "RFC-001 §9"     → /rfcs/rfc-001#9-input-source-consolidation
+ *   - "RFC-008 §A.8"   → /rfcs/rfc-008#a8-uniforme-…
+ *
+ * Section anchors come from rfcs.ts (rfcTargets), which parses each target
+ * RFC's own headings with the same github-slugger Astro uses, so "§N" resolves
+ * to the real heading id. A "§N" with no matching heading falls back to the
+ * page link (the number still shows, just without a fragment).
+ *
+ * What it deliberately does NOT touch:
+ *   - text already inside an <a> (hand-authored markdown links stay as-is),
+ *   - <code>/<pre> (an "RFC-007" inside a YAML example is content, not a link),
+ *   - a bare self-reference (an RFC linking to its own page top is noise) —
+ *     but a self-reference WITH a §section becomes an in-page anchor jump.
+ *
+ * Runs on RFC pages only (keyed off the source path under content/rfcs); a
+ * stray "RFC-008" elsewhere in the docs is left alone.
+ */
+
+// "RFC-008" or "RFC-8" (zero-padding optional), optionally followed by a
+// section reference: "§9", "§1.2", "§A.8". The reference glyph is U+00A7. The
+// section token is an optional leading letter (appendix sections, optionally
+// with its own dot as in "A.8") then dot-separated digit groups — the same
+// shape rfcs.ts keys on. Dots are only consumed *between* digits, so a
+// sentence-ending dot ("§5.") is never swallowed and "§1.2" keeps its dot.
+const REF =
+  /RFC-0*(\d+)(\s*§\s*((?:[A-Za-z]\.?)?\d+(?:\.\d+)*))?(?=[).,;:\s]|$)/g
+
+// Skip these subtrees entirely: existing links and code keep their text.
+const SKIP_TAGS = new Set(['a', 'code', 'pre'])
+
+/** Current RFC number from the source file path, or null for non-RFC pages. */
+function currentRfcNum(file: VFile | undefined): number | null {
+  const path = file?.path ?? ''
+  const m = path.match(/rfc-(\d+)\.md$/)
+  return m ? parseInt(m[1], 10) : null
+}
+
+/** github-slugger collapses "1.2"→"12", "A.8"→"a8"; mirror that for lookup. */
+function sectionKey(raw: string): string {
+  return raw.toLowerCase().replace(/[.\s]/g, '')
+}
+
+/**
+ * Build the replacement nodes for one text value: the parts between matches
+ * stay as text, each match becomes an <a> (or, for an unlinkable self-ref,
+ * stays as text). Returns null when there is nothing to link, so callers can
+ * leave the original node untouched.
+ */
+function linkify(
+  value: string,
+  targets: Map<number, RfcTarget>,
+  selfNum: number | null,
+): ElementContent[] | null {
+  const out: ElementContent[] = []
+  let last = 0
+  let linked = false
+
+  for (const m of value.matchAll(REF)) {
+    const [whole, numStr, , sectionRaw] = m
+    const start = m.index ?? 0
+    const num = parseInt(numStr, 10)
+    const target = targets.get(num)
+
+    // Unknown RFC number: leave the text as-is (no link to a 404).
+    if (!target) continue
+
+    const section = sectionRaw
+      ? target.sections.get(sectionKey(sectionRaw))
+      : undefined
+
+    // A self-reference to the page top is noise; a self-reference to a section
+    // is a useful in-page jump. Drop the former, keep the latter.
+    const isSelf = num === selfNum
+    if (isSelf && !section) continue
+
+    const href = section
+      ? `${isSelf ? '' : target.link}#${section}`
+      : target.link
+
+    // Emit the gap before this match, then the link.
+    if (start > last) out.push(text(value.slice(last, start)))
+    out.push(anchor(href, whole, target, sectionRaw))
+    last = start + whole.length
+    linked = true
+  }
+
+  if (!linked) return null
+  if (last < value.length) out.push(text(value.slice(last)))
+  return out
+}
+
+function text(value: string): Text {
+  return { type: 'text', value }
+}
+
+function anchor(
+  href: string,
+  label: string,
+  target: RfcTarget,
+  sectionRaw: string | undefined,
+): Element {
+  // Title gives the descriptive name on hover; the visible text stays exactly
+  // what the author wrote ("RFC-008 §A.8"), so prose reads unchanged.
+  const title = sectionRaw
+    ? `${target.id} §${sectionRaw} — ${target.title}`
+    : `${target.id} — ${target.title}`
+  return {
+    type: 'element',
+    tagName: 'a',
+    properties: { href, title, className: ['rfc-ref'] },
+    children: [text(label)],
+  }
+}
+
+export function rehypeRfcLinks() {
+  return (tree: Root, file: VFile) => {
+    const selfNum = currentRfcNum(file)
+    // Only RFC source files carry RFC cross-references worth auto-linking.
+    if (selfNum === null) return
+    const targets = rfcTargets()
+
+    const walk = (parent: { children?: ElementContent[] }) => {
+      const children = parent.children
+      if (!children) return
+      for (let i = 0; i < children.length; i++) {
+        const child = children[i]
+        if (child.type === 'element') {
+          if (SKIP_TAGS.has(child.tagName)) continue
+          walk(child)
+          continue
+        }
+        if (child.type !== 'text') continue
+        const replacement = linkify(child.value, targets, selfNum)
+        if (!replacement) continue
+        children.splice(i, 1, ...replacement)
+        i += replacement.length - 1 // skip over the nodes we just inserted
+      }
+    }
+
+    walk(tree as unknown as { children?: ElementContent[] })
+  }
+}
+
+export default rehypeRfcLinks

--- a/docs/src/lib/rfcs.ts
+++ b/docs/src/lib/rfcs.ts
@@ -7,6 +7,7 @@
 import { existsSync, readdirSync, readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import GithubSlugger from 'github-slugger'
 
 export interface RfcEntry {
   /** Numeric RFC number, e.g. 8 */
@@ -238,4 +239,104 @@ export function rfcSidebarItems(): { text: string; link: string }[] {
     { text: 'Overview', link: '/rfcs/' },
     ...getRfcs().map((r) => ({ text: `${r.id}: ${r.shortTitle}`, link: r.link })),
   ]
+}
+
+/** A cross-link target: the RFC page plus its section anchors. */
+export interface RfcTarget {
+  /** Zero-padded id, e.g. "RFC-008" */
+  id: string
+  /** Descriptive title, e.g. "Awb Administrative Procedures" */
+  title: string
+  /** Site-relative link to the page, e.g. "/rfcs/rfc-008" */
+  link: string
+  /**
+   * Section number (as a reader writes it after `§`, normalised) → the heading
+   * slug Astro generates. Normalisation removes the dots and lowercases, so
+   * "§9", "§1.2" and "§A.8" key on "9", "12", "a8" — matching how
+   * github-slugger collapses "9. …", "1.2. …" and "A.8 …" into ids.
+   */
+  sections: Map<string, string>
+}
+
+/**
+ * Normalise a section number the way github-slugger collapses a heading's
+ * leading numeric token: lowercase, drop dots and spaces. "1.2" → "12",
+ * "A.8" → "a8", "9" → "9". Used on both sides (heading parse and `§`
+ * reference) so the two cannot disagree.
+ */
+function normalizeSectionNumber(raw: string): string {
+  return raw.toLowerCase().replace(/[.\s]/g, '')
+}
+
+// Leading section token of a heading, e.g. "9. Foo" → "9", "A.8 Bar" → "A.8",
+// "1.2. Baz" → "1.2". Optional leading letter (appendix sections, optionally
+// with its own dot as in "A.8"), then dot-separated digit groups, then a
+// delimiter (the heading's own "." or the space before its title). Headings
+// without a number (Context, Why) produce no section entry and are reachable
+// only as the whole page.
+const HEADING_SECTION = /^((?:[A-Za-z]\.?)?\d+(?:\.\d+)*)[.\s]/
+
+/** Strip markdown inline syntax that would otherwise leak into a slug. */
+function headingText(line: string): string {
+  return line
+    .replace(/^#{1,6}\s+/, '')
+    .replace(/`([^`]*)`/g, '$1') // inline code: keep the contents
+    .trim()
+}
+
+/**
+ * Parse a single RFC file's body headings into a section-number → slug map,
+ * using the same github-slugger instance semantics Astro applies (a fresh
+ * slugger per document, so duplicate headings get -1/-2 suffixes in source
+ * order). Only headings that begin with a section number get an entry; the
+ * RFC page itself is always linkable without one.
+ */
+function parseSections(content: string): Map<string, string> {
+  const slugger = new GithubSlugger()
+  const sections = new Map<string, string>()
+  // Strip frontmatter so its lines never feed the slugger and shift suffixes.
+  const body = content.replace(FRONTMATTER, '')
+  let inFence = false
+  for (const line of body.split('\n')) {
+    // Track fenced code blocks so a "# comment" inside one is not a heading.
+    if (/^\s*(```|~~~)/.test(line)) {
+      inFence = !inFence
+      continue
+    }
+    if (inFence) continue
+    if (!/^#{1,6}\s/.test(line)) continue
+    const text = headingText(line)
+    // Slug every heading in order so duplicates dedupe exactly as Astro does.
+    const slug = slugger.slug(text)
+    const num = text.match(HEADING_SECTION)?.[1]
+    if (!num) continue
+    const key = normalizeSectionNumber(num)
+    // First heading wins for a given number; later collisions keep the slug
+    // they already produced (and the slugger has handled the id dedupe).
+    if (!sections.has(key)) sections.set(key, slug)
+  }
+  return sections
+}
+
+/**
+ * Every RFC keyed by its number, with the data the cross-link rehype plugin
+ * needs: the page link, the descriptive title (for link titles/aria), and the
+ * section-anchor map so `§N` references resolve to the right heading. Pure
+ * Node, runs at build time.
+ */
+export function rfcTargets(): Map<number, RfcTarget> {
+  const targets = new Map<number, RfcTarget>()
+  for (const rfc of getRfcs()) {
+    const content = readFileSync(
+      `${RFCS_DIR}/${rfc.link.replace('/rfcs/', '')}.md`,
+      'utf-8',
+    )
+    targets.set(rfc.num, {
+      id: rfc.id,
+      title: rfc.title,
+      link: rfc.link,
+      sections: parseSections(content),
+    })
+  }
+  return targets
 }


### PR DESCRIPTION
## Wat

RFC's verwijzen voortdurend naar elkaar ("RFC-008", "RFC-001 §9"), maar de meeste verwijzingen stonden als platte tekst, niet als link. Deze PR linkt ze automatisch bij het bouwen, inclusief een sprong naar de juiste paragraaf waar dat kan.

| Verwijzing in de tekst | Wordt |
|---|---|
| `RFC-008` | `/rfcs/rfc-008` |
| `RFC-001 §9` | `/rfcs/rfc-001#9-input-source-consolidation` |
| `RFC-008 §A.8` | `/rfcs/rfc-008#a8-...` |

## Hoe

- **`docs/src/lib/rehype-rfc-links.ts`** (nieuw): een rehype-plugin die over de gerenderde RFC-tekst loopt en elke kale verwijzing in een `<a>` zet.
- **`docs/src/lib/rfcs.ts`**: nieuwe `rfcTargets()` parseert de koppen van elke RFC met dezelfde `github-slugger` die Astro voor de heading-id's gebruikt, en bouwt een sectienummer-naar-anker map. Zo wijst `§N` naar de echte kop (`§1.2` en `§A.8` worden net als in de slug afgehandeld). Een `§N` zonder bijbehorende kop valt terug op de paginalink.
- **`docs/astro.config.mjs`**: plugin ingehangen na `rehype-source-lines` en vóór de code-viewer-reshape.

## Met opzet ongemoeid

- Tekst die al in een `<a>` staat (handgeschreven markdown-links blijven zoals ze zijn).
- Code in `<code>`/`<pre>` (een `RFC-007` in een YAML-voorbeeld is inhoud, geen link).
- Een kale zelfverwijzing (een RFC die naar zijn eigen paginatop linkt is ruis). Een zelfverwijzing mét sectie wordt wel een sprong binnen de pagina.
- Verwijzingen naar een sectie op naam (`§"Priority"`, `§Context`): die linken naar de juiste pagina, het naam-achtervoegsel blijft tekst. Alleen genummerde secties worden naar een anker gelinkt.

## Extra CSS

Geen. De links erven de standaard link-styling van `nldd-rich-text`. De `rfc-ref`-class is enkel een haakje voor eventuele latere styling.

## Verificatie

- `just docs-a11y` (de docs-CI-poort): 84/84 pagina's, 0 fouten.
- Interne-linkcontrole: geen kapotte links, dus alle gegenereerde sectie-ankers bestaan echt.