### PR TITLE
fix(pipeline): fail deterministic enrichment failures fast

### DIFF
--- a/packages/pipeline/src/job_queue.rs
+++ b/packages/pipeline/src/job_queue.rs
@@ -310,6 +310,7 @@ where
 /// failures (e.g. the enrichment LLM produced no machine_readable sections, or
 /// its output failed to parse) where retrying the same input reproduces the
 /// same failure and only burns budget and blocks the serial queue.
+#[tracing::instrument(skip(executor, error_result))]
 pub async fn fail_job_terminal<'e, E>(
     executor: E,
     job_id: Uuid,

--- a/packages/pipeline/src/job_queue.rs
+++ b/packages/pipeline/src/job_queue.rs
@@ -303,6 +303,42 @@ where
     Ok(job)
 }
 
+/// Mark a job as permanently failed regardless of remaining attempts.
+///
+/// Unlike [`fail_job`], this never reschedules for retry: it sets `failed`
+/// immediately even when `attempts < max_attempts`. Used for deterministic
+/// failures (e.g. the enrichment LLM produced no machine_readable sections, or
+/// its output failed to parse) where retrying the same input reproduces the
+/// same failure and only burns budget and blocks the serial queue.
+pub async fn fail_job_terminal<'e, E>(
+    executor: E,
+    job_id: Uuid,
+    error_result: Option<serde_json::Value>,
+) -> Result<Job>
+where
+    E: sqlx::PgExecutor<'e>,
+{
+    let job = sqlx::query_as::<_, Job>(
+        r#"
+        UPDATE jobs
+        SET status = 'failed'::job_status,
+            result = $2,
+            completed_at = now(),
+            scheduled_at = NULL
+        WHERE id = $1 AND status = 'processing'
+        RETURNING *
+        "#,
+    )
+    .bind(job_id)
+    .bind(&error_result)
+    .fetch_optional(executor)
+    .await?
+    .ok_or(PipelineError::JobNotProcessing(job_id))?;
+
+    tracing::warn!(job_id = %job.id, attempts = job.attempts, "job terminally failed (non-retryable)");
+    Ok(job)
+}
+
 /// Reap orphaned jobs stuck in 'processing' for longer than `timeout`.
 ///
 /// Jobs that remain in 'processing' beyond the timeout are assumed orphaned

--- a/packages/pipeline/src/law_status.rs
+++ b/packages/pipeline/src/law_status.rs
@@ -378,3 +378,22 @@ where
     }
     Ok(())
 }
+
+/// Set a law's status to `enrich_failed`, but never regress a law that already
+/// reached a terminal enrich state (`enriched` or `enrich_exhausted`). With dual
+/// providers a failing provider must not clobber a status another provider
+/// already earned. Returns the number of rows updated (0 = already terminal).
+#[tracing::instrument(skip(executor))]
+pub async fn mark_enrich_failed<'e, E>(executor: E, law_id: &str) -> Result<u64>
+where
+    E: sqlx::PgExecutor<'e>,
+{
+    let result = sqlx::query(
+        "UPDATE law_entries SET status = 'enrich_failed'::law_status, updated_at = now() \
+         WHERE law_id = $1 AND status NOT IN ('enriched', 'enrich_exhausted')",
+    )
+    .bind(law_id)
+    .execute(executor)
+    .await?;
+    Ok(result.rows_affected())
+}

