### PR TITLE
feat(editor): onthoud open wetten-tabs per traject

### DIFF
--- a/frontend/e2e/edit-test-loop.spec.js
+++ b/frontend/e2e/edit-test-loop.spec.js
@@ -23,18 +23,14 @@
 import { test, expect } from '@playwright/test';
 import * as yaml from 'js-yaml';
 import { loadCorpus, loadScenario, mockCorpusApi } from './helpers-corpus.js';
-import { gotoEditor, readYamlSource, setYamlPane, expectScenarioResult } from './helpers.js';
+import { gotoEditor, readYamlSource, setYamlPane, expectScenarioResult, clearOpenTabsStorage } from './helpers.js';
 
 const MINOR = 'Minderjarige heeft geen recht';
 
 test.describe('Edit → re-execute loop', () => {
   test.beforeEach(async ({ page }) => {
-    // Clear localStorage tabs to avoid bleed-over between test runs.
-    await page.addInitScript(() => {
-      try {
-        window.localStorage.removeItem('regelrecht-open-tabs');
-      } catch { /* ignore */ }
-    });
+    // Clear the per-traject open-tab storage (by prefix) to avoid bleed-over.
+    await clearOpenTabsStorage(page);
   });
 
   test('Minderjarige scenario goes red → green after adding age check', async ({ page }) => {

--- a/frontend/e2e/helpers.js
+++ b/frontend/e2e/helpers.js
@@ -11,6 +11,8 @@ const FIXTURE_DIR = resolve(import.meta.dirname, 'fixtures');
  * hangs under `/api/trajects/${TEST_TRAJECT_REF}/corpus/...`.
  */
 export const TEST_TRAJECT_REF = 'test-traject-0a1b2c3d';
+// A SECOND traject, so specs can exercise a traject switch (per-traject tabs).
+export const TEST_TRAJECT_B_REF = 'test-traject-b-0b1c2d3e';
 
 // Fake, non-personal signed-in identity for the mocked `/auth/status`. No real
 // names, emails, roles or tokens — just the shape `useAuth` reads. `.test` is a
@@ -36,11 +38,46 @@ const TEST_TRAJECT = {
   role: 'owner',
 };
 
+const TEST_TRAJECT_B = {
+  id: '00000000-0000-0000-0000-00000b1c2d3e',
+  ref: TEST_TRAJECT_B_REF,
+  name: 'E2E Test Traject B',
+  description: '',
+  scope: '',
+  status: 'bezig',
+  role: 'owner',
+};
+
+// The trajects the membership list returns. Both are always present so a spec
+// can switch between them; single-traject specs simply ignore the second.
+const TEST_TRAJECTS = [TEST_TRAJECT, TEST_TRAJECT_B];
+
 /**
  * Load a YAML fixture file as a string.
  */
 export function loadFixture(name) {
   return readFileSync(resolve(FIXTURE_DIR, name), 'utf-8');
+}
+
+/**
+ * Wipe the editor's per-traject open-tab storage before a run so tabs don't
+ * bleed across tests. The keys are now per-traject (`regelrecht-open-tabs:<ref>`
+ * / `regelrecht-active-tab:<ref>`), so a single un-suffixed removeItem is a
+ * no-op - clear by PREFIX instead. This matters more than before: a leftover
+ * `regelrecht-active-tab:<ref>` now makes the editor auto-open a document and
+ * replace the URL on entry.
+ * @param {import('@playwright/test').Page} page
+ */
+export async function clearOpenTabsStorage(page) {
+  await page.addInitScript(() => {
+    try {
+      for (const key of Object.keys(window.localStorage)) {
+        if (key.startsWith('regelrecht-open-tabs') || key.startsWith('regelrecht-active-tab')) {
+          window.localStorage.removeItem(key);
+        }
+      }
+    } catch { /* ignore */ }
+  });
 }
 
 /**
@@ -72,19 +109,24 @@ export async function mockAuthedEditor(page) {
     route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify([TEST_TRAJECT]),
+      body: JSON.stringify(TEST_TRAJECTS),
     }),
   );
-  // GET /api/trajects/{id} - single traject detail. Only the bare detail path;
+  // GET /api/trajects/{ref} - single traject detail. Only the bare detail path;
   // `/api/trajects/{ref}/corpus/...` falls through to the corpus handlers.
+  // Resolves whichever of the known trajects the URL segment names (falling
+  // back to the first) so a two-traject spec gets the right detail per ref.
   await page.route('**/api/trajects/*', (route, request) => {
     const { pathname } = new URL(request.url());
-    if (!/^\/api\/trajects\/[^/]+$/.test(pathname)) return route.fallback();
+    const match = pathname.match(/^\/api\/trajects\/([^/]+)$/);
+    if (!match) return route.fallback();
+    const ref = decodeURIComponent(match[1]);
+    const traject = TEST_TRAJECTS.find((t) => t.ref === ref) ?? TEST_TRAJECT;
     return route.fulfill({
       status: 200,
       contentType: 'application/json',
       body: JSON.stringify({
-        ...TEST_TRAJECT,
+        ...traject,
         members: [],
         pending_invites: [],
         sources: [],

--- a/frontend/e2e/machine-panel-edit-loop.spec.js
+++ b/frontend/e2e/machine-panel-edit-loop.spec.js
@@ -31,17 +31,14 @@ import {
   openActionEditor,
   saveActionSheet,
   expectScenarioResult,
+  clearOpenTabsStorage,
 } from './helpers.js';
 
 const MINOR = 'Minderjarige heeft geen recht';
 
 test.describe('Edit → re-execute loop via the structured operation editor', () => {
   test.beforeEach(async ({ page }) => {
-    await page.addInitScript(() => {
-      try {
-        window.localStorage.removeItem('regelrecht-open-tabs');
-      } catch { /* ignore */ }
-    });
+    await clearOpenTabsStorage(page);
   });
 
   test('editing the age threshold via the ActionSheet turns the scenario green', async ({ page }) => {

--- a/frontend/e2e/scenario-param-inputs.spec.js
+++ b/frontend/e2e/scenario-param-inputs.spec.js
@@ -8,7 +8,7 @@
  * (no editor-api / Postgres needed) and opens the scenario edit sheet.
  */
 import { test, expect } from '@playwright/test';
-import { loadFixture, gotoEditor } from './helpers.js';
+import { loadFixture, gotoEditor, clearOpenTabsStorage } from './helpers.js';
 import { mockCorpusApi } from './helpers-corpus.js';
 
 // A minimal scenario that passes one parameter of each declared datatype:
@@ -29,9 +29,7 @@ const SCENARIO = `Feature: Typed input controls
 
 test.describe('Scenario parameter input controls', () => {
   test.beforeEach(async ({ page }) => {
-    await page.addInitScript(() => {
-      try { window.localStorage.removeItem('regelrecht-open-tabs'); } catch { /* ignore */ }
-    });
+    await clearOpenTabsStorage(page);
 
     const fixture = loadFixture('zorgtoeslag-full.yaml');
     const corpus = new Map([

--- a/frontend/e2e/traject-tabs.spec.js
+++ b/frontend/e2e/traject-tabs.spec.js
@@ -1,0 +1,189 @@
+/**
+ * Per-traject open-tabs: isolation, restore-on-entry and self-heal end-to-end.
+ *
+ * Two trajects (A owns `wet_alpha`, B owns `wet_beta`); a law GET for a law that
+ * does not belong to the requested traject 404s, exactly as the real editor-api
+ * does. That lets us prove:
+ *   - opening a law in each traject keeps the two bars isolated;
+ *   - a traject switch shows exactly ONE tab item carrying the destination
+ *     traject's data-tab-key (a leftover/orphaned item - a "spooktab" - is
+ *     itself an <nldd-document-tab-bar-item>, so the count assertion catches it
+ *     without peering into shadow roots);
+ *   - the last active article is restored and the URL replaced on entry;
+ *   - a reload round-trips through localStorage (not just in-memory buckets);
+ *   - polluted storage from an earlier build (traject A's law parked under
+ *     traject B's key) heals: the tab 404s, disappears, the neutral state
+ *     appears, and the key is cleaned.
+ *
+ * Requires the WASM engine to be built (frontend/public/wasm/pkg); the editor
+ * mounts it but scenario execution is irrelevant here.
+ */
+import { test, expect } from '@playwright/test';
+import {
+  mockAuthedEditor,
+  TEST_TRAJECT_REF,
+  TEST_TRAJECT_B_REF,
+} from './helpers.js';
+
+const A = TEST_TRAJECT_REF;
+const B = TEST_TRAJECT_B_REF;
+const LAW_A = 'wet_alpha';
+const LAW_B = 'wet_beta';
+
+// Which laws each traject owns. A GET for a law NOT in the requested traject
+// 404s - that is what a real cross-traject request does, and what the restore /
+// self-heal logic keys on.
+const MEMBERSHIP = {
+  [A]: [LAW_A],
+  [B]: [LAW_B],
+};
+
+const openTabsKey = (ref) => `regelrecht-open-tabs:${ref}`;
+
+function lawYaml(id, name) {
+  return `$id: ${id}
+name: ${name}
+regulatory_layer: WET
+publication_date: '2024-12-20'
+valid_from: '2025-01-01'
+articles:
+  - number: '1'
+    text: 'Artikel 1 van ${name}.'
+  - number: '2'
+    text: 'Artikel 2 van ${name}.'
+`;
+}
+
+const LAW_NAMES = { [LAW_A]: 'Wet Alpha', [LAW_B]: 'Wet Beta' };
+
+async function mockCorpus(page) {
+  await mockAuthedEditor(page);
+
+  // Benign empties for the peripheral editor fetches so nothing errors while we
+  // exercise the tabs. Registered first (lowest LIFO priority).
+  await page.route('**/api/sources', (r) =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: '[]' }),
+  );
+  await page.route('**/corpus/laws', (r) =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: '[]' }),
+  );
+  await page.route('**/corpus/laws/*/versions', (r) =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: '[]' }),
+  );
+  await page.route('**/corpus/laws/*/scenarios', (r) =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: '[]' }),
+  );
+  await page.route('**/corpus/laws/*/scenarios/*', (r) =>
+    r.fulfill({ status: 200, contentType: 'text/plain; charset=utf-8', body: '' }),
+  );
+  await page.route('**/corpus/laws/*/outputs', (r) =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: '[]' }),
+  );
+
+  // The law GET/PUT itself: traject-aware. Registered LAST so LIFO puts it
+  // first; its regex only matches the bare `.../corpus/laws/{id}` tail, so the
+  // sub-path handlers above still win their URLs via fallback.
+  await page.route('**/trajects/*/corpus/laws/*', (route, request) => {
+    const { pathname } = new URL(request.url());
+    const match = pathname.match(/\/trajects\/([^/]+)\/corpus\/laws\/([^/]+)$/);
+    if (!match) return route.fallback();
+    if (request.method() === 'PUT') return route.fulfill({ status: 200, body: '' });
+    const ref = decodeURIComponent(match[1]);
+    const lawId = decodeURIComponent(match[2]);
+    if (!(MEMBERSHIP[ref] || []).includes(lawId)) {
+      return route.fulfill({ status: 404, body: `Law '${lawId}' not in traject` });
+    }
+    return route.fulfill({
+      status: 200,
+      contentType: 'text/yaml; charset=utf-8',
+      body: lawYaml(lawId, LAW_NAMES[lawId]),
+    });
+  });
+}
+
+const tabItems = (page) => page.locator('nldd-document-tab-bar-item');
+const neutralState = (page) =>
+  page.getByText('Open een artikel vanuit de tabbalk of Home', { exact: false });
+
+test.describe('Per-traject open tabs', () => {
+  test.beforeEach(async ({ page }) => {
+    // Deliberately NO clearOpenTabsStorage here: that helper is an
+    // addInitScript that re-runs on EVERY navigation, which would wipe the tabs
+    // this spec's reload/round-trip steps depend on. Playwright already gives
+    // each test a fresh context (empty localStorage), so no clear is needed.
+    await mockCorpus(page);
+  });
+
+  test('isolates, restores and self-heals across a traject switch', async ({ page }) => {
+    test.setTimeout(60_000);
+
+    // 1. Open wet in traject B.
+    await page.goto(`/trajecten/${B}/editor/${LAW_B}/1`);
+    await tabItems(page).first().waitFor({ timeout: 15_000 });
+    await expect(tabItems(page)).toHaveCount(1);
+    await expect(tabItems(page).first()).toHaveAttribute('data-tab-key', `${LAW_B}:1`);
+
+    // 2. Open wet in traject A (a fresh load into A's editor).
+    await page.goto(`/trajecten/${A}/editor/${LAW_A}/1`);
+    await tabItems(page).first().waitFor({ timeout: 15_000 });
+    await expect(tabItems(page)).toHaveCount(1);
+    await expect(tabItems(page).first()).toHaveAttribute('data-tab-key', `${LAW_A}:1`);
+
+    // 3. In-app switch to traject B via the traject menu: exactly one item, B's
+    //    key (a spooktab would be a second item), and the URL restored to B's
+    //    article by the restore-on-entry flow.
+    await page.locator('#traject-menu-btn-lg').click();
+    const trajectItemB = page.locator('nldd-menu-item[text="E2E Test Traject B"]').first();
+    await trajectItemB.waitFor({ state: 'attached', timeout: 5_000 });
+    // The traject menu-item is a radio that fires a custom `select` event (not a
+    // plain click) - dispatch that to drive selectTraject -> in-app switch.
+    await trajectItemB.evaluate((el) => el.dispatchEvent(new CustomEvent('select', { bubbles: true })));
+    await page.waitForURL(`**/trajecten/${B}/editor/${LAW_B}/1`, { timeout: 15_000 });
+    await expect(tabItems(page)).toHaveCount(1);
+    await expect(tabItems(page).first()).toHaveAttribute('data-tab-key', `${LAW_B}:1`);
+
+    // 4. Reload proves the localStorage round-trip (not just in-memory buckets):
+    //    entering B's editor root restores B's remembered article.
+    await page.goto(`/trajecten/${B}/editor`);
+    await page.waitForURL(`**/trajecten/${B}/editor/${LAW_B}/1`, { timeout: 15_000 });
+    await expect(tabItems(page)).toHaveCount(1);
+    await expect(tabItems(page).first()).toHaveAttribute('data-tab-key', `${LAW_B}:1`);
+
+    // 5. Back to A's editor root restores A's remembered article, isolated.
+    await page.goto(`/trajecten/${A}/editor`);
+    await page.waitForURL(`**/trajecten/${A}/editor/${LAW_A}/1`, { timeout: 15_000 });
+    await expect(tabItems(page)).toHaveCount(1);
+    await expect(tabItems(page).first()).toHaveAttribute('data-tab-key', `${LAW_A}:1`);
+  });
+
+  test('self-heals storage polluted with another traject\'s law', async ({ page }) => {
+    test.setTimeout(60_000);
+
+    // Poison B's storage with traject A's law (what an earlier build wrote), as
+    // if it had been persisted under the wrong key.
+    await page.addInitScript(
+      ([key, tabs, activeKey, active]) => {
+        try {
+          window.localStorage.setItem(key, tabs);
+          window.localStorage.setItem(activeKey, active);
+        } catch { /* ignore */ }
+      },
+      [
+        openTabsKey(B),
+        JSON.stringify([{ lawId: LAW_A, articleNumber: '1' }]),
+        `regelrecht-active-tab:${B}`,
+        JSON.stringify({ lawId: LAW_A, articleNumber: '1' }),
+      ],
+    );
+
+    // Entering B: the poisoned tab's law 404s in B, so it is pruned from the bar
+    // and from localStorage, and the neutral state appears.
+    await page.goto(`/trajecten/${B}/editor`);
+    await expect(neutralState(page)).toBeVisible({ timeout: 15_000 });
+    await expect(tabItems(page)).toHaveCount(0);
+
+    // The polluted key is cleaned.
+    const stored = await page.evaluate((k) => window.localStorage.getItem(k), openTabsKey(B));
+    expect(JSON.parse(stored ?? '[]')).toEqual([]);
+  });
+});

--- a/frontend/src/AppShell.vue
+++ b/frontend/src/AppShell.vue
@@ -14,7 +14,7 @@ import { useAddActions } from './composables/useAddActions.js';
 import {
   lastHomePath,
   lastEditorPath,
-  sectionTarget,
+  editorTabTarget as buildEditorTabTarget,
   homeTabTarget,
   isHomeSection,
   rememberHarvesterOrigin,
@@ -129,7 +129,7 @@ const libraryTabTarget = computed(() =>
   homeTabTarget(router, lastHomePath.value, activeTrajectRef.value),
 );
 const editorTabTarget = computed(() =>
-  sectionTarget(router, lastEditorPath.value, activeTrajectRef.value),
+  buildEditorTabTarget(router, lastEditorPath.value, activeTrajectRef.value),
 );
 const libraryTabHref = computed(() => router.resolve(libraryTabTarget.value).href);
 const editorTabHref = computed(() => router.resolve(editorTabTarget.value).href);
@@ -230,7 +230,7 @@ function onEnforcementConfirmClose() {
 }
 
 // View-specific toolbar bits published by the active view.
-const { lastSavedPr, documentTabs, activeDocumentTab, tabActions, editorChanges, editorActions, libraryEmpty } = useAppChrome();
+const { lastSavedPr, documentTabs, activeDocumentTab, documentTabsTrajectRef, tabActions, editorChanges, editorActions, libraryEmpty } = useAppChrome();
 
 // Just-in-time coach-mark on the toolbar search affordance: shown while the
 // library is empty (nothing curated yet). In the bare corpus it's app-driven and
@@ -562,20 +562,31 @@ function onTabDismiss(e) {
           <!-- `tabdismiss` (the bar), not `dismiss` (the item): the bar picks
                the replacement for a dismissed tab itself and hands it over as
                `nextItem`. See onTabDismiss. -->
+          <!-- `:key` on the bar (the traject the tabs belong to, published WITH
+               the tabs by the editor - see documentTabsTrajectRef): a traject
+               switch rebuilds the whole bar, tearing down its overflow menu,
+               ResizeObserver and every element reference it holds, so no
+               orphaned <nldd-document-tab-bar-item> ("spooktab") can survive
+               into the next traject. Keying on this shell's own activeTrajectRef
+               would flip a tick before documentTabs and rebuild against the old
+               set. The item :key is traject-prefixed for the same reason.
+               No has-dismiss-button (the item renders its own dismiss button in
+               0.8.44); accessible-label names the navigation landmark. -->
           <nldd-document-tab-bar
+            :key="documentTabsTrajectRef ?? ''"
+            accessible-label="Open artikelen"
             @nldd-reorder="tabActions.reorder($event.detail.fromIndex, $event.detail.toIndex)"
             @tabdismiss="onTabDismiss"
           >
             <nldd-document-tab-bar-item
               v-for="tab in documentTabs"
-              :key="tabActions.key(tab)"
+              :key="`${documentTabsTrajectRef ?? ''}:${tabActions.key(tab)}`"
               :data-tab-key="tabActions.key(tab)"
               :text="`Artikel ${tab.articleNumber}`"
               :supporting-text="tabActions.displayName(tab)"
               :short-text="`Art. ${tab.articleNumber}`"
               :short-supporting-text="tabActions.displayName(tab)"
               :selected="activeDocumentTab && tabActions.key(activeDocumentTab) === tabActions.key(tab) || undefined"
-              has-dismiss-button
               @click="tabActions.select(tab)"
             >
             </nldd-document-tab-bar-item>

--- a/frontend/src/EditorView.vue
+++ b/frontend/src/EditorView.vue
@@ -216,7 +216,7 @@ const {
 // the open law against the *previous* traject's dependencies. The
 // dependency walker re-loads on demand on the next run, so a single
 // `unloadAllLaws` is enough - no per-dep bookkeeping needed.
-watch(activeTrajectRef, (next) => {
+watch(activeTrajectRef, async (next) => {
   unloadAllLaws();
   // Tabs are scoped per traject: swap the bar to the new traject's own saved
   // set so the previous traject's tabs - which may point at laws this traject
@@ -235,7 +235,20 @@ watch(activeTrajectRef, (next) => {
     // fire first and steal the switch (its selectTab claims switchLaw's shared
     // useLatest last and wins), silently navigating to some other saved tab.
     activeTab.value = { lawId: lawId.value, articleNumber: String(selectedArticleNumber.value ?? '') };
-    switchLaw(lawId.value, selectedArticleNumber.value, next);
+    await switchLaw(lawId.value, selectedArticleNumber.value, next);
+    // On success the tab-add watch has added the law and re-affirmed activeTab;
+    // let it flush. On failure (the law isn't in this traject - the very case
+    // this feature targets, shown via the "niet beschikbaar" dialog) switchLaw
+    // leaves lawId/article untouched, so that watch never ran and the optimistic
+    // activeTab now points at a tab absent from openTabs. Drop it so the bar
+    // doesn't keep a phantom active tab. Bail if a newer switch superseded us.
+    await nextTick();
+    if (
+      activeTrajectRef.value === next && activeTab.value &&
+      !findTab(activeTab.value.lawId, activeTab.value.articleNumber)
+    ) {
+      activeTab.value = null;
+    }
   } else {
     // No law in the URL: restore this traject's own last active tab (or its
     // first tab), mirroring the initial-mount restore.

--- a/frontend/src/EditorView.vue
+++ b/frontend/src/EditorView.vue
@@ -218,7 +218,17 @@ const {
 // the open law against the *previous* traject's dependencies. The
 // dependency walker re-loads on demand on the next run, so a single
 // `unloadAllLaws` is enough - no per-dep bookkeeping needed.
+//
+// This handler is an async chain (`await switchLaw` on a deep link, then
+// `await nextTick`) that mutates shared state, so two switches in quick
+// succession (rapid back/forward across trajects) can overlap. Guard it with
+// the same `useLatest()` pattern `selectTab`/`onBeforeRouteUpdate` use, so a
+// stale invocation can't land its writes - or lower the auto-open latch a newer
+// switch raised - after the newer one, which would leave the bar showing the
+// previous traject's tabs while the route is on the new one.
+const claimTrajectSwitch = useLatest();
 watch(activeTrajectRef, async (next) => {
+  const isCurrent = claimTrajectSwitch();
   // A traject switch settles onto the section root: stand the auto-open
   // robustness net down for this tick so it doesn't force one of the freshly
   // swapped-in tabs active while we deliberately land on the neutral view.
@@ -248,6 +258,9 @@ watch(activeTrajectRef, async (next) => {
     // onBeforeRouteUpdate), this is skipped - no duplicate fetch.
     if (lawTrajectRef.value !== next || lawId.value !== route.params.lawId) {
       await switchLaw(route.params.lawId, route.params.articleNumber, next);
+      // A newer switch superseded us mid-load: drop our writes so we don't
+      // reconcile the bar against a traject the route already left.
+      if (!isCurrent()) return;
     }
     // Only reflect the URL's law as this traject's active tab when it actually
     // loaded FOR this traject. When the traject doesn't have the law, switchLaw
@@ -289,6 +302,9 @@ watch(activeTrajectRef, async (next) => {
     activeTab.value = null;
   }
   await nextTick();
+  // Only the latest switch may lower the latch: a stale invocation clearing it
+  // here would re-enable the auto-open net mid-way through a newer switch.
+  if (!isCurrent()) return;
   suppressTabAutoOpen = false;
 });
 
@@ -959,8 +975,10 @@ async function selectTab(tab) {
 // the URL has no law at all (so a refresh returns the user where they were),
 // otherwise simply the first open tab. selectTab sets activeTab synchronously,
 // so the empty state never flashes. With no open tabs this is a no-op and we
-// fall through to the empty state - the only case it should appear. Shared by
-// the initial mount and by traject switches (see watch(activeTrajectRef)).
+// fall through to the empty state - the only case it should appear. This runs
+// on the INITIAL mount only; a traject switch deliberately does NOT restore the
+// last active tab (see watch(activeTrajectRef), which lands on the neutral root
+// instead), so it never calls this.
 function openSavedActiveTab(trajectRef) {
   if (route.params.articleNumber || openTabs.value.length === 0) return;
   const lastActive = loadSavedActiveTab(trajectRef);

--- a/frontend/src/EditorView.vue
+++ b/frontend/src/EditorView.vue
@@ -194,6 +194,7 @@ const {
   selectedArticleNumber,
   switchLaw,
   clearLaw,
+  lawTrajectRef,
   loading,
   error,
   saving: lawSaving,
@@ -858,6 +859,15 @@ function findTab(lawIdVal, articleNumber) {
 // Add tab when initial law loads
 watch([() => lawId.value, selectedArticle], ([id, article]) => {
   if (!id || !article) return;
+  // Only record a tab for the traject the law was actually loaded through.
+  // During a cross-traject route change (browser back/forward, or any nav to a
+  // law URL in another traject) `switchLaw` loads the law a tick before the
+  // route - and thus `activeTrajectRef` - commits to the new traject. Keying on
+  // `activeTrajectRef.value` here would append this law to (and persist it
+  // under) the traject we're *leaving*, leaking a foreign law into its tab bar.
+  // Defer to watch(activeTrajectRef), which reconciles the bar under the
+  // correct traject once it commits.
+  if (lawTrajectRef.value !== activeTrajectRef.value) return;
   const num = String(article.number);
   if (!findTab(id, num)) {
     const MAX_TABS = 20;

--- a/frontend/src/EditorView.vue
+++ b/frontend/src/EditorView.vue
@@ -234,17 +234,32 @@ watch(activeTrajectRef, async (next) => {
   if (route.params.lawId) {
     // A URL that still names a law in the new traject can only come from a deep
     // link or browser back/forward now (the traject switcher navigates to the
-    // bare root - see trajectSwitchTarget). onBeforeRouteUpdate already ran
-    // switchLaw for that law through the new traject before this watch fired -
-    // but only reflect it as the active tab if it actually LOADED for this
-    // traject. When the new traject doesn't have the law, switchLaw 404s: it
-    // sets `error` and leaves `lawId`/`selectedArticleNumber` holding the
-    // PREVIOUS traject's law. Adopting those here would add that foreign law as
-    // an open+active tab and persist it under this traject - re-introducing the
-    // exact leak this PR fixes. Require a clean load whose id matches the URL;
-    // the error view renders the "niet beschikbaar" dialog for the failed case.
+    // bare root - see trajectSwitchTarget). Make sure that law is loaded THROUGH
+    // the new traject before adopting it as a tab.
+    //
+    // onBeforeRouteUpdate only (re)loads when the URL's lawId *changes*; a
+    // cross-traject nav that keeps the SAME lawId (a bookmarked/back-forward URL
+    // differing only in trajectRef, or a law shared across trajects) skips it,
+    // leaving law.value / selectedArticleNumber / useLaw's currentTrajectRef
+    // pointed at the PREVIOUS traject's copy. Reload here whenever the open law
+    // isn't already this traject's copy, so we never adopt stale, wrong-traject
+    // content - and so a later save PUTs to the right traject. When the id and
+    // traject already match (the lawId-changed deep link, loaded by
+    // onBeforeRouteUpdate), this is skipped - no duplicate fetch.
+    if (lawTrajectRef.value !== next || lawId.value !== route.params.lawId) {
+      await switchLaw(route.params.lawId, route.params.articleNumber, next);
+    }
+    // Only reflect the URL's law as this traject's active tab when it actually
+    // loaded FOR this traject. When the traject doesn't have the law, switchLaw
+    // 404s: `error` is set and lawId/selectedArticleNumber still hold the
+    // previous traject's law. Adopting that would add a foreign law as an
+    // open+active tab and persist it under this traject - re-introducing the
+    // exact leak this PR fixes. Require a clean load, for this traject, whose id
+    // matches the URL; the error view renders the "niet beschikbaar" dialog for
+    // the failed case.
     const loaded =
       !error.value &&
+      lawTrajectRef.value === next &&
       lawId.value === route.params.lawId &&
       selectedArticleNumber.value != null;
     if (loaded) {

--- a/frontend/src/EditorView.vue
+++ b/frontend/src/EditorView.vue
@@ -193,6 +193,7 @@ const {
   selectedArticle,
   selectedArticleNumber,
   switchLaw,
+  clearLaw,
   loading,
   error,
   saving: lawSaving,
@@ -217,6 +218,10 @@ const {
 // dependency walker re-loads on demand on the next run, so a single
 // `unloadAllLaws` is enough - no per-dep bookkeeping needed.
 watch(activeTrajectRef, async (next) => {
+  // A traject switch settles onto the section root: stand the auto-open
+  // robustness net down for this tick so it doesn't force one of the freshly
+  // swapped-in tabs active while we deliberately land on the neutral view.
+  suppressTabAutoOpen = true;
   unloadAllLaws();
   // Tabs are scoped per traject: swap the bar to the new traject's own saved
   // set so the previous traject's tabs - which may point at laws this traject
@@ -225,36 +230,33 @@ watch(activeTrajectRef, async (next) => {
   openTabs.value = loadSavedTabs(next);
   // Resolve the freshly swapped-in tabs' labels through the new traject.
   backfillTabLabels(next);
-  if (lawId.value) {
-    // The URL carried a law across the switch: keep showing it through the new
-    // traject. Point activeTab straight at that law (the tab-add watch re-adds
-    // and re-affirms it - and persists it under the new traject's key - once
-    // switchLaw settles). Setting it synchronously, rather than clearing to
-    // null, is deliberate: this switchLaw runs outside selectTab and doesn't
-    // await, so a null gap would let the "no active tab" robustness-net watch
-    // fire first and steal the switch (its selectTab claims switchLaw's shared
-    // useLatest last and wins), silently navigating to some other saved tab.
-    activeTab.value = { lawId: lawId.value, articleNumber: String(selectedArticleNumber.value ?? '') };
-    await switchLaw(lawId.value, selectedArticleNumber.value, next);
-    // On success the tab-add watch has added the law and re-affirmed activeTab;
-    // let it flush. On failure (the law isn't in this traject - the very case
-    // this feature targets, shown via the "niet beschikbaar" dialog) switchLaw
-    // leaves lawId/article untouched, so that watch never ran and the optimistic
-    // activeTab now points at a tab absent from openTabs. Drop it so the bar
-    // doesn't keep a phantom active tab. Bail if a newer switch superseded us.
-    await nextTick();
-    if (
-      activeTrajectRef.value === next && activeTab.value &&
-      !findTab(activeTab.value.lawId, activeTab.value.articleNumber)
-    ) {
-      activeTab.value = null;
+  if (route.params.lawId) {
+    // A URL that still names a law in the new traject can only come from a deep
+    // link or browser back/forward now (the traject switcher navigates to the
+    // bare root - see trajectSwitchTarget). onBeforeRouteUpdate already loaded
+    // that law through the new traject before this watch ran, so just reflect
+    // it as the active tab in the freshly swapped bar and persist it there.
+    if (lawId.value && selectedArticleNumber.value != null) {
+      const tab = { lawId: lawId.value, articleNumber: String(selectedArticleNumber.value) };
+      if (!findTab(tab.lawId, tab.articleNumber)) {
+        openTabs.value = [...openTabs.value, tab];
+        saveTabs(next, openTabs.value);
+      }
+      activeTab.value = tab;
+      saveActiveTab(next, tab);
     }
   } else {
-    // No law in the URL: restore this traject's own last active tab (or its
-    // first tab), mirroring the initial-mount restore.
+    // The common case: the switcher dropped us on the traject root with no law
+    // in the URL. Go to a neutral view - unload the previous traject's document
+    // (so it can't linger in the panes or leak across as an active tab) and
+    // leave every tab in the bar inactive. The user picks one to open it; we
+    // deliberately do NOT auto-restore the last active tab on a switch (unlike
+    // the initial mount), so switching trajects never re-opens a document.
+    clearLaw();
     activeTab.value = null;
-    openSavedActiveTab(next);
   }
+  await nextTick();
+  suppressTabAutoOpen = false;
 });
 
 // Notes (RFC-005/RFC-018) for the current law, resolved against its text.
@@ -837,6 +839,14 @@ const lawNames = ref({});
 // Active tab tracks which tab is selected
 const activeTab = ref(null);
 
+// Set true for the tick a traject switch takes to settle. The switch swaps the
+// tab bar to the new traject's set and lands on the neutral root with NO active
+// tab, which would otherwise trip the auto-open robustness net below into
+// opening one of the new tabs - exactly what a switch must not do. A plain
+// (non-reactive) latch is enough: the switch sets it before mutating and clears
+// it after nextTick, so the net's flush sees it raised.
+let suppressTabAutoOpen = false;
+
 function tabKey(tab) {
   return `${tab.lawId}:${tab.articleNumber}`;
 }
@@ -925,6 +935,9 @@ openSavedActiveTab(activeTrajectRef.value);
 // law they asked for - not silently land on some other tab.
 watch([activeTab, openTabs], ([tab, tabs]) => {
   if (route.params.articleNumber) return;
+  // A traject switch intentionally sits at the neutral root with tabs in the
+  // bar but none active; don't undo that by opening one.
+  if (suppressTabAutoOpen) return;
   if (!tab && tabs.length > 0) selectTab(tabs[0]).catch(console.warn);
 });
 
@@ -2084,14 +2097,19 @@ async function handleActionSave() {
              nothing here while that navigation commits. -->
         <nldd-page v-if="trajectMissing"></nldd-page>
 
-        <!-- Nothing to show at all: no open tabs, nothing loading, nothing
-             selected, no error to report. Deliberately NOT keyed on
-             `!activeTab` alone - that stays null for the WHOLE load of an
-             explicit article URL (the add-tab watch only sets it once the
-             article resolves), so keying on it would hide the panes behind a
-             full-page state exactly when we want them up. `!error` keeps a
-             failed explicit open on its own error branch below. -->
-        <nldd-page v-else-if="!activeTab && !loading && !selectedArticle && !error && openTabs.length === 0">
+        <!-- Neutral / root view: no active tab, nothing loading, nothing
+             selected, no error to report. Two cases land here - genuinely no
+             open tabs, and the moment right after a traject switch (tabs sit in
+             the bar but none is active, since a switch never auto-opens one).
+             Both show the same "pick a tab or go Home" prompt, so this is NOT
+             keyed on `openTabs.length`. Deliberately NOT keyed on `!activeTab`
+             alone either - that stays null for the WHOLE load of an explicit
+             article URL (the add-tab watch only sets it once the article
+             resolves), so keying on it would hide the panes behind a full-page
+             state exactly when we want them up; `!loading && !selectedArticle`
+             guards that. `!error` keeps a failed explicit open on its own error
+             branch below. -->
+        <nldd-page v-else-if="!activeTab && !loading && !selectedArticle && !error">
           <nldd-simple-section width="full">
             <nldd-inline-dialog text="Open een artikel vanuit de tabbalk of Home om te bewerken.">
               <nldd-button slot="actions" variant="secondary" text="Naar Home" :href="libraryTabHref" @click.prevent="router.push(libraryTabTarget)"></nldd-button>

--- a/frontend/src/EditorView.vue
+++ b/frontend/src/EditorView.vue
@@ -27,6 +27,7 @@ import { RETRY_MIN_SPINNER_MS } from './lib/retryFeedback.js';
 import { humanizeLawId } from './lib/lawName.js';
 import { quoteContext } from './lib/quoteContext.js';
 import { useLatest } from './lib/useLatest.js';
+import { loadSavedTabs, saveTabs, loadSavedActiveTab, saveActiveTab } from './lib/openTabsStorage.js';
 import { proposalDivergence } from './lib/taskReview.js';
 import ArticleText from './components/ArticleText.vue';
 import ArticleTextEditor from './components/ArticleTextEditor.vue';
@@ -217,8 +218,25 @@ const {
 // `unloadAllLaws` is enough - no per-dep bookkeeping needed.
 watch(activeTrajectRef, (next) => {
   unloadAllLaws();
+  // Tabs are scoped per traject: swap the bar to the new traject's own saved
+  // set so the previous traject's tabs - which may point at laws this traject
+  // doesn't have - leave the bar. Each traject's set was already persisted
+  // under its own key on every mutation, so nothing to save here.
+  openTabs.value = loadSavedTabs(next);
+  // Resolve the freshly swapped-in tabs' labels through the new traject.
+  backfillTabLabels(next);
   if (lawId.value) {
+    // The URL carried a law across the switch: keep showing it through the new
+    // traject. Clear activeTab so no stale (previous-traject) tab reads as
+    // selected; the tab-add watch re-adds and activates the law - and persists
+    // it under the new traject's key - once switchLaw settles.
+    activeTab.value = null;
     switchLaw(lawId.value, selectedArticleNumber.value, next);
+  } else {
+    // No law in the URL: restore this traject's own last active tab (or its
+    // first tab), mirroring the initial-mount restore.
+    activeTab.value = null;
+    openSavedActiveTab(next);
   }
 });
 
@@ -756,33 +774,11 @@ watch(graphSheetOpen, async (open) => {
   else graphSheetEl.value?.hide();
 });
 
-// --- Multi-law tab state (persisted in localStorage) ---
-const TABS_STORAGE_KEY = 'regelrecht-open-tabs';
-const ACTIVE_TAB_STORAGE_KEY = 'regelrecht-active-tab';
-
-function loadSavedTabs() {
-  try {
-    const saved = localStorage.getItem(TABS_STORAGE_KEY);
-    const parsed = saved ? JSON.parse(saved) : [];
-    return Array.isArray(parsed) ? parsed : [];
-  } catch { return []; }
-}
-
-function saveTabs(tabs) {
-  localStorage.setItem(TABS_STORAGE_KEY, JSON.stringify(tabs));
-}
-
-function loadSavedActiveTab() {
-  try {
-    const saved = localStorage.getItem(ACTIVE_TAB_STORAGE_KEY);
-    return saved ? JSON.parse(saved) : null;
-  } catch { return null; }
-}
-
-function saveActiveTab(tab) {
-  if (!tab) localStorage.removeItem(ACTIVE_TAB_STORAGE_KEY);
-  else localStorage.setItem(ACTIVE_TAB_STORAGE_KEY, JSON.stringify(tab));
-}
+// --- Multi-law tab state (persisted per traject in localStorage) ---
+// The open-tabs helpers (loadSavedTabs/saveTabs/loadSavedActiveTab/
+// saveActiveTab) live in lib/openTabsStorage.js and key on the active traject
+// ref, so each traject keeps its own tab bar. See that module for the storage
+// shape and the try/catch safe-default guarantee.
 
 /**
  * Build a router target for the editor that preserves the current
@@ -816,7 +812,7 @@ function libraryRouteFor(lawIdVal) {
   return homeTarget({ trajectRef: route.params.trajectRef, lawId: lawIdVal });
 }
 
-const openTabs = ref(loadSavedTabs());
+const openTabs = ref(loadSavedTabs(activeTrajectRef.value));
 
 // Cache for law names (populated on fetch)
 const lawNames = ref({});
@@ -840,10 +836,10 @@ watch([() => lawId.value, selectedArticle], ([id, article]) => {
     const MAX_TABS = 20;
     const tabs = [...openTabs.value, { lawId: id, articleNumber: num }];
     openTabs.value = tabs.length > MAX_TABS ? tabs.slice(-MAX_TABS) : tabs;
-    saveTabs(openTabs.value);
+    saveTabs(activeTrajectRef.value, openTabs.value);
   }
   activeTab.value = { lawId: id, articleNumber: num };
-  saveActiveTab(activeTab.value);
+  saveActiveTab(activeTrajectRef.value, activeTab.value);
   if (lawName.value) lawNames.value = { ...lawNames.value, [id]: lawName.value };
 });
 
@@ -879,20 +875,24 @@ async function selectTab(tab) {
   router.replace(editorRouteFor(tab.lawId, tab.articleNumber));
 }
 
-// On load there may be no article to edit yet - the URL carries no article
-// (just a traject, or a law without an article number). Rather than show the
-// empty state while tabs are still open, open one right away: the last active
-// tab when the URL has no law at all (so a refresh returns the user where they
-// were), otherwise simply the first open tab. selectTab sets activeTab
-// synchronously, so the empty state never flashes. With no open tabs we fall
-// through to it - the only case it should appear.
-if (!route.params.articleNumber && openTabs.value.length > 0) {
-  const lastActive = loadSavedActiveTab();
+// When the URL carries no article to edit (just a traject, or a law without an
+// article number), open one of the current traject's tabs right away instead of
+// flashing the empty state while tabs are still open: the last active tab when
+// the URL has no law at all (so a refresh returns the user where they were),
+// otherwise simply the first open tab. selectTab sets activeTab synchronously,
+// so the empty state never flashes. With no open tabs this is a no-op and we
+// fall through to the empty state - the only case it should appear. Shared by
+// the initial mount and by traject switches (see watch(activeTrajectRef)).
+function openSavedActiveTab(trajectRef) {
+  if (route.params.articleNumber || openTabs.value.length === 0) return;
+  const lastActive = loadSavedActiveTab(trajectRef);
   const restored = !route.params.lawId && lastActive?.lawId
     ? findTab(lastActive.lawId, lastActive.articleNumber)
     : null;
   selectTab(restored || openTabs.value[0]).catch(console.warn);
 }
+
+openSavedActiveTab(activeTrajectRef.value);
 
 // Robustness net for the setup logic above: whenever there is no active tab but
 // tabs are open (the active tab was closed while others remain, or openTabs
@@ -949,7 +949,7 @@ function closeTab(tab, next = null) {
   const index = openTabs.value.findIndex(t => tabKey(t) === tabKey(tab));
   const remaining = openTabs.value.filter(t => tabKey(t) !== tabKey(tab));
   openTabs.value = remaining;
-  saveTabs(remaining);
+  saveTabs(activeTrajectRef.value, remaining);
   if (!wasActive) return;
   // Removing index `i` shifts the right neighbour into `i`.
   const replacement = next ?? remaining[index] ?? remaining[index - 1] ?? null;
@@ -978,7 +978,7 @@ function reorderTabs(fromIndex, toIndex) {
   const [moved] = tabs.splice(fromIndex, 1);
   tabs.splice(toIndex, 0, moved);
   openTabs.value = tabs;
-  saveTabs(openTabs.value);
+  saveTabs(activeTrajectRef.value, openTabs.value);
 }
 
 registerTabActions({
@@ -997,16 +997,20 @@ watchEffect(() => {
 });
 onBeforeUnmount(clearEditorChrome);
 
-// Load lawNames for persisted tabs on startup (parallel, deduplicated).
-// Reads go through the currently-active traject so tab labels match
-// what the editor pane shows after a save.
-const uniqueLawIds = [...new Set(openTabs.value.map(t => t.lawId))];
-Promise.all(uniqueLawIds.map(async (id) => {
-  try {
-    const entry = await fetchLaw(activeTrajectRef.value, id);
-    lawNames.value = { ...lawNames.value, [id]: entry.lawName };
-  } catch { /* ignore */ }
-}));
+// Load lawNames for the open tabs (parallel, deduplicated). Reads go through
+// the given traject so tab labels match what the editor pane shows after a
+// save. Runs on startup and again after a traject switch, since a switch swaps
+// in that traject's own tab set whose labels still need resolving.
+function backfillTabLabels(trajectRef) {
+  const uniqueLawIds = [...new Set(openTabs.value.map(t => t.lawId))];
+  Promise.all(uniqueLawIds.map(async (id) => {
+    try {
+      const entry = await fetchLaw(trajectRef, id);
+      lawNames.value = { ...lawNames.value, [id]: entry.lawName };
+    } catch { /* ignore */ }
+  }));
+}
+backfillTabLabels(activeTrajectRef.value);
 
 // --- Engine ---
 const {

--- a/frontend/src/EditorView.vue
+++ b/frontend/src/EditorView.vue
@@ -227,10 +227,14 @@ watch(activeTrajectRef, (next) => {
   backfillTabLabels(next);
   if (lawId.value) {
     // The URL carried a law across the switch: keep showing it through the new
-    // traject. Clear activeTab so no stale (previous-traject) tab reads as
-    // selected; the tab-add watch re-adds and activates the law - and persists
-    // it under the new traject's key - once switchLaw settles.
-    activeTab.value = null;
+    // traject. Point activeTab straight at that law (the tab-add watch re-adds
+    // and re-affirms it - and persists it under the new traject's key - once
+    // switchLaw settles). Setting it synchronously, rather than clearing to
+    // null, is deliberate: this switchLaw runs outside selectTab and doesn't
+    // await, so a null gap would let the "no active tab" robustness-net watch
+    // fire first and steal the switch (its selectTab claims switchLaw's shared
+    // useLatest last and wins), silently navigating to some other saved tab.
+    activeTab.value = { lawId: lawId.value, articleNumber: String(selectedArticleNumber.value ?? '') };
     switchLaw(lawId.value, selectedArticleNumber.value, next);
   } else {
     // No law in the URL: restore this traject's own last active tab (or its
@@ -1011,6 +1015,10 @@ function backfillTabLabels(trajectRef) {
   Promise.all(uniqueLawIds.map(async (id) => {
     try {
       const entry = await fetchLaw(trajectRef, id);
+      // Drop late results from a superseded switch: a fast A -> B -> C swap
+      // could otherwise land B's label on C's tab when both trajects have the
+      // same law open (its name may differ per traject after a concept edit).
+      if (trajectRef !== activeTrajectRef.value) return;
       lawNames.value = { ...lawNames.value, [id]: entry.lawName };
     } catch { /* ignore */ }
   }));

--- a/frontend/src/EditorView.vue
+++ b/frontend/src/EditorView.vue
@@ -865,7 +865,12 @@ async function selectTab(tab) {
   if (tab.lawId === lawId.value) {
     selectedArticleNumber.value = tab.articleNumber;
   } else {
-    await switchLaw(tab.lawId, tab.articleNumber);
+    // Fetch through the tab's own traject (every open tab belongs to the
+    // active traject). Passing it explicitly matters when this restore runs
+    // right after a traject switch with no law in the URL: `switchLaw`'s
+    // internal traject is still the previous one, so without this the law
+    // would be read through the old traject's scope.
+    await switchLaw(tab.lawId, tab.articleNumber, route.params.trajectRef || null);
     if (!isCurrent()) return; // stale, another switch started
     lawNames.value = { ...lawNames.value, [tab.lawId]: lawName.value };
   }

--- a/frontend/src/EditorView.vue
+++ b/frontend/src/EditorView.vue
@@ -234,17 +234,34 @@ watch(activeTrajectRef, async (next) => {
   if (route.params.lawId) {
     // A URL that still names a law in the new traject can only come from a deep
     // link or browser back/forward now (the traject switcher navigates to the
-    // bare root - see trajectSwitchTarget). onBeforeRouteUpdate already loaded
-    // that law through the new traject before this watch ran, so just reflect
-    // it as the active tab in the freshly swapped bar and persist it there.
-    if (lawId.value && selectedArticleNumber.value != null) {
+    // bare root - see trajectSwitchTarget). onBeforeRouteUpdate already ran
+    // switchLaw for that law through the new traject before this watch fired -
+    // but only reflect it as the active tab if it actually LOADED for this
+    // traject. When the new traject doesn't have the law, switchLaw 404s: it
+    // sets `error` and leaves `lawId`/`selectedArticleNumber` holding the
+    // PREVIOUS traject's law. Adopting those here would add that foreign law as
+    // an open+active tab and persist it under this traject - re-introducing the
+    // exact leak this PR fixes. Require a clean load whose id matches the URL;
+    // the error view renders the "niet beschikbaar" dialog for the failed case.
+    const loaded =
+      !error.value &&
+      lawId.value === route.params.lawId &&
+      selectedArticleNumber.value != null;
+    if (loaded) {
       const tab = { lawId: lawId.value, articleNumber: String(selectedArticleNumber.value) };
       if (!findTab(tab.lawId, tab.articleNumber)) {
-        openTabs.value = [...openTabs.value, tab];
+        // Same MAX_TABS cap as the primary add-tab watch, so repeated
+        // cross-traject deep links can't grow a traject's set past the limit.
+        const tabs = [...openTabs.value, tab];
+        openTabs.value = tabs.length > MAX_TABS ? tabs.slice(-MAX_TABS) : tabs;
         saveTabs(next, openTabs.value);
       }
       activeTab.value = tab;
       saveActiveTab(next, tab);
+    } else {
+      // Failed cross-traject deep link: don't leave the previous traject's law
+      // marked active in this traject's bar (it isn't in `openTabs` here).
+      activeTab.value = null;
     }
   } else {
     // The common case: the switcher dropped us on the traject root with no law
@@ -834,6 +851,11 @@ function libraryRouteFor(lawIdVal) {
 
 const openTabs = ref(loadSavedTabs(activeTrajectRef.value));
 
+// Cap on how many law tabs a traject keeps open; the oldest are dropped past
+// this. Enforced wherever a tab is appended (the add-tab watch and the
+// traject-switch deep-link branch).
+const MAX_TABS = 20;
+
 // Cache for law names (populated on fetch)
 const lawNames = ref({});
 
@@ -870,7 +892,6 @@ watch([() => lawId.value, selectedArticle], ([id, article]) => {
   if (lawTrajectRef.value !== activeTrajectRef.value) return;
   const num = String(article.number);
   if (!findTab(id, num)) {
-    const MAX_TABS = 20;
     const tabs = [...openTabs.value, { lawId: id, articleNumber: num }];
     openTabs.value = tabs.length > MAX_TABS ? tabs.slice(-MAX_TABS) : tabs;
     saveTabs(activeTrajectRef.value, openTabs.value);

--- a/frontend/src/EditorView.vue
+++ b/frontend/src/EditorView.vue
@@ -27,7 +27,8 @@ import { RETRY_MIN_SPINNER_MS } from './lib/retryFeedback.js';
 import { humanizeLawId } from './lib/lawName.js';
 import { quoteContext } from './lib/quoteContext.js';
 import { useLatest } from './lib/useLatest.js';
-import { loadSavedTabs, saveTabs, loadSavedActiveTab, saveActiveTab } from './lib/openTabsStorage.js';
+import { useOpenTabs } from './composables/useOpenTabs.js';
+import { createTabRestore } from './composables/useTabRestore.js';
 import { proposalDivergence } from './lib/taskReview.js';
 import ArticleText from './components/ArticleText.vue';
 import ArticleTextEditor from './components/ArticleTextEditor.vue';
@@ -206,6 +207,44 @@ const {
   lastSavedPr,
 } = useLaw(route.params.lawId, route.params.articleNumber, route.params.trajectRef);
 
+// --- Multi-law tab state (persisted per traject in localStorage) ---
+// Tab state is DERIVED from the active traject rather than a single ref that a
+// switch reassigns: `useOpenTabs` keeps a per-traject bucket and every mutation
+// takes an explicit trajectRef, so a late/stale write lands in its own bucket
+// and is invisible instead of leaking into the traject the route switched to.
+// The `openTabs`/`activeTab` computeds re-read the bucket for whatever traject
+// is active now, so a route commit flips the bar with nobody reassigning it.
+const {
+  tabs: openTabs,
+  activeTab,
+  publishedTrajectRef,
+  tabsFor,
+  activeTabFor,
+  findTab: findTabIn,
+  openTab,
+  setActiveTab,
+  closeTab: closeTabIn,
+  reorderTabs: reorderTabsIn,
+  dropLaw,
+} = useOpenTabs(activeTrajectRef);
+
+// Restore-on-entry flow (see useTabRestore): opens the last active article of a
+// traject when its editor is entered without a law in the URL, pruning tabs
+// whose law 404s in this traject. `canPrune` gates pruning on confirmed traject
+// membership (the list is still loading at mount, when every law-GET 404s).
+const tabRestore = createTabRestore({
+  tabsFor,
+  activeTabFor,
+  setActiveTab,
+  dropLaw,
+  switchLaw,
+  clearLaw,
+  error,
+  router,
+  editorRouteFor,
+  canPrune: () => activeTraject.value != null,
+});
+
 // When the active traject changes (router.push to /editor/{otherRef}/…)
 // the URL stays on the same component; re-fetch the open law through the
 // new traject's backends. The corpus list needs no handling here -
@@ -229,17 +268,14 @@ const {
 const claimTrajectSwitch = useLatest();
 watch(activeTrajectRef, async (next) => {
   const isCurrent = claimTrajectSwitch();
-  // A traject switch settles onto the section root: stand the auto-open
-  // robustness net down for this tick so it doesn't force one of the freshly
-  // swapped-in tabs active while we deliberately land on the neutral view.
+  // A traject switch reconciles the bar for `next`: stand the auto-open
+  // robustness net down for this tick so it doesn't race the restore below.
   suppressTabAutoOpen = true;
   unloadAllLaws();
-  // Tabs are scoped per traject: swap the bar to the new traject's own saved
-  // set so the previous traject's tabs - which may point at laws this traject
-  // doesn't have - leave the bar. Each traject's set was already persisted
-  // under its own key on every mutation, so nothing to save here.
-  openTabs.value = loadSavedTabs(next);
-  // Resolve the freshly swapped-in tabs' labels through the new traject.
+  // Tabs are DERIVED from the active traject: the `openTabs`/`activeTab`
+  // computeds have already flipped to `next`'s bucket now the route committed,
+  // so there is nothing to swap here. Resolve the swapped-in tabs' labels
+  // through the new traject.
   backfillTabLabels(next);
   if (route.params.lawId) {
     // A URL that still names a law in the new traject can only come from a deep
@@ -276,30 +312,20 @@ watch(activeTrajectRef, async (next) => {
       lawId.value === route.params.lawId &&
       selectedArticleNumber.value != null;
     if (loaded) {
-      const tab = { lawId: lawId.value, articleNumber: String(selectedArticleNumber.value) };
-      if (!findTab(tab.lawId, tab.articleNumber)) {
-        // Same MAX_TABS cap as the primary add-tab watch, so repeated
-        // cross-traject deep links can't grow a traject's set past the limit.
-        const tabs = [...openTabs.value, tab];
-        openTabs.value = tabs.length > MAX_TABS ? tabs.slice(-MAX_TABS) : tabs;
-        saveTabs(next, openTabs.value);
-      }
-      activeTab.value = tab;
-      saveActiveTab(next, tab);
+      // openTab de-dups, caps at MAX_TABS and marks it active - all under `next`.
+      openTab(next, { lawId: lawId.value, articleNumber: String(selectedArticleNumber.value) });
     } else {
       // Failed cross-traject deep link: don't leave the previous traject's law
-      // marked active in this traject's bar (it isn't in `openTabs` here).
-      activeTab.value = null;
+      // marked active in this traject's bar (it isn't in this bucket here).
+      setActiveTab(next, null);
     }
   } else {
-    // The common case: the switcher dropped us on the traject root with no law
-    // in the URL. Go to a neutral view - unload the previous traject's document
-    // (so it can't linger in the panes or leak across as an active tab) and
-    // leave every tab in the bar inactive. The user picks one to open it; we
-    // deliberately do NOT auto-restore the last active tab on a switch (unlike
-    // the initial mount), so switching trajects never re-opens a document.
-    clearLaw();
-    activeTab.value = null;
+    // No law in the URL (the switcher dropped us on the traject root): restore
+    // the last active article of the traject we just entered, pruning any tab
+    // whose law 404s here, or land on the neutral root. This deliberately
+    // replaces the previous "always neutral on switch" behaviour.
+    await tabRestore.restoreForTraject(next, { hasLawInUrl: false });
+    if (!isCurrent()) return;
   }
   await nextTick();
   // Only the latest switch may lower the latch: a stale invocation clearing it
@@ -842,11 +868,11 @@ watch(graphSheetOpen, async (open) => {
   else graphSheetEl.value?.hide();
 });
 
-// --- Multi-law tab state (persisted per traject in localStorage) ---
-// The open-tabs helpers (loadSavedTabs/saveTabs/loadSavedActiveTab/
-// saveActiveTab) live in lib/openTabsStorage.js and key on the active traject
-// ref, so each traject keeps its own tab bar. See that module for the storage
-// shape and the try/catch safe-default guarantee.
+// The per-traject tab store (`useOpenTabs`) and the restore-on-entry flow
+// (`useTabRestore`) are initialised near the useLaw block above; the storage
+// layer lives in lib/openTabsStorage.js (per-traject keys, sanitising reads,
+// try/catch safe defaults). What follows are the editor-side wrappers and
+// watches that drive them.
 
 /**
  * Build a router target for the editor that preserves the current
@@ -880,33 +906,28 @@ function libraryRouteFor(lawIdVal) {
   return homeTarget({ trajectRef: route.params.trajectRef, lawId: lawIdVal });
 }
 
-const openTabs = ref(loadSavedTabs(activeTrajectRef.value));
-
-// Cap on how many law tabs a traject keeps open; the oldest are dropped past
-// this. Enforced wherever a tab is appended (the add-tab watch and the
-// traject-switch deep-link branch).
-const MAX_TABS = 20;
-
-// Cache for law names (populated on fetch)
+// Cache for law names, keyed by `${trajectRef}::${lawId}`. Keyed per traject
+// (not by lawId alone) because a concept edit can give the same law a different
+// name per traject, so a bare-lawId cache would show the wrong label after a
+// switch.
 const lawNames = ref({});
+function lawNameKey(trajectRef, lawIdVal) {
+  return `${trajectRef || ''}::${lawIdVal}`;
+}
 
-// Active tab tracks which tab is selected
-const activeTab = ref(null);
-
-// Set true for the tick a traject switch takes to settle. The switch swaps the
-// tab bar to the new traject's set and lands on the neutral root with NO active
-// tab, which would otherwise trip the auto-open robustness net below into
-// opening one of the new tabs - exactly what a switch must not do. A plain
-// (non-reactive) latch is enough: the switch sets it before mutating and clears
-// it after nextTick, so the net's flush sees it raised.
+// Set true for the tick a traject switch takes to settle, so the auto-open
+// robustness net below doesn't race the restore. A plain (non-reactive) latch
+// is enough: the switch sets it before mutating and clears it after nextTick.
 let suppressTabAutoOpen = false;
 
 function tabKey(tab) {
   return `${tab.lawId}:${tab.articleNumber}`;
 }
 
+// Same-shape wrapper over the store's explicit-ref lookup, scoped to the active
+// traject (the only traject EditorView's watches ever add to).
 function findTab(lawIdVal, articleNumber) {
-  return openTabs.value.find(t => t.lawId === lawIdVal && t.articleNumber === String(articleNumber));
+  return findTabIn(activeTrajectRef.value, lawIdVal, articleNumber);
 }
 
 // Add tab when initial law loads
@@ -921,21 +942,21 @@ watch([() => lawId.value, selectedArticle], ([id, article]) => {
   // Defer to watch(activeTrajectRef), which reconciles the bar under the
   // correct traject once it commits.
   if (lawTrajectRef.value !== activeTrajectRef.value) return;
-  const num = String(article.number);
-  if (!findTab(id, num)) {
-    const tabs = [...openTabs.value, { lawId: id, articleNumber: num }];
-    openTabs.value = tabs.length > MAX_TABS ? tabs.slice(-MAX_TABS) : tabs;
-    saveTabs(activeTrajectRef.value, openTabs.value);
+  // openTab de-dups, caps at MAX_TABS and marks it active - all under the active
+  // traject's own bucket.
+  openTab(activeTrajectRef.value, { lawId: id, articleNumber: String(article.number) });
+  if (lawName.value) {
+    lawNames.value = { ...lawNames.value, [lawNameKey(activeTrajectRef.value, id)]: lawName.value };
   }
-  activeTab.value = { lawId: id, articleNumber: num };
-  saveActiveTab(activeTrajectRef.value, activeTab.value);
-  if (lawName.value) lawNames.value = { ...lawNames.value, [id]: lawName.value };
 });
 
 // Also populate lawNames when lawName resolves
 watch(lawName, (name) => {
   if (name && lawId.value) {
-    lawNames.value = { ...lawNames.value, [lawId.value]: name };
+    lawNames.value = {
+      ...lawNames.value,
+      [lawNameKey(activeTrajectRef.value, lawId.value)]: name,
+    };
   }
 });
 
@@ -945,7 +966,7 @@ const claimTabSwitch = useLatest();
 
 async function selectTab(tab) {
   const isCurrent = claimTabSwitch();
-  activeTab.value = tab;
+  setActiveTab(activeTrajectRef.value, tab);
   // Restore snapshot if the user is mid-edit, otherwise the partial mutations
   // would persist into the new tab's view.
   if (activeAction.value) {
@@ -961,7 +982,10 @@ async function selectTab(tab) {
     // would be read through the old traject's scope.
     await switchLaw(tab.lawId, tab.articleNumber, route.params.trajectRef || null);
     if (!isCurrent()) return; // stale, another switch started
-    lawNames.value = { ...lawNames.value, [tab.lawId]: lawName.value };
+    lawNames.value = {
+      ...lawNames.value,
+      [lawNameKey(activeTrajectRef.value, tab.lawId)]: lawName.value,
+    };
   }
   // Sync the URL so deep-linking and browser back/forward stay in step.
   // `replace` (not `push`) keeps history clean - a tab switch isn't
@@ -969,38 +993,28 @@ async function selectTab(tab) {
   router.replace(editorRouteFor(tab.lawId, tab.articleNumber));
 }
 
-// When the URL carries no article to edit (just a traject, or a law without an
-// article number), open one of the current traject's tabs right away instead of
-// flashing the empty state while tabs are still open: the last active tab when
-// the URL has no law at all (so a refresh returns the user where they were),
-// otherwise simply the first open tab. selectTab sets activeTab synchronously,
-// so the empty state never flashes. With no open tabs this is a no-op and we
-// fall through to the empty state - the only case it should appear. This runs
-// on the INITIAL mount only; a traject switch deliberately does NOT restore the
-// last active tab (see watch(activeTrajectRef), which lands on the neutral root
-// instead), so it never calls this.
-function openSavedActiveTab(trajectRef) {
-  if (route.params.articleNumber || openTabs.value.length === 0) return;
-  const lastActive = loadSavedActiveTab(trajectRef);
-  const restored = !route.params.lawId && lastActive?.lawId
-    ? findTab(lastActive.lawId, lastActive.articleNumber)
-    : null;
-  selectTab(restored || openTabs.value[0]).catch(console.warn);
-}
+// On the INITIAL mount, restore the last active article of this traject when
+// the URL carries no law (a fresh load / refresh returns the user where they
+// were); a law in the URL is a deep link and wins. A traject switch and browser
+// back/forward run the same restore through their own hooks (the
+// watch(activeTrajectRef) else-branch and onBeforeRouteUpdate below). Replaces
+// the old openSavedActiveTab. Pruning a 404'ing tab is gated on confirmed
+// traject membership, so at mount - before the traject list has loaded - the
+// restore leaves tabs in place and a later entry re-runs it.
+tabRestore
+  .restoreForTraject(activeTrajectRef.value, { hasLawInUrl: !!route.params.lawId })
+  .catch(console.warn);
 
-openSavedActiveTab(activeTrajectRef.value);
-
-// Robustness net for the setup logic above: whenever there is no active tab but
-// tabs are open (the active tab was closed while others remain, or openTabs
-// filled in after mount), open the first one so the panes show instead of the
-// empty state. The empty state then only appears with genuinely no open tabs.
-// NEVER when the URL names an article: that is an explicit open, and if it
-// fails the user must see the "niet beschikbaar / niet geladen" dialog for the
-// law they asked for - not silently land on some other tab.
+// Robustness net: whenever there is no active tab but tabs are open (e.g. the
+// active tab was closed while others remain), open the first one so the panes
+// show instead of the empty state. The empty state then only appears with
+// genuinely no open tabs. NEVER when the URL names an article: that is an
+// explicit open, and if it fails the user must see the "niet beschikbaar /
+// niet geladen" dialog for the law they asked for - not silently land on some
+// other tab.
 watch([activeTab, openTabs], ([tab, tabs]) => {
   if (route.params.articleNumber) return;
-  // A traject switch intentionally sits at the neutral root with tabs in the
-  // bar but none active; don't undo that by opening one.
+  // A traject switch reconciles the bar via restore; don't race it here.
   if (suppressTabAutoOpen) return;
   if (!tab && tabs.length > 0) selectTab(tabs[0]).catch(console.warn);
 });
@@ -1027,12 +1041,30 @@ watch(trajectMissing, (missing) => {
 onBeforeRouteUpdate(async (to) => {
   const newLawId = to.params.lawId;
   const newArticle = to.params.articleNumber;
-  if (!newLawId) return;
+  if (!newLawId) {
+    // Back/forward (or the Home/Editor tab) to the bare editor root WITHIN the
+    // same traject: the watch(activeTrajectRef) won't fire (ref unchanged), so
+    // restore the last active article here. A trajectRef change is left to that
+    // watch (which restores too). Not awaited and not blocking: restore's own
+    // `router.replace` fires only after its `switchLaw` await, by which point
+    // this navigation to the bare root has already committed.
+    const trajectChanged =
+      (to.params.trajectRef || null) !== (route.params.trajectRef || null);
+    if (!trajectChanged) {
+      tabRestore
+        .restoreForTraject(to.params.trajectRef || null, { hasLawInUrl: false })
+        .catch(console.warn);
+    }
+    return;
+  }
   if (newLawId !== lawId.value) {
     const isCurrent = claimTabSwitch();
     await switchLaw(newLawId, newArticle, to.params.trajectRef || null);
     if (!isCurrent()) return;
-    lawNames.value = { ...lawNames.value, [newLawId]: lawName.value };
+    lawNames.value = {
+      ...lawNames.value,
+      [lawNameKey(to.params.trajectRef || null, newLawId)]: lawName.value,
+    };
   } else if (newArticle && String(newArticle) !== String(selectedArticleNumber.value)) {
     selectedArticleNumber.value = String(newArticle);
   }
@@ -1045,19 +1077,22 @@ onBeforeRouteUpdate(async (to) => {
 // neighbour to the right, else the one to the left.
 function closeTab(tab, next = null) {
   const wasActive = !!activeTab.value && tabKey(activeTab.value) === tabKey(tab);
-  const index = openTabs.value.findIndex(t => tabKey(t) === tabKey(tab));
-  const remaining = openTabs.value.filter(t => tabKey(t) !== tabKey(tab));
-  openTabs.value = remaining;
-  saveTabs(activeTrajectRef.value, remaining);
+  // The store removes the tab, promotes the replacement (the bar's `next` pick,
+  // else right-then-left) and persists both keys - closing the active tab and
+  // reloading must not resurrect it.
+  const replacement = closeTabIn(activeTrajectRef.value, tab, next);
   if (!wasActive) return;
-  // Removing index `i` shifts the right neighbour into `i`.
-  const replacement = next ?? remaining[index] ?? remaining[index - 1] ?? null;
+  // Drive selectTab so the promoted tab's law actually loads into the panes.
   if (replacement) selectTab(replacement).catch(console.warn);
-  else activeTab.value = null;
+  else {
+    // Last tab closed: clear the panes and sit on the traject's editor root.
+    clearLaw();
+    router.replace(editorRouteFor(null, null));
+  }
 }
 
 function tabDisplayName(tab) {
-  return lawNames.value[tab.lawId] || humanizeLawId(tab.lawId);
+  return lawNames.value[lawNameKey(activeTrajectRef.value, tab.lawId)] || humanizeLawId(tab.lawId);
 }
 
 // Publish the editor-only chrome (federated "PR #N" indicator + document
@@ -1068,16 +1103,7 @@ function tabDisplayName(tab) {
 // nldd-reorder with array indices; mirror the move into openTabs so the new
 // order persists (and the md+ document-tab-bar follows it).
 function reorderTabs(fromIndex, toIndex) {
-  const tabs = [...openTabs.value];
-  if (
-    fromIndex < 0 || fromIndex >= tabs.length ||
-    toIndex < 0 || toIndex >= tabs.length ||
-    fromIndex === toIndex
-  ) return;
-  const [moved] = tabs.splice(fromIndex, 1);
-  tabs.splice(toIndex, 0, moved);
-  openTabs.value = tabs;
-  saveTabs(activeTrajectRef.value, openTabs.value);
+  reorderTabsIn(activeTrajectRef.value, fromIndex, toIndex);
 }
 
 registerTabActions({
@@ -1092,6 +1118,11 @@ watchEffect(() => {
     pr: lastSavedPr.value,
     tabs: openTabs.value,
     activeTab: activeTab.value,
+    // Publish the traject the tabs belong to IN THE SAME effect that publishes
+    // the tabs, so the bar can key its rebuild on a value that moves together
+    // with `documentTabs` - not a sibling ref that flips a tick earlier and
+    // would rebuild the bar against the old tabs (leaving a spooktab).
+    trajectRef: publishedTrajectRef.value,
   });
 });
 onBeforeUnmount(clearEditorChrome);
@@ -1101,7 +1132,7 @@ onBeforeUnmount(clearEditorChrome);
 // save. Runs on startup and again after a traject switch, since a switch swaps
 // in that traject's own tab set whose labels still need resolving.
 function backfillTabLabels(trajectRef) {
-  const uniqueLawIds = [...new Set(openTabs.value.map(t => t.lawId))];
+  const uniqueLawIds = [...new Set(tabsFor(trajectRef).map(t => t.lawId))];
   Promise.all(uniqueLawIds.map(async (id) => {
     try {
       const entry = await fetchLaw(trajectRef, id);
@@ -1109,7 +1140,7 @@ function backfillTabLabels(trajectRef) {
       // could otherwise land B's label on C's tab when both trajects have the
       // same law open (its name may differ per traject after a concept edit).
       if (trajectRef !== activeTrajectRef.value) return;
-      lawNames.value = { ...lawNames.value, [id]: entry.lawName };
+      lawNames.value = { ...lawNames.value, [lawNameKey(trajectRef, id)]: entry.lawName };
     } catch { /* ignore */ }
   }));
 }

--- a/frontend/src/components/MobileTrajectSheet.vue
+++ b/frontend/src/components/MobileTrajectSheet.vue
@@ -4,7 +4,7 @@ import { useRoute, useRouter } from 'vue-router';
 import { useTrajects } from '../composables/useTrajects.js';
 import { useAuth } from '../composables/useAuth.js';
 import { useLoginToChooser } from '../composables/useLoginToChooser.js';
-import { homeTarget, isHomeSection } from '../composables/useLastVisitedRoute.js';
+import { homeTarget, trajectSwitchTarget } from '../composables/useLastVisitedRoute.js';
 import { useAppChrome } from '../composables/useAppChrome.js';
 import TrajectCreateForm from './TrajectCreateForm.vue';
 
@@ -70,14 +70,14 @@ function onSheetClose() {
   sheetMode.value = 'list';
 }
 
-// --- Navigatie naar traject (bibliotheek vs editor, zelfde wet/artikel) ---
+// --- Navigatie naar traject (bibliotheek vs editor) ---
+// Een traject-wissel landt op de root van de sectie waar je in zit: de wet die
+// je bekeek gaat niet mee (het nieuwe traject heeft z'n eigen corpus), zodat we
+// geen document proberen te openen dat daar niet bestaat. De editor toont de
+// eigen opgeslagen tabbladen van het nieuwe traject in de balk zonder er een te
+// openen. Zie trajectSwitchTarget.
 async function goToTraject(trajectRef) {
-  const lawId = route.params.lawId || undefined;
-  const articleNumber = route.params.articleNumber || undefined;
-  const target = isHomeSection(route.name)
-    ? homeTarget({ trajectRef, lawId, articleNumber })
-    : { name: 'editor-traject', params: { trajectRef, lawId, articleNumber } };
-  await router.push(target);
+  await router.push(trajectSwitchTarget(route.name, trajectRef));
 }
 
 // Switch to the traject-less global corpus ("Corpus juris") - a peer of the

--- a/frontend/src/components/MobileTrajectSheet.vue
+++ b/frontend/src/components/MobileTrajectSheet.vue
@@ -15,7 +15,7 @@ import TrajectCreateForm from './TrajectCreateForm.vue';
 // document-tab-bar. Hergebruikt dezelfde composables/handlers als TrajectMenu.
 const { trajects, activeTrajectRef, activeTraject, loading, createTraject } = useTrajects();
 const { authenticated } = useAuth();
-const { documentTabs, activeDocumentTab, tabActions } = useAppChrome();
+const { documentTabs, activeDocumentTab, documentTabsTrajectRef, tabActions } = useAppChrome();
 const route = useRoute();
 const router = useRouter();
 
@@ -325,7 +325,7 @@ onBeforeUnmount(() => {
             <nldd-list variant="box">
               <nldd-list-item
                 v-for="tab in documentTabs"
-                :key="tabActions.key(tab)"
+                :key="`${documentTabsTrajectRef ?? ''}:${tabActions.key(tab)}`"
                 size="md"
                 button
                 :selected="isActiveTab(tab) || undefined"

--- a/frontend/src/components/TrajectMenu.vue
+++ b/frontend/src/components/TrajectMenu.vue
@@ -4,7 +4,7 @@ import { useRoute, useRouter } from 'vue-router';
 import { useTrajects } from '../composables/useTrajects.js';
 import { useAuth } from '../composables/useAuth.js';
 import { useLoginToChooser } from '../composables/useLoginToChooser.js';
-import { homeTarget, isHomeSection } from '../composables/useLastVisitedRoute.js';
+import { homeTarget, trajectSwitchTarget } from '../composables/useLastVisitedRoute.js';
 import TrajectCreateForm from './TrajectCreateForm.vue';
 
 const props = defineProps({
@@ -68,21 +68,16 @@ function goToCorpusJuris() {
 }
 
 /**
- * Navigate to a traject - push the user into the traject-scoped view of
- * the section they are currently in (bibliotheek or editor), at the same
- * law they were viewing. Picking a traject from the bibliotheek keeps you
- * in the bibliotheek; from the editor it keeps you in the editor. Per-tab
- * state: a switch here only affects this tab, never other open tabs.
+ * Navigate to a traject - push the user into the traject-scoped view of the
+ * section they are currently in (bibliotheek or editor), at that section's
+ * ROOT. A switch deliberately drops the law you were viewing: the new traject
+ * has its own corpus, so carrying the old lawId across would try to open a
+ * document it doesn't have (and leak the previous traject's tab). The editor
+ * shows the new traject's own saved tabs in the bar without auto-opening one.
+ * Per-tab state: a switch here only affects this tab, never other open tabs.
  */
 async function goToTraject(trajectRef) {
-  const lawId = route.params.lawId || undefined;
-  const articleNumber = route.params.articleNumber || undefined;
-  // Stay in the section you're in: Home keeps you on Home (bare traject or its
-  // corpus, per homeTarget); the editor keeps you in the editor.
-  const target = isHomeSection(route.name)
-    ? homeTarget({ trajectRef, lawId, articleNumber })
-    : { name: 'editor-traject', params: { trajectRef, lawId, articleNumber } };
-  await router.push(target);
+  await router.push(trajectSwitchTarget(route.name, trajectRef));
 }
 
 const menuBtnId = computed(() => `traject-menu-btn-${props.idSuffix}`);

--- a/frontend/src/composables/useAppChrome.js
+++ b/frontend/src/composables/useAppChrome.js
@@ -57,6 +57,13 @@ const lastSavedPr = shallowRef(null);
 const documentTabs = shallowRef([]);
 const activeDocumentTab = shallowRef(null);
 const tabActions = shallowRef(null); // { key, displayName, select, close, reorder }
+// The traject ref the current `documentTabs` belong to, published in the SAME
+// update as the tabs. The shell keys its `<nldd-document-tab-bar>` rebuild on
+// this (not on its own `activeTrajectRef`, which flips a tick earlier than the
+// tabs and would rebuild the bar against the previous traject's set, leaving a
+// spooktab). A rebuild tears down the bar's overflow menu, ResizeObserver and
+// every element reference it holds.
+const documentTabsTrajectRef = shallowRef(null);
 // Article-level pending-changes bar (Wijzigingenbalk). The editor publishes
 // the dirty/saving/undo state reactively and registers the action callbacks;
 // the shell renders the bar while there are unsaved changes.
@@ -74,6 +81,7 @@ export function useAppChrome() {
     lastSavedPr,
     documentTabs,
     activeDocumentTab,
+    documentTabsTrajectRef,
     tabActions,
     editorChanges,
     editorActions,
@@ -87,10 +95,11 @@ export function setLibraryEmpty(empty) {
   libraryEmpty.value = !!empty;
 }
 
-export function setEditorChrome({ pr, tabs, activeTab }) {
+export function setEditorChrome({ pr, tabs, activeTab, trajectRef }) {
   lastSavedPr.value = pr ?? null;
   documentTabs.value = tabs ?? [];
   activeDocumentTab.value = activeTab ?? null;
+  documentTabsTrajectRef.value = trajectRef ?? null;
 }
 
 export function registerTabActions(actions) {
@@ -115,6 +124,7 @@ export function clearEditorChrome() {
   lastSavedPr.value = null;
   documentTabs.value = [];
   activeDocumentTab.value = null;
+  documentTabsTrajectRef.value = null;
   tabActions.value = null;
   editorChanges.value = null;
   editorActions.value = null;

--- a/frontend/src/composables/useLastVisitedRoute.js
+++ b/frontend/src/composables/useLastVisitedRoute.js
@@ -58,6 +58,19 @@ export function homeTarget({ trajectRef, lawId, articleNumber } = {}) {
     : { name: 'home', params: {} };
 }
 
+// Where a traject switch should land: the ROOT of the section you're in
+// (Home or editor), in the newly picked traject. A switch deliberately does
+// NOT carry the law/article you were viewing - the new traject's corpus
+// differs, so the old lawId points at a document it doesn't have. Carrying it
+// across made the editor try to open that foreign document (and leak the
+// previous traject's tab). Landing on the bare root instead lets the editor
+// show the new traject's own saved tabs in the bar without auto-opening one.
+export function trajectSwitchTarget(routeName, trajectRef) {
+  return isHomeSection(routeName)
+    ? homeTarget({ trajectRef })
+    : { name: 'editor-traject', params: { trajectRef } };
+}
+
 function storageKeyFor(routeName) {
   if (routeName === 'editor-traject') return 'editor';
   // The whole Home section shares one key so the last write wins regardless of

--- a/frontend/src/composables/useLastVisitedRoute.js
+++ b/frontend/src/composables/useLastVisitedRoute.js
@@ -141,6 +141,17 @@ export function sectionTarget(router, storedPath, activeRef) {
 
   if (isEditor) {
     if (activeRef) {
+      const storedRef = loc.params.trajectRef || null;
+      // Cross-traject: the stored path names a DIFFERENT traject, so its lawId
+      // belongs to that traject and may not exist here. Do NOT stamp it onto
+      // the active traject (that produced the "niet beschikbaar in dit traject"
+      // dead end). Land on the active traject's editor root and let the
+      // restore-on-entry flow open the right article - the same rule as
+      // trajectSwitchTarget. (A traject-less chooser/global editor path carries
+      // an unscoped law and is handled below.)
+      if (storedRef && storedRef !== activeRef) {
+        return { name: 'editor-traject', params: { trajectRef: activeRef } };
+      }
       params.trajectRef = activeRef;
       // A stored chooser path carries the intended law as query.
       if (loc.query?.law) params.lawId = loc.query.law;
@@ -196,15 +207,29 @@ export function sectionTarget(router, storedPath, activeRef) {
   });
 }
 
-// Target for the Home tab: the last-visited Home path, with the ACTIVE
-// traject re-stamped onto it (via sectionTarget) so a Home<->Editor tab
-// switch keeps you in the traject you're working in instead of restoring a
-// stale scope (e.g. Corpus juris after opening a public deep-link). When the
-// stored path already carries the active scope it's returned verbatim, so
-// query/hash (the open werkdocument's `?task=`, the #yaml detail tab)
-// survive exactly like before.
-export function homeTabTarget(router, storedPath, activeRef) {
+// Shared same-traject shortcut for the top-level tab targets: when the stored
+// path already carries the active scope, return it VERBATIM so query/hash (a
+// werkdocument's `?task=`, the #yaml detail tab, the editor's exact article)
+// survive exactly; otherwise re-stamp/rebuild via sectionTarget. Both the Home
+// and Editor tab reuse this instead of each duplicating the check.
+function tabTargetFor(router, storedPath, activeRef) {
   const storedRef = router.resolve(storedPath).params.trajectRef || null;
   if (storedRef === (activeRef || null)) return storedPath;
   return sectionTarget(router, storedPath, activeRef);
+}
+
+// Target for the Home tab: the last-visited Home path, with the ACTIVE traject
+// re-stamped onto it so a Home<->Editor tab switch keeps you in the traject
+// you're working in instead of restoring a stale scope (e.g. Corpus juris after
+// opening a public deep-link).
+export function homeTabTarget(router, storedPath, activeRef) {
+  return tabTargetFor(router, storedPath, activeRef);
+}
+
+// Target for the Editor tab: same same-traject-verbatim / cross-traject-rebuild
+// rule as the Home tab. On a cross-traject stored path sectionTarget now lands
+// on the active traject's editor ROOT (dropping the foreign lawId), and the
+// editor's restore-on-entry flow opens the right article.
+export function editorTabTarget(router, storedPath, activeRef) {
+  return tabTargetFor(router, storedPath, activeRef);
 }

--- a/frontend/src/composables/useLastVisitedRoute.test.js
+++ b/frontend/src/composables/useLastVisitedRoute.test.js
@@ -1,7 +1,15 @@
 import { describe, it, expect } from 'vitest';
-import { trajectSwitchTarget } from './useLastVisitedRoute.js';
+import { trajectSwitchTarget, sectionTarget, editorTabTarget } from './useLastVisitedRoute.js';
 
 const REF = 'ander-traject-12345678';
+const ACTIVE = 'actief-traject-0a1b2c3d';
+
+// Minimal fake router: `resolve(path)` returns a canned resolution keyed on the
+// exact path, so sectionTarget's branch logic can be exercised without a real
+// router instance.
+function fakeRouter(map) {
+  return { resolve: (path) => map[path] };
+}
 
 describe('trajectSwitchTarget', () => {
   it('lands the editor on the bare traject root, dropping the open law', () => {
@@ -27,5 +35,52 @@ describe('trajectSwitchTarget', () => {
       expect(target.name).toBe('traject-home');
       expect(target.params).toEqual({ trajectRef: REF });
     }
+  });
+});
+
+describe('sectionTarget (Editor tab)', () => {
+  it('drops a foreign lawId on a cross-traject editor path', () => {
+    // The stored editor path belongs to a DIFFERENT traject: its lawId may not
+    // exist in the active one, so we must NOT stamp it onto the active traject.
+    // Land on the active traject's editor root and let restore take over.
+    const stored = `/trajecten/${REF}/editor/wet_x/2`;
+    const router = fakeRouter({
+      [stored]: {
+        name: 'editor-traject',
+        params: { trajectRef: REF, lawId: 'wet_x', articleNumber: '2' },
+        query: {},
+      },
+    });
+    const target = sectionTarget(router, stored, ACTIVE);
+    expect(target).toEqual({ name: 'editor-traject', params: { trajectRef: ACTIVE } });
+    expect(target.params.lawId).toBeUndefined();
+  });
+
+  it('returns the stored path verbatim when its traject matches the active one', () => {
+    // Same traject: the Editor tab keeps the exact law/article (and any
+    // query/hash) - the whole point of remembering where the user was.
+    const stored = `/trajecten/${ACTIVE}/editor/wet_x/2`;
+    const router = fakeRouter({
+      [stored]: {
+        name: 'editor-traject',
+        params: { trajectRef: ACTIVE, lawId: 'wet_x', articleNumber: '2' },
+        query: {},
+      },
+    });
+    expect(editorTabTarget(router, stored, ACTIVE)).toBe(stored);
+  });
+
+  it('keeps the chooser `?law=` intact, upgrading it onto the active traject', () => {
+    // A traject-less chooser path carries an UNSCOPED intended law (not a law
+    // from another traject), so it is stamped onto the active traject to open.
+    const stored = '/editor?law=wet_x';
+    const router = fakeRouter({
+      [stored]: { name: 'editor', params: {}, query: { law: 'wet_x' } },
+    });
+    const target = sectionTarget(router, stored, ACTIVE);
+    expect(target).toEqual({
+      name: 'editor-traject',
+      params: { trajectRef: ACTIVE, lawId: 'wet_x' },
+    });
   });
 });

--- a/frontend/src/composables/useLastVisitedRoute.test.js
+++ b/frontend/src/composables/useLastVisitedRoute.test.js
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { trajectSwitchTarget } from './useLastVisitedRoute.js';
+
+const REF = 'ander-traject-12345678';
+
+describe('trajectSwitchTarget', () => {
+  it('lands the editor on the bare traject root, dropping the open law', () => {
+    // A switch from the editor must not carry the law/article across: the new
+    // traject has its own corpus, so the old lawId would point at a document it
+    // doesn't have. We navigate to the traject-scoped editor root instead.
+    const target = trajectSwitchTarget('editor-traject', REF);
+    expect(target).toEqual({ name: 'editor-traject', params: { trajectRef: REF } });
+    expect(target.params.lawId).toBeUndefined();
+    expect(target.params.articleNumber).toBeUndefined();
+  });
+
+  it('lands Home on the bare traject home, dropping the open law', () => {
+    // Same rule for the bibliotheek side: go to the traject home root, not the
+    // corpus view of a law the new traject may not have.
+    const target = trajectSwitchTarget('library-traject', REF);
+    expect(target).toEqual({ name: 'traject-home', params: { trajectRef: REF } });
+  });
+
+  it('treats every Home-section route name as Home', () => {
+    for (const name of ['traject-home', 'corpus-juris', 'werkdocumenten-traject', 'taken-traject']) {
+      const target = trajectSwitchTarget(name, REF);
+      expect(target.name).toBe('traject-home');
+      expect(target.params).toEqual({ trajectRef: REF });
+    }
+  });
+});

--- a/frontend/src/composables/useLaw.js
+++ b/frontend/src/composables/useLaw.js
@@ -265,6 +265,27 @@ export function useLaw(lawParam, articleParam, trajectRefParam) {
   }
 
   /**
+   * Drop the currently open law and return to the "nothing open" state (no
+   * law, no article, no error, not loading). Used when a traject switch lands
+   * on the section root: the previous traject's law must not linger in the
+   * panes, and `lawId` must read `null` so the editor shows its neutral empty
+   * state instead of trying to keep the old document up. Clearing `lawParam`
+   * too drops the initial-route fallback, so `lawId` really settles on `null`.
+   * Invalidates any in-flight load/switch so a late response can't repopulate
+   * the cleared state.
+   */
+  function clearLaw() {
+    claimSwitch();
+    lawParam = null;
+    law.value = null;
+    rawYaml.value = '';
+    selectedArticleNumber.value = null;
+    currentEtag.value = null;
+    error.value = null;
+    loading.value = false;
+  }
+
+  /**
    * Persist edited law YAML to the backend via PUT.
    *
    * On success, updates `rawYaml` + `law` locally so downstream consumers
@@ -458,6 +479,7 @@ export function useLaw(lawParam, articleParam, trajectRefParam) {
     selectedArticle,
     selectedArticleNumber,
     switchLaw,
+    clearLaw,
     loading,
     error,
     saving,

--- a/frontend/src/composables/useLaw.js
+++ b/frontend/src/composables/useLaw.js
@@ -129,6 +129,14 @@ export function useLaw(lawParam, articleParam, trajectRefParam) {
   // update this when navigation crosses trajects, so URL builders read
   // through the closure instead of capturing a snapshot.
   let currentTrajectRef = trajectRefParam || null;
+  // Reactive mirror of `currentTrajectRef`, kept in sync wherever it is
+  // reassigned. Consumers use this to learn which traject the *open law* was
+  // loaded through - which is NOT necessarily the route's active traject
+  // during a cross-traject navigation: `switchLaw` updates it a tick before
+  // the route (and thus `activeTrajectRef`) commits, so a watcher on the law
+  // can tell "this law belongs to the traject I'm loading into" apart from
+  // "…the traject I'm still leaving".
+  const lawTrajectRef = ref(currentTrajectRef);
   // If the parameter looks like a URL, fetch directly; otherwise build
   // the API URL from the current trajectRef.
   const initialDirectUrl =
@@ -239,6 +247,7 @@ export function useLaw(lawParam, articleParam, trajectRefParam) {
       saving.value = false;
       if (newTrajectRef !== undefined) {
         currentTrajectRef = newTrajectRef || null;
+        lawTrajectRef.value = currentTrajectRef;
       }
       const entry = await fetchLaw(currentTrajectRef, newLawId);
       if (!isCurrent()) return;
@@ -480,6 +489,7 @@ export function useLaw(lawParam, articleParam, trajectRefParam) {
     selectedArticleNumber,
     switchLaw,
     clearLaw,
+    lawTrajectRef,
     loading,
     error,
     saving,

--- a/frontend/src/composables/useLaw.js
+++ b/frontend/src/composables/useLaw.js
@@ -235,6 +235,18 @@ export function useLaw(lawParam, articleParam, trajectRefParam) {
    * article / traject in one step. Passing `newTrajectRef` is how a
    * cross-traject URL change drives a fresh fetch (and the cache key
    * keeps the previous traject's copy untouched).
+   *
+   * `claimSwitch` is a SHARED staleness token across every caller
+   * (`selectTab`, `onBeforeRouteUpdate`, `watch(activeTrajectRef)`,
+   * `restoreForTraject`, retry): a later call supersedes an earlier one
+   * regardless of which site started it. On supersession this returns `false`
+   * WITHOUT touching `law.value`/`error.value` (the winning call owns those);
+   * on a completed load (success OR its own error) it returns `true`. A caller
+   * whose own guard can't tell "someone else's call won the shared race" apart
+   * from "my call finished" must check this so it doesn't act on refs that now
+   * reflect a different request.
+   *
+   * @returns {Promise<boolean>} whether THIS call was the one that completed.
    */
   async function switchLaw(newLawId, articleNumber, newTrajectRef, { minLoadingMs = 0 } = {}) {
     const isCurrent = claimSwitch();
@@ -250,7 +262,7 @@ export function useLaw(lawParam, articleParam, trajectRefParam) {
         lawTrajectRef.value = currentTrajectRef;
       }
       const entry = await fetchLaw(currentTrajectRef, newLawId);
-      if (!isCurrent()) return;
+      if (!isCurrent()) return false;
       law.value = entry.law;
       rawYaml.value = entry.rawYaml;
       currentEtag.value = entry.etag ?? null;
@@ -260,7 +272,7 @@ export function useLaw(lawParam, articleParam, trajectRefParam) {
         selectedArticleNumber.value = String(articles.value[0].number);
       }
     } catch (e) {
-      if (!isCurrent()) return;
+      if (!isCurrent()) return false;
       failed = true;
       error.value = e;
     } finally {
@@ -271,6 +283,7 @@ export function useLaw(lawParam, articleParam, trajectRefParam) {
         if (isCurrent()) loading.value = false;
       }
     }
+    return true;
   }
 
   /**

--- a/frontend/src/composables/useLaw.test.js
+++ b/frontend/src/composables/useLaw.test.js
@@ -348,3 +348,47 @@ describe('useLaw law_create-flow (seedFromYaml + createLaw)', () => {
     expect(law.saveError.value).toBeTruthy();
   });
 });
+
+describe('useLaw clearLaw (traject-switch reset)', () => {
+  it('drops the open law so lawId settles on null and the panes go empty', async () => {
+    globalThis.fetch = vi.fn().mockImplementation(async () =>
+      res({ body: '$id: wet_clear\nname: V1\narticles:\n  - number: "1"\n', etag: '"v1"' }),
+    );
+
+    const law = useLaw('wet_clear', '1', 'tr-12345678');
+    await waitForLoaded(law);
+    expect(law.lawId.value).toBe('wet_clear');
+    expect(law.selectedArticleNumber.value).toBe('1');
+
+    law.clearLaw();
+
+    // The initial-route lawParam fallback is dropped too, so lawId is truly null
+    // (not the stale route slug) and the editor shows its neutral empty state.
+    expect(law.lawId.value).toBeNull();
+    expect(law.law.value).toBeNull();
+    expect(law.selectedArticle.value).toBeNull();
+    expect(law.selectedArticleNumber.value).toBeNull();
+    expect(law.rawYaml.value).toBe('');
+    expect(law.error.value).toBeNull();
+    expect(law.loading.value).toBe(false);
+  });
+
+  it('makes an in-flight load discard its writes so a late response cannot repopulate', async () => {
+    let release;
+    const gate = new Promise((r) => { release = r; });
+    globalThis.fetch = vi.fn().mockImplementation(async () => {
+      await gate;
+      return res({ body: '$id: wet_slow\nname: V1\narticles:\n  - number: "1"\n', etag: '"v1"' });
+    });
+
+    const law = useLaw('wet_slow', '1', 'tr-12345678');
+    // The load is still in flight (gated). Clear before it resolves.
+    law.clearLaw();
+    release();
+    await waitForLoaded(law);
+
+    // The stale load's writes were discarded: still cleared.
+    expect(law.lawId.value).toBeNull();
+    expect(law.law.value).toBeNull();
+  });
+});

--- a/frontend/src/composables/useLaw.test.js
+++ b/frontend/src/composables/useLaw.test.js
@@ -392,3 +392,27 @@ describe('useLaw clearLaw (traject-switch reset)', () => {
     expect(law.law.value).toBeNull();
   });
 });
+
+describe('useLaw lawTrajectRef (which traject the open law belongs to)', () => {
+  it('exposes the initial traject and follows a cross-traject switchLaw', async () => {
+    globalThis.fetch = vi.fn().mockImplementation(async () =>
+      res({ body: '$id: wet_x\nname: V1\narticles:\n  - number: "1"\n', etag: '"v1"' }),
+    );
+
+    const law = useLaw('wet_x', '1', 'tr-alpha');
+    await waitForLoaded(law);
+    // Starts on the traject the composable was constructed with.
+    expect(law.lawTrajectRef.value).toBe('tr-alpha');
+
+    // A cross-traject switch retargets the open law's traject. This is the
+    // signal EditorView's add-tab watch uses to avoid persisting a freshly
+    // loaded law under the traject the route is still leaving during a
+    // back/forward navigation.
+    await law.switchLaw('wet_x', '1', 'tr-beta');
+    expect(law.lawTrajectRef.value).toBe('tr-beta');
+
+    // A same-traject switch (newTrajectRef omitted) leaves it untouched.
+    await law.switchLaw('wet_x', '1');
+    expect(law.lawTrajectRef.value).toBe('tr-beta');
+  });
+});

--- a/frontend/src/composables/useOpenTabs.js
+++ b/frontend/src/composables/useOpenTabs.js
@@ -1,0 +1,195 @@
+import { computed, ref } from 'vue';
+import {
+  loadSavedTabs,
+  saveTabs,
+  loadSavedActiveTab,
+  saveActiveTab,
+  MAX_TABS,
+} from '../lib/openTabsStorage.js';
+
+/**
+ * The editor's open-tab store, bucketed per traject.
+ *
+ * The previous design kept a single `openTabs` ref and, on a traject switch,
+ * reassigned it to the new traject's saved set (`openTabs.value =
+ * loadSavedTabs(next)`). Every writer read the active traject ref *at write
+ * time* (`saveTabs(activeTrajectRef.value, …)`) - a global computed read after
+ * an `await`, so a late/stale write could land under whichever traject the
+ * route had meanwhile switched to. That is the root of the cross-traject leak.
+ *
+ * Here tab state is instead *derived* from the active traject: a
+ * `Map<trajectRef, { tabs, active }>`, lazily hydrated from localStorage, and
+ * every mutation takes an **explicit** `trajectRef`. A late write for traject A
+ * lands in A's bucket and is simply invisible while B is active, rather than
+ * corrupting B. The reactive `tabs` / `activeTab` computeds re-read the bucket
+ * for whatever traject is active *now*, so a route commit flips the bar without
+ * anyone reassigning it.
+ *
+ * A single reactive `version` counter is the only dependency: buckets are plain
+ * objects mutated in place (always a NEW array + `version.value++`, never an
+ * in-place array splice), so consumers stay cheap and there is no per-tab
+ * reactivity to leak. No lifecycle hooks, so this is directly unit-testable.
+ *
+ * A tab has the shape `{ lawId, articleNumber }` (`articleNumber` a string).
+ */
+export function useOpenTabs(activeTrajectRef) {
+  // Map<string, { tabs: Tab[], active: Tab | null }>. Keyed on the traject ref
+  // coerced to a string ('' for the traject-less read-only editor).
+  const buckets = new Map();
+  // The single reactive dependency. Bumped on every mutation; the computeds and
+  // the explicit-ref readers below take it as their only reactive input.
+  const version = ref(0);
+
+  function keyOf(trajectRef) {
+    return trajectRef ?? '';
+  }
+
+  // Lazy hydration: a bucket is loaded from localStorage the first time it is
+  // touched, so opening tab A while B is active never reads B's storage.
+  function bucket(trajectRef) {
+    const key = keyOf(trajectRef);
+    let b = buckets.get(key);
+    if (!b) {
+      b = { tabs: loadSavedTabs(trajectRef), active: loadSavedActiveTab(trajectRef) };
+      buckets.set(key, b);
+    }
+    return b;
+  }
+
+  function tabKey(tab) {
+    return `${tab.lawId}:${tab.articleNumber}`;
+  }
+
+  function normalize(tab) {
+    return { lawId: tab.lawId, articleNumber: String(tab.articleNumber) };
+  }
+
+  // --- Explicit-ref reads (used by the restore flow, which always names the
+  //     traject it is restoring). Read `version` so they stay reactive when
+  //     called from within a computed/watch. ---
+  function tabsFor(trajectRef) {
+    version.value;
+    return bucket(trajectRef).tabs;
+  }
+  function activeTabFor(trajectRef) {
+    version.value;
+    return bucket(trajectRef).active;
+  }
+  function findTab(trajectRef, lawId, articleNumber) {
+    const num = String(articleNumber);
+    return tabsFor(trajectRef).find((t) => t.lawId === lawId && t.articleNumber === num) ?? null;
+  }
+
+  // --- Reactive views for the currently active traject. ---
+  const tabs = computed(() => tabsFor(activeTrajectRef.value));
+  const activeTab = computed(() => activeTabFor(activeTrajectRef.value));
+  // The traject ref that the current `tabs` / `activeTab` belong to, published
+  // alongside them so the bar can key its rebuild on the SAME value that moves
+  // with the tabs (not a sibling ref that flips a tick earlier).
+  const publishedTrajectRef = computed(() => {
+    version.value;
+    return activeTrajectRef.value;
+  });
+
+  // --- Mutations (explicit trajectRef; never mutate an array in place). ---
+
+  /**
+   * Add a tab to a traject's bucket (de-duplicated, `MAX_TABS`-capped) and, by
+   * default, mark it active. Persists both keys it touches.
+   */
+  function openTab(trajectRef, tab, { activate = true } = {}) {
+    const b = bucket(trajectRef);
+    const t = normalize(tab);
+    if (!b.tabs.some((x) => tabKey(x) === tabKey(t))) {
+      const next = [...b.tabs, t];
+      b.tabs = next.length > MAX_TABS ? next.slice(-MAX_TABS) : next;
+      saveTabs(trajectRef, b.tabs);
+    }
+    if (activate) {
+      b.active = t;
+      saveActiveTab(trajectRef, t);
+    }
+    version.value++;
+    return t;
+  }
+
+  /** Set (or clear, when `tab` is null) a traject's active tab and persist it. */
+  function setActiveTab(trajectRef, tab) {
+    const b = bucket(trajectRef);
+    b.active = tab ? normalize(tab) : null;
+    saveActiveTab(trajectRef, b.active);
+    version.value++;
+    return b.active;
+  }
+
+  /**
+   * Remove a tab. When it was the active one, promote a replacement: the
+   * caller's explicit `next` (the bar's own pick), else the neighbour to the
+   * right, else the one to the left, else null. Persists the new active tab too
+   * - closing the active tab and reloading must not resurrect it.
+   */
+  function closeTab(trajectRef, tab, next = null) {
+    const b = bucket(trajectRef);
+    const target = tabKey(normalize(tab));
+    const index = b.tabs.findIndex((x) => tabKey(x) === target);
+    if (index === -1) return b.active;
+    const remaining = b.tabs.filter((x) => tabKey(x) !== target);
+    b.tabs = remaining;
+    saveTabs(trajectRef, remaining);
+    if (b.active && tabKey(b.active) === target) {
+      // Removing index `i` shifts the right neighbour into `i`.
+      b.active = next ?? remaining[index] ?? remaining[index - 1] ?? null;
+      saveActiveTab(trajectRef, b.active);
+    }
+    version.value++;
+    return b.active;
+  }
+
+  /** Move a tab within a traject's bucket and persist the new order. */
+  function reorderTabs(trajectRef, fromIndex, toIndex) {
+    const b = bucket(trajectRef);
+    if (
+      fromIndex < 0 || fromIndex >= b.tabs.length ||
+      toIndex < 0 || toIndex >= b.tabs.length ||
+      fromIndex === toIndex
+    ) {
+      return;
+    }
+    const next = [...b.tabs];
+    const [moved] = next.splice(fromIndex, 1);
+    next.splice(toIndex, 0, moved);
+    b.tabs = next;
+    saveTabs(trajectRef, next);
+    version.value++;
+  }
+
+  /**
+   * Drop every tab pointing at `lawId` from a traject (the self-heal for a law
+   * that 404's in this traject), clear the active tab when it was one of them,
+   * and re-persist both keys.
+   */
+  function dropLaw(trajectRef, lawId) {
+    const b = bucket(trajectRef);
+    b.tabs = b.tabs.filter((x) => x.lawId !== lawId);
+    saveTabs(trajectRef, b.tabs);
+    if (b.active && b.active.lawId === lawId) {
+      b.active = null;
+    }
+    saveActiveTab(trajectRef, b.active);
+    version.value++;
+  }
+
+  return {
+    tabs,
+    activeTab,
+    publishedTrajectRef,
+    tabsFor,
+    activeTabFor,
+    findTab,
+    openTab,
+    setActiveTab,
+    closeTab,
+    reorderTabs,
+    dropLaw,
+  };
+}

--- a/frontend/src/composables/useOpenTabs.js
+++ b/frontend/src/composables/useOpenTabs.js
@@ -94,10 +94,10 @@ export function useOpenTabs(activeTrajectRef) {
   // --- Mutations (explicit trajectRef; never mutate an array in place). ---
 
   /**
-   * Add a tab to a traject's bucket (de-duplicated, `MAX_TABS`-capped) and, by
-   * default, mark it active. Persists both keys it touches.
+   * Add a tab to a traject's bucket (de-duplicated, `MAX_TABS`-capped) and mark
+   * it active. Persists both keys it touches.
    */
-  function openTab(trajectRef, tab, { activate = true } = {}) {
+  function openTab(trajectRef, tab) {
     const b = bucket(trajectRef);
     const t = normalize(tab);
     if (!b.tabs.some((x) => tabKey(x) === tabKey(t))) {
@@ -105,10 +105,8 @@ export function useOpenTabs(activeTrajectRef) {
       b.tabs = next.length > MAX_TABS ? next.slice(-MAX_TABS) : next;
       saveTabs(trajectRef, b.tabs);
     }
-    if (activate) {
-      b.active = t;
-      saveActiveTab(trajectRef, t);
-    }
+    b.active = t;
+    saveActiveTab(trajectRef, t);
     version.value++;
     return t;
   }

--- a/frontend/src/composables/useOpenTabs.test.js
+++ b/frontend/src/composables/useOpenTabs.test.js
@@ -71,12 +71,12 @@ describe('useOpenTabs', () => {
     expect(store.tabs.value).toEqual([{ lawId: 'law_a', articleNumber: '5' }]);
   });
 
-  it('openTab with activate:false leaves the active tab unchanged', () => {
+  it('openTab activates the newly opened tab', () => {
     const active = ref(A);
     const store = useOpenTabs(active);
     store.openTab(A, TAB_A1);
-    store.openTab(A, TAB_A2, { activate: false });
-    expect(store.activeTab.value).toEqual(TAB_A1);
+    store.openTab(A, TAB_A2);
+    expect(store.activeTab.value).toEqual(TAB_A2);
     expect(store.tabs.value).toEqual([TAB_A1, TAB_A2]);
   });
 

--- a/frontend/src/composables/useOpenTabs.test.js
+++ b/frontend/src/composables/useOpenTabs.test.js
@@ -1,0 +1,163 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { useOpenTabs } from './useOpenTabs.js';
+
+// useOpenTabs buckets the editor's open tabs per traject and derives the active
+// bar from the active traject ref. These pin the bucket isolation that fixes
+// the cross-traject leak, plus the closeTab/dropLaw/persistence contracts.
+
+const A = 'traject-a-00000001';
+const B = 'traject-b-00000002';
+const TAB_A1 = { lawId: 'law_a', articleNumber: '1' };
+const TAB_A2 = { lawId: 'law_a', articleNumber: '2' };
+const TAB_C1 = { lawId: 'law_c', articleNumber: '1' };
+
+const tabsKey = (ref_) => `regelrecht-open-tabs:${ref_}`;
+const activeKey = (ref_) => `regelrecht-active-tab:${ref_}`;
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('useOpenTabs', () => {
+  it('isolates buckets: opening in A while B is active leaves tabs.value alone and writes A', () => {
+    const active = ref(B);
+    const store = useOpenTabs(active);
+    expect(store.tabs.value).toEqual([]);
+
+    store.openTab(A, TAB_A1);
+
+    // The active (B) bar is untouched...
+    expect(store.tabs.value).toEqual([]);
+    // ...while A's own bucket + key got the write.
+    expect(store.tabsFor(A)).toEqual([TAB_A1]);
+    expect(JSON.parse(localStorage.getItem(tabsKey(A)))).toEqual([TAB_A1]);
+    expect(localStorage.getItem(tabsKey(B))).toBeNull();
+  });
+
+  it('lands a stale write in its own bucket, invisible to the active traject', () => {
+    const active = ref(A);
+    const store = useOpenTabs(active);
+    store.openTab(A, TAB_A1);
+    // The route switched to B while a late write for A is still coming.
+    active.value = B;
+    store.openTab(A, TAB_A2);
+    expect(store.tabs.value).toEqual([]); // B stays empty
+    expect(store.tabsFor(A)).toEqual([TAB_A1, TAB_A2]);
+  });
+
+  it('lazily hydrates a bucket from localStorage', () => {
+    localStorage.setItem(tabsKey(A), JSON.stringify([TAB_A1, TAB_C1]));
+    localStorage.setItem(activeKey(A), JSON.stringify(TAB_C1));
+    const active = ref(A);
+    const store = useOpenTabs(active);
+    expect(store.tabs.value).toEqual([TAB_A1, TAB_C1]);
+    expect(store.activeTab.value).toEqual(TAB_C1);
+  });
+
+  it('caps a bucket at MAX_TABS (20), dropping the oldest', () => {
+    const active = ref(A);
+    const store = useOpenTabs(active);
+    for (let i = 0; i < 25; i++) store.openTab(A, { lawId: `law_${i}`, articleNumber: '1' });
+    expect(store.tabs.value).toHaveLength(20);
+    expect(store.tabs.value[0]).toEqual({ lawId: 'law_5', articleNumber: '1' });
+    expect(store.tabs.value[19]).toEqual({ lawId: 'law_24', articleNumber: '1' });
+  });
+
+  it('normalises a numeric articleNumber on openTab', () => {
+    const active = ref(A);
+    const store = useOpenTabs(active);
+    store.openTab(A, { lawId: 'law_a', articleNumber: 5 });
+    expect(store.tabs.value).toEqual([{ lawId: 'law_a', articleNumber: '5' }]);
+  });
+
+  it('openTab with activate:false leaves the active tab unchanged', () => {
+    const active = ref(A);
+    const store = useOpenTabs(active);
+    store.openTab(A, TAB_A1);
+    store.openTab(A, TAB_A2, { activate: false });
+    expect(store.activeTab.value).toEqual(TAB_A1);
+    expect(store.tabs.value).toEqual([TAB_A1, TAB_A2]);
+  });
+
+  it('closeTab promotes the right neighbour then the left, and PERSISTS the new active tab', () => {
+    const active = ref(A);
+    const store = useOpenTabs(active);
+    store.openTab(A, TAB_A1);
+    store.openTab(A, TAB_A2);
+    store.openTab(A, TAB_C1); // tabs [A1, A2, C1]
+    store.setActiveTab(A, TAB_A2); // middle active
+
+    const repl = store.closeTab(A, TAB_A2);
+    expect(repl).toEqual(TAB_C1); // right neighbour
+    expect(store.activeTab.value).toEqual(TAB_C1);
+    // Persisted - closing the active tab and reloading must not resurrect it.
+    expect(JSON.parse(localStorage.getItem(activeKey(A)))).toEqual(TAB_C1);
+
+    const repl2 = store.closeTab(A, TAB_C1); // no right neighbour -> left
+    expect(repl2).toEqual(TAB_A1);
+  });
+
+  it('closeTab honours the caller-provided next pick (the bar own choice)', () => {
+    const active = ref(A);
+    const store = useOpenTabs(active);
+    store.openTab(A, TAB_A1);
+    store.openTab(A, TAB_A2);
+    store.openTab(A, TAB_C1);
+    store.setActiveTab(A, TAB_C1);
+    expect(store.closeTab(A, TAB_C1, TAB_A1)).toEqual(TAB_A1);
+  });
+
+  it('closing a non-active tab keeps the active tab', () => {
+    const active = ref(A);
+    const store = useOpenTabs(active);
+    store.openTab(A, TAB_A1);
+    store.openTab(A, TAB_A2); // active A2
+    expect(store.closeTab(A, TAB_A1)).toEqual(TAB_A2);
+    expect(store.activeTab.value).toEqual(TAB_A2);
+  });
+
+  it('dropLaw removes every tab of a law, clears the active tab, cleans both keys', () => {
+    const active = ref(A);
+    const store = useOpenTabs(active);
+    store.openTab(A, TAB_A1);
+    store.openTab(A, TAB_A2);
+    store.openTab(A, TAB_C1);
+    store.setActiveTab(A, TAB_A1); // active is law_a
+
+    store.dropLaw(A, 'law_a');
+    expect(store.tabs.value).toEqual([TAB_C1]);
+    expect(store.activeTab.value).toBeNull();
+    expect(JSON.parse(localStorage.getItem(tabsKey(A)))).toEqual([TAB_C1]);
+    expect(localStorage.getItem(activeKey(A))).toBeNull();
+  });
+
+  it('dropLaw keeps a different active tab', () => {
+    const active = ref(A);
+    const store = useOpenTabs(active);
+    store.openTab(A, TAB_A1);
+    store.openTab(A, TAB_C1); // active C1
+    store.dropLaw(A, 'law_a');
+    expect(store.tabs.value).toEqual([TAB_C1]);
+    expect(store.activeTab.value).toEqual(TAB_C1);
+  });
+
+  it('reorderTabs moves a tab and persists the new order', () => {
+    const active = ref(A);
+    const store = useOpenTabs(active);
+    store.openTab(A, TAB_A1);
+    store.openTab(A, TAB_A2);
+    store.openTab(A, TAB_C1);
+    store.reorderTabs(A, 0, 2);
+    expect(store.tabs.value).toEqual([TAB_A2, TAB_C1, TAB_A1]);
+    expect(JSON.parse(localStorage.getItem(tabsKey(A)))).toEqual([TAB_A2, TAB_C1, TAB_A1]);
+  });
+
+  it('publishedTrajectRef tracks the active ref', () => {
+    const active = ref(A);
+    const store = useOpenTabs(active);
+    expect(store.publishedTrajectRef.value).toBe(A);
+    active.value = B;
+    expect(store.publishedTrajectRef.value).toBe(B);
+  });
+});

--- a/frontend/src/composables/useTabRestore.js
+++ b/frontend/src/composables/useTabRestore.js
@@ -25,7 +25,7 @@ import { useLatest } from '../lib/useLatest.js';
  * @param {(ref: string|null) => Tab|null} deps.activeTabFor - saved active tab
  * @param {(ref: string|null, tab: Tab|null) => void} deps.setActiveTab
  * @param {(ref: string|null, lawId: string) => void} deps.dropLaw
- * @param {(lawId: string, article: string, ref: string|null) => Promise<void>} deps.switchLaw
+ * @param {(lawId: string, article: string, ref: string|null) => Promise<boolean>} deps.switchLaw - resolves to whether THIS call won the shared staleness race
  * @param {() => void} deps.clearLaw
  * @param {{ value: { status?: number } | null }} deps.error - useLaw's error ref
  * @param {{ replace: Function }} deps.router
@@ -99,9 +99,18 @@ export function createTabRestore({
       // Set active synchronously BEFORE the await (mirrors `selectTab`) so the
       // neutral empty state never flashes between rounds.
       setActiveTab(trajectRef, candidate);
-      await switchLaw(candidate.lawId, candidate.articleNumber, trajectRef);
+      const won = await switchLaw(candidate.lawId, candidate.articleNumber, trajectRef);
       // A newer restore superseded us: drop every write from here on.
       if (!isCurrent()) return;
+      // `switchLaw` shares one staleness token across ALL callers, so a
+      // concurrent `selectTab` / route-switch (the user clicking a different
+      // tab mid-restore) can win that race and make OUR call a silent no-op -
+      // it returns `false` and leaves `error.value`/`law.value` reflecting the
+      // OTHER call's result. Our own `isCurrent()` (a private restore token)
+      // can't see that, so without this check we'd read a foreign `error`
+      // (wrongly pruning `candidate`, or stamping the URL at a law that never
+      // loaded). Drop our writes; the winning caller drives the bar/URL.
+      if (!won) return;
 
       // Prune ONLY on a confirmed hard 404. `canPrune` gates on settled traject
       // membership: at mount the membership list is still loading and every

--- a/frontend/src/composables/useTabRestore.js
+++ b/frontend/src/composables/useTabRestore.js
@@ -1,0 +1,131 @@
+import { MAX_TABS } from '../lib/openTabsStorage.js';
+import { useLatest } from '../lib/useLatest.js';
+
+/**
+ * The editor's "open the right document when you enter a traject" flow.
+ *
+ * On entering a traject's editor WITHOUT a law in the URL - a fresh page load,
+ * a traject switch, coming back through the Home/Editor tab, or browser
+ * back/forward to the bare root - restore the last active article of *that*
+ * traject and stamp it into the URL with `router.replace`. When the URL already
+ * carries a law it wins (a deep link) and we do nothing.
+ *
+ * A remembered article whose law is a hard 404 in this traject is pruned - from
+ * the bar and from localStorage - and the next candidate is tried, so polluted
+ * storage from earlier builds heals itself. Only a `status === 404` prunes; a
+ * network error or a 5xx leaves the tab in place (per construction: a fetch
+ * that never reached the server throws a `TypeError` with no `.status`). With
+ * no candidate left we land on the neutral root.
+ *
+ * Factored out of `EditorView.vue` (which has no test file) as a dependency-
+ * injected factory so the whole cascade is unit-testable.
+ *
+ * @param {object} deps
+ * @param {(ref: string|null) => Tab[]} deps.tabsFor - current tabs for a traject
+ * @param {(ref: string|null) => Tab|null} deps.activeTabFor - saved active tab
+ * @param {(ref: string|null, tab: Tab|null) => void} deps.setActiveTab
+ * @param {(ref: string|null, lawId: string) => void} deps.dropLaw
+ * @param {(lawId: string, article: string, ref: string|null) => Promise<void>} deps.switchLaw
+ * @param {() => void} deps.clearLaw
+ * @param {{ value: { status?: number } | null }} deps.error - useLaw's error ref
+ * @param {{ replace: Function }} deps.router
+ * @param {(lawId: string|null, article: string|null) => object} deps.editorRouteFor
+ * @param {() => boolean} deps.canPrune - true once traject membership is confirmed
+ */
+export function createTabRestore({
+  tabsFor,
+  activeTabFor,
+  setActiveTab,
+  dropLaw,
+  switchLaw,
+  clearLaw,
+  error,
+  router,
+  editorRouteFor,
+  canPrune,
+}) {
+  // Supersede an in-flight restore when a newer one starts (rapid A->B->A
+  // switching): the stale restore drops its writes instead of racing the new
+  // traject's restore.
+  const claim = useLatest();
+
+  function landNeutral(trajectRef) {
+    // No document to show: unload the previous law, clear the active tab and
+    // sit on the traject's editor root ("Open een artikel vanuit de tabbalk of
+    // Home").
+    clearLaw();
+    setActiveTab(trajectRef, null);
+    router.replace(editorRouteFor(null, null));
+  }
+
+  /**
+   * Restore the last active (or first) article for `trajectRef`.
+   *
+   * @param {string|null} trajectRef
+   * @param {{ hasLawInUrl: boolean }} opts
+   */
+  async function restoreForTraject(trajectRef, { hasLawInUrl }) {
+    // The traject-less read-only editor buckets under '' and drives its own
+    // `?law=` query; never auto-open there.
+    if (!trajectRef) return;
+    // A law in the URL is an explicit open (deep link / back-forward): it wins,
+    // no restore, and the "niet beschikbaar in dit traject" page stays for a
+    // law this traject lacks.
+    if (hasLawInUrl) return;
+
+    const isCurrent = claim();
+    // The remembered article is preferred; capture it before any mutation so a
+    // later prune of its law falls back to the first surviving tab.
+    const remembered = activeTabFor(trajectRef);
+
+    // Each round opens (and validates) one candidate; a 404 prunes it and loops.
+    // `MAX_TABS` is the belt: every prune removes at least one tab, so the loop
+    // can never outrun the bucket.
+    for (let round = 0; round <= MAX_TABS; round++) {
+      const current = tabsFor(trajectRef);
+      if (current.length === 0) {
+        landNeutral(trajectRef);
+        return;
+      }
+      // Prefer the remembered article while it still exists; otherwise the
+      // first surviving tab.
+      const candidate =
+        (remembered &&
+          current.find(
+            (t) => t.lawId === remembered.lawId && t.articleNumber === remembered.articleNumber,
+          )) ||
+        current[0];
+
+      // Set active synchronously BEFORE the await (mirrors `selectTab`) so the
+      // neutral empty state never flashes between rounds.
+      setActiveTab(trajectRef, candidate);
+      await switchLaw(candidate.lawId, candidate.articleNumber, trajectRef);
+      // A newer restore superseded us: drop every write from here on.
+      if (!isCurrent()) return;
+
+      // Prune ONLY on a confirmed hard 404. `canPrune` gates on settled traject
+      // membership: at mount the membership list is still loading and every
+      // law-GET 404s, so this check must sit AFTER the await (subtle: pruning
+      // before membership settles would wipe a traject's whole bar).
+      if (error.value?.status === 404) {
+        if (canPrune()) {
+          dropLaw(trajectRef, candidate.lawId);
+          continue;
+        }
+        // Membership not yet confirmed - leave the tab and stop; a later entry
+        // (once the list loads) re-runs the restore and can prune then.
+        return;
+      }
+      // Network error / 5xx: leave the tab and its error dialog in place.
+      if (error.value) return;
+
+      // Clean load: sync the URL so a refresh / back-forward stays in step.
+      router.replace(editorRouteFor(candidate.lawId, candidate.articleNumber));
+      return;
+    }
+    // Belt tripped (should be unreachable): settle on the neutral root.
+    landNeutral(trajectRef);
+  }
+
+  return { restoreForTraject };
+}

--- a/frontend/src/composables/useTabRestore.test.js
+++ b/frontend/src/composables/useTabRestore.test.js
@@ -12,9 +12,11 @@ const T2 = { lawId: 'law_2', articleNumber: '3' };
 /**
  * Build a restore instance over a fake bucket + a fake `switchLaw` that sets
  * `error` from a `laws` status map. `laws[lawId]` is 404 | 500 | 'network' |
- * undefined(ok). `canPrune` defaults to true.
+ * undefined(ok). `switchLaw` resolves to whether THIS call won the shared
+ * staleness race (defaults to always winning; `switchWon: false` simulates a
+ * concurrent caller superseding it). `canPrune` defaults to true.
  */
-function harness({ tabs = [], active = null, laws = {}, canPrune = true } = {}) {
+function harness({ tabs = [], active = null, laws = {}, canPrune = true, switchWon = true } = {}) {
   const state = {
     tabs: [...tabs],
     active,
@@ -38,11 +40,16 @@ function harness({ tabs = [], active = null, laws = {}, canPrune = true } = {}) 
     },
     switchLaw: async (lawId) => {
       const status = laws[lawId];
+      // Model `error` as whatever is VISIBLE after the await. When this call is
+      // superseded (`switchWon: false`) the value on the shared ref belongs to
+      // the winning caller - surface it anyway, so the test proves restore
+      // ignores a foreign error (no wrong prune / URL stamp) purely on `won`.
       state.error.value =
         status === 404 ? { status: 404 }
         : status === 500 ? { status: 500 }
         : status === 'network' ? new TypeError('fetch failed')
         : null;
+      return switchWon;
     },
     clearLaw: () => { state.cleared++; },
     error: state.error,
@@ -152,5 +159,25 @@ describe('createTabRestore', () => {
     const second = restore.restoreForTraject(REF, { hasLawInUrl: false });
     await Promise.all([first, second]);
     expect(state.replaced).toEqual([{ lawId: 'law_1', articleNumber: '1' }]);
+  });
+
+  it('drops its writes when a concurrent caller wins the shared switchLaw race', async () => {
+    // switchLaw shares one staleness token across all callers; a concurrent
+    // selectTab / route-switch (the user clicking another tab mid-restore) can
+    // win it, making OUR switchLaw a no-op that returns false and leaves
+    // error/law reflecting the OTHER call. Restore must not stamp the URL for a
+    // candidate that never loaded, nor prune it on a foreign error.
+    const { restore, state } = harness({
+      tabs: [T1],
+      active: T1,
+      // Even if the shared error looked like a 404, a superseded call must not
+      // prune: the 404 belongs to whatever the winning caller requested.
+      laws: { law_1: 404 },
+      switchWon: false,
+    });
+    await restore.restoreForTraject(REF, { hasLawInUrl: false });
+    expect(state.replaced).toEqual([]);
+    expect(state.dropped).toEqual([]);
+    expect(state.tabs).toEqual([T1]);
   });
 });

--- a/frontend/src/composables/useTabRestore.test.js
+++ b/frontend/src/composables/useTabRestore.test.js
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'vitest';
+import { createTabRestore } from './useTabRestore.js';
+
+// useTabRestore drives "open the right article when you enter a traject". These
+// pin the four landing branches, the 404 prune-cascade, the never-prune rules
+// (5xx / unconfirmed membership) and the superseded-claim guard.
+
+const REF = 'traject-a-00000001';
+const T1 = { lawId: 'law_1', articleNumber: '1' };
+const T2 = { lawId: 'law_2', articleNumber: '3' };
+
+/**
+ * Build a restore instance over a fake bucket + a fake `switchLaw` that sets
+ * `error` from a `laws` status map. `laws[lawId]` is 404 | 500 | 'network' |
+ * undefined(ok). `canPrune` defaults to true.
+ */
+function harness({ tabs = [], active = null, laws = {}, canPrune = true } = {}) {
+  const state = {
+    tabs: [...tabs],
+    active,
+    error: { value: null },
+    replaced: [],
+    dropped: [],
+    activeSetTo: [],
+    cleared: 0,
+  };
+  const restore = createTabRestore({
+    tabsFor: () => state.tabs,
+    activeTabFor: () => state.active,
+    setActiveTab: (_ref, tab) => {
+      state.active = tab;
+      state.activeSetTo.push(tab);
+    },
+    dropLaw: (_ref, lawId) => {
+      state.tabs = state.tabs.filter((t) => t.lawId !== lawId);
+      state.dropped.push(lawId);
+      if (state.active && state.active.lawId === lawId) state.active = null;
+    },
+    switchLaw: async (lawId) => {
+      const status = laws[lawId];
+      state.error.value =
+        status === 404 ? { status: 404 }
+        : status === 500 ? { status: 500 }
+        : status === 'network' ? new TypeError('fetch failed')
+        : null;
+    },
+    clearLaw: () => { state.cleared++; },
+    error: state.error,
+    router: { replace: (t) => state.replaced.push(t) },
+    editorRouteFor: (lawId, articleNumber) => ({ lawId, articleNumber }),
+    canPrune: () => canPrune,
+  });
+  return { restore, state };
+}
+
+describe('createTabRestore', () => {
+  it('does nothing for the traject-less read-only editor', async () => {
+    const { restore, state } = harness({ tabs: [T1] });
+    await restore.restoreForTraject(null, { hasLawInUrl: false });
+    expect(state.activeSetTo).toEqual([]);
+    expect(state.replaced).toEqual([]);
+  });
+
+  it('does nothing when the URL already carries a law (deep link wins)', async () => {
+    const { restore, state } = harness({ tabs: [T1] });
+    await restore.restoreForTraject(REF, { hasLawInUrl: true });
+    expect(state.activeSetTo).toEqual([]);
+    expect(state.replaced).toEqual([]);
+  });
+
+  it('restores the remembered active article and syncs the URL', async () => {
+    const { restore, state } = harness({ tabs: [T1, T2], active: T2 });
+    await restore.restoreForTraject(REF, { hasLawInUrl: false });
+    expect(state.active).toEqual(T2);
+    expect(state.replaced).toEqual([{ lawId: 'law_2', articleNumber: '3' }]);
+  });
+
+  it('falls back to the first tab when nothing is remembered', async () => {
+    const { restore, state } = harness({ tabs: [T1, T2], active: null });
+    await restore.restoreForTraject(REF, { hasLawInUrl: false });
+    expect(state.active).toEqual(T1);
+    expect(state.replaced).toEqual([{ lawId: 'law_1', articleNumber: '1' }]);
+  });
+
+  it('lands on the neutral root with no tabs', async () => {
+    const { restore, state } = harness({ tabs: [] });
+    await restore.restoreForTraject(REF, { hasLawInUrl: false });
+    expect(state.cleared).toBe(1);
+    expect(state.active).toBeNull();
+    expect(state.replaced).toEqual([{ lawId: null, articleNumber: null }]);
+  });
+
+  it('prunes a 404 tab, tries the next candidate, then the neutral root', async () => {
+    // Remembered T1 404s; T2 also 404s -> both pruned -> neutral root.
+    const { restore, state } = harness({
+      tabs: [T1, T2],
+      active: T1,
+      laws: { law_1: 404, law_2: 404 },
+    });
+    await restore.restoreForTraject(REF, { hasLawInUrl: false });
+    expect(state.dropped).toEqual(['law_1', 'law_2']);
+    expect(state.tabs).toEqual([]);
+    expect(state.replaced).toEqual([{ lawId: null, articleNumber: null }]);
+  });
+
+  it('prunes the 404 tab then opens the surviving one', async () => {
+    const { restore, state } = harness({
+      tabs: [T1, T2],
+      active: T1,
+      laws: { law_1: 404 },
+    });
+    await restore.restoreForTraject(REF, { hasLawInUrl: false });
+    expect(state.dropped).toEqual(['law_1']);
+    expect(state.tabs).toEqual([T2]);
+    expect(state.replaced).toEqual([{ lawId: 'law_2', articleNumber: '3' }]);
+  });
+
+  it('never prunes on a 5xx: leaves the tab and its error dialog', async () => {
+    const { restore, state } = harness({ tabs: [T1], active: T1, laws: { law_1: 500 } });
+    await restore.restoreForTraject(REF, { hasLawInUrl: false });
+    expect(state.dropped).toEqual([]);
+    expect(state.tabs).toEqual([T1]);
+    // No URL rewrite to a law - the error stays up.
+    expect(state.replaced).toEqual([]);
+  });
+
+  it('never prunes on a network error (no .status)', async () => {
+    const { restore, state } = harness({ tabs: [T1], active: T1, laws: { law_1: 'network' } });
+    await restore.restoreForTraject(REF, { hasLawInUrl: false });
+    expect(state.dropped).toEqual([]);
+    expect(state.tabs).toEqual([T1]);
+    expect(state.replaced).toEqual([]);
+  });
+
+  it('does not prune before traject membership is confirmed (canPrune=false)', async () => {
+    const { restore, state } = harness({
+      tabs: [T1],
+      active: T1,
+      laws: { law_1: 404 },
+      canPrune: false,
+    });
+    await restore.restoreForTraject(REF, { hasLawInUrl: false });
+    expect(state.dropped).toEqual([]);
+    expect(state.tabs).toEqual([T1]);
+  });
+
+  it('a superseded restore drops its writes', async () => {
+    const { restore, state } = harness({ tabs: [T1], active: T1 });
+    // Two overlapping restores: the first is superseded by the second before
+    // its switchLaw resolves, so only the second reaches router.replace.
+    const first = restore.restoreForTraject(REF, { hasLawInUrl: false });
+    const second = restore.restoreForTraject(REF, { hasLawInUrl: false });
+    await Promise.all([first, second]);
+    expect(state.replaced).toEqual([{ lawId: 'law_1', articleNumber: '1' }]);
+  });
+});

--- a/frontend/src/lib/openTabsStorage.js
+++ b/frontend/src/lib/openTabsStorage.js
@@ -1,0 +1,66 @@
+/**
+ * Per-traject persistence for the editor's open law tabs.
+ *
+ * The editor's tab bar is scoped to the active traject: each traject remembers
+ * its own set of open tabs and which one was active, so switching trajects
+ * swaps the bar to that traject's set instead of carrying over tabs that point
+ * at laws the new traject doesn't have.
+ *
+ * Keys follow the per-entity `regelrecht-<feature>:<id>` convention used
+ * elsewhere (cf. `useDraftNotes.js`), here `<id>` is the traject ref. All
+ * access is wrapped in try/catch with a safe default so full/disabled storage
+ * never breaks the editor - tab persistence is best-effort.
+ *
+ * A tab has the shape `{ lawId, articleNumber }`.
+ */
+
+const TABS_STORAGE_PREFIX = 'regelrecht-open-tabs:';
+const ACTIVE_TAB_STORAGE_PREFIX = 'regelrecht-active-tab:';
+
+function tabsKey(trajectRef) {
+  return `${TABS_STORAGE_PREFIX}${trajectRef ?? ''}`;
+}
+
+function activeTabKey(trajectRef) {
+  return `${ACTIVE_TAB_STORAGE_PREFIX}${trajectRef ?? ''}`;
+}
+
+/** The saved open tabs for a traject, or `[]` when there are none / on error. */
+export function loadSavedTabs(trajectRef) {
+  try {
+    const saved = localStorage.getItem(tabsKey(trajectRef));
+    const parsed = saved ? JSON.parse(saved) : [];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+/** Persist a traject's open tabs (best-effort). */
+export function saveTabs(trajectRef, tabs) {
+  try {
+    localStorage.setItem(tabsKey(trajectRef), JSON.stringify(tabs));
+  } catch {
+    /* quota/full or disabled - tabs are best-effort */
+  }
+}
+
+/** The saved active tab for a traject, or `null` when none / on error. */
+export function loadSavedActiveTab(trajectRef) {
+  try {
+    const saved = localStorage.getItem(activeTabKey(trajectRef));
+    return saved ? JSON.parse(saved) : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Persist (or clear, when `tab` is falsy) a traject's active tab. */
+export function saveActiveTab(trajectRef, tab) {
+  try {
+    if (!tab) localStorage.removeItem(activeTabKey(trajectRef));
+    else localStorage.setItem(activeTabKey(trajectRef), JSON.stringify(tab));
+  } catch {
+    /* quota/full or disabled - tabs are best-effort */
+  }
+}

--- a/frontend/src/lib/openTabsStorage.js
+++ b/frontend/src/lib/openTabsStorage.js
@@ -12,10 +12,22 @@
  * never breaks the editor - tab persistence is best-effort.
  *
  * A tab has the shape `{ lawId, articleNumber }`.
+ *
+ * Reads are sanitised (see `sanitizeTabs`): earlier builds of the per-traject
+ * feature briefly wrote one traject's law under another traject's key, and
+ * nothing validated the stored content, so that pollution outlived the write
+ * fix. Sanitising on read (drop malformed entries, normalise `articleNumber`
+ * to a string, de-duplicate, cap at `MAX_TABS`) heals such storage the moment
+ * it is loaded.
  */
 
 const TABS_STORAGE_PREFIX = 'regelrecht-open-tabs:';
 const ACTIVE_TAB_STORAGE_PREFIX = 'regelrecht-active-tab:';
+
+// Cap on how many law tabs a traject keeps open; the oldest are dropped past
+// this. Lives here (rather than in EditorView) so both the sanitising read and
+// the in-memory store (`useOpenTabs`) enforce the same bound.
+export const MAX_TABS = 20;
 
 function tabsKey(trajectRef) {
   return `${TABS_STORAGE_PREFIX}${trajectRef ?? ''}`;
@@ -25,12 +37,45 @@ function activeTabKey(trajectRef) {
   return `${ACTIVE_TAB_STORAGE_PREFIX}${trajectRef ?? ''}`;
 }
 
+/**
+ * Coerce one stored value into a valid tab `{ lawId, articleNumber }` or
+ * `null`. A tab needs a non-empty string `lawId` and an `articleNumber`; the
+ * latter is normalised to a string so a legacy numeric value and a string
+ * value never read as two different tabs.
+ */
+export function sanitizeTab(raw) {
+  if (!raw || typeof raw !== 'object') return null;
+  const { lawId, articleNumber } = raw;
+  if (typeof lawId !== 'string' || lawId === '') return null;
+  if (articleNumber == null || articleNumber === '') return null;
+  return { lawId, articleNumber: String(articleNumber) };
+}
+
+/**
+ * Sanitise a parsed tab array: drop malformed entries, normalise
+ * `articleNumber` to a string, de-duplicate by `lawId:articleNumber`
+ * (first occurrence wins) and cap at `MAX_TABS` (keeping the newest).
+ */
+export function sanitizeTabs(parsed) {
+  if (!Array.isArray(parsed)) return [];
+  const seen = new Set();
+  const clean = [];
+  for (const raw of parsed) {
+    const tab = sanitizeTab(raw);
+    if (!tab) continue;
+    const key = `${tab.lawId}:${tab.articleNumber}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    clean.push(tab);
+  }
+  return clean.length > MAX_TABS ? clean.slice(-MAX_TABS) : clean;
+}
+
 /** The saved open tabs for a traject, or `[]` when there are none / on error. */
 export function loadSavedTabs(trajectRef) {
   try {
     const saved = localStorage.getItem(tabsKey(trajectRef));
-    const parsed = saved ? JSON.parse(saved) : [];
-    return Array.isArray(parsed) ? parsed : [];
+    return sanitizeTabs(saved ? JSON.parse(saved) : []);
   } catch {
     return [];
   }
@@ -49,7 +94,7 @@ export function saveTabs(trajectRef, tabs) {
 export function loadSavedActiveTab(trajectRef) {
   try {
     const saved = localStorage.getItem(activeTabKey(trajectRef));
-    return saved ? JSON.parse(saved) : null;
+    return sanitizeTab(saved ? JSON.parse(saved) : null);
   } catch {
     return null;
   }

--- a/frontend/src/lib/openTabsStorage.test.js
+++ b/frontend/src/lib/openTabsStorage.test.js
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import {
+  loadSavedTabs,
+  saveTabs,
+  loadSavedActiveTab,
+  saveActiveTab,
+} from './openTabsStorage.js';
+
+// openTabsStorage keeps the editor's open law tabs per traject: each traject
+// ref gets its own `regelrecht-open-tabs:<ref>` / `regelrecht-active-tab:<ref>`
+// key. These pin the per-traject isolation and the try/catch safe defaults.
+
+const TAB_A = { lawId: 'wet_op_de_zorgtoeslag', articleNumber: '1' };
+const TAB_B = { lawId: 'algemene_wet_inkomensafhankelijke_regelingen', articleNumber: '7' };
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('openTabsStorage', () => {
+  it('persists and reloads tabs under a per-traject key', () => {
+    saveTabs('traject-alpha', [TAB_A, TAB_B]);
+    expect(loadSavedTabs('traject-alpha')).toEqual([TAB_A, TAB_B]);
+    expect(localStorage.getItem('regelrecht-open-tabs:traject-alpha')).toBe(
+      JSON.stringify([TAB_A, TAB_B]),
+    );
+  });
+
+  it('isolates tabs between trajects', () => {
+    saveTabs('traject-alpha', [TAB_A]);
+    saveTabs('traject-beta', [TAB_B]);
+    expect(loadSavedTabs('traject-alpha')).toEqual([TAB_A]);
+    expect(loadSavedTabs('traject-beta')).toEqual([TAB_B]);
+  });
+
+  it('returns [] for an unknown traject', () => {
+    expect(loadSavedTabs('nope')).toEqual([]);
+  });
+
+  it('returns [] when the stored value is not an array', () => {
+    localStorage.setItem('regelrecht-open-tabs:x', JSON.stringify({ not: 'an array' }));
+    expect(loadSavedTabs('x')).toEqual([]);
+  });
+
+  it('returns [] on malformed JSON instead of throwing', () => {
+    localStorage.setItem('regelrecht-open-tabs:x', '{broken');
+    expect(loadSavedTabs('x')).toEqual([]);
+  });
+
+  it('persists and reloads the active tab per traject', () => {
+    saveActiveTab('traject-alpha', TAB_A);
+    saveActiveTab('traject-beta', TAB_B);
+    expect(loadSavedActiveTab('traject-alpha')).toEqual(TAB_A);
+    expect(loadSavedActiveTab('traject-beta')).toEqual(TAB_B);
+  });
+
+  it('clears the active tab when saving a falsy value', () => {
+    saveActiveTab('traject-alpha', TAB_A);
+    saveActiveTab('traject-alpha', null);
+    expect(loadSavedActiveTab('traject-alpha')).toBeNull();
+    expect(localStorage.getItem('regelrecht-active-tab:traject-alpha')).toBeNull();
+  });
+
+  it('returns null for an unknown active tab', () => {
+    expect(loadSavedActiveTab('nope')).toBeNull();
+  });
+
+  describe('safe defaults when storage is unavailable', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('swallows write failures (e.g. quota full / disabled)', () => {
+      vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+        throw new Error('QuotaExceededError');
+      });
+      expect(() => saveTabs('t', [TAB_A])).not.toThrow();
+      expect(() => saveActiveTab('t', TAB_A)).not.toThrow();
+    });
+
+    it('returns safe defaults when reads throw', () => {
+      vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+        throw new Error('SecurityError');
+      });
+      expect(loadSavedTabs('t')).toEqual([]);
+      expect(loadSavedActiveTab('t')).toBeNull();
+    });
+  });
+});

