### PR TITLE
feat(editor): mint GitHub App tokens for traject repos

### DIFF
--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -2412,6 +2412,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64 0.22.1",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "kasuari"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3138,6 +3153,16 @@ name = "peg-runtime"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555b1514d2d99d78150d3c799d4c357a3e2c2a8062cd108e93a06d9057629c5"
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
+]
 
 [[package]]
 name = "pem-rfc7468"
@@ -3885,6 +3910,7 @@ dependencies = [
  "base64 0.22.1",
  "flate2",
  "jsonschema",
+ "jsonwebtoken",
  "regelrecht-engine",
  "regelrecht-law-model",
  "reqwest 0.13.2",
@@ -4768,6 +4794,18 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
+]
 
 [[package]]
 name = "siphasher"

--- a/packages/corpus/Cargo.toml
+++ b/packages/corpus/Cargo.toml
@@ -24,6 +24,7 @@ jsonschema = { version = "0.46", optional = true }
 base64 = { workspace = true, optional = true }
 flate2 = { version = "1", optional = true }
 tar = { version = "0.4", optional = true }
+jsonwebtoken = { version = "9", optional = true }
 walkdir.workspace = true
 
 [features]
@@ -32,7 +33,7 @@ default = ["github"]
 # JSON bodies and base64-encoded file contents, so `github` pulls both
 # in alongside reqwest. The implements-index bulk read downloads the repo
 # archive (tarball) in one request, so it also needs gzip + tar.
-github = ["dep:reqwest", "dep:serde_json", "dep:base64", "dep:flate2", "dep:tar"]
+github = ["dep:reqwest", "dep:serde_json", "dep:base64", "dep:flate2", "dep:tar", "dep:jsonwebtoken"]
 # Schema validation for note (annotation) YAML. Pulls in jsonschema; only
 # the editor-api write path needs it, so it stays optional.
 annotation-validation = ["dep:jsonschema", "dep:serde_json"]

--- a/packages/corpus/src/auth.rs
+++ b/packages/corpus/src/auth.rs
@@ -104,8 +104,22 @@ pub async fn resolve_token_async(
 ) -> Result<Option<String>> {
     if let Some(providers) = providers {
         if let Some(minter) = providers.minter_for(source) {
-            if let Some(token) = minter.token_for_source(source).await? {
-                return Ok(Some(token));
+            match minter.token_for_source(source).await {
+                Ok(Some(token)) => return Ok(Some(token)),
+                // The provider can't serve this source (not installed / repo
+                // not in the install) — fall through to the static chain.
+                Ok(None) => {}
+                // A provider failure (transient GitHub 5xx/429, mint error,
+                // expired key, …) must NOT hard-fail the source: the whole
+                // point of the hybrid is that the static env/file token keeps
+                // working. Log and fall through rather than propagate.
+                Err(e) => {
+                    tracing::warn!(
+                        source_id = %source.id,
+                        error = %e,
+                        "provider token mint failed; falling back to static token chain"
+                    );
+                }
             }
         }
     }
@@ -432,6 +446,19 @@ sources:
         }
     }
 
+    /// A minter that always errors, to prove a provider failure doesn't
+    /// hard-fail the source but falls through to the static chain.
+    struct FailingMinter;
+
+    #[async_trait::async_trait]
+    impl AppTokenMinter for FailingMinter {
+        async fn token_for_source(&self, _source: &Source) -> Result<Option<String>> {
+            Err(CorpusError::Git(
+                "simulated transient GitHub error".to_string(),
+            ))
+        }
+    }
+
     fn github_probe(id: &str) -> Source {
         Source {
             id: id.to_string(),
@@ -490,5 +517,23 @@ sources:
             .unwrap();
         unsafe { std::env::remove_var(key) };
         assert_eq!(got.as_deref(), Some("env-fallback-token"));
+    }
+
+    /// A provider *error* (transient GitHub failure, mint error) must not
+    /// hard-fail: the resolver logs and still falls through to the static
+    /// per-source env var instead of propagating the error.
+    #[tokio::test]
+    async fn resolve_token_async_falls_back_when_minter_errors() {
+        let key = "CORPUS_AUTH_PROVIDER_ERR_SRC_TOKEN";
+        unsafe { std::env::set_var(key, "env-after-error") };
+        let registry = ProviderAuthRegistry {
+            github: Some(Arc::new(FailingMinter)),
+        };
+        let src = github_probe("provider-err-src");
+        let got = resolve_token_async(&src, None, Some(&registry), true)
+            .await
+            .unwrap();
+        unsafe { std::env::remove_var(key) };
+        assert_eq!(got.as_deref(), Some("env-after-error"));
     }
 }

--- a/packages/corpus/src/auth.rs
+++ b/packages/corpus/src/auth.rs
@@ -1,6 +1,122 @@
 use std::path::Path;
+use std::sync::Arc;
 
 use crate::error::{CorpusError, Result};
+use crate::models::{Source, SourceType};
+
+/// Mints a short-lived, repo-scoped token for a source on demand, instead
+/// of relying on a long-lived stored PAT.
+///
+/// One implementation per VCS provider — today
+/// [`crate::github_app::GitHubAppAuth`] (GitHub App installation tokens).
+/// Kept as an abstract trait here (not behind the `github` feature) so the
+/// resolver, the [`ProviderAuthRegistry`] factory, and the editor-api
+/// state can refer to it without pulling in reqwest; the concrete,
+/// network-backed implementations live in their provider modules.
+///
+/// `token_for_source` returns `Ok(None)` when this provider can't serve
+/// the source — the source is a different provider's kind, or the app has
+/// no access (e.g. not installed on the owner). That's the signal for the
+/// caller to fall back to the static env/file token chain rather than
+/// fail.
+#[async_trait::async_trait]
+pub trait AppTokenMinter: Send + Sync {
+    async fn token_for_source(&self, source: &Source) -> Result<Option<String>>;
+}
+
+/// Factory + registry of per-provider credential minters.
+///
+/// Built once from the environment ([`ProviderAuthRegistry::from_env`]):
+/// each provider self-configures and is simply absent when its env isn't
+/// set. [`minter_for`](Self::minter_for) routes a source to its provider's
+/// minter by [`SourceType`], so adding GitLab (or any other provider)
+/// later is a new field + a new match arm here — call sites don't change.
+#[derive(Default, Clone)]
+pub struct ProviderAuthRegistry {
+    /// GitHub App minter. Other providers (GitLab, Azure DevOps, …) get
+    /// their own field here when implemented.
+    github: Option<Arc<dyn AppTokenMinter>>,
+}
+
+impl ProviderAuthRegistry {
+    /// Load every supported provider's minter from the environment. A
+    /// provider whose env isn't configured stays `None` (the source then
+    /// falls back to the static token chain). Errors only when a provider
+    /// is half-configured (e.g. GitHub app id set but key unreadable).
+    pub fn from_env() -> Result<Self> {
+        Ok(Self {
+            github: load_github_app_minter()?,
+        })
+    }
+
+    /// The minter for `source`'s provider, or `None` when that provider
+    /// has no app-auth configured / the source has no remote provider
+    /// (local).
+    pub fn minter_for(&self, source: &Source) -> Option<&dyn AppTokenMinter> {
+        match &source.source_type {
+            SourceType::GitHub { .. } => self.github.as_deref(),
+            SourceType::Local { .. } => None,
+        }
+    }
+
+    /// Whether any provider minter is configured — for startup logging so
+    /// operators can confirm the app-auth path is active.
+    pub fn is_configured(&self) -> bool {
+        self.github.is_some()
+    }
+}
+
+/// Build the GitHub App minter from the environment, or `None` when the
+/// app isn't configured. Gated on the `github` feature; without it the
+/// provider is simply unavailable.
+#[cfg(feature = "github")]
+fn load_github_app_minter() -> Result<Option<Arc<dyn AppTokenMinter>>> {
+    Ok(crate::github_app::GitHubAppAuth::from_env()?
+        .map(|a| Arc::new(a) as Arc<dyn AppTokenMinter>))
+}
+
+#[cfg(not(feature = "github"))]
+fn load_github_app_minter() -> Result<Option<Arc<dyn AppTokenMinter>>> {
+    Ok(None)
+}
+
+/// Resolve a token for a source, preferring a provider-minted short-lived
+/// token (GitHub App, …) when one is available, then the static env/file
+/// chain.
+///
+/// Resolution order:
+/// 0. **Provider minter** (`providers`) — routed by [`SourceType`]. Mints
+///    a short-lived, repo-scoped token; nothing long-lived is stored. A
+///    `None` from the minter (provider not configured / app not installed)
+///    falls through to the static chain.
+/// 1.–N. the static chain via [`resolve_token_strict`] (when `strict`) or
+///    [`resolve_token_for_source`] (otherwise).
+///
+/// `strict` mirrors the two static resolvers: pass `true` for any source
+/// whose lookup key is derived from untrusted input (the writable-own
+/// source of a traject), so an unknown key fails closed instead of
+/// leaking the legacy `CORPUS_GIT_TOKEN`.
+pub async fn resolve_token_async(
+    source: &Source,
+    auth_file: Option<&Path>,
+    providers: Option<&ProviderAuthRegistry>,
+    strict: bool,
+) -> Result<Option<String>> {
+    if let Some(providers) = providers {
+        if let Some(minter) = providers.minter_for(source) {
+            if let Some(token) = minter.token_for_source(source).await? {
+                return Ok(Some(token));
+            }
+        }
+    }
+
+    if strict {
+        let key = source.auth_ref.as_deref().unwrap_or(&source.id);
+        resolve_token_strict(key, auth_file)
+    } else {
+        resolve_token_for_source(&source.id, source.auth_ref.as_deref(), auth_file)
+    }
+}
 
 /// Construct the per-source token env-var name from a slug.
 ///
