### PR TITLE
feat(editor): add a law or regulation from an uploaded document in a traject

### DIFF
--- a/frontend/src/EditorView.vue
+++ b/frontend/src/EditorView.vue
@@ -197,6 +197,8 @@ const {
   saving: lawSaving,
   saveError: lawSaveError,
   saveLaw,
+  seedFromYaml,
+  createLaw,
   currentEtag,
   lastSavedPr,
 } = useLaw(route.params.lawId, route.params.articleNumber, route.params.trajectRef);
@@ -1370,6 +1372,12 @@ const {
   reject: rejectReviewInternal,
 } = useTaskReview();
 const reviewActive = computed(() => !!reviewTask.value);
+// `law_create`-taak: de wet bestaat nog niet in het traject; het voorstel
+// wordt integraal in de editor geseed en Opslaan gaat via het create-pad
+// (POST) in plaats van de PUT.
+const reviewIsLawCreate = computed(
+  () => reviewTask.value?.payload?.kind === 'law_create',
+);
 const reviewTaskIdParam = computed(() =>
   typeof route.query.task === 'string' ? route.query.task : null,
 );
@@ -1444,12 +1452,19 @@ function applyProposedContent(proposedYaml) {
 const REVIEW_HIDDEN_CHANGES_NOTE = 'Zie ook het YAML-paneel voor wijzigingen buiten dit artikel.';
 const reviewBannerVariant = computed(() => {
   if (reviewLoadError.value) return 'critical';
+  if (reviewIsLawCreate.value) return 'neutral';
   if (reviewStale.value) return 'warning';
   if (reviewActive.value && !reviewSeeded.value) return 'warning';
   return 'neutral';
 });
+const reviewBannerText = computed(() =>
+  reviewIsLawCreate.value ? 'Nieuwe wet uit documentconversie' : 'Voorstel uit verrijking',
+);
 const reviewBannerSupportingText = computed(() => {
   if (reviewLoadError.value) return reviewLoadError.value;
+  if (reviewIsLawCreate.value) {
+    return 'Controleer de wet; Opslaan voegt de wet toe aan het traject, Verwerpen wijst af.';
+  }
   if (!reviewSeeded.value) {
     return 'Voorstel raakt alleen inhoud die hier niet zichtbaar is - bekijk het YAML-paneel.';
   }
@@ -1486,11 +1501,49 @@ watch(
   { immediate: true },
 );
 
+// `law_create`-variant van de watch hierboven: de wet bestaat nog niet, dus
+// de load eindigt in een 404 en `selectedArticle` komt er nooit - de normale
+// watch kan niet vuren. Bij een 404 mét ?task= halen we de taak alsnog op;
+// is het een law_create-taak voor precies deze wet, dan wordt het voorstel
+// integraal geseed (`seedFromYaml`) in plaats van gespliced - de hele wet ÍS
+// het voorstel. Elke andere combinatie laat de bestaande 404-foutstaat staan.
+watch(
+  [error, reviewTaskIdParam],
+  ([err, taskId]) => {
+    if (!taskId || err?.status !== 404) return;
+    if (reviewAttemptedForTaskId === taskId) return;
+    reviewAttemptedForTaskId = taskId;
+    loadReview(taskId, null).then(() => {
+      const task = reviewTask.value;
+      if (
+        task?.payload?.kind === 'law_create' &&
+        task?.payload?.law_id === lawId.value &&
+        reviewProposedContent.value
+      ) {
+        seedFromYaml(reviewProposedContent.value);
+        // Niets is als dirty edit geseed: de banner levert de primaire
+        // opslaan-knop (zie `reviewSeeded` in de template), niet de
+        // Wijzigingenbalk.
+        reviewSeeded.value = false;
+        reviewHasHiddenChanges.value = false;
+      }
+    });
+  },
+  { immediate: true },
+);
+
 // "Verwerpen" in the review banner: resolve the task as rejected, throw
 // away the seeded edit (same discard the Wijzigingenbalk offers), and
 // leave review mode.
 async function rejectReview() {
+  const wasLawCreate = reviewIsLawCreate.value;
   await rejectReviewInternal();
+  if (wasLawCreate) {
+    // De wet bestaat niet (en komt er na verwerpen ook niet): terugroutes
+    // naar de wetsroute zouden op een 404 landen, dus terug naar Home.
+    router.replace(libraryTabTarget.value);
+    return;
+  }
   discardArticle();
   clearReviewQuery();
 }
@@ -1560,7 +1613,14 @@ async function handleLawSave() {
   lastSaveTouchedText.value = reviewActive.value ? true : isArticleTextDirty.value;
   lastSaveTouchedMachine.value = reviewActive.value ? true : isMachineReadableDirty.value;
   try {
-    await saveLaw(lawYaml);
+    // law_create: de wet bestaat nog niet in het traject, dus het voorstel
+    // gaat door het create-pad (POST, pad server-side afgeleid) - daarna
+    // bestaat de wet en nemen vervolg-saves de normale PUT.
+    if (reviewActive.value && reviewIsLawCreate.value) {
+      await createLaw(lawYaml);
+    } else {
+      await saveLaw(lawYaml);
+    }
     if (lawId.value !== savedLawId) return; // law switched mid-PUT
     // points at the re-parsed article. The `watch(selectedArticle)` above
     // fires on the next microtask - leaving a window where the dirty
@@ -2069,7 +2129,7 @@ async function handleActionSave() {
                nldd-button-group), so it carries "Verwerpen"/"Voorstel
                opslaan en goedkeuren" without any custom CSS. -->
           <nldd-container v-if="reviewActive || reviewLoadError" padding="8">
-            <nldd-banner :variant="reviewBannerVariant" text="Voorstel uit verrijking" :supporting-text="reviewBannerSupportingText">
+            <nldd-banner :variant="reviewBannerVariant" :text="reviewBannerText" :supporting-text="reviewBannerSupportingText">
               <!-- Wijzigingenbalk only appears when a pane is dirty, which
                    `!reviewSeeded` never is (nothing was seeded into the
                    panes) - give the banner its own primary action so

--- a/frontend/src/LibraryView.conversionJobs.test.js
+++ b/frontend/src/LibraryView.conversionJobs.test.js
@@ -89,12 +89,15 @@ vi.mock('./composables/useTrajectDocumentJobs.js', () => ({
   }),
 }));
 
-// Capture the onUploaded callback LibraryView hands in, so a test can fire it
-// with an upload result the way a real successful upload would.
-let onUploaded = null;
+// Capture the onUploaded callbacks LibraryView hands in, so a test can fire
+// one with an upload result the way a real successful upload would.
+// LibraryView wires useDocumentUpload twice (werkdocument-upload eerst, dan
+// de wet-upload), dus per aanroep vastleggen; `onUploaded` = de werkdoc-cb.
+let onUploadedCbs = [];
+const onUploaded = (...args) => onUploadedCbs[0]?.(...args);
 vi.mock('./composables/useDocumentUpload.js', () => ({
   useDocumentUpload: (_uploadFn, uploadedCb) => {
-    onUploaded = uploadedCb;
+    onUploadedCbs.push(uploadedCb);
     return {
       fileInput: ref(null),
       uploadError: ref(null),
@@ -143,6 +146,7 @@ async function jobLeavesList() {
 }
 
 beforeEach(() => {
+  onUploadedCbs = [];
   documents.value = [];
   jobs.value = [];
   openDoc.mockReset().mockResolvedValue(undefined);

--- a/frontend/src/LibraryView.vue
+++ b/frontend/src/LibraryView.vue
@@ -16,7 +16,7 @@ import TasksSidebarItem from './components/TasksSidebarItem.vue';
 import { useAuth } from './composables/useAuth.js';
 import { lawFetchInit } from './composables/useLaw.js';
 import { useTrajects, refreshTrajects } from './composables/useTrajects.js';
-import { lawsListUrl, lawUrl, changedLawsUrl } from './composables/corpusUrls.js';
+import { lawsListUrl, lawUrl, lawUploadUrl, changedLawsUrl } from './composables/corpusUrls.js';
 import { SUPPORT_EMAIL, paneChromeVisible } from './constants.js';
 import { registerSearchPopover, setLibraryEmpty } from './composables/useAppChrome.js';
 import { homeTarget } from './composables/useLastVisitedRoute.js';
@@ -215,6 +215,68 @@ function dismissJobCancelError() {
 function retryUpload() {
   docUploadError.value = null;
   nextTick(() => onDocUpload());
+}
+
+// --- Wet of regel toevoegen uit een geüpload document ----------------------
+// De "+" onder de wettenlijst (alleen in een traject): upload een PDF/Word-
+// document dat de backend omzet naar een basis-wet en automatisch verrijkt;
+// het resultaat komt terug als law_create-taak in het Taken-paneel. Zelfde
+// resultaat-object-stijl als `uploadDocument` (useTrajectDocuments) zodat
+// `useDocumentUpload` de foutafhandeling kan hergebruiken.
+async function uploadLawDocument(file) {
+  if (!activeTrajectRef.value) {
+    return { ok: false, error: 'Geen actief traject.', retryable: false };
+  }
+  const form = new FormData();
+  form.append('file', file);
+  try {
+    // Raw fetch: geen Content-Type zetten, de browser bepaalt de
+    // multipart-boundary zelf (zelfde afweging als uploadDocument).
+    const res = await fetch(lawUploadUrl(activeTrajectRef.value), {
+      method: 'POST',
+      body: form,
+    });
+    if (!res.ok) {
+      const unsupported = res.status === 404 || res.status === 405 || res.status === 501;
+      let text = '';
+      try { text = await res.text(); } catch { /* generieke melding hieronder */ }
+      const error = unsupported
+        ? 'Uploaden wordt door de server nog niet ondersteund.'
+        : (text || `Uploaden mislukt (foutcode ${res.status}).`);
+      return { ok: false, error, retryable: !unsupported };
+    }
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, error: e.message, retryable: true };
+  }
+}
+const lawUploadStarted = ref(false);
+function dismissLawUploadStarted() {
+  lawUploadStarted.value = false;
+}
+const {
+  fileInput: lawFileInput,
+  uploadError: lawUploadError,
+  uploadRetryable: lawUploadRetryable,
+  onUpload: onLawUpload,
+  onFileChange: onLawFileChange,
+} = useDocumentUpload(uploadLawDocument, () => {
+  lawUploadStarted.value = true;
+});
+// Zelfde modal-behandeling als de werkdocument-upload, met een eigen modal
+// zodat de retry-actie de juiste picker heropent.
+const lawUploadErrorModalEl = ref(null);
+watch(lawUploadError, async (err) => {
+  await nextTick();
+  if (err) lawUploadErrorModalEl.value?.show?.();
+  else lawUploadErrorModalEl.value?.hide?.();
+});
+function dismissLawUploadError() {
+  lawUploadError.value = null;
+}
+function retryLawUpload() {
+  lawUploadError.value = null;
+  nextTick(() => onLawUpload());
 }
 
 // Name the open document in the unsaved-changes guard so it's clear what's at
@@ -1408,6 +1470,38 @@ watch(activeTrajectRef, () => {
                       </nldd-list-item>
                     </nldd-list>
                   </template>
+                  <!-- Wet of regel toevoegen uit een geüpload document (alleen
+                       in een traject): start de conversie-naar-wet-keten; de
+                       voortgang en het resultaat verschijnen in het
+                       Taken-paneel. Zelfde toolbar/icon-button-patroon als de
+                       werkdocument-upload; één actie, dus direct een klik in
+                       plaats van een menu. -->
+                  <template v-if="activeTrajectRef">
+                    <nldd-spacer size="24"></nldd-spacer>
+                    <nldd-toolbar label="Wetacties">
+                      <nldd-toolbar-item slot="start">
+                        <nldd-icon-button
+                          id="law-upload-btn"
+                          icon="plus-small"
+                          text="Wet of regel toevoegen uit document"
+                          expandable
+                          tooltip-timing="never"
+                          @click="onLawUpload"
+                        ></nldd-icon-button>
+                      </nldd-toolbar-item>
+                    </nldd-toolbar>
+                    <input ref="lawFileInput" type="file" accept=".pdf,.doc,.docx" hidden @change="onLawFileChange" />
+                    <template v-if="lawUploadStarted">
+                      <nldd-spacer size="8"></nldd-spacer>
+                      <nldd-banner
+                        variant="success"
+                        text="Conversie gestart"
+                        supporting-text="Je krijgt een taak zodra de wet klaarstaat voor beoordeling."
+                        dismissible
+                        @dismiss="dismissLawUploadStarted"
+                      ></nldd-banner>
+                    </template>
+                  </template>
                 </template>
               </nldd-simple-section>
             </nldd-page>
@@ -1763,6 +1857,19 @@ watch(activeTrajectRef, () => {
     >
       <nldd-button slot="actions" variant="primary" text="Sluit" @click="dismissUploadError"></nldd-button>
       <nldd-button v-if="docUploadRetryable" slot="actions" variant="secondary" text="Probeer opnieuw" @click="retryUpload"></nldd-button>
+    </nldd-modal-dialog>
+  </Teleport>
+
+  <Teleport to="body">
+    <nldd-modal-dialog
+      ref="lawUploadErrorModalEl"
+      variant="alert"
+      text="Uploaden mislukt"
+      :supporting-text="lawUploadError || ''"
+      @close="dismissLawUploadError"
+    >
+      <nldd-button slot="actions" variant="primary" text="Sluit" @click="dismissLawUploadError"></nldd-button>
+      <nldd-button v-if="lawUploadRetryable" slot="actions" variant="secondary" text="Probeer opnieuw" @click="retryLawUpload"></nldd-button>
     </nldd-modal-dialog>
   </Teleport>
 

--- a/frontend/src/LibraryView.vue
+++ b/frontend/src/LibraryView.vue
@@ -26,6 +26,7 @@ import { useDocumentUpload } from './composables/useDocumentUpload.js';
 import { useDocumentTaskReview } from './composables/useDocumentTaskReview.js';
 import { humanizeLawId } from './lib/lawName.js';
 import { apiFetch, apiFetchJson, ApiError } from './lib/apiFetch.js';
+import { uploadMultipart } from './lib/uploadMultipart.js';
 import { useLatest } from './lib/useLatest.js';
 import { holdRetryFloor, RETRY_MIN_SPINNER_MS } from './lib/retryFeedback.js';
 
@@ -220,35 +221,14 @@ function retryUpload() {
 // --- Wet of regel toevoegen uit een geüpload document ----------------------
 // De "+" onder de wettenlijst (alleen in een traject): upload een PDF/Word-
 // document dat de backend omzet naar een basis-wet en automatisch verrijkt;
-// het resultaat komt terug als law_create-taak in het Taken-paneel. Zelfde
-// resultaat-object-stijl als `uploadDocument` (useTrajectDocuments) zodat
-// `useDocumentUpload` de foutafhandeling kan hergebruiken.
+// het resultaat komt terug als law_create-taak in het Taken-paneel. De
+// multipart-POST en foutclassificatie delen we met de werkdocument-upload
+// via `uploadMultipart`.
 async function uploadLawDocument(file) {
   if (!activeTrajectRef.value) {
     return { ok: false, error: 'Geen actief traject.', retryable: false };
   }
-  const form = new FormData();
-  form.append('file', file);
-  try {
-    // Raw fetch: geen Content-Type zetten, de browser bepaalt de
-    // multipart-boundary zelf (zelfde afweging als uploadDocument).
-    const res = await fetch(lawUploadUrl(activeTrajectRef.value), {
-      method: 'POST',
-      body: form,
-    });
-    if (!res.ok) {
-      const unsupported = res.status === 404 || res.status === 405 || res.status === 501;
-      let text = '';
-      try { text = await res.text(); } catch { /* generieke melding hieronder */ }
-      const error = unsupported
-        ? 'Uploaden wordt door de server nog niet ondersteund.'
-        : (text || `Uploaden mislukt (foutcode ${res.status}).`);
-      return { ok: false, error, retryable: !unsupported };
-    }
-    return { ok: true };
-  } catch (e) {
-    return { ok: false, error: e.message, retryable: true };
-  }
+  return uploadMultipart(lawUploadUrl(activeTrajectRef.value), file);
 }
 const lawUploadStarted = ref(false);
 function dismissLawUploadStarted() {

--- a/frontend/src/LibraryView.vue
+++ b/frontend/src/LibraryView.vue
@@ -1460,12 +1460,13 @@ watch(activeTrajectRef, () => {
                     <nldd-spacer size="24"></nldd-spacer>
                     <nldd-toolbar label="Wetacties">
                       <nldd-toolbar-item slot="start">
+                        <!-- Géén `expandable`: dat is de disclosure-chevron
+                             voor menu/popover-knoppen; dit is een directe
+                             actie. De tekst verschijnt als tooltip. -->
                         <nldd-icon-button
                           id="law-upload-btn"
                           icon="plus-small"
                           text="Wet of regel toevoegen uit document"
-                          expandable
-                          tooltip-timing="never"
                           @click="onLawUpload"
                         ></nldd-icon-button>
                       </nldd-toolbar-item>

--- a/frontend/src/components/TasksPane.vue
+++ b/frontend/src/components/TasksPane.vue
@@ -37,6 +37,12 @@ function runningText(job) {
     const name = job.target_path?.split('/').pop() || 'werkdocument';
     return `Conversie loopt - ${name}`;
   }
+  if (job.job_type === 'law_convert') {
+    // target_path draagt voor law_convert de geüploade bestandsnaam
+    // (COALESCE in list_running_task_jobs_for_account).
+    const name = job.target_path?.split('/').pop() || 'document';
+    return `Wet maken loopt - ${name}`;
+  }
   return `Verrijking loopt - ${job.law_id}`;
 }
 

--- a/frontend/src/composables/corpusUrls.js
+++ b/frontend/src/composables/corpusUrls.js
@@ -95,6 +95,22 @@ export function documentUploadUrl(trajectRef) {
   return `${corpusBase(trajectRef)}/documents/upload`;
 }
 
+// Upload a source document that becomes a NEW law in the traject: the
+// backend converts it to a base-law YAML (law_convert job), chains an
+// enrichment, and delivers the result as a `law_create` review task.
+export function lawUploadUrl(trajectRef) {
+  requireTraject(trajectRef, 'law upload');
+  return `${corpusBase(trajectRef)}/laws/upload`;
+}
+
+// Create a NEW law in the traject (the approve-step of a `law_create`
+// review task). POST body = the full law YAML; the corpus path is
+// derived server-side from the validated body.
+export function lawCreateUrl(trajectRef) {
+  requireTraject(trajectRef, 'law create');
+  return `${corpusBase(trajectRef)}/laws`;
+}
+
 // Running/failed document-conversion jobs for the traject, backing the
 // werkdocumenten conversion-status block.
 export function documentJobsUrl(trajectRef) {

--- a/frontend/src/composables/useLaw.js
+++ b/frontend/src/composables/useLaw.js
@@ -1,7 +1,7 @@
 import { computed, ref, shallowRef } from 'vue';
 import * as yaml from 'js-yaml';
 import { lastSavedPr, sanitizeSavedPr } from './useSavedPr.js';
-import { lawUrl } from './corpusUrls.js';
+import { lawCreateUrl, lawUrl } from './corpusUrls.js';
 import { apiFetch } from '../lib/apiFetch.js';
 import { createLruMap } from '../lib/lruMap.js';
 import { useLatest } from '../lib/useLatest.js';
@@ -370,6 +370,85 @@ export function useLaw(lawParam, articleParam, trajectRefParam) {
     }
   }
 
+  /**
+   * Seed the editor state from raw YAML without any network fetch. Used by
+   * the `law_create`-review flow: the law does not exist in the traject yet
+   * (the normal `load()` 404'ed), so the task's proposed YAML IS the content
+   * to show. Clears the load error and settles `loading` so the editor
+   * renders the proposal like a normally loaded law.
+   */
+  function seedFromYaml(yamlText) {
+    let parsed;
+    try {
+      parsed = yaml.load(yamlText);
+    } catch {
+      return false; // malformed proposal - keep the current (error) state
+    }
+    law.value = parsed;
+    rawYaml.value = yamlText;
+    currentEtag.value = null;
+    error.value = null;
+    loading.value = false;
+    if (articles.value.length > 0) {
+      selectedArticleNumber.value = String(articles.value[0].number);
+    }
+    return true;
+  }
+
+  /**
+   * Create a NEW law in the active traject via POST (the approve-step of a
+   * `law_create` review task). Same body/etag/PR plumbing as `saveLaw`, but
+   * without `If-Match` (there is nothing to be concurrent with yet); the
+   * backend derives the corpus path from the validated YAML. After a
+   * successful create the law exists in the traject, so follow-up saves go
+   * through the normal `saveLaw` PUT.
+   */
+  async function createLaw(yamlText) {
+    if (!currentTrajectRef) {
+      throw new Error('Cannot create law: no active traject');
+    }
+    const savedTrajectRef = currentTrajectRef;
+    saving.value = true;
+    saveError.value = null;
+    try {
+      const res = await apiFetch(lawCreateUrl(savedTrajectRef), {
+        method: 'POST',
+        headers: { 'Content-Type': 'text/yaml; charset=utf-8' },
+        body: yamlText,
+        // Same proxy-guard as saveLaw: only surface text/plain bodies (the
+        // editor-api's own 400/409 messages), fall back generic otherwise.
+        errorMessage: (status, body, contentType) =>
+          contentType.startsWith('text/plain') && body
+            ? body
+            : `Save failed: ${status}`,
+      });
+      let json = null;
+      try {
+        json = await res.json();
+        lastSavedPr.value = sanitizeSavedPr(json?.pr);
+      } catch {
+        // Bare 200 without JSON - treat as successful.
+      }
+      const newEtag = res.headers.get('ETag') ?? json?.etag ?? null;
+      const parsed = yaml.load(yamlText);
+      rawYaml.value = yamlText;
+      law.value = parsed;
+      currentEtag.value = newEtag;
+      const resolvedId = parsed?.$id;
+      if (resolvedId) {
+        lawCache.set(
+          lawCacheKey(savedTrajectRef, resolvedId),
+          makeEntry(parsed, yamlText, newEtag)
+        );
+      }
+    } catch (e) {
+      saveError.value = e;
+      throw e;
+    } finally {
+      saving.value = false;
+    }
+  }
+
   return {
     law,
     lawId,
@@ -384,6 +463,8 @@ export function useLaw(lawParam, articleParam, trajectRefParam) {
     saving,
     saveError,
     saveLaw,
+    seedFromYaml,
+    createLaw,
     currentEtag,
     lastSavedPr,
   };

--- a/frontend/src/composables/useLaw.test.js
+++ b/frontend/src/composables/useLaw.test.js
@@ -278,3 +278,73 @@ describe('useLaw fetch dedup (single-flight)', () => {
     expect(callCount).toBe(2);
   });
 });
+
+describe('useLaw law_create-flow (seedFromYaml + createLaw)', () => {
+  it('seedFromYaml vult de editorstate zonder netwerk en wist de load-fout', async () => {
+    // De load 404't (de wet bestaat nog niet in het traject).
+    globalThis.fetch = vi.fn().mockImplementation(async () =>
+      res({ ok: false, status: 404, body: 'Law not found' }),
+    );
+    const law = useLaw('nieuwe_wet', null, 'tr-12345678');
+    await waitForLoaded(law);
+    expect(law.error.value).toBeTruthy();
+
+    const seeded = law.seedFromYaml(
+      '$id: nieuwe_wet\narticles:\n  - number: "1"\n    text: t\n',
+    );
+    expect(seeded).toBe(true);
+    expect(law.error.value).toBeNull();
+    expect(law.law.value.$id).toBe('nieuwe_wet');
+    expect(law.selectedArticleNumber.value).toBe('1');
+    expect(law.currentEtag.value).toBeNull();
+  });
+
+  it('seedFromYaml laat de foutstaat staan bij kapotte YAML', async () => {
+    globalThis.fetch = vi.fn().mockImplementation(async () =>
+      res({ ok: false, status: 404, body: 'Law not found' }),
+    );
+    const law = useLaw('nieuwe_wet2', null, 'tr-12345678');
+    await waitForLoaded(law);
+    expect(law.seedFromYaml('niet: [valide yaml')).toBe(false);
+    expect(law.error.value).toBeTruthy();
+  });
+
+  it('createLaw POST naar het create-endpoint en ketent de ETag voor vervolg-saves', async () => {
+    const calls = [];
+    globalThis.fetch = vi.fn().mockImplementation(async (url, opts) => {
+      calls.push({ url, opts: opts ?? {} });
+      if (opts?.method === 'POST') {
+        return res({ etag: '"created"', json: { pr: null, etag: '"created"' } });
+      }
+      return res({ ok: false, status: 404, body: 'Law not found' });
+    });
+    const law = useLaw('nieuwe_wet3', null, 'tr-12345678');
+    await waitForLoaded(law);
+    law.seedFromYaml('$id: nieuwe_wet3\narticles:\n  - number: "1"\n    text: t\n');
+
+    await law.createLaw('$id: nieuwe_wet3\narticles:\n  - number: "1"\n    text: t\n');
+
+    const post = calls.find((c) => c.opts?.method === 'POST');
+    expect(post).toBeTruthy();
+    expect(post.url).toBe('/api/trajects/tr-12345678/corpus/laws');
+    // Geen If-Match op een create: er is nog niets om mee te racen.
+    expect(post.opts.headers['If-Match']).toBeUndefined();
+    expect(law.currentEtag.value).toBe('"created"');
+    expect(law.lawId.value).toBe('nieuwe_wet3');
+  });
+
+  it('createLaw geeft de servermelding door (bijv. een 409-slugconflict)', async () => {
+    globalThis.fetch = vi.fn().mockImplementation(async (url, opts) => {
+      if (opts?.method === 'POST') {
+        return res({ ok: false, status: 409, body: 'Er bestaat al een wet met dit $id in dit traject; pas het $id in de YAML aan.' });
+      }
+      return res({ ok: false, status: 404, body: 'Law not found' });
+    });
+    const law = useLaw('nieuwe_wet4', null, 'tr-12345678');
+    await waitForLoaded(law);
+    await expect(law.createLaw('$id: nieuwe_wet4\narticles: []\n')).rejects.toThrow(
+      /bestaat al een wet/i,
+    );
+    expect(law.saveError.value).toBeTruthy();
+  });
+});

--- a/frontend/src/composables/useTrajectDocuments.js
+++ b/frontend/src/composables/useTrajectDocuments.js
@@ -21,6 +21,7 @@ import {
   requireTraject,
 } from './corpusUrls.js';
 import { apiFetchJson } from '../lib/apiFetch.js';
+import { uploadMultipart } from '../lib/uploadMultipart.js';
 import { useLatest } from '../lib/useLatest.js';
 
 const STORAGE_PREFIX = 'regelrecht-doc-draft:';
@@ -395,36 +396,14 @@ export function useTrajectDocuments(trajectRef) {
   async function uploadDocument(file) {
     requireTraject(trajectRef.value, 'document upload');
     saveError.value = null;
-    const form = new FormData();
-    form.append('file', file);
-    try {
-      // Raw fetch, result-object style like `saveCurrent`. Do NOT set
-      // Content-Type - the browser adds the multipart boundary itself.
-      const res = await fetch(documentUploadUrl(trajectRef.value), {
-        method: 'POST',
-        body: form,
-      });
-      if (!res.ok) {
-        // 404/405/501 mean the backend doesn't offer the upload endpoint (the
-        // conversion feature isn't enabled yet) - a human message, and retrying
-        // won't help. Other statuses keep the server's text (or the code) and
-        // stay retryable.
-        const unsupported = res.status === 404 || res.status === 405 || res.status === 501;
-        const text = await safeText(res);
-        const error = unsupported
-          ? 'Uploaden wordt door de server nog niet ondersteund.'
-          : (text || `Uploaden mislukt (foutcode ${res.status}).`);
-        // Surface via the returned result only (the consumer shows its own
-        // upload dialog); don't also set saveError, which raises a 2nd modal.
-        return { ok: false, error, retryable: !unsupported };
-      }
-      const json = await safeJson(res);
-      // Refresh the list so the poller (and, once converted, the .md) show up.
-      await fetchList();
-      return { ok: true, targetPath: json?.target_path ?? null };
-    } catch (e) {
-      return { ok: false, error: e.message };
-    }
+    // Shared multipart POST (raw fetch + 404/405/501 classification). Errors
+    // surface via the returned result only (the consumer shows its own upload
+    // dialog); don't also set saveError, which raises a 2nd modal.
+    const result = await uploadMultipart(documentUploadUrl(trajectRef.value), file);
+    if (!result.ok) return result;
+    // Refresh the list so the poller (and, once converted, the .md) show up.
+    await fetchList();
+    return { ok: true, targetPath: result.json?.target_path ?? null };
   }
 
   async function deleteDocument(path) {

--- a/frontend/src/lib/taskReview.test.js
+++ b/frontend/src/lib/taskReview.test.js
@@ -67,6 +67,26 @@ describe('reviewTarget', () => {
       reviewTarget({ id: 't7', payload: { kind: 'document', target_path: 'bijv-rapport.md' } }),
     ).toBeNull();
   });
+
+  it('routeert een law_create-taak naar de editor-traject-route (wet-branch)', () => {
+    const task = {
+      id: 't8',
+      task_type: 'job_review',
+      payload: {
+        kind: 'law_create',
+        traject_ref: 'mijn-traject-1a2b3c4d',
+        law_id: 'werkinstructie_toetsing',
+      },
+    };
+    const target = reviewTarget(task);
+    expect(target).not.toBeNull();
+    const resolved = router.resolve(target);
+    expect(resolved.name).toBe('editor-traject');
+    expect(resolved.params.lawId).toBe('werkinstructie_toetsing');
+    expect(resolved.fullPath).toBe(
+      '/trajecten/mijn-traject-1a2b3c4d/editor/werkinstructie_toetsing?task=t8',
+    );
+  });
 });
 
 describe('proposalDivergence', () => {

--- a/frontend/src/lib/uploadMultipart.js
+++ b/frontend/src/lib/uploadMultipart.js
@@ -1,0 +1,39 @@
+/**
+ * uploadMultipart - de gedeelde multipart-POST voor bestandsuploads
+ * (werkdocument- en wet-upload). Eén plek voor de raw-fetch (bewust geen
+ * Content-Type: de browser zet zelf de multipart-boundary), de
+ * 404/405/501-classificatie ("endpoint bestaat niet op deze server, retry
+ * helpt niet") en de `{ ok, error, retryable }`-resultaatvorm die
+ * `useDocumentUpload` verwacht. Op succes draagt `json` de geparste
+ * responsebody (of `null` bij een lege body) zodat de aanroeper er zijn
+ * eigen velden (target_path, job_id) uit kan lezen.
+ */
+export async function uploadMultipart(url, file) {
+  const form = new FormData();
+  form.append('file', file);
+  try {
+    const res = await fetch(url, { method: 'POST', body: form });
+    if (!res.ok) {
+      const unsupported = res.status === 404 || res.status === 405 || res.status === 501;
+      let text = '';
+      try {
+        text = await res.text();
+      } catch {
+        /* generieke melding hieronder */
+      }
+      const error = unsupported
+        ? 'Uploaden wordt door de server nog niet ondersteund.'
+        : (text || `Uploaden mislukt (foutcode ${res.status}).`);
+      return { ok: false, error, retryable: !unsupported };
+    }
+    let json = null;
+    try {
+      json = await res.json();
+    } catch {
+      /* lege of niet-JSON-body: json blijft null */
+    }
+    return { ok: true, json };
+  } catch (e) {
+    return { ok: false, error: e.message, retryable: true };
+  }
+}

--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -4113,6 +4113,7 @@ dependencies = [
  "libc",
  "pretty_assertions",
  "regelrecht-corpus",
+ "regelrecht-engine",
  "regelrecht-harvester",
  "regelrecht-law-model",
  "regelrecht-pipeline",

--- a/packages/admin/Dockerfile
+++ b/packages/admin/Dockerfile
@@ -51,6 +51,12 @@ COPY packages/law-model/ law-model/
 COPY packages/pipeline/ pipeline/
 COPY packages/harvester/ harvester/
 COPY packages/shared/ shared/
+# regelrecht-engine (validate feature, pulled in by pipeline's law_convert)
+# embeds the JSON schemas via `include_str!("../../../schema/...")`, relative
+# to engine/src/. The crate lives at /build/engine here (not
+# /build/packages/engine), so that literal resolves to /schema/... — same
+# layout trick as frontend/Dockerfile.
+COPY schema/ /schema/
 # Invalidate cargo's fingerprint cache so it recompiles with real source
 # instead of using the stub binary from cargo-chef cook.
 RUN find . -name '*.rs' -exec touch {} + && \

--- a/packages/admin/src/handlers.rs
+++ b/packages/admin/src/handlers.rs
@@ -1066,6 +1066,7 @@ pub async fn create_enrich_jobs(
             traject_id: None,
             traject_ref: None,
             source_etag: None,
+            new_law: None,
         };
 
         let payload_json = serde_json::to_value(&enrich_payload).map_err(|e| {

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -2725,6 +2725,58 @@ pub async fn list_traject_documents(
 /// Upload formats accepted in fase 1: PDF and Word.
 const UPLOAD_DOCUMENT_EXTENSIONS: &[&str] = &["pdf", "doc", "docx"];
 
+/// Pull the uploaded file out of a multipart body (the `file` field) and gate
+/// it on [`UPLOAD_DOCUMENT_EXTENSIONS`]. Shared by the werkdocument- and
+/// wet-upload endpoints. Returns `(filename, content_type, bytes)`.
+async fn read_upload_multipart(
+    multipart: &mut Multipart,
+) -> Result<(String, String, Vec<u8>), (StatusCode, String)> {
+    let mut filename: Option<String> = None;
+    let mut content_type: Option<String> = None;
+    let mut data: Option<Vec<u8>> = None;
+    while let Some(field) = multipart
+        .next_field()
+        .await
+        .map_err(|e| (StatusCode::BAD_REQUEST, format!("Ongeldige upload: {e}")))?
+    {
+        if field.name() == Some("file") {
+            filename = field.file_name().map(|s| s.to_string());
+            content_type = field.content_type().map(|s| s.to_string());
+            let bytes = field.bytes().await.map_err(|e| {
+                (
+                    StatusCode::BAD_REQUEST,
+                    format!("Kon het bestand niet lezen: {e}"),
+                )
+            })?;
+            data = Some(bytes.to_vec());
+            break;
+        }
+    }
+    let filename = filename.ok_or((
+        StatusCode::BAD_REQUEST,
+        "Geen bestand in de upload (het 'file'-veld ontbreekt).".to_string(),
+    ))?;
+    let data = data.filter(|d| !d.is_empty()).ok_or((
+        StatusCode::BAD_REQUEST,
+        "Het geüploade bestand is leeg.".to_string(),
+    ))?;
+    let content_type = content_type.unwrap_or_else(|| "application/octet-stream".to_string());
+
+    // Only PDF/Word in fase 1.
+    let ext = std::path::Path::new(&filename)
+        .extension()
+        .and_then(|s| s.to_str())
+        .map(|e| e.to_ascii_lowercase())
+        .unwrap_or_default();
+    if !UPLOAD_DOCUMENT_EXTENSIONS.contains(&ext.as_str()) {
+        return Err((
+            StatusCode::UNSUPPORTED_MEDIA_TYPE,
+            "Alleen PDF- en Word-documenten (.pdf, .doc, .docx) worden ondersteund.".to_string(),
+        ));
+    }
+    Ok((filename, content_type, data))
+}
+
 #[derive(Debug, Serialize)]
 pub struct UploadDocumentResponse {
     /// The `.md` path the converted document will appear at once its
@@ -2814,50 +2866,8 @@ pub async fn upload_traject_document(
     let traject = require_traject_corpus_from_ref(&state, &session, &traject_ref).await?;
     let traject_id = resolve_traject_ref(pool, &traject_ref).await?;
 
-    // Pull the uploaded file out of the multipart body (the `file` field).
-    let mut filename: Option<String> = None;
-    let mut content_type: Option<String> = None;
-    let mut data: Option<Vec<u8>> = None;
-    while let Some(field) = multipart
-        .next_field()
-        .await
-        .map_err(|e| (StatusCode::BAD_REQUEST, format!("Ongeldige upload: {e}")))?
-    {
-        if field.name() == Some("file") {
-            filename = field.file_name().map(|s| s.to_string());
-            content_type = field.content_type().map(|s| s.to_string());
-            let bytes = field.bytes().await.map_err(|e| {
-                (
-                    StatusCode::BAD_REQUEST,
-                    format!("Kon het bestand niet lezen: {e}"),
-                )
-            })?;
-            data = Some(bytes.to_vec());
-            break;
-        }
-    }
-    let filename = filename.ok_or((
-        StatusCode::BAD_REQUEST,
-        "Geen bestand in de upload (het 'file'-veld ontbreekt).".to_string(),
-    ))?;
-    let data = data.filter(|d| !d.is_empty()).ok_or((
-        StatusCode::BAD_REQUEST,
-        "Het geüploade bestand is leeg.".to_string(),
-    ))?;
-    let content_type = content_type.unwrap_or_else(|| "application/octet-stream".to_string());
-
-    // Only PDF/Word in fase 1.
-    let ext = std::path::Path::new(&filename)
-        .extension()
-        .and_then(|s| s.to_str())
-        .map(|e| e.to_ascii_lowercase())
-        .unwrap_or_default();
-    if !UPLOAD_DOCUMENT_EXTENSIONS.contains(&ext.as_str()) {
-        return Err((
-            StatusCode::UNSUPPORTED_MEDIA_TYPE,
-            "Alleen PDF- en Word-documenten (.pdf, .doc, .docx) worden ondersteund.".to_string(),
-        ));
-    }
+    // Pull the uploaded file out of the multipart body and gate the extension.
+    let (filename, content_type, data) = read_upload_multipart(&mut multipart).await?;
 
     // Derive a collision-safe target markdown path against the existing docs.
     // A failed listing must NOT be swallowed: an empty `existing` set would let
@@ -2961,6 +2971,205 @@ pub async fn upload_traject_document(
         StatusCode::ACCEPTED,
         Json(UploadDocumentResponse { target_path }),
     ))
+}
+
+#[derive(Debug, Serialize)]
+pub struct UploadLawResponse {
+    pub job_id: uuid::Uuid,
+}
+
+/// POST /api/trajects/{traject_ref}/corpus/laws/upload
+///
+/// Accept a multipart upload of a PDF/Word document and enqueue a
+/// `law_convert` job: the worker turns it into a harvested base-law YAML and
+/// chains a task-flow enrichment on it. The user gets a single review task
+/// with the enriched law at the end (kind `law_create`); approving it lands
+/// the law in the traject via `create_traject_law`. Responds `202 Accepted`
+/// with the job id; there is no target path yet, because the conversion
+/// itself chooses the law's `$id` and `regulatory_layer`.
+pub async fn upload_traject_law(
+    State(state): State<AppState>,
+    Extension(account): Extension<AccountRecord>,
+    session: Session,
+    Path(traject_ref): Path<String>,
+    mut multipart: Multipart,
+) -> Result<(StatusCode, Json<UploadLawResponse>), (StatusCode, String)> {
+    let pool = state.pool.as_ref().ok_or((
+        StatusCode::SERVICE_UNAVAILABLE,
+        "database not configured".to_string(),
+    ))?;
+    // Membership guard (also resolves the traject); the id feeds the job payload.
+    let _traject = require_traject_corpus_from_ref(&state, &session, &traject_ref).await?;
+    let traject_id = resolve_traject_ref(pool, &traject_ref).await?;
+
+    let (filename, content_type, data) = read_upload_multipart(&mut multipart).await?;
+
+    // Persist the bytes and enqueue the conversion job in one transaction,
+    // guarded by the same per-account taak-flow-cap as enrich-op-aanvraag
+    // (each law_convert chains an enrich job, so it counts toward that cap).
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| upload_internal_error("begin tx", e))?;
+    crate::task_requests::enforce_task_job_cap(&mut tx, account.id).await?;
+
+    let (upload_id,): (uuid::Uuid,) = sqlx::query_as(
+        "INSERT INTO document_uploads (traject_ref, filename, content_type, bytes) \
+         VALUES ($1, $2, $3, $4) RETURNING id",
+    )
+    .bind(&traject_ref)
+    .bind(&filename)
+    .bind(&content_type)
+    .bind(&data)
+    .fetch_one(&mut *tx)
+    .await
+    .map_err(|e| upload_internal_error("insert upload", e))?;
+
+    let payload = regelrecht_pipeline::law_convert::LawConvertPayload {
+        upload_id,
+        traject_id,
+        traject_ref: traject_ref.clone(),
+        filename: filename.clone(),
+        provider: Some(state.config.task_enrich_provider.clone()),
+        requested_by: Some(account.id),
+        deliver: Some("task".to_string()),
+    };
+    let payload_json = serde_json::to_value(&payload)
+        .map_err(|e| upload_internal_error("serialize payload", e))?;
+    let req = regelrecht_pipeline::job_queue::CreateJobRequest::new(
+        regelrecht_pipeline::JobType::LawConvert,
+        // Synthetic job key; real identity ($id) is chosen by the conversion.
+        format!("lawdoc:{traject_ref}/{filename}"),
+    )
+    .with_traject_ref(traject_ref.clone())
+    // Single attempt, like document-convert: a retry would re-run the
+    // expensive LLM structuring and most failures are deterministic. A
+    // failure surfaces as a job_failed task; re-uploading is the retry.
+    .with_max_attempts(1)
+    .with_payload(payload_json);
+    let job = regelrecht_pipeline::job_queue::create_job(&mut *tx, req)
+        .await
+        .map_err(|e| upload_internal_error("create job", e))?;
+    tx.commit()
+        .await
+        .map_err(|e| upload_internal_error("commit tx", e))?;
+
+    Ok((
+        StatusCode::ACCEPTED,
+        Json(UploadLawResponse { job_id: job.id }),
+    ))
+}
+
+/// POST /api/trajects/{traject_ref}/corpus/laws: create a NEW law in the
+/// traject's writable-own source.
+///
+/// The approve-step of a `law_create` review task: `save_law` (PUT) can only
+/// write laws that already exist in the traject's index, so a freshly
+/// converted law needs this create path. Unlike `save_law` the body gets
+/// FULL schema validation (there is no existing file to fall back on), and
+/// the corpus path is derived **server-side** from the validated body:
+/// `regulation/nl/{regulatory_layer}/{$id}/{valid_from}.yaml`.
+pub async fn create_traject_law(
+    State(state): State<AppState>,
+    Extension(account): Extension<AccountRecord>,
+    session: Session,
+    Path(traject_ref): Path<String>,
+    headers: axum::http::HeaderMap,
+    body: String,
+) -> Result<axum::response::Response, (StatusCode, String)> {
+    use axum::response::IntoResponse;
+    let author = Some(require_editor_user(&session).await?);
+
+    // Full validation: schema + $id-slug + regulatory_layer + valid_from,
+    // the same single validator the law-convert worker uses, so what the
+    // worker produced (and the reviewer possibly edited) is what lands.
+    // The error body lists the validation errors; they are plain schema
+    // paths/messages, not echoed free-form user input.
+    let meta = regelrecht_pipeline::law_convert::validate_law_yaml(&body).map_err(|errors| {
+        (
+            StatusCode::BAD_REQUEST,
+            format!("Wet valideert niet tegen het schema: {}", errors.join("; ")),
+        )
+    })?;
+    let law_id = meta.law_id.clone();
+
+    let traject = require_traject_corpus_from_ref(&state, &session, &traject_ref).await?;
+    let traject_id = resolve_traject_ref(
+        state.pool.as_ref().ok_or((
+            StatusCode::SERVICE_UNAVAILABLE,
+            "database not configured".to_string(),
+        ))?,
+        &traject_ref,
+    )
+    .await?;
+
+    // A law with this $id anywhere in the federated index is a conflict: the
+    // create path must never shadow or overwrite an existing law. (Editing
+    // an existing law goes through the PUT.)
+    if traject.corpus.source_map.get_law(&law_id).is_some() {
+        return Err((
+            StatusCode::CONFLICT,
+            "Er bestaat al een wet met dit $id in dit traject; pas het $id in de YAML aan."
+                .to_string(),
+        ));
+    }
+
+    // Standard corpus layout, relative to the writable-own source root.
+    let relative_path = PathBuf::from("regulation")
+        .join("nl")
+        .join(meta.regulatory_layer.as_dir_name())
+        .join(&law_id)
+        .join(format!("{}.yaml", meta.valid_from));
+
+    // The writable-own backend (same routing as documents: the law does not
+    // exist yet, so there is no per-law source to route from).
+    let backend = resolve_traject_documents_writer(&traject).await?;
+    // Belt-and-braces against an index blind spot (e.g. a file committed on
+    // the branch after the current snapshot was built).
+    if backend
+        .read_file(&relative_path)
+        .await
+        .map_err(corpus_write_error("law"))?
+        .is_some()
+    {
+        return Err((
+            StatusCode::CONFLICT,
+            "Er staat al een wetsbestand op dit pad in het traject; pas het $id in de YAML aan."
+                .to_string(),
+        ));
+    }
+    let token_override =
+        github_oauth::user_write_token_for_backend(&state, account.id, &headers, &**backend)
+            .await?;
+
+    backend
+        .write_file(&relative_path, &body)
+        .await
+        .map_err(corpus_write_error("law"))?;
+    let outcome = backend
+        .persist(&WriteContext {
+            message: format!("Nieuwe wet {} uit documentconversie", law_id),
+            author,
+            token_override,
+        })
+        .await
+        .map_err(corpus_write_error("law"))?;
+    drop(backend);
+
+    let new_etag = document_etag(&body);
+
+    // Read-your-writes for requests still holding the current snapshot …
+    traject.record_save(law_id.clone(), body).await;
+    traject.record_changed_law(&law_id).await;
+    // … and a full cache drop so the next request rebuilds the index with
+    // the new file on the branch. Without this the law stays invisible to
+    // the PUT/save path (which requires an index entry) until the TTL
+    // refresh happens to run.
+    state.trajects.invalidate(traject_id).await;
+
+    let mut response = save_response_from_traject(outcome);
+    response.etag = Some(new_etag.clone());
+    Ok(([(axum::http::header::ETAG, new_etag)], Json(response)).into_response())
 }
 
 /// GET /api/trajects/{traject_ref}/corpus/documents/jobs

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -3080,6 +3080,19 @@ pub async fn create_traject_law(
     use axum::response::IntoResponse;
     let author = Some(require_editor_user(&session).await?);
 
+    // Membership guard FIRST, before any body work — the schema validation
+    // below is CPU-bound over an up-to-5MB body and must not be reachable
+    // for non-members (same ordering as the upload handlers).
+    let traject = require_traject_corpus_from_ref(&state, &session, &traject_ref).await?;
+    let traject_id = resolve_traject_ref(
+        state.pool.as_ref().ok_or((
+            StatusCode::SERVICE_UNAVAILABLE,
+            "database not configured".to_string(),
+        ))?,
+        &traject_ref,
+    )
+    .await?;
+
     // Full validation: schema + $id-slug + regulatory_layer + valid_from,
     // the same single validator the law-convert worker uses, so what the
     // worker produced (and the reviewer possibly edited) is what lands.
@@ -3092,16 +3105,6 @@ pub async fn create_traject_law(
         )
     })?;
     let law_id = meta.law_id.clone();
-
-    let traject = require_traject_corpus_from_ref(&state, &session, &traject_ref).await?;
-    let traject_id = resolve_traject_ref(
-        state.pool.as_ref().ok_or((
-            StatusCode::SERVICE_UNAVAILABLE,
-            "database not configured".to_string(),
-        ))?,
-        &traject_ref,
-    )
-    .await?;
 
     // A law with this $id anywhere in the federated index is a conflict: the
     // create path must never shadow or overwrite an existing law. (Editing

--- a/packages/editor-api/src/lib.rs
+++ b/packages/editor-api/src/lib.rs
@@ -12,6 +12,7 @@ pub mod crypto;
 pub mod feature_flags;
 pub mod github_oauth;
 pub mod state;
+pub mod task_requests;
 pub mod traject_corpus;
 pub mod trajects;
 pub mod user_notes;

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -488,6 +488,18 @@ async fn main() {
                 .layer(axum::extract::DefaultBodyLimit::max(MAX_UPLOAD_BODY)),
         )
         .route(
+            // Static segment wins over `{law_id}` in the router, so this
+            // does not shadow the per-law routes.
+            "/api/trajects/{traject_ref}/corpus/laws/upload",
+            axum::routing::post(corpus_handlers::upload_traject_law)
+                .layer(axum::extract::DefaultBodyLimit::max(MAX_UPLOAD_BODY)),
+        )
+        .route(
+            "/api/trajects/{traject_ref}/corpus/laws",
+            axum::routing::post(corpus_handlers::create_traject_law)
+                .layer(axum::extract::DefaultBodyLimit::max(MAX_LAW_BODY)),
+        )
+        .route(
             "/api/trajects/{traject_ref}/corpus/laws/{law_id}/enrich",
             axum::routing::post(task_requests::request_enrich),
         )

--- a/packages/editor-api/src/task_requests.rs
+++ b/packages/editor-api/src/task_requests.rs
@@ -82,6 +82,7 @@ pub async fn request_enrich(
         traject_id: Some(traject_id),
         traject_ref: Some(traject_ref.clone()),
         source_etag: Some(source_etag),
+        new_law: None,
     };
     let payload_json = serde_json::to_value(&payload).map_err(internal("payload serialiseren"))?;
 
@@ -89,34 +90,7 @@ pub async fn request_enrich(
     // op (law_id, provider) via de bestaande unieke actieve-enrich-index.
     let mut tx = pool.begin().await.map_err(internal("begin tx"))?;
 
-    // Serialiseer per account: de cap-check hieronder is anders een
-    // COUNT-then-INSERT-race (zelfde TOCTOU-klasse als harvest_request;
-    // zelfde remedie: een xact-scoped advisory lock).
-    sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended('task_enrich:' || $1::text, 0))")
-        .bind(account.id.to_string())
-        .execute(&mut *tx)
-        .await
-        .map_err(internal("account-lock nemen"))?;
-
-    // Per-account-cap: telt actieve taak-flow-jobs van dit account vóórdat we
-    // er nog een bij enqueuen, zodat een scripted flood niet de prio-80-queue
-    // of het LLM-uurbudget kan opsouperen.
-    let (active_count,): (i64,) = sqlx::query_as(
-        "SELECT COUNT(*) FROM jobs \
-         WHERE job_type = 'enrich' AND status IN ('pending', 'processing') \
-           AND payload->>'requested_by' = $1",
-    )
-    .bind(account.id.to_string())
-    .fetch_one(&mut *tx)
-    .await
-    .map_err(internal("actieve taak-jobs tellen"))?;
-    if active_count >= MAX_ACTIVE_TASK_JOBS_PER_ACCOUNT {
-        return Err((
-            StatusCode::TOO_MANY_REQUESTS,
-            "Je hebt te veel verrijkingen tegelijk lopen; wacht tot er een paar klaar zijn."
-                .to_string(),
-        ));
-    }
+    enforce_task_job_cap(&mut tx, account.id).await?;
 
     // max_attempts 3 (default expliciet): transiënte fouten (fork-exhaustion,
     // provider-hiccups) zijn retryable; de input-blob overleeft tot definitief
@@ -144,6 +118,42 @@ pub async fn request_enrich(
         StatusCode::ACCEPTED,
         Json(EnrichRequestResponse { job_id: job.id }),
     ))
+}
+
+/// Per-account-cap op actieve taak-flow-jobs, binnen de transactie van de
+/// aanroeper. Serialiseert eerst per account (xact-scoped advisory lock):
+/// de COUNT-then-INSERT is anders een TOCTOU-race (zelfde klasse en remedie
+/// als harvest_request). Telt naast enrich- ook law_convert-jobs mee: elke
+/// law_convert ketent immers een enrich-job na. Gedeeld door `request_enrich`
+/// en de law-upload in `corpus_handlers`.
+pub(crate) async fn enforce_task_job_cap(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    account_id: Uuid,
+) -> Result<(), (StatusCode, String)> {
+    sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended('task_enrich:' || $1::text, 0))")
+        .bind(account_id.to_string())
+        .execute(&mut **tx)
+        .await
+        .map_err(internal("account-lock nemen"))?;
+
+    let (active_count,): (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM jobs \
+         WHERE job_type IN ('enrich', 'law_convert') \
+           AND status IN ('pending', 'processing') \
+           AND payload->>'requested_by' = $1",
+    )
+    .bind(account_id.to_string())
+    .fetch_one(&mut **tx)
+    .await
+    .map_err(internal("actieve taak-jobs tellen"))?;
+    if active_count >= MAX_ACTIVE_TASK_JOBS_PER_ACCOUNT {
+        return Err((
+            StatusCode::TOO_MANY_REQUESTS,
+            "Je hebt te veel verrijkingen tegelijk lopen; wacht tot er een paar klaar zijn."
+                .to_string(),
+        ));
+    }
+    Ok(())
 }
 
 fn internal<E: std::fmt::Display>(what: &'static str) -> impl FnOnce(E) -> (StatusCode, String) {

--- a/packages/pipeline/Cargo.toml
+++ b/packages/pipeline/Cargo.toml
@@ -24,6 +24,9 @@ path = "src/bin/pipeline_api.rs"
 
 [dependencies]
 regelrecht-corpus = { path = "../corpus" }
+# `validate` voor de JSON-schema-validatie van gegenereerde basis-wet-YAML
+# (law_convert); de engine hangt alleen aan shared + law-model, geen cyclus.
+regelrecht-engine = { path = "../engine", features = ["validate"] }
 regelrecht-harvester = { path = "../harvester" }
 regelrecht-law-model = { path = "../law-model" }
 regelrecht-shared = { path = "../shared", features = ["telemetry"] }

--- a/packages/pipeline/Dockerfile
+++ b/packages/pipeline/Dockerfile
@@ -60,6 +60,12 @@ COPY packages/law-model/ law-model/
 COPY packages/pipeline/ pipeline/
 COPY packages/harvester/ harvester/
 COPY packages/shared/ shared/
+# regelrecht-engine (validate feature, pulled in by pipeline's law_convert)
+# embeds the JSON schemas via `include_str!("../../../schema/...")`, relative
+# to engine/src/. The crate lives at /build/engine here (not
+# /build/packages/engine), so that literal resolves to /schema/... — same
+# layout trick as frontend/Dockerfile.
+COPY schema/ /schema/
 ARG BIN=regelrecht-pipeline-api
 # Invalidate cargo's fingerprint cache so it recompiles with real source
 # instead of using the stub binary from cargo-chef cook.

--- a/packages/pipeline/migrations/0030_law_convert_job_type.sql
+++ b/packages/pipeline/migrations/0030_law_convert_job_type.sql
@@ -1,0 +1,6 @@
+-- no-transaction
+-- Nieuw jobtype voor het omzetten van een geüpload document naar een
+-- basis-wet-YAML (geharveste wet zonder machine_readable). ALTER TYPE ...
+-- ADD VALUE kan niet in een transactieblok, vandaar de no-transaction-marker
+-- (zelfde patroon als 0025_document_convert_job_type.sql).
+ALTER TYPE job_type ADD VALUE IF NOT EXISTS 'law_convert';

--- a/packages/pipeline/src/document_convert.rs
+++ b/packages/pipeline/src/document_convert.rs
@@ -97,10 +97,10 @@ pub async fn delete_upload(pool: &PgPool, upload_id: Uuid) -> Result<()> {
 }
 
 /// Delete upload rows no longer referenced by an active (`pending`/`processing`)
-/// document_convert job. This garbage-collects bytes orphaned when a worker
-/// crashed mid-conversion and the generic orphan reaper failed the job without
-/// running the type-specific [`delete_upload`]. Returns the number of rows
-/// removed.
+/// document_convert or law_convert job. This garbage-collects bytes orphaned
+/// when a worker crashed mid-conversion and the generic orphan reaper failed
+/// the job without running the type-specific [`delete_upload`]. Returns the
+/// number of rows removed.
 ///
 /// Safe because editor-api inserts the upload row and its job in a single
 /// transaction, so a row with no active job is genuinely orphaned — the short
@@ -112,7 +112,7 @@ pub async fn cleanup_orphaned_uploads(pool: &PgPool) -> Result<u64> {
         WHERE du.created_at < now() - interval '15 minutes'
           AND NOT EXISTS (
               SELECT 1 FROM jobs j
-              WHERE j.job_type = 'document_convert'
+              WHERE j.job_type IN ('document_convert', 'law_convert')
                 AND j.status IN ('pending', 'processing')
                 AND j.payload->>'upload_id' = du.id::text
           )
@@ -453,7 +453,7 @@ fn build_convert_prompt(input_file: &Path, output_path: &Path) -> String {
 /// Pick a file extension for the scratch input file from the original filename,
 /// falling back to the content type. Keeps the extension the agent sees honest
 /// so it can detect the format.
-fn extension_for(filename: &str, content_type: &str) -> String {
+pub(crate) fn extension_for(filename: &str, content_type: &str) -> String {
     if let Some(ext) = Path::new(filename)
         .extension()
         .and_then(|e| e.to_str())
@@ -500,7 +500,7 @@ pub async fn execute_document_convert(
 ///
 /// `pandoc` handles the office/markup formats; `pdftotext` (poppler) handles
 /// PDF. Both are baked into the enrich-worker image.
-async fn try_deterministic_convert(
+pub(crate) async fn try_deterministic_convert(
     input_file: &Path,
     ext: &str,
     output_path: &Path,

--- a/packages/pipeline/src/enrich.rs
+++ b/packages/pipeline/src/enrich.rs
@@ -474,6 +474,12 @@ pub struct EnrichPayload {
     /// `document_etag()` van de wet-YAML op aanvraagmoment (staleness-check).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_etag: Option<String>,
+    /// `true` wanneer deze enrichment een NIEUWE wet betreft die nog niet in
+    /// het traject bestaat (geketend vanuit een `law_convert`-job). Stuurt de
+    /// review-taak: `kind: "law_create"` + eigen titel, zodat de editor het
+    /// voorstel als aan-te-maken wet behandelt i.p.v. als wijziging.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub new_law: Option<bool>,
 }
 
 impl EnrichPayload {
@@ -1659,6 +1665,7 @@ mod tests {
             traject_id: None,
             traject_ref: None,
             source_etag: None,
+            new_law: None,
         };
 
         let json = serde_json::to_string(&payload).unwrap();
@@ -1678,6 +1685,7 @@ mod tests {
             traject_id: None,
             traject_ref: None,
             source_etag: None,
+            new_law: None,
         };
         let json_no_provider = serde_json::to_string(&payload_no_provider).unwrap();
         assert!(!json_no_provider.contains("provider"));
@@ -1926,6 +1934,7 @@ related_legislation:
             traject_id: Some(uuid::Uuid::new_v4()),
             traject_ref: Some("testtraject-abcd1234".into()),
             source_etag: Some("\"abc\"".into()),
+            new_law: None,
         };
         let roundtrip: EnrichPayload =
             serde_json::from_value(serde_json::to_value(&new).unwrap()).unwrap();
@@ -2248,6 +2257,7 @@ articles:
             traject_id: None,
             traject_ref: None,
             source_etag: None,
+            new_law: None,
         };
 
         let config = test_config(LlmProvider::OpenCode {
@@ -2318,6 +2328,7 @@ articles:
             traject_id: None,
             traject_ref: None,
             source_etag: None,
+            new_law: None,
         };
 
         let config = test_config(LlmProvider::OpenCode {
@@ -2371,6 +2382,7 @@ articles:
             traject_id: None,
             traject_ref: None,
             source_etag: None,
+            new_law: None,
         };
 
         let config = test_config(LlmProvider::OpenCode {

--- a/packages/pipeline/src/law_convert.rs
+++ b/packages/pipeline/src/law_convert.rs
@@ -1,0 +1,660 @@
+//! Law-convert jobs: turn an uploaded PDF/Word document into a harvested
+//! base-law YAML (a law without `machine_readable`), then chain a task-flow
+//! enrich job on it.
+//!
+//! The conversion mirrors [`crate::document_convert`]: known formats are first
+//! reduced to text deterministically (`pandoc`/`pdftotext`), after which the
+//! LLM agent structures that text into a schema-conformant base-law YAML —
+//! choosing the `regulatory_layer` itself, because the upload can be anything
+//! from a formal wet to uitvoeringsbeleid or a werkinstructie. The produced
+//! YAML is validated in Rust against the JSON schema, with one repair round.
+//! On success the worker does NOT create a review task itself: it enqueues a
+//! task-flow enrich job with the base YAML as input blob, and the single
+//! review task the user sees comes from the existing enrich task flow (see
+//! `worker::finish_enrich_task_job`, steered by `EnrichPayload::new_law`).
+
+use std::path::Path;
+
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use regelrecht_shared::RegulatoryLayer;
+
+use crate::document_convert::{extension_for, try_deterministic_convert, Upload};
+use crate::enrich::{run_llm_subprocess, EnrichConfig, EnrichPayload};
+use crate::error::{PipelineError, Result};
+use crate::job_queue::{self, CreateJobRequest};
+use crate::models::{Job, JobType, Priority};
+use crate::tasks::{self, BlobKind};
+
+/// Prioriteit van de geketende enrich-job: gelijk aan de interactieve
+/// enrich-op-aanvraag (task_requests.rs), want ook hier wacht een mens.
+const CHAINED_ENRICH_PRIORITY: i32 = 80;
+
+/// Payload carried by a `law_convert` job. The raw bytes live in
+/// `document_uploads` (referenced by `upload_id`), same as document-convert.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LawConvertPayload {
+    /// Row id in `document_uploads` holding the uploaded bytes.
+    pub upload_id: Uuid,
+    /// Owning traject's id (feeds the chained enrich payload + failure task).
+    pub traject_id: Uuid,
+    /// Owning traject ref (also mirrored onto `jobs.traject_ref`).
+    pub traject_ref: String,
+    /// Original uploaded filename. Only for display: failure-task titles and
+    /// the "Bezig"-sectie of the takenpaneel — the slug/$id is chosen by the
+    /// conversion itself.
+    pub filename: String,
+    /// LLM provider override (`"claude"` / `"opencode"`); `None` uses the
+    /// worker default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
+    /// Account dat de upload deed; wordt de assignee van de uiteindelijke
+    /// review-taak (via de geketende enrich-job) en van een `job_failed`-taak.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requested_by: Option<Uuid>,
+    /// `"task"` ⇒ taak-flow. Law-convert kent alléén de taak-flow (er is geen
+    /// direct-push-pad); het veld bestaat zodat de generieke
+    /// `list_running_task_jobs_for_account`-query dit jobtype meepakt.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deliver: Option<String>,
+}
+
+impl LawConvertPayload {
+    /// Taak-flow: resultaat via de geketende enrich-taak i.p.v. een push.
+    pub fn deliver_as_task(&self) -> bool {
+        self.deliver.as_deref() == Some("task")
+    }
+}
+
+/// Metadata extracted from a validated base-law YAML. Also consumed by
+/// editor-api's law-create endpoint, which derives the corpus path from it —
+/// keep validation and extraction in this one place.
+#[derive(Debug, Clone)]
+pub struct ValidatedLawMeta {
+    pub law_id: String,
+    pub regulatory_layer: RegulatoryLayer,
+    pub valid_from: chrono::NaiveDate,
+}
+
+/// A validated, freshly-generated base law.
+#[derive(Debug)]
+pub struct GeneratedLaw {
+    pub yaml: String,
+    pub meta: ValidatedLawMeta,
+}
+
+/// Abstraction over the LLM structuring step so the orchestration can be
+/// unit-tested without spawning a subprocess (mirrors
+/// [`crate::document_convert::DocumentConverter`]).
+#[async_trait::async_trait]
+pub trait LawStructurer: Send + Sync {
+    /// Run the agent with `prompt` in `work_dir`; the prompt names the file
+    /// the agent must write its YAML to.
+    async fn structure(&self, prompt: &str, work_dir: &Path, config: &EnrichConfig) -> Result<()>;
+}
+
+/// Production structurer: the enrich LLM subprocess with shell access (the
+/// agent may need `pandoc`/`pdftotext` for the fallback path where no
+/// deterministic conversion was possible).
+pub struct LlmLawStructurer;
+
+#[async_trait::async_trait]
+impl LawStructurer for LlmLawStructurer {
+    async fn structure(&self, prompt: &str, work_dir: &Path, config: &EnrichConfig) -> Result<()> {
+        run_llm_subprocess(&config.provider, prompt, None, work_dir, config, true).await
+    }
+}
+
+/// Name of the YAML file the agent must produce in its working directory.
+const OUTPUT_FILE: &str = "law.yaml";
+/// Name of the deterministically extracted text, when extraction succeeded.
+const SOURCE_TEXT_FILE: &str = "source.md";
+
+/// `$schema` URL the generated law must carry (pinned; the enrichment that
+/// follows works on the same version).
+const SCHEMA_URL: &str = "https://raw.githubusercontent.com/MinBZK/regelrecht/refs/tags/schema-v0.5.6/schema/v0.5.6/schema.json";
+
+/// Sanitize the uploaded filename into something safe for the synthetic
+/// `upload://` source-URL (schema `url` is `format: uri`, so no spaces).
+fn sanitize_for_url(filename: &str) -> String {
+    let cleaned: String = filename
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '_' {
+                c.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    if cleaned.is_empty() {
+        "document".to_string()
+    } else {
+        cleaned
+    }
+}
+
+/// Build the structuring prompt. `source_file` is the file the agent reads:
+/// the deterministically extracted text when available, otherwise the raw
+/// upload (and the agent converts it itself, mirroring document-convert's
+/// agentic fallback).
+fn build_structure_prompt(source_file: &str, source_is_text: bool, source_url: &str) -> String {
+    let read_step = if source_is_text {
+        format!(
+            "1. Read `{source_file}` in your current working directory: the extracted text of \
+             the source document."
+        )
+    } else {
+        format!(
+            "1. The file `{source_file}` in your current working directory is the raw uploaded \
+             document. First convert it to text yourself — the tools `pandoc` (Word/HTML/… → \
+             Markdown) and `pdftotext` (PDF → text) are installed; do NOT rely on network \
+             access. If no tool fits, read and transcribe it directly."
+        )
+    };
+    let layers = [
+        ("GRONDWET", "constitutional law"),
+        ("WET", "a formal law (wet in formele zin)"),
+        ("AMVB", "algemene maatregel van bestuur"),
+        ("KONINKLIJK_BESLUIT", "koninklijk besluit"),
+        ("MINISTERIELE_REGELING", "ministeriële regeling"),
+        (
+            "BELEIDSREGEL",
+            "beleidsregel (policy rule of an bestuursorgaan)",
+        ),
+        (
+            "UITVOERINGSBELEID",
+            "uitvoeringsbeleid, werkinstructies or other internal implementation policy of a \
+             ministry or organisation — the default for internal documents",
+        ),
+        ("EU_VERORDENING", "EU regulation"),
+        ("EU_RICHTLIJN", "EU directive"),
+        ("VERDRAG", "international treaty"),
+        ("GEMEENTELIJKE_VERORDENING", "municipal ordinance"),
+        ("PROVINCIALE_VERORDENING", "provincial ordinance"),
+        ("WATERSCHAPS_VERORDENING", "water board ordinance"),
+    ]
+    .into_iter()
+    .map(|(k, v)| format!("   - `{k}`: {v}"))
+    .collect::<Vec<_>>()
+    .join("\n");
+    let today = Utc::now().format("%Y-%m-%d");
+    format!(
+        "You are converting a source document into a regelrecht base-law YAML file — the same \
+         article-based format the BWB harvester produces. The document is not necessarily a \
+         formal law: it can also be ministry policy, werkinstructies, or other regulations.\n\n\
+         {read_step}\n\
+         2. Determine the regulatory level of the document and pick the matching \
+         `regulatory_layer` value:\n{layers}\n\
+         3. Write a YAML document with exactly this top-level structure (base law only — do \
+         NOT add `machine_readable`; that is a later, separate step):\n\
+         ```yaml\n\
+         ---\n\
+         $schema: {SCHEMA_URL}\n\
+         $id: <snake_case slug of the document title, only [a-z0-9_]>\n\
+         regulatory_layer: <value from step 2>\n\
+         publication_date: '<YYYY-MM-DD from the document; if unknown, use the valid_from date>'\n\
+         valid_from: '<YYYY-MM-DD the rules take effect per the document; if unknown, use {today}>'\n\
+         url: {source_url}\n\
+         articles:\n\
+           - number: '<article/section number>'\n\
+             text: >-\n\
+               <the verbatim text of the article>\n\
+             url: {source_url}#<number>\n\
+         ```\n\
+         Optionally add a top-level `preamble` (string) for introductory text that precedes \
+         the articles, and `officiele_titel`/`organisation` when the document states them.\n\
+         4. Articles: when the document has numbered articles or sections, keep that numbering \
+         (as strings, e.g. '1', '2a'). Otherwise split the document into logical sections and \
+         number them '1', '2', …. Transcribe the text of each article verbatim — do NOT \
+         summarize, translate, add commentary, or omit content.\n\
+         5. Write ONLY the YAML document to a file named `{OUTPUT_FILE}` in your current \
+         working directory — no surrounding code fences, no explanations.\n\n\
+         The final deliverable is the file `{OUTPUT_FILE}`."
+    )
+}
+
+/// Build the repair prompt for the second (and final) agent run after schema
+/// validation failed. The invalid `law.yaml` is still in the workdir.
+fn build_repair_prompt(errors: &[String]) -> String {
+    let list = errors
+        .iter()
+        .map(|e| format!("- {e}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!(
+        "The file `{OUTPUT_FILE}` you produced does not validate against the regelrecht JSON \
+         schema. Fix `{OUTPUT_FILE}` in place so it validates, changing as little as possible \
+         and keeping all article text verbatim. The validation errors:\n{list}\n\n\
+         Write the corrected YAML to `{OUTPUT_FILE}` (overwrite it). Write ONLY the YAML \
+         document — no code fences, no explanations."
+    )
+}
+
+/// Validate generated base-law YAML: JSON-schema plus the invariants the rest
+/// of the chain relies on ($id slug shape, parseable regulatory_layer, a real
+/// `valid_from` date). Returns the extracted identity on success, or the full
+/// error list (for the repair prompt / a 400 body) on failure.
+pub fn validate_law_yaml(yaml: &str) -> std::result::Result<ValidatedLawMeta, Vec<String>> {
+    let value: serde_json::Value = match serde_yaml_ng::from_str(yaml) {
+        Ok(v) => v,
+        Err(e) => return Err(vec![format!("YAML parse error: {e}")]),
+    };
+
+    let mut errors = Vec::new();
+
+    match regelrecht_engine::schema::detect_version(&value) {
+        Some(version) => match regelrecht_engine::schema::validation_errors_for(version, &value) {
+            Ok(schema_errors) => errors.extend(schema_errors),
+            Err(e) => errors.push(format!("schema validation failed: {e}")),
+        },
+        None => errors.push(format!(
+            "$schema: missing or unknown schema version (use exactly `{SCHEMA_URL}`)"
+        )),
+    }
+
+    let law_id = value
+        .get("$id")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default()
+        .to_string();
+    let slug_ok = !law_id.is_empty()
+        && law_id
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_');
+    if !slug_ok {
+        errors.push(format!(
+            "$id: must be a non-empty snake_case slug matching [a-z0-9_]+ (got `{law_id}`)"
+        ));
+    }
+
+    let layer: Option<RegulatoryLayer> = value
+        .get("regulatory_layer")
+        .and_then(|v| serde_json::from_value(v.clone()).ok());
+    if layer.is_none() {
+        errors.push("regulatory_layer: missing or not a known layer value".to_string());
+    }
+
+    let valid_from = value
+        .get("valid_from")
+        .and_then(|v| v.as_str())
+        .and_then(|s| chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d").ok());
+    if valid_from.is_none() {
+        errors.push("valid_from: missing or not a YYYY-MM-DD date".to_string());
+    }
+
+    match (layer, valid_from) {
+        (Some(regulatory_layer), Some(valid_from)) if errors.is_empty() => Ok(ValidatedLawMeta {
+            law_id,
+            regulatory_layer,
+            valid_from,
+        }),
+        _ => Err(errors),
+    }
+}
+
+/// Load the upload, run the conversion in a fresh working directory, validate
+/// (with one repair round), and return the generated law. The caller (worker)
+/// chains the enrich job and cleans up the upload row + job.
+pub async fn execute_law_convert(
+    pool: &PgPool,
+    payload: &LawConvertPayload,
+    config: &EnrichConfig,
+    structurer: &dyn LawStructurer,
+) -> Result<GeneratedLaw> {
+    let upload = crate::document_convert::load_upload(pool, payload.upload_id).await?;
+    let work_dir = std::env::temp_dir().join(format!("lawconvert-{}", payload.upload_id));
+    // Clear any stale directory left by a previous attempt of this same job.
+    let _ = tokio::fs::remove_dir_all(&work_dir).await;
+    tokio::fs::create_dir_all(&work_dir).await?;
+
+    let result = convert_law_in_dir(&work_dir, &upload, config, structurer).await;
+
+    // Always remove the working directory, success or failure.
+    let _ = tokio::fs::remove_dir_all(&work_dir).await;
+    result
+}
+
+/// The filesystem half of the conversion, split out so it can be unit-tested
+/// with a fake structurer and a synthetic upload (no DB, no LLM).
+pub(crate) async fn convert_law_in_dir(
+    work_dir: &Path,
+    upload: &Upload,
+    config: &EnrichConfig,
+    structurer: &dyn LawStructurer,
+) -> Result<GeneratedLaw> {
+    let ext = extension_for(&upload.filename, &upload.content_type);
+    let input_file = work_dir.join(format!("input.{ext}"));
+    tokio::fs::write(&input_file, &upload.bytes).await?;
+
+    // Deterministic-first text extraction, same rationale as document-convert:
+    // reliable, offline, and it keeps the untrusted binary away from the
+    // Bash-enabled LLM where the tools can handle it.
+    let source_text_path = work_dir.join(SOURCE_TEXT_FILE);
+    let extracted = try_deterministic_convert(&input_file, &ext, &source_text_path)
+        .await
+        .is_some();
+    let (source_file, source_is_text) = if extracted {
+        (SOURCE_TEXT_FILE.to_string(), true)
+    } else {
+        (format!("input.{ext}"), false)
+    };
+
+    let source_url = format!("upload://{}", sanitize_for_url(&upload.filename));
+    let prompt = build_structure_prompt(&source_file, source_is_text, &source_url);
+    structurer.structure(&prompt, work_dir, config).await?;
+
+    let output_path = work_dir.join(OUTPUT_FILE);
+    let yaml = read_output(&output_path).await?;
+    match validate_law_yaml(&yaml) {
+        Ok(meta) => Ok(GeneratedLaw { yaml, meta }),
+        Err(errors) => {
+            // One repair round: feed the validation errors back to the agent.
+            // A second failure is deterministic content trouble — the job is
+            // single-attempt, so this surfaces as a job_failed task.
+            tracing::info!(
+                errors = errors.len(),
+                "generated law YAML invalid, running repair round"
+            );
+            let repair = build_repair_prompt(&errors);
+            structurer.structure(&repair, work_dir, config).await?;
+            let yaml = read_output(&output_path).await?;
+            match validate_law_yaml(&yaml) {
+                Ok(meta) => Ok(GeneratedLaw { yaml, meta }),
+                Err(errors) => Err(PipelineError::Enrich(format!(
+                    "generated law YAML still invalid after repair round: {}",
+                    errors.join("; ")
+                ))),
+            }
+        }
+    }
+}
+
+async fn read_output(output_path: &Path) -> Result<String> {
+    let yaml = tokio::fs::read_to_string(output_path).await.map_err(|e| {
+        PipelineError::Enrich(format!(
+            "conversion produced no readable YAML at {}: {e}",
+            output_path.display()
+        ))
+    })?;
+    if yaml.trim().is_empty() {
+        return Err(PipelineError::Enrich(
+            "conversion produced empty YAML".to_string(),
+        ));
+    }
+    Ok(yaml)
+}
+
+/// Chain step, in one transaction: enqueue the task-flow enrich job with the
+/// generated base YAML as input blob, and complete the convert job. The
+/// single review task the user sees is created later by the enrich task flow
+/// (`worker::finish_enrich_task_job`, with `kind: "law_create"`).
+pub async fn finish_law_convert_job(
+    pool: &PgPool,
+    convert_job: &Job,
+    payload: &LawConvertPayload,
+    law: &GeneratedLaw,
+) -> Result<()> {
+    // Same synthetic repo-relative path convention as `request_enrich` in
+    // editor-api: the parent directory name doubles as slug for the
+    // feature-file detection in execute_enrich.
+    let yaml_path = format!("laws/{}/law.yaml", law.meta.law_id);
+    let enrich_payload = EnrichPayload {
+        law_id: law.meta.law_id.clone(),
+        yaml_path: yaml_path.clone(),
+        provider: payload.provider.clone(),
+        depth: None,
+        requested_by: payload.requested_by,
+        deliver: Some("task".to_string()),
+        traject_id: Some(payload.traject_id),
+        traject_ref: Some(payload.traject_ref.clone()),
+        source_etag: None,
+        new_law: Some(true),
+    };
+    let payload_json = serde_json::to_value(&enrich_payload)
+        .map_err(|e| PipelineError::Enrich(format!("serialize enrich payload: {e}")))?;
+
+    let mut tx = pool.begin().await?;
+    let req = CreateJobRequest::new(JobType::Enrich, &law.meta.law_id)
+        .with_traject_ref(&payload.traject_ref)
+        .with_priority(Priority::new(CHAINED_ENRICH_PRIORITY))
+        .with_payload(payload_json)
+        .with_max_attempts(3);
+    let enrich_job = job_queue::create_enrich_job_if_not_exists(&mut *tx, req).await?;
+    let Some(enrich_job) = enrich_job else {
+        // Er loopt al een actieve enrich voor deze (slug, provider, traject) —
+        // kan alleen bij een tweede upload die op dezelfde slug uitkomt.
+        // Rollback (impliciet) en laat de aanroeper dit als terminale fout met
+        // job_failed-taak afhandelen.
+        return Err(PipelineError::Enrich(format!(
+            "er loopt al een verrijking voor wet '{}' in dit traject; \
+             de nieuwe wet is niet aangemaakt",
+            law.meta.law_id
+        )));
+    };
+    tasks::insert_blob(
+        &mut *tx,
+        enrich_job.id,
+        BlobKind::Input,
+        &yaml_path,
+        &law.yaml,
+    )
+    .await?;
+    job_queue::complete_job(
+        &mut *tx,
+        convert_job.id,
+        Some(serde_json::json!({ "law_id": law.meta.law_id })),
+    )
+    .await?;
+    tx.commit().await?;
+    tracing::info!(
+        convert_job = %convert_job.id,
+        enrich_job = %enrich_job.id,
+        law_id = %law.meta.law_id,
+        layer = law.meta.regulatory_layer.as_str(),
+        "law-convert chained into enrich task job"
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::enrich::LlmProvider;
+
+    fn test_config() -> EnrichConfig {
+        EnrichConfig::for_test(LlmProvider::Claude {
+            path: "claude".into(),
+            model: None,
+        })
+    }
+
+    fn valid_yaml() -> String {
+        // Regel-voor-regel gejoined: een `\`-continuation in een gewone string
+        // stript leidende spaties en zou de YAML-indentatie slopen.
+        [
+            "---".to_string(),
+            format!("$schema: {SCHEMA_URL}"),
+            "$id: werkinstructie_toetsing".to_string(),
+            "regulatory_layer: UITVOERINGSBELEID".to_string(),
+            "publication_date: '2026-01-15'".to_string(),
+            "valid_from: '2026-02-01'".to_string(),
+            "url: upload://werkinstructie.pdf".to_string(),
+            "articles:".to_string(),
+            "  - number: '1'".to_string(),
+            "    text: De aanvraag wordt binnen acht weken beoordeeld.".to_string(),
+            "    url: 'upload://werkinstructie.pdf#1'".to_string(),
+        ]
+        .join("\n")
+            + "\n"
+    }
+
+    #[test]
+    fn payload_roundtrips_and_backcompat() {
+        let account = Uuid::new_v4();
+        let payload = LawConvertPayload {
+            upload_id: Uuid::nil(),
+            traject_id: Uuid::nil(),
+            traject_ref: "abcd1234".to_string(),
+            filename: "beleid.pdf".to_string(),
+            provider: Some("claude".to_string()),
+            requested_by: Some(account),
+            deliver: Some("task".to_string()),
+        };
+        let json = serde_json::to_value(&payload).unwrap();
+        assert_eq!(json["filename"], "beleid.pdf");
+        let back: LawConvertPayload = serde_json::from_value(json).unwrap();
+        assert_eq!(back, payload);
+        assert!(back.deliver_as_task());
+    }
+
+    #[test]
+    fn validate_accepts_valid_law() {
+        let meta = validate_law_yaml(&valid_yaml()).unwrap();
+        assert_eq!(meta.law_id, "werkinstructie_toetsing");
+        assert_eq!(meta.regulatory_layer, RegulatoryLayer::Uitvoeringsbeleid);
+        assert_eq!(meta.valid_from.to_string(), "2026-02-01");
+    }
+
+    #[test]
+    fn validate_rejects_bad_slug_layer_and_date() {
+        let yaml = [
+            "---".to_string(),
+            format!("$schema: {SCHEMA_URL}"),
+            "$id: Foute Slug".to_string(),
+            "regulatory_layer: NOTULEN".to_string(),
+            "publication_date: '2026-01-15'".to_string(),
+            "valid_from: binnenkort".to_string(),
+            "url: upload://x.pdf".to_string(),
+            "articles:".to_string(),
+            "  - number: '1'".to_string(),
+            "    text: t".to_string(),
+            "    url: 'upload://x.pdf#1'".to_string(),
+        ]
+        .join("\n");
+        let errors = validate_law_yaml(&yaml).unwrap_err();
+        assert!(errors.iter().any(|e| e.contains("$id")));
+        assert!(errors.iter().any(|e| e.contains("regulatory_layer")));
+        assert!(errors.iter().any(|e| e.contains("valid_from")));
+    }
+
+    #[test]
+    fn validate_rejects_unknown_schema() {
+        let yaml = "---\n$id: x\narticles: []\n";
+        let errors = validate_law_yaml(yaml).unwrap_err();
+        assert!(errors.iter().any(|e| e.contains("$schema")));
+    }
+
+    #[test]
+    fn prompt_names_source_and_output() {
+        let prompt = build_structure_prompt("source.md", true, "upload://beleid.pdf");
+        assert!(prompt.contains("`source.md`"));
+        assert!(prompt.contains("`law.yaml`"));
+        assert!(prompt.contains("UITVOERINGSBELEID"));
+        assert!(prompt.to_lowercase().contains("do not summarize"));
+        // Base law only — enrichment is the separate next step.
+        assert!(prompt.contains("do NOT add `machine_readable`"));
+    }
+
+    #[test]
+    fn sanitize_for_url_strips_unsafe_chars() {
+        assert_eq!(
+            sanitize_for_url("Mijn Beleid (v2).pdf"),
+            "mijn-beleid--v2-.pdf"
+        );
+        assert_eq!(sanitize_for_url(""), "document");
+    }
+
+    /// Fake structurer that writes a fixed sequence of YAML outputs, one per
+    /// call — proving the validate + repair-round orchestration.
+    struct FakeStructurer {
+        outputs: std::sync::Mutex<Vec<String>>,
+        calls: std::sync::atomic::AtomicUsize,
+    }
+
+    impl FakeStructurer {
+        fn new(outputs: Vec<String>) -> Self {
+            Self {
+                outputs: std::sync::Mutex::new(outputs),
+                calls: std::sync::atomic::AtomicUsize::new(0),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl LawStructurer for FakeStructurer {
+        async fn structure(
+            &self,
+            _prompt: &str,
+            work_dir: &Path,
+            _config: &EnrichConfig,
+        ) -> Result<()> {
+            self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            let yaml = self.outputs.lock().unwrap().remove(0);
+            std::fs::write(work_dir.join(OUTPUT_FILE), yaml).unwrap();
+            Ok(())
+        }
+    }
+
+    fn test_upload() -> Upload {
+        // A `.bin` extension no deterministic tool handles, so the structurer
+        // gets the raw-file variant of the prompt.
+        Upload {
+            filename: "beleid.bin".to_string(),
+            content_type: "application/octet-stream".to_string(),
+            bytes: b"raw bytes".to_vec(),
+        }
+    }
+
+    #[tokio::test]
+    async fn convert_returns_validated_law_first_try() {
+        let dir = tempfile::tempdir().unwrap();
+        let structurer = FakeStructurer::new(vec![valid_yaml()]);
+        let law = convert_law_in_dir(dir.path(), &test_upload(), &test_config(), &structurer)
+            .await
+            .unwrap();
+        assert_eq!(law.meta.law_id, "werkinstructie_toetsing");
+        assert_eq!(
+            law.meta.regulatory_layer,
+            RegulatoryLayer::Uitvoeringsbeleid
+        );
+        assert_eq!(
+            structurer.calls.load(std::sync::atomic::Ordering::SeqCst),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn convert_runs_one_repair_round_then_succeeds() {
+        let dir = tempfile::tempdir().unwrap();
+        let structurer = FakeStructurer::new(vec!["not: [valid law".to_string(), valid_yaml()]);
+        let law = convert_law_in_dir(dir.path(), &test_upload(), &test_config(), &structurer)
+            .await
+            .unwrap();
+        assert_eq!(law.meta.law_id, "werkinstructie_toetsing");
+        assert_eq!(
+            structurer.calls.load(std::sync::atomic::Ordering::SeqCst),
+            2
+        );
+    }
+
+    #[tokio::test]
+    async fn convert_fails_terminally_after_failed_repair() {
+        let dir = tempfile::tempdir().unwrap();
+        let structurer = FakeStructurer::new(vec![
+            "not: [valid law".to_string(),
+            "still: invalid\n".to_string(),
+        ]);
+        let err = convert_law_in_dir(dir.path(), &test_upload(), &test_config(), &structurer)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("still invalid after repair"));
+        assert_eq!(
+            structurer.calls.load(std::sync::atomic::Ordering::SeqCst),
+            2
+        );
+    }
+}

--- a/packages/pipeline/src/law_convert.rs
+++ b/packages/pipeline/src/law_convert.rs
@@ -92,19 +92,35 @@ pub struct GeneratedLaw {
 #[async_trait::async_trait]
 pub trait LawStructurer: Send + Sync {
     /// Run the agent with `prompt` in `work_dir`; the prompt names the file
-    /// the agent must write its YAML to.
-    async fn structure(&self, prompt: &str, work_dir: &Path, config: &EnrichConfig) -> Result<()>;
+    /// the agent must write its YAML to. `allow_bash` widens the toolset with
+    /// een shell — alléén nodig wanneer de agent het rauwe bestand zelf moet
+    /// converteren (de fallback zonder deterministische extractie).
+    async fn structure(
+        &self,
+        prompt: &str,
+        work_dir: &Path,
+        config: &EnrichConfig,
+        allow_bash: bool,
+    ) -> Result<()>;
 }
 
-/// Production structurer: the enrich LLM subprocess with shell access (the
-/// agent may need `pandoc`/`pdftotext` for the fallback path where no
-/// deterministic conversion was possible).
+/// Production structurer: the enrich LLM subprocess. Shell-toegang is
+/// least-privilege: de structurering zelf is Read/Write-werk op tekst; alleen
+/// de rauwe-bestand-fallback krijgt Bash (voor `pandoc`/`pdftotext`). De
+/// agent-lane mét Bash bleek op de kale Alpine-worker bovendien onbetrouwbaar
+/// (zie de document-convert-historie), dus de gewone route vermijdt hem.
 pub struct LlmLawStructurer;
 
 #[async_trait::async_trait]
 impl LawStructurer for LlmLawStructurer {
-    async fn structure(&self, prompt: &str, work_dir: &Path, config: &EnrichConfig) -> Result<()> {
-        run_llm_subprocess(&config.provider, prompt, None, work_dir, config, true).await
+    async fn structure(
+        &self,
+        prompt: &str,
+        work_dir: &Path,
+        config: &EnrichConfig,
+        allow_bash: bool,
+    ) -> Result<()> {
+        run_llm_subprocess(&config.provider, prompt, None, work_dir, config, allow_bash).await
     }
 }
 
@@ -345,7 +361,13 @@ pub(crate) async fn convert_law_in_dir(
 
     let source_url = format!("upload://{}", sanitize_for_url(&upload.filename));
     let prompt = build_structure_prompt(&source_file, source_is_text, &source_url);
-    structurer.structure(&prompt, work_dir, config).await?;
+    // Bash alléén wanneer de agent het rauwe bestand nog zelf moet
+    // converteren; op al-geëxtraheerde tekst is de structurering puur
+    // Read/Write-werk (least privilege, en de Bash-lane is op de kale
+    // Alpine-worker onbetrouwbaar gebleken).
+    structurer
+        .structure(&prompt, work_dir, config, !source_is_text)
+        .await?;
 
     let output_path = work_dir.join(OUTPUT_FILE);
     let yaml = read_output(&output_path).await?;
@@ -360,7 +382,10 @@ pub(crate) async fn convert_law_in_dir(
                 "generated law YAML invalid, running repair round"
             );
             let repair = build_repair_prompt(&errors);
-            structurer.structure(&repair, work_dir, config).await?;
+            // De reparatieronde bewerkt alleen nog `law.yaml`: nooit Bash.
+            structurer
+                .structure(&repair, work_dir, config, false)
+                .await?;
             let yaml = read_output(&output_path).await?;
             match validate_law_yaml(&yaml) {
                 Ok(meta) => Ok(GeneratedLaw { yaml, meta }),
@@ -569,18 +594,27 @@ mod tests {
     }
 
     /// Fake structurer that writes a fixed sequence of YAML outputs, one per
-    /// call — proving the validate + repair-round orchestration.
+    /// call — proving the validate + repair-round orchestration. Registreert
+    /// per aanroep ook de gevraagde Bash-toegang (least-privilege-check).
     struct FakeStructurer {
         outputs: std::sync::Mutex<Vec<String>>,
-        calls: std::sync::atomic::AtomicUsize,
+        bash_per_call: std::sync::Mutex<Vec<bool>>,
     }
 
     impl FakeStructurer {
         fn new(outputs: Vec<String>) -> Self {
             Self {
                 outputs: std::sync::Mutex::new(outputs),
-                calls: std::sync::atomic::AtomicUsize::new(0),
+                bash_per_call: std::sync::Mutex::new(Vec::new()),
             }
+        }
+
+        fn calls(&self) -> usize {
+            self.bash_per_call.lock().unwrap().len()
+        }
+
+        fn bash_flags(&self) -> Vec<bool> {
+            self.bash_per_call.lock().unwrap().clone()
         }
     }
 
@@ -591,8 +625,9 @@ mod tests {
             _prompt: &str,
             work_dir: &Path,
             _config: &EnrichConfig,
+            allow_bash: bool,
         ) -> Result<()> {
-            self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            self.bash_per_call.lock().unwrap().push(allow_bash);
             let yaml = self.outputs.lock().unwrap().remove(0);
             std::fs::write(work_dir.join(OUTPUT_FILE), yaml).unwrap();
             Ok(())
@@ -621,10 +656,10 @@ mod tests {
             law.meta.regulatory_layer,
             RegulatoryLayer::Uitvoeringsbeleid
         );
-        assert_eq!(
-            structurer.calls.load(std::sync::atomic::Ordering::SeqCst),
-            1
-        );
+        assert_eq!(structurer.calls(), 1);
+        // Rauwe .bin zonder deterministische extractie: de agent moet zelf
+        // converteren, dus Bash aan.
+        assert_eq!(structurer.bash_flags(), vec![true]);
     }
 
     #[tokio::test]
@@ -635,10 +670,9 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(law.meta.law_id, "werkinstructie_toetsing");
-        assert_eq!(
-            structurer.calls.load(std::sync::atomic::Ordering::SeqCst),
-            2
-        );
+        assert_eq!(structurer.calls(), 2);
+        // De reparatieronde bewerkt alleen law.yaml: nooit Bash.
+        assert_eq!(structurer.bash_flags(), vec![true, false]);
     }
 
     #[tokio::test]
@@ -652,9 +686,6 @@ mod tests {
             .await
             .unwrap_err();
         assert!(err.to_string().contains("still invalid after repair"));
-        assert_eq!(
-            structurer.calls.load(std::sync::atomic::Ordering::SeqCst),
-            2
-        );
+        assert_eq!(structurer.calls(), 2);
     }
 }

--- a/packages/pipeline/src/law_status.rs
+++ b/packages/pipeline/src/law_status.rs
@@ -294,12 +294,12 @@ fn fail_count_column(job_type: crate::models::JobType) -> &'static str {
     match job_type {
         crate::models::JobType::Harvest => "harvest_fail_count",
         crate::models::JobType::Enrich => "enrich_fail_count",
-        // document_convert jobs are traject-scoped, not law-scoped: they have no
-        // `law_entries` row and never go through the per-law fail-count / exhaust
-        // path (the worker fails them with plain `fail_job`). Reaching here is a
-        // programming error.
-        crate::models::JobType::DocumentConvert => {
-            unreachable!("document_convert jobs have no law-status fail counter")
+        // document_convert/law_convert jobs are traject-scoped, not law-scoped:
+        // they have no `law_entries` row and never go through the per-law
+        // fail-count / exhaust path (the worker fails them with plain
+        // `fail_job`). Reaching here is a programming error.
+        crate::models::JobType::DocumentConvert | crate::models::JobType::LawConvert => {
+            unreachable!("convert jobs have no law-status fail counter")
         }
     }
 }
@@ -366,9 +366,9 @@ where
             LawStatusValue::EnrichFailed,
             LawStatusValue::EnrichExhausted,
         ),
-        // See `fail_count_column`: document_convert is not law-scoped.
-        crate::models::JobType::DocumentConvert => {
-            unreachable!("document_convert jobs are not law-scoped and cannot be exhausted")
+        // See `fail_count_column`: convert jobs are not law-scoped.
+        crate::models::JobType::DocumentConvert | crate::models::JobType::LawConvert => {
+            unreachable!("convert jobs are not law-scoped and cannot be exhausted")
         }
     };
     // Only exhaust if status is still the corresponding failed state,

--- a/packages/pipeline/src/lib.rs
+++ b/packages/pipeline/src/lib.rs
@@ -10,6 +10,7 @@ pub mod harvest;
 pub mod harvest_request;
 pub mod health;
 pub mod job_queue;
+pub mod law_convert;
 pub mod law_status;
 pub mod models;
 pub mod tasks;

--- a/packages/pipeline/src/models.rs
+++ b/packages/pipeline/src/models.rs
@@ -13,6 +13,11 @@ pub enum JobType {
     #[sqlx(rename = "document_convert")]
     #[serde(rename = "document_convert")]
     DocumentConvert,
+    /// Convert an uploaded document (PDF/Word) to a harvested base-law YAML
+    /// and chain a task-flow enrich job on it. Scoped to a traject.
+    #[sqlx(rename = "law_convert")]
+    #[serde(rename = "law_convert")]
+    LawConvert,
 }
 
 #[derive(

--- a/packages/pipeline/src/tasks.rs
+++ b/packages/pipeline/src/tasks.rs
@@ -120,19 +120,21 @@ pub async fn count_open_tasks_for_account(pool: &PgPool, account_id: Uuid) -> Re
     Ok(count)
 }
 
-/// Eén lopende taak-flow-job voor de "Bezig"-sectie: een enrich- of
-/// document_convert-job die deze gebruiker via `deliver: "task"` heeft
-/// aangevraagd en die nog niet is afgerond (job_review/job_failed-taak
-/// bestaat pas na completion/failure).
+/// Eén lopende taak-flow-job voor de "Bezig"-sectie: een enrich-,
+/// document_convert- of law_convert-job die deze gebruiker via
+/// `deliver: "task"` heeft aangevraagd en die nog niet is afgerond
+/// (job_review/job_failed-taak bestaat pas na completion/failure).
 #[derive(Debug, Clone, sqlx::FromRow, Serialize)]
 pub struct RunningTaskJob {
     pub job_id: Uuid,
     pub job_type: JobType,
     pub law_id: String,
     pub traject_ref: Option<String>,
-    /// Doelbestand van een document_convert-job (payload `target_path`);
-    /// None voor enrich-jobs. Het `law_id`-veld draagt voor conversies een
-    /// synthetische `doc:`-sleutel, dus de weergave leest dit veld.
+    /// Weergavenaam voor conversie-jobs: het doelbestand van een
+    /// document_convert-job (payload `target_path`) of de bestandsnaam van
+    /// een law_convert-upload (payload `filename`); None voor enrich-jobs.
+    /// Het `law_id`-veld draagt voor conversies een synthetische sleutel
+    /// (`doc:`/`lawdoc:`), dus de weergave leest dit veld.
     pub target_path: Option<String>,
     pub status: JobStatus,
     pub created_at: DateTime<Utc>,
@@ -148,9 +150,10 @@ pub async fn list_running_task_jobs_for_account(
 ) -> Result<Vec<RunningTaskJob>> {
     let jobs = sqlx::query_as::<_, RunningTaskJob>(
         "SELECT id AS job_id, job_type, law_id, traject_ref, \
-                payload->>'target_path' AS target_path, status, created_at \
+                COALESCE(payload->>'target_path', payload->>'filename') AS target_path, \
+                status, created_at \
          FROM jobs \
-         WHERE job_type IN ('enrich', 'document_convert') \
+         WHERE job_type IN ('enrich', 'document_convert', 'law_convert') \
            AND status IN ('pending', 'processing') \
            AND payload->>'deliver' = 'task' \
            AND payload->>'requested_by' = $1 \

--- a/packages/pipeline/src/worker.rs
+++ b/packages/pipeline/src/worker.rs
@@ -888,7 +888,14 @@ pub async fn run_enrich_worker(config: WorkerConfig) -> Result<()> {
         // Law-convert jobs (upload → basis-wet-YAML) run before the cap gate
         // for the same reason as document-convert: interactive uploads. The
         // enrich job they chain into DOES fall under the hourly cap.
-        match process_next_law_convert_job(&pool, &enrich_config, config.job_timeout).await {
+        match process_next_law_convert_job(
+            &pool,
+            &enrich_config,
+            config.job_timeout,
+            config.orphan_timeout,
+        )
+        .await
+        {
             Ok(JobOutcome::Processed) => {
                 consecutive_resource_failures = 0;
                 current_interval = config.poll_interval;
@@ -1459,11 +1466,13 @@ async fn process_next_law_convert_job(
     pool: &PgPool,
     enrich_config: &EnrichConfig,
     job_timeout: Duration,
+    orphan_timeout: Duration,
 ) -> Result<JobOutcome> {
     let job = match job_queue::claim_job(pool, Some(JobType::LawConvert)).await? {
         Some(job) => job,
         None => return Ok(JobOutcome::Idle),
     };
+    tracing::info!(job_id = %job.id, law_id = %job.law_id, "processing law-convert job");
 
     // Malformed payload is deterministisch: terminaal falen, en de upload
     // best-effort opruimen als het id nog uit de raw payload te vissen is.
@@ -1510,18 +1519,39 @@ async fn process_next_law_convert_job(
         Some(provider) => enrich_config.with_provider_override(provider),
         None => enrich_config.clone(),
     };
-    job_config.timeout = job_timeout;
+    // De generieke orphan-reaper (reap_orphaned_jobs) kent geen heartbeat en
+    // faalt élke processing-job ouder dan orphan_timeout — bij max_attempts=1
+    // zou een trage/hangende LLM-run dus stil verdwijnen, zonder
+    // job_failed-taak. Begrens de hele conversie (beide agent-runs samen)
+    // ruim ónder de reaper-window, zodat de worker de race altijd wint en
+    // een te trage run in het zichtbare foutpad eindigt. kill_on_drop op het
+    // subprocess ruimt de agent op wanneer de buitenste timeout afgaat.
+    let reaper_margin = orphan_timeout
+        .saturating_sub(Duration::from_secs(120))
+        .max(Duration::from_secs(60));
+    let convert_deadline = job_timeout.min(reaper_margin);
+    job_config.timeout = convert_deadline;
 
-    let run_result = match law_convert::execute_law_convert(
-        pool,
-        &payload,
-        &job_config,
-        &LlmLawStructurer,
+    let run_result = match tokio::time::timeout(
+        convert_deadline,
+        law_convert::execute_law_convert(pool, &payload, &job_config, &LlmLawStructurer),
     )
     .await
     {
-        Ok(law) => law_convert::finish_law_convert_job(pool, &job, &payload, &law).await,
-        Err(e) => Err(e),
+        Err(_elapsed) => {
+            // De gedropte future komt niet meer aan zijn eigen tempdir-cleanup
+            // toe; ruim de werkdirectory hier op (pad is deterministisch).
+            let _ = tokio::fs::remove_dir_all(
+                std::env::temp_dir().join(format!("lawconvert-{}", payload.upload_id)),
+            )
+            .await;
+            Err(PipelineError::Enrich(format!(
+                "conversie-time-out na {}s (begrensd onder de reaper-window)",
+                convert_deadline.as_secs()
+            )))
+        }
+        Ok(Ok(law)) => law_convert::finish_law_convert_job(pool, &job, &payload, &law).await,
+        Ok(Err(e)) => Err(e),
     };
 
     match run_result {

--- a/packages/pipeline/src/worker.rs
+++ b/packages/pipeline/src/worker.rs
@@ -16,6 +16,7 @@ use crate::enrich::{
 use crate::error::{PipelineError, Result};
 use crate::harvest::{execute_harvest, HarvestPayload, HarvestResult, MAX_HARVEST_DEPTH};
 use crate::job_queue::{self, CreateJobRequest};
+use crate::law_convert::{self, LawConvertPayload, LlmLawStructurer};
 use crate::law_status;
 use crate::models::{JobType, LawStatusValue, Priority};
 
@@ -501,6 +502,7 @@ async fn process_next_job(
                         traject_id: None,
                         traject_ref: None,
                         source_etag: None,
+                        new_law: None,
                     };
                     let payload_json = match serde_json::to_value(&enrich_payload) {
                         Ok(json) => json,
@@ -876,6 +878,34 @@ pub async fn run_enrich_worker(config: WorkerConfig) -> Result<()> {
             Ok(JobOutcome::Idle) => { /* no document-convert job — continue to enrich */ }
             Err(e) => {
                 tracing::error!(error = %e, "error processing document-convert job");
+                current_interval = (current_interval * 2)
+                    .max(config.poll_interval)
+                    .min(config.max_poll_interval);
+                continue;
+            }
+        }
+
+        // Law-convert jobs (upload → basis-wet-YAML) run before the cap gate
+        // for the same reason as document-convert: interactive uploads. The
+        // enrich job they chain into DOES fall under the hourly cap.
+        match process_next_law_convert_job(&pool, &enrich_config, config.job_timeout).await {
+            Ok(JobOutcome::Processed) => {
+                consecutive_resource_failures = 0;
+                current_interval = config.poll_interval;
+                continue;
+            }
+            Ok(JobOutcome::ResourceExhausted) => {
+                handle_resource_exhaustion(
+                    &mut consecutive_resource_failures,
+                    config.max_consecutive_resource_failures,
+                    "law-convert",
+                );
+                current_interval = config.poll_interval;
+                continue;
+            }
+            Ok(JobOutcome::Idle) => { /* no law-convert job, continue to enrich */ }
+            Err(e) => {
+                tracing::error!(error = %e, "error processing law-convert job");
                 current_interval = (current_interval * 2)
                     .max(config.poll_interval)
                     .min(config.max_poll_interval);
@@ -1420,6 +1450,138 @@ async fn run_document_convert(
     Ok(false)
 }
 
+/// Verwerk één `law_convert`-job: geüpload document → gevalideerde
+/// basis-wet-YAML → geketende taak-flow-enrich-job (het kettingstuk zit in
+/// `law_convert::finish_law_convert_job`). Spiegel van
+/// [`process_next_document_convert_job`]: single-attempt, terminale fouten
+/// krijgen atomair een `job_failed`-taak en de upload-bytes worden opgeruimd.
+async fn process_next_law_convert_job(
+    pool: &PgPool,
+    enrich_config: &EnrichConfig,
+    job_timeout: Duration,
+) -> Result<JobOutcome> {
+    let job = match job_queue::claim_job(pool, Some(JobType::LawConvert)).await? {
+        Some(job) => job,
+        None => return Ok(JobOutcome::Idle),
+    };
+
+    // Malformed payload is deterministisch: terminaal falen, en de upload
+    // best-effort opruimen als het id nog uit de raw payload te vissen is.
+    let payload: LawConvertPayload = match job
+        .payload
+        .as_ref()
+        .ok_or_else(|| PipelineError::Worker("law_convert job has no payload".to_string()))
+        .and_then(|p| {
+            serde_json::from_value(p.clone())
+                .map_err(|e| PipelineError::Worker(format!("payload deserialization failed: {e}")))
+        }) {
+        Ok(payload) => payload,
+        Err(e) => {
+            let msg = format!("invalid law_convert payload: {e}");
+            tracing::error!(job_id = %job.id, error = %msg);
+            if let Some(id) = job
+                .payload
+                .as_ref()
+                .and_then(|p| p.get("upload_id"))
+                .and_then(|v| v.as_str())
+                .and_then(|s| uuid::Uuid::parse_str(s).ok())
+            {
+                let _ = document_convert::delete_upload(pool, id).await;
+            }
+            job_queue::fail_job_terminal(pool, job.id, Some(serde_json::json!({ "error": msg })))
+                .await?;
+            return Ok(JobOutcome::Processed);
+        }
+    };
+
+    // Law-convert kent alléén de taak-flow: zonder `requested_by` is er geen
+    // assignee voor de uiteindelijke review-taak, en zonder `deliver: task`
+    // is er geen aflever-pad (er bestaat geen direct-push-variant).
+    if !payload.deliver_as_task() || payload.requested_by.is_none() {
+        let msg = "law_convert vereist deliver=task met requested_by".to_string();
+        tracing::error!(job_id = %job.id, error = %msg);
+        let _ = document_convert::delete_upload(pool, payload.upload_id).await;
+        job_queue::fail_job_terminal(pool, job.id, Some(serde_json::json!({ "error": msg })))
+            .await?;
+        return Ok(JobOutcome::Processed);
+    }
+
+    let mut job_config = match &payload.provider {
+        Some(provider) => enrich_config.with_provider_override(provider),
+        None => enrich_config.clone(),
+    };
+    job_config.timeout = job_timeout;
+
+    let run_result = match law_convert::execute_law_convert(
+        pool,
+        &payload,
+        &job_config,
+        &LlmLawStructurer,
+    )
+    .await
+    {
+        Ok(law) => law_convert::finish_law_convert_job(pool, &job, &payload, &law).await,
+        Err(e) => Err(e),
+    };
+
+    match run_result {
+        Ok(()) => {
+            // De keten staat (enrich-job + input-blob + complete, atomair);
+            // alleen de transiënte upload-bytes resten nog.
+            if let Err(e) = document_convert::delete_upload(pool, payload.upload_id).await {
+                tracing::warn!(job_id = %job.id, error = %e, "failed to delete law upload after success");
+            }
+            Ok(JobOutcome::Processed)
+        }
+        Err(e) => {
+            let msg = e.to_string();
+            tracing::error!(job_id = %job.id, error = %msg, "law-convert job failed");
+            // Zelfde atomaire fail+taak-transactie als document-convert:
+            // single-attempt, dus terminaal, en de aanvrager moet het zien.
+            let fail_result: Result<()> = async {
+                let mut tx = pool.begin().await?;
+                job_queue::fail_job_terminal(
+                    &mut *tx,
+                    job.id,
+                    Some(serde_json::json!({ "error": msg.clone() })),
+                )
+                .await?;
+                if let Some(account_id) = payload.requested_by {
+                    crate::tasks::create_task(
+                        &mut *tx,
+                        crate::tasks::NewTask {
+                            task_type: crate::tasks::TaskType::JobFailed,
+                            assignee_account_id: Some(account_id),
+                            traject_id: Some(payload.traject_id),
+                            job_id: Some(job.id),
+                            title: format!("Conversie naar wet mislukt: {}", payload.filename),
+                            payload: Some(serde_json::json!({
+                                "traject_ref": payload.traject_ref,
+                                "filename": payload.filename,
+                                "error": msg.clone(),
+                            })),
+                        },
+                    )
+                    .await?;
+                }
+                tx.commit().await?;
+                Ok(())
+            }
+            .await;
+            // Upload-bytes alleen weg wanneer de fail+taak echt gecommit is
+            // (zelfde afweging als het document-convert-pad).
+            if fail_result.is_ok() {
+                if let Err(e) = document_convert::delete_upload(pool, payload.upload_id).await {
+                    tracing::warn!(job_id = %job.id, error = %e, "failed to delete law upload after terminal failure");
+                }
+            }
+            fail_result?;
+
+            Ok(outcome_for_error(&msg))
+        }
+    }
+}
+
 /// Taak-flow: materialiseer de input-blob(s) van een enrich-taak-job in een
 /// eigen werkdirectory, zodat `execute_enrich` zonder git-checkout kan
 /// draaien. Retourneert de workdir-root (TempDir houdt hem in leven).
@@ -1485,6 +1647,25 @@ pub async fn finish_enrich_task_job(
         .await?;
     }
     job_queue::complete_job(&mut *tx, job.id, result_json).await?;
+    // Een nieuwe wet (geketend vanuit law_convert) krijgt een eigen titel en
+    // een `kind`-discriminator, zodat de editor het voorstel als aan te maken
+    // wet behandelt (create-pad) i.p.v. als wijziging van een bestaande.
+    let new_law = payload.new_law == Some(true);
+    let mut task_payload = serde_json::json!({
+        "law_id": payload.law_id,
+        "yaml_path": payload.yaml_path,
+        "traject_ref": payload.traject_ref,
+        "source_etag": payload.source_etag,
+        "provider": payload.provider,
+    });
+    if new_law {
+        task_payload["kind"] = serde_json::json!("law_create");
+    }
+    let title = if new_law {
+        format!("Nieuwe wet beoordelen: {}", payload.law_id)
+    } else {
+        format!("Verrijking beoordelen: {}", payload.law_id)
+    };
     crate::tasks::create_task(
         &mut *tx,
         crate::tasks::NewTask {
@@ -1492,14 +1673,8 @@ pub async fn finish_enrich_task_job(
             assignee_account_id: payload.requested_by,
             traject_id: payload.traject_id,
             job_id: Some(job.id),
-            title: format!("Verrijking beoordelen: {}", payload.law_id),
-            payload: Some(serde_json::json!({
-                "law_id": payload.law_id,
-                "yaml_path": payload.yaml_path,
-                "traject_ref": payload.traject_ref,
-                "source_etag": payload.source_etag,
-                "provider": payload.provider,
-            })),
+            title,
+            payload: Some(task_payload),
         },
     )
     .await?;
@@ -1567,6 +1742,14 @@ async fn finalize_failed_task_job_tx(
         .map_err(|e| PipelineError::Enrich(format!("invalid enrich payload: {e}")))?;
 
     crate::tasks::delete_blobs_for_job(&mut **tx, job.id).await?;
+    let title = if payload.new_law == Some(true) {
+        // De geketende enrich van een geüploade wet: de gebruiker kent geen
+        // "verrijking", alleen de wet die er niet kwam. De input-blob (de
+        // basis-YAML) gaat hier mee weg; opnieuw uploaden is het herstel.
+        format!("Wet aanmaken mislukt: {}", payload.law_id)
+    } else {
+        format!("Verrijking mislukt: {}", payload.law_id)
+    };
     crate::tasks::create_task(
         &mut **tx,
         crate::tasks::NewTask {
@@ -1574,7 +1757,7 @@ async fn finalize_failed_task_job_tx(
             assignee_account_id: payload.requested_by,
             traject_id: payload.traject_id,
             job_id: Some(job.id),
-            title: format!("Verrijking mislukt: {}", payload.law_id),
+            title,
             payload: Some(serde_json::json!({
                 "law_id": payload.law_id,
                 "traject_ref": payload.traject_ref,

--- a/packages/pipeline/tests/law_convert_tests.rs
+++ b/packages/pipeline/tests/law_convert_tests.rs
@@ -1,0 +1,287 @@
+//! DB-tests voor de law-convert-keten: upload → basis-wet-YAML → geketende
+//! taak-flow-enrich-job → law_create-review-taak. Patroon tasks_tests.rs.
+
+use serde_json::json;
+
+use regelrecht_pipeline::job_queue::{self, CreateJobRequest};
+use regelrecht_pipeline::law_convert::{
+    finish_law_convert_job, GeneratedLaw, LawConvertPayload, ValidatedLawMeta,
+};
+use regelrecht_pipeline::models::{JobStatus, JobType};
+use regelrecht_pipeline::tasks::{self, BlobKind};
+use regelrecht_pipeline::test_utils::TestDb;
+use regelrecht_pipeline::worker::finish_enrich_task_job;
+use regelrecht_shared::RegulatoryLayer;
+
+/// Maak een account + traject om FK's te vullen (patroon tasks_tests.rs).
+async fn seed_account_and_traject(db: &TestDb) -> (uuid::Uuid, uuid::Uuid) {
+    let (account_id,): (uuid::Uuid,) = sqlx::query_as(
+        "INSERT INTO accounts (person_sub, email, name) \
+         VALUES ('sub-test', 'tester@example.org', 'Test Persoon') RETURNING id",
+    )
+    .fetch_one(&db.pool)
+    .await
+    .unwrap();
+    let (traject_id,): (uuid::Uuid,) = sqlx::query_as(
+        "INSERT INTO trajects (name, created_by) VALUES ('Testtraject', $1) RETURNING id",
+    )
+    .bind(account_id)
+    .fetch_one(&db.pool)
+    .await
+    .unwrap();
+    (account_id, traject_id)
+}
+
+fn convert_payload(
+    upload_id: uuid::Uuid,
+    traject_id: uuid::Uuid,
+    account_id: uuid::Uuid,
+) -> LawConvertPayload {
+    LawConvertPayload {
+        upload_id,
+        traject_id,
+        traject_ref: "testtraject-abcd1234".to_string(),
+        filename: "beleid.pdf".to_string(),
+        provider: Some("claude".to_string()),
+        requested_by: Some(account_id),
+        deliver: Some("task".to_string()),
+    }
+}
+
+fn generated_law() -> GeneratedLaw {
+    GeneratedLaw {
+        yaml: "$id: werkinstructie_toetsing\narticles: []\n".to_string(),
+        meta: ValidatedLawMeta {
+            law_id: "werkinstructie_toetsing".to_string(),
+            regulatory_layer: RegulatoryLayer::Uitvoeringsbeleid,
+            valid_from: chrono::NaiveDate::from_ymd_opt(2026, 2, 1).unwrap(),
+        },
+    }
+}
+
+async fn create_and_claim_convert_job(
+    db: &TestDb,
+    payload: &LawConvertPayload,
+) -> regelrecht_pipeline::models::Job {
+    job_queue::create_job(
+        &db.pool,
+        CreateJobRequest::new(
+            JobType::LawConvert,
+            "lawdoc:testtraject-abcd1234/beleid.pdf",
+        )
+        .with_traject_ref("testtraject-abcd1234")
+        .with_payload(serde_json::to_value(payload).unwrap())
+        .with_max_attempts(1),
+    )
+    .await
+    .unwrap();
+    // Claim zodat complete_job ('processing' vereist) slaagt.
+    job_queue::claim_job(&db.pool, Some(JobType::LawConvert))
+        .await
+        .unwrap()
+        .unwrap()
+}
+
+#[tokio::test]
+async fn test_finish_law_convert_job_chains_enrich_with_input_blob() {
+    let db = TestDb::new().await;
+    let (account_id, traject_id) = seed_account_and_traject(&db).await;
+    let payload = convert_payload(uuid::Uuid::new_v4(), traject_id, account_id);
+    let job = create_and_claim_convert_job(&db, &payload).await;
+
+    finish_law_convert_job(&db.pool, &job, &payload, &generated_law())
+        .await
+        .unwrap();
+
+    // Convert-job completed.
+    let done = job_queue::get_job(&db.pool, job.id).await.unwrap();
+    assert_eq!(done.status, JobStatus::Completed);
+
+    // Geketende enrich-job met taak-flow-payload en new_law-marker.
+    let enrich = job_queue::claim_job(&db.pool, Some(JobType::Enrich))
+        .await
+        .unwrap()
+        .expect("geketende enrich-job aanwezig");
+    assert_eq!(enrich.law_id, "werkinstructie_toetsing");
+    // `traject_ref` is een kolom (geen veld op `Job`); direct uit de rij lezen.
+    let (row_ref,): (Option<String>,) =
+        sqlx::query_as("SELECT traject_ref FROM jobs WHERE id = $1")
+            .bind(enrich.id)
+            .fetch_one(&db.pool)
+            .await
+            .unwrap();
+    assert_eq!(row_ref.as_deref(), Some("testtraject-abcd1234"));
+    let enrich_payload = enrich.payload.clone().unwrap();
+    assert_eq!(enrich_payload["deliver"], "task");
+    assert_eq!(enrich_payload["new_law"], true);
+    assert_eq!(
+        enrich_payload["requested_by"],
+        json!(account_id.to_string())
+    );
+
+    // De basis-YAML rijdt mee als input-blob op het synthetische pad.
+    let inputs = tasks::load_blobs(&db.pool, enrich.id, BlobKind::Input)
+        .await
+        .unwrap();
+    assert_eq!(inputs.len(), 1);
+    assert_eq!(inputs[0].path, "laws/werkinstructie_toetsing/law.yaml");
+    assert_eq!(
+        inputs[0].content,
+        "$id: werkinstructie_toetsing\narticles: []\n"
+    );
+}
+
+#[tokio::test]
+async fn test_finish_law_convert_job_conflicts_on_running_enrich() {
+    let db = TestDb::new().await;
+    let (account_id, traject_id) = seed_account_and_traject(&db).await;
+
+    // Al een actieve enrich voor dezelfde (slug, provider, traject).
+    job_queue::create_job(
+        &db.pool,
+        CreateJobRequest::new(JobType::Enrich, "werkinstructie_toetsing")
+            .with_traject_ref("testtraject-abcd1234")
+            .with_payload(json!({
+                "law_id": "werkinstructie_toetsing",
+                "yaml_path": "laws/werkinstructie_toetsing/law.yaml",
+                "provider": "claude",
+            })),
+    )
+    .await
+    .unwrap();
+
+    let payload = convert_payload(uuid::Uuid::new_v4(), traject_id, account_id);
+    let job = create_and_claim_convert_job(&db, &payload).await;
+
+    let err = finish_law_convert_job(&db.pool, &job, &payload, &generated_law())
+        .await
+        .unwrap_err();
+    assert!(err.to_string().contains("loopt al een verrijking"));
+
+    // Rollback: de convert-job is NIET completed (de aanroeper faalt hem
+    // daarna terminaal met een job_failed-taak).
+    let still = job_queue::get_job(&db.pool, job.id).await.unwrap();
+    assert_eq!(still.status, JobStatus::Processing);
+}
+
+#[tokio::test]
+async fn test_finish_enrich_task_job_new_law_creates_law_create_task() {
+    let db = TestDb::new().await;
+    let (account_id, traject_id) = seed_account_and_traject(&db).await;
+    job_queue::create_job(
+        &db.pool,
+        CreateJobRequest::new(JobType::Enrich, "werkinstructie_toetsing").with_payload(json!({
+            "law_id": "werkinstructie_toetsing",
+            "yaml_path": "laws/werkinstructie_toetsing/law.yaml",
+            "provider": "claude",
+            "requested_by": account_id,
+            "deliver": "task",
+            "traject_id": traject_id,
+            "traject_ref": "testtraject-abcd1234",
+            "new_law": true
+        })),
+    )
+    .await
+    .unwrap();
+    let job = job_queue::claim_job(&db.pool, Some(JobType::Enrich))
+        .await
+        .unwrap()
+        .unwrap();
+
+    let dir = tempfile::tempdir().unwrap();
+    let law_abs = dir.path().join("laws/werkinstructie_toetsing/law.yaml");
+    tokio::fs::create_dir_all(law_abs.parent().unwrap())
+        .await
+        .unwrap();
+    tokio::fs::write(&law_abs, "verrijkt: ja").await.unwrap();
+
+    finish_enrich_task_job(&db.pool, &job, dir.path(), &[law_abs], None)
+        .await
+        .unwrap();
+
+    let open = tasks::list_open_tasks_for_account(&db.pool, account_id)
+        .await
+        .unwrap();
+    assert_eq!(open.len(), 1);
+    assert_eq!(open[0].task_type, "job_review");
+    assert_eq!(
+        open[0].title,
+        "Nieuwe wet beoordelen: werkinstructie_toetsing"
+    );
+    let task_payload = open[0].payload.as_ref().unwrap();
+    assert_eq!(task_payload["kind"], "law_create");
+    assert_eq!(task_payload["law_id"], "werkinstructie_toetsing");
+    assert_eq!(task_payload["traject_ref"], "testtraject-abcd1234");
+}
+
+#[tokio::test]
+async fn test_cleanup_orphaned_uploads_spares_pending_law_convert_upload() {
+    let db = TestDb::new().await;
+    let (account_id, traject_id) = seed_account_and_traject(&db).await;
+
+    // Upload-rij, kunstmatig oud zodat de 15-min-grace niet beschermt.
+    let (upload_id,): (uuid::Uuid,) = sqlx::query_as(
+        "INSERT INTO document_uploads (traject_ref, filename, content_type, bytes, created_at) \
+         VALUES ('testtraject-abcd1234', 'beleid.pdf', 'application/pdf', $1, \
+                 now() - interval '1 hour') RETURNING id",
+    )
+    .bind(b"pdf-bytes".to_vec())
+    .fetch_one(&db.pool)
+    .await
+    .unwrap();
+
+    let payload = convert_payload(upload_id, traject_id, account_id);
+    job_queue::create_job(
+        &db.pool,
+        CreateJobRequest::new(
+            JobType::LawConvert,
+            "lawdoc:testtraject-abcd1234/beleid.pdf",
+        )
+        .with_traject_ref("testtraject-abcd1234")
+        .with_payload(serde_json::to_value(&payload).unwrap())
+        .with_max_attempts(1),
+    )
+    .await
+    .unwrap();
+
+    // Een wachtende law_convert-job houdt zijn upload vast.
+    regelrecht_pipeline::document_convert::cleanup_orphaned_uploads(&db.pool)
+        .await
+        .unwrap();
+    let (count,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM document_uploads WHERE id = $1")
+        .bind(upload_id)
+        .fetch_one(&db.pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        count, 1,
+        "upload van een actieve law_convert-job blijft staan"
+    );
+}
+
+#[tokio::test]
+async fn test_running_task_jobs_include_law_convert_with_filename() {
+    let db = TestDb::new().await;
+    let (account_id, traject_id) = seed_account_and_traject(&db).await;
+    let payload = convert_payload(uuid::Uuid::new_v4(), traject_id, account_id);
+    job_queue::create_job(
+        &db.pool,
+        CreateJobRequest::new(
+            JobType::LawConvert,
+            "lawdoc:testtraject-abcd1234/beleid.pdf",
+        )
+        .with_traject_ref("testtraject-abcd1234")
+        .with_payload(serde_json::to_value(&payload).unwrap())
+        .with_max_attempts(1),
+    )
+    .await
+    .unwrap();
+
+    let running = tasks::list_running_task_jobs_for_account(&db.pool, account_id)
+        .await
+        .unwrap();
+    assert_eq!(running.len(), 1);
+    assert_eq!(running[0].job_type, JobType::LawConvert);
+    // Weergavenaam: de bestandsnaam (COALESCE op payload.filename).
+    assert_eq!(running[0].target_path.as_deref(), Some("beleid.pdf"));
+}


### PR DESCRIPTION
## What

Inside a traject (and only there), the left sidebar gets a **+** button under the law list. It uploads a PDF/DOC/DOCX document that is converted into a harvested base-law YAML, automatically enriched, and delivered as a single review task. Approving the task (save in the editor) commits the law into the traject repository.

The uploaded document is not necessarily a formal law: it can be ministry uitvoeringsbeleid, beleidsregels, or werkinstructies. The converter interprets the correct `regulatory_layer` itself, so the law lands at the right corpus path (`regulation/nl/{layer}/{$id}/{valid_from}.yaml`).

## How

**Pipeline** (`law_convert` job, migration 0030)
- Deterministic text extraction first (`pandoc`/`pdftotext`, same as document-convert), then an LLM agent structures the text into a schema-conformant base-law YAML (picks `regulatory_layer`, `$id` slug, `valid_from`; verbatim article text; no `machine_readable`).
- The produced YAML is validated in Rust against the JSON schema (engine `validate` feature) with one repair round.
- On success the job **chains**: in one transaction it enqueues the existing task-flow enrich job with the base YAML as input blob (`EnrichPayload.new_law`). The single review task the user sees comes from the existing enrich task flow, with `kind: law_create` and its own titles.
- Single-attempt like document-convert; failures surface as a `job_failed` task. Orphaned-upload GC and the running-jobs list now cover `law_convert` too.

**editor-api**
- `POST /api/trajects/{ref}/corpus/laws/upload`: multipart upload (same extension allowlist and per-account task-job cap as the other task flows), enqueues the `law_convert` job.
- `POST /api/trajects/{ref}/corpus/laws`: the approve step. `save_law` (PUT) can only write laws that already exist in the index, so a new law needs this create path: full schema validation, path derived server-side from the validated body, 409 on an existing `$id`, traject-corpus cache invalidated after persist.

**frontend**
- Plus button under the law sections in the sidebar (`v-if="activeTrajectRef"`), reusing the `useDocumentUpload` plumbing and the existing upload-error modal pattern.
- `law_create` review flow in the editor: the law 404s (it does not exist yet), so the proposal is seeded wholesale (`useLaw.seedFromYaml`) and saving goes through the create path (`useLaw.createLaw`); rejecting routes back to Home. Running conversions show up in the Taken panel.

## Tests

- Pipeline: unit tests for payload/validation/repair-round orchestration; DB tests for the chain transaction (enrich job + input blob + dedup conflict), the `law_create` task, upload GC, and the running-jobs list.
- editor-api tests pass locally (not run in CI).
- Frontend: vitest for `reviewTarget` (law_create), `seedFromYaml`/`createLaw`, and the adjusted LibraryView upload wiring.
- `just check` green; full frontend suite green.

## Not in v1 (follow-ups)

- If the chained enrichment fails terminally, the base YAML is lost (re-upload is the retry); delivering the unenriched base law as a fallback review task is a follow-up.
- No cancel endpoint for a running conversion; rejecting the review task commits nothing.