### PR TITLE
feat(admin): allow POST via ADMIN_API_KEY for programmatic job enqueue

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,7 +47,7 @@ WORKER_MAX_POLL_INTERVAL_SECS=60
 # ENRICH_HOURLY_LIMIT=4
 # ENRICH_NIGHT_MULTIPLIER=5
 
-# === Admin API Key (optional, enables Bearer token auth for GET + DELETE) ===
+# === Admin API Key (optional, enables Bearer token auth for GET + POST + DELETE) ===
 # ADMIN_API_KEY=change-me-to-a-long-random-string-at-least-32-chars
 
 # === Editor: central corpus GitHub token (fixes local rate-limit) ===

--- a/docs/src/content/docs/auth-and-roles.md
+++ b/docs/src/content/docs/auth-and-roles.md
@@ -325,11 +325,15 @@ Keycloak.
 
 ## Programmatic access (admin API key)
 
-The harvester-admin service accepts a bearer API key on **GET** and **DELETE**
-requests (`ADMIN_API_KEY` env var). This is an out-of-band trust path, the holder
-is treated as a `regelrecht-admin`-equivalent for those methods. POST is never
-allowed via the API key path; use a user session with `harvester-writer` or
-`harvester-admin` for mutations. The editor service has no API key path.
+The harvester-admin service accepts a bearer API key on **GET**, **POST** and
+**DELETE** requests (`ADMIN_API_KEY` env var). This is an out-of-band trust path,
+the holder is treated as a `regelrecht-admin`-equivalent for every method — so
+scripts and services can enqueue harvest/enrich jobs (`POST /api/harvest-jobs`,
+`POST /api/enrich-jobs`) without driving an interactive OIDC/SSO session. Because
+the trust is method-based (not route-based), the key also reaches the admin-tier
+POST routes (`reset-exhausted`, source `sync`) — consistent with it already
+permitting the destructive `DELETE /api/jobs`. A user session with the matching
+role still works too. The editor service has no API key path.
 
 ## Implementation pointers
 

--- a/docs/src/content/docs/auth-and-roles.md
+++ b/docs/src/content/docs/auth-and-roles.md
@@ -327,7 +327,7 @@ Keycloak.
 
 The harvester-admin service accepts a bearer API key on **GET**, **POST** and
 **DELETE** requests (`ADMIN_API_KEY` env var). This is an out-of-band trust path,
-the holder is treated as a `regelrecht-admin`-equivalent for every method — so
+the holder is treated as a `regelrecht-admin`-equivalent on those methods — so
 scripts and services can enqueue harvest/enrich jobs (`POST /api/harvest-jobs`,
 `POST /api/enrich-jobs`) without driving an interactive OIDC/SSO session. Because
 the trust is method-based (not route-based), the key also reaches the admin-tier

--- a/packages/admin/src/config.rs
+++ b/packages/admin/src/config.rs
@@ -69,7 +69,7 @@ impl AppConfig {
                     "ADMIN_API_KEY is shorter than 32 characters — consider using a longer key"
                 );
             }
-            tracing::info!("API key authentication is enabled (GET + DELETE)");
+            tracing::info!("API key authentication is enabled (GET + POST + DELETE)");
         }
 
         let api_key_hash = api_key

