### PR TITLE
fix(pipeline): reaped task-flow jobs no longer vanish silently

### DIFF
--- a/packages/pipeline/src/job_queue.rs
+++ b/packages/pipeline/src/job_queue.rs
@@ -36,17 +36,19 @@ fn to_pg_interval(duration: Duration) -> Result<PgInterval> {
         .map_err(|_| PipelineError::InvalidInput(format!("invalid interval: {duration:?}")))
 }
 
-/// Internal row type for the reaper CTE result.
-#[derive(sqlx::FromRow)]
-struct ReapedRow {
-    #[allow(dead_code)]
-    id: Uuid,
-    #[allow(dead_code)]
-    law_id: String,
-    #[allow(dead_code)]
-    job_type: JobType,
-    #[allow(dead_code)]
-    status: JobStatus,
+/// Een door de reaper geraakte job. `status` is de NIEUWE status: `Pending`
+/// wanneer er nog pogingen over waren (her-poging), `Failed` bij terminaal.
+/// De payload rijdt mee zodat de aanroeper voor terminaal gefaalde
+/// taak-flow-jobs alsnog een `job_failed`-taak kan aanmaken — zonder die
+/// nazorg verdwijnt zo'n job stil uit de "Bezig"-lijst (zie
+/// `tasks::notify_reaped_task_jobs`).
+#[derive(Debug, sqlx::FromRow)]
+pub struct ReapedJob {
+    pub id: Uuid,
+    pub law_id: String,
+    pub job_type: JobType,
+    pub status: JobStatus,
+    pub payload: Option<serde_json::Value>,
 }
 
 pub struct CreateJobRequest {
@@ -362,16 +364,22 @@ where
 /// (e.g., the worker crashed). If the job still has retries left, it is reset
 /// to 'pending'; otherwise it is marked 'failed'.
 ///
-/// Returns the number of reaped jobs.
+/// Returns the reaped jobs (atomically claimed by THIS caller: de UPDATE …
+/// RETURNING geeft elke rij aan precies één concurrent reaper), zodat de
+/// aanroeper nazorg kan doen — met name `tasks::notify_reaped_task_jobs`
+/// voor terminaal gefaalde taak-flow-jobs.
 #[tracing::instrument(skip(executor))]
-pub async fn reap_orphaned_jobs<'e, E>(executor: E, timeout: std::time::Duration) -> Result<u64>
+pub async fn reap_orphaned_jobs<'e, E>(
+    executor: E,
+    timeout: std::time::Duration,
+) -> Result<Vec<ReapedJob>>
 where
     E: sqlx::PgExecutor<'e>,
 {
     let timeout_interval = sqlx::postgres::types::PgInterval::try_from(timeout)
         .map_err(|_| PipelineError::InvalidInput(format!("invalid reaper timeout: {timeout:?}")))?;
 
-    let reaped_rows = sqlx::query_as::<_, ReapedRow>(
+    let reaped_rows = sqlx::query_as::<_, ReapedJob>(
         r#"
         WITH reaped AS (
             UPDATE jobs
@@ -386,20 +394,22 @@ where
                 END
             WHERE status = 'processing'
               AND started_at < now() - $1::interval
-            RETURNING id, law_id, job_type, status
+            RETURNING id, law_id, job_type, status, payload
         )
-        SELECT id, law_id, job_type, status FROM reaped
+        SELECT id, law_id, job_type, status, payload FROM reaped
         "#,
     )
     .bind(timeout_interval)
     .fetch_all(executor)
     .await?;
 
-    let count = reaped_rows.len() as u64;
-    if count > 0 {
-        tracing::warn!(count, "reaped orphaned jobs stuck in processing");
+    if !reaped_rows.is_empty() {
+        tracing::warn!(
+            count = reaped_rows.len(),
+            "reaped orphaned jobs stuck in processing"
+        );
     }
-    Ok(count)
+    Ok(reaped_rows)
 }
 
 /// Create a harvest job only if no active (pending/processing) harvest job

--- a/packages/pipeline/src/tasks.rs
+++ b/packages/pipeline/src/tasks.rs
@@ -236,6 +236,105 @@ pub async fn open_document_task_target_paths(
     Ok(rows.into_iter().filter_map(|(p,)| p).collect())
 }
 
+/// Maak `job_failed`-taken voor door de reaper TERMINAAL gefaalde
+/// taak-flow-jobs (payload `deliver: "task"` met een `requested_by`).
+///
+/// Zonder deze nazorg verdwijnt zo'n job stil: de "Bezig"-regel in het
+/// takenpaneel verdwijnt en de aanvrager krijgt nooit te zien dat er iets
+/// misging (waargenomen bij trage law-convert-runs, maar het gat gold voor
+/// álle taak-flow-jobtypen). Her-pogingen (status terug naar pending) slaan
+/// we over: die komen gewoon opnieuw langs. Ruimt per gefaalde job ook de
+/// job-blobs op (patroon `finalize_failed_task_job_tx`). Best-effort per
+/// job: één mislukte taak-insert mag de reaper-loop niet stoppen.
+pub async fn notify_reaped_task_jobs(
+    pool: &PgPool,
+    reaped: &[crate::job_queue::ReapedJob],
+) -> Result<()> {
+    for job in reaped {
+        if job.status != JobStatus::Failed {
+            continue;
+        }
+        let Some(payload) = job.payload.as_ref() else {
+            continue;
+        };
+        if payload.get("deliver").and_then(|v| v.as_str()) != Some("task") {
+            continue;
+        }
+        let Some(assignee) = payload
+            .get("requested_by")
+            .and_then(|v| v.as_str())
+            .and_then(|s| Uuid::parse_str(s).ok())
+        else {
+            continue;
+        };
+        let traject_id = payload
+            .get("traject_id")
+            .and_then(|v| v.as_str())
+            .and_then(|s| Uuid::parse_str(s).ok());
+        let str_field = |key: &str| payload.get(key).and_then(|v| v.as_str());
+
+        let title = match job.job_type {
+            // Harvest-jobs zijn nooit taak-flow; de deliver-check hierboven
+            // filtert ze al, dit is een expliciet vangnet.
+            JobType::Harvest => continue,
+            JobType::Enrich => {
+                let law_id = str_field("law_id").unwrap_or(&job.law_id);
+                if payload.get("new_law").and_then(|v| v.as_bool()) == Some(true) {
+                    format!("Wet aanmaken mislukt: {law_id}")
+                } else {
+                    format!("Verrijking mislukt: {law_id}")
+                }
+            }
+            JobType::DocumentConvert => format!(
+                "Conversie mislukt: {}",
+                str_field("target_path").unwrap_or("werkdocument")
+            ),
+            JobType::LawConvert => format!(
+                "Conversie naar wet mislukt: {}",
+                str_field("filename").unwrap_or("document")
+            ),
+        };
+
+        let mut task_payload = serde_json::json!({
+            "error": "De verwerking duurde te lang of de worker is herstart; \
+                      de job is afgebroken.",
+        });
+        for key in ["traject_ref", "law_id", "target_path", "filename"] {
+            if let Some(v) = str_field(key) {
+                task_payload[key] = serde_json::json!(v);
+            }
+        }
+
+        let result: Result<()> = async {
+            let mut tx = pool.begin().await?;
+            delete_blobs_for_job(&mut *tx, job.id).await?;
+            create_task(
+                &mut *tx,
+                NewTask {
+                    task_type: TaskType::JobFailed,
+                    assignee_account_id: Some(assignee),
+                    traject_id,
+                    job_id: Some(job.id),
+                    title,
+                    payload: Some(task_payload),
+                },
+            )
+            .await?;
+            tx.commit().await?;
+            Ok(())
+        }
+        .await;
+        if let Err(e) = result {
+            tracing::warn!(
+                job_id = %job.id,
+                error = %e,
+                "job_failed-taak voor gereapte taak-flow-job aanmaken mislukt"
+            );
+        }
+    }
+    Ok(())
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BlobKind {
     Input,

--- a/packages/pipeline/src/worker.rs
+++ b/packages/pipeline/src/worker.rs
@@ -144,8 +144,18 @@ fn spawn_reaper(
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         loop {
-            if let Err(e) = job_queue::reap_orphaned_jobs(&pool, orphan_timeout).await {
-                tracing::warn!(error = %e, "failed to reap orphaned jobs");
+            match job_queue::reap_orphaned_jobs(&pool, orphan_timeout).await {
+                Ok(reaped) => {
+                    // Terminaal gefaalde taak-flow-jobs krijgen alsnog een
+                    // job_failed-taak; zonder dit verdwijnt de "Bezig"-regel
+                    // stil en hoort de aanvrager nooit dat het misging.
+                    if let Err(e) = crate::tasks::notify_reaped_task_jobs(&pool, &reaped).await {
+                        tracing::warn!(error = %e, "failed to create tasks for reaped jobs");
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "failed to reap orphaned jobs");
+                }
             }
             // GC upload bytes orphaned when a worker died mid-conversion: the
             // generic reaper above fails such a job without running the
@@ -860,7 +870,14 @@ pub async fn run_enrich_worker(config: WorkerConfig) -> Result<()> {
         // interactive, user-initiated uploads (naturally rate-limited) and must
         // not be blocked when bulk enrichment has hit its budget cap. They still
         // share this worker's LLM CLI environment and OAuth token.
-        match process_next_document_convert_job(&pool, &enrich_config, config.job_timeout).await {
+        match process_next_document_convert_job(
+            &pool,
+            &enrich_config,
+            config.job_timeout,
+            config.orphan_timeout,
+        )
+        .await
+        {
             Ok(JobOutcome::Processed) => {
                 consecutive_resource_failures = 0;
                 current_interval = config.poll_interval;
@@ -1273,6 +1290,7 @@ async fn process_next_document_convert_job(
     pool: &PgPool,
     enrich_config: &EnrichConfig,
     job_timeout: Duration,
+    orphan_timeout: Duration,
 ) -> Result<JobOutcome> {
     let job = match job_queue::claim_job(pool, Some(JobType::DocumentConvert)).await? {
         Some(job) => job,
@@ -1325,14 +1343,21 @@ async fn process_next_document_convert_job(
     }
 
     // Apply the payload's provider override (if any) and bound the run by the
-    // worker's job timeout, mirroring the enrich path.
+    // worker's job timeout, mirroring the enrich path. Net als law-convert
+    // begrensd ónder de reaper-window: de agent-fallback kan traag zijn, en
+    // een gereapte single-attempt-job zou anders stil verdwijnen — de
+    // begrenzing laat een te trage run in het zichtbare foutpad eindigen.
     let mut job_config = match &payload.provider {
         Some(provider) => enrich_config.with_provider_override(provider),
         None => enrich_config.clone(),
     };
-    job_config.timeout = job_timeout;
+    let reaper_margin = orphan_timeout
+        .saturating_sub(Duration::from_secs(120))
+        .max(Duration::from_secs(60));
+    let convert_deadline = job_timeout.min(reaper_margin);
+    job_config.timeout = convert_deadline;
 
-    match run_document_convert(pool, &job, &payload, &job_config).await {
+    match run_document_convert(pool, &job, &payload, &job_config, convert_deadline).await {
         Ok(true) => {
             // Taak-flow: `finish_document_convert_task_job` already inserted the
             // result-blob, completed the job, and created the review-taak,
@@ -1445,10 +1470,29 @@ async fn run_document_convert(
     job: &crate::models::Job,
     payload: &DocumentConvertPayload,
     config: &EnrichConfig,
+    convert_deadline: Duration,
 ) -> Result<bool> {
-    let markdown =
-        document_convert::execute_document_convert(pool, payload, config, &LlmDocumentConverter)
-            .await?;
+    // Buitenste begrenzing ónder de reaper-window (zie de aanroeper): de
+    // gedropte future komt niet meer aan zijn eigen tempdir-cleanup toe, dus
+    // die doen we hier; kill_on_drop ruimt het agent-subprocess op.
+    let markdown = match tokio::time::timeout(
+        convert_deadline,
+        document_convert::execute_document_convert(pool, payload, config, &LlmDocumentConverter),
+    )
+    .await
+    {
+        Err(_elapsed) => {
+            let _ = tokio::fs::remove_dir_all(
+                std::env::temp_dir().join(format!("docconvert-{}", payload.upload_id)),
+            )
+            .await;
+            return Err(PipelineError::Enrich(format!(
+                "conversie-time-out na {}s (begrensd onder de reaper-window)",
+                convert_deadline.as_secs()
+            )));
+        }
+        Ok(r) => r?,
+    };
     if payload.deliver_as_task() {
         finish_document_convert_task_job(pool, job, payload, &markdown).await?;
         return Ok(true);

--- a/packages/pipeline/tests/job_queue_tests.rs
+++ b/packages/pipeline/tests/job_queue_tests.rs
@@ -353,10 +353,13 @@ async fn test_reap_orphaned_jobs_resets_to_pending() {
         .await
         .unwrap();
 
-    let count = job_queue::reap_orphaned_jobs(&db.pool, Duration::from_secs(60))
+    let reaped_jobs = job_queue::reap_orphaned_jobs(&db.pool, Duration::from_secs(60))
         .await
         .unwrap();
-    assert_eq!(count, 1);
+    assert_eq!(reaped_jobs.len(), 1);
+    // De teruggegeven rij draagt de NIEUWE status en de payload mee.
+    assert_eq!(reaped_jobs[0].id, job.id);
+    assert_eq!(reaped_jobs[0].status, JobStatus::Pending);
 
     // Job should be back to pending (still has retries left: attempts=1, max=3)
     let reaped = job_queue::get_job(&db.pool, job.id).await.unwrap();
@@ -381,10 +384,11 @@ async fn test_reap_orphaned_jobs_permanently_fails_exhausted() {
         .await
         .unwrap();
 
-    let count = job_queue::reap_orphaned_jobs(&db.pool, Duration::from_secs(60))
+    let reaped_jobs = job_queue::reap_orphaned_jobs(&db.pool, Duration::from_secs(60))
         .await
         .unwrap();
-    assert_eq!(count, 1);
+    assert_eq!(reaped_jobs.len(), 1);
+    assert_eq!(reaped_jobs[0].status, JobStatus::Failed);
 
     // Job should be permanently failed (attempts=1 >= max_attempts=1)
     let reaped = job_queue::get_job(&db.pool, job.id).await.unwrap();
@@ -397,20 +401,20 @@ async fn test_reap_orphaned_jobs_returns_zero_when_none_orphaned() {
     let db = TestDb::new().await;
 
     // No jobs at all
-    let count = job_queue::reap_orphaned_jobs(&db.pool, Duration::from_secs(60))
+    let reaped_jobs = job_queue::reap_orphaned_jobs(&db.pool, Duration::from_secs(60))
         .await
         .unwrap();
-    assert_eq!(count, 0);
+    assert!(reaped_jobs.is_empty());
 
     // A processing job that is NOT yet timed out
     let req = CreateJobRequest::new(JobType::Harvest, "BWBR0001840");
     job_queue::create_job(&db.pool, req).await.unwrap();
     job_queue::claim_job(&db.pool, None).await.unwrap().unwrap();
 
-    let count = job_queue::reap_orphaned_jobs(&db.pool, Duration::from_secs(3600))
+    let reaped_jobs = job_queue::reap_orphaned_jobs(&db.pool, Duration::from_secs(3600))
         .await
         .unwrap();
-    assert_eq!(count, 0);
+    assert!(reaped_jobs.is_empty());
 }
 
 #[tokio::test]

--- a/packages/pipeline/tests/tasks_tests.rs
+++ b/packages/pipeline/tests/tasks_tests.rs
@@ -806,3 +806,137 @@ async fn test_traject_enrich_not_blocked_by_corpus_enrich() {
         .unwrap();
     assert!(dup_corpus.is_none());
 }
+
+/// Door de reaper terminaal gefaalde taak-flow-jobs moeten alsnog een
+/// job_failed-taak opleveren; her-pogingen (terug naar pending) en
+/// niet-taak-flow-jobs niet.
+#[tokio::test]
+async fn test_notify_reaped_task_jobs_creates_failed_tasks() {
+    use std::time::Duration;
+
+    let db = TestDb::new().await;
+    let (account_id, traject_id) = seed_account_and_traject(&db).await;
+
+    // 1. Terminale taak-flow law_convert (max_attempts=1).
+    job_queue::create_job(
+        &db.pool,
+        CreateJobRequest::new(
+            JobType::LawConvert,
+            "lawdoc:testtraject-abcd1234/beleid.pdf",
+        )
+        .with_traject_ref("testtraject-abcd1234")
+        .with_max_attempts(1)
+        .with_payload(json!({
+            "upload_id": uuid::Uuid::new_v4(),
+            "traject_id": traject_id,
+            "traject_ref": "testtraject-abcd1234",
+            "filename": "beleid.pdf",
+            "requested_by": account_id,
+            "deliver": "task",
+        })),
+    )
+    .await
+    .unwrap();
+    // 2. Taak-flow enrich met retries over: reap zet hem terug naar pending,
+    //    dus géén taak.
+    job_queue::create_job(
+        &db.pool,
+        CreateJobRequest::new(JobType::Enrich, "test_wet")
+            .with_max_attempts(3)
+            .with_payload(json!({
+                "law_id": "test_wet",
+                "yaml_path": "laws/test_wet/law.yaml",
+                "requested_by": account_id,
+                "deliver": "task",
+            })),
+    )
+    .await
+    .unwrap();
+    // 3. Niet-taak-flow harvest, terminaal: reaped maar geen taak.
+    job_queue::create_job(
+        &db.pool,
+        CreateJobRequest::new(JobType::Harvest, "BWBR0000000").with_max_attempts(1),
+    )
+    .await
+    .unwrap();
+
+    // Claim alle drie en antidateer ze voorbij de reaper-window.
+    while job_queue::claim_job(&db.pool, None)
+        .await
+        .unwrap()
+        .is_some()
+    {}
+    sqlx::query("UPDATE jobs SET started_at = now() - interval '2 hours'")
+        .execute(&db.pool)
+        .await
+        .unwrap();
+
+    let reaped = job_queue::reap_orphaned_jobs(&db.pool, Duration::from_secs(60))
+        .await
+        .unwrap();
+    assert_eq!(reaped.len(), 3);
+    tasks::notify_reaped_task_jobs(&db.pool, &reaped)
+        .await
+        .unwrap();
+
+    let open = tasks::list_open_tasks_for_account(&db.pool, account_id)
+        .await
+        .unwrap();
+    assert_eq!(
+        open.len(),
+        1,
+        "alleen de terminale taak-flow-job krijgt een taak"
+    );
+    assert_eq!(open[0].task_type, "job_failed");
+    assert_eq!(open[0].title, "Conversie naar wet mislukt: beleid.pdf");
+    assert_eq!(open[0].traject_id, Some(traject_id));
+    let payload = open[0].payload.as_ref().unwrap();
+    assert_eq!(payload["traject_ref"], "testtraject-abcd1234");
+    assert!(payload["error"].as_str().unwrap().contains("afgebroken"));
+}
+
+/// De nieuwe-wet-variant van een gereapte enrich krijgt de law_create-titel.
+#[tokio::test]
+async fn test_notify_reaped_new_law_enrich_gets_law_create_title() {
+    use std::time::Duration;
+
+    let db = TestDb::new().await;
+    let (account_id, traject_id) = seed_account_and_traject(&db).await;
+    job_queue::create_job(
+        &db.pool,
+        CreateJobRequest::new(JobType::Enrich, "werkinstructie_toetsing")
+            .with_max_attempts(1)
+            .with_payload(json!({
+                "law_id": "werkinstructie_toetsing",
+                "yaml_path": "laws/werkinstructie_toetsing/law.yaml",
+                "requested_by": account_id,
+                "deliver": "task",
+                "traject_id": traject_id,
+                "traject_ref": "testtraject-abcd1234",
+                "new_law": true,
+            })),
+    )
+    .await
+    .unwrap();
+    job_queue::claim_job(&db.pool, None).await.unwrap().unwrap();
+    sqlx::query("UPDATE jobs SET started_at = now() - interval '2 hours'")
+        .execute(&db.pool)
+        .await
+        .unwrap();
+
+    let reaped = job_queue::reap_orphaned_jobs(&db.pool, Duration::from_secs(60))
+        .await
+        .unwrap();
+    tasks::notify_reaped_task_jobs(&db.pool, &reaped)
+        .await
+        .unwrap();
+
+    let open = tasks::list_open_tasks_for_account(&db.pool, account_id)
+        .await
+        .unwrap();
+    assert_eq!(open.len(), 1);
+    assert_eq!(
+        open[0].title,
+        "Wet aanmaken mislukt: werkinstructie_toetsing"
+    );
+}


### PR DESCRIPTION
Follow-up to #950, addressing the robustness gap found during its smoke test.

## Problem

The orphan reaper fails any job stuck in 'processing' past `orphan_timeout` without a heartbeat check, and it never created a `job_failed` task. For task-flow jobs (`deliver: "task"`) that meant the requester saw the running item disappear from the Taken panel with no trace — observed repeatedly with slow `law_convert` runs on the pr950 preview, but the gap applied to all task-flow job types (enrich, document_convert, law_convert).

## Changes

- `reap_orphaned_jobs` now returns the reaped rows (id, law_id, job_type, NEW status, payload) instead of a bare count. The atomic `UPDATE … RETURNING` hands each row to exactly one concurrent reaper.
- New `tasks::notify_reaped_task_jobs`: for reaped jobs that ended TERMINAL and are task-flow with a `requested_by`, create a `job_failed` task with the job-type-appropriate title ("Verrijking mislukt", "Wet aanmaken mislukt" for `new_law`, "Conversie mislukt", "Conversie naar wet mislukt") and clean up the job blobs. Retried jobs (reaped back to pending) and non-task-flow jobs are skipped. Best-effort per job so one failed insert never stops the reaper loop.
- `document_convert` processing gets the same below-the-reaper-window bound that #950 gave `law_convert`, so a slow agent-fallback conversion fails visibly (job_failed task) instead of being reaped.

## Tests

- Adapted the existing reaper tests to the new return type (and asserting the returned rows).
- New DB tests: terminal task-flow law_convert gets a task while a retryable enrich and a non-task-flow harvest do not; the `new_law` enrich variant gets the "Wet aanmaken mislukt" title.