### PR TITLE
docs: skill voor docs-proza met detector voor AI-tells

### DIFF
--- a/.claude/skills/docs-writing/SKILL.md
+++ b/.claude/skills/docs-writing/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: docs-writing
+description: "Writing rules for the regelrecht docs site (docs/). Use when writing or editing prose under docs/ — RFCs, guides, component docs, concept pages, and the NL/EN landing copy. Keeps docs prose free of AI-generated tells and consistent with the site's government-technical register. Not for code, commit messages, or PR descriptions."
+---
+
+# docs-writing
+
+Prose in `docs/` is read by lawmakers, civil servants, and developers outside the team. It must read as written by a person, and it must sit in one consistent register: precise, government-technical, unhurried. The failure mode is not "wrong" but prose that is technically fine yet pattern-matches to LLM output — a reader notices within a paragraph, and for a government transparency project that costs credibility.
+
+This skill covers everything under `docs/`:
+
+- **English technical docs** — `docs/src/content/docs/**` (guide, operations, components, concepts, reference) and `docs/src/content/rfcs/**`. These are English, in a government-technical register.
+- **Bilingual landing copy** — `docs/src/lib/landing-content.ts`. NL is the original; EN is a translation kept in the *same* register. Edit both datasets together; never let them drift.
+
+There is precedent for this problem in the repo: PR #888 stripped LLM stylistic tells from draft RFCs by hand. This skill is that cleanup made repeatable.
+
+## The tool detects; you decide
+
+`check-prose-style.mjs` (next to this file) is a linter, not an arbiter. It catches mechanical signatures — em-dashes, banned phrases, "not X, but Y" contrasts — so your attention is free for the things a regex cannot see: rhythm, rule-of-three, register, whether a flagged contrast is actually a tell.
+
+**You are the arbiter.** Run the script, read each finding, and judge it. An `error` from the script is almost always right (em-dashes and banned phrases have near-zero false positives), so clear them all. A `warn` is a *candidate* — a regex flagged a "not ... but" that may be a dramatic contrast or may be incidental. Read the sentence and decide. Do not blindly rewrite every warning, and do not blindly trust a green run either: the script is silent on cadence and rule-of-three, which are the tells it cannot mechanize. A clean script plus a careful human read is the bar, not the script alone.
+
+```bash
+# From the repo root. No args => the default docs prose set.
+node .claude/skills/docs-writing/check-prose-style.mjs
+
+# One file (e.g. the RFC you just touched):
+node .claude/skills/docs-writing/check-prose-style.mjs docs/src/content/rfcs/rfc-025.md
+
+# Make warnings fail too, for a final gate:
+node .claude/skills/docs-writing/check-prose-style.mjs --strict
+```
+
+`error` findings exit 1; `warn` findings are reported but exit 0 unless `--strict`. Code is stripped before matching (fenced blocks, inline `code`, and everything outside string literals in `.ts`), so `--no-verify`, `a - b`, and dashes inside code never trip it.
+
+## What the script cannot see — check these by hand
+
+The regex catches surface tells. These are the ones you read for:
+
+- **Rhythm.** Vary sentence and paragraph length. Every sentence at 15–20 words and every paragraph at three sentences reads as machine-generated even when every word is right. This is the single biggest tell and the script is blind to it.
+- **Rule-of-three.** "X, Y, and Z" noun lists in titles and opening sentences are the structural signature LLMs overuse most. Two or four items is fine; three is suspicious unless the three things genuinely exist. Read every heading and lede aloud.
+- **Rhetorical-question-then-answer.** "The result? Faster builds." Cut the question, lead with the answer. (Not linted — too many real FAQ questions on this site to distinguish mechanically.)
+- **Closing that restates the opening.** Trust the reader; end on the last real point.
+- **Manufactured balance.** Perfectly symmetric bullet lists, every bullet ending in a neat summary clause, adjacent bullets starting with the same verb. Humans trail off and vary.
+- **Hedge-stacking.** "I think", "perhaps", "it seems" on every sentence. One or two load-bearing hedges are fine; the pattern-frequency is the tell.
+
+## Register for these docs
+
+- **English docs are government-technical, not marketing.** State what a thing does and how. No "powerful", "seamless", "elegant", "robust" unless substantiated on the same line. The landing page sells; the docs explain.
+- **Be specific and name things.** "The harvester converts BWB XML to YAML" beats "the tool processes the data". "RFC-007" beats "an earlier design". Link RFCs and concept pages by their real identifiers — the site auto-links `RFC-NNN`.
+- **Criticism and limitations stated plainly.** "This does not handle cross-law cycles yet" beats "there may be some edge cases to consider". Docs that hedge every limitation read as generated.
+- **Domain terms keep their form.** Dutch domain vocabulary (`bewindspersoon`, `toetsingsinkomen`, `machine_readable`, `open_terms`) stays as-is in English prose. Keycloak "realm", "IT-landschap", "klantreis" are real terms here, not banned words — that is why the linter leaves them alone.
+- **Landing NL is the source of truth.** When you edit `landing-content.ts`, write or revise the NL string first, then bring the EN translation into the same register. A change to one dataset that skips the other is a bug.
+
+## Docs-specific mechanics
+
+- **Frontmatter is reader-facing.** `title` and `description` render on the page and in search results — they get the same anti-tell treatment as the body. RFC frontmatter has required fields (`title`, `status`, `implementation`, `date`, `authors`); see `rfc-000.md` and `template.md`. Ground `status` and `implementation` in the codebase, not the RFC's aspirations.
+- **Mermaid diagrams need an accessible name** (enforced separately by the a11y gate). When you add a diagram, its meaning must also be legible from the prose around it — do not make the diagram load-bearing for a reader who cannot see it.
+- **Do not hand-edit generated files.** If a page is code-generated, change the source. (The BDD grammar and RFC link-rewriting are generated; markdown content pages are not.)
+
+## Hard rules (unconditional)
+
+These hold even without opening the checklist:
+
+- **No em-dashes (—) or en-dashes (–) as punctuation.** Ever. Comma, period, parentheses, colon, or rewrite.
+- **American English** for English text (organize, analyze, behavior) unless told otherwise.
+- **No emoji in running prose**, no random mid-sentence bolding for emphasis.
+
+## Before you ship a docs change
+
+1. Run `check-prose-style.mjs` on the files you touched. Clear every `error`.
+2. Read each `warn` and decide: real contrast → rewrite; incidental → leave it.
+3. Read your headings and ledes aloud. Rule-of-three? Rewrite.
+4. Scan for uniform rhythm — vary it.
+5. If you edited `landing-content.ts`, confirm NL and EN both changed and match register.
+6. Build still passes: `just docs-build` (or `npm run build` in `docs/`).
+
+Then, if the prose is going to Anne to paste somewhere, pipe it through `pbcopy`.

