### PR TITLE
feat(editor): wet zoeken in centraal corpus, promoten naar traject en harvest-fallback via taken

### DIFF
--- a/frontend/src/EditorView.vue
+++ b/frontend/src/EditorView.vue
@@ -730,6 +730,14 @@ function onSearchSelectLaw(lawIdVal) {
   router.push(libraryRouteFor(lawIdVal));
 }
 
+// Een wet die vanuit de zoekresultaten naar het traject is gepromoot: ververs
+// de gedeelde corpus-lijst (de wet hoort nu bij de eigen traject-repo) en open
+// haar in de bibliotheek — zelfde afronding als een afgeronde harvest.
+async function onSearchLawPromoted(lawIdVal) {
+  await refreshCorpusLaws();
+  router.push(libraryRouteFor(lawIdVal));
+}
+
 async function onSearchHarvestAvailable(slug) {
   // Best-effort reload - a failure just means the list below may not
   // include the fresh law yet.
@@ -2804,6 +2812,7 @@ async function handleActionSave() {
       ref="searchPopoverRef"
       @select-law="onSearchSelectLaw"
       @harvest-available="onSearchHarvestAvailable"
+      @promoted="onSearchLawPromoted"
     />
   </Teleport>
 

--- a/frontend/src/LibraryView.vue
+++ b/frontend/src/LibraryView.vue
@@ -7,6 +7,7 @@ import MachineReadable from './components/MachineReadable.vue';
 import YamlView from './components/YamlView.vue';
 import ActionSheet from './components/ActionSheet.vue';
 import SearchPopover from './components/SearchPopover.vue';
+import AddLawPopover from './components/AddLawPopover.vue';
 import DocumentList from './components/DocumentList.vue';
 import DocumentEditor from './components/DocumentEditor.vue';
 import TrajectDetailsPane from './components/TrajectDetailsPane.vue';
@@ -257,6 +258,31 @@ function dismissLawUploadError() {
 function retryLawUpload() {
   lawUploadError.value = null;
   nextTick(() => onLawUpload());
+}
+
+// --- Wet toevoegen uit het centrale corpus (promote / traject-harvest) -----
+// De zoek-flow achter "Zoeken in het centrale corpus…": promoten kopieert de
+// wet naar de traject-repo, en voor een niet-gevonden wet start een BWB-id
+// een traject-scoped harvest via het taken-mechanisme (AddLawPopover).
+const addLawPopoverRef = ref(null);
+function openAddLawSearch() {
+  addLawPopoverRef.value?.show(document.getElementById('law-add-btn'));
+}
+// Na een geslaagde promote: index verversen (de wet staat nu in de
+// traject-repo) en de wet openen — dezelfde afronding als een afgeronde
+// harvest in de globale zoeker (onHarvestAvailable).
+async function onLawPromoted(lawId) {
+  await loadIndex();
+  selectLaw(lawId);
+}
+// Een gestarte traject-harvest is async: bevestig met dezelfde banner-vorm
+// als de document-upload dat de voortgang in het Taken-paneel verschijnt.
+const lawHarvestStarted = ref(false);
+function onTrajectHarvestRequested() {
+  lawHarvestStarted.value = true;
+}
+function dismissLawHarvestStarted() {
+  lawHarvestStarted.value = false;
 }
 
 // Name the open document in the unsaved-changes guard so it's clear what's at
@@ -1450,25 +1476,29 @@ watch(activeTrajectRef, () => {
                       </nldd-list-item>
                     </nldd-list>
                   </template>
-                  <!-- Wet of regel toevoegen uit een geüpload document (alleen
-                       in een traject): start de conversie-naar-wet-keten; de
-                       voortgang en het resultaat verschijnen in het
-                       Taken-paneel. Zelfde toolbar/icon-button-patroon als de
-                       werkdocument-upload; één actie, dus direct een klik in
-                       plaats van een menu. -->
+                  <!-- Wet toevoegen (alleen in een traject): één "+"-menu met
+                       twee routes — zoeken in het centrale corpus (promoten,
+                       met harvest-fallback via het taken-mechanisme) of een
+                       PDF/Word-document uploaden dat de conversie-naar-wet-
+                       keten start. Zelfde menu-patroon als de werkdocument-
+                       toevoegknop. -->
                   <template v-if="activeTrajectRef">
                     <nldd-spacer size="24"></nldd-spacer>
                     <nldd-toolbar label="Wetacties">
                       <nldd-toolbar-item slot="start">
-                        <!-- Géén `expandable`: dat is de disclosure-chevron
-                             voor menu/popover-knoppen; dit is een directe
-                             actie. De tekst verschijnt als tooltip. -->
                         <nldd-icon-button
-                          id="law-upload-btn"
+                          id="law-add-btn"
                           icon="plus-small"
-                          text="Wet of regel toevoegen uit document"
-                          @click="onLawUpload"
+                          text="Wet toevoegen"
+                          expandable
+                          tooltip-timing="never"
+                          popup-type="menu"
+                          popovertarget="law-add-menu"
                         ></nldd-icon-button>
+                        <nldd-menu id="law-add-menu" anchor="law-add-btn">
+                          <nldd-menu-item icon="search" text="Zoeken in het centrale corpus…" @select="openAddLawSearch"></nldd-menu-item>
+                          <nldd-menu-item icon="upload-to-cloud" text="PDF of DOCX uploaden…" @select="onLawUpload"></nldd-menu-item>
+                        </nldd-menu>
                       </nldd-toolbar-item>
                     </nldd-toolbar>
                     <input ref="lawFileInput" type="file" accept=".pdf,.doc,.docx" hidden @change="onLawFileChange" />
@@ -1480,6 +1510,16 @@ watch(activeTrajectRef, () => {
                         supporting-text="Je krijgt een taak zodra de wet klaarstaat voor beoordeling."
                         dismissible
                         @dismiss="dismissLawUploadStarted"
+                      ></nldd-banner>
+                    </template>
+                    <template v-if="lawHarvestStarted">
+                      <nldd-spacer size="8"></nldd-spacer>
+                      <nldd-banner
+                        variant="success"
+                        text="Ophalen gestart"
+                        supporting-text="De aanvraag staat bij Taken; je krijgt een taak zodra de wet klaarstaat voor beoordeling."
+                        dismissible
+                        @dismiss="dismissLawHarvestStarted"
                       ></nldd-banner>
                     </template>
                   </template>
@@ -1811,6 +1851,11 @@ watch(activeTrajectRef, () => {
       ref="searchPopoverRef"
       @select-law="(lawId) => selectLaw(lawId, true)"
       @harvest-available="onHarvestAvailable"
+    />
+    <AddLawPopover
+      ref="addLawPopoverRef"
+      @promoted="onLawPromoted"
+      @harvest-requested="onTrajectHarvestRequested"
     />
   </Teleport>
   <!-- Unsaved-changes guard for in-view werkdocument navigation. -->

--- a/frontend/src/LibraryView.vue
+++ b/frontend/src/LibraryView.vue
@@ -1480,29 +1480,24 @@ watch(activeTrajectRef, () => {
                       </nldd-list-item>
                     </nldd-list>
                   </template>
-                  <!-- Wet toevoegen (alleen in een traject): één "+"-menu met
-                       twee routes — zoeken in het centrale corpus (promoten,
-                       met harvest-fallback via het taken-mechanisme) of een
-                       PDF/Word-document uploaden dat de conversie-naar-wet-
-                       keten start. Zelfde menu-patroon als de werkdocument-
-                       toevoegknop. -->
+                  <!-- Wet toevoegen (alleen in een traject): de "+" opent
+                       DIRECT de "Wet toevoegen"-zoeker (AddLawPopover) —
+                       zonder menu-tussenstap. De tweede route (PDF/Word-
+                       document uploaden → conversie-naar-wet-keten) zit ín
+                       die popover als actie onder de zoekresultaten. -->
                   <template v-if="activeTrajectRef">
                     <nldd-spacer size="24"></nldd-spacer>
                     <nldd-toolbar label="Wetacties">
                       <nldd-toolbar-item slot="start">
+                        <!-- Géén `expandable`: dat is de disclosure-chevron
+                             voor menu/popover-knoppen; dit is een directe
+                             actie. De tekst verschijnt als tooltip. -->
                         <nldd-icon-button
                           id="law-add-btn"
                           icon="plus-small"
                           text="Wet toevoegen"
-                          expandable
-                          tooltip-timing="never"
-                          popup-type="menu"
-                          popovertarget="law-add-menu"
+                          @click="openAddLawSearch"
                         ></nldd-icon-button>
-                        <nldd-menu id="law-add-menu" anchor="law-add-btn">
-                          <nldd-menu-item icon="search" text="Zoeken in het centrale corpus…" @select="openAddLawSearch"></nldd-menu-item>
-                          <nldd-menu-item icon="upload-to-cloud" text="PDF of DOCX uploaden…" @select="onLawUpload"></nldd-menu-item>
-                        </nldd-menu>
                       </nldd-toolbar-item>
                     </nldd-toolbar>
                     <input ref="lawFileInput" type="file" accept=".pdf,.doc,.docx" hidden @change="onLawFileChange" />
@@ -1861,6 +1856,7 @@ watch(activeTrajectRef, () => {
       ref="addLawPopoverRef"
       @promoted="onLawPromoted"
       @harvest-requested="onTrajectHarvestRequested"
+      @upload-requested="onLawUpload"
     />
   </Teleport>
   <!-- Unsaved-changes guard for in-view werkdocument navigation. -->

--- a/frontend/src/LibraryView.vue
+++ b/frontend/src/LibraryView.vue
@@ -268,9 +268,10 @@ const addLawPopoverRef = ref(null);
 function openAddLawSearch() {
   addLawPopoverRef.value?.show(document.getElementById('law-add-btn'));
 }
-// Na een geslaagde promote: index verversen (de wet staat nu in de
-// traject-repo) en de wet openen — dezelfde afronding als een afgeronde
-// harvest in de globale zoeker (onHarvestAvailable).
+// Na een geslaagde promote (via de AddLawPopover óf de "Toevoegen aan
+// traject"-knop in de gewone zoekresultaten): index verversen (de wet staat
+// nu in de traject-repo) en de wet openen — dezelfde afronding als een
+// afgeronde harvest in de globale zoeker (onHarvestAvailable).
 async function onLawPromoted(lawId) {
   await loadIndex();
   selectLaw(lawId);
@@ -1851,6 +1852,7 @@ watch(activeTrajectRef, () => {
       ref="searchPopoverRef"
       @select-law="(lawId) => selectLaw(lawId, true)"
       @harvest-available="onHarvestAvailable"
+      @promoted="onLawPromoted"
     />
     <AddLawPopover
       ref="addLawPopoverRef"

--- a/frontend/src/LibraryView.vue
+++ b/frontend/src/LibraryView.vue
@@ -271,10 +271,13 @@ function openAddLawSearch() {
 // Na een geslaagde promote (via de AddLawPopover óf de "Toevoegen aan
 // traject"-knop in de gewone zoekresultaten): index verversen (de wet staat
 // nu in de traject-repo) en de wet openen — dezelfde afronding als een
-// afgeronde harvest in de globale zoeker (onHarvestAvailable).
-async function onLawPromoted(lawId) {
+// afgeronde harvest in de globale zoeker (onHarvestAvailable). Vanuit de
+// zoekresultaten focussen we ook het sidebar-item (focusAfter), net als
+// select-law uit dezelfde popover — daarvoor stelt SearchPopover de
+// 'promoted'-emit uit tot na _returnFocus.
+async function onLawPromoted(lawId, focusAfter = false) {
   await loadIndex();
-  selectLaw(lawId);
+  selectLaw(lawId, focusAfter);
 }
 // Een gestarte traject-harvest is async: bevestig met dezelfde banner-vorm
 // als de document-upload dat de voortgang in het Taken-paneel verschijnt.
@@ -1852,7 +1855,7 @@ watch(activeTrajectRef, () => {
       ref="searchPopoverRef"
       @select-law="(lawId) => selectLaw(lawId, true)"
       @harvest-available="onHarvestAvailable"
-      @promoted="onLawPromoted"
+      @promoted="(lawId) => onLawPromoted(lawId, true)"
     />
     <AddLawPopover
       ref="addLawPopoverRef"

--- a/frontend/src/components/AddLawPopover.test.js
+++ b/frontend/src/components/AddLawPopover.test.js
@@ -211,4 +211,19 @@ describe('AddLawPopover', () => {
     expect(rows).toHaveLength(1);
     expect(rows[0].get('nldd-text-cell').attributes('text')).toBe('Voorbeeldwet extern');
   });
+
+  it('biedt de document-upload als route en emit "upload-requested" (popover sluit eerst)', async () => {
+    // De uploadoptie zat eerst in het plus-menu naast de zoeker; dat menu is
+    // vervallen (de plus opent direct deze popover), dus de route leeft nu
+    // hier. De file-picker zelf zit in LibraryView — de popover moet vóór de
+    // emit sluiten zodat de picker niet achter het popover opent.
+    const wrapper = mount(AddLawPopover);
+    const hide = vi.fn();
+    wrapper.vm.$refs.popoverRef.hide = hide;
+
+    await wrapper.get('[data-testid="add-law-upload"]').trigger('click');
+
+    expect(hide).toHaveBeenCalledTimes(1);
+    expect(wrapper.emitted('upload-requested')).toEqual([[]]);
+  });
 });

--- a/frontend/src/components/AddLawPopover.test.js
+++ b/frontend/src/components/AddLawPopover.test.js
@@ -1,0 +1,198 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { nextTick } from 'vue';
+import AddLawPopover from './AddLawPopover.vue';
+
+// De popover is traject-gebonden: useTrajects() leest de trajectRef uit de
+// route. Fictieve ref, geen echte repo/traject-namen (publiek testbestand).
+const TRAJECT_REF = 'voorbeeld-abcd1234';
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ params: { trajectRef: TRAJECT_REF } }),
+}));
+
+// Traject-scoped zoekrespons: het traject federeert de centrale seed, dus de
+// lijst mengt eigen-repo-treffers (source_priority 0, al in het traject) met
+// centrale-seed-treffers (hogere priority, promoteerbaar). Fictieve namen.
+const SEARCH_LAWS = [
+  {
+    law_id: 'wet_voorbeeld',
+    name: 'Wet voorbeeld',
+    source_id: 'central',
+    source_name: 'Centrale Regelrecht Corpus',
+    source_priority: 2,
+  },
+  {
+    law_id: 'wet_al_binnen',
+    name: 'Wet al binnen',
+    source_id: 'traject-own',
+    source_name: 'example-org/traject-corpus-example',
+    source_priority: 0,
+  },
+];
+
+const PROMOTABLE = SEARCH_LAWS[0];
+
+function stubFetch({ searchLaws = SEARCH_LAWS, bwbResults = [] } = {}) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url, init = {}) => {
+      const u = String(url);
+      if (u.includes('/auth/status')) return { ok: false, json: async () => ({}) };
+      if (u.includes('/harvest/search')) return { ok: true, json: async () => bwbResults };
+      if (u.includes('/promote') && init.method === 'POST') {
+        return { ok: true, json: async () => ({ law_id: 'wet_voorbeeld', copied_files: 3 }) };
+      }
+      if (u.includes('/corpus/harvest') && init.method === 'POST') {
+        return { ok: true, status: 202, json: async () => ({ job_id: 'j1' }) };
+      }
+      if (u.startsWith(`/api/trajects/${TRAJECT_REF}/corpus/laws`)) {
+        return { ok: true, json: async () => searchLaws };
+      }
+      return { ok: true, json: async () => [] };
+    }),
+  );
+}
+
+beforeEach(() => {
+  stubFetch();
+});
+
+// Voorbij de 200ms-debounce plus de fetches.
+const settle = () => new Promise((r) => setTimeout(r, 300));
+
+async function searchFor(wrapper, term) {
+  wrapper.vm.search = term;
+  await nextTick();
+  await settle();
+  await nextTick();
+}
+
+describe('AddLawPopover', () => {
+  it('zoekt via de traject-scoped corpus-API en sorteert eigen repo eerst', async () => {
+    const wrapper = mount(AddLawPopover);
+    await searchFor(wrapper, 'wet');
+
+    const urls = fetch.mock.calls.map((c) => String(c[0]));
+    expect(
+      urls.some(
+        (u) => u.startsWith(`/api/trajects/${TRAJECT_REF}/corpus/laws?`) && u.includes('q=wet'),
+      ),
+    ).toBe(true);
+    // Geen tweede zoekpad: de globale corpus-URL wordt niet aangeroepen.
+    expect(urls.some((u) => u.startsWith('/api/corpus/laws'))).toBe(false);
+    expect(wrapper.vm.sortedLaws.map((l) => l.law_id)).toEqual([
+      'wet_al_binnen',
+      'wet_voorbeeld',
+    ]);
+  });
+
+  it('markeert een wet die al in de traject-repo staat (priority 0) als niet-promoteerbaar', async () => {
+    const wrapper = mount(AddLawPopover);
+    await searchFor(wrapper, 'wet');
+
+    const rows = wrapper.findAll('nldd-list-item[data-law-id]');
+    const binnen = rows.find((r) => r.attributes('data-law-id') === 'wet_al_binnen');
+    expect(binnen.get('nldd-text-cell').attributes('supporting-text')).toBe('Al in dit traject');
+    expect(binnen.get('nldd-button').attributes('disabled')).toBeDefined();
+
+    const buiten = rows.find((r) => r.attributes('data-law-id') === 'wet_voorbeeld');
+    expect(buiten.get('nldd-button').attributes('disabled')).toBeUndefined();
+  });
+
+  it('promoot via POST /promote en emit "promoted"', async () => {
+    const wrapper = mount(AddLawPopover);
+    await searchFor(wrapper, 'wet');
+
+    await wrapper.vm.promote(PROMOTABLE);
+
+    const promoteCall = fetch.mock.calls.find(
+      (c) => String(c[0]).includes('/promote') && c[1]?.method === 'POST',
+    );
+    expect(String(promoteCall[0])).toBe(
+      `/api/trajects/${TRAJECT_REF}/corpus/laws/wet_voorbeeld/promote`,
+    );
+    expect(wrapper.emitted('promoted')).toEqual([['wet_voorbeeld']]);
+  });
+
+  it('een 409 op promote markeert de wet alsnog als al-in-traject', async () => {
+    stubFetch();
+    fetch.mockImplementation(async (url, init = {}) => {
+      const u = String(url);
+      if (u.includes('/promote') && init.method === 'POST') {
+        return { ok: false, status: 409, text: async () => 'al in traject', headers: { get: () => '' } };
+      }
+      if (u.includes('/auth/status')) return { ok: false, json: async () => ({}) };
+      if (u.startsWith(`/api/trajects/${TRAJECT_REF}/corpus/laws`)) {
+        return { ok: true, json: async () => [] };
+      }
+      return { ok: true, json: async () => SEARCH_LAWS };
+    });
+
+    const wrapper = mount(AddLawPopover);
+    await searchFor(wrapper, 'wet');
+    await wrapper.vm.promote(PROMOTABLE);
+    await nextTick();
+
+    expect(wrapper.emitted('promoted')).toBeUndefined();
+    expect(wrapper.vm.isInTraject(PROMOTABLE)).toBe(true);
+  });
+
+  it('valt bij nul corpus-treffers terug op de wetten.overheid.nl-zoeker', async () => {
+    stubFetch({
+      searchLaws: [],
+      bwbResults: [{ bwb_id: 'BWBR0002399', title: 'Voorbeeldwet extern', type: 'wet' }],
+    });
+    const wrapper = mount(AddLawPopover);
+    await searchFor(wrapper, 'voorbeeldwet');
+    // Debounce van useBwbSearch (400ms) na de corpus-respons.
+    await new Promise((r) => setTimeout(r, 450));
+    await nextTick();
+
+    const urls = fetch.mock.calls.map((c) => String(c[0]));
+    expect(urls.some((u) => u.includes('/harvest/search'))).toBe(true);
+    const row = wrapper.get('nldd-list-item[data-bwb-id="BWBR0002399"]');
+    expect(row.get('nldd-text-cell').attributes('text')).toBe('Voorbeeldwet extern');
+  });
+
+  it('start een traject-scoped harvest voor een BWB-resultaat en emit "harvest-requested"', async () => {
+    const wrapper = mount(AddLawPopover);
+    await wrapper.vm.requestTrajectHarvest('BWBR0002399', 'Voorbeeldwet extern');
+
+    const call = fetch.mock.calls.find(
+      (c) => String(c[0]).includes('/corpus/harvest') && c[1]?.method === 'POST',
+    );
+    expect(String(call[0])).toBe(`/api/trajects/${TRAJECT_REF}/corpus/harvest`);
+    expect(JSON.parse(call[1].body)).toEqual({
+      bwb_id: 'BWBR0002399',
+      law_name: 'Voorbeeldwet extern',
+    });
+    expect(wrapper.emitted('harvest-requested')).toEqual([['BWBR0002399']]);
+    expect(wrapper.vm.harvestState.BWBR0002399).toBe('requested');
+  });
+
+  it('een 409 op de harvest-aanvraag toont "er loopt al een aanvraag"', async () => {
+    fetch.mockImplementation(async (url, init = {}) => {
+      const u = String(url);
+      if (u.includes('/corpus/harvest') && init.method === 'POST') {
+        return { ok: false, status: 409, text: async () => 'loopt al', headers: { get: () => '' } };
+      }
+      if (u.includes('/auth/status')) return { ok: false, json: async () => ({}) };
+      return { ok: true, json: async () => [] };
+    });
+    const wrapper = mount(AddLawPopover);
+    await wrapper.vm.requestTrajectHarvest('BWBR0002399');
+    expect(wrapper.vm.harvestState.BWBR0002399).toBe('conflict');
+    expect(wrapper.emitted('harvest-requested')).toBeUndefined();
+  });
+
+  it('herkent een direct getypt BWB-id (ook lowercase) als harvest-kandidaat', async () => {
+    stubFetch({ searchLaws: [] });
+    const wrapper = mount(AddLawPopover);
+    await searchFor(wrapper, 'bwbr0002399');
+    expect(wrapper.vm.bwbIdQuery).toBe('BWBR0002399');
+
+    await searchFor(wrapper, 'wet op het voortgezet onderwijs');
+    expect(wrapper.vm.bwbIdQuery).toBe(null);
+  });
+});

--- a/frontend/src/components/AddLawPopover.test.js
+++ b/frontend/src/components/AddLawPopover.test.js
@@ -195,4 +195,20 @@ describe('AddLawPopover', () => {
     await searchFor(wrapper, 'wet op het voortgezet onderwijs');
     expect(wrapper.vm.bwbIdQuery).toBe(null);
   });
+
+  it('toont één rij wanneer de externe zoeker het getypte BWB-id ook vindt', async () => {
+    stubFetch({
+      searchLaws: [],
+      bwbResults: [{ bwb_id: 'BWBR0002399', title: 'Voorbeeldwet extern', type: 'wet' }],
+    });
+    const wrapper = mount(AddLawPopover);
+    await searchFor(wrapper, 'BWBR0002399');
+    // Debounce van useBwbSearch (400ms) na de corpus-respons.
+    await new Promise((r) => setTimeout(r, 450));
+    await nextTick();
+
+    const rows = wrapper.findAll('nldd-list-item[data-bwb-id="BWBR0002399"]');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].get('nldd-text-cell').attributes('text')).toBe('Voorbeeldwet extern');
+  });
 });

--- a/frontend/src/components/AddLawPopover.vue
+++ b/frontend/src/components/AddLawPopover.vue
@@ -1,0 +1,372 @@
+<script setup>
+/**
+ * AddLawPopover - "Wet toevoegen" vanuit een traject, in één flow:
+ *
+ * 1. Zoek in het centrale corpus (op naam en law-id) via dezelfde
+ *    traject-scoped zoek-API die de bibliotheekzoeker voedt — het traject
+ *    federeert de centrale corpus-seed, dus die zoekt door het volledige
+ *    centrale corpus én markeert wat al in de eigen repo staat
+ *    (source_priority 0). Géén tweede zoekpad.
+ * 2. Gevonden? "Toevoegen aan traject" kopieert de volledige wet-map
+ *    (versie-YAML's + scenario's) naar de traject-repo via de
+ *    promote-endpoint. Staat de wet al in het traject, dan is de rij
+ *    uitgeschakeld ("Al in dit traject").
+ * 3. Niet gevonden? Met een BWB-id (direct getypt, of via de
+ *    wetten.overheid.nl-zoeker) start "Ophalen naar traject" een
+ *    traject-scoped harvest via het taken-mechanisme; de aanvraag is
+ *    direct zichtbaar in het takenpaneel en het resultaat komt terug
+ *    als review-taak.
+ *
+ * Positionering/plumbing (show/anchor/breakpoints, listbox-als-zoek-UI)
+ * spiegelt SearchPopover.vue - dezelfde design-system-componenten en
+ * hetzelfde combobox-patroon.
+ */
+import { ref, computed, watch, nextTick } from 'vue';
+import { useBwbSearch, MIN_QUERY_LENGTH } from '../composables/useBwbSearch.js';
+import { useTrajects } from '../composables/useTrajects.js';
+import { lawsListUrl, lawPromoteUrl, trajectHarvestUrl } from '../composables/corpusUrls.js';
+import { apiFetch, apiFetchJson, ApiError } from '../lib/apiFetch.js';
+import { useLatest } from '../lib/useLatest.js';
+
+const listTranslations = { 'components.list.search-placeholder-text': 'Zoek een wet of BWB-id…' };
+
+const emit = defineEmits(['promoted', 'harvest-requested']);
+
+const { activeTrajectRef } = useTrajects();
+const { results: bwbResults, loading: bwbLoading, search: searchBwb, clear: clearBwb } = useBwbSearch();
+
+const search = ref('');
+const popoverRef = ref(null);
+const useCenteredPosition = ref(true);
+const isAnchored = ref(false);
+
+// Zelfde breakpoints als SearchPopover (bron: design-system breakpoints.ts).
+const BREAKPOINT_MD_MIN = 641;
+const BREAKPOINT_LG_MIN = 1008;
+
+// Corpus-treffers (traject-gefedereerd: eigen repo + centrale seed) voor de
+// huidige zoekterm.
+const centralLaws = ref([]);
+// Law-ids die al in de traject-repo staan (source_priority 0): promoten is
+// dan niet mogelijk. Een 409 van de backend vult deze set ook bij.
+const inTrajectIds = ref(new Set());
+const searching = ref(false);
+const searchFailed = ref(false);
+
+// Per law_id: 'busy' tijdens de promote-POST; 409 markeert de wet alsnog
+// als al-in-traject. Per bwb_id: 'busy' | 'requested' | 'conflict' | 'error'.
+const promoteState = ref({});
+const promoteError = ref(null);
+const harvestState = ref({});
+
+function displayName(law) {
+  if (law.display_name) return law.display_name;
+  if (law.name) return law.name;
+  return law.law_id.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+const sortedLaws = computed(() =>
+  [...centralLaws.value].sort(
+    (a, b) =>
+      (a.source_priority ?? Number.MAX_SAFE_INTEGER) -
+      (b.source_priority ?? Number.MAX_SAFE_INTEGER),
+  ),
+);
+
+// Direct getypt BWB-id: bied ophalen aan zonder dat de externe zoeker het
+// hoeft te vinden (acceptatie: "een BWB-id mag ook").
+const bwbIdQuery = computed(() => {
+  const term = search.value.trim().toUpperCase();
+  return /^BWB[A-Z0-9]{3,17}$/.test(term) ? term : null;
+});
+
+const claimSearch = useLatest();
+let debounceTimer = null;
+
+watch(search, (q) => {
+  clearBwb();
+  searchFailed.value = false;
+  promoteError.value = null;
+  if (debounceTimer) clearTimeout(debounceTimer);
+  const term = q.trim();
+  if (term.length < MIN_QUERY_LENGTH) {
+    claimSearch();
+    centralLaws.value = [];
+    searching.value = false;
+    return;
+  }
+  searching.value = true;
+  debounceTimer = setTimeout(() => runSearch(term), 200);
+});
+
+async function runSearch(term) {
+  const isCurrent = claimSearch();
+  try {
+    // Traject-scoped zoekopdracht: dekt de volledige centrale seed (het
+    // traject federeert die) én de eigen repo. source_priority 0 = de
+    // eigen schrijfbare repo → al in het traject, niet promoteerbaar.
+    const laws = await apiFetchJson(
+      lawsListUrl(activeTrajectRef.value, `q=${encodeURIComponent(term)}&limit=60`),
+    );
+    if (!isCurrent()) return;
+    centralLaws.value = laws;
+    inTrajectIds.value = new Set(
+      laws.filter((l) => l.source_priority === 0).map((l) => l.law_id),
+    );
+    searchFailed.value = false;
+    // Niets in het centrale corpus: val terug op wetten.overheid.nl zodat
+    // de gebruiker met een BWB-id een traject-harvest kan starten.
+    if (laws.length === 0) searchBwb(term);
+  } catch {
+    if (isCurrent()) {
+      centralLaws.value = [];
+      searchFailed.value = true;
+    }
+  } finally {
+    if (isCurrent()) searching.value = false;
+  }
+}
+
+function isInTraject(law) {
+  return inTrajectIds.value.has(law.law_id);
+}
+
+async function promote(law) {
+  if (!activeTrajectRef.value) return;
+  const id = law.law_id;
+  if (promoteState.value[id] === 'busy' || isInTraject(law)) return;
+  promoteState.value = { ...promoteState.value, [id]: 'busy' };
+  promoteError.value = null;
+  try {
+    await apiFetchJson(lawPromoteUrl(activeTrajectRef.value, id), { method: 'POST' });
+    promoteState.value = { ...promoteState.value, [id]: 'done' };
+    emit('promoted', id);
+    close();
+  } catch (e) {
+    promoteState.value = { ...promoteState.value, [id]: null };
+    if (e instanceof ApiError && e.status === 409) {
+      // Backend is de autoriteit: markeer als al-in-traject.
+      inTrajectIds.value = new Set([...inTrajectIds.value, id]);
+    } else {
+      promoteError.value =
+        'Toevoegen aan het traject is mislukt. Probeer het opnieuw of neem contact op.';
+    }
+  }
+}
+
+async function requestTrajectHarvest(bwbId, lawName) {
+  if (!activeTrajectRef.value) return;
+  const state = harvestState.value[bwbId];
+  if (state === 'busy' || state === 'requested') return;
+  harvestState.value = { ...harvestState.value, [bwbId]: 'busy' };
+  try {
+    await apiFetch(trajectHarvestUrl(activeTrajectRef.value), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ bwb_id: bwbId, law_name: lawName || undefined }),
+    });
+    harvestState.value = { ...harvestState.value, [bwbId]: 'requested' };
+    emit('harvest-requested', bwbId);
+  } catch (e) {
+    harvestState.value = {
+      ...harvestState.value,
+      [bwbId]: e instanceof ApiError && e.status === 409 ? 'conflict' : 'error',
+    };
+  }
+}
+
+function harvestStatusText(bwbId, fallback) {
+  switch (harvestState.value[bwbId]) {
+    case 'busy':
+      return 'Aanvragen…';
+    case 'requested':
+      return 'Aanvraag gestart — volg de voortgang bij Taken';
+    case 'conflict':
+      return 'Er loopt al een aanvraag voor deze wet';
+    case 'error':
+      return 'Aanvragen mislukt — probeer het opnieuw';
+    default:
+      return fallback || '';
+  }
+}
+
+function close() {
+  popoverRef.value?.hide();
+}
+
+function onListInput(e) {
+  search.value = e.detail?.value ?? '';
+}
+
+function onListKeydown(e) {
+  if (e.key === 'Escape' && !e.defaultPrevented) close();
+}
+
+function onPopoverClose() {
+  search.value = '';
+  clearBwb();
+  promoteError.value = null;
+}
+
+/** Public API: open het popover, verankerd aan het gegeven trigger-element. */
+async function show(anchorEl) {
+  if (!popoverRef.value) return;
+  if (anchorEl) popoverRef.value.anchorElement = anchorEl;
+  useCenteredPosition.value = window.matchMedia(`(min-width: ${BREAKPOINT_LG_MIN}px)`).matches;
+  isAnchored.value = window.matchMedia(
+    `(min-width: ${BREAKPOINT_MD_MIN}px) and (max-width: ${BREAKPOINT_LG_MIN - 1}px)`,
+  ).matches;
+  await nextTick();
+  popoverRef.value.show();
+}
+
+// Zelfde focus-hook als SearchPopover: de listbox bezit z'n eigen input.
+function onPopoverOpen() {
+  const list = popoverRef.value?.querySelector('nldd-list');
+  const input = list?.shadowRoot?.querySelector('.list__search-field-input');
+  if (input) {
+    input.value = '';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    input.focus();
+  }
+}
+
+defineExpose({ show });
+</script>
+
+<template>
+  <nldd-popover
+    ref="popoverRef"
+    accessible-label="Wet toevoegen aan traject"
+    :width="useCenteredPosition ? '720px' : '360px'"
+    placement="bottom-end"
+    :centered="useCenteredPosition || null"
+    :top="useCenteredPosition ? '0' : null"
+    sm-full-height
+    @open="onPopoverOpen"
+    @close="onPopoverClose"
+  >
+    <nldd-container padding="16">
+      <nldd-list
+        type="listbox"
+        variant="simple"
+        height="min(70vh, 560px)"
+        accessible-label="Wet toevoegen aan traject"
+        :translations="listTranslations"
+        empty-text="Geen resultaten gevonden"
+        empty-supporting-text="Zoek op naam, law-id of BWB-id"
+        @input="onListInput"
+        @keydown="onListKeydown"
+      >
+        <nldd-button
+          v-if="!isAnchored"
+          slot="search-bar-end"
+          size="md"
+          text="Sluit"
+          @click="close"
+        ></nldd-button>
+
+        <!-- Fout bij promoten: één banner boven de resultaten. -->
+        <nldd-list-item v-if="promoteError" size="md">
+          <nldd-icon-cell size="20" icon="alert" color="critical"></nldd-icon-cell>
+          <nldd-spacer-cell size="8"></nldd-spacer-cell>
+          <nldd-text-cell :text="promoteError" color="critical"></nldd-text-cell>
+        </nldd-list-item>
+
+        <!-- Centrale-corpus-treffers: promoten naar het traject. -->
+        <nldd-list-item
+          v-for="law in sortedLaws"
+          :key="law.law_id"
+          size="md"
+          :data-law-id="law.law_id"
+        >
+          <nldd-text-cell
+            :text="displayName(law)"
+            :supporting-text="isInTraject(law) ? 'Al in dit traject' : law.source_name || undefined"
+          ></nldd-text-cell>
+          <nldd-spacer-cell size="8"></nldd-spacer-cell>
+          <nldd-cell>
+            <nldd-button
+              size="sm"
+              variant="primary"
+              text="Toevoegen aan traject"
+              :disabled="isInTraject(law) || undefined"
+              :loading="promoteState[law.law_id] === 'busy' || undefined"
+              @click="promote(law)"
+            ></nldd-button>
+          </nldd-cell>
+        </nldd-list-item>
+
+        <!-- Direct getypt BWB-id: traject-harvest zonder externe zoeker. -->
+        <nldd-list-item v-if="bwbIdQuery && sortedLaws.length === 0" size="md" :data-bwb-id="bwbIdQuery">
+          <nldd-icon-cell size="20"><nldd-icon name="harvest"></nldd-icon></nldd-icon-cell>
+          <nldd-spacer-cell size="8"></nldd-spacer-cell>
+          <nldd-text-cell
+            :text="bwbIdQuery"
+            :supporting-text="harvestStatusText(bwbIdQuery, 'Niet in het centrale corpus — haal op uit wetten.overheid.nl')"
+          ></nldd-text-cell>
+          <nldd-spacer-cell size="8"></nldd-spacer-cell>
+          <nldd-cell>
+            <nldd-button
+              size="sm"
+              variant="primary"
+              text="Ophalen naar traject"
+              :disabled="['busy', 'requested'].includes(harvestState[bwbIdQuery]) || undefined"
+              @click="requestTrajectHarvest(bwbIdQuery)"
+            ></nldd-button>
+          </nldd-cell>
+        </nldd-list-item>
+
+        <!-- Externe wetten.overheid.nl-treffers (alleen wanneer het centrale
+             corpus niets vond): traject-scoped harvest per resultaat. -->
+        <nldd-list-item
+          v-for="result in bwbResults"
+          :key="result.bwb_id"
+          size="md"
+          :data-bwb-id="result.bwb_id"
+        >
+          <nldd-icon-cell size="20"><nldd-icon name="harvest"></nldd-icon></nldd-icon-cell>
+          <nldd-spacer-cell size="8"></nldd-spacer-cell>
+          <nldd-text-cell
+            :text="result.title"
+            :supporting-text="harvestStatusText(result.bwb_id, `${result.type} - ${result.bwb_id}`)"
+          ></nldd-text-cell>
+          <nldd-spacer-cell size="8"></nldd-spacer-cell>
+          <nldd-cell>
+            <nldd-button
+              size="sm"
+              variant="primary"
+              text="Ophalen naar traject"
+              :disabled="['busy', 'requested'].includes(harvestState[result.bwb_id]) || undefined"
+              @click="requestTrajectHarvest(result.bwb_id, result.title)"
+            ></nldd-button>
+          </nldd-cell>
+        </nldd-list-item>
+
+        <!-- States zonder zichtbare opties. -->
+        <div slot="empty">
+          <nldd-inline-dialog v-if="searching" text="Zoeken in het centrale corpus…"></nldd-inline-dialog>
+          <nldd-inline-dialog
+            v-else-if="searchFailed"
+            variant="alert"
+            text="Zoeken is mislukt"
+            supporting-text="Het centrale corpus kon niet worden doorzocht. Probeer het opnieuw."
+          ></nldd-inline-dialog>
+          <nldd-inline-dialog
+            v-else-if="bwbLoading"
+            text="Zoeken op wetten.overheid.nl..."
+          ></nldd-inline-dialog>
+          <nldd-inline-dialog
+            v-else-if="search.length > 0 && search.length < MIN_QUERY_LENGTH"
+            text="Typ minimaal drie tekens om te zoeken"
+          ></nldd-inline-dialog>
+          <nldd-inline-dialog
+            v-else
+            text="Geen resultaten gevonden"
+            supporting-text="Zoek op naam, law-id of BWB-id (bijv. BWBR0002399)"
+          ></nldd-inline-dialog>
+        </div>
+      </nldd-list>
+    </nldd-container>
+  </nldd-popover>
+</template>

--- a/frontend/src/components/AddLawPopover.vue
+++ b/frontend/src/components/AddLawPopover.vue
@@ -80,6 +80,16 @@ const bwbIdQuery = computed(() => {
   return /^BWB[A-Z0-9]{3,17}$/.test(term) ? term : null;
 });
 
+// De directe rij alleen tonen zolang de externe zoeker hetzelfde id niet al
+// als resultaat (met titel) toont — anders staan er twee rijen voor dezelfde
+// wet met dezelfde harvest-knop.
+const showDirectBwbRow = computed(
+  () =>
+    bwbIdQuery.value &&
+    sortedLaws.value.length === 0 &&
+    !bwbResults.value.some((r) => r.bwb_id === bwbIdQuery.value),
+);
+
 const claimSearch = useLatest();
 let debounceTimer = null;
 
@@ -297,13 +307,16 @@ defineExpose({ show });
           </nldd-cell>
         </nldd-list-item>
 
-        <!-- Direct getypt BWB-id: traject-harvest zonder externe zoeker. -->
-        <nldd-list-item v-if="bwbIdQuery && sortedLaws.length === 0" size="md" :data-bwb-id="bwbIdQuery">
+        <!-- Direct getypt BWB-id: traject-harvest zonder externe zoeker.
+             De corpus-zoeker matcht niet op BWB-id, dus "0 treffers" bewijst
+             hier niet dat de wet buiten het corpus valt — geen "niet in het
+             centrale corpus"-claim in de begeleidende tekst. -->
+        <nldd-list-item v-if="showDirectBwbRow" size="md" :data-bwb-id="bwbIdQuery">
           <nldd-icon-cell size="20"><nldd-icon name="harvest"></nldd-icon></nldd-icon-cell>
           <nldd-spacer-cell size="8"></nldd-spacer-cell>
           <nldd-text-cell
             :text="bwbIdQuery"
-            :supporting-text="harvestStatusText(bwbIdQuery, 'Niet in het centrale corpus — haal op uit wetten.overheid.nl')"
+            :supporting-text="harvestStatusText(bwbIdQuery, 'Haal dit BWB-id op uit wetten.overheid.nl')"
           ></nldd-text-cell>
           <nldd-spacer-cell size="8"></nldd-spacer-cell>
           <nldd-cell>

--- a/frontend/src/components/AddLawPopover.vue
+++ b/frontend/src/components/AddLawPopover.vue
@@ -31,7 +31,7 @@ import { useLatest } from '../lib/useLatest.js';
 
 const listTranslations = { 'components.list.search-placeholder-text': 'Zoek een wet of BWB-id…' };
 
-const emit = defineEmits(['promoted', 'harvest-requested']);
+const emit = defineEmits(['promoted', 'harvest-requested', 'upload-requested']);
 
 const { activeTrajectRef } = useTrajects();
 const { results: bwbResults, loading: bwbLoading, search: searchBwb, clear: clearBwb } = useBwbSearch();
@@ -193,6 +193,16 @@ function close() {
   // `?.` op hide zelf: in tests (happy-dom) is het custom element niet
   // geüpgraded en bestaat de methode niet.
   popoverRef.value?.hide?.();
+}
+
+// Derde route naast promoten en harvest: een PDF/Word-document uploaden dat
+// de conversie-naar-wet-keten start (voorheen een apart item in het
+// plus-menu; dat menu is vervallen — de plus opent nu direct deze zoeker).
+// De file-picker zelf leeft in LibraryView; eerst sluiten, anders opent de
+// picker achter het popover.
+function requestUpload() {
+  close();
+  emit('upload-requested');
 }
 
 function onListInput(e) {
@@ -371,6 +381,20 @@ defineExpose({ show });
           ></nldd-inline-dialog>
         </div>
       </nldd-list>
+
+      <!-- Alternatieve route: staat de wet nergens (of alleen op papier),
+           upload dan een PDF/Word-document — de conversie-naar-wet-keten
+           levert het resultaat als review-taak op. Buiten de listbox zodat
+           de empty-states van de zoeker blijven werken. -->
+      <nldd-spacer size="8"></nldd-spacer>
+      <nldd-button
+        size="md"
+        variant="secondary"
+        start-icon="upload-to-cloud"
+        text="PDF of DOCX uploaden…"
+        data-testid="add-law-upload"
+        @click="requestUpload"
+      ></nldd-button>
     </nldd-container>
   </nldd-popover>
 </template>

--- a/frontend/src/components/AddLawPopover.vue
+++ b/frontend/src/components/AddLawPopover.vue
@@ -24,7 +24,8 @@
 import { ref, computed, watch, nextTick } from 'vue';
 import { useBwbSearch, MIN_QUERY_LENGTH } from '../composables/useBwbSearch.js';
 import { useTrajects } from '../composables/useTrajects.js';
-import { lawsListUrl, lawPromoteUrl, trajectHarvestUrl } from '../composables/corpusUrls.js';
+import { useLawPromote } from '../composables/useLawPromote.js';
+import { lawsListUrl, trajectHarvestUrl } from '../composables/corpusUrls.js';
 import { apiFetch, apiFetchJson, ApiError } from '../lib/apiFetch.js';
 import { useLatest } from '../lib/useLatest.js';
 
@@ -47,16 +48,21 @@ const BREAKPOINT_LG_MIN = 1008;
 // Corpus-treffers (traject-gefedereerd: eigen repo + centrale seed) voor de
 // huidige zoekterm.
 const centralLaws = ref([]);
-// Law-ids die al in de traject-repo staan (source_priority 0): promoten is
-// dan niet mogelijk. Een 409 van de backend vult deze set ook bij.
-const inTrajectIds = ref(new Set());
 const searching = ref(false);
 const searchFailed = ref(false);
 
-// Per law_id: 'busy' tijdens de promote-POST; 409 markeert de wet alsnog
-// als al-in-traject. Per bwb_id: 'busy' | 'requested' | 'conflict' | 'error'.
-const promoteState = ref({});
-const promoteError = ref(null);
+// Gedeelde promote-logica (ook gebruikt door de gewone zoekresultaten in
+// SearchPopover): per-wet busy-state, al-in-traject-set, 409-afhandeling.
+const {
+  promoteState,
+  promoteError,
+  setLawsFromSearch,
+  isInTraject: isLawIdInTraject,
+  clearPromoteError,
+  promote: promoteLaw,
+} = useLawPromote(activeTrajectRef);
+
+// Per bwb_id: 'busy' | 'requested' | 'conflict' | 'error'.
 const harvestState = ref({});
 
 function displayName(law) {
@@ -96,7 +102,7 @@ let debounceTimer = null;
 watch(search, (q) => {
   clearBwb();
   searchFailed.value = false;
-  promoteError.value = null;
+  clearPromoteError();
   if (debounceTimer) clearTimeout(debounceTimer);
   const term = q.trim();
   if (term.length < MIN_QUERY_LENGTH) {
@@ -120,9 +126,7 @@ async function runSearch(term) {
     );
     if (!isCurrent()) return;
     centralLaws.value = laws;
-    inTrajectIds.value = new Set(
-      laws.filter((l) => l.source_priority === 0).map((l) => l.law_id),
-    );
+    setLawsFromSearch(laws);
     searchFailed.value = false;
     // Niets in het centrale corpus: val terug op wetten.overheid.nl zodat
     // de gebruiker met een BWB-id een traject-harvest kan starten.
@@ -138,29 +142,14 @@ async function runSearch(term) {
 }
 
 function isInTraject(law) {
-  return inTrajectIds.value.has(law.law_id);
+  return isLawIdInTraject(law.law_id);
 }
 
 async function promote(law) {
-  if (!activeTrajectRef.value) return;
-  const id = law.law_id;
-  if (promoteState.value[id] === 'busy' || isInTraject(law)) return;
-  promoteState.value = { ...promoteState.value, [id]: 'busy' };
-  promoteError.value = null;
-  try {
-    await apiFetchJson(lawPromoteUrl(activeTrajectRef.value, id), { method: 'POST' });
-    promoteState.value = { ...promoteState.value, [id]: 'done' };
-    emit('promoted', id);
+  const outcome = await promoteLaw(law.law_id);
+  if (outcome === 'done') {
+    emit('promoted', law.law_id);
     close();
-  } catch (e) {
-    promoteState.value = { ...promoteState.value, [id]: null };
-    if (e instanceof ApiError && e.status === 409) {
-      // Backend is de autoriteit: markeer als al-in-traject.
-      inTrajectIds.value = new Set([...inTrajectIds.value, id]);
-    } else {
-      promoteError.value =
-        'Toevoegen aan het traject is mislukt. Probeer het opnieuw of neem contact op.';
-    }
   }
 }
 
@@ -201,7 +190,9 @@ function harvestStatusText(bwbId, fallback) {
 }
 
 function close() {
-  popoverRef.value?.hide();
+  // `?.` op hide zelf: in tests (happy-dom) is het custom element niet
+  // geüpgraded en bestaat de methode niet.
+  popoverRef.value?.hide?.();
 }
 
 function onListInput(e) {
@@ -215,7 +206,7 @@ function onListKeydown(e) {
 function onPopoverClose() {
   search.value = '';
   clearBwb();
-  promoteError.value = null;
+  clearPromoteError();
 }
 
 /** Public API: open het popover, verankerd aan het gegeven trigger-element. */

--- a/frontend/src/components/SearchPopover.test.js
+++ b/frontend/src/components/SearchPopover.test.js
@@ -246,6 +246,39 @@ describe('SearchPopover "Toevoegen aan traject" in zoekresultaten', () => {
     expect(wrapper.emitted('select-law')).toBeUndefined();
   });
 
+  it('een promote die pas na het sluiten resolvet, emit niet alsnog in een latere sessie', async () => {
+    let resolvePromote;
+    fetch.mockImplementation(async (url, init = {}) => {
+      const u = String(url);
+      if (u.includes('/auth/status')) return { ok: false, json: async () => ({}) };
+      if (u.includes('/promote') && init.method === 'POST') {
+        return new Promise((r) => {
+          resolvePromote = () => r({ ok: true, json: async () => ({}) });
+        });
+      }
+      if (u.includes('/corpus/laws') && u.includes('q=')) {
+        return { ok: true, json: async () => LAWS };
+      }
+      return { ok: true, json: async () => [] };
+    });
+
+    const wrapper = mount(SearchPopover);
+    await searchFor(wrapper, 'zorgverzekering');
+
+    // De gebruiker sluit de popover terwijl de promote-POST nog loopt…
+    await promoteButtons(wrapper)[0].trigger('click');
+    await wrapper.get('nldd-popover').trigger('close');
+    // …waarna de POST alsnog slaagt: close() is dan een no-op (de popover is
+    // al dicht, dus geen 'close'-event) en de pending emit mag niet blijven
+    // hangen tot een volgende sessie.
+    resolvePromote();
+    await settle();
+
+    await wrapper.get('nldd-popover').trigger('open');
+    await wrapper.get('nldd-popover').trigger('close');
+    expect(wrapper.emitted('promoted')).toBeUndefined();
+  });
+
   it('een 409 markeert de wet als al-in-traject: knop weg, "Al in dit traject"', async () => {
     fetch.mockImplementation(async (url, init = {}) => {
       const u = String(url);

--- a/frontend/src/components/SearchPopover.test.js
+++ b/frontend/src/components/SearchPopover.test.js
@@ -8,9 +8,12 @@ import SearchPopover from './SearchPopover.vue';
 // `wrapper.vm` and assert on the `sortedLaws` computed.
 //
 // useTrajects() calls vue-router's useRoute(); mock it so the component mounts
-// without a router (no active traject → global /api/corpus URL).
+// without a router. Default: no active traject → global /api/corpus URL. The
+// traject-scoped promote tests swap in a trajectRef per test (vi.hoisted so
+// the hoisted mock factory can reference it).
+const routeMock = vi.hoisted(() => ({ params: {} }));
 vi.mock('vue-router', () => ({
-  useRoute: () => ({ params: {} }),
+  useRoute: () => routeMock,
 }));
 
 // Central corpus (priority 2) listed before the private traject repo
@@ -32,6 +35,7 @@ const LAWS = [
 ];
 
 beforeEach(() => {
+  routeMock.params = {};
   vi.stubGlobal(
     'fetch',
     vi.fn(async (url) => {
@@ -154,5 +158,151 @@ describe('SearchPopover server-side search', () => {
       .map((c) => String(c[0]))
       .filter((u) => u.includes('/harvest/search'));
     expect(bwbCalls).toHaveLength(0);
+  });
+
+  it('renders no promote buttons outside a traject (global corpus scope)', async () => {
+    const wrapper = mount(SearchPopover);
+    await searchFor(wrapper, 'zorgverzekering');
+
+    expect(wrapper.findAll('nldd-list-item[data-law-id]')).toHaveLength(2);
+    expect(promoteButtons(wrapper)).toHaveLength(0);
+  });
+});
+
+// Fictieve traject-ref (publiek testbestand, geen echte repo/traject-namen).
+const TRAJECT_REF = 'voorbeeld-abcd1234';
+
+async function searchFor(wrapper, term) {
+  wrapper.vm.search = term;
+  await nextTick();
+  await settle();
+  await nextTick();
+}
+
+function promoteButtons(wrapper) {
+  return wrapper
+    .findAll('nldd-button')
+    .filter((b) => b.attributes('text') === 'Toevoegen aan traject');
+}
+
+describe('SearchPopover "Toevoegen aan traject" in zoekresultaten', () => {
+  beforeEach(() => {
+    routeMock.params = { trajectRef: TRAJECT_REF };
+  });
+
+  it('toont de knop alleen bij federatie-treffers die nog niet in de eigen repo staan', async () => {
+    const wrapper = mount(SearchPopover);
+    await searchFor(wrapper, 'zorgverzekering');
+
+    const rows = wrapper.findAll('nldd-list-item[data-law-id]');
+    const central = rows.find((r) => r.attributes('data-law-id') === 'besluit_zorgverzekering');
+    const own = rows.find(
+      (r) => r.attributes('data-law-id') === 'besluit_zorgverzekering_example',
+    );
+
+    // Centrale-seed-treffer (priority 2): wel een promote-knop.
+    expect(
+      central.findAll('nldd-button').some((b) => b.attributes('text') === 'Toevoegen aan traject'),
+    ).toBe(true);
+    // Eigen-repo-treffer (priority 0): geen knop - er valt niets te promoten.
+    expect(own.findAll('nldd-button')).toHaveLength(0);
+    expect(own.get('nldd-text-cell').attributes('supporting-text')).toBe(
+      'example-org/regelrecht-corpus-example',
+    );
+  });
+
+  it('promoot via POST /promote en emit "promoted" (niet select-law) na sluiten', async () => {
+    fetch.mockImplementation(async (url, init = {}) => {
+      const u = String(url);
+      if (u.includes('/auth/status')) return { ok: false, json: async () => ({}) };
+      if (u.includes('/promote') && init.method === 'POST') {
+        return { ok: true, json: async () => ({ law_id: 'besluit_zorgverzekering' }) };
+      }
+      if (u.includes('/corpus/laws') && u.includes('q=')) {
+        return { ok: true, json: async () => LAWS };
+      }
+      return { ok: true, json: async () => [] };
+    });
+
+    const wrapper = mount(SearchPopover);
+    await searchFor(wrapper, 'zorgverzekering');
+
+    await promoteButtons(wrapper)[0].trigger('click');
+    await settle();
+
+    const promoteCall = fetch.mock.calls.find(
+      (c) => String(c[0]).includes('/promote') && c[1]?.method === 'POST',
+    );
+    expect(String(promoteCall[0])).toBe(
+      `/api/trajects/${TRAJECT_REF}/corpus/laws/besluit_zorgverzekering/promote`,
+    );
+
+    // Zelfde deferral als select-law: de emit komt pas als de popover dicht
+    // is, zodat de focus-op-de-wet van de parent wint van _returnFocus.
+    expect(wrapper.emitted('promoted')).toBeUndefined();
+    await wrapper.get('nldd-popover').trigger('close');
+    expect(wrapper.emitted('promoted')).toEqual([['besluit_zorgverzekering']]);
+    // click.stop: de knop mag de rij-navigatie (select-law) niet triggeren.
+    expect(wrapper.emitted('select-law')).toBeUndefined();
+  });
+
+  it('een 409 markeert de wet als al-in-traject: knop weg, "Al in dit traject"', async () => {
+    fetch.mockImplementation(async (url, init = {}) => {
+      const u = String(url);
+      if (u.includes('/auth/status')) return { ok: false, json: async () => ({}) };
+      if (u.includes('/promote') && init.method === 'POST') {
+        return { ok: false, status: 409, text: async () => 'al in traject', headers: { get: () => '' } };
+      }
+      if (u.includes('/corpus/laws') && u.includes('q=')) {
+        return { ok: true, json: async () => LAWS };
+      }
+      return { ok: true, json: async () => [] };
+    });
+
+    const wrapper = mount(SearchPopover);
+    await searchFor(wrapper, 'zorgverzekering');
+
+    await promoteButtons(wrapper)[0].trigger('click');
+    await settle();
+    await nextTick();
+
+    expect(promoteButtons(wrapper)).toHaveLength(0);
+    const central = wrapper.get('nldd-list-item[data-law-id="besluit_zorgverzekering"]');
+    expect(central.get('nldd-text-cell').attributes('supporting-text')).toBe('Al in dit traject');
+    await wrapper.get('nldd-popover').trigger('close');
+    expect(wrapper.emitted('promoted')).toBeUndefined();
+  });
+
+  it('een niet-409-fout toont de foutbanner en laat de knop staan', async () => {
+    fetch.mockImplementation(async (url, init = {}) => {
+      const u = String(url);
+      if (u.includes('/auth/status')) return { ok: false, json: async () => ({}) };
+      if (u.includes('/promote') && init.method === 'POST') {
+        return { ok: false, status: 500, text: async () => 'boem', headers: { get: () => '' } };
+      }
+      if (u.includes('/corpus/laws') && u.includes('q=')) {
+        return { ok: true, json: async () => LAWS };
+      }
+      return { ok: true, json: async () => [] };
+    });
+
+    const wrapper = mount(SearchPopover);
+    await searchFor(wrapper, 'zorgverzekering');
+
+    await promoteButtons(wrapper)[0].trigger('click');
+    await settle();
+    await nextTick();
+
+    expect(wrapper.vm.promoteError).toBeTruthy();
+    // De banner-rij draagt de melding als attribute op de nldd-text-cell
+    // (custom elements renderen tekst niet als DOM-tekst in happy-dom).
+    const bannerTexts = wrapper
+      .findAll('nldd-text-cell')
+      .map((c) => c.attributes('text'));
+    expect(bannerTexts).toContain(
+      'Toevoegen aan het traject is mislukt. Probeer het opnieuw of neem contact op.',
+    );
+    expect(promoteButtons(wrapper)).toHaveLength(1);
+    expect(wrapper.emitted('promoted')).toBeUndefined();
   });
 });

--- a/frontend/src/components/SearchPopover.vue
+++ b/frontend/src/components/SearchPopover.vue
@@ -4,6 +4,7 @@ import { useBwbSearch, MIN_QUERY_LENGTH } from '../composables/useBwbSearch.js';
 import { useBwbHarvest } from '../composables/useBwbHarvest.js';
 import { useAuth } from '../composables/useAuth.js';
 import { useTrajects } from '../composables/useTrajects.js';
+import { useLawPromote } from '../composables/useLawPromote.js';
 import { lawsListUrl } from '../composables/corpusUrls.js';
 import { apiFetchJson } from '../lib/apiFetch.js';
 import { useLatest } from '../lib/useLatest.js';
@@ -13,9 +14,23 @@ import { SEARCH_PLACEHOLDER, SEARCH_ACCESSIBLE_LABEL } from '../constants.js';
 // so this popover stays in sync with the main search-field in AppShell.
 const listTranslations = { 'components.list.search-placeholder-text': SEARCH_PLACEHOLDER };
 
-const emit = defineEmits(['select-law', 'harvest-available']);
+const emit = defineEmits(['select-law', 'harvest-available', 'promoted']);
 
 const { activeTrajectRef } = useTrajects();
+
+// "Toevoegen aan traject" direct vanuit de zoekresultaten: een treffer uit een
+// gefedereerde bron (de centrale seed, source_priority > 0) die nog niet in de
+// eigen traject-repo staat, krijgt een promote-knop in de rij. Zelfde gedeelde
+// logica als de "Wet toevoegen"-flow (AddLawPopover) - geen tweede
+// promote-implementatie.
+const {
+  promoteState,
+  promoteError,
+  setLawsFromSearch,
+  isInTraject: isLawIdInTraject,
+  clearPromoteError,
+  promote: promoteLaw,
+} = useLawPromote(activeTrajectRef);
 
 const { results: bwbResults, loading: bwbLoading, search: searchBwb, clear: clearBwb } = useBwbSearch();
 const {
@@ -100,6 +115,7 @@ let debounceTimer = null;
 watch(search, (q) => {
   clearBwb();
   searchFailed.value = false;
+  clearPromoteError();
   if (debounceTimer) clearTimeout(debounceTimer);
   const term = q.trim();
   if (term.length < MIN_QUERY_LENGTH) {
@@ -123,6 +139,9 @@ async function runCorpusSearch(term) {
     const laws = await apiFetchJson(url);
     if (!isCurrent()) return; // a newer query superseded this one
     serverLaws.value = laws;
+    // Ververs de al-in-traject-set (source_priority 0 = eigen repo) zodat de
+    // promote-knop alleen op nog-niet-gepromote federatie-treffers verschijnt.
+    setLawsFromSearch(laws);
     searchFailed.value = false;
     // No match anywhere in the corpus → offer the external wetten.overheid.nl
     // search (unless the user must log in first to reach it).
@@ -157,7 +176,9 @@ function bwbItemClick(result) {
 }
 
 function close() {
-  popoverRef.value?.hide();
+  // `?.` op hide zelf: in tests (happy-dom) is het custom element niet
+  // geüpgraded en bestaat de methode niet.
+  popoverRef.value?.hide?.();
 }
 
 /**
@@ -184,9 +205,16 @@ function onListKeydown(e) {
 function onPopoverClose() {
   search.value = '';
   clearBwb();
-  // Emit the deferred selection now: the popover has closed and already run its
-  // _returnFocus, so the parent's focus-the-law wins (see selectLaw).
-  if (pendingSelectLawId !== null) {
+  clearPromoteError();
+  // Emit the deferred promote/selection now: the popover has closed and
+  // already run its _returnFocus, so the parent's focus-the-law wins (see
+  // selectLaw / promoteFromRow).
+  if (pendingPromotedLawId !== null) {
+    const lawId = pendingPromotedLawId;
+    pendingPromotedLawId = null;
+    pendingSelectLawId = null;
+    emit('promoted', lawId);
+  } else if (pendingSelectLawId !== null) {
     const lawId = pendingSelectLawId;
     pendingSelectLawId = null;
     emit('select-law', lawId);
@@ -204,6 +232,38 @@ let pendingSelectLawId = null;
 function selectLaw(lawId) {
   pendingSelectLawId = lawId;
   close();
+}
+
+// The promoted law id, emitted on 'promoted' once the popover has fully closed
+// (same deferral as pendingSelectLawId): the parent refreshes its index and
+// opens/focuses the law, which must win from the popover's _returnFocus.
+let pendingPromotedLawId = null;
+
+/**
+ * Alleen federatie-treffers (centrale seed, source_priority > 0) die nog niet
+ * in de eigen traject-repo staan krijgen de knop; buiten een traject (globale
+ * corpus-weergave) is er niets om naartoe te promoten. Na een 409 verhuist de
+ * wet naar de al-in-traject-set en toont de rij "Al in dit traject".
+ */
+function canPromote(law) {
+  return (
+    Boolean(activeTrajectRef.value) &&
+    law.source_priority !== 0 &&
+    !isLawIdInTraject(law.law_id)
+  );
+}
+
+function lawSupportingText(law) {
+  if (law.source_priority !== 0 && isLawIdInTraject(law.law_id)) return 'Al in dit traject';
+  return law.source_name || undefined;
+}
+
+async function promoteFromRow(law) {
+  const outcome = await promoteLaw(law.law_id);
+  if (outcome === 'done') {
+    pendingPromotedLawId = law.law_id;
+    close();
+  }
 }
 
 /**
@@ -321,19 +381,43 @@ defineExpose({ show });
           @click="close"
         ></nldd-button>
 
+        <!-- Fout bij promoten: één banner boven de resultaten (zelfde vorm
+             als in AddLawPopover). -->
+        <nldd-list-item v-if="promoteError" size="md">
+          <nldd-icon-cell size="20" icon="alert" color="critical"></nldd-icon-cell>
+          <nldd-spacer-cell size="8"></nldd-spacer-cell>
+          <nldd-text-cell :text="promoteError" color="critical"></nldd-text-cell>
+        </nldd-list-item>
+
         <!-- Interne corpus-treffers: platte lijst, eigen repo eerst (op
-             bron-prioriteit), met de bron als ondertitel per rij. -->
+             bron-prioriteit), met de bron als ondertitel per rij. Een treffer
+             uit de centrale seed die nog niet in de eigen traject-repo staat,
+             krijgt direct een "Toevoegen aan traject"-knop (click.stop: de
+             knop mag de rij-navigatie niet triggeren). -->
         <nldd-list-item
           v-for="law in sortedLaws"
           :key="law.law_id"
+          :data-law-id="law.law_id"
           size="md"
           button
           @click="selectLaw(law.law_id)"
         >
           <nldd-text-cell
             :text="displayName(law)"
-            :supporting-text="law.source_name || undefined"
+            :supporting-text="lawSupportingText(law)"
           ></nldd-text-cell>
+          <template v-if="canPromote(law)">
+            <nldd-spacer-cell size="8"></nldd-spacer-cell>
+            <nldd-cell>
+              <nldd-button
+                size="sm"
+                variant="secondary"
+                text="Toevoegen aan traject"
+                :loading="promoteState[law.law_id] === 'busy' || undefined"
+                @click.stop="promoteFromRow(law)"
+              ></nldd-button>
+            </nldd-cell>
+          </template>
         </nldd-list-item>
 
         <!-- Externe wetten.overheid.nl-treffers (alleen wanneer de corpus niets

--- a/frontend/src/components/SearchPopover.vue
+++ b/frontend/src/components/SearchPopover.vue
@@ -318,6 +318,13 @@ async function show(anchorEl, initialSearch = '') {
  * to the host. The `open` event fires AFTER _manageFocus, so our focus wins.
  */
 function onPopoverOpen() {
+  // Verse sessie: gooi een pending emit van een vorige sessie weg. Die kan
+  // blijven hangen wanneer de promote-POST pas resolvet nadat de gebruiker de
+  // popover al sloot — close() is dan een no-op (de popover is al dicht, dus
+  // geen 'close'-event) en zonder deze reset zou de eerstvolgende close een
+  // stale 'promoted' emitten en een legitieme select-law verdringen.
+  pendingPromotedLawId = null;
+  pendingSelectLawId = null;
   const list = popoverRef.value?.querySelector('nldd-list');
   const input = list?.shadowRoot?.querySelector('.list__search-field-input');
   if (input) {

--- a/frontend/src/components/TasksPane.test.js
+++ b/frontend/src/components/TasksPane.test.js
@@ -68,6 +68,21 @@ describe('TasksPane', () => {
     expect(indicators[0].attributes('text')).toBe('Conversie loopt - rapport.md');
   });
 
+  it('toont een lopende traject-harvest met het BWB-id', async () => {
+    const wrapper = await mountPane(
+      [],
+      [{
+        job_id: 'j3',
+        job_type: 'traject_harvest',
+        law_id: 'BWBR0002399',
+        status: 'pending',
+      }]
+    );
+    const indicators = wrapper.findAll('nldd-activity-indicator');
+    expect(indicators).toHaveLength(1);
+    expect(indicators[0].attributes('text')).toBe('Wet ophalen loopt - BWBR0002399');
+  });
+
   it('toont zowel de Bezig-sectie als de takenlijst wanneer beide gevuld zijn', async () => {
     const wrapper = await mountPane(
       [{ id: 't1', task_type: 'job_review', title: 'Verrijking beoordelen: andere_wet', payload: {} }],

--- a/frontend/src/components/TasksPane.vue
+++ b/frontend/src/components/TasksPane.vue
@@ -43,6 +43,10 @@ function runningText(job) {
     const name = job.target_path?.split('/').pop() || 'document';
     return `Wet maken loopt - ${name}`;
   }
+  if (job.job_type === 'traject_harvest') {
+    // law_id draagt hier het BWB-id van de op te halen wet.
+    return `Wet ophalen loopt - ${job.law_id}`;
+  }
   return `Verrijking loopt - ${job.law_id}`;
 }
 

--- a/frontend/src/composables/corpusUrls.js
+++ b/frontend/src/composables/corpusUrls.js
@@ -111,6 +111,21 @@ export function lawCreateUrl(trajectRef) {
   return `${corpusBase(trajectRef)}/laws`;
 }
 
+// Promote: kopieer een wet uit het CENTRALE corpus (alle versie-YAML's +
+// scenario's) naar de traject-repo, via het gewone traject-schrijfpad.
+export function lawPromoteUrl(trajectRef, lawId) {
+  requireTraject(trajectRef, 'law promote');
+  return `${lawUrl(trajectRef, lawId)}/promote`;
+}
+
+// Traject-scoped harvest via het taken-mechanisme: POST { bwb_id } start een
+// async BWB-download + geketende enrich; het resultaat komt terug als
+// `law_create`-review-taak in het takenpaneel.
+export function trajectHarvestUrl(trajectRef) {
+  requireTraject(trajectRef, 'traject harvest');
+  return `${corpusBase(trajectRef)}/harvest`;
+}
+
 // Running/failed document-conversion jobs for the traject, backing the
 // werkdocumenten conversion-status block.
 export function documentJobsUrl(trajectRef) {

--- a/frontend/src/composables/useLawPromote.js
+++ b/frontend/src/composables/useLawPromote.js
@@ -1,0 +1,77 @@
+// Gedeelde "Toevoegen aan traject"-logica (promote): één implementatie van de
+// POST /promote-aanroep met per-wet busy-state, de al-in-traject-administratie
+// en de 409-afhandeling. Gebruikt door zowel de AddLawPopover ("Wet
+// toevoegen"-flow) als de gewone zoekresultaten (SearchPopover) — geen tweede
+// promote-implementatie.
+//
+// De al-in-traject-set wordt gevoed vanuit de traject-gefedereerde zoeklijst:
+// source_priority 0 = de eigen schrijfbare traject-repo, dus niet (nogmaals)
+// promoteerbaar. De backend blijft de autoriteit: een 409 op de promote
+// markeert de wet alsnog als al-in-traject.
+import { ref } from 'vue';
+import { lawPromoteUrl } from './corpusUrls.js';
+import { apiFetchJson, ApiError } from '../lib/apiFetch.js';
+
+export const PROMOTE_ERROR_TEXT =
+  'Toevoegen aan het traject is mislukt. Probeer het opnieuw of neem contact op.';
+
+export function useLawPromote(activeTrajectRef) {
+  // Per law_id: 'busy' tijdens de promote-POST, 'done' na succes.
+  const promoteState = ref({});
+  // Eén foutmelding voor de laatste mislukte promote (niet-409).
+  const promoteError = ref(null);
+  // Law-ids die al in de traject-repo staan (source_priority 0, of 409 van de
+  // backend): promoten is dan niet mogelijk.
+  const inTrajectIds = ref(new Set());
+
+  /** Ververs de al-in-traject-set vanuit een traject-gefedereerde zoeklijst. */
+  function setLawsFromSearch(laws) {
+    inTrajectIds.value = new Set(
+      laws.filter((l) => l.source_priority === 0).map((l) => l.law_id),
+    );
+  }
+
+  function isInTraject(lawId) {
+    return inTrajectIds.value.has(lawId);
+  }
+
+  function clearPromoteError() {
+    promoteError.value = null;
+  }
+
+  /**
+   * Kopieer de wet naar de traject-repo via de promote-endpoint.
+   * Retourneert 'done' | 'conflict' | 'error', of null als de aanroep een
+   * no-op was (geen traject, al bezig, of al in het traject).
+   */
+  async function promote(lawId) {
+    if (!activeTrajectRef.value) return null;
+    if (promoteState.value[lawId] === 'busy' || isInTraject(lawId)) return null;
+    promoteState.value = { ...promoteState.value, [lawId]: 'busy' };
+    promoteError.value = null;
+    try {
+      await apiFetchJson(lawPromoteUrl(activeTrajectRef.value, lawId), { method: 'POST' });
+      promoteState.value = { ...promoteState.value, [lawId]: 'done' };
+      return 'done';
+    } catch (e) {
+      promoteState.value = { ...promoteState.value, [lawId]: null };
+      if (e instanceof ApiError && e.status === 409) {
+        // Backend is de autoriteit: markeer als al-in-traject.
+        inTrajectIds.value = new Set([...inTrajectIds.value, lawId]);
+        return 'conflict';
+      }
+      promoteError.value = PROMOTE_ERROR_TEXT;
+      return 'error';
+    }
+  }
+
+  return {
+    promoteState,
+    promoteError,
+    inTrajectIds,
+    setLawsFromSearch,
+    isInTraject,
+    clearPromoteError,
+    promote,
+  };
+}

--- a/packages/corpus/src/github.rs
+++ b/packages/corpus/src/github.rs
@@ -154,6 +154,13 @@ mod inner {
 
     impl GitHubFetcher {
         /// Create a new fetcher.
+        ///
+        /// The API base defaults to `api.github.com`; the `GITHUB_API_BASE`
+        /// env var overrides it process-wide. That override exists for
+        /// integration tests that stand up a wiremock GitHub (the fetcher is
+        /// constructed deep inside backend/registry code with no config
+        /// plumbing to inject a base URL) and doubles as a GitHub
+        /// Enterprise seam. Production deployments leave it unset.
         pub fn new() -> Result<Self> {
             let client = reqwest::Client::builder()
                 .user_agent("regelrecht-corpus/0.1")
@@ -162,9 +169,15 @@ mod inner {
                 .build()
                 .map_err(|e| CorpusError::Config(format!("Failed to create HTTP client: {}", e)))?;
 
+            let api_base = std::env::var("GITHUB_API_BASE")
+                .ok()
+                .map(|s| s.trim().trim_end_matches('/').to_string())
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| "https://api.github.com".to_string());
+
             Ok(Self {
                 client,
-                api_base: "https://api.github.com".to_string(),
+                api_base,
                 etag_cache: HashMap::new(),
                 rate_limit_remaining: None,
             })

--- a/packages/corpus/src/github_api_backend.rs
+++ b/packages/corpus/src/github_api_backend.rs
@@ -69,6 +69,12 @@ struct Inner {
     sha_cache: HashMap<PathBuf, String>,
     /// Buffered writes/deletes, in insertion order.
     pending: Vec<(PathBuf, PendingWrite)>,
+    /// Whether the target branch is known to exist. Set by a successful
+    /// `ensure_ready` (rest-token bootstrap) or by the lazy bootstrap in
+    /// `persist`. A token-less backend skips branch creation at
+    /// `ensure_ready`, so the first user-token write mints the branch
+    /// itself — this flag keeps that to one round-trip per backend.
+    branch_ready: bool,
 }
 
 pub struct GitHubApiBackend {
@@ -82,7 +88,11 @@ pub struct GitHubApiBackend {
     /// Path prefix inside the repo (same role as `repo_subpath` on
     /// `GitBackend`). Source-relative paths are joined under this.
     sub_path: Option<String>,
-    /// OAuth/PAT token for the API. `None` makes the backend read-only.
+    /// OAuth/PAT token for the API. `None` makes the backend read-only
+    /// **at rest** (`is_writable` = false): writes can then still land via
+    /// a per-call `WriteContext::token_override` (the acting editor user's
+    /// own GitHub token) — `persist` refuses only when *neither* token is
+    /// present.
     token: Option<String>,
     inner: Mutex<Inner>,
 }
@@ -104,6 +114,7 @@ impl GitHubApiBackend {
                 fetcher: GitHubFetcher::new()?,
                 sha_cache: HashMap::new(),
                 pending: Vec::new(),
+                branch_ready: false,
             }),
         })
     }
@@ -178,6 +189,63 @@ impl GitHubApiBackend {
             Some((_, sha)) => Ok(Some(sha)),
             None => Ok(None),
         }
+    }
+
+    /// Ensure `branch` exists on `repo`, creating it from `base_branch`
+    /// when missing. Shared by `ensure_ready` (rest-token bootstrap at
+    /// backend init) and `persist` (lazy bootstrap with the per-call
+    /// user token, for backends that had no token at init).
+    async fn ensure_branch(
+        fetcher: &mut GitHubFetcher,
+        repo: &str,
+        branch: &str,
+        base_branch: Option<&str>,
+        token: Option<&str>,
+    ) -> Result<()> {
+        let exists = fetcher.branch_exists(repo, branch, token).await?;
+        if exists {
+            return Ok(());
+        }
+        let base = base_branch.ok_or_else(|| {
+            CorpusError::Config(format!(
+                "branch '{}' does not exist on {} and no base_branch \
+                 was configured to seed it from",
+                branch, repo
+            ))
+        })?;
+        // TOCTOU on lazy branch creation: between our `branch_exists`
+        // returning false and this POST, another activation (different
+        // backend instance, same traject) can win the race and create
+        // the branch first. GitHub then 422s us with "Reference already
+        // exists". Re-check `branch_exists` on any create_branch failure;
+        // if the branch is present now the desired post-condition holds
+        // and we treat the create as a benign no-op.
+        match fetcher.create_branch(repo, branch, base, token).await {
+            Ok(()) => {
+                tracing::info!(
+                    repo = %repo,
+                    branch = %branch,
+                    base = %base,
+                    "GitHubApiBackend: created traject branch from base"
+                );
+            }
+            Err(e) => {
+                let now_exists = fetcher
+                    .branch_exists(repo, branch, token)
+                    .await
+                    .unwrap_or(false);
+                if now_exists {
+                    tracing::info!(
+                        repo = %repo,
+                        branch = %branch,
+                        "GitHubApiBackend: create_branch lost a benign race; branch already exists"
+                    );
+                } else {
+                    return Err(e);
+                }
+            }
+        }
+        Ok(())
     }
 }
 
@@ -266,13 +334,12 @@ impl RepoBackend for GitHubApiBackend {
             .collect())
     }
 
+    // No token guard here: a backend without a rest-token can still
+    // commit via `WriteContext::token_override` (per-user GitHub OAuth),
+    // and the override only becomes visible at `persist`. Buffer now;
+    // `persist` refuses with `ReadOnly` when neither token is present.
     async fn write_file(&self, relative_path: &Path, content: &str) -> Result<()> {
         validate_relative(relative_path)?;
-        if self.token.is_none() {
-            return Err(CorpusError::ReadOnly(
-                "GitHubApiBackend has no push token".to_string(),
-            ));
-        }
         let mut inner = self.inner.lock().await;
         let base_sha = inner.sha_cache.get(relative_path).cloned();
         inner.pending.push((
@@ -285,13 +352,9 @@ impl RepoBackend for GitHubApiBackend {
         Ok(())
     }
 
+    // Same stance as `write_file`: token enforcement lives in `persist`.
     async fn delete_file(&self, relative_path: &Path) -> Result<()> {
         validate_relative(relative_path)?;
-        if self.token.is_none() {
-            return Err(CorpusError::ReadOnly(
-                "GitHubApiBackend has no push token".to_string(),
-            ));
-        }
         let mut inner = self.inner.lock().await;
         let base_sha = inner.sha_cache.get(relative_path).cloned();
         inner.pending.push((
@@ -442,8 +505,16 @@ impl RepoBackend for GitHubApiBackend {
         // OAuth token) supersedes the backend's baked-in token for this write,
         // so the commit authenticates *as the user* and GitHub enforces their
         // push rights. Absent an override we fall back to the configured token
-        // — byte-identical to the pre-spike behaviour.
-        let token = ctx.token_override.as_deref().or(self.token.as_deref());
+        // — byte-identical to the pre-spike behaviour. Neither present =
+        // read-only: this is where the token guard lives now that
+        // `write_file`/`delete_file` buffer unconditionally (the override
+        // only exists at persist time). The drained pending buffer is
+        // dropped on this error, same as any other failing persist.
+        let Some(token) = ctx.token_override.as_deref().or(self.token.as_deref()) else {
+            return Err(CorpusError::ReadOnly(
+                "GitHubApiBackend has no push token (neither configured nor per-user)".to_string(),
+            ));
+        };
 
         // With a user token the commit is left unattributed on our side:
         // the Contents API then defaults author/committer to the
@@ -481,6 +552,24 @@ impl RepoBackend for GitHubApiBackend {
         // single write before calling persist, so there is no partially-
         // applied multi-write batch to recover here.
         let mut inner = self.inner.lock().await;
+
+        // Lazy branch bootstrap for the user-token write mode: a backend
+        // without a rest-token skipped branch creation at `ensure_ready`
+        // (it had nothing to authenticate with), so the first persist must
+        // mint the traject branch itself — with the same effective token
+        // that authenticates the commit.
+        if !inner.branch_ready {
+            Self::ensure_branch(
+                &mut inner.fetcher,
+                &repo,
+                &self.branch,
+                self.base_branch.as_deref(),
+                Some(token),
+            )
+            .await?;
+            inner.branch_ready = true;
+        }
+
         for (path, pw) in pending {
             let api_path = self.api_path(&path)?;
             match pw.op {
@@ -494,7 +583,7 @@ impl RepoBackend for GitHubApiBackend {
                         pw.base_sha.as_deref(),
                         committer.as_ref(),
                         &ctx.message,
-                        token,
+                        Some(token),
                     )
                     .await?;
                     new_shas.insert(path, new_sha);
@@ -503,8 +592,14 @@ impl RepoBackend for GitHubApiBackend {
                     let sha_for_delete = match &pw.base_sha {
                         Some(s) => s.clone(),
                         None => {
-                            match Self::fetch_sha(&mut inner, &repo, &self.branch, &api_path, token)
-                                .await?
+                            match Self::fetch_sha(
+                                &mut inner,
+                                &repo,
+                                &self.branch,
+                                &api_path,
+                                Some(token),
+                            )
+                            .await?
                             {
                                 Some(s) => s,
                                 // Already gone: treat as a successful delete,
@@ -521,7 +616,7 @@ impl RepoBackend for GitHubApiBackend {
                         &sha_for_delete,
                         committer.as_ref(),
                         &ctx.message,
-                        token,
+                        Some(token),
                     )
                     .await?;
                     // Drop the cached SHA so a next read sees the file as
@@ -555,70 +650,32 @@ impl RepoBackend for GitHubApiBackend {
 
     #[tracing::instrument(name = "gh_ensure_ready", skip_all, fields(branch = %self.branch))]
     async fn ensure_ready(&mut self) -> Result<()> {
-        // Read-only backends have nothing to bootstrap — the branch
-        // either exists (reads work) or it doesn't (reads 404 as
-        // they'd 404 on a missing file), and we don't try to mint a
-        // branch without a write token.
+        // Backends without a rest-token have nothing to bootstrap here —
+        // the branch either exists (reads work) or it doesn't (reads 404
+        // as they'd 404 on a missing file), and we can't mint a branch
+        // without a token. In the user-token write mode the first
+        // `persist` bootstraps the branch instead, with the per-call
+        // override token.
         if self.token.is_none() {
             return Ok(());
         }
         // Branch-check (+ lazy create) round-trips against GitHub; feeds
         // the `ensure_ready` Server-Timing phase on the cold-build path.
         let ready_start = std::time::Instant::now();
-        let inner = self.inner.get_mut();
         let repo = format!("{}/{}", self.owner, self.repo);
-        let exists = inner
-            .fetcher
-            .branch_exists(&repo, &self.branch, self.token.as_deref())
-            .await?;
-        if exists {
-            timing::record("ensure_ready", ready_start.elapsed());
-            return Ok(());
-        }
-        let base = self.base_branch.as_deref().ok_or_else(|| {
-            CorpusError::Config(format!(
-                "branch '{}' does not exist on {}/{} and no base_branch \
-                 was configured to seed it from",
-                self.branch, self.owner, self.repo
-            ))
-        })?;
-        // TOCTOU on lazy branch creation: between our `branch_exists`
-        // returning false and this POST, another activation (different
-        // backend instance, same traject) can win the race and create
-        // the branch first. GitHub then 422s us with "Reference already
-        // exists". Re-check `branch_exists` on any create_branch failure;
-        // if the branch is present now the desired post-condition holds
-        // and we treat the create as a benign no-op.
-        match inner
-            .fetcher
-            .create_branch(&repo, &self.branch, base, self.token.as_deref())
-            .await
-        {
-            Ok(()) => {
-                tracing::info!(
-                    repo = %repo,
-                    branch = %self.branch,
-                    base = %base,
-                    "GitHubApiBackend: created traject branch from base"
-                );
-            }
-            Err(e) => {
-                let now_exists = inner
-                    .fetcher
-                    .branch_exists(&repo, &self.branch, self.token.as_deref())
-                    .await
-                    .unwrap_or(false);
-                if now_exists {
-                    tracing::info!(
-                        repo = %repo,
-                        branch = %self.branch,
-                        "GitHubApiBackend: create_branch lost a benign race; branch already exists"
-                    );
-                } else {
-                    return Err(e);
-                }
-            }
-        }
+        let branch = self.branch.clone();
+        let base_branch = self.base_branch.clone();
+        let token = self.token.clone();
+        let inner = self.inner.get_mut();
+        Self::ensure_branch(
+            &mut inner.fetcher,
+            &repo,
+            &branch,
+            base_branch.as_deref(),
+            token.as_deref(),
+        )
+        .await?;
+        inner.branch_ready = true;
         timing::record("ensure_ready", ready_start.elapsed());
         Ok(())
     }
@@ -877,6 +934,17 @@ mod tests {
     /// JSON body of the resulting Contents API PUT.
     async fn persist_and_capture_put_body(ctx: WriteContext) -> serde_json::Value {
         let server = MockServer::start().await;
+        // `persist` bootstraps the branch lazily when `ensure_ready` never
+        // ran (this helper builds the backend directly); an existing branch
+        // is a single ref GET.
+        Mock::given(method("GET"))
+            .and(path_matcher("/repos/acme/corpus/git/ref/heads/main"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ref": "refs/heads/main",
+                "object": {"sha": "branch-sha"}
+            })))
+            .mount(&server)
+            .await;
         Mock::given(method("PUT"))
             .and(path_matcher(
                 "/repos/acme/corpus/contents/regulation/nl/wet/foo/2025-01-01.yaml",

--- a/packages/corpus/tests/github_api_backend.rs
+++ b/packages/corpus/tests/github_api_backend.rs
@@ -45,9 +45,25 @@ fn ctx() -> WriteContext {
     WriteContext::new("test commit".to_string(), None)
 }
 
+/// `persist` bootstraps the traject branch lazily when `ensure_ready` never
+/// ran (these tests construct the backend directly, so `branch_ready` is
+/// false): mount the ref-GET reporting the branch as already existing so a
+/// persisting test needs no create-branch mocks.
+async fn mount_branch_exists(server: &MockServer) {
+    Mock::given(method("GET"))
+        .and(path("/repos/acme/corpus/git/ref/heads/traject/abc"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "ref": "refs/heads/traject/abc",
+            "object": { "sha": "branch-sha" },
+        })))
+        .mount(server)
+        .await;
+}
+
 #[tokio::test]
 async fn read_file_returns_content_and_caches_sha_for_later_write() {
     let server = MockServer::start().await;
+    mount_branch_exists(&server).await;
 
     // Read returns content + sha.
     Mock::given(method("GET"))
@@ -90,6 +106,7 @@ async fn read_file_returns_content_and_caches_sha_for_later_write() {
 #[tokio::test]
 async fn persist_with_token_override_authenticates_as_the_user() {
     let server = MockServer::start().await;
+    mount_branch_exists(&server).await;
 
     // The PUT must carry the *override* token — the acting user's own
     // credential — not the backend's baked-in "test-token". Matching on the
@@ -122,6 +139,7 @@ async fn persist_with_token_override_authenticates_as_the_user() {
 #[tokio::test]
 async fn persist_without_override_keeps_the_backend_token() {
     let server = MockServer::start().await;
+    mount_branch_exists(&server).await;
 
     // The counterpart: no override → the configured backend token, exactly
     // the pre-spike behaviour every non-editor call site relies on.
@@ -145,6 +163,7 @@ async fn persist_without_override_keeps_the_backend_token() {
 #[tokio::test]
 async fn write_without_prior_read_resolves_sha_lazily_at_persist() {
     let server = MockServer::start().await;
+    mount_branch_exists(&server).await;
 
     // First PUT (no sha) returns 422 — file already exists; backend must
     // then GET sha and re-PUT.
@@ -192,6 +211,7 @@ async fn write_without_prior_read_resolves_sha_lazily_at_persist() {
 #[tokio::test]
 async fn put_409_refreshes_sha_and_retries_once() {
     let server = MockServer::start().await;
+    mount_branch_exists(&server).await;
 
     // The caller read the file once, caching sha-old.
     Mock::given(method("GET"))
@@ -246,6 +266,7 @@ async fn put_409_refreshes_sha_and_retries_once() {
 #[tokio::test]
 async fn delete_path_resolves_sha_then_deletes() {
     let server = MockServer::start().await;
+    mount_branch_exists(&server).await;
 
     // No prior read → backend must GET sha first.
     Mock::given(method("GET"))
@@ -275,6 +296,7 @@ async fn delete_path_resolves_sha_then_deletes() {
 #[tokio::test]
 async fn delete_already_gone_is_no_op() {
     let server = MockServer::start().await;
+    mount_branch_exists(&server).await;
 
     // GET 404 → file already gone → persist swallows the delete.
     Mock::given(method("GET"))

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -1555,6 +1555,7 @@ struct TrajectLawWrite {
 /// the looked-up law (for its `relative_path`), the write-target source
 /// id, and an owned guard over the traject's writable backend.
 async fn resolve_traject_law_write(
+    state: &AppState,
     traject: &Arc<TrajectCorpus>,
     law_id: &str,
 ) -> Result<TrajectLawWrite, (StatusCode, String)> {
@@ -1569,18 +1570,43 @@ async fn resolve_traject_law_write(
             StatusCode::SERVICE_UNAVAILABLE,
             "Writable backend not initialised".to_string(),
         ))?;
-    if !entry.writable {
-        return Err((StatusCode::FORBIDDEN, "Source is read-only".to_string()));
-    }
     // Per-source write mutex: every save to the same traject source
     // serialises here, so contention (a second save waiting out the
     // first's GitHub round-trips) shows up as a fat `lock` phase.
     let backend = timing::measure("lock", entry.backend.clone().lock_owned()).await;
+    require_traject_backend_writable(state, entry.writable, &**backend).await?;
     Ok(TrajectLawWrite {
         law,
         write_source_id: write_target_source_id,
         backend,
     })
+}
+
+/// The single writability gate for traject writes.
+///
+/// A backend that is writable at rest (configured service token, or a
+/// natively writable local dir) always passes. A backend that is
+/// read-only at rest still passes when this deployment routes writes
+/// through the acting user's own GitHub token AND the backend honors
+/// `WriteContext::token_override` — the deployed federation config for a
+/// user-created traject repo has no service token on purpose, and 403-ing
+/// there would break every write in the user-token mode (the pr952
+/// promote bug). The subsequent `user_write_token_for_backend` call then
+/// enforces the linked-token requirement (428 when absent/expired), and
+/// `persist` itself still refuses (`CorpusError::ReadOnly` → 403) if a
+/// write somehow reaches it with no token at all.
+async fn require_traject_backend_writable(
+    state: &AppState,
+    writable_at_rest: bool,
+    backend: &dyn RepoBackend,
+) -> Result<(), (StatusCode, String)> {
+    if writable_at_rest {
+        return Ok(());
+    }
+    if backend.supports_token_override() && github_oauth::user_token_write_mode(state).await? {
+        return Ok(());
+    }
+    Err((StatusCode::FORBIDDEN, "Source is read-only".to_string()))
 }
 
 /// Source-relative path of a law's scenario file.
@@ -1759,10 +1785,11 @@ async fn read_traject_scenario_cached(
 /// the law/scenario writes use), so notes land in the same traject
 /// branch/PR as the rest of the edits in the session.
 async fn resolve_traject_annotation_target(
+    state: &AppState,
     traject: &Arc<TrajectCorpus>,
     law_id: &str,
 ) -> Result<EditorWriteTarget, (StatusCode, String)> {
-    let write = resolve_traject_law_write(traject, law_id).await?;
+    let write = resolve_traject_law_write(state, traject, law_id).await?;
     Ok(EditorWriteTarget {
         relative_path: PathBuf::from("annotations")
             .join(law_id)
@@ -1813,7 +1840,7 @@ pub async fn save_scenario(
     let author = Some(require_editor_user(&session).await?);
 
     let traject = require_traject_corpus_from_ref(&state, &session, &traject_ref).await?;
-    let write = resolve_traject_law_write(&traject, &law_id).await?;
+    let write = resolve_traject_law_write(&state, &traject, &law_id).await?;
     // Resolved-backend-aware: a local writable-own backend ignores the
     // override, so enforcement must not 428 a save that never reaches GitHub.
     let token_override =
@@ -2013,7 +2040,7 @@ pub async fn save_annotations(
         }));
     }
     let new_notes = public_notes;
-    let target = resolve_traject_annotation_target(&traject, &law_id).await?;
+    let target = resolve_traject_annotation_target(&state, &traject, &law_id).await?;
     let EditorWriteTarget {
         relative_path,
         backend,
@@ -2231,7 +2258,7 @@ pub async fn save_law(
     // corpus so we can mirror the saved body into its read-your-writes
     // overlay after `persist` succeeds.
     let traject = require_traject_corpus_from_ref(&state, &session, &traject_ref).await?;
-    let write = resolve_traject_law_write(&traject, &law_id).await?;
+    let write = resolve_traject_law_write(&state, &traject, &law_id).await?;
     let token_override =
         github_oauth::user_write_token_for_backend(&state, account.id, &headers, &**write.backend)
             .await?;
@@ -2304,7 +2331,7 @@ pub async fn delete_scenario(
     let author = Some(require_editor_user(&session).await?);
 
     let traject = require_traject_corpus_from_ref(&state, &session, &traject_ref).await?;
-    let write = resolve_traject_law_write(&traject, &law_id).await?;
+    let write = resolve_traject_law_write(&state, &traject, &law_id).await?;
     let token_override =
         github_oauth::user_write_token_for_backend(&state, account.id, &headers, &**write.backend)
             .await?;
@@ -2578,6 +2605,7 @@ fn traject_documents_base(traject_ref: &str) -> PathBuf {
 /// `write_target_for_source.values().next()`, which relied on every
 /// value being identical (true today, but unenforced).
 async fn resolve_traject_documents_writer(
+    state: &AppState,
     traject: &Arc<TrajectCorpus>,
 ) -> Result<tokio::sync::OwnedMutexGuard<Box<dyn RepoBackend>>, (StatusCode, String)> {
     let entry = traject
@@ -2588,10 +2616,9 @@ async fn resolve_traject_documents_writer(
             StatusCode::SERVICE_UNAVAILABLE,
             "Writable backend not initialised".to_string(),
         ))?;
-    if !entry.writable {
-        return Err((StatusCode::FORBIDDEN, "Source is read-only".to_string()));
-    }
-    Ok(entry.backend.clone().lock_owned().await)
+    let backend = entry.backend.clone().lock_owned().await;
+    require_traject_backend_writable(state, entry.writable, &**backend).await?;
+    Ok(backend)
 }
 
 /// Read the `If-Match` header value, trimmed. `None` when absent or empty.
@@ -2692,7 +2719,7 @@ pub async fn list_traject_documents(
     Path(traject_ref): Path<String>,
 ) -> Result<Json<TrajectDocumentList>, (StatusCode, String)> {
     let traject = require_traject_corpus_from_ref(&state, &session, &traject_ref).await?;
-    let backend = resolve_traject_documents_writer(&traject).await?;
+    let backend = resolve_traject_documents_writer(&state, &traject).await?;
     let base = traject_documents_base(&traject_ref);
     let entries = backend
         .list_files_recursive(&base, None)
@@ -2874,7 +2901,7 @@ pub async fn upload_traject_document(
     // the derivation hand back a name that already exists, and the worker's
     // unconditional write would silently overwrite that document. Fail the
     // upload instead.
-    let backend = resolve_traject_documents_writer(&traject).await?;
+    let backend = resolve_traject_documents_writer(&state, &traject).await?;
 
     let base = traject_documents_base(&traject_ref);
     let mut existing: Vec<String> = backend
@@ -3126,7 +3153,7 @@ pub async fn create_traject_law(
 
     // The writable-own backend (same routing as documents: the law does not
     // exist yet, so there is no per-law source to route from).
-    let backend = resolve_traject_documents_writer(&traject).await?;
+    let backend = resolve_traject_documents_writer(&state, &traject).await?;
     // Belt-and-braces against an index blind spot (e.g. a file committed on
     // the branch after the current snapshot was built).
     if backend
@@ -3250,7 +3277,7 @@ pub async fn promote_corpus_law(
     // Schrijfpad: de writable-own backend van het traject (zelfde routing als
     // documents/create: per-wet routing bestaat nog niet, want de wet zit nog
     // niet in de traject-repo).
-    let backend = resolve_traject_documents_writer(&traject).await?;
+    let backend = resolve_traject_documents_writer(&state, &traject).await?;
 
     // Geen dubbele/overschreven bestanden, per bestandssoort:
     // - Wet-versie-YAML al op het doelpad (bijv. via een eerdere save_law op
@@ -3517,7 +3544,7 @@ pub async fn get_traject_document(
     use axum::response::IntoResponse;
     validate_document_path(&doc_path)?;
     let traject = require_traject_corpus_from_ref(&state, &session, &traject_ref).await?;
-    let backend = resolve_traject_documents_writer(&traject).await?;
+    let backend = resolve_traject_documents_writer(&state, &traject).await?;
     let relative_path = traject_documents_base(&traject_ref).join(&doc_path);
     let content = backend
         .read_file(&relative_path)
@@ -3583,7 +3610,7 @@ pub async fn save_traject_document(
     }
 
     let traject = require_traject_corpus_from_ref(&state, &session, &traject_ref).await?;
-    let backend = resolve_traject_documents_writer(&traject).await?;
+    let backend = resolve_traject_documents_writer(&state, &traject).await?;
     let token_override =
         github_oauth::user_write_token_for_backend(&state, account.id, &headers, &**backend)
             .await?;
@@ -3651,7 +3678,7 @@ pub async fn delete_traject_document(
     let author = Some(require_editor_user(&session).await?);
 
     let traject = require_traject_corpus_from_ref(&state, &session, &traject_ref).await?;
-    let backend = resolve_traject_documents_writer(&traject).await?;
+    let backend = resolve_traject_documents_writer(&state, &traject).await?;
     let token_override =
         github_oauth::user_write_token_for_backend(&state, account.id, &headers, &**backend)
             .await?;

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -3252,32 +3252,49 @@ pub async fn promote_corpus_law(
     // niet in de traject-repo).
     let backend = resolve_traject_documents_writer(&traject).await?;
 
-    // Geen dubbele bestanden: bestaat er al een wet-versiebestand op het
-    // doelpad (bijv. via een eerdere save_law op de gefedereerde wet, of een
-    // commit die de index nog niet zag), dan weigeren we de hele promote.
+    // Geen dubbele/overschreven bestanden, per bestandssoort:
+    // - Wet-versie-YAML al op het doelpad (bijv. via een eerdere save_law op
+    //   de gefedereerde wet, of een commit die de index nog niet zag) → 409
+    //   voor de hele promote.
+    // - Scenario-file al op het doelpad: dat is een traject-edit —
+    //   `save_scenario` routeert scenario's van gefedereerde wetten naar de
+    //   writable-own zónder dat er een wet-YAML in de traject-repo staat.
+    //   Die edit mag een promote niet stilletjes overschrijven; de
+    //   traject-versie wint (zelfde "eigen repo boven seed"-regel als
+    //   source_priority 0) en de rest van de wet-map wordt gewoon gekopieerd.
+    let mut to_write: Vec<&PromoteFile> = Vec::with_capacity(files.len());
     for file in &files {
+        let exists = backend
+            .read_file(&file.relative_path)
+            .await
+            .map_err(corpus_write_error("law"))?
+            .is_some();
+        if !exists {
+            to_write.push(file);
+            continue;
+        }
         if file
             .relative_path
             .extension()
             .is_some_and(|ext| ext == "yaml")
-            && backend
-                .read_file(&file.relative_path)
-                .await
-                .map_err(corpus_write_error("law"))?
-                .is_some()
         {
             return Err((
                 StatusCode::CONFLICT,
                 "Deze wet staat al (deels) in dit traject.".to_string(),
             ));
         }
+        tracing::info!(
+            law_id = %law_id,
+            path = %file.relative_path.display(),
+            "promote: bestand bestaat al in de traject-repo (traject-edit wint), overslaan"
+        );
     }
 
     let token_override =
         github_oauth::user_write_token_for_backend(&state, account.id, &headers, &**backend)
             .await?;
 
-    for file in &files {
+    for file in &to_write {
         backend
             .write_file(&file.relative_path, &file.content)
             .await
@@ -3309,7 +3326,7 @@ pub async fn promote_corpus_law(
 
     Ok(Json(PromoteResponse {
         law_id,
-        copied_files: files.len(),
+        copied_files: to_write.len(),
         pr: outcome.pr.map(|pr| SavePrInfo {
             url: pr.html_url,
             number: pr.number,

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -3175,6 +3175,269 @@ pub async fn create_traject_law(
     Ok(([(axum::http::header::ETAG, new_etag)], Json(response)).into_response())
 }
 
+/// Response body of a promote: how many files were copied and, when the
+/// traject backend opened a PR for the commit, its coordinates.
+#[derive(Debug, Serialize)]
+pub struct PromoteResponse {
+    pub law_id: String,
+    pub copied_files: usize,
+    pub pr: Option<SavePrInfo>,
+}
+
+/// One file collected from a seed source for a promote, addressed by its
+/// source-relative path — which doubles as the write path in the traject's
+/// writable-own source, exactly like `save_law`'s write-routing for a
+/// federated law (`resolve_traject_law_write` reuses `law.relative_path`).
+struct PromoteFile {
+    relative_path: PathBuf,
+    content: String,
+}
+
+/// POST /api/trajects/{traject_ref}/corpus/laws/{law_id}/promote
+///
+/// Kopieer een wet uit het centrale corpus (de gefedereerde seed-bron van
+/// het traject, bijv. `minbzk-central`) naar de traject-repo: alle
+/// versie-YAML's (inclusief `machine_readable`) plus de bijbehorende
+/// `scenarios/*.feature`-bestanden, in één commit via het bestaande
+/// traject-schrijfpad (zelfde commit- en autorisatiegedrag als het opslaan
+/// van een wet). Staat de wet al in de traject-repo, dan 409 — er ontstaan
+/// nooit dubbele bestanden.
+///
+/// De bron is bewust het traject-gefedereerde corpus en niet de globale
+/// corpus-state: de traject-index dekt de volledige seed (metadata-only,
+/// lazy bodies), terwijl de globale state in productie alleen favorieten
+/// materialiseert (`load_favorites_async`).
+pub async fn promote_corpus_law(
+    State(state): State<AppState>,
+    Extension(account): Extension<AccountRecord>,
+    session: Session,
+    Path((traject_ref, law_id)): Path<(String, String)>,
+    headers: axum::http::HeaderMap,
+) -> Result<Json<PromoteResponse>, (StatusCode, String)> {
+    let author = Some(require_editor_user(&session).await?);
+
+    // Membership guard FIRST (same ordering as create_traject_law), and the
+    // traject-id for the cache invalidation afterwards.
+    let traject = require_traject_corpus_from_ref(&state, &session, &traject_ref).await?;
+    let traject_id = resolve_traject_ref(
+        state.pool.as_ref().ok_or((
+            StatusCode::SERVICE_UNAVAILABLE,
+            "database not configured".to_string(),
+        ))?,
+        &traject_ref,
+    )
+    .await?;
+
+    // Al in de traject-repo volgens de gefedereerde index? Dan is promoten
+    // zinloos/gevaarlijk (overschrijven van traject-edits). De index kan een
+    // blinde vlek hebben (file net gecommit); de per-bestand check verderop
+    // is de belt-and-braces.
+    if let Some(law) = traject.corpus.source_map.get_law(&law_id) {
+        if law.source_id == traject.writable_own_source_id {
+            return Err((
+                StatusCode::CONFLICT,
+                "Deze wet staat al in dit traject.".to_string(),
+            ));
+        }
+    }
+
+    // Verzamel alle te kopiëren bestanden uit de seed-bron(nen), vóórdat de
+    // writable-own-lock genomen wordt. Alleen seed-locks worden hier (één
+    // tegelijk) gehouden — de writable-own → seed lock-orde-invariant blijft
+    // daarmee intact.
+    let files = collect_promote_files(&traject, &law_id).await?;
+
+    // Schrijfpad: de writable-own backend van het traject (zelfde routing als
+    // documents/create: per-wet routing bestaat nog niet, want de wet zit nog
+    // niet in de traject-repo).
+    let backend = resolve_traject_documents_writer(&traject).await?;
+
+    // Geen dubbele bestanden: bestaat er al een wet-versiebestand op het
+    // doelpad (bijv. via een eerdere save_law op de gefedereerde wet, of een
+    // commit die de index nog niet zag), dan weigeren we de hele promote.
+    for file in &files {
+        if file
+            .relative_path
+            .extension()
+            .is_some_and(|ext| ext == "yaml")
+            && backend
+                .read_file(&file.relative_path)
+                .await
+                .map_err(corpus_write_error("law"))?
+                .is_some()
+        {
+            return Err((
+                StatusCode::CONFLICT,
+                "Deze wet staat al (deels) in dit traject.".to_string(),
+            ));
+        }
+    }
+
+    let token_override =
+        github_oauth::user_write_token_for_backend(&state, account.id, &headers, &**backend)
+            .await?;
+
+    for file in &files {
+        backend
+            .write_file(&file.relative_path, &file.content)
+            .await
+            .map_err(corpus_write_error("law"))?;
+    }
+    let outcome = backend
+        .persist(&WriteContext {
+            message: format!("Voeg wet {} toe uit het centrale corpus", law_id),
+            author,
+            token_override,
+        })
+        .await
+        .map_err(corpus_write_error("law"))?;
+    drop(backend);
+
+    // Read-your-writes + index-verversing, zoals create_traject_law: de
+    // nieuwste versie in de overlay, de wet in de changed-lijst, en een
+    // cache-drop zodat de volgende request de wet in de traject-index ziet.
+    if let Some(newest) = files
+        .iter()
+        .find(|f| f.relative_path.extension().is_some_and(|e| e == "yaml"))
+    {
+        traject
+            .record_save(law_id.clone(), newest.content.clone())
+            .await;
+    }
+    traject.record_changed_law(&law_id).await;
+    state.trajects.invalidate(traject_id).await;
+
+    Ok(Json(PromoteResponse {
+        law_id,
+        copied_files: files.len(),
+        pr: outcome.pr.map(|pr| SavePrInfo {
+            url: pr.html_url,
+            number: pr.number,
+        }),
+    }))
+}
+
+/// Verzamel de volledige wet-map van `law_id` uit de seed-bron(nen) van het
+/// traject: elk versie-YAML (nieuwste eerst, lazy-fetch waar de index alleen
+/// metadata heeft) plus de `scenarios/*.feature`-bestanden naast de wet.
+/// Versies uit de writable-own-bron worden overgeslagen (die staan er al).
+///
+/// Lock-discipline: houdt uitsluitend seed-backend-locks, één tegelijk —
+/// de aanroeper neemt de writable-own-lock pas ná dit verzamelen, dus de
+/// writable-own → seed lock-orde-invariant kan hier niet schenden.
+async fn collect_promote_files(
+    traject: &Arc<TrajectCorpus>,
+    law_id: &str,
+) -> Result<Vec<PromoteFile>, (StatusCode, String)> {
+    let not_found = || {
+        (
+            StatusCode::NOT_FOUND,
+            "Deze wet is niet gevonden in het centrale corpus van dit traject.".to_string(),
+        )
+    };
+    let versions: Vec<LoadedLaw> = traject
+        .corpus
+        .source_map
+        .get_law_versions(law_id)
+        .ok_or_else(not_found)?
+        .iter()
+        .filter(|v| v.source_id != traject.writable_own_source_id)
+        .cloned()
+        .collect();
+    if versions.is_empty() {
+        return Err(not_found());
+    }
+
+    let fetch_error = |what: &'static str, path: &std::path::Path, e: &dyn std::fmt::Display| {
+        tracing::warn!(law_id = %law_id, path = %path.display(), error = %e, "promote: {what} lezen uit seed-bron mislukt");
+        (
+            StatusCode::BAD_GATEWAY,
+            "Kon de wet niet volledig uit het centrale corpus lezen.".to_string(),
+        )
+    };
+
+    // Dedupe op relative_path: dezelfde versie kan uit meerdere seeds
+    // geïndexeerd zijn; get_law_versions sorteert hoogste prioriteit eerst,
+    // dus de eerste treffer per pad wint.
+    let mut seen = std::collections::BTreeSet::new();
+    let mut files = Vec::new();
+    for version in &versions {
+        let relative_path = PathBuf::from(&version.relative_path);
+        // Defensief: de index is vertrouwd, maar deze paden worden 1-op-1
+        // schrijfpaden in de traject-repo.
+        if version.relative_path.contains("..") || relative_path.is_absolute() {
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Ongeldig bronpad in de corpus-index.".to_string(),
+            ));
+        }
+        if !seen.insert(relative_path.clone()) {
+            continue;
+        }
+        let content = if !version.yaml_content.is_empty() {
+            version.yaml_content.clone()
+        } else {
+            // Metadata-only indexvermelding: body lazy fetchen via de
+            // seed-backend, net als de traject-scoped reads doen.
+            let entry = traject.corpus.backends.get(&version.source_id).ok_or((
+                StatusCode::BAD_GATEWAY,
+                "Seed-backend van het centrale corpus is niet beschikbaar.".to_string(),
+            ))?;
+            let backend = entry.backend.lock().await;
+            backend
+                .read_file(&relative_path)
+                .await
+                .map_err(|e| fetch_error("wet-versie", &relative_path, &e))?
+                .ok_or_else(|| {
+                    fetch_error(
+                        "wet-versie",
+                        &relative_path,
+                        &"bestand ontbreekt bij de bron",
+                    )
+                })?
+        };
+        files.push(PromoteFile {
+            relative_path,
+            content,
+        });
+    }
+
+    // Scenario's naast de wet (criterium: de volledige wet-map). We lezen ze
+    // van de seed van de best-passende versie; een leesfout is een harde
+    // fout — stilletjes zonder scenario's promoten zou het acceptatiecriterium
+    // schenden zonder dat iemand het ziet.
+    let primary = &versions[0];
+    let law_dir = PathBuf::from(&primary.relative_path)
+        .parent()
+        .map(PathBuf::from)
+        .ok_or((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Kan de wet-map niet bepalen.".to_string(),
+        ))?;
+    let scenarios_dir = law_dir.join("scenarios");
+    if let Some(entry) = traject.corpus.backends.get(&primary.source_id) {
+        let backend = entry.backend.lock().await;
+        let entries = backend
+            .list_files(&scenarios_dir, Some("feature"))
+            .await
+            .map_err(|e| fetch_error("scenario-lijst", &scenarios_dir, &e))?;
+        for entry in entries {
+            let path = scenarios_dir.join(&entry.name);
+            let content = backend
+                .read_file(&path)
+                .await
+                .map_err(|e| fetch_error("scenario", &path, &e))?
+                .ok_or_else(|| fetch_error("scenario", &path, &"bestand ontbreekt bij de bron"))?;
+            files.push(PromoteFile {
+                relative_path: path,
+                content,
+            });
+        }
+    }
+
+    Ok(files)
+}
+
 /// GET /api/trajects/{traject_ref}/corpus/documents/jobs
 ///
 /// List the traject's document-convert jobs that are still relevant to show

--- a/packages/editor-api/src/github_oauth.rs
+++ b/packages/editor-api/src/github_oauth.rs
@@ -895,6 +895,25 @@ pub async fn write_requires_user_token(
         })
 }
 
+/// [`write_requires_user_token`], tolerating an unconfigured OAuth
+/// integration: `false` when `github_oauth` is absent (the pre-spike
+/// service-token world).
+///
+/// Used by the traject write resolvers to decide whether a backend that is
+/// read-only **at rest** (no configured service token) may still be
+/// written through: in user-token mode the acting user's own GitHub token
+/// authenticates the commit (`WriteContext::token_override`), so "no
+/// service token" must not 403 the write up-front — the deployed
+/// federation config for a user-created traject repo intentionally has no
+/// `CORPUS_AUTH_*` token for that repo (fail-closed against shipping the
+/// central token to a user-chosen repo).
+pub async fn user_token_write_mode(state: &AppState) -> Result<bool, (StatusCode, String)> {
+    match state.config.github_oauth.as_ref() {
+        Some(oauth) => write_requires_user_token(state, oauth).await,
+        None => Ok(false),
+    }
+}
+
 /// Resolve the per-user GitHub credential to attach to an editor write, read
 /// from the sealed token cookie riding on this request.
 ///

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -504,6 +504,18 @@ async fn main() {
             axum::routing::post(task_requests::request_enrich),
         )
         .route(
+            // Promote: kopieer een wet uit het centrale corpus naar de
+            // traject-repo (zelfde schrijfpad/autorisatie als save_law).
+            "/api/trajects/{traject_ref}/corpus/laws/{law_id}/promote",
+            axum::routing::post(corpus_handlers::promote_corpus_law),
+        )
+        .route(
+            // Traject-scoped harvest via het taken-mechanisme: BWB-download
+            // op de worker + geketende taak-flow-enrich (law_convert-patroon).
+            "/api/trajects/{traject_ref}/corpus/harvest",
+            axum::routing::post(task_requests::request_traject_harvest),
+        )
+        .route(
             "/api/trajects/{traject_ref}/corpus/documents/{*doc_path}",
             axum::routing::put(corpus_handlers::save_traject_document)
                 .delete(corpus_handlers::delete_traject_document)

--- a/packages/editor-api/src/task_requests.rs
+++ b/packages/editor-api/src/task_requests.rs
@@ -120,12 +120,141 @@ pub async fn request_enrich(
     ))
 }
 
+/// Bovengrens op de meegegeven weergavenaam: hij landt in taak-titels en in
+/// de job-payload, dus onbegrensde user input hoort daar niet thuis.
+const MAX_LAW_NAME_CHARS: usize = 200;
+
+#[derive(serde::Deserialize)]
+pub struct TrajectHarvestRequest {
+    pub bwb_id: String,
+    /// Weergavenaam uit de zoekresultaten (optioneel; alleen voor titels).
+    #[serde(default)]
+    pub law_name: Option<String>,
+}
+
+#[derive(serde::Serialize)]
+pub struct TrajectHarvestResponse {
+    pub job_id: Uuid,
+}
+
+/// Valideer en normaliseer een door de gebruiker aangeleverd BWB-id.
+/// Canonieke vorm is hoofdletters (`BWBR0018451`); lowercase input wordt
+/// genormaliseerd. De vorm-check is bewust ruim (BWBR/BWBV/…): de harvester
+/// zelf is de autoriteit over wat echt bestaat.
+fn normalize_bwb_id(raw: &str) -> Option<String> {
+    let id = raw.trim().to_ascii_uppercase();
+    let ok = id.starts_with("BWB")
+        && (6..=20).contains(&id.len())
+        && id.chars().all(|c| c.is_ascii_alphanumeric());
+    ok.then_some(id)
+}
+
+/// POST /api/trajects/{traject_ref}/corpus/harvest
+///
+/// Start een traject-scoped harvest via het taken-mechanisme: enqueue een
+/// `traject_harvest`-job (BWB-download op de harvest-worker) die een
+/// taak-flow-enrich ketent (zie `pipeline::traject_harvest`). De aanvraag is
+/// direct zichtbaar in het takenpaneel als lopende aanvraag; het resultaat
+/// komt terug als `law_create`-review-taak van de aanvrager.
+pub async fn request_traject_harvest(
+    State(state): State<AppState>,
+    session: Session,
+    Extension(account): Extension<AccountRecord>,
+    Path(traject_ref): Path<String>,
+    axum::Json(req): axum::Json<TrajectHarvestRequest>,
+) -> Result<(StatusCode, Json<TrajectHarvestResponse>), (StatusCode, String)> {
+    let pool = state.pool.as_ref().ok_or((
+        StatusCode::SERVICE_UNAVAILABLE,
+        "database niet geconfigureerd".to_string(),
+    ))?;
+
+    let bwb_id = normalize_bwb_id(&req.bwb_id).ok_or((
+        StatusCode::BAD_REQUEST,
+        "Geen geldig BWB-id (verwacht bijv. BWBR0018451).".to_string(),
+    ))?;
+    let law_name = req
+        .law_name
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| s.chars().take(MAX_LAW_NAME_CHARS).collect::<String>());
+
+    // Zelfde guard + resolutie als de enrich-aanvraag: membership-check en
+    // traject-id voor de payload/taak.
+    let _traject = require_traject_corpus_from_ref(&state, &session, &traject_ref).await?;
+    let traject_id = resolve_traject_ref(pool, &traject_ref).await?;
+
+    let payload = regelrecht_pipeline::traject_harvest::TrajectHarvestPayload {
+        bwb_id: bwb_id.clone(),
+        traject_id,
+        traject_ref: traject_ref.clone(),
+        law_name,
+        provider: Some(state.config.task_enrich_provider.clone()),
+        requested_by: Some(account.id),
+        deliver: Some("task".into()),
+    };
+    let payload_json = serde_json::to_value(&payload).map_err(internal("payload serialiseren"))?;
+
+    let mut tx = pool.begin().await.map_err(internal("begin tx"))?;
+
+    enforce_task_job_cap(&mut tx, account.id).await?;
+
+    // Serialiseer per (traject, wet) en dedup dan tegen actieve jobs: twee
+    // leden die dezelfde wet tegelijk aanvragen zouden anders allebei langs
+    // de SELECT komen (zelfde TOCTOU-klasse en remedie als harvest_request).
+    sqlx::query(
+        "SELECT pg_advisory_xact_lock(hashtextextended('traject_harvest:' || $1 || ':' || $2, 0))",
+    )
+    .bind(&traject_ref)
+    .bind(&bwb_id)
+    .execute(&mut *tx)
+    .await
+    .map_err(internal("harvest-lock nemen"))?;
+
+    let existing: Option<(Uuid,)> = sqlx::query_as(
+        "SELECT id FROM jobs \
+         WHERE job_type = 'traject_harvest' AND law_id = $1 AND traject_ref = $2 \
+           AND status IN ('pending', 'processing') \
+         LIMIT 1",
+    )
+    .bind(&bwb_id)
+    .bind(&traject_ref)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(internal("actieve harvest-jobs zoeken"))?;
+    if existing.is_some() {
+        return Err((
+            StatusCode::CONFLICT,
+            "Er loopt al een ophaal-aanvraag voor deze wet in dit traject.".to_string(),
+        ));
+    }
+
+    // max_attempts 3: BWB-outages en netwerkfouten zijn transiënt en de
+    // harvest is idempotent; deterministische fouten failt de worker
+    // terminaal (zie process_next_traject_harvest_job).
+    let req = CreateJobRequest::new(JobType::TrajectHarvest, &bwb_id)
+        .with_traject_ref(&traject_ref)
+        .with_priority(Priority::new(TASK_ENRICH_PRIORITY))
+        .with_payload(payload_json)
+        .with_max_attempts(3);
+    let job = job_queue::create_job(&mut *tx, req)
+        .await
+        .map_err(internal("enqueue traject-harvest"))?;
+    tx.commit().await.map_err(internal("commit"))?;
+
+    Ok((
+        StatusCode::ACCEPTED,
+        Json(TrajectHarvestResponse { job_id: job.id }),
+    ))
+}
+
 /// Per-account-cap op actieve taak-flow-jobs, binnen de transactie van de
 /// aanroeper. Serialiseert eerst per account (xact-scoped advisory lock):
 /// de COUNT-then-INSERT is anders een TOCTOU-race (zelfde klasse en remedie
-/// als harvest_request). Telt naast enrich- ook law_convert-jobs mee: elke
-/// law_convert ketent immers een enrich-job na. Gedeeld door `request_enrich`
-/// en de law-upload in `corpus_handlers`.
+/// als harvest_request). Telt naast enrich- ook law_convert- en
+/// traject_harvest-jobs mee: die ketenen immers elk een enrich-job na.
+/// Gedeeld door `request_enrich`, `request_traject_harvest` en de law-upload
+/// in `corpus_handlers`.
 pub(crate) async fn enforce_task_job_cap(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     account_id: Uuid,
@@ -138,7 +267,7 @@ pub(crate) async fn enforce_task_job_cap(
 
     let (active_count,): (i64,) = sqlx::query_as(
         "SELECT COUNT(*) FROM jobs \
-         WHERE job_type IN ('enrich', 'law_convert') \
+         WHERE job_type IN ('enrich', 'law_convert', 'traject_harvest') \
            AND status IN ('pending', 'processing') \
            AND payload->>'requested_by' = $1",
     )
@@ -180,5 +309,32 @@ mod tests {
         let id = Uuid::new_v4();
         let json = serde_json::to_value(id).expect("uuid serialiseert");
         assert_eq!(json, serde_json::Value::String(id.to_string()));
+    }
+
+    #[test]
+    fn normalize_bwb_id_accepts_and_uppercases_valid_ids() {
+        assert_eq!(
+            normalize_bwb_id("BWBR0018451").as_deref(),
+            Some("BWBR0018451")
+        );
+        assert_eq!(
+            normalize_bwb_id("  bwbr0018451 ").as_deref(),
+            Some("BWBR0018451")
+        );
+        // Verdragen (BWBV) vallen ook onder BWB.
+        assert_eq!(
+            normalize_bwb_id("BWBV0001000").as_deref(),
+            Some("BWBV0001000")
+        );
+    }
+
+    #[test]
+    fn normalize_bwb_id_rejects_garbage() {
+        assert!(normalize_bwb_id("").is_none());
+        assert!(normalize_bwb_id("BWB").is_none());
+        assert!(normalize_bwb_id("CVDR681386").is_none());
+        assert!(normalize_bwb_id("BWBR00184-1").is_none());
+        assert!(normalize_bwb_id("BWBR001845100000000000").is_none());
+        assert!(normalize_bwb_id("wet_op_de_zorgtoeslag").is_none());
     }
 }

--- a/packages/editor-api/tests/promote_law_test.rs
+++ b/packages/editor-api/tests/promote_law_test.rs
@@ -273,6 +273,51 @@ async fn promote_refuses_a_law_already_in_the_traject_repo() {
 }
 
 #[tokio::test]
+async fn promote_keeps_a_traject_edited_scenario_of_a_federated_law() {
+    // `save_scenario` routeert scenario's van gefedereerde wetten naar de
+    // writable-own zonder dat er een wet-YAML in de traject-repo staat. Zo'n
+    // traject-edit mag een promote niet stilletjes overschrijven: de
+    // traject-versie wint, de wet-YAML's worden gewoon gekopieerd.
+    let db = TestDb::new().await;
+    let central = tempfile::tempdir().unwrap();
+    write_central_law(central.path());
+    let state = empty_state(db.pool.clone());
+
+    let (owner, sub) = seed_account(&db.pool, "alice@test.local").await;
+    let traject_dir = tempfile::tempdir().unwrap();
+    let scenario_dir = traject_dir
+        .path()
+        .join("wet")
+        .join(LAW_ID)
+        .join("scenarios");
+    std::fs::create_dir_all(&scenario_dir).unwrap();
+    std::fs::write(
+        scenario_dir.join("basis.feature"),
+        "Feature: basis (traject-edit)\n",
+    )
+    .unwrap();
+    let traject_id = seeded_traject(&db.pool, owner, traject_dir.path(), central.path()).await;
+    let tref = traject_ref(traject_id);
+
+    let response = promote(state, session_for(&sub).await, &tref, LAW_ID)
+        .await
+        .expect("promote must succeed despite the scenario edit");
+    assert_eq!(
+        response.0.copied_files, 2,
+        "2 versies; scenario overgeslagen"
+    );
+
+    let base = traject_dir.path().join("wet").join(LAW_ID);
+    assert!(base.join("2025-01-01.yaml").exists());
+    assert!(base.join("2024-01-01.yaml").exists());
+    assert_eq!(
+        std::fs::read_to_string(base.join("scenarios").join("basis.feature")).unwrap(),
+        "Feature: basis (traject-edit)\n",
+        "traject-edit mag niet overschreven worden"
+    );
+}
+
+#[tokio::test]
 async fn promote_404s_for_a_law_missing_from_the_central_corpus() {
     let db = TestDb::new().await;
     let central = tempfile::tempdir().unwrap();

--- a/packages/editor-api/tests/promote_law_test.rs
+++ b/packages/editor-api/tests/promote_law_test.rs
@@ -1,0 +1,290 @@
+//! Integration tests for `corpus_handlers::promote_corpus_law`: een wet uit
+//! de centrale-corpus-seed van het traject kopiëren naar de traject-repo —
+//! alle versie-YAML's plus de `scenarios/*.feature`-bestanden, en een 409
+//! wanneer de wet al in het traject staat (geen dubbele bestanden).
+//!
+//! Zelfde hermetische opzet als `traject_reads_test.rs`: lokale sources, geen
+//! GitHub/netwerk, handlers direct aangeroepen met inline axum-extractors.
+//! Het traject heeft twee sources, zoals in productie: een read-seed die het
+//! centrale corpus speelt en een (lege) writable-own repo.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::Arc;
+
+use axum::extract::{Extension, Path, State};
+use axum::http::{HeaderMap, StatusCode};
+use pretty_assertions::assert_eq;
+use sqlx::PgPool;
+use tokio::sync::{Mutex, RwLock};
+use tower_sessions::Session;
+use tower_sessions_memory_store::MemoryStore;
+use uuid::Uuid;
+
+use regelrecht_auth::handlers::{
+    SESSION_KEY_EMAIL, SESSION_KEY_EMAIL_VERIFIED, SESSION_KEY_NAME, SESSION_KEY_SUB,
+};
+use regelrecht_editor_api::accounts::AccountRecord;
+use regelrecht_editor_api::config::AppConfig;
+use regelrecht_editor_api::corpus_handlers::promote_corpus_law;
+use regelrecht_editor_api::state::{AppState, CorpusState};
+use regelrecht_editor_api::traject_corpus::TrajectCorpusCache;
+
+use regelrecht_pipeline::test_utils::TestDb;
+
+const LAW_ID: &str = "wet_voorbeeld_promotie";
+
+fn empty_state(pool: PgPool) -> AppState {
+    AppState {
+        corpus: Arc::new(RwLock::new(CorpusState::empty())),
+        oidc_client: None,
+        end_session_url: None,
+        config: Arc::new(AppConfig {
+            oidc: None,
+            base_url: None,
+            github_oauth: None,
+            task_enrich_provider: "claude".to_string(),
+        }),
+        http_client: reqwest::Client::new(),
+        pool: Some(pool),
+        pipeline_api_url: None,
+        harvest_admin_url: None,
+        reload_lock: Arc::new(Mutex::new(())),
+        trajects: Arc::new(TrajectCorpusCache::new()),
+    }
+}
+
+async fn seed_account(pool: &PgPool, email: &str) -> (Uuid, String) {
+    let sub = format!("sub-{email}");
+    let (id,): (Uuid,) = sqlx::query_as(
+        "INSERT INTO accounts (person_sub, email, name) VALUES ($1, $2, $3) RETURNING id",
+    )
+    .bind(&sub)
+    .bind(email)
+    .bind("Test User")
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    (id, sub)
+}
+
+/// Traject met twee lokale sources, zoals in productie: een read-seed op
+/// `seed_dir` (het "centrale corpus", priority 2) en een writable-own op
+/// `own_dir` (priority 0). Saves op seed-wetten routeren naar de
+/// writable-own via `write_target_for_source` — hetzelfde pad dat promote
+/// gebruikt.
+async fn seeded_traject(
+    pool: &PgPool,
+    owner_id: Uuid,
+    own_dir: &std::path::Path,
+    seed_dir: &std::path::Path,
+) -> Uuid {
+    let (traject_id,): (Uuid,) = sqlx::query_as(
+        "INSERT INTO trajects (name, description, scope, created_by)
+         VALUES ('Test', '', '', $1) RETURNING id",
+    )
+    .bind(owner_id)
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO traject_members (traject_id, account_id, role)
+         VALUES ($1, $2, 'owner')",
+    )
+    .bind(traject_id)
+    .bind(owner_id)
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO traject_corpus_sources
+         (traject_id, source_id, name, source_type, local_path,
+          priority, scopes, is_writable_own)
+         VALUES ($1, 'local', 'Local', 'local'::corpus_source_type, $2,
+                 0, '[]'::jsonb, TRUE)",
+    )
+    .bind(traject_id)
+    .bind(own_dir.to_string_lossy().to_string())
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO traject_corpus_sources
+         (traject_id, source_id, name, source_type, local_path,
+          priority, scopes, is_writable_own)
+         VALUES ($1, 'central-seed', 'Centrale Corpus', 'local'::corpus_source_type, $2,
+                 2, '[]'::jsonb, FALSE)",
+    )
+    .bind(traject_id)
+    .bind(seed_dir.to_string_lossy().to_string())
+    .execute(pool)
+    .await
+    .unwrap();
+    traject_id
+}
+
+fn traject_ref(traject_id: Uuid) -> String {
+    format!("test-{}", &traject_id.to_string()[..8])
+}
+
+async fn session_for(sub: &str) -> Session {
+    let session = Session::new(None, Arc::new(MemoryStore::default()), None);
+    session.insert(SESSION_KEY_SUB, sub).await.unwrap();
+    session.insert(SESSION_KEY_NAME, "Test User").await.unwrap();
+    session
+        .insert(SESSION_KEY_EMAIL, "alice@test.local")
+        .await
+        .unwrap();
+    session
+        .insert(SESSION_KEY_EMAIL_VERIFIED, true)
+        .await
+        .unwrap();
+    session
+}
+
+fn test_account() -> AccountRecord {
+    AccountRecord {
+        id: Uuid::new_v4(),
+        person_sub: "test-sub".to_string(),
+        email: "test@example.gov".to_string(),
+        name: "Test User".to_string(),
+    }
+}
+
+/// Schrijf de volledige wet-map in het centrale corpus: twee versies (met
+/// `machine_readable`-marker in de nieuwste) en één scenario-file.
+fn write_central_law(central_dir: &std::path::Path) {
+    let law_dir = central_dir.join("wet").join(LAW_ID);
+    std::fs::create_dir_all(law_dir.join("scenarios")).unwrap();
+    std::fs::write(
+        law_dir.join("2025-01-01.yaml"),
+        format!("$id: {LAW_ID}\nname: Versie 2025\nmachine_readable: MARKER_2025\n"),
+    )
+    .unwrap();
+    std::fs::write(
+        law_dir.join("2024-01-01.yaml"),
+        format!("$id: {LAW_ID}\nname: Versie 2024\n"),
+    )
+    .unwrap();
+    std::fs::write(
+        law_dir.join("scenarios").join("basis.feature"),
+        "Feature: basis\n",
+    )
+    .unwrap();
+}
+
+async fn promote(
+    state: AppState,
+    session: Session,
+    tref: &str,
+    law_id: &str,
+) -> Result<axum::Json<regelrecht_editor_api::corpus_handlers::PromoteResponse>, (StatusCode, String)>
+{
+    promote_corpus_law(
+        State(state),
+        Extension(test_account()),
+        session,
+        Path((tref.to_string(), law_id.to_string())),
+        HeaderMap::new(),
+    )
+    .await
+}
+
+#[tokio::test]
+async fn promote_copies_all_versions_and_scenarios_to_the_traject_repo() {
+    let db = TestDb::new().await;
+    let central = tempfile::tempdir().unwrap();
+    write_central_law(central.path());
+    let state = empty_state(db.pool.clone());
+
+    let (owner, sub) = seed_account(&db.pool, "alice@test.local").await;
+    let traject_dir = tempfile::tempdir().unwrap();
+    let traject_id = seeded_traject(&db.pool, owner, traject_dir.path(), central.path()).await;
+    let tref = traject_ref(traject_id);
+
+    let response = promote(state.clone(), session_for(&sub).await, &tref, LAW_ID)
+        .await
+        .expect("promote must succeed");
+    assert_eq!(response.0.law_id, LAW_ID);
+    assert_eq!(response.0.copied_files, 3, "2 versies + 1 scenario");
+
+    // De volledige wet-map staat nu in de traject-repo, byte-voor-byte,
+    // inclusief machine_readable en het scenario.
+    let base = traject_dir.path().join("wet").join(LAW_ID);
+    let newest = std::fs::read_to_string(base.join("2025-01-01.yaml")).unwrap();
+    assert!(newest.contains("MARKER_2025"), "got: {newest}");
+    assert_eq!(
+        newest,
+        std::fs::read_to_string(
+            central
+                .path()
+                .join("wet")
+                .join(LAW_ID)
+                .join("2025-01-01.yaml")
+        )
+        .unwrap()
+    );
+    assert!(base.join("2024-01-01.yaml").exists());
+    assert_eq!(
+        std::fs::read_to_string(base.join("scenarios").join("basis.feature")).unwrap(),
+        "Feature: basis\n"
+    );
+}
+
+#[tokio::test]
+async fn promote_refuses_a_law_already_in_the_traject_repo() {
+    let db = TestDb::new().await;
+    let central = tempfile::tempdir().unwrap();
+    write_central_law(central.path());
+    let state = empty_state(db.pool.clone());
+
+    let (owner, sub) = seed_account(&db.pool, "alice@test.local").await;
+    let traject_dir = tempfile::tempdir().unwrap();
+    let traject_id = seeded_traject(&db.pool, owner, traject_dir.path(), central.path()).await;
+    let tref = traject_ref(traject_id);
+
+    let _ = promote(state.clone(), session_for(&sub).await, &tref, LAW_ID)
+        .await
+        .expect("first promote must succeed");
+
+    // Tweede promote: de wet staat al in de traject-repo → 409, en er
+    // veranderen geen bestanden (geen dubbele/overschreven bestanden).
+    let before = std::fs::read_to_string(
+        traject_dir
+            .path()
+            .join("wet")
+            .join(LAW_ID)
+            .join("2025-01-01.yaml"),
+    )
+    .unwrap();
+    let err = promote(state.clone(), session_for(&sub).await, &tref, LAW_ID)
+        .await
+        .expect_err("second promote must be refused");
+    assert_eq!(err.0, StatusCode::CONFLICT);
+    let after = std::fs::read_to_string(
+        traject_dir
+            .path()
+            .join("wet")
+            .join(LAW_ID)
+            .join("2025-01-01.yaml"),
+    )
+    .unwrap();
+    assert_eq!(before, after);
+}
+
+#[tokio::test]
+async fn promote_404s_for_a_law_missing_from_the_central_corpus() {
+    let db = TestDb::new().await;
+    let central = tempfile::tempdir().unwrap();
+    let state = empty_state(db.pool.clone());
+
+    let (owner, sub) = seed_account(&db.pool, "alice@test.local").await;
+    let traject_dir = tempfile::tempdir().unwrap();
+    let traject_id = seeded_traject(&db.pool, owner, traject_dir.path(), central.path()).await;
+    let tref = traject_ref(traject_id);
+
+    let err = promote(state, session_for(&sub).await, &tref, "wet_bestaat_niet")
+        .await
+        .expect_err("unknown law must 404");
+    assert_eq!(err.0, StatusCode::NOT_FOUND);
+}

--- a/packages/editor-api/tests/promote_user_token_write_test.rs
+++ b/packages/editor-api/tests/promote_user_token_write_test.rs
@@ -1,0 +1,383 @@
+//! Deployed-achtige federatie-configuratie voor de "Wet toevoegen"-promote:
+//! een read-only seed (het centrale corpus) plus een **GitHub-backed
+//! writable-own met `gh_path`-subpath en ZONDER geconfigureerd service-token**
+//! — precies de pr952-preview-config waarin promote met 403 "Source is
+//! read-only" faalde terwijl de deployment in de user-token-schrijfmodus
+//! staat (`github.user_oauth` / `GITHUB_USER_TOKEN_REQUIRED`): het traject is
+//! aangemaakt op een user-gekozen repo, dus er bestaat bewust geen
+//! `CORPUS_AUTH_*`-token voor die repo (fail-closed) en elke write hoort via
+//! het gekoppelde GitHub-token van de acterende gebruiker te lopen.
+//!
+//! Zonder de fix (writability-gate die de user-token-modus kent + een
+//! GitHubApiBackend die zonder rest-token buffert en bij `persist` met het
+//! override-token commit én de traject-branch bootstrapt) faalt de
+//! promote-scenario hieronder aantoonbaar met die 403.
+//!
+//! GitHub wordt gespeeld door wiremock; `GITHUB_API_BASE` (de test-seam in
+//! `GitHubFetcher::new`) wijst de fetchers daarheen. Alle scenario's staan in
+//! ÉÉN test zodat die env-var niet tussen parallelle tests kan racen.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::Arc;
+
+use axum::extract::{Extension, Path, State};
+use axum::http::{HeaderMap, StatusCode};
+use pretty_assertions::assert_eq;
+use sqlx::PgPool;
+use tokio::sync::{Mutex, RwLock};
+use tower_sessions::Session;
+use tower_sessions_memory_store::MemoryStore;
+use uuid::Uuid;
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use regelrecht_auth::handlers::{
+    SESSION_KEY_EMAIL, SESSION_KEY_EMAIL_VERIFIED, SESSION_KEY_NAME, SESSION_KEY_SUB,
+};
+use regelrecht_editor_api::accounts::AccountRecord;
+use regelrecht_editor_api::config::AppConfig;
+use regelrecht_editor_api::corpus_handlers::{promote_corpus_law, save_law};
+use regelrecht_editor_api::github_oauth::{self, GithubOAuth};
+use regelrecht_editor_api::state::{AppState, CorpusState};
+use regelrecht_editor_api::traject_corpus::TrajectCorpusCache;
+
+use regelrecht_pipeline::test_utils::TestDb;
+
+const LAW_ID: &str = "wet_voorbeeld_promotie";
+const OWN_REPO: &str = "example-org/example-traject-repo";
+const OWN_BRANCH: &str = "traject-voorbeeld";
+const OWN_SUBPATH: &str = "corpus/regulation";
+
+fn state_with_user_token_mode(pool: PgPool, oauth: GithubOAuth) -> AppState {
+    AppState {
+        corpus: Arc::new(RwLock::new(CorpusState::empty())),
+        oidc_client: None,
+        end_session_url: None,
+        config: Arc::new(AppConfig {
+            oidc: None,
+            base_url: None,
+            github_oauth: Some(oauth),
+            task_enrich_provider: "claude".to_string(),
+        }),
+        http_client: reqwest::Client::new(),
+        pool: Some(pool),
+        pipeline_api_url: None,
+        harvest_admin_url: None,
+        reload_lock: Arc::new(Mutex::new(())),
+        trajects: Arc::new(TrajectCorpusCache::new()),
+    }
+}
+
+async fn seed_account(pool: &PgPool, email: &str) -> (Uuid, String) {
+    let sub = format!("sub-{email}");
+    let (id,): (Uuid,) = sqlx::query_as(
+        "INSERT INTO accounts (person_sub, email, name) VALUES ($1, $2, $3) RETURNING id",
+    )
+    .bind(&sub)
+    .bind(email)
+    .bind("Test User")
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    (id, sub)
+}
+
+/// Traject zoals de deployed preview: een GitHub writable-own op een
+/// user-gekozen repo (subpath, auth_ref waarvoor géén
+/// `CORPUS_AUTH_*_TOKEN`-env bestaat → geen rest-token, backend read-only
+/// at rest) plus een lokale read-seed die het centrale corpus speelt.
+async fn seeded_traject(pool: &PgPool, owner_id: Uuid, seed_dir: &std::path::Path) -> Uuid {
+    let (traject_id,): (Uuid,) = sqlx::query_as(
+        "INSERT INTO trajects (name, description, scope, created_by)
+         VALUES ('Test', '', '', $1) RETURNING id",
+    )
+    .bind(owner_id)
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO traject_members (traject_id, account_id, role)
+         VALUES ($1, $2, 'owner')",
+    )
+    .bind(traject_id)
+    .bind(owner_id)
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO traject_corpus_sources
+         (traject_id, source_id, name, source_type,
+          gh_owner, gh_repo, gh_branch, gh_base_branch, gh_path,
+          priority, auth_ref, is_writable_own)
+         VALUES ($1, 'traject-own-test', 'Eigen repo', 'github'::corpus_source_type,
+                 'example-org', 'example-traject-repo', $2, 'main', $3,
+                 0, 'example-unset-token-ref', TRUE)",
+    )
+    .bind(traject_id)
+    .bind(OWN_BRANCH)
+    .bind(OWN_SUBPATH)
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO traject_corpus_sources
+         (traject_id, source_id, name, source_type, local_path,
+          priority, scopes, is_writable_own)
+         VALUES ($1, 'central-seed', 'Centrale Corpus', 'local'::corpus_source_type, $2,
+                 2, '[]'::jsonb, FALSE)",
+    )
+    .bind(traject_id)
+    .bind(seed_dir.to_string_lossy().to_string())
+    .execute(pool)
+    .await
+    .unwrap();
+    traject_id
+}
+
+fn traject_ref(traject_id: Uuid) -> String {
+    format!("test-{}", &traject_id.to_string()[..8])
+}
+
+async fn session_for(sub: &str) -> Session {
+    let session = Session::new(None, Arc::new(MemoryStore::default()), None);
+    session.insert(SESSION_KEY_SUB, sub).await.unwrap();
+    session.insert(SESSION_KEY_NAME, "Test User").await.unwrap();
+    session
+        .insert(SESSION_KEY_EMAIL, "alice@test.local")
+        .await
+        .unwrap();
+    session
+        .insert(SESSION_KEY_EMAIL_VERIFIED, true)
+        .await
+        .unwrap();
+    session
+}
+
+/// Volledige wet-map in het centrale corpus: twee versies plus één
+/// scenario-file — de drie bestanden die de promote moet kopiëren.
+fn write_central_law(central_dir: &std::path::Path) {
+    let law_dir = central_dir.join("wet").join(LAW_ID);
+    std::fs::create_dir_all(law_dir.join("scenarios")).unwrap();
+    std::fs::write(
+        law_dir.join("2025-01-01.yaml"),
+        format!("$id: {LAW_ID}\nname: Versie 2025\nmachine_readable: MARKER_2025\n"),
+    )
+    .unwrap();
+    std::fs::write(
+        law_dir.join("2024-01-01.yaml"),
+        format!("$id: {LAW_ID}\nname: Versie 2024\n"),
+    )
+    .unwrap();
+    std::fs::write(
+        law_dir.join("scenarios").join("basis.feature"),
+        "Feature: basis\n",
+    )
+    .unwrap();
+}
+
+/// Mocks voor de user-token-schrijfflow op de traject-repo:
+/// branch-bootstrap (bestaat nog niet → aanmaken vanaf `main`) en de
+/// Contents-PUT's, allemaal geauthenticeerd met het user-token.
+async fn mount_write_mocks(server: &MockServer) {
+    // Branch-check van de traject-branch: bestaat nog niet bij de eerste
+    // bootstrap (404, eenmalig), daarna wél — de save-scenario bouwt het
+    // traject-corpus opnieuw op (promote invalideert de cache) en diens
+    // persist-bootstrap moet de bestaande branch zien in plaats van hem
+    // nogmaals aan te maken.
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/repos/{OWN_REPO}/git/ref/heads/{OWN_BRANCH}"
+        )))
+        .respond_with(ResponseTemplate::new(404))
+        .up_to_n_times(1)
+        .mount(server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/repos/{OWN_REPO}/git/ref/heads/{OWN_BRANCH}"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "ref": format!("refs/heads/{OWN_BRANCH}"),
+            "object": { "sha": "branch-sha" },
+        })))
+        .mount(server)
+        .await;
+    // Base-ref voor de branch-create.
+    Mock::given(method("GET"))
+        .and(path(format!("/repos/{OWN_REPO}/git/ref/heads/main")))
+        .and(header("authorization", "Bearer user-token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "ref": "refs/heads/main",
+            "object": { "sha": "base-sha" },
+        })))
+        .mount(server)
+        .await;
+    // Branch aanmaken — met het user-token (er ís geen ander token).
+    Mock::given(method("POST"))
+        .and(path(format!("/repos/{OWN_REPO}/git/refs")))
+        .and(header("authorization", "Bearer user-token"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+            "ref": format!("refs/heads/{OWN_BRANCH}"),
+        })))
+        .expect(1)
+        .mount(server)
+        .await;
+    // Contents-PUT's: de drie promote-bestanden (en later de save) landen
+    // onder de subpath, geauthenticeerd als de gebruiker.
+    for file in [
+        format!("wet/{LAW_ID}/2025-01-01.yaml"),
+        format!("wet/{LAW_ID}/2024-01-01.yaml"),
+        format!("wet/{LAW_ID}/scenarios/basis.feature"),
+    ] {
+        Mock::given(method("PUT"))
+            .and(path(format!(
+                "/repos/{OWN_REPO}/contents/{OWN_SUBPATH}/{file}"
+            )))
+            .and(header("authorization", "Bearer user-token"))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                "content": { "sha": format!("sha-{file}") },
+            })))
+            .mount(server)
+            .await;
+    }
+}
+
+/// PUT-paden (Contents API) die wiremock ontving, in volgorde.
+async fn received_put_paths(server: &MockServer) -> Vec<String> {
+    server
+        .received_requests()
+        .await
+        .unwrap()
+        .iter()
+        .filter(|r| r.method.as_str() == "PUT")
+        .map(|r| r.url.path().to_string())
+        .collect()
+}
+
+/// Eén test voor alle scenario's: de `GITHUB_API_BASE`-override is
+/// proces-breed, dus parallelle tests met elk een eigen mockserver zouden
+/// elkaars fetchers verhangen.
+#[tokio::test]
+async fn user_token_mode_writes_promote_and_save_through_the_traject_repo() {
+    let server = MockServer::start().await;
+    // Test-seam (zie `GitHubFetcher::new`): alle fetchers in dit proces —
+    // ook die diep in `build_traject_corpus` — praten tegen wiremock.
+    std::env::set_var("GITHUB_API_BASE", server.uri());
+
+    let db = TestDb::new().await;
+    let central = tempfile::tempdir().unwrap();
+    write_central_law(central.path());
+
+    let oauth = GithubOAuth::for_tests(true); // user-token-schrijfmodus aan
+    let state = state_with_user_token_mode(db.pool.clone(), oauth.clone());
+
+    let (owner_id, sub) = seed_account(&db.pool, "alice@test.local").await;
+    let account = AccountRecord {
+        id: owner_id,
+        person_sub: sub.clone(),
+        email: "alice@test.local".to_string(),
+        name: "Test User".to_string(),
+    };
+    let traject_id = seeded_traject(&db.pool, owner_id, central.path()).await;
+    let tref = traject_ref(traject_id);
+
+    mount_write_mocks(&server).await;
+
+    // --- Scenario 1: geen gekoppeld GitHub-account → 428 (koppel-flow),
+    // niet de oude 403 "Source is read-only". Fail-closed: zonder
+    // user-token wordt er niets geschreven.
+    let err = promote_corpus_law(
+        State(state.clone()),
+        Extension(account.clone()),
+        session_for(&sub).await,
+        Path((tref.clone(), LAW_ID.to_string())),
+        HeaderMap::new(),
+    )
+    .await
+    .expect_err("zonder gekoppeld token moet de promote weigeren");
+    assert_eq!(
+        err.0,
+        StatusCode::PRECONDITION_REQUIRED,
+        "verwacht de koppel-flow (428), kreeg: {} {}",
+        err.0,
+        err.1
+    );
+    assert_eq!(
+        received_put_paths(&server).await,
+        Vec::<String>::new(),
+        "zonder token mag er niets richting GitHub geschreven zijn"
+    );
+
+    // --- Scenario 2: gekoppeld GitHub-account → de promote kopieert de
+    // volledige wet-map naar de traject-repo, onder de subpath, met het
+    // user-token (pre-fix faalde dit met 403 "Source is read-only").
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        axum::http::header::COOKIE,
+        axum::http::HeaderValue::from_str(&github_oauth::seal_token_cookie_for_tests(
+            &oauth,
+            account.id,
+            "user-token",
+        ))
+        .unwrap(),
+    );
+
+    let response = promote_corpus_law(
+        State(state.clone()),
+        Extension(account.clone()),
+        session_for(&sub).await,
+        Path((tref.clone(), LAW_ID.to_string())),
+        headers.clone(),
+    )
+    .await
+    .expect("promote met gekoppeld token moet slagen");
+    assert_eq!(response.0.law_id, LAW_ID);
+    assert_eq!(response.0.copied_files, 3, "2 versies + 1 scenario");
+
+    let puts = received_put_paths(&server).await;
+    assert_eq!(puts.len(), 3, "drie Contents-PUT's, got: {puts:?}");
+    for file in [
+        format!("wet/{LAW_ID}/2025-01-01.yaml"),
+        format!("wet/{LAW_ID}/2024-01-01.yaml"),
+        format!("wet/{LAW_ID}/scenarios/basis.feature"),
+    ] {
+        let expected = format!("/repos/{OWN_REPO}/contents/{OWN_SUBPATH}/{file}");
+        assert!(
+            puts.contains(&expected),
+            "PUT naar {expected} ontbreekt, got: {puts:?}"
+        );
+    }
+
+    // --- Scenario 3: een gewone law-save door dezelfde gebruiker volgt
+    // exact hetzelfde schrijfpad (zelfde backend, zelfde subpath, zelfde
+    // user-token-autorisatie) — promote en save zijn hetzelfde pad.
+    let body = format!("$id: {LAW_ID}\nname: Versie 2025 (bewerkt)\n");
+    save_law(
+        State(state.clone()),
+        Extension(account.clone()),
+        session_for(&sub).await,
+        Path((tref.clone(), LAW_ID.to_string())),
+        headers,
+        body,
+    )
+    .await
+    .expect("law-save met gekoppeld token moet slagen");
+
+    let puts = received_put_paths(&server).await;
+    assert_eq!(
+        puts.len(),
+        4,
+        "de save is één extra Contents-PUT, got: {puts:?}"
+    );
+    assert_eq!(
+        puts[3],
+        format!("/repos/{OWN_REPO}/contents/{OWN_SUBPATH}/wet/{LAW_ID}/2025-01-01.yaml"),
+        "de save landt op hetzelfde subpath-schrijfpad als de promote"
+    );
+
+    // De branch-bootstrap (POST /git/refs, `.expect(1)` op de mock) is
+    // precies één keer gebeurd: bij de eerste geslaagde persist, met het
+    // user-token. wiremock verifieert dat bij drop van de server.
+    std::env::remove_var("GITHUB_API_BASE");
+}

--- a/packages/editor-api/tests/traject_harvest_request_test.rs
+++ b/packages/editor-api/tests/traject_harvest_request_test.rs
@@ -1,0 +1,244 @@
+//! Integration tests for `task_requests::request_traject_harvest`: de
+//! traject-scoped harvest-aanvraag (taken-mechanisme). Pint vast dat een
+//! aanvraag een `traject_harvest`-job enqueue't met het juiste
+//! taak-flow-payload (deliver=task, requested_by, prioriteit 80), dat een
+//! tweede aanvraag voor dezelfde wet dedupliceert (409) en dat een ongeldig
+//! BWB-id met 400 wordt geweigerd.
+//!
+//! Zelfde hermetische opzet als `promote_law_test.rs` / `traject_reads_test.rs`.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::Arc;
+
+use axum::extract::{Extension, Path, State};
+use axum::http::StatusCode;
+use pretty_assertions::assert_eq;
+use sqlx::PgPool;
+use tokio::sync::{Mutex, RwLock};
+use tower_sessions::Session;
+use tower_sessions_memory_store::MemoryStore;
+use uuid::Uuid;
+
+use regelrecht_auth::handlers::{
+    SESSION_KEY_EMAIL, SESSION_KEY_EMAIL_VERIFIED, SESSION_KEY_NAME, SESSION_KEY_SUB,
+};
+use regelrecht_editor_api::accounts::AccountRecord;
+use regelrecht_editor_api::config::AppConfig;
+use regelrecht_editor_api::state::{AppState, CorpusState};
+use regelrecht_editor_api::task_requests::{request_traject_harvest, TrajectHarvestRequest};
+use regelrecht_editor_api::traject_corpus::TrajectCorpusCache;
+
+use regelrecht_pipeline::test_utils::TestDb;
+
+const BWB_ID: &str = "BWBR0002399";
+
+fn empty_state(pool: PgPool) -> AppState {
+    AppState {
+        corpus: Arc::new(RwLock::new(CorpusState::empty())),
+        oidc_client: None,
+        end_session_url: None,
+        config: Arc::new(AppConfig {
+            oidc: None,
+            base_url: None,
+            github_oauth: None,
+            task_enrich_provider: "claude".to_string(),
+        }),
+        http_client: reqwest::Client::new(),
+        pool: Some(pool),
+        pipeline_api_url: None,
+        harvest_admin_url: None,
+        reload_lock: Arc::new(Mutex::new(())),
+        trajects: Arc::new(TrajectCorpusCache::new()),
+    }
+}
+
+async fn seed_account(pool: &PgPool, email: &str) -> (Uuid, String) {
+    let sub = format!("sub-{email}");
+    let (id,): (Uuid,) = sqlx::query_as(
+        "INSERT INTO accounts (person_sub, email, name) VALUES ($1, $2, $3) RETURNING id",
+    )
+    .bind(&sub)
+    .bind(email)
+    .bind("Test User")
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    (id, sub)
+}
+
+async fn local_traject(pool: &PgPool, owner_id: Uuid, corpus_dir: &std::path::Path) -> Uuid {
+    let (traject_id,): (Uuid,) = sqlx::query_as(
+        "INSERT INTO trajects (name, description, scope, created_by)
+         VALUES ('Test', '', '', $1) RETURNING id",
+    )
+    .bind(owner_id)
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO traject_members (traject_id, account_id, role)
+         VALUES ($1, $2, 'owner')",
+    )
+    .bind(traject_id)
+    .bind(owner_id)
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO traject_corpus_sources
+         (traject_id, source_id, name, source_type, local_path,
+          priority, scopes, is_writable_own)
+         VALUES ($1, 'local', 'Local', 'local'::corpus_source_type, $2,
+                 0, '[]'::jsonb, TRUE)",
+    )
+    .bind(traject_id)
+    .bind(corpus_dir.to_string_lossy().to_string())
+    .execute(pool)
+    .await
+    .unwrap();
+    traject_id
+}
+
+fn traject_ref(traject_id: Uuid) -> String {
+    format!("test-{}", &traject_id.to_string()[..8])
+}
+
+async fn session_for(sub: &str) -> Session {
+    let session = Session::new(None, Arc::new(MemoryStore::default()), None);
+    session.insert(SESSION_KEY_SUB, sub).await.unwrap();
+    session.insert(SESSION_KEY_NAME, "Test User").await.unwrap();
+    session
+        .insert(SESSION_KEY_EMAIL, "alice@test.local")
+        .await
+        .unwrap();
+    session
+        .insert(SESSION_KEY_EMAIL_VERIFIED, true)
+        .await
+        .unwrap();
+    session
+}
+
+fn account(account_id: Uuid) -> AccountRecord {
+    AccountRecord {
+        id: account_id,
+        person_sub: "test-sub".to_string(),
+        email: "test@example.gov".to_string(),
+        name: "Test User".to_string(),
+    }
+}
+
+async fn request(
+    state: AppState,
+    sub: &str,
+    account_id: Uuid,
+    tref: &str,
+    bwb_id: &str,
+    law_name: Option<&str>,
+) -> Result<StatusCode, (StatusCode, String)> {
+    let (status, _body) = request_traject_harvest(
+        State(state),
+        session_for(sub).await,
+        Extension(account(account_id)),
+        Path(tref.to_string()),
+        axum::Json(TrajectHarvestRequest {
+            bwb_id: bwb_id.to_string(),
+            law_name: law_name.map(String::from),
+        }),
+    )
+    .await?;
+    Ok(status)
+}
+
+#[tokio::test]
+async fn harvest_request_enqueues_a_task_flow_job() {
+    let db = TestDb::new().await;
+    let state = empty_state(db.pool.clone());
+    let (owner, sub) = seed_account(&db.pool, "alice@test.local").await;
+    let corpus_dir = tempfile::tempdir().unwrap();
+    let traject_id = local_traject(&db.pool, owner, corpus_dir.path()).await;
+    let tref = traject_ref(traject_id);
+
+    let status = request(
+        state,
+        &sub,
+        owner,
+        &tref,
+        // lowercase input wordt genormaliseerd naar de canonieke vorm.
+        &BWB_ID.to_lowercase(),
+        Some("Voorbeeldwet"),
+    )
+    .await
+    .expect("harvest request must be accepted");
+    assert_eq!(status, StatusCode::ACCEPTED);
+
+    let (job_type, law_id, job_tref, priority, payload): (
+        String,
+        String,
+        Option<String>,
+        i32,
+        serde_json::Value,
+    ) = sqlx::query_as("SELECT job_type::text, law_id, traject_ref, priority, payload FROM jobs")
+        .fetch_one(&db.pool)
+        .await
+        .unwrap();
+    assert_eq!(job_type, "traject_harvest");
+    assert_eq!(law_id, BWB_ID);
+    assert_eq!(job_tref.as_deref(), Some(tref.as_str()));
+    assert_eq!(
+        priority, 80,
+        "een mens wacht erop: boven de bulk-prioriteit"
+    );
+    assert_eq!(payload["bwb_id"], BWB_ID);
+    assert_eq!(payload["deliver"], "task");
+    assert_eq!(payload["law_name"], "Voorbeeldwet");
+    assert_eq!(payload["requested_by"], owner.to_string());
+    assert_eq!(payload["traject_id"], traject_id.to_string());
+}
+
+#[tokio::test]
+async fn duplicate_harvest_request_for_same_law_and_traject_conflicts() {
+    let db = TestDb::new().await;
+    let state = empty_state(db.pool.clone());
+    let (owner, sub) = seed_account(&db.pool, "alice@test.local").await;
+    let corpus_dir = tempfile::tempdir().unwrap();
+    let traject_id = local_traject(&db.pool, owner, corpus_dir.path()).await;
+    let tref = traject_ref(traject_id);
+
+    let first = request(state.clone(), &sub, owner, &tref, BWB_ID, None)
+        .await
+        .expect("first request must be accepted");
+    assert_eq!(first, StatusCode::ACCEPTED);
+
+    let err = request(state, &sub, owner, &tref, BWB_ID, None)
+        .await
+        .expect_err("second request must conflict");
+    assert_eq!(err.0, StatusCode::CONFLICT);
+
+    let (count,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM jobs")
+        .fetch_one(&db.pool)
+        .await
+        .unwrap();
+    assert_eq!(count, 1, "dedup: er blijft één actieve job");
+}
+
+#[tokio::test]
+async fn invalid_bwb_id_is_rejected_with_400() {
+    let db = TestDb::new().await;
+    let state = empty_state(db.pool.clone());
+    let (owner, sub) = seed_account(&db.pool, "alice@test.local").await;
+    let corpus_dir = tempfile::tempdir().unwrap();
+    let traject_id = local_traject(&db.pool, owner, corpus_dir.path()).await;
+    let tref = traject_ref(traject_id);
+
+    let err = request(state, &sub, owner, &tref, "wet_op_de_zorgtoeslag", None)
+        .await
+        .expect_err("slug is geen BWB-id");
+    assert_eq!(err.0, StatusCode::BAD_REQUEST);
+
+    let (count,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM jobs")
+        .fetch_one(&db.pool)
+        .await
+        .unwrap();
+    assert_eq!(count, 0);
+}

--- a/packages/editor-api/tests/traject_reads_test.rs
+++ b/packages/editor-api/tests/traject_reads_test.rs
@@ -413,23 +413,40 @@ async fn ttl_refresh_picks_up_upstream_laws_and_reconciles_saves() {
     .unwrap();
     write_law(corpus.path(), "EXTERNAL");
 
-    // The next request refreshes the snapshot (TTL expired): the new law
-    // is indexed without a traject delete/recreate or process restart…
-    let Json(entries) = list_traject_corpus_laws(
-        State(state.clone()),
-        session_for(&sub).await,
-        Path(tref.clone()),
-        Query(PaginationParams {
-            offset: 0,
-            limit: None,
-            q: None,
-            ids: None,
-        }),
-    )
-    .await
-    .expect("law list must succeed");
+    // A next request refreshes the snapshot (TTL expired) and the new law
+    // is indexed without a traject delete/recreate or process restart.
+    //
+    // The refresh is stale-while-revalidate: a request past the TTL serves
+    // the stale snapshot and kicks the re-enumeration off in a *background*
+    // task (see `spawn_background_refresh`), so no single request is
+    // guaranteed to observe the post-write snapshot — in particular, a
+    // refresh spawned by an earlier request may have enumerated the sources
+    // just *before* the writes above landed. Poll (bounded) until a request
+    // is served the refreshed snapshot; asserting on one shot made this
+    // test scheduling-dependent and flaky.
+    let mut indexed = false;
+    for _ in 0..50 {
+        let Json(entries) = list_traject_corpus_laws(
+            State(state.clone()),
+            session_for(&sub).await,
+            Path(tref.clone()),
+            Query(PaginationParams {
+                offset: 0,
+                limit: None,
+                q: None,
+                ids: None,
+            }),
+        )
+        .await
+        .expect("law list must succeed");
+        if entries.iter().any(|e| e.law_id == "andere_wet") {
+            indexed = true;
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
     assert!(
-        entries.iter().any(|e| e.law_id == "andere_wet"),
+        indexed,
         "refreshed snapshot must index the upstream-added law"
     );
 
@@ -439,7 +456,16 @@ async fn ttl_refresh_picks_up_upstream_laws_and_reconciles_saves() {
     // stops pinning its own stale save (which would otherwise turn every
     // cross-replica edit into a permanent 412 loop — the user could
     // never fetch the conflicting content their If-Match fails against).
-    let (_etag, after) = read_law(state, session_for(&sub).await, &tref).await;
+    // Same stale-while-revalidate caveat as above: poll, don't one-shot.
+    let mut after = String::new();
+    for _ in 0..50 {
+        let (_etag, body) = read_law(state.clone(), session_for(&sub).await, &tref).await;
+        after = body;
+        if after.contains("EXTERNAL") {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
     assert!(
         after.contains("EXTERNAL"),
         "expected reads to converge to the externally written content; got: {after}"

--- a/packages/pipeline/migrations/0031_traject_harvest_job_type.sql
+++ b/packages/pipeline/migrations/0031_traject_harvest_job_type.sql
@@ -1,0 +1,7 @@
+-- no-transaction
+-- Nieuw jobtype voor een traject-scoped harvest: haal een wet uit BWB op en
+-- keten er een taak-flow-enrich aan (zoals law_convert), zonder de centrale
+-- corpus-repo aan te raken. ALTER TYPE ... ADD VALUE kan niet in een
+-- transactieblok, vandaar de no-transaction-marker (zelfde patroon als
+-- 0025_document_convert_job_type.sql en 0030_law_convert_job_type.sql).
+ALTER TYPE job_type ADD VALUE IF NOT EXISTS 'traject_harvest';

--- a/packages/pipeline/src/law_convert.rs
+++ b/packages/pipeline/src/law_convert.rs
@@ -33,6 +33,12 @@ use crate::tasks::{self, BlobKind};
 /// enrich-op-aanvraag (task_requests.rs), want ook hier wacht een mens.
 const CHAINED_ENRICH_PRIORITY: i32 = 80;
 
+/// Marker in de dedup-fout van [`chain_enrich_and_complete`] ("er loopt al
+/// een verrijking …"). De worker classificeert de fout hiermee als
+/// deterministisch (terminaal, geen retry) — door de gedeelde const kan de
+/// formulering niet stilletjes uit de pas lopen met de matcher in `worker.rs`.
+pub(crate) const ENRICH_IN_PROGRESS_MARKER: &str = "er loopt al een verrijking";
+
 /// Payload carried by a `law_convert` job. The raw bytes live in
 /// `document_uploads` (referenced by `upload_id`), same as document-convert.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -466,7 +472,7 @@ pub async fn chain_enrich_and_complete(
         // Rollback (impliciet) en laat de aanroeper dit als terminale fout met
         // job_failed-taak afhandelen.
         return Err(PipelineError::Enrich(format!(
-            "er loopt al een verrijking voor wet '{}' in dit traject; \
+            "{ENRICH_IN_PROGRESS_MARKER} voor wet '{}' in dit traject; \
              de nieuwe wet is niet aangemaakt",
             law.meta.law_id
         )));

--- a/packages/pipeline/src/law_convert.rs
+++ b/packages/pipeline/src/law_convert.rs
@@ -413,14 +413,25 @@ async fn read_output(output_path: &Path) -> Result<String> {
     Ok(yaml)
 }
 
+/// Context for chaining a task-flow enrich job onto the job that produced a
+/// base law. Shared by `law_convert` (document → wet) and `traject_harvest`
+/// (BWB → wet): both end in the same "enrich as review task" chain.
+#[derive(Debug, Clone)]
+pub struct EnrichChainContext {
+    pub provider: Option<String>,
+    pub requested_by: Option<Uuid>,
+    pub traject_id: Uuid,
+    pub traject_ref: String,
+}
+
 /// Chain step, in one transaction: enqueue the task-flow enrich job with the
-/// generated base YAML as input blob, and complete the convert job. The
+/// generated base YAML as input blob, and complete the producing job. The
 /// single review task the user sees is created later by the enrich task flow
 /// (`worker::finish_enrich_task_job`, with `kind: "law_create"`).
-pub async fn finish_law_convert_job(
+pub async fn chain_enrich_and_complete(
     pool: &PgPool,
-    convert_job: &Job,
-    payload: &LawConvertPayload,
+    source_job: &Job,
+    ctx: &EnrichChainContext,
     law: &GeneratedLaw,
 ) -> Result<()> {
     // Same synthetic repo-relative path convention as `request_enrich` in
@@ -430,12 +441,12 @@ pub async fn finish_law_convert_job(
     let enrich_payload = EnrichPayload {
         law_id: law.meta.law_id.clone(),
         yaml_path: yaml_path.clone(),
-        provider: payload.provider.clone(),
+        provider: ctx.provider.clone(),
         depth: None,
-        requested_by: payload.requested_by,
+        requested_by: ctx.requested_by,
         deliver: Some("task".to_string()),
-        traject_id: Some(payload.traject_id),
-        traject_ref: Some(payload.traject_ref.clone()),
+        traject_id: Some(ctx.traject_id),
+        traject_ref: Some(ctx.traject_ref.clone()),
         source_etag: None,
         new_law: Some(true),
     };
@@ -444,14 +455,14 @@ pub async fn finish_law_convert_job(
 
     let mut tx = pool.begin().await?;
     let req = CreateJobRequest::new(JobType::Enrich, &law.meta.law_id)
-        .with_traject_ref(&payload.traject_ref)
+        .with_traject_ref(&ctx.traject_ref)
         .with_priority(Priority::new(CHAINED_ENRICH_PRIORITY))
         .with_payload(payload_json)
         .with_max_attempts(3);
     let enrich_job = job_queue::create_enrich_job_if_not_exists(&mut *tx, req).await?;
     let Some(enrich_job) = enrich_job else {
         // Er loopt al een actieve enrich voor deze (slug, provider, traject) —
-        // kan alleen bij een tweede upload die op dezelfde slug uitkomt.
+        // kan alleen bij een tweede aanvraag die op dezelfde slug uitkomt.
         // Rollback (impliciet) en laat de aanroeper dit als terminale fout met
         // job_failed-taak afhandelen.
         return Err(PipelineError::Enrich(format!(
@@ -470,19 +481,36 @@ pub async fn finish_law_convert_job(
     .await?;
     job_queue::complete_job(
         &mut *tx,
-        convert_job.id,
+        source_job.id,
         Some(serde_json::json!({ "law_id": law.meta.law_id })),
     )
     .await?;
     tx.commit().await?;
     tracing::info!(
-        convert_job = %convert_job.id,
+        source_job = %source_job.id,
+        source_job_type = ?source_job.job_type,
         enrich_job = %enrich_job.id,
         law_id = %law.meta.law_id,
         layer = law.meta.regulatory_layer.as_str(),
-        "law-convert chained into enrich task job"
+        "chained into enrich task job"
     );
     Ok(())
+}
+
+/// Chain step for law-convert; see [`chain_enrich_and_complete`].
+pub async fn finish_law_convert_job(
+    pool: &PgPool,
+    convert_job: &Job,
+    payload: &LawConvertPayload,
+    law: &GeneratedLaw,
+) -> Result<()> {
+    let ctx = EnrichChainContext {
+        provider: payload.provider.clone(),
+        requested_by: payload.requested_by,
+        traject_id: payload.traject_id,
+        traject_ref: payload.traject_ref.clone(),
+    };
+    chain_enrich_and_complete(pool, convert_job, &ctx, law).await
 }
 
 #[cfg(test)]

--- a/packages/pipeline/src/law_status.rs
+++ b/packages/pipeline/src/law_status.rs
@@ -294,12 +294,14 @@ fn fail_count_column(job_type: crate::models::JobType) -> &'static str {
     match job_type {
         crate::models::JobType::Harvest => "harvest_fail_count",
         crate::models::JobType::Enrich => "enrich_fail_count",
-        // document_convert/law_convert jobs are traject-scoped, not law-scoped:
-        // they have no `law_entries` row and never go through the per-law
-        // fail-count / exhaust path (the worker fails them with plain
-        // `fail_job`). Reaching here is a programming error.
-        crate::models::JobType::DocumentConvert | crate::models::JobType::LawConvert => {
-            unreachable!("convert jobs have no law-status fail counter")
+        // document_convert/law_convert/traject_harvest jobs are traject-scoped,
+        // not law-scoped: they have no `law_entries` row and never go through
+        // the per-law fail-count / exhaust path (the worker fails them with
+        // plain `fail_job`). Reaching here is a programming error.
+        crate::models::JobType::DocumentConvert
+        | crate::models::JobType::LawConvert
+        | crate::models::JobType::TrajectHarvest => {
+            unreachable!("traject-scoped jobs have no law-status fail counter")
         }
     }
 }
@@ -366,9 +368,11 @@ where
             LawStatusValue::EnrichFailed,
             LawStatusValue::EnrichExhausted,
         ),
-        // See `fail_count_column`: convert jobs are not law-scoped.
-        crate::models::JobType::DocumentConvert | crate::models::JobType::LawConvert => {
-            unreachable!("convert jobs are not law-scoped and cannot be exhausted")
+        // See `fail_count_column`: these job types are not law-scoped.
+        crate::models::JobType::DocumentConvert
+        | crate::models::JobType::LawConvert
+        | crate::models::JobType::TrajectHarvest => {
+            unreachable!("traject-scoped jobs are not law-scoped and cannot be exhausted")
         }
     };
     // Only exhaust if status is still the corresponding failed state,

--- a/packages/pipeline/src/lib.rs
+++ b/packages/pipeline/src/lib.rs
@@ -16,6 +16,7 @@ pub mod models;
 pub mod tasks;
 #[cfg(feature = "test-utils")]
 pub mod test_utils;
+pub mod traject_harvest;
 pub mod untranslatables;
 pub mod worker;
 

--- a/packages/pipeline/src/models.rs
+++ b/packages/pipeline/src/models.rs
@@ -18,6 +18,14 @@ pub enum JobType {
     #[sqlx(rename = "law_convert")]
     #[serde(rename = "law_convert")]
     LawConvert,
+    /// Harvest a law from BWB for one traject (task flow): download + parse
+    /// the base-law YAML and chain a task-flow enrich job on it, exactly like
+    /// [`JobType::LawConvert`] does after its conversion. Unlike
+    /// [`JobType::Harvest`] this never touches the central corpus repo — the
+    /// result travels as job blobs and lands via the review task's approve.
+    #[sqlx(rename = "traject_harvest")]
+    #[serde(rename = "traject_harvest")]
+    TrajectHarvest,
 }
 
 #[derive(

--- a/packages/pipeline/src/tasks.rs
+++ b/packages/pipeline/src/tasks.rs
@@ -121,8 +121,8 @@ pub async fn count_open_tasks_for_account(pool: &PgPool, account_id: Uuid) -> Re
 }
 
 /// Eén lopende taak-flow-job voor de "Bezig"-sectie: een enrich-,
-/// document_convert- of law_convert-job die deze gebruiker via
-/// `deliver: "task"` heeft aangevraagd en die nog niet is afgerond
+/// document_convert-, law_convert- of traject_harvest-job die deze gebruiker
+/// via `deliver: "task"` heeft aangevraagd en die nog niet is afgerond
 /// (job_review/job_failed-taak bestaat pas na completion/failure).
 #[derive(Debug, Clone, sqlx::FromRow, Serialize)]
 pub struct RunningTaskJob {
@@ -153,7 +153,7 @@ pub async fn list_running_task_jobs_for_account(
                 COALESCE(payload->>'target_path', payload->>'filename') AS target_path, \
                 status, created_at \
          FROM jobs \
-         WHERE job_type IN ('enrich', 'document_convert', 'law_convert') \
+         WHERE job_type IN ('enrich', 'document_convert', 'law_convert', 'traject_harvest') \
            AND status IN ('pending', 'processing') \
            AND payload->>'deliver' = 'task' \
            AND payload->>'requested_by' = $1 \
@@ -293,13 +293,19 @@ pub async fn notify_reaped_task_jobs(
                 "Conversie naar wet mislukt: {}",
                 str_field("filename").unwrap_or("document")
             ),
+            JobType::TrajectHarvest => format!(
+                "Wet ophalen mislukt: {}",
+                str_field("law_name")
+                    .or_else(|| str_field("bwb_id"))
+                    .unwrap_or(&job.law_id)
+            ),
         };
 
         let mut task_payload = serde_json::json!({
             "error": "De verwerking duurde te lang of de worker is herstart; \
                       de job is afgebroken.",
         });
-        for key in ["traject_ref", "law_id", "target_path", "filename"] {
+        for key in ["traject_ref", "law_id", "target_path", "filename", "bwb_id"] {
             if let Some(v) = str_field(key) {
                 task_payload[key] = serde_json::json!(v);
             }

--- a/packages/pipeline/src/traject_harvest.rs
+++ b/packages/pipeline/src/traject_harvest.rs
@@ -20,6 +20,12 @@ use crate::error::{PipelineError, Result};
 use crate::harvest::{execute_harvest, HarvestPayload};
 use crate::law_convert::{validate_law_yaml, GeneratedLaw};
 
+/// Marker in de schema-validatiefout hieronder. De worker classificeert de
+/// fout hiermee als deterministisch (terminaal, geen retry) — door de
+/// gedeelde const kan de formulering niet stilletjes uit de pas lopen met de
+/// matcher in `worker.rs`.
+pub(crate) const SCHEMA_MISMATCH_MARKER: &str = "valideert niet tegen het schema";
+
 /// Payload van een `traject_harvest`-job. Spiegel van
 /// [`crate::law_convert::LawConvertPayload`], maar de bron is een BWB-id in
 /// plaats van geüploade bytes.
@@ -68,9 +74,15 @@ pub async fn execute_traject_harvest(
     payload: &TrajectHarvestPayload,
     http_client: &Client,
 ) -> Result<GeneratedLaw> {
+    // Werkdirectory op basis van het server-gegenereerde traject-UUID, nooit
+    // de traject-ref: de ref is een URL-pad-segment waarvan alleen het
+    // 8-hex-suffix gevalideerd wordt — het slug-deel is vrije (ASCII-)tekst en
+    // een percent-encoded `/` overleeft axum's routing. In een pad dat door
+    // `remove_dir_all`/`create_dir_all` gaat zou dat path-traversal zijn.
+    // Zelfde patroon als docconvert/lawconvert (upload_id-UUID).
     let work_dir = std::env::temp_dir().join(format!(
         "trajectharvest-{}-{}",
-        payload.traject_ref, payload.bwb_id
+        payload.traject_id, payload.bwb_id
     ));
     // Clear any stale directory left by a previous attempt of this same job.
     let _ = tokio::fs::remove_dir_all(&work_dir).await;
@@ -110,7 +122,7 @@ async fn harvest_law_in_dir(
         // hoort als terminale fout in het job_failed-pad te eindigen. De
         // harvester hoort schema-conform te schrijven; dit is het vangnet.
         Err(errors) => Err(PipelineError::Enrich(format!(
-            "geharveste YAML voor {bwb_id} valideert niet tegen het schema: {}",
+            "geharveste YAML voor {bwb_id} {SCHEMA_MISMATCH_MARKER}: {}",
             errors.join("; ")
         ))),
     }

--- a/packages/pipeline/src/traject_harvest.rs
+++ b/packages/pipeline/src/traject_harvest.rs
@@ -1,0 +1,171 @@
+//! Traject-scoped harvest (taak-flow): haal een wet uit BWB op voor één
+//! traject en keten er een taak-flow-enrich aan.
+//!
+//! Anders dan het corpus-brede [`crate::harvest`]-pad raakt dit de centrale
+//! corpus-repo nooit aan: de harvest schrijft in een eigen tijdelijke
+//! werkdirectory, de geproduceerde basis-wet-YAML gaat als input-blob mee met
+//! een geketende enrich-job (`deliver: "task"`, `new_law: true` — het
+//! law_convert-patroon), en het resultaat komt als `law_create`-review-taak
+//! terug bij de aanvrager. Goedkeuren landt de wet in de traject-repo via het
+//! gewone law-create-pad. Een directe harvest chain't NIET automatisch een
+//! enrich — voor deze flow is de keten dus expliciet (productie-geleerd).
+
+use std::path::Path;
+
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::error::{PipelineError, Result};
+use crate::harvest::{execute_harvest, HarvestPayload};
+use crate::law_convert::{validate_law_yaml, GeneratedLaw};
+
+/// Payload van een `traject_harvest`-job. Spiegel van
+/// [`crate::law_convert::LawConvertPayload`], maar de bron is een BWB-id in
+/// plaats van geüploade bytes.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TrajectHarvestPayload {
+    /// BWB-identifier van de op te halen wet (bijv. "BWBR0018451").
+    pub bwb_id: String,
+    /// Owning traject's id (feeds the chained enrich payload + failure task).
+    pub traject_id: Uuid,
+    /// Owning traject ref (also mirrored onto `jobs.traject_ref`).
+    pub traject_ref: String,
+    /// Weergavenaam uit de zoekresultaten, alleen voor titels van taken; de
+    /// echte naam/slug komt uit de harvest zelf.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub law_name: Option<String>,
+    /// LLM-provider voor de geketende enrich; `None` = worker-default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
+    /// Account dat de harvest aanvroeg; wordt de assignee van de uiteindelijke
+    /// review-taak (via de geketende enrich-job) en van een `job_failed`-taak.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requested_by: Option<Uuid>,
+    /// `"task"` ⇒ taak-flow. Traject-harvest kent alléén de taak-flow; het
+    /// veld bestaat zodat de generieke `list_running_task_jobs_for_account`-
+    /// query en de reaper-nazorg dit jobtype meepakken.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deliver: Option<String>,
+}
+
+impl TrajectHarvestPayload {
+    /// Taak-flow: resultaat via de geketende enrich-taak i.p.v. een push.
+    pub fn deliver_as_task(&self) -> bool {
+        self.deliver.as_deref() == Some("task")
+    }
+
+    /// Weergavenaam voor taak-titels: de meegegeven naam of het BWB-id.
+    pub fn display_name(&self) -> &str {
+        self.law_name.as_deref().unwrap_or(&self.bwb_id)
+    }
+}
+
+/// Voer de harvest uit in een eigen tijdelijke werkdirectory en lever de
+/// gevalideerde basis-wet-YAML op. De aanroeper (worker) ketent de enrich en
+/// completet de job via [`crate::law_convert::chain_enrich_and_complete`].
+pub async fn execute_traject_harvest(
+    payload: &TrajectHarvestPayload,
+    http_client: &Client,
+) -> Result<GeneratedLaw> {
+    let work_dir = std::env::temp_dir().join(format!(
+        "trajectharvest-{}-{}",
+        payload.traject_ref, payload.bwb_id
+    ));
+    // Clear any stale directory left by a previous attempt of this same job.
+    let _ = tokio::fs::remove_dir_all(&work_dir).await;
+    tokio::fs::create_dir_all(&work_dir).await?;
+
+    let result = harvest_law_in_dir(&work_dir, &payload.bwb_id, http_client).await;
+
+    // Always remove the working directory, success or failure.
+    let _ = tokio::fs::remove_dir_all(&work_dir).await;
+    result
+}
+
+/// De bestandssysteem-helft van de traject-harvest: harvest naar `work_dir`,
+/// lees de geproduceerde YAML terug en valideer hem met dezelfde validator
+/// als law-convert/law-create — zo is wat de reviewer straks goedkeurt per
+/// constructie ook wat `create_traject_law` accepteert.
+async fn harvest_law_in_dir(
+    work_dir: &Path,
+    bwb_id: &str,
+    http_client: &Client,
+) -> Result<GeneratedLaw> {
+    let harvest_payload = HarvestPayload::for_law(bwb_id, None);
+    let (result, files) =
+        execute_harvest(&harvest_payload, work_dir, "regulation", http_client).await?;
+    tracing::info!(
+        bwb_id = %bwb_id,
+        law_name = %result.law_name,
+        slug = %result.slug,
+        articles = result.article_count,
+        "traject harvest downloaded law"
+    );
+
+    let yaml = tokio::fs::read_to_string(&files.content).await?;
+    match validate_law_yaml(&yaml) {
+        Ok(meta) => Ok(GeneratedLaw { yaml, meta }),
+        // Deterministisch: dezelfde bron produceert dezelfde YAML, dus dit
+        // hoort als terminale fout in het job_failed-pad te eindigen. De
+        // harvester hoort schema-conform te schrijven; dit is het vangnet.
+        Err(errors) => Err(PipelineError::Enrich(format!(
+            "geharveste YAML voor {bwb_id} valideert niet tegen het schema: {}",
+            errors.join("; ")
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn payload_roundtrips_and_backcompat() {
+        let account = Uuid::new_v4();
+        let payload = TrajectHarvestPayload {
+            bwb_id: "BWBR0002399".to_string(),
+            traject_id: Uuid::nil(),
+            traject_ref: "voorbeeld-abcd1234".to_string(),
+            law_name: Some("Voorbeeldwet".to_string()),
+            provider: Some("claude".to_string()),
+            requested_by: Some(account),
+            deliver: Some("task".to_string()),
+        };
+        let json = serde_json::to_value(&payload).unwrap();
+        assert_eq!(json["bwb_id"], "BWBR0002399");
+        assert_eq!(json["deliver"], "task");
+        let back: TrajectHarvestPayload = serde_json::from_value(json).unwrap();
+        assert_eq!(back, payload);
+        assert!(back.deliver_as_task());
+    }
+
+    #[test]
+    fn minimal_payload_deserializes_without_optionals() {
+        let json = serde_json::json!({
+            "bwb_id": "BWBR0002399",
+            "traject_id": Uuid::nil(),
+            "traject_ref": "voorbeeld-abcd1234",
+        });
+        let payload: TrajectHarvestPayload = serde_json::from_value(json).unwrap();
+        assert!(payload.law_name.is_none());
+        assert!(payload.provider.is_none());
+        assert!(payload.requested_by.is_none());
+        assert!(!payload.deliver_as_task());
+        assert_eq!(payload.display_name(), "BWBR0002399");
+    }
+
+    #[test]
+    fn display_name_prefers_law_name() {
+        let payload = TrajectHarvestPayload {
+            bwb_id: "BWBR0002399".to_string(),
+            traject_id: Uuid::nil(),
+            traject_ref: "voorbeeld-abcd1234".to_string(),
+            law_name: Some("Voorbeeldwet".to_string()),
+            provider: None,
+            requested_by: None,
+            deliver: None,
+        };
+        assert_eq!(payload.display_name(), "Voorbeeldwet");
+    }
+}

--- a/packages/pipeline/src/worker.rs
+++ b/packages/pipeline/src/worker.rs
@@ -1773,8 +1773,8 @@ async fn process_next_traject_harvest_job(
                 PipelineError::Harvester(
                     regelrecht_harvester::HarvesterError::NoConsolidatedText { .. }
                 )
-            ) || msg.contains("valideert niet tegen het schema")
-                || msg.contains("er loopt al een verrijking");
+            ) || msg.contains(traject_harvest::SCHEMA_MISMATCH_MARKER)
+                || msg.contains(law_convert::ENRICH_IN_PROGRESS_MARKER);
 
             let fail_and_notify: Result<()> = async {
                 let mut tx = pool.begin().await?;

--- a/packages/pipeline/src/worker.rs
+++ b/packages/pipeline/src/worker.rs
@@ -19,6 +19,7 @@ use crate::job_queue::{self, CreateJobRequest};
 use crate::law_convert::{self, LawConvertPayload, LlmLawStructurer};
 use crate::law_status;
 use crate::models::{JobType, LawStatusValue, Priority};
+use crate::traject_harvest::{self, TrajectHarvestPayload};
 
 /// Local night window (Europe/Amsterdam) as a half-open hour-of-day range
 /// `[start, end)`. Hours in this range get the multiplied enrich cap.
@@ -255,6 +256,35 @@ pub async fn run_harvest_worker(config: WorkerConfig) -> Result<()> {
             }
             _ = tokio::time::sleep(current_interval) => {
                 // Ready to process next job
+            }
+        }
+
+        // Traject-scoped harvests (taak-flow) gaan vóór de corpus-brede
+        // queue: een mens wacht erop (prio 80-aanvraag uit de editor), en de
+        // corpus-brede harvest kan lange bulkruns draaien. Spiegel van hoe de
+        // enrich-worker document-/law-convert-jobs vóór de enrich-cap draait.
+        match process_next_traject_harvest_job(&pool, &config, &http_client).await {
+            Ok(JobOutcome::Processed) => {
+                consecutive_resource_failures = 0;
+                current_interval = config.poll_interval;
+                continue;
+            }
+            Ok(JobOutcome::ResourceExhausted) => {
+                handle_resource_exhaustion(
+                    &mut consecutive_resource_failures,
+                    config.max_consecutive_resource_failures,
+                    "traject-harvest",
+                );
+                current_interval = config.poll_interval;
+                continue;
+            }
+            Ok(JobOutcome::Idle) => { /* geen traject-harvest — door naar de gewone queue */ }
+            Err(e) => {
+                tracing::error!(error = %e, "error processing traject-harvest job");
+                current_interval = (current_interval * 2)
+                    .max(config.poll_interval)
+                    .min(config.max_poll_interval);
+                continue;
             }
         }
 
@@ -1650,6 +1680,147 @@ async fn process_next_law_convert_job(
                 }
             }
             fail_result?;
+
+            Ok(outcome_for_error(&msg))
+        }
+    }
+}
+
+/// Verwerk één `traject_harvest`-job: BWB-download → gevalideerde
+/// basis-wet-YAML → geketende taak-flow-enrich-job (het kettingstuk is
+/// [`law_convert::chain_enrich_and_complete`] — zelfde keten als law-convert).
+/// Draait op de harvest-worker (die heeft de BWB-machinerie); de geketende
+/// enrich draait daarna op de enrich-worker.
+async fn process_next_traject_harvest_job(
+    pool: &PgPool,
+    config: &WorkerConfig,
+    http_client: &Client,
+) -> Result<JobOutcome> {
+    let job = match job_queue::claim_job(pool, Some(JobType::TrajectHarvest)).await? {
+        Some(job) => job,
+        None => return Ok(JobOutcome::Idle),
+    };
+    tracing::info!(job_id = %job.id, law_id = %job.law_id, attempt = job.attempts, "processing traject-harvest job");
+
+    // Malformed payload is deterministisch: terminaal falen. Zonder payload
+    // is er ook geen aanvrager om een taak voor te maken.
+    let payload: TrajectHarvestPayload = match job
+        .payload
+        .as_ref()
+        .ok_or_else(|| PipelineError::Worker("traject_harvest job has no payload".to_string()))
+        .and_then(|p| {
+            serde_json::from_value(p.clone())
+                .map_err(|e| PipelineError::Worker(format!("payload deserialization failed: {e}")))
+        }) {
+        Ok(payload) => payload,
+        Err(e) => {
+            let msg = format!("invalid traject_harvest payload: {e}");
+            tracing::error!(job_id = %job.id, error = %msg);
+            job_queue::fail_job_terminal(pool, job.id, Some(serde_json::json!({ "error": msg })))
+                .await?;
+            return Ok(JobOutcome::Processed);
+        }
+    };
+
+    // Traject-harvest kent alléén de taak-flow: zonder `requested_by` is er
+    // geen assignee voor de uiteindelijke review-taak, en zonder
+    // `deliver: task` geen aflever-pad (er bestaat geen direct-push-variant).
+    if !payload.deliver_as_task() || payload.requested_by.is_none() {
+        let msg = "traject_harvest vereist deliver=task met requested_by".to_string();
+        tracing::error!(job_id = %job.id, error = %msg);
+        job_queue::fail_job_terminal(pool, job.id, Some(serde_json::json!({ "error": msg })))
+            .await?;
+        return Ok(JobOutcome::Processed);
+    }
+
+    // Zelfde buitenboord-timeout als de corpus-brede harvest: de BWB-fetches
+    // hebben geen eigen deadline en dit is een sequentiële workerloop.
+    let run_result = match tokio::time::timeout(
+        config.job_timeout,
+        traject_harvest::execute_traject_harvest(&payload, http_client),
+    )
+    .await
+    {
+        Err(_elapsed) => Err(PipelineError::Worker(format!(
+            "traject-harvest timed out after {}s",
+            config.job_timeout.as_secs()
+        ))),
+        Ok(Ok(law)) => {
+            let ctx = law_convert::EnrichChainContext {
+                provider: payload.provider.clone(),
+                requested_by: payload.requested_by,
+                traject_id: payload.traject_id,
+                traject_ref: payload.traject_ref.clone(),
+            };
+            law_convert::chain_enrich_and_complete(pool, &job, &ctx, &law).await
+        }
+        Ok(Err(e)) => Err(e),
+    };
+
+    match run_result {
+        Ok(()) => Ok(JobOutcome::Processed),
+        Err(e) => {
+            let msg = e.to_string();
+            tracing::error!(job_id = %job.id, error = %msg, "traject-harvest job failed");
+            // Deterministische fouten (geen geconsolideerde tekst; YAML die
+            // niet valideert; een al-lopende enrich op dezelfde slug) falen
+            // terminaal — een retry reproduceert exact hetzelfde. Transiënte
+            // fouten (BWB-outage, netwerk, timeout) doorlopen fail_job met
+            // backoff tot max_attempts; pas bij definitief falen krijgt de
+            // aanvrager de job_failed-taak.
+            let deterministic = matches!(
+                e,
+                PipelineError::Harvester(
+                    regelrecht_harvester::HarvesterError::NoConsolidatedText { .. }
+                )
+            ) || msg.contains("valideert niet tegen het schema")
+                || msg.contains("er loopt al een verrijking");
+
+            let fail_and_notify: Result<()> = async {
+                let mut tx = pool.begin().await?;
+                let terminal = if deterministic {
+                    job_queue::fail_job_terminal(
+                        &mut *tx,
+                        job.id,
+                        Some(serde_json::json!({ "error": msg.clone() })),
+                    )
+                    .await?;
+                    true
+                } else {
+                    let failed = job_queue::fail_job(
+                        &mut *tx,
+                        job.id,
+                        Some(serde_json::json!({ "error": msg.clone() })),
+                    )
+                    .await?;
+                    failed.status == crate::models::JobStatus::Failed
+                };
+                if terminal {
+                    if let Some(account_id) = payload.requested_by {
+                        crate::tasks::create_task(
+                            &mut *tx,
+                            crate::tasks::NewTask {
+                                task_type: crate::tasks::TaskType::JobFailed,
+                                assignee_account_id: Some(account_id),
+                                traject_id: Some(payload.traject_id),
+                                job_id: Some(job.id),
+                                title: format!("Wet ophalen mislukt: {}", payload.display_name()),
+                                payload: Some(serde_json::json!({
+                                    "traject_ref": payload.traject_ref,
+                                    "bwb_id": payload.bwb_id,
+                                    "law_name": payload.law_name,
+                                    "error": msg.clone(),
+                                })),
+                            },
+                        )
+                        .await?;
+                    }
+                }
+                tx.commit().await?;
+                Ok(())
+            }
+            .await;
+            fail_and_notify?;
 
             Ok(outcome_for_error(&msg))
         }


### PR DESCRIPTION
## Wat

Vanuit een traject een wet toevoegen in één flow:

1. **Zoeken** — de "+" onder de wettenlijst wordt een menu; "Zoeken in het centrale corpus…" opent een popover (`AddLawPopover`) dat de bestaande traject-scoped corpus-zoek-API hergebruikt (dezelfde die de bibliotheekzoeker voedt — geen tweede zoekpad). Een BWB-id mag ook, direct getypt of via de wetten.overheid.nl-fallback.
2. **Promoten** — `POST /api/trajects/{ref}/corpus/laws/{law_id}/promote` kopieert de volledige wet-map uit de centrale-corpus-seed naar de traject-repo: alle versie-YAML's inclusief `machine_readable`, plus de `scenarios/*.feature`-bestanden, in één commit via het bestaande traject-schrijfpad (zelfde autorisatie/commit-gedrag als `save_law`, inclusief user-token-override). Staat de wet al in de traject-repo (source_priority 0), dan is de knop uitgeschakeld en weigert de backend met 409 — geen dubbele bestanden.
3. **Harvest-fallback** — `POST /api/trajects/{ref}/corpus/harvest` start met een BWB-id een traject-scoped harvest via het taken-mechanisme: nieuw jobtype `traject_harvest` (migratie 0031) op de harvest-worker, dat de geharveste basis-wet valideert en **expliciet een taak-flow-enrich ketent** via het uit `law_convert` gedeelde `chain_enrich_and_complete` (een directe harvest chain't immers geen enrich). De aanvraag is direct zichtbaar in het takenpaneel ("Wet ophalen loopt – BWBR…"); het resultaat komt terug als `law_create`-review-taak en goedkeuren landt via het gewone law-create-pad (`create_traject_law`).

## Waarom de traject-seed en niet de globale corpus-state

De promote leest uit het traject-gefedereerde corpus (de `minbzk-central`-seed): die index dekt de volledige centrale corpus (metadata-only, lazy bodies), terwijl de globale state in productie alleen favorieten materialiseert (`load_favorites_async`). Dit is ook exact de write-routing die `save_law` voor gefedereerde wetten gebruikt, dus paden blijven per constructie consistent.

## Guards

- Membership + `editor-writer`-rol op beide endpoints (bestaande route-middleware).
- Promote: 409 op index-treffer in de eigen repo én belt-and-braces per doelbestand; 404 wanneer de wet niet in de seed staat.
- Harvest: BWB-id-vormvalidatie (400), dedup per (traject, wet) onder advisory lock (409), bestaande per-account-taakcap telt `traject_harvest` nu mee.
- Reaper-nazorg: een gereapte `traject_harvest`-job levert alsnog een `job_failed`-taak.

## Tests

- `packages/editor-api/tests/promote_law_test.rs` — kopieert versies + scenario's byte-voor-byte, 409 bij herhaalde promote, 404 bij onbekende wet (testcontainers).
- `packages/editor-api/tests/traject_harvest_request_test.rs` — 202 + jobinhoud (deliver=task, prio 80), dedup-409, 400 op ongeldig id.
- Unit: BWB-id-normalisatie, `TrajectHarvestPayload`-serde, taakcap/reaper-titels.
- Vitest: `AddLawPopover.test.js` (zoekpad, sortering, al-in-traject, promote/409, BWB-fallback, harvest/409, direct BWB-id) en `TasksPane.test.js` (nieuw running-label). Volledige suite: 57 files / 579 tests groen.
- Geen e2e toegevoegd: de flow vereist een draaiende editor-api + Postgres + harvest-worker; de Playwright-harness draait alleen Vite met route-interceptie, waarmee een e2e de component-tests zou dupliceren zonder extra dekking. Zeg het gerust als je hem toch wilt.

`just check` is groen (de drie `untranslatables`-lib-tests vereisen lokaal `TESTCONTAINERS_HOST_OVERRIDE`, zoals gedocumenteerd in `test_utils.rs`); ook `editor-api-test` en `pipeline-integration-test` draaien groen.

## Custom CSS (criterium 7)

**Geen.** `AddLawPopover` is volledig opgebouwd uit `nldd-*`-componenten (zelfde popover/listbox-patroon als `SearchPopover`) en heeft geen `<style>`-blok; ook in `LibraryView` is geen styling toegevoegd.

## Buiten scope (conform ticket)

Geen sync/versie-drift van gepromote wetten, geen recursieve harvest van gedelegeerde regelingen, geen bulk-promote, geen harvester-admin-wijzigingen.
