### PR TITLE
fix(docs): @astrojs/markdown-remark als directe dependency

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -8,6 +8,7 @@
       "name": "regelrecht-docs",
       "version": "1.0.0",
       "dependencies": {
+        "@astrojs/markdown-remark": "^7.2.1",
         "@astrojs/mdx": "^7.0.2",
         "@nldd/design-system": "^0.8.62",
         "astro": "^7.0.6",
@@ -239,6 +240,31 @@
         "unified": "^11.0.5"
       }
     },
+    "node_modules/@astrojs/markdown-remark": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.2.1.tgz",
+      "integrity": "sha512-jPVNIqTvk+yKviikszv/Y1U4jGUSKpp/Nw48QZV4qjWgp70j4Lkq3lhSDRbWwCfgKvEyO9GHuVbV1dM2WYXy1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/internal-helpers": "0.10.1",
+        "@astrojs/prism": "4.0.2",
+        "github-slugger": "^2.0.0",
+        "hast-util-from-html": "^2.0.3",
+        "hast-util-to-text": "^4.0.2",
+        "mdast-util-definitions": "^6.0.0",
+        "rehype-raw": "^7.0.0",
+        "rehype-stringify": "^10.0.1",
+        "remark-gfm": "^4.0.1",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.1.2",
+        "remark-smartypants": "^3.0.2",
+        "unified": "^11.0.5",
+        "unist-util-remove-position": "^5.0.0",
+        "unist-util-visit": "^5.1.0",
+        "unist-util-visit-parents": "^6.0.2",
+        "vfile": "^6.0.3"
+      }
+    },
     "node_modules/@astrojs/markdown-satteri": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@astrojs/markdown-satteri/-/markdown-satteri-0.3.3.tgz",
@@ -283,31 +309,6 @@
         "@astrojs/markdown-satteri": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@astrojs/mdx/node_modules/@astrojs/markdown-remark": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.2.1.tgz",
-      "integrity": "sha512-jPVNIqTvk+yKviikszv/Y1U4jGUSKpp/Nw48QZV4qjWgp70j4Lkq3lhSDRbWwCfgKvEyO9GHuVbV1dM2WYXy1w==",
-      "license": "MIT",
-      "dependencies": {
-        "@astrojs/internal-helpers": "0.10.1",
-        "@astrojs/prism": "4.0.2",
-        "github-slugger": "^2.0.0",
-        "hast-util-from-html": "^2.0.3",
-        "hast-util-to-text": "^4.0.2",
-        "mdast-util-definitions": "^6.0.0",
-        "rehype-raw": "^7.0.0",
-        "rehype-stringify": "^10.0.1",
-        "remark-gfm": "^4.0.1",
-        "remark-parse": "^11.0.0",
-        "remark-rehype": "^11.1.2",
-        "remark-smartypants": "^3.0.2",
-        "unified": "^11.0.5",
-        "unist-util-remove-position": "^5.0.0",
-        "unist-util-visit": "^5.1.0",
-        "unist-util-visit-parents": "^6.0.2",
-        "vfile": "^6.0.3"
       }
     },
     "node_modules/@astrojs/prism": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -12,6 +12,7 @@
     "a11y": "astro build && node scripts/check-rfc-coverage.mjs && node scripts/check-mermaid-alt.mjs && node scripts/check-heading-order.mjs && node scripts/check-links.mjs && node scripts/gen-pa11yci.mjs && start-server-and-test 'astro preview --port 4173' http://localhost:4173 'pa11y-ci'"
   },
   "dependencies": {
+    "@astrojs/markdown-remark": "^7.2.1",
     "@astrojs/mdx": "^7.0.2",
     "@nldd/design-system": "^0.8.62",
     "astro": "^7.0.6",


### PR DESCRIPTION
## Waarom

De docs-build en de accessibility-gate faalden op `main` (zichtbaar in de post-merge CI-run van #909). De oorzaak zit niet in die PR: **Astro 7** stelde Sätteri in als standaard-Markdown-processor en levert `@astrojs/markdown-remark` niet langer standaard mee. `docs/astro.config.mjs` gebruikt `remarkPlugins`/`rehypePlugins`, die op die processor draaien, dus zonder de directe dependency faalt `astro build` bij config-validatie:

```
markdown.remarkPlugins, markdown.rehypePlugins, and markdown.remarkRehype run on
the unified processor from @astrojs/markdown-remark, which is no longer installed
by default now that Sätteri is the default Markdown processor.
```

Lokaal bleef dit onzichtbaar (oude Astro 6 nog in `node_modules`), maar CI doet `npm ci` en installeert de vastgepinde `^7.0.6`, waar het brak. Vermoedelijk binnengeslopen via de Astro-versiebump.

## Wat

`@astrojs/markdown-remark@^7.2.1` toegevoegd als directe dependency in `docs/package.json` (het zat er alleen nog transitief in via `@astrojs/mdx`), plus de bijbehorende lockfile-update.

## Getest

Schone `npm ci` met Astro **7.0.6** (exact de versie die CI installeert):
- `astro build` slaagt weer — 84 pagina's gebouwd (viel eerst om bij config-validatie).
- Alle docs-check-scripts groen: `check-rfc-coverage`, `check-mermaid-alt`, `check-heading-order`, `check-links`, `check-schema-version`.
