### PR TITLE
fix(editor): service-token gaat voor bij traject-writes en duidelijke 403-melding bij GitHub-weigering

### DIFF
--- a/frontend/src/lib/apiAuthGuard.js
+++ b/frontend/src/lib/apiAuthGuard.js
@@ -17,7 +17,10 @@ import { useGithubAuth } from '../composables/useGithubAuth.js';
 // 428 (Precondition Required) gets the same treatment for the GitHub link:
 // the backend answers a traject write with 428 when this deployment requires
 // the acting user's own GitHub token (`github.user_oauth` flag or
-// GITHUB_USER_TOKEN_REQUIRED) and the user hasn't linked (or it expired).
+// GITHUB_USER_TOKEN_REQUIRED), the write target has no configured service
+// token (a configured token takes precedence and needs no link — see
+// `user_write_token_for_backend` in the editor-api), and the user hasn't
+// linked (or it expired).
 // Instead of a dead-end error toast, the guard bounces straight into the
 // GitHub consent flow via `useGithubAuth().connect()`, which returns to the
 // current page with a `?github=connected|error|denied` marker. Note the

--- a/packages/corpus/src/error.rs
+++ b/packages/corpus/src/error.rs
@@ -24,6 +24,16 @@ pub enum CorpusError {
     /// strings.
     #[error("conflict: {0}")]
     Conflict(String),
+
+    /// GitHub refused a write with a 403: the authenticating identity has
+    /// no push access to the repository or organisation (e.g. missing
+    /// repo permissions, or an org's OAuth App access restrictions
+    /// blocking a user token). Surfaced separately from `Git` so callers
+    /// can translate it into a clear "not allowed" message instead of a
+    /// generic internal error. Carries the GitHub response text for
+    /// operator logging — never show it to end users verbatim.
+    #[error("write denied by GitHub (403): {0}")]
+    WriteDenied(String),
 }
 
 pub type Result<T> = std::result::Result<T, CorpusError>;

--- a/packages/corpus/src/github.rs
+++ b/packages/corpus/src/github.rs
@@ -799,7 +799,9 @@ mod inner {
         /// SHA so callers can chain writes without an extra GET.
         ///
         /// Maps 409 to [`CorpusError::Conflict`] so backends can detect a
-        /// concurrent-write race and retry; everything else is `Git`.
+        /// concurrent-write race and retry, and 403 to
+        /// [`CorpusError::WriteDenied`] (no push access for the
+        /// authenticating identity); everything else is `Git`.
         #[allow(clippy::too_many_arguments)]
         #[tracing::instrument(name = "gh_http", skip_all, fields(method = "PUT", kind = "contents", repo = %repo))]
         pub async fn put_file(
@@ -848,6 +850,13 @@ mod inner {
                     path
                 )));
             }
