### PR TITLE
feat(editor): latency instrumentation for the corpus write path

### DIFF
--- a/packages/corpus/src/client.rs
+++ b/packages/corpus/src/client.rs
@@ -4,6 +4,7 @@ use tokio::process::Command;
 
 use crate::config::CorpusConfig;
 use crate::error::{CorpusError, Result};
+use crate::timing;
 
 /// Best-effort: write the snapshot contents back to disk after a failed
 /// `checkout -B`. Used only on the error path so the working tree does not
@@ -73,17 +74,22 @@ impl CorpusClient {
     ///
     /// If the repo directory doesn't exist, clones it (shallow, single branch).
     /// If it exists, fetches and resets to the remote branch.
+    #[tracing::instrument(name = "corpus_ensure_repo", skip(self))]
     pub async fn ensure_repo(&mut self) -> Result<()> {
         self.ensure_askpass_script()?;
 
         let repo_path = &self.config.repo_path;
 
+        // `clone` / `git_fetch` feed the Server-Timing phases of the same
+        // name: the cold clone is the dominant cost of a traject's first
+        // access (seconds), so it is worth isolating from the GitHub API
+        // round-trips in the breakdown.
         if repo_path.join(".git").exists() {
             tracing::info!(path = %repo_path.display(), "corpus repo exists, updating");
-            self.git_fetch_reset().await?;
+            timing::measure("git_fetch", self.git_fetch_reset()).await?;
         } else {
             tracing::info!(path = %repo_path.display(), "cloning corpus repo");
-            self.git_clone().await?;
+            timing::measure("clone", self.git_clone()).await?;
         }
 
         Ok(())
@@ -508,6 +514,7 @@ impl CorpusClient {
         Ok(true)
     }
 
+    #[tracing::instrument(name = "git_clone", skip(self), fields(branch = %self.config.branch))]
     async fn git_clone(&self) -> Result<()> {
         let url = self.config.clone_url();
         let path_str = self.config.repo_path.to_string_lossy().to_string();
@@ -668,6 +675,7 @@ impl CorpusClient {
         Ok(())
     }
 
+    #[tracing::instrument(name = "git_fetch_reset", skip(self), fields(branch = %self.config.branch))]
     async fn git_fetch_reset(&self) -> Result<()> {
         self.run_git(&["fetch", "--depth", "1", "origin", &self.config.branch])
             .await?;

--- a/packages/corpus/src/github.rs
+++ b/packages/corpus/src/github.rs
@@ -603,6 +603,7 @@ mod inner {
         /// Fetch a single file's content **plus** its blob SHA. The SHA is
         /// what the Contents API expects on a subsequent update PUT for
         /// optimistic concurrency. Returns `Ok(None)` on 404.
+        #[tracing::instrument(name = "gh_http", skip_all, fields(method = "GET", kind = "contents", repo = %repo))]
         pub async fn fetch_file_with_sha(
             &mut self,
             repo: &str,
@@ -623,6 +624,7 @@ mod inner {
                 .await
                 .map_err(|e| CorpusError::Git(format!("GitHub API request failed: {}", e)))?;
             self.track_rate_limit(&response);
+            tracing::debug!(status = %response.status(), "gh contents GET response");
 
             if response.status() == reqwest::StatusCode::NOT_FOUND {
                 return Ok(None);
@@ -665,6 +667,7 @@ mod inner {
         /// codeload URL (carrying its own token), which reqwest follows
         /// automatically — so this works for private repos with just the
         /// Bearer token on the initial request.
+        #[tracing::instrument(name = "gh_http", skip_all, fields(method = "GET", kind = "tarball", repo = %repo))]
         pub async fn fetch_archive_implements(
             &mut self,
             repo: &str,
@@ -712,6 +715,7 @@ mod inner {
         /// directory we return an empty list (404). Files only — sub-
         /// directories, symlinks and submodules are filtered out by the
         /// caller via [`DirectoryEntry::entry_type`].
+        #[tracing::instrument(name = "gh_http", skip_all, fields(method = "GET", kind = "contents_dir", repo = %repo))]
         pub async fn list_directory(
             &mut self,
             repo: &str,
@@ -780,6 +784,7 @@ mod inner {
         /// Maps 409 to [`CorpusError::Conflict`] so backends can detect a
         /// concurrent-write race and retry; everything else is `Git`.
         #[allow(clippy::too_many_arguments)]
+        #[tracing::instrument(name = "gh_http", skip_all, fields(method = "PUT", kind = "contents", repo = %repo))]
         pub async fn put_file(
             &mut self,
             repo: &str,
@@ -817,6 +822,7 @@ mod inner {
             self.track_rate_limit(&response);
 
             let status = response.status();
+            tracing::debug!(status = %status, "gh contents PUT response");
             if status == reqwest::StatusCode::CONFLICT {
                 return Err(CorpusError::Conflict(format!(
                     "Contents API PUT {} hit a 409 (stale sha)",
@@ -842,6 +848,7 @@ mod inner {
         /// blob SHA. 404 is treated as "already gone" (idempotent — same
         /// shape as [`crate::backend::RepoBackend::delete_file`]).
         #[allow(clippy::too_many_arguments)]
+        #[tracing::instrument(name = "gh_http", skip_all, fields(method = "DELETE", kind = "contents", repo = %repo))]
         pub async fn delete_file_via_api(
             &mut self,
             repo: &str,
@@ -897,6 +904,7 @@ mod inner {
 
         /// Check whether a branch exists. Returns `Ok(true)` on 200,
         /// `Ok(false)` on 404, error on anything else.
+        #[tracing::instrument(name = "gh_http", skip_all, fields(method = "GET", kind = "ref", repo = %repo))]
         pub async fn branch_exists(
             &mut self,
             repo: &str,
@@ -915,6 +923,7 @@ mod inner {
             self.track_rate_limit(&response);
 
             let status = response.status();
+            tracing::debug!(status = %status, "gh ref GET response");
             if status.is_success() {
                 return Ok(true);
             }
@@ -933,6 +942,7 @@ mod inner {
         /// Create `branch` pointing at the tip of `base_branch`. The base
         /// branch must already exist; the target branch must NOT exist
         /// (GitHub returns 422 otherwise — surfaced as `Git`).
+        #[tracing::instrument(name = "gh_http", skip_all, fields(method = "POST", kind = "create_branch", repo = %repo))]
         pub async fn create_branch(
             &mut self,
             repo: &str,
@@ -1010,6 +1020,7 @@ mod inner {
         /// beyond that. A traject realistically edits a handful of laws, so
         /// we read the first page only; a diff larger than 300 files would
         /// be under-reported (acceptable for the curated-sidebar use case).
+        #[tracing::instrument(name = "gh_http", skip_all, fields(method = "GET", kind = "compare", repo = %repo))]
         pub async fn compare_files(
             &mut self,
             repo: &str,

--- a/packages/corpus/src/github_api_backend.rs
+++ b/packages/corpus/src/github_api_backend.rs
@@ -426,7 +426,11 @@ impl RepoBackend for GitHubApiBackend {
             return Ok(PersistOutcome::default());
         }
         // Wall-clock of the whole Contents API commit (PUT/DELETE, plus any
-        // sha-refresh retry) — the `gh_put` Server-Timing phase.
+        // sha-refresh retry) — the `gh_put` Server-Timing phase. Best-effort,
+        // same as `ensure_ready`: recorded only on the success path below, so
+        // a `persist` that fails via `?` (e.g. a `try_put` error) yields a
+        // response with no `gh_put` phase. `persist` is not a single future,
+        // so it can't use the record-on-both-paths `timing::measure` wrapper.
         let put_start = std::time::Instant::now();
 
         // Committer falls back to a service identity when no human is

--- a/packages/corpus/src/github_api_backend.rs
+++ b/packages/corpus/src/github_api_backend.rs
@@ -36,6 +36,7 @@ use crate::backend::{FileEntry, PersistOutcome, RecursiveFileEntry, RepoBackend,
 use crate::error::{CorpusError, Result};
 use crate::github::{Committer, GitHubFetcher};
 use crate::models::GitHubSource;
+use crate::timing;
 
 /// Pending change buffered between `write_file`/`delete_file` and
 /// `persist`. `base_sha` is `Some` when the caller read the file first
@@ -200,18 +201,22 @@ fn validate_relative(path: &Path) -> Result<()> {
 
 #[async_trait]
 impl RepoBackend for GitHubApiBackend {
+    #[tracing::instrument(name = "gh_read_file", skip_all, fields(path = %relative_path.display()))]
     async fn read_file(&self, relative_path: &Path) -> Result<Option<String>> {
         let api_path = self.api_path(relative_path)?;
         let mut inner = self.inner.lock().await;
-        let outcome = inner
-            .fetcher
-            .fetch_file_with_sha(
+        // One Contents API GET — the If-Match precondition read on the save
+        // path lands here, so it feeds the `gh_get` Server-Timing phase.
+        let outcome = timing::measure(
+            "gh_get",
+            inner.fetcher.fetch_file_with_sha(
                 &self.full_repo(),
                 &self.branch,
                 &api_path,
                 self.token.as_deref(),
-            )
-            .await?;
+            ),
+        )
+        .await?;
         match outcome {
             Some((content, sha)) => {
                 inner.sha_cache.insert(relative_path.to_path_buf(), sha);
@@ -411,6 +416,7 @@ impl RepoBackend for GitHubApiBackend {
         Ok(out)
     }
 
+    #[tracing::instrument(name = "gh_persist", skip_all)]
     async fn persist(&self, ctx: &WriteContext) -> Result<PersistOutcome> {
         let pending: Vec<(PathBuf, PendingWrite)> = {
             let mut inner = self.inner.lock().await;
@@ -419,6 +425,9 @@ impl RepoBackend for GitHubApiBackend {
         if pending.is_empty() {
             return Ok(PersistOutcome::default());
         }
+        // Wall-clock of the whole Contents API commit (PUT/DELETE, plus any
+        // sha-refresh retry) — the `gh_put` Server-Timing phase.
+        let put_start = std::time::Instant::now();
 
         // Committer falls back to a service identity when no human is
         // attached — same shape as `GitBackend` (the trailer/co-author
@@ -504,6 +513,8 @@ impl RepoBackend for GitHubApiBackend {
             inner.sha_cache.insert(path, sha);
         }
 
+        timing::record("gh_put", put_start.elapsed());
+
         // Contents API commits straight to the configured branch — no
         // PR is opened. The trajectflow already accepted `pr: None`
         // from the previous `GitBackend` impl, so this is wire-
@@ -511,6 +522,7 @@ impl RepoBackend for GitHubApiBackend {
         Ok(PersistOutcome::default())
     }
 
+    #[tracing::instrument(name = "gh_ensure_ready", skip_all, fields(branch = %self.branch))]
     async fn ensure_ready(&mut self) -> Result<()> {
         // Read-only backends have nothing to bootstrap — the branch
         // either exists (reads work) or it doesn't (reads 404 as
@@ -519,6 +531,9 @@ impl RepoBackend for GitHubApiBackend {
         if self.token.is_none() {
             return Ok(());
         }
+        // Branch-check (+ lazy create) round-trips against GitHub; feeds
+        // the `ensure_ready` Server-Timing phase on the cold-build path.
+        let ready_start = std::time::Instant::now();
         let inner = self.inner.get_mut();
         let repo = format!("{}/{}", self.owner, self.repo);
         let exists = inner
@@ -526,6 +541,7 @@ impl RepoBackend for GitHubApiBackend {
             .branch_exists(&repo, &self.branch, self.token.as_deref())
             .await?;
         if exists {
+            timing::record("ensure_ready", ready_start.elapsed());
             return Ok(());
         }
         let base = self.base_branch.as_deref().ok_or_else(|| {
@@ -572,6 +588,7 @@ impl RepoBackend for GitHubApiBackend {
                 }
             }
         }
+        timing::record("ensure_ready", ready_start.elapsed());
         Ok(())
     }
 
@@ -651,8 +668,13 @@ async fn try_put(
             // A PUT without `sha` against an existing file returns 422
             // ("sha was not supplied"). Resolve the SHA and retry once
             // — covers `save_law` / `save_scenario` which call
-            // `write_file` without a preceding `read_file`.
-            tracing::debug!(repo = %repo, path = %path, "PUT 422 — fetching sha and retrying as update");
+            // `write_file` without a preceding `read_file`. This is the
+            // extra GET→PUT round-trip a cold sha-cache pays; logged at
+            // info with `gh_put_retry=422` so it can be counted in
+            // `zad logs`. It stays inside the enclosing `gh_put` phase
+            // (no separate header phase) so the Server-Timing breakdown
+            // does not double-count this leg.
+            tracing::info!(repo = %repo, path = %path, gh_put_retry = 422, "PUT 422 — fetching sha and retrying as update");
             let fresh = fetcher
                 .fetch_file_with_sha(repo, branch, path, token)
                 .await?

--- a/packages/corpus/src/lib.rs
+++ b/packages/corpus/src/lib.rs
@@ -17,6 +17,7 @@ pub mod registry;
 #[cfg(feature = "github")]
 pub mod repo_access;
 pub mod source_map;
+pub mod timing;
 pub mod validation;
 
 pub use backend::PrInfo;

--- a/packages/corpus/src/timing.rs
+++ b/packages/corpus/src/timing.rs
@@ -1,0 +1,179 @@
+//! Request-scoped phase timing.
+//!
+//! The editor's write and build paths are dominated by GitHub round-trips
+//! (Contents API GET/PUT, branch create, `git clone`). To see *where* a
+//! request spends its time we record named phase durations from deep in
+//! the corpus code and surface them two ways:
+//!
+//! * as a `Server-Timing` response header (editor-api middleware), and
+//! * implicitly in the logs via `tracing` spans on the same call sites.
+//!
+//! Mechanism: a `tokio` task-local holding a shared [`Recorder`]. The
+//! editor-api middleware installs one per request via [`scope`]; deep code
+//! calls [`measure`] / [`record`], which are cheap no-ops when no recorder
+//! is installed (a worker process, a unit test, a non-instrumented
+//! endpoint). Nothing has to be threaded through the call graph.
+//!
+//! This lives in `regelrecht-corpus` — not `regelrecht-shared` — on
+//! purpose: both the corpus backends *and* editor-api already depend on
+//! this crate, so no new crate dependency edge is introduced (and
+//! `regelrecht-shared` stays free of a `tokio` dependency).
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+/// Collects the phase durations recorded during a single request.
+#[derive(Default)]
+pub struct Recorder {
+    /// `(phase name, wall-clock duration)` in the order phases first fire.
+    /// A phase name may repeat (e.g. two Contents GETs in one save); the
+    /// formatter accumulates by name.
+    phases: Mutex<Vec<(&'static str, Duration)>>,
+}
+
+impl Recorder {
+    /// A fresh shared recorder, ready to hand to [`scope`].
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+
+    /// Append a phase measurement. Poisoned-lock tolerant: instrumentation
+    /// must never take down the request it is measuring.
+    fn push(&self, name: &'static str, dur: Duration) {
+        if let Ok(mut phases) = self.phases.lock() {
+            phases.push((name, dur));
+        }
+    }
+
+    /// Render the recorded phases plus `total` as a `Server-Timing` header
+    /// value, e.g. `lock;dur=40.0, gh_get;dur=210.3, total;dur=850.0`.
+    pub fn server_timing_header(&self, total: Duration) -> String {
+        let phases = self.phases.lock().map(|p| p.clone()).unwrap_or_default();
+        format_server_timing(&phases, total)
+    }
+}
+
+tokio::task_local! {
+    static RECORDER: Arc<Recorder>;
+}
+
+/// Run `fut` with `recorder` installed as the request-scoped recorder, so
+/// any [`measure`]/[`record`] call reached from within `fut` (on the same
+/// task) lands in it. Calls from tasks spawned inside `fut` are NOT
+/// captured — task-locals do not cross `tokio::spawn`.
+pub async fn scope<F>(recorder: Arc<Recorder>, fut: F) -> F::Output
+where
+    F: Future,
+{
+    RECORDER.scope(recorder, fut).await
+}
+
+/// Record a phase against the current request's recorder, if one is
+/// installed. A no-op otherwise — safe to call from any context.
+pub fn record(name: &'static str, dur: Duration) {
+    let _ = RECORDER.try_with(|recorder| recorder.push(name, dur));
+}
+
+/// Await `fut`, recording its wall-clock duration under `name` against the
+/// current request's recorder (no-op when none is installed). Returns the
+/// future's output unchanged.
+pub async fn measure<F>(name: &'static str, fut: F) -> F::Output
+where
+    F: Future,
+{
+    let start = Instant::now();
+    let out = fut.await;
+    record(name, start.elapsed());
+    out
+}
+
+/// Sum durations per phase name (first-seen order preserved) and render a
+/// `Server-Timing` header value, always ending in `total`.
+fn format_server_timing(phases: &[(&'static str, Duration)], total: Duration) -> String {
+    let mut order: Vec<&'static str> = Vec::new();
+    let mut sums: HashMap<&'static str, Duration> = HashMap::new();
+    for (name, dur) in phases {
+        if !sums.contains_key(name) {
+            order.push(name);
+        }
+        *sums.entry(name).or_default() += *dur;
+    }
+
+    let mut parts: Vec<String> = order
+        .iter()
+        .map(|name| format!("{};dur={:.1}", name, millis(sums[name])))
+        .collect();
+    parts.push(format!("total;dur={:.1}", millis(total)));
+    parts.join(", ")
+}
+
+fn millis(d: Duration) -> f64 {
+    d.as_secs_f64() * 1000.0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn formats_phases_and_appends_total_last() {
+        let phases = vec![
+            ("lock", Duration::from_millis(40)),
+            ("gh_get", Duration::from_millis(210)),
+            ("gh_put", Duration::from_millis(580)),
+        ];
+        let header = format_server_timing(&phases, Duration::from_millis(850));
+        assert_eq!(
+            header,
+            "lock;dur=40.0, gh_get;dur=210.0, gh_put;dur=580.0, total;dur=850.0"
+        );
+    }
+
+    #[test]
+    fn accumulates_repeated_phase_names_in_first_seen_order() {
+        let phases = vec![
+            ("gh_get", Duration::from_millis(100)),
+            ("gh_put", Duration::from_millis(300)),
+            ("gh_get", Duration::from_millis(50)),
+        ];
+        let header = format_server_timing(&phases, Duration::from_millis(500));
+        // gh_get keeps its first position and sums to 150.
+        assert_eq!(
+            header,
+            "gh_get;dur=150.0, gh_put;dur=300.0, total;dur=500.0"
+        );
+    }
+
+    #[test]
+    fn header_with_no_phases_is_just_total() {
+        let header = format_server_timing(&[], Duration::from_millis(12));
+        assert_eq!(header, "total;dur=12.0");
+    }
+
+    #[tokio::test]
+    async fn record_outside_scope_is_a_noop() {
+        // Must not panic when no recorder is installed.
+        record("gh_get", Duration::from_millis(5));
+        let out = measure("gh_put", async { 7 }).await;
+        assert_eq!(out, 7);
+    }
+
+    #[tokio::test]
+    async fn measure_and_record_land_in_the_scoped_recorder() {
+        let recorder = Recorder::new();
+        let captured = recorder.clone();
+        scope(recorder, async {
+            record("lock", Duration::from_millis(10));
+            measure("gh_get", async {}).await;
+        })
+        .await;
+        let header = captured.server_timing_header(Duration::from_millis(20));
+        assert!(
+            header.starts_with("lock;dur=10.0, gh_get;dur="),
+            "got: {header}"
+        );
+        assert!(header.ends_with("total;dur=20.0"), "got: {header}");
+    }
+}

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -20,6 +20,7 @@ use regelrecht_corpus::dto::{build_source_summaries, PaginationParams, SourceSum
 use regelrecht_corpus::source_map::{
     collect_law_outputs, extract_law_id, validate_yaml_syntax, LoadedLaw,
 };
+use regelrecht_corpus::timing;
 use regelrecht_corpus::CorpusError;
 
 use crate::accounts::AccountRecord;
@@ -1457,7 +1458,10 @@ async fn resolve_traject_law_write(
     if !entry.writable {
         return Err((StatusCode::FORBIDDEN, "Source is read-only".to_string()));
     }
-    let backend = entry.backend.clone().lock_owned().await;
+    // Per-source write mutex: every save to the same traject source
+    // serialises here, so contention (a second save waiting out the
+    // first's GitHub round-trips) shows up as a fat `lock` phase.
+    let backend = timing::measure("lock", entry.backend.clone().lock_owned()).await;
     Ok(TrajectLawWrite {
         law,
         write_source_id: write_target_source_id,

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -33,7 +33,11 @@ use state::{AppState, CorpusState};
 
 #[tokio::main]
 async fn main() {
-    regelrecht_shared::telemetry::init_subscriber("info");
+    // The editor is the service that wants the write/build-path latency
+    // breakdown, so it opts *itself* into span-close timing logs (passing
+    // `true`), while the shared subscriber leaves them off by default for
+    // the hot-path workers. `LOG_SPAN_EVENTS` still overrides at runtime.
+    regelrecht_shared::telemetry::init_subscriber_with_spans("info", true);
 
     let app_config = config::AppConfig::from_env();
 
@@ -515,6 +519,11 @@ async fn main() {
             .merge(user_notes_reader_routes)
             .merge(user_notes_writer_routes)
             .with_state(app_state)
+            // Innermost custom layer: wraps the routed handlers most
+            // tightly, so the request-scoped timing recorder is installed
+            // (and read back into the `Server-Timing` header) around the
+            // exact code that records the phases.
+            .layer(axum_middleware::from_fn(middleware::server_timing))
             // Inside the session layer (session loaded) and outside the route
             // role gates (fresh roles / a dropped auth marker are seen by the
             // gate). Innermost .layer() so session_layer wraps it.
@@ -551,6 +560,9 @@ async fn main() {
             .merge(user_notes_reader_routes)
             .merge(user_notes_writer_routes)
             .with_state(app_state)
+            // See the auth branch above: innermost layer so the timing
+            // recorder wraps the routed handlers.
+            .layer(axum_middleware::from_fn(middleware::server_timing))
             .layer(session_layer)
             .layer(axum_middleware::from_fn(middleware::security_headers))
             .layer(TraceLayer::new_for_http())

--- a/packages/editor-api/src/middleware.rs
+++ b/packages/editor-api/src/middleware.rs
@@ -1,1 +1,37 @@
 pub use regelrecht_auth::middleware::{refresh_session_token, require_role, security_headers};
+
+use axum::extract::Request;
+use axum::http::{header::HeaderName, HeaderValue};
+use axum::middleware::Next;
+use axum::response::Response;
+use regelrecht_corpus::timing;
+use std::time::Instant;
+
+/// `Server-Timing` header name, added to every response.
+static SERVER_TIMING: HeaderName = HeaderName::from_static("server-timing");
+
+/// Per-request middleware that installs a [`timing::Recorder`] for the
+/// duration of the request and, once the handler returns, emits the
+/// collected phase durations plus `total` as a `Server-Timing` response
+/// header — e.g. `lock;dur=40.0, gh_get;dur=210.3, gh_put;dur=580.1,
+/// total;dur=850.0`.
+///
+/// The phases are recorded deep in the corpus write/build path (GitHub
+/// Contents GET/PUT, per-source lock wait, cold clone/index) via the
+/// task-local recorder; see [`regelrecht_corpus::timing`]. Endpoints that
+/// touch none of that still get a `total`.
+///
+/// Same-origin note: the editor SPA is served by this very service, so
+/// `Timing-Allow-Origin` is not needed for DevTools to read the header.
+/// The phase names leak no secrets and the endpoints already sit behind
+/// auth, so the header is always on.
+pub async fn server_timing(req: Request, next: Next) -> Response {
+    let recorder = timing::Recorder::new();
+    let start = Instant::now();
+    let mut response = timing::scope(recorder.clone(), next.run(req)).await;
+    let header = recorder.server_timing_header(start.elapsed());
+    if let Ok(value) = HeaderValue::from_str(&header) {
+        response.headers_mut().insert(SERVER_TIMING.clone(), value);
+    }
+    response
+}

--- a/packages/editor-api/src/traject_corpus.rs
+++ b/packages/editor-api/src/traject_corpus.rs
@@ -30,6 +30,7 @@ use std::time::{Duration, Instant};
 use regelrecht_corpus::backend::create_backend;
 use regelrecht_corpus::models::{GitHubSource, LocalSource, Source, SourceType};
 use regelrecht_corpus::source_map::collect_law_implements;
+use regelrecht_corpus::timing;
 use regelrecht_corpus::{CorpusRegistry, SourceMap};
 use sqlx::PgPool;
 use tokio::sync::{Mutex, RwLock};
@@ -929,7 +930,8 @@ impl TrajectCorpusCache {
             let state = slot.state.read().await;
             match state.as_ref() {
                 Some(cached) if cached.is_fresh(self.index_ttl) => {
-                    return Ok(cached.corpus.clone())
+                    tracing::debug!(traject = %traject_id, cache = "hit", "traject corpus served from cache");
+                    return Ok(cached.corpus.clone());
                 }
                 Some(cached) => Some(cached.corpus.clone()),
                 None => None,
@@ -953,7 +955,8 @@ impl TrajectCorpusCache {
             let state = slot.state.read().await;
             match state.as_ref() {
                 Some(cached) if cached.is_fresh(self.index_ttl) => {
-                    return Ok(cached.corpus.clone())
+                    tracing::debug!(traject = %traject_id, cache = "hit", "traject corpus served from cache");
+                    return Ok(cached.corpus.clone());
                 }
                 Some(cached) => Some(cached.corpus.clone()),
                 None => None,
@@ -961,40 +964,49 @@ impl TrajectCorpusCache {
         };
 
         let corpus = match stale {
-            None => build_traject_corpus(pool, traject_id, auth_file.as_deref()).await?,
-            Some(old) => match refresh_traject_corpus(&old, traject_id).await {
-                Ok(refreshed) => refreshed,
-                Err(e) => {
-                    // Serve (and re-arm) the stale snapshot rather than
-                    // failing reads on a transient enumeration error; the
-                    // re-armed `built_at` stops every subsequent request
-                    // from re-attempting against a throttled upstream.
-                    // Rate-limit the warn: a permanently broken source
-                    // fails every TTL window, and repeating the same warn
-                    // each minute drowns the log without new signal.
-                    let failures = slot.refresh_failures.fetch_add(1, Ordering::SeqCst) + 1;
-                    if failures == 1 || failures % FAILED_REFRESH_WARN_EVERY == 0 {
-                        tracing::warn!(
-                            traject = %traject_id,
-                            error = %e,
-                            consecutive_failures = failures,
-                            "traject index refresh failed; serving stale snapshot for another TTL"
-                        );
-                    } else {
-                        tracing::debug!(
-                            traject = %traject_id,
-                            error = %e,
-                            consecutive_failures = failures,
-                            "traject index refresh failed again; serving stale snapshot for another TTL"
-                        );
+            None => {
+                tracing::debug!(traject = %traject_id, cache = "cold", "building traject corpus (cold)");
+                timing::measure(
+                    "build",
+                    build_traject_corpus(pool, traject_id, auth_file.as_deref()),
+                )
+                .await?
+            }
+            Some(old) => {
+                match timing::measure("refresh", refresh_traject_corpus(&old, traject_id)).await {
+                    Ok(refreshed) => refreshed,
+                    Err(e) => {
+                        // Serve (and re-arm) the stale snapshot rather than
+                        // failing reads on a transient enumeration error; the
+                        // re-armed `built_at` stops every subsequent request
+                        // from re-attempting against a throttled upstream.
+                        // Rate-limit the warn: a permanently broken source
+                        // fails every TTL window, and repeating the same warn
+                        // each minute drowns the log without new signal.
+                        let failures = slot.refresh_failures.fetch_add(1, Ordering::SeqCst) + 1;
+                        if failures == 1 || failures % FAILED_REFRESH_WARN_EVERY == 0 {
+                            tracing::warn!(
+                                traject = %traject_id,
+                                error = %e,
+                                consecutive_failures = failures,
+                                "traject index refresh failed; serving stale snapshot for another TTL"
+                            );
+                        } else {
+                            tracing::debug!(
+                                traject = %traject_id,
+                                error = %e,
+                                consecutive_failures = failures,
+                                "traject index refresh failed again; serving stale snapshot for another TTL"
+                            );
+                        }
+                        *slot.state.write().await = Some(CachedCorpus {
+                            corpus: old.clone(),
+                            built_at: Instant::now(),
+                        });
+                        return Ok(old);
                     }
-                    *slot.state.write().await = Some(CachedCorpus {
-                        corpus: old.clone(),
-                        built_at: Instant::now(),
-                    });
-                    return Ok(old);
                 }
-            },
+            }
         };
 
         slot.refresh_failures.store(0, Ordering::SeqCst);
@@ -1048,6 +1060,7 @@ impl From<regelrecht_corpus::error::CorpusError> for TrajectCorpusError {
 
 /// Build a fresh [`TrajectCorpus`]: load sources from DB, clone backends,
 /// produce a [`SourceMap`].
+#[tracing::instrument(name = "build_traject_corpus", skip_all, fields(traject = %traject_id))]
 async fn build_traject_corpus(
     pool: &PgPool,
     traject_id: Uuid,
@@ -1237,29 +1250,30 @@ async fn build_traject_corpus(
     // failing entirely on what is usually a transient GitHub hiccup. The hard
     // failure path is the writable-own *backend* init above, which returns
     // `Err` so a broken write target never opens silently.
-    let source_map = match registry.index_all_sources_async(auth_file).await {
-        Ok((map, failed)) => {
-            if failed.iter().any(|id| id == &writable_own_source_id) {
-                tracing::error!(
-                    traject = %traject_id,
-                    source_id = %writable_own_source_id,
-                    "traject writable-own source failed to load — the traject's own laws \
-                     will be missing from the bibliotheek until the corpus is rebuilt"
-                );
+    let source_map =
+        match timing::measure("index", registry.index_all_sources_async(auth_file)).await {
+            Ok((map, failed)) => {
+                if failed.iter().any(|id| id == &writable_own_source_id) {
+                    tracing::error!(
+                        traject = %traject_id,
+                        source_id = %writable_own_source_id,
+                        "traject writable-own source failed to load — the traject's own laws \
+                         will be missing from the bibliotheek until the corpus is rebuilt"
+                    );
+                }
+                map
             }
-            map
-        }
-        Err(e) => {
-            tracing::warn!(
-                traject = %traject_id,
-                error = %e,
-                "traject corpus load failed, falling back to local-only"
-            );
-            registry
-                .load_local_sources()
-                .unwrap_or_else(|_| SourceMap::new())
-        }
-    };
+            Err(e) => {
+                tracing::warn!(
+                    traject = %traject_id,
+                    error = %e,
+                    "traject corpus load failed, falling back to local-only"
+                );
+                registry
+                    .load_local_sources()
+                    .unwrap_or_else(|_| SourceMap::new())
+            }
+        };
 
     Ok(Arc::new(TrajectCorpus {
         corpus: CorpusState {

--- a/packages/shared/src/telemetry.rs
+++ b/packages/shared/src/telemetry.rs
@@ -3,6 +3,8 @@
 //! Each binary previously hand-rolled the same `tracing_subscriber::fmt()`
 //! initialization. [`init_subscriber`] consolidates that pattern.
 
+use std::env::VarError;
+
 use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::EnvFilter;
 
@@ -54,8 +56,9 @@ pub fn init_subscriber_with_spans(default_level: &str, default_span_events: bool
     }
 }
 
-/// Resolve the [`FmtSpan`] mask: `LOG_SPAN_EVENTS` wins when set, otherwise
-/// fall back to the caller's `default_on` (CLOSE when on, NONE when off).
+/// Resolve the [`FmtSpan`] mask: a *set* `LOG_SPAN_EVENTS` always wins;
+/// only a genuinely absent variable falls back to the caller's `default_on`
+/// (CLOSE when on, NONE when off).
 fn resolve_span_events(default_on: bool) -> FmtSpan {
     match std::env::var("LOG_SPAN_EVENTS") {
         Ok(raw) => match raw.to_ascii_lowercase().as_str() {
@@ -66,7 +69,12 @@ fn resolve_span_events(default_on: bool) -> FmtSpan {
             // Explicit off (or any unrecognised value) — never span events.
             _ => FmtSpan::NONE,
         },
-        Err(_) if default_on => FmtSpan::CLOSE,
-        Err(_) => FmtSpan::NONE,
+        // The variable is set but not valid UTF-8: it is still an explicit
+        // (if garbled) override, so treat it as "unrecognised" → off, never
+        // silently fall back to `default_on`.
+        Err(VarError::NotUnicode(_)) => FmtSpan::NONE,
+        // Genuinely unset: honour the per-service default.
+        Err(VarError::NotPresent) if default_on => FmtSpan::CLOSE,
+        Err(VarError::NotPresent) => FmtSpan::NONE,
     }
 }

--- a/packages/shared/src/telemetry.rs
+++ b/packages/shared/src/telemetry.rs
@@ -3,6 +3,7 @@
 //! Each binary previously hand-rolled the same `tracing_subscriber::fmt()`
 //! initialization. [`init_subscriber`] consolidates that pattern.
 
+use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::EnvFilter;
 
 /// Install the default `tracing_subscriber::fmt` global subscriber, honoring
@@ -12,13 +13,60 @@ use tracing_subscriber::EnvFilter;
 /// already set up a subscriber) leaves the existing subscriber intact rather
 /// than panicking. The error is reported on stderr because the very subscriber
 /// we tried to install is unavailable at that moment.
+///
+/// Span events are off (`FmtSpan::NONE`) — the pre-existing behaviour every
+/// caller had. See [`init_subscriber_with_spans`] to turn them on.
 pub fn init_subscriber(default_level: &str) {
+    init_subscriber_with_spans(default_level, false);
+}
+
+/// Like [`init_subscriber`], but `default_span_events` chooses the fallback
+/// when `LOG_SPAN_EVENTS` is unset.
+///
+/// ## Span-close timing logs
+///
+/// With span events on (`FmtSpan::CLOSE`), a log line is emitted when each
+/// `tracing` span closes, carrying its `time.busy`/`time.idle` duration.
+/// This turns the `#[tracing::instrument]` spans on the editor's
+/// write/build path into a per-step latency breakdown in `zad logs`.
+///
+/// It is **opt-in per service** on purpose: `init_subscriber` is shared by
+/// hot-path services (the harvest/enrich workers, the pipeline API), where
+/// a close event per span would multiply log volume for no benefit — they
+/// keep the `default_span_events = false` default. Only services that want
+/// the breakdown (editor-api) call this with `true`.
+///
+/// `LOG_SPAN_EVENTS`, when set, always wins over `default_span_events` — so
+/// an operator can force spans on (`close`/`new`/`active`/`full`) or off
+/// (`none`, or any unrecognised value) without a redeploy. Passing the
+/// default as an argument rather than mutating the process environment
+/// avoids the `set_var`-under-a-running-runtime data-race caveat and keeps
+/// the setting from leaking into child processes (git subprocesses, etc.).
+pub fn init_subscriber_with_spans(default_level: &str, default_span_events: bool) {
     if let Err(e) = tracing_subscriber::fmt()
         .with_env_filter(
             EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default_level)),
         )
+        .with_span_events(resolve_span_events(default_span_events))
         .try_init()
     {
         eprintln!("warning: tracing subscriber already initialized: {e}");
+    }
+}
+
+/// Resolve the [`FmtSpan`] mask: `LOG_SPAN_EVENTS` wins when set, otherwise
+/// fall back to the caller's `default_on` (CLOSE when on, NONE when off).
+fn resolve_span_events(default_on: bool) -> FmtSpan {
+    match std::env::var("LOG_SPAN_EVENTS") {
+        Ok(raw) => match raw.to_ascii_lowercase().as_str() {
+            "close" => FmtSpan::CLOSE,
+            "new" => FmtSpan::NEW,
+            "active" => FmtSpan::ACTIVE,
+            "full" => FmtSpan::FULL,
+            // Explicit off (or any unrecognised value) — never span events.
+            _ => FmtSpan::NONE,
+        },
+        Err(_) if default_on => FmtSpan::CLOSE,
+        Err(_) => FmtSpan::NONE,
     }
 }


### PR DESCRIPTION
## What & why

The editor feels slow because git repositories (GitHub) back the corpus storage: saving laws/scenarios, starting trajects and editing annotations all wait synchronously on GitHub calls. Before optimizing, we want to *see* where the time goes per request. This PR is **pure instrumentation** — no behavior change to the save path.

Two outputs:

1. **Tracing spans with duration logging** around the expensive steps of the write/build path, so `zad logs` shows a per-action breakdown.
2. **A `Server-Timing` response header** on the corpus endpoints, so the same breakdown is visible in browser DevTools (Network → Timing) next to the frontend waterfall.

Out of scope (deliberately): Prometheus/Grafana metrics, and any change to the save path itself.

## How it works

- New `regelrecht_corpus::timing` module: a `tokio` task-local holding a request-scoped `Recorder`. The editor-api middleware installs one per request via `timing::scope`; deep corpus code calls `timing::measure(name, fut)` / `timing::record(name, dur)`, which are **no-ops when no recorder is installed** (worker processes, unit tests). Nothing is threaded through the call graph.
  - It lives in `regelrecht-corpus` (not `regelrecht-shared`) on purpose: both the corpus backends *and* editor-api already depend on this crate, so **no new crate dependency edge** is introduced, and `regelrecht-shared` stays free of a `tokio` dependency.
- New editor-api `server_timing` middleware formats the recorded phases + `total` into the header, e.g. `lock;dur=0.1, gh_get;dur=210.3, gh_put;dur=580.1, total;dur=850.0`.
- Span-close timing logs are **opt-in** via `LOG_SPAN_EVENTS` in the shared subscriber (`FmtSpan::CLOSE`). `init_subscriber` is shared with the hot-path workers (harvest/enrich/pipeline), where a close-event-per-span would explode log volume — so the default stays off and **editor-api opts itself in** (`LOG_SPAN_EVENTS=close`) in `main`.

### Instrumented phases (header + logs)

| phase | where | meaning |
|-------|-------|---------|
| `lock` | `resolve_traject_law_write` | wait on the per-source write mutex |
| `gh_get` | `GitHubApiBackend::read_file` | Contents API GET (If-Match precondition read) |
| `gh_put` | `GitHubApiBackend::persist` | Contents API commit (PUT/DELETE), incl. any 422 retry leg |
| `ensure_ready` | `GitHubApiBackend::ensure_ready` | branch check + lazy create |
| `clone` / `git_fetch` | `CorpusClient::ensure_repo` | cold `git clone` / fetch-reset of a seed source |
| `index` | `build_traject_corpus` | `index_all_sources_async` (per-source Trees index) |
| `build` / `refresh` | `get_or_build` | cold traject-corpus build vs. TTL refresh (cache-hit logs `cache=hit`) |
| `total` | middleware | whole request |

Log-only (Part 1): per-HTTP-call `gh_http` spans in the fetcher (method + endpoint kind + status), `git_clone`/`git_fetch_reset` spans, and the countable `gh_put_retry=422` info line on the cold-sha-cache retry path (kept out of the header so the phases don't double-count that leg).

## Verification

Static + unit verification (all green on this branch):

- `cargo fmt --check` (workspace) ✓
- `cargo clippy --all-features` with `RUSTFLAGS=-Dwarnings` (workspace) ✓
- `cargo check -p regelrecht-editor-api -p regelrecht-corpus` ✓
- `cargo test -p regelrecht-corpus timing` → **5 passed** (header formatting, per-name accumulation, total-always-last, no-op outside scope, scoped record/measure) ✓
- `cargo test -p regelrecht-editor-api --lib` → **64 passed** ✓

**Live measurement deferred to the preview (explicit shortcut).** The spec asks
for a local end-to-end run (real save + traject-open) with the `Server-Timing`
header and span-duration log lines captured as evidence. By agreement we ship on
green unit tests + review and let the reviewer read the first real breakdown off
the live preview:

- Preview editor: **https://editor-pr919-regel-k4c.rig.prd1.gn2.quattro.rijksapps.nl**
- Do a save in the editor → DevTools → Network → the save (PUT) request → Timing tab: the `Server-Timing` phases (`lock`, `gh_get`, `gh_put`, `total`, …) render there.
- `zad logs pr919` (or the deployment log) for the `close` span lines and the `gh_put_retry=422` counter.

> Heads-up unrelated to this PR: `packages/editor-api/tests/save_annotations_test.rs`
> does **not compile against current `main`** (it calls `get_annotations` with a
> `Session` arg the 2-arg handler no longer takes). editor-api integration tests
> don't run in CI, so it rotted silently. It is out of scope here; flagging it so
> it can be fixed separately. `just check` is unaffected — it runs
> `editor-api-check` (compile), not the integration tests.

## Shortcuts / notes

- **Task-locals do not cross `tokio::spawn`.** If `index_all_sources_async` fans out per-source work onto spawned tasks, those inner phases won't reach the *header* (they still log their own span-close durations). The header still shows the aggregate `index` phase measured at the call site. Acceptable — the header is a summary, the logs have the detail.
- No new dependencies; only `tracing`/`tracing-subscriber`/`tokio` features already present.
- `Timing-Allow-Origin` is **not** set: the SPA is served same-origin by this service, so DevTools can read the header without it. Header names leak no secrets and endpoints sit behind auth, so it's always on.
- **Log volume:** defaulting editor-api to span-close events adds one INFO close line per instrumented span (notably one per GitHub round-trip). Intended — that *is* the breakdown — but a real change to editor-api's log output. Workers/pipeline are unaffected (they never opt in). `LOG_SPAN_EVENTS=none` turns it off without a redeploy.
- The `ensure_ready` and `gh_put` (`persist`) phases are best-effort: their durations are recorded on the success paths, not on a mid-function `?` error return (both functions are multi-step, not a single future to wrap with `timing::measure`, which records on both outcomes). A failed save/branch-create response may therefore omit that phase.
- A code review (correctness, save-path invariance, secret-leak, async-trait/instrument composition) found no correctness bugs; the two actionable notes (avoid `env::set_var` under the runtime → explicit `init_subscriber_with_spans(_, true)` param; drop the overlapping `gh_put_retry` header phase) are applied.
