### PR TITLE
fix(editor): traject-reads gebruiken het persoonlijke GitHub-token als het server-token ontbreekt

### DIFF
--- a/packages/corpus/src/backend.rs
+++ b/packages/corpus/src/backend.rs
@@ -109,6 +109,29 @@ pub trait RepoBackend: Send + Sync {
     /// Read a file's contents. Returns `None` if the file does not exist.
     async fn read_file(&self, relative_path: &Path) -> Result<Option<String>>;
 
+    /// [`read_file`], authenticating with `token_override` when this
+    /// backend supports per-call tokens (see
+    /// [`RepoBackend::supports_token_override`]) — the read analogue of
+    /// [`WriteContext::token_override`]. `None` (or a backend that never
+    /// authenticates reads per call) falls back to [`read_file`]'s
+    /// behaviour, so the default implementation just delegates.
+    ///
+    /// This exists for the traject flow where the writable-own source has
+    /// no configured service token (fail-closed against shipping the
+    /// central token to a user-chosen repo): reads on that source can then
+    /// ride the acting editor user's own GitHub token per request, exactly
+    /// like `persist` does for writes.
+    ///
+    /// [`read_file`]: RepoBackend::read_file
+    async fn read_file_with_token(
+        &self,
+        relative_path: &Path,
+        token_override: Option<&str>,
+    ) -> Result<Option<String>> {
+        let _ = token_override;
+        self.read_file(relative_path).await
+    }
+
     /// Write a file's contents, creating parent directories as needed.
     ///
     /// For git backends this writes to the local checkout without committing.
@@ -120,6 +143,20 @@ pub trait RepoBackend: Send + Sync {
 
     /// List files in a directory, optionally filtered by extension (without dot).
     async fn list_files(&self, dir: &Path, extension: Option<&str>) -> Result<Vec<FileEntry>>;
+
+    /// [`list_files`] with a per-call token override — same contract as
+    /// [`RepoBackend::read_file_with_token`].
+    ///
+    /// [`list_files`]: RepoBackend::list_files
+    async fn list_files_with_token(
+        &self,
+        dir: &Path,
+        extension: Option<&str>,
+        token_override: Option<&str>,
+    ) -> Result<Vec<FileEntry>> {
+        let _ = token_override;
+        self.list_files(dir, extension).await
+    }
 
     /// List all files in a directory tree, recursively, optionally filtered by
     /// extension (without dot). Returned entries carry their path relative to
@@ -150,6 +187,20 @@ pub trait RepoBackend: Send + Sync {
                 relative_path: f.name,
             })
             .collect())
+    }
+
+    /// [`list_files_recursive`] with a per-call token override — same
+    /// contract as [`RepoBackend::read_file_with_token`].
+    ///
+    /// [`list_files_recursive`]: RepoBackend::list_files_recursive
+    async fn list_files_recursive_with_token(
+        &self,
+        dir: &Path,
+        extension: Option<&str>,
+        token_override: Option<&str>,
+    ) -> Result<Vec<RecursiveFileEntry>> {
+        let _ = token_override;
+        self.list_files_recursive(dir, extension).await
     }
 
     /// Return every YAML law's `implements` list as `(source-relative

