### PR TITLE
feat(editor): traject-indexscan valt terug op het user-token en faalt luid zonder token

### DIFF
--- a/frontend/src/LibraryView.vue
+++ b/frontend/src/LibraryView.vue
@@ -928,6 +928,22 @@ const isEmptyLibrary = computed(
   () => !loading.value && !indexError.value && !selectedLawId.value && sidebarSections.value.length === 0 && !isWerkdocMode.value && !isInstellingenMode.value && !isTakenMode.value,
 );
 
+// Supporting text for the index-error pane: prefer the backend's own
+// (Dutch) explanation — e.g. "De bibliotheek van dit traject is niet
+// beschikbaar: de traject-repo kon niet worden gescand (…)" — over the
+// generic fallback. Length-capped so an unexpected HTML/stack body from
+// an intermediary never floods the dialog.
+const indexErrorSupportingText = computed(() => {
+  const body = indexError.value?.body;
+  if (typeof body === 'string') {
+    const text = body.trim();
+    if (text && text.length <= 300 && !text.startsWith('<') && !text.startsWith('{')) {
+      return text;
+    }
+  }
+  return 'De gegevens konden niet worden opgehaald.';
+});
+
 // Tell the shell whether the library is empty so it can show the just-in-time
 // search coach-mark on the toolbar field; reset on unmount so it doesn't linger
 // on the editor route.
