### PR TITLE
feat: surface enrichment untranslatables in the harvester UI

### DIFF
--- a/frontend/src/AppShell.vue
+++ b/frontend/src/AppShell.vue
@@ -187,7 +187,7 @@ const hasDocumentTabs = computed(
               <nldd-icon-button id="settings-menu-btn-md" size="md" icon="account" text="Account" tooltip-timing="never" expandable popovertarget="settings-menu-md"></nldd-icon-button>
               <nldd-menu id="settings-menu-md" anchor="settings-menu-btn-md">
                 <nldd-menu-item v-if="!authLoading && authenticated" :text="person?.name || person?.email" disabled></nldd-menu-item>
-                <nldd-menu-item v-if="canViewHarvesting" text="Corpusinwinning" icon="gear" @click.stop="goToHarvesting"></nldd-menu-item>
+                <nldd-menu-item v-if="canViewHarvesting" text="Harvester" icon="gear" @click.stop="goToHarvesting"></nldd-menu-item>
                 <nldd-menu-divider v-if="canViewHarvesting"></nldd-menu-divider>
                 <nldd-menu-group text="Functies">
                 <nldd-menu-item
@@ -254,7 +254,7 @@ const hasDocumentTabs = computed(
               <nldd-icon-button id="settings-menu-btn-lg" size="md" icon="account" text="Account" tooltip-timing="never" expandable popovertarget="settings-menu-lg"></nldd-icon-button>
               <nldd-menu id="settings-menu-lg" anchor="settings-menu-btn-lg">
                 <nldd-menu-item v-if="!authLoading && authenticated" :text="person?.name || person?.email" disabled></nldd-menu-item>
-                <nldd-menu-item v-if="canViewHarvesting" text="Corpusinwinning" icon="gear" @click.stop="goToHarvesting"></nldd-menu-item>
+                <nldd-menu-item v-if="canViewHarvesting" text="Harvester" icon="gear" @click.stop="goToHarvesting"></nldd-menu-item>
                 <nldd-menu-divider v-if="canViewHarvesting"></nldd-menu-divider>
                 <nldd-menu-group text="Functies">
                 <nldd-menu-item
@@ -433,7 +433,7 @@ const hasDocumentTabs = computed(
               <nldd-icon-button id="settings-menu-btn-sm" size="lg" icon="account" text="Account" tooltip-timing="never" popovertarget="settings-menu-sm"></nldd-icon-button>
               <nldd-menu id="settings-menu-sm" anchor="settings-menu-btn-sm">
                 <nldd-menu-item v-if="!authLoading && authenticated" :text="person?.name || person?.email" disabled></nldd-menu-item>
-                <nldd-menu-item v-if="canViewHarvesting" text="Corpusinwinning" icon="gear" @click.stop="goToHarvesting"></nldd-menu-item>
+                <nldd-menu-item v-if="canViewHarvesting" text="Harvester" icon="gear" @click.stop="goToHarvesting"></nldd-menu-item>
                 <nldd-menu-divider v-if="canViewHarvesting"></nldd-menu-divider>
                 <nldd-menu-group text="Functies">
                 <nldd-menu-item

--- a/frontend/src/harvester/HarvesterView.vue
+++ b/frontend/src/harvester/HarvesterView.vue
@@ -46,6 +46,7 @@ const deploymentName = computed(() =>
 const tabs = [
   { key: 'law-entries', label: 'Wetten', route: '/harvesting/law-entries' },
   { key: 'jobs', label: 'Taken', route: '/harvesting/jobs' },
+  { key: 'untranslatables', label: 'Untranslatables', route: '/harvesting/untranslatables' },
 ];
 const activeTab = computed(() => route.name);
 

--- a/frontend/src/harvester/HarvesterView.vue
+++ b/frontend/src/harvester/HarvesterView.vue
@@ -71,7 +71,7 @@ function goToLibrary() {
           </nldd-toolbar-item>
           <nldd-toolbar-title
             slot="start"
-            text="Corpusinwinning"
+            text="Harvester"
             supporting-text="RegelRecht"
             min-width="fit-content"
           ></nldd-toolbar-title>

--- a/frontend/src/harvester/components/UntranslatableDetailPanel.vue
+++ b/frontend/src/harvester/components/UntranslatableDetailPanel.vue
@@ -80,7 +80,7 @@ function onSheetClose() {
               <nldd-text-cell text="Accepted" color="secondary" width="fit-content" />
               <nldd-spacer-cell size="12" />
               <nldd-cell width="full" style="align-items: flex-end">
-                <StatusBadge :status="row.accepted ? 'accepted' : 'rejected'" size="md" />
+                <StatusBadge :status="row.accepted ? 'accepted' : 'open'" size="md" />
               </nldd-cell>
             </nldd-list-item>
           </nldd-list>

--- a/frontend/src/harvester/components/UntranslatableDetailPanel.vue
+++ b/frontend/src/harvester/components/UntranslatableDetailPanel.vue
@@ -1,0 +1,98 @@
+<script setup>
+/**
+ * UntranslatableDetailPanel — right-side sheet showing one untranslatable
+ * (RFC-012) in full. DetailPanel.vue is job-shaped (hardcoded job fields), so
+ * this is a sibling rather than a reuse. The long free-text fields (reason,
+ * suggestion, legal text excerpt) don't fit a table cell and live here.
+ */
+import { computed, ref, watch } from 'vue';
+import StatusBadge from './StatusBadge.vue';
+import { formatDate } from '../formatters.js';
+
+const props = defineProps({
+  row: { type: Object, default: null },
+  isOpen: { type: Boolean, default: false },
+});
+
+const emit = defineEmits(['close']);
+
+const sheetRef = ref(null);
+
+watch(() => props.isOpen, (open) => {
+  if (open) sheetRef.value?.show();
+  else sheetRef.value?.hide();
+});
+
+const infoFields = computed(() => {
+  if (!props.row) return [];
+  return [
+    ['Law', props.row.law_name || props.row.law_id],
+    ['Law ID', props.row.law_id],
+    ['Article', props.row.article],
+    ['Construct', props.row.construct],
+    ['Provider', props.row.provider],
+    ['Enrich job', props.row.enrich_job_id],
+    ['Captured', formatDate(props.row.created_at)],
+  ].filter(([, value]) => value != null);
+});
+
+// Long free-text sections, each shown only when present.
+const textSections = computed(() => {
+  const r = props.row;
+  if (!r) return [];
+  const out = [];
+  if (r.reason) out.push({ title: 'Reason', code: r.reason });
+  if (r.suggestion) out.push({ title: 'Suggestion', code: r.suggestion });
+  if (r.legal_text_excerpt) {
+    out.push({ title: 'Legal text excerpt', code: r.legal_text_excerpt });
+  }
+  return out;
+});
+
+function onSheetClose() {
+  if (props.isOpen) emit('close');
+}
+</script>
+
+<template>
+  <Teleport to="body">
+    <nldd-sheet
+      ref="sheetRef"
+      placement="right"
+      accessible-label="Untranslatable details"
+      @close="onSheetClose"
+    >
+      <nldd-page sticky-header>
+        <nldd-top-title-bar
+          slot="header"
+          text="Untranslatable details"
+          dismiss-text="Close"
+          @dismiss="$emit('close')"
+        />
+        <nldd-simple-section v-if="row">
+          <nldd-list variant="simple">
+            <nldd-list-item v-for="[label, value] in infoFields" :key="label">
+              <nldd-text-cell :text="label" color="secondary" width="fit-content" />
+              <nldd-spacer-cell size="12" />
+              <nldd-text-cell :text="String(value)" horizontal-alignment="right" />
+            </nldd-list-item>
+            <nldd-list-item>
+              <nldd-text-cell text="Accepted" color="secondary" width="fit-content" />
+              <nldd-spacer-cell size="12" />
+              <nldd-cell width="full" style="align-items: flex-end">
+                <StatusBadge :status="row.accepted ? 'accepted' : 'rejected'" size="md" />
+              </nldd-cell>
+            </nldd-list-item>
+          </nldd-list>
+
+          <template v-for="section in textSections" :key="section.title">
+            <nldd-spacer size="16" />
+            <nldd-title size="6"><h3>{{ section.title }}</h3></nldd-title>
+            <nldd-spacer size="4" />
+            <nldd-code-viewer wrap>{{ section.code }}</nldd-code-viewer>
+          </template>
+        </nldd-simple-section>
+      </nldd-page>
+    </nldd-sheet>
+  </Teleport>
+</template>

--- a/frontend/src/harvester/composables/useUntranslatables.js
+++ b/frontend/src/harvester/composables/useUntranslatables.js
@@ -1,0 +1,78 @@
+import { ref, reactive, computed } from 'vue';
+import { usePollingFetch } from './usePollingFetch.js';
+import { UNTRANSLATABLE_SORT_KEYS } from '../constants.js';
+
+// Mirrors useLawEntries: server-side paginated/sorted/filtered list, polled.
+// Reads GET /api/harvest-admin/untranslatables (editor-api proxies to the
+// harvester-admin service).
+export function useUntranslatables() {
+  const sort = ref('created_at');
+  const order = ref('desc');
+  const limit = ref(50);
+  const offset = ref(0);
+  const filters = reactive({});
+
+  function buildUrl() {
+    const params = new URLSearchParams();
+    if (UNTRANSLATABLE_SORT_KEYS.has(sort.value)) {
+      params.set('sort', sort.value);
+    }
+    params.set('order', order.value === 'asc' ? 'asc' : 'desc');
+    params.set('limit', String(limit.value));
+    params.set('offset', String(offset.value));
+    for (const [key, value] of Object.entries(filters)) {
+      if (value) params.set(key, value);
+    }
+    return `/api/harvest-admin/untranslatables?${params.toString()}`;
+  }
+
+  const { data, totalCount, loading, error, refresh, startPolling, stopPolling } =
+    usePollingFetch(buildUrl);
+
+  function setSort(key, newOrder) {
+    if (!UNTRANSLATABLE_SORT_KEYS.has(key)) return;
+    if (newOrder === 'asc' || newOrder === 'desc') {
+      sort.value = key;
+      order.value = newOrder;
+    } else if (sort.value === key) {
+      order.value = order.value === 'asc' ? 'desc' : 'asc';
+    } else {
+      sort.value = key;
+      order.value = 'desc';
+    }
+    offset.value = 0;
+    refresh();
+  }
+
+  function setFilter(key, value) {
+    if (value) {
+      filters[key] = value;
+    } else {
+      delete filters[key];
+    }
+    offset.value = 0;
+    refresh();
+  }
+
+  function goToPage(page) {
+    const maxPage = Math.max(1, Math.ceil(totalCount.value / limit.value));
+    const clamped = Math.max(1, Math.min(page, maxPage));
+    offset.value = (clamped - 1) * limit.value;
+    refresh();
+  }
+
+  const currentPage = computed(() => Math.floor(offset.value / limit.value) + 1);
+  const totalPages = computed(() => Math.max(1, Math.ceil(totalCount.value / limit.value)));
+
+  // Initial load + start polling
+  refresh();
+  startPolling();
+
+  return {
+    data, totalCount, loading, error,
+    sort, order, limit, offset, filters,
+    currentPage, totalPages,
+    setSort, setFilter, goToPage,
+    refresh, startPolling, stopPolling,
+  };
+}

--- a/frontend/src/harvester/composables/useUntranslatables.test.js
+++ b/frontend/src/harvester/composables/useUntranslatables.test.js
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { useUntranslatables } from './useUntranslatables.js';
+
+// Minimal Response-like stub for a paginated JSON body.
+function res({ data = [], total = data.length } = {}) {
+  return {
+    ok: true,
+    status: 200,
+    headers: { get: () => null },
+    async json() {
+      return { data, total, limit: 50, offset: 0 };
+    },
+  };
+}
+
+// The composable fires an initial fetch + starts a 20s poll on creation. Fake
+// timers keep the poll from firing during the test; we stop it in afterEach.
+let stop = null;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  if (stop) stop();
+  stop = null;
+  vi.useRealTimers();
+});
+
+/** Create the composable, wait for its initial fetch to settle. */
+async function create(fetchSpy) {
+  globalThis.fetch = fetchSpy;
+  const comp = useUntranslatables();
+  stop = comp.stopPolling;
+  await comp.refresh();
+  return comp;
+}
+
+/** URL string of the most recent fetch call. */
+function lastUrl(fetchSpy) {
+  return fetchSpy.mock.calls.at(-1)[0];
+}
+
+describe('useUntranslatables', () => {
+  it('issues an initial fetch with default sort/order/pagination', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(res({ data: [{ id: '1' }], total: 1 }));
+    const comp = await create(fetchSpy);
+
+    const url = lastUrl(fetchSpy);
+    expect(url).toContain('/api/harvest-admin/untranslatables?');
+    expect(url).toContain('sort=created_at');
+    expect(url).toContain('order=desc');
+    expect(url).toContain('limit=50');
+    expect(url).toContain('offset=0');
+    expect(comp.data.value).toEqual([{ id: '1' }]);
+    expect(comp.totalCount.value).toBe(1);
+  });
+
+  it('applies a valid sort with explicit order and resets offset', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(res());
+    const comp = await create(fetchSpy);
+
+    comp.setSort('law_id', 'asc');
+    await Promise.resolve();
+    const url = lastUrl(fetchSpy);
+    expect(url).toContain('sort=law_id');
+    expect(url).toContain('order=asc');
+    expect(url).toContain('offset=0');
+  });
+
+  it('toggles order when re-sorting the same key', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(res());
+    const comp = await create(fetchSpy);
+
+    comp.setSort('construct');
+    await Promise.resolve();
+    expect(lastUrl(fetchSpy)).toContain('order=desc');
+
+    comp.setSort('construct');
+    await Promise.resolve();
+    expect(lastUrl(fetchSpy)).toContain('order=asc');
+  });
+
+  it('ignores a sort key outside the allowlist (no fetch)', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(res());
+    const comp = await create(fetchSpy);
+    const before = fetchSpy.mock.calls.length;
+
+    comp.setSort('bogus');
+    await Promise.resolve();
+    expect(fetchSpy.mock.calls.length).toBe(before);
+  });
+
+  it('adds and removes filters', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(res());
+    const comp = await create(fetchSpy);
+
+    comp.setFilter('provider', 'claude');
+    await Promise.resolve();
+    expect(lastUrl(fetchSpy)).toContain('provider=claude');
+
+    comp.setFilter('accepted', 'true');
+    await Promise.resolve();
+    expect(lastUrl(fetchSpy)).toContain('accepted=true');
+
+    comp.setFilter('provider', '');
+    await Promise.resolve();
+    expect(lastUrl(fetchSpy)).not.toContain('provider=');
+  });
+
+  it('paginates by translating a page into an offset', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(res({ data: [], total: 150 }));
+    const comp = await create(fetchSpy);
+
+    comp.goToPage(3);
+    await Promise.resolve();
+    expect(lastUrl(fetchSpy)).toContain('offset=100');
+  });
+});

