### PR TITLE
chore(deps): migrate frontend to js-yaml v5

### DIFF
--- a/frontend/e2e/complex-actions.spec.js
+++ b/frontend/e2e/complex-actions.spec.js
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { interceptLaw, gotoEditor, selectArticle, readYamlPane } from './helpers.js';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
 

--- a/frontend/e2e/edit-test-loop.spec.js
+++ b/frontend/e2e/edit-test-loop.spec.js
@@ -20,7 +20,7 @@
  * reproduces the real dependency graph.
  */
 import { test, expect } from '@playwright/test';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import { loadCorpus, loadScenario, mockCorpusApi } from './helpers-corpus.js';
 
 test.describe('Edit → re-execute loop', () => {

--- a/frontend/e2e/full-roundtrip.spec.js
+++ b/frontend/e2e/full-roundtrip.spec.js
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { interceptLaw, gotoEditor, selectArticle, readYamlPane, loadFixture } from './helpers.js';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 
 /**
  * Load the pinned zorgtoeslag fixture (snapshot of the corpus law file).

--- a/frontend/e2e/helpers-corpus.js
+++ b/frontend/e2e/helpers-corpus.js
@@ -11,7 +11,7 @@
 import { readFileSync, readdirSync, statSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 

--- a/frontend/e2e/helpers.js
+++ b/frontend/e2e/helpers.js
@@ -1,6 +1,6 @@
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 
 const FIXTURE_DIR = resolve(import.meta.dirname, 'fixtures');
 

--- a/frontend/e2e/operation-binding.spec.js
+++ b/frontend/e2e/operation-binding.spec.js
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { interceptLaw, gotoEditor, selectArticle, readYamlPane } from './helpers.js';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -39,7 +39,7 @@
     "@vitejs/plugin-vue": "^6.0.7",
     "@vue/test-utils": "^2.4.11",
     "happy-dom": "^20.10.6",
-    "js-yaml": "^4.2.0",
+    "js-yaml": "^5.1.0",
     "jsdom": "^29.1.1",
     "vite": "^8.0.16",
     "vitest": "^4.1.9",

--- a/frontend/scripts/copy-laws.js
+++ b/frontend/scripts/copy-laws.js
@@ -11,7 +11,7 @@
 import { cpSync, existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from 'fs';
 import { resolve, dirname, relative } from 'path';
 import { fileURLToPath } from 'url';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, '..');

--- a/frontend/src/EditorView.vue
+++ b/frontend/src/EditorView.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { ref, computed, reactive, watch, watchEffect, nextTick, onBeforeUnmount } from 'vue';
 import { useRoute, useRouter, onBeforeRouteUpdate } from 'vue-router';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import { useLaw, fetchLaw } from './composables/useLaw.js';
 import { lawsListUrl } from './composables/corpusUrls.js';
 import { useEngine } from './composables/useEngine.js';

--- a/frontend/src/LibraryView.vue
+++ b/frontend/src/LibraryView.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { ref, computed, shallowRef, nextTick, watch, watchEffect, onBeforeUnmount } from 'vue';
 import { useRoute, useRouter, onBeforeRouteUpdate } from 'vue-router';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import ArticleText from './components/ArticleText.vue';
 import MachineReadable from './components/MachineReadable.vue';
 import YamlView from './components/YamlView.vue';

--- a/frontend/src/components/ScenarioBuilder.vue
+++ b/frontend/src/components/ScenarioBuilder.vue
@@ -25,7 +25,7 @@ import { useLatest } from '../lib/useLatest.js';
 import { parseFeature } from '../gherkin/parser.js';
 import { mapFeatureToForm, getEffectiveSetup, formStateToGherkin, syncEditedValues } from '../gherkin/formMapper.js';
 import { matchStatus, humanize } from '../utils/outputFormat.js';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import { buildArticleMap, buildTypeMap, buildExternalFieldTypeMap } from '../utils/articleMapping.js';
 import ScenarioForm from './ScenarioForm.vue';
 

--- a/frontend/src/components/YamlView.vue
+++ b/frontend/src/components/YamlView.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { computed } from 'vue';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 
 const props = defineProps({
   article: { type: Object, default: null },

--- a/frontend/src/composables/useAmbiguityVocabulary.js
+++ b/frontend/src/composables/useAmbiguityVocabulary.js
@@ -9,7 +9,7 @@
  * picker and the CI check read one source and cannot drift.
  */
 import { ref } from 'vue';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import { apiFetchText } from '../lib/apiFetch.js';
 
 // Session cache: the file does not change while the editor is open.

--- a/frontend/src/composables/useDependencies.js
+++ b/frontend/src/composables/useDependencies.js
@@ -9,7 +9,7 @@
  * federated corpus and scenarios already declare the regulations they need.
  */
 import { ref } from 'vue';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import { useBwbHarvest } from './useBwbHarvest.js';
 import { loadLawVersions } from './useEngine.js';
 import { implementorsUrl } from './corpusUrls.js';

--- a/frontend/src/composables/useDraftNotes.js
+++ b/frontend/src/composables/useDraftNotes.js
@@ -13,7 +13,7 @@
  * `__draft` marker so the UI can show them as unsaved and offer delete/export.
  */
 import { ref, computed, watch } from 'vue';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import { lastSavedPr, sanitizeSavedPr } from './useSavedPr.js';
 import { annotationsUrl, requireTraject } from './corpusUrls.js';
 import { apiFetch, apiFetchText } from '../lib/apiFetch.js';

--- a/frontend/src/composables/useDraftNotes.test.js
+++ b/frontend/src/composables/useDraftNotes.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { ref } from 'vue';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import { useDraftNotes } from './useDraftNotes.js';
 import { lastSavedPr } from './useSavedPr.js';
 

--- a/frontend/src/composables/useLaw.js
+++ b/frontend/src/composables/useLaw.js
@@ -1,5 +1,5 @@
 import { computed, ref, shallowRef } from 'vue';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import { lastSavedPr, sanitizeSavedPr } from './useSavedPr.js';
 import { lawUrl } from './corpusUrls.js';
 import { apiFetch } from '../lib/apiFetch.js';

--- a/frontend/src/composables/useLawGraph.js
+++ b/frontend/src/composables/useLawGraph.js
@@ -21,7 +21,7 @@
  * that scheme has to be rethought.
  */
 import { ref, watch } from 'vue';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import { MarkerType, Position } from '@vue-flow/core';
 import { extractRegulationRefs } from './useDependencies.js';
 import { useLatest } from '../lib/useLatest.js';

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "@vitejs/plugin-vue": "^6.0.7",
         "@vue/test-utils": "^2.4.11",
         "happy-dom": "^20.10.6",
-        "js-yaml": "^4.2.0",
+        "js-yaml": "^5.1.0",
         "jsdom": "^29.1.1",
         "vite": "^8.0.16",
         "vitest": "^4.1.9",
@@ -2892,9 +2892,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.1.0.tgz",
+      "integrity": "sha512-s8VA5jkR8f22S3NAXmhKPFqGUduqZGlsufabVOgN14iTdw/RXcym7bKkbwjxLK9Yw2lEvvmJjFp119+KPeo8Kg==",
       "dev": true,
       "funding": [
         {
@@ -2911,7 +2911,7 @@
         "argparse": "^2.0.1"
       },
       "bin": {
-        "js-yaml": "bin/js-yaml.js"
+        "js-yaml": "bin/js-yaml.mjs"
       }
     },
     "node_modules/jsdom": {


### PR DESCRIPTION
Supersedes Dependabot #870, which couldn't auto-merge for two reasons — a root-workspace lockfile out of sync (fixed structurally in #876) **and** a genuine breaking API change in js-yaml 5. This PR does the real migration.

## What v5 breaks
js-yaml 5 was rewritten in TypeScript and **dropped the default export** — the public API is now flat named exports (`load`, `dump`, …). So `import yaml from 'js-yaml'` resolves to `undefined` and every `yaml.load`/`yaml.dump` call throws.

## The change
Replace every `import yaml from 'js-yaml'` with a **namespace import** `import * as yaml from 'js-yaml'`, across all 17 call sites (`src/`, `e2e/`, `scripts/copy-laws.js`). All `yaml.load(...)` / `yaml.dump(..., dumpOpts)` call sites stay byte-for-byte unchanged.

No option changes were needed:
- `dump`'s `lineWidth` and `noRefs` (our `dumpOpts = { lineWidth: 80, noRefs: true }`) still exist in v5.
- v5's default load schema (YAML 1.2 CORE) parses our corpus identically — verified there are **no merge keys, custom `!!` tags, unquoted ISO dates, or yes/no booleans** in the YAML the editor loads, and no editor code treats loaded values as `Date` objects (`valid_from` is handled as a string).
- load → dump → load round-trip on a real law (`wet_op_de_zorgtoeslag`) is deep-equal.

## Dependency / lockfile
`js-yaml` 4.2.0 → **5.1.0** in `frontend/package.json` + regenerated root `package-lock.json` (frontend is a root-workspace member since #860).

## Verification
- ✅ 415 unit tests pass (`vitest run`, 40 files) — includes `useDraftNotes.test.js` which round-trips YAML.
- ✅ `vite build` succeeds.
- ✅ clean `npm ci` at root, 0 vulnerabilities.

Closes #870