--- a/frontend/src/lib/openTabsStorage.test.js
+++ b/frontend/src/lib/openTabsStorage.test.js
@@ -65,6 +65,67 @@ describe('openTabsStorage', () => {
     expect(loadSavedActiveTab('nope')).toBeNull();
   });
 
+  describe('sanitises stored content on read', () => {
+    it('drops entries missing lawId or articleNumber', () => {
+      localStorage.setItem(
+        'regelrecht-open-tabs:x',
+        JSON.stringify([
+          TAB_A,
+          { articleNumber: '3' }, // no lawId
+          { lawId: 'some_law' }, // no articleNumber
+          null,
+          'not-an-object',
+          TAB_B,
+        ]),
+      );
+      expect(loadSavedTabs('x')).toEqual([TAB_A, TAB_B]);
+    });
+
+    it('normalises a numeric articleNumber to a string', () => {
+      localStorage.setItem(
+        'regelrecht-open-tabs:x',
+        JSON.stringify([{ lawId: 'some_law', articleNumber: 5 }]),
+      );
+      expect(loadSavedTabs('x')).toEqual([{ lawId: 'some_law', articleNumber: '5' }]);
+    });
+
+    it('de-duplicates identical tabs (numeric vs string article collapse)', () => {
+      localStorage.setItem(
+        'regelrecht-open-tabs:x',
+        JSON.stringify([
+          { lawId: 'some_law', articleNumber: 5 },
+          { lawId: 'some_law', articleNumber: '5' },
+        ]),
+      );
+      expect(loadSavedTabs('x')).toEqual([{ lawId: 'some_law', articleNumber: '5' }]);
+    });
+
+    it('caps the stored set at MAX_TABS, keeping the newest', () => {
+      const many = Array.from({ length: 25 }, (_, i) => ({
+        lawId: `law_${i}`,
+        articleNumber: '1',
+      }));
+      localStorage.setItem('regelrecht-open-tabs:x', JSON.stringify(many));
+      const loaded = loadSavedTabs('x');
+      expect(loaded).toHaveLength(20);
+      expect(loaded[0]).toEqual({ lawId: 'law_5', articleNumber: '1' });
+      expect(loaded[19]).toEqual({ lawId: 'law_24', articleNumber: '1' });
+    });
+
+    it('drops a malformed active tab', () => {
+      localStorage.setItem('regelrecht-active-tab:x', JSON.stringify({ articleNumber: '3' }));
+      expect(loadSavedActiveTab('x')).toBeNull();
+    });
+
+    it('normalises a numeric articleNumber on the active tab', () => {
+      localStorage.setItem(
+        'regelrecht-active-tab:x',
+        JSON.stringify({ lawId: 'some_law', articleNumber: 5 }),
+      );
+      expect(loadSavedActiveTab('x')).toEqual({ lawId: 'some_law', articleNumber: '5' });
+    });
+  });
+
   describe('safe defaults when storage is unavailable', () => {
     afterEach(() => {
       vi.restoreAllMocks();

--- a/frontend/src/router.test.js
+++ b/frontend/src/router.test.js
@@ -142,11 +142,16 @@ describe('sectionTarget - traject preserved across tab switches', () => {
     expect(t.params.lawId).toBe('wet_op_de_zorgtoeslag');
   });
 
-  it('re-stamps a stale stored traject with the currently active one', () => {
+  it('drops a foreign lawId on a cross-traject editor path, landing on the editor root', () => {
+    // The stored editor path names a DIFFERENT traject: its lawId belongs to
+    // that traject and may not exist in the active one. Stamping it across gave
+    // a "niet beschikbaar in dit traject" dead end, so we now land on the active
+    // traject's editor root and let the restore-on-entry flow open the right
+    // article (same rule as trajectSwitchTarget).
     const t = sectionTarget(router, '/trajecten/old-deadbeef/editor/foo', REF);
     expect(t.name).toBe('editor-traject');
     expect(t.params.trajectRef).toBe(REF);
-    expect(t.params.lawId).toBe('foo');
+    expect(t.params.lawId).toBeUndefined();
   });
 
   it('strips the traject when none is active (Geen traject)', () => {


### PR DESCRIPTION
## Wat

De editor onthoudt nu **per traject** welke wetten-tabs open staan (en welke actief is), en herstelt die set zodra je een traject opent of ernaartoe wisselt.

## Waarom

De open tabs werden globaal in localStorage bewaard - één set voor alle trajecten. Bij een traject-switch bleven daardoor tabs openstaan die bij het nieuwe traject niet horen (ze verwijzen naar wetten die in dat traject niet bestaan). Traject-state is bedoeld als per-browser-tab state; per-traject localStorage sluit daarop aan.

## Wijzigingen

- Open tabs en de actieve tab worden per traject gekeyd op de traject-ref: `regelrecht-open-tabs:<ref>` en `regelrecht-active-tab:<ref>`, volgens de bestaande per-entity key-conventie (`regelrecht-<feature>:<id>`).
- Bij openen van / wisselen naar een traject wordt de voor dat traject opgeslagen set geladen en getoond, inclusief de bijbehorende actieve tab; de tabs van het vorige traject verdwijnen uit de tab-balk. Labels van de nieuw ingeladen tabs worden voor het nieuwe traject opgehaald.
- De localStorage-helpers zijn naar een kleine lib-module `frontend/src/lib/openTabsStorage.js` getild die op de traject-ref keyt, met `try/catch` en veilige defaults zodat volle/uitgeschakelde storage de editor niet breekt.

Bestaand gedrag binnen één traject blijft ongewijzigd: tab openen bij laden van een wet, `MAX_TABS = 20`, `selectTab`/`closeTab`/`reorderTabs` en de label-backfill.

## Scope

Puur frontend/localStorage - geen backend-/API-persistentie, geen migratie van de oude globale key (die wordt genegeerd).

## Tests

- Nieuwe unit tests voor `openTabsStorage` (per-traject isolatie, safe defaults bij malformed JSON / uitgeschakelde storage).
- Volledige frontend-testsuite groen (`vitest run`, 693 tests), productie-build groen (`vite build`).