--- a/frontend/src/harvester/constants.js
+++ b/frontend/src/harvester/constants.js
@@ -76,6 +76,59 @@ export const GROUPED_COLUMNS = [
   { key: 'total_jobs', label: 'Jobs', sortable: true, filter: { key: 'status', options: JOB_STATUSES, label: 'Status' }, width: 'fit-content', minWidth: '24px', align: 'right', hideBelow: '640px' },
 ];
 
+// Untranslatables (RFC-012): one row per legal construct the enrichment agent
+// could not express with the engine's current operation set. Atomic grain —
+// grouped views (per construct / per law) are aggregation over this same list.
+export const UNTRANSLATABLE_PROVIDERS = ['opencode', 'claude'];
+
+export const UNTRANSLATABLE_COLUMNS = [
+  {
+    key: 'law_name',
+    label: 'Law',
+    filter: { key: 'law_id', type: 'text', label: 'Law' },
+    overline: (row) => row.law_id,
+    text: (row) => row.law_name || '—',
+    supportingText: (row) =>
+      row.created_at ? `Captured at ${formatDate(row.created_at)}` : undefined,
+  },
+  {
+    key: 'article',
+    label: 'Article',
+    width: 'fit-content',
+    minWidth: '60px',
+    text: (row) => row.article || '—',
+  },
+  {
+    key: 'construct',
+    label: 'Construct',
+    filter: { key: 'construct', type: 'text', label: 'Construct' },
+    text: (row) => row.construct || '—',
+  },
+  {
+    // Free-text, potentially long: the cell truncates natively; full text lives
+    // in the detail panel.
+    key: 'reason',
+    label: 'Reason',
+    hideBelow: '640px',
+    text: (row) => row.reason || '—',
+  },
+  {
+    key: 'accepted',
+    label: 'Accepted',
+    filter: { options: ['true', 'false'] },
+    width: 120,
+  },
+  {
+    key: 'provider',
+    label: 'Provider',
+    filter: { options: UNTRANSLATABLE_PROVIDERS },
+    width: 'fit-content',
+    minWidth: '80px',
+    hideBelow: '640px',
+    text: (row) => row.provider || '—',
+  },
+];
+
 // Sort menus are independent from visible columns — users should be able to
 // sort by fields that aren't shown as a separate column.
 // `directionLabels` controls which directions appear in the menu:
