### PR TITLE
style: replace em dashes with hyphens in frontend texts

### DIFF
--- a/frontend-lawmaking/src/App.vue
+++ b/frontend-lawmaking/src/App.vue
@@ -14,7 +14,7 @@
           <nldd-toolbar-title
             slot="start"
             text="Wetgevingsproces"
-            supporting-text="Van wetsvoorstel tot geldend recht — het wetgevingsproces als GitFlow"
+            supporting-text="Van wetsvoorstel tot geldend recht - het wetgevingsproces als GitFlow"
           ></nldd-toolbar-title>
 
           <!-- Playback: step navigation -->
@@ -95,7 +95,7 @@
       </nldd-container>
 
       <!-- Main content: the hand-rolled SVG GitFlow canvas (documented design-
-           system exception — no nldd equivalent for a graph canvas). -->
+           system exception - no nldd equivalent for a graph canvas). -->
       <nldd-full-bleed-section>
         <div class="diagram-area" @click="selectedStageId = null">
           <FlowDiagram

--- a/frontend-lawmaking/src/components/StageDetail.vue
+++ b/frontend-lawmaking/src/components/StageDetail.vue
@@ -75,7 +75,7 @@ watch(
     // Render the v-if="shownStage" content before opening so the sheet never
     // animates in empty. `{ flush: 'post' }` wouldn't suffice here: this watcher
     // itself sets `shownStage`, so the content render is still pending when the
-    // callback runs — awaiting nextTick flushes it first.
+    // callback runs - awaiting nextTick flushes it first.
     await nextTick();
     sheetEl.value?.show();
   },