+            if status == reqwest::StatusCode::FORBIDDEN {
+                return Err(CorpusError::WriteDenied(format!(
+                    "Contents API PUT {} returned 403: {}",
+                    path,
+                    response.text().await.unwrap_or_default()
+                )));
+            }
             if !status.is_success() {
                 return Err(CorpusError::Git(format!(
                     "GitHub Contents API PUT {} returned {}: {}",
@@ -865,7 +874,8 @@ mod inner {
 
         /// Delete a file via Contents API DELETE. Requires the current
         /// blob SHA. 404 is treated as "already gone" (idempotent — same
-        /// shape as [`crate::backend::RepoBackend::delete_file`]).
+        /// shape as [`crate::backend::RepoBackend::delete_file`]); 403
+        /// maps to [`CorpusError::WriteDenied`], like [`Self::put_file`].
         #[allow(clippy::too_many_arguments)]
         #[tracing::instrument(name = "gh_http", skip_all, fields(method = "DELETE", kind = "contents", repo = %repo))]
         pub async fn delete_file_via_api(
@@ -910,6 +920,13 @@ mod inner {
                 return Err(CorpusError::Conflict(format!(
                     "Contents API DELETE {} hit a 409 (stale sha)",
                     path
+                )));
+            }
+            if status == reqwest::StatusCode::FORBIDDEN {
+                return Err(CorpusError::WriteDenied(format!(
+                    "Contents API DELETE {} returned 403: {}",
+                    path,
+                    response.text().await.unwrap_or_default()
                 )));
             }
             if !status.is_success() {
@@ -962,7 +979,9 @@ mod inner {
 
         /// Create `branch` pointing at the tip of `base_branch`. The base
         /// branch must already exist; the target branch must NOT exist
-        /// (GitHub returns 422 otherwise — surfaced as `Git`).
+        /// (GitHub returns 422 otherwise — surfaced as `Git`). A 403 on
+        /// the ref-create (no push access) maps to
+        /// [`CorpusError::WriteDenied`], like [`Self::put_file`].
         #[tracing::instrument(name = "gh_http", skip_all, fields(method = "POST", kind = "create_branch", repo = %repo))]
         pub async fn create_branch(
             &mut self,
@@ -1015,10 +1034,19 @@ mod inner {
                 .await
                 .map_err(|e| CorpusError::Git(format!("GitHub API request failed: {}", e)))?;
             self.track_rate_limit(&response);
-            if !response.status().is_success() {
+            let status = response.status();
+            if status == reqwest::StatusCode::FORBIDDEN {
+                return Err(CorpusError::WriteDenied(format!(
+                    "Refs API POST (create branch {}@{}) returned 403: {}",
+                    repo,
+                    branch,
+                    response.text().await.unwrap_or_default()
+                )));
+            }
+            if !status.is_success() {
                 return Err(CorpusError::Git(format!(
                     "GitHub Refs API POST returned {} for {}@{}: {}",
-                    response.status(),
+                    status,
                     repo,
                     branch,
                     response.text().await.unwrap_or_default()

--- a/packages/corpus/src/github.rs
+++ b/packages/corpus/src/github.rs
@@ -611,6 +611,24 @@ mod inner {
             self.rate_limit_remaining
         }
 
+        /// True when a 403 response is GitHub *rate limiting* rather than
+        /// a permissions refusal: primary rate-limit exhaustion answers
+        /// 403 with `x-ratelimit-remaining: 0`, and secondary limits
+        /// answer 403 with a `retry-after` header. Callers keep those on
+        /// the generic `Git` path instead of
+        /// [`CorpusError::WriteDenied`] — a "no write access" message for
+        /// a transient limit would mislead the user (the same reasoning
+        /// that keeps 404 generic on the write paths).
+        fn forbidden_is_rate_limit(response: &reqwest::Response) -> bool {
+            response.headers().contains_key("retry-after")
+                || response
+                    .headers()
+                    .get("x-ratelimit-remaining")
+                    .and_then(|v| v.to_str().ok())
+                    .map(str::trim)
+                    == Some("0")
+        }
+
         // -----------------------------------------------------------------
         // Backend-oriented API (used by GitHubApiBackend; no ETag cache —
         // backend reads want the current state of the branch on every
@@ -801,7 +819,8 @@ mod inner {
         /// Maps 409 to [`CorpusError::Conflict`] so backends can detect a
         /// concurrent-write race and retry, and 403 to
         /// [`CorpusError::WriteDenied`] (no push access for the
-        /// authenticating identity); everything else is `Git`.
+        /// authenticating identity) — except rate-limit 403s
+        /// ([`Self::forbidden_is_rate_limit`]); everything else is `Git`.
         #[allow(clippy::too_many_arguments)]
         #[tracing::instrument(name = "gh_http", skip_all, fields(method = "PUT", kind = "contents", repo = %repo))]
         pub async fn put_file(
@@ -850,7 +869,8 @@ mod inner {
                     path
                 )));
             }
-            if status == reqwest::StatusCode::FORBIDDEN {
+            if status == reqwest::StatusCode::FORBIDDEN && !Self::forbidden_is_rate_limit(&response)
+            {
                 return Err(CorpusError::WriteDenied(format!(
                     "Contents API PUT {} returned 403: {}",
                     path,
@@ -922,7 +942,8 @@ mod inner {
                     path
                 )));
             }
-            if status == reqwest::StatusCode::FORBIDDEN {
+            if status == reqwest::StatusCode::FORBIDDEN && !Self::forbidden_is_rate_limit(&response)
+            {
                 return Err(CorpusError::WriteDenied(format!(
                     "Contents API DELETE {} returned 403: {}",
                     path,
@@ -1035,7 +1056,8 @@ mod inner {
                 .map_err(|e| CorpusError::Git(format!("GitHub API request failed: {}", e)))?;
             self.track_rate_limit(&response);
             let status = response.status();
-            if status == reqwest::StatusCode::FORBIDDEN {
+            if status == reqwest::StatusCode::FORBIDDEN && !Self::forbidden_is_rate_limit(&response)
+            {
                 return Err(CorpusError::WriteDenied(format!(
                     "Refs API POST (create branch {}@{}) returned 403: {}",
                     repo,

--- a/packages/corpus/tests/github_api_backend.rs
+++ b/packages/corpus/tests/github_api_backend.rs
@@ -264,6 +264,80 @@ async fn put_409_refreshes_sha_and_retries_once() {
 }
 
 #[tokio::test]
+async fn put_403_maps_to_write_denied() {
+    let server = MockServer::start().await;
+    mount_branch_exists(&server).await;
+
+    // GitHub refuses the write outright — e.g. the authenticating identity
+    // has no push access, or an org's OAuth App access restrictions block
+    // the token. Must surface as `WriteDenied` (with the response text for
+    // logging), not as a generic `Git` error, and without any sha-refresh
+    // retry (`expect(1)` pins that).
+    Mock::given(method("PUT"))
+        .and(path("/repos/acme/corpus/contents/laws/x.yaml"))
+        .respond_with(
+            ResponseTemplate::new(403)
+                .set_body_string("{\"message\":\"Resource not accessible by integration\"}"),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let b = backend(&server);
+    b.write_file(Path::new("laws/x.yaml"), "geweigerd\n")
+        .await
+        .unwrap();
+    let err = b
+        .persist(&ctx())
+        .await
+        .expect_err("a GitHub 403 on PUT must fail the persist");
+    match err {
+        regelrecht_corpus::error::CorpusError::WriteDenied(msg) => {
+            assert!(
+                msg.contains("Resource not accessible"),
+                "the GitHub response text must ride along for logging, got: {msg}"
+            );
+        }
+        other => panic!("expected WriteDenied, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn delete_403_maps_to_write_denied() {
+    let server = MockServer::start().await;
+    mount_branch_exists(&server).await;
+
+    // Sha-resolve GET for the blind delete.
+    Mock::given(method("GET"))
+        .and(path("/repos/acme/corpus/contents/laws/y.yaml"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "name": "y.yaml", "path": "laws/y.yaml",
+            "sha": "sha-d1", "type": "file",
+            "content": b64("doomed"), "encoding": "base64",
+        })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("DELETE"))
+        .and(path("/repos/acme/corpus/contents/laws/y.yaml"))
+        .respond_with(ResponseTemplate::new(403).set_body_string("forbidden"))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let b = backend(&server);
+    b.delete_file(Path::new("laws/y.yaml")).await.unwrap();
+    let err = b
+        .persist(&ctx())
+        .await
+        .expect_err("a GitHub 403 on DELETE must fail the persist");
+    assert!(
+        matches!(err, regelrecht_corpus::error::CorpusError::WriteDenied(_)),
+        "expected WriteDenied, got: {err:?}"
+    );
+}
+
+#[tokio::test]
 async fn delete_path_resolves_sha_then_deletes() {
     let server = MockServer::start().await;
     mount_branch_exists(&server).await;

--- a/packages/corpus/tests/github_api_backend.rs
+++ b/packages/corpus/tests/github_api_backend.rs
@@ -303,6 +303,41 @@ async fn put_403_maps_to_write_denied() {
 }
 
 #[tokio::test]
+async fn put_403_rate_limit_stays_generic_git_error() {
+    let server = MockServer::start().await;
+    mount_branch_exists(&server).await;
+
+    // GitHub answers rate-limit exhaustion ALSO with a 403 (primary limit:
+    // `x-ratelimit-remaining: 0`). That is transient, not a permissions
+    // refusal — it must NOT become `WriteDenied` (which the editor-api
+    // translates into a permanent-sounding "geen schrijftoegang" message)
+    // but stay on the generic `Git` path.
+    Mock::given(method("PUT"))
+        .and(path("/repos/acme/corpus/contents/laws/x.yaml"))
+        .respond_with(
+            ResponseTemplate::new(403)
+                .insert_header("x-ratelimit-remaining", "0")
+                .set_body_string("{\"message\":\"API rate limit exceeded\"}"),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let b = backend(&server);
+    b.write_file(Path::new("laws/x.yaml"), "gelimiteerd\n")
+        .await
+        .unwrap();
+    let err = b
+        .persist(&ctx())
+        .await
+        .expect_err("a rate-limited 403 on PUT must still fail the persist");
+    assert!(
+        matches!(err, regelrecht_corpus::error::CorpusError::Git(_)),
+        "a rate-limit 403 must stay a generic Git error, got: {err:?}"
+    );
+}
+
+#[tokio::test]
 async fn delete_403_maps_to_write_denied() {
     let server = MockServer::start().await;
     mount_branch_exists(&server).await;

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -1540,6 +1540,9 @@ async fn resolve_backend_for_law(
 /// `ReadOnly` is an expected, recoverable precondition (e.g. the resolved
 /// backend is a baked-in local source on a read-only container filesystem),
 /// and the message is safe to surface to the user as `403 Forbidden`.
+/// `WriteDenied` (GitHub itself answered 403 on the write call) also maps
+/// to `403 Forbidden`, with a fixed Dutch "geen schrijftoegang" message —
+/// the GitHub response text is logged, never echoed.
 ///
 /// Every other variant (IO, git command failures, push failures, …) goes
 /// out as `500 Internal Server Error` with a **generic** message. The full
@@ -1562,6 +1565,24 @@ fn corpus_write_error(kind: &'static str) -> impl FnOnce(CorpusError) -> (Status
             StatusCode::CONFLICT,
             "Concurrent edit detected, please retry".to_string(),
         ),
+        // GitHub refused the write outright (403): the authenticating
+        // identity — typically the user's own linked token in the
+        // user-token write mode — has no push access to the repo or its
+        // org (e.g. OAuth App access restrictions). Deliberately NOT the
+        // generic 500: the user can't do anything with "internal error",
+        // but "geen schrijftoegang" points at the actual problem. The
+        // full GitHub response goes to the operator log only. Note that
+        // `apiAuthGuard.js` intentionally does not intercept 403, so this
+        // message reaches the save-failed modal verbatim.
+        CorpusError::WriteDenied(_) => {
+            tracing::warn!(error = %e, kind = %kind, "GitHub denied corpus write (403)");
+            (
+                StatusCode::FORBIDDEN,
+                "GitHub staat deze wijziging niet toe met jouw gekoppelde account: \
+                 geen schrijftoegang tot deze repository of organisatie."
+                    .to_string(),
+            )
+        }
         _ => {
             tracing::warn!(error = %e, kind = %kind, "corpus write/persist failed");
             (
@@ -1839,9 +1860,12 @@ async fn resolve_traject_law_write(
 /// user-created traject repo has no service token on purpose, and 403-ing
 /// there would break every write in the user-token mode (the pr952
 /// promote bug). The subsequent `user_write_token_for_backend` call then
-/// enforces the linked-token requirement (428 when absent/expired), and
-/// `persist` itself still refuses (`CorpusError::ReadOnly` → 403) if a
-/// write somehow reaches it with no token at all.
+/// applies the token-precedence rule: a configured service token goes
+/// first (the write proceeds without an override), and only on token-less
+/// backends is the linked-token requirement enforced (428 when
+/// absent/expired). `persist` itself still refuses
+/// (`CorpusError::ReadOnly` → 403) if a write somehow reaches it with no
+/// token at all.
 async fn require_traject_backend_writable(
     state: &AppState,
     writable_at_rest: bool,

--- a/packages/editor-api/src/github_oauth.rs
+++ b/packages/editor-api/src/github_oauth.rs
@@ -96,9 +96,11 @@ pub struct GithubOAuth {
     ///   user, linked or not, so a linked user's saves to the operator-managed
     ///   central repo can't start 403-ing because their personal token lacks
     ///   access.
-    /// * required on (either switch): every traject write uses the acting
-    ///   user's token; a save with no linked (or an expired) token is refused
-    ///   with 428 rather than silently falling back to the configured token.
+    /// * required on (either switch): a configured service token still takes
+    ///   precedence per backend (see [`user_write_token_for_backend`]); only
+    ///   writes to token-less, override-capable backends must carry the
+    ///   acting user's token, and a save there with no linked (or an
+    ///   expired) token is refused with 428.
     pub require_user_token: bool,
     /// Relay mode. When set, `/login` sends GitHub a **fixed** `redirect_uri`
     /// of `{callback_base}/auth/github/relay` instead of the deployment's own
@@ -867,11 +869,11 @@ pub async fn disconnect(
 ///   GitHub-koppeling UI, so switching the feature on in the Functies menu
 ///   also switches enforcement on. Linking is never offered-but-inert.
 ///
-/// A flag-read failure propagates as 500: on the write path the contract is
-/// "never silently fall back to the service token", and that includes not
-/// guessing when the flag store is unreadable. (In practice the session
-/// store shares the same database, so requests rarely get this far with a
-/// broken pool.)
+/// A flag-read failure propagates as 500: on a token-less backend the
+/// requiredness decision determines whether a write may proceed at all,
+/// and that must not be guessed when the flag store is unreadable. (In
+/// practice the session store shares the same database, so requests
+/// rarely get this far with a broken pool.)
 pub async fn write_requires_user_token(
     state: &AppState,
     oauth: &GithubOAuth,
@@ -931,8 +933,14 @@ pub async fn user_token_write_mode(state: &AppState) -> Result<bool, (StatusCode
 /// returns 428 for any other reason would silently hijack its callers into
 /// the koppel-flow. Pick a different status for other preconditions.
 ///
-/// Write handlers should prefer [`user_write_token_for_backend`], which
-/// additionally skips enforcement for backends that ignore the override.
+/// Precedence contract: a configured service token goes first; the
+/// user-token requirement (incl. the 428 connect-flow) applies only to
+/// token-less write targets. Write handlers should therefore prefer
+/// [`user_write_token_for_backend`], which encodes that rule (and skips
+/// enforcement for backends that ignore the override). Callers of this
+/// bare function must apply the same precedence themselves — resolve the
+/// configured token first and only demand the user token when there is
+/// none (see the create-traject preflight in `trajects.rs`).
 pub async fn user_write_token(
     state: &AppState,
     account_id: Uuid,
@@ -977,11 +985,12 @@ async fn user_token_when_required(
         return Ok(None);
     }
 
-    // From here `require_user_token` is on, so the contract is "never silently
-    // fall back to the service token": the only outcomes are the user's own
-    // token or a 428. `open_token_cookie` folds every failure mode (absent,
-    // tampered, wrong key, foreign account) into `None` = not linked, which
-    // fails closed into the 428 below.
+    // From here the user-token mode is on AND the caller established that
+    // no configured service token applies (the `_for_backend` wrappers
+    // return early on `is_writable` backends): the only outcomes are the
+    // user's own token or a 428. `open_token_cookie` folds every failure
+    // mode (absent, tampered, wrong key, foreign account) into `None` =
+    // not linked, which fails closed into the 428 below.
     match open_token_cookie(oauth, headers, account_id) {
         Some(link) if !link.expired() => {
             tracing::debug!(
@@ -1004,6 +1013,16 @@ async fn user_token_when_required(
 /// any token at all. Demanding a linked GitHub account there would 428 every
 /// save with a requirement linking can never satisfy. So: resolve the write
 /// target first, then call this with the resolved backend.
+///
+/// Mirrors [`user_read_token_for_backend`]: a backend with its own
+/// configured (service) token keeps writing with it — `Ok(None)`, so
+/// `persist` uses the backend token and stamps the commit with the
+/// session identity, exactly the pre-user-token flow. The user-token
+/// requirement (and its 428 connect-flow) applies only to token-less,
+/// override-capable backends. Routing writes on a service-token repo
+/// through the user's personal token instead would 403 for every member
+/// whose token GitHub refuses on that repo (no direct push access, or an
+/// org's OAuth App access restrictions blocking the editor app).
 pub async fn user_write_token_for_backend(
     state: &AppState,
     account_id: Uuid,
@@ -1013,19 +1032,24 @@ pub async fn user_write_token_for_backend(
     if !backend.supports_token_override() {
         return Ok(None);
     }
+    // `is_writable` on the Contents-API backend means "has a configured
+    // rest token" — the one backend kind that reaches this point. A
+    // configured service token takes precedence over the user token.
+    if backend.is_writable() {
+        return Ok(None);
+    }
     user_write_token(state, account_id, headers).await
 }
 
 /// The read-path analogue of [`user_write_token_for_backend`]: resolve the
 /// per-user GitHub credential for a **read** on `backend`.
 ///
-/// Narrower than the write path in one deliberate way: a backend that has
-/// its own configured (service) token keeps reading with it — `Ok(None)`,
-/// behaviour unchanged — even in the user-token write mode. The write path
-/// overrides an existing service token to make the *commit* authenticate as
-/// the user; a read has no attribution concern, and rerouting working
-/// service-token reads through personal tokens would break members without
-/// direct repo access.
+/// Same precedence rule as the write path: a backend that has its own
+/// configured (service) token keeps using it — `Ok(None)`, behaviour
+/// unchanged — even in the user-token write mode. Rerouting working
+/// service-token traffic through personal tokens would break members
+/// without direct repo access (or whose token GitHub blocks via OAuth App
+/// access restrictions).
 ///
 /// So the outcomes are:
 ///

--- a/packages/editor-api/src/trajects.rs
+++ b/packages/editor-api/src/trajects.rs
@@ -853,56 +853,60 @@ async fn resolve_writable_target(
                 ));
             }
 
-            // Resolve the token to preflight the repo with. Prefer the acting
-            // user's OWN GitHub token (user-OAuth spike): the preflight then
-            // validates *their* push access to the chosen repo — the
-            // entitlement check GitHub gives us for free, so the editor never
-            // needs an all-access credential to police repo choice (the gap
-            // that #885 tracks).
+            // Resolve the token to preflight the repo with, following the
+            // same precedence rule as the write path
+            // (`user_write_token_for_backend`): a configured per-repo
+            // service token goes first — the eventual writes on this repo
+            // run over that token too, so preflighting with the user's
+            // personal token would validate an access path the traject
+            // will never use. The strict context (`TokenContext::strict`)
+            // is deliberate: `auth_ref` derives from user-supplied repo
+            // coords, so an unknown ref must NOT fall back to
+            // `CORPUS_GIT_TOKEN` (that would ship the central token to a
+            // user-picked repo, a token-exfiltration vector).
             //
-            // Fall back to the *strict* per-repo operator token when the user
-            // hasn't linked GitHub and this deployment doesn't require it. The
-            // strict context (`TokenContext::strict`) is deliberate: `auth_ref`
-            // derives from user-supplied repo coords, so an unknown ref must
-            // NOT fall back to `CORPUS_GIT_TOKEN` (that would ship the central
-            // token to a user-picked repo, a token-exfiltration vector).
-            // `user_write_token` returns 428 when a linked token is required
-            // but absent.
-            let token =
-                match crate::github_oauth::user_write_token(state, account_id, headers).await? {
-                    Some(user_token) => user_token,
-                    None => {
-                        let auth_file = {
-                            let corpus = state.corpus.read().await;
-                            corpus.auth_file.clone()
-                        };
-                        regelrecht_corpus::auth::CredentialResolver::new(auth_file.as_deref())
-                        .resolve(regelrecht_corpus::auth::TokenContext::strict(&auth_ref))
-                        .map(regelrecht_corpus::auth::TokenDecision::into_token)
-                        .map_err(|e| {
-                            tracing::error!(error = %e, "auth lookup failed for new traject repo");
-                            (
-                                StatusCode::INTERNAL_SERVER_ERROR,
-                                "auth lookup failed".to_string(),
-                            )
-                        })?
-                        .ok_or_else(|| {
-                            let env_name = regelrecht_corpus::auth::token_env_name(&auth_ref);
-                            tracing::warn!(
-                                auth_ref = %auth_ref,
-                                env_name = %env_name,
-                                "no token configured for user-supplied repo"
-                            );
-                            (
-                                StatusCode::SERVICE_UNAVAILABLE,
-                                format!(
-                                    "deze repo is nog niet door je beheerder geconfigureerd \
+            // Only for a token-less ref does the acting user's OWN GitHub
+            // token come into play (user-OAuth spike): the preflight then
+            // validates *their* push access to the chosen repo — the
+            // entitlement check GitHub gives us for free, so the editor
+            // never needs an all-access credential to police repo choice
+            // (the gap that #885 tracks). `user_write_token` returns 428
+            // when a linked token is required but absent.
+            let auth_file = {
+                let corpus = state.corpus.read().await;
+                corpus.auth_file.clone()
+            };
+            let service_token =
+                regelrecht_corpus::auth::CredentialResolver::new(auth_file.as_deref())
+                    .resolve(regelrecht_corpus::auth::TokenContext::strict(&auth_ref))
+                    .map(regelrecht_corpus::auth::TokenDecision::into_token)
+                    .map_err(|e| {
+                        tracing::error!(error = %e, "auth lookup failed for new traject repo");
+                        (
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            "auth lookup failed".to_string(),
+                        )
+                    })?;
+            let token = match service_token {
+                Some(service_token) => service_token,
+                None => crate::github_oauth::user_write_token(state, account_id, headers)
+                    .await?
+                    .ok_or_else(|| {
+                        let env_name = regelrecht_corpus::auth::token_env_name(&auth_ref);
+                        tracing::warn!(
+                            auth_ref = %auth_ref,
+                            env_name = %env_name,
+                            "no token configured for user-supplied repo"
+                        );
+                        (
+                            StatusCode::SERVICE_UNAVAILABLE,
+                            format!(
+                                "deze repo is nog niet door je beheerder geconfigureerd \
                              (verwacht env var {env_name})"
-                                ),
-                            )
-                        })?
-                    }
-                };
+                            ),
+                        )
+                    })?,
+            };
 
             // The OAuth config's `api_base` (a pub field, overridable in
             // tests with a wiremock server) wins over the real default, so

--- a/packages/editor-api/tests/service_token_write_precedence_test.rs
+++ b/packages/editor-api/tests/service_token_write_precedence_test.rs
@@ -1,0 +1,434 @@
+//! Voorrangsregel voor traject-writes: een geconfigureerd server-side
+//! service-token (`CORPUS_AUTH_*`) gaat vóór het persoonlijke GitHub-token
+//! van de gebruiker — het schrijfpad-spiegelbeeld van de leespad-regel uit
+//! PR #955. Plus: een GitHub-403 op de write landt als een duidelijke
+//! Nederlandse 403 bij de gebruiker in plaats van een generieke 500.
+//!
+//! Deployed-achtige federatie-config zoals `promote_user_token_write_test`:
+//! een GitHub-backed writable-own plus een lokale seed als centraal corpus,
+//! met de user-token-schrijfmodus AAN. Twee trajecten:
+//!
+//! * **mét service-token** (auth_ref met geconfigureerd
+//!   `CORPUS_AUTH_*_TOKEN`-env): saves lopen over het service-token — ook
+//!   voor een gebruiker zónder GitHub-koppeling (geen 428) én voor een
+//!   gebruiker mét koppeling (het user-token overschrijft niet meer). De
+//!   commit draagt de sessie-identiteit als committer-stempel.
+//! * **zónder service-token** (auth_ref zonder env): de bestaande
+//!   user-token-flow blijft werken — de save committet met het gekoppelde
+//!   token (regressiebescherming).
+//!
+//! GitHub wordt gespeeld door wiremock via de proces-brede
+//! `GITHUB_API_BASE`-seam — daarom staan alle scenario's in ÉÉN test
+//! (zelfde afweging als `promote_user_token_write_test.rs`). Het
+//! service-token komt uit een env var en is dus eveneens proces-breed;
+//! test-binaries zijn aparte processen, dus dit lekt niet naar andere
+//! testbestanden.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::Arc;
+
+use axum::extract::{Extension, Path, State};
+use axum::http::{HeaderMap, StatusCode};
+use pretty_assertions::assert_eq;
+use sqlx::PgPool;
+use tokio::sync::{Mutex, RwLock};
+use tower_sessions::Session;
+use tower_sessions_memory_store::MemoryStore;
+use uuid::Uuid;
+use wiremock::matchers::{body_partial_json, header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use regelrecht_auth::handlers::{
+    SESSION_KEY_EMAIL, SESSION_KEY_EMAIL_VERIFIED, SESSION_KEY_NAME, SESSION_KEY_SUB,
+};
+use regelrecht_editor_api::accounts::AccountRecord;
+use regelrecht_editor_api::config::AppConfig;
+use regelrecht_editor_api::corpus_handlers::save_law;
+use regelrecht_editor_api::github_oauth::{self, GithubOAuth};
+use regelrecht_editor_api::state::{AppState, CorpusState};
+use regelrecht_editor_api::traject_corpus::TrajectCorpusCache;
+
+use regelrecht_pipeline::test_utils::TestDb;
+
+const LAW_ID: &str = "wet_voorbeeld_service";
+const DENIED_LAW_ID: &str = "wet_voorbeeld_geweigerd";
+const SERVICE_REPO: &str = "example-org/example-service-repo";
+const TOKENLESS_REPO: &str = "example-org/example-traject-repo";
+const OWN_BRANCH: &str = "traject-voorbeeld";
+const OWN_SUBPATH: &str = "corpus/regulation";
+const SERVICE_AUTH_REF: &str = "example-service-token-ref";
+const SERVICE_TOKEN_ENV: &str = "CORPUS_AUTH_EXAMPLE_SERVICE_TOKEN_REF_TOKEN";
+const SERVICE_TOKEN: &str = "service-token";
+const USER_TOKEN: &str = "user-token";
+
+/// De exacte gebruikerstekst waarop de "Opslaan mislukt"-modal de
+/// GitHub-weigering toont (acceptatiecriterium — niet herformuleren).
+const DENIED_MESSAGE: &str = "GitHub staat deze wijziging niet toe met jouw gekoppelde account: \
+     geen schrijftoegang tot deze repository of organisatie.";
+
+fn state_with_user_token_mode(pool: PgPool, oauth: GithubOAuth) -> AppState {
+    AppState {
+        corpus: Arc::new(RwLock::new(CorpusState::empty())),
+        oidc_client: None,
+        end_session_url: None,
+        config: Arc::new(AppConfig {
+            oidc: None,
+            base_url: None,
+            github_oauth: Some(oauth),
+            task_enrich_provider: "claude".to_string(),
+        }),
+        http_client: reqwest::Client::new(),
+        pool: Some(pool),
+        pipeline_api_url: None,
+        harvest_admin_url: None,
+        reload_lock: Arc::new(Mutex::new(())),
+        trajects: Arc::new(TrajectCorpusCache::new()),
+    }
+}
+
+async fn seed_account(pool: &PgPool, email: &str) -> (Uuid, String) {
+    let sub = format!("sub-{email}");
+    let (id,): (Uuid,) = sqlx::query_as(
+        "INSERT INTO accounts (person_sub, email, name) VALUES ($1, $2, $3) RETURNING id",
+    )
+    .bind(&sub)
+    .bind(email)
+    .bind("Test User")
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    (id, sub)
+}
+
+/// Traject met een GitHub writable-own (repo + auth_ref parametrisch) en
+/// een lokale read-seed als centraal corpus.
+async fn seeded_traject(
+    pool: &PgPool,
+    owner_id: Uuid,
+    seed_dir: &std::path::Path,
+    repo: &str,
+    auth_ref: &str,
+) -> Uuid {
+    let (gh_owner, gh_repo) = repo.split_once('/').unwrap();
+    let (traject_id,): (Uuid,) = sqlx::query_as(
+        "INSERT INTO trajects (name, description, scope, created_by)
+         VALUES ('Test', '', '', $1) RETURNING id",
+    )
+    .bind(owner_id)
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO traject_members (traject_id, account_id, role)
+         VALUES ($1, $2, 'owner')",
+    )
+    .bind(traject_id)
+    .bind(owner_id)
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO traject_corpus_sources
+         (traject_id, source_id, name, source_type,
+          gh_owner, gh_repo, gh_branch, gh_base_branch, gh_path,
+          priority, auth_ref, is_writable_own)
+         VALUES ($1, 'traject-own-test', 'Eigen repo', 'github'::corpus_source_type,
+                 $2, $3, $4, 'main', $5,
+                 0, $6, TRUE)",
+    )
+    .bind(traject_id)
+    .bind(gh_owner)
+    .bind(gh_repo)
+    .bind(OWN_BRANCH)
+    .bind(OWN_SUBPATH)
+    .bind(auth_ref)
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO traject_corpus_sources
+         (traject_id, source_id, name, source_type, local_path,
+          priority, scopes, is_writable_own)
+         VALUES ($1, 'central-seed', 'Centrale Corpus', 'local'::corpus_source_type, $2,
+                 2, '[]'::jsonb, FALSE)",
+    )
+    .bind(traject_id)
+    .bind(seed_dir.to_string_lossy().to_string())
+    .execute(pool)
+    .await
+    .unwrap();
+    traject_id
+}
+
+fn traject_ref(traject_id: Uuid) -> String {
+    format!("test-{}", &traject_id.to_string()[..8])
+}
+
+async fn session_for(sub: &str) -> Session {
+    let session = Session::new(None, Arc::new(MemoryStore::default()), None);
+    session.insert(SESSION_KEY_SUB, sub).await.unwrap();
+    session.insert(SESSION_KEY_NAME, "Test User").await.unwrap();
+    session
+        .insert(SESSION_KEY_EMAIL, "alice@test.local")
+        .await
+        .unwrap();
+    session
+        .insert(SESSION_KEY_EMAIL_VERIFIED, true)
+        .await
+        .unwrap();
+    session
+}
+
+/// Seed-wetten in het "centrale corpus": de save-target en de wet waarop
+/// GitHub de write gaat weigeren.
+fn write_central_laws(central_dir: &std::path::Path) {
+    for law_id in [LAW_ID, DENIED_LAW_ID] {
+        let law_dir = central_dir.join("wet").join(law_id);
+        std::fs::create_dir_all(&law_dir).unwrap();
+        std::fs::write(
+            law_dir.join("2025-01-01.yaml"),
+            format!("$id: {law_id}\nname: Seed-versie\n"),
+        )
+        .unwrap();
+    }
+}
+
+/// Branch-check op een repo: de traject-branch bestaat al, dus geen
+/// create-branch-bootstrap nodig.
+async fn mount_branch_exists(server: &MockServer, repo: &str) {
+    Mock::given(method("GET"))
+        .and(path(format!("/repos/{repo}/git/ref/heads/{OWN_BRANCH}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "ref": format!("refs/heads/{OWN_BRANCH}"),
+            "object": { "sha": "branch-sha" },
+        })))
+        .mount(server)
+        .await;
+}
+
+/// Lege Trees-listing zodat de indexscan van de GitHub-source niets
+/// oplevert (de wetten komen uit de lokale seed) maar ook niet faalt.
+async fn mount_empty_tree(server: &MockServer, repo: &str) {
+    Mock::given(method("GET"))
+        .and(path(format!("/repos/{repo}/git/trees/{OWN_BRANCH}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "sha": "tree-sha",
+            "truncated": false,
+            "tree": [],
+        })))
+        .mount(server)
+        .await;
+}
+
+/// Alle Authorization-headers van PUT-requests die wiremock ontving.
+async fn received_put_auths(server: &MockServer) -> Vec<String> {
+    server
+        .received_requests()
+        .await
+        .unwrap()
+        .iter()
+        .filter(|r| r.method.as_str() == "PUT")
+        .map(|r| {
+            r.headers
+                .get("authorization")
+                .map(|v| v.to_str().unwrap_or_default().to_string())
+                .unwrap_or_default()
+        })
+        .collect()
+}
+
+/// Eén test voor alle scenario's: de `GITHUB_API_BASE`-override en het
+/// `CORPUS_AUTH_*`-service-token zijn proces-brede env vars, dus parallelle
+/// tests zouden elkaars configuratie verhangen.
+#[tokio::test]
+async fn service_token_takes_precedence_on_writes_and_github_403_maps_to_dutch_403() {
+    let server = MockServer::start().await;
+    std::env::set_var("GITHUB_API_BASE", server.uri());
+    std::env::set_var(SERVICE_TOKEN_ENV, SERVICE_TOKEN);
+
+    let db = TestDb::new().await;
+    let central = tempfile::tempdir().unwrap();
+    write_central_laws(central.path());
+
+    let oauth = GithubOAuth::for_tests(true); // user-token-schrijfmodus AAN
+    let state = state_with_user_token_mode(db.pool.clone(), oauth.clone());
+
+    let (owner_id, sub) = seed_account(&db.pool, "alice@test.local").await;
+    let account = AccountRecord {
+        id: owner_id,
+        person_sub: sub.clone(),
+        email: "alice@test.local".to_string(),
+        name: "Test User".to_string(),
+    };
+
+    // Traject A: writable-own MET geconfigureerd service-token.
+    let service_traject = seeded_traject(
+        &db.pool,
+        owner_id,
+        central.path(),
+        SERVICE_REPO,
+        SERVICE_AUTH_REF,
+    )
+    .await;
+    let service_tref = traject_ref(service_traject);
+    // Traject B: writable-own ZONDER service-token (auth_ref zonder env).
+    let tokenless_traject = seeded_traject(
+        &db.pool,
+        owner_id,
+        central.path(),
+        TOKENLESS_REPO,
+        "example-unset-token-ref",
+    )
+    .await;
+    let tokenless_tref = traject_ref(tokenless_traject);
+
+    mount_branch_exists(&server, SERVICE_REPO).await;
+    mount_branch_exists(&server, TOKENLESS_REPO).await;
+    mount_empty_tree(&server, SERVICE_REPO).await;
+    mount_empty_tree(&server, TOKENLESS_REPO).await;
+
+    // Contents-PUT op de service-repo: alleen het service-token matcht, en
+    // de commit moet de sessie-identiteit als committer-stempel dragen —
+    // het pre-user-token-gedrag.
+    Mock::given(method("PUT"))
+        .and(path(format!(
+            "/repos/{SERVICE_REPO}/contents/{OWN_SUBPATH}/wet/{LAW_ID}/2025-01-01.yaml"
+        )))
+        .and(header("authorization", format!("Bearer {SERVICE_TOKEN}")))
+        .and(body_partial_json(serde_json::json!({
+            "committer": { "name": "Test User", "email": "alice@test.local" },
+        })))
+        .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+            "content": { "sha": "sha-new" },
+        })))
+        .mount(&server)
+        .await;
+
+    // GitHub weigert de write op de tweede wet: 403 (bijv. OAuth App
+    // access restrictions of ontbrekende push-rechten).
+    Mock::given(method("PUT"))
+        .and(path(format!(
+            "/repos/{SERVICE_REPO}/contents/{OWN_SUBPATH}/wet/{DENIED_LAW_ID}/2025-01-01.yaml"
+        )))
+        .respond_with(
+            ResponseTemplate::new(403)
+                .set_body_string("{\"message\":\"Resource not accessible by integration\"}"),
+        )
+        .mount(&server)
+        .await;
+
+    // Contents-PUT op de token-loze repo: alleen het user-token matcht.
+    Mock::given(method("PUT"))
+        .and(path(format!(
+            "/repos/{TOKENLESS_REPO}/contents/{OWN_SUBPATH}/wet/{LAW_ID}/2025-01-01.yaml"
+        )))
+        .and(header("authorization", format!("Bearer {USER_TOKEN}")))
+        .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+            "content": { "sha": "sha-user" },
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // ------------------------------------------------------------------
+    // Scenario 1: service-token-repo + NIET-gekoppelde gebruiker → de
+    // save slaagt over het service-token, zonder 428/koppel-flow, en de
+    // commit is gestempeld met de sessie-identiteit (body-matcher op de
+    // PUT-mock hierboven).
+    // ------------------------------------------------------------------
+    let body = format!("$id: {LAW_ID}\nname: Bewerkt zonder koppeling\n");
+    save_law(
+        State(state.clone()),
+        Extension(account.clone()),
+        session_for(&sub).await,
+        Path((service_tref.clone(), LAW_ID.to_string())),
+        HeaderMap::new(),
+        body,
+    )
+    .await
+    .expect("save op een service-token-repo mag geen GitHub-koppeling eisen");
+    assert_eq!(
+        received_put_auths(&server).await,
+        vec![format!("Bearer {SERVICE_TOKEN}")],
+        "de write moet over het geconfigureerde service-token lopen"
+    );
+
+    // ------------------------------------------------------------------
+    // Scenario 2: service-token-repo + WEL-gekoppelde gebruiker → nog
+    // steeds het service-token; het persoonlijke token overschrijft de
+    // write niet meer (de oude override-regel).
+    // ------------------------------------------------------------------
+    let mut linked_headers = HeaderMap::new();
+    linked_headers.insert(
+        axum::http::header::COOKIE,
+        axum::http::HeaderValue::from_str(&github_oauth::seal_token_cookie_for_tests(
+            &oauth, account.id, USER_TOKEN,
+        ))
+        .unwrap(),
+    );
+
+    let body = format!("$id: {LAW_ID}\nname: Bewerkt met koppeling\n");
+    save_law(
+        State(state.clone()),
+        Extension(account.clone()),
+        session_for(&sub).await,
+        Path((service_tref.clone(), LAW_ID.to_string())),
+        linked_headers.clone(),
+        body,
+    )
+    .await
+    .expect("save met koppeling moet slagen — over het service-token");
+    let auths = received_put_auths(&server).await;
+    assert_eq!(
+        auths,
+        vec![
+            format!("Bearer {SERVICE_TOKEN}"),
+            format!("Bearer {SERVICE_TOKEN}"),
+        ],
+        "een gekoppeld user-token mag het service-token niet meer overschrijven"
+    );
+
+    // ------------------------------------------------------------------
+    // Scenario 3: GitHub weigert de write (403) → de gebruiker krijgt een
+    // duidelijke Nederlandse 403, niet de generieke 500.
+    // ------------------------------------------------------------------
+    let body = format!("$id: {DENIED_LAW_ID}\nname: Wordt geweigerd\n");
+    let err = save_law(
+        State(state.clone()),
+        Extension(account.clone()),
+        session_for(&sub).await,
+        Path((service_tref.clone(), DENIED_LAW_ID.to_string())),
+        HeaderMap::new(),
+        body,
+    )
+    .await
+    .expect_err("een GitHub-403 moet de save laten falen");
+    assert_eq!(
+        err.0,
+        StatusCode::FORBIDDEN,
+        "geen generieke 500: {}",
+        err.1
+    );
+    assert_eq!(err.1, DENIED_MESSAGE);
+
+    // ------------------------------------------------------------------
+    // Scenario 4: token-loze repo + gekoppelde gebruiker → de bestaande
+    // user-token-override blijft werken (de PUT-mock matcht alleen
+    // `Bearer user-token`, `.expect(1)` verifieert bij drop).
+    // ------------------------------------------------------------------
+    let body = format!("$id: {LAW_ID}\nname: Bewerkt op token-loze repo\n");
+    save_law(
+        State(state.clone()),
+        Extension(account.clone()),
+        session_for(&sub).await,
+        Path((tokenless_tref.clone(), LAW_ID.to_string())),
+        linked_headers,
+        body,
+    )
+    .await
+    .expect("save op een token-loze repo moet met het gekoppelde token slagen");
+
+    std::env::remove_var(SERVICE_TOKEN_ENV);
+    std::env::remove_var("GITHUB_API_BASE");
+}

--- a/packages/pipeline/src/lib.rs
+++ b/packages/pipeline/src/lib.rs
@@ -8,8 +8,10 @@
 //! worker levert zijn resultaat op als job-blob + taak
 //! (`deliver: "task"`, zie o.a. [`worker::finish_enrich_task_job`] en
 //! [`worker::finish_document_convert_task_job`]), de gebruiker keurt goed in
-//! de editor, en de editor doet de commit namens de gebruiker met diens eigen
-//! OAuth-token (client-gedreven via de save-endpoints van editor-api).
+//! de editor, en de editor volgt daarbij de token-voorrangsregel bij het
+//! committen (service-token indien geconfigureerd, anders het eigen
+//! OAuth-token van de gebruiker; client-gedreven via de save-endpoints van
+//! editor-api).
 //!
 //! Het corpus-token (`CORPUS_GIT_TOKEN`, via `CorpusConfig`) is uitsluitend
 //! voor de **centrale** corpus-repo — de operator-repo waar de klassieke


### PR DESCRIPTION
## Wat

Trajecten op repos met een geconfigureerd server-side service-token (`CORPUS_AUTH_*`) zijn weer opslaanbaar in user-token-modus, en een door GitHub geweigerde write (403) landt als een duidelijke "niet toegestaan"-melding bij de gebruiker in plaats van een generieke 500.

## Hoe

**Schrijfpad spiegelt leespad** (`user_write_token_for_backend`, `packages/editor-api/src/github_oauth.rs`): `backend.is_writable()` → `Ok(None)`, identiek aan `user_read_token_for_backend` (PR #955). De write loopt dan over het service-token en `persist` stempelt de commit met de sessie-identiteit. De user-token-eis (incl. 428/koppelflow) geldt alleen nog voor token-loze, override-capabele backends. De create-traject-preflight (`trajects.rs`, de enige `user_write_token`-caller buiten `_for_backend`) volgt dezelfde voorrangsregel: geconfigureerd token eerst, user-token alleen op token-loze refs.

**GitHub-403 → eigen foutvariant**: nieuwe `CorpusError::WriteDenied(String)` met de GitHub-responsetekst voor logging, gezet op 403 bij PUT/DELETE contents en branch-create (`packages/corpus/src/github.rs`). `corpus_write_error` vertaalt die naar HTTP 403 met: *"GitHub staat deze wijziging niet toe met jouw gekoppelde account: geen schrijftoegang tot deze repository of organisatie."* — de volledige GitHub-fout gaat op warn-niveau naar de log. Alleen 403 wordt zo geclassificeerd; 404/409/422 houden hun bestaande route.

**Docs bijgewerkt**: het oude contract "never silently fall back to the service token" is vervangen door de nieuwe voorrangsregel op `user_write_token`(`_for_backend`), `require_user_token`, `require_traject_backend_writable` en het commentaar in `apiAuthGuard.js` (comment-only; 403 wordt daar bewust niet onderschept, de bestaande "Opslaan mislukt"-modal toont de servertekst al).

## Tests

- Nieuw `packages/editor-api/tests/service_token_write_precedence_test.rs` (wiremock): service-token-repo + niet-gekoppelde gebruiker → save zonder 428, commit met sessie-stempel; gekoppelde gebruiker → nog steeds service-token; GitHub-403 → HTTP 403 met de NL-tekst; token-loze repo + gekoppelde gebruiker → user-token-override blijft werken.
- Nieuw in `packages/corpus/tests/github_api_backend.rs`: 403 op PUT en DELETE → `CorpusError::WriteDenied` (zonder sha-refresh-retry).
- Bestaande suites: `cargo test` (corpus 195, editor-api volledig incl. `promote_user_token_write_test` en `trajects_test`) en frontend-vitest (683 tests, 61 files) groen; `just format`/`just lint`/`just editor-api-lint` groen.

