### PR TITLE
docs: kale schema-versiehistorie voor v0.3.x reconstrueren

### DIFF
--- a/docs/src/content/docs/reference/schema.md
+++ b/docs/src/content/docs/reference/schema.md
@@ -31,9 +31,9 @@ This table is the single source of truth for which schema version introduced whi
 | v0.5.1 | Tag-based immutable schema URLs; refinements within the v0.5.x line | [RFC-013](/rfcs/rfc-013) |
 | v0.5.0 | `hooks`, `overrides` (reactive execution); `procedure`, `procedure_id` (Awb lifecycle); Woo support | [RFC-007](/rfcs/rfc-007), [RFC-008](/rfcs/rfc-008) |
 | v0.4.0 | `open_terms`, `implements` (IoC); `legal_character`; `date` and `array` value types | [RFC-003](/rfcs/rfc-003) |
-| v0.3.2 | Minor fixes | |
-| v0.3.1 | Patch release | |
-| v0.3.0 | Cross-law reference refinements | |
+| v0.3.2 | `SUBTRACT_DATE` split into its own date operation with a `unit` (`days`, `months`, `years`) | |
+| v0.3.1 | Structured `references` on articles (`bwb_id`, `artikel`, `lid`, `onderdeel`, ...) for runtime cross-reference resolution | |
+| v0.3.0 | Typed operation definitions (arithmetic, logical, comparison, conditional, switch) with semantic operands and `legal_basis`, replacing the single untyped operation | [RFC-004](/rfcs/rfc-004) |
 | v0.2.0 | Initial public schema: `regulatory_layer`, `competent_authority`, `execution.produces`, cross-law references (`source`) | [RFC-001](/rfcs/rfc-001), [RFC-002](/rfcs/rfc-002) |
 
 Multi-organization execution ([RFC-009](/rfcs/rfc-009)) reuses `competent_authority` (v0.2.0) and adds no schema construct of its own.


### PR DESCRIPTION
## Waarom

De versiehistorie op de schema-referentiepagina had voor **v0.3.0**, **v0.3.1** en **v0.3.2** alleen nietszeggende teksten ("Minor fixes", "Patch release", "Cross-law reference refinements"). Die vertellen niet wat er daadwerkelijk veranderde, terwijl de tabel juist "the single source of truth for which schema version introduced which construct" heet te zijn.

De schema-directories staan allemaal nog in de repo, dus dit is exact te reconstrueren uit de diffs tussen `schema/v0.2.0` → `v0.3.0` → `v0.3.1` → `v0.3.2`.

## Wat

| Versie | Was | Wordt |
|--------|-----|-------|
| v0.3.0 | Cross-law reference refinements | Getypeerde operatie-definities (arithmetic/logical/comparison/conditional/switch) met semantische operanden en `legal_basis`, ter vervanging van de losse ongetypeerde `operation` — [RFC-004](/rfcs/rfc-004) |
| v0.3.1 | Patch release | Gestructureerde `references` op artikelen (`bwb_id`, `artikel`, `lid`, `onderdeel`, ...) voor runtime-resolutie van kruisverwijzingen |
| v0.3.2 | Minor fixes | `SUBTRACT_DATE` losgetrokken in een eigen date-operatie met een `unit` (`days`/`months`/`years`) |

De v0.3.0-rij krijgt nu ook de RFC-koppeling die er hoorde: RFC-004 (Uniform Operation Syntax) landde precies deze operatie-opsplitsing.

## Getest

Docs-guards groen: `check-schema-version`, `check-links`, `check-heading-order`.
