### PR TITLE
feat(pipeline): depth-based priority for auto-enrich jobs

### DIFF
--- a/packages/pipeline/README.md
+++ b/packages/pipeline/README.md
@@ -181,6 +181,44 @@ tx.commit().await?;
 | `LawStatusValue` | `Unknown`, `Queued`, `Harvesting`, `Harvested`, `HarvestFailed`, `Enriching`, `Enriched`, `EnrichFailed` |
 | `Priority` | 0–100 (default: 50, higher = processed first) |
 
+## Job priorities
+
+Workers claim the next job with `ORDER BY priority DESC, created_at ASC`
+(`job_queue::claim_job`). **A higher priority number is picked up first**; equal
+priorities are served oldest-first. `Priority` clamps to `0–100` (default 50).
+
+Priorities are chosen so that work a human explicitly asked for runs ahead of
+speculative work the pipeline discovered on its own (referenced laws pulled in by
+harvesting, related legislation pulled in by enrichment).
+
+| Job | Created by | Priority |
+|-----|-----------|----------|
+| Harvest — editor request (BWB search / dependency walker) | `api/harvest.rs` (`EDITOR_HARVEST_PRIORITY`) | 80 |
+| Harvest — admin `POST /api/harvest-jobs` | `admin::handlers` | 50 default (caller may override) |
+| Harvest — recursive follow-up (referenced laws) | `worker.rs` | 30 |
+| Harvest — related legislation (spawned by enrichment) | `worker.rs` (`related_harvest_priority`) | 39 and below (`RELATED_HARVEST_BASE 40 − (depth + 1)`) |
+| Enrich — admin `POST /api/enrich-jobs` | `admin::handlers` | 50 default (caller may override) |
+| Enrich — auto after a **direct** harvest | `worker.rs` (`auto_enrich_priority`) | 50 |
+| Enrich — auto after a **recursive** harvest | `worker.rs` (`RECURSIVE_ENRICH_PRIORITY`) | 10 |
+| Enrich — auto-retry after failure | `worker.rs` | inherits the failed job's priority |
+
+### Auto-enrich priority by harvest depth
+
+When `ENRICH_AUTO_ENQUEUE` is on, a successful harvest auto-creates one enrich
+job per provider. The priority of that enrich job depends on the harvest's
+recursion `depth` (from the `HarvestPayload`):
+
+- **Direct / root harvest** (`depth` `None` or `0`) — the enrich job uses the
+  default priority (**50**), same as a manually requested enrich.
+- **Recursive follow-up harvest** (`depth` `>= 1`) — the enrich job uses
+  `RECURSIVE_ENRICH_PRIORITY` (**10**), so recursively-discovered laws are
+  enriched only after everything directly or manually requested has been
+  processed.
+
+`ENRICH_AUTO_ENQUEUE` remains the global on/off switch — when off, no enrich job
+is auto-created for either case. A byte-identical re-harvest (`changed = false`)
+and an `enrich_exhausted` law still skip auto-enrich entirely.
+
 ## Database
 
 ### Requirements

--- a/packages/pipeline/src/worker.rs
+++ b/packages/pipeline/src/worker.rs
@@ -477,6 +477,7 @@ async fn process_next_job(
                         }
                     };
                     let enrich_req = CreateJobRequest::new(JobType::Enrich, &job.law_id)
