### PR TITLE
feat(editor): show human-friendly werkdocument titles from frontmatter

### DIFF
--- a/frontend/src/LibraryView.vue
+++ b/frontend/src/LibraryView.vue
@@ -131,7 +131,7 @@ function retryUpload() {
 // Name the open document in the unsaved-changes guard so it's clear what's at
 // risk (falls back to a generic phrasing if the name isn't resolved yet).
 const docNavGuardText = computed(() => {
-  const name = docsMgr.displayTitle(openDocPath.value);
+  const name = docsMgr.titleForPath(openDocPath.value);
   return name
     ? `'${name}' heeft wijzigingen die nog niet zijn opgeslagen. Als je verdergaat, gaan ze verloren.`
     : 'Dit document heeft wijzigingen die nog niet zijn opgeslagen. Als je verdergaat, gaan ze verloren.';

--- a/frontend/src/components/ConversionStatus.test.js
+++ b/frontend/src/components/ConversionStatus.test.js
@@ -14,11 +14,11 @@ describe('ConversionStatus', () => {
     expect(wrapper.find('.conversion-status').exists()).toBe(false);
   });
 
-  it('shows a spinner for a running conversion (title without .md)', () => {
-    const wrapper = mountStatus([{ id: '1', target_path: 'report.md', status: 'processing' }]);
+  it('shows a spinner for a running conversion (de-slugged title, no .md)', () => {
+    const wrapper = mountStatus([{ id: '1', target_path: 'mijn-report.md', status: 'processing' }]);
     const indicator = wrapper.find('nldd-activity-indicator');
     expect(indicator.exists()).toBe(true);
-    expect(indicator.attributes('text')).toContain('report');
+    expect(indicator.attributes('text')).toContain('Mijn report');
     expect(indicator.attributes('text')).not.toContain('.md');
   });
 
@@ -40,7 +40,7 @@ describe('ConversionStatus', () => {
     const dialog = wrapper.find('nldd-inline-dialog');
     expect(dialog.exists()).toBe(true);
     expect(dialog.attributes('variant')).toBe('alert');
-    expect(dialog.attributes('text')).toContain('brief');
+    expect(dialog.attributes('text')).toContain('Brief');
     expect(dialog.attributes('supporting-text')).toBe('boom');
   });
 });

--- a/frontend/src/components/ConversionStatus.vue
+++ b/frontend/src/components/ConversionStatus.vue
@@ -11,13 +11,16 @@
  * endpoint falls back to including failed rows (with `error`), and this is
  * the old inline failure UI from before the taken-mechanisme existed.
  */
+import { deslugifyDocPath } from '../lib/docTitle.js';
+
 defineProps({
   jobs: { type: Array, default: () => [] },
 });
 
+// A pending conversion has no body (and thus no frontmatter title) yet, so
+// the de-slugged target path is the best available name.
 function title(job) {
-  const path = job.target_path || 'document';
-  return path.replace(/\.md$/, '');
+  return deslugifyDocPath(job.target_path || 'document');
 }
 </script>
 

--- a/frontend/src/components/DocumentEditor.vue
+++ b/frontend/src/components/DocumentEditor.vue
@@ -55,6 +55,8 @@ const {
   pendingDeletePath,
   deleteNotice,
   displayTitle,
+  titleForPath,
+  currentTitle,
   onBodyInput,
   onTitleInput,
   handleSave,
@@ -66,8 +68,10 @@ const {
   confirmDelete,
 } = m;
 
-// Document name shown in the top toolbar title.
-const docName = computed(() => displayTitle(currentPath.value) || 'Document');
+// Document name shown in the top toolbar title: the live frontmatter title
+// when the body carries one, else the de-slugged path. The rename sheet below
+// keeps using displayTitle/titleDraft (the raw path-based name).
+const docName = computed(() => currentTitle.value || 'Document');
 
 // A load failure leaves nothing to edit, so it replaces the whole body as an
 // inline dialog. Save / conflict / delete failures are modals and a
@@ -438,7 +442,7 @@ function dismissDeleteNotice() {
     <nldd-modal-dialog
       ref="deleteModalEl"
       variant="alert"
-      :text="pendingDeletePath ? `${displayTitle(pendingDeletePath)} verwijderen?` : 'Document verwijderen?'"
+      :text="pendingDeletePath ? `${titleForPath(pendingDeletePath)} verwijderen?` : 'Document verwijderen?'"
       supporting-text="Het document wordt definitief uit het traject verwijderd. Dit kan niet ongedaan worden gemaakt."
       @close="cancelDelete"
     >

--- a/frontend/src/components/DocumentList.test.js
+++ b/frontend/src/components/DocumentList.test.js
@@ -6,6 +6,7 @@ import DocumentList from './DocumentList.vue';
 // custom elements under happy-dom; we assert against attributes/markup rather
 // than rendered shadow DOM.
 const DOCS = [{ path: 'beleid.md' }, { path: 'nota/bijlage.txt' }];
+const TITLED_DOCS = [{ path: 'mijn-brief.md', title: 'Mijn Brief' }, { path: 'beleid.md' }];
 
 function mountList(props = {}) {
   return mount(DocumentList, {
@@ -19,11 +20,18 @@ describe('DocumentList', () => {
     expect(wrapper.findAll('nldd-list-item')).toHaveLength(DOCS.length);
   });
 
-  it('hides the .md extension but keeps .txt visible', () => {
+  it('de-slugs paths without a frontmatter title (extension hidden, folder kept)', () => {
     const wrapper = mountList();
     const texts = wrapper.findAll('nldd-text-cell').map((c) => c.attributes('text'));
-    expect(texts).toContain('beleid');
-    expect(texts).toContain('nota/bijlage.txt');
+    expect(texts).toContain('Beleid');
+    expect(texts).toContain('nota/Bijlage');
+  });
+
+  it('prefers the frontmatter title over the de-slugged path', () => {
+    const wrapper = mountList({ documents: TITLED_DOCS });
+    const texts = wrapper.findAll('nldd-text-cell').map((c) => c.attributes('text'));
+    expect(texts).toContain('Mijn Brief');
+    expect(texts).toContain('Beleid');
   });
 
   it('emits select with the document path when a row is clicked', async () => {

--- a/frontend/src/components/DocumentList.vue
+++ b/frontend/src/components/DocumentList.vue
@@ -2,16 +2,14 @@
 // Presentational werkdocumenten list for the Home werkdocumenten sidebar: each
 // row is a button that selects the document in place (emits `select`). Creating
 // a new document is a toolbar action above the list, not a row here.
+import { docDisplayTitle } from '../lib/docTitle.js';
+
 defineProps({
   documents: { type: Array, default: () => [] },
   // Highlight the open document.
   selectedPath: { type: String, default: null },
 });
 defineEmits(['select']);
-
-function title(path) {
-  return path ? path.replace(/\.md$/, '') : '';
-}
 </script>
 
 <template>
@@ -26,7 +24,7 @@ function title(path) {
     >
       <nldd-icon-cell slot="start" size="20"><nldd-icon name="text-document"></nldd-icon></nldd-icon-cell>
       <nldd-spacer-cell slot="start" size="8"></nldd-spacer-cell>
-      <nldd-text-cell :text="title(doc.path)"></nldd-text-cell>
+      <nldd-text-cell :text="docDisplayTitle(doc)"></nldd-text-cell>
       <nldd-spacer-cell size="8"></nldd-spacer-cell>
       <nldd-icon-cell size="20"><nldd-icon name="chevron-right"></nldd-icon></nldd-icon-cell>
     </nldd-list-item>

--- a/frontend/src/composables/useDocumentsManager.js
+++ b/frontend/src/composables/useDocumentsManager.js
@@ -10,6 +10,7 @@
  * shown, sheet open/close) stays in the components.
  */
 import { computed, ref, watch } from 'vue';
+import { deslugifyDocPath, docDisplayTitle, frontmatterTitle } from '../lib/docTitle.js';
 import { useTrajectDocuments } from './useTrajectDocuments.js';
 
 export function useDocumentsManager(trajectRef) {
@@ -61,11 +62,37 @@ export function useDocumentsManager(trajectRef) {
   );
 
   // --- Titels ---
+  // Twee soorten titels, met verschillende contracten:
+  //
+  // 1. displayTitle/pathFromTitle: het RAUWE pad-gebaseerde exemplaar dat de
+  //    hernoem-sheet gebruikt. De rename-flow leunt op de invariant
+  //    `pathFromTitle(displayTitle(p)) === p` — deze mogen dus nooit een
+  //    "mooie" titel (spaties/hoofdletters) opleveren, anders wordt elke
+  //    save een rename.
+  // 2. titleForPath/currentTitle: puur voor WEERGAVE — frontmatter-titel als
+  //    die er is, anders het gedeslugifyde pad. Nooit terugvertalen naar een
+  //    pad.
+  //
   // '.md' blijft verborgen voor de gebruiker; '.txt' wijkt af van de default en
   // blijft daarom zichtbaar.
   function displayTitle(path) {
     return path ? path.replace(/\.md$/, '') : '';
   }
+  // Weergavetitel voor een pad: de frontmatter-titel uit de opgehaalde lijst,
+  // anders deslugify.
+  function titleForPath(path) {
+    const entry = documents.value.find((d) => d.path === path);
+    return entry ? docDisplayTitle(entry) : deslugifyDocPath(path);
+  }
+  // Live titel van het GEOPENDE document, geparseerd uit de body die de
+  // gebruiker bewerkt — zo volgt de editor-kop een frontmatter-edit direct.
+  // Tijdens het laden bevat currentBody nog het vorige document; val dan
+  // terug op het pad tot docLoading klaart.
+  const currentTitle = computed(
+    () =>
+      (!docLoading.value && frontmatterTitle(currentBody.value))
+      || deslugifyDocPath(currentPath.value),
+  );
   function pathFromTitle(title) {
     const t = title.trim();
     if (!t) return '';
@@ -229,11 +256,11 @@ export function useDocumentsManager(trajectRef) {
     }
     if (result?.conflict) {
       deleteNotice.value =
-        `"${displayTitle(path)}" is intussen door iemand anders gewijzigd; de lijst is ververst. ` +
+        `"${titleForPath(path)}" is intussen door iemand anders gewijzigd; de lijst is ververst. ` +
         `Open het document om de huidige versie te zien voordat je het verwijdert.`;
     } else {
       deleteNotice.value =
-        saveError.value?.message || `Verwijderen van "${displayTitle(path)}" is mislukt.`;
+        saveError.value?.message || `Verwijderen van "${titleForPath(path)}" is mislukt.`;
     }
     return false;
   }
@@ -247,7 +274,7 @@ export function useDocumentsManager(trajectRef) {
     titleDraft, titleError,
     pendingDeletePath, deleteNotice,
     // derived helpers
-    displayTitle,
+    displayTitle, titleForPath, currentTitle,
     // actions
     open, startNew, close, uploadDocument,
     onBodyInput, onTitleInput,

--- a/frontend/src/composables/useDocumentsManager.test.js
+++ b/frontend/src/composables/useDocumentsManager.test.js
@@ -59,6 +59,29 @@ describe('useDocumentsManager', () => {
     expect(m.displayTitle(null)).toBe('');
   });
 
+  it('titleForPath prefers the frontmatter title from the list, else de-slugs', () => {
+    h.api.documents.value = [
+      { path: 'mijn-brief.md', title: 'Mijn Brief' },
+      { path: 'beleid-nota.md' },
+    ];
+    expect(m.titleForPath('mijn-brief.md')).toBe('Mijn Brief');
+    expect(m.titleForPath('beleid-nota.md')).toBe('Beleid nota');
+    // Not in the list (e.g. just deleted): de-slug the path itself.
+    expect(m.titleForPath('onbekend-doc.md')).toBe('Onbekend doc');
+  });
+
+  it('currentTitle follows a frontmatter edit live and falls back while loading', () => {
+    h.api.currentPath.value = 'mijn-brief.md';
+    h.api.currentBody.value = 'Body zonder frontmatter.';
+    expect(m.currentTitle.value).toBe('Mijn brief');
+    h.api.currentBody.value = '---\ntitle: Mijn Brief aan de Kamer\n---\n\nBody.';
+    expect(m.currentTitle.value).toBe('Mijn Brief aan de Kamer');
+    // While loading, currentBody still holds the previous document; the
+    // path-derived fallback prevents a flash of the wrong title.
+    h.api.docLoading.value = true;
+    expect(m.currentTitle.value).toBe('Mijn brief');
+  });
+
   it('onTitleInput sanitizes the name to a valid path (no error shown)', () => {
     m.onTitleInput({ target: { value: 'Beleid Nota' } });
     expect(m.titleDraft.value).toBe('beleid-nota'); // uppercase -> lower, space -> '-'

--- a/frontend/src/composables/useTrajectDocuments.js
+++ b/frontend/src/composables/useTrajectDocuments.js
@@ -314,9 +314,13 @@ export function useTrajectDocuments(trajectRef) {
       clearDraft(trajectRef.value, currentPath.value);
       savedBody.value = currentBody.value;
       // Reload the list - a freshly created document needs to appear
-      // in the sidebar without a manual refresh.
+      // in the sidebar without a manual refresh (await: the caller may
+      // navigate to it). An updated document refreshes non-blocking so a
+      // changed frontmatter title doesn't linger stale in the sidebar.
       if (res.status === 201) {
         await fetchList();
+      } else {
+        fetchList().catch(() => {});
       }
       return { ok: true, created: res.status === 201, pr: json?.pr ?? null };
     } catch (e) {

--- a/frontend/src/composables/useTrajectDocuments.test.js
+++ b/frontend/src/composables/useTrajectDocuments.test.js
@@ -31,7 +31,11 @@ beforeEach(() => {
 describe('useTrajectDocuments', () => {
   it('fetches the documents list for the active traject', async () => {
     const fetchSpy = vi.fn().mockResolvedValue(
-      res({ json: { documents: [{ path: 'notes.md' }, { path: 'mvt/concept.md' }] } }),
+      res({
+        json: {
+          documents: [{ path: 'notes.md', title: 'Notities' }, { path: 'mvt/concept.md' }],
+        },
+      }),
     );
     globalThis.fetch = fetchSpy;
 
@@ -44,6 +48,9 @@ describe('useTrajectDocuments', () => {
       'notes.md',
       'mvt/concept.md',
     ]);
+    // The optional frontmatter title from the list response rides along.
+    expect(documents.value[0].title).toBe('Notities');
+    expect(documents.value[1].title).toBeUndefined();
   });
 
   it('uploads a document as multipart and refreshes the list', async () => {
@@ -105,6 +112,13 @@ describe('useTrajectDocuments', () => {
     expect(put).toBeTruthy();
     expect(put.opts.headers['If-Match']).toBe('"v1"');
     expect(docs.currentEtag.value).toBe('"new"');
+
+    // A 200 save refreshes the list non-blocking so a changed frontmatter
+    // title shows up in the sidebar without a manual refresh.
+    await nextTick();
+    const listCallsAfterPut =
+      calls.filter((c) => c.url.endsWith('/corpus/documents') && !c.opts.method).length;
+    expect(listCallsAfterPut).toBeGreaterThanOrEqual(2);
   });
 
   it('surfaces a 412 as a conflict instead of overwriting silently', async () => {

--- a/frontend/src/lib/docTitle.js
+++ b/frontend/src/lib/docTitle.js
@@ -1,0 +1,63 @@
+/**
+ * Display titles for werkdocumenten. The document's identity stays its path
+ * (restricted to [a-z0-9._-]); these helpers only decide what the user SEES:
+ * a `title:` from a leading YAML frontmatter block when present, otherwise a
+ * de-slugged rendering of the filename. The raw path-based name used by the
+ * rename sheet lives in useDocumentsManager (displayTitle/pathFromTitle) and
+ * must stay path-faithful — do not swap it for these.
+ */
+import * as yaml from 'js-yaml';
+
+/**
+ * Title from a leading YAML frontmatter block (`---` … `---`), or null.
+ * Cosmetic only: any malformed shape (no opening fence, unterminated fence,
+ * YAML parse error, non-scalar or empty title) yields null, never throws.
+ */
+export function frontmatterTitle(body) {
+  if (typeof body !== 'string') return null;
+  const text = body.replace(/^\uFEFF/, '');
+  // This runs on every keystroke (the editor header follows the live body),
+  // so bail before splitting: the common no-frontmatter case must be O(1),
+  // and a real frontmatter block is tiny \u2014 scan at most the first 8 KiB
+  // rather than the whole (possibly PDF-sized) document.
+  if (!text.startsWith('---')) return null;
+  const lines = text.slice(0, 8192).split('\n');
+  if (lines[0].replace(/\r$/, '') !== '---') return null;
+  const end = lines.findIndex((line, i) => i > 0 && line.replace(/\r$/, '') === '---');
+  if (end === -1) return null;
+  let parsed;
+  try {
+    parsed = yaml.load(lines.slice(1, end).join('\n'));
+  } catch {
+    return null;
+  }
+  const title = parsed && typeof parsed === 'object' ? parsed.title : undefined;
+  if (typeof title !== 'string' && typeof title !== 'number') return null;
+  const trimmed = String(title).trim();
+  return trimmed || null;
+}
+
+/**
+ * De-slugged fallback title for a document path: last segment with the
+ * extension stripped, `-`/`_` turned into spaces (runs collapsed), first
+ * letter capitalized. Any directory prefix stays as-is so two same-named
+ * documents in different folders remain distinguishable:
+ * `nota/bijlage-v2.md` → "nota/Bijlage v2".
+ */
+export function deslugifyDocPath(path) {
+  if (!path) return '';
+  const slash = path.lastIndexOf('/');
+  const prefix = slash === -1 ? '' : path.slice(0, slash + 1);
+  const name = path
+    .slice(slash + 1)
+    .replace(/\.[^.]+$/, '')
+    .replace(/[-_]+/g, ' ')
+    .trim();
+  return prefix + name.charAt(0).toUpperCase() + name.slice(1);
+}
+
+/** Display title for a list entry: its frontmatter title, else the de-slugged path. */
+export function docDisplayTitle(entry) {
+  if (!entry) return '';
+  return entry.title || deslugifyDocPath(entry.path);
+}

--- a/frontend/src/lib/docTitle.test.js
+++ b/frontend/src/lib/docTitle.test.js
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { frontmatterTitle, deslugifyDocPath, docDisplayTitle } from './docTitle.js';
+
+describe('frontmatterTitle', () => {
+  it('extracts a plain title', () => {
+    expect(frontmatterTitle('---\ntitle: Mijn Brief\n---\n\nBody.')).toBe('Mijn Brief');
+  });
+
+  it('extracts a quoted title containing a colon and quotes', () => {
+    expect(frontmatterTitle('---\ntitle: "Rapport: Q3 \\"final\\""\n---\nBody.')).toBe(
+      'Rapport: Q3 "final"',
+    );
+  });
+
+  it('stringifies a numeric title', () => {
+    expect(frontmatterTitle('---\ntitle: 2024\n---\n')).toBe('2024');
+  });
+
+  it('tolerates CRLF line endings and a BOM', () => {
+    expect(frontmatterTitle('\uFEFF---\r\ntitle: Nota\r\n---\r\nBody.')).toBe('Nota');
+  });
+
+  it('returns null without a leading fence', () => {
+    expect(frontmatterTitle('# Kop\n\nBody.')).toBeNull();
+    expect(frontmatterTitle('')).toBeNull();
+    expect(frontmatterTitle(null)).toBeNull();
+    // A thematic break further down is not frontmatter.
+    expect(frontmatterTitle('Body.\n---\ntitle: X\n---\n')).toBeNull();
+  });
+
+  it('returns null on an unterminated fence', () => {
+    expect(frontmatterTitle('---\ntitle: X\n')).toBeNull();
+  });
+
+  it('returns null on invalid YAML instead of throwing', () => {
+    expect(frontmatterTitle('---\ntitle: [\n---\n')).toBeNull();
+  });
+
+  it('returns null for a missing, empty, blank or non-scalar title', () => {
+    expect(frontmatterTitle('---\nauthor: X\n---\n')).toBeNull();
+    expect(frontmatterTitle('---\ntitle: ""\n---\n')).toBeNull();
+    expect(frontmatterTitle('---\ntitle: "   "\n---\n')).toBeNull();
+    expect(frontmatterTitle('---\ntitle: [a, b]\n---\n')).toBeNull();
+    expect(frontmatterTitle('---\ntitle: true\n---\n')).toBeNull();
+  });
+});
+
+describe('deslugifyDocPath', () => {
+  it('strips the extension, expands separators and capitalizes', () => {
+    expect(deslugifyDocPath('untitled.md')).toBe('Untitled');
+    expect(deslugifyDocPath('mijn-brief-2.md')).toBe('Mijn brief 2');
+    expect(deslugifyDocPath('een_lang__verhaal.md')).toBe('Een lang verhaal');
+  });
+
+  it('keeps the folder prefix as-is and works for .txt', () => {
+    expect(deslugifyDocPath('nota/bijlage.txt')).toBe('nota/Bijlage');
+    expect(deslugifyDocPath('mvt/concept-v2.md')).toBe('mvt/Concept v2');
+  });
+
+  it('returns an empty string for empty input', () => {
+    expect(deslugifyDocPath(null)).toBe('');
+    expect(deslugifyDocPath('')).toBe('');
+  });
+});
+
+describe('docDisplayTitle', () => {
+  it('prefers the entry title and falls back to the de-slugged path', () => {
+    expect(docDisplayTitle({ path: 'mijn-brief.md', title: 'Mijn Brief' })).toBe('Mijn Brief');
+    expect(docDisplayTitle({ path: 'mijn-brief.md' })).toBe('Mijn brief');
+    expect(docDisplayTitle(null)).toBe('');
+  });
+});

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -2467,6 +2467,10 @@ const ALLOWED_DOCUMENT_EXTENSIONS: &[&str] = &["md", "txt"];
 pub struct TrajectDocumentListEntry {
     /// Path relative to `documents/<traject-ref>/`, forward slashes.
     pub path: String,
+    /// Display title from the document's YAML frontmatter, when present.
+    /// Cosmetic only — the path stays the document's identity.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -2482,6 +2486,44 @@ pub struct SaveDocumentResponse {
     /// Mirrors `SaveResponse.pr` — populated when the writable
     /// backend surfaced a PR link.
     pub pr: Option<SavePrInfo>,
+}
+
+/// Extract `title:` from a leading YAML frontmatter block (`---` … `---`).
+///
+/// Cosmetic only: every malformed shape — no opening fence, unterminated
+/// fence, YAML parse error, non-scalar or empty `title` — yields `None`,
+/// never an error, so a hand-edited document can't break the list.
+fn frontmatter_title(body: &str) -> Option<String> {
+    let body = body.strip_prefix('\u{feff}').unwrap_or(body);
+    let mut lines = body.lines();
+    if lines.next()?.trim_end_matches('\r') != "---" {
+        return None;
+    }
+    let mut block = String::new();
+    let mut closed = false;
+    for line in lines {
+        if line.trim_end_matches('\r') == "---" {
+            closed = true;
+            break;
+        }
+        block.push_str(line.trim_end_matches('\r'));
+        block.push('\n');
+    }
+    if !closed {
+        return None;
+    }
+    let value: serde_yaml_ng::Value = serde_yaml_ng::from_str(&block).ok()?;
+    let title = match value.get("title")? {
+        serde_yaml_ng::Value::String(s) => s.clone(),
+        serde_yaml_ng::Value::Number(n) => n.to_string(),
+        _ => return None,
+    };
+    let title = title.trim();
+    if title.is_empty() {
+        None
+    } else {
+        Some(title.to_string())
+    }
 }
 
 /// Compute the document ETag used for optimistic-concurrency checks.
@@ -2707,18 +2749,33 @@ pub async fn list_traject_documents(
     // Filter at the API boundary too — the on-disk tree could carry a
     // stray hand-committed file (e.g. an editor's `~` backup or a
     // hidden `.DS_Store`) and the API should not advertise those.
-    let documents = entries
-        .into_iter()
-        .filter(|e| {
-            std::path::Path::new(&e.relative_path)
-                .extension()
-                .and_then(|s| s.to_str())
-                .is_some_and(|ext| ALLOWED_DOCUMENT_EXTENSIONS.contains(&ext))
-        })
-        .map(|e| TrajectDocumentListEntry {
+    let mut documents = Vec::new();
+    for e in entries.into_iter().filter(|e| {
+        std::path::Path::new(&e.relative_path)
+            .extension()
+            .and_then(|s| s.to_str())
+            .is_some_and(|ext| ALLOWED_DOCUMENT_EXTENSIONS.contains(&ext))
+    }) {
+        // Read each body to surface its frontmatter title. Local/clone
+        // backends make this N cheap disk reads; the GitHub-API backend
+        // pays one Contents call per document (ETag-cached), fine for the
+        // handful of documents a traject carries. If a traject ever holds
+        // hundreds, a Trees-API bulk fetch is the escape hatch. A failed
+        // read only costs that entry its title, never the listing.
+        let title = match backend.read_file(&base.join(&e.relative_path)).await {
+            Ok(Some(body)) => frontmatter_title(&body),
+            Ok(None) => None,
+            Err(err) => {
+                tracing::debug!(error = %err, path = %e.relative_path,
+                    "document body read for title failed");
+                None
+            }
+        };
+        documents.push(TrajectDocumentListEntry {
             path: e.relative_path,
-        })
-        .collect();
+            title,
+        });
+    }
     Ok(Json(TrajectDocumentList { documents }))
 }
 
@@ -3470,6 +3527,63 @@ mod tests {
             "mijn-brief.md"
         );
         assert!(validate_document_path(&derive_markdown_target("a...b   c.doc", &[])).is_ok());
+    }
+
+    #[test]
+    fn frontmatter_title_extracts_plain_and_quoted_titles() {
+        assert_eq!(
+            frontmatter_title("---\ntitle: Mijn Brief\n---\n\nBody."),
+            Some("Mijn Brief".to_string())
+        );
+        assert_eq!(
+            frontmatter_title("---\ntitle: \"Rapport: Q3 \\\"final\\\"\"\n---\nBody."),
+            Some("Rapport: Q3 \"final\"".to_string())
+        );
+        // Numbers are legitimate titles.
+        assert_eq!(
+            frontmatter_title("---\ntitle: 2024\n---\n"),
+            Some("2024".to_string())
+        );
+        // CRLF line endings and a BOM must not defeat the fence scan.
+        assert_eq!(
+            frontmatter_title("\u{feff}---\r\ntitle: Nota\r\n---\r\nBody."),
+            Some("Nota".to_string())
+        );
+    }
+
+    #[test]
+    fn frontmatter_title_yields_none_on_malformed_input() {
+        // No frontmatter at all.
+        assert_eq!(frontmatter_title("# Kop\n\nBody."), None);
+        assert_eq!(frontmatter_title(""), None);
+        // A thematic break further down is not frontmatter.
+        assert_eq!(frontmatter_title("Body.\n---\ntitle: X\n---\n"), None);
+        // Unterminated fence.
+        assert_eq!(frontmatter_title("---\ntitle: X\n"), None);
+        // Invalid YAML between the fences.
+        assert_eq!(frontmatter_title("---\ntitle: [\n---\n"), None);
+        // Missing, empty, blank or non-scalar title.
+        assert_eq!(frontmatter_title("---\nauthor: X\n---\n"), None);
+        assert_eq!(frontmatter_title("---\ntitle: \"\"\n---\n"), None);
+        assert_eq!(frontmatter_title("---\ntitle: \"   \"\n---\n"), None);
+        assert_eq!(frontmatter_title("---\ntitle: [a, b]\n---\n"), None);
+        assert_eq!(frontmatter_title("---\ntitle: true\n---\n"), None);
+    }
+
+    #[test]
+    fn document_list_entry_omits_absent_title() {
+        let entry = TrajectDocumentListEntry {
+            path: "beleid.md".to_string(),
+            title: None,
+        };
+        let json = serde_json::to_value(&entry).unwrap();
+        assert_eq!(json, serde_json::json!({"path": "beleid.md"}));
+        let entry = TrajectDocumentListEntry {
+            path: "beleid.md".to_string(),
+            title: Some("Beleid 2024".to_string()),
+        };
+        let json = serde_json::to_value(&entry).unwrap();
+        assert_eq!(json["title"], "Beleid 2024");
     }
 
     #[test]

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -2495,6 +2495,20 @@ pub struct SaveDocumentResponse {
 /// never an error, so a hand-edited document can't break the list.
 fn frontmatter_title(body: &str) -> Option<String> {
     let body = body.strip_prefix('\u{feff}').unwrap_or(body);
+    // Scan at most the first 8 KiB, matching the editor's `frontmatterTitle`
+    // (`frontend/src/lib/docTitle.js`) so both parsers honour the same
+    // contract: a real frontmatter block is tiny, and a closing fence buried
+    // beyond 8 KiB yields no title in either place rather than only here.
+    const SCAN_CAP: usize = 8192;
+    let body = if body.len() > SCAN_CAP {
+        let mut end = SCAN_CAP;
+        while !body.is_char_boundary(end) {
+            end -= 1;
+        }
+        &body[..end]
+    } else {
+        body
+    };
     let mut lines = body.lines();
     if lines.next()?.trim_end_matches('\r') != "---" {
         return None;
@@ -3568,6 +3582,17 @@ mod tests {
         assert_eq!(frontmatter_title("---\ntitle: \"   \"\n---\n"), None);
         assert_eq!(frontmatter_title("---\ntitle: [a, b]\n---\n"), None);
         assert_eq!(frontmatter_title("---\ntitle: true\n---\n"), None);
+    }
+
+    #[test]
+    fn frontmatter_title_caps_scan_like_the_editor() {
+        // A closing fence buried beyond the 8 KiB scan cap yields no title,
+        // matching the editor's `frontmatterTitle` so both parsers agree.
+        let body = format!("---\ntitle: Diep\n{}\n---\n", "x".repeat(9000));
+        assert_eq!(frontmatter_title(&body), None);
+        // A title well within the cap is still found even with a large body.
+        let body = format!("---\ntitle: Ondiep\n---\n{}", "x".repeat(9000));
+        assert_eq!(frontmatter_title(&body), Some("Ondiep".to_string()));
     }
 
     #[test]

--- a/packages/pipeline/src/document_convert.rs
+++ b/packages/pipeline/src/document_convert.rs
@@ -490,6 +490,38 @@ async fn try_deterministic_convert(
     }
 }
 
+/// Prepend a YAML frontmatter block carrying the original uploaded
+/// filename's stem as `title:`, so the human-readable name survives the
+/// slugged `target_path` ("Mijn Brief.docx" → `mijn-brief.md` keeps
+/// showing as "Mijn Brief" in the editor). Skipped when the stem is
+/// empty or when the produced markdown already starts with a frontmatter
+/// fence — never stack two blocks. YAML escaping (filenames can carry
+/// `:`, quotes, `#`) is delegated to serde_yaml_ng.
+fn with_title_frontmatter(markdown: String, original_filename: &str) -> String {
+    let stem = Path::new(original_filename)
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .map(str::trim)
+        .unwrap_or("");
+    if stem.is_empty() {
+        return markdown;
+    }
+    if markdown
+        .trim_start_matches('\u{feff}')
+        .lines()
+        .next()
+        .is_some_and(|first| first.trim_end() == "---")
+    {
+        return markdown;
+    }
+    let mut map = std::collections::BTreeMap::new();
+    map.insert("title", stem);
+    match serde_yaml_ng::to_string(&map) {
+        Ok(yaml) => format!("---\n{yaml}---\n\n{markdown}"),
+        Err(_) => markdown,
+    }
+}
+
 /// The pure filesystem half of the conversion, split out so it can be unit-tested
 /// with a fake converter and a synthetic upload (no DB, no LLM).
 async fn convert_in_dir(
@@ -515,26 +547,28 @@ async fn convert_in_dir(
     // crucially — keeps the untrusted document away from the Bash-enabled LLM,
     // shrinking the prompt-injection surface. The agentic path stays as a
     // fallback for formats the tools don't handle (or when they are absent).
-    if let Some(markdown) = try_deterministic_convert(&input_file, &ext, &output_path).await {
-        return Ok(markdown);
-    }
+    let markdown =
+        if let Some(markdown) = try_deterministic_convert(&input_file, &ext, &output_path).await {
+            markdown
+        } else {
+            converter
+                .convert(&input_file, work_dir, &output_path, config)
+                .await?;
 
-    converter
-        .convert(&input_file, work_dir, &output_path, config)
-        .await?;
-
-    let markdown = tokio::fs::read_to_string(&output_path).await.map_err(|e| {
-        PipelineError::Enrich(format!(
-            "conversion produced no readable markdown at {}: {e}",
-            output_path.display()
-        ))
-    })?;
-    if markdown.trim().is_empty() {
-        return Err(PipelineError::Enrich(
-            "conversion produced empty markdown".to_string(),
-        ));
-    }
-    Ok(markdown)
+            let markdown = tokio::fs::read_to_string(&output_path).await.map_err(|e| {
+                PipelineError::Enrich(format!(
+                    "conversion produced no readable markdown at {}: {e}",
+                    output_path.display()
+                ))
+            })?;
+            if markdown.trim().is_empty() {
+                return Err(PipelineError::Enrich(
+                    "conversion produced empty markdown".to_string(),
+                ));
+            }
+            markdown
+        };
+    Ok(with_title_frontmatter(markdown, &upload.filename))
 }
 
 #[cfg(test)]
@@ -625,8 +659,9 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         // A `.bin` extension no deterministic tool handles, so the agentic
         // fallback (the FakeConverter) runs and we test that orchestration.
+        // The original filename's stem must come back as a frontmatter title.
         let upload = Upload {
-            filename: "report.bin".to_string(),
+            filename: "Mijn Brief.bin".to_string(),
             content_type: "application/octet-stream".to_string(),
             bytes: b"raw bytes".to_vec(),
         };
@@ -636,7 +671,7 @@ mod tests {
         let md = convert_in_dir(
             dir.path(),
             &upload,
-            "report.md",
+            "mijn-brief.md",
             &EnrichConfig::for_test(crate::enrich::LlmProvider::Claude {
                 path: "claude".into(),
                 model: None,
@@ -645,7 +680,45 @@ mod tests {
         )
         .await
         .unwrap();
-        assert_eq!(md, "# Report\n\nBody.\n");
+        assert_eq!(md, "---\ntitle: Mijn Brief\n---\n\n# Report\n\nBody.\n");
+    }
+
+    #[test]
+    fn with_title_frontmatter_prepends_stem_as_title() {
+        assert_eq!(
+            with_title_frontmatter("Body.\n".to_string(), "Mijn Brief.docx"),
+            "---\ntitle: Mijn Brief\n---\n\nBody.\n"
+        );
+    }
+
+    #[test]
+    fn with_title_frontmatter_escapes_yaml_special_characters() {
+        // Filenames can carry `:` and quotes; the emitted block must stay
+        // valid YAML and round-trip to the exact stem.
+        let md = with_title_frontmatter("Body.\n".to_string(), "Rapport: Q3 \"final\".pdf");
+        let block = md
+            .strip_prefix("---\n")
+            .and_then(|rest| rest.split_once("\n---\n"))
+            .expect("frontmatter block present")
+            .0;
+        let parsed: std::collections::BTreeMap<String, String> =
+            serde_yaml_ng::from_str(block).unwrap();
+        assert_eq!(parsed["title"], "Rapport: Q3 \"final\"");
+        assert!(md.ends_with("\n\nBody.\n"));
+    }
+
+    #[test]
+    fn with_title_frontmatter_skips_existing_block_and_empty_stem() {
+        // Never stack a second frontmatter block on converter output that
+        // already carries one.
+        let existing = "---\ntitle: Al aanwezig\n---\n\nBody.\n".to_string();
+        assert_eq!(
+            with_title_frontmatter(existing.clone(), "iets.docx"),
+            existing
+        );
+        // An unusable stem leaves the markdown untouched (frontend falls
+        // back to de-slugging the path).
+        assert_eq!(with_title_frontmatter("Body.\n".to_string(), ""), "Body.\n");
     }
 
     #[tokio::test]

--- a/packages/pipeline/src/document_convert.rs
+++ b/packages/pipeline/src/document_convert.rs
@@ -510,7 +510,12 @@ fn with_title_frontmatter(markdown: String, original_filename: &str) -> String {
         .trim_start_matches('\u{feff}')
         .lines()
         .next()
-        .is_some_and(|first| first.trim_end() == "---")
+        // A fence line is exactly `---` (only a trailing `\r` tolerated), the
+        // same notion both title extractors use. Do not accept trailing spaces
+        // here: `--- ` is body, not a fence — treating it as "already fenced"
+        // would suppress the title block while the extractors would then find
+        // no frontmatter, leaving the document with no title at all.
+        .is_some_and(|first| first.trim_end_matches('\r') == "---")
     {
         return markdown;
     }
@@ -719,6 +724,18 @@ mod tests {
         // An unusable stem leaves the markdown untouched (frontend falls
         // back to de-slugging the path).
         assert_eq!(with_title_frontmatter("Body.\n".to_string(), ""), "Body.\n");
+    }
+
+    #[test]
+    fn with_title_frontmatter_treats_trailing_space_fence_as_body() {
+        // `--- ` (trailing space) is not a fence line to the title extractors,
+        // so it must not count as "already fenced" — otherwise the title block
+        // is skipped here yet no frontmatter is found downstream, leaving the
+        // document titleless. The block must be prepended.
+        assert_eq!(
+            with_title_frontmatter("--- \nnot really frontmatter\n".to_string(), "Brief.docx"),
+            "---\ntitle: Brief\n---\n\n--- \nnot really frontmatter\n"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

Werkdocumenten showed their slugified file path (`mijn-brief`) as their name everywhere, and uploading destroyed the original filename ("Mijn Brief.docx" → `mijn-brief.md`). This PR gives documents a human-friendly display title:

1. **Frontmatter title wins** — if the document body starts with a YAML frontmatter block containing `title:`, that title is shown in the sidebar list, the editor header, and dialogs.
2. **De-slugged fallback** — otherwise the filename is made readable for display: extension stripped, `-`/`_` → spaces, first letter capitalized (`mijn-brief-2.md` → "Mijn brief 2").
3. **Upload preserves the original name** — the conversion worker now prepends `---\ntitle: Mijn Brief\n---` to the converted markdown, so uploaded documents get their real name back.

## How

- **editor-api** (`corpus_handlers.rs`): new `frontmatter_title` helper; the documents LIST response gains an optional `title` per entry (read failures or malformed frontmatter never break the list — the entry just has no title). Note: LIST now reads each document body; acceptable for the handful of documents a traject carries, escape hatch documented in a comment.
- **pipeline** (`document_convert.rs`): `with_title_frontmatter` prepends the original filename's stem as a YAML-escaped `title:` at the single point where all converters (pandoc/pdftotext/agent) converge; never stacks a second block, and an empty conversion still fails before the prepend.
- **frontend**: new shared `lib/docTitle.js` (`frontmatterTitle`/`deslugifyDocPath`/`docDisplayTitle`, reusing the existing `js-yaml` dep) replaces three duplicated de-slug sites; `useDocumentsManager` gains display-only `titleForPath` + live `currentTitle` (the editor header follows a frontmatter edit as you type); a 200 save refreshes the list non-blocking so a changed title doesn't linger stale.

## Deliberately out of scope

- The frontmatter block stays visible in the editor body (no strip/merge on open/save).
- The rename sheet keeps its current path-rename behavior (`displayTitle`/`pathFromTitle` are untouched — the rename flow relies on `pathFromTitle(displayTitle(p)) === p`, and the existing rename test suite passes unchanged as the regression guard).
- URLs keep using document paths.

## Testing

- Rust: new inline unit tests for `frontmatter_title` (fences, CRLF/BOM, invalid YAML, empty/non-scalar titles, wire format) and `with_title_frontmatter` (YAML escaping round-trip, existing-block/empty-stem skips); `fmt`/`clippy` clean.
- Frontend: new `docTitle.test.js` edge-case matrix; updated DocumentList/ConversionStatus/useTrajectDocuments/useDocumentsManager suites — full vitest run green (527 tests).