--- a/packages/corpus/src/github_api_backend.rs
+++ b/packages/corpus/src/github_api_backend.rs
@@ -271,6 +271,20 @@ fn validate_relative(path: &Path) -> Result<()> {
 impl RepoBackend for GitHubApiBackend {
     #[tracing::instrument(name = "gh_read_file", skip_all, fields(path = %relative_path.display()))]
     async fn read_file(&self, relative_path: &Path) -> Result<Option<String>> {
+        self.read_file_with_token(relative_path, None).await
+    }
+
+    // The read-side counterpart of `persist`'s `ctx.token_override`: a
+    // per-call user token supersedes the backend's baked-in token for this
+    // one Contents API GET, so a request-bound read on a private repo
+    // without a configured service token can authenticate as the acting
+    // editor user. Absent an override the configured token (or none) is
+    // used — byte-identical to `read_file`.
+    async fn read_file_with_token(
+        &self,
+        relative_path: &Path,
+        token_override: Option<&str>,
+    ) -> Result<Option<String>> {
         let api_path = self.api_path(relative_path)?;
         let mut inner = self.inner.lock().await;
         // One Contents API GET — the If-Match precondition read on the save
@@ -281,7 +295,7 @@ impl RepoBackend for GitHubApiBackend {
                 &self.full_repo(),
                 &self.branch,
                 &api_path,
-                self.token.as_deref(),
+                token_override.or(self.token.as_deref()),
             ),
         )
         .await?;
@@ -369,6 +383,16 @@ impl RepoBackend for GitHubApiBackend {
 
     #[tracing::instrument(name = "gh_list_files", skip_all, fields(dir = %dir.display()))]
     async fn list_files(&self, dir: &Path, extension: Option<&str>) -> Result<Vec<FileEntry>> {
+        self.list_files_with_token(dir, extension, None).await
+    }
+
+    // Same per-call token override stance as `read_file_with_token`.
+    async fn list_files_with_token(
+        &self,
+        dir: &Path,
+        extension: Option<&str>,
+        token_override: Option<&str>,
+    ) -> Result<Vec<FileEntry>> {
         let api_dir = self.api_path(dir)?;
         let mut inner = self.inner.lock().await;
         // One Contents API directory GET — feeds the `gh_list` Server-
@@ -380,7 +404,7 @@ impl RepoBackend for GitHubApiBackend {
                 &self.full_repo(),
                 &self.branch,
                 &api_dir,
-                self.token.as_deref(),
+                token_override.or(self.token.as_deref()),
             ),
         )
         .await?;
@@ -404,6 +428,17 @@ impl RepoBackend for GitHubApiBackend {
         &self,
         dir: &Path,
         extension: Option<&str>,
+    ) -> Result<Vec<RecursiveFileEntry>> {
+        self.list_files_recursive_with_token(dir, extension, None)
+            .await
+    }
+
+    // Same per-call token override stance as `read_file_with_token`.
+    async fn list_files_recursive_with_token(
+        &self,
+        dir: &Path,
+        extension: Option<&str>,
+        token_override: Option<&str>,
     ) -> Result<Vec<RecursiveFileEntry>> {
         let api_root = self.api_path(dir)?;
         let mut inner = self.inner.lock().await;
@@ -431,7 +466,7 @@ impl RepoBackend for GitHubApiBackend {
                     &self.full_repo(),
                     &self.branch,
                     &api_dir,
-                    self.token.as_deref(),
+                    token_override.or(self.token.as_deref()),
                 )
                 .await?;
             // The Contents API caps a single directory listing at 1000

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -7,6 +7,7 @@ use axum::Json;
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 use tower_sessions::Session;
+use uuid::Uuid;
 
 use regelrecht_auth::handlers::{
     SESSION_KEY_EMAIL, SESSION_KEY_EMAIL_VERIFIED, SESSION_KEY_NAME, SESSION_KEY_SUB,
@@ -119,14 +120,100 @@ pub struct LawOutputEntry {
 /// `TrajectCorpus` it resolved via `require_traject_corpus_from_ref`, to
 /// snapshot a law's YAML through the same read path the editor uses.
 pub(crate) enum ReadScope {
-    Traject(Arc<TrajectCorpus>),
+    Traject(TrajectScope),
     Global(tokio::sync::OwnedRwLockReadGuard<CorpusState>),
 }
 
+/// Traject-scoped read state: the per-traject corpus plus the outcome of
+/// the per-request read-token resolution for its writable-own source.
+///
+/// The token outcome is resolved eagerly at scope construction but
+/// surfaced **lazily**: a read that never touches the writable-own
+/// backend (seed laws, source listings) must keep working for a user
+/// without a linked GitHub account, so the deferred `Err` (the 428
+/// connect-flow) only fires at the call sites that actually read the
+/// writable-own source. The token itself lives only in this per-request
+/// struct — never in the shared `TrajectCorpus` or any cache key.
+pub(crate) struct TrajectScope {
+    traject: Arc<TrajectCorpus>,
+    own_read_token: Result<Option<String>, (StatusCode, String)>,
+}
+
+impl TrajectScope {
+    /// The token to authenticate a writable-own read with, or the
+    /// deferred 428 when this deployment requires a user token for that
+    /// source and the caller hasn't linked one. Call this at the moment
+    /// a read actually targets the writable-own backend — not earlier.
+    fn own_read_token(&self) -> Result<Option<&str>, (StatusCode, String)> {
+        match &self.own_read_token {
+            Ok(token) => Ok(token.as_deref()),
+            Err(e) => Err(e.clone()),
+        }
+    }
+
+    /// [`Self::own_read_token`], but only when `law_id`'s body actually
+    /// resolves from the writable-own source — a seed-served law must
+    /// neither carry the personal token nor trip the deferred 428.
+    fn own_read_token_for_law(&self, law_id: &str) -> Result<Option<&str>, (StatusCode, String)> {
+        let from_own = self
+            .traject
+            .corpus
+            .source_map
+            .get_law(law_id)
+            .is_some_and(|l| l.source_id == self.traject.writable_own_source_id);
+        if from_own {
+            self.own_read_token()
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Like [`Self::own_read_token_for_law`], for the full version set:
+    /// the token (or deferred 428) applies as soon as *any* indexed
+    /// version of the law lives on the writable-own source.
+    fn own_read_token_for_law_versions(
+        &self,
+        law_id: &str,
+    ) -> Result<Option<&str>, (StatusCode, String)> {
+        let any_own = self
+            .traject
+            .corpus
+            .source_map
+            .get_law_versions(law_id)
+            .is_some_and(|vs| {
+                vs.iter()
+                    .any(|v| v.source_id == self.traject.writable_own_source_id)
+            });
+        if any_own {
+            self.own_read_token()
+        } else {
+            Ok(None)
+        }
+    }
+}
+
 impl ReadScope {
+    /// Build a traject scope, resolving the per-request read token for
+    /// the traject's writable-own source (see [`TrajectScope`]).
+    ///
+    /// `pub(crate)`: `task_requests` snapshots law YAML through the same
+    /// read path and must resolve the same token.
+    pub(crate) async fn for_traject(
+        state: &AppState,
+        account_id: Uuid,
+        headers: &axum::http::HeaderMap,
+        traject: Arc<TrajectCorpus>,
+    ) -> Self {
+        let own_read_token = resolve_own_read_token(state, account_id, headers, &traject).await;
+        ReadScope::Traject(TrajectScope {
+            traject,
+            own_read_token,
+        })
+    }
+
     fn corpus(&self) -> &CorpusState {
         match self {
-            ReadScope::Traject(t) => &t.corpus,
+            ReadScope::Traject(t) => &t.traject.corpus,
             ReadScope::Global(g) => g,
         }
     }
@@ -136,12 +223,22 @@ impl ReadScope {
     /// takes precedence over the source_map snapshot, so a save +
     /// re-open in the same traject returns the new content without a
     /// full source_map rebuild.
-    async fn law_yaml(
-        &self,
-        law_id: &str,
-    ) -> Result<Option<String>, regelrecht_corpus::error::CorpusError> {
+    ///
+    /// Backend failures (lazy fetch threw) map to 502 "failed to load",
+    /// distinguishable from a genuine `Ok(None)` miss; a writable-own law
+    /// that needs the caller's GitHub link maps to the 428 connect-flow.
+    async fn law_yaml(&self, law_id: &str) -> Result<Option<String>, (StatusCode, String)> {
         match self {
-            ReadScope::Traject(t) => t.law_yaml(law_id).await,
+            ReadScope::Traject(t) => {
+                // Deferred read-token outcome: loud (428) when the body
+                // lives on a writable-own source we cannot read for this
+                // user, instead of a silent 404 from GitHub.
+                let token = t.own_read_token_for_law(law_id)?;
+                t.traject
+                    .law_yaml_with_read_token(law_id, token)
+                    .await
+                    .map_err(law_read_error(law_id))
+            }
             // The global corpus is fully loaded up front, so there's no lazy
             // fetch that could fail — a miss is always a genuine miss.
             ReadScope::Global(g) => {
@@ -154,12 +251,21 @@ impl ReadScope {
     /// Mirrors [`Self::law_yaml`] but returns the full version set (newest-first)
     /// so the scenario loader can hand them all to the engine. An unknown law is
     /// an empty vec, not an error.
-    async fn law_yaml_versions(
-        &self,
-        law_id: &str,
-    ) -> Result<Vec<String>, regelrecht_corpus::error::CorpusError> {
+    async fn law_yaml_versions(&self, law_id: &str) -> Result<Vec<String>, (StatusCode, String)> {
         match self {
-            ReadScope::Traject(t) => t.law_yaml_versions(law_id).await,
+            ReadScope::Traject(t) => {
+                let token = t.own_read_token_for_law_versions(law_id)?;
+                t.traject
+                    .law_yaml_versions_with_read_token(law_id, token)
+                    .await
+                    .map_err(|e| {
+                        tracing::warn!(law_id = %law_id, error = %e, "failed to load law versions");
+                        (
+                            StatusCode::BAD_GATEWAY,
+                            format!("Kon versies van wet '{law_id}' niet laden"),
+                        )
+                    })
+            }
             // The global corpus is fully loaded up front (like `law_yaml`), so
             // eagerly-loaded (local-source) bodies are present; filter any
             // metadata-only sentinel so the loader never receives an empty YAML
@@ -183,9 +289,49 @@ impl ReadScope {
     }
 }
 
-/// Read a law's YAML within a scope, mapping the outcome to an HTTP error:
-/// a backend failure (lazy fetch threw) becomes 502 "failed to load" so it's
-/// distinguishable from a genuine 404 miss; the error is logged for operators.
+/// Map a law-body backend failure to the client-facing 502; the raw error
+/// is logged for operators.
+fn law_read_error(
+    law_id: &str,
+) -> impl FnOnce(regelrecht_corpus::error::CorpusError) -> (StatusCode, String) + '_ {
+    move |e| {
+        tracing::warn!(law_id = %law_id, error = %e, "failed to load law body");
+        (
+            StatusCode::BAD_GATEWAY,
+            format!("Kon wet '{law_id}' niet laden"),
+        )
+    }
+}
+
+/// Resolve the per-request read token for a traject's writable-own
+/// backend (see [`github_oauth::user_read_token_for_backend`] for the
+/// decision table). The result — including the deferred 428 — is stored
+/// on the [`TrajectScope`] and only surfaced by reads that actually
+/// target the writable-own source.
+async fn resolve_own_read_token(
+    state: &AppState,
+    account_id: Uuid,
+    headers: &axum::http::HeaderMap,
+    traject: &TrajectCorpus,
+) -> Result<Option<String>, (StatusCode, String)> {
+    let Some(entry) = traject.corpus.backends.get(&traject.writable_own_source_id) else {
+        return Ok(None);
+    };
+    // Writable at rest = the backend has its own credential (service
+    // token, or a natively writable local dir): reads keep using it,
+    // behaviour unchanged — and we skip the backend lock entirely.
+    if entry.writable {
+        return Ok(None);
+    }
+    // Lock only long enough for the two synchronous capability probes
+    // inside `user_read_token_for_backend`; no I/O under this guard.
+    let backend = entry.backend.lock().await;
+    github_oauth::user_read_token_for_backend(state, account_id, headers, &**backend).await
+}
+
+/// Read a law's YAML within a scope. 502 for a backend failure, 404 for a
+/// genuine miss, 428 when the writable-own source needs the caller's
+/// GitHub link (see [`ReadScope::law_yaml`]).
 ///
 /// `pub(crate)`: also used by `task_requests` to snapshot the wet-YAML an
 /// enrich-op-aanvraag ships as its input blob.
@@ -195,14 +341,7 @@ pub(crate) async fn read_law_yaml(
 ) -> Result<String, (StatusCode, String)> {
     scope
         .law_yaml(law_id)
-        .await
-        .map_err(|e| {
-            tracing::warn!(law_id = %law_id, error = %e, "failed to load law body");
-            (
-                StatusCode::BAD_GATEWAY,
-                format!("Kon wet '{law_id}' niet laden"),
-            )
-        })?
+        .await?
         .ok_or_else(|| (StatusCode::NOT_FOUND, format!("Law '{law_id}' not found")))
 }
 
@@ -221,13 +360,18 @@ async fn global_scope(state: &AppState) -> ReadScope {
 /// UUID before the membership query (see `resolve_traject_ref`). Returns
 /// 403 when the caller is not a member, 404 when the ref doesn't match
 /// any known traject, 400 when the ref is malformed.
+///
+/// `account` + `headers` feed the per-request read-token resolution for
+/// the traject's writable-own source (see [`TrajectScope`]).
 async fn require_traject_scope(
     state: &AppState,
     session: &Session,
+    account: &AccountRecord,
+    headers: &axum::http::HeaderMap,
     traject_ref: &str,
 ) -> Result<ReadScope, (StatusCode, String)> {
     let traject = require_traject_corpus_from_ref(state, session, traject_ref).await?;
-    Ok(ReadScope::Traject(traject))
+    Ok(ReadScope::for_traject(state, account.id, headers, traject).await)
 }
 
 /// GET /api/sources — list all registered corpus sources (global).
@@ -242,10 +386,12 @@ pub async fn list_sources(
 /// but routed through the traject's per-source backends.
 pub async fn list_traject_sources(
     State(state): State<AppState>,
+    Extension(account): Extension<AccountRecord>,
     session: Session,
     Path(traject_ref): Path<String>,
+    headers: axum::http::HeaderMap,
 ) -> Result<Json<Vec<SourceSummary>>, (StatusCode, String)> {
-    let scope = require_traject_scope(&state, &session, &traject_ref).await?;
+    let scope = require_traject_scope(&state, &session, &account, &headers, &traject_ref).await?;
     Ok(Json(list_sources_in_scope(&scope)))
 }
 
@@ -270,11 +416,13 @@ pub async fn list_corpus_laws(
 /// but the source_map comes from the traject's per-source backends.
 pub async fn list_traject_corpus_laws(
     State(state): State<AppState>,
+    Extension(account): Extension<AccountRecord>,
     session: Session,
     Path(traject_ref): Path<String>,
     Query(params): Query<PaginationParams>,
+    headers: axum::http::HeaderMap,
 ) -> Result<Json<Vec<CorpusLawEntry>>, (StatusCode, String)> {
-    let scope = require_traject_scope(&state, &session, &traject_ref).await?;
+    let scope = require_traject_scope(&state, &session, &account, &headers, &traject_ref).await?;
     Ok(Json(list_corpus_laws_in_scope(&scope, params)))
 }
 
@@ -429,10 +577,12 @@ pub async fn get_corpus_law(
 /// global GET but with the traject's read-your-writes overlay applied.
 pub async fn get_traject_corpus_law(
     State(state): State<AppState>,
+    Extension(account): Extension<AccountRecord>,
     session: Session,
     Path((traject_ref, law_id)): Path<(String, String)>,
+    headers: axum::http::HeaderMap,
 ) -> Result<EtaggedContentResponse, (StatusCode, String)> {
-    let scope = require_traject_scope(&state, &session, &traject_ref).await?;
+    let scope = require_traject_scope(&state, &session, &account, &headers, &traject_ref).await?;
     get_corpus_law_in_scope(&scope, &law_id).await
 }
 
@@ -463,10 +613,12 @@ pub async fn get_corpus_law_versions(
 /// read-your-writes overlay.
 pub async fn get_traject_corpus_law_versions(
     State(state): State<AppState>,
+    Extension(account): Extension<AccountRecord>,
     session: Session,
     Path((traject_ref, law_id)): Path<(String, String)>,
+    headers: axum::http::HeaderMap,
 ) -> Result<Json<Vec<String>>, (StatusCode, String)> {
-    let scope = require_traject_scope(&state, &session, &traject_ref).await?;
+    let scope = require_traject_scope(&state, &session, &account, &headers, &traject_ref).await?;
     get_corpus_law_versions_in_scope(&scope, &law_id).await
 }
 
@@ -474,15 +626,9 @@ async fn get_corpus_law_versions_in_scope(
     scope: &ReadScope,
     law_id: &str,
 ) -> Result<Json<Vec<String>>, (StatusCode, String)> {
-    let versions = scope.law_yaml_versions(law_id).await.map_err(|e| {
-        // A backend failure (lazy fetch threw) is a 502, distinguishable from
-        // a genuine "no such law" empty array; logged for operators.
-        tracing::warn!(law_id = %law_id, error = %e, "failed to load law versions");
-        (
-            StatusCode::BAD_GATEWAY,
-            format!("Kon versies van wet '{law_id}' niet laden"),
-        )
-    })?;
+    // A backend failure (lazy fetch threw) is a 502, distinguishable from
+    // a genuine "no such law" empty array (see `ReadScope::law_yaml_versions`).
+    let versions = scope.law_yaml_versions(law_id).await?;
     Ok(Json(versions))
 }
 
@@ -499,10 +645,12 @@ pub async fn list_law_outputs(
 /// global but with the traject overlay.
 pub async fn list_traject_law_outputs(
     State(state): State<AppState>,
+    Extension(account): Extension<AccountRecord>,
     session: Session,
     Path((traject_ref, law_id)): Path<(String, String)>,
+    headers: axum::http::HeaderMap,
 ) -> Result<Json<Vec<LawOutputEntry>>, (StatusCode, String)> {
-    let scope = require_traject_scope(&state, &session, &traject_ref).await?;
+    let scope = require_traject_scope(&state, &session, &account, &headers, &traject_ref).await?;
     list_law_outputs_in_scope(&scope, &law_id).await
 }
 
@@ -549,10 +697,12 @@ pub async fn list_law_implementors(
 /// as the global view but resolved through the traject's federated corpus.
 pub async fn list_traject_law_implementors(
     State(state): State<AppState>,
+    Extension(account): Extension<AccountRecord>,
     session: Session,
     Path((traject_ref, law_id)): Path<(String, String)>,
+    headers: axum::http::HeaderMap,
 ) -> Result<Json<Vec<String>>, (StatusCode, String)> {
-    let scope = require_traject_scope(&state, &session, &traject_ref).await?;
+    let scope = require_traject_scope(&state, &session, &account, &headers, &traject_ref).await?;
     Ok(Json(implementors_in_scope(&scope, &law_id).await))
 }
 
@@ -570,8 +720,8 @@ async fn implementors_in_scope(scope: &ReadScope, law_id: &str) -> Vec<String> {
         // per-request signal here is debug-only — a warn per lookup would
         // re-log the same incident on every panel open until the next
         // rebuild self-heals it.
-        ReadScope::Traject(traject) => {
-            let result = traject.implementors_of(law_id).await;
+        ReadScope::Traject(ts) => {
+            let result = ts.traject.implementors_of(law_id).await;
             if result.skipped_count > 0 {
                 tracing::debug!(
                     law_id = %law_id,
@@ -660,10 +810,12 @@ pub async fn list_scenarios(
 /// scenario is visible without a corpus reload.
 pub async fn list_traject_scenarios(
     State(state): State<AppState>,
+    Extension(account): Extension<AccountRecord>,
     session: Session,
     Path((traject_ref, law_id)): Path<(String, String)>,
+    headers: axum::http::HeaderMap,
 ) -> Result<Json<Vec<ScenarioEntry>>, (StatusCode, String)> {
-    let scope = require_traject_scope(&state, &session, &traject_ref).await?;
+    let scope = require_traject_scope(&state, &session, &account, &headers, &traject_ref).await?;
     list_scenarios_in_scope(&scope, &law_id).await
 }
 
@@ -694,7 +846,8 @@ async fn list_scenarios_in_scope(
         // law file itself was never saved there, AND seed scenarios that
         // were never copied to the branch keep showing up (their GET
         // falls back to the seed the same way).
-        ReadScope::Traject(traject) => {
+        ReadScope::Traject(ts) => {
+            let traject = &ts.traject;
             // Per-snapshot cache: the editor requests this listing on
             // every law open, and a rebuild costs one `list_files` per
             // backend plus a read per scenario file — the most GitHub-
@@ -728,6 +881,10 @@ async fn list_scenarios_in_scope(
                 Err(_) => return Ok(Json(Vec::new())),
             };
             let write_source_id = traject_write_source_id(traject, law);
+            // The write-target listing reads the writable-own source, so
+            // this is where a missing GitHub link surfaces loudly (428)
+            // instead of a silently seed-only listing.
+            let own_read_token = ts.own_read_token()?;
             let mut names = std::collections::BTreeSet::new();
             // Lock order: write target first, released before the seed
             // backend is touched (writable-own → seed, never the
@@ -738,9 +895,14 @@ async fn list_scenarios_in_scope(
                 let Some(entry) = traject.corpus.backends.get(source_id) else {
                     continue;
                 };
+                // Personal token only on the write-target (writable-own)
+                // leg; the seed listing never carries it.
+                let token = (source_id == write_source_id)
+                    .then_some(own_read_token)
+                    .flatten();
                 let backend = entry.backend.lock().await;
                 let entries = backend
-                    .list_files(&scenarios_dir, Some("feature"))
+                    .list_files_with_token(&scenarios_dir, Some("feature"), token)
                     .await
                     .map_err(list_error)?;
                 drop(backend);
@@ -760,7 +922,7 @@ async fn list_scenarios_in_scope(
             for filename in names {
                 let relative_path = scenarios_dir.join(&filename);
                 let target_law_ids =
-                    match read_traject_scenario_cached(traject, law, &relative_path).await {
+                    match read_traject_scenario_cached(ts, law, &relative_path).await {
                         Ok(Some(content)) => extract_target_law_ids(&content),
                         // Listed but unreadable on every routing leg: a
                         // ghost. GitHub's directory listing is eventually
@@ -864,10 +1026,12 @@ pub async fn get_scenario(
 /// — traject-scoped scenario read.
 pub async fn get_traject_scenario(
     State(state): State<AppState>,
+    Extension(account): Extension<AccountRecord>,
     session: Session,
     Path((traject_ref, law_id, filename)): Path<(String, String, String)>,
+    headers: axum::http::HeaderMap,
 ) -> Result<EtaggedContentResponse, (StatusCode, String)> {
-    let scope = require_traject_scope(&state, &session, &traject_ref).await?;
+    let scope = require_traject_scope(&state, &session, &account, &headers, &traject_ref).await?;
     get_scenario_in_scope(&scope, &law_id, &filename).await
 }
 
@@ -885,10 +1049,10 @@ async fn get_scenario_in_scope(
         // checked against. See `read_traject_file_via_write_target` for
         // the 412-loop this prevents. Cached per snapshot; saves keep the
         // entry coherent (see `read_traject_scenario_cached`).
-        ReadScope::Traject(traject) => {
-            let law = traject_law(traject, law_id)?;
+        ReadScope::Traject(ts) => {
+            let law = traject_law(&ts.traject, law_id)?;
             let relative_path = scenario_relative_path(law, filename)?;
-            read_traject_scenario_cached(traject, law, &relative_path).await?
+            read_traject_scenario_cached(ts, law, &relative_path).await?
         }
         // Global: no write target exists; keep the read-only resolution.
         ReadScope::Global(_) => {
@@ -946,7 +1110,8 @@ fn resolve_annotation_read_backend(
     law_id: &str,
 ) -> Result<SharedBackend, (StatusCode, String)> {
     match scope {
-        ReadScope::Traject(traject) => {
+        ReadScope::Traject(ts) => {
+            let traject = &ts.traject;
             let law = traject_law(traject, law_id)?;
             // Mirror `resolve_traject_law_write`: a law from a
             // non-writable_own source is routed to the writable_own
@@ -1031,8 +1196,9 @@ pub async fn get_traject_annotations(
     session: Session,
     Extension(account): Extension<AccountRecord>,
     Path((traject_ref, law_id)): Path<(String, String)>,
+    headers: axum::http::HeaderMap,
 ) -> Result<YamlResponse, (StatusCode, String)> {
-    let scope = require_traject_scope(&state, &session, &traject_ref).await?;
+    let scope = require_traject_scope(&state, &session, &account, &headers, &traject_ref).await?;
     let sidecar = match get_annotations_in_scope(&scope, &law_id).await {
         Ok((_, _, content)) => Some(content),
         // Absent sidecar is fine here: the caller may still have personal
@@ -1125,14 +1291,26 @@ async fn read_annotations_in_scope(
     // letting a stale backend read pass the guard and overwrite the
     // save's fresh entry.
     let mut gen_before = 0;
-    if let ReadScope::Traject(traject) = scope {
-        gen_before = traject.sidecar_write_generation();
-        if let Some(cached) = traject.cached_sidecar(&annotations_cache_key(law_id)).await {
+    if let ReadScope::Traject(ts) = scope {
+        gen_before = ts.traject.sidecar_write_generation();
+        if let Some(cached) = ts
+            .traject
+            .cached_sidecar(&annotations_cache_key(law_id))
+            .await
+        {
             return Ok(cached);
         }
     }
 
     let backend = resolve_annotation_read_backend(scope, law_id)?;
+
+    // Traject-scoped, the resolved backend is the write target — the
+    // writable-own source — so this read carries the per-request token
+    // (or surfaces the deferred 428) exactly like the scenario reads.
+    let own_read_token = match scope {
+        ReadScope::Traject(ts) => ts.own_read_token()?.map(str::to_string),
+        ReadScope::Global(_) => None,
+    };
 
     // RFC-018 §1: keyed by law id at the source root, regardless of where
     // the law file lives. Same path the `save_annotations` write uses.
@@ -1142,17 +1320,20 @@ async fn read_annotations_in_scope(
 
     let content = {
         let backend = backend.lock().await;
-        backend.read_file(&relative_path).await.map_err(|e| {
-            tracing::warn!(law_id = %law_id, error = %e, "get_annotations backend read failed");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "Failed to read annotations".to_string(),
-            )
-        })?
+        backend
+            .read_file_with_token(&relative_path, own_read_token.as_deref())
+            .await
+            .map_err(|e| {
+                tracing::warn!(law_id = %law_id, error = %e, "get_annotations backend read failed");
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Failed to read annotations".to_string(),
+                )
+            })?
     };
 
-    if let ReadScope::Traject(traject) = scope {
-        traject
+    if let ReadScope::Traject(ts) = scope {
+        ts.traject
             .store_sidecar_read(annotations_cache_key(law_id), content.clone(), gen_before)
             .await;
     }
@@ -1637,10 +1818,11 @@ async fn current_content_for_write(
     write: &TrajectLawWrite,
     relative_path: &std::path::Path,
     kind: &'static str,
+    own_read_token: Option<&str>,
 ) -> Result<Option<String>, (StatusCode, String)> {
     if let Some(text) = write
         .backend
-        .read_file(relative_path)
+        .read_file_with_token(relative_path, own_read_token)
         .await
         .map_err(corpus_write_error(kind))?
     {
@@ -1710,6 +1892,7 @@ async fn read_traject_file_via_write_target(
     law: &LoadedLaw,
     relative_path: &std::path::Path,
     kind: &'static str,
+    own_read_token: Option<&str>,
 ) -> Result<Option<String>, (StatusCode, String)> {
     let write_source_id = traject_write_source_id(traject, law);
     let entry = traject.corpus.backends.get(&write_source_id).ok_or((
@@ -1718,8 +1901,11 @@ async fn read_traject_file_via_write_target(
     ))?;
     {
         let backend = entry.backend.lock().await;
+        // The write target is the writable-own source, so this leg may
+        // ride the per-request user token. The seed fallback below never
+        // does.
         if let Some(text) = backend
-            .read_file(relative_path)
+            .read_file_with_token(relative_path, own_read_token)
             .await
             .map_err(corpus_write_error(kind))?
         {
@@ -1752,10 +1938,11 @@ fn scenario_cache_key(relative_path: &std::path::Path) -> String {
 /// wrong). Cross-replica edits converge at the next snapshot, like law
 /// bodies.
 async fn read_traject_scenario_cached(
-    traject: &Arc<TrajectCorpus>,
+    ts: &TrajectScope,
     law: &LoadedLaw,
     relative_path: &std::path::Path,
 ) -> Result<Option<String>, (StatusCode, String)> {
+    let traject = &ts.traject;
     let key = scenario_cache_key(relative_path);
     // Generation captured before the cache probe: a save/delete landing
     // while the read is in flight bumps it, and the store below is then
@@ -1768,8 +1955,13 @@ async fn read_traject_scenario_cached(
     if let Some(cached) = traject.cached_sidecar(&key).await {
         return Ok(cached);
     }
+    // Token (or deferred 428) resolved only on a cache miss: cached
+    // *content* is fine to serve — every traject route already passed
+    // the membership check.
+    let own_read_token = ts.own_read_token()?;
     let content =
-        read_traject_file_via_write_target(traject, law, relative_path, "scenario").await?;
+        read_traject_file_via_write_target(traject, law, relative_path, "scenario", own_read_token)
+            .await?;
     traject
         .store_sidecar_read(key, content.clone(), gen_before)
         .await;
@@ -1850,10 +2042,26 @@ pub async fn save_scenario(
 
     // Optimistic concurrency, same semantics as documents. Only read the
     // current content when the client actually sent a precondition — a
-    // header-less save stays a single write, no extra backend read.
+    // header-less save stays a single write, no extra backend read. The
+    // precondition read uses the read-token mechanism (a token-less
+    // writable-own backend reads with the user's token), so it compares
+    // against the same bytes the GET served.
     if let Some(if_match) = extract_if_match(&headers) {
-        let current =
-            current_content_for_write(&traject, &write, &relative_path, "scenario").await?;
+        let read_token = github_oauth::user_read_token_for_backend(
+            &state,
+            account.id,
+            &headers,
+            &**write.backend,
+        )
+        .await?;
+        let current = current_content_for_write(
+            &traject,
+            &write,
+            &relative_path,
+            "scenario",
+            read_token.as_deref(),
+        )
+        .await?;
         check_if_match(current.as_deref(), Some(&if_match), "Scenario")?;
     }
 
@@ -2055,9 +2263,14 @@ pub async fn save_annotations(
 
     // Read the current sidecar from the traject backend (the branch this
     // traject's PR is built on — read-your-writes within the traject).
-    // Absent file = first notes for this law.
+    // Absent file = first notes for this law. Uses the read-token
+    // mechanism: on a token-less writable-own backend this read would
+    // otherwise 404 on a private repo and silently drop the existing
+    // notes from the append base.
+    let read_token =
+        github_oauth::user_read_token_for_backend(&state, account.id, &headers, &**backend).await?;
     let base_text: Option<String> = backend
-        .read_file(&relative_path)
+        .read_file_with_token(&relative_path, read_token.as_deref())
         .await
         .map_err(corpus_write_error("annotations"))?;
 
@@ -2271,7 +2484,21 @@ pub async fn save_law(
     // mutex (acquired by `resolve_traject_law_write` above), so a
     // concurrent save cannot slip between the check and the write.
     if let Some(if_match) = extract_if_match(&headers) {
-        let current = current_content_for_write(&traject, &write, &relative_path, "law").await?;
+        let read_token = github_oauth::user_read_token_for_backend(
+            &state,
+            account.id,
+            &headers,
+            &**write.backend,
+        )
+        .await?;
+        let current = current_content_for_write(
+            &traject,
+            &write,
+            &relative_path,
+            "law",
+            read_token.as_deref(),
+        )
+        .await?;
         check_if_match(current.as_deref(), Some(&if_match), "Wet")?;
     }
 
@@ -2664,9 +2891,10 @@ async fn enforce_if_match(
     backend: &dyn RepoBackend,
     relative_path: &std::path::Path,
     if_match: Option<&str>,
+    read_token: Option<&str>,
 ) -> Result<Option<String>, (StatusCode, String)> {
     let current = backend
-        .read_file(relative_path)
+        .read_file_with_token(relative_path, read_token)
         .await
         .map_err(corpus_write_error("document"))?;
     check_if_match(current.as_deref(), if_match, "Document")
@@ -2715,14 +2943,22 @@ fn check_if_match(
 /// offers the create form.
 pub async fn list_traject_documents(
     State(state): State<AppState>,
+    Extension(account): Extension<AccountRecord>,
     session: Session,
     Path(traject_ref): Path<String>,
+    headers: axum::http::HeaderMap,
 ) -> Result<Json<TrajectDocumentList>, (StatusCode, String)> {
     let traject = require_traject_corpus_from_ref(&state, &session, &traject_ref).await?;
     let backend = resolve_traject_documents_writer(&state, &traject).await?;
+    // Documents live exclusively on the writable-own source, so this read
+    // rides the per-request user token when that source has no service
+    // token — and fails loud (428, the GitHub connect-flow) instead of
+    // returning a silently empty list when the user hasn't linked GitHub.
+    let read_token =
+        github_oauth::user_read_token_for_backend(&state, account.id, &headers, &**backend).await?;
     let base = traject_documents_base(&traject_ref);
     let entries = backend
-        .list_files_recursive(&base, None)
+        .list_files_recursive_with_token(&base, None, read_token.as_deref())
         .await
         .map_err(|e| {
             tracing::warn!(error = %e, "list_files_recursive on documents failed");
@@ -2883,6 +3119,7 @@ pub async fn upload_traject_document(
     Extension(account): Extension<AccountRecord>,
     session: Session,
     Path(traject_ref): Path<String>,
+    headers: axum::http::HeaderMap,
     mut multipart: Multipart,
 ) -> Result<(StatusCode, Json<UploadDocumentResponse>), (StatusCode, String)> {
     let pool = state.pool.as_ref().ok_or((
@@ -2902,10 +3139,15 @@ pub async fn upload_traject_document(
     // unconditional write would silently overwrite that document. Fail the
     // upload instead.
     let backend = resolve_traject_documents_writer(&state, &traject).await?;
+    // Same read-token routing as `list_traject_documents`: without it a
+    // token-less writable-own repo lists empty and the collision check is
+    // blind.
+    let read_token =
+        github_oauth::user_read_token_for_backend(&state, account.id, &headers, &**backend).await?;
 
     let base = traject_documents_base(&traject_ref);
     let mut existing: Vec<String> = backend
-        .list_files_recursive(&base, None)
+        .list_files_recursive_with_token(&base, None, read_token.as_deref())
         .await
         .map_err(|e| upload_internal_error("list documents for collision check", e))?
         .into_iter()
@@ -3154,10 +3396,12 @@ pub async fn create_traject_law(
     // The writable-own backend (same routing as documents: the law does not
     // exist yet, so there is no per-law source to route from).
     let backend = resolve_traject_documents_writer(&state, &traject).await?;
+    let read_token =
+        github_oauth::user_read_token_for_backend(&state, account.id, &headers, &**backend).await?;
     // Belt-and-braces against an index blind spot (e.g. a file committed on
     // the branch after the current snapshot was built).
     if backend
-        .read_file(&relative_path)
+        .read_file_with_token(&relative_path, read_token.as_deref())
         .await
         .map_err(corpus_write_error("law"))?
         .is_some()
@@ -3278,6 +3522,11 @@ pub async fn promote_corpus_law(
     // documents/create: per-wet routing bestaat nog niet, want de wet zit nog
     // niet in de traject-repo).
     let backend = resolve_traject_documents_writer(&state, &traject).await?;
+    // Leestoken voor de bestaat-al-checks hieronder: zonder service-token
+    // leest een privé traject-repo anders overal 404 en zou de promote
+    // bestaande traject-edits stilletjes overschrijven.
+    let read_token =
+        github_oauth::user_read_token_for_backend(&state, account.id, &headers, &**backend).await?;
 
     // Geen dubbele/overschreven bestanden, per bestandssoort:
     // - Wet-versie-YAML al op het doelpad (bijv. via een eerdere save_law op
@@ -3292,7 +3541,7 @@ pub async fn promote_corpus_law(
     let mut to_write: Vec<&PromoteFile> = Vec::with_capacity(files.len());
     for file in &files {
         let exists = backend
-            .read_file(&file.relative_path)
+            .read_file_with_token(&file.relative_path, read_token.as_deref())
             .await
             .map_err(corpus_write_error("law"))?
             .is_some();
@@ -3538,16 +3787,23 @@ pub async fn cancel_traject_document_convert_job(
 /// next PUT/DELETE to detect a concurrent edit.
 pub async fn get_traject_document(
     State(state): State<AppState>,
+    Extension(account): Extension<AccountRecord>,
     session: Session,
     Path((traject_ref, doc_path)): Path<(String, String)>,
+    headers: axum::http::HeaderMap,
 ) -> Result<axum::response::Response, (StatusCode, String)> {
     use axum::response::IntoResponse;
     validate_document_path(&doc_path)?;
     let traject = require_traject_corpus_from_ref(&state, &session, &traject_ref).await?;
     let backend = resolve_traject_documents_writer(&state, &traject).await?;
+    // Same read-token routing as the listing: user token on a token-less
+    // writable-own source, 428 instead of a misleading 404 when the user
+    // hasn't linked GitHub.
+    let read_token =
+        github_oauth::user_read_token_for_backend(&state, account.id, &headers, &**backend).await?;
     let relative_path = traject_documents_base(&traject_ref).join(&doc_path);
     let content = backend
-        .read_file(&relative_path)
+        .read_file_with_token(&relative_path, read_token.as_deref())
         .await
         .map_err(corpus_write_error("document"))?
         .ok_or((StatusCode::NOT_FOUND, "Document niet gevonden".to_string()))?;
@@ -3614,12 +3870,19 @@ pub async fn save_traject_document(
     let token_override =
         github_oauth::user_write_token_for_backend(&state, account.id, &headers, &**backend)
             .await?;
+    let read_token =
+        github_oauth::user_read_token_for_backend(&state, account.id, &headers, &**backend).await?;
     let relative_path = traject_documents_base(&traject_ref).join(&doc_path);
 
     let if_match = extract_if_match(&headers);
-    let existed_before = enforce_if_match(&**backend, &relative_path, if_match.as_deref())
-        .await?
-        .is_some();
+    let existed_before = enforce_if_match(
+        &**backend,
+        &relative_path,
+        if_match.as_deref(),
+        read_token.as_deref(),
+    )
+    .await?
+    .is_some();
 
     backend
         .write_file(&relative_path, &body)
@@ -3682,12 +3945,19 @@ pub async fn delete_traject_document(
     let token_override =
         github_oauth::user_write_token_for_backend(&state, account.id, &headers, &**backend)
             .await?;
+    let read_token =
+        github_oauth::user_read_token_for_backend(&state, account.id, &headers, &**backend).await?;
     let relative_path = traject_documents_base(&traject_ref).join(&doc_path);
 
     let if_match = extract_if_match(&headers);
-    let existed = enforce_if_match(&**backend, &relative_path, if_match.as_deref())
-        .await?
-        .is_some();
+    let existed = enforce_if_match(
+        &**backend,
+        &relative_path,
+        if_match.as_deref(),
+        read_token.as_deref(),
+    )
+    .await?
+    .is_some();
     if !existed {
         return Err((StatusCode::NOT_FOUND, "Document niet gevonden".to_string()));
     }
@@ -4103,7 +4373,7 @@ mod tests {
         let backend = StubBackend {
             body: Some("hello".to_string()),
         };
-        let etag = enforce_if_match(&backend, StdPath::new("x"), None)
+        let etag = enforce_if_match(&backend, StdPath::new("x"), None, None)
             .await
             .unwrap();
         assert_eq!(etag.as_deref(), Some(document_etag("hello").as_str()));
@@ -4112,7 +4382,7 @@ mod tests {
     #[tokio::test]
     async fn enforce_if_match_returns_none_when_file_absent_and_no_precondition() {
         let backend = StubBackend { body: None };
-        let etag = enforce_if_match(&backend, StdPath::new("x"), None)
+        let etag = enforce_if_match(&backend, StdPath::new("x"), None, None)
             .await
             .unwrap();
         assert!(etag.is_none());
@@ -4123,7 +4393,7 @@ mod tests {
         let backend = StubBackend {
             body: Some("hello".to_string()),
         };
-        let err = enforce_if_match(&backend, StdPath::new("x"), Some("\"stale\""))
+        let err = enforce_if_match(&backend, StdPath::new("x"), Some("\"stale\""), None)
             .await
             .expect_err("must refuse stale etag");
         assert_eq!(err.0, StatusCode::PRECONDITION_FAILED);
@@ -4135,7 +4405,7 @@ mod tests {
             body: Some("hello".to_string()),
         };
         let etag = document_etag("hello");
-        let returned = enforce_if_match(&backend, StdPath::new("x"), Some(&etag))
+        let returned = enforce_if_match(&backend, StdPath::new("x"), Some(&etag), None)
             .await
             .unwrap();
         assert_eq!(returned.as_deref(), Some(etag.as_str()));
@@ -4146,7 +4416,7 @@ mod tests {
         // `If-Match: *` semantically means "match any existing version".
         // Against a file that doesn't exist yet, the precondition fails.
         let backend = StubBackend { body: None };
-        let err = enforce_if_match(&backend, StdPath::new("x"), Some("*"))
+        let err = enforce_if_match(&backend, StdPath::new("x"), Some("*"), None)
             .await
             .expect_err("must refuse `*` against missing file");
         assert_eq!(err.0, StatusCode::PRECONDITION_FAILED);
@@ -4157,7 +4427,7 @@ mod tests {
         let backend = StubBackend {
             body: Some("anything".to_string()),
         };
-        let returned = enforce_if_match(&backend, StdPath::new("x"), Some("*"))
+        let returned = enforce_if_match(&backend, StdPath::new("x"), Some("*"), None)
             .await
             .unwrap();
         assert_eq!(

--- a/packages/editor-api/src/github_oauth.rs
+++ b/packages/editor-api/src/github_oauth.rs
@@ -938,6 +938,28 @@ pub async fn user_write_token(
     account_id: Uuid,
     headers: &HeaderMap,
 ) -> Result<Option<String>, (StatusCode, String)> {
+    user_token_when_required(
+        state,
+        account_id,
+        headers,
+        "Je GitHub-koppeling is verlopen. Koppel je account opnieuw om op te slaan.",
+        "Koppel je GitHub-account om in dit traject op te slaan. \
+         De wijziging wordt met jouw eigen GitHub-toegang weggeschreven.",
+    )
+    .await
+}
+
+/// Shared core of [`user_write_token`] and [`user_read_token_for_backend`]:
+/// the requiredness gate, the cookie resolution, and the 428 semantics —
+/// parameterised only in the user-facing messages so the read path can say
+/// "lezen" where the write path says "opslaan".
+async fn user_token_when_required(
+    state: &AppState,
+    account_id: Uuid,
+    headers: &HeaderMap,
+    expired_msg: &str,
+    missing_msg: &str,
+) -> Result<Option<String>, (StatusCode, String)> {
     let Some(oauth) = state.config.github_oauth.as_ref() else {
         return Ok(None);
     };
@@ -964,21 +986,12 @@ pub async fn user_write_token(
         Some(link) if !link.expired() => {
             tracing::debug!(
                 github_login = %link.github_login,
-                "authorizing traject write as the linked GitHub user"
+                "authorizing traject access as the linked GitHub user"
             );
             Ok(Some(link.access_token))
         }
-        Some(_expired) => Err((
-            StatusCode::PRECONDITION_REQUIRED,
-            "Je GitHub-koppeling is verlopen. Koppel je account opnieuw om op te slaan."
-                .to_string(),
-        )),
-        None => Err((
-            StatusCode::PRECONDITION_REQUIRED,
-            "Koppel je GitHub-account om in dit traject op te slaan. \
-             De wijziging wordt met jouw eigen GitHub-toegang weggeschreven."
-                .to_string(),
-        )),
+        Some(_expired) => Err((StatusCode::PRECONDITION_REQUIRED, expired_msg.to_string())),
+        None => Err((StatusCode::PRECONDITION_REQUIRED, missing_msg.to_string())),
     }
 }
 
@@ -1001,6 +1014,54 @@ pub async fn user_write_token_for_backend(
         return Ok(None);
     }
     user_write_token(state, account_id, headers).await
+}
+
+/// The read-path analogue of [`user_write_token_for_backend`]: resolve the
+/// per-user GitHub credential for a **read** on `backend`.
+///
+/// Narrower than the write path in one deliberate way: a backend that has
+/// its own configured (service) token keeps reading with it — `Ok(None)`,
+/// behaviour unchanged — even in the user-token write mode. The write path
+/// overrides an existing service token to make the *commit* authenticate as
+/// the user; a read has no attribution concern, and rerouting working
+/// service-token reads through personal tokens would break members without
+/// direct repo access.
+///
+/// So the outcomes are:
+///
+/// * backend ignores token overrides (local source, clone-based git) →
+///   `Ok(None)`;
+/// * backend has a service token → `Ok(None)` (read uses it, as before);
+/// * backend is token-less and override-capable (the traject writable-own
+///   Contents-API backend on a user-chosen repo) → the user's own token,
+///   or the same 428 connect-flow the write path uses when the user hasn't
+///   linked GitHub. Without the user-token mode enabled this stays
+///   `Ok(None)` — the pre-existing (silently degrading) behaviour, exactly
+///   like writes stay on the service-token path there.
+pub async fn user_read_token_for_backend(
+    state: &AppState,
+    account_id: Uuid,
+    headers: &HeaderMap,
+    backend: &dyn RepoBackend,
+) -> Result<Option<String>, (StatusCode, String)> {
+    if !backend.supports_token_override() {
+        return Ok(None);
+    }
+    // `is_writable` on the Contents-API backend means "has a configured
+    // rest token" — the one backend kind that reaches this point.
+    if backend.is_writable() {
+        return Ok(None);
+    }
+    user_token_when_required(
+        state,
+        account_id,
+        headers,
+        "Je GitHub-koppeling is verlopen. Koppel je account opnieuw om de \
+         inhoud van dit traject te kunnen lezen.",
+        "Koppel je GitHub-account om de inhoud van dit traject te kunnen \
+         lezen. De traject-repo wordt met jouw eigen GitHub-toegang gelezen.",
+    )
+    .await
 }
 
 // --- GitHub HTTP calls -----------------------------------------------------

--- a/packages/editor-api/src/task_requests.rs
+++ b/packages/editor-api/src/task_requests.rs
@@ -46,6 +46,7 @@ pub async fn request_enrich(
     session: Session,
     Extension(account): Extension<AccountRecord>,
     Path((traject_ref, law_id)): Path<(String, String)>,
+    headers: axum::http::HeaderMap,
 ) -> Result<(StatusCode, Json<EnrichRequestResponse>), (StatusCode, String)> {
     let pool = state.pool.as_ref().ok_or((
         StatusCode::SERVICE_UNAVAILABLE,
@@ -57,8 +58,10 @@ pub async fn request_enrich(
     let traject = require_traject_corpus_from_ref(&state, &session, &traject_ref).await?;
     let traject_id = resolve_traject_ref(pool, &traject_ref).await?;
 
-    // Snapshot de wet zoals de gebruiker hem nu ziet (traject-scope).
-    let scope = ReadScope::Traject(traject);
+    // Snapshot de wet zoals de gebruiker hem nu ziet (traject-scope),
+    // inclusief het per-request leestoken voor de writable-own source —
+    // zonder service-token leest de wet-body anders via de seed of 404't.
+    let scope = ReadScope::for_traject(&state, account.id, &headers, traject).await;
     let yaml = read_law_yaml(&scope, &law_id).await?;
     if yaml.len() > MAX_INPUT_BYTES {
         return Err((

--- a/packages/editor-api/src/traject_corpus.rs
+++ b/packages/editor-api/src/traject_corpus.rs
@@ -371,6 +371,21 @@ impl TrajectCorpus {
         &self,
         law_id: &str,
     ) -> Result<Option<String>, regelrecht_corpus::error::CorpusError> {
+        self.law_yaml_with_read_token(law_id, None).await
+    }
+
+    /// [`Self::law_yaml`] with a per-request read token for the
+    /// **writable-own** source (the acting user's own GitHub token,
+    /// resolved by the request handler). The token is applied *only* when
+    /// the law's body resolves from the writable-own source — seed sources
+    /// never see it — and it is passed through per call, never stored on
+    /// this (shared, cross-user) structure. Cached *content* is fine: every
+    /// traject route runs a membership check before reaching this.
+    pub async fn law_yaml_with_read_token(
+        &self,
+        law_id: &str,
+        own_read_token: Option<&str>,
+    ) -> Result<Option<String>, regelrecht_corpus::error::CorpusError> {
         if let Some(text) = self.overlay.read().await.get(law_id) {
             return Ok(Some(text.clone()));
         }
@@ -396,11 +411,16 @@ impl TrajectCorpus {
             return Ok(None);
         };
 
+        // The personal token authenticates exclusively against the
+        // traject's own repo; a seed read must never carry it.
+        let token = (source_id == self.writable_own_source_id)
+            .then_some(own_read_token)
+            .flatten();
         let content = {
             let backend = entry.backend.lock().await;
             // `?` propagates a read error rather than collapsing it to None.
             backend
-                .read_file(std::path::Path::new(&relative_path))
+                .read_file_with_token(std::path::Path::new(&relative_path), token)
                 .await?
         };
         let Some(content) = content else {
@@ -436,9 +456,15 @@ impl TrajectCorpus {
     /// versions are served from the index body (local sources) or lazily fetched
     /// via their own backend + `relative_path` (GitHub sources). Returns an empty
     /// vec when no version of the id is indexed.
-    pub async fn law_yaml_versions(
+    ///
+    /// Accepts the per-request writable-own read token — same contract as
+    /// [`Self::law_yaml_with_read_token`]: the token is only ever applied
+    /// to versions whose source is the writable-own, per call, never
+    /// stored. Pass `None` outside a user-request context.
+    pub async fn law_yaml_versions_with_read_token(
         &self,
         law_id: &str,
+        own_read_token: Option<&str>,
     ) -> Result<Vec<String>, regelrecht_corpus::error::CorpusError> {
         // Snapshot the per-version index metadata, then drop the borrow before
         // any await below.
@@ -500,10 +526,15 @@ impl TrajectCorpus {
             // per-version `loadLawVersions` isolation. A law that ends up with no
             // fetchable version surfaces to the loader as a missing dependency
             // (retried on the next run), not a hard 502.
+            // Personal token only for the writable-own source, like
+            // `law_yaml_with_read_token`.
+            let token = (source_id == self.writable_own_source_id)
+                .then_some(own_read_token)
+                .flatten();
             let content = {
                 let backend = entry.backend.lock().await;
                 match backend
-                    .read_file(std::path::Path::new(&relative_path))
+                    .read_file_with_token(std::path::Path::new(&relative_path), token)
                     .await
                 {
                     Ok(content) => content,
@@ -2169,6 +2200,126 @@ mod tests {
         assert_eq!(
             corpus.law_yaml("wet_a").await.unwrap().as_deref(),
             Some("$id: wet_a\nname: saved\n")
+        );
+    }
+
+    /// Backend gedraagt zich als een privé repo achter de Contents-API:
+    /// zonder het verwachte per-call token leest elke file als 404
+    /// (`Ok(None)`). Met `required_token: None` modelleert hij een
+    /// seed-backend die het persoonlijke token nooit mag ontvangen.
+    struct TokenGatedBackend {
+        files: HashMap<String, String>,
+        required_token: Option<String>,
+    }
+
+    #[async_trait]
+    impl RepoBackend for TokenGatedBackend {
+        async fn read_file(&self, path: &Path) -> CorpusResult<Option<String>> {
+            self.read_file_with_token(path, None).await
+        }
+        async fn read_file_with_token(
+            &self,
+            path: &Path,
+            token: Option<&str>,
+        ) -> CorpusResult<Option<String>> {
+            match &self.required_token {
+                // Privé repo: alleen het juiste token leest; anders 404.
+                Some(required) if token != Some(required.as_str()) => return Ok(None),
+                Some(_) => {}
+                // Seed-bron: het persoonlijke token mag hier nooit landen.
+                None => assert!(
+                    token.is_none(),
+                    "seed backend must never receive the personal read token"
+                ),
+            }
+            Ok(self.files.get(path.to_str().unwrap()).cloned())
+        }
+        async fn write_file(&self, _: &Path, _: &str) -> CorpusResult<()> {
+            Ok(())
+        }
+        async fn delete_file(&self, _: &Path) -> CorpusResult<()> {
+            Ok(())
+        }
+        async fn list_files(&self, _: &Path, _: Option<&str>) -> CorpusResult<Vec<FileEntry>> {
+            Ok(Vec::new())
+        }
+        async fn persist(&self, _: &CorpusWriteContext) -> CorpusResult<PersistOutcome> {
+            Ok(PersistOutcome::default())
+        }
+        async fn ensure_ready(&mut self) -> CorpusResult<()> {
+            Ok(())
+        }
+        fn supports_token_override(&self) -> bool {
+            true
+        }
+        fn is_writable(&self) -> bool {
+            false
+        }
+    }
+
+    #[tokio::test]
+    async fn law_yaml_forwards_the_read_token_only_to_the_writable_own_source() {
+        let mut map = SourceMap::new();
+        metadata_entry(&mut map, "wet_eigen", "own");
+        metadata_entry(&mut map, "wet_seed", "seed");
+        let backends = HashMap::from([
+            (
+                "own".to_string(),
+                BackendEntry {
+                    backend: Arc::new(Mutex::new(Box::new(TokenGatedBackend {
+                        files: HashMap::from([(
+                            "wet/wet_eigen/2025-01-01.yaml".to_string(),
+                            "$id: wet_eigen\n".to_string(),
+                        )]),
+                        required_token: Some("user-token".to_string()),
+                    }) as Box<dyn RepoBackend>)),
+                    writable: false,
+                },
+            ),
+            (
+                "seed".to_string(),
+                BackendEntry {
+                    backend: Arc::new(Mutex::new(Box::new(TokenGatedBackend {
+                        files: HashMap::from([(
+                            "wet/wet_seed/2025-01-01.yaml".to_string(),
+                            "$id: wet_seed\n".to_string(),
+                        )]),
+                        required_token: None,
+                    }) as Box<dyn RepoBackend>)),
+                    writable: false,
+                },
+            ),
+        ]);
+        let corpus = test_corpus(map, backends);
+
+        // Zonder token blijft de privé writable-own onleesbaar (GitHub's 404
+        // → `Ok(None)`), en er wordt níets negatiefs gecachet…
+        assert_eq!(
+            corpus
+                .law_yaml_with_read_token("wet_eigen", None)
+                .await
+                .unwrap(),
+            None
+        );
+        // …met het per-request token leest dezelfde wet wél.
+        assert_eq!(
+            corpus
+                .law_yaml_with_read_token("wet_eigen", Some("user-token"))
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("$id: wet_eigen\n")
+        );
+
+        // Een seed-read binnen dezelfde request geeft het token NIET door
+        // (de assert in de stub bewaakt dat) en slaagt gewoon.
+        assert_eq!(
+            corpus
+                .law_yaml_with_read_token("wet_seed", Some("user-token"))
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("$id: wet_seed\n")
         );
     }
 

--- a/packages/editor-api/tests/list_scenarios_test.rs
+++ b/packages/editor-api/tests/list_scenarios_test.rs
@@ -8,7 +8,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use axum::extract::{Path, State};
+use axum::extract::{Extension, Path, State};
 use sqlx::PgPool;
 use tokio::sync::{Mutex, RwLock};
 use tower_sessions::Session;
@@ -16,6 +16,7 @@ use tower_sessions_memory_store::MemoryStore;
 use uuid::Uuid;
 
 use regelrecht_auth::handlers::SESSION_KEY_SUB;
+use regelrecht_editor_api::accounts::AccountRecord;
 use regelrecht_editor_api::config::AppConfig;
 use regelrecht_editor_api::corpus_handlers::{list_scenarios, list_traject_scenarios};
 use regelrecht_editor_api::state::{AppState, BackendEntry, CorpusState};
@@ -161,10 +162,18 @@ async fn list_traject_scenarios_returns_target_law_ids() {
     write_corpus(corpus.path());
     let traject = local_traject(&db.pool, owner, corpus.path()).await;
 
+    let account = AccountRecord {
+        id: owner,
+        person_sub: sub.clone(),
+        email: "alice@test.local".to_string(),
+        name: "Test User".to_string(),
+    };
     let axum::Json(entries) = list_traject_scenarios(
         State(state),
+        Extension(account),
         session_for(&sub).await,
         Path((traject_ref(traject), LAW_ID.to_string())),
+        axum::http::HeaderMap::new(),
     )
     .await
     .expect("list_traject_scenarios must succeed");

--- a/packages/editor-api/tests/save_annotations_test.rs
+++ b/packages/editor-api/tests/save_annotations_test.rs
@@ -350,6 +350,7 @@ async fn read_annotations(state: AppState, account: &AccountRecord, traject_id: 
         session,
         Extension(account.clone()),
         Path((traject_ref(traject_id), LAW_ID.to_string())),
+        HeaderMap::new(),
     )
     .await
     .expect("get_traject_annotations must succeed");
@@ -403,6 +404,7 @@ async fn missing_sidecar_returns_404() {
         session,
         Extension(account.clone()),
         Path((traject_ref(traject_id), LAW_ID.to_string())),
+        HeaderMap::new(),
     )
     .await
     .expect_err("no sidecar yet, expect 404");
@@ -591,6 +593,7 @@ async fn cross_traject_isolation_on_reads() {
         session,
         Extension(account.clone()),
         Path((traject_ref(traject_b), LAW_ID.to_string())),
+        HeaderMap::new(),
     )
     .await
     .expect_err("traject B must not see traject A's notes");

--- a/packages/editor-api/tests/traject_own_index_test.rs
+++ b/packages/editor-api/tests/traject_own_index_test.rs
@@ -327,9 +327,11 @@ async fn traject_index_shows_promoted_law_and_surfaces_failed_own_scans() {
     // gerapporteerde prod-gedrag — gereproduceerd zonder GitHub-token.
     let laws = list_traject_corpus_laws(
         State(state.clone()),
+        Extension(account.clone()),
         session_for(&sub).await,
         Path(tref_a.clone()),
         ids_query(),
+        HeaderMap::new(),
     )
     .await
     .expect("laws-listing moet slagen");
@@ -343,8 +345,10 @@ async fn traject_index_shows_promoted_law_and_surfaces_failed_own_scans() {
     // Niet langer stil: /sources meldt per source waaróm de scan faalde.
     let sources = list_traject_sources(
         State(state.clone()),
+        Extension(account.clone()),
         session_for(&sub).await,
         Path(tref_a.clone()),
+        HeaderMap::new(),
     )
     .await
     .expect("sources-listing moet slagen");
@@ -402,9 +406,11 @@ async fn traject_index_shows_promoted_law_and_surfaces_failed_own_scans() {
 
     let laws = list_traject_corpus_laws(
         State(state.clone()),
+        Extension(account.clone()),
         session_for(&sub).await,
         Path(tref_b.clone()),
         ids_query(),
+        HeaderMap::new(),
     )
     .await
     .expect("laws-listing moet slagen");
@@ -420,8 +426,10 @@ async fn traject_index_shows_promoted_law_and_surfaces_failed_own_scans() {
 
     let sources = list_traject_sources(
         State(state.clone()),
+        Extension(account.clone()),
         session_for(&sub).await,
         Path(tref_b.clone()),
+        HeaderMap::new(),
     )
     .await
     .expect("sources-listing moet slagen");

--- a/packages/editor-api/tests/traject_reads_test.rs
+++ b/packages/editor-api/tests/traject_reads_test.rs
@@ -168,8 +168,10 @@ fn if_match_headers(etag: &str) -> HeaderMap {
 async fn read_law(state: AppState, session: Session, tref: &str) -> (String, String) {
     let (status, headers, body) = get_traject_corpus_law(
         State(state),
+        Extension(test_account()),
         session,
         Path((tref.to_string(), LAW_ID.to_string())),
+        HeaderMap::new(),
     )
     .await
     .expect("get_traject_corpus_law must succeed");
@@ -228,8 +230,10 @@ async fn read_scenario(
 ) -> (String, String) {
     let (status, headers, body) = get_traject_scenario(
         State(state),
+        Extension(test_account()),
         session,
         Path((tref.to_string(), LAW_ID.to_string(), filename.to_string())),
+        HeaderMap::new(),
     )
     .await
     .expect("scenario GET must succeed");
@@ -428,6 +432,7 @@ async fn ttl_refresh_picks_up_upstream_laws_and_reconciles_saves() {
     for _ in 0..50 {
         let Json(entries) = list_traject_corpus_laws(
             State(state.clone()),
+            Extension(test_account()),
             session_for(&sub).await,
             Path(tref.clone()),
             Query(PaginationParams {
@@ -436,6 +441,7 @@ async fn ttl_refresh_picks_up_upstream_laws_and_reconciles_saves() {
                 q: None,
                 ids: None,
             }),
+            HeaderMap::new(),
         )
         .await
         .expect("law list must succeed");
@@ -507,8 +513,10 @@ async fn revoked_membership_is_403_on_traject_read() {
 
     let err = get_traject_corpus_law(
         State(state),
+        Extension(test_account()),
         session_for(&sub).await,
         Path((traject_ref(traject_id), LAW_ID.to_string())),
+        HeaderMap::new(),
     )
     .await
     .expect_err("revoked membership must refuse the traject read");
@@ -920,8 +928,10 @@ async fn scenario_list_unions_write_target_and_seed() {
 
     let Json(entries) = list_traject_scenarios(
         State(state),
+        Extension(test_account()),
         session_for(&sub).await,
         Path((tref, LAW_ID.to_string())),
+        HeaderMap::new(),
     )
     .await
     .expect("list must succeed");

--- a/packages/editor-api/tests/traject_user_token_reads_test.rs
+++ b/packages/editor-api/tests/traject_user_token_reads_test.rs
@@ -1,0 +1,480 @@
+//! Request-gebonden reads op de writable-own source met het persoonlijke
+//! GitHub-token van de ingelogde gebruiker (ticket: reads gebruiken het
+//! user-token wanneer het server-token ontbreekt — het leespad-vervolg op
+//! de user-token-schrijfflow van #952/#953).
+//!
+//! Deployed-achtige federatie-config, zoals `promote_user_token_write_test`:
+//! een GitHub-backed **writable-own zonder geconfigureerd service-token**
+//! (privé user-gekozen repo, fail-closed) plus een lokale seed als centraal
+//! corpus, met de user-token-modus aan. Vóór de fix degradeerden alle reads
+//! op die source stil (lege documentenlijst, 404 op documenten, seed-versies
+//! van traject-bestanden); nu:
+//!
+//! * **mét** gekoppeld GitHub-account leest elke request-gebonden read de
+//!   traject-repo met het user-token (documenten, scenario's, wet-bodies);
+//! * **zónder** gekoppeld account falen precies die reads luid met 428 (de
+//!   koppel-flow), terwijl reads die de writable-own niet raken (seed-wetten,
+//!   de wettenlijst) gewoon blijven werken.
+//!
+//! GitHub wordt gespeeld door wiremock via de proces-brede
+//! `GITHUB_API_BASE`-seam — daarom staan alle scenario's in ÉÉN test
+//! (zelfde afweging als `promote_user_token_write_test.rs`). De indexscan
+//! (Trees API) is hier bewust wél leesbaar zonder token: het ticket
+//! repareert de request-gebonden reads, niet de scan — de fixture zet dus
+//! een gevulde index neer en laat alleen de Contents-reads authenticatie
+//! eisen.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::Arc;
+
+use axum::extract::{Extension, Path, Query, State};
+use axum::http::{HeaderMap, StatusCode};
+use base64::Engine as _;
+use pretty_assertions::assert_eq;
+use sqlx::PgPool;
+use tokio::sync::{Mutex, RwLock};
+use tower_sessions::Session;
+use tower_sessions_memory_store::MemoryStore;
+use uuid::Uuid;
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use regelrecht_auth::handlers::{
+    SESSION_KEY_EMAIL, SESSION_KEY_EMAIL_VERIFIED, SESSION_KEY_NAME, SESSION_KEY_SUB,
+};
+use regelrecht_corpus::dto::PaginationParams;
+use regelrecht_editor_api::accounts::AccountRecord;
+use regelrecht_editor_api::config::AppConfig;
+use regelrecht_editor_api::corpus_handlers::{
+    get_traject_corpus_law, get_traject_document, get_traject_scenario, list_traject_corpus_laws,
+    list_traject_documents,
+};
+use regelrecht_editor_api::github_oauth::{self, GithubOAuth};
+use regelrecht_editor_api::state::{AppState, CorpusState};
+use regelrecht_editor_api::traject_corpus::TrajectCorpusCache;
+
+use regelrecht_pipeline::test_utils::TestDb;
+
+const SEED_LAW_ID: &str = "wet_voorbeeld_seed";
+const OWN_LAW_ID: &str = "wet_voorbeeld_traject";
+const OWN_REPO: &str = "example-org/example-traject-repo";
+const OWN_BRANCH: &str = "traject-voorbeeld";
+const OWN_SUBPATH: &str = "corpus/regulation";
+const USER_TOKEN: &str = "user-token";
+
+const OWN_LAW_BODY: &str = "$id: wet_voorbeeld_traject\nname: TRAJECT_REPO_VERSIE\n";
+const BRANCH_SCENARIO: &str = "Feature: traject-versie\n";
+const DOCUMENT_BODY: &str = "# Notitie\n";
+
+fn state_with_user_token_mode(pool: PgPool, oauth: GithubOAuth) -> AppState {
+    AppState {
+        corpus: Arc::new(RwLock::new(CorpusState::empty())),
+        oidc_client: None,
+        end_session_url: None,
+        config: Arc::new(AppConfig {
+            oidc: None,
+            base_url: None,
+            github_oauth: Some(oauth),
+            task_enrich_provider: "claude".to_string(),
+        }),
+        http_client: reqwest::Client::new(),
+        pool: Some(pool),
+        pipeline_api_url: None,
+        harvest_admin_url: None,
+        reload_lock: Arc::new(Mutex::new(())),
+        trajects: Arc::new(TrajectCorpusCache::new()),
+    }
+}
+
+async fn seed_account(pool: &PgPool, email: &str) -> (Uuid, String) {
+    let sub = format!("sub-{email}");
+    let (id,): (Uuid,) = sqlx::query_as(
+        "INSERT INTO accounts (person_sub, email, name) VALUES ($1, $2, $3) RETURNING id",
+    )
+    .bind(&sub)
+    .bind(email)
+    .bind("Test User")
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    (id, sub)
+}
+
+/// Traject zoals deployed: GitHub writable-own op een user-gekozen repo
+/// (auth_ref zonder geconfigureerd `CORPUS_AUTH_*_TOKEN`-env → server-side
+/// géén token) plus een lokale read-seed die het centrale corpus speelt.
+async fn seeded_traject(pool: &PgPool, owner_id: Uuid, seed_dir: &std::path::Path) -> Uuid {
+    let (traject_id,): (Uuid,) = sqlx::query_as(
+        "INSERT INTO trajects (name, description, scope, created_by)
+         VALUES ('Test', '', '', $1) RETURNING id",
+    )
+    .bind(owner_id)
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO traject_members (traject_id, account_id, role)
+         VALUES ($1, $2, 'owner')",
+    )
+    .bind(traject_id)
+    .bind(owner_id)
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO traject_corpus_sources
+         (traject_id, source_id, name, source_type,
+          gh_owner, gh_repo, gh_branch, gh_base_branch, gh_path,
+          priority, auth_ref, is_writable_own)
+         VALUES ($1, 'traject-own-test', 'Eigen repo', 'github'::corpus_source_type,
+                 'example-org', 'example-traject-repo', $2, 'main', $3,
+                 0, 'example-unset-token-ref', TRUE)",
+    )
+    .bind(traject_id)
+    .bind(OWN_BRANCH)
+    .bind(OWN_SUBPATH)
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO traject_corpus_sources
+         (traject_id, source_id, name, source_type, local_path,
+          priority, scopes, is_writable_own)
+         VALUES ($1, 'central-seed', 'Centrale Corpus', 'local'::corpus_source_type, $2,
+                 2, '[]'::jsonb, FALSE)",
+    )
+    .bind(traject_id)
+    .bind(seed_dir.to_string_lossy().to_string())
+    .execute(pool)
+    .await
+    .unwrap();
+    traject_id
+}
+
+fn traject_ref(traject_id: Uuid) -> String {
+    format!("test-{}", &traject_id.to_string()[..8])
+}
+
+async fn session_for(sub: &str) -> Session {
+    let session = Session::new(None, Arc::new(MemoryStore::default()), None);
+    session.insert(SESSION_KEY_SUB, sub).await.unwrap();
+    session.insert(SESSION_KEY_NAME, "Test User").await.unwrap();
+    session
+        .insert(SESSION_KEY_EMAIL, "alice@test.local")
+        .await
+        .unwrap();
+    session
+        .insert(SESSION_KEY_EMAIL_VERIFIED, true)
+        .await
+        .unwrap();
+    session
+}
+
+/// Seed-wet met een scenario in het "centrale corpus".
+fn write_seed_law(central_dir: &std::path::Path) {
+    let law_dir = central_dir.join("wet").join(SEED_LAW_ID);
+    std::fs::create_dir_all(law_dir.join("scenarios")).unwrap();
+    std::fs::write(
+        law_dir.join("2025-01-01.yaml"),
+        format!("$id: {SEED_LAW_ID}\nname: SEED_VERSIE\n"),
+    )
+    .unwrap();
+    std::fs::write(
+        law_dir.join("scenarios").join("basis.feature"),
+        "Feature: seed-versie\n",
+    )
+    .unwrap();
+}
+
+/// Contents-API-antwoord voor één bestand (base64, zoals GitHub het stuurt).
+fn contents_file_json(name: &str, api_path: &str, body: &str) -> serde_json::Value {
+    serde_json::json!({
+        "name": name,
+        "path": api_path,
+        "sha": format!("sha-{name}"),
+        "type": "file",
+        "content": base64::engine::general_purpose::STANDARD.encode(body),
+        "encoding": "base64",
+    })
+}
+
+/// Trees-listing van de traject-repo: de indexscan ziet de traject-eigen
+/// wet én het branch-scenario van de seed-wet. Bewust zonder auth-eis —
+/// de fixture isoleert het request-gebonden Contents-leespad.
+async fn mount_tree(server: &MockServer) {
+    Mock::given(method("GET"))
+        .and(path(format!("/repos/{OWN_REPO}/git/trees/{OWN_BRANCH}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "sha": "tree-sha",
+            "truncated": false,
+            "tree": [
+                {
+                    "path": format!("{OWN_SUBPATH}/wet/{OWN_LAW_ID}/2025-01-01.yaml"),
+                    "type": "blob",
+                    "sha": "blob-own-law",
+                },
+            ],
+        })))
+        .mount(server)
+        .await;
+}
+
+/// Contents-mocks die **alleen** met het user-token antwoorden; zonder
+/// `Authorization: Bearer user-token` valt elke request door naar
+/// wiremock's default 404 — precies wat GitHub op een privé-repo doet.
+async fn mount_authenticated_contents(server: &MockServer, tref: &str) {
+    // Wet-body van de traject-eigen wet.
+    let own_law_path = format!("{OWN_SUBPATH}/wet/{OWN_LAW_ID}/2025-01-01.yaml");
+    Mock::given(method("GET"))
+        .and(path(format!("/repos/{OWN_REPO}/contents/{own_law_path}")))
+        .and(header("authorization", format!("Bearer {USER_TOKEN}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(contents_file_json(
+            "2025-01-01.yaml",
+            &own_law_path,
+            OWN_LAW_BODY,
+        )))
+        .mount(server)
+        .await;
+
+    // Branch-kopie van het scenario van de seed-wet (write-target-routing:
+    // de branchversie hoort de seed-kopie te overrulen).
+    let scenario_path = format!("{OWN_SUBPATH}/wet/{SEED_LAW_ID}/scenarios/basis.feature");
+    Mock::given(method("GET"))
+        .and(path(format!("/repos/{OWN_REPO}/contents/{scenario_path}")))
+        .and(header("authorization", format!("Bearer {USER_TOKEN}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(contents_file_json(
+            "basis.feature",
+            &scenario_path,
+            BRANCH_SCENARIO,
+        )))
+        .mount(server)
+        .await;
+
+    // Documentenmap + één werkdocument.
+    let docs_dir = format!("{OWN_SUBPATH}/documents/{tref}");
+    Mock::given(method("GET"))
+        .and(path(format!("/repos/{OWN_REPO}/contents/{docs_dir}")))
+        .and(header("authorization", format!("Bearer {USER_TOKEN}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+            {
+                "name": "notitie.md",
+                "path": format!("{docs_dir}/notitie.md"),
+                "sha": "sha-notitie",
+                "type": "file",
+            },
+        ])))
+        .mount(server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/repos/{OWN_REPO}/contents/{docs_dir}/notitie.md"
+        )))
+        .and(header("authorization", format!("Bearer {USER_TOKEN}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(contents_file_json(
+            "notitie.md",
+            &format!("{docs_dir}/notitie.md"),
+            DOCUMENT_BODY,
+        )))
+        .mount(server)
+        .await;
+}
+
+fn all_query() -> Query<PaginationParams> {
+    Query(PaginationParams {
+        offset: 0,
+        limit: None,
+        q: None,
+        ids: None,
+    })
+}
+
+/// Eén test voor alle scenario's: de `GITHUB_API_BASE`-override is
+/// proces-breed, dus parallelle tests met elk een eigen mockserver zouden
+/// elkaars fetchers verhangen.
+#[tokio::test]
+async fn user_token_reads_serve_the_private_traject_repo_and_fail_loud_without_link() {
+    let server = MockServer::start().await;
+    std::env::set_var("GITHUB_API_BASE", server.uri());
+
+    let db = TestDb::new().await;
+    let central = tempfile::tempdir().unwrap();
+    write_seed_law(central.path());
+
+    let oauth = GithubOAuth::for_tests(true); // user-token-modus aan
+    let state = state_with_user_token_mode(db.pool.clone(), oauth.clone());
+
+    let (owner_id, sub) = seed_account(&db.pool, "alice@test.local").await;
+    let account = AccountRecord {
+        id: owner_id,
+        person_sub: sub.clone(),
+        email: "alice@test.local".to_string(),
+        name: "Test User".to_string(),
+    };
+    let traject_id = seeded_traject(&db.pool, owner_id, central.path()).await;
+    let tref = traject_ref(traject_id);
+
+    mount_tree(&server).await;
+    mount_authenticated_contents(&server, &tref).await;
+
+    let mut linked_headers = HeaderMap::new();
+    linked_headers.insert(
+        axum::http::header::COOKIE,
+        axum::http::HeaderValue::from_str(&github_oauth::seal_token_cookie_for_tests(
+            &oauth, account.id, USER_TOKEN,
+        ))
+        .unwrap(),
+    );
+
+    // ------------------------------------------------------------------
+    // Scenario 1: GEEN gekoppeld GitHub-account. Elke read die de
+    // writable-own source raakt faalt luid met 428 (de koppel-flow) —
+    // niet met een stille lege lijst of een generieke 404. Eerst, zodat
+    // geen enkele cache al met het token gevuld is.
+    // ------------------------------------------------------------------
+    let err = list_traject_documents(
+        State(state.clone()),
+        Extension(account.clone()),
+        session_for(&sub).await,
+        Path(tref.clone()),
+        HeaderMap::new(),
+    )
+    .await
+    .expect_err("documentenlijst zonder koppeling moet weigeren, niet leeg teruggeven");
+    assert_eq!(err.0, StatusCode::PRECONDITION_REQUIRED, "{}", err.1);
+
+    let err = get_traject_document(
+        State(state.clone()),
+        Extension(account.clone()),
+        session_for(&sub).await,
+        Path((tref.clone(), "notitie.md".to_string())),
+        HeaderMap::new(),
+    )
+    .await
+    .expect_err("document-GET zonder koppeling moet weigeren, niet 404'en");
+    assert_eq!(err.0, StatusCode::PRECONDITION_REQUIRED, "{}", err.1);
+
+    let err = get_traject_corpus_law(
+        State(state.clone()),
+        Extension(account.clone()),
+        session_for(&sub).await,
+        Path((tref.clone(), OWN_LAW_ID.to_string())),
+        HeaderMap::new(),
+    )
+    .await
+    .expect_err("wet-body uit de traject-repo zonder koppeling moet weigeren");
+    assert_eq!(err.0, StatusCode::PRECONDITION_REQUIRED, "{}", err.1);
+
+    let err = get_traject_scenario(
+        State(state.clone()),
+        Extension(account.clone()),
+        session_for(&sub).await,
+        Path((
+            tref.clone(),
+            SEED_LAW_ID.to_string(),
+            "basis.feature".to_string(),
+        )),
+        HeaderMap::new(),
+    )
+    .await
+    .expect_err("scenario-GET (write-target = traject-repo) zonder koppeling moet weigeren");
+    assert_eq!(err.0, StatusCode::PRECONDITION_REQUIRED, "{}", err.1);
+
+    // …maar reads die de writable-own NIET raken blijven werken: de
+    // seed-wet leest gewoon, en de wettenlijst (index-only) toont de
+    // traject-eigen wet.
+    let (status, _headers, body) = get_traject_corpus_law(
+        State(state.clone()),
+        Extension(account.clone()),
+        session_for(&sub).await,
+        Path((tref.clone(), SEED_LAW_ID.to_string())),
+        HeaderMap::new(),
+    )
+    .await
+    .expect("seed-wet moet zonder koppeling leesbaar blijven");
+    assert_eq!(status, StatusCode::OK);
+    assert!(body.contains("SEED_VERSIE"), "got: {body}");
+
+    let laws = list_traject_corpus_laws(
+        State(state.clone()),
+        Extension(account.clone()),
+        session_for(&sub).await,
+        Path(tref.clone()),
+        all_query(),
+        HeaderMap::new(),
+    )
+    .await
+    .expect("wettenlijst moet zonder koppeling blijven werken");
+    assert!(
+        laws.0.iter().any(|l| l.law_id == OWN_LAW_ID),
+        "traject-eigen wet moet in de index staan, got: {:?}",
+        laws.0.iter().map(|l| &l.law_id).collect::<Vec<_>>()
+    );
+
+    // ------------------------------------------------------------------
+    // Scenario 2: MET gekoppeld GitHub-account lezen alle drie de
+    // pad-groepen de traject-repo met het user-token.
+    // ------------------------------------------------------------------
+    let docs = list_traject_documents(
+        State(state.clone()),
+        Extension(account.clone()),
+        session_for(&sub).await,
+        Path(tref.clone()),
+        linked_headers.clone(),
+    )
+    .await
+    .expect("documentenlijst met koppeling moet slagen");
+    let paths: Vec<&str> = docs.0.documents.iter().map(|d| d.path.as_str()).collect();
+    assert_eq!(paths, vec!["notitie.md"]);
+
+    let response = get_traject_document(
+        State(state.clone()),
+        Extension(account.clone()),
+        session_for(&sub).await,
+        Path((tref.clone(), "notitie.md".to_string())),
+        linked_headers.clone(),
+    )
+    .await
+    .expect("document-GET met koppeling moet slagen");
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(String::from_utf8(bytes.to_vec()).unwrap(), DOCUMENT_BODY);
+
+    let (status, _headers, body) = get_traject_corpus_law(
+        State(state.clone()),
+        Extension(account.clone()),
+        session_for(&sub).await,
+        Path((tref.clone(), OWN_LAW_ID.to_string())),
+        linked_headers.clone(),
+    )
+    .await
+    .expect("wet-body uit de traject-repo met koppeling moet slagen");
+    assert_eq!(status, StatusCode::OK);
+    assert!(
+        body.contains("TRAJECT_REPO_VERSIE"),
+        "de body moet uit de traject-repo komen, got: {body}"
+    );
+
+    let (status, _headers, body) = get_traject_scenario(
+        State(state.clone()),
+        Extension(account.clone()),
+        session_for(&sub).await,
+        Path((
+            tref.clone(),
+            SEED_LAW_ID.to_string(),
+            "basis.feature".to_string(),
+        )),
+        linked_headers.clone(),
+    )
+    .await
+    .expect("scenario-GET met koppeling moet slagen");
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        body, BRANCH_SCENARIO,
+        "de branchversie (via user-token) moet de seed-kopie overrulen"
+    );
+
+    std::env::remove_var("GITHUB_API_BASE");
+}


### PR DESCRIPTION
## Wat

Request-gebonden reads op de **writable-own source** van een traject (werkdocumenten, scenario's, annotaties, wet-bodies en de If-Match-precondition-reads) gebruiken nu — net als het schrijfpad — het persoonlijke GitHub-OAuth-token van de ingelogde gebruiker wanneer er geen server-side `CORPUS_AUTH_*`-token voor die (privé) repo bestaat. Voorheen degradeerden die reads stil: lege documentenlijst, 404 op documenten, lege scenario's/annotaties en een wet-body die terugviel op de seed, terwijl writes via `user_write_token_for_backend` wél werkten (reproductie: het privé-traject uit ticket #6 / PR #953).

## Hoe

- **`RepoBackend`** krijgt read-varianten met per-call token-override (`read_file_with_token`, `list_files_with_token`, `list_files_recursive_with_token`). `GitHubApiBackend` implementeert ze als de leestegenhanger van `WriteContext::token_override`; alle andere backends negeren de override via de default-impl.
- **`github_oauth::user_read_token_for_backend`** spiegelt `user_write_token_for_backend` (incl. de `supports_token_override()`-check zodat local-stack/preview zonder GitHub niet onterecht 428't), met één bewust verschil: een geconfigureerd service-token gaat vóór — server-token aanwezig → gedrag ongewijzigd. Alleen op een token-loze, override-capabele backend in de user-token-modus wordt het persoonlijke token gebruikt.
- **`ReadScope`** draagt per request de token-resolutie voor de writable-own source. Het uitgestelde 428 vuurt uitsluitend bij reads die die source echt raken: seed-wetten, de wettenlijst en source-listings blijven werken zonder gekoppeld account. Het token wordt nooit opgeslagen in gedeelde structuren (`TrajectCorpus`, backend-cache, `body_cache`-keys) en nooit doorgegeven aan seed-backends; gecachte *content* blijft toegestaan omdat elke traject-route al een membership-check doet.
- **Luid falen:** ontbreekt óók het persoonlijke token (geen gekoppeld account), dan geven deze reads dezelfde 428-semantiek als het schrijfpad (de bestaande connect-flow van `apiAuthGuard.js`), niet een stil-lege lijst of generieke 404. Geen frontend-wijzigingen nodig.

## Bekende beperking (bewust buiten scope, zie ticket)

De **indexscan**, implements-scan en TTL-refresh draaien buiten een user-sessie en blijven op het server-token. Zonder server-token ziet de wet-**index** de writable-own source dus nog steeds niet: de wet-resolutie "traject boven centraal" vergt nog steeds een server-token (sinds #953 wél zichtbaar per source via `index_error`). Deze PR repareert de request-gebonden reads, niet de scan.

## Tests

- Unit-test `law_yaml_forwards_the_read_token_only_to_the_writable_own_source` (token-routing: alleen de writable-own backend ziet het token, de seed-backend nooit).
- Nieuwe wiremock-integratietest `traject_user_token_reads_test.rs` in de stijl van `promote_user_token_write_test.rs`: per pad-groep (documenten, scenario's, wet-bodies) (a) user-token laat de read slagen tegen de "privé" traject-repo en (b) zonder gekoppeld account volgt 428, terwijl seed-reads en de wettenlijst blijven werken.
- Bestaande suites groen: `just check`-recipes (format/lint/build-check/validate/tests) plus alle editor-api-integratietests (55 tests, incl. `traject_reads_test`, `save_annotations_test`, `traject_own_index_test`, `promote_user_token_write_test`).
