### PR TITLE
fix(frontend): home tab re-stamps the active traject

### DIFF
--- a/frontend/src/AppShell.vue
+++ b/frontend/src/AppShell.vue
@@ -14,6 +14,7 @@ import {
   lastHomePath,
   lastEditorPath,
   sectionTarget,
+  homeTabTarget,
   isHomeSection,
   rememberHarvesterOrigin,
 } from './composables/useLastVisitedRoute.js';
@@ -114,11 +115,15 @@ const router = useRouter();
 // or a traject law). Kept named isLibraryRoute to limit this refactor's blast
 // radius.
 const isLibraryRoute = computed(() => isHomeSection(route.name));
-// Home tab restores the last home path verbatim (its own scope), like the
-// harvester return - so you continue exactly where you were. The Editor tab
-// keeps re-stamping the active traject (it carries the editor's traject logic:
-// chooser + law-as-query when no traject is active).
-const libraryTabTarget = computed(() => lastHomePath.value);
+// Home tab: the last home path with the active traject re-stamped onto it
+// (see homeTabTarget) - switching Home<->Editor keeps you in the traject
+// you're working in, instead of restoring a stale scope (e.g. Corpus juris
+// after opening a public deep-link). The Editor tab does the same via
+// sectionTarget, which additionally carries the editor's traject logic
+// (chooser + law-as-query when no traject is active).
+const libraryTabTarget = computed(() =>
+  homeTabTarget(router, lastHomePath.value, activeTrajectRef.value),
+);
 const editorTabTarget = computed(() =>
   sectionTarget(router, lastEditorPath.value, activeTrajectRef.value),
 );

--- a/frontend/src/composables/useLastVisitedRoute.js
+++ b/frontend/src/composables/useLastVisitedRoute.js
@@ -77,8 +77,8 @@ export function recordLastVisited(routeName, fullPath) {
 
 // The Home section's last-visited full path — the public landing, a public law,
 // the traject bibliotheek, werkdocumenten or instellingen — all under the 'home'
-// key. The Home tab restores this verbatim (like the harvester return) so
-// switching back to Home reopens exactly where you were, whatever its scope.
+// key. The Home tab restores this through homeTabTarget (below): verbatim when
+// the stored scope matches the active traject, re-stamped onto it otherwise.
 export const lastHomePath = computed(() => _lastVisited.value.home ?? '/');
 
 // `/editor` (no traject) is the read-only editor. The first visit

--- a/frontend/src/composables/useLastVisitedRoute.js
+++ b/frontend/src/composables/useLastVisitedRoute.js
@@ -162,11 +162,24 @@ export function sectionTarget(router, storedPath, activeRef) {
     return { name: 'taken-traject', params: { trajectRef: activeRef } };
   }
 
-  // Home section (corpus) — the active traject scope wins over whatever the
+  // Home section (corpus): the active traject scope wins over whatever the
   // stored path carried (re-stamped, or dropped when browsing without a traject).
   return homeTarget({
     trajectRef: activeRef || undefined,
     lawId: params.lawId,
     articleNumber: params.articleNumber,
   });
+}
+
+// Target for the Home tab: the last-visited Home path, with the ACTIVE
+// traject re-stamped onto it (via sectionTarget) so a Home<->Editor tab
+// switch keeps you in the traject you're working in instead of restoring a
+// stale scope (e.g. Corpus juris after opening a public deep-link). When the
+// stored path already carries the active scope it's returned verbatim, so
+// query/hash (the open werkdocument's `?task=`, the #yaml detail tab)
+// survive exactly like before.
+export function homeTabTarget(router, storedPath, activeRef) {
+  const storedRef = router.resolve(storedPath).params.trajectRef || null;
+  if (storedRef === (activeRef || null)) return storedPath;
+  return sectionTarget(router, storedPath, activeRef);
 }

--- a/frontend/src/composables/useLastVisitedRoute.js
+++ b/frontend/src/composables/useLastVisitedRoute.js
@@ -162,6 +162,18 @@ export function sectionTarget(router, storedPath, activeRef) {
     return { name: 'taken-traject', params: { trajectRef: activeRef } };
   }
 
