### PR TITLE
refactor(corpus): centraliseer server-token-resolutie in CredentialResolver met TokenDecision

### DIFF
--- a/packages/corpus/src/auth.rs
+++ b/packages/corpus/src/auth.rs
@@ -59,10 +59,22 @@ pub enum TokenOrigin {
 }
 
 /// Outcome of a token lookup: the token (if any) plus where it came from.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct TokenDecision {
     token: Option<String>,
     origin: TokenOrigin,
+}
+
+/// Redacts the token, like [`SourceAuth`]'s `Debug` — decisions are meant
+/// to be logged (that's the point of [`TokenOrigin`]), so a derived
+/// `Debug` would put the raw secret one `{:?}` away from the log output.
+impl std::fmt::Debug for TokenDecision {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TokenDecision")
+            .field("token", &self.token.as_ref().map(|_| "***"))
+            .field("origin", &self.origin)
+            .finish()
+    }
 }
 
 impl TokenDecision {

--- a/packages/corpus/src/auth.rs
+++ b/packages/corpus/src/auth.rs
@@ -40,86 +40,194 @@ impl std::fmt::Debug for SourceAuth {
     }
 }
 
-/// Look up a GitHub token for a source.
-///
-/// Uses `auth_ref` as the lookup key when provided, otherwise falls back
-/// to `source_id`. This matches the RFC-010 design where `auth_ref` in the
-/// manifest references an entry in the auth config.
-///
-/// Resolution order:
-/// 1. Environment variable `CORPUS_AUTH_{KEY}_TOKEN` (uppercased, hyphens → underscores)
-/// 2. `corpus-auth.yaml` file (if it exists)
-/// 3. Legacy shared `CORPUS_GIT_TOKEN` (harvester-era fallback)
-/// 4. None (unauthenticated, lower rate limits)
-///
-/// **Security**: the legacy fallback at step 3 returns the same token
-/// for *any* `auth_ref`, which makes it unsafe whenever the `auth_ref`
-/// is derived from user input (e.g. a user picking which repo a
-/// traject points at). Use [`resolve_token_strict`] there instead —
-/// it omits the legacy fallback so an unknown `auth_ref` cleanly
-/// returns `None` rather than leaking the central token to a
-/// user-chosen repo on the outgoing API call.
-pub fn resolve_token_for_source(
-    source_id: &str,
-    auth_ref: Option<&str>,
-    auth_file: Option<&Path>,
-) -> Result<Option<String>> {
-    let key = auth_ref.unwrap_or(source_id);
-    resolve_token(key, auth_file)
+/// Where a resolved server token came from. Makes the strict-vs-legacy
+/// outcome observable at every call-site: a `LegacyShared` origin on a
+/// path that should never see the shared token is a bug you can now
+/// assert on (and log), instead of an invisible property of *which*
+/// resolver function happened to be called.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TokenOrigin {
+    /// Per-source environment variable `CORPUS_AUTH_{KEY}_TOKEN`.
+    ServiceEnv,
+    /// Per-source entry in the `corpus-auth.yaml` auth file.
+    ServiceAuthFile,
+    /// Legacy shared `CORPUS_GIT_TOKEN` (harvester-era single token).
+    /// Never produced for strict lookups.
+    LegacyShared,
+    /// No token found — the request will go out unauthenticated.
+    None,
 }
 