--- a/packages/pipeline/src/worker.rs
+++ b/packages/pipeline/src/worker.rs
@@ -103,6 +103,10 @@ fn is_resource_exhaustion(err: &str) -> bool {
 /// succeed on a later attempt and must stay retryable.
 fn is_deterministic_content_failure(err: &str) -> bool {
     let e = err.to_ascii_lowercase();
+    // These markers track PipelineError's `#[error(...)]` Display formats
+    // ("YAML error: …" on `Yaml`, and the `Enrich` message from enrich.rs). The
+    // `deterministic_markers_track_error_display_format` test constructs the real
+    // errors so a format change fails loudly instead of silently regressing.
     const MARKERS: &[&str] = &[
         "no machine_readable sections", // LLM returned nothing usable
         "yaml error",                   // parse / deserialize / schema-validation failure
@@ -1854,6 +1858,30 @@ mod tests {
         assert!(!is_deterministic_content_failure(
             "IO error: Resource temporarily unavailable (os error 11)"
         ));
+    }
+
+    #[test]
+    fn deterministic_markers_track_error_display_format() {
+        // The classifier matches on error Display strings, so its markers are
+        // coupled to PipelineError's `#[error(...)]` formats. Construct the real
+        // errors and run them through the classifier: if a format string drifts
+        // (e.g. "YAML error:" is renamed), this fails instead of silently
+        // regressing content failures back to the 30-retry ladder.
+        let yaml_err: PipelineError = serde_yaml_ng::from_str::<i32>("[1, 2]")
+            .expect_err("deserializing a sequence into i32 must fail")
+            .into();
+        assert!(
+            is_deterministic_content_failure(&yaml_err.to_string()),
+            "PipelineError::Yaml Display must still match a classifier marker"
+        );
+
+        let enrich_err = PipelineError::Enrich(
+            "LLM produced no machine_readable sections (3 articles needed enrichment)".to_string(),
+        );
+        assert!(
+            is_deterministic_content_failure(&enrich_err.to_string()),
+            "PipelineError::Enrich Display must preserve the message the classifier keys on"
+        );
     }
 
     #[test]

--- a/packages/pipeline/src/worker.rs
+++ b/packages/pipeline/src/worker.rs
@@ -1485,7 +1485,7 @@ async fn process_next_enrich_job(
                 "enrichment failed"
             );
 
-            let error_json = serde_json::json!({ "error": err_str.clone() });
+            let error_json = serde_json::json!({ "error": &err_str });
 
             if is_deterministic_content_failure(&err_str) {
                 // Deterministic content failure (LLM produced no machine_readable

--- a/packages/pipeline/src/worker.rs
+++ b/packages/pipeline/src/worker.rs
@@ -1494,21 +1494,35 @@ async fn process_next_enrich_job(
                 // only), so a provider that already enriched this law keeps 'enriched'.
                 match job_queue::fail_job_terminal(pool, job.id, Some(error_json)).await {
                     Ok(_) => {
-                        if let Err(status_err) =
-                            law_status::mark_enrich_failed(pool, &job.law_id).await
-                        {
-                            tracing::warn!(error = %status_err, law_id = %job.law_id, "failed to set status to enrich_failed");
+                        // Log the actual outcome — never claim "exhausted" when a
+                        // DB error left the law unchanged, or when the other
+                        // provider had already reached a terminal state (0 rows).
+                        match law_status::mark_enrich_failed(pool, &job.law_id).await {
+                            Ok(0) => {
+                                tracing::warn!(
+                                    job_id = %job.id,
+                                    law_id = %job.law_id,
+                                    "deterministic content failure — job failed without retry; law already in a terminal state, status kept"
+                                );
+                            }
+                            Ok(_) => {
+                                if let Err(ex_err) =
+                                    law_status::exhaust_law(pool, &job.law_id, JobType::Enrich)
+                                        .await
+                                {
+                                    tracing::warn!(error = %ex_err, law_id = %job.law_id, "failed to mark law enrich_exhausted");
+                                } else {
+                                    tracing::warn!(
+                                        job_id = %job.id,
+                                        law_id = %job.law_id,
+                                        "deterministic content failure — marked enrich_exhausted without retry"
+                                    );
+                                }
+                            }
+                            Err(status_err) => {
+                                tracing::warn!(error = %status_err, law_id = %job.law_id, "failed to set status to enrich_failed");
+                            }
                         }
-                        if let Err(ex_err) =
-                            law_status::exhaust_law(pool, &job.law_id, JobType::Enrich).await
-                        {
-                            tracing::warn!(error = %ex_err, law_id = %job.law_id, "failed to mark law enrich_exhausted");
-                        }
-                        tracing::warn!(
-                            job_id = %job.id,
-                            law_id = %job.law_id,
-                            "deterministic content failure — marked enrich_exhausted without retry"
-                        );
                     }
                     Err(fail_err) => {
                         tracing::error!(job_id = %job.id, error = %fail_err, "failed to terminally fail job");

--- a/packages/pipeline/src/worker.rs
+++ b/packages/pipeline/src/worker.rs
@@ -1496,41 +1496,42 @@ async fn process_next_enrich_job(
                 // queue behind ~30 doomed runs. Fail terminally and exhaust the law
                 // in one step. The exhaust is guarded (enrich_failed → enrich_exhausted
                 // only), so a provider that already enriched this law keeps 'enriched'.
-                match job_queue::fail_job_terminal(pool, job.id, Some(error_json)).await {
-                    Ok(_) => {
-                        // Log the actual outcome — never claim "exhausted" when a
-                        // DB error left the law unchanged, or when the other
-                        // provider had already reached a terminal state (0 rows).
-                        match law_status::mark_enrich_failed(pool, &job.law_id).await {
-                            Ok(0) => {
-                                tracing::warn!(
-                                    job_id = %job.id,
-                                    law_id = %job.law_id,
-                                    "deterministic content failure — job failed without retry; law already in a terminal state, status kept"
-                                );
-                            }
-                            Ok(_) => {
-                                if let Err(ex_err) =
-                                    law_status::exhaust_law(pool, &job.law_id, JobType::Enrich)
-                                        .await
-                                {
-                                    tracing::warn!(error = %ex_err, law_id = %job.law_id, "failed to mark law enrich_exhausted");
-                                } else {
-                                    tracing::warn!(
-                                        job_id = %job.id,
-                                        law_id = %job.law_id,
-                                        "deterministic content failure — marked enrich_exhausted without retry"
-                                    );
-                                }
-                            }
-                            Err(status_err) => {
-                                tracing::warn!(error = %status_err, law_id = %job.law_id, "failed to set status to enrich_failed");
-                            }
-                        }
+                // Terminal-fail the job and transition the law atomically: if any
+                // step errors, the transaction rolls back and the job is left in
+                // 'processing' for the reaper to reclaim and retry (self-healing
+                // once the DB recovers) — never a law stranded in 'enriching' with
+                // a failed job and no follow-up. `mark_enrich_failed` is guarded
+                // (NOT IN enriched/enrich_exhausted), so 0 rows means another
+                // provider already reached a terminal state — keep it, skip the
+                // exhaust.
+                let fast_fail = async {
+                    let mut tx = pool.begin().await?;
+                    job_queue::fail_job_terminal(&mut *tx, job.id, Some(error_json)).await?;
+                    let rows = law_status::mark_enrich_failed(&mut *tx, &job.law_id).await?;
+                    if rows > 0 {
+                        law_status::exhaust_law(&mut *tx, &job.law_id, JobType::Enrich).await?;
                     }
-                    Err(fail_err) => {
-                        tracing::error!(job_id = %job.id, error = %fail_err, "failed to terminally fail job");
-                    }
+                    tx.commit().await?;
+                    Ok::<u64, PipelineError>(rows)
+                }
+                .await;
+                match fast_fail {
+                    Ok(0) => tracing::warn!(
+                        job_id = %job.id,
+                        law_id = %job.law_id,
+                        "deterministic content failure — job failed without retry; law already in a terminal state, status kept"
+                    ),
+                    Ok(_) => tracing::warn!(
+                        job_id = %job.id,
+                        law_id = %job.law_id,
+                        "deterministic content failure — marked enrich_exhausted without retry"
+                    ),
+                    Err(e) => tracing::error!(
+                        job_id = %job.id,
+                        law_id = %job.law_id,
+                        error = %e,
+                        "fast-fail transaction rolled back; job left in 'processing' for the reaper to retry"
+                    ),
                 }
             } else {
                 match job_queue::fail_job(pool, job.id, Some(error_json)).await {

--- a/packages/pipeline/src/worker.rs
+++ b/packages/pipeline/src/worker.rs
@@ -91,6 +91,25 @@ fn is_resource_exhaustion(err: &str) -> bool {
     MARKERS.iter().any(|m| e.contains(m))
 }
 
+/// Returns true when an enrichment error is deterministic — re-running the same
+/// law with the same provider reproduces it, so retrying wastes LLM budget and
+/// blocks the serial queue. These are content/output faults: the LLM produced no
+/// machine_readable sections at all, or its output failed to parse/validate
+/// against the schema (malformed YAML, wrong types, missing fields — all
+/// surfaced as `PipelineError::Yaml`, i.e. "YAML error: …").
+///
+/// Transient faults (timeouts, reaped/stuck jobs, corpus/git-push failures,
+/// resource exhaustion, network errors) are deliberately excluded — those can
+/// succeed on a later attempt and must stay retryable.
+fn is_deterministic_content_failure(err: &str) -> bool {
+    let e = err.to_ascii_lowercase();
+    const MARKERS: &[&str] = &[
+        "no machine_readable sections", // LLM returned nothing usable
+        "yaml error",                   // parse / deserialize / schema-validation failure
+    ];
+    MARKERS.iter().any(|m| e.contains(m))
+}
+
 /// Interval between orphaned-job reaper runs.
 const REAPER_INTERVAL: Duration = Duration::from_secs(60);
 
@@ -1272,14 +1291,7 @@ async fn process_next_enrich_job(
                 Ok(failed_job) => {
                     if failed_job.status == crate::models::JobStatus::Failed {
                         // Set EnrichFailed only if not already Enriched or EnrichExhausted.
-                        if let Err(e) = sqlx::query(
-                            "UPDATE law_entries SET status = 'enrich_failed'::law_status, updated_at = now() \
-                             WHERE law_id = $1 AND status NOT IN ('enriched', 'enrich_exhausted')",
-                        )
-                        .bind(&job.law_id)
-                        .execute(pool)
-                        .await
-                        {
+                        if let Err(e) = law_status::mark_enrich_failed(pool, &job.law_id).await {
                             tracing::warn!(error = %e, law_id = %job.law_id, "failed to update law status to enrich_failed");
                         }
 
@@ -1374,13 +1386,7 @@ async fn process_next_enrich_job(
                     match job_queue::fail_job(pool, job.id, Some(error_json)).await {
                         Ok(failed_job) if failed_job.status == crate::models::JobStatus::Failed => {
                             // Set EnrichFailed only if not already Enriched or EnrichExhausted.
-                            if let Err(e) = sqlx::query(
-                                "UPDATE law_entries SET status = 'enrich_failed'::law_status, updated_at = now() \
-                                 WHERE law_id = $1 AND status NOT IN ('enriched', 'enrich_exhausted')",
-                            )
-                            .bind(&job.law_id)
-                            .execute(pool)
-                            .await
+                            if let Err(e) = law_status::mark_enrich_failed(pool, &job.law_id).await
                             {
                                 tracing::warn!(error = %e, law_id = %job.law_id, "failed to update law status to enrich_failed");
                             }
@@ -1466,7 +1472,8 @@ async fn process_next_enrich_job(
             }
         }
         Ok(Err(e)) => {
-            let outcome = outcome_for_error(&e.to_string());
+            let err_str = e.to_string();
+            let outcome = outcome_for_error(&err_str);
             tracing::error!(
                 job_id = %job.id,
                 law_id = %job.law_id,
@@ -1474,47 +1481,76 @@ async fn process_next_enrich_job(
                 "enrichment failed"
             );
 
-            let error_json = serde_json::json!({ "error": e.to_string() });
-            match job_queue::fail_job(pool, job.id, Some(error_json)).await {
-                Ok(failed_job) => {
-                    if failed_job.status == crate::models::JobStatus::Failed {
-                        // Set EnrichFailed only if not already Enriched or EnrichExhausted.
-                        if let Err(status_err) = sqlx::query(
-                            "UPDATE law_entries SET status = 'enrich_failed'::law_status, updated_at = now() \
-                             WHERE law_id = $1 AND status NOT IN ('enriched', 'enrich_exhausted')",
-                        )
-                        .bind(&job.law_id)
-                        .execute(pool)
-                        .await
+            let error_json = serde_json::json!({ "error": err_str.clone() });
+
+            if is_deterministic_content_failure(&err_str) {
+                // Deterministic content failure (LLM produced no machine_readable
+                // sections, or its output failed to parse/validate). Re-running the
+                // same law with the same provider reproduces it, so the normal
+                // retry ladder (3 inner attempts × up to EXHAUSTED_THRESHOLD
+                // recreated jobs) only wastes LLM budget and blocks the serial
+                // queue behind ~30 doomed runs. Fail terminally and exhaust the law
+                // in one step. The exhaust is guarded (enrich_failed → enrich_exhausted
+                // only), so a provider that already enriched this law keeps 'enriched'.
+                match job_queue::fail_job_terminal(pool, job.id, Some(error_json)).await {
+                    Ok(_) => {
+                        if let Err(status_err) =
+                            law_status::mark_enrich_failed(pool, &job.law_id).await
                         {
                             tracing::warn!(error = %status_err, law_id = %job.law_id, "failed to set status to enrich_failed");
                         }
-
-                        handle_enrich_exhausted_or_retry(
-                            pool,
-                            &job.law_id,
-                            &payload,
-                            job.priority,
-                            exhausted_threshold,
-                        )
-                        .await;
-                    } else {
-                        // Job will be retried — atomically reset to Harvested only if
-                        // status is currently Enriching. Cannot regress from Enriched.
-                        if let Err(status_err) = law_status::update_status_if(
-                            pool,
-                            &job.law_id,
-                            LawStatusValue::Enriching,
-                            LawStatusValue::Harvested,
-                        )
-                        .await
+                        if let Err(ex_err) =
+                            law_status::exhaust_law(pool, &job.law_id, JobType::Enrich).await
                         {
-                            tracing::warn!(error = %status_err, law_id = %job.law_id, "failed to reset status to harvested for retry");
+                            tracing::warn!(error = %ex_err, law_id = %job.law_id, "failed to mark law enrich_exhausted");
                         }
+                        tracing::warn!(
+                            job_id = %job.id,
+                            law_id = %job.law_id,
+                            "deterministic content failure — marked enrich_exhausted without retry"
+                        );
+                    }
+                    Err(fail_err) => {
+                        tracing::error!(job_id = %job.id, error = %fail_err, "failed to terminally fail job");
                     }
                 }
-                Err(fail_err) => {
-                    tracing::error!(job_id = %job.id, error = %fail_err, "failed to mark job as failed");
+            } else {
+                match job_queue::fail_job(pool, job.id, Some(error_json)).await {
+                    Ok(failed_job) => {
+                        if failed_job.status == crate::models::JobStatus::Failed {
+                            // Set EnrichFailed only if not already Enriched or EnrichExhausted.
+                            if let Err(status_err) =
+                                law_status::mark_enrich_failed(pool, &job.law_id).await
+                            {
+                                tracing::warn!(error = %status_err, law_id = %job.law_id, "failed to set status to enrich_failed");
+                            }
+
+                            handle_enrich_exhausted_or_retry(
+                                pool,
+                                &job.law_id,
+                                &payload,
+                                job.priority,
+                                exhausted_threshold,
+                            )
+                            .await;
+                        } else {
+                            // Job will be retried — atomically reset to Harvested only if
+                            // status is currently Enriching. Cannot regress from Enriched.
+                            if let Err(status_err) = law_status::update_status_if(
+                                pool,
+                                &job.law_id,
+                                LawStatusValue::Enriching,
+                                LawStatusValue::Harvested,
+                            )
+                            .await
+                            {
+                                tracing::warn!(error = %status_err, law_id = %job.law_id, "failed to reset status to harvested for retry");
+                            }
+                        }
+                    }
+                    Err(fail_err) => {
+                        tracing::error!(job_id = %job.id, error = %fail_err, "failed to mark job as failed");
+                    }
                 }
             }
 
@@ -1765,6 +1801,44 @@ mod tests {
         ));
         assert!(!is_resource_exhaustion(
             "YAML error: did not find expected key at line 5 column 3"
+        ));
+    }
+
+    #[test]
+    fn classifies_content_failures_as_deterministic() {
+        // Real strings observed from failed enrich jobs (opencode) — retrying
+        // these reproduces the same failure, so they must fail fast.
+        assert!(is_deterministic_content_failure(
+            "enrichment error: LLM produced no machine_readable sections (159 articles needed enrichment)"
+        ));
+        assert!(is_deterministic_content_failure(
+            "YAML error: articles[4].machine_readable.untranslatables[0]: missing field `construct` at line 445 column 11"
+        ));
+        assert!(is_deterministic_content_failure(
+            "YAML error: articles[9].machine_readable: invalid type: sequence, expected struct MachineReadable at line 395 column 7"
+        ));
+        assert!(is_deterministic_content_failure(
+            "YAML error: did not find expected key at line 177 column 3"
+        ));
+    }
+
+    #[test]
+    fn does_not_classify_transient_failures_as_deterministic() {
+        // Transient faults must stay retryable — a later attempt can succeed.
+        assert!(!is_deterministic_content_failure(
+            "reaped: job stuck in processing"
+        ));
+        assert!(!is_deterministic_content_failure(
+            "job timed out after 600s"
+        ));
+        assert!(!is_deterministic_content_failure(
+            "enrichment error: corpus push failed: git command failed: could not read from remote"
+        ));
+        assert!(!is_deterministic_content_failure(
+            "enrichment error: claude exited with exit status: 1"
+        ));
+        assert!(!is_deterministic_content_failure(
+            "IO error: Resource temporarily unavailable (os error 11)"
         ));
     }
 

--- a/packages/pipeline/tests/job_queue_tests.rs
+++ b/packages/pipeline/tests/job_queue_tests.rs
@@ -190,6 +190,59 @@ async fn test_fail_job_with_retry() {
 }
 
 #[tokio::test]
+async fn test_fail_job_terminal_fails_immediately_without_retry() {
+    let db = TestDb::new().await;
+
+    // max_attempts = 3, but a terminal failure must not reschedule even on the
+    // first attempt (deterministic content failures should not burn retries).
+    let req = CreateJobRequest::new(JobType::Enrich, "BWBR0001840").with_max_attempts(3);
+    let job = job_queue::create_job(&db.pool, req).await.unwrap();
+
+    let claimed = job_queue::claim_job(&db.pool, None).await.unwrap().unwrap();
+    assert_eq!(claimed.attempts, 1, "still on the first attempt");
+
+    let failed = job_queue::fail_job_terminal(
+        &db.pool,
+        job.id,
+        Some(json!({"error": "LLM produced no machine_readable sections"})),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        failed.status,
+        JobStatus::Failed,
+        "terminal failure must mark Failed even with attempts < max_attempts"
+    );
+    assert!(failed.completed_at.is_some());
+    assert!(
+        failed.scheduled_at.is_none(),
+        "terminally failed job must not carry a retry schedule"
+    );
+
+    let none = job_queue::claim_job(&db.pool, None).await.unwrap();
+    assert!(
+        none.is_none(),
+        "terminally failed job must not be reclaimed"
+    );
+}
+
+#[tokio::test]
+async fn test_fail_job_terminal_requires_processing_state() {
+    let db = TestDb::new().await;
+
+    // A job that was never claimed is 'pending', not 'processing' — terminal
+    // fail must reject it (mirrors fail_job's guard).
+    let req = CreateJobRequest::new(JobType::Enrich, "BWBR0001840");
+    let job = job_queue::create_job(&db.pool, req).await.unwrap();
+
+    let err = job_queue::fail_job_terminal(&db.pool, job.id, None)
+        .await
+        .unwrap_err();
+    assert!(matches!(err, PipelineError::JobNotProcessing(_)));
+}
+
+#[tokio::test]
 async fn test_fail_job_sets_exponential_backoff_schedule() {
     let db = TestDb::new().await;
 

--- a/packages/pipeline/tests/law_status_tests.rs
+++ b/packages/pipeline/tests/law_status_tests.rs
@@ -347,3 +347,65 @@ async fn test_update_status_unless_any_protects_multiple_statuses() {
         .unwrap();
     assert_eq!(entry.status, LawStatusValue::Queued);
 }
+
+#[tokio::test]
+async fn test_mark_enrich_failed_guards_terminal_states() {
+    let db = TestDb::new().await;
+
+    // A non-terminal law is marked enrich_failed and reports one affected row.
+    law_status::upsert_law(&db.pool, "failing_law", None, None)
+        .await
+        .unwrap();
+    law_status::update_status(&db.pool, "failing_law", LawStatusValue::Enriching)
+        .await
+        .unwrap();
+    let rows = law_status::mark_enrich_failed(&db.pool, "failing_law")
+        .await
+        .unwrap();
+    assert_eq!(rows, 1, "a non-terminal law is marked enrich_failed");
+    assert_eq!(
+        law_status::get_law(&db.pool, "failing_law")
+            .await
+            .unwrap()
+            .status,
+        LawStatusValue::EnrichFailed
+    );
+
+    // A law another provider already enriched must NOT regress: 0 rows, status kept.
+    law_status::upsert_law(&db.pool, "done_law", None, None)
+        .await
+        .unwrap();
+    law_status::update_status(&db.pool, "done_law", LawStatusValue::Enriched)
+        .await
+        .unwrap();
+    let rows = law_status::mark_enrich_failed(&db.pool, "done_law")
+        .await
+        .unwrap();
+    assert_eq!(rows, 0, "an already-enriched law must not be regressed");
+    assert_eq!(
+        law_status::get_law(&db.pool, "done_law")
+            .await
+            .unwrap()
+            .status,
+        LawStatusValue::Enriched
+    );
+
+    // Same for an already-exhausted law.
+    law_status::upsert_law(&db.pool, "exhausted_law", None, None)
+        .await
+        .unwrap();
+    law_status::update_status(&db.pool, "exhausted_law", LawStatusValue::EnrichExhausted)
+        .await
+        .unwrap();
+    let rows = law_status::mark_enrich_failed(&db.pool, "exhausted_law")
+        .await
+        .unwrap();
+    assert_eq!(rows, 0, "an already-exhausted law must not be regressed");
+    assert_eq!(
+        law_status::get_law(&db.pool, "exhausted_law")
+            .await
+            .unwrap()
+            .status,
+        LawStatusValue::EnrichExhausted
+    );
+}


### PR DESCRIPTION
## Problem

The enrichworker runs each law through two providers (`claude`, `opencode`) and had **two nested retry layers**:

1. **Inner** — a job retries up to `max_attempts` (3) with exponential backoff (same job row).
2. **Outer** — when a job exhausts its 3 attempts, `handle_enrich_exhausted_or_retry` creates a **brand-new** enrich job, repeating until the law's `enrich_fail_count` reaches `EXHAUSTED_THRESHOLD` (10) and the law is marked `enrich_exhausted`.

So one deterministically-failing law+provider burned **~30 doomed serial runs** (10 jobs × 3 attempts). Because the worker processes serially, those blocked productive jobs — including the *other* provider, which often succeeds — behind them. Observed in the current 100-law batch: `opencode` fails on almost every law (`LLM produced no machine_readable sections`, malformed YAML), and each failure churned the queue for hours.

## Fix

Classify enrichment failures:

| Class | Markers | Behaviour |
|---|---|---|
| **Deterministic (content)** | `no machine_readable sections`, `YAML error: …` (parse/deserialize/schema) | **Fail fast**: `fail_job_terminal` (no inner retry) → `mark_enrich_failed` → `exhaust_law`. One run, then the law is `enrich_exhausted`. |
| **Transient** | timeouts, `reaped: job stuck in processing`, corpus/git-push failures, resource exhaustion | Unchanged — keeps the full retry ladder. |

Re-running a deterministic content failure reproduces it, so retrying only wastes LLM budget and queue time. This cuts ~30 doomed runs → 1 per failing law+provider.

### Correctness / two-provider safety
- `exhaust_law` is guarded (`enrich_failed → enrich_exhausted` only) and the preceding `mark_enrich_failed` is guarded (`WHERE status NOT IN ('enriched','enrich_exhausted')`). The success path uses an **unconditional** `update_status(Enriched)`. So whichever order the two providers run, a provider that succeeds keeps the law `'enriched'` — a failing provider never regresses it. The still-pending sibling job is not blocked and runs to completion.
- The fast path reaches the **same terminal state** today's code reaches after 10 rounds — it just gets there in one step.

## Changes

- `packages/pipeline/src/job_queue.rs` — new `fail_job_terminal` (mark `failed` immediately regardless of remaining attempts; same `processing`-state guard as `fail_job`).
- `packages/pipeline/src/worker.rs` — `is_deterministic_content_failure` classifier (next to the existing `is_resource_exhaustion`); fast-fail branch in the `Ok(Err(e))` enrich-failure arm.
- `packages/pipeline/src/law_status.rs` — extract the guarded `enrich_failed` update into `mark_enrich_failed` (was inlined in four places — DRY).

## Testing

- Classifier unit tests (real observed failure strings, both classes) — pass, no DB needed.
- `fail_job_terminal` DB tests (immediate `Failed` on first attempt, no reschedule, not reclaimable, rejects non-`processing`) — compile here; run in CI with Postgres.
- `cargo fmt --check` + `cargo clippy` clean.
- Reviewed by a code-review subagent: no blocking issues; confirmed the status transitions and cleanup control-flow.