@@ -303,5 +419,76 @@ sources:
         let result = resolve_token_strict("strict-per-source-ok", None).unwrap();
         unsafe { std::env::remove_var(key) };
         assert_eq!(result, Some("per-source-value".to_string()));
+    }
+
+    /// A minter that returns a fixed answer, to exercise the resolver's
+    /// provider tier without a network call.
+    struct FakeMinter(Option<String>);
+
+    #[async_trait::async_trait]
+    impl AppTokenMinter for FakeMinter {
+        async fn token_for_source(&self, _source: &Source) -> Result<Option<String>> {
+            Ok(self.0.clone())
+        }
+    }
+
+    fn github_probe(id: &str) -> Source {
+        Source {
+            id: id.to_string(),
+            name: id.to_string(),
+            source_type: SourceType::GitHub {
+                github: crate::models::GitHubSource {
+                    owner: "acme".to_string(),
+                    repo: "corpus".to_string(),
+                    branch: "main".to_string(),
+                    path: None,
+                    git_ref: None,
+                },
+            },
+            scopes: Vec::new(),
+            priority: 0,
+            auth_ref: None,
+        }
+    }
+
+    /// A default (unconfigured) registry has no minter for any source, so
+    /// `resolve_token_async` behaves exactly like the static chain.
+    #[test]
+    fn default_registry_has_no_minter() {
+        let registry = ProviderAuthRegistry::default();
+        assert!(!registry.is_configured());
+        assert!(registry.minter_for(&github_probe("x")).is_none());
+    }
+
+    /// When a provider minter yields a token it wins over the static
+    /// env/file chain — the whole point of the app-auth tier.
+    #[tokio::test]
+    async fn resolve_token_async_prefers_provider_minter() {
+        let registry = ProviderAuthRegistry {
+            github: Some(Arc::new(FakeMinter(Some("minted-token".to_string())))),
+        };
+        let src = github_probe("provider-wins-src");
+        let got = resolve_token_async(&src, None, Some(&registry), true)
+            .await
+            .unwrap();
+        assert_eq!(got.as_deref(), Some("minted-token"));
+    }
+
+    /// When the minter declines (app not installed → `None`), the resolver
+    /// falls back to the static per-source env var. Uses a unique key, so
+    /// no `ENV_LOCK` and no legacy fallback are involved.
+    #[tokio::test]
+    async fn resolve_token_async_falls_back_when_minter_declines() {
+        let key = "CORPUS_AUTH_PROVIDER_FALLBACK_SRC_TOKEN";
+        unsafe { std::env::set_var(key, "env-fallback-token") };
+        let registry = ProviderAuthRegistry {
+            github: Some(Arc::new(FakeMinter(None))),
+        };
+        let src = github_probe("provider-fallback-src");
+        let got = resolve_token_async(&src, None, Some(&registry), true)
+            .await
+            .unwrap();
+        unsafe { std::env::remove_var(key) };
+        assert_eq!(got.as_deref(), Some("env-fallback-token"));
     }
 }

--- a/packages/corpus/src/github_app.rs
+++ b/packages/corpus/src/github_app.rs
@@ -78,6 +78,14 @@ mod inner {
         token: String,
     }
 
+    /// A cached token-resolution result with its expiry: `Some(token)` is a
+    /// live installation token, `None` the negative "repo not in this
+    /// install" verdict.
+    type CachedToken = (Option<String>, SystemTime);
+    /// A cached installation-lookup result with its expiry: `Some(id)` when
+    /// installed on the owner, `None` for the "not installed" verdict.
+    type CachedInstallation = (Option<u64>, SystemTime);
+
     /// Authenticates to GitHub as a GitHub App and mints short-lived
     /// per-repo installation tokens. Construct once at startup
     /// ([`GitHubAppAuth::from_env`]) and share via `Arc`.
@@ -93,11 +101,14 @@ mod inner {
         /// expiry ([`INSTALLATION_TTL`]) bounds how long that verdict (and a
         /// positive id, in case of uninstall+reinstall) is trusted. Keyed
         /// lowercase because GitHub owners are case-insensitive.
-        installations: Mutex<HashMap<String, (Option<u64>, SystemTime)>>,
-        /// (lowercased owner, lowercased repo) → (token, expiry). Keyed
-        /// lowercase because GitHub owner/repo names are case-insensitive,
-        /// so differently-cased references share one cached token.
-        tokens: Mutex<HashMap<(String, String), (String, SystemTime)>>,
+        installations: Mutex<HashMap<String, CachedInstallation>>,
+        /// (lowercased owner, lowercased repo) → (token-or-negative, expiry).
+        /// `Some(token)` is a live installation token; `None` is the negative
+        /// verdict "repo not in this install" (422), cached briefly so it
+        /// isn't re-minted on every call. Keyed lowercase because GitHub
+        /// owner/repo names are case-insensitive, so differently-cased
+        /// references share one cached entry.
+        tokens: Mutex<HashMap<(String, String), CachedToken>>,
     }
 
     impl GitHubAppAuth {
@@ -184,10 +195,12 @@ mod inner {
             // the original casing is still sent on the API calls below.
             let key = (owner.to_lowercase(), repo.to_lowercase());
 
-            // Serve a still-valid cached token without any network call.
-            if let Some((token, expiry)) = self.tokens.lock().await.get(&key) {
+            // Serve a still-valid cached result without any network call.
+            // A cached `None` is the negative verdict ("repo not in this
+            // install"); both are honoured until they expire.
+            if let Some((cached, expiry)) = self.tokens.lock().await.get(&key) {
                 if *expiry > SystemTime::now() {
-                    return Ok(Some(token.clone()));
+                    return Ok(cached.clone());
                 }
             }
 
@@ -198,15 +211,23 @@ mod inner {
             };
 
             // 422 (repo not in this installation's selected set) → the app
-            // can't serve this repo; fall back to the static chain.
+            // can't serve this repo; fall back to the static chain. Negative-
+            // cache it for the short installation TTL (mirroring the
+            // not-installed verdict) so a persistently-not-selected repo
+            // doesn't re-mint and 422 on every corpus operation, while a
+            // later repo-selection change still takes effect within minutes.
             let Some(token) = self.mint_token(installation_id, repo).await? else {
+                self.tokens
+                    .lock()
+                    .await
+                    .insert(key, (None, SystemTime::now() + INSTALLATION_TTL));
                 return Ok(None);
             };
             let expiry = SystemTime::now() + TOKEN_TTL;
             self.tokens
                 .lock()
                 .await
-                .insert(key, (token.clone(), expiry));
+                .insert(key, (Some(token.clone()), expiry));
             Ok(Some(token))
         }
 
@@ -558,13 +579,20 @@ Bz/gbfBkAPp8C+YDnkQV0dls16CS9wWhTrg8eJustV6QJ96Uw9h4+WZdPZCo9D9s
                 })))
                 .mount(&server)
                 .await;
+            // Exactly one mint: the 422 verdict must be negative-cached so a
+            // second resolution doesn't hit the API again.
             Mock::given(method("POST"))
                 .and(path_matcher("/app/installations/42/access_tokens"))
                 .respond_with(ResponseTemplate::new(422))
+                .expect(1)
                 .mount(&server)
                 .await;
 
             let auth = app(&server);
