### PR TITLE
fix(editor): traject-eigen indexscan resolvet token strikt en meldt scan-falen per source

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2243,9 +2243,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/admin/src/corpus_handlers.rs
+++ b/packages/admin/src/corpus_handlers.rs
@@ -21,9 +21,13 @@ pub async fn list_sources(
     State(state): State<AppState>,
 ) -> Result<Json<Vec<SourceSummary>>, ApiError> {
     let corpus = state.corpus.read().await;
+    // The admin corpus state doesn't track per-source scan health (its
+    // sources are operator-managed manifest entries); pass no failures so
+    // `index_error` serialises as null on every source.
     Ok(Json(build_source_summaries(
         &corpus.registry,
         &corpus.source_map,
+        &std::collections::HashMap::new(),
     )))
 }
 

--- a/packages/corpus/src/auth.rs
+++ b/packages/corpus/src/auth.rs
@@ -68,6 +68,28 @@ pub fn resolve_token_for_source(
     resolve_token(key, auth_file)
 }
 
+/// Resolve the token for a [`Source`](crate::models::Source), honouring its
+/// [`strict_auth`](crate::models::Source::strict_auth) flag: strict sources
+/// (user-supplied repo coordinates, e.g. a traject's writable-own repo) never
+/// fall back to the legacy shared `CORPUS_GIT_TOKEN`; regular manifest
+/// sources keep the legacy fallback for single-PAT deployments.
+///
+/// This is the one resolver every *source-driven* lookup should go through —
+/// scans, fetches and backend construction resolving through different rules
+/// is exactly how a promote-write can succeed while the subsequent index scan
+/// of the same repo silently fails.
+pub fn resolve_source_token(
+    source: &crate::models::Source,
+    auth_file: Option<&Path>,
+) -> Result<Option<String>> {
+    let key = source.auth_ref.as_deref().unwrap_or(&source.id);
+    if source.strict_auth {
+        resolve_token_strict(key, auth_file)
+    } else {
+        resolve_token(key, auth_file)
+    }
+}
+
 /// Like [`resolve_token_for_source`] but only consults the per-source
 /// env var and the auth file. Returns `None` when neither yields a
 /// token — the legacy `CORPUS_GIT_TOKEN` fallback is intentionally
@@ -303,5 +325,45 @@ sources:
         let result = resolve_token_strict("strict-per-source-ok", None).unwrap();
         unsafe { std::env::remove_var(key) };
         assert_eq!(result, Some("per-source-value".to_string()));
+    }
+
+    fn local_source(auth_ref: &str, strict_auth: bool) -> crate::models::Source {
+        crate::models::Source {
+            id: "src".to_string(),
+            name: "Src".to_string(),
+            source_type: crate::models::SourceType::Local {
+                local: crate::models::LocalSource {
+                    path: std::path::PathBuf::from("unused"),
+                },
+            },
+            scopes: vec![],
+            priority: 0,
+            auth_ref: Some(auth_ref.to_string()),
+            strict_auth,
+        }
+    }
+
+    #[test]
+    fn resolve_source_token_strict_source_skips_legacy_token() {
+        // A `strict_auth` source (traject writable-own, user-supplied repo
+        // coords) must resolve like `resolve_token_strict` on EVERY path
+        // that goes through the source object — most importantly the index
+        // scan, which used to fall back to `CORPUS_GIT_TOKEN` while the
+        // push path resolved strictly.
+        let _g = ENV_LOCK.lock().unwrap();
+        let prev = std::env::var("CORPUS_GIT_TOKEN").ok();
+        unsafe { std::env::set_var("CORPUS_GIT_TOKEN", "central-secret") };
+        let strict = resolve_source_token(&local_source("user-picked-ref", true), None).unwrap();
+        let legacy = resolve_source_token(&local_source("user-picked-ref", false), None).unwrap();
+        match prev {
+            Some(v) => unsafe { std::env::set_var("CORPUS_GIT_TOKEN", v) },
+            None => unsafe { std::env::remove_var("CORPUS_GIT_TOKEN") },
+        }
+        assert_eq!(strict, None, "strict source must not leak the legacy token");
+        assert_eq!(
+            legacy,
+            Some("central-secret".to_string()),
+            "manifest sources keep the legacy single-PAT fallback"
+        );
     }
 }

--- a/packages/corpus/src/dto.rs
+++ b/packages/corpus/src/dto.rs
@@ -56,6 +56,12 @@ pub struct SourceSummary {
     pub source_type: String,
     pub priority: u32,
     pub law_count: usize,
+    /// Why the last index scan of this source failed, when it did. `None`
+    /// means the scan succeeded — so a `law_count` of 0 with `index_error:
+    /// null` is a genuinely empty source, while `law_count: 0` plus an error
+    /// here means the source couldn't be read at all (missing/invalid token,
+    /// unreachable repo) and its laws are silently absent from resolution.
+    pub index_error: Option<String>,
 }
 
 /// Stable string tag for a [`SourceType`] used in JSON responses.
@@ -67,9 +73,14 @@ pub fn source_type_tag(source_type: &SourceType) -> &'static str {
 }
 
 /// Build the [`SourceSummary`] list returned by `GET /api/sources`.
