### PR TITLE
docs: schema-referentie bijwerken naar v0.5.6 en tegen drift borgen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,10 @@ jobs:
               - corpus/regulation/**
               - schema/**
               - script/**
+              # The schema reference doc is version-locked to schema/latest by
+              # provenance-checks; edit it and that guard must re-run.
+              - docs/src/content/docs/reference/schema.md
+              - docs/scripts/check-schema-version.mjs
               - Justfile
               - .pre-commit-config.yaml
               - .yamllint
@@ -198,6 +202,19 @@ jobs:
             exit 1
           fi
           echo "schema/latest correctly points to $HIGHEST"
+
+      # The schema reference doc hand-states the current version; this asserts
+      # it tracks schema/latest so a schema bump can't leave the docs behind.
+      # Node-only, reads source files (no astro build).
+      - name: Setup Node.js
+        if: needs.changes.outputs.ci == 'true'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
+        with:
+          node-version: '22'
+
+      - name: Check schema reference doc tracks schema/latest
+        if: needs.changes.outputs.ci == 'true'
+        run: node docs/scripts/check-schema-version.mjs
 
       - name: Check engine version bump on source changes
         if: needs.changes.outputs.ci == 'true' && github.event_name == 'pull_request'

--- a/docs/package.json
+++ b/docs/package.json
@@ -8,6 +8,7 @@
     "build": "astro build",
     "preview": "astro preview",
     "check:rfc-coverage": "node scripts/check-rfc-coverage.mjs",
+    "check:schema-version": "node scripts/check-schema-version.mjs",
     "a11y": "astro build && node scripts/check-rfc-coverage.mjs && node scripts/check-mermaid-alt.mjs && node scripts/check-heading-order.mjs && node scripts/check-links.mjs && node scripts/gen-pa11yci.mjs && start-server-and-test 'astro preview --port 4173' http://localhost:4173 'pa11y-ci'"
   },
   "dependencies": {

--- a/docs/scripts/check-schema-version.mjs
+++ b/docs/scripts/check-schema-version.mjs
@@ -1,0 +1,94 @@
+// Assert the schema reference page tracks the latest released schema version.
+//
+// `reference/schema.md` hand-states the current schema version in three places
+// (a "current version is vX.Y.Z" line, an immutable-tag example URL, and the
+// top row of the Version History table). None of them are derived from the
+// repo, so the page silently rots the moment `schema/latest` is bumped and
+// nobody edits the doc: it then advertises an old version as current while
+// looking authoritative, and law authors copy a stale `$schema` URL. This
+// check makes CI fail when the page falls behind `schema/latest`, so the
+// versioned schema and its documentation can never drift apart again.
+//
+// It reads source files only (the `schema/latest` symlink + the markdown), not
+// the astro build, so it runs without `astro build`. The `schema/` tree lives
+// outside docs/ and is not in the docs Docker build context, but it IS present
+// in the CI repo checkout where this script runs (see the provenance-checks
+// job). Non-zero exit fails the gate.
+
+import { readdirSync, readFileSync, existsSync, lstatSync, readlinkSync } from 'node:fs';
+import { basename } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SCHEMA_DIR = fileURLToPath(new URL('../../schema', import.meta.url));
+const PAGE = fileURLToPath(
+  new URL('../src/content/docs/reference/schema.md', import.meta.url),
+);
+
+if (!existsSync(SCHEMA_DIR)) {
+  // Outside the CI checkout (e.g. the docs-only Docker build context) the
+  // schema tree is absent. Skip rather than fail: this guard is a CI gate, not
+  // a build step, and there is nothing to compare against here.
+  console.log('check-schema-version: schema/ not present, skipping (not a full-repo checkout)');
+  process.exit(0);
+}
+
+// The released version is whatever schema/latest resolves to — the single
+// source of truth the rest of the repo already keys off (provenance-checks
+// asserts the symlink points at the highest schema/vX.Y.Z directory).
+const latestLink = `${SCHEMA_DIR}/latest`;
+let latest;
+if (existsSync(latestLink) && lstatSync(latestLink).isSymbolicLink()) {
+  latest = basename(readlinkSync(latestLink));
+} else {
+  // Fall back to the highest versioned directory (e.g. checkouts that
+  // materialize symlinks as plain dirs).
+  latest = readdirSync(SCHEMA_DIR)
+    .filter((n) => /^v\d+\.\d+\.\d+$/.test(n))
+    .sort((a, b) =>
+      a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' }),
+    )
+    .at(-1);
+}
+
+if (!latest || !/^v\d+\.\d+\.\d+$/.test(latest)) {
+  console.error(`check-schema-version FAILED: could not determine latest schema version from ${SCHEMA_DIR}`);
+  process.exit(1);
+}
+
+const page = readFileSync(PAGE, 'utf8');
+const problems = [];
+
+// 1. The prose "current version is vX.Y.Z" line must name the latest version.
+const currentLine = page.match(/current schema version is \*\*(v\d+\.\d+\.\d+)\*\*/);
+if (!currentLine) {
+  problems.push('could not find the "current schema version is **vX.Y.Z**" line');
+} else if (currentLine[1] !== latest) {
+  problems.push(
+    `"current schema version" says ${currentLine[1]} but schema/latest is ${latest}`,
+  );
+}
+
+// 2. The example immutable-tag URL must point at the latest version's tag+dir.
+const expectedUrl = `https://raw.githubusercontent.com/MinBZK/regelrecht/refs/tags/schema-${latest}/schema/${latest}/schema.json`;
+if (!page.includes(expectedUrl)) {
+  problems.push(`the example schema URL does not point at ${latest} (expected ${expectedUrl})`);
+}
+
+// 3. The Version History table must have a row for the latest version, so the
+//    thing that changed is actually described (with its RFC).
+const historyRow = new RegExp(`^\\|\\s*${latest.replace(/\./g, '\\.')}\\s*\\|`, 'm');
+if (!historyRow.test(page)) {
+  problems.push(`the Version History table has no row for ${latest}`);
+}
+
+if (problems.length) {
+  console.error(`check-schema-version FAILED (schema/latest is ${latest}):`);
+  for (const p of problems) console.error('  - ' + p);
+  console.error(
+    '\nUpdate docs/src/content/docs/reference/schema.md: bump the current-version line ' +
+      'and tag URL, and add a Version History row describing what the new version introduces.',
+  );
+  process.exit(1);
+}
+
+console.log(`check-schema-version passed: reference page tracks schema/latest (${latest}).`);

