### PR TITLE
fix(deps): bump crossbeam-epoch to 0.9.20 for RUSTSEC-2026-0204

### DIFF
--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -893,9 +893,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## What

Bumps the transitive dependency `crossbeam-epoch` `0.9.18 → 0.9.20` (lockfile-only, no manifest change) to clear **RUSTSEC-2026-0204**.

## Why

RUSTSEC-2026-0204 — invalid pointer dereference in the `fmt::Pointer` impl for `Atomic`/`Shared` when the underlying pointer is null. Affected `>=0.9.0, <0.9.20`; patched in `0.9.20`.

The advisory was published *after* main's last `Security Audit` run, so `main` is green only because it hasn't re-audited yet. Every open PR currently fails the `Security Audit` check until this lands — this is a workspace-wide fix, not tied to any feature branch.

## Verification

- `cargo deny check advisories --config ../deny.toml` → `advisories ok`
- `cargo check --workspace` → clean

## Notes

Follow-up idea (not in this PR): install `cargo-deny` in `just dev-setup` and/or add a scheduled daily audit so advisory-drift is caught on its own track instead of red-X'ing whoever pushes next.