+///
+/// `index_failures` maps source id → the error of the last failed index scan
+/// (empty when every source enumerated fine, or when the caller doesn't
+/// track scan health).
 pub fn build_source_summaries(
     registry: &CorpusRegistry,
     source_map: &SourceMap,
+    index_failures: &std::collections::HashMap<String, String>,
 ) -> Vec<SourceSummary> {
     registry
         .sources()
@@ -85,7 +96,54 @@ pub fn build_source_summaries(
                 source_type: source_type_tag(&source.source_type).to_string(),
                 priority: source.priority,
                 law_count,
+                index_error: index_failures.get(&source.id).cloned(),
             }
         })
         .collect()
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::models::{LocalSource, Source};
+
+    fn source(id: &str, priority: u32) -> Source {
+        Source {
+            id: id.to_string(),
+            name: id.to_string(),
+            source_type: SourceType::Local {
+                local: LocalSource {
+                    path: std::path::PathBuf::from("unused"),
+                },
+            },
+            scopes: vec![],
+            priority,
+            auth_ref: None,
+            strict_auth: false,
+        }
+    }
+
+    #[test]
+    fn summaries_carry_the_index_error_of_a_failed_source() {
+        // A failed scan and a genuinely empty source both show law_count 0;
+        // `index_error` is what tells them apart on `GET /api/sources`.
+        let registry =
+            CorpusRegistry::from_sources(vec![source("broken", 0), source("healthy", 2)]);
+        let failures = std::collections::HashMap::from([(
+            "broken".to_string(),
+            "GitHub Trees API returned 404".to_string(),
+        )]);
+
+        let summaries = build_source_summaries(&registry, &SourceMap::new(), &failures);
+
+        let broken = summaries.iter().find(|s| s.id == "broken").unwrap();
+        assert_eq!(broken.law_count, 0);
+        assert_eq!(
+            broken.index_error.as_deref(),
+            Some("GitHub Trees API returned 404")
+        );
+        let healthy = summaries.iter().find(|s| s.id == "healthy").unwrap();
+        assert_eq!(healthy.index_error, None);
+    }
 }

--- a/packages/corpus/src/lib.rs
+++ b/packages/corpus/src/lib.rs
@@ -33,7 +33,7 @@ pub use github_api_backend::GitHubApiBackend;
 pub use models::{RegistryManifest, Source, SourceType};
 #[cfg(feature = "github")]
 pub use pr_client::PullRequestClient;
-pub use registry::CorpusRegistry;
+pub use registry::{CorpusRegistry, SourceIndexFailure};
 #[cfg(feature = "github")]
 pub use repo_access::{validate_repo_access, RepoAccessError, RepoInfo};
 pub use source_map::SourceMap;

--- a/packages/corpus/src/models.rs
+++ b/packages/corpus/src/models.rs
@@ -21,6 +21,15 @@ pub struct Source {
     /// Reference to auth configuration. When absent, source is public.
     #[serde(default)]
     pub auth_ref: Option<String>,
+    /// When set, token resolution for this source never falls back to the
+    /// legacy shared `CORPUS_GIT_TOKEN` (see
+    /// [`crate::auth::resolve_token_strict`]). Set for sources whose
+    /// `auth_ref` derives from user input — a traject's writable-own repo —
+    /// where the legacy fallback would ship the central token to a
+    /// user-chosen repo on every read/scan. Not part of the manifest
+    /// format; operator-managed manifest sources default to `false`.
+    #[serde(default)]
+    pub strict_auth: bool,
 }
 
 /// Source type discriminator with configuration.
@@ -213,6 +222,7 @@ sources:
                 scopes: vec![],
                 priority: 5,
                 auth_ref: None,
+                strict_auth: false,
             }],
         };
 

--- a/packages/corpus/src/registry.rs
+++ b/packages/corpus/src/registry.rs
@@ -4,6 +4,17 @@ use crate::error::{CorpusError, Result};
 use crate::models::{RegistryManifest, Source, SourceType};
 use crate::source_map::SourceMap;
 
+/// A source that failed to enumerate during
+/// [`CorpusRegistry::index_all_sources_async`], with the error it failed on.
+/// Carrying the message (not just the id) lets callers surface *why* the
+/// source's laws are missing — a `law_count: 0` with no reason is
+/// indistinguishable from a genuinely empty repo.
+#[derive(Debug, Clone)]
+pub struct SourceIndexFailure {
+    pub source_id: String,
+    pub error: String,
+}
+
 /// Corpus registry that manages source definitions.
 ///
 /// Loads sources from `corpus-registry.yaml` and optionally merges
