### PR TITLE
feat(pipeline): borg het worker/traject-contract met jobniveau-guards

### DIFF
--- a/packages/pipeline/src/document_convert.rs
+++ b/packages/pipeline/src/document_convert.rs
@@ -9,7 +9,14 @@
 //! convert (pick a tool, or read it directly). This module owns the payload
 //! type, the transient upload storage helpers, the status-list query for the
 //! editor, and the conversion orchestration. The worker (see `worker.rs`) drives
-//! it and writes the produced markdown back to the traject's git corpus.
+//! it and delivers the produced markdown as a job-blob + review-taak
+//! (`worker::finish_document_convert_task_job`); the editor commits it to the
+//! traject repo namens de gebruiker after approval.
+//!
+//! Per het worker/traject-contract (zie de crate-doc in `lib.rs`) bevat deze
+//! module bewust géén git-push-pad: een sessieloze worker schrijft nooit met
+//! een server-token naar een traject-repo. De guard die dat afdwingt is
+//! [`DocumentConvertPayload::require_task_delivery`].
 
 use std::path::{Path, PathBuf};
 
@@ -17,9 +24,6 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use sqlx::PgPool;
 use uuid::Uuid;
-
-use regelrecht_corpus::backend::{create_backend, WriteContext};
-use regelrecht_corpus::models::{GitHubSource, LocalSource, Source, SourceType};
 
 use crate::enrich::{run_llm_subprocess, EnrichConfig};
 use crate::error::{PipelineError, Result};
@@ -50,8 +54,9 @@ pub struct DocumentConvertPayload {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub requested_by: Option<Uuid>,
     /// `"task"` ⇒ resultaat als job_blobs + review-taak, géén push (taak-flow;
-    /// editor-api zet dit op elke upload). Afwezig ⇒ oude gedrag (jobs van
-    /// vóór het taken-mechanisme): directe push naar de traject-branch.
+    /// editor-api zet dit op elke upload). Elke andere waarde — inclusief
+    /// afwezig, het pre-taken-mechanisme directe-push-gedrag — wordt door de
+    /// worker terminaal geweigerd: zie [`Self::require_task_delivery`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub deliver: Option<String>,
 }
@@ -60,6 +65,27 @@ impl DocumentConvertPayload {
     /// Taak-flow: resultaat naar Postgres + taak i.p.v. push naar git.
     pub fn deliver_as_task(&self) -> bool {
         self.deliver.as_deref() == Some("task")
+    }
+
+    /// Contract-guard op jobniveau: een document-convert-job heeft altijd een
+    /// traject-doel (`traject_id`), en per het worker/traject-contract (zie de
+    /// crate-doc) mag een sessieloze worker nooit met een server-token naar
+    /// een traject-repo pushen. Oplevering kan dus uitsluitend via de
+    /// taak-flow: `deliver: "task"` mét een `requested_by` als assignee van de
+    /// review-taak. Al het andere — het verwijderde directe-push-gedrag van
+    /// jobs van vóór het taken-mechanisme incluis — hoort terminaal en luid te
+    /// falen, vóór de (kostbare) conversie. Spiegel van de `law_convert`-gate
+    /// in `worker.rs`.
+    pub fn require_task_delivery(&self) -> Result<()> {
+        if !self.deliver_as_task() || self.requested_by.is_none() {
+            return Err(PipelineError::Worker(
+                "document_convert vereist deliver=task met requested_by: een traject-write \
+                 loopt altijd via een review-taak (editor-commit namens de gebruiker), nooit \
+                 via een directe push vanuit de worker"
+                    .to_string(),
+            ));
+        }
+        Ok(())
     }
 }
 
