### PR TITLE
docs: strip LLM stylistic tells from draft/proposed RFCs

### DIFF
--- a/docs/src/content/rfcs/rfc-020.md
+++ b/docs/src/content/rfcs/rfc-020.md
@@ -16,18 +16,18 @@ depends_on:
 
 **Problem.** [RFC-019](/rfcs/rfc-019) selects law versions against a **single global
 `calculation_date`**. That answers "is this law in force today?", but Dutch law routinely requires
-resolving a referenced law **as it stood on a different date** - and that date must **propagate** to
+resolving a referenced law **as it stood on a different date**, and that date must **propagate** to
 everything resolved beneath the reference:
 
-- **Eerbiedigende werking / overgangsrecht** - the old law stays applicable to existing cases
+- **Eerbiedigende werking / overgangsrecht**: the old law stays applicable to existing cases
   (Aanwijzing 5.64). Real corpus case: CEK23's staartzin, "*met dien verstande dat zij van
   toepassing blijft op subsidies die voor die datum zijn verstrekt*" ([RFC-019](/rfcs/rfc-019)
   example A).
-- **Statische vs. dynamische verwijzing** (Aanwijzing 3.47) - a static reference freezes the text
+- **Statische vs. dynamische verwijzing** (Aanwijzing 3.47): a static reference freezes the text
   on a date and survives later change/repeal. Statutory formula: "*zoals dat luidde op <datum>*"
   (e.g. Wet IB 2001 art. 10bis.1: "*zoals dat luidde op 31 december 2012*"); Aanwijzing 3.47 itself:
   "*zoals zij op een gegeven tijdstip luidden*".
-- **Ex nunc / ex tunc** - the heroverweging in bezwaar (Awb art. 7:11) is in beginsel ex nunc, with
+- **Ex nunc / ex tunc**: the heroverweging in bezwaar (Awb art. 7:11) is in beginsel ex nunc, with
   exceptions; which event date governs is Awb + jurisprudence.
 - **Lex mitior** (Awb art. 5:46 lid 4) even requires **two dates in one decision**: a bestuurlijke
   boete compares the rule at the *overtreding* and at the *beschikking* and must apply the one most
@@ -39,18 +39,18 @@ for a **reference** to be resolved at one of those dates instead of the global `
 
 ## Decision
 
-Add an optional **`as_of`** to a cross-law reference / open-term resolution: the referenced law -
-and everything beneath it - is resolved at that date, using [RFC-019](/rfcs/rfc-019)'s
+Add an optional **`as_of`** to a cross-law reference / open-term resolution: the referenced law
+(and everything beneath it) is resolved at that date, using [RFC-019](/rfcs/rfc-019)'s
 `valid_from`/`valid_to` selection.
 
-### Grounding - the law and jurisprudence this RFC is built on
+### Grounding: the law and jurisprudence this RFC is built on
 
 | Source | Vindplaats | Role in this RFC |
 |---|---|---|
-| Awb art. 7:11 (heroverweging) | [BWBR0005537](https://wetten.overheid.nl/BWBR0005537) | lid 1: "*Indien het bezwaar ontvankelijk is, vindt op grondslag daarvan een heroverweging van het bestreden besluit plaats.*" - example A |
-| Awb art. 5:46 lid 4 + art. 1 lid 2 Sr | [BWBR0005537](https://wetten.overheid.nl/BWBR0005537) · [BWBR0001854](https://wetten.overheid.nl/BWBR0001854) | lex mitior codified: "*Artikel 1, tweede lid, van het Wetboek van Strafrecht is van overeenkomstige toepassing.*" - §4, example C |
-| Ex-nunc jurisprudence | ABRvS *Greenpeace* 28-10-2020 ([ECLI:NL:RVS:2020:2571](https://uitspraken.rechtspraak.nl/details?id=ECLI:NL:RVS:2020:2571), standard arrest, r.o. 6.2.3-6.2.9) · *Steenwijkerland* 21-12-2016 ([ECLI:NL:RVS:2016:3388](https://uitspraken.rechtspraak.nl/details?id=ECLI:NL:RVS:2016:3388)) · *Berg en Dal* 21-02-2018 ([ECLI:NL:RVS:2018:610](https://uitspraken.rechtspraak.nl/details?id=ECLI:NL:RVS:2018:610), exception-side anchor) | the ex-nunc default is jurisprudential, not statutory - §3 |
-| Lex-mitior jurisprudence | ABRvS 21-05-2025 ([ECLI:NL:RVS:2025:2223](https://uitspraken.rechtspraak.nl/details?id=ECLI:NL:RVS:2025:2223)) · ABRvS 30-08-2023 ([ECLI:NL:RVS:2023:3291](https://uitspraken.rechtspraak.nl/details?id=ECLI:NL:RVS:2023:3291)) · CBb 06-07-2021 ([ECLI:NL:CBB:2021:700](https://uitspraken.rechtspraak.nl/details?id=ECLI:NL:CBB:2021:700)) | mandatory favourable-provision duty confirmed through beroep - §4 |
+| Awb art. 7:11 (heroverweging) | [BWBR0005537](https://wetten.overheid.nl/BWBR0005537) | lid 1: "*Indien het bezwaar ontvankelijk is, vindt op grondslag daarvan een heroverweging van het bestreden besluit plaats.*" (example A) |
+| Awb art. 5:46 lid 4 + art. 1 lid 2 Sr | [BWBR0005537](https://wetten.overheid.nl/BWBR0005537) · [BWBR0001854](https://wetten.overheid.nl/BWBR0001854) | lex mitior codified: "*Artikel 1, tweede lid, van het Wetboek van Strafrecht is van overeenkomstige toepassing.*" (§4, example C) |
+| Ex-nunc jurisprudence | ABRvS *Greenpeace* 28-10-2020 ([ECLI:NL:RVS:2020:2571](https://uitspraken.rechtspraak.nl/details?id=ECLI:NL:RVS:2020:2571), standard arrest, r.o. 6.2.3-6.2.9) · *Steenwijkerland* 21-12-2016 ([ECLI:NL:RVS:2016:3388](https://uitspraken.rechtspraak.nl/details?id=ECLI:NL:RVS:2016:3388)) · *Berg en Dal* 21-02-2018 ([ECLI:NL:RVS:2018:610](https://uitspraken.rechtspraak.nl/details?id=ECLI:NL:RVS:2018:610), exception-side anchor) | the ex-nunc default is jurisprudential, not statutory (§3) |
+| Lex-mitior jurisprudence | ABRvS 21-05-2025 ([ECLI:NL:RVS:2025:2223](https://uitspraken.rechtspraak.nl/details?id=ECLI:NL:RVS:2025:2223)) · ABRvS 30-08-2023 ([ECLI:NL:RVS:2023:3291](https://uitspraken.rechtspraak.nl/details?id=ECLI:NL:RVS:2023:3291)) · CBb 06-07-2021 ([ECLI:NL:CBB:2021:700](https://uitspraken.rechtspraak.nl/details?id=ECLI:NL:CBB:2021:700)) | mandatory favourable-provision duty confirmed through beroep (§4) |
 | Aanwijzingen 3.47 / 5.60 / 5.61 / 5.64 | [BWBR0005730](https://wetten.overheid.nl/BWBR0005730), deep links via [kcbr.nl](https://www.kcbr.nl) | drafting conventions: statische/dynamische verwijzing, plaats overgangsrecht, onmiddellijke werking, eerbiedigende werking (besluit van de Minister-President, not substantive law) |
 | Wet IB 2001 art. 10bis.1 | [BWBR0011353](https://wetten.overheid.nl/BWBR0011353) | the "*zoals dat luidde op <datum>*" static-reference formula in live legislation |
 | Awb bezwaartermijn chain | `corpus/.../algemene_wet_bestuursrecht/1994-01-01.yaml`, `features/bezwaartermijn.feature` | existing modeled lifecycle this RFC builds on |
@@ -63,7 +63,7 @@ Conflating these is the root confusion:
 |---|---|---|
 | **Instrument validity** | When is this *text* in force? | `valid_from` / `valid_to` ([RFC-019](/rfcs/rfc-019)) |
 | **Substantive scope** | Which period/facts does the norm *govern*? | the rule's conditions + `temporal` metadata ([RFC-001](/rfcs/rfc-001) §8) |
-| **Applicable-date selection** | *Which version-date* do we evaluate a reference against? | **this RFC** - computed by law, carried per reference |
+| **Applicable-date selection** | *Which version-date* do we evaluate a reference against? | **this RFC**, computed by law, carried per reference |
 
 ### 2. `as_of` on a reference, propagating down the subtree
 
@@ -76,24 +76,24 @@ input:
       as_of: $besluit_datum        # resolve the referenced law as it stood on this date
 ```
 