--- a/docs/scripts/check-schema-version.mjs
+++ b/docs/scripts/check-schema-version.mjs
@@ -75,8 +75,11 @@ if (!page.includes(expectedUrl)) {
 }
 
 // 3. The Version History table must have a row for the latest version, so the
-//    thing that changed is actually described (with its RFC).
-const historyRow = new RegExp(`^\\|\\s*${latest.replace(/\./g, '\\.')}\\s*\\|`, 'm');
+//    thing that changed is actually described (with its RFC). `latest` is a
+//    validated vX.Y.Z string, but escape every regex metacharacter (not just
+//    the dots) so the pattern stays literal regardless of its shape.
+const escaped = latest.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+const historyRow = new RegExp(`^\\|\\s*${escaped}\\s*\\|`, 'm');
 if (!historyRow.test(page)) {
   problems.push(`the Version History table has no row for ${latest}`);
 }

--- a/docs/src/content/docs/reference/schema.md
+++ b/docs/src/content/docs/reference/schema.md
@@ -7,12 +7,12 @@ The law format is defined by a JSON Schema. All law YAML files in the corpus mus
 
 ## Current Version
 
-The current schema version is **v0.5.4**.
+The current schema version is **v0.5.6**.
 
 Schema URLs use immutable git tags to guarantee reproducibility. The format is:
 
 ```
-https://raw.githubusercontent.com/MinBZK/regelrecht/refs/tags/schema-v0.5.4/schema/v0.5.4/schema.json
+https://raw.githubusercontent.com/MinBZK/regelrecht/refs/tags/schema-v0.5.6/schema/v0.5.6/schema.json
 ```
 
 The tag `schema-vX.Y.Z` is created when a schema version is released. Using tags instead of `refs/heads/main` ensures that the schema a law file references can never change underneath it. See [RFC-013](/rfcs/rfc-013) for the rationale.
