### PR TITLE
ci: target root npm workspace in Dependabot so the lockfile stays in sync

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,8 +26,15 @@ updates:
           - patch
 
 
+  # Single entry for the root npm workspace. frontend, frontend-lawmaking and
+  # packages/admin/frontend-src are workspace members sharing one root
+  # package-lock.json (since #860). Dependabot must target the root directory so
+  # it updates the member package.json *and* the root lockfile in sync;
+  # targeting a member directory bumps only its package.json and leaves the root
+  # lockfile out of sync, breaking `npm ci`. (/docs keeps its own lockfile and
+  # has its own entry below.)
   - package-ecosystem: npm
-    directory: /frontend
+    directory: /
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
@@ -66,23 +73,6 @@ updates:
           - version-update:semver-major
           - version-update:semver-minor
 
-
-  - package-ecosystem: npm
-    directory: /packages/admin/frontend-src
-    schedule:
-      interval: weekly
-    open-pull-requests-limit: 10
-    labels:
-      - dependencies
-      - javascript
-    groups:
-      npm-minor-patch:
-        update-types:
-          - minor
-          - patch
-    ignore:
-      # Our own design package — bump manually, not via Dependabot
-      - dependency-name: '@nldd/design-system'
 
   - package-ecosystem: docker
     directory: /packages/admin
@@ -125,23 +115,6 @@ updates:
 
   - package-ecosystem: npm
     directory: /docs
-    schedule:
-      interval: weekly
-    open-pull-requests-limit: 10
-    labels:
-      - dependencies
-      - javascript
-    groups:
-      npm-minor-patch:
-        update-types:
-          - minor
-          - patch
-    ignore:
-      # Our own design package — bump manually, not via Dependabot
-      - dependency-name: '@nldd/design-system'
-
-  - package-ecosystem: npm
-    directory: /frontend-lawmaking
     schedule:
       interval: weekly
     open-pull-requests-limit: 10


### PR DESCRIPTION
## Problem
Since #860, `frontend/`, `frontend-lawmaking/` and `packages/admin/frontend-src/` are members of the **root** npm workspace and share one `/package-lock.json`. But `.github/dependabot.yml` still had three separate npm entries pointing at those member directories.

Result: Dependabot bumps `<member>/package.json` but never regenerates the root lockfile, so every frontend npm PR fails `npm ci`:
> npm error `npm ci` can only install packages when your package.json and package-lock.json … are in sync
> npm error Invalid: lock file's @cucumber/gherkin@40.0.0 does not satisfy @cucumber/gherkin@41.0.0

This is what broke #868 (@cucumber/gherkin) and #870 (js-yaml). `/docs` was unaffected because it keeps its own `docs/package-lock.json`.

## Fix
Consolidate the three member npm entries into a **single `directory: "/"`** entry. Dependabot supports npm workspaces: when pointed at the workspace root it updates the member `package.json` files **and** the root lockfile together. `/docs` keeps its own entry (separate lockfile, not a workspace member).

Net change to coverage: identical (the root entry covers all workspace members + `frontend-shared`); the `npm-minor-patch` group and the `@nldd/design-system` ignore are preserved. Side benefit: fewer, consolidated frontend dependency PRs.

## Follow-up once merged
- **#868** (@cucumber/gherkin 40→41): only blocked by the lockfile; `@dependabot recreate` should regenerate it green and let it merge. The JS change itself is trivial.
- **#870** (js-yaml 4→**5**): this also has a *real* breaking API change (default export removed; `Type` API replaced; `load`/`dump` option semantics changed) that breaks the editor's `import yaml from 'js-yaml'`. The lockfile fix is necessary but **not sufficient** — it needs either a code migration or a Dependabot `ignore` rule to stay on v4. Tracked separately.