### PR TITLE
feat(editor): document conversions deliver as review tasks

### DIFF
--- a/frontend/src/LibraryView.docReview.test.js
+++ b/frontend/src/LibraryView.docReview.test.js
@@ -1,0 +1,311 @@
+// Targeted tests for the document-review orchestration in LibraryView.vue
+// (rejectDocReview / onDocSaved / clearDocReviewQuery / the proposal-seeding
+// watch, ~lines 240-380). LibraryView.vue itself has no other test coverage
+// (it's a 1500-line multi-concern view with no existing test harness), so
+// this file mounts it `shallow` with every composable it touches replaced by
+// a controllable stub - deliberately narrow: it exercises only the
+// review-flow surface, not the rest of the view (laws browsing, search,
+// traject panes, ...), which stay in their default/empty state.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { ref } from 'vue';
+
+// --- vue-router: no real router install. `onBeforeRouteUpdate`/
+// `onBeforeRouteLeave` are just named exports LibraryView calls once at
+// setup to register a callback - stubbing them as no-ops absorbs that
+// registration without needing real guard machinery (same technique
+// TasksSheet.test.js / MobileTrajectSheet.test.js use for useRoute/useRouter).
+const routeState = {
+  name: 'werkdocumenten-traject',
+  params: { trajectRef: 'traject-abcd1234', docPath: '' },
+  query: {},
+  fullPath: '/traject/traject-abcd1234/werkdocumenten',
+};
+const replaceMock = vi.fn();
+const pushMock = vi.fn();
+vi.mock('vue-router', () => ({
+  useRoute: () => routeState,
+  useRouter: () => ({ replace: replaceMock, push: pushMock, resolve: () => ({ href: '#' }) }),
+  onBeforeRouteUpdate: vi.fn(),
+  onBeforeRouteLeave: vi.fn(),
+}));
+
+vi.mock('./composables/useAuth.js', () => ({
+  useAuth: () => ({ authenticated: ref(true), login: vi.fn() }),
+}));
+
+vi.mock('./composables/useTrajects.js', () => ({
+  useTrajects: () => ({
+    activeTrajectRef: ref('traject-abcd1234'),
+    activeTraject: ref({ name: 'Testtraject' }),
+  }),
+  refreshTrajects: vi.fn(),
+}));
+
+vi.mock('./lib/apiFetch.js', () => ({
+  apiFetch: vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => [] }),
+  apiFetchJson: vi.fn().mockResolvedValue([]),
+  ApiError: class ApiError extends Error {},
+}));
+
+vi.mock('./composables/useFeatureFlags.js', () => ({
+  useFeatureFlags: () => ({ isEnabled: () => true }),
+}));
+
+// The manager stub deliberately keeps `currentPath`/`currentBody`/`docLoading`/
+// `docError` as module-level refs so tests can drive the exact state the
+// review-flow watch reacts to, and assert on `dropDraft`/`open` (aliased
+// `openDoc` in LibraryView) being called (or not).
+const openDoc = vi.fn().mockResolvedValue(undefined);
+const dropDraft = vi.fn();
+const currentPath = ref('report.md');
+const currentBody = ref('');
+const docLoading = ref(false);
+const docError = ref(null);
+vi.mock('./composables/useDocumentsManager.js', () => ({
+  useDocumentsManager: () => ({
+    documents: ref([]),
+    listLoading: ref(false),
+    listError: ref(null),
+    currentPath,
+    currentBody,
+    hasChanges: ref(false),
+    docLoading,
+    docError,
+    saving: ref(false),
+    open: openDoc,
+    startNew: vi.fn(),
+    close: vi.fn(),
+    uploadDocument: vi.fn(),
+    displayTitle: (p) => p,
+    dropDraft,
+  }),
+}));
+
+vi.mock('./composables/useTrajectDocumentJobs.js', () => ({
+  useTrajectDocumentJobs: () => ({
+    jobs: ref([]),
+    refresh: vi.fn(),
+    startPolling: vi.fn(),
+    stopPolling: vi.fn(),
+  }),
+}));
+
+vi.mock('./composables/useDocumentUpload.js', () => ({
+  useDocumentUpload: () => ({
+    fileInput: ref(null),
+    uploadError: ref(null),
+    uploadRetryable: ref(false),
+    onUpload: vi.fn(),
+    onFileChange: vi.fn(),
+  }),
+}));
+
+// The composable under test's caller-side orchestration: kept as
+// module-level refs (identity-equal to what LibraryView destructures) so
+// tests can set `reviewTask.value` / `proposedContent.value` directly and
+// assert on `loadError.value` after a failed resolve.
+const reviewTask = ref(null);
+const proposedContent = ref(null);
+const loadError = ref(null);
+const loadReview = vi.fn();
+const approveAfterSave = vi.fn();
+const rejectTask = vi.fn();
+vi.mock('./composables/useDocumentTaskReview.js', () => ({
+  useDocumentTaskReview: () => ({
+    reviewTask,
+    proposedContent,
+    loadError,
+    loadReview,
+    approveAfterSave,
+    reject: rejectTask,
+  }),
+}));
+
+import LibraryView from './LibraryView.vue';
+
+function mountLibrary() {
+  return shallowMount(LibraryView, { global: { stubs: { teleport: true } } });
+}
+
+beforeEach(() => {
+  reviewTask.value = null;
+  proposedContent.value = null;
+  loadError.value = null;
+  loadReview.mockReset().mockResolvedValue(undefined);
+  approveAfterSave.mockReset();
+  rejectTask.mockReset();
+  openDoc.mockReset().mockResolvedValue(undefined);
+  dropDraft.mockReset();
+  replaceMock.mockReset().mockReturnValue(Promise.resolve());
+  pushMock.mockReset();
+  currentPath.value = 'report.md';
+  currentBody.value = '';
+  docLoading.value = false;
+  docError.value = null;
+  routeState.name = 'werkdocumenten-traject';
+  routeState.params = { trajectRef: 'traject-abcd1234', docPath: '' };
+  routeState.query = {};
+});
+
+function openReview(overrides = {}) {
+  reviewTask.value = {
+    id: 't1',
+    payload: { target_path: 'report.md', traject_ref: 'traject-abcd1234', ...overrides },
+  };
+  routeState.query = { task: 't1' };
+}
+
+describe('LibraryView document-review flow', () => {
+  // Fix 1: "Verwerpen" must throw away the seeded draft before reopening the
+  // document - otherwise the debounced localStorage persistence in
+  // useTrajectDocuments resurrects the rejected proposal as a 'draft-present'
+  // notice (or leaves an orphan draft for a document that never existed).
+  it('rejectDocReview drops the draft before reopening the document, then clears the task query', async () => {
+    rejectTask.mockResolvedValue(undefined);
+    openReview();
+    const wrapper = mountLibrary();
+    await wrapper.vm.$nextTick();
+
+    const order = [];
+    dropDraft.mockImplementation(() => order.push('dropDraft'));
+    openDoc.mockImplementation(() => {
+      order.push('openDoc');
+      return Promise.resolve();
+    });
+
+    await wrapper.vm.rejectDocReview();
+
+    expect(rejectTask).toHaveBeenCalled();
+    expect(order).toEqual(['dropDraft', 'openDoc']);
+    expect(openDoc).toHaveBeenCalledWith('report.md');
+    expect(replaceMock).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'werkdocumenten-traject' }),
+    );
+  });
+
+  // Fix 6: a failed reject-resolve must not be treated as a successful
+  // reject - the draft/document state stays untouched and the failure is
+  // surfaced, not silently swallowed.
+  it('rejectDocReview leaves the draft and task open when the resolve call fails', async () => {
+    rejectTask.mockRejectedValue(new Error('network'));
+    openReview();
+    const wrapper = mountLibrary();
+    await wrapper.vm.$nextTick();
+
+    await wrapper.vm.rejectDocReview();
+
+    expect(dropDraft).not.toHaveBeenCalled();
+    expect(openDoc).not.toHaveBeenCalled();
+    expect(replaceMock).not.toHaveBeenCalled();
+    expect(loadError.value).toMatch(/mislukt/i);
+  });
+
+  // Fix 2 + Fix 4: onDocSaved only approves when the saved path AND traject
+  // match the task under review.
+  it('onDocSaved approves and clears the task query when the saved path matches', async () => {
+    approveAfterSave.mockResolvedValue(undefined);
+    openReview();
+    const wrapper = mountLibrary();
+    await wrapper.vm.$nextTick();
+
+    await wrapper.vm.onDocSaved('report.md');
+
+    expect(approveAfterSave).toHaveBeenCalled();
+    expect(replaceMock).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'werkdocumenten-traject' }),
+    );
+  });
+
+  it('onDocSaved ignores a save of a different path (e.g. renamed away from target_path)', async () => {
+    openReview();
+    const wrapper = mountLibrary();
+    await wrapper.vm.$nextTick();
+
+    await wrapper.vm.onDocSaved('other.md');
+
+    expect(approveAfterSave).not.toHaveBeenCalled();
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+
+  it('onDocSaved ignores a review task that belongs to a different traject', async () => {
+    openReview({ traject_ref: 'ander-traject-9999zzzz' });
+    const wrapper = mountLibrary();
+    await wrapper.vm.$nextTick();
+
+    await wrapper.vm.onDocSaved('report.md');
+
+    expect(approveAfterSave).not.toHaveBeenCalled();
+  });
+
+  // Fix 6: a failed approve-resolve must not crash the (already-succeeded)
+  // save flow; the task simply stays open.
+  it('onDocSaved leaves the task open without crashing when the resolve call fails', async () => {
+    approveAfterSave.mockRejectedValue(new Error('network'));
+    openReview();
+    const wrapper = mountLibrary();
+    await wrapper.vm.$nextTick();
+
+    await expect(wrapper.vm.onDocSaved('report.md')).resolves.toBeUndefined();
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+
+  // Fix 3: a save-and-leave already lets the user's chosen navigation
+  // through before the approve-resolve settles; clearDocReviewQuery must not
+  // drag them back once the route has moved off the werkdocumenten/task URL.
+  it('clearDocReviewQuery does not stomp a navigation the user already made', async () => {
+    approveAfterSave.mockResolvedValue(undefined);
+    openReview();
+    const wrapper = mountLibrary();
+    await wrapper.vm.$nextTick();
+
+    routeState.name = 'library-traject';
+    await wrapper.vm.onDocSaved('report.md');
+
+    expect(approveAfterSave).toHaveBeenCalled();
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+
+  // Fix 2: the seeding `.then()` callback must re-validate against the
+  // task's own payload before writing into the editor body - a stale
+  // response arriving after the user has moved to another document must not
+  // seed the wrong one.
+  it('seeds the proposal into the document body when the task matches the open document', async () => {
+    openReview();
+    loadReview.mockImplementation(() => {
+      proposedContent.value = '# Voorstel';
+      return Promise.resolve();
+    });
+
+    const wrapper = mountLibrary();
+    await wrapper.vm.$nextTick();
+    await wrapper.vm.$nextTick();
+
+    expect(loadReview).toHaveBeenCalledWith('t1');
+    expect(currentBody.value).toBe('# Voorstel');
+  });
+
+  it('skips seeding when the open document changed while the task fetch was in flight', async () => {
+    openReview();
+    let resolveLoad;
+    loadReview.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveLoad = resolve;
+        }),
+    );
+
+    const wrapper = mountLibrary();
+    await wrapper.vm.$nextTick();
+    expect(loadReview).toHaveBeenCalledWith('t1');
+
+    // The user navigated to a different document before the fetch resolved.
+    currentPath.value = 'other.md';
+    proposedContent.value = '# Voorstel';
+    resolveLoad();
+    await wrapper.vm.$nextTick();
+    await wrapper.vm.$nextTick();
+
+    expect(currentBody.value).toBe('');
+  });
+});

--- a/frontend/src/LibraryView.docReview.test.js
+++ b/frontend/src/LibraryView.docReview.test.js
@@ -201,6 +201,36 @@ describe('LibraryView document-review flow', () => {
     expect(loadError.value).toMatch(/mislukt/i);
   });
 
+  // A retry after a failed reject must clear the stale critical banner: the
+  // second call succeeds, so the "Verwerpen ... mislukt" error may not linger.
+  it('rejectDocReview clears a prior reject-failure banner on a successful retry', async () => {
+    rejectTask.mockResolvedValue(undefined);
+    openReview();
+    loadError.value = 'Verwerpen van het voorstel is mislukt. Probeer het opnieuw.';
+    const wrapper = mountLibrary();
+    await wrapper.vm.$nextTick();
+
+    await wrapper.vm.rejectDocReview();
+
+    expect(rejectTask).toHaveBeenCalled();
+    expect(loadError.value).toBeNull();
+  });
+
+  // Approving (Opslaan) after a prior reject-failure must also drop the stale
+  // banner - otherwise it stays visible while the task is already resolved.
+  it('onDocSaved clears a prior reject-failure banner on a successful approval', async () => {
+    approveAfterSave.mockResolvedValue(undefined);
+    openReview();
+    loadError.value = 'Verwerpen van het voorstel is mislukt. Probeer het opnieuw.';
+    const wrapper = mountLibrary();
+    await wrapper.vm.$nextTick();
+
+    await wrapper.vm.onDocSaved('report.md');
+
+    expect(approveAfterSave).toHaveBeenCalled();
+    expect(loadError.value).toBeNull();
+  });
+
   // Fix 2 + Fix 4: onDocSaved only approves when the saved path AND traject
   // match the task under review.
   it('onDocSaved approves and clears the task query when the saved path matches', async () => {

--- a/frontend/src/LibraryView.vue
+++ b/frontend/src/LibraryView.vue
@@ -22,12 +22,15 @@ import { homeTarget } from './composables/useLastVisitedRoute.js';
 import { useDocumentsManager } from './composables/useDocumentsManager.js';
 import { useTrajectDocumentJobs } from './composables/useTrajectDocumentJobs.js';
 import { useDocumentUpload } from './composables/useDocumentUpload.js';
+import { useDocumentTaskReview } from './composables/useDocumentTaskReview.js';
+import { useFeatureFlags } from './composables/useFeatureFlags.js';
 import { humanizeLawId } from './lib/lawName.js';
 import { apiFetch, apiFetchJson, ApiError } from './lib/apiFetch.js';
 import { useLatest } from './lib/useLatest.js';
 import { holdRetryFloor, RETRY_MIN_SPINNER_MS } from './lib/retryFeedback.js';
 
 const { authenticated, login } = useAuth();
+const { isEnabled } = useFeatureFlags();
 
 // Provided by AppShell: shows the login-warning popover anchored to an element,
 // so "Bewerken" gates on login the same way the Editor tab does.
@@ -234,6 +237,106 @@ function onDocNew() {
 function onDocBack() {
   guardedDocNavigate(() => closeDoc());
 }
+
+// --- Review-modus (job_review-taak, payload.kind === 'document') --------
+// `?task=<id>` + the tasks.job_review flag on the werkdocumenten route:
+// show a document-conversion job_review task's proposed markdown as an
+// unsaved edit on the addressed document, the same way EditorView seeds a
+// law-review proposal into the article panes. Mirrors EditorView's
+// `useTaskReview` wiring; see the comment on useDocumentTaskReview.js for
+// why the fetch/resolve logic lives in the composable while the seeding
+// (this component's job, since it owns `docsMgr`) lives here.
+const {
+  reviewTask: docReviewTask,
+  proposedContent: docReviewProposedContent,
+  loadError: docReviewLoadError,
+  loadReview: loadDocReview,
+  approveAfterSave: docReviewApproveAfterSave,
+  reject: docReviewRejectInternal,
+} = useDocumentTaskReview();
+const docReviewActive = computed(() => !!docReviewTask.value);
+// Guards against re-firing loadDocReview for a task id already attempted -
+// approve/reject null out `docReviewTask`, which would otherwise look
+// indistinguishable from "not loaded yet" and re-trigger against the task
+// we just resolved.
+let docReviewAttemptedForTaskId = null;
+
+// Whether the tasks.job_review flag is on, split out as its own reactive
+// source for the same reason as EditorView's `taskReviewFlagEnabled`:
+// useFeatureFlags resolves asynchronously, so a document that finishes
+// loading before that fetch lands must still re-evaluate once it does.
+const taskReviewFlagEnabled = computed(() => isEnabled('tasks.job_review'));
+const docReviewTaskIdParam = computed(() =>
+  isWerkdocMode.value && typeof route.query.task === 'string' ? route.query.task : null,
+);
+
+// Fires once the addressed document has finished its (possibly 404) open -
+// `openDoc(docPath)` (route-driven, see the initial-load/onBeforeRouteUpdate
+// wiring below) already sets `currentPath`/`docError` before this can act,
+// so this only has to wait for the per-document `docLoading` to clear (not
+// `docsLoading`, which tracks the sidebar's document *list* fetch).
+watch(
+  [docsMgr.docLoading, openDocPath, taskReviewFlagEnabled, docReviewTaskIdParam],
+  ([isDocLoading, docPath, flagEnabled, taskId]) => {
+    if (isDocLoading || !docPath || !taskId || !flagEnabled) return;
+    if (docReviewAttemptedForTaskId === taskId) return;
+    docReviewAttemptedForTaskId = taskId;
+    loadDocReview(taskId).then(() => {
+      if (!docReviewProposedContent.value) return;
+      // The target document doesn't exist yet on the branch (the usual
+      // case - a conversion is never pushed) - openDoc's 404 branch left a
+      // 'not-found' docError blocking the editor body (see
+      // useTrajectDocuments.js); clear it so the proposal renders as a
+      // brand-new document instead of a blocking "Document niet gevonden".
+      // When the document DOES already exist, docError is left as-is
+      // (openDoc already loaded the real savedBody/etag) and the proposal
+      // simply overwrites currentBody as a draft-seed, so the existing
+      // conflict mechanism (currentEtag as If-Match on save) keeps working.
+      if (docsMgr.docError.value?.kind === 'not-found') {
+        docsMgr.docError.value = null;
+      }
+      docsMgr.currentBody.value = docReviewProposedContent.value;
+    });
+  },
+  { immediate: true },
+);
+
+// Drop `?task=` from the URL once the review is resolved (approved or
+// rejected) so a refresh/back-navigation doesn't re-open review mode.
+function clearDocReviewQuery() {
+  router.replace({
+    name: 'werkdocumenten-traject',
+    params: { trajectRef: activeTrajectRef.value, docPath: openDocPath.value || '' },
+  });
+}
+
+// "Verwerpen" in the review banner: resolve the task as rejected and
+// re-fetch the document's real server state (whichever it is - still
+// nonexistent, or its unmodified saved body) so the seeded proposal is
+// thrown away, mirroring EditorView's `discardArticle()` on reject.
+async function rejectDocReview() {
+  const path = docReviewTask.value?.payload?.target_path;
+  await docReviewRejectInternal();
+  if (path) await openDoc(path);
+  clearDocReviewQuery();
+}
+
+// A successful save of the exact document under review IS the approval
+// (spec: save first, then resolve) - hooked onto DocumentEditor's 'saved'
+// event, its existing save-success point, rather than duplicating the save
+// path. Ignores saves of any other document (there shouldn't be one open at
+// the same time, but this keeps the check honest).
+async function onDocSaved() {
+  if (!docReviewActive.value) return;
+  if (docReviewTask.value?.payload?.target_path !== openDocPath.value) return;
+  await docReviewApproveAfterSave();
+  clearDocReviewQuery();
+}
+
+const docReviewBannerVariant = computed(() => (docReviewLoadError.value ? 'critical' : 'neutral'));
+const docReviewBannerSupportingText = computed(() =>
+  docReviewLoadError.value || 'Opslaan keurt het voorstel goed, Verwerpen wijst af.',
+);
 
 // Keep the user's traject scope across in-app navigations. A traject with a law
 // stays on `library-traject`, a traject without one on `traject-home`; publicly,
@@ -1208,7 +1311,25 @@ watch(activeTrajectRef, () => {
           <!-- Main (werkdoc mode): the document editor, or a placeholder. -->
           <nldd-split-view-pane v-else-if="isWerkdocMode" slot="main" :has-content="hasOpenDoc || undefined">
             <nldd-page v-if="hasOpenDoc" sticky-header sticky-footer>
-              <DocumentEditor ref="docEditorEl" :manager="docsMgr" :traject-name="trajectName" @back="onDocBack"></DocumentEditor>
+              <!-- Review-modus (job_review-taak, payload.kind === 'document'):
+                   a full-width, low bar above the document editor, same
+                   pattern/variants as EditorView's law-review banner (PR
+                   #935/#936). A bare nldd-container + nldd-banner in
+                   DocumentEditor's default (body) slot, ahead of its own
+                   nldd-simple-section - both land in nldd-page's body area,
+                   in source order, so the banner sits above the editor. -->
+              <nldd-container v-if="docReviewActive || docReviewLoadError" padding="8">
+                <nldd-banner :variant="docReviewBannerVariant" text="Voorstel uit documentconversie" :supporting-text="docReviewBannerSupportingText">
+                  <nldd-button
+                    v-if="docReviewActive"
+                    slot="actions"
+                    variant="secondary"
+                    text="Verwerpen"
+                    @click="rejectDocReview"
+                  ></nldd-button>
+                </nldd-banner>
+              </nldd-container>
+              <DocumentEditor ref="docEditorEl" :manager="docsMgr" :traject-name="trajectName" @back="onDocBack" @saved="onDocSaved"></DocumentEditor>
             </nldd-page>
             <nldd-page v-else>
               <nldd-simple-section width="full">

--- a/frontend/src/LibraryView.vue
+++ b/frontend/src/LibraryView.vue
@@ -162,11 +162,15 @@ function onTrajectGone() {
 
 // Mirror the open document into the URL (refresh / bookmark / back). Guard the
 // redundant replace the initial open would trigger (URL already names the doc).
+// Only the PATH is normalized: the query rijdt mee, anders zou deze mirror een
+// binnenkomende `?task=<id>` (document-review-taak) direct weer strippen
+// voordat de review-activatie hem heeft kunnen lezen.
 watch(openDocPath, (p) => {
   if (!isWerkdocMode.value) return;
   const target = {
     name: 'werkdocumenten-traject',
     params: { trajectRef: activeTrajectRef.value, docPath: p || '' },
+    query: route.query,
   };
   if (router.resolve(target).href !== route.fullPath) {
     router.replace(target).catch(() => {});

--- a/frontend/src/LibraryView.vue
+++ b/frontend/src/LibraryView.vue
@@ -343,6 +343,9 @@ function clearDocReviewQuery() {
 // leaving the user with no way back to it.
 async function rejectDocReview() {
   const path = docReviewTask.value?.payload?.target_path;
+  // Clear a prior failure so a retry (or a later success) drops the stale
+  // critical banner instead of leaving it up after the reject succeeds.
+  docReviewLoadError.value = null;
   try {
     await docReviewRejectInternal();
   } catch (e) {
@@ -386,6 +389,8 @@ async function onDocSaved(savedPath) {
     console.warn('Goedkeuren van documentvoorstel mislukt:', e);
     return;
   }
+  // A successful approval clears any stale reject-failure banner too.
+  docReviewLoadError.value = null;
   clearDocReviewQuery();
 }
 

--- a/frontend/src/LibraryView.vue
+++ b/frontend/src/LibraryView.vue
@@ -283,6 +283,16 @@ watch(
     docReviewAttemptedForTaskId = taskId;
     loadDocReview(taskId).then(() => {
       if (!docReviewProposedContent.value) return;
+      // Stale-callback guard: `docPath`/`activeTrajectRef` may have moved on
+      // (another document opened, or the traject switched) while the fetch
+      // was in flight. Re-check against the task's own payload - a mismatch
+      // means this response no longer addresses what's on screen, so leave
+      // both the body and any docError alone rather than seeding the wrong
+      // document (or wiping a real 'not-found'/'load-error' for it).
+      const payload = docReviewTask.value?.payload;
+      if (payload?.target_path !== openDocPath.value || payload?.traject_ref !== activeTrajectRef.value) {
+        return;
+      }
       // The target document doesn't exist yet on the branch (the usual
       // case - a conversion is never pushed) - openDoc's 404 branch left a
       // 'not-found' docError blocking the editor body (see
@@ -302,8 +312,15 @@ watch(
 );
 
 // Drop `?task=` from the URL once the review is resolved (approved or
-// rejected) so a refresh/back-navigation doesn't re-open review mode.
+// rejected) so a refresh/back-navigation doesn't re-open review mode. Guarded
+// on still being on the werkdocumenten route with a `?task=` query: a
+// save-and-leave (saveDocAndLeave below) already lets the user's chosen
+// navigation through before this resolves (`onDocSaved` awaits the task
+// resolve, which finishes after `resolveDocGuard` has moved the route/doc
+// on) - without the guard this `replace` would stomp that navigation and
+// drag the user back to the just-approved document.
 function clearDocReviewQuery() {
+  if (route.name !== 'werkdocumenten-traject' || typeof route.query.task !== 'string') return;
   router.replace({
     name: 'werkdocumenten-traject',
     params: { trajectRef: activeTrajectRef.value, docPath: openDocPath.value || '' },
@@ -313,10 +330,31 @@ function clearDocReviewQuery() {
 // "Verwerpen" in the review banner: resolve the task as rejected and
 // re-fetch the document's real server state (whichever it is - still
 // nonexistent, or its unmodified saved body) so the seeded proposal is
-// thrown away, mirroring EditorView's `discardArticle()` on reject.
+// thrown away, mirroring EditorView's `discardArticle()` on reject. Wrapped
+// in try/catch (EditorView's law-review reject doesn't need this - it has no
+// resolve-failure path exercised in practice - but this one does): a failed
+// resolve must NOT be treated as a successful reject, so the seeded proposal
+// stays in place and `openDoc`/`clearDocReviewQuery` are skipped entirely -
+// otherwise the banner would disappear while the task is still open,
+// leaving the user with no way back to it.
 async function rejectDocReview() {
   const path = docReviewTask.value?.payload?.target_path;
-  await docReviewRejectInternal();
+  try {
+    await docReviewRejectInternal();
+  } catch (e) {
+    console.warn('Verwerpen van documentvoorstel mislukt:', e);
+    docReviewLoadError.value = 'Verwerpen van het voorstel is mislukt. Probeer het opnieuw.';
+    return;
+  }
+  // Drop the seeded proposal's draft (localStorage + in-memory body) BEFORE
+  // re-opening: `openDoc` re-reads the server state, but the debounced draft
+  // persistence in useTrajectDocuments already wrote the seeded proposal to
+  // localStorage by the time the user clicks Verwerpen - without this,
+  // reopening the (still-nonexistent, for the common case) document would
+  // resurrect the rejected proposal as a 'draft-present' notice, and a
+  // rejected proposal for a document that never existed would leave an
+  // orphan draft behind indefinitely.
+  docsMgr.dropDraft();
   if (path) await openDoc(path);
   clearDocReviewQuery();
 }
@@ -324,12 +362,26 @@ async function rejectDocReview() {
 // A successful save of the exact document under review IS the approval
 // (spec: save first, then resolve) - hooked onto DocumentEditor's 'saved'
 // event, its existing save-success point, rather than duplicating the save
-// path. Ignores saves of any other document (there shouldn't be one open at
-// the same time, but this keeps the check honest).
-async function onDocSaved() {
+// path. `savedPath` is the path DocumentEditor actually just saved (see its
+// `emit('saved', savedPath)` call sites) - falls back to `openDocPath.value`
+// for safety, though every emitter passes it explicitly. Also gates on the
+// traject: `docReviewTask` is a task fetched for a specific traject_ref, so
+// a traject switch that happens to land on a document with the same path
+// must not resolve a review that belongs to the other traject. Wrapped in
+// try/catch: a failed resolve leaves the task open (by design - the assignee
+// still has to act on it) without crashing the save flow, which already
+// succeeded on the server.
+async function onDocSaved(savedPath) {
   if (!docReviewActive.value) return;
-  if (docReviewTask.value?.payload?.target_path !== openDocPath.value) return;
-  await docReviewApproveAfterSave();
+  const path = savedPath ?? openDocPath.value;
+  const payload = docReviewTask.value?.payload;
+  if (payload?.target_path !== path || payload?.traject_ref !== activeTrajectRef.value) return;
+  try {
+    await docReviewApproveAfterSave();
+  } catch (e) {
+    console.warn('Goedkeuren van documentvoorstel mislukt:', e);
+    return;
+  }
   clearDocReviewQuery();
 }
 

--- a/frontend/src/components/DocumentEditor.vue
+++ b/frontend/src/components/DocumentEditor.vue
@@ -36,7 +36,7 @@ const props = defineProps({
   // Shown as the subtitle under the document title, for traject context.
   trajectName: { type: String, default: '' },
 });
-const emit = defineEmits(['deleted', 'back']);
+const emit = defineEmits(['deleted', 'back', 'saved']);
 
 const m = props.manager;
 const {
@@ -105,10 +105,18 @@ onUnmounted(() => {
 // The top-bar Save (and Ctrl/Cmd+S) only persist the body; renaming happens in
 // the sheet. Reset titleDraft to the current name first so a name left half-
 // edited in a dismissed rename sheet can never trigger an accidental rename.
+// Emits 'saved' on success - the save-success hook a document-task review
+// (useDocumentTaskReview, wired in LibraryView.vue) uses to resolve the task
+// as approved, mirroring how EditorView's law-review approves after its own
+// save succeeds. Not emitted from `saveRename` (the rename sheet), which
+// calls `handleSave` directly - renaming isn't part of the save-and-approve
+// flow a review is watching for.
 async function saveDocument() {
   if (saving.value || !currentPath.value) return false;
   titleDraft.value = displayTitle(currentPath.value);
-  return await handleSave();
+  const ok = await handleSave();
+  if (ok) emit('saved');
+  return ok;
 }
 
 // Exposed so the parent's leave-guard can offer a "save and close" action

--- a/frontend/src/components/DocumentEditor.vue
+++ b/frontend/src/components/DocumentEditor.vue
@@ -108,14 +108,16 @@ onUnmounted(() => {
 // Emits 'saved' on success - the save-success hook a document-task review
 // (useDocumentTaskReview, wired in LibraryView.vue) uses to resolve the task
 // as approved, mirroring how EditorView's law-review approves after its own
-// save succeeds. Not emitted from `saveRename` (the rename sheet), which
-// calls `handleSave` directly - renaming isn't part of the save-and-approve
-// flow a review is watching for.
+// save succeeds. The payload is the path that was under review WHEN THE SAVE
+// STARTED (captured before `handleSave`, which can move `currentPath` for a
+// rename) - LibraryView's `onDocSaved` gates on that path matching the
+// task's `target_path`, not on wherever the document ended up.
 async function saveDocument() {
   if (saving.value || !currentPath.value) return false;
+  const savedPath = currentPath.value;
   titleDraft.value = displayTitle(currentPath.value);
   const ok = await handleSave();
-  if (ok) emit('saved');
+  if (ok) emit('saved', savedPath);
   return ok;
 }
 
@@ -142,9 +144,18 @@ async function openRename() {
   await nextTick();
   renameFieldEl.value?.focus?.();
 }
+// Also emits 'saved' (see `saveDocument` above): renaming still commits
+// whatever body was in the editor, so it must still trip the review-approve
+// hook when that body is the one under review - even though the document
+// may end up at a different path than `target_path`, `savedPath` (captured
+// before the rename) is what LibraryView's gate compares against.
 async function saveRename() {
+  const savedPath = currentPath.value;
   const ok = await handleSave();
-  if (ok) renameSheetEl.value?.hide?.();
+  if (ok) {
+    emit('saved', savedPath);
+    renameSheetEl.value?.hide?.();
+  }
 }
 
 // --- Delete ---
@@ -182,9 +193,15 @@ function conflictReload() {
   conflict.value = null;
   reloadCurrent();
 }
-function conflictOverwrite() {
+// Async + emits 'saved' on success (see `saveDocument` above): "Lokaal
+// overschrijven" commits the in-editor body via a force-write, bypassing
+// `handleSave`/`saveDocument` entirely - without this the review-approve
+// hook would never fire for a conflict resolved this way.
+async function conflictOverwrite() {
   conflict.value = null;
-  overwriteServer();
+  const savedPath = currentPath.value;
+  const result = await overwriteServer();
+  if (result?.ok) emit('saved', savedPath);
 }
 
 const deleteNoticeModalEl = ref(null);

--- a/frontend/src/components/TasksSheet.test.js
+++ b/frontend/src/components/TasksSheet.test.js
@@ -69,6 +69,22 @@ describe('TasksSheet', () => {
     expect(wrapper.find('nldd-inline-dialog').exists()).toBe(false);
   });
 
+  it('toont een lopende documentconversie met de bestandsnaam uit target_path', async () => {
+    const wrapper = await mountSheet(
+      [],
+      [{
+        job_id: 'j2',
+        job_type: 'document_convert',
+        law_id: 'doc:testtraject-abcd1234/analyses/rapport.md',
+        target_path: 'analyses/rapport.md',
+        status: 'processing',
+      }]
+    );
+    const indicators = wrapper.findAll('nldd-activity-indicator');
+    expect(indicators).toHaveLength(1);
+    expect(indicators[0].attributes('text')).toBe('Conversie loopt - rapport.md');
+  });
+
   it('toont zowel de Bezig-sectie als de takenlijst wanneer beide gevuld zijn', async () => {
     const wrapper = await mountSheet(
       [{ id: 't1', task_type: 'job_review', title: 'Verrijking beoordelen: andere_wet', payload: {} }],

--- a/frontend/src/components/TasksSheet.test.js
+++ b/frontend/src/components/TasksSheet.test.js
@@ -129,6 +129,24 @@ describe('TasksSheet', () => {
     expect(isOpen.value).toBe(false);
   });
 
+  it('navigeert naar de werkdocumenten-route met ?task= voor een document-review-taak, met het documents-icoon', async () => {
+    const wrapper = await mountSheet([
+      {
+        id: 't5',
+        task_type: 'job_review',
+        title: 'Documentconversie beoordelen: bijv-rapport.md',
+        payload: { kind: 'document', traject_ref: 'traject-abcd1234', target_path: 'bijv-rapport.md' },
+      },
+    ]);
+    expect(wrapper.get('nldd-icon-cell').attributes('icon')).toBe('documents');
+    await wrapper.get('nldd-button').trigger('click');
+    expect(pushMock).toHaveBeenCalledWith({
+      name: 'werkdocumenten-traject',
+      params: { trajectRef: 'traject-abcd1234', docPath: 'bijv-rapport.md' },
+      query: { task: 't5' },
+    });
+  });
+
   it('toont een disabled Beoordelen-knop voor een taak zonder traject_ref/law_id', async () => {
     const wrapper = await mountSheet([
       { id: 't3', task_type: 'job_review', title: 'Verrijking beoordelen: ???', payload: {} },

--- a/frontend/src/components/TasksSheet.vue
+++ b/frontend/src/components/TasksSheet.vue
@@ -31,6 +31,17 @@ function dismiss(task) {
   resolveTask(task.id, 'dismissed');
 }
 
+// A failed task always gets the alert icon; an open job_review task's icon
+// depends on what it's reviewing - a document-conversion proposal
+// (payload.kind === 'document') gets the 'documents' alias (icon-aliases.js:
+// 'documents' -> file-text-stack, already used elsewhere e.g. TrajectMenu.vue),
+// anything else (a law-review proposal) keeps the generic 'tasks' icon.
+function taskIcon(task) {
+  if (task.task_type === 'job_failed') return 'alert';
+  if (task.payload?.kind === 'document') return 'documents';
+  return 'tasks';
+}
+
 // "Beoordelen" navigeert naar het artikel in de editor (met de taak-id als
 // query) en sluit de sheet. Taken zonder traject_ref/law_id in de payload
 // tonen een disabled knop (zie :disabled hieronder) in plaats van te
@@ -83,7 +94,7 @@ function review(task) {
               <nldd-icon-cell
                 slot="start"
                 size="20"
-                :icon="task.task_type === 'job_failed' ? 'alert' : 'tasks'"
+                :icon="taskIcon(task)"
                 :color="task.task_type === 'job_failed' ? 'critical' : undefined"
               ></nldd-icon-cell>
               <nldd-spacer-cell slot="start" size="8"></nldd-spacer-cell>

--- a/frontend/src/components/TasksSheet.vue
+++ b/frontend/src/components/TasksSheet.vue
@@ -42,6 +42,17 @@ function taskIcon(task) {
   return 'tasks';
 }
 
+// Label voor een lopende taak-flow-job. Een document_convert-job draagt een
+// synthetische `doc:`-sleutel als law_id; de bestandsnaam uit target_path is
+// het herkenbare handvat voor de gebruiker.
+function runningText(job) {
+  if (job.job_type === 'document_convert') {
+    const name = job.target_path?.split('/').pop() || 'werkdocument';
+    return `Conversie loopt - ${name}`;
+  }
+  return `Verrijking loopt - ${job.law_id}`;
+}
+
 // "Beoordelen" navigeert naar het artikel in de editor (met de taak-id als
 // query) en sluit de sheet. Taken zonder traject_ref/law_id in de payload
 // tonen een disabled knop (zie :disabled hieronder) in plaats van te
@@ -74,11 +85,11 @@ function review(task) {
                 <nldd-icon-cell slot="start" size="20">
                   <nldd-activity-indicator
                     size="16"
-                    :text="`Verrijking loopt - ${job.law_id}`"
+                    :text="runningText(job)"
                   ></nldd-activity-indicator>
                 </nldd-icon-cell>
                 <nldd-spacer-cell slot="start" size="8"></nldd-spacer-cell>
-                <nldd-text-cell :text="`Verrijking loopt - ${job.law_id}`"></nldd-text-cell>
+                <nldd-text-cell :text="runningText(job)"></nldd-text-cell>
               </nldd-list-item>
             </nldd-list>
             <nldd-spacer size="16"></nldd-spacer>

--- a/frontend/src/composables/useDocumentTaskReview.js
+++ b/frontend/src/composables/useDocumentTaskReview.js
@@ -1,0 +1,64 @@
+/**
+ * useDocumentTaskReview - review-modus voor een job_review-taak met
+ * `payload.kind === 'document'` (documentconversie) in de werkdocumenten-
+ * sectie.
+ *
+ * Zelfde vorm als useTaskReview.js (de wet-tegenhanger): haal de taakdetail
+ * op, valideer 'm, en lever (a) de voorgestelde markdown, (b) approve/reject-
+ * acties. Puur fetch/resolve - het INZETTEN van de voorgestelde markdown als
+ * niet-opgeslagen wijziging in de documenten-manager (en het weer terugdraaien
+ * bij Verwerpen) is orkestratie die, net als bij de wet-review in
+ * EditorView.vue, in de aanroeper (LibraryView.vue) blijft: deze composable
+ * kent de documenten-manager niet.
+ */
+import { ref } from 'vue';
+import { useTaskActions } from './useTasks.js';
+
+export function useDocumentTaskReview() {
+  // useTaskActions(), not useTasks(): zie useTaskReview.js - voorkomt dat elke
+  // (ook anonieme) bezoeker van de werkdocumenten-sectie de 30s-poll van de
+  // gedeelde takenlijst start.
+  const { fetchTask, resolveTask } = useTaskActions();
+  const reviewTask = ref(null);
+  const proposedContent = ref(null);
+  const loadError = ref(null);
+
+  async function loadReview(taskId) {
+    try {
+      const detail = await fetchTask(taskId);
+      if (detail.task_type !== 'job_review' || detail.status !== 'open') {
+        loadError.value = 'Deze taak is al afgehandeld.';
+        return;
+      }
+      const payload = detail.payload || {};
+      if (payload.kind !== 'document' || !payload.traject_ref || !payload.target_path) {
+        loadError.value = 'Geen documentvoorstel gevonden bij deze taak.';
+        return;
+      }
+      const results = detail.results || [];
+      const doc = results.find((r) => r.path === payload.target_path) || results[0];
+      if (!doc) {
+        loadError.value = 'Geen resultaat gevonden bij deze taak.';
+        return;
+      }
+      reviewTask.value = detail;
+      proposedContent.value = doc.content;
+    } catch (e) {
+      loadError.value = 'Taak laden mislukt.';
+    }
+  }
+
+  async function approveAfterSave() {
+    if (reviewTask.value) await resolveTask(reviewTask.value.id, 'approved');
+    reviewTask.value = null;
+    proposedContent.value = null;
+  }
+
+  async function reject() {
+    if (reviewTask.value) await resolveTask(reviewTask.value.id, 'rejected');
+    reviewTask.value = null;
+    proposedContent.value = null;
+  }
+
+  return { reviewTask, proposedContent, loadError, loadReview, approveAfterSave, reject };
+}

--- a/frontend/src/composables/useDocumentTaskReview.test.js
+++ b/frontend/src/composables/useDocumentTaskReview.test.js
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useDocumentTaskReview } from './useDocumentTaskReview.js';
+
+const fetchTask = vi.fn();
+const resolveTask = vi.fn();
+vi.mock('./useTasks.js', () => ({
+  useTaskActions: () => ({ fetchTask: (...a) => fetchTask(...a), resolveTask: (...a) => resolveTask(...a) }),
+}));
+
+function openTask(overrides = {}) {
+  return {
+    id: 't1',
+    task_type: 'job_review',
+    status: 'open',
+    payload: {
+      kind: 'document',
+      traject_ref: 'mijn-traject-1a2b3c4d',
+      target_path: 'bijv-rapport.md',
+    },
+    results: [{ path: 'bijv-rapport.md', content: '# Rapport\n\nVoorstel.' }],
+    ...overrides,
+  };
+}
+
+describe('useDocumentTaskReview', () => {
+  beforeEach(() => {
+    fetchTask.mockReset();
+    resolveTask.mockReset();
+  });
+
+  it('laadt het voorstel van een open document-review-taak', async () => {
+    fetchTask.mockResolvedValue(openTask());
+    const { reviewTask, proposedContent, loadError, loadReview } = useDocumentTaskReview();
+    await loadReview('t1');
+    expect(fetchTask).toHaveBeenCalledWith('t1');
+    expect(reviewTask.value?.id).toBe('t1');
+    expect(proposedContent.value).toBe('# Rapport\n\nVoorstel.');
+    expect(loadError.value).toBeNull();
+  });
+
+  it('kiest het result-blob op payload.target_path', async () => {
+    fetchTask.mockResolvedValue(
+      openTask({
+        results: [
+          { path: 'anders.md', content: 'niet dit' },
+          { path: 'bijv-rapport.md', content: 'wel dit' },
+        ],
+      }),
+    );
+    const { proposedContent, loadReview } = useDocumentTaskReview();
+    await loadReview('t1');
+    expect(proposedContent.value).toBe('wel dit');
+  });
+
+  it('weigert een taak die al afgehandeld is', async () => {
+    fetchTask.mockResolvedValue(openTask({ status: 'resolved' }));
+    const { reviewTask, proposedContent, loadError, loadReview } = useDocumentTaskReview();
+    await loadReview('t1');
+    expect(reviewTask.value).toBeNull();
+    expect(proposedContent.value).toBeNull();
+    expect(loadError.value).toBe('Deze taak is al afgehandeld.');
+  });
+
+  it('weigert een taak van het verkeerde type', async () => {
+    fetchTask.mockResolvedValue(openTask({ task_type: 'job_failed' }));
+    const { reviewTask, loadError, loadReview } = useDocumentTaskReview();
+    await loadReview('t1');
+    expect(reviewTask.value).toBeNull();
+    expect(loadError.value).toBe('Deze taak is al afgehandeld.');
+  });
+
+  it('weigert een taak zonder kind: document in de payload (bijv. een wet-review)', async () => {
+    fetchTask.mockResolvedValue(
+      openTask({ payload: { traject_ref: 'mijn-traject-1a2b3c4d', law_id: 'test_wet' } }),
+    );
+    const { reviewTask, loadError, loadReview } = useDocumentTaskReview();
+    await loadReview('t1');
+    expect(reviewTask.value).toBeNull();
+    expect(loadError.value).toBe('Geen documentvoorstel gevonden bij deze taak.');
+  });
+
+  it('weigert een taak zonder target_path in de payload', async () => {
+    fetchTask.mockResolvedValue(
+      openTask({ payload: { kind: 'document', traject_ref: 'mijn-traject-1a2b3c4d' } }),
+    );
+    const { reviewTask, loadError, loadReview } = useDocumentTaskReview();
+    await loadReview('t1');
+    expect(reviewTask.value).toBeNull();
+    expect(loadError.value).toBe('Geen documentvoorstel gevonden bij deze taak.');
+  });
+
+  it('zet loadError wanneer er geen result-blob bij de taak zit', async () => {
+    fetchTask.mockResolvedValue(openTask({ results: [] }));
+    const { reviewTask, loadError, loadReview } = useDocumentTaskReview();
+    await loadReview('t1');
+    expect(reviewTask.value).toBeNull();
+    expect(loadError.value).toBe('Geen resultaat gevonden bij deze taak.');
+  });
+
+  it('zet loadError wanneer fetchTask faalt', async () => {
+    fetchTask.mockRejectedValue(new Error('netwerk'));
+    const { loadError, loadReview } = useDocumentTaskReview();
+    await loadReview('t1');
+    expect(loadError.value).toBe('Taak laden mislukt.');
+  });
+
+  it('approveAfterSave resolvet als approved en reset de review-state', async () => {
+    fetchTask.mockResolvedValue(openTask());
+    const { reviewTask, proposedContent, loadReview, approveAfterSave } = useDocumentTaskReview();
+    await loadReview('t1');
+    await approveAfterSave();
+    expect(resolveTask).toHaveBeenCalledWith('t1', 'approved');
+    expect(reviewTask.value).toBeNull();
+    expect(proposedContent.value).toBeNull();
+  });
+
+  it('reject resolvet als rejected en reset de review-state', async () => {
+    fetchTask.mockResolvedValue(openTask());
+    const { reviewTask, proposedContent, loadReview, reject } = useDocumentTaskReview();
+    await loadReview('t1');
+    await reject();
+    expect(resolveTask).toHaveBeenCalledWith('t1', 'rejected');
+    expect(reviewTask.value).toBeNull();
+    expect(proposedContent.value).toBeNull();
+  });
+
+  it('approveAfterSave/reject zijn een no-op zonder actieve review', async () => {
+    const { approveAfterSave, reject } = useDocumentTaskReview();
+    await approveAfterSave();
+    await reject();
+    expect(resolveTask).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/composables/useTrajectDocuments.js
+++ b/frontend/src/composables/useTrajectDocuments.js
@@ -147,8 +147,14 @@ export function useTrajectDocuments(trajectRef) {
         // previous document's saved content (spurious dirty state).
         savedBody.value = '';
         currentEtag.value = null;
+        // Distinct kind from the generic 'load-error' below: a document-task
+        // review (useDocumentTaskReview) needs to tell "doesn't exist yet -
+        // seed the proposal as a new document" apart from a real fetch
+        // failure. DocumentEditor's blockingError check treats both the same
+        // (`kind !== 'draft-present'`), so this is not a behaviour change for
+        // the normal not-a-review flow.
         docError.value = {
-          kind: 'load-error',
+          kind: 'not-found',
           message: 'Document niet gevonden',
         };
         return;

--- a/frontend/src/composables/useTrajectDocuments.test.js
+++ b/frontend/src/composables/useTrajectDocuments.test.js
@@ -176,4 +176,40 @@ describe('useTrajectDocuments', () => {
     expect(docs.savedBody.value).toBe('# Server');
     expect(docs.docError.value).toBeNull();
   });
+
+  it('dropDraft clears an orphan draft for a document that does not exist on the server', async () => {
+    // Mirrors a rejected document-review proposal: the target document is
+    // never pushed (404), a proposal/edit gets typed into it and debounced
+    // to localStorage, and "Verwerpen" must not leave that draft behind -
+    // reopening the (still-nonexistent) document later would otherwise
+    // resurrect it as a 'draft-present' notice forever.
+    vi.useFakeTimers();
+    try {
+      const trajectRef = ref('mig-1a2b3c4d');
+      globalThis.fetch = vi.fn().mockImplementation(async (url) => {
+        if (url.endsWith('/documents')) return res({ json: { documents: [] } });
+        return res({ ok: false, status: 404 });
+      });
+
+      const docs = useTrajectDocuments(trajectRef);
+      await docs.openDocument('proposal.md');
+      expect(docs.docError.value?.kind).toBe('not-found');
+
+      docs.currentBody.value = '# Voorstel';
+      await vi.advanceTimersByTimeAsync(600);
+      expect(
+        localStorage.getItem('regelrecht-doc-draft:mig-1a2b3c4d:proposal.md'),
+      ).toBe('# Voorstel');
+
+      docs.dropDraft();
+
+      expect(
+        localStorage.getItem('regelrecht-doc-draft:mig-1a2b3c4d:proposal.md'),
+      ).toBeNull();
+      expect(docs.currentBody.value).toBe('');
+      expect(docs.docError.value).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/frontend/src/lib/taskReview.js
+++ b/frontend/src/lib/taskReview.js
@@ -1,21 +1,37 @@
 /**
  * reviewTarget - de router-target voor de "Beoordelen"-knop van een
- * job_review-taak: de traject-scoped editor-route voor de wet (zie
- * router.js, route `editor-traject`:
- * `editor/:trajectRef([a-z0-9-]+-[0-9a-f]{8})/:lawId?/:articleNumber?`),
- * met de taak-id als `?task=`-query zodat de editor de taak kan koppelen aan
- * het geopende artikel.
+ * job_review-taak. Vertakt op `payload.kind`:
+ *  - `kind === 'document'`: de werkdocumenten-route (router.js, route
+ *    `werkdocumenten-traject`: `trajecten/:trajectRef([a-z0-9-]+-[0-9a-f]{8})/
+ *    werkdocumenten/:docPath(.*)?`), met `docPath` op `payload.target_path` -
+ *    het werkdocument bestaat op de branch meestal nog niet, dus deze route
+ *    is ook de deep-link naar een nog-niet-bestaand document.
+ *  - anders (wet-review): de traject-scoped editor-route (route
+ *    `editor-traject`: `editor/:trajectRef([a-z0-9-]+-[0-9a-f]{8})/:lawId?/
+ *    :articleNumber?`), met `payload.law_id`.
+ * Beide dragen de taak-id als `?task=`-query zodat de bestemming de taak kan
+ * koppelen aan wat er geopend wordt.
  *
  * Puur en los van de router/sheet zodat de route-opbouw te testen is zonder
- * een component te mounten. Geeft `null` terug wanneer de taak geen
- * `traject_ref`/`law_id` in de payload heeft (bijv. een corrupte of
+ * een component te mounten. Geeft `null` terug wanneer de taak niet genoeg
+ * payload-velden heeft voor een van beide routes (bijv. een corrupte of
  * onvolledige taak) - de aanroeper toont dan geen/een disabled knop in
  * plaats van te crashen of naar een kapotte route te navigeren.
  */
 export function reviewTarget(task) {
   const trajectRef = task?.payload?.traject_ref;
+  if (!trajectRef) return null;
+  if (task?.payload?.kind === 'document') {
+    const targetPath = task.payload.target_path;
+    if (!targetPath) return null;
+    return {
+      name: 'werkdocumenten-traject',
+      params: { trajectRef, docPath: targetPath },
+      query: { task: task.id },
+    };
+  }
   const lawId = task?.payload?.law_id;
-  if (!trajectRef || !lawId) return null;
+  if (!lawId) return null;
   return {
     name: 'editor-traject',
     params: { trajectRef, lawId },

--- a/frontend/src/lib/taskReview.test.js
+++ b/frontend/src/lib/taskReview.test.js
@@ -31,6 +31,42 @@ describe('reviewTarget', () => {
   it('geeft null voor een taak zonder payload', () => {
     expect(reviewTarget({ id: 't4' })).toBeNull();
   });
+
+  it('bouwt de werkdocumenten-route met ?task= voor een document-review-taak', () => {
+    const task = {
+      id: 't5',
+      task_type: 'job_review',
+      payload: {
+        kind: 'document',
+        traject_ref: 'mijn-traject-1a2b3c4d',
+        target_path: 'bijv-rapport.md',
+      },
+    };
+    const target = reviewTarget(task);
+    expect(target).not.toBeNull();
+    const resolved = router.resolve(target);
+    expect(resolved.name).toBe('werkdocumenten-traject');
+    expect(resolved.params.trajectRef).toBe('mijn-traject-1a2b3c4d');
+    expect(resolved.params.docPath).toBe('bijv-rapport.md');
+    expect(resolved.fullPath).toBe(
+      '/trajecten/mijn-traject-1a2b3c4d/werkdocumenten/bijv-rapport.md?task=t5',
+    );
+  });
+
+  it('geeft null voor een document-review-taak zonder target_path', () => {
+    expect(
+      reviewTarget({
+        id: 't6',
+        payload: { kind: 'document', traject_ref: 'mijn-traject-1a2b3c4d' },
+      }),
+    ).toBeNull();
+  });
+
+  it('geeft null voor een document-review-taak zonder traject_ref', () => {
+    expect(
+      reviewTarget({ id: 't7', payload: { kind: 'document', target_path: 'bijv-rapport.md' } }),
+    ).toBeNull();
+  });
 });
 
 describe('proposalDivergence', () => {

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -2931,6 +2931,18 @@ pub async fn upload_traject_document(
                 upload_internal_error("list pending conversions for collision check", e)
             })?,
     );
+    // Also reserve the target paths of OPEN document-review tasks: a
+    // task-delivered conversion is already `completed` on the job (so it
+    // doesn't show up in `pending_target_paths` above) while the reviewer
+    // hasn't approved/rejected yet - the `.md` doesn't exist, but the name is
+    // still spoken for until the task resolves.
+    existing.extend(
+        regelrecht_pipeline::tasks::open_document_task_target_paths(pool, traject_id)
+            .await
+            .map_err(|e| {
+                upload_internal_error("list open document review tasks for collision check", e)
+            })?,
+    );
     let target_path = derive_markdown_target(&filename, &existing);
 
     // Persist the bytes and enqueue the conversion job in one transaction.

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -2866,18 +2866,33 @@ pub async fn upload_traject_document(
     // upload instead.
     let backend = resolve_traject_documents_writer(&traject).await?;
 
-    // Enforcement gate, on the writer resolved above (one lock, not two). The
-    // conversion runs in a background worker that can never carry the acting
-    // user's cookie-bound token, so its write would always fall back to the
-    // backend's configured token. With user-token enforcement on that is
-    // exactly the silent service-token fallback `require_user_token` forbids —
-    // refuse the upload fail-closed. Deliberately NOT a 428: linking GitHub
-    // would not change anything here, so the koppel-flow redirect would loop.
-    // Only for a backend that honors the override, though: a local writable-own
-    // (preview/local-stack) writes without any token, so there is no service-
-    // token fallback to forbid. The cheap backend check runs first; the flag
-    // read (a DB round-trip) only fires for GitHub-backed trajects.
-    if backend.supports_token_override() {
+    // Taak-flow-gate: met `tasks.job_review` AAN levert de conversie zijn
+    // resultaat als result-blob + review-taak terug (zie
+    // `finish_document_convert_task_job`) - de worker pusht dan niets meer,
+    // dus de enforcement-guard hieronder is niet meer van toepassing (het
+    // committen gebeurt pas bij goedkeuren, in de request-context van de
+    // gebruiker, met diens token wanneer enforcement aan staat). Deze
+    // flag-read is bewust onvoorwaardelijk (één extra DB-round-trip per
+    // upload, ook voor lokale backends): de afleverkeuze moet op
+    // enqueue-moment in de payload vastliggen, ongeacht het backend-type.
+    let task_delivery =
+        crate::feature_flags::flag_enabled(pool, crate::feature_flags::TASKS_JOB_REVIEW)
+            .await
+            .map_err(|e| upload_internal_error("read tasks.job_review flag", e))?;
+
+    // Enforcement gate, on the writer resolved above (one lock, not two). Only
+    // relevant with the taak-flow OFF: the conversion then runs in a background
+    // worker that can never carry the acting user's cookie-bound token, so its
+    // write would always fall back to the backend's configured token. With
+    // user-token enforcement on that is exactly the silent service-token
+    // fallback `require_user_token` forbids — refuse the upload fail-closed.
+    // Deliberately NOT a 428: linking GitHub would not change anything here, so
+    // the koppel-flow redirect would loop. Only for a backend that honors the
+    // override, though: a local writable-own (preview/local-stack) writes
+    // without any token, so there is no service-token fallback to forbid. The
+    // cheap checks run first; `write_requires_user_token`'s own flag read (a
+    // DB round-trip) only fires for GitHub-backed trajects in push-mode.
+    if !task_delivery && backend.supports_token_override() {
         if let Some(oauth) = state.config.github_oauth.as_ref() {
             if github_oauth::write_requires_user_token(&state, oauth).await? {
                 return Err((
@@ -2942,6 +2957,7 @@ pub async fn upload_traject_document(
         target_path: target_path.clone(),
         provider: None,
         requested_by: Some(account.id),
+        deliver: task_delivery.then(|| "task".to_string()),
     };
     let payload_json = serde_json::to_value(&payload)
         .map_err(|e| upload_internal_error("serialize payload", e))?;

--- a/packages/pipeline/src/document_convert.rs
+++ b/packages/pipeline/src/document_convert.rs
@@ -49,6 +49,18 @@ pub struct DocumentConvertPayload {
     /// `job_failed`-taak. `None` voor jobs van vóór dit veld.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub requested_by: Option<Uuid>,
+    /// `"task"` ⇒ resultaat als job_blobs + review-taak, géén push (taak-flow;
+    /// gezet door editor-api wanneer de tasks.job_review-flag aan staat bij
+    /// enqueue). Afwezig ⇒ oude gedrag: directe push naar de traject-branch.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deliver: Option<String>,
+}
+
+impl DocumentConvertPayload {
+    /// Taak-flow: resultaat naar Postgres + taak i.p.v. push naar git.
+    pub fn deliver_as_task(&self) -> bool {
+        self.deliver.as_deref() == Some("task")
+    }
 }
 
 /// An uploaded document loaded from `document_uploads`.
@@ -550,6 +562,7 @@ mod tests {
             target_path: "report.md".to_string(),
             provider: Some("claude".to_string()),
             requested_by: None,
+            deliver: None,
         };
         let json = serde_json::to_value(&payload).unwrap();
         assert_eq!(json["upload_id"], "00000000-0000-0000-0000-000000000000");
@@ -567,9 +580,41 @@ mod tests {
             target_path: "report.md".to_string(),
             provider: None,
             requested_by: None,
+            deliver: None,
         };
         let json = serde_json::to_value(&payload).unwrap();
         assert!(json.get("provider").is_none());
+    }
+
+    #[test]
+    fn payload_deliver_task_fields_roundtrip_and_backcompat() {
+        // Oude payloads (zonder deliver-veld) moeten blijven deserialiseren en
+        // vallen terug op het oude directe-push-gedrag.
+        let old = serde_json::json!({
+            "upload_id": Uuid::nil(),
+            "traject_id": Uuid::nil(),
+            "traject_ref": "abcd1234",
+            "target_path": "report.md",
+        });
+        let parsed: DocumentConvertPayload = serde_json::from_value(old).unwrap();
+        assert!(parsed.deliver.is_none());
+        assert!(!parsed.deliver_as_task());
+
+        // Nieuwe payloads dragen het deliver-veld mee.
+        let account = Uuid::new_v4();
+        let new = DocumentConvertPayload {
+            upload_id: Uuid::nil(),
+            traject_id: Uuid::nil(),
+            traject_ref: "abcd1234".to_string(),
+            target_path: "report.md".to_string(),
+            provider: None,
+            requested_by: Some(account),
+            deliver: Some("task".to_string()),
+        };
+        let roundtrip: DocumentConvertPayload =
+            serde_json::from_value(serde_json::to_value(&new).unwrap()).unwrap();
+        assert_eq!(roundtrip.requested_by, Some(account));
+        assert!(roundtrip.deliver_as_task());
     }
 
     #[test]

--- a/packages/pipeline/src/tasks.rs
+++ b/packages/pipeline/src/tasks.rs
@@ -202,6 +202,30 @@ pub async fn resolve_task(
     Ok(task)
 }
 
+/// Target paths reserved by OPEN document-review tasks of a traject: a
+/// task-delivered conversion is already `completed` on the underlying job
+/// (see `finish_document_convert_task_job`) while the review itself is still
+/// unresolved and the `.md` doesn't exist on the branch yet. The upload
+/// collision check (`pending_target_paths`, which only looks at
+/// pending/processing jobs) misses this window — a second upload with the
+/// same derived name would collide with a name that's really still "in use"
+/// by the open task. Approving/rejecting the task (or letting it lapse) frees
+/// the name again, since the task's status then stops matching `= 'open'`.
+pub async fn open_document_task_target_paths(
+    pool: &PgPool,
+    traject_id: Uuid,
+) -> Result<Vec<String>> {
+    let rows = sqlx::query_as::<_, (Option<String>,)>(
+        "SELECT payload->>'target_path' FROM tasks \
+         WHERE traject_id = $1 AND status = 'open' AND task_type = 'job_review' \
+           AND payload->>'kind' = 'document' AND payload->>'target_path' IS NOT NULL",
+    )
+    .bind(traject_id)
+    .fetch_all(pool)
+    .await?;
+    Ok(rows.into_iter().filter_map(|(p,)| p).collect())
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BlobKind {
     Input,

--- a/packages/pipeline/src/tasks.rs
+++ b/packages/pipeline/src/tasks.rs
@@ -12,7 +12,7 @@ use sqlx::PgPool;
 use uuid::Uuid;
 
 use crate::error::Result;
-use crate::models::JobStatus;
+use crate::models::{JobStatus, JobType};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
 #[sqlx(type_name = "task_status", rename_all = "lowercase")]
@@ -120,14 +120,20 @@ pub async fn count_open_tasks_for_account(pool: &PgPool, account_id: Uuid) -> Re
     Ok(count)
 }
 
-/// Eén lopende taak-flow-job voor de "Bezig"-sectie: een enrich-job die deze
-/// gebruiker via `deliver: "task"` heeft aangevraagd en die nog niet is
-/// afgerond (job_review/job_failed-taak bestaat pas na completion/failure).
+/// Eén lopende taak-flow-job voor de "Bezig"-sectie: een enrich- of
+/// document_convert-job die deze gebruiker via `deliver: "task"` heeft
+/// aangevraagd en die nog niet is afgerond (job_review/job_failed-taak
+/// bestaat pas na completion/failure).
 #[derive(Debug, Clone, sqlx::FromRow, Serialize)]
 pub struct RunningTaskJob {
     pub job_id: Uuid,
+    pub job_type: JobType,
     pub law_id: String,
     pub traject_ref: Option<String>,
+    /// Doelbestand van een document_convert-job (payload `target_path`);
+    /// None voor enrich-jobs. Het `law_id`-veld draagt voor conversies een
+    /// synthetische `doc:`-sleutel, dus de weergave leest dit veld.
+    pub target_path: Option<String>,
     pub status: JobStatus,
     pub created_at: DateTime<Utc>,
 }
@@ -141,9 +147,10 @@ pub async fn list_running_task_jobs_for_account(
     account_id: Uuid,
 ) -> Result<Vec<RunningTaskJob>> {
     let jobs = sqlx::query_as::<_, RunningTaskJob>(
-        "SELECT id AS job_id, law_id, traject_ref, status, created_at \
+        "SELECT id AS job_id, job_type, law_id, traject_ref, \
+                payload->>'target_path' AS target_path, status, created_at \
          FROM jobs \
-         WHERE job_type = 'enrich' \
+         WHERE job_type IN ('enrich', 'document_convert') \
            AND status IN ('pending', 'processing') \
            AND payload->>'deliver' = 'task' \
            AND payload->>'requested_by' = $1 \

--- a/packages/pipeline/src/worker.rs
+++ b/packages/pipeline/src/worker.rs
@@ -1273,6 +1273,20 @@ async fn process_next_document_convert_job(
         }
     };
 
+    // Taak-flow-gate, vóór de (kostbare) conversie: zonder `requested_by` is
+    // er geen zinvolle assignee voor de review-taak, dus zo'n job kan nooit
+    // afgeleverd worden. Terminaal falen zónder taak (mirrors the enrich
+    // gate in `process_next_enrich_job`) - de upload-bytes worden ook
+    // meteen opgeruimd, er is toch geen aflever-pad meer voor ze.
+    if payload.deliver_as_task() && payload.requested_by.is_none() {
+        let msg = "taak-flow-payload zonder requested_by".to_string();
+        tracing::error!(job_id = %job.id, error = %msg);
+        let _ = document_convert::delete_upload(pool, payload.upload_id).await;
+        job_queue::fail_job_terminal(pool, job.id, Some(serde_json::json!({ "error": msg })))
+            .await?;
+        return Ok(JobOutcome::Processed);
+    }
+
     // Apply the payload's provider override (if any) and bound the run by the
     // worker's job timeout, mirroring the enrich path.
     let mut job_config = match &payload.provider {
@@ -1281,8 +1295,17 @@ async fn process_next_document_convert_job(
     };
     job_config.timeout = job_timeout;
 
-    match run_document_convert(pool, &payload, &job_config).await {
-        Ok(()) => {
+    match run_document_convert(pool, &job, &payload, &job_config).await {
+        Ok(true) => {
+            // Taak-flow: `finish_document_convert_task_job` already inserted the
+            // result-blob, completed the job, and created the review-taak,
+            // atomically. Only the transient upload bytes remain to clean up.
+            if let Err(e) = document_convert::delete_upload(pool, payload.upload_id).await {
+                tracing::warn!(job_id = %job.id, error = %e, "failed to delete document upload after success");
+            }
+            Ok(JobOutcome::Processed)
+        }
+        Ok(false) => {
             // The markdown is already committed to git at this point. Drop the
             // transient upload bytes BEFORE propagating any complete_job error —
             // otherwise a failed status update would `?`-return past the cleanup
@@ -1382,17 +1405,26 @@ async fn process_next_document_convert_job(
     }
 }
 
-/// Convert the uploaded document to markdown and commit it to the traject.
+/// Convert the uploaded document to markdown and deliver it - either pushed
+/// straight to the traject (old behaviour), or as a result-blob + review-taak
+/// (taak-flow, `payload.deliver_as_task()`). Returns `true` when the taak-flow
+/// ran: `finish_document_convert_task_job` already completed the job as part
+/// of its own transaction, so the caller must NOT call `complete_job` again.
 async fn run_document_convert(
     pool: &PgPool,
+    job: &crate::models::Job,
     payload: &DocumentConvertPayload,
     config: &EnrichConfig,
-) -> Result<()> {
+) -> Result<bool> {
     let markdown =
         document_convert::execute_document_convert(pool, payload, config, &LlmDocumentConverter)
             .await?;
+    if payload.deliver_as_task() {
+        finish_document_convert_task_job(pool, job, payload, &markdown).await?;
+        return Ok(true);
+    }
     document_convert::write_markdown_to_traject(pool, payload, &markdown).await?;
-    Ok(())
+    Ok(false)
 }
 
 /// Taak-flow: materialiseer de input-blob(s) van een enrich-taak-job in een
@@ -1474,6 +1506,50 @@ pub async fn finish_enrich_task_job(
                 "traject_ref": payload.traject_ref,
                 "source_etag": payload.source_etag,
                 "provider": payload.provider,
+            })),
+        },
+    )
+    .await?;
+    tx.commit().await?;
+    Ok(())
+}
+
+/// Taak-flow succes voor document-convert: sla de gegenereerde markdown op
+/// als result-blob en maak de review-taak aan - atomair met complete_job.
+/// De worker pusht niets; goedkeuren gebeurt in de request-context van de
+/// gebruiker (met diens token wanneer enforcement aan staat).
+pub async fn finish_document_convert_task_job(
+    pool: &PgPool,
+    job: &crate::models::Job,
+    payload: &DocumentConvertPayload,
+    markdown: &str,
+) -> Result<()> {
+    let mut tx = pool.begin().await?;
+    // Hygiëne: er zijn geen input-blobs voor document-convert (de bytes
+    // leven in `document_uploads`), maar dit ruimt defensief een eventuele
+    // stale result-blob van een eerdere poging op.
+    crate::tasks::delete_blobs_for_job(&mut *tx, job.id).await?;
+    crate::tasks::insert_blob(
+        &mut *tx,
+        job.id,
+        crate::tasks::BlobKind::Result,
+        &payload.target_path,
+        markdown,
+    )
+    .await?;
+    job_queue::complete_job(&mut *tx, job.id, None).await?;
+    crate::tasks::create_task(
+        &mut *tx,
+        crate::tasks::NewTask {
+            task_type: crate::tasks::TaskType::JobReview,
+            assignee_account_id: payload.requested_by,
+            traject_id: Some(payload.traject_id),
+            job_id: Some(job.id),
+            title: format!("Werkdocument beoordelen: {}", payload.target_path),
+            payload: Some(serde_json::json!({
+                "kind": "document",
+                "traject_ref": payload.traject_ref,
+                "target_path": payload.target_path,
             })),
         },
     )

--- a/packages/pipeline/tests/tasks_tests.rs
+++ b/packages/pipeline/tests/tasks_tests.rs
@@ -607,6 +607,27 @@ async fn test_list_running_task_jobs_for_account() {
     .await
     .unwrap();
 
+    // Eigen document_convert-taak-flow-job: hoort ook in de "Bezig"-lijst,
+    // met target_path als weergave-handvat (law_id is een doc:-sleutel).
+    let own_doc_job = job_queue::create_job(
+        &db.pool,
+        CreateJobRequest::new(
+            JobType::DocumentConvert,
+            "doc:testtraject-abcd1234/analyses/rapport.md",
+        )
+        .with_traject_ref("testtraject-abcd1234")
+        .with_payload(json!({
+            "upload_id": uuid::Uuid::new_v4(),
+            "traject_id": traject_id,
+            "traject_ref": "testtraject-abcd1234",
+            "target_path": "analyses/rapport.md",
+            "requested_by": account_id,
+            "deliver": "task"
+        })),
+    )
+    .await
+    .unwrap();
+
     // Corpus-brede job (geen deliver/requested_by) voor dezelfde wet - hoort
     // niet in de taak-flow-lijst thuis, ongeacht account.
     job_queue::create_job(
@@ -635,20 +656,30 @@ async fn test_list_running_task_jobs_for_account() {
     let running = tasks::list_running_task_jobs_for_account(&db.pool, account_id)
         .await
         .unwrap();
-    assert_eq!(running.len(), 1);
-    assert_eq!(running[0].job_id, own_job.id);
-    assert_eq!(running[0].law_id, "test_wet");
+    assert_eq!(running.len(), 2);
+    // Nieuwste eerst: de document_convert-job is na de enrich-job aangemaakt.
+    assert_eq!(running[0].job_id, own_doc_job.id);
+    assert_eq!(running[0].job_type, JobType::DocumentConvert);
     assert_eq!(
-        running[0].traject_ref.as_deref(),
+        running[0].target_path.as_deref(),
+        Some("analyses/rapport.md")
+    );
+    assert_eq!(running[1].job_id, own_job.id);
+    assert_eq!(running[1].job_type, JobType::Enrich);
+    assert_eq!(running[1].law_id, "test_wet");
+    assert_eq!(running[1].target_path, None);
+    assert_eq!(
+        running[1].traject_ref.as_deref(),
         Some("testtraject-abcd1234")
     );
     assert_eq!(
-        running[0].status,
+        running[1].status,
         regelrecht_pipeline::models::JobStatus::Pending
     );
 
-    // Claim + complete de eigen job: eenmaal afgerond hoort hij niet meer in
-    // de "Bezig"-lijst (hij verschijnt dan als job_review-taak i.p.v.).
+    // Claim + complete de eigen enrich-job: eenmaal afgerond hoort hij niet
+    // meer in de "Bezig"-lijst (hij verschijnt dan als job_review-taak
+    // i.p.v.); de nog lopende document_convert-job blijft staan.
     let claimed = job_queue::claim_job(&db.pool, Some(JobType::Enrich))
         .await
         .unwrap()
@@ -661,7 +692,8 @@ async fn test_list_running_task_jobs_for_account() {
     let after = tasks::list_running_task_jobs_for_account(&db.pool, account_id)
         .await
         .unwrap();
-    assert!(after.is_empty());
+    assert_eq!(after.len(), 1);
+    assert_eq!(after[0].job_id, own_doc_job.id);
 }
 
 /// `include_failed` mirrors `!tasks.job_review`: flag ON (taken-mechanisme

--- a/packages/pipeline/tests/tasks_tests.rs
+++ b/packages/pipeline/tests/tasks_tests.rs
@@ -357,6 +357,86 @@ async fn test_finish_document_convert_task_job_creates_task_and_result_blob() {
 }
 
 #[tokio::test]
+async fn test_open_document_task_target_paths_reserves_names_until_resolved() {
+    let db = TestDb::new().await;
+    let (account_id, traject_id) = seed_account_and_traject(&db).await;
+    let (other_traject_id,): (uuid::Uuid,) = sqlx::query_as(
+        "INSERT INTO trajects (name, created_by) VALUES ('Ander traject', $1) RETURNING id",
+    )
+    .bind(account_id)
+    .fetch_one(&db.pool)
+    .await
+    .unwrap();
+
+    let payload = DocumentConvertPayload {
+        upload_id: uuid::Uuid::new_v4(),
+        traject_id,
+        traject_ref: "testtraject-abcd1234".to_string(),
+        target_path: "report.md".to_string(),
+        provider: None,
+        requested_by: Some(account_id),
+        deliver: Some("task".to_string()),
+    };
+    let _created = job_queue::create_job(
+        &db.pool,
+        CreateJobRequest::new(
+            JobType::DocumentConvert,
+            "doc:testtraject-abcd1234/report.md",
+        )
+        .with_traject_ref("testtraject-abcd1234")
+        .with_payload(serde_json::to_value(&payload).unwrap())
+        .with_max_attempts(1),
+    )
+    .await
+    .unwrap();
+    let job = job_queue::claim_job(&db.pool, Some(JobType::DocumentConvert))
+        .await
+        .unwrap()
+        .unwrap();
+
+    // Nog geen taak - lege reservering.
+    assert!(tasks::open_document_task_target_paths(&db.pool, traject_id)
+        .await
+        .unwrap()
+        .is_empty());
+
+    // Task-delivered conversie: de job is 'completed' (dus buiten
+    // `pending_target_paths`), maar de review is nog open - de naam moet nu
+    // gereserveerd zijn.
+    finish_document_convert_task_job(&db.pool, &job, &payload, "# Report\n\nBody.\n")
+        .await
+        .unwrap();
+
+    let reserved = tasks::open_document_task_target_paths(&db.pool, traject_id)
+        .await
+        .unwrap();
+    assert_eq!(reserved, vec!["report.md".to_string()]);
+
+    // Een ander traject ziet de reservering niet, ongeacht dezelfde naam.
+    assert!(
+        tasks::open_document_task_target_paths(&db.pool, other_traject_id)
+            .await
+            .unwrap()
+            .is_empty()
+    );
+
+    // Na goedkeuren (of afwijzen) van de review-taak vervalt de reservering.
+    let open = tasks::list_open_tasks_for_account(&db.pool, account_id)
+        .await
+        .unwrap();
+    assert_eq!(open.len(), 1);
+    tasks::resolve_task(&db.pool, open[0].id, account_id, TaskStatus::Approved)
+        .await
+        .unwrap()
+        .expect("assignee mag resolven");
+
+    assert!(tasks::open_document_task_target_paths(&db.pool, traject_id)
+        .await
+        .unwrap()
+        .is_empty());
+}
+
+#[tokio::test]
 async fn test_fail_enrich_task_job_creates_failed_task_and_cleans_input() {
     let db = TestDb::new().await;
     let (account_id, traject_id) = seed_account_and_traject(&db).await;

--- a/packages/pipeline/tests/tasks_tests.rs
+++ b/packages/pipeline/tests/tasks_tests.rs
@@ -1,11 +1,13 @@
 use serde_json::json;
 
+use regelrecht_pipeline::document_convert::DocumentConvertPayload;
 use regelrecht_pipeline::job_queue::{self, CreateJobRequest};
 use regelrecht_pipeline::models::JobType;
 use regelrecht_pipeline::tasks::{self, BlobKind, NewTask, TaskStatus, TaskType};
 use regelrecht_pipeline::test_utils::TestDb;
 use regelrecht_pipeline::worker::{
-    fail_enrich_task_job, fail_enrich_task_job_with_retry, finish_enrich_task_job,
+    fail_enrich_task_job, fail_enrich_task_job_with_retry, finish_document_convert_task_job,
+    finish_enrich_task_job,
 };
 
 /// Maak een account + traject om FK's te vullen. tasks.assignee_account_id
@@ -290,6 +292,68 @@ async fn test_finish_enrich_task_job_creates_task_and_result_blobs() {
     assert_eq!(open.len(), 1);
     assert_eq!(open[0].task_type, "job_review");
     assert_eq!(open[0].job_id, Some(job.id));
+}
+
+#[tokio::test]
+async fn test_finish_document_convert_task_job_creates_task_and_result_blob() {
+    let db = TestDb::new().await;
+    let (account_id, traject_id) = seed_account_and_traject(&db).await;
+    let payload = DocumentConvertPayload {
+        upload_id: uuid::Uuid::new_v4(),
+        traject_id,
+        traject_ref: "testtraject-abcd1234".to_string(),
+        target_path: "report.md".to_string(),
+        provider: None,
+        requested_by: Some(account_id),
+        deliver: Some("task".to_string()),
+    };
+    let _created = job_queue::create_job(
+        &db.pool,
+        CreateJobRequest::new(
+            JobType::DocumentConvert,
+            "doc:testtraject-abcd1234/report.md",
+        )
+        .with_traject_ref("testtraject-abcd1234")
+        .with_payload(serde_json::to_value(&payload).unwrap())
+        .with_max_attempts(1),
+    )
+    .await
+    .unwrap();
+    // Claim zodat complete_job ('processing' vereist) slaagt.
+    let job = job_queue::claim_job(&db.pool, Some(JobType::DocumentConvert))
+        .await
+        .unwrap()
+        .unwrap();
+
+    finish_document_convert_task_job(&db.pool, &job, &payload, "# Report\n\nBody.\n")
+        .await
+        .unwrap();
+
+    // Job completed, result-blob met target_path + markdown.
+    let done = job_queue::get_job(&db.pool, job.id).await.unwrap();
+    assert_eq!(
+        done.status,
+        regelrecht_pipeline::models::JobStatus::Completed
+    );
+    let results = tasks::load_blobs(&db.pool, job.id, BlobKind::Result)
+        .await
+        .unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].path, "report.md");
+    assert_eq!(results[0].content, "# Report\n\nBody.\n");
+
+    // job_review-taak met kind=document/traject_ref/target_path, juiste assignee.
+    let open = tasks::list_open_tasks_for_account(&db.pool, account_id)
+        .await
+        .unwrap();
+    assert_eq!(open.len(), 1);
+    assert_eq!(open[0].task_type, "job_review");
+    assert_eq!(open[0].job_id, Some(job.id));
+    assert_eq!(open[0].traject_id, Some(traject_id));
+    let task_payload = open[0].payload.as_ref().unwrap();
+    assert_eq!(task_payload["kind"], "document");
+    assert_eq!(task_payload["traject_ref"], "testtraject-abcd1234");
+    assert_eq!(task_payload["target_path"], "report.md");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Why

Follow-up #1 from #935. With user-token enforcement on, uploading a werkdocument was refused with a 403 ("the conversion writes in the background and cannot commit on your behalf") — the background push was the last place the tasks mechanism didn't cover. Conversions also required a per-traject `CORPUS_AUTH_*` push token even without enforcement.

## What

With feature flag `tasks.job_review` **on**:

- Uploading is always allowed (the 403 guard is skipped — nothing pushes in the background anymore). The delivery choice is frozen into the job payload at enqueue (`deliver: "task"`), like the enrich flow.
- The worker converts as before (pandoc/pdftotext, LLM fallback) but stores the markdown as a result blob and creates a `job_review` task (payload `kind: "document"`, `traject_ref`, `target_path`) atomically with `complete_job` — no push, no token needed. This removes the per-traject `CORPUS_AUTH_*` requirement for conversions entirely.
- "Beoordelen" opens the werkdocument with the proposed markdown as an unsaved change (blind create for not-yet-existing files; draft-seed with If-Match conflict handling for existing ones). **Opslaan saves via the normal documents PUT — in the user's request context, so with their linked GitHub token under enforcement — and resolves the task as approved.** Verwerpen resolves as rejected and restores server state (including dropping the proposal draft).
- Failed conversions already became dismissable tasks in #935; unchanged here.
- Running conversions now show in the "Bezig" section of the tasks sheet, next to running enrich requests: `list_running_task_jobs_for_account` covers `document_convert` task-flow jobs too, and the sheet labels them with the filename from `target_path` ("Conversie loopt - rapport.md").

With the flag **off**: byte-identical old behavior (403 guard + direct worker push with the per-source token).

Review hardening included: proposal drafts are dropped on reject, seed/approve validate path+traject, approve hook covers conflict-overwrite and rename saves, upload name reservation now also counts open document review tasks, and resolve errors are handled.

## Testing

- Pipeline: 12 integration tests (incl. new task-delivery and name-reservation tests, running-jobs test now also covers a document_convert job); editor-api suites green (now also in CI via #931); frontend 538 tests across 56 files, build clean; `just format/lint/build-check` clean.
- Preview smoke test to follow in this PR (upload under flag → task → beoordelen → opslaan → document committed as the user).

## Notes

- No new migrations; builds entirely on the #935 tables.
- The werkdocumenten list shows a spinner while converting; after task delivery the result appears in the tasks sheet rather than directly as an `.md`. The tasks sheet also lists the running conversion in its "Bezig" section, so the progress and the resulting task live in one place.
