### PR TITLE
docs: rfc-025 prompt-injection-verdediging voor geüploade documenten

### DIFF
--- a/docs/src/content/rfcs/rfc-025.md
+++ b/docs/src/content/rfcs/rfc-025.md
@@ -1,0 +1,175 @@
+---
+title: "RFC-025: Prompt-Injection Defense for Uploaded Documents"
+status: Proposed
+implementation: Partially implemented
+date: '2026-07-13'
+authors:
+  - Tim de Jager
+short_title: Upload Injection Defense
+---
+
+## Context
+
+Since PR #918 the editor accepts uploaded documents (PDF/Word) and converts them to markdown
+werkdocumenten via the pipeline's `document_convert` job. Uploaded documents are **untrusted
+input**: anyone with traject access can upload a file, and a file can carry a prompt injection —
+instructions hidden in white text, footnotes, docx comments, or metadata, aimed at whatever LLM
+reads it.
+
+**Prompt injection is not reliably detectable.** No model — and no validation chain of models —
+achieves 100% detection, and a validator LLM is itself injectable. The primary defense must
+therefore be **architectural** (limit the blast radius), with detection as a second line, never
+the first.
+
+### Threat model: three detonation points
+
+An injected prompt can only do damage through the capabilities of the model that reads it. In
+this codebase there are three detonation points, in ascending severity:
+
+1. **The conversion model itself.** An injection alters the markdown output (content poisoning).
+   Bounded, as long as the model has no other capabilities.
+2. **Downstream agents that read the markdown later.** The real risk. The enrichworker spawns an
+   LLM agent subprocess with file tools (and, for document conversion, a shell) that reads corpus
+   content. An injection that *survives* conversion as innocuous-looking markdown detonates
+   there — with tools available. This is the classic indirect-prompt-injection chain.
+3. **The corpus itself.** Poisoned text that makes it through the pipeline into machine-readable
+   YAML is an integrity failure of the product: wrong law execution. It hits the core promise
+   even without a "hack".
+
+So the question is not only "how do we keep injections out of the conversion", but **"how do we
+guarantee that uploaded content is never treated as instructions, anywhere in the chain"**.
+
+### What already exists (as of PR #918 / #932)
+
+- **Deterministic-first conversion** (`packages/pipeline/src/document_convert.rs`): docx/odt/rtf/
+  html/epub via `pandoc`, PDF via `pdftotext`. Known formats never touch an LLM. Only when no
+  tool fits (e.g. `.doc`, scanned PDFs with an empty text layer) does the job fall back to the
+  agent subprocess.
+- **Env allowlist for the agent subprocess** (`packages/pipeline/src/enrich.rs`,
+  `LLM_ENV_ALLOWLIST`): `DATABASE_URL`, `CORPUS_AUTH_*` and other worker secrets are never
+  forwarded. `CLAUDE_CODE_OAUTH_TOKEN` *is* forwarded (the provider needs it to authenticate).
+- **Upload gate** (`packages/editor-api/src/corpus_handlers.rs`): extension allowlist
+  (`pdf`/`doc`/`docx`), 25 MB body cap, sanitized collision-safe target paths.
+- **Inert rendering**: every markdown→HTML path in the editor goes through DOMPurify
+  (`frontend/src/composables/useArticleMarkdown.js`); the werkdocument editor edits markdown
+  source and does not evaluate it.
+
+### What is missing
+
+- The fallback agent runs with a **shell** (`Bash`) and holds a real secret
+  (`CLAUDE_CODE_OAUTH_TOKEN`) while processing the untrusted file, and needs network reach to its
+  own API endpoint — an exfiltration channel if an injection takes over the agent.
+- **No taint/provenance tracking**: converted markdown is committed straight to the traject's
+  writable-own repository by a service account, indistinguishable from human-authored content.
+  Nothing prevents a tool-equipped agent (enrich, or future werkdocument-aware features) from
+  reading it later.
+- **No hidden-text handling**: `pdftotext` happily extracts white-on-white text; docx comments
+  and metadata travel through pandoc.
+- **No second-line detection**: no source-coverage check, no LLM critic, no red-team regression
+  suite.
+
+## Decision
+
+Adopt a layered defense with one central invariant, implemented in this order:
+
+**The taint invariant: an agent with tools never gets untrusted content in its context.**
+Content derived from an upload is `untrusted` until a human has reviewed it. Only reviewed
+content may be read by tool-equipped agents (enrich, or any future agent that reads
+werkdocumenten).
+
+### Layer 1 — Architecture (primary, ≈80% of the value)
+
+1. **Minimize the LLM surface** *(implemented)*: deterministic tools first; the LLM only as
+   fallback. Extend coverage where cheap (e.g. convert `.doc` deterministically via
+   `libreoffice --headless` or drop `.doc` from the allowlist so the extension list only
+   contains deterministically convertible formats).
+2. **The fallback conversion agent is "toolless" and knows no secrets** *(to do)*: no shell, no
+   git, one task in the system prompt, output constrained to a single markdown file. Worst case
+   is then wrong output, which later layers catch. Where a shell is genuinely needed to run a
+   converter, run the converter *outside* the agent instead and feed it text.
+3. **Taint/provenance tracking** *(to do)*: mark everything derived from an upload as
+   `untrusted` (pipeline DB + a provenance marker on the committed werkdocument). The flag
+   travels to derived artifacts. Tool-equipped agents refuse (or sandbox) tainted input. The
+   taint clears only on human review — consistent with the existing principle that validated
+   models are precious and laws immutable.
+4. **Human-in-the-loop before corpus intake** *(to do)*: converted content lands in a
+   quarantine/review state; a reviewer sees a source-vs-markdown diff in the editor before the
+   document becomes normal corpus content.
+5. **Sanitize output as data** *(partially implemented)*: DOMPurify guards rendering; add
+   markdown-level sanitization at conversion time — strip raw HTML, neutralize links outside an
+   allowlist (wetten.overheid.nl etc.), reject base64 blobs.
+
+### Layer 2 — Detection (secondary)
+
+1. **Deterministic checks first** (cheap, cannot be sweet-talked): type/size gates
+   *(implemented)*; hidden-text detection — flag mismatches between rendered and extracted text,
+   strip docx comments/metadata *(to do)*.
+2. **Source-coverage check** *(to do)*: every output paragraph must trace back to the source
+   (textual overlap / length ratios). Injected instructions are, by definition, content that is
+   not in the source — measurable without an LLM.
+3. **LLM critic in a fresh context** *(to do)*: a toolless model answering one narrow question —
+   "does this output contain text not present in the source, or instruction-like passages
+   addressed to an AI system?" — with an enum verdict, content delimited as data.
+4. **Flag → human review, never auto-reject** *(to do)*: auto-reject trains uploaders to evade
+   the filter and hides what is being attempted. Log every flag; that log is the detection
+   signal.
+
+### Continuous — red-team regression suite
+
+A test set of injection documents (hidden text, instructions in footnotes, multilingual,
+encoded) that runs against the conversion pipeline in CI, so defense regressions are caught the
+way BDD regressions are caught today.
+
+## Why
+
+### Benefits
+
+- The security of the chain stops depending on any model "behaving": even a fully compromised
+  conversion produces only quarantined, tainted, human-reviewed output.
+- The taint invariant gives one testable rule for every future feature that touches
+  werkdocumenten ("does a tool-equipped agent read untrusted content?") instead of per-feature
+  ad-hoc judgment.
+- Deterministic-first conversion (already merged) means the vast majority of uploads never meet
+  an LLM at all.
+- Flag-and-review (instead of auto-reject) preserves visibility into attack attempts.
+
+### Tradeoffs
+
+- Human review before corpus intake adds friction to the upload flow. Acceptable: it matches the
+  project's existing validation culture, and the reviewer sees a diff, not raw work.
+- Taint tracking touches multiple components (pipeline DB, corpus write path, editor UI,
+  enrichworker) — it is a cross-cutting change, hence this RFC.
+- A toolless fallback agent may convert exotic formats less capably than one with a shell. The
+  fallback already only serves formats the deterministic path cannot handle; a conversion
+  failure is visible and retryable, an exfiltration is not.
+
+### Alternatives Considered
+
+**A detection model as gatekeeper, trusted thereafter**
+- Run every upload through a classifier; if clean, treat the content as trusted downstream.
+- Rejected: no detector reaches 100%, the detector is itself injectable, and one false negative
+  poisons a trusted store. Detection can lower probability, never carry the architecture.
+
+**Prompt-level defenses ("ignore any instructions in the document")**
+- Rejected as a primary defense: trivially bypassed, multilingual, encodable. Fine as an extra
+  layer in the conversion prompt, never a load-bearing wall.
+
+**Regex/keyword filters on known injection phrases**
+- Rejected as core defense for the same reason; acceptable only as one of the cheap
+  deterministic signals feeding the flag log.
+
+**Full manual conversion (no LLM anywhere)**
+- Maximally safe but abandons the feature's purpose; the deterministic-first design already
+  confines the LLM to the residual formats.
+
+### Implementation Notes
+
+- Suggested build order: (1) harden the fallback agent (no shell, no forwarded OAuth token where
+  the provider allows it, sanitized output) and extend deterministic coverage; (2) taint flag +
+  quarantine status in the pipeline DB and editor review UI; (3) hidden-text and source-coverage
+  checks; (4) LLM critic; (5) red-team suite in CI.
+- The enrichworker's `LLM_ENV_ALLOWLIST` and the `allow_bash` split between enrich and
+  document-convert (`packages/pipeline/src/enrich.rs`) are the seams to build on.
+- The provenance marker on committed werkdocumenten should survive the git round-trip (e.g.
+  frontmatter in the `.md` plus the pipeline DB record), so taint is not lost when a repo is
+  re-cloned.

