### PR TITLE
feat(engine): schema↔model conformiteitssuite (advies 12)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,11 +134,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Check schema versions registered in validate.rs
+      - name: Check schema versions registered in schema.rs
         if: needs.changes.outputs.ci == 'true'
         run: |
-          # Every schema/vX.Y.Z/ directory must appear in validate.rs
-          VALIDATE_RS="packages/engine/src/bin/validate.rs"
+          # Every schema/vX.Y.Z/ directory must appear in the embedded schema table.
+          VALIDATE_RS="packages/engine/src/schema.rs"
           MISSING=""
           for dir in schema/v*/; do
             version=$(basename "$dir")
@@ -147,11 +147,11 @@ jobs:
             fi
           done
           if [ -n "$MISSING" ]; then
-            echo "ERROR: Schema versions not registered in validate.rs:"
+            echo "ERROR: Schema versions not registered in schema.rs:"
             printf "$MISSING"
             exit 1
           fi
-          echo "All schema versions registered in validate.rs"
+          echo "All schema versions registered in schema.rs"
 
       - name: Check corpus schema references
         if: needs.changes.outputs.ci == 'true'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,13 @@ git worktree add .worktrees/feature-branch feature-branch
 Laws are stored as article-based YAML files conforming to the official JSON schema:
 - Schema: `schema/latest/schema.json` (symlink to the current version directory in this repo)
 
+The hand-authored `schema.json` is the **canonical, language-agnostic contract**; the Rust
+`law-model` (`packages/law-model/`) is one implementation that must *conform* to it (neither is
+generated from the other). `just conformance` proves this — a corpus differential plus synthetic
+fixtures, the structural twin of the BDD bucket-B suite. See
+`packages/engine/tests/conformance/README.md`. The model is currently more permissive than the
+schema in a few documented ways (`KNOWN_GAPS`); reconciling that is tracked separately.
+
 ### Cross-Law References
 
 Laws reference each other via `source` on input fields:

--- a/Justfile
+++ b/Justfile
@@ -57,8 +57,16 @@ validate *FILES:
 validate-annotations *FILES:
     script/validate-annotations.sh {{FILES}}
 
+# Schema↔model conformance suite — proves the Rust law-model conforms to the
+# canonical schema.json. Standalone helper; `just test` already runs it via
+# --all-features. Needs the `validate` feature (jsonschema). See
+# packages/engine/tests/conformance/README.md.
+conformance:
+    cd packages && {{ci_flags}} cargo test -p regelrecht-engine --features validate --test conformance
+
 # Run all quality checks (format + lint + check + validate + validate-annotations + tests)
 # Note: pipeline-integration-test excluded — it requires Docker (testcontainers)
+# Note: the conformance suite runs as part of `test` (cargo test --all-features).
 check: format lint build-check validate validate-annotations test harvester-test pipeline-test admin-fmt admin-lint admin-check admin-test admin-frontend editor-api-fmt editor-api-lint editor-api-check
 
 # --- Tests ---

--- a/packages/engine/Cargo.toml
+++ b/packages/engine/Cargo.toml
@@ -99,6 +99,11 @@ walkdir.workspace = true
 tracing-subscriber.workspace = true
 criterion = { version = "0.8", features = ["html_reports"] }
 rust_decimal_macros.workspace = true
+# Used by the schema↔model conformance suite (tests/conformance.rs, requires the
+# `validate` feature). serde_json/serde_yaml_ng are regular deps but must be
+# re-declared here to be in scope for the integration-test crate.
+serde_json.workspace = true
+serde_yaml_ng.workspace = true
 
 [[bench]]
 name = "uri_parsing"

--- a/packages/engine/src/bin/validate.rs
+++ b/packages/engine/src/bin/validate.rs
@@ -1,98 +1,8 @@
-use std::collections::HashMap;
 use std::path::Path;
 use std::process;
 
-use jsonschema::Validator;
 use regelrecht_engine::article::{ArticleBasedLaw, LawLoad};
