### PR TITLE
test(frontend): deterministische browser-smoketest tegen deployed preview

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -104,6 +104,53 @@ pipeline-integration-test:
 # Run all tests (engine + harvester + pipeline unit + pipeline integration + editor-api)
 test-all: test harvester-test pipeline-test pipeline-integration-test editor-api-test
 
+# Optionele variabelen-overrides (moeten VOOR de recipe-naam staan in just):
+#   just PR=886 smoke-preview
+#   just URL=https://editor.regelrecht.rijks.app smoke-preview
+PR := ""
+URL := ""
+
+# Token-vrije browser-smoketest tegen een DEPLOYED editor-preview (of productie):
+# echte Keycloak-login + editor-api + DB + WASM. Draai met een PR-nummer of een
+# volledige URL. De test-user-creds komen uit /workspace/.cred (override met
+# SMOKE_CRED_FILE) - nooit in de repo.
+#
+# Drie manieren om het doel op te geven (positioneel is het handigst):
+#   just smoke-preview 886                                    # PR-preview #886
+#   just smoke-preview https://editor.regelrecht.rijks.app    # exacte URL
+#   just PR=886 smoke-preview                                 # via variabele
+smoke-preview TARGET="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    target="{{TARGET}}"
+    if [ -n "{{URL}}" ]; then
+      base="{{URL}}"
+    elif [ -n "{{PR}}" ]; then
+      base="https://editor-pr{{PR}}-regel-k4c.rig.prd1.gn2.quattro.rijksapps.nl"
+    elif [ -n "$target" ]; then
+      case "$target" in
+        http://*|https://*) base="$target" ;;
+        *) base="https://editor-pr${target}-regel-k4c.rig.prd1.gn2.quattro.rijksapps.nl" ;;
+      esac
+    else
+      echo "Geef een doel mee, bijv. 'just smoke-preview 886' of 'just URL=<url> smoke-preview'." >&2
+      exit 2
+    fi
+    cred="${SMOKE_CRED_FILE:-/workspace/.cred}"
+    if [ ! -f "$cred" ]; then
+      echo "Cred-bestand niet gevonden: $cred (verwacht regels 'Username:'/'Password:')." >&2
+      exit 2
+    fi
+    export SMOKE_BASE_URL="$base"
+    export SMOKE_USER="$(sed -n 's/^Username:[[:space:]]*//p' "$cred" | head -n1)"
+    export SMOKE_PASS="$(sed -n 's/^Password:[[:space:]]*//p' "$cred" | head -n1)"
+    if [ -z "$SMOKE_USER" ] || [ -z "$SMOKE_PASS" ]; then
+      echo "Kon Username/Password niet uit $cred lezen." >&2
+      exit 2
+    fi
+    echo "Smoke-test tegen $SMOKE_BASE_URL"
+    npx playwright test -c frontend/playwright.smoke.config.js
+
 # --- Mutation testing ---
 
 # Run mutation testing on engine (in-place because tests use relative paths to corpus/)

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -3,4 +3,5 @@ node_modules/
 public/data/
 test-results/
 playwright-report/