+  // Instellingen sub-mode of Home: same preservation as werkdocumenten
+  // (re-stamp the active traject, keep the open tab). Without this branch the
+  // generic fallback below would silently collapse a stored instellingen path
+  // to the traject home on a scope mismatch.
+  const isInstellingen = name === 'instellingen-traject'
+    || (name == null && /\/instellingen($|[/?#])/.test(storedPath));
+  if (isInstellingen && activeRef) {
+    const target = { name: 'instellingen-traject', params: { trajectRef: activeRef } };
+    if (params.tab) target.params.tab = params.tab;
+    return target;
+  }
+
   // Home section (corpus): the active traject scope wins over whatever the
   // stored path carried (re-stamped, or dropped when browsing without a traject).
   return homeTarget({

--- a/frontend/src/router.test.js
+++ b/frontend/src/router.test.js
@@ -166,6 +166,25 @@ describe('sectionTarget - traject preserved across tab switches', () => {
     expect(t.name).toBe('home');
   });
 
+  it('re-stamps the active traject onto a stored instellingen path, keeping the tab', () => {
+    const t = sectionTarget(router, '/trajecten/old-deadbeef/instellingen/leden', REF);
+    expect(t.name).toBe('instellingen-traject');
+    expect(t.params.trajectRef).toBe(REF);
+    expect(t.params.tab).toBe('leden');
+  });
+
+  it('preserves the instellingen sub-mode without a tab', () => {
+    const t = sectionTarget(router, `/trajecten/${REF}/instellingen`, REF);
+    expect(t.name).toBe('instellingen-traject');
+    expect(t.params.trajectRef).toBe(REF);
+    expect(t.params.tab).toBeUndefined();
+  });
+
+  it('drops the instellingen sub-mode when no traject is active', () => {
+    const t = sectionTarget(router, `/trajecten/${REF}/instellingen/details`, null);
+    expect(t.name).toBe('home');
+  });
+
   it('sends the Editor tab to the chooser when no traject is active', () => {
     // The editor requires a traject: with none active, the stored editor
     // path collapses to the chooser and the law travels along as query.
@@ -221,5 +240,12 @@ describe('homeTabTarget - Home tab carries the active traject', () => {
     expect(t.name).toBe('corpus-juris');
     expect(t.params.trajectRef).toBeUndefined();
     expect(t.params.lawId).toBe('foo');
+  });
+
+  it('keeps the instellingen sub-mode when re-stamping onto another traject', () => {
+    const t = homeTabTarget(router, '/trajecten/old-deadbeef/instellingen/details', REF);
+    expect(t.name).toBe('instellingen-traject');
+    expect(t.params.trajectRef).toBe(REF);
+    expect(t.params.tab).toBe('details');
   });
 });

--- a/frontend/src/router.test.js
+++ b/frontend/src/router.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import router from './router.js';
-import { sectionTarget } from './composables/useLastVisitedRoute.js';
+import { sectionTarget, homeTabTarget } from './composables/useLastVisitedRoute.js';
 
 // A valid traject ref is `{slug}-{8hex}` (see the route regex). A plain
 // law `$id` uses underscores and must NOT match the traject route.
@@ -188,5 +188,38 @@ describe('sectionTarget - traject preserved across tab switches', () => {
     expect(sectionTarget(router, '/totally/unknown', null).name).toBe('home');
     // Section is derived from the path prefix so the right tab is kept.
     expect(sectionTarget(router, '/editor-bogus/x', null).name).toBe('editor');
+  });
+});
+
+describe('homeTabTarget - Home tab carries the active traject', () => {
+  it('restores the stored path verbatim when it already carries the active scope (hash intact)', () => {
+    const stored = `/trajecten/${REF}/corpus/foo/3#yaml`;
+    expect(homeTabTarget(router, stored, REF)).toBe(stored);
+  });
+
+  it('restores a public stored path verbatim when no traject is active', () => {
+    expect(homeTabTarget(router, '/corpus-juris/foo', null)).toBe('/corpus-juris/foo');
+  });
+
+  it('re-stamps the active traject onto a stored public law path', () => {
+    const t = homeTabTarget(router, '/corpus-juris/foo/3', REF);
+    expect(t.name).toBe('library-traject');
+    expect(t.params.trajectRef).toBe(REF);
+    expect(t.params.lawId).toBe('foo');
+    expect(t.params.articleNumber).toBe('3');
+  });
+
+  it('re-stamps the active traject over a stale stored traject', () => {
+    const t = homeTabTarget(router, '/trajecten/old-deadbeef/corpus/foo', REF);
+    expect(t.name).toBe('library-traject');
+    expect(t.params.trajectRef).toBe(REF);
+    expect(t.params.lawId).toBe('foo');
+  });
+
+  it('drops the stored traject when none is active', () => {
+    const t = homeTabTarget(router, `/trajecten/${REF}/corpus/foo`, null);
+    expect(t.name).toBe('corpus-juris');
+    expect(t.params.trajectRef).toBeUndefined();
+    expect(t.params.lawId).toBe('foo');
   });
 });


### PR DESCRIPTION
## What

The Home tab restored the last-visited Home path verbatim, so switching from a traject-scoped editor back to Home could land you in a stale scope - e.g. Corpus juris after opening a public deep-link - where the traject menu items (Instellingen / Werkdocumenten / Taken) don't exist.

The Home tab now re-stamps the **active** traject onto the stored path via a new `homeTabTarget` helper, mirroring what the Editor tab already does through `sectionTarget`:

- Editor in traject X → Home now lands in traject X's Home (same law preserved), not in whatever scope Home last had.
- When the stored path already carries the active scope it is still restored **verbatim**, so query/hash state (the open werkdocument's `?task=`, the `#yaml` detail tab) survives exactly like before.
- Werkdocumenten sub-mode keeps being preserved/re-stamped by the existing `sectionTarget` branches.

## Tests
- New `homeTabTarget` cases in `router.test.js` (verbatim same-scope incl. hash, re-stamp onto public path, re-stamp over stale traject, drop without traject).
- Full frontend vitest suite green (545 tests).

Follow-up from #939 (independent; no code dependency).

## Smoketest (pr940 preview)

Opened the public `/corpus-juris/wet_op_de_zorgtoeslag` deep-link (Home records it), switched to the editor in the "zorgtoeslag private repo" traject, then clicked the Home tab. It now lands on `/trajecten/{ref}/corpus/wet_op_de_zorgtoeslag` - traject scope with its sidebar menu, same law still open - instead of the traject-less Corpus juris page:

![Home tab lands in the active traject](https://files.catbox.moe/71ktq3.png)