-
-/// Embedded schemas keyed by their `$id` URL suffix (version path).
-///
-/// These are compiled-in from the repo's schema/ directory and are guaranteed
-/// to be valid JSON at build time.
-fn load_schemas() -> Result<HashMap<&'static str, serde_json::Value>, String> {
-    let mut schemas = HashMap::new();
-    let v020: serde_json::Value =
-        serde_json::from_str(include_str!("../../../../schema/v0.2.0/schema.json"))
-            .map_err(|e| format!("invalid v0.2.0 schema JSON: {e}"))?;
-    let v030: serde_json::Value =
-        serde_json::from_str(include_str!("../../../../schema/v0.3.0/schema.json"))
-            .map_err(|e| format!("invalid v0.3.0 schema JSON: {e}"))?;
-    let v031: serde_json::Value =
-        serde_json::from_str(include_str!("../../../../schema/v0.3.1/schema.json"))
-            .map_err(|e| format!("invalid v0.3.1 schema JSON: {e}"))?;
-    let v032: serde_json::Value =
-        serde_json::from_str(include_str!("../../../../schema/v0.3.2/schema.json"))
-            .map_err(|e| format!("invalid v0.3.2 schema JSON: {e}"))?;
-    let v040: serde_json::Value =
-        serde_json::from_str(include_str!("../../../../schema/v0.4.0/schema.json"))
-            .map_err(|e| format!("invalid v0.4.0 schema JSON: {e}"))?;
-    let v050: serde_json::Value =
-        serde_json::from_str(include_str!("../../../../schema/v0.5.0/schema.json"))
-            .map_err(|e| format!("invalid v0.5.0 schema JSON: {e}"))?;
-    let v051: serde_json::Value =
-        serde_json::from_str(include_str!("../../../../schema/v0.5.1/schema.json"))
-            .map_err(|e| format!("invalid v0.5.1 schema JSON: {e}"))?;
-    let v052: serde_json::Value =
-        serde_json::from_str(include_str!("../../../../schema/v0.5.2/schema.json"))
-            .map_err(|e| format!("invalid v0.5.2 schema JSON: {e}"))?;
-    let v053: serde_json::Value =
-        serde_json::from_str(include_str!("../../../../schema/v0.5.3/schema.json"))
-            .map_err(|e| format!("invalid v0.5.3 schema JSON: {e}"))?;
-    let v054: serde_json::Value =
-        serde_json::from_str(include_str!("../../../../schema/v0.5.4/schema.json"))
-            .map_err(|e| format!("invalid v0.5.4 schema JSON: {e}"))?;
-    let v055: serde_json::Value =
-        serde_json::from_str(include_str!("../../../../schema/v0.5.5/schema.json"))
-            .map_err(|e| format!("invalid v0.5.5 schema JSON: {e}"))?;
-    let v056: serde_json::Value =
-        serde_json::from_str(include_str!("../../../../schema/v0.5.6/schema.json"))
-            .map_err(|e| format!("invalid v0.5.6 schema JSON: {e}"))?;
-    schemas.insert("v0.2.0", v020);
-    schemas.insert("v0.3.0", v030);
-    schemas.insert("v0.3.1", v031);
-    schemas.insert("v0.3.2", v032);
-    schemas.insert("v0.4.0", v040);
-    schemas.insert("v0.5.0", v050);
-    schemas.insert("v0.5.1", v051);
-    schemas.insert("v0.5.2", v052);
-    schemas.insert("v0.5.3", v053);
-    schemas.insert("v0.5.4", v054);
-    schemas.insert("v0.5.5", v055);
-    schemas.insert("v0.5.6", v056);
-    Ok(schemas)
-}
-
-/// Detect schema version from the `$schema` field in the YAML document.
-fn detect_version(value: &serde_json::Value) -> Option<&str> {
-    let schema_url = value.get("$schema")?.as_str()?;
-    if schema_url.contains("v0.5.6") {
-        Some("v0.5.6")
-    } else if schema_url.contains("v0.5.5") {
-        Some("v0.5.5")
-    } else if schema_url.contains("v0.5.4") {
-        Some("v0.5.4")
-    } else if schema_url.contains("v0.5.3") {
-        Some("v0.5.3")
-    } else if schema_url.contains("v0.5.2") {
-        Some("v0.5.2")
-    } else if schema_url.contains("v0.5.1") {
-        Some("v0.5.1")
-    } else if schema_url.contains("v0.5.0") {
-        Some("v0.5.0")
-    } else if schema_url.contains("v0.4.0") {
-        Some("v0.4.0")
-    } else if schema_url.contains("v0.3.2") {
-        Some("v0.3.2")
-    } else if schema_url.contains("v0.3.1") {
-        Some("v0.3.1")
-    } else if schema_url.contains("v0.3.0") {
-        Some("v0.3.0")
-    } else if schema_url.contains("v0.2.0") {
-        Some("v0.2.0")
-    } else {
-        None
-    }
-}
+use regelrecht_engine::schema::{detect_version, load_schemas, validation_errors};
 
 fn main() {
     let args: Vec<String> = std::env::args().skip(1).collect();
@@ -147,20 +57,18 @@ fn main() {
         let schema_ok = match version {
             Some(ver) => {
                 let schema = &schemas[ver];
-                match Validator::new(schema) {
-                    Ok(validator) => {
-                        let errors: Vec<_> = validator.iter_errors(&value).collect();
-                        if errors.is_empty() {
-                            eprintln!("OK: {} (schema {ver})", path.display());
-                            true
-                        } else {
-                            eprintln!("FAIL: {}: schema ({ver})", path.display());
-                            for error in &errors {
-                                eprintln!("  - {}: {}", error.instance_path(), error);
-                            }
-                            failed = true;
-                            false
+                match validation_errors(schema, &value) {
+                    Ok(errors) if errors.is_empty() => {
+                        eprintln!("OK: {} (schema {ver})", path.display());
+                        true
+                    }
+                    Ok(errors) => {
+                        eprintln!("FAIL: {}: schema ({ver})", path.display());
+                        for error in &errors {
+                            eprintln!("  - {error}");
                         }
+                        failed = true;
+                        false
                     }
                     Err(e) => {
                         eprintln!(

--- a/packages/engine/src/lib.rs
+++ b/packages/engine/src/lib.rs
@@ -37,6 +37,8 @@ pub mod operations;
 pub mod priority;
 pub mod receipt;
 pub mod resolver;
+#[cfg(feature = "validate")]
+pub mod schema;
 pub mod service;
 pub mod trace;
 pub mod types;

--- a/packages/engine/src/schema.rs
+++ b/packages/engine/src/schema.rs
@@ -113,3 +113,41 @@ pub fn validation_errors(
         .map(|error| format!("{}: {error}", error.instance_path()))
         .collect())
 }
+
+/// All embedded schemas compiled once, keyed by version. Built lazily on first
+/// use and cached for the process — callers validating many documents (e.g. the
+/// conformance suite over the whole corpus) avoid recompiling the schema per
+/// call. `Err` means a schema failed to load or compile.
+fn compiled_validators() -> &'static Result<HashMap<&'static str, Validator>, String> {
+    static CACHE: std::sync::OnceLock<Result<HashMap<&'static str, Validator>, String>> =
+        std::sync::OnceLock::new();
+    CACHE.get_or_init(|| {
+        let schemas = load_schemas()?;
+        let mut validators = HashMap::with_capacity(schemas.len());
+        for (version, schema) in &schemas {
+            let validator =
+                Validator::new(schema).map_err(|e| format!("compile schema {version}: {e}"))?;
+            validators.insert(*version, validator);
+        }
+        Ok(validators)
+    })
+}
+
+/// Validate `value` against the cached validator for `version`, returning the
+/// validation errors as formatted `"{instance_path}: {message}"` strings (empty
+/// == valid). Unlike [`validation_errors`], the validator is compiled once and
+/// reused across calls. `Err` means the version is unknown or a schema failed to
+/// compile.
+pub fn validation_errors_for(
+    version: &str,
+    value: &serde_json::Value,
+) -> Result<Vec<String>, String> {
+    let validators = compiled_validators().as_ref().map_err(String::clone)?;
+    let validator = validators
+        .get(version)
+        .ok_or_else(|| format!("unknown schema version {version}"))?;
+    Ok(validator
+        .iter_errors(value)
+        .map(|error| format!("{}: {error}", error.instance_path()))
+        .collect())
+}

--- a/packages/engine/src/schema.rs
+++ b/packages/engine/src/schema.rs
@@ -1,0 +1,115 @@
+//! Embedded JSON Schemas + version detection, shared by the `validate` binary
+//! and the schema↔model conformance test suite.
+//!
+//! Only compiled with the `validate` feature (which pulls in `jsonschema`).
+//! Keeping the schema-loading list and version detection here means there is a
+//! single copy of the 12-version `include_str!` table — see the CI guard
+//! "Check schema versions registered in schema.rs" which greps this file.
+
+use std::collections::HashMap;
+
+use jsonschema::Validator;
+
+/// Embedded schemas keyed by their `$id` URL suffix (version path).
+///
+/// These are compiled-in from the repo's schema/ directory and are guaranteed
+/// to be valid JSON at build time.
+pub fn load_schemas() -> Result<HashMap<&'static str, serde_json::Value>, String> {
+    let mut schemas = HashMap::new();
+    let v020: serde_json::Value =
+        serde_json::from_str(include_str!("../../../schema/v0.2.0/schema.json"))
+            .map_err(|e| format!("invalid v0.2.0 schema JSON: {e}"))?;
+    let v030: serde_json::Value =
+        serde_json::from_str(include_str!("../../../schema/v0.3.0/schema.json"))
+            .map_err(|e| format!("invalid v0.3.0 schema JSON: {e}"))?;
+    let v031: serde_json::Value =
+        serde_json::from_str(include_str!("../../../schema/v0.3.1/schema.json"))
+            .map_err(|e| format!("invalid v0.3.1 schema JSON: {e}"))?;
+    let v032: serde_json::Value =
+        serde_json::from_str(include_str!("../../../schema/v0.3.2/schema.json"))
+            .map_err(|e| format!("invalid v0.3.2 schema JSON: {e}"))?;
+    let v040: serde_json::Value =
+        serde_json::from_str(include_str!("../../../schema/v0.4.0/schema.json"))
+            .map_err(|e| format!("invalid v0.4.0 schema JSON: {e}"))?;
+    let v050: serde_json::Value =
+        serde_json::from_str(include_str!("../../../schema/v0.5.0/schema.json"))
+            .map_err(|e| format!("invalid v0.5.0 schema JSON: {e}"))?;
+    let v051: serde_json::Value =
+        serde_json::from_str(include_str!("../../../schema/v0.5.1/schema.json"))
+            .map_err(|e| format!("invalid v0.5.1 schema JSON: {e}"))?;
+    let v052: serde_json::Value =
+        serde_json::from_str(include_str!("../../../schema/v0.5.2/schema.json"))
+            .map_err(|e| format!("invalid v0.5.2 schema JSON: {e}"))?;
+    let v053: serde_json::Value =
+        serde_json::from_str(include_str!("../../../schema/v0.5.3/schema.json"))
+            .map_err(|e| format!("invalid v0.5.3 schema JSON: {e}"))?;
+    let v054: serde_json::Value =
+        serde_json::from_str(include_str!("../../../schema/v0.5.4/schema.json"))
+            .map_err(|e| format!("invalid v0.5.4 schema JSON: {e}"))?;
+    let v055: serde_json::Value =
+        serde_json::from_str(include_str!("../../../schema/v0.5.5/schema.json"))
+            .map_err(|e| format!("invalid v0.5.5 schema JSON: {e}"))?;
+    let v056: serde_json::Value =
+        serde_json::from_str(include_str!("../../../schema/v0.5.6/schema.json"))
+            .map_err(|e| format!("invalid v0.5.6 schema JSON: {e}"))?;
+    schemas.insert("v0.2.0", v020);
+    schemas.insert("v0.3.0", v030);
+    schemas.insert("v0.3.1", v031);
+    schemas.insert("v0.3.2", v032);
+    schemas.insert("v0.4.0", v040);
+    schemas.insert("v0.5.0", v050);
+    schemas.insert("v0.5.1", v051);
+    schemas.insert("v0.5.2", v052);
+    schemas.insert("v0.5.3", v053);
+    schemas.insert("v0.5.4", v054);
+    schemas.insert("v0.5.5", v055);
+    schemas.insert("v0.5.6", v056);
+    Ok(schemas)
+}
+
+/// Detect schema version from the `$schema` field in the YAML document.
+pub fn detect_version(value: &serde_json::Value) -> Option<&'static str> {
+    let schema_url = value.get("$schema")?.as_str()?;
+    if schema_url.contains("v0.5.6") {
+        Some("v0.5.6")
+    } else if schema_url.contains("v0.5.5") {
+        Some("v0.5.5")
+    } else if schema_url.contains("v0.5.4") {
+        Some("v0.5.4")
+    } else if schema_url.contains("v0.5.3") {
+        Some("v0.5.3")
+    } else if schema_url.contains("v0.5.2") {
+        Some("v0.5.2")
+    } else if schema_url.contains("v0.5.1") {
+        Some("v0.5.1")
+    } else if schema_url.contains("v0.5.0") {
+        Some("v0.5.0")
+    } else if schema_url.contains("v0.4.0") {
+        Some("v0.4.0")
+    } else if schema_url.contains("v0.3.2") {
+        Some("v0.3.2")
+    } else if schema_url.contains("v0.3.1") {
+        Some("v0.3.1")
+    } else if schema_url.contains("v0.3.0") {
+        Some("v0.3.0")
+    } else if schema_url.contains("v0.2.0") {
+        Some("v0.2.0")
+    } else {
+        None
+    }
+}
+
+/// Validate `value` against `schema`, returning the validation errors as
+/// formatted `"{instance_path}: {message}"` strings. An empty vec means the
+/// document is valid. `Err` is only returned when the schema itself fails to
+/// compile.
+pub fn validation_errors(
+    schema: &serde_json::Value,
+    value: &serde_json::Value,
+) -> Result<Vec<String>, String> {
+    let validator = Validator::new(schema).map_err(|e| e.to_string())?;
+    Ok(validator
+        .iter_errors(value)
+        .map(|error| format!("{}: {error}", error.instance_path()))
+        .collect())
+}

--- a/packages/engine/src/schema.rs
+++ b/packages/engine/src/schema.rs
@@ -10,93 +10,60 @@ use std::collections::HashMap;
 
 use jsonschema::Validator;
 
+/// Single source of truth for the embedded schema versions.
+///
+/// `include_str!` requires a literal path, so the version list can't be a
+/// runtime array — it lives here as a macro that hands the list to a callback
+/// macro. `load_schemas` and `detect_version` are both driven from it, so
+/// adding a schema version is a one-line change. The individual `"vX.Y.Z"`
+/// string literals also satisfy the CI guard "Check schema versions registered
+/// in schema.rs", which greps this file for each `schema/vX.Y.Z/` directory.
+macro_rules! with_schema_versions {
+    ($callback:ident) => {
+        $callback! {
+            "v0.2.0", "v0.3.0", "v0.3.1", "v0.3.2", "v0.4.0", "v0.5.0",
+            "v0.5.1", "v0.5.2", "v0.5.3", "v0.5.4", "v0.5.5", "v0.5.6",
+        }
+    };
+}
+
 /// Embedded schemas keyed by their `$id` URL suffix (version path).
 ///
 /// These are compiled-in from the repo's schema/ directory and are guaranteed
 /// to be valid JSON at build time.
 pub fn load_schemas() -> Result<HashMap<&'static str, serde_json::Value>, String> {
-    let mut schemas = HashMap::new();
-    let v020: serde_json::Value =
-        serde_json::from_str(include_str!("../../../schema/v0.2.0/schema.json"))
-            .map_err(|e| format!("invalid v0.2.0 schema JSON: {e}"))?;
-    let v030: serde_json::Value =
-        serde_json::from_str(include_str!("../../../schema/v0.3.0/schema.json"))
-            .map_err(|e| format!("invalid v0.3.0 schema JSON: {e}"))?;
-    let v031: serde_json::Value =
-        serde_json::from_str(include_str!("../../../schema/v0.3.1/schema.json"))
-            .map_err(|e| format!("invalid v0.3.1 schema JSON: {e}"))?;
-    let v032: serde_json::Value =
-        serde_json::from_str(include_str!("../../../schema/v0.3.2/schema.json"))
-            .map_err(|e| format!("invalid v0.3.2 schema JSON: {e}"))?;
-    let v040: serde_json::Value =
-        serde_json::from_str(include_str!("../../../schema/v0.4.0/schema.json"))
-            .map_err(|e| format!("invalid v0.4.0 schema JSON: {e}"))?;
-    let v050: serde_json::Value =
-        serde_json::from_str(include_str!("../../../schema/v0.5.0/schema.json"))
-            .map_err(|e| format!("invalid v0.5.0 schema JSON: {e}"))?;
-    let v051: serde_json::Value =
-        serde_json::from_str(include_str!("../../../schema/v0.5.1/schema.json"))
-            .map_err(|e| format!("invalid v0.5.1 schema JSON: {e}"))?;
-    let v052: serde_json::Value =
-        serde_json::from_str(include_str!("../../../schema/v0.5.2/schema.json"))
-            .map_err(|e| format!("invalid v0.5.2 schema JSON: {e}"))?;
-    let v053: serde_json::Value =
-        serde_json::from_str(include_str!("../../../schema/v0.5.3/schema.json"))
-            .map_err(|e| format!("invalid v0.5.3 schema JSON: {e}"))?;
-    let v054: serde_json::Value =
-        serde_json::from_str(include_str!("../../../schema/v0.5.4/schema.json"))
-            .map_err(|e| format!("invalid v0.5.4 schema JSON: {e}"))?;
-    let v055: serde_json::Value =
-        serde_json::from_str(include_str!("../../../schema/v0.5.5/schema.json"))
-            .map_err(|e| format!("invalid v0.5.5 schema JSON: {e}"))?;
-    let v056: serde_json::Value =
-        serde_json::from_str(include_str!("../../../schema/v0.5.6/schema.json"))
-            .map_err(|e| format!("invalid v0.5.6 schema JSON: {e}"))?;
-    schemas.insert("v0.2.0", v020);
-    schemas.insert("v0.3.0", v030);
-    schemas.insert("v0.3.1", v031);
-    schemas.insert("v0.3.2", v032);
-    schemas.insert("v0.4.0", v040);
-    schemas.insert("v0.5.0", v050);
-    schemas.insert("v0.5.1", v051);
-    schemas.insert("v0.5.2", v052);
-    schemas.insert("v0.5.3", v053);
-    schemas.insert("v0.5.4", v054);
-    schemas.insert("v0.5.5", v055);
-    schemas.insert("v0.5.6", v056);
-    Ok(schemas)
+    macro_rules! load {
+        ($($version:literal),* $(,)?) => {{
+            let mut schemas = HashMap::new();
+            $(
+                let schema: serde_json::Value = serde_json::from_str(include_str!(
+                    concat!("../../../schema/", $version, "/schema.json")
+                ))
+                .map_err(|e| format!("invalid {} schema JSON: {e}", $version))?;
+                schemas.insert($version, schema);
+            )*
+            schemas
+        }};
+    }
+    Ok(with_schema_versions!(load))
 }
 
 /// Detect schema version from the `$schema` field in the YAML document.
 pub fn detect_version(value: &serde_json::Value) -> Option<&'static str> {
     let schema_url = value.get("$schema")?.as_str()?;
-    if schema_url.contains("v0.5.6") {
-        Some("v0.5.6")
-    } else if schema_url.contains("v0.5.5") {
-        Some("v0.5.5")
-    } else if schema_url.contains("v0.5.4") {
-        Some("v0.5.4")
-    } else if schema_url.contains("v0.5.3") {
-        Some("v0.5.3")
-    } else if schema_url.contains("v0.5.2") {
-        Some("v0.5.2")
-    } else if schema_url.contains("v0.5.1") {
-        Some("v0.5.1")
-    } else if schema_url.contains("v0.5.0") {
-        Some("v0.5.0")
-    } else if schema_url.contains("v0.4.0") {
-        Some("v0.4.0")
-    } else if schema_url.contains("v0.3.2") {
-        Some("v0.3.2")
-    } else if schema_url.contains("v0.3.1") {
-        Some("v0.3.1")
-    } else if schema_url.contains("v0.3.0") {
-        Some("v0.3.0")
-    } else if schema_url.contains("v0.2.0") {
-        Some("v0.2.0")
-    } else {
-        None
+    macro_rules! detect {
+        ($($version:literal),* $(,)?) => {
+            // Version strings are mutually non-substring, so match order is
+            // irrelevant to correctness.
+            $(
+                if schema_url.contains($version) {
+                    return Some($version);
+                }
+            )*
+        };
     }
+    with_schema_versions!(detect);
+    None
 }
 
 /// Validate `value` against `schema`, returning the validation errors as

--- a/packages/engine/tests/conformance.rs
+++ b/packages/engine/tests/conformance.rs
@@ -15,11 +15,10 @@
 //!   - Tier B — synthetic fixtures exercising constructs the corpus may not hit.
 #![cfg(feature = "validate")]
 
-use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use regelrecht_engine::article::{ArticleBasedLaw, LawLoad};
-use regelrecht_engine::schema::{detect_version, load_schemas, validation_errors};
+use regelrecht_engine::schema::{detect_version, validation_errors_for};
 use serde_json::Value;
 use walkdir::WalkDir;
 
@@ -67,8 +66,8 @@ fn normalize(value: &Value) -> Value {
     }
 }
 
-fn schema_accepts(schemas: &HashMap<&str, Value>, version: &str, value: &Value) -> bool {
-    matches!(validation_errors(&schemas[version], value), Ok(errs) if errs.is_empty())
+fn schema_accepts(version: &str, value: &Value) -> bool {
+    matches!(validation_errors_for(version, value), Ok(errs) if errs.is_empty())
 }
 
 /// Tier A — every real corpus law must round-trip through schema ⋂ model.
@@ -81,7 +80,6 @@ fn schema_accepts(schemas: &HashMap<&str, Value>, version: &str, value: &Value) 
 #[test]
 fn tier_a_corpus_differential() {
     let root = repo_root();
-    let schemas = load_schemas().expect("load embedded schemas");
     let corpus = root.join("corpus/regulation");
 
     let mut checked = 0usize;
@@ -109,7 +107,7 @@ fn tier_a_corpus_differential() {
             .to_string();
 
         // (1) schema accepts the published law.
-        let errs = validation_errors(&schemas[version], &value).expect("compile schema");
+        let errs = validation_errors_for(version, &value).expect("compile schema");
         if !errs.is_empty() {
             hard_failures.push(format!(
                 "{rel}: schema {version} rejected a corpus law: {errs:?}"
@@ -131,7 +129,7 @@ fn tier_a_corpus_differential() {
         // `null` ≡ absent for an optional field — normalizing isolates real
         // structural problems from that serialization quirk.
         let reserialized = normalize(&serde_json::to_value(&law).expect("serialize model"));
-        if !validation_errors(&schemas[version], &reserialized)
+        if !validation_errors_for(version, &reserialized)
             .expect("compile schema")
             .is_empty()
         {
@@ -174,7 +172,6 @@ fn tier_a_corpus_differential() {
 ///              listed fixture the model now rejects must be removed.
 #[test]
 fn tier_b_fixtures() {
-    let schemas = load_schemas().expect("load embedded schemas");
     let base = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/conformance");
 
     // valid/
@@ -186,18 +183,18 @@ fn tier_b_fixtures() {
             .unwrap_or_else(|| panic!("valid fixture {name} lacks a recognised $schema"));
 
         assert!(
-            schema_accepts(&schemas, version, &value),
+            schema_accepts(version, &value),
             "valid fixture {name}: schema {version} should accept it but did not: {:?}",
-            validation_errors(&schemas[version], &value).unwrap()
+            validation_errors_for(version, &value).unwrap()
         );
         let law = ArticleBasedLaw::from_yaml_str(&content)
             .unwrap_or_else(|e| panic!("valid fixture {name}: model should parse it: {e}"));
         // Normalize away `null`-for-None before re-validating (see Tier A note).
         let reserialized = normalize(&serde_json::to_value(&law).expect("serialize"));
         assert!(
-            schema_accepts(&schemas, version, &reserialized),
+            schema_accepts(version, &reserialized),
             "valid fixture {name}: re-serialized model no longer schema-valid: {:?}",
-            validation_errors(&schemas[version], &reserialized).unwrap()
+            validation_errors_for(version, &reserialized).unwrap()
         );
     }
 
@@ -216,7 +213,7 @@ fn tier_b_fixtures() {
             .unwrap_or_else(|| panic!("invalid fixture {name} lacks a recognised $schema"));
 
         assert!(
-            !schema_accepts(&schemas, version, &value),
+            !schema_accepts(version, &value),
             "invalid fixture {name}: schema {version} unexpectedly accepted it — fixture is not actually invalid"
         );
 

--- a/packages/engine/tests/conformance.rs
+++ b/packages/engine/tests/conformance.rs
@@ -1,0 +1,267 @@
+//! Schema ↔ law-model conformance suite.
+//!
+//! The canonical, hand-authored `schema/*/schema.json` is the public contract
+//! for the law-YAML format; the Rust `law-model` is one implementation that must
+//! provably *conform* to it. This suite proves that — it is the structural twin
+//! of the BDD bucket-B engine-conformance suite (which proves an engine speaks
+//! the whole language behaviourally).
+//!
+//! Only built with the `validate` feature (which pulls in `jsonschema` via
+//! `regelrecht_engine::schema`). Run with `just conformance`. See
+//! `tests/conformance/README.md` for the contract and how to add fixtures.
+//!
+//! Two tiers (mirroring BDD bucket-A/B):
+//!   - Tier A — differential over the real corpus + a roundtrip fidelity report.
+//!   - Tier B — synthetic fixtures exercising constructs the corpus may not hit.
+#![cfg(feature = "validate")]
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use regelrecht_engine::article::{ArticleBasedLaw, LawLoad};
+use regelrecht_engine::schema::{detect_version, load_schemas, validation_errors};
+use serde_json::Value;
+use walkdir::WalkDir;
+
+/// Invalid (schema-rejected) Tier-B fixtures that the lenient `law-model`
+/// currently *accepts* anyway — i.e. the model is more permissive than the
+/// schema for these. This list IS the Phase-1 measurement of the soundness gap;
+/// each entry is a candidate to resolve in Phase 2 (tighten the model, or
+/// consciously declare the model lenient). Keep it in sync: an undocumented gap
+/// fails the suite, and so does a stale entry the model now rejects.
+const KNOWN_GAPS: &[&str] = &[
+    // Measured 2026-06-30 (Phase-1 MVP). The lenient `law-model` accepts these
+    // three schema-rejected shapes; only `bad_regulatory_layer` is conformant
+    // (the model rejects an unknown enum variant).
+    "missing_required_url.yaml", // schema requires top-level `url`; model treats it as optional
+    "unknown_field_in_article.yaml", // article is additionalProperties:false; serde silently drops the field
+    "wrong_type_publication_date.yaml", // schema wants a date string; model coerces the YAML integer
+];
+
+/// Repo root, derived from this crate's manifest dir (`packages/engine`).
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("resolve repo root")
+}
+
+/// Recursively sort object keys and drop nulls, so two structurally-equal
+/// documents compare equal regardless of key order or omitted-vs-null noise.
+fn normalize(value: &Value) -> Value {
+    match value {
+        Value::Object(map) => {
+            let mut keys: Vec<&String> = map.keys().collect();
+            keys.sort();
+            let mut out = serde_json::Map::new();
+            for k in keys {
+                let nv = normalize(&map[k]);
+                if !nv.is_null() {
+                    out.insert(k.clone(), nv);
+                }
+            }
+            Value::Object(out)
+        }
+        Value::Array(items) => Value::Array(items.iter().map(normalize).collect()),
+        other => other.clone(),
+    }
+}
+
+fn schema_accepts(schemas: &HashMap<&str, Value>, version: &str, value: &Value) -> bool {
+    matches!(validation_errors(&schemas[version], value), Ok(errs) if errs.is_empty())
+}
+
+/// Tier A — every real corpus law must round-trip through schema ⋂ model.
+///
+/// Hard assertions (already guaranteed by the `just validate` CI gate, made
+/// explicit here): every corpus law with a recognised `$schema` is accepted by
+/// that schema (1) and parses into the model (2). Reported, non-fatal in this
+/// MVP: whether the re-serialized model is still schema-valid (3) and value-
+/// stable (4) — these quantify lossy serialization for the Phase-2 decision.
+#[test]
+fn tier_a_corpus_differential() {
+    let root = repo_root();
+    let schemas = load_schemas().expect("load embedded schemas");
+    let corpus = root.join("corpus/regulation");
+
+    let mut checked = 0usize;
+    let mut hard_failures: Vec<String> = Vec::new();
+    let mut not_revalid: Vec<String> = Vec::new();
+    let mut value_drift: Vec<String> = Vec::new();
+
+    for entry in WalkDir::new(&corpus).into_iter().filter_map(Result::ok) {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("yaml") {
+            continue;
+        }
+        let content = std::fs::read_to_string(path).expect("read corpus file");
+        let Ok(mut value) = serde_yaml_ng::from_str::<Value>(&content) else {
+            continue; // not a YAML mapping we can reason about
+        };
+        let Some(version) = detect_version(&value) else {
+            continue; // no/unknown $schema → not a versioned law document
+        };
+        checked += 1;
+        let rel = path
+            .strip_prefix(&root)
+            .unwrap_or(path)
+            .display()
+            .to_string();
+
+        // (1) schema accepts the published law.
+        let errs = validation_errors(&schemas[version], &value).expect("compile schema");
+        if !errs.is_empty() {
+            hard_failures.push(format!(
+                "{rel}: schema {version} rejected a corpus law: {errs:?}"
+            ));
+            continue;
+        }
+        // (2) model parses the schema-valid law.
+        let law = match ArticleBasedLaw::from_yaml_str(&content) {
+            Ok(law) => law,
+            Err(e) => {
+                hard_failures.push(format!(
+                    "{rel}: model failed to parse a schema-valid law: {e}"
+                ));
+                continue;
+            }
+        };
+        // (3) re-serialized model still schema-valid (reported). Normalize first:
+        // the model emits `None` as explicit `null` (no skip_serializing_if), and
+        // `null` ≡ absent for an optional field — normalizing isolates real
+        // structural problems from that serialization quirk.
+        let reserialized = normalize(&serde_json::to_value(&law).expect("serialize model"));
+        if !validation_errors(&schemas[version], &reserialized)
+            .expect("compile schema")
+            .is_empty()
+        {
+            not_revalid.push(rel.clone());
+        }
+        // (4) value-stability (reported): compare modulo $schema meta + key order.
+        if let Value::Object(map) = &mut value {
+            map.remove("$schema");
+        }
+        if normalize(&value) != reserialized {
+            value_drift.push(rel);
+        }
+    }
+
+    eprintln!(
+        "Tier A: checked {checked} corpus laws | reported: {} not-revalidating, {} value-drift",
+        not_revalid.len(),
+        value_drift.len()
+    );
+    for r in &not_revalid {
+        eprintln!("  not-revalidating: {r}");
+    }
+    for r in &value_drift {
+        eprintln!("  value-drift: {r}");
+    }
+
+    assert!(checked > 0, "no corpus laws checked — corpus path wrong?");
+    assert!(
+        hard_failures.is_empty(),
+        "Tier A hard failures (schema⋂model disagreement on real laws):\n{}",
+        hard_failures.join("\n")
+    );
+}
+
+/// Tier B — synthetic fixtures exercising constructs the corpus may not hit.
+///
+/// `valid/`   : schema accepts ∧ model parses ∧ re-serialized still schema-valid.
+/// `invalid/` : schema rejects (asserted). The model verdict is measured: a
+///              wrongly-accepted fixture must be listed in `KNOWN_GAPS`, and a
+///              listed fixture the model now rejects must be removed.
+#[test]
+fn tier_b_fixtures() {
+    let schemas = load_schemas().expect("load embedded schemas");
+    let base = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/conformance");
+
+    // valid/
+    for path in fixtures_in(&base.join("valid")) {
+        let name = path.file_name().unwrap().to_string_lossy().to_string();
+        let content = std::fs::read_to_string(&path).expect("read fixture");
+        let value: Value = serde_yaml_ng::from_str(&content).expect("fixture is YAML");
+        let version = detect_version(&value)
+            .unwrap_or_else(|| panic!("valid fixture {name} lacks a recognised $schema"));
+
+        assert!(
+            schema_accepts(&schemas, version, &value),
+            "valid fixture {name}: schema {version} should accept it but did not: {:?}",
+            validation_errors(&schemas[version], &value).unwrap()
+        );
+        let law = ArticleBasedLaw::from_yaml_str(&content)
+            .unwrap_or_else(|e| panic!("valid fixture {name}: model should parse it: {e}"));
+        // Normalize away `null`-for-None before re-validating (see Tier A note).
+        let reserialized = normalize(&serde_json::to_value(&law).expect("serialize"));
+        assert!(
+            schema_accepts(&schemas, version, &reserialized),
+            "valid fixture {name}: re-serialized model no longer schema-valid: {:?}",
+            validation_errors(&schemas[version], &reserialized).unwrap()
+        );
+    }
+
+    // invalid/
+    let mut undocumented: Vec<String> = Vec::new();
+    let mut stale: Vec<String> = Vec::new();
+    let mut documented = 0usize;
+    let mut conformant = 0usize;
+    let mut seen: Vec<String> = Vec::new();
+    for path in fixtures_in(&base.join("invalid")) {
+        let name = path.file_name().unwrap().to_string_lossy().to_string();
+        seen.push(name.clone());
+        let content = std::fs::read_to_string(&path).expect("read fixture");
+        let value: Value = serde_yaml_ng::from_str(&content).expect("fixture is YAML");
+        let version = detect_version(&value)
+            .unwrap_or_else(|| panic!("invalid fixture {name} lacks a recognised $schema"));
+
+        assert!(
+            !schema_accepts(&schemas, version, &value),
+            "invalid fixture {name}: schema {version} unexpectedly accepted it — fixture is not actually invalid"
+        );
+
+        let model_accepts = ArticleBasedLaw::from_yaml_str(&content).is_ok();
+        let listed = KNOWN_GAPS.contains(&name.as_str());
+        match (model_accepts, listed) {
+            (true, false) => undocumented.push(name), // new soundness gap
+            (false, true) => stale.push(name),        // gap closed, list is stale
+            (false, false) => conformant += 1,        // model agrees with schema
+            (true, true) => documented += 1,          // documented gap
+        }
+    }
+
+    // Every KNOWN_GAPS entry must name a real invalid/ fixture, else a typo'd or
+    // orphaned entry rots silently (it can never be flagged stale/undocumented).
+    let orphaned: Vec<&&str> = KNOWN_GAPS
+        .iter()
+        .filter(|g| !seen.contains(&g.to_string()))
+        .collect();
+
+    eprintln!(
+        "Tier B: invalid fixtures — {conformant} conformant (model also rejects), {documented} documented gaps"
+    );
+
+    assert!(
+        orphaned.is_empty(),
+        "KNOWN_GAPS entries with no matching invalid/ fixture (remove or fix the filename): {orphaned:?}"
+    );
+    assert!(
+        undocumented.is_empty(),
+        "soundness gap(s) not documented in KNOWN_GAPS (model accepts what the schema rejects): {undocumented:?}"
+    );
+    assert!(
+        stale.is_empty(),
+        "stale KNOWN_GAPS entries — model now rejects these, remove them from KNOWN_GAPS: {stale:?}"
+    );
+}
+
+fn fixtures_in(dir: &Path) -> Vec<PathBuf> {
+    let mut out: Vec<PathBuf> = std::fs::read_dir(dir)
+        .unwrap_or_else(|e| panic!("read fixture dir {}: {e}", dir.display()))
+        .filter_map(Result::ok)
+        .map(|e| e.path())
+        .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("yaml"))
+        .collect();
+    out.sort();
+    out
+}

--- a/packages/engine/tests/conformance/README.md
+++ b/packages/engine/tests/conformance/README.md
@@ -1,0 +1,52 @@
+# Schema ↔ law-model conformance suite
+
+The canonical, hand-authored `schema/*/schema.json` is the **public, language-agnostic
+contract** for the law-YAML format — what a third-party engine author reads to know what a
+valid law is, and what `just validate` enforces. The Rust `law-model` (`packages/law-model/`)
+is *one* implementation that must provably **conform** to that contract. This suite proves it.
+
+It is the structural twin of the BDD bucket-B engine-conformance suite (`bdd/conformance/`):
+bucket-B proves an engine speaks the whole language *behaviourally*; this proves the model
+accepts exactly the whole language *structurally*.
+
+Run it with `just conformance` (it needs the engine's `validate` feature, which pulls in
+`jsonschema`). The test lives in `packages/engine/tests/conformance.rs`.
+
+## The contract
+
+For every candidate law document `d`, with schema-valid set `S` and model-parseable set `M`:
+
+- **Soundness** — `d ∈ M ⇒ d ∈ S`. If the model parses it, the schema accepts it
+  (the model is not *more permissive* than the spec).
+- **Completeness** — `d ∈ S ⇒ d ∈ M`, losslessly. If the schema accepts it, the model parses
+  it and a re-serialize round-trips to a schema-valid, value-equal document (the model is not
+  *more restrictive*, and does not silently drop data).
+
+## Two tiers
+
+- **Tier A — corpus differential** (`tier_a_corpus_differential`). Walks every
+  `corpus/regulation/**/*.yaml` with a recognised `$schema`. Hard assertions (also guaranteed
+  by the `just validate` CI gate, made explicit here): the schema accepts it and the model
+  parses it. **Reported, non-fatal**: whether the re-serialized model is still schema-valid and
+  value-stable — these quantify lossy serialization (the model emits `None` as `null`, etc.).
+- **Tier B — synthetic fixtures** (`tier_b_fixtures`), under `valid/` and `invalid/`. Each
+  fixture is a single, isolated construct.
+  - `valid/`: schema accepts ∧ model parses ∧ re-serialized (null-normalized) still schema-valid.
+  - `invalid/`: schema **rejects** (asserted). The model verdict is *measured* against `KNOWN_GAPS`.
+
+## `KNOWN_GAPS` (the measurement)
+
+The model has no `#[serde(deny_unknown_fields)]` and uses `#[serde(untagged)]` enums, so it is
+currently **more permissive** than the schema. `KNOWN_GAPS` in `conformance.rs` lists the
+`invalid/` fixtures the model *accepts* anyway — i.e. the soundness gap. The list is kept honest:
+an **undocumented** gap fails the suite, and a **stale** entry (the model now rejects it) also
+fails. Resolving these gaps (tighten the model vs. consciously declare it lenient) is a Phase-2
+decision driven by this measurement.
+
+## Adding a fixture
+
+1. Drop a `*.yaml` law document into `valid/` or `invalid/`. Give it a `$schema` line pinned to
+   the latest schema version and otherwise isolate the *one* construct under test (so a rejection
+   is attributable to it — mind conditional `required` rules, e.g. `WET` requires `bwb_id`).
+2. Run `just conformance`. For an `invalid/` fixture the model also accepts, add its filename to
+   `KNOWN_GAPS` with a one-line note on *why* the model is lenient.

--- a/packages/engine/tests/conformance/invalid/bad_regulatory_layer.yaml
+++ b/packages/engine/tests/conformance/invalid/bad_regulatory_layer.yaml
@@ -1,0 +1,10 @@
+---
+$schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/tags/schema-v0.5.6/schema/v0.5.6/schema.json
+$id: test_conformance_bad_layer
+regulatory_layer: NIET_BESTAANDE_LAAG
+publication_date: '2025-01-01'
+url: https://example.invalid/law
+articles:
+  - number: '1'
+    text: regulatory_layer is geen geldige enum-waarde.
+    url: https://example.invalid/law/artikel/1

--- a/packages/engine/tests/conformance/invalid/missing_required_url.yaml
+++ b/packages/engine/tests/conformance/invalid/missing_required_url.yaml
@@ -1,0 +1,10 @@
+---
+$schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/tags/schema-v0.5.6/schema/v0.5.6/schema.json
+$id: test_conformance_missing_url
+regulatory_layer: WET
+publication_date: '2025-01-01'
+bwb_id: BWBR0123456
+articles:
+  - number: '1'
+    text: Top-level url ontbreekt (schema vereist het).
+    url: https://example.invalid/law/artikel/1

--- a/packages/engine/tests/conformance/invalid/unknown_field_in_article.yaml
+++ b/packages/engine/tests/conformance/invalid/unknown_field_in_article.yaml
@@ -1,0 +1,12 @@
+---
+$schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/tags/schema-v0.5.6/schema/v0.5.6/schema.json
+$id: test_conformance_unknown_field
+regulatory_layer: WET
+publication_date: '2025-01-01'
+bwb_id: BWBR0123456
+url: https://example.invalid/law
+articles:
+  - number: '1'
+    text: Artikel met onbekend veld (article heeft additionalProperties false).
+    url: https://example.invalid/law/artikel/1
+    onbekend_veld: zou geweigerd moeten worden

--- a/packages/engine/tests/conformance/invalid/wrong_type_publication_date.yaml
+++ b/packages/engine/tests/conformance/invalid/wrong_type_publication_date.yaml
@@ -1,0 +1,11 @@
+---
+$schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/tags/schema-v0.5.6/schema/v0.5.6/schema.json
+$id: test_conformance_wrong_type
+regulatory_layer: WET
+publication_date: 20250101
+bwb_id: BWBR0123456
+url: https://example.invalid/law
+articles:
+  - number: '1'
+    text: publication_date is een getal in plaats van een datumstring.
+    url: https://example.invalid/law/artikel/1

--- a/packages/engine/tests/conformance/valid/minimal.yaml
+++ b/packages/engine/tests/conformance/valid/minimal.yaml
@@ -1,0 +1,11 @@
+---
+$schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/tags/schema-v0.5.6/schema/v0.5.6/schema.json
+$id: test_conformance_minimal
+regulatory_layer: WET
+publication_date: '2025-01-01'
+bwb_id: BWBR0123456
+url: https://example.invalid/law
+articles:
+  - number: '1'
+    text: Een testartikel.
+    url: https://example.invalid/law/artikel/1

--- a/packages/engine/tests/conformance/valid/with_optional_fields.yaml
+++ b/packages/engine/tests/conformance/valid/with_optional_fields.yaml
@@ -1,0 +1,13 @@
+---
+$schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/tags/schema-v0.5.6/schema/v0.5.6/schema.json
+$id: test_conformance_optionals
+regulatory_layer: MINISTERIELE_REGELING
+publication_date: '2024-12-20'
+valid_from: '2025-01-01'
+bwb_id: BWBR0099999
+name: Testregeling optionele velden
+url: https://example.invalid/law
+articles:
+  - number: '1'
+    text: Een testartikel met optionele topvelden.
+    url: https://example.invalid/law/artikel/1


### PR DESCRIPTION
## What & why

Advies 12 (schema-chain codegen), pipeline A: keep the canonical `schema/*/schema.json` and the Rust `law-model` from silently drifting.

After discussing the project's intent (engines should be buildable from the YAML format + RFCs and validated by BDD), we landed on **worldview Y: the schema is the canonical, language-agnostic contract and the engine *conforms* to it** — neither side is generated from the other. This PR adds a **schema↔model conformance suite**: the structural twin of the existing BDD bucket-A/B split (bucket-B proves an engine speaks the whole language *behaviourally*; this proves the model accepts exactly the whole language *structurally*).

This is the **Phase-1 MVP: measure the gap first**, before deciding whether to tighten the model.

## Changes

- **Phase 0 (DRY refactor):** extracted `load_schemas()` + `detect_version()` out of the `validate` binary into a reusable, feature-gated `engine::schema` module (plus a `validation_errors()` helper); rewired `bin/validate.rs` to use it. `just validate` output is unchanged (verified, incl. the schema-error format).
- **Phase 1 (suite):** `packages/engine/tests/conformance.rs` (gated behind the `validate` feature).
  - **Tier A — corpus differential:** every `corpus/regulation/**` law with a recognised `$schema` must schema-validate *and* model-parse (hard asserts — already guaranteed by the `just validate` gate, now explicit). Re-serialize roundtrip fidelity is *reported, non-fatal* (the MVP measurement).
  - **Tier B — synthetic fixtures** under `tests/conformance/{valid,invalid}/`, one isolated construct each, with a `KNOWN_GAPS` allowlist that honestly records where the lenient model accepts what the schema rejects.
- **Wiring:** `just conformance` recipe (the suite also runs via `just test`/`test-all` through `--all-features`); CI schema-version guard repointed to `schema.rs`.
- **Docs:** `tests/conformance/README.md` + a CLAUDE.md note. No RFC (by design).

## The measurement (drives the Phase-2 decision)

The schema has **no `additionalProperties: false` at the top level**, so the model isn't laxer there. The model *is* laxer than the schema in **3** concrete ways, now documented in `KNOWN_GAPS`:
1. missing required top-level `url` (model treats it as optional),
2. unknown field inside an `article` (article *is* `additionalProperties: false`; serde drops it),
3. `publication_date` as an integer (model coerces; schema wants a date string).

It correctly **rejects** an unknown `regulatory_layer` enum. Tier A: 25 corpus laws checked.

## Out of scope (follow-ups)

- **Phase 2** — decide, with this data, whether to tighten the model (`deny_unknown_fields` etc., gated on the corpus staying green) or consciously declare it lenient.
- **Pipeline B** (Rust↔TS DTOs) — separate cycle.

## Verification

`just conformance` green (Tier A 25 laws; Tier B 1 conformant, 3 documented gaps); `just validate` byte-identical; `cargo fmt`/clippy clean.