--- a/.claude/skills/docs-writing/check-prose-style.mjs
+++ b/.claude/skills/docs-writing/check-prose-style.mjs
@@ -1,0 +1,279 @@
+#!/usr/bin/env node
+// Mechanical anti-AI-tell filter for regelrecht docs prose.
+//
+// Two severities:
+//   error  — signatures with ~zero false positives. Exit 1. Fix before shipping.
+//            em-dashes, banned LLM phrases, "Overall,"-style summary openers.
+//   warn   — heuristic tells a human must judge (a regex cannot tell a real
+//            "not X, but Y" contrast from an incidental "not ... but" in one
+//            sentence). Reported, but exit stays 0 unless --strict.
+//
+// This is a linter, not a judge. Rhythm, rule-of-three, register, and whether a
+// flagged contrast is genuinely a tell still need the SKILL.md checklist and a
+// human eye. It exists to catch the mechanical stuff so the human read can spend
+// its attention on cadence.
+//
+// Scope: markdown/MDX prose under docs/src/content and the bilingual landing
+// copy in docs/src/lib/landing-content.ts. Code is not prose — fenced blocks,
+// inline `code`, and (in .ts) everything outside string literals are stripped
+// before matching, so `--no-verify`, `a - b`, and `foo—bar` in code never trip.
+//
+// Usage:
+//   node check-prose-style.mjs [path ...]     # defaults to the docs prose set
+//   node check-prose-style.mjs --strict       # warnings fail too (exit 1)
+//   node check-prose-style.mjs --help
+//
+// Default paths resolve against the repo root inferred from this file's location
+// (.claude/skills/docs-writing/ -> repo root), so it runs from anywhere.
+
+import { readdirSync, statSync, readFileSync, existsSync } from 'node:fs';
+import { join, relative, resolve, extname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = fileURLToPath(new URL('.', import.meta.url));
+// .claude/skills/docs-writing/ -> repo root is three levels up.
+const REPO_ROOT = resolve(HERE, '..', '..', '..');
+
+const DEFAULT_TARGETS = [
+  'docs/src/content',
+  'docs/src/lib/landing-content.ts',
+];
+
+// ---------------------------------------------------------------------------
+// Rules. `level` is 'error' or 'warn'. Regexes run over already-code-stripped
+// text. Keep messages short; SKILL.md carries the "why".
+//
+// The banned lists deliberately DROP words that carry a real technical meaning
+// in this repo (realm — Keycloak; landscape — "IT-landschap"; journey —
+// "klantreis"). A linter that cries wolf on domain vocabulary gets muted.
+// ---------------------------------------------------------------------------
+
+const RULES = [
+  {
+    id: 'em-dash',
+    level: 'error',
+    // em-dash and en-dash used as punctuation. A hyphen-minus is fine.
+    re: /[—–]/g,
+    msg: 'em-dash / en-dash',
+    hint: 'Rewrite with a comma, period, parentheses, or colon. Never an em-dash.',
+  },
+  {
+    id: 'banned-en',
+    level: 'error',
+    re: /\b(it is worth noting|it should be noted|it is important to (?:note|emphasi[sz]e)|in the current landscape|in a world where|at the intersection of|delve|deep dive|dive deep|tapestry|groundbreaking|game-changer|paradigm shift|buckle up|let'?s dive in|here'?s the thing)\b/gi,
+    msg: 'banned phrase (EN)',
+    hint: 'Rewrite the sentence from scratch — swapping one word leaves the cadence.',
+  },
+  {
+    id: 'banned-nl',
+    level: 'error',
+    re: /\b(het is belangrijk om op te merken|het is vermeldenswaardig|in het huidige landschap|in een wereld waarin|laten we eerlijk zijn|laat dat even bezinken|baanbrekend|game-changer)\b/gi,
+    msg: 'verboden frase (NL)',
+    hint: 'Herschrijf de zin; één woord vervangen laat de cadans staan.',
+  },
+  {
+    id: 'summary-opener',
+    level: 'error',
+    // "Overall," / "In summary," / "Kortom," as a paragraph opener at line start
+    // (allowing markdown list/quote markers and bold before it).
+    re: /^[ \t>*+-]*(?:\*\*)?(Overall|In summary|In conclusion|Kortom|Al met al|Samengevat)(?:\*\*)?,/gim,
+    msg: 'summary-restating opener',
+    hint: 'Trust the reader; cut the recap or fold it into the last real point.',
+  },
+  {
+    id: 'not-x-but-y',
+    level: 'warn',
+    // "not X, but Y" / "niet X, maar Y". High recall, low precision: a regex
+    // cannot tell a dramatic contrast from an incidental one. Human decides.
+    re: /\bnot\b[^.?!;:\n]{1,55}?,\s+but\b|\bniet\b[^.?!;:\n]{1,55}?,\s+maar\b/gi,
+    msg: '"not X, but Y" / "niet X, maar Y" contrast (review)',
+    hint: 'If it is a dramatic binary contrast, state the positive claim directly. If incidental, ignore.',
+  },
+  {
+    id: 'not-x-not-y-but-z',
+    level: 'warn',
+    // The three-beat build-up Anne flagged by name. Rarer, so worth its own id.
+    re: /\bnot\b[^.?!\n]{1,45}?,\s*not\b[^.?!\n]{1,45}?,\s*but\b|\bniet\b[^.?!\n]{1,45}?,\s*niet\b[^.?!\n]{1,45}?,\s*maar\b/gi,
+    msg: '"not X, not Y, but Z" triple contrast (review)',
+    hint: 'The three-beat build-up is a signature tell. Rewrite as a plain statement.',
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Code stripping. Preserve line numbers so findings point at the real line.
+// ---------------------------------------------------------------------------
+
+// Replace matched spans with same-length whitespace (newlines kept) so byte
+// offsets and line numbers are unchanged.
+function blankOut(text, re) {
+  return text.replace(re, (m) => m.replace(/[^\n]/g, ' '));
+}
+
+function stripMarkdownCode(text) {
+  let t = text;
+  // Fenced code blocks ``` ... ``` and ~~~ ... ~~~ (also handles ```lang).
+  t = blankOut(t, /^([ \t]*)(```|~~~)[^\n]*\n[\s\S]*?^\1\2[^\n]*$/gm);
+  // Any dangling/unclosed fence to end of file.
+  t = blankOut(t, /^[ \t]*(```|~~~)[\s\S]*$/m);
+  // Inline code `...` (single or double backtick).
+  t = blankOut(t, /(`+)[^\n]*?\1/g);
+  return t;
+}
+
+// For .ts/.js: only the inside of string literals is prose. Blank everything
+// else so identifiers, operators, and JSDoc dashes never match. Handles ' " `.
+function stripToStringLiterals(text) {
+  const out = [];
+  let i = 0;
+  const n = text.length;
+  let quote = null;
+  while (i < n) {
+    const c = text[i];
+    if (quote) {
+      if (c === '\\') {
+        out.push(text[i], text[i + 1] ?? '');
+        i += 2;
+        continue;
+      }
+      if (c === quote) {
+        out.push(' ');
+        quote = null;
+        i++;
+        continue;
+      }
+      out.push(c === '\n' ? '\n' : c);
+      i++;
+      continue;
+    }
+    if (c === "'" || c === '"' || c === '`') {
+      quote = c;
+      out.push(' ');
+      i++;
+      continue;
+    }
+    out.push(c === '\n' ? '\n' : ' ');
+    i++;
+  }
+  return out.join('');
+}
+
+function proseOf(file, raw) {
+  const ext = extname(file);
+  if (ext === '.ts' || ext === '.js' || ext === '.mjs' || ext === '.cjs') {
+    return stripToStringLiterals(raw);
+  }
+  // Markdown/MDX: keep frontmatter in place (title/description are reader-facing
+  // prose), just strip code. The banned lists rarely false-positive on YAML keys.
+  return stripMarkdownCode(raw);
+}
+
+// ---------------------------------------------------------------------------
+// Walk targets -> file list.
+// ---------------------------------------------------------------------------
+
+const PROSE_EXT = new Set(['.md', '.mdx', '.ts', '.js', '.mjs', '.cjs']);
+
+function collect(target) {
+  const abs = resolve(REPO_ROOT, target);
+  if (!existsSync(abs)) {
+    console.error(`path not found: ${target}`);
+    process.exit(2);
+  }
+  if (statSync(abs).isFile()) return [abs];
+  const files = [];
+  const walk = (dir) => {
+    for (const entry of readdirSync(dir)) {
+      if (entry === 'node_modules' || entry.startsWith('.')) continue;
+      const full = join(dir, entry);
+      if (statSync(full).isDirectory()) walk(full);
+      else if (PROSE_EXT.has(extname(entry))) files.push(full);
+    }
+  };
+  walk(abs);
+  return files;
+}
+
+// ---------------------------------------------------------------------------
+// Main.
+// ---------------------------------------------------------------------------
+
+const argv = process.argv.slice(2);
+if (argv.includes('--help') || argv.includes('-h')) {
+  console.log(
+    'Usage: node check-prose-style.mjs [--strict] [path ...]\n\n' +
+      'Scans docs prose for anti-AI-tell violations.\n' +
+      '  errors (em-dashes, banned phrases, summary openers) always fail (exit 1).\n' +
+      '  warnings ("not X but Y" contrasts) are reported; --strict makes them fail too.\n\n' +
+      'No paths => the default docs prose set:\n' +
+      DEFAULT_TARGETS.map((t) => '  ' + t).join('\n') +
+      '\n\nPass a single file to check just that file.',
+  );
+  process.exit(0);
+}
+
+const strict = argv.includes('--strict');
+const targets = argv.filter((a) => !a.startsWith('--'));
+const files = (targets.length ? targets : DEFAULT_TARGETS).flatMap(collect);
+
+const findings = [];
+for (const file of files) {
+  const raw = readFileSync(file, 'utf8');
+  const prose = proseOf(file, raw);
+  const rel = relative(REPO_ROOT, file);
+  const rawLines = raw.split('\n');
+  const lineStart = [];
+  { let o = 0; for (const ln of rawLines) { lineStart.push(o); o += ln.length + 1; } }
+  const lineOf = (idx) => {
+    let lo = 0, hi = lineStart.length - 1;
+    while (lo < hi) { const mid = (lo + hi + 1) >> 1; if (lineStart[mid] <= idx) lo = mid; else hi = mid - 1; }
+    return lo + 1;
+  };
+  for (const rule of RULES) {
+    rule.re.lastIndex = 0;
+    let m;
+    while ((m = rule.re.exec(prose)) !== null) {
+      const line = lineOf(m.index);
+      const excerpt = (rawLines[line - 1] ?? '').trim().slice(0, 100);
+      findings.push({ rel, line, rule, excerpt });
+      if (m.index === rule.re.lastIndex) rule.re.lastIndex++; // guard zero-width
+    }
+  }
+}
+
+const errors = findings.filter((f) => f.rule.level === 'error');
+const warns = findings.filter((f) => f.rule.level === 'warn');
+
+function report(list) {
+  list.sort((a, b) => a.rel.localeCompare(b.rel) || a.line - b.line);
+  let lastFile = '';
+  for (const f of list) {
+    if (f.rel !== lastFile) { console.error(`  ${f.rel}`); lastFile = f.rel; }
+    console.error(`    ${f.line}: [${f.rule.id}] ${f.rule.msg}`);
+    console.error(`         ${f.excerpt}`);
+    console.error(`         → ${f.rule.hint}`);
+  }
+}
+
+if (errors.length === 0 && warns.length === 0) {
+  console.log(`Prose style check passed: ${files.length} file(s), no tells found.`);
+  process.exit(0);
+}
+
+if (errors.length) {
+  console.error(`Prose style ERRORS: ${errors.length} finding(s).\n`);
+  report(errors);
+  console.error('');
+}
+if (warns.length) {
+  console.error(`Prose style WARNINGS (review, not auto-fail): ${warns.length} finding(s).\n`);
+  report(warns);
+  console.error('');
+}
+
+const fail = errors.length > 0 || (strict && warns.length > 0);
+if (fail) {
+  console.error('Each hit means rewrite the sentence, not swap one word. See SKILL.md.');
+  process.exit(1);
+}
+console.error('No errors (warnings above are advisory). See SKILL.md for the human checklist.');
+process.exit(0);


### PR DESCRIPTION
Voegt een project-lokale skill `docs-writing` toe onder `.claude/skills/`. De skill legt schrijfregels vast voor de docs-site (`docs/`) en levert een detector-script mee.

## Waarom

De docs worden gelezen door wetgevingsjuristen, ambtenaren en ontwikkelaars buiten het team. Proza dat pattern-matcht op LLM-output valt daar op en kost geloofwaardigheid. PR #888 ruimde die tells eerder handmatig op in concept-RFC's. Deze skill maakt dat herhaalbaar.

De globale `writing-style` skill mikt breed (reviews, e-mail, Slack, NL+EN). Deze is smal: alleen `docs/`, en afgestemd op wat daar feitelijk staat. De Engelstalige technische docs en RFC's, plus de tweetalige NL/EN landing-copy in `landing-content.ts`.

## Het script

`check-prose-style.mjs` scant de proza onder `docs/` op mechanische tells:

- **errors** (falen hard): em-dashes en en-dashes, verboden frases, `Overall,`-achtige samenvat-openers.
- **warnings** (mens beoordeelt): `niet X, maar Y`-contrasten, inclusief de drieslag `niet X, niet Y, maar Z`.

Code-blokken, inline-code en alles buiten string-literals in `.ts` worden geblankt voor het matchen, met behoud van regelnummers. Zo geven `--no-verify`, `a - b` of een em-dash in een codevoorbeeld geen valse positieven. Getest tegen de hele huidige corpus: 57 em-dash-errors (allemaal echt, geen ruis), 8 warnings ter review. De banned-lijst laat bewust domeintermen staan die elders een LLM-tell zouden zijn (`realm` is Keycloak, `landschap` is IT-landschap), anders muten mensen de linter.

Draaien vanaf de repo-root:

```bash
node .claude/skills/docs-writing/check-prose-style.mjs            # hele docs-set
node .claude/skills/docs-writing/check-prose-style.mjs <file>     # één bestand
node .claude/skills/docs-writing/check-prose-style.mjs --strict   # warnings falen ook
```

## Het script detecteert, Claude beslist

De skill maakt expliciet dat het script een hulpmiddel is, geen scheidsrechter. Het vangt de mechanische signaturen zodat de menselijke leesbeurt zijn aandacht kan geven aan wat een regex niet ziet: ritme, rule-of-three, register, en of een gevlagd contrast echt een tell is. Een groene run is niet genoeg; de checklist in `SKILL.md` dekt het deel dat buiten het bereik van de regex valt.

## Scope

Deze PR raakt geen bestaande docs-inhoud aan. Alleen de nieuwe skill en het script. De 57 gedetecteerde em-dashes in bestaande docs zijn nog niet opgeruimd; dat is losse follow-up.