### PR TITLE
feat(editor): datatype-gestuurde cellen in scenario-bronnentabellen

### DIFF
--- a/frontend/src/components/DataSourceTable.test.js
+++ b/frontend/src/components/DataSourceTable.test.js
@@ -1,0 +1,48 @@
+import { mount } from '@vue/test-utils';
+import { describe, it, expect } from 'vitest';
+import DataSourceTable from './DataSourceTable.vue';
+import ScenarioParameterInput from './ScenarioParameterInput.vue';
+
+const fields = [
+  { name: 'verdragsinschrijving', type: 'boolean', unit: null },
+  { name: 'spaargeld', type: 'amount', unit: 'eurocent' },
+  { name: 'geboortedatum', type: 'date', unit: null },
+  { name: 'land_verblijf', type: 'string', unit: null },
+];
+
+const mountTable = (rows) =>
+  mount(DataSourceTable, {
+    props: { title: 'box', keyField: 'bsn', fields, modelValue: rows, defaultExpanded: true, drilledIn: true },
+  });
+
+const spiFor = (w, name) =>
+  w.findAllComponents(ScenarioParameterInput).find((c) => c.props('name') === name);
+
+describe('DataSourceTable typed cells', () => {
+  it('renders the control matching each column datatype', () => {
+    const w = mountTable([
+      { _id: 1, bsn: '1', verdragsinschrijving: 'false', spaargeld: '79547', geboortedatum: '2005-01-01', land_verblijf: 'NEDERLAND' },
+    ]);
+    // boolean -> kept tri-state dropdown (true/false/null)
+    expect(w.find('select').exists()).toBe(true);
+    expect(w.findAll('option').some((o) => o.attributes('value') === 'null')).toBe(true);
+    // amount/date/string -> reused ScenarioParameterInput with correct type/unit
+    expect(spiFor(w, 'spaargeld').props('type')).toBe('amount');
+    expect(spiFor(w, 'spaargeld').props('unit')).toBe('eurocent');
+    expect(spiFor(w, 'geboortedatum').props('type')).toBe('date');
+    expect(spiFor(w, 'land_verblijf').props('type')).toBe('string');
+    // boolean column is NOT routed through ScenarioParameterInput
+    expect(spiFor(w, 'verdragsinschrijving')).toBeUndefined();
+  });
+
+  it('displays a "null" cell as empty and clears to null', async () => {
+    const w = mountTable([
+      { _id: 1, bsn: '1', verdragsinschrijving: 'null', spaargeld: 'null', geboortedatum: null, land_verblijf: 'null' },
+    ]);
+    const spi = spiFor(w, 'spaargeld');
+    expect(spi.props('value')).toBe(''); // stored "null" -> displayed empty
+    spi.vm.$emit('update', ''); // user clears the field
+    await w.vm.$nextTick();
+    expect(w.emitted('update:modelValue').at(-1)[0][0].spaargeld).toBeNull();
+  });
+});

--- a/frontend/src/components/DataSourceTable.vue
+++ b/frontend/src/components/DataSourceTable.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { ref, computed } from 'vue';
+import ScenarioParameterInput from './ScenarioParameterInput.vue';
 
 let nextRowId = 0;
 
@@ -67,14 +68,14 @@ function defaultForType(type) {
   }
 }
 
