### PR TITLE
refactor(engine): unify input-resolution onto a single ResolutionContext

### DIFF
--- a/docs/src/content/docs/components/engine.md
+++ b/docs/src/content/docs/components/engine.md
@@ -270,8 +270,7 @@ The engine enforces compile-time security limits to prevent DoS:
 | `MAX_LOADED_LAWS` | 100 | Prevent memory exhaustion |
 | `MAX_YAML_SIZE` | 1 MB | Prevent YAML bombs |
 | `MAX_ARRAY_SIZE` | 1,000 | Prevent large array DoS |
-| `MAX_RESOLUTION_DEPTH` | 50 | Internal reference nesting |
-| `MAX_CROSS_LAW_DEPTH` | 20 | Cross-law reference nesting |
+| `MAX_CROSS_LAW_DEPTH` | 20 | Cross-law and internal reference nesting |
 | `MAX_OPERATION_DEPTH` | 100 | Operation nesting |
 
 ## Execution Receipt

--- a/packages/engine/src/config.rs
+++ b/packages/engine/src/config.rs
@@ -37,13 +37,16 @@ pub const MAX_YAML_SIZE: usize = 1_000_000;
 /// 1000 elements is sufficient for any reasonable law structure.
 pub const MAX_ARRAY_SIZE: usize = 1_000;
 
-/// Maximum depth for reference resolution in the service layer.
+/// Maximum combined depth for reference resolution in the service layer.
 ///
-/// Governs both cross-law reference chains and same-law (internal)
-/// article-reference chains, which share a single resolution context.
-/// Prevents infinite loops and stack overflow in reference chains.
-/// 20 levels is conservative - Dutch regulations typically have at most
-/// 3-5 levels (Wet -> Ministerieel Regeling -> Gemeentelijke Verordening).
+/// A single shared counter governs cross-law reference chains and same-law
+/// (internal) article-reference chains *together*: every hop of either kind
+/// draws on this one budget within a resolution chain, not on separate
+/// per-kind budgets. Prevents infinite loops and stack overflow.
+/// 20 levels is conservative: cross-law chains in Dutch regulations are
+/// typically 3-5 levels (Wet -> Ministeriele Regeling -> Gemeentelijke
+/// Verordening), with internal article chains within a law adding only a few
+/// more — well under the shared budget.
 pub const MAX_CROSS_LAW_DEPTH: usize = 20;
 
 /// Maximum nesting depth for operations during evaluation.

--- a/packages/engine/src/config.rs
+++ b/packages/engine/src/config.rs
@@ -37,15 +37,11 @@ pub const MAX_YAML_SIZE: usize = 1_000_000;
 /// 1000 elements is sufficient for any reasonable law structure.
 pub const MAX_ARRAY_SIZE: usize = 1_000;
 
-/// Maximum depth for internal reference resolution within a single law.
+/// Maximum depth for reference resolution in the service layer.
 ///
-/// Prevents stack overflow from deeply nested article references.
-/// 50 levels is far beyond what any legitimate law structure would need.
-pub const MAX_RESOLUTION_DEPTH: usize = 50;
-
-/// Maximum depth for cross-law reference resolution.
-///
-/// Prevents infinite loops in cross-law reference chains.
+/// Governs both cross-law reference chains and same-law (internal)
+/// article-reference chains, which share a single resolution context.
+/// Prevents infinite loops and stack overflow in reference chains.
 /// 20 levels is conservative - Dutch regulations typically have at most
 /// 3-5 levels (Wet -> Ministerieel Regeling -> Gemeentelijke Verordening).
 pub const MAX_CROSS_LAW_DEPTH: usize = 20;
