### PR TITLE
feat(editor): upload werkdocumenten with LLM conversion to markdown

### DIFF
--- a/frontend/src/WerkdocumentenView.vue
+++ b/frontend/src/WerkdocumentenView.vue
@@ -36,7 +36,7 @@ const jobsPoller = useTrajectDocumentJobs(activeTrajectRef);
 const { jobs: conversionJobs } = jobsPoller;
 
 // Hidden native file input + upload trigger (shared with the launcher sheet).
-const { fileInput, onUpload, onFileChange } = useDocumentUpload(uploadDocument, () =>
+const { fileInput, uploadError, onUpload, onFileChange } = useDocumentUpload(uploadDocument, () =>
   jobsPoller.startPolling(),
 );
 
@@ -152,6 +152,12 @@ function backToList() {
           <nldd-split-view-pane slot="sidebar" has-content>
             <nldd-page>
               <nldd-simple-section>
+                <nldd-inline-dialog
+                  v-if="uploadError"
+                  variant="alert"
+                  text="Uploaden mislukt"
+                  :supporting-text="uploadError"
+                ></nldd-inline-dialog>
                 <ConversionStatus :jobs="conversionJobs"></ConversionStatus>
                 <nldd-activity-indicator v-if="listLoading" text="Documenten laden" show-text></nldd-activity-indicator>
                 <nldd-inline-dialog

--- a/frontend/src/WerkdocumentenView.vue
+++ b/frontend/src/WerkdocumentenView.vue
@@ -10,14 +10,16 @@
  * it carries its own compact top bar — title + traject subtitle on the left,
  * a focused account menu (theme + logout) on the right.
  */
-import { computed, onMounted, watch, watchEffect } from 'vue';
+import { computed, onMounted, ref, watch, watchEffect } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { useTrajects } from './composables/useTrajects.js';
 import { useDocumentsManager } from './composables/useDocumentsManager.js';
+import { useTrajectDocumentJobs } from './composables/useTrajectDocumentJobs.js';
 import { useAuth } from './composables/useAuth.js';
 import { useColorScheme } from './composables/useColorScheme.js';
 import DocumentList from './components/DocumentList.vue';
 import DocumentEditor from './components/DocumentEditor.vue';
+import ConversionStatus from './components/ConversionStatus.vue';
 
 const route = useRoute();
 const router = useRouter();
@@ -26,7 +28,25 @@ const { authenticated, oidcConfigured, person, loading: authLoading, login, logo
 const { colorScheme, setColorScheme } = useColorScheme();
 
 const mgr = useDocumentsManager(activeTrajectRef);
-const { documents, listLoading, listError, currentPath, displayTitle, open, startNew, close } = mgr;
+const { documents, listLoading, listError, currentPath, displayTitle, open, startNew, close, uploadDocument } = mgr;
+
+// Conversion-status poller for uploaded documents being converted to markdown.
+const jobsPoller = useTrajectDocumentJobs(activeTrajectRef);
+const { jobs: conversionJobs } = jobsPoller;
+
+// Hidden native file input (no NLDD upload component exists — reported in PR).
+const fileInput = ref(null);
+function onUpload() {
+  fileInput.value?.click();
+}
+async function onFileChange(e) {
+  const file = e.target.files?.[0];
+  // Reset the input so re-picking the same file fires `change` again.
+  e.target.value = '';
+  if (!file) return;
+  const result = await uploadDocument(file);
+  if (result?.ok) jobsPoller.startPolling();
+}
 
 const colorSchemeOptions = [
   ['auto', 'Systeem'],
@@ -51,6 +71,10 @@ watchEffect(() => {
 // Open the document addressed by the URL on first load (deep link / refresh),
 // or start a fresh document when the launcher opened us with `?new=1`.
 onMounted(() => {
+  // Surface any conversions already running/failed for this traject, and keep
+  // polling while the page is open (the composable stops on unmount).
+  jobsPoller.startPolling();
+
   const initial = route.params.docPath;
   if (initial) {
     open(String(initial));
@@ -136,6 +160,7 @@ function backToList() {
           <nldd-split-view-pane slot="sidebar" has-content>
             <nldd-page>
               <nldd-simple-section>
+                <ConversionStatus :jobs="conversionJobs"></ConversionStatus>
                 <nldd-activity-indicator v-if="listLoading" text="Documenten laden" show-text></nldd-activity-indicator>
                 <nldd-inline-dialog
                   v-else-if="listError"
@@ -149,7 +174,15 @@ function backToList() {
                   :selected-path="currentPath"
                   @select="onSelect"
                   @new="onNew"
+                  @upload="onUpload"
                 ></DocumentList>
+                <input
+                  ref="fileInput"
+                  type="file"
+                  accept=".pdf,.doc,.docx"
+                  hidden
+                  @change="onFileChange"
+                />
               </nldd-simple-section>
             </nldd-page>
           </nldd-split-view-pane>

--- a/frontend/src/WerkdocumentenView.vue
+++ b/frontend/src/WerkdocumentenView.vue
@@ -10,11 +10,12 @@
  * it carries its own compact top bar — title + traject subtitle on the left,
  * a focused account menu (theme + logout) on the right.
  */
-import { computed, onMounted, ref, watch, watchEffect } from 'vue';
+import { computed, onMounted, watch, watchEffect } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { useTrajects } from './composables/useTrajects.js';
 import { useDocumentsManager } from './composables/useDocumentsManager.js';
 import { useTrajectDocumentJobs } from './composables/useTrajectDocumentJobs.js';
+import { useDocumentUpload } from './composables/useDocumentUpload.js';
 import { useAuth } from './composables/useAuth.js';
 import { useColorScheme } from './composables/useColorScheme.js';
 import DocumentList from './components/DocumentList.vue';
@@ -34,19 +35,10 @@ const { documents, listLoading, listError, currentPath, displayTitle, open, star
 const jobsPoller = useTrajectDocumentJobs(activeTrajectRef);
 const { jobs: conversionJobs } = jobsPoller;
 
-// Hidden native file input (no NLDD upload component exists — reported in PR).
-const fileInput = ref(null);
-function onUpload() {
-  fileInput.value?.click();
-}
-async function onFileChange(e) {
-  const file = e.target.files?.[0];
-  // Reset the input so re-picking the same file fires `change` again.
-  e.target.value = '';
-  if (!file) return;
-  const result = await uploadDocument(file);
-  if (result?.ok) jobsPoller.startPolling();
-}
+// Hidden native file input + upload trigger (shared with the launcher sheet).
+const { fileInput, onUpload, onFileChange } = useDocumentUpload(uploadDocument, () =>
+  jobsPoller.startPolling(),
+);
 
 const colorSchemeOptions = [
   ['auto', 'Systeem'],

--- a/frontend/src/WerkdocumentenView.vue
+++ b/frontend/src/WerkdocumentenView.vue
@@ -36,8 +36,10 @@ const jobsPoller = useTrajectDocumentJobs(activeTrajectRef);
 const { jobs: conversionJobs } = jobsPoller;
 
 // Hidden native file input + upload trigger (shared with the launcher sheet).
+// Polling is already running (started on mount), so just refresh to surface the
+// new job immediately — restarting would reset() and briefly flash the list empty.
 const { fileInput, uploadError, onUpload, onFileChange } = useDocumentUpload(uploadDocument, () =>
-  jobsPoller.startPolling(),
+  jobsPoller.refresh(),
 );
 
 const colorSchemeOptions = [

--- a/frontend/src/components/ConversionStatus.test.js
+++ b/frontend/src/components/ConversionStatus.test.js
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import ConversionStatus from './ConversionStatus.vue';
+
+// DS elements compile to raw custom elements under happy-dom; assert against
+// attributes rather than shadow DOM.
+function mountStatus(jobs) {
+  return mount(ConversionStatus, { props: { jobs } });
+}
+
+describe('ConversionStatus', () => {
+  it('renders nothing when there are no jobs', () => {
+    const wrapper = mountStatus([]);
+    expect(wrapper.find('.conversion-status').exists()).toBe(false);
+  });
+
+  it('shows a spinner for a running conversion (title without .md)', () => {
+    const wrapper = mountStatus([{ id: '1', target_path: 'report.md', status: 'processing' }]);
+    const indicator = wrapper.find('nldd-activity-indicator');
+    expect(indicator.exists()).toBe(true);
+    expect(indicator.attributes('text')).toContain('report');
+    expect(indicator.attributes('text')).not.toContain('.md');
+    // A running job is not an error dialog.
+    expect(wrapper.find('nldd-inline-dialog').exists()).toBe(false);
+  });
+
+  it('shows the failure reason for a failed conversion', () => {
+    const wrapper = mountStatus([
+      { id: '2', target_path: 'brief.md', status: 'failed', error: 'boom' },
+    ]);
+    const dialog = wrapper.find('nldd-inline-dialog');
+    expect(dialog.exists()).toBe(true);
+    expect(dialog.attributes('variant')).toBe('alert');
+    expect(dialog.attributes('text')).toContain('brief');
+    expect(dialog.attributes('supporting-text')).toBe('boom');
+  });
+});

--- a/frontend/src/components/ConversionStatus.vue
+++ b/frontend/src/components/ConversionStatus.vue
@@ -1,0 +1,45 @@
+<script setup>
+/**
+ * ConversionStatus — presentational list of a traject's in-progress and failed
+ * document-conversion jobs. A running job shows a spinner; a failed job shows
+ * its reason. Completed jobs are not shown here — they appear as the actual
+ * `.md` in the documents list. Renders nothing when there are no such jobs.
+ */
+defineProps({
+  jobs: { type: Array, default: () => [] },
+});
+
+function title(job) {
+  const path = job.target_path || 'document';
+  return path.replace(/\.md$/, '');
+}
+</script>
+
+<template>
+  <div v-if="jobs.length" class="conversion-status">
+    <template v-for="job in jobs" :key="job.id">
+      <nldd-inline-dialog
+        v-if="job.status === 'failed'"
+        variant="alert"
+        :text="`Conversie mislukt: ${title(job)}`"
+        :supporting-text="job.error || 'Onbekende fout'"
+      ></nldd-inline-dialog>
+      <nldd-activity-indicator
+        v-else
+        :text="`Wordt geconverteerd… — ${title(job)}`"
+        show-text
+      ></nldd-activity-indicator>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+/* Stack the status rows with a small gap. Custom spacing on top of the design
+   system — reported in the PR. */
+.conversion-status {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+</style>

--- a/frontend/src/components/DocumentList.test.js
+++ b/frontend/src/components/DocumentList.test.js
@@ -14,10 +14,10 @@ function mountList(props = {}) {
 }
 
 describe('DocumentList', () => {
-  it('renders one row per document plus the "Nieuw document" row', () => {
+  it('renders one row per document plus the "Nieuw document" and "uploaden" rows', () => {
     const wrapper = mountList();
     const items = wrapper.findAll('nldd-list-item');
-    expect(items).toHaveLength(DOCS.length + 1);
+    expect(items).toHaveLength(DOCS.length + 2);
   });
 
   it('hides the .md extension but keeps .txt visible', () => {
@@ -34,11 +34,18 @@ describe('DocumentList', () => {
     expect(wrapper.emitted('select')[0]).toEqual(['beleid.md']);
   });
 
-  it('emits new when the last row is clicked', async () => {
+  it('emits new when the "Nieuw document" row (second to last) is clicked', async () => {
+    const wrapper = mountList();
+    const items = wrapper.findAll('nldd-list-item');
+    await items[items.length - 2].trigger('click');
+    expect(wrapper.emitted('new')).toBeTruthy();
+  });
+
+  it('emits upload when the last row (uploaden) is clicked', async () => {
     const wrapper = mountList();
     const items = wrapper.findAll('nldd-list-item');
     await items[items.length - 1].trigger('click');
-    expect(wrapper.emitted('new')).toBeTruthy();
+    expect(wrapper.emitted('upload')).toBeTruthy();
   });
 
   it('marks the selected document row', () => {
@@ -65,10 +72,11 @@ describe('DocumentList', () => {
     expect(first.attributes('target')).toBe('_blank');
     expect(first.attributes('rel')).toBe('noopener');
 
-    // Last row: the "Nieuw document" action is a button (no href), but its @new
-    // handler opens the page in a new tab, so it mirrors the doc rows with the
-    // open-new-page icon rather than a chevron.
-    const newRow = rows[rows.length - 1];
+    // Second-to-last row: the "Nieuw document" action is a button (no href), but
+    // its @new handler opens the page in a new tab, so it mirrors the doc rows
+    // with the open-new-page icon rather than a chevron. (The last row is the
+    // upload action, which always uses a chevron.)
+    const newRow = rows[rows.length - 2];
     expect(newRow.attributes('href')).toBeUndefined();
     const newRowIcons = newRow.findAll('nldd-icon').map((i) => i.attributes('name'));
     expect(newRowIcons).toContain('open-new-page');

--- a/frontend/src/components/DocumentList.vue
+++ b/frontend/src/components/DocumentList.vue
@@ -15,7 +15,7 @@ const props = defineProps({
   // List style: 'box' in the launcher sheet, 'simple' on the standalone page.
   variant: { type: String, default: 'simple' },
 });
-const emit = defineEmits(['select', 'new']);
+const emit = defineEmits(['select', 'new', 'upload']);
 
 function title(path) {
   return path ? path.replace(/\.md$/, '') : '';
@@ -53,6 +53,14 @@ function onRowClick(path) {
       <nldd-text-cell text="Nieuw document"></nldd-text-cell>
       <nldd-spacer-cell size="8"></nldd-spacer-cell>
       <nldd-icon-cell size="20"><nldd-icon :name="hrefFor ? 'open-new-page' : 'chevron-right'"></nldd-icon></nldd-icon-cell>
+    </nldd-list-item>
+    <nldd-list-item size="md" button @click="$emit('upload')">
+      <nldd-spacer-cell slot="start" size="12"></nldd-spacer-cell>
+      <nldd-icon-cell slot="start" size="20"><nldd-icon name="cloud-arrow-up"></nldd-icon></nldd-icon-cell>
+      <nldd-spacer-cell slot="start" size="8"></nldd-spacer-cell>
+      <nldd-text-cell text="Document uploaden (PDF/Word)"></nldd-text-cell>
+      <nldd-spacer-cell size="8"></nldd-spacer-cell>
+      <nldd-icon-cell size="20"><nldd-icon name="chevron-right"></nldd-icon></nldd-icon-cell>
     </nldd-list-item>
   </nldd-list>
 </template>

--- a/frontend/src/components/TrajectDocuments.vue
+++ b/frontend/src/components/TrajectDocuments.vue
@@ -14,6 +14,7 @@ import { useTrajects } from '../composables/useTrajects.js';
 import { useDocumentsSheet } from '../composables/useDocumentsSheet.js';
 import { useTrajectDocuments } from '../composables/useTrajectDocuments.js';
 import { useTrajectDocumentJobs } from '../composables/useTrajectDocumentJobs.js';
+import { useDocumentUpload } from '../composables/useDocumentUpload.js';
 import DocumentList from './DocumentList.vue';
 import ConversionStatus from './ConversionStatus.vue';
 
@@ -26,7 +27,9 @@ const jobsPoller = useTrajectDocumentJobs(activeTrajectRef);
 const { jobs: conversionJobs } = jobsPoller;
 
 const browserEl = ref(null);
-const fileInput = ref(null);
+const { fileInput, onUpload, onFileChange } = useDocumentUpload(uploadDocument, () =>
+  jobsPoller.startPolling(),
+);
 
 watch(browserOpen, async (o) => {
   await nextTick();
@@ -41,18 +44,6 @@ watch(browserOpen, async (o) => {
     jobsPoller.stopPolling();
   }
 });
-
-// Hidden native file input (no NLDD upload component exists — reported in PR).
-function onUpload() {
-  fileInput.value?.click();
-}
-async function onFileChange(e) {
-  const file = e.target.files?.[0];
-  e.target.value = '';
-  if (!file) return;
-  const result = await uploadDocument(file);
-  if (result?.ok) jobsPoller.startPolling();
-}
 
 function pageUrl(path) {
   const ref = activeTrajectRef.value;

--- a/frontend/src/components/TrajectDocuments.vue
+++ b/frontend/src/components/TrajectDocuments.vue
@@ -13,24 +13,46 @@ import { computed, nextTick, ref, watch } from 'vue';
 import { useTrajects } from '../composables/useTrajects.js';
 import { useDocumentsSheet } from '../composables/useDocumentsSheet.js';
 import { useTrajectDocuments } from '../composables/useTrajectDocuments.js';
+import { useTrajectDocumentJobs } from '../composables/useTrajectDocumentJobs.js';
 import DocumentList from './DocumentList.vue';
+import ConversionStatus from './ConversionStatus.vue';
 
 const { activeTrajectRef, activeTraject } = useTrajects();
 const { isOpen: browserOpen, close: closeBrowser } = useDocumentsSheet();
-const { documents, loading: listLoading, listError, fetchList } = useTrajectDocuments(activeTrajectRef);
+const { documents, loading: listLoading, listError, fetchList, uploadDocument } =
+  useTrajectDocuments(activeTrajectRef);
+
+const jobsPoller = useTrajectDocumentJobs(activeTrajectRef);
+const { jobs: conversionJobs } = jobsPoller;
 
 const browserEl = ref(null);
+const fileInput = ref(null);
 
 watch(browserOpen, async (o) => {
   await nextTick();
   if (o) {
     browserEl.value?.show();
-    // Re-fetch on open so documents created in a page tab show up here.
+    // Re-fetch on open so documents created in a page tab show up here, and
+    // poll conversion jobs while the sheet is open.
     fetchList();
+    jobsPoller.startPolling();
   } else {
     browserEl.value?.hide();
+    jobsPoller.stopPolling();
   }
 });
+
+// Hidden native file input (no NLDD upload component exists — reported in PR).
+function onUpload() {
+  fileInput.value?.click();
+}
+async function onFileChange(e) {
+  const file = e.target.files?.[0];
+  e.target.value = '';
+  if (!file) return;
+  const result = await uploadDocument(file);
+  if (result?.ok) jobsPoller.startPolling();
+}
 
 function pageUrl(path) {
   const ref = activeTrajectRef.value;
@@ -65,6 +87,7 @@ const sheetTitle = computed(() =>
         ></nldd-top-title-bar>
 
         <nldd-simple-section>
+          <ConversionStatus :jobs="conversionJobs"></ConversionStatus>
           <nldd-activity-indicator v-if="listLoading" text="Documenten laden" show-text></nldd-activity-indicator>
           <nldd-inline-dialog
             v-else-if="listError"
@@ -78,7 +101,15 @@ const sheetTitle = computed(() =>
             :documents="documents"
             :href-for="pageUrl"
             @new="openNew"
+            @upload="onUpload"
           ></DocumentList>
+          <input
+            ref="fileInput"
+            type="file"
+            accept=".pdf,.doc,.docx"
+            hidden
+            @change="onFileChange"
+          />
         </nldd-simple-section>
       </nldd-page>
     </nldd-sheet>

--- a/frontend/src/components/TrajectDocuments.vue
+++ b/frontend/src/components/TrajectDocuments.vue
@@ -27,7 +27,7 @@ const jobsPoller = useTrajectDocumentJobs(activeTrajectRef);
 const { jobs: conversionJobs } = jobsPoller;
 
 const browserEl = ref(null);
-const { fileInput, onUpload, onFileChange } = useDocumentUpload(uploadDocument, () =>
+const { fileInput, uploadError, onUpload, onFileChange } = useDocumentUpload(uploadDocument, () =>
   jobsPoller.startPolling(),
 );
 
@@ -78,6 +78,12 @@ const sheetTitle = computed(() =>
         ></nldd-top-title-bar>
 
         <nldd-simple-section>
+          <nldd-inline-dialog
+            v-if="uploadError"
+            variant="alert"
+            text="Uploaden mislukt"
+            :supporting-text="uploadError"
+          ></nldd-inline-dialog>
           <ConversionStatus :jobs="conversionJobs"></ConversionStatus>
           <nldd-activity-indicator v-if="listLoading" text="Documenten laden" show-text></nldd-activity-indicator>
           <nldd-inline-dialog

--- a/frontend/src/components/TrajectDocuments.vue
+++ b/frontend/src/components/TrajectDocuments.vue
@@ -27,8 +27,10 @@ const jobsPoller = useTrajectDocumentJobs(activeTrajectRef);
 const { jobs: conversionJobs } = jobsPoller;
 
 const browserEl = ref(null);
+// Polling is already running (started when the sheet opened), so just refresh to
+// surface the new job immediately — restarting would reset() and flash the list.
 const { fileInput, uploadError, onUpload, onFileChange } = useDocumentUpload(uploadDocument, () =>
-  jobsPoller.startPolling(),
+  jobsPoller.refresh(),
 );
 
 watch(browserOpen, async (o) => {

--- a/frontend/src/composables/corpusUrls.js
+++ b/frontend/src/composables/corpusUrls.js
@@ -87,6 +87,21 @@ export function documentFileUrl(trajectRef, docPath) {
   return `${corpusBase(trajectRef)}/documents/${encoded}`;
 }
 
+// Multipart upload of a PDF/Word document; the backend stores the bytes
+// and enqueues an async conversion-to-markdown job. Traject-scoped only,
+// like the other document builders.
+export function documentUploadUrl(trajectRef) {
+  requireTraject(trajectRef, 'document upload');
+  return `${corpusBase(trajectRef)}/documents/upload`;
+}
+
+// Running/failed document-conversion jobs for the traject, backing the
+// werkdocumenten conversion-status block.
+export function documentJobsUrl(trajectRef) {
+  requireTraject(trajectRef, 'document jobs listing');
+  return `${corpusBase(trajectRef)}/documents/jobs`;
+}
+
 // Writes only exist under the traject prefix. Composables call this at
 // the top of their save function so the call-stack failure is "no
 // traject" instead of a malformed URL.

--- a/frontend/src/composables/useDocumentUpload.js
+++ b/frontend/src/composables/useDocumentUpload.js
@@ -1,0 +1,30 @@
+/**
+ * useDocumentUpload — the shared "hidden native file input + trigger" wiring for
+ * the werkdocumenten upload affordance, used by both the launcher sheet and the
+ * standalone page. No NLDD file-upload component exists, so the picker is a
+ * hidden `<input type="file">`; this keeps that one bit of non-design-system
+ * plumbing in a single place.
+ *
+ * @param {(file: File) => Promise<{ ok: boolean }>} uploadFn  performs the upload
+ * @param {() => void} [onUploaded]  called after a successful upload (e.g. start polling)
+ */
+import { ref } from 'vue';
+
+export function useDocumentUpload(uploadFn, onUploaded) {
+  const fileInput = ref(null);
+
+  function onUpload() {
+    fileInput.value?.click();
+  }
+
+  async function onFileChange(e) {
+    const file = e.target.files?.[0];
+    // Reset the input so re-picking the same file fires `change` again.
+    e.target.value = '';
+    if (!file) return;
+    const result = await uploadFn(file);
+    if (result?.ok && onUploaded) onUploaded();
+  }
+
+  return { fileInput, onUpload, onFileChange };
+}

--- a/frontend/src/composables/useDocumentUpload.js
+++ b/frontend/src/composables/useDocumentUpload.js
@@ -12,6 +12,9 @@ import { ref } from 'vue';
 
 export function useDocumentUpload(uploadFn, onUploaded) {
   const fileInput = ref(null);
+  // Surfaced to the consumer so a failed upload (400/413/503/network) is shown,
+  // not silently swallowed when the file picker closes.
+  const uploadError = ref(null);
 
   function onUpload() {
     fileInput.value?.click();
@@ -22,9 +25,14 @@ export function useDocumentUpload(uploadFn, onUploaded) {
     // Reset the input so re-picking the same file fires `change` again.
     e.target.value = '';
     if (!file) return;
+    uploadError.value = null;
     const result = await uploadFn(file);
-    if (result?.ok && onUploaded) onUploaded();
+    if (result?.ok) {
+      if (onUploaded) onUploaded();
+    } else {
+      uploadError.value = result?.error || 'Uploaden mislukt.';
+    }
   }
 
-  return { fileInput, onUpload, onFileChange };
+  return { fileInput, uploadError, onUpload, onFileChange };
 }

--- a/frontend/src/composables/useDocumentsManager.js
+++ b/frontend/src/composables/useDocumentsManager.js
@@ -32,6 +32,7 @@ export function useDocumentsManager(trajectRef) {
     saveCurrent,
     reloadCurrent,
     createDocument,
+    uploadDocument,
     deleteDocument,
     dropDraft,
   } = docs;
@@ -225,7 +226,7 @@ export function useDocumentsManager(trajectRef) {
     // derived helpers
     displayTitle,
     // actions
-    open, startNew, close,
+    open, startNew, close, uploadDocument,
     onBodyInput, onTitleInput, onViewModeChange,
     handleSave, undoChanges, overwriteServer,
     reloadCurrent, dropDraft,

--- a/frontend/src/composables/useTrajectDocumentJobs.js
+++ b/frontend/src/composables/useTrajectDocumentJobs.js
@@ -48,6 +48,9 @@ export function useTrajectDocumentJobs(trajectRef, { interval = DEFAULT_INTERVAL
 
   function startPolling() {
     stopPolling();
+    // Fresh start: drop any jobs from a previous traject and re-arm the
+    // initial-load flag so `loading` reflects this (re)start, not a stale run.
+    reset();
     refresh();
     timer = setInterval(refresh, interval);
   }

--- a/frontend/src/composables/useTrajectDocumentJobs.js
+++ b/frontend/src/composables/useTrajectDocumentJobs.js
@@ -20,6 +20,9 @@ export function useTrajectDocumentJobs(trajectRef, { interval = DEFAULT_INTERVAL
 
   let timer = null;
   let initialLoad = true;
+  // Guards the async gap in `startPolling`: if the component unmounts during the
+  // awaited first refresh, don't arm an interval that nothing would clear.
+  let mounted = true;
 
   async function refresh() {
     const ref_ = trajectRef.value;
@@ -55,6 +58,8 @@ export function useTrajectDocumentJobs(trajectRef, { interval = DEFAULT_INTERVAL
     // close/reopen can't let a stale in-flight response repopulate the list
     // after `reset()` cleared it.
     await refresh();
+    // Unmounted during the await → don't arm an orphan interval.
+    if (!mounted) return;
     timer = setInterval(refresh, interval);
   }
 
@@ -71,7 +76,10 @@ export function useTrajectDocumentJobs(trajectRef, { interval = DEFAULT_INTERVAL
     error.value = null;
   }
 
-  onUnmounted(stopPolling);
+  onUnmounted(() => {
+    mounted = false;
+    stopPolling();
+  });
 
   return { jobs, loading, error, refresh, startPolling, stopPolling, reset };
 }

--- a/frontend/src/composables/useTrajectDocumentJobs.js
+++ b/frontend/src/composables/useTrajectDocumentJobs.js
@@ -1,0 +1,71 @@
+/**
+ * useTrajectDocumentJobs — poll a traject's document-conversion jobs (running +
+ * failed) for the werkdocumenten conversion-status block.
+ *
+ * Mirrors the harvester `usePollingFetch` pattern (initial-load-only `loading`,
+ * keep-stale on poll failure, auto-stop on unmount) but for the `{ jobs: [...] }`
+ * response shape of `GET .../corpus/documents/jobs`. The consumer starts polling
+ * when its surface opens and stops when it closes.
+ */
+import { ref, onUnmounted } from 'vue';
+import { apiFetch } from '@regelrecht/frontend-shared';
+import { documentJobsUrl } from './corpusUrls.js';
+
+const DEFAULT_INTERVAL_MS = 4000;
+
+export function useTrajectDocumentJobs(trajectRef, { interval = DEFAULT_INTERVAL_MS } = {}) {
+  const jobs = ref([]);
+  const loading = ref(false);
+  const error = ref(null);
+
+  let timer = null;
+  let initialLoad = true;
+
+  async function refresh() {
+    const ref_ = trajectRef.value;
+    if (!ref_) {
+      jobs.value = [];
+      return;
+    }
+    if (initialLoad) loading.value = true;
+    try {
+      // 401 handled by the global apiAuthGuard (redirect); return early so we
+      // don't flash an error before it fires.
+      const res = await apiFetch(documentJobsUrl(ref_), { allowStatuses: [401] });
+      if (res.status === 401) return;
+      const json = await res.json();
+      jobs.value = Array.isArray(json?.jobs) ? json.jobs : [];
+      error.value = null;
+    } catch (e) {
+      // Keep stale jobs on a poll failure; only clear on the very first load.
+      if (initialLoad) jobs.value = [];
+      error.value = e;
+    } finally {
+      loading.value = false;
+      initialLoad = false;
+    }
+  }
+
+  function startPolling() {
+    stopPolling();
+    refresh();
+    timer = setInterval(refresh, interval);
+  }
+
+  function stopPolling() {
+    if (timer) {
+      clearInterval(timer);
+      timer = null;
+    }
+  }
+
+  function reset() {
+    initialLoad = true;
+    jobs.value = [];
+    error.value = null;
+  }
+
+  onUnmounted(stopPolling);
+
+  return { jobs, loading, error, refresh, startPolling, stopPolling, reset };
+}

--- a/frontend/src/composables/useTrajectDocumentJobs.js
+++ b/frontend/src/composables/useTrajectDocumentJobs.js
@@ -46,12 +46,15 @@ export function useTrajectDocumentJobs(trajectRef, { interval = DEFAULT_INTERVAL
     }
   }
 
-  function startPolling() {
+  async function startPolling() {
     stopPolling();
     // Fresh start: drop any jobs from a previous traject and re-arm the
     // initial-load flag so `loading` reflects this (re)start, not a stale run.
     reset();
-    refresh();
+    // Await the first fetch before arming the interval so a rapid
+    // close/reopen can't let a stale in-flight response repopulate the list
+    // after `reset()` cleared it.
+    await refresh();
     timer = setInterval(refresh, interval);
   }
 

--- a/frontend/src/composables/useTrajectDocuments.js
+++ b/frontend/src/composables/useTrajectDocuments.js
@@ -356,8 +356,9 @@ export function useTrajectDocuments(trajectRef) {
       });
       if (!res.ok) {
         const text = await safeText(res);
-        saveError.value = new Error(text || `Uploaden mislukt: ${res.status}`);
-        return { ok: false };
+        const err = new Error(text || `Uploaden mislukt: ${res.status}`);
+        saveError.value = err;
+        return { ok: false, error: err.message };
       }
       const json = await safeJson(res);
       // Refresh the list so the poller (and, once converted, the .md) show up.
@@ -365,7 +366,7 @@ export function useTrajectDocuments(trajectRef) {
       return { ok: true, targetPath: json?.target_path ?? null };
     } catch (e) {
       saveError.value = e;
-      return { ok: false };
+      return { ok: false, error: e.message };
     }
   }
 

--- a/frontend/src/composables/useTrajectDocuments.js
+++ b/frontend/src/composables/useTrajectDocuments.js
@@ -17,6 +17,7 @@ import { ref, watch } from 'vue';
 import {
   documentsListUrl,
   documentFileUrl,
+  documentUploadUrl,
   requireTraject,
 } from './corpusUrls.js';
 import { apiFetchJson } from '../lib/apiFetch.js';
@@ -335,6 +336,39 @@ export function useTrajectDocuments(trajectRef) {
     return result;
   }
 
+  /**
+   * Upload a PDF/Word document. Stores the bytes server-side and enqueues an
+   * async conversion-to-markdown job; the resulting `.md` appears in the list
+   * once the job completes (surfaced meanwhile by the conversion-status
+   * poller). Returns a result object `{ ok, targetPath }`.
+   */
+  async function uploadDocument(file) {
+    requireTraject(trajectRef.value, 'document upload');
+    saveError.value = null;
+    const form = new FormData();
+    form.append('file', file);
+    try {
+      // Raw fetch, result-object style like `saveCurrent`. Do NOT set
+      // Content-Type — the browser adds the multipart boundary itself.
+      const res = await fetch(documentUploadUrl(trajectRef.value), {
+        method: 'POST',
+        body: form,
+      });
+      if (!res.ok) {
+        const text = await safeText(res);
+        saveError.value = new Error(text || `Uploaden mislukt: ${res.status}`);
+        return { ok: false };
+      }
+      const json = await safeJson(res);
+      // Refresh the list so the poller (and, once converted, the .md) show up.
+      await fetchList();
+      return { ok: true, targetPath: json?.target_path ?? null };
+    } catch (e) {
+      saveError.value = e;
+      return { ok: false };
+    }
+  }
+
   async function deleteDocument(path) {
     requireTraject(trajectRef.value, 'document delete');
     // Same reasoning as in `saveCurrent`: if the doc being deleted is
@@ -463,6 +497,7 @@ export function useTrajectDocuments(trajectRef) {
     saveCurrent,
     reloadCurrent,
     createDocument,
+    uploadDocument,
     deleteDocument,
     dropDraft,
   };

--- a/frontend/src/composables/useTrajectDocuments.test.js
+++ b/frontend/src/composables/useTrajectDocuments.test.js
@@ -46,6 +46,36 @@ describe('useTrajectDocuments', () => {
     ]);
   });
 
+  it('uploads a document as multipart and refreshes the list', async () => {
+    const calls = [];
+    globalThis.fetch = vi.fn().mockImplementation(async (url, opts) => {
+      calls.push({ url, opts: opts ?? {} });
+      if (opts?.method === 'POST') {
+        return res({ status: 202, json: { target_path: 'rapport.md' } });
+      }
+      return res({ json: { documents: [] } });
+    });
+
+    const trajectRef = ref('mig-1a2b3c4d');
+    const { uploadDocument } = useTrajectDocuments(trajectRef);
+    const file = new File([new Uint8Array([1, 2, 3])], 'Rapport.pdf', {
+      type: 'application/pdf',
+    });
+    const result = await uploadDocument(file);
+
+    expect(result).toEqual({ ok: true, targetPath: 'rapport.md' });
+    const post = calls.find((c) => c.opts.method === 'POST');
+    expect(post.url).toBe('/api/trajects/mig-1a2b3c4d/corpus/documents/upload');
+    expect(post.opts.body).toBeInstanceOf(FormData);
+    expect(post.opts.body.get('file')).toBeInstanceOf(File);
+    // Content-Type must NOT be set — the browser adds the multipart boundary.
+    expect(post.opts.headers).toBeUndefined();
+    // A successful upload refreshes the document list (GET after the POST).
+    expect(
+      calls.some((c) => c.url.endsWith('/corpus/documents') && c.opts.method !== 'POST'),
+    ).toBe(true);
+  });
+
   it('captures the ETag on open and sends it back as If-Match on save', async () => {
     const trajectRef = ref('mig-1a2b3c4d');
     // 1st call: openDocument GET.

--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -273,6 +273,7 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
@@ -2654,6 +2655,23 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
 ]
 
 [[package]]

--- a/packages/editor-api/Cargo.toml
+++ b/packages/editor-api/Cargo.toml
@@ -16,7 +16,7 @@ name = "regelrecht-editor-api"
 path = "src/main.rs"
 
 [dependencies]
-axum.workspace = true
+axum = { workspace = true, features = ["multipart"] }
 regelrecht-auth = { path = "../auth" }
 regelrecht-shared = { path = "../shared", features = ["telemetry"] }
 regelrecht-corpus = { path = "../corpus", features = ["github", "annotation-validation"] }

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -2607,11 +2607,19 @@ pub async fn upload_traject_document(
     // Derive a collision-safe target markdown path against the existing docs.
     let backend = resolve_traject_documents_writer(&traject).await?;
     let base = traject_documents_base(&traject_ref);
-    let existing: Vec<String> = backend
+    let mut existing: Vec<String> = backend
         .list_files_recursive(&base, None)
         .await
         .map(|entries| entries.into_iter().map(|e| e.relative_path).collect())
         .unwrap_or_default();
+    // Also avoid colliding with conversions that are enqueued but haven't
+    // committed their `.md` yet — otherwise two same-named uploads both derive
+    // e.g. `report.md` and the second conversion overwrites the first.
+    existing.extend(
+        regelrecht_pipeline::document_convert::pending_target_paths(pool, &traject_ref)
+            .await
+            .unwrap_or_default(),
+    );
     let target_path = derive_markdown_target(&filename, &existing);
 
     // Persist the bytes and enqueue the conversion job in one transaction.

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -2653,6 +2653,12 @@ pub async fn upload_traject_document(
         format!("doc:{traject_ref}/{target_path}"),
     )
     .with_traject_ref(traject_ref.clone())
+    // Single attempt: a retry would re-run the (expensive) LLM conversion from
+    // scratch, and most failures here are deterministic (bad content, write
+    // config). A failed conversion stays visible in the status block for the
+    // user to re-upload. (Caching the produced markdown across retries is a
+    // possible future refinement.)
+    .with_max_attempts(1)
     .with_payload(payload_json);
     regelrecht_pipeline::job_queue::create_job(&mut *tx, req)
         .await

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -2512,16 +2512,25 @@ fn derive_markdown_target(filename: &str, existing: &[String]) -> String {
         .and_then(|s| s.to_str())
         .unwrap_or("document");
     let mut sanitized = String::with_capacity(raw_stem.len());
-    let mut prev_dash = false;
+    let mut last: Option<char> = None;
     for ch in raw_stem.chars() {
         let c = ch.to_ascii_lowercase();
-        if c.is_ascii_alphanumeric() || c == '.' || c == '_' || c == '-' {
-            sanitized.push(c);
-            prev_dash = false;
-        } else if !prev_dash {
-            sanitized.push('-');
-            prev_dash = true;
+        // Map to the allowed alphabet: alphanumerics and `_` pass through, any
+        // other character becomes a `-`. `.` is kept (extensions read naturally).
+        let mapped = if c.is_ascii_alphanumeric() || c == '_' {
+            c
+        } else if c == '.' {
+            '.'
+        } else {
+            '-'
+        };
+        // Collapse consecutive separators so a run of spaces or dots (e.g.
+        // `rapport..2024`) reduces to a single `-`/`.` rather than repeating.
+        if (mapped == '-' || mapped == '.') && last == Some(mapped) {
+            continue;
         }
+        sanitized.push(mapped);
+        last = Some(mapped);
     }
     let trimmed = sanitized.trim_matches(|c| c == '-' || c == '.');
     let stem = if trimmed.is_empty() {
@@ -3144,6 +3153,20 @@ mod tests {
             derive_markdown_target("report.pdf", &existing),
             "report-3.md"
         );
+    }
+
+    #[test]
+    fn derive_markdown_target_collapses_consecutive_separators() {
+        // Consecutive dots and spaces collapse to a single separator.
+        assert_eq!(
+            derive_markdown_target("rapport..2024.pdf", &[]),
+            "rapport.2024.md"
+        );
+        assert_eq!(
+            derive_markdown_target("mijn   brief.docx", &[]),
+            "mijn-brief.md"
+        );
+        assert!(validate_document_path(&derive_markdown_target("a...b   c.doc", &[])).is_ok());
     }
 
     #[test]

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use axum::extract::{Path, Query, State};
+use axum::extract::{Multipart, Path, Query, State};
 use axum::http::StatusCode;
 use axum::{Extension, Json};
 use serde::{Deserialize, Serialize};
@@ -2477,6 +2477,211 @@ pub async fn list_traject_documents(
     Ok(Json(TrajectDocumentList { documents }))
 }
 
+/// Upload formats accepted in fase 1: PDF and Word.
+const UPLOAD_DOCUMENT_EXTENSIONS: &[&str] = &["pdf", "doc", "docx"];
+
+#[derive(Debug, Serialize)]
+pub struct UploadDocumentResponse {
+    /// The `.md` path the converted document will appear at once its
+    /// conversion job completes.
+    pub target_path: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TrajectJobList {
+    pub jobs: Vec<regelrecht_pipeline::document_convert::TrajectJobView>,
+}
+
+/// Uniform 500 for the upload/jobs endpoints — logs the real cause, returns a
+/// generic Dutch message.
+fn upload_internal_error(context: &str, e: impl std::fmt::Display) -> (StatusCode, String) {
+    tracing::error!(error = %e, context, "document upload/jobs handler failed");
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "Er ging iets mis bij het verwerken van de upload.".to_string(),
+    )
+}
+
+/// Derive a collision-safe `<name>.md` target path from an uploaded filename,
+/// sanitized to the document-path rules (`[a-z0-9._-]`, no hidden/empty
+/// segments). Appends `-2`, `-3`, … when a document with the derived name
+/// already exists in the traject.
+fn derive_markdown_target(filename: &str, existing: &[String]) -> String {
+    let raw_stem = std::path::Path::new(filename)
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("document");
+    let mut sanitized = String::with_capacity(raw_stem.len());
+    let mut prev_dash = false;
+    for ch in raw_stem.chars() {
+        let c = ch.to_ascii_lowercase();
+        if c.is_ascii_alphanumeric() || c == '.' || c == '_' || c == '-' {
+            sanitized.push(c);
+            prev_dash = false;
+        } else if !prev_dash {
+            sanitized.push('-');
+            prev_dash = true;
+        }
+    }
+    let trimmed = sanitized.trim_matches(|c| c == '-' || c == '.');
+    let stem = if trimmed.is_empty() {
+        "document"
+    } else {
+        trimmed
+    };
+
+    let mut candidate = format!("{stem}.md");
+    let mut n = 2;
+    while existing.iter().any(|p| p == &candidate) {
+        candidate = format!("{stem}-{n}.md");
+        n += 1;
+    }
+    candidate
+}
+
+/// POST /api/trajects/{traject_ref}/corpus/documents/upload
+///
+/// Accept a multipart upload of a PDF/Word document, store its bytes in
+/// `document_uploads`, and enqueue a `document_convert` job that converts it to
+/// a markdown werkdocument. Responds `202 Accepted` with the target `.md` path
+/// the converted document will appear at.
+pub async fn upload_traject_document(
+    State(state): State<AppState>,
+    session: Session,
+    Path(traject_ref): Path<String>,
+    mut multipart: Multipart,
+) -> Result<(StatusCode, Json<UploadDocumentResponse>), (StatusCode, String)> {
+    let pool = state.pool.as_ref().ok_or((
+        StatusCode::SERVICE_UNAVAILABLE,
+        "database not configured".to_string(),
+    ))?;
+    // Membership guard (also resolves the traject); the id feeds the job payload.
+    let traject = require_traject_corpus_from_ref(&state, &session, &traject_ref).await?;
+    let traject_id = resolve_traject_ref(pool, &traject_ref).await?;
+
+    // Pull the uploaded file out of the multipart body (the `file` field).
+    let mut filename: Option<String> = None;
+    let mut content_type: Option<String> = None;
+    let mut data: Option<Vec<u8>> = None;
+    while let Some(field) = multipart
+        .next_field()
+        .await
+        .map_err(|e| (StatusCode::BAD_REQUEST, format!("Ongeldige upload: {e}")))?
+    {
+        if field.name() == Some("file") {
+            filename = field.file_name().map(|s| s.to_string());
+            content_type = field.content_type().map(|s| s.to_string());
+            let bytes = field.bytes().await.map_err(|e| {
+                (
+                    StatusCode::BAD_REQUEST,
+                    format!("Kon het bestand niet lezen: {e}"),
+                )
+            })?;
+            data = Some(bytes.to_vec());
+            break;
+        }
+    }
+    let filename = filename.ok_or((
+        StatusCode::BAD_REQUEST,
+        "Geen bestand in de upload (het 'file'-veld ontbreekt).".to_string(),
+    ))?;
+    let data = data.filter(|d| !d.is_empty()).ok_or((
+        StatusCode::BAD_REQUEST,
+        "Het geüploade bestand is leeg.".to_string(),
+    ))?;
+    let content_type = content_type.unwrap_or_else(|| "application/octet-stream".to_string());
+
+    // Only PDF/Word in fase 1.
+    let ext = std::path::Path::new(&filename)
+        .extension()
+        .and_then(|s| s.to_str())
+        .map(|e| e.to_ascii_lowercase())
+        .unwrap_or_default();
+    if !UPLOAD_DOCUMENT_EXTENSIONS.contains(&ext.as_str()) {
+        return Err((
+            StatusCode::UNSUPPORTED_MEDIA_TYPE,
+            "Alleen PDF- en Word-documenten (.pdf, .doc, .docx) worden ondersteund.".to_string(),
+        ));
+    }
+
+    // Derive a collision-safe target markdown path against the existing docs.
+    let backend = resolve_traject_documents_writer(&traject).await?;
+    let base = traject_documents_base(&traject_ref);
+    let existing: Vec<String> = backend
+        .list_files_recursive(&base, None)
+        .await
+        .map(|entries| entries.into_iter().map(|e| e.relative_path).collect())
+        .unwrap_or_default();
+    let target_path = derive_markdown_target(&filename, &existing);
+
+    // Persist the bytes and enqueue the conversion job in one transaction.
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| upload_internal_error("begin tx", e))?;
+    let (upload_id,): (uuid::Uuid,) = sqlx::query_as(
+        "INSERT INTO document_uploads (traject_ref, filename, content_type, bytes) \
+         VALUES ($1, $2, $3, $4) RETURNING id",
+    )
+    .bind(&traject_ref)
+    .bind(&filename)
+    .bind(&content_type)
+    .bind(&data)
+    .fetch_one(&mut *tx)
+    .await
+    .map_err(|e| upload_internal_error("insert upload", e))?;
+
+    let payload = regelrecht_pipeline::document_convert::DocumentConvertPayload {
+        upload_id,
+        traject_id,
+        traject_ref: traject_ref.clone(),
+        target_path: target_path.clone(),
+        provider: None,
+    };
+    let payload_json = serde_json::to_value(&payload)
+        .map_err(|e| upload_internal_error("serialize payload", e))?;
+    let req = regelrecht_pipeline::job_queue::CreateJobRequest::new(
+        regelrecht_pipeline::JobType::DocumentConvert,
+        format!("doc:{traject_ref}/{target_path}"),
+    )
+    .with_traject_ref(traject_ref.clone())
+    .with_payload(payload_json);
+    regelrecht_pipeline::job_queue::create_job(&mut *tx, req)
+        .await
+        .map_err(|e| upload_internal_error("create job", e))?;
+    tx.commit()
+        .await
+        .map_err(|e| upload_internal_error("commit tx", e))?;
+
+    Ok((
+        StatusCode::ACCEPTED,
+        Json(UploadDocumentResponse { target_path }),
+    ))
+}
+
+/// GET /api/trajects/{traject_ref}/corpus/documents/jobs
+///
+/// List the traject's document-convert jobs that are still relevant to show
+/// (running or failed — completed ones are represented by the actual `.md` in
+/// the documents list). Backs the werkdocumenten conversion-status block.
+pub async fn list_traject_document_convert_jobs(
+    State(state): State<AppState>,
+    session: Session,
+    Path(traject_ref): Path<String>,
+) -> Result<Json<TrajectJobList>, (StatusCode, String)> {
+    let pool = state.pool.as_ref().ok_or((
+        StatusCode::SERVICE_UNAVAILABLE,
+        "database not configured".to_string(),
+    ))?;
+    // Membership guard.
+    require_traject_corpus_from_ref(&state, &session, &traject_ref).await?;
+    let jobs =
+        regelrecht_pipeline::document_convert::list_traject_document_jobs(pool, &traject_ref)
+            .await
+            .map_err(|e| upload_internal_error("list document jobs", e))?;
+    Ok(Json(TrajectJobList { jobs }))
+}
+
 /// GET /api/trajects/{traject_ref}/corpus/documents/{*doc_path}
 ///
 /// Returns the raw markdown/text body, an appropriate `Content-Type`,
@@ -2884,6 +3089,32 @@ mod tests {
         assert!(validate_document_path("").is_err());
         assert!(validate_document_path("/").is_err());
         assert!(validate_document_path("a//b.md").is_err());
+    }
+
+    #[test]
+    fn derive_markdown_target_sanitizes_and_appends_md() {
+        assert_eq!(derive_markdown_target("Report.pdf", &[]), "report.md");
+        assert_eq!(
+            derive_markdown_target("Mijn Brief.docx", &[]),
+            "mijn-brief.md"
+        );
+        // Every derived target must satisfy the document-path rules.
+        assert!(validate_document_path(&derive_markdown_target("Béépje 2024!.doc", &[])).is_ok());
+    }
+
+    #[test]
+    fn derive_markdown_target_falls_back_when_stem_empty() {
+        let target = derive_markdown_target("...pdf", &[]);
+        assert!(validate_document_path(&target).is_ok());
+    }
+
+    #[test]
+    fn derive_markdown_target_resolves_collisions() {
+        let existing = vec!["report.md".to_string(), "report-2.md".to_string()];
+        assert_eq!(
+            derive_markdown_target("report.pdf", &existing),
+            "report-3.md"
+        );
     }
 
     #[test]

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -2605,20 +2605,35 @@ pub async fn upload_traject_document(
     }
 
     // Derive a collision-safe target markdown path against the existing docs.
+    // A failed listing must NOT be swallowed: an empty `existing` set would let
+    // the derivation hand back a name that already exists, and the worker's
+    // unconditional write would silently overwrite that document. Fail the
+    // upload instead.
     let backend = resolve_traject_documents_writer(&traject).await?;
     let base = traject_documents_base(&traject_ref);
     let mut existing: Vec<String> = backend
         .list_files_recursive(&base, None)
         .await
-        .map(|entries| entries.into_iter().map(|e| e.relative_path).collect())
-        .unwrap_or_default();
+        .map_err(|e| upload_internal_error("list documents for collision check", e))?
+        .into_iter()
+        .map(|e| e.relative_path)
+        .collect();
+    // Release the writable-backend lock before the DB work below — the backend
+    // is only needed for the listing, and holding its mutex through the
+    // transaction would serialize every writable-document op on this traject.
+    drop(backend);
     // Also avoid colliding with conversions that are enqueued but haven't
     // committed their `.md` yet — otherwise two same-named uploads both derive
-    // e.g. `report.md` and the second conversion overwrites the first.
+    // e.g. `report.md` and the second conversion overwrites the first. (This
+    // narrows but does not fully close a concurrent-upload window: two requests
+    // can both read the pending set before either commits its job — an
+    // acceptable residual TOCTOU for same-traject same-name simultaneous uploads.)
     existing.extend(
         regelrecht_pipeline::document_convert::pending_target_paths(pool, &traject_ref)
             .await
-            .unwrap_or_default(),
+            .map_err(|e| {
+                upload_internal_error("list pending conversions for collision check", e)
+            })?,
     );
     let target_path = derive_markdown_target(&filename, &existing);
 

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -195,6 +195,10 @@ async fn main() {
     // Twice the 64 KiB note-value cap (user_notes::MAX_BODY_VALUE_BYTES):
     // room for JSON escaping/overhead while still rejecting blobs early.
     const MAX_NOTE_BODY: usize = 128 * 1024;
+    // Uploaded PDF/Word documents (converted to markdown async). Much larger
+    // than the text caps since it carries a binary; still bounded to reject
+    // oversized files early (Postgres stores the bytes transiently).
+    const MAX_UPLOAD_BODY: usize = 25 * 1024 * 1024;
 
     // Reader routes — `editor-reader` covers user-scoped reads (favorites,
     // settings) and harvest search (search is behind auth because it triggers
@@ -378,6 +382,10 @@ async fn main() {
             get(corpus_handlers::list_traject_documents),
         )
         .route(
+            "/api/trajects/{traject_ref}/corpus/documents/jobs",
+            get(corpus_handlers::list_traject_document_convert_jobs),
+        )
+        .route(
             "/api/trajects/{traject_ref}/corpus/documents/{*doc_path}",
             get(corpus_handlers::get_traject_document),
         )
@@ -434,6 +442,11 @@ async fn main() {
             "/api/trajects/{traject_ref}/corpus/laws/{law_id}",
             axum::routing::put(corpus_handlers::save_law)
                 .layer(axum::extract::DefaultBodyLimit::max(MAX_LAW_BODY)),
+        )
+        .route(
+            "/api/trajects/{traject_ref}/corpus/documents/upload",
+            axum::routing::post(corpus_handlers::upload_traject_document)
+                .layer(axum::extract::DefaultBodyLimit::max(MAX_UPLOAD_BODY)),
         )
         .route(
             "/api/trajects/{traject_ref}/corpus/documents/{*doc_path}",

--- a/packages/pipeline/Dockerfile
+++ b/packages/pipeline/Dockerfile
@@ -98,7 +98,13 @@ ENTRYPOINT ["/sbin/tini", "--", "entrypoint.sh"]
 # which orphans its child processes — without an init those accumulate against
 # the container's low pids limit and eventually cause fork()/EAGAIN failures.
 FROM runtime-base AS enrich-worker
-RUN apk add --no-cache git nodejs npm tini
+# `pandoc-cli` (docx/html/…) and `poppler-utils` (pdftotext) give the
+# document-convert agent real, pre-installed converters. Without them the agent's
+# only route on this network-restricted Alpine image is to install a tool at
+# runtime (e.g. `pip install pypandoc-binary`) — but there is no pip/python here
+# and egress is locked down, so it flails and produces no output. Baking the
+# tools in makes docx/PDF conversion deterministic and needs no runtime egress.
+RUN apk add --no-cache git nodejs npm tini pandoc-cli poppler-utils
 
 # Install opencode and claude CLI globally (pinned versions for reproducibility)
 RUN npm install -g --ignore-scripts opencode-ai@1.2.25 @anthropic-ai/claude-code@2.1.74 && \

--- a/packages/pipeline/migrations/0025_document_convert_job_type.sql
+++ b/packages/pipeline/migrations/0025_document_convert_job_type.sql
@@ -1,8 +1,10 @@
+-- no-transaction
 -- Add the `document_convert` job type: an uploaded PDF/Word document is
 -- converted to markdown by the LLM agent (same subprocess machinery as
 -- enrich) and written back as a `.md` werkdocument in the traject.
 --
--- ALTER TYPE ... ADD VALUE cannot run in a transaction together with a
--- statement that *uses* the new value, so this lives in its own migration
--- file, ahead of any migration/code that references 'document_convert'.
+-- `ALTER TYPE ... ADD VALUE` cannot run inside a transaction block (Postgres
+-- error 25001), so this migration is marked `-- no-transaction` (must be the
+-- first line — sqlx reads that directive) and lives in its own file, ahead of
+-- any migration/code that references 'document_convert'.
 ALTER TYPE job_type ADD VALUE IF NOT EXISTS 'document_convert';

--- a/packages/pipeline/migrations/0025_document_convert_job_type.sql
+++ b/packages/pipeline/migrations/0025_document_convert_job_type.sql
@@ -1,0 +1,8 @@
+-- Add the `document_convert` job type: an uploaded PDF/Word document is
+-- converted to markdown by the LLM agent (same subprocess machinery as
+-- enrich) and written back as a `.md` werkdocument in the traject.
+--
+-- ALTER TYPE ... ADD VALUE cannot run in a transaction together with a
+-- statement that *uses* the new value, so this lives in its own migration
+-- file, ahead of any migration/code that references 'document_convert'.
+ALTER TYPE job_type ADD VALUE IF NOT EXISTS 'document_convert';

--- a/packages/pipeline/migrations/0026_jobs_traject_ref.sql
+++ b/packages/pipeline/migrations/0026_jobs_traject_ref.sql
@@ -1,0 +1,10 @@
+-- Generic job<->traject association. Nullable because the existing
+-- corpus-wide harvest/enrich jobs have no owning traject; only jobs that are
+-- scoped to a single traject (starting with document_convert) set it. This is
+-- the shared foundation that per-traject harvest/enrich will also build on.
+ALTER TABLE jobs ADD COLUMN traject_ref TEXT;
+
+-- Partial index: the werkdocumenten status query filters jobs by traject_ref;
+-- the vast majority of rows (harvest/enrich) have it NULL, so index only the
+-- populated ones.
+CREATE INDEX idx_jobs_traject ON jobs (traject_ref) WHERE traject_ref IS NOT NULL;

--- a/packages/pipeline/migrations/0027_document_uploads.sql
+++ b/packages/pipeline/migrations/0027_document_uploads.sql
@@ -1,0 +1,18 @@
+-- Transient storage for the raw bytes of an uploaded document (PDF/Word)
+-- while a `document_convert` job converts it to markdown. ZAD offers no
+-- object/blob storage service, so the binary rides in Postgres (bytea, under
+-- an app-enforced size cap). Rows are short-lived: the worker deletes the row
+-- after a successful conversion or a terminal failure, so the table never
+-- accumulates large blobs.
+--
+-- The owning job references the upload via `payload->>'upload_id'`; there is
+-- deliberately no FK back to `jobs` (the job is created in the same request,
+-- and the row is cleaned up by the worker, not by cascade).
+CREATE TABLE document_uploads (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    traject_ref   TEXT        NOT NULL,
+    filename      TEXT        NOT NULL,
+    content_type  TEXT        NOT NULL,
+    bytes         BYTEA       NOT NULL,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/packages/pipeline/src/document_convert.rs
+++ b/packages/pipeline/src/document_convert.rs
@@ -224,6 +224,28 @@ pub async fn list_traject_document_jobs(
     Ok(rows)
 }
 
+/// Target `.md` paths of the traject's still-pending/processing document-convert
+/// jobs. Used by the upload handler to make the derived target collision-safe
+/// against conversions that are enqueued but haven't committed their `.md` yet —
+/// without this, two uploads that derive the same name (e.g. two `report.pdf`)
+/// would both target `report.md` and the second conversion would overwrite the
+/// first once both commit.
+pub async fn pending_target_paths(pool: &PgPool, traject_ref: &str) -> Result<Vec<String>> {
+    let rows = sqlx::query_as::<_, (Option<String>,)>(
+        r#"
+        SELECT payload->>'target_path'
+        FROM jobs
+        WHERE traject_ref = $1
+          AND job_type = 'document_convert'
+          AND status IN ('pending', 'processing')
+        "#,
+    )
+    .bind(traject_ref)
+    .fetch_all(pool)
+    .await?;
+    Ok(rows.into_iter().filter_map(|(p,)| p).collect())
+}
+
 /// Abstraction over the actual document→markdown conversion so the orchestration
 /// can be unit-tested without spawning a real LLM subprocess (mirrors the
 /// [`crate::enrich::LlmRunner`] seam).

--- a/packages/pipeline/src/document_convert.rs
+++ b/packages/pipeline/src/document_convert.rs
@@ -78,6 +78,33 @@ pub async fn delete_upload(pool: &PgPool, upload_id: Uuid) -> Result<()> {
     Ok(())
 }
 
+/// Delete upload rows no longer referenced by an active (`pending`/`processing`)
+/// document_convert job. This garbage-collects bytes orphaned when a worker
+/// crashed mid-conversion and the generic orphan reaper failed the job without
+/// running the type-specific [`delete_upload`]. Returns the number of rows
+/// removed.
+///
+/// Safe because editor-api inserts the upload row and its job in a single
+/// transaction, so a row with no active job is genuinely orphaned — the short
+/// age grace is only belt-and-suspenders against clock/visibility skew.
+pub async fn cleanup_orphaned_uploads(pool: &PgPool) -> Result<u64> {
+    let result = sqlx::query(
+        r#"
+        DELETE FROM document_uploads du
+        WHERE du.created_at < now() - interval '15 minutes'
+          AND NOT EXISTS (
+              SELECT 1 FROM jobs j
+              WHERE j.job_type = 'document_convert'
+                AND j.status IN ('pending', 'processing')
+                AND j.payload->>'upload_id' = du.id::text
+          )
+        "#,
+    )
+    .execute(pool)
+    .await?;
+    Ok(result.rows_affected())
+}
+
 /// Row for a traject's writable-own corpus source, from `traject_corpus_sources`.
 #[derive(sqlx::FromRow)]
 struct WritableOwnSourceRow {
@@ -134,6 +161,10 @@ async fn load_writable_own_source(pool: &PgPool, traject_id: Uuid) -> Result<Sou
                priority, auth_ref
         FROM traject_corpus_sources
         WHERE traject_id = $1 AND is_writable_own = TRUE
+        -- A partial unique index already guarantees at most one such row per
+        -- traject; the deterministic order + LIMIT is defensive belt-and-braces.
+        ORDER BY priority DESC, source_id
+        LIMIT 1
         "#,
     )
     .bind(traject_id)

--- a/packages/pipeline/src/document_convert.rs
+++ b/packages/pipeline/src/document_convert.rs
@@ -165,6 +165,19 @@ pub async fn write_markdown_to_traject(
     let auth_key = source.auth_ref.clone().unwrap_or_else(|| source.id.clone());
     let token = regelrecht_corpus::auth::resolve_token_strict(&auth_key, None)?;
 
+    // A GitHub source with no push token would only commit into the worker's
+    // throwaway checkout (GitBackend goes local-only) and never reach the
+    // traject — silent data loss. Fail loudly instead, so the failure is visible
+    // in the werkdocumenten status block and the ops fix (set the token) is
+    // obvious. Local sources need no token (the local write IS the persistence).
+    if token.is_none() && matches!(source.source_type, SourceType::GitHub { .. }) {
+        return Err(PipelineError::Enrich(format!(
+            "no push token for traject source '{auth_key}' (expected env {}); the converted \
+             document cannot be persisted to the traject repository",
+            regelrecht_corpus::auth::token_env_name(&auth_key),
+        )));
+    }
+
     let mut backend = create_backend(&source, token.as_deref())?;
     backend.ensure_ready().await?;
 

--- a/packages/pipeline/src/document_convert.rs
+++ b/packages/pipeline/src/document_convert.rs
@@ -230,6 +230,10 @@ pub async fn list_traject_document_jobs(
           AND job_type = 'document_convert'
           AND status <> 'completed'
         ORDER BY created_at DESC
+        -- Bound the result: failed jobs are not auto-cleaned (phase 1), so a
+        -- traject with many failed uploads would otherwise grow this list (and
+        -- the status block that renders every row) without limit.
+        LIMIT 100
         "#,
     )
     .bind(traject_ref)

--- a/packages/pipeline/src/document_convert.rs
+++ b/packages/pipeline/src/document_convert.rs
@@ -360,9 +360,11 @@ fn build_convert_prompt(input_file: &Path, output_path: &Path) -> String {
          The document is the file `{input}` in your current working directory.\n\n\
          Do the following:\n\
          1. Inspect `{input}` and determine its format (for example PDF or Word).\n\
-         2. Decide on and carry out the best way to convert it to Markdown. You may use \
-            any command-line tool you consider suitable — and install one if needed \
-            (for example via `pip install --user`) — or read the document yourself and \
+         2. Decide on and carry out the best way to convert it to Markdown. The tools \
+            `pandoc` (Word/HTML/… → Markdown, e.g. `pandoc {input} -t gfm --wrap=none -o {output}`) \
+            and `pdftotext` (PDF → text) are already installed — prefer them. Do NOT rely on \
+            network access: this environment has no internet egress, so do not try to install \
+            packages (e.g. via `pip`). If no tool fits, read the document yourself and \
             transcribe it. Choose whatever yields the most faithful result.\n\
          3. Produce clean, well-structured GitHub-flavored Markdown that preserves the \
             document's headings, lists, tables and paragraph structure. Do NOT summarize, \

--- a/packages/pipeline/src/document_convert.rs
+++ b/packages/pipeline/src/document_convert.rs
@@ -1,0 +1,509 @@
+//! Document-convert jobs: turn an uploaded PDF/Word document into a clean
+//! markdown werkdocument.
+//!
+//! The heavy lifting is done by the same LLM agent subprocess that enrich uses
+//! (see [`crate::enrich::run_llm_subprocess`]); the agent decides for itself how
+//! to convert the document (pick/install a tool, or read it directly). This
+//! module owns the payload type, the transient upload storage helpers, the
+//! status-list query for the editor, and the conversion orchestration. The
+//! worker (see `worker.rs`) drives it and writes the produced markdown back to
+//! the traject's git corpus.
+
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use regelrecht_corpus::backend::{create_backend, WriteContext};
+use regelrecht_corpus::models::{GitHubSource, LocalSource, Source, SourceType};
+
+use crate::enrich::{run_llm_subprocess, EnrichConfig};
+use crate::error::{PipelineError, Result};
+use crate::models::JobStatus;
+
+/// Payload carried by a `document_convert` job. The raw bytes live in
+/// `document_uploads` (referenced by `upload_id`), not in the job payload.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DocumentConvertPayload {
+    /// Row id in `document_uploads` holding the uploaded bytes.
+    pub upload_id: Uuid,
+    /// Owning traject's id — used by the worker to look up the writable-own
+    /// corpus source directly (no ref-parsing round-trip).
+    pub traject_id: Uuid,
+    /// Owning traject ref (also mirrored onto `jobs.traject_ref`); used to build
+    /// the `documents/<traject_ref>/…` write path and for the status UI.
+    pub traject_ref: String,
+    /// Target werkdocument path, relative to `documents/<traject_ref>/`,
+    /// e.g. `"report.md"`. Already sanitized + collision-resolved by the
+    /// editor-api upload handler.
+    pub target_path: String,
+    /// LLM provider override (`"claude"` / `"opencode"`); `None` uses the
+    /// worker default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
+}
+
+/// An uploaded document loaded from `document_uploads`.
+pub struct Upload {
+    pub filename: String,
+    pub content_type: String,
+    pub bytes: Vec<u8>,
+}
+
+/// Load the raw bytes of an uploaded document.
+pub async fn load_upload(pool: &PgPool, upload_id: Uuid) -> Result<Upload> {
+    let row = sqlx::query_as::<_, (String, String, Vec<u8>)>(
+        "SELECT filename, content_type, bytes FROM document_uploads WHERE id = $1",
+    )
+    .bind(upload_id)
+    .fetch_optional(pool)
+    .await?
+    .ok_or_else(|| PipelineError::Enrich(format!("document upload {upload_id} not found")))?;
+    Ok(Upload {
+        filename: row.0,
+        content_type: row.1,
+        bytes: row.2,
+    })
+}
+
+/// Delete an uploaded document's bytes. Called by the worker after a successful
+/// conversion or a terminal failure — the transient blob is never kept.
+pub async fn delete_upload(pool: &PgPool, upload_id: Uuid) -> Result<()> {
+    sqlx::query("DELETE FROM document_uploads WHERE id = $1")
+        .bind(upload_id)
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+/// Row for a traject's writable-own corpus source, from `traject_corpus_sources`.
+#[derive(sqlx::FromRow)]
+struct WritableOwnSourceRow {
+    source_id: String,
+    name: String,
+    source_type: String,
+    gh_owner: Option<String>,
+    gh_repo: Option<String>,
+    gh_branch: Option<String>,
+    gh_path: Option<String>,
+    gh_ref: Option<String>,
+    local_path: Option<String>,
+    priority: i32,
+    auth_ref: Option<String>,
+}
+
+impl WritableOwnSourceRow {
+    /// Mirror of editor-api's `TrajectSourceRow::to_source`. Scopes are omitted
+    /// (they only gate reads; the worker only writes).
+    fn to_source(&self) -> Source {
+        let source_type = match self.source_type.as_str() {
+            "github" => SourceType::GitHub {
+                github: GitHubSource {
+                    owner: self.gh_owner.clone().unwrap_or_default(),
+                    repo: self.gh_repo.clone().unwrap_or_default(),
+                    branch: self.gh_branch.clone().unwrap_or_default(),
+                    path: self.gh_path.clone(),
+                    git_ref: self.gh_ref.clone(),
+                },
+            },
+            _ => SourceType::Local {
+                local: LocalSource {
+                    path: std::path::PathBuf::from(self.local_path.clone().unwrap_or_default()),
+                },
+            },
+        };
+        Source {
+            id: self.source_id.clone(),
+            name: self.name.clone(),
+            source_type,
+            scopes: Vec::new(),
+            priority: self.priority.max(0) as u32,
+            auth_ref: self.auth_ref.clone(),
+        }
+    }
+}
+
+/// Build a corpus [`Source`] for the traject's single writable-own source.
+async fn load_writable_own_source(pool: &PgPool, traject_id: Uuid) -> Result<Source> {
+    let row = sqlx::query_as::<_, WritableOwnSourceRow>(
+        r#"
+        SELECT source_id, name, source_type, gh_owner, gh_repo, gh_branch,
+               gh_path, gh_ref, local_path, priority, auth_ref
+        FROM traject_corpus_sources
+        WHERE traject_id = $1 AND is_writable_own = TRUE
+        "#,
+    )
+    .bind(traject_id)
+    .fetch_optional(pool)
+    .await?
+    .ok_or_else(|| {
+        PipelineError::Enrich(format!(
+            "traject {traject_id} has no writable-own corpus source"
+        ))
+    })?;
+    Ok(row.to_source())
+}
+
+/// Write the converted markdown into the traject's writable-own corpus and push
+/// it. This is a service-account commit straight to the source's branch (no PR):
+/// the async worker has no user session, so it mirrors how the enrich worker
+/// writes to the corpus rather than the editor's per-session PR flow. The file
+/// lands at `documents/<traject_ref>/<target_path>` — the same location the
+/// editor's document handler writes to — so it shows up as a normal werkdocument.
+pub async fn write_markdown_to_traject(
+    pool: &PgPool,
+    payload: &DocumentConvertPayload,
+    markdown: &str,
+) -> Result<()> {
+    let source = load_writable_own_source(pool, payload.traject_id).await?;
+    // Resolve a push token strictly by the source's auth key (env var
+    // `CORPUS_AUTH_<key>_TOKEN`); no auth file in the worker and no shared-token
+    // fallback — matches the editor's writable-own resolution.
+    let auth_key = source.auth_ref.clone().unwrap_or_else(|| source.id.clone());
+    let token = regelrecht_corpus::auth::resolve_token_strict(&auth_key, None)?;
+
+    let mut backend = create_backend(&source, token.as_deref())?;
+    backend.ensure_ready().await?;
+
+    let relative_path = Path::new("documents")
+        .join(&payload.traject_ref)
+        .join(&payload.target_path);
+    backend.write_file(&relative_path, markdown).await?;
+
+    let message = format!("document-convert: {}", payload.target_path);
+    backend
+        .persist(&WriteContext {
+            message,
+            author: None,
+        })
+        .await?;
+    Ok(())
+}
+
+/// A trimmed view of a `document_convert` job for the werkdocumenten status UI.
+/// Deliberately does not expose the full [`crate::models::Job`] (payload,
+/// attempts, timestamps beyond what the UI needs).
+#[derive(Debug, Clone, Serialize, sqlx::FromRow)]
+pub struct TrajectJobView {
+    pub id: Uuid,
+    /// Target `.md` path (from the job payload); `None` only for a malformed payload.
+    pub target_path: Option<String>,
+    pub status: JobStatus,
+    /// Failure reason (from `jobs.result->>'error'`), present when `status = failed`.
+    pub error: Option<String>,
+    pub created_at: DateTime<Utc>,
+}
+
+/// List the traject's document-convert jobs that are still relevant to show:
+/// everything that is not `completed` (pending, processing, failed). A completed
+/// job is represented by the actual `.md` in the documents list, so it drops out
+/// of this view.
+pub async fn list_traject_document_jobs(
+    pool: &PgPool,
+    traject_ref: &str,
+) -> Result<Vec<TrajectJobView>> {
+    let rows = sqlx::query_as::<_, TrajectJobView>(
+        r#"
+        SELECT id,
+               payload->>'target_path' AS target_path,
+               status,
+               result->>'error'        AS error,
+               created_at
+        FROM jobs
+        WHERE traject_ref = $1
+          AND job_type = 'document_convert'
+          AND status <> 'completed'
+        ORDER BY created_at DESC
+        "#,
+    )
+    .bind(traject_ref)
+    .fetch_all(pool)
+    .await?;
+    Ok(rows)
+}
+
+/// Abstraction over the actual document→markdown conversion so the orchestration
+/// can be unit-tested without spawning a real LLM subprocess (mirrors the
+/// [`crate::enrich::LlmRunner`] seam).
+#[async_trait::async_trait]
+pub trait DocumentConverter: Send + Sync {
+    /// Convert `input_file` (inside `work_dir`) to markdown, written to
+    /// `output_path`. The agent runs with `work_dir` as its working directory.
+    async fn convert(
+        &self,
+        input_file: &Path,
+        work_dir: &Path,
+        output_path: &Path,
+        config: &EnrichConfig,
+    ) -> Result<()>;
+}
+
+/// Production converter: prompts the LLM agent to figure out and perform the
+/// conversion itself, then write the markdown to `output_path`.
+pub struct LlmDocumentConverter;
+
+#[async_trait::async_trait]
+impl DocumentConverter for LlmDocumentConverter {
+    async fn convert(
+        &self,
+        input_file: &Path,
+        work_dir: &Path,
+        output_path: &Path,
+        config: &EnrichConfig,
+    ) -> Result<()> {
+        let prompt = build_convert_prompt(input_file, output_path);
+        run_llm_subprocess(
+            &config.provider,
+            &prompt,
+            Some(input_file),
+            work_dir,
+            config,
+        )
+        .await
+    }
+}
+
+/// Build the conversion prompt. The agent is deliberately given full latitude to
+/// decide the conversion approach (spec: "het taalmodel mag het zelf bedenken").
+fn build_convert_prompt(input_file: &Path, output_path: &Path) -> String {
+    let input = input_file
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("input");
+    let output = output_path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("output.md");
+    format!(
+        "You are converting an uploaded document to clean Markdown.\n\n\
+         The document is the file `{input}` in your current working directory.\n\n\
+         Do the following:\n\
+         1. Inspect `{input}` and determine its format (for example PDF or Word).\n\
+         2. Decide on and carry out the best way to convert it to Markdown. You may use \
+            any command-line tool you consider suitable — and install one if needed \
+            (for example via `pip install --user`) — or read the document yourself and \
+            transcribe it. Choose whatever yields the most faithful result.\n\
+         3. Produce clean, well-structured GitHub-flavored Markdown that preserves the \
+            document's headings, lists, tables and paragraph structure. Do NOT summarize, \
+            translate, add commentary, or omit content — transcribe faithfully.\n\
+         4. Write the resulting Markdown to a file named `{output}` in your current \
+            working directory. Write ONLY the Markdown document to that file — no \
+            surrounding code fences, no explanations.\n\n\
+         The final deliverable is the file `{output}`."
+    )
+}
+
+/// Pick a file extension for the scratch input file from the original filename,
+/// falling back to the content type. Keeps the extension the agent sees honest
+/// so it can detect the format.
+fn extension_for(filename: &str, content_type: &str) -> String {
+    if let Some(ext) = Path::new(filename)
+        .extension()
+        .and_then(|e| e.to_str())
+        .filter(|e| !e.is_empty())
+    {
+        return ext.to_ascii_lowercase();
+    }
+    match content_type {
+        "application/pdf" => "pdf",
+        "application/msword" => "doc",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document" => "docx",
+        _ => "bin",
+    }
+    .to_string()
+}
+
+/// Load the upload, run the conversion in a fresh working directory, and return
+/// the produced markdown. The caller (worker) is responsible for writing the
+/// markdown to git and for cleaning up the upload row + job.
+pub async fn execute_document_convert(
+    pool: &PgPool,
+    payload: &DocumentConvertPayload,
+    config: &EnrichConfig,
+    converter: &dyn DocumentConverter,
+) -> Result<String> {
+    let upload = load_upload(pool, payload.upload_id).await?;
+    let work_dir = std::env::temp_dir().join(format!("docconvert-{}", payload.upload_id));
+    // Clear any stale directory left by a previous attempt of this same job.
+    let _ = tokio::fs::remove_dir_all(&work_dir).await;
+    tokio::fs::create_dir_all(&work_dir).await?;
+
+    let result = convert_in_dir(&work_dir, &upload, &payload.target_path, config, converter).await;
+
+    // Always remove the working directory, success or failure.
+    let _ = tokio::fs::remove_dir_all(&work_dir).await;
+    result
+}
+
+/// The pure filesystem half of the conversion, split out so it can be unit-tested
+/// with a fake converter and a synthetic upload (no DB, no LLM).
+async fn convert_in_dir(
+    work_dir: &Path,
+    upload: &Upload,
+    target_path: &str,
+    config: &EnrichConfig,
+    converter: &dyn DocumentConverter,
+) -> Result<String> {
+    let ext = extension_for(&upload.filename, &upload.content_type);
+    let input_file = work_dir.join(format!("input.{ext}"));
+    tokio::fs::write(&input_file, &upload.bytes).await?;
+
+    let output_name = Path::new(target_path)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("output.md");
+    let output_path: PathBuf = work_dir.join(output_name);
+
+    converter
+        .convert(&input_file, work_dir, &output_path, config)
+        .await?;
+
+    let markdown = tokio::fs::read_to_string(&output_path).await.map_err(|e| {
+        PipelineError::Enrich(format!(
+            "conversion produced no readable markdown at {}: {e}",
+            output_path.display()
+        ))
+    })?;
+    if markdown.trim().is_empty() {
+        return Err(PipelineError::Enrich(
+            "conversion produced empty markdown".to_string(),
+        ));
+    }
+    Ok(markdown)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn payload_roundtrips_through_json() {
+        let payload = DocumentConvertPayload {
+            upload_id: Uuid::nil(),
+            traject_id: Uuid::nil(),
+            traject_ref: "abcd1234".to_string(),
+            target_path: "report.md".to_string(),
+            provider: Some("claude".to_string()),
+        };
+        let json = serde_json::to_value(&payload).unwrap();
+        assert_eq!(json["upload_id"], "00000000-0000-0000-0000-000000000000");
+        assert_eq!(json["target_path"], "report.md");
+        let back: DocumentConvertPayload = serde_json::from_value(json).unwrap();
+        assert_eq!(back, payload);
+    }
+
+    #[test]
+    fn payload_omits_absent_provider() {
+        let payload = DocumentConvertPayload {
+            upload_id: Uuid::nil(),
+            traject_id: Uuid::nil(),
+            traject_ref: "abcd1234".to_string(),
+            target_path: "report.md".to_string(),
+            provider: None,
+        };
+        let json = serde_json::to_value(&payload).unwrap();
+        assert!(json.get("provider").is_none());
+    }
+
+    #[test]
+    fn extension_prefers_filename_then_content_type() {
+        assert_eq!(
+            extension_for("Report.PDF", "application/octet-stream"),
+            "pdf"
+        );
+        assert_eq!(extension_for("brief.docx", "text/plain"), "docx");
+        assert_eq!(extension_for("noext", "application/pdf"), "pdf");
+        assert_eq!(extension_for("noext", "application/msword"), "doc");
+    }
+
+    #[test]
+    fn prompt_names_input_and_output_files() {
+        let prompt = build_convert_prompt(
+            Path::new("/tmp/wd/input.pdf"),
+            Path::new("/tmp/wd/report.md"),
+        );
+        assert!(prompt.contains("`input.pdf`"));
+        assert!(prompt.contains("`report.md`"));
+        // The agent must be told to transcribe faithfully, not summarize.
+        assert!(prompt.to_lowercase().contains("do not summarize"));
+    }
+
+    /// Fake converter that writes fixed markdown, proving the orchestration reads
+    /// back exactly what the agent produced and reports the input it received.
+    struct FakeConverter {
+        markdown: String,
+    }
+
+    #[async_trait::async_trait]
+    impl DocumentConverter for FakeConverter {
+        async fn convert(
+            &self,
+            input_file: &Path,
+            _work_dir: &Path,
+            output_path: &Path,
+            _config: &EnrichConfig,
+        ) -> Result<()> {
+            // The input file must have been materialized before we're called.
+            assert!(
+                input_file.exists(),
+                "input file should exist for the converter"
+            );
+            tokio::fs::write(output_path, &self.markdown).await.unwrap();
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn convert_in_dir_returns_produced_markdown() {
+        let dir = tempfile::tempdir().unwrap();
+        let upload = Upload {
+            filename: "report.pdf".to_string(),
+            content_type: "application/pdf".to_string(),
+            bytes: b"%PDF-1.4 fake".to_vec(),
+        };
+        let converter = FakeConverter {
+            markdown: "# Report\n\nBody.\n".to_string(),
+        };
+        let md = convert_in_dir(
+            dir.path(),
+            &upload,
+            "report.md",
+            &EnrichConfig::for_test(crate::enrich::LlmProvider::Claude {
+                path: "claude".into(),
+                model: None,
+            }),
+            &converter,
+        )
+        .await
+        .unwrap();
+        assert_eq!(md, "# Report\n\nBody.\n");
+    }
+
+    #[tokio::test]
+    async fn convert_in_dir_errors_on_empty_output() {
+        let dir = tempfile::tempdir().unwrap();
+        let upload = Upload {
+            filename: "report.pdf".to_string(),
+            content_type: "application/pdf".to_string(),
+            bytes: b"x".to_vec(),
+        };
+        let converter = FakeConverter {
+            markdown: "   \n".to_string(),
+        };
+        let err = convert_in_dir(
+            dir.path(),
+            &upload,
+            "report.md",
+            &EnrichConfig::for_test(crate::enrich::LlmProvider::Claude {
+                path: "claude".into(),
+                model: None,
+            }),
+            &converter,
+        )
+        .await
+        .unwrap_err();
+        assert!(err.to_string().contains("empty markdown"));
+    }
+}

--- a/packages/pipeline/src/document_convert.rs
+++ b/packages/pipeline/src/document_convert.rs
@@ -129,8 +129,9 @@ impl WritableOwnSourceRow {
 async fn load_writable_own_source(pool: &PgPool, traject_id: Uuid) -> Result<Source> {
     let row = sqlx::query_as::<_, WritableOwnSourceRow>(
         r#"
-        SELECT source_id, name, source_type, gh_owner, gh_repo, gh_branch,
-               gh_path, gh_ref, local_path, priority, auth_ref
+        SELECT source_id, name, source_type::text AS source_type,
+               gh_owner, gh_repo, gh_branch, gh_path, gh_ref, local_path,
+               priority, auth_ref
         FROM traject_corpus_sources
         WHERE traject_id = $1 AND is_writable_own = TRUE
         "#,

--- a/packages/pipeline/src/document_convert.rs
+++ b/packages/pipeline/src/document_convert.rs
@@ -296,6 +296,9 @@ impl DocumentConverter for LlmDocumentConverter {
             Some(input_file),
             work_dir,
             config,
+            // The agent may run/install a converter (e.g. pdftotext, pandoc),
+            // so the claude provider needs shell access here.
+            true,
         )
         .await
     }

--- a/packages/pipeline/src/document_convert.rs
+++ b/packages/pipeline/src/document_convert.rs
@@ -297,7 +297,12 @@ impl DocumentConverter for LlmDocumentConverter {
         run_llm_subprocess(
             &config.provider,
             &prompt,
-            Some(input_file),
+            // Deliberately NOT passed as OpenCode's `-f`: the input is a binary
+            // PDF/Word file, and `-f` feeds a file as text context (enrich only
+            // ever passed text YAML). The agent instead reads the file — named in
+            // the prompt — from its working directory, which works for both the
+            // opencode (`--dir`) and claude (`current_dir`) providers.
+            None,
             work_dir,
             config,
             // The agent may run/install a converter (e.g. pdftotext, pandoc),

--- a/packages/pipeline/src/document_convert.rs
+++ b/packages/pipeline/src/document_convert.rs
@@ -1,13 +1,15 @@
 //! Document-convert jobs: turn an uploaded PDF/Word document into a clean
 //! markdown werkdocument.
 //!
-//! The heavy lifting is done by the same LLM agent subprocess that enrich uses
-//! (see [`crate::enrich::run_llm_subprocess`]); the agent decides for itself how
-//! to convert the document (pick/install a tool, or read it directly). This
-//! module owns the payload type, the transient upload storage helpers, the
-//! status-list query for the editor, and the conversion orchestration. The
-//! worker (see `worker.rs`) drives it and writes the produced markdown back to
-//! the traject's git corpus.
+//! Known formats (docx/office via `pandoc`, PDF via `pdftotext`) are converted
+//! deterministically with a real tool — reliable, offline, and keeping the
+//! untrusted document away from the Bash-enabled LLM. Only when no tool fits
+//! does it fall back to the LLM agent subprocess that enrich uses (see
+//! [`crate::enrich::run_llm_subprocess`]), which decides for itself how to
+//! convert (pick a tool, or read it directly). This module owns the payload
+//! type, the transient upload storage helpers, the status-list query for the
+//! editor, and the conversion orchestration. The worker (see `worker.rs`) drives
+//! it and writes the produced markdown back to the traject's git corpus.
 
 use std::path::{Path, PathBuf};
 
@@ -418,6 +420,54 @@ pub async fn execute_document_convert(
     result
 }
 
+/// Try to convert `input_file` to markdown at `output_path` with a deterministic
+/// command-line tool, chosen by extension. Returns `Some(markdown)` on success,
+/// or `None` when the format is not handled, the tool is absent, it exits
+/// non-zero, or it produces empty output — every `None` case falls through to the
+/// agentic converter, so a missing tool or an odd file never hard-fails here.
+///
+/// `pandoc` handles the office/markup formats; `pdftotext` (poppler) handles
+/// PDF. Both are baked into the enrich-worker image.
+async fn try_deterministic_convert(
+    input_file: &Path,
+    ext: &str,
+    output_path: &Path,
+) -> Option<String> {
+    let mut cmd = match ext {
+        // pandoc reads these natively and emits GitHub-flavored Markdown.
+        "docx" | "odt" | "rtf" | "html" | "htm" | "epub" | "fb2" => {
+            let mut c = tokio::process::Command::new("pandoc");
+            c.arg(input_file)
+                .arg("-t")
+                .arg("gfm")
+                .arg("--wrap=none")
+                .arg("-o")
+                .arg(output_path);
+            c
+        }
+        // pandoc cannot read PDF; poppler's pdftotext extracts the text layer.
+        "pdf" => {
+            let mut c = tokio::process::Command::new("pdftotext");
+            c.arg("-layout").arg(input_file).arg(output_path);
+            c
+        }
+        _ => return None,
+    };
+
+    match cmd.status().await {
+        Ok(status) if status.success() => {
+            let markdown = tokio::fs::read_to_string(output_path).await.ok()?;
+            if markdown.trim().is_empty() {
+                None
+            } else {
+                Some(markdown)
+            }
+        }
+        // Tool missing (spawn error) or a non-zero exit → let the agent try.
+        _ => None,
+    }
+}
+
 /// The pure filesystem half of the conversion, split out so it can be unit-tested
 /// with a fake converter and a synthetic upload (no DB, no LLM).
 async fn convert_in_dir(
@@ -436,6 +486,16 @@ async fn convert_in_dir(
         .and_then(|s| s.to_str())
         .unwrap_or("output.md");
     let output_path: PathBuf = work_dir.join(output_name);
+
+    // Deterministic-first: for known formats convert with a real tool
+    // (`pandoc`/`pdftotext`) instead of the agent. This is reliable (the agent
+    // proved flaky at reliably writing the output file), needs no network, and —
+    // crucially — keeps the untrusted document away from the Bash-enabled LLM,
+    // shrinking the prompt-injection surface. The agentic path stays as a
+    // fallback for formats the tools don't handle (or when they are absent).
+    if let Some(markdown) = try_deterministic_convert(&input_file, &ext, &output_path).await {
+        return Ok(markdown);
+    }
 
     converter
         .convert(&input_file, work_dir, &output_path, config)
@@ -539,10 +599,12 @@ mod tests {
     #[tokio::test]
     async fn convert_in_dir_returns_produced_markdown() {
         let dir = tempfile::tempdir().unwrap();
+        // A `.bin` extension no deterministic tool handles, so the agentic
+        // fallback (the FakeConverter) runs and we test that orchestration.
         let upload = Upload {
-            filename: "report.pdf".to_string(),
-            content_type: "application/pdf".to_string(),
-            bytes: b"%PDF-1.4 fake".to_vec(),
+            filename: "report.bin".to_string(),
+            content_type: "application/octet-stream".to_string(),
+            bytes: b"raw bytes".to_vec(),
         };
         let converter = FakeConverter {
             markdown: "# Report\n\nBody.\n".to_string(),
@@ -566,8 +628,8 @@ mod tests {
     async fn convert_in_dir_errors_on_empty_output() {
         let dir = tempfile::tempdir().unwrap();
         let upload = Upload {
-            filename: "report.pdf".to_string(),
-            content_type: "application/pdf".to_string(),
+            filename: "report.bin".to_string(),
+            content_type: "application/octet-stream".to_string(),
             bytes: b"x".to_vec(),
         };
         let converter = FakeConverter {
@@ -586,5 +648,18 @@ mod tests {
         .await
         .unwrap_err();
         assert!(err.to_string().contains("empty markdown"));
+    }
+
+    #[tokio::test]
+    async fn deterministic_convert_returns_none_for_unhandled_format() {
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("input.bin");
+        tokio::fs::write(&input, b"data").await.unwrap();
+        let output = dir.path().join("out.md");
+        // Unknown extension → no tool is even spawned → None (agentic fallback).
+        assert!(try_deterministic_convert(&input, "bin", &output)
+            .await
+            .is_none());
+        assert!(!output.exists());
     }
 }

--- a/packages/pipeline/src/enrich.rs
+++ b/packages/pipeline/src/enrich.rs
@@ -126,9 +126,30 @@ impl LlmRunner for ProcessLlmRunner {
     ) -> Result<()> {
         let progress_path = progress_file_path(yaml_abs);
         let prompt = build_prompt(&payload.yaml_path, &progress_path.to_string_lossy());
-        let provider_name = config.provider.name().to_string();
+        run_llm_subprocess(&config.provider, &prompt, Some(yaml_abs), repo_path, config).await
+    }
+}
 
-        let mut cmd = build_command(&config.provider, &prompt, yaml_abs, repo_path);
+/// Spawn and supervise an LLM agent subprocess, provider-agnostically.
+///
+/// This is the reusable core lifted out of [`ProcessLlmRunner::run`]: it builds
+/// the command, drains stdout/stderr (retaining a bounded stderr tail for the
+/// error message), and races the child against the configured timeout and the
+/// RSS memory watchdog, killing the whole process group on either. `cwd` is the
+/// working directory the agent runs in (and writes its output into); `file_arg`
+/// is the optional single input file (OpenCode's `-f`). Callers supply their own
+/// `prompt` — enrich and document-convert differ only in that prompt.
+pub(crate) async fn run_llm_subprocess(
+    provider: &LlmProvider,
+    prompt: &str,
+    file_arg: Option<&Path>,
+    cwd: &Path,
+    config: &EnrichConfig,
+) -> Result<()> {
+    {
+        let provider_name = provider.name().to_string();
+
+        let mut cmd = build_command(provider, prompt, file_arg, cwd);
 
         // Both streams are piped and drained. stdout is drained-and-discarded: a
         // verbose agent (e.g. opencode `--format json`) inlines the full body of
@@ -628,6 +649,36 @@ pub struct EnrichConfig {
     provider_configs: std::collections::HashMap<String, LlmProvider>,
 }
 
+#[cfg(test)]
+impl EnrichConfig {
+    /// Build a config for tests (crate-internal), without reading the
+    /// environment. Shared by the enrich and document-convert test suites.
+    pub(crate) fn for_test(provider: LlmProvider) -> Self {
+        let mut provider_configs = std::collections::HashMap::new();
+        provider_configs.insert(
+            "opencode".to_string(),
+            LlmProvider::OpenCode {
+                path: "opencode".into(),
+                model: None,
+            },
+        );
+        provider_configs.insert(
+            "claude".to_string(),
+            LlmProvider::Claude {
+                path: "claude".into(),
+                model: Some("opus".into()),
+            },
+        );
+        EnrichConfig {
+            provider,
+            timeout: Duration::from_secs(600),
+            code_commit: "abc123".to_string(),
+            max_rss_mb: 3500,
+            provider_configs,
+        }
+    }
+}
+
 impl EnrichConfig {
     pub fn from_env() -> Self {
         let provider_name = std::env::var("LLM_PROVIDER").unwrap_or_else(|_| "opencode".into());
@@ -827,11 +878,15 @@ fn select_claude_token(raw: &str, bucket: u64) -> Option<(usize, usize, &str)> {
 /// The subprocess gets a stripped environment: only variables on
 /// `LLM_ENV_ALLOWLIST` are forwarded.  This prevents leaking DATABASE_URL
 /// and other secrets to the LLM process (which may have shell access).
+///
+/// `file_arg` is passed to OpenCode as its `-f` input file (the Claude provider
+/// ignores it and reads via its own tools from `cwd`). Enrich passes the law
+/// YAML; a caller with no single input file passes `None`.
 fn build_command(
     provider: &LlmProvider,
     prompt: &str,
-    yaml_abs: &Path,
-    repo_path: &Path,
+    file_arg: Option<&Path>,
+    cwd: &Path,
 ) -> tokio::process::Command {
     // Collect allowed env vars before creating the command.
     let safe_env: Vec<(String, String)> =
@@ -875,14 +930,11 @@ fn build_command(
             cmd.env_clear();
             cmd.envs(safe_env);
             cmd.env("NODE_OPTIONS", "--max-old-space-size=512");
-            cmd.arg("run")
-                .arg(prompt)
-                .arg("-f")
-                .arg(yaml_abs)
-                .arg("--format")
-                .arg("json")
-                .arg("--dir")
-                .arg(repo_path);
+            cmd.arg("run").arg(prompt);
+            if let Some(f) = file_arg {
+                cmd.arg("-f").arg(f);
+            }
+            cmd.arg("--format").arg("json").arg("--dir").arg(cwd);
             if let Some(ref m) = model {
                 cmd.arg("-m").arg(m);
             }
@@ -920,7 +972,7 @@ fn build_command(
                 .arg(prompt)
                 .arg("--allowedTools")
                 .arg("Read,Edit,Write,Grep,Glob")
-                .current_dir(repo_path);
+                .current_dir(cwd);
             if let Some(ref m) = model {
                 cmd.arg("--model").arg(m);
             }
@@ -1704,28 +1756,7 @@ related_legislation:
     }
 
     fn test_config(provider: LlmProvider) -> EnrichConfig {
-        let mut provider_configs = std::collections::HashMap::new();
-        provider_configs.insert(
-            "opencode".to_string(),
-            LlmProvider::OpenCode {
-                path: "opencode".into(),
-                model: None,
-            },
-        );
-        provider_configs.insert(
-            "claude".to_string(),
-            LlmProvider::Claude {
-                path: "claude".into(),
-                model: Some("opus".into()),
-            },
-        );
-        EnrichConfig {
-            provider,
-            timeout: Duration::from_secs(600),
-            code_commit: "abc123".to_string(),
-            max_rss_mb: 3500,
-            provider_configs,
-        }
+        EnrichConfig::for_test(provider)
     }
 
     #[test]

--- a/packages/pipeline/src/enrich.rs
+++ b/packages/pipeline/src/enrich.rs
@@ -126,7 +126,16 @@ impl LlmRunner for ProcessLlmRunner {
     ) -> Result<()> {
         let progress_path = progress_file_path(yaml_abs);
         let prompt = build_prompt(&payload.yaml_path, &progress_path.to_string_lossy());
-        run_llm_subprocess(&config.provider, &prompt, Some(yaml_abs), repo_path, config).await
+        run_llm_subprocess(
+            &config.provider,
+            &prompt,
+            Some(yaml_abs),
+            repo_path,
+            config,
+            // Enrich edits YAML in place; it does not need shell access.
+            false,
+        )
+        .await
     }
 }
 
@@ -139,17 +148,21 @@ impl LlmRunner for ProcessLlmRunner {
 /// working directory the agent runs in (and writes its output into); `file_arg`
 /// is the optional single input file (OpenCode's `-f`). Callers supply their own
 /// `prompt` — enrich and document-convert differ only in that prompt.
+/// `allow_bash` widens the `claude` provider's tool allowlist to include `Bash`
+/// (enrich keeps it off; document-convert needs it so the agent can run/install
+/// a converter). It has no effect on `opencode`, which has its own tool model.
 pub(crate) async fn run_llm_subprocess(
     provider: &LlmProvider,
     prompt: &str,
     file_arg: Option<&Path>,
     cwd: &Path,
     config: &EnrichConfig,
+    allow_bash: bool,
 ) -> Result<()> {
     {
         let provider_name = provider.name().to_string();
 
-        let mut cmd = build_command(provider, prompt, file_arg, cwd);
+        let mut cmd = build_command(provider, prompt, file_arg, cwd, allow_bash);
 
         // Both streams are piped and drained. stdout is drained-and-discarded: a
         // verbose agent (e.g. opencode `--format json`) inlines the full body of
@@ -887,6 +900,7 @@ fn build_command(
     prompt: &str,
     file_arg: Option<&Path>,
     cwd: &Path,
+    allow_bash: bool,
 ) -> tokio::process::Command {
     // Collect allowed env vars before creating the command.
     let safe_env: Vec<(String, String)> =
@@ -968,10 +982,17 @@ fn build_command(
                     }
                 }
             }
+            // `Bash` is only granted when the caller asks for it (document-convert
+            // may need to run/install a converter); enrich keeps the shell off.
+            let allowed_tools = if allow_bash {
+                "Bash,Read,Edit,Write,Grep,Glob"
+            } else {
+                "Read,Edit,Write,Grep,Glob"
+            };
             cmd.arg("-p")
                 .arg(prompt)
                 .arg("--allowedTools")
-                .arg("Read,Edit,Write,Grep,Glob")
+                .arg(allowed_tools)
                 .current_dir(cwd);
             if let Some(ref m) = model {
                 cmd.arg("--model").arg(m);

--- a/packages/pipeline/src/enrich.rs
+++ b/packages/pipeline/src/enrich.rs
@@ -159,168 +159,166 @@ pub(crate) async fn run_llm_subprocess(
     config: &EnrichConfig,
     allow_bash: bool,
 ) -> Result<()> {
-    {
-        let provider_name = provider.name().to_string();
+    let provider_name = provider.name().to_string();
 
-        let mut cmd = build_command(provider, prompt, file_arg, cwd, allow_bash);
+    let mut cmd = build_command(provider, prompt, file_arg, cwd, allow_bash);
 
-        // Both streams are piped and drained. stdout is drained-and-discarded: a
-        // verbose agent (e.g. opencode `--format json`) inlines the full body of
-        // every fetched page into its event stream, which would flood container
-        // logs. stderr is drained too — we MUST keep reading both or a full 64 KB
-        // OS pipe buffer blocks the child — but for stderr we also keep a bounded
-        // tail and re-log previews, so the LLM's real error (e.g. an auth 401) is
-        // both visible in the logs and attached to the job's failure.
-        cmd.stderr(std::process::Stdio::piped());
-        cmd.stdout(std::process::Stdio::piped());
-        let mut child = cmd.spawn().map_err(|e| {
-            PipelineError::Enrich(format!("failed to spawn {}: {e}", provider_name))
-        })?;
+    // Both streams are piped and drained. stdout is drained-and-discarded: a
+    // verbose agent (e.g. opencode `--format json`) inlines the full body of
+    // every fetched page into its event stream, which would flood container
+    // logs. stderr is drained too — we MUST keep reading both or a full 64 KB
+    // OS pipe buffer blocks the child — but for stderr we also keep a bounded
+    // tail and re-log previews, so the LLM's real error (e.g. an auth 401) is
+    // both visible in the logs and attached to the job's failure.
+    cmd.stderr(std::process::Stdio::piped());
+    cmd.stdout(std::process::Stdio::piped());
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| PipelineError::Enrich(format!("failed to spawn {}: {e}", provider_name)))?;
 
-        // Capture the PID before any wait reaps the child; the memory watchdog
-        // and process-group kill both need it.
-        let pid = child.id();
+    // Capture the PID before any wait reaps the child; the memory watchdog
+    // and process-group kill both need it.
+    let pid = child.id();
 
-        // Drain stderr, retaining the last `MAX_STDERR_CAPTURE` bytes for the
-        // error message and re-logging bounded previews so it stays visible.
-        let stderr_tail = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
-        let stderr_task = child.stderr.take().map(|mut stderr| {
-            let tail = stderr_tail.clone();
-            let stderr_provider = provider_name.clone();
-            tokio::spawn(async move {
-                let mut buf = [0u8; 8192];
-                loop {
-                    match stderr.read(&mut buf).await {
-                        Ok(0) | Err(_) => break, // EOF or pipe gone
-                        Ok(n) => {
-                            let text = String::from_utf8_lossy(&buf[..n]);
-                            let preview: String = text.trim().chars().take(500).collect();
-                            if !preview.is_empty() {
-                                tracing::warn!(provider = %stderr_provider, %preview, "agent stderr");
-                            }
-                            if let Ok(mut t) = tail.lock() {
-                                t.push_str(&text);
-                                if t.len() > MAX_STDERR_CAPTURE {
-                                    let mut cut = t.len() - MAX_STDERR_CAPTURE;
-                                    while cut < t.len() && !t.is_char_boundary(cut) {
-                                        cut += 1;
-                                    }
-                                    *t = t[cut..].to_string();
+    // Drain stderr, retaining the last `MAX_STDERR_CAPTURE` bytes for the
+    // error message and re-logging bounded previews so it stays visible.
+    let stderr_tail = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+    let stderr_task = child.stderr.take().map(|mut stderr| {
+        let tail = stderr_tail.clone();
+        let stderr_provider = provider_name.clone();
+        tokio::spawn(async move {
+            let mut buf = [0u8; 8192];
+            loop {
+                match stderr.read(&mut buf).await {
+                    Ok(0) | Err(_) => break, // EOF or pipe gone
+                    Ok(n) => {
+                        let text = String::from_utf8_lossy(&buf[..n]);
+                        let preview: String = text.trim().chars().take(500).collect();
+                        if !preview.is_empty() {
+                            tracing::warn!(provider = %stderr_provider, %preview, "agent stderr");
+                        }
+                        if let Ok(mut t) = tail.lock() {
+                            t.push_str(&text);
+                            if t.len() > MAX_STDERR_CAPTURE {
+                                let mut cut = t.len() - MAX_STDERR_CAPTURE;
+                                while cut < t.len() && !t.is_char_boundary(cut) {
+                                    cut += 1;
                                 }
+                                *t = t[cut..].to_string();
                             }
                         }
                     }
                 }
-            })
+            }
+        })
+    });
+    // Read the retained stderr tail, formatted as a "; stderr: …" suffix.
+    let stderr_suffix = || {
+        stderr_tail
+            .lock()
+            .ok()
+            .map(|t| t.trim().to_string())
+            .filter(|t| !t.is_empty())
+            .map(|t| format!("; stderr: {t}"))
+            .unwrap_or_default()
+    };
+
+    // Drain the agent's stdout so it never reaches container logs. We MUST
+    // keep reading it: if the OS pipe buffer (64 KB) fills, the child blocks
+    // indefinitely — the same deadlock the stderr comment above warns about.
+    // The task ends on EOF when the process exits or is killed.
+    if let Some(mut stdout) = child.stdout.take() {
+        let drain_provider = provider_name.clone();
+        tokio::spawn(async move {
+            // Drain in fixed-size chunks rather than whole lines: opencode
+            // inlines multi-MB page bodies as a single JSON line, so a
+            // line reader would allocate the entire body just to log a
+            // 200-char preview — a heap spike on the very worker this
+            // watchdog exists to protect. Reading into a fixed buffer keeps
+            // the pipe empty without ever holding more than `buf`.
+            let mut buf = [0u8; 8192];
+            loop {
+                match stdout.read(&mut buf).await {
+                    Ok(0) | Err(_) => break, // EOF or pipe gone (process exited/killed)
+                    Ok(n) => {
+                        // Bounded preview at debug only (off under the
+                        // default "info" subscriber). The leading bytes of a
+                        // read carry the event type and ids, not the large
+                        // inlined bodies; lossy is fine for a log preview.
+                        let preview = String::from_utf8_lossy(&buf[..n.min(200)]);
+                        let preview = preview.trim_end();
+                        if !preview.is_empty() {
+                            tracing::debug!(provider = %drain_provider, %preview, "agent stdout");
+                        }
+                    }
+                }
+            }
         });
-        // Read the retained stderr tail, formatted as a "; stderr: …" suffix.
-        let stderr_suffix = || {
-            stderr_tail
-                .lock()
-                .ok()
-                .map(|t| t.trim().to_string())
-                .filter(|t| !t.is_empty())
-                .map(|t| format!("; stderr: {t}"))
-                .unwrap_or_default()
-        };
+    }
 
-        // Drain the agent's stdout so it never reaches container logs. We MUST
-        // keep reading it: if the OS pipe buffer (64 KB) fills, the child blocks
-        // indefinitely — the same deadlock the stderr comment above warns about.
-        // The task ends on EOF when the process exits or is killed.
-        if let Some(mut stdout) = child.stdout.take() {
-            let drain_provider = provider_name.clone();
-            tokio::spawn(async move {
-                // Drain in fixed-size chunks rather than whole lines: opencode
-                // inlines multi-MB page bodies as a single JSON line, so a
-                // line reader would allocate the entire body just to log a
-                // 200-char preview — a heap spike on the very worker this
-                // watchdog exists to protect. Reading into a fixed buffer keeps
-                // the pipe empty without ever holding more than `buf`.
-                let mut buf = [0u8; 8192];
-                loop {
-                    match stdout.read(&mut buf).await {
-                        Ok(0) | Err(_) => break, // EOF or pipe gone (process exited/killed)
-                        Ok(n) => {
-                            // Bounded preview at debug only (off under the
-                            // default "info" subscriber). The leading bytes of a
-                            // read carry the event type and ids, not the large
-                            // inlined bodies; lossy is fine for a log preview.
-                            let preview = String::from_utf8_lossy(&buf[..n.min(200)]);
-                            let preview = preview.trim_end();
-                            if !preview.is_empty() {
-                                tracing::debug!(provider = %drain_provider, %preview, "agent stdout");
-                            }
-                        }
-                    }
-                }
-            });
+    let status = tokio::select! {
+        result = child.wait() => {
+            result.map_err(|e| {
+                PipelineError::Enrich(format!("failed to wait for {}: {e}", provider_name))
+            })?
         }
-
-        let status = tokio::select! {
-            result = child.wait() => {
-                result.map_err(|e| {
-                    PipelineError::Enrich(format!("failed to wait for {}: {e}", provider_name))
-                })?
-            }
-            _ = tokio::time::sleep(config.timeout) => {
-                terminate(&mut child, pid).await;
-                // Abort the drain task rather than leaving it detached: if a
-                // grandchild inherited fd 2 and survived terminate(), the task
-                // would otherwise leak. The tail read below is already populated.
-                if let Some(t) = &stderr_task {
-                    t.abort();
-                }
-                return Err(PipelineError::Enrich(format!(
-                    "{} timed out after {:?}{}",
-                    provider_name, config.timeout, stderr_suffix()
-                )));
-            }
-            observed_mb = watch_memory(pid, config.max_rss_mb) => {
-                tracing::error!(
-                    provider = %provider_name,
-                    pid = ?pid,
-                    observed_mb,
-                    limit_mb = config.max_rss_mb,
-                    "LLM subprocess exceeded memory limit, killing to protect the container"
-                );
-                terminate(&mut child, pid).await;
-                if let Some(t) = &stderr_task {
-                    t.abort();
-                }
-                return Err(PipelineError::Enrich(format!(
-                    "{provider_name} exceeded memory limit of {} MB (RSS {observed_mb} MB), killed{}",
-                    config.max_rss_mb, stderr_suffix()
-                )));
-            }
-        };
-
-        if !status.success() {
-            // Give the stderr drain a moment to finish so the tail is complete,
-            // but bound the wait: the child has exited, yet a leaked grandchild
-            // that inherited fd 2 could keep the pipe open and never EOF. Without
-            // a bound this await (outside the timeout/memory select!) would wedge
-            // the worker loop. Best-effort, like the tail in the other paths.
-            if let Some(task) = stderr_task {
-                let _ = tokio::time::timeout(Duration::from_secs(2), task).await;
+        _ = tokio::time::sleep(config.timeout) => {
+            terminate(&mut child, pid).await;
+            // Abort the drain task rather than leaving it detached: if a
+            // grandchild inherited fd 2 and survived terminate(), the task
+            // would otherwise leak. The tail read below is already populated.
+            if let Some(t) = &stderr_task {
+                t.abort();
             }
             return Err(PipelineError::Enrich(format!(
-                "{} exited with {}{}",
-                provider_name,
-                status,
-                stderr_suffix()
+                "{} timed out after {:?}{}",
+                provider_name, config.timeout, stderr_suffix()
             )));
         }
-
-        // Success: abort the drain task instead of leaving it detached — same
-        // fd-2/grandchild-leak guard as the timeout/OOM paths. Normally it has
-        // already finished (the child closed stderr on exit); aborting a finished
-        // task is a no-op.
-        if let Some(t) = &stderr_task {
-            t.abort();
+        observed_mb = watch_memory(pid, config.max_rss_mb) => {
+            tracing::error!(
+                provider = %provider_name,
+                pid = ?pid,
+                observed_mb,
+                limit_mb = config.max_rss_mb,
+                "LLM subprocess exceeded memory limit, killing to protect the container"
+            );
+            terminate(&mut child, pid).await;
+            if let Some(t) = &stderr_task {
+                t.abort();
+            }
+            return Err(PipelineError::Enrich(format!(
+                "{provider_name} exceeded memory limit of {} MB (RSS {observed_mb} MB), killed{}",
+                config.max_rss_mb, stderr_suffix()
+            )));
         }
-        Ok(())
+    };
+
+    if !status.success() {
+        // Give the stderr drain a moment to finish so the tail is complete,
+        // but bound the wait: the child has exited, yet a leaked grandchild
+        // that inherited fd 2 could keep the pipe open and never EOF. Without
+        // a bound this await (outside the timeout/memory select!) would wedge
+        // the worker loop. Best-effort, like the tail in the other paths.
+        if let Some(task) = stderr_task {
+            let _ = tokio::time::timeout(Duration::from_secs(2), task).await;
+        }
+        return Err(PipelineError::Enrich(format!(
+            "{} exited with {}{}",
+            provider_name,
+            status,
+            stderr_suffix()
+        )));
     }
+
+    // Success: abort the drain task instead of leaving it detached — same
+    // fd-2/grandchild-leak guard as the timeout/OOM paths. Normally it has
+    // already finished (the child closed stderr on exit); aborting a finished
+    // task is a no-op.
+    if let Some(t) = &stderr_task {
+        t.abort();
+    }
+    Ok(())
 }
 
 /// Kill the LLM subprocess and reap it.

--- a/packages/pipeline/src/job_queue.rs
+++ b/packages/pipeline/src/job_queue.rs
@@ -52,6 +52,9 @@ struct ReapedRow {
 pub struct CreateJobRequest {
     pub job_type: JobType,
     pub law_id: String,
+    /// Owning traject ref for traject-scoped jobs; `None` for corpus-wide
+    /// harvest/enrich jobs.
+    pub traject_ref: Option<String>,
     pub priority: Priority,
     pub payload: Option<serde_json::Value>,
     pub max_attempts: i32,
@@ -65,11 +68,18 @@ impl CreateJobRequest {
         Self {
             job_type,
             law_id: law_id.into(),
+            traject_ref: None,
             priority: Priority::default(),
             payload: None,
             max_attempts: 3,
             initial_delay: None,
         }
+    }
+
+    /// Associate the job with an owning traject.
+    pub fn with_traject_ref(mut self, traject_ref: impl Into<String>) -> Self {
+        self.traject_ref = Some(traject_ref.into());
+        self
     }
 
     pub fn with_priority(mut self, priority: Priority) -> Self {
@@ -102,13 +112,14 @@ where
     let initial_delay = req.initial_delay.map(to_pg_interval).transpose()?;
     let job = sqlx::query_as::<_, Job>(
         r#"
-        INSERT INTO jobs (job_type, law_id, priority, payload, max_attempts, scheduled_at)
-        VALUES ($1, $2, $3, $4, $5, now() + $6::interval)
+        INSERT INTO jobs (job_type, law_id, traject_ref, priority, payload, max_attempts, scheduled_at)
+        VALUES ($1, $2, $3, $4, $5, $6, now() + $7::interval)
         RETURNING *
         "#,
     )
     .bind(req.job_type)
     .bind(&req.law_id)
+    .bind(&req.traject_ref)
     .bind(req.priority.value())
     .bind(&req.payload)
     .bind(req.max_attempts)

--- a/packages/pipeline/src/law_status.rs
+++ b/packages/pipeline/src/law_status.rs
@@ -294,6 +294,13 @@ fn fail_count_column(job_type: crate::models::JobType) -> &'static str {
     match job_type {
         crate::models::JobType::Harvest => "harvest_fail_count",
         crate::models::JobType::Enrich => "enrich_fail_count",
+        // document_convert jobs are traject-scoped, not law-scoped: they have no
+        // `law_entries` row and never go through the per-law fail-count / exhaust
+        // path (the worker fails them with plain `fail_job`). Reaching here is a
+        // programming error.
+        crate::models::JobType::DocumentConvert => {
+            unreachable!("document_convert jobs have no law-status fail counter")
+        }
     }
 }
 
@@ -359,6 +366,10 @@ where
             LawStatusValue::EnrichFailed,
             LawStatusValue::EnrichExhausted,
         ),
+        // See `fail_count_column`: document_convert is not law-scoped.
+        crate::models::JobType::DocumentConvert => {
+            unreachable!("document_convert jobs are not law-scoped and cannot be exhausted")
+        }
     };
     // Only exhaust if status is still the corresponding failed state,
     // preventing a race with admin reset.

--- a/packages/pipeline/src/lib.rs
+++ b/packages/pipeline/src/lib.rs
@@ -2,6 +2,7 @@ pub mod api;
 mod api_state;
 pub mod config;
 pub mod db;
+pub mod document_convert;
 pub mod enrich;
 pub mod error;
 pub mod feature_flags;

--- a/packages/pipeline/src/models.rs
+++ b/packages/pipeline/src/models.rs
@@ -8,6 +8,11 @@ use uuid::Uuid;
 pub enum JobType {
     Harvest,
     Enrich,
+    /// Convert an uploaded document (PDF/Word) to a markdown werkdocument via
+    /// the LLM agent. Scoped to a traject (see [`Job::traject_ref`]).
+    #[sqlx(rename = "document_convert")]
+    #[serde(rename = "document_convert")]
+    DocumentConvert,
 }
 
 #[derive(

--- a/packages/pipeline/src/worker.rs
+++ b/packages/pipeline/src/worker.rs
@@ -8,6 +8,7 @@ use tokio::signal::unix::{signal, SignalKind};
 
 use crate::config::WorkerConfig;
 use crate::db;
+use crate::document_convert::{self, DocumentConvertPayload, LlmDocumentConverter};
 use crate::enrich::{
     create_enrich_corpus, enrich_branch_name, execute_enrich, progress_file_path, EnrichConfig,
     EnrichPayload, RelatedLegislation,
@@ -16,7 +17,7 @@ use crate::error::{PipelineError, Result};
 use crate::harvest::{execute_harvest, HarvestPayload, HarvestResult, MAX_HARVEST_DEPTH};
 use crate::job_queue::{self, CreateJobRequest};
 use crate::law_status;
-use crate::models::{JobType, LawStatusValue, Priority};
+use crate::models::{JobStatus, JobType, LawStatusValue, Priority};
 
 /// Local night window (Europe/Amsterdam) as a half-open hour-of-day range
 /// `[start, end)`. Hours in this range get the multiplied enrich cap.
@@ -816,6 +817,35 @@ pub async fn run_enrich_worker(config: WorkerConfig) -> Result<()> {
             }
         }
 
+        // Document-convert jobs run BEFORE the enrich hourly-cap gate: they are
+        // interactive, user-initiated uploads (naturally rate-limited) and must
+        // not be blocked when bulk enrichment has hit its budget cap. They still
+        // share this worker's LLM CLI environment and OAuth token.
+        match process_next_document_convert_job(&pool, &enrich_config, config.job_timeout).await {
+            Ok(JobOutcome::Processed) => {
+                consecutive_resource_failures = 0;
+                current_interval = config.poll_interval;
+                continue;
+            }
+            Ok(JobOutcome::ResourceExhausted) => {
+                handle_resource_exhaustion(
+                    &mut consecutive_resource_failures,
+                    config.max_consecutive_resource_failures,
+                    "document-convert",
+                );
+                current_interval = config.poll_interval;
+                continue;
+            }
+            Ok(JobOutcome::Idle) => { /* no document-convert job — continue to enrich */ }
+            Err(e) => {
+                tracing::error!(error = %e, "error processing document-convert job");
+                current_interval = (current_interval * 2)
+                    .max(config.poll_interval)
+                    .min(config.max_poll_interval);
+                continue;
+            }
+        }
+
         // Enforce the per-provider hourly run cap before claiming a job. The cap
         // is multiplied during the local night window (00:00–08:00 Europe/
         // Amsterdam) by ENRICH_NIGHT_MULTIPLIER, so bulk enrichment runs mostly
@@ -1145,6 +1175,94 @@ async fn harvest_related_legislation(
         unresolved,
         "related-legislation harvest summary"
     );
+}
+
+/// Process the next available document-convert job: convert an uploaded
+/// document to markdown (via the LLM agent) and write it back to the traject's
+/// corpus as a werkdocument.
+///
+/// Runs in the enrich worker so it reuses the LLM CLI environment, OAuth token
+/// and hourly budget. Returns `Idle` when no job is pending.
+async fn process_next_document_convert_job(
+    pool: &PgPool,
+    enrich_config: &EnrichConfig,
+    job_timeout: Duration,
+) -> Result<JobOutcome> {
+    let job = match job_queue::claim_job(pool, Some(JobType::DocumentConvert)).await? {
+        Some(job) => job,
+        None => return Ok(JobOutcome::Idle),
+    };
+
+    // Parse the payload. A malformed payload is deterministic — fail terminally
+    // (no retry) and still drop the transient upload if we can recover its id.
+    let payload: DocumentConvertPayload = match job
+        .payload
+        .as_ref()
+        .ok_or_else(|| PipelineError::Worker("document_convert job has no payload".to_string()))
+        .and_then(|p| {
+            serde_json::from_value(p.clone())
+                .map_err(|e| PipelineError::Worker(format!("payload deserialization failed: {e}")))
+        }) {
+        Ok(payload) => payload,
+        Err(e) => {
+            let msg = format!("invalid document_convert payload: {e}");
+            tracing::error!(job_id = %job.id, error = %msg);
+            job_queue::fail_job_terminal(pool, job.id, Some(serde_json::json!({ "error": msg })))
+                .await?;
+            return Ok(JobOutcome::Processed);
+        }
+    };
+
+    // Apply the payload's provider override (if any) and bound the run by the
+    // worker's job timeout, mirroring the enrich path.
+    let mut job_config = match &payload.provider {
+        Some(provider) => enrich_config.with_provider_override(provider),
+        None => enrich_config.clone(),
+    };
+    job_config.timeout = job_timeout;
+
+    match run_document_convert(pool, &payload, &job_config).await {
+        Ok(()) => {
+            job_queue::complete_job(pool, job.id, None).await?;
+            // Transient bytes are no longer needed once the markdown is committed.
+            if let Err(e) = document_convert::delete_upload(pool, payload.upload_id).await {
+                tracing::warn!(job_id = %job.id, error = %e, "failed to delete document upload after success");
+            }
+            Ok(JobOutcome::Processed)
+        }
+        Err(e) => {
+            let msg = e.to_string();
+            tracing::error!(job_id = %job.id, error = %msg, "document-convert job failed");
+            let failed = job_queue::fail_job(
+                pool,
+                job.id,
+                Some(serde_json::json!({ "error": msg.clone() })),
+            )
+            .await?;
+            // Once a job is terminally failed there is no retry to feed, so drop
+            // the upload bytes. A still-retryable failure keeps them for the
+            // next attempt.
+            if failed.status == JobStatus::Failed {
+                if let Err(e) = document_convert::delete_upload(pool, payload.upload_id).await {
+                    tracing::warn!(job_id = %job.id, error = %e, "failed to delete document upload after terminal failure");
+                }
+            }
+            Ok(outcome_for_error(&msg))
+        }
+    }
+}
+
+/// Convert the uploaded document to markdown and commit it to the traject.
+async fn run_document_convert(
+    pool: &PgPool,
+    payload: &DocumentConvertPayload,
+    config: &EnrichConfig,
+) -> Result<()> {
+    let markdown =
+        document_convert::execute_document_convert(pool, payload, config, &LlmDocumentConverter)
+            .await?;
+    document_convert::write_markdown_to_traject(pool, payload, &markdown).await?;
+    Ok(())
 }
 
 /// Process the next available enrich job.

--- a/packages/pipeline/src/worker.rs
+++ b/packages/pipeline/src/worker.rs
@@ -1234,11 +1234,15 @@ async fn process_next_document_convert_job(
 
     match run_document_convert(pool, &payload, &job_config).await {
         Ok(()) => {
-            job_queue::complete_job(pool, job.id, None).await?;
-            // Transient bytes are no longer needed once the markdown is committed.
+            // The markdown is already committed to git at this point. Drop the
+            // transient upload bytes BEFORE propagating any complete_job error —
+            // otherwise a failed status update would `?`-return past the cleanup
+            // and leak the (up to 25 MiB) BYTEA row.
+            let complete_result = job_queue::complete_job(pool, job.id, None).await;
             if let Err(e) = document_convert::delete_upload(pool, payload.upload_id).await {
                 tracing::warn!(job_id = %job.id, error = %e, "failed to delete document upload after success");
             }
+            complete_result?;
             Ok(JobOutcome::Processed)
         }
         Err(e) => {

--- a/packages/pipeline/src/worker.rs
+++ b/packages/pipeline/src/worker.rs
@@ -137,6 +137,18 @@ fn spawn_reaper(
             if let Err(e) = job_queue::reap_orphaned_jobs(&pool, orphan_timeout).await {
                 tracing::warn!(error = %e, "failed to reap orphaned jobs");
             }
+            // GC upload bytes orphaned when a worker died mid-conversion: the
+            // generic reaper above fails such a job without running the
+            // type-specific delete_upload, so sweep them here.
+            match document_convert::cleanup_orphaned_uploads(&pool).await {
+                Ok(n) if n > 0 => {
+                    tracing::info!(removed = n, "cleaned up orphaned document uploads")
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    tracing::warn!(error = %e, "failed to clean up orphaned document uploads")
+                }
+            }
             tokio::select! {
                 _ = cancel.cancelled() => break,
                 _ = tokio::time::sleep(REAPER_INTERVAL) => {}

--- a/packages/pipeline/src/worker.rs
+++ b/packages/pipeline/src/worker.rs
@@ -17,7 +17,7 @@ use crate::error::{PipelineError, Result};
 use crate::harvest::{execute_harvest, HarvestPayload, HarvestResult, MAX_HARVEST_DEPTH};
 use crate::job_queue::{self, CreateJobRequest};
 use crate::law_status;
-use crate::models::{JobStatus, JobType, LawStatusValue, Priority};
+use crate::models::{JobType, LawStatusValue, Priority};
 
 /// Local night window (Europe/Amsterdam) as a half-open hour-of-day range
 /// `[start, end)`. Hours in this range get the multiplied enrich cap.
@@ -1244,19 +1244,18 @@ async fn process_next_document_convert_job(
         Err(e) => {
             let msg = e.to_string();
             tracing::error!(job_id = %job.id, error = %msg, "document-convert job failed");
-            let failed = job_queue::fail_job(
+            // Document-convert jobs are single-attempt (the upload handler sets
+            // max_attempts=1): a retry would re-run the expensive LLM conversion
+            // and most failures are deterministic. Fail terminally and always
+            // drop the transient upload bytes — there is no retry to feed them to.
+            job_queue::fail_job_terminal(
                 pool,
                 job.id,
                 Some(serde_json::json!({ "error": msg.clone() })),
             )
             .await?;
-            // Once a job is terminally failed there is no retry to feed, so drop
-            // the upload bytes. A still-retryable failure keeps them for the
-            // next attempt.
-            if failed.status == JobStatus::Failed {
-                if let Err(e) = document_convert::delete_upload(pool, payload.upload_id).await {
-                    tracing::warn!(job_id = %job.id, error = %e, "failed to delete document upload after terminal failure");
-                }
+            if let Err(e) = document_convert::delete_upload(pool, payload.upload_id).await {
+                tracing::warn!(job_id = %job.id, error = %e, "failed to delete document upload after terminal failure");
             }
             Ok(outcome_for_error(&msg))
         }

--- a/packages/pipeline/src/worker.rs
+++ b/packages/pipeline/src/worker.rs
@@ -1252,15 +1252,18 @@ async fn process_next_document_convert_job(
             // max_attempts=1): a retry would re-run the expensive LLM conversion
             // and most failures are deterministic. Fail terminally and always
             // drop the transient upload bytes — there is no retry to feed them to.
-            job_queue::fail_job_terminal(
+            // Delete BEFORE propagating a fail_job_terminal error, so a failed
+            // status update can't `?`-return past the cleanup and leak the row.
+            let fail_result = job_queue::fail_job_terminal(
                 pool,
                 job.id,
                 Some(serde_json::json!({ "error": msg.clone() })),
             )
-            .await?;
+            .await;
             if let Err(e) = document_convert::delete_upload(pool, payload.upload_id).await {
                 tracing::warn!(job_id = %job.id, error = %e, "failed to delete document upload after terminal failure");
             }
+            fail_result?;
             Ok(outcome_for_error(&msg))
         }
     }

--- a/packages/pipeline/src/worker.rs
+++ b/packages/pipeline/src/worker.rs
@@ -1242,6 +1242,15 @@ async fn process_next_document_convert_job(
             if let Err(e) = document_convert::delete_upload(pool, payload.upload_id).await {
                 tracing::warn!(job_id = %job.id, error = %e, "failed to delete document upload after success");
             }
+            if let Err(e) = &complete_result {
+                // The markdown is already committed to git, but the status update
+                // failed. The job will show as in-progress until the orphan reaper
+                // reclaims it; log loudly so an operator can correlate.
+                tracing::error!(
+                    job_id = %job.id, error = %e, target = %payload.target_path,
+                    "document converted + committed, but marking the job completed failed"
+                );
+            }
             complete_result?;
             Ok(JobOutcome::Processed)
         }

--- a/packages/pipeline/src/worker.rs
+++ b/packages/pipeline/src/worker.rs
@@ -1207,6 +1207,17 @@ async fn process_next_document_convert_job(
         Err(e) => {
             let msg = format!("invalid document_convert payload: {e}");
             tracing::error!(job_id = %job.id, error = %msg);
+            // Best-effort: if the raw payload still yields a usable upload id,
+            // drop the orphaned bytes so a malformed job doesn't leak them.
+            if let Some(id) = job
+                .payload
+                .as_ref()
+                .and_then(|p| p.get("upload_id"))
+                .and_then(|v| v.as_str())
+                .and_then(|s| uuid::Uuid::parse_str(s).ok())
+            {
+                let _ = document_convert::delete_upload(pool, id).await;
+            }
             job_queue::fail_job_terminal(pool, job.id, Some(serde_json::json!({ "error": msg })))
                 .await?;
             return Ok(JobOutcome::Processed);


### PR DESCRIPTION
## What

Users can add a document to a traject's **werkdocumenten** by **uploading** it. Supported in phase 1: **PDF and Word (.doc/.docx)**. The uploaded file is converted to markdown **asynchronously** and the result is stored as a normal `.md` werkdocument via the existing documents git backend. The werkdocumenten screen shows the status of running and failed conversions.

Known formats are converted **deterministically** with a real tool baked into the worker image — `pandoc` for Word/office formats, `pdftotext` (poppler) for PDF. Only when no tool fits does it fall back to the **agentic** path (the same `claude`/`opencode` subprocess the enrich pipeline uses, which decides for itself how to convert). Deterministic-first is reliable, needs no network egress, and keeps the untrusted document away from the Bash-enabled LLM — shrinking the prompt-injection surface (per the security note below).

## How

**Pipeline** (`packages/pipeline`)
- New `document_convert` job type + migrations: `jobs.traject_ref` (generic job↔traject link — the foundation per-traject harvest/enrich will also use) and a `document_uploads` (bytea) table. ZAD has no blob storage, so the binary rides transiently in Postgres and is deleted after conversion / terminal failure.
- Extracted `run_llm_subprocess` from `ProcessLlmRunner::run` so enrich and document-convert share the exact spawn/drain/timeout/memory-watchdog machinery (no enrich-test change).
- `document_convert` module: payload, upload storage helpers, status-list query, deterministic conversion (`pandoc`/`pdftotext`, baked into the enrich-worker image) with the agentic `LlmDocumentConverter` as fallback, and a service-account git write-back to the traject's writable-own branch (no PR — the async worker has no user session, mirroring how enrich commits).
- The enrich worker processes document-convert jobs **ahead of** the enrich hourly-cap gate, so an interactive upload is never blocked by the bulk-enrich budget.

**editor-api** (`packages/editor-api`)
- `POST /api/trajects/{ref}/corpus/documents/upload` — multipart PDF/Word upload; stores bytes, derives a collision-safe `.md` target and enqueues a `document_convert` job (`202 Accepted`). 25 MiB body cap.
- `GET /api/trajects/{ref}/corpus/documents/jobs` — running/failed conversion jobs for the status block.

**Frontend** (`frontend`)
- "Document uploaden (PDF/Word)" row in the document list, an upload action, a conversion-status poller and a `ConversionStatus` component. Wired into both the launcher sheet and the standalone page.

## Reported deviations (per CLAUDE.md)

- **Non-design-system element:** the file picker is a hidden native `<input type="file" accept=".pdf,.doc,.docx">` triggered by an NLDD button/list-item, because `@nldd/design-system` has no file-upload/dropzone component. All visible UI is NLDD. This may be a signal for a design-system upload component.
- **Custom CSS:** `ConversionStatus.vue` adds `display:flex; flex-direction:column; gap:8px; margin-bottom:12px` to stack the status rows. That is the only custom styling on top of the design-system components.

## Testing

- Pipeline unit tests: payload (de)serialization, `target_path`/extension derivation, empty-output guard, fake-converter conversion flow.
- editor-api unit tests: `derive_markdown_target` sanitization + collision resolution.
- Frontend vitest: `uploadDocument` multipart POST, `ConversionStatus` render, updated `DocumentList` rows.
- `vite build` green.

## Smoketest on the preview (pr918)

Logged in, opened a traject's werkdocumenten, uploaded a PDF via the UI. Validated end-to-end and fixed three runtime bugs a DB-less unit test can't catch:
- Upload → `202` → `document_convert` job enqueued; jobs endpoint returns it; status block shows **"Wordt geconverteerd…"** live.
- The enrichworker claims the job (`job_type=DocumentConvert`) and runs the LLM conversion.
- **Bug 1 (fixed):** the git write-back query decoded the `corpus_source_type` enum into a Rust `String` — sqlx rejects that; now cast `source_type::text` (as editor-api does).
- **Bug 2 (fixed):** a retry re-ran the expensive LLM conversion → `max_attempts=1`.
- **Bug 3 (fixed):** with no push token the `GitBackend` went local-only — the `.md` was committed to the worker's throwaway checkout and never pushed, yet the job reported success (silent data loss). Now it fails loudly and the reason shows in the status block.

## ⚠️ Open decision: how the worker authenticates to push to traject repos

The async worker writes the `.md` with **service credentials** (it has no user session), resolving a token via `CORPUS_AUTH_<key>_TOKEN`. The **editor** instead mints short-lived **GitHub App** tokens per request. On the preview the enrichworker had no token for the traject repo, so the push silently no-op'd (now a loud failure). For the feature to actually persist conversions in production, we need to decide:
- **(a)** configure `CORPUS_AUTH_<key>_TOKEN` on the worker per traject repo (simple, but doesn't scale to federated private repos and contradicts the GitHub-App design), or
- **(b)** add GitHub App token minting to the worker path (like the editor) — the proper fix, larger.

This is the one thing blocking a fully green end-to-end conversion on the preview.

## Security & threat model (on-record acknowledgement)

The conversion is fully agentic by design: the LLM subprocess runs with `allow_bash: true` and immediately processes attacker-influenceable, user-uploaded content. This is a deliberate, accepted design choice, recorded here explicitly.

- **Who can trigger it (authorization).** The upload endpoint sits in the `editor-writer` tier — `POST .../corpus/documents/upload` is registered under `traject_writer_routes`, gated by the `require_role("editor-writer")` realm-role middleware (composite in Keycloak, so `editor-admin` inherits it), *and* the handler re-checks traject membership. So the attack surface is an **authenticated, attributable traject member with write privilege**, not an anonymous or read-only user.
- **Accepted risk.** Within that trusted group, a crafted PDF/Word file can carry prompt-injection instructions the model may follow (RCE-level subprocess behaviour). The subprocess env is stripped of `DATABASE_URL`/git tokens, but `CLAUDE_CODE_OAUTH_TOKEN` must remain (the claude CLI needs it to authenticate) and outbound network egress is unrestricted, so data exfiltration remains viable. The `opencode` default provider already had this surface via its own tool model.
- **Mitigation is architectural, not in-code.** Blast-radius reduction belongs at the container level (network-egress policy / sandbox), not in this handler — see the follow-up below. The broader indirect-injection chain (converted markdown later read by a tool-holding enrichment agent) is a cross-cutting concern captured in the prompt-injection advies (RFC candidate).

## Follow-ups (out of scope)

- **Security: restrict container network egress** for the conversion subprocess (egress allow-list / sandbox) so a successful injection cannot exfiltrate over the network. Add an operator note to the deployment runbook.

- Harvest/enrich populating `traject_ref` + a broader per-traject job overview.
- Dismiss/retry for a permanently-failed conversion job (phase 1: it stays visible with its reason).
- Caching the produced markdown across attempts (so a write failure doesn't re-run the LLM).
- Document conversions share the single enrich worker and can wait behind a long enrich job (no preemption of a running LLM subprocess).