+            assert_eq!(
+                auth.token_for("acme", "not-granted-repo").await.unwrap(),
+                None
+            );
             assert_eq!(
                 auth.token_for("acme", "not-granted-repo").await.unwrap(),
                 None

--- a/packages/corpus/src/github_app.rs
+++ b/packages/corpus/src/github_app.rs
@@ -34,6 +34,7 @@ mod inner {
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     use async_trait::async_trait;
+    use base64::Engine;
     use jsonwebtoken::{Algorithm, EncodingKey, Header};
     use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, AUTHORIZATION, USER_AGENT};
     use serde::{Deserialize, Serialize};
@@ -126,8 +127,15 @@ mod inner {
         /// back to the env/file token chain).
         ///
         /// - `GITHUB_APP_ID` — the numeric app id (or client id).
-        /// - `GITHUB_APP_PRIVATE_KEY` — the PEM contents, **or**
-        ///   `GITHUB_APP_PRIVATE_KEY_PATH` — a path to the PEM file.
+        /// - `GITHUB_APP_PRIVATE_KEY` — the PEM contents **or its base64
+        ///   encoding**, **or** `GITHUB_APP_PRIVATE_KEY_PATH` — a path to
+        ///   the PEM file.
+        ///
+        /// The base64 form exists because a raw PEM is multiline, and some
+        /// deployment platforms (e.g. ZAD passes env vars as a single
+        /// newline-separated `KEY=VALUE` blob) corrupt a value that itself
+        /// contains newlines. `base64 -w0 key.pem` gives a safe single-line
+        /// value.
         ///
         /// Returns `Ok(None)` when `GITHUB_APP_ID` is unset. Returns an
         /// error when the id is set but the key is missing/unreadable, so a
@@ -139,7 +147,7 @@ mod inner {
             if app_id.trim().is_empty() {
                 return Ok(None);
             }
-            let pem = if let Ok(inline) = std::env::var("GITHUB_APP_PRIVATE_KEY") {
+            let raw = if let Ok(inline) = std::env::var("GITHUB_APP_PRIVATE_KEY") {
                 if inline.trim().is_empty() {
                     return Err(CorpusError::Config(
                         "GITHUB_APP_ID is set but GITHUB_APP_PRIVATE_KEY is empty".to_string(),
@@ -159,6 +167,7 @@ mod inner {
                         .to_string(),
                 ));
             };
+            let pem = normalize_private_key(raw)?;
             Ok(Some(Self::new(app_id, &pem)?))
         }
 
@@ -337,6 +346,30 @@ mod inner {
         }
     }
 
+    /// Accept the private key either as a raw PEM (multiline) or as the
+    /// base64 encoding of a PEM (single line). A real PEM always carries the
+    /// dashed `-----BEGIN ` marker, and `-` is not in the base64 alphabet,
+    /// so the marker's presence unambiguously distinguishes the two — no
+    /// guessing. The base64 path tolerates embedded whitespace (wrapped
+    /// base64) by stripping it before decoding.
+    fn normalize_private_key(raw: Vec<u8>) -> Result<Vec<u8>> {
+        if raw.windows(11).any(|w| w == b"-----BEGIN ") {
+            return Ok(raw);
+        }
+        let cleaned: Vec<u8> = raw
+            .into_iter()
+            .filter(|b| !b.is_ascii_whitespace())
+            .collect();
+        base64::engine::general_purpose::STANDARD
+            .decode(&cleaned)
+            .map_err(|e| {
+                CorpusError::Config(format!(
+                    "GITHUB_APP_PRIVATE_KEY is neither a PEM (no -----BEGIN marker) \
+                     nor valid base64: {e}"
+                ))
+            })
+    }
+
     #[async_trait]
     impl AppTokenMinter for GitHubAppAuth {
         /// Mint a token for a GitHub source. Returns `Ok(None)` for non-
@@ -354,10 +387,11 @@ mod inner {
     mod tests {
         #![allow(clippy::unwrap_used)]
 
+        use base64::Engine;
         use wiremock::matchers::{method, path as path_matcher};
         use wiremock::{Mock, MockServer, ResponseTemplate};
 
-        use super::GitHubAppAuth;
+        use super::{normalize_private_key, GitHubAppAuth};
         use crate::auth::AppTokenMinter;
         use crate::models::{LocalSource, Source, SourceType};
 
@@ -416,6 +450,21 @@ Bz/gbfBkAPp8C+YDnkQV0dls16CS9wWhTrg8eJustV6QJ96Uw9h4+WZdPZCo9D9s
                 priority: 0,
                 auth_ref: None,
             }
+        }
+
+        /// The private key may be given as raw PEM (multiline) or as base64
+        /// of the PEM (single line, for env vars that can't carry
+        /// newlines). Both must reach the same key bytes; pure garbage is an
+        /// error, not a silent empty key.
+        #[test]
+        fn normalize_private_key_accepts_raw_pem_and_base64() {
+            let pem = TEST_PRIVATE_KEY.as_bytes().to_vec();
+            assert_eq!(normalize_private_key(pem.clone()).unwrap(), pem);
+
+            let b64 = base64::engine::general_purpose::STANDARD.encode(&pem);
+            assert_eq!(normalize_private_key(b64.into_bytes()).unwrap(), pem);
+
+            assert!(normalize_private_key(b"neither pem nor base64 !!!".to_vec()).is_err());
         }
 
         /// A non-GitHub source is not this provider's concern: the minter

--- a/packages/corpus/src/github_app.rs
+++ b/packages/corpus/src/github_app.rs
@@ -1,0 +1,533 @@
+//! GitHub App authentication: mint short-lived installation access
+//! tokens on demand instead of storing a long-lived PAT per source repo.
+//!
+//! ## Why
+//!
+//! The per-source `CORPUS_AUTH_{REF}_TOKEN` env var (see [`crate::auth`])
+//! means an operator must register a new secret for every private repo a
+//! traject points at. A GitHub App replaces all of those with a single
+//! secret — the app's private key — set once. For any repo the app is
+//! installed on, this module mints a 1-hour installation token scoped to
+//! that repo on demand, so nothing long-lived is stored anywhere.
+//!
+//! ## The token dance
+//!
+//! 1. Sign a short-lived **app JWT** (RS256) with the private key — pure
+//!    crypto, no network. Proves "I am this app".
+//! 2. Look up the **installation** of the app on the repo's owner
+//!    (`GET /orgs/{owner}/installation`, falling back to the user
+//!    endpoint for personal accounts). No installation → the app has no
+//!    access to that owner; we return `None` so the caller falls back to
+//!    the env/file token chain.
+//! 3. Mint an **installation access token**
+//!    (`POST /app/installations/{id}/access_tokens`), scoped to the one
+//!    repo with `contents:write` + `metadata:read`. Lives ~1 hour.
+//! 4. Hand the token back; downstream code uses it exactly like a PAT
+//!    (`Authorization: Bearer`, or via `GIT_ASKPASS` for clones).
+//!
+//! Minted tokens are cached per `(owner, repo)` and re-minted shortly
+//! before expiry, so a burst of reads/writes shares one token.
+
+#[cfg(feature = "github")]
+mod inner {
+    use std::collections::HashMap;
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+    use async_trait::async_trait;
+    use jsonwebtoken::{Algorithm, EncodingKey, Header};
+    use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, AUTHORIZATION, USER_AGENT};
+    use serde::{Deserialize, Serialize};
+    use tokio::sync::Mutex;
+
+    use crate::auth::AppTokenMinter;
+    use crate::error::{CorpusError, Result};
+    use crate::models::{Source, SourceType};
+
+    /// An installation token is valid for one hour. We treat it as expired
+    /// a little early so a token never expires mid-request after we handed
+    /// it out.
+    const TOKEN_TTL: Duration = Duration::from_secs(55 * 60);
+    /// The app JWT is short-lived; GitHub caps it at 10 minutes. Use 9 to
+    /// leave headroom for clock skew on both sides.
+    const JWT_TTL_SECS: u64 = 9 * 60;
+    /// How long an installation-lookup result (id *or* "not installed") is
+    /// trusted before re-checking. Short, so that installing the App on a
+    /// new owner — or uninstalling/reinstalling (which changes the
+    /// installation id) — takes effect within minutes instead of requiring
+    /// an editor restart.
+    const INSTALLATION_TTL: Duration = Duration::from_secs(5 * 60);
+
+    /// JWT claims for the app-level token (`iss` = app id).
+    #[derive(Serialize)]
+    struct AppClaims {
+        iat: u64,
+        exp: u64,
+        iss: String,
+    }
+
+    /// `GET /orgs|users/{owner}/installation` — we only need the id.
+    #[derive(Deserialize)]
+    struct InstallationResponse {
+        id: u64,
+    }
+
+    /// `POST /app/installations/{id}/access_tokens` — we only need the token.
+    #[derive(Deserialize)]
+    struct AccessTokenResponse {
+        token: String,
+    }
+
+    /// Authenticates to GitHub as a GitHub App and mints short-lived
+    /// per-repo installation tokens. Construct once at startup
+    /// ([`GitHubAppAuth::from_env`]) and share via `Arc`.
+    pub struct GitHubAppAuth {
+        app_id: String,
+        encoding_key: EncodingKey,
+        client: reqwest::Client,
+        /// API base; overridable for tests. No trailing slash.
+        api_base: String,
+        /// lowercased owner → (installation id, expiry). A `None` id means
+        /// "looked up, app is not installed on this owner" so we don't
+        /// re-hit the API on every read for an owner the app can't see; the
+        /// expiry ([`INSTALLATION_TTL`]) bounds how long that verdict (and a
+        /// positive id, in case of uninstall+reinstall) is trusted. Keyed
+        /// lowercase because GitHub owners are case-insensitive.
+        installations: Mutex<HashMap<String, (Option<u64>, SystemTime)>>,
+        /// (lowercased owner, lowercased repo) → (token, expiry). Keyed
+        /// lowercase because GitHub owner/repo names are case-insensitive,
+        /// so differently-cased references share one cached token.
+        tokens: Mutex<HashMap<(String, String), (String, SystemTime)>>,
+    }
+
+    impl GitHubAppAuth {
+        /// Build from an app id and a PEM-encoded RSA private key.
+        pub fn new(app_id: impl Into<String>, private_key_pem: &[u8]) -> Result<Self> {
+            let encoding_key = EncodingKey::from_rsa_pem(private_key_pem).map_err(|e| {
+                CorpusError::Config(format!("invalid GitHub App private key (RSA PEM): {e}"))
+            })?;
+            let client = reqwest::Client::builder()
+                .user_agent("regelrecht-corpus/0.1")
+                .connect_timeout(Duration::from_secs(30))
+                .timeout(Duration::from_secs(60))
+                .build()
+                .map_err(|e| CorpusError::Config(format!("failed to create HTTP client: {e}")))?;
+            Ok(Self {
+                app_id: app_id.into(),
+                encoding_key,
+                client,
+                api_base: "https://api.github.com".to_string(),
+                installations: Mutex::new(HashMap::new()),
+                tokens: Mutex::new(HashMap::new()),
+            })
+        }
+
+        /// Construct from the environment, or `None` when the GitHub App is
+        /// not configured (so deployments without it transparently fall
+        /// back to the env/file token chain).
+        ///
+        /// - `GITHUB_APP_ID` — the numeric app id (or client id).
+        /// - `GITHUB_APP_PRIVATE_KEY` — the PEM contents, **or**
+        ///   `GITHUB_APP_PRIVATE_KEY_PATH` — a path to the PEM file.
+        ///
+        /// Returns `Ok(None)` when `GITHUB_APP_ID` is unset. Returns an
+        /// error when the id is set but the key is missing/unreadable, so a
+        /// half-configured app fails loudly instead of silently disabling.
+        pub fn from_env() -> Result<Option<Self>> {
+            let Ok(app_id) = std::env::var("GITHUB_APP_ID") else {
+                return Ok(None);
+            };
+            if app_id.trim().is_empty() {
+                return Ok(None);
+            }
+            let pem = if let Ok(inline) = std::env::var("GITHUB_APP_PRIVATE_KEY") {
+                if inline.trim().is_empty() {
+                    return Err(CorpusError::Config(
+                        "GITHUB_APP_ID is set but GITHUB_APP_PRIVATE_KEY is empty".to_string(),
+                    ));
+                }
+                inline.into_bytes()
+            } else if let Ok(path) = std::env::var("GITHUB_APP_PRIVATE_KEY_PATH") {
+                std::fs::read(&path).map_err(|e| {
+                    CorpusError::Config(format!(
+                        "failed to read GITHUB_APP_PRIVATE_KEY_PATH ({path}): {e}"
+                    ))
+                })?
+            } else {
+                return Err(CorpusError::Config(
+                    "GITHUB_APP_ID is set but neither GITHUB_APP_PRIVATE_KEY nor \
+                     GITHUB_APP_PRIVATE_KEY_PATH is configured"
+                        .to_string(),
+                ));
+            };
+            Ok(Some(Self::new(app_id, &pem)?))
+        }
+
+        /// Mint a repo-scoped installation token for `owner/repo`, or
+        /// `Ok(None)` when the app is not installed on `owner`. Inherent
+        /// helper so call sites that already hold `owner`/`repo` directly
+        /// (e.g. the create-traject preflight) don't need to build a
+        /// [`Source`].
+        pub async fn token_for(&self, owner: &str, repo: &str) -> Result<Option<String>> {
+            // Cache key is lowercased (GitHub names are case-insensitive);
+            // the original casing is still sent on the API calls below.
+            let key = (owner.to_lowercase(), repo.to_lowercase());
+
+            // Serve a still-valid cached token without any network call.
+            if let Some((token, expiry)) = self.tokens.lock().await.get(&key) {
+                if *expiry > SystemTime::now() {
+                    return Ok(Some(token.clone()));
+                }
+            }
+
+            // No installation on this owner → the app can't help here; let
+            // the caller fall back to the env/file token chain.
+            let Some(installation_id) = self.installation_id(owner).await? else {
+                return Ok(None);
+            };
+
+            let token = self.mint_token(installation_id, repo).await?;
+            let expiry = SystemTime::now() + TOKEN_TTL;
+            self.tokens
+                .lock()
+                .await
+                .insert(key, (token.clone(), expiry));
+            Ok(Some(token))
+        }
+
+        /// Point the client at a different API base — for tests against a
+        /// wiremock server. Production uses [`GitHubAppAuth::new`].
+        pub fn with_api_base(mut self, base_url: impl Into<String>) -> Self {
+            self.api_base = base_url.into().trim_end_matches('/').to_string();
+            self
+        }
+
+        /// Sign a fresh app-level JWT (RS256, `iss` = app id, ~9 min).
+        fn generate_jwt(&self) -> Result<String> {
+            let now = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map_err(|e| CorpusError::Config(format!("system clock before unix epoch: {e}")))?
+                .as_secs();
+            let claims = AppClaims {
+                // Backdate `iat` 60s to tolerate minor clock skew between
+                // us and GitHub (GitHub rejects a future `iat`).
+                iat: now.saturating_sub(60),
+                exp: now + JWT_TTL_SECS,
+                iss: self.app_id.clone(),
+            };
+            jsonwebtoken::encode(&Header::new(Algorithm::RS256), &claims, &self.encoding_key)
+                .map_err(|e| CorpusError::Config(format!("failed to sign GitHub App JWT: {e}")))
+        }
+
+        /// Headers for an app-JWT-authenticated request.
+        fn jwt_headers(&self, jwt: &str) -> Result<HeaderMap> {
+            let mut headers = HeaderMap::new();
+            headers.insert(
+                USER_AGENT,
+                HeaderValue::from_static("regelrecht-corpus/0.1"),
+            );
+            headers.insert(
+                ACCEPT,
+                HeaderValue::from_static("application/vnd.github+json"),
+            );
+            headers.insert(
+                "X-GitHub-Api-Version",
+                HeaderValue::from_static("2022-11-28"),
+            );
+            let auth = HeaderValue::from_str(&format!("Bearer {jwt}"))
+                .map_err(|e| CorpusError::Config(format!("invalid JWT header value: {e}")))?;
+            headers.insert(AUTHORIZATION, auth);
+            Ok(headers)
+        }
+
+        /// Resolve (and cache) the installation id of this app on `owner`.
+        /// `Ok(None)` means the app is not installed on that owner. Cached
+        /// for [`INSTALLATION_TTL`] (both the id and the "not installed"
+        /// verdict) so a later install/uninstall is picked up without a
+        /// process restart.
+        async fn installation_id(&self, owner: &str) -> Result<Option<u64>> {
+            let cache_key = owner.to_lowercase();
+            if let Some((id, expiry)) = self.installations.lock().await.get(&cache_key) {
+                if *expiry > SystemTime::now() {
+                    return Ok(*id);
+                }
+            }
+
+            let jwt = self.generate_jwt()?;
+            // Try the org endpoint first, then the user endpoint — a
+            // personal-account install is reachable only via `/users/...`.
+            let id = match self.fetch_installation(&jwt, "orgs", owner).await? {
+                Some(id) => Some(id),
+                None => self.fetch_installation(&jwt, "users", owner).await?,
+            };
+
+            self.installations
+                .lock()
+                .await
+                .insert(cache_key, (id, SystemTime::now() + INSTALLATION_TTL));
+            Ok(id)
+        }
+
+        /// One installation lookup against `/{kind}/{owner}/installation`.
+        /// 404 → `Ok(None)` (not installed / wrong account kind).
+        async fn fetch_installation(
+            &self,
+            jwt: &str,
+            kind: &str,
+            owner: &str,
+        ) -> Result<Option<u64>> {
+            let url = format!("{}/{}/{}/installation", self.api_base, kind, owner);
+            let response = self
+                .client
+                .get(&url)
+                .headers(self.jwt_headers(jwt)?)
+                .send()
+                .await
+                .map_err(|e| {
+                    CorpusError::Git(format!("GitHub App installation lookup failed: {e}"))
+                })?;
+
+            if response.status() == reqwest::StatusCode::NOT_FOUND {
+                return Ok(None);
+            }
+            if !response.status().is_success() {
+                return Err(CorpusError::Git(format!(
+                    "GitHub App installation lookup for {owner} returned {}: {}",
+                    response.status(),
+                    response.text().await.unwrap_or_default()
+                )));
+            }
+            let parsed: InstallationResponse = response.json().await.map_err(|e| {
+                CorpusError::Git(format!("failed to parse installation response: {e}"))
+            })?;
+            Ok(Some(parsed.id))
+        }
+
+        /// Mint an installation token scoped to a single repo with
+        /// `contents:write` + `metadata:read`.
+        async fn mint_token(&self, installation_id: u64, repo: &str) -> Result<String> {
+            let jwt = self.generate_jwt()?;
+            let url = format!(
+                "{}/app/installations/{}/access_tokens",
+                self.api_base, installation_id
+            );
+            let body = serde_json::json!({
+                "repositories": [repo],
+                "permissions": { "contents": "write", "metadata": "read" },
+            });
+            let response = self
+                .client
+                .post(&url)
+                .headers(self.jwt_headers(&jwt)?)
+                .json(&body)
+                .send()
+                .await
+                .map_err(|e| CorpusError::Git(format!("GitHub App token mint failed: {e}")))?;
+
+            if !response.status().is_success() {
+                return Err(CorpusError::Git(format!(
+                    "GitHub App token mint for installation {installation_id} returned {}: {}",
+                    response.status(),
+                    response.text().await.unwrap_or_default()
+                )));
+            }
+            let parsed: AccessTokenResponse = response.json().await.map_err(|e| {
+                CorpusError::Git(format!("failed to parse access-token response: {e}"))
+            })?;
+            Ok(parsed.token)
+        }
+    }
+
+    #[async_trait]
+    impl AppTokenMinter for GitHubAppAuth {
+        /// Mint a token for a GitHub source. Returns `Ok(None)` for non-
+        /// GitHub sources (a different provider's minter handles those) and
+        /// when the app is not installed on the repo's owner.
+        async fn token_for_source(&self, source: &Source) -> Result<Option<String>> {
+            let SourceType::GitHub { github } = &source.source_type else {
+                return Ok(None);
+            };
+            self.token_for(&github.owner, &github.repo).await
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        #![allow(clippy::unwrap_used)]
+
+        use wiremock::matchers::{method, path as path_matcher};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        use super::GitHubAppAuth;
+        use crate::auth::AppTokenMinter;
+        use crate::models::{LocalSource, Source, SourceType};
+
+        /// A throwaway RSA key generated solely for these unit tests — it
+        /// authenticates nothing (the mock server never verifies the JWT)
+        /// and is not used by any deployment.
+        const TEST_PRIVATE_KEY: &str = "-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC0++TFH/Dgo3/y
+0XlFxJsNellsFDs6PLPNvuWvXHIkdkPlPtl1usDpd1G/J0k5DlQ0doE1BjXh9+Yw
+uPGsfLoHNhrQY63BVdvqwQw20ryfKfF62FuMtb7NG++LmVRTF6bBxgN0/8wmhRHw
+oHacnWhlDnLZnFvnh5NyDw4N5+I5vAilxQc9UPjk7WseiEGnDI5tihH1/qQWqjn0
+h0jTc3JPtbNwg2+tAHQQTX4zUSiWbiO0s/TPdwz9HpnlnvZejzEA5DLRLHN8HFSk
+UCTK28Pch+QabF6ShPe9MT8YGca4H7q5o46GISs0+MjXPYTA3oQdlv62n901eBH5
+v1fkk30VAgMBAAECggEABW//+pAwG3+uC2yRuS/j/K6tWxrsgJ5sRIU0v2UGpOPM
+vGl7/RaETz9ffF/Aym8Mxpq83Qv3uHdLOjGESUtiB29vtM0Z3lInDlGIfWktc5a+
+A5PWhE69kcoCE26i4vA1+WJqnixFRO8Aj/syNRhhl4+ska8p77XaDzY2lOJfoJ5h
+krzu0UxQhxo09JM3GdwZUOIpk0/8AJAhFU5SI5dlZgm03uWLiEQvMeZy931UcUw0
+IpKPIn4Wob7xsPZGxDMJEhxhr9HJmpuUIbl5I2Hf1OVhrVUXOAdhlxHszzsxJ82T
+eFBv6sNrBuJczDY2HDhW5j1pppHG9w2O+W8OaiHrbQKBgQD2Yso4AMwucZx+Dalp
+E32aslLCPrINWux+u/fxWgO6UI9SzaiCVWR5WEMqUH0JZyP5NAiBQToWha+OZt71
+b+EuaXF2cRUoxG8coTT/VvG0cOa6MrtJ+G38cVOeyOe7iqcjeSidWG5MxdSZbfXr
++3h7U/rr6qBiOiBc4ILux/RkvwKBgQC8C8mXbgmPG/r6fF7z//cSSYVCyGNuOjqX
+ikl3NaD+7bbWF2y/mfQzInBoLSij+oytdQIUYLQrqhCY1Xlw0EgsTrX64vRkigR+
+LlKM9rU/CS4n3KutnUMbOK+/GkdyJnwyHUIYasMl5zmMjrkO5hqcJkUbgp0ekCRZ
+DH2RZFivKwKBgQDTjOlSgqTOL/CNbw+J0BllzT0v2YMp4mrzOlPeoEpZHDijgT/x
+gH5/jiBFYcyqWSvTGjE/QhEtK2YcYAmKNaDkJ9crOldPpLI+o9AMecuZAeOp9ktH
+bQ6K1YdV6+zE4301AR+1UiuKscYkYvznvQiq4+Wr0M4a6QvGk2L4wSj/owKBgBBg
+xnIV92crfLSMWIjP5mkFVkH2yhIzqB7CwJtNZHRPp/kFmUcm1YoOmdO4+y0tCUui
+QUgdFBQpf8CP9z/IJEEXqensEnUfQDztM+trIWYYGpkGMz2v0MRyL3xpgYeDqpWC
+ztrpkY2fkfeYBq4xhGfNPX+j5KNg0ome+ODM6Jx5AoGAKuk2voq6qiK6GK+OjAUn
+Dowzu2cOag3v0urvaYlmKAjlN0T03sm3PHb6luiaFGiADbtgAe+Qa+4Xsy4csFVQ
+Bz/gbfBkAPp8C+YDnkQV0dls16CS9wWhTrg8eJustV6QJ96Uw9h4+WZdPZCo9D9s
+/qtQyRgVfnPLqQdv00kx3gw=
+-----END PRIVATE KEY-----";
+
+        fn app(server: &MockServer) -> GitHubAppAuth {
+            GitHubAppAuth::new("123456", TEST_PRIVATE_KEY.as_bytes())
+                .unwrap()
+                .with_api_base(server.uri())
+        }
+
+        fn github_source(owner: &str, repo: &str) -> Source {
+            Source {
+                id: format!("{owner}-{repo}"),
+                name: format!("{owner}/{repo}"),
+                source_type: SourceType::GitHub {
+                    github: crate::models::GitHubSource {
+                        owner: owner.to_string(),
+                        repo: repo.to_string(),
+                        branch: "main".to_string(),
+                        path: None,
+                        git_ref: None,
+                    },
+                },
+                scopes: Vec::new(),
+                priority: 0,
+                auth_ref: None,
+            }
+        }
+
+        /// A non-GitHub source is not this provider's concern: the minter
+        /// returns `None` (so the resolver falls back to the static chain)
+        /// without any network call.
+        #[tokio::test]
+        async fn non_github_source_returns_none() {
+            let server = MockServer::start().await;
+            let auth = app(&server);
+            let local = Source {
+                id: "local".to_string(),
+                name: "Local".to_string(),
+                source_type: SourceType::Local {
+                    local: LocalSource {
+                        path: "corpus".into(),
+                    },
+                },
+                scopes: Vec::new(),
+                priority: 0,
+                auth_ref: None,
+            };
+            assert_eq!(auth.token_for_source(&local).await.unwrap(), None);
+        }
+
+        /// Happy path: look up the org installation, mint a repo-scoped
+        /// token, and cache it — a second call serves from cache with no
+        /// extra network round-trips (both mocks `.expect(1)`).
+        #[tokio::test]
+        async fn mints_and_caches_installation_token() {
+            let server = MockServer::start().await;
+
+            Mock::given(method("GET"))
+                .and(path_matcher("/orgs/acme/installation"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "id": 42
+                })))
+                .expect(1)
+                .mount(&server)
+                .await;
+            Mock::given(method("POST"))
+                .and(path_matcher("/app/installations/42/access_tokens"))
+                .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                    "token": "ghs_installation_token"
+                })))
+                .expect(1)
+                .mount(&server)
+                .await;
+
+            let auth = app(&server);
+            let src = github_source("acme", "private-corpus");
+
+            let first = auth.token_for_source(&src).await.unwrap();
+            assert_eq!(first.as_deref(), Some("ghs_installation_token"));
+            // Second call must be served from the cache (no extra requests).
+            let second = auth.token_for_source(&src).await.unwrap();
+            assert_eq!(second.as_deref(), Some("ghs_installation_token"));
+        }
+
+        /// A personal account exposes its install only via `/users/...`;
+        /// the org lookup 404s and we transparently fall through.
+        #[tokio::test]
+        async fn falls_back_to_user_installation() {
+            let server = MockServer::start().await;
+
+            Mock::given(method("GET"))
+                .and(path_matcher("/orgs/octocat/installation"))
+                .respond_with(ResponseTemplate::new(404))
+                .mount(&server)
+                .await;
+            Mock::given(method("GET"))
+                .and(path_matcher("/users/octocat/installation"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "id": 7
+                })))
+                .mount(&server)
+                .await;
+            Mock::given(method("POST"))
+                .and(path_matcher("/app/installations/7/access_tokens"))
+                .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                    "token": "ghs_user_token"
+                })))
+                .mount(&server)
+                .await;
+
+            let auth = app(&server);
+            let token = auth.token_for("octocat", "personal-repo").await.unwrap();
+            assert_eq!(token.as_deref(), Some("ghs_user_token"));
+        }
+
+        /// The app is installed on neither the org nor the user: both
+        /// lookups 404, so we return `None` and let the caller fall back to
+        /// the env/file token chain — we never attempt a mint.
+        #[tokio::test]
+        async fn not_installed_returns_none() {
+            let server = MockServer::start().await;
+
+            Mock::given(method("GET"))
+                .and(path_matcher("/orgs/stranger/installation"))
+                .respond_with(ResponseTemplate::new(404))
+                .mount(&server)
+                .await;
+            Mock::given(method("GET"))
+                .and(path_matcher("/users/stranger/installation"))
+                .respond_with(ResponseTemplate::new(404))
+                .mount(&server)
+                .await;
+
+            let auth = app(&server);
+            assert_eq!(auth.token_for("stranger", "repo").await.unwrap(), None);
+        }
+    }
+}
+
+#[cfg(feature = "github")]
+pub use inner::GitHubAppAuth;

