### PR TITLE
perf(editor): stale-while-revalidate refreshes and snapshot caches for sidecar reads

### DIFF
--- a/packages/corpus/src/github_api_backend.rs
+++ b/packages/corpus/src/github_api_backend.rs
@@ -304,18 +304,23 @@ impl RepoBackend for GitHubApiBackend {
         Ok(())
     }
 
+    #[tracing::instrument(name = "gh_list_files", skip_all, fields(dir = %dir.display()))]
     async fn list_files(&self, dir: &Path, extension: Option<&str>) -> Result<Vec<FileEntry>> {
         let api_dir = self.api_path(dir)?;
         let mut inner = self.inner.lock().await;
-        let entries = inner
-            .fetcher
-            .list_directory(
+        // One Contents API directory GET — feeds the `gh_list` Server-
+        // Timing phase so listing round-trips (scenario listings) are
+        // visible next to `gh_get` instead of vanishing into `total`.
+        let entries = timing::measure(
+            "gh_list",
+            inner.fetcher.list_directory(
                 &self.full_repo(),
                 &self.branch,
                 &api_dir,
                 self.token.as_deref(),
-            )
-            .await?;
+            ),
+        )
+        .await?;
         let mut out: Vec<FileEntry> = entries
             .into_iter()
             .filter(|e| e.entry_type == "file")

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -746,7 +746,14 @@ async fn list_scenarios_in_scope(
                 let target_law_ids =
                     match read_traject_scenario_cached(traject, law, &relative_path).await {
                         Ok(Some(content)) => extract_target_law_ids(&content),
-                        Ok(None) => Vec::new(),
+                        // Listed but unreadable on every routing leg: a
+                        // ghost. GitHub's directory listing is eventually
+                        // consistent, so right after a delete commit the
+                        // (stale) listing can still name the file while
+                        // its content GET already 404s. Skip it — keeping
+                        // it would serve a listing entry whose GET can
+                        // only 404.
+                        Ok(None) => continue,
                         Err((_, err)) => {
                             tracing::warn!(
                                 law_id = %law_id,
@@ -1715,18 +1722,6 @@ async fn read_traject_scenario_cached(
     Ok(content)
 }
 
-async fn resolve_traject_scenario_target(
-    traject: &Arc<TrajectCorpus>,
-    law_id: &str,
-    filename: &str,
-) -> Result<EditorWriteTarget, (StatusCode, String)> {
-    let write = resolve_traject_law_write(traject, law_id).await?;
-    Ok(EditorWriteTarget {
-        relative_path: scenario_relative_path(&write.law, filename)?,
-        backend: write.backend,
-    })
-}
-
 /// Resolve the write target for a law's stand-off notes sidecar.
 ///
 /// The path is `annotations/{law_id}/annotations.yaml` at the source root,
@@ -1817,13 +1812,17 @@ pub async fn save_scenario(
         .map_err(corpus_write_error("scenario"))?;
 
     // Keep the per-snapshot read caches coherent with the save
-    // (read-your-writes): the file's content cache gets the new body, the
-    // law's listing is dropped so the next listing picks the file up (or
-    // its changed targets) without waiting out the snapshot TTL.
+    // (read-your-writes): the file's content cache gets the new body and
+    // the cached listing is updated in place. Surgical (not invalidate +
+    // rebuild): a rebuild would re-list GitHub's eventually-consistent
+    // directory view, which right after the commit can still miss this
+    // save and would then be cached for the rest of the snapshot window.
     traject
         .store_sidecar(scenario_cache_key(&relative_path), Some(body.clone()))
         .await;
-    traject.invalidate_scenario_list(&law_id).await;
+    traject
+        .record_scenario_saved(&law_id, &filename, extract_target_law_ids(&body))
+        .await;
 
     let new_etag = document_etag(&body);
     let mut response = save_response_from_traject(outcome);
@@ -2254,18 +2253,17 @@ pub async fn delete_scenario(
     let author = Some(require_editor_user(&session).await?);
 
     let traject = require_traject_corpus_from_ref(&state, &session, &traject_ref).await?;
-    let target = resolve_traject_scenario_target(&traject, &law_id, &filename).await?;
-    let EditorWriteTarget {
-        relative_path,
-        backend,
-    } = target;
+    let write = resolve_traject_law_write(&traject, &law_id).await?;
+    let relative_path = scenario_relative_path(&write.law, &filename)?;
 
-    backend
+    write
+        .backend
         .delete_file(&relative_path)
         .await
         .map_err(corpus_write_error("scenario"))?;
 
-    let outcome = backend
+    let outcome = write
+        .backend
         .persist(&WriteContext {
             message: format!("Delete scenario {} for {}", filename, law_id),
             author,
@@ -2275,12 +2273,49 @@ pub async fn delete_scenario(
 
     // Drop (don't negative-cache) the file's read-cache entry: after a
     // branch-side delete the next read may legitimately fall back to a
-    // seed copy of the scenario. The listing is dropped for the same
-    // reason.
+    // seed copy of the scenario.
     traject
         .invalidate_sidecar(&scenario_cache_key(&relative_path))
         .await;
-    traject.invalidate_scenario_list(&law_id).await;
+
+    // Update the cached listing in place — an invalidate-and-rebuild
+    // races GitHub's eventually-consistent directory view, which can
+    // still list the deleted file right after the commit and would then
+    // resurrect it in the cache for the rest of the snapshot window.
+    // What "in place" means depends on whether a seed copy remains: a
+    // federated law's scenario that was overridden on the branch falls
+    // back to the seed after the branch delete (same routing as the GET),
+    // so it stays listed with the seed's targets. The seed probe is one
+    // read, only for federated laws, on the rare delete path — and the
+    // legal writable-own → seed lock order is respected (`write.backend`
+    // holds the write-target guard). On a probe error we still remove
+    // the entry: the delete is the user's intent, and a hidden seed copy
+    // reappears at the next snapshot swap.
+    match read_seed_fallback(
+        &traject,
+        &write.law,
+        &write.write_source_id,
+        &relative_path,
+        "scenario",
+    )
+    .await
+    {
+        Ok(Some(seed_content)) => {
+            traject
+                .record_scenario_saved(&law_id, &filename, extract_target_law_ids(&seed_content))
+                .await;
+        }
+        Ok(None) => traject.record_scenario_deleted(&law_id, &filename).await,
+        Err((_, err)) => {
+            tracing::warn!(
+                law_id = %law_id,
+                file = %filename,
+                error = %err,
+                "seed probe after scenario delete failed; removing from cached listing"
+            );
+            traject.record_scenario_deleted(&law_id, &filename).await;
+        }
+    }
 
     Ok(Json(save_response_from_traject(outcome)))
 }

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -690,6 +690,16 @@ async fn list_scenarios_in_scope(
             // round-trip-heavy read on the law-open path. Scenario
             // save/delete invalidate the entry (read-your-writes);
             // upstream edits converge at the next snapshot.
+            // Captured before the cache probe (not merely before the
+            // backend I/O): a scenario save/delete landing while this
+            // listing is computed bumps the write generation and the
+            // store below is dropped, so the (older) listing can never
+            // mask the mutation. Capturing after the probe would leave a
+            // window — a write landing between probe and capture would
+            // hand us the post-write generation, letting a rebuild from
+            // GitHub's eventually-consistent (pre-write) directory view
+            // pass the guard.
+            let gen_before = traject.scenario_list_write_generation();
             if let Some(cached) = traject.cached_scenario_list(law_id).await {
                 return Ok(Json(
                     cached
@@ -706,11 +716,6 @@ async fn list_scenarios_in_scope(
                 Ok(dir) => dir.join("scenarios"),
                 Err(_) => return Ok(Json(Vec::new())),
             };
-            // Captured before any backend I/O: a scenario save/delete
-            // landing while this listing is computed bumps the write
-            // generation and the store below is dropped, so the (older)
-            // listing can never mask the mutation.
-            let gen_before = traject.sidecar_write_generation();
             let write_source_id = traject_write_source_id(traject, law);
             let mut names = std::collections::BTreeSet::new();
             // Lock order: write target first, released before the seed
@@ -1101,15 +1106,19 @@ async fn read_annotations_in_scope(
     scope: &ReadScope,
     law_id: &str,
 ) -> Result<Option<String>, (StatusCode, String)> {
-    // Captured before the backend read: `store_sidecar_read` drops the
+    // Captured before the cache probe: `store_sidecar_read` drops the
     // store when a save bumped the generation while this (potentially
     // slow) read was in flight, so it can never mask fresher content.
+    // Capturing after the probe would leave a window — a save landing
+    // between probe and capture would hand us the post-save generation,
+    // letting a stale backend read pass the guard and overwrite the
+    // save's fresh entry.
     let mut gen_before = 0;
     if let ReadScope::Traject(traject) = scope {
+        gen_before = traject.sidecar_write_generation();
         if let Some(cached) = traject.cached_sidecar(&annotations_cache_key(law_id)).await {
             return Ok(cached);
         }
-        gen_before = traject.sidecar_write_generation();
     }
 
     let backend = resolve_annotation_read_backend(scope, law_id)?;
@@ -1707,13 +1716,17 @@ async fn read_traject_scenario_cached(
     relative_path: &std::path::Path,
 ) -> Result<Option<String>, (StatusCode, String)> {
     let key = scenario_cache_key(relative_path);
+    // Generation captured before the cache probe: a save/delete landing
+    // while the read is in flight bumps it, and the store below is then
+    // dropped so these (older) bytes can't mask the write's entry.
+    // Capturing after the probe would leave a window — a save landing
+    // between probe and capture would hand us the post-save generation,
+    // letting a stale backend read pass the guard and overwrite the
+    // save's fresh entry.
+    let gen_before = traject.sidecar_write_generation();
     if let Some(cached) = traject.cached_sidecar(&key).await {
         return Ok(cached);
     }
-    // Generation captured before the read: a save/delete landing while
-    // the read is in flight bumps it, and the store below is then
-    // dropped so these (older) bytes can't mask the write's entry.
-    let gen_before = traject.sidecar_write_generation();
     let content =
         read_traject_file_via_write_target(traject, law, relative_path, "scenario").await?;
     traject

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -25,7 +25,7 @@ use regelrecht_corpus::CorpusError;
 
 use crate::accounts::AccountRecord;
 use crate::state::{AppState, CorpusState};
-use crate::traject_corpus::{TrajectCorpus, TrajectCorpusError};
+use crate::traject_corpus::{ScenarioListEntry, TrajectCorpus, TrajectCorpusError};
 use crate::trajects::resolve_traject_ref;
 use crate::user_notes;
 
@@ -684,11 +684,33 @@ async fn list_scenarios_in_scope(
         // were never copied to the branch keep showing up (their GET
         // falls back to the seed the same way).
         ReadScope::Traject(traject) => {
+            // Per-snapshot cache: the editor requests this listing on
+            // every law open, and a rebuild costs one `list_files` per
+            // backend plus a read per scenario file — the most GitHub-
+            // round-trip-heavy read on the law-open path. Scenario
+            // save/delete invalidate the entry (read-your-writes);
+            // upstream edits converge at the next snapshot.
+            if let Some(cached) = traject.cached_scenario_list(law_id).await {
+                return Ok(Json(
+                    cached
+                        .into_iter()
+                        .map(|e| ScenarioEntry {
+                            filename: e.filename,
+                            target_law_ids: e.target_law_ids,
+                        })
+                        .collect(),
+                ));
+            }
             let law = traject_law(traject, law_id)?;
             let scenarios_dir = match law_relative_dir(law) {
                 Ok(dir) => dir.join("scenarios"),
                 Err(_) => return Ok(Json(Vec::new())),
             };
+            // Captured before any backend I/O: a scenario save/delete
+            // landing while this listing is computed bumps the write
+            // generation and the store below is dropped, so the (older)
+            // listing can never mask the mutation.
+            let gen_before = traject.sidecar_write_generation();
             let write_source_id = traject_write_source_id(traject, law);
             let mut names = std::collections::BTreeSet::new();
             // Lock order: write target first, released before the seed
@@ -710,40 +732,56 @@ async fn list_scenarios_in_scope(
             }
             // Content goes through the same write-target-with-seed-fallback
             // per-file routing as the scenario GET, so the extracted targets
-            // reflect exactly the bytes the editor serves. Cost: one
-            // sequential read per file in this law's `scenarios/` dir —
-            // O(folder), typically 1-3 files, NOT the O(corpus) scan that
-            // hung federated trajects before (#762). Revisit with a batch
-            // read or index only if per-law scenario counts grow.
+            // reflect exactly the bytes the editor serves — and lands in the
+            // same per-file cache, so a subsequent scenario GET is free.
+            // Cost on a cache miss: one sequential read per file in this
+            // law's `scenarios/` dir — O(folder), typically 1-3 files, NOT
+            // the O(corpus) scan that hung federated trajects before
+            // (#762). Revisit with a batch read or index only if per-law
+            // scenario counts grow.
             let mut out = Vec::with_capacity(names.len());
+            let mut complete = true;
             for filename in names {
                 let relative_path = scenarios_dir.join(&filename);
-                let target_law_ids = match read_traject_file_via_write_target(
-                    traject,
-                    law,
-                    &relative_path,
-                    "scenario",
-                )
-                .await
-                {
-                    Ok(Some(content)) => extract_target_law_ids(&content),
-                    Ok(None) => Vec::new(),
-                    Err((_, err)) => {
-                        tracing::warn!(
-                            law_id = %law_id,
-                            file = %filename,
-                            error = %err,
-                            "scenario read failed during listing"
-                        );
-                        Vec::new()
-                    }
-                };
+                let target_law_ids =
+                    match read_traject_scenario_cached(traject, law, &relative_path).await {
+                        Ok(Some(content)) => extract_target_law_ids(&content),
+                        Ok(None) => Vec::new(),
+                        Err((_, err)) => {
+                            tracing::warn!(
+                                law_id = %law_id,
+                                file = %filename,
+                                error = %err,
+                                "scenario read failed during listing"
+                            );
+                            complete = false;
+                            Vec::new()
+                        }
+                    };
                 out.push(ScenarioEntry {
                     filename,
                     target_law_ids,
                 });
             }
-            // BTreeSet iteration is already sorted by filename.
+            // BTreeSet iteration is already sorted by filename. Only a
+            // fully-read listing is cached: a transient per-file read
+            // failure keeps its degraded (empty-targets) entry out of the
+            // snapshot cache, so the next request retries instead of
+            // serving the degraded listing for the whole window.
+            if complete {
+                traject
+                    .store_scenario_list_read(
+                        law_id.to_string(),
+                        out.iter()
+                            .map(|e| ScenarioListEntry {
+                                filename: e.filename.clone(),
+                                target_law_ids: e.target_law_ids.clone(),
+                            })
+                            .collect(),
+                        gen_before,
+                    )
+                    .await;
+            }
             out
         }
         // Global: no write target exists; keep the read-only resolution.
@@ -822,11 +860,12 @@ async fn get_scenario_in_scope(
         // fallback routing the save's `If-Match` check uses, so the GET
         // serves (and ETags) exactly the bytes a subsequent save is
         // checked against. See `read_traject_file_via_write_target` for
-        // the 412-loop this prevents.
+        // the 412-loop this prevents. Cached per snapshot; saves keep the
+        // entry coherent (see `read_traject_scenario_cached`).
         ReadScope::Traject(traject) => {
             let law = traject_law(traject, law_id)?;
             let relative_path = scenario_relative_path(law, filename)?;
-            read_traject_file_via_write_target(traject, law, &relative_path, "scenario").await?
+            read_traject_scenario_cached(traject, law, &relative_path).await?
         }
         // Global: no write target exists; keep the read-only resolution.
         ReadScope::Global(_) => {
@@ -1021,6 +1060,51 @@ async fn get_annotations_in_scope(
     scope: &ReadScope,
     law_id: &str,
 ) -> Result<YamlResponse, (StatusCode, String)> {
+    let content = read_annotations_in_scope(scope, law_id)
+        .await?
+        .ok_or((StatusCode::NOT_FOUND, "Annotations not found".to_string()))?;
+
+    Ok((
+        StatusCode::OK,
+        [(axum::http::header::CONTENT_TYPE, "text/yaml; charset=utf-8")],
+        content,
+    ))
+}
+
+/// Cache key for a law's annotations sidecar in
+/// [`TrajectCorpus::cached_sidecar`]. Prefixed so it can never collide
+/// with the scenario-file keys ([`scenario_cache_key`]) sharing the map.
+fn annotations_cache_key(law_id: &str) -> String {
+    format!("ann:{law_id}")
+}
+
+/// Read the raw annotations sidecar bytes for `law_id` within a scope.
+/// `Ok(None)` = the law exists but has no sidecar (the normal case).
+///
+/// Traject-scoped reads are cached per index snapshot — including the
+/// `None` outcome: the editor requests annotations on every law open,
+/// and rediscovering "no notes yet" would otherwise cost a full GitHub
+/// round-trip each time. `save_annotations` keeps the entry coherent
+/// within the snapshot window by storing the just-written body
+/// (read-your-writes); cross-replica edits converge at the next snapshot,
+/// like law bodies. Global (no-traject) reads stay uncached: they serve
+/// anonymous browsing against the central source, whose backend does its
+/// own ETag handling.
+async fn read_annotations_in_scope(
+    scope: &ReadScope,
+    law_id: &str,
+) -> Result<Option<String>, (StatusCode, String)> {
+    // Captured before the backend read: `store_sidecar_read` drops the
+    // store when a save bumped the generation while this (potentially
+    // slow) read was in flight, so it can never mask fresher content.
+    let mut gen_before = 0;
+    if let ReadScope::Traject(traject) = scope {
+        if let Some(cached) = traject.cached_sidecar(&annotations_cache_key(law_id)).await {
+            return Ok(cached);
+        }
+        gen_before = traject.sidecar_write_generation();
+    }
+
     let backend = resolve_annotation_read_backend(scope, law_id)?;
 
     // RFC-018 §1: keyed by law id at the source root, regardless of where
@@ -1029,25 +1113,24 @@ async fn get_annotations_in_scope(
         .join(law_id)
         .join("annotations.yaml");
 
-    let backend = backend.lock().await;
-    let content = backend
-        .read_file(&relative_path)
-        .await
-        .map_err(|e| {
+    let content = {
+        let backend = backend.lock().await;
+        backend.read_file(&relative_path).await.map_err(|e| {
             tracing::warn!(law_id = %law_id, error = %e, "get_annotations backend read failed");
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Failed to read annotations".to_string(),
             )
         })?
-        .ok_or((StatusCode::NOT_FOUND, "Annotations not found".to_string()))?;
-    drop(backend);
+    };
 
-    Ok((
-        StatusCode::OK,
-        [(axum::http::header::CONTENT_TYPE, "text/yaml; charset=utf-8")],
-        content,
-    ))
+    if let ReadScope::Traject(traject) = scope {
+        traject
+            .store_sidecar_read(annotations_cache_key(law_id), content.clone(), gen_before)
+            .await;
+    }
+
+    Ok(content)
 }
 
 // ---------------------------------------------------------------------------
@@ -1589,6 +1672,49 @@ async fn read_traject_file_via_write_target(
     read_seed_fallback(traject, law, &write_source_id, relative_path, kind).await
 }
 
+/// Cache key for one scenario file's content in
+/// [`TrajectCorpus::cached_sidecar`]. The relative path is unique across
+/// laws (it lives under the law's own directory), and the prefix keeps it
+/// disjoint from the annotations keys sharing the map.
+fn scenario_cache_key(relative_path: &std::path::Path) -> String {
+    format!("scn:{}", relative_path.display())
+}
+
+/// [`read_traject_file_via_write_target`] with a per-snapshot cache in
+/// front, for **GET-path scenario reads only** (the single-file GET and
+/// the listing's target extraction). `None` results are cached too — a
+/// seed-only law's write-target miss costs a GitHub round-trip to
+/// rediscover. Write-path preconditions (`current_content_for_write`,
+/// the `If-Match` checks) deliberately bypass this cache: they must
+/// compare against the branch as it *is*, under the write lock, not
+/// against a snapshot-aged copy.
+///
+/// Coherence: `save_scenario` stores the just-written body under this
+/// key, `delete_scenario` drops the entry (the next read may
+/// legitimately fall back to a seed copy, so a negative entry would be
+/// wrong). Cross-replica edits converge at the next snapshot, like law
+/// bodies.
+async fn read_traject_scenario_cached(
+    traject: &Arc<TrajectCorpus>,
+    law: &LoadedLaw,
+    relative_path: &std::path::Path,
+) -> Result<Option<String>, (StatusCode, String)> {
+    let key = scenario_cache_key(relative_path);
+    if let Some(cached) = traject.cached_sidecar(&key).await {
+        return Ok(cached);
+    }
+    // Generation captured before the read: a save/delete landing while
+    // the read is in flight bumps it, and the store below is then
+    // dropped so these (older) bytes can't mask the write's entry.
+    let gen_before = traject.sidecar_write_generation();
+    let content =
+        read_traject_file_via_write_target(traject, law, relative_path, "scenario").await?;
+    traject
+        .store_sidecar_read(key, content.clone(), gen_before)
+        .await;
+    Ok(content)
+}
+
 async fn resolve_traject_scenario_target(
     traject: &Arc<TrajectCorpus>,
     law_id: &str,
@@ -1689,6 +1815,15 @@ pub async fn save_scenario(
         })
         .await
         .map_err(corpus_write_error("scenario"))?;
+
+    // Keep the per-snapshot read caches coherent with the save
+    // (read-your-writes): the file's content cache gets the new body, the
+    // law's listing is dropped so the next listing picks the file up (or
+    // its changed targets) without waiting out the snapshot TTL.
+    traject
+        .store_sidecar(scenario_cache_key(&relative_path), Some(body.clone()))
+        .await;
+    traject.invalidate_scenario_list(&law_id).await;
 
     let new_etag = document_etag(&body);
     let mut response = save_response_from_traject(outcome);
@@ -1970,6 +2105,13 @@ pub async fn save_annotations(
         .await
         .map_err(corpus_write_error("annotations"))?;
 
+    // Read-your-writes for the per-snapshot annotations cache: the next
+    // GET serves the just-committed sidecar (replacing a possibly cached
+    // "no annotations yet") without a GitHub round-trip.
+    traject
+        .store_sidecar(annotations_cache_key(&law_id), Some(new_text))
+        .await;
+
     let mut response = save_response_from_traject(outcome);
     response.personal_saved = Some(personal_saved);
     Ok(Json(response))
@@ -2089,11 +2231,12 @@ pub async fn save_law(
     // the read-your-writes follow-up that used to be punted.
     traject.record_save(law_id.clone(), body).await;
 
-    // This save added (or kept) this law on the traject branch, so the
-    // cached changed-laws diff is now stale — drop it so the sidebar's
-    // "Bewerkt in dit traject" section reflects the edit on the next load
-    // instead of waiting out the TTL.
-    traject.invalidate_changed_cache().await;
+    // This save added (or kept) this law on the traject branch — fold it
+    // into the cached changed-laws diff so the sidebar's "Bewerkt in dit
+    // traject" section reflects the edit on the next load, without the
+    // synchronous GitHub Compare call a cache invalidation would cost
+    // that load.
+    traject.record_changed_law(&law_id).await;
 
     let mut response = save_response_from_traject(outcome);
     response.etag = Some(new_etag.clone());
@@ -2129,6 +2272,15 @@ pub async fn delete_scenario(
         })
         .await
         .map_err(corpus_write_error("scenario"))?;
+
+    // Drop (don't negative-cache) the file's read-cache entry: after a
+    // branch-side delete the next read may legitimately fall back to a
+    // seed copy of the scenario. The listing is dropped for the same
+    // reason.
+    traject
+        .invalidate_sidecar(&scenario_cache_key(&relative_path))
+        .await;
+    traject.invalidate_scenario_list(&law_id).await;
 
     Ok(Json(save_response_from_traject(outcome)))
 }

--- a/packages/editor-api/src/traject_corpus.rs
+++ b/packages/editor-api/src/traject_corpus.rs
@@ -120,16 +120,28 @@ pub struct TrajectCorpus {
     /// GitHub-round-trip-heavy read. Per-snapshot; invalidated by
     /// scenario save/delete.
     scenario_list_cache: RwLock<BoundedCache<Vec<ScenarioListEntry>>>,
-    /// Write-generation counter guarding `sidecar_cache` +
-    /// `scenario_list_cache` against a read/write race: a GET-path
-    /// backend read can take seconds, and a save/delete that lands in
-    /// the cache meanwhile must not be overwritten when that older read
-    /// finally completes — the pre-save bytes would then serve (with a
-    /// pre-save ETag, 412-looping the saver's next If-Match) until the
-    /// snapshot swap. Write-initiated mutations bump this under the
-    /// cache write lock; read-path stores capture it *before* their
-    /// backend read and insert only while it is unchanged.
+    /// Write-generation counter guarding `sidecar_cache` against a
+    /// read/write race: a GET-path backend read can take seconds, and a
+    /// save/delete that lands in the cache meanwhile must not be
+    /// overwritten when that older read finally completes — the pre-save
+    /// bytes would then serve (with a pre-save ETag, 412-looping the
+    /// saver's next If-Match) until the snapshot swap. Write-initiated
+    /// mutations bump this under the cache write lock; read-path stores
+    /// capture it *before* their cache probe (a capture after the probe
+    /// would let a write landing in between go unnoticed — the read
+    /// would see the post-write generation and re-cache possibly stale
+    /// backend bytes over the write's entry) and insert only while it is
+    /// unchanged. One counter per cache family (see
+    /// `scenario_list_write_gen`) so a write in one family never drops a
+    /// concurrent read-path store in the other.
     sidecar_write_gen: AtomicU64,
+    /// Write-generation counter guarding `scenario_list_cache` — the
+    /// listing analogue of `sidecar_write_gen`, with the same capture-
+    /// before-probe contract. Bumped by [`Self::record_scenario_saved`] /
+    /// [`Self::record_scenario_deleted`] so an in-flight listing rebuild
+    /// discards its (possibly pre-write) result instead of masking the
+    /// mutation.
+    scenario_list_write_gen: AtomicU64,
     /// "Law → laws it `implements`" index, built on demand by
     /// [`implementors_of`]. A TTL refresh carries the previous snapshot's
     /// index over as a *stale* value (see `implements_index_stale`) and
@@ -559,13 +571,20 @@ impl TrajectCorpus {
         self.sidecar_cache.read().await.get(key).cloned()
     }
 
-    /// Current write-generation of the sidecar caches. GET-path callers
-    /// capture this *before* their backend read and pass it to
-    /// [`Self::store_sidecar_read`] / [`Self::store_scenario_list_read`],
-    /// which then drop the store when a save/delete bumped the counter in
-    /// between — see `sidecar_write_gen`.
+    /// Current write-generation of `sidecar_cache`. GET-path callers
+    /// capture this *before* their cache probe + backend read and pass it
+    /// to [`Self::store_sidecar_read`], which then drops the store when a
+    /// save/delete bumped the counter in between — see
+    /// `sidecar_write_gen`.
     pub fn sidecar_write_generation(&self) -> u64 {
         self.sidecar_write_gen.load(Ordering::SeqCst)
+    }
+
+    /// Current write-generation of `scenario_list_cache` — the listing
+    /// counterpart of [`Self::sidecar_write_generation`], consumed by
+    /// [`Self::store_scenario_list_read`].
+    pub fn scenario_list_write_generation(&self) -> u64 {
+        self.scenario_list_write_gen.load(Ordering::SeqCst)
     }
 
     /// Store a GET-path sidecar read result for `key`, unless a
@@ -617,7 +636,7 @@ impl TrajectCorpus {
         gen_before: u64,
     ) {
         let mut cache = self.scenario_list_cache.write().await;
-        if self.sidecar_write_gen.load(Ordering::SeqCst) == gen_before {
+        if self.scenario_list_write_gen.load(Ordering::SeqCst) == gen_before {
             cache.insert(law_id, entries);
         }
     }
@@ -638,7 +657,7 @@ impl TrajectCorpus {
         target_law_ids: Vec<String>,
     ) {
         let mut cache = self.scenario_list_cache.write().await;
-        self.sidecar_write_gen.fetch_add(1, Ordering::SeqCst);
+        self.scenario_list_write_gen.fetch_add(1, Ordering::SeqCst);
         if let Some(mut entries) = cache.get(law_id).cloned() {
             match entries.iter_mut().find(|e| e.filename == filename) {
                 Some(entry) => entry.target_law_ids = target_law_ids,
@@ -662,7 +681,7 @@ impl TrajectCorpus {
     /// in-flight rebuild discards its result.
     pub async fn record_scenario_deleted(&self, law_id: &str, filename: &str) {
         let mut cache = self.scenario_list_cache.write().await;
-        self.sidecar_write_gen.fetch_add(1, Ordering::SeqCst);
+        self.scenario_list_write_gen.fetch_add(1, Ordering::SeqCst);
         if let Some(mut entries) = cache.get(law_id).cloned() {
             entries.retain(|e| e.filename != filename);
             cache.insert(law_id.to_string(), entries);
@@ -1596,6 +1615,7 @@ async fn build_traject_corpus(
         sidecar_cache: RwLock::new(BoundedCache::default()),
         scenario_list_cache: RwLock::new(BoundedCache::default()),
         sidecar_write_gen: AtomicU64::new(0),
+        scenario_list_write_gen: AtomicU64::new(0),
     }))
 }
 
@@ -1683,6 +1703,7 @@ async fn next_snapshot(old: &Arc<TrajectCorpus>, source_map: SourceMap) -> Arc<T
         sidecar_cache: RwLock::new(BoundedCache::default()),
         scenario_list_cache: RwLock::new(BoundedCache::default()),
         sidecar_write_gen: AtomicU64::new(0),
+        scenario_list_write_gen: AtomicU64::new(0),
     })
 }
 
@@ -1979,6 +2000,7 @@ mod tests {
             sidecar_cache: RwLock::new(BoundedCache::default()),
             scenario_list_cache: RwLock::new(BoundedCache::default()),
             sidecar_write_gen: AtomicU64::new(0),
+            scenario_list_write_gen: AtomicU64::new(0),
         }
     }
 
@@ -2318,6 +2340,7 @@ mod tests {
             sidecar_cache: RwLock::new(BoundedCache::default()),
             scenario_list_cache: RwLock::new(BoundedCache::default()),
             sidecar_write_gen: AtomicU64::new(0),
+            scenario_list_write_gen: AtomicU64::new(0),
         })
     }
 
@@ -2829,7 +2852,7 @@ mod tests {
                     filename: "x.feature".to_string(),
                     target_law_ids: vec!["wet_a".to_string()],
                 }],
-                corpus.sidecar_write_generation(),
+                corpus.scenario_list_write_generation(),
             )
             .await;
         assert_eq!(
@@ -2931,10 +2954,10 @@ mod tests {
                     filename: "deleted.feature".to_string(),
                     target_law_ids: vec![],
                 }],
-                corpus.sidecar_write_generation(),
+                corpus.scenario_list_write_generation(),
             )
             .await;
-        let gen_before = corpus.sidecar_write_generation();
+        let gen_before = corpus.scenario_list_write_generation();
         corpus
             .record_scenario_deleted("wet_a", "deleted.feature")
             .await;
@@ -2960,6 +2983,38 @@ mod tests {
             .store_sidecar_read("ann:wet_a".to_string(), None, gen_before)
             .await;
         assert_eq!(corpus.cached_sidecar("ann:wet_a").await, Some(None));
+
+        // The two cache families have independent generations: a scenario
+        // save/delete (listing counter) must not drop a concurrent
+        // sidecar read, and an annotation save (sidecar counter) must not
+        // drop a concurrent listing rebuild.
+        let gen_before = corpus.sidecar_write_generation();
+        corpus
+            .record_scenario_saved("wet_a", "b.feature", vec![])
+            .await;
+        corpus
+            .store_sidecar_read(
+                "ann:wet_b".to_string(),
+                Some("notes: []\n".to_string()),
+                gen_before,
+            )
+            .await;
+        assert_eq!(
+            corpus.cached_sidecar("ann:wet_b").await,
+            Some(Some("notes: []\n".to_string()))
+        );
+        let gen_before = corpus.scenario_list_write_generation();
+        corpus
+            .store_sidecar("ann:wet_b".to_string(), Some("notes: [x]\n".to_string()))
+            .await;
+        corpus
+            .store_scenario_list_read("wet_b".to_string(), Vec::new(), gen_before)
+            .await;
+        assert!(corpus
+            .cached_scenario_list("wet_b")
+            .await
+            .unwrap()
+            .is_empty());
     }
 
     #[test]

--- a/packages/editor-api/src/traject_corpus.rs
+++ b/packages/editor-api/src/traject_corpus.rs
@@ -13,17 +13,20 @@
 //! other.
 //!
 //! The cached index snapshot expires after [`TRAJECT_INDEX_TTL`]: the
-//! first request past the TTL re-enumerates the sources and swaps in a
-//! fresh [`SourceMap`] (new laws merged upstream, re-harvests, saves on
-//! another replica become visible without a process restart), while the
-//! backends, the post-save overlay (reconciled against the branch — see
-//! [`reconcile_overlay`]), the implements index/memo and the
-//! changed-laws cache carry over so in-flight saves, read-your-writes
-//! semantics and implementor lookups are unaffected.
+//! first request past the TTL kicks off a background re-enumeration of
+//! the sources that swaps in a fresh [`SourceMap`] (new laws merged
+//! upstream, re-harvests, saves on another replica become visible
+//! without a process restart) while every request — including that first
+//! one — keeps being served the stale snapshot (stale-while-revalidate;
+//! nobody waits out the GitHub round-trips). The backends, the post-save
+//! overlay (reconciled against the branch — see [`reconcile_overlay`]),
+//! the implements index/memo and the changed-laws cache carry over so
+//! in-flight saves, read-your-writes semantics and implementor lookups
+//! are unaffected.
 
 use std::collections::{HashMap, VecDeque};
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -98,7 +101,35 @@ pub struct TrajectCorpus {
     /// process restart. Bounded at [`BODY_CACHE_MAX_ENTRIES`] with FIFO
     /// eviction so a crawl across a large federated corpus can't grow it
     /// without limit.
-    body_cache: RwLock<BoundedBodyCache>,
+    body_cache: RwLock<BoundedCache<String>>,
+    /// Law-scoped sidecar files (annotations, individual scenario
+    /// `.feature` files) fetched lazily on first read, keyed by a
+    /// caller-prefixed string (see `corpus_handlers`). `None` entries are
+    /// cached too — "this law has no annotations" costs a full GitHub
+    /// round-trip to rediscover, and the editor asks on every law open.
+    ///
+    /// Per-snapshot like `body_cache` (upstream edits become visible
+    /// within [`TRAJECT_INDEX_TTL`]); writes keep it correct within the
+    /// window via [`Self::store_sidecar`] / [`Self::invalidate_sidecar`]
+    /// (read-your-writes, like the law-body `overlay`).
+    sidecar_cache: RwLock<BoundedCache<Option<String>>>,
+    /// Per-law scenario listing (filenames + extracted target law ids),
+    /// the result of the union-listing in `list_scenarios_in_scope`. One
+    /// entry costs 2 `list_files` calls plus a read per scenario file to
+    /// rebuild, so the editor's per-law-open listing is the single most
+    /// GitHub-round-trip-heavy read. Per-snapshot; invalidated by
+    /// scenario save/delete.
+    scenario_list_cache: RwLock<BoundedCache<Vec<ScenarioListEntry>>>,
+    /// Write-generation counter guarding `sidecar_cache` +
+    /// `scenario_list_cache` against a read/write race: a GET-path
+    /// backend read can take seconds, and a save/delete that lands in
+    /// the cache meanwhile must not be overwritten when that older read
+    /// finally completes — the pre-save bytes would then serve (with a
+    /// pre-save ETag, 412-looping the saver's next If-Match) until the
+    /// snapshot swap. Write-initiated mutations bump this under the
+    /// cache write lock; read-path stores capture it *before* their
+    /// backend read and insert only while it is unchanged.
+    sidecar_write_gen: AtomicU64,
     /// "Law → laws it `implements`" index, built on demand by
     /// [`implementors_of`]. A TTL refresh carries the previous snapshot's
     /// index over as a *stale* value (see `implements_index_stale`) and
@@ -143,8 +174,24 @@ pub struct TrajectCorpus {
     /// fallback when a fresh Compare call fails (e.g. token throttled), so
     /// the section degrades to slightly-stale rather than vanishing.
     /// Shared (via the `Arc`) across TTL index refreshes, like `overlay`:
-    /// a refresh must not undo `save_law`'s invalidation of this cache.
+    /// a refresh must not undo `save_law`'s update of this cache.
     changed_cache: Arc<RwLock<Option<ChangedLawsCache>>>,
+    /// Single-flight gate for the *background* changed-laws recompute
+    /// spawned by [`Self::changed_law_ids`] when the cache entry has
+    /// expired: only one task per traject recomputes, everyone else keeps
+    /// serving the stale ids. Shared across snapshots like the cache it
+    /// guards, so a refresh mid-recompute cannot admit a second Compare
+    /// call.
+    changed_refresh_in_flight: Arc<AtomicBool>,
+}
+
+/// One scenario file in a law's cached listing: the filename plus the law
+/// ids its `I evaluate … of "…"` steps target (the data
+/// `corpus_handlers::ScenarioEntry` is serialised from).
+#[derive(Clone)]
+pub struct ScenarioListEntry {
+    pub filename: String,
+    pub target_law_ids: Vec<String>,
 }
 
 /// Cached result of [`TrajectCorpus::changed_law_ids`] with the instant it
@@ -154,6 +201,17 @@ struct ChangedLawsCache {
     law_ids: Vec<String>,
 }
 
+/// RAII reset for a single-flight `AtomicBool` held by a spawned task:
+/// clears the flag when the task ends, *including* on panic — a latched
+/// flag would permanently disable the background path it guards.
+struct ResetOnDrop(Arc<AtomicBool>);
+
+impl Drop for ResetOnDrop {
+    fn drop(&mut self) {
+        self.0.store(false, Ordering::SeqCst);
+    }
+}
+
 /// How long a cached changed-laws diff is served before a fresh GitHub
 /// Compare call is made. Short enough that another member's save shows up
 /// promptly in the sidebar, long enough to collapse a burst of library
@@ -161,12 +219,14 @@ struct ChangedLawsCache {
 const CHANGED_LAWS_TTL: Duration = Duration::from_secs(60);
 
 /// How long a traject's cached index snapshot (its [`SourceMap`] plus the
-/// derived body / implements caches) is served before the first request
-/// past the deadline re-enumerates the sources. Same convergence target
-/// as [`CHANGED_LAWS_TTL`]: upstream changes (new laws merged, re-harvests,
-/// saves on another replica) show up within a minute instead of requiring
-/// a process restart, while a burst of library loads still hits the
-/// snapshot. The refresh keeps backends, the post-save overlay and the
+/// derived body / sidecar / implements caches) is served before the first
+/// request past the deadline triggers a *background* re-enumeration of
+/// the sources (stale-while-revalidate — the triggering request itself
+/// keeps serving the stale snapshot). Same convergence target as
+/// [`CHANGED_LAWS_TTL`]: upstream changes (new laws merged, re-harvests,
+/// saves on another replica) show up within roughly a minute instead of
+/// requiring a process restart, while a burst of library loads still hits
+/// the snapshot. The refresh keeps backends, the post-save overlay and the
 /// changed-laws cache (see [`TrajectCorpusCache::get_or_build`]).
 const TRAJECT_INDEX_TTL: Duration = Duration::from_secs(60);
 
@@ -188,34 +248,47 @@ const BODY_CACHE_MAX_ENTRIES: usize = 1024;
 /// [`RepoBackend::read_all_implements`]: regelrecht_corpus::backend::RepoBackend::read_all_implements
 const BULK_FETCH_THRESHOLD: usize = 16;
 
-/// Lazily-fetched law bodies with a FIFO size cap. FIFO (not LRU) keeps
-/// reads lock-cheap: a cache hit only needs the outer `RwLock`'s read
-/// guard, no per-hit reordering under a write lock. Eviction order only
-/// matters once a traject's read set exceeds [`BODY_CACHE_MAX_ENTRIES`],
-/// which is already crawl territory.
+/// Lazily-fetched per-snapshot values with a FIFO size cap, keyed by a
+/// caller-chosen string (law id for bodies, a prefixed key for sidecar
+/// files). FIFO (not LRU) keeps reads lock-cheap: a cache hit only needs
+/// the outer `RwLock`'s read guard, no per-hit reordering under a write
+/// lock. Eviction order only matters once a traject's read set exceeds
+/// [`BODY_CACHE_MAX_ENTRIES`], which is already crawl territory.
 #[derive(Default)]
-struct BoundedBodyCache {
-    map: HashMap<String, String>,
+struct BoundedCache<V> {
+    map: HashMap<String, V>,
     /// Insertion order of the keys in `map`, oldest first.
     order: VecDeque<String>,
 }
 
-impl BoundedBodyCache {
-    fn get(&self, law_id: &str) -> Option<&String> {
-        self.map.get(law_id)
+impl<V> BoundedCache<V> {
+    fn get(&self, key: &str) -> Option<&V> {
+        self.map.get(key)
     }
 
-    fn insert(&mut self, law_id: String, body: String) {
-        if !self.map.contains_key(&law_id) {
+    fn insert(&mut self, key: String, value: V) {
+        if !self.map.contains_key(&key) {
             while self.map.len() >= BODY_CACHE_MAX_ENTRIES {
                 let Some(oldest) = self.order.pop_front() else {
                     break;
                 };
                 self.map.remove(&oldest);
             }
-            self.order.push_back(law_id.clone());
+            self.order.push_back(key.clone());
         }
-        self.map.insert(law_id, body);
+        self.map.insert(key, value);
+    }
+
+    /// Drop one key, including its `order` entry. The O(n) deque scan is
+    /// fine — invalidations are save/delete-driven, so rare. Leaving the
+    /// order entry behind would be subtly wrong at capacity: a re-insert
+    /// of the same key appends a duplicate, and eviction popping the
+    /// stale front duplicate would `map.remove` the *live* re-inserted
+    /// value while its newer order entry survives.
+    fn remove(&mut self, key: &str) {
+        if self.map.remove(key).is_some() {
+            self.order.retain(|k| k != key);
+        }
     }
 }
 
@@ -473,6 +546,90 @@ impl TrajectCorpus {
                 index.implements_by_law.insert(law_id, implements);
             }
         }
+    }
+
+    /// Cached sidecar file content for `key` (annotations / scenario
+    /// files; the caller prefixes the key by kind — see
+    /// `corpus_handlers`). The outer `Option` is the cache verdict
+    /// (miss vs hit), the inner one the cached read result — `Some(None)`
+    /// means "we asked GitHub and the file does not exist", which is as
+    /// expensive to rediscover as a hit and far more common (most laws
+    /// have no annotations yet).
+    pub async fn cached_sidecar(&self, key: &str) -> Option<Option<String>> {
+        self.sidecar_cache.read().await.get(key).cloned()
+    }
+
+    /// Current write-generation of the sidecar caches. GET-path callers
+    /// capture this *before* their backend read and pass it to
+    /// [`Self::store_sidecar_read`] / [`Self::store_scenario_list_read`],
+    /// which then drop the store when a save/delete bumped the counter in
+    /// between — see `sidecar_write_gen`.
+    pub fn sidecar_write_generation(&self) -> u64 {
+        self.sidecar_write_gen.load(Ordering::SeqCst)
+    }
+
+    /// Store a GET-path sidecar read result for `key`, unless a
+    /// write-initiated mutation happened since the caller captured
+    /// `gen_before` — a slow read completing after a save must not
+    /// re-cache the pre-save bytes over the save's fresher entry.
+    pub async fn store_sidecar_read(&self, key: String, content: Option<String>, gen_before: u64) {
+        let mut cache = self.sidecar_cache.write().await;
+        if self.sidecar_write_gen.load(Ordering::SeqCst) == gen_before {
+            cache.insert(key, content);
+        }
+    }
+
+    /// Store a just-written sidecar body for `key` — the sidecar analogue
+    /// of [`Self::record_save`]'s read-your-writes. Bumps the write
+    /// generation (under the cache write lock) so an in-flight GET-path
+    /// read discards its possibly pre-save result instead of overwriting
+    /// this entry.
+    pub async fn store_sidecar(&self, key: String, content: Option<String>) {
+        let mut cache = self.sidecar_cache.write().await;
+        self.sidecar_write_gen.fetch_add(1, Ordering::SeqCst);
+        cache.insert(key, content);
+    }
+
+    /// Drop one sidecar cache entry so the next read resolves through the
+    /// real backend routing again. Used by scenario delete, where the
+    /// next read may legitimately fall back to a seed copy — a negative
+    /// cache entry would hide it. Bumps the write generation for the same
+    /// reason [`Self::store_sidecar`] does.
+    pub async fn invalidate_sidecar(&self, key: &str) {
+        let mut cache = self.sidecar_cache.write().await;
+        self.sidecar_write_gen.fetch_add(1, Ordering::SeqCst);
+        cache.remove(key);
+    }
+
+    /// Cached scenario listing for `law_id` (see `scenario_list_cache`).
+    pub async fn cached_scenario_list(&self, law_id: &str) -> Option<Vec<ScenarioListEntry>> {
+        self.scenario_list_cache.read().await.get(law_id).cloned()
+    }
+
+    /// Store the scenario listing computed for `law_id` on the GET path,
+    /// unless a write-initiated mutation happened since `gen_before` was
+    /// captured (same guard as [`Self::store_sidecar_read`] — a listing
+    /// computed before a save/delete must not mask it).
+    pub async fn store_scenario_list_read(
+        &self,
+        law_id: String,
+        entries: Vec<ScenarioListEntry>,
+        gen_before: u64,
+    ) {
+        let mut cache = self.scenario_list_cache.write().await;
+        if self.sidecar_write_gen.load(Ordering::SeqCst) == gen_before {
+            cache.insert(law_id, entries);
+        }
+    }
+
+    /// Drop the cached scenario listing for `law_id` after a scenario
+    /// save/delete, so the next listing reflects the mutation. Bumps the
+    /// write generation so an in-flight listing computation discards its
+    /// result.
+    pub async fn invalidate_scenario_list(&self, law_id: &str) {
+        let mut cache = self.scenario_list_cache.write().await;
+        self.sidecar_write_gen.fetch_add(1, Ordering::SeqCst);
+        cache.remove(law_id);
     }
 
     /// Law ids whose articles declare `implements` for `law_id` (the IoC
@@ -752,15 +909,37 @@ impl TrajectCorpus {
     /// any, is served rather than propagating the error — the sidebar keeps
     /// showing the last-known edit set instead of dropping the section.
     pub async fn changed_law_ids(
-        &self,
+        self: &Arc<Self>,
     ) -> Result<Vec<String>, regelrecht_corpus::error::CorpusError> {
-        // Fast path: a fresh cache entry serves without any GitHub call.
+        // Fresh or expired, a cached entry is always served immediately.
+        // Past the TTL the first caller additionally kicks off ONE
+        // background recompute (stale-while-revalidate) — nobody waits
+        // out the GitHub Compare round-trip on the request path, and
+        // convergence stays within one extra TTL window.
         if let Some(cached) = self.changed_cache.read().await.as_ref() {
-            if cached.computed_at.elapsed() < CHANGED_LAWS_TTL {
-                return Ok(cached.law_ids.clone());
+            if cached.computed_at.elapsed() >= CHANGED_LAWS_TTL
+                && self
+                    .changed_refresh_in_flight
+                    .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+                    .is_ok()
+            {
+                let corpus = self.clone();
+                tokio::spawn(async move {
+                    // RAII reset (not a trailing `store`): a panic inside
+                    // the recompute must not leave the flag latched true,
+                    // or no request would ever recompute again and the
+                    // stale ids would serve until process restart — the
+                    // AtomicBool analogue of the snapshot refresh's
+                    // OwnedMutexGuard.
+                    let _reset = ResetOnDrop(corpus.changed_refresh_in_flight.clone());
+                    corpus.recompute_changed_cache().await;
+                });
             }
+            return Ok(cached.law_ids.clone());
         }
 
+        // Nothing cached (first call of the process): compute on the
+        // request path — there is nothing stale to serve instead.
         match self.compute_changed_law_ids().await {
             Ok(ids) => {
                 *self.changed_cache.write().await = Some(ChangedLawsCache {
@@ -769,28 +948,62 @@ impl TrajectCorpus {
                 });
                 Ok(ids)
             }
+            Err(e) => Err(e),
+        }
+    }
+
+    /// The background leg of [`changed_law_ids`]'s stale-while-revalidate:
+    /// recompute the diff and swap it in. On failure the *stale* entry is
+    /// re-armed for another TTL window (matching the snapshot refresh's
+    /// degrade-to-stale stance) so a throttled upstream isn't re-hit by
+    /// every subsequent request.
+    ///
+    /// Known bounded race: the wholesale swap can undo a concurrent
+    /// [`Self::record_changed_law`] fold — a save that commits while the
+    /// Compare call is in flight may briefly drop out of the diff (the
+    /// Compare predates the save's commit, and the path→id mapping runs
+    /// through this possibly-older snapshot's `source_map`). Self-heals
+    /// at the next recompute, ≤ one [`CHANGED_LAWS_TTL`] window; the
+    /// pre-existing invalidate-based code had the same window around a
+    /// save.
+    async fn recompute_changed_cache(&self) {
+        match self.compute_changed_law_ids().await {
+            Ok(ids) => {
+                *self.changed_cache.write().await = Some(ChangedLawsCache {
+                    computed_at: Instant::now(),
+                    law_ids: ids,
+                });
+            }
             Err(e) => {
-                // Serve a stale entry (if we have one) rather than dropping
-                // the section when GitHub is momentarily unavailable /
-                // rate-limited. Only propagate when there's nothing cached.
-                if let Some(cached) = self.changed_cache.read().await.as_ref() {
-                    tracing::warn!(
-                        error = %e,
-                        "changed-laws compute failed; serving stale cached value"
-                    );
-                    return Ok(cached.law_ids.clone());
+                tracing::warn!(
+                    error = %e,
+                    "changed-laws recompute failed; serving stale cached value for another TTL"
+                );
+                if let Some(cached) = self.changed_cache.write().await.as_mut() {
+                    cached.computed_at = Instant::now();
                 }
-                Err(e)
             }
         }
     }
 
-    /// Drop the cached changed-laws diff so the next [`changed_law_ids`]
-    /// call recomputes against GitHub. Called by `save_law` so the saving
-    /// user's new edit shows up in the sidebar immediately instead of after
-    /// the TTL — the changed-laws analogue of [`record_save`].
-    pub async fn invalidate_changed_cache(&self) {
-        *self.changed_cache.write().await = None;
+    /// Fold a just-saved law into the cached changed-laws diff so the
+    /// saving user sees their edit in the sidebar immediately
+    /// (read-your-writes, the changed-laws analogue of [`record_save`]) —
+    /// without the synchronous GitHub Compare call that invalidating the
+    /// cache used to cost the next sidebar load. The entry's TTL clock is
+    /// deliberately NOT reset: the next recompute reconciles against the
+    /// real branch diff on schedule (covering e.g. a save that reverts a
+    /// law back to its base content, which should eventually disappear
+    /// from the list).
+    pub async fn record_changed_law(&self, law_id: &str) {
+        if let Some(cached) = self.changed_cache.write().await.as_mut() {
+            if !cached.law_ids.iter().any(|id| id == law_id) {
+                cached.law_ids.push(law_id.to_string());
+                cached.law_ids.sort();
+            }
+        }
+        // No cache entry yet: leave it absent — the next changed-laws
+        // request computes the real diff (which includes this save).
     }
 
     /// Uncached computation behind [`changed_law_ids`]: ask the writable-own
@@ -843,11 +1056,13 @@ impl CachedCorpus {
 /// Per-traject cache slot. `state` holds the current snapshot (None until
 /// first build); `build_lock` single-flights both the initial build and
 /// TTL refreshes so concurrent first-touches share one clone and a
-/// refresh herd collapses to one source enumeration.
+/// refresh herd collapses to one source enumeration. Behind an `Arc` so
+/// the background refresh task can carry its `OwnedMutexGuard` across
+/// `tokio::spawn`.
 #[derive(Default)]
 struct TrajectSlot {
     state: RwLock<Option<CachedCorpus>>,
-    build_lock: Mutex<()>,
+    build_lock: Arc<Mutex<()>>,
     /// Consecutive failed TTL refreshes. Serving stale stays correct
     /// indefinitely, but a permanently broken source would otherwise
     /// re-warn every TTL window — the count rate-limits the warn to the
@@ -903,12 +1118,14 @@ impl TrajectCorpusCache {
     /// `ensure_ready`), and stitches them into a [`CorpusState`].
     ///
     /// When the cached snapshot is older than the index TTL, the first
-    /// request past the deadline re-enumerates the sources and swaps in a
-    /// refreshed [`TrajectCorpus`] (see [`refresh_traject_corpus`] for
-    /// what carries over); concurrent requests keep being served the
-    /// stale snapshot while one refresh is in flight, and a failed
-    /// refresh extends the stale snapshot for another TTL window instead
-    /// of erroring reads (same degrade-to-stale stance as
+    /// request past the deadline kicks off a *background* refresh (see
+    /// [`refresh_traject_corpus`] for what carries over) and — like every
+    /// concurrent request while that refresh is in flight — keeps being
+    /// served the stale snapshot. No request ever waits out the source
+    /// re-enumeration (stale-while-revalidate); only the very first build
+    /// of a traject blocks, because there is nothing to serve yet. A
+    /// failed refresh extends the stale snapshot for another TTL window
+    /// instead of erroring reads (same degrade-to-stale stance as
     /// [`TrajectCorpus::changed_law_ids`]).
     pub async fn get_or_build(
         &self,
@@ -924,90 +1141,52 @@ impl TrajectCorpusCache {
         };
 
         // Fast path: a fresh snapshot serves without touching the build
-        // lock. A stale-but-present snapshot is remembered so it can be
-        // served when another task is already refreshing.
-        let stale = {
+        // lock. A stale snapshot is served just as fast — expiry only
+        // decides whether a background refresh is kicked off first.
+        {
             let state = slot.state.read().await;
             match state.as_ref() {
                 Some(cached) if cached.is_fresh(self.index_ttl) => {
                     tracing::debug!(traject = %traject_id, cache = "hit", "traject corpus served from cache");
                     return Ok(cached.corpus.clone());
                 }
-                Some(cached) => Some(cached.corpus.clone()),
-                None => None,
+                Some(cached) => {
+                    let stale = cached.corpus.clone();
+                    drop(state);
+                    // Stale: only one task refreshes (`try_lock`); everyone
+                    // else — including the winner — serves stale rather than
+                    // queueing up behind a network round-trip.
+                    if let Ok(guard) = slot.build_lock.clone().try_lock_owned() {
+                        spawn_background_refresh(
+                            guard,
+                            slot.clone(),
+                            stale.clone(),
+                            traject_id,
+                            self.index_ttl,
+                        );
+                    }
+                    return Ok(stale);
+                }
+                None => {}
             }
-        };
+        }
 
-        let _build = match &stale {
-            // Nothing cached: every caller must wait for the one build.
-            None => slot.build_lock.lock().await,
-            // Stale: only one task refreshes; the rest serve stale rather
-            // than queueing up behind a network round-trip.
-            Some(stale_corpus) => match slot.build_lock.try_lock() {
-                Ok(guard) => guard,
-                Err(_) => return Ok(stale_corpus.clone()),
-            },
-        };
+        // Nothing cached: every caller must wait for the one build.
+        let _build = slot.build_lock.clone().lock_owned().await;
 
         // Re-check under the build lock: the previous holder may have
-        // built/refreshed while we waited.
-        let stale = {
-            let state = slot.state.read().await;
-            match state.as_ref() {
-                Some(cached) if cached.is_fresh(self.index_ttl) => {
-                    tracing::debug!(traject = %traject_id, cache = "hit", "traject corpus served from cache");
-                    return Ok(cached.corpus.clone());
-                }
-                Some(cached) => Some(cached.corpus.clone()),
-                None => None,
-            }
-        };
+        // built while we waited.
+        if let Some(cached) = slot.state.read().await.as_ref() {
+            tracing::debug!(traject = %traject_id, cache = "hit", "traject corpus served from cache");
+            return Ok(cached.corpus.clone());
+        }
 
-        let corpus = match stale {
-            None => {
-                tracing::debug!(traject = %traject_id, cache = "cold", "building traject corpus (cold)");
-                timing::measure(
-                    "build",
-                    build_traject_corpus(pool, traject_id, auth_file.as_deref()),
-                )
-                .await?
-            }
-            Some(old) => {
-                match timing::measure("refresh", refresh_traject_corpus(&old, traject_id)).await {
-                    Ok(refreshed) => refreshed,
-                    Err(e) => {
-                        // Serve (and re-arm) the stale snapshot rather than
-                        // failing reads on a transient enumeration error; the
-                        // re-armed `built_at` stops every subsequent request
-                        // from re-attempting against a throttled upstream.
-                        // Rate-limit the warn: a permanently broken source
-                        // fails every TTL window, and repeating the same warn
-                        // each minute drowns the log without new signal.
-                        let failures = slot.refresh_failures.fetch_add(1, Ordering::SeqCst) + 1;
-                        if failures == 1 || failures % FAILED_REFRESH_WARN_EVERY == 0 {
-                            tracing::warn!(
-                                traject = %traject_id,
-                                error = %e,
-                                consecutive_failures = failures,
-                                "traject index refresh failed; serving stale snapshot for another TTL"
-                            );
-                        } else {
-                            tracing::debug!(
-                                traject = %traject_id,
-                                error = %e,
-                                consecutive_failures = failures,
-                                "traject index refresh failed again; serving stale snapshot for another TTL"
-                            );
-                        }
-                        *slot.state.write().await = Some(CachedCorpus {
-                            corpus: old.clone(),
-                            built_at: Instant::now(),
-                        });
-                        return Ok(old);
-                    }
-                }
-            }
-        };
+        tracing::debug!(traject = %traject_id, cache = "cold", "building traject corpus (cold)");
+        let corpus = timing::measure(
+            "build",
+            build_traject_corpus(pool, traject_id, auth_file.as_deref()),
+        )
+        .await?;
 
         slot.refresh_failures.store(0, Ordering::SeqCst);
         *slot.state.write().await = Some(CachedCorpus {
@@ -1022,6 +1201,91 @@ impl TrajectCorpusCache {
     /// served further.
     pub async fn invalidate(&self, traject_id: Uuid) {
         self.cells.write().await.remove(&traject_id);
+    }
+}
+
+/// The background leg of [`TrajectCorpusCache::get_or_build`]'s
+/// stale-while-revalidate: refresh the index snapshot off the request
+/// path and swap it into the slot. `guard` is the slot's build lock,
+/// won by `try_lock` on the request path and held until the swap so a
+/// concurrent expiry cannot start a second enumeration.
+///
+/// On failure the stale snapshot is re-armed for another TTL window —
+/// the re-armed `built_at` stops every subsequent request from
+/// re-attempting against a throttled upstream. The warn is rate-limited
+/// via `refresh_failures`: a permanently broken source fails every TTL
+/// window, and repeating the same warn each minute drowns the log
+/// without new signal.
+///
+/// Races it tolerates: a [`TrajectCorpusCache::invalidate`] between
+/// spawn and swap orphans the slot (it's no longer in `cells`), so the
+/// swap writes into state nobody reads again — the next request builds
+/// cold, which is exactly what invalidation asks for.
+fn spawn_background_refresh(
+    guard: tokio::sync::OwnedMutexGuard<()>,
+    slot: Arc<TrajectSlot>,
+    old: Arc<TrajectCorpus>,
+    traject_id: Uuid,
+    index_ttl: Duration,
+) {
+    tokio::spawn(async move {
+        let _guard = guard;
+        // Between losing the state read lock and winning the build lock a
+        // previous holder may already have refreshed — don't enumerate the
+        // sources twice within one TTL window.
+        if let Some(cached) = slot.state.read().await.as_ref() {
+            if cached.is_fresh(index_ttl) {
+                return;
+            }
+        }
+
+        let span = tracing::info_span!("traject_index_refresh", traject = %traject_id);
+        let outcome =
+            tracing::Instrument::instrument(refresh_traject_corpus(&old, traject_id), span).await;
+        apply_refresh_outcome(&slot, old, traject_id, outcome).await;
+    });
+}
+
+/// Swap a refresh outcome into the slot: a fresh snapshot on success, the
+/// re-armed stale one on failure. Factored out of
+/// [`spawn_background_refresh`] so the failure stance is unit-testable
+/// without needing a source that fails to enumerate.
+async fn apply_refresh_outcome(
+    slot: &TrajectSlot,
+    old: Arc<TrajectCorpus>,
+    traject_id: Uuid,
+    outcome: Result<Arc<TrajectCorpus>, TrajectCorpusError>,
+) {
+    match outcome {
+        Ok(refreshed) => {
+            slot.refresh_failures.store(0, Ordering::SeqCst);
+            *slot.state.write().await = Some(CachedCorpus {
+                corpus: refreshed,
+                built_at: Instant::now(),
+            });
+        }
+        Err(e) => {
+            let failures = slot.refresh_failures.fetch_add(1, Ordering::SeqCst) + 1;
+            if failures == 1 || failures.is_multiple_of(FAILED_REFRESH_WARN_EVERY) {
+                tracing::warn!(
+                    traject = %traject_id,
+                    error = %e,
+                    consecutive_failures = failures,
+                    "traject index refresh failed; serving stale snapshot for another TTL"
+                );
+            } else {
+                tracing::debug!(
+                    traject = %traject_id,
+                    error = %e,
+                    consecutive_failures = failures,
+                    "traject index refresh failed again; serving stale snapshot for another TTL"
+                );
+            }
+            *slot.state.write().await = Some(CachedCorpus {
+                corpus: old,
+                built_at: Instant::now(),
+            });
+        }
     }
 }
 
@@ -1285,12 +1549,16 @@ async fn build_traject_corpus(
         write_target_for_source,
         writable_own_source_id,
         overlay: Arc::new(RwLock::new(HashMap::new())),
-        body_cache: RwLock::new(BoundedBodyCache::default()),
+        body_cache: RwLock::new(BoundedCache::default()),
         implements_index: RwLock::new(None),
         implements_index_stale: AtomicBool::new(false),
         implements_build_lock: Mutex::new(()),
         implements_memo: Arc::new(RwLock::new(HashMap::new())),
         changed_cache: Arc::new(RwLock::new(None)),
+        changed_refresh_in_flight: Arc::new(AtomicBool::new(false)),
+        sidecar_cache: RwLock::new(BoundedCache::default()),
+        scenario_list_cache: RwLock::new(BoundedCache::default()),
+        sidecar_write_gen: AtomicU64::new(0),
     }))
 }
 
@@ -1368,12 +1636,16 @@ async fn next_snapshot(old: &Arc<TrajectCorpus>, source_map: SourceMap) -> Arc<T
         write_target_for_source: old.write_target_for_source.clone(),
         writable_own_source_id: old.writable_own_source_id.clone(),
         overlay: old.overlay.clone(),
-        body_cache: RwLock::new(BoundedBodyCache::default()),
+        body_cache: RwLock::new(BoundedCache::default()),
         implements_index: RwLock::new(carried_index),
         implements_index_stale: AtomicBool::new(true),
         implements_build_lock: Mutex::new(()),
         implements_memo: old.implements_memo.clone(),
         changed_cache: old.changed_cache.clone(),
+        changed_refresh_in_flight: old.changed_refresh_in_flight.clone(),
+        sidecar_cache: RwLock::new(BoundedCache::default()),
+        scenario_list_cache: RwLock::new(BoundedCache::default()),
+        sidecar_write_gen: AtomicU64::new(0),
     })
 }
 
@@ -1620,6 +1892,12 @@ mod tests {
         async fn list_files(&self, _: &Path, _: Option<&str>) -> CorpusResult<Vec<FileEntry>> {
             Ok(Vec::new())
         }
+        async fn changed_files(&self) -> CorpusResult<Vec<String>> {
+            if self.fail_reads {
+                return Err(CorpusError::Git("simulated throttle".to_string()));
+            }
+            Ok(Vec::new())
+        }
         async fn persist(&self, _: &CorpusWriteContext) -> CorpusResult<PersistOutcome> {
             Ok(PersistOutcome::default())
         }
@@ -1654,12 +1932,16 @@ mod tests {
             write_target_for_source: HashMap::new(),
             writable_own_source_id: "own".to_string(),
             overlay: Arc::new(RwLock::new(HashMap::new())),
-            body_cache: RwLock::new(BoundedBodyCache::default()),
+            body_cache: RwLock::new(BoundedCache::default()),
             implements_index: RwLock::new(None),
             implements_index_stale: AtomicBool::new(false),
             implements_build_lock: Mutex::new(()),
             implements_memo: Arc::new(RwLock::new(HashMap::new())),
             changed_cache: Arc::new(RwLock::new(None)),
+            changed_refresh_in_flight: Arc::new(AtomicBool::new(false)),
+            sidecar_cache: RwLock::new(BoundedCache::default()),
+            scenario_list_cache: RwLock::new(BoundedCache::default()),
+            sidecar_write_gen: AtomicU64::new(0),
         }
     }
 
@@ -1696,11 +1978,11 @@ mod tests {
         }
     }
 
-    // ---- BoundedBodyCache ----
+    // ---- BoundedCache ----
 
     #[test]
     fn body_cache_evicts_oldest_at_cap() {
-        let mut cache = BoundedBodyCache::default();
+        let mut cache = BoundedCache::default();
         for i in 0..BODY_CACHE_MAX_ENTRIES + 10 {
             cache.insert(format!("law_{i}"), "body".to_string());
         }
@@ -1716,7 +1998,7 @@ mod tests {
 
     #[test]
     fn body_cache_overwrite_does_not_grow_or_evict() {
-        let mut cache = BoundedBodyCache::default();
+        let mut cache = BoundedCache::default();
         cache.insert("a".to_string(), "v1".to_string());
         cache.insert("b".to_string(), "v1".to_string());
         cache.insert("a".to_string(), "v2".to_string());
@@ -1727,7 +2009,7 @@ mod tests {
 
     #[test]
     fn body_cache_overwrite_at_cap_does_not_evict() {
-        let mut cache = BoundedBodyCache::default();
+        let mut cache = BoundedCache::default();
         // Fill exactly to capacity.
         for i in 0..BODY_CACHE_MAX_ENTRIES {
             cache.insert(format!("law_{i}"), "v1".to_string());
@@ -1989,12 +2271,16 @@ mod tests {
             write_target_for_source: HashMap::new(),
             writable_own_source_id: "own".to_string(),
             overlay: Arc::new(RwLock::new(HashMap::new())),
-            body_cache: RwLock::new(BoundedBodyCache::default()),
+            body_cache: RwLock::new(BoundedCache::default()),
             implements_index: RwLock::new(None),
             implements_index_stale: AtomicBool::new(false),
             implements_build_lock: Mutex::new(()),
             implements_memo: Arc::new(RwLock::new(HashMap::new())),
             changed_cache: Arc::new(RwLock::new(None)),
+            changed_refresh_in_flight: Arc::new(AtomicBool::new(false)),
+            sidecar_cache: RwLock::new(BoundedCache::default()),
+            scenario_list_cache: RwLock::new(BoundedCache::default()),
+            sidecar_write_gen: AtomicU64::new(0),
         })
     }
 
@@ -2257,6 +2543,358 @@ mod tests {
             refreshed.law_yaml("wet_a").await.unwrap().as_deref(),
             Some("$id: wet_a\nname: saved\n")
         );
+    }
+
+    /// Poll `probe` until it returns `Some` or ~2s elapse — the background
+    /// tasks under test swap state asynchronously, so assertions await
+    /// convergence instead of racing the spawn.
+    async fn wait_for<T, F, Fut>(mut probe: F) -> T
+    where
+        F: FnMut() -> Fut,
+        Fut: std::future::Future<Output = Option<T>>,
+    {
+        for _ in 0..200 {
+            if let Some(v) = probe().await {
+                return v;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        panic!("background task did not converge within 2s");
+    }
+
+    #[tokio::test]
+    async fn background_refresh_swaps_in_a_fresh_snapshot() {
+        let dir = tempfile::tempdir().unwrap();
+        write_law_file(dir.path(), "wet_a", "$id: wet_a\nname: v1\n");
+        let old = local_corpus(dir.path()).await;
+
+        let slot = Arc::new(TrajectSlot::default());
+        *slot.state.write().await = Some(CachedCorpus {
+            corpus: old.clone(),
+            // Expired: eligible for refresh.
+            built_at: Instant::now() - Duration::from_secs(3600),
+        });
+
+        // Upstream gains a law the stale snapshot misses.
+        write_law_file(dir.path(), "wet_b", "$id: wet_b\nname: nieuw\n");
+
+        let guard = slot.build_lock.clone().try_lock_owned().unwrap();
+        spawn_background_refresh(
+            guard,
+            slot.clone(),
+            old.clone(),
+            Uuid::new_v4(),
+            Duration::from_secs(60),
+        );
+
+        let refreshed = wait_for(|| {
+            let slot = slot.clone();
+            let old = old.clone();
+            async move {
+                let state = slot.state.read().await;
+                let cached = state.as_ref().unwrap();
+                (!Arc::ptr_eq(&cached.corpus, &old)).then(|| cached.corpus.clone())
+            }
+        })
+        .await;
+
+        assert!(refreshed.corpus.source_map.get_law("wet_b").is_some());
+        // The build lock is free again: the next expiry can refresh.
+        assert!(slot.build_lock.clone().try_lock_owned().is_ok());
+    }
+
+    #[tokio::test]
+    async fn failed_refresh_outcome_rearms_the_stale_snapshot() {
+        let dir = tempfile::tempdir().unwrap();
+        write_law_file(dir.path(), "wet_a", "$id: wet_a\nname: v1\n");
+        let old = local_corpus(dir.path()).await;
+
+        let slot = TrajectSlot::default();
+        let expired = Instant::now() - Duration::from_secs(3600);
+        *slot.state.write().await = Some(CachedCorpus {
+            corpus: old.clone(),
+            built_at: expired,
+        });
+
+        apply_refresh_outcome(
+            &slot,
+            old.clone(),
+            Uuid::new_v4(),
+            Err(TrajectCorpusError::Corpus(
+                regelrecht_corpus::error::CorpusError::Config("enumeration failed".to_string()),
+            )),
+        )
+        .await;
+
+        // The stale snapshot is re-armed (fresh `built_at`), not replaced
+        // and not dropped: reads keep working against the last good state,
+        // and the fresh TTL window stops every subsequent request from
+        // re-attempting against a broken upstream.
+        let state = slot.state.read().await;
+        let cached = state.as_ref().unwrap();
+        assert!(Arc::ptr_eq(&cached.corpus, &old));
+        assert!(cached.built_at > expired);
+        assert_eq!(slot.refresh_failures.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn expired_changed_cache_serves_stale_and_recomputes_in_background() {
+        let mut map = SourceMap::new();
+        metadata_entry(&mut map, "wet_a", "own");
+        let corpus = Arc::new(test_corpus(
+            map,
+            HashMap::from([(
+                "own".to_string(),
+                backend_entry(StubBackend::with_files(&[])),
+            )]),
+        ));
+
+        // An expired cache entry with a value the real diff (empty — the
+        // stub's `changed_files` default) no longer contains.
+        *corpus.changed_cache.write().await = Some(ChangedLawsCache {
+            computed_at: Instant::now() - Duration::from_secs(3600),
+            law_ids: vec!["wet_a".to_string()],
+        });
+
+        // Served immediately, stale value and all — no Compare round-trip
+        // on the request path.
+        let ids = corpus.changed_law_ids().await.unwrap();
+        assert_eq!(ids, vec!["wet_a".to_string()]);
+
+        // …while the background recompute converges to the real diff and
+        // releases the single-flight flag (checked inside the same poll:
+        // the flag reset runs after the cache write, so asserting it
+        // outside the wait would race a multi-threaded runtime).
+        wait_for(|| {
+            let corpus = corpus.clone();
+            async move {
+                let cache = corpus.changed_cache.read().await;
+                let cached = cache.as_ref().unwrap();
+                (cached.law_ids.is_empty()
+                    && !corpus.changed_refresh_in_flight.load(Ordering::SeqCst))
+                .then_some(())
+            }
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn failed_changed_recompute_rearms_stale_and_releases_the_flag() {
+        let mut map = SourceMap::new();
+        metadata_entry(&mut map, "wet_a", "own");
+        let corpus = Arc::new(test_corpus(
+            map,
+            HashMap::from([("own".to_string(), backend_entry(StubBackend::failing()))]),
+        ));
+
+        let expired = Instant::now() - Duration::from_secs(3600);
+        *corpus.changed_cache.write().await = Some(ChangedLawsCache {
+            computed_at: expired,
+            law_ids: vec!["wet_a".to_string()],
+        });
+
+        // Stale value serves; the background recompute fails against the
+        // throttled backend.
+        let ids = corpus.changed_law_ids().await.unwrap();
+        assert_eq!(ids, vec!["wet_a".to_string()]);
+
+        // Failure stance: the stale ids survive, the TTL clock is
+        // re-armed (no per-request re-attempts against a broken
+        // upstream), and the single-flight flag is released so a later
+        // expiry can retry.
+        wait_for(|| {
+            let corpus = corpus.clone();
+            async move {
+                let cache = corpus.changed_cache.read().await;
+                let cached = cache.as_ref().unwrap();
+                (cached.computed_at > expired
+                    && cached.law_ids == vec!["wet_a".to_string()]
+                    && !corpus.changed_refresh_in_flight.load(Ordering::SeqCst))
+                .then_some(())
+            }
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn record_changed_law_folds_a_save_into_the_cached_diff() {
+        let mut map = SourceMap::new();
+        metadata_entry(&mut map, "wet_a", "own");
+        let corpus = Arc::new(test_corpus(
+            map,
+            HashMap::from([(
+                "own".to_string(),
+                backend_entry(StubBackend::with_files(&[])),
+            )]),
+        ));
+
+        // No cache entry yet: recording is a no-op (the next request
+        // computes the real diff, which already includes the save).
+        corpus.record_changed_law("wet_a").await;
+        assert!(corpus.changed_cache.read().await.is_none());
+
+        // With a cached diff the saved law is appended once, sorted, and
+        // the TTL clock is untouched.
+        let computed_at = Instant::now() - Duration::from_secs(30);
+        *corpus.changed_cache.write().await = Some(ChangedLawsCache {
+            computed_at,
+            law_ids: vec!["wet_b".to_string()],
+        });
+        corpus.record_changed_law("wet_a").await;
+        corpus.record_changed_law("wet_a").await;
+        let cache = corpus.changed_cache.read().await;
+        let cached = cache.as_ref().unwrap();
+        assert_eq!(
+            cached.law_ids,
+            vec!["wet_a".to_string(), "wet_b".to_string()]
+        );
+        assert_eq!(cached.computed_at, computed_at);
+    }
+
+    #[tokio::test]
+    async fn sidecar_cache_round_trips_and_resets_per_snapshot() {
+        let mut map = SourceMap::new();
+        metadata_entry(&mut map, "wet_a", "own");
+        let corpus = Arc::new(test_corpus(
+            map,
+            HashMap::from([(
+                "own".to_string(),
+                backend_entry(StubBackend::with_files(&[])),
+            )]),
+        ));
+
+        // Miss, then positive and *negative* results both cache.
+        assert!(corpus.cached_sidecar("ann:wet_a").await.is_none());
+        corpus
+            .store_sidecar("ann:wet_a".to_string(), Some("notes: []\n".to_string()))
+            .await;
+        corpus
+            .store_sidecar("scn:wet_a/x.feature".to_string(), None)
+            .await;
+        assert_eq!(
+            corpus.cached_sidecar("ann:wet_a").await,
+            Some(Some("notes: []\n".to_string()))
+        );
+        assert_eq!(
+            corpus.cached_sidecar("scn:wet_a/x.feature").await,
+            Some(None)
+        );
+
+        // Invalidation drops a single key.
+        corpus.invalidate_sidecar("ann:wet_a").await;
+        assert!(corpus.cached_sidecar("ann:wet_a").await.is_none());
+
+        // Scenario listings follow the same shape.
+        corpus
+            .store_scenario_list_read(
+                "wet_a".to_string(),
+                vec![ScenarioListEntry {
+                    filename: "x.feature".to_string(),
+                    target_law_ids: vec!["wet_a".to_string()],
+                }],
+                corpus.sidecar_write_generation(),
+            )
+            .await;
+        assert_eq!(
+            corpus
+                .cached_scenario_list("wet_a")
+                .await
+                .unwrap()
+                .first()
+                .unwrap()
+                .filename,
+            "x.feature"
+        );
+        corpus.invalidate_scenario_list("wet_a").await;
+        assert!(corpus.cached_scenario_list("wet_a").await.is_none());
+
+        // A snapshot swap starts with empty sidecar caches: upstream
+        // sidecar edits become visible within one TTL window, like law
+        // bodies.
+        corpus
+            .store_sidecar("scn:wet_a/y.feature".to_string(), None)
+            .await;
+        let mut next_map = SourceMap::new();
+        metadata_entry(&mut next_map, "wet_a", "own");
+        let next = next_snapshot(&corpus, next_map).await;
+        assert!(next.cached_sidecar("scn:wet_a/y.feature").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn stale_read_store_is_dropped_after_a_write_bumps_the_generation() {
+        let mut map = SourceMap::new();
+        metadata_entry(&mut map, "wet_a", "own");
+        let corpus = Arc::new(test_corpus(
+            map,
+            HashMap::from([(
+                "own".to_string(),
+                backend_entry(StubBackend::with_files(&[])),
+            )]),
+        ));
+
+        // A GET-path read starts (generation captured), then a save lands
+        // before the read completes: the read's store must be dropped so
+        // the pre-save bytes cannot mask the save (they'd otherwise serve
+        // — with a pre-save ETag — until the snapshot swap).
+        let gen_before = corpus.sidecar_write_generation();
+        corpus
+            .store_sidecar("scn:wet_a/x.feature".to_string(), Some("saved".to_string()))
+            .await;
+        corpus
+            .store_sidecar_read(
+                "scn:wet_a/x.feature".to_string(),
+                Some("pre-save".to_string()),
+                gen_before,
+            )
+            .await;
+        assert_eq!(
+            corpus.cached_sidecar("scn:wet_a/x.feature").await,
+            Some(Some("saved".to_string()))
+        );
+
+        // Same guard for the listing cache, against delete-invalidation:
+        // a listing computed before the delete must not resurrect.
+        let gen_before = corpus.sidecar_write_generation();
+        corpus.invalidate_scenario_list("wet_a").await;
+        corpus
+            .store_scenario_list_read(
+                "wet_a".to_string(),
+                vec![ScenarioListEntry {
+                    filename: "deleted.feature".to_string(),
+                    target_law_ids: vec![],
+                }],
+                gen_before,
+            )
+            .await;
+        assert!(corpus.cached_scenario_list("wet_a").await.is_none());
+
+        // An undisturbed read (no write in between) stores normally.
+        let gen_before = corpus.sidecar_write_generation();
+        corpus
+            .store_sidecar_read("ann:wet_a".to_string(), None, gen_before)
+            .await;
+        assert_eq!(corpus.cached_sidecar("ann:wet_a").await, Some(None));
+    }
+
+    #[test]
+    fn bounded_cache_remove_purges_the_order_entry() {
+        let mut cache: BoundedCache<String> = BoundedCache::default();
+        cache.insert("victim".to_string(), "v1".to_string());
+        cache.remove("victim");
+        cache.insert("victim".to_string(), "v2".to_string());
+        // Fill to capacity; evictions must pop genuinely-oldest keys, not
+        // a stale order duplicate of the re-inserted key (which would
+        // evict the live value while its newer order entry survives).
+        for i in 0..(BODY_CACHE_MAX_ENTRIES - 1) {
+            cache.insert(format!("filler-{i}"), "x".to_string());
+        }
+        assert_eq!(cache.get("victim"), Some(&"v2".to_string()));
+        // One past capacity: the oldest key ("victim", re-inserted first)
+        // is evicted exactly once — no double-eviction from a stale
+        // duplicate.
+        cache.insert("overflow".to_string(), "x".to_string());
+        assert!(cache.get("victim").is_none());
+        assert_eq!(cache.get("filler-0"), Some(&"x".to_string()));
     }
 }
 

--- a/packages/editor-api/src/traject_corpus.rs
+++ b/packages/editor-api/src/traject_corpus.rs
@@ -622,14 +622,51 @@ impl TrajectCorpus {
         }
     }
 
-    /// Drop the cached scenario listing for `law_id` after a scenario
-    /// save/delete, so the next listing reflects the mutation. Bumps the
-    /// write generation so an in-flight listing computation discards its
-    /// result.
-    pub async fn invalidate_scenario_list(&self, law_id: &str) {
+    /// Fold a just-saved scenario into the cached listing for `law_id`
+    /// (upsert, keeping the filename sort) instead of invalidating it.
+    /// Surgical on purpose: a full rebuild right after the commit would
+    /// re-list GitHub's Contents API, whose directory view is eventually
+    /// consistent — the rebuild can capture the pre-save view and cache
+    /// it for the rest of the snapshot window. No cached listing → no-op
+    /// (the next listing rebuilds and the file is on the branch). Bumps
+    /// the write generation so an in-flight rebuild discards its
+    /// (possibly pre-save) result.
+    pub async fn record_scenario_saved(
+        &self,
+        law_id: &str,
+        filename: &str,
+        target_law_ids: Vec<String>,
+    ) {
         let mut cache = self.scenario_list_cache.write().await;
         self.sidecar_write_gen.fetch_add(1, Ordering::SeqCst);
-        cache.remove(law_id);
+        if let Some(mut entries) = cache.get(law_id).cloned() {
+            match entries.iter_mut().find(|e| e.filename == filename) {
+                Some(entry) => entry.target_law_ids = target_law_ids,
+                None => {
+                    entries.push(ScenarioListEntry {
+                        filename: filename.to_string(),
+                        target_law_ids,
+                    });
+                    entries.sort_by(|a, b| a.filename.cmp(&b.filename));
+                }
+            }
+            cache.insert(law_id.to_string(), entries);
+        }
+    }
+
+    /// Remove a just-deleted scenario from the cached listing for
+    /// `law_id`. Surgical for the same eventual-consistency reason as
+    /// [`Self::record_scenario_saved`]: a rebuild racing GitHub's lagging
+    /// directory view would resurrect the deleted file in the cache for
+    /// up to a snapshot window. Bumps the write generation so an
+    /// in-flight rebuild discards its result.
+    pub async fn record_scenario_deleted(&self, law_id: &str, filename: &str) {
+        let mut cache = self.scenario_list_cache.write().await;
+        self.sidecar_write_gen.fetch_add(1, Ordering::SeqCst);
+        if let Some(mut entries) = cache.get(law_id).cloned() {
+            entries.retain(|e| e.filename != filename);
+            cache.insert(law_id.to_string(), entries);
+        }
     }
 
     /// Law ids whose articles declare `implements` for `law_id` (the IoC
@@ -2805,8 +2842,40 @@ mod tests {
                 .filename,
             "x.feature"
         );
-        corpus.invalidate_scenario_list("wet_a").await;
-        assert!(corpus.cached_scenario_list("wet_a").await.is_none());
+
+        // Saves upsert the cached listing in place (sorted), deletes
+        // remove the one entry — never a drop-and-rebuild, which would
+        // race GitHub's eventually-consistent directory view.
+        corpus
+            .record_scenario_saved("wet_a", "a.feature", vec!["wet_a".to_string()])
+            .await;
+        corpus
+            .record_scenario_saved("wet_a", "x.feature", vec!["wet_b".to_string()])
+            .await;
+        let listing = corpus.cached_scenario_list("wet_a").await.unwrap();
+        assert_eq!(
+            listing
+                .iter()
+                .map(|e| e.filename.as_str())
+                .collect::<Vec<_>>(),
+            vec!["a.feature", "x.feature"]
+        );
+        assert_eq!(listing[1].target_law_ids, vec!["wet_b".to_string()]);
+        corpus.record_scenario_deleted("wet_a", "x.feature").await;
+        let listing = corpus.cached_scenario_list("wet_a").await.unwrap();
+        assert_eq!(
+            listing
+                .iter()
+                .map(|e| e.filename.as_str())
+                .collect::<Vec<_>>(),
+            vec!["a.feature"]
+        );
+        // Without a cached listing both records are no-ops: nothing to
+        // update, the next listing rebuilds from the branch.
+        corpus
+            .record_scenario_saved("wet_other", "y.feature", vec![])
+            .await;
+        assert!(corpus.cached_scenario_list("wet_other").await.is_none());
 
         // A snapshot swap starts with empty sidecar caches: upstream
         // sidecar edits become visible within one TTL window, like law
@@ -2852,10 +2921,23 @@ mod tests {
             Some(Some("saved".to_string()))
         );
 
-        // Same guard for the listing cache, against delete-invalidation:
-        // a listing computed before the delete must not resurrect.
+        // Same guard for the listing cache: a listing computed before a
+        // delete's in-place update must not overwrite it (the deleted
+        // file would resurrect).
+        corpus
+            .store_scenario_list_read(
+                "wet_a".to_string(),
+                vec![ScenarioListEntry {
+                    filename: "deleted.feature".to_string(),
+                    target_law_ids: vec![],
+                }],
+                corpus.sidecar_write_generation(),
+            )
+            .await;
         let gen_before = corpus.sidecar_write_generation();
-        corpus.invalidate_scenario_list("wet_a").await;
+        corpus
+            .record_scenario_deleted("wet_a", "deleted.feature")
+            .await;
         corpus
             .store_scenario_list_read(
                 "wet_a".to_string(),
@@ -2866,7 +2948,11 @@ mod tests {
                 gen_before,
             )
             .await;
-        assert!(corpus.cached_scenario_list("wet_a").await.is_none());
+        assert!(corpus
+            .cached_scenario_list("wet_a")
+            .await
+            .unwrap()
+            .is_empty());
 
         // An undisturbed read (no write in between) stores normally.
         let gen_before = corpus.sidecar_write_generation();


### PR DESCRIPTION
## What & why

Follow-up to the latency instrumentation in #919. Live `Server-Timing` measurements on the pr919 preview showed where the editor's GitHub-backed read path actually spends its time:

| pain point | measured |
|---|---|
| synchronous 60s-TTL index refresh | **1.7–1.9s**, paid by one unlucky request per minute per traject |
| synchronous changed-laws Compare on TTL expiry | 0.6–1.0s |
| annotations GET (uncached, incl. 404) | 250ms–**5.7s** per law open |
| scenario listing + per-file reads (uncached, serial) | 0.6s–**7.0s** per law open |

GitHub Contents API calls have a heavy latency tail (baseline ~250–600ms, spikes of 3–7s), so the fix is to keep them off the request path entirely.

## How

**Stale-while-revalidate for the index snapshot** — `get_or_build` no longer awaits the re-enumeration on TTL expiry: the first request past the deadline spawns a background refresh task (single-flighted by an `OwnedMutexGuard` on the slot's build lock) and serves the stale snapshot, like every concurrent request already did. A failed refresh re-arms the stale snapshot for another TTL window (unchanged degrade-to-stale stance, now unit-tested via the extracted `apply_refresh_outcome`). Only the very first build of a traject still blocks — there is nothing to serve yet.

**Same pattern for changed-laws** — `changed_law_ids` serves the cached diff immediately and recomputes in the background (AtomicBool single-flight with an RAII `ResetOnDrop` guard so a panicking task can't latch the flag). `save_law` now folds the saved law id into the cached diff (`record_changed_law`) instead of invalidating it, so the sidebar's next load no longer pays a synchronous Compare after every save.

**Per-snapshot caches for sidecar reads** — `TrajectCorpus` gains two bounded FIFO caches, per index snapshot (so upstream edits converge within one TTL window, exactly like law bodies):
- `sidecar_cache`: annotations sidecars and individual scenario files, **including negative (404) results** — "this law has no annotations" was a full GitHub round-trip per law open;
- `scenario_list_cache`: the per-law scenario listing (2× `list_files` + a read per file to rebuild).

Coherence: saves store the just-written body (read-your-writes), deletes drop the entry (the next read may legitimately fall back to a seed copy). A **write-generation counter** guards against the read/write race where a slow in-flight GET would re-cache pre-save bytes over a fresh save (which would 412-loop the saver's next If-Match until the snapshot swap): GET-path stores capture the generation before their backend read and are dropped if a write bumped it meanwhile. Write-path `If-Match` precondition reads deliberately bypass all caches.

**`gh_list` Server-Timing phase** for `list_files` — the listing round-trips were the uninstrumented gap between `gh_get` and `total` in the #919 measurements.

## Expected effect (to verify on the preview)

- Law open (warm traject): annotations + scenarios drop from ~3–8 serial GitHub round-trips to 0 within a snapshot window.
- The periodic ~1.8s stall on a random request per minute disappears.
- `changed-laws` after a save no longer costs a synchronous Compare.

## Verification

- `cargo test -p regelrecht-editor-api --lib`: **72 passed** (10 new tests: background-refresh swap, failure re-arm, changed-laws SWR + failure re-arm + fold semantics, generation guard, cache reset per snapshot, bounded-cache eviction hygiene) ✓
- `cargo clippy --all-features` with `-Dwarnings` (editor-api + corpus): clean ✓
- `cargo fmt --check` ✓
- An adversarial code review ran before push; the one major finding (the read/write cache race above) is fixed with the generation guard, plus three minor findings (RAII flag reset, bounded-cache remove/re-insert eviction edge, fold-undo race documented as bounded).
- Live before/after measurement on the preview deployment follows (same probe set as the #919 baseline).

## Known limitations

- GitHub answers 404 for a private repo when a token is invalid/expired, so during a token hiccup existing sidecars can be negative-cached for up to one snapshot window (≤ ~60s) per key. Accepted: same conflation existed uncached, and errors (403/5xx) are never cached.
- A changed-laws recompute whose Compare call was in flight during a save can briefly drop that save from the "Bewerkt in dit traject" list; self-heals within one TTL (documented in code).