### PR TITLE
docs(editor): document CORPUS_AUTH_MINBZK_CENTRAL_TOKEN in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,21 @@ WORKER_MAX_POLL_INTERVAL_SECS=60
 # === Admin API Key (optional, enables Bearer token auth for GET + DELETE) ===
 # ADMIN_API_KEY=change-me-to-a-long-random-string-at-least-32-chars
 
+# === Editor: central corpus GitHub token (fixes local rate-limit) ===
+# The editor-api reads the central corpus (the `minbzk-central` source in
+# corpus-registry.yaml → MinBZK/regelrecht-corpus) through the GitHub Contents
+# API. Unauthenticated requests are capped at 60/hour per IP, so opening a few
+# laws locally quickly fails with "API rate limit exceeded" (editor-api then
+# returns 502). Set a token to raise the limit to 5000/hour.
+#
+# The var name is derived from the source id: CORPUS_AUTH_<ID>_TOKEN (uppercased,
+# hyphens → underscores). regelrecht-corpus is public, so any GitHub PAT with no
+# scopes suffices; a private source needs a token with Contents:read.
+# Extra/override sources you add in corpus-registry.local.yaml each get their own
+# CORPUS_AUTH_<ID>_TOKEN by the same rule. (Legacy shared fallback that applies to
+# every GitHub source: CORPUS_GIT_TOKEN.)
+# CORPUS_AUTH_MINBZK_CENTRAL_TOKEN=<YOUR_GH_TOKEN>
+
 # === Host port overrides (change if defaults collide with other services) ===
 # just dev:   postgres=5433, grafana=3002 (native services use 3000, 3001, 8000)
 # just local:  all services in Docker, no postgres host port


### PR DESCRIPTION
## What

Adds the central-corpus GitHub token variable to `.env.example`, documented as a commented placeholder next to `ADMIN_API_KEY`.

## Why

The editor-api reads the central corpus (`minbzk-central` → `MinBZK/regelrecht-corpus`) through the GitHub **Contents API**. Unauthenticated requests are capped at **60/hour per IP**, so opening a handful of laws locally quickly fails with `API rate limit exceeded` — the editor-api then returns a `502`. Setting a token raises the limit to 5000/hour.

Until now this variable (`CORPUS_AUTH_MINBZK_CENTRAL_TOKEN`) appeared nowhere in any `.example` file — only in a comment in `corpus-registry.yaml` and in the code. `.env.example` documents the pipeline/worker/admin side but said nothing about the editor's corpus reads, so contributors hit the rate limit with no obvious fix.

## Notes

- Left **commented out**: an uncommented `<YOUR_GH_TOKEN>` literal would be picked up by `just`'s `dotenv-load` and sent as `Authorization: Bearer <YOUR_GH_TOKEN>` → 401, which is worse than being unauthenticated.
- `regelrecht-corpus` is public, so any PAT with no scopes lifts the limit. The comment also points at the `CORPUS_GIT_TOKEN` legacy shared fallback and explains the `CORPUS_AUTH_<ID>_TOKEN` derivation rule for extra sources in `corpus-registry.local.yaml`.