@@ -113,10 +166,23 @@ export const LAW_ENTRY_SORT_OPTIONS = [
   { key: 'law_name', label: 'Name', directionLabels: DIR_TEXT },
 ];
 
+// Keys must match the backend sort allowlist (ALLOWED_SORT_COLUMNS_UNTRANSLATABLE):
+// all real untranslatables columns. The "Law" pivot sorts by law_id (a real
+// column), not the joined law_name.
+export const UNTRANSLATABLE_SORT_OPTIONS = [
+  { key: 'created_at', label: 'Recent changes' },
+  { key: 'law_id', label: 'Law', directionLabels: DIR_TEXT },
+  { key: 'construct', label: 'Construct', directionLabels: DIR_TEXT },
+  { key: 'article', label: 'Article', directionLabels: DIR_TEXT },
+  { key: 'accepted', label: 'Accepted' },
+  { key: 'provider', label: 'Provider', directionLabels: DIR_TEXT },
+];
+
 // Sort allowlists for server-side validation (defence in depth)
 export const LAW_ENTRY_SORT_KEYS = new Set(LAW_ENTRY_SORT_OPTIONS.map((o) => o.key));
 export const JOB_SORT_KEYS = new Set(JOB_SORT_OPTIONS.map((o) => o.key));
 export const GROUPED_SORT_KEYS = new Set(GROUPED_SORT_OPTIONS.map((o) => o.key));
