### PR TITLE
feat(frontend): verwijder de "toevoegen aan traject"-knop uit de zoekresultaten

### DIFF
--- a/frontend/src/EditorView.vue
+++ b/frontend/src/EditorView.vue
@@ -730,14 +730,6 @@ function onSearchSelectLaw(lawIdVal) {
   router.push(libraryRouteFor(lawIdVal));
 }
 
-// Een wet die vanuit de zoekresultaten naar het traject is gepromoot: ververs
-// de gedeelde corpus-lijst (de wet hoort nu bij de eigen traject-repo) en open
-// haar in de bibliotheek — zelfde afronding als een afgeronde harvest.
-async function onSearchLawPromoted(lawIdVal) {
-  await refreshCorpusLaws();
-  router.push(libraryRouteFor(lawIdVal));
-}
-
 async function onSearchHarvestAvailable(slug) {
   // Best-effort reload - a failure just means the list below may not
   // include the fresh law yet.
@@ -2813,7 +2805,6 @@ async function handleActionSave() {
       ref="searchPopoverRef"
       @select-law="onSearchSelectLaw"
       @harvest-available="onSearchHarvestAvailable"
-      @promoted="onSearchLawPromoted"
     />
   </Teleport>
 

--- a/frontend/src/LibraryView.vue
+++ b/frontend/src/LibraryView.vue
@@ -329,16 +329,12 @@ async function headerAddWerkdoc(kind) {
   if (kind === 'new') onDocNew();
   else onDocUpload();
 }
-// Na een geslaagde promote (via de AddLawSheet óf de "Toevoegen aan
-// traject"-knop in de gewone zoekresultaten): index verversen (de wet staat
+// Na een geslaagde promote (via de AddLawSheet): index verversen (de wet staat
 // nu in de traject-repo) en de wet openen — dezelfde afronding als een
-// afgeronde harvest in de globale zoeker (onHarvestAvailable). Vanuit de
-// zoekresultaten focussen we ook het sidebar-item (focusAfter), net als
-// select-law uit dezelfde popover — daarvoor stelt SearchPopover de
-// 'promoted'-emit uit tot na _returnFocus.
-async function onLawPromoted(lawId, focusAfter = false) {
+// afgeronde harvest in de globale zoeker (onHarvestAvailable).
+async function onLawPromoted(lawId) {
   await loadIndex();
-  selectLaw(lawId, focusAfter);
+  selectLaw(lawId);
 }
 // Een gestarte traject-harvest is async: bevestig met dezelfde banner-vorm
 // als de document-upload dat de voortgang in het Taken-paneel verschijnt.
@@ -2075,7 +2071,6 @@ watch(activeTrajectRef, () => {
       ref="searchPopoverRef"
       @select-law="(lawId) => selectLaw(lawId, true)"
       @harvest-available="onHarvestAvailable"
-      @promoted="(lawId) => onLawPromoted(lawId, true)"
     />
     <AddLawSheet
       ref="addLawSheetRef"

--- a/frontend/src/components/SearchPopover.test.js
+++ b/frontend/src/components/SearchPopover.test.js
@@ -9,8 +9,8 @@ import SearchPopover from './SearchPopover.vue';
 //
 // useTrajects() calls vue-router's useRoute(); mock it so the component mounts
 // without a router. Default: no active traject → global /api/corpus URL. The
-// traject-scoped promote tests swap in a trajectRef per test (vi.hoisted so
-// the hoisted mock factory can reference it).
+// traject-scoped tests swap in a trajectRef per test (vi.hoisted so the
+// hoisted mock factory can reference it).
 const routeMock = vi.hoisted(() => ({ params: {} }));
 vi.mock('vue-router', () => ({
   useRoute: () => routeMock,
@@ -185,157 +185,46 @@ function promoteButtons(wrapper) {
     .filter((b) => b.attributes('text') === 'Toevoegen aan traject');
 }
 
-describe('SearchPopover "Toevoegen aan traject" in zoekresultaten', () => {
+// De "Toevoegen aan traject"-knop is bewust uit de zoekresultaten verwijderd:
+// promoten van een wet uit het centrale corpus kan uitsluitend via de
+// expliciete "Wet toevoegen"-flow (AddLawSheet). Deze tests pinnen dat de
+// knop óók binnen een traject niet (terug)verschijnt.
+describe('SearchPopover zonder "Toevoegen aan traject" in zoekresultaten', () => {
   beforeEach(() => {
     routeMock.params = { trajectRef: TRAJECT_REF };
   });
 
-  it('toont de knop alleen bij federatie-treffers die nog niet in de eigen repo staan', async () => {
+  it('toont binnen een traject geen promote-knop; de ondertitel is de bron', async () => {
     const wrapper = mount(SearchPopover);
     await searchFor(wrapper, 'zorgverzekering');
 
     const rows = wrapper.findAll('nldd-list-item[data-law-id]');
-    const central = rows.find((r) => r.attributes('data-law-id') === 'besluit_zorgverzekering');
-    const own = rows.find(
-      (r) => r.attributes('data-law-id') === 'besluit_zorgverzekering_example',
-    );
+    expect(rows).toHaveLength(2);
+    // Ook de centrale-seed-treffer (priority 2, niet in de eigen repo) krijgt
+    // geen knop meer — promoten kan alleen nog via de AddLawSheet.
+    expect(promoteButtons(wrapper)).toHaveLength(0);
 
-    // Centrale-seed-treffer (priority 2): wel een promote-knop.
-    expect(
-      central.findAll('nldd-button').some((b) => b.attributes('text') === 'Toevoegen aan traject'),
-    ).toBe(true);
-    // Eigen-repo-treffer (priority 0): geen knop - er valt niets te promoten.
-    expect(own.findAll('nldd-button')).toHaveLength(0);
-    expect(own.get('nldd-text-cell').attributes('supporting-text')).toBe(
-      'example-org/regelrecht-corpus-example',
+    const central = rows.find((r) => r.attributes('data-law-id') === 'besluit_zorgverzekering');
+    expect(central.get('nldd-text-cell').attributes('supporting-text')).toBe(
+      'Centrale Regelrecht Corpus',
     );
   });
 
-  it('promoot via POST /promote en emit "promoted" (niet select-law) na sluiten', async () => {
-    fetch.mockImplementation(async (url, init = {}) => {
-      const u = String(url);
-      if (u.includes('/auth/status')) return { ok: false, json: async () => ({}) };
-      if (u.includes('/promote') && init.method === 'POST') {
-        return { ok: true, json: async () => ({ law_id: 'besluit_zorgverzekering' }) };
-      }
-      if (u.includes('/corpus/laws') && u.includes('q=')) {
-        return { ok: true, json: async () => LAWS };
-      }
-      return { ok: true, json: async () => [] };
-    });
-
+  it('een rij-klik navigeert alleen (select-law), er wordt niets gepromoot', async () => {
     const wrapper = mount(SearchPopover);
     await searchFor(wrapper, 'zorgverzekering');
 
-    await promoteButtons(wrapper)[0].trigger('click');
-    await settle();
+    await wrapper
+      .get('nldd-list-item[data-law-id="besluit_zorgverzekering"]')
+      .trigger('click');
+    // select-law wordt uitgesteld tot de popover dicht is (deferral).
+    await wrapper.get('nldd-popover').trigger('close');
 
-    const promoteCall = fetch.mock.calls.find(
+    expect(wrapper.emitted('select-law')).toEqual([['besluit_zorgverzekering']]);
+    expect(wrapper.emitted('promoted')).toBeUndefined();
+    const promoteCalls = fetch.mock.calls.filter(
       (c) => String(c[0]).includes('/promote') && c[1]?.method === 'POST',
     );
-    expect(String(promoteCall[0])).toBe(
-      `/api/trajects/${TRAJECT_REF}/corpus/laws/besluit_zorgverzekering/promote`,
-    );
-
-    // Zelfde deferral als select-law: de emit komt pas als de popover dicht
-    // is, zodat de focus-op-de-wet van de parent wint van _returnFocus.
-    expect(wrapper.emitted('promoted')).toBeUndefined();
-    await wrapper.get('nldd-popover').trigger('close');
-    expect(wrapper.emitted('promoted')).toEqual([['besluit_zorgverzekering']]);
-    // click.stop: de knop mag de rij-navigatie (select-law) niet triggeren.
-    expect(wrapper.emitted('select-law')).toBeUndefined();
-  });
-
-  it('een promote die pas na het sluiten resolvet, emit niet alsnog in een latere sessie', async () => {
-    let resolvePromote;
-    fetch.mockImplementation(async (url, init = {}) => {
-      const u = String(url);
-      if (u.includes('/auth/status')) return { ok: false, json: async () => ({}) };
-      if (u.includes('/promote') && init.method === 'POST') {
-        return new Promise((r) => {
-          resolvePromote = () => r({ ok: true, json: async () => ({}) });
-        });
-      }
-      if (u.includes('/corpus/laws') && u.includes('q=')) {
-        return { ok: true, json: async () => LAWS };
-      }
-      return { ok: true, json: async () => [] };
-    });
-
-    const wrapper = mount(SearchPopover);
-    await searchFor(wrapper, 'zorgverzekering');
-
-    // De gebruiker sluit de popover terwijl de promote-POST nog loopt…
-    await promoteButtons(wrapper)[0].trigger('click');
-    await wrapper.get('nldd-popover').trigger('close');
-    // …waarna de POST alsnog slaagt: close() is dan een no-op (de popover is
-    // al dicht, dus geen 'close'-event) en de pending emit mag niet blijven
-    // hangen tot een volgende sessie.
-    resolvePromote();
-    await settle();
-
-    await wrapper.get('nldd-popover').trigger('open');
-    await wrapper.get('nldd-popover').trigger('close');
-    expect(wrapper.emitted('promoted')).toBeUndefined();
-  });
-
-  it('een 409 markeert de wet als al-in-traject: knop weg, "Al in dit traject"', async () => {
-    fetch.mockImplementation(async (url, init = {}) => {
-      const u = String(url);
-      if (u.includes('/auth/status')) return { ok: false, json: async () => ({}) };
-      if (u.includes('/promote') && init.method === 'POST') {
-        return { ok: false, status: 409, text: async () => 'al in traject', headers: { get: () => '' } };
-      }
-      if (u.includes('/corpus/laws') && u.includes('q=')) {
-        return { ok: true, json: async () => LAWS };
-      }
-      return { ok: true, json: async () => [] };
-    });
-
-    const wrapper = mount(SearchPopover);
-    await searchFor(wrapper, 'zorgverzekering');
-
-    await promoteButtons(wrapper)[0].trigger('click');
-    await settle();
-    await nextTick();
-
-    expect(promoteButtons(wrapper)).toHaveLength(0);
-    const central = wrapper.get('nldd-list-item[data-law-id="besluit_zorgverzekering"]');
-    expect(central.get('nldd-text-cell').attributes('supporting-text')).toBe('Al in dit traject');
-    await wrapper.get('nldd-popover').trigger('close');
-    expect(wrapper.emitted('promoted')).toBeUndefined();
-  });
-
-  it('een niet-409-fout toont de foutbanner en laat de knop staan', async () => {
-    fetch.mockImplementation(async (url, init = {}) => {
-      const u = String(url);
-      if (u.includes('/auth/status')) return { ok: false, json: async () => ({}) };
-      if (u.includes('/promote') && init.method === 'POST') {
-        return { ok: false, status: 500, text: async () => 'boem', headers: { get: () => '' } };
-      }
-      if (u.includes('/corpus/laws') && u.includes('q=')) {
-        return { ok: true, json: async () => LAWS };
-      }
-      return { ok: true, json: async () => [] };
-    });
-
-    const wrapper = mount(SearchPopover);
-    await searchFor(wrapper, 'zorgverzekering');
-
-    await promoteButtons(wrapper)[0].trigger('click');
-    await settle();
-    await nextTick();
-
-    expect(wrapper.vm.promoteError).toBeTruthy();
-    // De banner-rij draagt de melding als attribute op de nldd-text-cell
-    // (custom elements renderen tekst niet als DOM-tekst in happy-dom).
-    const bannerTexts = wrapper
-      .findAll('nldd-text-cell')
-      .map((c) => c.attributes('text'));
-    expect(bannerTexts).toContain(
-      'Toevoegen aan het traject is mislukt. Probeer het opnieuw of neem contact op.',
-    );
-    expect(promoteButtons(wrapper)).toHaveLength(1);
-    expect(wrapper.emitted('promoted')).toBeUndefined();
+    expect(promoteCalls).toHaveLength(0);
   });
 });

--- a/frontend/src/components/SearchPopover.vue
+++ b/frontend/src/components/SearchPopover.vue
@@ -4,7 +4,6 @@ import { useBwbSearch, MIN_QUERY_LENGTH } from '../composables/useBwbSearch.js';
 import { useBwbHarvest } from '../composables/useBwbHarvest.js';
 import { useAuth } from '../composables/useAuth.js';
 import { useTrajects } from '../composables/useTrajects.js';
-import { useLawPromote } from '../composables/useLawPromote.js';
 import { lawsListUrl } from '../composables/corpusUrls.js';
 import { apiFetchJson } from '../lib/apiFetch.js';
 import { useLatest } from '../lib/useLatest.js';
@@ -14,23 +13,9 @@ import { SEARCH_PLACEHOLDER, SEARCH_ACCESSIBLE_LABEL } from '../constants.js';
 // so this popover stays in sync with the main search-field in AppShell.
 const listTranslations = { 'components.list.search-placeholder-text': SEARCH_PLACEHOLDER };
 
-const emit = defineEmits(['select-law', 'harvest-available', 'promoted']);
+const emit = defineEmits(['select-law', 'harvest-available']);
 
 const { activeTrajectRef } = useTrajects();
-
-// "Toevoegen aan traject" direct vanuit de zoekresultaten: een treffer uit een
-// gefedereerde bron (de centrale seed, source_priority > 0) die nog niet in de
-// eigen traject-repo staat, krijgt een promote-knop in de rij. Zelfde gedeelde
-// logica als de "Wet toevoegen"-flow (AddLawSheet) - geen tweede
-// promote-implementatie.
-const {
-  promoteState,
-  promoteError,
-  setLawsFromSearch,
-  isInTraject: isLawIdInTraject,
-  clearPromoteError,
-  promote: promoteLaw,
-} = useLawPromote(activeTrajectRef);
 
 const { results: bwbResults, loading: bwbLoading, search: searchBwb, clear: clearBwb } = useBwbSearch();
 const {
@@ -115,7 +100,6 @@ let debounceTimer = null;
 watch(search, (q) => {
   clearBwb();
   searchFailed.value = false;
-  clearPromoteError();
   if (debounceTimer) clearTimeout(debounceTimer);
   const term = q.trim();
   if (term.length < MIN_QUERY_LENGTH) {
@@ -139,9 +123,6 @@ async function runCorpusSearch(term) {
     const laws = await apiFetchJson(url);
     if (!isCurrent()) return; // a newer query superseded this one
     serverLaws.value = laws;
-    // Ververs de al-in-traject-set (source_priority 0 = eigen repo) zodat de
-    // promote-knop alleen op nog-niet-gepromote federatie-treffers verschijnt.
-    setLawsFromSearch(laws);
     searchFailed.value = false;
     // No match anywhere in the corpus → offer the external wetten.overheid.nl
     // search (unless the user must log in first to reach it).
@@ -205,16 +186,9 @@ function onListKeydown(e) {
 function onPopoverClose() {
   search.value = '';
   clearBwb();
-  clearPromoteError();
-  // Emit the deferred promote/selection now: the popover has closed and
-  // already run its _returnFocus, so the parent's focus-the-law wins (see
-  // selectLaw / promoteFromRow).
-  if (pendingPromotedLawId !== null) {
-    const lawId = pendingPromotedLawId;
-    pendingPromotedLawId = null;
-    pendingSelectLawId = null;
-    emit('promoted', lawId);
-  } else if (pendingSelectLawId !== null) {
+  // Emit the deferred selection now: the popover has closed and already run its
+  // _returnFocus, so the parent's focus-the-law wins (see selectLaw).
+  if (pendingSelectLawId !== null) {
     const lawId = pendingSelectLawId;
     pendingSelectLawId = null;
     emit('select-law', lawId);
@@ -232,38 +206,6 @@ let pendingSelectLawId = null;
 function selectLaw(lawId) {
   pendingSelectLawId = lawId;
   close();
-}
-
-// The promoted law id, emitted on 'promoted' once the popover has fully closed
-// (same deferral as pendingSelectLawId): the parent refreshes its index and
-// opens/focuses the law, which must win from the popover's _returnFocus.
-let pendingPromotedLawId = null;
-
-/**
- * Alleen federatie-treffers (centrale seed, source_priority > 0) die nog niet
- * in de eigen traject-repo staan krijgen de knop; buiten een traject (globale
- * corpus-weergave) is er niets om naartoe te promoten. Na een 409 verhuist de
- * wet naar de al-in-traject-set en toont de rij "Al in dit traject".
- */
-function canPromote(law) {
-  return (
-    Boolean(activeTrajectRef.value) &&
-    law.source_priority !== 0 &&
-    !isLawIdInTraject(law.law_id)
-  );
-}
-
-function lawSupportingText(law) {
-  if (law.source_priority !== 0 && isLawIdInTraject(law.law_id)) return 'Al in dit traject';
-  return law.source_name || undefined;
-}
-
-async function promoteFromRow(law) {
-  const outcome = await promoteLaw(law.law_id);
-  if (outcome === 'done') {
-    pendingPromotedLawId = law.law_id;
-    close();
-  }
 }
 
 /**
@@ -318,13 +260,6 @@ async function show(anchorEl, initialSearch = '') {
  * to the host. The `open` event fires AFTER _manageFocus, so our focus wins.
  */
 function onPopoverOpen() {
-  // Verse sessie: gooi een pending emit van een vorige sessie weg. Die kan
-  // blijven hangen wanneer de promote-POST pas resolvet nadat de gebruiker de
-  // popover al sloot — close() is dan een no-op (de popover is al dicht, dus
-  // geen 'close'-event) en zonder deze reset zou de eerstvolgende close een
-  // stale 'promoted' emitten en een legitieme select-law verdringen.
-  pendingPromotedLawId = null;
-  pendingSelectLawId = null;
   const list = popoverRef.value?.querySelector('nldd-list');
   const input = list?.shadowRoot?.querySelector('.list__search-field-input');
   if (input) {
@@ -388,19 +323,10 @@ defineExpose({ show });
           @click="close"
         ></nldd-button>
 
-        <!-- Fout bij promoten: één banner boven de resultaten (zelfde vorm
-             als in AddLawSheet). -->
-        <nldd-list-item v-if="promoteError" size="md">
-          <nldd-icon-cell size="20" icon="alert" color="critical"></nldd-icon-cell>
-          <nldd-spacer-cell size="8"></nldd-spacer-cell>
-          <nldd-text-cell :text="promoteError" color="critical"></nldd-text-cell>
-        </nldd-list-item>
-
         <!-- Interne corpus-treffers: platte lijst, eigen repo eerst (op
-             bron-prioriteit), met de bron als ondertitel per rij. Een treffer
-             uit de centrale seed die nog niet in de eigen traject-repo staat,
-             krijgt direct een "Toevoegen aan traject"-knop (click.stop: de
-             knop mag de rij-navigatie niet triggeren). -->
+             bron-prioriteit), met de bron als ondertitel per rij. Rijen
+             navigeren alleen naar de wet; promoten naar het traject kan
+             uitsluitend via de "Wet toevoegen"-flow (AddLawSheet). -->
         <nldd-list-item
           v-for="law in sortedLaws"
           :key="law.law_id"
@@ -411,20 +337,8 @@ defineExpose({ show });
         >
           <nldd-text-cell
             :text="displayName(law)"
-            :supporting-text="lawSupportingText(law)"
+            :supporting-text="law.source_name || undefined"
           ></nldd-text-cell>
-          <template v-if="canPromote(law)">
-            <nldd-spacer-cell size="8"></nldd-spacer-cell>
-            <nldd-cell>
-              <nldd-button
-                size="sm"
-                variant="secondary"
-                text="Toevoegen aan traject"
-                :loading="promoteState[law.law_id] === 'busy' || undefined"
-                @click.stop="promoteFromRow(law)"
-              ></nldd-button>
-            </nldd-cell>
-          </template>
         </nldd-list-item>
 
         <!-- Externe wetten.overheid.nl-treffers (alleen wanneer de corpus niets


### PR DESCRIPTION
## Wat

De "Toevoegen aan traject"-knop verdwijnt uit de zoekresultaat-rijen van de zoek-dropdown (`SearchPopover`). Promoten van een wet uit het centrale corpus naar het traject kan alleen nog via de expliciete "Wet toevoegen"-flow achter de plus (`AddLawSheet`).

## Waarom

Besluit na het zien van de gemergde #952-rework: de knop in de gewone zoekresultaten is niet gewenst. Rijen navigeren alleen nog naar de wet.

## Hoe

Grotendeels een terugdraai van de SearchPopover-kant van 352ebc4e, zonder de `useLawPromote`-extractie terug te draaien:

- `SearchPopover.vue`: knop, `canPromote`/`promoteFromRow`, `promoteError`-banner, `useLawPromote`-import, `promoted`-emit incl. het uitgestelde `pendingPromotedLawId`-mechanisme verwijderd; de rij-ondertitel toont weer gewoon `source_name` (de "Al in dit traject"-variant is mee verdwenen).
- `LibraryView.vue`: `@promoted`-listener op de SearchPopover verwijderd; de AddLawSheet-listener blijft (`onLawPromoted` weer zonder `focusAfter`).
- `EditorView.vue`: idem — de `@promoted`-listener en het dode `onSearchLawPromoted` uit dezelfde 352ebc4e-commit opgeruimd.
- `SearchPopover.test.js`: de knop-tests vervangen door tests die pinnen dat de knop er (ook binnen een traject) níét is en dat een rij-klik alleen `select-law` doet.

De AddLawSheet/plus-flow (incl. 409-afhandeling en harvest-fallback) en `useLawPromote.js` zijn onaangeraakt.

## Checks

- Frontend vitest-suite: 680 tests groen.
- `just check` groen (pipeline-/admin-DB-tests draaien hier met `TESTCONTAINERS_HOST_OVERRIDE` en een geïsoleerde `CARGO_TARGET_DIR` wegens een parallelle build in de dev-omgeving; failures daarzonder waren omgevingsruis, geen codefouten).