-- **Default = dynamic** (no `as_of`): follows the global `calculation_date` - the hoofdregel
+- **Default = dynamic** (no `as_of`): follows the global `calculation_date`, the hoofdregel
   (Aanwijzing 3.47) and current behaviour.
 - **`as_of: <date | $param>`**: a literal date models a *statische verwijzing*; a parameter (e.g.
   `$besluit_datum`) models ex tunc / eerbiedigende werking.
-- **Propagation: inherited down the subtree, innermost wins** - a statische verwijzing inside a
+- **Propagation: inherited down the subtree, innermost wins.** A statische verwijzing inside a
   dynamic context freezes only its own subtree.
 - **Recorded per reference**: the resolved date and selected version go into trace and receipt
-  ([RFC-013](/rfcs/rfc-013)), mirroring [RFC-019](/rfcs/rfc-019) §4 - the audit answer to "which
+  ([RFC-013](/rfcs/rfc-013)), mirroring [RFC-019](/rfcs/rfc-019) §4, the audit answer to "which
   version of which law was used, on what date basis".
 
 ### 3. The applicable date is computed by law, not by engine heuristic
 
 - The engine hard-codes no ex nunc/ex tunc/eerbiedigende-werking rules
   ([RFC-015](/rfcs/rfc-015): zero domain knowledge). The applicable date is *produced* by executing
-  the relevant rule - Awb 7:11 and/or the target law's own overgangsrecht - and passed as `as_of`.
+  the relevant rule (Awb 7:11 and/or the target law's own overgangsrecht) and passed as `as_of`.
   Event dates and date arithmetic exist ([RFC-008](/rfcs/rfc-008), [RFC-007](/rfcs/rfc-007) §3).
 - **There is no single statutory "applicable-date" article**:
-  - the ex-nunc reading of art. 7:11 is *jurisprudential* - standard arrest *Greenpeace*
+  - the ex-nunc reading of art. 7:11 is *jurisprudential*: the standard arrest *Greenpeace*
     (heroverweging "*op basis van de feiten en omstandigheden ten tijde van de heroverweging en op
     basis van het op dat moment geldende recht en beleid*", r.o. 6.2.3; exceptions in 6.2.4-6.2.9);
     *Berg en Dal* anchors the exception side;
@@ -104,15 +104,15 @@ input:
   Policy** default ([RFC-015](/rfcs/rfc-015)) annotated with their basis, overridable per reference
   via `as_of`. This refines [RFC-008](/rfcs/rfc-008)'s ex-nunc default; it does not contradict it.
 
-### 4. Multiple dates in one beoordeling - lex mitior
+### 4. Multiple dates in one beoordeling: lex mitior
 
 Art. 5:46 lid 4 Awb makes the lex-mitior principle (art. 1 lid 2 Sr) van overeenkomstige toepassing
-on bestuurlijke boetes - so one besluit op bezwaar can be ex nunc on the merits while the boete
+on bestuurlijke boetes, so one besluit op bezwaar can be ex nunc on the merits while the boete
 compares two dates. This **proves `as_of` must be per-reference**, not one global date.
 
 Four boundaries keep it faithful and out of the engine:
 
-- **Mandatory, not a free choice** - and "favourable" means favourable to the *offender*, never
+- **Mandatory, not a free choice**, and "favourable" means favourable to the *offender*, never
   "best result" in general.
 - **Punitive sanctions only** (afd. 5.4.1 Awb); a begunstigende beschikking has a single applicable
   version via ex nunc/ex tunc + overgangsrecht.
@@ -133,18 +133,18 @@ The IoC pattern (`open_terms`/`implements`, [RFC-003](/rfcs/rfc-003)) follows th
 propagation rule**: when a reference carries `as_of`, implementing regulations for the referenced
 subtree are selected at the propagated date, not at `calculation_date`. A statische verwijzing to
 an older version of a law therefore uses the implementing regulations *that were in force on that
-date* - the legally correct reading, and the only one consistent with "inherited down the subtree".
+date*, the legally correct reading, and the only one consistent with "inherited down the subtree".
 Selecting implementations at `calculation_date` would be an undocumented exception to that rule.
 
 ## Worked examples
 
-### A. Ex nunc vs. ex tunc - Awb 7:11 heroverweging
+### A. Ex nunc vs. ex tunc: Awb 7:11 heroverweging
 
 Whether the heroverweging applies the law of the *beslissing op bezwaar* moment (ex nunc) or of the
 original *besluit* moment (ex tunc) is selected by which event date is passed as `as_of`:
 
 ```yaml
-# Default (ex nunc): heroverweging follows current law - no as_of, uses calculation_date
+# Default (ex nunc): heroverweging follows current law; no as_of, uses calculation_date
 input:
   - name: oorspronkelijk_recht
     source:
@@ -163,11 +163,11 @@ input:
 ```
 
 *(Illustrative: the corpus `vreemdelingenwet_2000` does not yet expose
-`verblijfsvergunning_verleend`, and Awb 7:11 is not yet in the corpus Awb - the modeled chain today
+`verblijfsvergunning_verleend`, and Awb 7:11 is not yet in the corpus Awb; the modeled chain today
 is the bezwaartermijn. The example shows the mechanism; modeling the heroverweging is
 implementation work.)*
 
-### B. Statische verwijzing - frozen text by date
+### B. Statische verwijzing: frozen text by date
 
 ```yaml
 # "... de Wet X, zoals die luidde op 31 december 2000 ..."
@@ -179,11 +179,11 @@ input:
       as_of: '2000-12-31'   # static: survives later repeal of wet_x; date propagates down
 ```
 
-### C. Lex mitior - two dates, take the favourable one (art. 5:46 lid 4 Awb)
+### C. Lex mitior: two dates, take the favourable one (art. 5:46 lid 4 Awb)
 
-Two inputs resolve the *same* output at the two legally relevant moments; the selector (`MIN` - for
-a fixed fine, lower is favourable) lives in the law. Stays within the existing operation grammar:
-only `as_of` is new.
+Two inputs resolve the *same* output at the two legally relevant moments; the selector (`MIN`, since
+for a fixed fine the lower amount is favourable) lives in the law. Stays within the existing
+operation grammar: only `as_of` is new.
 
 ```yaml
 input:
@@ -192,7 +192,7 @@ input:
     source:
       regulation: wet_x
       output: boetebedrag
-      as_of: $overtreding_datum    # new stage input - see note below
+      as_of: $overtreding_datum    # new stage input; see note below
   - name: boete_besluitmoment
     type: amount
     source:
@@ -202,7 +202,7 @@ input:
 actions:
   - output: boete
     value:
-      operation: MIN          # gunstigste (= laagste) van twee momenten - art. 5:46 lid 4 Awb
+      operation: MIN          # gunstigste (= laagste) van twee momenten, art. 5:46 lid 4 Awb
       values:
         - $boete_overtredingsmoment
         - $boete_besluitmoment
@@ -210,7 +210,7 @@ actions:
 
 *(`$besluit_datum` is the existing [RFC-008](/rfcs/rfc-008) BEHANDELING stage input.
 `$overtreding_datum` is not: a boete procedure needs its own lifecycle that adds it as a stage
-input - that lifecycle is future RFC-008 extension work, alongside modeling this pattern.)*
+input; that lifecycle is future RFC-008 extension work, alongside modeling this pattern.)*
 
 ## Still open
 
@@ -225,15 +225,15 @@ input - that lifecycle is future RFC-008 extension work, alongside modeling this
   this model.
 - **No reset to `calculation_date` inside an inherited `as_of` context**: propagation (§2) is
   "inherited down the subtree, innermost wins", and `calculation_date` is an engine-level value
-  that is not addressable as a `$`-parameter in law YAML - so a referenced law cannot declare
+  that is not addressable as a `$`-parameter in law YAML, so a referenced law cannot declare
   "always resolve my sub-references at the current date" (e.g. a dynamic rate table). This is a
   deliberate constraint for temporal consistency. An explicit escape would need an **engine
   change** (injecting `calculation_date` as a reserved parameter, with name-collision and
-  nested-subtree semantics to settle), not just a schema addition - so it stays out of scope until
+  nested-subtree semantics to settle), not just a schema addition, so it stays out of scope until
   a real corpus case demands it.
 - **`as_of: $param` with the parameter absent at runtime**: silently falling back to
   `calculation_date` would hide a caller error and contradict [RFC-015](/rfcs/rfc-015)'s
-  zero-domain-knowledge policy - the engine cannot know whether the date was optional. The
+  zero-domain-knowledge policy, because the engine cannot know whether the date was optional. The
   expected resolution is a strict resolution error (mirroring how missing required inputs already
   fail), but this must be settled in the implementation.
 
@@ -251,12 +251,12 @@ Extends the cucumber-rs harness (`features/bezwaartermijn.feature`, `features/ei
    overrides for its subtree.
 5. *failure path*: `as_of` *past* the target's `valid_to` (e.g. `as_of: '2027-01-01'` on a law
    with `valid_to: '2026-12-31'`) yields a [RFC-019](/rfcs/rfc-019) §3 `SelectionReason` error
-   (`EndedOn`) reported against the resolved date - never a silent miss.
-6. *failure path, symmetric*: `as_of` *before* the target's `valid_from` (law not yet in force -
+   (`EndedOn`) reported against the resolved date, never a silent miss.
+6. *failure path, symmetric*: `as_of` *before* the target's `valid_from` (law not yet in force,
    e.g. an `overtreding_datum` predating the law) yields the corresponding `SelectionReason`
    error (`NotYetInForce`).
 7. *IoC propagation*: with an outer `as_of`, implementing regulations (`open_terms`/`implements`,
-   [RFC-003](/rfcs/rfc-003)) are selected at the propagated date, not at `calculation_date` -
+   [RFC-003](/rfcs/rfc-003)) are selected at the propagated date, not at `calculation_date`,
    the §5 rule, with two versions of an implementing regulation loaded.
 
 Plus `as_of` cases in the **Temporal** conformance level ([RFC-014](/rfcs/rfc-014)).