--- a/frontend-lawmaking/src/data/flowConstants.js
+++ b/frontend-lawmaking/src/data/flowConstants.js
@@ -1,4 +1,4 @@
-/** Branch/fork colors — drives node fill color */
+/** Branch/fork colors - drives node fill color */
 export const branchColors = {
   main: 'var(--color-branch-main)',
   develop: 'var(--color-branch-develop)',
@@ -18,7 +18,7 @@ export const typeColors = {
   release: 'var(--color-release)',
 };
 
-/** Legend entries — one per branch type */
+/** Legend entries - one per branch type */
 export const legend = [
   { label: 'Corpus Juris (main)', color: 'var(--color-branch-main)' },
   { label: 'Wetgevingskalender (develop)', color: 'var(--color-branch-develop)' },

--- a/frontend-lawmaking/src/data/flowDataAdvanced.js
+++ b/frontend-lawmaking/src/data/flowDataAdvanced.js
@@ -2,9 +2,9 @@
  * Advanced flow data: the full Dutch legislative process.
  *
  * Branch model (GitFlow):
- *   col 0: main (Corpus Juris — geldend recht)
- *   col 1: develop (Wetgevingskalender — voorstellen in procedure)
- *   col 2: ministry fork (wetsvoorstel — eigen omgeving ministerie)
+ *   col 0: main (Corpus Juris - geldend recht)
+ *   col 1: develop (Wetgevingskalender - voorstellen in procedure)
+ *   col 2: ministry fork (wetsvoorstel - eigen omgeving ministerie)
  *   col 3: internal sub-branch (beleid + juridisch team)
  *   col 4-8: parallel advisory/check forks (toetsen, consultatie)
  *   col 3-7: amendment branches (elk amendement eigen branch)
@@ -455,7 +455,7 @@ export const stages = [
     col: 1, step: 22,
   },
 
-  // === Koninklijke Boodschap — indiening bij TK ===
+  // === Koninklijke Boodschap - indiening bij TK ===
   {
     id: 'koninklijke-boodschap',
     branch: 'develop',
@@ -476,7 +476,7 @@ export const stages = [
     lawLabel: 'Initiatiefwetsvoorstel',
     subtitle: 'Voorstel vanuit de Kamer',
     description:
-      'Elk Tweede Kamerlid kan zelf een wetsvoorstel indienen — zonder regering. ' +
+      'Elk Tweede Kamerlid kan zelf een wetsvoorstel indienen - zonder regering. ' +
       'Vergelijkbaar met een external contributor die een PR opent.',
     col: 3, step: 23,
   },
@@ -560,9 +560,9 @@ export const stages = [
     type: 'commit',
     gitLabel: 'patch (Van der Berg)',
     lawLabel: 'Amendement A',
-    subtitle: 'Art. 3 lid 2 wijzigen — aangenomen',
+    subtitle: 'Art. 3 lid 2 wijzigen - aangenomen',
     description:
-      'Elk Kamerlid kan amendementen indienen — reviewer-submitted patches. ' +
+      'Elk Kamerlid kan amendementen indienen - reviewer-submitted patches. ' +
       'Dit amendement wijzigt artikel 3 lid 2.',
     col: 3, step: 31,
   },
@@ -570,23 +570,23 @@ export const stages = [
     id: 'amendement-b',
     branch: 'amend-b-branch',
     type: 'commit',
-    gitLabel: 'patch (Jansen) — overgenomen',
+    gitLabel: 'patch (Jansen) - overgenomen',
     lawLabel: 'Amendement B',
-    subtitle: 'Nieuw art. 5a — cherry-picked',
+    subtitle: 'Nieuw art. 5a - cherry-picked',
     description:
       'De minister neemt dit amendement over (cherry-pick). ' +
-      'Het wordt direct onderdeel van het voorstel — geen stemming nodig.',
+      'Het wordt direct onderdeel van het voorstel - geen stemming nodig.',
     col: 4, step: 31,
   },
   {
     id: 'amendement-c',
     branch: 'amend-c-branch',
     type: 'commit',
-    gitLabel: 'patch (De Vries) — conflicterend',
+    gitLabel: 'patch (De Vries) - conflicterend',
     lawLabel: 'Amendement C',
-    subtitle: 'Conflicteert met A — aangenomen',
+    subtitle: 'Conflicteert met A - aangenomen',
     description:
-      'Dit amendement wijzigt hetzelfde artikellid als A — een merge conflict. ' +
+      'Dit amendement wijzigt hetzelfde artikellid als A - een merge conflict. ' +
       'Bureau Wetgeving bepaalt de stemvolgorde: verste strekking eerst.',
     col: 5, step: 31,
   },
@@ -596,7 +596,7 @@ export const stages = [
     type: 'commit',
     gitLabel: 'patch/sub (op A)',
     lawLabel: 'Subamendement op A',
-    subtitle: 'Max 1 niveau diep — eerst gestemd',
+    subtitle: 'Max 1 niveau diep - eerst gestemd',
     description:
       'Een subamendement: wijziging op het amendement. Maximaal één niveau diep. ' +
       'Wordt altijd eerst in stemming gebracht.',
@@ -606,9 +606,9 @@ export const stages = [
     id: 'amendement-rejected',
     branch: 'rejected-branch',
     type: 'commit',
-    gitLabel: 'patch (Smit) — verworpen',
+    gitLabel: 'patch (Smit) - verworpen',
     lawLabel: 'Amendement verworpen',
-    subtitle: 'Dead end — geen merge',
+    subtitle: 'Dead end - geen merge',
     description: 'Dit amendement wordt verworpen bij stemming. De branch stopt hier.',
     col: 7, step: 31,
   },
@@ -630,7 +630,7 @@ export const stages = [
     id: 'stemmingen',
     branch: 'develop',
     type: 'merge',
-    gitLabel: 'merge queue — stemming',
+    gitLabel: 'merge queue - stemming',
     lawLabel: 'Stemmingen Tweede Kamer',
     subtitle: 'Per artikel, dan geheel',
     description:
@@ -671,7 +671,7 @@ export const stages = [
     gitLabel: 'approve / reject',
     lawLabel: 'Stemming Eerste Kamer',
     subtitle: 'Aannemen of verwerpen',
-    description: 'Aannemen of verwerpen — zonder wijziging. Protected branch: alleen approve/reject.',
+    description: 'Aannemen of verwerpen - zonder wijziging. Protected branch: alleen approve/reject.',
     col: 1, step: 36,
   },
 
@@ -730,7 +730,7 @@ export const stages = [
     lawLabel: 'Koninklijk Besluit',
     subtitle: 'Bekrachtiging door de Koning',
     description:
-      'De Koning is de enige maintainer van het Corpus Juris — alleen hij kan mergen ' +
+      'De Koning is de enige maintainer van het Corpus Juris - alleen hij kan mergen ' +
       'naar main, met de Minister als co-author op elke commit.',
     tags: [
       { label: 'Staatsblad', color: 'var(--color-branch-advisory)' },

--- a/frontend-lawmaking/src/data/flowDataSimple.js
+++ b/frontend-lawmaking/src/data/flowDataSimple.js
@@ -2,11 +2,11 @@
  * Simple view: Dutch law-making process as GitFlow.
  *
  * Branch model:
- *   col 0 — main (Corpus Juris, geldend recht)
- *   col 1 — develop (Wetgevingskalender, voorstellen in procedure)
- *   col 2 — fork: wetsvoorstel (ministry / fraction workspace)
- *   col 3 — topic branch within the wetsvoorstel fork
- *   col 4 — fork: advisory (Raad van State / toetsende organen)
+ *   col 0 - main (Corpus Juris, geldend recht)
+ *   col 1 - develop (Wetgevingskalender, voorstellen in procedure)
+ *   col 2 - fork: wetsvoorstel (ministry / fraction workspace)
+ *   col 3 - topic branch within the wetsvoorstel fork
+ *   col 4 - fork: advisory (Raad van State / toetsende organen)
  */
 
 export const branches = [
@@ -67,7 +67,7 @@ export const stages = [
     lawLabel: 'Corpus Juris',
     subtitle: 'Geldend recht',
     description:
-      'Het geheel van alle geldende Nederlandse wetgeving — de "main branch". ' +
+      'Het geheel van alle geldende Nederlandse wetgeving - de "main branch". ' +
       'Wat hier staat, is geldend recht.',
     col: 0, step: 0,
   },
@@ -80,7 +80,7 @@ export const stages = [
     subtitle: 'Main gaat door',
     description:
       'Terwijl het wetsvoorstel in procedure is, gaan andere wetten gewoon door. ' +
-      'Main verandert voortdurend — daarom zijn rebases nodig.',
+      'Main verandert voortdurend - daarom zijn rebases nodig.',
     col: 0, step: 5,
   },
 
@@ -145,7 +145,7 @@ export const stages = [
     lawLabel: 'Eerste concept',
     subtitle: 'Juridische tekst',
     description:
-      'Het eerste concept van de wettekst. Er volgen nog vele iteraties — ' +
+      'Het eerste concept van de wettekst. Er volgen nog vele iteraties - ' +
       'net als bij code wordt er voortdurend herzien en verbeterd.',
     col: 3, step: 6,
   },
@@ -207,7 +207,7 @@ export const stages = [
     lawLabel: 'Memorie van Toelichting',
     subtitle: 'Uitleg bij het voorstel',
     description:
-      'De Memorie van Toelichting legt uit waarom de wet er zo uitziet — ' +
+      'De Memorie van Toelichting legt uit waarom de wet er zo uitziet - ' +
       'vergelijkbaar met design docs en ADRs bij de code.',
     col: 2, step: 11,
   },
@@ -220,7 +220,7 @@ export const stages = [
     subtitle: 'Andere ministeries reageren',
     description:
       'Het voorstel circuleert langs alle relevante ministeries. ' +
-      'Hun feedback wordt verwerkt — cross-team review.',
+      'Hun feedback wordt verwerkt - cross-team review.',
     col: 2, step: 12,
   },
   {
@@ -231,7 +231,7 @@ export const stages = [
     lawLabel: 'Internetconsultatie',
     subtitle: '4+ weken publiek commentaar',
     description:
-      'Het voorstel gaat op internetconsultatie.nl — een publieke RFC. ' +
+      'Het voorstel gaat op internetconsultatie.nl - een publieke RFC. ' +
       'Burgers, NGOs en bedrijven geven feedback.',
     col: 2, step: 13,
   },
@@ -345,7 +345,7 @@ export const stages = [
     lawLabel: 'Tweede Kamer',
     subtitle: 'Behandeling & stemming',
     description:
-      'De Tweede Kamer behandelt het voorstel — vergelijkbaar met een PR review. ' +
+      'De Tweede Kamer behandelt het voorstel - vergelijkbaar met een PR review. ' +
       'Kamerleden dienen amendementen in, debatteren, en stemmen.',
     col: 1, step: 22,
   },
@@ -357,7 +357,7 @@ export const stages = [
     lawLabel: 'Amendementen TK',
     subtitle: 'Wijzigingen door Kamer',
     description:
-      'Amendementen van Kamerleden worden verwerkt — vergelijkbaar met ' +
+      'Amendementen van Kamerleden worden verwerkt - vergelijkbaar met ' +
       'reviewer-submitted patches die gemerged worden in de branch.',
     col: 1, step: 23,
   },
@@ -383,7 +383,7 @@ export const stages = [
     lawLabel: 'Koninklijk Besluit',
     subtitle: 'Bekrachtiging door de Koning',
     description:
-      'De Koning is de enige maintainer van het Corpus Juris — alleen hij kan mergen ' +
+      'De Koning is de enige maintainer van het Corpus Juris - alleen hij kan mergen ' +
       'naar main, met de Minister als co-author op elke commit. ' +
       'Publicatie in het Staatsblad en inwerkingtreding volgen automatisch.',
     tags: [
@@ -401,7 +401,7 @@ export const stages = [
     subtitle: 'Bijgewerkt',
     description:
       'Het Corpus Juris is bijgewerkt met de nieuwe wet. ' +
-      'Main gaat door — klaar voor het volgende wetsvoorstel.',
+      'Main gaat door - klaar voor het volgende wetsvoorstel.',
     col: 0, step: 26,
   },
 ];

--- a/frontend-lawmaking/src/data/flowDataWoo.js
+++ b/frontend-lawmaking/src/data/flowDataWoo.js
@@ -1,12 +1,12 @@
 /**
- * Real law: Wet open overheid (Woo) — kamerstuk 33328 + novelle 35112
+ * Real law: Wet open overheid (Woo) - kamerstuk 33328 + novelle 35112
  *
  * 9+ year journey from initiatiefwet to inwerkingtreding.
  * Dates are real. Row spacing is semi-proportional to time.
  *
  * Layout:
  *   col 0: main (Corpus Juris / Wob)
- *   col 1: initiatiefwet branch (33328 — the proposal)
+ *   col 1: initiatiefwet branch (33328 - the proposal)
  *   col 2: parliament (TK/EK treatment)
  *   col 3: CI checks / reviews (RvS, impact analysis)
  *   col 4: amendments (33328)
@@ -136,7 +136,7 @@ export const stages = [
     type: 'commit',
     gitLabel: 'main (HEAD)',
     lawLabel: 'Wet openbaarheid van bestuur',
-    subtitle: 'Wob — geldend recht sinds 1991',
+    subtitle: 'Wob - geldend recht sinds 1991',
     date: '',
     description:
       'De Wob is het geldende transparantierecht. Burgers moeten zelf informatie opvragen (passief). ' +
@@ -194,7 +194,7 @@ export const stages = [
     date: '22 nov 2012',
     description:
       'Peters verlaat de Kamer. Linda Voortman (GL) neemt de verdediging over. ' +
-      'De eerste van zes overdrachten — alsof de maintainer van een open-source project vertrekt ' +
+      'De eerste van zes overdrachten - alsof de maintainer van een open-source project vertrekt ' +
       'en iemand anders het overneemt.',
     col: 1, step: 4,
   },
@@ -292,7 +292,7 @@ export const stages = [
     col: 1, step: 10,
   },
 
-  // === 2015: Quiet year — sponsorship transfers ===
+  // === 2015: Quiet year - sponsorship transfers ===
   {
     id: 'handovers-2015',
     branch: 'initiative',
@@ -341,7 +341,7 @@ export const stages = [
     type: 'commit',
     gitLabel: 'patch (Oosenbrug/Fokke)',
     lawLabel: 'Amd. 21: Klachtprocedure',
-    subtitle: 'PvdA — aangenomen',
+    subtitle: 'PvdA - aangenomen',
     date: '7 apr 2016',
     description:
       'Amendement Oosenbrug/Fokke (PvdA): herintroductie klachtprocedure bij niet-tijdig beslissen.',
@@ -353,7 +353,7 @@ export const stages = [
     type: 'commit',
     gitLabel: 'patch (Segers/Veldman)',
     lawLabel: 'Amd. 22: Wob-jurisprudentie',
-    subtitle: 'CU/VVD — aangenomen',
+    subtitle: 'CU/VVD - aangenomen',
     date: '12 apr 2016',
     description:
       'Amendement Segers/Veldman (CU/VVD): aansluiting bij bestaande Wob-jurisprudentie.',
@@ -365,7 +365,7 @@ export const stages = [
     type: 'commit',
     gitLabel: 'patch (Segers/Oosenbrug)',
     lawLabel: 'Amd. 28: Kamerlid-info',
-    subtitle: 'CU/PvdA — aangenomen',
+    subtitle: 'CU/PvdA - aangenomen',
     date: '13 apr 2016',
     description:
       'Amendement Segers/Oosenbrug: informatie aan individuele Kamerleden beschermd.',
@@ -377,7 +377,7 @@ export const stages = [
     type: 'commit',
     gitLabel: 'patch (Veldman/Bisschop)',
     lawLabel: 'Amd. 34: Commissaris uitstellen',
-    subtitle: 'VVD/SGP — aangenomen',
+    subtitle: 'VVD/SGP - aangenomen',
     date: '13 apr 2016',
     description:
       'Amendement Veldman/Bisschop: Informatiecommissaris pas na evaluatie. ' +
@@ -390,7 +390,7 @@ export const stages = [
     type: 'commit',
     gitLabel: 'patches REJECTED (×3)',
     lawLabel: '3 amendementen verworpen',
-    subtitle: 'VVD/SGP — scope + bedrijfsgegevens',
+    subtitle: 'VVD/SGP - scope + bedrijfsgegevens',
     date: '13 apr 2016',
     description:
       'Drie amendementen van Veldman/Bisschop (VVD/SGP) verworpen: reikwijdte beperken (23), ' +
@@ -435,7 +435,7 @@ export const stages = [
     date: '19 apr 2016',
     description:
       'AANGENOMEN. Voor: SP, PvdD, PvdA, GL, D66, 50PLUS, CU, PVV. ' +
-      'Tegen: VVD, CDA, SGP. De VVD stemt tegen — dit verandert later.',
+      'Tegen: VVD, CDA, SGP. De VVD stemt tegen - dit verandert later.',
     col: 2, step: 17,
   },
 
@@ -449,7 +449,7 @@ export const stages = [
     subtitle: 'Experts gehoord',
     date: '7 jun 2016',
     description:
-      'De Eerste Kamer houdt een deskundigenbijeenkomst. Een ongebruikelijke stap — ' +
+      'De Eerste Kamer houdt een deskundigenbijeenkomst. Een ongebruikelijke stap - ' +
       'de EK wil eerst experts horen voordat ze het voorstel inhoudelijk behandelt.',
     col: 2, step: 18,
   },
@@ -471,7 +471,7 @@ export const stages = [
     id: 'impact-1',
     branch: 'parliament',
     type: 'ci-check',
-    gitLabel: 'CI: FAIL — "unexecutable"',
+    gitLabel: 'CI: FAIL - "unexecutable"',
     lawLabel: 'Impactanalyse deel 1',
     subtitle: '"Onuitvoerbaar, zeer hoge kosten"',
     date: '15 dec 2016',
@@ -485,7 +485,7 @@ export const stages = [
     id: 'impact-2',
     branch: 'parliament',
     type: 'ci-check',
-    gitLabel: 'CI: FAIL — part 2',
+    gitLabel: 'CI: FAIL - part 2',
     lawLabel: 'Impactanalyse deel 2',
     subtitle: 'Gemeenten, provincies, waterschappen',
     date: '13 jun 2017',
@@ -511,7 +511,7 @@ export const stages = [
     id: 'negotiations',
     branch: 'parliament',
     type: 'review',
-    gitLabel: 'stalled — negotiating fix',
+    gitLabel: 'stalled - negotiating fix',
     lawLabel: 'Onderhandelingen novelle',
     subtitle: 'Initiatiefnemers en regering overleggen',
     date: '2017-2018',
@@ -586,7 +586,7 @@ export const stages = [
     description:
       'Zes amendementen aangenomen op de novelle, waaronder: ' +
       'Van der Molen (CDA): geanonimiseerde beleidsopvattingen openbaar (n.a.v. toeslagenaffaire). ' +
-      'Snoeren/Bisschop (VVD/SGP): bedrijfsgegevens als absolute weigeringsgrond — ' +
+      'Snoeren/Bisschop (VVD/SGP): bedrijfsgegevens als absolute weigeringsgrond - ' +
       'dezelfde inhoud als het in 2016 verworpen amendement 33328-33! Politieke verschuiving.',
     col: 4, step: 28,
   },
@@ -610,7 +610,7 @@ export const stages = [
     type: 'merge',
     gitLabel: 'fix-PR merged (130-20)',
     lawLabel: 'Stemming TK novelle',
-    subtitle: '130 voor, 20 tegen — VVD nu VOOR',
+    subtitle: '130 voor, 20 tegen - VVD nu VOOR',
     date: '26 jan 2021',
     description:
       'De novelle wordt aangenomen met overweldigende meerderheid. ' +
@@ -645,7 +645,7 @@ export const stages = [
     date: '28 sep 2021',
     description:
       'Plenair debat over beide voorstellen tegelijk. Drie moties ingediend, ' +
-      'één ingetrokken. De Eerste Kamer kan niet amenderen — alleen aannemen of verwerpen.',
+      'één ingetrokken. De Eerste Kamer kan niet amenderen - alleen aannemen of verwerpen.',
     col: 2, step: 31,
   },
   {
@@ -654,7 +654,7 @@ export const stages = [
     type: 'merge',
     gitLabel: 'both PRs approved',
     lawLabel: 'Stemming Eerste Kamer',
-    subtitle: 'BEIDE aangenomen — CDA/CU tegen',
+    subtitle: 'BEIDE aangenomen - CDA/CU tegen',
     date: '5 okt 2021',
     description:
       'Beide voorstellen aangenomen bij zitten en opstaan. ' +
@@ -675,10 +675,10 @@ export const stages = [
     description:
       'De Koning ondertekent beide wetten. De feature branch wordt gemerged naar main. ' +
       'Publicatie in Staatsblad (Stb. 2021, 499+500) op 27 okt 2021. ' +
-      'Inwerkingtreding per 1 mei 2022 — de Wob wordt ingetrokken.',
+      'Inwerkingtreding per 1 mei 2022 - de Wob wordt ingetrokken.',
     tags: [
       { label: 'Stb. 2021, 499+500', color: 'var(--color-branch-advisory)' },
-      { label: '1 mei 2022 — go live', color: 'var(--color-branch-main)' },
+      { label: '1 mei 2022 - go live', color: 'var(--color-branch-main)' },
     ],
     col: 0, step: 33,
   },
@@ -736,7 +736,7 @@ export const connections = [
   { from: 'amend-22', to: 'plenair-2', type: 'merge-in' },
   { from: 'amend-28', to: 'plenair-2', type: 'merge-in' },
   { from: 'amend-34', to: 'plenair-2', type: 'merge-in' },
-  // amend-rejected: dead end — no merge back (verworpen)
+  // amend-rejected: dead end - no merge back (verworpen)
   { from: 'nvw-4', to: 'plenair-2', type: 'straight' },
 
   { from: 'plenair-2', to: 'tk-vote', type: 'straight' },
@@ -760,7 +760,7 @@ export const connections = [
   { from: 'novelle-committee', to: 'novelle-amend-accepted', type: 'branch-off' },
   { from: 'novelle-committee', to: 'novelle-amend-rejected', type: 'branch-off' },
   { from: 'novelle-amend-accepted', to: 'novelle-tk-vote', type: 'merge-in' },
-  // novelle-amend-rejected: dead end — no merge back (verworpen)
+  // novelle-amend-rejected: dead end - no merge back (verworpen)
   { from: 'novelle-committee', to: 'novelle-tk-vote', type: 'straight' },
 
   // Both go to EK

--- a/frontend/css/main.css
+++ b/frontend/css/main.css
@@ -2,7 +2,7 @@
 /* Component styles are provided by @nldd/design-system (imported in JS entry points) */
 
 :root {
-  /* Rijksoverheid donkerblauw — used by accent UI in editor components.
+  /* Rijksoverheid donkerblauw - used by accent UI in editor components.
      Same value already tokenised in landing/, frontend-lawmaking/, and the
      docs site; kept here so `#154273` doesn't keep cropping up inline. */
   --color-primary: #154273;

--- a/frontend/e2e/complex-actions.spec.js
+++ b/frontend/e2e/complex-actions.spec.js
@@ -6,7 +6,7 @@ import { resolve } from 'path';
 
 /**
  * Create a fixture with article 2 having definitions, params, inputs, outputs
- * but no actions yet — so we can test building complex actions from scratch.
+ * but no actions yet - so we can test building complex actions from scratch.
  */
 function createFixtureWithMetadata() {
   const base = readFileSync(resolve(import.meta.dirname, 'fixtures/zorgtoeslag-stripped.yaml'), 'utf-8');
@@ -61,7 +61,7 @@ test.describe('Complex actions', () => {
     }, 'heeft_recht_op_zorgtoeslag');
     await page.waitForTimeout(100);
 
-    // New actions have value='' — no OperationSettings shown
+    // New actions have value='' - no OperationSettings shown
     // We need to close and use YAML editing to set up the initial operation structure
     await panel.locator('nldd-button:has-text("Opslaan")').click();
     await page.waitForTimeout(300);
@@ -171,7 +171,7 @@ test.describe('Complex actions', () => {
     await panel.locator('[data-testid="add-nested-op-btn"]').evaluate(el => el.click());
     await page.waitForTimeout(200);
 
-    // Save should be rejected because the nested ADD has no values yet —
+    // Save should be rejected because the nested ADD has no values yet -
     // saving a structurally-incomplete operation would produce YAML the
     // engine cannot execute.
     await panel.locator('nldd-button:has-text("Opslaan")').click();

--- a/frontend/e2e/edit-test-loop.spec.js
+++ b/frontend/e2e/edit-test-loop.spec.js
@@ -4,7 +4,7 @@
  * Verifies the demo flow the editor was built for:
  *   1. Open wet_op_de_zorgtoeslag in the editor.
  *   2. Observe the *Minderjarige heeft geen recht op zorgtoeslag* scenario is
- *      red (badge = ✗) — age check isn't in the law's machine_readable.
+ *      red (badge = ✗) - age check isn't in the law's machine_readable.
  *   3. Edit article 2's machine_readable via the middle-pane YAML editor to
  *      add a leeftijd input + an AGE-based condition to the existing AND.
  *   4. ScenarioBuilder auto-reexecutes against the edited YAML.
@@ -49,11 +49,11 @@ test.describe('Edit → re-execute loop', () => {
       scenarioText,
     );
 
-    // Navigate directly to article 2 via the route param — that's where
+    // Navigate directly to article 2 via the route param - that's where
     // heeft_recht_op_zorgtoeslag lives and where we need to edit.
     await page.goto('/editor/wet_op_de_zorgtoeslag/2');
 
-    // Wait for the document tab bar to render — articles loaded.
+    // Wait for the document tab bar to render - articles loaded.
     await page.waitForSelector('nldd-document-tab-bar-item', { timeout: 15_000 });
 
     const minorHeader = page
@@ -61,7 +61,7 @@ test.describe('Edit → re-execute loop', () => {
       .filter({ hasText: 'Minderjarige' });
     await expect(minorHeader).toBeVisible({ timeout: 30_000 });
 
-    // Wait until the badge appears (either ✓ or ✗) — meaning execution
+    // Wait until the badge appears (either ✓ or ✗) - meaning execution
     // completed. The badge span has class sb-badge--pass or sb-badge--fail.
     await minorHeader
       .locator('.sb-badge--pass, .sb-badge--fail')
@@ -97,7 +97,7 @@ test.describe('Edit → re-execute loop', () => {
     // BRP art 1.2 requires both bsn and peildatum; we use the scenario's
     // calculation date as a literal here.
     //
-    // NOTE: a literal date is intentional for test isolation — the spec must
+    // NOTE: a literal date is intentional for test isolation - the spec must
     // remain stable regardless of the real calculation date at CI time. The
     // canonical production pattern (see `kieswet`) references a parameter
     // like `peildatum: $verkiezingsdatum` so the date tracks the runtime

--- a/frontend/e2e/fixtures/zorgtoeslag-full.yaml
+++ b/frontend/e2e/fixtures/zorgtoeslag-full.yaml
@@ -90,7 +90,7 @@ articles:
           # Art. 2 lid 2: "wordt het gezamenlijk toetsingsinkomen van de verzekerde en
           # de toeslagpartner in aanmerking genomen."
           # TODO #377: Bij partners moet het gezamenlijke toetsingsinkomen worden gebruikt.
-          # Geblokkeerd: engine ondersteunt geen conditionele input-resolutie — ophalen
+          # Geblokkeerd: engine ondersteunt geen conditionele input-resolutie - ophalen
           # partner-toetsingsinkomen via AWIR art. 8 met partner_bsn faalt bij null BSN.
           - name: toetsingsinkomen
             type: amount

--- a/frontend/e2e/helpers-corpus.js
+++ b/frontend/e2e/helpers-corpus.js
@@ -90,7 +90,7 @@ export function loadScenario(lawPath, filename) {
  * @param {string} scenarioFile - raw .feature text returned by the scenario fetch
  */
 export async function mockCorpusApi(page, corpus, scenarioLaw, scenarioFile) {
-  // GET /api/corpus/laws — list for dependency discovery (fallback handler).
+  // GET /api/corpus/laws - list for dependency discovery (fallback handler).
   await page.route('**/api/corpus/laws*', (route, request) => {
     const url = new URL(request.url());
     if (url.pathname !== '/api/corpus/laws') {
@@ -113,7 +113,7 @@ export async function mockCorpusApi(page, corpus, scenarioLaw, scenarioFile) {
     });
   });
 
-  // GET /api/corpus/laws/{law_id}/outputs — list outputs from all articles.
+  // GET /api/corpus/laws/{law_id}/outputs - list outputs from all articles.
   await page.route('**/api/corpus/laws/*/outputs', (route, request) => {
     const url = new URL(request.url());
     const match = url.pathname.match(/\/api\/corpus\/laws\/([^/]+)\/outputs$/);
@@ -131,8 +131,8 @@ export async function mockCorpusApi(page, corpus, scenarioLaw, scenarioFile) {
     });
   });
 
-  // GET /api/corpus/laws/{law_id} — serve from the corpus map.
-  // PUT /api/corpus/laws/{law_id} — no-op; useLaw.saveLaw() updates rawYaml
+  // GET /api/corpus/laws/{law_id} - serve from the corpus map.
+  // PUT /api/corpus/laws/{law_id} - no-op; useLaw.saveLaw() updates rawYaml
   // locally on success so the test doesn't need a real backend write.
   await page.route('**/api/corpus/laws/*', (route, request) => {
     const url = new URL(request.url());
@@ -155,7 +155,7 @@ export async function mockCorpusApi(page, corpus, scenarioLaw, scenarioFile) {
     });
   });
 
-  // GET /api/corpus/laws/{law_id}/scenarios — list, only for the target law.
+  // GET /api/corpus/laws/{law_id}/scenarios - list, only for the target law.
   await page.route('**/api/corpus/laws/*/scenarios', (route, request) => {
     const url = new URL(request.url());
     const match = url.pathname.match(/\/api\/corpus\/laws\/([^/]+)\/scenarios$/);
@@ -175,7 +175,7 @@ export async function mockCorpusApi(page, corpus, scenarioLaw, scenarioFile) {
     });
   });
 
-  // GET /api/corpus/laws/{law_id}/scenarios/{filename} — return the
+  // GET /api/corpus/laws/{law_id}/scenarios/{filename} - return the
   // scenario text for any law that asks. We only have one fixture so we
   // serve it for every match; tests that need multiple scenario files can
   // refine this later.
@@ -190,7 +190,7 @@ export async function mockCorpusApi(page, corpus, scenarioLaw, scenarioFile) {
     });
   });
 
-  // /api/sources — corpus source list (used by library page).
+  // /api/sources - corpus source list (used by library page).
   await page.route('**/api/sources', (route) =>
     route.fulfill({
       status: 200,
@@ -201,7 +201,7 @@ export async function mockCorpusApi(page, corpus, scenarioLaw, scenarioFile) {
     }),
   );
 
-  // /auth/status — OIDC disabled in tests; useAuth expects this shape.
+  // /auth/status - OIDC disabled in tests; useAuth expects this shape.
   await page.route('**/auth/status', (route) =>
     route.fulfill({
       status: 200,

--- a/frontend/e2e/machine-panel-edit-loop.spec.js
+++ b/frontend/e2e/machine-panel-edit-loop.spec.js
@@ -34,7 +34,7 @@ async function waitForSheetOpen(page, hostSelector) {
 
 /**
  * Wait for an nldd-sheet to be closed (host present + shadow `<dialog>`'s
- * `open` no longer true). The host MUST be present — otherwise a typo in
+ * `open` no longer true). The host MUST be present - otherwise a typo in
  * the selector or a test ordering bug would let this helper resolve
  * immediately and silently mask the error. Pair every `waitForSheetClosed`
  * call with an opening event so the host has been mounted at least once.
@@ -115,7 +115,7 @@ test.describe('Edit → re-execute loop via Machine panel', () => {
     // light-DOM `input` element is reachable via the locator's `>> input`
     // descendant, but Vue listens to the host's `input` event. Set value
     // and dispatch the input event so Vue's @input handler updates the
-    // model — same trick the existing helpers.fillSheetTextField uses.
+    // model - same trick the existing helpers.fillSheetTextField uses.
     async function setSheetField(label, value) {
       const listItem = editSheet.locator('nldd-list-item').filter({
         hasText: label,
@@ -199,7 +199,7 @@ test.describe('Edit → re-execute loop via Machine panel', () => {
     // The ActionSheet selects the LAST operation in the tree on open.
     // For the heeft_recht AND that's one of the leaf comparisons, not the
     // AND itself. We need to navigate up to the AND root (number "1") via
-    // the "Bovenliggende operaties" list — each row carries a stable
+    // the "Bovenliggende operaties" list - each row carries a stable
     // data-testid keyed off the operation number.
     await actionSheet
       .locator('[data-testid="parent-op-1-edit-btn"]')

--- a/frontend/scripts/copy-laws.js
+++ b/frontend/scripts/copy-laws.js
@@ -76,7 +76,7 @@ function findFeatureFiles(dir) {
 /** Extract metadata from a corpus YAML.
  *
  * Uses js-yaml so block scalars (`>-`, `|`) and quoted strings are decoded
- * correctly — the previous line-based parser captured the literal `>-`
+ * correctly - the previous line-based parser captured the literal `>-`
  * marker as the value, which broke the library entry for any YAML that
  * folded its name across multiple lines.
  */
@@ -178,7 +178,7 @@ for (const source of localSources) {
 // annotation directories are already keyed by the law's $id. The
 // _vocabulary/ dir is also copied: the note creator's ambiguity-tag picker
 // (RFC-018 write path) reads it so the editor's tag list and the CI
-// soft-validation list cannot drift — one source of truth.
+// soft-validation list cannot drift - one source of truth.
 const annotationsSrc = resolve(projectRoot, 'corpus', 'annotations');
 if (existsSync(annotationsSrc)) {
   const annotationsDest = resolve(destDir, 'annotations');

--- a/frontend/src/AppShell.vue
+++ b/frontend/src/AppShell.vue
@@ -18,7 +18,7 @@ import { useAppChrome, openSearch, onBarSearchKeydown } from './composables/useA
 // Persistent shell that owns the shared chrome (tab-bar, search trigger,
 // TrajectMenu, settings menu) and a nested <router-view> for the editor /
 // library bodies. Because both views are children of this one route record,
-// switching between them swaps only the nested router-view — the shell
+// switching between them swaps only the nested router-view - the shell
 // instance is reused, so the chrome never rebuilds (no refresh flash).
 
 const { authenticated, loading: authLoading, oidcConfigured, person, hasAnyRole, login, logout } = useAuth();
@@ -53,7 +53,7 @@ const colorSchemeOptions = [
 
 // Editor panel feature flags, toggled from the settings menu of either
 // section (the menu lives in the shell now, so the full editor set is in one
-// place — the library previously listed only the first four). Toggling from
+// place - the library previously listed only the first four). Toggling from
 // the library affects the editor the next time its panes render.
 const editorPanelFlags = [
   ['panel.article_text', 'Tekst editor'],
@@ -72,7 +72,7 @@ const router = useRouter();
 // Which top-level section is active, derived from the route. Both tabs are
 // always rendered; the active one shows `selected` and does not navigate,
 // the other carries the cross-section target (traject re-stamped via
-// sectionTarget) — matching the previous per-app behaviour.
+// sectionTarget) - matching the previous per-app behaviour.
 const isLibraryRoute = computed(
   () => route.name === 'library' || route.name === 'library-traject',
 );
@@ -105,7 +105,7 @@ function onEditorTab(e) {
 const { lastSavedPr, documentTabs, activeDocumentTab, tabActions, editorChanges, editorActions, libraryEmpty } = useAppChrome();
 
 // Just-in-time coach-mark on the toolbar search affordance: shown only while the
-// library is empty (nothing curated yet) and never dismissable — the app drives
+// library is empty (nothing curated yet) and never dismissable - the app drives
 // it, and it disappears by itself once the library has content. Each breakpoint
 // renders its search control in a different bar (sm icon-button, md text button,
 // lg search field), each in a pane that is display:none off-breakpoint. So we
@@ -116,7 +116,7 @@ let mdQuery = null;
 let lgQuery = null;
 // DS bar breakpoints, mirrored here for matchMedia. Keep in sync with
 // @nldd/design-system (src/assets/styles/breakpoints.ts): md >= 641px, lg >= 1008px.
-// If the DS shifts these thresholds, update them here too — otherwise the
+// If the DS shifts these thresholds, update them here too - otherwise the
 // coach-mark can anchor to a control that is hidden at the current breakpoint.
 const DS_MD_MIN = '(min-width: 641px)';
 const DS_LG_MIN = '(min-width: 1008px)';
@@ -150,7 +150,7 @@ const hasDocumentTabs = computed(
 <template>
   <nldd-app-view>
     <nldd-bar-split-view>
-      <!-- Primary Bar: md only — search and settings as buttons. The bar-split-
+      <!-- Primary Bar: md only - search and settings as buttons. The bar-split-
            view draws the divider automatically where the bar group meets main:
            on the library it sits under this bar; on the editor the document-tab-
            bar sits between, so toolbar + tabs read as one group above the single
@@ -218,7 +218,7 @@ const hasDocumentTabs = computed(
         </nldd-container>
       </nldd-split-view-pane>
 
-      <!-- Primary Bar: lg+ — search as input field in center slot -->
+      <!-- Primary Bar: lg+ - search as input field in center slot -->
       <nldd-split-view-pane slot="primary-bar-lg" above="lg">
         <nldd-container padding="8">
           <nldd-toolbar size="md">
@@ -285,7 +285,7 @@ const hasDocumentTabs = computed(
         </nldd-container>
       </nldd-split-view-pane>
 
-      <!-- Document Tab Bar (editor only, md+). Hidden on sm — there the tabs
+      <!-- Document Tab Bar (editor only, md+). Hidden on sm - there the tabs
            live in the MobileTrajectSheet opened from the traject row. Rendered
            only while the active view publishes open tabs, so the library never
            shows an empty bar. -->
@@ -309,7 +309,7 @@ const hasDocumentTabs = computed(
         </nldd-container>
       </nldd-split-view-pane>
 
-      <!-- Main content area — the active section's body. -->
+      <!-- Main content area - the active section's body. -->
       <nldd-split-view-pane slot="main">
         <router-view />
       </nldd-split-view-pane>

--- a/frontend/src/EditorView.vue
+++ b/frontend/src/EditorView.vue
@@ -64,7 +64,7 @@ const paneViews = ref(loadPaneViews());
 function loadPaneViews() {
   try {
     const stored = JSON.parse(localStorage.getItem(PANE_VIEWS_KEY) ?? 'null');
-    // Only accept entries we still recognise — a stale value left over
+    // Only accept entries we still recognise - a stale value left over
     // from a removed view (e.g. 'form' before scenario was renamed) or
     // an externally injected string would otherwise produce a pane with
     // no v-if branch matching it, briefly flashing an empty body before
@@ -94,7 +94,7 @@ watch(paneViews, (val) => {
 // Sync paneViews with availableViews when a flag flips:
 // - Drop panes whose view is no longer available (flag off → pane gone)
 // - Append a pane for any view that was JUST enabled by this change
-//   (in current available, not in previous) — so re-enabling a flag
+//   (in current available, not in previous) - so re-enabling a flag
 //   brings the pane back instead of silently leaving the user without
 //   it. The previous version compared "missing from paneViews" against
 //   the full available set, which spuriously appended every available
@@ -160,7 +160,7 @@ const canEdit = computed(
 );
 // The Tekst editor pane is editable whenever the user has write access. The
 // old `editor.article_text_edit` flag that gated this separately is merged into
-// the pane itself — the pane IS the editable text view, so this now just tracks
+// the pane itself - the pane IS the editable text view, so this now just tracks
 // canEdit (kept as a named alias for the text-edit affordances below).
 const canEditArticleText = computed(() => canEdit.value);
 
@@ -195,7 +195,7 @@ const {
 
 // When the active traject changes (router.push to /editor/{otherRef}/…)
 // the URL stays on the same component; re-fetch the open law through the
-// new traject's backends. The corpus list needs no handling here —
+// new traject's backends. The corpus list needs no handling here -
 // `useCorpusLaws(activeTrajectRef)` re-scopes reactively on the same
 // change. `switchLaw` crosses trajects too via its third argument so the
 // law cache key stays correct.
@@ -204,7 +204,7 @@ const {
 // without this a scenario run after a traject switch would evaluate
 // the open law against the *previous* traject's dependencies. The
 // dependency walker re-loads on demand on the next run, so a single
-// `unloadAllLaws` is enough — no per-dep bookkeeping needed.
+// `unloadAllLaws` is enough - no per-dep bookkeeping needed.
 watch(activeTrajectRef, (next) => {
   unloadAllLaws();
   if (lawId.value) {
@@ -222,7 +222,7 @@ const {
 } = useNotes(lawId, selectedArticle, activeTrajectRef);
 
 // Notes live in their own "Tekst viewer + notities" pane (panel.notes), shown
-// read-only against the raw article text — the resolver matches raw text, so it
+// read-only against the raw article text - the resolver matches raw text, so it
 // can't align with the editable WYSIWYG editor. No show/hide toggle: opening
 // the pane is the toggle.
 
@@ -270,7 +270,7 @@ function onCreateNote(note) {
 // Wiping drafts is irreversible (local-only until exported), so it goes
 // through a confirm modal. nldd-modal-dialog's API is show()/hide() (there
 // is no close()); a flag drives those via a watch, and @close just clears
-// the flag — same pattern as MachineReadable's delete confirm, which avoids
+// the flag - same pattern as MachineReadable's delete confirm, which avoids
 // the hide() -> @close -> hide() recursion.
 const clearDraftsModalEl = ref(null);
 const clearDraftsPending = ref(false);
@@ -316,7 +316,7 @@ async function exportNotes() {
 
 // Note write-back: PUT the new drafts to editor-api, which appends them to
 // the sidecar on the active traject's branch (same write model as law and
-// scenario edits since #632). No source picker — the traject's own corpus
+// scenario edits since #632). No source picker - the traject's own corpus
 // config decides where the notes land. The "PR #N" toolbar badge is driven
 // by the shared lastSavedPr ref, so a save that produced a PR lights it up
 // with no extra wiring here.
@@ -328,7 +328,7 @@ const notesSaveStatus = ref(null);
 // The save status/error describe the LAST save. A NEW draft appearing
 // after that save makes the confirmation stale ("Opslaan gelukt" next to
 // "1 concept, nog niet opgeslagen" is contradictory), so clear it then.
-// But a successful save itself drains drafts to zero — clearing on a
+// But a successful save itself drains drafts to zero - clearing on a
 // DECREASE would wipe the very confirmation `saveNotesToRepo` is about to
 // set, a race that previously only worked by microtask-ordering luck.
 // Only react to an increase; the count going down is the save completing.
@@ -356,7 +356,7 @@ async function saveNotesToRepo() {
     // pre-save cached resolution (typically []). Force a refetch so
     // the just-committed notes show up immediately instead of only
     // after the user navigates away and back. NoChange also refetches
-    // — it's cheap and keeps the post-save state consistent.
+    // - it's cheap and keeps the post-save state consistent.
     await reloadNotes();
   } catch (e) {
     notesSaveError.value = e?.message || 'Opslaan mislukt';
@@ -374,7 +374,7 @@ const searchPopoverRef = ref(null);
 // the shell's search button/field opens it.
 registerSearchPopover(searchPopoverRef);
 
-// Shared corpus list via `useCorpusLaws` — the same per-scope cache
+// Shared corpus list via `useCorpusLaws` - the same per-scope cache
 // MachineReadable reads, so an editor mount fires ONE laws-list fetch
 // instead of a private duplicate GET. Traject switches re-scope
 // reactively; fetch failures degrade to the humanized law id.
@@ -408,14 +408,14 @@ function retryLoadLaw() {
 }
 
 function onSearchSelectLaw(lawIdVal) {
-  // Open in the library — search currently only matches law names. As
+  // Open in the library - search currently only matches law names. As
   // soon as article-level search lands, we can route directly into the
   // editor (with the chosen article as the active tab).
   router.push(libraryRouteFor(lawIdVal));
 }
 
 async function onSearchHarvestAvailable(slug) {
-  // Best-effort reload — a failure just means the list below may not
+  // Best-effort reload - a failure just means the list below may not
   // include the fresh law yet.
   await apiFetch('/api/corpus/reload', {
     method: 'POST',
@@ -473,7 +473,7 @@ function saveActiveTab(tab) {
  * traject scope. With a traject in the URL the user stays in
  * `editor-traject` (full edit mode). EditorView only ever mounts under a
  * traject (the editor requires one), so the no-traject branch should not
- * fire here — but for safety it routes to the chooser with the law as
+ * fire here - but for safety it routes to the chooser with the law as
  * query rather than the (now removed) no-traject editor.
  */
 function editorRouteFor(lawIdVal, articleNumber) {
@@ -561,18 +561,18 @@ async function selectTab(tab) {
     lawNames.value = { ...lawNames.value, [tab.lawId]: lawName.value };
   }
   // Sync the URL so deep-linking and browser back/forward stay in step.
-  // `replace` (not `push`) keeps history clean — a tab switch isn't
+  // `replace` (not `push`) keeps history clean - a tab switch isn't
   // navigation the user wants to undo with the back button.
   router.replace(editorRouteFor(tab.lawId, tab.articleNumber));
 }
 
-// On load there may be no article to edit yet — the URL carries no article
+// On load there may be no article to edit yet - the URL carries no article
 // (just a traject, or a law without an article number). Rather than show the
 // empty state while tabs are still open, open one right away: the last active
 // tab when the URL has no law at all (so a refresh returns the user where they
 // were), otherwise simply the first open tab. selectTab sets activeTab
 // synchronously, so the empty state never flashes. With no open tabs we fall
-// through to it — the only case it should appear.
+// through to it - the only case it should appear.
 if (!route.params.articleNumber && openTabs.value.length > 0) {
   const lastActive = loadSavedActiveTab();
   const restored = !route.params.lawId && lastActive?.lawId
@@ -581,7 +581,7 @@ if (!route.params.articleNumber && openTabs.value.length > 0) {
   selectTab(restored || openTabs.value[0]).catch(console.warn);
 }
 
-// Browser back/forward (or any external navigation) — pull state from
+// Browser back/forward (or any external navigation) - pull state from
 // URL. Local mutations from selectTab already match the destination,
 // so the guards below short-circuit; the work only happens for true
 // URL changes.
@@ -707,7 +707,7 @@ function handleScenarioExecuted({ result, traceText, error, running, expectation
   lastExpectations.value = expectations || {};
   lastScenarioName.value = scenarioName || '';
   lastOutputName.value = outputName || null;
-  // Open exactly one of the two sheets — opening the second on top of
+  // Open exactly one of the two sheets - opening the second on top of
   // the first would leave the previous one as a stale layer that
   // re-appears when the user dismisses the foreground sheet.
   if (view === 'graph') {
@@ -719,7 +719,7 @@ function handleScenarioExecuted({ result, traceText, error, running, expectation
   }
 }
 
-// Clear the captured trace whenever the active law changes — otherwise
+// Clear the captured trace whenever the active law changes - otherwise
 // LawGraphView would re-flatten the old trace under the new lawId,
 // misattribute every step to the new law, and pin the "▶ start" badge
 // to a leaf that just happens to share the previous output's name.
@@ -752,7 +752,7 @@ const machineReadable = ref(null);
 // The YAML pane edits the machine-readable as text. There is something to edit
 // when the article carries machine_readable, or one was created/edited this
 // session (the live ref). With neither, the empty code editor is replaced by a
-// message — like the Machine pane and the read-only YAML view. Deliberately not
+// message - like the Machine pane and the read-only YAML view. Deliberately not
 // keyed on the live ref alone: clearing or mid-typing invalid YAML nulls it, and
 // that must not yank the editor out from under the user.
 const hasMachineReadable = computed(
@@ -786,7 +786,7 @@ function setTextEditorRef(idx) {
 // toggle-commando's aan. Lezen van activeFormats in de template houdt de
 // controls reactief in sync met de selectie.
 
-// Vet/Schuin: checkbox-control — de geselecteerde waardes zijn de actieve
+// Vet/Schuin: checkbox-control - de geselecteerde waardes zijn de actieve
 // inline-formats (beide kunnen tegelijk aan staan).
 function boldItalicValues(idx) {
   const refs = textEditorRefs[idx];
@@ -868,13 +868,13 @@ const parsedRawLaw = computed(() => {
 // into ScenarioBuilder, so in-memory edits re-execute scenarios without a
 // round-trip through the backend.
 //
-// Only the currently selected article's machine_readable is swapped — edits
+// Only the currently selected article's machine_readable is swapped - edits
 // on other articles are not tracked across tab switches (existing behavior
 // of the editor state model).
 //
 // KNOWN LIMITATION: when this value is sent to `saveLaw` (via the Machine
 // panel save button), the body is the `yaml.dump` output of the
-// reconstructed document — which strips YAML comments and may reorder
+// reconstructed document - which strips YAML comments and may reorder
 // top-level keys compared to `rawYaml`. The YAML-pane edit path preserves
 // the user's exact text via `yamlSource`, so it does not have this drift.
 // Today's corpus is harvester-generated and comment-free, so the impact is
@@ -888,7 +888,7 @@ const currentLawYaml = computed(() => {
   if (!base) return rawYaml.value;
   try {
     // Shallow-clone the doc and the articles array so our splice doesn't
-    // mutate the memoized `parsedRawLaw` value — Vue would consider the
+    // mutate the memoized `parsedRawLaw` value - Vue would consider the
     // computed still fresh but the next read would see our substituted
     // article instead of the original.
     const doc = { ...base };
@@ -910,7 +910,7 @@ const currentLawYaml = computed(() => {
     const mrPristine = baselineMr === currentMr
       || JSON.stringify(baselineMr) === JSON.stringify(currentMr);
     if (textPristine && mrPristine) return rawYaml.value;
-    // Only splice fields that have diverged from the base — passing
+    // Only splice fields that have diverged from the base - passing
     // `machineReadable.value` verbatim when it's null would erase the
     // article's machine_readable from the serialized doc, and similarly
     // for text. The dirty computeds below drive this same contract.
@@ -938,14 +938,14 @@ const currentLawYaml = computed(() => {
 // Load current law into engine. Reacts to currentLawYaml so in-memory
 // edits are immediately visible to scenarios. Goes through
 // useEngine.loadLawYaml so the engine's scope-tracking map sees this
-// load under the right traject — otherwise a later loadDependency call
+// load under the right traject - otherwise a later loadDependency call
 // for the same law id would treat it as already-current and skip the
 // refetch on a traject switch.
 // `currentLawYaml` re-dumps on every keystroke, so reacting directly would
 // reload the WASM engine per keystroke. Debounce the reload ~300ms after the
 // last edit; keep the first load (no previous yaml) synchronous so the initial
-// load isn't delayed. Subsequent transitions from an existing yaml — keystroke
-// edits, article switches, traject switches — debounce.
+// load isn't delayed. Subsequent transitions from an existing yaml - keystroke
+// edits, article switches, traject switches - debounce.
 let engineLoadDebounce = null;
 
 async function reloadEngineLaw(lawYaml, isReady) {
@@ -984,7 +984,7 @@ onBeforeUnmount(() => clearTimeout(engineLoadDebounce));
 // with a fresh `yaml.load(text)` object whose key order comes from the
 // textarea, so a no-op round-trip can flip this flag to `true` even when
 // the semantic content is unchanged. That's a conservative false positive
-// — the worst case is an enabled save button — so we accept it rather
+// - the worst case is an enabled save button - so we accept it rather
 // than pay for a canonical YAML dump on every keystroke.
 const isMachineReadableDirty = computed(() => {
   if (!selectedArticle.value) return false;
@@ -1005,7 +1005,7 @@ const isArticleTextDirty = computed(() => {
 
 // Tracks which pane(s) had dirty edits at the time of the most recent save
 // attempt. Used to scope `lawSaveError` to the pane that actually triggered
-// the save — without this, a save initiated from the machine pane that
+// the save - without this, a save initiated from the machine pane that
 // fails would surface the "Opslaan mislukt" dialog inside the text-pane
 // body too, blaming a pane the user didn't touch.
 const lastSaveTouchedText = ref(false);
@@ -1029,7 +1029,7 @@ async function handleLawSave() {
     await saveLaw(lawYaml);
     if (lawId.value !== savedLawId) return; // law switched mid-PUT
     // points at the re-parsed article. The `watch(selectedArticle)` above
-    // fires on the next microtask — leaving a window where the dirty
+    // fires on the next microtask - leaving a window where the dirty
     // computeds still see the pre-save values and the save button stays
     // enabled, enabling a double-save click. Reset local state explicitly
     // from the freshly-parsed article so both dirty flags clear
@@ -1039,7 +1039,7 @@ async function handleLawSave() {
     machineReadable.value = freshMr ? structuredClone(freshMr) : null;
     yamlSource.value = freshMr ? yaml.dump(freshMr, dumpOpts) : '';
     editedText.value = fresh?.text ?? '';
-    // Successful save — the dialog flags drop back to false.
+    // Successful save - the dialog flags drop back to false.
     lastSaveTouchedText.value = false;
     lastSaveTouchedMachine.value = false;
   } catch (e) {
@@ -1070,7 +1070,7 @@ const articleDirty = computed(
   () => isArticleTextDirty.value || isMachineReadableDirty.value,
 );
 
-// Throw away every in-memory edit for the selected article — the same reset
+// Throw away every in-memory edit for the selected article - the same reset
 // the post-save cleanup performs, minus the PUT.
 function discardArticle() {
   const fresh = selectedArticle.value;
@@ -1124,10 +1124,10 @@ watchEffect(() => {
 
 // Reflect navigation depth + unsaved state in the document title:
 //   "• Editor: Art. 5 · Wet op de zorgtoeslag · 15 juni test · RegelRecht"
-// A leading dot flags unsaved changes — it stays visible even when the tab
+// A leading dot flags unsaved changes - it stays visible even when the tab
 // title is truncated to its start. Then the mode prefix, then most-specific to
 // least-specific (article, law, traject) with the brand last. Lives here (after
-// articleDirty) and is always set — a static router.afterEach fallback used to
+// articleDirty) and is always set - a static router.afterEach fallback used to
 // race this effect on tab/article switches.
 watchEffect(() => {
   const detail = [];
@@ -1146,12 +1146,12 @@ function onYamlInput(event) {
   // host's `value` property is updated before dispatch so
   // event.target.value would also work, but reading from detail keeps
   // the contract explicit and matches how the storybook docs the API.
-  // `??` skips only null/undefined — a deliberate empty string passes
+  // `??` skips only null/undefined - a deliberate empty string passes
   // through as a valid "user cleared the editor" input.
   const text = event.detail?.value ?? event.target?.value;
   if (text == null) {
     // Structurally broken event (no detail, no value on target). Don't
-    // touch yamlSource — silently overwriting with the previous value
+    // touch yamlSource - silently overwriting with the previous value
     // would swallow keystrokes a user can see in the textarea but
     // never sees committed to the reactive source. Surface it loudly
     // instead so the regression is obvious in dev console.
@@ -1170,7 +1170,7 @@ function onYamlInput(event) {
 
 function handleSave({ section, key, newKey, index, data }) {
   // JSON round-trip clone: Vue reactive proxies aren't structuredClone-able
-  // in all envs. Safe because law YAML is JSON-plain — but Date/undefined
+  // in all envs. Safe because law YAML is JSON-plain - but Date/undefined
   // are NOT preserved, which only matters if a future field becomes
   // date-typed (use an explicit serialiser then).
   const mr = machineReadable.value
@@ -1222,7 +1222,7 @@ function handleSave({ section, key, newKey, index, data }) {
 // array index. Out-of-range indices and missing keys are no-ops so a
 // stale event from the UI can never crash.
 function handleDelete({ section, key, index }) {
-  // JSON clone — see handleSave: Date/undefined not preserved (fine for
+  // JSON clone - see handleSave: Date/undefined not preserved (fine for
   // JSON-plain law data).
   const mr = machineReadable.value
     ? JSON.parse(JSON.stringify(machineReadable.value))
@@ -1350,7 +1350,7 @@ function findIncompleteOperation(value) {
   // NOT wraps a single value/operation; reject the empty-string stub created
   // when transitioning from arithmetic ops via changeOperationType.
   if (op === 'NOT' && (value.value ?? '') === '') return op;
-  // AGE has two structural slots — both must be filled. Empty strings are
+  // AGE has two structural slots - both must be filled. Empty strings are
   // the seed values from changeOperationType('AGE'); reject them so the
   // user can't save a stub.
   if (op === 'AGE') {
@@ -1395,7 +1395,7 @@ async function handleActionSave() {
     }
     // Reject incomplete nested operations (e.g. ADD with empty values[]) that
     // the user inserted via "Voeg operatie toe" but never filled in.
-    // Note: a literal empty-string `value` is permitted at this layer — the
+    // Note: a literal empty-string `value` is permitted at this layer - the
     // schema validator on save handles type-specific validation; rejecting it
     // here would block the legitimate "set output now, fill value via YAML
     // pane later" workflow used by the test suite and the editor's manual
@@ -1410,8 +1410,8 @@ async function handleActionSave() {
   // sheet's "Opslaan" is a real save, so the Machine pane won't show a
   // separate dirty/save affordance for sheet edits. On a failed PUT the
   // edits stay in the model and the Machine pane's normal dirty/save
-  // affordance is the fallback — no data loss either way.
-  // JSON clone — see handleSave: reactive proxy not structuredClone-able;
+  // affordance is the fallback - no data loss either way.
+  // JSON clone - see handleSave: reactive proxy not structuredClone-able;
   // Date/undefined not preserved (fine for JSON-plain law YAML).
   machineReadable.value = JSON.parse(JSON.stringify(machineReadable.value));
   yamlSource.value = yaml.dump(machineReadable.value, dumpOpts);
@@ -1419,7 +1419,7 @@ async function handleActionSave() {
   // Close the sheet unconditionally: the mutations are already committed
   // above, so even if handleLawSave() throws the sheet must not stay open
   // showing a now-clean (isDirty === false) state. A failed PUT falls back
-  // to the Machine pane's normal dirty/save affordance — no data loss.
+  // to the Machine pane's normal dirty/save affordance - no data loss.
   try {
     await handleLawSave();
   } finally {
@@ -1468,7 +1468,7 @@ async function handleActionSave() {
           </nldd-simple-section>
         </nldd-page>
 
-        <!-- Error state — mirrors the library's law-load failure pattern.
+        <!-- Error state - mirrors the library's law-load failure pattern.
              404s typically mean "the law isn't part of the active traject"
              (e.g. after a traject switch); we surface a traject-specific
              message and a quick "Naar bibliotheek" exit. Other failures
@@ -1496,7 +1496,7 @@ async function handleActionSave() {
           </nldd-simple-section>
         </nldd-page>
 
-        <!-- All editor flags off — paneViews is empty so the
+        <!-- All editor flags off - paneViews is empty so the
              side-by-side view would render zero pane slots. Surface an
              explicit empty-state with a CTA to the settings menu so
              the user understands the editor isn't broken. -->
@@ -1514,7 +1514,7 @@ async function handleActionSave() {
         <nldd-side-by-side-split-view v-else :panes="String(paneViews.length)">
           <!-- Compound key: when a flag flip shifts which view sits at a
                given index, Vue would otherwise patch the existing pane in
-               place — leaking ScenarioBuilder form state and engine
+               place - leaking ScenarioBuilder form state and engine
                results into a different view. Re-keying on the view id
                forces an unmount + remount on identity change, at the
                (acceptable) cost of losing pane scroll position. -->
@@ -1610,7 +1610,7 @@ async function handleActionSave() {
                       ></nldd-menu-item>
                     </nldd-menu-group>
                   </nldd-toolbar-item>
-                  <!-- Vet/Schuin — checkbox segmented control (beide kunnen
+                  <!-- Vet/Schuin - checkbox segmented control (beide kunnen
                        tegelijk actief zijn). Bron van waarheid: de Tiptap-
                        editor; de control reflecteert de selectie. -->
                   <nldd-toolbar-item
@@ -1650,7 +1650,7 @@ async function handleActionSave() {
                       ></nldd-menu-item>
                     </nldd-menu-group>
                   </nldd-toolbar-item>
-                  <!-- Lijsttype — radio segmented control: geen / opsomming /
+                  <!-- Lijsttype - radio segmented control: geen / opsomming /
                        genummerd. "Geen" (minus-small) heft de actieve lijst op. -->
                   <nldd-toolbar-item
                     v-if="view === 'text' && selectedArticle && textEditorRefs[idx]"
@@ -1710,7 +1710,7 @@ async function handleActionSave() {
                 </nldd-toolbar>
               </nldd-container>
 
-              <!-- Tekst — WYSIWYG editor when the user can edit, otherwise the
+              <!-- Tekst - WYSIWYG editor when the user can edit, otherwise the
                    read-only ArticleText display. The format controls in the
                    header toolbar guard on `textEditorRefs[idx]`, which only the
                    WYSIWYG component populates, so they auto-hide when read-only. -->
@@ -1728,7 +1728,7 @@ async function handleActionSave() {
                 <ArticleText v-else :article="selectedArticle" />
               </nldd-simple-section>
 
-              <!-- Tekst viewer + notities — read-only article text with resolved
+              <!-- Tekst viewer + notities - read-only article text with resolved
                    note highlights and inline note authoring. A separate pane so
                    it can sit next to the Tekst editor for comparison; the
                    resolver matches raw text, so it can't share the editable
@@ -1764,7 +1764,7 @@ async function handleActionSave() {
                   <!-- Draft notes live in localStorage until written back.
                        "Opslaan naar repo" appends them to the sidecar on
                        the active traject's branch (same write model as
-                       law/scenario edits since #632). No source picker —
+                       law/scenario edits since #632). No source picker -
                        the traject's own corpus config decides the target.
                        Without an active traject the save button is
                        disabled, mirroring the law-edit buttons, so the
@@ -1849,7 +1849,7 @@ async function handleActionSave() {
                   <nldd-inline-dialog
                     variant="alert"
                     text="WASM engine niet geladen"
-                    :supporting-text="`${engineInitError.message} — voer 'just wasm-build' uit om de WASM module te bouwen.`"
+                    :supporting-text="`${engineInitError.message} - voer 'just wasm-build' uit om de WASM module te bouwen.`"
                   ></nldd-inline-dialog>
                 </nldd-simple-section>
                 <ScenarioBuilder
@@ -1905,7 +1905,7 @@ async function handleActionSave() {
     <nldd-button slot="actions" variant="destructive" text="Wis alles" data-testid="clear-drafts-confirm-btn" @click="confirmClearDrafts"></nldd-button>
   </nldd-modal-dialog>
 
-  <!-- Trace sheet — execution trace + expected outcomes for the most
+  <!-- Trace sheet - execution trace + expected outcomes for the most
        recently executed scenario. Opened from a scenario card's "Toon
        resultaat" button. -->
   <nldd-sheet
@@ -1931,7 +1931,7 @@ async function handleActionSave() {
     </nldd-page>
   </nldd-sheet>
 
-  <!-- Graph sheet — visual law graph with the scenario's trace overlay.
+  <!-- Graph sheet - visual law graph with the scenario's trace overlay.
        Opened from a scenario card's "Graaf" button. -->
   <nldd-sheet
     ref="graphSheetEl"

--- a/frontend/src/LibraryView.vue
+++ b/frontend/src/LibraryView.vue
@@ -43,7 +43,7 @@ function libraryRouteFor(params = {}) {
     : { name: 'library', params };
 }
 function editorRouteFor(lawIdVal, articleNumber) {
-  // Without an active traject the editor isn't reachable directly — the
+  // Without an active traject the editor isn't reachable directly - the
   // editor requires a traject. Send the user to the chooser, carrying the
   // law as query so it opens right after a traject is picked.
   return activeTrajectRef.value
@@ -75,8 +75,8 @@ const lawError = ref(null);
 const selectedArticleNumber = ref(null);
 
 // Recently-viewed laws (most-recent-first), persisted across sessions. Stored
-// as { law_id, name } so a law that fails to load in the active traject — and
-// therefore never enters the corpus index — still stays reachable + labelled.
+// as { law_id, name } so a law that fails to load in the active traject - and
+// therefore never enters the corpus index - still stays reachable + labelled.
 const RECENT_LAWS_KEY = 'regelrecht-recent-laws';
 const MAX_RECENT_LAWS = 12;
 function loadRecentLaws() {
@@ -94,7 +94,7 @@ function recordRecentLaw(lawId, name) {
   recentLaws.value = [entry, ...recentLaws.value.filter(r => r.law_id !== lawId)].slice(0, MAX_RECENT_LAWS);
   try {
     localStorage.setItem(RECENT_LAWS_KEY, JSON.stringify(recentLaws.value));
-  } catch { /* storage unavailable — keep the in-memory list */ }
+  } catch { /* storage unavailable - keep the in-memory list */ }
 }
 // Detail view (tekst/machine/yaml) is reflected in the URL hash so the
 // state is bookmarkable and shareable. English keys in the hash because
@@ -108,7 +108,7 @@ const detailView = computed({
   },
   set(value) {
     // Reject anything we don't recognise rather than silently stripping
-    // the hash — every call site today hard-codes a literal, so an
+    // the hash - every call site today hard-codes a literal, so an
     // unknown value is a programmer error. Warn in dev so a future
     // contributor adding a tab without updating VIEW_TO_HASH catches
     // it immediately; production silently no-ops to avoid console noise.
@@ -138,7 +138,7 @@ const activeAction = ref(null);
 // There is deliberately NO full-corpus fallback: the central corpus is the
 // full BWB corpus (thousands of laws), so dumping it into the sidebar isn't
 // useful and is exactly the "huge pile" we don't want loaded here. When
-// nothing is curated yet, the template shows a search CTA instead — full
+// nothing is curated yet, the template shows a search CTA instead - full
 // browse lives in the search popover.
 const sidebarSections = computed(() => {
   const list = laws.value;
@@ -217,7 +217,7 @@ const indexedLawName = computed(() => {
   return law ? displayName(law) : humanizeLawId(selectedLawId.value);
 });
 
-// Track the active law in "Recent bekeken" — including one that fails to load,
+// Track the active law in "Recent bekeken" - including one that fails to load,
 // so the sidebar reflects what the user is looking at even when nothing is
 // curated yet. Re-runs as the name resolves to upgrade the label from the
 // humanized id to the real name.
@@ -249,11 +249,11 @@ const lawErrorIs404 = computed(() => lawError.value?.status === 404);
 // On a traject-scoped browse the active traject name is appended (like the
 // editor) so the browser tab and history show which traject you are viewing.
 // Most-specific first so browser tab truncation preserves the article number.
-// We deliberately omit the "Bibliotheek:" prefix here (unlike the editor) —
+// We deliberately omit the "Bibliotheek:" prefix here (unlike the editor) -
 // browsing laws is the implicit default, and the law name carries enough
 // context. The editor still prefixes because "Wijzig:" disambiguates the
 // edit context from the read-only browse.
-// Always set (no early return) — router.afterEach used to set a static
+// Always set (no early return) - router.afterEach used to set a static
 // fallback but it raced with this effect on tab/article switches.
 watchEffect(() => {
   const detail = [];
@@ -293,7 +293,7 @@ async function loadFavorites() {
     });
     favorites.value = new Set(favIds);
   } catch (e) {
-    // Not authenticated (401/403) or endpoint unavailable — no favorites.
+    // Not authenticated (401/403) or endpoint unavailable - no favorites.
     // Only server errors are worth a console trace.
     if (e instanceof ApiError && e.status >= 500) console.warn(e.message);
   }
@@ -301,7 +301,7 @@ async function loadFavorites() {
 
 // Fetch the set of law ids edited in the active traject. Returns `null`
 // when there's no traject (global browse has no "changed" notion) or on
-// any failure — the "Bewerkt in dit traject" section then simply stays
+// any failure - the "Bewerkt in dit traject" section then simply stays
 // hidden instead of surfacing an error in the sidebar. The backend returns
 // an empty array (not an error) when nothing has been saved yet, which maps
 // to an empty Set and a hidden section all the same.
@@ -310,7 +310,7 @@ async function fetchChangedLawIds(trajectRef) {
   try {
     return new Set(await apiFetchJson(changedLawsUrl(trajectRef)));
   } catch {
-    // Any failure (HTTP or network) just hides the section — see above.
+    // Any failure (HTTP or network) just hides the section - see above.
     return null;
   }
 }
@@ -360,7 +360,7 @@ async function toggleFavorite(lawId) {
     // id) appears in the Favorieten section without a manual reload.
     loadIndex();
   } catch {
-    // HTTP or network failure — roll the optimistic toggle back.
+    // HTTP or network failure - roll the optimistic toggle back.
     revert();
   } finally {
     togglingFavorites.value.delete(lawId);
@@ -385,7 +385,7 @@ async function loadIndex() {
     if (!isCurrent()) return;
     changedLawIds.value = changedIds;
 
-    // Fetch metadata for just those ids via `?ids=` — never the whole corpus.
+    // Fetch metadata for just those ids via `?ids=` - never the whole corpus.
     // The central corpus is the full BWB corpus (thousands of laws); loading
     // it here only to filter out a handful would be wasteful and would miss
     // any favorite/edit that sorts past a page cap. Full browse lives in the
@@ -456,7 +456,7 @@ function retryLoadLaw() {
 
 function retryLoadCorpus() {
   indexError.value = null;
-  // loadIndex only flips loading back to false in its finally block —
+  // loadIndex only flips loading back to false in its finally block -
   // it never sets it to true. So after the first failure (loading is
   // false, indexError is truthy) we have to flip the spinner back on
   // here, otherwise the retry shows the error pane until the next
@@ -495,7 +495,7 @@ function selectLaw(lawId, focusAfter = false) {
   }
 
   // When triggered from the search popover we want focus to land on the
-  // newly-selected sidebar item — not on the popover trigger that
+  // newly-selected sidebar item - not on the popover trigger that
   // popover._returnFocus restores to. Schedule on nextTick so the popover
   // has fully closed (sync) and Vue has rendered the selected state, then
   // walk the list-item shadow DOM to focus its inner button (the host
@@ -519,7 +519,7 @@ function selectLawFromSection(lawId, sectionKey) {
 }
 
 // The single sidebar instance to highlight: the clicked section (when it still
-// holds the law), else the law's first occurrence — so exactly one instance is
+// holds the law), else the law's first occurrence - so exactly one instance is
 // selected, including on a deep-link where no section was clicked.
 const highlightSection = computed(() => {
   const id = selectedLawId.value;
@@ -542,7 +542,7 @@ function selectArticle(number) {
 }
 
 /**
- * Pane back-button handlers — URL-driven so browser back works the same
+ * Pane back-button handlers - URL-driven so browser back works the same
  * way as clicking the in-pane back button. Pushing the URL one level up
  * lets `onBeforeRouteUpdate` reactively pull the right local state into
  * sync. On sm the navigation-split-view shows the deepest pane with
@@ -553,15 +553,15 @@ function selectArticle(number) {
  * to identify which pane the back originated from and route accordingly.
  *
  * `back` is the event fired by nldd-top-title-bar's back-button (not
- * `dismiss` — that's the X-style close button on the right).
+ * `dismiss` - that's the X-style close button on the right).
  */
 function onPaneBack(e) {
   const path = e.composedPath();
   const pane = path.find(el => el.tagName === 'NLDD-SPLIT-VIEW-PANE');
   if (!pane) return;
   const slot = pane.getAttribute('slot');
-  // On any error state — corpus load failed (indexError) or this
-  // specific law failed (lawError) — back from the main pane should
+  // On any error state - corpus load failed (indexError) or this
+  // specific law failed (lawError) - back from the main pane should
   // return to the library root, not /library/<lawId>. The latter would
   // route the user back into the same error they just dismissed.
   if (slot === 'main') return (lawError.value || indexError.value) ? goToLibraryRoot() : goToLawRoot();
@@ -598,7 +598,7 @@ onBeforeRouteUpdate((to) => {
   const newArticle = to.params.articleNumber;
 
   if (!newLawId) {
-    // Navigated to /library with no lawId — clear state. No auto-select:
+    // Navigated to /library with no lawId - clear state. No auto-select:
     // the empty state (Wetten Browser only) is a valid landing view.
     selectedLawId.value = null;
     selectedLaw.value = null;
@@ -627,7 +627,7 @@ onBeforeRouteUpdate((to) => {
 
 // When a harvested law becomes available, reload the corpus and select it.
 async function onHarvestAvailable(slug) {
-  // Best-effort reload — a failure just means the index below may not
+  // Best-effort reload - a failure just means the index below may not
   // include the fresh law yet.
   await apiFetch('/api/corpus/reload', {
     method: 'POST',
@@ -653,7 +653,7 @@ loadIndex();
 // depending on `activeTrajectRef`. When the user switches traject in-place
 // (e.g. picking another traject from the TrajectMenu while staying in the
 // library, or "Geen traject"), the route param changes but the component
-// stays mounted — so refetch the index and the open law through the new
+// stays mounted - so refetch the index and the open law through the new
 // scope. Mirrors EditorApp's `watch(activeTrajectRef)`.
 watch(activeTrajectRef, () => {
   // Drop the previous traject's changed-set immediately so the
@@ -694,7 +694,7 @@ watch(activeTrajectRef, () => {
         </nldd-page>
 
         <!-- Nothing curated yet (no favorites, no traject edits, no open law):
-             leave the canvas blank — the just-in-time coach-mark on the toolbar
+             leave the canvas blank - the just-in-time coach-mark on the toolbar
              search field (AppShell) points the user at search. -->
         <nldd-page v-else-if="isEmptyLibrary"></nldd-page>
 
@@ -755,7 +755,7 @@ watch(activeTrajectRef, () => {
             </nldd-page>
           </nldd-split-view-pane>
 
-          <!-- Secondary Sidebar: Artikelen Lijst — only when a law is
+          <!-- Secondary Sidebar: Artikelen Lijst - only when a law is
                selected. When deselected the pane is removed from the DOM
                so the navigation-split-view reflows to spatial mode and
                shows the sidebar (Wetten Browser) alongside main. -->

--- a/frontend/src/TrajectChooserView.vue
+++ b/frontend/src/TrajectChooserView.vue
@@ -4,7 +4,7 @@ import { useRoute, useRouter } from 'vue-router';
 import { useTrajects, refreshTrajects } from './composables/useTrajects.js';
 import { lastLibraryPath } from './composables/useLastVisitedRoute.js';
 
-// Trajectkeuze-pagina — de landing wanneer de editor (of een traject-scoped
+// Trajectkeuze-pagina - de landing wanneer de editor (of een traject-scoped
 // bibliotheek) een traject vereist. Hier kies je een bestaand traject of ga je
 // door naar de aanmaakpagina. Een meegekregen wet (query `law`/`article`, gezet
 // door de redirect van oude no-traject editor-links) opent na de keuze direct.
@@ -50,7 +50,7 @@ function trajectTarget(trajectRef) {
 
 function selectTraject(t) {
   // `t.ref` serialises to null when the backend builds a TrajectSummary
-  // without fill_ref() — refuse to navigate (same guard as TrajectMenu).
+  // without fill_ref() - refuse to navigate (same guard as TrajectMenu).
   if (!t.ref) {
     console.warn('TrajectChooser: traject has no ref', t);
     return;
@@ -67,7 +67,7 @@ function trajectSupportingText(t) {
   const parts = [];
   if (t.status === 'afgerond') parts.push('Afgerond');
   if (t.description) parts.push(t.description);
-  return parts.join(' — ') || undefined;
+  return parts.join(' - ') || undefined;
 }
 </script>
 

--- a/frontend/src/TrajectCreateView.vue
+++ b/frontend/src/TrajectCreateView.vue
@@ -4,7 +4,7 @@ import { useRoute, useRouter } from 'vue-router';
 import TrajectCreateForm from './components/TrajectCreateForm.vue';
 import { createTraject } from './composables/useTrajects.js';
 
-// Nieuw-traject-pagina — bereikbaar vanaf de trajectkeuze-pagina. Gebruikt
+// Nieuw-traject-pagina - bereikbaar vanaf de trajectkeuze-pagina. Gebruikt
 // hetzelfde gedeelde formulier als de TrajectMenu-sheet; na het aanmaken ga je
 // direct de editor (of traject-scoped bibliotheek) in op het nieuwe traject,
 // met een eventueel meegekregen wet (query `law`/`article`) voorgeselecteerd.

--- a/frontend/src/WerkdocumentenView.vue
+++ b/frontend/src/WerkdocumentenView.vue
@@ -1,13 +1,13 @@
 <script setup>
 /**
- * WerkdocumentenView — standalone full-page werkdocumenten editor, opened in a
+ * WerkdocumentenView - standalone full-page werkdocumenten editor, opened in a
  * new browser tab from the in-sheet editor's "Open in nieuw tabblad". Gives the
  * documents a navigation-split-view (list sidebar + editor main) with all the
  * room the right-side sheet can't, while sharing the exact same logic
  * (useDocumentsManager) and presentational pieces (DocumentList/DocumentEditor).
  *
  * Top-level route (sibling of AppShell, not nested) so it has no app chrome;
- * it carries its own compact top bar — title + traject subtitle on the left,
+ * it carries its own compact top bar - title + traject subtitle on the left,
  * a focused account menu (theme + logout) on the right.
  */
 import { computed, onMounted, watch, watchEffect } from 'vue';
@@ -37,7 +37,7 @@ const { jobs: conversionJobs } = jobsPoller;
 
 // Hidden native file input + upload trigger (shared with the launcher sheet).
 // Polling is already running (started on mount), so just refresh to surface the
-// new job immediately — restarting would reset() and briefly flash the list empty.
+// new job immediately - restarting would reset() and briefly flash the list empty.
 const { fileInput, uploadError, onUpload, onFileChange } = useDocumentUpload(uploadDocument, () =>
   jobsPoller.refresh(),
 );

--- a/frontend/src/components/ActionSheet.vue
+++ b/frontend/src/components/ActionSheet.vue
@@ -7,7 +7,7 @@ const props = defineProps({
   action: { type: Object, default: null },
   article: { type: Object, default: null },
   editable: { type: Boolean, default: false },
-  /** A freshly added action — Save is always offered (you opened the
+  /** A freshly added action - Save is always offered (you opened the
    *  sheet to create it), regardless of the dirty snapshot. */
   isNew: { type: Boolean, default: false },
 });
@@ -62,7 +62,7 @@ const selectedOperation = computed(() => operationTree.value[selectedOpIndex.val
 
 // When the action has no operation (e.g. `value: $PERCENTAGE_LID_5`), the
 // operation tree is empty and the sheet would otherwise show a blank body.
-// Show the value verbatim from the YAML — `$VAR` refs stay in their CAPS +
+// Show the value verbatim from the YAML - `$VAR` refs stay in their CAPS +
 // underscore form because the `$` is a code-marker that pairs visually
 // with code-style identifiers (humanizing them to `$percentage lid 5`
 // reads inconsistently).
@@ -125,13 +125,13 @@ onUnmounted(() => {
       <nldd-simple-section>
         <!-- Output binding lives inside the operation's settings list (via
              OperationSettings' lead-row slot) at the top level, or in the
-             direct-value list below — so it sits in the same box as the
+             direct-value list below - so it sits in the same box as the
              other root rows instead of a separate box. -->
 
         <!-- Section A: Bovenliggende operaties -->
         <template v-if="parentOperations.length">
           <nldd-list variant="box" arrow-navigation>
-            <!-- Back/up navigation — clickable parent rows with a
+            <!-- Back/up navigation - clickable parent rows with a
                  chevron-left, identical in view and edit: click any
                  ancestor to jump up one or more levels. -->
             <nldd-list-item

--- a/frontend/src/components/AnnotatedText.test.js
+++ b/frontend/src/components/AnnotatedText.test.js
@@ -121,13 +121,13 @@ describe('AnnotatedText markdown highlighting', () => {
       ...wrapper.element.querySelectorAll('mark[data-primary-idx]'),
     ];
     expect(marks).toHaveLength(3);
-    // [7,12) — only A.
+    // [7,12) - only A.
     expect(marks[0].textContent).toBe('verze');
     expect(marks[0].dataset.noteIdx).toBe('0');
     expect(marks[0].dataset.primaryIdx).toBe('0');
     expect(marks[0].dataset.coverDepth).toBe('1');
     expect(marks[0].className).toContain('note-commenting');
-    // [12,17) — both, primary is A (earlier start), bg is the layered
+    // [12,17) - both, primary is A (earlier start), bg is the layered
     // marker class (no class-background; inline backgroundImage stacks).
     // coverDepth=2 drives the top-edge underline that makes same-motivation
     // overlap legible without depending on a colour shift.
@@ -137,7 +137,7 @@ describe('AnnotatedText markdown highlighting', () => {
     expect(marks[1].dataset.coverDepth).toBe('2');
     expect(marks[1].className).toContain('note-multi');
     expect(marks[1].style.backgroundImage).toContain('linear-gradient');
-    // [17,25) — only B.
+    // [17,25) - only B.
     expect(marks[2].textContent).toBe(' heeft a');
     expect(marks[2].dataset.noteIdx).toBe('1');
     expect(marks[2].dataset.primaryIdx).toBe('1');
@@ -178,7 +178,7 @@ describe('AnnotatedText markdown highlighting', () => {
   });
 
   it('caps cover-depth at 3 even when four+ notes share a span', async () => {
-    // Four notes on identical spans — none strictly contains another, all
+    // Four notes on identical spans - none strictly contains another, all
     // four are visible. coveringIdx.length is 4 but data-cover-depth must
     // clamp to '3' so the CSS rule set stays bounded.
     const wrapper = mountWith(ART, [
@@ -199,9 +199,9 @@ describe('AnnotatedText markdown highlighting', () => {
 
   it('hovering the outer in encapsulation bridges .note-hovered across the inner segment', async () => {
     // Same setup as the encapsulation test. Firing pointerover on the
-    // outer's left flank must add .note-hovered to all three marks — the
+    // outer's left flank must add .note-hovered to all three marks - the
     // inner segment too, even though it does not render the outer's
-    // background by default — so the outer's full extent reads as one
+    // background by default - so the outer's full extent reads as one
     // continuous range.
     const wrapper = mountWith(ART, [
       { note: noteVerzekerde, spans: [{ start: 3, end: 34 }] },
@@ -228,7 +228,7 @@ describe('AnnotatedText markdown highlighting', () => {
       number: '2',
       text: '1. eerste lid hier\n\n2. tweede lid daar',
     };
-    // Span from "eerste" (raw 3) through "tweede lid" — crosses the \n\n.
+    // Span from "eerste" (raw 3) through "tweede lid" - crosses the \n\n.
     const wrapper = mountWith(twoLeden, [
       { note: noteVerzekerde, spans: [{ start: 3, end: 34 }] },
     ]);
@@ -261,7 +261,7 @@ describe('AnnotatedText markdown highlighting', () => {
     const wrapper = mountWith(ART, []);
     await nextTick();
     // canCreate defaults false: no NoteCreator, no floating button, no
-    // selection anchor — the pane is purely a read view.
+    // selection anchor - the pane is purely a read view.
     expect(wrapper.find('[data-testid="create-note-btn"]').exists()).toBe(
       false,
     );
@@ -311,7 +311,7 @@ describe('AnnotatedText markdown highlighting', () => {
 // nldd-popover uses the native HTML popover API: showPopover() puts the
 // element in the top layer and steals focus. Opening it from a pointerover
 // while the user is mid-drag therefore lands the drag's pointermove on the
-// popover instead of the underlying text — selection cannot extend past the
+// popover instead of the underlying text - selection cannot extend past the
 // first mark it touches. These tests pin the drag-aware gate that closes
 // the hover-popover path during a selection drag, while keeping hover and
 // keyboard discoverability intact.
@@ -412,7 +412,7 @@ describe('AnnotatedText popover suppression during drag-selection', () => {
   it('does not open the popover when a non-collapsed selection lives inside the rich-text root', async () => {
     const { wrapper, mark } = await mountedWithMark();
     // Stub getSelection to return a non-collapsed Selection anchored inside
-    // the rich-text root — covers the post-mouseup path where the drag is
+    // the rich-text root - covers the post-mouseup path where the drag is
     // done but the selection is still standing.
     const fakeSel = {
       rangeCount: 1,
@@ -431,7 +431,7 @@ describe('AnnotatedText popover suppression during drag-selection', () => {
 
   it('ignores a secondary-button pointerup while a primary drag is in flight', async () => {
     // Right-button release mid-left-drag must not consume the left-drag's
-    // start coords or clear isDragging — otherwise the remaining drag would
+    // start coords or clear isDragging - otherwise the remaining drag would
     // fall back to only the selection-based guard for the rest of the
     // gesture and a pointerover on a mark could re-open the popover before
     // the actual left release.

--- a/frontend/src/components/AnnotatedText.vue
+++ b/frontend/src/components/AnnotatedText.vue
@@ -27,7 +27,7 @@ const props = defineProps({
 const emit = defineEmits(['create-note']);
 
 // Render the law text as markdown, identical to the Tekst pane with notes
-// off (shared pipeline so the two cannot drift — #646). The resolver matched
+// off (shared pipeline so the two cannot drift - #646). The resolver matched
 // char-offsets into the *raw* text; after rendering we re-anchor those onto
 // the DOM's text nodes and wrap each resolved span in a <mark> imperatively,
 // because the spans cross marked's generated <li>/<p> structure and cannot be
@@ -44,12 +44,12 @@ const noteByIdx = computed(() => props.notesForArticle.map((n) => n.note));
 // noteIdx -> all marks whose segment is covered by that note (visible or
 // suppressed by encapsulation). Built fresh by applyHighlights and consumed by
 // the hover handler to "bridge" a hovered note's full span across the marks it
-// is encapsulated within — the inner segment renders the inner note only by
+// is encapsulated within - the inner segment renders the inner note only by
 // default, but hover should still show the outer's extent.
 const hoverBridge = new Map();
 // Currently hover-bridged note idx, so .note-hovered can be removed cleanly
 // when the cursor leaves the bridged region. Declared alongside hoverBridge
-// because clearHighlights resets both together — a re-render mid-hover (e.g.
+// because clearHighlights resets both together - a re-render mid-hover (e.g.
 // a draft added while the cursor sits on a mark) must drop both the lookup
 // table and the tracker, or the next pointerover early-exits in
 // applyHoverBridge and .note-hovered never lands on the new marks.
@@ -76,12 +76,12 @@ function motivationClass(note) {
   return 'note-other';
 }
 
-// Same scheme but as a CSS colour — used for the inline layered backgrounds
+// Same scheme but as a CSS colour - used for the inline layered backgrounds
 // in segments with multiple visible notes. The values mirror these CSS rules
 // (search the file for each selector if you change one side): `:deep(mark.
 // note-linking)`, `note-commenting`, `note-questioning`, `note-tagging`,
-// `note-other`. Note the `questioning` row is 0.30 by design — slightly more
-// opaque so orange reads against light text — keep both sides in sync.
+// `note-other`. Note the `questioning` row is 0.30 by design - slightly more
+// opaque so orange reads against light text - keep both sides in sync.
 const MOTIVATION_COLOR = {
   linking: 'rgba(59, 130, 246, 0.28)',
   commenting: 'rgba(234, 179, 8, 0.28)',
@@ -114,7 +114,7 @@ function authorityClass(note) {
 //                         encapsulation segment)
 //   - data-cover-idx      comma-separated covering note indices (visible
 //                         plus any encapsulating outer suppressed in this
-//                         segment) — used by the hover-bridge to highlight a
+//                         segment) - used by the hover-bridge to highlight a
 //                         hovered note across regions where it is suppressed
 //   - data-primary-idx    the single note whose popover opens on hover
 //                         (earliest-start visible note in the segment)
@@ -179,7 +179,7 @@ function wrapSegmentSlice(slice, seg, notes) {
 
 // Unwrap every <mark> we added, restoring the original text nodes. v-html
 // resets the DOM when `html` changes, but a notes-only change (article
-// unchanged — e.g. once notes become editable) leaves the prior marks in
+// unchanged - e.g. once notes become editable) leaves the prior marks in
 // place, so applyHighlights must be idempotent and clean up first.
 function clearHighlights(root) {
   for (const mark of root.querySelectorAll('mark[data-primary-idx]')) {
@@ -323,7 +323,7 @@ function closePopoverNow() {
 function onDocPointerDown(event) {
   if (event.button !== 0) return; // only primary-button drags select text
   // A press inside the popover panel itself is interacting with the
-  // popover, not starting a new selection — closing it on its own mousedown
+  // popover, not starting a new selection - closing it on its own mousedown
   // would swallow any click inside (currently moot, the popover holds only
   // a `@click.prevent` link, but cheap insurance for any future control).
   const pop = popoverEl.value;
@@ -336,7 +336,7 @@ function onDocPointerDown(event) {
 function onDocPointerUp(event) {
   // Match the button filter from onDocPointerDown: a secondary-button
   // pointerup while the primary-button drag is still in flight must not
-  // consume the drag's start coords or clear isDragging — otherwise the
+  // consume the drag's start coords or clear isDragging - otherwise the
   // remaining drag falls through to only the isSelectingInRoot() guard.
   // pointercancel is exempt: any cancel aborts the whole gesture, primary
   // or not.
@@ -427,7 +427,7 @@ function openFor(el, note, idx) {
   try {
     if (!pop.matches?.(':popover-open')) pop.showPopover?.();
   } catch {
-    /* already open against another anchor — anchorElement moved it */
+    /* already open against another anchor - anchorElement moved it */
   }
 }
 
@@ -505,8 +505,8 @@ const selAnchorEl = useTemplateRef('selAnchorEl');
 // nodes); if the DOM->raw mapping were deferred to openCreator() a draft
 // resolving between selection and click would collapse the selection and the
 // note could not be created while any other note is highlighted. Mapping the
-// selection the instant it is made — while the live selection and the DOM it
-// was made against are still in sync — removes that race entirely.
+// selection the instant it is made - while the live selection and the DOM it
+// was made against are still in sync - removes that race entirely.
 const pendingRange = ref(null);
 
 function clearSelectionUi() {
@@ -542,7 +542,7 @@ function onSelectionChange() {
   const range = rawText ? selectionToRawRange(rawText, root) : null;
   if (!range) {
     // Unmappable selection (spans only stripped structure, or the render
-    // desynced) — no actionable note, drop the UI.
+    // desynced) - no actionable note, drop the UI.
     clearSelectionUi();
     return;
   }
@@ -589,7 +589,7 @@ function onCreatorCancel() {
 // The selected article can change while the creator is open (router nav).
 // selectionRange holds offsets into the OLD article text; NoteCreator's
 // :raw-text would switch to the new article and buildSelector would slice a
-// garbage substring at stale offsets — potentially persisting a note on the
+// garbage substring at stale offsets - potentially persisting a note on the
 // wrong text. Tear the creation flow down on any article change.
 watch(
   () => props.article,
@@ -769,7 +769,7 @@ onBeforeUnmount(() => {
 /* Multi-visible-note segments (partial overlap, layered backgrounds). The
    class is a marker only; the inline style on the mark stacks one
    linear-gradient layer per visible note so two 28%-opaque colours composite
-   into a third — see motivationColor() in the script. The single border-bottom
+   into a third - see motivationColor() in the script. The single border-bottom
    from the primary's authority class stays. */
 .annotated-wrap :deep(mark.note-multi) {
   background: none;

--- a/frontend/src/components/ArticleTextEditor.test.js
+++ b/frontend/src/components/ArticleTextEditor.test.js
@@ -30,7 +30,7 @@ describe('ArticleTextEditor', () => {
     expect(typeof exposed.toggleItalic).toBe('function');
     expect(typeof exposed.toggleBulletList).toBe('function');
     expect(typeof exposed.toggleOrderedList).toBe('function');
-    // activeFormats reflects the editor's current selection — only the shape
+    // activeFormats reflects the editor's current selection - only the shape
     // is part of the contract with the parent toolbar.
     expect(Object.keys(exposed.activeFormats).sort()).toEqual([
       'bold', 'bulletList', 'italic', 'orderedList',
@@ -73,7 +73,7 @@ describe('ArticleTextEditor', () => {
 
   // The remaining tests exercise tiptap under happy-dom. If the editor instance
   // doesn't initialise (e.g. because happy-dom lacks a DOM API tiptap depends
-  // on), we skip the assertion rather than fail — the toolbar/empty-state
+  // on), we skip the assertion rather than fail - the toolbar/empty-state
   // coverage above is the load-bearing part.
   it('emits update:modelValue with markdown when editor content changes', async () => {
     const wrapper = mountEditor({ modelValue: 'start' });
@@ -86,7 +86,7 @@ describe('ArticleTextEditor', () => {
     // dig it out of the EditorContent child component's props.
     const editorContent = wrapper.findComponent({ name: 'EditorContent' });
     if (!editorContent.exists() || !editorContent.props('editor')) {
-      // Editor failed to mount under happy-dom — skip without failing the suite.
+      // Editor failed to mount under happy-dom - skip without failing the suite.
       return;
     }
     const editor = editorContent.props('editor');

--- a/frontend/src/components/ArticleTextEditor.vue
+++ b/frontend/src/components/ArticleTextEditor.vue
@@ -17,7 +17,7 @@ const props = defineProps({
    * tags in the incoming markdown (e.g. `<em>`, `<sup>`, `<br>` from a
    * harvested corpus entry) are silently dropped on load. Editing such an
    * article and saving will strip the HTML from the persisted YAML even if
-   * the user typed nothing — the diff at the first save will be larger than
+   * the user typed nothing - the diff at the first save will be larger than
    * the "numbered-prose normalization" framing in the PR description
    * suggests. The engine ignores `text` so this is functionally lossless,
    * but the rendered output in downstream readers will change.
@@ -32,7 +32,7 @@ const editor = useEditor({
   editable: props.editable,
   extensions: [
     StarterKit,
-    // Strict commonmark — HTML embedded in source markdown is dropped rather
+    // Strict commonmark - HTML embedded in source markdown is dropped rather
     // than partially mapping into the prosemirror schema.
     //
     // Side effect: editing an article whose stored `text` already contains
@@ -67,7 +67,7 @@ watch(editor, (inst) => {
   const bump = () => { selectionTick.value++; };
   // `selectionUpdate` alone misses Ctrl+B style commands that change marks
   // without moving the cursor. `transaction` covers those, but fires on
-  // every keystroke too — gate it on a doc-or-selection change so the
+  // every keystroke too - gate it on a doc-or-selection change so the
   // toolbar re-render doesn't run on pure cursor motion within a paragraph.
   const onTransaction = ({ transaction: tr }) => {
     if (tr.docChanged || tr.selectionSet) bump();
@@ -84,14 +84,14 @@ watch(editor, (inst) => {
 }, { immediate: true });
 
 // Re-seed content when the parent swaps articles or a save completes. Skip if
-// the markdown already matches what the editor holds — calling setContent on
+// the markdown already matches what the editor holds - calling setContent on
 // every keystroke would reset the cursor.
 //
 // Track the previously-rendered article so we only reset the cursor on an
 // actual article switch. ProseMirror otherwise keeps the previous cursor
 // offset, which can land in the middle of the new article (or snap to the
 // end) and confuses the user. Within a single article we leave the selection
-// alone — e.g. a server-side save that round-trips an unchanged markdown
+// alone - e.g. a server-side save that round-trips an unchanged markdown
 // string should not yank the cursor to position 0.
 let lastArticleNumber = props.article ? String(props.article.number) : null;
 watch(() => props.modelValue, (next) => {
@@ -153,7 +153,7 @@ function redo() { editor.value?.chain().focus().redo().run(); }
 // Drop the undo/redo history. StarterKit (v3) exposes no clearHistory command,
 // so drop and re-add the ProseMirror history plugin: a fresh instance re-inits
 // with empty undo/redo stacks. Both steps go through Tiptap's own reconfigure
-// (registerPlugin/unregisterPlugin) so editor.state stays in sync — a bare
+// (registerPlugin/unregisterPlugin) so editor.state stays in sync - a bare
 // view.updateState leaves Tiptap's cached state untouched. Used after a discard
 // so Ctrl+Z can't step back into the thrown-away edits and re-dirty the article.
 function clearHistory() {

--- a/frontend/src/components/BreakableName.vue
+++ b/frontend/src/components/BreakableName.vue
@@ -5,7 +5,7 @@ import { computed } from 'vue';
  * Renders an identifier so the browser may wrap *after* each underscore.
  *
  * Long snake_case names (e.g. `geldige_partnertypen`) have no native break
- * opportunity, so a narrow column breaks them mid-word — one character per
+ * opportunity, so a narrow column breaks them mid-word - one character per
  * line in the worst case. Splitting on `_` and emitting a real <wbr> just
  * *before* each underscore gives a clean, opt-in break point: the name stays
  * on one line when it fits, and wraps only at underscores when it doesn't,
@@ -13,7 +13,7 @@ import { computed } from 'vue';
  * continues" signal than a trailing underscore). Unlike a zero-width space
  * this leaves nothing behind in copied text.
  *
- * Read-only display only — editable fields keep the raw value.
+ * Read-only display only - editable fields keep the raw value.
  */
 const props = defineProps({
   name: { type: String, required: true },

--- a/frontend/src/components/ConversionStatus.vue
+++ b/frontend/src/components/ConversionStatus.vue
@@ -1,8 +1,8 @@
 <script setup>
 /**
- * ConversionStatus — presentational list of a traject's in-progress and failed
+ * ConversionStatus - presentational list of a traject's in-progress and failed
  * document-conversion jobs. A running job shows a spinner; a failed job shows
- * its reason. Completed jobs are not shown here — they appear as the actual
+ * its reason. Completed jobs are not shown here - they appear as the actual
  * `.md` in the documents list. Renders nothing when there are no such jobs.
  */
 defineProps({
@@ -26,7 +26,7 @@ function title(job) {
       ></nldd-inline-dialog>
       <nldd-activity-indicator
         v-else
-        :text="`Wordt geconverteerd… — ${title(job)}`"
+        :text="`Wordt geconverteerd… - ${title(job)}`"
         show-text
       ></nldd-activity-indicator>
     </template>
@@ -35,7 +35,7 @@ function title(job) {
 
 <style scoped>
 /* Stack the status rows with a small gap. Custom spacing on top of the design
-   system — reported in the PR. */
+   system - reported in the PR. */
 .conversion-status {
   display: flex;
   flex-direction: column;

--- a/frontend/src/components/DataSourceTable.vue
+++ b/frontend/src/components/DataSourceTable.vue
@@ -120,11 +120,11 @@ const showBody = computed(() => props.drilledIn || expanded.value);
     </template>
 
     <template v-if="showBody">
-      <nldd-inline-dialog v-if="rows.length === 0" text="Geen gegevens — vul in indien relevant">
+      <nldd-inline-dialog v-if="rows.length === 0" text="Geen gegevens - vul in indien relevant">
         <nldd-button v-if="!readonly" slot="actions" size="md" start-icon="plus-small" @click="addRow" text="Voeg toe"></nldd-button>
       </nldd-inline-dialog>
 
-      <!-- One box list per row — identical layout regardless of row count,
+      <!-- One box list per row - identical layout regardless of row count,
            with the delete button at the bottom of each list. Spacers (not a
            flex-gap container) separate the stacked lists. -->
       <template v-for="(row, ri) in rows" :key="row._id ?? ri">
@@ -184,7 +184,7 @@ const showBody = computed(() => props.drilledIn || expanded.value);
 </template>
 
 <style scoped>
-/* The component needs a single root, but it must not generate a box —
+/* The component needs a single root, but it must not generate a box -
  * otherwise it blocks the nldd flex layout (flex-grow / centering of the
  * empty-state inline-dialog) of the enclosing simple-section. */
 .ds-root {

--- a/frontend/src/components/DocumentEditor.vue
+++ b/frontend/src/components/DocumentEditor.vue
@@ -1,11 +1,11 @@
 <script setup>
 /**
- * DocumentEditor — the active-document editor + preview + bottom toolbar,
+ * DocumentEditor - the active-document editor + preview + bottom toolbar,
  * driven by a useDocumentsManager instance passed in as `manager`. The host
  * (sheet master-detail or standalone page) owns the surrounding chrome
  * (title bar / page toolbar) and the list; this is purely the document body.
  *
- * Replaces the old draggable nldd-window: no window, no movable dialog — it
+ * Replaces the old draggable nldd-window: no window, no movable dialog - it
  * renders inline in whatever container the host gives it.
  */
 import { computed, nextTick, ref, watch } from 'vue';
@@ -51,7 +51,7 @@ const {
 // One blocking error at a time, and it replaces the editor body rather than
 // stacking above it: a load failure (docError) that produced no document leaves
 // nothing useful to edit, so it replaces the editor body. A save failure does
-// NOT block — the content is still in openTabs, so it stays an inline notice
+// NOT block - the content is still in openTabs, so it stays an inline notice
 // above the editor (below) and the save can be retried in place. Actionable
 // notices (conflict, draft-present, …) and title validation also stay inline.
 const blockingError = computed(() => {
@@ -77,7 +77,7 @@ async function onConfirmDelete() {
   if (wasOpenDocument) emit('deleted');
 }
 
-// Delete confirmation modal — imperative show()/hide() driven by the manager's
+// Delete confirmation modal - imperative show()/hide() driven by the manager's
 // pendingDeletePath, matching the editor's other NLDD dialogs.
 const deleteModalEl = ref(null);
 watch(pendingDeletePath, async (path) => {

--- a/frontend/src/components/DocumentList.vue
+++ b/frontend/src/components/DocumentList.vue
@@ -2,7 +2,7 @@
 // Presentational werkdocumenten list. Two consumers:
 //  - the launcher sheet: pass `hrefFor` so each document row is a native link
 //    that opens the standalone page in a new tab (open-new-page icon,
-//    target=_blank) — middle-click and modifier-click work as expected;
+//    target=_blank) - middle-click and modifier-click work as expected;
 //  - the standalone page's sidebar: no `hrefFor`, so rows are buttons that
 //    select in place (chevron icon, emits `select`).
 // "Nieuw document" is always a button (it creates, it has no stable URL).

--- a/frontend/src/components/EditSheet.test.js
+++ b/frontend/src/components/EditSheet.test.js
@@ -6,13 +6,13 @@ import EditSheet from './EditSheet.vue';
 // Vite is configured with `isCustomElement: tag => tag.startsWith('nldd-')`
 // (vite.config.js), so Vue's compiler emits raw HTML elements for the
 // `<nldd-sheet>` tag rather than Vue components. The Vue Test Utils
-// `stubs:` map doesn't apply to those — the template ref ends up pointing
+// `stubs:` map doesn't apply to those - the template ref ends up pointing
 // at a real HTMLElement in happy-dom, which has no `show()` / `hide()`
 // methods, so EditSheet's `watch(item, ...)` throws an unhandled
 // rejection on every mount.
 //
 // Register a minimal custom element that *does* expose show/hide so the
-// watcher runs cleanly. We don't care about visual rendering — the tests
+// watcher runs cleanly. We don't care about visual rendering - the tests
 // drive the component via `wrapper.vm.values` / `wrapper.vm.save()`.
 beforeAll(() => {
   if (typeof customElements !== 'undefined' && !customElements.get('nldd-sheet')) {
@@ -128,7 +128,7 @@ describe('EditSheet', () => {
       });
 
       // Fill name, sourceRegulation, sourceOutput by mutating the values
-      // ref directly — querying inputs by index is brittle when several
+      // ref directly - querying inputs by index is brittle when several
       // text-field stubs render.
       wrapper.vm.values.name = 'leeftijd';
       wrapper.vm.values.type = 'number';
@@ -290,7 +290,7 @@ describe('EditSheet', () => {
       wrapper.vm.save();
       await nextTick();
       const events = wrapper.emitted('save');
-      // User-typed value emits as a string — we don't second-guess what
+      // User-typed value emits as a string - we don't second-guess what
       // they meant, and the save path treats explicit edits as opaque
       // text.
       expect(events[0][0].data.source.parameters).toEqual({ threshold: '99' });
@@ -425,7 +425,7 @@ describe('EditSheet', () => {
   });
 
   // Tests drive the combo-box change handlers directly; filter/search UX lives in nldd-combo-box.
-  describe('input — law combo-box flow', () => {
+  describe('input - law combo-box flow', () => {
     const mockLaws = [
       { law_id: 'wet_basisregistratie_personen', name: null, display_name: 'Wet basisregistratie personen', source_id: 'local', source_name: 'Local' },
       { law_id: 'wet_op_de_zorgtoeslag', name: null, display_name: 'Wet op de zorgtoeslag', source_id: 'local', source_name: 'Local' },
@@ -505,7 +505,7 @@ describe('EditSheet', () => {
       wrapper.vm.values.name = 'custom_input';
       wrapper.vm.onOutputComboChange({ detail: { value: 'leeftijd' } });
       expect(wrapper.vm.values.name).toBe('custom_input');
-      // Type is still updated — it's determined by the source output, not the user
+      // Type is still updated - it's determined by the source output, not the user
       expect(wrapper.vm.values.type).toBe('number');
     });
 

--- a/frontend/src/components/EditSheet.vue
+++ b/frontend/src/components/EditSheet.vue
@@ -71,7 +71,7 @@ async function fetchLawsList() {
   try {
     lawsCache = await apiFetchJson(lawsListUrl(props.trajectRef, 'limit=1000'));
   } catch {
-    // HTTP or network failure — the law combobox just offers no
+    // HTTP or network failure - the law combobox just offers no
     // suggestions; nothing is cached so the next open retries.
     return [];
   }
@@ -103,7 +103,7 @@ async function fetchOutputsForLaw(lawId) {
       `/api/corpus/laws/${encodeURIComponent(lawId)}/outputs`,
     );
   } catch {
-    // HTTP or network failure — no output suggestions for this law.
+    // HTTP or network failure - no output suggestions for this law.
     availableOutputs.value = [];
   } finally {
     outputsLoading.value = false;
@@ -146,7 +146,7 @@ function onOutputComboChange(event) {
     if (!values.value.name) {
       values.value.name = outputName;
     }
-    // Always set type from the source output — it's determined by the external law
+    // Always set type from the source output - it's determined by the external law
     values.value.type = match.output_type || 'string';
     // Always reset and pre-populate source parameters from the selected
     // output's article. Without the unconditional reset, switching to an
@@ -234,7 +234,7 @@ watch(() => props.item, async (item) => {
     //     changed we emit the original typed value.
     //   - Non-scalar parameter values (objects/arrays) are stashed in
     //     `sourceParametersOverflow` and merged back on save so they
-    //     survive untouched — the user can only edit those via the YAML
+    //     survive untouched - the user can only edit those via the YAML
     //     pane.
     const params = item.data?.source?.parameters;
     const paramList = [];
@@ -310,7 +310,7 @@ function save() {
     if (!name.trim()) return;
     const data = { name: name.trim(), type };
     // Reduce the form's parameter rows back into a plain object. Skip
-    // rows with an empty key — they're either still being typed or were
+    // rows with an empty key - they're either still being typed or were
     // added and abandoned. Duplicate keys: last write wins (matches what
     // serializing an object would do anyway).
     //
@@ -337,7 +337,7 @@ function save() {
     // Emit `source` only when at least regulation OR output is set.
     // Parameters alone don't make a valid source block (the schema
     // requires regulation when source is present), so if the user has
-    // cleared both regulation and output we drop the entire source —
+    // cleared both regulation and output we drop the entire source -
     // including any overflow params. This matches the user's intent
     // ("disable the source binding") and avoids producing a malformed
     // source: { parameters: {...} } that would fail schema validation.
@@ -427,7 +427,7 @@ const sectionLabels = {
                        (dirty marking); @change delivers the value the
                        field normalises on commit/blur (locale/step). The
                        assignment is idempotent so a same-tick double-fire
-                       is harmless — do not drop @change. -->
+                       is harmless - do not drop @change. -->
                   <nldd-number-field
                     :value="values.displayValue"
                     :step="values.controlType === 'currency' ? '0.01' : (values.controlType === 'percentage' ? '0.001' : undefined)"
@@ -623,7 +623,7 @@ const sectionLabels = {
  *
  * The previous attempt used `display: grid` on the host element, but
  * `nldd-list-item` is a Lit web component whose internal shadow DOM lays
- * out slotted children with its own flexbox — the user-side grid rule
+ * out slotted children with its own flexbox - the user-side grid rule
  * is silently ignored, so the labels collapsed and the value fields
  * shrank to ~80px wide.
  *

--- a/frontend/src/components/LawGraphView.vue
+++ b/frontend/src/components/LawGraphView.vue
@@ -27,11 +27,11 @@ const props = defineProps({
   // enters trace-stepping mode: step list + detail panel appear below
   // the graph and nodes/edges get .trace-active/.trace-visited classes.
   result: { type: Object, default: null },
-  // The scenario's entry output name — pins the "▶ start" marker to the
+  // The scenario's entry output name - pins the "▶ start" marker to the
   // matching output leaf on the root law.
   outputName: { type: String, default: null },
   expectations: { type: Object, default: () => ({}) },
-  /** Active traject ref — routes dependency reads through the
+  /** Active traject ref - routes dependency reads through the
    *  traject's backend so the graph mirrors what the editor pane shows. */
   trajectRef: { type: String, default: null },
 });
@@ -83,7 +83,7 @@ function stepIsVisible(step) {
 
 // Filter-aware nav: when the user has the "Met highlights" filter on,
 // Vorige/Volgende must skip context-only steps that aren't rendered in
-// the list — otherwise the counter advances onto a row that the user
+// the list - otherwise the counter advances onto a row that the user
 // can't see and the step list looks frozen.
 function nextVisible() {
   for (let i = currentStepIdx.value + 1; i < steps.value.length; i++) {
@@ -123,7 +123,7 @@ const selectedRoot = ref(null);
 // Laws the user hid via the close button (visible but excluded).
 const hiddenLaws = ref(new Set());
 
-// Reset local UI state when the underlying law changes — the hidden set /
+// Reset local UI state when the underlying law changes - the hidden set /
 // selection shouldn't bleed into an unrelated graph.
 watch(() => props.lawId, () => {
   selectedRoot.value = null;
@@ -173,7 +173,7 @@ function handleNodeClick({ node, event }) {
   // A11Y LIMITATION (tracked for PR3 polish): the close button on a root
   // law node is detected here by DOM sniffing the click target. Keyboard
   // activation (Enter/Space on a focused button) dispatches a synthetic
-  // `click` that bubbles normally, so this path works for keyboards too —
+  // `click` that bubbles normally, so this path works for keyboards too -
   // but the close button has no independent activation path if Vue Flow
   // ever stops forwarding inner clicks via `node-click`. Wiring a proper
   // data-callback from the custom node component is deferred to PR3.
@@ -190,14 +190,14 @@ function handleNodeClick({ node, event }) {
 
 // Vue Flow's MiniMap takes a flat colour string (not a CSS variable),
 // so the palette token has to be resolved through getComputedStyle.
-// That call is one-shot and untracked — wrapping it in a computed
+// That call is one-shot and untracked - wrapping it in a computed
 // would need a fragile "touch colorScheme to register a dep" trick.
 // Instead, push the resolved value into a plain ref from a watcher:
 // the colorScheme dependency is now visible in the watch() argument
 // list, so a future cleanup can't accidentally drop it.
 //
 // OS-level scheme changes while colorScheme === 'auto' aren't tracked
-// (the composable doesn't expose that). Acceptable — the marker is
+// (the composable doesn't expose that). Acceptable - the marker is
 // decorative and the next graph re-render picks the new value up.
 const { colorScheme } = useColorScheme();
 const miniMapMarkerColor = ref('#ccc');
@@ -254,7 +254,7 @@ const currentStep = computed(() =>
         </VueFlow>
       </div>
 
-      <!-- Trace stepper — shown after a scenario runs -->
+      <!-- Trace stepper - shown after a scenario runs -->
       <div v-if="hasTrace" class="law-graph-trace">
         <div class="law-graph-trace__toolbar">
           <button
@@ -316,7 +316,7 @@ const currentStep = computed(() =>
 .law-graph-view {
   /* Fill the pane. nldd-page wraps slotted content in a flex column,
    * so flex-grow + min-height: 0 lets us claim every pixel the parent
-   * gives us — works equally inside a side pane and inside a bottom
+   * gives us - works equally inside a side pane and inside a bottom
    * sheet, no chrome-height arithmetic needed. */
   display: flex;
   flex-direction: column;

--- a/frontend/src/components/MachineReadable.test.js
+++ b/frontend/src/components/MachineReadable.test.js
@@ -80,7 +80,7 @@ async function clickBewerk(wrapper, index) {
 }
 
 // Add buttons all carry a stable data-testid (`add-{section}-btn`); using
-// it sidesteps copy churn — we changed labels from "Nieuwe X" to
+// it sidesteps copy churn - we changed labels from "Nieuwe X" to
 // "X toevoegen" and don't want the test to break on the next reword.
 const ADD_BTN_TESTID = {
   definitie: 'add-def-btn',

--- a/frontend/src/components/MachineReadable.vue
+++ b/frontend/src/components/MachineReadable.vue
@@ -14,7 +14,7 @@ const props = defineProps({
   saving: { type: Boolean, default: false },
   /** Error from the most recent save attempt (Error instance or null) */
   saveError: { type: Object, default: null },
-  /** Active traject ref — scopes the corpus-laws lookup so display
+  /** Active traject ref - scopes the corpus-laws lookup so display
    *  names reflect the traject's view (including its in-progress edits). */
   trajectRef: { type: String, default: null },
 });
@@ -26,12 +26,12 @@ const emit = defineEmits([
   'open-edit',
   'init-mr',
   'add-action',
-  // The Machine-pane "Opslaan" button — a real backend save of the law.
+  // The Machine-pane "Opslaan" button - a real backend save of the law.
   'save',
   /**
    * Patch a single machine_readable field in place (no backend save, just
    * marks the model dirty). Same `{ section, key, data }` shape the parent's
-   * handleSave dispatches on — used for inline edits like the produces
+   * handleSave dispatches on - used for inline edits like the produces
    * dropdowns. Distinct from `save` (which is the law PUT).
    */
   'patch',
@@ -160,7 +160,7 @@ function editOutput(index) {
   if (raw) emit('open-edit', { section: 'output', index, data: snapshot(raw) });
 }
 
-// Delete handlers — stage a confirmation in `pendingDelete`, then on
+// Delete handlers - stage a confirmation in `pendingDelete`, then on
 // confirm emit the delete event with the section + identity of the row.
 // The parent (EditorApp) is the source of truth for machineReadable,
 // so all mutations live there. The modal-dialog confirmation is here
@@ -182,7 +182,7 @@ const pendingSectionLabel = computed(
 watch(pendingDelete, async (val) => {
   await nextTick();
   // Guard against test envs where the modal-dialog custom element isn't
-  // upgraded — the ref then holds a plain HTMLElement without show/hide.
+  // upgraded - the ref then holds a plain HTMLElement without show/hide.
   // Optional-chaining on `?.show()` would still throw because it only
   // skips when `.value` is nullish, not when `.show` itself is undefined.
   const el = deleteModalEl.value;

--- a/frontend/src/components/MobileTrajectSheet.vue
+++ b/frontend/src/components/MobileTrajectSheet.vue
@@ -12,7 +12,7 @@ import TrajectCreateForm from './TrajectCreateForm.vue';
 
 // Mobiele (sm) samenvoeging van de traject-knop en de artikel-tabbladen-knop:
 // één full-width knop die een bottom-sheet opent met een "Traject"-lijst (de
-// menu-acties + traject-switcher + nieuw traject) en — in de editor — een
+// menu-acties + traject-switcher + nieuw traject) en - in de editor - een
 // "Artikelen"-lijst (de open tabbladen). md/lg houden TrajectMenu + de
 // document-tab-bar. Hergebruikt dezelfde composables/handlers als TrajectMenu.
 const { trajects, activeTrajectRef, activeTraject, loading, createTraject } = useTrajects();
@@ -86,7 +86,7 @@ async function selectTraject(t) {
   await goToTraject(t.ref);
 }
 
-// --- Traject-acties (sluiten dan openen — geen sheet-over-sheet) ---
+// --- Traject-acties (sluiten dan openen - geen sheet-over-sheet) ---
 function openDocuments() {
   closeSheet();
   documentsSheet.open();
@@ -231,7 +231,7 @@ onBeforeUnmount(() => {
           </nldd-inline-dialog>
         </nldd-simple-section>
 
-        <!-- Nieuw traject — zelfde formulier als de aanmaakpagina, in de sheet -->
+        <!-- Nieuw traject - zelfde formulier als de aanmaakpagina, in de sheet -->
         <nldd-simple-section v-else-if="sheetMode === 'create'">
           <TrajectCreateForm
             ref="createFormEl"
@@ -243,7 +243,7 @@ onBeforeUnmount(() => {
 
         <!-- Lijsten -->
         <nldd-simple-section v-else>
-          <!-- Acties van het actieve traject — bovenaan, zonder titel (de
+          <!-- Acties van het actieve traject - bovenaan, zonder titel (de
                sheet-titel dekt dit al). -->
           <nldd-list v-if="activeTraject" variant="box" arrow-navigation>
             <nldd-list-item size="md" button @click="openDocuments">
@@ -263,7 +263,7 @@ onBeforeUnmount(() => {
             </nldd-list-item>
           </nldd-list>
 
-          <!-- Trajecten-switcher + nieuw traject — eigen lijst met titel. -->
+          <!-- Trajecten-switcher + nieuw traject - eigen lijst met titel. -->
           <nldd-spacer v-if="activeTraject" size="24"></nldd-spacer>
           <nldd-title size="5"><h2>Trajecten</h2></nldd-title>
           <nldd-spacer size="8"></nldd-spacer>
@@ -290,7 +290,7 @@ onBeforeUnmount(() => {
           </nldd-list>
 
           <!-- Lijst 2: Artikelen (editor met open tabbladen). Reorder staat
-               tijdelijk uit op sm — eerst nog wat drag-bugs oplossen. -->
+               tijdelijk uit op sm - eerst nog wat drag-bugs oplossen. -->
           <template v-if="hasArticles">
             <nldd-spacer size="24"></nldd-spacer>
             <nldd-title size="5"><h2>Artikelen</h2></nldd-title>

--- a/frontend/src/components/NoteCreator.test.js
+++ b/frontend/src/components/NoteCreator.test.js
@@ -153,7 +153,7 @@ describe('NoteCreator', () => {
       },
     });
     await nextTick();
-    // Only the warning + a single "Annuleren" — no type picker, no save.
+    // Only the warning + a single "Annuleren" - no type picker, no save.
     expect(w.find('[data-testid="note-creator-status"]').exists()).toBe(true);
     expect(w.find('[data-testid="note-save"]').exists()).toBe(false);
     expect(w.find('[data-testid="note-comment-text"]').exists()).toBe(false);

--- a/frontend/src/components/NoteCreator.vue
+++ b/frontend/src/components/NoteCreator.vue
@@ -1,13 +1,13 @@
 <script setup>
 /**
- * NoteCreator — the note authoring form (RFC-018 write path, steps 3-5).
+ * NoteCreator - the note authoring form (RFC-018 write path, steps 3-5).
  *
  * Opened by AnnotatedText when the user selects text and clicks "Notitie".
  * Receives the raw [start,end) range the selection mapped to (selectionToRaw
  * already did the DOM->raw work). This component builds the TextQuoteSelector
  * (growing context until it is unique), lets the user pick a motivation and
  * fill the matching body, and emits a complete W3C Annotation object. It does
- * not persist — useDraftNotes (owned by EditorApp) does, so the new note
+ * not persist - useDraftNotes (owned by EditorApp) does, so the new note
  * highlights live alongside committed ones.
  */
 import { ref, computed, watch } from 'vue';
@@ -28,7 +28,7 @@ const props = defineProps({
   // Anchor element for the popover (the <mark>-less selection rectangle is
   // gone once the form opens, so AnnotatedText passes a stable anchor).
   anchor: { type: Object, default: null },
-  // Active traject ref. Required to surface the "Document" link mode —
+  // Active traject ref. Required to surface the "Document" link mode -
   // without a traject there is no documents folder to pick from.
   trajectRef: { type: String, default: '' },
 });
@@ -166,7 +166,7 @@ function reset() {
 // True while our own cancel()/save() is inside hidePopover(), so a `close`
 // dispatched synchronously from that call is recognized as self-inflicted.
 // The native popover spec queues toggle (and thus nldd's close) as a task,
-// which lands after the parent nulled `range` — the range guard below covers
+// which lands after the parent nulled `range` - the range guard below covers
 // that regime. This flag covers the synchronous regime, so onPopoverClose
 // stays correct regardless of how nldd-popover dispatches.
 let selfClosing = false;
@@ -189,7 +189,7 @@ function cancel() {
 // nldd-popover is popover="auto": the browser light-dismisses it on an
 // outside click or Esc without going through cancel(). The component fires
 // `close` on every dismissal, so a close that arrives while the form is
-// still open (range set) is an external dismiss and must cancel — otherwise
+// still open (range set) is an external dismiss and must cancel - otherwise
 // the parent keeps creatorOpen=true and suppresses the "Notitie" button for
 // every later selection. Closes from our own save()/cancel()/teardown are
 // filtered by the selfClosing flag (synchronous dispatch) or arrive after
@@ -272,7 +272,7 @@ function buildBody() {
   return text;
 }
 
-// One sharp line per failure reason — what went wrong + the single most
+// One sharp line per failure reason - what went wrong + the single most
 // useful fix. No bullet wall: the reason from buildSelector already
 // distinguishes "too common" from "not located", so the message can be
 // precise instead of listing every possibility.

--- a/frontend/src/components/OperationSettings.test.js
+++ b/frontend/src/components/OperationSettings.test.js
@@ -9,7 +9,7 @@ import OperationSettings from './OperationSettings.vue';
 // via wrapper.vm), so we leave them as raw HTMLElement and only stub the
 // methods that the watcher / lifecycle would otherwise complain about.
 beforeAll(() => {
-  // No custom element registration needed for OperationSettings — it
+  // No custom element registration needed for OperationSettings - it
   // doesn't call show()/hide() on any host the way EditSheet does.
 });
 
@@ -41,7 +41,7 @@ function mountOp(node, { editable = true } = {}) {
   });
 }
 
-describe('OperationSettings — AGE op', () => {
+describe('OperationSettings - AGE op', () => {
   describe('operationValues', () => {
     it('returns date_of_birth and reference_date rows for an AGE node', () => {
       const node = {
@@ -198,7 +198,7 @@ describe('OperationSettings — AGE op', () => {
   });
 });
 
-describe('OperationSettings — DATE_DIFF op', () => {
+describe('OperationSettings - DATE_DIFF op', () => {
   function dateDiffNode() {
     return {
       operation: 'DATE_DIFF',

--- a/frontend/src/components/OperationSettings.vue
+++ b/frontend/src/components/OperationSettings.vue
@@ -67,9 +67,9 @@ const canAddValue = computed(() => {
   if (op === 'NOT' || op === 'IF' || op === 'SWITCH') return false;
   // NOT_NULL never takes a value field (it only checks the subject is non-null)
   if (op === 'NOT_NULL') return false;
-  // AGE has a fixed shape (date_of_birth + reference_date) — no add slot.
+  // AGE has a fixed shape (date_of_birth + reference_date) - no add slot.
   if (op === 'AGE') return false;
-  // DATE_DIFF has a fixed shape (from + to + in) — no add slot.
+  // DATE_DIFF has a fixed shape (from + to + in) - no add slot.
   if (op === 'DATE_DIFF') return false;
   // Comparison ops always have exactly subject + value (or just subject for
   // NOT_NULL); operationValues pushes both unconditionally, so addValue() has
@@ -91,7 +91,7 @@ function canRemoveValue(val) {
   if (isComparisonOp.value && (val._kind === 'subject' || val._kind === 'value')) return false;
   // NOT needs value
   if (op === 'NOT' && val._kind === 'value') return false;
-  // AGE has two fixed structural slots — neither can be deleted.
+  // AGE has two fixed structural slots - neither can be deleted.
   if (op === 'AGE' && (val._kind === 'date_of_birth' || val._kind === 'reference_date')) return false;
   if (op === 'DATE_DIFF' && (val._kind === 'from' || val._kind === 'to' || val._kind === 'in')) return false;
   // IF and SWITCH share the cases[]/default schema and both need a default branch
@@ -102,7 +102,7 @@ function canRemoveValue(val) {
     if (op === 'IF') return false;
     if (op === 'SWITCH' && node.cases.length <= 1) return false;
   }
-  // AND/OR/arithmetic ops need at least one entry — block removal of the
+  // AND/OR/arithmetic ops need at least one entry - block removal of the
   // last condition or value so the user can't drain conditions: [] / values: []
   // and produce a semantically undefined node.
   if (val._kind === 'conditions' && Array.isArray(node?.conditions) && node.conditions.length <= 1) return false;
@@ -150,7 +150,7 @@ const operationValues = computed(() => {
     const isSwitch = node.operation === 'SWITCH';
     if (Array.isArray(node.cases)) {
       node.cases.forEach((c, i) => {
-        const prefix = isSwitch ? `Geval ${i + 1} — ` : '';
+        const prefix = isSwitch ? `Geval ${i + 1} - ` : '';
         if (c?.when !== undefined) vals.push({ _label: `${prefix}Als`, _value: c.when, _kind: 'case-when', _caseIndex: i });
         if (c?.then !== undefined) vals.push({ _label: `${prefix}Dan`, _value: c.then, _kind: 'case-then', _caseIndex: i });
       });
@@ -333,7 +333,7 @@ function changeOperationType(newType) {
     delete node.to;
     delete node.in;
   } else if (newType === 'AGE') {
-    // AGE has two fixed structural slots — seed both as empty strings so
+    // AGE has two fixed structural slots - seed both as empty strings so
     // the user can fill them via the form. Strip every other slot so the
     // node is shaped exactly like the engine's `ActionOperation::Age`.
     if (node.date_of_birth === undefined) node.date_of_birth = '';
@@ -398,10 +398,10 @@ function updateValue(val, event) {
 function updateDropdownValue(val, event) {
   const selected = event.target.value;
   // The '__nested__' sentinel is just the current operation's own row in
-  // the list — re-picking it means "keep the operation" (edit it via the
+  // the list - re-picking it means "keep the operation" (edit it via the
   // pencil), so it's a no-op. Picking anything else (a variable, literal,
   // or the empty option) replaces the value, including replacing a nested
-  // operation — otherwise switching e.g. an IF op to $bsn silently does
+  // operation - otherwise switching e.g. an IF op to $bsn silently does
   // nothing and never marks the action dirty. Consequence: picking the
   // empty "Selecteer…" option discards a nested op tree in one click,
   // same destructive trade as changeValueKind(); recovery is the
@@ -413,7 +413,7 @@ function updateDropdownValue(val, event) {
 
 
 // The Type radio (Waarde / Operatie) only applies to value slots that can
-// hold either a literal or a nested operation — not subject/date pickers.
+// hold either a literal or a nested operation - not subject/date pickers.
 function canChangeValueKind(val) {
   return val._kind !== 'subject'
     && val._kind !== 'date_of_birth'
@@ -439,7 +439,7 @@ function changeValueKind(val, kind) {
   } else if (kind === 'value' && isOp) {
     // Replaces the whole nested op with '' in one click. Deliberately
     // unconfirmed: this matches the equally-destructive sibling
-    // removeValue() in the same menu — both rely on the ActionSheet
+    // removeValue() in the same menu - both rely on the ActionSheet
     // "Annuleren" snapshot-restore as the single, consistent undo,
     // rather than introducing a one-off confirm dialog here.
     applyValueMutation(val, '');
@@ -487,7 +487,7 @@ function addValue() {
   // Don't inject values[] into nodes with structural value slots
   // (NOT uses single 'value', IF uses when/then/else, SWITCH uses cases/default)
   if (node.operation === 'NOT' || node.operation === 'IF' || node.operation === 'SWITCH') return;
-  // NOT_NULL is a unary check on subject only — never a value
+  // NOT_NULL is a unary check on subject only - never a value
   if (node.operation === 'NOT_NULL') return;
 
   if (Array.isArray(node.values)) {
@@ -690,7 +690,7 @@ function addValue() {
  * this component. The rule is in an unscoped `<style>` block alongside the
  * rest of the file's selectors (Vue scoped styles can't reach into NLDD
  * shadow DOM), so the class name is the only thing preventing bleed into
- * other components — keep the class unique to this component. */
+ * other components - keep the class unique to this component. */
 .operation-settings__title h4 {
   margin: 0;
 }

--- a/frontend/src/components/ScenarioBuilder.vue
+++ b/frontend/src/components/ScenarioBuilder.vue
@@ -1,6 +1,6 @@
 <script>
 // Parsed-version cache, MODULE-scoped (shared across all ScenarioBuilder
-// instances) so it survives remounts — switching the panel view away and back,
+// instances) so it survives remounts - switching the panel view away and back,
 // or opening another article, remounts this component. The data-source column
 // type map (`rebuildExternalFieldTypeMap`) is derived from these YAMLs, while
 // the WASM engine that gates whether `loadAllDependencies` re-fetches a dep is
@@ -81,7 +81,7 @@ const {
 
 // Mismatch warning: the selected scenario file declares execution targets
 // that do not include the opened law. Running it would evaluate that other
-// law — surface this instead of letting the run fail confusingly.
+// law - surface this instead of letting the run fail confusingly.
 const selectedScenarioEntry = computed(
   () => scenarioFiles.value.find((sf) => sf.filename === selectedScenarioFile.value) || null,
 );
@@ -194,7 +194,7 @@ async function fetchLawVersions(lawId) {
   const list = Array.isArray(yamls) ? yamls : [];
   // Only cache a non-empty result. An empty array (unknown/not-yet-harvested
   // law) must stay uncached so a retry after harvest re-fetches rather than
-  // returning the stale `[]` — `[]` is truthy, so caching it would short-
+  // returning the stale `[]` - `[]` is truthy, so caching it would short-
   // circuit the `if (versionsCache[lawId])` guard forever.
   if (list.length > 0) versionsCache[lawId] = list;
   return list;
@@ -209,7 +209,7 @@ const claimDependencyLoad = useLatest();
 // Debounced mirror of props.lawYaml. While the user types in the text or
 // machine pane, `lawYaml` changes on every keystroke (currentLawYaml re-dumps
 // the whole doc), which would re-run the expensive dependency reload + corpus
-// scan and toggle depsReady — making the scenario panel flicker. We only let
+// scan and toggle depsReady - making the scenario panel flicker. We only let
 // the cascade below fire ~300ms after the last edit. Same setTimeout debounce
 // pattern as ScenarioForm.vue's execute.
 const debouncedLawYaml = ref(props.lawYaml);
@@ -218,8 +218,8 @@ let lawYamlDebounce = null;
 watch(() => props.lawYaml, (val, prev) => {
   // First population or cleared→set (no prior law loaded): apply immediately so
   // the initial dependency load isn't delayed by 300ms. Any change from an
-  // existing value — keystroke edits, but also switching to another article of
-  // the already-open law — debounces.
+  // existing value - keystroke edits, but also switching to another article of
+  // the already-open law - debounces.
   clearTimeout(lawYamlDebounce);
   if (!prev) {
     debouncedLawYaml.value = val;
@@ -273,7 +273,7 @@ async function runDependencyLoad() {
     for (const depId of allDeps) {
       try {
         // Fetch versions unconditionally to populate versionsCache for the
-        // data-source type map (same rationale as loadAllDependencies — the
+        // data-source type map (same rationale as loadAllDependencies - the
         // map is built from cached YAMLs, independent of engine state); load
         // into the shared engine only if it isn't already present.
         const yamls = await fetchLawVersions(depId);
@@ -287,13 +287,13 @@ async function runDependencyLoad() {
   }
 
   if (isCurrent()) {
-    // The explicitly-declared deps are loaded — the panel is usable now, so
+    // The explicitly-declared deps are loaded - the panel is usable now, so
     // mark ready and let scenarios auto-execute. Implementing regulations
     // (IoC) load in the background: their corpus scan can be slow and is
     // best-effort, so it must not gate the panel. `loadImplementors` is
     // guarded to run at most once per law.
     //
-    // Deliberately fire-and-forget — there is no AbortController. If this
+    // Deliberately fire-and-forget - there is no AbortController. If this
     // component unmounts mid-scan the promise keeps running, which is safe:
     // Vue ignores ref writes after unmount, the shared WASM engine outlives
     // the component, and the guard resets on error so a fresh mount retries.
@@ -314,7 +314,7 @@ async function runDependencyLoad() {
 
 // `debouncedLawYaml`, `props.ready` and `formState` settle on separate ticks
 // during the initial load. Without coalescing, each settle fires this watch
-// and starts (then abandons, via the latest-guard) a full dependency scan — up
+// and starts (then abandons, via the latest-guard) a full dependency scan - up
 // to four overlapping corpus-wide reloads per open. A short debounce collapses
 // the burst into a single run after the inputs have settled.
 let depsScheduleTimer = null;
@@ -404,7 +404,7 @@ watch(
 // the execution-trace sheet (default), 'graph' for the law-graph sheet.
 function onShowDetails(index, view = 'trace') {
   // Prefer fresh data from the form ref, but its state may have been reset
-  // after a save/reload — fall back to the cached result in that case.
+  // after a save/reload - fall back to the cached result in that case.
   const formRef = scenarioRefs.value[index];
   const fresh = formRef?.getExecutionData?.();
   const hasFresh = fresh && (fresh.result || fresh.traceText || fresh.error);
@@ -421,7 +421,7 @@ function onShowDetails(index, view = 'trace') {
     // note on ScenarioForm.execute) so `running` is reset in its finally
     // before getExecutionData() is read here. The "Bezig met uitvoeren…"
     // branch in ExecutionTraceView and the lastRunning/lastReload
-    // scaffolding in EditorApp are therefore unreachable *by design* —
+    // scaffolding in EditorApp are therefore unreachable *by design* -
     // deliberately kept so the async path lights up for free if that
     // contract is ever lifted. Not dead code to be removed in isolation.
     running: !!fresh?.running,
@@ -438,7 +438,7 @@ function onShowDetails(index, view = 'trace') {
     // Known limitation: `index` is captured by value and the result
     // sheet can outlive the scenario sheet. It stays correct in practice
     // because scenario count/order is stable across an inputs-only save
-    // and cancelEdits() no longer replaces formState — so nothing
+    // and cancelEdits() no longer replaces formState - so nothing
     // reindexes scenarios while the sheet is open, and the UI has no
     // reorder/delete-scenario affordance. If the index ever did go out
     // of bounds, reExecute()'s optional chaining makes it a safe no-op
@@ -527,12 +527,12 @@ async function onSaveAndShow() {
 
 function cancelEdits() {
   // Discard unsaved edits *without* replacing formState. Re-parsing it
-  // remounts the whole overview — clearing cached results/refs (via the
+  // remounts the whole overview - clearing cached results/refs (via the
   // formState watcher) and resetting the scenarios-pane scroll position.
   // Edits live entirely in the edited ScenarioForm's local refs (only
   // synced into formState on save), so asking that form to re-init from
-  // its unchanged props discards them while leaving the overview — and
-  // its scroll position — intact, exactly as when nothing was edited.
+  // its unchanged props discards them while leaving the overview - and
+  // its scroll position - intact, exactly as when nothing was edited.
   const idx = selectedScenarioIndex.value;
   if (isDirty.value && idx !== null) {
     scenarioRefs.value[idx]?.discardEdits?.();
@@ -658,7 +658,7 @@ defineExpose({ save: onSave });
           dismiss-text="Annuleer"
           @dismiss="cancelEdits"
         ></nldd-top-title-bar>
-        <!-- Drilled-in header: its own bar — a back button to the scenario
+        <!-- Drilled-in header: its own bar - a back button to the scenario
              overview (the data-source heading lives in the content). -->
         <nldd-top-title-bar
           v-else
@@ -719,7 +719,7 @@ defineExpose({ save: onSave });
 /* Positioning context for the full-pane loading overlay. min-height fills the
    pane's scroll viewport so the backdrop covers the whole area, not just the
    (possibly empty) content. Flex column so the simple-section grows to the full
-   height — its empty-state inline-dialog then self-centers like elsewhere,
+   height - its empty-state inline-dialog then self-centers like elsewhere,
    instead of sitting at the top. The absolute overlay is unaffected. */
 .sb-pane {
   display: flex;

--- a/frontend/src/components/ScenarioForm.vue
+++ b/frontend/src/components/ScenarioForm.vue
@@ -115,7 +115,7 @@ const errorTraceText = ref(null);
 // All edits live in these refs and are only written back to formState on
 // save, so re-initialising here fully discards unsaved edits. Used both
 // when the scenario/setup props change and when the parent discards edits
-// (cancel / click-away) without replacing formState — see ScenarioBuilder.
+// (cancel / click-away) without replacing formState - see ScenarioBuilder.
 function discardEdits() {
   calculationDate.value = props.setup.calculationDate || new Date().toISOString().slice(0, 10);
   parameterValues.value = Object.fromEntries(
@@ -144,7 +144,7 @@ watch([() => props.setup, () => props.scenario], discardEdits, { deep: true });
 
 // Column types come from the dependency graph, which loads asynchronously after
 // the panel mounts. Re-type the data-source columns in place when the map
-// arrives — without rebuilding rows, so unsaved cell edits survive.
+// arrives - without rebuilding rows, so unsaved cell edits survive.
 watch(() => props.externalFieldTypeMap, () => {
   for (const ds of dataSources.value) {
     ds.fields = ds.fields.map((f) => typeField(f.name));
@@ -154,7 +154,7 @@ watch(() => props.externalFieldTypeMap, () => {
 // CONTRACT: execute() must stay fully synchronous. The WASM engine runs
 // in-process with no I/O, so `result`/`error`/`running` are all settled
 // (running reset in finally) before this returns, and callers read them
-// back immediately from the return value or getExecutionData() — e.g.
+// back immediately from the return value or getExecutionData() - e.g.
 // ScenarioBuilder.reExecute() / onSaveAndShow() and the auto-execute
 // loop. Introducing any await/timer/microtask here would make those
 // callers observe `running: true` and stale data. If async execution is
@@ -285,11 +285,11 @@ const hasExpectations = computed(() => Object.keys(expectations.value).length > 
 // Minimal field-level validation: a missing date, or an empty input that
 // caused an execution error, is marked invalid so the user sees which
 // field to fill (the raw engine message still shows as context). No
-// auto-revert — the input stays. We deliberately do NOT map engine error
+// auto-revert - the input stays. We deliberately do NOT map engine error
 // strings onto fields (incl. substring-matching the error against a param
 // name): that produced confusing cross-field invalid states (changing bsn
 // flagged loon_uit_dienstbetrekking) and was explicitly reverted. The
-// broad "any error + this field empty" mark is the accepted trade — it
+// broad "any error + this field empty" mark is the accepted trade - it
 // can over-mark a legitimately-blank optional param, but it never
 // mis-points at an unrelated field, which was the worse failure.
 const dateInvalid = computed(() => !calculationDate.value);
@@ -412,7 +412,7 @@ const dateErrorId = useId();
 
 <style scoped>
 /* Single component root required for v-show, but it must not generate a
- * box — otherwise it blocks the enclosing simple-section's nldd flex
+ * box - otherwise it blocks the enclosing simple-section's nldd flex
  * layout (flex-grow / centering of an empty data source's dialog). */
 .sf-root {
   display: contents;

--- a/frontend/src/components/ScenarioParameterInput.vue
+++ b/frontend/src/components/ScenarioParameterInput.vue
@@ -9,7 +9,7 @@ import { centsToEuros, eurosToCents } from '../utils/currency.js';
 //
 // Round-trip is handled here: scenario values often arrive as strings parsed
 // from Gherkin ("true" / "1500" / "2025-01-01"), and downstream consumers
-// (engine execute + Gherkin re-serialisation) accept real JS types — so we
+// (engine execute + Gherkin re-serialisation) accept real JS types - so we
 // coerce to the right type on the way out. See ScenarioForm.execute() and
 // formMapper.syncEditedValues().
 const props = defineProps({

--- a/frontend/src/components/SearchPopover.vue
+++ b/frontend/src/components/SearchPopover.vue
@@ -25,14 +25,14 @@ const needsLogin = computed(() => oidcConfigured.value && !authenticated.value);
 const search = ref('');
 const popoverRef = ref(null);
 const useCenteredPosition = ref(true);
-// md only: popover anchors below the trigger button — clicking outside closes
+// md only: popover anchors below the trigger button - clicking outside closes
 // it, so an explicit Sluit button is just clutter. On sm (full-height sheet)
 // and lg (centered overlay) the user needs an explicit way to close.
 const isAnchored = ref(false);
 
 // Source of truth: @nldd/design-system's `assets/styles/breakpoints.ts`
 // (smMax: 640px, mdMin: 641px, mdMax: 1007px, lgMin: 1008px). Keep in
-// sync until the design system exports breakpoints publicly — currently
+// sync until the design system exports breakpoints publicly - currently
 // the file isn't listed in the package's `exports` field, so a deep
 // import isn't supported. The previous values used `696` for mdMin
 // which didn't match the design-system at all (probably a typo); aligned
@@ -53,7 +53,7 @@ function displayName(law) {
 
 // Results of the server-side corpus search (`?q=`). The corpus index can
 // hold thousands of laws, so the popover queries the backend rather than
-// filtering a preloaded client-side list — that's the only way the search
+// filtering a preloaded client-side list - that's the only way the search
 // can reach every law, not just the first page. Ordered private-repo-first
 // by the backend; `groupedLaws` sections them by source.
 const serverLaws = ref([]);
@@ -72,7 +72,7 @@ const searchFailed = ref(false);
  * priority 0 sorts above the seeded central corpus) and then alphabetically.
  * The popover renders one labelled section per group so a search surfaces
  * matches from the private repo and the central corpus under their own
- * headers — the external wetten.overheid.nl fallback only kicks in when the
+ * headers - the external wetten.overheid.nl fallback only kicks in when the
  * corpus has no match (see `serverLaws` handling below).
  */
 const groupedLaws = computed(() => {
@@ -109,7 +109,7 @@ watch(search, (q) => {
   const term = q.trim();
   if (term.length < MIN_QUERY_LENGTH) {
     // Claim (and discard) a generation so any fetch already in flight
-    // (debounce fired before this clear) is discarded when it resolves —
+    // (debounce fired before this clear) is discarded when it resolves -
     // otherwise it would repopulate serverLaws for the cleared term and
     // fire a spurious BWB search.
     claimSearch();
@@ -201,7 +201,7 @@ function selectLaw(lawId) {
  * from multiple places (e.g. desktop search-field and mobile icon-button)
  * without each one needing a stable ID.
  *
- * Optional `initialSearch` lets the trigger seed the search value — used
+ * Optional `initialSearch` lets the trigger seed the search value - used
  * for the Spotlight-style "type-to-open" UX where pressing a key on the
  * bar's search-field intercepts the keystroke and forwards it as the
  * initial query in the popover.
@@ -217,7 +217,7 @@ async function show(anchorEl, initialSearch = '') {
   useCenteredPosition.value = window.matchMedia(`(min-width: ${BREAKPOINT_LG_MIN}px)`).matches;
   isAnchored.value = window.matchMedia(`(min-width: ${BREAKPOINT_MD_MIN}px) and (max-width: ${BREAKPOINT_LG_MIN - 1}px)`).matches;
   // Wait for Vue to propagate the new `centered` / `top` / `width` props
-  // onto the popover element before opening — otherwise the first
+  // onto the popover element before opening - otherwise the first
   // reposition() inside the popover's toggle handler runs against the
   // previous breakpoint's props (e.g. centered=true held over from lg)
   // and the popover lands in the wrong position. The Lit-side update on
@@ -234,7 +234,7 @@ async function show(anchorEl, initialSearch = '') {
  * updateComplete and would otherwise steal focus back to the host. The
  * `open` event fires AFTER _manageFocus, so our focus call wins last.
  *
- * The shadow-root vs light-DOM lookup is to be defensive — different
+ * The shadow-root vs light-DOM lookup is to be defensive - different
  * design-system versions may render the <input> differently.
  */
 function onPopoverOpen() {
@@ -248,7 +248,7 @@ defineExpose({ show });
 
 <template>
   <!--
-    Two positioning modes — toggled by `show()` based on viewport:
+    Two positioning modes - toggled by `show()` based on viewport:
     - lg+: free-positioned (centered horizontally, top-aligned). Big
       Spotlight-style overlay regardless of which trigger fired show().
     - md: anchored below the trigger button via Floating UI (default).
@@ -274,7 +274,7 @@ defineExpose({ show });
           @input="search = $event.target.value"
           @keydown="onSearchKeydown"
         ></nldd-search-field>
-        <!-- Op md anchort de popover naast de trigger — naast de popover
+        <!-- Op md anchort de popover naast de trigger - naast de popover
              klikken sluit 'm. Op sm (full-height sheet) en lg (centered
              overlay) heeft de gebruiker een expliciete sluit-knop nodig. -->
         <nldd-button v-if="!isAnchored" size="md" text="Sluit" @click="close"></nldd-button>
@@ -339,7 +339,7 @@ defineExpose({ show });
             >
               <nldd-text-cell
                 :text="result.title"
-                :supporting-text="statusText(result.bwb_id, `${result.type} — ${result.bwb_id}`)"
+                :supporting-text="statusText(result.bwb_id, `${result.type} - ${result.bwb_id}`)"
               >
               </nldd-text-cell>
               <nldd-spacer-cell size="8"></nldd-spacer-cell>

--- a/frontend/src/components/TrajectCreateForm.vue
+++ b/frontend/src/components/TrajectCreateForm.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { ref } from 'vue';
 
-// Gedeeld aanmaakformulier voor een traject — gebruikt door de
+// Gedeeld aanmaakformulier voor een traject - gebruikt door de
 // TrajectMenu-sheet en de /editor/nieuw-traject-pagina. Gebouwd op de
 // NLDD-formulierfamilie: nldd-form (light-DOM <form>), nldd-form-field
 // met help-teksten en nldd-form-actions met de submit-knop. Het formulier
@@ -11,7 +11,7 @@ import { ref } from 'vue';
 // krijgt `{ payload }` of `{ error }` terug; `reset()` maakt de velden
 // leeg.
 defineProps({
-  // Foutmelding van de host (validatie of mislukte create) — boven de
+  // Foutmelding van de host (validatie of mislukte create) - boven de
   // acties getoond zodat de melding bij de velden staat.
   error: { type: String, default: null },
   // Create-call onderweg: toont de busy-regel en blokkeert de knop.
@@ -25,14 +25,14 @@ function emptyForm() {
     name: '',
     description: '',
     // When `useCustomRepo` is false the create call omits the repo
-    // fields and the backend falls back to the default MinBZK repo —
+    // fields and the backend falls back to the default MinBZK repo -
     // existing trajects keep their behaviour unchanged.
     useCustomRepo: false,
     repo_owner: '',
     repo_name: '',
     base_branch: 'main',
     // Sub-path within the repo where regulation YAML files live. Empty
-    // means "everything under repo root" — the right default for user
+    // means "everything under repo root" - the right default for user
     // repos dedicated to regulations. Set to e.g. `regulation/nl` when
     // the YAMLs live in a sub-directory.
     repo_path: '',
@@ -46,7 +46,7 @@ function reset() {
 }
 
 // Build the request body. Only attach the repo fields when the toggle
-// is on — leaving them out lets the backend pick the MinBZK default
+// is on - leaving them out lets the backend pick the MinBZK default
 // so existing flows are unchanged for users who don't need a custom
 // repo. Returns { payload } on success or { error } when validation
 // fails.
@@ -174,7 +174,7 @@ function bind(field) {
             <code>{{ form.repo_owner || '…' }}/{{ form.repo_name || '…' }}</code>
             (basis: <code>{{ form.base_branch || 'main' }}</code>).
             Je beheerder moet voor deze repo een <code>CORPUS_AUTH_*_TOKEN</code>
-            env-var hebben gezet — anders krijg je een foutmelding bij aanmaken.
+            env-var hebben gezet - anders krijg je een foutmelding bij aanmaken.
             Commits verschijnen onder je eigen naam (uit je SSO-account), niet
             onder het service-account.
           </p>
@@ -196,7 +196,7 @@ function bind(field) {
       <nldd-activity-indicator
         v-if="busy"
         show-text
-        text="Traject wordt aangemaakt en branch wordt op de remote gezet — dit kan even duren."
+        text="Traject wordt aangemaakt en branch wordt op de remote gezet - dit kan even duren."
       ></nldd-activity-indicator>
 
       <nldd-form-actions>

--- a/frontend/src/components/TrajectDocuments.vue
+++ b/frontend/src/components/TrajectDocuments.vue
@@ -1,6 +1,6 @@
 <script setup>
 /**
- * TrajectDocuments — the werkdocumenten launcher sheet, opened from the traject
+ * TrajectDocuments - the werkdocumenten launcher sheet, opened from the traject
  * menu. It only lists the documents; opening or creating one always happens in
  * a separate browser tab on the standalone WerkdocumentenView page (there is no
  * in-sheet editing anymore). That keeps a single edit surface per document and
@@ -28,7 +28,7 @@ const { jobs: conversionJobs } = jobsPoller;
 
 const browserEl = ref(null);
 // Polling is already running (started when the sheet opened), so just refresh to
-// surface the new job immediately — restarting would reset() and flash the list.
+// surface the new job immediately - restarting would reset() and flash the list.
 const { fileInput, uploadError, onUpload, onFileChange } = useDocumentUpload(uploadDocument, () =>
   jobsPoller.refresh(),
 );

--- a/frontend/src/components/TrajectInfoDialog.test.js
+++ b/frontend/src/components/TrajectInfoDialog.test.js
@@ -77,7 +77,7 @@ describe('TrajectInfoDialog', () => {
     const texts = cellTexts(wrapper);
     expect(texts).toContain('Tariefswijziging 2026');
     expect(texts).toContain('Waarom dit traject');
-    // Scope is merged into Beschrijving — no separate Scope row.
+    // Scope is merged into Beschrijving - no separate Scope row.
     expect(texts).toContain('Beschrijving');
     expect(texts).not.toContain('Scope');
     expect(texts).toContain('bezig');
@@ -91,7 +91,7 @@ describe('TrajectInfoDialog', () => {
     await flushPromises();
 
     // nldd-link compiles to a raw custom element in the test env (vite
-    // isCustomElement), so assert on its attributes — the underlying <a>,
+    // isCustomElement), so assert on its attributes - the underlying <a>,
     // slot text, and auto-rel only exist once the real Lit component
     // upgrades in the browser. We bind href/target/text/rel explicitly so
     // they are present as attributes here.

--- a/frontend/src/components/TrajectInfoDialog.vue
+++ b/frontend/src/components/TrajectInfoDialog.vue
@@ -118,7 +118,7 @@ async function confirmDelete() {
   }
 }
 
-// --- Verlaten (bijdrager) — zelfde bevestigingsmodal als verwijderen. ---
+// --- Verlaten (bijdrager) - zelfde bevestigingsmodal als verwijderen. ---
 const leaveModalEl = ref(null);
 const confirmingLeave = ref(false);
 const leaveBusy = ref(false);
@@ -285,7 +285,7 @@ async function confirmLeave() {
     </nldd-sheet>
   </Teleport>
 
-  <!-- Delete confirmation — NLDD modal, consistent with TrajectDocuments'
+  <!-- Delete confirmation - NLDD modal, consistent with TrajectDocuments'
        delete dialog. -->
   <Teleport to="body">
     <nldd-modal-dialog
@@ -307,7 +307,7 @@ async function confirmLeave() {
     </nldd-modal-dialog>
   </Teleport>
 
-  <!-- Leave confirmation — same NLDD modal pattern as delete, from the
+  <!-- Leave confirmation - same NLDD modal pattern as delete, from the
        contributor's side. -->
   <Teleport to="body">
     <nldd-modal-dialog

--- a/frontend/src/components/TrajectMembersDialog.vue
+++ b/frontend/src/components/TrajectMembersDialog.vue
@@ -35,7 +35,7 @@ function roleLabel(role) {
 }
 
 // A traject must always keep at least one owner, so the sole owner can be
-// neither demoted nor removed — they get no actions menu at all. Promote
+// neither demoted nor removed - they get no actions menu at all. Promote
 // someone else first (or delete the traject).
 const ownerCount = computed(() => members.value.filter((m) => m.role === 'owner').length);
 function canManageMember(m) {
@@ -238,8 +238,8 @@ async function clickRemoveInvite(inv) {
                     <nldd-menu :id="`member-menu-${m.account_id}`" :anchor="`member-more-${m.account_id}`">
                       <!-- Een eigenaar kun je niet rechtstreeks verwijderen (een
                            traject houdt altijd minstens één eigenaar). Degradeer
-                           'm eerst naar bijdrager — dat kan pas als er nóg een
-                           eigenaar is — daarna verschijnt 'Verwijder lid'. -->
+                           'm eerst naar bijdrager - dat kan pas als er nóg een
+                           eigenaar is - daarna verschijnt 'Verwijder lid'. -->
                       <nldd-menu-item
                         v-if="m.role === 'owner'"
                         text="Maak bijdrager"

--- a/frontend/src/components/TrajectMenu.vue
+++ b/frontend/src/components/TrajectMenu.vue
@@ -39,7 +39,7 @@ const documentsSheet = useDocumentsSheet();
 const loginToChooser = useLoginToChooser();
 
 /**
- * Navigate to a traject — push the user into the traject-scoped view of
+ * Navigate to a traject - push the user into the traject-scoped view of
  * the section they are currently in (bibliotheek or editor), at the same
  * law they were viewing. Picking a traject from the bibliotheek keeps you
  * in the bibliotheek; from the editor it keeps you in the editor. Per-tab
@@ -118,7 +118,7 @@ function openInfoForActive() {
 }
 
 // Na een verwijderd traject: stond je erin (de actieve ref eindigt op de
-// laatste 8 hex-tekens van het uuid), navigeer dan naar de sectie-root —
+// laatste 8 hex-tekens van het uuid), navigeer dan naar de sectie-root -
 // editor → trajectkeuze, bibliotheek → gewone bibliotheek. De trajectlijst
 // zelf is al ververst door deleteTraject.
 function onTrajectDeleted(deletedId) {
@@ -137,7 +137,7 @@ function closeCreate() {
 async function selectTraject(t) {
   // `t.ref` is a server-supplied `Option<String>` and serialises to
   // `null` when a `TrajectSummary` is built without calling
-  // `fill_ref()`. Refuse to navigate — silently routing to
+  // `fill_ref()`. Refuse to navigate - silently routing to
   // `/editor/null/...` would just bounce off the trajectRef regex
   // and confuse the user. Treat as a programming error on the
   // backend side, log and bail.
@@ -163,7 +163,7 @@ async function submitCreate() {
   try {
     const created = await createTraject(payload);
     showCreate.value = false;
-    // Jump straight into the new traject — same per-tab navigation as
+    // Jump straight into the new traject - same per-tab navigation as
     // selecting from the dropdown. Mirror the `selectTraject` guard:
     // the backend's `create` handler always calls `fill_ref()` so this
     // shouldn't fire today, but a future refactor that returns a
@@ -196,7 +196,7 @@ async function submitCreate() {
     :horizontal-alignment="fullWidth ? 'left' : undefined"
   ></nldd-button>
   <!-- Logged in: the active traject's actions first, then the traject switcher
-       + create below a divider. "Geen traject" is not an option — you leave
+       + create below a divider. "Geen traject" is not an option - you leave
        traject scope by navigating, not from this menu. -->
   <nldd-menu v-if="authenticated" :id="menuId" :anchor="menuBtnId">
     <nldd-menu-item
@@ -233,7 +233,7 @@ async function submitCreate() {
     ></nldd-menu-item>
   </nldd-menu>
 
-  <!-- Not logged in: no menu — a popover explaining that trajecten unlock
+  <!-- Not logged in: no menu - a popover explaining that trajecten unlock
        once you sign in. -->
   <nldd-popover
     v-else

--- a/frontend/src/components/graph/LawNode.vue
+++ b/frontend/src/components/graph/LawNode.vue
@@ -33,11 +33,11 @@ defineProps({
   /* Translucent ink so the close button sits on any service colour
    * (light or dark mode) without a per-mode override. color-mix on
    * --semantics-content-color picks up the theme's high-contrast
-   * ink — black-ish in light, white-ish in dark — at 65% opacity.
+   * ink - black-ish in light, white-ish in dark - at 65% opacity.
    *
    * color-mix(in oklch, ...) needs Chrome 111+/FF 113+/Safari 16.2+,
    * which is strictly within the design system's existing light-dark()
-   * floor (Chrome 123+/FF 120+/Safari 17.5+) — anything that can paint
+   * floor (Chrome 123+/FF 120+/Safari 17.5+) - anything that can paint
    * the rest of the page can paint this too. The fallback color
    * declaration below makes the button visible on the (long-defunct)
    * older browsers that load this stylesheet but can't parse color-mix. */

--- a/frontend/src/components/graph/TraceStepList.vue
+++ b/frontend/src/components/graph/TraceStepList.vue
@@ -14,7 +14,7 @@ const emit = defineEmits(['select-step']);
 const listEl = ref(null);
 
 // Tag each visible step with its index in the unfiltered `steps` array
-// so the template can read it directly — avoids an O(n) `steps.indexOf`
+// so the template can read it directly - avoids an O(n) `steps.indexOf`
 // per row, per render (the loop itself was O(visibleSteps × steps)).
 const visibleSteps = computed(() => {
   const all = props.steps;

--- a/frontend/src/components/graph/graph-styles.css
+++ b/frontend/src/components/graph/graph-styles.css
@@ -22,7 +22,7 @@
  * effects below need only Chrome 111+/FF 113+/Safari 16.2+, so they're
  * strictly inside that floor. On the rare browser old enough to skip
  * the glow but still load this stylesheet, the trace highlight outline
- * + background remain — the missing shadow degrades cleanly.
+ * + background remain - the missing shadow degrades cleanly.
  */
 
 .vue-flow .root {
@@ -32,7 +32,7 @@
   color: var(--semantics-content-color);
 }
 
-/* Service colors — one per regulatory_layer index (see LAYER_COLOR_INDEX
+/* Service colors - one per regulatory_layer index (see LAYER_COLOR_INDEX
  * in useLawGraph.js). Each hue maps to a NLDD palette family; the -700
  * border + -100 background combo auto-flips for dark mode through the
  * baked-in light-dark() in palettes.generated.css. */
@@ -144,7 +144,7 @@
   outline-offset: 1px !important;
 }
 
-/* Start point — sticky dashed blue outline + "▶ start" label on the
+/* Start point - sticky dashed blue outline + "▶ start" label on the
  * scenario's root law and initial output leaf. Stays visible across
  * all steps so users can always see where the trace began. */
 .vue-flow__node.trace-start {
@@ -159,7 +159,7 @@
   left: -4px;
   background: var(--primitives-color-lintblauw-600);
   /* Use neutral-0 so the label stays white-on-blue in light mode and
-   * picks up the auto-flipped near-black on light-blue in dark mode —
+   * picks up the auto-flipped near-black on light-blue in dark mode -
    * both retain comfortable contrast against the auto-adjusted bg. */
   color: var(--primitives-color-neutral-0);
   font-size: 10px;

--- a/frontend/src/composables/corpusUrls.js
+++ b/frontend/src/composables/corpusUrls.js
@@ -1,13 +1,13 @@
 // Centralised URL builders for the editor's corpus endpoints. The two
-// shapes — global (`/api/corpus/...`, read-only) and traject-scoped
-// (`/api/trajects/{ref}/corpus/...`, read + write) — are picked by
+// shapes - global (`/api/corpus/...`, read-only) and traject-scoped
+// (`/api/trajects/{ref}/corpus/...`, read + write) - are picked by
 // whether a traject ref is present at call time. Putting the choice in
 // one place keeps composables aligned and prevents the pattern from
 // drifting per file.
 //
 // The `trajectRef` is the URL-form identifier `{slug}-{8hex}` returned
 // by the backend on `t.ref`. The backend resolves it back to a UUID via
-// `resolve_traject_ref` — frontend code never needs to know the UUID
+// `resolve_traject_ref` - frontend code never needs to know the UUID
 // shape, only the ref string.
 
 function corpusBase(trajectRef) {
@@ -23,7 +23,7 @@ export function lawUrl(trajectRef, lawId) {
 // All versions of a law (newest-first), as a JSON array of YAML strings.
 // Unlike `lawUrl` (one "best for today" body), the scenario dependency loader
 // feeds every version to the engine so its date-aware version selection can
-// pick the one in force on the scenario's calculation date — otherwise a
+// pick the one in force on the scenario's calculation date - otherwise a
 // referenced law that has a future-dated version would load only that future
 // version and fail "not yet in force" for a past-dated scenario.
 export function lawVersionsUrl(trajectRef, lawId) {
@@ -36,7 +36,7 @@ export function lawsListUrl(trajectRef, query = '') {
 }
 
 // Law ids edited in a traject (branch-vs-base diff). Only exists under the
-// traject prefix — there is no global "changed laws" notion — so this is
+// traject prefix - there is no global "changed laws" notion - so this is
 // traject-only, like the documents builders. Callers already short-circuit
 // the no-traject case (see `fetchChangedLawIds`); the guard here documents
 // that contract and fails loudly if a future caller forgets it.
@@ -68,7 +68,7 @@ export function annotationsUrl(trajectRef, lawId) {
 // Documents live under the traject-scope only. The list endpoint
 // returns every document in the traject's documents folder, the file
 // endpoint reads/writes one specific path. Both forms require a
-// trajectRef — there is no global-scope counterpart by design.
+// trajectRef - there is no global-scope counterpart by design.
 export function documentsListUrl(trajectRef) {
   requireTraject(trajectRef, 'documents listing');
   return `${corpusBase(trajectRef)}/documents`;
@@ -76,7 +76,7 @@ export function documentsListUrl(trajectRef) {
 
 // The document path is hierarchical (e.g. "mvt/concept.md"), so each
 // segment is encoded individually instead of `encodeURIComponent`-ing
-// the whole thing — that would turn `/` into `%2F` and break the
+// the whole thing - that would turn `/` into `%2F` and break the
 // axum wildcard match.
 export function documentFileUrl(trajectRef, docPath) {
   requireTraject(trajectRef, 'document access');

--- a/frontend/src/composables/useAmbiguityVocabulary.js
+++ b/frontend/src/composables/useAmbiguityVocabulary.js
@@ -1,5 +1,5 @@
 /**
- * useAmbiguityVocabulary — the controlled tag list for questioning notes.
+ * useAmbiguityVocabulary - the controlled tag list for questioning notes.
  *
  * RFC-018 Decision 9: a questioning note over an open norm carries a tagging
  * body whose value is one of these ids. The list is deliberately *not* a JSON

--- a/frontend/src/composables/useAppChrome.js
+++ b/frontend/src/composables/useAppChrome.js
@@ -4,11 +4,11 @@ import { shallowRef, onBeforeUnmount } from 'vue';
 //
 // The Bibliotheek/Editor switch keeps the shell (toolbars, tab-bar,
 // settings menu) mounted and only swaps the nested <router-view>. A few
-// toolbar bits are view-specific — the search trigger (both views), the
+// toolbar bits are view-specific - the search trigger (both views), the
 // federated "PR #N" write-back indicator and the document-tab-bar (editor
-// only). Rather than teleport those into the shell's toolbars — which
+// only). Rather than teleport those into the shell's toolbars - which
 // `nldd-toolbar` rejects, since slotted items must be its *direct*
-// children and teleport would reorder them — the active view publishes
+// children and teleport would reorder them - the active view publishes
 // them here and the shell renders everything itself, in the original
 // order. Module-level singleton, matching the other composables
 // (`useColorScheme`, `useFeatureFlags`).
@@ -24,7 +24,7 @@ export function registerSearchPopover(ref_) {
   popoverRef = ref_;
   // Clear on unmount, but only if this view still owns the registration. The
   // entering view registers in its setup before the leaving view unmounts, so
-  // guarding on identity avoids nulling a registration that already moved on —
+  // guarding on identity avoids nulling a registration that already moved on -
   // making the cleanup safe even if the route topology changes that ordering.
   onBeforeUnmount(() => {
     if (popoverRef === ref_) popoverRef = null;

--- a/frontend/src/composables/useArticleMarkdown.js
+++ b/frontend/src/composables/useArticleMarkdown.js
@@ -2,8 +2,8 @@
  * Shared article-text markdown pipeline.
  *
  * ArticleText.vue (Tekst pane, notes off) and AnnotatedText.vue (Tekst pane,
- * notes on) must render the law text identically — same list nesting, same
- * paragraph breaks — so toggling Notities does not visually reflow the text.
+ * notes on) must render the law text identically - same list nesting, same
+ * paragraph breaks - so toggling Notities does not visually reflow the text.
  * Keeping the marked + DOMPurify config in one place is the only way to
  * guarantee that; a drift here is exactly the "duidelijke stap terug"
  * regression #646 is about.

--- a/frontend/src/composables/useBwbHarvest.js
+++ b/frontend/src/composables/useBwbHarvest.js
@@ -1,5 +1,5 @@
 /**
- * useBwbHarvest — request and track harvesting of external laws.
+ * useBwbHarvest - request and track harvesting of external laws.
  *
  * Manages the lifecycle of harvest requests: submitting, polling for status,
  * and determining when a law becomes available. Works with the pipeline-api
@@ -19,7 +19,7 @@ const POLLING_STATUSES = new Set(['queued', 'already_queued', 'harvesting', 'enr
 const POLL_INTERVAL_MS = 5000;
 const POLL_MAX_MS = 10 * 60 * 1000; // 10 minutes
 
-// Module-level shared state — all callers of useBwbHarvest() share these refs.
+// Module-level shared state - all callers of useBwbHarvest() share these refs.
 /** @type {import('vue').Ref<Record<string, string>>} Status per BWB ID */
 const harvestStatus = ref({});
 /** @type {import('vue').Ref<Record<string, string>>} Resolved slug per BWB ID */
@@ -87,7 +87,7 @@ async function pollHarvestStatus() {
     const stillActive = Object.values(updatedStatus).some(s => POLLING_STATUSES.has(s));
     if (!stillActive) stopPolling();
   } catch {
-    // Poll is best-effort — HTTP errors and network failures alike just
+    // Poll is best-effort - HTTP errors and network failures alike just
     // wait for the next tick.
   }
 }

--- a/frontend/src/composables/useBwbSearch.js
+++ b/frontend/src/composables/useBwbSearch.js
@@ -1,5 +1,5 @@
 /**
- * useBwbSearch — search for laws on external sources (wetten.overheid.nl).
+ * useBwbSearch - search for laws on external sources (wetten.overheid.nl).
  *
  * Provides debounced search and result management. Results come from the
  * pipeline-api (proxied through editor-api at /api/harvest/search).
@@ -17,7 +17,7 @@ export function useBwbSearch() {
   let debounceTimer = null;
 
   /**
-   * Search for laws matching the query. Debounced — safe to call on every keystroke.
+   * Search for laws matching the query. Debounced - safe to call on every keystroke.
    * @param {string} query - The search query (minimum 3 characters)
    */
   function search(query) {
@@ -36,7 +36,7 @@ export function useBwbSearch() {
           `/api/harvest/search?q=${encodeURIComponent(q)}`,
         );
       } catch {
-        // BWB search is best-effort — clear stale results on any failure
+        // BWB search is best-effort - clear stale results on any failure
         // (HTTP error or network).
         results.value = [];
       } finally {

--- a/frontend/src/composables/useColorScheme.js
+++ b/frontend/src/composables/useColorScheme.js
@@ -1,5 +1,5 @@
 /**
- * Color scheme picker — automatic (follows OS), light, or dark.
+ * Color scheme picker - automatic (follows OS), light, or dark.
  *
  * Thin facade over the shared `useColorScheme`: the editor persists the
  * preference server-side (via `useUserSettings`) and falls back to localStorage

--- a/frontend/src/composables/useCorpusLaws.js
+++ b/frontend/src/composables/useCorpusLaws.js
@@ -6,11 +6,11 @@ import { humanizeLawId } from '../lib/lawName.js';
 
 /**
  * Shared corpus-laws list, scoped by the active traject. Each distinct
- * traject (and the global view) gets its own cached payload — switching
+ * traject (and the global view) gets its own cached payload - switching
  * trajects routes through the corresponding `/api/trajects/{ref}/corpus/laws`
  * endpoint without losing the previous traject's data on rebound.
  *
- * Module-level state — every consumer for the same `trajectRef` shares
+ * Module-level state - every consumer for the same `trajectRef` shares
  * the same list/promise.
  */
 
@@ -26,7 +26,7 @@ const FETCH_LIMIT = 1000;
 // hops between many trajects accumulates one entry per scope forever.
 // 5 is enough to cover the global view + a handful of recently-used
 // trajects without thrashing. The global scope (`''`) follows the same
-// rules — that's fine because it just gets re-fetched on demand. The
+// rules - that's fine because it just gets re-fetched on demand. The
 // companion promise map is kept in sync via `onEvict`.
 const SCOPE_CACHE_MAX = 5;
 
@@ -48,7 +48,7 @@ function ensureFetched(trajectRef) {
   if (fetchByScope.has(key)) {
     // Cache hit: `get` touches, so the LRU treats this access as recent.
     // Without this an often-accessed scope can be evicted before a
-    // genuinely-stale one that happened to be added more recently —
+    // genuinely-stale one that happened to be added more recently -
     // the invariant "most recently used is kept" only holds if the
     // touch runs on every access, not just on miss.
     lawsByScope.get(key);
@@ -61,7 +61,7 @@ function ensureFetched(trajectRef) {
       lawsRef.value = Array.isArray(list) ? list : [];
       if (lawsRef.value.length >= FETCH_LIMIT) {
         console.warn(
-          `useCorpusLaws: hit the ${FETCH_LIMIT}-law cap — laws beyond this won't resolve to display names. ` +
+          `useCorpusLaws: hit the ${FETCH_LIMIT}-law cap - laws beyond this won't resolve to display names. ` +
           `Pagination needs to be added if the corpus has grown past ${FETCH_LIMIT} entries.`,
         );
       }
@@ -85,14 +85,14 @@ function ensureFetched(trajectRef) {
  */
 export function useCorpusLaws(trajectRef) {
   // A plain string passed here gets silently wrapped in a static
-  // `ref(value)` that never reacts to the caller's scope changes —
+  // `ref(value)` that never reacts to the caller's scope changes -
   // which would look like "the corpus list is stuck" without any
   // error. All current callers pass a `Ref` (via `toRef(props, ...)`
   // or `computed`); a dev-mode warning catches future misuses before
   // they ship as a silent regression.
   if (trajectRef !== undefined && trajectRef !== null && !('value' in trajectRef)) {
     console.warn(
-      'useCorpusLaws: trajectRef should be a Ref, got plain value — list will not react to scope changes',
+      'useCorpusLaws: trajectRef should be a Ref, got plain value - list will not react to scope changes',
       trajectRef,
     );
   }
@@ -121,7 +121,7 @@ export function useCorpusLaws(trajectRef) {
       if (p && capturedRef) {
         p.then(() => {
           // Only commit if this is still the active scope by the time
-          // the fetch resolves — avoids a cross-scope late write.
+          // the fetch resolves - avoids a cross-scope late write.
           if (scopeKey(refSource.value) === key) {
             laws.value = capturedRef.value;
           }
@@ -164,8 +164,8 @@ export function useCorpusLaws(trajectRef) {
       p = (async () => {
         // Serialize behind whatever fetch currently owns the slot (a
         // settled promise resolves immediately). Busting an *in-flight*
-        // fetch would orphan it — firing the duplicate concurrent GET
-        // this file exists to avoid — and let its late settle race the
+        // fetch would orphan it - firing the duplicate concurrent GET
+        // this file exists to avoid - and let its late settle race the
         // refreshed list with stale data.
         const current = fetchByScope.get(key);
         if (current) await current;

--- a/frontend/src/composables/useCorpusLaws.test.js
+++ b/frontend/src/composables/useCorpusLaws.test.js
@@ -97,7 +97,7 @@ describe('useCorpusLaws', () => {
     expect(resolvers).toHaveLength(1);
 
     // Once the initial fetch settles, the refresh busts the slot and
-    // re-fetches — its result wins, never the pre-refresh list.
+    // re-fetches - its result wins, never the pre-refresh list.
     resolvers[0]([{ law_id: 'wet_old' }]);
     await flush();
     expect(resolvers).toHaveLength(2);

--- a/frontend/src/composables/useDependencies.js
+++ b/frontend/src/composables/useDependencies.js
@@ -1,10 +1,10 @@
 /**
- * useDependencies — recursive dependency graph walker for law YAML files.
+ * useDependencies - recursive dependency graph walker for law YAML files.
  *
  * Parses a law's YAML structure to find all `source.regulation` references,
  * fetches each dependency via the API, loads it into the engine, and recurses.
  * Implementing regulations (the IoC reverse link) are loaded separately via
- * `loadImplementors`, which calls the backend `implementors` endpoint — kept
+ * `loadImplementors`, which calls the backend `implementors` endpoint - kept
  * OFF the critical path because that corpus scan can be slow on a large
  * federated corpus and scenarios already declare the regulations they need.
  */
@@ -63,7 +63,7 @@ export function useDependencies() {
    * traject ref is needed here. It returns **all** versions of a law (the
    * engine keys versions by `($id, valid_from)`, so several bodies of one law
    * coexist), and the engine picks the version in force on the scenario's
-   * calculation date — a referenced law that has a future-dated version would
+   * calculation date - a referenced law that has a future-dated version would
    * otherwise load only that future version and fail "not yet in force".
    *
    * @param {string} lawYamlText - Raw YAML text of the main law
@@ -93,7 +93,7 @@ export function useDependencies() {
       const missingDeps = [];
 
       for (const lawId of toLoad) {
-        // Fetch the version YAMLs unconditionally — even for a law already in
+        // Fetch the version YAMLs unconditionally - even for a law already in
         // the engine. They feed two consumers that are independent of engine
         // state: the transitive-ref scan below, and (via `versionsCache` in
         // ScenarioBuilder) the data-source column type map. The WASM engine is
@@ -105,16 +105,16 @@ export function useDependencies() {
         let yamls = [];
         // Whether this law is sound enough to scan for transitive deps: already
         // in the engine, or newly loaded without error. A law that was fetched
-        // but failed to load into the engine is broken/missing — we must NOT
+        // but failed to load into the engine is broken/missing - we must NOT
         // chase its transitive refs (would queue deps of a law that can't run).
         let usable = alreadyLoaded;
         try {
           yamls = await fetchLawVersions(lawId);
           // Load every version (isolating each) so the engine's date-aware
           // selection can pick the one in force on the scenario's calculation
-          // date. Skip the engine load when the law is already present — only
+          // date. Skip the engine load when the law is already present - only
           // its YAML (cached above) is still needed. For a not-yet-loaded law,
-          // no loadable version — empty list or every version unloadable — is a
+          // no loadable version - empty list or every version unloadable - is a
           // missing dependency (harvest requested below).
           if (!alreadyLoaded && !loadLawVersions(engine, yamls, lawId)) {
             throw new Error(`no loadable version for '${lawId}'`);
@@ -139,13 +139,13 @@ export function useDependencies() {
         }
 
         // Recurse for transitive deps of a usable law only. Collect from every
-        // version — a `source.regulation` reference can appear in one version
+        // version - a `source.regulation` reference can appear in one version
         // and not another, and a scenario may be evaluated at any calculation
         // date (including a future one), so a reference introduced only by a
         // future version must still be loadable. Runs for already-loaded laws
         // too, so a dep reachable only through one is still discovered and
         // cached. This can over-fetch a transitive law that no in-force version
-        // needs; that's an accepted, bounded cost — `select_in` never selects a
+        // needs; that's an accepted, bounded cost - `select_in` never selects a
         // not-yet-in-force version.
         if (usable) {
           const newDeps = [];

--- a/frontend/src/composables/useDependencies.test.js
+++ b/frontend/src/composables/useDependencies.test.js
@@ -82,7 +82,7 @@ describe('useDependencies.loadAllDependencies', () => {
   it('loads EVERY version of a dependency (in-force + future), not just one', async () => {
     // Regression for the temporal-federation bug: a referenced law that has a
     // future-dated version must have *all* its versions loaded so the engine
-    // can pick the one in force on the scenario date — loading only the future
+    // can pick the one in force on the scenario date - loading only the future
     // version would fail "not yet in force" for a past-dated scenario.
     const inForce = '$id: zorgverzekeringswet\nvalid_from: \'2025-01-01\'\narticles: []\n';
     const future = '$id: zorgverzekeringswet\nvalid_from: \'2099-01-01\'\narticles: []\n';
@@ -103,7 +103,7 @@ describe('useDependencies.loadAllDependencies', () => {
   it('isolates an unloadable version: a bad version does not drop the good ones', async () => {
     // Regression for the federated-corpus case where a law has an executable
     // version AND an old-schema / text-only harvested version the engine can't
-    // parse. The harvested version must not abort the whole law — the engine
+    // parse. The harvested version must not abort the whole law - the engine
     // must still hold the executable one so select_in can resolve it.
     const bad = '$id: zorgverzekeringswet\nvalid_from: \'2026-02-21\'\nUNLOADABLE: true\n';
     const good = '$id: zorgverzekeringswet\nvalid_from: \'2025-01-01\'\narticles: []\n';
@@ -121,7 +121,7 @@ describe('useDependencies.loadAllDependencies', () => {
   });
 
   it('treats an empty version list as a missing dependency (requests harvest)', async () => {
-    // /versions returning [] means no version is available — the loader must
+    // /versions returning [] means no version is available - the loader must
     // not silently succeed; it routes the id to the harvest request like a
     // fetch failure. The harvest call is the only network request.
     const fetchSpy = vi.fn(async (url) => {
@@ -146,7 +146,7 @@ describe('useDependencies.loadAllDependencies', () => {
     // persists across scenario-panel mounts (and is pre-warmed by the machine
     // view), so a dependency is often already loaded by the time the panel
     // resolves its graph. The data-source column type map is built from the
-    // fetched version YAMLs (versionsCache), NOT from the engine — so an
+    // fetched version YAMLs (versionsCache), NOT from the engine - so an
     // already-loaded dep must STILL have its versions fetched. Gating the fetch
     // on `engine.hasLaw` left the cache empty on a warm engine and collapsed
     // every typed cell (boolean dropdown, euro field, date picker) to a plain
@@ -166,7 +166,7 @@ describe('useDependencies.loadAllDependencies', () => {
   it('does not chase transitive deps of a fetched-but-unloadable (missing) law', async () => {
     // The transitive-ref scan must run only for a "usable" law (already loaded,
     // or newly loaded). A law whose versions are all fetched but unloadable is
-    // missing/broken — chasing its refs would queue deps of a law that can't
+    // missing/broken - chasing its refs would queue deps of a law that can't
     // run. (Regression for moving the scan out of the try/catch.)
     const unloadableZvw = [
       '$id: zorgverzekeringswet',

--- a/frontend/src/composables/useDocumentUpload.js
+++ b/frontend/src/composables/useDocumentUpload.js
@@ -1,5 +1,5 @@
 /**
- * useDocumentUpload — the shared "hidden native file input + trigger" wiring for
+ * useDocumentUpload - the shared "hidden native file input + trigger" wiring for
  * the werkdocumenten upload affordance, used by both the launcher sheet and the
  * standalone page. No NLDD file-upload component exists, so the picker is a
  * hidden `<input type="file">`; this keeps that one bit of non-design-system

--- a/frontend/src/composables/useDocumentsManager.js
+++ b/frontend/src/composables/useDocumentsManager.js
@@ -1,5 +1,5 @@
 /**
- * useDocumentsManager — the full werkdocumenten editing logic (list + active
+ * useDocumentsManager - the full werkdocumenten editing logic (list + active
  * document + title/save/delete/conflict/draft handling), lifted out of the old
  * TrajectDocuments window so it can back BOTH the in-sheet master-detail and
  * the standalone navigation-split-view page.
@@ -103,7 +103,7 @@ export function useDocumentsManager(trajectRef) {
     }
   }
 
-  // Close the open document without deleting it — clears the editor back to
+  // Close the open document without deleting it - clears the editor back to
   // "nothing selected". Used by the standalone page's back affordance (on a
   // narrow viewport the split view stacks, so "terug" returns to the list).
   function close() {
@@ -136,7 +136,7 @@ export function useDocumentsManager(trajectRef) {
       const result = await saveCurrent();
       return !!result?.ok;
     }
-    // Hernoemen: geen rename-API — schrijf eerst onder het nieuwe pad (blind
+    // Hernoemen: geen rename-API - schrijf eerst onder het nieuwe pad (blind
     // create) en verwijder daarna het oude pad. In die volgorde raakt een
     // mislukking nooit inhoud kwijt.
     //

--- a/frontend/src/composables/useDocumentsManager.test.js
+++ b/frontend/src/composables/useDocumentsManager.test.js
@@ -96,7 +96,7 @@ describe('useDocumentsManager', () => {
     await nextTick();
     m.titleDraft.value = 'nieuw';
     const ok = await m.handleSave();
-    // The rename itself succeeded — content is saved under the new name.
+    // The rename itself succeeded - content is saved under the new name.
     expect(ok).toBe(true);
     expect(h.api.currentPath.value).toBe('nieuw.md');
     expect(h.api.deleteDocument).toHaveBeenCalledWith('oud.md');

--- a/frontend/src/composables/useDocumentsSheet.js
+++ b/frontend/src/composables/useDocumentsSheet.js
@@ -1,5 +1,5 @@
 /**
- * useDocumentsSheet — shared open/close state for the traject-documents
+ * useDocumentsSheet - shared open/close state for the traject-documents
  * browser sheet.
  *
  * The sheet is triggered from the TrajectMenu ("Documenten…") but rendered

--- a/frontend/src/composables/useDraftNotes.js
+++ b/frontend/src/composables/useDraftNotes.js
@@ -1,11 +1,11 @@
 /**
- * useDraftNotes — local-only note authoring store (RFC-018 write path, MVP).
+ * useDraftNotes - local-only note authoring store (RFC-018 write path, MVP).
  *
  * Notes a user creates in the editor live in `localStorage`, keyed per law,
  * until they are written back. Two ways out: `exportYaml` produces a YAML
  * document for a manual commit (the original RFC-018 §10 MVP, still here for
  * the offline case), and `saveToRepo` PUTs that same document to editor-api,
- * which validates it and opens a PR against the chosen source — the same
+ * which validates it and opens a PR against the chosen source - the same
  * traject branch+PR path law and scenario edits already use.
  *
  * Draft notes are merged into the resolved-notes list by the caller so they
@@ -39,7 +39,7 @@ function persist(lawId, list) {
   try {
     localStorage.setItem(storageKey(lawId), JSON.stringify(list));
   } catch {
-    /* quota/full or disabled — drafts are best-effort in the MVP */
+    /* quota/full or disabled - drafts are best-effort in the MVP */
   }
 }
 
@@ -54,8 +54,8 @@ export function useDraftNotes(lawId, trajectRef) {
 
   // Re-read from storage whenever the law changes. A real watch (not a lazy
   // resync inside every method/computed) keeps `drafts` authoritative for the
-  // current law at all times, so useResolvedDraftNotes — which watches lawId
-  // independently — never resolves the previous law's selectors against the
+  // current law at all times, so useResolvedDraftNotes - which watches lawId
+  // independently - never resolves the previous law's selectors against the
   // new law between a law switch and the next store method call.
   watch(lawId, (id) => {
     drafts.value = loadFor(id);
@@ -105,13 +105,13 @@ export function useDraftNotes(lawId, trajectRef) {
    *
    * The committed notes are read from the *raw sidecar file*, not from the
    * resolver output. The WASM resolver drops notes whose target.source names a
-   * different law (federated sidecars may carry notes for several laws — see
+   * different law (federated sidecars may carry notes for several laws - see
    * resolveNotes in wasm.rs); rebuilding the export from resolved notes would
    * silently truncate those on commit. Re-parsing the original file preserves
    * every committed note verbatim and only appends the drafts.
    *
    * Async because it fetches the sidecar; a missing sidecar (404) is normal
-   * for a law that has no committed notes yet — the export is then just the
+   * for a law that has no committed notes yet - the export is then just the
    * drafts.
    */
   async function exportYaml(lawIdOverride) {
@@ -122,7 +122,7 @@ export function useDraftNotes(lawId, trajectRef) {
     // Snapshot drafts BEFORE the await: watch(lawId) swaps drafts.value
     // synchronously on a law switch, so reading it after the fetch could mix
     // law A's committed notes with law B's drafts. Drafts are the only copy
-    // of unsaved work — silent loss is the worst outcome here.
+    // of unsaved work - silent loss is the worst outcome here.
     const snapshotDrafts = [...drafts.value];
     let committed = [];
     try {
@@ -133,7 +133,7 @@ export function useDraftNotes(lawId, trajectRef) {
       if (Array.isArray(doc?.annotations)) committed = doc.annotations;
     } catch {
       // 404 (no sidecar yet), other HTTP errors, network and parse
-      // failures all fall through to drafts-only — the author still gets
+      // failures all fall through to drafts-only - the author still gets
       // a valid file to commit, so no work is lost.
     }
     const annotations = [
@@ -155,12 +155,12 @@ export function useDraftNotes(lawId, trajectRef) {
    * is routed through the session's active traject (same model as law and
    * scenario edits since #632): the notes land in that traject's writable
    * branch, so a note and a law edit made in the same session ride the
-   * same PR. No source is chosen here — the traject's own corpus config
+   * same PR. No source is chosen here - the traject's own corpus config
    * decides the target. With no active traject the backend returns 403.
    *
    * The request body is **only the new drafts**, not the merged file: the
    * backend reads the current sidecar from the traject branch and appends.
-   * That is why there is no `/data` fetch here — rebuilding the file
+   * That is why there is no `/data` fetch here - rebuilding the file
    * client-side from the stale static mirror was the blind-overwrite bug.
    *
    * On success the saved law's drafts are cleared (they are committed now)
@@ -199,11 +199,11 @@ export function useDraftNotes(lawId, trajectRef) {
       // committed and it skipped the write/commit/PR entirely.
       noChange = json?.no_change === true;
     } catch {
-      // No JSON body — treat as success, pr stays null.
+      // No JSON body - treat as success, pr stays null.
     }
     // Only OVERWRITE the badge when this save produced a PR. A PR-less
     // 200 (local source, or a NoChange re-save) must NOT null an existing
-    // badge — same "keep any prior PR" rule as useLaw.saveLaw. Nulling it
+    // badge - same "keep any prior PR" rule as useLaw.saveLaw. Nulling it
     // here made a re-save look like the work vanished.
     if (pr) {
       lastSavedPr.value = pr;

--- a/frontend/src/composables/useDraftNotes.test.js
+++ b/frontend/src/composables/useDraftNotes.test.js
@@ -89,7 +89,7 @@ describe('useDraftNotes', () => {
 
   it('exports the raw sidecar notes + drafts (preserving cross-law notes)', async () => {
     // The committed file carries a note for ANOTHER law (federated sidecar).
-    // The resolver would drop it; exportYaml must NOT — it re-parses the file.
+    // The resolver would drop it; exportYaml must NOT - it re-parses the file.
     const otherLawNote = {
       ...NOTE,
       target: { ...NOTE.target, source: 'regelrecht://andere_wet' },
@@ -130,14 +130,14 @@ describe('useDraftNotes', () => {
 });
 
 // saveToRepo now does ONE request: a PUT whose body is the JSON array of
-// new drafts. No /data GET — the backend reads the base from the session
+// new drafts. No /data GET - the backend reads the base from the session
 // branch and appends. Single stub for the PUT.
 function stubSave(putResponse) {
   globalThis.fetch = vi.fn(() => Promise.resolve(putResponse));
 }
 
 describe('useDraftNotes.saveToRepo', () => {
-  // Traject ref used across these saveToRepo tests — must look like
+  // Traject ref used across these saveToRepo tests - must look like
   // `{slug}-{8hex}` so the URL builder produces the canonical shape and
   // the assertions stay stable.
   const TRAJECT_REF = 'tarief-2026-3f4a8b2c';
@@ -231,13 +231,13 @@ describe('useDraftNotes.saveToRepo', () => {
     const result = await saveToRepo();
 
     expect(result).toEqual({ pr: null, noChange: true });
-    // Badge untouched — the earlier PR is still shown.
+    // Badge untouched - the earlier PR is still shown.
     expect(lastSavedPr.value).toEqual({
       url: 'https://github.com/x/y/pull/3',
       number: 3,
       branch: 'b',
     });
-    // Drafts cleared (they are already upstream) — that is fine because
+    // Drafts cleared (they are already upstream) - that is fine because
     // the caller now has noChange to show an explicit message.
     expect(drafts.value).toHaveLength(0);
   });

--- a/frontend/src/composables/useEngine.js
+++ b/frontend/src/composables/useEngine.js
@@ -1,5 +1,5 @@
 /**
- * useEngine — singleton WasmEngine instance with lazy initialization.
+ * useEngine - singleton WasmEngine instance with lazy initialization.
  *
  * Provides the engine and helpers for loading laws and dependencies.
  */
@@ -13,7 +13,7 @@ let initPromise = null;
 
 // Per-law tracking of which traject scope a YAML was loaded under. The
 // WASM engine itself only knows law id, so without this every scope
-// would see whichever copy happened to be loaded first — switching
+// would see whichever copy happened to be loaded first - switching
 // trajects then runs scenarios against a stale dependency. Keyed by
 // `lawId`, value is the `trajectRef || ''` the load used.
 //
@@ -24,7 +24,7 @@ let initPromise = null;
 // change. Cap mirrors `lawCache`'s order of magnitude (`useLaw.js`).
 const loadedScopes = createLruMap(50, {
   onEvict: (lawId) => {
-    // Drop the WASM-side copy alongside the tracking entry — without
+    // Drop the WASM-side copy alongside the tracking entry - without
     // this the engine retains the law in memory even though our
     // scope-tracking forgot it, defeating the whole "safety net" of
     // the cap. `hasLaw` guards an unloadLaw call that the engine
@@ -75,14 +75,14 @@ async function initEngine() {
  *
  * Loads **every** version of the law (not just today's-best) so the
  * engine's date-aware resolution can pick the one in force on a given
- * calculation date — the same contract the scenario dependency walker
+ * calculation date - the same contract the scenario dependency walker
  * uses. This keeps a single "load a law into the engine" semantic: any
  * caller (notes, gherkin steps) that brings a law into the shared engine
  * brings its full version set, so the `engine.hasLaw` skip guard never
  * leaves a law with only one (possibly future-dated) version loaded.
  *
  * If the law was previously loaded under a *different* scope, unload the
- * stale copy first (`unloadLaw` drops all of its versions) — otherwise
+ * stale copy first (`unloadLaw` drops all of its versions) - otherwise
  * scenario runs after a traject switch would evaluate against the
  * previous scope's dependencies.
  */
@@ -98,7 +98,7 @@ async function loadDependency(lawId, trajectRef = null) {
     errorMessage: (status) => `Failed to fetch versions of law '${lawId}': ${status}`,
   });
   // Only record the scope once a body actually loaded, so an empty result
-  // (unknown law) — or one whose every version was unloadable — stays
+  // (unknown law) - or one whose every version was unloadable - stays
   // retryable rather than masking the law as "loaded under this scope".
   if (loadLawVersions(engine, yamls, lawId)) {
     loadedScopes.set(lawId, scope);
@@ -143,7 +143,7 @@ export function loadLawVersions(engine, yamls, lawId) {
  * another scope is still valid.
  *
  * Re-loads (same `lawId`) unload the previous copy first so the
- * engine sees the new YAML — `engine.loadLaw` on a known id is a no-op
+ * engine sees the new YAML - `engine.loadLaw` on a known id is a no-op
  * in the WASM binding.
  */
 async function loadLawYaml(yaml, lawId = null, trajectRef = null) {
@@ -185,9 +185,9 @@ function unloadAllLaws() {
 
 export function useEngine() {
   return {
-    /** Ref<boolean> — true when the WASM engine is ready */
+    /** Ref<boolean> - true when the WASM engine is ready */
     ready,
-    /** Ref<Error|null> — set if init failed */
+    /** Ref<Error|null> - set if init failed */
     initError,
     /** Initialize and return the engine instance */
     initEngine,
@@ -197,7 +197,7 @@ export function useEngine() {
     loadLawYaml,
     /** Unload a single law from the engine */
     unloadLaw,
-    /** Unload every tracked law — used on traject switch to flush stale deps */
+    /** Unload every tracked law - used on traject switch to flush stale deps */
     unloadAllLaws,
     /** Get the engine instance (must be initialized first) */
     getEngine: () => engineInstance,

--- a/frontend/src/composables/useEngine.test.js
+++ b/frontend/src/composables/useEngine.test.js
@@ -5,7 +5,7 @@ import { describe, it, expect, vi } from 'vitest';
 // surfaces, which only happens if `apiFetchText` is actually imported and
 // called. A regression that dropped the import (it's used only on the WASM-
 // init path, which the dependency-loader tests mock past) would instead make
-// `initEngine` throw `ReferenceError: apiFetchText is not defined` — caught here.
+// `initEngine` throw `ReferenceError: apiFetchText is not defined` - caught here.
 vi.mock('../lib/apiFetch.js', () => ({
   apiFetchText: vi.fn().mockRejectedValue(new Error('SENTINEL_GLUE_FETCH')),
   apiFetchJson: vi.fn().mockResolvedValue([]),
@@ -17,7 +17,7 @@ describe('useEngine.initEngine', () => {
   it('uses apiFetchText to fetch the WASM glue (regression: import must exist)', async () => {
     const { initEngine, initError } = useEngine();
     await expect(initEngine()).rejects.toThrow('SENTINEL_GLUE_FETCH');
-    // It reached the glue fetch and failed there — not a ReferenceError from a
+    // It reached the glue fetch and failed there - not a ReferenceError from a
     // missing import.
     expect(initError.value).toBeInstanceOf(Error);
     expect(initError.value.message).toBe('SENTINEL_GLUE_FETCH');

--- a/frontend/src/composables/useFeatureFlags.js
+++ b/frontend/src/composables/useFeatureFlags.js
@@ -1,5 +1,5 @@
 /**
- * useFeatureFlags — singleton feature flag store with API sync.
+ * useFeatureFlags - singleton feature flag store with API sync.
  *
  * Fetches flags from /api/feature-flags on first use, falls back to
  * hardcoded defaults when the API is unavailable (e.g. no database).
@@ -86,7 +86,7 @@ async function toggle(key) {
       saveLocal({ ...loadLocal(), [key]: newValue });
       return;
     }
-    // Clear any stale local override for this key — server is now authoritative.
+    // Clear any stale local override for this key - server is now authoritative.
     const local = loadLocal();
     if (key in local) {
       delete local[key];

--- a/frontend/src/composables/useFeatureFlags.test.js
+++ b/frontend/src/composables/useFeatureFlags.test.js
@@ -14,7 +14,7 @@ function stubFetch(putResponse) {
     vi.fn((input, init) => {
       const method = init?.method ?? 'GET';
       if (method === 'PUT') return Promise.resolve(putResponse());
-      // GET /api/feature-flags — empty server set, so DEFAULTS apply.
+      // GET /api/feature-flags - empty server set, so DEFAULTS apply.
       return Promise.resolve(
         new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } }),
       );
@@ -45,7 +45,7 @@ describe('useFeatureFlags', () => {
     expect(saved['panel.notes']).toBe(true);
   });
 
-  it('reverts the toggle when OIDC is configured and the write fails (prod — no sticky override)', async () => {
+  it('reverts the toggle when OIDC is configured and the write fails (prod - no sticky override)', async () => {
     // With OIDC configured, /auth/status reports it; a failed write must not
     // persist a local override that would beat the server on the next load.
     vi.stubGlobal(
@@ -97,7 +97,7 @@ describe('useFeatureFlags', () => {
     await toggle('panel.notes');
 
     expect(isEnabled('panel.notes')).toBe(true);
-    // Server is authoritative — no lingering local override.
+    // Server is authoritative - no lingering local override.
     const saved = JSON.parse(localStorage.getItem('regelrecht-feature-flags') || '{}');
     expect('panel.notes' in saved).toBe(false);
   });

--- a/frontend/src/composables/useLastVisitedRoute.js
+++ b/frontend/src/composables/useLastVisitedRoute.js
@@ -23,7 +23,7 @@ function save() {
   try {
     sessionStorage.setItem(STORAGE_KEY, JSON.stringify(_lastVisited.value));
   } catch {
-    /* storage may be disabled / quota exceeded — fall back to memory only */
+    /* storage may be disabled / quota exceeded - fall back to memory only */
   }
 }
 
@@ -53,7 +53,7 @@ export const lastLibraryPath = computed(() => _lastVisited.value.library ?? '/li
 
 // `/editor` (no traject) is the read-only editor. The first visit
 // lands there; subsequent visits restore the most-recently-seen
-// editor URL — the traject chooser OR a traject-scoped editor,
+// editor URL - the traject chooser OR a traject-scoped editor,
 // whichever the user was on last.
 export const lastEditorPath = computed(
   () => _lastVisited.value.editor ?? '/editor',

--- a/frontend/src/composables/useLaw.js
+++ b/frontend/src/composables/useLaw.js
@@ -57,7 +57,7 @@ function makeEntry(law, rawYaml, etag) {
 }
 
 // In-flight law GETs, keyed like `lawCache`. Simultaneous callers share
-// one request instead of racing duplicate GETs against an empty cache —
+// one request instead of racing duplicate GETs against an empty cache -
 // which is exactly what an editor mount does: `useLaw().load()` fetches
 // the routed law while the persisted-tab label loader `fetchLaw`s the
 // same id in parallel. Entries are removed when the request settles, so
@@ -66,7 +66,7 @@ const pendingLawFetches = new Map();
 
 /**
  * The network leg shared by `fetchLaw` and `useLaw().load()`: always
- * fetches (no cache read — `load()` relies on that for freshness),
+ * fetches (no cache read - `load()` relies on that for freshness),
  * single-flighted per cache key, and stores the entry in `lawCache`
  * under the requested id (and the body's resolved `$id`, when the two
  * differ) before resolving.
@@ -81,7 +81,7 @@ function fetchLawFresh(trajectRef, lawId) {
     const law = yaml.load(text);
     const entry = makeEntry(law, text, res.headers.get('ETag'));
     // Always overwrite: this is fresh content, so any pre-existing entry
-    // is by definition stale (older body and/or ETag) — keeping it would
+    // is by definition stale (older body and/or ETag) - keeping it would
     // hand `fetchLaw`/`switchLaw` callers outdated YAML and a
     // precondition doomed to 412.
     lawCache.set(key, entry);
@@ -154,7 +154,7 @@ export function useLaw(lawParam, articleParam, trajectRefParam) {
     const isCurrent = claimSwitch();
     // Snapshot before any await: a concurrent `switchLaw` mutates
     // `currentTrajectRef`, and the direct-URL cache write below must key
-    // on the traject this load was issued for — not whichever traject the
+    // on the traject this load was issued for - not whichever traject the
     // user has navigated to by the time the response body arrives.
     const loadTrajectRef = currentTrajectRef;
     try {
@@ -310,7 +310,7 @@ export function useLaw(lawParam, articleParam, trajectRefParam) {
         json = await res.json();
         lastSavedPr.value = sanitizeSavedPr(json?.pr);
       } catch {
-        // Older deployments return a bare 200 without JSON — keep the
+        // Older deployments return a bare 200 without JSON - keep the
         // existing PR (if any) and treat the save as successful.
       }
       // Chain the new ETag for the next save. The header is

--- a/frontend/src/composables/useLaw.test.js
+++ b/frontend/src/composables/useLaw.test.js
@@ -88,7 +88,7 @@ describe('useLaw optimistic concurrency', () => {
       /door iemand anders gewijzigd/i,
     );
     expect(law.saveError.value?.message).toMatch(/herlaad/i);
-    // The stale ETag is kept — the user reloads to pick up a fresh one.
+    // The stale ETag is kept - the user reloads to pick up a fresh one.
     expect(law.currentEtag.value).toBe('"v1"');
   });
 });
@@ -155,7 +155,7 @@ describe('useLaw fetch dedup (single-flight)', () => {
     await waitForLoaded(a);
     expect(callCount).toBe(1);
 
-    // A subsequent fresh load (load() never reads the cache) fires a new GET —
+    // A subsequent fresh load (load() never reads the cache) fires a new GET -
     // proving the settled promise wasn't pinned in the pending map.
     const b = useLaw('wet_pending_clear', null, 'tr-dedupe');
     await waitForLoaded(b);
@@ -175,7 +175,7 @@ describe('useLaw fetch dedup (single-flight)', () => {
     expect(bySlug.law.$id).toBe('wet_canonical');
 
     // The dual-cache write under the resolved `$id` means a later fetch by
-    // the canonical id is served from cache — no extra GET.
+    // the canonical id is served from cache - no extra GET.
     const byId = await fetchLaw('tr-dedupe', 'wet_canonical');
     expect(byId).toBe(bySlug);
     expect(callCount).toBe(1);
@@ -185,7 +185,7 @@ describe('useLaw fetch dedup (single-flight)', () => {
     // The direct-URL branch caches under the traject the load was issued
     // for. If a cross-traject switchLaw lands while the response body is
     // still streaming, the late cache write must go to the OLD traject's
-    // key — never the new one, where it would shadow the real law.
+    // key - never the new one, where it would shadow the real law.
     let releaseText;
     const calls = [];
     globalThis.fetch = vi.fn().mockImplementation(async (url) => {
@@ -209,7 +209,7 @@ describe('useLaw fetch dedup (single-flight)', () => {
     releaseText('$id: wet_direct\nname: Direct\n');
     await waitForLoaded(law);
 
-    // Fetching the same id in the new traject must go to the network —
+    // Fetching the same id in the new traject must go to the network -
     // a cache hit here would serve the direct-URL body as tr-new content.
     const before = calls.length;
     const entry = await fetchLaw('tr-new', 'wet_direct');
@@ -218,7 +218,7 @@ describe('useLaw fetch dedup (single-flight)', () => {
     expect(entry.law.$id).toBe('wet_direct');
   });
 
-  it('does not pin a rejected fetch — the next call retries', async () => {
+  it('does not pin a rejected fetch - the next call retries', async () => {
     let callCount = 0;
     globalThis.fetch = vi.fn().mockImplementation(async () => {
       callCount += 1;

--- a/frontend/src/composables/useLawGraph.js
+++ b/frontend/src/composables/useLawGraph.js
@@ -1,11 +1,11 @@
 /**
- * useLawGraph — build a Vue Flow node/edge graph for a root law + its
+ * useLawGraph - build a Vue Flow node/edge graph for a root law + its
  * transitive dependencies.
  *
  * Ported from demo/graph/src/routes/+page.svelte (branch
  * feature/demo-leenstelsel-tegemoetkoming). The YAML parsing, per-law
  * aggregation, layered layout and edge construction follow that demo
- * byte-for-byte — changes there and here need to stay in lockstep.
+ * byte-for-byte - changes there and here need to stay in lockstep.
  *
  * Edge ID format MUST match what lib/traceEdges.js (PR2) looks up:
  *   - cross-law input:  "${lawId}-input-${name}->${targetLaw}-output-${name}"
@@ -275,7 +275,7 @@ function buildGraph(lawsMap) {
     nodes.push({
       id: law.id,
       type: 'law',
-      data: { label: `${law.layer} — ${law.name}` },
+      data: { label: `${law.layer} - ${law.name}` },
       position: { x: rootIdx++ * 400, y: 0 },
       width: 500,
       height: Math.max(leftHeight, rightHeight) + 120,
@@ -712,7 +712,7 @@ export function useLawGraph({ rootLawId, fetchLawYaml }) {
   const error = ref(null);
   // Law ids whose YAML could not be fetched during the BFS walk. The graph
   // still renders the laws that did load, but the UI should warn the user
-  // that some dependencies are missing — otherwise a partial graph looks
+  // that some dependencies are missing - otherwise a partial graph looks
   // complete and silently omits connections.
   const missingDeps = ref([]);
 

--- a/frontend/src/composables/useNotes.js
+++ b/frontend/src/composables/useNotes.js
@@ -1,5 +1,5 @@
 /**
- * useNotes — fetch a law's note sidecar and resolve it against the loaded law.
+ * useNotes - fetch a law's note sidecar and resolve it against the loaded law.
  *
  * Notes are W3C Web Annotations anchored to legal text via a TextQuoteSelector
  * (RFC-005). The Rust resolver runs in WASM (`engine.resolveNotes`) so the
@@ -22,7 +22,7 @@ import { useLatest } from '../lib/useLatest.js';
 // the note-editing phase): the lawId key part is `law.$id`, which does
 // not encode the law *version*. A save through the editor changes the
 // text without changing `$id`, so the cache is not invalidated on save
-// — editing a law in-session and reopening its Notities pane could show
+// - editing a law in-session and reopening its Notities pane could show
 // offsets resolved against the pre-save text. Once notes become
 // editable, key by `$id` + version and invalidate on save.
 const cache = new Map();
@@ -46,7 +46,7 @@ export function useNotes(lawId, selectedArticle, trajectRef) {
   // Generation guard: each load() call claims a generation; only the latest
   // is allowed to write reactive state. Without this, navigating between laws
   // while a slow annotations fetch is in flight lets the older response
-  // overwrite the newer law's notes — and because article numbers collide
+  // overwrite the newer law's notes - and because article numbers collide
   // across laws ('1','2','3' everywhere) the stale offsets would silently
   // highlight wrong spans. useLaw guards the same race the same way.
   const claimLoad = useLatest();
@@ -84,7 +84,7 @@ export function useNotes(lawId, selectedArticle, trajectRef) {
       // With an active traject the read goes through that traject's
       // backend (where `save_annotations` writes) so a freshly-appended
       // note is visible immediately. Without a traject this falls back
-      // to the global annotation route — the central source's main view.
+      // to the global annotation route - the central source's main view.
       const res = await apiFetch(annotationsUrl(tr, id), {
         allowStatuses: [404],
         errorMessage: (status) => `Kon notities niet laden: ${status}`,
@@ -100,7 +100,7 @@ export function useNotes(lawId, selectedArticle, trajectRef) {
       const engine = await initEngine();
       // The resolver needs the law's articles loaded; mirror how the
       // rest of the editor pulls a law into the engine. Call
-      // `loadDependency` unconditionally — it short-circuits when the
+      // `loadDependency` unconditionally - it short-circuits when the
       // engine already has the law under the same scope, and unloads +
       // refetches when a previous load came from a different traject.
       // A bare `if (!engine.hasLaw(id))` gate here would skip that scope
@@ -121,7 +121,7 @@ export function useNotes(lawId, selectedArticle, trajectRef) {
     }
   }
 
-  // Re-load on either the law or the active-traject changing — the
+  // Re-load on either the law or the active-traject changing - the
   // sidecar lives per traject branch, so a switch needs a fresh fetch
   // even if the law id stayed put.
   const trackers = trajectRef ? [lawId, trajectRef] : [lawId];
@@ -133,7 +133,7 @@ export function useNotes(lawId, selectedArticle, trajectRef) {
    * run `load`. Used after `saveToRepo` so a just-committed note shows
    * up immediately instead of waiting for a navigation away and back.
    *
-   * `load()` alone won't do — it returns the cached `[]` from the
+   * `load()` alone won't do - it returns the cached `[]` from the
    * first pre-save fetch and silently leaves the user looking at an
    * empty notes pane right after they hit "Opslaan".
    */
@@ -180,7 +180,7 @@ export function useNotes(lawId, selectedArticle, trajectRef) {
           ? `parsefout: ${e.error}`
           : e.match.status === 'orphaned'
             ? 'niet gevonden in de wettekst (orphaned)'
-            : 'meerdere matches (ambigu) — voeg context toe',
+            : 'meerdere matches (ambigu) - voeg context toe',
       })),
   );
 
@@ -208,7 +208,7 @@ export function useResolvedDraftNotes(draftNotes, lawId, selectedArticle, trajec
   // Generation guard: resolve() awaits initEngine/loadDependency (slow on a
   // law switch). Without this, a resolve started before a law switch can
   // finish after the one started by the switch and overwrite it with stale
-  // data — and because draft selectors resolve per-law, that would highlight
+  // data - and because draft selectors resolve per-law, that would highlight
   // the previous law's drafts on the new law. useNotes.load() guards the same
   // race the same way.
   const claimResolve = useLatest();
@@ -226,7 +226,7 @@ export function useResolvedDraftNotes(draftNotes, lawId, selectedArticle, trajec
     try {
       const engine = await initEngine();
       // Pass the scope so the engine cache can detect a stale copy
-      // from a previous traject and refetch — without this a switch
+      // from a previous traject and refetch - without this a switch
       // would keep highlighting drafts against the old law content.
       await loadDependency(id, tr);
       const out = [];
@@ -278,7 +278,7 @@ export function useResolvedDraftNotes(draftNotes, lawId, selectedArticle, trajec
  * Overlap handling: marks are sorted by start (longest first on ties); a mark
  * that starts inside an already-emitted mark is dropped. The resolver
  * de-duplicates a single selector's matches, but two *different* notes
- * annotating overlapping spans is a legitimate RFC-018 case — the later one
+ * annotating overlapping spans is a legitimate RFC-018 case - the later one
  * is silently not rendered here (it is not surfaced in `issues` either, since
  * it resolved fine). Acceptable for display-only; the note-editing phase will
  * need layered rendering instead of a flat partition.

--- a/frontend/src/composables/useNotesHighlight.js
+++ b/frontend/src/composables/useNotesHighlight.js
@@ -14,12 +14,12 @@
  * their text, and align that against the raw text with a two-pointer scan.
  *
  * Assumption (not an invariant the code can enforce): the only transforms
- * marked applies to corpus law text are raw-only — numbered-list prefixes
+ * marked applies to corpus law text are raw-only - numbered-list prefixes
  * (`1. `) dropped from the visible text, and whitespace runs collapsed by
  * HTML. Under that assumption every DOM char appears in the raw text in the
  * same order, the scan only ever skips *raw* characters, and a raw span maps
  * to a contiguous DOM range. Inline markdown that *adds* DOM characters
- * (`**bold**`, `[text](url)`, headings) would break this — corpus articles
+ * (`**bold**`, `[text](url)`, headings) would break this - corpus articles
  * are not expected to contain it, but if a DOM char cannot be matched the
  * scan reports `desynced` so the caller can drop highlighting for that
  * article rather than smear every offset onto the wrong words.
@@ -51,7 +51,7 @@ export function buildAlignment(rawText, domNodes) {
   // char (the "\n\n" paragraph break) were allowed to map onto such a node,
   // a span crossing two list items would produce a slice for it and
   // AnnotatedText would wrap a focusable, styled <mark> around a bare "\n"
-  // sitting between <li>s — invalid HTML and an empty highlight blob. The
+  // sitting between <li>s - invalid HTML and an empty highlight blob. The
   // raw paragraph break instead aligns via the normal raw-advance path.
   const dom = [];
   for (const { node, text } of domNodes) {
@@ -67,7 +67,7 @@ export function buildAlignment(rawText, domNodes) {
   let d = 0;
   // Track the longest contiguous run of *significant* (non-whitespace) DOM
   // chars that the scan had to skip. A real divergence this two-pointer scan
-  // cannot model — inline markdown that added visible DOM text — shows up as
+  // cannot model - inline markdown that added visible DOM text - shows up as
   // exactly that: a contiguous block of DOM chars with no raw counterpart,
   // after which every offset is shifted (the "smear"). The legitimate
   // raw-only transforms (list prefixes, collapsed whitespace) never leave

--- a/frontend/src/composables/useNotesHighlight.test.js
+++ b/frontend/src/composables/useNotesHighlight.test.js
@@ -28,7 +28,7 @@ describe('buildAlignment', () => {
 
   it('skips a numbered-list prefix that marked removed from the DOM', () => {
     // Raw lid text "1. Indien ..."; marked renders <li><p>Indien ...</p></li>,
-    // so the DOM text node is "Indien ..." — the "1. " is raw-only.
+    // so the DOM text node is "Indien ..." - the "1. " is raw-only.
     const raw = '1. Indien de normpremie';
     const domText = 'Indien de normpremie';
     const node = tn(domText);

--- a/frontend/src/composables/useNotesSegments.js
+++ b/frontend/src/composables/useNotesSegments.js
@@ -1,5 +1,5 @@
 /**
- * planSegments — overlap-aware render plan for note highlights.
+ * planSegments - overlap-aware render plan for note highlights.
  *
  * Replaces the flat-partition overlap drop that #647 inherited from
  * markRanges. Given each note's resolved spans (with the note's index in
@@ -16,7 +16,7 @@
  * AND X.end >= Y.end AND at least one inequality is strict) and both cover
  * the same segment, X is suppressed in that segment so the inner note shows
  * cleanly. X stays in the `coveringIdx` so hovering it bridges back to its
- * full span. Identical spans both render — neither strictly contains the
+ * full span. Identical spans both render - neither strictly contains the
  * other.
  *
  * Partial overlap (neither contains the other): both render layered.
@@ -66,7 +66,7 @@ export function planSegments(items) {
     // a non-empty covering set always has at least one minimal element that
     // survives the filter. A throw would surface a regression loudly but
     // also become an unhandled rejection in AnnotatedText's async watcher
-    // and silently drop the whole render — so log loudly and skip just this
+    // and silently drop the whole render - so log loudly and skip just this
     // segment, leaving the rest of the article highlighted.
     if (visible.length === 0) {
       // eslint-disable-next-line no-console
@@ -104,7 +104,7 @@ function strictlyContains(outer, inner) {
 
 function pickPrimary(visible) {
   // Earliest span.start wins (the note that "starts first" in document
-  // order). On a tie, lowest idx — that is the order the note appears in
+  // order). On a tie, lowest idx - that is the order the note appears in
   // notesForArticle, which is the YAML order for committed notes.
   let best = visible[0];
   for (let i = 1; i < visible.length; i++) {

--- a/frontend/src/composables/useNotesSegments.test.js
+++ b/frontend/src/composables/useNotesSegments.test.js
@@ -43,7 +43,7 @@ describe('planSegments', () => {
   });
 
   it('splits a partial overlap into three segments, both visible in the middle', () => {
-    // A:[10,20) and B:[15,25) — neither contains the other, both render in
+    // A:[10,20) and B:[15,25) - neither contains the other, both render in
     // the overlap. Primary in the overlap is A (earlier start).
     expect(
       planSegments([
@@ -85,7 +85,7 @@ describe('planSegments', () => {
     ]);
   });
 
-  it('renders identical spans layered — neither strictly contains the other', () => {
+  it('renders identical spans layered - neither strictly contains the other', () => {
     // Two notes on exactly the same span: both visible, primary by lowest idx.
     expect(
       planSegments([
@@ -166,7 +166,7 @@ describe('planSegments', () => {
   });
 
   it('deduplicates a note that contributes two spans to one segment', () => {
-    // A single note (idx 0) has two spans that both cover [15,20) — could
+    // A single note (idx 0) has two spans that both cover [15,20) - could
     // happen if a TextQuoteSelector matches two adjacent occurrences. The
     // visibleIdx/coveringIdx lists must dedupe so the renderer paints one
     // background layer, not two of the same colour.
@@ -185,7 +185,7 @@ describe('planSegments', () => {
   it('merges adjacent segments with identical coverage', () => {
     // A:[10,40) and B:[20,30) inside A produce 3 segments, but if another
     // unrelated note D:[50,60) is added it should NOT introduce extra
-    // boundaries in A's region — already true; this test guards against a
+    // boundaries in A's region - already true; this test guards against a
     // regression where stray boundaries got injected.
     const plan = planSegments([
       { start: 10, end: 40, idx: 0 },

--- a/frontend/src/composables/useSavedPr.js
+++ b/frontend/src/composables/useSavedPr.js
@@ -1,8 +1,8 @@
 /**
- * useSavedPr — the "last saved PR" badge state shared across save paths.
+ * useSavedPr - the "last saved PR" badge state shared across save paths.
  *
  * Successor of `useEditorSession.js`: the per-tab session id and its
- * `X-Editor-Session` header are gone — writes are scoped by the traject
+ * `X-Editor-Session` header are gone - writes are scoped by the traject
  * in the URL path (`/api/trajects/{ref}/corpus/...`) and the backend
  * never read the header. What remains is the PR bookkeeping that the
  * traject write-back path still returns on every save.
@@ -12,7 +12,7 @@ import { ref } from 'vue';
 
 /**
  * Module-level shared ref so every composable that performs a save
- * (useLaw, useScenarios, useDraftNotes, …) updates the same value — and
+ * (useLaw, useScenarios, useDraftNotes, …) updates the same value - and
  * the AppShell's "PR #N" badge picks up the most recent PR regardless of
  * which pane triggered the save. Saves in the same traject land on the
  * same upstream branch/PR, so a single shared ref is exactly what the
@@ -23,7 +23,7 @@ export const lastSavedPr = ref(null);
 /**
  * Sanitize a PR payload from the editor-api before storing it in
  * `lastSavedPr`. Only PRs whose `url` is an explicit `https://` link survive
- * — anything else (missing url, `javascript:`, relative paths) is collapsed
+ * - anything else (missing url, `javascript:`, relative paths) is collapsed
  * to `null` so the `<a :href>` binding can never accept an attacker-controlled
  * scheme even if the backend ever misbehaves.
  */

--- a/frontend/src/composables/useScenarios.js
+++ b/frontend/src/composables/useScenarios.js
@@ -1,5 +1,5 @@
 /**
- * useScenarios — fetch, manage, and save scenario files for a law.
+ * useScenarios - fetch, manage, and save scenario files for a law.
  *
  * Reads pick the global or traject-scoped URL based on `trajectRef`;
  * writes only succeed with a traject, matching the backend invariant
@@ -18,7 +18,7 @@ import { apiFetch } from '../lib/apiFetch.js';
 
 /**
  * True when the scenario file declares execution targets and none of
- * them is the opened law — running it would evaluate a different law.
+ * them is the opened law - running it would evaluate a different law.
  * Files without a parseable execution step (`target_law_ids` empty)
  * count as "unknown", not as a mismatch.
  */
@@ -58,7 +58,7 @@ export function useScenarios(lawId, trajectRef = ref(null)) {
       const res = await fetch(scenariosListUrl(trajectRef.value, lawId.value));
       if (!res.ok) {
         // Deliberately raw fetch + silent branch: a law without scenarios
-        // is normal, not an error — every non-ok status maps to an empty
+        // is normal, not an error - every non-ok status maps to an empty
         // list without surfacing anything.
         scenarios.value = [];
         return;
@@ -69,7 +69,7 @@ export function useScenarios(lawId, trajectRef = ref(null)) {
       // then prefer files whose targets are unknown (no parseable
       // execution step) over known mismatches; finally fall back to the
       // first file. Folder placement is no longer the source of truth
-      // for the law↔scenario binding — the file's execution steps are.
+      // for the law↔scenario binding - the file's execution steps are.
       if (scenarios.value.length > 0 && !selectedScenario.value) {
         const preferred =
           scenarios.value.find((s) => s.target_law_ids?.includes(lawId.value)) ||
@@ -117,7 +117,7 @@ export function useScenarios(lawId, trajectRef = ref(null)) {
 
     // Snapshot the scope before the await (mirrors useLaw.saveLaw): if
     // the user switches law/traject while the PUT is in flight, the
-    // watch below clears `scenarioEtags` for the new scope — the stale
+    // watch below clears `scenarioEtags` for the new scope - the stale
     // completion must not re-insert its ETag (keys are bare filenames
     // like `basis.feature`, which recur across laws, so the entry would
     // poison the new law's same-named scenario with a foreign
@@ -161,10 +161,10 @@ export function useScenarios(lawId, trajectRef = ref(null)) {
         json = await res.json();
         lastSavedPr.value = sanitizeSavedPr(json?.pr);
       } catch {
-        // Older deployments returned a bare 200 — keep the prior PR.
+        // Older deployments returned a bare 200 - keep the prior PR.
       }
       // Bail on the success path if the user switched law/traject
-      // mid-flight — the new scope's state must not absorb this save.
+      // mid-flight - the new scope's state must not absorb this save.
       if (lawId.value !== savedLawId || trajectRef.value !== savedTrajectRef) return;
       // Chain the new ETag for the next save of this scenario. Header
       // is authoritative; body echo is the fallback.
@@ -189,7 +189,7 @@ export function useScenarios(lawId, trajectRef = ref(null)) {
   watch([lawId, trajectRef], () => {
     selectedScenario.value = null;
     featureText.value = '';
-    // ETags belong to the previous law/traject's files — a save in the
+    // ETags belong to the previous law/traject's files - a save in the
     // new scope must not carry a stale precondition.
     scenarioEtags.clear();
     fetchScenarios().catch(() => {});

--- a/frontend/src/composables/useTextSelection.js
+++ b/frontend/src/composables/useTextSelection.js
@@ -1,9 +1,9 @@
 /**
- * useTextSelection — turn a DOM selection in the rendered article into a
+ * useTextSelection - turn a DOM selection in the rendered article into a
  * TextQuoteSelector against the *raw* law text (RFC-018 write path, step 2).
  *
  * The Tekst pane renders the raw article text through marked (list prefixes
- * stripped, whitespace collapsed — see useNotesHighlight.js). A user selecting
+ * stripped, whitespace collapsed - see useNotesHighlight.js). A user selecting
  * "zorgtoeslag" with the mouse selects it in that rendered DOM, but a note's
  * TextQuoteSelector must quote the *raw* text the resolver matches against, or
  * it will not round-trip. So a selection is mapped DOM -> raw using the same
@@ -321,7 +321,7 @@ export function buildSelector(rawText, range, lawId, engine, articleNumber) {
     try {
       result = engine.resolveNote(lawId, selector);
     } catch {
-      // Resolver threw (law not loaded etc.) — caller surfaces it.
+      // Resolver threw (law not loaded etc.) - caller surfaces it.
       return { selector, exact, status: 'orphaned', reason: 'not-found' };
     }
     if (isExactlyOurSelection(result)) {

--- a/frontend/src/composables/useTextSelection.test.js
+++ b/frontend/src/composables/useTextSelection.test.js
@@ -49,7 +49,7 @@ describe('selectionToRawRange', () => {
   });
 
   it('maps a selection that starts at an element boundary (ol, 0)', () => {
-    // marked renders "<ol>\n<li>..." — childNodes[0] of <ol> is a "\n" text
+    // marked renders "<ol>\n<li>..." - childNodes[0] of <ol> is a "\n" text
     // node with no raw counterpart. A drag starting at the very beginning of
     // the list reports start as (ol, 0); the scan must skip the "\n" and not
     // dead-end. Regression for the element-endpoint-on-whitespace bug.

--- a/frontend/src/composables/useTraceStepping.js
+++ b/frontend/src/composables/useTraceStepping.js
@@ -1,5 +1,5 @@
 /**
- * useTraceStepping — step through a WASM `TraceResult` against the current
+ * useTraceStepping - step through a WASM `TraceResult` against the current
  * law graph and expose active/visited node & edge sets for CSS
  * highlighting.
  *
@@ -7,10 +7,10 @@
  * feature/demo-leenstelsel-tegemoetkoming.
  *
  * Cost model:
- *   - `steps`            — O(N) per (result, nodes, edges) change. Cached.
- *   - `next`/`prev`/`goto` — O(1) on the pointer itself.
- *   - `activeEdgeIds` / `activeNodeIds` — O(1) per `currentStepIdx` change.
- *   - `visitedEdgeIds` / `visitedNodeIds` — O(currentStepIdx) per
+ *   - `steps`            - O(N) per (result, nodes, edges) change. Cached.
+ *   - `next`/`prev`/`goto` - O(1) on the pointer itself.
+ *   - `activeEdgeIds` / `activeNodeIds` - O(1) per `currentStepIdx` change.
+ *   - `visitedEdgeIds` / `visitedNodeIds` - O(currentStepIdx) per
  *     `currentStepIdx` change. Forward traversal of an N-step trace is
  *     therefore O(N²). Acceptable today (typical traces are <100 steps).
  *     PR3 polish: amortise via mutated refs in next/prev/goto.
@@ -26,9 +26,9 @@ import {
 
 /**
  * @param {object} opts
- * @param {import('vue').Ref<object|null>} opts.result  — TraceResult from engine
- * @param {import('vue').Ref<Array>} opts.nodes         — Vue Flow nodes
- * @param {import('vue').Ref<Array>} opts.edges         — Vue Flow edges
+ * @param {import('vue').Ref<object|null>} opts.result  - TraceResult from engine
+ * @param {import('vue').Ref<Array>} opts.nodes         - Vue Flow nodes
+ * @param {import('vue').Ref<Array>} opts.edges         - Vue Flow edges
  * @param {import('vue').Ref<string|null>} opts.rootLawId
  * @param {import('vue').Ref<string|null>} opts.outputName
  */
@@ -61,7 +61,7 @@ export function useTraceStepping({ result, nodes, edges, rootLawId, outputName }
   // - The first listens to `result`: when a fresh trace arrives we want
   //   step 0 selected immediately, even before the graph has been
   //   enriched. The pointer may briefly point at a step that does not
-  //   exist yet — that's fine, the second watcher clamps it once
+  //   exist yet - that's fine, the second watcher clamps it once
   //   `steps` updates.
   // - The second listens to `steps`: when enrichment finishes, or the
   //   graph rebuilds and `steps` shrinks, the pointer is clamped to a

--- a/frontend/src/composables/useTrajectDetail.js
+++ b/frontend/src/composables/useTrajectDetail.js
@@ -1,11 +1,11 @@
 /**
- * useTrajectDetail — fetch one traject's full detail (`GET /api/trajects/:id`),
+ * useTrajectDetail - fetch one traject's full detail (`GET /api/trajects/:id`),
  * including its `sources`, for the read-only Traject-info sheet.
  *
  * Same endpoint and fresh-state-per-call shape as `useTrajectMembers`, but
  * keeps the whole `TrajectDetail` object (that composable discards `sources`).
- * The `id` argument is the traject **UUID** — the same value
- * `TrajectMenu.openMembersForActive` passes for member management — not the
+ * The `id` argument is the traject **UUID** - the same value
+ * `TrajectMenu.openMembersForActive` passes for member management - not the
  * URL `ref` form.
  */
 import { ref } from 'vue';

--- a/frontend/src/composables/useTrajectDocumentJobs.js
+++ b/frontend/src/composables/useTrajectDocumentJobs.js
@@ -1,5 +1,5 @@
 /**
- * useTrajectDocumentJobs — poll a traject's document-conversion jobs (running +
+ * useTrajectDocumentJobs - poll a traject's document-conversion jobs (running +
  * failed) for the werkdocumenten conversion-status block.
  *
  * Mirrors the harvester `usePollingFetch` pattern (initial-load-only `loading`,

--- a/frontend/src/composables/useTrajectDocuments.js
+++ b/frontend/src/composables/useTrajectDocuments.js
@@ -1,5 +1,5 @@
 /**
- * useTrajectDocuments — manage markdown / plain-text documents that
+ * useTrajectDocuments - manage markdown / plain-text documents that
  * live alongside laws in a traject's corpus branch.
  *
  * Reads, writes and deletes go through `/api/trajects/{ref}/corpus/documents`
@@ -10,7 +10,7 @@
  * `useDraftNotes` voor notities aanhoudt.
  *
  * @param {import('vue').Ref<string|null>} trajectRef Active traject ref.
- *   Required for every operation here — documents only exist under a
+ *   Required for every operation here - documents only exist under a
  *   traject scope (there is no global counterpart).
  */
 import { ref, watch } from 'vue';
@@ -43,7 +43,7 @@ function persistDraft(trajectRef, docPath, text) {
   try {
     localStorage.setItem(draftKey(trajectRef, docPath), text);
   } catch {
-    /* quota / unavailable — drafts are best-effort */
+    /* quota / unavailable - drafts are best-effort */
   }
 }
 
@@ -56,7 +56,7 @@ function clearDraft(trajectRef, docPath) {
 }
 
 export function useTrajectDocuments(trajectRef) {
-  // Top-level state — the list of documents in the current traject.
+  // Top-level state - the list of documents in the current traject.
   const documents = ref([]);
   const loading = ref(false);
   const listError = ref(null);
@@ -73,7 +73,7 @@ export function useTrajectDocuments(trajectRef) {
   const docError = ref(null);
   const saving = ref(false);
   const saveError = ref(null);
-  // Set to a localised string when a save returned 412 — the editor
+  // Set to a localised string when a save returned 412 - the editor
   // surfaces a conflict banner and lets the user choose
   // "lokaal overschrijven" or "server-versie laden".
   const conflict = ref(null);
@@ -123,10 +123,10 @@ export function useTrajectDocuments(trajectRef) {
     cancelDraftTimer();
     try {
       // Raw fetch on purpose: every status maps to its own docError shape
-      // below (404, other non-ok, draft divergence) — a thrown error would
+      // below (404, other non-ok, draft divergence) - a thrown error would
       // collapse those branches.
       const res = await fetch(documentFileUrl(trajectRef.value, path));
-      // A newer openDocument started while this fetch was in flight — drop
+      // A newer openDocument started while this fetch was in flight - drop
       // this stale response so it can't overwrite the newer document.
       if (!isCurrent()) return;
       if (res.status === 404) {
@@ -153,7 +153,7 @@ export function useTrajectDocuments(trajectRef) {
         return;
       }
       const serverBody = await res.text();
-      // Re-check after the body read — another open may have superseded us.
+      // Re-check after the body read - another open may have superseded us.
       if (!isCurrent()) return;
       const serverEtag = res.headers.get('ETag');
 
@@ -222,13 +222,13 @@ export function useTrajectDocuments(trajectRef) {
    * Pass `{ ifMatch: '*' }` to force-overwrite whatever version exists
    * (used by `overwriteServer` in the conflict-resolution path); note `*`
    * still 412s when the file does not exist, so it cannot create. The
-   * create flow instead passes `{ ifMatch: null }` — a blind write with no
+   * create flow instead passes `{ ifMatch: null }` - a blind write with no
    * precondition, which is what lands a brand-new file.
    */
   async function saveCurrent({ ifMatch } = {}) {
     if (!currentPath.value) return;
     requireTraject(trajectRef.value, 'document save');
-    // Drop any pending draft flush — if it fires after `clearDraft`
+    // Drop any pending draft flush - if it fires after `clearDraft`
     // below, it'd re-create the localStorage row we just removed and
     // leak a phantom draft for the next open.
     cancelDraftTimer();
@@ -261,7 +261,7 @@ export function useTrajectDocuments(trajectRef) {
         // that no longer exists (someone deleted it). Discriminate on what
         // WE sent rather than parsing the server's (localisable) error
         // string: the backend only emits the "deleted" 412 for `If-Match: *`
-        // against a missing file — i.e. exactly the force-overwrite path —
+        // against a missing file - i.e. exactly the force-overwrite path -
         // so `ifMatchValue === '*'` here is an unambiguous, language-stable
         // signal. The deleted case is a dead end for the concurrent-edit
         // buttons ("Server-versie laden" 404s, "Lokaal overschrijven" 412s
@@ -290,7 +290,7 @@ export function useTrajectDocuments(trajectRef) {
       // convenience for clients that can't read headers.
       currentEtag.value = res.headers.get('ETag') ?? json?.etag ?? currentEtag.value;
       clearDraft(trajectRef.value, currentPath.value);
-      // Reload the list — a freshly created document needs to appear
+      // Reload the list - a freshly created document needs to appear
       // in the sidebar without a manual refresh.
       if (res.status === 201) {
         await fetchList();
@@ -305,7 +305,7 @@ export function useTrajectDocuments(trajectRef) {
   }
 
   /** Force-replace the local body with whatever the server currently
-   *  holds — used as the resolution path for a 412 conflict. */
+   *  holds - used as the resolution path for a 412 conflict. */
   async function reloadCurrent() {
     if (!currentPath.value) return;
     clearDraft(trajectRef.value, currentPath.value);
@@ -318,7 +318,7 @@ export function useTrajectDocuments(trajectRef) {
    * `200/201 OK`. The caller (`useDocumentsManager.startNew`) only ever
    * passes a freshly generated `untitled-*.md` path that isn't in the
    * already-fetched list, so a collision needs a concurrent create of the
-   * same name between list-refresh and submit — a race a future iteration
+   * same name between list-refresh and submit - a race a future iteration
    * can close by adding `If-None-Match: *` support to the backend.
    */
   async function createDocument(path) {
@@ -349,7 +349,7 @@ export function useTrajectDocuments(trajectRef) {
     form.append('file', file);
     try {
       // Raw fetch, result-object style like `saveCurrent`. Do NOT set
-      // Content-Type — the browser adds the multipart boundary itself.
+      // Content-Type - the browser adds the multipart boundary itself.
       const res = await fetch(documentUploadUrl(trajectRef.value), {
         method: 'POST',
         body: form,
@@ -381,7 +381,7 @@ export function useTrajectDocuments(trajectRef) {
     // surfaces as a 412 instead of being silently destroyed. The open
     // document already has its ETag in `currentEtag`; for any other entry
     // (the list does not cache per-entry ETags) fetch the current ETag
-    // first. A non-OK GET (e.g. 404 — already gone) leaves `ifMatch` null
+    // first. A non-OK GET (e.g. 404 - already gone) leaves `ifMatch` null
     // and the DELETE falls through to report the real outcome.
     let ifMatch =
       path === currentPath.value && currentEtag.value ? currentEtag.value : null;
@@ -395,13 +395,13 @@ export function useTrajectDocuments(trajectRef) {
         });
         if (head.ok) ifMatch = head.headers.get('ETag');
       } catch {
-        /* network error — proceed unconditionally; DELETE surfaces its own error */
+        /* network error - proceed unconditionally; DELETE surfaces its own error */
       }
     }
     const headers = {};
     if (ifMatch) headers['If-Match'] = ifMatch;
     try {
-      // Raw fetch on purpose: same result-object style as `saveCurrent` —
+      // Raw fetch on purpose: same result-object style as `saveCurrent` -
       // 412 and 404 are normal branches here, not errors.
       const res = await fetch(documentFileUrl(trajectRef.value, path), {
         method: 'DELETE',
@@ -411,7 +411,7 @@ export function useTrajectDocuments(trajectRef) {
         // A concurrent modification means our delete precondition failed.
         // Do NOT reuse the save-conflict `conflict` ref: its banner offers
         // "reload"/"overwrite" actions that operate on the *open* document
-        // (and "overwrite" is a PUT — the wrong resolution for a delete).
+        // (and "overwrite" is a PUT - the wrong resolution for a delete).
         // Refresh the list so the caller re-evaluates against current
         // state, and return a typed result for the panel to surface.
         await fetchList();
@@ -419,7 +419,7 @@ export function useTrajectDocuments(trajectRef) {
       }
       if (res.status === 404) {
         // The document is already gone (deleted remotely between the list
-        // load and this click — e.g. the unconditional path where the HEAD
+        // load and this click - e.g. the unconditional path where the HEAD
         // probe 404'd). Delete is idempotent, so treat it as success: drop
         // the local draft, clear it if it was the open one, and refresh the
         // list so the stale sidebar entry disappears instead of lingering
@@ -447,7 +447,7 @@ export function useTrajectDocuments(trajectRef) {
       await fetchList();
       return { ok: true };
     } catch (e) {
-      // Network error (Failed to fetch / timeout) — surface it through
+      // Network error (Failed to fetch / timeout) - surface it through
       // the same `saveError` banner the editor already shows, so a failed
       // delete isn't swallowed silently. Mirrors `saveCurrent`'s catch.
       saveError.value = e;
@@ -455,7 +455,7 @@ export function useTrajectDocuments(trajectRef) {
     }
   }
 
-  // Re-fetch the list whenever the active traject changes — switching
+  // Re-fetch the list whenever the active traject changes - switching
   // trajects routes through a different writable backend.
   //
   // Critically, also reset the per-document state: a document loaded from

--- a/frontend/src/composables/useTrajectDocuments.test.js
+++ b/frontend/src/composables/useTrajectDocuments.test.js
@@ -68,7 +68,7 @@ describe('useTrajectDocuments', () => {
     expect(post.url).toBe('/api/trajects/mig-1a2b3c4d/corpus/documents/upload');
     expect(post.opts.body).toBeInstanceOf(FormData);
     expect(post.opts.body.get('file')).toBeInstanceOf(File);
-    // Content-Type must NOT be set — the browser adds the multipart boundary.
+    // Content-Type must NOT be set - the browser adds the multipart boundary.
     expect(post.opts.headers).toBeUndefined();
     // A successful upload refreshes the document list (GET after the POST).
     expect(

--- a/frontend/src/composables/useTrajectMembers.js
+++ b/frontend/src/composables/useTrajectMembers.js
@@ -59,7 +59,7 @@ export function useTrajectMembers() {
       method: 'PATCH',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ role }),
-      // 409 is the backend's atomic "can't demote the last owner" guard — only
+      // 409 is the backend's atomic "can't demote the last owner" guard - only
       // reachable when demoting an owner to contributor. Surface the workflow.
       errorMessage: (status, body) =>
         status === 409

--- a/frontend/src/composables/useTrajects.js
+++ b/frontend/src/composables/useTrajects.js
@@ -7,7 +7,7 @@ import { useAuth } from './useAuth.js';
 // may use the editor (`authorized`) whose membership list has finished loading
 // (`!loading`) without error (`!errored`), that ref is not among their
 // memberships (`activeTraject` is null). That means the traject either does not
-// exist or the user has no access — we deliberately do not distinguish the two
+// exist or the user has no access - we deliberately do not distinguish the two
 // (no information leak about traject existence).
 //
 // `authorized` mirrors `canEdit`'s `!oidcConfigured || authenticated` idiom so
@@ -34,13 +34,13 @@ async function loadTrajects() {
   // while the new list is in flight, instead of holding the stale label
   // for the duration of the round-trip.
   loading.value = true;
-  // Clear any prior error so it reflects only this fetch — otherwise a single
+  // Clear any prior error so it reflects only this fetch - otherwise a single
   // historical network blip stays sticky and would permanently suppress the
   // trajectMissing message (which gates on `!error`) for the whole session.
   error.value = null;
   try {
     // Raw fetch + ok-branch on purpose: a non-ok status (e.g. 401 on a
-    // public page) keeps the previous list without setting `error` —
+    // public page) keeps the previous list without setting `error` -
     // only a network failure surfaces through the catch.
     const resp = await fetch('/api/trajects');
     if (resp.ok) {
@@ -99,7 +99,7 @@ export async function leaveTraject(trajectId) {
 
 // Active traject lives in `route.params.trajectRef` (per-tab state),
 // derived here so consumers do not each repeat the lookup. Returns
-// `null` for any route without a traject param — that's the "global
+// `null` for any route without a traject param - that's the "global
 // browse" mode where edits are not available. The ref is the URL form
 // `{slug}-{8hex}` returned on `t.ref`; the backend resolver looks up
 // the matching traject by the trailing 8 hex chars of its UUID.
@@ -109,7 +109,7 @@ export function useTrajects() {
   const activeTrajectRef = computed(() => route.params.trajectRef || null);
   // Guard against `t.ref` being null/undefined: the backend serialises
   // it as `null` when a `TrajectSummary` is built without calling
-  // `fill_ref()` (defensive contract — see editor-api/trajects.rs).
+  // `fill_ref()` (defensive contract - see editor-api/trajects.rs).
   // Skip those rather than risk a `null === null` match against a
   // missing `activeTrajectRef`.
   const activeTraject = computed(

--- a/frontend/src/composables/useUserSettings.js
+++ b/frontend/src/composables/useUserSettings.js
@@ -1,5 +1,5 @@
 /**
- * useUserSettings — singleton per-user settings store with API sync.
+ * useUserSettings - singleton per-user settings store with API sync.
  *
  * Fetches settings from /api/user/settings on first use and merges them on
  * top of client-side defaults. Falls back to defaults on any failure (401,
@@ -21,7 +21,7 @@ const DEFAULTS = {
 };
 
 // Cache the theme in localStorage so a returning user sees the right palette
-// immediately on next page load — without this the page mounts with the
+// immediately on next page load - without this the page mounts with the
 // prefers-color-scheme default and flips after the /api/user/settings fetch
 // resolves, which is a visible whole-page flicker. The server remains the
 // source of truth: a successful fetch always overwrites the cached value.
@@ -40,7 +40,7 @@ function writeCachedTheme(value) {
   try {
     window.localStorage?.setItem(THEME_STORAGE_KEY, value);
   } catch {
-    // Ignore storage errors (private mode, quota, disabled) — flicker on
+    // Ignore storage errors (private mode, quota, disabled) - flicker on
     // next load is the only consequence.
   }
 }
@@ -54,7 +54,7 @@ const settings = ref({
 const loaded = ref(false);
 
 // Keys the user has touched locally before `loadSettings` resolved. The
-// initial fetch must NOT overwrite these — otherwise a toggle clicked
+// initial fetch must NOT overwrite these - otherwise a toggle clicked
 // during the fetch latency window would briefly flip back to the stale
 // server value while the PUT is still in flight.
 const dirtyKeys = new Set();
@@ -80,7 +80,7 @@ async function loadSettings() {
       // Precedence: server > current settings (cached + user toggles) >
       // DEFAULTS. Spreading settings.value before data prevents an empty
       // `{}` response from overwriting a cached theme on a returning user
-      // whose server row was never written — same flicker the cache
+      // whose server row was never written - same flicker the cache
       // exists to prevent.
       const merged = { ...DEFAULTS, ...settings.value, ...sanitized };
       // Preserve values the user already set locally during this fetch.
@@ -93,7 +93,7 @@ async function loadSettings() {
       // 401 (auth off), 503 (no DB) and network errors all collapse to
       // the same outcome: keep the editor loading on whatever's already
       // in settings.value (cachedTheme + DEFAULTS + any user toggles).
-      // We have nothing better to merge — and resetting to DEFAULTS would
+      // We have nothing better to merge - and resetting to DEFAULTS would
       // re-introduce the flicker the localStorage cache exists to avoid.
       console.warn('Keeping cached/default user settings:', e.message);
     } finally {
@@ -117,7 +117,7 @@ async function setSetting(key, value) {
   } catch (e) {
     // 401 (anonymous), 503 (no DB), 5xx all collapse to "local-only mode":
     // keep the value in settings.value + localStorage so the picker remains
-    // functional. Do not revert — the documented contract is that anonymous
+    // functional. Do not revert - the documented contract is that anonymous
     // users still get a working picker via the localStorage cache.
     if (e instanceof ApiError) {
       console.warn(`User setting PUT not persisted (HTTP ${e.status})`);
@@ -129,7 +129,7 @@ async function setSetting(key, value) {
     // resolves before the GET, dropping the guard here would let the GET's
     // (possibly pre-PUT) snapshot clobber the user's just-confirmed value
     // when `loadSettings` reads `dirtyKeys`. After initial load the await
-    // is free — `fetchPromise` is already resolved.
+    // is free - `fetchPromise` is already resolved.
     if (fetchPromise) {
       try { await fetchPromise; } catch { /* GET error already handled */ }
     }
@@ -139,7 +139,7 @@ async function setSetting(key, value) {
 
 // The `data-scheme` attribute on <html> is applied by the shared
 // `useColorScheme` (see src/composables/useColorScheme.js), which consumes this
-// store's `theme`/`setTheme` as its persistence backend — so theme application
+// store's `theme`/`setTheme` as its persistence backend - so theme application
 // lives in exactly one place across all three frontends.
 
 export function useUserSettings() {

--- a/frontend/src/gherkin/actions.js
+++ b/frontend/src/gherkin/actions.js
@@ -1,5 +1,5 @@
 /**
- * Editor BDD semantics — the single JS dispatch file (mirror of Rust dispatch.rs).
+ * Editor BDD semantics - the single JS dispatch file (mirror of Rust dispatch.rs).
  *
  * One `dispatch(ctx, engine, action, args, table, { loadDependency })` runs the
  * effect for a canonical grammar action. The generated grammar
@@ -228,6 +228,6 @@ export async function dispatch(ctx, engine, action, args, table, { loadDependenc
       throw tierUnsupported('notes');
 
     default:
-      throw new Error(`unknown action '${action}' — grammar/dispatch out of sync`);
+      throw new Error(`unknown action '${action}' - grammar/dispatch out of sync`);
   }
 }

--- a/frontend/src/gherkin/context.js
+++ b/frontend/src/gherkin/context.js
@@ -1,5 +1,5 @@
 /**
- * ExecutionContext — holds state for a single scenario execution.
+ * ExecutionContext - holds state for a single scenario execution.
  */
 export class ExecutionContext {
   constructor() {

--- a/frontend/src/gherkin/formMapper.js
+++ b/frontend/src/gherkin/formMapper.js
@@ -11,7 +11,7 @@ import { GRAMMAR } from './grammar.generated.js';
 // --- Generated grammar lookups (single source of truth for phrasing) ---
 
 // Emit-templates keyed by grammar entry id, and a capitalized keyword prefix
-// (Given/When/Then) per entry id — both derived from GRAMMAR so phrasing and
+// (Given/When/Then) per entry id - both derived from GRAMMAR so phrasing and
 // keyword stay single-sourced.
 const TPL = Object.fromEntries(GRAMMAR.map((e) => [e.id, e.template]));
 const KW = Object.fromEntries(
@@ -290,7 +290,7 @@ export function syncEditedValues(formState, scenarioIndex, values) {
       // Update existing scenario-level parameter
       scenario.setup.parameters[scenarioParamMap.get(name)].value = value;
     } else if (bgParamMap.has(name)) {
-      // Background param — add scenario override only if value differs
+      // Background param - add scenario override only if value differs
       const bgValue = bgParamMap.get(name).value;
       if (String(bgValue) !== String(value)) {
         scenario.setup.parameters.push({ name, value });
@@ -298,7 +298,7 @@ export function syncEditedValues(formState, scenarioIndex, values) {
     }
   }
 
-  // Drop scenario-level overrides that now match the background — otherwise
+  // Drop scenario-level overrides that now match the background - otherwise
   // a save/edit/save cycle accumulates redundant `Given parameter ...` steps.
   scenario.setup.parameters = scenario.setup.parameters.filter((p) => {
     if (!bgParamMap.has(p.name)) return true;
@@ -320,12 +320,12 @@ export function syncEditedValues(formState, scenarioIndex, values) {
         // Update existing scenario-level data source in place
         scenario.setup.dataSources[scenarioDsMap.get(stateDs.sourceName)] = stateDs;
       } else if (bgDsMap.has(stateDs.sourceName)) {
-        // Background data source — add scenario override only if it differs
+        // Background data source - add scenario override only if it differs
         if (!dataSourcesEqual(bgDsMap.get(stateDs.sourceName), stateDs)) {
           scenario.setup.dataSources.push(stateDs);
         }
       } else {
-        // Wholly new data source — add at scenario level
+        // Wholly new data source - add at scenario level
         scenario.setup.dataSources.push(stateDs);
       }
     }
@@ -339,7 +339,7 @@ export function syncEditedValues(formState, scenarioIndex, values) {
 
   // Sync calculation date (scenario-level override).
   // Treat `null`, `undefined` and `""` as "user cleared the field" so that
-  // a clear is not silently dropped — otherwise the next save would write
+  // a clear is not silently dropped - otherwise the next save would write
   // the stale date back to the .feature file.
   if (calculationDate !== undefined) {
     const cleared = calculationDate === null || calculationDate === '';
@@ -489,6 +489,6 @@ function formatAssertion(assertion) {
     case 'contains':
       return ['assert_contains', TPL.assert_contains([assertion.outputName, assertion.value])];
     default:
-      throw new Error(`formatAssertion: unhandled assertionType '${assertion.assertionType}' — classifier/serializer out of sync`);
+      throw new Error(`formatAssertion: unhandled assertionType '${assertion.assertionType}' - classifier/serializer out of sync`);
   }
 }

--- a/frontend/src/gherkin/parser.js
+++ b/frontend/src/gherkin/parser.js
@@ -1,5 +1,5 @@
 /**
- * Gherkin parser — wraps @cucumber/gherkin to produce a simplified AST.
+ * Gherkin parser - wraps @cucumber/gherkin to produce a simplified AST.
  *
  * Returns { feature, scenarios[] } where each scenario has steps[]
  * and optional dataTables.

--- a/frontend/src/gherkin/steps.js
+++ b/frontend/src/gherkin/steps.js
@@ -2,7 +2,7 @@
  * Gherkin step executor for the RegelRecht editor engine.
  *
  * Step definitions are derived from the generated canonical grammar
- * (grammar.generated.js) — never hand-listed here. Each definition is
+ * (grammar.generated.js) - never hand-listed here. Each definition is
  * { pattern: RegExp, tier: string, execute: async (ctx, engine, match, step) => void }.
  * The actual semantics live in actions.js (the single dispatch file). The editor
  * supports only the `core` tier; non-core steps throw via their action arm.

--- a/frontend/src/harvester/HarvesterView.vue
+++ b/frontend/src/harvester/HarvesterView.vue
@@ -1,9 +1,9 @@
 <script setup>
 /**
- * HarvesterView — the harvester-admin "Corpusinwinning" section, merged into the editor.
+ * HarvesterView - the harvester-admin "Corpusinwinning" section, merged into the editor.
  *
  * Top-level route (sibling of AppShell, not nested) so it carries its own
- * compact chrome instead of the editor's app chrome — mirroring the other
+ * compact chrome instead of the editor's app chrome - mirroring the other
  * standalone views (WerkdocumentenView, TrajectChooserView). It hosts the two
  * sub-screens (Law Entries / Jobs) via a nested <router-view>, matching the
  * original standalone admin dashboard's App shell.

--- a/frontend/src/harvester/charts/chartColors.js
+++ b/frontend/src/harvester/charts/chartColors.js
@@ -3,7 +3,7 @@
  *
  * ECharts renders to canvas, so it can't consume CSS custom properties or
  * light-dark() directly. Each token is resolved by computing it on a probe
- * element and normalizing through a 1×1 canvas — which also converts oklch()
+ * element and normalizing through a 1×1 canvas - which also converts oklch()
  * (the NLDD primitive format, unsupported by zrender) to plain rgb.
  *
  * The probe hangs off document.body, NOT the chart's own container: freshly
@@ -47,7 +47,7 @@ export function resolveChartColors() {
   const colors = {};
   try {
     if (ctx && getComputedStyle(document.body).colorScheme === 'normal') {
-      // light-dark() is invalid under color-scheme: normal — the design
+      // light-dark() is invalid under color-scheme: normal - the design
       // system's scheme isn't applied yet. Signal "not ready".
       return null;
     }

--- a/frontend/src/harvester/charts/dailyJobsChart.js
+++ b/frontend/src/harvester/charts/dailyJobsChart.js
@@ -35,7 +35,7 @@ export function formatAxisDate(isoDate) {
  *   One entry per day, ascending (as served by dashboard-stats `daily`).
  * @param {{succeeded: string, failed: string, added: string, text: string,
  *          textSecondary: string, grid: string, surface: string}} colors
- *   Resolved concrete colors (rgb/hex — canvas can't read CSS variables).
+ *   Resolved concrete colors (rgb/hex - canvas can't read CSS variables).
  */
 export function buildDailyJobsOption(entries, colors) {
   // Succeeded under, failed on top: the stack totals "finished that day" and
@@ -67,7 +67,7 @@ export function buildDailyJobsOption(entries, colors) {
       trigger: 'axis',
       axisPointer: { type: 'shadow' },
       valueFormatter: formatAxisNumber,
-      // Theme the tooltip too — the ECharts default is white-on-light only.
+      // Theme the tooltip too - the ECharts default is white-on-light only.
       backgroundColor: colors.surface,
       borderColor: colors.grid,
       textStyle: { color: colors.text },

--- a/frontend/src/harvester/components/DailyJobsChart.vue
+++ b/frontend/src/harvester/components/DailyJobsChart.vue
@@ -4,7 +4,7 @@
  * single job type. Data comes in as plain entries; colors are resolved from
  * the NLDD tokens at mount and re-resolved when the color scheme flips
  * (data-scheme attribute for the explicit picker, the media query for
- * 'auto') — the tokens are light-dark() pairs the canvas can't track itself.
+ * 'auto') - the tokens are light-dark() pairs the canvas can't track itself.
  */
 import { computed, onMounted, onUnmounted, shallowRef } from 'vue';
 import { use } from 'echarts/core';

--- a/frontend/src/harvester/components/UntranslatableDetailPanel.vue
+++ b/frontend/src/harvester/components/UntranslatableDetailPanel.vue
@@ -1,6 +1,6 @@
 <script setup>
 /**
- * UntranslatableDetailPanel — right-side sheet showing one untranslatable
+ * UntranslatableDetailPanel - right-side sheet showing one untranslatable
  * (RFC-012) in full. DetailPanel.vue is job-shaped (hardcoded job fields), so
  * this is a sibling rather than a reuse. The long free-text fields (reason,
  * suggestion, legal text excerpt) don't fit a table cell and live here.

--- a/frontend/src/harvester/composables/usePollingFetch.js
+++ b/frontend/src/harvester/composables/usePollingFetch.js
@@ -22,7 +22,7 @@ export function usePollingFetch(buildUrl, options = {}) {
     try {
       // 401 is handled by the editor's global apiAuthGuard (redirect to
       // login); return early on it so we don't flash an error state before the
-      // redirect — matching the mutation call sites (RowActions etc.). apiFetch
+      // redirect - matching the mutation call sites (RowActions etc.). apiFetch
       // throws ApiError on other non-ok statuses, caught below.
       const response = await apiFetch(url, { allowStatuses: [401] });
       if (response.status === 401) return;

--- a/frontend/src/harvester/composables/useTableFilters.js
+++ b/frontend/src/harvester/composables/useTableFilters.js
@@ -16,7 +16,7 @@ export function useTableFilters(getFilters, emit) {
     Object.values(getFilters() || {}).some((v) => v !== '' && v != null),
   );
 
-  // Clear every active filter by emitting an empty value per key — the
+  // Clear every active filter by emitting an empty value per key - the
   // parent's setFilter handler deletes a filter when given a falsy value.
   function clearFilters() {
     for (const key of Object.keys(getFilters() || {})) {

--- a/frontend/src/harvester/constants.js
+++ b/frontend/src/harvester/constants.js
@@ -77,9 +77,9 @@ export const GROUPED_COLUMNS = [
 ];
 
 // Untranslatables (RFC-012): one row per legal construct the enrichment agent
-// could not express with the engine's current operation set. Atomic grain —
+// could not express with the engine's current operation set. Atomic grain -
 // grouped views (per construct / per law) are aggregation over this same list.
-// Keep in sync with ENRICH_PROVIDERS in packages/pipeline/src/enrich.rs — a
+// Keep in sync with ENRICH_PROVIDERS in packages/pipeline/src/enrich.rs - a
 // provider added there but not here still displays, only its filter option is missing.
 export const UNTRANSLATABLE_PROVIDERS = ['opencode', 'claude'];
 
@@ -131,7 +131,7 @@ export const UNTRANSLATABLE_COLUMNS = [
   },
 ];
 
-// Sort menus are independent from visible columns — users should be able to
+// Sort menus are independent from visible columns - users should be able to
 // sort by fields that aren't shown as a separate column.
 // `directionLabels` controls which directions appear in the menu:
 //  - both keys → menu has both ascending + descending items
@@ -143,7 +143,7 @@ const DIR_DATE    = { desc: 'new - old', asc: 'old - new' };
 const DIR_NUMERIC = { desc: 'high - low', asc: 'low - high' };
 const DIR_TEXT    = { asc: 'a - z', desc: 'z - a' };
 
-// Sort options are ordered by relevance — most useful pivots first.
+// Sort options are ordered by relevance - most useful pivots first.
 export const JOB_SORT_OPTIONS = [
   { key: 'created_at', label: 'Recent changes' },
   { key: 'status', label: 'Status' },
@@ -201,7 +201,7 @@ export const STATUS_BADGE_MAP = {
   pending: 'neutral',
   unknown: 'neutral',
   queued: 'neutral',
-  // No consolidated text to harvest — informational, terminal, not a failure.
+  // No consolidated text to harvest - informational, terminal, not a failure.
   not_harvestable: 'neutral',
   // Untranslatables (RFC-012): the human-review `accepted` flag rendered as a
   // badge. `accepted` is a review gate that defaults to false, so false means

--- a/frontend/src/harvester/harvester.css
+++ b/frontend/src/harvester/harvester.css
@@ -1,4 +1,4 @@
-/* Harvester "Corpusinwinning" section styles — the component-specific hooks ported from
+/* Harvester "Corpusinwinning" section styles - the component-specific hooks ported from
    the standalone admin dashboard (packages/admin/frontend-src/css/admin.css).
    These target light-DOM class hooks in the ported table/toolbar components, so
    they must be global (an SFC `<style scoped>` on HarvesterView would not reach
@@ -56,7 +56,7 @@
   background: var(--primitives-color-critical-450);
 }
 
-/* Daily jobs charts (Overzicht) — ECharts needs an explicit height to render. */
+/* Daily jobs charts (Overzicht) - ECharts needs an explicit height to render. */
 .daily-jobs-chart {
   height: 260px;
 }

--- a/frontend/src/harvester/views/JobsView.vue
+++ b/frontend/src/harvester/views/JobsView.vue
@@ -31,7 +31,7 @@ const { job: detailJob, isOpen: detailOpen, open: openDetail, close: closeDetail
 const { isOpen: lawJobsSheetOpen, open: openLawJobs } = useLawJobsSheet();
 
 // Sync viewMode to URL so a refresh keeps the selected view. Grouped is the
-// default — omit the param in that case to keep the URL clean.
+// default - omit the param in that case to keep the URL clean.
 watch(viewMode, (mode) => {
   const { view, ...rest } = route.query;
   router.replace({ query: mode === 'flat' ? { ...rest, view: 'flat' } : rest });

--- a/frontend/src/harvester/views/OverviewView.test.js
+++ b/frontend/src/harvester/views/OverviewView.test.js
@@ -46,7 +46,7 @@ const STATS = {
 const openDetail = vi.fn();
 const closeDetail = vi.fn();
 
-// Per-mount stats value — tests can swap it to mount with a variant payload.
+// Per-mount stats value - tests can swap it to mount with a variant payload.
 let currentStats = STATS;
 
 vi.mock('../composables/useDashboardStats.js', () => ({

--- a/frontend/src/harvester/views/OverviewView.vue
+++ b/frontend/src/harvester/views/OverviewView.vue
@@ -36,7 +36,7 @@ const topKpis = computed(() => {
 
 // Harvest and enrich are treated as two separate kinds, each with its own
 // titled section: status breakdown + executed counts next to the daily chart.
-// `daily` is absent while an older API is deployed — then chartEntries stays
+// `daily` is absent while an older API is deployed - then chartEntries stays
 // empty and the chart simply doesn't render.
 const typePanels = computed(() => {
   const s = stats.value;

--- a/frontend/src/lib/apiAuthGuard.js
+++ b/frontend/src/lib/apiAuthGuard.js
@@ -14,7 +14,7 @@ import { ensureAuthReady, useAuth } from '../composables/useAuth.js';
 // `useAuth().login()` redirect so there is one auth path, not two.
 //
 // Deliberately NOT handled here:
-// - 403 (authenticated but missing role) is not a re-login case — redirecting
+// - 403 (authenticated but missing role) is not a re-login case - redirecting
 //   would loop. Call sites show their own "no access" message.
 // - Only same-origin `/api/*` responses are intercepted, so `/auth/*` (incl.
 //   `/auth/status`), `/data/*`, `/wasm/*` and cross-origin fetches pass through.
@@ -22,7 +22,7 @@ import { ensureAuthReady, useAuth } from '../composables/useAuth.js';
 //   call `/api/*` endpoints that 401 without a session (e.g. `/library` loads
 //   `/api/favorites`, which the editor tolerates as "no favorites"), and local
 //   dev runs with OIDC disabled. We only redirect a session that loaded
-//   authenticated against a configured IdP and then got a 401 — i.e. its
+//   authenticated against a configured IdP and then got a 401 - i.e. its
 //   session expired. This mirrors the router guard's `oidcConfigured` gate.
 
 /**
@@ -36,7 +36,7 @@ export function isApiUrl(input) {
   let url;
   try {
     // Resolve against the full current URL (not just the origin) so bare
-    // relative paths resolve exactly as the browser's fetch does — e.g. on
+    // relative paths resolve exactly as the browser's fetch does - e.g. on
     // `/trajects/123`, `fetch('api/x')` hits `/trajects/api/x`, not `/api/x`.
     url = new URL(raw, window.location.href);
   } catch {
@@ -68,7 +68,7 @@ export function installApiAuthGuard() {
       if (oidcConfigured.value && authenticated.value && !redirecting) {
         redirecting = true;
         // No explicit returnUrl: the navigation has already committed, so
-        // window.location reflects the page the user is actually on — exactly
+        // window.location reflects the page the user is actually on - exactly
         // where they should return after re-auth.
         login();
       }

--- a/frontend/src/lib/apiAuthGuard.test.js
+++ b/frontend/src/lib/apiAuthGuard.test.js
@@ -60,7 +60,7 @@ describe('isApiUrl', () => {
   });
 
   it('resolves bare relative paths against the document path, like fetch', () => {
-    // On /trajects/123, fetch('api/x') hits /trajects/api/x — NOT an API call.
+    // On /trajects/123, fetch('api/x') hits /trajects/api/x - NOT an API call.
     window.history.pushState({}, '', '/trajects/123');
     try {
       expect(isApiUrl('api/trajects')).toBe(false);
@@ -84,7 +84,7 @@ describe('installApiAuthGuard', () => {
   });
 
   it('does NOT redirect an unauthenticated session (anonymous public-page 401)', async () => {
-    // e.g. /library loading /api/favorites without a session — tolerated, no bounce.
+    // e.g. /library loading /api/favorites without a session - tolerated, no bounce.
     const { wrapped } = await freshGuard(401, { authenticated: false });
     await wrapped('/api/favorites');
     expect(loginSpy).not.toHaveBeenCalled();

--- a/frontend/src/lib/lruMap.js
+++ b/frontend/src/lib/lruMap.js
@@ -1,5 +1,5 @@
 /**
- * createLruMap — a Map with least-recently-used eviction.
+ * createLruMap - a Map with least-recently-used eviction.
  *
  * Consolidates the copy-pasted "Map insertion order IS the LRU order"
  * caches (law cache in `useLaw`, per-scope laws list in `useCorpusLaws`,
@@ -9,7 +9,7 @@
  *
  * `onEvict(key, value)` lets a cache keep companion state in sync when
  * an entry falls out (drop a paired promise, unload a law from the WASM
- * engine, …). It only fires for capacity evictions — not for explicit
+ * engine, …). It only fires for capacity evictions - not for explicit
  * `delete`/`clear`, where the caller is already managing the entry.
  *
  * @template K, V

--- a/frontend/src/lib/lruMap.test.js
+++ b/frontend/src/lib/lruMap.test.js
@@ -46,7 +46,7 @@ describe('createLruMap', () => {
     lru.set('a', 1);
     lru.set('b', 2);
     expect(lru.peek('a')).toBe(1);
-    lru.set('c', 3); // 'a' is still oldest — peek did not bump it
+    lru.set('c', 3); // 'a' is still oldest - peek did not bump it
     expect(lru.has('a')).toBe(false);
   });
 

--- a/frontend/src/lib/traceEdges.js
+++ b/frontend/src/lib/traceEdges.js
@@ -1,5 +1,5 @@
 /**
- * traceEdges — flatten a PathNode trace tree into a linear step list and
+ * traceEdges - flatten a PathNode trace tree into a linear step list and
  * match each step to graph edge / node IDs for highlighting.
  *
  * Ported 1:1 from demo/graph/src/lib/traceEdges.ts on branch
@@ -19,7 +19,7 @@
  *   - delegate: `${lawId}-delegate-${name}`
  *   - impl:     `${lawId}-impl-${name}`
  *
- * If you change either scheme, update BOTH this file and useLawGraph.js —
+ * If you change either scheme, update BOTH this file and useLawGraph.js -
  * the integration test in traceEdges.test.js is the tripwire.
  */
 
@@ -127,14 +127,14 @@ export function flattenTraceSteps(root, rootLawId) {
 /**
  * Pre-index edges so per-step matchers don't have to scan the full edge
  * list. `useTraceStepping.steps` builds this once per (graph) change and
- * passes it to every `edgeIdsForStep` call — cuts step enrichment from
+ * passes it to every `edgeIdsForStep` call - cuts step enrichment from
  * O(steps × edges) to O(steps).
  *
  * Buckets mirror the four switch arms in `edgeIdsForStep`:
- *   - bySource           — `${law}-input-${name}` → edges with that source
- *   - byImplOpenTerm     — open-term name → `impl:` edges ending `:${name}`
- *   - byOvrSourceLaw     — law id → `ovr:${law}:` edges
- *   - byHookPrefix       — `hook:${name}->` → edges with that prefix
+ *   - bySource           - `${law}-input-${name}` → edges with that source
+ *   - byImplOpenTerm     - open-term name → `impl:` edges ending `:${name}`
+ *   - byOvrSourceLaw     - law id → `ovr:${law}:` edges
+ *   - byHookPrefix       - `hook:${name}->` → edges with that prefix
  */
 export function buildEdgeIndex(edges) {
   const bySource = new Map();
@@ -159,7 +159,7 @@ export function buildEdgeIndex(edges) {
       const colon = arrow !== -1 ? e.id.indexOf(':', arrow + 2) : -1;
       if (colon !== -1) push(byImplOpenTerm, e.id.substring(colon + 1), e);
     } else if (e.id.startsWith('ovr:')) {
-      // `ovr:${lawA}:${art}->${lawB}:${art}` — bucket by `lawA`
+      // `ovr:${lawA}:${art}->${lawB}:${art}` - bucket by `lawA`
       const head = e.id.indexOf(':');
       const tail = e.id.indexOf(':', head + 1);
       if (head !== -1 && tail !== -1) {
@@ -210,7 +210,7 @@ function splitQualifiedName(name) {
  * get highlighted.
  *
  * Pass a pre-built `index` from `buildEdgeIndex(edges)` to skip the full
- * edge scan — `useTraceStepping` does this for every step at once.
+ * edge scan - `useTraceStepping` does this for every step at once.
  * Without it, a transient index is built locally so the function still
  * works on its own (test-friendly).
  */
@@ -237,7 +237,7 @@ export function edgeIdsForStep(step, edges, index) {
       return out;
     }
     case 'open_term_resolution': {
-      // `lawId` is ambiguous on open_term steps — `flattenTraceSteps`
+      // `lawId` is ambiguous on open_term steps - `flattenTraceSteps`
       // doesn't switch `descendLawId` on this node type, so the engine
       // emits it under whichever law was active (typically the higher
       // declaring law, not the implementing one). The `impl:` edge id
@@ -265,7 +265,7 @@ export function edgeIdsForStep(step, edges, index) {
     case 'override_resolution': {
       // Edge ID format: `ovr:${lawA}:${art}->${lawB}:${article}`
       // TODO(PR3): step.name carries the overridden output but goes
-      // unused — when one law overrides multiple outputs all `ovr:`
+      // unused - when one law overrides multiple outputs all `ovr:`
       // edges from that law light up simultaneously. A precise match
       // would also constrain by source/target output name once the
       // engine starts emitting the output in the trace node.
@@ -338,7 +338,7 @@ export function graphNodeIdsForStep(step, nodes, nodeIdSet) {
       break;
     }
     case 'requirement':
-      // Just the law root — nothing more specific.
+      // Just the law root - nothing more specific.
       break;
     case 'resolve': {
       const rt = step.resolveType;

--- a/frontend/src/lib/traceEdges.perf.test.js
+++ b/frontend/src/lib/traceEdges.perf.test.js
@@ -5,12 +5,12 @@
  * trace of 500 steps mixing every node type the matcher handles, then
  * measures how long it takes to enrich each step with `edgeIds` and
  * `nodeIds`. This is the work `useTraceStepping.steps` does once per
- * (result, graph) change — the user-perceived hang after running a
+ * (result, graph) change - the user-perceived hang after running a
  * scenario on a heavy law.
  *
  * Numbers are logged via `console.log`; the assert is a generous upper
  * bound so the test stays green on slow CI runners. The intent is the
- * log line — read the PR body for baseline → after numbers.
+ * log line - read the PR body for baseline → after numbers.
  */
 import { describe, it, expect } from 'vitest';
 import {
@@ -82,7 +82,7 @@ function buildSyntheticGraph() {
   return { nodes, edges };
 }
 
-// Flat-ish trace tree — STEP_COUNT children under one root, every child
+// Flat-ish trace tree - STEP_COUNT children under one root, every child
 // rotates through the matcher's recognised node types so each step does
 // non-trivial filter work.
 function buildSyntheticTrace() {
@@ -172,7 +172,7 @@ describe('trace edge enrichment perf', () => {
     expect(baseline).toBeLessThan(2000);
     expect(flat.length).toBeGreaterThanOrEqual(150);
     // Minimum bar: any measurable speedup. Slow CI runners are too noisy
-    // for a tighter ratio assert — read the logged speedup line for the
+    // for a tighter ratio assert - read the logged speedup line for the
     // real number (typically 70-90× on a developer laptop).
     expect(after).toBeLessThan(baseline);
   });

--- a/frontend/src/lib/traceEdges.test.js
+++ b/frontend/src/lib/traceEdges.test.js
@@ -123,7 +123,7 @@ describe('edgeIdsForStep', () => {
     ]);
   });
 
-  // open_term_resolution: step.lawId is ambiguous — flattenTraceSteps
+  // open_term_resolution: step.lawId is ambiguous - flattenTraceSteps
   // doesn't switch descendLawId on this node type, so the engine emits
   // it under whichever law is currently active (typically the higher
   // declaring law, e.g. wet_A). The matcher must work for either id.

--- a/frontend/src/lib/useLatest.js
+++ b/frontend/src/lib/useLatest.js
@@ -1,5 +1,5 @@
 /**
- * useLatest — the "generation counter" guard against stale async writes.
+ * useLatest - the "generation counter" guard against stale async writes.
  *
  * The editor re-implemented this pattern at every place where a slow
  * response could land after a newer request superseded it (law switch,
@@ -9,7 +9,7 @@
  *   async function load() {
  *     const gen = ++generation;
  *     const res = await fetch(...);
- *     if (gen !== generation) return; // stale — discard
+ *     if (gen !== generation) return; // stale - discard
  *   }
  *
  * `useLatest()` captures that counter. Each call to the returned `claim`
@@ -27,7 +27,7 @@
  * supersede each other (e.g. `load()` and `switchLaw()` writing the same
  * refs) share one instance; independent resources get their own.
  *
- * @returns {() => () => boolean} claim — starts a new generation,
+ * @returns {() => () => boolean} claim - starts a new generation,
  *   returns its `isCurrent` predicate.
  */
 export function useLatest() {

--- a/frontend/src/lib/useLatest.test.js
+++ b/frontend/src/lib/useLatest.test.js
@@ -38,7 +38,7 @@ describe('useLatest', () => {
       writes.push(value);
     }
 
-    // Slow "old" load resolves after the fast "new" one — only the
+    // Slow "old" load resolves after the fast "new" one - only the
     // newest may write.
     await Promise.all([load('old', 20), load('new', 0)]);
     expect(writes).toEqual(['new']);

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -11,8 +11,8 @@ const router = createRouter({
       // Persistent shell: holds the shared chrome (toolbars, tab-bar,
       // settings menu, traject-switcher) and a nested <router-view> for the
       // section bodies. Editor and library are children of this one record,
-      // so switching between them reuses the shell instance — only the nested
-      // router-view swaps — and the chrome never rebuilds on a tab switch.
+      // so switching between them reuses the shell instance - only the nested
+      // router-view swaps - and the chrome never rebuilds on a tab switch.
       path: '/',
       component: AppShell,
       children: [
@@ -25,7 +25,7 @@ const router = createRouter({
           //
           // The `:trajectRef` regex pins the param to `{slug}-{8hex}` so a
           // plain law-id slug like `wet_op_de_zorgtoeslag` does NOT match
-          // here — it falls through to the no-traject library below.
+          // here - it falls through to the no-traject library below.
           path: 'library/:trajectRef([a-z0-9-]+-[0-9a-f]{8})/:lawId?/:articleNumber?',
           name: 'library-traject',
           component: LibraryView,
@@ -81,7 +81,7 @@ const router = createRouter({
       ],
     },
     {
-      // Trajectchooser — sectie-neutrale URL (library|editor via `sectie`,
+      // Trajectchooser - sectie-neutrale URL (library|editor via `sectie`,
       // default editor) zodat zowel de bibliotheek als de editor 'm gebruiken;
       // `law`/`article` dragen de beoogde bestemming mee. Top-level route (geen
       // AppShell-child), zoals werkdocumenten: geen app-chrome, de pagina draagt
@@ -92,7 +92,7 @@ const router = createRouter({
       meta: { title: 'Trajecten', requiresAuth: true },
     },
     {
-      // Nieuw traject aanmaken — eigen pagina met het gedeelde aanmaakformulier
+      // Nieuw traject aanmaken - eigen pagina met het gedeelde aanmaakformulier
       // (TrajectCreateForm). Ook top-level (geen app-chrome). Het statische pad
       // `/editor/nieuw-traject` scoort boven de dynamische `/editor/...`-routes
       // in de AppShell, dus een traject-ref of wet-id matcht deze nooit.
@@ -102,9 +102,9 @@ const router = createRouter({
       meta: { title: 'Nieuw traject', requiresAuth: true },
     },
     {
-      // Harvester-admin "Corpusinwinning" section — the merged harvester dashboard.
+      // Harvester-admin "Corpusinwinning" section - the merged harvester dashboard.
       // Top-level route (sibling of AppShell, not nested) so it carries its own
-      // chrome (HarvesterView), with the two sub-screens as nested children —
+      // chrome (HarvesterView), with the two sub-screens as nested children -
       // mirroring the original standalone admin dashboard. Gated on any
       // harvester-* role via `meta.requiresRole` (checked in `beforeEach`);
       // write actions inside are enforced server-side by the harvester-admin
@@ -176,7 +176,7 @@ const router = createRouter({
 // block the client-side navigation until `/auth/status` has resolved, so the
 // target component never mounts until we know the user may enter.
 // Unauthenticated users are always sent to `/auth/login` and the navigation
-// is cancelled — the previous route stays visible until the browser leaves,
+// is cancelled - the previous route stays visible until the browser leaves,
 // instead of flashing the protected UI. Deliberately NOT conditional on
 // `oidcConfigured`: the editor must never open without login, including
 // environments without OIDC (there `/auth/login` either serves the dev login
@@ -209,6 +209,6 @@ router.afterEach((to) => {
 });
 
 // document.title is owned by the route components (they reflect law + article
-// state) via watchEffect — see the note that used to live here on main.
+// state) via watchEffect - see the note that used to live here on main.
 
 export default router;

--- a/frontend/src/router.test.js
+++ b/frontend/src/router.test.js
@@ -42,7 +42,7 @@ describe('route disambiguation (traject vs no-traject)', () => {
   });
 });
 
-describe('sectionTarget — traject preserved across tab switches', () => {
+describe('sectionTarget - traject preserved across tab switches', () => {
   it('stamps the active traject when entering a section without one', () => {
     const t = sectionTarget(router, '/library/wet_op_de_zorgtoeslag', REF);
     expect(t.name).toBe('library-traject');

--- a/frontend/src/shims/node-module.js
+++ b/frontend/src/shims/node-module.js
@@ -8,7 +8,7 @@
 //
 // `createRequire` is a Node-only API; in the browser the bundler stubs
 // `node:module` to an empty object, so `createRequire` is undefined and the
-// call throws `TypeError: createRequire is not a function` at module load —
+// call throws `TypeError: createRequire is not a function` at module load -
 // crashing every view that imports the gherkin parser (the whole editor).
 //
 // We never use that version string, so provide a minimal `createRequire` whose

--- a/frontend/src/utils/articleMapping.js
+++ b/frontend/src/utils/articleMapping.js
@@ -61,7 +61,7 @@ export function buildTypeMap(articles) {
 }
 
 /**
- * Builds a fieldName -> { type, unit } map for EXTERNAL data-source fields —
+ * Builds a fieldName -> { type, unit } map for EXTERNAL data-source fields -
  * inputs whose `source` is empty (no `regulation` and no `output`), i.e. raw
  * data the engine resolves by field name (e.g. insurance.verdragsinschrijving).
  * Spans a set of law docs (the current law + its loaded dependencies), because
@@ -79,7 +79,7 @@ export function buildExternalFieldTypeMap(lawDocs) {
         const src = f.source;
         // External data-source fields are declared with an empty `source: {}`
         // (a `regulation` means cross-law, an `output` means internal). Match
-        // exactly that — an empty object — rather than merely "no regulation and
+        // exactly that - an empty object - rather than merely "no regulation and
         // no output", so a malformed source carrying other keys isn't
         // misclassified as external. (versionsCache YAML is not schema-checked.)
         const isExternal = src && typeof src === 'object' && Object.keys(src).length === 0;

--- a/frontend/src/utils/operationTree.js
+++ b/frontend/src/utils/operationTree.js
@@ -34,7 +34,7 @@ export const OPERATION_LABELS = {
 const DATE_DIFF_UNIT_LABELS = { days: 'dagen', months: 'maanden', years: 'jaren' };
 
 export function collectAvailableVariables(article) {
-  // Engine built-in context variables — always available regardless of
+  // Engine built-in context variables - always available regardless of
   // article content. `referencedate` is the calculation date injected by
   // the engine from the scenario's "Given the calculation date is ..."
   const vars = [
@@ -88,7 +88,7 @@ export function buildOperationTree(action) {
     return [];
   }
 
-  // Onderwerp/Waarde rows keep YAML form verbatim — identifiers must match
+  // Onderwerp/Waarde rows keep YAML form verbatim - identifiers must match
   // their `$VAR` references. But the Titel row is a human-readable LABEL,
   // not a snippet of YAML; if the user later adds a `title:` field on the
   // operation, it'd never have `$` or underscores, and a derived title
@@ -175,7 +175,7 @@ function isOperationNode(v) {
   return v != null && typeof v === 'object' && v.operation;
 }
 
-// Subtitle generation — produces a compact, infix-style description of what
+// Subtitle generation - produces a compact, infix-style description of what
 // an operation node does. Examples:
 //   EQUALS  → "$x = 0"
 //   AND (3) → "$a en $b en $c"
@@ -255,7 +255,7 @@ export function describeSubtitle(node) {
     return labels.join(' + ');
   }
 
-  // IF/SWITCH have no single subject and multiple branches — any one-line
+  // IF/SWITCH have no single subject and multiple branches - any one-line
   // summary leaves out important parts of the operation. The structural
   // count ("1 conditie + standaard") was technically accurate but confusing
   // because it doesn't tell the reader what the operation actually returns.
@@ -293,7 +293,7 @@ function formatArgName(v) {
   if (typeof v === 'number') return String(v);
   if (typeof v === 'boolean') return String(v);
   if (isOperationNode(v)) {
-    // Prefer the first variable inside the nested op — much more informative
+    // Prefer the first variable inside the nested op - much more informative
     // than the operation label. So `AND( IN($a, ...), IN($b, ...) )` reads
     // as `$a en $b` instead of `(in lijst) en (in lijst)`. Falls back to
     // `(label)` only when the nested op holds no variable refs at all.
@@ -308,7 +308,7 @@ function formatArgName(v) {
 /**
  * Operand renderer for compositional ops (AND/OR/ADD/SUBTRACT/MIN/MAX/etc.).
  * Returns a clean label when the operand can be cleanly named, or `null`
- * when it's a nameless nested op — `null` signals the caller to fall back
+ * when it's a nameless nested op - `null` signals the caller to fall back
  * to the count-summary form rather than emit half-information like
  * `$a − (als/dan)` where the right side carries multiple operands but only
  * the wrapper type is shown.
@@ -332,10 +332,10 @@ function nameableOperand(v) {
  * all-caps idents) so the result reads like prose. Used as the Titel row in
  * OperationSettings, the row text in ActionSheet's parent-ops list, and the
  * (operatie) suffix on dropdown nested options. Falls through to the user-
- * supplied `node.title` (no derivation) when present — that's handled at
+ * supplied `node.title` (no derivation) when present - that's handled at
  * the buildOperationTree layer.
  *
- * Per-token regex (`$IDENT`) so each variable is humanised independently —
+ * Per-token regex (`$IDENT`) so each variable is humanised independently -
  * a string like `$PERCENTAGE_LID_5 + $aantal_dagen` becomes
  * `percentage lid 5 + aantal dagen` instead of inheriting the all-caps state
  * from one of its tokens.

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -6,7 +6,7 @@ import vue from '@vitejs/plugin-vue';
 // at import time (a Node-only API). In the browser build that throws and
 // crashes every view importing the gherkin parser, so alias `node:module` to a
 // browser shim that provides a harmless `createRequire`. Scope it to the build
-// only — under vitest (Node) the real `node:module` works, so we leave it.
+// only - under vitest (Node) the real `node:module` works, so we leave it.
 const isVitest = !!process.env.VITEST;
 const nodeModuleShim = fileURLToPath(
   new URL('./src/shims/node-module.js', import.meta.url),


### PR DESCRIPTION
## What

Mechanical replacement of em dashes (`—`) with plain hyphens (`-`) across `frontend/` and `frontend-lawmaking/` source, test, and e2e files: UI message strings, code comments, and the test assertions that match those strings (639 lines, 126 files).

Deliberately **not** replaced:
- Standalone `'—'` literals used as empty-value placeholders in table cells (a typographic convention, not a message).
- `frontend/src/gherkin/grammar.generated.js` (generated file; its header em dash comes from `bdd/codegen/gen-js.mjs`).
- Markdown research docs under `frontend-lawmaking/doc/` (not user-facing UI).

## Verification

- `npm test -w frontend`: 455 tests passed.
- `npm run build -w frontend-lawmaking`: builds clean.
- No regex character classes or generated files affected.