### PR TITLE
feat(editor): show clear message for unknown or inaccessible traject

### DIFF
--- a/frontend/src/EditorView.vue
+++ b/frontend/src/EditorView.vue
@@ -154,7 +154,7 @@ function movePane(idx, target) {
 //     `canEdit` is true; writes land in that traject's branch.
 // Pick a traject in the TrajectMenu to flip from the first shape to
 // the second.
-const { activeTrajectRef, activeTraject } = useTrajects();
+const { activeTrajectRef, activeTraject, trajectMissing } = useTrajects();
 const canEdit = computed(
   () => (!oidcConfigured.value || authenticated.value) && activeTrajectRef.value !== null,
 );
@@ -1434,11 +1434,29 @@ async function handleActionSave() {
 </script>
 
 <template>
+        <!-- The URL names a traject the user has no membership for: it was
+             deleted, never existed, or access was revoked. We do not
+             distinguish these (no leak of traject existence). Takes
+             precedence over every editor state below, including the law-404
+             branch, so a missing traject never shows "<law> is niet
+             beschikbaar in dit traject". -->
+        <nldd-page v-if="trajectMissing">
+          <nldd-simple-section width="full">
+            <nldd-inline-dialog
+              variant="alert"
+              text="Dit traject bestaat niet of je hebt geen toegang."
+              supporting-text="Ga terug naar het overzicht om een traject te kiezen."
+            >
+              <nldd-button slot="actions" variant="primary" text="Naar overzicht" :href="libraryTabHref" @click.prevent="router.push(libraryTabTarget)"></nldd-button>
+            </nldd-inline-dialog>
+          </nldd-simple-section>
+        </nldd-page>
+
         <!-- Empty state: no tabs open. The CTA points back to the library
              since that's the only way to create new tabs; mention the tab
              bar too because closed tabs may still be visible alongside this
              empty state on the next pane. -->
-        <nldd-page v-if="!activeTab">
+        <nldd-page v-else-if="!activeTab">
           <nldd-simple-section width="full">
             <nldd-inline-dialog text="Open een artikel vanuit de tabbalk of de bibliotheek om te bewerken.">
               <nldd-button slot="actions" variant="secondary" text="Ga naar bibliotheek" :href="libraryTabHref" @click.prevent="router.push(libraryTabTarget)"></nldd-button>

--- a/frontend/src/composables/useTrajects.js
+++ b/frontend/src/composables/useTrajects.js
@@ -3,15 +3,20 @@ import { useRoute } from 'vue-router';
 import { apiFetch, apiFetchJson } from '../lib/apiFetch.js';
 import { useAuth } from './useAuth.js';
 
-// Pure predicate: the URL names a traject (`trajectRef`) but, for an
-// authenticated user whose membership list has finished loading, that ref
-// is not among their memberships (`activeTraject` is null). That means the
-// traject either does not exist or the user has no access — we deliberately
-// do not distinguish the two (no information leak about traject existence).
-// The `authenticated` + `!loading` gates avoid a false flash while auth and
-// the list are still resolving.
-export function isTrajectMissing(trajectRef, authenticated, loading, activeTraject) {
-  return trajectRef != null && authenticated && !loading && activeTraject == null;
+// Pure predicate: the URL names a traject (`trajectRef`) but, for a user who
+// may use the editor (`authorized`) and whose membership list has finished
+// loading (`!loading`), that ref is not among their memberships
+// (`activeTraject` is null). That means the traject either does not exist or
+// the user has no access — we deliberately do not distinguish the two (no
+// information leak about traject existence).
+//
+// `authorized` mirrors `canEdit`'s `!oidcConfigured || authenticated` idiom so
+// the message also works in OIDC-not-configured (dev) deployments. The
+// `!loading` gate covers the trajects-list fetch; the auth side needs no gate
+// here because the `requiresAuth` router guard awaits `/auth/status` before
+// EditorView mounts, so `authorized` is already settled by the time this runs.
+export function isTrajectMissing(trajectRef, authorized, loading, activeTraject) {
+  return trajectRef != null && authorized && !loading && activeTraject == null;
 }
 
 const trajects = ref([]);
@@ -103,11 +108,11 @@ export function useTrajects() {
   const activeTraject = computed(
     () => trajects.value.find((t) => t.ref && t.ref === activeTrajectRef.value) || null,
   );
-  const { authenticated } = useAuth();
+  const { authenticated, oidcConfigured } = useAuth();
   const trajectMissing = computed(() =>
     isTrajectMissing(
       activeTrajectRef.value,
-      authenticated.value,
+      !oidcConfigured.value || authenticated.value,
       loading.value,
       activeTraject.value,
     ),

--- a/frontend/src/composables/useTrajects.js
+++ b/frontend/src/composables/useTrajects.js
@@ -4,19 +4,22 @@ import { apiFetch, apiFetchJson } from '../lib/apiFetch.js';
 import { useAuth } from './useAuth.js';
 
 // Pure predicate: the URL names a traject (`trajectRef`) but, for a user who
-// may use the editor (`authorized`) and whose membership list has finished
-// loading (`!loading`), that ref is not among their memberships
-// (`activeTraject` is null). That means the traject either does not exist or
-// the user has no access — we deliberately do not distinguish the two (no
-// information leak about traject existence).
+// may use the editor (`authorized`) whose membership list has finished loading
+// (`!loading`) without error (`!errored`), that ref is not among their
+// memberships (`activeTraject` is null). That means the traject either does not
+// exist or the user has no access — we deliberately do not distinguish the two
+// (no information leak about traject existence).
 //
 // `authorized` mirrors `canEdit`'s `!oidcConfigured || authenticated` idiom so
 // the message also works in OIDC-not-configured (dev) deployments. The
-// `!loading` gate covers the trajects-list fetch; the auth side needs no gate
-// here because the `requiresAuth` router guard awaits `/auth/status` before
-// EditorView mounts, so `authorized` is already settled by the time this runs.
-export function isTrajectMissing(trajectRef, authorized, loading, activeTraject) {
-  return trajectRef != null && authorized && !loading && activeTraject == null;
+// `!loading` + `!errored` gates cover the trajects-list fetch: a network
+// failure leaves the list empty but is NOT a missing traject, so `errored`
+// suppresses a false "does not exist" for a transient blip. The auth side
+// needs no gate because the `requiresAuth` router guard awaits `/auth/status`
+// before EditorView mounts, so `authorized` is already settled by the time this
+// runs.
+export function isTrajectMissing(trajectRef, authorized, loading, errored, activeTraject) {
+  return trajectRef != null && authorized && !loading && !errored && activeTraject == null;
 }
 
 const trajects = ref([]);
@@ -31,6 +34,10 @@ async function loadTrajects() {
   // while the new list is in flight, instead of holding the stale label
   // for the duration of the round-trip.
   loading.value = true;
+  // Clear any prior error so it reflects only this fetch — otherwise a single
+  // historical network blip stays sticky and would permanently suppress the
+  // trajectMissing message (which gates on `!error`) for the whole session.
+  error.value = null;
   try {
     // Raw fetch + ok-branch on purpose: a non-ok status (e.g. 401 on a
     // public page) keeps the previous list without setting `error` —
@@ -114,6 +121,7 @@ export function useTrajects() {
       activeTrajectRef.value,
       !oidcConfigured.value || authenticated.value,
       loading.value,
+      error.value != null,
       activeTraject.value,
     ),
   );

--- a/frontend/src/composables/useTrajects.js
+++ b/frontend/src/composables/useTrajects.js
@@ -1,6 +1,18 @@
 import { computed, ref } from 'vue';
 import { useRoute } from 'vue-router';
 import { apiFetch, apiFetchJson } from '../lib/apiFetch.js';
+import { useAuth } from './useAuth.js';
+
+// Pure predicate: the URL names a traject (`trajectRef`) but, for an
+// authenticated user whose membership list has finished loading, that ref
+// is not among their memberships (`activeTraject` is null). That means the
+// traject either does not exist or the user has no access — we deliberately
+// do not distinguish the two (no information leak about traject existence).
+// The `authenticated` + `!loading` gates avoid a false flash while auth and
+// the list are still resolving.
+export function isTrajectMissing(trajectRef, authenticated, loading, activeTraject) {
+  return trajectRef != null && authenticated && !loading && activeTraject == null;
+}
 
 const trajects = ref([]);
 const loading = ref(true);
@@ -91,10 +103,20 @@ export function useTrajects() {
   const activeTraject = computed(
     () => trajects.value.find((t) => t.ref && t.ref === activeTrajectRef.value) || null,
   );
+  const { authenticated } = useAuth();
+  const trajectMissing = computed(() =>
+    isTrajectMissing(
+      activeTrajectRef.value,
+      authenticated.value,
+      loading.value,
+      activeTraject.value,
+    ),
+  );
   return {
     trajects,
     activeTrajectRef,
     activeTraject,
+    trajectMissing,
     loading,
     error,
     createTraject,

--- a/frontend/src/composables/useTrajects.test.js
+++ b/frontend/src/composables/useTrajects.test.js
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { isTrajectMissing } from './useTrajects.js';
+
+describe('isTrajectMissing', () => {
+  const ref = 'zorgtoeslag-12345678';
+  const member = { ref, name: 'Zorgtoeslag' };
+
+  it('is true when the URL names a traject not in the membership list', () => {
+    // authenticated, list done loading, ref not found → missing
+    expect(isTrajectMissing(ref, true, false, null)).toBe(true);
+  });
+
+  it('is false when the traject is one of the memberships', () => {
+    expect(isTrajectMissing(ref, true, false, member)).toBe(false);
+  });
+
+  it('is false while the membership list is still loading', () => {
+    expect(isTrajectMissing(ref, true, true, null)).toBe(false);
+  });
+
+  it('is false when the user is not authenticated', () => {
+    expect(isTrajectMissing(ref, false, false, null)).toBe(false);
+  });
+
+  it('is false for the global view (no traject in the URL)', () => {
+    expect(isTrajectMissing(null, true, false, null)).toBe(false);
+  });
+});

--- a/frontend/src/composables/useTrajects.test.js
+++ b/frontend/src/composables/useTrajects.test.js
@@ -6,7 +6,7 @@ describe('isTrajectMissing', () => {
   const member = { ref, name: 'Zorgtoeslag' };
 
   it('is true when the URL names a traject not in the membership list', () => {
-    // authenticated, list done loading, ref not found → missing
+    // authorized, list done loading, ref not found → missing
     expect(isTrajectMissing(ref, true, false, null)).toBe(true);
   });
 
@@ -18,7 +18,7 @@ describe('isTrajectMissing', () => {
     expect(isTrajectMissing(ref, true, true, null)).toBe(false);
   });
 
-  it('is false when the user is not authenticated', () => {
+  it('is false when the user is not authorized', () => {
     expect(isTrajectMissing(ref, false, false, null)).toBe(false);
   });
 

--- a/frontend/src/composables/useTrajects.test.js
+++ b/frontend/src/composables/useTrajects.test.js
@@ -1,28 +1,34 @@
 import { describe, it, expect } from 'vitest';
 import { isTrajectMissing } from './useTrajects.js';
 
+// Signature: isTrajectMissing(trajectRef, authorized, loading, errored, activeTraject)
 describe('isTrajectMissing', () => {
   const ref = 'zorgtoeslag-12345678';
   const member = { ref, name: 'Zorgtoeslag' };
 
   it('is true when the URL names a traject not in the membership list', () => {
-    // authorized, list done loading, ref not found → missing
-    expect(isTrajectMissing(ref, true, false, null)).toBe(true);
+    // authorized, list done loading, no error, ref not found → missing
+    expect(isTrajectMissing(ref, true, false, false, null)).toBe(true);
   });
 
   it('is false when the traject is one of the memberships', () => {
-    expect(isTrajectMissing(ref, true, false, member)).toBe(false);
+    expect(isTrajectMissing(ref, true, false, false, member)).toBe(false);
   });
 
   it('is false while the membership list is still loading', () => {
-    expect(isTrajectMissing(ref, true, true, null)).toBe(false);
+    expect(isTrajectMissing(ref, true, true, false, null)).toBe(false);
+  });
+
+  it('is false when the trajects fetch errored (e.g. network blip)', () => {
+    // empty list from a failed fetch must not read as "does not exist"
+    expect(isTrajectMissing(ref, true, false, true, null)).toBe(false);
   });
 
   it('is false when the user is not authorized', () => {
-    expect(isTrajectMissing(ref, false, false, null)).toBe(false);
+    expect(isTrajectMissing(ref, false, false, false, null)).toBe(false);
   });
 
   it('is false for the global view (no traject in the URL)', () => {
-    expect(isTrajectMissing(null, true, false, null)).toBe(false);
+    expect(isTrajectMissing(null, true, false, false, null)).toBe(false);
   });
 });


### PR DESCRIPTION
## Problem

Opening the editor at a traject URL whose traject is no longer among the user's memberships (e.g. after the owner deleted it) showed a misleading half-state: the law-404 message *"<law> is niet beschikbaar in dit traject"* plus a traject menu rendering as if no traject was selected. The backend returns the same HTTP 404 for both "traject does not resolve" and "law not in this traject's corpus", and the frontend only branched on the status code.

## Fix (frontend-only)

Detect the condition locally — the URL names a traject (`activeTrajectRef`) but, for an authenticated user whose membership list has loaded, it is not among their memberships (`activeTraject == null`). `GET /api/trajects` returns all memberships with no cap, so this is reliable.

- `isTrajectMissing()` pure predicate + `trajectMissing` computed in `useTrajects` (gated on `authenticated` + `!loading` to avoid a false flash during load).
- `EditorView` renders an NDD inline alert **"Dit traject bestaat niet of je hebt geen toegang."** as the first template branch, taking precedence over the law-404 branch. Works with or without a law in the URL.

We deliberately do **not** distinguish 404 (not found) from 403 (no access): one combined message leaks no information about traject existence to non-members.

## Out of scope (deliberate)

- 404/403 distinction (see above).
- Cleaning up the GitHub branch on traject delete (backend leaves it on purpose).
- TrajectMenu tweak — with the clear inline message, the menu showing "Trajecten" for a traject you have no membership for is honest.

## Tests

- New unit tests for `isTrajectMissing` (5/5 green).
- Full frontend suite green (35 files / 363 tests); `npm run build` succeeds.
- No additional CSS; design-system (`nldd-*`) components only.

## Manual verification

To smoke-test on the preview: open a valid traject, delete it (or use a `{slug}-{8hex}` ref you're not a member of), navigate to the URL and hard-reload → expect the "bestaat niet of geen toegang" message + "Naar overzicht" button.