### PR TITLE
feat(pipeline): hourly enrich limit with night multiplier

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,15 +36,16 @@ WORKER_MAX_POLL_INTERVAL_SECS=60
 # LLM timeout to job_timeout-30s. For big laws raise both, e.g. 3600 / 3900.
 # LLM_TIMEOUT_SECS=3600
 # WORKER_JOB_TIMEOUT_SECS=3900
-# Cap how many enrichments this worker's provider (LLM_PROVIDER) runs per UTC day
-# (counted from the jobs table across all run states, survives restarts).
+# Cap how many enrichments this worker's provider (LLM_PROVIDER) runs per local
+# clock-hour (Europe/Amsterdam). During the night window (00:00–08:00 local) the
+# cap is multiplied by ENRICH_NIGHT_MULTIPLIER, so bulk enrichment runs overnight.
 # FAIL-CLOSED: unset or 0 pauses enrichment entirely — a worker must be given an
 # explicit positive limit to run. Once the cap is reached it pauses the whole
-# worker until the next UTC day, so use it on a provider-dedicated worker (e.g. a
-# claude-only enrichworker). Keeps a personal Claude token from running the whole
-# corpus at once. Every enrich worker (incl. the VLAM/opencode one) now needs an
-# explicit limit to do any work.
-# ENRICH_DAILY_LIMIT=100
+# worker until the next local hour. Keeps a personal Claude token from running the
+# whole corpus at once. Every enrich worker (incl. the VLAM/opencode one) needs an
+# explicit limit to do any work. ENRICH_NIGHT_MULTIPLIER defaults to 1 (no boost).
+# ENRICH_HOURLY_LIMIT=4
+# ENRICH_NIGHT_MULTIPLIER=5
 
 # === Admin API Key (optional, enables Bearer token auth for GET + DELETE) ===
 # ADMIN_API_KEY=change-me-to-a-long-random-string-at-least-32-chars

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -85,7 +85,9 @@ services:
       CLAUDE_CODE_OAUTH_TOKEN: ${CLAUDE_CODE_OAUTH_TOKEN:-}
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
       # Fail-closed: unset/0 pauses enrichment; set a positive value to run.
-      ENRICH_DAILY_LIMIT: ${ENRICH_DAILY_LIMIT:-0}
+      # The night window (00:00–08:00 Europe/Amsterdam) multiplies the cap.
+      ENRICH_HOURLY_LIMIT: ${ENRICH_HOURLY_LIMIT:-0}
+      ENRICH_NIGHT_MULTIPLIER: ${ENRICH_NIGHT_MULTIPLIER:-1}
       REGULATION_REPO_PATH: /tmp/regulation-repo
       REGULATION_OUTPUT_BASE: regulation/nl
       WORKER_POLL_INTERVAL_SECS: ${WORKER_POLL_INTERVAL_SECS:-5}