+                        .with_priority(auto_enrich_priority(payload.depth))
                         .with_payload(payload_json);
                     match job_queue::create_enrich_job_if_not_exists(pool, enrich_req).await {
                         Ok(Some(enrich_job)) => {
@@ -940,6 +941,23 @@ const RELATED_HARVEST_BASE: i32 = 40;
 /// result into the valid `0..=100` range.
 fn related_harvest_priority(enrich_depth: u32) -> Priority {
     Priority::new(RELATED_HARVEST_BASE - (enrich_depth as i32 + 1))
+}
+
+/// Priority for enrich jobs auto-created after a *recursive* (follow-up)
+/// harvest. Well below the default (50) so speculative, recursively-discovered
+/// enrichments always yield to directly/manually requested enrich work.
+const RECURSIVE_ENRICH_PRIORITY: i32 = 10;
+
+/// Auto-enrich priority for a harvest at the given `depth`. Root/direct harvests
+/// (depth `None`/`0`) keep the default priority; recursive follow-up harvests
+/// (depth `>= 1`) drop to [`RECURSIVE_ENRICH_PRIORITY`] so they are claimed only
+/// after all directly/manually requested enrich jobs.
+fn auto_enrich_priority(depth: Option<u32>) -> Priority {
+    if depth.unwrap_or(0) == 0 {
+        Priority::default()
+    } else {
+        Priority::new(RECURSIVE_ENRICH_PRIORITY)
+    }
 }
 
 /// True when `s` is a syntactically valid BWB regulation id (`^BWBR\d{7}$`).
@@ -1828,6 +1846,29 @@ mod tests {
         assert_eq!(hourly_cap(4, 1, 3), 4);
         // Saturating: a huge multiplier can't overflow.
         assert_eq!(hourly_cap(u32::MAX, 5, 3), u32::MAX);
+    }
+
+    #[test]
+    fn auto_enrich_priority_by_depth() {
+        // Root/direct harvests keep the default priority.
+        assert_eq!(
+            auto_enrich_priority(None).value(),
+            Priority::default().value()
+        );
+        assert_eq!(
+            auto_enrich_priority(Some(0)).value(),
+            Priority::default().value()
+        );
+        // Recursive follow-up harvests (depth >= 1) drop to the low priority so
+        // they yield to directly/manually requested enrich work.
+        assert_eq!(
+            auto_enrich_priority(Some(1)).value(),
+            RECURSIVE_ENRICH_PRIORITY
+        );
+        assert_eq!(
+            auto_enrich_priority(Some(5)).value(),
+            RECURSIVE_ENRICH_PRIORITY
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

Auto-enrich jobs created after a successful harvest now get a priority that depends on the harvest's recursion depth:

- **Direct / root harvest** (`depth` `None`/`0`) → enrich at priority **50** (unchanged).
- **Recursive follow-up harvest** (`depth` `>= 1`) → enrich at priority **10** (`RECURSIVE_ENRICH_PRIORITY`).

The queue claims with `ORDER BY priority DESC, created_at ASC` (higher = first), so recursively-discovered laws now yield in the queue to anything a human directly or manually requested, instead of competing at the same priority.

## Why

With `ENRICH_AUTO_ENQUEUE` on, every successful harvest — direct or recursively discovered via referenced laws — auto-created enrich jobs at the same default priority (50). Speculative, recursively-discovered enrichments could therefore run ahead of, or alongside, the enrich for the law someone actually asked for.

## Scope / non-goals

- `ENRICH_AUTO_ENQUEUE` stays the global on/off switch (unchanged) — off means nothing auto-enriches, for either case.
- The byte-identical re-harvest skip (`changed == false`) and the `enrich_exhausted` skip are unchanged.
- The auto-retry path already inherits the failed job's priority, so a recursive enrich started at 10 stays at 10 on retries — no extra change needed.
- No change to harvest priorities or the related-legislation harvest priority scheme.

## Changes

- `packages/pipeline/src/worker.rs` — new `RECURSIVE_ENRICH_PRIORITY = 10`, pure helper `auto_enrich_priority(depth) -> Priority`, wired into the auto-enrich `CreateJobRequest`; unit test for `None`/`0`/`1`/`5`.
- `packages/pipeline/README.md` — new "Job priorities" section documenting the queue ordering rule and which job is created at which priority.
- `docs/superpowers/specs/…` — design spec.

## Verification

- `just format`, `just lint`, `just build-check` — all green.
- `just pipeline-test` — new `auto_enrich_priority_by_depth` test passes; full suite green (DB-backed tests pass with the testcontainers host override).