--- a/packages/admin/src/main.rs
+++ b/packages/admin/src/main.rs
@@ -232,7 +232,7 @@ async fn main() {
     // editor-api /api/harvest-admin/* proxy. This binary no longer serves a
     // SPA, so there is no static fallback — unmatched paths 404. The API
     // surface (/health, /metrics, /auth/*, /api/*) stays a standalone,
-    // publicly-addressable harvest API (OIDC + ADMIN_API_KEY on GET/DELETE).
+    // publicly-addressable harvest API (OIDC + ADMIN_API_KEY on GET/POST/DELETE).
 
     let port: u16 = env::var("ADMIN_PORT")
         .ok()

--- a/packages/admin/src/middleware.rs
+++ b/packages/admin/src/middleware.rs
@@ -836,10 +836,13 @@ mod tests {
     #[tokio::test]
     async fn api_key_post_passes_regardless_of_role() {
         // POST is in API_KEY_ALLOWED_METHODS — the bearer path accepts it
-        // as admin-equivalent without consulting the session role, so a valid
-        // key can enqueue jobs on any role-gated route.
+        // without consulting the session role, so a valid key can enqueue jobs
+        // on any role-gated route. A non-admin gate (harvester-writer) is used
+        // here so the pass is evidently a method-based bypass, not a role match;
+        // together with `api_key_valid_post_passes` (a reader-gated route) the
+        // two cases span the "regardless of role" claim.
         let state = test_state_with_api_key(true, Some("test-key"));
-        let app = role_app(state, "harvester-admin");
+        let app = role_app(state, "harvester-writer");
         let response = app
             .oneshot(
                 axum::http::Request::builder()

--- a/packages/admin/src/middleware.rs
+++ b/packages/admin/src/middleware.rs
@@ -17,7 +17,12 @@ use crate::error::ApiError;
 use crate::state::AppState;
 
 /// Methods allowed via API key authentication (no OIDC session required).
-const API_KEY_ALLOWED_METHODS: &[Method] = &[Method::GET, Method::DELETE];
+///
+/// Covers every method the API exposes (GET reads, POST enqueues harvest/enrich
+/// jobs and triggers resets/syncs, DELETE removes jobs), so the key is a full
+/// admin-equivalent for programmatic access. POST is included so scripts and
+/// services can enqueue jobs without driving an interactive OIDC/SSO session.
+const API_KEY_ALLOWED_METHODS: &[Method] = &[Method::GET, Method::POST, Method::DELETE];
 
 type RequireAuthFuture = Pin<Box<dyn Future<Output = Result<Response, ApiError>> + Send>>;
 
@@ -26,7 +31,8 @@ type RequireAuthFuture = Pin<Box<dyn Future<Output = Result<Response, ApiError>>
 /// Two trust paths:
 /// 1. A valid bearer API key — out-of-band trust, treated as regelrecht-admin
 ///    equivalent for the methods listed in [`API_KEY_ALLOWED_METHODS`]
-///    (GET/DELETE). The key holder is whoever provisioned the deployment.
+///    (GET/POST/DELETE — i.e. all of them). The key holder is whoever
+///    provisioned the deployment.
 /// 2. An authenticated OIDC session — must carry `required_role` in
 ///    `SESSION_KEY_ROLES`. Composite expansion in Keycloak means higher
 ///    roles automatically satisfy lower-role checks.
@@ -370,7 +376,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn api_key_valid_post_returns_403() {
+    async fn api_key_valid_post_passes() {
         let state = test_state_with_api_key(true, Some("test-key"));
         let app = test_app(state);
 
@@ -386,7 +392,9 @@ mod tests {
             .await
             .expect("response");
 
-        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        // POST is admin-equivalent via API key so scripts can enqueue jobs
+        // without an OIDC session.
+        assert_eq!(response.status(), StatusCode::OK);
     }
 
     #[tokio::test]
@@ -826,11 +834,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn api_key_post_still_rejected_regardless_of_role() {
-        // POST is not in API_KEY_ALLOWED_METHODS — the bearer path rejects
-        // it before role checks. Verifies the order of operations is unchanged.
+    async fn api_key_post_passes_regardless_of_role() {
+        // POST is in API_KEY_ALLOWED_METHODS — the bearer path accepts it
+        // as admin-equivalent without consulting the session role, so a valid
+        // key can enqueue jobs on any role-gated route.
         let state = test_state_with_api_key(true, Some("test-key"));
-        let app = role_app(state, "harvester-writer");
+        let app = role_app(state, "harvester-admin");
         let response = app
             .oneshot(
                 axum::http::Request::builder()
@@ -842,6 +851,6 @@ mod tests {
             )
             .await
             .expect("response");
-        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        assert_eq!(response.status(), StatusCode::OK);
     }
 }

--- a/packages/admin/src/middleware.rs
+++ b/packages/admin/src/middleware.rs
@@ -18,10 +18,12 @@ use crate::state::AppState;
 
 /// Methods allowed via API key authentication (no OIDC session required).
 ///
-/// Covers every method the API exposes (GET reads, POST enqueues harvest/enrich
-/// jobs and triggers resets/syncs, DELETE removes jobs), so the key is a full
-/// admin-equivalent for programmatic access. POST is included so scripts and
-/// services can enqueue jobs without driving an interactive OIDC/SSO session.
+/// Within this set the key is an admin-equivalent for programmatic access: GET
+/// reads, POST enqueues harvest/enrich jobs and triggers resets/syncs, DELETE
+/// removes jobs. POST is included so scripts and services can enqueue jobs
+/// without driving an interactive OIDC/SSO session. Any method outside the set
+/// is rejected, so a route added with a different method does not silently
+/// widen what the key can do.
 const API_KEY_ALLOWED_METHODS: &[Method] = &[Method::GET, Method::POST, Method::DELETE];
 
 type RequireAuthFuture = Pin<Box<dyn Future<Output = Result<Response, ApiError>> + Send>>;
@@ -30,9 +32,9 @@ type RequireAuthFuture = Pin<Box<dyn Future<Output = Result<Response, ApiError>>
 ///
 /// Two trust paths:
 /// 1. A valid bearer API key — out-of-band trust, treated as regelrecht-admin
-///    equivalent for the methods listed in [`API_KEY_ALLOWED_METHODS`]
-///    (GET/POST/DELETE — i.e. all of them). The key holder is whoever
-///    provisioned the deployment.
+///    equivalent for the methods listed in [`API_KEY_ALLOWED_METHODS`]; other
+///    methods are refused. The key holder is whoever provisioned the
+///    deployment.
 /// 2. An authenticated OIDC session — must carry `required_role` in
 ///    `SESSION_KEY_ROLES`. Composite expansion in Keycloak means higher
 ///    roles automatically satisfy lower-role checks.

--- a/packages/admin/src/middleware.rs
+++ b/packages/admin/src/middleware.rs
@@ -197,12 +197,17 @@ mod tests {
         let store = MemoryStore::default();
         let session_layer = SessionManagerLayer::new(store);
 
+        // PUT is registered only so the API-key method gate can be exercised
+        // on a method outside `API_KEY_ALLOWED_METHODS`; the service itself
+        // serves no PUT route. Without a matching handler axum answers 405
+        // before `route_layer` runs, so the gate would never be reached.
         Router::new()
             .route(
                 "/test",
                 get(|| async { "ok" })
                     .post(|| async { "ok" })
-                    .delete(|| async { "ok" }),
+                    .delete(|| async { "ok" })
+                    .put(|| async { "ok" }),
             )
             .route_layer(axum_middleware::from_fn_with_state(
                 state.clone(),
@@ -397,6 +402,29 @@ mod tests {
         // POST is admin-equivalent via API key so scripts can enqueue jobs
         // without an OIDC session.
         assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn api_key_method_outside_allowlist_returns_403() {
+        // The allowlist is a deliberate subset, not "every method": a valid
+        // key on a method that is not listed is refused before any role check,
+        // so a route added on a new method does not silently widen the key.
+        let state = test_state_with_api_key(true, Some("test-key"));
+        let app = test_app(state);
+
+        let response = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .method("PUT")
+                    .uri("/test")
+                    .header("authorization", "Bearer test-key")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

Allow the harvester-admin `ADMIN_API_KEY` bearer token to be used on **POST** requests. Previously the key path only permitted `GET` + `DELETE`, so enqueuing harvest/enrich jobs required an interactive OIDC/SSO browser session — awkward for scripts and services.

`API_KEY_ALLOWED_METHODS` now includes `Method::POST`, so a valid key can hit:
- `POST /api/harvest-jobs` and `POST /api/enrich-jobs` (the motivating use case — enqueue jobs from a script)
- and, because the trust is method-based rather than route-based, the admin-tier `POST /api/law_entries/{id}/reset-exhausted` and `POST /api/sources/{id}/sync`.

## Why this is safe

The API key is already documented as a `regelrecht-admin`-equivalent out-of-band trust path and already permits the **destructive** `DELETE /api/jobs`. Extending it to POST — whose reachable routes are job creation plus the recoverable reset-exhausted / source-sync operations — is a *smaller* escalation than what the key already grants. Scoping POST to only the job routes isn't expressible in the current method-based allowlist (it would need per-route key config, a larger design change), so keeping the uniform method-based model is the consistent choice.

## Changes

- `packages/admin/src/middleware.rs` — add `Method::POST` to `API_KEY_ALLOWED_METHODS`; update the `require_auth` doc comment; flip the two method-gate unit tests (`api_key_valid_post_passes`, `api_key_post_passes_regardless_of_role`).
- `packages/admin/src/config.rs` — startup log now reads `(GET + POST + DELETE)`.
- `packages/admin/src/main.rs` — comment updated.
- `docs/src/content/docs/auth-and-roles.md` — "Programmatic access" section updated.

## Testing

- `cargo test -p regelrecht-admin --lib` → 64 passed (all middleware / API-key gate tests included).
- `cargo fmt --check` and `cargo clippy --all-targets` on the admin package clean.
- `handler_tests` require Postgres (testcontainers) and were not run in this env; the diff does not touch any handler.