@@ -171,11 +182,7 @@ impl CorpusRegistry {
 
         for source in &self.sources {
             if let SourceType::GitHub { github } = &source.source_type {
-                let token = crate::auth::resolve_token_for_source(
-                    &source.id,
-                    source.auth_ref.as_deref(),
-                    auth_file,
-                )?;
+                let token = crate::auth::resolve_source_token(source, auth_file)?;
                 match fetcher
                     .fetch_source_filtered(github, token.as_deref(), &missing)
                     .await?
@@ -224,16 +231,18 @@ impl CorpusRegistry {
     /// rate limit. The library/search only needs the index; content is only
     /// needed when a specific law is opened.
     ///
-    /// Returns the index plus the ids of any sources that failed to enumerate
-    /// (non-fatal, mirroring [`load_all_sources_async`]).
+    /// Returns the index plus a [`SourceIndexFailure`] per source that failed
+    /// to enumerate (non-fatal, mirroring [`load_all_sources_async`]) — the
+    /// error string travels with the id so callers can surface *why* a
+    /// source's laws are missing instead of only showing a zero law count.
     #[cfg(feature = "github")]
     pub async fn index_all_sources_async(
         &self,
         auth_file: Option<&Path>,
-    ) -> Result<(SourceMap, Vec<String>)> {
+    ) -> Result<(SourceMap, Vec<SourceIndexFailure>)> {
         let mut map = SourceMap::new();
         let mut fetcher = crate::github::GitHubFetcher::new()?;
-        let mut failed: Vec<String> = Vec::new();
+        let mut failed: Vec<SourceIndexFailure> = Vec::new();
 
         for source in &self.sources {
             if let Err(e) = Self::index_one_source(&mut map, &mut fetcher, source, auth_file).await
@@ -243,13 +252,16 @@ impl CorpusRegistry {
                     error = %e,
                     "failed to index corpus source, skipping"
                 );
-                failed.push(source.id.clone());
+                failed.push(SourceIndexFailure {
+                    source_id: source.id.clone(),
+                    error: e.to_string(),
+                });
             }
         }
 
         if !failed.is_empty() {
             tracing::warn!(
-                failed = ?failed,
+                failed = ?failed.iter().map(|f| f.source_id.as_str()).collect::<Vec<_>>(),
                 indexed = map.len(),
                 "some corpus sources failed to index"
             );
@@ -282,11 +294,13 @@ impl CorpusRegistry {
                 map.load_source(source)?;
             }
             SourceType::GitHub { github } => {
-                let token = crate::auth::resolve_token_for_source(
-                    &source.id,
-                    source.auth_ref.as_deref(),
-                    auth_file,
-                )?;
+                // `resolve_source_token` honours `strict_auth`: the scan of a
+                // traject's writable-own repo resolves with exactly the same
+                // rules as its push path, so a repo the server can push to is
+                // also a repo the server can index (and vice versa — no more
+                // "promote succeeded but the index reads with a different
+                // token and comes back empty").
+                let token = crate::auth::resolve_source_token(source, auth_file)?;
                 for (law_id, path, sha) in fetcher
                     .list_source_law_paths(github, token.as_deref())
                     .await?

--- a/packages/corpus/src/source_map.rs
+++ b/packages/corpus/src/source_map.rs
@@ -889,6 +889,7 @@ mod tests {
             scopes: vec![],
             priority,
             auth_ref: None,
+            strict_auth: false,
         }
     }
 

--- a/packages/corpus/src/validation.rs
+++ b/packages/corpus/src/validation.rs
@@ -158,6 +158,7 @@ mod tests {
             scopes,
             priority,
             auth_ref: None,
+            strict_auth: false,
         }
     }
 

--- a/packages/corpus/tests/federation.rs
+++ b/packages/corpus/tests/federation.rs
@@ -27,6 +27,7 @@ fn make_local_source(id: &str, name: &str, path: PathBuf, priority: u32) -> Sour
         scopes: vec![],
         priority,
         auth_ref: None,
+        strict_auth: false,
     }
 }
 

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -251,7 +251,7 @@ pub async fn list_traject_sources(
 
 fn list_sources_in_scope(scope: &ReadScope) -> Vec<SourceSummary> {
     let corpus = scope.corpus();
-    build_source_summaries(&corpus.registry, &corpus.source_map)
+    build_source_summaries(&corpus.registry, &corpus.source_map, &corpus.index_failures)
 }
 
 /// GET /api/corpus/laws — list loaded laws with source metadata (global view).

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -778,6 +778,11 @@ async fn init_corpus(favorites: &HashSet<String>) -> CorpusState {
         source_map,
         backends,
         auth_file: auth_file.map(|p| p.to_path_buf()),
+        // The global startup path loads favorites with its own all-or-
+        // nothing fallback above; per-source scan health is only tracked
+        // on the traject path (`build_traject_corpus`), where a silently
+        // missing source changes which corpus a law resolves from.
+        index_failures: HashMap::new(),
     }
 }
 

--- a/packages/editor-api/src/state.rs
+++ b/packages/editor-api/src/state.rs
@@ -88,6 +88,13 @@ pub struct CorpusState {
     pub backends: HashMap<String, BackendEntry>,
     /// Path to corpus-auth.yaml for GitHub authentication during reload.
     pub auth_file: Option<PathBuf>,
+    /// Source id → error of the last failed index scan for that source.
+    /// Sources absent from this map enumerated fine. Surfaced on
+    /// `GET /api/sources` (and the traject variant) as `index_error`, so a
+    /// source whose scan failed is distinguishable from a genuinely empty
+    /// one — a failing traject writable-own source otherwise reads as
+    /// `law_count: 0` while its laws silently fall back to the seed corpus.
+    pub index_failures: HashMap<String, String>,
 }
 
 impl CorpusState {
@@ -98,6 +105,7 @@ impl CorpusState {
             source_map: SourceMap::new(),
             backends: HashMap::new(),
             auth_file: None,
+            index_failures: HashMap::new(),
         }
     }
 }

--- a/packages/editor-api/src/traject_corpus.rs
+++ b/packages/editor-api/src/traject_corpus.rs
@@ -1434,24 +1434,18 @@ async fn build_traject_corpus(
     // Build a backend per source, scoped to a traject-specific clone path.
     let mut backends: HashMap<String, BackendEntry> = HashMap::new();
     for (row, source) in rows.iter().zip(sources.iter()) {
-        // For the writable-own source we resolve strictly (no legacy
-        // `CORPUS_GIT_TOKEN` fallback). The `auth_ref` on this row was
-        // derived from the create-request's repo coords, so a missing
-        // per-repo token MUST fail closed — not transparently ship the
-        // central token to a user-chosen GitHub repo on the next push.
+        // Token resolution honours `Source::strict_auth` (set by
+        // `to_source` for the writable-own row): the writable-own resolves
+        // strictly (no legacy `CORPUS_GIT_TOKEN` fallback), because its
+        // `auth_ref` was derived from the create-request's repo coords and a
+        // missing per-repo token MUST fail closed — not transparently ship
+        // the central token to a user-chosen GitHub repo on the next push.
         // Seeded (non-writable) sources keep the legacy fallback so
         // pre-existing deployments that rely on a single global PAT for
-        // read-only mirrors keep working.
-        let token_result = if row.is_writable_own {
-            let key = source.auth_ref.as_deref().unwrap_or(&source.id);
-            regelrecht_corpus::auth::resolve_token_strict(key, auth_file)
-        } else {
-            regelrecht_corpus::auth::resolve_token_for_source(
-                &source.id,
-                source.auth_ref.as_deref(),
-                auth_file,
-            )
-        };
+        // read-only mirrors keep working. The index scan below
+        // (`index_all_sources_async`) goes through the same resolver, so
+        // scan and push can no longer disagree about the token.
+        let token_result = regelrecht_corpus::auth::resolve_source_token(source, auth_file);
         let token = token_result.unwrap_or_else(|e| {
             tracing::warn!(
                 traject = %traject_id,
@@ -1462,10 +1456,12 @@ async fn build_traject_corpus(
             None
         });
         // Diagnostic: token=None on the writable-own source means git
-        // push will hit "could not read Username" later. Surface it now
-        // with both the source_id and the resolved auth_ref so an
-        // operator can see whether the row carries the expected ref and
-        // whether the env var matches.
+        // push will hit "could not read Username" later, and — for a
+        // private repo — the index scan and every lazy body read will 404
+        // just as hard, silently resolving the traject's own laws from the
+        // seed corpus instead. Surface it now with both the source_id and
+        // the resolved auth_ref so an operator can see whether the row
+        // carries the expected ref and whether the env var matches.
         if token.is_none() && source.id == writable_own_source_id {
             let expected_env = regelrecht_corpus::auth::token_env_name(
                 source.auth_ref.as_deref().unwrap_or(&source.id),
@@ -1476,7 +1472,8 @@ async fn build_traject_corpus(
                 auth_ref = ?source.auth_ref,
                 auth_file = ?auth_file,
                 expected_env = %expected_env,
-                "traject writable-own source resolved NO token — push will fail"
+                "traject writable-own source resolved NO token — pushes will fail, and \
+                 on a private repo reads/index scans fail too (laws fall back to seed sources)"
             );
         }
 
@@ -1570,18 +1567,25 @@ async fn build_traject_corpus(
     // failing entirely on what is usually a transient GitHub hiccup. The hard
     // failure path is the writable-own *backend* init above, which returns
     // `Err` so a broken write target never opens silently.
-    let source_map =
+    let (source_map, index_failures) =
         match timing::measure("index", registry.index_all_sources_async(auth_file)).await {
             Ok((map, failed)) => {
-                if failed.iter().any(|id| id == &writable_own_source_id) {
+                if let Some(f) = failed
+                    .iter()
+                    .find(|f| f.source_id == writable_own_source_id)
+                {
                     tracing::error!(
                         traject = %traject_id,
                         source_id = %writable_own_source_id,
-                        "traject writable-own source failed to load — the traject's own laws \
-                         will be missing from the bibliotheek until the corpus is rebuilt"
+                        error = %f.error,
+                        "traject writable-own source failed to index — the traject's own laws \
+                         are missing from the bibliotheek and silently resolve from the seed \
+                         sources until the scan succeeds"
                     );
                 }
-                map
+                let failures: HashMap<String, String> =
+                    failed.into_iter().map(|f| (f.source_id, f.error)).collect();
+                (map, failures)
             }
             Err(e) => {
                 tracing::warn!(
@@ -1589,9 +1593,21 @@ async fn build_traject_corpus(
                     error = %e,
                     "traject corpus load failed, falling back to local-only"
                 );
-                registry
-                    .load_local_sources()
-                    .unwrap_or_else(|_| SourceMap::new())
+                // Local-only fallback: every non-local source is absent from
+                // the map, so record the enumeration error against each of
+                // them — `/sources` then shows why their law_count is 0.
+                let failures: HashMap<String, String> = registry
+                    .sources()
+                    .iter()
+                    .filter(|s| matches!(s.source_type, SourceType::GitHub { .. }))
+                    .map(|s| (s.id.clone(), e.to_string()))
+                    .collect();
+                (
+                    registry
+                        .load_local_sources()
+                        .unwrap_or_else(|_| SourceMap::new()),
+                    failures,
+                )
             }
         };
 
@@ -1601,6 +1617,7 @@ async fn build_traject_corpus(
             source_map,
             backends,
             auth_file: auth_file.map(|p| p.to_path_buf()),
+            index_failures,
         },
         write_target_for_source,
         writable_own_source_id,
@@ -1660,9 +1677,13 @@ async fn refresh_traject_corpus(
         .index_all_sources_async(auth_file.as_deref())
         .await?;
     if !failed.is_empty() {
+        let details: Vec<String> = failed
+            .iter()
+            .map(|f| format!("{}: {}", f.source_id, f.error))
+            .collect();
         return Err(TrajectCorpusError::Corpus(
             regelrecht_corpus::error::CorpusError::Config(format!(
-                "index refresh for traject {traject_id} failed to enumerate sources: {failed:?}"
+                "index refresh for traject {traject_id} failed to enumerate sources: {details:?}"
             )),
         ));
     }
@@ -1689,6 +1710,10 @@ async fn next_snapshot(old: &Arc<TrajectCorpus>, source_map: SourceMap) -> Arc<T
             source_map,
             backends: old.corpus.backends.clone(),
             auth_file: old.corpus.auth_file.clone(),
+            // A refresh only lands when every source enumerated (see
+            // `refresh_traject_corpus`), so the refreshed snapshot has no
+            // scan failures to report.
+            index_failures: HashMap::new(),
         },
         write_target_for_source: old.write_target_for_source.clone(),
         writable_own_source_id: old.writable_own_source_id.clone(),
@@ -1986,6 +2011,7 @@ mod tests {
                 source_map,
                 backends,
                 auth_file: None,
+                index_failures: HashMap::new(),
             },
             write_target_for_source: HashMap::new(),
             writable_own_source_id: "own".to_string(),
@@ -2307,6 +2333,7 @@ mod tests {
             scopes: vec![],
             priority: 0,
             auth_ref: None,
+            strict_auth: false,
         };
         let registry = CorpusRegistry::from_sources(vec![source.clone()]);
         let source_map = registry.load_local_sources().unwrap();
@@ -2326,6 +2353,7 @@ mod tests {
                 source_map,
                 backends,
                 auth_file: None,
+                index_failures: HashMap::new(),
             },
             write_target_for_source: HashMap::new(),
             writable_own_source_id: "own".to_string(),
@@ -3074,6 +3102,12 @@ impl TrajectSourceRow {
             scopes,
             priority: self.priority.max(0) as u32,
             auth_ref: self.auth_ref.clone(),
+            // The writable-own's `auth_ref` derives from user-supplied repo
+            // coords (create-traject request), so EVERY token lookup for it
+            // — backend construction here, but also the index scan inside
+            // `CorpusRegistry::index_all_sources_async` — must resolve
+            // strictly, without the legacy `CORPUS_GIT_TOKEN` fallback.
+            strict_auth: self.is_writable_own,
         }
     }
 }

--- a/packages/editor-api/tests/list_scenarios_test.rs
+++ b/packages/editor-api/tests/list_scenarios_test.rs
@@ -225,6 +225,7 @@ async fn list_scenarios_global_returns_target_law_ids() {
             source_map,
             backends,
             auth_file: None,
+            index_failures: std::collections::HashMap::new(),
         })),
         oidc_client: None,
         end_session_url: None,

--- a/packages/editor-api/tests/traject_own_index_test.rs
+++ b/packages/editor-api/tests/traject_own_index_test.rs
@@ -1,0 +1,437 @@
+//! Reproductie + regressietests voor "traject-eigen corpus indexeert 0
+//! wetten na promote" (tickets #6, vervolg op de promote-flow van #952).
+//!
+//! Twee scenario's rond dezelfde deployed-achtige federatie-config als
+//! `promote_user_token_write_test.rs` — GitHub-backed writable-own zonder
+//! server-side `CORPUS_AUTH_*`-token, lokale seed als centraal corpus,
+//! schrijven via het gekoppelde user-token:
+//!
+//! 1. **Onleesbare traject-repo (het prod-symptoom).** De promote slaagt
+//!    (write met user-token), maar de server-side indexscan van de
+//!    writable-own faalt — zoals op een privé-repo zonder geconfigureerd
+//!    token: unauthenticated Trees-API geeft 404. De wet resolvet dan stil
+//!    uit de seed (priority 2) in plaats van de traject-repo (priority 0):
+//!    exact het waargenomen gedrag. De test pint dat `GET .../sources` dit
+//!    niet langer stil laat: de writable-own toont `law_count: 0` mét een
+//!    `index_error`, in plaats van alleen een nietszeggende 0.
+//! 2. **Happy path van #952.** Zodra de scan de traject-repo wél kan lezen
+//!    (Trees-API geeft de gepromote bestanden terug), staat de wet in de
+//!    traject-index op `source_priority: 0` en is de source gezond
+//!    (`index_error: null`, `law_count: 1`).
+//!
+//! GitHub wordt gespeeld door wiremock via de proces-brede
+//! `GITHUB_API_BASE`-seam — daarom staan beide scenario's in ÉÉN test
+//! (zelfde afweging als `promote_user_token_write_test.rs`).
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::Arc;
+
+use axum::extract::{Extension, Path, Query, State};
+use axum::http::HeaderMap;
+use pretty_assertions::assert_eq;
+use sqlx::PgPool;
+use tokio::sync::{Mutex, RwLock};
+use tower_sessions::Session;
+use tower_sessions_memory_store::MemoryStore;
+use uuid::Uuid;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use regelrecht_auth::handlers::{
+    SESSION_KEY_EMAIL, SESSION_KEY_EMAIL_VERIFIED, SESSION_KEY_NAME, SESSION_KEY_SUB,
+};
+use regelrecht_corpus::dto::PaginationParams;
+use regelrecht_editor_api::accounts::AccountRecord;
+use regelrecht_editor_api::config::AppConfig;
+use regelrecht_editor_api::corpus_handlers::{
+    list_traject_corpus_laws, list_traject_sources, promote_corpus_law,
+};
+use regelrecht_editor_api::github_oauth::{self, GithubOAuth};
+use regelrecht_editor_api::state::{AppState, CorpusState};
+use regelrecht_editor_api::traject_corpus::TrajectCorpusCache;
+
+use regelrecht_pipeline::test_utils::TestDb;
+
+const LAW_ID: &str = "wet_voorbeeld_promotie";
+const OWN_BRANCH: &str = "traject-voorbeeld";
+const OWN_SUBPATH: &str = "corpus/regulation";
+
+fn state_with_user_token_mode(pool: PgPool, oauth: GithubOAuth) -> AppState {
+    AppState {
+        corpus: Arc::new(RwLock::new(CorpusState::empty())),
+        oidc_client: None,
+        end_session_url: None,
+        config: Arc::new(AppConfig {
+            oidc: None,
+            base_url: None,
+            github_oauth: Some(oauth),
+            task_enrich_provider: "claude".to_string(),
+        }),
+        http_client: reqwest::Client::new(),
+        pool: Some(pool),
+        pipeline_api_url: None,
+        harvest_admin_url: None,
+        reload_lock: Arc::new(Mutex::new(())),
+        trajects: Arc::new(TrajectCorpusCache::new()),
+    }
+}
+
+async fn seed_account(pool: &PgPool, email: &str) -> (Uuid, String) {
+    let sub = format!("sub-{email}");
+    let (id,): (Uuid,) = sqlx::query_as(
+        "INSERT INTO accounts (person_sub, email, name) VALUES ($1, $2, $3) RETURNING id",
+    )
+    .bind(&sub)
+    .bind(email)
+    .bind("Test User")
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    (id, sub)
+}
+
+/// Traject zoals deployed: GitHub writable-own op een user-gekozen repo
+/// (auth_ref zonder geconfigureerd `CORPUS_AUTH_*_TOKEN`-env → server-side
+/// géén token) plus een lokale read-seed die het centrale corpus speelt.
+async fn seeded_traject(
+    pool: &PgPool,
+    owner_id: Uuid,
+    own_repo_owner: &str,
+    own_repo_name: &str,
+    seed_dir: &std::path::Path,
+) -> Uuid {
+    let (traject_id,): (Uuid,) = sqlx::query_as(
+        "INSERT INTO trajects (name, description, scope, created_by)
+         VALUES ('Test', '', '', $1) RETURNING id",
+    )
+    .bind(owner_id)
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO traject_members (traject_id, account_id, role)
+         VALUES ($1, $2, 'owner')",
+    )
+    .bind(traject_id)
+    .bind(owner_id)
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO traject_corpus_sources
+         (traject_id, source_id, name, source_type,
+          gh_owner, gh_repo, gh_branch, gh_base_branch, gh_path,
+          priority, auth_ref, is_writable_own)
+         VALUES ($1, 'traject-own-test', 'Eigen repo', 'github'::corpus_source_type,
+                 $2, $3, $4, 'main', $5,
+                 0, 'example-unset-token-ref', TRUE)",
+    )
+    .bind(traject_id)
+    .bind(own_repo_owner)
+    .bind(own_repo_name)
+    .bind(OWN_BRANCH)
+    .bind(OWN_SUBPATH)
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO traject_corpus_sources
+         (traject_id, source_id, name, source_type, local_path,
+          priority, scopes, is_writable_own)
+         VALUES ($1, 'central-seed', 'Centrale Corpus', 'local'::corpus_source_type, $2,
+                 2, '[]'::jsonb, FALSE)",
+    )
+    .bind(traject_id)
+    .bind(seed_dir.to_string_lossy().to_string())
+    .execute(pool)
+    .await
+    .unwrap();
+    traject_id
+}
+
+fn traject_ref(traject_id: Uuid) -> String {
+    format!("test-{}", &traject_id.to_string()[..8])
+}
+
+async fn session_for(sub: &str) -> Session {
+    let session = Session::new(None, Arc::new(MemoryStore::default()), None);
+    session.insert(SESSION_KEY_SUB, sub).await.unwrap();
+    session.insert(SESSION_KEY_NAME, "Test User").await.unwrap();
+    session
+        .insert(SESSION_KEY_EMAIL, "alice@test.local")
+        .await
+        .unwrap();
+    session
+        .insert(SESSION_KEY_EMAIL_VERIFIED, true)
+        .await
+        .unwrap();
+    session
+}
+
+/// Volledige wet-map in het centrale corpus: twee versies plus één
+/// scenario-file — de bestanden die de promote kopieert.
+fn write_central_law(central_dir: &std::path::Path) {
+    let law_dir = central_dir.join("wet").join(LAW_ID);
+    std::fs::create_dir_all(law_dir.join("scenarios")).unwrap();
+    std::fs::write(
+        law_dir.join("2025-01-01.yaml"),
+        format!("$id: {LAW_ID}\nname: Versie 2025\n"),
+    )
+    .unwrap();
+    std::fs::write(
+        law_dir.join("2024-01-01.yaml"),
+        format!("$id: {LAW_ID}\nname: Versie 2024\n"),
+    )
+    .unwrap();
+    std::fs::write(
+        law_dir.join("scenarios").join("basis.feature"),
+        "Feature: basis\n",
+    )
+    .unwrap();
+}
+
+/// Mocks voor de user-token-schrijfflow op één traject-repo: branch-check
+/// (bestaat al), en de Contents-PUT's van de promote.
+async fn mount_write_mocks(server: &MockServer, own_repo: &str) {
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/repos/{own_repo}/git/ref/heads/{OWN_BRANCH}"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "ref": format!("refs/heads/{OWN_BRANCH}"),
+            "object": { "sha": "branch-sha" },
+        })))
+        .mount(server)
+        .await;
+    for file in [
+        format!("wet/{LAW_ID}/2025-01-01.yaml"),
+        format!("wet/{LAW_ID}/2024-01-01.yaml"),
+        format!("wet/{LAW_ID}/scenarios/basis.feature"),
+    ] {
+        Mock::given(method("PUT"))
+            .and(path(format!(
+                "/repos/{own_repo}/contents/{OWN_SUBPATH}/{file}"
+            )))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                "content": { "sha": format!("sha-{file}") },
+            })))
+            .mount(server)
+            .await;
+    }
+}
+
+/// De Trees-API-listing van een traject-repo waar de gepromote wet op de
+/// branch staat — wat de indexscan ziet zodra hij de repo kán lezen.
+async fn mount_tree_with_promoted_law(server: &MockServer, own_repo: &str) {
+    Mock::given(method("GET"))
+        .and(path(format!("/repos/{own_repo}/git/trees/{OWN_BRANCH}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "sha": "tree-sha",
+            "truncated": false,
+            "tree": [
+                {
+                    "path": format!("{OWN_SUBPATH}/wet/{LAW_ID}/2025-01-01.yaml"),
+                    "type": "blob",
+                    "sha": "blob-2025",
+                },
+                {
+                    "path": format!("{OWN_SUBPATH}/wet/{LAW_ID}/2024-01-01.yaml"),
+                    "type": "blob",
+                    "sha": "blob-2024",
+                },
+                {
+                    "path": format!("{OWN_SUBPATH}/wet/{LAW_ID}/scenarios/basis.feature"),
+                    "type": "blob",
+                    "sha": "blob-feature",
+                },
+            ],
+        })))
+        .mount(server)
+        .await;
+}
+
+fn ids_query() -> Query<PaginationParams> {
+    Query(PaginationParams {
+        offset: 0,
+        limit: None,
+        q: None,
+        ids: Some(LAW_ID.to_string()),
+    })
+}
+
+/// Eén test voor beide scenario's: de `GITHUB_API_BASE`-override is
+/// proces-breed, dus parallelle tests met elk een eigen mockserver zouden
+/// elkaars fetchers verhangen.
+#[tokio::test]
+async fn traject_index_shows_promoted_law_and_surfaces_failed_own_scans() {
+    let server = MockServer::start().await;
+    std::env::set_var("GITHUB_API_BASE", server.uri());
+
+    let db = TestDb::new().await;
+    let central = tempfile::tempdir().unwrap();
+    write_central_law(central.path());
+
+    let oauth = GithubOAuth::for_tests(true); // user-token-schrijfmodus aan
+    let state = state_with_user_token_mode(db.pool.clone(), oauth.clone());
+
+    let (owner_id, sub) = seed_account(&db.pool, "alice@test.local").await;
+    let account = AccountRecord {
+        id: owner_id,
+        person_sub: sub.clone(),
+        email: "alice@test.local".to_string(),
+        name: "Test User".to_string(),
+    };
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        axum::http::header::COOKIE,
+        axum::http::HeaderValue::from_str(&github_oauth::seal_token_cookie_for_tests(
+            &oauth,
+            account.id,
+            "user-token",
+        ))
+        .unwrap(),
+    );
+
+    // ------------------------------------------------------------------
+    // Scenario 1: de indexscan kan de traject-repo NIET lezen (prod-
+    // symptoom: privé-repo, geen server-side token → Trees-API 404, hier
+    // wiremock's default voor het ongemockte trees-pad van repo A).
+    // ------------------------------------------------------------------
+    let repo_a = "example-org/example-unreadable-repo";
+    let traject_a = seeded_traject(
+        &db.pool,
+        owner_id,
+        "example-org",
+        "example-unreadable-repo",
+        central.path(),
+    )
+    .await;
+    let tref_a = traject_ref(traject_a);
+    mount_write_mocks(&server, repo_a).await;
+
+    // De promote zelf slaagt: de write gaat met het user-token.
+    let response = promote_corpus_law(
+        State(state.clone()),
+        Extension(account.clone()),
+        session_for(&sub).await,
+        Path((tref_a.clone(), LAW_ID.to_string())),
+        headers.clone(),
+    )
+    .await
+    .expect("promote met gekoppeld token moet slagen");
+    assert_eq!(response.0.copied_files, 3, "2 versies + 1 scenario");
+
+    // …maar de herbouwde index (promote invalideert de cache) mist de
+    // traject-repo: de wet valt stil terug op de seed. Dit ís het
+    // gerapporteerde prod-gedrag — gereproduceerd zonder GitHub-token.
+    let laws = list_traject_corpus_laws(
+        State(state.clone()),
+        session_for(&sub).await,
+        Path(tref_a.clone()),
+        ids_query(),
+    )
+    .await
+    .expect("laws-listing moet slagen");
+    assert_eq!(laws.0.len(), 1, "wet resolvet nog steeds — uit de seed");
+    assert_eq!(laws.0[0].source_id, "central-seed");
+    assert_eq!(
+        laws.0[0].source_priority, 2,
+        "onleesbare traject-repo → stille fallback naar de seed (priority 2)"
+    );
+
+    // Niet langer stil: /sources meldt per source waaróm de scan faalde.
+    let sources = list_traject_sources(
+        State(state.clone()),
+        session_for(&sub).await,
+        Path(tref_a.clone()),
+    )
+    .await
+    .expect("sources-listing moet slagen");
+    let own = sources
+        .0
+        .iter()
+        .find(|s| s.id == "traject-own-test")
+        .expect("writable-own source ontbreekt in /sources");
+    assert_eq!(own.law_count, 0);
+    let err = own
+        .index_error
+        .as_deref()
+        .expect("gefaalde scan moet een index_error op de source zetten");
+    assert!(
+        err.contains("404"),
+        "index_error moet de onderliggende fout dragen, got: {err}"
+    );
+    let seed = sources.0.iter().find(|s| s.id == "central-seed").unwrap();
+    assert_eq!(
+        seed.index_error, None,
+        "de gezonde seed-source mag geen fout dragen"
+    );
+
+    // ------------------------------------------------------------------
+    // Scenario 2 (happy path #952): de scan kan de traject-repo WèL lezen
+    // → de gepromote wet staat in de traject-index op priority 0.
+    // ------------------------------------------------------------------
+    let repo_b = "example-org/example-readable-repo";
+    let traject_b = seeded_traject(
+        &db.pool,
+        owner_id,
+        "example-org",
+        "example-readable-repo",
+        central.path(),
+    )
+    .await;
+    let tref_b = traject_ref(traject_b);
+    mount_write_mocks(&server, repo_b).await;
+
+    let response = promote_corpus_law(
+        State(state.clone()),
+        Extension(account.clone()),
+        session_for(&sub).await,
+        Path((tref_b.clone(), LAW_ID.to_string())),
+        headers.clone(),
+    )
+    .await
+    .expect("promote met gekoppeld token moet slagen");
+    assert_eq!(response.0.copied_files, 3);
+
+    // Pas ná de promote de Trees-listing mounten: tijdens de promote-build
+    // hoort de repo nog leeg/onbereikbaar te zijn (anders weigert de
+    // promote met 409 "staat al in dit traject").
+    mount_tree_with_promoted_law(&server, repo_b).await;
+
+    let laws = list_traject_corpus_laws(
+        State(state.clone()),
+        session_for(&sub).await,
+        Path(tref_b.clone()),
+        ids_query(),
+    )
+    .await
+    .expect("laws-listing moet slagen");
+    assert_eq!(laws.0.len(), 1, "één resolutie per wet, got: {:?}", laws.0);
+    assert_eq!(
+        laws.0[0].source_id, "traject-own-test",
+        "de gepromote wet moet uit de traject-eigen source komen"
+    );
+    assert_eq!(
+        laws.0[0].source_priority, 0,
+        "traject-eigen source wint met priority 0"
+    );
+
+    let sources = list_traject_sources(
+        State(state.clone()),
+        session_for(&sub).await,
+        Path(tref_b.clone()),
+    )
+    .await
+    .expect("sources-listing moet slagen");
+    let own = sources
+        .0
+        .iter()
+        .find(|s| s.id == "traject-own-test")
+        .expect("writable-own source ontbreekt in /sources");
+    assert_eq!(own.law_count, 1, "de gepromote wet telt mee in de index");
+    assert_eq!(own.index_error, None, "gezonde scan → geen index_error");
+
+    std::env::remove_var("GITHUB_API_BASE");
+}