+export const UNTRANSLATABLE_SORT_KEYS = new Set(UNTRANSLATABLE_SORT_OPTIONS.map((o) => o.key));
 
 export const STATUS_BADGE_MAP = {
   completed: 'success',
@@ -135,6 +201,9 @@ export const STATUS_BADGE_MAP = {
   queued: 'neutral',
   // No consolidated text to harvest — informational, terminal, not a failure.
   not_harvestable: 'neutral',
+  // Untranslatables (RFC-012): a human-reviewed `accepted` flag rendered as a badge.
+  accepted: 'success',
+  rejected: 'critical',
 };
 
 export const DATE_FORMATTER = new Intl.DateTimeFormat('nl-NL', {

--- a/frontend/src/harvester/constants.js
+++ b/frontend/src/harvester/constants.js
@@ -79,6 +79,8 @@ export const GROUPED_COLUMNS = [
 // Untranslatables (RFC-012): one row per legal construct the enrichment agent
 // could not express with the engine's current operation set. Atomic grain —
 // grouped views (per construct / per law) are aggregation over this same list.
+// Keep in sync with ENRICH_PROVIDERS in packages/pipeline/src/enrich.rs — a
+// provider added there but not here still displays, only its filter option is missing.
 export const UNTRANSLATABLE_PROVIDERS = ['opencode', 'claude'];
 
 export const UNTRANSLATABLE_COLUMNS = [
@@ -201,9 +203,12 @@ export const STATUS_BADGE_MAP = {
   queued: 'neutral',
   // No consolidated text to harvest — informational, terminal, not a failure.
   not_harvestable: 'neutral',
-  // Untranslatables (RFC-012): a human-reviewed `accepted` flag rendered as a badge.
+  // Untranslatables (RFC-012): the human-review `accepted` flag rendered as a
+  // badge. `accepted` is a review gate that defaults to false, so false means
+  // "not yet reviewed / open" (neutral), NOT "rejected" (which would wrongly
+  // paint every fresh untranslatable red).
   accepted: 'success',
-  rejected: 'critical',
+  open: 'neutral',
 };
 
 export const DATE_FORMATTER = new Intl.DateTimeFormat('nl-NL', {

--- a/frontend/src/harvester/views/UntranslatablesView.test.js
+++ b/frontend/src/harvester/views/UntranslatablesView.test.js
@@ -1,0 +1,59 @@
+import { shallowMount } from '@vue/test-utils';
+import { describe, it, expect, vi } from 'vitest';
+import { ref, reactive } from 'vue';
+import UntranslatablesView from './UntranslatablesView.vue';
+import DataTable from '../components/DataTable.vue';
+import UntranslatableDetailPanel from '../components/UntranslatableDetailPanel.vue';
+import { UNTRANSLATABLE_COLUMNS, UNTRANSLATABLE_SORT_OPTIONS } from '../constants.js';
+
+const setSort = vi.fn();
+const setFilter = vi.fn();
+const goToPage = vi.fn();
+
+vi.mock('../composables/useUntranslatables.js', () => ({
+  useUntranslatables: () => ({
+    data: ref([{ id: '1', law_id: 'test_law', construct: 'rounding', accepted: false }]),
+    loading: ref(false),
+    error: ref(null),
+    sort: ref('created_at'),
+    order: ref('desc'),
+    filters: reactive({}),
+    currentPage: ref(1),
+    totalPages: ref(1),
+    setSort,
+    setFilter,
+    goToPage,
+  }),
+}));
+
+describe('UntranslatablesView', () => {
+  it('wires the DataTable with the untranslatable columns and clickable rows', () => {
+    const w = shallowMount(UntranslatablesView);
+    const table = w.findComponent(DataTable);
+    expect(table.props('columns')).toBe(UNTRANSLATABLE_COLUMNS);
+    expect(table.props('sortOptions')).toBe(UNTRANSLATABLE_SORT_OPTIONS);
+    expect(table.props('clickableRows')).toBe(true);
+  });
+
+  it('forwards sort/filter/page events to the composable', () => {
+    const w = shallowMount(UntranslatablesView);
+    const table = w.findComponent(DataTable);
+    table.vm.$emit('sort', 'law_id', 'asc');
+    table.vm.$emit('filter-change', 'provider', 'claude');
+    expect(setSort).toHaveBeenCalledWith('law_id', 'asc');
+    expect(setFilter).toHaveBeenCalledWith('provider', 'claude');
+  });
+
+  it('opens the detail panel with the clicked row', async () => {
+    const w = shallowMount(UntranslatablesView);
+    const panel = w.findComponent(UntranslatableDetailPanel);
+    expect(panel.props('isOpen')).toBe(false);
+
+    const row = { id: '1', construct: 'rounding' };
+    w.findComponent(DataTable).vm.$emit('row-click', row);
+    await w.vm.$nextTick();
+
+    expect(panel.props('isOpen')).toBe(true);
+    expect(panel.props('row')).toEqual(row);
+  });
+});

--- a/frontend/src/harvester/views/UntranslatablesView.vue
+++ b/frontend/src/harvester/views/UntranslatablesView.vue
@@ -46,7 +46,7 @@ function closeDetail() {
     @row-click="openDetail"
   >
     <template #cell-accepted="{ row }">
-      <StatusBadge :status="row.accepted ? 'accepted' : 'rejected'" />
+      <StatusBadge :status="row.accepted ? 'accepted' : 'open'" />
     </template>
     <template #pagination>
       <PaginationControls

--- a/frontend/src/harvester/views/UntranslatablesView.vue
+++ b/frontend/src/harvester/views/UntranslatablesView.vue
@@ -1,0 +1,60 @@
+<script setup>
+import { ref } from 'vue';
+import { useUntranslatables } from '../composables/useUntranslatables.js';
+import { UNTRANSLATABLE_COLUMNS, UNTRANSLATABLE_SORT_OPTIONS } from '../constants.js';
+import DataTable from '../components/DataTable.vue';
+import StatusBadge from '../components/StatusBadge.vue';
+import PaginationControls from '../components/PaginationControls.vue';
+import UntranslatableDetailPanel from '../components/UntranslatableDetailPanel.vue';
+
+const {
+  data, loading, error,
+  sort, order, filters,
+  currentPage, totalPages,
+  setSort, setFilter, goToPage,
+} = useUntranslatables();
+
+// Read-only detail: no polling needed, unlike the jobs sheet.
+const selected = ref(null);
+const detailOpen = ref(false);
+
+function openDetail(row) {
+  selected.value = row;
+  detailOpen.value = true;
+}
+
+function closeDetail() {
+  detailOpen.value = false;
+}
+</script>
+
+<template>
+  <DataTable
+    :columns="UNTRANSLATABLE_COLUMNS"
+    :sort-options="UNTRANSLATABLE_SORT_OPTIONS"
+    :data="data"
+    :loading="loading"
+    :error="error"
+    :sort="sort"
+    :order="order"
+    :filters="filters"
+    :clickable-rows="true"
+    empty-text="No untranslatables"
+    empty-supporting-text="They appear here after an enrichment flags a construct"
+    @sort="setSort"
+    @filter-change="setFilter"
+    @row-click="openDetail"
+  >
+    <template #cell-accepted="{ row }">
+      <StatusBadge :status="row.accepted ? 'accepted' : 'rejected'" />
+    </template>
+    <template #pagination>
+      <PaginationControls
+        :current-page="currentPage"
+        :total-pages="totalPages"
+        @page-change="goToPage"
+      />
+    </template>
+  </DataTable>
+  <UntranslatableDetailPanel :row="selected" :is-open="detailOpen" @close="closeDetail" />
+</template>

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -133,6 +133,11 @@ const router = createRouter({
           name: 'jobs',
           component: () => import('./harvester/views/JobsView.vue'),
         },
+        {
+          path: 'untranslatables',
+          name: 'untranslatables',
+          component: () => import('./harvester/views/UntranslatablesView.vue'),
+        },
       ],
     },
     {

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -112,7 +112,7 @@ const router = createRouter({
       path: '/harvesting',
       component: () => import('./harvester/HarvesterView.vue'),
       meta: {
-        title: 'Corpusinwinning',
+        title: 'Harvester',
         requiresAuth: true,
         requiresRole: [
           'harvester-reader',

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -57,9 +57,11 @@ export default defineConfig({
       // @cucumber/gherkin 40 and @cucumber/messages 33 ship as pure ESM. The
       // vmThreads pool loads external ESM in a separate VM context, which throws
       // "Linked modules must use the same context". Inlining lets vitest process
-      // them in the test context instead.
+      // them in the test context instead. The @regelrecht/frontend-shared
+      // workspace package (ESM) hits the same issue when a test transitively
+      // imports it (e.g. usePollingFetch → apiFetch), so inline it too.
       deps: {
-        inline: [/@cucumber\//],
+        inline: [/@cucumber\//, /@regelrecht\//],
       },
     },
   },

--- a/packages/admin/src/handlers.rs
+++ b/packages/admin/src/handlers.rs
@@ -10,7 +10,7 @@ use regelrecht_pipeline::{EnrichPayload, JobType, Priority, ENRICH_PROVIDERS};
 use serde::{Deserialize, Serialize};
 
 use crate::error::ApiError;
-use crate::models::{Job, LawEntry, PaginatedResponse};
+use crate::models::{Job, LawEntry, PaginatedResponse, Untranslatable};
 use crate::state::AppState;
 
 /// Map a sqlx error to a 500 ApiError, logging the cause with `op` so the log
@@ -195,6 +195,141 @@ pub async fn list_law_entries(
             .await
             .map_err(db_err("data query failed"))?
     };
+
+    Ok(Json(PaginatedResponse {
+        data,
+        total,
+        limit,
+        offset,
+    }))
+}
+
+// --- Untranslatables ---
+
+#[derive(Deserialize)]
+pub struct UntranslatablesQuery {
+    pub law_id: Option<String>,
+    pub provider: Option<String>,
+    pub accepted: Option<bool>,
+    pub construct: Option<String>,
+    pub sort: Option<String>,
+    pub order: Option<String>,
+    pub limit: Option<i64>,
+    pub offset: Option<i64>,
+}
+
+const ALLOWED_SORT_COLUMNS_UNTRANSLATABLE: &[&str] = &[
+    "id",
+    "law_id",
+    "provider",
+    "article",
+    "construct",
+    "accepted",
+    "created_at",
+];
+
+pub async fn list_untranslatables(
+    State(state): State<AppState>,
+    Query(params): Query<UntranslatablesQuery>,
+) -> Result<Json<PaginatedResponse<Untranslatable>>, ApiError> {
+    let pool = &state.pool;
+    let limit = clamped_limit(params.limit);
+    let offset = clamped_offset(params.offset);
+
+    let sort_column = validated_sort_column(
+        params.sort.as_deref(),
+        ALLOWED_SORT_COLUMNS_UNTRANSLATABLE,
+        "created_at",
+    )
+    .ok_or(ApiError::BadRequest("invalid sort column".to_string()))?;
+
+    let order = normalized_order(params.order.as_deref());
+
+    // Build dynamic WHERE clause for multi-filter support. Columns are qualified
+    // with `u.` so they stay unambiguous under the law_entries join.
+    let mut where_clauses = Vec::new();
+    let mut bind_index: usize = 1;
+
+    if params.law_id.is_some() {
+        // Partial / case-insensitive match, matching the jobs/law search fields.
+        where_clauses.push(format!("u.law_id ILIKE ${bind_index}"));
+        bind_index += 1;
+    }
+    if params.provider.is_some() {
+        where_clauses.push(format!("u.provider = ${bind_index}"));
+        bind_index += 1;
+    }
+    if params.accepted.is_some() {
+        where_clauses.push(format!("u.accepted = ${bind_index}"));
+        bind_index += 1;
+    }
+    if params.construct.is_some() {
+        where_clauses.push(format!("u.construct ILIKE ${bind_index}"));
+        bind_index += 1;
+    }
+
+    let where_sql = if where_clauses.is_empty() {
+        String::new()
+    } else {
+        format!("WHERE {}", where_clauses.join(" AND "))
+    };
+
+    // Count query (no join needed — filters are all on the untranslatables table).
+    // Filter values are bound in the same order for the count and data queries.
+    let count_sql = format!("SELECT COUNT(*) FROM untranslatables u {where_sql}");
+    let mut count_query = sqlx::query_scalar::<_, i64>(&count_sql);
+    if let Some(ref law_id) = params.law_id {
+        count_query = count_query.bind(format!("%{}%", like_escape(law_id)));
+    }
+    if let Some(ref provider) = params.provider {
+        count_query = count_query.bind(provider);
+    }
+    if let Some(accepted) = params.accepted {
+        count_query = count_query.bind(accepted);
+    }
+    if let Some(ref construct) = params.construct {
+        count_query = count_query.bind(format!("%{}%", like_escape(construct)));
+    }
+
+    let total: i64 = count_query
+        .fetch_one(pool)
+        .await
+        .map_err(db_err("count query failed"))?;
+
+    // Data query — sort column is validated against an allowlist above, so
+    // interpolating it into the query string is safe. LEFT JOIN so an
+    // untranslatable whose law_entry is missing still appears (law_name = NULL).
+    let limit_idx = bind_index;
+    let offset_idx = bind_index + 1;
+    let data_sql = format!(
+        "SELECT u.id, u.law_id, le.law_name, u.enrich_job_id, u.provider, \
+         u.article, u.construct, u.reason, u.suggestion, u.legal_text_excerpt, \
+         u.accepted, u.created_at \
+         FROM untranslatables u \
+         LEFT JOIN law_entries le ON le.law_id = u.law_id \
+         {where_sql} \
+         ORDER BY u.{sort_column} {order} LIMIT ${limit_idx} OFFSET ${offset_idx}"
+    );
+
+    let mut data_query = sqlx::query_as::<_, Untranslatable>(&data_sql);
+    if let Some(ref law_id) = params.law_id {
+        data_query = data_query.bind(format!("%{}%", like_escape(law_id)));
+    }
+    if let Some(ref provider) = params.provider {
+        data_query = data_query.bind(provider);
+    }
+    if let Some(accepted) = params.accepted {
+        data_query = data_query.bind(accepted);
+    }
+    if let Some(ref construct) = params.construct {
+        data_query = data_query.bind(format!("%{}%", like_escape(construct)));
+    }
+    data_query = data_query.bind(limit).bind(offset);
+
+    let data: Vec<Untranslatable> = data_query
+        .fetch_all(pool)
+        .await
+        .map_err(db_err("data query failed"))?;
 
     Ok(Json(PaginatedResponse {
         data,

--- a/packages/admin/src/main.rs
+++ b/packages/admin/src/main.rs
@@ -157,6 +157,7 @@ async fn main() {
         .route("/api/jobs", get(handlers::list_jobs))
         .route("/api/jobs/summary", get(handlers::list_jobs_summary))
         .route("/api/jobs/{job_id}", get(handlers::get_job))
+        .route("/api/untranslatables", get(handlers::list_untranslatables))
         .route("/api/sources", get(corpus_handlers::list_sources))
         .route("/api/corpus/laws", get(corpus_handlers::list_corpus_laws))
         .route("/api/info", get(handlers::platform_info))

--- a/packages/admin/src/models.rs
+++ b/packages/admin/src/models.rs
@@ -15,3 +15,22 @@ pub struct PaginatedResponse<T: Serialize> {
     pub limit: i64,
     pub offset: i64,
 }
+
+/// A captured untranslatable (RFC-012) as returned by the harvester API. Unlike
+/// the pipeline row type, this carries the joined `law_name` (from `law_entries`)
+/// for display; the join is a LEFT JOIN, so `law_name` may be `None`.
+#[derive(Serialize, sqlx::FromRow)]
+pub struct Untranslatable {
+    pub id: uuid::Uuid,
+    pub law_id: String,
+    pub law_name: Option<String>,
+    pub enrich_job_id: uuid::Uuid,
+    pub provider: String,
+    pub article: String,
+    pub construct: String,
+    pub reason: String,
+    pub suggestion: Option<String>,
+    pub legal_text_excerpt: Option<String>,
+    pub accepted: bool,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+}

--- a/packages/admin/tests/handler_tests.rs
+++ b/packages/admin/tests/handler_tests.rs
@@ -41,8 +41,181 @@ fn test_app(pool: sqlx::PgPool) -> Router {
     Router::new()
         .route("/api/law_entries", get(handlers::list_law_entries))
         .route("/api/jobs", get(handlers::list_jobs))
+        .route("/api/untranslatables", get(handlers::list_untranslatables))
         .route("/api/harvest-jobs", post(handlers::create_harvest_job))
         .with_state(state)
+}
+
+/// Seed one untranslatable row for `law_id`/`provider`. Creates the law_entry
+/// (so the join has a `law_name`) and an enrich job (to satisfy the FK) on first
+/// use, then inserts the row. Returns nothing — tests query via the handler.
+async fn seed_untranslatable(
+    pool: &sqlx::PgPool,
+    law_id: &str,
+    law_name: &str,
+    provider: &str,
+    construct: &str,
+    accepted: bool,
+) {
+    regelrecht_pipeline::law_status::upsert_law(pool, law_id, Some(law_name), None)
+        .await
+        .unwrap();
+    let job = job_queue::create_job(pool, CreateJobRequest::new(JobType::Enrich, law_id))
+        .await
+        .unwrap();
+    sqlx::query(
+        "INSERT INTO untranslatables \
+         (law_id, enrich_job_id, provider, article, construct, reason, accepted) \
+         VALUES ($1, $2, $3, '1', $4, 'reason', $5)",
+    )
+    .bind(law_id)
+    .bind(job.id)
+    .bind(provider)
+    .bind(construct)
+    .bind(accepted)
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+async fn get_untranslatables(pool: &sqlx::PgPool, query: &str) -> Value {
+    let app = test_app(pool.clone());
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/untranslatables{query}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    body_json(response).await
+}
+
+// --- list_untranslatables ---
+
+#[tokio::test]
+async fn list_untranslatables_empty() {
+    let db = TestDb::new().await;
+    let json = get_untranslatables(&db.pool, "").await;
+    assert_eq!(json["total"], 0);
+    assert_eq!(json["data"].as_array().unwrap().len(), 0);
+}
+
+#[tokio::test]
+async fn list_untranslatables_returns_rows_with_law_name() {
+    let db = TestDb::new().await;
+    seed_untranslatable(
+        &db.pool, "test_law", "Test Law", "opencode", "rounding", false,
+    )
+    .await;
+    seed_untranslatable(
+        &db.pool,
+        "test_law",
+        "Test Law",
+        "opencode",
+        "table_lookup",
+        true,
+    )
+    .await;
+
+    let json = get_untranslatables(&db.pool, "").await;
+    assert_eq!(json["total"], 2);
+    // law_name comes from the LEFT JOIN on law_entries.
+    assert_eq!(json["data"][0]["law_name"], "Test Law");
+}
+
+#[tokio::test]
+async fn list_untranslatables_filters_by_accepted() {
+    let db = TestDb::new().await;
+    seed_untranslatable(
+        &db.pool, "test_law", "Test Law", "opencode", "rounding", false,
+    )
+    .await;
+    seed_untranslatable(
+        &db.pool,
+        "test_law",
+        "Test Law",
+        "opencode",
+        "table_lookup",
+        true,
+    )
+    .await;
+
+    let json = get_untranslatables(&db.pool, "?accepted=true").await;
+    assert_eq!(json["total"], 1);
+    assert_eq!(json["data"][0]["construct"], "table_lookup");
+}
+
+#[tokio::test]
+async fn list_untranslatables_filters_by_law_id_partial() {
+    let db = TestDb::new().await;
+    seed_untranslatable(
+        &db.pool,
+        "wet_alpha",
+        "Wet Alpha",
+        "opencode",
+        "rounding",
+        false,
+    )
+    .await;
+    seed_untranslatable(
+        &db.pool, "wet_beta", "Wet Beta", "opencode", "rounding", false,
+    )
+    .await;
+
+    let json = get_untranslatables(&db.pool, "?law_id=alpha").await;
+    assert_eq!(json["total"], 1);
+    assert_eq!(json["data"][0]["law_id"], "wet_alpha");
+}
+
+#[tokio::test]
+async fn list_untranslatables_filters_by_provider() {
+    let db = TestDb::new().await;
+    seed_untranslatable(
+        &db.pool, "test_law", "Test Law", "opencode", "rounding", false,
+    )
+    .await;
+    seed_untranslatable(
+        &db.pool, "test_law", "Test Law", "claude", "rounding", false,
+    )
+    .await;
+
+    let json = get_untranslatables(&db.pool, "?provider=claude").await;
+    assert_eq!(json["total"], 1);
+    assert_eq!(json["data"][0]["provider"], "claude");
+}
+
+#[tokio::test]
+async fn list_untranslatables_rejects_invalid_sort() {
+    let db = TestDb::new().await;
+    let app = test_app(db.pool.clone());
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/untranslatables?sort=bogus")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn list_untranslatables_pagination() {
+    let db = TestDb::new().await;
+    for construct in ["a", "b", "c"] {
+        seed_untranslatable(
+            &db.pool, "test_law", "Test Law", "opencode", construct, false,
+        )
+        .await;
+    }
+
+    let json = get_untranslatables(&db.pool, "?limit=1&offset=1").await;
+    assert_eq!(json["total"], 3);
+    assert_eq!(json["data"].as_array().unwrap().len(), 1);
 }
 
 async fn body_json(response: axum::http::Response<Body>) -> Value {

--- a/packages/pipeline/migrations/0023_untranslatables.sql
+++ b/packages/pipeline/migrations/0023_untranslatables.sql
@@ -1,0 +1,24 @@
+-- Captures RFC-012 "untranslatables": legal constructs the enrichment agent
+-- could not express with the engine's current operation set. One row per
+-- (law, provider, article, construct). Refreshed wholesale per (law_id,
+-- provider) on each successful enrich completion (delete-and-replace), so the
+-- table always reflects the latest enrich run for that provider.
+CREATE TABLE untranslatables (
+    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    law_id              TEXT NOT NULL,
+    -- Enrich job that produced this capture. ON DELETE CASCADE so purging a
+    -- job (or the whole jobs table in tests) cleans these up automatically.
+    enrich_job_id       UUID NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
+    provider            TEXT NOT NULL,
+    article             TEXT NOT NULL,
+    construct           TEXT NOT NULL,
+    reason              TEXT NOT NULL,
+    suggestion          TEXT,
+    legal_text_excerpt  TEXT,
+    accepted            BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_untranslatables_law_id ON untranslatables (law_id);
+CREATE INDEX idx_untranslatables_construct ON untranslatables (construct);
+CREATE INDEX idx_untranslatables_accepted ON untranslatables (accepted);

--- a/packages/pipeline/src/enrich.rs
+++ b/packages/pipeline/src/enrich.rs
@@ -480,6 +480,27 @@ pub struct EnrichResult {
     /// enqueue follow-up harvests. Empty when no sidecar was written.
     #[serde(default)]
     pub related_legislation: Vec<RelatedLegislation>,
+    /// Untranslatable constructs captured from the enriched YAML (RFC-012):
+    /// legal constructs the agent could not express with the engine's current
+    /// operation set. The worker persists these to the `untranslatables` table;
+    /// they also ride here in `jobs.result`. `#[serde(default)]` keeps older
+    /// stored results deserializable.
+    #[serde(default)]
+    pub untranslatables: Vec<CapturedUntranslatable>,
+}
+
+/// A single untranslatable captured from an enriched article, flattened for
+/// persistence. DB-free by design: it rides in `jobs.result` JSON and is written
+/// to the `untranslatables` table by the worker.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CapturedUntranslatable {
+    /// The owning article's number (`Article.number`).
+    pub article: String,
+    pub construct: String,
+    pub reason: String,
+    pub suggestion: Option<String>,
+    pub legal_text_excerpt: Option<String>,
+    pub accepted: bool,
 }
 
 /// Metadata written alongside the enriched law YAML as `.enrichment.yaml`.
@@ -1164,6 +1185,9 @@ pub async fn execute_enrich_with_runner(
     // Never fails: absent/malformed → empty (see read_enrichment_result_envelope).
     let related_legislation = read_enrichment_result_envelope(&yaml_abs).await;
 
+    // Capture the untranslatables the agent flagged in the enriched YAML (RFC-012).
+    let untranslatables = collect_untranslatables(&yaml_abs).await?;
+
     // Collect written files for corpus staging
     let mut written_files = vec![yaml_abs.clone(), metadata_path];
 
@@ -1210,6 +1234,7 @@ pub async fn execute_enrich_with_runner(
         provider: provider_name,
         branch,
         related_legislation,
+        untranslatables,
     };
 
     Ok((result, written_files))
@@ -1270,6 +1295,36 @@ async fn count_article_stats(path: &Path) -> Result<(usize, usize)> {
         .filter(|article| article.machine_readable.is_some())
         .count();
     Ok((total, with_machine_readable))
+}
+
+/// Collect all untranslatables from an enriched law YAML, flattened to
+/// [`CapturedUntranslatable`] with the owning article number attached.
+///
+/// Parses the law into the canonical [`ArticleBasedLaw`] model, mirroring
+/// [`count_article_stats`]. Returns an empty vec when no article declares any.
+async fn collect_untranslatables(path: &Path) -> Result<Vec<CapturedUntranslatable>> {
+    let content = tokio::fs::read_to_string(path).await?;
+    let law: ArticleBasedLaw = serde_yaml_ng::from_str(&content)?;
+    let mut out = Vec::new();
+    for article in &law.articles {
+        let Some(machine_readable) = &article.machine_readable else {
+            continue;
+        };
+        let Some(entries) = &machine_readable.untranslatables else {
+            continue;
+        };
+        for entry in entries {
+            out.push(CapturedUntranslatable {
+                article: article.number.clone(),
+                construct: entry.construct.clone(),
+                reason: entry.reason.clone(),
+                suggestion: entry.suggestion.clone(),
+                legal_text_excerpt: entry.legal_text_excerpt.clone(),
+                accepted: entry.accepted,
+            });
+        }
+    }
+    Ok(out)
 }
 
 #[cfg(test)]
@@ -1341,6 +1396,7 @@ mod tests {
             provider: "opencode".to_string(),
             branch: "enrich/opencode".to_string(),
             related_legislation: Vec::new(),
+            untranslatables: Vec::new(),
         };
 
         let json = serde_json::to_value(&result).unwrap();
@@ -1659,6 +1715,90 @@ articles:
         let (total, with_mr) = count_article_stats(&path).await.unwrap();
         assert_eq!(total, 3);
         assert_eq!(with_mr, 1);
+    }
+
+    #[tokio::test]
+    async fn test_collect_untranslatables() {
+        // Two articles carry untranslatables (one accepted, one not); a third
+        // article has a machine_readable section without any. The collector must
+        // flatten every entry, attach the owning article number, and preserve the
+        // optional fields + accepted flag.
+        let yaml = r#"---
+$id: test_law
+regulatory_layer: WET
+publication_date: '2025-01-01'
+valid_from: '2025-01-01'
+articles:
+  - number: '1'
+    text: Article one.
+    machine_readable:
+      untranslatables:
+        - construct: rounding
+          reason: Engine cannot round yet.
+          suggestion: Add a ROUND operation.
+          legal_text_excerpt: naar boven afgerond op hele euro's
+          accepted: false
+  - number: '2'
+    text: Article two.
+    machine_readable:
+      execution:
+        actions: []
+  - number: '3'
+    text: Article three.
+    machine_readable:
+      untranslatables:
+        - construct: table_lookup
+          reason: Table lookup unsupported.
+          accepted: true
+"#;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("law.yaml");
+        tokio::fs::write(&path, yaml).await.unwrap();
+
+        let collected = collect_untranslatables(&path).await.unwrap();
+        assert_eq!(collected.len(), 2);
+
+        let rounding = collected
+            .iter()
+            .find(|u| u.construct == "rounding")
+            .expect("rounding entry");
+        assert_eq!(rounding.article, "1");
+        assert_eq!(rounding.reason, "Engine cannot round yet.");
+        assert_eq!(
+            rounding.suggestion.as_deref(),
+            Some("Add a ROUND operation.")
+        );
+        assert_eq!(
+            rounding.legal_text_excerpt.as_deref(),
+            Some("naar boven afgerond op hele euro's")
+        );
+        assert!(!rounding.accepted);
+
+        let lookup = collected
+            .iter()
+            .find(|u| u.construct == "table_lookup")
+            .expect("table_lookup entry");
+        assert_eq!(lookup.article, "3");
+        assert!(lookup.suggestion.is_none());
+        assert!(lookup.legal_text_excerpt.is_none());
+        assert!(lookup.accepted);
+    }
+
+    #[tokio::test]
+    async fn test_collect_untranslatables_none() {
+        let yaml = r#"---
+$id: test_law
+regulatory_layer: WET
+publication_date: '2025-01-01'
+articles:
+  - number: '1'
+    text: Article one.
+"#;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("law.yaml");
+        tokio::fs::write(&path, yaml).await.unwrap();
+
+        assert!(collect_untranslatables(&path).await.unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/packages/pipeline/src/lib.rs
+++ b/packages/pipeline/src/lib.rs
@@ -13,6 +13,7 @@ pub mod law_status;
 pub mod models;
 #[cfg(feature = "test-utils")]
 pub mod test_utils;
+pub mod untranslatables;
 pub mod worker;
 
 pub use api_state::ApiState;
@@ -30,4 +31,6 @@ pub use harvest::{HarvestPayload, HarvestResult, MAX_HARVEST_DEPTH};
 // handler `api::harvest::request_harvest` shares that name, so callers import
 // it path-qualified via the module.
 pub use harvest_request::{HarvestRequestOptions, HarvestRequestOutcome};
-pub use models::{FeatureFlag, Job, JobStatus, JobType, LawEntry, LawStatusValue, Priority};
+pub use models::{
+    FeatureFlag, Job, JobStatus, JobType, LawEntry, LawStatusValue, Priority, Untranslatable,
+};

--- a/packages/pipeline/src/models.rs
+++ b/packages/pipeline/src/models.rs
@@ -135,6 +135,24 @@ pub struct LawEntry {
     pub updated_at: DateTime<Utc>,
 }
 
+/// A single untranslatable construct captured during enrichment (RFC-012),
+/// one row per (law, provider, article, construct). Mirrors the
+/// `untranslatables` table; refreshed per (law_id, provider) on each enrich.
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct Untranslatable {
+    pub id: Uuid,
+    pub law_id: String,
+    pub enrich_job_id: Uuid,
+    pub provider: String,
+    pub article: String,
+    pub construct: String,
+    pub reason: String,
+    pub suggestion: Option<String>,
+    pub legal_text_excerpt: Option<String>,
+    pub accepted: bool,
+    pub created_at: DateTime<Utc>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
 pub struct FeatureFlag {
     pub key: String,

--- a/packages/pipeline/src/untranslatables.rs
+++ b/packages/pipeline/src/untranslatables.rs
@@ -1,0 +1,205 @@
+//! Persistence for RFC-012 "untranslatables" captured during enrichment.
+//!
+//! The enrichment agent flags legal constructs it cannot express with the
+//! engine's current operation set in the law YAML (`machine_readable.
+//! untranslatables`). [`crate::enrich`] collects those into
+//! [`CapturedUntranslatable`]s (DB-free); the worker calls
+//! [`replace_untranslatables`] on successful completion to mirror them into the
+//! `untranslatables` table so they surface in the harvester UI.
+
+use uuid::Uuid;
+
+use crate::enrich::CapturedUntranslatable;
+use crate::error::Result;
+
+/// Delete-and-replace all untranslatables for `(law_id, provider)` with the
+/// freshly captured set from an enrich run.
+///
+/// Idempotent per `(law_id, provider)`: re-running enrichment for the same
+/// provider fully refreshes that provider's rows without touching another
+/// provider's. Takes a single connection so the delete + inserts stay atomic
+/// with the caller's transaction (`complete_job`).
+#[tracing::instrument(skip(conn, entries), fields(count = entries.len()))]
+pub async fn replace_untranslatables(
+    conn: &mut sqlx::PgConnection,
+    law_id: &str,
+    provider: &str,
+    enrich_job_id: Uuid,
+    entries: &[CapturedUntranslatable],
+) -> Result<()> {
+    sqlx::query("DELETE FROM untranslatables WHERE law_id = $1 AND provider = $2")
+        .bind(law_id)
+        .bind(provider)
+        .execute(&mut *conn)
+        .await?;
+
+    for entry in entries {
+        sqlx::query(
+            r#"
+            INSERT INTO untranslatables
+                (law_id, enrich_job_id, provider, article, construct,
+                 reason, suggestion, legal_text_excerpt, accepted)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+            "#,
+        )
+        .bind(law_id)
+        .bind(enrich_job_id)
+        .bind(provider)
+        .bind(&entry.article)
+        .bind(&entry.construct)
+        .bind(&entry.reason)
+        .bind(&entry.suggestion)
+        .bind(&entry.legal_text_excerpt)
+        .bind(entry.accepted)
+        .execute(&mut *conn)
+        .await?;
+    }
+
+    tracing::info!(
+        law_id,
+        provider,
+        count = entries.len(),
+        "untranslatables replaced"
+    );
+    Ok(())
+}
+
+#[cfg(all(test, feature = "test-utils"))]
+mod tests {
+    use super::*;
+    use crate::job_queue::{create_job, CreateJobRequest};
+    use crate::law_status::upsert_law;
+    use crate::models::{JobType, Untranslatable};
+    use crate::test_utils::TestDb;
+
+    fn entry(construct: &str, accepted: bool) -> CapturedUntranslatable {
+        CapturedUntranslatable {
+            article: "1".to_string(),
+            construct: construct.to_string(),
+            reason: format!("cannot express {construct}"),
+            suggestion: None,
+            legal_text_excerpt: None,
+            accepted,
+        }
+    }
+
+    async fn seed_enrich_job(db: &TestDb, law_id: &str) -> Uuid {
+        upsert_law(&db.pool, law_id, Some("Test Law"), None)
+            .await
+            .unwrap();
+        create_job(&db.pool, CreateJobRequest::new(JobType::Enrich, law_id))
+            .await
+            .unwrap()
+            .id
+    }
+
+    async fn fetch_all(db: &TestDb) -> Vec<Untranslatable> {
+        sqlx::query_as::<_, Untranslatable>("SELECT * FROM untranslatables ORDER BY construct")
+            .fetch_all(&db.pool)
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn replace_inserts_captured_entries() {
+        let db = TestDb::new().await;
+        let job_id = seed_enrich_job(&db, "test_law").await;
+        let mut conn = db.pool.acquire().await.unwrap();
+
+        replace_untranslatables(
+            &mut conn,
+            "test_law",
+            "opencode",
+            job_id,
+            &[entry("rounding", false), entry("table_lookup", true)],
+        )
+        .await
+        .unwrap();
+
+        let rows = fetch_all(&db).await;
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].construct, "rounding");
+        assert_eq!(rows[0].law_id, "test_law");
+        assert_eq!(rows[0].provider, "opencode");
+        assert_eq!(rows[0].enrich_job_id, job_id);
+        assert!(!rows[0].accepted);
+        assert!(rows[1].accepted);
+    }
+
+    #[tokio::test]
+    async fn replace_is_idempotent_per_law_and_provider() {
+        let db = TestDb::new().await;
+        let job_id = seed_enrich_job(&db, "test_law").await;
+        let mut conn = db.pool.acquire().await.unwrap();
+
+        // First run flags two constructs.
+        replace_untranslatables(
+            &mut conn,
+            "test_law",
+            "opencode",
+            job_id,
+            &[entry("rounding", false), entry("table_lookup", false)],
+        )
+        .await
+        .unwrap();
+
+        // Second run of the same provider flags only one — the old set must be
+        // fully replaced, not appended (no duplicates, no stale rows).
+        replace_untranslatables(
+            &mut conn,
+            "test_law",
+            "opencode",
+            job_id,
+            &[entry("date_diff", false)],
+        )
+        .await
+        .unwrap();
+
+        let rows = fetch_all(&db).await;
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].construct, "date_diff");
+    }
+
+    #[tokio::test]
+    async fn replace_leaves_other_providers_untouched() {
+        let db = TestDb::new().await;
+        let job_id = seed_enrich_job(&db, "test_law").await;
+        let mut conn = db.pool.acquire().await.unwrap();
+
+        replace_untranslatables(
+            &mut conn,
+            "test_law",
+            "opencode",
+            job_id,
+            &[entry("a", false)],
+        )
+        .await
+        .unwrap();
+        replace_untranslatables(
+            &mut conn,
+            "test_law",
+            "claude",
+            job_id,
+            &[entry("b", false)],
+        )
+        .await
+        .unwrap();
+
+        // Re-running opencode must not clear the claude rows.
+        replace_untranslatables(
+            &mut conn,
+            "test_law",
+            "opencode",
+            job_id,
+            &[entry("c", false)],
+        )
+        .await
+        .unwrap();
+
+        let rows = fetch_all(&db).await;
+        assert_eq!(rows.len(), 2);
+        let providers: Vec<_> = rows.iter().map(|r| r.provider.as_str()).collect();
+        assert!(providers.contains(&"claude"));
+        assert!(providers.contains(&"opencode"));
+    }
+}

--- a/packages/pipeline/src/worker.rs
+++ b/packages/pipeline/src/worker.rs
@@ -1345,6 +1345,17 @@ async fn process_next_enrich_job(
 
                 let mut tx = pool.begin().await?;
                 job_queue::complete_job(&mut *tx, job.id, result_json).await?;
+                // Mirror the captured untranslatables into their table so they
+                // surface in the harvester UI. Atomic with the completion:
+                // delete-and-replace per (law_id, provider).
+                crate::untranslatables::replace_untranslatables(
+                    &mut tx,
+                    &result.law_id,
+                    &result.provider,
+                    job.id,
+                    &result.untranslatables,
+                )
+                .await?;
                 law_status::update_status(&mut *tx, &job.law_id, LawStatusValue::Enriched).await?;
                 tx.commit().await?;
                 Ok(())


### PR DESCRIPTION
## What & why

Untranslatables (RFC-012) are legal constructs the enrichment agent cannot yet express with the engine's operation set (rounding, table lookups, calendar logic, discretionary norms, …). It flags them per article in a law's `machine_readable.untranslatables`. Until now those entries lived **only** in the corpus git YAML on the per-provider `enrich/{provider}` branch — they reached no database and no UI. The only "model is incomplete here" signal in the harvester UI was the coarse `coverage_score`.

This captures untranslatables when an enrichment produces them and surfaces them **read-only** as a new **Untranslatables** tab in Corpusinwinning, so we can work on them (clean up the law, or file an engine feature request).

## Approach

Stored **atomically — one row per untranslatable** — so grouped views (per construct / per law) stay derivable later. Capture point is enrichment → a new DB table.

**Pipeline** (`packages/pipeline`)
- New `untranslatables` table (migration `0023`).
- `enrich.rs` collects untranslatables from the enriched YAML into `EnrichResult` (DB-free; they also ride along in `jobs.result`).
- The worker mirrors them into the table via **delete-and-replace per `(law_id, provider)`**, atomic with `complete_job` (a failure rolls back the whole completion).

**Admin API** (`packages/admin`)
- Read-only `GET /api/untranslatables`: paginated, sortable (allowlist), filterable by `law_id` / `provider` / `accepted` / `construct`; LEFT JOINs `law_entries` for `law_name`. The editor-api `/api/harvest-admin/*` proxy forwards it (no proxy change).

**Frontend** (`frontend/src/harvester`)
- New "Untranslatables" tab built entirely on the existing `DataTable` + a right-side detail sheet; new `useUntranslatables` composable mirroring `useLawEntries`. No new UI primitives.

## Out of scope (future work)
- Mutations from the UI (toggling `accepted`), grouped views, writing back to YAML.

## Testing
- Pipeline: unit (YAML → captured set) + testcontainers idempotency/provider-isolation — 5/5.
- Admin: handler tests (empty / join / filters / invalid-sort / pagination) — 7/7.
- Frontend: vitest for the composable (URL building, sort toggle, allowlist, filters, pagination) and the view wiring — 9/9. Production build green.

## Note — custom CSS on the design system
Per CLAUDE.md I must report any custom styling on top of NLDD components: `UntranslatableDetailPanel.vue` uses an inline `style="align-items: flex-end"` on the Accepted `<nldd-cell>`. This is the **same idiom already used in `DataTable.vue`** (right-aligned cells), not a new hack — flagged for visibility.