### PR TITLE
docs: commit- en PR-titel-conventies vastleggen in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,25 @@ This repository uses pre-commit hooks for code quality:
 
 **No branding in commits.** Do not add "Generated with Claude Code" or "Co-Authored-By: Claude" lines to commit messages.
 
+### Commit & PR Title Conventions
+
+PR titles are linted by `.github/workflows/pr-title.yml` (a failing title blocks
+merge). The format is **Conventional Commits**: `type(scope): subject`, where
+`(scope)` is optional. Commit messages should follow the same shape.
+
+- **Allowed types**: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`,
+  `test`, `chore`, `build`, `ci`.
+- **Allowed scopes** (optional): `engine`, `admin`, `pipeline`, `harvester`,
+  `editor`, `corpus`, `frontend`, `lawmaking`, `docs`, `grafana`, `ci`,
+  `schema`, `deps`, `dev`. An unlisted scope fails the lint.
+- **The subject MUST start with a lowercase letter** (`subjectPattern:
+  ^[a-z].*$`). This is the easiest rule to trip on: `docs: RFC-…` fails because
+  "RFC" is uppercase — write `docs: verwijzingen naar RFC's …` instead. Editing
+  the PR title re-runs the check; no new commit needed.
+
+Per the global convention these subjects are written in **Dutch** (PR
+descriptions too), while code identifiers stay English.
+
 ### Test Data
 
 **Never use real secret or private information in tests.** This is a public


### PR DESCRIPTION
## Wat

De PR-titel-lint (`.github/workflows/pr-title.yml`) blokkeert merge bij een foute titel, maar de regels stonden nergens in `CLAUDE.md`. Deze PR legt ze vast, naast de bestaande commit-conventies.

## Waarom

Vorige PR (#853) faalde eerst op de titel-check: het subject moet met een kleine letter beginnen (`subjectPattern: ^[a-z].*$`), en `docs: RFC-…` begint met een hoofdletter. Dat kostte een extra CI-ronde. Met de toegestane types/scopes en die kleine-letter-val gedocumenteerd voorkomen we dat.

## Wat is toegevoegd

Een subsectie "Commit & PR Title Conventions" met:
- het Conventional-Commits-formaat (`type(scope): subject`),
- de volledige lijst toegestane types en scopes uit de workflow,
- de kleine-letter-regel voor het subject, met het concrete struikelvoorbeeld,
- de herinnering dat subjects (en PR-beschrijvingen) in het Nederlands zijn.