@@ -87,12 +83,6 @@ mod tests {
 
         assert!(MAX_ARRAY_SIZE >= 100, "Should allow reasonable arrays");
         assert!(MAX_ARRAY_SIZE <= 10_000, "Should not allow huge arrays");
-
-        assert!(
-            MAX_RESOLUTION_DEPTH >= 10,
-            "Should allow reasonable nesting"
-        );
-        assert!(MAX_RESOLUTION_DEPTH <= 100, "Should limit deep nesting");
 
         assert!(MAX_CROSS_LAW_DEPTH >= 5, "Should allow typical chains");
         assert!(MAX_CROSS_LAW_DEPTH <= 50, "Should limit deep chains");

--- a/packages/engine/src/engine.rs
+++ b/packages/engine/src/engine.rs
@@ -20,14 +20,13 @@
 //! ```
 
 use crate::article::{Action, ActionOperation, Article, ArticleBasedLaw};
-use crate::config;
 use crate::context::RuleContext;
 use crate::error::{EngineError, Result};
 use crate::operations::{evaluate_value, execute_operation};
 use crate::trace::{PathNode, TraceBuilder};
 use crate::types::{PathNodeType, Value};
 use std::cell::RefCell;
-use std::collections::{BTreeMap, HashSet};
+use std::collections::BTreeMap;
 use std::rc::Rc;
 
 /// Provenance of an output value: how it was produced during execution.
@@ -77,6 +76,17 @@ pub struct ArticleResult {
 ///
 /// The engine orchestrates the execution of an article's actions,
 /// resolving variables and evaluating operations to produce outputs.
+///
+/// The engine evaluates **one article in isolation**: it expects every input
+/// it needs to already be present in `parameters`. It does **not** resolve
+/// cross-article (`source.output`) or cross-law (`source.regulation`)
+/// references itself. An unresolved internal (`source.output`) input is left
+/// untouched (a consuming action then surfaces a `VariableNotFound`), while an
+/// unresolved external (`source.regulation`) input — which this engine can
+/// never resolve on its own — yields [`EngineError::ExternalReferenceNotResolved`].
+/// All reference resolution, cycle detection and depth limiting live in
+/// [`crate::LawExecutionService`], which is the single resolution authority and
+/// the entry point every production caller uses.
 pub struct ArticleEngine<'a> {
     /// Article to execute
     article: &'a Article,
@@ -136,10 +146,7 @@ impl<'a> ArticleEngine<'a> {
         calculation_date: &str,
         requested_output: Option<&str>,
     ) -> Result<ArticleResult> {
-        // Initialize visited set with current article to detect circular references
-        let visited = HashSet::from([self.article.number.clone()]);
-
-        self.evaluate_internal(parameters, calculation_date, requested_output, visited, 0)
+        self.evaluate_internal_traced(parameters, calculation_date, requested_output, None)
     }
 
     /// Execute this article's logic with trace support.
@@ -152,75 +159,26 @@ impl<'a> ArticleEngine<'a> {
         requested_output: Option<&str>,
         trace: Rc<RefCell<TraceBuilder>>,
     ) -> Result<ArticleResult> {
-        let visited = HashSet::from([self.article.number.clone()]);
-
-        self.evaluate_internal_traced(
-            parameters,
-            calculation_date,
-            requested_output,
-            visited,
-            0,
-            Some(trace),
-        )
+        self.evaluate_internal_traced(parameters, calculation_date, requested_output, Some(trace))
     }
 
-    /// Internal evaluation method that tracks visited articles for circular reference detection.
+    /// Internal evaluation, optionally tracing.
     ///
-    /// # Arguments
-    /// * `parameters` - Input parameters
-    /// * `calculation_date` - Date for calculations
-    /// * `requested_output` - Specific output to calculate (optional)
-    /// * `visited` - Set of article numbers already in the resolution chain
-    /// * `depth` - Current resolution depth
-    fn evaluate_internal(
-        &self,
-        parameters: BTreeMap<String, Value>,
-        calculation_date: &str,
-        requested_output: Option<&str>,
-        visited: HashSet<String>,
-        depth: usize,
-    ) -> Result<ArticleResult> {
-        self.evaluate_internal_traced(
-            parameters,
-            calculation_date,
-            requested_output,
-            visited,
-            depth,
-            None,
-        )
-    }
-
-    /// Internal evaluation with optional tracing.
+    /// `parameters` must already contain every value this article needs;
+    /// cross-article/cross-law resolution is [`crate::LawExecutionService`]'s job.
     fn evaluate_internal_traced(
         &self,
         parameters: BTreeMap<String, Value>,
         calculation_date: &str,
         requested_output: Option<&str>,
-        visited: HashSet<String>,
-        depth: usize,
         trace: Option<Rc<RefCell<TraceBuilder>>>,
     ) -> Result<ArticleResult> {
         tracing::debug!(
             law_id = %self.law.id,
             article = %self.article.number,
-            depth = depth,
             requested_output = ?requested_output,
             "Starting article evaluation"
         );
-
-        // Check depth limit
-        if depth > config::MAX_RESOLUTION_DEPTH {
-            tracing::warn!(
-                law_id = %self.law.id,
-                article = %self.article.number,
-                depth = depth,
-                "Resolution depth exceeded"
-            );
-            return Err(EngineError::CircularReference(format!(
-                "Resolution depth exceeded {} levels. Possible circular reference involving article '{}'",
-                config::MAX_RESOLUTION_DEPTH, self.article.number
-            )));
-        }
 
         // Create execution context
         let mut context = RuleContext::new(parameters.clone(), calculation_date)?;
@@ -235,8 +193,8 @@ impl<'a> ArticleEngine<'a> {
             context.set_definitions(definitions);
         }
 
-        // Resolve inputs with sources (internal references)
-        self.resolve_input_sources(&mut context, &parameters, calculation_date, &visited, depth)?;
+        // Guard against any input that still carries an unresolved external source.
+        self.check_input_sources(&parameters)?;
 
         // Execute actions (with trace instrumentation)
         self.execute_actions_traced(&mut context, requested_output)?;
@@ -281,139 +239,42 @@ impl<'a> ArticleEngine<'a> {
         Ok(result)
     }
 
-    /// Resolve input sources (internal and external references).
+    /// Validate that every input carrying an external `source` was pre-resolved.
     ///
-    /// This processes inputs that have a `source` specification and resolves them
-    /// before action execution. Internal references (same law) are resolved directly.
-    /// External references require a ServiceProvider (Phase 7).
+    /// Reference resolution is owned by [`crate::LawExecutionService`], which
+    /// resolves inputs (data sources, cross-law and cross-article references)
+    /// and passes the values in via `parameters`. This single-article engine
+    /// only checks that a `source.regulation` input it cannot resolve itself is
+    /// already present; internal (`source.output`) and empty (`source: {}`)
+    /// inputs are left untouched — they are either already in `parameters` or
+    /// stay unresolved (a consuming action then surfaces a `VariableNotFound`).
     ///
     /// # Arguments
-    /// * `context` - Execution context
-    /// * `parameters` - Input parameters
-    /// * `calculation_date` - Date for calculations
-    /// * `visited` - Set of article numbers already in the resolution chain
-    /// * `depth` - Current resolution depth
-    fn resolve_input_sources(
-        &self,
-        context: &mut RuleContext,
-        parameters: &BTreeMap<String, Value>,
-        calculation_date: &str,
-        visited: &HashSet<String>,
-        depth: usize,
-    ) -> Result<()> {
-        let inputs = self.article.get_inputs();
-
-        for input in inputs {
-            let source = match &input.source {
-                Some(s) => s,
-                None => continue, // No source, skip
+    /// * `parameters` - Input parameters (already-resolved values)
+    fn check_input_sources(&self, parameters: &BTreeMap<String, Value>) -> Result<()> {
+        for input in self.article.get_inputs() {
+            let Some(source) = &input.source else {
+                continue; // No source, nothing to check
             };
 
-            // Determine the type of reference:
-            // 1. External: source.regulation is set (simple cross-law reference)
-            // 2. Internal: source.output is set (same-law reference)
-            // 3. Empty source: resolved by DataSourceRegistry in service layer
-
+            // An external (cross-law) reference can only be resolved by the
+            // service layer. If it was not pre-resolved into parameters, this
+            // standalone engine cannot proceed.
             if let Some(regulation) = &source.regulation {
-                // External reference: requires ServiceProvider
-                // Check if value was pre-resolved via parameters
-                if parameters.contains_key(&input.name) {
-                    continue;
+                if !parameters.contains_key(&input.name) {
+                    return Err(EngineError::ExternalReferenceNotResolved {
+                        input_name: input.name.clone(),
+                        regulation: regulation.clone(),
+                        output: source.output.clone().unwrap_or_default(),
+                    });
                 }
-
-                return Err(EngineError::ExternalReferenceNotResolved {
-                    input_name: input.name.clone(),
-                    regulation: regulation.clone(),
-                    output: source.output.clone().unwrap_or_default(),
-                });
-            } else if let Some(output_name) = &source.output {
-                // Internal reference: resolve within the same law.
-                // Check if already resolved by service layer.
-                if parameters.contains_key(&input.name) {
-                    continue;
-                }
-                let value = self.resolve_internal_reference(
-                    output_name,
-                    parameters,
-                    calculation_date,
-                    visited,
-                    depth,
-                )?;
-                context.set_resolved_input(&input.name, value);
-            } else {
-                // Empty source (source: {}) — resolved by DataSourceRegistry in service layer.
-                // Check if already provided as parameter.
-                if parameters.contains_key(&input.name) {
-                    continue;
-                }
-                // Otherwise leave unresolved — the service layer will handle it.
             }
+            // Internal (`source.output`) and empty (`source: {}`) inputs need no
+            // action here: resolved by the service when present in parameters,
+            // otherwise intentionally left unresolved.
         }
 
         Ok(())
-    }
-
-    /// Resolve an internal reference (within the same law).
-    ///
-    /// Finds the article that produces the given output and executes it.
-    /// Tracks visited articles to detect indirect circular references (A→B→A).
-    ///
-    /// # Arguments
-    /// * `output_name` - Name of the output to resolve
-    /// * `parameters` - Input parameters
-    /// * `calculation_date` - Date for calculations
-    /// * `visited` - Set of article numbers already in the resolution chain
-    /// * `depth` - Current resolution depth
-    fn resolve_internal_reference(
-        &self,
-        output_name: &str,
-        parameters: &BTreeMap<String, Value>,
-        calculation_date: &str,
-        visited: &HashSet<String>,
-        depth: usize,
-    ) -> Result<Value> {
-        // Find the article that produces this output
-        let article = self
-            .law
-            .find_article_by_output(output_name)
-            .ok_or_else(|| EngineError::OutputNotFound {
-                law_id: self.law.id.clone(),
-                output: output_name.to_string(),
-            })?;
-
-        // Check for circular reference (direct or indirect)
-        // visited already contains the current article (and all its callers)
-        if visited.contains(&article.number) {
-            return Err(EngineError::CircularReference(format!(
-                "Circular reference detected: article '{}' references output '{}' from article '{}', \
-                 which is already in the resolution chain: {:?}",
-                self.article.number, output_name, article.number, visited
-            )));
-        }
-
-        // Add the target article to visited set for the recursive call
-        let mut new_visited = visited.clone();
-        new_visited.insert(article.number.clone());
-
-        // Execute the referenced article with updated visited set
-        let engine = ArticleEngine::new(article, self.law);
-        let result = engine.evaluate_internal(
-            parameters.clone(),
-            calculation_date,
-            Some(output_name),
-            new_visited,
-            depth + 1,
-        )?;
-
-        // Extract the requested output
-        result
-            .outputs
-            .get(output_name)
-            .cloned()
-            .ok_or_else(|| EngineError::OutputNotFound {
-                law_id: self.law.id.clone(),
-                output: output_name.to_string(),
-            })
     }
 
     /// Execute all actions in order, with optional trace instrumentation.
@@ -1007,353 +868,6 @@ articles:
         let result = engine.evaluate(BTreeMap::new(), "2025-06-15").unwrap();
 
         assert_eq!(result.outputs.get("current_year"), Some(&Value::Int(2025)));
-    }
-
-    // -------------------------------------------------------------------------
-    // Internal Reference Resolution Tests
-    // -------------------------------------------------------------------------
-
-    #[test]
-    fn test_internal_reference_basic() {
-        // Law with two articles: article 2 references output from article 1
-        let yaml = r#"
-$id: internal_ref_law
-regulatory_layer: WET
-publication_date: '2025-01-01'
-articles:
-  - number: '1'
-    text: Base calculation article
-    machine_readable:
-      definitions:
-        BASE_VALUE:
-          value: 100
-      execution:
-        output:
-          - name: base_amount
-            type: number
-        actions:
-          - output: base_amount
-            value: $BASE_VALUE
-  - number: '2'
-    text: Derived calculation using internal reference
-    machine_readable:
-      execution:
-        input:
-          - name: base_amount
-            type: number
-            source:
-              output: base_amount
-        output:
-          - name: doubled_amount
-            type: number
-        actions:
-          - output: doubled_amount
-            operation: MULTIPLY
-            values:
-              - $base_amount
-              - 2
-"#;
-        let law = ArticleBasedLaw::from_yaml_str(yaml).unwrap();
-        let article = law.find_article_by_number("2").unwrap();
-        let engine = ArticleEngine::new(article, &law);
-
-        let result = engine.evaluate(BTreeMap::new(), "2025-01-01").unwrap();
-
-        // doubled_amount should be 100 * 2 = 200
-        assert_eq!(result.outputs.get("doubled_amount"), Some(&Value::Int(200)));
-        // base_amount should be in resolved_inputs
-        assert_eq!(
-            result.resolved_inputs.get("base_amount"),
-            Some(&Value::Int(100))
-        );
-    }
-
-    #[test]
-    fn test_internal_reference_chain() {
-        // Law with three articles: 3 -> 2 -> 1
-        let yaml = r#"
-$id: chain_law
-regulatory_layer: WET
-publication_date: '2025-01-01'
-articles:
-  - number: '1'
-    text: First article
-    machine_readable:
-      execution:
-        output:
-          - name: first_value
-            type: number
-        actions:
-          - output: first_value
-            value: 10
-  - number: '2'
-    text: Second article references first
-    machine_readable:
-      execution:
-        input:
-          - name: first_value
-            type: number
-            source:
-              output: first_value
-        output:
-          - name: second_value
-            type: number
-        actions:
-          - output: second_value
-            operation: ADD
-            values:
-              - $first_value
-              - 5
-  - number: '3'
-    text: Third article references second
-    machine_readable:
-      execution:
-        input:
-          - name: second_value
-            type: number
-            source:
-              output: second_value
-        output:
-          - name: third_value
-            type: number
-        actions:
-          - output: third_value
-            operation: MULTIPLY
-            values:
-              - $second_value
-              - 2
-"#;
-        let law = ArticleBasedLaw::from_yaml_str(yaml).unwrap();
-        let article = law.find_article_by_number("3").unwrap();
-        let engine = ArticleEngine::new(article, &law);
-
-        let result = engine.evaluate(BTreeMap::new(), "2025-01-01").unwrap();
-
-        // Chain: first_value = 10, second_value = 10 + 5 = 15, third_value = 15 * 2 = 30
-        assert_eq!(result.outputs.get("third_value"), Some(&Value::Int(30)));
-    }
-
-    #[test]
-    fn test_internal_reference_with_parameters() {
-        // Referenced article uses parameters passed through
-        let yaml = r#"
-$id: param_law
-regulatory_layer: WET
-publication_date: '2025-01-01'
-articles:
-  - number: '1'
-    text: Article that uses parameter
-    machine_readable:
-      execution:
-        parameters:
-          - name: multiplier
-            type: number
-            required: true
-        output:
-          - name: base_result
-            type: number
-        actions:
-          - output: base_result
-            operation: MULTIPLY
-            values:
-              - 100
-              - $multiplier
-  - number: '2'
-    text: Article that references article 1
-    machine_readable:
-      execution:
-        parameters:
-          - name: multiplier
-            type: number
-            required: true
-        input:
-          - name: base_result
-            type: number
-            source:
-              output: base_result
-        output:
-          - name: final_result
-            type: number
-        actions:
-          - output: final_result
-            operation: ADD
-            values:
-              - $base_result
-              - 50
-"#;
-        let law = ArticleBasedLaw::from_yaml_str(yaml).unwrap();
-        let article = law.find_article_by_number("2").unwrap();
-        let engine = ArticleEngine::new(article, &law);
-
-        let mut params = BTreeMap::new();
-        params.insert("multiplier".to_string(), Value::Int(3));
-
-        let result = engine.evaluate(params, "2025-01-01").unwrap();
-
-        // base_result = 100 * 3 = 300, final_result = 300 + 50 = 350
-        assert_eq!(result.outputs.get("final_result"), Some(&Value::Int(350)));
-    }
-
-    #[test]
-    fn test_circular_reference_detection() {
-        // Article that references itself should fail
-        let yaml = r#"
-$id: circular_law
-regulatory_layer: WET
-publication_date: '2025-01-01'
-articles:
-  - number: '1'
-    text: Self-referencing article
-    machine_readable:
-      execution:
-        input:
-          - name: my_output
-            type: number
-            source:
-              output: my_output
-        output:
-          - name: my_output
-            type: number
-        actions:
-          - output: my_output
-            value: $my_output
-"#;
-        let law = ArticleBasedLaw::from_yaml_str(yaml).unwrap();
-        let article = law.find_article_by_number("1").unwrap();
-        let engine = ArticleEngine::new(article, &law);
-
-        let result = engine.evaluate(BTreeMap::new(), "2025-01-01");
-
-        assert!(matches!(result, Err(EngineError::CircularReference(_))));
-    }
-
-    #[test]
-    fn test_indirect_circular_reference_detection() {
-        // Indirect circular reference: A → B → A should fail
-        let yaml = r#"
-$id: indirect_circular_law
-regulatory_layer: WET
-publication_date: '2025-01-01'
-articles:
-  - number: '1'
-    text: Article A references B
-    machine_readable:
-      execution:
-        input:
-          - name: value_from_b
-            type: number
-            source:
-              output: output_b
-        output:
-          - name: output_a
-            type: number
-        actions:
-          - output: output_a
-            operation: ADD
-            values:
-              - $value_from_b
-              - 1
-  - number: '2'
-    text: Article B references A (creates cycle)
-    machine_readable:
-      execution:
-        input:
-          - name: value_from_a
-            type: number
-            source:
-              output: output_a
-        output:
-          - name: output_b
-            type: number
-        actions:
-          - output: output_b
-            operation: ADD
-            values:
-              - $value_from_a
-              - 2
-"#;
-        let law = ArticleBasedLaw::from_yaml_str(yaml).unwrap();
-
-        // Starting from article 1: A → B → A (cycle detected)
-        let article = law.find_article_by_number("1").unwrap();
-        let engine = ArticleEngine::new(article, &law);
-
-        let result = engine.evaluate(BTreeMap::new(), "2025-01-01");
-
-        assert!(
-            matches!(result, Err(EngineError::CircularReference(_))),
-            "Expected CircularReference error for A→B→A cycle, got: {:?}",
-            result
-        );
-    }
-
-    #[test]
-    fn test_three_way_circular_reference() {
-        // Three-way circular reference: A → B → C → A should fail
-        let yaml = r#"
-$id: three_way_circular_law
-regulatory_layer: WET
-publication_date: '2025-01-01'
-articles:
-  - number: '1'
-    text: Article A references B
-    machine_readable:
-      execution:
-        input:
-          - name: from_b
-            type: number
-            source:
-              output: output_b
-        output:
-          - name: output_a
-            type: number
-        actions:
-          - output: output_a
-            value: $from_b
-  - number: '2'
-    text: Article B references C
-    machine_readable:
-      execution:
-        input:
-          - name: from_c
-            type: number
-            source:
-              output: output_c
-        output:
-          - name: output_b
-            type: number
-        actions:
-          - output: output_b
-            value: $from_c
-  - number: '3'
-    text: Article C references A (completes cycle)
-    machine_readable:
-      execution:
-        input:
-          - name: from_a
-            type: number
-            source:
-              output: output_a
-        output:
-          - name: output_c
-            type: number
-        actions:
-          - output: output_c
-            value: $from_a
-"#;
-        let law = ArticleBasedLaw::from_yaml_str(yaml).unwrap();
-
-        // Starting from article 1: A → B → C → A (cycle detected)
-        let article = law.find_article_by_number("1").unwrap();
-        let engine = ArticleEngine::new(article, &law);
-
-        let result = engine.evaluate(BTreeMap::new(), "2025-01-01");
-
-        assert!(
-            matches!(result, Err(EngineError::CircularReference(_))),
-            "Expected CircularReference error for A→B→C→A cycle, got: {:?}",
-            result
-        );
     }
 
     #[test]

--- a/packages/engine/src/lib.rs
+++ b/packages/engine/src/lib.rs
@@ -65,7 +65,7 @@ pub use article::{
 };
 pub use config::{
     MAX_ARRAY_SIZE, MAX_CROSS_LAW_DEPTH, MAX_LOADED_LAWS, MAX_OPERATION_DEPTH, MAX_PROPERTY_DEPTH,
-    MAX_RESOLUTION_DEPTH, MAX_YAML_SIZE,
+    MAX_YAML_SIZE,
 };
 pub use context::RuleContext;
 pub use data_source::{DataSource, DataSourceMatch, DataSourceRegistry, DictDataSource};

--- a/packages/engine/src/service.rs
+++ b/packages/engine/src/service.rs
@@ -2130,10 +2130,20 @@ impl LawExecutionService {
                     res_ctx.trace_set_result(value.clone());
                     context.set_resolved_input(&input.name, value.clone());
                 } else {
+                    // The referenced article ran but produced no such output
+                    // (e.g. an IF action whose branch was not taken). Surface the
+                    // precise cause here instead of leaving the input unresolved
+                    // and letting the consuming action fail later with a generic
+                    // VariableNotFound. Mirrors the external-reference path
+                    // (resolve_external_input_internal), which errors the same way.
                     res_ctx.trace_set_message(format!(
                         "Internal reference: output '{}' not in result from article {}",
                         output_name, ref_article.number
                     ));
+                    return Err(EngineError::OutputNotFound {
+                        law_id: law.id.clone(),
+                        output: output_name.to_string(),
+                    });
                 }
             } else {
                 // Empty source (source: {}) — resolved from DataSourceRegistry only.
@@ -3244,6 +3254,69 @@ articles:
 
         // base_result = 100 * 3 = 300, final_result = 300 + 50 = 350
         assert_eq!(result.outputs.get("final_result"), Some(&Value::Int(350)));
+    }
+
+    #[test]
+    fn test_service_internal_reference_missing_output_errors() {
+        // Article 2 internally references `missing_output`, which article 1
+        // declares but never produces (no action emits it). The referenced
+        // article runs successfully but its result lacks the output. This must
+        // surface as OutputNotFound at the resolution site — mirroring the
+        // external-reference path — rather than being silently left unresolved
+        // and failing later with a generic VariableNotFound on the input.
+        let law = r#"
+$id: missing_internal_output_law
+regulatory_layer: WET
+publication_date: '2025-01-01'
+articles:
+  - number: '1'
+    text: Declares an output it never produces
+    machine_readable:
+      execution:
+        output:
+          - name: produced
+            type: number
+          - name: missing_output
+            type: number
+        actions:
+          - output: produced
+            value: 1
+  - number: '2'
+    text: References the never-produced output
+    machine_readable:
+      execution:
+        input:
+          - name: missing_output
+            type: number
+            source:
+              output: missing_output
+        output:
+          - name: result
+            type: number
+        actions:
+          - output: result
+            value: $missing_output
+"#;
+
+        let mut service = LawExecutionService::new();
+        service.load_law(law).unwrap();
+
+        let result = service.evaluate_law_output(
+            "missing_internal_output_law",
+            "result",
+            BTreeMap::new(),
+            "2025-01-01",
+        );
+
+        match result {
+            Err(EngineError::OutputNotFound { output, .. }) => {
+                assert_eq!(output, "missing_output");
+            }
+            other => panic!(
+                "Expected OutputNotFound for an unproduced internal output, got: {:?}",
+                other
+            ),
+        }
     }
 
     // -------------------------------------------------------------------------

--- a/packages/engine/src/service.rs
+++ b/packages/engine/src/service.rs
@@ -3015,6 +3015,237 @@ articles:
         }
     }
 
+    #[test]
+    fn test_service_internal_self_reference_is_circular() {
+        // Degenerate same-law cycle: an article's input sources its own output.
+        let law = r#"
+$id: internal_self_ref_law
+regulatory_layer: WET
+publication_date: '2025-01-01'
+articles:
+  - number: '1'
+    text: References its own output
+    machine_readable:
+      execution:
+        input:
+          - name: my_output
+            type: number
+            source:
+              output: my_output
+        output:
+          - name: my_output
+            type: number
+        actions:
+          - output: my_output
+            value: $my_output
+"#;
+
+        let mut service = LawExecutionService::new();
+        service.load_law(law).unwrap();
+
+        let result = service.evaluate_law_output(
+            "internal_self_ref_law",
+            "my_output",
+            BTreeMap::new(),
+            "2025-01-01",
+        );
+
+        assert!(
+            matches!(result, Err(EngineError::CircularReference(_))),
+            "Expected CircularReference error for a self-referencing article, got: {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_service_internal_reference_basic() {
+        // Article 2's input sources article 1's output (same law). Resolution is
+        // owned by the service; the value flows through to article 2's action.
+        let law = r#"
+$id: internal_ref_law
+regulatory_layer: WET
+publication_date: '2025-01-01'
+articles:
+  - number: '1'
+    text: Base calculation article
+    machine_readable:
+      definitions:
+        BASE_VALUE:
+          value: 100
+      execution:
+        output:
+          - name: base_amount
+            type: number
+        actions:
+          - output: base_amount
+            value: $BASE_VALUE
+  - number: '2'
+    text: Derived calculation using internal reference
+    machine_readable:
+      execution:
+        input:
+          - name: base_amount
+            type: number
+            source:
+              output: base_amount
+        output:
+          - name: doubled_amount
+            type: number
+        actions:
+          - output: doubled_amount
+            operation: MULTIPLY
+            values:
+              - $base_amount
+              - 2
+"#;
+
+        let mut service = LawExecutionService::new();
+        service.load_law(law).unwrap();
+
+        let result = service
+            .evaluate_law_output(
+                "internal_ref_law",
+                "doubled_amount",
+                BTreeMap::new(),
+                "2025-01-01",
+            )
+            .expect("internal reference must resolve");
+
+        // doubled_amount = base_amount (100) * 2 = 200
+        assert_eq!(result.outputs.get("doubled_amount"), Some(&Value::Int(200)));
+    }
+
+    #[test]
+    fn test_service_internal_reference_chain() {
+        // A chain of internal references within one law: 3 -> 2 -> 1.
+        let law = r#"
+$id: chain_law
+regulatory_layer: WET
+publication_date: '2025-01-01'
+articles:
+  - number: '1'
+    text: First article
+    machine_readable:
+      execution:
+        output:
+          - name: first_value
+            type: number
+        actions:
+          - output: first_value
+            value: 10
+  - number: '2'
+    text: Second article references first
+    machine_readable:
+      execution:
+        input:
+          - name: first_value
+            type: number
+            source:
+              output: first_value
+        output:
+          - name: second_value
+            type: number
+        actions:
+          - output: second_value
+            operation: ADD
+            values:
+              - $first_value
+              - 5
+  - number: '3'
+    text: Third article references second
+    machine_readable:
+      execution:
+        input:
+          - name: second_value
+            type: number
+            source:
+              output: second_value
+        output:
+          - name: third_value
+            type: number
+        actions:
+          - output: third_value
+            operation: MULTIPLY
+            values:
+              - $second_value
+              - 2
+"#;
+
+        let mut service = LawExecutionService::new();
+        service.load_law(law).unwrap();
+
+        let result = service
+            .evaluate_law_output("chain_law", "third_value", BTreeMap::new(), "2025-01-01")
+            .expect("internal reference chain must resolve");
+
+        // first_value = 10, second_value = 10 + 5 = 15, third_value = 15 * 2 = 30
+        assert_eq!(result.outputs.get("third_value"), Some(&Value::Int(30)));
+    }
+
+    #[test]
+    fn test_service_internal_reference_with_parameters() {
+        // The referenced article consumes a parameter that the caller supplies;
+        // the internal reference must still resolve correctly.
+        let law = r#"
+$id: param_law
+regulatory_layer: WET
+publication_date: '2025-01-01'
+articles:
+  - number: '1'
+    text: Article that uses parameter
+    machine_readable:
+      execution:
+        parameters:
+          - name: multiplier
+            type: number
+            required: true
+        output:
+          - name: base_result
+            type: number
+        actions:
+          - output: base_result
+            operation: MULTIPLY
+            values:
+              - 100
+              - $multiplier
+  - number: '2'
+    text: Article that references article 1
+    machine_readable:
+      execution:
+        parameters:
+          - name: multiplier
+            type: number
+            required: true
+        input:
+          - name: base_result
+            type: number
+            source:
+              output: base_result
+        output:
+          - name: final_result
+            type: number
+        actions:
+          - output: final_result
+            operation: ADD
+            values:
+              - $base_result
+              - 50
+"#;
+
+        let mut service = LawExecutionService::new();
+        service.load_law(law).unwrap();
+
+        let mut params = BTreeMap::new();
+        params.insert("multiplier".to_string(), Value::Int(3));
+
+        let result = service
+            .evaluate_law_output("param_law", "final_result", params, "2025-01-01")
+            .expect("internal reference with parameters must resolve");
+
+        // base_result = 100 * 3 = 300, final_result = 300 + 50 = 350
+        assert_eq!(result.outputs.get("final_result"), Some(&Value::Int(350)));
+    }
+
     // -------------------------------------------------------------------------
     // Parameter Override Tests
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## What & why

Picks up **Advies 13b** (engine: unify the two input-resolution paths — source of the "cycle-crash" bug class).

The engine had **two duplicated input-resolution paths**, each with its own cycle detector:

- **Path 1** — `ArticleEngine::resolve_input_sources` + `resolve_internal_reference`: resolved same-law `source.output` references by recursively spinning up sub-engines, with its own `visited: HashSet<article_number>` and depth cap (`MAX_RESOLUTION_DEPTH`).
- **Path 2** — `LawExecutionService::resolve_inputs_with_service` threading a single `ResolutionContext` (data-source → cross-law → internal tiers), used by **every production caller** (`wasm`, `tui`, `bin/evaluate`).

When the service called into `ArticleEngine` for action execution, the engine **reset to a fresh visited-set and depth 0**, so a cross-law↔internal cycle could evade *both* detectors. That seam is the cycle-crash class.

## Change

- Delete `resolve_internal_reference`; reduce `resolve_input_sources` → `check_input_sources`, which only validates that external (`source.regulation`) inputs were pre-resolved and otherwise leaves inputs untouched (lenient).
- Drop the now-dead `visited`/`depth` plumbing and the engine-level depth check.
- `ArticleEngine` now executes a **single article from already-resolved parameters**; `LawExecutionService`'s `ResolutionContext` is the **single resolution authority** — one cycle-detection scheme, one depth counter spanning cross-law + internal hops.

**No production behavior change**: every production caller already goes through the service, which pre-resolves inputs into `combined_params` before the engine runs. The only behavioral change is for *standalone* `ArticleEngine` with multi-article internal refs (tests/benches only): an unresolved internal input now surfaces as `VariableNotFound` rather than being auto-resolved.

## Tests

Six engine-level tests that relied on standalone multi-article internal resolution are migrated to the service layer, where value (basic/chain/with-parameters), self/indirect/three-way cycle, diamond and deep-chain depth cases are all covered.

## Relationship to #511

The todo marked 13b as blocked by #511 (RFC-016/017). On inspection #511 does **not** unify these paths — it adds a data-source tier alongside them and leaves both resolvers intact. So 13b is **independent of #511**; landing it first *shrinks* #511's surface (one resolver to extend, not two) rather than colliding.

## Verification

- `just format` ✓
- `just lint` (full workspace, `-Dwarnings`) ✓
- `just test` — 382 unit tests ✓
- `just bdd` — 11 features / 76 scenarios / 587 steps ✓
- `cargo bench -p regelrecht-engine --no-run` ✓