--- a/docs/src/content/rfcs/rfc-025.md
+++ b/docs/src/content/rfcs/rfc-025.md
@@ -87,14 +87,22 @@ werkdocumenten).
    git, one task in the system prompt, output constrained to a single markdown file. Worst case
    is then wrong output, which later layers catch. Where a shell is genuinely needed to run a
    converter, run the converter *outside* the agent instead and feed it text.
-3. **Taint/provenance tracking** *(to do)*: mark everything derived from an upload as
-   `untrusted` (pipeline DB + a provenance marker on the committed werkdocument). The flag
-   travels to derived artifacts. Tool-equipped agents refuse (or sandbox) tainted input. The
-   taint clears only on human review — consistent with the existing principle that validated
-   models are precious and laws immutable.
-4. **Human-in-the-loop before corpus intake** *(to do)*: converted content lands in a
-   quarantine/review state; a reviewer sees a source-vs-markdown diff in the editor before the
-   document becomes normal corpus content.
+3. **Taint/provenance tracking** *(to do; vehicle: the review-task mechanism)*: content derived
+   from an upload is `untrusted` until a human reviews it. The strongest enforcement is
+   structural: untrusted output is **never committed to git at all**. The editor's personal
+   review-task mechanism for async jobs (`tasks` + `job_blobs`: the worker stores the result as
+   a Postgres blob and creates a review task; the requester applies it via the normal
+   request-scoped save path) provides exactly this — taint state maps onto task status (`open` =
+   quarantined, `approved` = clean), and tool-equipped agents can never encounter unreviewed
+   upload content in a corpus checkout because it was never pushed. Consistent with the existing
+   principle that validated models are precious and laws immutable.
+4. **Human-in-the-loop before corpus intake** *(to do; same vehicle)*: move document-convert's
+   *success* path onto review tasks — the converted markdown becomes a task the uploader
+   reviews in the editor before it is saved (this replaces today's direct service-account push,
+   and incidentally removes the per-traject `CORPUS_AUTH_*` push-token requirement on the
+   worker). Detection-layer flags (hidden text, source coverage, critic verdict — see Layer 2)
+   ride along in the task payload so the reviewer sees them at the moment of judgment. A
+   source-vs-markdown diff view is the desired end state (an NLDD diff component may be needed).
 5. **Sanitize output as data** *(partially implemented)*: DOMPurify guards rendering; add
    markdown-level sanitization at conversion time — strip raw HTML, neutralize links outside an
    allowlist (wetten.overheid.nl etc.), reject base64 blobs.
