### PR TITLE
test(frontend): e2e-specs moderniseren naar geauthenticeerde traject-routing

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -101,8 +101,11 @@ pipeline-test:
 pipeline-integration-test:
     cd packages/pipeline && {{ci_flags}} cargo test --test '*'
 
-# Run the frontend Playwright e2e specs (mocked backend, no Postgres/token needed)
-test-e2e:
+# Run the frontend Playwright e2e specs (mocked backend, no Postgres/token needed).
+# Depends on wasm-build: the scenario-execution specs run the real WASM engine
+# in-browser, so the compiled artifact under frontend/public/wasm/pkg must exist.
+# cargo caches, so the build is a near-no-op once warm.
+test-e2e: wasm-build
     npm run test:e2e -w frontend
 
 # Run all tests (engine + harvester + pipeline unit + pipeline integration + editor-api)

--- a/Justfile
+++ b/Justfile
@@ -101,6 +101,10 @@ pipeline-test:
 pipeline-integration-test:
     cd packages/pipeline && {{ci_flags}} cargo test --test '*'
 
+# Run the frontend Playwright e2e specs (mocked backend, no Postgres/token needed)
+test-e2e:
+    npm run test:e2e -w frontend
+
 # Run all tests (engine + harvester + pipeline unit + pipeline integration + editor-api)
 test-all: test harvester-test pipeline-test pipeline-integration-test editor-api-test
 

--- a/frontend/e2e/action-crud.spec.js
+++ b/frontend/e2e/action-crud.spec.js
@@ -1,5 +1,14 @@
 import { test, expect } from '@playwright/test';
