### PR TITLE
feat(pipeline): personal Claude login for enricher + daily run cap

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,7 +20,22 @@ WORKER_MAX_POLL_INTERVAL_SECS=60
 # (Pro/Max) via `claude setup-token`. ANTHROPIC_API_KEY is intentionally not used
 # by the enricher (never forwarded to the claude subprocess), so it can't take
 # precedence over the OAuth token.
-# CLAUDE_CODE_OAUTH_TOKEN=
+# May hold MULTIPLE comma-separated tokens; each run picks one, rotating ~every
+# 100s, to spread load across several subscriptions.
+# CLAUDE_CODE_OAUTH_TOKEN=token1,token2,token3
+
+# === Enrich Worker: auto-enqueue (recursive enrich) ===
+# OFF by default: harvesting a law does NOT enqueue enrich jobs; enrichment is
+# requested explicitly via POST /api/enrich-jobs. Set true to enrich every
+# harvested law automatically (the old recursive behavior).
+# ENRICH_AUTO_ENQUEUE=false
+
+# === Enrich Worker: timeouts ===
+# LLM_TIMEOUT_SECS caps a single LLM run (default 600). WORKER_JOB_TIMEOUT_SECS
+# must be LARGER than LLM_TIMEOUT_SECS (default 1200), else the worker shrinks the
+# LLM timeout to job_timeout-30s. For big laws raise both, e.g. 3600 / 3900.
+# LLM_TIMEOUT_SECS=3600
+# WORKER_JOB_TIMEOUT_SECS=3900
 # Cap how many enrichments this worker's provider (LLM_PROVIDER) runs per UTC day
 # (counted from the jobs table across all run states, survives restarts).
 # FAIL-CLOSED: unset or 0 pauses enrichment entirely — a worker must be given an

--- a/.env.example
+++ b/.env.example
@@ -15,8 +15,22 @@ WORKER_MAX_POLL_INTERVAL_SECS=60
 # VLAM_API_KEY=
 # VLAM_BASE_URL=
 
-# === Enrich Worker: Anthropic API Key (for claude provider) ===
+# === Enrich Worker: Claude auth (for claude provider) ===
+# Personal Claude subscription (Pro/Max) via `claude setup-token` — the headless
+# "personal login". ANTHROPIC_API_KEY must be UNSET for this to take effect (it
+# takes precedence over the OAuth token).
+# CLAUDE_CODE_OAUTH_TOKEN=
+# Or a metered Console API key instead of a personal subscription:
 # ANTHROPIC_API_KEY=
+# Cap how many enrichments this worker's provider (LLM_PROVIDER) runs per UTC day
+# (counted from the jobs table across all run states, survives restarts).
+# FAIL-CLOSED: unset or 0 pauses enrichment entirely — a worker must be given an
+# explicit positive limit to run. Once the cap is reached it pauses the whole
+# worker until the next UTC day, so use it on a provider-dedicated worker (e.g. a
+# claude-only enrichworker). Keeps a personal Claude token from running the whole
+# corpus at once. Every enrich worker (incl. the VLAM/opencode one) now needs an
+# explicit limit to do any work.
+# ENRICH_DAILY_LIMIT=100
 
 # === Admin API Key (optional, enables Bearer token auth for GET + DELETE) ===
 # ADMIN_API_KEY=change-me-to-a-long-random-string-at-least-32-chars

--- a/.env.example
+++ b/.env.example
@@ -16,12 +16,11 @@ WORKER_MAX_POLL_INTERVAL_SECS=60
 # VLAM_BASE_URL=
 
 # === Enrich Worker: Claude auth (for claude provider) ===
-# Personal Claude subscription (Pro/Max) via `claude setup-token` — the headless
-# "personal login". ANTHROPIC_API_KEY must be UNSET for this to take effect (it
-# takes precedence over the OAuth token).
+# The claude provider authenticates ONLY with a personal Claude subscription
+# (Pro/Max) via `claude setup-token`. ANTHROPIC_API_KEY is intentionally not used
+# by the enricher (never forwarded to the claude subprocess), so it can't take
+# precedence over the OAuth token.
 # CLAUDE_CODE_OAUTH_TOKEN=