-function inputType(fieldType) {
-  switch (fieldType) {
-    case 'number':
-    case 'amount':
-      return 'number';
-    default:
-      return 'text';
-  }
+// Null contract for data-source cells: null / undefined / the gherkin string
+// "null" all mean "not provided" and display as empty; clearing stores null.
+// (Mirrors steps.js `'null' -> null` and formMapper `null/'' -> 'null'`.)
+function cellDisplay(v) {
+  return v == null || v === 'null' ? '' : v;
+}
+function cellStore(rowIndex, fieldName, v) {
+  updateCell(rowIndex, fieldName, v === '' || v == null ? null : v);
 }
 
 // All columns: key field + declared fields (deduplicated)
@@ -83,7 +84,7 @@ const allColumns = computed(() => {
   const seen = new Set();
 
   seen.add(props.keyField);
-  cols.push({ name: props.keyField, type: 'string', isKey: true });
+  cols.push({ name: props.keyField, type: 'string', unit: null, isKey: true });
 
   for (const field of props.fields) {
     if (!seen.has(field.name)) {
@@ -149,12 +150,13 @@ const showBody = computed(() => props.drilledIn || expanded.value);
               </nldd-dropdown>
             </nldd-cell>
             <nldd-cell v-else width="full" min-width="120px">
-              <nldd-text-field
-                size="md"
-                :type="inputType(col.type)"
-                :value="String(row[col.name] ?? '')"
-                @input="updateCell(ri, col.name, $event.target?.value ?? $event.detail?.value ?? '')"
-              ></nldd-text-field>
+              <ScenarioParameterInput
+                :type="col.type"
+                :unit="col.unit"
+                :name="col.name"
+                :value="cellDisplay(row[col.name])"
+                @update="cellStore(ri, col.name, $event)"
+              />
             </nldd-cell>
           </nldd-list-item>
 

--- a/frontend/src/components/ScenarioBuilder.vue
+++ b/frontend/src/components/ScenarioBuilder.vue
@@ -235,12 +235,14 @@ onBeforeUnmount(() => clearTimeout(lawYamlDebounce));
 // typed cells. Tolerates unparseable/text-only versions.
 function rebuildExternalFieldTypeMap() {
   const docs = [{ articles: props.articles || [] }];
-  for (const versions of Object.values(versionsCache)) {
+  for (const [lawId, versions] of Object.entries(versionsCache)) {
     for (const v of Array.isArray(versions) ? versions : []) {
       try {
         const doc = yaml.load(v);
         if (doc && typeof doc === 'object') docs.push(doc);
-      } catch { /* skip unparseable version */ }
+      } catch (e) {
+        console.warn(`Skipped an unparseable cached version of '${lawId}' while building the type map:`, e);
+      }
     }
   }
   externalFieldTypeMap.value = buildExternalFieldTypeMap(docs);

--- a/frontend/src/components/ScenarioBuilder.vue
+++ b/frontend/src/components/ScenarioBuilder.vue
@@ -7,7 +7,9 @@
 // itself a shared singleton that stays warm across mounts. A per-instance cache
 // would therefore be empty on every remount once the engine is warm, forcing a
 // full dependency re-fetch each time. Invalidated per-traject in
-// `fetchLawVersions`.
+// `fetchLawVersions`. Assumes at most one ScenarioBuilder is mounted at a time
+// (the scenario panel): `versionsCacheTrajectRef` is shared, so two concurrent
+// instances with different trajectRefs would invalidate each other's cache.
 const versionsCache = {};
 let versionsCacheTrajectRef = null;
 </script>
@@ -300,7 +302,7 @@ async function runDependencyLoad() {
         loadImplementors(mainLawId, props.engine, fetchLawVersions, props.trajectRef),
       )
         .then(() => { if (isCurrent()) rebuildExternalFieldTypeMap(); })
-        .catch(() => {});
+        .catch((e) => console.warn('Implementor load / re-type failed (non-fatal):', e));
     }
   }
 }

--- a/frontend/src/components/ScenarioBuilder.vue
+++ b/frontend/src/components/ScenarioBuilder.vue
@@ -1,3 +1,17 @@
+<script>
+// Parsed-version cache, MODULE-scoped (shared across all ScenarioBuilder
+// instances) so it survives remounts — switching the panel view away and back,
+// or opening another article, remounts this component. The data-source column
+// type map (`rebuildExternalFieldTypeMap`) is derived from these YAMLs, while
+// the WASM engine that gates whether `loadAllDependencies` re-fetches a dep is
+// itself a shared singleton that stays warm across mounts. A per-instance cache
+// would therefore be empty on every remount once the engine is warm, forcing a
+// full dependency re-fetch each time. Invalidated per-traject in
+// `fetchLawVersions`.
+const versionsCache = {};
+let versionsCacheTrajectRef = null;
+</script>
+
 <script setup>
 import { ref, computed, watch, nextTick, onBeforeUnmount } from 'vue';
 import { useDependencies } from '../composables/useDependencies.js';
@@ -163,9 +177,6 @@ watch(featureText, (text) => {
 // traject switch doesn't return the previous traject's bodies. The dependency
 // loader needs *every* version of a law (not just today's-best) so the engine
 // can pick the one in force on the scenario's calculation date.
-const versionsCache = {};
-let versionsCacheTrajectRef = null;
-
 async function fetchLawVersions(lawId) {
   if (versionsCacheTrajectRef !== props.trajectRef) {
     Object.keys(versionsCache).forEach((k) => delete versionsCache[k]);

--- a/frontend/src/components/ScenarioBuilder.vue
+++ b/frontend/src/components/ScenarioBuilder.vue
@@ -265,8 +265,12 @@ async function runDependencyLoad() {
     }
     for (const depId of allDeps) {
       try {
+        // Fetch versions unconditionally to populate versionsCache for the
+        // data-source type map (same rationale as loadAllDependencies — the
+        // map is built from cached YAMLs, independent of engine state); load
+        // into the shared engine only if it isn't already present.
+        const yamls = await fetchLawVersions(depId);
         if (!props.engine.hasLaw(depId)) {
-          const yamls = await fetchLawVersions(depId);
           loadLawVersions(props.engine, yamls, depId);
         }
       } catch (e) {

--- a/frontend/src/components/ScenarioBuilder.vue
+++ b/frontend/src/components/ScenarioBuilder.vue
@@ -39,6 +39,9 @@ const props = defineProps({
   /** Active traject ref. Required for scenario writes; reads route
    *  through the matching traject's backend so a save is visible
    *  without a corpus reload. */
+  // Single-instance assumption: the module-scoped versionsCache keys on this
+  // trajectRef (see the <script> block at the top), so at most one
+  // ScenarioBuilder may be mounted at a time.
   trajectRef: { type: String, default: null },
 });
 

--- a/frontend/src/components/ScenarioBuilder.vue
+++ b/frontend/src/components/ScenarioBuilder.vue
@@ -9,7 +9,8 @@ import { useLatest } from '../lib/useLatest.js';
 import { parseFeature } from '../gherkin/parser.js';
 import { mapFeatureToForm, getEffectiveSetup, formStateToGherkin, syncEditedValues } from '../gherkin/formMapper.js';
 import { matchStatus, humanize } from '../utils/outputFormat.js';
-import { buildArticleMap, buildTypeMap } from '../utils/articleMapping.js';
+import yaml from 'js-yaml';
+import { buildArticleMap, buildTypeMap, buildExternalFieldTypeMap } from '../utils/articleMapping.js';
 import ScenarioForm from './ScenarioForm.vue';
 
 const props = defineProps({
@@ -32,6 +33,9 @@ const articleMap = computed(() => buildArticleMap(props.articles));
 // Datatype mapping: drives the per-type scenario input controls (boolean ->
 // switch, amount -> currency field, etc.) in ScenarioForm.
 const typeMap = computed(() => buildTypeMap(props.articles));
+// External data-source column types, collected from the current law + the
+// already-fetched dependency YAMLs. Rebuilt when the dependency load settles.
+const externalFieldTypeMap = ref(new Map());
 
 // --- Dependencies ---
 const {
@@ -212,6 +216,23 @@ watch(() => props.lawYaml, (val, prev) => {
 
 onBeforeUnmount(() => clearTimeout(lawYamlDebounce));
 
+// Collect external data-source column types from the current law plus the
+// dependency YAMLs already fetched into versionsCache (parsed with js-yaml).
+// Called once the dependency load settles so the data-source tables can render
+// typed cells. Tolerates unparseable/text-only versions.
+function rebuildExternalFieldTypeMap() {
+  const docs = [{ articles: props.articles || [] }];
+  for (const versions of Object.values(versionsCache)) {
+    for (const v of Array.isArray(versions) ? versions : []) {
+      try {
+        const doc = yaml.load(v);
+        if (doc && typeof doc === 'object') docs.push(doc);
+      } catch { /* skip unparseable version */ }
+    }
+  }
+  externalFieldTypeMap.value = buildExternalFieldTypeMap(docs);
+}
+
 // Run the dependency cascade for the current law + scenarios. Reads the
 // latest prop/state values at call time (not captured watch args) so a
 // debounced run always uses the freshest inputs.
@@ -255,8 +276,16 @@ async function runDependencyLoad() {
     // Vue ignores ref writes after unmount, the shared WASM engine outlives
     // the component, and the guard resets on error so a fresh mount retries.
     depsReady.value = true;
+    rebuildExternalFieldTypeMap();
     if (mainLawId) {
-      loadImplementors(mainLawId, props.engine, fetchLawVersions, props.trajectRef);
+      // Implementor regulations load in the background, populating versionsCache
+      // after the rebuild above. Re-type once they settle so any source:{}
+      // fields they declare get picked up (idempotent; skipped if superseded).
+      Promise.resolve(
+        loadImplementors(mainLawId, props.engine, fetchLawVersions, props.trajectRef),
+      )
+        .then(() => { if (isCurrent()) rebuildExternalFieldTypeMap(); })
+        .catch(() => {});
     }
   }
 }
@@ -634,6 +663,7 @@ defineExpose({ save: onSave });
             :law-id="lawId"
             :article-map="articleMap"
             :type-map="typeMap"
+            :external-field-type-map="externalFieldTypeMap"
             @show-details="() => onShowDetails(i)"
             @executed="(data) => onScenarioResult(i, data)"
             @change="markDirty"

--- a/frontend/src/components/ScenarioForm.datasources.test.js
+++ b/frontend/src/components/ScenarioForm.datasources.test.js
@@ -1,0 +1,40 @@
+import { mount } from '@vue/test-utils';
+import { describe, it, expect } from 'vitest';
+import ScenarioForm from './ScenarioForm.vue';
+import DataSourceTable from './DataSourceTable.vue';
+
+const baseSetup = () => ({
+  calculationDate: '2025-01-01',
+  parameters: [],
+  dataSources: [
+    { sourceName: 'insurance', keyField: 'bsn', headers: ['bsn', 'verdragsinschrijving', 'onbekend'], rows: [['1', 'false', 'x']] },
+  ],
+});
+
+const mountForm = (externalFieldTypeMap) =>
+  mount(ScenarioForm, {
+    props: { scenario: { assertions: [] }, setup: baseSetup(), lawId: 'l', externalFieldTypeMap },
+  });
+
+// The editable DataSourceTable only renders once a source is drilled into.
+const drillIn = (w) => w.find('[data-testid="ds-row-0"]').trigger('click');
+const fieldsOf = (w) => w.findComponent(DataSourceTable).props('fields');
+
+describe('ScenarioForm data-source column typing', () => {
+  it('types data-source columns from the map (fallback string, key excluded)', async () => {
+    const w = mountForm(new Map([['verdragsinschrijving', { type: 'boolean', unit: null }]]));
+    await drillIn(w);
+    const f = fieldsOf(w);
+    expect(f.find((c) => c.name === 'verdragsinschrijving').type).toBe('boolean');
+    expect(f.find((c) => c.name === 'onbekend').type).toBe('string'); // not in map -> fallback
+    expect(f.some((c) => c.name === 'bsn')).toBe(false); // key field excluded
+  });
+
+  it('re-types columns in place when the map arrives asynchronously', async () => {
+    const w = mountForm(new Map()); // empty at mount -> all string
+    await drillIn(w);
+    expect(fieldsOf(w).find((c) => c.name === 'verdragsinschrijving').type).toBe('string');
+    await w.setProps({ externalFieldTypeMap: new Map([['verdragsinschrijving', { type: 'boolean', unit: null }]]) });
+    expect(fieldsOf(w).find((c) => c.name === 'verdragsinschrijving').type).toBe('boolean');
+  });
+});

--- a/frontend/src/components/ScenarioForm.vue
+++ b/frontend/src/components/ScenarioForm.vue
@@ -20,6 +20,8 @@ const props = defineProps({
   articleMap: { type: Object, default: null },
   /** Datatype mapping from buildTypeMap(): name -> { type, unit } */
   typeMap: { type: Object, default: null },
+  /** External data-source field types from buildExternalFieldTypeMap(): name -> { type, unit } */
+  externalFieldTypeMap: { type: Object, default: null },
 });
 
 // Resolve a parameter's declared datatype/unit; default to a plain text field
@@ -27,6 +29,13 @@ const props = defineProps({
 // machine_readable).
 function paramMeta(name) {
   return props.typeMap?.get(name) ?? { type: 'string', unit: null };
+}
+
+// Resolve an external data-source column's datatype/unit from the dependency
+// graph; default to a plain text field for columns not found in the map.
+function typeField(name) {
+  const meta = props.externalFieldTypeMap?.get(name);
+  return { name, type: meta?.type ?? 'string', unit: meta?.unit ?? null };
 }
 
 const emit = defineEmits(['show-details', 'executed', 'change', 'drill-change']);
@@ -43,7 +52,7 @@ function initDataSources() {
   return (props.setup.dataSources || []).map((ds) => ({
     sourceName: ds.sourceName,
     keyField: ds.keyField,
-    fields: ds.headers.filter((h) => h !== ds.keyField).map((h) => ({ name: h, type: 'string' })),
+    fields: ds.headers.filter((h) => h !== ds.keyField).map((h) => typeField(h)),
     rows: ds.rows.map((row, i) => {
       const obj = { _id: i };
       ds.headers.forEach((h, j) => { obj[h] = row[j] ?? ''; });
@@ -132,6 +141,15 @@ function discardEdits() {
 
 // Re-init when scenario/setup changes
 watch([() => props.setup, () => props.scenario], discardEdits, { deep: true });
+
+// Column types come from the dependency graph, which loads asynchronously after
+// the panel mounts. Re-type the data-source columns in place when the map
+// arrives — without rebuilding rows, so unsaved cell edits survive.
+watch(() => props.externalFieldTypeMap, () => {
+  for (const ds of dataSources.value) {
+    ds.fields = ds.fields.map((f) => typeField(f.name));
+  }
+});
 
 // CONTRACT: execute() must stay fully synchronous. The WASM engine runs
 // in-process with no I/O, so `result`/`error`/`running` are all settled

--- a/frontend/src/composables/useDependencies.js
+++ b/frontend/src/composables/useDependencies.js
@@ -93,54 +93,67 @@ export function useDependencies() {
       const missingDeps = [];
 
       for (const lawId of toLoad) {
-        if (engine.hasLaw(lawId)) {
-          loaded++;
-          loadedDeps.value = [...loadedDeps.value, lawId];
-          progress.value = `${loaded}/${total} wetten geladen`;
-          continue;
-        }
-
+        // Fetch the version YAMLs unconditionally — even for a law already in
+        // the engine. They feed two consumers that are independent of engine
+        // state: the transitive-ref scan below, and (via `versionsCache` in
+        // ScenarioBuilder) the data-source column type map. The WASM engine is
+        // a shared singleton that persists across scenario-panel mounts and is
+        // pre-warmed by the machine view, so gating this fetch on
+        // `engine.hasLaw` left `versionsCache` empty on a warm engine and
+        // collapsed every typed data-source cell back to a plain string field.
+        const alreadyLoaded = engine.hasLaw(lawId);
+        let yamls = [];
         try {
-          const yamls = await fetchLawVersions(lawId);
+          yamls = await fetchLawVersions(lawId);
           // Load every version (isolating each) so the engine's date-aware
           // selection can pick the one in force on the scenario's calculation
-          // date. No version loading — empty list or every version unloadable —
-          // is treated as a missing dependency (harvest requested below).
-          if (!loadLawVersions(engine, yamls, lawId)) {
+          // date. Skip the engine load when the law is already present — only
+          // its YAML (cached above) is still needed. For a not-yet-loaded law,
+          // no loadable version — empty list or every version unloadable — is a
+          // missing dependency (harvest requested below).
+          if (!alreadyLoaded && !loadLawVersions(engine, yamls, lawId)) {
             throw new Error(`no loadable version for '${lawId}'`);
           }
           loaded++;
           loadedDeps.value = [...loadedDeps.value, lawId];
           progress.value = `${loaded}/${total} wetten geladen`;
-
-          // Recurse for transitive deps. Collect from every version — a
-          // `source.regulation` reference can appear in one version and not
-          // another, and a scenario may be evaluated at any calculation date
-          // (including a future one), so a reference introduced only by a
-          // future version must still be loadable. This can over-fetch a
-          // transitive law that no in-force version needs; that's an accepted,
-          // bounded cost — the engine's `select_in` simply never selects a
-          // not-yet-in-force version.
-          const newDeps = [];
-          for (const versionYaml of yamls) {
-            // Isolate the ref scan per version too: a version that loaded into
-            // the engine but is malformed for `js-yaml` must not throw here and
-            // get the (already-loaded) law spuriously marked missing + harvested.
-            try {
-              collectDeps(yaml.load(versionYaml), visited, newDeps);
-            } catch (e) {
-              console.warn(`Skipped transitive-ref scan of an unparseable version of '${lawId}':`, e);
-            }
-          }
-          if (newDeps.length > 0) {
-            toLoad.push(...newDeps);
-            total = toLoad.length;
-          }
         } catch (e) {
-          console.warn(`Failed to load dependency '${lawId}':`, e);
-          missingDeps.push(lawId);
           loaded++;
-          progress.value = `${loaded}/${total} wetten geladen (${lawId} mislukt)`;
+          if (alreadyLoaded) {
+            // Already executable in the engine; only the type-map YAML couldn't
+            // be (re)fetched. Don't route it to harvest as if it were missing.
+            console.warn(`Could not refetch versions of already-loaded '${lawId}'; type map may be incomplete:`, e);
+            loadedDeps.value = [...loadedDeps.value, lawId];
+            progress.value = `${loaded}/${total} wetten geladen`;
+          } else {
+            console.warn(`Failed to load dependency '${lawId}':`, e);
+            missingDeps.push(lawId);
+            progress.value = `${loaded}/${total} wetten geladen (${lawId} mislukt)`;
+          }
+        }
+
+        // Recurse for transitive deps. Collect from every version — a
+        // `source.regulation` reference can appear in one version and not
+        // another, and a scenario may be evaluated at any calculation date
+        // (including a future one), so a reference introduced only by a future
+        // version must still be loadable. Runs for already-loaded laws too, so
+        // a dep reachable only through one is still discovered and cached. This
+        // can over-fetch a transitive law that no in-force version needs;
+        // that's an accepted, bounded cost — `select_in` never selects a
+        // not-yet-in-force version.
+        const newDeps = [];
+        for (const versionYaml of yamls) {
+          // Isolate the ref scan per version: a version that loaded into the
+          // engine but is malformed for `js-yaml` must not throw here.
+          try {
+            collectDeps(yaml.load(versionYaml), visited, newDeps);
+          } catch (e) {
+            console.warn(`Skipped transitive-ref scan of an unparseable version of '${lawId}':`, e);
+          }
+        }
+        if (newDeps.length > 0) {
+          toLoad.push(...newDeps);
+          total = toLoad.length;
         }
       }
 

--- a/frontend/src/composables/useDependencies.js
+++ b/frontend/src/composables/useDependencies.js
@@ -103,6 +103,11 @@ export function useDependencies() {
         // collapsed every typed data-source cell back to a plain string field.
         const alreadyLoaded = engine.hasLaw(lawId);
         let yamls = [];
+        // Whether this law is sound enough to scan for transitive deps: already
+        // in the engine, or newly loaded without error. A law that was fetched
+        // but failed to load into the engine is broken/missing — we must NOT
+        // chase its transitive refs (would queue deps of a law that can't run).
+        let usable = alreadyLoaded;
         try {
           yamls = await fetchLawVersions(lawId);
           // Load every version (isolating each) so the engine's date-aware
@@ -114,6 +119,7 @@ export function useDependencies() {
           if (!alreadyLoaded && !loadLawVersions(engine, yamls, lawId)) {
             throw new Error(`no loadable version for '${lawId}'`);
           }
+          usable = true;
           loaded++;
           loadedDeps.value = [...loadedDeps.value, lawId];
           progress.value = `${loaded}/${total} wetten geladen`;
@@ -132,28 +138,30 @@ export function useDependencies() {
           }
         }
 
-        // Recurse for transitive deps. Collect from every version — a
-        // `source.regulation` reference can appear in one version and not
-        // another, and a scenario may be evaluated at any calculation date
-        // (including a future one), so a reference introduced only by a future
-        // version must still be loadable. Runs for already-loaded laws too, so
-        // a dep reachable only through one is still discovered and cached. This
-        // can over-fetch a transitive law that no in-force version needs;
-        // that's an accepted, bounded cost — `select_in` never selects a
+        // Recurse for transitive deps of a usable law only. Collect from every
+        // version — a `source.regulation` reference can appear in one version
+        // and not another, and a scenario may be evaluated at any calculation
+        // date (including a future one), so a reference introduced only by a
+        // future version must still be loadable. Runs for already-loaded laws
+        // too, so a dep reachable only through one is still discovered and
+        // cached. This can over-fetch a transitive law that no in-force version
+        // needs; that's an accepted, bounded cost — `select_in` never selects a
         // not-yet-in-force version.
-        const newDeps = [];
-        for (const versionYaml of yamls) {
-          // Isolate the ref scan per version: a version that loaded into the
-          // engine but is malformed for `js-yaml` must not throw here.
-          try {
-            collectDeps(yaml.load(versionYaml), visited, newDeps);
-          } catch (e) {
-            console.warn(`Skipped transitive-ref scan of an unparseable version of '${lawId}':`, e);
+        if (usable) {
+          const newDeps = [];
+          for (const versionYaml of yamls) {
+            // Isolate the ref scan per version: a version that loaded into the
+            // engine but is malformed for `js-yaml` must not throw here.
+            try {
+              collectDeps(yaml.load(versionYaml), visited, newDeps);
+            } catch (e) {
+              console.warn(`Skipped transitive-ref scan of an unparseable version of '${lawId}':`, e);
+            }
           }
-        }
-        if (newDeps.length > 0) {
-          toLoad.push(...newDeps);
-          total = toLoad.length;
+          if (newDeps.length > 0) {
+            toLoad.push(...newDeps);
+            total = toLoad.length;
+          }
         }
       }
 

--- a/frontend/src/composables/useDependencies.test.js
+++ b/frontend/src/composables/useDependencies.test.js
@@ -140,6 +140,28 @@ describe('useDependencies.loadAllDependencies', () => {
     const harvestCalls = fetchSpy.mock.calls.filter((c) => String(c[0]).includes('/harvest'));
     expect(harvestCalls.length).toBeGreaterThan(0);
   });
+
+  it('refetches versions for a dep already in the (warm) engine, without reloading it', async () => {
+    // Regression for the data-source typing bug: the shared WASM engine
+    // persists across scenario-panel mounts (and is pre-warmed by the machine
+    // view), so a dependency is often already loaded by the time the panel
+    // resolves its graph. The data-source column type map is built from the
+    // fetched version YAMLs (versionsCache), NOT from the engine — so an
+    // already-loaded dep must STILL have its versions fetched. Gating the fetch
+    // on `engine.hasLaw` left the cache empty on a warm engine and collapsed
+    // every typed cell (boolean dropdown, euro field, date picker) to a plain
+    // string field. The engine load itself is correctly skipped (already there).
+    const engine = fakeEngine();
+    engine.loaded.add('zorgverzekeringswet'); // pre-warm: dep already loaded
+    const fetchLawVersions = vi.fn(async (id) => DEP_VERSIONS[id]);
+
+    const { loadAllDependencies } = useDependencies();
+    await loadAllDependencies(MAIN_LAW, engine, fetchLawVersions);
+
+    expect(fetchLawVersions).toHaveBeenCalledWith('zorgverzekeringswet');
+    // Not re-loaded into the engine: no body was handed to loadLaw for it.
+    expect(engine.bodies.some((b) => b.includes('$id: zorgverzekeringswet'))).toBe(false);
+  });
 });
 
 describe('useDependencies.loadImplementors', () => {

--- a/frontend/src/composables/useDependencies.test.js
+++ b/frontend/src/composables/useDependencies.test.js
@@ -162,6 +162,44 @@ describe('useDependencies.loadAllDependencies', () => {
     // Not re-loaded into the engine: no body was handed to loadLaw for it.
     expect(engine.bodies.some((b) => b.includes('$id: zorgverzekeringswet'))).toBe(false);
   });
+
+  it('does not chase transitive deps of a fetched-but-unloadable (missing) law', async () => {
+    // The transitive-ref scan must run only for a "usable" law (already loaded,
+    // or newly loaded). A law whose versions are all fetched but unloadable is
+    // missing/broken — chasing its refs would queue deps of a law that can't
+    // run. (Regression for moving the scan out of the try/catch.)
+    const unloadableZvw = [
+      '$id: zorgverzekeringswet',
+      'UNLOADABLE: true',
+      'articles:',
+      "  - number: '1'",
+      '    machine_readable:',
+      '      execution:',
+      '        input:',
+      '          - name: x',
+      '            source:',
+      '              regulation: regeling_standaardpremie',
+      '              output: y',
+    ].join('\n') + '\n';
+    const fetchSpy = vi.fn(async (url) => {
+      if (String(url).includes('/harvest')) return res({ results: [] });
+      return res([], false, 404);
+    });
+    globalThis.fetch = fetchSpy;
+    const engine = fakeEngine();
+    const fetchLawVersions = vi.fn(async (id) =>
+      id === 'zorgverzekeringswet' ? [unloadableZvw] : DEP_VERSIONS[id],
+    );
+
+    const { loadAllDependencies } = useDependencies();
+    await loadAllDependencies(MAIN_LAW, engine, fetchLawVersions);
+
+    // The unloadable law is missing (never registered in the engine)...
+    expect(engine.loaded.has('zorgverzekeringswet')).toBe(false);
+    expect(fetchLawVersions).toHaveBeenCalledWith('zorgverzekeringswet');
+    // ...and its transitive ref was NOT chased.
+    expect(fetchLawVersions).not.toHaveBeenCalledWith('regeling_standaardpremie');
+  });
 });
 
 describe('useDependencies.loadImplementors', () => {

--- a/frontend/src/utils/articleMapping.js
+++ b/frontend/src/utils/articleMapping.js
@@ -77,7 +77,12 @@ export function buildExternalFieldTypeMap(lawDocs) {
     for (const article of doc?.articles || []) {
       for (const f of article.machine_readable?.execution?.input || []) {
         const src = f.source;
-        const isExternal = src && !src.regulation && !src.output;
+        // External data-source fields are declared with an empty `source: {}`
+        // (a `regulation` means cross-law, an `output` means internal). Match
+        // exactly that — an empty object — rather than merely "no regulation and
+        // no output", so a malformed source carrying other keys isn't
+        // misclassified as external. (versionsCache YAML is not schema-checked.)
+        const isExternal = src && typeof src === 'object' && Object.keys(src).length === 0;
         if (isExternal && f.name && f.type) {
           map.set(f.name, { type: f.type, unit: f.type_spec?.unit ?? null });
         }

--- a/frontend/src/utils/articleMapping.js
+++ b/frontend/src/utils/articleMapping.js
@@ -59,3 +59,30 @@ export function buildTypeMap(articles) {
 
   return typeMap;
 }
+
+/**
+ * Builds a fieldName -> { type, unit } map for EXTERNAL data-source fields —
+ * inputs whose `source` is empty (no `regulation` and no `output`), i.e. raw
+ * data the engine resolves by field name (e.g. insurance.verdragsinschrijving).
+ * Spans a set of law docs (the current law + its loaded dependencies), because
+ * data-source fields are declared by the leaf laws, not the law under test.
+ * Last doc wins on a name collision. Drives typed cells in DataSourceTable.
+ *
+ * @param {Array<{articles?: Array}>} lawDocs - parsed law documents
+ * @returns {Map<string, { type: string, unit: (string|null) }>}
+ */
+export function buildExternalFieldTypeMap(lawDocs) {
+  const map = new Map();
+  for (const doc of lawDocs || []) {
+    for (const article of doc?.articles || []) {
+      for (const f of article.machine_readable?.execution?.input || []) {
+        const src = f.source;
+        const isExternal = src && !src.regulation && !src.output;
+        if (isExternal && f.name && f.type) {
+          map.set(f.name, { type: f.type, unit: f.type_spec?.unit ?? null });
+        }
+      }
+    }
+  }
+  return map;
+}

--- a/frontend/src/utils/articleMapping.test.js
+++ b/frontend/src/utils/articleMapping.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildTypeMap } from './articleMapping.js';
+import { buildTypeMap, buildExternalFieldTypeMap } from './articleMapping.js';
 
 describe('buildTypeMap', () => {
   it('maps parameter and input names to their declared type', () => {
@@ -57,5 +57,40 @@ describe('buildTypeMap', () => {
   it('handles empty / nullish input', () => {
     expect(buildTypeMap(undefined).size).toBe(0);
     expect(buildTypeMap([]).size).toBe(0);
+  });
+});
+
+describe('buildExternalFieldTypeMap', () => {
+  const law = (inputs) => ({ articles: [{ machine_readable: { execution: { input: inputs } } }] });
+
+  it('collects external (source:{}) inputs as name -> {type, unit}', () => {
+    const m = buildExternalFieldTypeMap([law([
+      { name: 'verdragsinschrijving', type: 'boolean', source: {} },
+      { name: 'spaargeld', type: 'amount', type_spec: { unit: 'eurocent' }, source: {} },
+    ])]);
+    expect(m.get('verdragsinschrijving')).toEqual({ type: 'boolean', unit: null });
+    expect(m.get('spaargeld')).toEqual({ type: 'amount', unit: 'eurocent' });
+  });
+
+  it('excludes cross-law (source.regulation) and internal (source.output) inputs', () => {
+    const m = buildExternalFieldTypeMap([law([
+      { name: 'toetsingsinkomen', type: 'amount', source: { regulation: 'awir', output: 'x' } },
+      { name: 'internal', type: 'number', source: { output: 'y' } },
+    ])]);
+    expect(m.has('toetsingsinkomen')).toBe(false);
+    expect(m.has('internal')).toBe(false);
+  });
+
+  it('merges across multiple law docs; last doc wins on name collision', () => {
+    const m = buildExternalFieldTypeMap([
+      law([{ name: 'x', type: 'string', source: {} }]),
+      law([{ name: 'x', type: 'boolean', source: {} }]),
+    ]);
+    expect(m.get('x')).toEqual({ type: 'boolean', unit: null });
+  });
+
+  it('tolerates empty / missing docs and articles without machine_readable', () => {
+    expect(buildExternalFieldTypeMap(undefined).size).toBe(0);
+    expect(buildExternalFieldTypeMap([null, { articles: [{}] }]).size).toBe(0);
   });
 });


### PR DESCRIPTION
## Wat

Maakt de cellen in de scenario-**bronnentabellen** (de "Bronnen": `personal_data`, `insurance`, `box1/2/3`, `detenties`, …) datatype-gestuurd — net zoals #748 dat voor de scenario-parameters deed. Per kolom rendert nu het juiste control:

- `boolean` → de bestaande **tri-state dropdown** (`true/false/null`), bewust behouden: bronfeiten kunnen echt afwezig zijn (`null`), en een binaire switch kan dat niet uitdrukken.
- `amount` → euro-bewust nummerveld (eurocent ⇄ euro), `number` → nummerveld, `date` → datumkiezer, `string` → tekstveld — via hergebruik van `ScenarioParameterInput` uit #748 (geen duplicatie, geen extra CSS).

## Hoe

De kolomtypes stonden nergens in het scenario (de gherkin-headers waren allemaal `string`). Ze leven in de **leaf-wetten** die de externe data lezen: een input met leeg `source: {}` draagt `name` + `type` (+ `type_spec`). De engine matcht bronkolommen op **veldnaam**.

- Nieuw `buildExternalFieldTypeMap()` verzamelt die types over de **al-geladen wetgraaf** (huidige wet + de dependency-YAMLs die al in `versionsCache` staan, geparsed met `js-yaml`). Geen backend-wijziging, geen extra fetches.
- `ScenarioBuilder` bouwt de map zodra de dependency-load settelt (en opnieuw nadat implementatie-regelingen async binnenkomen) en geeft 'm door aan `ScenarioForm`.
- `ScenarioForm.initDataSources()` typeert de kolommen (fallback `string`, key-veld uitgesloten) en hertypeert in-place bij async binnenkomst van de map — zonder rij-edits te verliezen.

## Null-contract

`null` / `undefined` / de gherkin-string `'null'` → leeg weergegeven; een leeggemaakte cel → `null` (sluit aan op `steps.js` `'null' → null` en `formMapper` `null/'' → 'null'`). Booleans houden hun null-optie via de dropdown.

## Tests

- `buildExternalFieldTypeMap`: externe-veld-verzameling, cross-law/internal-uitsluiting, collision (last-wins), lege/onparseerbare docs.
- `DataSourceTable`: control-per-datatype, null round-trip, euro-amount.
- `ScenarioForm`: kolom-typering uit de map (fallback + key-exclusie) + async hertypering.
- Volledige frontend-suite groen (372 tests).

Bouwt voort op #748. Geen backend- of schema-wijziging.
