### PR TITLE
feat(lawmaking): migrate UI to the NLDD design system

### DIFF
--- a/frontend-lawmaking/package-lock.json
+++ b/frontend-lawmaking/package-lock.json
@@ -8,7 +8,7 @@
       "name": "regelrecht-frontend-lawmaking",
       "version": "1.0.0",
       "dependencies": {
-        "@nldd/design-system": "^0.8.62",
+        "@nldd/design-system": "^0.8.63",
         "vue": "^3.5.38"
       },
       "devDependencies": {
@@ -171,9 +171,9 @@
       }
     },
     "node_modules/@nldd/design-system": {
-      "version": "0.8.62",
-      "resolved": "https://registry.npmjs.org/@nldd/design-system/-/design-system-0.8.62.tgz",
-      "integrity": "sha512-1roLjgSWvz6+lJg8ILYMXEysXVk/VrJAeHr0Oor6bbM4PTGcU4Ape8nhqXZIOw23dlqH2hWxjX4pfIRD8inkZQ==",
+      "version": "0.8.63",
+      "resolved": "https://registry.npmjs.org/@nldd/design-system/-/design-system-0.8.63.tgz",
+      "integrity": "sha512-iTqZZtfcDt42vVP2dkNbrUi/U+vuGRkLL7LGgnJULm4Hl9XxIHEOR1CpvW3DnOE+nLRyally/mEhhQopfglubg==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@floating-ui/dom": "^1.7.6",

--- a/frontend-lawmaking/package.json
+++ b/frontend-lawmaking/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@nldd/design-system": "^0.8.62",
+    "@nldd/design-system": "^0.8.63",
     "vue": "^3.5.38"
   },
   "devDependencies": {

--- a/frontend-lawmaking/src/App.vue
+++ b/frontend-lawmaking/src/App.vue
@@ -1,82 +1,125 @@
 <template>
-  <rr-page>
-    <div class="app">
-      <!-- Sticky Header -->
-      <header class="app__header">
-        <div class="app__header-content">
-          <img
-            src="/assets/rijkswapen.svg"
-            alt="Rijkswapen"
-            class="app__logo"
+  <nldd-app-view>
+    <nldd-page sticky-header>
+      <!-- Sticky header: branding + playback/zoom/view controls -->
+      <nldd-container slot="header" padding="8">
+        <nldd-toolbar size="md">
+          <nldd-toolbar-item slot="start">
+            <img
+              src="/assets/rijkswapen.svg"
+              alt="Rijkswapen"
+              class="app-logo"
+            />
+          </nldd-toolbar-item>
+          <nldd-toolbar-title
+            slot="start"
+            text="Wetgevingsproces"
+            supporting-text="Van wetsvoorstel tot geldend recht — het wetgevingsproces als GitFlow"
+          ></nldd-toolbar-title>
+
+          <!-- Playback: step navigation -->
+          <nldd-toolbar-item slot="end">
+            <nldd-icon-button
+              icon="chevron-double-left"
+              text="Naar begin"
+              :disabled="activeStep <= 0 || undefined"
+              @click="resetSteps"
+            ></nldd-icon-button>
+          </nldd-toolbar-item>
+          <nldd-toolbar-item slot="end">
+            <nldd-icon-button
+              icon="chevron-left"
+              text="Stap terug"
+              :disabled="activeStep <= 0 || undefined"
+              @click="stepBack"
+            ></nldd-icon-button>
+          </nldd-toolbar-item>
+          <nldd-toolbar-item slot="end">
+            <nldd-icon-button
+              icon="chevron-right"
+              text="Stap vooruit"
+              :disabled="activeStep >= maxStep || undefined"
+              @click="stepForward"
+            ></nldd-icon-button>
+          </nldd-toolbar-item>
+          <nldd-toolbar-item slot="end">
+            <nldd-icon-button
+              icon="chevron-double-right"
+              text="Naar einde"
+              :disabled="activeStep >= maxStep || undefined"
+              @click="goToEnd"
+            ></nldd-icon-button>
+          </nldd-toolbar-item>
+
+          <!-- Playback: play/pause. The design system has no media-transport
+               glyph, so this is a labelled button; `isPlaying` is the single
+               source of truth (a plain button keeps no internal toggle state),
+               and the filled `primary` variant signals the playing state. -->
+          <nldd-toolbar-item slot="end">
+            <nldd-button
+              :text="isPlaying ? 'Pauzeren' : 'Afspelen'"
+              :variant="isPlaying ? 'primary' : 'secondary'"
+              @click="togglePlay"
+            ></nldd-button>
+          </nldd-toolbar-item>
+
+          <nldd-toolbar-item slot="end">
+            <nldd-tag :text="`${activeStep + 1} / ${maxStep + 1}`"></nldd-tag>
+          </nldd-toolbar-item>
+
+          <!-- Zoom -->
+          <nldd-toolbar-item slot="end">
+            <nldd-icon-button icon="plus" text="Zoom in" @click="diagramRef?.zoomIn()"></nldd-icon-button>
+          </nldd-toolbar-item>
+          <nldd-toolbar-item slot="end">
+            <nldd-icon-button icon="minus" text="Zoom uit" @click="diagramRef?.zoomOut()"></nldd-icon-button>
+          </nldd-toolbar-item>
+          <nldd-toolbar-item slot="end">
+            <nldd-icon-button icon="arrow-2-counter-clockwise" text="Centreren" @click="diagramRef?.resetView()"></nldd-icon-button>
+          </nldd-toolbar-item>
+
+          <!-- View mode -->
+          <nldd-toolbar-item slot="end">
+            <nldd-segmented-control
+              size="md"
+              width="fit-content"
+              :value="viewMode"
+              @change="onViewModeChange"
+            >
+              <nldd-segmented-control-item value="simple" text="Eenvoudig"></nldd-segmented-control-item>
+              <nldd-segmented-control-item value="advanced" text="Uitgebreid"></nldd-segmented-control-item>
+              <nldd-segmented-control-item value="woo" text="Wet open overheid"></nldd-segmented-control-item>
+            </nldd-segmented-control>
+          </nldd-toolbar-item>
+        </nldd-toolbar>
+      </nldd-container>
+
+      <!-- Main content: the hand-rolled SVG GitFlow canvas (documented design-
+           system exception — no nldd equivalent for a graph canvas). -->
+      <nldd-full-bleed-section>
+        <div class="diagram-area" @click="selectedStageId = null">
+          <FlowDiagram
+            ref="diagramRef"
+            :stages="currentStages"
+            :branches="currentBranches"
+            :connections="currentConnections"
+            :phases="currentPhases"
+            :timeline="currentTimeline"
+            :active-step="activeStep"
+            :selected-id="selectedStageId"
+            @select-stage="onSelectStage"
           />
-          <div class="app__header-text">
-            <h1 class="app__title">Wetgevingsproces</h1>
-            <p class="app__subtitle">Van wetsvoorstel tot geldend recht — het wetgevingsproces als GitFlow</p>
-          </div>
-
-          <!-- Playback controls -->
-          <div class="header-controls">
-            <button class="header-btn" @click="resetSteps" :disabled="activeStep <= 0" title="Begin" aria-label="Terug naar begin">&#x23EE;</button>
-            <button class="header-btn" @click="stepBack" :disabled="activeStep <= 0" title="Vorige" aria-label="Stap terug">&#x258F;&#x25C0;</button>
-            <button class="header-btn" :class="{ 'header-btn--playing': isPlaying }" @click="togglePlay" :title="isPlaying ? 'Pauzeren' : 'Afspelen'" :aria-label="isPlaying ? 'Pauzeren' : 'Afspelen'">{{ isPlaying ? '⏸' : '▶' }}</button>
-            <button class="header-btn" @click="stepForward" :disabled="activeStep >= maxStep" title="Volgende" aria-label="Stap vooruit">&#x25B6;&#x258F;</button>
-            <button class="header-btn" @click="goToEnd" :disabled="activeStep >= maxStep" title="Einde" aria-label="Naar einde">&#x23ED;</button>
-            <span class="header-controls__step">{{ activeStep + 1 }}/{{ maxStep + 1 }}</span>
-          </div>
-
-          <!-- Zoom controls -->
-          <div class="header-controls">
-            <button class="header-btn" @click="diagramRef?.zoomIn()" title="Zoom in">+</button>
-            <button class="header-btn" @click="diagramRef?.zoomOut()" title="Zoom uit">&minus;</button>
-            <button class="header-btn" @click="diagramRef?.resetView()" title="Centreren">&#x27F2;</button>
-          </div>
-
-          <!-- View toggle -->
-          <div class="app__toggle">
-            <div class="toggle-bar">
-              <button
-                class="toggle-bar__item"
-                :class="{ 'toggle-bar__item--active': viewMode === 'simple' }"
-                @click="setViewMode('simple')"
-              >Eenvoudig</button>
-              <button
-                class="toggle-bar__item"
-                :class="{ 'toggle-bar__item--active': viewMode === 'advanced' }"
-                @click="setViewMode('advanced')"
-              >Uitgebreid</button>
-              <button
-                class="toggle-bar__item"
-                :class="{ 'toggle-bar__item--active': viewMode === 'woo' }"
-                @click="setViewMode('woo')"
-              >Wet open overheid</button>
-            </div>
-          </div>
+          <FlowLegend />
         </div>
-      </header>
+      </nldd-full-bleed-section>
+    </nldd-page>
 
-      <!-- Main content area -->
-      <div class="app__content" @click="selectedStageId = null">
-        <FlowDiagram
-          ref="diagramRef"
-          :stages="currentStages"
-          :branches="currentBranches"
-          :connections="currentConnections"
-          :phases="currentPhases"
-          :timeline="currentTimeline"
-          :active-step="activeStep"
-          :selected-id="selectedStageId"
-          @select-stage="onSelectStage"
-        />
-        <FlowLegend />
-      </div>
-
-      <!-- Detail panel -->
-      <StageDetail
-        :stage="selectedStage"
-        @close="selectedStageId = null"
-      />
-    </div>
-  </rr-page>
+    <!-- Detail panel as a design-system sheet -->
+    <StageDetail
+      :stage="selectedStage"
+      @close="selectedStageId = null"
+    />
+  </nldd-app-view>
 </template>
 
 <script setup>
@@ -130,6 +173,13 @@ function setViewMode(mode) {
   viewMode.value = mode;
   activeStep.value = 0;
   selectedStageId.value = null;
+}
+
+// nldd-segmented-control emits a `change` CustomEvent carrying the selected
+// item value in `detail.value`.
+function onViewModeChange(e) {
+  const mode = e.detail?.value;
+  if (mode && mode !== viewMode.value) setViewMode(mode);
 }
 
 const selectedStage = computed(() => {
@@ -204,142 +254,17 @@ onUnmounted(() => {
 </script>
 
 <style scoped>
-.app {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-  min-height: 100vh;
-}
-
-.app__header {
-  background: var(--color-primary);
-  color: white;
-  padding: var(--spacing-2) var(--spacing-6);
-  flex-shrink: 0;
-  position: sticky;
-  top: 0;
-  z-index: 20;
-}
-
-.app__header-content {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-4);
-  max-width: 1600px;
-  margin: 0 auto;
-}
-
-.app__logo {
-  height: 36px;
+/* Brand logo sizing inside the design-system toolbar (the design system has no
+   logo slot for this app-level mark). */
+.app-logo {
+  height: 32px;
   width: auto;
-  filter: brightness(0) invert(1);
+  display: block;
 }
 
-.app__header-text {
-  flex: 1;
-  min-width: 0;
-}
-
-.app__title {
-  font-size: var(--font-size-lg);
-  font-weight: 700;
-  margin: 0;
-  line-height: var(--line-height-tight);
-}
-
-.app__subtitle {
-  font-size: var(--font-size-xs);
-  margin: 1px 0 0;
-  opacity: 0.75;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-/* Header controls (playback + zoom) */
-.header-controls {
-  display: flex;
-  align-items: center;
-  gap: 2px;
-  flex-shrink: 0;
-}
-
-.header-btn {
-  width: 30px;
-  height: 30px;
-  border: none;
-  border-radius: var(--border-radius-sm);
-  background: transparent;
-  color: rgba(255, 255, 255, 0.8);
-  font-size: 14px;
-  line-height: 1;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: background var(--transition-fast);
-}
-
-.header-btn:hover:not(:disabled) {
-  background: rgba(255, 255, 255, 0.15);
-  color: white;
-}
-
-.header-btn:disabled {
-  opacity: 0.3;
-  cursor: default;
-}
-
-.header-btn--playing {
-  background: rgba(255, 255, 255, 0.2);
-  color: white;
-}
-
-.header-controls__step {
-  font-size: 11px;
-  color: rgba(255, 255, 255, 0.6);
-  min-width: 40px;
-  text-align: center;
-  font-variant-numeric: tabular-nums;
-}
-
-/* View toggle */
-.app__toggle {
-  flex-shrink: 0;
-}
-
-.toggle-bar {
-  display: flex;
-  border-radius: var(--border-radius-md);
-  overflow: hidden;
-  border: 1px solid rgba(255, 255, 255, 0.3);
-}
-
-.toggle-bar__item {
-  padding: 5px 14px;
-  font-size: var(--font-size-xs);
-  font-family: var(--font-family);
-  font-weight: 400;
-  border: none;
-  cursor: pointer;
-  color: rgba(255, 255, 255, 0.8);
-  background: transparent;
-  transition: background var(--transition-fast), color var(--transition-fast);
-}
-
-.toggle-bar__item:hover {
-  background: rgba(255, 255, 255, 0.1);
-}
-
-.toggle-bar__item--active {
-  background: rgba(255, 255, 255, 0.2);
-  color: white;
-  font-weight: 700;
-}
-
-.app__content {
-  flex: 1;
-  overflow: auto;
+/* Centre the SVG canvas (the documented design-system exception) inside the
+   full-bleed section. */
+.diagram-area {
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/frontend-lawmaking/src/components/StageDetail.vue
+++ b/frontend-lawmaking/src/components/StageDetail.vue
@@ -47,7 +47,7 @@
 </template>
 
 <script setup>
-import { ref, watch } from 'vue';
+import { ref, watch, nextTick } from 'vue';
 
 const props = defineProps({
   stage: { type: Object, default: null },
@@ -66,13 +66,18 @@ const shownStage = ref(null);
 // parent stays declarative (`:stage` / `@close`).
 watch(
   () => props.stage,
-  (stage) => {
-    if (stage) {
-      shownStage.value = stage;
-      sheetEl.value?.show();
-    } else {
+  async (stage) => {
+    if (!stage) {
       sheetEl.value?.hide();
+      return;
     }
+    shownStage.value = stage;
+    // Render the v-if="shownStage" content before opening so the sheet never
+    // animates in empty. `{ flush: 'post' }` wouldn't suffice here: this watcher
+    // itself sets `shownStage`, so the content render is still pending when the
+    // callback runs — awaiting nextTick flushes it first.
+    await nextTick();
+    sheetEl.value?.show();
   },
 );
 

--- a/frontend-lawmaking/src/components/StageDetail.vue
+++ b/frontend-lawmaking/src/components/StageDetail.vue
@@ -1,195 +1,98 @@
 <template>
-  <transition name="slide">
-    <div v-if="stage" class="stage-detail">
-      <div class="stage-detail__header">
-        <h2 class="stage-detail__title">{{ stage.lawLabel }}</h2>
-        <button
-          class="stage-detail__close"
-          @click="$emit('close')"
-          aria-label="Sluiten"
-        >&#x2715;</button>
-      </div>
+  <Teleport to="body">
+    <nldd-sheet
+      ref="sheetEl"
+      placement="right"
+      width="420px"
+      accessible-label="Toelichting fase"
+      @close="onClose"
+    >
+      <nldd-page sticky-header>
+        <nldd-top-title-bar
+          slot="header"
+          :text="shownStage?.lawLabel || ''"
+          dismiss-text="Sluit"
+          @dismiss="$emit('close')"
+        ></nldd-top-title-bar>
 
-      <div class="stage-detail__mapping">
-        <div class="stage-detail__mapping-row">
-          <span class="stage-detail__mapping-icon">&#x1F4BB;</span>
-          <div>
-            <div class="stage-detail__mapping-label">Git / CI/CD</div>
-            <div class="stage-detail__mapping-value stage-detail__mapping-value--git">{{ stage.gitLabel }}</div>
+        <nldd-simple-section v-if="shownStage">
+          <!-- Git ⇆ wetgeving mapping -->
+          <nldd-list variant="box">
+            <nldd-list-item size="md">
+              <nldd-text-cell text="Git / CI/CD" :supporting-text="shownStage.gitLabel"></nldd-text-cell>
+            </nldd-list-item>
+            <nldd-list-item size="md">
+              <nldd-text-cell text="Wetgeving" :supporting-text="shownStage.lawLabel"></nldd-text-cell>
+            </nldd-list-item>
+          </nldd-list>
+
+          <nldd-spacer size="16"></nldd-spacer>
+
+          <nldd-rich-text>
+            <p>{{ shownStage.description }}</p>
+          </nldd-rich-text>
+
+          <nldd-spacer size="16"></nldd-spacer>
+
+          <div class="stage-detail__meta">
+            <nldd-tag :text="shownStage.type"></nldd-tag>
+            <nldd-rich-text v-if="shownStage.subtitle">
+              <p class="stage-detail__subtitle">{{ shownStage.subtitle }}</p>
+            </nldd-rich-text>
           </div>
-        </div>
-        <div class="stage-detail__mapping-arrow">&#x21C6;</div>
-        <div class="stage-detail__mapping-row">
-          <span class="stage-detail__mapping-icon">&#x2696;</span>
-          <div>
-            <div class="stage-detail__mapping-label">Wetgeving</div>
-            <div class="stage-detail__mapping-value">{{ stage.lawLabel }}</div>
-          </div>
-        </div>
-      </div>
-
-      <p class="stage-detail__description">{{ stage.description }}</p>
-
-      <div class="stage-detail__meta">
-        <span class="stage-detail__badge" :style="{ background: badgeColor }">
-          {{ stage.type }}
-        </span>
-        <span v-if="stage.subtitle" class="stage-detail__subtitle">
-          {{ stage.subtitle }}
-        </span>
-      </div>
-    </div>
-  </transition>
+        </nldd-simple-section>
+      </nldd-page>
+    </nldd-sheet>
+  </Teleport>
 </template>
 
 <script setup>
-import { computed } from 'vue';
-import { branchColors, typeColors } from '../data/flowConstants.js';
+import { ref, watch } from 'vue';
 
 const props = defineProps({
   stage: { type: Object, default: null },
 });
 
-defineEmits(['close']);
+const emit = defineEmits(['close']);
 
-const badgeColor = computed(() => {
-  if (!props.stage) return '';
-  return branchColors[props.stage.branch]
-    || typeColors[props.stage.type]
-    || 'var(--color-branch-main)';
-});
+const sheetEl = ref(null);
+
+// `shownStage` keeps the last stage rendered while the sheet plays its close
+// animation, so the panel never flashes empty on dismiss. It is cleared only
+// once the sheet's `close` event confirms the animation finished.
+const shownStage = ref(null);
+
+// Drive the imperative nldd-sheet open/close from the `stage` prop so the
+// parent stays declarative (`:stage` / `@close`).
+watch(
+  () => props.stage,
+  (stage) => {
+    if (stage) {
+      shownStage.value = stage;
+      sheetEl.value?.show();
+    } else {
+      sheetEl.value?.hide();
+    }
+  },
+);
+
+// Fires once the sheet finishes closing — including dismissals the parent
+// didn't initiate (Escape / backdrop). Clear the rendered stage and notify the
+// parent so its `selectedStageId` stays in sync and the node can re-open later.
+function onClose() {
+  shownStage.value = null;
+  emit('close');
+}
 </script>
 
 <style scoped>
-.stage-detail {
-  position: fixed;
-  top: var(--nav-height);
-  right: 0;
-  bottom: 0;
-  width: 380px;
-  max-width: 100vw;
-  background: var(--color-surface);
-  border-left: 1px solid var(--color-border);
-  box-shadow: var(--shadow-md);
-  padding: var(--spacing-6);
-  overflow-y: auto;
-  z-index: 10;
-}
-
-.stage-detail__header {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  margin-bottom: var(--spacing-6);
-}
-
-.stage-detail__close {
-  background: none;
-  border: 1px solid var(--color-border);
-  border-radius: var(--border-radius-sm);
-  cursor: pointer;
-  font-size: 16px;
-  padding: 4px 8px;
-  color: var(--color-text-secondary);
-  line-height: 1;
-  flex-shrink: 0;
-}
-
-.stage-detail__close:hover {
-  background: var(--color-slate-100);
-  color: var(--color-text-primary);
-}
-
-.stage-detail__title {
-  font-size: var(--font-size-2xl);
-  font-weight: 700;
-  margin: 0;
-  line-height: var(--line-height-snug);
-}
-
-.stage-detail__mapping {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-3);
-  padding: var(--spacing-4);
-  background: var(--color-slate-50);
-  border-radius: var(--border-radius-lg);
-  margin-bottom: var(--spacing-6);
-}
-
-.stage-detail__mapping-row {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-2);
-  flex: 1;
-}
-
-.stage-detail__mapping-icon {
-  font-size: 24px;
-  line-height: 1;
-}
-
-.stage-detail__mapping-label {
-  font-size: var(--font-size-xs);
-  color: var(--color-text-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
-
-.stage-detail__mapping-value {
-  font-size: var(--font-size-sm);
-  font-weight: 700;
-}
-
-.stage-detail__mapping-value--git {
-  font-family: var(--font-family-mono);
-  font-weight: 400;
-}
-
-.stage-detail__mapping-arrow {
-  font-size: 20px;
-  color: var(--color-text-muted);
-  flex-shrink: 0;
-}
-
-.stage-detail__description {
-  font-size: var(--font-size-base);
-  line-height: var(--line-height-relaxed);
-  color: var(--color-text-primary);
-  margin: 0 0 var(--spacing-6);
-}
-
 .stage-detail__meta {
   display: flex;
   align-items: center;
   gap: var(--spacing-2);
 }
 
-.stage-detail__badge {
-  display: inline-block;
-  padding: 2px 10px;
-  border-radius: 12px;
-  font-size: var(--font-size-xs);
-  color: white;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-}
-
 .stage-detail__subtitle {
-  font-size: var(--font-size-sm);
-  color: var(--color-text-secondary);
-}
-
-/* Slide transition */
-.slide-enter-active,
-.slide-leave-active {
-  transition: transform 0.3s ease, opacity 0.3s ease;
-}
-
-.slide-enter-from,
-.slide-leave-to {
-  transform: translateX(100%);
-  opacity: 0;
+  margin: 0;
 }
 </style>

--- a/frontend-lawmaking/src/components/StageDetail.vue
+++ b/frontend-lawmaking/src/components/StageDetail.vue
@@ -12,7 +12,7 @@
           slot="header"
           :text="shownStage?.lawLabel || ''"
           dismiss-text="Sluit"
-          @dismiss="$emit('close')"
+          @dismiss="sheetEl?.hide()"
         ></nldd-top-title-bar>
 
         <nldd-simple-section v-if="shownStage">
@@ -76,9 +76,10 @@ watch(
   },
 );
 
-// Fires once the sheet finishes closing — including dismissals the parent
-// didn't initiate (Escape / backdrop). Clear the rendered stage and notify the
-// parent so its `selectedStageId` stays in sync and the node can re-open later.
+// The single close path: fires once the sheet finishes closing, whatever
+// triggered it (the Sluit button's hide(), Escape, backdrop, or the parent
+// nulling `stage`). Clear the rendered stage and notify the parent so its
+// `selectedStageId` stays in sync and the node can re-open later.
 function onClose() {
   shownStage.value = null;
   emit('close');

--- a/frontend-lawmaking/vite.config.js
+++ b/frontend-lawmaking/vite.config.js
@@ -7,7 +7,7 @@ export default defineConfig({
     vue({
       template: {
         compilerOptions: {
-          isCustomElement: (tag) => tag.startsWith('rr-'),
+          isCustomElement: (tag) => tag.startsWith('nldd-'),
         },
       },
     }),


### PR DESCRIPTION
## What & why

`frontend-lawmaking` had drifted off the MinBZK NLDD design system. Its `App.vue`
wrapped everything in a **non-existent `<rr-page>` element** (a leftover from a
prefix-rename) and used **0** `nldd-*` components — all chrome was hand-rolled.
This is deliverable **A** of codebase-audit advies 15: put the standard UI back on
the design system.

## Changes

- **Page shell**: `<rr-page>` → `nldd-app-view` > `nldd-page` (sticky header).
- **Toolbar** (`nldd-toolbar`): playback navigation as `nldd-icon-button`s
  (`chevron-double-left` / `chevron-left` / `chevron-right` / `chevron-double-right`),
  a play/pause `nldd-button` (controlled by `isPlaying`, filled `primary` while
  playing), a step `nldd-tag`, zoom `nldd-icon-button`s (`plus` / `minus` /
  `arrow-2-counter-clockwise`), and an `nldd-segmented-control` for the view mode.
- **Detail panel**: `StageDetail` rewritten from a hand-rolled fixed panel into an
  `nldd-sheet` (right placement), driven declaratively from the selected stage. The
  last stage stays rendered through the close animation so the panel never flashes
  empty.
- **vite**: `isCustomElement` prefix `rr-` → `nldd-`.
- **Version**: `@nldd/design-system` `^0.8.62` → `^0.8.63` (aligned with `frontend`).

Net **−172 lines** (hand-rolled chrome CSS removed).

## Documented design-system exception

The **SVG GitFlow canvas** (`FlowDiagram.vue` / `FlowNode.vue` / `FlowConnection.vue` /
`FlowLegend.vue`, ~540 lines) is **kept hand-rolled** — the design system has no
graph-canvas equivalent. These files are untouched; they continue to own the
branch-colour tokens in `css/variables.css`.

Note: the design system has **no media-transport (play/pause) glyph**, so play/pause is
a labelled button rather than an icon button — a design adaptation, not a custom-CSS
shortcut.

## Remaining custom CSS (reported per CLAUDE.md)

All that is left on top of the design system, in the two migrated files:

| File | Rule | Why |
|------|------|-----|
| `App.vue` | `.app-logo` (32px height) | sizing the Rijkswapen mark — the toolbar has no logo slot |
| `App.vue` | `.diagram-area` (flex column, centre) | centres the SVG-canvas exception in the full-bleed section |
| `StageDetail.vue` | `.stage-detail__meta` (flex row, gap) | lays out the tag + subtitle row |
| `StageDetail.vue` | `.stage-detail__subtitle` (`margin:0`) | resets the rich-text paragraph margin |

(Pre-existing canvas CSS in the four Flow* components + `css/variables.css`/`main.css`
is part of the documented exception and is unchanged.)

Also a minor visual simplification: the per-branch coloured type badge is now a plain
`nldd-tag` (monochrome).

## Verification

- `npm run build` ✅
- Smoke-tested the built site: playback (play/pause/step/begin/end), zoom, view toggle
  (Eenvoudig/Uitgebreid/Wet open overheid), and the detail sheet all work; no console
  errors.

### Screenshots

Toolbar (single row, all controls):

![toolbar](https://files.catbox.moe/9ee429.png)

Detail sheet (node click):

![sheet](https://files.catbox.moe/hkuv3l.png)

Uitgebreid view:

![advanced](https://files.catbox.moe/zy2rg6.png)
