### PR TITLE
fix(harvester): emit folded scalars for wrapped law text

### DIFF
--- a/corpus/regulation/nl/ministeriele_regeling/regeling_standaardpremie/2024-01-01.yaml
+++ b/corpus/regulation/nl/ministeriele_regeling/regeling_standaardpremie/2024-01-01.yaml
@@ -18,7 +18,7 @@ legal_basis:
     article: 18e
 articles:
   - number: '1'
-    text: |-
+    text: >-
       De standaardpremie, bedoeld in [artikel 4 van de Wet op de
       zorgtoeslag](https://wetten.overheid.nl/BWBR0018451/2024-01-01#Artikel4), bedraagt voor het berekeningsjaar 2024: €
       1.987,–.

--- a/corpus/regulation/nl/ministeriele_regeling/regeling_standaardpremie/2025-01-01.yaml
+++ b/corpus/regulation/nl/ministeriele_regeling/regeling_standaardpremie/2025-01-01.yaml
@@ -18,7 +18,7 @@ legal_basis:
     article: 18e
 articles:
   - number: '1'
-    text: |-
+    text: >-
       De standaardpremie, bedoeld in [artikel 4 van de Wet op de
       zorgtoeslag](https://wetten.overheid.nl/BWBR0018451/2025-01-01#Artikel4), bedraagt voor het berekeningsjaar 2025: €
       2.112,–.

--- a/corpus/regulation/nl/ministeriele_regeling/subsidieregeling_bekostiging_plafond_energietarieven_kleinverbruikers_2023/2022-12-15.yaml
+++ b/corpus/regulation/nl/ministeriele_regeling/subsidieregeling_bekostiging_plafond_energietarieven_kleinverbruikers_2023/2022-12-15.yaml
@@ -10,15 +10,18 @@ valid_to: '2026-12-31'
 bwb_id: BWBR0047628
 url: https://wetten.overheid.nl/BWBR0047628/2022-12-15
 preamble:
-  text: |-
+  text: >-
     Gelet op Verordening (EU) 2022/1854 van de Raad van 6 oktober 2022 betreffende een noodinterventie in verband met
     de hoge energieprijzen (PbEU 2022 LI 261/1)
+
 
     Handelende in overeenstemming met de mededeling van de Europese Commissie van 9 oktober 2022 betreffende het
     Tijdelijk crisiskader voor staatssteunmaatregelen ter ondersteuning van de economie na de Russische agressie tegen
     Oekraïne (PbEU 2022, C 426/01);
 
+
     Gelet op de artikelen 2, eerste en tweede lid, en 3 van de Kaderwet EZK- en LNV-subsidies;
+
 
     Besluit:
   url: https://wetten.overheid.nl/BWBR0047628/2022-12-15#ArtikelAanhef
@@ -247,12 +250,15 @@ articles:
       kleinverbruikaansluiting achterwege laten, indien de betreffende kleinverbruiker hierom verzoekt.
     url: https://wetten.overheid.nl/BWBR0047628/2022-12-15#Artikel2.1
   - number: '2.2'
-    text: |-
+    text: >-
       1 Het plafondtarief voor elektriciteit wordt vastgesteld op: € 0,24755 per kWh.
+
 
       2 Het plafondtarief voor gas wordt vastgesteld op: € 0,85734 per m3(n).
 
+
       3 Het plafondtarief voor warmte wordt vastgesteld op: € 47,38 per GJ.
+
 
       4 De plafondtarieven, bedoeld in de voorgaande leden, zijn exclusief energiebelasting en ODE en inclusief 21% btw.
     url: https://wetten.overheid.nl/BWBR0047628/2022-12-15#Artikel2.2
@@ -341,11 +347,13 @@ articles:
       - id: ref1
         bwb_id: BWBR0047628
   - number: '2.6'
-    text: |-
+    text: >-
       De subsidie wordt verleend onder de volgende opschortende voorwaarden:
+
 
       a. goedkeuring van de Europese Commissie in een procedure als bedoeld in artikel 108, derde lid, van het Verdrag
       betreffende de werking van de Europese Unie met betrekking tot deze regeling;
+
 
       b. instemming van de Staten-Generaal met het bij brief van de Minister van Economische Zaken en Klimaat van
       17 november 2022 ingediende voorstel van wet tot wijziging van de begrotingsstaat van het Ministerie van
@@ -353,10 +361,11 @@ articles:
       in verband met hoge energieprijzen), Kamerstukken II, vergaderjaar 2022/23, 36252.
     url: https://wetten.overheid.nl/BWBR0047628/2022-12-15#Artikel2.6
   - number: '2.7'
-    text: |-
+    text: >-
       1 De Minister maakt na de datum van subsidieverlening de gegevens bekend, bedoeld in paragraaf 3, onderdeel 76, van
       het Tijdelijk crisiskader voor staatssteunmaatregelen ter ondersteuning van de economie na de Russische agressie
       tegen Oekraïne (PbEU 2022, C 426/01).
+
 
       2 De gegevens, bedoeld in het tweede lid, blijven ten minste tien jaar openbaar beschikbaar.
     url: https://wetten.overheid.nl/BWBR0047628/2022-12-15#Artikel2.7
@@ -742,27 +751,30 @@ articles:
         bwb_id: BWBR0011440
         artikel: '37'
   - number: '4.4'
-    text: |-
+    text: >-
       1 De Minister beslist op een aanvraag voor subsidieverlening binnen twee weken na ontvangst van de aanvraag.
+
 
       2 Deze termijn kan eenmaal met ten hoogste twee weken worden verlengd.
     url: https://wetten.overheid.nl/BWBR0047628/2022-12-15#Artikel4.4
   - number: '4.5'
-    text: |-
+    text: >-
       In de beschikking tot subsidieverlening wordt geen bedrag opgenomen waarop de subsidie ten hoogste kan worden
       vastgesteld.
     url: https://wetten.overheid.nl/BWBR0047628/2022-12-15#Artikel4.5
   - number: '4.6'
-    text: |-
+    text: >-
       De Minister beslist afwijzend op een aanvraag voor subsidie indien:
 
+
       a. de aanvraag niet voldoet aan de bij deze regeling gestelde regels;
+
 
       b. de subsidieaanvrager failliet is verklaard of hem surséance van betaling is verleend, dan wel een verzoek
       daartoe bij de rechtbank is ingediend.
     url: https://wetten.overheid.nl/BWBR0047628/2022-12-15#Artikel4.6
   - number: '4.7'
-    text: |-
+    text: >-
       De Minister maakt zo spoedig mogelijk na een besluit tot subsidieverlening de naam van de subsidieontvanger en het
       inschrijvingsnummer in het handelsregister bekend.
     url: https://wetten.overheid.nl/BWBR0047628/2022-12-15#Artikel4.7
@@ -817,15 +829,16 @@ articles:
         artikel: '3.5'
         hoofdstuk: '3'
   - number: '5.3'
-    text: |-
+    text: >-
       1 De subsidieontvanger voert een zodanige administratie dat daaruit op elk moment op een eenvoudige en duidelijke
       wijze is af te leiden dat hij voldoet aan de bij deze regeling gestelde eisen.
+
 
       2 De subsidieontvanger bewaart de administratie tot tien jaar na de datum van de beschikking tot de
       subsidievaststelling.
     url: https://wetten.overheid.nl/BWBR0047628/2022-12-15#Artikel5.3
   - number: '5.4'
-    text: |-
+    text: >-
       De subsidieontvanger verleent gedurende vijf jaar na de datum van de beschikking tot subsidievaststelling
       medewerking aan een evaluatie door de Minister van de doeltreffendheid en de effecten van de aan hem verleende
       subsidie, voor zover medewerking redelijkerwijs van hem kan worden verlangd.
@@ -898,16 +911,17 @@ articles:
       bevindingen van een accountant verlangen, opgesteld volgens de door de Minister gegeven aanwijzingen.
     url: https://wetten.overheid.nl/BWBR0047628/2022-12-15#Artikel5.6
   - number: '5.7'
-    text: |-
+    text: >-
       1 De subsidieontvanger deelt onverwijld de indiening bij de rechtbank van een verzoek tot faillietverklaring van
       hem, tot verlening van surseance van betaling aan hem of tot toepassing van de schuldsaneringsregeling natuurlijke
       personen over hem schriftelijk mee aan de Minister.
+
 
       2 De subsidieontvanger verstrekt op verzoek aan de Minister alle overige bescheiden, gegevens of inlichtingen die
       nodig zijn voor een beslissing over de subsidie.
     url: https://wetten.overheid.nl/BWBR0047628/2022-12-15#Artikel5.7
   - number: '5.8'
-    text: |-
+    text: >-
       De subsidieontvanger is aangesloten bij een instantie voor buitengerechtelijke geschilbeslechting die bevoegd is
       klachten te behandelen van kleinverbruikers tegen leveranciers over de toepassing van deze regeling.
     url: https://wetten.overheid.nl/BWBR0047628/2022-12-15#Artikel5.8
@@ -934,21 +948,24 @@ articles:
         bwb_id: BWBR0033729
         artikel: '5'
   - number: 6.1.1
-    text: |-
+    text: >-
       De Minister verstrekt in 2023 maandelijks een voorschot voor de toepassing van het prijsplafond voor elektriciteit
       of gas op maandelijks in te dienen aanvragen.
     url: https://wetten.overheid.nl/BWBR0047628/2022-12-15#Artikel6.1.1
   - number: 6.1.2
-    text: |-
+    text: >-
       1 Het cumulatieve voorschot van alle reeds verstrekte voorschotten wordt maandelijks ambtshalve gecorrigeerd aan de
       hand van de eindfacturen die in die kalendermaand zijn verstrekt, totdat het cumulatieve voorschot is gecorrigeerd
       voor alle eindfacturen waarbij toepassing van het prijsplafond aan orde was in de periode waar de eindfactuur op
       ziet.
 
+
       2 Een reeds verstrekt voorschot kan op verzoek van de subsidieontvanger achteraf eenmalig worden gecorrigeerd:
+
 
       a. aan kleinverbruikaansluitingen waarvoor op het moment van indiening van de aanvraag voor dat voorschot nog geen
       sprake was van een leveringsovereenkomst; of
+
 
       b. indien sprake is van andere wijzigingen die substantiële invloed kunnen hebben op de hoogte van dat voorschot,
       met uitzondering van de in het eerste lid bedoelde correcties aan de hand van de eindfacturen.
@@ -1087,8 +1104,9 @@ articles:
       kalendermaand waar de aanvraag voor een voorschot op ziet, omgerekend naar m3(n) gas.
     url: https://wetten.overheid.nl/BWBR0047628/2022-12-15#Artikel6.1.6
   - number: 6.1.7
-    text: |-
+    text: >-
       1 De aanvraag voor eerste voorschot wordt gelijktijdig ingediend met de aanvraag voor subsidieverlening.
+
 
       2 De aanvraag voor het tweede en het daaropvolgende voorschot wordt ingediend uiterlijk op de vijftiende dag, om
       17:00 uur, van de kalendermaand die voorafgaat aan de kalendermaand waarop het voorschot betrekking heeft.
@@ -1128,19 +1146,20 @@ articles:
       het prijsplafond zal plaatsvinden.
     url: https://wetten.overheid.nl/BWBR0047628/2022-12-15#Artikel6.1.8
   - number: 6.1.9
-    text: |-
+    text: >-
       1 De Minister geeft een beschikking op een aanvraag voor een voorschot binnen twee weken na ontvangst van de
       aanvraag.
+
 
       2 Deze termijn kan eenmaal met ten hoogste twee weken worden verlengd.
     url: https://wetten.overheid.nl/BWBR0047628/2022-12-15#Artikel6.1.9
   - number: 6.2.1
-    text: |-
+    text: >-
       De Minister verstrekt op aanvraag één keer in 2023 een voorschot voor de toepassing van het prijsplafond voor
       warmte.
     url: https://wetten.overheid.nl/BWBR0047628/2022-12-15#Artikel6.2.1
   - number: 6.2.2
-    text: |-
+    text: >-
       Het jaarlijkse voorschot kan op verzoek van de subsidieontvanger worden gecorrigeerd bij wijzigingen van het aantal
       kleinverbruikaansluitingen of een contractueel leveringstarief.
     url: https://wetten.overheid.nl/BWBR0047628/2022-12-15#Artikel6.2.2
@@ -1233,14 +1252,15 @@ articles:
       worden geleverd in 2023, waarvoor de toepassing van het prijsplafond zal plaatsvinden.
     url: https://wetten.overheid.nl/BWBR0047628/2022-12-15#Artikel6.2.6
   - number: 6.2.7
-    text: |-
+    text: >-
       1 De Minister geeft een beschikking op een aanvraag voor een voorschot binnen twee weken na ontvangst van de
       aanvraag.
+
 
       2 Deze termijn kan eenmaal met ten hoogste twee weken worden verlengd.
     url: https://wetten.overheid.nl/BWBR0047628/2022-12-15#Artikel6.2.7
   - number: '7.1'
-    text: |-
+    text: >-
       Een subsidieontvanger dient uiterlijk 30 juni 2025, 17:00 uur, een aanvraag in voor subsidievaststelling voor de
       toepassing van het prijsplafond voor elektriciteit, gas of warmte.
     url: https://wetten.overheid.nl/BWBR0047628/2022-12-15#Artikel7.1
@@ -1302,9 +1322,10 @@ articles:
     text: De Minister beslist op een aanvraag voor subsidievaststelling binnen dertien weken na ontvangst van de aanvraag.
     url: https://wetten.overheid.nl/BWBR0047628/2022-12-15#Artikel7.3
   - number: '8.1'
-    text: |-
+    text: >-
       1 Deze regeling treedt in werking met ingang van de dag na de datum van uitgifte van de Staatscourant waarin zij
       wordt geplaatst.
+
 
       2 Deze regeling vervalt met ingang van 1 januari 2027, met dien verstande dat zij van toepassing blijft op
       subsidies die voor die datum zijn verstrekt.

--- a/corpus/regulation/nl/wet/algemene_wet_inkomensafhankelijke_regelingen/2025-01-01.yaml
+++ b/corpus/regulation/nl/wet/algemene_wet_inkomensafhankelijke_regelingen/2025-01-01.yaml
@@ -8,7 +8,7 @@ url: https://wetten.overheid.nl/BWBR0018472/2025-01-01
 name: '#wet_naam'
 articles:
   - number: '1'
-    text: |-
+    text: >-
       Artikel 1. Toepassingsgebied 1. Deze wet geldt voor inkomensafhankelijke regelingen. 2. In afwijking van het eerste
       lid is deze wet op inkomensafhankelijke regelingen die vóór 1. januari 2006. van kracht zijn, slechts van
       toepassing voor zover dit in de desbetreffende inkomensafhankelijke regeling is bepaald. 3. Onder
@@ -17,7 +17,7 @@ articles:
       hoogte van de bijdrage in die regelingen afhankelijk is gesteld van draagkracht.
     url: https://wetten.overheid.nl/BWBR0018472/2025-01-01#Artikel1
   - number: '2'
-    text: |-
+    text: >-
       Artikel 2. Definities 1. In deze wet en de daarop berustende bepalingen, alsmede in inkomensafhankelijke
       regelingen, wordt verstaan onder: a. belastbaar loon: het belastbare loon bedoeld in [artikel 9. van de Wet op de
       loonbelasting 1964](jci1.3:c:BWBR0002471&artikel=9) ; b. berekeningsjaar: het kalenderjaar waarop de tegemoetkoming
@@ -43,7 +43,7 @@ articles:
       onder Onze Minister: Onze Minister van Financiën.
     url: https://wetten.overheid.nl/BWBR0018472/2025-01-01#Artikel2
   - number: '3'
-    text: |-
+    text: >-
       Artikel 3. Partner 1. De partner van de belanghebbende is degene die hierna als eerste wordt genoemd: a. de niet
       duurzaam gescheiden levende echtgenoot of geregistreerde partner; b. degene die op hetzelfde woonadres als de
       belanghebbende staat ingeschreven in de gemeentelijke basisadministratie persoonsgegevens en: 1°. voor de
@@ -121,7 +121,7 @@ articles:
               subject: $partnerschap_type
               value: $geldige_partnertypen
   - number: '4'
-    text: |-
+    text: >-
       Artikel 4. Kind 1. Kind is de bloedverwant of aanverwant in de neergaande lijn van de belanghebbende of zijn
       partner, die in belangrijke mate wordt onderhouden door de belanghebbende of zijn partner en op hetzelfde woonadres
       als de belanghebbende staat ingeschreven in de gemeentelijke basisadministratie persoonsgegevens. Met een
@@ -135,14 +135,14 @@ articles:
       gesteld krachtens [artikel 1.5 van de Wet inkomstenbelasting 2001](jci1.3:c:BWBR0011353&artikel=1.5) .
     url: https://wetten.overheid.nl/BWBR0018472/2025-01-01#Artikel4
   - number: '5'
-    text: |-
+    text: >-
       Artikel 5. Tijdvak partnerschap en medebewonerschap Voor de toepassing van deze wet en de daarop berustende
       bepalingen, alsmede voor de toepassing van inkomensafhankelijke regelingen, wordt met de aanwezigheid van een
       partner of medebewoner geen rekening gehouden in de kalendermaand waarin het partnerschap of medebewonerschap
       aanvangt of eindigt.
     url: https://wetten.overheid.nl/BWBR0018472/2025-01-01#Artikel5
   - number: '6'
-    text: |-
+    text: >-
       Artikel 6. Gelijkstelling met gemeentelijke basisadministratie persoonsgegevens 1. Voor de toepassing van deze wet
       en de daarop berustende bepalingen wordt met de gemeentelijke basisadministratie persoonsgegevens gelijkgesteld een
       daarmee naar aard en strekking overeenkomende administratie buiten Nederland. 2. Bij regeling van Onze Minister in
@@ -155,7 +155,7 @@ articles:
       toepassing van het tweede en derde lid wordt naar de omstandigheden beoordeeld waar iemand woont.
     url: https://wetten.overheid.nl/BWBR0018472/2025-01-01#Artikel6
   - number: '7'
-    text: |-
+    text: >-
       Artikel 7. Draagkracht 1. Ter bepaling van de draagkracht voor de toepassing van een inkomensafhankelijke regeling
       wordt het toetsingsinkomen, bedoeld in artikel 8. , van de belanghebbende en dat van zijn partner in aanmerking
       genomen. 2. Indien in een inkomensafhankelijke regeling is bepaald dat naast de draagkracht van de belanghebbende
@@ -179,7 +179,7 @@ articles:
       2001](jci1.3:c:BWBR0011353&artikel=10.2) van overeenkomstige toepassing.
     url: https://wetten.overheid.nl/BWBR0018472/2025-01-01#Artikel7
   - number: '8'
-    text: |-
+    text: >-
       Artikel 8. Toetsingsinkomen 1. Toetsingsinkomen is: a. indien over het berekeningsjaar een aanslag
       inkomstenbelasting is of wordt vastgesteld: het verzamelinkomen, zoals dat in die aanslag is opgenomen; b. indien
       over het berekeningsjaar geen aanslag inkomstenbelasting is of wordt vastgesteld: het belastbare loon, zoals dat
@@ -245,7 +245,7 @@ articles:
                 - $verzamelinkomen
                 - $buitenlands_inkomen
   - number: '9'
-    text: |-
+    text: >-
       Artikel 9. Wijziging status vreemdelingen; partner of medebewoner is vreemdeling 1. Indien aan een vreemdeling
       tijdens een rechtmatig verblijf als bedoeld in [artikel 8, onderdelen a tot en met e, en l, van de Vreemdelingenwet
       2000](jci1.3:c:BWBR0011823&artikel=8) een tegemoetkoming is toegekend, heeft de omstandigheid dat hij aansluitend
@@ -261,7 +261,7 @@ articles:
       2000](jci1.3:c:BWBR0011823&artikel=8) .
     url: https://wetten.overheid.nl/BWBR0018472/2025-01-01#Artikel9
   - number: '10'
-    text: |-
+    text: >-
       Artikel 10. Uitoefening rechten door minderjarigen 1. Een minderjarige is bekwaam de rechtshandelingen te
       verrichten die noodzakelijk zijn om een tegemoetkoming te verkrijgen. Hij is voorts bekwaam de rechtshandelingen te
       verrichten die noodzakelijk zijn met betrekking tot de uitoefening, onderscheidenlijk de nakoming van de voor hem
@@ -271,14 +271,14 @@ articles:
       overleden.
     url: https://wetten.overheid.nl/BWBR0018472/2025-01-01#Artikel10
   - number: '11'
-    text: |-
+    text: >-
       Artikel 11. Toepassingsgebied 1. De bepalingen van dit hoofdstuk gelden voor de inkomensafhankelijke regelingen
       waarvan de uitvoering bij die regeling is opgedragen aan de Belastingdienst/Toeslagen. 2. Onder
       Belastingdienst/Toeslagen wordt verstaan: het organisatieonderdeel van de rijksbelastingdienst dat is belast met
       het toekennen, uitbetalen en terugvorderen van tegemoetkomingen.
     url: https://wetten.overheid.nl/BWBR0018472/2025-01-01#Artikel11
   - number: '12'
-    text: |-
+    text: >-
       Artikel 12. Uitzonderingen op de Algemene wet bestuursrecht Voor de toepassing van dit hoofdstuk blijft [titel 4.2
       van de Algemene wet bestuursrecht](jci1.3:c:BWBR0005537&titeldeel=4.2) buiten toepassing en zijn [artikel
       3:40](jci1.3:c:BWBR0005537&artikel=3:40) en de [hoofdstukken 4](jci1.3:c:BWBR0005537&hoofdstuk=4) ,
@@ -287,19 +287,19 @@ articles:
       32. .
     url: https://wetten.overheid.nl/BWBR0018472/2025-01-01#Artikel12
   - number: '13'
-    text: |-
+    text: >-
       Artikel 13. Gebruik sociaal-fiscaalnummer De Belastingdienst/Toeslagen maakt voor de uitvoering van deze wet
       gebruik van het sociaal-fiscaalnummer.
     url: https://wetten.overheid.nl/BWBR0018472/2025-01-01#Artikel13
   - number: '14'
-    text: |-
+    text: >-
       Artikel 14. Toekennen tegemoetkoming 1. Een tegemoetkoming wordt op aanvraag toegekend door de
       Belastingdienst/Toeslagen. 2. Indien partners een gezamenlijke aanspraak op een tegemoetkoming hebben, wordt de
       tegemoetkoming uitsluitend toegekend aan de aanvrager. 3. Het bedrag van de tegemoetkoming wordt rekenkundig
       afgerond op hele euro’s. 4. Een tegemoetkoming wordt niet toegekend indien deze minder dan € 24. zou bedragen.
     url: https://wetten.overheid.nl/BWBR0018472/2025-01-01#Artikel14
   - number: '15'
-    text: |-
+    text: >-
       Artikel 15. Aanvraag tegemoetkoming 1. Een aanvraag om een tegemoetkoming met betrekking tot een berekeningsjaar
       kan tot 1. april van het jaar volgend op het berekeningsjaar worden ingediend bij de Belastingdienst/Toeslagen. 2.
       Indien de belanghebbende een partner heeft, wordt de aanvraag mede ondertekend door de partner. 3. Indien in een
@@ -318,7 +318,7 @@ articles:
       beide kamers der Staten-Generaal is overgelegd.
     url: https://wetten.overheid.nl/BWBR0018472/2025-01-01#Artikel15
   - number: '16'
-    text: |-
+    text: >-
       Artikel 16. Voorschot op tegemoetkoming 1. Indien de tegemoetkoming naar verwachting niet binnen acht weken na
       ontvangst van de aanvraag zal worden toegekend, verleent de Belastingdienst/Toeslagen de belanghebbende een
       voorschot tot het bedrag waarop de tegemoetkoming vermoedelijk zal worden vastgesteld. 2. Ingeval de belanghebbende
@@ -331,7 +331,7 @@ articles:
       5. Een herziening van het voorschot kan leiden tot een terug te vorderen bedrag.
     url: https://wetten.overheid.nl/BWBR0018472/2025-01-01#Artikel16
   - number: '17'
-    text: |-
+    text: >-
       Artikel 17. Na voorschot melding wijziging omstandigheden 1. Indien een voorschot op de tegemoetkoming is verleend
       en er een relevante wijziging optreedt in de omstandigheden die van belang zijn voor de beoordeling van de
       aanspraak op of de bepaling van de hoogte van de tegemoetkoming, is de belanghebbende gehouden die wijziging te
@@ -341,7 +341,7 @@ articles:
       melding betrekking heeft op een medebewoner, wordt de melding mede ondertekend door die medebewoner.
     url: https://wetten.overheid.nl/BWBR0018472/2025-01-01#Artikel17
   - number: '18'
-    text: |-
+    text: >-
       Artikel 18. Verzoeken van Belastingdienst/Toeslagen tot informatieverstrekking 1. Een belanghebbende, een partner
       en een medebewoner verstrekken de Belastingdienst/Toeslagen desgevraagd alle gegevens en inlichtingen die voor de
       beoordeling van de aanspraak op of de bepaling van de hoogte van de tegemoetkoming van belang kunnen zijn. 2. De
@@ -352,7 +352,7 @@ articles:
       de Belastingdienst/Toeslagen ambtshalve de hoogte van de tegemoetkoming.
     url: https://wetten.overheid.nl/BWBR0018472/2025-01-01#Artikel18
   - number: '19'
-    text: |-
+    text: >-
       Artikel 19. Beslistermijn toekenning tegemoetkoming 1. Indien ten name van de belanghebbende, zijn partner of een
       medebewoner over het berekeningsjaar een aanslag inkomstenbelasting wordt vastgesteld, kent de
       Belastingdienst/Toeslagen de tegemoetkoming met betrekking tot dat berekeningsjaar toe binnen acht weken na de
@@ -364,7 +364,7 @@ articles:
       noemen van een redelijke termijn waarbinnen toekenning zal plaatsvinden.
     url: https://wetten.overheid.nl/BWBR0018472/2025-01-01#Artikel19
   - number: '20'
-    text: |-
+    text: >-
       Artikel 20. Herziening tegemoetkoming wegens wijziging fiscale gegevens na toekenning 1. Indien na de toekenning
       van de tegemoetkoming uit een wijziging van een verzamelinkomen of belastbaar loon of uit een eerste vaststelling
       van een verzamelinkomen blijkt dat de tegemoetkoming tot een te hoog of te laag bedrag is toegekend, herziet de
@@ -375,7 +375,7 @@ articles:
       leiden tot een uit te betalen bedrag doch ook tot een terug te vorderen bedrag.
     url: https://wetten.overheid.nl/BWBR0018472/2025-01-01#Artikel20
   - number: '21'
-    text: |-
+    text: >-
       Artikel 21. Herziening tegemoetkoming om andere reden 1. De Belastingdienst/Toeslagen kan een toegekende
       tegemoetkoming herzien: a. op grond van feiten of omstandigheden waarvan de dienst bij de toekenning redelijkerwijs
       niet op de hoogte kon zijn en op grond waarvan de tegemoetkoming vermoedelijk tot een te hoog bedrag is toegekend,
@@ -385,7 +385,7 @@ articles:
       herziening op grond van dit artikel kan leiden tot een terug te vorderen bedrag.
     url: https://wetten.overheid.nl/BWBR0018472/2025-01-01#Artikel21
   - number: '22'
-    text: |-
+    text: >-
       Artikel 22. Uitbetaling voorschot 1. Een voorschot dat wordt verleend vóór de aanvang van het berekeningsjaar
       waarop het voorschot betrekking heeft, wordt uitbetaald in 12. gelijke termijnen. De uitbetaling van de eerste
       termijn vindt plaats in de maand december voorafgaand aan het berekeningsjaar en elke volgende termijn telkens een
@@ -398,19 +398,19 @@ articles:
       wordt in één bedrag uitbetaald in de maand van dagtekening.
     url: https://wetten.overheid.nl/BWBR0018472/2025-01-01#Artikel22
   - number: '23'
-    text: |-
+    text: >-
       Artikel 23. Opschorten uitbetaling voorschot De Belastingdienst/Toeslagen kan de uitbetaling van een voorschot
       geheel of gedeeltelijk opschorten indien redelijkerwijs kan worden vermoed dat het voorschot ten onrechte of tot
       een te hoog bedrag is verleend. De belanghebbende wordt van de opschorting schriftelijk in kennis gesteld.
     url: https://wetten.overheid.nl/BWBR0018472/2025-01-01#Artikel23
   - number: '24'
-    text: |-
+    text: >-
       Artikel 24. Uitbetaling tegemoetkoming 1. Een tegemoetkoming wordt uitbetaald binnen vier weken na dagtekening van
       de beschikking. 2. Indien voorschotten zijn verleend, worden deze verrekend met de tegemoetkoming. 3. De in het
       tweede lid bedoelde verrekening kan leiden tot een terug te vorderen bedrag.
     url: https://wetten.overheid.nl/BWBR0018472/2025-01-01#Artikel24
   - number: '25'
-    text: |-
+    text: >-
       Artikel 25. Wijze van uitbetaling 1. Uitbetaling van een voorschot of een tegemoetkoming geschiedt door de
       Belastingdienst/Toeslagen door middel van een bijschrijving op een ten name van de belanghebbende of diens partner
       bestaande bankrekening, bestemd voor girale betaling, tenzij daartoe door de belanghebbende een andere rekening is
@@ -418,14 +418,14 @@ articles:
       rekening als bedoeld in het eerste lid.
     url: https://wetten.overheid.nl/BWBR0018472/2025-01-01#Artikel25
   - number: '26'
-    text: |-
+    text: >-
       Artikel 26. Terugvordering is verschuldigd door belanghebbende Indien een herziening van een tegemoetkoming of een
       herziening van een voorschot leidt tot een terug te vorderen bedrag dan wel een verrekening van een voorschot met
       een tegemoetkoming daartoe leidt, is de belanghebbende het bedrag van de terugvordering in zijn geheel
       verschuldigd.
     url: https://wetten.overheid.nl/BWBR0018472/2025-01-01#Artikel26
   - number: '27'
-    text: |-
+    text: >-
       Artikel 27. Rente bij beschikkingen na een half jaar na berekeningsjaar 1. Over uit te betalen bedragen wordt rente
       vergoed en over terug te vorderen bedragen wordt rente in rekening gebracht. 2. De rente wordt enkelvoudig berekend
       over het tijdvak dat aanvangt op 1. juli van het jaar volgend op het berekeningsjaar en eindigt op de dag van de
@@ -434,7 +434,7 @@ articles:
       van de Algemene wet inzake rijksbelastingen](jci1.3:c:BWBR0002320&artikel=30f) .
     url: https://wetten.overheid.nl/BWBR0018472/2025-01-01#Artikel27
   - number: '28'
-    text: |-
+    text: >-
       Artikel 28. Betalingstermijn van twee maanden bij terugvordering 1. De belanghebbende heeft de verplichting om het
       bedrag van een terugvordering alsmede de op de voet van artikel 27. verschuldigde rente binnen twee maanden na de
       dagtekening van de beschikking tot terugvordering te betalen aan de Belastingdienst/Toeslagen. 2. Het bedrag van
@@ -442,13 +442,13 @@ articles:
       Algemene termijnenwet is niet van toepassing op de in dit artikel gestelde termijnen.
     url: https://wetten.overheid.nl/BWBR0018472/2025-01-01#Artikel28
   - number: '29'
-    text: |-
+    text: >-
       Artikel 29. Rente bij te late betaling terugvordering Bij overschrijding van de in artikel 28. bedoelde
       betalingstermijn is rente verschuldigd met overeenkomstige toepassing van de [artikelen
       28](jci1.3:c:BWBR0004770&artikel=28) en [29 van de Invorderingswet 1990](jci1.3:c:BWBR0004770&artikel=29) .
     url: https://wetten.overheid.nl/BWBR0018472/2025-01-01#Artikel29
   - number: '30'
-    text: |-
+    text: >-
       Artikel 30. Verrekening 1. De Belastingdienst/Toeslagen kan een door de belanghebbende verschuldigd bedrag aan
       terugvordering verrekenen met een aan hem uit te betalen tegemoetkoming of voorschot daarop, een en ander ongeacht
       de inkomensafhankelijke regeling die het betreft en ongeacht het berekeningsjaar. 2. De Belastingdienst/Toeslagen
@@ -460,7 +460,7 @@ articles:
       worden betrokken.
     url: https://wetten.overheid.nl/BWBR0018472/2025-01-01#Artikel30
   - number: '31'
-    text: |-
+    text: >-
       Artikel 31. Uitstel van betaling bij terugvordering 1. De Belastingdienst/Toeslagen kan onder voorwaarden aan de
       belanghebbende voor een bepaalde tijd bij beschikking uitstel van betaling verlenen. Gedurende het uitstel vangt de
       in artikel 32. bedoelde dwanginvordering niet aan, of wordt deze geschorst. Het uitstel kan tussentijds bij
@@ -468,7 +468,7 @@ articles:
       van uitstel van betaling.
     url: https://wetten.overheid.nl/BWBR0018472/2025-01-01#Artikel31
   - number: '32'
-    text: |-
+    text: >-
       Artikel 32. Dwanginvordering bij terugvordering 1. Indien de belanghebbende het bedrag van de terugvordering,
       daaronder begrepen de in artikel 27. bedoelde rente alsmede bestuurlijke boeten, niet binnen de gestelde termijn
       betaalt, maant de Belastingdienst/Toeslagen hem schriftelijk aan om alsnog binnen tien dagen na de dagtekening van
@@ -490,7 +490,7 @@ articles:
       overeenkomstige toepassing van [artikel 27. van de Invorderingswet 1990](jci1.3:c:BWBR0004770&artikel=27) .
     url: https://wetten.overheid.nl/BWBR0018472/2025-01-01#Artikel32
   - number: '33'
-    text: |-
+    text: >-
       Artikel 33. Aansprakelijkheid bij terugvordering 1. De partner van de belanghebbende is hoofdelijk aansprakelijk
       voor een door de belanghebbende verschuldigd bedrag aan terugvordering, daaronder begrepen de in de artikelen 27.
       en 29. bedoelde rente alsmede de kosten van dwanginvordering. De partner is niet aansprakelijk voor een aan de
@@ -500,7 +500,7 @@ articles:
       van overeenkomstige toepassing.
     url: https://wetten.overheid.nl/BWBR0018472/2025-01-01#Artikel33
   - number: '34'
-    text: |-
+    text: >-
       Artikel 34. Aanvullende bepalingen inzake invordering van een terugvordering 1. De Belastingdienst/Toeslagen
       beschikt ten behoeve van de invordering naast de bevoegdheden ingevolge deze wet, ook over de bevoegdheden die een
       schuldeiser heeft op grond van enige andere wettelijke bepaling. 2. Tot het verrichten van de bij of krachtens een
@@ -513,20 +513,20 @@ articles:
       artikel 27. en de bestuurlijke boete, naar evenredigheid.
     url: https://wetten.overheid.nl/BWBR0018472/2025-01-01#Artikel34
   - number: '35'
-    text: |-
+    text: >-
       Artikel 35. Aanvang bezwaartermijn In afwijking van [artikel 6:8 van de Algemene wet
       bestuursrecht](jci1.3:c:BWBR0005537&artikel=6:8) vangt de termijn voor het instellen van bezwaar aan op de dag na
       die van dagtekening van de beschikking, tenzij de dag van dagtekening gelegen is vóór de dag van de bekendmaking.
     url: https://wetten.overheid.nl/BWBR0018472/2025-01-01#Artikel35
   - number: '36'
-    text: |-
+    text: >-
       Artikel 36. Aanvang beroepstermijn In afwijking van [artikel 6:8 van de Algemene wet
       bestuursrecht](jci1.3:c:BWBR0005537&artikel=6:8) vangt de termijn voor het instellen van beroep tegen een uitspraak
       op bezwaar aan op de dag na die van dagtekening van de uitspraak, tenzij de dag van dagtekening is gelegen vóór de
       dag van de bekendmaking.
     url: https://wetten.overheid.nl/BWBR0018472/2025-01-01#Artikel36
   - number: '37'
-    text: |-
+    text: >-
       Artikel 37. Bezwaar inzake meer beschikkingen vervat in één geschrift 1. Een bezwaar tegen de toekenning of
       herziening van een tegemoetkoming wordt, tenzij uit het bezwaarschrift het tegendeel blijkt, geacht mede te zijn
       gericht tegen de toekenning of herziening van andere tegemoetkomingen over hetzelfde berekeningsjaar die bij
@@ -537,7 +537,7 @@ articles:
       gevallen vervatten in één geschrift.
     url: https://wetten.overheid.nl/BWBR0018472/2025-01-01#Artikel37
   - number: '38'
-    text: |-
+    text: >-
       Artikel 38. Informatieverstrekking aan de Belastingdienst/Toeslagen 1. Openbare lichamen en rechtspersonen die bij
       of krachtens een bijzondere wet rechtspersoonlijkheid hebben verkregen, de onder hen ressorterende instellingen en
       diensten, alsmede lichamen die hoofdzakelijk uitvoering geven aan het beleid van het Rijk, en bij algemene
@@ -555,14 +555,14 @@ articles:
       natuurlijke personen, maat- en vennootschappen, verenigingen, instellingen en diensten.
     url: https://wetten.overheid.nl/BWBR0018472/2025-01-01#Artikel38
   - number: 38a
-    text: |-
+    text: >-
       Artikel 38a Gegevensverstrekking door de Belastingdienst/Toeslagen De Belastingdienst/Toeslagen kan onder bij of
       krachtens algemene maatregel van bestuur te bepalen voorwaarden ten behoeve van bij algemene maatregel van bestuur
       aan te wijzen voorzieningen die de dienstverlening voortvloeiende uit de uitvoering van deze wet verbeteren,
       gegevens verstrekken die voor deze dienstverlening nodig zijn.
     url: https://wetten.overheid.nl/BWBR0018472/2025-01-01#Artikel38a
   - number: '39'
-    text: |-
+    text: >-
       Artikel 39. Informatie-uitwisseling 1. De Belastingdienst/Toeslagen en de inspecteur en ontvanger, bedoeld in
       [artikel 2, derde lid, onderdeel b, van de Algemene wet inzake rijksbelastingen](jci1.3:c:BWBR0002320&artikel=2) ,
       wisselen de gegevens en inlichtingen uit die nodig zijn voor de uitvoering van deze wet en voor de heffing en
@@ -574,7 +574,7 @@ articles:
       Belastingdienst/Toeslagen.
     url: https://wetten.overheid.nl/BWBR0018472/2025-01-01#Artikel39
   - number: '40'
-    text: |-
+    text: >-
       Artikel 40. Boete bij niet, niet tijdige of onjuiste informatieverstrekking door belanghebbenden 1. Indien de
       belanghebbende, zijn partner of een medebewoner gehouden is tot het verstrekken van gegevens of inlichtingen, en
       hij deze niet dan wel niet binnen de ingevolge artikel 18, derde lid , gestelde termijn verstrekt, kan de
@@ -594,7 +594,7 @@ articles:
       tegemoetkoming betrekking heeft.
     url: https://wetten.overheid.nl/BWBR0018472/2025-01-01#Artikel40
   - number: '41'
-    text: |-
+    text: >-
       Artikel 41. Boete bij niet, niet tijdige of onjuiste informatieverstrekking door derden 1. Indien een bij algemene
       maatregel van bestuur aangewezen natuurlijke persoon, maat- of vennootschap, vereniging of andere rechtspersoon,
       instelling of dienst als bedoeld in artikel 38, eerste lid , op grond van artikel 38. gehouden is tot het
@@ -614,14 +614,14 @@ articles:
       termijn is verstreken.
     url: https://wetten.overheid.nl/BWBR0018472/2025-01-01#Artikel41
   - number: '42'
-    text: |-
+    text: >-
       Artikel 42. Vrijwillige verbetering Indien de belanghebbende, zijn partner of een medebewoner de
       Belastingdienst/Toeslagen alsnog de juiste en volledige gegevens en inlichtingen verstrekt voordat hij weet of
       redelijkerwijs moet vermoeden dat de Belastingdienst/Toeslagen met de onjuistheid of onvolledigheid bekend is of
       bekend zal worden, wordt aan hem niet de boete, bedoeld in artikel 40. , opgelegd.
     url: https://wetten.overheid.nl/BWBR0018472/2025-01-01#Artikel42
   - number: '43'
-    text: |-
+    text: >-
       Artikel 43. Toezichthouders 1. Met het toezicht op de naleving van het bepaalde bij of krachtens deze wet zijn
       belast de bij besluit van Onze Ministers wie het aangaat, aangewezen ambtenaren. 2. De toezichthouder beschikt niet
       over de bevoegdheden, genoemd in de [artikelen 5:15](jci1.3:c:BWBR0005537&artikel=5:15) ,
@@ -630,7 +630,7 @@ articles:
       mededeling gedaan door plaatsing in de Staatscourant.
     url: https://wetten.overheid.nl/BWBR0018472/2025-01-01#Artikel43
   - number: '44'
-    text: |-
+    text: >-
       Artikel 44. Opsporingsambtenaren 1. Met de opsporing van de feiten omschreven in de [artikelen 225. tot en met
       227b](jci1.3:c:BWBR0001854&artikel=225) , [447c](jci1.3:c:BWBR0001854&artikel=447c) en [447d van het Wetboek van
       Strafrecht](jci1.3:c:BWBR0001854&artikel=447d) , voor zover het feit voor de toepassing van deze wet van belang is,
@@ -642,7 +642,7 @@ articles:
       het eerste lid wordt mededeling gedaan door plaatsing in de Staatscourant.
     url: https://wetten.overheid.nl/BWBR0018472/2025-01-01#Artikel44
   - number: '45'
-    text: |-
+    text: >-
       Artikel 45. Beslagverbod 1. Een tegemoetkoming is niet vatbaar voor vervreemding, verpanding, belening of beslag,
       waaronder begrepen beslag ingevolge faillissement of toepassing van de schuldsaneringsregeling natuurlijke
       personen, tenzij het betreft beslag wegens: a. een vordering tot nakoming van een betalingsverplichting wegens een
@@ -651,25 +651,25 @@ articles:
       inkomensafhankelijke regeling. 2. Elk beding dat strijdt met het eerste lid is nietig.
     url: https://wetten.overheid.nl/BWBR0018472/2025-01-01#Artikel45
   - number: '46'
-    text: |-
+    text: >-
       Artikel 46. Samenloop met buitenlandse tegemoetkomingen Bij algemene maatregel van bestuur kunnen regels worden
       gesteld ter voorkoming of beperking van samenloop van tegemoetkomingen met naar aard en strekking daarmee
       overeenkomende tegemoetkomingen op grond van wetgeving van een andere mogendheid.
     url: https://wetten.overheid.nl/BWBR0018472/2025-01-01#Artikel46
   - number: '47'
-    text: |-
+    text: >-
       Artikel 47. Hardheidsclausule Bij regeling van Onze Minister in overeenstemming met Onze Ministers wie het aangaat
       kan een van deze wet afwijkende maatregel worden getroffen voor groepen van gevallen waarin toepassing van artikel
       7, derde of vierde lid , leidt tot een onbillijkheid van overwegende aard.
     url: https://wetten.overheid.nl/BWBR0018472/2025-01-01#Artikel47
   - number: '48'
-    text: |-
+    text: >-
       Artikel 48. Evaluatie Onze Minister zendt, in overeenstemming met Onze Ministers wie het mede aangaat, binnen drie
       jaar na de inwerkingtreding van deze wet, en vervolgens vijfjaarlijks, aan de Staten-Generaal een verslag over de
       doeltreffendheid en de effecten van deze wet in de praktijk.
     url: https://wetten.overheid.nl/BWBR0018472/2025-01-01#Artikel48
   - number: '49'
-    text: |-
+    text: >-
       Artikel 49. Tijdelijke regeling wijziging van omstandigheden en wijziging leeftijd Voor de berekeningsjaren 2006,
       2007. en 2008. wordt voor de beoordeling van de aanspraak op of de bepaling van de hoogte van een tegemoetkoming op
       grond van een inkomensafhankelijke regeling als bedoeld in artikel 11, eerste lid , een wijziging in de
@@ -678,7 +678,7 @@ articles:
       5. buiten toepassing.
     url: https://wetten.overheid.nl/BWBR0018472/2025-01-01#Artikel49
   - number: '50'
-    text: |-
+    text: >-
       Artikel 50. Inwerkingtreding Deze wet treedt in werking op 1. september 2005. en geldt voor berekeningsjaren die
       aanvangen op of na 1. januari 2006.
     url: https://wetten.overheid.nl/BWBR0018472/2025-01-01#Artikel50

--- a/corpus/regulation/nl/wet/kieswet/2025-01-01.yaml
+++ b/corpus/regulation/nl/wet/kieswet/2025-01-01.yaml
@@ -101,7 +101,7 @@ articles:
                               subject: $is_in_openbare_dienst_bes
                               value: true
   - number: B5
-    text: |-
+    text: >-
       Van het kiesrecht zijn uitgesloten zij die bij onherroepelijke rechterlijke uitspraak van het kiesrecht zijn
       ontzet.
     url: https://wetten.overheid.nl/BWBR0004627/2025-02-12#AfdelingII_HoofdstukB_ArtikelB5

--- a/corpus/regulation/nl/wet/participatiewet/2022-03-15.yaml
+++ b/corpus/regulation/nl/wet/participatiewet/2022-03-15.yaml
@@ -323,14 +323,17 @@ articles:
       van dit artikel van toepassing zijnde norm voor de echtgenoot van 21 jaar of ouder.
     url: https://wetten.overheid.nl/BWBR0015703/2022-03-15#Artikel22a
   - number: '23'
-    text: |-
+    text: >-
       **Normen in inrichting**
+
 
       1. Bij een verblijf in een inrichting is de norm per kalendermaand, indien het betreft:    a. een alleenstaande of
       een alleenstaande ouder: € 345,68;    b. gehuwden: € 537,69.
 
+
       2. Het bedrag van de norm, bedoeld in het eerste lid, wordt verhoogd met:    a. voor een alleenstaande of een
       alleenstaande ouder € 34,00;    b. voor gehuwden € 79,00.
+
 
       3. Indien een van de gehuwden in een inrichting verblijft, is de norm de som van de normen die voor ieder van hen
       als alleenstaande of alleenstaande ouder zouden gelden.
@@ -349,22 +352,27 @@ articles:
     url: https://wetten.overheid.nl/BWBR0015703/2022-03-15#Artikel24
 
   - number: '43'
-    text: |-
+    text: >-
       **Vaststelling op aanvraag**
+
 
       1. Het college stelt het recht op bijstand op schriftelijke aanvraag of, indien een schriftelijke aanvraag niet
       mogelijk is, ambtshalve vast.
 
+
       2. De bijstand wordt door de echtgenoten gezamenlijk aangevraagd dan wel door een van hen met schriftelijke
       toestemming van de ander.
 
+
       3. Het college stelt het recht op bijstand ambtshalve vast indien een van de echtgenoten niet met de aanvraag
       instemt, doch bijstandsverlening, gezien de belangen van de overige gezinsleden, niettemin geboden is.
+
 
       4. Het college houdt, indien artikel 41, vierde lid, van toepassing is, bij de vaststelling van het recht op
       algemene bijstand rekening met de houding en gedragingen van de meerderjarige personen die ten tijde van de
       aanvraag van algemene bijstand jonger dan 27 jaar zijn gedurende de vier weken na de melding, bedoeld in artikel
       44.
+
 
       5. Indien artikel 41, vierde lid, niet van toepassing is, beoordeelt het college in ieder geval de houding en
       gedragingen gedurende de vier weken na de melding, bedoeld in artikel 44, van de meerderjarige personen die ten

--- a/corpus/regulation/nl/wet/penitentiaire_beginselenwet/2025-01-01.yaml
+++ b/corpus/regulation/nl/wet/penitentiaire_beginselenwet/2025-01-01.yaml
@@ -184,9 +184,10 @@ articles:
       e commissie, de benoeming en het ontslag van haar leden alsmede over de werkzaamheden van de maandcommissaris.
     url: https://wetten.overheid.nl/BWBR0009709/2025-01-01#Artikel7
   - number: '8'
-    text: |-
+    text: >-
       Artikel 8 1. Onze Minister bepaalt de bestemming van elke inrichting of afdeling ingevolge de artikelen 9 tot en met 14
       en stelt regels voor de plaatsing en overplaatsing van de gedetineerden.
+
 
       2. Onze Minister kan delen van een inrichting als afdeling met een aparte bestemming aanwijzen.
     url: https://wetten.overheid.nl/BWBR0009709/2025-01-01#Artikel8
@@ -1700,7 +1701,7 @@ articles:
       ng van deze wet.
     url: https://wetten.overheid.nl/BWBR0009709/2025-01-01#Artikel93
   - number: '94'
-    text: |-
+    text: >-
       Artikel 94 Deze wet treedt in werking op een bij koninklijk besluit te bepalen tijdstip. Bij koninklijk besluit kan een
       ander tijdstip worden vastgesteld waarop artikel 76 in werking treedt.
     url: https://wetten.overheid.nl/BWBR0009709/2025-01-01#Artikel94

--- a/corpus/regulation/nl/wet/wet_basisregistratie_personen/2025-02-12.yaml
+++ b/corpus/regulation/nl/wet/wet_basisregistratie_personen/2025-02-12.yaml
@@ -8,43 +8,58 @@ url: https://wetten.overheid.nl/BWBR0033715/2025-02-12
 name: '#wet_naam'
 articles:
   - number: '1.1'
-    text: |-
+    text: >-
       Artikel 1.1 In deze wet en de daarop berustende bepalingen wordt verstaan onder:
+
 
       a. *Onze Minister:* Onze Minister van Binnenlandse Zaken en Koninkrijksrelaties;
 
+
       b. *de basisregistratie:* de basisregistratie personen, bedoeld in artikel 1.2 ;
+
 
       c. *de persoonslijst:* het geheel van gegevens, bedoeld in artikel 2.7, eerste lid , en 2.69, eerste lid , over één
       persoon in de basisregistratie;
 
+
       d. *de inschrijving:* de opneming van een persoonslijst in de basisregistratie;
 
+
       e. *de ingeschrevene:* degene ten aanzien van wie een persoonslijst in de basisregistratie is opgenomen;
+
 
       f. *de ingezetene:* de ingeschrevene, die zijn adres heeft in een gemeente in Nederland, en op wiens persoonslijst
       niet het gegeven van zijn overlijden of van vertrek uit Nederland als actueel gegeven is opgenomen;
 
+
       g. *de systematische verstrekking van gegevens of het systematisch verstrekken van gegevens:* de verstrekking of
       het verstrekken van gegevens uit de basisregistratie, bedoeld in artikel 3.1, tweede lid ;
+
 
       h. *de bijhoudingsgemeente:* de gemeente waarvan het college van burgemeester en wethouders op grond van artikel
       1.4 verantwoordelijk is voor de bijhouding van de persoonslijst;
 
+
       i. *een vreemdeling:* degene die de Nederlandse nationaliteit niet bezit en niet op grond van een wettelijke
       bepaling als Nederlander wordt behandeld;
 
+
       j. *de aangifte van verblijf en adres:* de aangifte, bedoeld in artikel 2.38 ;
+
 
       k. *een beëdigde vertaler:* een vertaler als bedoeld in [artikel 1, onder d, van de Wet beëdigde tolken en
       vertalers](jci1.3:c:BWBR0022704&artikel=1) ;
 
+
       l. *de aangifte van adreswijziging:* de aangifte, bedoeld in artikel 2.39 ;
+
 
       m. *de aangifte van vertrek:* de aangifte, bedoeld in artikel 2.43 ;
 
+
       n. *een authentiek gegeven:* een in de basisregistratie opgenomen gegeven dat op grond van artikel 1.6 als
       authentiek wordt aangemerkt;
+
 
       o. *het woonadres:* - - 1° het adres waar betrokkene woont, waaronder begrepen het adres van een woning die zich in
       een voertuig of vaartuig bevindt, indien het voertuig of vaartuig een vaste stand- of ligplaats heeft, of, indien
@@ -57,107 +72,130 @@ articles:
       het adres waar, bij het ontbreken van een adres als bedoeld onder 1, betrokkene naar redelijke verwachting
       gedurende drie maanden ten minste twee derde van de tijd zal overnachten;
 
+
       p. *het briefadres:* het adres waar voor betrokkene bestemde geschriften in ontvangst worden genomen;
+
 
       q. *het adres:* het woonadres, dan wel bij het ontbreken hiervan of bij toepassing van artikel 2.40 of 2.41 , het
       briefadres;
 
+
       r. *de briefadresgever:* de natuurlijke persoon of rechtspersoon, bedoeld in artikel 2.42 , die een briefadres ter
       beschikking stelt;
 
+
       s. *het burgerservicenummer:* het nummer, bedoeld in [artikel 1, onder b, van de Wet algemene bepalingen
       burgerservicenummer](jci1.3:c:BWBR0022428&artikel=1) ;
+
 
       t. *een overheidsorgaan:* - - 1° een orgaan van een rechtspersoon die krachtens publiekrecht is ingesteld, of - 2°
       een ander persoon of college, met enig openbaar gezag bekleed; - 1° een orgaan van een rechtspersoon die krachtens
       publiekrecht is ingesteld, of - 2° een ander persoon of college, met enig openbaar gezag bekleed;
 
+
       u. *een derde:* elke natuurlijke persoon niet zijnde een overheidsorgaan of een ingeschrevene en elke rechtspersoon
       die niet krachtens publiekrecht is ingesteld, noch met enig openbaar gezag is bekleed;
 
+
       v. *openbare lichamen:* de openbare lichamen Bonaire, Sint Eustatius en Saba;
 
+
       w. *een inschrijfvoorziening:* een voorziening als bedoeld in artikel 2.64 ;
+
 
       x. *het Besluit bevolkingsboekhouding:* het Besluit bevolkingsboekhouding zoals dat gold op de laatste dag voor de
       intrekking van de Wet bevolkings- en verblijfsregisters.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel1.1
   - number: '1.2'
-    text: |-
+    text: >-
       Artikel 1.2 Er is een basisregistratie personen. De basisregistratie bevat persoonsgegevens over de ingezetenen van
       Nederland. De basisregistratie bevat persoonsgegevens over niet-ingezetenen voor zover deze wet daarin voorziet.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel1.2
   - number: '1.3'
-    text: |-
+    text: >-
       Artikel 1.3 1 De basisregistratie heeft tot doel overheidsorganen te voorzien van de in de registratie opgenomen
       gegevens, voor zover deze gegevens noodzakelijk zijn voor de vervulling van hun taak.
+
 
       2. De basisregistratie heeft mede tot doel derden te voorzien van de in de registratie opgenomen gegevens, in bij
       of krachtens deze wet aangewezen gevallen.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel1.3
   - number: '1.4'
-    text: |-
+    text: >-
       Artikel 1.4 1 Het college van burgemeester en wethouders is verantwoordelijk voor het bijhouden van
       persoonsgegevens in de basisregistratie overeenkomstig afdeling 1 van hoofdstuk 2 .
+
 
       2. Onze Minister is verantwoordelijk voor het bijhouden van persoonsgegevens in de basisregistratie overeenkomstig
       afdeling 2 van hoofdstuk 2 .
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel1.4
   - number: '1.5'
-    text: |-
+    text: >-
       Artikel 1.5 1 Onze Minister is verantwoordelijk voor de verstrekking van gegevens uit de basisregistratie die hij
       doet bij of krachtens hoofdstuk 3 .
+
 
       2. Het college van burgemeester en wethouders is verantwoordelijk voor de verstrekking van gegevens uit de
       basisregistratie die hij doet bij of krachtens hoofdstuk 3 .
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel1.5
   - number: '1.6'
-    text: |-
+    text: >-
       Artikel 1.6 Bij algemene maatregel van bestuur wordt bepaald welke van de algemene gegevens, bedoeld in de
       artikelen 2.7 en 2.69 , worden aangemerkt als authentieke gegevens.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel1.6
   - number: '1.7'
-    text: |-
+    text: >-
       Artikel 1.7 1 Het bestuursorgaan dat bij de vervulling van zijn taak informatie over een ingeschrevene nodig heeft
       die in de vorm van een authentiek gegeven beschikbaar is in de basisregistratie, gebruikt voor die informatie dat
       gegeven.
 
+
       2. Het eerste lid is niet van toepassing indien:
+
 
       a. bij het gegeven een aantekening als bedoeld in artikel 2.26 of 2.76 is geplaatst;
 
+
       b. het bestuursorgaan ten aanzien van het gegeven een mededeling als bedoeld in artikel 2.34, eerste lid , doet;
 
+
       c. bij wettelijk voorschrift anders is bepaald;
+
 
       d. een goede vervulling van de taak van het bestuursorgaan door de onverkorte toepassing van het eerste lid wordt
       belet.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel1.7
   - number: '1.8'
-    text: |-
+    text: >-
       Artikel 1.8 Een ingeschrevene aan wie door een bestuursorgaan een gegeven wordt gevraagd, waarop artikel 1.7,
       eerste lid , van toepassing is, behoeft dat gegeven niet mede te delen, behoudens voor zover het gegeven naar het
       oordeel van het bestuursorgaan noodzakelijk is voor een deugdelijke vaststelling van de identiteit van betrokkene.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel1.8
   - number: '1.9'
-    text: |-
+    text: >-
       Artikel 1.9 1 De basisregistratie bestaat uit gemeentelijke en centrale voorzieningen.
+
 
       2. Het college van burgemeester en wethouders is verantwoordelijk voor de gemeentelijke voorziening.
 
+
       3. Onze Minister is verantwoordelijk voor de centrale voorzieningen.
+
 
       4. Onze Minister draagt zorg voor een stelsel van berichtuitwisseling ten behoeve van de bijhouding en de
       raadpleging van de basisregistratie en de systematische verstrekking van gegevens.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel1.9
   - number: '1.10'
-    text: |-
+    text: >-
       Artikel 1.10 1 Bij of krachtens algemene maatregel van bestuur worden regels gesteld omtrent:
+
 
       a. de technische en administratieve inrichting en werking en de beveiliging van de basisregistratie;
 
+
       b. de uitwisseling van berichten tussen de centrale voorzieningen en de gemeentelijke voorzieningen en tussen de
       centrale voorzieningen en de overheidsorganen waaraan en derden aan wie systematisch gegevens worden verstrekt.
+
 
       2. De in het eerste lid bedoelde regels omvatten mede eisen omtrent de deugdelijke uitvoering van werkzaamheden, de
       beveiliging van gegevens en de bescherming van de persoonlijke levenssfeer, die een bewerker in acht moet nemen als
@@ -165,45 +203,52 @@ articles:
       verricht.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel1.10
   - number: '1.11'
-    text: |-
+    text: >-
       Artikel 1.11 1 Het college van burgemeester en wethouders draagt zorg dat de gemeentelijke voorziening functioneert
       overeenkomstig de regels, bedoeld in artikel 1.10 .
 
+
       2. Onze Minister draagt zorg dat de centrale voorzieningen functioneren overeenkomstig de regels, bedoeld in
       artikel 1.10 .
+
 
       3. Het overheidsorgaan waaraan of de derde aan wie systematisch gegevens worden verstrekt draagt zorg dat de
       uitwisseling van berichten in verband met de systematische verstrekking van gegevens van zijn kant geschiedt
       overeenkomstig de regels, bedoeld in artikel 1.10 .
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel1.11
   - number: '1.12'
-    text: |-
+    text: >-
       Artikel 1.12 1 Onze Minister kan een onderzoek verrichten om vast te stellen of een overheidsorgaan waaraan
       systematisch gegevens worden verstrekt, voldoet aan de regels, bedoeld in artikel 1.10 .
+
 
       2. Het eerste lid is niet van toepassing op organen van gemeenten, provincies of gemeenschappelijke regelingen
       waaraan zij deelnemen.
 
+
       3. Bij regeling van Onze Minister kan worden bepaald op welke wijze het overheidsorgaan medewerking verleent aan
       het onderzoek.
+
 
       4. Het eerste en derde lid zijn van overeenkomstige toepassing op een derde aan wie systematisch gegevens worden
       verstrekt.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel1.12
   - number: '1.13'
-    text: |-
+    text: >-
       Artikel 1.13 De [artikelen 49](jci1.3:c:BWBR0011468&artikel=49) en [50 van de Wet bescherming
       persoonsgegevens](jci1.3:c:BWBR0011468&artikel=50) zijn van overeenkomstige toepassing.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel1.13
   - number: '1.14'
-    text: |-
+    text: >-
       Artikel 1.14 1 De gemeenten en de overheidsorganen waaraan en derden aan wie op grond van artikel 3.2 , 3.3 , 3.13
       of 3.14 gegevens worden verstrekt of informatie ter beschikking wordt gesteld, dragen bij in de kosten in verband
       met de uitvoering van deze wet. Indien een van deze betrokkenen geen rechtspersoonlijkheid bezit, komt de bijdrage
       ten laste van de rechtspersoon waartoe de betrokkene behoort.
 
+
       2. Bij algemene maatregel van bestuur wordt bepaald welke categorieën van kosten het betreft en worden de
       grondslagen bepaald van de bijdragen van de betrokkenen.
+
 
       3. Bij of krachtens algemene maatregel van bestuur worden nadere regels gesteld omtrent de vaststelling en de
       betaling van de bijdragen. Daarbij kan worden bepaald dat Onze Minister het in rekening te brengen bedrag op nul
@@ -211,43 +256,52 @@ articles:
       Koninkrijksrelaties die in de plaats treedt van de bijdrage van de betrokkene.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel1.14
   - number: '1.15'
-    text: |-
+    text: >-
       Artikel 1.15 1 Onze Minister overlegt periodiek met representatieve vertegenwoordigingen van de gemeenten, van de
       aangewezen bestuursorganen als bedoeld in artikel 2.65 en van de overheidsorganen en derden aan wie op grond van
       artikel 3.2 , 3.3 of 3.13 gegevens uit de basisregistratie worden verstrekt.
 
+
       2. Alle onderwerpen die bij of krachtens deze wet worden geregeld, lenen zich voor overleg. In ieder geval wordt
       overleg gepleegd over:
 
+
       a. wijzigingen in het bepaalde bij of krachtens deze wet;
+
 
       b. de uitgangspunten van het te voeren kwaliteitsbeleid;
 
+
       c. de uitgangspunten van het uitvoeren van artikel 1.14 .
+
 
       3. Onze Minister kan met betrekking tot het overleg nadere regels stellen.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel1.15
   - number: '2.1'
-    text: |-
+    text: >-
       Artikel 2.1 1 Deze afdeling is van toepassing op personen die als ingezetene in de basisregistratie zijn of worden
       ingeschreven en op ingeschrevenen die op het moment van hun overlijden ingezetene waren.
+
 
       2. Met betrekking tot de ingeschrevene die geen ingezetene meer is, worden krachtens deze afdeling geen nieuwe
       algemene gegevens opgenomen.
 
+
       3. In afwijking van het eerste of tweede lid worden gegevens opgenomen krachtens deze afdeling, voor zover:
 
+
       a. het feiten betreft die zich hebben voorgedaan in de tijd dat de ingeschrevene nog ingezetene was, of
+
 
       b. dit bij algemene maatregel van bestuur is bepaald.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.1
   - number: '2.2'
-    text: |-
+    text: >-
       Artikel 2.2 De inschrijving in de basisregistratie geschiedt op grond van de geboorteakte, de aangifte van de
       betrokkene of ambtshalve.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.2
   - number: '2.3'
-    text: |-
+    text: >-
       Artikel 2.3 Op grond van de geboorteakte, opgemaakt door een ambtenaar van de burgerlijke stand in Nederland,
       waarop als geboorteplaats een plaats in Nederland is vermeld, geschiedt de inschrijving van het kind dat niet reeds
       is ingeschreven en waarvan de moeder op de geboortedatum van het kind als ingezetene is ingeschreven. De
@@ -255,24 +309,27 @@ articles:
       ingezetene is ingeschreven.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.3
   - number: '2.4'
-    text: |-
+    text: >-
       Artikel 2.4 1 Op grond van zijn aangifte van verblijf en adres wordt degene die rechtmatig verblijf geniet, niet in
       de basisregistratie is ingeschreven en naar redelijke verwachting gedurende een half jaar ten minste twee derde van
       de tijd in Nederland verblijf zal houden, ingeschreven in de basisregistratie door het college van burgemeester en
       wethouders van de gemeente waar hij zijn adres heeft.
 
+
       2. Indien een persoon als bedoeld in het eerste lid in gebreke is met het doen van aangifte, draagt het college
       ambtshalve zorg voor de inschrijving. Het college van burgemeester en wethouders is bevoegd de betrokkene alsnog op
       grond van zijn aangifte in te schrijven, indien de aangifte na afloop van de aangiftetermijn geschiedt.
 
+
       3. Inschrijving geschiedt niet dan nadat de identiteit van de betrokkene deugdelijk is vastgesteld.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.4
   - number: '2.5'
-    text: |-
+    text: >-
       Artikel 2.5 1 Inschrijving op grond van artikel 2.4 van een persoon die komt vanuit Aruba, Curaçao, Sint Maarten,
       of een van de openbare lichamen, vindt niet plaats, dan nadat hij een hem betreffend verhuisbericht, verstrekt door
       de verantwoordelijke voor de verwerking van gegevens in de basisadministratie in Aruba, Curaçao, Sint Maarten of
       een van de openbare lichamen waar hij laatstelijk als ingezetene was ingeschreven, heeft overgelegd.
+
 
       2. In het geval dat anderszins blijkt dat het vertrek van de betrokken persoon is verwerkt in de basisadministratie
       in Aruba, Curaçao, Sint Maarten of een van de openbare lichamen waar hij laatstelijk als ingezetene was
@@ -280,21 +337,25 @@ articles:
       burgemeester en wethouders afwijken van het bepaalde in het eerste lid.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.5
   - number: '2.6'
-    text: |-
+    text: >-
       Artikel 2.6 1 Bij algemene maatregel van bestuur worden categorieën bepaald van personen, die in verband met hun
       bijzondere verblijfsrechtelijke positie niet in aanmerking komen voor inschrijving.
+
 
       2. Bij of krachtens de maatregel kunnen regels worden gesteld ten aanzien van een persoon die behoort tot een
       categorie als bedoeld in het eerste lid, omtrent:
 
+
       a. het niet-inschrijven van de persoon;
+
 
       b. het aanmerken van de persoon die reeds is ingeschreven als een ingeschrevene die wegens zijn vertrek uit
       Nederland niet als ingezetene is ingeschreven.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.6
   - number: '2.7'
-    text: |-
+    text: >-
       Artikel 2.7 1 In de basisregistratie worden over de ingeschrevene uitsluitend de volgende gegevens opgenomen:
+
 
       a. algemene gegevens: - 1° gegevens over de burgerlijke staat waar het betreft de naam, de geboorte, het geslacht,
       de ouders, het huwelijk, dan wel geregistreerd partnerschap en eerdere huwelijken of eerder geregistreerde
@@ -326,6 +387,7 @@ articles:
       met de uitvoering van de [Kieswet](jci1.3:c:BWBR0004627) ; - 11° gegevens, noodzakelijk in verband met de
       uitvoering van de [Paspoortwet](jci1.3:c:BWBR0005212) .
 
+
       b. administratieve gegevens: - 1° gegevens in verband met de inschrijving en de wijziging van de
       bijhoudingsgemeente; - 2° gegevens ter aanduiding van akten en andere geschriften waaruit algemene gegevens zijn
       verkregen, dan wel van de rechtsgrond krachtens welke gegevens over het Nederlanderschap zijn opgenomen; - 3°
@@ -340,10 +402,13 @@ articles:
       onderzoek naar die onjuistheid of strijdigheid, alsmede andere gegevens, noodzakelijk in verband met de bijhouding
       van de basisregistratie; - 4° gegevens over de beperking van de verstrekking van gegevens aan derden.
 
+
       2. De algemene en administratieve gegevens worden nader bepaald bij of krachtens algemene maatregel van bestuur.
+
 
       3. Een algemeen gegeven dat is opgenomen, blijft opgenomen, behoudens het bepaalde in artikel 2.57 en behoudens de
       gegevens, bedoeld in het eerste lid, onder a, onderdelen 10° en 11°.
+
 
       4. Bij of krachtens algemene maatregel van bestuur worden de verwijdering en de vernietiging van de algemene
       gegevens, bedoeld in het eerste lid, onder a, onderdelen 10° en 11°, en de administratieve gegevens, bedoeld in het
@@ -372,37 +437,46 @@ articles:
               date_of_birth: $geboortedatum
               reference_date: $peildatum
   - number: '2.8'
-    text: |-
+    text: >-
       Artikel 2.8 1 De gegevens over de burgerlijke staat worden, indien zij feiten betreffen die zich in Nederland
       hebben voorgedaan, ontleend aan een geschrift als bedoeld onder a en bij gebreke hiervan aan een geschrift als
       bedoeld onder b:
 
+
       a. een akte over het desbetreffende feit, die is opgenomen in de registers van de burgerlijke stand in Nederland;
+
 
       b. een door de ambtenaar van de burgerlijke stand opgemaakte akte, een besluit, een in kracht van gewijsde gegane
       rechterlijke uitspraak of een notariële akte, over het desbetreffende feit.
+
 
       2. De gegevens over de burgerlijke staat worden, indien zij feiten betreffen die zich buiten Nederland hebben
       voorgedaan, ontleend aan een geschrift als bedoeld onder a, bij gebreke hiervan aan een geschrift als bedoeld onder
       b of c, bij gebreke ook hiervan aan een geschrift als bedoeld onder d en bij gebreke ten slotte ook hiervan aan een
       geschrift als bedoeld onder e:
 
+
       a. een akte over het desbetreffende feit, die is opgenomen in de registers van de Nederlandse burgerlijke stand;
+
 
       b. een in Nederland gedane rechterlijke uitspraak over het desbetreffende feit die in kracht van gewijsde is
       gegaan;
+
 
       c. een buiten Nederland overeenkomstig de plaatselijke voorschriften door een bevoegde instantie opgemaakte akte
       die ten doel heeft tot bewijs te dienen van het desbetreffende feit, of een over dat feit gedane rechterlijke
       uitspraak, of bij gebreke daarvan een akte van bekendheid of beëdigde verklaring, bedoeld in [artikel 45 van Boek 1
       van het Burgerlijk Wetboek](jci1.3:c:BWBR0002656&artikel=45) ;
 
+
       d. een geschrift dat overeenkomstig de plaatselijke voorschriften is opgemaakt door een bevoegde instantie, waarin
       het desbetreffende feit is vermeld;
+
 
       e. een verklaring over het desbetreffende feit die betrokkene ten overstaan van een door het college van
       burgemeester en wethouders aangewezen ambtenaar onder eed of belofte heeft afgelegd, die op schrift is gesteld en
       door betrokkene is ondertekend.
+
 
       3. De gegevens over de burgerlijke staat worden, indien zij feiten betreffen die zich in Nederland hebben
       voorgedaan en waarvan een in Nederland geaccrediteerde consulaire ambtenaar van een ander land bevoegd een akte
@@ -433,21 +507,23 @@ articles:
               subject: $partnerschap_type
               value: $geldige_partnertypen
   - number: '2.9'
-    text: |-
+    text: >-
       Artikel 2.9 1 Aan een geschrift als bedoeld in artikel 2.8, tweede lid, onder c, d, of e , dan wel artikel 2.8,
       derde lid, worden geen gegevens ontleend over het huwelijk of het geregistreerd partnerschap dat is gesloten tussen
       echtgenoten dan wel geregistreerde partners van wie ten minste één vreemdeling is, voordat het college van
       burgemeester en wethouders zich een door de korpschef in de zin van de [Vreemdelingenwet
       2000](jci1.3:c:BWBR0011823) afgegeven verklaring heeft doen overleggen.
 
+
       2. De verklaring is niet vereist indien voldaan is aan de eisen genoemd in [artikel 25, vierde lid, onder b, c of
       d, van Boek 1 van het Burgerlijk Wetboek](jci1.3:c:BWBR0002656&artikel=25) .
+
 
       3. Op de verklaring zijn de regels in en krachtens [artikel 44, eerste lid, onder k, en derde lid, van Boek 1 van
       het Burgerlijk Wetboek](jci1.3:c:BWBR0002656&artikel=44) van overeenkomstige toepassing.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.9
   - number: '2.10'
-    text: |-
+    text: >-
       Artikel 2.10 1 Indien aannemelijk is dat omtrent een gegeven over de familierechtelijke betrekkingen tot de ouders
       of de kinderen, over het huwelijk en de eerdere huwelijken, over de echtgenoot en de eerdere echtgenoten, over het
       geregistreerd partnerschap en de eerdere geregistreerde partnerschappen of over de geregistreerde partner en de
@@ -455,26 +531,30 @@ articles:
       verschaft, mogen deze gegevens niet worden ontleend aan een geschrift als bedoeld in artikel 2.8, tweede lid, onder
       e.
 
+
       2. Aan een geschrift als bedoeld in artikel 2.8, tweede lid, onder c, d of e , alsmede artikel 2.8, derde lid,
       worden geen gegevens ontleend, voor zover de Nederlandse openbare orde zich verzet tegen de erkenning van de
       rechtsgeldigheid van de in deze geschriften vermelde feiten.
 
+
       3. Aan een geschrift als bedoeld in artikel 2.8, tweede lid, onder d en e , worden geen gegevens ontleend, indien
       aannemelijk is dat de gegevens onjuist zijn.
+
 
       4. Aan een geschrift als bedoeld in artikel 2.8, tweede lid, onder e , worden geen gegevens ontleend, dan nadat de
       gegevens voor zover mogelijk zijn geverifieerd door raadpleging van de basisregistratie en zo nodig van andere
       registers of van geschriften die door de betrokkene zijn overgelegd.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.10
   - number: '2.11'
-    text: |-
+    text: >-
       Artikel 2.11 Op de persoonslijst van een persoon worden geen gegevens over zijn kind opgenomen indien het kind ten
       tijde van de inschrijving van de persoon reeds is overleden en het kind zelf geen ingeschrevene is.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.11
   - number: '2.12'
-    text: |-
+    text: >-
       Artikel 2.12 1 Bij gerede twijfel over de toepassing van artikel 2.8, tweede en derde lid , en artikel 2.10, eerste
       en tweede lid , wordt advies ingewonnen van de ambtenaar van de burgerlijke stand in de gemeente.
+
 
       2. Indien bij de ontlening van gegevens over een huwelijk dat is gesloten tussen echtgenoten van wie ten minste één
       vreemdeling is, aan een geschrift als bedoeld in artikel 2.8, tweede lid, onder c, d, of e , dan wel artikel 2.8,
@@ -485,27 +565,31 @@ articles:
       gegevens over het huwelijk advies van de ambtenaar van de burgerlijke stand van de gemeente 's-Gravenhage
       ingewonnen.
 
+
       3. Indien na het advies, bedoeld in het eerste lid, gerede twijfel blijft bestaan of het voornemen bestaat van het
       advies af te wijken, wordt het advies van de Commissie van advies voor de zaken betreffende de burgerlijke staat en
       de nationaliteit ingewonnen.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.12
   - number: '2.13'
-    text: |-
+    text: >-
       Artikel 2.13 1 De gegevens over curatele worden ontleend aan het curatele- en bewindregister.
+
 
       2. De gegevens over het gezag dat over de minderjarige wordt uitgeoefend, worden ontleend aan het gezagsregister.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.13
   - number: '2.14'
-    text: |-
+    text: >-
       Artikel 2.14 1 Gegevens over het Nederlanderschap worden opgenomen met toepassing van de [Rijkswet op het
       Nederlanderschap](jci1.3:c:BWBR0003738) , van andere op het Nederlanderschap betrekking hebbende wettelijke
       bepalingen en van verdragen waaruit het Nederlanderschap voortvloeit.
+
 
       2. Indien omtrent een ingeschrevene akten als bedoeld in [artikel 22, eerste lid, onder b, c en d, van de Rijkswet
       op het Nederlanderschap](jci1.3:c:BWBR0003738&artikel=22) zijn opgenomen in het in dat lid bedoelde register, wordt
       aan deze akten het gegeven over het Nederlanderschap ontleend. Indien omtrent een ingeschrevene een afschrift wordt
       overgelegd van de in de eerste volzin bedoelde akten uit het register, bedoeld in artikel 22, tweede lid, van de
       genoemde wet, wordt het gegeven over het Nederlanderschap aan dit afschrift ontleend.
+
 
       3. Een gegeven over het Nederlanderschap wordt ontleend aan de bevestiging van de verklaring tot verkrijging van
       het Nederlanderschap of het uittreksel van het besluit tot verlening van het Nederlanderschap, waarvan de
@@ -519,28 +603,33 @@ articles:
       zover het in deze gevallen gaat om verkrijging of verlening van het Nederlanderschap wordt daarbij afgeweken van
       het tweede lid.
 
+
       4. In de gevallen bedoeld in [artikel 17 van de Rijkswet op het Nederlanderschap](jci1.3:c:BWBR0003738&artikel=17)
       , worden de gegevens over het Nederlanderschap ontleend aan een afschrift van een in kracht van gewijsde gegane
       uitspraak van een rechterlijke instantie in Nederland.
+
 
       5. Indien een afschrift wordt overgelegd van een uitspraak van het Gemeenschappelijk Hof van Justitie van Aruba,
       Curaçao, Sint Maarten en van Bonaire, Sint Eustatius en Saba krachtens [artikel 17 van de Rijkswet op het
       Nederlanderschap](jci1.3:c:BWBR0003738&artikel=17) , worden de gegevens over het Nederlanderschap aan dit afschrift
       ontleend.
 
+
       6. Gegevens over de behandeling als Nederlander van een persoon die niet het Nederlanderschap bezit, worden
       opgenomen met toepassing van de [Wet betreffende de positie van Molukkers](jci1.3:c:BWBR0003052) .
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.14
   - number: '2.15'
-    text: |-
+    text: >-
       Artikel 2.15 1 Gegevens over een vreemde nationaliteit worden ontleend aan een beschikking of uitspraak van een
       daartoe volgens het ter plaatse geldend recht bevoegde administratieve of rechterlijke instantie, die tot doel
       heeft tot bewijs te dienen van de betreffende nationaliteit, dan wel opgenomen met toepassing van het betreffende
       nationaliteitsrecht.
 
+
       2. Indien gegevens over een vreemde nationaliteit niet overeenkomstig het eerste lid kunnen worden verkregen,
       kunnen deze gegevens worden ontleend aan een geschrift van een volgens het ter plaatse geldend recht bevoegde
       autoriteit, dat gegevens vermeldt over die nationaliteit.
+
 
       3. Indien de betrokkene geen nationaliteit bezit of de nationaliteit niet kan worden vastgesteld, wordt dit gegeven
       opgenomen. Indien een rechterlijke uitspraak op grond van [artikel 17 van de Rijkswet op het
@@ -548,31 +637,33 @@ articles:
       Nederlandse nationaliteit bezit, wordt daarvan melding gemaakt.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.15
   - number: '2.16'
-    text: |-
+    text: >-
       Artikel 2.16 Gegevens in verband met het verblijfsrecht van de vreemdeling worden ontleend aan mededelingen
       daarover van Onze Minister van Veiligheid en Justitie aan het college van burgemeester en wethouders.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.16
   - number: '2.17'
-    text: |-
+    text: >-
       Artikel 2.17 Bij de inschrijving van een vreemdeling op grond van artikel 2.4 , worden gegevens inzake de
       geboortedatum en de nationaliteit die niet als zodanig kunnen worden opgenomen overeenkomstig de artikelen 2.8 en
       2.15 , ontleend aan een mededeling daarover van Onze Minister van Veiligheid en Justitie voor zover deze gegevens
       door hem zijn vastgesteld in het kader van de toelating van de betrokkene tot Nederland.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.17
   - number: '2.18'
-    text: |-
+    text: >-
       Artikel 2.18 Bij de inschrijving op grond van artikel 2.3 worden de gegevens omtrent het adres ontleend aan de
       persoonslijst van de moeder. Als datum van inschrijving wordt de geboortedatum opgenomen.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.18
   - number: '2.19'
-    text: |-
+    text: >-
       Artikel 2.19 1 Aan de aangifte van verblijf en adres van degene die rechtmatig verblijf geniet, naar redelijke
       verwachting gedurende een half jaar ten minste twee derde van de tijd in Nederland verblijf zal houden en die zijn
       adres heeft in de betrokken gemeente, worden gegevens betreffende het verblijf in Nederland, het adres en het
       vorige verblijf buiten Nederland ontleend.
 
+
       2. Indien aannemelijk is dat een gegeven betreffende het vorige verblijf buiten Nederland onjuist is, wordt dit
       gegeven niet opgenomen.
+
 
       3. Indien een persoon als bedoeld in het eerste lid in gebreke is met het doen van aangifte, draagt het college van
       burgemeester en wethouders van de gemeente waar betrokkene zijn adres heeft, ambtshalve zorg voor opneming van
@@ -580,19 +671,23 @@ articles:
       en wethouders is bevoegd de gegevens alsnog aan de aangifte van de betrokkene te ontlenen, indien de aangifte na
       afloop van de aangiftetermijn geschiedt.
 
+
       4. Als datum van aanvang van het verblijf in Nederland en van vestiging van het adres in de gemeente wordt de dag
       opgenomen waarop de aangifte is ontvangen, dan wel de dag waarop van het voornemen tot ambtshalve opneming van
       gegevens over het verblijf en adres aan betrokkene schriftelijk mededeling is gedaan.
 
+
       5. De gegevens worden niet opgenomen dan nadat de identiteit van de betrokkene deugdelijk is vastgesteld.
+
 
       6. Indien de betrokkene komt vanuit Aruba, Curaçao, Sint Maarten, of een van de openbare lichamen, is artikel 2.5
       van overeenkomstige toepassing.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.19
   - number: '2.20'
-    text: |-
+    text: >-
       Artikel 2.20 1 Aan de aangifte van een ingezetene die zijn adres heeft gewijzigd, worden gegevens betreffende het
       adres ontleend, tenzij aannemelijk is dat de gegevens onjuist zijn.
+
 
       2. Indien een ingezetene die zijn adres heeft gewijzigd, in gebreke is met het doen van aangifte, draagt het
       college van burgemeester en wethouders van de gemeente waar betrokkene zijn adres heeft, ambtshalve zorg voor
@@ -600,42 +695,51 @@ articles:
       alsnog aan de aangifte van de betrokkene te ontlenen, indien de aangifte na afloop van de aangiftetermijn
       geschiedt.
 
+
       3. Als datum van adreswijziging wordt opgenomen:
 
+
       a. de in de aangifte vermelde datum van adreswijziging, als tijdig aangifte is gedaan;
+
 
       b. de dag waarop de aangifte is ontvangen, in de overige gevallen waarin de gegevens aan de aangifte van de
       betrokkene worden ontleend;
 
+
       c. de dag waarop van het voornemen tot opneming aan betrokkene schriftelijk mededeling is gedaan, bij ambtshalve
       opneming van de gegevens.
+
 
       4. De gewijzigde gegevens worden niet opgenomen dan nadat de identiteit van de betrokkene deugdelijk is
       vastgesteld.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.20
   - number: '2.21'
-    text: |-
+    text: >-
       Artikel 2.21 1 Aan de aangifte van vertrek van de ingezetene die naar redelijke verwachting gedurende een jaar ten
       minste twee derde van de tijd buiten Nederland zal verblijven, worden gegevens betreffende het vertrek uit
       Nederland en het volgende verblijf buiten Nederland ontleend.
+
 
       2. Indien de ingezetene in gebreke is met het doen van aangifte, draagt het college van burgemeester en wethouders
       van de bijhoudingsgemeente ambtshalve zorg voor opneming van gegevens betreffende het vertrek en het volgende
       verblijf buiten Nederland. Het college van burgemeester en wethouders is bevoegd de gegevens alsnog aan de aangifte
       van de ingezetene te ontlenen, indien de aangifte na afloop van de aangiftetermijn geschiedt.
 
+
       3. Als datum van vertrek uit Nederland en van opheffing van het adres wordt de dag opgenomen waarop de aangifte is
       ontvangen, dan wel de dag waarop van het voornemen tot ambtshalve opneming van gegevens over het vertrek aan de
       ingeschrevene schriftelijk mededeling is gedaan.
 
+
       4. De gegevens worden niet opgenomen dan nadat de identiteit van de betrokkene deugdelijk is vastgesteld.
+
 
       5. Indien de ingezetene in de aangifte van vertrek meldt te gaan verblijven in Aruba, Curaçao, Sint Maarten of een
       van de openbare lichamen, verstrekt het college van burgemeester en wethouders aan hem kosteloos een
       verhuisbericht, volgens een door Onze Minister vast te stellen model.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.21
   - number: '2.22'
-    text: |-
+    text: >-
       Artikel 2.22 1 Indien een ingezetene niet kan worden bereikt, van hem geen aangifte van wijziging van zijn adres of
       van vertrek is ontvangen als bedoeld in artikel 2.20, eerste lid , of 2.21, eerste lid , en na gedegen onderzoek
       geen gegevens over hem kunnen worden achterhaald betreffende het verblijf in Nederland, het vertrek uit Nederland
@@ -643,52 +747,58 @@ articles:
       bijhoudingsgemeente ambtshalve zorg voor de opneming van het gegeven van het vertrek van de ingezetene uit
       Nederland.
 
+
       2. Als datum van vertrek uit Nederland en van opheffing van het adres wordt de dag opgenomen waarop het voornemen
       tot ambtshalve opneming van gegevens over het vertrek is bekendgemaakt.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.22
   - number: '2.23'
-    text: |-
+    text: >-
       Artikel 2.23 1 Indien het woonadres ontbreekt dan wel artikel 2.40 of artikel 2.41 van toepassing is, wordt op
       aangifte een briefadres opgenomen.
+
 
       2. Het college van burgemeester en wethouders is bevoegd ambtshalve een briefadres op te nemen indien het woonadres
       ontbreekt en geen aangifte wordt gedaan van een briefadres. Het college neemt ambtshalve geen briefadres op dan met
       instemming van de briefadresgever.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.23
   - number: '2.24'
-    text: |-
+    text: >-
       Artikel 2.24 1 Het burgerservicenummer dat aan een persoon is toegekend overeenkomstig [artikel 8 van de Wet
       algemene bepalingen burgerservicenummer](jci1.3:c:BWBR0022428&artikel=8) wordt opgenomen op zijn persoonslijst,
       voordat over de betrokken persoon voor de eerste keer gegevens worden verstrekt.
+
 
       2. De gegevens over het burgerservicenummer van de ouders, de echtgenoot, de eerdere echtgenoten, de geregistreerde
       partner, de eerdere geregistreerde partners en de kinderen worden ontleend aan de desbetreffende persoonslijsten.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.24
   - number: '2.25'
-    text: |-
+    text: >-
       Artikel 2.25 De gegevens over het gebruik van de geslachtsnaam van de echtgenoot, de eerdere echtgenoot, de
       geregistreerde partner of de eerdere geregistreerde partner worden opgenomen op schriftelijk verzoek van de daartoe
       krachtens [artikel 9 van Boek 1 van het Burgerlijk Wetboek](jci1.3:c:BWBR0002656&artikel=9) bevoegde ingeschrevene,
       dan wel op grond van een rechterlijke uitspraak als bedoeld in artikel 9 van Boek 1 van het Burgerlijk Wetboek.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.25
   - number: '2.26'
-    text: |-
+    text: >-
       Artikel 2.26 Omtrent de beslissing dat een opgenomen algemeen gegeven onjuist is of, indien het een gegeven over de
       burgerlijke staat betreft, in strijd is met de Nederlandse openbare orde, omtrent een onderzoek naar die
       onjuistheid of strijdigheid, alsmede omtrent de omstandigheid dat de ingeschrevene geen ingezetene meer is, wordt
       een aantekening geplaatst bij de desbetreffende gegevens.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.26
   - number: '2.27'
-    text: |-
+    text: >-
       Artikel 2.27 1 De ambtenaar van de burgerlijke stand die in een van de onder hem berustende registers melding heeft
       gemaakt van een feit dat van belang is voor de bijhouding van de basisregistratie, brengt de gegevens ter zake
       terstond ter kennis van zijn college van burgemeester en wethouders.
 
+
       2. Een hem ingevolge een verdrag inzake de internationale uitwisseling van gegevens op het gebied van de
       burgerlijke stand toegezonden kennisgeving doet hij terstond toekomen aan zijn college.
 
+
       3. Hij verstrekt aan het college van burgemeester en wethouders dat daarom vraagt, zo spoedig mogelijk alle
       inlichtingen die dat college nodig heeft voor de bijhouding van de basisregistratie.
+
 
       4. De ambtenaar van de burgerlijke stand van de gemeente 's-Gravenhage, die wegens het ontbreken van een akte in de
       onder hem berustende registers geen latere vermelding als bedoeld in [artikel 20 van Boek 1 van het Burgerlijk
@@ -698,25 +808,28 @@ articles:
       en wethouders.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.27
   - number: '2.28'
-    text: |-
+    text: >-
       Artikel 2.28 1 De griffier van de rechtbank die in het curatele- en bewindregister melding heeft gemaakt van een
       rechterlijke uitspraak waarbij met betrekking tot een persoon een voorziening in de curatele is getroffen, doet
       daarvan mededeling aan het college van burgemeester en wethouders van de bijhoudingsgemeente, onder vermelding van
       de persoon die het betreft en de datum waarop de rechtsgeldigheid van de voorziening ingaat.
 
+
       2. De griffier doet overeenkomstige mededeling van elke beslissing, houdende vernietiging van een rechterlijke
       uitspraak als bedoeld in het eerste lid, en van beëindiging van de curatele.
+
 
       3. De griffier van de rechtbank die in het gezagsregister aantekening heeft gehouden van een wijziging in het gezag
       dat over een minderjarige wordt uitgeoefend, welke van belang is voor de bijhouding van de basisregistratie, met
       betrekking tot de in artikel 2.7, eerste lid, onder a, onder 3° , bedoelde gegevens, doet van de wijziging
       mededeling aan het college van burgemeester en wethouders van de bijhoudingsgemeente van de minderjarige.
 
+
       4. De in het derde lid bedoelde mededeling geeft uitsluitend aan welke minderjarige het betreft, welke wijziging in
       het gezag heeft plaatsgevonden alsmede de datum waarop de wijziging ingaat.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.28
   - number: '2.29'
-    text: |-
+    text: >-
       Artikel 2.29 1 Indien Onze Minister van Veiligheid en Justitie in het openbaar register, bedoeld in [artikel 22,
       eerste lid, van de Rijkswet op het Nederlanderschap](jci1.3:c:BWBR0003738&artikel=22) , melding heeft gemaakt van
       het feit dat een persoon een verklaring tot verkrijging van het Nederlanderschap of een verklaring van afstand van
@@ -725,8 +838,10 @@ articles:
       en wethouders van de bijhoudingsgemeente. De mededeling bevat de datum waarop de verklaring in ontvangst is genomen
       of de datum waarop het Nederlanderschap is verkregen of verloren.
 
+
       2. Een mededeling als bedoeld in het eerste lid blijft achterwege indien artikel 2.14, derde lid , van toepassing
       is.
+
 
       3. De griffier van de rechtbank Den Haag dan wel de griffier van de Hoge Raad zendt een afschrift van een in kracht
       van gewijsde gegane rechterlijke uitspraak houdende de vaststelling van het Nederlanderschap of de vaststelling van
@@ -734,81 +849,87 @@ articles:
       bijhoudingsgemeente.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.29
   - number: '2.30'
-    text: |-
+    text: >-
       Artikel 2.30 Onze Minister van Veiligheid en Justitie doet van de gegevens in verband met het verblijfsrecht van de
       vreemdeling die voor de bijhouding van de basisregistratie van belang zijn, mededeling aan het college van
       burgemeester en wethouders van de bijhoudingsgemeente.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.30
   - number: '2.31'
-    text: |-
+    text: >-
       Artikel 2.31 Bij algemene maatregel van bestuur worden gevallen bepaald waarin het college van burgemeester en
       wethouders aan een korpschef als bedoeld in de [Vreemdelingenwet 2000](jci1.3:c:BWBR0011823) een afschrift toezendt
       van een beslissing als bedoeld in artikel 2.60 om op grond van artikel 2.10, tweede lid , een gegeven betreffende
       een vreemdeling niet in de basisregistratie op te nemen.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.31
   - number: '2.32'
-    text: |-
+    text: >-
       Artikel 2.32 De griffier van het betrokken gerecht zendt een afschrift van een in kracht van gewijsde gegane
       uitspraak als bedoeld in [artikel 9 van Boek 1 van het Burgerlijk Wetboek](jci1.3:c:BWBR0002656&artikel=9) aan het
       college van burgemeester en wethouders van de bijhoudingsgemeente van de onbevoegd verklaarde.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.32
   - number: '2.33'
-    text: |-
+    text: >-
       Artikel 2.33 Bij algemene maatregel van bestuur kunnen aan overheidsorganen verplichtingen worden opgelegd tot het
       doen van mededeling aan het college van burgemeester en wethouders van de betrokken gemeente inzake het van
       toepassing zijn van artikel 2.6 .
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.33
   - number: '2.34'
-    text: |-
+    text: >-
       Artikel 2.34 1 Een bestuursorgaan dat in verband met de verstrekking van een authentiek gegeven uit de
       basisregistratie gerede twijfel heeft over de juistheid van dat gegeven, doet hiervan mededeling aan het college
       van burgemeester en wethouders van de bijhoudingsgemeente.
 
+
       2. Onze Minister wijst de bestuursorganen aan die tevens mededeling doen in verband met de verstrekking van andere
       dan authentieke gegevens.
+
 
       3. Bij of krachtens algemene maatregel van bestuur worden de gevallen waarin en de wijze waarop de mededeling wordt
       gedaan, alsmede de kennisgeving van het college van burgemeester en wethouders aan het bestuursorgaan naar
       aanleiding van een mededeling, geregeld.
+
 
       4. Het college van burgemeester en wethouders kan nadere regels stellen omtrent het doen van mededeling door en de
       kennisgeving aan bestuursorganen die een orgaan zijn van de desbetreffende gemeente en kan een of meer van deze
       bestuursorganen aanwijzen om tevens mededeling te doen in verband met de verstrekking van andere dan authentieke
       gegevens.
 
+
       5. Voor zover een mededeling als bedoeld in het eerste lid betrekking heeft op een gegeven dat op grond van een
       andere wet is overgenomen uit een andere registratie, zendt het college van burgemeester en wethouders die
       mededeling door aan de verantwoordelijke voor de verwerking van dat gegeven in die andere registratie.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.34
   - number: '2.35'
-    text: |-
+    text: >-
       Artikel 2.35 1 Een college van burgemeester en wethouders dat van de ambtenaar van de burgerlijke stand in zijn
       gemeente gegevens heeft ontvangen die van belang zijn voor de bijhouding van de basisregistratie door een andere
       gemeente, doet terstond mededeling van die gegevens aan het college van burgemeester en wethouders van de andere
       gemeente.
+
 
       2. Een college dat van de ambtenaar van de burgerlijke stand in zijn gemeente een ingevolge een verdrag inzake de
       internationale uitwisseling van gegevens op het gebied van de burgerlijke stand toegezonden kennisgeving heeft
       ontvangen die van belang is voor de bijhouding van de basisregistratie door een andere gemeente, doet die
       kennisgeving terstond toekomen aan het college van burgemeester en wethouders van de andere gemeente.
 
+
       3. Onze Minister, dan wel een college van burgemeester en wethouders, verstrekt aan een college van burgemeester en
       wethouders dat daar belang bij heeft spontaan of op verzoek zo spoedig mogelijk alle inlichtingen die van belang
       zijn voor een goede uitvoering van de taak met betrekking tot de basisregistratie.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.35
   - number: '2.36'
-    text: |-
+    text: >-
       Artikel 2.36 Bij algemene maatregel van bestuur kunnen aan overheidsorganen verplichtingen worden opgelegd tot het
       verschaffen aan het college van burgemeester en wethouders van de gegevens, bedoeld in artikel 2.7, eerste lid,
       onder a, onderdelen 10° en 11° .
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.36
   - number: '2.37'
-    text: |-
+    text: >-
       Artikel 2.37 Bij of krachtens algemene maatregel van bestuur kunnen regels worden gesteld met betrekking tot de
       wijze waarop aan de verplichtingen bedoeld in deze paragraaf moet worden voldaan.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.37
   - number: '2.38'
-    text: |-
+    text: >-
       Artikel 2.38 1 Degene die naar redelijke verwachting gedurende een half jaar ten minste twee derde van de tijd in
       Nederland verblijf zal houden, meldt zich uiterlijk op de vijfde dag na de aanvang van zijn verblijf in persoon bij
       het college van burgemeester en wethouders van de gemeente waar hij zijn woonadres heeft om daarbij schriftelijk
@@ -816,8 +937,10 @@ articles:
       binnen de gestelde termijn bij het college van burgemeester en wethouders van de gemeente waar hij zijn briefadres
       heeft om de bedoelde aangifte te doen.
 
+
       2. Hij doet in de aangifte mededeling van de gegevens over zijn toekomstig verblijf in Nederland, over zijn adres
       in de gemeente en over het vorige verblijf buiten Nederland.
+
 
       3. Hij geeft bij de aangifte de inlichtingen en overlegt de geschriften ter zake van feiten betreffende zijn
       burgerlijke staat, zijn nationaliteit en zijn eerder verblijf in Nederland, die noodzakelijk zijn voor de
@@ -828,100 +951,124 @@ articles:
       in de basisadministratie in Aruba, Curaçao, Sint Maarten of een van de openbare lichamen, waar hij laatstelijk als
       ingezetene was ingeschreven.
 
+
       4. Degene die naar redelijke verwachting gedurende een half jaar ten minste twee derde van de tijd in Nederland
       verblijf zal houden, doet aangifte van verblijf en adres overeenkomstig het eerste tot en met het derde lid, op het
       moment dat hij ophoudt te behoren tot een categorie als bedoeld in artikel 2.6 .
 
+
       5. In een geval als bedoeld in het vierde lid vangt de in het eerste lid bedoelde termijn van vijf dagen aan met
       ingang van de dag na die waarop een in dat lid bedoelde situatie is ingetreden.
 
+
       6. Aangifte van verblijf en adres blijft achterwege indien:
+
 
       a. het verblijf aanvangt door geboorte en inschrijving plaatsvindt op grond van de geboorteakte,
 
+
       b. de betrokkene behoort tot een categorie van personen als bedoeld in artikel 2.6 , of
+
 
       c. de betrokkene een vreemdeling is die geen rechtmatig verblijf geniet.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.38
   - number: '2.39'
-    text: |-
+    text: >-
       Artikel 2.39 1 De ingezetene die zijn adres wijzigt doet hiervan schriftelijk aangifte bij het college van
       burgemeester en wethouders van de gemeente waar hij zijn nieuwe adres heeft.
+
 
       2. Hij doet niet eerder aangifte dan vier weken vóór de beoogde datum van adreswijziging en niet later dan de
       vijfde dag na de adreswijziging. Hij doet in de aangifte mededeling van de datum van adreswijziging en van de
       gegevens over het nieuwe en het vorige adres.
 
+
       3. Indien een ingezetene geen woonadres heeft, kiest hij een briefadres. Het eerste en tweede lid zijn van
       overeenkomstige toepassing.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.39
   - number: '2.40'
-    text: |-
+    text: >-
       Artikel 2.40 1 Degene die zijn woonadres heeft in een instelling die is aangewezen op grond van het derde of het
       vierde lid kan, in afwijking van de artikelen 2.38, eerste lid , en 2.39, eerste lid , in plaats van zijn woonadres
       een briefadres kiezen en daarvan overeenkomstig de genoemde bepalingen aangifte doen.
+
 
       2. Een instelling wordt slechts aangewezen indien de aard van de instelling meebrengt, dat door opneming van het
       adres daarvan in de basisregistratie de persoonlijke levenssfeer van de betrokkenen onevenredig zou kunnen worden
       geschaad.
 
+
       3. Onze Minister kan categorieën van instellingen dan wel instellingen afzonderlijk aanwijzen, voor zover het
       betreft:
 
+
       a. instellingen voor gezondheidszorg;
+
 
       b. instellingen op het gebied van de kinderbescherming;
 
+
       c. penitentiaire instellingen.
+
 
       4. Het college van burgemeester en wethouders kan een in de gemeente gevestigde instelling aanwijzen indien het
       betreft een instelling op het terrein van maatschappelijke opvang, bedoeld in [artikel 1, eerste lid, onderdeel g,
       onder 7°, van de Wet maatschappelijke ondersteuning](jci1.3:c:BWBR0020031&artikel=1) .
 
+
       5. Het hoofd van een aangewezen instelling doet aan de betrokken personen tijdig schriftelijk mededeling van de
       mogelijkheid tot aangifte van een briefadres.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.40
   - number: '2.41'
-    text: |-
+    text: >-
       Artikel 2.41 1 Voor zover het opnemen van een woonadres naar het oordeel van de burgemeester om veiligheidsredenen
       niet wenselijk is, kan de betrokkene in afwijking van artikel 2.38, eerste lid , en 2.39, eerste lid , in plaats
       van zijn woonadres een briefadres kiezen en daarvan overeenkomstig de genoemde bepalingen aangifte doen.
 
+
       2. Bij algemene maatregel van bestuur kunnen nadere regels worden gesteld omtrent de toepassing van het eerste lid.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.41
   - number: '2.42'
-    text: |-
+    text: >-
       Artikel 2.42 Als briefadresgever kan worden gekozen:
 
+
       a. een natuurlijke persoon die als ingezetene is ingeschreven;
+
 
       b. een rechtspersoon die zijn zetel heeft in Nederland en die door het college van burgemeester en wethouders is
       aangewezen om als briefadresgever in zijn gemeente op te treden.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.42
   - number: '2.43'
-    text: |-
+    text: >-
       Artikel 2.43 1 De ingezetene die naar redelijke verwachting gedurende een jaar ten minste twee derde van de tijd
       buiten Nederland zal verblijven, doet bij het college van burgemeester en wethouders van de bijhoudingsgemeente
       voor zijn vertrek uit Nederland schriftelijk aangifte van vertrek. De aangiftetermijn vangt aan op de vijfde dag
       voor de dag van vertrek.
 
+
       2. De ingezetene doet in die aangifte mededeling van de gegevens over zijn vertrek en het volgende verblijf buiten
       Nederland.
 
+
       3. Ter uitvoering van het eerste lid verschijnt de ingezetene in persoon bij het college, indien:
+
 
       a. niet alle ingezetenen met hetzelfde woonadres de verplichting, bedoeld in het eerste lid, vervullen, of
 
+
       b. niet voor alle ingezetenen met hetzelfde woonadres de verplichting, bedoeld in het eerste lid, wordt vervuld.
+
 
       4. Een minderjarige verschijnt in persoon, tenzij alle ingezetenen met hetzelfde woonadres aangifte van vertrek
       doen of aangifte van vertrek voor hen wordt gedaan.
+
 
       5. Bij algemene maatregel van bestuur kunnen regels worden gesteld omtrent bijzondere gevallen waarin het eerste
       lid niet van toepassing is.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.43
   - number: '2.44'
-    text: |-
+    text: >-
       Artikel 2.44 De ingezetene brengt alle feiten betreffende zijn burgerlijke staat en nationaliteit die zich buiten
       Nederland hebben voorgedaan, zo spoedig mogelijk ter kennis aan het college van burgemeester en wethouders. Hij
       verstrekt aan het college, desgevraagd in persoon, de inlichtingen en overlegt de geschriften die noodzakelijk zijn
@@ -929,28 +1076,32 @@ articles:
       geschrift een door een beëdigde vertaler vervaardigde Nederlandse vertaling over.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.44
   - number: '2.45'
-    text: |-
+    text: >-
       Artikel 2.45 1 Degene die aangifte heeft gedaan als bedoeld in de artikelen 2.38 tot en met 2.40 en artikel 2.43 ,
       geeft op verzoek van het college van burgemeester en wethouders de inlichtingen ter zake van zijn aangifte die van
       belang zijn voor de bijhouding met betrekking tot hem van de basisregistratie. Deze verplichting is van
       overeenkomstige toepassing ten aanzien van het overleggen van geschriften. De betrokkene verschijnt hierbij
       desgevraagd in persoon.
 
+
       2. In de aangifte van een briefadres worden de redenen voor de aangifte van een briefadres medegedeeld. Bij de
       aangifte wordt een schriftelijke verklaring van instemming gevoegd van de briefadresgever.
 
+
       3. De briefadresgever draagt zorg dat voor de houder van het briefadres bestemde geschriften of inlichtingen
       daarover, aan hem worden doorgegeven of medegedeeld.
+
 
       4. De briefadresgever verstrekt op verzoek van het college van burgemeester en wethouders, desgevraagd in persoon,
       ter zake van dat briefadres de inlichtingen en overlegt de geschriften die noodzakelijk zijn voor de bijhouding van
       de basisregistratie.
 
+
       5. Bij algemene maatregel van bestuur kunnen nadere regels worden gesteld omtrent de toepassing van het eerste tot
       en met vierde lid.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.45
   - number: '2.46'
-    text: |-
+    text: >-
       Artikel 2.46 De ingezetene verstrekt op verzoek van het college van burgemeester en wethouders over feiten
       betreffende zijn burgerlijke staat en nationaliteit, desgevraagd in persoon, de inlichtingen en overlegt de
       geschriften die noodzakelijk zijn voor de bijhouding van de basisregistratie. Op verzoek van het college van
@@ -958,7 +1109,7 @@ articles:
       vertaling over.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.46
   - number: '2.47'
-    text: |-
+    text: >-
       Artikel 2.47 Degene ten aanzien van wie het college van burgemeester en wethouders het redelijke vermoeden heeft
       dat hij in gebreke is met het doen van een aangifte als bedoeld in de artikelen 2.38 tot en met 2.43 , verstrekt op
       verzoek van het college van burgemeester en wethouders, desgevraagd in persoon, binnen een door het college in het
@@ -966,26 +1117,33 @@ articles:
       bijhouding met betrekking tot hem van de basisregistratie.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.47
   - number: '2.48'
-    text: |-
+    text: >-
       Artikel 2.48 De verplichtingen, vermeld in de artikelen 2.38 , 2.39 en 2.43 tot en met 2.47 , rusten op:
 
+
       a. ouders, voogden en verzorgers voor minderjarigen jonger dan 16 jaar;
+
 
       b. ouders, voogden en verzorgers voor inwonende minderjarigen van 16 jaar of ouder, tenzij de minderjarige zelf de
       verplichting vervult;
 
+
       c. curatoren voor onder curatele gestelden.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.48
   - number: '2.49'
-    text: |-
+    text: >-
       Artikel 2.49 1 De verplichtingen, vermeld in de artikelen 2.39 en 2.44 tot en met 2.46 , kunnen worden vervuld
       door:
 
+
       a. de ouder en zijn meerderjarige kind, indien beiden hetzelfde woonadres hebben, voor elkaar;
+
 
       b. echtgenoten dan wel geregistreerde partners die hetzelfde woonadres hebben, voor elkaar;
 
+
       c. elke meerderjarige voor een persoon die hem daartoe schriftelijk gemachtigd heeft;
+
 
       d. het hoofd van een instelling voor gezondheidszorg voor een in die instelling verblijvende persoon die wegens de
       toestand van zijn gezondheid niet in staat kan worden geacht aan zijn verplichtingen te voldoen of een machtiging
@@ -993,8 +1151,10 @@ articles:
       aanverwanten tot en met de tweede graad van een zodanig persoon, onder overlegging van een schriftelijke verklaring
       ter zake van het hoofd van de desbetreffende instelling.
 
+
       2. In de gevallen, bedoeld in het eerste lid, kan het college van burgemeester en wethouders de vertegenwoordigde
       overeenkomstig de genoemde artikelen oproepen om in persoon te verschijnen tot het verstrekken van inlichtingen.
+
 
       3. Het eerste en tweede lid zijn van overeenkomstige toepassing op de in artikel 2.38 vermelde verplichtingen voor
       zover het bij algemene maatregel van bestuur bepaalde gevallen betreft. De maatregel bepaalt tevens de gevallen
@@ -1003,21 +1163,25 @@ articles:
       kan worden afgezien dat de betrokkene zelf de verplichtingen vervult en zich daartoe in persoon meldt bij het
       college.
 
+
       4. Het eerste lid, onderdelen a, b en d, en het tweede lid zijn van overeenkomstige toepassing op de in artikel
       2.43 vermelde verplichting, met dien verstande dat, behoudens bij algemene maatregel van bestuur te bepalen
       gevallen, een ouder en zijn meerderjarige kind en echtgenoten dan wel geregistreerde partners voor elkaar slechts
       de aangifteplicht kunnen vervullen, indien:
 
+
       a. zij die verplichting ook voor zichzelf vervullen, en
+
 
       b. alle andere ingezetenen met hetzelfde woonadres die verplichting vervullen of die verplichting voor hen wordt
       vervuld. De tweede en derde volzin van het derde lid zijn van overeenkomstige toepassing.
+
 
       5. Voor de toepassing van het eerste lid wordt met betrekking tot de verplichtingen, vermeld in artikel 2.39 ,
       onder woonadres het nieuwe woonadres verstaan.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.49
   - number: '2.50'
-    text: |-
+    text: >-
       Artikel 2.50 Het hoofd van een instelling of bedrijf waar personen verblijf plegen te houden, de instellingen,
       bedoeld in artikel 2.40 daaronder begrepen, verstrekt, indien de instelling of het bedrijf ter zake door het
       college van burgemeester en wethouders is aangewezen, op door het college te bepalen tijdstippen aan het college de
@@ -1026,18 +1190,19 @@ articles:
       tijd zullen overnachten.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.50
   - number: '2.51'
-    text: |-
+    text: >-
       Artikel 2.51 De echtgenoot, de geregistreerde partner en andere nabestaanden tot en met de tweede graad van een
       ingezetene die in het buitenland is overleden, verstrekken op verzoek van het college van burgemeester en
       wethouders van de gemeente waar betrokkene is ingeschreven, aan het college, voor zover mogelijk, de inlichtingen
       over dat overlijden en overleggen de geschriften die noodzakelijk zijn voor de bijhouding van de basisregistratie.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.51
   - number: '2.52'
-    text: |-
+    text: >-
       Artikel 2.52 1 Degene die ter uitvoering van ingevolge deze paragraaf op hem rustende verplichtingen in persoon bij
       het college van burgemeester en wethouders verschijnt, overlegt desgevraagd met het oog op de vaststelling van zijn
       identiteit een op hem betrekking hebbend document als bedoeld in [artikel 1 van de Wet op de
       identificatieplicht](jci1.3:c:BWBR0006297&artikel=1) .
+
 
       2. De in artikel 2.48 bedoelde ouders, voogden, verzorgers en curatoren van minderjarigen of onder curatele
       gestelden, laten desgevraagd de minderjarige of de onder curatele gestelde met het oog op de vaststelling van de
@@ -1045,99 +1210,122 @@ articles:
       betrekking hebbend document als bedoeld in het eerste lid.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.52
   - number: '2.53'
-    text: |-
+    text: >-
       Artikel 2.53 1 Een verzoek als bedoeld in deze paragraaf wordt gericht aan het college van burgemeester en
       wethouders van de bijhoudingsgemeente.
 
+
       2. Een verzoek als bedoeld in artikel 2.55 kan ook worden gericht aan het college van enige andere gemeente in
       Nederland.
+
 
       3. Een verzoek als bedoeld in artikel 2.55 kan ook worden gericht aan Onze Minister. In dat geval treedt Onze
       Minister voor de toepassing van artikel 2.55 in de plaats van het college van burgemeester en wethouders en wordt
       het verzoek gedaan door tussenkomst van een inschrijfvoorziening.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.53
   - number: '2.54'
-    text: |-
+    text: >-
       Artikel 2.54 1 Het college van burgemeester en wethouders zendt binnen vier weken na een inschrijving als bedoeld
       in de artikelen 2.3 en 2.4 , alsmede binnen vier weken nadat een ingeschrevene die geen ingezetene was ingezetene
       is geworden, aan de ingeschrevene in begrijpelijke vorm een volledig overzicht van zijn persoonslijst.
 
+
       2. Bij minderjarigen jonger dan 16 jaar en bij onder curatele gestelden geschiedt de toezending aan de ouders,
       voogden of verzorgers, onderscheidenlijk aan de curator.
+
 
       3. Bij de toezending wordt schriftelijk mededeling gedaan van de hoofdlijnen van de ter zake van de
       basisregistratie geldende regels, waaronder ten minste de hoofdlijnen van de regels betreffende de identiteit van
       de voor de verwerking verantwoordelijke, de doeleinden van de basisregistratie, de opgenomen gegevenscategorieën,
       de categorieën van ontvangers van gegevens en de rechten van de ingeschrevene.
 
+
       4. Degene die aangifte van verblijf en adres doet, wordt bij die gelegenheid schriftelijk op de hoogte gesteld van
       het recht, bedoeld in artikel 2.59 .
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.54
   - number: '2.55'
-    text: |-
+    text: >-
       Artikel 2.55 1 Het college van burgemeester en wethouders deelt een ieder op diens verzoek schriftelijk binnen vier
       weken kosteloos mede of hem betreffende persoonsgegevens in de basisregistratie worden verwerkt. Indien zodanige
       gegevens worden verwerkt, wordt de verzoeker met betrekking tot de basisregistratie de in artikel 2.54, derde lid ,
       bedoelde schriftelijke mededeling gedaan.
 
+
       2. Het college verleent een ieder op diens verzoek binnen vier weken kosteloos inzage in hem betreffende gegevens
       in de basisregistratie.
+
 
       3. Het college verstrekt een ieder op diens verzoek binnen vier weken een, desgevraagd gewaarmerkt, afschrift in
       begrijpelijke vorm van de hem betreffende persoonsgegevens die in de basisregistratie worden verwerkt, alsmede de
       beschikbare informatie over de oorsprong van die gegevens voor zover die niet van de verzoeker zelf afkomstig zijn.
 
+
       4. Het college draagt zorg voor een deugdelijke vaststelling van de identiteit van de verzoeker.
+
 
       5. De verzoeken, bedoeld in het eerste tot en met derde lid, worden gedaan door:
 
+
       a. ouders, voogden of verzorgers voor minderjarigen jonger dan 16 jaar;
 
+
       b. curatoren voor onder curatele gestelden.
+
 
       6. Aan het verzoek wordt geen gevolg gegeven indien dat niet met een redelijke tussenpoos is gedaan ten opzichte
       van een eerder verzoek.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.55
   - number: '2.56'
-    text: |-
+    text: >-
       Artikel 2.56 1 Het college van burgemeester en wethouders neemt op schriftelijk verzoek van de daartoe krachtens
       [artikel 9 van Boek 1 van het Burgerlijk Wetboek](jci1.3:c:BWBR0002656&artikel=9) bevoegde ingeschrevene binnen
       vier weken kosteloos op zijn persoonslijst de gegevens op over het gebruik van de geslachtsnaam van de echtgenoot,
       de eerdere echtgenoot, de geregistreerde partner of de eerdere geregistreerde partner.
 
+
       2. Het college doet van de opneming van de gegevens terstond schriftelijk mededeling aan de verzoeker.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.56
   - number: '2.57'
-    text: |-
+    text: >-
       Artikel 2.57 1 Het college van burgemeester en wethouders verwijdert op schriftelijk verzoek van de adoptiefouders
       van een minderjarige jonger dan 16 jaar, of op schriftelijk verzoek van een adoptiefkind van 16 jaar of ouder,
       binnen vier weken kosteloos van de persoonslijst van het adoptiefkind, de vóór de adoptie geldende algemene
       gegevens voor zover het betreft:
 
+
       a. gegevens over de naam;
+
 
       b. gegevens over één of beide ouders;
 
+
       c. gegevens over de bij de adoptie verloren nationaliteit;
+
 
       d. gegevens over de bijhoudingsgemeente en het adres in die gemeente alsmede over het verblijf in Nederland en het
       vertrek uit Nederland.
 
+
       2. Het college verwijdert op schriftelijk verzoek van de ouder met wie door een uitspraak van adoptie de
       familierechtelijke betrekkingen tot een kind zijn verbroken, binnen vier weken kosteloos van de persoonslijst van
       die ouder de algemene gegevens over dat kind.
+
 
       3. Het college verwijdert op schriftelijk verzoek van de ingeschrevene binnen vier weken kosteloos van zijn
       persoonslijst de algemene gegevens die zijn gewijzigd in verband met een rechterlijke last tot wijziging van de
       vermelding van het geslacht in de geboorteakte van de ingeschrevene, voor zover deze gegevens golden vóór de
       wijziging en het betreft:
 
+
       a. gegevens over de naam;
+
 
       b. gegevens over het geslacht;
 
+
       c. gegevens over het gebruik van de geslachtsnaam van de echtgenoot, de eerdere echtgenoot, de geregistreerde
       partner of de eerdere geregistreerde partner.
+
 
       4. Het college verwijdert op schriftelijk verzoek van de ingeschrevene die de leeftijd van 16 jaar heeft bereikt,
       binnen vier weken kosteloos van zijn persoonslijst de algemene gegevens over de naam en het geslacht van een ouder,
@@ -1145,32 +1333,38 @@ articles:
       de ingeschrevene, die zijn gewijzigd in verband met een rechterlijke last tot wijziging van de vermelding van het
       geslacht in de geboorteakte van de ouder, eerdere echtgenoot, eerdere geregistreerde partner of het kind.
 
+
       5. Artikel 2.55, vierde lid , is van toepassing op een verzoek als bedoeld in het eerste tot en met vierde lid. Op
       een verzoek als bedoeld in het derde of vierde lid is bovendien artikel 2.55, vijfde lid, van overeenkomstige
       toepassing.
 
+
       6. Het college doet van de verwijdering terstond schriftelijk mededeling aan de verzoeker.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.57
   - number: '2.58'
-    text: |-
+    text: >-
       Artikel 2.58 1 Het college van burgemeester en wethouders voldoet binnen vier weken kosteloos aan het verzoek van
       betrokkene hem betreffende gegevens in de basisregistratie te verbeteren, aan te vullen of te verwijderen, indien
       deze feitelijk onjuist dan wel onvolledig zijn of in strijd met een wettelijk voorschrift worden verwerkt. Het
       verzoek bevat de aan te brengen wijzigingen.
 
+
       2. Het college geeft aan het verzoek uitvoering met inachtneming van het bepaalde bij of krachtens deze afdeling.
+
 
       3. Het college kan de termijn, bedoeld in het eerste lid, voor zover noodzakelijk, met telkens acht weken
       verlengen, indien het verzoek gegevens over de burgerlijke staat of de nationaliteit betreft. Het college doet
       terstond schriftelijk mededeling van de verlening aan de verzoeker.
 
+
       4. Artikel 2.55, vierde en vijfde lid , is van overeenkomstige toepassing.
+
 
       5. Het college van burgemeester en wethouders doet van de uitvoering van het verzoek terstond schriftelijk
       mededeling aan de verzoeker.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.58
   - number: '2.59'
-    text: |-
+    text: >-
       Artikel 2.59 Het college van burgemeester en wethouders vermeldt op schriftelijk verzoek van de betrokkene
       kosteloos op zijn persoonslijst een aantekening omtrent beperking van de verstrekking van gegevens aan derden. Het
       college geeft binnen vier weken gevolg aan het verzoek en doet daarvan terstond schriftelijk mededeling aan de
@@ -1179,112 +1373,133 @@ articles:
       en vijfde lid , is van overeenkomstige toepassing.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.59
   - number: '2.60'
-    text: |-
+    text: >-
       Artikel 2.60 Een beslissing van het college van burgemeester en wethouders om:
 
+
       a. aan een aangifte geen of slechts ten dele gevolg te geven;
+
 
       b. een gegeven over de burgerlijke staat niet op te nemen, dan wel een geschrift daarover dat als akte is
       aangeboden niet als zodanig aan te merken;
 
+
       c. een gegeven over de nationaliteit niet op te nemen;
+
 
       d. ambtshalve over te gaan tot inschrijving, of tot opneming van gegevens in het geval dat inschrijving of opneming
       op grond van een aangifte had moeten geschieden;
 
+
       e. ambtshalve over te gaan tot verbetering, aanvulling of verwijdering van een algemeen gegeven;
+
 
       f. bij een opgenomen algemeen gegeven een aantekening over de onjuistheid van dat gegeven of over de strijdigheid
       daarvan met de Nederlandse openbare orde te plaatsen;
+
 
       g. niet te voldoen aan een verzoek als bedoeld in de artikelen 2.55 tot en met 2.59 , wordt gelijkgesteld met een
       besluit in de zin van de [Algemene wet bestuursrecht](jci1.3:c:BWBR0005537) .
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.60
   - number: '2.61'
-    text: |-
+    text: >-
       Artikel 2.61 1 Indien de rechter het beroep, ingesteld tegen een besluit als bedoeld in artikel 2.60 , gegrond
       verklaart met toepassing van [artikel 8:72, derde lid, onderdeel b, of vierde lid, van de Algemene wet
       bestuursrecht](jci1.3:c:BWBR0005537&artikel=8:72) , doet hij dat met inachtneming van het bepaalde bij of krachtens
       deze afdeling.
+
 
       2. Voor zover een besluit als bedoeld in artikel 2.60 het Nederlanderschap betreft, kan de betrokkene zich
       uitsluitend wenden tot de rechtbank Den Haag met een verzoek als bedoeld in [artikel 17 van de Rijkswet op het
       Nederlanderschap](jci1.3:c:BWBR0003738&artikel=17) .
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.61
   - number: '2.62'
-    text: |-
+    text: >-
       Artikel 2.62 In deze afdeling en de daarop berustende bepalingen wordt verstaan onder een aangewezen
       bestuursorgaan: een bestuursorgaan als bedoeld in artikel 2.65 , voor zover het betreft de taken en gevallen waar
       de in dat artikel bedoelde aanwijzing betrekking op heeft.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.62
   - number: '2.63'
-    text: |-
+    text: >-
       Artikel 2.63 1 Deze afdeling is van toepassing op personen die niet als ingezetene in de basisregistratie zijn
       ingeschreven, met uitzondering van personen die op het moment van hun overlijden ingezetene waren.
 
+
       2. In afwijking van het eerste lid worden geen gegevens opgenomen krachtens deze afdeling in een geval als bedoeld
       in artikel 2.1, derde lid .
+
 
       3. De krachtens deze afdeling over een ingeschrevene opgenomen gegevens worden zodra hij ingezetene wordt opnieuw
       vastgesteld met inachtneming van de eerste afdeling van dit hoofdstuk .
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.63
   - number: '2.64'
-    text: |-
+    text: >-
       Artikel 2.64 Onze Minister houdt in Nederland voorzieningen in stand ten behoeve van de uitvoering van deze wet
       inzake:
 
+
       a. het inschrijven van niet-ingezetenen;
+
 
       b. het indienen van verzoeken van niet-ingezetenen aan Onze Minister.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.64
   - number: '2.65'
-    text: |-
+    text: >-
       Artikel 2.65 Bij algemene maatregel van bestuur kunnen bestuursorganen worden aangewezen die bevoegd zijn om Onze
       Minister een verzoek te doen als bedoeld in artikel 2.68, eerste lid , of een opgave als bedoeld in artikel 2.70,
       derde lid, onderdeel a . Bij de maatregel wordt bepaald op welke taken van het bestuursorgaan de aanwijzing
       betrekking heeft. Daarbij kan tevens bepaald worden op welke gevallen de aanwijzing betrekking heeft.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.65
   - number: '2.66'
-    text: |-
+    text: >-
       Artikel 2.66 1 Onze Minister schrijft een persoon in de basisregistratie in op grond van een verzoek als bedoeld in
       artikel 2.67 of artikel 2.68 .
+
 
       2. Inschrijving geschiedt niet als de betrokkene reeds in de basisregistratie is ingeschreven.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.66
   - number: '2.67'
-    text: |-
+    text: >-
       Artikel 2.67 1 Eenieder kan Onze Minister verzoeken hem in te schrijven in de basisregistratie.
+
 
       2. Bij zijn verzoek overlegt de betrokkene ten minste de bij of krachtens algemene maatregel van bestuur aangewezen
       bescheiden ten behoeve van een juiste inschrijving.
+
 
       3. Onze Minister gaat niet over tot inschrijving dan nadat de betrokkene ten behoeve van de vaststelling van zijn
       identiteit in persoon bij de inschrijfvoorziening is verschenen. Bij of krachtens algemene maatregel van bestuur
       kan worden bepaald in welke gevallen van de verschijning in persoon kan worden afgezien.
 
+
       4. Onze Minister gaat niet over tot inschrijving dan nadat de identiteit van de betrokkene deugdelijk is
       vastgesteld.
+
 
       5. Onze Minister gaat niet over tot inschrijving als de betrokkene op grond van de eerste afdeling van dit
       hoofdstuk voor inschrijving in aanmerking komt.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.67
   - number: '2.68'
-    text: |-
+    text: >-
       Artikel 2.68 1 Een aangewezen bestuursorgaan kan Onze Minister verzoeken om een persoon in te schrijven in de
       basisregistratie.
+
 
       2. Het bestuursorgaan verzoekt alleen om inschrijving als het zelf gegevens over de betrokkene verwerkt in verband
       met de uitoefening van zijn taak.
 
+
       3. Het bestuursorgaan verzoekt niet om inschrijving dan nadat de identiteit van de betrokkene deugdelijk is
       vastgesteld.
+
 
       4. Het bestuursorgaan verzoekt niet om inschrijving als de betrokkene op grond van de eerste afdeling van dit
       hoofdstuk voor inschrijving in aanmerking komt.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.68
   - number: '2.69'
-    text: |-
+    text: >-
       Artikel 2.69 1 In de basisregistratie worden over de ingeschrevene uitsluitend de volgende gegevens opgenomen:
+
 
       a. algemene gegevens: - 1° gegevens over de burgerlijke staat waar het betreft de naam, de geboorte, het geslacht
       en het overlijden; - 2° gegevens over de nationaliteit, met dien verstande dat geen gegevens over een vreemde
@@ -1296,6 +1511,7 @@ articles:
       Nederlanderschap of het feit dat de betrokkene als Nederlander wordt behandeld; - 3° gegevens in verband met het
       verblijfsrecht van de vreemdeling; - 4° gegevens over het woonadres; - 5° gegevens over het burgerservicenummer van
       de ingeschrevene;
+
 
       b. administratieve gegevens: - 1° gegevens in verband met de inschrijving; - 2° gegevens over het
       niet-ingezetenschap; - 3° gegevens over de opgave van algemene gegevens die het aangewezen bestuursorgaan heeft
@@ -1314,32 +1530,40 @@ articles:
       noodzakelijk in verband met de bijhouding van de basisregistratie; - 6° gegevens over de beperking van de
       verstrekking van gegevens aan derden.
 
+
       2. Artikel 2.7, tweede tot en met vierde lid , is van overeenkomstige toepassing.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.69
   - number: '2.70'
-    text: |-
+    text: >-
       Artikel 2.70 1 Onze Minister neemt de gegevens over de burgerservicenummers op, overeenkomstig artikel 2.24 .
+
 
       2. Onze Minister neemt bij een inschrijving als bedoeld in artikel 2.67 de bij algemene maatregel van bestuur
       aangewezen algemene gegevens op.
 
+
       3. Onze Minister neemt in de overige gevallen algemene gegevens op:
+
 
       a. door ontlening aan een opgave van een aangewezen bestuursorgaan;
 
+
       b. op verzoek van de ingeschrevene.
+
 
       4. Onze Minister draagt zorg voor het opnemen van de administratieve gegevens die betrekking hebben op de algemene
       gegevens.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.70
   - number: '2.71'
-    text: |-
+    text: >-
       Artikel 2.71 1 Het aangewezen bestuursorgaan dat een opgave doet als bedoeld in artikel 2.70, derde lid, onder a ,
       geeft daarbij toepassing aan de artikelen 2.72 tot en met 2.75 .
+
 
       2. Indien het bestuursorgaan op grond van een wet, een verdrag of een besluit van een volkenrechtelijke organisatie
       gehouden is de desbetreffende gegevens te ontlenen aan een opgave van een buitenlands orgaan, ontleent het
       bestuursorgaan deze gegevens aan die opgave.
+
 
       3. Indien Onze Minister gegevens opneemt, anders dan door ontlening aan een opgave van een aangewezen
       bestuursorgaan, geeft hij daarbij toepassing aan de artikelen 2.72 tot en met 2.75 .
@@ -1353,174 +1577,204 @@ articles:
       Artikel 2.73 De gegevens over de nationaliteit worden vastgesteld overeenkomstig de artikelen 2.14 en 2.15 .
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.73
   - number: '2.74'
-    text: |-
+    text: >-
       Artikel 2.74 De gegevens in verband met het verblijfsrecht van de vreemdeling worden ontleend aan de gegevens die
       Onze Minister van Veiligheid en Justitie daarover tot zijn beschikking heeft.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.74
   - number: '2.75'
-    text: |-
+    text: >-
       Artikel 2.75 1 De gegevens over het woonadres worden ontleend aan een opgave van de ingeschrevene.
 
+
       2. Indien aannemelijk is dat een gegeven in de opgave onjuist is, wordt het gegeven niet aan de opgave ontleend.
+
 
       3. Als de ingeschrevene geen opgave heeft gedaan of aannemelijk is dat de opgave onjuiste gegevens bevat, kunnen de
       gegevens ambtshalve worden vastgesteld.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.75
   - number: '2.76'
-    text: |-
+    text: >-
       Artikel 2.76 Omtrent de vaststelling dat een opgenomen algemeen gegeven onjuist is of, indien het een gegeven over
       de burgerlijke staat betreft, in strijd is met de Nederlandse openbare orde, omtrent een onderzoek naar die
       onjuistheid of strijdigheid, alsmede omtrent de omstandigheid dat de ingeschrevene geen ingezetene is, wordt een
       aantekening geplaatst bij de desbetreffende gegevens.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.76
   - number: '2.77'
-    text: |-
+    text: >-
       Artikel 2.77 Bij of krachtens algemene maatregel van bestuur worden regels gesteld omtrent de wijze waarop een
       verzoek als bedoeld in artikel 2.68 en een opgave als bedoeld in artikel 2.70, derde lid , worden gedaan en omtrent
       de informatie die daarbij wordt overgelegd.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.77
   - number: '2.78'
-    text: |-
+    text: >-
       Artikel 2.78 1 Een aangewezen bestuursorgaan doet alleen een opgave als bedoeld in artikel 2.70, derde lid, onder a
       , voor zover het zelf de desbetreffende gegevens verwerkt in verband met de uitoefening van zijn taak. Als het
       bestuursorgaan bij die uitoefening de beschikking krijgt over gegevens over een ingeschrevene, die door middel van
       een dergelijke opgave kunnen leiden tot bijhouding van de basisregistratie, doet het bestuursorgaan opgave aan Onze
       Minister.
 
+
       2. Indien bij een algemeen gegeven een aantekening is geplaatst omtrent een onderzoek naar de onjuistheid of
       strijdigheid met de openbare orde, bevordert een aangewezen bestuursorgaan de goede vaststelling van het gegeven,
       voor zover het bestuursorgaan zelf het gegeven verwerkt in verband met de uitoefening van zijn taak.
+
 
       3. Bij of krachtens algemene maatregel van bestuur kunnen nadere regels worden gesteld omtrent de uitvoering van
       het eerste en tweede lid.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.78
   - number: '2.79'
-    text: |-
+    text: >-
       Artikel 2.79 1 De persoon die aan Onze Minister een verzoek als bedoeld in deze afdeling richt, doet dit door
       tussenkomst van een inschrijfvoorziening.
 
+
       2. Bij of krachtens algemene maatregel van bestuur kunnen nadere regels worden gesteld omtrent de indiening van een
       verzoek als bedoeld in het eerste lid en de informatie die daarbij wordt overgelegd.
+
 
       3. Bij algemene maatregel van bestuur worden regels gesteld omtrent de door de verzoeker verschuldigde rechten
       wegens handelingen ter uitvoering van het verzoek. Rechten kunnen slechts worden geheven voor zover de handelingen
       niet kosteloos moeten worden verricht.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.79
   - number: '2.80'
-    text: |-
+    text: >-
       Artikel 2.80 Indien Onze Minister in verband met het opnemen van gegevens in de basisregistratie over een persoon
       aan de betrokkene verzoekt om een document als bedoeld in [artikel 1 van de Wet op de
       identificatieplicht](jci1.3:c:BWBR0006297&artikel=1) met het oog op de vaststelling van diens identiteit, is de
       betrokkene verplicht een dergelijk op hem betrekking hebbend document over te leggen.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.80
   - number: '2.81'
-    text: |-
+    text: >-
       Artikel 2.81 1 Onze Minister stelt binnen vier weken na een inschrijving als bedoeld in artikel 2.66 aan de
       ingeschrevene in begrijpelijke vorm een volledig overzicht ter beschikking van zijn persoonslijst.
+
 
       2. Onze Minister vermeldt op schriftelijk verzoek van de betrokkene op zijn persoonslijst kosteloos een aantekening
       omtrent beperking van de verstrekking van gegevens aan derden. Onze Minister geeft binnen vier weken gevolg aan het
       verzoek en doet daarvan terstond schriftelijk mededeling aan de verzoeker, onder vermelding van de geldende regels
       ter zake.
 
+
       3. De artikelen 2.54, tweede en derde lid , 2.55 , 2.57 , 2.58 , 2.60 en 2.61 zijn van overeenkomstige toepassing
       ten aanzien van niet-ingezetenen met dien verstande dat Onze Minister in de plaats treedt van het college van
       burgemeester en wethouders en dat voor de toepassing van artikel 2.60, onderdeel a, voor «aangifte» wordt gelezen:
       verzoek.
 
+
       4. Een verzoek als bedoeld in artikel 2.55 kan ook worden gericht aan het college van burgemeester en wethouders
       van enige gemeente in Nederland.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel2.81
   - number: '3.1'
-    text: |-
+    text: >-
       Artikel 3.1 1 Deze paragraaf is van toepassing op de systematische verstrekking van gegevens uit de
       basisregistratie.
+
 
       2. Bij of krachtens algemene maatregel van bestuur wordt geregeld welke verstrekkingen systematische verstrekkingen
       zijn en worden nadere regels gesteld over deze verstrekkingen.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel3.1
   - number: '3.2'
-    text: |-
+    text: >-
       Artikel 3.2 1 Onze Minister verstrekt gegevens aan een overheidsorgaan, voor zover dit is bepaald in een besluit
       van Onze Minister.
 
+
       2. Onze Minister neemt het besluit op verzoek van het overheidsorgaan. Het verzoek bevat de gronden voor de
       verstrekking en de gegevens waarop het verzoek betrekking heeft.
+
 
       3. Bij de bepaling van de gegevens die worden verstrekt, worden de gegevens opgenomen die in het verzoek zijn
       vermeld voor zover het overheidsorgaan aantoont dat deze gegevens noodzakelijk zijn voor de goede vervulling van
       zijn taak.
 
+
       4. Bij het besluit wordt in ieder geval bepaald over welke categorieën van personen gegevens worden verstrekt,
       welke gegevens het betreft en in welke gevallen gegevens worden verstrekt.
+
 
       5. Aan het besluit kunnen voorschriften en beperkingen worden verbonden in het belang van een zorgvuldige en
       doelmatige gegevensverstrekking.
 
+
       6. Onze Minister draagt zorg voor onverwijlde publicatie van het besluit in de Staatscourant.
+
 
       7. Bij of krachtens algemene maatregel van bestuur kunnen nadere regels worden gesteld omtrent de indiening van het
       verzoek en de bekendmaking van het besluit.
 
+
       8. Onze Minister kan een besluit als bedoeld in het eerste lid weigeren te nemen of het besluit intrekken, indien
       de gevraagde gegevensverstrekking zodanig is dat verstrekking op grond van paragraaf 2 aangewezen is.
+
 
       9. Indien een overheidsorgaan verschillende taken uitoefent waarvoor gegevens worden gevraagd, kan Onze Minister
       bij het besluit de verschillende taken in aanmerking nemen.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel3.2
   - number: '3.3'
-    text: |-
+    text: >-
       Artikel 3.3 1 Bij algemene maatregel van bestuur worden door derden verrichte werkzaamheden met een gewichtig
       maatschappelijk belang aangewezen, ten behoeve waarvan gegevens uit de basisregistratie kunnen worden verstrekt. De
       maatregel bepaalt tevens de categorieën van derden die voor de verstrekking in aanmerking komen en bepaalt of
       artikel 3.21 op de verstrekking van toepassing is. De maatregel kan beperkingen bevatten ten aanzien van de
       gegevens die kunnen worden verstrekt.
 
+
       2. Bij de maatregel worden slechts werkzaamheden aangewezen die samenhangen met een overheidstaak, strekken tot het
       in stand houden van een voorziening voor burgers die onderwerp is van overheidszorg, of waarbij anderszins gelet op
       de overheidsbemoeienis met die werkzaamheden, ondersteuning daarvan door gegevensverstrekking uit de
       basisregistratie gerechtvaardigd is.
 
+
       3. Artikel 3.2 is van overeenkomstige toepassing.
+
 
       4. Op een verstrekking als bedoeld in het eerste lid is [artikel 76 van de Wet bescherming
       persoonsgegevens](jci1.3:c:BWBR0011468&artikel=76) van overeenkomstige toepassing.
+
 
       5. De voordracht voor een krachtens het eerste lid vast te stellen algemene maatregel van bestuur wordt niet eerder
       gedaan dan vier weken nadat het ontwerp aan beide kamers der Staten-Generaal is overgelegd.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel3.3
   - number: '3.4'
-    text: |-
+    text: >-
       Artikel 3.4 1 Deze paragraaf is van toepassing op de verstrekking van gegevens uit de basisregistratie, anders dan
       de systematische verstrekking, bedoeld in paragraaf 1 .
+
 
       2. Krachtens deze paragraaf kunnen gegevens worden verstrekt over alle ingeschrevenen.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel3.4
   - number: '3.5'
-    text: |-
+    text: >-
       Artikel 3.5 1 Het college van burgemeester en wethouders verstrekt op verzoek van een overheidsorgaan aan hem
       gegevens, voor zover deze gegevens noodzakelijk zijn voor de goede vervulling van zijn taak.
 
+
       2. Het verzoek bevat de gronden voor de verstrekking.
+
 
       3. Voor zover krachtens het bepaalde in deze paragraaf gegevens kunnen worden verstrekt, wordt op verzoek een
       gewaarmerkt afschrift van de in het verzoek aangewezen gegevens verstrekt.
+
 
       4. Het college weigert het verzoek indien de gevraagde gegevensverstrekking zodanig is dat verstrekking op grond
       van paragraaf 1 aangewezen is. Bij algemene maatregel van bestuur worden nadere regels gesteld omtrent gevallen
       waarin het college het verzoek moet weigeren.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel3.5
   - number: '3.6'
-    text: |-
+    text: >-
       Artikel 3.6 1 Het college van burgemeester en wethouders verstrekt op verzoek van een derde aan hem gegevens voor
       zover:
 
+
       a. het gebruik van die gegevens is voorgeschreven in een algemeen verbindend voorschrift,
+
 
       b. de derde voorafgaande schriftelijke toestemming heeft van de ingeschrevene over wie gegevens worden verstrekt,
       of
 
+
       c. de verstrekking in overeenstemming is met het tweede lid.
+
 
       2. Bij algemene maatregel van bestuur worden door derden verrichte werkzaamheden met een gewichtig maatschappelijk
       belang aangewezen, ten behoeve waarvan gegevens uit de basisregistratie kunnen worden verstrekt. De maatregel
@@ -1528,37 +1782,44 @@ articles:
       de verstrekking van toepassing is. De maatregel kan beperkingen bevatten ten aanzien van de gegevens die kunnen
       worden verstrekt.
 
+
       3. Artikel 3.3, tweede en vierde lid , en artikel 3.5, tweede, derde en vierde lid , zijn van overeenkomstige
       toepassing.
+
 
       4. De voordracht voor een krachtens het tweede lid vast te stellen algemene maatregel van bestuur wordt niet eerder
       gedaan dan vier weken nadat het ontwerp aan beide kamers der Staten-Generaal is overgelegd.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel3.6
   - number: '3.7'
-    text: |-
+    text: >-
       Artikel 3.7 1 Deze paragraaf is van toepassing op de verstrekking van gegevens uit de basisregistratie door het
       college van burgemeester van wethouders, anders dan de verstrekking, bedoeld in paragraaf 2 .
+
 
       2. Krachtens deze paragraaf worden uitsluitend gegevens verstrekt over ingeschrevenen ten aanzien van wie het
       college op grond van artikel 1.4 verantwoordelijk is voor de bijhouding van de persoonslijst.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel3.7
   - number: '3.8'
-    text: |-
+    text: >-
       Artikel 3.8 1 Bij of krachtens gemeentelijke verordening kunnen regels gesteld worden omtrent de verstrekking van
       gegevens aan overheidsorganen die een orgaan zijn van de gemeente.
+
 
       2. Aan een overheidsorgaan worden slechts gegevens verstrekt voor zover deze gegevens noodzakelijk zijn voor de
       goede vervulling van zijn taak.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel3.8
   - number: '3.9'
-    text: |-
+    text: >-
       Artikel 3.9 1 Op verzoek van een derde kunnen aan hem gegevens worden verstrekt voor zover daarin is voorzien bij
       gemeentelijke verordening en voor zover:
+
 
       a. de derde voorafgaande schriftelijke toestemming heeft van de ingeschrevene over wie gegevens worden verstrekt,
       of
 
+
       b. de verstrekking in overeenstemming is met het tweede lid.
+
 
       2. Bij gemeentelijke verordening kunnen door derden verrichte werkzaamheden met een gewichtig maatschappelijk
       belang voor de gemeente worden aangewezen, ten behoeve waarvan gegevens uit de basisregistratie kunnen worden
@@ -1567,9 +1828,11 @@ articles:
       gerechtvaardigde belang van de derde en het belang of de fundamentele rechten en vrijheden van de ingeschrevene
       niet aan de verstrekking in de weg staan.
 
+
       3. Aan een overheidsorgaan van, dan wel een persoon of organisatie gevestigd in een land buiten de Europese Unie
       worden slechts gegevens verstrekt overeenkomstig het eerste lid, onderdeel b, indien een verdrag of een besluit van
       een volkenrechtelijke organisatie in de verstrekking van die gegevens voorziet.
+
 
       4. De verstrekking kan uitsluitend betrekking hebben op algemene gegevens over de naam, het geslacht, de
       geslachtsnaam van de echtgenoot dan wel geregistreerde partner, de eerdere echtgenoot of eerdere geregistreerde
@@ -1577,13 +1840,15 @@ articles:
       de eerdere echtgenoot of eerdere geregistreerde partner, het adres, de bijhoudingsgemeente, de geboortedatum en de
       datum van overlijden.
 
+
       5. Artikel 3.3, tweede en vierde lid , en artikel 3.5, derde lid , zijn van overeenkomstige toepassing.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel3.9
   - number: '3.10'
-    text: |-
+    text: >-
       Artikel 3.10 1 Voor zover een algemeen gegeven wordt verstrekt waarbij een aantekening is geplaatst als bedoeld in
       artikel 2.26 , 2.59 , 2.76 of 2.81, tweede lid , wordt dat gegeven uitsluitend verstrekt onder mededeling van die
       aantekening.
+
 
       2. De verstrekking van algemene gegevens die zijn opgenomen krachtens artikel 2.70, tweede of derde lid , geschiedt
       met de mededeling van de bron waaruit de gegevens zijn verkregen, dan wel van de rechtsgrond krachtens welke de
@@ -1591,132 +1856,153 @@ articles:
       medegedeeld welk bestuursorgaan de opgave heeft gedaan.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel3.10
   - number: '3.11'
-    text: |-
+    text: >-
       Artikel 3.11 1 Het bestuursorgaan dat verantwoordelijk is voor de verstrekking van gegevens houdt gedurende twintig
       jaren volgend op de verstrekking aantekening van de verstrekking.
+
 
       2. Bij of krachtens algemene maatregel van bestuur wordt bepaald van welke verstrekkingen geen aantekening wordt
       gehouden in verband met de veiligheid van de staat of de voorkoming, opsporing of vervolging van strafbare feiten.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel3.11
   - number: '3.12'
-    text: |-
+    text: >-
       Artikel 3.12 Bij of krachtens algemene maatregel van bestuur kan een regeling worden getroffen omtrent de
       verstrekking van algemene en administratieve gegevens aan een verantwoordelijke voor de verwerking van gegevens in
       een basisadministratie in Aruba, Curaçao, Sint Maarten of een van de openbare lichamen.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel3.12
   - number: '3.13'
-    text: |-
+    text: >-
       Artikel 3.13 1 Een andere verstrekking uit de basisregistratie dan die bedoeld in de paragrafen 1 , 2 of 3 of in
       artikel 3.12 is slechts toegestaan voor zover daarin is voorzien bij algemene maatregel van bestuur en voor zover:
 
+
       a. de verstrekking plaats vindt voor historische, statistische of wetenschappelijke doeleinden;
+
 
       b. de persoonlijke levenssfeer niet onevenredig wordt geschaad;
 
+
       c. door de ontvanger van de gegevens de nodige voorzieningen zijn getroffen ten einde te verzekeren dat de verdere
       verwerking uitsluitend geschiedt ten behoeve van de onder a genoemde doeleinden.
+
 
       2. Bij of krachtens de in het eerste lid bedoelde maatregel kunnen nadere regels worden gesteld omtrent de
       verstrekking en de wijze waarop deze plaatsvindt.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel3.13
   - number: '3.14'
-    text: |-
+    text: >-
       Artikel 3.14 1 Onze Minister kan aan een overheidsorgaan of aan een derde informatie ter beschikking stellen die is
       verkregen door bewerking van gegevens uit de basisregistratie. Het betreft uitsluitend informatie die niet
       herleidbaar is tot gegevens betreffende een geïdentificeerde of identificeerbare ingeschrevene.
+
 
       2. Bij of krachtens algemene maatregel van bestuur kunnen nadere regels worden gesteld omtrent het ter beschikking
       stellen van informatie, bedoeld in het eerste lid.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel3.14
   - number: '3.15'
-    text: |-
+    text: >-
       Artikel 3.15 Indien op grond van de artikelen 2.55, derde lid , 3.5, derde lid , 3.6, derde lid , of 3.9, vijfde
       lid , een gewaarmerkt afschrift wordt verstrekt van gegevens ten aanzien van een vreemdeling op wiens persoonslijst
       geen actuele gegevens zijn opgenomen in verband met het verblijfsrecht, wordt hiervan mededeling gedaan op dat
       afschrift.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel3.15
   - number: '3.16'
-    text: |-
+    text: >-
       Artikel 3.16 Een derde kan bij het verwerken van persoonsgegevens gebruik maken van het burgerservicenummer voor
       zover dit noodzakelijk is in verband met de juiste verstrekking van gegevens aan hem uit de basisregistratie.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel3.16
   - number: '3.17'
-    text: |-
+    text: >-
       Artikel 3.17 1 De verstrekking van gegevens op grond van de artikelen 3.2 , 3.3 en 3.13 geschiedt kosteloos,
       onverminderd het bepaalde in artikel 1.14 .
+
 
       2. Het eerste lid is van overeenkomstige toepassing op het ter beschikking stellen van informatie, bedoeld in
       artikel 3.14 .
 
+
       3. Andere verstrekkingen aan een overheidsorgaan en verstrekkingen op grond van artikel 3.12 geschieden kosteloos.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel3.17
   - number: '3.18'
-    text: |-
+    text: >-
       Artikel 3.18 Een beslissing op grond van deze afdeling omtrent het verstrekken van gegevens of het ter beschikking
       stellen van informatie wordt gelijkgesteld met een besluit in de zin van de [Algemene wet
       bestuursrecht](jci1.3:c:BWBR0005537) .
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel3.18
   - number: '3.19'
-    text: |-
+    text: >-
       Artikel 3.19 1 Een verzoek als bedoeld in de artikelen 3.22 en 3.23 kan worden gericht aan het college van
       burgemeester en wethouders van enige gemeente.
+
 
       2. Het verzoek kan ook worden gericht aan Onze Minister. In dat geval treedt Onze Minister voor de toepassing van
       de artikelen 3.22 en 3.23 in de plaats van het college en wordt het verzoek gedaan door tussenkomst van een
       inschrijfvoorziening.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel3.19
   - number: '3.20'
-    text: |-
+    text: >-
       Artikel 3.20 De verstrekking aan de betrokkene van hem betreffende gegevens geschiedt ingevolge artikel 2.55 of
       ingevolge artikel 2.81 in samenhang met artikel 2.55.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel3.20
   - number: '3.21'
-    text: |-
+    text: >-
       Artikel 3.21 1 Indien op de persoonslijst een aantekening omtrent beperking van de verstrekking van gegevens aan
       derden is vermeld, worden geen gegevens van de persoonslijst verstrekt op grond van:
 
+
       a. de artikelen 3.3 en 3.6 , voor zover de beperking van de verstrekking van toepassing is;
 
+
       b. artikel 3.9 .
+
 
       2. In afwijking van het eerste lid verstrekt het college van burgemeester en wethouders gegevens op grond van
       artikel 3.6, eerste lid, onderdelen a en c , indien de persoonlijke levenssfeer daardoor niet onevenredig wordt
       geschaad.
 
+
       3. Het college maakt een beschikking, waarmee het toepassing geeft aan het tweede lid, terstond bekend aan de
       betrokkene. Het geeft geen uitvoering aan de beschikking binnen een bij die beschikking gestelde termijn.
 
+
       4. Artikel 2.55, vierde en vijfde lid , is van overeenkomstige toepassing.
+
 
       5. Het college neemt passende maatregelen om ten minste eens per jaar aan de ingezetenen het recht, bedoeld in het
       eerste lid, bekend te maken. De bekendmaking vindt plaats via één of meer dag-, nieuws-, of huis-aan-huisbladen of
       op een andere geschikte wijze.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel3.21
   - number: '3.22'
-    text: |-
+    text: >-
       Artikel 3.22 1 Het college van burgemeester en wethouders deelt aan de betrokkene op diens verzoek kosteloos en
       schriftelijk binnen vier weken mede of hem betreffende gegevens gedurende twintig jaren voorafgaande aan het
       verzoek uit de basisregistratie zijn verstrekt aan een overheidsorgaan of een derde.
+
 
       2. Indien zodanige verstrekking is geschied, doet het college daarvan desgevraagd binnen vier weken na ontvangst
       van het verzoek kosteloos en schriftelijk mededeling aan verzoeker. Het college kan volstaan met een in algemene
       termen gestelde mededeling omtrent de verstrekking, tenzij het belang van de verzoeker daardoor onevenredig wordt
       geschaad.
 
+
       3. Het college voldoet niet aan het in het eerste en tweede lid bedoelde verzoek voor zover:
 
+
       a. van de verstrekking geen aantekening is gehouden krachtens artikel 3.11, tweede lid ;
+
 
       b. dit noodzakelijk is in het belang van de veiligheid van de staat of de voorkoming, opsporing en vervolging van
       strafbare feiten.
 
+
       4. Bij of krachtens algemene maatregel van bestuur kan nader geregeld worden in welke gevallen toepassing gegeven
       moet worden aan het derde lid, onderdeel b.
+
 
       5. Artikel 2.55, vierde en vijfde lid , is van overeenkomstige toepassing.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel3.22
   - number: '3.23'
-    text: |-
+    text: >-
       Artikel 3.23 1 Het college van burgemeester en wethouders doet op schriftelijk verzoek van de betrokkene, indien op
       grond van het verzoek, bedoeld in de artikelen 2.57 en 2.58 , een besluit als bedoeld in artikel 2.60 , dan wel de
       uitspraak van de rechter, bedoeld in artikel 2.61 , ten aanzien van hem gegevens zijn verbeterd, aangevuld of
@@ -1724,151 +2010,183 @@ articles:
       aan het verzoek en in de sedert dat verzoek verstreken tijd, de desbetreffende gegevens zijn verstrekt, tenzij dit
       onmogelijk blijkt of een onevenredige inspanning kost.
 
+
       2. Het verzoek, bedoeld in het eerste lid, kan de betrokkene aan het college richten tot uiterlijk acht weken nadat
       hij van de wijziging kennis heeft kunnen nemen.
+
 
       3. Het college doet aan de verzoeker desgevraagd opgave van degenen aan wie de mededeling, bedoeld in het eerste
       lid, is gedaan. Artikel 3.22, derde lid , is van overeenkomstige toepassing.
 
+
       4. Artikel 2.55, vierde en vijfde lid , is van overeenkomstige toepassing.
+
 
       5. Dit artikel is van overeenkomstige toepassing indien gegevens ten aanzien van de betrokkene zijn verbeterd,
       aangevuld of verwijderd op grond van een verzoek ingevolge artikel 2.81 in samenhang met de artikelen 2.57 , 2.58,
       2.60 en 2.61 .
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel3.23
   - number: '3.24'
-    text: |-
+    text: >-
       Artikel 3.24 Een beslissing op een verzoek als bedoeld in deze afdeling wordt gelijkgesteld met een besluit in de
       zin van de [Algemene wet bestuursrecht](jci1.3:c:BWBR0005537) .
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel3.24
   - number: '4.1'
-    text: |-
+    text: >-
       Artikel 4.1 1 Het College bescherming persoonsgegevens ziet in het belang van de bescherming van de persoonlijke
       levenssfeer toe op de uitvoering van deze wet.
+
 
       2. De [artikelen 60](jci1.3:c:BWBR0011468&artikel=60) , [61](jci1.3:c:BWBR0011468&artikel=61) en [65 van de Wet
       bescherming persoonsgegevens](jci1.3:c:BWBR0011468&artikel=65) zijn van overeenkomstige toepassing.
 
+
       3. De [artikelen 124](jci1.3:c:BWBR0005416&artikel=124) en [268 van de
       Gemeentewet](jci1.3:c:BWBR0005416&artikel=268) blijven buiten toepassing ten aanzien van het toezicht op het
       college van burgemeester en wethouders inzake de uitvoering van de hoofdstukken 2 en 3 .
+
 
       4. Het College wordt om advies gevraagd over voorstellen van wet tot wijziging van deze wet en ontwerpen van
       algemene maatregelen van bestuur op grond van deze wet die geheel of voor een belangrijk deel betrekking hebben op
       de verwerking van persoonsgegevens.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel4.1
   - number: '4.2'
-    text: |-
+    text: >-
       Artikel 4.2 Het college van burgemeester en wethouders wijst ambtenaren aan die zijn belast met het toezicht op de
       naleving van de verplichtingen van de burger ingevolge hoofdstuk 2, afdeling 1, paragraaf 5 .
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel4.2
   - number: '4.3'
-    text: |-
+    text: >-
       Artikel 4.3 1 Het college van burgemeester en wethouders verricht periodiek een onderzoek naar de inrichting, de
       werking en de beveiliging van de basisregistratie, alsmede naar de verwerking van gegevens in de basisregistratie,
       voor zover het de gemeentelijke voorziening betreft of het college verantwoordelijk is voor de bijhouding.
 
+
       2. Het college van burgemeester en wethouders zendt periodiek een uittreksel van de resultaten van het onderzoek
       aan het College bescherming persoonsgegevens.
+
 
       3. Het eerste en tweede lid zijn van overeenkomstige toepassing op Onze Minister met dien verstande dat het
       onderzoek betrekking heeft op de centrale voorzieningen.
 
+
       4. Het college van burgemeester en wethouders zendt periodiek een uittreksel van de resultaten van het onderzoek
       aan Onze Minister ten behoeve van een landelijk beeld van de in het eerste lid bedoelde aspecten.
+
 
       5. Bij of krachtens algemene maatregel van bestuur worden nadere regels gesteld met betrekking tot de periodiciteit
       en de uitvoering van de onderzoeken, bedoeld in het eerste lid, en de periodiciteit van de in het tweede en vierde
       lid bedoelde verzendingen en de inhoud van de in die leden bedoelde uittreksels.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel4.3
   - number: '4.4'
-    text: |-
+    text: >-
       Artikel 4.4 1 Het college van burgemeester en wethouders is ten behoeve van de uitvoering van deze wet tot een bij
       koninklijk besluit te bepalen datum verantwoordelijk voor de verwerking van persoonsgegevens in het
       persoonsregister, bedoeld in het Besluit bevolkingsboekhouding.
+
 
       2. Bij of krachtens algemene maatregel van bestuur kunnen regels worden gesteld omtrent de in het eerste lid
       bedoelde verwerking van persoonsgegevens. Daarbij kan worden bepaald dat het persoonsregister op een andere wijze
       dan in de vorm van persoonskaarten, bedoeld in het Besluit bevolkingsboekhouding, kan worden aangehouden en kan de
       vernietiging van de persoonskaarten worden geregeld.
 
+
       3. Uit het persoonsregister worden geen andere gegevens verstrekt dan:
+
 
       a. gegevens als bedoeld in artikel 2.7 ;
 
+
       b. gegevens uit vak 23 van de persoonskaart.
+
 
       4. Op de verstrekking, bedoeld in het derde lid, is hoofdstuk 3 , met uitzondering van de artikelen 3.1 tot en met
       3.3 , van overeenkomstige toepassing.
 
+
       5. De artikelen 2.53, eerste lid , 2.55 en 2.57 tot en met 2.61 zijn van overeenkomstige toepassing.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel4.4
   - number: '4.5'
-    text: |-
+    text: >-
       Artikel 4.5 1 Onze Minister is ten behoeve van de uitvoering van deze wet tot een bij koninklijk besluit te bepalen
       datum verantwoordelijk voor de verwerking van persoonsgegevens in het persoonskaartenarchief en het
       schakelregister, bedoeld in het Besluit bevolkingsboekhouding.
+
 
       2. Onze Minister kan de verantwoordelijkheid voor de verwerking, bedoeld in het eerste lid, overdragen aan het
       college van burgemeester en wethouders van een gemeente. De overdracht geschiedt slechts na instemming van dat
       college.
 
+
       3. Ten aanzien van het persoonskaartenarchief is artikel 4.4, tweede tot en met vijfde lid , van overeenkomstige
       toepassing.
+
 
       4. Ten aanzien van het schakelregister is artikel 4.4, tweede, vierde en vijfde lid , van overeenkomstige
       toepassing.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel4.5
   - number: '4.6'
-    text: |-
+    text: >-
       Artikel 4.6 Onze Minister, of het in artikel 4.5, tweede lid , bedoelde college van burgemeester en wethouders,
       verstrekt op verzoek van het college dat een persoon inschrijft van wie in het persoonskaartenarchief een
       persoonskaart is opgenomen, de gegevens die zijn vermeld op de desbetreffende persoonskaart. Deze gegevens blijven
       berusten bij het college waaraan ze zijn verstrekt, waarbij artikel 4.4 van overeenkomstige toepassing is.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel4.6
   - number: '4.7'
-    text: |-
+    text: >-
       Artikel 4.7 1 Er is een centraal archief van overledenen, bestaande uit de persoonskaarten, bedoeld in het Besluit
       bevolkingsboekhouding.
+
 
       2. Onze Minister is verantwoordelijk voor de verwerking van persoonsgegevens in het centraal archief van
       overledenen, bedoeld in het eerste lid. Hij treft een regeling ter bescherming van de persoonlijke levenssfeer.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel4.7
   - number: '4.8'
-    text: |-
+    text: >-
       Artikel 4.8 1 Bij of krachtens algemene maatregel van bestuur worden regels gesteld omtrent heffingen in verband
       met de verstrekking van gegevens uit de hierna genoemde registraties, voor zover Onze Minister verantwoordelijk is
       voor de verwerking van persoonsgegevens in deze registraties:
 
+
       a. het persoonskaartenarchief;
+
 
       b. het schakelregister;
 
+
       c. het centraal archief van overledenen.
+
 
       2. Op grond van de in het eerste lid bedoelde regels kunnen uitsluitend heffingen ingesteld worden in verband met
       de verstrekking van gegevens aan derden, anders dan de verstrekking overeenkomstig artikel 3.3 , en in verband met
       de verstrekking aan de betrokkene van hem betreffende gegevens.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel4.8
   - number: '4.9'
-    text: |-
+    text: >-
       Artikel 4.9 1 Naast de in artikel 2.7 bedoelde algemene gegevens worden tot een bij koninklijk besluit te bepalen
       datum over de op grond van hoofdstuk 1, afdeling 1, paragraaf 2 ingeschreven personen de volgende algemene gegevens
       opgenomen:
 
+
       a. het administratienummer van de ingeschrevene;
+
 
       b. de administratienummers van de ouders, de echtgenoot, de eerdere echtgenoten, de geregistreerde partner, de
       eerdere geregistreerde partners en de kinderen;
 
+
       c. de data waarop de onder a en b bedoelde nummers van kracht zijn geworden of beëindigd.
+
 
       2. Naast de in artikel 2.69 bedoelde algemene gegevens worden tot een bij koninklijk besluit te bepalen datum over
       de op grond van hoofdstuk 1, afdeling 2, paragraaf 2 ingeschreven personen de volgende algemene gegevens opgenomen:
 
+
       a. het administratienummer van de ingeschrevene;
 
+
       b. de datum waarop het nummer van kracht is geworden of beëindigd.
+
 
       3. Tot de laatste van de in de aanhef van het eerste en tweede lid bedoelde data blijft [artikel 50 van de Wet
       gemeentelijke basisadministratie persoonsgegevens](jci1.3:c:BWBR0006723&artikel=50) zoals dat luidde voor de
@@ -1877,116 +2195,136 @@ articles:
       tweede, derde en zesde lid, van overeenkomstige toepassing, met dien verstande dat het nummer wordt toegekend door
       Onze Minister. Onze Minister neemt de gegevens, bedoeld in het tweede lid, op in de basisregistratie.
 
+
       4. Een overheidsorgaan kan tot de in het derde lid bedoelde datum bij het verwerken van persoonsgegevens in het
       kader van de uitvoering van zijn taak gebruik maken van het administratienummer.
+
 
       5. Een derde kan tot de in het derde lid bedoelde datum bij het verwerken van persoonsgegevens gebruik maken van
       het administratienummer voor zover dit noodzakelijk is in verband met de juiste verstrekking aan hem van gegevens
       uit de basisregistratie.
 
+
       6. Na de in het derde lid bedoelde datum wordt het administratienummer niet meer gebruikt.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel4.9
   - number: '4.10'
-    text: |-
+    text: >-
       Artikel 4.10 1 Een besluit als bedoeld in [artikel 91, eerste lid, van de Wet gemeentelijke basisadministratie
       persoonsgegevens](jci1.3:c:BWBR0006723&artikel=91) geldt na de inwerkingtreding van deze wet als een besluit als
       bedoeld in artikel 3.2 .
+
 
       2. Een besluit als bedoeld in [artikel 99, zevende lid, van de Wet gemeentelijke basisadministratie
       persoonsgegevens](jci1.3:c:BWBR0006723&artikel=99) geldt na de inwerkingtreding van deze wet als een besluit als
       bedoeld in artikel 3.3 .
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel4.10
   - number: '4.11'
-    text: |-
+    text: >-
       Artikel 4.11 Een persoonslijst als bedoeld in [artikel 1 van de Wet gemeentelijke basisadministratie
       persoonsgegevens](jci1.3:c:BWBR0006723&artikel=1) geldt na de inwerkingtreding van deze wet als een persoonslijst
       als bedoeld in artikel 1.1, onderdeel c , van deze wet.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel4.11
   - number: '4.12'
-    text: |-
+    text: >-
       Artikel 4.12 Bij of krachtens algemene maatregel van bestuur worden regels gesteld omtrent het verwijderen en
       vernietigen van gegevens over een vreemde nationaliteit naast gegevens over het Nederlanderschap of het feit dat de
       betrokkene als Nederlander wordt behandeld. Daarbij kan worden afgeweken van de artikelen 2.7 en 2.69 .
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel4.12
   - number: '4.13'
-    text: |-
+    text: >-
       Artikel 4.13 1 Dit artikel is van toepassing op gevallen als bedoeld in artikel 2.1, derde lid , met uitzondering
       van het geval dat de betrokkene op het moment van zijn overlijden ingezetene was.
+
 
       2. De voormalige bijhoudingsgemeente doet aan Onze Minister een opgave van de gegevens die in de basisregistratie
       moeten worden opgenomen.
 
+
       3. Onze Minister neemt de gegevens op door deze te ontlenen aan de in het tweede lid bedoelde opgave.
+
 
       4. Bij of krachtens algemene maatregel van bestuur kunnen nadere regels worden gesteld omtrent de wijze waarop een
       opgave wordt gedaan en de informatie die daarbij wordt overgelegd.
 
+
       5. Dit artikel is van toepassing tot een bij koninklijk besluit te bepalen tijdstip.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel4.13
   - number: '4.14'
-    text: |-
+    text: >-
       Artikel 4.14 De verplichting, bedoeld in artikel 2.81, eerste lid , is niet van toepassing na een inschrijving als
       bedoeld in artikel 2.66 , indien de inschrijving geschiedt op grond van een verzoek als bedoeld in artikel 2.68 en
       wordt gedaan ten aanzien van op het moment van inwerkingtreding van deze wet bij de aangewezen bestuursorganen
       bekende personen.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel4.14
   - number: '4.15'
-    text: |-
+    text: >-
       Artikel 4.15 1 Een college van burgemeester en wethouders geeft uitvoering aan deze wet met behulp van de
       gemeentelijke voorziening waarmee uitvoering werd gegeven aan de [Wet gemeentelijke basisadministratie
       persoonsgegevens](jci1.3:c:BWBR0006723&artikel=1) (de oude gemeentelijke voorziening) of met de gemeentelijke
       voorziening die is toegesneden op de basisregistratie personen (de nieuwe gemeentelijke voorziening).
 
+
       2. De overgang van gemeenten van de oude naar de nieuwe voorzieningen geschiedt per gemeente of groep van
       gemeenten.
+
 
       3. Bij of krachtens algemene maatregel van bestuur worden regels gesteld in verband met de overgang, waaronder
       regels omtrent het tijdstip van de overgang. Bij deze regels kan worden afgeweken van de hoofdstukken 2 en 3 van
       deze wet, voor zover het betreft:
 
+
       a. de conversie van gegevens, indien een gemeente met een oude voorziening de bijhoudingsgemeente wordt;
+
 
       b. het doen van verzoeken als bedoeld in artikel 2.53 aan een ander dan de bijhoudingsgemeente;
 
+
       c. het doen van een verzoek als bedoeld in artikel 2.59 ;
+
 
       d. het verstrekken van gegevens op grond van de artikelen 3.5 en 3.6 over personen waarvoor de gemeente niet de
       bijhoudingsgemeente is;
 
+
       e. het doen van verzoeken als bedoeld in artikel 3.19 aan een ander dan de bijhoudingsgemeente, en
+
 
       f. overige aspecten inzake de bijhouding en verstrekking van gegevens, voor zover de afwijking noodzakelijk is in
       verband met een goede bijhouding en verstrekking van de gegevens in de basisregistratie gedurende de overgang van
       de oude naar de nieuwe voorzieningen.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel4.15
   - number: '4.16'
-    text: |-
+    text: >-
       Artikel 4.16 1 Een overheidsorgaan waaraan of een derde aan wie systematisch gegevens worden verstrekt wisselt
       berichten uit met de centrale voorzieningen op de wijze waarop de berichtuitwisseling plaats vond onder de [Wet
       gemeentelijke basisadministratie persoonsgegevens](jci1.3:c:BWBR0006723) (de oude berichtuitwisseling) of op de
       wijze die is toegesneden op de basisregistratie personen (de nieuwe berichtuitwisseling).
+
 
       2. De overgang van de in het eerste lid bedoelde overheidsorganen of derden van de oude naar de nieuwe
       berichtuitwisseling geschiedt per overheidsorgaan of derde, of per groep van organen of derden. De overgang kan
       betrekking hebben op delen van de organisatie van het overheidsorgaan of de derde en op verschillende wijzen van
       systematische verstrekking.
 
+
       3. Bij of krachtens algemene maatregel van bestuur worden regels gesteld in verband met de overgang, waaronder
       regels omtrent het tijdstip van de overgang.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel4.16
   - number: '4.17'
-    text: |-
+    text: >-
       Artikel 4.17 Het college van burgemeester en wethouders kan een bestuurlijke boete van ten hoogste 325 euro
       opleggen:
 
+
       a. ter zake van overtreding van de artikelen 2.38 , 2.39 , 2.40, vijfde lid , 2.43 tot en met 2.47 , 2.50 , 2.51 en
       2.52 ;
+
 
       b. aan degene met een woonadres in de gemeente die bewust toelaat dat een andere persoon met datzelfde woonadres is
       ingeschreven, terwijl hij weet dat dit onjuist is.
     url: https://wetten.overheid.nl/BWBR0033715/2025-02-12#Artikel4.17
   - number: '4.18'
-    text: |-
+    text: >-
       Artikel 4.18 De termijn, bedoeld in [artikel 12, eerste lid, van de Archiefwet
       1995](jci1.3:c:BWBR0007376&artikel=12) vangt aan bij degene die op de dag van zijn overlijden ingezetene is, op die
       dag, en bij degene die na vertrek uit Nederland op de dag vallende honderd jaar na de geboorte niet ingezetene is,

--- a/corpus/regulation/nl/wet/wet_inkomstenbelasting_2001/2024-01-01.yaml
+++ b/corpus/regulation/nl/wet/wet_inkomstenbelasting_2001/2024-01-01.yaml
@@ -86,7 +86,7 @@ articles:
                 - $vervreemdingsvoordelen
 
   - number: '5.2'
-    text: |-
+    text: >-
       Rendementsgrondslag is de waarde van de bezittingen verminderd met de waarde van de schulden. De
       rendementsgrondslag aan het begin van het kalenderjaar (peildatum 1 januari) wordt als uitgangspunt genomen.
     url: https://wetten.overheid.nl/BWBR0011353/2024-01-01#Artikel5.2

--- a/corpus/regulation/nl/wet/wet_inkomstenbelasting_2001/2025-01-01.yaml
+++ b/corpus/regulation/nl/wet/wet_inkomstenbelasting_2001/2025-01-01.yaml
@@ -86,7 +86,7 @@ articles:
                 - $vervreemdingsvoordelen
 
   - number: '5.2'
-    text: |-
+    text: >-
       Rendementsgrondslag is de waarde van de bezittingen verminderd met de waarde van de schulden. De
       rendementsgrondslag aan het begin van het kalenderjaar (peildatum 1 januari) wordt als uitgangspunt genomen.
     url: https://wetten.overheid.nl/BWBR0011353/2025-01-01#Artikel5.2

--- a/corpus/regulation/nl/wet/wet_op_de_zorgtoeslag/2024-01-01.yaml
+++ b/corpus/regulation/nl/wet/wet_op_de_zorgtoeslag/2024-01-01.yaml
@@ -10,8 +10,9 @@ name: '#wet_naam'
 competent_authority: '#bevoegd_gezag'
 articles:
   - number: '1'
-    text: |-
+    text: >-
       In deze wet en de daarop berustende bepalingen wordt verstaan onder:
+
 
       a. verzekerde: degene die ingevolge de Zorgverzekeringswet verzekerd is; b. toetsingsinkomen: het verzamelinkomen,
       bedoeld in artikel 2.18 van de Wet inkomstenbelasting 2001; c. drempelinkomen: het bedrag, bedoeld in artikel 2,
@@ -19,7 +20,7 @@ articles:
       artikel 4.
     url: https://wetten.overheid.nl/BWBR0018451/2024-01-01#Artikel1
   - number: 1a
-    text: |-
+    text: >-
       In deze wet en de daarop berustende bepalingen wordt verstaan onder Onze Minister: Onze Minister van
       Volksgezondheid, Welzijn en Sport.
     url: https://wetten.overheid.nl/BWBR0018451/2024-01-01#Artikel1a
@@ -27,27 +28,33 @@ articles:
       definitions:
         verantwoordelijke_autoriteit: Minister van Volksgezondheid, Welzijn en Sport
   - number: '2'
-    text: |-
+    text: >-
       1. Indien de normpremie voor een verzekerde in het berekeningsjaar minder bedraagt dan de standaardpremie in dat
       jaar, heeft de verzekerde aanspraak op een zorgtoeslag ter grootte van dat verschil. Voor een verzekerde met een
       toeslagpartner geldt het dubbele van de standaardpremie en worden de verzekerde en de toeslagpartner geacht
       gezamenlijk aanspraak te maken op zorgtoeslag.
 
+
       2. De normpremie bedraagt een percentage van het drempelinkomen in het berekeningsjaar, vermeerderd met een
       percentage van het toetsingsinkomen van de verzekerde. Ingeval de verzekerde een toeslagpartner heeft, wordt het
       gezamenlijk toetsingsinkomen van de verzekerde en de toeslagpartner in aanmerking genomen.
+
 
       3. De percentages, bedoeld in het tweede lid, bedragen voor een verzekerde met een toeslagpartner 4,256 procent van
       het drempelinkomen, vermeerderd met 13,670 procent van het toetsingsinkomen, en voor een verzekerde zonder
       toeslagpartner 1,879 procent van het drempelinkomen, vermeerderd met 13,670 procent van het toetsingsinkomen. Bij
       ministeriële regeling kunnen deze percentages worden gewijzigd.
 
+
       4. In afwijking van het eerste lid bedraagt de aanspraak op een zorgtoeslag voor een verzekerde met een partner die
       geen verzekerde is, vijftig procent van het op grond van het eerste lid berekende bedrag.
 
+
       5. De aanspraak op een zorgtoeslag wordt voor iedere kalendermaand afzonderlijk bepaald.
 
+
       6. Bij ministeriële regeling kunnen nadere regels worden gesteld.
+
 
       7. Onze Minister zendt een voornemen tot wijziging van de percentages, bedoeld in het derde lid, ten minste twee
       weken voor de vaststelling aan beide kamers der Staten-Generaal.
@@ -204,7 +211,7 @@ articles:
                   subject: $hoogte_zorgtoeslag
                   value: 0
   - number: '3'
-    text: |-
+    text: >-
       Een verzekerde heeft geen aanspraak op zorgtoeslag indien de rendementsgrondslag, bedoeld in artikel 5.2 van de Wet
       inkomstenbelasting 2001, van de verzekerde of, ingeval de verzekerde een toeslagpartner heeft, de gezamenlijke
       rendementsgrondslag van de verzekerde en de toeslagpartner op de peildatum meer bedraagt dan € 127.582 voor een
@@ -259,7 +266,7 @@ articles:
                     then: $vermogensgrens_aanvrager_met_toeslagpartner
                 default: $vermogensgrens_alleenstaand
   - number: '4'
-    text: |-
+    text: >-
       Onze Minister stelt uiterlijk 22 dagen voorafgaande aan het berekeningsjaar bij regeling de standaardpremie voor
       het berekeningsjaar vast.
     url: https://wetten.overheid.nl/BWBR0018451/2024-01-01#Artikel4
@@ -281,16 +288,18 @@ articles:
           - output: standaardpremie
             value: $standaardpremie
   - number: 4a
-    text: |-
+    text: >-
       Voor de persoon, bedoeld in artikel 69 van de Zorgverzekeringswet, wordt de standaardpremie aangepast aan de hand
       van de verhouding tussen de zorguitgaven per verzekerde in het land waar de persoon woont en de zorguitgaven per
       verzekerde in Nederland.
     url: https://wetten.overheid.nl/BWBR0018451/2024-01-01#Artikel4a
   - number: '5'
-    text: |-
+    text: >-
       1. De Dienst Toeslagen is belast met de uitvoering van deze wet.
 
+
       2. Tot en met 4. [Procedurele bepalingen over aanvraag en betaling]
+
 
       5. De zorgtoeslag komt ten laste van het Rijk.
     url: https://wetten.overheid.nl/BWBR0018451/2024-01-01#Artikel5
@@ -300,7 +309,7 @@ articles:
           - output: bevoegd_gezag
             value: Dienst Toeslagen
   - number: '6'
-    text: |-
+    text: >-
       Onze Minister zendt binnen vier jaar na de inwerkingtreding van deze wet, en vervolgens telkens na vier jaar, aan
       de Staten-Generaal een verslag over de doeltreffendheid en de effecten van deze wet in de praktijk.
     url: https://wetten.overheid.nl/BWBR0018451/2024-01-01#Artikel6

--- a/corpus/regulation/nl/wet/wet_op_de_zorgtoeslag/2025-01-01.yaml
+++ b/corpus/regulation/nl/wet/wet_op_de_zorgtoeslag/2025-01-01.yaml
@@ -10,8 +10,9 @@ name: '#wet_naam'
 competent_authority: '#bevoegd_gezag'
 articles:
   - number: '1'
-    text: |-
+    text: >-
       In deze wet en de daarop berustende bepalingen wordt verstaan onder:
+
 
       a. verzekerde: degene die ingevolge de Zorgverzekeringswet verzekerd is; b. toetsingsinkomen: het verzamelinkomen,
       bedoeld in artikel 2.18 van de Wet inkomstenbelasting 2001; c. drempelinkomen: het bedrag, bedoeld in artikel 2,
@@ -19,7 +20,7 @@ articles:
       artikel 4.
     url: https://wetten.overheid.nl/BWBR0018451/2025-01-01#Artikel1
   - number: 1a
-    text: |-
+    text: >-
       In deze wet en de daarop berustende bepalingen wordt verstaan onder Onze Minister: Onze Minister van
       Volksgezondheid, Welzijn en Sport.
     url: https://wetten.overheid.nl/BWBR0018451/2025-01-01#Artikel1a
@@ -27,27 +28,33 @@ articles:
       definitions:
         verantwoordelijke_autoriteit: Minister van Volksgezondheid, Welzijn en Sport
   - number: '2'
-    text: |-
+    text: >-
       1. Indien de normpremie voor een verzekerde in het berekeningsjaar minder bedraagt dan de standaardpremie in dat
       jaar, heeft de verzekerde aanspraak op een zorgtoeslag ter grootte van dat verschil. Voor een verzekerde met een
       toeslagpartner geldt het dubbele van de standaardpremie en worden de verzekerde en de toeslagpartner geacht
       gezamenlijk aanspraak te maken op zorgtoeslag.
 
+
       2. De normpremie bedraagt een percentage van het drempelinkomen in het berekeningsjaar, vermeerderd met een
       percentage van het toetsingsinkomen van de verzekerde. Ingeval de verzekerde een toeslagpartner heeft, wordt het
       gezamenlijk toetsingsinkomen van de verzekerde en de toeslagpartner in aanmerking genomen.
+
 
       3. De percentages, bedoeld in het tweede lid, bedragen voor een verzekerde met een toeslagpartner 4,273 procent van
       het drempelinkomen, vermeerderd met 13,700 procent van het toetsingsinkomen, en voor een verzekerde zonder
       toeslagpartner 1,896 procent van het drempelinkomen, vermeerderd met 13,700 procent van het toetsingsinkomen. Bij
       ministeriële regeling kunnen deze percentages worden gewijzigd.
 
+
       4. In afwijking van het eerste lid bedraagt de aanspraak op een zorgtoeslag voor een verzekerde met een partner die
       geen verzekerde is, vijftig procent van het op grond van het eerste lid berekende bedrag.
 
+
       5. De aanspraak op een zorgtoeslag wordt voor iedere kalendermaand afzonderlijk bepaald.
 
+
       6. Bij ministeriële regeling kunnen nadere regels worden gesteld.
+
 
       7. Onze Minister zendt een voornemen tot wijziging van de percentages, bedoeld in het derde lid, ten minste twee
       weken voor de vaststelling aan beide kamers der Staten-Generaal.
@@ -228,7 +235,7 @@ articles:
                   subject: $hoogte_zorgtoeslag
                   value: 0
   - number: '3'
-    text: |-
+    text: >-
       Een verzekerde heeft geen aanspraak op zorgtoeslag indien de rendementsgrondslag, bedoeld in artikel 5.2 van de Wet
       inkomstenbelasting 2001, van de verzekerde of, ingeval de verzekerde een toeslagpartner heeft, de gezamenlijke
       rendementsgrondslag van de verzekerde en de toeslagpartner op de peildatum meer bedraagt dan € 141.896 voor een
@@ -287,7 +294,7 @@ articles:
                     then: $vermogensgrens_aanvrager_met_toeslagpartner
                 default: $vermogensgrens_alleenstaand
   - number: '4'
-    text: |-
+    text: >-
       Onze Minister stelt uiterlijk 22 dagen voorafgaande aan het berekeningsjaar bij regeling de standaardpremie voor
       het berekeningsjaar vast.
     url: https://wetten.overheid.nl/BWBR0018451/2025-01-01#Artikel4
@@ -309,16 +316,18 @@ articles:
           - output: standaardpremie
             value: $standaardpremie
   - number: 4a
-    text: |-
+    text: >-
       Voor de persoon, bedoeld in artikel 69 van de Zorgverzekeringswet, wordt de standaardpremie aangepast aan de hand
       van de verhouding tussen de zorguitgaven per verzekerde in het land waar de persoon woont en de zorguitgaven per
       verzekerde in Nederland.
     url: https://wetten.overheid.nl/BWBR0018451/2025-01-01#Artikel4a
   - number: '5'
-    text: |-
+    text: >-
       1. De Dienst Toeslagen is belast met de uitvoering van deze wet.
 
+
       2. Tot en met 4. [Procedurele bepalingen over aanvraag en betaling]
+
 
       5. De zorgtoeslag komt ten laste van het Rijk.
     url: https://wetten.overheid.nl/BWBR0018451/2025-01-01#Artikel5
@@ -328,7 +337,7 @@ articles:
           - output: bevoegd_gezag
             value: Dienst Toeslagen
   - number: '6'
-    text: |-
+    text: >-
       Onze Minister zendt binnen vier jaar na de inwerkingtreding van deze wet, en vervolgens telkens na vier jaar, aan
       de Staten-Generaal een verslag over de doeltreffendheid en de effecten van deze wet in de praktijk.
     url: https://wetten.overheid.nl/BWBR0018451/2025-01-01#Artikel6

--- a/corpus/regulation/nl/wet/wet_open_overheid/2025-02-12.yaml
+++ b/corpus/regulation/nl/wet/wet_open_overheid/2025-02-12.yaml
@@ -11,23 +11,27 @@ competent_authority: '#bevoegd_gezag'
 articles:
   # Hoofdstuk 1 - Rechten
   - number: '1.1'
-    text: |-
+    text: >-
       Eenieder heeft recht op toegang tot publieke informatie zonder daartoe een belang te hoeven stellen, behoudens bij
       deze wet gestelde beperkingen.
     url: https://wetten.overheid.nl/BWBR0045754/2025-02-12#Artikel1.1
 
   # Hoofdstuk 2 - Algemene bepalingen
   - number: '2.1'
-    text: |-
+    text: >-
       In deze wet en de daarop berustende bepalingen wordt verstaan onder:
+
 
       a. document: een door een orgaan, persoon of college als bedoeld in artikel 2.2, eerste lid, opgemaakt of ontvangen
       schriftelijk stuk of ander geheel van vastgelegde gegevens dat naar zijn aard verband houdt met de publieke taak van
       dat orgaan, die persoon of dat college;
 
+
       b. milieu-informatie: hetgeen daaronder wordt verstaan in artikel 19.1a van de Wet milieubeheer;
 
+
       c. Onze Minister: Onze Minister van Binnenlandse Zaken en Koninkrijksrelaties;
+
 
       d. publieke informatie: informatie neergelegd in documenten die berusten bij een orgaan, persoon of college als
       bedoeld in artikel 2.2, eerste lid, of informatie die krachtens artikel 2.3 door een bestuursorgaan kan worden
@@ -94,14 +98,14 @@ articles:
     url: https://wetten.overheid.nl/BWBR0045754/2025-02-12#Artikel2.4
 
   - number: '2.5'
-    text: |-
+    text: >-
       Bij de toepassing van deze wet wordt uitgegaan van het algemeen belang van openbaarheid van publieke informatie voor
       de democratische samenleving.
     url: https://wetten.overheid.nl/BWBR0045754/2025-02-12#Artikel2.5
 
   # Hoofdstuk 3 - Openbaarmaking uit eigen beweging
   - number: '3.1'
-    text: |-
+    text: >-
       1. Het bestuursorgaan dat het rechtstreeks aangaat, maakt bij de uitvoering van zijn taak uit eigen beweging de bij
       het bestuursorgaan berustende informatie neergelegd in documenten voor eenieder openbaar, indien dit zonder
       onevenredige inspanning of kosten redelijkerwijs mogelijk is, behoudens voor zover de artikelen 5.1, eerste, tweede en
@@ -109,12 +113,15 @@ articles:
       Deze informatie betreft in ieder geval informatie over het beleid, inclusief de voorbereiding, uitvoering, naleving,
       handhaving en evaluatie.
 
+
       2. Het bestuursorgaan doet bij een gedeeltelijke niet-openbaarmaking hiervan mededeling gelijktijdig met de
       openbaarmaking.
+
 
       3. Documenten als bedoeld in het eerste lid worden niet openbaar gemaakt dan nadat belanghebbenden die naar
       verwachting bedenkingen zullen hebben tegen openbaarmaking, in de gelegenheid zijn gesteld binnen een door het
       bestuursorgaan gestelde termijn hun zienswijze naar voren te brengen.
+
 
       4. Het bestuursorgaan deelt een belanghebbende mede dat toepassing wordt gegeven aan het eerste lid, onder vermelding
       van het tijdstip van openbaarmaking en de openbaar te maken documenten. De mededeling wordt gelijkgesteld met een
@@ -256,21 +263,21 @@ articles:
     url: https://wetten.overheid.nl/BWBR0045754/2025-02-12#Artikel3.3a
 
   - number: 3.3b
-    text: |-
+    text: >-
       De openbaarmaking van de in de artikelen 3.3 en 3.3a genoemde documenten geschiedt elektronisch op een algemeen
       toegankelijke wijze door middel van een door Onze Minister in stand gehouden digitale infrastructuur. Deze
       infrastructuur is beschikbaar voor de openbaarmaking van andere documenten.
     url: https://wetten.overheid.nl/BWBR0045754/2025-02-12#Artikel3.3b
 
   - number: '3.4'
-    text: |-
+    text: >-
       In afwijking van de artikelen 5.1 en 5.2 kan een bestuursorgaan informatie uit eigen beweging openbaar maken, wanneer
       een ander zwaarwegend algemeen belang, daaronder begrepen het belang van openbare veiligheid, de volksgezondheid of
       het milieu of de bescherming van de democratische rechtsorde, dat in een concreet geval vergt.
     url: https://wetten.overheid.nl/BWBR0045754/2025-02-12#Artikel3.4
 
   - number: '3.5'
-    text: |-
+    text: >-
       Een bestuursorgaan besteedt in de jaarlijkse begroting dan wel de jaarlijkse begroting van het openbaar lichaam of de
       rechtspersoon waarvan het bestuursorgaan deel uit maakt, aandacht aan de beleidsvoornemens inzake de uitvoering van
       deze wet en doet in de jaarlijkse verantwoording verslag van de uitvoering ervan, mede in relatie tot de
@@ -279,26 +286,32 @@ articles:
 
   # Hoofdstuk 4 - Openbaarmaking op verzoek
   - number: '4.1'
-    text: |-
+    text: >-
       1. Eenieder kan een verzoek om publieke informatie richten tot een bestuursorgaan of een onder verantwoordelijkheid
       van een bestuursorgaan werkzame instelling, dienst of bedrijf. In het laatste geval beslist het verantwoordelijke
       bestuursorgaan op het verzoek.
 
+
       2. Een verzoek kan mondeling of schriftelijk worden ingediend en kan elektronisch worden verzonden op de door het
       bestuursorgaan aangegeven wijze.
 
+
       3. De verzoeker behoeft bij zijn verzoek geen belang te stellen.
+
 
       4. De verzoeker vermeldt bij zijn verzoek de aangelegenheid of het daarop betrekking hebbende document, waarover hij
       informatie wenst te ontvangen.
 
+
       5. Indien een verzoek te algemeen geformuleerd is, verzoekt het bestuursorgaan binnen twee weken na ontvangst van het
       verzoek de verzoeker om het verzoek te preciseren en is het de verzoeker daarbij behulpzaam.
+
 
       6. Het bestuursorgaan kan besluiten een verzoek niet te behandelen, indien de verzoeker niet meewerkt aan een verzoek
       tot precisering als bedoeld het vijfde lid. In afwijking van artikel 4:5, vierde lid, van de Algemene wet
       bestuursrecht wordt het besluit om het verzoek niet te behandelen aan de verzoeker bekendgemaakt binnen twee weken
       nadat het verzoek is gepreciseerd of nadat de daarvoor gestelde termijn ongebruikt is verstreken.
+
 
       7. Een verzoek om informatie wordt ingewilligd met inachtneming van het bepaalde in hoofdstuk 5.
     url: https://wetten.overheid.nl/BWBR0045754/2025-02-12#Artikel4.1
@@ -309,16 +322,18 @@ articles:
     url: https://wetten.overheid.nl/BWBR0045754/2025-02-12#Artikel4.1a
 
   - number: '4.2'
-    text: |-
+    text: >-
       1. Voor zover het verzoek betrekking heeft op informatie die berust bij een ander bestuursorgaan dan dat waarbij het
       verzoek is ingediend, wordt de verzoeker zo nodig naar dat bestuursorgaan verwezen. Is het verzoek schriftelijk
       gedaan, dan wordt het voor zover betrekking hebbend op informatie die bij een ander bestuursorgaan berust, onverwijld
       doorgezonden aan dat bestuursorgaan, onder mededeling van de doorzending aan de verzoeker.
 
+
       2. Indien het verzoek betrekking heeft op informatie die op grond van enig wettelijk voorschrift bij het
       bestuursorgaan had behoren te berusten, vordert het bestuursorgaan de gevraagde informatie van degene die over de
       informatie beschikt. Degene die over de gevraagde informatie beschikt, verstrekt deze per omgaande aan het
       bestuursorgaan.
+
 
       3. Voor zover een verzoek als bedoeld in artikel 4.1, eerste lid, dat is gericht aan een der Kamers of de verenigde
       vergadering der Staten-Generaal, betrekking heeft op informatie die door de regering vertrouwelijk aan de
@@ -327,7 +342,7 @@ articles:
     url: https://wetten.overheid.nl/BWBR0045754/2025-02-12#Artikel4.2
 
   - number: 4.2a
-    text: |-
+    text: >-
       Indien een voldoende gespecificeerd verzoek zodanig omvangrijk is dat niet binnen de termijn van artikel 4.4, eerste
       lid, kan worden beslist, treedt het bestuursorgaan voor het einde van die termijn in overleg met de verzoeker over de
       prioritering van de afhandeling van het verzoek. Het bestuursorgaan verstrekt de gevraagde documenten zo veel mogelijk
@@ -351,27 +366,32 @@ articles:
     url: https://wetten.overheid.nl/BWBR0045754/2025-02-12#Artikel4.3
 
   - number: '4.4'
-    text: |-
+    text: >-
       1. Het bestuursorgaan beslist op het verzoek om informatie zo spoedig mogelijk, doch uiterlijk binnen vier weken
       gerekend vanaf de dag na die waarop het verzoek is ontvangen.
+
 
       2. Het bestuursorgaan kan de beslissing voor ten hoogste twee weken verdagen, indien de omvang of de gecompliceerdheid
       van de informatie een verlenging rechtvaardigt. Van de verdaging wordt voor de afloop van de eerste termijn
       schriftelijk gemotiveerd mededeling gedaan aan de verzoeker.
+
 
       3. Onverminderd artikel 4:15 van de Algemene wet bestuursrecht wordt de termijn voor het geven van een beschikking
       opgeschort gerekend vanaf de dag na die waarop het bestuursorgaan de verzoeker meedeelt dat toepassing is gegeven aan
       artikel 4:8 van de Algemene wet bestuursrecht, tot en met de dag waarop door de belanghebbende of belanghebbenden een
       zienswijze naar voren is gebracht of de daarvoor gestelde termijn ongebruikt is verstreken.
 
+
       4. Indien de opschorting, bedoeld in het derde lid, eindigt, doet het bestuursorgaan daarvan zo spoedig mogelijk
       mededeling aan de verzoeker, onder vermelding van de termijn binnen welke de beschikking alsnog moet worden gegeven.
+
 
       5. Indien het bestuursorgaan heeft besloten informatie te verstrekken, wordt de informatie verstrekt tegelijk met de
       bekendmaking van het besluit, tenzij naar verwachting een belanghebbende bezwaar daartegen heeft, in welk geval de
       informatie wordt verstrekt twee weken nadat de beslissing is bekendgemaakt. Indien wordt verzocht om een voorlopige
       voorziening als bedoeld in artikel 8:81 van de Algemene wet bestuursrecht, wordt de openbaarmaking opgeschort totdat
       de voorzieningenrechter uitspraak heeft gedaan of het verzoek is ingetrokken.
+
 
       6. Indien het bestuursorgaan heeft besloten informatie te verstrekken die rechtstreeks betrekking heeft op een derde
       of die van een derde afkomstig is, deelt het bestuursorgaan dit besluit gelijktijdig mede aan deze derde.
@@ -445,16 +465,17 @@ articles:
               default: $uiterste_beslisdatum
 
   - number: '4.5'
-    text: |-
+    text: >-
       1. Het bestuursorgaan verstrekt de informatie in de door verzoeker verzochte vorm of, indien dit redelijkerwijs niet
       gevergd kan worden, met inachtneming van het bepaalde in artikel 2.4, derde lid.
+
 
       2. Indien de informatie reeds in een voor de verzoeker gemakkelijk toegankelijke vorm voor het publiek beschikbaar is,
       wijst het bestuursorgaan de verzoeker daarop.
     url: https://wetten.overheid.nl/BWBR0045754/2025-02-12#Artikel4.5
 
   - number: '4.6'
-    text: |-
+    text: >-
       Indien de verzoeker kennelijk een ander doel heeft dan het verkrijgen van publieke informatie of indien het verzoek
       evident geen bestuurlijke aangelegenheid betreft, kan het bestuursorgaan binnen twee weken na ontvangst van het
       verzoek, dan wel onverwijld nadat is gebleken dat de verzoeker kennelijk een ander doel heeft dan het verkrijgen van
@@ -462,7 +483,7 @@ articles:
     url: https://wetten.overheid.nl/BWBR0045754/2025-02-12#Artikel4.6
 
   - number: '4.7'
-    text: |-
+    text: >-
       Ter beantwoording van vragen over de beschikbaarheid van publieke informatie wijst het bestuursorgaan een of meer
       contactpersonen aan.
     url: https://wetten.overheid.nl/BWBR0045754/2025-02-12#Artikel4.7
@@ -697,23 +718,26 @@ articles:
                   value: $heeft_lid5_weigeringsgrond
 
   - number: '5.2'
-    text: |-
+    text: >-
       1. In geval van een verzoek om informatie uit documenten, opgesteld ten behoeve van intern beraad, wordt geen
       informatie verstrekt over daarin opgenomen persoonlijke beleidsopvattingen. Onder persoonlijke beleidsopvattingen
       worden verstaan ambtelijke adviezen, visies, standpunten en overwegingen ten behoeve van intern beraad, niet zijnde
       feiten, prognoses, beleidsalternatieven, de gevolgen van een bepaald beleidsalternatief of andere onderdelen met een
       overwegend objectief karakter.
 
+
       2. Het bestuursorgaan kan over persoonlijke beleidsopvattingen met het oog op een goede en democratische
       bestuursvoering informatie verstrekken in niet tot personen herleidbare vorm. Indien degene die deze opvattingen heeft
       geuit of zich erachter heeft gesteld, daarmee heeft ingestemd, kan de informatie in tot personen herleidbare vorm
       worden verstrekt.
+
 
       3. Onverminderd het eerste en tweede lid wordt uit documenten opgesteld ten behoeve van formele bestuurlijke
       besluitvorming door een minister, een commissaris van de Koning, Gedeputeerde Staten, een gedeputeerde, het college
       van burgemeester en wethouders, een burgemeester, een wethouder, het dagelijks bestuur van een waterschap of een lid
       van dat bestuur, informatie verstrekt over persoonlijke beleidsopvattingen in niet tot personen herleidbare vorm,
       tenzij het kunnen voeren van intern beraad onevenredig wordt geschaad.
+
 
       4. In afwijking van het eerste lid wordt bij milieu-informatie het belang van de bescherming van de persoonlijke
       beleidsopvattingen afgewogen tegen het belang van openbaarmaking. Informatie over persoonlijke beleidsopvattingen kan
@@ -722,7 +746,7 @@ articles:
     url: https://wetten.overheid.nl/BWBR0045754/2025-02-12#Artikel5.2
 
   - number: '5.3'
-    text: |-
+    text: >-
       Bij een verzoek om informatie die ouder is dan vijf jaar motiveert het bestuursorgaan bij een weigering van die
       informatie waarom de in artikel 5.1, tweede of vijfde lid, of artikel 5.2 bedoelde belangen ondanks het tijdsverloop
       zwaarder wegen dan het algemeen belang van openbaarheid.
@@ -759,18 +783,19 @@ articles:
               value: 5
 
   - number: '5.4'
-    text: |-
+    text: >-
       In afwijking van de artikelen 5.1 en 5.2 is informatie die berust bij de formateur of de informateur, dan wel
       informatie die door een bestuursorgaan aan de formateur of de informateur is gezonden niet openbaar totdat de formatie
       is afgerond.
     url: https://wetten.overheid.nl/BWBR0045754/2025-02-12#Artikel5.4
 
   - number: 5.4a
-    text: |-
+    text: >-
       1. In afwijking van de artikelen 5.1 en 5.2 is niet openbaar de informatie betreffende de ondersteuning van
       individuele leden van de Eerste Kamer of de Tweede Kamer der Staten-Generaal, provinciale staten of de gemeenteraad
       door ambtenaren werkzaam bij de Eerste Kamer of de Tweede Kamer, de griffie van provinciale staten of de griffie van
       de gemeenteraad.
+
 
       2. In afwijking van artikel 5.2, eerste lid, wordt met betrekking tot informatie die aan individuele Kamerleden wordt
       verstrekt onder persoonlijke beleidsopvattingen verstaan ambtelijke adviezen, visies, standpunten en overwegingen ten
@@ -778,7 +803,7 @@ articles:
     url: https://wetten.overheid.nl/BWBR0045754/2025-02-12#Artikel5.4a
 
   - number: '5.5'
-    text: |-
+    text: >-
       1. Onverminderd het elders bij wet bepaalde, verstrekt een bestuursorgaan iedere natuurlijke of rechtspersoon op diens
       verzoek de op de verzoeker betrekking hebbende in documenten neergelegde informatie, tenzij een in artikel 5.1, eerste
       lid, onderdelen a, b en c, alsmede d en e, voor zover betrekking hebbend op derden, genoemd belang aan de orde is of
@@ -786,11 +811,14 @@ articles:
       bij toegang tot op hem betrekking hebbende informatie. De verzoeker vermeldt bij zijn verzoek de aangelegenheid of het
       daarop betrekking hebbende document, waarover hij informatie wenst te ontvangen.
 
+
       2. Het eerste lid is van overeenkomstige toepassing op een verzoek met betrekking tot gegevens ten aanzien van een
       overleden echtgenoot, geregistreerd partner, kind of ouder van de verzoeker, tenzij een schriftelijke wilsverklaring
       van de overledene aan de verstrekking in de weg staat.
 
+
       3. Het bestuursorgaan draagt zorg voor een deugdelijke vaststelling van de identiteit van de verzoeker.
+
 
       4. Het bestuursorgaan kan aan de verstrekking voorwaarden verbinden ter bescherming van een van de belangen, genoemd
       in de artikelen 5.1 en 5.2, tenzij de gevraagde informatie met toepassing van de artikelen 5.1 en 5.2 openbaar voor
@@ -798,12 +826,14 @@ articles:
     url: https://wetten.overheid.nl/BWBR0045754/2025-02-12#Artikel5.5
 
   - number: '5.6'
-    text: |-
+    text: >-
       1. Het bestuursorgaan kan, in geval informatie ingevolge de artikelen 5.1 en 5.2 niet openbaar gemaakt kan worden,
       besluiten de informatie uitsluitend aan de verzoeker te verstrekken, indien er klemmende redenen zijn om de verzoeker
       niettegenstaande de toepasselijke uitzonderingsgrond of -gronden de gevraagde informatie niet te onthouden.
 
+
       2. Het eerste lid vindt slechts toepassing voor zover dit niet in strijd is met een toepasselijke geheimhoudingsplicht.
+
 
       3. Het bestuursorgaan kan aan de verstrekking voorwaarden verbinden ter bescherming van een van de belangen, genoemd
       in de artikelen 5.1 en 5.2.
@@ -826,22 +856,25 @@ articles:
 
   # Hoofdstuk 6 - Digitale informatiehuishouding
   - number: '6.1'
-    text: |-
+    text: >-
       Het bestuursorgaan treft maatregelen ten behoeve van het duurzaam toegankelijk maken van de digitale documenten,
       bedoeld in artikel 2.4, eerste lid.
     url: https://wetten.overheid.nl/BWBR0045754/2025-02-12#Artikel6.1
 
   - number: '6.2'
-    text: |-
+    text: >-
       1. Onze Minister, in overeenstemming met Onze Minister van Onderwijs, Cultuur en Wetenschap, zendt een meerjarenplan
       naar de Staten-Generaal over de wijze waarop bestuursorganen hun digitale overheidsinformatie duurzaam toegankelijk
       maken.
 
+
       2. Het meerjarenplan bevat langetermijndoelen voor de verbetering van de wijze waarop digitale documenten worden
       vervaardigd, geordend, bewaard, vernietigd en ontsloten alsmede de stappen die daartoe op korte termijn worden gezet.
 
+
       3. Het meerjarenplan voorziet in stappen waarmee wordt bereikt dat eenieder zo veel mogelijk inzicht kan hebben in de
       aanwezigheid van publieke informatie bij een orgaan, persoon of college als bedoeld in artikel 2.2, eerste lid.
+
 
       4. Onze Minister, in overeenstemming met Onze Minister van Onderwijs, Cultuur en Wetenschap, vult het meerjarenplan
       aan met de nodige maatregelen tot de digitale overheidsinformatie voldoende duurzaam toegankelijk is.
@@ -849,13 +882,16 @@ articles:
 
   # Hoofdstuk 7 - Het adviescollege openbaarheid en informatiehuishouding
   - number: '7.1'
-    text: |-
+    text: >-
       1. Er is een Adviescollege openbaarheid en informatiehuishouding.
+
 
       2. Het college bestaat uit een voorzitter en ten hoogste vier andere leden.
 
+
       3. De benoeming van de leden bij koninklijk besluit geschiedt op voordracht van Onze Minister, in overeenstemming met
       Onze Minister van Onderwijs, Cultuur en Wetenschap.
+
 
       4. De artikelen 13, 16 en 19 van de Kaderwet zelfstandige bestuursorganen zijn van overeenkomstige toepassing.
     url: https://wetten.overheid.nl/BWBR0045754/2025-02-12#Artikel7.1
@@ -887,9 +923,10 @@ articles:
     url: https://wetten.overheid.nl/BWBR0045754/2025-02-12#Artikel7.2
 
   - number: '7.3'
-    text: |-
+    text: >-
       1. Alvorens een advies als bedoeld in artikel 7.2, vierde lid, uit te brengen, bemiddelt het college tussen het
       bestuursorgaan en de klager. Het bestuursorgaan werkt aan de bemiddeling mee.
+
 
       2. Indien de klacht mede betrekking heeft op een besluit op grond van deze wet waartegen bezwaar open staat, wordt de
       termijn voor het indienen van bezwaar, bedoeld in artikel 6:7 van de Algemene wet bestuursrecht, opgeschort tot het
@@ -897,9 +934,11 @@ articles:
       uitgebracht. De opschorting van de bezwaartermijn vangt aan met ingang van de dag nadat de klager de klacht aan het
       college heeft gezonden.
 
+
       3. Indien de klager bezwaar maakt tegen het besluit, bedoeld in het tweede lid, beslist het bestuursorgaan in
       afwijking van artikel 7:10, eerste lid, van de Algemene wet bestuursrecht binnen twee weken nadat het college advies
       heeft uitgebracht, dan wel aan de klager en het bestuursorgaan heeft bericht dat geen advies zal worden uitgebracht.
+
 
       4. Bij algemene maatregel van bestuur kunnen nadere regels worden gesteld over de wijze waarop klachten worden
       ingediend en het college tussen het bestuursorgaan en de klager bemiddelt als bedoeld in het eerste lid.
@@ -911,10 +950,11 @@ articles:
     url: https://wetten.overheid.nl/BWBR0045754/2025-02-12#Artikel7.4
 
   - number: '7.5'
-    text: |-
+    text: >-
       1. De leden van het college alsmede de ambtenaren van zijn bureau zijn tot geheimhouding verplicht voor zover zij
       krachtens deze wet beschikken over documenten die door het bestuursorgaan waarvan zij afkomstig zijn niet openbaar
       zijn gemaakt.
+
 
       2. Voor zover een aan het college gericht verzoek op grond van deze wet betrekking heeft op door een bestuursorgaan
       aan het college verstrekte informatie, zendt het college het verzoek ter behandeling door aan het bestuursorgaan.
@@ -922,16 +962,17 @@ articles:
 
   # Hoofdstuk 8 - Overige bepalingen
   - number: '8.1'
-    text: |-
+    text: >-
       1. Overtreding van een voorwaarde die op grond van artikel 5.5, vierde lid, 5.6, derde lid, of artikel 5.7, tweede of
       derde lid, aan een verstrekking is verbonden, wordt gestraft met gevangenisstraf van ten hoogste een jaar of geldboete
       van de vierde categorie.
+
 
       2. Het in het eerste lid strafbaar gestelde feit is een misdrijf.
     url: https://wetten.overheid.nl/BWBR0045754/2025-02-12#Artikel8.1
 
   - number: '8.2'
-    text: |-
+    text: >-
       Paragraaf 4.1.3.2 van de Algemene wet bestuursrecht is niet van toepassing op besluiten op grond van deze wet en op
       beslissingen op bezwaar tegen deze besluiten.
     url: https://wetten.overheid.nl/BWBR0045754/2025-02-12#Artikel8.2
@@ -979,32 +1020,35 @@ articles:
     url: https://wetten.overheid.nl/BWBR0045754/2025-02-12#Artikel8.5
 
   - number: '8.6'
-    text: |-
+    text: >-
       1. De openbaarmaking van informatie op grond van deze wet is kosteloos.
+
 
       2. Voor de vervaardiging van kopieen van documenten kan een bestuursorgaan een redelijke vergoeding vragen, die de
       kostprijs van de verstrekte informatiedragers niet overstijgt.
+
 
       3. Op voordracht van Onze Minister kunnen bij of krachtens algemene maatregel van bestuur regels worden gesteld met
       betrekking tot het tweede lid.
     url: https://wetten.overheid.nl/BWBR0045754/2025-02-12#Artikel8.6
 
   - number: '8.7'
-    text: |-
+    text: >-
       Op voordracht van Onze Minister kunnen bij of krachtens algemene maatregel van bestuur regels worden gesteld over de
       wijze waarop een bestuursorgaan de uitvoering van deze wet organiseert.
     url: https://wetten.overheid.nl/BWBR0045754/2025-02-12#Artikel8.7
 
   - number: '8.8'
-    text: |-
+    text: >-
       De artikelen 3.1, 3.3, 4.1, 5.1, eerste, tweede en vijfde lid, en 5.2 zijn niet van toepassing op informatie waarvoor
       een bepaling geldt die is opgenomen in de bijlage bij deze wet.
     url: https://wetten.overheid.nl/BWBR0045754/2025-02-12#Artikel8.8
 
   - number: '8.9'
-    text: |-
+    text: >-
       1. Onze Minister zendt binnen vijf jaar na de inwerkingtreding van deze wet aan de Staten-Generaal een verslag over de
       doeltreffendheid en de effecten van deze wet in de praktijk.
+
 
       2. In deze evaluatie wordt in ieder geval aandacht besteed aan de vraag of het noodzakelijk is om een
       Informatiecommissaris in te stellen.
@@ -1017,30 +1061,31 @@ articles:
     url: https://wetten.overheid.nl/BWBR0045754/2025-02-12#Artikel10.1
 
   - number: '10.2'
-    text: |-
+    text: >-
       1. Documenten die voor de inwerkingtreding van deze wet zijn opgesteld, worden niet openbaar gemaakt op grond van
       artikel 3.1, eerste lid, of artikel 3.3, eerste of tweede lid, tenzij het bestuursorgaan dat redelijkerwijs mogelijk
       acht.
+
 
       2. Het eerste lid is niet van toepassing op documenten die voor de datum van inwerkingtreding van deze wet zijn
       opgesteld en waarvan de aktieve openbaarmaking reeds op grond van de Wet openbaarheid van bestuur plaatsvond.
     url: https://wetten.overheid.nl/BWBR0045754/2025-02-12#Artikel10.2
 
   - number: 10.2a
-    text: |-
+    text: >-
       Voor documenten die voor de inwerkingtreding van deze wet zijn opgesteld en waarop een verzoek betrekking heeft, zijn
       de bepalingen van deze wet van toepassing, tenzij toepassing daarvan onredelijk bezwarend is voor het betrokken
       bestuursorgaan.
     url: https://wetten.overheid.nl/BWBR0045754/2025-02-12#Artikel10.2a
 
   - number: 10.2b
-    text: |-
+    text: >-
       De bepalingen van deze wet zijn niet van toepassing op adviezen van de Afdeling advisering van de Raad van State die
       voor de inwerkingtreding van deze wet zijn uitgebracht.
     url: https://wetten.overheid.nl/BWBR0045754/2025-02-12#Artikel10.2b
 
   - number: 10.2c
-    text: |-
+    text: >-
       De bepalingen van deze wet zijn niet van toepassing op documenten waarop artikel 8.8 van toepassing is die voor de
       inwerkingtreding van deze wet zijn opgesteld.
     url: https://wetten.overheid.nl/BWBR0045754/2025-02-12#Artikel10.2c

--- a/corpus/regulation/nl/wet/zorgverzekeringswet/2025-01-01.yaml
+++ b/corpus/regulation/nl/wet/zorgverzekeringswet/2025-01-01.yaml
@@ -8,94 +8,122 @@ url: https://wetten.overheid.nl/BWBR0018450/2025-01-01
 name: '#wet_naam'
 articles:
   - number: '1'
-    text: |-
+    text: >-
       Artikel 1 In deze wet en de daarop berustende bepalingen wordt verstaan onder:
+
 
       a. verzekeraar: een verzekeringsonderneming als bedoeld in de eerste richtlijn schadeverzekering;
 
+
       b. zorgverzekeraar: een verzekeraar, voor zover deze zorgverzekeringen aanbiedt of uitvoert;
 
+
       c. verzekeringnemer: een persoon die met een zorgverzekeraar een zorgverzekering heeft gesloten;
+
 
       d. zorgverzekering: een tussen een zorgverzekeraar en een verzekeringnemer ten behoeve van een
       verzekeringsplichtige gesloten schadeverzekering, die voldoet aan hetgeen daarover bij of krachtens deze wet is
       geregeld, en waarvan de verzekerde prestaties het bij of krachtens deze wet geregelde niet te boven gaan;
 
+
       e. verzekeringsplichtige: degene die op grond van artikel 2 verplicht is zich krachtens een zorgverzekering te
       verzekeren of te laten verzekeren;
 
+
       f. verzekerde: degene wiens risico van behoefte aan zorg of overige diensten, als bedoeld in artikel 10 , door een
       zorgverzekering wordt gedekt;
+
 
       g. eigen risico: een door de verzekeringnemer met de zorgverzekeraar als onderdeel van de zorgverzekering
       overeengekomen bedrag aan kosten van zorg of overige diensten, als bedoeld bij of krachtens artikel 11 , dat de
       verzekerde voor zijn rekening zal nemen;
 
+
       h. zorgpolis: de akte waarin de tussen een verzekeringnemer en een zorgverzekeraar gesloten zorgverzekering is
       vastgelegd;
+
 
       i. modelovereenkomst: model van een zorgverzekering, waarin een overzicht wordt gegeven van de rechten en plichten
       die de verzekeringnemer, de verzekerde en de zorgverzekeraar jegens elkaar zullen hebben indien een overeenkomst
       volgens het desbetreffende model wordt gesloten;
 
+
       j. sociaal-fiscaalnummer: het nummer, bedoeld in [artikel 2, derde lid, onderdeel j, van de Algemene wet inzake
       rijksbelastingen](jci1.3:c:BWBR0002320&artikel=2) ;
+
 
       k. inhoudingsplichtige: de inhoudingsplichtige in de zin van de [Wet op de loonbelasting
       1964](jci1.3:c:BWBR0002471) dan wel in de zin van de [Wet financiering sociale verzekeringen](jci1.3:c:BWBR0017745)
       ;
 
+
       l. instelling:
 
+
       1°. een instelling in de zin van de [Wet toelating zorginstellingen](jci1.3:c:BWBR0018906) ;
+
 
       2°. een in het buitenland gevestigde rechtspersoon die in het desbetreffende land zorg verleent in het kader van
       het in dat land bestaande socialezekerheidsstelsel, dan wel zich richt op het verlenen van zorg aan specifieke
       groepen van publieke functionarissen;
 
+
       1°. een instelling in de zin van de [Wet toelating zorginstellingen](jci1.3:c:BWBR0018906) ;
+
 
       2°. een in het buitenland gevestigde rechtspersoon die in het desbetreffende land zorg verleent in het kader van
       het in dat land bestaande socialezekerheidsstelsel, dan wel zich richt op het verlenen van zorg aan specifieke
       groepen van publieke functionarissen;
+
 
       m. Onze Minister: Onze Minister van Volksgezondheid, Welzijn en Sport;
 
+
       m. College toezicht: het College van toezicht op de zorgverzekeringen, genoemd in artikel 77, eerste lid ;
+
 
       o. College zorgverzekeringen: het College voor zorgverzekeringen, genoemd in artikel 58, eerste lid ;
 
+
       p. Zorgverzekeringsfonds: het fonds, genoemd in artikel 39 ;
+
 
       q. eerste richtlijn schadeverzekering: [richtlijn nr. 73/239/EEG](31973L0239) van de Raad van de Europese
       Gemeenschappen van 24 juli 1973 tot coördinatie van de wettelijke en bestuursrechtelijke bepalingen betreffende de
       toegang tot het directe verzekeringsbedrijf, met uitzondering van de levensverzekeringsbranche en de uitoefening
       daarvan (PbEG L 228);
 
+
       r. generieke verevening: bijstelling van het deelbedrag op basis van het verschil per zorgverzekeraar tussen de
       kosten en het deelbedrag in relatie met de verschillen tussen de kosten en het deelbedrag bij andere
       zorgverzekeraars, per onderscheiden categorie van prestaties;
 
+
       s. loontijdvak: het loontijdvak, bedoeld in [artikel 25, eerste en vierde lid, van de Wet op de loonbelasting
       1964](jci1.3:c:BWBR0002471&artikel=25) ;
+
 
       t. bijdragebetalingstijdvak: het kalenderjaar.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel1
   - number: '2'
-    text: |-
+    text: >-
       Artikel 2 1 Degene die ingevolge de [Algemene Wet Bijzondere Ziektekosten](jci1.3:c:BWBR0002614) en de daarop
       gebaseerde regelgeving van rechtswege verzekerd is, is verplicht zich krachtens een zorgverzekering te verzekeren
       of te laten verzekeren tegen het in artikel 10 bedoelde risico.
 
+
       2. In afwijking van het eerste lid is niet verzekeringsplichtig:
+
 
       a. de militaire ambtenaar in werkelijke dienst als bedoeld in [artikel 1, eerste lid juncto vierde lid, onderdeel
       a, van de Militaire ambtenarenwet 1931](jci1.3:c:BWBR0001952&artikel=1) , alsmede de militair aan wie buitengewoon
       verlof met behoud van militaire inkomsten is verleend;
 
+
       b. de natuurlijke persoon die op grond van [artikel 64, eerste lid, van de Wet financiering sociale
       verzekeringen](jci1.3:c:BWBR0017745&artikel=64) is ontheven van de verplichtingen, opgelegd op grond van de
       [Algemene Wet Bijzondere Ziektekosten](jci1.3:c:BWBR0002614) .
+
 
       3. Degene die het gezag over een minderjarige, jonger dan achttien jaar, uitoefent, een curator, een bewindvoerder
       of een mentor als bedoeld in de [titels 16](jci1.3:c:BWBR0002656&titeldeel=16) ,
@@ -136,13 +164,15 @@ articles:
                   subject: $verdragsinschrijving
                   value: true
   - number: '3'
-    text: |-
+    text: >-
       Artikel 3 1 Een zorgverzekeraar is verplicht met of ten behoeve van iedere verzekeringsplichtige die in zijn
       werkgebied woont alsmede met of ten behoeve van iedere verzekeringsplichtige die in het buitenland woont,
       desgevraagd een zorgverzekering te sluiten.
 
+
       2. Indien een zorgverzekeraar in een provincie verschillende varianten van de zorgverzekering aanbiedt, kan voor
       iedere in die provincie wonende verzekeringsplichtige uit alle varianten worden gekozen.
+
 
       3. De zorgverzekeraar stelt alle varianten van de zorgverzekering die hij in een provincie aanbiedt, in de vorm van
       modelovereenkomsten ter beschikking aan personen die overwegen ten behoeve van een in die provincie wonende
@@ -150,17 +180,22 @@ articles:
       varianten toevoegt of wijzigt, aan de verzekeringnemers die ten behoeve van een in die provincie wonende
       verzekeringsplichtige een zorgverzekering met hem hebben gesloten.
 
+
       4. In afwijking van het eerste lid is een zorgverzekeraar niet verplicht een zorgverzekering te sluiten met of ten
       behoeve van een verzekeringsplichtige wiens eerdere zorgverzekering hij of de verzekeringnemer binnen een periode
       van vijf jaar, gelegen onmiddellijk voorafgaande aan het verzoek tot het sluiten van de verzekering, heeft opgezegd
       of ontbonden wegens:
 
+
       a. opzettelijke misleiding door de verzekeringnemer of de verzekerde, of
+
 
       b. het niet betalen van de premie, bedoeld in artikel 17, vijfde lid .
 
+
       5. In afwijking van het tweede lid kan ten behoeve van een in het buitenland wonende verzekeringsplichtige worden
       gekozen tussen alle varianten van de zorgverzekering die een zorgverzekeraar in Nederland aanbiedt.
+
 
       6. In afwijking van het derde lid worden degene die ten behoeve van een in het buitenland wonende
       verzekeringsplichtige een zorgverzekering wenst te sluiten alle modelovereenkomsten die de zorgverzekeraar in
@@ -168,18 +203,22 @@ articles:
       verzekeringnemer alle toegevoegde of gewijzigde varianten die die zorgverzekeraar aanbiedt ter beschikking gesteld.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel3
   - number: '4'
-    text: |-
+    text: >-
       Artikel 4 1 Degene die een zorgverzekering wenst te sluiten, vermeldt bij het verzoek daartoe het
       sociaal-fiscaalnummer van de te verzekeren persoon.
 
+
       2. De zorgverzekeraar stelt, voor zover dat redelijkerwijs nodig is voor de uitvoering van de zorgverzekering en
       van deze wet, de identiteit van de te verzekeren persoon vast.
+
 
       3. De in het tweede lid bedoelde vaststelling geschiedt aan de hand van documenten als bedoeld in [artikel 1 van de
       Wet op de identificatieplicht](jci1.3:c:BWBR0006297&artikel=1) , die de verzekeringnemer of de te verzekeren
       persoon hem desgevraagd ter inzage geeft.
 
+
       4. De zorgverzekeraar neemt aard en nummer van de in het derde lid bedoelde documenten in zijn administratie op.
+
 
       5. De zorgverzekeraar verlangt van de vreemdeling, bedoeld in de [Vreemdelingenwet 2000](jci1.3:c:BWBR0011823) ,
       voor wie hem wordt verzocht een zorgverzekering te sluiten, een kopie van het document of de schriftelijke
@@ -188,10 +227,11 @@ articles:
       bestuursrecht](jci1.3:c:BWBR0005537&artikel=4:3) .
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel4
   - number: '5'
-    text: |-
+    text: >-
       Artikel 5 1 De zorgverzekering gaat in op de dag waarop de zorgverzekeraar het verzoek, bedoeld in artikel 3,
       eerste lid , en, indien het tweede of vijfde lid van dat artikel van toepassing is, de aanduiding van de variant
       waar de verzekeringnemer voor kiest, heeft ontvangen.
+
 
       2. Indien de zorgverzekeraar op basis van het in het eerste lid bedoelde verzoek niet vast kan stellen of hij
       verplicht is voor de te verzekeren persoon een zorgverzekering te sluiten, en hij de persoon die de verzekering
@@ -199,218 +239,272 @@ articles:
       de zorgverzekering, in afwijking van het eerste lid, in op de dag waarop laatstbedoelde persoon aan dit verzoek
       heeft voldaan.
 
+
       3. De zorgverzekeraar verstrekt degene die het verzoek, bedoeld in het eerste lid, doet en, indien dit een ander is
       dan degene ten behoeve van wiens verzekering het verzoek is gedaan, laatstbedoelde persoon onverwijld:
 
+
       a. een bewijs van het verzoek, bedoeld in het eerste lid, waarop de datum van ontvangst is vermeld;
+
 
       b. een bewijs van de ontvangst van gegevens, bedoeld in het tweede lid, waarop de datum van de ontvangst is
       vermeld.
+
 
       4. Indien degene ten behoeve van wie de zorgverzekering wordt gesloten op de dag waarop de zorgverzekeraar het
       verzoek, bedoeld in het eerste lid, ontvangt reeds op grond van een zorgverzekering verzekerd is, en de
       verzekeringnemer aangeeft de zorgverzekering te willen laten ingaan op een door hem aangegeven, latere dag dan de
       dag, bedoeld in het eerste of tweede lid, gaat de verzekering op die latere dag in.
 
+
       5. Indien de zorgverzekering ingaat binnen vier maanden nadat de verzekeringsplicht is ontstaan, werkt deze,
       zonodig in afwijking van [artikel 925, eerste lid, van boek 7 van het Burgerlijk
       Wetboek](jci1.3:c:BWBR0005290&artikel=925) , terug tot en met de dag waarop die plicht ontstond.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel5
   - number: '6'
-    text: |-
+    text: >-
       Artikel 6 1 De zorgverzekering eindigt van rechtswege met ingang van de dag volgende op de dag waarop:
+
 
       a. de verzekeraar ten gevolge van wijziging of intrekking van zijn vergunning tot uitoefening van het
       schadeverzekeringsbedrijf, geen zorgverzekeringen meer mag aanbieden;
 
+
       b. de verzekerde ten gevolge van wijziging van het werkgebied buiten het werkgebied van de zorgverzekeraar komt te
       wonen;
 
+
       c. de verzekerde overlijdt;
 
+
       d. de verzekeringsplicht van de verzekerde eindigt.
+
 
       2. De zorgverzekering eindigt van rechtswege met ingang van de eerste dag van de tweede maand volgende op de dag
       waarop de verzekerde, zonder dat zijn verzekeringsplicht eindigt, ten gevolge van verhuizing komt te wonen buiten
       een provincie waarin zijn zorgverzekeraar de ten behoeve van hem gesloten variant van de zorgverzekering aanbiedt
       of uitvoert.
 
+
       3. De zorgverzekeraar stelt de verzekeringnemer uiterlijk twee maanden voordat een zorgverzekering op grond van het
       eerste lid, onderdeel a of b eindigt, van dit einde op de hoogte, onder vermelding van de reden daarvan en de datum
       waarop de verzekering eindigt.
 
+
       4. De verzekeringnemer stelt de zorgverzekeraar onverwijld op de hoogte van alle feiten en omstandigheden over de
       verzekerde die op grond van het eerste lid, onderdeel c of d, dan wel het tweede lid tot het einde van de
       zorgverzekering hebben geleid of kunnen leiden.
+
 
       5. Indien de zorgverzekeraar op grond van de in het vierde lid bedoelde gegevens tot de conclusie komt dat de
       zorgverzekering zal eindigen of geëindigd is, deelt hij dit, onder vermelding van de reden daarvan en de datum
       waarop de verzekering eindigt of geëindigd is, onverwijld aan de verzekeringnemer mede.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel6
   - number: '7'
-    text: |-
+    text: >-
       Artikel 7 1 De verzekeringnemer kan de zorgverzekering voor 1 november van ieder jaar met ingang van 1 januari van
       het volgende kalenderjaar opzeggen.
+
 
       2. De verzekeringnemer die een ander dan zichzelf heeft verzekerd, kan de zorgverzekering opzeggen indien de
       verzekerde krachtens een andere zorgverzekering verzekerd wordt.
 
+
       3. In afwijking van [artikel 940, vierde lid, van Boek 7 van het Burgerlijk
       Wetboek](jci1.3:c:BWBR0005290&artikel=940) :
+
 
       a. kan de verzekeringnemer de zorgverzekering opzeggen in de periode gelegen tussen de datum waarop zijn
       zorgverzekeraar hem het voornemen tot verhoging van de grondslag van de premie heeft meegedeeld en de
       inwerkingtreding van die verhoging;
 
+
       b. kan de verzekeringnemer niet opzeggen indien een wijziging in de verzekerde prestaties ten nadele van de
       verzekeringnemer of de verzekerde rechtstreeks voortvloeit uit een wijziging van de bij of krachtens de artikelen
       11 tot en met 14 gestelde regels.
 
+
       4. De opzegging, bedoeld in het tweede lid, of in het derde lid, onderdeel a, gaat in op de eerste dag van de
       tweede kalendermaand volgende op de dag waarop de verzekeringnemer heeft opgezegd.
+
 
       5. In afwijking van het vierde lid gaat een opzegging, bedoeld in het tweede lid, in met ingang van de dag waarop
       de verzekerde krachtens de andere zorgverzekering verzekerd wordt, indien die opzegging voorafgaande aan
       laatstbedoelde dag door de zorgverzekeraar is ontvangen.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel7
   - number: '8'
-    text: |-
+    text: >-
       Artikel 8 1 Aan een opzegging of ontbinding van de zorgverzekering wegens het niet betalen van de verschuldigde
       premie, wordt geen terugwerkende kracht verleend, noch wordt daaraan een verplichting verbonden tot ongedaanmaking
       of vergoeding van hetgeen partijen reeds ter nakoming van de zorgverzekering jegens elkaar hebben verricht.
+
 
       2. Een zorgverzekeraar mag de zorgverzekering gedurende de periode, bedoeld in artikel 24 , niet opzeggen of
       ontbinden.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel8
   - number: '9'
-    text: |-
+    text: >-
       Artikel 9 1 De zorgverzekeraar verstrekt de verzekeringnemer en, indien deze een ander is dan de verzekeringnemer,
       de verzekerde zo spoedig mogelijk na het sluiten van de zorgverzekering en vervolgens voorafgaande aan ieder
       kalenderjaar een zorgpolis.
 
+
       2. Indien de zorgverzekering eindigt, verstrekt de zorgverzekeraar de verzekeringnemer en, indien deze een ander is
       dan de verzekeringnemer, de verzekerde een bewijs van het einde van de zorgverzekering, waarop worden aangetekend:
 
+
       a. naam, adres, woonplaats en sociaal-fiscaalnummer van de verzekerde;
+
 
       b. naam, adres en woonplaats van de verzekeringnemer;
 
+
       c. naam, adres en woonplaats van de zorgverzekeraar;
+
 
       d. de dag waarop de zorgverzekering eindigt;
 
+
       e. of voor de verzekerde op die dag een eigen risico gold en zo ja, met welke ingangsdatum, voor welk bedrag en met
       welke in verband daarmee verleende korting.
+
 
       3. Indien de zorgverzekering eindigt om de in artikel 6, eerste lid, onderdeel d , genoemde reden, wordt dat op het
       in het tweede lid bedoelde bewijs aangetekend.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel9
   - number: '10'
-    text: |-
+    text: >-
       Artikel 10 Het krachtens de zorgverzekering te verzekeren risico is de behoefte aan:
+
 
       a. geneeskundige zorg, waaronder de integrale eerstelijnszorg zoals die door huisartsen en verloskundigen pleegt te
       geschieden;
 
+
       b. mondzorg;
+
 
       c. farmaceutische zorg;
 
+
       d. hulpmiddelenzorg;
+
 
       e. verpleging;
 
+
       f. verzorging, waaronder de kraamzorg;
 
+
       g. verblijf in verband met geneeskundige zorg;
+
 
       h. vervoer in verband met het ontvangen van zorg of diensten als bedoeld in de onderdelen a tot en met g, dan wel
       in verband met een aanspraak op grond van de [Algemene Wet Bijzondere Ziektekosten](jci1.3:c:BWBR0002614) .
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel10
   - number: '11'
-    text: |-
+    text: >-
       Artikel 11 1 De zorgverzekeraar heeft jegens zijn verzekerden een zorgplicht die zodanig wordt vormgegeven, dat de
       verzekerde bij wie het verzekerde risico zich voordoet, krachtens de zorgverzekering recht heeft op prestaties
       bestaande uit:
 
+
       a. de zorg of de overige diensten waaraan hij behoefte heeft, of
+
 
       b. vergoeding van de kosten van deze zorg of overige diensten alsmede, desgevraagd, activiteiten gericht op het
       verkrijgen van deze zorg of diensten.
 
+
       2. In de zorgverzekering kunnen combinaties van verzekerde prestaties als bedoeld in het eerste lid, onderdeel a of
       b, worden opgenomen.
+
 
       3. Bij algemene maatregel van bestuur worden de inhoud en omvang van de in het eerste lid bedoelde prestaties nader
       geregeld en kan voor bij die maatregel aan te wijzen vormen van zorg of overige diensten worden bepaald dat een
       deel van de kosten voor rekening van de verzekerde komt.
 
+
       4. In de algemene maatregel van bestuur kan worden bepaald dat bij ministeriële regeling:
+
 
       a. vormen van zorg of overige diensten kunnen worden uitgezonderd van de in het eerste lid bedoelde of in de
       maatregel nader omschreven prestaties;
 
+
       b. de inhoud en omvang van de prestaties bestaande uit zorg als bedoeld in artikel 10, onderdelen a, c en d , nader
       wordt geregeld;
 
+
       c. nadere regels kunnen worden gesteld over het deel van de kosten dat voor rekening van de verzekerde komt.
+
 
       5. Een zorgverzekeraar kan modelovereenkomsten aanbieden waarin, in geringe afwijking van het bepaalde bij of
       krachtens het eerste en derde lid, bepaalde om ethische of levensbeschouwelijke redenen controversiële prestaties
       buiten de dekking van de zorgverzekering blijven.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel11
   - number: '12'
-    text: |-
+    text: >-
       Artikel 12 1 Bij algemene maatregel van bestuur kunnen ter bescherming van het algemeen belang vormen van zorg of
       overige diensten worden aangewezen die de zorgverzekeraar slechts verstrekt of vergoedt indien tussen hem en de
       aanbieder van de desbetreffende zorg of dienst een overeenkomst over de te leveren zorg of dienst en de daarvoor in
       rekening te brengen prijs is gesloten, dan wel indien de aanbieder bij hem in dienst is.
+
 
       2. Bij deze algemene maatregel van bestuur kunnen tevens vormen van zorg of overige diensten worden aangewezen
       waarvoor de zorgverzekeraar met iedere instelling die binnen zijn werkgebied is gelegen of waarvan zijn verzekerden
       naar verwachting regelmatig gebruik zullen maken, op haar verzoek een overeenkomst als bedoeld in het eerste lid
       sluit.
 
+
       3. Een instelling als bedoeld in artikel 1, onderdeel l, onder 1° , die voor een in het tweede lid bedoelde vorm
       van zorg of dienst een overeenkomst met een zorgverzekeraar heeft gesloten, is verplicht desgevraagd met een andere
       zorgverzekeraar een gelijke overeenkomst te sluiten.
+
 
       4. Het tweede en het derde lid gelden niet indien de zorgverzekeraar respectievelijk instelling ernstige bezwaren
       heeft tegen het sluiten van een overeenkomst met de instelling respectievelijk zorgverzekeraar die om die
       overeenkomst vraagt.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel12
   - number: '13'
-    text: |-
+    text: >-
       Artikel 13 1 Indien een verzekerde krachtens zijn zorgverzekering een bepaalde vorm van zorg of een andere dienst
       dient te betrekken van een aanbieder met wie zijn zorgverzekeraar een overeenkomst over deze zorg of dienst en de
       daarvoor in rekening te brengen prijs heeft gesloten of van een aanbieder die bij zijn zorgverzekeraar in dienst
       is, en hij deze zorg of andere dienst desalniettemin betrekt van een andere aanbieder, heeft hij recht op een door
       de zorgverzekeraar te bepalen vergoeding van de voor deze zorg of dienst gemaakte kosten.
 
+
       2. De zorgverzekeraar neemt de wijze waarop hij de vergoeding berekent in de modelovereenkomst op.
+
 
       3. Indien bij of krachtens de algemene maatregel van bestuur, bedoeld in artikel 11 , is bepaald dat een deel van
       de kosten van een bepaalde vorm van zorg of van een bepaalde andere dienst voor rekening van de verzekerde komt,
       verwerkt de zorgverzekeraar dit in de wijze waarop hij de vergoeding voor de desbetreffende vorm van zorg of dienst
       berekent.
 
+
       4. De wijze waarop de vergoeding wordt berekend is voor alle verzekerden, bedoeld in het eerste lid, die in een
       zelfde situatie een zelfde vorm van zorg of dienst behoeven, gelijk.
+
 
       5. Indien een overeenkomst tussen een zorgverzekeraar en een aanbieder als bedoeld in het eerste lid wordt
       beëindigd, houdt een verzekerde die op het moment van beëindiging van de overeenkomst zorg ontvangt van deze
       aanbieder recht op zorgverlening door die aanbieder voor rekening van deze zorgverzekeraar.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel13
   - number: '14'
-    text: |-
+    text: >-
       Artikel 14 1 De vraag of een verzekerde behoefte heeft aan een bepaalde vorm van zorg of een bepaalde andere dienst
       wordt slechts op basis van zorginhoudelijke criteria beantwoord.
+
 
       2. De zorgverzekeraar neemt in zijn modelovereenkomst op dat geneeskundige zorg zoals medisch-specialisten die
       plegen te bieden, met uitzondering van acute zorg, slechts toegankelijk is na verwijzing door in die overeenkomst
       aangewezen categorieën zorgaanbieders, waaronder in ieder geval de huisarts.
 
+
       3. Dit lid is nog niet in werking getreden.
+
 
       4. Dit lid is nog niet in werking getreden.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel14
@@ -418,132 +512,160 @@ articles:
     text: Artikel 14a Dit onderdeel is nog niet inwerking getreden
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel14a
   - number: '15'
-    text: |-
+    text: >-
       Artikel 15 1 De [artikelen 941, eerste lid](jci1.3:c:BWBR0005290&artikel=941) , en [957 van Boek 7 van het
       Burgerlijk Wetboek](jci1.3:c:BWBR0005290&artikel=957) zijn niet van toepassing.
+
 
       2. Zonodig in afwijking van [artikel 952 van Boek 7 van het Burgerlijk Wetboek](jci1.3:c:BWBR0005290&artikel=952)
       is de zorgverzekeraar niet bevoegd een verzekerde prestatie geheel of gedeeltelijk te weigeren indien het intreden
       van het verzekerde risico aan de verzekerde is te wijten.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel15
   - number: '16'
-    text: |-
+    text: >-
       Artikel 16 1 Krachtens de zorgverzekering is de verzekeringnemer premie verschuldigd.
+
 
       2. In afwijking van [artikel 925 van Boek 7 van het Burgerlijk Wetboek](jci1.3:c:BWBR0005290&artikel=925) en van
       het eerste lid is voor een verzekerde tot de eerste dag van de kalendermaand volgende op de kalendermaand waarin
       hij de leeftijd van achttien jaar heeft bereikt, geen premie verschuldigd.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel16
   - number: '17'
-    text: |-
+    text: >-
       Artikel 17 1 De zorgverzekeraar stelt voor iedere variant van de zorgverzekering die hij aanbiedt, de grondslag van
       de premie en de bij die variant behorende premiekorting of premiekortingen vast en neemt deze in de
       modelovereenkomst op.
+
 
       2. De grondslag van de premie is gelijk voor varianten die wat betreft de te verzekeren prestaties als bedoeld in
       artikel 11, eerste lid , of de keuzemogelijkheden tussen aanbieders van zorg of van overige diensten als bedoeld in
       dat lid, niet van elkaar verschillen.
 
+
       3. Indien de zorgverzekeraar gebruik maakt van zijn bevoegdheid, bedoeld in artikel 11, vijfde lid , is de
       grondslag van de premie gelijk aan de grondslag die hij heeft of zou hebben vastgesteld voor een modelovereenkomst
       met volledige dekking.
 
+
       4. De grondslag van de premie is de premie indien geen premiekorting als bedoeld in artikel 18, vierde lid , of
       artikel 19 geldt of zou gelden.
+
 
       5. De verschuldigde premie is gelijk aan de grondslag van de premie behorende bij de variant van de zorgverzekering
       die de verzekeringnemer gekozen heeft, verminderd met de premiekortingen, bedoeld in de artikelen 18, vierde lid ,
       of 19 , indien deze van toepassing zijn.
 
+
       6. De zorgverzekeraar geeft de wijze waarop de verschuldigde premie van de grondslag van de premie wordt afgeleid
       in de modelovereenkomst weer, en neemt de wijze waarop de door de verzekeringnemer verschuldigde premie van de
       grondslag van de premie is afgeleid in de zorgpolis op.
+
 
       7. Een wijziging in de grondslag van de premie treedt niet eerder in werking dan met ingang van de eerste dag van
       de tweede kalendermaand volgende op de maand waarin deze aan de verzekeringnemer is medegedeeld.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel17
   - number: '18'
-    text: |-
+    text: >-
       Artikel 18 1 De zorgverzekeraar kan met een werkgever overeenkomen dat hij een geldelijk voordeel verstrekt indien
       diens werknemers of hun gezinsleden verzekerd worden op basis van een in die overeenkomst aan te wijzen
       modelovereenkomst.
 
+
       2. Het voordeel bedraagt, per werknemer die of gezinslid dat op basis van de desbetreffende modelovereenkomst
       verzekerd wordt, niet meer dan 10% van de grondslag van de bij die modelovereenkomst behorende premie.
 
+
       3. In de overeenkomst, bedoeld in het eerste lid, wordt ten minste bepaald:
+
 
       a. de hoogte van het voordeel, waarbij die hoogte mag variëren al naar gelang het aantal volgens de desbetreffende
       modelovereenkomst verzekerde werknemers of gezinsleden;
 
+
       b. de verdeling van het voordeel over de werkgever en de volgens de desbetreffende modelovereenkomst verzekerde
       werknemers of gezinsleden.
+
 
       4. Indien het voordeel of een deel daarvan aan de verzekeringnemer wordt verstrekt, geschiedt dit in de vorm van
       een korting op de grondslag van de premie.
 
+
       5. Het eerste tot en met vierde lid zijn tevens van toepassing ten aanzien van een rechtspersoon, niet zijnde een
       werkgever, met betrekking tot de verzekering van natuurlijke personen wier belangen die rechtspersoon behartigt.
+
 
       6. Bij algemene maatregel van bestuur kunnen, om te voorkomen dat afbreuk wordt gedaan aan het sociale karakter van
       de verzekering, nadere en zonodig afwijkende regels worden gesteld.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel18
   - number: '19'
-    text: |-
+    text: >-
       Artikel 19 1 De zorgverzekeraar biedt van iedere zorgverzekering met een bepaalde combinatie van te verzekeren
       prestaties als bedoeld in artikel 11, eerste lid , een variant zonder eigen risico aan.
+
 
       2. De zorgverzekeraar kan voor de verzekering van een persoon van achttien jaar of ouder varianten van de
       zorgverzekering aanbieden met een eigen risico van € 100, € 200, € 300, € 400 of € 500 per kalenderjaar,
       waartegenover hij een korting op de grondslag van de premie verleent.
 
+
       3. De korting mag afhangen van:
+
 
       a. de omvang van het voor de verzekerde gekozen eigen risico;
 
+
       b. het aantal kalenderjaren waarvoor een eigen risico voor de verzekerde gegolden heeft.
+
 
       4. De zorgverzekeraar neemt in zijn modelovereenkomst op welke premiekorting bij welk eigen risico voor welk aantal
       kalenderjaren geldt.
+
 
       5. Indien de zorgverzekeraar een of meer van de door hem aangeboden eigen risico’s laat vervallen, geeft de
       zorgverzekeraar de verzekeringnemers die een zorgverzekering met zo’n eigen risico hebben afgesloten, de
       mogelijkheid om te kiezen voor een zorgverzekering met een lager of zonder eigen risico.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel19
   - number: '20'
-    text: |-
+    text: >-
       Artikel 20 Bij algemene maatregel van bestuur kunnen vormen van zorg of overige diensten worden aangewezen waarvan
       de kosten tot een bij of krachtens die maatregel te bepalen bedrag buiten een eigen risico vallen.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel20
   - number: '21'
-    text: |-
+    text: >-
       Artikel 21 1 Indien een zorgverzekering niet op 1 januari van een kalenderjaar ingaat of eindigt, is het in dat
       kalenderjaar voor die overeenkomst geldende bedrag van het eigen risico gelijk aan het voor het gehele kalenderjaar
       geldende bedrag, vermenigvuldigd met een breuk waarvan de teller gelijk is aan het aantal dagen in dat kalenderjaar
       waarover de zorgverzekering zal lopen of heeft gelopen, en de noemer aan het aantal dagen in het desbetreffende
       kalenderjaar.
 
+
       2. In afwijking van het eerste lid wordt het in het kalenderjaar geldende bedrag van het eigen risico indien dat
       gedurende het kalenderjaar wijzigt en de verzekeringnemer onmiddellijk voorafgaande aan die wijziging reeds een
       zorgverzekering met de zorgverzekeraar had gesloten, als volgt berekend:
 
+
       a. ieder bedrag aan eigen risico dat in het desbetreffende kalenderjaar heeft gegolden of zal gelden, wordt
       vermenigvuldigd met het aantal in dat jaar gelegen dagen waarvoor dat risico gold of zal gelden;
 
+
       b. de op grond van onderdeel a berekende bedragen worden bij elkaar opgeteld;
 
+
       c. het op grond van onderdeel b berekende bedrag wordt gedeeld door het aantal dagen in het kalenderjaar.
+
 
       3. Het op grond van het eerste of tweede lid berekende bedrag wordt afgerond op hele euro’s.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel21
   - number: '22'
-    text: |-
+    text: >-
       Artikel 22 1 Indien de waarde van de verzekerde prestaties die in een kalenderjaar ten behoeve van een verzekerde
       zijn verstrekt, lager is dan een bij algemene maatregel van bestuur te bepalen bedrag, heeft de verzekerde jegens
       de zorgverzekeraar recht op een bedrag, de no-claimteruggave, dat gelijk is aan het verschil tussen het bij de
       maatregel bepaalde bedrag en eerderbedoelde waarde.
 
+
       2. Geen recht op een no-claimteruggave hebben verzekerden voor wie geen premie verschuldigd is.
+
 
       3. Indien de zorgverzekering niet op 1 januari van een kalenderjaar is ingegaan respectievelijk is geëindigd en de
       verzekeringnemer niet direct voorafgaande aan de ingangsdatum respectievelijk direct volgende op de datum waarop de
@@ -553,36 +675,44 @@ articles:
       dagen in het kalenderjaar waarover de zorgverzekering liep dan wel premie verschuldigd was, en de noemer aan het
       aantal dagen in dat kalenderjaar.
 
+
       4. Indien het derde lid van toepassing is, wordt de no-claimteruggave berekend door van het ingevolge dat lid
       bepaalde bedrag af te trekken de waarde van de verzekerde prestaties, genoten vanaf respectievelijk tot de dag
       waarop de zorgverzekering inging respectievelijk eindigde, dan wel vanaf de dag waarop voor de verzekerde premie
       verschuldigd werd.
 
+
       5. Bij algemene maatregel van bestuur wordt bepaald:
+
 
       a. welke vormen van zorg of overige diensten in welke mate buiten beschouwing blijven bij het bepalen van de waarde
       van de verzekerde prestaties, bedoeld in het eerste en vierde lid;
 
+
       b. binnen welke termijn en op welke wijze de uitkering wordt betaald;
+
 
       c. de gevolgen van het bekend worden van gebruik van zorg in een kalenderjaar waarvoor reeds uitbetaling van de
       uitkering heeft plaatsgevonden;
+
 
       d. het indexcijfer waarmee het in het eerste lid bedoelde, bij algemene maatregel van bestuur te bepalen bedrag
       jaarlijks bij ministeriële regeling wordt herzien, alsmede de berekeningswijze en de afronding die bij die
       herziening worden gehanteerd.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel22
   - number: '23'
-    text: |-
+    text: >-
       Artikel 23 1 Kosten van zorg of een andere dienst worden toegerekend aan het kalenderjaar waarin de zorg of dienst
       is genoten, met dien verstande dat de kosten van zorg of een andere dienst die in twee achtereenvolgende
       kalenderjaren is genoten en door de zorgaanbieder of andere dienstverlener in één bedrag in rekening zijn gebracht,
       worden toegerekend aan het kalenderjaar waarin de zorg of dienst is aangevangen.
 
+
       2. Bedragen als bedoeld in artikel 11, derde of vierde lid , die voor rekening van de verzekerde komen, of kosten
       als bedoeld in artikel 13, eerste lid , voor zover zij voor rekening van de verzekerde blijven, worden bij de
       berekening van de no-claimteruggave en de beantwoording van de vraag of een voor zijn verzekering geldend eigen
       risico wordt overschreden, buiten aanmerking gelaten.
+
 
       3. Een zorgverzekeraar brengt kosten van zorg of overige diensten slechts in mindering op een voor een bepaald
       kalenderjaar geldend eigen risico, voor zover deze het bij algemene maatregel van bestuur, bedoeld in artikel 22,
@@ -590,65 +720,77 @@ articles:
       kalenderjaar berekende bedrag, hebben overschreden.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel23
   - number: '24'
-    text: |-
+    text: >-
       Artikel 24 1 De rechten en plichten uit de zorgverzekering zijn van rechtswege opgeschort gedurende de periode
       waarover Onze Minister van Justitie in het kader van de uitvoering van een rechterlijke uitspraak verantwoordelijk
       is voor de verstrekking van geneeskundige zorg aan een verzekerde.
+
 
       2. De verzekeringnemer of de verzekerde meldt de zorgverzekeraar de dag waarop de periode, bedoeld in het eerste
       lid, aanvangt en eindigt.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel24
   - number: '25'
-    text: |-
+    text: >-
       Artikel 25 1 Een verzekeraar meldt het voornemen zorgverzekeringen aan te bieden en uit te voeren schriftelijk aan
       het College toezicht, onder vermelding van de dag met ingang waarvan hij zorgverzekeringen zal aanbieden.
 
+
       2. De verzekeraar voegt bij de melding alle modelovereenkomsten volgens welke hij zorgverzekeringen wenst aan te
       bieden.
+
 
       3. Een zorgverzekeraar legt wijzigingen in zijn modelovereenkomsten of nieuwe modelovereenkomsten voordat deze
       ingaan aan het College toezicht over.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel25
   - number: '26'
-    text: |-
+    text: >-
       Artikel 26 1 Het College toezicht tekent de datum van ontvangst aan op het geschrift waarmee de melding, bedoeld in
       artikel 25, eerste lid , is gedaan, alsmede op de modelovereenkomsten of wijzigingen daarvan, bedoeld in artikel
       25, tweede en derde lid .
 
+
       2. Het College toezicht zendt de verzekeraar onverwijld een bewijs van ontvangst, waarin die datum is vermeld.
+
 
       3. Het College toezicht zendt het College zorgverzekeringen onverwijld een afschrift van de melding, de
       modelovereenkomsten of de wijzigingen in de modelovereenkomsten, onder vermelding van de datum van ontvangst ervan.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel26
   - number: '27'
-    text: |-
+    text: >-
       Artikel 27 Een verzekeraar die ten onrechte een verzekering als zorgverzekering aanbiedt of uitvoert, is gehouden
       de schade die een verzekeringsplichtige of degene die hem heeft verzekerd dientengevolge lijdt, te vergoeden.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel27
   - number: '28'
-    text: |-
+    text: >-
       Artikel 28 1 De statuten van een zorgverzekeraar:
+
 
       a. voorzien in toezicht op het beleid van het bestuur en op de algemene gang van zaken in de rechtspersoon en de
       daarmee verbonden onderneming,
 
+
       b. bieden waarborgen voor een redelijke mate van invloed van de verzekerden op het beleid, en
+
 
       c. sluiten iedere verplichting van de verzekeringnemers, verzekerden, gewezen verzekeringnemers of gewezen
       verzekerden tot het doen van een bijdrage in tekorten van de rechtspersoon uit.
+
 
       2. Bij algemene maatregel van bestuur kunnen regels worden gesteld over de mate van invloed die verzekerden ten
       minste op het beleid van een zorgverzekeraar dienen te hebben.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel28
   - number: '29'
-    text: |-
+    text: >-
       Artikel 29 1 Het werkgebied van een zorgverzekeraar is Nederland.
+
 
       2. In afwijking van het eerste lid kan een zorgverzekeraar zijn werkgebied tot een of meer gehele provincies van
       Nederland beperken zolang bij hem minder dan 850 000 verzekerden op basis van een zorgverzekering verzekerd zijn.
 
+
       3. Voor de bepaling van het aantal verzekerden, bedoeld in het tweede lid, wordt uitgegaan van het gemiddelde
       aantal verzekerden in het tweede jaar voorafgaande aan het jaar waarvoor de bepaling geschiedt.
+
 
       4. Bij ministeriële regeling kunnen regels worden gesteld over de wijze waarop het aantal verzekerden wordt bepaald
       indien de zorgverzekeraar in het tweede of eerste jaar voorafgaande aan het jaar waarvoor de bepaling geschiedt,
@@ -656,274 +798,348 @@ articles:
       deze verzekeraar zorgverzekeringen van een andere zorgverzekeraar heeft overgenomen.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel29
   - number: '30'
-    text: |-
+    text: >-
       Artikel 30 1 Een zorgverzekeraar die geen zorgverzekeringen meer wenst aan te bieden of uit te voeren, meldt het
       voornemen hiertoe schriftelijk aan het College toezicht, onder vermelding van de dag met ingang waarvan hij geen
       zorgverzekeringen meer zal uitvoeren.
 
+
       2. Artikel 26 is van overeenkomstige toepassing.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel30
   - number: '31'
-    text: |-
+    text: >-
       Artikel 31 1 Indien krachtens [hoofdstuk IX van de Wet toezicht verzekeringsbedrijf
       1993](jci1.3:c:BWBR0006509&hoofdstuk=IX) jegens een zorgverzekeraar of een voormalige zorgverzekeraar de
       noodregeling is uitgesproken of een voormalige zorgverzekeraar failliet is verklaard, voldoet het College
       zorgverzekeringen aan de verzekerden jegens die zorgverzekeraar of voormalige zorgverzekeraar bestaande vorderingen
       ter zake van een recht op vergoeding als bedoeld in artikel 11, eerste lid, onderdeel b , of artikel 13 .
 
+
       2. De vorderingen, bedoeld in het eerste lid, gaan bij wijze van subrogatie op het College zorgverzekeringen over
       voor zover dat college deze heeft voldaan.
+
 
       3. Het Rijk is tegenover het College zorgverzekeringen aansprakelijk voor de betalingen, bedoeld in het eerste lid.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel31
   - number: '32'
-    text: |-
+    text: >-
       Artikel 32 1 Het College zorgverzekeringen kent een zorgverzekeraar die voldaan heeft aan zijn verplichtingen,
       bedoeld in artikel 25 , voor ieder kalenderjaar waarin hij zorgverzekeringen aanbiedt en uitvoert een bijdrage toe.
 
+
       2. Bij algemene maatregel van bestuur worden regels omtrent de berekening van de bijdragen gesteld.
+
 
       3. De regels, bedoeld in het tweede lid, bepalen ten minste dat de hoogte van de bijdrage wordt berekend op basis
       van bij die maatregel te bepalen, voor alle zorgverzekeraars gelijke criteria, waaronder in ieder geval het aantal
       verzekerden bij een zorgverzekeraar en een aantal verzekerdenkenmerken.
 
+
       4. Bij ministeriële regeling:
+
 
       a. wordt voor 1 oktober van ieder jaar bepaald welk bedrag in totaal voor het daaropvolgende kalenderjaar aan de
       zorgverzekeraars kan worden toegekend;
+
 
       b. kan worden bepaald dat in aanvulling op de criteria, bedoeld in het derde lid, voor de berekening van de hoogte
       van de bijdragen eenmalig rekening wordt gehouden met een bij die regeling te bepalen, voor alle zorgverzekeraars
       gelijk criterium;
 
+
       c. wordt statistisch onderbouwd aan elk criterium als bedoeld in het derde lid of aan een criterium als bedoeld in
       onderdeel b een bijdrage gekoppeld;
+
 
       d. worden nadere regels omtrent de berekening van de bijdragen gesteld en wordt geregeld hoe de op grond van het
       eerste lid toegekende bijdragen door het College zorgverzekeringen worden betaald.
 
+
       5. Het College zorgverzekeringen stelt jaarlijks voor 15 oktober beleidsregels vast waarin wordt aangegeven op
       welke wijze toepassing wordt gegeven aan de in het vierde lid bedoelde regels.
+
 
       6. De toekenning, bedoeld in het eerste lid, geschiedt voor 1 november van het jaar voorafgaande aan het jaar
       waarvoor de bijdrage wordt gegeven.
 
+
       7. De beleidsregels, bedoeld in het vijfde lid, behoeven de goedkeuring van Onze Minister.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel32
   - number: '33'
-    text: |-
+    text: >-
       Artikel 33 1 Bij ministeriële regeling kunnen, ingeval van een kernexplosie of natuurramp, of andere buitengewone
       gebeurtenissen die niet tot het normale bedrijfsrisico van zorgverzekeraars kunnen worden gerekend, na aanvang van
       het kalenderjaar middelen voor bijdragen aan een of meer zorgverzekeraars beschikbaar worden gesteld.
 
+
       2. Het College zorgverzekeringen kent de bijdragen aan de bij de ministeriële regeling aangewezen zorgverzekeraars
       toe.
 
+
       3. Bij ministeriële regeling worden regels omtrent de berekening van de bijdragen gesteld en wordt geregeld hoe de
       toegekende bijdragen door het College zorgverzekeringen worden betaald.
+
 
       4. Artikel 32, vijfde en zevende lid , zijn, met uitzondering van de in het vijfde lid genoemde datum, van
       overeenkomstige toepassing.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel33
   - number: '34'
-    text: |-
+    text: >-
       Artikel 34 1 Uiterlijk in het tweede jaar volgende op het kalenderjaar waarvoor de bijdragen, bedoeld in artikel 32
       en 33 , zijn toegekend, stelt het College zorgverzekeringen de bijdrage vast.
+
 
       2. De vaststelling van een bijdrage als bedoeld in artikel 32 , houdt in ieder geval in een herberekening van de
       bijdrage op basis van het werkelijke aantal verzekerden dat de zorgverzekeraar in het desbetreffende jaar had en de
       werkelijke verdeling van de verzekerdenkenmerken als bedoeld in artikel 32, derde lid , over die verzekerden, voor
       zover de daartoe benodigde gegevens tijdig bij het College zorgverzekeringen zijn aangeleverd.
 
+
       3. Bij of krachtens algemene maatregel van bestuur worden nadere regels omtrent de berekening van de bijdragen
       gesteld, met dien verstande dat generieke verevening slechts tot en met 31 december 2010 mogelijk is.
+
 
       4. Het College zorgverzekeringen stelt beleidsregels op waarin wordt aangegeven op welke wijze toepassing wordt
       gegeven aan de in het derde lid bedoelde regels en op welke wijze een vergoeding voor rentekosten wordt verleend
       respectievelijk in rekening wordt gebracht.
+
 
       5. Indien de vastgestelde bijdrage hoger is dan de toegekende bijdrage betaalt het College zorgverzekeringen de
       zorgverzekeraar of diens rechtsopvolger het verschil, vermeerderd met de rentekosten, en indien de vastgestelde
       bijdrage lager is dan de toegekende bijdrage vordert het College zorgverzekeringen het verschil, vermeerderd met de
       rentekosten, van de zorgverzekeraar of diens rechtsopvolger terug.
 
+
       6. Het College zorgverzekeringen is bevoegd het bedrag dat na toepassing van het eerste en vijfde lid aan de
       zorgverzekeraar dient te worden betaald respectievelijk van de zorgverzekeraar dient te worden teruggevorderd, te
       verrekenen met een toekenning van een bijdrage als bedoeld in artikel 32 of 33 over een later jaar.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel34
   - number: '35'
-    text: |-
+    text: >-
       Artikel 35 1 Het College zorgverzekeringen draagt zorg voor het inrichten en in stand houden van een administratie,
       waarin van iedere verzekerde wordt opgenomen:
 
+
       a. het sociaal-fiscaalnummer;
 
+
       b. de zorgverzekeraar waarbij de verzekerde verzekerd is;
+
 
       c. de persoonsgegevens, waaronder persoonsgegevens betreffende de gezondheid als bedoeld in de [Wet bescherming
       persoonsgegevens](jci1.3:c:BWBR0011468) , die noodzakelijk zijn voor de berekening van aan de zorgverzekeraar
       toekomende bijdragen als bedoeld in de artikelen 32 tot en met 34 .
 
+
       2. De zorgverzekeraar meldt het College zorgverzekeringen, onder vermelding van de ingangsdatum ervan, iedere door
       hem gesloten zorgverzekering, alsmede, indien de zorgverzekering is geëindigd, de datum waarop deze eindigde.
+
 
       3. Indien het College zorgverzekeringen constateert dat een verzekerde bij twee of meer zorgverzekeraars verzekerd
       is, stelt hij de betrokken zorgverzekeraars daarvan, onder vermelding van de namen van alle zorgverzekeraars
       waarbij de verzekerde verzekerd is, terstond op de hoogte.
 
+
       4. Bij ministeriële regeling kunnen:
+
 
       a. regels worden gesteld over de in de administratie van het College zorgverzekeringen op te nemen persoonsgegevens
       als bedoeld in het eerste lid, onderdeel c;
+
 
       b. regels worden gesteld over de inrichting van de administratie van het College zorgverzekeringen, bedoeld in het
       eerste lid.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel35
   - number: '36'
-    text: |-
+    text: >-
       Artikel 36 Op rechten of verplichtingen die voortvloeien uit hetgeen in deze paragraaf geregeld is, is [titel 4.2
       van de Algemene wet bestuursrecht](jci1.3:c:BWBR0005537&titeldeel=4.2) niet van toepassing.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel36
   - number: '37'
-    text: |-
+    text: >-
       Artikel 37 1 De zorgverzekeraar zendt binnen zes maanden na afloop van het boekjaar twee exemplaren van zijn
       jaarrekening en van zijn jaarverslag aan het College toezicht.
+
 
       2. Een zorgverzekeraar die [artikel 403 van Boek 2 van het Burgerlijk Wetboek](jci1.3:c:BWBR0003045&artikel=403)
       toepast, zendt de jaarrekening, het jaarverslag en de geconsolideerde jaarrekening onverwijld na de neerlegging van
       het jaarverslag en de geconsolideerde jaarrekening ten kantore van het handelsregister, in tweevoud aan het College
       toezicht.
 
+
       3. De zorgverzekeraar voegt bij de stukken, bedoeld in het eerste of tweede lid, twee afschriften van de
       accountantsverklaringen die hij op grond van het Burgerlijk Wetboek of de [Wet toezicht verzekeringsbedrijf
       1993](jci1.3:c:BWBR0006509) over deze stukken dient te laten opstellen.
+
 
       4. Het College toezicht zendt het College zorgverzekeringen onverwijld één exemplaar van de in het eerste tot en
       met derde lid bedoelde stukken.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel37
   - number: '38'
-    text: |-
+    text: >-
       Artikel 38 1 De zorgverzekeraar zendt voor 1 juli aan het College toezicht in tweevoud een uitvoeringsverslag
       waarin hij:
 
+
       a. rapporteert over de uitvoering van deze wet in het voorafgaande kalenderjaar, en
+
 
       b. een overzicht geeft van zijn voornemens met betrekking tot de uitvoering van deze wet in het lopende
       kalenderjaar en het daaropvolgende kalenderjaar.
 
+
       2. Bij ministeriële regeling kunnen nadere voorschriften worden gesteld omtrent de inhoud van het
       uitvoeringsverslag.
 
+
       3. De voorschriften, bedoeld in het tweede lid, kunnen in het bijzonder betrekking hebben op naleving van een in de
       regeling aan te wijzen gedragscode.
+
 
       4. De zorgverzekeraar voegt bij het uitvoeringsverslag twee exemplaren van een verslag met bevindingen van een
       accountant als bedoeld in [artikel 393 van Boek 2 van het Burgerlijk Wetboek](jci1.3:c:BWBR0003045&artikel=393)
       over de vraag of:
 
+
       a. het uitvoeringsverslag overeenkomstig de daarvoor geldende regels is opgesteld;
+
 
       b. de uitvoering is geschied overeenkomstig de verplichtingen die bij of krachtens deze wet in het voorafgaande
       kalenderjaar op de zorgverzekeraar rustten.
 
+
       5. Artikel 37, vierde lid , is van overeenkomstige toepassing.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel38
   - number: '39'
-    text: |-
+    text: >-
       Artikel 39 1 Er is een Zorgverzekeringsfonds.
 
+
       2. Ten gunste van het Zorgverzekeringsfonds komen:
+
 
       a. de inkomensafhankelijke bijdragen, bedoeld in paragraaf 5.2 , alsmede de daarmee verband houdende bestuurlijke
       boeten en renten;
 
+
       b. de rijksbijdrage, bedoeld in artikel 54 ;
+
 
       c. een rijksbijdrage als bedoeld in de artikelen 55 of 56 ;
 
+
       d. een bedrag van iedere rekening, bedoeld in artikel 70 , gelijk aan:
 
-      1°. jaarlijks: de helft van de bijdragevervangende belastingen die degenen wier bijdragevervangende belastingen op
-      die rekening werden gestort, over het voorafgaande kalenderjaar gezamenlijk verschuldigd waren, of zoveel minder
-      als het saldo bedraagt;
-
-      2°. voor iedere tot een huishouding als bedoeld in artikel 70, tweede lid , behorende gemoedsbezwaarde die alsnog
-      verzekeringsplichtig wordt dan wel overlijdt: het saldo van de rekening gedeeld door het aantal tot de huishouding
-      behorende gemoedsbezwaarden;
-
-      3°. indien de rekening met toepassing van artikel 70, achtste lid , wordt opgeheven: het saldo van de rekening;
 
       1°. jaarlijks: de helft van de bijdragevervangende belastingen die degenen wier bijdragevervangende belastingen op
       die rekening werden gestort, over het voorafgaande kalenderjaar gezamenlijk verschuldigd waren, of zoveel minder
       als het saldo bedraagt;
 
+
       2°. voor iedere tot een huishouding als bedoeld in artikel 70, tweede lid , behorende gemoedsbezwaarde die alsnog
       verzekeringsplichtig wordt dan wel overlijdt: het saldo van de rekening gedeeld door het aantal tot de huishouding
       behorende gemoedsbezwaarden;
 
+
       3°. indien de rekening met toepassing van artikel 70, achtste lid , wordt opgeheven: het saldo van de rekening;
+
+
+      1°. jaarlijks: de helft van de bijdragevervangende belastingen die degenen wier bijdragevervangende belastingen op
+      die rekening werden gestort, over het voorafgaande kalenderjaar gezamenlijk verschuldigd waren, of zoveel minder
+      als het saldo bedraagt;
+
+
+      2°. voor iedere tot een huishouding als bedoeld in artikel 70, tweede lid , behorende gemoedsbezwaarde die alsnog
+      verzekeringsplichtig wordt dan wel overlijdt: het saldo van de rekening gedeeld door het aantal tot de huishouding
+      behorende gemoedsbezwaarden;
+
+
+      3°. indien de rekening met toepassing van artikel 70, achtste lid , wordt opgeheven: het saldo van de rekening;
+
 
       e. aan het College zorgverzekeringen betaalde bedragen ter gehele of gedeeltelijke voldoening van vorderingen als
       bedoeld in artikel 31, tweede lid ;
 
+
       f. de bijdragen en boeten, bedoeld in artikel 69 ;
 
+
       g. de inkomsten die in verband met deze wet voortvloeien uit internationale overeenkomsten;
+
 
       h. door het College toezicht van verzekeraars geïnde dwangsommen, alsmede ingevorderde boeten als bedoeld in de
       artikelen 96 tot en met 100 , wat betreft de boeten, bedoeld in artikel 96 , nadat deze zijn verminderd met de in
       het zesde lid van dat artikel bedoelde vergoeding.
 
+
       3. Ten laste van het Zorgverzekeringfonds komen:
+
 
       a. de bijdragen, bedoeld in de artikelen 32 , 33 en 34 ;
 
+
       b. subsidies als bedoeld in artikel 68 , inclusief vergoedingen als bedoeld in het tweede lid van dat artikel ;
 
+
       c. door het College zorgverzekeringen voldane vorderingen als bedoeld in artikel 31, eerste lid ;
+
 
       d. uitgaven in verband met molest als bedoeld in artikel 55 , inclusief vergoedingen als bedoeld in het derde lid
       van dat artikel ;
 
+
       e. de uitgaven die in verband met deze wet voortvloeien uit internationale overeenkomsten.
+
 
       4. Uit het Zorgverzekeringsfonds worden, volgens bij ministeriële regeling te stellen regels, middelen gebruikt
       voor het vormen en in stand houden van een voor de doelstelling van het fonds noodzakelijke reserve.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel39
   - number: '40'
-    text: |-
+    text: >-
       Artikel 40 1 Het College zorgverzekeringen beheert en administreert afzonderlijk het Zorgverzekeringsfonds.
+
 
       2. Het College zorgverzekeringen houdt de financiële middelen die deel uitmaken van het Zorgverzekeringsfonds, in
       rekening-courant bij Onze Minister van Financiën.
 
+
       3. Het College zorgverzekeringen kan, voor de uitvoering van zijn wettelijke taken, beschikken over de financiële
       middelen die hij in rekening-courant bij Onze Minister van Financiën aanhoudt.
+
 
       4. In afwijking van het tweede lid kan het College zorgverzekeringen een deel van de in dat lid bedoelde financiële
       middelen buiten de in dat lid bedoelde rekening-courant houden.
 
+
       5. Onze Minister stelt in overeenstemming met Onze Minister van Financiën, na overleg met het College
       zorgverzekeringen, de omvang van het in het vierde lid bedoelde deel van de financiële middelen vast.
+
 
       6. Bij een tekort aan financiële middelen maakt het College zorgverzekeringen uitsluitend gebruik van de
       kredietfaciliteiten die door Onze Minister van Financiën worden verleend.
 
+
       7. Onze Minister van Financiën informeert dagelijks het College zorgverzekeringen ten aanzien van de
       rekening-courant, in elk geval met betrekking tot:
 
+
       a. de slotstanden per dag;
 
+
       b. alle dagelijks geboekte mutaties of transacties in de rekening-courant.
+
 
       8. Het College zorgverzekeringen informeert Onze Minister van Financiën ten aanzien van de rekening-courant in elk
       geval met betrekking tot de prognoses van de saldi van de rekening-courant.
 
+
       9. Onze Minister van Financiën brengt voor het beheer van de rekening-courant geen kosten in rekening.
+
 
       10. Onze Minister stelt in overeenstemming met Onze Minister van Financiën, na overleg met het College
       zorgverzekeringen, regels omtrent de rente die over de saldi van de in het tweede lid bedoelde rekening-courant
       wordt vergoed onderscheidenlijk in rekening wordt gebracht.
+
 
       11. Onze Minister kan in overeenstemming met Onze Minister van Financiën, na overleg met het College
       zorgverzekeringen, regels stellen omtrent het tweede, zevende en achtste lid.
@@ -937,9 +1153,10 @@ articles:
       Artikel 42 De inkomensafhankelijke bijdrage over een jaar wordt geheven over het bijdrage-inkomen van dat jaar.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel42
   - number: '43'
-    text: |-
+    text: >-
       Artikel 43 1 Het bijdrage-inkomen van een jaar is het gezamenlijke bedrag van hetgeen door de verzekeringsplichtige
       in dat jaar is genoten aan:
+
 
       a. belastbaar loon overeenkomstig de wettelijke bepalingen van de loonbelasting, verminderd met de ingevolge
       artikel 46 genoten vergoeding en met uitzondering van loon als bedoeld in [artikel 31, eerste lid, onderdelen b tot
@@ -949,25 +1166,31 @@ articles:
       voordeel, en vermeerderd met loon, bepaald volgens de regels van [artikel 3.82 van de Wet inkomstenbelasting
       2001](jci1.3:c:BWBR0011353&artikel=3.82) ;
 
+
       b. belastbare winst uit onderneming, bepaald volgens de regels van [afdeling 3.2 van de Wet inkomstenbelasting
       2001](jci1.3:c:BWBR0011353&afdeling=3.2) ;
+
 
       c. belastbaar resultaat uit overige werkzaamheden, bepaald volgens de regels van [afdeling 3.4 van de Wet
       inkomstenbelasting 2001](jci1.3:c:BWBR0011353&afdeling=3.4) , met uitzondering van de in de [artikelen
       3.91](jci1.3:c:BWBR0011353&artikel=3.91) en [3.92 van de Wet inkomstenbelasting
       2001](jci1.3:c:BWBR0011353&artikel=3.92) bedoelde werkzaamheden;
 
+
       d. belastbare periodieke uitkeringen en verstrekkingen, bepaald volgens de regels van [afdeling 3.5 van de Wet
       inkomstenbelasting 2001](jci1.3:c:BWBR0011353&afdeling=3.5) .
+
 
       2. Het bijdrage-inkomen wordt ten minste op nihil gesteld en wordt tot geen hoger bedrag in aanmerking genomen dan
       het bij regeling van Onze Minister, in overeenstemming met Onze Minister van Sociale Zaken en Werkgelegenheid en
       Onze Minister van Financiën, vastgestelde bedrag.
 
+
       3. Bij de berekening van het bijdrage-inkomen blijft het van dezelfde inhoudingsplichtige ontvangen loon als
       bedoeld in het eerste lid, onderdeel a, buiten aanmerking voor zover dat meer bedraagt dan een bij regeling van
       Onze Minister in overeenstemming met Onze Minister van Financiën en Onze Minister van Sociale Zaken en
       Werkgelegenheid, vastgesteld bedrag vermenigvuldigd met het aantal loontijdvakken van het bijdragebetalingstijdvak.
+
 
       4. Indien een verzekeringsplichtige in het bijdragebetalingstijdvak zijn naam, adres of woonplaats niet aan de
       inhoudingsplichtige heeft verstrekt dan wel zijn identiteit niet is vastgesteld en niet is opgenomen in de
@@ -978,64 +1201,75 @@ articles:
       genoten.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel43
   - number: '44'
-    text: |-
+    text: >-
       Artikel 44 1 Het bedrag, bedoeld in artikel 43, tweede lid , wordt jaarlijks bij beschikking van Onze Minister, in
       overeenstemming met Onze Minister van Sociale Zaken en Werkgelegenheid en Onze Minister van Financiën, herzien,
       waarbij met inachtneming van het bij en krachtens het tweede lid bepaalde, het laatstelijk vastgestelde bedrag
       wordt verhoogd of verlaagd overeenkomstig het procentuele verschil tussen het indexcijfer der lonen op 31 juli
       daaraan voorafgaande en het indexcijfer, dat bij de laatste herziening is gehanteerd.
 
+
       2. Onder indexcijfer der lonen wordt verstaan het indexcijfer van de CAO-lonen per maand inclusief bijzondere
       uitkeringen, sector particuliere bedrijven, zoals dat op basis van het jaar 2000 wordt berekend door het Centraal
       Bureau voor de Statistiek naar de stand op de laatste werkdag van elke kalendermaand en voor de eerste maal, al dan
       niet voorlopig, wordt gepubliceerd in het Statistisch Bulletin van het Centraal Bureau voor de Statistiek.
 
+
       3. Het in het tweede lid genoemde jaartal kan bij regeling van Onze Minister worden gewijzigd.
+
 
       4. Bij de eerstvolgende herziening nadat een in het derde lid bedoelde regeling is getroffen, wordt, in afwijking
       van het eerste lid, het procentuele verschil gehanteerd tussen het indexcijfer der lonen op 31 juli daaraan
       voorafgaande en het indexcijfer, dat bij de laatste herziening zou zijn gehanteerd, ware de indexcijferreeks reeds
       op het gewijzigde jaartal gebaseerd.
 
+
       5. Indien daartoe een bijzondere aanleiding bestaat, kan bij algemene maatregel van bestuur van de in het eerste en
       tweede lid aangegeven aanpassingsmethode worden afgeweken.
+
 
       6. Indien een wijziging ingaat op een ander tijdstip dan 1 januari, vindt de vaststelling plaats in overeenstemming
       met Onze Minister van Financiën en kunnen daarbij regels worden gesteld omtrent de wijze van berekening van de
       bijdrage over het gehele kalenderjaar.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel44
   - number: '45'
-    text: |-
+    text: >-
       Artikel 45 1 De inkomensafhankelijke bijdrage bedraagt een percentage van het bijdrage-inkomen.
+
 
       2. Het in het eerste lid bedoelde bijdragepercentage wordt bij regeling van Onze Minister, in overeenstemming met
       Onze Minister van Sociale Zaken en Werkgelegenheid en Onze Minister van Financiën, vastgesteld.
 
+
       3. Voor daarbij aan te geven bestanddelen van het bijdrage-inkomen kan een afwijkend bijdragepercentage worden
       vastgesteld.
+
 
       4. De bijdragepercentages worden zodanig vastgesteld, dat de som van de inkomensafhankelijke bijdragen gelijk is
       aan 50% van de som van bij ministeriële regeling te bepalen, ten gunste van het Zorgverzekeringsfonds of van de
       zorgverzekeraars komende inkomsten.
 
+
       5. Na afloop van het kalenderjaar vastgestelde verschillen tussen de bedragen van de inkomsten die in de
       ministeriële regeling, bedoeld in het vierde lid, in aanmerking waren genomen en de werkelijke bedragen van die
       inkomsten, worden verrekend bij de vaststelling van het bijdragepercentage in een volgend jaar.
+
 
       6. Indien een wijziging van het bijdragepercentage ingaat op een ander tijdstip dan 1 januari, vindt de
       vaststelling plaats in overeenstemming met Onze Minister van Financiën en kunnen daarbij regels worden gesteld
       omtrent de wijze van berekening van de bijdrage over het gehele kalenderjaar.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel45
   - number: '46'
-    text: |-
+    text: >-
       Artikel 46 1 Een verzekeringsplichtige die bij regeling van Onze Minister aan te wijzen loon overeenkomstig de
       wettelijke bepalingen van de loonbelasting geniet, heeft recht op een volledige vergoeding door de
       inhoudingsplichtige van de inkomensafhankelijke bijdrage over dit deel van het bijdrage-inkomen.
 
+
       2. Voor de toepassing van het eerste lid is artikel 43, tweede lid , van overeenkomstige toepassing.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel46
   - number: '47'
-    text: |-
+    text: >-
       Artikel 47 Bij regeling van Onze Minister, in overeenstemming met Onze Minister van Financiën en Onze Minister van
       Sociale Zaken en Werkgelegenheid, kunnen nadere regels worden gesteld met betrekking tot deze paragraaf.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel47
@@ -1044,54 +1278,63 @@ articles:
       Artikel 48 De rijksbelastingdienst heft de inkomensafhankelijke bijdrage.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel48
   - number: '49'
-    text: |-
+    text: >-
       Artikel 49 1 Voor zover het bijdrage-inkomen bestaat uit loon als bedoeld in artikel 43, eerste lid, onderdeel a ,
       dat van een inhoudingsplichtige wordt genoten, wordt de inkomensafhankelijke bijdrage bij wijze van inhouding
       geheven met overeenkomstige toepassing van de voor de heffing van de loonbelasting geldende regels.
+
 
       2. Voor zover het bijdrage-inkomen bestaat uit andere dan de in het eerste lid bedoelde bestanddelen, wordt de
       inkomensafhankelijke bijdrage bij wege van aanslag geheven met overeenkomstige toepassing van de voor de heffing
       van de inkomstenbelasting geldende regels, met uitzondering van [artikel 3.154 van de Wet inkomstenbelasting
       2001](jci1.3:c:BWBR0011353&artikel=3.154) .
 
+
       3. Bij de vaststelling van de ingevolge het tweede lid op te leggen aanslag wordt de bijdrage die op grond van
       artikel 43, tweede lid , juncto artikel 45 ten hoogste kan worden geheven verminderd met de bijdrage die op grond
       van het eerste lid is ingehouden.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel49
   - number: '50'
-    text: |-
+    text: >-
       Artikel 50 1 Indien over het bijdrage-inkomen inkomensafhankelijke bijdrage is ingehouden over een hoger
       bijdrage-inkomen dan het bedrag, bedoeld in artikel 43, tweede lid , stelt de inspecteur, bedoeld in de [Wet
       financiering sociale verzekeringen](jci1.3:c:BWBR0017745) , bij voor bezwaar vatbare beschikking het bedrag van de
       teveel betaalde bijdrage vast.
 
+
       2. Indien het bijdrage-inkomen waarover inkomensafhankelijke bijdrage is ingehouden van verschillende
       inhoudingsplichtigen is ontvangen, wordt het bedrag van de teveel ingehouden bijdrage als bedoeld in het eerste lid
       naar evenredigheid toegerekend aan de door deze inhoudingsplichtigen ingehouden bijdrage.
+
 
       3. In afwijking in zoverre van de vorige leden wordt het bedrag van teveel ingehouden bijdrage voor zover mogelijk
       toegerekend aan de inkomensafhankelijke bijdrage over het bijdrage-inkomen waarop artikel 46, eerste lid , niet van
       toepassing is.
 
+
       4. Bij regeling van Onze Minister, in overeenstemming met Onze Minister van Financiën, kunnen nadere en zo nodig
       afwijkende regels worden gesteld.
+
 
       5. In afwijking van de [artikelen 25b](jci1.3:c:BWBR0002320&artikel=25b) , [27f](jci1.3:c:BWBR0002320&artikel=27f)
       , [27j, derde lid](jci1.3:c:BWBR0002320&artikel=27j) , en [29i van de Algemene wet inzake
       rijksbelastingen](jci1.3:c:BWBR0002320&artikel=29i) verleent de inspecteur een teruggave van een ingehouden bedrag
       aan inkomensafhankelijke bijdrage over loon als bedoeld in artikel 46, eerste lid , aan de inhoudingsplichtige.
 
+
       6. In afwijking van [artikel 5a van de Algemene wet inzake rijksbelastingen](jci1.3:c:BWBR0002320&artikel=5a)
       beslist de inspecteur op aanvragen als bedoeld in dit artikel binnen een redelijke termijn als bedoeld in [afdeling
       4.1.3 van de Algemene wet bestuursrecht](jci1.3:c:BWBR0005537&afdeling=4.1.3) en met toepassing van die afdeling.
+
 
       7. Indien in verband met de gevraagde beschikking informatie is gevraagd aan een persoon of instantie buiten
       Nederland en om die reden de beschikking niet binnen redelijke termijn gegeven kan worden, wordt de termijn met ten
       hoogte zes maanden verlengd en wordt de aanvrager van deze verlenging schriftelijk op de hoogte gesteld.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel50
   - number: '51'
-    text: |-
+    text: >-
       Artikel 51 1 De rijksbelastingdienst vordert de inkomensafhankelijke bijdrage in.
+
 
       2. Bij de invordering van de bijdrage zijn, naar gelang artikel 49, eerste lid , dan wel tweede lid van toepassing
       is, de regels geldende voor de invordering van de loonbelasting, met uitzondering van [artikel 38, eerste lid,
@@ -1099,207 +1342,247 @@ articles:
       inkomstenbelasting van overeenkomstige toepassing.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel51
   - number: '52'
-    text: |-
+    text: >-
       Artikel 52 Bij regeling van Onze Minister en Onze Minister van Financiën worden regels gesteld met betrekking tot
       de afdracht van de inkomensafhankelijke bijdragen alsmede van de daarmee verband houdende bestuurlijke boeten en
       renten door de rijksbelastingdienst aan het Zorgverzekeringsfonds.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel52
   - number: '53'
-    text: |-
+    text: >-
       Artikel 53 Bij regeling van Onze Minister, in overeenstemming met Onze Minister van Financiën en Onze Minister van
       Sociale Zaken en Werkgelegenheid, kunnen nadere regels worden gesteld met betrekking tot deze paragraaf.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel53
   - number: '54'
-    text: |-
+    text: >-
       Artikel 54 1 Onze Minister verleent jaarlijks aan het Zorgverzekeringsfonds een bijdrage in de financiering van de
       zorgverzekering voor verzekerden jonger dan achttien jaar.
+
 
       2. De bijdrage is gelijk aan het bedrag dat daarvoor in de wet tot vaststelling van de begroting van zijn
       ministerie voor dat jaar is toegestaan.
 
+
       3. De bijdrage wordt betaald in gelijke maandelijkse delen.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel54
   - number: '55'
-    text: |-
+    text: >-
       Artikel 55 1 Onze Minister kan, in overeenstemming met Onze Minister van Financiën, een bijdrage aan het
       Zorgverzekeringsfonds verlenen ter gehele of gedeeltelijke betaling van zorg of overige diensten als bedoeld in
       artikel 10 , in geval de behoefte aan die zorg of diensten is veroorzaakt door of ontstaan uit gewapend conflict,
       burgeroorlog, opstand, binnenlandse onlusten, oproer, muiterij of terrorisme.
 
+
       2. Bij ministeriële regeling wordt bepaald:
+
 
       a. welke vormen van zorg of overige diensten voor welk gedeelte met de bijdrage worden betaald;
 
+
       b. ten behoeve van welke personen de bijdrage wordt betaald;
+
 
       c. onder welke voorwaarden en op welke wijze deze zorg of overige diensten door het College zorgverzekeringen wordt
       betaald.
+
 
       3. In een regeling als bedoeld in het tweede lid kan worden bepaald dat zorgverzekeraars het College
       zorgverzekeringen bijstand verlenen bij het uitvoeren van de ministeriële regeling, bedoeld in het tweede lid, en
       welke vergoeding daar voor de zorgverzekeraars tegenover staat.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel55
   - number: '56'
-    text: |-
+    text: >-
       Artikel 56 Indien de situatie, bedoeld in artikel 31, eerste lid , zich heeft voorgedaan, verstrekt Onze Minister
       een bijdrage aan het Zorgverzekeringsfonds ter hoogte van het verschil tussen het bedrag aan voldane vorderingen,
       als bedoeld in artikel 31, eerste lid , en het bedrag dat het College zorgverzekeringen ter zake van de
       vorderingen, bedoeld in artikel 31, tweede lid , heeft ontvangen.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel56
   - number: '57'
-    text: |-
+    text: >-
       Artikel 57 1 Van de persoon die op grond van artikel 2, tweede lid, onderdeel b , niet verzekeringsplichtig is,
       wordt met overeenkomstige toepassing van [hoofdstuk 5 van de Wet financiering sociale
       verzekeringen](jci1.3:c:BWBR0017745&hoofdstuk=5) en [artikel 58 van die wet](jci1.3:c:BWBR0017745&artikel=58)
       belasting geheven, tot het bedrag van de inkomensafhankelijke bijdrage, bedoeld in artikel 43, tweede lid , dat de
       persoon verschuldigd zou zijn als ware hij verzekeringsplichtig.
 
+
       2. Indien de in het eerste lid bedoelde belasting wordt geheven over op grond van artikel 46, eerste lid ,
       aangewezen loon, is artikel 46 van overeenkomstige toepassing.
+
 
       3. De rijksbelastingdienst stort de belasting, bedoeld in het eerste lid, op de rekening, bedoeld in artikel 70,
       eerste dan wel tweede lid .
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel57
   - number: '58'
-    text: |-
+    text: >-
       Artikel 58 1 Er is een College voor zorgverzekeringen, dat rechtspersoonlijkheid bezit.
 
+
       2. Het College zorgverzekeringen is gevestigd in een door Onze Minister te bepalen plaats.
+
 
       3. Het College zorgverzekeringen is belast met de taken die hem bij of krachtens wet of internationale overeenkomst
       zijn opgedragen.
 
+
       4. Het College zorgverzekeringen wordt in en buiten rechte vertegenwoordigd door de voorzitter.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel58
   - number: '59'
-    text: |-
+    text: >-
       Artikel 59 1 Het College zorgverzekeringen bestaat uit een oneven aantal van ten hoogste negen leden, onder wie de
       voorzitter.
 
+
       2. Onze Minister benoemt, schorst en ontslaat de voorzitter en de overige leden.
+
 
       3. Benoeming vindt plaats op grond van de deskundigheid die nodig is voor de uitoefening van de taken van het
       College zorgverzekeringen alsmede op grond van maatschappelijke kennis en ervaring.
 
+
       4. De leden worden benoemd voor ten hoogste vier jaar. Herbenoeming kan twee maal en telkens voor ten hoogste vier
       jaar plaatsvinden.
+
 
       5. Bij de samenstelling van het College zorgverzekeringen wordt gestreefd naar evenredige deelneming van vrouwen en
       van personen behorende tot etnische of culturele minderheidsgroepen.
 
+
       6. Het lidmaatschap van het College zorgverzekeringen is onverenigbaar met het lidmaatschap van het College
       toezicht of van het bestuur van De Nederlandsche Bank N.V.
+
 
       7. Het lidmaatschap eindigt tussentijds door overlijden, ontslag op eigen verzoek of ontslag om zwaarwichtige
       redenen door Onze Minister.
 
+
       8. Van een besluit tot benoeming, schorsing of ontslag wordt mededeling gedaan in de Staatscourant.
 
+
       9. Bij ministeriële regeling:
+
 
       a. worden de vergoeding van reis- en verblijfkosten en verdere vergoedingen aan leden van het College
       zorgverzekeringen en leden van commissies vastgesteld;
 
+
       b. kunnen nadere regels over hun rechtspositie worden vastgesteld;
+
 
       c. worden andere functies of werkzaamheden dan die, genoemd in het zesde lid, aangewezen, die niet verenigbaar zijn
       met het lidmaatschap van het College zorgverzekeringen.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel59
   - number: '60'
-    text: |-
+    text: >-
       Artikel 60 1 Het College zorgverzekeringen stelt een bestuursreglement vast.
+
 
       2. In het bestuursreglement kan het College zorgverzekeringen voorzien in de instelling van commissies en kan het
       hun samenstelling en taken regelen.
 
+
       3. In commissies kunnen personen deelnemen die geen lid van het College zorgverzekeringen zijn.
+
 
       4. Vergaderingen van het College zorgverzekeringen en van commissies zijn openbaar, behoudens voor zover in het
       bestuursreglement anders is bepaald.
 
+
       5. Het bestuursreglement behoeft de goedkeuring van Onze Minister.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel60
   - number: '61'
-    text: |-
+    text: >-
       Artikel 61 1 Op de rechtspositie van het personeel van het College zorgverzekeringen zijn de regels die gelden voor
       ambtenaren die zijn aangesteld bij ministeries van toepassing, met dien verstande dat waar in deze regels een
       bevoegdheid is toegekend aan een andere minister dan Onze Minister van Binnenlandse Zaken en Koninkrijksrelaties,
       deze bevoegdheid wordt uitgeoefend door het College zorgverzekeringen.
 
+
       2. Bij algemene maatregel van bestuur kan worden afgeweken van de in het eerste lid bedoelde regels.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel61
   - number: '62'
-    text: |-
+    text: >-
       Artikel 62 Onze Minister kan beleidsregels vaststellen met betrekking tot de werkwijze en de uitoefening van de
       taken van het College zorgverzekeringen.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel62
   - number: '63'
-    text: |-
+    text: >-
       Artikel 63 1 Een besluit van het College zorgverzekeringen kan bij koninklijk besluit worden vernietigd.
+
 
       2. Van een besluit tot vernietiging wordt mededeling gedaan door plaatsing in de Staatscourant.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel63
   - number: '64'
-    text: |-
+    text: >-
       Artikel 64 1 Het College zorgverzekeringen bevordert de eenduidige uitleg van de aard, inhoud en omvang van de
       prestaties, bedoeld in artikel 11 .
+
 
       2. Het College zorgverzekeringen kan de zorgverzekeraars met het oog hierop richtlijnen geven.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel64
   - number: '65'
-    text: |-
+    text: >-
       Artikel 65 Het College zorgverzekeringen geeft aan zorgverzekeraars, aan zorgaanbieders en aan burgers voorlichting
       over de aard, inhoud en omvang van de prestaties, bedoeld in artikel 11 .
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel65
   - number: '66'
-    text: |-
+    text: >-
       Artikel 66 1 Het College zorgverzekeringen rapporteert Onze Minister desgevraagd over voorgenomen beleid inzake
       aard, inhoud en omvang van de prestaties, bedoeld in artikel 11 .
+
 
       2. Het College zorgverzekeringen signaleert gevraagd en ongevraagd aan Onze Minister feitelijke ontwikkelingen die
       aanleiding kunnen geven tot wijzigingen van de aard, inhoud en omvang van de prestaties, bedoeld in artikel 11 .
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel66
   - number: '67'
-    text: |-
+    text: >-
       Artikel 67 Het College zorgverzekeringen bevordert de afstemming van de uitvoering:
 
+
       a. van en tussen de zorgverzekering en de algemene verzekering bijzondere ziektekosten, en
+
 
       b. van deze verzekeringen met de uitvoering van het beleid op andere terreinen van de volksgezondheid en op andere
       terreinen van sociale zekerheid.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel67
   - number: '68'
-    text: |-
+    text: >-
       Artikel 68 1 Bij ministeriële regeling kan worden bepaald dat het College zorgverzekeringen overeenkomstig in die
       regeling gestelde regels tijdelijk subsidies verstrekt voor zorg of andere diensten, ten aanzien waarvan het
       voornemen bestaat deze te doen opnemen in de te verzekeren prestaties.
+
 
       2. In een regeling als bedoeld in het eerste lid kan worden bepaald dat zorgverzekeraars het College
       zorgverzekeringen bijstand verlenen bij de verstrekking van subsidies behorende tot een in die regeling genoemde
       categorie, en welke vergoeding zij daarvoor ontvangen.
 
+
       3. Onze Minister kan jaarlijks voor een categorie van subsidies het subsidieplafond voor het komende jaar
       bekendmaken.
+
 
       4. In een regeling als bedoeld in het eerste lid kan aan het College zorgverzekeringen worden opgedragen nadere
       regels te stellen.
 
+
       5. Nadere regels als bedoeld in het vierde lid behoeven de goedkeuring van Onze Minister.
+
 
       6. Goedkeuring kan slechts worden onthouden wegens strijd met het recht of het belang van de volksgezondheid.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel68
   - number: '69'
-    text: |-
+    text: >-
       Artikel 69 1 In het buitenland wonende personen die met toepassing van een Verordening van de Raad van de Europese
       Gemeenschappen dan wel toepassing van zodanige verordening krachtens de overeenkomst betreffende de Europese
       Economische Ruimte of een verdrag inzake sociale zekerheid in geval van behoefte aan zorg recht hebben op zorg of
       vergoeding van de kosten daarvan, zoals voorzien in de wetgeving over de verzekering voor zorg van hun woonland,
       melden zich, tenzij zij op grond van deze wet verzekeringsplichtig zijn, bij het College zorgverzekeringen aan.
 
+
       2. De in het eerste lid bedoelde personen zijn een bij ministeriële regeling te bepalen bijdrage verschuldigd, die
       voor de toepassing van artikel 22 alsmede, voor een bij die regeling te bepalen gedeelte van de bijdrage, voor de
       toepassing van de [Wet op de zorgtoeslag](jci1.3:c:BWBR0018451) als premie voor een zorgverzekering wordt
       beschouwd.
+
 
       3. Indien de melding niet is geschied binnen vier maanden nadat het recht, bedoeld in het eerste lid, is ontstaan,
       legt het College zorgverzekeringen degene die de melding had moeten doen een boete op, die gelijk is aan 130% van
@@ -1307,44 +1590,56 @@ articles:
       gelijk aan de periode gelegen tussen de dag waarop het recht ontstond en de dag waarop de melding is geschied, maar
       met een maximum van vijf jaren.
 
+
       4. Het College zorgverzekeringen is belast met de administratie, voortvloeiend uit het eerste lid en de daar
       genoemde internationale regels, alsmede met de heffing en de inning van de bijdrage, bedoeld in het tweede lid.
 
+
       5. Bij ministeriële regeling:
+
 
       a. kan, in afwijking van het vierde lid, worden bepaald dat de bijdrage, bedoeld in het tweede lid, door een orgaan
       dat pensioen of rente uitkeert, op dat pensioen of die rente wordt ingehouden en aan het Zorgverzekeringsfonds
       wordt afgedragen;
 
+
       b. kunnen regels worden gesteld over de wijze waarop het College zorgverzekeringen zijn taak, bedoeld in het vierde
       lid, uitoefent of de organen, bedoeld in onderdeel a, de in dat onderdeel bedoelde werkzaamheden uitvoeren.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel69
   - number: '70'
-    text: |-
+    text: >-
       Artikel 70 1 Het College zorgverzekeringen opent voor iedere gemoedsbezwaarde, bedoeld in artikel 2, tweede lid,
       onderdeel b , een rekening, waarop de geheven bijdragevervangende belasting, bedoeld in artikel 57, eerste lid ,
       wordt gestort.
+
 
       2. In afwijking van het eerste lid opent of houdt het College zorgverzekeringen één rekening in stand indien twee
       of meer gemoedsbezwaarden als bedoeld in artikel 2, tweede lid, onderdeel b , een gezamenlijke huishouding voeren,
       en worden op die rekening de belastingen van ieder van deze gemoedsbezwaarden gestort.
 
+
       3. Tot de rekening is geen ander begunstigd dan het College zorgverzekeringen.
 
+
       4. Het saldo wordt door het College zorgverzekeringen gebruikt voor het doen van:
+
 
       a. uitkeringen ter vergoeding van kosten van zorg of overige diensten als bedoeld in artikel 11 , voor zover deze
       zijn verleend aan een gemoedsbezwaarde voor wie de rekening in stand wordt gehouden, of aan een tot zijn
       huishouding behorend kind, jonger dan achttien jaar;
 
+
       b. uitkeringen als bedoeld in artikel 39, tweede lid, onderdeel d .
+
 
       5. Uitkeringen als bedoeld in het vierde lid, onderdeel a, worden slechts op verzoek van een gemoedsbezwaarde voor
       wie de rekening in stand wordt gehouden, gedaan.
 
+
       6. De kosten van zorg of overige diensten worden niet vergoed voor zover deze voor een verzekerde op grond van de
       regels, gesteld bij of krachtens de algemene maatregel van bestuur, bedoeld in artikel 11, derde of vierde lid ,
       voor eigen rekening blijven.
+
 
       7. De kosten van zorg of overige diensten, verleend aan een gemoedsbezwaarde van achttien jaar of ouder, worden
       slechts vergoed voor zover het bedrag daarvan in een kalenderjaar meer bedraagt dan het verschil tussen het bij
@@ -1352,94 +1647,117 @@ articles:
       bedrag dat een verzekerde naar verwachting in het daaropvolgende jaar ingevolge artikel 22 van de
       Zorgverzekeringswet terug ontvangt, bedoeld in artikel 4, eerste lid, van de Wet op de zorgtoeslag.
 
+
       8. Het College zorgverzekeringen heft een rekening op indien alle gemoedsbezwaarden voor wie de rekening in stand
       werd gehouden, verzekeringsplichtig zijn geworden dan wel zijn overleden.
+
 
       9. Indien een gemoedsbezwaarde een gezamenlijke huishouding is gaan vormen met een andere gemoedsbezwaarde, heft
       het College zorgverzekeringen een van de twee rekeningen op, onder overmaking van het saldo naar de overblijvende
       rekening.
 
+
       10. Het College zorgverzekeringen zorgt per gemoedsbezwaarde of huishouding, bedoeld in het tweede lid, voor een
       ordentelijke administratie van de stortingen op en de uitkeringen ten laste van de rekening.
 
+
       11. Bij ministeriële regeling kunnen ter zake van het bepaalde in het eerste tot en met tiende lid nadere regels en
       uitvoeringsregels worden gegeven.
+
 
       12. Het College zorgverzekeringen is bevoegd de werkzaamheden, bedoeld bij of krachtens het eerste tot en met elfde
       lid, onder vergoeding van de daarmee gepaard gaande kosten, uit te besteden aan een of meer zorgverzekeraars.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel70
   - number: '71'
-    text: |-
+    text: >-
       Artikel 71 1 Het College zorgverzekeringen zendt jaarlijks voor 1 oktober aan Onze Minister een jaarplan voor het
       volgende kalenderjaar.
 
+
       2. Het jaarplan omvat:
+
 
       a. een werkprogramma met een beschrijving van de activiteiten die het College zorgverzekeringen voornemens is ter
       uitvoering van zijn taken te verrichten,
 
+
       b. een begroting van de beheerskosten voor de uitvoering van de voorgenomen activiteiten, en
+
 
       c. een meerjarenraming voor de vier kalenderjaren volgend op het begrotingsjaar.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel71
   - number: '72'
-    text: |-
+    text: >-
       Artikel 72 1 Onze Minister stelt jaarlijks voor 1 december het budget voor de beheerskosten van het College
       zorgverzekeringen voor het volgende kalenderjaar vast.
 
+
       2. Onze Minister kan besluiten het budget voor de beheerskosten van het College zorgverzekeringen te wijzigen.
+
 
       3. Indien gedurende het jaar aanmerkelijke verschillen ontstaan of dreigen te ontstaan tussen de werkelijke en de
       begrote baten en lasten, doet het College zorgverzekeringen daarvan onverwijld mededeling aan Onze Minister, onder
       vermelding van de oorzaak van de verschillen.
 
+
       4. Het College zorgverzekeringen gaat met betrekking tot de beheerskosten geen verplichtingen aan en doet geen
       uitgaven die leiden tot overschrijding van het vastgestelde budget voor de beheerskosten.
+
 
       5. Indien het budget voor de beheerskosten niet is vastgesteld voor 1 januari van het kalenderjaar waarop de
       begroting betrekking heeft, is het College zorgverzekeringen bevoegd, teneinde zijn activiteiten gaande te houden,
       te beschikken over ten hoogste een derde gedeelte van het budget dat laatstelijk voor hem voor een geheel jaar is
       vastgesteld.
 
+
       6. Onze Minister kan besluiten dat het College zorgverzekeringen in een geval als bedoeld in het vijfde lid, kan
       beschikken over meer dan een derde gedeelte van het budget dat laatstelijk voor hem voor een geheel jaar is
       vastgesteld.
+
 
       7. Het door Onze Minister vastgestelde budget voor de beheerskosten van het College zorgverzekeringen wordt gedekt
       uit ’s Rijks kas.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel72
   - number: '73'
-    text: |-
+    text: >-
       Artikel 73 1 Het College zorgverzekeringen zendt jaarlijks voor 15 maart aan Onze Minister een jaarverantwoording
       over het afgelopen kalenderjaar, alsmede het verslag van bevindingen, bedoeld in het zesde lid.
 
+
       2. De jaarverantwoording omvat:
+
 
       a. een jaarrekening, en
 
+
       b. een jaarverslag omtrent het door het College zorgverzekeringen gevoerde beleid, de doeltreffendheid van dat
       beleid, de bedrijfsvoering en de uitvoering van het werkprogramma in het afgelopen kalenderjaar.
+
 
       3. Het College zorgverzekeringen legt in zijn jaarrekening, die zoveel mogelijk met overeenkomstige toepassing van
       [titel 9 van Boek 2 van het Burgerlijk Wetboek](jci1.3:c:BWBR0003045&titeldeel=9) wordt ingericht, rekening en
       verantwoording af over zijn beheerskosten en over de rechtmatigheid en doelmatigheid van het beheer in het
       afgelopen kalenderjaar.
 
+
       4. De jaarrekening gaat vergezeld van een verklaring omtrent de getrouwheid, afgegeven door een accountant als
       bedoeld in [artikel 393 van Boek 2 van het Burgerlijk Wetboek](jci1.3:c:BWBR0003045&artikel=393) , die bereid is
       Onze Minister desgevraagd inzicht te geven in zijn controlewerkzaamheden.
 
+
       5. De verklaring heeft mede betrekking op de rechtmatige verkrijging en besteding van de middelen door het College
       zorgverzekeringen.
+
 
       6. De accountant voegt bij de verklaring een verslag van zijn bevindingen over de vraag of het beheer en de
       organisatie voldoen aan eisen van rechtmatigheid, ordelijkheid, controleerbaarheid en doelmatigheid.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel73
   - number: '74'
-    text: |-
+    text: >-
       Artikel 74 1 Het College zorgverzekeringen zendt jaarlijks voor 15 maart aan Onze Minister met betrekking tot het
       Zorgverzekeringsfonds een jaarrekening over het afgelopen kalenderjaar, alsmede het verslag van bevindingen,
       bedoeld in het vijfde lid.
+
 
       2. Het College zorgverzekeringen legt in de jaarrekening, die zoveel mogelijk met overeenkomstige toepassing van
       [titel 9 van Boek 2 van het Burgerlijk Wetboek](jci1.3:c:BWBR0003045&titeldeel=9) wordt ingericht, rekening en
@@ -1447,140 +1765,174 @@ articles:
       31 december, alsmede over de rechtmatigheid en doelmatigheid van het beheer van dat fonds in het afgelopen
       kalenderjaar.
 
+
       3. De jaarrekening gaat vergezeld van een verklaring omtrent de getrouwheid, afgegeven door een accountant als
       bedoeld in [artikel 393 van Boek 2 van het Burgerlijk Wetboek](jci1.3:c:BWBR0003045&artikel=393) , die bereid is
       Onze Minister desgevraagd inzicht te geven in zijn controlewerkzaamheden.
 
+
       4. De verklaring heeft mede betrekking op de rechtmatige verkrijging en besteding van de middelen van het
       Zorgverzekeringsfonds.
+
 
       5. De accountant voegt bij de verklaring een verslag van zijn bevindingen over de vraag of het beheer en de
       organisatie voldoen aan eisen van rechtmatigheid, ordelijkheid, controleerbaarheid en doelmatigheid.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel74
   - number: '75'
-    text: |-
+    text: >-
       Artikel 75 1 De onderdelen «werkprogramma» en «begroting» van het jaarplan, bedoeld in artikel 71 , het onderdeel
       «jaarrekening» van de jaarverantwoording, bedoeld in artikel 73 , en de jaarrekening, bedoeld in artikel 74 ,
       behoeven de goedkeuring van Onze Minister.
 
+
       2. Het eerste lid geldt niet voor wijzigingen in een goedgekeurde begroting, mits:
 
+
       a. de totale omvang van de begroting geen wijziging ondergaat, en
+
 
       b. de wijziging per groep van kostensoorten en baten, gerekend over het desbetreffende begrotingsjaar, een bedrag
       van 5 procent van het in artikel 72 bedoelde budget niet te boven gaat.
 
+
       3. Bij ministeriële regeling kunnen regels worden gesteld over de inhoud en de inrichting van:
+
 
       a. het jaarplan, bedoeld in artikel 71 ;
 
+
       b. de jaarverantwoording, bedoeld in artikel 73 ;
 
+
       c. de jaarrekening, bedoeld in artikel 74 ;
+
 
       d. de verklaringen, bedoeld in de artikelen 73, vierde lid en 74, derde lid , de verslagen van bevindingen, bedoeld
       in artikel 73, zesde lid en 74, vijfde lid , alsmede het aan die verklaringen en verslagen ten grondslag liggende
       onderzoek.
 
+
       4. Bij ministeriële regeling worden regels gesteld over de wijze waarop en de voorwaarden waaronder het budget,
       bedoeld in artikel 72 , wordt vastgesteld.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel75
   - number: '76'
-    text: |-
+    text: >-
       Artikel 76 1 Na de goedkeuring, bedoeld in artikel 75, eerste lid , stelt het College zorgverzekeringen het
       jaarplan, de jaarverantwoording en de jaarrekening van het Zorgverzekeringsfonds algemeen verkrijgbaar.
+
 
       2. Onze Minister brengt zijn oordeel over het functioneren van het College zorgverzekeringen ter kennis van beide
       Kamers der Staten-Generaal.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel76
   - number: '77'
-    text: |-
+    text: >-
       Artikel 77 1 Er is een College van toezicht op de zorgverzekeringen, dat rechtspersoonlijkheid bezit.
+
 
       2. Het College toezicht is gevestigd in een door Onze Minister te bepalen plaats.
 
+
       3. Het College toezicht is, voor zover dit niet aan andere toezichthouders is voorbehouden, belast met:
+
 
       a. het toezicht op de rechtmatige uitvoering door de zorgverzekeraars van hetgeen bij of krachtens deze wet is
       geregeld;
 
+
       b. het toezicht op de rechtmatige afrekening van de bijdragen, bedoeld in de artikelen 32 tot en met 34 , nadat een
       verzekeraar opgehouden is zorgverzekeringen uit te voeren;
 
+
       c. het toezicht op de uitvoering van andere wetten, volgens bij of krachtens die wetten te bepalen criteria.
+
 
       4. Het College toezicht wordt in en buiten rechte vertegenwoordigd door de voorzitter.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel77
   - number: '78'
-    text: |-
+    text: >-
       Artikel 78 1 Het College toezicht bestaat uit een oneven aantal van ten hoogste vijf leden, onder wie de
       voorzitter.
+
 
       2. De artikelen 59, tweede tot en met negende lid , en 60 tot en met 63 zijn van overeenkomstige toepassing.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel78
   - number: '79'
-    text: |-
+    text: >-
       Artikel 79 1 Het College toezicht wijst de medewerkers aan die toezichthouders zijn als bedoeld in [artikel 5:11
       van de Algemene wet bestuursrecht](jci1.3:c:BWBR0005537&artikel=5:11) .
+
 
       2. Van een besluit als bedoeld in het eerste lid wordt mededeling gedaan door plaatsing in de Staatscourant.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel79
   - number: '80'
-    text: |-
+    text: >-
       Artikel 80 1 Het College toezicht zendt voor 1 november aan Onze Minister en aan het College zorgverzekeringen een
       samenvattend rapport over de rechtmatigheid van de uitvoering van deze wet en de daarop gebaseerde regelgeving door
       de zorgverzekeraars in het voorafgaande kalenderjaar.
 
+
       2. Onze Minister zendt het rapport, bedoeld in het eerste lid, aan beide kamers der Staten-Generaal.
 
+
       3. Het College toezicht stelt het rapport, bedoeld in het eerste lid, algemeen verkrijgbaar.
+
 
       4. Bij ministeriële regeling kunnen regels worden gesteld over de inhoud en inrichting van het rapport, bedoeld in
       het eerste lid.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel80
   - number: '81'
-    text: |-
+    text: >-
       Artikel 81 1 Het College toezicht maakt, onverminderd zijn bevoegdheid tot eigen onderzoek, zoveel mogelijk gebruik
       van de resultaten van door anderen verrichte controles.
+
 
       2. De zorgverzekeraars verstrekken desgevraagd aan het College toezicht de informatie over de uitgevoerde
       werkzaamheden van hen die met de controle zijn belast en lichten hem volledig in over de resultaten van de controle
       door overlegging van rapporten of op andere door het College toezicht aan te geven wijze.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel81
   - number: '82'
-    text: |-
+    text: >-
       Artikel 82 1 Het College toezicht rapporteert desgevraagd aan Onze Minister over de uitvoerbaarheid,
       doeltreffendheid en doelmatigheid van voorgenomen beleid in verband met de uitoefening van zijn toezichthoudende
       taak.
 
+
       2. Het College toezicht stelt op verzoek van Onze Minister onderzoek in bij zorgverzekeraars.
+
 
       3. Het College toezicht kan tevens op verzoek van het College zorgverzekeringen onderzoek bij de zorgverzekeraars
       instellen.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel82
   - number: '83'
-    text: |-
+    text: >-
       Artikel 83 1 Het College toezicht maakt ten behoeve van de inzichtelijkheid, voor verzekeringsplichtigen, van de
       zorgverzekeringsmarkt informatie openbaar met betrekking tot:
 
+
       a. de inhoud van de modelovereenkomsten;
+
 
       b. de wijze van dienstverlening aan verzekerden en verzekeringnemers.
 
+
       2. Het eerste lid geldt niet indien naar het oordeel van het College toezicht anderen reeds in voldoende mate in
       openbaarmaking van de daar bedoelde informatie voorzien.
+
 
       3. Bij ministeriële regeling kan nader worden bepaald op welke onderwerpen de openbaarmaking, bedoeld in het eerste
       lid, betrekking heeft.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel83
   - number: '84'
-    text: |-
+    text: >-
       Artikel 84 1 Het College zorgverzekeringen kan in overeenstemming met het College toezicht regels stellen met
       betrekking tot de administratie van de zorgverzekeraars.
 
+
       2. Het College toezicht kan regels stellen met betrekking tot:
 
+
       a. de controle door de zorgverzekeraars;
+
 
       b. de inhoud en inrichting van het accountantsverslag, bedoeld in artikel 38 , en van het aan dat verslag ten
       grondslag liggende onderzoek.
@@ -1590,23 +1942,26 @@ articles:
       Artikel 85 Paragraaf 6.3 is, met uitzondering van artikel 74 , van overeenkomstige toepassing.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel85
   - number: '86'
-    text: |-
+    text: >-
       Artikel 86 1 De zorgverzekeraar neemt het sociaal-fiscaalnummer van zijn verzekerden en, gedurende zeven jaren na
       het einde van de verzekering, van zijn gewezen verzekerden met het oog op de uitvoering van de zorgverzekering en
       van deze wet in zijn administratie op.
 
+
       2. De zorgverzekeraar verifieert het sociaal-fiscaalnummer in relatie tot de bijbehorende persoonsidentificerende
       gegevens van de verzekerde indien daartoe aanleiding is.
+
 
       3. Bij gegevensuitwisseling tussen de zorgverzekeraars en de in de artikelen 88 en 89 genoemde personen en
       instanties wordt, voor zover die personen en instanties tot gebruik van dat nummer bevoegd zijn, het
       sociaal-fiscaalnummer gebruikt.
 
+
       4. Bij algemene maatregel van bestuur kunnen nadere regels worden gesteld met betrekking tot het eerste en tweede
       lid.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel86
   - number: '87'
-    text: |-
+    text: >-
       Artikel 87 1 Een zorgaanbieder die aan een verzekerde zorg of andere diensten, bedoeld in artikel 11 , heeft
       verleend, en die de kosten daarvan krachtens een door hem met de zorgverzekeraar gesloten overeenkomst rechtstreeks
       bij die zorgverzekeraar in rekening brengt, verstrekt die zorgverzekeraar of een door die zorgverzekeraar
@@ -1615,20 +1970,24 @@ articles:
       van de zorgverzekering of van deze wet, dan wel stelt hem deze gegevens voor dit doel voor inzage of het nemen van
       afschrift ter beschikking.
 
+
       2. Een zorgaanbieder die aan een verzekerde zorg of andere diensten, bedoeld in artikel 11 , heeft verleend en die
       de kosten daarvan bij de verzekerde in rekening brengt, verstrekt hem de persoonsgegevens, waaronder
       persoonsgegevens betreffende zijn gezondheid als bedoeld in de [Wet bescherming
       persoonsgegevens](jci1.3:c:BWBR0011468) , die voor zijn zorgverzekeraar noodzakelijk zijn voor de uitvoering van de
       zorgverzekering of van deze wet.
 
+
       3. De zorgaanbieder, bedoeld in het eerste of tweede lid, verstrekt een door Onze Minister aangewezen persoon
       kosteloos bij ministeriële regeling omschreven, voor de uitvoering van deze wet noodzakelijke persoonsgegevens,
       waaronder persoonsgegevens betreffende de gezondheid als bedoeld in de [Wet bescherming
       persoonsgegevens](jci1.3:c:BWBR0011468) .
 
+
       4. Personen werkzaam ten behoeve van een zorgaanbieder als bedoeld in het eerste of tweede lid, verstrekken die
       zorgaanbieder de persoonsgegevens die hij nodig heeft om te kunnen voldoen aan zijn verplichtingen bedoeld in het
       eerste, tweede en derde lid.
+
 
       5. Personen werkzaam bij de zorgverzekeraar, bij een door de zorgverzekeraar aangewezen persoon als bedoeld in het
       eerste lid, of bij de door Onze Minister aangewezen persoon als bedoeld in het derde lid, voor wie niet reeds uit
@@ -1636,18 +1995,23 @@ articles:
       bedoeld in het eerste, tweede of derde lid, behoudens voor zover enig wettelijk voorschrift hen tot mededeling
       verplicht.
 
+
       6. Bij ministeriële regeling kan worden bepaald:
+
 
       a. tot welke gegevens de verplichting, bedoeld in het eerste of tweede lid, zich in ieder geval uitstrekt;
 
+
       b. op welke wijze gegevens, bedoeld in het eerste of tweede lid, worden verstrekt;
 
+
       c. volgens welke technische standaarden elektronische gegevensverstrekking plaatsvindt;
+
 
       d. aan welke beveiligingseisen elektronische gegevensverstrekking voldoet.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel87
   - number: '88'
-    text: |-
+    text: >-
       Artikel 88 1 Een ieder verstrekt op verzoek aan de zorgverzekeraars, het College zorgverzekeringen, het College
       toezicht, Onze Minister, de rijksbelastingdienst, het Uitvoeringsinstituut werknemersverzekeringen, de Sociale
       verzekeringsbank, het gemeentebestuur, of aan een daartoe door of vanwege een van deze zorgverzekeraars of
@@ -1655,20 +2019,23 @@ articles:
       [Wet bescherming persoonsgegevens](jci1.3:c:BWBR0011468) , die noodzakelijk zijn voor de uitvoering van de
       zorgverzekeringen of van deze wet.
 
+
       2. De in het eerste lid bedoelde gegevens en inlichtingen worden op verzoek verstrekt in schriftelijke vorm of in
       een andere vorm die redelijkerwijs kan worden verlangd, binnen een termijn die schriftelijk wordt gesteld bij het
       in het eerste lid bedoelde verzoek.
+
 
       3. Een ieder geeft op verzoek van een rechtspersoon als bedoeld in het eerste lid, inzage in alle bescheiden en
       andere gegevensdragers, stelt deze op verzoek ter beschikking voor het nemen van afschrift en verleent de terzake
       verlangde medewerking, voor zover dit noodzakelijk is voor de uitvoering van deze wet door de desbetreffende
       zorgverzekeraars of instanties.
 
+
       4. Bij ministeriële regeling kunnen nadere regels worden gesteld met betrekking tot het eerste, tweede of derde
       lid.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel88
   - number: '89'
-    text: |-
+    text: >-
       Artikel 89 1 De in artikel 88, eerste lid , bedoelde zorgverzekeraars en instanties zijn bevoegd uit eigen beweging
       en verplicht op verzoek binnen een bij dat verzoek genoemde termijn, uit de onder hun verantwoordelijkheid gevoerde
       administratie, aan elkaar, aan een daartoe door of vanwege hen aangewezen persoon of aan een door Onze Minister
@@ -1676,75 +2043,89 @@ articles:
       persoonsgegevens](jci1.3:c:BWBR0011468) , te verstrekken die noodzakelijk zijn voor de uitvoering van de
       zorgverzekeringen of van deze wet.
 
+
       2. Een zorgverzekeraar verleent op verzoek van het College zorgverzekeringen dan wel van het College toezicht aan
       door het desbetreffende college aangewezen personen inzage in alle bescheiden en andere gegevensdragers, stelt deze
       op verzoek ter beschikking voor het nemen van afschrift en verleent de terzake verlangde medewerking, voor zover
       het desbetreffende college dit nodig acht voor de uitoefening van zijn taak.
 
+
       3. Alle ambtenaren tot afgifte van uittreksels uit registers van burgerlijke stand bevoegd, zijn verplicht aan een
       in artikel 88, eerste lid , bedoelde zorgverzekeraar of instantie de door deze gevraagde uittreksels uit de
       registers kosteloos toe te zenden.
+
 
       4. Griffiers van colleges, geheel of ten dele met rechtspraak belast, verstrekken op verzoek, kosteloos, aan een
       zorgverzekeraar, aan het College zorgverzekeringen of aan het College toezicht alle gegevens, inlichtingen en
       uittreksels uit of afschriften van uitspraken, registers en andere stukken, die noodzakelijk zijn voor de
       uitvoering van deze wet door de zorgverzekeraar of het desbetreffende college.
 
+
       5. Bij algemene maatregel van bestuur worden nadere regels gesteld over de verstrekking van gegevens door de
       rijksbelastingdienst aan de zorgverzekeraars.
+
 
       6. Bij ministeriële regeling kunnen nadere regels worden gesteld met betrekking tot het eerste of tweede lid.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel89
   - number: '90'
-    text: |-
+    text: >-
       Artikel 90 1 Het College toezicht, onderscheidenlijk het College zorgverzekeringen kan na overleg met het College
       zorgverzekeringen, onderscheidenlijk het College toezicht bij regeling bepalen welke gegevens en inlichtingen
       regelmatig door de zorgverzekeraars moeten worden verstrekt.
+
 
       2. De regels kunnen mede omvatten het tijdstip en de wijze waarop de gegevens en inlichtingen moeten worden
       verstrekt, alsmede dat een accountant als bedoeld in [artikel 393 van Boek 2 van het Burgerlijk
       Wetboek](jci1.3:c:BWBR0003045&artikel=393) de juistheid van de verstrekte gegevens en inlichtingen bevestigt.
 
+
       3. Bij ministeriële regeling kan worden bepaald welke statistische gegevens de zorgverzekeraars verzamelen
       betreffende vormen van zorg en andere diensten.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel90
   - number: '91'
-    text: |-
+    text: >-
       Artikel 91 1 Het College zorgverzekeringen en het College toezicht verstrekken Onze Minister uit eigen beweging
       inlichtingen over ontwikkelingen die ertoe leiden of kunnen leiden dat ten behoeve van verzekerden niet vrij kan
       worden gekozen tussen zorgverzekeraars en de door hen aangeboden varianten van de zorgverzekering of die een
       rechtmatige en volledige uitvoering van zorgverzekeringen jegens de verzekeringnemers of verzekerden in gevaar
       kunnen brengen.
 
+
       2. Het College zorgverzekeringen en het College toezicht verstrekken desgevraagd aan Onze Minister, aan het College
       tarieven gezondheidszorg, bedoeld in de [Wet tarieven gezondheidszorg](jci1.3:c:BWBR0003356) , of aan het College
       bouw of het College sanering, bedoeld in de Wet toelating zorginstellingen, de voor de uitoefening van hun taak
       benodigde inlichtingen en gegevens.
+
 
       3. Het College zorgverzekeringen en het College toezicht verlenen aan door Onze Minister of door een
       bestuursorgaan, bedoeld in het tweede lid, aangewezen personen toegang tot en inzage in zakelijke gegevens en
       bescheiden, voor zover dat voor de vervulling van hun taak redelijkerwijs nodig is.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel91
   - number: '92'
-    text: |-
+    text: >-
       Artikel 92 1 Een zorgverzekeraar maakt voor de verstrekking of ontvangst van gegevens aan of van personen, aan te
       wijzen door het College zorgverzekeringen, gebruik van een elektronische infrastructuur.
 
+
       2. Het College zorgverzekeringen kan met betrekking tot het eerste lid regels stellen over:
+
 
       a. de aard en omvang van de gegevens en de voorschriften waaraan de verstrekking of ontvangst ten minste moet
       voldoen;
 
+
       b. de wijze waarop de verstrekking of ontvangst van gegevens plaatsvindt, waaronder begrepen de aansluiting van
       zorgverzekeraars op de infrastructuur;
+
 
       c. de wijze waarop het gebruik van de infrastructuur wordt georganiseerd en beheerd, waaronder begrepen de
       inrichting en instandhouding van een gemeenschappelijke database;
 
+
       d. de financiering van het gebruik van de infrastructuur en de wijze waarop de kosten ervan worden verdeeld.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel92
   - number: '93'
-    text: |-
+    text: >-
       Artikel 93 1 Het is een ieder die uit hoofde van de toepassing van deze wet of van krachtens deze wet genomen
       besluiten enige taak vervult of heeft vervuld, verboden van vertrouwelijke gegevens of inlichtingen die ingevolge
       deze wet dan wel ingevolge [afdeling 5.2 van de Algemene wet bestuursrecht](jci1.3:c:BWBR0005537&afdeling=5.2) zijn
@@ -1752,9 +2133,11 @@ articles:
       ontvangen, verder of anders gebruik te maken of daaraan verder of anders bekendheid te geven dan voor de uitvoering
       van zijn taak of bij of krachtens deze wet wordt geëist.
 
+
       2. In afwijking van het eerste lid kunnen het College toezicht en het College zorgverzekeringen met gebruikmaking
       van vertrouwelijke gegevens of inlichtingen verkregen bij de uitvoering van hun taken op grond van deze wet,
       mededelingen doen, indien deze niet kunnen worden herleid tot afzonderlijke personen of ondernemingen.
+
 
       3. In afwijking van het eerste lid en van [artikel 182 van de Wet toezicht verzekeringsbedrijf
       1993](jci1.3:c:BWBR0006509&artikel=182) zijn het College toezicht, het College zorgverzekeringen, De Nederlandsche
@@ -1762,11 +2145,14 @@ articles:
       bevoegd aan elkaar en aan Onze Minister vertrouwelijke gegevens of inlichtingen omtrent afzonderlijke verzekeraars
       te verschaffen.
 
+
       4. Het eerste lid laat, ten aanzien van degene op wie dat lid van toepassing is, onverlet:
+
 
       a. de toepasselijkheid van de bepalingen van het [Wetboek van Strafvordering](jci1.3:c:BWBR0001903) welke
       betrekking hebben op het als getuige of deskundige in strafzaken afleggen van een verklaring omtrent gegevens of
       inlichtingen verkregen bij de vervulling van de ingevolge deze wet opgedragen taak;
+
 
       b. de toepasselijkheid van de bepalingen van het [Wetboek van Burgerlijke Rechtsvordering](jci1.3:c:BWBR0001827) en
       van [artikel 66 van de Faillissementswet](jci1.3:c:BWBR0001860&artikel=66) welke betrekking hebben op het als
@@ -1775,290 +2161,361 @@ articles:
       taak, voor zover het gaat om gegevens of inlichtingen omtrent een verzekeraar die in staat van faillissement is
       verklaard of op grond van een rechterlijke uitspraak is ontbonden;
 
+
       c. de bevoegdheden van de Algemene Rekenkamer ingevolge [artikel 91 van de Comptabiliteitswet
       2001](jci1.3:c:BWBR0013891&artikel=91) , voor zover deze niet bij artikel 121 zijn beperkt.
+
 
       5. Het vierde lid, onderdeel b, geldt niet voor gegevens of inlichtingen die betrekking hebben op verzekeraars die
       betrokken zijn of zijn geweest bij een poging de desbetreffende verzekeraar in staat te stellen zijn bedrijf voort
       te zetten.
+
 
       6. De Algemene Rekenkamer is bij het doen van mededelingen als bedoeld in [artikel 91, elfde tot en met veertiende
       lid, van de Comptabiliteitswet 2001](jci1.3:c:BWBR0013891&artikel=91) , verplicht tot geheimhouding, voor zover het
       betreft gegevens en inlichtingen die haar ingevolge het vierde lid, onderdeel c, bekend zijn geworden.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel93
   - number: '94'
-    text: |-
+    text: >-
       Artikel 94 1 Het College toezicht kan uit hoofde van zijn toezichthoudende taak een aanwijzing geven aan een
       zorgverzekeraar, dan wel aan een verzekeraar die verzekeringen als zorgverzekering aanbiedt of uitvoert die niet
       aan het bij of krachtens deze wet geregelde voldoen.
 
+
       2. Het College toezicht geeft geen aanwijzing omtrent de beoordeling of behandeling van individuele gevallen.
 
+
       3. Bij de aanwijzing stelt het College toezicht een termijn waarbinnen de verzekeraar aan de aanwijzing voldoet.
+
 
       4. Indien de verzekeraar niet binnen de termijn, bedoeld in het derde lid, aan de aanwijzing voldoet, is het
       College toezicht bevoegd:
 
+
       a. bestuursdwang toe te passen, of
+
 
       b. ter openbare kennis te brengen, zo nodig onder vermelding van de overwegingen die tot die kennisgeving hebben
       geleid:
 
-      1°. dat een verzekeraar verzekeringen als zorgverzekering aanbiedt of uitvoert die niet aan het bij of krachtens
-      deze wet geregelde voldoen;
-
-      2°. dat een zorgverzekeraar in strijd handelt met een of meer door het College toezicht genoemde, bij of krachtens
-      deze wet geregelde bepalingen;
-
-      3°. dat aan een verzekeraar een last onder dwangsom of een bestuurlijke boete is opgelegd.
 
       1°. dat een verzekeraar verzekeringen als zorgverzekering aanbiedt of uitvoert die niet aan het bij of krachtens
       deze wet geregelde voldoen;
 
+
       2°. dat een zorgverzekeraar in strijd handelt met een of meer door het College toezicht genoemde, bij of krachtens
       deze wet geregelde bepalingen;
 
+
       3°. dat aan een verzekeraar een last onder dwangsom of een bestuurlijke boete is opgelegd.
+
+
+      1°. dat een verzekeraar verzekeringen als zorgverzekering aanbiedt of uitvoert die niet aan het bij of krachtens
+      deze wet geregelde voldoen;
+
+
+      2°. dat een zorgverzekeraar in strijd handelt met een of meer door het College toezicht genoemde, bij of krachtens
+      deze wet geregelde bepalingen;
+
+
+      3°. dat aan een verzekeraar een last onder dwangsom of een bestuurlijke boete is opgelegd.
+
 
       5. Het College toezicht stelt, indien hij voornemens is een feit ter openbare kennis te brengen, de betrokken
       verzekeraar daarvan in kennis onder vermelding van de gronden waarop het voornemen berust.
+
 
       6. In afwijking van [artikel 4:8 van de Algemene wet bestuursrecht](jci1.3:c:BWBR0005537&artikel=4:8) is het
       College toezicht niet gehouden de betrokken verzekeraar in de gelegenheid te stellen om zijn zienswijze naar voren
       te brengen, indien van de betrokken verzekeraar geen adres bekend is en het adres ook niet met een redelijke
       inspanning kan worden verkregen.
 
+
       7. De beschikking om een feit ter openbare kennis te brengen, vermeldt in ieder geval het feit dat ter openbare
       kennis wordt gebracht alsmede de wijze waarop en de termijn waarna dit zal geschieden.
 
+
       8. Het ter openbare kennis brengen geschiedt niet eerder dan nadat vijf werkdagen zijn verstreken na de
       bekendmaking, bedoeld in het vijfde lid, aan de verzekeraar.
+
 
       9. Indien de verzekeraar verzoekt om een voorlopige voorziening als bedoeld in [artikel 8:81 van de Algemene wet
       bestuursrecht](jci1.3:c:BWBR0005537&artikel=8:81) te treffen, wordt de werking van de beschikking opgeschort totdat
       er een uitspraak is van de voorzieningenrechter.
 
+
       10. Indien het adequaat functioneren van de verzekeringsmarkt of de positie van de verzekeraars op die markt geen
       uitstel toelaat, kan de toezichthouder, in afwijking van de voorgaande leden, het feit onverwijld ter openbare
       kennis brengen.
+
 
       11. Indien de verzekeraar na een publicatie als bedoeld in het vierde lid, onderdeel b, alsnog voldoet aan de
       aanwijzing, doet het College toezicht hiervan op dezelfde wijze mededeling als bij de voorafgaande publicatie.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel94
   - number: '95'
-    text: |-
+    text: >-
       Artikel 95 1 Het College toezicht kan een zorgverzekeraar een last onder dwangsom opleggen ter zake van overtreding
       van de voorschriften gesteld bij of krachtens de artikelen 3 , 4, tweede tot en met vijfde lid , 5, derde lid , 9 ,
       25, derde lid , 28 , 29, eerste en tweede lid , 35, tweede lid , 37 , 38, eerste en vierde lid , 64, tweede lid ,
       68, tweede lid , 81, tweede lid , 84 , 86 , 89, eerste, tweede en vijfde lid , 90 , 92 , 96, vijfde lid , of 114 .
 
+
       2. Het College toezicht kan een verzekeraar respectievelijk rechtspersoon een last onder dwangsom opleggen ter zake
       van overtreding van de artikelen 25, eerste en tweede lid , respectievelijk 30 .
 
+
       3. Het College toezicht kan een verzekeraar die verzekeringen als zorgverzekering aanbiedt of uitvoert die niet aan
       het bij of krachtens deze wet geregelde voldoen, een last onder dwangsom opleggen.
+
 
       4. De [artikelen 5:32, tweede tot en met vijfde lid](jci1.3:c:BWBR0005537&artikel=5:32) , en [5:33 tot en met 5:35
       van de Algemene wet bestuursrecht](jci1.3:c:BWBR0005537&artikel=5:33) zijn van toepassing, met dien verstande dat
       een door het College toezicht ingevorderde dwangsom aan het Zorgverzekeringsfonds wordt afgedragen.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel95
   - number: '96'
-    text: |-
+    text: >-
       Artikel 96 1 Indien de zorgverzekering niet binnen vier maanden na het ontstaan van de verzekeringsplicht is
       ingegaan of indien een verzekeringsplichtige niet met ingang van de dag volgende op de dag waarop een
       zorgverzekering is geëindigd op grond van een andere zorgverzekering verzekerd is, legt het College
       zorgverzekeringen de verzekerde een bestuurlijke boete op.
 
+
       2. In afwijking van het eerste lid:
+
 
       a. wordt geen boete opgelegd indien de verzekerde op de eerste dag van de kalendermaand, volgende op de maand
       waarop de zorgverzekering ingaat, jonger dan achttien jaar was;
 
+
       b. wordt de boete indien artikel 2, derde lid , van toepassing is, opgelegd aan de curator, de bewindvoerder of de
       mentor.
+
 
       3. De hoogte van de boete is gelijk aan 130% van de premie, bedoeld in artikel 17, vijfde lid , over een periode
       gelijk aan de periode gelegen tussen de dag waarop de verzekeringsplicht ontstond en de dag waarop de
       zorgverzekering inging, dan wel gelegen tussen de dag waarop de zorgverzekering eindigde en de dag waarop een
       nieuwe zorgverzekering inging.
 
+
       4. Indien de periode, bedoeld in het derde lid, langer is dan vijf jaren, wordt zij op vijf jaren gesteld.
+
 
       5. De voorbereiding en de uitvoering van boetebeschikkingen wordt namens het College zorgverzekeringen door de
       zorgverzekeraars verricht.
 
+
       6. De zorgverzekeraars hebben als vergoeding voor hun werkzaamheden, bedoeld in het vijfde lid, recht op een door
       het College zorgverzekeringen te bepalen percentage van de door hen ingevorderde boeten.
+
 
       7. De zorgverzekeraars dragen de ingevorderde boeten onder aftrek van de vergoeding, bedoeld in het vijfde lid, af
       aan het Zorgverzekeringsfonds.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel96
   - number: '97'
-    text: |-
+    text: >-
       Artikel 97 1 Het College toezicht kan een bestuurlijke boete opleggen aan een zorgverzekeraar die niet voldoet aan
       de voorschriften, gesteld bij of krachtens de artikelen 3 , 25, derde lid , 28 , of 29, eerste en tweede lid .
+
 
       2. Het College toezicht kan een bestuurlijke boete opleggen aan een verzekeraar respectievelijk rechtspersoon die
       niet voldoet respectievelijk niet heeft voldaan aan de voorschriften, gesteld bij de artikelen 25, eerste en tweede
       lid , respectievelijk 30 .
 
+
       3. De boete voor een afzonderlijke overtreding bedraagt ten hoogste € 500 000.
+
 
       4. Het College toezicht draagt ingevorderde boeten af aan het Zorgverzekeringsfonds.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel97
   - number: '98'
-    text: |-
+    text: >-
       Artikel 98 1 Het College toezicht kan een bestuurlijke boete opleggen aan een zorgverzekeraar die dat college of
       een door hem aangewezen persoon onjuiste of onvolledige informatie heeft verschaft met betrekking tot de aantallen
       bij hem verzekerde verzekeringsplichtigen of hun verzekerdenkenmerken, noodzakelijk voor de vaststelling van de
       bijdragen, bedoeld in de artikelen 32 tot en met 34 .
 
+
       2. De boete voor een afzonderlijke overtreding bedraagt ten hoogste € 10 000 000.
+
 
       3. Het College toezicht draagt ingevorderde boeten af aan het Zorgverzekeringsfonds.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel98
   - number: '99'
-    text: |-
+    text: >-
       Artikel 99 1 Het College toezicht kan een bestuurlijke boete opleggen aan een zorgverzekeraar die niet voldoet aan
       de voorschriften, gesteld bij of krachtens de artikelen 4, tweede tot en met vijfde lid , 5, derde lid , 9 , 35,
       tweede lid , 37 , 38, eerste en vierde lid , 64, tweede lid , 68, tweede lid , 81, tweede lid , 84 , 86 , 90 , 92
       of 114 .
 
+
       2. De boete voor een afzonderlijke overtreding bedraagt ten hoogste € 100 000.
+
 
       3. Het College toezicht draagt ingevorderde boeten af aan het Zorgverzekeringsfonds.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel99
   - number: '100'
-    text: |-
+    text: >-
       Artikel 100 1 Het College toezicht kan een bestuurlijke boete opleggen aan degene die niet voldoet aan een hem
       ingevolge artikel 88 of 89 opgelegde verplichting.
 
+
       2. De boete voor een afzonderlijke overtreding bedraagt ten hoogste € 2 250.
+
 
       3. Het College toezicht draagt ingevorderde boeten af aan het Zorgverzekeringsfonds.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel100
   - number: '101'
-    text: |-
+    text: >-
       Artikel 101 1 In de artikelen 102 tot en met 112 wordt verstaan onder:
+
 
       a. overtreding: een gedraging of het nalaten van een gedraging, die of dat kan leiden tot de oplegging van een
       bestuurlijke boete als bedoeld in de artikelen 69 , 96 , 97 , 98 , 99 of 100 ;
+
 
       b. overtreder: degene aan wie het College zorgverzekeringen dan wel het College toezicht wegens een overtreding een
       bestuurlijke boete overweegt op te leggen of oplegt. 2 [Artikel 51 van het Wetboek van
       Strafrecht](jci1.3:c:BWBR0001854&artikel=51) is van overeenkomstige toepassing.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel101
   - number: '102'
-    text: |-
+    text: >-
       Artikel 102 1 Degene die wordt verhoord met het oog op het opleggen van een bestuurlijke boete, is niet verplicht
       ten behoeve daarvan verklaringen omtrent de overtreding af te leggen.
+
 
       2. De betrokkene wordt hierop gewezen alvorens hem mondeling wordt gevraagd verklaringen af te leggen, en in ieder
       geval wanneer hij in de gelegenheid wordt gesteld over het voornemen tot oplegging van de bestuurlijke boete zijn
       zienswijze naar voren te brengen.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel102
   - number: '103'
-    text: |-
+    text: >-
       Artikel 103 1 Het College zorgverzekeringen dan wel het College toezicht maakt van de overtreding een rapport op.
+
 
       2. Het rapport is gedagtekend en vermeldt:
 
+
       a. de naam van de overtreder;
+
 
       b. de overtreding alsmede het overtreden voorschrift;
 
+
       c. zo nodig een aanduiding van de plaats waar en het tijdstip waarop de overtreding is geconstateerd.
+
 
       3. Indien van de overtreding een proces-verbaal als bedoeld in [artikel 152 van het Wetboek van
       Strafvordering](jci1.3:c:BWBR0001903&artikel=152) is opgemaakt, treedt dit in de plaats van het rapport.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel103
   - number: '104'
-    text: |-
+    text: >-
       Artikel 104 1 Het College zorgverzekeringen dan wel het College toezicht stelt de overtreder desgevraagd in de
       gelegenheid de gegevens waarop het opleggen van de bestuurlijke boete, dan wel het voornemen daartoe, berust, in te
       zien en daarvan afschriften te vervaardigen.
+
 
       2. Voor zover blijkt dat de verdediging van de overtreder dit redelijkerwijs vergt, draagt het College
       zorgverzekeringen dan wel het College toezicht er zoveel mogelijk zorg voor dat deze gegevens aan de overtreder
       worden medegedeeld in een voor deze begrijpelijke taal.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel104
   - number: '105'
-    text: |-
+    text: >-
       Artikel 105 1 In afwijking van artikel 4.1.2 van de Algemene wet bestuursrecht wordt de overtreder steeds in de
       gelegenheid gesteld zijn zienswijze over het voornemen tot het opleggen van een bestuurlijke boete naar voren te
       brengen.
 
+
       2. Bij de uitnodiging tot het naar voren brengen van zijn zienswijze wordt het rapport, bedoeld in artikel 103 ,
       aan de overtreder toegezonden of uitgereikt.
+
 
       3. Het College zorgverzekeringen dan wel het College toezicht zorgt voor bijstand door een tolk, indien blijkt dat
       de verdediging van de overtreder dit redelijkerwijs vergt.
 
+
       4. Indien het College zorgverzekeringen dan wel het College toezicht nadat de overtreder zijn zienswijze naar voren
       heeft gebracht, beslist dat:
 
+
       a. voor de overtreding geen bestuurlijke boete zal worden opgelegd, of
+
 
       b. de overtreding aan de officier van justitie zal worden voorgelegd, wordt dit schriftelijk aan de overtreder
       medegedeeld.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel105
   - number: '106'
-    text: |-
+    text: >-
       Artikel 106 1 Het College zorgverzekeringen dan wel het College toezicht legt geen bestuurlijke boete op:
+
 
       a. voor zover de overtreding niet aan de overtreder kan worden verweten;
 
+
       b. voor zover voor de overtreding een rechtvaardigingsgrond bestond;
+
 
       c. indien aan de overtreder wegens dezelfde overtreding reeds eerder een bestuurlijke boete is opgelegd, dan wel
       een kennisgeving als bedoeld in artikel 105, vierde lid, aanhef en onderdeel a , is bekendgemaakt;
 
+
       d. indien tegen de overtreder wegens dezelfde gedraging:
 
+
       1°. een strafvervolging is ingesteld en het onderzoek ter terechtzitting is begonnen, of
+
 
       2°. het recht tot strafvordering is vervallen ingevolge [artikel 74](jci1.3:c:BWBR0001854&artikel=74) of [74c van
       het Wetboek van Strafrecht](jci1.3:c:BWBR0001854&artikel=74c) , ingevolge [artikel 37 van de Wet op de economische
       delicten](jci1.3:c:BWBR0002063&artikel=37) , dan wel ingevolge [artikel 76 van de Algemene wet inzake
       rijksbelastingen](jci1.3:c:BWBR0002320&artikel=76) .
 
+
       1°. een strafvervolging is ingesteld en het onderzoek ter terechtzitting is begonnen, of
+
 
       2°. het recht tot strafvordering is vervallen ingevolge [artikel 74](jci1.3:c:BWBR0001854&artikel=74) of [74c van
       het Wetboek van Strafrecht](jci1.3:c:BWBR0001854&artikel=74c) , ingevolge [artikel 37 van de Wet op de economische
       delicten](jci1.3:c:BWBR0002063&artikel=37) , dan wel ingevolge [artikel 76 van de Algemene wet inzake
       rijksbelastingen](jci1.3:c:BWBR0002320&artikel=76) .
+
 
       2. Indien de gedraging tevens een strafbaar feit is, wordt zij aan de officier van justitie voorgelegd, tenzij met
       het openbaar ministerie is overeengekomen, dat daarvan kan worden afgezien.
 
+
       3. Bij ministeriële regeling kan worden bepaald in welke gevallen van een voorlegging als bedoeld in het tweede lid
       wordt afgezien.
+
 
       4. Voor een gedraging die aan de officier van justitie moet worden voorgelegd, legt het College toezicht slechts
       een bestuurlijke boete op indien:
 
+
       a. de officier van justitie aan het bestuursorgaan heeft medegedeeld van strafvervolging tegen de overtreder af te
       zien, of
+
 
       b. het College toezicht niet binnen dertien weken een reactie van de officier van justitie heeft ontvangen.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel106
   - number: '107'
-    text: |-
+    text: >-
       Artikel 107 1 Het College zorgverzekeringen dan wel het College toezicht legt geen bestuurlijke boete op indien de
       overtreder is overleden.
 
+
       2. Een bestuurlijke boete vervalt indien zij op het tijdstip van het overlijden van de overtreder niet
       onherroepelijk is.
+
 
       3. Een onherroepelijke bestuurlijke boete vervalt voor zover zij op het in het tweede lid bedoelde tijdstip nog
       niet is betaald.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel107
   - number: '108'
-    text: |-
+    text: >-
       Artikel 108 1 Indien de overtreder aannemelijk maakt dat een bestuurlijke boete, berekend op grond van artikel 69
       of artikel 96, derde en vierde lid , wegens bijzondere omstandigheden te hoog is, legt het College
       zorgverzekeringen een lagere bestuurlijke boete op.
+
 
       2. Een bestuurlijke boete op grond van de artikelen 97 , 98 , 99 of 100 wordt afgestemd op de ernst van de
       overtreding en de mate waarin deze aan de overtreder kan worden verweten, waarbij zo nodig rekening wordt gehouden
@@ -2066,189 +2523,217 @@ articles:
       Strafrecht](jci1.3:c:BWBR0001854&artikel=1) is van overeenkomstige toepassing.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel108
   - number: '109'
-    text: |-
+    text: >-
       Artikel 109 Mandaat tot het opleggen van een bestuurlijke boete wordt niet verleend aan degene die van de
       overtreding een rapport of proces-verbaal heeft opgemaakt.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel109
   - number: '110'
-    text: |-
+    text: >-
       Artikel 110 1 Het College zorgverzekeringen dan wel het College toezicht beslist omtrent het opleggen van de
       bestuurlijke boete binnen dertien weken na de dagtekening van het rapport.
+
 
       2. De beslistermijn wordt opgeschort met ingang van de dag waarop de gedraging aan het openbaar ministerie is
       voorgelegd, tot de dag waarop het College zorgverzekeringen dan wel het College toezicht weer bevoegd wordt een
       bestuurlijke boete op te leggen.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel110
   - number: '111'
-    text: |-
+    text: >-
       Artikel 111 De beschikking tot oplegging van een bestuurlijke boete vermeldt:
+
 
       a. de naam van de overtreder;
 
+
       b. de overtreding alsmede het overtreden voorschrift;
+
 
       c. zo nodig een aanduiding van de plaats waar en het tijdstip waarop de overtreding is geconstateerd;
 
+
       d. het bedrag van de boete;
+
 
       e. de termijn waarbinnen de boete betaald moet worden.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel111
   - number: '112'
-    text: |-
+    text: >-
       Artikel 112 1 De bevoegdheid tot het opleggen van een bestuurlijke boete vervalt vijf jaren nadat de overtreding
       heeft plaatsgevonden.
+
 
       2. Indien tegen de bestuurlijke boete bezwaar wordt gemaakt of beroep wordt ingesteld, wordt de vervaltermijn
       opgeschort tot onherroepelijk op het bezwaar of beroep is beslist.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel112
   - number: '113'
-    text: |-
+    text: >-
       Artikel 113 1 Een boete wordt betaald binnen zes weken na inwerkingtreding van de beschikking waarbij de boete is
       opgelegd.
 
+
       2. De boete wordt vermeerderd met de wettelijke rente, te rekenen vanaf de dag waarop sedert de bekendmaking van de
       beschikking zes weken zijn verstreken.
+
 
       3. Indien niet is betaald binnen de in het eerste lid genoemde termijn, wordt degene aan wie de boete is opgelegd
       schriftelijk bevolen binnen twee weken het bedrag van de boete, verhoogd met de kosten van de aanmaning, alsnog te
       betalen.
 
+
       4. Bij gebreke van betaling binnen de in het derde lid genoemde termijn, kan het College zorgverzekeringen dan wel
       het College toezicht de verschuldigde boete, verhoogd met de kosten van de aanmaning en van de invordering, bij
       dwangbevel invorderen.
+
 
       5. Het dwangbevel wordt op kosten van degene die de boete verschuldigd is, bij deurwaardersexploot betekend en
       levert een executoriale titel op in de zin van het [Tweede Boek van het Wetboek van Burgerlijke
       Rechtsvordering](jci1.3:c:BWBR0001827&boek=Tweede) .
 
+
       6. Gedurende zes weken na de dag van betekening staat verzet tegen het dwangbevel open door dagvaarding van het
       College zorgverzekeringen dan wel het College toezicht.
+
 
       7. Het verzet schorst de tenuitvoerlegging niet, tenzij de voorzieningenrechter van de rechtbank in kort geding
       desgevraagd anders beslist.
 
+
       8. Het verzet kan niet worden gegrond op de stelling dat de boete ten onrechte of voor een te hoog bedrag is
       vastgesteld.
+
 
       9. De bevoegdheid tot invordering vervalt twee jaar nadat de beschikking inzake oplegging van de boete
       onherroepelijk is geworden.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel113
   - number: '114'
-    text: |-
+    text: >-
       Artikel 114 1 De zorgverzekeraar zorgt ervoor dat zijn verzekeringnemers en verzekerden geschillen over de
       uitvoering van de zorgverzekering kunnen voorleggen aan een onafhankelijke instantie.
+
 
       2. De onafhankelijke instantie neemt een geschil slechts in behandeling nadat de verzekeringnemer of de verzekerde
       de zorgverzekeraar heeft verzocht zijn beslissing te heroverwegen, en deze niet binnen redelijke termijn of niet
       naar tevredenheid van de verzekeringnemer of verzekerde heeft gereageerd.
 
+
       3. De onafhankelijke instantie vraagt advies aan het College zorgverzekeringen indien het geschil betrekking heeft
       op de zorg of de overige diensten, bedoeld in artikel 11 , dan wel de vergoeding van die zorg of diensten.
+
 
       4. Het College zorgverzekeringen zendt zijn advies binnen vier weken na ontvangst van de adviesaanvraag aan de
       onafhankelijke instantie.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel114
   - number: '115'
-    text: |-
+    text: >-
       Artikel 115 In afwijking van [artikel 8:7, tweede lid, van de Algemene wet
       bestuursrecht](jci1.3:c:BWBR0005537&artikel=8:7) is voor beroepen tegen beschikkingen van het College toezicht, als
       bedoeld in de artikelen 94 , 95 , 97 , 98 , 99 of, indien de beschikking tot een verzekeraar is gericht, 100 , de
       rechtbank te Rotterdam bevoegd.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel115
   - number: '116'
-    text: |-
+    text: >-
       Artikel 116 1 In afwijking van [artikel 8:7, tweede lid, van de Algemene wet
       bestuursrecht](jci1.3:c:BWBR0005537&artikel=8:7) kan een belanghebbende tegen ingevolge deze wet genomen besluiten,
       niet zijnde besluiten als bedoeld in [artikel 8:2 van de Algemene wet
       bestuursrecht](jci1.3:c:BWBR0005537&artikel=8:2) , van Onze Minister, van het College zorgverzekeringen of van het
       College toezicht beroep instellen bij de Afdeling bestuursrechtspraak van de Raad van State.
 
+
       2. Het eerste lid geldt niet:
 
+
       a. voor een beschikking tot oplegging van een boete als bedoeld in artikel 96 ;
+
 
       b. voor een beschikking, inhoudende een aanwijzing als bedoeld in artikel 94 , een beschikking tot oplegging van
       een last onder dwangsom als bedoeld in artikel 95 , of een beschikking tot oplegging van een boete als bedoeld in
       artikel 97 , 98 , 99 of 100 ;
 
+
       c. voor een beschikking, genomen jegens een persoon die behoort tot het personeel van de genoemde colleges.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel116
   - number: '117'
-    text: |-
+    text: >-
       Artikel 117 1 Indien beroep is ingesteld tegen een bestuurlijke boete is, in afwijking van de [artikelen
       8:27](jci1.3:c:BWBR0005537&artikel=8:27) en [8:28 van de Algemene wet
       bestuursrecht](jci1.3:c:BWBR0005537&artikel=8:28) , de partij aan wie de bestuurlijke boete is opgelegd, niet
       verplicht omtrent de overtreding verklaringen af te leggen.
 
+
       2. Voor de rechtbank deze partij ondervraagt, deelt zij haar mede dat zij niet verplicht is tot antwoorden.
+
 
       3. Indien de rechtbank een beschikking tot het opleggen van een bestuurlijke boete vernietigt, neemt zij een
       beslissing omtrent het opleggen van de boete en bepaalt zij dat haar uitspraak in zoverre in de plaatst treedt van
       de vernietigde beschikking.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel117
   - number: '118'
-    text: |-
+    text: >-
       Artikel 118 1 Een verzekerde die voor rekening van zijn zorgverzekering bij ministeriële regeling aan te wijzen
       zorg of andere diensten als bedoeld in artikel 11 wenst te genieten, verstrekt aan de persoon of instelling die die
       zorg of dienst verleent ter inzage een identiteitsbewijs als bedoeld in [artikel 1, eerste lid, van de Wet op de
       identificatieplicht](jci1.3:c:BWBR0006297&artikel=1) , of een ander bij ministeriële regeling aan te wijzen
       document waarmee zijn identiteit kan worden vastgesteld.
 
+
       2. Indien het identiteitsbewijs niet onmiddellijk ter inzage kan worden verstrekt, kan de persoon of instelling
       toestaan dat uiterlijk binnen een termijn van veertien dagen aan deze verplichting wordt voldaan.
+
 
       3. De persoon of instelling stelt aan de hand van het ter inzage verstrekte document de identiteit vast van degene
       aan wie de in het eerste lid bedoelde zorg of dienst wordt verleend, en neemt het in dat document opgenomen
       sociaal-fiscaalnummer van de verzekerde in zijn administratie op.
 
+
       4. Dit lid is nog niet in werking getreden.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel118
   - number: '119'
-    text: |-
+    text: >-
       Artikel 119 1 Een overeenkomst met betrekking tot de verzekering van geneeskundige zorg of de kosten daarvan,
       gesloten voor een verzekerde met of ten behoeve van wie tevens een zorgverzekering is gesloten, vervalt met ingang
       van de dag waarop de bij en krachtens artikel 11 te verzekeren prestaties worden uitgebreid, voor zover aan de
       overeenkomst rechten kunnen worden ontleend, gelijkwaardig aan die, welke vanaf dat moment uit de zorgverzekering
       voortvloeien.
 
+
       2. De premie die voor de op grond van het eerste lid geheel of gedeeltelijk vervallen overeenkomst is
       vooruitbetaald, wordt door de verzekeraar al naar gelang van het vervallen gedeelte der overeenkomst terugbetaald,
       onder aftrek van ten hoogste 25% van het terug te betalen bedrag.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel119
   - number: '120'
-    text: |-
+    text: >-
       Artikel 120 Een beding van een verzekeraar die een ziektekostenverzekering ter aanvulling van de zorgverzekering
       aanbiedt, inhoudende dat de ziektekostenverzekering eindigt of door de verzekeraar mag worden opgezegd indien met
       of ten behoeve van de verzekerde een zorgverzekering met een andere zorgverzekeraar wordt gesloten, is nietig.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel120
   - number: '121'
-    text: |-
+    text: >-
       Artikel 121 De bevoegdheden die [artikel 91 van de Comptabiliteitswet 2001](jci1.3:c:BWBR0013891&artikel=91) de
       Algemene Rekenkamer verschaft ten aanzien van rechtspersonen als bedoeld in het eerste lid, onderdeel d, van dat
       artikel, gelden niet ten aanzien van de wijze waarop zorgverzekeraars de opbrengst van bij of krachtens deze wet
       ingestelde heffingen aanwenden.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel121
   - number: '122'
-    text: |-
+    text: >-
       Artikel 122 Een zorgverzekeraar wordt, voor zover deze niet kan worden aangemerkt als onderneming in de zin van
       artikel 81 van het Verdrag tot oprichting van de Europese Gemeenschap, voor de toepassing van de
       [Mededingingswet](jci1.3:c:BWBR0008691) aangemerkt als onderneming in de zin van [artikel 1 van die
       wet](jci1.3:c:BWBR0008691&artikel=1) .
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel122
   - number: '123'
-    text: |-
+    text: >-
       Artikel 123 Bij algemene maatregel van bestuur kunnen, zo nodig in afwijking van deze wet, tijdelijke voorzieningen
       worden getroffen voor het geval het College zorgverzekeringen of het College toezicht zijn uit de wet
       voortvloeiende verplichtingen niet naar behoren nakomt.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel123
   - number: '124'
-    text: |-
+    text: >-
       Artikel 124 De voordracht voor een krachtens de artikelen 11, derde of vierde lid , 22, vijfde lid , en 32, tweede
       lid , vast te stellen algemene maatregel van bestuur wordt niet eerder gedaan dan vier weken nadat het ontwerp aan
       beide kamers der Staten-Generaal is overgelegd.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel124
   - number: '125'
-    text: |-
+    text: >-
       Artikel 125 Onze Minister zendt binnen vijf jaar na de inwerkingtreding van deze wet aan de Staten-Generaal een
       verslag over de doeltreffendheid en de effecten van deze wet in de praktijk.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel125
@@ -2257,7 +2742,7 @@ articles:
       Artikel 126 Voor de uitvoering van deze wet kunnen bij algemene maatregel van bestuur nadere regels worden gesteld.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel126
   - number: '127'
-    text: |-
+    text: >-
       Artikel 127 De artikelen van deze wet treden in werking op een bij koninklijk besluit te bepalen tijdstip, dat voor
       de verschillende artikelen of onderdelen daarvan verschillend kan worden vastgesteld.
     url: https://wetten.overheid.nl/BWBR0018450/2025-01-01#Artikel127

--- a/packages/harvester/src/error.rs
+++ b/packages/harvester/src/error.rs
@@ -83,12 +83,14 @@ pub enum HarvesterError {
     #[error("YAML serialization failed: {0}")]
     YamlSerialization(#[from] serde_yaml_ng::Error),
 
-    /// The number of multi-line `text:` blocks in the serialized YAML does not
-    /// match the fold plan built during struct generation. This means the
-    /// writer's emission invariant broke; folding must never guess which block
-    /// gets which style, so the write fails instead.
-    #[error("YAML text-block fold plan mismatch: planned {expected} multi-line text blocks, found {found}")]
-    FoldPlanMismatch { expected: usize, found: usize },
+    /// A serialized `text: |-` block could not be aligned with any remaining
+    /// fold-plan entry: its reconstructed content matched no planned text (in
+    /// document order). This means the writer's emission invariant broke;
+    /// folding must never guess which block gets which style, so the write
+    /// fails instead. Leftover plan entries are legal (serde may emit a text
+    /// with tabs/control characters as a quoted scalar rather than a block).
+    #[error("YAML text-block fold plan mismatch: {detail}")]
+    FoldPlanMismatch { detail: String },
 
     /// No BWB ID found in JCI reference.
     #[error("No BWB ID found in JCI reference: {0}")]

--- a/packages/harvester/src/error.rs
+++ b/packages/harvester/src/error.rs
@@ -83,6 +83,13 @@ pub enum HarvesterError {
     #[error("YAML serialization failed: {0}")]
     YamlSerialization(#[from] serde_yaml_ng::Error),
 
+    /// The number of multi-line `text:` blocks in the serialized YAML does not
+    /// match the fold plan built during struct generation. This means the
+    /// writer's emission invariant broke; folding must never guess which block
+    /// gets which style, so the write fails instead.
+    #[error("YAML text-block fold plan mismatch: planned {expected} multi-line text blocks, found {found}")]
+    FoldPlanMismatch { expected: usize, found: usize },
+
     /// No BWB ID found in JCI reference.
     #[error("No BWB ID found in JCI reference: {0}")]
     InvalidJciReference(String),

--- a/packages/harvester/src/yaml/text.rs
+++ b/packages/harvester/src/yaml/text.rs
@@ -17,10 +17,14 @@ static REFERENCE_LINK_PATTERN: LazyLock<Regex> =
 static MISSING_SPACE_AFTER_COMMA: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"([a-zA-Z]),([a-zA-Z])").expect("valid regex"));
 
-/// Regex pattern for reference definition lines ([refN]: url) at line start.
+/// Regex pattern for markdown reference definition lines (`[label]: url`) at
+/// line start. Matches any label, not just the `refN` labels the harvester
+/// generates today — the fold invariant is "no line-oriented reference
+/// definitions at all", and an unrecognized label folding into prose would
+/// break the markdown link.
 #[allow(clippy::expect_used)] // Static regex that is guaranteed to be valid
 static REFERENCE_DEFINITION_PATTERN: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"(?m)^\[ref\d+\]: ").expect("valid regex"));
+    LazyLock::new(|| Regex::new(r"(?m)^\[[^\]]+\]: ").expect("valid regex"));
 
 /// Check if text contains reference-style links that would be broken by wrapping.
 fn contains_reference_link(text: &str) -> bool {
@@ -52,7 +56,7 @@ pub fn classify_text_style(normalized: &str, emitted: &str) -> TextStyle {
         return TextStyle::Literal;
     }
 
-    // Markdown reference definitions ([refN]: url) are line-oriented: folding
+    // Markdown reference definitions ([label]: url) are line-oriented: folding
     // would join consecutive definitions onto one line and break the markdown.
     if REFERENCE_DEFINITION_PATTERN.is_match(normalized) {
         return TextStyle::Literal;
@@ -375,6 +379,14 @@ mod tests {
     fn test_classify_reference_definitions_are_literal() {
         // [refN]: lines are line-oriented markdown; folding would join them.
         let text = "Zie [artikel 4][ref1] voor de premie die hier verder wordt toegelicht in een lange zin.\n\n[ref1]: https://example.com/a\n[ref2]: https://example.com/b";
+        assert_eq!(classify(text, 60), TextStyle::Literal);
+    }
+
+    #[test]
+    fn test_classify_non_ref_label_definitions_are_literal() {
+        // The invariant covers ANY markdown reference definition label, not
+        // just the `refN` labels the harvester generates today.
+        let text = "Zie [artikel 4][wet] voor de premie die hier verder wordt toegelicht in een lange zin.\n\n[wet]: https://example.com/a";
         assert_eq!(classify(text, 60), TextStyle::Literal);
     }
 

--- a/packages/harvester/src/yaml/text.rs
+++ b/packages/harvester/src/yaml/text.rs
@@ -17,9 +17,88 @@ static REFERENCE_LINK_PATTERN: LazyLock<Regex> =
 static MISSING_SPACE_AFTER_COMMA: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"([a-zA-Z]),([a-zA-Z])").expect("valid regex"));
 
+/// Regex pattern for reference definition lines ([refN]: url) at line start.
+#[allow(clippy::expect_used)] // Static regex that is guaranteed to be valid
+static REFERENCE_DEFINITION_PATTERN: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?m)^\[ref\d+\]: ").expect("valid regex"));
+
 /// Check if text contains reference-style links that would be broken by wrapping.
 fn contains_reference_link(text: &str) -> bool {
     REFERENCE_LINK_PATTERN.is_match(text)
+}
+
+/// Block scalar style for a multi-line text field in the emitted YAML.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TextStyle {
+    /// Literal block scalar (`|-`): every newline in the emitted string is a
+    /// real newline after loading.
+    Literal,
+    /// Folded block scalar (`>-`): wrap newlines fold back to spaces on load,
+    /// so only paragraph breaks (`\n\n`) survive in the loaded string.
+    Folded,
+}
+
+/// Decide the block scalar style for a text field.
+///
+/// `normalized` is the unwrapped source text (after [`normalize_text`]);
+/// `emitted` is the (possibly wrapped) string that goes into the YAML struct.
+/// Folding is only safe when every newline that wrapping introduced is
+/// cosmetic — i.e. the source itself contains no deliberate hard line breaks
+/// and nothing that folded-scalar semantics would corrupt. When in doubt this
+/// returns [`TextStyle::Literal`], which keeps today's byte-identical output.
+pub fn classify_text_style(normalized: &str, emitted: &str) -> TextStyle {
+    // Single-line emission: serde writes a plain/quoted scalar, nothing to fold.
+    if !emitted.contains('\n') {
+        return TextStyle::Literal;
+    }
+
+    // Markdown reference definitions ([refN]: url) are line-oriented: folding
+    // would join consecutive definitions onto one line and break the markdown.
+    if REFERENCE_DEFINITION_PATTERN.is_match(normalized) {
+        return TextStyle::Literal;
+    }
+
+    // Every maximal newline run in the source must be exactly 2 (a paragraph
+    // break). A run of 1 is a deliberate hard line break (e.g. a `- ` list
+    // built by the splitter) that folding would join into prose; a run of 3+
+    // would need 3+ blank lines in the folded block (yamllint empty-lines max).
+    let mut run = 0usize;
+    for ch in normalized.chars().chain(std::iter::once('\0')) {
+        if ch == '\n' {
+            run += 1;
+        } else {
+            if run != 0 && run != 2 {
+                return TextStyle::Literal;
+            }
+            run = 0;
+        }
+    }
+
+    // "More-indented" lines do not fold and switch folded-scalar semantics.
+    if normalized
+        .lines()
+        .any(|l| l.starts_with(' ') || l.starts_with('\t'))
+    {
+        return TextStyle::Literal;
+    }
+
+    // Defensive re-checks on the emitted string. These should all follow from
+    // the rules above plus textwrap behavior, but folding an unexpected shape
+    // would corrupt legal text, so verify at runtime and fall back instead.
+    let lines: Vec<&str> = emitted.lines().collect();
+    let first_last_blank = lines
+        .first()
+        .zip(lines.last())
+        .is_none_or(|(f, l)| f.trim().is_empty() || l.trim().is_empty());
+    let unsafe_line = lines.iter().any(|l| {
+        l.starts_with(' ') || l.starts_with('\t') || (!l.is_empty() && l.trim_end() != *l)
+    });
+    let double_blank = lines.windows(2).any(|w| w[0].is_empty() && w[1].is_empty());
+    if first_last_blank || unsafe_line || double_blank {
+        return TextStyle::Literal;
+    }
+
+    TextStyle::Folded
 }
 
 /// Normalize common typographical issues in source text.
@@ -261,5 +340,64 @@ mod tests {
     fn test_normalize_text_multiple_occurrences() {
         // Should fix multiple occurrences
         assert_eq!(normalize_text("a,b,c,d"), "a, b, c, d");
+    }
+
+    /// Convenience: classify a source text through the same normalize+wrap
+    /// path the writer uses.
+    fn classify(source: &str, width: usize) -> TextStyle {
+        let normalized = normalize_text(source);
+        let emitted = wrap_text(&normalized, width);
+        classify_text_style(&normalized, &emitted)
+    }
+
+    #[test]
+    fn test_classify_single_line_emission_is_literal() {
+        // Nothing to fold when the emitted string has no newlines.
+        assert_eq!(
+            classify_text_style("korte tekst", "korte tekst"),
+            TextStyle::Literal
+        );
+    }
+
+    #[test]
+    fn test_classify_wrapped_prose_is_folded() {
+        let prose = "Indien de normpremie voor een verzekerde in het berekeningsjaar minder bedraagt dan de standaardpremie in dat jaar, heeft de verzekerde aanspraak op een zorgtoeslag.";
+        assert_eq!(classify(prose, 60), TextStyle::Folded);
+    }
+
+    #[test]
+    fn test_classify_multi_paragraph_prose_is_folded() {
+        let prose = "Eerste paragraaf die lang genoeg is om over de wrap-breedte heen te gaan bij het serialiseren.\n\nTweede paragraaf die eveneens lang genoeg is om gewrapt te worden door de writer.";
+        assert_eq!(classify(prose, 60), TextStyle::Folded);
+    }
+
+    #[test]
+    fn test_classify_reference_definitions_are_literal() {
+        // [refN]: lines are line-oriented markdown; folding would join them.
+        let text = "Zie [artikel 4][ref1] voor de premie die hier verder wordt toegelicht in een lange zin.\n\n[ref1]: https://example.com/a\n[ref2]: https://example.com/b";
+        assert_eq!(classify(text, 60), TextStyle::Literal);
+    }
+
+    #[test]
+    fn test_classify_hard_single_newline_is_literal() {
+        // A single \n in the source is a deliberate hard break (e.g. a list
+        // the splitter built); folding would join it into prose.
+        let text = "- eerste onderdeel van de opsomming die hier staat\n- tweede onderdeel van de opsomming die hier staat";
+        assert_eq!(classify(text, 60), TextStyle::Literal);
+    }
+
+    #[test]
+    fn test_classify_indented_line_is_literal() {
+        // More-indented lines switch folded-scalar semantics; never fold them.
+        let text = "Aanhef van het artikel dat lang genoeg is om te wrappen op de ingestelde breedte:\n\n  - *onderdeel* met inspringing";
+        assert_eq!(classify(text, 60), TextStyle::Literal);
+    }
+
+    #[test]
+    fn test_classify_triple_newline_is_literal() {
+        // \n\n\n would need three blank lines in a folded block (yamllint
+        // empty-lines max 2), so it must stay literal.
+        let text = "Eerste stuk tekst dat lang genoeg is om gewrapt te worden door de yaml writer.\n\n\nTweede stuk tekst na een dubbele lege regel dat ook lang genoeg is.";
+        assert_eq!(classify(text, 60), TextStyle::Literal);
     }
 }

--- a/packages/harvester/src/yaml/text.rs
+++ b/packages/harvester/src/yaml/text.rs
@@ -97,6 +97,9 @@ pub fn classify_text_style(normalized: &str, emitted: &str) -> TextStyle {
     let unsafe_line = lines.iter().any(|l| {
         l.starts_with(' ') || l.starts_with('\t') || (!l.is_empty() && l.trim_end() != *l)
     });
+    // Redundant with the newline-run check on `normalized` above; kept to
+    // catch the hypothetical case where normalize_text/wrap_text_default
+    // would inject back-to-back blank lines that were not in the source.
     let double_blank = lines.windows(2).any(|w| w[0].is_empty() && w[1].is_empty());
     if first_last_blank || unsafe_line || double_blank {
         return TextStyle::Literal;

--- a/packages/harvester/src/yaml/writer.rs
+++ b/packages/harvester/src/yaml/writer.rs
@@ -82,9 +82,12 @@ struct YamlLaw {
     articles: Vec<YamlArticle>,
 }
 
-/// Normalize and wrap a text field, recording the block scalar style for
-/// every multi-line emission in `fold_plan` (document order).
-fn prepare_text(raw: &str, fold_plan: &mut Vec<TextStyle>) -> String {
+/// Normalize and wrap a text field, recording the emitted text and its block
+/// scalar style for every multi-line emission in `fold_plan` (document order).
+///
+/// The stored `String` is the exact emitted (wrapped) text; [`fold_text_blocks`]
+/// aligns it against the `text: |-` blocks serde actually emitted.
+fn prepare_text(raw: &str, fold_plan: &mut Vec<(String, TextStyle)>) -> String {
     // First normalize the text to fix typographical issues from source XML
     let normalized = normalize_text(raw);
 
@@ -95,21 +98,25 @@ fn prepare_text(raw: &str, fold_plan: &mut Vec<TextStyle>) -> String {
         normalized.clone()
     };
 
-    // Multi-line strings serialize as block scalars; record which style
-    // fold_text_blocks must apply to this block.
+    // Multi-line strings usually serialize as block scalars; record the emitted
+    // text plus which style fold_text_blocks should apply. serde may instead
+    // emit a quoted single-line scalar (e.g. when the text has an interior tab
+    // or control character); such entries simply find no matching block and are
+    // skipped during alignment.
     if text.contains('\n') {
-        fold_plan.push(classify_text_style(&normalized, &text));
+        fold_plan.push((text.clone(), classify_text_style(&normalized, &text)));
     }
     text
 }
 
 /// Generate a schema-compliant YAML structure from a Law object, plus the
-/// fold plan: one [`TextStyle`] per multi-line text field in document order
-/// (preamble first, then articles — matching serde's emission order).
-fn generate_yaml_struct(law: &Law, effective_date: &str) -> (YamlLaw, Vec<TextStyle>) {
+/// fold plan: one `(emitted_text, TextStyle)` per multi-line text field in
+/// document order (preamble first, then articles — matching serde's emission
+/// order).
+fn generate_yaml_struct(law: &Law, effective_date: &str) -> (YamlLaw, Vec<(String, TextStyle)>) {
     let law_id = law.metadata.to_slug();
     let is_cvdr = law.metadata.cvdr_id.is_some();
-    let mut fold_plan: Vec<TextStyle> = Vec::new();
+    let mut fold_plan: Vec<(String, TextStyle)> = Vec::new();
 
     // Convert preamble if present (normalize and wrap like articles)
     let preamble = law.preamble.as_ref().map(|p| YamlPreamble {
@@ -174,6 +181,16 @@ fn generate_yaml_struct(law: &Law, effective_date: &str) -> (YamlLaw, Vec<TextSt
     (yaml_law, fold_plan)
 }
 
+/// Regex matching the end of a block scalar header line (the value is a literal
+/// `|` or folded `>` indicator, with an optional explicit indentation digit and
+/// an optional chomping indicator). Applied to the *trimmed* line, e.g.
+/// `text: |-`, `text: >`, `text: |2-`, `foo: >+`. The `: ` anchor keeps a plain
+/// scalar that merely ends in `|`/`>` (which YAML would quote anyway) from
+/// matching.
+#[allow(clippy::expect_used)]
+static BLOCK_SCALAR_HEADER_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r": [|>]\d*[+-]?$").expect("valid regex"));
+
 /// Indent YAML sequences to comply with `indent-sequences: true`.
 ///
 /// serde_yaml_ng places sequence items (`- `) at the same indent as their parent key.
@@ -185,21 +202,48 @@ fn generate_yaml_struct(law: &Law, effective_date: &str) -> (YamlLaw, Vec<TextSt
 /// - number: '1'        - number: '1'
 ///   text: foo            text: foo
 /// ```
+///
+/// It is block-scalar-aware: content lines inside a `|`/`>` block are shifted by
+/// exactly the same amount as their header line and are NOT interpreted as
+/// sequence items, even when they start with `- `. Treating a `- ` block-content
+/// line as a sequence item would over-indent it non-uniformly (only dashed lines
+/// shift), corrupting the literal text and breaking [`fold_text_blocks`]'s
+/// min-indent reconstruction.
 fn indent_yaml_sequences(yaml: &str) -> String {
     let mut result: Vec<String> = Vec::new();
     // Stack of indent levels where sequences start
     let mut seq_indents: Vec<usize> = Vec::new();
+    // When inside a block scalar: (header's original indent, the extra shift
+    // frozen at the header line). Content lines reuse this shift verbatim.
+    let mut block: Option<(usize, usize)> = None;
 
     for line in yaml.lines() {
         let trimmed = line.trim_start();
 
-        // Pass empty lines through unchanged
+        // Pass empty lines through unchanged (blank lines inside a block scalar
+        // keep the block open — they carry no indentation to compare).
         if trimmed.is_empty() {
             result.push(line.to_string());
             continue;
         }
 
         let indent = line.len() - trimmed.len();
+
+        // Inside a block scalar: a line indented deeper than the header is block
+        // content — emit it with the frozen shift, never as a sequence item. A
+        // line at or below the header's indent ends the block; fall through to
+        // normal processing.
+        if let Some((header_indent, frozen_extra)) = block {
+            if indent > header_indent {
+                if frozen_extra > 0 {
+                    result.push(format!("{}{}", " ".repeat(indent + frozen_extra), trimmed));
+                } else {
+                    result.push(line.to_string());
+                }
+                continue;
+            }
+            block = None;
+        }
 
         // Pop sequences we've exited: either moved to a shallower indent,
         // or returned to the same indent but not as a sequence continuation.
@@ -221,6 +265,14 @@ fn indent_yaml_sequences(yaml: &str) -> String {
 
         // Apply extra indentation
         let extra = seq_indents.len() * 2;
+
+        // Detect a block scalar header (`key: |`, `key: >-`, …). The header line
+        // itself is indented normally below; subsequent deeper lines are block
+        // content shifted by this same `extra`.
+        if BLOCK_SCALAR_HEADER_RE.is_match(trimmed) {
+            block = Some((indent, extra));
+        }
+
         if extra > 0 {
             result.push(format!("{}{}", " ".repeat(indent + extra), trimmed));
         } else {
@@ -332,30 +384,42 @@ fn fix_yaml_quoting(yaml: &str) -> String {
         .join("\n")
 }
 
-/// Regex matching the header line of a multi-line `text:` block scalar as
-/// serde_yaml_ng emits it (`text: |-`, or `text: |N-` when the first content
-/// line starts with whitespace and needs an explicit indentation indicator).
+/// Regex matching the header line of a plain multi-line `text:` block scalar as
+/// serde_yaml_ng emits it (`text: |-`). Headers with an explicit indentation
+/// indicator (`text: |N-`, emitted when the first content line starts with
+/// whitespace) deliberately do NOT match: such blocks always classify as
+/// `Literal` anyway, so they are passed through verbatim without consuming a
+/// plan entry.
 #[allow(clippy::expect_used)]
 static TEXT_BLOCK_HEADER_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^(\s*)text: \|\d*-$").expect("valid regex"));
+    LazyLock::new(|| Regex::new(r"^(\s*)text: \|-$").expect("valid regex"));
 
 /// Rewrite `text: |-` literal blocks to folded (`>-`) blocks per the fold plan.
 ///
-/// The plan is produced by [`generate_yaml_struct`]: one entry per multi-line
-/// text field in document order. `text` is the only multi-line field the
-/// writer emits, so the blocks encountered here correspond 1:1 to the plan;
-/// any count mismatch means that invariant broke and we fail loudly rather
-/// than guess which block gets which style.
+/// The plan is produced by [`generate_yaml_struct`]: one `(emitted_text, style)`
+/// entry per multi-line text field in document order. The emitted `text: |-`
+/// blocks are an *ordered subsequence* of that plan: serde emits most multi-line
+/// texts as a `|-` block, but chooses a double-quoted single-line scalar for a
+/// text that contains an interior tab or other control character — that field
+/// then appears in the plan with no corresponding block.
+///
+/// Alignment is therefore positional + content-based: for each `|-` block we
+/// reconstruct its original text and advance a plan pointer, skipping any plan
+/// entries whose text does not match (those were emitted as quoted scalars).
+/// A block that matches no remaining plan entry means the emission invariant
+/// broke and we fail loudly (`FoldPlanMismatch`) rather than guess which style
+/// applies. Leftover plan entries after the scan are legal — they are the
+/// quoted-scalar emissions.
 ///
 /// Folded semantics: a single line break loads as a space (undoing the
 /// cosmetic wrap), and N consecutive breaks load as N-1 newlines — so each
 /// blank line (a `\n\n` paragraph break in the source) must become two blank
 /// lines to survive the round trip. [`classify_text_style`] only marks a
 /// block `Folded` when its content makes that transformation exact.
-fn fold_text_blocks(yaml: &str, plan: &[TextStyle]) -> Result<String> {
+fn fold_text_blocks(yaml: &str, plan: &[(String, TextStyle)]) -> Result<String> {
     let lines: Vec<&str> = yaml.lines().collect();
     let mut out: Vec<String> = Vec::with_capacity(lines.len() + plan.len());
-    let mut next_block = 0usize;
+    let mut k = 0usize;
     let mut i = 0usize;
 
     while i < lines.len() {
@@ -366,14 +430,6 @@ fn fold_text_blocks(yaml: &str, plan: &[TextStyle]) -> Result<String> {
             continue;
         };
         let key_indent = caps.get(1).map_or(0, |m| m.as_str().len());
-        let style =
-            plan.get(next_block)
-                .copied()
-                .ok_or_else(|| HarvesterError::FoldPlanMismatch {
-                    expected: plan.len(),
-                    found: next_block + 1,
-                })?;
-        next_block += 1;
 
         // Collect the block: lines that are blank or indented deeper than the key.
         let mut end = i + 1;
@@ -385,11 +441,54 @@ fn fold_text_blocks(yaml: &str, plan: &[TextStyle]) -> Result<String> {
             }
             end += 1;
         }
+        let block_lines = &lines[i + 1..end];
+
+        // Reconstruct the original emitted text. The block indentation is the
+        // minimum leading whitespace over the non-blank lines — exactly what a
+        // YAML parser auto-detects. `indent_yaml_sequences` shifts every block
+        // line (dashed or not) by the same amount, so the content is uniformly
+        // indented here; stripping the detected minimum recovers the wrapped
+        // text, and any genuinely deeper-indented source line keeps its extra
+        // spaces. Blank lines → empty string; join with '\n' (chomping `-`: no
+        // trailing newline).
+        let block_indent = block_lines
+            .iter()
+            .filter(|l| !l.trim().is_empty())
+            .map(|l| l.len() - l.trim_start().len())
+            .min()
+            .unwrap_or(key_indent + 2);
+        let reconstructed = block_lines
+            .iter()
+            .map(|l| {
+                if l.trim().is_empty() {
+                    ""
+                } else {
+                    &l[block_indent..]
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        // Advance the plan pointer past quoted-scalar emissions until the text
+        // matches; a block with no matching plan entry fails loudly.
+        while k < plan.len() && plan[k].0 != reconstructed {
+            k += 1;
+        }
+        let style =
+            plan.get(k)
+                .map(|(_, s)| *s)
+                .ok_or_else(|| HarvesterError::FoldPlanMismatch {
+                    detail: format!(
+                    "serialized `text: |-` block did not match any remaining fold-plan entry: {:?}",
+                    reconstructed.chars().take(60).collect::<String>()
+                ),
+                })?;
+        k += 1;
 
         match style {
             TextStyle::Folded => {
                 out.push(format!("{}text: >-", " ".repeat(key_indent)));
-                for l in &lines[i + 1..end] {
+                for l in block_lines {
                     if l.trim().is_empty() {
                         // Paragraph break: fold semantics eat one line break,
                         // so a blank line must double to keep `\n\n`.
@@ -402,18 +501,12 @@ fn fold_text_blocks(yaml: &str, plan: &[TextStyle]) -> Result<String> {
             }
             TextStyle::Literal => {
                 out.push(line.to_string());
-                out.extend(lines[i + 1..end].iter().map(|l| l.to_string()));
+                out.extend(block_lines.iter().map(|l| l.to_string()));
             }
         }
         i = end;
     }
 
-    if next_block != plan.len() {
-        return Err(HarvesterError::FoldPlanMismatch {
-            expected: plan.len(),
-            found: next_block,
-        });
-    }
     Ok(out.join("\n"))
 }
 
@@ -603,6 +696,21 @@ mod tests {
         assert_eq!(
             result,
             "top: val\nitems:\n  - name: a\n    val: 1\n  - name: b\n    nested:\n      - id: x\n        v: 1"
+        );
+    }
+
+    #[test]
+    fn test_indent_yaml_sequences_block_scalar_content() {
+        // A literal block whose content mixes a non-dashed line, a blank line,
+        // and `- ` lines must be shifted uniformly by the enclosing sequence's
+        // extra (+2) — the `- ` content lines must NOT be treated as sequence
+        // items (which would over-indent them to +4).
+        let input =
+            "articles:\n- number: '1'\n  text: |-\n    intro:\n\n    - item een\n    - item twee\n  url: x";
+        let result = indent_yaml_sequences(input);
+        assert_eq!(
+            result,
+            "articles:\n  - number: '1'\n    text: |-\n      intro:\n\n      - item een\n      - item twee\n    url: x"
         );
     }
 
@@ -850,6 +958,33 @@ articles:
                 expect_wrapped: false,
                 expect_indicator: None,
             },
+            Case {
+                // Regression: a long single-paragraph text with an interior tab
+                // makes serde emit a double-quoted single-line scalar instead of
+                // a block. The fold plan then has an entry with no matching
+                // block; content-subsequence alignment must skip it rather than
+                // fail generation. serde's quoted scalar preserves the wrap
+                // newlines, so the loaded text is the wrapped text.
+                name: "long text with interior tab emits a quoted scalar",
+                source: "Indien de normpremie voor een verzekerde in het berekeningsjaar minder bedraagt dan de\tstandaardpremie in dat jaar, heeft de verzekerde aanspraak op een zorgtoeslag.",
+                owned_source: None,
+                expect_wrapped: true,
+                expect_indicator: None,
+            },
+            Case {
+                // Regression: a chapeau/intro line followed by `- ` bullet lines
+                // in a literal block. `indent_yaml_sequences` must NOT treat the
+                // dashed content lines as sequence items — a non-uniform
+                // over-indent would leave stray spaces after min-indent
+                // reconstruction, breaking the fold-plan match and failing
+                // generation entirely. The single `\n` between bullets keeps the
+                // block Literal (`|-`). Loads back verbatim, bullets at column 0.
+                name: "chapeau then dash list stays literal and round-trips exactly",
+                source: "1 In deze regeling wordt verstaan onder:\n\n- *accountant:* een accountant als bedoeld in artikel 393 van Boek 2 van het Burgerlijk Wetboek en nog wat woorden om de tekst lang te maken;\n- *btw:* omzetbelasting",
+                owned_source: None,
+                expect_wrapped: true,
+                expect_indicator: Some("|-"),
+            },
         ];
 
         for case in &cases {
@@ -892,6 +1027,22 @@ articles:
                 }
             }
 
+            // Column-0 list content must survive without injected leading
+            // spaces: `indent_yaml_sequences` used to over-indent `- ` block
+            // lines (mistaking them for sequence items), which the min-indent
+            // reconstruction then leaked back as stray leading spaces.
+            if matches!(
+                case.name,
+                "chapeau then dash list stays literal and round-trips exactly"
+                    | "column-0 list stays literal"
+            ) {
+                assert!(
+                    !loaded.lines().any(|l| l.starts_with(' ')),
+                    "case '{}': loaded text has an injected leading space\n{loaded}",
+                    case.name
+                );
+            }
+
             // Output hygiene: yamllint limits (empty-lines max 2) and folded
             // blocks free of accidental more-indented lines.
             let lines: Vec<&str> = yaml.lines().collect();
@@ -905,8 +1056,8 @@ articles:
 
     #[test]
     fn test_fold_text_blocks_plan_mismatch_errors() {
-        // One multi-line text block in the YAML, but an empty plan: the
-        // writer invariant broke and folding must refuse to guess.
+        // A `text: |-` block whose reconstructed content matches no plan entry
+        // (here: empty plan) means the emission invariant broke — fail loudly.
         let yaml = "articles:\n  - number: '1'\n    text: |-\n      regel een\n      regel twee\n";
         let err = fold_text_blocks(yaml, &[]).unwrap_err();
         assert!(
@@ -914,8 +1065,26 @@ articles:
             "unexpected error: {err}"
         );
 
-        // More plan entries than blocks must also fail.
-        let err = fold_text_blocks("key: value\n", &[TextStyle::Folded]).unwrap_err();
+        // Plan entries with NO matching block are legal now: serde may emit a
+        // text as a quoted scalar (tabs/control chars). Leftovers must NOT
+        // error, and the input passes through unchanged.
+        let input = "key: value\n";
+        let out = fold_text_blocks(
+            input,
+            &[("some emitted\ntext".to_string(), TextStyle::Folded)],
+        )
+        .unwrap();
+        assert_eq!(out, "key: value");
+
+        // Misassignment safety: a block whose content is B cannot be silently
+        // matched to a plan entry for A — it must fail rather than fold the
+        // wrong block.
+        let yaml_b = "text: |-\n  regel B\n  regel B twee\n";
+        let err = fold_text_blocks(
+            yaml_b,
+            &[("regel A\nregel A twee".to_string(), TextStyle::Folded)],
+        )
+        .unwrap_err();
         assert!(
             err.to_string().contains("fold plan mismatch"),
             "unexpected error: {err}"

--- a/packages/harvester/src/yaml/writer.rs
+++ b/packages/harvester/src/yaml/writer.rs
@@ -389,7 +389,8 @@ fn fix_yaml_quoting(yaml: &str) -> String {
 /// indicator (`text: |N-`, emitted when the first content line starts with
 /// whitespace) deliberately do NOT match: such blocks always classify as
 /// `Literal` anyway, so they are passed through verbatim without consuming a
-/// plan entry.
+/// plan entry. The clip form (`text: |`, emitted for text ending in a
+/// newline) is excluded for the same reason — a safe literal pass-through.
 #[allow(clippy::expect_used)]
 static TEXT_BLOCK_HEADER_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^(\s*)text: \|-$").expect("valid regex"));
@@ -454,6 +455,10 @@ fn fold_text_blocks(yaml: &str, plan: &[(String, TextStyle)]) -> Result<String> 
         // text, and any genuinely deeper-indented source line keeps its extra
         // spaces. Blank lines → empty string; join with '\n' (chomping `-`: no
         // trailing newline).
+        // Stripping the minimum indent recovers the emitted text exactly
+        // because indent_yaml_sequences shifts all content lines of a block
+        // uniformly (frozen at the header). If that invariant ever breaks,
+        // reconstruction diverges and the alignment below fails loudly.
         let block_indent = block_lines
             .iter()
             .filter(|l| !l.trim().is_empty())

--- a/packages/harvester/src/yaml/writer.rs
+++ b/packages/harvester/src/yaml/writer.rs
@@ -8,9 +8,11 @@ use std::sync::LazyLock;
 use regex::Regex;
 use serde::Serialize;
 
-use super::text::{normalize_text, should_wrap_text, wrap_text_default};
+use super::text::{
+    classify_text_style, normalize_text, should_wrap_text, wrap_text_default, TextStyle,
+};
 use crate::config::SCHEMA_URL;
-use crate::error::Result;
+use crate::error::{HarvesterError, Result};
 use crate::types::{Law, Reference};
 
 /// Regex matching a single-quoted YAML scalar value on a key line.
@@ -80,46 +82,49 @@ struct YamlLaw {
     articles: Vec<YamlArticle>,
 }
 
-/// Generate a schema-compliant YAML structure from a Law object.
-fn generate_yaml_struct(law: &Law, effective_date: &str) -> YamlLaw {
+/// Normalize and wrap a text field, recording the block scalar style for
+/// every multi-line emission in `fold_plan` (document order).
+fn prepare_text(raw: &str, fold_plan: &mut Vec<TextStyle>) -> String {
+    // First normalize the text to fix typographical issues from source XML
+    let normalized = normalize_text(raw);
+
+    // Then wrap if needed
+    let text = if should_wrap_text(&normalized) {
+        wrap_text_default(&normalized)
+    } else {
+        normalized.clone()
+    };
+
+    // Multi-line strings serialize as block scalars; record which style
+    // fold_text_blocks must apply to this block.
+    if text.contains('\n') {
+        fold_plan.push(classify_text_style(&normalized, &text));
+    }
+    text
+}
+
+/// Generate a schema-compliant YAML structure from a Law object, plus the
+/// fold plan: one [`TextStyle`] per multi-line text field in document order
+/// (preamble first, then articles — matching serde's emission order).
+fn generate_yaml_struct(law: &Law, effective_date: &str) -> (YamlLaw, Vec<TextStyle>) {
     let law_id = law.metadata.to_slug();
     let is_cvdr = law.metadata.cvdr_id.is_some();
+    let mut fold_plan: Vec<TextStyle> = Vec::new();
 
-    // Convert preamble if present
-    let preamble = law.preamble.as_ref().map(|p| {
-        // Normalize and wrap preamble text like articles
-        let normalized = normalize_text(&p.text);
-        let text = if should_wrap_text(&normalized) {
-            wrap_text_default(&normalized)
-        } else {
-            normalized
-        };
-        YamlPreamble {
-            text,
-            url: p.url.clone(),
-        }
+    // Convert preamble if present (normalize and wrap like articles)
+    let preamble = law.preamble.as_ref().map(|p| YamlPreamble {
+        text: prepare_text(&p.text, &mut fold_plan),
+        url: p.url.clone(),
     });
 
     let articles: Vec<YamlArticle> = law
         .articles
         .iter()
-        .map(|article| {
-            // First normalize the text to fix typographical issues from source XML
-            let normalized = normalize_text(&article.text);
-
-            // Then wrap if needed
-            let text = if should_wrap_text(&normalized) {
-                wrap_text_default(&normalized)
-            } else {
-                normalized
-            };
-
-            YamlArticle {
-                number: article.number.clone(),
-                text,
-                url: article.url.clone(),
-                references: article.references.clone(),
-            }
+        .map(|article| YamlArticle {
+            number: article.number.clone(),
+            text: prepare_text(&article.text, &mut fold_plan),
+            url: article.url.clone(),
+            references: article.references.clone(),
         })
         .collect();
 
@@ -147,7 +152,7 @@ fn generate_yaml_struct(law: &Law, effective_date: &str) -> YamlLaw {
         )
     };
 
-    YamlLaw {
+    let yaml_law = YamlLaw {
         schema: SCHEMA_URL.to_string(),
         id: law_id,
         regulatory_layer: law.metadata.regulatory_layer.as_str().to_string(),
@@ -165,7 +170,8 @@ fn generate_yaml_struct(law: &Law, effective_date: &str) -> YamlLaw {
         url,
         preamble,
         articles,
-    }
+    };
+    (yaml_law, fold_plan)
 }
 
 /// Indent YAML sequences to comply with `indent-sequences: true`.
@@ -326,14 +332,100 @@ fn fix_yaml_quoting(yaml: &str) -> String {
         .join("\n")
 }
 
+/// Regex matching the header line of a multi-line `text:` block scalar as
+/// serde_yaml_ng emits it (`text: |-`, or `text: |N-` when the first content
+/// line starts with whitespace and needs an explicit indentation indicator).
+#[allow(clippy::expect_used)]
+static TEXT_BLOCK_HEADER_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^(\s*)text: \|\d*-$").expect("valid regex"));
+
+/// Rewrite `text: |-` literal blocks to folded (`>-`) blocks per the fold plan.
+///
+/// The plan is produced by [`generate_yaml_struct`]: one entry per multi-line
+/// text field in document order. `text` is the only multi-line field the
+/// writer emits, so the blocks encountered here correspond 1:1 to the plan;
+/// any count mismatch means that invariant broke and we fail loudly rather
+/// than guess which block gets which style.
+///
+/// Folded semantics: a single line break loads as a space (undoing the
+/// cosmetic wrap), and N consecutive breaks load as N-1 newlines — so each
+/// blank line (a `\n\n` paragraph break in the source) must become two blank
+/// lines to survive the round trip. [`classify_text_style`] only marks a
+/// block `Folded` when its content makes that transformation exact.
+fn fold_text_blocks(yaml: &str, plan: &[TextStyle]) -> Result<String> {
+    let lines: Vec<&str> = yaml.lines().collect();
+    let mut out: Vec<String> = Vec::with_capacity(lines.len() + plan.len());
+    let mut next_block = 0usize;
+    let mut i = 0usize;
+
+    while i < lines.len() {
+        let line = lines[i];
+        let Some(caps) = TEXT_BLOCK_HEADER_RE.captures(line) else {
+            out.push(line.to_string());
+            i += 1;
+            continue;
+        };
+        let key_indent = caps.get(1).map_or(0, |m| m.as_str().len());
+        let style =
+            plan.get(next_block)
+                .copied()
+                .ok_or_else(|| HarvesterError::FoldPlanMismatch {
+                    expected: plan.len(),
+                    found: next_block + 1,
+                })?;
+        next_block += 1;
+
+        // Collect the block: lines that are blank or indented deeper than the key.
+        let mut end = i + 1;
+        while end < lines.len() {
+            let l = lines[end];
+            let trimmed = l.trim_start();
+            if !trimmed.is_empty() && l.len() - trimmed.len() <= key_indent {
+                break;
+            }
+            end += 1;
+        }
+
+        match style {
+            TextStyle::Folded => {
+                out.push(format!("{}text: >-", " ".repeat(key_indent)));
+                for l in &lines[i + 1..end] {
+                    if l.trim().is_empty() {
+                        // Paragraph break: fold semantics eat one line break,
+                        // so a blank line must double to keep `\n\n`.
+                        out.push(String::new());
+                        out.push(String::new());
+                    } else {
+                        out.push((*l).to_string());
+                    }
+                }
+            }
+            TextStyle::Literal => {
+                out.push(line.to_string());
+                out.extend(lines[i + 1..end].iter().map(|l| l.to_string()));
+            }
+        }
+        i = end;
+    }
+
+    if next_block != plan.len() {
+        return Err(HarvesterError::FoldPlanMismatch {
+            expected: plan.len(),
+            found: next_block,
+        });
+    }
+    Ok(out.join("\n"))
+}
+
 /// Generate YAML string from a Law object.
 pub fn generate_yaml(law: &Law, effective_date: &str) -> Result<String> {
-    let yaml_struct = generate_yaml_struct(law, effective_date);
+    let (yaml_struct, fold_plan) = generate_yaml_struct(law, effective_date);
     let yaml_string = serde_yaml_ng::to_string(&yaml_struct)?;
 
     // Post-process for yamllint compliance
     let yaml_string = fix_yaml_quoting(&yaml_string);
     let yaml_string = indent_yaml_sequences(&yaml_string);
+    let yaml_string = fold_text_blocks(&yaml_string, &fold_plan)?;
 
     // Add document start marker and clean up trailing whitespace
     let lines: Vec<&str> = yaml_string.lines().map(|l| l.trim_end()).collect();
@@ -639,6 +731,7 @@ articles:
         for (law, date) in [
             (create_test_law(), "2025-01-01"),
             (create_test_cvdr_law(), "2024-01-01"),
+            (create_test_folded_law(), "2026-01-01"),
         ] {
             let yaml = generate_yaml(&law, date).unwrap();
             let parsed: regelrecht_law_model::ArticleBasedLaw = serde_yaml_ng::from_str(&yaml)
@@ -648,5 +741,184 @@ articles:
             assert_eq!(parsed.articles.len(), law.articles.len());
             assert_eq!(parsed.regulatory_layer, law.metadata.regulatory_layer);
         }
+    }
+
+    /// Long multi-paragraph prose that must wrap (>115 chars) and fold back
+    /// to the unwrapped source on load.
+    const FOLDABLE_PROSE: &str = "Indien de normpremie voor een verzekerde in het berekeningsjaar minder bedraagt dan de standaardpremie in dat jaar, heeft de verzekerde aanspraak op een zorgtoeslag ter grootte van dat verschil.\n\nDe normpremie bedraagt een percentage van het drempelinkomen in het berekeningsjaar, vermeerderd met een percentage van het toetsingsinkomen van de verzekerde (artikel 2, tweede lid).";
+
+    fn create_test_folded_law() -> Law {
+        let mut law = create_test_law();
+        law.add_article(Article::new(
+            "2",
+            FOLDABLE_PROSE,
+            "https://wetten.overheid.nl/BWBR0018451/2026-01-01#Artikel2",
+        ));
+        law
+    }
+
+    /// Golden byte-identity test for a folded (`>-`) text block: wrapped
+    /// lines, and a doubled blank line for the paragraph break so the
+    /// `\n\n` survives the folded round trip.
+    #[test]
+    fn test_generate_yaml_golden_folded() {
+        let law = create_test_folded_law();
+        let yaml = generate_yaml(&law, "2026-01-01").unwrap();
+        let expected = format!(
+            "---
+$schema: {SCHEMA_URL}
+$id: wet_op_de_zorgtoeslag
+regulatory_layer: WET
+publication_date: '2005-12-29'
+valid_from: '2026-01-01'
+bwb_id: BWBR0018451
+url: https://wetten.overheid.nl/BWBR0018451/2026-01-01
+articles:
+  - number: '1'
+    text: 'In deze wet wordt verstaan onder toeslagpartner: partner.'
+    url: https://wetten.overheid.nl/BWBR0018451/2025-01-01#Artikel1
+  - number: '2'
+    text: >-
+      Indien de normpremie voor een verzekerde in het berekeningsjaar minder bedraagt dan de standaardpremie in dat jaar,
+      heeft de verzekerde aanspraak op een zorgtoeslag ter grootte van dat verschil.
+
+
+      De normpremie bedraagt een percentage van het drempelinkomen in het berekeningsjaar, vermeerderd met een percentage
+      van het toetsingsinkomen van de verzekerde (artikel 2, tweede lid).
+    url: https://wetten.overheid.nl/BWBR0018451/2026-01-01#Artikel2
+"
+        );
+        assert_eq!(yaml, expected);
+    }
+
+    /// Round-trip property over representative text shapes: emitting and
+    /// re-parsing must yield exactly the expected string — the unwrapped
+    /// source for foldable prose, the wrapped text for literal fallbacks.
+    /// Also pins output hygiene: no 3+ consecutive blank lines anywhere, and
+    /// no folded content line starting with whitespace.
+    #[test]
+    fn test_fold_round_trip_property() {
+        let long_url = format!(
+            "https://example.com/{}",
+            "zeer-lange-url-component/".repeat(6)
+        );
+        struct Case {
+            name: &'static str,
+            source: &'static str,
+            owned_source: Option<String>,
+            /// None = round trip must return the source unchanged (folded or
+            /// short). Some(f) = expected loaded text derived from the source.
+            expect_wrapped: bool,
+            expect_indicator: Option<&'static str>,
+        }
+        let ref_heavy_source = format!(
+            "Zie [artikel 4 van de Wet op de zorgtoeslag][ref1] en [artikel 2.18 van de Wet inkomstenbelasting 2001][ref2] voor de berekening van de premie.\n\n[ref1]: {long_url}\n[ref2]: https://example.com/b\n[ref3]: https://example.com/c\n[ref4]: https://example.com/d"
+        );
+        let cases = [
+            Case {
+                name: "multi-paragraph unicode prose folds to unwrapped source",
+                source: "Indien de normpremie voor een verzekerde in het berekeningsjaar minder bedraagt dan de standaardpremie (€ 1,50 per maand, 3\u{00b0} categorie) in dat jaar, heeft de verzekerd\u{00eb} aanspraak op een zorgtoeslag.\n\nDe pensioengerechtigde leeftijd, bedoeld in artikel 7a van de Algemene Ouderdomswet, wordt verhoogd met drie maanden per kalenderjaar tot de leeftijd van zeventig jaar is bereikt.",
+                owned_source: None,
+                expect_wrapped: false,
+                expect_indicator: Some(">-"),
+            },
+            Case {
+                name: "reference definitions stay literal, each on its own line",
+                source: "",
+                owned_source: Some(ref_heavy_source),
+                expect_wrapped: true,
+                expect_indicator: Some("|-"),
+            },
+            Case {
+                name: "column-0 list stays literal",
+                source: "- eerste onderdeel van de opsomming met voldoende lengte om de wrap-drempel te halen zodat er gewrapt wordt\n- tweede onderdeel van de opsomming met voldoende lengte om de wrap-drempel te halen",
+                owned_source: None,
+                expect_wrapped: true,
+                expect_indicator: Some("|-"),
+            },
+            Case {
+                name: "triple newline stays literal",
+                source: "Eerste stuk tekst dat ruim voldoende lengte heeft om de wrap-drempel van tachtig tekens te overschrijden.\n\n\nTweede stuk tekst na een dubbele lege regel, eveneens lang genoeg om te wrappen.",
+                owned_source: None,
+                expect_wrapped: true,
+                expect_indicator: Some("|-"),
+            },
+            Case {
+                name: "short text stays a plain scalar",
+                source: "Begripsbepalingen.",
+                owned_source: None,
+                expect_wrapped: false,
+                expect_indicator: None,
+            },
+        ];
+
+        for case in &cases {
+            let source: &str = case.owned_source.as_deref().unwrap_or(case.source);
+            let mut law = create_test_law();
+            law.add_article(Article::new("2", source, "https://example.com/#2"));
+            let yaml = generate_yaml(&law, "2026-01-01").unwrap();
+            let parsed: regelrecht_law_model::ArticleBasedLaw = serde_yaml_ng::from_str(&yaml)
+                .unwrap_or_else(|e| panic!("case '{}': output must parse: {e}\n{yaml}", case.name));
+            let loaded = &parsed.articles[1].text;
+
+            let normalized = normalize_text(source);
+            let expected = if case.expect_wrapped {
+                wrap_text_default(&normalized)
+            } else {
+                normalized.clone()
+            };
+            assert_eq!(
+                loaded, &expected,
+                "case '{}': loaded text mismatch\n{yaml}",
+                case.name
+            );
+
+            if let Some(indicator) = case.expect_indicator {
+                assert!(
+                    yaml.contains(&format!("text: {indicator}\n")),
+                    "case '{}': expected `text: {indicator}` block\n{yaml}",
+                    case.name
+                );
+            }
+
+            // Reference definitions must each keep their own line after load.
+            if source.contains("]: ") {
+                for line in normalized.lines().filter(|l| l.starts_with("[ref")) {
+                    assert!(
+                        loaded.lines().any(|l| l == line),
+                        "case '{}': ref definition line lost: {line}\n{loaded}",
+                        case.name
+                    );
+                }
+            }
+
+            // Output hygiene: yamllint limits (empty-lines max 2) and folded
+            // blocks free of accidental more-indented lines.
+            let lines: Vec<&str> = yaml.lines().collect();
+            assert!(
+                !lines.windows(3).any(|w| w.iter().all(|l| l.is_empty())),
+                "case '{}': 3+ consecutive blank lines\n{yaml}",
+                case.name
+            );
+        }
+    }
+
+    #[test]
+    fn test_fold_text_blocks_plan_mismatch_errors() {
+        // One multi-line text block in the YAML, but an empty plan: the
+        // writer invariant broke and folding must refuse to guess.
+        let yaml = "articles:\n  - number: '1'\n    text: |-\n      regel een\n      regel twee\n";
+        let err = fold_text_blocks(yaml, &[]).unwrap_err();
+        assert!(
+            err.to_string().contains("fold plan mismatch"),
+            "unexpected error: {err}"
+        );
+
+        // More plan entries than blocks must also fail.
+        let err = fold_text_blocks("key: value\n", &[TextStyle::Folded]).unwrap_err();
+        assert!(
+            err.to_string().contains("fold plan mismatch"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/packages/harvester/src/yaml/writer.rs
+++ b/packages/harvester/src/yaml/writer.rs
@@ -416,6 +416,9 @@ static TEXT_BLOCK_HEADER_RE: LazyLock<Regex> =
 /// blank line (a `\n\n` paragraph break in the source) must become two blank
 /// lines to survive the round trip. [`classify_text_style`] only marks a
 /// block `Folded` when its content makes that transformation exact.
+///
+/// Note: a trailing newline in `yaml` is not preserved in the output; the
+/// caller is responsible for any required terminal newline.
 fn fold_text_blocks(yaml: &str, plan: &[(String, TextStyle)]) -> Result<String> {
     let lines: Vec<&str> = yaml.lines().collect();
     let mut out: Vec<String> = Vec::with_capacity(lines.len() + plan.len());

--- a/packages/harvester/tests/fixtures/zorgtoeslag/expected.yaml
+++ b/packages/harvester/tests/fixtures/zorgtoeslag/expected.yaml
@@ -1,5 +1,5 @@
 ---
-$schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/heads/main/schema/v0.3.1/schema.json
+$schema: https://raw.githubusercontent.com/MinBZK/regelrecht/refs/tags/schema-v0.5.4/schema/v0.5.4/schema.json
 $id: wet_op_de_zorgtoeslag
 regulatory_layer: WET
 publication_date: '2024-10-16'
@@ -7,14 +7,17 @@ valid_from: '2025-01-01'
 bwb_id: BWBR0018451
 url: https://wetten.overheid.nl/BWBR0018451/2025-01-01
 preamble:
-  text: |-
+  text: >-
     Wij Beatrix, bij de gratie Gods, Koningin der Nederlanden, Prinses van Oranje-Nassau, enz. enz. enz.
 
+
     Allen, die deze zullen zien of horen lezen, saluut! doen te weten:
+
 
     Alzo Wij in overweging genomen hebben, dat het wenselijk is dat personen voor wie de premie voor een
     zorgverzekering in verhouding tot hun inkomen een te zware last vormt, een financiële tegemoetkoming kunnen
     krijgen;
+
 
     Zo is het, dat Wij, de Raad van State gehoord, en met gemeen overleg der Staten-Generaal, hebben goedgevonden en
     verstaan, gelijk Wij goedvinden en verstaan bij deze:
@@ -121,7 +124,7 @@ articles:
         bwb_id: BWBR0018451
         artikel: '4'
   - number: 1.1.h
-    text: |-
+    text: >-
       de normpremie: de aan de hand van het drempelinkomen en het toetsingsinkomen van de verzekerde berekende premie
       voor een zorgverzekering in het berekeningsjaar.
     url: https://wetten.overheid.nl/BWBR0018451/2025-01-01#Artikel1
@@ -129,27 +132,27 @@ articles:
     text: De hoogte van de zorgtoeslag is afhankelijk van de draagkracht op basis van het inkomen en het vermogen.
     url: https://wetten.overheid.nl/BWBR0018451/2025-01-01#Artikel1
   - number: '2.1'
-    text: |-
+    text: >-
       Indien de normpremie voor een verzekerde in het berekeningsjaar minder bedraagt dan de standaardpremie in dat jaar,
       heeft de verzekerde aanspraak op een zorgtoeslag ter grootte van dat verschil. Voor een verzekerde met een partner
       wordt daarbij tweemaal de standaardpremie in aanmerking genomen; in dat geval worden de verzekerde en zijn partner
       voor de toepassing van deze wet geacht gezamenlijk één aanspraak te hebben.
     url: https://wetten.overheid.nl/BWBR0018451/2025-01-01#Artikel2
   - number: '2.2'
-    text: |-
+    text: >-
       De normpremie bedraagt een percentage van het drempelinkomen in het berekeningsjaar, vermeerderd met een percentage
       van het toetsingsinkomen van de verzekerde in dat jaar voorzover dat toetsingsinkomen het drempelinkomen te boven
       gaat. Voor een verzekerde met een partner wordt daarbij het gezamenlijke toetsingsinkomen in aanmerking genomen.
     url: https://wetten.overheid.nl/BWBR0018451/2025-01-01#Artikel2
   - number: '2.3'
-    text: |-
+    text: >-
       De percentages worden voor verzekerden met een partner vastgesteld op 4,273% van het drempelinkomen, vermeerderd
       met 13,700% van het toetsingsinkomen voor zover dat boven het drempelinkomen uitgaat en voor een verzekerde zonder
       partner op 1,896% van het drempelinkomen, vermeerderd met 13,700% van het toetsingsinkomen voor zover dat boven het
       drempelinkomen uitgaat. Deze percentages kunnen bij algemene maatregel van bestuur worden gewijzigd.
     url: https://wetten.overheid.nl/BWBR0018451/2025-01-01#Artikel2
   - number: '2.4'
-    text: |-
+    text: >-
       In afwijking van het eerste lid bedraagt de aanspraak op een zorgtoeslag voor een verzekerde met een partner die
       geen verzekerde is, vijftig procent van het op grond van het eerste lid berekende bedrag.
     url: https://wetten.overheid.nl/BWBR0018451/2025-01-01#Artikel2
@@ -160,7 +163,7 @@ articles:
     text: Bij regeling van Onze Minister kunnen omtrent het bepaalde in het vijfde lid nadere regels worden gesteld.
     url: https://wetten.overheid.nl/BWBR0018451/2025-01-01#Artikel2
   - number: '2.7'
-    text: |-
+    text: >-
       De voordracht voor een krachtens het derde lid vast te stellen algemene maatregel van bestuur wordt niet eerder
       gedaan dan twee weken nadat het ontwerp aan beide kamers der Staten-Generaal is overgelegd.
     url: https://wetten.overheid.nl/BWBR0018451/2025-01-01#Artikel2
@@ -177,8 +180,8 @@ articles:
 
 
       [ref1]: https://wetten.overheid.nl/BWBR0018472#Artikel7
-      [ref2]: https://wetten.overheid.nl/BWBR0011353#Artikel5
-      [ref3]: https://wetten.overheid.nl/BWBR0011353#Artikel5
+      [ref2]: https://wetten.overheid.nl/BWBR0011353#Artikel5.3
+      [ref3]: https://wetten.overheid.nl/BWBR0011353#Artikel5.13
     url: https://wetten.overheid.nl/BWBR0018451/2025-01-01#Artikel3
     references:
       - id: ref1
@@ -186,10 +189,10 @@ articles:
         artikel: '7'
       - id: ref2
         bwb_id: BWBR0011353
-        artikel: '5'
+        artikel: '5.3'
       - id: ref3
         bwb_id: BWBR0011353
-        artikel: '5'
+        artikel: '5.13'
   - number: '3.2'
     text: |-
       Bij het begin van het kalenderjaar worden de bedragen, bedoeld in het eerste lid, bij
@@ -197,24 +200,24 @@ articles:
       [artikel 10.2 van de Wet inkomstenbelasting 2001][ref1].
 
 
-      [ref1]: https://wetten.overheid.nl/BWBR0011353#Artikel10
+      [ref1]: https://wetten.overheid.nl/BWBR0011353#Artikel10.2
     url: https://wetten.overheid.nl/BWBR0018451/2025-01-01#Artikel3
     references:
       - id: ref1
         bwb_id: BWBR0011353
-        artikel: '10'
+        artikel: '10.2'
   - number: '3.3'
-    text: |-
+    text: >-
       Indien er aanleiding is om de bedragen, bedoeld in het eerste lid, te verhogen op een andere wijze dan op grond van
       het tweede lid, worden de bedragen vastgesteld bij algemene maatregel van bestuur.
     url: https://wetten.overheid.nl/BWBR0018451/2025-01-01#Artikel3
   - number: '3.4'
-    text: |-
+    text: >-
       De overeenkomstig het tweede en derde lid aangepaste bedragen treden in de plaats van de bedragen, genoemd in het
       eerste lid.
     url: https://wetten.overheid.nl/BWBR0018451/2025-01-01#Artikel3
   - number: '3.5'
-    text: |-
+    text: >-
       Indien een verhoging als bedoeld in het derde lid wordt toegepast, vindt deze verhoging plaats nadat het tweede lid
       toepassing heeft gevonden.
     url: https://wetten.overheid.nl/BWBR0018451/2025-01-01#Artikel3
@@ -252,7 +255,7 @@ articles:
         bwb_id: BWBR0018451
         artikel: '4'
   - number: 4a.2
-    text: |-
+    text: >-
       Bij ministeriële regeling wordt jaarlijks uiterlijk in november per land het in het eerste lid bedoelde
       verhoudingsgetal vastgesteld.
     url: https://wetten.overheid.nl/BWBR0018451/2025-01-01#Artikel4a
@@ -303,7 +306,7 @@ articles:
 
 
       [ref1]: https://wetten.overheid.nl/BWBR0018472#Artikel25
-      [ref2]: https://wetten.overheid.nl/BWBR0035917#Artikel6
+      [ref2]: https://wetten.overheid.nl/BWBR0035917#Artikel6.1.1
       [ref3]: https://wetten.overheid.nl/BWBR0018450#Artikel18d
       [ref4]: https://wetten.overheid.nl/BWBR0018450#Artikel18e
     url: https://wetten.overheid.nl/BWBR0018451/2025-01-01#Artikel5
@@ -313,7 +316,7 @@ articles:
         artikel: '25'
       - id: ref2
         bwb_id: BWBR0035917
-        artikel: '6'
+        artikel: 6.1.1
       - id: ref3
         bwb_id: BWBR0018450
         artikel: 18d
@@ -364,7 +367,7 @@ articles:
     text: De zorgtoeslag komt ten laste van het Rijk.
     url: https://wetten.overheid.nl/BWBR0018451/2025-01-01#Artikel5
   - number: '6'
-    text: |-
+    text: >-
       Onze Minister zendt binnen vier jaar na de inwerkingtreding van deze wet, en vervolgens telkens na vier jaar,
       aan de Staten-Generaal een verslag over de doeltreffendheid en de effecten van deze wet in de praktijk, in het
       bijzonder van de bij of krachtens deze wet vastgestelde percentages ter bepaling van de normpremie.

--- a/packages/harvester/tests/integration_test.rs
+++ b/packages/harvester/tests/integration_test.rs
@@ -310,6 +310,67 @@ fn test_yaml_validates_structure() {
     assert!(articles.is_sequence(), "articles should be an array");
 }
 
+/// Golden: the generated YAML for the zorgtoeslag fixture matches
+/// `fixtures/zorgtoeslag/expected.yaml` byte-for-byte. The fixture documents
+/// the writer's real-world output shape (folded prose blocks, literal blocks
+/// for reference-bearing articles, quoting, indentation). After an
+/// intentional writer change, regenerate it with:
+/// `UPDATE_EXPECTED=1 cargo test --test integration_test`
+#[test]
+fn test_yaml_matches_expected_fixture() {
+    let law = run_pipeline();
+    let yaml = generate_yaml(&law, "2025-01-01").expect("Failed to generate YAML");
+    let path =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/zorgtoeslag/expected.yaml");
+    if std::env::var_os("UPDATE_EXPECTED").is_some() {
+        fs::write(&path, &yaml).expect("failed to update expected.yaml");
+    }
+    let expected = fs::read_to_string(&path).expect("failed to read expected.yaml");
+    assert_eq!(
+        yaml, expected,
+        "generated YAML diverges from expected.yaml; rerun with UPDATE_EXPECTED=1 after an intentional writer change"
+    );
+}
+
+#[test]
+fn test_yaml_folds_wrapped_prose() {
+    let law = run_pipeline();
+    let yaml = generate_yaml(&law, "2025-01-01").expect("Failed to generate YAML");
+
+    // The preamble is long multi-paragraph prose: it must be emitted as a
+    // folded block so the cosmetic 115-char wrapping does not become real
+    // newlines in the loaded text.
+    assert!(
+        yaml.contains("  text: >-\n"),
+        "preamble should emit a folded block\n{yaml}"
+    );
+
+    let parsed: serde_yaml_ng::Value =
+        serde_yaml_ng::from_str(&yaml).expect("Generated YAML should be valid");
+    let preamble_text = parsed
+        .get("preamble")
+        .and_then(|p| p.get("text"))
+        .and_then(|t| t.as_str())
+        .expect("preamble.text should be a string");
+
+    // Every newline that survives loading must be a paragraph break: single
+    // newlines were cosmetic wraps and fold back to spaces.
+    let mut rest = preamble_text;
+    while let Some(pos) = rest.find('\n') {
+        rest = &rest[pos..];
+        let run = rest.chars().take_while(|&c| c == '\n').count();
+        assert_eq!(
+            run, 2,
+            "loaded preamble may only contain paragraph breaks (\\n\\n), found a run of {run}:\n{preamble_text}"
+        );
+        rest = &rest[run..];
+    }
+    assert!(
+        preamble_text.contains("Wij Beatrix"),
+        "folded preamble should round-trip its content"
+    );
+}
+
 #[test]
 fn test_references_extracted() {
     let law = run_pipeline();

--- a/script/migrate_text_to_folded.py
+++ b/script/migrate_text_to_folded.py
@@ -39,6 +39,7 @@ import io
 import re
 import sys
 from pathlib import Path
+from typing import NoReturn
 
 try:
     from ruamel.yaml import YAML
@@ -189,7 +190,7 @@ def verify(original_text: str, new_text: str, migrated: dict, path: Path):
         fail(path, "transform is not idempotent on its own output")
 
 
-def fail(path: Path, message: str, *details):
+def fail(path: Path, message: str, *details) -> NoReturn:
     print(f"ERROR: {path}: {message}", file=sys.stderr)
     for detail in details:
         print(detail, file=sys.stderr)

--- a/script/migrate_text_to_folded.py
+++ b/script/migrate_text_to_folded.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Migrate soft-wrapped law text from literal (|-) to folded (>-) block scalars.
+
+The harvester used to wrap article/preamble text at 115 chars with real
+newlines inside literal block scalars, so the cosmetic wrapping became real
+``\\n`` characters in the loaded data. The harvester now emits folded (``>-``)
+blocks for pure prose (see packages/harvester/src/yaml/writer.rs); this script
+performs the matching one-off migration of existing corpus files.
+
+Per text field (``preamble.text`` and ``articles[*].text``) the wrap newlines
+are joined back to spaces and the scalar is re-emitted in folded style, with
+the original wrap points as fold positions — so the diff is exactly
+``|-`` -> ``>-`` plus a doubled blank line per paragraph break.
+
+A field is left untouched (literal) when folding would not be provably safe:
+
+- it contains markdown reference definitions (``[refN]: url`` lines are
+  line-oriented; folding would join them),
+- any line starts with whitespace (more-indented lines change folded-scalar
+  semantics),
+- it contains runs of 2+ blank lines, or starts/ends with a blank line,
+- any single line break is not provably wrap-forced at width 115 (then it is
+  a deliberate hard break, e.g. a markdown list).
+
+Before writing anything the script verifies its own output: the dumped YAML
+is reloaded and every migrated field must equal the computed unwrapped text,
+every skipped field must be unchanged, the documents must be deep-equal
+otherwise, and the transform must be idempotent. Any mismatch aborts without
+writing.
+
+Usage:
+    python script/migrate_text_to_folded.py [paths...]        # default: corpus/regulation
+    python script/migrate_text_to_folded.py --dry-run          # show diffs, write nothing
+"""
+
+import argparse
+import difflib
+import io
+import re
+import sys
+from pathlib import Path
+
+try:
+    from ruamel.yaml import YAML
+    from ruamel.yaml.scalarstring import FoldedScalarString, LiteralScalarString
+except ImportError:
+    print(
+        "ERROR: ruamel.yaml is required for round-trip YAML formatting.\n"
+        "Install with: pip install ruamel.yaml",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+# Must match TEXT_WRAP_WIDTH in packages/harvester/src/config.rs.
+WRAP_WIDTH = 115
+
+REF_DEFINITION_RE = re.compile(r"^\[ref\d+\]: ")
+
+
+def make_yaml():
+    yaml = YAML()
+    yaml.preserve_quotes = True
+    yaml.explicit_start = True
+    yaml.width = 4096  # never re-flow scalars we did not touch
+    yaml.indent(mapping=2, sequence=4, offset=2)
+    return yaml
+
+
+def unwrap_field(value: str):
+    """Return (unwrapped, fold_positions) if the field is provably safe to
+    fold, else None.
+
+    Safe means: every single line break is a cosmetic wrap at WRAP_WIDTH and
+    every blank line is exactly one paragraph break. ``fold_positions`` are
+    the character offsets (into the unwrapped string) of the original wrap
+    points, so the folded emission reproduces the original line layout.
+    """
+    if "\n" not in value:
+        return None
+
+    lines = value.split("\n")
+    if lines[0].strip() == "" or lines[-1].strip() == "":
+        return None
+    for line in lines:
+        if REF_DEFINITION_RE.match(line):
+            return None
+        if line.startswith((" ", "\t")) or line != line.rstrip():
+            return None
+    # Runs of 2+ blank lines cannot round-trip within yamllint's
+    # empty-lines: max 2 (a \n\n\n needs three blank lines when folded).
+    if "\n\n\n" in value:
+        return None
+
+    paragraphs = value.split("\n\n")
+    unwrapped_paragraphs = []
+    fold_positions = []
+    offset = 0
+    for p, paragraph in enumerate(paragraphs):
+        if p > 0:
+            offset += 2  # the \n\n paragraph separator
+        plines = paragraph.split("\n")
+        for a, b in zip(plines, plines[1:]):
+            # The break must have been wrap-forced: line a plus the first
+            # word of line b would not have fit within WRAP_WIDTH. If it
+            # would have fit, the newline was a deliberate hard break.
+            first_word = b.split(" ", 1)[0]
+            if len(a) + 1 + len(first_word) <= WRAP_WIDTH:
+                return None
+        for i, pline in enumerate(plines):
+            if i > 0:
+                fold_positions.append(offset - 1)  # position of the joining space
+            offset += len(pline) + 1  # +1 for the space/newline that follows
+        offset -= 1  # last line of the paragraph has no separator yet
+        unwrapped_paragraphs.append(" ".join(plines))
+    return "\n\n".join(unwrapped_paragraphs), fold_positions
+
+
+def iter_text_fields(data):
+    """Yield (container, key, path) for every text field in scope."""
+    preamble = data.get("preamble")
+    if isinstance(preamble, dict) and isinstance(preamble.get("text"), str):
+        yield preamble, "text", "preamble.text"
+    for i, article in enumerate(data.get("articles") or []):
+        if isinstance(article, dict) and isinstance(article.get("text"), str):
+            yield article, "text", f"articles[{i}].text"
+
+
+def transform(data):
+    """Fold eligible text fields in-place. Returns {path: unwrapped}.
+
+    Only literal (``|-``) blocks are candidates — plain scalars have no
+    newlines and existing folded blocks are already in the target style.
+    """
+    migrated = {}
+    for container, key, path in iter_text_fields(data):
+        if not isinstance(container[key], LiteralScalarString):
+            continue
+        result = unwrap_field(str(container[key]))
+        if result is None:
+            continue
+        unwrapped, fold_positions = result
+        scalar = FoldedScalarString(unwrapped)
+        scalar.fold_pos = fold_positions
+        container[key] = scalar
+        migrated[path] = unwrapped
+    return migrated
+
+
+def dump(yaml, data) -> str:
+    buf = io.StringIO()
+    yaml.dump(data, buf)
+    return buf.getvalue()
+
+
+def verify(original_text: str, new_text: str, migrated: dict, path: Path):
+    """Fail loudly (exit 1) unless the migration round-trips exactly."""
+    yaml = make_yaml()
+    original = yaml.load(original_text)
+    reloaded = yaml.load(new_text)
+
+    fields_old = {p: str(c[k]) for c, k, p in iter_text_fields(original)}
+    fields_new = {p: str(c[k]) for c, k, p in iter_text_fields(reloaded)}
+    if set(fields_old) != set(fields_new):
+        fail(path, "text field set changed", fields_old.keys(), fields_new.keys())
+    for field_path, old_value in fields_old.items():
+        expected = migrated.get(field_path, old_value)
+        actual = fields_new[field_path]
+        if actual != expected:
+            diff = "\n".join(
+                difflib.unified_diff(
+                    expected.split("\n"), actual.split("\n"), "expected", "actual", lineterm=""
+                )
+            )
+            fail(path, f"round-trip mismatch in {field_path}", diff)
+
+    # Everything except the migrated text fields must be untouched.
+    for container, key, field_path in iter_text_fields(original):
+        if field_path in migrated:
+            container[key] = migrated[field_path]
+    plain = YAML(typ="safe")
+    if plain.load(dump(make_yaml(), original)) != plain.load(new_text):
+        fail(path, "document content drifted outside text fields")
+
+    # Idempotency: transforming the migrated document again must reproduce
+    # the same output text.
+    transform(reloaded)
+    if dump(make_yaml(), reloaded) != new_text:
+        fail(path, "transform is not idempotent on its own output")
+
+
+def fail(path: Path, message: str, *details):
+    print(f"ERROR: {path}: {message}", file=sys.stderr)
+    for detail in details:
+        print(detail, file=sys.stderr)
+    sys.exit(1)
+
+
+def migrate_file(path: Path, dry_run: bool) -> bool:
+    original_text = path.read_text(encoding="utf-8")
+    yaml = make_yaml()
+    data = yaml.load(original_text)
+    if not isinstance(data, dict):
+        return False
+
+    migrated = transform(data)
+    if not migrated:
+        return False
+
+    new_text = dump(yaml, data)
+    verify(original_text, new_text, migrated, path)
+
+    if dry_run:
+        sys.stdout.writelines(
+            difflib.unified_diff(
+                original_text.splitlines(keepends=True),
+                new_text.splitlines(keepends=True),
+                str(path),
+                str(path),
+            )
+        )
+    else:
+        path.write_text(new_text, encoding="utf-8")
+    print(f"{'would migrate' if dry_run else 'migrated'}: {path} ({len(migrated)} fields)")
+    return True
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("paths", nargs="*", default=["corpus/regulation"], type=Path)
+    parser.add_argument("--dry-run", action="store_true", help="show diffs, write nothing")
+    args = parser.parse_args()
+
+    files = []
+    for p in args.paths:
+        p = Path(p)
+        if p.is_dir():
+            files.extend(sorted(p.rglob("*.yaml")))
+        else:
+            files.append(p)
+
+    changed = sum(migrate_file(f, args.dry_run) for f in files)
+    print(f"{changed}/{len(files)} files {'would be ' if args.dry_run else ''}migrated")
+
+
+if __name__ == "__main__":
+    main()

--- a/script/migrate_text_to_folded.py
+++ b/script/migrate_text_to_folded.py
@@ -14,7 +14,7 @@ the original wrap points as fold positions — so the diff is exactly
 
 A field is left untouched (literal) when folding would not be provably safe:
 
-- it contains markdown reference definitions (``[refN]: url`` lines are
+- it contains markdown reference definitions (``[label]: url`` lines are
   line-oriented; folding would join them),
 - any line starts with whitespace (more-indented lines change folded-scalar
   semantics),
@@ -54,7 +54,8 @@ except ImportError:
 # Must match TEXT_WRAP_WIDTH in packages/harvester/src/config.rs.
 WRAP_WIDTH = 115
 
-REF_DEFINITION_RE = re.compile(r"^\[ref\d+\]: ")
+# Any markdown reference definition label, not just the harvester's `refN`.
+REF_DEFINITION_RE = re.compile(r"^\[[^\]]+\]: ")
 
 
 def make_yaml():


### PR DESCRIPTION
## Why

Law text in corpus YAML is wrapped at 115 chars for readability, but the harvester stored those wraps inside **literal** block scalars (`|-`) — a YAML style that preserves every newline. The cosmetic wrapping therefore became real `\n` characters in the loaded data. Markdown renderers fold them (soft breaks), but every plain-text consumer sees hard line breaks at the wrap points: pasting article text into the editor shows spurious enters (reproduced on production), note anchors carry `\n` inside quotes, and diffs/tools see multi-line strings where the law has none.

The editor already writes **folded** scalars (`>-`) on save (js-yaml). This PR makes the harvester emit the same style, and migrates the existing monorepo corpus.

## What

**Commit 1 — harvester writer** (`packages/harvester/src/yaml/`):
- `classify_text_style` (text.rs): decides per text field whether folding is provably safe. Folded only when every newline is a cosmetic wrap: no markdown reference definitions (`[refN]: url` is line-oriented), no deliberate hard breaks (single `\n` in the unwrapped source, e.g. lists), no indented lines, no 3+ newline runs, plus defensive re-checks on the emitted string.
- `fold_text_blocks` (writer.rs): serde_yaml_ng cannot emit folded style, so this post-processing step rewrites `text: |-` blocks to `text: >-` per the fold plan computed during struct generation. Paragraph breaks double their blank line (folded semantics: N breaks load as N−1 newlines). A plan/output mismatch fails the write loudly instead of guessing.
- Unsafe fields keep today's literal output **byte-for-byte**.
- New invariant, pinned by tests: `parse(generate_yaml(law)).text` equals the unwrapped source for folded fields, and the wrapped text for literal fallbacks.
- Tests: folded golden, round-trip table test (unicode prose, ref definitions, column-0 lists, indented lines, `\n\n\n`, short text), per-rule classifier tests, plan-mismatch test. The previously **unreferenced** `zorgtoeslag/expected.yaml` fixture is now a real golden with an `UPDATE_EXPECTED=1` regeneration path. Note: the fixture had been stale since schema v0.3.1, so the regeneration also picks up all pipeline changes merged since then — schema URL, article-level granularity, and more precise `artikel` reference identifiers (`'5'`→`'5.3'`, `'10'`→`'10.2'`, etc.). Those reference corrections reflect current harvester output; the live corpus picks them up at the next re-harvest (see follow-ups).
- `script/migrate_text_to_folded.py`: one-off migration (ruamel.yaml round-trip, `--dry-run`, mandatory self-verification: round-trip equality per field, deep-equality of the rest of the document, idempotency — any mismatch aborts without writing).

**Commit 2 — corpus migration** (`corpus/regulation/**`):
- 14 of 25 files migrated (~390 text fields). The diff is mechanical by construction: verified that the only removed lines are `text: |-` headers and the only added lines are `text: >-` headers and blank lines — zero content lines changed.
- Fields with reference definitions, hard breaks or indented lines stay `|-`, matching the new writer behavior.

## Verification

- `just harvester-test`: 240 unit + 11 integration + 12 doc tests green.
- `just check` (format, clippy, build, schema validation, unit tests): green.
- `just bdd`: 76 scenarios / 587 steps green against the migrated corpus (scenario asserts are value-based; no scenario needed changes).
- Migration script self-verification + idempotency on all 25 files; yamllint green via pre-commit (folded lines ≤121 chars, paragraph breaks hit exactly `empty-lines: max 2`).
- Harvester CLI end-to-end on a real BWB law: output emits `>-` for prose, `|-` for ref-bearing fields, and re-parsing yields text whose only newlines are paragraph breaks.

## Out of scope (follow-ups)

- Running the migration on MinBZK/regelrecht-corpus (`development` branch) — after this PR's review.
- Editor paste bug (tiptap-markdown `preserveWhitespace: true` + `white-space: break-spaces` shows pasted soft-wraps as enters) — separate issue; no longer corpus-critical.
- Pre-existing `fix_yaml_quoting` bug: its regexes are not block-scalar-aware (a content line shaped like `woord: 42` inside a block would be quoted), and its float heuristic quotes `'5.3'` but not `6.1.1` (visible in the regenerated fixture; both parse as strings, purely cosmetic). Not worsened here; separate fix.
- Re-harvest of the corpus (already planned for the article-granularity follow-up of #743) will also pick up the corrected `artikel` reference identifiers and the fixed block-content indentation.