--- a/packages/pipeline/src/config.rs
+++ b/packages/pipeline/src/config.rs
@@ -79,7 +79,8 @@ pub struct WorkerConfig {
     /// Default: 5. Configurable via `WORKER_MAX_CONSECUTIVE_RESOURCE_FAILURES`.
     pub max_consecutive_resource_failures: u32,
     /// Maximum number of enrichment jobs (for this worker's provider) that may
-    /// run per UTC calendar day. Configurable via `ENRICH_DAILY_LIMIT`.
+    /// run per local clock-hour (Europe/Amsterdam). Configurable via
+    /// `ENRICH_HOURLY_LIMIT`.
     ///
     /// **Fail-closed**: absent (or unparseable) reads as `0`, and `0` pauses
     /// enrichment entirely — a worker must be given an explicit positive limit
@@ -90,9 +91,14 @@ pub struct WorkerConfig {
     /// Enforced by the enrich worker against the durable `jobs` table, so the
     /// cap survives restarts. The cap keys on this worker's configured provider
     /// (`LLM_PROVIDER`), and once reached it pauses the whole worker until the
-    /// UTC day rolls over — so it is meant for a provider-dedicated worker (e.g.
-    /// a claude-only enrichworker).
-    pub enrich_daily_limit: u32,
+    /// next local hour — so it is meant for a provider-dedicated worker (e.g. a
+    /// claude-only enrichworker).
+    pub enrich_hourly_limit: u32,
+    /// Multiplier applied to `enrich_hourly_limit` during the local night window
+    /// (00:00–08:00 Europe/Amsterdam), so bulk enrichment runs mostly overnight.
+    /// Configurable via `ENRICH_NIGHT_MULTIPLIER`. Default `1` (no boost) so a
+    /// missing or typo'd value never silently amplifies spend.
+    pub enrich_night_multiplier: u32,
     /// When true, a completed harvest auto-enqueues enrich jobs for that law.
     /// Off by default; enrichment is otherwise requested explicitly via the admin
     /// API. Configurable via `ENRICH_AUTO_ENQUEUE`.
@@ -121,7 +127,8 @@ impl std::fmt::Debug for WorkerConfig {
                 "max_consecutive_resource_failures",
                 &self.max_consecutive_resource_failures,
             )
-            .field("enrich_daily_limit", &self.enrich_daily_limit)
+            .field("enrich_hourly_limit", &self.enrich_hourly_limit)
+            .field("enrich_night_multiplier", &self.enrich_night_multiplier)
             .field("auto_enrich_enqueue", &self.auto_enrich_enqueue)
             .field("related_harvest_max_depth", &self.related_harvest_max_depth)
             .finish()
@@ -175,18 +182,31 @@ impl WorkerConfig {
                 .unwrap_or(5)
                 .max(1);
 
-        // Per-provider daily run cap. Fail-closed: absent reads as 0 (paused),
+        // Per-provider hourly run cap. Fail-closed: absent reads as 0 (paused),
         // and a present-but-unparseable value warns and also reads as 0 rather
         // than silently disabling the cap (this guards spend on a personal token).
-        let enrich_daily_limit: u32 = match std::env::var("ENRICH_DAILY_LIMIT") {
+        let enrich_hourly_limit: u32 = match std::env::var("ENRICH_HOURLY_LIMIT") {
             Ok(raw) => raw.parse::<u32>().unwrap_or_else(|_| {
                 tracing::warn!(
                     value = %raw,
-                    "ENRICH_DAILY_LIMIT is not a valid non-negative integer; treating as 0 (enrichment paused)"
+                    "ENRICH_HOURLY_LIMIT is not a valid non-negative integer; treating as 0 (enrichment paused)"
                 );
                 0
             }),
             Err(_) => 0,
+        };
+
+        // Night-window multiplier. Default 1 (no boost). Present-but-unparseable
+        // warns and reads as 1 rather than amplifying spend on a typo.
+        let enrich_night_multiplier: u32 = match std::env::var("ENRICH_NIGHT_MULTIPLIER") {
+            Ok(raw) => raw.parse::<u32>().unwrap_or_else(|_| {
+                tracing::warn!(
+                    value = %raw,
+                    "ENRICH_NIGHT_MULTIPLIER is not a valid non-negative integer; treating as 1 (no night boost)"
+                );
+                1
+            }),
+            Err(_) => 1,
         };
 
         // Auto-enrich after harvest is opt-in; unset/unrecognized reads as false.
@@ -216,7 +236,8 @@ impl WorkerConfig {
             orphan_timeout: Duration::from_secs(orphan_timeout_secs),
             exhausted_threshold,
             max_consecutive_resource_failures,
-            enrich_daily_limit,
+            enrich_hourly_limit,
+            enrich_night_multiplier,
             auto_enrich_enqueue,
             related_harvest_max_depth,
         })

--- a/packages/pipeline/src/config.rs
+++ b/packages/pipeline/src/config.rs
@@ -97,7 +97,8 @@ pub struct WorkerConfig {
     /// Multiplier applied to `enrich_hourly_limit` during the local night window
     /// (00:00–08:00 Europe/Amsterdam), so bulk enrichment runs mostly overnight.
     /// Configurable via `ENRICH_NIGHT_MULTIPLIER`. Default `1` (no boost) so a
-    /// missing or typo'd value never silently amplifies spend.
+    /// missing or typo'd value never silently amplifies spend; clamped to a
+    /// minimum of `1` so an explicit `0` can't invert the intent (night pause).
     pub enrich_night_multiplier: u32,
     /// When true, a completed harvest auto-enqueues enrich jobs for that law.
     /// Off by default; enrichment is otherwise requested explicitly via the admin
@@ -197,7 +198,10 @@ impl WorkerConfig {
         };
 
         // Night-window multiplier. Default 1 (no boost). Present-but-unparseable
-        // warns and reads as 1 rather than amplifying spend on a typo.
+        // warns and reads as 1 rather than amplifying spend on a typo. Clamped to
+        // a minimum of 1 (`.max(1)`) so an explicit `0` can't invert the intent —
+        // a 0 would make the night cap `base * 0 = 0`, pausing the worker at night
+        // and running it only by day. Never amplifies spend.
         let enrich_night_multiplier: u32 = match std::env::var("ENRICH_NIGHT_MULTIPLIER") {
             Ok(raw) => raw.parse::<u32>().unwrap_or_else(|_| {
                 tracing::warn!(
@@ -207,7 +211,8 @@ impl WorkerConfig {
                 1
             }),
             Err(_) => 1,
-        };
+        }
+        .max(1);
 
         // Auto-enrich after harvest is opt-in; unset/unrecognized reads as false.
         let auto_enrich_enqueue = std::env::var("ENRICH_AUTO_ENQUEUE")

--- a/packages/pipeline/src/job_queue.rs
+++ b/packages/pipeline/src/job_queue.rs
@@ -131,7 +131,9 @@ where
 ///
 /// Timezone is resolved by Postgres (`AT TIME ZONE 'Europe/Amsterdam'`), which is
 /// DST-correct; no chrono-tz needed. Served by the existing partial index
-/// `0022_enrich_daily_count_index` on `((payload->>'provider'), started_at)`.
+/// `0022_enrich_daily_count_index` on `((payload->>'provider'), started_at)`:
+/// the hour bound lives in the `WHERE` clause, so the scan is bounded to the
+/// current hour bucket (a `COUNT(*) FILTER (...)` would not push into the index).
 ///
 /// Counts every job that actually ran this hour, in ANY status; only never-run
 /// `pending` jobs (`started_at IS NULL`) are excluded. Relies on every enqueue
@@ -150,16 +152,14 @@ where
     let row = sqlx::query_as::<_, (i64, i32)>(
         r#"
         SELECT
-            COUNT(*) FILTER (
-                WHERE started_at >= date_trunc(
-                    'hour', now() AT TIME ZONE 'Europe/Amsterdam'
-                ) AT TIME ZONE 'Europe/Amsterdam'
-            ) AS ran_this_hour,
+            COUNT(*) AS ran_this_hour,
             EXTRACT(HOUR FROM now() AT TIME ZONE 'Europe/Amsterdam')::int AS local_hour
         FROM jobs
         WHERE job_type = 'enrich'
           AND started_at IS NOT NULL
           AND payload->>'provider' = $1
+          AND started_at >= date_trunc('hour', now() AT TIME ZONE 'Europe/Amsterdam')
+                            AT TIME ZONE 'Europe/Amsterdam'
         "#,
     )
     .bind(provider)

--- a/packages/pipeline/src/job_queue.rs
+++ b/packages/pipeline/src/job_queue.rs
@@ -120,46 +120,53 @@ where
     Ok(job)
 }
 
-/// Count enrichment jobs for `provider` that have started running today (UTC
-/// calendar day).
+/// Count enrich jobs for `provider` started within the current local clock-hour
+/// bucket (Europe/Amsterdam), and return that bucket's local hour-of-day
+/// (`0..=23`) so the caller can pick the day vs night cap.
 ///
-/// Used to enforce a per-provider daily run cap (see `ENRICH_DAILY_LIMIT`),
-/// which protects a personal Claude subscription token from running the whole
-/// corpus in one go. Reads the durable `jobs` table so the cap holds across
-/// worker restarts/redeploys (an in-memory counter would reset on every pod
-/// restart).
+/// Used to enforce a per-provider hourly run cap (see `ENRICH_HOURLY_LIMIT` +
+/// `ENRICH_NIGHT_MULTIPLIER`), which protects a personal Claude subscription
+/// token from running the whole corpus in one go. Reads the durable `jobs` table
+/// so the cap holds across worker restarts/redeploys.
 ///
-/// Counts every job that actually ran today, in ANY status — started,
-/// processing, completed, failed, and failed-and-awaiting-retry all count
-/// (`fail_job` keeps `started_at`, and a re-claim refreshes it). Only never-run
-/// `pending` jobs (`started_at IS NULL`, which spent no tokens) are excluded.
-/// A job counts once per day regardless of how many retries it took.
+/// Timezone is resolved by Postgres (`AT TIME ZONE 'Europe/Amsterdam'`), which is
+/// DST-correct; no chrono-tz needed. Served by the existing partial index
+/// `0022_enrich_daily_count_index` on `((payload->>'provider'), started_at)`.
 ///
-/// Relies on every enqueue path setting `payload.provider` (the admin and
-/// auto-enrich both do, one job per provider); a provider-less payload would run
-/// under the worker's default provider but not be counted here.
+/// Counts every job that actually ran this hour, in ANY status; only never-run
+/// `pending` jobs (`started_at IS NULL`) are excluded. Relies on every enqueue
+/// path setting `payload.provider`.
 ///
 /// Not transactional with the caller's claim: with N concurrent workers the cap
-/// may be exceeded by up to N near the boundary. That's acceptable for a spend
-/// guard.
-pub async fn count_enrich_jobs_started_today<'e, E>(executor: E, provider: &str) -> Result<i64>
+/// may be exceeded by up to N near the hour boundary. That's acceptable for a
+/// spend guard.
+pub async fn count_enrich_jobs_started_this_hour<'e, E>(
+    executor: E,
+    provider: &str,
+) -> Result<(i64, i32)>
 where
     E: sqlx::PgExecutor<'e>,
 {
-    let count = sqlx::query_scalar::<_, i64>(
+    let row = sqlx::query_as::<_, (i64, i32)>(
         r#"
-        SELECT COUNT(*)
+        SELECT
+            COUNT(*) FILTER (
+                WHERE started_at >= date_trunc(
+                    'hour', now() AT TIME ZONE 'Europe/Amsterdam'
+                ) AT TIME ZONE 'Europe/Amsterdam'
+            ) AS ran_this_hour,
+            EXTRACT(HOUR FROM now() AT TIME ZONE 'Europe/Amsterdam')::int AS local_hour
         FROM jobs
         WHERE job_type = 'enrich'
+          AND started_at IS NOT NULL
           AND payload->>'provider' = $1
-          AND started_at >= date_trunc('day', now() AT TIME ZONE 'UTC') AT TIME ZONE 'UTC'
         "#,
     )
     .bind(provider)
     .fetch_one(executor)
     .await?;
 
-    Ok(count)
+    Ok(row)
 }
 
 /// Claim the highest-priority pending job using FOR UPDATE SKIP LOCKED.

--- a/packages/pipeline/src/worker.rs
+++ b/packages/pipeline/src/worker.rs
@@ -26,7 +26,7 @@ const NIGHT_END_HOUR: i32 = 8;
 /// The enrich cap for a given local hour-of-day: the base hourly limit during
 /// the day, times `night_multiplier` during the night window. Saturating so a
 /// large multiplier can't overflow `u32`.
-pub fn hourly_cap(base: u32, night_multiplier: u32, local_hour: i32) -> u32 {
+fn hourly_cap(base: u32, night_multiplier: u32, local_hour: i32) -> u32 {
     if (NIGHT_START_HOUR..NIGHT_END_HOUR).contains(&local_hour) {
         base.saturating_mul(night_multiplier)
     } else {
@@ -764,11 +764,11 @@ pub async fn run_enrich_worker(config: WorkerConfig) -> Result<()> {
 
     let mut current_interval = std::time::Duration::ZERO;
     let mut consecutive_resource_failures: u32 = 0;
-    // Log the "paused on daily limit" state at info only on the first hit, then
-    // debug while it persists — otherwise a paused worker (e.g. ENRICH_DAILY_LIMIT
+    // Log the "paused on hourly limit" state at info only on the first hit, then
+    // debug while it persists — otherwise a paused worker (e.g. ENRICH_HOURLY_LIMIT
     // unset) emits an info line every poll interval indefinitely. Reset once a job
     // actually runs so a later pause is surfaced again.
-    let mut daily_limit_pause_logged = false;
+    let mut hourly_limit_pause_logged = false;
 
     loop {
         tokio::select! {
@@ -787,47 +787,70 @@ pub async fn run_enrich_worker(config: WorkerConfig) -> Result<()> {
             }
         }
 
-        // Enforce the per-provider daily run cap before claiming a job. Counted
-        // from the durable `jobs` table (not an in-memory counter) so the cap
-        // holds across worker restarts/redeploys. Primarily protects a personal
-        // Claude subscription token from running the whole corpus in one day.
-        // Fail-closed: a limit of 0 (the default when ENRICH_DAILY_LIMIT is
+        // Enforce the per-provider hourly run cap before claiming a job. The cap
+        // is multiplied during the local night window (00:00–08:00 Europe/
+        // Amsterdam) by ENRICH_NIGHT_MULTIPLIER, so bulk enrichment runs mostly
+        // overnight. Counted from the durable `jobs` table (not an in-memory
+        // counter) so the cap holds across restarts/redeploys.
+        //
+        // Fail-closed: a base limit of 0 (the default when ENRICH_HOURLY_LIMIT is
         // unset) pauses the worker without even querying.
         //
         // The cap keys on the worker's configured provider (LLM_PROVIDER), not
-        // the per-job payload provider. That is exact for a provider-dedicated
-        // worker (the intended deployment); a worker serving multiple providers
-        // would under-count the non-default provider's runs.
-        let limit = config.enrich_daily_limit;
+        // the per-job payload provider — exact for a provider-dedicated worker
+        // (the intended deployment).
+        let base = config.enrich_hourly_limit;
         let provider = enrich_config.provider.name();
-        let over_limit = if limit == 0 {
-            true
+        // `Some((cap, local_hour))` when we must pause; `None` when clear to run.
+        // A base of 0 pauses with a sentinel hour of -1 (renders as window=day).
+        let pause: Option<(u32, i32)> = if base == 0 {
+            Some((0, -1))
         } else {
-            match job_queue::count_enrich_jobs_started_today(&pool, provider).await {
-                Ok(ran_today) => ran_today >= i64::from(limit),
+            match job_queue::count_enrich_jobs_started_this_hour(&pool, provider).await {
+                Ok((ran_this_hour, local_hour)) => {
+                    let cap = hourly_cap(base, config.enrich_night_multiplier, local_hour);
+                    if ran_this_hour >= i64::from(cap) {
+                        Some((cap, local_hour))
+                    } else {
+                        None
+                    }
+                }
                 Err(e) => {
-                    tracing::warn!(error = %e, "failed to check daily enrich limit, proceeding");
-                    false
+                    tracing::warn!(error = %e, "failed to check hourly enrich limit, proceeding");
+                    None
                 }
             }
         };
-        if over_limit {
+        if let Some((cap, local_hour)) = pause {
             current_interval = config.max_poll_interval;
-            if !daily_limit_pause_logged {
+            let window = if (NIGHT_START_HOUR..NIGHT_END_HOUR).contains(&local_hour) {
+                "night"
+            } else {
+                "day"
+            };
+            if !hourly_limit_pause_logged {
                 tracing::info!(
                     provider,
-                    limit,
+                    cap,
+                    local_hour,
+                    window,
                     next_poll = ?current_interval,
-                    "daily enrich limit reached (or ENRICH_DAILY_LIMIT unset/0), pausing until the UTC day rolls over"
+                    "hourly enrich limit reached (or ENRICH_HOURLY_LIMIT unset/0), pausing until the next local hour"
                 );
-                daily_limit_pause_logged = true;
+                hourly_limit_pause_logged = true;
             } else {
-                tracing::debug!(provider, limit, "still paused on daily enrich limit");
+                tracing::debug!(
+                    provider,
+                    cap,
+                    local_hour,
+                    window,
+                    "still paused on hourly enrich limit"
+                );
             }
             continue;
         }
         // Not paused this cycle — re-arm the info-level pause log for the next pause.
-        daily_limit_pause_logged = false;
+        hourly_limit_pause_logged = false;
 
         match process_next_enrich_job(
             &pool,
@@ -1401,7 +1424,7 @@ async fn process_next_enrich_job(
                     // sources, legal bases the extref-only harvester misses).
                     // Always on, but depth-capped so the recursion is bounded (and
                     // the LLM-costly re-enrichment of those harvests is separately
-                    // gated by ENRICH_AUTO_ENQUEUE + ENRICH_DAILY_LIMIT).
+                    // gated by ENRICH_AUTO_ENQUEUE + ENRICH_HOURLY_LIMIT).
                     let enrich_depth = payload.depth.unwrap_or(0);
                     if enrich_depth < related_harvest_max_depth {
                         harvest_related_legislation(

--- a/packages/pipeline/src/worker.rs
+++ b/packages/pipeline/src/worker.rs
@@ -23,11 +23,16 @@ use crate::models::{JobType, LawStatusValue, Priority};
 const NIGHT_START_HOUR: i32 = 0;
 const NIGHT_END_HOUR: i32 = 8;
 
+/// Whether the given local hour-of-day falls in the night window `[start, end)`.
+fn is_night_hour(local_hour: i32) -> bool {
+    (NIGHT_START_HOUR..NIGHT_END_HOUR).contains(&local_hour)
+}
+
 /// The enrich cap for a given local hour-of-day: the base hourly limit during
 /// the day, times `night_multiplier` during the night window. Saturating so a
 /// large multiplier can't overflow `u32`.
 fn hourly_cap(base: u32, night_multiplier: u32, local_hour: i32) -> u32 {
-    if (NIGHT_START_HOUR..NIGHT_END_HOUR).contains(&local_hour) {
+    if is_night_hour(local_hour) {
         base.saturating_mul(night_multiplier)
     } else {
         base
@@ -823,7 +828,7 @@ pub async fn run_enrich_worker(config: WorkerConfig) -> Result<()> {
         };
         if let Some((cap, local_hour)) = pause {
             current_interval = config.max_poll_interval;
-            let window = if (NIGHT_START_HOUR..NIGHT_END_HOUR).contains(&local_hour) {
+            let window = if is_night_hour(local_hour) {
                 "night"
             } else {
                 "day"

--- a/packages/pipeline/src/worker.rs
+++ b/packages/pipeline/src/worker.rs
@@ -18,6 +18,22 @@ use crate::job_queue::{self, CreateJobRequest};
 use crate::law_status;
 use crate::models::{JobType, LawStatusValue, Priority};
 
+/// Local night window (Europe/Amsterdam) as a half-open hour-of-day range
+/// `[start, end)`. Hours in this range get the multiplied enrich cap.
+const NIGHT_START_HOUR: i32 = 0;
+const NIGHT_END_HOUR: i32 = 8;
+
+/// The enrich cap for a given local hour-of-day: the base hourly limit during
+/// the day, times `night_multiplier` during the night window. Saturating so a
+/// large multiplier can't overflow `u32`.
+pub fn hourly_cap(base: u32, night_multiplier: u32, local_hour: i32) -> u32 {
+    if (NIGHT_START_HOUR..NIGHT_END_HOUR).contains(&local_hour) {
+        base.saturating_mul(night_multiplier)
+    } else {
+        base
+    }
+}
+
 /// Outcome of attempting to process a single job, used to drive the
 /// resource-exhaustion circuit breaker in the worker loops.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1655,6 +1671,22 @@ async fn handle_enrich_exhausted_or_retry(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn hourly_cap_day_vs_night() {
+        // Day hours [8, 24) use the base limit.
+        assert_eq!(hourly_cap(4, 5, 8), 4, "08:00 is the first day hour");
+        assert_eq!(hourly_cap(4, 5, 12), 4);
+        assert_eq!(hourly_cap(4, 5, 23), 4);
+        // Night hours [0, 8) get base * multiplier.
+        assert_eq!(hourly_cap(4, 5, 0), 20, "midnight is a night hour");
+        assert_eq!(hourly_cap(4, 5, 3), 20);
+        assert_eq!(hourly_cap(4, 5, 7), 20, "07:00 is the last night hour");
+        // Default multiplier 1 means no boost.
+        assert_eq!(hourly_cap(4, 1, 3), 4);
+        // Saturating: a huge multiplier can't overflow.
+        assert_eq!(hourly_cap(u32::MAX, 5, 3), u32::MAX);
+    }
 
     #[test]
     fn classifies_fork_eagain_errors_as_resource_exhaustion() {

--- a/packages/pipeline/tests/job_queue_tests.rs
+++ b/packages/pipeline/tests/job_queue_tests.rs
@@ -469,7 +469,7 @@ async fn test_concurrent_claim_safety() {
 }
 
 #[tokio::test]
-async fn test_count_enrich_jobs_started_today() {
+async fn test_count_enrich_jobs_started_this_hour() {
     let db = TestDb::new().await;
 
     // Two claude enrich jobs and one opencode enrich job (payload provider set,
@@ -504,23 +504,26 @@ async fn test_count_enrich_jobs_started_today() {
         .unwrap();
 
     // Only the two claimed claude jobs count; pending c3, opencode, and harvest excluded.
-    let claude = job_queue::count_enrich_jobs_started_today(&db.pool, "claude")
+    let (claude, local_hour) = job_queue::count_enrich_jobs_started_this_hour(&db.pool, "claude")
         .await
         .unwrap();
-    assert_eq!(claude, 2, "two claude enrich jobs started today");
+    assert_eq!(claude, 2, "two claude enrich jobs started this hour");
+    assert!((0..=23).contains(&local_hour), "local hour is 0..=23");
 
-    let opencode = job_queue::count_enrich_jobs_started_today(&db.pool, "opencode")
+    let (opencode, _) = job_queue::count_enrich_jobs_started_this_hour(&db.pool, "opencode")
         .await
         .unwrap();
     assert_eq!(opencode, 1, "provider filter is per-provider");
 
-    // A run from a previous day falls outside today's UTC window.
-    sqlx::query("UPDATE jobs SET started_at = now() - interval '2 days' WHERE law_id = 'c1'")
+    // A run from a previous hour falls outside the current clock-hour bucket.
+    // (2h back is always before the current bucket start, which is <=59min behind
+    // now, so this assertion is not sensitive to where in the hour the test runs.)
+    sqlx::query("UPDATE jobs SET started_at = now() - interval '2 hours' WHERE law_id = 'c1'")
         .execute(&db.pool)
         .await
         .unwrap();
-    let claude = job_queue::count_enrich_jobs_started_today(&db.pool, "claude")
+    let (claude, _) = job_queue::count_enrich_jobs_started_this_hour(&db.pool, "claude")
         .await
         .unwrap();
-    assert_eq!(claude, 1, "backdated run excluded from today's count");
+    assert_eq!(claude, 1, "backdated run excluded from this hour's count");
 }


### PR DESCRIPTION
## What

Converts the enrich worker's per-provider **daily** run cap into a per-provider **hourly** cap, with a higher ceiling during the local night window so bulk enrichment runs mostly overnight.

- `ENRICH_HOURLY_LIMIT` (u32) — max enrich runs per local clock-hour. **Fail-closed**: absent / unparseable / `0` ⇒ `0` ⇒ worker paused (unchanged spend-guard philosophy). Replaces `ENRICH_DAILY_LIMIT`.
- `ENRICH_NIGHT_MULTIPLIER` (u32, default `1` = no boost) — during the night window the cap is `hourly_limit × multiplier`. Default 1 and warn-on-unparseable so a missing/typo'd value never silently amplifies spend.
- **Night window** = local hour-of-day `[0, 8)` in **Europe/Amsterdam** (00:00–08:00), DST-correct via Postgres `AT TIME ZONE` — no new crate.
- **Counting window** = fixed local clock-hour bucket (`date_trunc('hour', … Europe/Amsterdam)`), parallel to the old fixed calendar-day bucket.

Example (`ENRICH_HOURLY_LIMIT=4`, `ENRICH_NIGHT_MULTIPLIER=5`): day 16 h × 4 = 64, night 8 h × 20 = 160, ≈ 224 runs/day.

## How

- `config.rs`: swap `enrich_daily_limit` for `enrich_hourly_limit` + `enrich_night_multiplier`.
- `job_queue.rs`: `count_enrich_jobs_started_today` → `count_enrich_jobs_started_this_hour`, returning `(count, local_hour)`. The hour bound stays in the `WHERE` clause so the existing partial index `0022` still range-scans (a `COUNT(*) FILTER` would defeat it).
- `worker.rs`: pure `hourly_cap(base, multiplier, local_hour)` helper (saturating) picks the day/night cap; the gate logs `cap`, `local_hour`, and `window=day|night`.
- **No migration** — partial index `0022` serves the hourly range unchanged (left immutable to avoid checksum drift).

## Tests

- Unit: `hourly_cap_day_vs_night` (day/night boundaries, default-1 no-boost, saturating overflow).
- Integration (testcontainers): `test_count_enrich_jobs_started_this_hour` — current-hour count, previous-hour exclusion, per-provider scoping, `pending` (NULL `started_at`) excluded, `local_hour` in range.

## ⚠️ Deploy checklist (not a no-op deploy)

Because the worker is fail-closed, the existing `ENRICH_DAILY_LIMIT` ZAD env var on the enrichworker becomes dead on deploy and the worker will **pause** until the new vars are set. In the same rollout, update the enrichworker component env:

- set `ENRICH_HOURLY_LIMIT` (note the **unit changed** — a former daily `100` is *not* an hourly `100`; pick an hourly value),
- optionally set `ENRICH_NIGHT_MULTIPLIER` (defaults to `1` = no night boost),
- remove the now-unused `ENRICH_DAILY_LIMIT`.

## Notes

- Once/year DST fall-back: during the repeated 02:00–03:00 wall-clock hour, `AT TIME ZONE` resolves the ambiguous local time to one offset, giving a ~1 h slight over-allowance in the night window. Acceptable for a spend guard.