@@ -23,6 +23,8 @@ This table is the single source of truth for which schema version introduced whi
 
 | Version | Introduces | RFC |
 |---------|-----------|-----|
+| v0.5.6 | Quantity `unit` labels (`euro`, `ratio`, `percentage`) and structured `definitions` constants carrying `type`/`type_spec` | [RFC-023](/rfcs/rfc-023) |
+| v0.5.5 | `ROUND`, `CEIL`, `FLOOR` rounding operations (explicit statutory rounding) | [RFC-024](/rfcs/rfc-024) |
 | v0.5.4 | `DATE_DIFF` operation; date operands for the comparison operators | [RFC-021](/rfcs/rfc-021) |
 | v0.5.3 | `valid_to` (law end date) | [RFC-019](/rfcs/rfc-019) |
 | v0.5.2 | `annotation-schema.json` for stand-off notes | [RFC-005](/rfcs/rfc-005), [RFC-018](/rfcs/rfc-018) |


### PR DESCRIPTION
## Waarom

De schema-referentiepagina op [regelrecht.rijks.app/reference/schema](https://regelrecht.rijks.app/reference/schema) stond nog op **v0.5.4**, terwijl `schema/latest` al naar **v0.5.6** wijst. De "current version"-regel, de voorbeeld-tag-URL en de versiehistorie liepen twee patch-releases achter. Wie de pagina las om een `$schema`-URL over te nemen, kreeg een verouderde versie mee.

De pagina noemt de versie op drie plekken hardgecodeerd en niets daarvan wordt uit de repo afgeleid, dus dit soort drift kon stil ontstaan zodra `schema/latest` bumpt en de pagina niet mee gaat.

## Wat

**De pagina bijgewerkt naar v0.5.6:**
- "Current version"-regel en voorbeeld-tag-URL.
- Versiehistorie: rij voor **v0.5.5** (`ROUND`/`CEIL`/`FLOOR`, [RFC-024](https://regelrecht.rijks.app/rfcs/rfc-024)) en **v0.5.6** (quantity-`unit`-labels + gestructureerde `definitions`-constanten met `type`/`type_spec`, [RFC-023](https://regelrecht.rijks.app/rfcs/rfc-023)).

**Een CI-guard om herhaling te voorkomen:**
- `docs/scripts/check-schema-version.mjs` leest `schema/latest` (de bron van waarheid waar de rest van de repo al op stuurt) en faalt wanneer de referentiepagina eronder wegloopt: het controleert de current-version-regel, de tag-URL én of er een historie-rij voor de nieuwste versie bestaat. In de trant van de bestaande `check-rfc-coverage.mjs`.
- Draait in de `provenance-checks`-job — leest alleen bronbestanden, geen `astro build` nodig. De `ci`-paths-filter bevat nu ook de pagina zelf, zodat de guard herdraait bij zowel een schema-bump als een handmatige edit van de pagina.
- Ook lokaal aan te roepen: `npm run check:schema-version` (in `docs/`).

## Waarom een guard en geen auto-generatie

De docs-Docker-build kopieert alleen `docs/` in de build-context; `schema/` is daar niet bereikbaar, dus een build-time read zou lokaal werken en de container breken. En de versiehistorie draagt per-versie proza (wat veranderde, welke RFC) dat sowieso niet machinaal hoort te ontstaan. Een guard die een mens dwingt die rij te schrijven is de juiste vorm.

## Getest

- Guard slaagt op de bijgewerkte pagina.
- Guard gesimuleerd tegen exact de drift die nu optrad (pagina terug op v0.5.4): faalt met alle drie de specifieke problemen (current-version, tag-URL, ontbrekende historie-rij).

> [!NOTE]
> De live site werkt pas bij na een docs-deploy vanaf `main`, dus de gepubliceerde pagina blijft op v0.5.4 tot deze PR gemerged is.