+.auth/
 public/corpus-registry.yaml

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -26,6 +26,45 @@ npm run build
 npm run preview
 ```
 
+## Testing
+
+### Mocked component + e2e suite (`e2e/`)
+
+`npm run test:e2e` runs the Playwright specs in `e2e/` against a local Vite dev
+server with the backend **mocked** (see `playwright.config.js`). Fast, hermetic,
+no auth. Selector helpers live in `e2e/helpers.js`.
+
+### Deployed-preview smoke suite (`e2e-smoke/`)
+
+A **token-free, deterministic** smoke test that drives the core editor flow
+against a **deployed** PR-preview (or production) through the full stack:
+real Keycloak login, editor-api, DB and WASM. It is the SpecFlow/Selenium-style
+counterpart to the mocked suite — no LLM tokens, repeatable on every change.
+
+```bash
+# From the repo root:
+just smoke-preview PR=886                                   # editor-pr886 preview
+just smoke-preview URL=https://editor.regelrecht.rijks.app  # any deployed URL
+```
+
+The recipe sets `SMOKE_BASE_URL` and injects the shared test-user credentials
+(`SMOKE_USER` / `SMOKE_PASS`) from the local cred file — credentials are **never**
+committed and only ever read from the environment. `global-setup.js` logs in once
+and stores the session in `.auth/state.json` (git-ignored); each spec reuses it.
+
+Layout:
+
+- `playwright.smoke.config.js` — no `webServer`; `baseURL` from `SMOKE_BASE_URL`.
+- `e2e-smoke/global-setup.js` — deterministic login + `/auth/status` check.
+- `e2e-smoke/smoke.spec.js` — the core flow (library → trajecten → create traject →
+  editor → edit → save → reload → persist), cleaning up every traject it creates.
+- `e2e-smoke/smoke-helpers.js` — preview-only helpers (login, traject CRUD). Selector
+  helpers are **reused** from `e2e/helpers.js`, not copied.
+
+**This smoke suite is the living contract for the editor.** When you add or change
+an editor feature, **extend `e2e-smoke/smoke.spec.js`** so the deployed preview keeps
+smoking the full, growing set of core behaviour — not just the frontend in isolation.
+
 ## Browser Support
 
 This prototype uses modern CSS features including:

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -42,9 +42,13 @@ real Keycloak login, editor-api, DB and WASM. It is the SpecFlow/Selenium-style
 counterpart to the mocked suite — no LLM tokens, repeatable on every change.
 
 ```bash
