### PR TITLE
fix(editor): add tasks.job_review toggle to feature flags menu

### DIFF
--- a/frontend/src/AppShell.vue
+++ b/frontend/src/AppShell.vue
@@ -110,12 +110,13 @@ const editorPanelFlags = [
 // effects: it shows the Koppel/Ontkoppel items below AND makes the backend
 // require the acting user's own GitHub token for traject writes (a save
 // without a linked token then 428s, which apiAuthGuard.js turns into a
-// redirect through the connect flow).
-const functieFlags = computed(() =>
-  githubStatus.value?.configured
-    ? [...editorPanelFlags, ['github.user_oauth', 'GitHub-koppeling']]
-    : editorPanelFlags,
-);
+// redirect through the connect flow). The Taken toggle gates the whole
+// taken-mechanisme (see the `showTasks` comment above).
+const functieFlags = computed(() => [
+  ...editorPanelFlags,
+  ...(githubStatus.value?.configured ? [['github.user_oauth', 'GitHub-koppeling']] : []),
+  ['tasks.job_review', 'Taken'],
+]);
 
 const route = useRoute();
 const router = useRouter();


### PR DESCRIPTION
## Why

PR #935 registered the `tasks.job_review` flag in both registries (frontend `useFeatureFlags.js` DEFAULTS and the backend `feature_flags.rs` allow-list), but never added it to the `functieFlags` list in `AppShell.vue` that renders the "Feature flags" menu. The flag therefore works via the API but has no toggle in the editor UI.

## What

Adds `['tasks.job_review', 'Taken']` to the `functieFlags` menu list. The list is restructured as a flat spread so the conditional GitHub-koppeling entry and the unconditional Taken entry compose cleanly.

## Testing

- Frontend vitest: 512/512 passed.
- Prose style check on `AppShell.vue`: clean.