-/// Resolve the token for a [`Source`](crate::models::Source), honouring its
-/// [`strict_auth`](crate::models::Source::strict_auth) flag: strict sources
-/// (user-supplied repo coordinates, e.g. a traject's writable-own repo) never
-/// fall back to the legacy shared `CORPUS_GIT_TOKEN`; regular manifest
-/// sources keep the legacy fallback for single-PAT deployments.
-///
-/// This is the one resolver every *source-driven* lookup should go through —
-/// scans, fetches and backend construction resolving through different rules
-/// is exactly how a promote-write can succeed while the subsequent index scan
-/// of the same repo silently fails.
-pub fn resolve_source_token(
-    source: &crate::models::Source,
-    auth_file: Option<&Path>,
-) -> Result<Option<String>> {
-    let key = source.auth_ref.as_deref().unwrap_or(&source.id);
-    if source.strict_auth {
-        resolve_token_strict(key, auth_file)
-    } else {
-        resolve_token(key, auth_file)
+/// Outcome of a token lookup: the token (if any) plus where it came from.
+#[derive(Debug, Clone)]
+pub struct TokenDecision {
+    token: Option<String>,
+    origin: TokenOrigin,
+}
+
+impl TokenDecision {
+    /// The resolved token, if any.
+    pub fn token(&self) -> Option<&str> {
+        self.token.as_deref()
+    }
+
+    /// Where the token came from ([`TokenOrigin::None`] when absent).
+    pub fn origin(&self) -> TokenOrigin {
+        self.origin
+    }
+
+    /// Consume the decision, keeping only the token. For call-sites that
+    /// feed the token straight into a backend and don't need the origin.
+    pub fn into_token(self) -> Option<String> {
+        self.token
     }
 }
 
-/// Like [`resolve_token_for_source`] but only consults the per-source
-/// env var and the auth file. Returns `None` when neither yields a
-/// token — the legacy `CORPUS_GIT_TOKEN` fallback is intentionally
-/// skipped.
+/// What to resolve a token *for*. Constructed via [`TokenContext::for_source`]
+/// (the canonical route — strictness comes from
+/// [`Source::strict_auth`](crate::models::Source::strict_auth)) or
+/// [`TokenContext::strict`] (for lookups keyed by user-derived input where no
+/// [`Source`](crate::models::Source) object exists yet, e.g. the
+/// create-traject preflight).
 ///
-/// Use this for any code path where the lookup key is derived from
-/// untrusted input. Today that's the writable-own source of a traject
-/// whose repo coordinates came from the create-request — without this
-/// guard, an attacker-controlled `auth_ref` would fall through to the
-/// shared `CORPUS_GIT_TOKEN` and ship it (via `Authorization: Bearer`)
-/// to a repo the attacker controls, a token-exfiltration vector.
-pub fn resolve_token_strict(auth_ref: &str, auth_file: Option<&Path>) -> Result<Option<String>> {
-    // 1. Per-source environment variable
-    let env_key = token_env_name(auth_ref);
-    if let Ok(token) = std::env::var(&env_key) {
-        if !token.is_empty() {
-            return Ok(Some(token));
+/// There is deliberately **no** constructor that requests the legacy
+/// `CORPUS_GIT_TOKEN` fallback for a bare key: the fallback is only
+/// reachable through a `Source` whose `strict_auth` is `false` (i.e. an
+/// operator-managed manifest source). A new call-site therefore cannot
+/// opt into the legacy fallback for a user-derived key by picking the
+/// "wrong" function — the exfiltration vector this module exists to close.
+#[derive(Debug, Clone, Copy)]
+pub struct TokenContext<'a> {
+    /// Lookup key: the source's `auth_ref` when set, else its id.
+    key: &'a str,
+    /// Strict lookups never fall back to the legacy shared token.
+    strict: bool,
+}
+
+impl<'a> TokenContext<'a> {
+    /// Context for a [`Source`](crate::models::Source): key is `auth_ref`
+    /// (falling back to the source id), strictness follows
+    /// [`strict_auth`](crate::models::Source::strict_auth).
+    pub fn for_source(source: &'a crate::models::Source) -> Self {
+        Self {
+            key: source.auth_ref.as_deref().unwrap_or(&source.id),
+            strict: source.strict_auth,
         }
     }
 
-    // 2. Auth file. We deliberately do NOT fall through to
-    // `CORPUS_GIT_TOKEN` afterwards — see `resolve_token` for the legacy
-    // fallback path.
-    find_in_auth_file(auth_ref, auth_file)
+    /// Strict context for a bare auth key derived from untrusted input
+    /// (e.g. repo coordinates from a create-traject request). Never falls
+    /// back to the legacy shared `CORPUS_GIT_TOKEN`: an unknown key cleanly
+    /// resolves to no token instead of shipping the central token (via
+    /// `Authorization: Bearer`) to a repo the requester controls.
+    pub fn strict(key: &'a str) -> Self {
+        Self { key, strict: true }
+    }
+
+    /// The env var an operator must set for this lookup to succeed via the
+    /// environment — for diagnostics.
+    pub fn env_name(&self) -> String {
+        token_env_name(self.key)
+    }
+}
+
+/// The one entry point for answering "which server token do we use for this
+/// source". All server-side GitHub credential lookups (backend construction,
+/// index scans, fetches, push preflights, worker writes) go through
+/// [`CredentialResolver::resolve`], so the strict-vs-legacy decision lives in
+/// exactly one place instead of being re-encoded per call-site.
+///
+/// Resolution order:
+/// 1. Per-source environment variable `CORPUS_AUTH_{KEY}_TOKEN`
+///    (uppercased, hyphens → underscores). Use this for multi-source
+///    setups that need isolation between source repos.
+/// 2. `corpus-auth.yaml` file (if it exists) — explicit per-source
+///    entries, same purpose as (1) but file-backed.
+/// 3. **Non-strict contexts only:** legacy shared `CORPUS_GIT_TOKEN`. The
+///    harvester era used this single global token for one upstream repo.
+///    We accept it as a fallback so deployments that still set only the
+///    legacy variable keep working for *every* manifest GitHub source
+///    without duplicating the secret under each per-source name.
+///    Per-source vars/file entries above still win. Strict contexts skip
+///    this step entirely — see [`TokenContext::strict`] for why.
+/// 4. No token (unauthenticated, lower rate limits).
+///
+/// This layer knows nothing about sessions, user OAuth, or HTTP status
+/// codes; user-token fallbacks live in the editor-api on top of the
+/// [`TokenDecision`] this returns.
+#[derive(Debug, Clone, Copy)]
+pub struct CredentialResolver<'a> {
+    auth_file: Option<&'a Path>,
+}
+
+impl<'a> CredentialResolver<'a> {
+    /// Build a resolver that consults the given `corpus-auth.yaml` (if any)
+    /// as its file-backed lookup step.
+    pub fn new(auth_file: Option<&'a Path>) -> Self {
+        Self { auth_file }
+    }
+
+    /// Resolve a token for the given context. See the type-level docs for
+    /// the resolution order.
+    pub fn resolve(&self, ctx: TokenContext<'_>) -> Result<TokenDecision> {
+        // 1. Per-source environment variable
+        if let Some(token) = non_empty_env(&token_env_name(ctx.key)) {
+            return Ok(TokenDecision {
+                token: Some(token),
+                origin: TokenOrigin::ServiceEnv,
+            });
+        }
+
+        // 2. Auth file
+        if let Some(token) = find_in_auth_file(ctx.key, self.auth_file)? {
+            return Ok(TokenDecision {
+                token: Some(token),
+                origin: TokenOrigin::ServiceAuthFile,
+            });
+        }
+
+        // 3. Legacy shared CORPUS_GIT_TOKEN — never for strict contexts:
+        // a strict key derives from user input, and falling through here
+        // would ship the central token to a user-chosen repo.
+        if !ctx.strict {
+            if let Some(token) = non_empty_env("CORPUS_GIT_TOKEN") {
+                return Ok(TokenDecision {
+                    token: Some(token),
+                    origin: TokenOrigin::LegacyShared,
+                });
+            }
+        }
+
+        // 4. No token
+        Ok(TokenDecision {
+            token: None,
+            origin: TokenOrigin::None,
+        })
+    }
+
+    /// Convenience for the common source-driven lookup:
+    /// `resolve(TokenContext::for_source(source))`. Every scan, fetch and
+    /// backend construction for a [`Source`](crate::models::Source) should
+    /// go through here — scans, fetches and backend construction resolving
+    /// through different rules is exactly how a promote-write can succeed
+    /// while the subsequent index scan of the same repo silently fails.
+    pub fn resolve_source(&self, source: &crate::models::Source) -> Result<TokenDecision> {
+        self.resolve(TokenContext::for_source(source))
+    }
+}
+
+/// Read an env var, treating "unset" and "set but empty" the same way
+/// (empty tokens would send a bogus `Authorization` header downstream).
+fn non_empty_env(key: &str) -> Option<String> {
+    match std::env::var(key) {
+        Ok(v) if !v.is_empty() => Some(v),
+        _ => None,
+    }
 }
 
 /// Read the auth file (if any) and look up `auth_ref` in it. Returns
-/// `None` when the file is absent or the ref isn't listed. Shared
-/// between [`resolve_token`] and [`resolve_token_strict`] so both
-/// parsers stay in lock-step — a future change to the auth-file shape
+/// `None` when the file is absent or the ref isn't listed. The single
+/// parser for the auth-file shape — a future change to the file format
 /// only needs to land here.
 fn find_in_auth_file(auth_ref: &str, auth_file: Option<&Path>) -> Result<Option<String>> {
     let Some(path) = auth_file else {
@@ -149,46 +257,6 @@ fn find_in_auth_file(auth_ref: &str, auth_file: Option<&Path>) -> Result<Option<
         .map(|entry| entry.token.clone()))
 }
 
-/// Look up a GitHub token by key.
-///
-/// Resolution order:
-/// 1. Per-source environment variable `CORPUS_AUTH_{KEY}_TOKEN`
-///    (uppercased, hyphens → underscores). Use this for multi-source
-///    setups that need isolation between source repos.
-/// 2. `corpus-auth.yaml` file (if it exists) — explicit per-source
-///    entries, same purpose as (1) but file-backed.
-/// 3. Legacy shared environment variable `CORPUS_GIT_TOKEN`. The
-///    harvester era used this single global token for one upstream
-///    repo. We accept it as a fallback so deployments that still set
-///    only the legacy variable keep working for *every* GitHub source
-///    without needing to duplicate the secret under each per-source
-///    name. Per-source vars set above still win.
-/// 4. None (unauthenticated, lower rate limits).
-pub fn resolve_token(source_id: &str, auth_file: Option<&Path>) -> Result<Option<String>> {
-    // 1. Per-source environment variable
-    let env_key = token_env_name(source_id);
-    if let Ok(token) = std::env::var(&env_key) {
-        if !token.is_empty() {
-            return Ok(Some(token));
-        }
-    }
-
-    // 2. Auth file
-    if let Some(token) = find_in_auth_file(source_id, auth_file)? {
-        return Ok(Some(token));
-    }
-
-    // 3. Legacy shared CORPUS_GIT_TOKEN (harvester-era single token)
-    if let Ok(token) = std::env::var("CORPUS_GIT_TOKEN") {
-        if !token.is_empty() {
-            return Ok(Some(token));
-        }
-    }
-
-    // 4. No token
-    Ok(None)
-}
-
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
@@ -205,20 +273,132 @@ mod tests {
     // unique-named var don't need it.
     static ENV_LOCK: Mutex<()> = Mutex::new(());
 
+    fn resolve_key(key: &str, strict: bool, auth_file: Option<&Path>) -> TokenDecision {
+        CredentialResolver::new(auth_file)
+            .resolve(if strict {
+                TokenContext::strict(key)
+            } else {
+                // Non-strict bare-key contexts are deliberately not
+                // constructible outside this crate; the tests reach the
+                // non-strict path the same way production does — through
+                // a Source with `strict_auth: false`.
+                TokenContext { key, strict: false }
+            })
+            .unwrap()
+    }
+
+    /// RAII guard: set an env var for the duration of a test, restoring
+    /// the previous value (or absence) on drop — even on assert failure,
+    /// so one failing case can't poison the environment for the next.
+    struct EnvVarGuard {
+        key: String,
+        prev: Option<String>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &str, value: &str) -> Self {
+            let prev = std::env::var(key).ok();
+            unsafe { std::env::set_var(key, value) };
+            Self {
+                key: key.to_string(),
+                prev,
+            }
+        }
+
+        fn unset(key: &str) -> Self {
+            let prev = std::env::var(key).ok();
+            unsafe { std::env::remove_var(key) };
+            Self {
+                key: key.to_string(),
+                prev,
+            }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match &self.prev {
+                Some(v) => unsafe { std::env::set_var(&self.key, v) },
+                None => unsafe { std::env::remove_var(&self.key) },
+            }
+        }
+    }
+
+    /// Full decision table: every combination of
+    /// `{strict, per-source env set, auth-file entry present, legacy set}`
+    /// against the expected `TokenDecision`. Pins the three standing
+    /// guarantees in one place: env wins over file, per-source wins over
+    /// legacy, and strict lookups never see the legacy token.
     #[test]
-    fn test_resolve_token_from_env() {
+    fn decision_table_covers_all_strict_env_file_legacy_combinations() {
+        let _g = ENV_LOCK.lock().unwrap();
+
+        let key = "decision-table-src";
+        let env_key = token_env_name(key);
+        assert_eq!(env_key, "CORPUS_AUTH_DECISION_TABLE_SRC_TOKEN");
+
+        let yaml = format!("sources:\n  - id: {key}\n    token: file-token\n");
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(yaml.as_bytes()).unwrap();
+
+        // (strict, env, file, legacy) -> (expected token, expected origin)
+        #[rustfmt::skip]
+        let cases: &[(bool, bool, bool, bool, Option<&str>, TokenOrigin)] = &[
+            // Non-strict: env > file > legacy > none.
+            (false, true,  true,  true,  Some("env-token"),    TokenOrigin::ServiceEnv),
+            (false, true,  true,  false, Some("env-token"),    TokenOrigin::ServiceEnv),
+            (false, true,  false, true,  Some("env-token"),    TokenOrigin::ServiceEnv),
+            (false, true,  false, false, Some("env-token"),    TokenOrigin::ServiceEnv),
+            (false, false, true,  true,  Some("file-token"),   TokenOrigin::ServiceAuthFile),
+            (false, false, true,  false, Some("file-token"),   TokenOrigin::ServiceAuthFile),
+            (false, false, false, true,  Some("legacy-token"), TokenOrigin::LegacyShared),
+            (false, false, false, false, None,                 TokenOrigin::None),
+            // Strict: identical, except legacy is never consulted.
+            (true,  true,  true,  true,  Some("env-token"),    TokenOrigin::ServiceEnv),
+            (true,  true,  true,  false, Some("env-token"),    TokenOrigin::ServiceEnv),
+            (true,  true,  false, true,  Some("env-token"),    TokenOrigin::ServiceEnv),
+            (true,  true,  false, false, Some("env-token"),    TokenOrigin::ServiceEnv),
+            (true,  false, true,  true,  Some("file-token"),   TokenOrigin::ServiceAuthFile),
+            (true,  false, true,  false, Some("file-token"),   TokenOrigin::ServiceAuthFile),
+            (true,  false, false, true,  None,                 TokenOrigin::None),
+            (true,  false, false, false, None,                 TokenOrigin::None),
+        ];
+
+        for &(strict, env, has_file, legacy, want_token, want_origin) in cases {
+            let _env = if env {
+                EnvVarGuard::set(&env_key, "env-token")
+            } else {
+                EnvVarGuard::unset(&env_key)
+            };
+            let _legacy = if legacy {
+                EnvVarGuard::set("CORPUS_GIT_TOKEN", "legacy-token")
+            } else {
+                EnvVarGuard::unset("CORPUS_GIT_TOKEN")
+            };
+            let auth_file = has_file.then(|| file.path());
+
+            let decision = resolve_key(key, strict, auth_file);
+            let case = format!("strict={strict} env={env} file={has_file} legacy={legacy}");
+            assert_eq!(decision.token(), want_token, "token mismatch for {case}");
+            assert_eq!(decision.origin(), want_origin, "origin mismatch for {case}");
+        }
+    }
+
+    #[test]
+    fn resolve_reads_per_source_env_var() {
         // Use a unique env var name to avoid test interference
         let key = "CORPUS_AUTH_TEST_SOURCE_123_TOKEN";
         unsafe { std::env::set_var(key, "env-token-value") };
 
-        let result = resolve_token("test-source-123", None).unwrap();
-        assert_eq!(result, Some("env-token-value".to_string()));
+        let decision = resolve_key("test-source-123", false, None);
+        assert_eq!(decision.token(), Some("env-token-value"));
+        assert_eq!(decision.origin(), TokenOrigin::ServiceEnv);
 
         unsafe { std::env::remove_var(key) };
     }
 
     #[test]
-    fn test_resolve_token_from_file() {
+    fn resolve_reads_auth_file() {
         let yaml = r#"
 sources:
   - id: amsterdam
@@ -229,90 +409,79 @@ sources:
         let mut file = NamedTempFile::new().unwrap();
         file.write_all(yaml.as_bytes()).unwrap();
 
-        let result = resolve_token("amsterdam", Some(file.path())).unwrap();
-        assert_eq!(result, Some("file-token-123".to_string()));
+        let decision = resolve_key("amsterdam", false, Some(file.path()));
+        assert_eq!(decision.token(), Some("file-token-123"));
+        assert_eq!(decision.origin(), TokenOrigin::ServiceAuthFile);
 
-        let result = resolve_token("rotterdam", Some(file.path())).unwrap();
-        assert_eq!(result, Some("file-token-456".to_string()));
+        let decision = resolve_key("rotterdam", false, Some(file.path()));
+        assert_eq!(decision.token(), Some("file-token-456"));
     }
 
     #[test]
-    fn test_resolve_token_none() {
+    fn resolve_without_any_source_is_none() {
         let _g = ENV_LOCK.lock().unwrap();
         // Make sure the legacy CORPUS_GIT_TOKEN doesn't leak from the
         // test runner's environment and turn this assertion into a flake.
-        let legacy_was_set = std::env::var("CORPUS_GIT_TOKEN").ok();
-        unsafe { std::env::remove_var("CORPUS_GIT_TOKEN") };
-        let result = resolve_token("nonexistent", None).unwrap();
-        if let Some(prev) = legacy_was_set {
-            unsafe { std::env::set_var("CORPUS_GIT_TOKEN", prev) };
-        }
-        assert_eq!(result, None);
+        let _legacy = EnvVarGuard::unset("CORPUS_GIT_TOKEN");
+        let decision = resolve_key("nonexistent", false, None);
+        assert_eq!(decision.token(), None);
+        assert_eq!(decision.origin(), TokenOrigin::None);
     }
 
     #[test]
-    fn test_resolve_token_falls_back_to_legacy_corpus_git_token() {
+    fn resolve_falls_back_to_legacy_corpus_git_token() {
         let _g = ENV_LOCK.lock().unwrap();
         // No per-source var, no auth file → resolver picks up
         // CORPUS_GIT_TOKEN so deployments that still set only the legacy
         // single-token variable keep working across all sources.
-        let prev = std::env::var("CORPUS_GIT_TOKEN").ok();
-        unsafe { std::env::set_var("CORPUS_GIT_TOKEN", "legacy-token-value") };
-        let result = resolve_token("any-source-here", None).unwrap();
-        match prev {
-            Some(v) => unsafe { std::env::set_var("CORPUS_GIT_TOKEN", v) },
-            None => unsafe { std::env::remove_var("CORPUS_GIT_TOKEN") },
-        }
-        assert_eq!(result, Some("legacy-token-value".to_string()));
+        let _legacy = EnvVarGuard::set("CORPUS_GIT_TOKEN", "legacy-token-value");
+        let decision = resolve_key("any-source-here", false, None);
+        assert_eq!(decision.token(), Some("legacy-token-value"));
+        assert_eq!(decision.origin(), TokenOrigin::LegacyShared);
     }
 
     #[test]
-    fn test_per_source_env_wins_over_legacy_corpus_git_token() {
+    fn per_source_env_wins_over_legacy_corpus_git_token() {
         let _g = ENV_LOCK.lock().unwrap();
-        let prev_legacy = std::env::var("CORPUS_GIT_TOKEN").ok();
-        let per_source_key = "CORPUS_AUTH_PRIORITY_TEST_TOKEN";
-        unsafe { std::env::set_var("CORPUS_GIT_TOKEN", "legacy-loses") };
-        unsafe { std::env::set_var(per_source_key, "per-source-wins") };
-        let result = resolve_token("priority-test", None).unwrap();
-        unsafe { std::env::remove_var(per_source_key) };
-        match prev_legacy {
-            Some(v) => unsafe { std::env::set_var("CORPUS_GIT_TOKEN", v) },
-            None => unsafe { std::env::remove_var("CORPUS_GIT_TOKEN") },
-        }
-        assert_eq!(result, Some("per-source-wins".to_string()));
+        let _legacy = EnvVarGuard::set("CORPUS_GIT_TOKEN", "legacy-loses");
+        let _per_source = EnvVarGuard::set("CORPUS_AUTH_PRIORITY_TEST_TOKEN", "per-source-wins");
+        let decision = resolve_key("priority-test", false, None);
+        assert_eq!(decision.token(), Some("per-source-wins"));
+        assert_eq!(decision.origin(), TokenOrigin::ServiceEnv);
     }
 
     #[test]
-    fn test_resolve_token_missing_file_is_none() {
-        let result = resolve_token("test", Some(Path::new("/nonexistent/auth.yaml"))).unwrap();
-        assert_eq!(result, None);
+    fn resolve_with_missing_auth_file_is_none() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let _legacy = EnvVarGuard::unset("CORPUS_GIT_TOKEN");
+        let decision = resolve_key("test", false, Some(Path::new("/nonexistent/auth.yaml")));
+        assert_eq!(decision.token(), None);
     }
 
     #[test]
-    fn resolve_token_strict_skips_legacy_corpus_git_token() {
-        // The whole point of `resolve_token_strict`: an unknown auth_ref
+    fn strict_context_skips_legacy_corpus_git_token() {
+        // The whole point of a strict context: an unknown auth key
         // must NOT fall through to `CORPUS_GIT_TOKEN`. If it did, an
-        // attacker who can pick `auth_ref` (via repo coords on the
+        // attacker who can pick the key (via repo coords on the
         // create-traject endpoint) would harvest the operator's
         // central token on the next outgoing GitHub call. This test
         // pins the strict behaviour so a future refactor of the
         // resolver can't silently regress it.
         let _g = ENV_LOCK.lock().unwrap();
-        let prev = std::env::var("CORPUS_GIT_TOKEN").ok();
-        unsafe { std::env::set_var("CORPUS_GIT_TOKEN", "central-secret") };
-        let result = resolve_token_strict("attacker-supplied-key", None).unwrap();
-        match prev {
-            Some(v) => unsafe { std::env::set_var("CORPUS_GIT_TOKEN", v) },
-            None => unsafe { std::env::remove_var("CORPUS_GIT_TOKEN") },
-        }
+        let _legacy = EnvVarGuard::set("CORPUS_GIT_TOKEN", "central-secret");
+        let decision = CredentialResolver::new(None)
+            .resolve(TokenContext::strict("attacker-supplied-key"))
+            .unwrap();
         assert_eq!(
-            result, None,
+            decision.token(),
+            None,
             "strict resolver must NOT leak the legacy token"
         );
+        assert_eq!(decision.origin(), TokenOrigin::None);
     }
 
     #[test]
-    fn resolve_token_strict_still_uses_per_source_env() {
+    fn strict_context_still_uses_per_source_env() {
         // The strict variant still honours the explicit per-source env
         // var — that's the path operators are supposed to configure.
         // Holds `ENV_LOCK` like the sibling strict test: even though
@@ -320,11 +489,13 @@ sources:
         // a concurrent test holding the lock and mutating arbitrary
         // env vars can't race with this one.
         let _g = ENV_LOCK.lock().unwrap();
-        let key = "CORPUS_AUTH_STRICT_PER_SOURCE_OK_TOKEN";
-        unsafe { std::env::set_var(key, "per-source-value") };
-        let result = resolve_token_strict("strict-per-source-ok", None).unwrap();
-        unsafe { std::env::remove_var(key) };
-        assert_eq!(result, Some("per-source-value".to_string()));
+        let _per_source =
+            EnvVarGuard::set("CORPUS_AUTH_STRICT_PER_SOURCE_OK_TOKEN", "per-source-value");
+        let decision = CredentialResolver::new(None)
+            .resolve(TokenContext::strict("strict-per-source-ok"))
+            .unwrap();
+        assert_eq!(decision.token(), Some("per-source-value"));
+        assert_eq!(decision.origin(), TokenOrigin::ServiceEnv);
     }
 
     fn local_source(auth_ref: &str, strict_auth: bool) -> crate::models::Source {
@@ -344,26 +515,72 @@ sources:
     }
 
     #[test]
-    fn resolve_source_token_strict_source_skips_legacy_token() {
+    fn resolve_source_strict_source_skips_legacy_token() {
         // A `strict_auth` source (traject writable-own, user-supplied repo
-        // coords) must resolve like `resolve_token_strict` on EVERY path
-        // that goes through the source object — most importantly the index
-        // scan, which used to fall back to `CORPUS_GIT_TOKEN` while the
-        // push path resolved strictly.
+        // coords) must resolve strictly on EVERY path that goes through the
+        // source object — most importantly the index scan, which used to
+        // fall back to `CORPUS_GIT_TOKEN` while the push path resolved
+        // strictly.
         let _g = ENV_LOCK.lock().unwrap();
-        let prev = std::env::var("CORPUS_GIT_TOKEN").ok();
-        unsafe { std::env::set_var("CORPUS_GIT_TOKEN", "central-secret") };
-        let strict = resolve_source_token(&local_source("user-picked-ref", true), None).unwrap();
-        let legacy = resolve_source_token(&local_source("user-picked-ref", false), None).unwrap();
-        match prev {
-            Some(v) => unsafe { std::env::set_var("CORPUS_GIT_TOKEN", v) },
-            None => unsafe { std::env::remove_var("CORPUS_GIT_TOKEN") },
-        }
-        assert_eq!(strict, None, "strict source must not leak the legacy token");
+        let _legacy = EnvVarGuard::set("CORPUS_GIT_TOKEN", "central-secret");
+        let resolver = CredentialResolver::new(None);
+        let strict = resolver
+            .resolve_source(&local_source("user-picked-ref", true))
+            .unwrap();
+        let legacy = resolver
+            .resolve_source(&local_source("user-picked-ref", false))
+            .unwrap();
         assert_eq!(
-            legacy,
-            Some("central-secret".to_string()),
+            strict.token(),
+            None,
+            "strict source must not leak the legacy token"
+        );
+        assert_eq!(strict.origin(), TokenOrigin::None);
+        assert_eq!(
+            legacy.token(),
+            Some("central-secret"),
             "manifest sources keep the legacy single-PAT fallback"
         );
+        assert_eq!(legacy.origin(), TokenOrigin::LegacyShared);
+    }
+
+    #[test]
+    fn resolve_source_uses_auth_ref_over_source_id() {
+        // The lookup key is `auth_ref` when present (RFC-010: `auth_ref`
+        // in the manifest references an entry in the auth config), the
+        // source id otherwise.
+        let _g = ENV_LOCK.lock().unwrap();
+        let _per_ref = EnvVarGuard::set("CORPUS_AUTH_REF_KEY_WINS_TOKEN", "ref-token");
+        let decision = CredentialResolver::new(None)
+            .resolve_source(&local_source("ref-key-wins", false))
+            .unwrap();
+        assert_eq!(decision.token(), Some("ref-token"));
+
+        let mut no_ref = local_source("unused", false);
+        no_ref.auth_ref = None;
+        no_ref.id = "id-key-wins".to_string();
+        let _per_id = EnvVarGuard::set("CORPUS_AUTH_ID_KEY_WINS_TOKEN", "id-token");
+        let decision = CredentialResolver::new(None)
+            .resolve_source(&no_ref)
+            .unwrap();
+        assert_eq!(decision.token(), Some("id-token"));
+    }
+
+    #[test]
+    fn empty_env_var_counts_as_unset() {
+        // An empty per-source var must not shadow the auth file (or
+        // produce an empty Authorization header downstream).
+        let _g = ENV_LOCK.lock().unwrap();
+        let key = "empty-env-src";
+        let _empty = EnvVarGuard::set(&token_env_name(key), "");
+        let _legacy = EnvVarGuard::unset("CORPUS_GIT_TOKEN");
+
+        let yaml = format!("sources:\n  - id: {key}\n    token: file-wins\n");
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(yaml.as_bytes()).unwrap();
+
+        let decision = resolve_key(key, false, Some(file.path()));
+        assert_eq!(decision.token(), Some("file-wins"));
+        assert_eq!(decision.origin(), TokenOrigin::ServiceAuthFile);
     }
 }

--- a/packages/corpus/src/models.rs
+++ b/packages/corpus/src/models.rs
@@ -23,7 +23,7 @@ pub struct Source {
     pub auth_ref: Option<String>,
     /// When set, token resolution for this source never falls back to the
     /// legacy shared `CORPUS_GIT_TOKEN` (see
-    /// [`crate::auth::resolve_token_strict`]). Set for sources whose
+    /// [`crate::auth::TokenContext::strict`]). Set for sources whose
     /// `auth_ref` derives from user input — a traject's writable-own repo —
     /// where the legacy fallback would ship the central token to a
     /// user-chosen repo on every read/scan. Not part of the manifest

--- a/packages/corpus/src/registry.rs
+++ b/packages/corpus/src/registry.rs
@@ -182,7 +182,9 @@ impl CorpusRegistry {
 
         for source in &self.sources {
             if let SourceType::GitHub { github } = &source.source_type {
-                let token = crate::auth::resolve_source_token(source, auth_file)?;
+                let token = crate::auth::CredentialResolver::new(auth_file)
+                    .resolve_source(source)?
+                    .into_token();
                 match fetcher
                     .fetch_source_filtered(github, token.as_deref(), &missing)
                     .await?
@@ -294,13 +296,15 @@ impl CorpusRegistry {
                 map.load_source(source)?;
             }
             SourceType::GitHub { github } => {
-                // `resolve_source_token` honours `strict_auth`: the scan of a
+                // `resolve_source` honours `strict_auth`: the scan of a
                 // traject's writable-own repo resolves with exactly the same
                 // rules as its push path, so a repo the server can push to is
                 // also a repo the server can index (and vice versa — no more
                 // "promote succeeded but the index reads with a different
                 // token and comes back empty").
-                let token = crate::auth::resolve_source_token(source, auth_file)?;
+                let token = crate::auth::CredentialResolver::new(auth_file)
+                    .resolve_source(source)?
+                    .into_token();
                 for (law_id, path, sha) in fetcher
                     .list_source_law_paths(github, token.as_deref())
                     .await?

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -799,15 +799,21 @@ async fn init_backends(
     let mut backends = HashMap::new();
 
     for source in registry.sources() {
-        let token = regelrecht_corpus::auth::resolve_token_for_source(
-            &source.id,
-            source.auth_ref.as_deref(),
-            auth_file,
-        )
-        .unwrap_or_else(|e| {
-            tracing::warn!(source_id = %source.id, error = %e, "failed to resolve auth token");
-            None
-        });
+        // Explicit decision: resolution follows the source's `strict_auth`
+        // flag (via `resolve_source`) instead of hardcoding the
+        // legacy-fallback variant this call-site used before. For the global
+        // registry that is behaviourally identical — manifest sources carry
+        // `strict_auth: false`, so single-PAT deployments that only set
+        // `CORPUS_GIT_TOKEN` keep working — but a strict source ever
+        // reaching this path now resolves strictly, consistent with the
+        // traject backend path in `traject_corpus.rs`.
+        let token = regelrecht_corpus::auth::CredentialResolver::new(auth_file)
+            .resolve_source(source)
+            .map(regelrecht_corpus::auth::TokenDecision::into_token)
+            .unwrap_or_else(|e| {
+                tracing::warn!(source_id = %source.id, error = %e, "failed to resolve auth token");
+                None
+            });
 
         // When a push token is present, the backend will push commits to the
         // remote repo. This requires authentication on the write endpoints —

--- a/packages/editor-api/src/traject_corpus.rs
+++ b/packages/editor-api/src/traject_corpus.rs
@@ -1476,7 +1476,9 @@ async fn build_traject_corpus(
         // read-only mirrors keep working. The index scan below
         // (`index_all_sources_async`) goes through the same resolver, so
         // scan and push can no longer disagree about the token.
-        let token_result = regelrecht_corpus::auth::resolve_source_token(source, auth_file);
+        let token_result = regelrecht_corpus::auth::CredentialResolver::new(auth_file)
+            .resolve_source(source)
+            .map(regelrecht_corpus::auth::TokenDecision::into_token);
         let token = token_result.unwrap_or_else(|e| {
             tracing::warn!(
                 traject = %traject_id,

--- a/packages/editor-api/src/trajects.rs
+++ b/packages/editor-api/src/trajects.rs
@@ -862,22 +862,23 @@ async fn resolve_writable_target(
             //
             // Fall back to the *strict* per-repo operator token when the user
             // hasn't linked GitHub and this deployment doesn't require it. The
-            // strict resolver (not `resolve_token`) is deliberate: `auth_ref`
+            // strict context (`TokenContext::strict`) is deliberate: `auth_ref`
             // derives from user-supplied repo coords, so an unknown ref must
             // NOT fall back to `CORPUS_GIT_TOKEN` (that would ship the central
             // token to a user-picked repo, a token-exfiltration vector).
             // `user_write_token` returns 428 when a linked token is required
             // but absent.
-            let token = match crate::github_oauth::user_write_token(state, account_id, headers)
-                .await?
-            {
-                Some(user_token) => user_token,
-                None => {
-                    let auth_file = {
-                        let corpus = state.corpus.read().await;
-                        corpus.auth_file.clone()
-                    };
-                    regelrecht_corpus::auth::resolve_token_strict(&auth_ref, auth_file.as_deref())
+            let token =
+                match crate::github_oauth::user_write_token(state, account_id, headers).await? {
+                    Some(user_token) => user_token,
+                    None => {
+                        let auth_file = {
+                            let corpus = state.corpus.read().await;
+                            corpus.auth_file.clone()
+                        };
+                        regelrecht_corpus::auth::CredentialResolver::new(auth_file.as_deref())
+                        .resolve(regelrecht_corpus::auth::TokenContext::strict(&auth_ref))
+                        .map(regelrecht_corpus::auth::TokenDecision::into_token)
                         .map_err(|e| {
                             tracing::error!(error = %e, "auth lookup failed for new traject repo");
                             (
@@ -900,8 +901,8 @@ async fn resolve_writable_target(
                                 ),
                             )
                         })?
-                }
-            };
+                    }
+                };
 
             // The OAuth config's `api_base` (a pub field, overridable in
             // tests with a wiremock server) wins over the real default, so

--- a/packages/pipeline/src/document_convert.rs
+++ b/packages/pipeline/src/document_convert.rs
@@ -167,8 +167,8 @@ impl WritableOwnSourceRow {
             priority: self.priority.max(0) as u32,
             auth_ref: self.auth_ref.clone(),
             // Writable-own rows carry a user-derived `auth_ref`; resolution
-            // must never fall back to the shared legacy token (the worker
-            // below indeed resolves via `resolve_token_strict`).
+            // must never fall back to the shared legacy token (the central
+            // `CredentialResolver` below honours this flag).
             strict_auth: true,
         }
     }
@@ -212,11 +212,14 @@ pub async fn write_markdown_to_traject(
     markdown: &str,
 ) -> Result<()> {
     let source = load_writable_own_source(pool, payload.traject_id).await?;
-    // Resolve a push token strictly by the source's auth key (env var
-    // `CORPUS_AUTH_<key>_TOKEN`); no auth file in the worker and no shared-token
+    // Resolve a push token via the central resolver (env var
+    // `CORPUS_AUTH_<key>_TOKEN`); no auth file in the worker, and the source's
+    // `strict_auth: true` (set in `to_source`) means no shared-token
     // fallback — matches the editor's writable-own resolution.
     let auth_key = source.auth_ref.clone().unwrap_or_else(|| source.id.clone());
-    let token = regelrecht_corpus::auth::resolve_token_strict(&auth_key, None)?;
+    let token = regelrecht_corpus::auth::CredentialResolver::new(None)
+        .resolve_source(&source)?
+        .into_token();
 
     // A GitHub source with no push token would only commit into the worker's
     // throwaway checkout (GitBackend goes local-only) and never reach the


### PR DESCRIPTION
## Wat

Alle server-token-resolutie in `packages/corpus` gaat nu door één ingang: `CredentialResolver::resolve(TokenContext) -> TokenDecision`. De vier losse resolvers (`resolve_token`, `resolve_token_strict`, `resolve_token_for_source`, `resolve_source_token`) zijn erin opgegaan en verwijderd; `token_env_name` blijft de single source of truth voor de env-var-naam in operator-diagnostiek.

- **`TokenDecision { token, origin }`** met `TokenOrigin` (`ServiceEnv` / `ServiceAuthFile` / `LegacyShared` / `None`) maakt de herkomst van elk token expliciet en logbaar/assertbaar.
- **`TokenContext`** heeft precies twee constructors: `for_source(&Source)` (strictness volgt `Source::strict_auth`) en `strict(key)` (voor user-derived keys zonder `Source`-object, zoals de create-traject-preflight). Er is bewust **geen** niet-strikte constructor voor een kale key — de legacy `CORPUS_GIT_TOKEN`-fallback is alleen bereikbaar via een `Source` met `strict_auth: false`, dus een nieuwe call-site kan de strict/legacy-keuze niet meer per ongeluk zelf maken (de exfiltratie-as uit het ticket).

## Gemigreerde call-sites (mechanisch, gedragsidentiek)

| Call-site | Voorheen | Nu |
|---|---|---|
| `corpus/src/registry.rs:185,303` (fetch + indexscan) | `resolve_source_token` | `resolver.resolve_source(source)` |
| `editor-api/src/traject_corpus.rs` (traject-backends) | `resolve_source_token` | `resolver.resolve_source(source)` |
| `editor-api/src/trajects.rs` (create-preflight) | handmatig `resolve_token_strict` | `resolve(TokenContext::strict(&auth_ref))` |
| `pipeline/src/document_convert.rs` (worker-write) | handmatig `resolve_token_strict` | `resolver.resolve_source(&source)` (source draagt `strict_auth: true`) |
| `editor-api/src/main.rs` `init_backends` | `resolve_token_for_source` (altijd mét legacy-fallback) | `resolver.resolve_source(source)` — zie hieronder |

## Expliciete gedragskeuze (main.rs `init_backends`)

`init_backends` volgt nu `strict_auth` van de source in plaats van hardcoded de legacy-fallback-variant. Voor het globale register is dat **gedragsidentiek**: manifest-sources hebben `strict_auth: false`, dus single-PAT-deployments die alleen `CORPUS_GIT_TOKEN` zetten blijven werken. Zou er ooit een strikte source op dit pad komen, dan resolvet die nu strikt — consistent met het traject-backend-pad. Dit staat ook als comment bij de call-site.

## Tests

- Nieuwe beslistabel-test: alle 16 combinaties van `{strict, env aanwezig, auth-file aanwezig, legacy aanwezig}` tegen verwachte token + `TokenOrigin`, incl. de bestaande garanties (env wint van file, per-source wint van legacy, strict lekt nooit legacy).
- Bestaande auth-tests geport naar de nieuwe API met behoud van hun pinnende assertions; `strict_auth`-gedrag via `resolve_source` nu expliciet gedekt, plus een test dat een lege env-var niet het auth-file maskeert.
- Geen sessie-/OAuth-/HTTP-kennis in deze laag; de editor-api-lagen bouwen op `TokenDecision` (vervolgticket).

## Checks

`just check` groen (format, clippy, build-check, validate, engine/harvester/pipeline/admin/editor-api); `just editor-api-test` en corpus-doctests groen.