-# From the repo root:
-just smoke-preview PR=886                                   # editor-pr886 preview
-just smoke-preview URL=https://editor.regelrecht.rijks.app  # any deployed URL
+# From the repo root — pass the target positionally:
+just smoke-preview 886                                  # editor-pr886 preview
+just smoke-preview https://editor.regelrecht.rijks.app  # any deployed URL
+
+# Or as a just variable (must precede the recipe name):
+just PR=886 smoke-preview
+just URL=https://editor.regelrecht.rijks.app smoke-preview
 ```
 
 The recipe sets `SMOKE_BASE_URL` and injects the shared test-user credentials

--- a/frontend/e2e-smoke/global-setup.js
+++ b/frontend/e2e-smoke/global-setup.js
@@ -1,0 +1,48 @@
+import { chromium } from '@playwright/test';
+import { mkdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { login } from './smoke-helpers.js';
+
+// Where the authenticated session is stored. Kept next to the config (frontend/
+// .auth/state.json) and git-ignored - it holds the Keycloak session cookie.
+export const STORAGE_STATE = resolve(import.meta.dirname, '..', '.auth', 'state.json');
+
+/**
+ * Global setup for the deployed-preview smoke suite: log in once with the
+ * shared test user, verify the session, and persist `storageState` so every
+ * spec reuses the same authenticated context without re-driving Keycloak.
+ *
+ * All environment-specific input comes from env vars (never hardcoded):
+ *   SMOKE_BASE_URL  - the preview/prod base URL (also set as `use.baseURL`)
+ *   SMOKE_USER      - Keycloak username of the shared test user
+ *   SMOKE_PASS      - its password
+ */
+export default async function globalSetup(config) {
+  const baseURL =
+    process.env.SMOKE_BASE_URL || config.projects?.[0]?.use?.baseURL;
+  const user = process.env.SMOKE_USER;
+  const pass = process.env.SMOKE_PASS;
+
+  if (!baseURL) {
+    throw new Error('SMOKE_BASE_URL is required (the deployed preview/prod base URL).');
+  }
+  if (!user || !pass) {
+    throw new Error(
+      'SMOKE_USER and SMOKE_PASS are required. The `just smoke-preview` recipe injects them from the local cred file.',
+    );
+  }
+
+  const browser = await chromium.launch();
+  try {
+    const context = await browser.newContext({ baseURL });
+    const page = await context.newPage();
+
+    await login(page, { user, pass });
+
+    mkdirSync(dirname(STORAGE_STATE), { recursive: true });
+    await context.storageState({ path: STORAGE_STATE });
+    await context.close();
+  } finally {
+    await browser.close();
+  }
+}

--- a/frontend/e2e-smoke/smoke-helpers.js
+++ b/frontend/e2e-smoke/smoke-helpers.js
@@ -1,0 +1,128 @@
+// Helpers specific to the deployed-preview smoke suite. Selector helpers that
+// the mocked `e2e/` suite already owns (article tabs, the machine-readable
+// pane) are imported from `../e2e/helpers.js` rather than copied - see
+// `smoke.spec.js`. What lives here is preview-only: the deterministic Keycloak
+// login (ported from the `regelrecht-editor-login` skill) and the traject
+// create/delete plumbing that drives setup/teardown through `page.request`.
+
+/**
+ * Deterministic Keycloak login for the shared test user, ported from the
+ * `regelrecht-editor-login` skill. Navigates to `/auth/login`, fills the
+ * username/password card (NOT "SSO Rijk"), submits, and waits until Keycloak
+ * has bounced back to the app. Works both from a `Page` (global-setup) and is
+ * side-effect only - the caller owns the resulting session cookie.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {object} opts
+ * @param {string} opts.user
+ * @param {string} opts.pass
+ */
+export async function login(page, { user, pass }) {
+  if (!user || !pass) {
+    throw new Error('login(): user and pass are required (set SMOKE_USER / SMOKE_PASS)');
+  }
+  // `/auth/login` is `requiresAuth` and boots the Keycloak redirect.
+  await page.goto('/auth/login', { waitUntil: 'domcontentloaded' });
+
+  // The username/password inputs live under a card that the accessibility
+  // snapshot does not surface, but plain locators reach them fine.
+  await page.waitForSelector('#username', { timeout: 30_000 });
+  await page.fill('#username', user);
+  await page.fill('#password', pass);
+
+  // Submitting the password field posts the Keycloak form; wait until we've
+  // left the login/Keycloak pages and are back on the app origin.
+  await Promise.all([
+    page
+      .waitForURL(
+        (url) => !url.href.includes('/auth/login') && !/keycloak|realms/.test(url.href),
+        { timeout: 45_000 },
+      )
+      .catch(() => {}),
+    page.press('#password', 'Enter'),
+  ]);
+
+  // Confirm the session is live before we hand back control. `/auth/status`
+  // carries the just-minted session cookie automatically.
+  await expectAuthenticated(page);
+}
+
+/**
+ * Fetch `/auth/status` from within the page context and assert the session is
+ * authenticated. Returns the parsed status object.
+ * @param {import('@playwright/test').Page} page
+ */
+export async function expectAuthenticated(page) {
+  const status = await page.evaluate(async () => {
+    const res = await fetch('/auth/status', { headers: { accept: 'application/json' } });
+    return res.json();
+  });
+  if (!status || status.authenticated !== true) {
+    throw new Error(`Not authenticated after login: ${JSON.stringify(status)}`);
+  }
+  return status;
+}
+
+/**
+ * Create a traject through the API with an ephemeral, timestamped name so a
+ * re-run never collides with a leftover. Returns the created summary
+ * (`{ id, ref, name, ... }`). The default (no custom repo) branch pushes to the
+ * central corpus, which is what the smoke flow exercises.
+ *
+ * @param {import('@playwright/test').APIRequestContext} request
+ * @param {object} [opts]
+ * @param {string} [opts.prefix]
+ */
+export async function createTraject(request, { prefix = 'smoke' } = {}) {
+  const name = `${prefix}-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`;
+  const res = await request.post('/api/trajects', {
+    headers: { 'content-type': 'application/json' },
+    data: { name, description: 'Ephemeral traject aangemaakt door de smoke-suite.' },
+  });
+  if (!res.ok()) {
+    throw new Error(`POST /api/trajects failed: ${res.status()} ${await res.text()}`);
+  }
+  const created = await res.json();
+  if (!created.id || !created.ref) {
+    throw new Error(`Unexpected traject create response: ${JSON.stringify(created)}`);
+  }
+  return created;
+}
+
+/**
+ * Hard-delete a traject by UUID (owner-only, backend returns 204). Best-effort:
+ * logs rather than throws so a teardown loop cleans up every traject even if
+ * one delete fails.
+ * @param {import('@playwright/test').APIRequestContext} request
+ * @param {string} trajectId
+ */
+export async function deleteTraject(request, trajectId) {
+  try {
+    const res = await request.delete(`/api/trajects/${encodeURIComponent(trajectId)}`);
+    if (!res.ok() && res.status() !== 404) {
+      // eslint-disable-next-line no-console
+      console.warn(`DELETE /api/trajects/${trajectId} -> ${res.status()} ${await res.text()}`);
+    }
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn(`DELETE /api/trajects/${trajectId} threw: ${err.message}`);
+  }
+}
+
+/**
+ * Read one traject-scoped law body as text (YAML). Used to assert persistence
+ * without re-parsing the DOM.
+ * @param {import('@playwright/test').APIRequestContext} request
+ * @param {string} trajectRef
+ * @param {string} lawId
+ */
+export async function readTrajectLaw(request, trajectRef, lawId) {
+  const res = await request.get(
+    `/api/trajects/${encodeURIComponent(trajectRef)}/corpus/laws/${encodeURIComponent(lawId)}`,
+    { headers: { accept: 'text/yaml' } },
+  );
+  if (!res.ok()) {
+    throw new Error(`GET traject law failed: ${res.status()} ${await res.text()}`);
+  }
+  return res.text();
+}

--- a/frontend/e2e-smoke/smoke.spec.js
+++ b/frontend/e2e-smoke/smoke.spec.js
@@ -1,0 +1,155 @@
+import { test, expect, request as apiRequest } from '@playwright/test';
+// Reuse the selector helpers the mocked `e2e/` suite already owns instead of
+// copying them (DRY). `machineReadablePane` returns the editor's
+// machine-readable region; the smoke flow asserts against the exact same
+// contract the mocked specs do.
+import { machineReadablePane } from '../e2e/helpers.js';
+import { STORAGE_STATE } from './global-setup.js';
+import { createTraject, deleteTraject, readTrajectLaw } from './smoke-helpers.js';
+
+// The canonical fixture law + a stable article. Present in the deployed corpus;
+// a fresh traject forks it without a machine_readable block on article 1, which
+// is exactly the "empty state -> author -> persist" path the smoke exercises.
+const LAW_ID = 'wet_op_de_zorgtoeslag';
+const ARTICLE = '1';
+
+// Trajects created during the run, torn down in afterAll so a second run starts
+// clean. Stored by UUID (`id`), which the owner-only DELETE takes.
+const createdTrajects = [];
+// The traject the editor steps run against (set by the create test).
+let traject = null;
+
+test.describe.configure({ mode: 'serial' });
+
+test.afterAll(async () => {
+  if (createdTrajects.length === 0) return;
+  // A fresh request context carrying the same authenticated session as the
+  // specs (afterAll runs outside a test's fixtures).
+  const ctx = await apiRequest.newContext({
+    baseURL: process.env.SMOKE_BASE_URL,
+    storageState: STORAGE_STATE,
+  });
+  try {
+    for (const id of createdTrajects) {
+      await deleteTraject(ctx, id);
+    }
+  } finally {
+    await ctx.dispose();
+  }
+});
+
+test('1) /library toont de wettenlijst tegen de echte corpus', async ({ page }) => {
+  await page.goto('/library');
+  // `/library` redirects to Home; the SPA booting against the real backend
+  // sets the document title.
+  await expect(page).toHaveTitle(/RegelRecht/);
+
+  // The corpus law list is served by the real editor-api. Assert the known
+  // fixture law is in it - this is the data behind the wettenlijst.
+  const res = await page.request.get('/api/corpus/laws?limit=1000');
+  expect(res.ok()).toBeTruthy();
+  const laws = await res.json();
+  expect(Array.isArray(laws)).toBeTruthy();
+  expect(laws.length).toBeGreaterThan(0);
+  expect(laws.some((l) => l.law_id === LAW_ID)).toBeTruthy();
+
+  // Open the law in the library so it renders in the UI, confirming the
+  // wettenlijst is navigable, not just an API payload: the sidebar shows the
+  // law entry and the title reflects the opened law.
+  await page.goto(`/corpus-juris/${LAW_ID}`);
+  await expect(page.locator(`nldd-list-item[data-law-id="${LAW_ID}"]`).first()).toBeVisible();
+});
+
+test('2) /trajecten rendert', async ({ page }) => {
+  await page.goto('/trajecten');
+  await expect(page.locator('#kies-traject-titel')).toBeVisible();
+});
+
+test('3) maakt een traject aan via de API', async ({ page }) => {
+  traject = await createTraject(page.request);
+  createdTrajects.push(traject.id);
+  expect(traject.ref).toMatch(/^[a-z0-9-]+-[0-9a-f]{8}$/);
+  expect(traject.role).toBe('owner');
+});
+
+test('4) editor opent de wet, kiest artikel en toont het machine-paneel', async ({ page }) => {
+  expect(traject, 'traject uit stap 3').not.toBeNull();
+
+  await page.goto(`/trajecten/${traject.ref}/editor/${LAW_ID}/${ARTICLE}`);
+  // Article tabs appear once the traject-scoped law has loaded through the full
+  // stack (editor-api + corpus + WASM).
+  await expect(
+    page.locator('nldd-document-tab-bar-item', { hasText: `Artikel ${ARTICLE}` }).first(),
+  ).toBeVisible({ timeout: 60_000 });
+
+  // The machine-readable pane must resolve to one of its two KNOWN states -
+  // populated content or the "no machine-readable yet" empty state - not stay
+  // stuck loading. On a fresh traject fork it is the empty state.
+  const emptyState = page.locator('[data-testid="no-machine-readable"]');
+  await expect(emptyState.or(machineReadablePane(page)).first()).toBeVisible({ timeout: 30_000 });
+});
+
+test('5) lichte edit -> opslaan -> reload -> persisteert', async ({ page }) => {
+  expect(traject, 'traject uit stap 3').not.toBeNull();
+
+  await page.goto(`/trajecten/${traject.ref}/editor/${LAW_ID}/${ARTICLE}`);
+  await expect(
+    page.locator('nldd-document-tab-bar-item', { hasText: `Artikel ${ARTICLE}` }).first(),
+  ).toBeVisible({ timeout: 60_000 });
+
+  const initBtn = page.locator('[data-testid="init-mr-btn"]');
+  // Precondition for this write smoke: article 1 has no machine_readable yet, so
+  // the pane offers the "author a machine version" button. If a deployment's
+  // corpus already ships machine_readable here, there is nothing to author -
+  // skip rather than assert a false negative.
+  if ((await initBtn.count()) === 0) {
+    test.skip(true, `${LAW_ID} artikel ${ARTICLE} heeft al machine_readable in dit corpus - geen init-stap om te smoken`);
+  }
+
+  // Author an (empty) machine_readable scaffold: this dirties the article and
+  // raises the Wijzigingenbalk.
+  await initBtn.first().click();
+  await expect(machineReadablePane(page).first()).toBeVisible();
+
+  const changesBar = page.locator('nldd-split-view-pane[slot="changes-bar"]');
+  const saveBtn = changesBar.locator('nldd-button[text="Opslaan"]').first();
+  await expect(saveBtn).toBeVisible();
+
+  // The save PUTs the whole law and commits+pushes to the corpus remote, so it
+  // is slow - wait on the response, not a fixed timeout. nldd-button is a Lit
+  // element; dispatch the click on the element itself (matches the e2e helpers).
+  const putPromise = page.waitForResponse(
+    (r) => r.request().method() === 'PUT' && r.url().includes(`/corpus/laws/${LAW_ID}`),
+    { timeout: 150_000 },
+  );
+  await saveBtn.evaluate((el) => el.click());
+  const put = await putPromise;
+
+  // Some deployments require the acting user's OWN linked GitHub token for
+  // traject writes and answer 428 (Precondition Required) when it is missing.
+  // That is an environment precondition, not a regression in the editor - skip
+  // the persistence assertion with an actionable reason.
+  if (put.status() === 428) {
+    test.skip(
+      true,
+      'Traject-write vereist een gekoppelde persoonlijke GitHub-token (428). ' +
+        'Draai tegen een preview met de service-account-schrijfweg, of koppel de test-user in de UI.',
+    );
+  }
+  expect(put.ok(), `PUT ${put.url()} -> ${put.status()}`).toBeTruthy();
+
+  // The Wijzigingenbalk clears once the save settled.
+  await expect(changesBar).toHaveCount(0, { timeout: 30_000 });
+
+  // Persistence, two ways: the API now serves a machine_readable body...
+  const lawYaml = await readTrajectLaw(page.request, traject.ref, LAW_ID);
+  expect(lawYaml).toContain('machine_readable');
+
+  // ...and a fresh page load shows the populated pane instead of the empty state.
+  await page.goto(`/trajecten/${traject.ref}/editor/${LAW_ID}/${ARTICLE}`);
+  await expect(
+    page.locator('nldd-document-tab-bar-item', { hasText: `Artikel ${ARTICLE}` }).first(),
+  ).toBeVisible({ timeout: 60_000 });
+  await expect(machineReadablePane(page).first()).toBeVisible({ timeout: 30_000 });
+  await expect(page.locator('[data-testid="no-machine-readable"]')).toHaveCount(0);
+});

--- a/frontend/playwright.smoke.config.js
+++ b/frontend/playwright.smoke.config.js
@@ -1,0 +1,51 @@
+import { defineConfig } from '@playwright/test';
+import { resolve } from 'node:path';
+
+// Isolated Playwright project for the deployed-preview smoke test. Unlike the
+// mocked `e2e/` suite (own Vite on :7100, intercepted backend), this suite runs
+// the real editor against a DEPLOYED preview (or production): a real Keycloak
+// login, the real editor-api + DB + WASM. Hence: no `webServer`, `baseURL`
+// comes from the environment, and a `globalSetup` logs in once and hands every
+// spec a persisted authenticated session.
+//
+// Run it via `just smoke-preview PR=<n>` (or `URL=<full-url>`), which sets
+// SMOKE_BASE_URL and reads the test-user creds from /workspace/.cred into
+// SMOKE_USER / SMOKE_PASS.
+
+const STORAGE_STATE = resolve(import.meta.dirname, '.auth', 'state.json');
+
+export default defineConfig({
+  testDir: './e2e-smoke',
+  // Traject writes commit + push to a git remote, so a save round-trip can take
+  // a minute. Budget generously per test; the individual waits are bounded too.
+  timeout: 240_000,
+  expect: { timeout: 15_000 },
+  // A deployed preview is a shared, sometimes-cold environment; one retry
+  // absorbs a transient blip without masking a real regression.
+  retries: 1,
+  // The flow is stateful (create -> edit -> persist -> teardown), so it must run
+  // in order on a single worker.
+  workers: 1,
+  fullyParallel: false,
+  reporter: [['list']],
+  globalSetup: './e2e-smoke/global-setup.js',
+  use: {
+    baseURL: process.env.SMOKE_BASE_URL,
+    storageState: STORAGE_STATE,
+    headless: true,
+    // A cold preview can be slow to boot the SPA and its API.
+    navigationTimeout: 60_000,
+    actionTimeout: 30_000,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    // Wide enough that the editor renders its panes side-by-side (the Machine
+    // pane is visible without a pane-switch).
+    viewport: { width: 1600, height: 1000 },
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { browserName: 'chromium' },
+    },
+  ],
+});


### PR DESCRIPTION
## Wat

Een **token-vrije, deterministische** Playwright-smoketest die de kernflow van de editor draait tegen een **deployed** PR-preview (of productie) door de volledige stack heen: een echte Keycloak-login, editor-api, database en WASM. Het is de SpecFlow/Selenium-achtige tegenhanger van de bestaande *mocked* `e2e/`-suite - geen LLM-tokens, herhaalbaar bij elke wijziging.

## Waarom

De bestaande browser-automatisering test de editor alleen met een gemockte backend of via een handmatige, token-gedreven flow. Er was geen herhaalbaar script dat de editor tegen de échte, gedeployede stack smoket (auth + api + db + wasm samen). Deze suite vult dat gat en is bedoeld als **levend contract**: nieuwe editor-features breiden `e2e-smoke/smoke.spec.js` uit.

## Wat zit erin

- **`frontend/playwright.smoke.config.js`** - geïsoleerd project: geen `webServer`, `baseURL` uit `SMOKE_BASE_URL`, sessie uit `.auth/state.json`, `globalSetup`, Chromium, `retries: 1`, ruime timeouts (traject-writes committen/pushen naar een git-remote).
- **`e2e-smoke/global-setup.js`** - logt éénmalig deterministisch in (poort van de handmatige login-flow), verifieert `/auth/status` → `authenticated: true`, en bewaart de sessie. Creds komen uitsluitend uit env (`SMOKE_USER`/`SMOKE_PASS`); nergens hardcoded.
- **`e2e-smoke/smoke.spec.js`** - de kernflow: (1) bibliotheek toont de wettenlijst tegen de echte corpus; (2) `/trajecten` rendert; (3) traject aangemaakt via `page.request.post('/api/trajects')` met een efemere naam; (4) editor opent de wet + artikel en toont het machine-paneel; (5) lichte edit → opslaan → reload → persisteert. `afterAll` ruimt elk aangemaakt traject op, zodat een tweede run schoon begint.
- **`e2e-smoke/smoke-helpers.js`** - preview-only helpers (login, traject-CRUD via `page.request`). De selector-helpers worden **hergebruikt** uit `e2e/helpers.js`, niet gekopieerd.
- **`Justfile`** - recipe `smoke-preview`: zet `SMOKE_BASE_URL`, injecteert de test-user-creds uit het lokale cred-bestand naar `SMOKE_USER`/`SMOKE_PASS` (nooit in de repo), en draait de suite.
- **`frontend/.gitignore`** - negeert `.auth/` (sessiecookie); `git status` blijft schoon na een run.
- **`frontend/README.md`** - documenteert de conventie: de smoke-suite is het levende contract.

## Handmatige verificatie

Gedraaid tegen productie (`https://editor.regelrecht.rijks.app`):

```
just smoke-preview https://editor.regelrecht.rijks.app
# (of: just smoke-preview 886  voor een PR-preview,  just URL=<url> smoke-preview)
```

Resultaat: stappen 1-4 groen, het aangemaakte traject opgeruimd (`git status` schoon, geen achtergebleven trajecten). Stap 5 (edit → opslaan → persisteert) wordt op deze omgeving **overgeslagen**: productie eist voor traject-writes een gekoppelde persoonlijke GitHub-token en antwoordt `428 Precondition Required`. Dat is een omgevings-precondtie, geen editor-regressie - de test slaat de persistentie-assertie dan met een duidelijke reden over. Tegen een preview met de service-account-schrijfweg draait stap 5 volledig door en assert de persistentie.

## Buiten scope

CI-integratie (aparte fase), het moderniseren van de bestaande mocked specs, en aanpassingen aan de ship-/kanban-flows.