@@ -1166,6 +1182,17 @@ async function loadIndex() {
     // search popover instead.
     const ids = new Set([...(favorites.value || []), ...(changedIds || [])]);
     if (ids.size === 0) {
+      // In een traject is "niets samengesteld" niet hetzelfde als "alles in
+      // orde": als de traject-repo niet gescand kan worden weigert de backend
+      // de traject-bibliotheek expliciet (428 koppel-flow / 502 met uitleg).
+      // Probe die status ook zonder ids, zodat de gebruiker de foutstatus
+      // ziet in plaats van een normaal ogende lege bibliotheek.
+      if (trajectRef) {
+        await apiFetch(lawsListUrl(trajectRef, 'limit=1'), {
+          errorMessage: (status) => `Failed to load corpus: ${status}`,
+        });
+        if (!isCurrent()) return;
+      }
       laws.value = [];
       return;
     }
@@ -1548,7 +1575,7 @@ watch(activeTrajectRef, () => {
             <nldd-inline-dialog
               variant="alert"
               text="Wetten en regels zijn niet geladen"
-              supporting-text="De gegevens konden niet worden opgehaald."
+              :supporting-text="indexErrorSupportingText"
             >
               <nldd-button slot="actions" variant="primary" text="Probeer opnieuw" @click="retryLoadCorpus"></nldd-button>
               <nldd-button slot="actions" variant="secondary" text="Neem contact op via e-mail" :href="`mailto:${SUPPORT_EMAIL}`"></nldd-button>

--- a/packages/corpus/src/lib.rs
+++ b/packages/corpus/src/lib.rs
@@ -33,7 +33,7 @@ pub use github_api_backend::GitHubApiBackend;
 pub use models::{RegistryManifest, Source, SourceType};
 #[cfg(feature = "github")]
 pub use pr_client::PullRequestClient;
-pub use registry::{CorpusRegistry, SourceIndexFailure};
+pub use registry::{CorpusRegistry, ScanTokenOverride, SourceIndexFailure};
 #[cfg(feature = "github")]
 pub use repo_access::{validate_repo_access, RepoAccessError, RepoInfo};
 pub use source_map::SourceMap;

--- a/packages/corpus/src/registry.rs
+++ b/packages/corpus/src/registry.rs
@@ -15,6 +15,26 @@ pub struct SourceIndexFailure {
     pub error: String,
 }
 
+/// Per-call token override for the index scan of exactly **one** source.
+///
+/// Carries the acting user's personal GitHub token into the enumeration of
+/// a traject's writable-own repo when the server has no `CORPUS_AUTH_*`
+/// token for it — the scan-side mirror of the request-bound reads that
+/// already fall back to the user's token. Two hard rules keep the token
+/// contained:
+///
+/// * it is applied **only** when the server-side resolution for
+///   `source_id` yields no token (a source with its own service token
+///   keeps scanning with that), and never for any other source;
+/// * it lives for the duration of the call — the registry never stores it.
+#[derive(Clone, Copy)]
+pub struct ScanTokenOverride<'a> {
+    /// The one source id the override may authenticate.
+    pub source_id: &'a str,
+    /// The per-call token (e.g. the linked user's OAuth token).
+    pub token: &'a str,
+}
+
 /// Corpus registry that manages source definitions.
 ///
 /// Loads sources from `corpus-registry.yaml` and optionally merges
@@ -242,12 +262,28 @@ impl CorpusRegistry {
         &self,
         auth_file: Option<&Path>,
     ) -> Result<(SourceMap, Vec<SourceIndexFailure>)> {
+        self.index_all_sources_with_override(auth_file, None).await
+    }
+
+    /// [`Self::index_all_sources_async`] with an optional per-call
+    /// [`ScanTokenOverride`]: the traject build path passes the acting
+    /// user's token here so the writable-own repo can be enumerated when
+    /// the server has no token for it. See the override type for the
+    /// containment rules (single source, server token wins, never stored).
+    #[cfg(feature = "github")]
+    pub async fn index_all_sources_with_override(
+        &self,
+        auth_file: Option<&Path>,
+        scan_override: Option<ScanTokenOverride<'_>>,
+    ) -> Result<(SourceMap, Vec<SourceIndexFailure>)> {
         let mut map = SourceMap::new();
         let mut fetcher = crate::github::GitHubFetcher::new()?;
         let mut failed: Vec<SourceIndexFailure> = Vec::new();
 
         for source in &self.sources {
-            if let Err(e) = Self::index_one_source(&mut map, &mut fetcher, source, auth_file).await
+            if let Err(e) =
+                Self::index_one_source(&mut map, &mut fetcher, source, auth_file, scan_override)
+                    .await
             {
                 tracing::warn!(
                     source_id = %source.id,
@@ -290,6 +326,7 @@ impl CorpusRegistry {
         fetcher: &mut crate::github::GitHubFetcher,
         source: &Source,
         auth_file: Option<&Path>,
+        scan_override: Option<ScanTokenOverride<'_>>,
     ) -> Result<()> {
         match &source.source_type {
             SourceType::Local { .. } => {
@@ -302,9 +339,19 @@ impl CorpusRegistry {
                 // also a repo the server can index (and vice versa — no more
                 // "promote succeeded but the index reads with a different
                 // token and comes back empty").
-                let token = crate::auth::CredentialResolver::new(auth_file)
+                let mut token = crate::auth::CredentialResolver::new(auth_file)
                     .resolve_source(source)?
                     .into_token();
+                // Only when the server resolves NO token may the per-call
+                // override authenticate this scan — and only for the one
+                // source it was issued for. A configured service token always
+                // wins (mirroring the request-bound read fallback), and the
+                // override never reaches any other (seed) source.
+                if token.is_none() {
+                    if let Some(o) = scan_override.filter(|o| o.source_id == source.id) {
+                        token = Some(o.token.to_string());
+                    }
+                }
                 for (law_id, path, sha) in fetcher
                     .list_source_law_paths(github, token.as_deref())
                     .await?

--- a/packages/corpus/tests/index_scan_override.rs
+++ b/packages/corpus/tests/index_scan_override.rs
@@ -1,0 +1,214 @@
+//! Pint de inperkingsregels van [`ScanTokenOverride`] op de indexscan
+//! (`index_all_sources_with_override`):
+//!
+//! 1. het override-token authenticeert de scan van precies de source
+//!    waarvoor het is afgegeven (de writable-own van een traject) wanneer
+//!    de server géén token voor die source resolvet;
+//! 2. het override-token bereikt **nooit** een andere source — de seed
+//!    scant met z'n eigen servertoken (de mock matcht exact op dat token,
+//!    dus een gelekt user-token zou de seed-scan laten falen);
+//! 3. een geconfigureerd servertoken wint van het override-token — de
+//!    scan-spiegel van de request-gebonden read-fallback uit PR #955.
+//!
+//! GitHub wordt gespeeld door wiremock via de proces-brede
+//! `GITHUB_API_BASE`-seam; alle fases staan daarom in ÉÉN test.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use regelrecht_corpus::models::{GitHubSource, Scope, Source, SourceType};
+use regelrecht_corpus::{CorpusRegistry, ScanTokenOverride};
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const OWN_BRANCH: &str = "traject-branch";
+const SEED_BRANCH: &str = "main";
+
+fn github_source(
+    id: &str,
+    owner: &str,
+    repo: &str,
+    branch: &str,
+    priority: u32,
+    auth_ref: &str,
+    strict_auth: bool,
+) -> Source {
+    Source {
+        id: id.to_string(),
+        name: id.to_string(),
+        source_type: SourceType::GitHub {
+            github: GitHubSource {
+                owner: owner.to_string(),
+                repo: repo.to_string(),
+                branch: branch.to_string(),
+                path: None,
+                git_ref: None,
+            },
+        },
+        scopes: Vec::<Scope>::new(),
+        priority,
+        auth_ref: Some(auth_ref.to_string()),
+        strict_auth,
+    }
+}
+
+/// Trees-listing met één wet, alleen geserveerd wanneer de request het
+/// verwachte Bearer-token draagt. Elke andere request op dit pad valt
+/// door naar wiremock's default 404 — precies GitHub's gedrag op een
+/// privé-repo zonder (of met een verkeerd) token.
+async fn mount_tree_requiring_token(server: &MockServer, repo: &str, branch: &str, token: &str) {
+    Mock::given(method("GET"))
+        .and(path(format!("/repos/{repo}/git/trees/{branch}")))
+        .and(header("authorization", format!("Bearer {token}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "sha": "tree-sha",
+            "truncated": false,
+            "tree": [
+                {
+                    "path": format!("wet/wet_van_{}/2025-01-01.yaml", repo.replace(['/', '-'], "_")),
+                    "type": "blob",
+                    "sha": "blob-1",
+                },
+            ],
+        })))
+        .mount(server)
+        .await;
+}
+
+#[tokio::test]
+async fn scan_override_reaches_only_its_source_and_loses_from_server_tokens() {
+    let server = MockServer::start().await;
+    std::env::set_var("GITHUB_API_BASE", server.uri());
+    // De seed heeft een servertoken; de mock matcht er exact op, dus als
+    // de override daar zou lekken (Bearer user-token) faalt de seed-scan.
+    std::env::set_var("CORPUS_AUTH_EXAMPLE_SEED_REF_TOKEN", "seed-server-token");
+
+    let own = github_source(
+        "traject-own",
+        "example-org",
+        "example-own-repo",
+        OWN_BRANCH,
+        0,
+        // Geen CORPUS_AUTH_*-env voor deze ref: server resolvet géén token.
+        "example-unset-own-ref",
+        true,
+    );
+    let seed = github_source(
+        "seed-gh",
+        "example-org",
+        "example-seed-repo",
+        SEED_BRANCH,
+        2,
+        "example-seed-ref",
+        false,
+    );
+    let registry = CorpusRegistry::from_sources(vec![own, seed]);
+
+    mount_tree_requiring_token(
+        &server,
+        "example-org/example-own-repo",
+        OWN_BRANCH,
+        "user-token",
+    )
+    .await;
+    mount_tree_requiring_token(
+        &server,
+        "example-org/example-seed-repo",
+        SEED_BRANCH,
+        "seed-server-token",
+    )
+    .await;
+
+    // ------------------------------------------------------------------
+    // Fase 1: zonder override faalt de token-loze writable-own (404); de
+    // seed scant gewoon met z'n servertoken.
+    // ------------------------------------------------------------------
+    let (map, failed) = registry.index_all_sources_async(None).await.unwrap();
+    assert_eq!(failed.len(), 1, "alleen de token-loze own hoort te falen");
+    assert_eq!(failed[0].source_id, "traject-own");
+    assert!(
+        failed[0].error.contains("404"),
+        "scan-fout moet de onderliggende 404 dragen, got: {}",
+        failed[0].error
+    );
+    assert!(map
+        .get_law("wet_van_example_org_example_seed_repo")
+        .is_some());
+
+    // ------------------------------------------------------------------
+    // Fase 2: met override scant de own via het user-token; de seed
+    // blijft op z'n servertoken (mock zou anders niet matchen).
+    // ------------------------------------------------------------------
+    let (map, failed) = registry
+        .index_all_sources_with_override(
+            None,
+            Some(ScanTokenOverride {
+                source_id: "traject-own",
+                token: "user-token",
+            }),
+        )
+        .await
+        .unwrap();
+    assert!(
+        failed.is_empty(),
+        "beide sources moeten scannen: {failed:?}"
+    );
+    assert!(map
+        .get_law("wet_van_example_org_example_own_repo")
+        .is_some());
+    assert!(map
+        .get_law("wet_van_example_org_example_seed_repo")
+        .is_some());
+
+    // ------------------------------------------------------------------
+    // Fase 3: zodra de own-source wél een servertoken heeft, wint dat van
+    // de override. De trees-mock voor het servertoken serveert een ANDERE
+    // wet dan de user-token-mock, dus het resultaat verraadt welk token
+    // de scan droeg.
+    // ------------------------------------------------------------------
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/repos/example-org/example-own-repo/git/trees/{OWN_BRANCH}"
+        )))
+        .and(header("authorization", "Bearer own-server-token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "sha": "tree-sha-2",
+            "truncated": false,
+            "tree": [
+                { "path": "wet/wet_via_servertoken/2025-01-01.yaml", "type": "blob", "sha": "blob-2" },
+            ],
+        })))
+        .mount(&server)
+        .await;
+    std::env::set_var(
+        "CORPUS_AUTH_EXAMPLE_UNSET_OWN_REF_TOKEN",
+        "own-server-token",
+    );
+
+    let (map, failed) = registry
+        .index_all_sources_with_override(
+            None,
+            Some(ScanTokenOverride {
+                source_id: "traject-own",
+                token: "user-token",
+            }),
+        )
+        .await
+        .unwrap();
+    std::env::remove_var("CORPUS_AUTH_EXAMPLE_UNSET_OWN_REF_TOKEN");
+    assert!(
+        failed.is_empty(),
+        "scan met servertoken moet slagen: {failed:?}"
+    );
+    assert!(
+        map.get_law("wet_via_servertoken").is_some(),
+        "een geconfigureerd servertoken moet de scan dragen, niet de override"
+    );
+    assert!(
+        map.get_law("wet_van_example_org_example_own_repo")
+            .is_none(),
+        "de user-token-listing mag niet gebruikt zijn zodra er een servertoken is"
+    );
+
+    std::env::remove_var("CORPUS_AUTH_EXAMPLE_SEED_REF_TOKEN");
+    std::env::remove_var("GITHUB_API_BASE");
+}

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -370,8 +370,56 @@ async fn require_traject_scope(
     headers: &axum::http::HeaderMap,
     traject_ref: &str,
 ) -> Result<ReadScope, (StatusCode, String)> {
-    let traject = require_traject_corpus_from_ref(state, session, traject_ref).await?;
+    // Resolve the user's linked-token *candidate* BEFORE the corpus build:
+    // the index scan of a token-less writable-own repo authenticates with
+    // it (`ScanTokenOverride` scopes it to that one source, and only when
+    // the server resolves no token). A deferred 428 is swallowed here —
+    // seed-only browsing must keep working for unlinked users; the
+    // `ReadScope` re-resolves the token and raises the 428 at the call
+    // sites that actually need the writable-own source (including the
+    // traject-library gate in `require_traject_index`).
+    let scan_token = github_oauth::user_read_token(state, account.id, headers)
+        .await
+        .unwrap_or(None);
+    let traject = require_traject_corpus_from_ref_with_scan_token(
+        state,
+        session,
+        traject_ref,
+        scan_token.as_deref(),
+    )
+    .await?;
     Ok(ReadScope::for_traject(state, account.id, headers, traject).await)
+}
+
+/// Criterion "luid falen": when the traject's writable-own source failed
+/// to index, the traject-scoped law index must refuse to serve instead of
+/// presenting a normal-looking list in which every law silently resolved
+/// from the central seed corpus. A missing/expired GitHub link is the one
+/// *actionable* cause, so that surfaces as the deferred 428 (the connect
+/// flow); any other scan failure maps to an explicit 502 carrying the
+/// scan error. `/sources` deliberately stays outside this gate — the
+/// per-source `index_error` there is how the failure is diagnosed.
+fn require_traject_index(scope: &ReadScope) -> Result<(), (StatusCode, String)> {
+    let ReadScope::Traject(t) = scope else {
+        return Ok(());
+    };
+    let Some(err) = t.traject.own_index_error() else {
+        return Ok(());
+    };
+    // Deferred read-token outcome first: unlinked (or expired) in
+    // user-token mode → 428 into the koppel-flow.
+    t.own_read_token()?;
+    tracing::warn!(
+        error = %err,
+        "traject library refused: writable-own source failed to index"
+    );
+    Err((
+        StatusCode::BAD_GATEWAY,
+        format!(
+            "De bibliotheek van dit traject is niet beschikbaar: de traject-repo kon niet \
+             worden gescand ({err})"
+        ),
+    ))
 }
 
 /// GET /api/sources — list all registered corpus sources (global).
@@ -423,6 +471,9 @@ pub async fn list_traject_corpus_laws(
     headers: axum::http::HeaderMap,
 ) -> Result<Json<Vec<CorpusLawEntry>>, (StatusCode, String)> {
     let scope = require_traject_scope(&state, &session, &account, &headers, &traject_ref).await?;
+    // No silent central-only fallback: a traject whose own repo couldn't
+    // be scanned fails this listing loudly (428 koppel-flow / 502).
+    require_traject_index(&scope)?;
     Ok(Json(list_corpus_laws_in_scope(&scope, params)))
 }
 
@@ -1610,6 +1661,21 @@ pub(crate) async fn require_traject_corpus_from_ref(
     session: &Session,
     traject_ref: &str,
 ) -> Result<Arc<TrajectCorpus>, (StatusCode, String)> {
+    require_traject_corpus_from_ref_with_scan_token(state, session, traject_ref, None).await
+}
+
+/// [`require_traject_corpus_from_ref`] with the acting user's linked
+/// GitHub token as index-scan candidate (see
+/// [`TrajectCorpusCache::get_or_build`](crate::traject_corpus::TrajectCorpusCache::get_or_build)
+/// — transient, only for the writable-own source, never stored). Only the
+/// library read path resolves and passes a token; the write handlers keep
+/// the plain variant, their per-request tokens ride on the write itself.
+async fn require_traject_corpus_from_ref_with_scan_token(
+    state: &AppState,
+    session: &Session,
+    traject_ref: &str,
+    own_scan_token: Option<&str>,
+) -> Result<Arc<TrajectCorpus>, (StatusCode, String)> {
     let pool = state.pool.as_ref().ok_or((
         StatusCode::SERVICE_UNAVAILABLE,
         "database not configured".to_string(),
@@ -1664,7 +1730,7 @@ pub(crate) async fn require_traject_corpus_from_ref(
     };
     state
         .trajects
-        .get_or_build(pool, traject_id, auth_file)
+        .get_or_build(pool, traject_id, auth_file, own_scan_token)
         .await
         .map_err(traject_corpus_error)
 }

--- a/packages/editor-api/src/github_oauth.rs
+++ b/packages/editor-api/src/github_oauth.rs
@@ -1052,6 +1052,26 @@ pub async fn user_read_token_for_backend(
     if backend.is_writable() {
         return Ok(None);
     }
+    user_read_token(state, account_id, headers).await
+}
+
+/// [`user_read_token_for_backend`] without the backend probes: the raw
+/// requiredness gate + cookie resolution with the read-path messages.
+///
+/// Exists for the one caller that needs the token *before* any backend
+/// exists — the traject **index scan**, which resolves a candidate token
+/// ahead of `build_traject_corpus` so the enumeration of a token-less
+/// writable-own repo can authenticate as the acting user. Because there is
+/// no backend to scope the decision to, callers must treat the result as a
+/// *candidate*: apply it only where a server-side token is absent (the
+/// corpus-side [`regelrecht_corpus::ScanTokenOverride`] enforces that) and
+/// defer the `Err` (428 connect-flow) until a traject-scoped read actually
+/// needs the writable-own source.
+pub async fn user_read_token(
+    state: &AppState,
+    account_id: Uuid,
+    headers: &HeaderMap,
+) -> Result<Option<String>, (StatusCode, String)> {
     user_token_when_required(
         state,
         account_id,

--- a/packages/editor-api/src/traject_corpus.rs
+++ b/packages/editor-api/src/traject_corpus.rs
@@ -195,6 +195,16 @@ pub struct TrajectCorpus {
     /// guards, so a refresh mid-recompute cannot admit a second Compare
     /// call.
     changed_refresh_in_flight: Arc<AtomicBool>,
+    /// Whether this snapshot's index scan had a per-request user token
+    /// available as fallback for the writable-own source. Only a bool —
+    /// the token itself is **never** stored on this shared, cross-user
+    /// structure (nor in any cache key). [`TrajectCorpusCache::get_or_build`]
+    /// uses it to decide whether a snapshot whose writable-own scan failed
+    /// is worth rebuilding now that a request *does* carry a token: a
+    /// failure scanned *without* one may succeed with it; a failure
+    /// scanned *with* one waits for the TTL instead of re-scanning on
+    /// every request.
+    own_index_scanned_with_user_token: bool,
 }
 
 /// One scenario file in a law's cached listing: the filename plus the law
@@ -352,6 +362,19 @@ pub struct ImplementorsResult {
 }
 
 impl TrajectCorpus {
+    /// The index-scan failure of the **writable-own** source in this
+    /// snapshot, if any. `Some` means the traject's own laws are missing
+    /// from the index — every law would silently resolve from the seed
+    /// sources — so callers serving the traject-scoped library gate on
+    /// this and fail loudly instead of presenting a normal-looking
+    /// central-corpus-only list.
+    pub fn own_index_error(&self) -> Option<&str> {
+        self.corpus
+            .index_failures
+            .get(&self.writable_own_source_id)
+            .map(String::as_str)
+    }
+
     /// Resolve the YAML content for a law in this traject, preferring the
     /// post-save overlay over the source_map snapshot built at traject
     /// activation time.
@@ -1214,12 +1237,36 @@ impl TrajectCorpusCache {
     /// failed refresh extends the stale snapshot for another TTL window
     /// instead of erroring reads (same degrade-to-stale stance as
     /// [`TrajectCorpus::changed_law_ids`]).
+    ///
+    /// `own_scan_token` is the acting user's linked GitHub token, used
+    /// **transiently** as a fallback for the index scan of the traject's
+    /// writable-own source when the server has no token for it (the scan
+    /// mirror of the request-bound read fallback). It is never stored on
+    /// the cached snapshot or in any key — only the *result* of a scan is
+    /// shared, which is acceptable because the law metadata it produces is
+    /// visible to every traject member anyway. One extra rule: a cached
+    /// snapshot whose writable-own scan **failed without** a user token is
+    /// rebuilt synchronously when a request finally carries one — serving
+    /// the broken snapshot to that request would fail it loudly for no
+    /// reason when the user's own access can heal the index right now.
     pub async fn get_or_build(
         &self,
         pool: &PgPool,
         traject_id: Uuid,
         auth_file: Option<PathBuf>,
+        own_scan_token: Option<&str>,
     ) -> Result<Arc<TrajectCorpus>, TrajectCorpusError> {
+        // A snapshot whose writable-own scan failed while no user token was
+        // available is worth one immediate retry now that this request
+        // carries a token. (A failure scanned WITH a token is served as-is
+        // — retrying it per request would hammer GitHub with scans that
+        // keep failing; the TTL refresh retries on schedule.)
+        let heals_own_index = |corpus: &TrajectCorpus| {
+            own_scan_token.is_some()
+                && corpus.own_index_error().is_some()
+                && !corpus.own_index_scanned_with_user_token
+        };
+
         let slot = {
             let mut map = self.cells.write().await;
             map.entry(traject_id)
@@ -1233,6 +1280,10 @@ impl TrajectCorpusCache {
         {
             let state = slot.state.read().await;
             match state.as_ref() {
+                Some(cached) if heals_own_index(&cached.corpus) => {
+                    // Fall through to the synchronous build below: this
+                    // request's token can repair the broken index.
+                }
                 Some(cached) if cached.is_fresh(self.index_ttl) => {
                     tracing::debug!(traject = %traject_id, cache = "hit", "traject corpus served from cache");
                     return Ok(cached.corpus.clone());
@@ -1242,7 +1293,9 @@ impl TrajectCorpusCache {
                     drop(state);
                     // Stale: only one task refreshes (`try_lock`); everyone
                     // else — including the winner — serves stale rather than
-                    // queueing up behind a network round-trip.
+                    // queueing up behind a network round-trip. The refresh
+                    // borrows this request's scan token (owned copy for the
+                    // spawned task; dropped with it).
                     if let Ok(guard) = slot.build_lock.clone().try_lock_owned() {
                         spawn_background_refresh(
                             guard,
@@ -1250,6 +1303,7 @@ impl TrajectCorpusCache {
                             stale.clone(),
                             traject_id,
                             self.index_ttl,
+                            own_scan_token.map(str::to_string),
                         );
                     }
                     return Ok(stale);
@@ -1258,20 +1312,24 @@ impl TrajectCorpusCache {
             }
         }
 
-        // Nothing cached: every caller must wait for the one build.
+        // Nothing cached (or a broken-own-index snapshot this request's
+        // token can heal): every caller must wait for the one build.
         let _build = slot.build_lock.clone().lock_owned().await;
 
         // Re-check under the build lock: the previous holder may have
-        // built while we waited.
+        // built while we waited. A snapshot this request's token could
+        // still heal is NOT served — it is exactly what we came to rebuild.
         if let Some(cached) = slot.state.read().await.as_ref() {
-            tracing::debug!(traject = %traject_id, cache = "hit", "traject corpus served from cache");
-            return Ok(cached.corpus.clone());
+            if !heals_own_index(&cached.corpus) {
+                tracing::debug!(traject = %traject_id, cache = "hit", "traject corpus served from cache");
+                return Ok(cached.corpus.clone());
+            }
         }
 
         tracing::debug!(traject = %traject_id, cache = "cold", "building traject corpus (cold)");
         let corpus = timing::measure(
             "build",
-            build_traject_corpus(pool, traject_id, auth_file.as_deref()),
+            build_traject_corpus(pool, traject_id, auth_file.as_deref(), own_scan_token),
         )
         .await?;
 
@@ -1314,6 +1372,7 @@ fn spawn_background_refresh(
     old: Arc<TrajectCorpus>,
     traject_id: Uuid,
     index_ttl: Duration,
+    own_scan_token: Option<String>,
 ) {
     tokio::spawn(async move {
         let _guard = guard;
@@ -1327,8 +1386,13 @@ fn spawn_background_refresh(
         }
 
         let span = tracing::info_span!("traject_index_refresh", traject = %traject_id);
-        let outcome =
-            tracing::Instrument::instrument(refresh_traject_corpus(&old, traject_id), span).await;
+        let outcome = tracing::Instrument::instrument(
+            refresh_traject_corpus(&old, traject_id, own_scan_token.as_deref()),
+            span,
+        )
+        .await;
+        // `own_scan_token` dies with this task — the refreshed snapshot
+        // only ever carries the scan *result*.
         apply_refresh_outcome(&slot, old, traject_id, outcome).await;
     });
 }
@@ -1411,11 +1475,18 @@ impl From<regelrecht_corpus::error::CorpusError> for TrajectCorpusError {
 
 /// Build a fresh [`TrajectCorpus`]: load sources from DB, clone backends,
 /// produce a [`SourceMap`].
+///
+/// `own_scan_token`: per-call user-token fallback for the index scan of
+/// the writable-own source (see [`TrajectCorpusCache::get_or_build`]).
+/// Consumed by the enumeration only — it is not handed to the backends
+/// (request-bound reads/writes resolve their own per-request token) and
+/// never stored on the returned structure.
 #[tracing::instrument(name = "build_traject_corpus", skip_all, fields(traject = %traject_id))]
 async fn build_traject_corpus(
     pool: &PgPool,
     traject_id: Uuid,
     auth_file: Option<&std::path::Path>,
+    own_scan_token: Option<&str>,
 ) -> Result<Arc<TrajectCorpus>, TrajectCorpusError> {
     let rows = sqlx::query_as::<_, TrajectSourceRow>(
         "SELECT source_id, name, source_type::text AS source_type,
@@ -1505,8 +1576,10 @@ async fn build_traject_corpus(
                 auth_ref = ?source.auth_ref,
                 auth_file = ?auth_file,
                 expected_env = %expected_env,
-                "traject writable-own source resolved NO token — pushes will fail, and \
-                 on a private repo reads/index scans fail too (laws fall back to seed sources)"
+                user_scan_token = own_scan_token.is_some(),
+                "traject writable-own source resolved NO server token — server-side pushes \
+                 fail, and on a private repo reads/index scans only work through the acting \
+                 user's linked GitHub token (user_scan_token says whether this build has one)"
             );
         }
 
@@ -1600,49 +1673,61 @@ async fn build_traject_corpus(
     // failing entirely on what is usually a transient GitHub hiccup. The hard
     // failure path is the writable-own *backend* init above, which returns
     // `Err` so a broken write target never opens silently.
-    let (source_map, index_failures) =
-        match timing::measure("index", registry.index_all_sources_async(auth_file)).await {
-            Ok((map, failed)) => {
-                if let Some(f) = failed
-                    .iter()
-                    .find(|f| f.source_id == writable_own_source_id)
-                {
-                    tracing::error!(
-                        traject = %traject_id,
-                        source_id = %writable_own_source_id,
-                        error = %f.error,
-                        "traject writable-own source failed to index — the traject's own laws \
-                         are missing from the bibliotheek and silently resolve from the seed \
-                         sources until the scan succeeds"
-                    );
-                }
-                let failures: HashMap<String, String> =
-                    failed.into_iter().map(|f| (f.source_id, f.error)).collect();
-                (map, failures)
-            }
-            Err(e) => {
-                tracing::warn!(
+    // The scan may fall back to the acting user's token for the
+    // writable-own source — and only for that source, only when the
+    // server-side resolution yields no token (both enforced corpus-side
+    // by `ScanTokenOverride`).
+    let scan_override = own_scan_token.map(|token| regelrecht_corpus::ScanTokenOverride {
+        source_id: &writable_own_source_id,
+        token,
+    });
+    let (source_map, index_failures) = match timing::measure(
+        "index",
+        registry.index_all_sources_with_override(auth_file, scan_override),
+    )
+    .await
+    {
+        Ok((map, failed)) => {
+            if let Some(f) = failed
+                .iter()
+                .find(|f| f.source_id == writable_own_source_id)
+            {
+                tracing::error!(
                     traject = %traject_id,
-                    error = %e,
-                    "traject corpus load failed, falling back to local-only"
+                    source_id = %writable_own_source_id,
+                    error = %f.error,
+                    "traject writable-own source failed to index — the traject-scoped \
+                     library refuses to serve (no silent fallback to seed-only laws) \
+                     until a scan succeeds"
                 );
-                // Local-only fallback: every non-local source is absent from
-                // the map, so record the enumeration error against each of
-                // them — `/sources` then shows why their law_count is 0.
-                let failures: HashMap<String, String> = registry
-                    .sources()
-                    .iter()
-                    .filter(|s| matches!(s.source_type, SourceType::GitHub { .. }))
-                    .map(|s| (s.id.clone(), e.to_string()))
-                    .collect();
-                (
-                    registry
-                        .load_local_sources()
-                        .unwrap_or_else(|_| SourceMap::new()),
-                    failures,
-                )
             }
-        };
+            let failures: HashMap<String, String> =
+                failed.into_iter().map(|f| (f.source_id, f.error)).collect();
+            (map, failures)
+        }
+        Err(e) => {
+            tracing::warn!(
+                traject = %traject_id,
+                error = %e,
+                "traject corpus load failed, falling back to local-only"
+            );
+            // Local-only fallback: every non-local source is absent from
+            // the map, so record the enumeration error against each of
+            // them — `/sources` then shows why their law_count is 0.
+            let failures: HashMap<String, String> = registry
+                .sources()
+                .iter()
+                .filter(|s| matches!(s.source_type, SourceType::GitHub { .. }))
+                .map(|s| (s.id.clone(), e.to_string()))
+                .collect();
+            (
+                registry
+                    .load_local_sources()
+                    .unwrap_or_else(|_| SourceMap::new()),
+                failures,
+            )
+        }
+    };
 
     Ok(Arc::new(TrajectCorpus {
         corpus: CorpusState {
@@ -1666,6 +1751,9 @@ async fn build_traject_corpus(
         scenario_list_cache: RwLock::new(BoundedCache::default()),
         sidecar_write_gen: AtomicU64::new(0),
         scenario_list_write_gen: AtomicU64::new(0),
+        // Only the *fact* that a user token was available; the token
+        // itself dies with this call.
+        own_index_scanned_with_user_token: own_scan_token.is_some(),
     }))
 }
 
@@ -1703,11 +1791,21 @@ async fn build_traject_corpus(
 async fn refresh_traject_corpus(
     old: &Arc<TrajectCorpus>,
     traject_id: Uuid,
+    own_scan_token: Option<&str>,
 ) -> Result<Arc<TrajectCorpus>, TrajectCorpusError> {
     let registry = old.corpus.registry.clone();
     let auth_file = old.corpus.auth_file.clone();
+    // Same user-token fallback as the cold build: without it, a traject
+    // whose writable-own repo is only readable through the acting user's
+    // token could never refresh its index (every TTL refresh would fail
+    // and re-arm the stale snapshot forever). Transient, like everywhere
+    // else — the refreshed snapshot never carries the token.
+    let scan_override = own_scan_token.map(|token| regelrecht_corpus::ScanTokenOverride {
+        source_id: &old.writable_own_source_id,
+        token,
+    });
     let (source_map, failed) = registry
-        .index_all_sources_async(auth_file.as_deref())
+        .index_all_sources_with_override(auth_file.as_deref(), scan_override)
         .await?;
     if !failed.is_empty() {
         let details: Vec<String> = failed
@@ -1762,6 +1860,11 @@ async fn next_snapshot(old: &Arc<TrajectCorpus>, source_map: SourceMap) -> Arc<T
         scenario_list_cache: RwLock::new(BoundedCache::default()),
         sidecar_write_gen: AtomicU64::new(0),
         scenario_list_write_gen: AtomicU64::new(0),
+        // A refresh only lands when every source enumerated, so this
+        // snapshot has no own-index failure the flag could qualify;
+        // carrying the old value keeps the field truthful about how the
+        // *last* failed scan (if the caller re-arms `old`) was attempted.
+        own_index_scanned_with_user_token: old.own_index_scanned_with_user_token,
     })
 }
 
@@ -2060,6 +2163,7 @@ mod tests {
             scenario_list_cache: RwLock::new(BoundedCache::default()),
             sidecar_write_gen: AtomicU64::new(0),
             scenario_list_write_gen: AtomicU64::new(0),
+            own_index_scanned_with_user_token: false,
         }
     }
 
@@ -2522,6 +2626,7 @@ mod tests {
             scenario_list_cache: RwLock::new(BoundedCache::default()),
             sidecar_write_gen: AtomicU64::new(0),
             scenario_list_write_gen: AtomicU64::new(0),
+            own_index_scanned_with_user_token: false,
         })
     }
 
@@ -2548,7 +2653,7 @@ mod tests {
         write_law_file(dir.path(), "wet_b", "$id: wet_b\nname: nieuw\n");
         assert!(old.corpus.source_map.get_law("wet_b").is_none());
 
-        let refreshed = refresh_traject_corpus(&old, Uuid::new_v4())
+        let refreshed = refresh_traject_corpus(&old, Uuid::new_v4(), None)
             .await
             .expect("local refresh must succeed");
 
@@ -2599,7 +2704,7 @@ mod tests {
             "regeling_a",
             &law_body("regeling_a", Some("wet_hoger")),
         );
-        let refreshed = refresh_traject_corpus(&old, Uuid::new_v4())
+        let refreshed = refresh_traject_corpus(&old, Uuid::new_v4(), None)
             .await
             .expect("local refresh must succeed");
 
@@ -2748,7 +2853,7 @@ mod tests {
         // Another replica / a direct push moves the branch past our save.
         write_law_file(dir.path(), "wet_a", "$id: wet_a\nname: extern\n");
 
-        let refreshed = refresh_traject_corpus(&old, Uuid::new_v4())
+        let refreshed = refresh_traject_corpus(&old, Uuid::new_v4(), None)
             .await
             .expect("local refresh must succeed");
 
@@ -2774,7 +2879,7 @@ mod tests {
         old.record_save("wet_a".to_string(), "$id: wet_a\nname: saved\n".to_string())
             .await;
 
-        let refreshed = refresh_traject_corpus(&old, Uuid::new_v4())
+        let refreshed = refresh_traject_corpus(&old, Uuid::new_v4(), None)
             .await
             .expect("local refresh must succeed");
 
@@ -2826,6 +2931,7 @@ mod tests {
             old.clone(),
             Uuid::new_v4(),
             Duration::from_secs(60),
+            None,
         );
 
         let refreshed = wait_for(|| {

--- a/packages/editor-api/tests/traject_index_user_token_test.rs
+++ b/packages/editor-api/tests/traject_index_user_token_test.rs
@@ -1,0 +1,466 @@
+//! Integratietests voor ticket "traject-indexscan: user-token fallback +
+//! luid falen zonder token" (vervolg op #953/#955).
+//!
+//! Zelfde deployed-achtige federatie-config als `traject_own_index_test.rs`
+//! — GitHub-backed writable-own zonder server-side `CORPUS_AUTH_*`-token,
+//! lokale seed als centraal corpus, user-token-schrijfmodus aan — maar nu
+//! rond de **indexscan** zelf:
+//!
+//! 1. **User-token scan (happy path).** De privé traject-repo is alleen
+//!    leesbaar met het gekoppelde user-token (de Trees-mock matcht exact op
+//!    `Bearer user-token`). De traject-bibliotheek toont de wet dan uit de
+//!    traject-repo (priority 0), federatie met de seed blijft werken, en
+//!    `/sources` is gezond.
+//! 2. **Snapshot deelbaar, token niet.** Een tweede lid zónder gekoppeld
+//!    GitHub-account wordt uit de gecachte snapshot bediend (metadata is
+//!    voor alle leden zichtbaar) — maar na een cache-invalidatie kan de
+//!    server de repo NIET meer scannen: het token is nergens bewaard, de
+//!    herbouwde index faalt en de bibliotheek faalt **luid** met de
+//!    428-koppel-flow in plaats van stil alleen seed-wetten te tonen.
+//! 3. **Zelfheling.** Zodra een request mét gekoppeld token binnenkomt,
+//!    wordt de kapotte (token-loos gescande) snapshot synchroon herbouwd
+//!    en is de bibliotheek weer gezond.
+//! 4. **Gekoppeld maar geen toegang.** Faalt de scan ook mét user-token,
+//!    dan is de fout een expliciete 502 (met de scan-fout), geen 428 en
+//!    geen stille fallback. `index_error` blijft zichtbaar op `/sources`.
+//!
+//! GitHub wordt gespeeld door wiremock via de proces-brede
+//! `GITHUB_API_BASE`-seam — daarom staan alle scenario's in ÉÉN test.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::Arc;
+
+use axum::extract::{Extension, Path, Query, State};
+use axum::http::{HeaderMap, StatusCode};
+use pretty_assertions::assert_eq;
+use sqlx::PgPool;
+use tokio::sync::{Mutex, RwLock};
+use tower_sessions::Session;
+use tower_sessions_memory_store::MemoryStore;
+use uuid::Uuid;
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use regelrecht_auth::handlers::{
+    SESSION_KEY_EMAIL, SESSION_KEY_EMAIL_VERIFIED, SESSION_KEY_NAME, SESSION_KEY_SUB,
+};
+use regelrecht_corpus::dto::PaginationParams;
+use regelrecht_editor_api::accounts::AccountRecord;
+use regelrecht_editor_api::config::AppConfig;
+use regelrecht_editor_api::corpus_handlers::{list_traject_corpus_laws, list_traject_sources};
+use regelrecht_editor_api::github_oauth::{self, GithubOAuth};
+use regelrecht_editor_api::state::{AppState, CorpusState};
+use regelrecht_editor_api::traject_corpus::TrajectCorpusCache;
+
+use regelrecht_pipeline::test_utils::TestDb;
+
+const TRAJECT_LAW: &str = "wet_traject_eigen";
+const SEED_ONLY_LAW: &str = "wet_alleen_centraal";
+const OWN_BRANCH: &str = "traject-voorbeeld";
+const OWN_SUBPATH: &str = "corpus/regulation";
+const USER_TOKEN: &str = "user-token";
+
+fn state_with_user_token_mode(pool: PgPool, oauth: GithubOAuth) -> AppState {
+    AppState {
+        corpus: Arc::new(RwLock::new(CorpusState::empty())),
+        oidc_client: None,
+        end_session_url: None,
+        config: Arc::new(AppConfig {
+            oidc: None,
+            base_url: None,
+            github_oauth: Some(oauth),
+            task_enrich_provider: "claude".to_string(),
+        }),
+        http_client: reqwest::Client::new(),
+        pool: Some(pool),
+        pipeline_api_url: None,
+        harvest_admin_url: None,
+        reload_lock: Arc::new(Mutex::new(())),
+        trajects: Arc::new(TrajectCorpusCache::new()),
+    }
+}
+
+async fn seed_account(pool: &PgPool, email: &str) -> (Uuid, String) {
+    let sub = format!("sub-{email}");
+    let (id,): (Uuid,) = sqlx::query_as(
+        "INSERT INTO accounts (person_sub, email, name) VALUES ($1, $2, $3) RETURNING id",
+    )
+    .bind(&sub)
+    .bind(email)
+    .bind("Test User")
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    (id, sub)
+}
+
+/// Traject zoals deployed: GitHub writable-own op een user-gekozen repo
+/// (auth_ref zonder geconfigureerd `CORPUS_AUTH_*_TOKEN`-env → server-side
+/// géén token) plus een lokale read-seed die het centrale corpus speelt.
+async fn seeded_traject(
+    pool: &PgPool,
+    owner_id: Uuid,
+    own_repo_owner: &str,
+    own_repo_name: &str,
+    seed_dir: &std::path::Path,
+) -> Uuid {
+    let (traject_id,): (Uuid,) = sqlx::query_as(
+        "INSERT INTO trajects (name, description, scope, created_by)
+         VALUES ('Test', '', '', $1) RETURNING id",
+    )
+    .bind(owner_id)
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO traject_members (traject_id, account_id, role)
+         VALUES ($1, $2, 'owner')",
+    )
+    .bind(traject_id)
+    .bind(owner_id)
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO traject_corpus_sources
+         (traject_id, source_id, name, source_type,
+          gh_owner, gh_repo, gh_branch, gh_base_branch, gh_path,
+          priority, auth_ref, is_writable_own)
+         VALUES ($1, 'traject-own-test', 'Eigen repo', 'github'::corpus_source_type,
+                 $2, $3, $4, 'main', $5,
+                 0, 'example-unset-token-ref', TRUE)",
+    )
+    .bind(traject_id)
+    .bind(own_repo_owner)
+    .bind(own_repo_name)
+    .bind(OWN_BRANCH)
+    .bind(OWN_SUBPATH)
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO traject_corpus_sources
+         (traject_id, source_id, name, source_type, local_path,
+          priority, scopes, is_writable_own)
+         VALUES ($1, 'central-seed', 'Centrale Corpus', 'local'::corpus_source_type, $2,
+                 2, '[]'::jsonb, FALSE)",
+    )
+    .bind(traject_id)
+    .bind(seed_dir.to_string_lossy().to_string())
+    .execute(pool)
+    .await
+    .unwrap();
+    traject_id
+}
+
+async fn add_member(pool: &PgPool, traject_id: Uuid, account_id: Uuid) {
+    sqlx::query(
+        "INSERT INTO traject_members (traject_id, account_id, role)
+         VALUES ($1, $2, 'contributor')",
+    )
+    .bind(traject_id)
+    .bind(account_id)
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+fn traject_ref(traject_id: Uuid) -> String {
+    format!("test-{}", &traject_id.to_string()[..8])
+}
+
+async fn session_for(sub: &str, email: &str) -> Session {
+    let session = Session::new(None, Arc::new(MemoryStore::default()), None);
+    session.insert(SESSION_KEY_SUB, sub).await.unwrap();
+    session.insert(SESSION_KEY_NAME, "Test User").await.unwrap();
+    session.insert(SESSION_KEY_EMAIL, email).await.unwrap();
+    session
+        .insert(SESSION_KEY_EMAIL_VERIFIED, true)
+        .await
+        .unwrap();
+    session
+}
+
+fn write_central_law(central_dir: &std::path::Path, law_id: &str) {
+    let law_dir = central_dir.join("wet").join(law_id);
+    std::fs::create_dir_all(&law_dir).unwrap();
+    std::fs::write(
+        law_dir.join("2025-01-01.yaml"),
+        format!("$id: {law_id}\nname: Centrale versie\n"),
+    )
+    .unwrap();
+}
+
+/// De Trees-listing van de traject-repo — alleen geserveerd wanneer de
+/// request het gekoppelde user-token draagt. Elke andere (token-loze)
+/// request valt door naar wiremock's default 404: GitHub's gedrag op een
+/// privé-repo zonder token.
+async fn mount_tree_requiring_user_token(server: &MockServer, own_repo: &str) {
+    Mock::given(method("GET"))
+        .and(path(format!("/repos/{own_repo}/git/trees/{OWN_BRANCH}")))
+        .and(header("authorization", format!("Bearer {USER_TOKEN}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "sha": "tree-sha",
+            "truncated": false,
+            "tree": [
+                {
+                    "path": format!("{OWN_SUBPATH}/wet/{TRAJECT_LAW}/2025-01-01.yaml"),
+                    "type": "blob",
+                    "sha": "blob-2025",
+                },
+            ],
+        })))
+        .mount(server)
+        .await;
+}
+
+fn ids_query() -> Query<PaginationParams> {
+    Query(PaginationParams {
+        offset: 0,
+        limit: None,
+        q: None,
+        ids: Some(format!("{TRAJECT_LAW},{SEED_ONLY_LAW}")),
+    })
+}
+
+fn cookie_headers(oauth: &GithubOAuth, account_id: Uuid) -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        axum::http::header::COOKIE,
+        axum::http::HeaderValue::from_str(&github_oauth::seal_token_cookie_for_tests(
+            oauth, account_id, USER_TOKEN,
+        ))
+        .unwrap(),
+    );
+    headers
+}
+
+/// Eén test voor alle scenario's: de `GITHUB_API_BASE`-override is
+/// proces-breed, dus parallelle tests met elk een eigen mockserver zouden
+/// elkaars fetchers verhangen.
+#[tokio::test]
+async fn traject_index_scans_with_user_token_and_fails_loud_without_any_token() {
+    let server = MockServer::start().await;
+    std::env::set_var("GITHUB_API_BASE", server.uri());
+
+    let db = TestDb::new().await;
+    let central = tempfile::tempdir().unwrap();
+    write_central_law(central.path(), TRAJECT_LAW);
+    write_central_law(central.path(), SEED_ONLY_LAW);
+
+    let oauth = GithubOAuth::for_tests(true); // user-token-modus aan
+    let state = state_with_user_token_mode(db.pool.clone(), oauth.clone());
+
+    // Alice heeft haar GitHub-account gekoppeld; Bob (ook lid) niet.
+    let (alice_id, alice_sub) = seed_account(&db.pool, "alice@test.local").await;
+    let (bob_id, bob_sub) = seed_account(&db.pool, "bob@test.local").await;
+    let alice = AccountRecord {
+        id: alice_id,
+        person_sub: alice_sub.clone(),
+        email: "alice@test.local".to_string(),
+        name: "Test User".to_string(),
+    };
+    let bob = AccountRecord {
+        id: bob_id,
+        person_sub: bob_sub.clone(),
+        email: "bob@test.local".to_string(),
+        name: "Test User".to_string(),
+    };
+    let alice_headers = cookie_headers(&oauth, alice.id);
+
+    // ------------------------------------------------------------------
+    // Scenario 1 (happy path): privé repo, alleen leesbaar met Alice's
+    // user-token → de scan slaagt via dat token en de traject-wet wint op
+    // priority 0. De seed-only wet blijft zichtbaar (federatie).
+    // ------------------------------------------------------------------
+    let repo_a = "example-org/example-private-repo";
+    let traject_a = seeded_traject(
+        &db.pool,
+        alice_id,
+        "example-org",
+        "example-private-repo",
+        central.path(),
+    )
+    .await;
+    add_member(&db.pool, traject_a, bob_id).await;
+    let tref_a = traject_ref(traject_a);
+    mount_tree_requiring_user_token(&server, repo_a).await;
+
+    let laws = list_traject_corpus_laws(
+        State(state.clone()),
+        Extension(alice.clone()),
+        session_for(&alice_sub, &alice.email).await,
+        Path(tref_a.clone()),
+        ids_query(),
+        alice_headers.clone(),
+    )
+    .await
+    .expect("scan via user-token: de bibliotheek moet werken");
+    assert_eq!(
+        laws.0.len(),
+        2,
+        "traject-wet + seed-only wet, got {:?}",
+        laws.0
+    );
+    let traject_law = laws.0.iter().find(|l| l.law_id == TRAJECT_LAW).unwrap();
+    assert_eq!(
+        traject_law.source_id, "traject-own-test",
+        "de traject-wet moet uit de traject-eigen source komen, niet de seed"
+    );
+    assert_eq!(traject_law.source_priority, 0);
+    let seed_law = laws.0.iter().find(|l| l.law_id == SEED_ONLY_LAW).unwrap();
+    assert_eq!(
+        seed_law.source_id, "central-seed",
+        "seed-only wetten blijven zichtbaar zodra de traject-scan slaagt"
+    );
+
+    let sources = list_traject_sources(
+        State(state.clone()),
+        Extension(alice.clone()),
+        session_for(&alice_sub, &alice.email).await,
+        Path(tref_a.clone()),
+        alice_headers.clone(),
+    )
+    .await
+    .expect("sources-listing moet slagen");
+    let own = sources
+        .0
+        .iter()
+        .find(|s| s.id == "traject-own-test")
+        .unwrap();
+    assert_eq!(own.law_count, 1, "de traject-wet telt mee in de index");
+    assert_eq!(own.index_error, None, "gezonde scan → geen index_error");
+
+    // ------------------------------------------------------------------
+    // Scenario 2a: de gecachte snapshot (het scan-*resultaat*) is deelbaar
+    // — Bob, zonder koppeling, wordt eruit bediend. Metadata is voor alle
+    // traject-leden zichtbaar; het token zelf zit nergens in.
+    // ------------------------------------------------------------------
+    let laws = list_traject_corpus_laws(
+        State(state.clone()),
+        Extension(bob.clone()),
+        session_for(&bob_sub, &bob.email).await,
+        Path(tref_a.clone()),
+        ids_query(),
+        HeaderMap::new(),
+    )
+    .await
+    .expect("gecachte gezonde snapshot bedient ook ongekoppelde leden");
+    assert_eq!(laws.0.len(), 2);
+
+    // ------------------------------------------------------------------
+    // Scenario 2b: na een cache-invalidatie moet de server opnieuw
+    // scannen. Bob's request draagt geen token en Alice's token is
+    // nergens bewaard → de scan faalt (unauthenticated Trees → 404) en de
+    // bibliotheek faalt LUID met de 428-koppel-flow — geen stille lijst
+    // met alleen seed-wetten.
+    // ------------------------------------------------------------------
+    state.trajects.invalidate(traject_a).await;
+    let err = list_traject_corpus_laws(
+        State(state.clone()),
+        Extension(bob.clone()),
+        session_for(&bob_sub, &bob.email).await,
+        Path(tref_a.clone()),
+        ids_query(),
+        HeaderMap::new(),
+    )
+    .await
+    .expect_err("zonder enig token mag de bibliotheek NIET stil terugvallen op de seed");
+    assert_eq!(
+        err.0,
+        StatusCode::PRECONDITION_REQUIRED,
+        "ongekoppeld in user-token-modus → 428 de koppel-flow in, got: {}: {}",
+        err.0,
+        err.1
+    );
+
+    // Criterium: `index_error` blijft ondertussen zichtbaar op /sources —
+    // dat endpoint is de diagnose-route en valt buiten de poort.
+    let sources = list_traject_sources(
+        State(state.clone()),
+        Extension(bob.clone()),
+        session_for(&bob_sub, &bob.email).await,
+        Path(tref_a.clone()),
+        HeaderMap::new(),
+    )
+    .await
+    .expect("/sources moet ook bij een kapotte scan blijven werken");
+    let own = sources
+        .0
+        .iter()
+        .find(|s| s.id == "traject-own-test")
+        .unwrap();
+    assert_eq!(own.law_count, 0);
+    let index_err = own
+        .index_error
+        .as_deref()
+        .expect("gefaalde scan moet een index_error op de source zetten");
+    assert!(index_err.contains("404"), "got: {index_err}");
+
+    // ------------------------------------------------------------------
+    // Scenario 3 (zelfheling): Alice's volgende request draagt wél een
+    // token → de kapotte token-loos-gescande snapshot wordt synchroon
+    // herbouwd en de bibliotheek is weer gezond.
+    // ------------------------------------------------------------------
+    let laws = list_traject_corpus_laws(
+        State(state.clone()),
+        Extension(alice.clone()),
+        session_for(&alice_sub, &alice.email).await,
+        Path(tref_a.clone()),
+        ids_query(),
+        alice_headers.clone(),
+    )
+    .await
+    .expect("een request mét token moet de kapotte snapshot herbouwen");
+    assert_eq!(laws.0.len(), 2);
+    assert_eq!(
+        laws.0
+            .iter()
+            .find(|l| l.law_id == TRAJECT_LAW)
+            .unwrap()
+            .source_priority,
+        0
+    );
+
+    // ------------------------------------------------------------------
+    // Scenario 4: gekoppeld maar géén toegang — de scan faalt ook mét
+    // user-token (repo zonder Trees-mock → altijd 404). Expliciete 502
+    // met de scan-fout, geen 428 (koppelen lost dit niet op) en geen
+    // stille seed-fallback.
+    // ------------------------------------------------------------------
+    let traject_b = seeded_traject(
+        &db.pool,
+        alice_id,
+        "example-org",
+        "example-no-access-repo",
+        central.path(),
+    )
+    .await;
+    let tref_b = traject_ref(traject_b);
+
+    let err = list_traject_corpus_laws(
+        State(state.clone()),
+        Extension(alice.clone()),
+        session_for(&alice_sub, &alice.email).await,
+        Path(tref_b.clone()),
+        ids_query(),
+        alice_headers.clone(),
+    )
+    .await
+    .expect_err("scan-fout mét token → expliciete fout, geen stille fallback");
+    assert_eq!(
+        err.0,
+        StatusCode::BAD_GATEWAY,
+        "gekoppeld-maar-geen-toegang is geen koppel-probleem: 502, got: {}: {}",
+        err.0,
+        err.1
+    );
+    assert!(
+        err.1.contains("404"),
+        "de fout moet de onderliggende scan-fout dragen, got: {}",
+        err.1
+    );
+
+    std::env::remove_var("GITHUB_API_BASE");
+}

--- a/packages/editor-api/tests/traject_own_index_test.rs
+++ b/packages/editor-api/tests/traject_own_index_test.rs
@@ -7,13 +7,16 @@
 //! schrijven via het gekoppelde user-token:
 //!
 //! 1. **Onleesbare traject-repo (het prod-symptoom).** De promote slaagt
-//!    (write met user-token), maar de server-side indexscan van de
-//!    writable-own faalt — zoals op een privé-repo zonder geconfigureerd
-//!    token: unauthenticated Trees-API geeft 404. De wet resolvet dan stil
-//!    uit de seed (priority 2) in plaats van de traject-repo (priority 0):
-//!    exact het waargenomen gedrag. De test pint dat `GET .../sources` dit
-//!    niet langer stil laat: de writable-own toont `law_count: 0` mét een
-//!    `index_error`, in plaats van alleen een nietszeggende 0.
+//!    (write met user-token), maar de indexscan van de writable-own faalt
+//!    — zoals op een privé-repo zonder geconfigureerd token:
+//!    unauthenticated Trees-API geeft 404, en hier faalt ook het
+//!    user-token (ongemockt trees-pad). Sinds de user-token-fallback op de
+//!    scan valt de bibliotheek dan niet langer stil terug op de seed: de
+//!    listing faalt luid (428 zonder gekoppeld token, 502 mét token dat
+//!    de repo alsnog niet kan lezen). `GET .../sources` blijft de diagnose
+//!    dragen: de writable-own toont `law_count: 0` mét een `index_error`.
+//!    (De volledige user-token-scanflow — succes via het token, heling na
+//!    een kapotte snapshot — staat in `traject_index_user_token_test.rs`.)
 //! 2. **Happy path van #952.** Zodra de scan de traject-repo wél kan lezen
 //!    (Trees-API geeft de gepromote bestanden terug), staat de wet in de
 //!    traject-index op `source_priority: 0` en is de source gezond
@@ -323,9 +326,10 @@ async fn traject_index_shows_promoted_law_and_surfaces_failed_own_scans() {
     assert_eq!(response.0.copied_files, 3, "2 versies + 1 scenario");
 
     // …maar de herbouwde index (promote invalideert de cache) mist de
-    // traject-repo: de wet valt stil terug op de seed. Dit ís het
-    // gerapporteerde prod-gedrag — gereproduceerd zonder GitHub-token.
-    let laws = list_traject_corpus_laws(
+    // traject-repo. Sinds de user-token-fallback op de indexscan valt de
+    // bibliotheek dan niet langer stil terug op de seed: een request
+    // zónder gekoppeld token faalt luid met de 428-koppel-flow…
+    let err = list_traject_corpus_laws(
         State(state.clone()),
         Extension(account.clone()),
         session_for(&sub).await,
@@ -334,12 +338,34 @@ async fn traject_index_shows_promoted_law_and_surfaces_failed_own_scans() {
         HeaderMap::new(),
     )
     .await
-    .expect("laws-listing moet slagen");
-    assert_eq!(laws.0.len(), 1, "wet resolvet nog steeds — uit de seed");
-    assert_eq!(laws.0[0].source_id, "central-seed");
+    .expect_err("onleesbare traject-repo zonder token mag niet stil terugvallen op de seed");
     assert_eq!(
-        laws.0[0].source_priority, 2,
-        "onleesbare traject-repo → stille fallback naar de seed (priority 2)"
+        err.0,
+        axum::http::StatusCode::PRECONDITION_REQUIRED,
+        "zonder gekoppeld token hoort de bibliotheek de 428-koppel-flow te geven, got: {}: {}",
+        err.0,
+        err.1
+    );
+
+    // …en een request mét gekoppeld token (dat deze repo alsnog niet kan
+    // lezen — het trees-pad is ongemockt, dus ook met token 404) faalt
+    // expliciet met een 502 die de scan-fout draagt.
+    let err = list_traject_corpus_laws(
+        State(state.clone()),
+        Extension(account.clone()),
+        session_for(&sub).await,
+        Path(tref_a.clone()),
+        ids_query(),
+        headers.clone(),
+    )
+    .await
+    .expect_err("scan-fout mét token → expliciete fout, geen stille fallback");
+    assert_eq!(
+        err.0,
+        axum::http::StatusCode::BAD_GATEWAY,
+        "got: {}: {}",
+        err.0,
+        err.1
     );
 
     // Niet langer stil: /sources meldt per source waaróm de scan faalde.


### PR DESCRIPTION
## Wat

Wanneer de server-side indexscan van een traject-repo geen `CORPUS_AUTH_*`-token heeft, gebruikt de scan nu het **persoonlijke GitHub-token** van de ingelogde gebruiker — net als de request-gebonden reads uit #955. Is er **geen enkel token**, dan faalt de traject-bibliotheek **luid** in plaats van stil alleen centrale-corpus-wetten te tonen (het prod-symptoom op `duo-46921d4d`: favorieten toonden 'Centrale Regelrecht Corpus' i.p.v. de DUO-traject-repo).

## Hoe

- **corpus**: nieuw `ScanTokenOverride` op `index_all_sources_with_override` — het per-call token authenticeert uitsluitend de éne opgegeven source (de writable-own), en alleen wanneer de server-side resolutie geen token oplevert; een geconfigureerd servertoken wint altijd. Het token wordt nergens opgeslagen.
- **editor-api**: de library-leesroute resolvet het gekoppelde user-token vóór de corpus-build en geeft het transient door aan de scan — cold build, synchrone heal-rebuild van een snapshot die token-loos faalde, én de TTL-refresh. Gedeeld gecachet wordt alleen het scan-*resultaat* (wetmetadata die alle leden toch zien); op `TrajectCorpus` staat enkel een bool of de scan een token had.
- **Luid falen**: `GET /api/trajects/{ref}/corpus/laws` weigert wanneer de writable-own niet gescand kon worden — **428** (koppel-flow) zonder gekoppeld token, **502** met de scan-fout wanneer ook het user-token de repo niet kan lezen. `index_error` blijft zichtbaar op `/api/trajects/{ref}/sources` en `/api/sources` (diagnose-route, bewust buiten de poort).
- **frontend**: `LibraryView` probe't in traject-context de index ook zonder favorieten/edits en toont de backend-uitleg in de bestaande foutstatus; 428 loopt via de bestaande `apiAuthGuard`-redirect de GitHub-koppel-flow in.

## Tests

- `packages/corpus/tests/index_scan_override.rs`: pint de override-inperkingen (alleen de opgegeven source, servertoken wint, geen lek naar seed-sources — de seed-mock matcht exact op het servertoken).
- `packages/editor-api/tests/traject_index_user_token_test.rs`: scan via user-token → wet op priority 0 met werkende federatie; gedeelde snapshot zonder tokenopslag (na cache-invalidatie faalt een token-loze rebuild luid met 428); zelfheling zodra een request mét token binnenkomt; 502-pad voor gekoppeld-maar-geen-toegang.
- `traject_own_index_test.rs` bijgewerkt: pint nu het luide falen i.p.v. de stille seed-fallback.

Checks: `just check` groen (fmt, clippy `-Dwarnings`, tests incl. alle editor-api-integratietests), frontend `vitest` 587/587 groen.
