### PR TITLE
docs(docs): markeer RFC-023 en RFC-024 als geïmplementeerd

### DIFF
--- a/docs/src/content/rfcs/rfc-023.md
+++ b/docs/src/content/rfcs/rfc-023.md
@@ -1,7 +1,7 @@
 ---
 title: "RFC-023: Quantities in Law YAML (Money, Percentages, and Dimensioned Values)"
 status: Proposed
-implementation: Not implemented
+implementation: Implemented
 date: '2026-06-16'
 authors:
 - Tim de Jager

--- a/docs/src/content/rfcs/rfc-024.md
+++ b/docs/src/content/rfcs/rfc-024.md
@@ -1,7 +1,7 @@
 ---
 title: "RFC-024: Precision and Rounding in Law YAML (Modeling Statutory Rounding)"
 status: Proposed
-implementation: Not implemented
+implementation: Implemented
 date: '2026-06-16'
 authors:
 - Tim de Jager


### PR DESCRIPTION
Both RFCs shipped as merged engine features but their frontmatter still read `implementation: Not implemented`. This flips only the `implementation` field to `Implemented`; `status` stays `Proposed` (the code landed ahead of formal acceptance — the two fields are orthogonal per CLAUDE.md).

- **RFC-023** (Quantities/Units) — PR #850, `packages/engine/src/units.rs`
- **RFC-024** (Precision & Rounding) — PR #848, `ROUND`/`CEIL`/`FLOOR` ops in `operations.rs` backed by `rust_decimal`

No status/lifecycle change; docs-only.