@@ -121,130 +147,6 @@ pub async fn cleanup_orphaned_uploads(pool: &PgPool) -> Result<u64> {
     .execute(pool)
     .await?;
     Ok(result.rows_affected())
-}
-
-/// Row for a traject's writable-own corpus source, from `traject_corpus_sources`.
-#[derive(sqlx::FromRow)]
-struct WritableOwnSourceRow {
-    source_id: String,
-    name: String,
-    source_type: String,
-    gh_owner: Option<String>,
-    gh_repo: Option<String>,
-    gh_branch: Option<String>,
-    gh_path: Option<String>,
-    gh_ref: Option<String>,
-    local_path: Option<String>,
-    priority: i32,
-    auth_ref: Option<String>,
-}
-
-impl WritableOwnSourceRow {
-    /// Mirror of editor-api's `TrajectSourceRow::to_source`. Scopes are omitted
-    /// (they only gate reads; the worker only writes).
-    fn to_source(&self) -> Source {
-        let source_type = match self.source_type.as_str() {
-            "github" => SourceType::GitHub {
-                github: GitHubSource {
-                    owner: self.gh_owner.clone().unwrap_or_default(),
-                    repo: self.gh_repo.clone().unwrap_or_default(),
-                    branch: self.gh_branch.clone().unwrap_or_default(),
-                    path: self.gh_path.clone(),
-                    git_ref: self.gh_ref.clone(),
-                },
-            },
-            _ => SourceType::Local {
-                local: LocalSource {
-                    path: std::path::PathBuf::from(self.local_path.clone().unwrap_or_default()),
-                },
-            },
-        };
-        Source {
-            id: self.source_id.clone(),
-            name: self.name.clone(),
-            source_type,
-            scopes: Vec::new(),
-            priority: self.priority.max(0) as u32,
-            auth_ref: self.auth_ref.clone(),
-            // Writable-own rows carry a user-derived `auth_ref`; resolution
-            // must never fall back to the shared legacy token (the central
-            // `CredentialResolver` below honours this flag).
-            strict_auth: true,
-        }
-    }
-}
-
-/// Build a corpus [`Source`] for the traject's single writable-own source.
-async fn load_writable_own_source(pool: &PgPool, traject_id: Uuid) -> Result<Source> {
-    let row = sqlx::query_as::<_, WritableOwnSourceRow>(
-        r#"
-        SELECT source_id, name, source_type::text AS source_type,
-               gh_owner, gh_repo, gh_branch, gh_path, gh_ref, local_path,
-               priority, auth_ref
-        FROM traject_corpus_sources
-        WHERE traject_id = $1 AND is_writable_own = TRUE
-        -- A partial unique index already guarantees at most one such row per
-        -- traject; the deterministic order + LIMIT is defensive belt-and-braces.
-        ORDER BY priority DESC, source_id
-        LIMIT 1
-        "#,
-    )
-    .bind(traject_id)
-    .fetch_optional(pool)
-    .await?
-    .ok_or_else(|| {
-        PipelineError::Enrich(format!(
-            "traject {traject_id} has no writable-own corpus source"
-        ))
-    })?;
-    Ok(row.to_source())
-}
-
-/// Write the converted markdown into the traject's writable-own corpus and push
-/// it. This is a service-account commit straight to the source's branch (no PR):
-/// the async worker has no user session, so it mirrors how the enrich worker
-/// writes to the corpus rather than the editor's per-session PR flow. The file
-/// lands at `documents/<traject_ref>/<target_path>` — the same location the
-/// editor's document handler writes to — so it shows up as a normal werkdocument.
-pub async fn write_markdown_to_traject(
-    pool: &PgPool,
-    payload: &DocumentConvertPayload,
-    markdown: &str,
-) -> Result<()> {
-    let source = load_writable_own_source(pool, payload.traject_id).await?;
-    // Resolve a push token via the central resolver (env var
-    // `CORPUS_AUTH_<key>_TOKEN`); no auth file in the worker, and the source's
-    // `strict_auth: true` (set in `to_source`) means no shared-token
-    // fallback — matches the editor's writable-own resolution.
-    let auth_key = source.auth_ref.clone().unwrap_or_else(|| source.id.clone());
-    let token = regelrecht_corpus::auth::CredentialResolver::new(None)
-        .resolve_source(&source)?
-        .into_token();
-
-    // A GitHub source with no push token would only commit into the worker's
-    // throwaway checkout (GitBackend goes local-only) and never reach the
-    // traject — silent data loss. Fail loudly instead, so the failure is visible
-    // in the werkdocumenten status block and the ops fix (set the token) is
-    // obvious. Local sources need no token (the local write IS the persistence).
-    if token.is_none() && matches!(source.source_type, SourceType::GitHub { .. }) {
-        return Err(PipelineError::Enrich(format!(
-            "no push token for traject source '{auth_key}' (expected env {}); the converted \
-             document cannot be persisted to the traject repository",
-            regelrecht_corpus::auth::token_env_name(&auth_key),
-        )));
-    }
-
-    let mut backend = create_backend(&source, token.as_deref())?;
-    backend.ensure_ready().await?;
-
-    let relative_path = Path::new("documents")
-        .join(&payload.traject_ref)
-        .join(&payload.target_path);
-    backend.write_file(&relative_path, markdown).await?;
-
-    let message = format!("document-convert: {}", payload.target_path);
-    backend.persist(&WriteContext::new(message, None)).await?;
-    Ok(())
 }
 
 /// A trimmed view of a `document_convert` job for the werkdocumenten status UI.
