### PR TITLE
feat(pipeline): guard enrichment against a stale base branch

### DIFF
--- a/packages/corpus/src/client.rs
+++ b/packages/corpus/src/client.rs
@@ -671,6 +671,36 @@ impl CorpusClient {
         Ok(())
     }
 
+    /// Fetch the base branch shallowly and return the git blob SHA of `path` on
+    /// it. Uses `FETCH_HEAD` (the single-branch enrich clone never creates
+    /// `origin/<base>`). Blob SHA is content-addressed, so it is comparable
+    /// across clones.
+    pub async fn fetch_base_blob_sha(&self, base_branch: &str, path: &str) -> Result<String> {
+        self.run_git(&["fetch", "--depth", "1", "origin", base_branch])
+            .await?;
+        let sha = self
+            .run_git_output(&["rev-parse", &format!("FETCH_HEAD:{path}")])
+            .await?;
+        Ok(sha.trim().to_string())
+    }
+
+    /// Whether `path` is tracked in the current checkout/branch.
+    pub async fn is_tracked(&self, path: &str) -> Result<bool> {
+        let listed = self.run_git_output(&["ls-files", "--", path]).await?;
+        Ok(!listed.trim().is_empty())
+    }
+
+    /// Check `path` out of the most recent `FETCH_HEAD` and unstage it, so it
+    /// does not pollute an empty `git status --porcelain` check before the
+    /// enrichment commits. Call `fetch_base_blob_sha` first so `FETCH_HEAD` is
+    /// set.
+    pub async fn checkout_path_from_fetch_head(&self, path: &str) -> Result<()> {
+        self.run_git(&["checkout", "FETCH_HEAD", "--", path])
+            .await?;
+        self.run_git(&["reset", "HEAD", "--", path]).await?;
+        Ok(())
+    }
+
     async fn configure_git_user(&self) -> Result<()> {
         self.run_git(&["config", "user.name", &self.config.git_author_name])
             .await?;
@@ -866,6 +896,27 @@ mod tests {
                 .await
                 .unwrap();
         }
+    }
+
+    /// git blob SHA of `content` as git would compute it (matches rev-parse of
+    /// a committed/fetched blob with identical bytes).
+    fn git_hash_object(content: &str) -> String {
+        use std::io::Write;
+        use std::process::{Command, Stdio};
+        let mut child = Command::new("git")
+            .args(["hash-object", "--stdin"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .unwrap();
+        child
+            .stdin
+            .take()
+            .unwrap()
+            .write_all(content.as_bytes())
+            .unwrap();
+        let out = child.wait_with_output().unwrap();
+        String::from_utf8(out.stdout).unwrap().trim().to_string()
     }
 
     #[test]
@@ -1716,6 +1767,99 @@ mod tests {
         assert!(repo_path
             .join("regulation/nl/wet/new_law/2025-01-01.yaml")
             .exists());
+    }
+
+    #[tokio::test]
+    async fn fetch_base_blob_sha_returns_stable_content_hash() {
+        let dir = tempfile::tempdir().unwrap();
+        let bare_path = setup_bare_repo(dir.path()).await;
+        let bare_url = format!("file://{}", bare_path.display());
+
+        // Enrichment clone on a branch that doesn't exist yet (born from development).
+        let repo_path = dir.path().join("enrich-clone");
+        let mut config = CorpusConfig::new(&bare_url, &repo_path);
+        config.branch = "enrich/test".into();
+        let mut client = CorpusClient::new(config);
+        client.ensure_repo().await.unwrap();
+
+        // Push a law file to development with known content.
+        let base_content = "new law content";
+        let path = "regulation/nl/wet/new_law/2025-01-01.yaml";
+        let tmp = dir.path().join("setup");
+        clone_with_config(&bare_path, &tmp).await;
+        let new_law = tmp.join("regulation/nl/wet/new_law");
+        tokio::fs::create_dir_all(&new_law).await.unwrap();
+        tokio::fs::write(new_law.join("2025-01-01.yaml"), base_content)
+            .await
+            .unwrap();
+        for args in [
+            vec!["add", "."],
+            vec!["commit", "-m", "harvest new law"],
+            vec!["push", "origin", "development"],
+        ] {
+            Command::new("git")
+                .args(&args)
+                .current_dir(&tmp)
+                .output()
+                .await
+                .unwrap();
+        }
+
+        let sha = client
+            .fetch_base_blob_sha("development", path)
+            .await
+            .unwrap();
+
+        // `git hash-object` of the same bytes must equal the reported blob SHA.
+        let expected = git_hash_object(base_content);
+        assert_eq!(sha, expected);
+    }
+
+    #[tokio::test]
+    async fn is_tracked_reflects_branch_contents() {
+        let dir = tempfile::tempdir().unwrap();
+        let bare_path = setup_bare_repo(dir.path()).await;
+        let bare_url = format!("file://{}", bare_path.display());
+
+        // Enrichment clone born from development (without the new law).
+        let repo_path = dir.path().join("enrich-clone");
+        let mut config = CorpusConfig::new(&bare_url, &repo_path);
+        config.branch = "enrich/test".into();
+        let mut client = CorpusClient::new(config);
+        client.ensure_repo().await.unwrap();
+
+        // Push a new law to development after the enrich branch was created.
+        let path = "regulation/nl/wet/new_law/2025-01-01.yaml";
+        let tmp = dir.path().join("setup");
+        clone_with_config(&bare_path, &tmp).await;
+        let new_law = tmp.join("regulation/nl/wet/new_law");
+        tokio::fs::create_dir_all(&new_law).await.unwrap();
+        tokio::fs::write(new_law.join("2025-01-01.yaml"), "new law content")
+            .await
+            .unwrap();
+        for args in [
+            vec!["add", "."],
+            vec!["commit", "-m", "harvest new law"],
+            vec!["push", "origin", "development"],
+        ] {
+            Command::new("git")
+                .args(&args)
+                .current_dir(&tmp)
+                .output()
+                .await
+                .unwrap();
+        }
+
+        // The law exists on development but not on the enrich branch.
+        assert!(!client.is_tracked(path).await.unwrap());
+
+        client
+            .fetch_base_blob_sha("development", path)
+            .await
+            .unwrap();
+        client.checkout_path_from_fetch_head(path).await.unwrap();
+        client.run_git(&["add", "--", path]).await.unwrap();
+        assert!(client.is_tracked(path).await.unwrap());
     }
 
     #[tokio::test]

--- a/packages/corpus/src/client.rs
+++ b/packages/corpus/src/client.rs
@@ -630,47 +630,6 @@ impl CorpusClient {
         Ok(())
     }
 
-    /// Pull `paths` from `base_branch` into the working tree without a merge commit, leaving them unstaged so the next `commit_and_push` absorbs them.
-    pub async fn checkout_from_branch(&self, base_branch: &str, paths: &[&str]) -> Result<()> {
-        // Skip already-tracked paths so prior machine_readable additions
-        // aren't overwritten by the raw base-branch version.
-        let mut missing: Vec<&str> = Vec::new();
-        for path in paths {
-            let listed = self.run_git_output(&["ls-files", "--", path]).await?;
-            if listed.trim().is_empty() {
-                missing.push(path);
-            }
-        }
-        if missing.is_empty() {
-            tracing::debug!(paths = ?paths, "all paths already tracked, skipping checkout from base");
-            return Ok(());
-        }
-
-        self.run_git(&["fetch", "--depth", "1", "origin", base_branch])
-            .await?;
-
-        // Use FETCH_HEAD rather than `origin/<base_branch>`: the enrichment
-        // clone is `--single-branch` for `enrich/<provider>`, so its fetch
-        // refspec never creates `refs/remotes/origin/<base_branch>` even
-        // after `git fetch origin <base_branch>`. FETCH_HEAD is always set.
-        let mut args = vec!["checkout", "FETCH_HEAD", "--"];
-        args.extend(&missing);
-        self.run_git(&args).await?;
-
-        // Unstage the checked-out files so they don't pollute an empty
-        // `git status --porcelain` check before the enrichment commits.
-        let mut reset_args = vec!["reset", "HEAD", "--"];
-        reset_args.extend(&missing);
-        self.run_git(&reset_args).await?;
-
-        tracing::info!(
-            base = %base_branch,
-            paths = ?missing,
-            "checked out paths from base branch"
-        );
-        Ok(())
-    }
-
     /// Fetch the base branch shallowly and return the git blob SHA of `path` on
     /// it. Uses `FETCH_HEAD` (the single-branch enrich clone never creates
     /// `origin/<base>`). Blob SHA is content-addressed, so it is comparable
@@ -1472,7 +1431,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_checkout_from_branch_incorporates_new_files() {
+    async fn checkout_path_from_fetch_head_materializes_new_law() {
+        // An untracked base-branch path is fetched and materialized into the
+        // working tree, unstaged, with the exact base bytes. (Migrated from the
+        // old "incorporates new files" checkout-from-base test.)
         let dir = tempfile::tempdir().unwrap();
         let bare_path = setup_bare_repo(dir.path()).await;
         let bare_url = format!("file://{}", bare_path.display());
@@ -1486,11 +1448,13 @@ mod tests {
         client.ensure_repo().await.unwrap();
 
         // Push a new file to development (simulating a harvested law)
+        let base_content = "new law content";
+        let path = "regulation/nl/wet/new_law/2025-01-01.yaml";
         let tmp = dir.path().join("setup");
         clone_with_config(&bare_path, &tmp).await;
         let new_law = tmp.join("regulation/nl/wet/new_law");
         tokio::fs::create_dir_all(&new_law).await.unwrap();
-        tokio::fs::write(new_law.join("2025-01-01.yaml"), "new law content")
+        tokio::fs::write(new_law.join("2025-01-01.yaml"), base_content)
             .await
             .unwrap();
         for args in [
@@ -1506,24 +1470,25 @@ mod tests {
                 .unwrap();
         }
 
-        // The new law should NOT be present on the enrichment branch yet
-        assert!(!repo_path
-            .join("regulation/nl/wet/new_law/2025-01-01.yaml")
-            .exists());
+        // The new law is not tracked on the enrichment branch yet.
+        assert!(!client.is_tracked(path).await.unwrap());
+        assert!(!repo_path.join(path).exists());
 
-        // Checkout the specific file from development (matches production code path)
+        // Fetch the base blob (sets FETCH_HEAD) and materialize the path from it.
         client
-            .checkout_from_branch(
-                "development",
-                &["regulation/nl/wet/new_law/2025-01-01.yaml"],
-            )
+            .fetch_base_blob_sha("development", path)
             .await
             .unwrap();
-        assert!(repo_path
-            .join("regulation/nl/wet/new_law/2025-01-01.yaml")
-            .exists());
+        client.checkout_path_from_fetch_head(path).await.unwrap();
 
-        // Unstaged so the file appears as `??` (untracked) rather than `A`
+        // File is present with the exact base bytes.
+        assert!(repo_path.join(path).exists());
+        let content = tokio::fs::read_to_string(repo_path.join(path))
+            .await
+            .unwrap();
+        assert_eq!(git_hash_object(&content), git_hash_object(base_content));
+
+        // Left unstaged so the file appears as `??` (untracked) rather than `A`
         // (staged-new). commit_and_push uses explicit `git add -- <paths>`
         // which picks up untracked files, so the machine_readable additions
         // and new file land in the same commit.
@@ -1545,69 +1510,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_checkout_from_branch_skips_already_tracked_files() {
-        let dir = tempfile::tempdir().unwrap();
-        let bare_path = setup_bare_repo(dir.path()).await;
-        let bare_url = format!("file://{}", bare_path.display());
-
-        // Push a law file to development
-        let tmp = dir.path().join("setup");
-        clone_with_config(&bare_path, &tmp).await;
-        let law_dir = tmp.join("regulation/nl/wet/enriched_law");
-        tokio::fs::create_dir_all(&law_dir).await.unwrap();
-        tokio::fs::write(law_dir.join("2025-01-01.yaml"), "raw content")
-            .await
-            .unwrap();
-        for args in [
-            vec!["add", "."],
-            vec!["commit", "-m", "harvest law"],
-            vec!["push", "origin", "development"],
-        ] {
-            Command::new("git")
-                .args(&args)
-                .current_dir(&tmp)
-                .output()
-                .await
-                .unwrap();
-        }
-
-        // Create enrichment branch (inherits the law from development)
-        let repo_path = dir.path().join("enrich-clone");
-        let mut config = CorpusConfig::new(&bare_url, &repo_path);
-        config.branch = "enrich/test".into();
-        let mut client = CorpusClient::new(config);
-        client.ensure_repo().await.unwrap();
-
-        // Simulate enrichment: modify the file with machine_readable content
-        let yaml_path = repo_path.join("regulation/nl/wet/enriched_law/2025-01-01.yaml");
-        tokio::fs::write(&yaml_path, "enriched content with machine_readable")
-            .await
-            .unwrap();
-        client
-            .commit_and_push(&[yaml_path.clone()], "enrich: add machine_readable")
-            .await
-            .unwrap();
-
-        // Now call checkout_from_branch — it should SKIP the file because
-        // it's already tracked on the enrichment branch
-        client
-            .checkout_from_branch(
-                "development",
-                &["regulation/nl/wet/enriched_law/2025-01-01.yaml"],
-            )
-            .await
-            .unwrap();
-
-        // File content should still be the enriched version, NOT overwritten
-        let content = tokio::fs::read_to_string(&yaml_path).await.unwrap();
-        assert_eq!(
-            content, "enriched content with machine_readable",
-            "already-tracked file should not be overwritten by development version"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_checkout_from_branch_fetches_new_version_when_old_exists() {
+    async fn checkout_path_from_fetch_head_materializes_new_version_alongside_old() {
+        // An older version of the law is already tracked on the enrichment
+        // branch; materializing a newer base-branch version adds it without
+        // disturbing the old one. (Migrated from the old "fetches new version
+        // when old exists" checkout-from-base test.)
         let dir = tempfile::tempdir().unwrap();
         let bare_path = setup_bare_repo(dir.path()).await;
         let bare_url = format!("file://{}", bare_path.display());
@@ -1639,9 +1546,9 @@ mod tests {
         config.branch = "enrich/test".into();
         let mut client = CorpusClient::new(config);
         client.ensure_repo().await.unwrap();
-        assert!(repo_path
-            .join("regulation/nl/wet/some_law/2024-01-01.yaml")
-            .exists());
+        let old_path = "regulation/nl/wet/some_law/2024-01-01.yaml";
+        assert!(client.is_tracked(old_path).await.unwrap());
+        assert!(repo_path.join(old_path).exists());
 
         // Push a NEW version to development
         tokio::fs::write(law_dir.join("2025-01-01.yaml"), "new version")
@@ -1660,37 +1567,35 @@ mod tests {
                 .unwrap();
         }
 
-        // New version should NOT be on the enrichment branch yet
-        assert!(!repo_path
-            .join("regulation/nl/wet/some_law/2025-01-01.yaml")
-            .exists());
+        // New version is not on the enrichment branch yet.
+        let new_path = "regulation/nl/wet/some_law/2025-01-01.yaml";
+        assert!(!client.is_tracked(new_path).await.unwrap());
+        assert!(!repo_path.join(new_path).exists());
 
-        // Checkout the specific new file (not the directory!)
+        // Materialize only the new-version file from the base branch.
         client
-            .checkout_from_branch(
-                "development",
-                &["regulation/nl/wet/some_law/2025-01-01.yaml"],
-            )
+            .fetch_base_blob_sha("development", new_path)
+            .await
+            .unwrap();
+        client
+            .checkout_path_from_fetch_head(new_path)
             .await
             .unwrap();
 
-        // New version present, old version still intact
-        assert!(repo_path
-            .join("regulation/nl/wet/some_law/2025-01-01.yaml")
-            .exists());
-        assert!(repo_path
-            .join("regulation/nl/wet/some_law/2024-01-01.yaml")
-            .exists());
+        // New version present, old version still intact.
+        assert!(repo_path.join(new_path).exists());
+        assert!(repo_path.join(old_path).exists());
     }
 
     #[tokio::test]
-    async fn test_checkout_from_branch_works_with_preexisting_enrichment_branch() {
+    async fn fetch_base_blob_sha_reachable_on_single_branch_clone() {
         // Regression: when the enrichment branch already exists on the remote,
         // ensure_repo clones it with `--single-branch --branch enrich/<provider>`.
         // The configured fetch refspec then only matches enrich/<provider>, so
         // `git fetch origin development` does NOT update refs/remotes/origin/development.
-        // checkout_from_branch must still be able to reach the fetched commit —
-        // which it does via FETCH_HEAD.
+        // fetch_base_blob_sha must still be able to reach the fetched commit —
+        // which it does via FETCH_HEAD. (Migrated from the old "works with
+        // preexisting enrichment branch" checkout-from-base test.)
         let dir = tempfile::tempdir().unwrap();
         let bare_path = setup_bare_repo(dir.path()).await;
         let bare_url = format!("file://{}", bare_path.display());
@@ -1712,9 +1617,11 @@ mod tests {
         }
 
         // Now push a new law to development (not yet on enrich/test).
+        let base_content = "new law content";
+        let path = "regulation/nl/wet/new_law/2025-01-01.yaml";
         let law_dir = tmp.join("regulation/nl/wet/new_law");
         tokio::fs::create_dir_all(&law_dir).await.unwrap();
-        tokio::fs::write(law_dir.join("2025-01-01.yaml"), "new law content")
+        tokio::fs::write(law_dir.join("2025-01-01.yaml"), base_content)
             .await
             .unwrap();
         for args in [
@@ -1752,21 +1659,16 @@ mod tests {
         let refs_str = String::from_utf8_lossy(&refs.stdout);
         assert!(
             !refs_str.contains("refs/remotes/origin/development"),
-            "expected no origin/development tracking ref before checkout_from_branch, got: {refs_str}"
+            "expected no origin/development tracking ref before fetch, got: {refs_str}"
         );
 
-        // This would fail with `invalid reference: origin/development` before the FETCH_HEAD fix.
-        client
-            .checkout_from_branch(
-                "development",
-                &["regulation/nl/wet/new_law/2025-01-01.yaml"],
-            )
+        // This would fail with `invalid reference: origin/development` before the
+        // FETCH_HEAD approach: fetch_base_blob_sha resolves the blob via FETCH_HEAD.
+        let sha = client
+            .fetch_base_blob_sha("development", path)
             .await
             .unwrap();
-
-        assert!(repo_path
-            .join("regulation/nl/wet/new_law/2025-01-01.yaml")
-            .exists());
+        assert_eq!(sha, git_hash_object(base_content));
     }
 
     #[tokio::test]

--- a/packages/pipeline/src/enrich.rs
+++ b/packages/pipeline/src/enrich.rs
@@ -1006,9 +1006,10 @@ pub async fn create_enrich_corpus(
     // prevents an unrelated `checkout` or `reset` failure from silently
     // dropping the enrichment back to production's branch.
     //
-    // Pass the exact file path (not the directory) so the `ls-files` guard
-    // inside `checkout_from_branch` doesn't match sibling files and skip
-    // fetching a newly harvested version of an already-known law.
+    // The freshness guard below works on the exact file path (not the
+    // directory): `is_tracked` and `fetch_base_blob_sha` resolve a single blob,
+    // so a newly harvested version of an already-known law is judged on its own
+    // path rather than being masked by a sibling version in the same directory.
     let preferred_base = base_config.branch.as_str();
     let preferred_exists = if preferred_base == "development" || branch_is_known(preferred_base) {
         true

--- a/packages/pipeline/src/enrich.rs
+++ b/packages/pipeline/src/enrich.rs
@@ -1048,7 +1048,7 @@ pub async fn create_enrich_corpus(
             return Err(PipelineError::BaseDrift {
                 yaml_path: normalized.clone(),
                 base: base_branch.to_string(),
-                expected: stored.unwrap_or_default(),
+                expected: stored.unwrap_or_else(|| "(none recorded)".to_string()),
                 actual: base_sha,
             });
         }

--- a/packages/pipeline/src/enrich.rs
+++ b/packages/pipeline/src/enrich.rs
@@ -921,18 +921,6 @@ fn build_command(
     cmd
 }
 
-/// Create a `CorpusClient` for the enrichment branch.
-///
-/// Clones the base corpus config but sets the branch to the enrichment branch.
-/// The client's `ensure_repo()` will auto-create the branch if it doesn't exist.
-///
-/// Each invocation uses a unique checkout directory (keyed by branch + job ID)
-/// to prevent concurrent workers from clobbering each other's checkouts.
-///
-/// Uses sparse checkout to only materialize the law directory being enriched
-/// plus the `features/` directory. This prevents the LLM subprocess from
-/// indexing the entire corpus (thousands of files), which would exceed context
-/// limits and cause excessive memory usage.
 /// Result of preparing the per-job enrichment checkout: the client plus the
 /// base-branch blob SHA of the target law (recorded into `.enrichment.yaml`
 /// as `source_hash`).
@@ -945,16 +933,33 @@ pub struct EnrichCorpus {
 /// present and non-empty. Returns `None` when the file is absent/unparseable
 /// or the field is empty (both treated as "unknown provenance").
 async fn read_stored_source_hash(repo_path: &Path, normalized_law_path: &str) -> Option<String> {
+    #[derive(serde::Deserialize)]
+    struct Provenance {
+        #[serde(default)]
+        source_hash: String,
+    }
     let meta_rel = Path::new(normalized_law_path)
         .parent()?
         .join(".enrichment.yaml");
     let content = tokio::fs::read_to_string(repo_path.join(meta_rel))
         .await
         .ok()?;
-    let meta: EnrichmentMetadata = serde_yaml_ng::from_str(&content).ok()?;
-    (!meta.source_hash.is_empty()).then_some(meta.source_hash)
+    let prov: Provenance = serde_yaml_ng::from_str(&content).ok()?;
+    (!prov.source_hash.is_empty()).then_some(prov.source_hash)
 }
 
+/// Create a `CorpusClient` for the enrichment branch.
+///
+/// Clones the base corpus config but sets the branch to the enrichment branch.
+/// The client's `ensure_repo()` will auto-create the branch if it doesn't exist.
+///
+/// Each invocation uses a unique checkout directory (keyed by branch + job ID)
+/// to prevent concurrent workers from clobbering each other's checkouts.
+///
+/// Uses sparse checkout to only materialize the law directory being enriched
+/// plus the `features/` directory. This prevents the LLM subprocess from
+/// indexing the entire corpus (thousands of files), which would exceed context
+/// limits and cause excessive memory usage.
 pub async fn create_enrich_corpus(
     base_config: &CorpusConfig,
     branch: &str,

--- a/packages/pipeline/src/enrich.rs
+++ b/packages/pipeline/src/enrich.rs
@@ -52,9 +52,19 @@ fn pick_enrich_base(preferred: &str, preferred_exists: bool) -> &str {
 pub(crate) enum BaseAction {
     /// Law not yet on the enrich branch — check it out fresh from the base.
     CheckoutFresh,
-    /// Law present and its base is unchanged — keep the existing enrichment.
+    /// Law present and its recorded base matches the current base — unchanged,
+    /// keep the existing enrichment (no fresh checkout).
     Skip,
-    /// Law present but its base moved (or provenance is missing) — fail loudly.
+    /// Law present but with no usable recorded provenance — a "legacy"
+    /// enrichment written before the freshness guard existed. Adopt the current
+    /// base blob SHA as its baseline (recorded on the next metadata write) and
+    /// proceed without a fresh checkout, rather than failing. This grandfathers
+    /// every pre-guard enrichment so introducing the guard does not turn them
+    /// all into an immediate `Drift` on first re-enrichment.
+    AdoptBaseline,
+    /// Law present and its *recorded* base moved — fail loudly rather than
+    /// silently re-enriching on top of a base that differs from the one the
+    /// enrichment was generated against.
     Drift,
 }
 
@@ -70,8 +80,14 @@ pub(crate) fn decide_base_action(
         return BaseAction::CheckoutFresh;
     }
     match stored_source_hash {
-        Some(h) if !h.is_empty() && h == base_sha => BaseAction::Skip,
-        _ => BaseAction::Drift,
+        // No usable provenance recorded (absent or empty) — a pre-guard
+        // enrichment. Grandfather it by adopting the current base as its
+        // baseline instead of treating the unknown as drift.
+        None | Some("") => BaseAction::AdoptBaseline,
+        // Recorded base matches the current base — unchanged.
+        Some(h) if h == base_sha => BaseAction::Skip,
+        // Recorded base differs from the current base — genuine drift.
+        Some(_) => BaseAction::Drift,
     }
 }
 
@@ -1070,8 +1086,9 @@ async fn resolve_enrich_base(
 
     // Freshness guard: compare the target law's base version against the
     // provenance recorded in a prior enrichment. New law -> check out fresh;
-    // unchanged base -> keep existing enrichment; changed/unknown base ->
-    // fail loudly (do NOT auto-overwrite a possibly-validated enrichment).
+    // unchanged base -> keep existing enrichment; missing provenance (a legacy,
+    // pre-guard enrichment) -> adopt the current base as baseline and proceed;
+    // changed base -> fail loudly (do NOT auto-overwrite on a moved base).
     let base_sha = client.fetch_base_blob_sha(base_branch, normalized).await?;
     let tracked = client.is_tracked(normalized).await?;
     let stored = read_stored_source_hash(client.repo_path(), normalized).await;
@@ -1083,6 +1100,18 @@ async fn resolve_enrich_base(
         }
         BaseAction::Skip => {
             tracing::debug!(path = %normalized, "base unchanged, no fresh checkout needed");
+        }
+        BaseAction::AdoptBaseline => {
+            // Legacy enrichment with no recorded provenance. Keep the existing
+            // enrichment (no fresh checkout, like Skip); the current base blob
+            // SHA returned below is stamped as `source_hash` on the next
+            // `.enrichment.yaml` write, establishing the baseline so subsequent
+            // runs can detect real drift.
+            tracing::info!(
+                path = %normalized,
+                base = %base_branch,
+                "no recorded provenance for tracked law; adopting current base as baseline (legacy enrichment grandfathered)"
+            );
         }
         BaseAction::Drift => {
             return Err(PipelineError::BaseDrift {
@@ -1507,11 +1536,18 @@ mod tests {
     }
 
     #[test]
-    fn decide_base_action_missing_or_empty_provenance_is_drift() {
-        assert_eq!(decide_base_action(true, None, "sha_new"), BaseAction::Drift);
+    fn decide_base_action_missing_or_empty_provenance_adopts_baseline() {
+        // A tracked law with no recorded provenance is a pre-guard "legacy"
+        // enrichment: grandfather it by adopting the current base as baseline,
+        // never a terminal drift (that would fail every existing enrichment the
+        // moment the guard ships).
+        assert_eq!(
+            decide_base_action(true, None, "sha_new"),
+            BaseAction::AdoptBaseline
+        );
         assert_eq!(
             decide_base_action(true, Some(""), "sha_new"),
-            BaseAction::Drift
+            BaseAction::AdoptBaseline
         );
     }
 

--- a/packages/pipeline/src/enrich.rs
+++ b/packages/pipeline/src/enrich.rs
@@ -48,8 +48,6 @@ fn pick_enrich_base(preferred: &str, preferred_exists: bool) -> &str {
 
 /// Outcome of comparing a target law's base version against the enrichment's
 /// recorded provenance. Pure decision so it can be unit-tested without git.
-// used by create_enrich_corpus in a later task
-#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum BaseAction {
     /// Law not yet on the enrich branch — check it out fresh from the base.
@@ -63,8 +61,6 @@ pub(crate) enum BaseAction {
 /// Decide what to do for a target law given whether it is already tracked on
 /// the enrich branch, the `source_hash` recorded in its `.enrichment.yaml`
 /// (if any), and the current base-branch blob SHA of the law.
-// used by create_enrich_corpus in a later task
-#[allow(dead_code)]
 pub(crate) fn decide_base_action(
     tracked: bool,
     stored_source_hash: Option<&str>,
@@ -937,12 +933,34 @@ fn build_command(
 /// plus the `features/` directory. This prevents the LLM subprocess from
 /// indexing the entire corpus (thousands of files), which would exceed context
 /// limits and cause excessive memory usage.
+/// Result of preparing the per-job enrichment checkout: the client plus the
+/// base-branch blob SHA of the target law (recorded into `.enrichment.yaml`
+/// as `source_hash`).
+pub struct EnrichCorpus {
+    pub client: CorpusClient,
+    pub source_hash: String,
+}
+
+/// Read the `source_hash` recorded in the target law's `.enrichment.yaml`, if
+/// present and non-empty. Returns `None` when the file is absent/unparseable
+/// or the field is empty (both treated as "unknown provenance").
+async fn read_stored_source_hash(repo_path: &Path, normalized_law_path: &str) -> Option<String> {
+    let meta_rel = Path::new(normalized_law_path)
+        .parent()?
+        .join(".enrichment.yaml");
+    let content = tokio::fs::read_to_string(repo_path.join(meta_rel))
+        .await
+        .ok()?;
+    let meta: EnrichmentMetadata = serde_yaml_ng::from_str(&content).ok()?;
+    (!meta.source_hash.is_empty()).then_some(meta.source_hash)
+}
+
 pub async fn create_enrich_corpus(
     base_config: &CorpusConfig,
     branch: &str,
     job_id: Uuid,
     yaml_path: &str,
-) -> Result<CorpusClient> {
+) -> Result<EnrichCorpus> {
     let mut config = base_config.clone();
     config.branch = branch.into();
 
@@ -1004,11 +1022,36 @@ pub async fn create_enrich_corpus(
         );
     }
 
-    client
-        .checkout_from_branch(base_branch, &[&normalized])
-        .await?;
+    // Freshness guard: compare the target law's base version against the
+    // provenance recorded in a prior enrichment. New law -> check out fresh;
+    // unchanged base -> keep existing enrichment; changed/unknown base ->
+    // fail loudly (do NOT auto-overwrite a possibly-validated enrichment).
+    let base_sha = client.fetch_base_blob_sha(base_branch, &normalized).await?;
+    let tracked = client.is_tracked(&normalized).await?;
+    let stored = read_stored_source_hash(client.repo_path(), &normalized).await;
 
-    Ok(client)
+    match decide_base_action(tracked, stored.as_deref(), &base_sha) {
+        BaseAction::CheckoutFresh => {
+            client.checkout_path_from_fetch_head(&normalized).await?;
+            tracing::info!(base = %base_branch, path = %normalized, "checked out law fresh from base");
+        }
+        BaseAction::Skip => {
+            tracing::debug!(path = %normalized, "base unchanged, keeping existing enrichment");
+        }
+        BaseAction::Drift => {
+            return Err(PipelineError::BaseDrift {
+                yaml_path: normalized.clone(),
+                base: base_branch.to_string(),
+                expected: stored.unwrap_or_default(),
+                actual: base_sha,
+            });
+        }
+    }
+
+    Ok(EnrichCorpus {
+        client,
+        source_hash: base_sha,
+    })
 }
 
 /// Ensure `.claude/skills/` exist in the target repo directory.

--- a/packages/pipeline/src/enrich.rs
+++ b/packages/pipeline/src/enrich.rs
@@ -516,6 +516,10 @@ pub struct EnrichmentMetadata {
     pub articles_total: usize,
     /// Total articles with a `machine_readable` section after enrichment.
     pub articles_with_machine_readable: usize,
+    /// Git blob SHA of the base-branch law YAML this enrichment was generated
+    /// from. Empty when unknown (files written before this field existed).
+    #[serde(default)]
+    pub source_hash: String,
 }
 
 /// Supported LLM providers for enrichment.
@@ -1171,6 +1175,7 @@ pub async fn execute_enrich_with_runner(
         coverage_score,
         articles_total: articles_before,
         articles_with_machine_readable,
+        source_hash: String::new(),
     };
 
     let metadata_path = yaml_abs
@@ -1633,6 +1638,7 @@ related_legislation:
             coverage_score: 0.7,
             articles_total: 10,
             articles_with_machine_readable: 7,
+            source_hash: String::new(),
         };
 
         let yaml = serde_yaml_ng::to_string(&meta).unwrap();
@@ -1641,6 +1647,33 @@ related_legislation:
 
         let deserialized: EnrichmentMetadata = serde_yaml_ng::from_str(&yaml).unwrap();
         assert_eq!(deserialized.articles_with_machine_readable, 7);
+    }
+
+    #[test]
+    fn enrichment_metadata_source_hash_defaults_when_absent() {
+        // A .enrichment.yaml written before this field existed.
+        let legacy = "law_id: BWBR0001\ntimestamp: '2026-01-01T00:00:00Z'\nprovider: claude\nmodel: m\nprompt_hash: p\ncode_commit: c\ncoverage_score: 1.0\narticles_total: 1\narticles_with_machine_readable: 1\n";
+        let meta: EnrichmentMetadata = serde_yaml_ng::from_str(legacy).unwrap();
+        assert_eq!(meta.source_hash, "");
+    }
+
+    #[test]
+    fn enrichment_metadata_source_hash_roundtrips() {
+        let meta = EnrichmentMetadata {
+            law_id: "BWBR0001".into(),
+            timestamp: "2026-01-01T00:00:00Z".into(),
+            provider: "claude".into(),
+            model: "m".into(),
+            prompt_hash: "p".into(),
+            code_commit: "c".into(),
+            coverage_score: 1.0,
+            articles_total: 1,
+            articles_with_machine_readable: 1,
+            source_hash: "abc123".into(),
+        };
+        let yaml = serde_yaml_ng::to_string(&meta).unwrap();
+        let back: EnrichmentMetadata = serde_yaml_ng::from_str(&yaml).unwrap();
+        assert_eq!(back.source_hash, "abc123");
     }
 
     #[test]

--- a/packages/pipeline/src/enrich.rs
+++ b/packages/pipeline/src/enrich.rs
@@ -1169,8 +1169,9 @@ pub async fn execute_enrich(
     payload: &EnrichPayload,
     repo_path: &Path,
     config: &EnrichConfig,
+    source_hash: &str,
 ) -> Result<(EnrichResult, Vec<PathBuf>)> {
-    execute_enrich_with_runner(payload, repo_path, config, &ProcessLlmRunner).await
+    execute_enrich_with_runner(payload, repo_path, config, source_hash, &ProcessLlmRunner).await
 }
 
 /// Execute the enrichment: call the LLM runner to generate machine_readable sections.
@@ -1181,6 +1182,7 @@ pub async fn execute_enrich_with_runner(
     payload: &EnrichPayload,
     repo_path: &Path,
     config: &EnrichConfig,
+    source_hash: &str,
     runner: &dyn LlmRunner,
 ) -> Result<(EnrichResult, Vec<PathBuf>)> {
     let normalized_path = normalize_yaml_path(&payload.yaml_path)?;
@@ -1256,7 +1258,7 @@ pub async fn execute_enrich_with_runner(
         coverage_score,
         articles_total: articles_before,
         articles_with_machine_readable,
-        source_hash: String::new(),
+        source_hash: source_hash.to_string(),
     };
 
     let metadata_path = yaml_abs
@@ -2063,7 +2065,7 @@ articles:
         });
 
         let (result, written_files) =
-            execute_enrich_with_runner(&payload, dir.path(), &config, &FakeLlmRunner)
+            execute_enrich_with_runner(&payload, dir.path(), &config, "", &FakeLlmRunner)
                 .await
                 .unwrap();
 
@@ -2127,7 +2129,7 @@ articles:
             model: None,
         });
 
-        let err = execute_enrich_with_runner(&payload, dir.path(), &config, &FailingLlmRunner)
+        let err = execute_enrich_with_runner(&payload, dir.path(), &config, "", &FailingLlmRunner)
             .await
             .unwrap_err();
 
@@ -2175,7 +2177,7 @@ articles:
             model: None,
         });
 
-        let err = execute_enrich_with_runner(&payload, dir.path(), &config, &NoopLlmRunner)
+        let err = execute_enrich_with_runner(&payload, dir.path(), &config, "", &NoopLlmRunner)
             .await
             .unwrap_err();
 

--- a/packages/pipeline/src/enrich.rs
+++ b/packages/pipeline/src/enrich.rs
@@ -46,6 +46,39 @@ fn pick_enrich_base(preferred: &str, preferred_exists: bool) -> &str {
     }
 }
 
+/// Outcome of comparing a target law's base version against the enrichment's
+/// recorded provenance. Pure decision so it can be unit-tested without git.
+// used by create_enrich_corpus in a later task
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BaseAction {
+    /// Law not yet on the enrich branch — check it out fresh from the base.
+    CheckoutFresh,
+    /// Law present and its base is unchanged — keep the existing enrichment.
+    Skip,
+    /// Law present but its base moved (or provenance is missing) — fail loudly.
+    Drift,
+}
+
+/// Decide what to do for a target law given whether it is already tracked on
+/// the enrich branch, the `source_hash` recorded in its `.enrichment.yaml`
+/// (if any), and the current base-branch blob SHA of the law.
+// used by create_enrich_corpus in a later task
+#[allow(dead_code)]
+pub(crate) fn decide_base_action(
+    tracked: bool,
+    stored_source_hash: Option<&str>,
+    base_sha: &str,
+) -> BaseAction {
+    if !tracked {
+        return BaseAction::CheckoutFresh;
+    }
+    match stored_source_hash {
+        Some(h) if !h.is_empty() && h == base_sha => BaseAction::Skip,
+        _ => BaseAction::Drift,
+    }
+}
+
 /// Trait abstracting the LLM invocation so `execute_enrich` can be tested
 /// with a fake provider that doesn't spawn real processes.
 #[async_trait::async_trait]
@@ -1354,6 +1387,44 @@ mod tests {
         // remote-exists bool is moot and we always use `development`.
         assert_eq!(pick_enrich_base("development", true), "development");
         assert_eq!(pick_enrich_base("development", false), "development");
+    }
+
+    #[test]
+    fn decide_base_action_new_law_checks_out_fresh() {
+        assert_eq!(
+            decide_base_action(false, None, "sha_new"),
+            BaseAction::CheckoutFresh
+        );
+        // Even if a stored hash somehow exists, an untracked path is a fresh checkout.
+        assert_eq!(
+            decide_base_action(false, Some("sha_old"), "sha_new"),
+            BaseAction::CheckoutFresh
+        );
+    }
+
+    #[test]
+    fn decide_base_action_unchanged_base_skips() {
+        assert_eq!(
+            decide_base_action(true, Some("sha"), "sha"),
+            BaseAction::Skip
+        );
+    }
+
+    #[test]
+    fn decide_base_action_changed_base_is_drift() {
+        assert_eq!(
+            decide_base_action(true, Some("sha_old"), "sha_new"),
+            BaseAction::Drift
+        );
+    }
+
+    #[test]
+    fn decide_base_action_missing_or_empty_provenance_is_drift() {
+        assert_eq!(decide_base_action(true, None, "sha_new"), BaseAction::Drift);
+        assert_eq!(
+            decide_base_action(true, Some(""), "sha_new"),
+            BaseAction::Drift
+        );
     }
 
     #[test]

--- a/packages/pipeline/src/enrich.rs
+++ b/packages/pipeline/src/enrich.rs
@@ -998,6 +998,46 @@ pub async fn create_enrich_corpus(
     let mut client = CorpusClient::new(config);
     client.ensure_repo().await?;
 
+    // Past `ensure_repo()` a per-job git clone exists on disk. Resolving the
+    // base branch, checking freshness, or checking out the law can all fail —
+    // including a deliberate `BaseDrift` bail-out. The worker's shared cleanup
+    // only captures the checkout path on the success path, so on any error we
+    // must remove the clone here; otherwise an errored (and especially a
+    // drifted, awaiting-human) job leaks its clone on a disk/OOM-sensitive
+    // worker.
+    let checkout_dir = client.repo_path().to_path_buf();
+    let source_hash = match resolve_enrich_base(&client, base_config, &normalized).await {
+        Ok(source_hash) => source_hash,
+        Err(e) => {
+            if let Err(rm) = tokio::fs::remove_dir_all(&checkout_dir).await {
+                tracing::warn!(
+                    path = %checkout_dir.display(),
+                    error = %rm,
+                    "failed to clean up per-job corpus checkout after enrich setup error"
+                );
+            }
+            return Err(e);
+        }
+    };
+
+    Ok(EnrichCorpus {
+        client,
+        source_hash,
+    })
+}
+
+/// Resolve the enrichment base branch and materialize the target law from it,
+/// returning the base blob SHA to record as provenance (`source_hash`).
+///
+/// Split out from [`create_enrich_corpus`] so that every error it can raise — a
+/// git probe failure, a checkout failure, or a [`PipelineError::BaseDrift`]
+/// bail-out — flows through a single caller-side cleanup that removes the
+/// per-job clone. Only `&self` methods are used; the clone already exists.
+async fn resolve_enrich_base(
+    client: &CorpusClient,
+    base_config: &CorpusConfig,
+    normalized: &str,
+) -> Result<String> {
     // Prefer the worker's own base branch (e.g. `pr574`) so PR deployments
     // enrich their own harvested YAML, not production's. Probe the remote
     // first and fall back to `development` only when the branch doesn't
@@ -1032,21 +1072,21 @@ pub async fn create_enrich_corpus(
     // provenance recorded in a prior enrichment. New law -> check out fresh;
     // unchanged base -> keep existing enrichment; changed/unknown base ->
     // fail loudly (do NOT auto-overwrite a possibly-validated enrichment).
-    let base_sha = client.fetch_base_blob_sha(base_branch, &normalized).await?;
-    let tracked = client.is_tracked(&normalized).await?;
-    let stored = read_stored_source_hash(client.repo_path(), &normalized).await;
+    let base_sha = client.fetch_base_blob_sha(base_branch, normalized).await?;
+    let tracked = client.is_tracked(normalized).await?;
+    let stored = read_stored_source_hash(client.repo_path(), normalized).await;
 
     match decide_base_action(tracked, stored.as_deref(), &base_sha) {
         BaseAction::CheckoutFresh => {
-            client.checkout_path_from_fetch_head(&normalized).await?;
+            client.checkout_path_from_fetch_head(normalized).await?;
             tracing::info!(base = %base_branch, path = %normalized, "checked out law fresh from base");
         }
         BaseAction::Skip => {
-            tracing::debug!(path = %normalized, "base unchanged, keeping existing enrichment");
+            tracing::debug!(path = %normalized, "base unchanged, no fresh checkout needed");
         }
         BaseAction::Drift => {
             return Err(PipelineError::BaseDrift {
-                yaml_path: normalized.clone(),
+                yaml_path: normalized.to_string(),
                 base: base_branch.to_string(),
                 expected: stored.unwrap_or_else(|| "(none recorded)".to_string()),
                 actual: base_sha,
@@ -1054,10 +1094,7 @@ pub async fn create_enrich_corpus(
         }
     }
 
-    Ok(EnrichCorpus {
-        client,
-        source_hash: base_sha,
-    })
+    Ok(base_sha)
 }
 
 /// Ensure `.claude/skills/` exist in the target repo directory.

--- a/packages/pipeline/src/error.rs
+++ b/packages/pipeline/src/error.rs
@@ -35,6 +35,14 @@ pub enum PipelineError {
     #[error("enrichment error: {0}")]
     Enrich(String),
 
+    #[error("base drift for {yaml_path}: base branch {base} changed (was {expected}, now {actual}); human review / re-enrich required")]
+    BaseDrift {
+        yaml_path: String,
+        base: String,
+        expected: String,
+        actual: String,
+    },
+
     #[error("worker error: {0}")]
     Worker(String),
 

--- a/packages/pipeline/src/job_queue.rs
+++ b/packages/pipeline/src/job_queue.rs
@@ -306,10 +306,15 @@ where
 /// Mark a job as permanently failed regardless of remaining attempts.
 ///
 /// Unlike [`fail_job`], this never reschedules for retry: it sets `failed`
-/// immediately even when `attempts < max_attempts`. Used for deterministic
-/// failures (e.g. the enrichment LLM produced no machine_readable sections, or
-/// its output failed to parse) where retrying the same input reproduces the
-/// same failure and only burns budget and blocks the serial queue.
+/// immediately even when `attempts < max_attempts`. Use this for deterministic
+/// failures that cannot succeed on retry against the same inputs, where
+/// retrying only burns budget and blocks the serial queue. Examples:
+/// - the enrichment LLM produced no machine_readable sections, or its output
+///   failed to parse; or
+/// - enrichment base drift, where the base is stale relative to the recorded
+///   provenance and every retry would re-fail against the same base (and, on
+///   each non-final attempt, flip-flop the law status Enriching -> Harvested
+///   before finally landing on Failed).
 #[tracing::instrument(skip(executor, error_result))]
 pub async fn fail_job_terminal<'e, E>(
     executor: E,

--- a/packages/pipeline/src/worker.rs
+++ b/packages/pipeline/src/worker.rs
@@ -1212,6 +1212,33 @@ async fn process_next_enrich_job(
                 tracing::info!(branch = %branch, "created enrichment branch corpus");
                 Some(enrich_corpus)
             }
+            Err(e @ PipelineError::BaseDrift { .. }) => {
+                // A previously-enriched law's base moved. Do NOT enrich on a
+                // stale base and do NOT overwrite the existing enrichment —
+                // fail the job loudly for human review / re-enrich.
+                tracing::error!(error = %e, law_id = %job.law_id, branch = %branch, "base drift detected; failing enrich job");
+                let error_json =
+                    serde_json::json!({ "error": e.to_string(), "kind": "base_drift" });
+                match job_queue::fail_job(pool, job.id, Some(error_json)).await {
+                    Ok(failed_job) if failed_job.status == crate::models::JobStatus::Failed => {
+                        if let Err(se) = sqlx::query(
+                            "UPDATE law_entries SET status = 'enrich_failed'::law_status, updated_at = now() \
+                             WHERE law_id = $1 AND status NOT IN ('enriched', 'enrich_exhausted')",
+                        )
+                        .bind(&job.law_id)
+                        .execute(pool)
+                        .await
+                        {
+                            tracing::warn!(error = %se, law_id = %job.law_id, "failed to update law status to enrich_failed");
+                        }
+                    }
+                    Ok(_) => {}
+                    Err(fe) => {
+                        tracing::error!(error = %fe, "failed to mark base-drift enrich job as failed")
+                    }
+                }
+                return Ok(JobOutcome::Processed);
+            }
             Err(e) => {
                 tracing::warn!(error = %e, branch = %branch, "failed to create enrichment branch corpus, proceeding without");
                 None
@@ -1274,9 +1301,14 @@ async fn process_next_enrich_job(
         );
     }
 
+    let source_hash = enrich_corpus
+        .as_ref()
+        .map(|c| c.source_hash.clone())
+        .unwrap_or_default();
+
     let enrich_outcome = tokio::time::timeout(
         job_timeout,
-        execute_enrich(&payload, &effective_repo, &bounded_config),
+        execute_enrich(&payload, &effective_repo, &bounded_config, &source_hash),
     )
     .await;
 

--- a/packages/pipeline/src/worker.rs
+++ b/packages/pipeline/src/worker.rs
@@ -1232,7 +1232,18 @@ async fn process_next_enrich_job(
                             tracing::warn!(error = %se, law_id = %job.law_id, "failed to update law status to enrich_failed");
                         }
                     }
-                    Ok(_) => {}
+                    Ok(_) => {
+                        if let Err(e) = law_status::update_status_if(
+                            pool,
+                            &job.law_id,
+                            LawStatusValue::Enriching,
+                            LawStatusValue::Harvested,
+                        )
+                        .await
+                        {
+                            tracing::warn!(error = %e, law_id = %job.law_id, "failed to reset law status to harvested");
+                        }
+                    }
                     Err(fe) => {
                         tracing::error!(error = %fe, "failed to mark base-drift enrich job as failed")
                     }

--- a/packages/pipeline/src/worker.rs
+++ b/packages/pipeline/src/worker.rs
@@ -1219,8 +1219,15 @@ async fn process_next_enrich_job(
                 tracing::error!(error = %e, law_id = %job.law_id, branch = %branch, "base drift detected; failing enrich job");
                 let error_json =
                     serde_json::json!({ "error": e.to_string(), "kind": "base_drift" });
-                match job_queue::fail_job(pool, job.id, Some(error_json)).await {
-                    Ok(failed_job) if failed_job.status == crate::models::JobStatus::Failed => {
+                // Terminal-fail (not fail_job): base drift is deterministic
+                // against the same base, so it must NOT re-enter the job-level
+                // retry loop. fail_job_terminal marks the job Failed in one shot
+                // instead of bouncing it back to 'pending' up to max_attempts —
+                // which would deterministically re-fail against the same base
+                // and flip-flop the law status Enriching -> Harvested on each
+                // non-final attempt before finally landing on Failed.
+                match job_queue::fail_job_terminal(pool, job.id, Some(error_json)).await {
+                    Ok(_failed_job) => {
                         if let Err(se) = sqlx::query(
                             "UPDATE law_entries SET status = 'enrich_failed'::law_status, updated_at = now() \
                              WHERE law_id = $1 AND status NOT IN ('enriched', 'enrich_exhausted')",
@@ -1231,18 +1238,13 @@ async fn process_next_enrich_job(
                         {
                             tracing::warn!(error = %se, law_id = %job.law_id, "failed to update law status to enrich_failed");
                         }
-                    }
-                    Ok(_) => {
-                        if let Err(e) = law_status::update_status_if(
-                            pool,
-                            &job.law_id,
-                            LawStatusValue::Enriching,
-                            LawStatusValue::Harvested,
-                        )
-                        .await
-                        {
-                            tracing::warn!(error = %e, law_id = %job.law_id, "failed to reset law status to harvested");
-                        }
+                        // Deliberately NOT calling handle_enrich_exhausted_or_retry here,
+                        // and the job was terminal-failed above: unlike the other enrich
+                        // failures (timeout, commit failure, enrich error), base drift is
+                        // part of neither the job-level retry loop nor the law-level
+                        // exhaust loop. The base is unchanged-but-stale relative to the
+                        // recorded provenance, so any retry would just re-fail against the
+                        // same base. Drift requires a human to review and re-enrich.
                     }
                     Err(fe) => {
                         tracing::error!(error = %fe, "failed to mark base-drift enrich job as failed")

--- a/packages/pipeline/src/worker.rs
+++ b/packages/pipeline/src/worker.rs
@@ -1208,9 +1208,9 @@ async fn process_next_enrich_job(
     let branch = enrich_branch_name(effective_config.provider.name());
     let enrich_corpus = if let Some(base_config) = corpus_config {
         match create_enrich_corpus(base_config, &branch, job.id, &payload.yaml_path).await {
-            Ok(client) => {
+            Ok(enrich_corpus) => {
                 tracing::info!(branch = %branch, "created enrichment branch corpus");
-                Some(client)
+                Some(enrich_corpus)
             }
             Err(e) => {
                 tracing::warn!(error = %e, branch = %branch, "failed to create enrichment branch corpus, proceeding without");

--- a/packages/pipeline/src/worker.rs
+++ b/packages/pipeline/src/worker.rs
@@ -1224,7 +1224,7 @@ async fn process_next_enrich_job(
     // Use the enrichment branch repo if available, otherwise the base repo
     let effective_repo = enrich_corpus
         .as_ref()
-        .map(|c| c.repo_path().to_path_buf())
+        .map(|c| c.client.repo_path().to_path_buf())
         .unwrap_or_else(|| repo_path.to_path_buf());
 
     // Ensure skill files are available in the repo checkout so the LLM can
@@ -1235,7 +1235,9 @@ async fn process_next_enrich_job(
     }
 
     // Capture the per-job checkout path for cleanup after the job completes.
-    let checkout_path = enrich_corpus.as_ref().map(|c| c.repo_path().to_path_buf());
+    let checkout_path = enrich_corpus
+        .as_ref()
+        .map(|c| c.client.repo_path().to_path_buf());
 
     // Compute the progress file path and spawn a background polling task.
     // The LLM writes phase info to this file; we relay it to the DB every 10s.
@@ -1346,6 +1348,7 @@ async fn process_next_enrich_job(
                         result.provider, result.law_id, result.yaml_path
                     );
                     corpus
+                        .client
                         .commit_and_push(&written_files, &message)
                         .await
                         .map_err(|e| PipelineError::Enrich(format!("corpus push failed: {e}")))?;

--- a/packages/pipeline/tests/enrich_corpus_tests.rs
+++ b/packages/pipeline/tests/enrich_corpus_tests.rs
@@ -1,0 +1,125 @@
+//! End-to-end coverage of the base-freshness guard in `create_enrich_corpus`.
+//!
+//! The pure `decide_base_action` unit tests (in `enrich.rs`) pin the decision
+//! logic, and the corpus crate's primitives (`fetch_base_blob_sha`,
+//! `is_tracked`, sparse checkout) are tested next to their implementation. This
+//! test wires the two together through the real `create_enrich_corpus` glue: it
+//! builds a bare git remote whose `enrich/test` branch carries a law plus a
+//! `.enrichment.yaml` recording a *stale* `source_hash`, then asserts the guard
+//! fails the job loudly with `BaseDrift` instead of silently re-enriching over a
+//! possibly-validated result.
+
+use std::path::Path;
+
+use regelrecht_corpus::CorpusConfig;
+use regelrecht_pipeline::enrich::create_enrich_corpus;
+use regelrecht_pipeline::PipelineError;
+use uuid::Uuid;
+
+/// Run a git command in `dir` and assert it succeeded.
+async fn run_git(dir: &Path, args: &[&str]) {
+    let output = tokio::process::Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .await
+        .expect("failed to spawn git");
+    assert!(
+        output.status.success(),
+        "git {:?} failed: {}",
+        args,
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// Configure a committer identity on a working clone.
+async fn configure_user(repo: &Path) {
+    run_git(repo, &["config", "user.name", "test"]).await;
+    run_git(repo, &["config", "user.email", "test@test.nl"]).await;
+}
+
+/// Write `content` to `rel` inside `repo`, creating parent directories.
+async fn write_file(repo: &Path, rel: &str, content: &str) {
+    let path = repo.join(rel);
+    tokio::fs::create_dir_all(path.parent().unwrap())
+        .await
+        .unwrap();
+    tokio::fs::write(&path, content).await.unwrap();
+}
+
+/// A law that is already enriched on `enrich/test` but whose recorded
+/// `source_hash` no longer matches the base blob (the base moved after the
+/// enrichment was recorded) must fail as `BaseDrift`, never be re-enriched.
+#[tokio::test]
+async fn create_enrich_corpus_fails_on_drifted_base() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+
+    // 1. Bare remote with a `development` branch carrying one law YAML.
+    let bare = root.join("bare.git");
+    run_git(
+        root,
+        &[
+            "init",
+            "--bare",
+            "--initial-branch=development",
+            bare.to_str().unwrap(),
+        ],
+    )
+    .await;
+    let bare_url = format!("file://{}", bare.display());
+
+    let law_path = "regulation/nl/wet/test_law/2025-01-01.yaml";
+    let meta_path = "regulation/nl/wet/test_law/.enrichment.yaml";
+    let law_content = "$id: test_law\narticles: []\n";
+
+    // Seed `development` through a working clone.
+    let seed = root.join("seed");
+    run_git(root, &["clone", &bare_url, seed.to_str().unwrap()]).await;
+    configure_user(&seed).await;
+    write_file(&seed, law_path, law_content).await;
+    run_git(&seed, &["add", "."]).await;
+    run_git(&seed, &["commit", "-m", "harvest law"]).await;
+    run_git(&seed, &["push", "origin", "development"]).await;
+
+    // 2. `enrich/test`: the same law bytes plus a `.enrichment.yaml` whose
+    //    `source_hash` is a stale placeholder that does NOT equal the base blob
+    //    SHA of the law — simulating a base that moved after enrichment.
+    run_git(&seed, &["checkout", "-b", "enrich/test"]).await;
+    let stale_meta = "law_id: test_law\n\
+         provider: claude\n\
+         source_hash: \"0000000000000000000000000000000000000000\"\n";
+    write_file(&seed, meta_path, stale_meta).await;
+    run_git(&seed, &["add", "."]).await;
+    run_git(&seed, &["commit", "-m", "enrich law with stale provenance"]).await;
+    run_git(&seed, &["push", "-u", "origin", "enrich/test"]).await;
+
+    // 3. base_config: the worker's own base branch is `development`.
+    let mut base_config = CorpusConfig::new(&bare_url, root.join("base-checkout"));
+    base_config.branch = "development".into();
+
+    // 4. Run the real enrichment-checkout glue against `enrich/test`. It clones
+    //    the enrich branch (sparse), fetches the base blob SHA, reads the stored
+    //    provenance, and applies the freshness decision.
+    let result = create_enrich_corpus(&base_config, "enrich/test", Uuid::new_v4(), law_path).await;
+
+    // 5. Stale provenance -> a loud, retryable failure, never a silent overwrite.
+    match result {
+        Err(PipelineError::BaseDrift {
+            yaml_path,
+            base,
+            expected,
+            actual,
+        }) => {
+            assert_eq!(yaml_path, law_path);
+            assert_eq!(base, "development");
+            assert_eq!(expected, "0000000000000000000000000000000000000000");
+            assert_ne!(
+                actual, expected,
+                "actual base blob SHA must differ from the stale recorded one"
+            );
+        }
+        Err(other) => panic!("expected BaseDrift, got error: {other:?}"),
+        Ok(_) => panic!("expected BaseDrift, but create_enrich_corpus succeeded"),
+    }
+}

--- a/packages/pipeline/tests/enrich_corpus_tests.rs
+++ b/packages/pipeline/tests/enrich_corpus_tests.rs
@@ -110,7 +110,9 @@ async fn create_enrich_corpus_fails_on_drifted_base() {
     //    provenance, and applies the freshness decision.
     let result = create_enrich_corpus(&base_config, "enrich/test", Uuid::new_v4(), law_path).await;
 
-    // 5. Stale provenance -> a loud, retryable failure, never a silent overwrite.
+    // 5. Stale provenance -> a loud, terminal failure (requires human
+    //    re-enrich; handled via fail_job_terminal, never retried), never a
+    //    silent overwrite.
     match result {
         Err(PipelineError::BaseDrift {
             yaml_path,

--- a/packages/pipeline/tests/enrich_corpus_tests.rs
+++ b/packages/pipeline/tests/enrich_corpus_tests.rs
@@ -8,6 +8,13 @@
 //! `.enrichment.yaml` recording a *stale* `source_hash`, then asserts the guard
 //! fails the job loudly with `BaseDrift` instead of silently re-enriching over a
 //! possibly-validated result.
+//!
+//! NOTE: this test is DB-free — it needs only `git` and a temp dir, no
+//! testcontainers/Postgres. It lives in the integration `tests/` target (rather
+//! than as a `#[cfg(test)]` unit test) purely for filesystem/git isolation: it
+//! shells out to real `git` against a bare remote in a `tempfile` dir. It is not
+//! Docker-dependent, and it also runs under `just test-all`, so coverage isn't
+//! gated on the Docker-only `pipeline-integration-test` recipe.
 
 use std::path::Path;
 


### PR DESCRIPTION
## Problem

Enrichment runs on shared `enrich/{provider}` branches (`enrich/claude`, `enrich/opencode`). Those branches accumulate enriched laws over time on top of whatever base they were born from — and nothing checked that the base was still current. In one incident `enrich/claude` was sitting on `main` while harvesting had moved to `development`: the branch was **7911 commits and a whole schema/article-granularity generation behind**. Every re-enrichment silently regenerated `machine_readable` on top of a stale, wrong-shaped base, quietly discarding possibly hand-validated work.

## The fix

Record provenance and refuse to enrich against a moved base:

- **Record `source_hash`** — the git blob SHA of the base-branch law YAML the enrichment was generated from — into each law's `.enrichment.yaml`.
- **Before re-enriching a law**, compare its current base blob SHA to the recorded `source_hash` via a pure `decide_base_action`:
  - **new law** (not yet on the enrich branch) → check it out fresh from the base;
  - **unchanged** (recorded hash == base blob SHA) → proceed, keep the existing enrichment;
  - **drifted / missing provenance** (hash differs or absent) → **fail the job loudly** as `enrich_failed`. Never auto-overwrite a possibly-validated enrichment.
- The base reference is the existing `pick_enrich_base` result — `development` today, `main` if the corpus is migrated later — so **no base-selection code changes**, the guard just observes the base that would already have been used.

The freshness check operates on the exact law file path (via `is_tracked` / `fetch_base_blob_sha` resolving a single blob), so a newly harvested version of an already-known law is judged on its own path rather than masked by a sibling version in the same directory.

## Out of scope / future work

- Enrichment validation-state tracking (knowing *which* enrichments a human has validated).
- A schema-migration path for laws enriched against an older schema generation.
- The `development` → `main` migration itself.
- Whole-branch drift monitoring (this guards per-law at enrich time, not the branch as a whole).

## Notes

The 9 commits are TDD-structured (pure decision function and error variant first, then corpus primitives, then the glue, then the loud-failure/retry wiring, then a final refactor). This PR adds one end-to-end test wiring `create_enrich_corpus` against a real bare-git remote whose `enrich/test` branch carries a stale `.enrichment.yaml`, asserting the guard returns `BaseDrift`.

Design + plan: /workspace/superpowers-specs/2026-07-02-enrich-base-freshness-guard-*.md (local reference)