--- a/packages/corpus/src/github_app.rs
+++ b/packages/corpus/src/github_app.rs
@@ -137,9 +137,12 @@ mod inner {
         /// contains newlines. `base64 -w0 key.pem` gives a safe single-line
         /// value.
         ///
-        /// Returns `Ok(None)` when `GITHUB_APP_ID` is unset. Returns an
-        /// error when the id is set but the key is missing/unreadable, so a
-        /// half-configured app fails loudly instead of silently disabling.
+        /// Returns `Ok(None)` when `GITHUB_APP_ID` is unset (app simply not
+        /// configured). Returns `Err` when the id is set but the key is
+        /// missing/unreadable, so a half-configured app surfaces loudly
+        /// rather than parsing to a silent no-op — the caller decides whether
+        /// that `Err` is fatal (the editor logs it at error level and
+        /// continues on the static token chain rather than refusing to boot).
         pub fn from_env() -> Result<Option<Self>> {
             let Ok(app_id) = std::env::var("GITHUB_APP_ID") else {
                 return Ok(None);
@@ -194,7 +197,11 @@ mod inner {
                 return Ok(None);
             };
 
-            let token = self.mint_token(installation_id, repo).await?;
+            // 422 (repo not in this installation's selected set) → the app
+            // can't serve this repo; fall back to the static chain.
+            let Some(token) = self.mint_token(installation_id, repo).await? else {
+                return Ok(None);
+            };
             let expiry = SystemTime::now() + TOKEN_TTL;
             self.tokens
                 .lock()
@@ -313,7 +320,13 @@ mod inner {
 
         /// Mint an installation token scoped to a single repo with
         /// `contents:write` + `metadata:read`.
-        async fn mint_token(&self, installation_id: u64, repo: &str) -> Result<String> {
+        ///
+        /// Returns `Ok(None)` when the repo is **not part of this
+        /// installation's selected repositories** (GitHub answers 422). That
+        /// is the normal case for a least-privilege "only select
+        /// repositories" install, not an error — the caller then falls back
+        /// to the static token chain instead of hard-failing the source.
+        async fn mint_token(&self, installation_id: u64, repo: &str) -> Result<Option<String>> {
             let jwt = self.generate_jwt()?;
             let url = format!(
                 "{}/app/installations/{}/access_tokens",
@@ -332,6 +345,13 @@ mod inner {
                 .await
                 .map_err(|e| CorpusError::Git(format!("GitHub App token mint failed: {e}")))?;
 
+            // 422 = at least one requested repo isn't accessible to this
+            // installation (the "only select repositories" case). The app
+            // genuinely can't serve this repo → signal fall-through, don't
+            // error.
+            if response.status() == reqwest::StatusCode::UNPROCESSABLE_ENTITY {
+                return Ok(None);
+            }
             if !response.status().is_success() {
                 return Err(CorpusError::Git(format!(
                     "GitHub App token mint for installation {installation_id} returned {}: {}",
@@ -342,7 +362,7 @@ mod inner {
             let parsed: AccessTokenResponse = response.json().await.map_err(|e| {
                 CorpusError::Git(format!("failed to parse access-token response: {e}"))
             })?;
-            Ok(parsed.token)
+            Ok(Some(parsed.token))
         }
     }
 
@@ -521,6 +541,34 @@ Bz/gbfBkAPp8C+YDnkQV0dls16CS9wWhTrg8eJustV6QJ96Uw9h4+WZdPZCo9D9s
             // Second call must be served from the cache (no extra requests).
             let second = auth.token_for_source(&src).await.unwrap();
             assert_eq!(second.as_deref(), Some("ghs_installation_token"));
+        }
+
+        /// "Only select repositories" install: the owner has an
+        /// installation, but the target repo isn't in its selected set, so
+        /// the mint returns 422. That must surface as `Ok(None)` (the app
+        /// can't serve this repo → fall back to the static chain), not an
+        /// error that would break the fallback.
+        #[tokio::test]
+        async fn repo_not_in_installation_returns_none() {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path_matcher("/orgs/acme/installation"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "id": 42
+                })))
+                .mount(&server)
+                .await;
+            Mock::given(method("POST"))
+                .and(path_matcher("/app/installations/42/access_tokens"))
+                .respond_with(ResponseTemplate::new(422))
+                .mount(&server)
+                .await;
+
+            let auth = app(&server);
+            assert_eq!(
+                auth.token_for("acme", "not-granted-repo").await.unwrap(),
+                None
+            );
         }
 
         /// A personal account exposes its install only via `/users/...`;

--- a/packages/corpus/src/github_app.rs
+++ b/packages/corpus/src/github_app.rs
@@ -204,9 +204,15 @@ mod inner {
                 }
             }
 
+            // One JWT for the whole cold mint — the installation lookup and
+            // the token mint that follow are milliseconds apart and the JWT
+            // is valid for minutes, so signing it once (rather than per
+            // helper) avoids a redundant RSA signing operation.
+            let jwt = self.generate_jwt()?;
+
             // No installation on this owner → the app can't help here; let
             // the caller fall back to the env/file token chain.
-            let Some(installation_id) = self.installation_id(owner).await? else {
+            let Some(installation_id) = self.installation_id(owner, &jwt).await? else {
                 return Ok(None);
             };
 
@@ -216,7 +222,16 @@ mod inner {
             // not-installed verdict) so a persistently-not-selected repo
             // doesn't re-mint and 422 on every corpus operation, while a
             // later repo-selection change still takes effect within minutes.
-            let Some(token) = self.mint_token(installation_id, repo).await? else {
+            let Some(token) = self.mint_token(installation_id, repo, &jwt).await? else {
+                // Log so an operator can tell a deliberately-excluded repo
+                // apart from a typo'd `owner/repo` — both surface as 422, and
+                // without this the App bypass is silent for the TTL window.
+                tracing::warn!(
+                    owner = %owner,
+                    repo = %repo,
+                    "GitHub App: repo not in installation's selected repositories (422); \
+                     falling back to static token chain"
+                );
                 self.tokens
                     .lock()
                     .await
@@ -281,7 +296,7 @@ mod inner {
         /// for [`INSTALLATION_TTL`] (both the id and the "not installed"
         /// verdict) so a later install/uninstall is picked up without a
         /// process restart.
-        async fn installation_id(&self, owner: &str) -> Result<Option<u64>> {
+        async fn installation_id(&self, owner: &str, jwt: &str) -> Result<Option<u64>> {
             let cache_key = owner.to_lowercase();
             if let Some((id, expiry)) = self.installations.lock().await.get(&cache_key) {
                 if *expiry > SystemTime::now() {
@@ -289,12 +304,11 @@ mod inner {
                 }
             }
 
-            let jwt = self.generate_jwt()?;
             // Try the org endpoint first, then the user endpoint — a
             // personal-account install is reachable only via `/users/...`.
-            let id = match self.fetch_installation(&jwt, "orgs", owner).await? {
+            let id = match self.fetch_installation(jwt, "orgs", owner).await? {
                 Some(id) => Some(id),
-                None => self.fetch_installation(&jwt, "users", owner).await?,
+                None => self.fetch_installation(jwt, "users", owner).await?,
             };
 
             self.installations
@@ -347,8 +361,12 @@ mod inner {
         /// is the normal case for a least-privilege "only select
         /// repositories" install, not an error — the caller then falls back
         /// to the static token chain instead of hard-failing the source.
-        async fn mint_token(&self, installation_id: u64, repo: &str) -> Result<Option<String>> {
-            let jwt = self.generate_jwt()?;
+        async fn mint_token(
+            &self,
+            installation_id: u64,
+            repo: &str,
+            jwt: &str,
+        ) -> Result<Option<String>> {
             let url = format!(
                 "{}/app/installations/{}/access_tokens",
                 self.api_base, installation_id
@@ -360,7 +378,7 @@ mod inner {
             let response = self
                 .client
                 .post(&url)
-                .headers(self.jwt_headers(&jwt)?)
+                .headers(self.jwt_headers(jwt)?)
                 .json(&body)
                 .send()
                 .await

--- a/packages/corpus/src/lib.rs
+++ b/packages/corpus/src/lib.rs
@@ -10,6 +10,8 @@ pub mod error;
 pub mod github;
 #[cfg(feature = "github")]
 pub mod github_api_backend;
+#[cfg(feature = "github")]
+pub mod github_app;
 pub mod models;
 #[cfg(feature = "github")]
 pub mod pr_client;
@@ -29,6 +31,8 @@ pub use error::CorpusError;
 pub use github::{FetchResult, GitHubFetcher};
 #[cfg(feature = "github")]
 pub use github_api_backend::GitHubApiBackend;
+#[cfg(feature = "github")]
+pub use github_app::GitHubAppAuth;
 pub use models::{RegistryManifest, Source, SourceType};
 #[cfg(feature = "github")]
 pub use pr_client::PullRequestClient;

--- a/packages/corpus/src/registry.rs
+++ b/packages/corpus/src/registry.rs
@@ -148,6 +148,7 @@ impl CorpusRegistry {
         &self,
         law_ids: &std::collections::HashSet<String>,
         auth_file: Option<&Path>,
+        providers: Option<&crate::auth::ProviderAuthRegistry>,
     ) -> Result<SourceMap> {
         let mut map = SourceMap::new();
         let mut fetcher = crate::github::GitHubFetcher::new()?;
@@ -171,11 +172,8 @@ impl CorpusRegistry {
 
         for source in &self.sources {
             if let SourceType::GitHub { github } = &source.source_type {
-                let token = crate::auth::resolve_token_for_source(
-                    &source.id,
-                    source.auth_ref.as_deref(),
-                    auth_file,
-                )?;
+                let token =
+                    crate::auth::resolve_token_async(source, auth_file, providers, false).await?;
                 match fetcher
                     .fetch_source_filtered(github, token.as_deref(), &missing)
                     .await?
@@ -230,13 +228,15 @@ impl CorpusRegistry {
     pub async fn index_all_sources_async(
         &self,
         auth_file: Option<&Path>,
+        providers: Option<&crate::auth::ProviderAuthRegistry>,
     ) -> Result<(SourceMap, Vec<String>)> {
         let mut map = SourceMap::new();
         let mut fetcher = crate::github::GitHubFetcher::new()?;
         let mut failed: Vec<String> = Vec::new();
 
         for source in &self.sources {
-            if let Err(e) = Self::index_one_source(&mut map, &mut fetcher, source, auth_file).await
+            if let Err(e) =
+                Self::index_one_source(&mut map, &mut fetcher, source, auth_file, providers).await
             {
                 tracing::warn!(
                     source_id = %source.id,
@@ -276,17 +276,15 @@ impl CorpusRegistry {
         fetcher: &mut crate::github::GitHubFetcher,
         source: &Source,
         auth_file: Option<&Path>,
+        providers: Option<&crate::auth::ProviderAuthRegistry>,
     ) -> Result<()> {
         match &source.source_type {
             SourceType::Local { .. } => {
                 map.load_source(source)?;
             }
             SourceType::GitHub { github } => {
-                let token = crate::auth::resolve_token_for_source(
-                    &source.id,
-                    source.auth_ref.as_deref(),
-                    auth_file,
-                )?;
+                let token =
+                    crate::auth::resolve_token_async(source, auth_file, providers, false).await?;
                 for (law_id, path, sha) in fetcher
                     .list_source_law_paths(github, token.as_deref())
                     .await?

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -1307,13 +1307,13 @@ async fn require_traject_corpus_from_ref(
         ));
     }
 
-    let auth_file = {
+    let (auth_file, providers) = {
         let corpus = state.corpus.read().await;
-        corpus.auth_file.clone()
+        (corpus.auth_file.clone(), corpus.providers.clone())
     };
     state
         .trajects
-        .get_or_build(pool, traject_id, auth_file)
+        .get_or_build(pool, traject_id, auth_file, providers)
         .await
         .map_err(traject_corpus_error)
 }
@@ -1994,11 +1994,16 @@ pub async fn reload_corpus(
     // Gather everything we need under a read lock so concurrent readers
     // (law fetches, scenario loads, dependency resolution) are not blocked
     // for the duration of the GitHub round-trip.
-    let (registry, auth_file, mut law_ids) = {
+    let (registry, auth_file, providers, mut law_ids) = {
         let corpus = state.corpus.read().await;
         let law_ids: std::collections::HashSet<String> =
             corpus.source_map.laws().map(|l| l.law_id.clone()).collect();
-        (corpus.registry.clone(), corpus.auth_file.clone(), law_ids)
+        (
+            corpus.registry.clone(),
+            corpus.auth_file.clone(),
+            corpus.providers.clone(),
+            law_ids,
+        )
     };
 
     // Include any extras the caller explicitly requests (e.g. a freshly
@@ -2010,7 +2015,7 @@ pub async fn reload_corpus(
     }
 
     let new_map = registry
-        .load_favorites_async(&law_ids, auth_file.as_deref())
+        .load_favorites_async(&law_ids, auth_file.as_deref(), Some(&providers))
         .await
         .map_err(|e| {
             tracing::error!(error = %e, "corpus reload failed");

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -557,7 +557,22 @@ async fn init_corpus(favorites: &HashSet<String>) -> CorpusState {
         None
     };
 
-    let source_map = match registry.load_favorites_async(favorites, auth_file).await {
+    // Per-provider credential minters (GitHub App, …). When configured,
+    // these mint short-lived repo-scoped tokens on demand so a private repo
+    // can be coupled to a traject without a per-repo `CORPUS_AUTH_*` env
+    // var; the static auth_file/env chain remains the fallback.
+    let providers = regelrecht_corpus::auth::ProviderAuthRegistry::from_env().unwrap_or_else(|e| {
+        tracing::error!(error = %e, "GitHub App auth is half-configured; continuing without it");
+        regelrecht_corpus::auth::ProviderAuthRegistry::default()
+    });
+    if providers.is_configured() {
+        tracing::info!("provider app-auth configured (GitHub App); tokens minted on demand");
+    }
+
+    let source_map = match registry
+        .load_favorites_async(favorites, auth_file, Some(&providers))
+        .await
+    {
         Ok(map) => {
             tracing::info!(laws = map.len(), "loaded corpus laws");
             map
@@ -577,13 +592,14 @@ async fn init_corpus(favorites: &HashSet<String>) -> CorpusState {
         }
     };
 
-    let backends = init_backends(&registry, auth_file).await;
+    let backends = init_backends(&registry, auth_file, &providers).await;
 
     CorpusState {
         registry,
         source_map,
         backends,
         auth_file: auth_file.map(|p| p.to_path_buf()),
+        providers,
     }
 }
 
@@ -596,15 +612,18 @@ async fn init_corpus(favorites: &HashSet<String>) -> CorpusState {
 async fn init_backends(
     registry: &regelrecht_corpus::CorpusRegistry,
     auth_file: Option<&std::path::Path>,
+    providers: &regelrecht_corpus::auth::ProviderAuthRegistry,
 ) -> HashMap<String, crate::state::BackendEntry> {
     let mut backends = HashMap::new();
 
     for source in registry.sources() {
-        let token = regelrecht_corpus::auth::resolve_token_for_source(
-            &source.id,
-            source.auth_ref.as_deref(),
+        let token = regelrecht_corpus::auth::resolve_token_async(
+            source,
             auth_file,
+            Some(providers),
+            false,
         )
+        .await
         .unwrap_or_else(|e| {
             tracing::warn!(source_id = %source.id, error = %e, "failed to resolve auth token");
             None

--- a/packages/editor-api/src/state.rs
+++ b/packages/editor-api/src/state.rs
@@ -82,6 +82,12 @@ pub struct CorpusState {
     pub backends: HashMap<String, BackendEntry>,
     /// Path to corpus-auth.yaml for GitHub authentication during reload.
     pub auth_file: Option<PathBuf>,
+    /// Per-provider credential minters (GitHub App, …). Preferred over the
+    /// static `auth_file`/env token chain when a provider is configured, so
+    /// a private repo can be coupled to a traject without registering a
+    /// per-repo token. Cheap to clone (shares each minter's `Arc` + its
+    /// token cache); empty when no provider is configured.
+    pub providers: regelrecht_corpus::auth::ProviderAuthRegistry,
 }
 
 impl CorpusState {
@@ -92,6 +98,7 @@ impl CorpusState {
             source_map: SourceMap::new(),
             backends: HashMap::new(),
             auth_file: None,
+            providers: regelrecht_corpus::auth::ProviderAuthRegistry::default(),
         }
     }
 }

--- a/packages/editor-api/src/traject_corpus.rs
+++ b/packages/editor-api/src/traject_corpus.rs
@@ -914,6 +914,7 @@ impl TrajectCorpusCache {
         pool: &PgPool,
         traject_id: Uuid,
         auth_file: Option<PathBuf>,
+        providers: regelrecht_corpus::auth::ProviderAuthRegistry,
     ) -> Result<Arc<TrajectCorpus>, TrajectCorpusError> {
         let slot = {
             let mut map = self.cells.write().await;
@@ -961,7 +962,9 @@ impl TrajectCorpusCache {
         };
 
         let corpus = match stale {
-            None => build_traject_corpus(pool, traject_id, auth_file.as_deref()).await?,
+            None => {
+                build_traject_corpus(pool, traject_id, auth_file.as_deref(), &providers).await?
+            }
             Some(old) => match refresh_traject_corpus(&old, traject_id).await {
                 Ok(refreshed) => refreshed,
                 Err(e) => {
@@ -1052,6 +1055,7 @@ async fn build_traject_corpus(
     pool: &PgPool,
     traject_id: Uuid,
     auth_file: Option<&std::path::Path>,
+    providers: &regelrecht_corpus::auth::ProviderAuthRegistry,
 ) -> Result<Arc<TrajectCorpus>, TrajectCorpusError> {
     let rows = sqlx::query_as::<_, TrajectSourceRow>(
         "SELECT source_id, name, source_type::text AS source_type,
@@ -1101,25 +1105,23 @@ async fn build_traject_corpus(
     // Build a backend per source, scoped to a traject-specific clone path.
     let mut backends: HashMap<String, BackendEntry> = HashMap::new();
     for (row, source) in rows.iter().zip(sources.iter()) {
-        // For the writable-own source we resolve strictly (no legacy
-        // `CORPUS_GIT_TOKEN` fallback). The `auth_ref` on this row was
-        // derived from the create-request's repo coords, so a missing
-        // per-repo token MUST fail closed — not transparently ship the
-        // central token to a user-chosen GitHub repo on the next push.
-        // Seeded (non-writable) sources keep the legacy fallback so
-        // pre-existing deployments that rely on a single global PAT for
-        // read-only mirrors keep working.
-        let token_result = if row.is_writable_own {
-            let key = source.auth_ref.as_deref().unwrap_or(&source.id);
-            regelrecht_corpus::auth::resolve_token_strict(key, auth_file)
-        } else {
-            regelrecht_corpus::auth::resolve_token_for_source(
-                &source.id,
-                source.auth_ref.as_deref(),
-                auth_file,
-            )
-        };
-        let token = token_result.unwrap_or_else(|e| {
+        // Prefer a provider-minted short-lived token (GitHub App, …) when
+        // configured, then the static chain. For the writable-own source
+        // the static chain resolves strictly (no legacy `CORPUS_GIT_TOKEN`
+        // fallback): its `auth_ref` was derived from the create-request's
+        // repo coords, so a missing per-repo token MUST fail closed — not
+        // transparently ship the central token to a user-chosen GitHub repo
+        // on the next push. Seeded (non-writable) sources keep the legacy
+        // fallback so pre-existing deployments that rely on a single global
+        // PAT for read-only mirrors keep working.
+        let token = regelrecht_corpus::auth::resolve_token_async(
+            source,
+            auth_file,
+            Some(providers),
+            row.is_writable_own,
+        )
+        .await
+        .unwrap_or_else(|e| {
             tracing::warn!(
                 traject = %traject_id,
                 source_id = %source.id,
@@ -1237,7 +1239,10 @@ async fn build_traject_corpus(
     // failing entirely on what is usually a transient GitHub hiccup. The hard
     // failure path is the writable-own *backend* init above, which returns
     // `Err` so a broken write target never opens silently.
-    let source_map = match registry.index_all_sources_async(auth_file).await {
+    let source_map = match registry
+        .index_all_sources_async(auth_file, Some(providers))
+        .await
+    {
         Ok((map, failed)) => {
             if failed.iter().any(|id| id == &writable_own_source_id) {
                 tracing::error!(
@@ -1267,6 +1272,7 @@ async fn build_traject_corpus(
             source_map,
             backends,
             auth_file: auth_file.map(|p| p.to_path_buf()),
+            providers: providers.clone(),
         },
         write_target_for_source,
         writable_own_source_id,
@@ -1318,7 +1324,7 @@ async fn refresh_traject_corpus(
     let registry = old.corpus.registry.clone();
     let auth_file = old.corpus.auth_file.clone();
     let (source_map, failed) = registry
-        .index_all_sources_async(auth_file.as_deref())
+        .index_all_sources_async(auth_file.as_deref(), Some(&old.corpus.providers))
         .await?;
     if !failed.is_empty() {
         return Err(TrajectCorpusError::Corpus(
@@ -1350,6 +1356,7 @@ async fn next_snapshot(old: &Arc<TrajectCorpus>, source_map: SourceMap) -> Arc<T
             source_map,
             backends: old.corpus.backends.clone(),
             auth_file: old.corpus.auth_file.clone(),
+            providers: old.corpus.providers.clone(),
         },
         write_target_for_source: old.write_target_for_source.clone(),
         writable_own_source_id: old.writable_own_source_id.clone(),
@@ -1636,6 +1643,7 @@ mod tests {
                 source_map,
                 backends,
                 auth_file: None,
+                providers: regelrecht_corpus::auth::ProviderAuthRegistry::default(),
             },
             write_target_for_source: HashMap::new(),
             writable_own_source_id: "own".to_string(),
@@ -1971,6 +1979,7 @@ mod tests {
                 source_map,
                 backends,
                 auth_file: None,
+                providers: regelrecht_corpus::auth::ProviderAuthRegistry::default(),
             },
             write_target_for_source: HashMap::new(),
             writable_own_source_id: "own".to_string(),

--- a/packages/editor-api/src/trajects.rs
+++ b/packages/editor-api/src/trajects.rs
@@ -851,42 +851,65 @@ async fn resolve_writable_target(
                 ));
             }
 
-            // Resolve the token. Use the *strict* resolver here — the
-            // `auth_ref` is derived from user-supplied repo coords, so
-            // an unknown ref must NOT fall back to `CORPUS_GIT_TOKEN`
-            // (that would ship the central token to a repo the user
-            // picked, a token-exfiltration vector). The strict variant
-            // returns `None` when no per-repo env var or auth-file
-            // entry is configured, which we then surface as a clean
-            // 503 with the expected env-var name.
-            let auth_file = {
+            // Resolve the token. Prefer a provider-minted short-lived
+            // token (GitHub App, …) when configured; otherwise the *strict*
+            // static resolver — the `auth_ref` is derived from
+            // user-supplied repo coords, so an unknown ref must NOT fall
+            // back to `CORPUS_GIT_TOKEN` (that would ship the central token
+            // to a repo the user picked, a token-exfiltration vector). When
+            // neither yields a token we surface a clean 503 naming both the
+            // env var and the GitHub App as ways to grant access.
+            let (auth_file, providers) = {
                 let corpus = state.corpus.read().await;
-                corpus.auth_file.clone()
+                (corpus.auth_file.clone(), corpus.providers.clone())
             };
-            let token =
-                regelrecht_corpus::auth::resolve_token_strict(&auth_ref, auth_file.as_deref())
-                    .map_err(|e| {
-                        tracing::error!(error = %e, "auth lookup failed for new traject repo");
-                        (
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            "auth lookup failed".to_string(),
-                        )
-                    })?
-                    .ok_or_else(|| {
-                        let env_name = regelrecht_corpus::auth::token_env_name(&auth_ref);
-                        tracing::warn!(
-                            auth_ref = %auth_ref,
-                            env_name = %env_name,
-                            "no token configured for user-supplied repo"
-                        );
-                        (
-                            StatusCode::SERVICE_UNAVAILABLE,
-                            format!(
-                                "deze repo is nog niet door je beheerder geconfigureerd \
-                         (verwacht env var {env_name})"
-                            ),
-                        )
-                    })?;
+            // Minimal GitHub source describing the repo under validation, so
+            // the resolver can route it to the GitHub App minter.
+            let probe_source = regelrecht_corpus::Source {
+                id: auth_ref.clone(),
+                name: format!("{owner}/{repo}"),
+                source_type: regelrecht_corpus::SourceType::GitHub {
+                    github: regelrecht_corpus::models::GitHubSource {
+                        owner: owner.to_string(),
+                        repo: repo.to_string(),
+                        branch: base_branch.to_string(),
+                        path: None,
+                        git_ref: None,
+                    },
+                },
+                scopes: Vec::new(),
+                priority: 0,
+                auth_ref: Some(auth_ref.clone()),
+            };
+            let token = regelrecht_corpus::auth::resolve_token_async(
+                &probe_source,
+                auth_file.as_deref(),
+                Some(&providers),
+                true,
+            )
+            .await
+            .map_err(|e| {
+                tracing::error!(error = %e, "auth lookup failed for new traject repo");
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "auth lookup failed".to_string(),
+                )
+            })?
+            .ok_or_else(|| {
+                let env_name = regelrecht_corpus::auth::token_env_name(&auth_ref);
+                tracing::warn!(
+                    auth_ref = %auth_ref,
+                    env_name = %env_name,
+                    "no token configured for user-supplied repo (no GitHub App access, no env/file token)"
+                );
+                (
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    format!(
+                        "deze repo is nog niet door je beheerder geconfigureerd \
+                         (installeer de GitHub App op de repo, of zet env var {env_name})"
+                    ),
+                )
+            })?;
 
             let info = regelrecht_corpus::repo_access::validate_repo_access(
                 "https://api.github.com",

--- a/packages/editor-api/tests/list_scenarios_test.rs
+++ b/packages/editor-api/tests/list_scenarios_test.rs
@@ -222,6 +222,7 @@ async fn list_scenarios_global_returns_target_law_ids() {
             source_map,
             backends,
             auth_file: None,
+            providers: regelrecht_corpus::auth::ProviderAuthRegistry::default(),
         })),
         oidc_client: None,
         end_session_url: None,


### PR DESCRIPTION
## Why

Today, coupling a **private** repo to a traject in the editor requires an operator to register a per-repo `CORPUS_AUTH_{REF}_TOKEN` env var on the editor component. That doesn't scale: env-var sprawl, a manual ops step per traject, and a long-lived PAT per repo. We also don't want to store tokens in the database.

ZAD offers no keyvault/secret-manager service (only postgres/redis/minio/keycloak/storage), so this builds the scalable alternative on top of GitHub itself: a **GitHub App** that mints short-lived, repo-scoped installation tokens on demand. Nothing long-lived is stored anywhere — only the app's private key, set once.

## What

A **hybrid** design: a provider-keyed factory becomes the top tier of the existing token resolver, with the current static chain kept intact as the fallback.

- **`packages/corpus/src/github_app.rs`** (new) — `GitHubAppAuth`: signs an app JWT (RS256), looks up the installation on the repo's owner (`/orgs/{owner}/installation`, falling back to `/users/{owner}/installation` for personal accounts), mints an installation token scoped to the one repo with `contents:write` + `metadata:read`, and caches both the installation lookup and the minted token with a TTL.
- **`packages/corpus/src/auth.rs`** — new `AppTokenMinter` trait, a **`ProviderAuthRegistry` factory** (`from_env`) that routes a source to its provider's minter by `SourceType`, and an async `resolve_token_async`. Resolution order: provider minter → per-source env var → `corpus-auth.yaml` → legacy `CORPUS_GIT_TOKEN`. The writable-own traject source keeps its **strict** static fallback (no legacy-token leak to a user-chosen repo).
- Threaded the registry through the registry async index/favorites paths and the editor-api wiring (`state.rs`, `main.rs`, `traject_corpus.rs`, `trajects.rs`, `corpus_handlers.rs`). The create-traject preflight now accepts "install the GitHub App on the repo" as an alternative to the env var.

### Factory / extensibility

`ProviderAuthRegistry` is provider-keyed — **today only GitHub is implemented**; GitLab / Azure DevOps slot in later as a new field + match arm, with call sites unchanged. Non-GitHub and local sources, and any deployment that doesn't configure the app, fall through to the existing env/file chain — behavior is byte-identical to before.

### Commit attribution

Unchanged and already correct: `persist` sets the commit `author` to the editor user, so App-minted commits still show the person who made the edit.

## Configuration (operator, one-time)

1. Register a GitHub App (org → Developer settings → GitHub Apps): permissions **Contents: Read & write** + **Metadata: Read**, webhooks off, installable on *Any account* (needed for cross-org single-repo installs).
2. Install it (org-wide, or "Only select repositories"). External orgs can install on exactly one repo.
3. Set on the editor component: `GITHUB_APP_ID` and `GITHUB_APP_PRIVATE_KEY` — the PEM **or its base64** (`base64 -w0 key.pem`, a single line — preferred where the platform passes env vars as a newline-separated blob, e.g. ZAD) — or `GITHUB_APP_PRIVATE_KEY_PATH` to a mounted PEM.

Testable with a **personal account** + a personal private repo — no org required.

## Tests

- `github_app.rs`: non-GitHub source → `None`; mint + cache (second call hits cache, no extra requests); org→user fallback; not-installed → `None` (wiremock).
- `auth.rs`: default registry has no minter; provider minter wins over the static chain; minter declines → falls back to per-source env var.
- `just format`, `just lint` (clippy clean), all corpus + editor-api unit tests green.

## Authorization model — deliberate decision

A code review confirmed the security invariant (no legacy `CORPUS_GIT_TOKEN` leak to a user-chosen repo) and the hybrid fallback. One behavioural point was reviewed and **consciously accepted**:

**Repo targeting is bounded by the App's installation scope, not by an in-app entitlement check.** Verified: per-traject membership (`traject_members`, owner/contributor) gates access to an *already-created* traject; it does **not** gate creation or repo choice. `POST /api/trajects` is gated only by the `editor-writer` role, and `resolve_writable_target` validates the *operator token's* push access — not whether the acting user is entitled to that specific repo. So with an **org-wide** ("All repositories") install, any `editor-writer` could couple a traject to any repo in that org.

**Accepted for now**: installation scope *is* the authorization boundary (installing the App = granting it). Recommended deploy mode for tighter control is a **selective install** (the operator picks which repos the App can see), which preserves the "someone deliberately enabled this repo" property of today's per-repo env var.

**Planned follow-up — #885**: bound repo choice in-app (operator allowlist / specific create-role / org↔user entitlement) enforced in `resolve_writable_target` (`trajects.rs:748`), so org-wide installs stay safe without relying solely on GitHub-side install scope. This is inherently a trust seam between two authz systems (editor roles/membership vs. GitHub App install scope) — the follow-up moves the seam from "installation scope" to an in-app entitlement. Parked for now.

### Other follow-ups (not blockers)
- Index/enumeration path resolves the writable-own source non-strictly (pre-existing; unreachable in practice because the create-time strict check guarantees a token exists).
- `mint_token` assumes the ~1h GitHub TTL rather than parsing `expires_at`; no single-flight on a cold-cache mint race (redundant mint only).
