### PR TITLE
feat(frontend): daily harvest and enrich job charts on the overview dashboard

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 public/data/
 test-results/
 playwright-report/
+public/corpus-registry.yaml

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,10 +15,10 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
-    "@regelrecht/frontend-shared": "*",
     "@cucumber/gherkin": "^41.0.0",
     "@cucumber/messages": "^33.0.2",
     "@nldd/design-system": "^0.8.63",
+    "@regelrecht/frontend-shared": "*",
     "@tiptap/core": "^3.27.1",
     "@tiptap/starter-kit": "^3.27.1",
     "@tiptap/vue-3": "^3.27.1",
@@ -27,8 +27,10 @@
     "@vue-flow/core": "^1.48.2",
     "@vue-flow/minimap": "^1.5.4",
     "dompurify": "^3.4.10",
+    "echarts": "^6.1.0",
     "marked": "^18.0.5",
-    "tiptap-markdown": "^0.9.0"
+    "tiptap-markdown": "^0.9.0",
+    "vue-echarts": "^8.0.1"
   },
   "overrides": {
     "brace-expansion": "^5.0.5",

--- a/frontend/src/harvester/charts/chartColors.js
+++ b/frontend/src/harvester/charts/chartColors.js
@@ -45,7 +45,15 @@ export function resolveChartColors(referenceEl = document.body) {
         continue;
       }
       ctx.clearRect(0, 0, 1, 1);
+      // Canvas silently keeps the previous fillStyle on a parse failure; seed
+      // a sentinel so an unparseable value falls back to the computed string
+      // instead of leaking the previous token's color.
+      ctx.fillStyle = '#010203';
       ctx.fillStyle = resolved;
+      if (ctx.fillStyle === '#010203' && resolved !== '#010203') {
+        colors[key] = resolved;
+        continue;
+      }
       ctx.fillRect(0, 0, 1, 1);
       const [r, g, b] = ctx.getImageData(0, 0, 1, 1).data;
       colors[key] = `rgb(${r}, ${g}, ${b})`;

--- a/frontend/src/harvester/charts/chartColors.js
+++ b/frontend/src/harvester/charts/chartColors.js
@@ -5,6 +5,13 @@
  * light-dark() directly. Each token is resolved by computing it on a probe
  * element and normalizing through a 1×1 canvas — which also converts oklch()
  * (the NLDD primitive format, unsupported by zrender) to plain rgb.
+ *
+ * The probe hangs off document.body, NOT the chart's own container: freshly
+ * mounted NLDD subtrees compute `color-scheme: normal` until the custom
+ * elements upgrade, and under `normal` every light-dark() is invalid and
+ * resolves to black. body already carries the design system's `light dark`
+ * at mount, and it follows the data-scheme switch, so probing there is both
+ * correct and available immediately.
  */
 
 // succeeded/failed use the same expressions as the .status-bar__segment--*
@@ -21,13 +28,16 @@ const TOKEN_EXPRESSIONS = {
   text: 'var(--semantics-content-color)',
   textSecondary: 'var(--semantics-content-secondary-color)',
   grid: 'light-dark(var(--primitives-color-neutral-150), var(--primitives-color-neutral-250))',
-  surface: 'var(--semantics-surfaces-background-color)',
 };
 
-export function resolveChartColors(referenceEl = document.body) {
+/**
+ * @returns {object|null} The resolved colors, or null when the page's color
+ *   scheme isn't established yet (caller should retry on a later frame).
+ */
+export function resolveChartColors() {
   const probe = document.createElement('span');
   probe.style.display = 'none';
-  referenceEl.appendChild(probe);
+  document.body.appendChild(probe);
 
   const canvas = document.createElement('canvas');
   canvas.width = 1;
@@ -36,13 +46,16 @@ export function resolveChartColors(referenceEl = document.body) {
 
   const colors = {};
   try {
-    for (const [key, expression] of Object.entries(TOKEN_EXPRESSIONS)) {
-      probe.style.color = expression;
-      const resolved = getComputedStyle(probe).color;
+    if (ctx && getComputedStyle(document.body).colorScheme === 'normal') {
+      // light-dark() is invalid under color-scheme: normal — the design
+      // system's scheme isn't applied yet. Signal "not ready".
+      return null;
+    }
+
+    const toRgb = (resolved) => {
       if (!ctx) {
         // No 2D context (test environments): fall back to the computed string.
-        colors[key] = resolved;
-        continue;
+        return resolved;
       }
       ctx.clearRect(0, 0, 1, 1);
       // Canvas silently keeps the previous fillStyle on a parse failure; seed
@@ -51,13 +64,21 @@ export function resolveChartColors(referenceEl = document.body) {
       ctx.fillStyle = '#010203';
       ctx.fillStyle = resolved;
       if (ctx.fillStyle === '#010203' && resolved !== '#010203') {
-        colors[key] = resolved;
-        continue;
+        return resolved;
       }
       ctx.fillRect(0, 0, 1, 1);
       const [r, g, b] = ctx.getImageData(0, 0, 1, 1).data;
-      colors[key] = `rgb(${r}, ${g}, ${b})`;
+      return `rgb(${r}, ${g}, ${b})`;
+    };
+
+    for (const [key, expression] of Object.entries(TOKEN_EXPRESSIONS)) {
+      probe.style.color = expression;
+      colors[key] = toRgb(getComputedStyle(probe).color);
     }
+    // The charts sit on transparent nldd-cards, so the visible surface behind
+    // the marks is the page background (there is no NLDD surface token that
+    // resolves at :root level).
+    colors.surface = toRgb(getComputedStyle(document.body).backgroundColor);
   } finally {
     probe.remove();
   }

--- a/frontend/src/harvester/charts/chartColors.js
+++ b/frontend/src/harvester/charts/chartColors.js
@@ -1,0 +1,57 @@
+/**
+ * Resolve the NLDD design tokens the charts need to concrete rgb() strings.
+ *
+ * ECharts renders to canvas, so it can't consume CSS custom properties or
+ * light-dark() directly. Each token is resolved by computing it on a probe
+ * element and normalizing through a 1×1 canvas — which also converts oklch()
+ * (the NLDD primitive format, unsupported by zrender) to plain rgb.
+ */
+
+// succeeded/failed use the same expressions as the .status-bar__segment--*
+// rules in harvester.css, so the charts stay color-consistent with the rest
+// of the dashboard. added is hemelblauw rather than the accent: the accent
+// blue fails the chart-palette checks (chroma floor, dark-mode contrast),
+// hemelblauw is the nearest passing NLDD hue.
+const TOKEN_EXPRESSIONS = {
+  succeeded:
+    'light-dark(var(--primitives-color-success-450), var(--primitives-color-success-550))',
+  failed: 'var(--primitives-color-critical-450)',
+  added:
+    'light-dark(var(--primitives-color-hemelblauw-500), var(--primitives-color-hemelblauw-550))',
+  text: 'var(--semantics-content-color)',
+  textSecondary: 'var(--semantics-content-secondary-color)',
+  grid: 'light-dark(var(--primitives-color-neutral-150), var(--primitives-color-neutral-250))',
+  surface: 'var(--semantics-surfaces-background-color)',
+};
+
+export function resolveChartColors(referenceEl = document.body) {
+  const probe = document.createElement('span');
+  probe.style.display = 'none';
+  referenceEl.appendChild(probe);
+
+  const canvas = document.createElement('canvas');
+  canvas.width = 1;
+  canvas.height = 1;
+  const ctx = canvas.getContext('2d', { willReadFrequently: true });
+
+  const colors = {};
+  try {
+    for (const [key, expression] of Object.entries(TOKEN_EXPRESSIONS)) {
+      probe.style.color = expression;
+      const resolved = getComputedStyle(probe).color;
+      if (!ctx) {
+        // No 2D context (test environments): fall back to the computed string.
+        colors[key] = resolved;
+        continue;
+      }
+      ctx.clearRect(0, 0, 1, 1);
+      ctx.fillStyle = resolved;
+      ctx.fillRect(0, 0, 1, 1);
+      const [r, g, b] = ctx.getImageData(0, 0, 1, 1).data;
+      colors[key] = `rgb(${r}, ${g}, ${b})`;
+    }
+  } finally {
+    probe.remove();
+  }
+  return colors;
+}

--- a/frontend/src/harvester/charts/chartColors.test.js
+++ b/frontend/src/harvester/charts/chartColors.test.js
@@ -8,7 +8,7 @@ import { resolveChartColors } from './chartColors.js';
 // probe cleaned up.
 describe('resolveChartColors', () => {
   it('returns a string for every chart slot', () => {
-    const colors = resolveChartColors(document.body);
+    const colors = resolveChartColors();
     for (const key of [
       'succeeded',
       'failed',
@@ -24,7 +24,7 @@ describe('resolveChartColors', () => {
 
   it('removes the probe element again', () => {
     const before = document.body.childElementCount;
-    resolveChartColors(document.body);
+    resolveChartColors();
     expect(document.body.childElementCount).toBe(before);
   });
 });

--- a/frontend/src/harvester/charts/chartColors.test.js
+++ b/frontend/src/harvester/charts/chartColors.test.js
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { resolveChartColors } from './chartColors.js';
+
+// happy-dom has no real canvas 2D context and no NLDD stylesheet, so this
+// exercises the fallback path: every token resolves to its computed-style
+// string (empty here) instead of a canvas-normalized rgb() value. The
+// invariants that hold on both paths: every slot present as a string, and the
+// probe cleaned up.
+describe('resolveChartColors', () => {
+  it('returns a string for every chart slot', () => {
+    const colors = resolveChartColors(document.body);
+    for (const key of [
+      'succeeded',
+      'failed',
+      'added',
+      'text',
+      'textSecondary',
+      'grid',
+      'surface',
+    ]) {
+      expect(colors[key], key).toBeTypeOf('string');
+    }
+  });
+
+  it('removes the probe element again', () => {
+    const before = document.body.childElementCount;
+    resolveChartColors(document.body);
+    expect(document.body.childElementCount).toBe(before);
+  });
+});

--- a/frontend/src/harvester/charts/dailyJobsChart.js
+++ b/frontend/src/harvester/charts/dailyJobsChart.js
@@ -1,0 +1,90 @@
+/**
+ * Option-builder for the daily harvest/enrich jobs charts (ECharts).
+ *
+ * Pure functions so the mapping is unit-testable without a canvas: the Vue
+ * wrapper (DailyJobsChart.vue) resolves the design-token colors in the
+ * browser and injects them here.
+ */
+
+export const SERIES_LABELS = {
+  added: 'Toegevoegd',
+  succeeded: 'Geslaagd',
+  failed: 'Gefaald',
+};
+
+const AXIS_DATE_FORMAT = new Intl.DateTimeFormat('nl-NL', {
+  day: 'numeric',
+  month: 'short',
+});
+
+// 'YYYY-MM-DD' → short Dutch axis label, e.g. '6 jul'.
+export function formatAxisDate(isoDate) {
+  const date = new Date(`${isoDate}T00:00:00`);
+  return Number.isNaN(date.getTime()) ? isoDate : AXIS_DATE_FORMAT.format(date);
+}
+
+/**
+ * @param {Array<{date: string, added: number, succeeded: number, failed: number}>} entries
+ *   One entry per day, ascending (as served by dashboard-stats `daily`).
+ * @param {{succeeded: string, failed: string, added: string, text: string,
+ *          textSecondary: string, grid: string, surface: string}} colors
+ *   Resolved concrete colors (rgb/hex — canvas can't read CSS variables).
+ */
+export function buildDailyJobsOption(entries, colors) {
+  // Succeeded under, failed on top: the stack totals "finished that day" and
+  // the red cap is immediately visible. Added is a separate event (created vs
+  // finished), so it rides on top as a line instead of stacking in.
+  const bar = (key) => ({
+    name: SERIES_LABELS[key],
+    type: 'bar',
+    stack: 'afgerond',
+    data: entries.map((e) => e[key]),
+    color: colors[key],
+    barMaxWidth: 20,
+    // 1px surface-colored border keeps stacked segments visually separated.
+    itemStyle: { borderColor: colors.surface, borderWidth: 1 },
+  });
+
+  return {
+    animation: false,
+    grid: { left: 8, right: 8, top: 36, bottom: 8, containLabel: true },
+    legend: {
+      top: 0,
+      left: 0,
+      icon: 'roundRect',
+      itemWidth: 10,
+      itemHeight: 10,
+      textStyle: { color: colors.text, fontSize: 12 },
+    },
+    tooltip: {
+      trigger: 'axis',
+      axisPointer: { type: 'shadow' },
+    },
+    xAxis: {
+      type: 'category',
+      data: entries.map((e) => formatAxisDate(e.date)),
+      axisTick: { show: false },
+      axisLine: { lineStyle: { color: colors.grid } },
+      axisLabel: { color: colors.textSecondary, fontSize: 11 },
+    },
+    yAxis: {
+      type: 'value',
+      minInterval: 1,
+      splitLine: { lineStyle: { color: colors.grid } },
+      axisLabel: { color: colors.textSecondary, fontSize: 11 },
+    },
+    series: [
+      bar('succeeded'),
+      bar('failed'),
+      {
+        name: SERIES_LABELS.added,
+        type: 'line',
+        data: entries.map((e) => e.added),
+        color: colors.added,
+        lineStyle: { width: 2 },
+        symbol: 'circle',
+        symbolSize: 6,
+      },
+    ],
+  };
+}

--- a/frontend/src/harvester/charts/dailyJobsChart.js
+++ b/frontend/src/harvester/charts/dailyJobsChart.js
@@ -59,6 +59,10 @@ export function buildDailyJobsOption(entries, colors) {
     tooltip: {
       trigger: 'axis',
       axisPointer: { type: 'shadow' },
+      // Theme the tooltip too — the ECharts default is white-on-light only.
+      backgroundColor: colors.surface,
+      borderColor: colors.grid,
+      textStyle: { color: colors.text },
     },
     xAxis: {
       type: 'category',

--- a/frontend/src/harvester/charts/dailyJobsChart.js
+++ b/frontend/src/harvester/charts/dailyJobsChart.js
@@ -17,6 +17,13 @@ const AXIS_DATE_FORMAT = new Intl.DateTimeFormat('nl-NL', {
   month: 'short',
 });
 
+// nl-NL grouping (1.500, not the ECharts default 1,500), consistent with
+// formatNumber elsewhere on the dashboard.
+const AXIS_NUMBER_FORMAT = new Intl.NumberFormat('nl-NL');
+export function formatAxisNumber(value) {
+  return AXIS_NUMBER_FORMAT.format(value);
+}
+
 // 'YYYY-MM-DD' → short Dutch axis label, e.g. '6 jul'.
 export function formatAxisDate(isoDate) {
   const date = new Date(`${isoDate}T00:00:00`);
@@ -59,6 +66,7 @@ export function buildDailyJobsOption(entries, colors) {
     tooltip: {
       trigger: 'axis',
       axisPointer: { type: 'shadow' },
+      valueFormatter: formatAxisNumber,
       // Theme the tooltip too — the ECharts default is white-on-light only.
       backgroundColor: colors.surface,
       borderColor: colors.grid,
@@ -75,7 +83,11 @@ export function buildDailyJobsOption(entries, colors) {
       type: 'value',
       minInterval: 1,
       splitLine: { lineStyle: { color: colors.grid } },
-      axisLabel: { color: colors.textSecondary, fontSize: 11 },
+      axisLabel: {
+        color: colors.textSecondary,
+        fontSize: 11,
+        formatter: formatAxisNumber,
+      },
     },
     series: [
       bar('succeeded'),

--- a/frontend/src/harvester/charts/dailyJobsChart.test.js
+++ b/frontend/src/harvester/charts/dailyJobsChart.test.js
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildDailyJobsOption,
+  formatAxisDate,
+  SERIES_LABELS,
+} from './dailyJobsChart.js';
+
+const COLORS = {
+  succeeded: '#0a0',
+  failed: '#a00',
+  added: '#00a',
+  text: '#111',
+  textSecondary: '#666',
+  grid: '#eee',
+  surface: '#fff',
+};
+
+const ENTRIES = [
+  { date: '2026-07-06', added: 3, succeeded: 2, failed: 1 },
+  { date: '2026-07-07', added: 0, succeeded: 0, failed: 0 },
+];
+
+describe('buildDailyJobsOption', () => {
+  it('maps entries to stacked succeeded/failed bars and an added line', () => {
+    const opt = buildDailyJobsOption(ENTRIES, COLORS);
+    const [succeeded, failed, added] = opt.series;
+
+    expect(succeeded.name).toBe(SERIES_LABELS.succeeded);
+    expect(succeeded.type).toBe('bar');
+    expect(failed.type).toBe('bar');
+    // Same stack → the bars stack; added is a line, not stacked.
+    expect(succeeded.stack).toBe(failed.stack);
+    expect(added.type).toBe('line');
+    expect(added.stack).toBeUndefined();
+
+    expect(succeeded.data).toEqual([2, 0]);
+    expect(failed.data).toEqual([1, 0]);
+    expect(added.data).toEqual([3, 0]);
+    expect(opt.xAxis.data).toHaveLength(2);
+  });
+
+  it('applies the injected colors per series', () => {
+    const opt = buildDailyJobsOption(ENTRIES, COLORS);
+    expect(opt.series.map((s) => s.color)).toEqual(['#0a0', '#a00', '#00a']);
+  });
+
+  it('starts the y-axis at zero with integer ticks', () => {
+    const opt = buildDailyJobsOption(ENTRIES, COLORS);
+    expect(opt.yAxis.type).toBe('value');
+    expect(opt.yAxis.minInterval).toBe(1);
+  });
+});
+
+describe('formatAxisDate', () => {
+  it('formats YYYY-MM-DD as a short Dutch date', () => {
+    expect(formatAxisDate('2026-07-06')).toBe('6 jul');
+  });
+
+  it('passes through unparseable input', () => {
+    expect(formatAxisDate('garbage')).toBe('garbage');
+  });
+});

--- a/frontend/src/harvester/charts/dailyJobsChart.test.js
+++ b/frontend/src/harvester/charts/dailyJobsChart.test.js
@@ -51,6 +51,14 @@ describe('buildDailyJobsOption', () => {
   });
 });
 
+describe('formatAxisNumber', () => {
+  it('formats with nl-NL grouping', async () => {
+    const { formatAxisNumber } = await import('./dailyJobsChart.js');
+    expect(formatAxisNumber(1500)).toBe('1.500');
+    expect(formatAxisNumber(0)).toBe('0');
+  });
+});
+
 describe('formatAxisDate', () => {
   it('formats YYYY-MM-DD as a short Dutch date', () => {
     expect(formatAxisDate('2026-07-06')).toBe('6 jul');

--- a/frontend/src/harvester/components/DailyJobsChart.vue
+++ b/frontend/src/harvester/components/DailyJobsChart.vue
@@ -1,0 +1,77 @@
+<script setup>
+/**
+ * One daily-jobs chart (stacked succeeded/failed bars + added line) for a
+ * single job type. Data comes in as plain entries; colors are resolved from
+ * the NLDD tokens at mount and re-resolved when the color scheme flips
+ * (data-scheme attribute for the explicit picker, the media query for
+ * 'auto') — the tokens are light-dark() pairs the canvas can't track itself.
+ */
+import { computed, onMounted, onUnmounted, ref, shallowRef } from 'vue';
+import { use } from 'echarts/core';
+import { CanvasRenderer } from 'echarts/renderers';
+import { BarChart, LineChart } from 'echarts/charts';
+import {
+  GridComponent,
+  TooltipComponent,
+  LegendComponent,
+} from 'echarts/components';
+import VChart from 'vue-echarts';
+import { buildDailyJobsOption } from '../charts/dailyJobsChart.js';
+import { resolveChartColors } from '../charts/chartColors.js';
+
+use([
+  CanvasRenderer,
+  BarChart,
+  LineChart,
+  GridComponent,
+  TooltipComponent,
+  LegendComponent,
+]);
+
+const props = defineProps({
+  title: { type: String, required: true },
+  entries: { type: Array, required: true },
+});
+
+const chartRoot = ref(null);
+const colors = shallowRef(null);
+
+function refreshColors() {
+  colors.value = resolveChartColors(chartRoot.value ?? document.body);
+}
+
+let schemeObserver = null;
+let darkMedia = null;
+onMounted(() => {
+  refreshColors();
+  schemeObserver = new MutationObserver(refreshColors);
+  schemeObserver.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ['data-scheme'],
+  });
+  darkMedia = window.matchMedia?.('(prefers-color-scheme: dark)');
+  darkMedia?.addEventListener?.('change', refreshColors);
+});
+onUnmounted(() => {
+  schemeObserver?.disconnect();
+  darkMedia?.removeEventListener?.('change', refreshColors);
+});
+
+const option = computed(() =>
+  colors.value ? buildDailyJobsOption(props.entries, colors.value) : null,
+);
+</script>
+
+<template>
+  <nldd-card>
+    <nldd-container padding="16">
+      <nldd-title size="6">
+        <h3>{{ title }}</h3>
+      </nldd-title>
+      <nldd-spacer size="12"></nldd-spacer>
+      <div ref="chartRoot" class="daily-jobs-chart">
+        <v-chart v-if="option" :option="option" autoresize />
+      </div>
+    </nldd-container>
+  </nldd-card>
+</template>

--- a/frontend/src/harvester/components/DailyJobsChart.vue
+++ b/frontend/src/harvester/components/DailyJobsChart.vue
@@ -49,6 +49,10 @@ function refreshColors(attemptsLeft = 30) {
     colors.value = resolved;
   } else if (attemptsLeft > 0) {
     retryFrame = requestAnimationFrame(() => refreshColors(attemptsLeft - 1));
+  } else {
+    console.warn(
+      'DailyJobsChart: color-scheme never left "normal"; chart not rendered',
+    );
   }
 }
 

--- a/frontend/src/harvester/components/DailyJobsChart.vue
+++ b/frontend/src/harvester/components/DailyJobsChart.vue
@@ -6,7 +6,7 @@
  * (data-scheme attribute for the explicit picker, the media query for
  * 'auto') — the tokens are light-dark() pairs the canvas can't track itself.
  */
-import { computed, onMounted, onUnmounted, ref, shallowRef } from 'vue';
+import { computed, onMounted, onUnmounted, shallowRef } from 'vue';
 import { use } from 'echarts/core';
 import { CanvasRenderer } from 'echarts/renderers';
 import { BarChart, LineChart } from 'echarts/charts';
@@ -33,28 +33,42 @@ const props = defineProps({
   entries: { type: Array, required: true },
 });
 
-const chartRoot = ref(null);
 const colors = shallowRef(null);
 
-function refreshColors() {
-  colors.value = resolveChartColors(chartRoot.value ?? document.body);
+// resolveChartColors returns null while the design system's color-scheme
+// hasn't been applied yet (light-dark() would resolve to black then); retry a
+// few frames until it lands.
+let retryFrame = null;
+function refreshColors(attemptsLeft = 30) {
+  if (retryFrame) {
+    cancelAnimationFrame(retryFrame);
+    retryFrame = null;
+  }
+  const resolved = resolveChartColors();
+  if (resolved) {
+    colors.value = resolved;
+  } else if (attemptsLeft > 0) {
+    retryFrame = requestAnimationFrame(() => refreshColors(attemptsLeft - 1));
+  }
 }
 
 let schemeObserver = null;
 let darkMedia = null;
+const onSchemeChange = () => refreshColors();
 onMounted(() => {
   refreshColors();
-  schemeObserver = new MutationObserver(refreshColors);
+  schemeObserver = new MutationObserver(onSchemeChange);
   schemeObserver.observe(document.documentElement, {
     attributes: true,
     attributeFilter: ['data-scheme'],
   });
   darkMedia = window.matchMedia?.('(prefers-color-scheme: dark)');
-  darkMedia?.addEventListener?.('change', refreshColors);
+  darkMedia?.addEventListener?.('change', onSchemeChange);
 });
 onUnmounted(() => {
   schemeObserver?.disconnect();
-  darkMedia?.removeEventListener?.('change', refreshColors);
+  darkMedia?.removeEventListener?.('change', onSchemeChange);
+  if (retryFrame) cancelAnimationFrame(retryFrame);
 });
 
 const option = computed(() =>
@@ -69,7 +83,7 @@ const option = computed(() =>
         <h3>{{ title }}</h3>
       </nldd-title>
       <nldd-spacer size="12"></nldd-spacer>
-      <div ref="chartRoot" class="daily-jobs-chart">
+      <div class="daily-jobs-chart">
         <v-chart v-if="option" :option="option" autoresize />
       </div>
     </nldd-container>

--- a/frontend/src/harvester/harvester.css
+++ b/frontend/src/harvester/harvester.css
@@ -55,3 +55,8 @@
 .status-bar__segment--failed {
   background: var(--primitives-color-critical-450);
 }
+
+/* Daily jobs charts (Overzicht) — ECharts needs an explicit height to render. */
+.daily-jobs-chart {
+  height: 260px;
+}

--- a/frontend/src/harvester/views/OverviewView.test.js
+++ b/frontend/src/harvester/views/OverviewView.test.js
@@ -46,9 +46,12 @@ const STATS = {
 const openDetail = vi.fn();
 const closeDetail = vi.fn();
 
+// Per-mount stats value — tests can swap it to mount with a variant payload.
+let currentStats = STATS;
+
 vi.mock('../composables/useDashboardStats.js', () => ({
   useDashboardStats: () => ({
-    stats: ref(STATS),
+    stats: ref(currentStats),
     loading: ref(false),
     error: ref(null),
   }),
@@ -104,17 +107,30 @@ describe('OverviewView', () => {
     const charts = w.findAllComponents(DailyJobsChart);
     expect(charts).toHaveLength(2);
 
-    expect(charts[0].props('title')).toBe('Harvest per dag');
+    // Charts sit in the right column of their type's half/half section.
+    expect(charts[0].attributes('slot')).toBe('right');
     expect(charts[0].props('entries')).toEqual([
       { date: '2026-07-06', added: 4, succeeded: 3, failed: 1 },
       { date: '2026-07-07', added: 1, succeeded: 0, failed: 0 },
     ]);
 
-    expect(charts[1].props('title')).toBe('Enrich per dag');
     expect(charts[1].props('entries')).toEqual([
       { date: '2026-07-06', added: 2, succeeded: 2, failed: 0 },
       { date: '2026-07-07', added: 0, succeeded: 1, failed: 1 },
     ]);
+  });
+
+  it('hides the charts (but keeps the panels) when the API has no daily block', () => {
+    const stripped = { ...STATS };
+    delete stripped.daily;
+    currentStats = stripped;
+    try {
+      const w = shallowMount(OverviewView);
+      expect(w.findAllComponents(DailyJobsChart)).toHaveLength(0);
+      expect(w.html()).toContain('Harvest');
+    } finally {
+      currentStats = STATS;
+    }
   });
 
   it('wires the failures DataTable with the recent_failures data', () => {

--- a/frontend/src/harvester/views/OverviewView.test.js
+++ b/frontend/src/harvester/views/OverviewView.test.js
@@ -3,6 +3,7 @@ import { describe, it, expect, afterEach, vi } from 'vitest';
 import { ref } from 'vue';
 import OverviewView from './OverviewView.vue';
 import DataTable from '../components/DataTable.vue';
+import DailyJobsChart from '../components/DailyJobsChart.vue';
 
 const STATS = {
   jobs: {
@@ -19,6 +20,18 @@ const STATS = {
     last_7d: { total: 210, harvest: 140, enrich: 70 },
   },
   open_untranslatables: 23,
+  daily: [
+    {
+      date: '2026-07-06',
+      harvest: { added: 4, succeeded: 3, failed: 1 },
+      enrich: { added: 2, succeeded: 2, failed: 0 },
+    },
+    {
+      date: '2026-07-07',
+      harvest: { added: 1, succeeded: 0, failed: 0 },
+      enrich: { added: 0, succeeded: 1, failed: 1 },
+    },
+  ],
   recent_failures: [
     {
       id: 'job-1',
@@ -84,6 +97,24 @@ describe('OverviewView', () => {
     // harvest.completed = 830, enrich.completed = 350
     expect(html).toContain('text="830"');
     expect(html).toContain('text="350"');
+  });
+
+  it('renders one daily chart per job type with mapped entries', () => {
+    const w = shallowMount(OverviewView);
+    const charts = w.findAllComponents(DailyJobsChart);
+    expect(charts).toHaveLength(2);
+
+    expect(charts[0].props('title')).toBe('Harvest per dag');
+    expect(charts[0].props('entries')).toEqual([
+      { date: '2026-07-06', added: 4, succeeded: 3, failed: 1 },
+      { date: '2026-07-07', added: 1, succeeded: 0, failed: 0 },
+    ]);
+
+    expect(charts[1].props('title')).toBe('Enrich per dag');
+    expect(charts[1].props('entries')).toEqual([
+      { date: '2026-07-06', added: 2, succeeded: 2, failed: 0 },
+      { date: '2026-07-07', added: 0, succeeded: 1, failed: 1 },
+    ]);
   });
 
   it('wires the failures DataTable with the recent_failures data', () => {

--- a/frontend/src/harvester/views/OverviewView.vue
+++ b/frontend/src/harvester/views/OverviewView.vue
@@ -35,10 +35,13 @@ const topKpis = computed(() => {
 });
 
 // Harvest and enrich are treated as two separate kinds, each with its own
-// status breakdown and executed counts.
+// titled section: status breakdown + executed counts next to the daily chart.
+// `daily` is absent while an older API is deployed — then chartEntries stays
+// empty and the chart simply doesn't render.
 const typePanels = computed(() => {
   const s = stats.value;
   if (!s) return [];
+  const daily = s.daily ?? [];
   return [
     { key: 'harvest', label: 'Harvest' },
     { key: 'enrich', label: 'Enrich' },
@@ -52,21 +55,7 @@ const typePanels = computed(() => {
     })),
     today: s.executed.today[key] ?? 0,
     last7d: s.executed.last_7d[key] ?? 0,
-  }));
-});
-
-// Daily chart data per type, mapped from the shared `daily` block. `daily` is
-// absent while an older API is deployed — then the charts simply don't render.
-const dailyCharts = computed(() => {
-  const daily = stats.value?.daily ?? [];
-  if (!daily.length) return [];
-  return [
-    { key: 'harvest', title: 'Harvest per dag' },
-    { key: 'enrich', title: 'Enrich per dag' },
-  ].map(({ key, title }) => ({
-    key,
-    title,
-    entries: daily.map((d) => ({ date: d.date, ...d[key] })),
+    chartEntries: daily.map((d) => ({ date: d.date, ...d[key] })),
   }));
 });
 
@@ -97,72 +86,66 @@ async function onFailureClick(row) {
   </nldd-simple-section>
 
   <template v-else-if="stats">
-    <!-- Top-level totals -->
-    <nldd-simple-section>
-      <nldd-collection item-width="240px">
-        <nldd-card v-for="kpi in topKpis" :key="kpi.label">
-          <nldd-container padding="16">
-            <nldd-title size="2">
-              <span slot="overline">{{ kpi.label }}</span>
-              {{ formatNumber(kpi.value) }}
-            </nldd-title>
-          </nldd-container>
-        </nldd-card>
-      </nldd-collection>
-    </nldd-simple-section>
+    <!-- Top-level totals: same half/half rhythm as the per-type sections
+         below, so every card on the page shares one width -->
+    <nldd-one-half-one-half-section>
+      <nldd-card v-for="(kpi, i) in topKpis" :key="kpi.label" :slot="i === 0 ? 'left' : 'right'">
+        <nldd-container padding="16">
+          <nldd-title size="2">
+            <span slot="overline">{{ kpi.label }}</span>
+            {{ formatNumber(kpi.value) }}
+          </nldd-title>
+        </nldd-container>
+      </nldd-card>
+    </nldd-one-half-one-half-section>
 
-    <!-- Per-type detail: harvest and enrich as two separate kinds -->
-    <nldd-simple-section>
-      <nldd-collection item-width="320px">
-        <nldd-card v-for="panel in typePanels" :key="panel.key">
-          <nldd-container padding="16">
-            <nldd-title size="3">
-              <span slot="overline">{{ panel.label }}</span>
-              {{ formatNumber(panel.total) }}
-              <span slot="subtitle">jobs totaal</span>
-            </nldd-title>
+    <!-- Per type (harvest/enrich) one titled section: details next to the
+         daily chart -->
+    <nldd-one-half-one-half-section v-for="panel in typePanels" :key="panel.key">
+      <nldd-title slot="header" size="6"><h3>{{ panel.label }}</h3></nldd-title>
 
-            <nldd-spacer size="16"></nldd-spacer>
+      <nldd-card slot="left">
+        <nldd-container padding="16">
+          <nldd-title size="3">
+            {{ formatNumber(panel.total) }}
+            <span slot="subtitle">jobs totaal</span>
+          </nldd-title>
 
-            <nldd-list variant="simple">
-              <nldd-list-item v-for="item in panel.statuses" :key="item.status">
-                <nldd-cell width="fit-content">
-                  <StatusBadge :status="item.status" size="md" />
-                </nldd-cell>
-                <nldd-text-cell :text="formatNumber(item.count)" horizontal-alignment="right" />
-              </nldd-list-item>
-            </nldd-list>
+          <nldd-spacer size="16"></nldd-spacer>
 
-            <nldd-spacer size="12"></nldd-spacer>
-            <nldd-divider></nldd-divider>
-            <nldd-spacer size="12"></nldd-spacer>
+          <nldd-list variant="simple">
+            <nldd-list-item v-for="item in panel.statuses" :key="item.status">
+              <nldd-cell width="fit-content">
+                <StatusBadge :status="item.status" size="md" />
+              </nldd-cell>
+              <nldd-text-cell :text="formatNumber(item.count)" horizontal-alignment="right" />
+            </nldd-list-item>
+          </nldd-list>
 
-            <nldd-list variant="simple">
-              <nldd-list-item>
-                <nldd-text-cell text="Uitgevoerd vandaag" color="secondary" />
-                <nldd-text-cell :text="formatNumber(panel.today)" horizontal-alignment="right" />
-              </nldd-list-item>
-              <nldd-list-item>
-                <nldd-text-cell text="Afgelopen 7 dagen" color="secondary" />
-                <nldd-text-cell :text="formatNumber(panel.last7d)" horizontal-alignment="right" />
-              </nldd-list-item>
-            </nldd-list>
-          </nldd-container>
-        </nldd-card>
-      </nldd-collection>
-    </nldd-simple-section>
+          <nldd-spacer size="12"></nldd-spacer>
+          <nldd-divider></nldd-divider>
+          <nldd-spacer size="12"></nldd-spacer>
 
-    <!-- Daily added/succeeded/failed charts, one per job type -->
-    <nldd-simple-section v-if="dailyCharts.length">
-      <nldd-collection item-width="420px">
-        <DailyJobsChart
-          v-for="chart in dailyCharts"
-          :key="chart.key"
-          :title="chart.title"
-          :entries="chart.entries"
-        />
-      </nldd-collection>
-    </nldd-simple-section>
+          <nldd-list variant="simple">
+            <nldd-list-item>
+              <nldd-text-cell text="Uitgevoerd vandaag" color="secondary" />
+              <nldd-text-cell :text="formatNumber(panel.today)" horizontal-alignment="right" />
+            </nldd-list-item>
+            <nldd-list-item>
+              <nldd-text-cell text="Afgelopen 7 dagen" color="secondary" />
+              <nldd-text-cell :text="formatNumber(panel.last7d)" horizontal-alignment="right" />
+            </nldd-list-item>
+          </nldd-list>
+        </nldd-container>
+      </nldd-card>
+
+      <DailyJobsChart
+        v-if="panel.chartEntries.length"
+        slot="right"
+        :title="'Per dag'"
+        :entries="panel.chartEntries"
+      />
+    </nldd-one-half-one-half-section>
 
     <!-- Recent failures -->
     <nldd-simple-section>

--- a/frontend/src/harvester/views/OverviewView.vue
+++ b/frontend/src/harvester/views/OverviewView.vue
@@ -6,6 +6,7 @@ import { useJobDetail } from '../composables/useJobDetail.js';
 import { JOB_STATUSES } from '../constants.js';
 import { formatNumber, formatStatus } from '../formatters.js';
 import DataTable from '../components/DataTable.vue';
+import DailyJobsChart from '../components/DailyJobsChart.vue';
 import DetailPanel from '../components/DetailPanel.vue';
 import StatusBadge from '../components/StatusBadge.vue';
 
@@ -51,6 +52,21 @@ const typePanels = computed(() => {
     })),
     today: s.executed.today[key] ?? 0,
     last7d: s.executed.last_7d[key] ?? 0,
+  }));
+});
+
+// Daily chart data per type, mapped from the shared `daily` block. `daily` is
+// absent while an older API is deployed — then the charts simply don't render.
+const dailyCharts = computed(() => {
+  const daily = stats.value?.daily ?? [];
+  if (!daily.length) return [];
+  return [
+    { key: 'harvest', title: 'Harvest per dag' },
+    { key: 'enrich', title: 'Enrich per dag' },
+  ].map(({ key, title }) => ({
+    key,
+    title,
+    entries: daily.map((d) => ({ date: d.date, ...d[key] })),
   }));
 });
 
@@ -133,6 +149,18 @@ async function onFailureClick(row) {
             </nldd-list>
           </nldd-container>
         </nldd-card>
+      </nldd-collection>
+    </nldd-simple-section>
+
+    <!-- Daily added/succeeded/failed charts, one per job type -->
+    <nldd-simple-section v-if="dailyCharts.length">
+      <nldd-collection item-width="420px">
+        <DailyJobsChart
+          v-for="chart in dailyCharts"
+          :key="chart.key"
+          :title="chart.title"
+          :entries="chart.entries"
+        />
       </nldd-collection>
     </nldd-simple-section>
 

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -60,10 +60,8 @@ export default defineConfig({
       // them in the test context instead. The @regelrecht/frontend-shared
       // workspace package (ESM) hits the same issue when a test transitively
       // imports it (e.g. usePollingFetch → apiFetch), so inline it too.
-      // echarts/vue-echarts/zrender are also pure ESM (imported by the
-      // harvester dashboard charts).
       deps: {
-        inline: [/@cucumber\//, /@regelrecht\//, /^echarts/, /^vue-echarts/, /^zrender/],
+        inline: [/@cucumber\//, /@regelrecht\//],
       },
     },
   },

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -60,8 +60,10 @@ export default defineConfig({
       // them in the test context instead. The @regelrecht/frontend-shared
       // workspace package (ESM) hits the same issue when a test transitively
       // imports it (e.g. usePollingFetch → apiFetch), so inline it too.
+      // echarts/vue-echarts/zrender are also pure ESM (imported by the
+      // harvester dashboard charts).
       deps: {
-        inline: [/@cucumber\//, /@regelrecht\//],
+        inline: [/@cucumber\//, /@regelrecht\//, /^echarts/, /^vue-echarts/, /^zrender/],
       },
     },
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,8 +29,10 @@
         "@vue-flow/core": "^1.48.2",
         "@vue-flow/minimap": "^1.5.4",
         "dompurify": "^3.4.10",
+        "echarts": "^6.1.0",
         "marked": "^18.0.5",
-        "tiptap-markdown": "^0.9.0"
+        "tiptap-markdown": "^0.9.0",
+        "vue-echarts": "^8.0.1"
       },
       "devDependencies": {
         "@playwright/test": "^1.61.0",
@@ -2628,6 +2630,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/echarts": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-6.1.0.tgz",
+      "integrity": "sha512-q0yaFPggC9FUdsWH4blavRWFmxdrIodbkoKNAjJudAI6CA9gNPxHtV2RcZNEepZVlk4yvBYkOkbk6HIVpIyHZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "2.3.0",
+        "zrender": "6.1.0"
+      }
+    },
+    "node_modules/echarts/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
+    },
     "node_modules/editorconfig": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-1.0.7.tgz",
@@ -4704,6 +4722,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/vue-echarts": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/vue-echarts/-/vue-echarts-8.0.1.tgz",
+      "integrity": "sha512-23rJTFLu1OUEGRWjJGmdGt8fP+8+ja1gVgzMYPIPaHWpXegcO1viIAaeu2H4QHESlVeHzUAHIxKXGrwjsyXAaA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "echarts": "^6.0.0",
+        "vue": "^3.3.0"
+      }
+    },
     "node_modules/vue-router": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-5.1.0.tgz",
@@ -5000,6 +5028,21 @@
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
       }
+    },
+    "node_modules/zrender": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-6.1.0.tgz",
+      "integrity": "sha512-oEGMDB6pOP2S6OwRR4PdVv610zrjnA3Bh+JnSG12fYJlBKjtNAoEb5fSUoCOOINlH96I2fU38/A2UpRKs67xYQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tslib": "2.3.0"
+      }
+    },
+    "node_modules/zrender/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
     },
     "packages/frontend-shared": {
       "name": "@regelrecht/frontend-shared",

--- a/packages/admin/src/handlers.rs
+++ b/packages/admin/src/handlers.rs
@@ -696,12 +696,30 @@ pub struct RecentFailure {
     pub error: String,
 }
 
+/// Per-day counts for one job type: jobs created that day (`added`) and jobs
+/// that reached a terminal status that day (`succeeded`/`failed`).
+#[derive(Serialize, Default)]
+pub struct DailyCounts {
+    pub added: i64,
+    pub succeeded: i64,
+    pub failed: i64,
+}
+
+/// One Europe/Amsterdam calendar day (`YYYY-MM-DD`) in the 14-day window.
+#[derive(Serialize)]
+pub struct DailyEntry {
+    pub date: String,
+    pub harvest: DailyCounts,
+    pub enrich: DailyCounts,
+}
+
 #[derive(Serialize)]
 pub struct DashboardStats {
     pub jobs: JobsBlock,
     pub executed: ExecutedBlock,
     pub open_untranslatables: i64,
     pub recent_failures: Vec<RecentFailure>,
+    pub daily: Vec<DailyEntry>,
 }
 
 /// Aggregate snapshot for the harvester "Overzicht" dashboard: job counts by
@@ -797,11 +815,73 @@ pub async fn dashboard_stats(
     .await
     .map_err(db_err("dashboard recent-failures query failed"))?;
 
+    // 5. Daily series for the last 14 Europe/Amsterdam days: jobs added
+    //    (created_at) and jobs finished (completed_at, split by outcome), per
+    //    type. Days without activity come back as explicit zero rows so the
+    //    frontend never fills gaps. The `recent` pre-filter keeps the join off
+    //    the full jobs table; 15 days gives slack for the UTC↔Amsterdam offset.
+    let daily_rows = sqlx::query_as::<_, (String, i64, i64, i64, i64, i64, i64)>(
+        "WITH days AS ( \
+             SELECT ((now() AT TIME ZONE 'Europe/Amsterdam')::date - offs) AS day \
+             FROM generate_series(13, 0, -1) AS offs \
+         ), recent AS ( \
+             SELECT job_type::text AS job_type, status::text AS status, \
+                    created_at, completed_at \
+             FROM jobs \
+             WHERE created_at >= now() - INTERVAL '15 days' \
+                OR (status IN ('completed', 'failed') \
+                    AND completed_at >= now() - INTERVAL '15 days') \
+         ) \
+         SELECT to_char(days.day, 'YYYY-MM-DD'), \
+             COUNT(*) FILTER (WHERE r.job_type = 'harvest' \
+                 AND (r.created_at AT TIME ZONE 'Europe/Amsterdam')::date = days.day), \
+             COUNT(*) FILTER (WHERE r.job_type = 'harvest' AND r.status = 'completed' \
+                 AND (r.completed_at AT TIME ZONE 'Europe/Amsterdam')::date = days.day), \
+             COUNT(*) FILTER (WHERE r.job_type = 'harvest' AND r.status = 'failed' \
+                 AND (r.completed_at AT TIME ZONE 'Europe/Amsterdam')::date = days.day), \
+             COUNT(*) FILTER (WHERE r.job_type = 'enrich' \
+                 AND (r.created_at AT TIME ZONE 'Europe/Amsterdam')::date = days.day), \
+             COUNT(*) FILTER (WHERE r.job_type = 'enrich' AND r.status = 'completed' \
+                 AND (r.completed_at AT TIME ZONE 'Europe/Amsterdam')::date = days.day), \
+             COUNT(*) FILTER (WHERE r.job_type = 'enrich' AND r.status = 'failed' \
+                 AND (r.completed_at AT TIME ZONE 'Europe/Amsterdam')::date = days.day) \
+         FROM days \
+         LEFT JOIN recent r \
+             ON (r.created_at AT TIME ZONE 'Europe/Amsterdam')::date = days.day \
+             OR (r.status IN ('completed', 'failed') \
+                 AND (r.completed_at AT TIME ZONE 'Europe/Amsterdam')::date = days.day) \
+         GROUP BY days.day \
+         ORDER BY days.day",
+    )
+    .fetch_all(pool)
+    .await
+    .map_err(db_err("dashboard daily-series query failed"))?;
+
+    let daily: Vec<DailyEntry> = daily_rows
+        .into_iter()
+        .map(
+            |(date, h_added, h_succeeded, h_failed, e_added, e_succeeded, e_failed)| DailyEntry {
+                date,
+                harvest: DailyCounts {
+                    added: h_added,
+                    succeeded: h_succeeded,
+                    failed: h_failed,
+                },
+                enrich: DailyCounts {
+                    added: e_added,
+                    succeeded: e_succeeded,
+                    failed: e_failed,
+                },
+            },
+        )
+        .collect();
+
     Ok(Json(DashboardStats {
         jobs,
         executed,
         open_untranslatables,
         recent_failures,
+        daily,
     }))
 }
 

--- a/packages/admin/src/handlers.rs
+++ b/packages/admin/src/handlers.rs
@@ -818,38 +818,40 @@ pub async fn dashboard_stats(
     // 5. Daily series for the last 14 Europe/Amsterdam days: jobs added
     //    (created_at) and jobs finished (completed_at, split by outcome), per
     //    type. Days without activity come back as explicit zero rows so the
-    //    frontend never fills gaps. The `recent` pre-filter keeps the join off
-    //    the full jobs table; 15 days gives slack for the UTC↔Amsterdam offset.
+    //    frontend never fills gaps. Pre-aggregate per (day, type, kind) first —
+    //    a day-skeleton joined directly against the jobs rows degrades into an
+    //    O(days × rows) nested loop. The 15-day cutoffs give slack for the
+    //    UTC↔Amsterdam offset; at most 6 aggregate rows join per day, so the
+    //    SUM FILTER never double-counts.
     let daily_rows = sqlx::query_as::<_, (String, i64, i64, i64, i64, i64, i64)>(
         "WITH days AS ( \
              SELECT ((now() AT TIME ZONE 'Europe/Amsterdam')::date - offs) AS day \
              FROM generate_series(13, 0, -1) AS offs \
-         ), recent AS ( \
-             SELECT job_type::text AS job_type, status::text AS status, \
-                    created_at, completed_at \
+         ), events AS ( \
+             SELECT (created_at AT TIME ZONE 'Europe/Amsterdam')::date AS day, \
+                    job_type::text AS job_type, 'added' AS kind, COUNT(*) AS n \
              FROM jobs \
              WHERE created_at >= now() - INTERVAL '15 days' \
-                OR (status IN ('completed', 'failed') \
-                    AND completed_at >= now() - INTERVAL '15 days') \
+             GROUP BY 1, 2 \
+             UNION ALL \
+             SELECT (completed_at AT TIME ZONE 'Europe/Amsterdam')::date, \
+                    job_type::text, \
+                    CASE status::text WHEN 'completed' THEN 'succeeded' ELSE 'failed' END, \
+                    COUNT(*) \
+             FROM jobs \
+             WHERE status IN ('completed', 'failed') \
+               AND completed_at >= now() - INTERVAL '15 days' \
+             GROUP BY 1, 2, 3 \
          ) \
          SELECT to_char(days.day, 'YYYY-MM-DD'), \
-             COUNT(*) FILTER (WHERE r.job_type = 'harvest' \
-                 AND (r.created_at AT TIME ZONE 'Europe/Amsterdam')::date = days.day), \
-             COUNT(*) FILTER (WHERE r.job_type = 'harvest' AND r.status = 'completed' \
-                 AND (r.completed_at AT TIME ZONE 'Europe/Amsterdam')::date = days.day), \
-             COUNT(*) FILTER (WHERE r.job_type = 'harvest' AND r.status = 'failed' \
-                 AND (r.completed_at AT TIME ZONE 'Europe/Amsterdam')::date = days.day), \
-             COUNT(*) FILTER (WHERE r.job_type = 'enrich' \
-                 AND (r.created_at AT TIME ZONE 'Europe/Amsterdam')::date = days.day), \
-             COUNT(*) FILTER (WHERE r.job_type = 'enrich' AND r.status = 'completed' \
-                 AND (r.completed_at AT TIME ZONE 'Europe/Amsterdam')::date = days.day), \
-             COUNT(*) FILTER (WHERE r.job_type = 'enrich' AND r.status = 'failed' \
-                 AND (r.completed_at AT TIME ZONE 'Europe/Amsterdam')::date = days.day) \
+             COALESCE(SUM(e.n) FILTER (WHERE e.job_type = 'harvest' AND e.kind = 'added'), 0)::bigint, \
+             COALESCE(SUM(e.n) FILTER (WHERE e.job_type = 'harvest' AND e.kind = 'succeeded'), 0)::bigint, \
+             COALESCE(SUM(e.n) FILTER (WHERE e.job_type = 'harvest' AND e.kind = 'failed'), 0)::bigint, \
+             COALESCE(SUM(e.n) FILTER (WHERE e.job_type = 'enrich' AND e.kind = 'added'), 0)::bigint, \
+             COALESCE(SUM(e.n) FILTER (WHERE e.job_type = 'enrich' AND e.kind = 'succeeded'), 0)::bigint, \
+             COALESCE(SUM(e.n) FILTER (WHERE e.job_type = 'enrich' AND e.kind = 'failed'), 0)::bigint \
          FROM days \
-         LEFT JOIN recent r \
-             ON (r.created_at AT TIME ZONE 'Europe/Amsterdam')::date = days.day \
-             OR (r.status IN ('completed', 'failed') \
-                 AND (r.completed_at AT TIME ZONE 'Europe/Amsterdam')::date = days.day) \
+         LEFT JOIN events e ON e.day = days.day \
          GROUP BY days.day \
          ORDER BY days.day",
     )

--- a/packages/admin/tests/handler_tests.rs
+++ b/packages/admin/tests/handler_tests.rs
@@ -701,6 +701,12 @@ async fn dashboard_stats_on_empty_db() {
     assert_eq!(json["executed"]["today"]["total"], 0);
     assert_eq!(json["open_untranslatables"], 0);
     assert_eq!(json["recent_failures"].as_array().unwrap().len(), 0);
+    // The daily series always spans 14 days, all zeros on an empty DB.
+    let daily = json["daily"].as_array().unwrap();
+    assert_eq!(daily.len(), 14);
+    assert!(daily
+        .iter()
+        .all(|d| d["harvest"]["added"] == 0 && d["enrich"]["failed"] == 0));
 }
 
 #[tokio::test]
@@ -884,4 +890,101 @@ async fn dashboard_stats_failure_reason_falls_back_when_no_error_key() {
     let failures = json["recent_failures"].as_array().unwrap();
     assert_eq!(failures.len(), 1);
     assert_eq!(failures[0]["error"], "onbekend");
+}
+
+#[tokio::test]
+async fn dashboard_stats_daily_series_fourteen_days() {
+    let db = TestDb::new().await;
+    let pool = db.pool.clone();
+
+    // Harvest job created today, still pending → counts as added only.
+    job_queue::create_job(
+        &pool,
+        CreateJobRequest::new(JobType::Harvest, "BWBR0000040"),
+    )
+    .await
+    .unwrap();
+
+    // Enrich job created and completed today → added + succeeded today.
+    job_queue::create_job(&pool, CreateJobRequest::new(JobType::Enrich, "BWBR0000041"))
+        .await
+        .unwrap();
+    let claimed = job_queue::claim_job(&pool, Some(JobType::Enrich))
+        .await
+        .unwrap()
+        .unwrap();
+    job_queue::complete_job(&pool, claimed.id, None)
+        .await
+        .unwrap();
+
+    // Harvest job created 5 days ago, failed 3 days ago: added counts on the
+    // creation day, failed on the completion day.
+    let failed = job_queue::create_job(
+        &pool,
+        CreateJobRequest::new(JobType::Harvest, "BWBR0000042"),
+    )
+    .await
+    .unwrap();
+    sqlx::query(
+        "UPDATE jobs SET status = 'failed', \
+         created_at = now() - interval '5 days', \
+         completed_at = now() - interval '3 days' WHERE id = $1",
+    )
+    .bind(failed.id)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    // Harvest job created and completed 20 days ago → outside the window.
+    let old = job_queue::create_job(
+        &pool,
+        CreateJobRequest::new(JobType::Harvest, "BWBR0000043"),
+    )
+    .await
+    .unwrap();
+    sqlx::query(
+        "UPDATE jobs SET status = 'completed', \
+         created_at = now() - interval '20 days', \
+         completed_at = now() - interval '20 days' WHERE id = $1",
+    )
+    .bind(old.id)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let json = get_dashboard_stats(&pool).await;
+    let daily = json["daily"].as_array().unwrap();
+    assert_eq!(daily.len(), 14);
+
+    // Dates ascend and the last entry is today's Europe/Amsterdam date (same
+    // source of truth as the query: Postgres).
+    let today: String = sqlx::query_scalar(
+        "SELECT to_char((now() AT TIME ZONE 'Europe/Amsterdam')::date, 'YYYY-MM-DD')",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(daily[13]["date"], today.as_str());
+    for pair in daily.windows(2) {
+        assert!(pair[0]["date"].as_str().unwrap() < pair[1]["date"].as_str().unwrap());
+    }
+
+    // Today (index 13): 1 harvest added, 1 enrich added + succeeded.
+    assert_eq!(daily[13]["harvest"]["added"], 1);
+    assert_eq!(daily[13]["harvest"]["succeeded"], 0);
+    assert_eq!(daily[13]["harvest"]["failed"], 0);
+    assert_eq!(daily[13]["enrich"]["added"], 1);
+    assert_eq!(daily[13]["enrich"]["succeeded"], 1);
+
+    // 5 days ago (index 8): the failed harvest counts as added there;
+    // 3 days ago (index 10): it counts as failed there.
+    assert_eq!(daily[8]["harvest"]["added"], 1);
+    assert_eq!(daily[10]["harvest"]["failed"], 1);
+
+    // The 20-day-old job appears nowhere in the window.
+    let total_harvest_added: i64 = daily
+        .iter()
+        .map(|d| d["harvest"]["added"].as_i64().unwrap())
+        .sum();
+    assert_eq!(total_harvest_added, 2);
 }

--- a/packages/admin/tests/handler_tests.rs
+++ b/packages/admin/tests/handler_tests.rs
@@ -704,9 +704,13 @@ async fn dashboard_stats_on_empty_db() {
     // The daily series always spans 14 days, all zeros on an empty DB.
     let daily = json["daily"].as_array().unwrap();
     assert_eq!(daily.len(), 14);
-    assert!(daily
-        .iter()
-        .all(|d| d["harvest"]["added"] == 0 && d["enrich"]["failed"] == 0));
+    assert!(daily.iter().all(|d| {
+        ["harvest", "enrich"].iter().all(|t| {
+            ["added", "succeeded", "failed"]
+                .iter()
+                .all(|k| d[t][k] == 0)
+        })
+    }));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What

Daily job charts on the harvester **Overzicht** tab — per job type (harvest/enrich), over the last 14 days (Europe/Amsterdam):

- **Toegevoegd** (added, on `created_at`) as a line
- **Geslaagd** / **Gefaald** (succeeded/failed, on `completed_at`) as stacked bars — the stack totals "finished that day"

Added rides on top as a line rather than stacking in, because it is a different event (created vs finished); stacking it would suggest double counting.

The overview page is restructured into one width rhythm: a KPI half/half row (jobs total, open untranslatables), then per job type a titled `nldd-one-half-one-half-section` with the detail card on the left and the daily chart on the right (columns wrap on narrow viewports).

## Screenshots

| Light | Dark |
|---|---|
| ![overview light](https://files.catbox.moe/d5wqw6.png) | ![overview dark](https://files.catbox.moe/v3xr3f.png) |

## How

- **Backend** (`packages/admin`): `GET /api/dashboard-stats` gains a `daily` block — 14 Europe/Amsterdam calendar days with explicit zero rows, pre-aggregated per (day, type, kind) so the query stays O(rows) (a naive day-skeleton join degraded to ~970 ms at 100k jobs; this variant avoids the nested loop and the disk sort). No new endpoint, no extra polling.
- **Frontend** (`frontend/src/harvester`): new `DailyJobsChart.vue` (vue-echarts, tree-shaken echarts modules) + a pure option-builder (`charts/dailyJobsChart.js`, unit-tested without canvas) + a token resolver (`charts/chartColors.js`) that normalizes the NLDD `light-dark(oklch(...))` tokens to `rgb()` via a 1×1 canvas (zrender can't parse oklch) and re-resolves on color-scheme changes (`data-scheme` mutations + `prefers-color-scheme`). Axis/tooltip numbers use nl-NL grouping.
- **Mount-timing gotcha** (found while smoke testing the preview): a freshly mounted NLDD subtree computes `color-scheme: normal` until the custom elements upgrade, and under `normal` every `light-dark()` expression is invalid and resolves to black. The token probe therefore hangs off `document.body` (which already carries the scheme at mount), with a bounded rAF retry as backstop.
- New dependencies: `echarts` + `vue-echarts` (Apache-2.0 / MIT).

## Design-system note (custom UI report)

There is no `ndd-chart` component, so the chart canvas itself is custom UI next to the design system. Mitigations:

- All chart colors come from NLDD design tokens. Succeeded/failed reuse the exact status-bar expressions already in `harvester.css`; the added line uses `hemelblauw-500/550` instead of the accent because the accent blue fails the chart-palette checks (chroma floor; 2.92:1 contrast on the dark surface). The surface color is read from `body`'s computed background (the cards are transparent and no NLDD surface token resolves at `:root`).
- Palette validated programmatically (six-checks chart-palette validator) in both light and dark mode: **all checks pass**. The deutan red↔green pair scores ΔE ~10.5 (in the 8–12 band), which is acceptable because identity is never color-alone: fixed stack order, the added series is a line (shape), legend and tooltip labels.
- **Custom CSS added** (must-report per project convention): one rule, `.daily-jobs-chart { height: 260px; }` — ECharts needs an explicit container height. Everything else is NDD components.

## Tests

- Rust: `dashboard_stats_daily_series_fourteen_days` (testcontainers) covering window size, ascending Amsterdam dates, added-vs-finished day attribution and window exclusion; empty-DB zeros.
- Vitest: option-builder unit tests, token-resolver fallback tests, OverviewView mapping tests (charts in the right column, panels survive an API without `daily`).
- `just check` green; smoke tested on the pr916 preview: colors correct on fresh mount, tooltip, live dark-mode re-theme.