-# Or a metered Console API key instead of a personal subscription:
-# ANTHROPIC_API_KEY=
 # Cap how many enrichments this worker's provider (LLM_PROVIDER) runs per UTC day
 # (counted from the jobs table across all run states, survives restarts).
 # FAIL-CLOSED: unset or 0 pauses enrichment entirely — a worker must be given an

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -83,7 +83,10 @@ services:
       OPENCODE_MODEL: ${OPENCODE_MODEL:-vlam/ubiops-deployment/bzk-dig-mistralmedium-flexibel//chat-model}
       VLAM_API_KEY: ${VLAM_API_KEY:-}
       VLAM_BASE_URL: ${VLAM_BASE_URL:-}
+      CLAUDE_CODE_OAUTH_TOKEN: ${CLAUDE_CODE_OAUTH_TOKEN:-}
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      # Fail-closed: unset/0 pauses enrichment; set a positive value to run.
+      ENRICH_DAILY_LIMIT: ${ENRICH_DAILY_LIMIT:-0}
       REGULATION_REPO_PATH: /tmp/regulation-repo
       REGULATION_OUTPUT_BASE: regulation/nl
       WORKER_POLL_INTERVAL_SECS: ${WORKER_POLL_INTERVAL_SECS:-5}

--- a/packages/pipeline/entrypoint-enrich.sh
+++ b/packages/pipeline/entrypoint-enrich.sh
@@ -53,10 +53,10 @@ printf '{"dependencies":{"@ai-sdk/openai-compatible":"*"}}' \
   > "$HOME/.config/opencode/package.json"
 
 # --- Claude auth ---
-# Both credentials are read directly from env by the claude CLI — no file is written:
-#   - CLAUDE_CODE_OAUTH_TOKEN: a personal Claude subscription token (`claude setup-token`),
-#     the way to authenticate against a Pro/Max plan headlessly.
-#   - ANTHROPIC_API_KEY: a metered Console API key.
-# ANTHROPIC_API_KEY takes precedence, so it must be unset for the OAuth token to be used.
+# The claude provider authenticates with a personal Claude subscription via
+# CLAUDE_CODE_OAUTH_TOKEN (`claude setup-token`), read directly from env — no file
+# is written. ANTHROPIC_API_KEY is intentionally NOT used: it is not forwarded to
+# the claude subprocess (see LLM_ENV_ALLOWLIST), so it can never take precedence
+# over the OAuth token, even if it is still set here.
 
 exec regelrecht-enrich-worker

--- a/packages/pipeline/entrypoint-enrich.sh
+++ b/packages/pipeline/entrypoint-enrich.sh
@@ -53,6 +53,10 @@ printf '{"dependencies":{"@ai-sdk/openai-compatible":"*"}}' \
   > "$HOME/.config/opencode/package.json"
 
 # --- Claude auth ---
-# ANTHROPIC_API_KEY is read directly from env by claude CLI — no file needed.
+# Both credentials are read directly from env by the claude CLI — no file is written:
+#   - CLAUDE_CODE_OAUTH_TOKEN: a personal Claude subscription token (`claude setup-token`),
+#     the way to authenticate against a Pro/Max plan headlessly.
+#   - ANTHROPIC_API_KEY: a metered Console API key.
+# ANTHROPIC_API_KEY takes precedence, so it must be unset for the OAuth token to be used.
 
 exec regelrecht-enrich-worker

--- a/packages/pipeline/migrations/0022_enrich_daily_count_index.sql
+++ b/packages/pipeline/migrations/0022_enrich_daily_count_index.sql
@@ -1,0 +1,8 @@
+-- Partial index supporting the per-provider daily enrich-run count
+-- (count_enrich_jobs_started_today). The daily-limit gate runs that query on
+-- every enrich-worker poll cycle, filtering enrich jobs by their payload
+-- provider and started_at within the current UTC day; without an index it scans
+-- the whole jobs table each time.
+CREATE INDEX IF NOT EXISTS idx_jobs_enrich_provider_started_at
+    ON jobs ((payload ->> 'provider'), started_at)
+    WHERE job_type = 'enrich' AND started_at IS NOT NULL;

--- a/packages/pipeline/src/config.rs
+++ b/packages/pipeline/src/config.rs
@@ -78,6 +78,21 @@ pub struct WorkerConfig {
     /// so retrying in-process just burns job retry budget in a tight loop.
     /// Default: 5. Configurable via `WORKER_MAX_CONSECUTIVE_RESOURCE_FAILURES`.
     pub max_consecutive_resource_failures: u32,
+    /// Maximum number of enrichment jobs (for this worker's provider) that may
+    /// run per UTC calendar day. Configurable via `ENRICH_DAILY_LIMIT`.
+    ///
+    /// **Fail-closed**: absent (or unparseable) reads as `0`, and `0` pauses
+    /// enrichment entirely — a worker must be given an explicit positive limit
+    /// to run. This protects a personal Claude subscription token from being
+    /// spent by accident (a forgotten env var runs nothing rather than the whole
+    /// corpus).
+    ///
+    /// Enforced by the enrich worker against the durable `jobs` table, so the
+    /// cap survives restarts. The cap keys on this worker's configured provider
+    /// (`LLM_PROVIDER`), and once reached it pauses the whole worker until the
+    /// UTC day rolls over — so it is meant for a provider-dedicated worker (e.g.
+    /// a claude-only enrichworker).
+    pub enrich_daily_limit: u32,
 }
 
 impl std::fmt::Debug for WorkerConfig {
@@ -97,6 +112,7 @@ impl std::fmt::Debug for WorkerConfig {
                 "max_consecutive_resource_failures",
                 &self.max_consecutive_resource_failures,
             )
+            .field("enrich_daily_limit", &self.enrich_daily_limit)
             .finish()
     }
 }
@@ -148,6 +164,20 @@ impl WorkerConfig {
                 .unwrap_or(5)
                 .max(1);
 
+        // Per-provider daily run cap. Fail-closed: absent reads as 0 (paused),
+        // and a present-but-unparseable value warns and also reads as 0 rather
+        // than silently disabling the cap (this guards spend on a personal token).
+        let enrich_daily_limit: u32 = match std::env::var("ENRICH_DAILY_LIMIT") {
+            Ok(raw) => raw.parse::<u32>().unwrap_or_else(|_| {
+                tracing::warn!(
+                    value = %raw,
+                    "ENRICH_DAILY_LIMIT is not a valid non-negative integer; treating as 0 (enrichment paused)"
+                );
+                0
+            }),
+            Err(_) => 0,
+        };
+
         Ok(Self {
             database_url,
             max_connections,
@@ -160,6 +190,7 @@ impl WorkerConfig {
             orphan_timeout: Duration::from_secs(orphan_timeout_secs),
             exhausted_threshold,
             max_consecutive_resource_failures,
+            enrich_daily_limit,
         })
     }
 

--- a/packages/pipeline/src/config.rs
+++ b/packages/pipeline/src/config.rs
@@ -93,6 +93,10 @@ pub struct WorkerConfig {
     /// UTC day rolls over — so it is meant for a provider-dedicated worker (e.g.
     /// a claude-only enrichworker).
     pub enrich_daily_limit: u32,
+    /// When true, a completed harvest auto-enqueues enrich jobs for that law.
+    /// Off by default; enrichment is otherwise requested explicitly via the admin
+    /// API. Configurable via `ENRICH_AUTO_ENQUEUE`.
+    pub auto_enrich_enqueue: bool,
 }
 
 impl std::fmt::Debug for WorkerConfig {
@@ -113,6 +117,7 @@ impl std::fmt::Debug for WorkerConfig {
                 &self.max_consecutive_resource_failures,
             )
             .field("enrich_daily_limit", &self.enrich_daily_limit)
+            .field("auto_enrich_enqueue", &self.auto_enrich_enqueue)
             .finish()
     }
 }
@@ -178,6 +183,16 @@ impl WorkerConfig {
             Err(_) => 0,
         };
 
