### PR TITLE
perf(frontend): dedupe law body and laws-list fetches on editor open

### DIFF
--- a/frontend/src/EditorView.vue
+++ b/frontend/src/EditorView.vue
@@ -3,7 +3,7 @@ import { ref, computed, reactive, watch, watchEffect, nextTick, onBeforeUnmount 
 import { useRoute, useRouter, onBeforeRouteUpdate } from 'vue-router';
 import * as yaml from 'js-yaml';
 import { useLaw, fetchLaw } from './composables/useLaw.js';
-import { lawsListUrl } from './composables/corpusUrls.js';
+import { useCorpusLaws } from './composables/useCorpusLaws.js';
 import { useEngine } from './composables/useEngine.js';
 import { useAuth } from './composables/useAuth.js';
 import { useTrajects } from './composables/useTrajects.js';
@@ -20,7 +20,7 @@ import {
   clearEditorChrome,
 } from './composables/useAppChrome.js';
 import { SUPPORT_EMAIL } from './constants.js';
-import { apiFetch, apiFetchJson } from './lib/apiFetch.js';
+import { apiFetch } from './lib/apiFetch.js';
 import { humanizeLawId } from './lib/lawName.js';
 import { useLatest } from './lib/useLatest.js';
 import ArticleText from './components/ArticleText.vue';
@@ -369,34 +369,26 @@ const resultSheetOpen = ref(false);
 const graphSheetOpen = ref(false);
 
 // --- Corpus search (reuse the shared SearchPopover) ---
-const corpusLaws = ref([]);
 const searchPopoverRef = ref(null);
 // The toolbar search control lives in the AppShell; register our popover so
 // the shell's search button/field opens it.
 registerSearchPopover(searchPopoverRef);
 
-// Discards stale responses across rapid traject switches.
-const claimCorpusLaws = useLatest();
-
-async function loadCorpusLaws() {
-  const isCurrent = claimCorpusLaws();
-  try {
-    const list = await apiFetchJson(lawsListUrl(activeTrajectRef.value, 'limit=1000'));
-    if (!isCurrent()) return; // stale response, discard
-    corpusLaws.value = list.sort((a, b) => a.law_id.localeCompare(b.law_id));
-  } catch { /* ignore HTTP and network failures alike — search is a convenience */ }
-}
-loadCorpusLaws();
+// Shared corpus list via `useCorpusLaws` — the same per-scope cache
+// MachineReadable reads, so an editor mount fires ONE laws-list fetch
+// instead of a private duplicate GET. Traject switches re-scope
+// reactively; fetch failures degrade to the humanized law id.
+const { displayName: corpusDisplayName } = useCorpusLaws(activeTrajectRef);
 
 /**
  * Display name for the failed law on the error inline-dialog. Tries the
- * corpus index (loaded for the search popover) first; falls back to the
- * URL slug so the user always sees a concrete identifier.
+ * corpus index first; falls back to the URL slug (via `humanizeLawId`
+ * inside `displayName`) so the user always sees a concrete identifier.
  */
 const failedLawName = computed(() => {
   const id = lawId.value;
   if (!id) return '';
-  return corpusLaws.value.find(l => l.law_id === id)?.name || humanizeLawId(id);
+  return corpusDisplayName(id);
 });
 
 // True when the law fetch errored with 404 (law missing or not in active traject's corpus).

--- a/frontend/src/EditorView.vue
+++ b/frontend/src/EditorView.vue
@@ -194,10 +194,11 @@ const {
 } = useLaw(route.params.lawId, route.params.articleNumber, route.params.trajectRef);
 
 // When the active traject changes (router.push to /editor/{otherRef}/…)
-// the URL stays on the same component; refresh the corpus index and
-// re-fetch the open law through the new traject's backends. `switchLaw`
-// crosses trajects too via its third argument so the law cache key
-// stays correct.
+// the URL stays on the same component; re-fetch the open law through the
+// new traject's backends. The corpus list needs no handling here —
+// `useCorpusLaws(activeTrajectRef)` re-scopes reactively on the same
+// change. `switchLaw` crosses trajects too via its third argument so the
+// law cache key stays correct.
 //
 // Also flush the WASM engine: it caches loaded laws by id only, so
 // without this a scenario run after a traject switch would evaluate
@@ -206,7 +207,6 @@ const {
 // `unloadAllLaws` is enough — no per-dep bookkeeping needed.
 watch(activeTrajectRef, (next) => {
   unloadAllLaws();
-  loadCorpusLaws();
   if (lawId.value) {
     switchLaw(lawId.value, selectedArticleNumber.value, next);
   }
@@ -378,7 +378,10 @@ registerSearchPopover(searchPopoverRef);
 // MachineReadable reads, so an editor mount fires ONE laws-list fetch
 // instead of a private duplicate GET. Traject switches re-scope
 // reactively; fetch failures degrade to the humanized law id.
-const { displayName: corpusDisplayName } = useCorpusLaws(activeTrajectRef);
+const {
+  displayName: corpusDisplayName,
+  refresh: refreshCorpusLaws,
+} = useCorpusLaws(activeTrajectRef);
 
 /**
  * Display name for the failed law on the error inline-dialog. Tries the
@@ -419,7 +422,9 @@ async function onSearchHarvestAvailable(slug) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ law_ids: [slug] }),
   }).catch(() => {});
-  await loadCorpusLaws();
+  // Bust the shared per-scope cache so the fresh law shows up with its
+  // real display name instead of the humanized slug fallback.
+  await refreshCorpusLaws();
   router.push(libraryRouteFor(slug));
 }
 const resultSheetEl = ref(null);
@@ -583,7 +588,7 @@ if (!route.params.articleNumber && openTabs.value.length > 0) {
 //
 // trajectRef-only changes are intentionally NOT handled here: the
 // `watch(activeTrajectRef)` above already does `unloadAllLaws` +
-// `loadCorpusLaws` + `switchLaw`, and triggering switchLaw twice in
+// `switchLaw`, and triggering switchLaw twice in
 // the same tick would burn an extra fetch (the first await loses
 // useLaw's stale-switch race, but still hits the network). This guard
 // handles the law / article portion only.

--- a/frontend/src/composables/useCorpusLaws.js
+++ b/frontend/src/composables/useCorpusLaws.js
@@ -31,6 +31,10 @@ const FETCH_LIMIT = 1000;
 const SCOPE_CACHE_MAX = 5;
 
 const fetchByScope = new Map(); // scopeKey -> Promise
+// In-flight `refresh()` per scope. A second refresh while one is running
+// joins it instead of deleting the first one's promise out of
+// `fetchByScope` mid-flight and firing yet another request.
+const refreshByScope = new Map(); // scopeKey -> Promise
 const lawsByScope = createLruMap(SCOPE_CACHE_MAX, {
   onEvict: (key) => fetchByScope.delete(key), // scopeKey -> Ref<Array>
 });
@@ -148,9 +152,29 @@ export function useCorpusLaws(trajectRef) {
    * Ref is updated, so any *new* consumer sees the fresh list).
    */
   async function refresh() {
-    const key = scopeKey(refSource.value);
-    fetchByScope.delete(key);
-    const p = ensureFetched(refSource.value);
+    // Snapshot the scope at call time; `refSource` may re-scope while the
+    // awaits below are in flight, and the bust/re-fetch must stay on the
+    // scope the caller asked to refresh.
+    const scope = refSource.value;
+    const key = scopeKey(scope);
+    // Single-flight per scope: concurrent refreshes share one re-fetch
+    // instead of each busting the slot and stacking duplicate GETs.
+    let p = refreshByScope.get(key);
+    if (!p) {
+      p = (async () => {
+        // Serialize behind whatever fetch currently owns the slot (a
+        // settled promise resolves immediately). Busting an *in-flight*
+        // fetch would orphan it — firing the duplicate concurrent GET
+        // this file exists to avoid — and let its late settle race the
+        // refreshed list with stale data.
+        const current = fetchByScope.get(key);
+        if (current) await current;
+        fetchByScope.delete(key);
+        return ensureFetched(scope);
+      })();
+      refreshByScope.set(key, p);
+      p.catch(() => {}).finally(() => refreshByScope.delete(key));
+    }
     const capturedRef = lawsByScope.peek(key);
     await p;
     // Same stale-scope guard as the watcher: only commit if the caller's

--- a/frontend/src/composables/useCorpusLaws.js
+++ b/frontend/src/composables/useCorpusLaws.js
@@ -140,5 +140,26 @@ export function useCorpusLaws(trajectRef) {
     return humanizeLawId(lawId);
   }
 
-  return { laws, displayName };
+  /**
+   * Bust the active scope's cache and re-fetch (e.g. after a corpus
+   * reload added a law server-side). Updates this consumer's `laws`;
+   * other already-mounted consumers of the same scope keep their
+   * current snapshot until they re-scope or remount (the shared scope
+   * Ref is updated, so any *new* consumer sees the fresh list).
+   */
+  async function refresh() {
+    const key = scopeKey(refSource.value);
+    fetchByScope.delete(key);
+    const p = ensureFetched(refSource.value);
+    const capturedRef = lawsByScope.peek(key);
+    await p;
+    // Same stale-scope guard as the watcher: only commit if the caller's
+    // scope is still the active one by the time the fetch resolves.
+    if (capturedRef && scopeKey(refSource.value) === key) {
+      laws.value = capturedRef.value;
+    }
+    return laws.value;
+  }
+
+  return { laws, displayName, refresh };
 }

--- a/frontend/src/composables/useCorpusLaws.test.js
+++ b/frontend/src/composables/useCorpusLaws.test.js
@@ -59,4 +59,51 @@ describe('useCorpusLaws', () => {
     expect(laws.value).toHaveLength(2);
     expect(displayName('wet_b')).toBe('Wet B (officieel)');
   });
+
+  it('joins a concurrent refresh() instead of firing a duplicate re-fetch', async () => {
+    const useCorpusLaws = await freshUseCorpusLaws();
+    apiFetchJson.mockResolvedValueOnce([{ law_id: 'wet_a', name: 'Wet A' }]);
+
+    const { laws, refresh } = useCorpusLaws(ref('tr-1'));
+    await flush();
+    expect(apiFetchJson).toHaveBeenCalledTimes(1);
+
+    apiFetchJson.mockResolvedValue([
+      { law_id: 'wet_a', name: 'Wet A' },
+      { law_id: 'wet_b', name: 'Wet B' },
+    ]);
+    // Two concurrent refreshes share one re-fetch (the second must not
+    // orphan the first one's in-flight promise and fire a third GET).
+    await Promise.all([refresh(), refresh()]);
+
+    expect(apiFetchJson).toHaveBeenCalledTimes(2);
+    expect(laws.value).toHaveLength(2);
+  });
+
+  it('refresh() during the initial in-flight fetch serializes instead of duplicating the GET', async () => {
+    const useCorpusLaws = await freshUseCorpusLaws();
+    const resolvers = [];
+    apiFetchJson.mockImplementation(
+      () => new Promise((resolve) => resolvers.push(resolve)),
+    );
+
+    const { laws, refresh } = useCorpusLaws(ref('tr-1'));
+    expect(resolvers).toHaveLength(1);
+
+    // Refresh while the initial fetch is still in flight: it must not
+    // orphan that request and fire a concurrent duplicate GET.
+    const refreshed = refresh();
+    await flush();
+    expect(resolvers).toHaveLength(1);
+
+    // Once the initial fetch settles, the refresh busts the slot and
+    // re-fetches — its result wins, never the pre-refresh list.
+    resolvers[0]([{ law_id: 'wet_old' }]);
+    await flush();
+    expect(resolvers).toHaveLength(2);
+    resolvers[1]([{ law_id: 'wet_old' }, { law_id: 'wet_new' }]);
+
+    await refreshed;
+    expect(laws.value.map((l) => l.law_id)).toEqual(['wet_old', 'wet_new']);
+  });
 });

--- a/frontend/src/composables/useCorpusLaws.test.js
+++ b/frontend/src/composables/useCorpusLaws.test.js
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ref } from 'vue';
+
+// Route the composable's network leg through a controllable spy. The
+// factory closes over `apiFetchJson` so it survives `vi.resetModules()`.
+const apiFetchJson = vi.fn();
+vi.mock('../lib/apiFetch.js', () => ({
+  apiFetchJson: (...args) => apiFetchJson(...args),
+}));
+
+// The composable keeps module-level per-scope caches; import a fresh
+// copy per test so tests can't leak scope state into each other.
+async function freshUseCorpusLaws() {
+  vi.resetModules();
+  const mod = await import('./useCorpusLaws.js');
+  return mod.useCorpusLaws;
+}
+
+// Flush the microtask/watcher chain so the fetch commit lands.
+async function flush() {
+  await new Promise((resolve) => setTimeout(resolve));
+}
+
+beforeEach(() => {
+  apiFetchJson.mockReset();
+});
+
+describe('useCorpusLaws', () => {
+  it('shares one fetch between consumers of the same scope', async () => {
+    const useCorpusLaws = await freshUseCorpusLaws();
+    apiFetchJson.mockResolvedValue([{ law_id: 'wet_a', name: 'Wet A' }]);
+
+    const first = useCorpusLaws(ref('tr-1'));
+    const second = useCorpusLaws(ref('tr-1'));
+    await flush();
+
+    expect(apiFetchJson).toHaveBeenCalledTimes(1);
+    expect(first.laws.value).toHaveLength(1);
+    expect(second.displayName('wet_a')).toBe('Wet A');
+  });
+
+  it('refresh() busts the scope cache, re-fetches and commits the new list', async () => {
+    const useCorpusLaws = await freshUseCorpusLaws();
+    apiFetchJson.mockResolvedValueOnce([{ law_id: 'wet_a', name: 'Wet A' }]);
+
+    const { laws, displayName, refresh } = useCorpusLaws(ref('tr-1'));
+    await flush();
+    expect(apiFetchJson).toHaveBeenCalledTimes(1);
+    // Before the refresh the unknown law falls back to the humanized id.
+    expect(displayName('wet_b')).toBe('Wet B');
+
+    apiFetchJson.mockResolvedValueOnce([
+      { law_id: 'wet_a', name: 'Wet A' },
+      { law_id: 'wet_b', display_name: 'Wet B (officieel)' },
+    ]);
+    await refresh();
+
+    expect(apiFetchJson).toHaveBeenCalledTimes(2);
+    expect(laws.value).toHaveLength(2);
+    expect(displayName('wet_b')).toBe('Wet B (officieel)');
+  });
+});

--- a/frontend/src/composables/useLaw.js
+++ b/frontend/src/composables/useLaw.js
@@ -152,6 +152,11 @@ export function useLaw(lawParam, articleParam, trajectRefParam) {
 
   async function load() {
     const isCurrent = claimSwitch();
+    // Snapshot before any await: a concurrent `switchLaw` mutates
+    // `currentTrajectRef`, and the direct-URL cache write below must key
+    // on the traject this load was issued for — not whichever traject the
+    // user has navigated to by the time the response body arrives.
+    const loadTrajectRef = currentTrajectRef;
     try {
       loading.value = true;
       let entry;
@@ -162,18 +167,19 @@ export function useLaw(lawParam, articleParam, trajectRefParam) {
         if (!isCurrent()) return;
         const text = await res.text();
         // Deliberately no second staleness check between `.text()` and the
-        // parse (the original had one): the content is fresh either way, so
-        // parsing + caching it mirrors `fetchLawFresh` semantics, and the
-        // final `isCurrent()` below still guards all component state.
+        // parse (the original had one): the content is fresh either way and
+        // the cache key is snapshotted above, so caching it mirrors
+        // `fetchLawFresh` semantics even if this load went stale mid-flight;
+        // the final `isCurrent()` below still guards all component state.
         const parsed = yaml.load(text);
         entry = makeEntry(parsed, text, res.headers.get('ETag'));
         const resolvedId = parsed?.$id || lawParam;
-        lawCache.set(lawCacheKey(currentTrajectRef, resolvedId), entry);
+        lawCache.set(lawCacheKey(loadTrajectRef, resolvedId), entry);
       } else {
         // Fresh fetch (never the cache), shared with any concurrent
         // `fetchLaw` for the same law so a mount doesn't fire duplicate
         // GETs. Cache writes happen inside `fetchLawFresh`.
-        entry = await fetchLawFresh(currentTrajectRef, lawParam);
+        entry = await fetchLawFresh(loadTrajectRef, lawParam);
       }
       if (!isCurrent()) return;
       rawYaml.value = entry.rawYaml;

--- a/frontend/src/composables/useLaw.js
+++ b/frontend/src/composables/useLaw.js
@@ -161,6 +161,10 @@ export function useLaw(lawParam, articleParam, trajectRefParam) {
         const res = await apiFetch(initialDirectUrl, lawFetchInit);
         if (!isCurrent()) return;
         const text = await res.text();
+        // Deliberately no second staleness check between `.text()` and the
+        // parse (the original had one): the content is fresh either way, so
+        // parsing + caching it mirrors `fetchLawFresh` semantics, and the
+        // final `isCurrent()` below still guards all component state.
         const parsed = yaml.load(text);
         entry = makeEntry(parsed, text, res.headers.get('ETag'));
         const resolvedId = parsed?.$id || lawParam;

--- a/frontend/src/composables/useLaw.js
+++ b/frontend/src/composables/useLaw.js
@@ -48,6 +48,14 @@ export const lawFetchInit = Object.freeze({
   errorMessage: (status) => `Failed to fetch: ${status}`,
 });
 
+// The single cache-entry shape shared by every producer (fresh fetch,
+// direct-URL load, save). The `etag` is echoed back as `If-Match` on the
+// next save so a concurrent edit by another traject member surfaces as a
+// 412 instead of a silent overwrite (same chain as useTrajectDocuments).
+function makeEntry(law, rawYaml, etag) {
+  return { law, rawYaml, lawName: resolveLawName(law), etag };
+}
+
 // In-flight law GETs, keyed like `lawCache`. Simultaneous callers share
 // one request instead of racing duplicate GETs against an empty cache —
 // which is exactly what an editor mount does: `useLaw().load()` fetches
@@ -71,15 +79,7 @@ function fetchLawFresh(trajectRef, lawId) {
     const res = await apiFetch(lawUrl(trajectRef, lawId), lawFetchInit);
     const text = await res.text();
     const law = yaml.load(text);
-    const entry = {
-      law,
-      rawYaml: text,
-      lawName: resolveLawName(law),
-      // Echoed back as `If-Match` on the next save so a concurrent edit
-      // by another traject member surfaces as a 412 instead of a silent
-      // overwrite (same chain as useTrajectDocuments).
-      etag: res.headers.get('ETag'),
-    };
+    const entry = makeEntry(law, text, res.headers.get('ETag'));
     // Always overwrite: this is fresh content, so any pre-existing entry
     // is by definition stale (older body and/or ETag) — keeping it would
     // hand `fetchLaw`/`switchLaw` callers outdated YAML and a
@@ -162,12 +162,7 @@ export function useLaw(lawParam, articleParam, trajectRefParam) {
         if (!isCurrent()) return;
         const text = await res.text();
         const parsed = yaml.load(text);
-        entry = {
-          law: parsed,
-          rawYaml: text,
-          lawName: resolveLawName(parsed),
-          etag: res.headers.get('ETag'),
-        };
+        entry = makeEntry(parsed, text, res.headers.get('ETag'));
         const resolvedId = parsed?.$id || lawParam;
         lawCache.set(lawCacheKey(currentTrajectRef, resolvedId), entry);
       } else {
@@ -321,12 +316,7 @@ export function useLaw(lawParam, articleParam, trajectRefParam) {
       }
       const resolvedId = parsed?.$id || savedLawId;
       const savedKey = lawCacheKey(savedTrajectRef, resolvedId);
-      lawCache.set(savedKey, {
-        law: parsed,
-        rawYaml: yamlText,
-        lawName: resolveLawName(parsed),
-        etag: newEtag,
-      });
+      lawCache.set(savedKey, makeEntry(parsed, yamlText, newEtag));
     } catch (e) {
       if (lawId.value === savedLawId && currentTrajectRef === savedTrajectRef) {
         saveError.value = e;

--- a/frontend/src/composables/useLaw.js
+++ b/frontend/src/composables/useLaw.js
@@ -48,6 +48,54 @@ export const lawFetchInit = Object.freeze({
   errorMessage: (status) => `Failed to fetch: ${status}`,
 });
 
+// In-flight law GETs, keyed like `lawCache`. Simultaneous callers share
+// one request instead of racing duplicate GETs against an empty cache —
+// which is exactly what an editor mount does: `useLaw().load()` fetches
+// the routed law while the persisted-tab label loader `fetchLaw`s the
+// same id in parallel. Entries are removed when the request settles, so
+// a failed fetch never pins a rejected promise (retries hit the network).
+const pendingLawFetches = new Map();
+
+/**
+ * The network leg shared by `fetchLaw` and `useLaw().load()`: always
+ * fetches (no cache read — `load()` relies on that for freshness),
+ * single-flighted per cache key, and stores the entry in `lawCache`
+ * under the requested id (and the body's resolved `$id`, when the two
+ * differ) before resolving.
+ */
+function fetchLawFresh(trajectRef, lawId) {
+  const key = lawCacheKey(trajectRef, lawId);
+  const pending = pendingLawFetches.get(key);
+  if (pending) return pending;
+  const p = (async () => {
+    const res = await apiFetch(lawUrl(trajectRef, lawId), lawFetchInit);
+    const text = await res.text();
+    const law = yaml.load(text);
+    const entry = {
+      law,
+      rawYaml: text,
+      lawName: resolveLawName(law),
+      // Echoed back as `If-Match` on the next save so a concurrent edit
+      // by another traject member surfaces as a 412 instead of a silent
+      // overwrite (same chain as useTrajectDocuments).
+      etag: res.headers.get('ETag'),
+    };
+    // Always overwrite: this is fresh content, so any pre-existing entry
+    // is by definition stale (older body and/or ETag) — keeping it would
+    // hand `fetchLaw`/`switchLaw` callers outdated YAML and a
+    // precondition doomed to 412.
+    lawCache.set(key, entry);
+    const resolvedId = law?.$id;
+    if (resolvedId && resolvedId !== lawId) {
+      lawCache.set(lawCacheKey(trajectRef, resolvedId), entry);
+    }
+    return entry;
+  })();
+  pendingLawFetches.set(key, p);
+  p.catch(() => {}).finally(() => pendingLawFetches.delete(key));
+  return p;
+}
+
 /**
  * Fetch a law's YAML, possibly from cache. The traject id is part of
  * the cache key so this never returns content from a different traject
@@ -60,20 +108,7 @@ export async function fetchLaw(trajectRef, lawId) {
   const key = lawCacheKey(trajectRef, lawId);
   const cached = lawCache.get(key);
   if (cached) return cached;
-  const res = await apiFetch(lawUrl(trajectRef, lawId), lawFetchInit);
-  const text = await res.text();
-  const law = yaml.load(text);
-  const entry = {
-    law,
-    rawYaml: text,
-    lawName: resolveLawName(law),
-    // Echoed back as `If-Match` on the next save so a concurrent edit
-    // by another traject member surfaces as a 412 instead of a silent
-    // overwrite (same chain as useTrajectDocuments).
-    etag: res.headers.get('ETag'),
-  };
-  lawCache.set(key, entry);
-  return entry;
+  return fetchLawFresh(trajectRef, lawId);
 }
 
 export function useLaw(lawParam, articleParam, trajectRefParam) {
@@ -119,26 +154,32 @@ export function useLaw(lawParam, articleParam, trajectRefParam) {
     const isCurrent = claimSwitch();
     try {
       loading.value = true;
-      const url = initialDirectUrl ?? lawUrl(currentTrajectRef, lawParam);
-      const res = await apiFetch(url, lawFetchInit);
+      let entry;
+      if (initialDirectUrl) {
+        // Direct URL: no law id to key the shared in-flight map on, so
+        // fetch inline and cache under the body's resolved `$id`.
+        const res = await apiFetch(initialDirectUrl, lawFetchInit);
+        if (!isCurrent()) return;
+        const text = await res.text();
+        const parsed = yaml.load(text);
+        entry = {
+          law: parsed,
+          rawYaml: text,
+          lawName: resolveLawName(parsed),
+          etag: res.headers.get('ETag'),
+        };
+        const resolvedId = parsed?.$id || lawParam;
+        lawCache.set(lawCacheKey(currentTrajectRef, resolvedId), entry);
+      } else {
+        // Fresh fetch (never the cache), shared with any concurrent
+        // `fetchLaw` for the same law so a mount doesn't fire duplicate
+        // GETs. Cache writes happen inside `fetchLawFresh`.
+        entry = await fetchLawFresh(currentTrajectRef, lawParam);
+      }
       if (!isCurrent()) return;
-      const text = await res.text();
-      if (!isCurrent()) return;
-      rawYaml.value = text;
-      law.value = yaml.load(text);
-      currentEtag.value = res.headers.get('ETag');
-      const resolvedId = law.value?.$id || lawParam;
-      const key = lawCacheKey(currentTrajectRef, resolvedId);
-      // Always overwrite: `load()` just fetched fresh content, so any
-      // pre-existing entry is by definition stale (older body and/or
-      // ETag) — keeping it would hand `fetchLaw`/`switchLaw` callers
-      // outdated YAML and a precondition doomed to 412.
-      lawCache.set(key, {
-        law: law.value,
-        rawYaml: text,
-        lawName: resolveLawName(law.value),
-        etag: currentEtag.value,
-      });
+      rawYaml.value = entry.rawYaml;
+      law.value = entry.law;
+      currentEtag.value = entry.etag;
       if (articles.value.length > 0 && !selectedArticleNumber.value) {
         if (initialArticle && articles.value.some(a => String(a.number) === initialArticle)) {
           selectedArticleNumber.value = initialArticle;

--- a/frontend/src/composables/useLaw.test.js
+++ b/frontend/src/composables/useLaw.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { useLaw } from './useLaw.js';
+import { useLaw, fetchLaw } from './useLaw.js';
 
 // Helper: shape a Response-like object with headers + body + status.
 // Mirrors the harness in useTrajectDocuments.test.js.
@@ -90,5 +90,87 @@ describe('useLaw optimistic concurrency', () => {
     expect(law.saveError.value?.message).toMatch(/herlaad/i);
     // The stale ETag is kept — the user reloads to pick up a fresh one.
     expect(law.currentEtag.value).toBe('"v1"');
+  });
+});
+
+describe('useLaw fetch dedup (single-flight)', () => {
+  it('shares one GET between concurrent callers for the same key', async () => {
+    let callCount = 0;
+    globalThis.fetch = vi.fn().mockImplementation(async () => {
+      callCount += 1;
+      return res({ body: '$id: wet_single_flight\nname: V1\n', etag: '"v1"' });
+    });
+
+    // Two concurrent fetches for the same key (mirrors an editor mount:
+    // useLaw().load() and fetchLaw() racing the same id against an empty cache).
+    const p1 = fetchLaw('tr-dedupe', 'wet_single_flight');
+    const p2 = fetchLaw('tr-dedupe', 'wet_single_flight');
+    // The second caller joins the in-flight request instead of firing its own.
+    expect(callCount).toBe(1);
+
+    const [e1, e2] = await Promise.all([p1, p2]);
+    // Both callers get the same resolved entry, from one GET.
+    expect(e1).toBe(e2);
+    expect(e1.law.$id).toBe('wet_single_flight');
+    expect(callCount).toBe(1);
+  });
+
+  it('clears the pending entry on settle so a later fresh load re-fetches', async () => {
+    let callCount = 0;
+    globalThis.fetch = vi.fn().mockImplementation(async () => {
+      callCount += 1;
+      return res({ body: '$id: wet_pending_clear\nname: V1\n', etag: '"v1"' });
+    });
+
+    // First fresh load fires GET #1 and settles.
+    const a = useLaw('wet_pending_clear', null, 'tr-dedupe');
+    await waitForLoaded(a);
+    expect(callCount).toBe(1);
+
+    // A subsequent fresh load (load() never reads the cache) fires a new GET —
+    // proving the settled promise wasn't pinned in the pending map.
+    const b = useLaw('wet_pending_clear', null, 'tr-dedupe');
+    await waitForLoaded(b);
+    expect(callCount).toBe(2);
+  });
+
+  it('caches under the resolved $id so a later fetch by canonical id is a hit', async () => {
+    let callCount = 0;
+    globalThis.fetch = vi.fn().mockImplementation(async () => {
+      callCount += 1;
+      return res({ body: '$id: wet_canonical\nname: V1\n', etag: '"v1"' });
+    });
+
+    // Requested by a slug that differs from the body's `$id`.
+    const bySlug = await fetchLaw('tr-dedupe', 'wet-canonical-slug');
+    expect(callCount).toBe(1);
+    expect(bySlug.law.$id).toBe('wet_canonical');
+
+    // The dual-cache write under the resolved `$id` means a later fetch by
+    // the canonical id is served from cache — no extra GET.
+    const byId = await fetchLaw('tr-dedupe', 'wet_canonical');
+    expect(byId).toBe(bySlug);
+    expect(callCount).toBe(1);
+  });
+
+  it('does not pin a rejected fetch — the next call retries', async () => {
+    let callCount = 0;
+    globalThis.fetch = vi.fn().mockImplementation(async () => {
+      callCount += 1;
+      if (callCount === 1) throw new Error('network down');
+      return res({ body: '$id: wet_retry\nname: V1\n', etag: '"v1"' });
+    });
+
+    // First call fails; a failed fetch must not pin a rejected promise.
+    await expect(fetchLaw('tr-dedupe', 'wet_retry')).rejects.toThrow(
+      /network down/i,
+    );
+    expect(callCount).toBe(1);
+
+    // The retry gets a fresh GET (nothing was cached, nothing pinned) and
+    // succeeds.
+    const entry = await fetchLaw('tr-dedupe', 'wet_retry');
+    expect(entry.law.$id).toBe('wet_retry');
+    expect(callCount).toBe(2);
   });
 });

--- a/frontend/src/composables/useLaw.test.js
+++ b/frontend/src/composables/useLaw.test.js
@@ -115,6 +115,34 @@ describe('useLaw fetch dedup (single-flight)', () => {
     expect(callCount).toBe(1);
   });
 
+  it('shares one GET between load() and a concurrent fetchLaw (editor mount)', async () => {
+    // The exact regression this PR fixes: on editor mount, useLaw().load()
+    // fetches the routed law while the persisted-tab label loader
+    // fetchLaw()s the same id in parallel against an empty cache.
+    let callCount = 0;
+    let release;
+    globalThis.fetch = vi.fn().mockImplementation(async () => {
+      callCount += 1;
+      // Hold the GET open so the second caller arrives while it's in flight.
+      await new Promise((resolve) => { release = resolve; });
+      return res({ body: '$id: wet_mount_race\nname: V1\n', etag: '"v1"' });
+    });
+
+    const law = useLaw('wet_mount_race', null, 'tr-dedupe');
+    const labelFetch = fetchLaw('tr-dedupe', 'wet_mount_race');
+    expect(callCount).toBe(1);
+
+    release();
+    const entry = await labelFetch;
+    await waitForLoaded(law);
+
+    expect(callCount).toBe(1);
+    expect(entry.law.$id).toBe('wet_mount_race');
+    // Both consumers converge on the same fetched content.
+    expect(law.rawYaml.value).toBe(entry.rawYaml);
+    expect(law.currentEtag.value).toBe('"v1"');
+  });
+
   it('clears the pending entry on settle so a later fresh load re-fetches', async () => {
     let callCount = 0;
     globalThis.fetch = vi.fn().mockImplementation(async () => {
@@ -151,6 +179,43 @@ describe('useLaw fetch dedup (single-flight)', () => {
     const byId = await fetchLaw('tr-dedupe', 'wet_canonical');
     expect(byId).toBe(bySlug);
     expect(callCount).toBe(1);
+  });
+
+  it('a traject switch during a direct-URL load cannot poison the new traject cache', async () => {
+    // The direct-URL branch caches under the traject the load was issued
+    // for. If a cross-traject switchLaw lands while the response body is
+    // still streaming, the late cache write must go to the OLD traject's
+    // key — never the new one, where it would shadow the real law.
+    let releaseText;
+    const calls = [];
+    globalThis.fetch = vi.fn().mockImplementation(async (url) => {
+      calls.push(url);
+      if (url === '/direct/wet_direct.yaml') {
+        return {
+          ok: true,
+          status: 200,
+          headers: { get: (k) => (k.toLowerCase() === 'etag' ? '"d1"' : null) },
+          // Body held open so the traject switch can land mid-flight.
+          text: () => new Promise((resolve) => { releaseText = resolve; }),
+        };
+      }
+      return res({ body: `$id: ${url.split('/').pop()}\nname: X\n`, etag: '"x1"' });
+    });
+
+    const law = useLaw('/direct/wet_direct.yaml', null, 'tr-old');
+    await vi.waitFor(() => expect(releaseText).toBeDefined());
+    // Cross-traject navigation while the direct body is still streaming.
+    await law.switchLaw('wet_other', null, 'tr-new');
+    releaseText('$id: wet_direct\nname: Direct\n');
+    await waitForLoaded(law);
+
+    // Fetching the same id in the new traject must go to the network —
+    // a cache hit here would serve the direct-URL body as tr-new content.
+    const before = calls.length;
+    const entry = await fetchLaw('tr-new', 'wet_direct');
+    expect(calls.length).toBe(before + 1);
+    expect(calls[calls.length - 1]).toBe('/api/trajects/tr-new/corpus/laws/wet_direct');
+    expect(entry.law.$id).toBe('wet_direct');
   });
 
   it('does not pin a rejected fetch — the next call retries', async () => {


### PR DESCRIPTION
## What & why

Part of the editor↔GitHub performance track (follow-up to the instrumentation in #919). The editor-open waterfall showed two avoidable duplicate requests fired on every editor mount:

1. **Law body fetched twice**: `useLaw().load()` fetches the routed law while the persisted-tab label loader calls `fetchLaw()` for the same law id in the same tick — the shared cache is still empty at that point, so both hit the network.
2. **`laws?limit=1000` fetched twice**: `EditorView` kept a private `loadCorpusLaws()` fetch for the failed-law display name, next to the shared per-scope cache in `useCorpusLaws` that `MachineReadable` already uses.

## How

- **`useLaw.js`**: a module-level in-flight map (`pendingLawFetches`), shared by `load()` and `fetchLaw()`. Simultaneous callers share one GET; entries are dropped when the request settles so a failed fetch never pins a rejected promise. `load()` keeps its always-fresh semantics (it never *reads* the cache, it only shares the in-flight request), and the fresh entry is cached under both the requested id and the body's resolved `$id`.
- **`EditorView.vue`**: the private corpus-laws fetch is replaced by `useCorpusLaws(activeTrajectRef)` — same module-level per-scope cache as `MachineReadable`, so an editor mount fires one list fetch total. `failedLawName` now goes through the composable's `displayName` (`display_name || name || humanizeLawId`), which is a strict improvement over the previous `name || humanizeLawId`.

## Verification

- `npm run -w frontend test`: **440 passed (46 files)** ✓
- Live smoketest on the preview deployment follows once it's up (network tab should show exactly one law-body GET and one `laws?limit=1000` GET per editor mount).