-import { interceptLaw, gotoEditor, selectArticle, readYamlPane } from './helpers.js';
+import {
+  interceptLaw,
+  gotoEditor,
+  selectArticle,
+  readYamlPane,
+  setYamlPane,
+  openSheet,
+  openActionEditor,
+  saveActionSheet,
+} from './helpers.js';
 
 test.describe('Action CRUD', () => {
   test.beforeEach(async ({ page }) => {
@@ -7,19 +16,19 @@ test.describe('Action CRUD', () => {
     await gotoEditor(page);
   });
 
-  test('add a simple literal-value action', async ({ page }) => {
+  test('add an action with an arithmetic operation via the sheet', async ({ page }) => {
     await selectArticle(page, '5');
 
     // Init machine_readable
     await page.locator('[data-testid="init-mr-btn"]').click();
     await page.waitForTimeout(300);
 
-    // Click "Voeg actie toe"
+    // Click "Actie toevoegen" - a new action opens the sheet seeded with an
+    // editable EQUALS stub (see the "blocks empty save" test below).
     await page.locator('[data-testid="add-action-btn"]').click();
     await page.waitForTimeout(300);
 
-    // ActionSheet should be open
-    const panel = page.locator('nldd-sheet:visible');
+    const panel = openSheet(page);
     await expect(panel).toBeVisible();
 
     // Set output name
@@ -30,73 +39,84 @@ test.describe('Action CRUD', () => {
     }, 'bevoegd_gezag');
     await page.waitForTimeout(100);
 
-    // The operation tree should be empty for a new action with value=''
-    // The OperationSettings won't show since there's no operation
-    // Let's save and check the YAML
-    await panel.locator('nldd-button:has-text("Opslaan")').click();
-    await page.waitForTimeout(300);
+    // Switch the operation to an arithmetic ADD (needs no subject variable,
+    // so it can be completed on an otherwise-empty article) and give it a
+    // value so the save guard accepts it.
+    const typeSelect = panel.locator('[data-testid="operation-type-dropdown"] select');
+    await typeSelect.evaluate((el, val) => {
+      el.value = val;
+      el.dispatchEvent(new Event('change', { bubbles: true }));
+    }, 'ADD');
+    await page.waitForTimeout(150);
+
+    await panel.locator('[data-testid="add-value-btn"]').click();
+    await page.waitForTimeout(150);
+
+    const value0 = panel.locator('[data-testid="op-value-0"] nldd-text-field input');
+    await value0.evaluate((el, val) => {
+      el.value = val;
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    }, '5');
+    await page.waitForTimeout(100);
+
+    // Save - a complete operation now passes the guard and the sheet closes.
+    await saveActionSheet(page);
+    await expect(openSheet(page)).toHaveCount(0);
 
     // Verify YAML
     const yaml = await readYamlPane(page);
     expect(yaml.execution.actions).toHaveLength(1);
     expect(yaml.execution.actions[0].output).toBe('bevoegd_gezag');
+    expect(yaml.execution.actions[0].value.operation).toBe('ADD');
+    expect(yaml.execution.actions[0].value.values).toContain(5);
   });
 
-  test('add action with output name and literal value via YAML editing', async ({ page }) => {
+  test('author an action with a literal value via the YAML pane', async ({ page }) => {
     await selectArticle(page, '8');
+
+    // Init machine_readable, then author a literal-value action through the
+    // YAML pane - the editor's manual escape hatch for shapes the structured
+    // form does not build (a bare literal output value).
+    await page.locator('[data-testid="init-mr-btn"]').click();
+    await page.waitForTimeout(300);
+
+    await setYamlPane(page, `definitions: {}
+execution:
+  parameters: []
+  input: []
+  output: []
+  actions:
+    - output: wet_naam
+      value: Wet op de zorgtoeslag
+`);
+    await page.waitForTimeout(300);
+
+    // Verify YAML round-trips.
+    const yaml = await readYamlPane(page);
+    expect(yaml.execution.actions).toHaveLength(1);
+    expect(yaml.execution.actions[0].output).toBe('wet_naam');
+    expect(yaml.execution.actions[0].value).toBe('Wet op de zorgtoeslag');
+
+    // The action renders in the machine pane and its sheet shows the literal
+    // value verbatim (the ActionSheet's direct-value display).
+    await openActionEditor(page, 'wet_naam');
+    await expect(openSheet(page)).toContainText('Wet op de zorgtoeslag');
+  });
+
+  test('adding an action blocks saving until its seeded operation is filled', async ({ page }) => {
+    await selectArticle(page, '2');
 
     // Init machine_readable
     await page.locator('[data-testid="init-mr-btn"]').click();
     await page.waitForTimeout(300);
 
-    // Add an action
+    // Add an action and set only its output - the seeded EQUALS operation is
+    // still empty, so saving must be rejected (an incomplete operation would
+    // produce YAML the engine cannot execute).
     await page.locator('[data-testid="add-action-btn"]').click();
     await page.waitForTimeout(300);
 
-    const panel = page.locator('nldd-sheet:visible');
-
-    // Set output name
-    const outputField = panel.locator('[data-testid="action-output-field"] input');
-    await outputField.evaluate((el, val) => {
-      el.value = val;
-      el.dispatchEvent(new Event('input', { bubbles: true }));
-    }, 'wet_naam');
-    await page.waitForTimeout(100);
-
-    // Save actionsheet
-    await panel.locator('nldd-button:has-text("Opslaan")').click();
-    await page.waitForTimeout(300);
-
-    // Now manually edit the YAML to set the value (simpler than building UI for literal string values)
-    const textarea = page.locator('.editor-yaml-textarea');
-    const currentYaml = await textarea.inputValue();
-    const updatedYaml = currentYaml.replace("value: ''", "value: Wet op de zorgtoeslag");
-    await textarea.evaluate((el, val) => {
-      el.value = val;
-      el.dispatchEvent(new Event('input', { bubbles: true }));
-    }, updatedYaml);
-    await page.waitForTimeout(200);
-
-    // Read back YAML
-    const yaml = await readYamlPane(page);
-    expect(yaml.execution.actions[0].output).toBe('wet_naam');
-    expect(yaml.execution.actions[0].value).toBe('Wet op de zorgtoeslag');
-  });
-
-  test('add action with operation type and values', async ({ page }) => {
-    await selectArticle(page, '2');
-
-    // Init and add outputs first (needed for action output binding)
-    await page.locator('[data-testid="init-mr-btn"]').click();
-    await page.waitForTimeout(300);
-
-    // Add an action
-    await page.locator('[data-testid="add-action-btn"]').click();
-    await page.waitForTimeout(300);
-
-    const panel = page.locator('nldd-sheet:visible');
-
-    // Set output name
+    const panel = openSheet(page);
     const outputField = panel.locator('[data-testid="action-output-field"] input');
     await outputField.evaluate((el, val) => {
       el.value = val;
@@ -104,13 +124,12 @@ test.describe('Action CRUD', () => {
     }, 'hoogte_zorgtoeslag');
     await page.waitForTimeout(100);
 
-    // No OperationSettings visible yet because action.value is '' (not an operation)
-    // Save and verify
-    await panel.locator('nldd-button:has-text("Opslaan")').click();
-    await page.waitForTimeout(300);
+    await saveActionSheet(page);
+    await page.waitForTimeout(200);
 
-    const yaml = await readYamlPane(page);
-    expect(yaml.execution.actions).toHaveLength(1);
-    expect(yaml.execution.actions[0].output).toBe('hoogte_zorgtoeslag');
+    // The sheet stays open and the middle pane surfaces the guard message.
+    await expect(openSheet(page)).toBeVisible();
+    const banner = page.locator('nldd-banner[variant="critical"]');
+    await expect(banner).toHaveAttribute('text', /Operatie 'EQUALS' is nog niet ingevuld/);
   });
 });

--- a/frontend/e2e/action-crud.spec.js
+++ b/frontend/e2e/action-crud.spec.js
@@ -19,7 +19,7 @@ test.describe('Action CRUD', () => {
     await page.waitForTimeout(300);
 
     // ActionSheet should be open
-    const panel = page.locator('nldd-sheet');
+    const panel = page.locator('nldd-sheet:visible');
     await expect(panel).toBeVisible();
 
     // Set output name
@@ -53,7 +53,7 @@ test.describe('Action CRUD', () => {
     await page.locator('[data-testid="add-action-btn"]').click();
     await page.waitForTimeout(300);
 
-    const panel = page.locator('nldd-sheet');
+    const panel = page.locator('nldd-sheet:visible');
 
     // Set output name
     const outputField = panel.locator('[data-testid="action-output-field"] input');
@@ -94,7 +94,7 @@ test.describe('Action CRUD', () => {
     await page.locator('[data-testid="add-action-btn"]').click();
     await page.waitForTimeout(300);
 
-    const panel = page.locator('nldd-sheet');
+    const panel = page.locator('nldd-sheet:visible');
 
     // Set output name
     const outputField = panel.locator('[data-testid="action-output-field"] input');

--- a/frontend/e2e/complex-actions.spec.js
+++ b/frontend/e2e/complex-actions.spec.js
@@ -38,11 +38,10 @@ test.describe('Complex actions', () => {
   test('add action with AND operation containing comparison conditions', async ({ page }) => {
     const fixtureYaml = createFixtureWithMetadata();
 
-    await page.route('**/api/corpus/laws/wet_op_de_zorgtoeslag', route =>
+    await page.route('**/corpus/laws/wet_op_de_zorgtoeslag', route =>
       route.fulfill({ status: 200, contentType: 'text/yaml', body: fixtureYaml })
     );
-    await page.goto('/editor/wet_op_de_zorgtoeslag');
-    await page.waitForSelector('nldd-document-tab-bar-item', { timeout: 10_000 });
+    await gotoEditor(page);
 
     await selectArticle(page, '2');
     await page.waitForTimeout(300);
@@ -51,7 +50,7 @@ test.describe('Complex actions', () => {
     await page.locator('[data-testid="add-action-btn"]').click();
     await page.waitForTimeout(300);
 
-    const panel = page.locator('nldd-sheet');
+    const panel = page.locator('nldd-sheet:visible');
 
     // Set output
     const outputField = panel.locator('[data-testid="action-output-field"] input');
@@ -109,7 +108,7 @@ test.describe('Complex actions', () => {
     await page.waitForTimeout(300);
 
     // ActionSheet should show the AND operation
-    const panel2 = page.locator('nldd-sheet');
+    const panel2 = page.locator('nldd-sheet:visible');
     await expect(panel2).toBeVisible();
 
     // The ActionSheet initially selects the deepest operation in the tree.
@@ -130,11 +129,10 @@ test.describe('Complex actions', () => {
   test('add nested operation via button and verify in YAML', async ({ page }) => {
     const fixtureYaml = createFixtureWithMetadata();
 
-    await page.route('**/api/corpus/laws/wet_op_de_zorgtoeslag', route =>
+    await page.route('**/corpus/laws/wet_op_de_zorgtoeslag', route =>
       route.fulfill({ status: 200, contentType: 'text/yaml', body: fixtureYaml })
     );
-    await page.goto('/editor/wet_op_de_zorgtoeslag');
-    await page.waitForSelector('nldd-document-tab-bar-item', { timeout: 10_000 });
+    await gotoEditor(page);
 
     await selectArticle(page, '2');
     await page.waitForTimeout(300);
@@ -165,7 +163,7 @@ test.describe('Complex actions', () => {
     await actionItem.locator('nldd-button:has-text("Bewerk")').click();
     await page.waitForTimeout(300);
 
-    const panel = page.locator('nldd-sheet');
+    const panel = page.locator('nldd-sheet:visible');
 
     // Click "Voeg operatie toe" to add a nested ADD (empty values[])
     await panel.locator('[data-testid="add-nested-op-btn"]').evaluate(el => el.click());

--- a/frontend/e2e/complex-actions.spec.js
+++ b/frontend/e2e/complex-actions.spec.js
@@ -1,5 +1,14 @@
 import { test, expect } from '@playwright/test';
-import { interceptLaw, gotoEditor, selectArticle, readYamlPane } from './helpers.js';
+import {
+  gotoEditor,
+  selectArticle,
+  readYamlPane,
+  readYamlSource,
+  setYamlPane,
+  openSheet,
+  openActionEditor,
+  saveActionSheet,
+} from './helpers.js';
 import * as yaml from 'js-yaml';
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
@@ -35,7 +44,7 @@ function createFixtureWithMetadata() {
 }
 
 test.describe('Complex actions', () => {
-  test('add action with AND operation containing comparison conditions', async ({ page }) => {
+  test('AND operation with comparison conditions round-trips and renders', async ({ page }) => {
     const fixtureYaml = createFixtureWithMetadata();
 
     await page.route('**/corpus/laws/wet_op_de_zorgtoeslag', route =>
@@ -46,47 +55,25 @@ test.describe('Complex actions', () => {
     await selectArticle(page, '2');
     await page.waitForTimeout(300);
 
-    // Add an action
-    await page.locator('[data-testid="add-action-btn"]').click();
-    await page.waitForTimeout(300);
-
-    const panel = page.locator('nldd-sheet:visible');
-
-    // Set output
-    const outputField = panel.locator('[data-testid="action-output-field"] input');
-    await outputField.evaluate((el, val) => {
-      el.value = val;
-      el.dispatchEvent(new Event('input', { bubbles: true }));
-    }, 'heeft_recht_op_zorgtoeslag');
-    await page.waitForTimeout(100);
-
-    // New actions have value='' - no OperationSettings shown
-    // We need to close and use YAML editing to set up the initial operation structure
-    await panel.locator('nldd-button:has-text("Opslaan")').click();
-    await page.waitForTimeout(300);
-
-    // Edit YAML directly to set up the AND operation with conditions
-    const textarea = page.locator('.editor-yaml-textarea');
-    const currentYaml = await textarea.inputValue();
-
-    // Replace the action's value with an AND operation
+    // Author the AND operation through the YAML pane. The structured form
+    // seeds new actions with an empty EQUALS stub and won't build a nested
+    // boolean tree from scratch, so YAML is the authoring path here.
+    const currentYaml = await readYamlSource(page);
     const updatedYaml = currentYaml.replace(
-      "value: ''",
-      `value:
-            operation: AND
-            conditions:
-              - operation: GREATER_THAN_OR_EQUAL
-                subject: $leeftijd
-                value: 18
-              - operation: EQUALS
-                subject: $is_verzekerde
-                value: true`
+      'actions: []',
+      `actions:
+    - output: heeft_recht_op_zorgtoeslag
+      value:
+        operation: AND
+        conditions:
+          - operation: GREATER_THAN_OR_EQUAL
+            subject: $leeftijd
+            value: 18
+          - operation: EQUALS
+            subject: $is_verzekerde
+            value: true`
     );
-
-    await textarea.evaluate((el, val) => {
-      el.value = val;
-      el.dispatchEvent(new Event('input', { bubbles: true }));
-    }, updatedYaml);
+    await setYamlPane(page, updatedYaml);
     await page.waitForTimeout(300);
 
     // Verify YAML round-trips correctly
@@ -102,31 +89,17 @@ test.describe('Complex actions', () => {
     expect(action.value.conditions[1].subject).toBe('$is_verzekerde');
     expect(action.value.conditions[1].value).toBe(true);
 
-    // Now open the ActionSheet and verify the operation tree renders
-    const actionItem = page.locator('nldd-list-item:has(nldd-text-cell:has-text("heeft_recht_op_zorgtoeslag"))').last();
-    await actionItem.locator('nldd-button:has-text("Bewerk")').click();
-    await page.waitForTimeout(300);
+    // Open the ActionSheet and verify the operation tree renders. It opens on
+    // the root operation, so the type dropdown shows AND.
+    await openActionEditor(page, 'heeft_recht_op_zorgtoeslag');
+    const panel = openSheet(page);
+    await expect(panel).toBeVisible();
 
-    // ActionSheet should show the AND operation
-    const panel2 = page.locator('nldd-sheet:visible');
-    await expect(panel2).toBeVisible();
-
-    // The ActionSheet initially selects the deepest operation in the tree.
-    // Verify the operation settings panel rendered (has a type dropdown)
-    const typeSelect = panel2.locator('[data-testid="operation-type-dropdown"] select');
-    const currentType = await typeSelect.evaluate(el => el.value);
-    // Should be one of the comparison ops (the leaves of the AND tree)
-    expect(['EQUALS', 'GREATER_THAN_OR_EQUAL']).toContain(currentType);
-
-    // Verify the "Bovenliggende operaties" section is shown (since we're viewing a child)
-    await expect(panel2.locator('text=Bovenliggende operaties')).toBeVisible();
-
-    // Close
-    await panel2.locator('nldd-button:has-text("Opslaan")').click();
-    await page.waitForTimeout(200);
+    const typeSelect = panel.locator('[data-testid="operation-type-dropdown"] select');
+    expect(await typeSelect.evaluate(el => el.value)).toBe('AND');
   });
 
-  test('add nested operation via button and verify in YAML', async ({ page }) => {
+  test('turning a value into an empty nested operation blocks the save', async ({ page }) => {
     const fixtureYaml = createFixtureWithMetadata();
 
     await page.route('**/corpus/laws/wet_op_de_zorgtoeslag', route =>
@@ -137,11 +110,8 @@ test.describe('Complex actions', () => {
     await selectArticle(page, '2');
     await page.waitForTimeout(300);
 
-    // Set up an action with a MAX operation via YAML editing
-    const textarea = page.locator('.editor-yaml-textarea');
-    const currentYaml = await textarea.inputValue();
-
-    // Replace "actions: []" with a real action
+    // Author an action with a MAX operation over a single literal value.
+    const currentYaml = await readYamlSource(page);
     const updatedYaml = currentYaml.replace(
       'actions: []',
       `actions:
@@ -151,35 +121,28 @@ test.describe('Complex actions', () => {
         values:
           - 0`
     );
-
-    await textarea.evaluate((el, val) => {
-      el.value = val;
-      el.dispatchEvent(new Event('input', { bubbles: true }));
-    }, updatedYaml);
+    await setYamlPane(page, updatedYaml);
     await page.waitForTimeout(300);
 
-    // Open the action sheet
-    const actionItem = page.locator('nldd-list-item:has(nldd-text-cell:has-text("hoogte_zorgtoeslag"))').last();
-    await actionItem.locator('nldd-button:has-text("Bewerk")').click();
-    await page.waitForTimeout(300);
+    await openActionEditor(page, 'hoogte_zorgtoeslag');
+    const panel = openSheet(page);
 
-    const panel = page.locator('nldd-sheet:visible');
-
-    // Click "Voeg operatie toe" to add a nested ADD (empty values[])
-    await panel.locator('[data-testid="add-nested-op-btn"]').evaluate(el => el.click());
+    // Convert the literal value into a nested operation via its row-actions
+    // menu. changeValueKind seeds an empty `ADD { values: [] }` - structurally
+    // incomplete on purpose.
+    await panel
+      .locator('[data-testid="op-value-0"] nldd-menu-item[text="Operatie"]')
+      .first()
+      .evaluate((el) => el.click());
     await page.waitForTimeout(200);
 
-    // Save should be rejected because the nested ADD has no values yet -
-    // saving a structurally-incomplete operation would produce YAML the
-    // engine cannot execute.
-    await panel.locator('nldd-button:has-text("Opslaan")').click();
-    await page.waitForTimeout(300);
+    // Saving must be rejected: an empty nested operation would produce YAML
+    // the engine cannot execute.
+    await saveActionSheet(page);
+    await page.waitForTimeout(200);
 
-    // The action sheet should still be open (save was blocked)
     await expect(panel).toBeVisible();
-
-    // The middle pane should display the parse error from handleActionSave
-    const error = page.locator('.editor-parse-error-detail');
-    await expect(error).toContainText("Operatie 'ADD' is nog niet ingevuld");
+    const banner = page.locator('nldd-banner[variant="critical"]');
+    await expect(banner).toHaveAttribute('text', /Operatie 'ADD' is nog niet ingevuld/);
   });
 });

--- a/frontend/e2e/definitions.spec.js
+++ b/frontend/e2e/definitions.spec.js
@@ -15,7 +15,7 @@ test.describe('Definitions', () => {
     await page.waitForTimeout(300);
 
     // Click "Nieuwe definitie" button
-    await page.locator('nldd-button:has-text("Nieuwe definitie")').click();
+    await page.locator('[data-testid="add-def-btn"]').click();
     await waitForSheet(page);
 
     // Set name
@@ -46,7 +46,7 @@ test.describe('Definitions', () => {
     await page.waitForTimeout(300);
 
     // Add definition: drempelinkomen_alleenstaande = 3971900
-    await page.locator('nldd-button:has-text("Nieuwe definitie")').click();
+    await page.locator('[data-testid="add-def-btn"]').click();
     await waitForSheet(page);
 
     await fillSheetTextField(page, 'Naam', 'drempelinkomen_alleenstaande');

--- a/frontend/e2e/edit-test-loop.spec.js
+++ b/frontend/e2e/edit-test-loop.spec.js
@@ -4,25 +4,28 @@
  * Verifies the demo flow the editor was built for:
  *   1. Open wet_op_de_zorgtoeslag in the editor.
  *   2. Observe the *Minderjarige heeft geen recht op zorgtoeslag* scenario is
- *      red (badge = ✗) - age check isn't in the law's machine_readable.
- *   3. Edit article 2's machine_readable via the middle-pane YAML editor to
- *      add a leeftijd input + an AGE-based condition to the existing AND.
+ *      failing (its result sheet reports "Mislukt") - the age check isn't in
+ *      the law's machine_readable, so a minor still qualifies.
+ *   3. Edit article 2's machine_readable via the YAML pane to add a leeftijd
+ *      input + an age condition to the existing AND.
  *   4. ScenarioBuilder auto-reexecutes against the edited YAML.
- *   5. Observe the scenario badge is now green (badge = ✓).
+ *   5. Observe the scenario result is now passing ("Geslaagd").
  *
- * This is the smoke-test for the propagation chain we just wired up:
+ * This is the smoke-test for the propagation chain:
  *   machineReadable edit → currentLawYaml computed → engine reload →
  *   ScenarioBuilder lawYaml prop → dependency reload → auto-execute.
  *
  * All corpus laws, the scenarios list, the scenario feature file, and the
  * PUT save endpoint are mocked from the on-disk corpus directory so the
- * spec doesn't need a running editor-api. This keeps it CI-friendly and
- * reproduces the real dependency graph.
+ * spec doesn't need a running editor-api. Requires the WASM engine to be
+ * built (frontend/public/wasm/pkg, via `just wasm-build`).
  */
 import { test, expect } from '@playwright/test';
 import * as yaml from 'js-yaml';
 import { loadCorpus, loadScenario, mockCorpusApi } from './helpers-corpus.js';
-import { gotoEditor } from './helpers.js';
+import { gotoEditor, readYamlSource, setYamlPane, expectScenarioResult } from './helpers.js';
+
+const MINOR = 'Minderjarige heeft geen recht';
 
 test.describe('Edit → re-execute loop', () => {
   test.beforeEach(async ({ page }) => {
@@ -35,6 +38,9 @@ test.describe('Edit → re-execute loop', () => {
   });
 
   test('Minderjarige scenario goes red → green after adding age check', async ({ page }) => {
+    // Full-corpus dependency loading + 13 scenarios executing twice (before and
+    // after the edit) needs well over the default 30s per-test budget.
+    test.setTimeout(180_000);
     const corpus = loadCorpus();
     const zorgtoeslag = corpus.get('wet_op_de_zorgtoeslag');
     expect(zorgtoeslag, 'wet_op_de_zorgtoeslag must exist in the test corpus').toBeTruthy();
@@ -54,52 +60,22 @@ test.describe('Edit → re-execute loop', () => {
     // heeft_recht_op_zorgtoeslag lives and where we need to edit.
     await gotoEditor(page, 'wet_op_de_zorgtoeslag', '2');
 
-    const minorHeader = page
-      .locator('.sb-accordion-header')
-      .filter({ hasText: 'Minderjarige' });
-    await expect(minorHeader).toBeVisible({ timeout: 30_000 });
-
-    // Wait until the badge appears (either ✓ or ✗) - meaning execution
-    // completed. The badge span has class sb-badge--pass or sb-badge--fail.
-    await minorHeader
-      .locator('.sb-badge--pass, .sb-badge--fail')
-      .first()
-      .waitFor({ timeout: 30_000 });
-
-    // Initial state: scenario is failed (age check not in the law).
-    await expect(minorHeader).toHaveClass(/sb-header--fail/);
-
-    // Toggle the middle pane to YAML view. nldd-segmented-control-item is
-    // a custom element whose click target lives in shadow DOM, so instead
-    // of clicking we synthesize the change event the way EditorApp's
-    // `onMiddlePaneChange` handler expects: it reads `event.target.value`
-    // first, then falls back to `event.detail[0]`.
-    await page.locator('[data-testid="middle-pane-toggle"]').evaluate((el) => {
-      el.value = 'yaml';
-      el.dispatchEvent(new Event('change', { bubbles: true }));
-    });
-    // Wait for Vue to re-render the YAML pane.
-    await page.waitForSelector('.editor-yaml-textarea', { timeout: 5000 });
+    // Initial state: the scenario is failing (age check not in the law), so
+    // its result sheet reports "Mislukt".
+    await expectScenarioResult(page, MINOR, 'Mislukt');
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(300);
 
     // Grab the current YAML (article 2's machine_readable), parse it,
-    // surgically add the leeftijd input and the AND condition, and write
-    // it back into the textarea.
-    const textarea = page.locator('.editor-yaml-textarea');
-    await expect(textarea).toBeVisible();
-
-    const originalYaml = await textarea.inputValue();
+    // surgically add the leeftijd input and the age condition, and write it
+    // back into the code editor.
+    const originalYaml = await readYamlSource(page);
     expect(originalYaml).toContain('heeft_recht_op_zorgtoeslag');
     const mr = yaml.load(originalYaml);
 
     // Inject leeftijd input (sourced from BRP with a literal peildatum).
-    // BRP art 1.2 requires both bsn and peildatum; we use the scenario's
-    // calculation date as a literal here.
-    //
-    // NOTE: a literal date is intentional for test isolation - the spec must
-    // remain stable regardless of the real calculation date at CI time. The
-    // canonical production pattern (see `kieswet`) references a parameter
-    // like `peildatum: $verkiezingsdatum` so the date tracks the runtime
-    // context; don't copy the literal form into corpus laws.
+    // A literal date is intentional for test isolation - the spec must remain
+    // stable regardless of the real calculation date at CI time.
     mr.execution.input.push({
       name: 'leeftijd',
       type: 'number',
@@ -114,9 +90,6 @@ test.describe('Edit → re-execute loop', () => {
     });
 
     // Append the age condition to the heeft_recht_op_zorgtoeslag AND.
-    // Assert the action is shaped the way we expect before mutating so a
-    // future refactor (e.g. top-level op change) produces a legible error
-    // instead of a bare `Cannot read properties of undefined` on .push.
     const heeftRecht = mr.execution.actions.find(
       (a) => a.output === 'heeft_recht_op_zorgtoeslag',
     );
@@ -134,29 +107,15 @@ test.describe('Edit → re-execute loop', () => {
 
     const editedYaml = yaml.dump(mr, { lineWidth: 80, noRefs: true });
 
-    // Fill the textarea by dispatching an input event; the editor's
-    // onYamlInput handler parses the text and updates machineReadable.
-    await textarea.evaluate((el, val) => {
-      el.value = val;
-      el.dispatchEvent(new Event('input', { bubbles: true }));
-    }, editedYaml);
+    // Write the edited YAML through the code editor; the editor's onYamlInput
+    // handler parses it and updates machineReadable, which re-executes the
+    // scenarios against the edited law.
+    await setYamlPane(page, editedYaml);
 
-    // Toggle back to the form view so the scenarios accordion mounts
-    // again. The middle pane only shows one of the two views at a time;
-    // remounting ScenarioBuilder kicks off its immediate `lawYaml` watch,
-    // which reloads dependencies against the edited law and re-executes.
-    await page.locator('[data-testid="middle-pane-toggle"]').evaluate((el) => {
-      el.value = 'form';
-      el.dispatchEvent(new Event('change', { bubbles: true }));
-    });
-
-    // Re-execution fires via the currentLawYaml → ScenarioBuilder lawYaml
-    // prop chain. Allow the engine + dependency reload + scenario run to
-    // complete.
-    const minorHeaderAfter = page
-      .locator('.sb-accordion-header')
-      .filter({ hasText: 'Minderjarige' })
-      .first();
-    await expect(minorHeaderAfter).toHaveClass(/sb-header--pass/, { timeout: 60_000 });
+    // Allow the engine + dependency reload + scenario re-run to complete, then
+    // re-open the result sheet: the minor now fails the age check, so the AND
+    // is false and the scenario passes ("Geslaagd").
+    await page.waitForTimeout(1000);
+    await expectScenarioResult(page, MINOR, 'Geslaagd');
   });
 });

--- a/frontend/e2e/edit-test-loop.spec.js
+++ b/frontend/e2e/edit-test-loop.spec.js
@@ -22,6 +22,7 @@
 import { test, expect } from '@playwright/test';
 import * as yaml from 'js-yaml';
 import { loadCorpus, loadScenario, mockCorpusApi } from './helpers-corpus.js';
+import { gotoEditor } from './helpers.js';
 
 test.describe('Edit → re-execute loop', () => {
   test.beforeEach(async ({ page }) => {
@@ -51,10 +52,7 @@ test.describe('Edit → re-execute loop', () => {
 
     // Navigate directly to article 2 via the route param - that's where
     // heeft_recht_op_zorgtoeslag lives and where we need to edit.
-    await page.goto('/editor/wet_op_de_zorgtoeslag/2');
-
-    // Wait for the document tab bar to render - articles loaded.
-    await page.waitForSelector('nldd-document-tab-bar-item', { timeout: 15_000 });
+    await gotoEditor(page, 'wet_op_de_zorgtoeslag', '2');
 
     const minorHeader = page
       .locator('.sb-accordion-header')

--- a/frontend/e2e/full-roundtrip.spec.js
+++ b/frontend/e2e/full-roundtrip.spec.js
@@ -16,11 +16,10 @@ test.describe('Full round-trip', () => {
     const original = loadOriginal();
     const fullYaml = loadFixture('zorgtoeslag-full.yaml');
 
-    await page.route('**/api/corpus/laws/wet_op_de_zorgtoeslag', route =>
+    await page.route('**/corpus/laws/wet_op_de_zorgtoeslag', route =>
       route.fulfill({ status: 200, contentType: 'text/yaml', body: fullYaml })
     );
-    await page.goto('/editor/wet_op_de_zorgtoeslag');
-    await page.waitForSelector('nldd-document-tab-bar-item', { timeout: 10_000 });
+    await gotoEditor(page);
 
     // Article 1a: simple definition
     await selectArticle(page, '1a');
@@ -146,7 +145,7 @@ execution:
     await actionItem.locator('nldd-button:has-text("Bewerk")').click();
     await page.waitForTimeout(300);
 
-    const panel = page.locator('nldd-sheet');
+    const panel = page.locator('nldd-sheet:visible');
     await expect(panel).toBeVisible();
 
     // Verify the operation type

--- a/frontend/e2e/full-roundtrip.spec.js
+++ b/frontend/e2e/full-roundtrip.spec.js
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { interceptLaw, gotoEditor, selectArticle, readYamlPane, loadFixture } from './helpers.js';
+import { interceptLaw, gotoEditor, selectArticle, readYamlPane, setYamlPane, openSheet, openActionEditor, loadFixture } from './helpers.js';
 import * as yaml from 'js-yaml';
 
 /**
@@ -95,7 +95,6 @@ test.describe('Full round-trip', () => {
     await page.waitForTimeout(300);
 
     // Edit YAML directly to add complete machine_readable
-    const textarea = page.locator('.editor-yaml-textarea');
     const mrYaml = `definitions:
   drempelinkomen_alleenstaande:
     value: 3971900
@@ -126,29 +125,27 @@ execution:
         value: 18
 `;
 
-    await textarea.evaluate((el, val) => {
-      el.value = val;
-      el.dispatchEvent(new Event('input', { bubbles: true }));
-    }, mrYaml);
+    await setYamlPane(page, mrYaml);
     await page.waitForTimeout(300);
 
     // Verify the machine readable view shows the data
     const mrPane = page.locator('[data-testid="machine-readable"]');
     await expect(mrPane).toContainText('drempelinkomen_alleenstaande');
-    await expect(mrPane).toContainText('BESCHIKKING');
     await expect(mrPane).toContainText('bsn');
     await expect(mrPane).toContainText('leeftijd');
     await expect(mrPane).toContainText('heeft_recht_op_zorgtoeslag');
+    // legal_character renders as an editable dropdown (label "beschikking"),
+    // so assert the bound select value rather than the raw enum text.
+    const legalBasis = mrPane.locator('select[aria-label="Juridische basis"]');
+    expect(await legalBasis.evaluate((el) => el.value)).toBe('BESCHIKKING');
 
-    // Verify the action is displayed and can be opened
-    const actionItem = page.locator('nldd-list-item:has(nldd-text-cell:has-text("heeft_recht_op_zorgtoeslag"))').last();
-    await actionItem.locator('nldd-button:has-text("Bewerk")').click();
-    await page.waitForTimeout(300);
+    // Verify the action is displayed and can be opened via its row-actions menu
+    await openActionEditor(page, 'heeft_recht_op_zorgtoeslag');
 
-    const panel = page.locator('nldd-sheet:visible');
+    const panel = openSheet(page);
     await expect(panel).toBeVisible();
 
-    // Verify the operation type
+    // Verify the operation type (opens on the root operation)
     const typeSelect = panel.locator('[data-testid="operation-type-dropdown"] select');
     const currentType = await typeSelect.evaluate(el => el.value);
     expect(currentType).toBe('GREATER_THAN_OR_EQUAL');

--- a/frontend/e2e/helpers-corpus.js
+++ b/frontend/e2e/helpers-corpus.js
@@ -72,6 +72,47 @@ export function loadCorpus(rootDir = CORPUS_ROOT) {
 }
 
 /**
+ * Recursively walk a corpus directory and collect **every** version YAML per
+ * `$id` (newest publication_date first). Returns Map<lawId, string[]>.
+ *
+ * The engine's dependency loader fetches `/corpus/laws/{id}/versions` and loads
+ * the whole version set so its date-aware resolver can pick the one in force on
+ * the scenario's calculation date. Returning only a single picked version would
+ * make a scenario dated before the latest file fail to resolve, so the versions
+ * mock must serve all of them.
+ */
+export function loadCorpusVersions(rootDir = CORPUS_ROOT) {
+  const byId = new Map();
+
+  function visit(dir) {
+    for (const entry of readdirSync(dir)) {
+      const full = resolve(dir, entry);
+      if (statSync(full).isDirectory()) {
+        visit(full);
+      } else if (entry.endsWith('.yaml')) {
+        const content = readFileSync(full, 'utf-8');
+        const idMatch = content.match(/^\$id:\s*['"]?([^'"\n]+)['"]?$/m);
+        if (!idMatch) continue;
+        const lawId = idMatch[1].trim();
+        const pubMatch = content.match(/^publication_date:\s*['"]?([^'"\n]+)['"]?$/m);
+        const pubDate = pubMatch ? pubMatch[1].trim() : '';
+        const list = byId.get(lawId) ?? [];
+        list.push({ content, pubDate });
+        byId.set(lawId, list);
+      }
+    }
+  }
+
+  visit(rootDir);
+  // Newest-first, matching the editor-api `/versions` contract.
+  for (const [id, list] of byId) {
+    list.sort((a, b) => (a.pubDate < b.pubDate ? 1 : a.pubDate > b.pubDate ? -1 : 0));
+    byId.set(id, list.map((e) => e.content));
+  }
+  return byId;
+}
+
+/**
  * Find a scenario .feature file next to a law's YAML on disk. Returns the
  * raw text or null when no scenarios directory exists for that law.
  */
@@ -201,6 +242,27 @@ export async function mockCorpusApi(page, corpus, scenarioLaw, scenarioFile) {
       status: 200,
       contentType: 'text/plain; charset=utf-8',
       body: scenarioFile,
+    });
+  });
+
+  // GET .../corpus/laws/{law_id}/versions - the full version set the engine's
+  // dependency loader pulls to run scenarios (cross-law resolution). Serve
+  // every on-disk version for real-corpus specs; for a synthetic corpus map
+  // (a spec that fabricates a law not on disk) fall back to that entry's single
+  // content. Registered last so Playwright's LIFO order checks it before the
+  // generic `/corpus/laws/*` handler.
+  const allVersions = loadCorpusVersions();
+  await page.route('**/corpus/laws/*/versions', (route, request) => {
+    const url = new URL(request.url());
+    const match = url.pathname.match(new RegExp(`${LAWS_PATH}\\/([^/]+)\\/versions$`));
+    if (!match) return route.fallback();
+    const lawId = decodeURIComponent(match[1]);
+    const versions = allVersions.get(lawId)
+      ?? (corpus.has(lawId) ? [corpus.get(lawId).content] : []);
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(versions),
     });
   });
 

--- a/frontend/e2e/helpers-corpus.js
+++ b/frontend/e2e/helpers-corpus.js
@@ -12,6 +12,15 @@ import { readFileSync, readdirSync, statSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import * as yaml from 'js-yaml';
+import { mockAuthedEditor } from './helpers.js';
+
+// Corpus law endpoints exist in two shapes: the global read-only
+// `/api/corpus/laws/...` and the authenticated, traject-scoped
+// `/api/trajects/{ref}/corpus/laws/...` the editor actually reads through. This
+// fragment matches the common `.../corpus/laws` tail of both, so one set of
+// handlers serves either caller. The Playwright route globs below drop the
+// `/api` prefix (`**` + `/corpus/laws...`) to match both for the same reason.
+const LAWS_PATH = String.raw`\/api(?:\/trajects\/[^/]+)?\/corpus\/laws`;
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -90,10 +99,15 @@ export function loadScenario(lawPath, filename) {
  * @param {string} scenarioFile - raw .feature text returned by the scenario fetch
  */
 export async function mockCorpusApi(page, corpus, scenarioLaw, scenarioFile) {
-  // GET /api/corpus/laws - list for dependency discovery (fallback handler).
-  await page.route('**/api/corpus/laws*', (route, request) => {
+  // Authenticated `/auth/status` + `/api/trajects` list/detail so the
+  // traject-scoped, `requiresAuth` editor route mounts. (Kept in the shared
+  // helper so every corpus-driven spec gets the same signed-in shape.)
+  await mockAuthedEditor(page);
+
+  // GET .../corpus/laws - list for dependency discovery (fallback handler).
+  await page.route('**/corpus/laws*', (route, request) => {
     const url = new URL(request.url());
-    if (url.pathname !== '/api/corpus/laws') {
+    if (!new RegExp(`^${LAWS_PATH}$`).test(url.pathname)) {
       return route.fallback();
     }
     const entries = [...corpus.entries()].map(([law_id, entry]) => {
@@ -113,10 +127,10 @@ export async function mockCorpusApi(page, corpus, scenarioLaw, scenarioFile) {
     });
   });
 
-  // GET /api/corpus/laws/{law_id}/outputs - list outputs from all articles.
-  await page.route('**/api/corpus/laws/*/outputs', (route, request) => {
+  // GET .../corpus/laws/{law_id}/outputs - list outputs from all articles.
+  await page.route('**/corpus/laws/*/outputs', (route, request) => {
     const url = new URL(request.url());
-    const match = url.pathname.match(/\/api\/corpus\/laws\/([^/]+)\/outputs$/);
+    const match = url.pathname.match(new RegExp(`${LAWS_PATH}\\/([^/]+)\\/outputs$`));
     if (!match) return route.fallback();
     const lawId = decodeURIComponent(match[1]);
     const entry = corpus.get(lawId);
@@ -131,10 +145,10 @@ export async function mockCorpusApi(page, corpus, scenarioLaw, scenarioFile) {
     });
   });
 
-  // GET /api/corpus/laws/{law_id} - serve from the corpus map.
-  // PUT /api/corpus/laws/{law_id} - no-op; useLaw.saveLaw() updates rawYaml
+  // GET .../corpus/laws/{law_id} - serve from the corpus map.
+  // PUT .../corpus/laws/{law_id} - no-op; useLaw.saveLaw() updates rawYaml
   // locally on success so the test doesn't need a real backend write.
-  await page.route('**/api/corpus/laws/*', (route, request) => {
+  await page.route('**/corpus/laws/*', (route, request) => {
     const url = new URL(request.url());
     const pathname = url.pathname;
     if (pathname.includes('/scenarios') || pathname.includes('/outputs')) {
@@ -155,10 +169,10 @@ export async function mockCorpusApi(page, corpus, scenarioLaw, scenarioFile) {
     });
   });
 
-  // GET /api/corpus/laws/{law_id}/scenarios - list, only for the target law.
-  await page.route('**/api/corpus/laws/*/scenarios', (route, request) => {
+  // GET .../corpus/laws/{law_id}/scenarios - list, only for the target law.
+  await page.route('**/corpus/laws/*/scenarios', (route, request) => {
     const url = new URL(request.url());
-    const match = url.pathname.match(/\/api\/corpus\/laws\/([^/]+)\/scenarios$/);
+    const match = url.pathname.match(new RegExp(`${LAWS_PATH}\\/([^/]+)\\/scenarios$`));
     if (!match) return route.fallback();
     const lawId = decodeURIComponent(match[1]);
     if (lawId === scenarioLaw.id) {
@@ -179,9 +193,9 @@ export async function mockCorpusApi(page, corpus, scenarioLaw, scenarioFile) {
   // scenario text for any law that asks. We only have one fixture so we
   // serve it for every match; tests that need multiple scenario files can
   // refine this later.
-  await page.route('**/api/corpus/laws/*/scenarios/*', (route, request) => {
+  await page.route('**/corpus/laws/*/scenarios/*', (route, request) => {
     const url = new URL(request.url());
-    const match = url.pathname.match(/\/api\/corpus\/laws\/([^/]+)\/scenarios\/([^/]+)$/);
+    const match = url.pathname.match(new RegExp(`${LAWS_PATH}\\/([^/]+)\\/scenarios\\/([^/]+)$`));
     if (!match) return route.fallback();
     return route.fulfill({
       status: 200,
@@ -198,15 +212,6 @@ export async function mockCorpusApi(page, corpus, scenarioLaw, scenarioFile) {
       body: JSON.stringify([
         { id: 'local', name: 'Local Test Corpus', source_type: 'local', priority: 1, law_count: corpus.size },
       ]),
-    }),
-  );
-
-  // /auth/status - OIDC disabled in tests; useAuth expects this shape.
-  await page.route('**/auth/status', (route) =>
-    route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ authenticated: false, oidc_configured: false }),
     }),
   );
 }

--- a/frontend/e2e/helpers.js
+++ b/frontend/e2e/helpers.js
@@ -5,6 +5,38 @@ import * as yaml from 'js-yaml';
 const FIXTURE_DIR = resolve(import.meta.dirname, 'fixtures');
 
 /**
+ * A placeholder traject ref used across the e2e mocks. It satisfies the
+ * router's `{slug}-{8hex}` shape (`[a-z0-9-]+-[0-9a-f]{8}`), so the
+ * authenticated, traject-scoped editor route accepts it and the law API
+ * hangs under `/api/trajects/${TEST_TRAJECT_REF}/corpus/...`.
+ */
+export const TEST_TRAJECT_REF = 'test-traject-0a1b2c3d';
+
+// Fake, non-personal signed-in identity for the mocked `/auth/status`. No real
+// names, emails, roles or tokens — just the shape `useAuth` reads. `.test` is a
+// reserved TLD, so the address can never resolve to a real mailbox.
+const TEST_PERSON = {
+  sub: 'e2e-test-user',
+  name: 'E2E Test',
+  email: 'e2e@example.test',
+  roles: [],
+};
+
+// Minimal traject the mocked `/api/trajects` list/detail returns. `ref` MUST
+// match `TEST_TRAJECT_REF` so `useTrajects` resolves the active traject and
+// `trajectMissing` stays false; the id is any UUID whose last 8 hex chars match
+// the ref's suffix (the backend resolver keys off those).
+const TEST_TRAJECT = {
+  id: '00000000-0000-0000-0000-00000a1b2c3d',
+  ref: TEST_TRAJECT_REF,
+  name: 'E2E Test Traject',
+  description: '',
+  scope: '',
+  status: 'bezig',
+  role: 'owner',
+};
+
+/**
  * Load a YAML fixture file as a string.
  */
 export function loadFixture(name) {
@@ -12,14 +44,68 @@ export function loadFixture(name) {
 }
 
 /**
- * Intercept the law API and serve a local YAML fixture instead.
+ * Mock the auth + traject endpoints so the `requiresAuth`, traject-scoped
+ * editor routes mount under Playwright without a real backend or SSO. The
+ * router guard awaits `/auth/status` (served as authenticated here), and
+ * `useTrajects` needs the active ref present in the `/api/trajects` list.
+ *
+ * The traject detail handler only answers the bare `/api/trajects/{id}`
+ * endpoint and falls through for its `/corpus/...` sub-routes, leaving those
+ * to the corpus mocks.
+ *
+ * @param {import('@playwright/test').Page} page
+ */
+export async function mockAuthedEditor(page) {
+  await page.route('**/auth/status', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        authenticated: true,
+        oidc_configured: true,
+        person: TEST_PERSON,
+      }),
+    }),
+  );
+  // GET /api/trajects - the membership list `useTrajects` reads.
+  await page.route('**/api/trajects', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([TEST_TRAJECT]),
+    }),
+  );
+  // GET /api/trajects/{id} - single traject detail. Only the bare detail path;
+  // `/api/trajects/{ref}/corpus/...` falls through to the corpus handlers.
+  await page.route('**/api/trajects/*', (route, request) => {
+    const { pathname } = new URL(request.url());
+    if (!/^\/api\/trajects\/[^/]+$/.test(pathname)) return route.fallback();
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        ...TEST_TRAJECT,
+        members: [],
+        pending_invites: [],
+        sources: [],
+      }),
+    });
+  });
+}
+
+/**
+ * Intercept the law API and serve a local YAML fixture instead. The glob
+ * matches both the global (`/api/corpus/laws/{lawId}`) and the traject-scoped
+ * (`/api/trajects/{ref}/corpus/laws/{lawId}`) endpoint, so the authenticated
+ * editor - which reads through the active traject - is served the same fixture
+ * as any legacy global caller.
  * @param {import('@playwright/test').Page} page
  * @param {string} lawId - e.g. 'wet_op_de_zorgtoeslag'
  * @param {string} fixtureName - e.g. 'zorgtoeslag-stripped.yaml'
  */
 export async function interceptLaw(page, lawId, fixtureName) {
   const body = loadFixture(fixtureName);
-  await page.route(`**/api/corpus/laws/${lawId}`, (route) =>
+  await page.route(`**/corpus/laws/${lawId}`, (route) =>
     route.fulfill({
       status: 200,
       contentType: 'text/yaml',
@@ -28,7 +114,7 @@ export async function interceptLaw(page, lawId, fixtureName) {
   );
   // Also intercept the default law id from the fixture itself
   if (lawId !== 'wet_op_de_zorgtoeslag') {
-    await page.route('**/api/corpus/laws/wet_op_de_zorgtoeslag', (route) =>
+    await page.route('**/corpus/laws/wet_op_de_zorgtoeslag', (route) =>
       route.fulfill({
         status: 200,
         contentType: 'text/yaml',
@@ -39,44 +125,92 @@ export async function interceptLaw(page, lawId, fixtureName) {
 }
 
 /**
- * Navigate to the editor and wait for it to load.
+ * Navigate to the traject-scoped editor and wait for it to load. Sets up the
+ * auth + traject mocks first so the `requiresAuth` route mounts, then goes to
+ * `/trajecten/${TEST_TRAJECT_REF}/editor/${lawId}[/${articleNumber}]`.
  * @param {import('@playwright/test').Page} page
- * @param {string} [lawId] - law query param
+ * @param {string} [lawId] - law id path segment
+ * @param {string|number} [articleNumber] - optional article path segment
  */
-export async function gotoEditor(page, lawId = 'wet_op_de_zorgtoeslag') {
-  await page.goto(`/editor/${lawId}`);
+export async function gotoEditor(page, lawId = 'wet_op_de_zorgtoeslag', articleNumber) {
+  await mockAuthedEditor(page);
+  const article = articleNumber != null ? `/${articleNumber}` : '';
+  await page.goto(`/trajecten/${TEST_TRAJECT_REF}/editor/${lawId}${article}`);
   // Wait for the document tab bar to appear (articles loaded)
   await page.waitForSelector('nldd-document-tab-bar-item', { timeout: 10_000 });
 }
 
 /**
- * Click an article tab in the editor.
+ * Make an article the active editing target.
+ *
+ * The editor's document tab bar only lists already-open (law, article) tabs,
+ * and each item carries its label in the web component's `text` attribute
+ * (shadow DOM), not as light-DOM text. So we match on that attribute. When the
+ * requested article has no tab yet, we open it by pointing the traject-scoped
+ * editor route at that article - exactly the state opening it from the document
+ * list produces - then wait for and select its tab.
  * @param {import('@playwright/test').Page} page
  * @param {string|number} articleNumber
  */
 export async function selectArticle(page, articleNumber) {
-  const tabs = page.locator('nldd-document-tab-bar-item');
-  const count = await tabs.count();
-  for (let i = 0; i < count; i++) {
-    const text = await tabs.nth(i).textContent();
-    if (text.trim().includes(`Artikel ${articleNumber}`)) {
-      await tabs.nth(i).click();
-      // Small wait for reactivity to settle
-      await page.waitForTimeout(200);
-      return;
-    }
+  const target = String(articleNumber);
+  const tab = () =>
+    page.locator(`nldd-document-tab-bar-item[text="Artikel ${target}"]`).first();
+  if ((await tab().count()) === 0) {
+    const { pathname, search } = new URL(page.url());
+    // .../editor/{lawId}[/{article}] -> swap in (or append) the article segment.
+    const next = pathname.replace(/(\/editor\/[^/]+)(?:\/[^/]+)?$/, `$1/${target}`);
+    await page.goto(next + search);
+    await tab().waitFor({ timeout: 10_000 });
   }
-  throw new Error(`Article ${articleNumber} tab not found`);
+  await tab().click();
+  // Small wait for reactivity to settle
+  await page.waitForTimeout(200);
 }
 
 /**
- * Read the YAML textarea content and parse it.
+ * The YAML pane's code editor. The editor moved from a plain
+ * `.editor-yaml-textarea` to the design-system `nldd-code-editor` web
+ * component, bound to the selected article's machine_readable YAML.
+ * @param {import('@playwright/test').Page} page
+ */
+export function yamlEditor(page) {
+  return page.locator('nldd-code-editor').first();
+}
+
+/**
+ * Raw string content of the YAML code editor (the selected article's
+ * machine_readable, serialised). Specs that string-manipulate the YAML read
+ * this, edit it, and hand it back through {@link setYamlPane}.
+ * @param {import('@playwright/test').Page} page
+ * @returns {Promise<string>}
+ */
+export async function readYamlSource(page) {
+  return yamlEditor(page).evaluate((el) => el.value ?? '');
+}
+
+/**
+ * Replace the YAML code editor content, driving the same input path a user's
+ * keystrokes take. `nldd-code-editor` reads the new value from
+ * `event.detail.value`, so we dispatch that shape directly - robust against
+ * the component's internal editor state.
+ * @param {import('@playwright/test').Page} page
+ * @param {string} text
+ */
+export async function setYamlPane(page, text) {
+  await yamlEditor(page).evaluate((el, val) => {
+    el.value = val;
+    el.dispatchEvent(new CustomEvent('input', { detail: { value: val }, bubbles: true }));
+  }, text);
+}
+
+/**
+ * Read the YAML pane content and parse it.
  * @param {import('@playwright/test').Page} page
  * @returns {Promise<object|null>}
  */
 export async function readYamlPane(page) {
-  const textarea = page.locator('.editor-yaml-textarea');
-  const text = await textarea.inputValue();
+  const text = await readYamlSource(page);
   if (!text.trim()) return null;
   return yaml.load(text);
 }
@@ -120,11 +254,22 @@ export async function selectDropdown(container, label, value) {
 }
 
 /**
+ * The single open edit/action sheet. The editor keeps several `nldd-sheet`
+ * hosts mounted at once (one per dialog kind), all but the open one hidden, so
+ * a bare `nldd-sheet` locator is ambiguous. Filtering on visibility targets the
+ * one dialog that is actually open.
+ * @param {import('@playwright/test').Page} page
+ */
+export function openSheet(page) {
+  return page.locator('nldd-sheet:visible');
+}
+
+/**
  * Wait for the edit sheet to be visible.
  * @param {import('@playwright/test').Page} page
  */
 export async function waitForEditSheet(page) {
-  await page.locator('nldd-sheet').waitFor({ state: 'visible', timeout: 5000 });
+  await openSheet(page).first().waitFor({ state: 'visible', timeout: 5000 });
   await page.waitForTimeout(100);
 }
 
@@ -133,8 +278,7 @@ export async function waitForEditSheet(page) {
  * @param {import('@playwright/test').Page} page
  */
 export async function saveEditSheet(page) {
-  const sheet = page.locator('nldd-sheet');
-  await sheet.locator('nldd-button:has-text("Opslaan")').click();
+  await openSheet(page).locator('nldd-button:has-text("Opslaan")').click();
   await page.waitForTimeout(200);
 }
 
@@ -143,21 +287,19 @@ export async function saveEditSheet(page) {
  * @param {import('@playwright/test').Page} page
  */
 export async function saveActionSheet(page) {
-  const sheet = page.locator('nldd-sheet');
-  await sheet.locator('nldd-button:has-text("Opslaan")').click();
+  await openSheet(page).locator('nldd-button:has-text("Opslaan")').click();
   await page.waitForTimeout(200);
 }
 
 /**
- * Wait for the nldd-sheet dialog to be open (Lit component uses internal <dialog>).
+ * Wait for an nldd-sheet dialog to be open (Lit component uses internal <dialog>).
  * @param {import('@playwright/test').Page} page
  */
 export async function waitForSheet(page) {
   await page.waitForFunction(() => {
-    const sheet = document.querySelector('nldd-sheet');
-    if (!sheet) return false;
-    const dialog = sheet.shadowRoot?.querySelector('dialog');
-    return dialog?.open ?? false;
+    return [...document.querySelectorAll('nldd-sheet')].some(
+      (sheet) => sheet.shadowRoot?.querySelector('dialog')?.open ?? false,
+    );
   }, { timeout: 5000 });
   await page.waitForTimeout(200);
 }
@@ -167,7 +309,7 @@ export async function waitForSheet(page) {
  * Uses evaluate to bypass shadow DOM visibility issues.
  */
 export async function fillSheetTextField(page, labelText, value) {
-  const sheet = page.locator('nldd-sheet');
+  const sheet = openSheet(page);
   const listItem = sheet.locator(`nldd-list-item:has(nldd-text-cell:has-text("${labelText}"))`);
   const input = listItem.locator('nldd-text-field input');
   await input.evaluate((el, val) => {
@@ -181,7 +323,7 @@ export async function fillSheetTextField(page, labelText, value) {
  * Dispatches both native and custom events for Vue binding.
  */
 export async function fillSheetNumberField(page, labelText, value) {
-  const sheet = page.locator('nldd-sheet');
+  const sheet = openSheet(page);
   const listItem = sheet.locator(`nldd-list-item:has(nldd-text-cell:has-text("${labelText}"))`);
   const numberField = listItem.locator('nldd-number-field');
   await numberField.evaluate((el, val) => {
@@ -199,7 +341,7 @@ export async function fillSheetNumberField(page, labelText, value) {
  * Select a value in an nldd-dropdown inside nldd-sheet by label text.
  */
 export async function selectSheetDropdown(page, labelText, value) {
-  const sheet = page.locator('nldd-sheet');
+  const sheet = openSheet(page);
   const listItem = sheet.locator(`nldd-list-item:has(nldd-text-cell:has-text("${labelText}"))`);
   const select = listItem.locator('select');
   await select.evaluate((el, val) => {
@@ -212,8 +354,7 @@ export async function selectSheetDropdown(page, labelText, value) {
  * Click "Opslaan" in the nldd-sheet.
  */
 export async function saveSheet(page) {
-  const sheet = page.locator('nldd-sheet');
-  const btn = sheet.locator('nldd-button:has-text("Opslaan")');
+  const btn = openSheet(page).locator('nldd-button:has-text("Opslaan")');
   await btn.evaluate(el => el.click());
   await page.waitForTimeout(300);
 }

--- a/frontend/e2e/helpers.js
+++ b/frontend/e2e/helpers.js
@@ -233,6 +233,40 @@ export async function clickButton(container, text) {
 }
 
 /**
+ * Open the ActionSheet in edit mode for the machine-readable action whose
+ * output name is `output`. The row's edit affordance moved from an inline
+ * "Bewerk" button to a RowActionsMenu ("more" icon) whose Edit menu-item
+ * carries the `action-<output>-edit-btn` test-id. The menu-item lives in a
+ * closed popover, so a direct DOM click (evaluate) fires its handler without
+ * needing the popover open - the same pattern the sheet-save helpers use.
+ * @param {import('@playwright/test').Page} page
+ * @param {string} output
+ */
+export async function openActionEditor(page, output) {
+  await page
+    .locator(`[data-testid="action-${output}-edit-btn"]`)
+    .first()
+    .evaluate((el) => el.click());
+  await waitForEditSheet(page);
+}
+
+/**
+ * Remove the i-th value row of the currently selected operation in the open
+ * ActionSheet. The inline "minus" icon-button was replaced by a per-row
+ * actions menu ("more" icon) whose "Verwijder" item drives removeValue. The
+ * item sits in a closed popover, so we click it directly via the DOM.
+ * @param {import('@playwright/test').Page} page
+ * @param {number} index
+ */
+export async function removeOpValue(page, index) {
+  await openSheet(page)
+    .locator(`[data-testid="op-value-${index}"] nldd-menu-item[text="Verwijder"]`)
+    .first()
+    .evaluate((el) => el.click());
+  await page.waitForTimeout(200);
+}
+
+/**
  * Fill an nldd-text-field by label within a container.
  * The nldd-text-field wraps a native <input> in shadow DOM.
  */
@@ -274,20 +308,29 @@ export async function waitForEditSheet(page) {
 }
 
 /**
- * Click "Opslaan" in the edit sheet.
+ * Click "Opslaan" in the EditSheet (definitions / parameters / inputs /
+ * outputs). The footer save button carries a stable `edit-sheet-save-btn`
+ * test-id; the label text lives in the web component's shadow DOM, so we
+ * target the id and click through the DOM (robust against shadow visibility).
  * @param {import('@playwright/test').Page} page
  */
 export async function saveEditSheet(page) {
-  await openSheet(page).locator('nldd-button:has-text("Opslaan")').click();
+  await openSheet(page)
+    .locator('[data-testid="edit-sheet-save-btn"]')
+    .evaluate((el) => el.click());
   await page.waitForTimeout(200);
 }
 
 /**
- * Click "Opslaan" in the action sheet (nldd-sheet on main).
+ * Click "Opslaan" in the ActionSheet. The save button carries a stable
+ * `action-sheet-save-btn` test-id and only renders while editable and
+ * new/dirty.
  * @param {import('@playwright/test').Page} page
  */
 export async function saveActionSheet(page) {
-  await openSheet(page).locator('nldd-button:has-text("Opslaan")').click();
+  await openSheet(page)
+    .locator('[data-testid="action-sheet-save-btn"]')
+    .evaluate((el) => el.click());
   await page.waitForTimeout(200);
 }
 
@@ -338,6 +381,25 @@ export async function fillSheetNumberField(page, labelText, value) {
 }
 
 /**
+ * Set an nldd-combo-box value inside the open sheet by its test-id. The
+ * combo-box's change handler reads `event.detail.value`, so we dispatch that
+ * shape directly - it does not require a matching menu-item to be present,
+ * which lets a spec bind a source regulation without mocking the full law
+ * list.
+ * @param {import('@playwright/test').Page} page
+ * @param {string} testid
+ * @param {string} value
+ */
+export async function setSheetComboBox(page, testid, value) {
+  await openSheet(page)
+    .locator(`[data-testid="${testid}"]`)
+    .evaluate((el, val) => {
+      el.value = val;
+      el.dispatchEvent(new CustomEvent('change', { detail: { value: val }, bubbles: true }));
+    }, value);
+}
+
+/**
  * Select a value in an nldd-dropdown inside nldd-sheet by label text.
  */
 export async function selectSheetDropdown(page, labelText, value) {
@@ -351,10 +413,46 @@ export async function selectSheetDropdown(page, labelText, value) {
 }
 
 /**
- * Click "Opslaan" in the nldd-sheet.
+ * Poll a scenario card's result sheet until it reports the wanted status
+ * ("Mislukt" / "Geslaagd"). Scenarios auto-execute sequentially once their
+ * dependency laws finish loading, and the overview cards carry no pass/fail
+ * badge, so we (re)open the result sheet and read its outcome, retrying until
+ * execution has produced one. The result sheet reads fresh data from the
+ * scenario form on every open, so re-clicking picks up a later run. Throws with
+ * the last-seen sheet text if the status never appears within `timeout`.
+ * @param {import('@playwright/test').Page} page
+ * @param {string} title - substring of the scenario card's name
+ * @param {string} want - 'Mislukt' or 'Geslaagd'
+ * @param {number} [timeout]
+ */
+export async function expectScenarioResult(page, title, want, timeout = 60_000) {
+  const card = page.locator('nldd-card').filter({ hasText: title });
+  await card.waitFor({ state: 'visible', timeout: 30_000 });
+  const deadline = Date.now() + timeout;
+  let lastText = '';
+  while (Date.now() < deadline) {
+    await card.getByRole('button', { name: 'Resultaat' }).click();
+    const sheet = openSheet(page);
+    await sheet.waitFor({ state: 'visible', timeout: 10_000 });
+    await page.waitForTimeout(500);
+    if ((await sheet.getByText(want, { exact: false }).count()) > 0) {
+      return;
+    }
+    lastText = (await sheet.innerText().catch(() => '')) || lastText;
+    // Close and retry - a later auto-execute pass may have produced a result.
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(1000);
+  }
+  throw new Error(`scenario "${title}" never reported "${want}". Last sheet text:\n${lastText}`);
+}
+
+/**
+ * Click "Opslaan" in the EditSheet (nldd-sheet). The footer save button
+ * carries a stable `edit-sheet-save-btn` test-id and only renders once the
+ * form is dirty.
  */
 export async function saveSheet(page) {
-  const btn = openSheet(page).locator('nldd-button:has-text("Opslaan")');
+  const btn = openSheet(page).locator('[data-testid="edit-sheet-save-btn"]');
   await btn.evaluate(el => el.click());
   await page.waitForTimeout(300);
 }

--- a/frontend/e2e/inputs.spec.js
+++ b/frontend/e2e/inputs.spec.js
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { interceptLaw, gotoEditor, selectArticle, readYamlPane, waitForSheet, fillSheetTextField, selectSheetDropdown, saveSheet } from './helpers.js';
+import { interceptLaw, gotoEditor, selectArticle, readYamlPane, waitForSheet, fillSheetTextField, selectSheetDropdown, setSheetComboBox, openSheet, saveSheet } from './helpers.js';
 
 test.describe('Inputs with sources', () => {
   test.beforeEach(async ({ page }) => {
@@ -15,13 +15,20 @@ test.describe('Inputs with sources', () => {
     await page.waitForTimeout(300);
 
     // Add input: leeftijd from wet_basisregistratie_personen
-    await page.locator('nldd-button:has-text("Nieuwe input")').click();
+    await page.locator('[data-testid="add-input-btn"]').click();
     await waitForSheet(page);
 
     await fillSheetTextField(page, 'Naam', 'leeftijd');
     await selectSheetDropdown(page, 'Type', 'number');
-    await fillSheetTextField(page, 'Bron regelgeving', 'wet_basisregistratie_personen');
-    await fillSheetTextField(page, 'Bron output', 'leeftijd');
+    // Bron regelgeving is a combo-box; bind the regulation id directly. With
+    // no law-list / outputs mock, Bron output falls back to a plain text field.
+    await setSheetComboBox(page, 'law-combo-box', 'wet_basisregistratie_personen');
+    await page.waitForTimeout(100);
+    const outputField = openSheet(page).locator('[data-testid="output-text-field"] input');
+    await outputField.evaluate((el, val) => {
+      el.value = val;
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    }, 'leeftijd');
     await saveSheet(page);
 
     // Verify YAML

--- a/frontend/e2e/machine-panel-edit-loop.spec.js
+++ b/frontend/e2e/machine-panel-edit-loop.spec.js
@@ -1,55 +1,41 @@
 /**
- * Form-driven edit → re-execute loop end-to-end.
+ * Structured (Machine-panel) edit → re-execute loop end-to-end.
  *
  * Sister spec to `edit-test-loop.spec.js`. Same red → green flow on the
- * zorgtoeslag *Minderjarige* scenario, but performed entirely through the
- * structured editor on the right-hand Machine panel (EditSheet for inputs,
- * ActionSheet/OperationSettings for action operation trees) instead of the
- * middle-pane YAML textarea.
+ * zorgtoeslag *Minderjarige* scenario, but the edit that flips the result is
+ * driven through the structured operation editor (ActionSheet /
+ * OperationSettings) instead of the YAML pane.
  *
- * The intent is to lock in the workflow the user actually wants to use:
- *  - "Nieuwe input" → fill EditSheet form (incl. source.parameters) → save
- *  - "Bewerk" on the heeft_recht_op_zorgtoeslag action → ActionSheet
- *  - Add a new operation under the AND → set type to GREATER_THAN_OR_EQUAL,
- *    subject $leeftijd, value 18 → save
- *  - Scenario badge flips to green
+ * Why the setup is seeded via YAML rather than typed into the form:
+ *  - The structured editor no longer offers an "add condition" affordance on a
+ *    logical operation (AND/OR): `canAddValue` is false for logical ops, so a
+ *    fresh condition can only be introduced through YAML.
+ *  - A cross-law input whose source needs a *literal* peildatum date can't be
+ *    bound through the EditSheet's dropdown-only source-parameter controls.
+ * So the leeftijd input and a placeholder age condition (threshold 0, which a
+ * minor still passes → scenario stays red) are seeded through YAML, and the
+ * red → green flip is then performed entirely through the structured
+ * ActionSheet: navigate into the age condition and change its threshold to 18.
+ * This locks in the form-driven edit → re-execute propagation chain.
  *
- * Hand-editing YAML is the escape hatch; this is the happy path.
+ * Requires the WASM engine to be built (frontend/public/wasm/pkg).
  */
 import { test, expect } from '@playwright/test';
+import * as yaml from 'js-yaml';
 import { loadCorpus, loadScenario, mockCorpusApi } from './helpers-corpus.js';
-import { gotoEditor } from './helpers.js';
+import {
+  gotoEditor,
+  readYamlSource,
+  setYamlPane,
+  openSheet,
+  openActionEditor,
+  saveActionSheet,
+  expectScenarioResult,
+} from './helpers.js';
 
-/**
- * Wait for an nldd-sheet to be open. The host element itself doesn't change
- * `display`; visibility lives on the shadow-DOM `<dialog>`'s `open` attribute.
- */
-async function waitForSheetOpen(page, hostSelector) {
-  await page.waitForFunction((sel) => {
-    const sheet = document.querySelector(sel);
-    if (!sheet) return false;
-    const dialog = sheet.shadowRoot?.querySelector('dialog');
-    return dialog?.open === true;
-  }, hostSelector, { timeout: 5000 });
-}
+const MINOR = 'Minderjarige heeft geen recht';
 
-/**
- * Wait for an nldd-sheet to be closed (host present + shadow `<dialog>`'s
- * `open` no longer true). The host MUST be present - otherwise a typo in
- * the selector or a test ordering bug would let this helper resolve
- * immediately and silently mask the error. Pair every `waitForSheetClosed`
- * call with an opening event so the host has been mounted at least once.
- */
-async function waitForSheetClosed(page, hostSelector) {
-  await page.waitForFunction((sel) => {
-    const sheet = document.querySelector(sel);
-    if (!sheet) return false; // wait for the host to be in the DOM
-    const dialog = sheet.shadowRoot?.querySelector('dialog');
-    return dialog?.open !== true;
-  }, hostSelector, { timeout: 5000 });
-}
-
-test.describe('Edit → re-execute loop via Machine panel', () => {
+test.describe('Edit → re-execute loop via the structured operation editor', () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
       try {
@@ -58,7 +44,11 @@ test.describe('Edit → re-execute loop via Machine panel', () => {
     });
   });
 
-  test('add leeftijd input + AND condition via Machine panel turns scenario green', async ({ page }) => {
+  test('editing the age threshold via the ActionSheet turns the scenario green', async ({ page }) => {
+    // Full-corpus dependency loading + 13 scenarios executing twice needs well
+    // over the default 30s per-test budget.
+    test.setTimeout(180_000);
+
     const corpus = loadCorpus();
     const zorgtoeslag = corpus.get('wet_op_de_zorgtoeslag');
     expect(zorgtoeslag).toBeTruthy();
@@ -74,204 +64,81 @@ test.describe('Edit → re-execute loop via Machine panel', () => {
       scenarioText,
     );
 
-    // Open article 2 directly via the route param (avoids the
-    // selectArticle helper bug noted in the previous PR).
     await gotoEditor(page, 'wet_op_de_zorgtoeslag', '2');
 
-    // --- Initial state: Minderjarige scenario is red ---
-    const minorHeader = page
-      .locator('.sb-accordion-header')
-      .filter({ hasText: 'Minderjarige' })
-      .first();
-    await expect(minorHeader).toBeVisible({ timeout: 30_000 });
-    await minorHeader
-      .locator('.sb-badge--pass, .sb-badge--fail')
-      .first()
-      .waitFor({ timeout: 30_000 });
-    await expect(minorHeader).toHaveClass(/sb-header--fail/);
+    // Seed the leeftijd input + a placeholder age condition (threshold 0) into
+    // article 2's machine_readable via the YAML pane. The minor still passes
+    // age >= 0, so the scenario stays red until we tighten the threshold.
+    const originalYaml = await readYamlSource(page);
+    expect(originalYaml).toContain('heeft_recht_op_zorgtoeslag');
+    const mr = yaml.load(originalYaml);
 
-    // --- Toggle right pane to Machine view ---
-    // EditorApp tags both segmented controls with data-testids so the
-    // spec doesn't have to rely on positional `.nth()` selectors that
-    // would silently break on layout reorder.
-    await page.locator('[data-testid="right-pane-toggle"]').evaluate((el) => {
-      el.value = 'machine';
-      el.dispatchEvent(new Event('change', { bubbles: true }));
+    mr.execution.input.push({
+      name: 'leeftijd',
+      type: 'number',
+      source: {
+        regulation: 'wet_basisregistratie_personen',
+        output: 'leeftijd',
+        parameters: {
+          bsn: '$bsn',
+          peildatum: '2025-01-01',
+        },
+      },
     });
-    // Wait for the Machine panel to render the existing inputs section.
-    await page.waitForSelector('[data-testid="machine-readable"]', { timeout: 5_000 });
-    await page.waitForSelector('[data-testid="section-inputs"]', { timeout: 5_000 });
 
-    // --- Click "Nieuwe input" to open EditSheet ---
-    await page
-      .locator('[data-testid="add-input-btn"]')
-      .first()
-      .evaluate((el) => el.click());
-
-    const editSheet = page.locator('nldd-sheet.edit-sheet');
-    await waitForSheetOpen(page, 'nldd-sheet.edit-sheet');
-
-    // Helper: nldd-text-field renders an input inside its shadow DOM. The
-    // light-DOM `input` element is reachable via the locator's `>> input`
-    // descendant, but Vue listens to the host's `input` event. Set value
-    // and dispatch the input event so Vue's @input handler updates the
-    // model - same trick the existing helpers.fillSheetTextField uses.
-    async function setSheetField(label, value) {
-      const listItem = editSheet.locator('nldd-list-item').filter({
-        hasText: label,
-      });
-      const input = listItem.locator('nldd-text-field input').first();
-      await input.evaluate((el, val) => {
-        el.value = val;
-        el.dispatchEvent(new Event('input', { bubbles: true }));
-      }, value);
-    }
-
-    async function setSheetDropdown(label, value) {
-      const listItem = editSheet.locator('nldd-list-item').filter({
-        hasText: label,
-      });
-      const select = listItem.locator('select').first();
-      await select.evaluate((el, val) => {
-        el.value = val;
-        el.dispatchEvent(new Event('change', { bubbles: true }));
-      }, value);
-    }
-
-    await setSheetField('Naam', 'leeftijd');
-    await setSheetDropdown('Type', 'number');
-    await setSheetField('Bron regelgeving', 'wet_basisregistratie_personen');
-    await setSheetField('Bron output', 'leeftijd');
-
-    // --- Add source.parameters: bsn=$bsn, peildatum=2025-01-01 ---
-    // Each row's data-testid is keyed off `_rowId` (a monotonic counter)
-    // not the array index, so the testids are stable across deletions.
-    // Walk the rendered list in DOM order (which is also row order) and
-    // fill the nth-from-the-bottom row.
-    const addParamBtn = editSheet.locator('[data-testid="source-param-add-btn"]');
-    await addParamBtn.click();
-    await addParamBtn.click();
-
-    const paramRows = editSheet.locator('[data-testid="source-parameters-list"] nldd-list-item');
-    // The list ends with the "Voeg parameter toe" row, so the editable
-    // rows are the first N. Wait for both new rows to be present before
-    // filling them.
-    await expect(paramRows).toHaveCount(3); // 2 param rows + add button row
-
-    async function setParamRow(rowIdx, key, value) {
-      const row = paramRows.nth(rowIdx);
-      const inputs = row.locator('nldd-text-field input');
-      await inputs.nth(0).evaluate((el, v) => {
-        el.value = v;
-        el.dispatchEvent(new Event('input', { bubbles: true }));
-      }, key);
-      await inputs.nth(1).evaluate((el, v) => {
-        el.value = v;
-        el.dispatchEvent(new Event('input', { bubbles: true }));
-      }, value);
-    }
-    await setParamRow(0, 'bsn', '$bsn');
-    await setParamRow(1, 'peildatum', '2025-01-01');
-
-    // --- Save the EditSheet ---
-    // nldd-button renders its label via the `text` attribute through Lit's
-    // shadow DOM and the property is not reflected back, so a [text=]
-    // attribute selector or hasText filter wouldn't match the host. We
-    // tagged the save button with a data-testid for stable targeting.
-    await editSheet
-      .locator('[data-testid="edit-sheet-save-btn"]')
-      .evaluate((el) => el.click());
-    await waitForSheetClosed(page, 'nldd-sheet.edit-sheet');
-
-    // The new input should now appear in the Machine panel inputs list.
-    await expect(
-      page.locator('[data-testid="input-row-leeftijd"]'),
-    ).toBeAttached({ timeout: 5_000 });
-
-    // --- Open the heeft_recht_op_zorgtoeslag action via ActionSheet ---
-    await page
-      .locator('[data-testid="action-heeft_recht_op_zorgtoeslag-edit-btn"]')
-      .evaluate((el) => el.click());
-
-    const actionSheet = page.locator('nldd-sheet.action-sheet');
-    await waitForSheetOpen(page, 'nldd-sheet.action-sheet');
-
-    // The ActionSheet selects the LAST operation in the tree on open.
-    // For the heeft_recht AND that's one of the leaf comparisons, not the
-    // AND itself. We need to navigate up to the AND root (number "1") via
-    // the "Bovenliggende operaties" list - each row carries a stable
-    // data-testid keyed off the operation number.
-    await actionSheet
-      .locator('[data-testid="parent-op-1-edit-btn"]')
-      .evaluate((el) => el.click());
-
-    // The AND already has 3 conditions in zorgtoeslag article 2; each
-    // surfaces as a `p.value-help-text` row with a "Bewerk" link. Snapshot
-    // the count so we can assert the next click added a fourth row before
-    // we try to interact with it (otherwise `.last()` could race against
-    // Vue's flush and target the pre-existing third condition).
-    const conditionLinks = actionSheet.locator('p.value-help-text a');
-    const initialConditionCount = await conditionLinks.count();
-
-    // Now OperationSettings shows the AND. Click "Voeg operatie toe"
-    // which appends a fresh EQUALS condition to the AND's conditions[].
-    await actionSheet
-      .locator('[data-testid="add-nested-op-btn"]')
-      .click();
-
-    // Wait for the new condition's row to render before clicking it.
-    await expect(conditionLinks).toHaveCount(initialConditionCount + 1);
-
-    // The new condition appears as the last value row. Its "Bewerk" link
-    // is inside the value-help-text paragraph; clicking it selects the
-    // new operation in OperationSettings.
-    await conditionLinks.last().click();
-
-    // --- Configure the new condition ---
-    // Change operation type to GREATER_THAN_OR_EQUAL via the dropdown.
-    const opTypeDropdown = actionSheet.locator(
-      '[data-testid="operation-type-dropdown"] select',
+    const heeftRecht = mr.execution.actions.find(
+      (a) => a.output === 'heeft_recht_op_zorgtoeslag',
     );
-    await opTypeDropdown.evaluate((el) => {
-      el.value = 'GREATER_THAN_OR_EQUAL';
-      el.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(heeftRecht?.value?.operation).toBe('AND');
+    expect(Array.isArray(heeftRecht.value.conditions)).toBe(true);
+    heeftRecht.value.conditions.push({
+      operation: 'GREATER_THAN_OR_EQUAL',
+      subject: '$leeftijd',
+      value: 0,
     });
+    const seededConditionIndex = heeftRecht.value.conditions.length - 1;
 
-    // The OperationSettings now shows two rows: Onderwerp + Waarde.
-    // Onderwerp is empty (a literal '') so it renders as a text input;
-    // typing `$leeftijd` is interpreted as a variable ref by the engine.
-    const onderwerpRow = actionSheet
-      .locator('nldd-list-item')
-      .filter({ hasText: 'Onderwerp' });
-    await onderwerpRow
-      .locator('nldd-text-field input')
+    await setYamlPane(page, yaml.dump(mr, { lineWidth: 80, noRefs: true }));
+    await page.waitForTimeout(1000);
+
+    // Red: a minor passes age >= 0, so the AND is still true and the scenario
+    // (which expects no entitlement) fails.
+    await expectScenarioResult(page, MINOR, 'Mislukt');
+    // Close the (bottom-placed) result sheet before opening the ActionSheet so
+    // only one sheet is visible.
+    await openSheet(page).getByRole('button', { name: 'Sluit' }).click();
+    await expect(openSheet(page)).toHaveCount(0);
+
+    // --- Structured edit: open the action and tighten the age threshold ---
+    await openActionEditor(page, 'heeft_recht_op_zorgtoeslag');
+    // With the result sheet closed, the ActionSheet is the only visible sheet.
+    const sheet = openSheet(page);
+
+    // The sheet opens on the root AND; each condition is a nested-operation
+    // value row. Drill into the seeded age condition via its edit pencil (the
+    // icon-button's `icon` prop isn't reflected to an attribute, so target its
+    // stable `text` label).
+    await sheet
+      .locator(`[data-testid="op-value-${seededConditionIndex}"] nldd-icon-button[text="Bewerken"]`)
       .first()
-      .evaluate((el) => {
-        el.value = '$leeftijd';
-        el.dispatchEvent(new Event('input', { bubbles: true }));
-      });
-
-    const waardeRow = actionSheet
-      .locator('nldd-list-item')
-      .filter({ hasText: 'Waarde' });
-    await waardeRow
-      .locator('nldd-text-field input')
-      .first()
-      .evaluate((el) => {
-        el.value = '18';
-        el.dispatchEvent(new Event('input', { bubbles: true }));
-      });
-
-    // --- Save the ActionSheet ---
-    await actionSheet
-      .locator('[data-testid="action-sheet-save-btn"]')
       .evaluate((el) => el.click());
-    await waitForSheetClosed(page, 'nldd-sheet.action-sheet');
+    await page.waitForTimeout(200);
 
-    // --- Scenarios re-execute against the edited machine_readable ---
-    // ScenarioBuilder is still mounted in the middle pane (we never
-    // toggled it away), so the watch on `props.lawYaml` (= currentLawYaml)
-    // fires when machineReadable mutates and re-runs all scenarios.
-    await expect(minorHeader).toHaveClass(/sb-header--pass/, { timeout: 60_000 });
+    // OperationSettings now shows the comparison's Onderwerp (op-value-0) and
+    // Waarde (op-value-1). Change the threshold literal from 0 to 18.
+    const waarde = sheet.locator('[data-testid="op-value-1"] nldd-text-field input');
+    await waarde.evaluate((el) => {
+      el.value = '18';
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    await page.waitForTimeout(100);
+
+    await saveActionSheet(page);
+    await expect(openSheet(page)).toHaveCount(0);
+
+    // Green: the minor now fails age >= 18, so the AND is false, entitlement is
+    // false, and the scenario passes after re-execution.
+    await page.waitForTimeout(1000);
+    await expectScenarioResult(page, MINOR, 'Geslaagd');
   });
 });

--- a/frontend/e2e/machine-panel-edit-loop.spec.js
+++ b/frontend/e2e/machine-panel-edit-loop.spec.js
@@ -18,6 +18,7 @@
  */
 import { test, expect } from '@playwright/test';
 import { loadCorpus, loadScenario, mockCorpusApi } from './helpers-corpus.js';
+import { gotoEditor } from './helpers.js';
 
 /**
  * Wait for an nldd-sheet to be open. The host element itself doesn't change
@@ -75,8 +76,7 @@ test.describe('Edit → re-execute loop via Machine panel', () => {
 
     // Open article 2 directly via the route param (avoids the
     // selectArticle helper bug noted in the previous PR).
-    await page.goto('/editor/wet_op_de_zorgtoeslag/2');
-    await page.waitForSelector('nldd-document-tab-bar-item', { timeout: 15_000 });
+    await gotoEditor(page, 'wet_op_de_zorgtoeslag', '2');
 
     // --- Initial state: Minderjarige scenario is red ---
     const minorHeader = page

--- a/frontend/e2e/metadata-params-outputs.spec.js
+++ b/frontend/e2e/metadata-params-outputs.spec.js
@@ -15,7 +15,7 @@ test.describe('Parameters and Outputs', () => {
     await page.waitForTimeout(300);
 
     // --- Add parameter: bsn (string, required) ---
-    await page.locator('nldd-button:has-text("Nieuwe parameter")').click();
+    await page.locator('[data-testid="add-param-btn"]').click();
     await waitForSheet(page);
 
     await fillSheetTextField(page, 'Naam', 'bsn');
@@ -32,7 +32,7 @@ test.describe('Parameters and Outputs', () => {
     await expect(page.locator('[data-testid="machine-readable"]')).toContainText('bsn');
 
     // --- Add output: heeft_recht_op_zorgtoeslag (boolean) ---
-    await page.locator('nldd-button:has-text("Nieuwe output")').click();
+    await page.locator('[data-testid="add-output-btn"]').click();
     await waitForSheet(page);
 
     await fillSheetTextField(page, 'Naam', 'heeft_recht_op_zorgtoeslag');
@@ -40,7 +40,7 @@ test.describe('Parameters and Outputs', () => {
     await saveSheet(page);
 
     // --- Add output: hoogte_zorgtoeslag (amount) ---
-    await page.locator('nldd-button:has-text("Nieuwe output")').click();
+    await page.locator('[data-testid="add-output-btn"]').click();
     await waitForSheet(page);
 
     await fillSheetTextField(page, 'Naam', 'hoogte_zorgtoeslag');

--- a/frontend/e2e/metadata-params-outputs.spec.js
+++ b/frontend/e2e/metadata-params-outputs.spec.js
@@ -21,7 +21,7 @@ test.describe('Parameters and Outputs', () => {
     await fillSheetTextField(page, 'Naam', 'bsn');
 
     // Toggle required
-    const sheet = page.locator('nldd-sheet');
+    const sheet = page.locator('nldd-sheet:visible');
     const requiredSwitch = sheet.locator('nldd-switch');
     await requiredSwitch.evaluate(el => el.click());
     await page.waitForTimeout(100);

--- a/frontend/e2e/operation-binding.spec.js
+++ b/frontend/e2e/operation-binding.spec.js
@@ -1,5 +1,13 @@
 import { test, expect } from '@playwright/test';
-import { interceptLaw, gotoEditor, selectArticle, readYamlPane } from './helpers.js';
+import {
+  gotoEditor,
+  selectArticle,
+  readYamlPane,
+  openActionEditor,
+  removeOpValue,
+  saveActionSheet,
+  openSheet,
+} from './helpers.js';
 import * as yaml from 'js-yaml';
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
@@ -50,13 +58,10 @@ test.describe('Operation binding', () => {
     await selectArticle(page, '2');
     await page.waitForTimeout(300);
 
-    // Click "Bewerk" on the action in the Acties section (last list item with "resultaat")
-    const actionItems = page.locator('nldd-list-item:has(nldd-text-cell:has-text("resultaat"))');
-    await actionItems.last().locator('nldd-button:has-text("Bewerk")').click();
-    await page.waitForTimeout(300);
+    // Open the action editor for `resultaat` via its row-actions menu.
+    await openActionEditor(page, 'resultaat');
 
-    // ActionSheet should be open
-    const panel = page.locator('nldd-sheet:visible');
+    const panel = openSheet(page);
     await expect(panel).toBeVisible();
 
     // Verify the operation type is currently ADD
@@ -72,8 +77,7 @@ test.describe('Operation binding', () => {
     await page.waitForTimeout(100);
 
     // Save
-    await panel.locator('nldd-button:has-text("Opslaan")').click();
-    await page.waitForTimeout(300);
+    await saveActionSheet(page);
 
     // Verify YAML
     const parsedYaml = await readYamlPane(page);
@@ -91,12 +95,9 @@ test.describe('Operation binding', () => {
     await selectArticle(page, '2');
     await page.waitForTimeout(300);
 
-    // Click "Bewerk" on the action in the Acties section (last list item with "resultaat")
-    const actionItems = page.locator('nldd-list-item:has(nldd-text-cell:has-text("resultaat"))');
-    await actionItems.last().locator('nldd-button:has-text("Bewerk")').click();
-    await page.waitForTimeout(300);
+    await openActionEditor(page, 'resultaat');
 
-    const panel = page.locator('nldd-sheet:visible');
+    const panel = openSheet(page);
 
     // Find value 1 input (should be 10)
     const value1Input = panel.locator('[data-testid="op-value-0"] nldd-text-field input');
@@ -107,8 +108,7 @@ test.describe('Operation binding', () => {
     await page.waitForTimeout(100);
 
     // Save
-    await panel.locator('nldd-button:has-text("Opslaan")').click();
-    await page.waitForTimeout(300);
+    await saveActionSheet(page);
 
     // Verify YAML
     const parsedYaml = await readYamlPane(page);
@@ -127,20 +127,16 @@ test.describe('Operation binding', () => {
     await selectArticle(page, '2');
     await page.waitForTimeout(300);
 
-    // Click "Bewerk" on the action in the Acties section (last list item with "resultaat")
-    const actionItems = page.locator('nldd-list-item:has(nldd-text-cell:has-text("resultaat"))');
-    await actionItems.last().locator('nldd-button:has-text("Bewerk")').click();
-    await page.waitForTimeout(300);
+    await openActionEditor(page, 'resultaat');
 
-    const panel = page.locator('nldd-sheet:visible');
+    const panel = openSheet(page);
 
     // Click "Voeg waarde toe"
     await panel.locator('[data-testid="add-value-btn"]').click();
     await page.waitForTimeout(200);
 
     // Save
-    await panel.locator('nldd-button:has-text("Opslaan")').click();
-    await page.waitForTimeout(300);
+    await saveActionSheet(page);
 
     // Verify YAML - should now have 3 values
     const parsedYaml = await readYamlPane(page);
@@ -148,7 +144,7 @@ test.describe('Operation binding', () => {
     expect(parsedYaml.execution.actions[0].value.values[2]).toBe(0); // Default new value
   });
 
-  test('removing a value via minus button updates YAML', async ({ page }) => {
+  test('removing a value via the row-actions menu updates YAML', async ({ page }) => {
     const fixtureYaml = createFixtureWithAction();
 
     await page.route('**/corpus/laws/wet_op_de_zorgtoeslag', route =>
@@ -159,21 +155,13 @@ test.describe('Operation binding', () => {
     await selectArticle(page, '2');
     await page.waitForTimeout(300);
 
-    // Click "Bewerk" on the action in the Acties section (last list item with "resultaat")
-    const actionItems = page.locator('nldd-list-item:has(nldd-text-cell:has-text("resultaat"))');
-    await actionItems.last().locator('nldd-button:has-text("Bewerk")').click();
-    await page.waitForTimeout(300);
+    await openActionEditor(page, 'resultaat');
 
-    const panel = page.locator('nldd-sheet:visible');
-
-    // Click minus button on first value (nldd-icon-button may be "not visible" to Playwright)
-    const removeBtn = panel.locator('[data-testid="op-value-0"] nldd-icon-button[icon="minus"]');
-    await removeBtn.evaluate(el => el.click());
-    await page.waitForTimeout(200);
+    // Remove the first value (10) via its row-actions "Verwijder" item.
+    await removeOpValue(page, 0);
 
     // Save
-    await panel.locator('nldd-button:has-text("Opslaan")').click();
-    await page.waitForTimeout(300);
+    await saveActionSheet(page);
 
     // Verify YAML - should now have 1 value (20 remains)
     const parsedYaml = await readYamlPane(page);

--- a/frontend/e2e/operation-binding.spec.js
+++ b/frontend/e2e/operation-binding.spec.js
@@ -42,11 +42,10 @@ test.describe('Operation binding', () => {
   test('changing operation type updates YAML', async ({ page }) => {
     const fixtureYaml = createFixtureWithAction();
 
-    await page.route('**/api/corpus/laws/wet_op_de_zorgtoeslag', route =>
+    await page.route('**/corpus/laws/wet_op_de_zorgtoeslag', route =>
       route.fulfill({ status: 200, contentType: 'text/yaml', body: fixtureYaml })
     );
-    await page.goto('/editor/wet_op_de_zorgtoeslag');
-    await page.waitForSelector('nldd-document-tab-bar-item', { timeout: 10_000 });
+    await gotoEditor(page);
 
     await selectArticle(page, '2');
     await page.waitForTimeout(300);
@@ -57,7 +56,7 @@ test.describe('Operation binding', () => {
     await page.waitForTimeout(300);
 
     // ActionSheet should be open
-    const panel = page.locator('nldd-sheet');
+    const panel = page.locator('nldd-sheet:visible');
     await expect(panel).toBeVisible();
 
     // Verify the operation type is currently ADD
@@ -84,11 +83,10 @@ test.describe('Operation binding', () => {
   test('changing literal value updates YAML', async ({ page }) => {
     const fixtureYaml = createFixtureWithAction();
 
-    await page.route('**/api/corpus/laws/wet_op_de_zorgtoeslag', route =>
+    await page.route('**/corpus/laws/wet_op_de_zorgtoeslag', route =>
       route.fulfill({ status: 200, contentType: 'text/yaml', body: fixtureYaml })
     );
-    await page.goto('/editor/wet_op_de_zorgtoeslag');
-    await page.waitForSelector('nldd-document-tab-bar-item', { timeout: 10_000 });
+    await gotoEditor(page);
 
     await selectArticle(page, '2');
     await page.waitForTimeout(300);
@@ -98,7 +96,7 @@ test.describe('Operation binding', () => {
     await actionItems.last().locator('nldd-button:has-text("Bewerk")').click();
     await page.waitForTimeout(300);
 
-    const panel = page.locator('nldd-sheet');
+    const panel = page.locator('nldd-sheet:visible');
 
     // Find value 1 input (should be 10)
     const value1Input = panel.locator('[data-testid="op-value-0"] nldd-text-field input');
@@ -121,11 +119,10 @@ test.describe('Operation binding', () => {
   test('adding a value via button updates YAML', async ({ page }) => {
     const fixtureYaml = createFixtureWithAction();
 
-    await page.route('**/api/corpus/laws/wet_op_de_zorgtoeslag', route =>
+    await page.route('**/corpus/laws/wet_op_de_zorgtoeslag', route =>
       route.fulfill({ status: 200, contentType: 'text/yaml', body: fixtureYaml })
     );
-    await page.goto('/editor/wet_op_de_zorgtoeslag');
-    await page.waitForSelector('nldd-document-tab-bar-item', { timeout: 10_000 });
+    await gotoEditor(page);
 
     await selectArticle(page, '2');
     await page.waitForTimeout(300);
@@ -135,7 +132,7 @@ test.describe('Operation binding', () => {
     await actionItems.last().locator('nldd-button:has-text("Bewerk")').click();
     await page.waitForTimeout(300);
 
-    const panel = page.locator('nldd-sheet');
+    const panel = page.locator('nldd-sheet:visible');
 
     // Click "Voeg waarde toe"
     await panel.locator('[data-testid="add-value-btn"]').click();
@@ -154,11 +151,10 @@ test.describe('Operation binding', () => {
   test('removing a value via minus button updates YAML', async ({ page }) => {
     const fixtureYaml = createFixtureWithAction();
 
-    await page.route('**/api/corpus/laws/wet_op_de_zorgtoeslag', route =>
+    await page.route('**/corpus/laws/wet_op_de_zorgtoeslag', route =>
       route.fulfill({ status: 200, contentType: 'text/yaml', body: fixtureYaml })
     );
-    await page.goto('/editor/wet_op_de_zorgtoeslag');
-    await page.waitForSelector('nldd-document-tab-bar-item', { timeout: 10_000 });
+    await gotoEditor(page);
 
     await selectArticle(page, '2');
     await page.waitForTimeout(300);
@@ -168,7 +164,7 @@ test.describe('Operation binding', () => {
     await actionItems.last().locator('nldd-button:has-text("Bewerk")').click();
     await page.waitForTimeout(300);
 
-    const panel = page.locator('nldd-sheet');
+    const panel = page.locator('nldd-sheet:visible');
 
     // Click minus button on first value (nldd-icon-button may be "not visible" to Playwright)
     const removeBtn = panel.locator('[data-testid="op-value-0"] nldd-icon-button[icon="minus"]');

--- a/frontend/e2e/scenario-param-inputs.spec.js
+++ b/frontend/e2e/scenario-param-inputs.spec.js
@@ -8,7 +8,7 @@
  * (no editor-api / Postgres needed) and opens the scenario edit sheet.
  */
 import { test, expect } from '@playwright/test';
-import { loadFixture } from './helpers.js';
+import { loadFixture, gotoEditor } from './helpers.js';
 import { mockCorpusApi } from './helpers-corpus.js';
 
 // A minimal scenario that passes one parameter of each declared datatype:
@@ -46,8 +46,7 @@ test.describe('Scenario parameter input controls', () => {
   });
 
   test('renders a switch for boolean, number-field for amount, text-field for string', async ({ page }) => {
-    await page.goto('/editor/zorgtoeslagwet/2');
-    await page.waitForSelector('nldd-document-tab-bar-item', { timeout: 15_000 });
+    await gotoEditor(page, 'zorgtoeslagwet', '2');
 
     // Open the scenario edit sheet via the card's "Bewerk" button.
     const edit = page.getByRole('button', { name: 'Bewerk' }).first();


### PR DESCRIPTION
## Wat

De mocked Playwright-e2e-suite (`frontend/e2e/`) draaide niet meer: de specs
stammen van vóór de geauthenticeerde, traject-scoped editor en mikten op de
oude publieke route `/editor/:lawId`, die de router nu achter authenticatie
naar `/trajecten` redirect. Bovendien is de editor-UI sindsdien breder
geëvolueerd. Deze PR brengt de volledige suite — 11 specs, 20 testcases —
weer groen op de huidige editor, zodat `just test-e2e` een snelle, infra-loze
(geen Postgres/token) frontend-regressiesuite is.

## Wijzigingen

**Auth/routing-fundament (gedeelde helpers).**
- `mockAuthedEditor()` levert een geauthenticeerde `/auth/status` (fictieve,
  niet-persoonsgebonden identiteit) plus `/api/trajects` lijst + detail, zodat
  `requiresAuth`-routes mounten.
- `interceptLaw()` en de corpus-mocks matchen zowel `/api/corpus/laws/*` als de
  traject-scoped `/api/trajects/*/corpus/laws/*` endpoints.
- `gotoEditor()` navigeert naar `/trajecten/{ref}/editor/{lawId}[/{article}]`;
  `selectArticle()` matcht het tab-label op het shadow-DOM `text`-attribuut.
- Nieuwe read/set-helpers voor de vernieuwde YAML-pane (`nldd-code-editor`) en
  de meerdere gelijktijdig-gemounte `nldd-sheet`-dialogen.

**Interactielaag gemoderniseerd.**
- Rij-acties (bewerken/verwijderen) lopen nu via het RowActionsMenu i.p.v.
  losse "Bewerk"-knoppen; add- en save-knoppen worden op hun stabiele
  `data-testid`s aangesproken.
- Actieflows houden rekening met het nieuwe gedrag: een verse actie krijgt een
  lege `EQUALS`-operatie die leeg-opslaan blokkeert. Specs vullen de operatie
  in of controleren juist die blokkade; complexe operatiebomen worden via het
  YAML-paneel geauteurd en via de ActionSheet geverifieerd.
- Bron-regelgeving is een combo-box geworden; de input-spec bindt de regeling
  daar direct op.

**Scenario-executie (rood → groen).**
- De overzichtskaarten tonen geen pass/fail-badge meer, dus de edit→re-execute
  specs lezen de uitkomst ("Mislukt"/"Geslaagd") uit het resultaatpaneel.
- De corpus-mock bedient nu ook het `/versions`-endpoint dat de engine gebruikt
  om afhankelijke wetten te laden — zonder dat faalde elke scenario-uitvoering.
- Omdat de gestructureerde editor geen "conditie toevoegen" op een logische
  operatie meer biedt, drijft de machine-panel-spec de red→green-flip via het
  aanpassen van een bestaande conditie in de ActionSheet.

**Justfile.** `test-e2e` bouwt eerst de WASM-engine (die de scenario-specs
in-browser uitvoeren) en draait dan de Playwright-suite, zodat de suite
zichzelf bedruipt.

## Status

- **Baseline op de branch-basis:** 20/20 testcases rood (auth-bounce + drift).
- **Nu:** 20/20 groen via `just test-e2e` (twee opeenvolgende runs stabiel).

## Bewust buiten scope

Deployed-preview smoketest met echte login, en CI-integratie / uitbreiding van
`just check` (later, wanneer bewezen).