@@ -266,13 +266,13 @@ Plus `as_of` cases in the **Temporal** conformance level ([RFC-014](/rfcs/rfc-01
 ### Benefits
 
 - **Legally faithful references**: ex nunc/ex tunc, statische verwijzing and eerbiedigende werking
-  are modeled by *which date* a reference resolves at - grounded in Awb, Aanwijzingen and
+  are modeled by *which date* a reference resolves at, grounded in Awb, Aanwijzingen and
   jurisprudence, not in engine heuristics.
 - **Composes with [RFC-019](/rfcs/rfc-019)**: a static `as_of` can resolve an earlier version even
   after the target's `valid_to`; an ended reference at the default date still fails honestly
   (RFC-019 §3, stated relative to the resolved date).
 - **Reuses existing machinery**: event dates ([RFC-008](/rfcs/rfc-008)), date arithmetic
-  ([RFC-007](/rfcs/rfc-007)), version selection ([RFC-019](/rfcs/rfc-019)) - only `as_of` and its
+  ([RFC-007](/rfcs/rfc-007)), version selection ([RFC-019](/rfcs/rfc-019)); only `as_of` and its
   propagation are new.
 
 ### Tradeoffs
@@ -286,7 +286,7 @@ Plus `as_of` cases in the **Temporal** conformance level ([RFC-014](/rfcs/rfc-01
 ### Alternatives Considered
 
 - **One global date for all version selection (status quo + RFC-019).** Rejected: cannot express ex
-  tunc, statische verwijzing or eerbiedigende werking - each resolves a reference at a non-global
+  tunc, statische verwijzing or eerbiedigende werking; each resolves a reference at a non-global
   date.
 - **Engine "tries all dates and picks the best" for lex mitior.** Rejected: deciding what counts as
   favourable is domain knowledge; the two moments and the selector belong in the law (§4).
@@ -298,16 +298,16 @@ Plus `as_of` cases in the **Temporal** conformance level ([RFC-014](/rfcs/rfc-01
 - **Schema**: additive `as_of` on `source` (literal date or `$`-parameter), encoded as the
   existing union pattern `oneOf: [variableReference, {type: string, format: date}]` so malformed
   dates and unprefixed parameter names fail validation. `as_of` is only meaningful when
-  `regulation` is present (there is no law to version-select otherwise) - the schema must make
+  `regulation` is present (there is no law to version-select otherwise); the schema must make
   that conditional (e.g. `if: {required: [regulation]}`), not silently ignore it. `source` is
-  `additionalProperties: false`, so this needs a new minor schema version - additive, non-breaking.
+  `additionalProperties: false`, so this needs a new minor schema version (additive, non-breaking).
 - **Engine**: thread `as_of` (default `calculation_date`) through the cross-law resolution path;
   inherit down the subtree, innermost wins; reuse [RFC-019](/rfcs/rfc-019)'s selection at the
   resolved date; include the resolved date in memoization and cycle-detection keys; report
   selection failures ([RFC-019](/rfcs/rfc-019) §3 `SelectionReason`) relative to the resolved date.
   Date-keyed cycle detection catches same-date self-reference; a regressive chain (A at *D*
   referencing A at *D−1*, and so on) has a unique key per step and is backstopped by the engine's
-  existing cross-law depth limit (`MAX_CROSS_LAW_DEPTH`) - a deliberate constraint, since static
+  existing cross-law depth limit (`MAX_CROSS_LAW_DEPTH`), a deliberate constraint, since static
   corpus YAML cannot generate ever-older `as_of` values itself.
 - **Receipt/trace**: record the resolved date per reference ([RFC-013](/rfcs/rfc-013)).
 - **Policy**: an Engine Policy entry for the ex-nunc / onmiddellijke-werking default, annotated

--- a/docs/src/content/rfcs/rfc-023.md
+++ b/docs/src/content/rfcs/rfc-023.md
@@ -1,5 +1,5 @@
 ---
-title: "RFC-023: Quantities in Law YAML — Money, Percentages, and Dimensioned Values"
+title: "RFC-023: Quantities in Law YAML (Money, Percentages, and Dimensioned Values)"
 status: Proposed
 implementation: Not implemented
 date: '2026-06-16'
@@ -13,18 +13,18 @@ short_title: Quantities in Law YAML
 ## Summary
 
 Today a law YAML stores money, ratios and percentages as bare numbers, so `3971900` or
-`0.01896` is indistinguishable from any other number — a factor-of-100 faithfulness risk. This RFC
+`0.01896` is indistinguishable from any other number, a factor-of-100 faithfulness risk. This RFC
 makes a value's *quantity-kind* an explicit label.
 
 **Decided (YAML/modeling layer):**
 
-1. Declare quantity-kind with `type` + `type_spec.unit` — on inputs, outputs, parameters **and**
+1. Declare quantity-kind with `type` + `type_spec.unit`, on inputs, outputs, parameters **and**
    `definitions` constants.
 2. Extend the `type_spec.unit` enum with `euro`, `ratio`, `percentage` (alongside existing
    `eurocent`, `years`, `weeks`, `months`, `days`).
 3. `ratio` and `percentage` are distinct labels; any division by 100 is an explicit value operation,
    never implied by the label.
-4. A unit is a label, not a computational constraint — tagging a value never changes it.
+4. A unit is a label, not a computational constraint; tagging a value never changes it.
 5. `definitions` entries may be *optionally* structured to carry `type`/`type_spec`; the bare
    `naam: 123` form stays valid.
 
@@ -33,7 +33,7 @@ is RFC-024. See [In practice](#in-practice) for worked YAML.
 
 ## Context
 
-The question is narrow — **how does a law YAML say what a number *means*?** — and today it often
+The question is narrow: **how does a law YAML say what a number *means*?** Today it often
 can't. The situations below, all from the current corpus, are what the language must be able to express.
 
 **1. The corpus already encodes quantities, but ambiguously.** `wet_op_de_zorgtoeslag` stores, in one
@@ -42,16 +42,16 @@ can't. The situations below, all from the current corpus, are what the language 
 ```yaml
 # corpus/regulation/nl/wet/wet_op_de_zorgtoeslag/2025-01-01.yaml (definitions, ~L56)
 drempelinkomen_alleenstaande:
-  value: 3971900        # eurocent — i.e. € 39.719,00. Nothing here says "eurocent".
+  value: 3971900        # eurocent, i.e. € 39.719,00. Nothing here says "eurocent".
 percentage_drempelinkomen_alleenstaande:
   value: 0.01896        # a 0–1 ratio (1,896%). Nothing here says "ratio, not percent".
 ```
 
-Guess wrong and you are off by a factor of 100 — in either direction.
+Guess wrong and you are off by a factor of 100, in either direction.
 
 **2. The same legal concept is stored in two incompatible ways.** Where zorgtoeslag uses decimal
-ratios, the Diemen `afstemmingsverordening_participatiewet` stores percentages as whole integers — and
-crucially these are **bare, untyped constants** in the schema-free `definitions` block: no `type`, no
+ratios, the Diemen `afstemmingsverordening_participatiewet` stores percentages as whole integers, and
+these are **bare, untyped constants** in the schema-free `definitions` block: no `type`, no
 unit, nothing to disambiguate them:
 
 ```yaml
@@ -59,30 +59,30 @@ unit, nothing to disambiguate them:
 #   afstemmingsverordening_participatiewet/2015-01-01.yaml (definitions, ~L69)
 definitions:                 # schema-free: `{ "type": "object", "additionalProperties": true }`
   PERCENTAGE_CATEGORIE_1:
-    value: 5                 # 5 percent — a bare integer, no type, no unit
+    value: 5                 # 5 percent (a bare integer, no type, no unit)
   PERCENTAGE_CATEGORIE_2:
-    value: 30                # 30 percent — indistinguishable from a raw multiplier 30
+    value: 30                # 30 percent (indistinguishable from a raw multiplier 30)
 ```
 
 There is no way today to tell "30 percent" from "raw multiplier 30." The `type: number` declarations
-that *do* appear elsewhere in this file sit on `parameters` and `input`/`output` fields — never on
+that *do* appear elsewhere in this file sit on `parameters` and `input`/`output` fields, never on
 these constants, which by construction cannot carry a type (see situation 5).
 
 **3. Quantities cross law boundaries.** A consuming law pulls another law's output via
-`source.regulation` + `output` — e.g. zorgtoeslag consumes `toetsingsinkomen` from the AWIR
+`source.regulation` + `output`, e.g. zorgtoeslag consumes `toetsingsinkomen` from the AWIR
 (`algemene_wet_inkomensafhankelijke_regelingen`). Both ends are already labeled today: the AWIR output
 and the zorgtoeslag input each declare `type: amount` + `type_spec.unit: eurocent`. So the YAML can already
-*express* this; what is missing is *checking* that producer and consumer agree — an engine concern
+*express* this; what is missing is *checking* that producer and consumer agree, which is an engine concern
 (see Implementation Notes), not a gap in the language.
 
 **4. Money is routinely sub-cent.** The corpus is social-domain today, but fiscal law is coming, and it
-is dense with sub-cent amounts — reached two different ways:
+is dense with sub-cent amounts, reached two different ways:
 
-- **A scaled base unit.** Excise duty (*accijns*) is denominated **per 1.000 liter** at two decimals —
+- **A scaled base unit.** Excise duty (*accijns*) is denominated **per 1.000 liter** at two decimals,
   e.g. € 844,69 / 1.000 L (enacted 2026). The printed figure is tidy, but the per-liter value it
   implies is € 0,84469 = 84,469 eurocent per liter, *not* a whole number of cents.
 - **A tariff printed directly at sub-cent precision.** Energy tax (*energiebelasting*, first bracket
-  electricity) is € 0,09161 / kWh (2026, excl. VAT) — a five-decimal per-kWh rate set straight in the
+  electricity) is € 0,09161 / kWh (2026, excl. VAT): a five-decimal per-kWh rate set straight in the
   legislation, no scaling trick involved.
 
 Different mechanisms, same modeling consequence: a money value is not always a whole number of cents.
@@ -90,13 +90,13 @@ Different mechanisms, same modeling consequence: a money value is not always a w
 This forces a principle the rest of this RFC relies on: **a unit is a label, not a computational
 constraint.** The arithmetic and the literal values determine the sum, so tagging a value never
 changes it by itself. The one way a `unit: eurocent` tag *could* corrupt a correct sum is by
-triggering implicit rounding — which is why labeling and rounding are kept strictly separate (rounding
+triggering implicit rounding, which is why labeling and rounding are kept strictly separate (rounding
 lives in [RFC-024](/rfcs/rfc-024)).
 
-**5. The place where misreading originates cannot carry a label at all.** The `definitions` block — the
-home of every constant in points 1–2 — is schema-free: in the schema it is
+**5. The place where misreading originates cannot carry a label at all.** The `definitions` block, the
+home of every constant in points 1–2, is schema-free: in the schema it is
 `{ "type": "object", "additionalProperties": true }`. Inputs and outputs can carry `type` /
-`type_spec`; constants cannot. That is precisely backwards, because constants are raw magic numbers
+`type_spec`; constants cannot. That is backwards: constants are raw magic numbers
 with no surrounding context to disambiguate them.
 
 ## Decision
@@ -108,18 +108,18 @@ provides it.
 | # | Situation in legislation (grounded) | What the YAML must express | Modeling primitive (YAML layer) |
 |---|---|---|---|
 | 1 | Money in whole cents (zorgtoeslag `3971900`) | "this is money, denominated in eurocent" | `type: amount` + `type_spec.unit: eurocent` (exists) |
-| 2 | Sub-cent tariffs (accijns, energiebelasting) | "this money value is not a whole number of cents; the label must not force whole cents" | a money label usable without implying integer cents (`euro` / `eurocent`), paired with `type_spec.precision` (in the schema; issue #444) to state decimal places. Rounding is out of scope — see RFC-024 |
+| 2 | Sub-cent tariffs (accijns, energiebelasting) | "this money value is not a whole number of cents; the label must not force whole cents" | a money label usable without implying integer cents (`euro` / `eurocent`), paired with `type_spec.precision` (in the schema; issue #444) to state decimal places. Rounding is out of scope (see RFC-024) |
 | 3 | Percentage stored as ratio (`0.01896`, `0.137`) | "this is a 0–1 ratio, not a 0–100 percent, not a bare multiplier" | `type_spec.unit: ratio` |
 | 4 | Percentage stored as whole percent (`5`, `30`) | "this is a 0–100 percent" | `type_spec.unit: percentage` |
 | 5 | Constants in `definitions` carry no type | "a constant can declare its quantity-kind" | make `definitions` entries *optionally* structured so a constant carries `type` + `type_spec`; the bare `naam: 123` form stays valid |
 
 (Durations and cross-law unit flow are *already* expressible with existing vocabulary and are not
-decisions of this RFC — see [Already expressible](#already-expressible) below.)
+decisions of this RFC; see [Already expressible](#already-expressible) below.)
 
 Concretely, this RFC decides, at the YAML/modeling layer:
 
 1. **Quantity-kind is an explicit, first-class label**, declared with `type` + `type_spec.unit`,
-   available on inputs, outputs, parameters, **and definitions/constants** — closing the schema-free
+   available on inputs, outputs, parameters, **and definitions/constants**, closing the schema-free
    `definitions` gap (situation 5).
 2. **Extend the `type_spec.unit` enum** with `euro`, `ratio`, and `percentage`, alongside the
    existing `eurocent`, `years`, `weeks`, `months`, `days`. Adding `euro` does **not** deprecate
@@ -128,7 +128,7 @@ Concretely, this RFC decides, at the YAML/modeling layer:
 3. **`ratio` and `percentage` are distinct labels for the same dimension**, and the corpus keeps both.
    We do not force a single canonical form, because some texts state "1,896" as a ratio and others
    state "30 procent" literally. Whether a `percentage` is divided by 100 is a *value* concern,
-   expressed by an explicit `DIVIDE … 100` in the YAML where the value is *applied* — never something
+   expressed by an explicit `DIVIDE … 100` in the YAML where the value is *applied*, never something
    the label silently performs. The corpus already works this way, and across a law boundary: the
    Diemen `afstemmingsverordening_participatiewet` stores the verlagingspercentages as whole percents
    (`5`, `30`) and uses them directly in its `IF` cases, while the national `participatiewet` that
@@ -143,7 +143,7 @@ Concretely, this RFC decides, at the YAML/modeling layer:
    (backward-compatible); the structured form lets a constant carry `type` and `type_spec`, reusing
    the existing field shape so there is one way to describe a quantity everywhere.
 
-This RFC does not decide how the engine *checks*, *infers*, or *reconciles* units — only what the YAML
+This RFC does not decide how the engine *checks*, *infers*, or *reconciles* units, only what the YAML
 may *say*. See Implementation Notes.
 
 ### In practice
@@ -153,7 +153,7 @@ Context situations 1–2):
 
 ```yaml
 definitions:
-  # money constant — was a bare `3971900`
+  # money constant (was a bare 3971900)
   drempelinkomen_alleenstaande:
     value: 3971900
     type: amount
@@ -183,7 +183,7 @@ input:
       unit: eurocent
 ```
 
-The bare `naam: 123` form stays valid, so labeling is incremental — a constant is upgraded only when
+The bare `naam: 123` form stays valid, so labeling is incremental: a constant is upgraded only when
 someone annotates it.
 
 ### Already expressible
@@ -195,7 +195,7 @@ of reaching for a bare `type: number`:
 - **Durations.** A value meant as months / years / days is modeled with the existing time units
   `years`, `weeks`, `months`, `days` (RFC-001), not a bare `type: number`. No new unit is required.
 - **Cross-law unit flow.** The consuming `source` input already declares its expected
-  `type_spec.unit`, and producing laws label their outputs too (Context situation 3 — zorgtoeslag's
+  `type_spec.unit`, and producing laws label their outputs too (Context situation 3: zorgtoeslag's
   `toetsingsinkomen` and the AWIR output both carry `unit: eurocent`). Reconciling a producer/consumer
   *mismatch* is an engine concern (see Implementation Notes), not a YAML-layer addition.
 
@@ -204,11 +204,11 @@ of reaching for a bare `type: number`:
 ### Benefits
 
 - A labeled value states its quantity-kind explicitly, removing the factor-of-100 ambiguity at the
-  source. The label is not self-enforcing — at the YAML layer it is inert until a consumer acts on it
-  (engine unit-checks are deferred, see Implementation Notes) — but a reader, human or tool, no longer
+  source. The label is not self-enforcing (at the YAML layer it is inert until a consumer acts on it;
+  engine unit-checks are deferred, see Implementation Notes), but a reader, human or tool, no longer
   has to *guess* whether `3971900` is euros or cents.
 - The label is consumed by more than the engine: the editor renders the correct input control from a
-  value's `type`/`type_spec` (a boolean switch, a euro field) — see PR #748 — so a single YAML-layer
+  value's `type`/`type_spec` (a boolean switch, a euro field; see PR #748), so a single YAML-layer
   decision pays off across the engine, the editor UI, and scenario inputs.
 - Cross-law flows become checkable once the engine reconciles units (deferred): the consuming law
   states the unit it expects to receive.
@@ -227,7 +227,7 @@ of reaching for a bare `type: number`:
 ### Alternatives Considered
 
 **Alternative 1: a single canonical percentage form (ratio only).**
-Force every percentage to a 0–1 ratio. Rejected: it distorts faithful modeling — a law that says "30
+Force every percentage to a 0–1 ratio. Rejected: it distorts faithful modeling. A law that says "30
 procent" should be transcribable as `30` with a `percentage` label, not silently rewritten to `0.30`.
 
 **Alternative 2: drop `eurocent`, use `euro` floats everywhere.**
@@ -237,7 +237,7 @@ floats invites the very precision loss this work is trying to prevent.
 **Alternative 3: bundle rounding into the unit (the RFC-015 coercion).**
 Let `unit: eurocent` imply round-to-integer. Rejected: empirically false for sub-cent tariffs
 (accijns, energiebelasting), and it hides a legal decision inside a unit label. Rounding must be a
-law-modeled instruction — see RFC-024.
+law-modeled instruction (see RFC-024).
 
 **Alternative 4: leave `definitions` schema-free and rely on naming conventions.**
 Rejected: that is the status quo that produces the factor-of-100 ambiguity in situations 1–2.
@@ -248,8 +248,8 @@ This RFC is intentionally silent on the engine. The unit *algebra* (which unit p
 each operation), unit *inference* over expression trees, the static-validation and runtime mismatch
 checks, the error type for a mismatch, and cross-law unit *reconciliation* are engine concerns,
 specified and implemented separately. A prototype of that engine machinery already exists in PR #729
-(*units of measurement on values*), which originally drafted itself as "RFC-019" — a number since
-assigned on `main` to an unrelated RFC (Law End Dates). This RFC **supersedes the modeling decisions**
+(*units of measurement on values*), which originally drafted itself as "RFC-019" (a number since
+assigned on `main` to an unrelated RFC, Law End Dates). This RFC **supersedes the modeling decisions**
 in that draft, reframed situation-first; the Rust code in PR #729 can serve as the implementation of
 this RFC's deferred engine track. The only concrete artifact this RFC implies is a future schema
 version that adds the `euro`/`ratio`/`percentage` units and the optional structured
@@ -257,14 +257,14 @@ version that adds the `euro`/`ratio`/`percentage` units and the optional structu
 
 ## References
 
-- [RFC-001: YAML Schema Design Decisions](/rfcs/rfc-001) — the type system, `type_spec` and unit enum
+- [RFC-001: YAML Schema Design Decisions](/rfcs/rfc-001): the type system, `type_spec` and unit enum
   this RFC extends (the `type_spec.precision` field lives in the schema; see issue #444)
-- [RFC-012: Untranslatables](/rfcs/rfc-012) — the "grow the vocabulary only when real legal texts
+- [RFC-012: Untranslatables](/rfcs/rfc-012): the "grow the vocabulary only when real legal texts
   demand it" philosophy this RFC follows
-- [RFC-015: Engine Policy](/rfcs/rfc-015) — the `unit: eurocent → round_to_integer` coercion this RFC
+- [RFC-015: Engine Policy](/rfcs/rfc-015): the `unit: eurocent → round_to_integer` coercion this RFC
   declines to adopt at the label level
-- [RFC-024: Precision and Rounding in Law YAML](/rfcs/rfc-024) — where rounding is modeled
-- PR #729 — prototype units-of-measurement engine machinery (the deferred implementation track)
-- PR #748 — editor scenario inputs rendered from `type`/`type_spec` (a non-engine consumer)
-- Issue #444 — `type_spec.precision`/`min`/`max` parsed but not enforced
+- [RFC-024: Precision and Rounding in Law YAML](/rfcs/rfc-024): where rounding is modeled
+- PR #729: prototype units-of-measurement engine machinery (the deferred implementation track)
+- PR #748: editor scenario inputs rendered from `type`/`type_spec` (a non-engine consumer)
+- Issue #444: `type_spec.precision`/`min`/`max` parsed but not enforced
 - [Glossary of Dutch Legal Terms](/reference/glossary)

--- a/docs/src/content/rfcs/rfc-024.md
+++ b/docs/src/content/rfcs/rfc-024.md
@@ -1,5 +1,5 @@
 ---
-title: "RFC-024: Precision and Rounding in Law YAML — Modeling Statutory Rounding"
+title: "RFC-024: Precision and Rounding in Law YAML (Modeling Statutory Rounding)"
 status: Proposed
 implementation: Not implemented
 date: '2026-06-16'
@@ -36,7 +36,7 @@ bedrag van de tegemoetkoming wordt rekenkundig afgerond op hele euro's"*
 ```
 
 [RFC-012](/rfcs/rfc-012) names rounding as *the* canonical untranslatable and suggests adding a
-rounding operation. This RFC is the situation-first mechanism that resolves it — in keeping with
+rounding operation. This RFC is the situation-first mechanism that resolves it, in keeping with
 RFC-012's own rule that the vocabulary grows only when real legal texts demand it.
 
 **2. Rounding has both a direction and a target.** Directions seen in or expected from Dutch law:
@@ -45,25 +45,25 @@ Targets: whole euro, whole cent, or a number of decimals. "Round to whole euros,
 up to whole euros" are different instructions and must be distinguishable.
 
 **3. Thresholds and caps are rounding-adjacent and under-modeled.** The AWIR continues: *"Een
-tegemoetkoming wordt niet toegekend indien deze minder dan € 24 zou bedragen"* (`:299`) — a
+tegemoetkoming wordt niet toegekend indien deze minder dan € 24 zou bedragen"* (`:299`), a
 below-threshold-to-nothing rule that is not modeled today. Zero-floors (`MAX(0, …)` in zorgtoeslag)
 and wealth caps (vermogensgrens, via `LESS_THAN_OR_EQUAL`) *are* modeled with existing operations.
 
 **4. Intermediate precision matters, and intermediate values must not be rounded.** The
-Zorgverzekeringswet computes a day-based pro-rata fraction — *"vermenigvuldigd met een breuk waarvan de
-teller gelijk is aan het aantal dagen … en de noemer aan het aantal dagen in het … kalenderjaar"*
-(`:522`) — and only *then* rounds the result to whole euros (`:537`). Two distinct rules apply, from two
-distinct sources (researched in issue #299): **intermediate calculations are not rounded** — standing
-Belastingdienst/Toeslagen administrative policy, not a court ruling — and **rekenkundig (half-up) is the
-default rounding method unless a law says otherwise** — established by the Hoge Raad (HR 15 May 2009,
-ECLI:NL:HR:2009:BI1980, itself a VAT case). Double-rounding an intermediate value shifts a legally
-binding amount.
+Zorgverzekeringswet computes a day-based pro-rata fraction (*"vermenigvuldigd met een breuk waarvan de
+teller gelijk is aan het aantal dagen … en de noemer aan het aantal dagen in het … kalenderjaar"*,
+`:522`) and only *then* rounds the result to whole euros (`:537`). Two distinct rules apply, from two
+distinct sources (researched in issue #299). First, **intermediate calculations are not rounded**:
+standing Belastingdienst/Toeslagen administrative policy, not a court ruling. Second, **rekenkundig
+(half-up) is the default rounding method unless a law says otherwise**: established by the Hoge Raad
+(HR 15 May 2009, ECLI:NL:HR:2009:BI1980, itself a VAT case). Double-rounding an intermediate value
+shifts a legally binding amount.
 
 **5. The engine currently rounds money implicitly, which is the wrong place for the decision.** Today
 the engine rounds eurocent outputs at the result boundary regardless of what the law says, and
 [RFC-015](/rfcs/rfc-015) proposes formalizing that as a `unit: eurocent → round_to_integer` coercion.
-But "currency must be whole cents" is empirically false (sub-cent accijns and energiebelasting tariffs
-— see RFC-023 §Context). **The law, not a unit-coercion policy, must decide whether and how a value is
+But "currency must be whole cents" is empirically false (sub-cent accijns and energiebelasting tariffs;
+see RFC-023 §Context). **The law, not a unit-coercion policy, must decide whether and how a value is
 rounded.** This RFC supplies the law-level vocabulary that lets that implicit engine behavior become
 law-controlled (issue #304).
 
@@ -75,41 +75,41 @@ expressiveness it requires and the primitive that provides it.
 | # | Situation in legislation (grounded) | What the YAML must express | Modeling primitive |
 |---|---|---|---|
 | 1 | "rekenkundig afgerond op hele euro's" (AWIR, zvw) | round to nearest, half-up, at a named point | `ROUND` + `precision` (half-up is its default) |
-| 2 | "naar boven afgerond op hele euro's" (the open untranslatable) | round up | `CEIL` + `precision` — flips the `accepted: false` entry to expressible |
-| 3 | "naar beneden" / "afkapping" | round down | `FLOOR` + `precision` (toward-zero `TRUNCATE` is deferred — see Alternative 4) |
+| 2 | "naar boven afgerond op hele euro's" (the open untranslatable) | round up | `CEIL` + `precision` (flips the `accepted: false` entry to expressible) |
+| 3 | "naar beneden" / "afkapping" | round down | `FLOOR` + `precision` (toward-zero `TRUNCATE` is deferred; see Alternative 4) |
 | 4 | Round to whole *cent* / to N decimals (sub-cent tariffs, e.g. 5 dp) | the granularity to round to | the `precision` field (decimal places) on any of these operations |
 | 5 | Pro-rata fraction then round (zvw art. 21) | full precision through the intermediate `DIVIDE`; round only at the named step | principle: **no implicit intermediate rounding** |
 
-(Below-threshold-to-nothing and zero-floor/cap need no new operation — they are existing patterns, see
-[Already expressible](#already-expressible) below. Banker's rounding / half-even is not in scope — see
+(Below-threshold-to-nothing and zero-floor/cap need no new operation; they are existing patterns, see
+[Already expressible](#already-expressible) below. Banker's rounding / half-even is not in scope; see
 decision 2.)
 
 Concretely, this RFC decides, at the YAML/modeling layer:
 
-1. **Rounding is an explicit, modeled legal instruction — never an implicit side effect of a type or
+1. **Rounding is an explicit, modeled legal instruction, never an implicit side effect of a type or
    unit.** This is the direct counter to the current boundary rounding and to RFC-015's unit coercion.
-2. **Introduce three distinct rounding operations** — `ROUND` (round to nearest), `CEIL` (round up),
+2. **Introduce three distinct rounding operations**: `ROUND` (round to nearest), `CEIL` (round up),
    and `FLOOR` (round down). Each is a **unary** operation: one operand
-   in `value:` (mirroring the unary `NOT`), plus a **`precision`** — the number of decimal places to
+   in `value:` (mirroring the unary `NOT`), plus a **`precision`**, the number of decimal places to
    round to, in the value's own unit (RFC-023). `precision` is a field **on the operation itself**,
    deliberately *not* read implicitly from the operand's `type_spec`, so the rounding instruction is
    always visible where it applies. `precision: 0` rounds to whole units, `precision: 5` to five
    decimals; rounding to whole euros is `precision: 0` on a euro-denominated value (and `precision: -2`
-   on one held in eurocent). This is the abstract granularity knob — no money-specific "whole euro"
+   on one held in eurocent). This is the abstract granularity knob; no money-specific "whole euro"
    keyword in the language.
 
    Distinct functions get distinct names, consistent with RFC-004's `ADD`/`SUBTRACT` and `MIN`/`MAX`
    and its stated philosophy that *"the operation name describes what happens."* `CEIL`, `FLOOR`
-   and round-to-nearest are genuinely different functions, not modes of one — so they are
+   and round-to-nearest are genuinely different functions, not modes of one, so they are
    not collapsed into a single `mode`-parametrised operation (see Alternatives Considered).
 
    `ROUND` is round-to-nearest with **half-up** as its default tie-break (the HR-2009 default). A
-   different tie-break — banker's rounding / **half-even** — is *not* part of this RFC: no corpus text
+   different tie-break, banker's rounding / **half-even**, is *not* part of this RFC: no corpus text
    demands it yet, so per RFC-012 it is left to a future optional `tie:` field on `ROUND` alone
    (`CEIL`/`FLOOR` have no tie-break). [RFC-014](/rfcs/rfc-014) already anticipates rounding
    joining the Core conformance level "when added."
 
-   Worked example — the AWIR's *"rekenkundig afgerond op hele euro's"* (`:298`), rounding the
+   Worked example: the AWIR's *"rekenkundig afgerond op hele euro's"* (`:298`), rounding the
    full-precision result of an earlier `SUBTRACT` only at the named step:
 
    ```yaml
@@ -132,7 +132,7 @@ Concretely, this RFC decides, at the YAML/modeling layer:
    value: $berekend_bedrag
    ```
 
-   And rounding to a number of decimals is just a non-zero `precision` — here an energiebelasting line
+   And rounding to a number of decimals is just a non-zero `precision`: here an energiebelasting line
    rounded half-up to whole cents (two decimals of a euro), or to five decimals for a sub-cent tariff:
 
    ```yaml
@@ -146,7 +146,7 @@ Concretely, this RFC decides, at the YAML/modeling layer:
    ```
 
 3. **Half-up (rekenkundig) is `ROUND`'s documented default tie-break** (per the Hoge Raad's 2009 VAT
-   ruling; issue #299) — but rounding is **never applied implicitly**. A law that rounds must say so
+   ruling; issue #299), but rounding is **never applied implicitly**. A law that rounds must say so
    with an explicit rounding operation. Where the law is silent, no rounding occurs (matching the
    "don't round intermediates" policy).
 4. **Intermediate values carry full precision.** As a normative rule: nothing rounds a value between
@@ -154,21 +154,21 @@ Concretely, this RFC decides, at the YAML/modeling layer:
    #299.)
 5. **This resolves the rounding untranslatable.** Once these rounding operations exist, the
    `test_untranslatables` "naar boven afgerond" entry (a `CEIL`) flips from `accepted: false` to
-   expressible — the concrete legal text that, per RFC-012, justifies growing the vocabulary.
+   expressible, the concrete legal text that, per RFC-012, justifies growing the vocabulary.
 
-This RFC does not specify the rounding *algorithm* or its edge cases — only the modeling vocabulary and
+This RFC does not specify the rounding *algorithm* or its edge cases, only the modeling vocabulary and
 the legal-default policy. See Implementation Notes.
 
 ### Already expressible
 
-These rounding-adjacent situations need **no new operation** — existing RFC-004 operations already
+These rounding-adjacent situations need **no new operation**: existing RFC-004 operations already
 cover them. They are not decisions of this RFC; they are recorded as patterns (with a worked example)
 so authors model them instead of leaving them implicit:
 
 - **Below-threshold-to-nothing.** *"niet toegekend indien minder dan € 24"* (AWIR `:299`) is an `IF`
   with a `LESS_THAN` comparison. The AWIR € 24 floor is the worked example authors should follow.
 - **Zero-floor / cap.** Clamping to a minimum or maximum (`MAX(0, …)`, the vermogensgrens cap) uses
-  the existing `MIN` / `MAX` operations — no rounding primitive involved.
+  the existing `MIN` / `MAX` operations, no rounding primitive involved.
 
 ## Why
 
@@ -188,8 +188,8 @@ so authors model them instead of leaving them implicit:
 - It grows the operation vocabulary, against the project's minimalism instinct. But RFC-012's own rule
   sanctions growth when real texts demand it, and the corpus demands it (AWIR, zvw,
   test_untranslatables).
-- Modelers must now *think about* rounding explicitly rather than relying on a silent default. That is
-  the point: the law's rounding becomes visible and auditable.
+- Modelers must now *think about* rounding explicitly rather than relying on a silent default, which is
+  deliberate: the law's rounding becomes visible and auditable.
 
 ### Alternatives Considered
 
@@ -202,13 +202,13 @@ Rejected: empirically wrong for sub-cent tariffs, and it hides a legal decision 
 configuration. The law text must control rounding.
 
 **Alternative 3: a single `ROUND` operation with a `mode` field** (`mode: half_up|ceil|floor`).
-Tempting, because the rounding direction becomes one comparable field and new variants slot in without
+One appeal is that the rounding direction becomes one comparable field and new variants slot in without
 new operations. Rejected: `ceil`, `floor` and round-to-nearest are genuinely *different
-functions*, not spellings of one — and RFC-004 already names different functions distinctly
+functions*, not spellings of one, and RFC-004 already names different functions distinctly
 (`ADD`/`SUBTRACT`, `MIN`/`MAX`), with the stated philosophy that *"the operation name describes what
 happens."* A single `mode`-parametrised `ROUND` would be the only such special case in the vocabulary.
 (The IF/SWITCH unification is **not** a precedent here: those were two syntaxes of one control-flow
-operation, whereas the rounding directions are distinct functions. RFC-004 is also not a flat enum —
+operation, whereas the rounding directions are distinct functions. RFC-004 is also not a flat enum:
 it groups operations by purpose with distinct operand fields, so "matching the enum" argues nothing.)
 Keeping the operations distinct also keeps each schema trivial: only `ROUND` ever needs a tie-break
 field; `CEIL`/`FLOOR` need none.
@@ -216,7 +216,7 @@ field; `CEIL`/`FLOOR` need none.
 **Alternative 4: also ship `TRUNCATE` (round toward zero) now.**
 Rejected for this RFC: `TRUNCATE` and `FLOOR` differ *only for negative values* (`FLOOR(-2.3) = -3`,
 `TRUNCATE(-2.3) = -2`); for non-negative values they are identical. The amounts Dutch law rounds
-"naar beneden" / "afkapping" — bedragen, tarieven, breuken — are non-negative, so `FLOOR` already
+"naar beneden" / "afkapping" (bedragen, tarieven, breuken) are non-negative, so `FLOOR` already
 covers every grounded corpus case, and no corpus text demands toward-zero rounding of a negative.
 Per RFC-012's rule that the vocabulary grows only when a real legal text demands it, `TRUNCATE` is
 deferred until such a text appears; it can then be added as a fourth unary operation with no change to
@@ -242,15 +242,15 @@ vocabulary and the legal-default policy; the engine track decides the computatio
 
 ## References
 
-- [RFC-004: Uniform Operation Syntax](/rfcs/rfc-004) — the operation vocabulary `ROUND`/`CEIL`/`FLOOR` join
-- [RFC-012: Untranslatables](/rfcs/rfc-012) — the rounding untranslatable this RFC resolves
-- [RFC-023: Quantities in Law YAML](/rfcs/rfc-023) — the unit a rounded value's `precision` is relative to
-- [RFC-014: Engine Conformance Test Suite](/rfcs/rfc-014) — where rounding ops join the Core level
-- [RFC-015: Engine Policy](/rfcs/rfc-015) — the engine-policy rounding track this RFC constrains
-- [RFC-001: YAML Schema Design Decisions](/rfcs/rfc-001) — the type system and `type_spec` (the
+- [RFC-004: Uniform Operation Syntax](/rfcs/rfc-004): the operation vocabulary `ROUND`/`CEIL`/`FLOOR` join
+- [RFC-012: Untranslatables](/rfcs/rfc-012): the rounding untranslatable this RFC resolves
+- [RFC-023: Quantities in Law YAML](/rfcs/rfc-023): the unit a rounded value's `precision` is relative to
+- [RFC-014: Engine Conformance Test Suite](/rfcs/rfc-014): where rounding ops join the Core level
+- [RFC-015: Engine Policy](/rfcs/rfc-015): the engine-policy rounding track this RFC constrains
+- [RFC-001: YAML Schema Design Decisions](/rfcs/rfc-001): the type system and `type_spec` (the
   `type_spec.precision` field a rounding result targets lives in the schema; see issue #444)
-- Issue #299 — research on rounding rules (Hoge Raad half-up default; don't round intermediates)
-- Issue #304 — "engine hardcodes eurocent rounding — should be law-controlled"
-- Issue #444 — `type_spec.precision` parsed but not enforced
-- PR #791 — engine boundary-rounding track
+- Issue #299: research on rounding rules (Hoge Raad half-up default; don't round intermediates)
+- Issue #304: "engine hardcodes eurocent rounding, should be law-controlled"
+- Issue #444: `type_spec.precision` parsed but not enforced
+- PR #791: engine boundary-rounding track
 - [Glossary of Dutch Legal Terms](/reference/glossary)


### PR DESCRIPTION
Removes em-dashes and filler tics from the three draft/proposed RFCs authored here — rfc-020, rfc-023, rfc-024 — so they read less like generated text.

## What changed
- **Em-dashes (—) → plain punctuation.** rfc-023 and rfc-024 each had 42; both now at zero. Replaced with commas, colons or parentheses per context.
- **Title em-dashes → parentheticals.** `RFC-023: … YAML — Money, …` becomes `… YAML (Money, …)`; same for rfc-024. The `RFC-NNN:` prefix (which the docs sidebar strips) is preserved, so parsing/short_title is unaffected.
- **rfc-020's spaced-hyphen (` - `) em-dash substitutes** normalised to real punctuation.
- **Filler tics removed:** "crucially", "precisely backwards", "That is the point", "Tempting, because …".

## What did not change
- All content, references, ECLI/BWB citations, code blocks and `#anchor` links are intact.
- En-dashes were kept only where they are correct numeric ranges (`0–1`, `0–100`, `1–2`).
- Line-for-line rewrites (133 insertions / 133 deletions), no structural edits.

Only Draft/Proposed RFCs by this author were touched; the Accepted RFCs and those by other authors were left alone.