@@ -633,8 +535,9 @@ mod tests {
 
     #[test]
     fn payload_deliver_task_fields_roundtrip_and_backcompat() {
-        // Oude payloads (zonder deliver-veld) moeten blijven deserialiseren en
-        // vallen terug op het oude directe-push-gedrag.
+        // Oude payloads (zonder deliver-veld) moeten blijven deserialiseren —
+        // maar hun directe-push-gedrag bestaat niet meer: de guard weigert ze
+        // terminaal (zie `require_task_delivery_rejects_non_task_payloads`).
         let old = serde_json::json!({
             "upload_id": Uuid::nil(),
             "traject_id": Uuid::nil(),
@@ -660,6 +563,57 @@ mod tests {
             serde_json::from_value(serde_json::to_value(&new).unwrap()).unwrap();
         assert_eq!(roundtrip.requested_by, Some(account));
         assert!(roundtrip.deliver_as_task());
+    }
+
+    /// Basispayload met traject-doel voor de guard-tests hieronder.
+    fn traject_payload(
+        deliver: Option<&str>,
+        requested_by: Option<Uuid>,
+    ) -> DocumentConvertPayload {
+        DocumentConvertPayload {
+            upload_id: Uuid::nil(),
+            traject_id: Uuid::new_v4(),
+            traject_ref: "voorbeeld-abcd1234".to_string(),
+            target_path: "report.md".to_string(),
+            provider: None,
+            requested_by,
+            deliver: deliver.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn require_task_delivery_rejects_non_task_payloads() {
+        // Het worker/traject-contract: een document-convert-job (altijd een
+        // traject-doel) mag uitsluitend via de taak-flow opleveren. Zonder
+        // `deliver: "task"` — het verwijderde pre-taken directe-push-gedrag —
+        // moet de guard weigeren, wélke andere waarde er ook staat.
+        let account = Uuid::new_v4();
+        for deliver in [None, Some("push"), Some("Task"), Some("")] {
+            let err = traject_payload(deliver, Some(account))
+                .require_task_delivery()
+                .unwrap_err();
+            assert!(
+                err.to_string().contains("deliver=task"),
+                "deliver={deliver:?} moet met een duidelijke contractfout geweigerd worden, kreeg: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn require_task_delivery_rejects_task_without_requested_by() {
+        // Zonder aanvrager is er geen assignee voor de review-taak, dus ook
+        // geen aflever-pad — net zo terminaal als een niet-task-payload.
+        let err = traject_payload(Some("task"), None)
+            .require_task_delivery()
+            .unwrap_err();
+        assert!(err.to_string().contains("requested_by"));
+    }
+
+    #[test]
+    fn require_task_delivery_accepts_the_task_flow() {
+        traject_payload(Some("task"), Some(Uuid::new_v4()))
+            .require_task_delivery()
+            .expect("taak-flow-payload met aanvrager is het enige geldige aflever-pad");
     }
 
     #[test]

--- a/packages/pipeline/src/enrich.rs
+++ b/packages/pipeline/src/enrich.rs
@@ -565,6 +565,27 @@ impl EnrichPayload {
     pub fn deliver_as_task(&self) -> bool {
         self.deliver.as_deref() == Some("task")
     }
+
+    /// Contract-guard voor het corpus-brede (klassieke) enrich-pad: dat pad
+    /// pusht met het centrale corpus-token (`CorpusConfig`/`CORPUS_GIT_TOKEN`)
+    /// naar de centrale corpus-repo — de operator-repo — en mag dus alléén
+    /// corpus-brede jobs verwerken. Een payload met een traject-doel
+    /// (`traject_id`/`traject_ref`) hoort bij de taak-flow
+    /// (`deliver: "task"` → blob + review-taak; zie het worker/traject-contract
+    /// in de crate-doc); belandt zo'n payload tóch hier, dan is dat een
+    /// enqueue-fout die terminaal en luid moet falen in plaats van met het
+    /// server-token naar een verkeerd doel te schrijven.
+    pub fn require_corpus_wide_target(&self) -> Result<()> {
+        if self.traject_id.is_some() || self.traject_ref.is_some() {
+            return Err(PipelineError::Worker(
+                "enrich-payload met traject-doel zonder deliver=task: traject-oplevering \
+                 loopt altijd via een review-taak, het corpus-brede push-pad is alleen \
+                 voor de centrale corpus-repo"
+                    .to_string(),
+            ));
+        }
+        Ok(())
+    }
 }
 
 /// All known provider names. Used to create one enrich job per provider
@@ -2173,6 +2194,53 @@ mod tests {
 
         assert_eq!(deserialized.law_id, "BWBR0018451");
         assert!(deserialized.yaml_path.contains("zorgtoeslag"));
+    }
+
+    /// Minimale corpus-brede payload; de guard-tests zetten er traject-velden op.
+    fn corpus_wide_payload() -> EnrichPayload {
+        EnrichPayload {
+            law_id: "BWBR0018451".to_string(),
+            yaml_path: "regulation/nl/wet/wet_op_de_zorgtoeslag/2025-01-01.yaml".to_string(),
+            provider: None,
+            depth: None,
+            requested_by: None,
+            deliver: None,
+            traject_id: None,
+            traject_ref: None,
+            source_etag: None,
+            new_law: None,
+            chunk_articles: None,
+            skip_mvt: None,
+        }
+    }
+
+    #[test]
+    fn require_corpus_wide_target_accepts_central_corpus_jobs() {
+        // De klassieke corpus-brede enrich (geen traject-velden) blijft
+        // gewoon werken met het centrale corpus-token.
+        corpus_wide_payload()
+            .require_corpus_wide_target()
+            .expect("corpus-brede payload hoort door de guard te komen");
+    }
+
+    #[test]
+    fn require_corpus_wide_target_rejects_traject_payloads() {
+        // Worker/traject-contract: het corpus-brede push-pad (centrale repo,
+        // centrale token) mag nooit een traject-gerichte payload verwerken —
+        // die hoort via de taak-flow af te buigen. traject_id én traject_ref
+        // triggeren elk afzonderlijk, zodat een half-gevulde payload (bijv.
+        // een nieuwe enqueue die maar één veld zet) niet doorglipt.
+        let mut with_id = corpus_wide_payload();
+        with_id.traject_id = Some(Uuid::new_v4());
+        assert!(with_id.require_corpus_wide_target().is_err());
+
+        let mut with_ref = corpus_wide_payload();
+        with_ref.traject_ref = Some("voorbeeld-abcd1234".to_string());
+        let err = with_ref.require_corpus_wide_target().unwrap_err();
+        assert!(
+            err.to_string().contains("review-taak"),
+            "de fout moet naar het contract verwijzen, kreeg: {err}"
+        );
     }
 
     #[test]

--- a/packages/pipeline/src/lib.rs
+++ b/packages/pipeline/src/lib.rs
@@ -1,3 +1,31 @@
+//! PostgreSQL-backed job queue, law status tracking, and the pipeline workers
+//! (harvest, enrich, document/law-convert).
+//!
+//! # Het worker/traject-contract
+//!
+//! **Pipeline-workers schrijven nooit met een server-token naar een
+//! traject-repo.** Een traject-write loopt altijd via een review-taak: de
+//! worker levert zijn resultaat op als job-blob + taak
+//! (`deliver: "task"`, zie o.a. [`worker::finish_enrich_task_job`] en
+//! [`worker::finish_document_convert_task_job`]), de gebruiker keurt goed in
+//! de editor, en de editor doet de commit namens de gebruiker met diens eigen
+//! OAuth-token (client-gedreven via de save-endpoints van editor-api).
+//!
+//! Het corpus-token (`CORPUS_GIT_TOKEN`, via `CorpusConfig`) is uitsluitend
+//! voor de **centrale** corpus-repo — de operator-repo waar de klassieke
+//! corpus-brede enrich zijn `enrich/*`-branches pusht. Guards borgen dit op
+//! jobniveau, niet op call-site-conventie:
+//!
+//! - `document_convert`: [`document_convert::DocumentConvertPayload::require_task_delivery`]
+//!   — een job zonder `deliver: "task"` + `requested_by` faalt terminaal vóór
+//!   de conversie; er bestaat geen push-pad meer in die module.
+//! - `law_convert`: kent alléén de taak-flow (zelfde gate in `worker.rs`).
+//! - `enrich`: de taak-flow buigt af naar blob + taak; het corpus-brede pad
+//!   weigert traject-gerichte payloads via
+//!   [`enrich::EnrichPayload::require_corpus_wide_target`].
+//! - `traject_harvest`: schrijft in een werkdirectory en ketent een
+//!   taak-flow-enrich — raakt zelf geen traject-repo aan.
+
 pub mod api;
 mod api_state;
 pub mod config;

--- a/packages/pipeline/src/worker.rs
+++ b/packages/pipeline/src/worker.rs
@@ -1376,13 +1376,17 @@ async fn process_next_document_convert_job(
         }
     };
 
-    // Taak-flow-gate, vóór de (kostbare) conversie: zonder `requested_by` is
-    // er geen zinvolle assignee voor de review-taak, dus zo'n job kan nooit
-    // afgeleverd worden. Terminaal falen zónder taak (mirrors the enrich
-    // gate in `process_next_enrich_job`) - de upload-bytes worden ook
-    // meteen opgeruimd, er is toch geen aflever-pad meer voor ze.
-    if payload.deliver_as_task() && payload.requested_by.is_none() {
-        let msg = "taak-flow-payload zonder requested_by".to_string();
+    // Contract-guard, vóór de (kostbare) conversie: een document-convert-job
+    // heeft een traject-doel en mag dus uitsluitend via de taak-flow
+    // opleveren — het directe-push-pad naar de traject-repo is verwijderd
+    // (worker/traject-contract, zie de crate-doc). Dit dekt zowel
+    // `deliver != "task"` (waaronder jobs van vóór het taken-mechanisme) als
+    // een ontbrekende `requested_by` (geen assignee voor de review-taak).
+    // Terminaal falen zónder taak, spiegel van de `law_convert`-gate
+    // hieronder; de upload-bytes worden meteen opgeruimd, er is toch geen
+    // aflever-pad meer voor ze.
+    if let Err(e) = payload.require_task_delivery() {
+        let msg = e.to_string();
         tracing::error!(job_id = %job.id, error = %msg);
         let _ = document_convert::delete_upload(pool, payload.upload_id).await;
         job_queue::fail_job_terminal(pool, job.id, Some(serde_json::json!({ "error": msg })))
@@ -1406,34 +1410,13 @@ async fn process_next_document_convert_job(
     job_config.timeout = convert_deadline;
 
     match run_document_convert(pool, &job, &payload, &job_config, convert_deadline).await {
-        Ok(true) => {
+        Ok(()) => {
             // Taak-flow: `finish_document_convert_task_job` already inserted the
             // result-blob, completed the job, and created the review-taak,
             // atomically. Only the transient upload bytes remain to clean up.
             if let Err(e) = document_convert::delete_upload(pool, payload.upload_id).await {
                 tracing::warn!(job_id = %job.id, error = %e, "failed to delete document upload after success");
             }
-            Ok(JobOutcome::Processed)
-        }
-        Ok(false) => {
-            // The markdown is already committed to git at this point. Drop the
-            // transient upload bytes BEFORE propagating any complete_job error —
-            // otherwise a failed status update would `?`-return past the cleanup
-            // and leak the (up to 25 MiB) BYTEA row.
-            let complete_result = job_queue::complete_job(pool, job.id, None).await;
-            if let Err(e) = document_convert::delete_upload(pool, payload.upload_id).await {
-                tracing::warn!(job_id = %job.id, error = %e, "failed to delete document upload after success");
-            }
-            if let Err(e) = &complete_result {
-                // The markdown is already committed to git, but the status update
-                // failed. The job will show as in-progress until the orphan reaper
-                // reclaims it; log loudly so an operator can correlate.
-                tracing::error!(
-                    job_id = %job.id, error = %e, target = %payload.target_path,
-                    "document converted + committed, but marking the job completed failed"
-                );
-            }
-            complete_result?;
             Ok(JobOutcome::Processed)
         }
         Err(e) => {
@@ -1508,18 +1491,19 @@ async fn process_next_document_convert_job(
     }
 }
 
-/// Convert the uploaded document to markdown and deliver it - either pushed
-/// straight to the traject (old behaviour), or as a result-blob + review-taak
-/// (taak-flow, `payload.deliver_as_task()`). Returns `true` when the taak-flow
-/// ran: `finish_document_convert_task_job` already completed the job as part
-/// of its own transaction, so the caller must NOT call `complete_job` again.
+/// Convert the uploaded document to markdown and deliver it as a result-blob +
+/// review-taak (taak-flow — het enige aflever-pad; de guard in de aanroeper
+/// heeft al geborgd dat `payload.deliver_as_task()` waar is, en het oude
+/// directe-push-pad naar de traject-repo bestaat niet meer).
+/// `finish_document_convert_task_job` completes the job as part of its own
+/// transaction, so the caller must NOT call `complete_job` again.
 async fn run_document_convert(
     pool: &PgPool,
     job: &crate::models::Job,
     payload: &DocumentConvertPayload,
     config: &EnrichConfig,
     convert_deadline: Duration,
-) -> Result<bool> {
+) -> Result<()> {
     // Buitenste begrenzing ónder de reaper-window (zie de aanroeper): de
     // gedropte future komt niet meer aan zijn eigen tempdir-cleanup toe, dus
     // die doen we hier; kill_on_drop ruimt het agent-subprocess op.
@@ -1541,12 +1525,8 @@ async fn run_document_convert(
         }
         Ok(r) => r?,
     };
-    if payload.deliver_as_task() {
-        finish_document_convert_task_job(pool, job, payload, &markdown).await?;
-        return Ok(true);
-    }
-    document_convert::write_markdown_to_traject(pool, payload, &markdown).await?;
-    Ok(false)
+    finish_document_convert_task_job(pool, job, payload, &markdown).await?;
+    Ok(())
 }
 
 /// Verwerk één `law_convert`-job: geüpload document → gevalideerde
@@ -2342,6 +2322,19 @@ async fn process_next_enrich_job(
             return Ok(JobOutcome::Processed);
         }
         return process_enrich_task_job(pool, &job, &payload, enrich_config, job_timeout).await;
+    }
+
+    // Contract-borging (worker/traject-contract, zie de crate-doc): vanaf hier
+    // loopt het corpus-brede pad, dat met het centrale corpus-token naar de
+    // centrale corpus-repo pusht. Een payload met een traject-doel die niet
+    // via de taak-flow hierboven is afgebogen, is een enqueue-fout — terminaal
+    // falen in plaats van met het server-token door te pushen.
+    if let Err(e) = payload.require_corpus_wide_target() {
+        let msg = e.to_string();
+        tracing::error!(job_id = %job.id, law_id = %job.law_id, error = %msg);
+        job_queue::fail_job_terminal(pool, job.id, Some(serde_json::json!({ "error": msg })))
+            .await?;
+        return Ok(JobOutcome::Processed);
     }
 
     // Override the provider if the payload specifies one
@@ -3280,5 +3273,136 @@ mod tests {
         let root = HarvestPayload::for_law("BWBR0018451", None);
         let root_json = serde_json::to_string(&root).unwrap();
         assert!(!root_json.contains("depth"));
+    }
+}
+
+/// DB-backed borging van het worker/traject-contract op jobniveau (zie de
+/// crate-doc): een document-convert-job die niet via de taak-flow oplevert,
+/// wordt door [`process_next_document_convert_job`] terminaal geweigerd —
+/// vóór de conversie, zonder taak, zonder blob, en (structureel: het push-pad
+/// bestaat niet meer in `document_convert`) zonder ook maar een git-backend
+/// aan te raken.
+#[cfg(all(test, feature = "test-utils"))]
+mod contract_tests {
+    use super::*;
+    use crate::enrich::LlmProvider;
+    use crate::test_utils::TestDb;
+    use serde_json::json;
+
+    /// Seed een upload + document-convert-job zoals de upload-handler dat doet,
+    /// maar met een vrij te kiezen payload (om het contract te kunnen schenden).
+    async fn seed_job(db: &TestDb, payload: serde_json::Value) -> (uuid::Uuid, uuid::Uuid) {
+        let (upload_id,): (uuid::Uuid,) = sqlx::query_as(
+            "INSERT INTO document_uploads (traject_ref, filename, content_type, bytes) \
+             VALUES ('testtraject-abcd1234', 'bron.pdf', 'application/pdf', $1) RETURNING id",
+        )
+        .bind(vec![1u8, 2, 3])
+        .fetch_one(&db.pool)
+        .await
+        .expect("insert upload");
+
+        let mut payload = payload;
+        payload["upload_id"] = json!(upload_id);
+        let job = job_queue::create_job(
+            &db.pool,
+            CreateJobRequest::new(
+                JobType::DocumentConvert,
+                "doc:testtraject-abcd1234/report.md",
+            )
+            .with_traject_ref("testtraject-abcd1234")
+            .with_payload(payload)
+            .with_max_attempts(1),
+        )
+        .await
+        .expect("create job");
+        (job.id, upload_id)
+    }
+
+    async fn process_one(db: &TestDb) {
+        // De guard vuurt vóór de conversie; er wordt dus nooit een LLM
+        // gespawnd en de timeouts zijn niet relevant.
+        let config = EnrichConfig::for_test(LlmProvider::Claude {
+            path: "claude".into(),
+            model: None,
+        });
+        process_next_document_convert_job(
+            &db.pool,
+            &config,
+            Duration::from_secs(60),
+            Duration::from_secs(1800),
+        )
+        .await
+        .expect("verwerking hoort netjes af te ronden (met een terminaal gefaalde job)");
+    }
+
+    /// Assert dat de job terminaal gefaald is met de contractfout, de upload is
+    /// opgeruimd, en er niets is afgeleverd: geen review-taak, geen result-blob
+    /// — en dus aantoonbaar geen push-materiaal.
+    async fn assert_rejected_without_delivery(db: &TestDb, job_id: uuid::Uuid) {
+        let (status, error): (String, Option<String>) =
+            sqlx::query_as("SELECT status::text, result->>'error' FROM jobs WHERE id = $1")
+                .bind(job_id)
+                .fetch_one(&db.pool)
+                .await
+                .expect("job row");
+        assert_eq!(status, "failed", "de job faalt terminaal");
+        assert!(
+            error
+                .as_deref()
+                .unwrap_or_default()
+                .contains("deliver=task"),
+            "de fout benoemt het contract, kreeg: {error:?}"
+        );
+
+        let (uploads, tasks, blobs): (i64, i64, i64) = sqlx::query_as(
+            "SELECT (SELECT COUNT(*) FROM document_uploads), \
+                    (SELECT COUNT(*) FROM tasks), \
+                    (SELECT COUNT(*) FROM job_blobs)",
+        )
+        .fetch_one(&db.pool)
+        .await
+        .expect("counts");
+        assert_eq!(uploads, 0, "de upload-bytes zijn opgeruimd");
+        assert_eq!(tasks, 0, "geen taak: de guard faalt zonder aflever-pad");
+        assert_eq!(blobs, 0, "geen result-blob: er is niets opgeleverd");
+    }
+
+    #[tokio::test]
+    async fn document_convert_without_task_delivery_fails_terminally() {
+        // Een pre-taken-mechanisme-payload (geen deliver-veld): het oude
+        // directe-push-gedrag bestaat niet meer, dus dit moet terminaal falen.
+        let db = TestDb::new().await;
+        let (job_id, _upload) = seed_job(
+            &db,
+            json!({
+                "traject_id": uuid::Uuid::new_v4(),
+                "traject_ref": "testtraject-abcd1234",
+                "target_path": "report.md",
+            }),
+        )
+        .await;
+
+        process_one(&db).await;
+        assert_rejected_without_delivery(&db, job_id).await;
+    }
+
+    #[tokio::test]
+    async fn document_convert_task_delivery_without_requested_by_fails_terminally() {
+        // deliver=task zonder aanvrager: geen assignee voor de review-taak,
+        // dus ook geen aflever-pad — zelfde terminale weigering.
+        let db = TestDb::new().await;
+        let (job_id, _upload) = seed_job(
+            &db,
+            json!({
+                "traject_id": uuid::Uuid::new_v4(),
+                "traject_ref": "testtraject-abcd1234",
+                "target_path": "report.md",
+                "deliver": "task",
+            }),
+        )
+        .await;
+
+        process_one(&db).await;
+        assert_rejected_without_delivery(&db, job_id).await;
     }
 }


### PR DESCRIPTION
## Wat & waarom

Pipeline-workers mogen structureel niet met een server-token naar een traject-repo kunnen pushen; traject-writes lopen altijd via een review-taak, waarna de editor de commit doet namens de gebruiker (user-OAuth-token). Dat contract zat impliciet in de code — met één dood-maar-gevaarlijk direct-push-pad. Deze PR maakt het expliciet en dwingt het af:

- **Direct-push-pad verwijderd**: `write_markdown_to_traject` (incl. de writable-own-source-lookup) is weg uit `document_convert.rs`. De module bevat geen git-push-code meer — één nieuwe enqueue zonder `deliver:"task"` kan dus nooit meer met het server-token naar een user-repo pushen.
- **Guard op jobniveau (document_convert)**: `DocumentConvertPayload::require_task_delivery` — jobs zonder `deliver:"task"` + `requested_by` falen terminaal en luid, vóór de (kostbare) conversie. Spiegel van de bestaande `law_convert`-gate.
- **Guard voor het corpus-brede enrich-pad**: `EnrichPayload::require_corpus_wide_target` — een traject-gerichte payload (`traject_id`/`traject_ref`) die niet via de taak-flow afboog, faalt terminaal in plaats van met het centrale corpus-token door te pushen. Daarmee ligt vast dat `CORPUS_GIT_TOKEN` alleen de centrale corpus-repo raakt; de klassieke corpus-brede enrich blijft ongewijzigd werken.
- **Contract gedocumenteerd** in de crate-doc van `packages/pipeline/src/lib.rs` (worker/traject-contract, incl. verwijzing naar de guards en de flows die het al goed deden).

## Tests

- Unit-tests voor beide guards (weigering per variant + het geldige taak-flow-pad).
- DB-backed contract-tests op jobniveau (`worker::contract_tests`): een DocumentConvert-job met traject-doel en `deliver != "task"` (of zonder `requested_by`) faalt terminaal — geen taak, geen result-blob, upload opgeruimd, en er bestaat geen push-pad meer dat geraakt kán worden.
- `just check` volledig groen; pipeline-integratietests (`cargo test --test '*'`) ook.