--- a/packages/pipeline/src/document_convert.rs
+++ b/packages/pipeline/src/document_convert.rs
@@ -166,6 +166,10 @@ impl WritableOwnSourceRow {
             scopes: Vec::new(),
             priority: self.priority.max(0) as u32,
             auth_ref: self.auth_ref.clone(),
+            // Writable-own rows carry a user-derived `auth_ref`; resolution
+            // must never fall back to the shared legacy token (the worker
+            // below indeed resolves via `resolve_token_strict`).
+            strict_auth: true,
         }
     }
 }


### PR DESCRIPTION
## Wat

Een via de promote-flow (#952) naar de traject-repo geschreven wet laadde op een deployment zonder per-repo servertoken niet uit de traject-eigen source (priority 0), maar viel **stil** terug op het centrale corpus — de traject-source toonde alleen `law_count: 0`.

## Root cause (token-hypothese bevestigd)

De hypothese uit het ticket klopt op codeniveau en is in een integratietest 1-op-1 gereproduceerd:

- De promote **schrijft** met het user-OAuth-token (`token_override` via `user_write_token_for_backend`) — die kant slaagt.
- De server-side **indexscan** van dezelfde repo (`CorpusRegistry::index_all_sources_async` → `index_one_source`) las met een ander resolutiepad: `resolve_token_for_source` mét legacy `CORPUS_GIT_TOKEN`-fallback, waar push/backendconstructie strikt resolven (`resolve_token_strict`).
- Zonder geconfigureerd `CORPUS_AUTH_<owner-repo-slug>_TOKEN` (en zonder bruikbaar legacy-token) scant de server een privé-repo unauthenticated → Trees-API 404 → source faalt te enumereren → lege index → wet resolvet uit de seed (priority 2). Precies het waargenomen prod-gedrag; `traject_own_index_test.rs` reproduceert het zonder netwerk (wiremock).

Naast de deploy-config-kant (ontbrekende env-var; de exacte naam staat als bevinding op het ticket — bewust niet in deze publieke PR) zat er dus ook een echte code-inconsistentie: scan en push konden over verschillende tokens beschikken, en de legacy-fallback op het scanpad zou het centrale token naar een user-gekozen repo sturen — het exfiltratie-lek waarvoor `resolve_token_strict` juist bestaat, maar dan op het leespad.

## Fix

- `Source.strict_auth` (gezet voor writable-own rows, ook in de pipeline-worker) laat élk token-resolutiepad — indexscan, favorites-fetch, backendconstructie — dezelfde strikte regels volgen via de nieuwe `auth::resolve_source_token`.
- Scan-falen is niet langer stil: `index_all_sources_async` geeft per gefaalde source de fout terug (`SourceIndexFailure`); `GET /api/trajects/{ref}/sources` (en `/api/sources`) tonen die als `index_error` per source, zodat `law_count: 0` mét fout te onderscheiden is van een écht lege repo.
- De bestaande `tracing::error!` bij een gefaalde writable-own-scan draagt nu de onderliggende fout mee; de "resolved NO token"-diagnostiek benoemt naast pushes ook reads/scans.

## Tests

- Nieuw `packages/editor-api/tests/traject_own_index_test.rs`: (1) prod-repro — promote slaagt, onleesbare traject-repo → fallback naar seed (priority 2) + `index_error` op de source; (2) happy path #952 — leesbare repo → gepromote wet in de traject-index op `source_priority: 0`, `law_count: 1`, geen `index_error`.
- Unit tests voor `resolve_source_token` (strict vs. legacy) en `build_source_summaries` (`index_error`).
- `just check` groen (format, clippy, check, validate, unit tests, harvester-, pipeline-, admin- en editor-api-tests; testcontainers via `TESTCONTAINERS_HOST_OVERRIDE`).