+        // Auto-enrich after harvest is opt-in; unset/unrecognized reads as false.
+        let auto_enrich_enqueue = std::env::var("ENRICH_AUTO_ENQUEUE")
+            .map(|v| {
+                matches!(
+                    v.trim().to_ascii_lowercase().as_str(),
+                    "1" | "true" | "yes" | "on"
+                )
+            })
+            .unwrap_or(false);
+
         Ok(Self {
             database_url,
             max_connections,
@@ -191,6 +206,7 @@ impl WorkerConfig {
             exhausted_threshold,
             max_consecutive_resource_failures,
             enrich_daily_limit,
+            auto_enrich_enqueue,
         })
     }
 

--- a/packages/pipeline/src/enrich.rs
+++ b/packages/pipeline/src/enrich.rs
@@ -341,9 +341,13 @@ pub struct EnrichmentMetadata {
 ///
 /// Both providers manage their own authentication:
 /// - **OpenCode/VLAM**: reads `~/.local/share/opencode/auth.json` (set via `opencode auth`)
-/// - **Claude**: reads `~/.claude/.credentials` or `ANTHROPIC_API_KEY` env var
+/// - **Claude**: reads `CLAUDE_CODE_OAUTH_TOKEN` (a personal Claude subscription token from
+///   `claude setup-token`) or `ANTHROPIC_API_KEY` (a Console API key). Note that
+///   `ANTHROPIC_API_KEY` takes precedence, so it must be *unset* for the OAuth token to be
+///   used. Both are read directly from the environment; no credentials file is written.
 ///
-/// In Docker, mount the appropriate auth files or set env vars.
+/// In Docker, set the appropriate env vars (both auth vars are forwarded to the subprocess
+/// via `LLM_ENV_ALLOWLIST`).
 #[derive(Debug, Clone)]
 pub enum LlmProvider {
     OpenCode {
@@ -548,6 +552,7 @@ const LLM_ENV_ALLOWLIST: &[&str] = &[
     "XDG_",
     // Provider-specific auth
     "ANTHROPIC_API_KEY",
+    "CLAUDE_CODE_OAUTH_TOKEN",
     "VLAM_API_KEY",
     "OPENCODE_",
 ];

--- a/packages/pipeline/src/enrich.rs
+++ b/packages/pipeline/src/enrich.rs
@@ -208,9 +208,13 @@ impl LlmRunner for ProcessLlmRunner {
         };
 
         if !status.success() {
-            // Let the stderr drain finish so the tail is complete before we read it.
+            // Give the stderr drain a moment to finish so the tail is complete,
+            // but bound the wait: the child has exited, yet a leaked grandchild
+            // that inherited fd 2 could keep the pipe open and never EOF. Without
+            // a bound this await (outside the timeout/memory select!) would wedge
+            // the worker loop. Best-effort, like the tail in the other paths.
             if let Some(task) = stderr_task {
-                let _ = task.await;
+                let _ = tokio::time::timeout(Duration::from_secs(2), task).await;
             }
             return Err(PipelineError::Enrich(format!(
                 "{} exited with {}{}",
@@ -725,11 +729,15 @@ fn build_command(
                     .map(|d| d.as_secs() / 100)
                     .unwrap_or(0);
                 if let Some((idx, count, token)) = select_claude_token(&raw, bucket) {
+                    // Always apply the selected (trimmed) token — even for a
+                    // single token — so stray whitespace or a trailing comma
+                    // never reaches claude verbatim. Never log the token value;
+                    // only the 1-based position and count.
+                    cmd.env("CLAUDE_CODE_OAUTH_TOKEN", token);
                     if count > 1 {
-                        cmd.env("CLAUDE_CODE_OAUTH_TOKEN", token);
                         tracing::info!(
-                            token_count = count,
-                            selected_index = idx,
+                            using_token = idx + 1,
+                            of_tokens = count,
                             "selected claude oauth token (rotating by ~100s)"
                         );
                     }

--- a/packages/pipeline/src/enrich.rs
+++ b/packages/pipeline/src/enrich.rs
@@ -233,6 +233,13 @@ impl LlmRunner for ProcessLlmRunner {
             )));
         }
 
+        // Success: abort the drain task instead of leaving it detached — same
+        // fd-2/grandchild-leak guard as the timeout/OOM paths. Normally it has
+        // already finished (the child closed stderr on exit); aborting a finished
+        // task is a no-op.
+        if let Some(t) = &stderr_task {
+            t.abort();
+        }
         Ok(())
     }
 }

--- a/packages/pipeline/src/enrich.rs
+++ b/packages/pipeline/src/enrich.rs
@@ -186,6 +186,12 @@ impl LlmRunner for ProcessLlmRunner {
             }
             _ = tokio::time::sleep(config.timeout) => {
                 terminate(&mut child, pid).await;
+                // Abort the drain task rather than leaving it detached: if a
+                // grandchild inherited fd 2 and survived terminate(), the task
+                // would otherwise leak. The tail read below is already populated.
+                if let Some(t) = &stderr_task {
+                    t.abort();
+                }
                 return Err(PipelineError::Enrich(format!(
                     "{} timed out after {:?}{}",
                     provider_name, config.timeout, stderr_suffix()
@@ -200,6 +206,9 @@ impl LlmRunner for ProcessLlmRunner {
                     "LLM subprocess exceeded memory limit, killing to protect the container"
                 );
                 terminate(&mut child, pid).await;
+                if let Some(t) = &stderr_task {
+                    t.abort();
+                }
                 return Err(PipelineError::Enrich(format!(
                     "{provider_name} exceeded memory limit of {} MB (RSS {observed_mb} MB), killed{}",
                     config.max_rss_mb, stderr_suffix()
@@ -690,11 +699,13 @@ fn build_command(
         provider = provider.name(),
         model = ?model,
         prompt_chars = prompt.len(),
-        forwarded_env = ?forwarded_env,
         claude_oauth_token_kind = ?oauth_token_kind,
         anthropic_api_key_present_in_worker_env = std::env::var_os("ANTHROPIC_API_KEY").is_some(),
         "spawning LLM subprocess"
     );
+    // The forwarded env var NAMES are static between spawns — keep them at debug
+    // so they don't add a long line to every job's info logs.
+    tracing::debug!(provider = provider.name(), forwarded_env = ?forwarded_env, "forwarded env to LLM subprocess");
 
     let mut cmd = match provider {
         LlmProvider::OpenCode { path, model } => {

--- a/packages/pipeline/src/enrich.rs
+++ b/packages/pipeline/src/enrich.rs
@@ -62,6 +62,11 @@ pub trait LlmRunner: Send + Sync {
     ) -> Result<()>;
 }
 
+/// Max bytes of the LLM subprocess's stderr to retain for diagnostics. The tail
+/// (most recent output) is kept and appended to the error on a non-zero exit, so
+/// a failure reports the real cause (e.g. an auth `401`) instead of a bare code.
+const MAX_STDERR_CAPTURE: usize = 4096;
+
 /// Default runner that spawns a real CLI process.
 pub struct ProcessLlmRunner;
 
@@ -80,13 +85,14 @@ impl LlmRunner for ProcessLlmRunner {
 
         let mut cmd = build_command(&config.provider, &prompt, yaml_abs, repo_path);
 
-        // stderr is inherited so the LLM's own errors/stack traces stay visible
-        // in the worker's logs. stdout is piped and drained (see below) instead
-        // of inherited: a verbose agent (e.g. opencode `--format json`) inlines
-        // the full body of every fetched page into its event stream, which
-        // would otherwise flood container logs and bury the worker's own
-        // tracing lines.
-        cmd.stderr(std::process::Stdio::inherit());
+        // Both streams are piped and drained. stdout is drained-and-discarded: a
+        // verbose agent (e.g. opencode `--format json`) inlines the full body of
+        // every fetched page into its event stream, which would flood container
+        // logs. stderr is drained too — we MUST keep reading both or a full 64 KB
+        // OS pipe buffer blocks the child — but for stderr we also keep a bounded
+        // tail and re-log previews, so the LLM's real error (e.g. an auth 401) is
+        // both visible in the logs and attached to the job's failure.
+        cmd.stderr(std::process::Stdio::piped());
         cmd.stdout(std::process::Stdio::piped());
         let mut child = cmd.spawn().map_err(|e| {
             PipelineError::Enrich(format!("failed to spawn {}: {e}", provider_name))
@@ -95,6 +101,49 @@ impl LlmRunner for ProcessLlmRunner {
         // Capture the PID before any wait reaps the child; the memory watchdog
         // and process-group kill both need it.
         let pid = child.id();
+
+        // Drain stderr, retaining the last `MAX_STDERR_CAPTURE` bytes for the
+        // error message and re-logging bounded previews so it stays visible.
+        let stderr_tail = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+        let stderr_task = child.stderr.take().map(|mut stderr| {
+            let tail = stderr_tail.clone();
+            let stderr_provider = provider_name.clone();
+            tokio::spawn(async move {
+                let mut buf = [0u8; 8192];
+                loop {
+                    match stderr.read(&mut buf).await {
+                        Ok(0) | Err(_) => break, // EOF or pipe gone
+                        Ok(n) => {
+                            let text = String::from_utf8_lossy(&buf[..n]);
+                            let preview: String = text.trim().chars().take(500).collect();
+                            if !preview.is_empty() {
+                                tracing::warn!(provider = %stderr_provider, %preview, "agent stderr");
+                            }
+                            if let Ok(mut t) = tail.lock() {
+                                t.push_str(&text);
+                                if t.len() > MAX_STDERR_CAPTURE {
+                                    let mut cut = t.len() - MAX_STDERR_CAPTURE;
+                                    while cut < t.len() && !t.is_char_boundary(cut) {
+                                        cut += 1;
+                                    }
+                                    *t = t[cut..].to_string();
+                                }
+                            }
+                        }
+                    }
+                }
+            })
+        });
+        // Read the retained stderr tail, formatted as a "; stderr: …" suffix.
+        let stderr_suffix = || {
+            stderr_tail
+                .lock()
+                .ok()
+                .map(|t| t.trim().to_string())
+                .filter(|t| !t.is_empty())
+                .map(|t| format!("; stderr: {t}"))
+                .unwrap_or_default()
+        };
 
         // Drain the agent's stdout so it never reaches container logs. We MUST
         // keep reading it: if the OS pipe buffer (64 KB) fills, the child blocks
@@ -138,8 +187,8 @@ impl LlmRunner for ProcessLlmRunner {
             _ = tokio::time::sleep(config.timeout) => {
                 terminate(&mut child, pid).await;
                 return Err(PipelineError::Enrich(format!(
-                    "{} timed out after {:?}",
-                    provider_name, config.timeout
+                    "{} timed out after {:?}{}",
+                    provider_name, config.timeout, stderr_suffix()
                 )));
             }
             observed_mb = watch_memory(pid, config.max_rss_mb) => {
@@ -152,16 +201,22 @@ impl LlmRunner for ProcessLlmRunner {
                 );
                 terminate(&mut child, pid).await;
                 return Err(PipelineError::Enrich(format!(
-                    "{provider_name} exceeded memory limit of {} MB (RSS {observed_mb} MB), killed",
-                    config.max_rss_mb
+                    "{provider_name} exceeded memory limit of {} MB (RSS {observed_mb} MB), killed{}",
+                    config.max_rss_mb, stderr_suffix()
                 )));
             }
         };
 
         if !status.success() {
+            // Let the stderr drain finish so the tail is complete before we read it.
+            if let Some(task) = stderr_task {
+                let _ = task.await;
+            }
             return Err(PipelineError::Enrich(format!(
-                "{} exited with {}",
-                provider_name, status,
+                "{} exited with {}{}",
+                provider_name,
+                status,
+                stderr_suffix()
             )));
         }
 
@@ -341,13 +396,14 @@ pub struct EnrichmentMetadata {
 ///
 /// Both providers manage their own authentication:
 /// - **OpenCode/VLAM**: reads `~/.local/share/opencode/auth.json` (set via `opencode auth`)
-/// - **Claude**: reads `CLAUDE_CODE_OAUTH_TOKEN` (a personal Claude subscription token from
-///   `claude setup-token`) or `ANTHROPIC_API_KEY` (a Console API key). Note that
-///   `ANTHROPIC_API_KEY` takes precedence, so it must be *unset* for the OAuth token to be
-///   used. Both are read directly from the environment; no credentials file is written.
+/// - **Claude**: authenticates with a **personal Claude subscription** via
+///   `CLAUDE_CODE_OAUTH_TOKEN` (from `claude setup-token`), read directly from the
+///   environment; no credentials file is written. `ANTHROPIC_API_KEY` is intentionally NOT
+///   used — it is not on `LLM_ENV_ALLOWLIST`, so it is never forwarded to `claude` and can
+///   never take precedence over the OAuth token.
 ///
-/// In Docker, set the appropriate env vars (both auth vars are forwarded to the subprocess
-/// via `LLM_ENV_ALLOWLIST`).
+/// In Docker, set the appropriate env var (forwarded to the subprocess via
+/// `LLM_ENV_ALLOWLIST`).
 #[derive(Debug, Clone)]
 pub enum LlmProvider {
     OpenCode {
@@ -550,8 +606,14 @@ const LLM_ENV_ALLOWLIST: &[&str] = &[
     "SHELL",
     "TMPDIR",
     "XDG_",
-    // Provider-specific auth
-    "ANTHROPIC_API_KEY",
+    // Provider-specific auth.
+    //
+    // NOTE: ANTHROPIC_API_KEY is deliberately NOT forwarded. The claude provider
+    // authenticates only with a personal subscription via CLAUDE_CODE_OAUTH_TOKEN.
+    // Keeping ANTHROPIC_API_KEY out of the subprocess env means that even if it is
+    // still set on the worker (e.g. a leftover), it can never reach `claude` and
+    // silently take precedence over the OAuth token — the exact footgun that
+    // makes claude fail auth at startup.
     "CLAUDE_CODE_OAUTH_TOKEN",
     "VLAM_API_KEY",
     "OPENCODE_",
@@ -578,6 +640,36 @@ fn build_command(
     // Collect allowed env vars before creating the command.
     let safe_env: Vec<(String, String)> =
         std::env::vars().filter(|(k, _)| env_allowed(k)).collect();
+
+    // Diagnostic logging: record exactly what will be spawned and which env vars
+    // are forwarded (NAMES only — never values). Classify the OAuth token by its
+    // non-secret prefix so a misconfiguration (an API key pasted into the OAuth
+    // slot) is obvious, and flag whether ANTHROPIC_API_KEY is still present in the
+    // worker env even though it is deliberately never forwarded.
+    let forwarded_env: Vec<&str> = safe_env.iter().map(|(k, _)| k.as_str()).collect();
+    let oauth_token_kind = std::env::var("CLAUDE_CODE_OAUTH_TOKEN").ok().map(|t| {
+        if t.is_empty() {
+            "empty"
+        } else if t.starts_with("sk-ant-oat") {
+            "oauth-token (sk-ant-oat…)"
+        } else if t.starts_with("sk-ant-api") {
+            "WRONG: looks like an API key (sk-ant-api…)"
+        } else {
+            "unrecognized-prefix"
+        }
+    });
+    let model = match provider {
+        LlmProvider::OpenCode { model, .. } | LlmProvider::Claude { model, .. } => model.as_deref(),
+    };
+    tracing::info!(
+        provider = provider.name(),
+        model = ?model,
+        prompt_chars = prompt.len(),
+        forwarded_env = ?forwarded_env,
+        claude_oauth_token_kind = ?oauth_token_kind,
+        anthropic_api_key_present_in_worker_env = std::env::var_os("ANTHROPIC_API_KEY").is_some(),
+        "spawning LLM subprocess"
+    );
 
     let mut cmd = match provider {
         LlmProvider::OpenCode { path, model } => {

--- a/packages/pipeline/src/enrich.rs
+++ b/packages/pipeline/src/enrich.rs
@@ -626,6 +626,27 @@ fn env_allowed(key: &str) -> bool {
         .any(|prefix| key == *prefix || key.starts_with(prefix))
 }
 
+/// Select one Claude OAuth token from a comma-separated list, rotating by a
+/// time `bucket` so consecutive runs spread across several personal
+/// subscriptions (each token has its own usage/rate limits).
+///
+/// `CLAUDE_CODE_OAUTH_TOKEN` may hold multiple tokens separated by commas. The
+/// chosen index is `bucket % n`; callers pass `unix_secs / 100`, so the active
+/// token rotates roughly every 100 seconds. Returns `(index, count, token)`, or
+/// `None` when there are no non-empty tokens. Pure so it can be unit-tested.
+fn select_claude_token(raw: &str, bucket: u64) -> Option<(usize, usize, &str)> {
+    let tokens: Vec<&str> = raw
+        .split(',')
+        .map(|t| t.trim())
+        .filter(|t| !t.is_empty())
+        .collect();
+    if tokens.is_empty() {
+        return None;
+    }
+    let idx = (bucket % tokens.len() as u64) as usize;
+    Some((idx, tokens.len(), tokens[idx]))
+}
+
 /// Build the command for the configured LLM provider.
 ///
 /// The subprocess gets a stripped environment: only variables on
@@ -695,6 +716,25 @@ fn build_command(
             cmd.env_clear();
             cmd.envs(safe_env);
             cmd.env("NODE_OPTIONS", "--max-old-space-size=512");
+            // If CLAUDE_CODE_OAUTH_TOKEN holds several comma-separated tokens,
+            // override the forwarded value with a single one chosen by a
+            // time-rotating index, so load spreads across the subscriptions.
+            if let Ok(raw) = std::env::var("CLAUDE_CODE_OAUTH_TOKEN") {
+                let bucket = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_secs() / 100)
+                    .unwrap_or(0);
+                if let Some((idx, count, token)) = select_claude_token(&raw, bucket) {
+                    if count > 1 {
+                        cmd.env("CLAUDE_CODE_OAUTH_TOKEN", token);
+                        tracing::info!(
+                            token_count = count,
+                            selected_index = idx,
+                            "selected claude oauth token (rotating by ~100s)"
+                        );
+                    }
+                }
+            }
             cmd.arg("-p")
                 .arg(prompt)
                 .arg("--allowedTools")
@@ -1253,6 +1293,25 @@ mod tests {
         assert!(ENRICH_PROVIDERS.contains(&"opencode"));
         assert!(ENRICH_PROVIDERS.contains(&"claude"));
         assert_eq!(ENRICH_PROVIDERS.len(), 2);
+    }
+
+    #[test]
+    fn test_select_claude_token() {
+        // empty / whitespace-only -> None
+        assert_eq!(select_claude_token("", 0), None);
+        assert_eq!(select_claude_token("  , ,", 5), None);
+
+        // single token -> always that token, index 0
+        assert_eq!(select_claude_token("tokA", 0), Some((0, 1, "tokA")));
+        assert_eq!(select_claude_token(" tokA ", 999), Some((0, 1, "tokA")));
+
+        // multiple tokens -> rotate by bucket % n, whitespace trimmed
+        assert_eq!(select_claude_token("a, b , c", 0), Some((0, 3, "a")));
+        assert_eq!(select_claude_token("a, b , c", 1), Some((1, 3, "b")));
+        assert_eq!(select_claude_token("a, b , c", 2), Some((2, 3, "c")));
+        assert_eq!(select_claude_token("a, b , c", 3), Some((0, 3, "a")));
+        // large bucket (e.g. unix_secs/100) still wraps correctly
+        assert_eq!(select_claude_token("a,b", 17_000_001), Some((1, 2, "b")));
     }
 
     #[test]

--- a/packages/pipeline/src/job_queue.rs
+++ b/packages/pipeline/src/job_queue.rs
@@ -120,6 +120,48 @@ where
     Ok(job)
 }
 
+/// Count enrichment jobs for `provider` that have started running today (UTC
+/// calendar day).
+///
+/// Used to enforce a per-provider daily run cap (see `ENRICH_DAILY_LIMIT`),
+/// which protects a personal Claude subscription token from running the whole
+/// corpus in one go. Reads the durable `jobs` table so the cap holds across
+/// worker restarts/redeploys (an in-memory counter would reset on every pod
+/// restart).
+///
+/// Counts every job that actually ran today, in ANY status — started,
+/// processing, completed, failed, and failed-and-awaiting-retry all count
+/// (`fail_job` keeps `started_at`, and a re-claim refreshes it). Only never-run
+/// `pending` jobs (`started_at IS NULL`, which spent no tokens) are excluded.
+/// A job counts once per day regardless of how many retries it took.
+///
+/// Relies on every enqueue path setting `payload.provider` (the admin and
+/// auto-enrich both do, one job per provider); a provider-less payload would run
+/// under the worker's default provider but not be counted here.
+///
+/// Not transactional with the caller's claim: with N concurrent workers the cap
+/// may be exceeded by up to N near the boundary. That's acceptable for a spend
+/// guard.
+pub async fn count_enrich_jobs_started_today<'e, E>(executor: E, provider: &str) -> Result<i64>
+where
+    E: sqlx::PgExecutor<'e>,
+{
+    let count = sqlx::query_scalar::<_, i64>(
+        r#"
+        SELECT COUNT(*)
+        FROM jobs
+        WHERE job_type = 'enrich'
+          AND payload->>'provider' = $1
+          AND started_at >= date_trunc('day', now() AT TIME ZONE 'UTC') AT TIME ZONE 'UTC'
+        "#,
+    )
+    .bind(provider)
+    .fetch_one(executor)
+    .await?;
+
+    Ok(count)
+}
+
 /// Claim the highest-priority pending job using FOR UPDATE SKIP LOCKED.
 /// Jobs scheduled in the future (`scheduled_at > now()`, set by the retry
 /// backoff) are skipped until they become due.

--- a/packages/pipeline/src/worker.rs
+++ b/packages/pipeline/src/worker.rs
@@ -384,6 +384,20 @@ async fn process_next_job(
             // idx_unique_active_enrich_job partial unique index to atomically
             // prevent duplicate enrich jobs — no TOCTOU race possible.
 
+            // Auto-enrich is opt-in. By default, harvesting a law does NOT
+            // enqueue enrich jobs — enrichment is requested explicitly via the
+            // admin API (POST /api/enrich-jobs). This prevents the recursive
+            // "harvest everything → enrich everything" queue from filling up
+            // (and burning LLM budget) for laws nobody asked to enrich. Set
+            // ENRICH_AUTO_ENQUEUE=true to restore the old recursive behavior.
+            let auto_enrich = std::env::var("ENRICH_AUTO_ENQUEUE")
+                .map(|v| {
+                    matches!(
+                        v.trim().to_ascii_lowercase().as_str(),
+                        "1" | "true" | "yes" | "on"
+                    )
+                })
+                .unwrap_or(false);
             // Skip auto-enrich if law is exhausted for enrich
             let enrich_exhausted = match law_status::get_law(pool, &job.law_id).await {
                 Ok(law) => law.status == LawStatusValue::EnrichExhausted,
@@ -392,7 +406,9 @@ async fn process_next_job(
                     false
                 }
             };
-            if enrich_exhausted {
+            if !auto_enrich {
+                tracing::info!(law_id = %job.law_id, "auto-enrich disabled (set ENRICH_AUTO_ENQUEUE=true to enable); not enqueuing enrich jobs");
+            } else if enrich_exhausted {
                 tracing::info!(law_id = %job.law_id, "skipping auto-enrich: law is enrich_exhausted");
             } else {
                 for provider_name in crate::enrich::ENRICH_PROVIDERS {

--- a/packages/pipeline/src/worker.rs
+++ b/packages/pipeline/src/worker.rs
@@ -763,6 +763,11 @@ pub async fn run_enrich_worker(config: WorkerConfig) -> Result<()> {
         // Claude subscription token from running the whole corpus in one day.
         // Fail-closed: a limit of 0 (the default when ENRICH_DAILY_LIMIT is
         // unset) pauses the worker without even querying.
+        //
+        // The cap keys on the worker's configured provider (LLM_PROVIDER), not
+        // the per-job payload provider. That is exact for a provider-dedicated
+        // worker (the intended deployment); a worker serving multiple providers
+        // would under-count the non-default provider's runs.
         let limit = config.enrich_daily_limit;
         let provider = enrich_config.provider.name();
         let over_limit = if limit == 0 {

--- a/packages/pipeline/src/worker.rs
+++ b/packages/pipeline/src/worker.rs
@@ -384,20 +384,13 @@ async fn process_next_job(
             // idx_unique_active_enrich_job partial unique index to atomically
             // prevent duplicate enrich jobs — no TOCTOU race possible.
 
-            // Auto-enrich is opt-in. By default, harvesting a law does NOT
-            // enqueue enrich jobs — enrichment is requested explicitly via the
-            // admin API (POST /api/enrich-jobs). This prevents the recursive
-            // "harvest everything → enrich everything" queue from filling up
-            // (and burning LLM budget) for laws nobody asked to enrich. Set
-            // ENRICH_AUTO_ENQUEUE=true to restore the old recursive behavior.
-            let auto_enrich = std::env::var("ENRICH_AUTO_ENQUEUE")
-                .map(|v| {
-                    matches!(
-                        v.trim().to_ascii_lowercase().as_str(),
-                        "1" | "true" | "yes" | "on"
-                    )
-                })
-                .unwrap_or(false);
+            // Auto-enrich is opt-in (parsed once in WorkerConfig from
+            // ENRICH_AUTO_ENQUEUE). By default, harvesting a law does NOT enqueue
+            // enrich jobs — enrichment is requested explicitly via the admin API
+            // (POST /api/enrich-jobs). This prevents the recursive "harvest
+            // everything → enrich everything" queue from filling up (and burning
+            // LLM budget) for laws nobody asked to enrich.
+            let auto_enrich = config.auto_enrich_enqueue;
             // Skip auto-enrich if law is exhausted for enrich
             let enrich_exhausted = match law_status::get_law(pool, &job.law_id).await {
                 Ok(law) => law.status == LawStatusValue::EnrichExhausted,

--- a/packages/pipeline/src/worker.rs
+++ b/packages/pipeline/src/worker.rs
@@ -742,6 +742,11 @@ pub async fn run_enrich_worker(config: WorkerConfig) -> Result<()> {
 
     let mut current_interval = std::time::Duration::ZERO;
     let mut consecutive_resource_failures: u32 = 0;
+    // Log the "paused on daily limit" state at info only on the first hit, then
+    // debug while it persists — otherwise a paused worker (e.g. ENRICH_DAILY_LIMIT
+    // unset) emits an info line every poll interval indefinitely. Reset once a job
+    // actually runs so a later pause is surfaced again.
+    let mut daily_limit_pause_logged = false;
 
     loop {
         tokio::select! {
@@ -786,14 +791,21 @@ pub async fn run_enrich_worker(config: WorkerConfig) -> Result<()> {
         };
         if over_limit {
             current_interval = config.max_poll_interval;
-            tracing::info!(
-                provider,
-                limit,
-                next_poll = ?current_interval,
-                "daily enrich limit reached (or ENRICH_DAILY_LIMIT unset/0), pausing until the UTC day rolls over"
-            );
+            if !daily_limit_pause_logged {
+                tracing::info!(
+                    provider,
+                    limit,
+                    next_poll = ?current_interval,
+                    "daily enrich limit reached (or ENRICH_DAILY_LIMIT unset/0), pausing until the UTC day rolls over"
+                );
+                daily_limit_pause_logged = true;
+            } else {
+                tracing::debug!(provider, limit, "still paused on daily enrich limit");
+            }
             continue;
         }
+        // Not paused this cycle — re-arm the info-level pause log for the next pause.
+        daily_limit_pause_logged = false;
 
         match process_next_enrich_job(
             &pool,

--- a/packages/pipeline/src/worker.rs
+++ b/packages/pipeline/src/worker.rs
@@ -407,7 +407,10 @@ async fn process_next_job(
                 }
             };
             if !auto_enrich {
-                tracing::info!(law_id = %job.law_id, "auto-enrich disabled (set ENRICH_AUTO_ENQUEUE=true to enable); not enqueuing enrich jobs");
+                // debug, not info: with auto-enrich off by default this fires for
+                // every harvested law (~22k on a full corpus harvest) — steady-state
+                // noise, not an event worth surfacing at info.
+                tracing::debug!(law_id = %job.law_id, "auto-enrich disabled (set ENRICH_AUTO_ENQUEUE=true to enable); not enqueuing enrich jobs");
             } else if enrich_exhausted {
                 tracing::info!(law_id = %job.law_id, "skipping auto-enrich: law is enrich_exhausted");
             } else {

--- a/packages/pipeline/src/worker.rs
+++ b/packages/pipeline/src/worker.rs
@@ -741,6 +741,36 @@ pub async fn run_enrich_worker(config: WorkerConfig) -> Result<()> {
             }
         }
 
+        // Enforce the per-provider daily run cap before claiming a job. Counted
+        // from the durable `jobs` table (not an in-memory counter) so the cap
+        // holds across worker restarts/redeploys. Primarily protects a personal
+        // Claude subscription token from running the whole corpus in one day.
+        // Fail-closed: a limit of 0 (the default when ENRICH_DAILY_LIMIT is
+        // unset) pauses the worker without even querying.
+        let limit = config.enrich_daily_limit;
+        let provider = enrich_config.provider.name();
+        let over_limit = if limit == 0 {
+            true
+        } else {
+            match job_queue::count_enrich_jobs_started_today(&pool, provider).await {
+                Ok(ran_today) => ran_today >= i64::from(limit),
+                Err(e) => {
+                    tracing::warn!(error = %e, "failed to check daily enrich limit, proceeding");
+                    false
+                }
+            }
+        };
+        if over_limit {
+            current_interval = config.max_poll_interval;
+            tracing::info!(
+                provider,
+                limit,
+                next_poll = ?current_interval,
+                "daily enrich limit reached (or ENRICH_DAILY_LIMIT unset/0), pausing until the UTC day rolls over"
+            );
+            continue;
+        }
+
         match process_next_enrich_job(
             &pool,
             &repo_path,

--- a/packages/pipeline/tests/job_queue_tests.rs
+++ b/packages/pipeline/tests/job_queue_tests.rs
@@ -467,3 +467,60 @@ async fn test_concurrent_claim_safety() {
 
     assert_eq!(claimed_count, 1);
 }
+
+#[tokio::test]
+async fn test_count_enrich_jobs_started_today() {
+    let db = TestDb::new().await;
+
+    // Two claude enrich jobs and one opencode enrich job (payload provider set,
+    // as the admin enqueues them), plus a harvest job that must never count.
+    for law in ["c1", "c2"] {
+        let req =
+            CreateJobRequest::new(JobType::Enrich, law).with_payload(json!({"provider": "claude"}));
+        job_queue::create_job(&db.pool, req).await.unwrap();
+    }
+    let req =
+        CreateJobRequest::new(JobType::Enrich, "o1").with_payload(json!({"provider": "opencode"}));
+    job_queue::create_job(&db.pool, req).await.unwrap();
+    job_queue::create_job(&db.pool, CreateJobRequest::new(JobType::Harvest, "h1"))
+        .await
+        .unwrap();
+    // A pending (never claimed) claude job: started_at is NULL, so it must not count.
+    let req =
+        CreateJobRequest::new(JobType::Enrich, "c3").with_payload(json!({"provider": "claude"}));
+    job_queue::create_job(&db.pool, req).await.unwrap();
+
+    // Claiming sets started_at = now(). Claim the three oldest enrich jobs
+    // (c1, c2, o1 by creation order) and the harvest job; c3 stays pending.
+    for _ in 0..3 {
+        job_queue::claim_job(&db.pool, Some(JobType::Enrich))
+            .await
+            .unwrap()
+            .unwrap();
+    }
+    job_queue::claim_job(&db.pool, Some(JobType::Harvest))
+        .await
+        .unwrap()
+        .unwrap();
+
+    // Only the two claimed claude jobs count; pending c3, opencode, and harvest excluded.
+    let claude = job_queue::count_enrich_jobs_started_today(&db.pool, "claude")
+        .await
+        .unwrap();
+    assert_eq!(claude, 2, "two claude enrich jobs started today");
+
+    let opencode = job_queue::count_enrich_jobs_started_today(&db.pool, "opencode")
+        .await
+        .unwrap();
+    assert_eq!(opencode, 1, "provider filter is per-provider");
+
+    // A run from a previous day falls outside today's UTC window.
+    sqlx::query("UPDATE jobs SET started_at = now() - interval '2 days' WHERE law_id = 'c1'")
+        .execute(&db.pool)
+        .await
+        .unwrap();
+    let claude = job_queue::count_enrich_jobs_started_today(&db.pool, "claude")
+        .await
+        .unwrap();
+    assert_eq!(claude, 1, "backdated run excluded from today's count");
+}


### PR DESCRIPTION
## Why

Two related changes to the enrich-worker's `claude` provider:

1. **Personal Claude login.** Let the enricher authenticate `claude -p` with a *personal Claude subscription* (Pro/Max) via a `claude setup-token` OAuth token, instead of a metered Console API key. This survives container redeploys because it lives as a ZAD component env var (ZAD has no persistent storage / read-only rootfs — an on-disk `~/.claude` login can't persist and can't be created headlessly).
2. **Daily run cap.** Keep that personal token from running the whole ~22k-law corpus in one day.

## What

- **`CLAUDE_CODE_OAUTH_TOKEN` added to `LLM_ENV_ALLOWLIST`** (`enrich.rs`). The worker strips the subprocess env to this allowlist, so without it the token never reaches `claude -p`. The CLI reads it as an OAuth bearer token (the documented headless path); `ANTHROPIC_API_KEY` must be **unset** because it takes precedence.
- **`ENRICH_DAILY_LIMIT`** — a per-provider daily run cap, counted from the durable `jobs` table (survives restarts; an in-memory counter would reset on every pod restart). Counts every job that ran today in **any** status (started / failed / retrying), excluding only never-run `pending` jobs. Enforced pre-claim in `run_enrich_worker`; once reached it pauses the worker until the UTC day rolls over.
  - **Fail-closed:** unset or `0` = paused. A worker needs an explicit positive limit to run. A forgotten env var runs *nothing* rather than the whole corpus.
- Docs/parity in `entrypoint-enrich.sh`, `.env.example`, `docker-compose.dev.yml`.
- Integration test covers the count query (provider filter, run-state inclusion, UTC day boundary).

## ⚠️ Operational impact

`ENRICH_DAILY_LIMIT` is fail-closed, so **every enrich worker — including the VLAM/opencode one — now needs an explicit positive `ENRICH_DAILY_LIMIT` or it will not enrich anything.** Set it on each enrich worker before/at deploy.

The cap keys on the worker's configured `LLM_PROVIDER` and pauses the whole worker when reached, so it is intended for a **provider-dedicated** worker (e.g. a claude-only enrichworker).

## To use the personal login (on the claude enrichworker component)

1. `claude setup-token` (personal Pro/Max account) → copy the token.
2. Set `CLAUDE_CODE_OAUTH_TOKEN=<token>`, `LLM_PROVIDER=claude`, `ENRICH_DAILY_LIMIT=<n>`.
3. **Remove `ANTHROPIC_API_KEY`** on that component (precedence).

## Testing

- `cargo check` / `fmt` / `clippy` clean; pre-commit hooks pass.
- New integration test `test_count_enrich_jobs_started_today` passes.
- End-to-end: set the env as above and run a real Claude enrichment for a few laws; success proves the auth, and the worker logs `daily enrich limit reached … pausing` once the cap hits.

## Notes

- Personal-login caveats: shares your subscription's usage/rate-limit pool (same account); ~1-year token, no auto-refresh.
- Multi-worker race on the cap can overrun by up to N near the boundary — acceptable for a spend guard.