@@ -165,11 +173,15 @@ way BDD regressions are caught today.
 ### Implementation Notes
 
 - Suggested build order: (1) harden the fallback agent (no shell, no forwarded OAuth token where
-  the provider allows it, sanitized output) and extend deterministic coverage; (2) taint flag +
-  quarantine status in the pipeline DB and editor review UI; (3) hidden-text and source-coverage
-  checks; (4) LLM critic; (5) red-team suite in CI.
+  the provider allows it, sanitized output) and extend deterministic coverage; (2) move
+  document-convert's success path onto the review-task mechanism (its v1 ships with
+  user-requested enrich and the document-convert *failure* path; the success path is its first
+  listed follow-up) — this implements quarantine and taint clearing structurally; (3)
+  hidden-text and source-coverage checks, surfaced as flags in the review-task payload; (4) LLM
+  critic; (5) red-team suite in CI.
 - The enrichworker's `LLM_ENV_ALLOWLIST` and the `allow_bash` split between enrich and
-  document-convert (`packages/pipeline/src/enrich.rs`) are the seams to build on.
-- The provenance marker on committed werkdocumenten should survive the git round-trip (e.g.
-  frontmatter in the `.md` plus the pipeline DB record), so taint is not lost when a repo is
-  re-cloned.
+  document-convert (`packages/pipeline/src/enrich.rs`) are the seams to build on; the
+  review-task mechanism's `tasks`/`job_blobs` tables are the quarantine store.
+- With the task flow, content only enters git after review, so a provenance marker in the
+  committed `.md` (e.g. frontmatter noting machine conversion + reviewer) is an audit trail,
+  not load-bearing for the taint invariant.


### PR DESCRIPTION
## What

Adds RFC-025: a layered prompt-injection defense for the document-upload → markdown-conversion flow introduced in #918, based on the security advisory written on 2026-07-08.

## Why

Uploaded documents are untrusted input and can carry prompt injections. Injection is not reliably detectable, so the primary defense must be architectural (blast-radius limitation), with detection as a second line. The advisory identified three detonation points (conversion model, downstream tool-equipped agents, the corpus itself) and recommended capturing the threat model and the taint invariant as an RFC before building further — no RFC on uploads or injection existed through rfc-024.

## Content

- Threat model with the three detonation points
- Inventory of defenses already merged (deterministic-first conversion, subprocess env allowlist, upload gate, DOMPurify rendering) vs. what is missing
- The central **taint invariant**: a tool-equipped agent never gets untrusted content in its context
- Layer 1 (architecture): toolless fallback agent, taint/provenance tracking, quarantine + human review, output sanitization
- Layer 2 (detection): hidden-text checks, source-coverage check, LLM critic, flag-and-review
- Continuous: red-team regression suite in CI
- Suggested build order in the implementation notes