### PR TITLE
feat(editor): sta werkdocument-upload van elk formaat toe

### DIFF
--- a/frontend/src/AppShell.vue
+++ b/frontend/src/AppShell.vue
@@ -357,7 +357,7 @@ function onTabDismiss(e) {
                 <nldd-menu-item icon="new-text-document" text="Werkdocument toevoegen">
                   <nldd-menu>
                     <nldd-menu-item icon="new-text-document" text="Nieuw document" @select="triggerNewWerkdoc"></nldd-menu-item>
-                    <nldd-menu-item icon="upload-to-cloud" text="Document uploaden (PDF, Word of Markdown)…" @select="triggerUploadWerkdoc"></nldd-menu-item>
+                    <nldd-menu-item icon="upload-to-cloud" text="Document uploaden…" @select="triggerUploadWerkdoc"></nldd-menu-item>
                   </nldd-menu>
                 </nldd-menu-item>
                 <nldd-menu-item icon="add-user" text="Leden uitnodigen…" @select="triggerInviteMembers"></nldd-menu-item>
@@ -474,7 +474,7 @@ function onTabDismiss(e) {
                 <nldd-menu-item icon="new-text-document" text="Werkdocument toevoegen">
                   <nldd-menu>
                     <nldd-menu-item icon="new-text-document" text="Nieuw document" @select="triggerNewWerkdoc"></nldd-menu-item>
-                    <nldd-menu-item icon="upload-to-cloud" text="Document uploaden (PDF, Word of Markdown)…" @select="triggerUploadWerkdoc"></nldd-menu-item>
+                    <nldd-menu-item icon="upload-to-cloud" text="Document uploaden…" @select="triggerUploadWerkdoc"></nldd-menu-item>
                   </nldd-menu>
                 </nldd-menu-item>
                 <nldd-menu-item icon="add-user" text="Leden uitnodigen…" @select="triggerInviteMembers"></nldd-menu-item>
@@ -712,7 +712,7 @@ function onTabDismiss(e) {
                 <nldd-menu-item icon="new-text-document" text="Werkdocument toevoegen">
                   <nldd-menu>
                     <nldd-menu-item icon="new-text-document" text="Nieuw document" @select="triggerNewWerkdoc"></nldd-menu-item>
-                    <nldd-menu-item icon="upload-to-cloud" text="Document uploaden (PDF, Word of Markdown)…" @select="triggerUploadWerkdoc"></nldd-menu-item>
+                    <nldd-menu-item icon="upload-to-cloud" text="Document uploaden…" @select="triggerUploadWerkdoc"></nldd-menu-item>
                   </nldd-menu>
                 </nldd-menu-item>
                 <nldd-menu-item icon="add-user" text="Leden uitnodigen…" @select="triggerInviteMembers"></nldd-menu-item>

--- a/frontend/src/LibraryView.vue
+++ b/frontend/src/LibraryView.vue
@@ -1561,7 +1561,11 @@ watch(activeTrajectRef, () => {
              Stond hij in het werkdocumenten-paneel, dan is `docFileInput` in
              taken-modus null en klikt `onUpload()` stilletjes niets aan -
              optional chaining slikt dat zonder een kik. -->
-        <input ref="docFileInput" type="file" accept=".pdf,.doc,.docx,.md,.markdown" hidden @change="onDocFileChange" />
+        <!-- No `accept` filter: werkdocumenten accept any format. Markdown is
+             stored as-is; every other format is converted server-side (a
+             deterministic tool when one fits, otherwise the enricher) and comes
+             back as a reviewable markdown werkdocument. -->
+        <input ref="docFileInput" type="file" hidden @change="onDocFileChange" />
 
         <!-- Full-page "no usable content" states (matching EditorView): shown
              instead of the split-view so the error / CTA spans the full width,
@@ -1766,7 +1770,7 @@ watch(activeTrajectRef, () => {
                     ></nldd-icon-button>
                     <nldd-menu id="werkdoc-add-menu" anchor="werkdoc-add-btn">
                       <nldd-menu-item icon="new-text-document" text="Nieuw document" @select="onDocNew"></nldd-menu-item>
-                      <nldd-menu-item icon="upload-to-cloud" text="Document uploaden (PDF, Word of Markdown)…" @select="onDocUpload"></nldd-menu-item>
+                      <nldd-menu-item icon="upload-to-cloud" text="Document uploaden…" @select="onDocUpload"></nldd-menu-item>
                     </nldd-menu>
                   </nldd-toolbar-item>
                 </nldd-toolbar>

--- a/frontend/src/composables/useTrajectDocuments.js
+++ b/frontend/src/composables/useTrajectDocuments.js
@@ -388,9 +388,11 @@ export function useTrajectDocuments(trajectRef) {
   }
 
   /**
-   * Upload a PDF/Word document. Stores the bytes server-side and enqueues an
-   * async conversion-to-markdown job; the resulting `.md` appears in the list
-   * once the job completes (surfaced meanwhile by the conversion-status
+   * Upload a document of any format. Markdown is stored as-is; any other format
+   * is stored server-side and enqueues an async conversion-to-markdown job (a
+   * deterministic tool when one fits, otherwise the enricher, returning a
+   * reviewable markdown result). The resulting `.md` appears in the list once
+   * the job/review completes (surfaced meanwhile by the conversion-status
    * poller). Returns a result object `{ ok, targetPath }`.
    */
   async function uploadDocument(file) {

--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -3075,22 +3075,43 @@ pub async fn list_traject_documents(
     Ok(Json(TrajectDocumentList { documents }))
 }
 
-/// Formats that need a conversion step to become a markdown werkdocument: they
-/// are turned into `.md` by a `document_convert` job. Also the set the wet-upload
-/// (`law_convert`) endpoint accepts.
+/// Formats the wet-upload (`law_convert`) endpoint accepts. A law upload feeds
+/// the convert-to-law chain, which is only meaningful for a text-bearing
+/// document, so this endpoint keeps a deterministic allow-list — unlike the
+/// werkdocument upload, which accepts any format (see [`upload_traject_document`]).
 const UPLOAD_DOCUMENT_EXTENSIONS: &[&str] = &["pdf", "doc", "docx"];
 
 /// Markdown is the werkdocument target format itself, so a `.md`/`.markdown`
-/// upload needs no conversion: its bytes are stored as-is (pass-through). These
-/// are accepted on top of [`UPLOAD_DOCUMENT_EXTENSIONS`] by the werkdocument
-/// upload only — a wet-upload of markdown makes no sense and stays rejected.
+/// upload needs no conversion: its bytes are stored as-is (pass-through) instead
+/// of going through a `document_convert` job.
 const MARKDOWN_PASSTHROUGH_EXTENSIONS: &[&str] = &["md", "markdown"];
 
-/// Everything the werkdocument upload accepts: the convertible formats plus the
-/// markdown pass-through set. (Kept as one array because `const` cannot
-/// concatenate slices; `werkdoc_upload_extensions_is_the_union` guards against
-/// it drifting from the two source sets.)
-const WERKDOC_UPLOAD_EXTENSIONS: &[&str] = &["pdf", "doc", "docx", "md", "markdown"];
+/// Enforce the optional upload allow-list on `filename`. `None` accepts any
+/// format (the werkdocument upload — the conversion pipeline routes it), while
+/// `Some(list)` rejects any extension outside the list with a 415 (the
+/// wet-upload). Split out of [`read_upload_multipart`] so the gate is unit-
+/// testable without building a multipart request.
+fn check_upload_format(
+    filename: &str,
+    allowed: Option<&[&str]>,
+) -> Result<(), (StatusCode, String)> {
+    let Some(allowed) = allowed else {
+        return Ok(());
+    };
+    let ext = lowercase_extension(filename);
+    if allowed.contains(&ext.as_str()) {
+        return Ok(());
+    }
+    let list = allowed
+        .iter()
+        .map(|e| format!(".{e}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    Err((
+        StatusCode::UNSUPPORTED_MEDIA_TYPE,
+        format!("Dit bestandsformaat wordt niet ondersteund. Toegestaan: {list}."),
+    ))
+}
 
 /// The lowercased file extension of `filename`, or an empty string when it has
 /// none. Shared by the upload gate and the markdown pass-through branch so the
@@ -3105,11 +3126,14 @@ fn lowercase_extension(filename: &str) -> String {
 
 /// Pull the uploaded file out of a multipart body (the `file` field) and gate
 /// its extension on `allowed`. Shared by the werkdocument- and wet-upload
-/// endpoints, which pass different allow-lists. Returns
-/// `(filename, content_type, bytes)`.
+/// endpoints: the wet-upload passes `Some(allow-list)` (only text-bearing
+/// documents feed the convert-to-law chain), while the werkdocument upload
+/// passes `None` — it accepts any format and routes non-markdown through the
+/// deterministic/agentic conversion pipeline. The empty-file guard always
+/// applies. Returns `(filename, content_type, bytes)`.
 async fn read_upload_multipart(
     multipart: &mut Multipart,
-    allowed: &[&str],
+    allowed: Option<&[&str]>,
 ) -> Result<(String, String, Vec<u8>), (StatusCode, String)> {
     let mut filename: Option<String> = None;
     let mut content_type: Option<String> = None;
@@ -3142,19 +3166,11 @@ async fn read_upload_multipart(
     ))?;
     let content_type = content_type.unwrap_or_else(|| "application/octet-stream".to_string());
 
-    // Gate on the caller-supplied allow-list.
-    let ext = lowercase_extension(&filename);
-    if !allowed.contains(&ext.as_str()) {
-        let list = allowed
-            .iter()
-            .map(|e| format!(".{e}"))
-            .collect::<Vec<_>>()
-            .join(", ");
-        return Err((
-            StatusCode::UNSUPPORTED_MEDIA_TYPE,
-            format!("Dit bestandsformaat wordt niet ondersteund. Toegestaan: {list}."),
-        ));
-    }
+    // Gate on the caller-supplied allow-list, when there is one. `None` means
+    // "accept any format" (the werkdocument upload): the empty-file check above
+    // is then the only sanity guard, and the conversion pipeline decides per
+    // format whether a deterministic tool fits or the agentic fallback runs.
+    check_upload_format(&filename, allowed)?;
     Ok((filename, content_type, data))
 }
 
@@ -3243,12 +3259,14 @@ async fn write_markdown_passthrough(
 
 /// POST /api/trajects/{traject_ref}/corpus/documents/upload
 ///
-/// Accept a multipart upload. A PDF/Word document has its bytes stored in
-/// `document_uploads` and a `document_convert` job enqueued that converts it to
-/// a markdown werkdocument (responds `202 Accepted`). A markdown upload needs no
-/// conversion: its bytes are written straight to the target `.md` (pass-through,
-/// responds `201 Created`). Either way the response carries the target `.md`
-/// path the document appears at.
+/// Accept a multipart upload of any format. A non-markdown document has its bytes
+/// stored in `document_uploads` and a `document_convert` job enqueued that
+/// converts it to a markdown werkdocument (responds `202 Accepted`) — via a
+/// deterministic tool when one fits (pandoc/pdftotext) or the agentic enricher
+/// fallback otherwise, the result returning as a reviewable markdown task. A
+/// markdown upload needs no conversion: its bytes are written straight to the
+/// target `.md` (pass-through, responds `201 Created`). Either way the response
+/// carries the target `.md` path the document appears at.
 pub async fn upload_traject_document(
     State(state): State<AppState>,
     Extension(account): Extension<AccountRecord>,
@@ -3265,11 +3283,12 @@ pub async fn upload_traject_document(
     let traject = require_traject_corpus_from_ref(&state, &session, &traject_ref).await?;
     let traject_id = resolve_traject_ref(pool, &traject_ref).await?;
 
-    // Pull the uploaded file out of the multipart body and gate the extension.
-    // Werkdocumenten also accept markdown (stored as-is, see the pass-through
-    // branch below), on top of the convertible PDF/Word formats.
-    let (filename, content_type, data) =
-        read_upload_multipart(&mut multipart, WERKDOC_UPLOAD_EXTENSIONS).await?;
+    // Pull the uploaded file out of the multipart body. Werkdocumenten accept
+    // any format (`None` = no allow-list): markdown is stored as-is (pass-through
+    // branch below), and every other format is routed through the conversion
+    // pipeline, which picks a deterministic tool when one fits (pandoc/pdftotext)
+    // or the agentic enricher fallback otherwise, returning reviewable markdown.
+    let (filename, content_type, data) = read_upload_multipart(&mut multipart, None).await?;
     let ext = lowercase_extension(&filename);
 
     // Derive a collision-safe target markdown path against the existing docs.
@@ -3450,10 +3469,10 @@ pub async fn upload_traject_law(
     let _traject = require_traject_corpus_from_ref(&state, &session, &traject_ref).await?;
     let traject_id = resolve_traject_ref(pool, &traject_ref).await?;
 
-    // Wet-upload only accepts convertible formats; markdown pass-through is a
-    // werkdocument-only affordance.
+    // Wet-upload only accepts the convertible allow-list; the werkdocument
+    // upload's any-format acceptance does not apply here.
     let (filename, content_type, data) =
-        read_upload_multipart(&mut multipart, UPLOAD_DOCUMENT_EXTENSIONS).await?;
+        read_upload_multipart(&mut multipart, Some(UPLOAD_DOCUMENT_EXTENSIONS)).await?;
 
     // Persist the bytes and enqueue the conversion job in one transaction,
     // guarded by the same per-account taak-flow-cap as enrich-op-aanvraag
@@ -4460,27 +4479,47 @@ mod tests {
     }
 
     #[test]
-    fn werkdoc_upload_extensions_is_the_union() {
-        // WERKDOC_UPLOAD_EXTENSIONS is hand-written (const can't concat slices);
-        // keep it exactly the convertible set plus the pass-through set.
-        let mut expected: Vec<&str> = UPLOAD_DOCUMENT_EXTENSIONS
-            .iter()
-            .chain(MARKDOWN_PASSTHROUGH_EXTENSIONS.iter())
-            .copied()
-            .collect();
-        expected.sort_unstable();
-        let mut actual: Vec<&str> = WERKDOC_UPLOAD_EXTENSIONS.to_vec();
-        actual.sort_unstable();
-        assert_eq!(actual, expected);
+    fn markdown_is_passthrough_but_not_a_wet_upload_format() {
+        // A markdown upload takes the werkdocument pass-through branch (its
+        // extension classifies it), but markdown is never a convertible
+        // (wet-upload) format.
+        for ext in MARKDOWN_PASSTHROUGH_EXTENSIONS {
+            assert!(!UPLOAD_DOCUMENT_EXTENSIONS.contains(ext));
+        }
     }
 
     #[test]
-    fn markdown_is_werkdoc_passthrough_but_not_a_wet_upload_format() {
-        // A markdown upload is accepted as a werkdocument and takes the
-        // pass-through branch, but is never a convertible (wet-upload) format.
-        for ext in MARKDOWN_PASSTHROUGH_EXTENSIONS {
-            assert!(WERKDOC_UPLOAD_EXTENSIONS.contains(ext));
-            assert!(!UPLOAD_DOCUMENT_EXTENSIONS.contains(ext));
+    fn check_upload_format_accepts_any_format_when_ungated() {
+        // The werkdocument upload passes `None`: any file is accepted whatever
+        // its extension — no 415 for an image, spreadsheet, presentation, or an
+        // unknown/extension-less name. The conversion pipeline decides the route.
+        for name in [
+            "scan.png",
+            "sheet.xlsx",
+            "deck.pptx",
+            "README",
+            "notes.odt",
+            "page.html",
+            "archive.weird",
+        ] {
+            assert!(
+                check_upload_format(name, None).is_ok(),
+                "{name} should be accepted by the any-format upload"
+            );
+        }
+    }
+
+    #[test]
+    fn check_upload_format_gates_on_allow_list_for_wet_upload() {
+        // The wet-upload keeps its allow-list: a non-listed format is 415, a
+        // listed one passes.
+        let err = check_upload_format("scan.png", Some(UPLOAD_DOCUMENT_EXTENSIONS)).unwrap_err();
+        assert_eq!(err.0, StatusCode::UNSUPPORTED_MEDIA_TYPE);
+        for name in ["brief.pdf", "brief.doc", "brief.docx", "BRIEF.PDF"] {
+            assert!(
+                check_upload_format(name, Some(UPLOAD_DOCUMENT_EXTENSIONS)).is_ok(),
+                "{name} should pass the wet-upload allow-list"
+            );
         }
     }
 

--- a/packages/pipeline/src/document_convert.rs
+++ b/packages/pipeline/src/document_convert.rs
@@ -1,10 +1,11 @@
-//! Document-convert jobs: turn an uploaded PDF/Word document into a clean
+//! Document-convert jobs: turn an uploaded document of any format into a clean
 //! markdown werkdocument.
 //!
 //! Known formats (docx/office via `pandoc`, PDF via `pdftotext`) are converted
 //! deterministically with a real tool — reliable, offline, and keeping the
-//! untrusted document away from the Bash-enabled LLM. Only when no tool fits
-//! does it fall back to the LLM agent subprocess that enrich uses (see
+//! untrusted document away from the Bash-enabled LLM. Any other format (the
+//! upload boundary no longer gates on an allow-list) falls back to the LLM
+//! agent subprocess that enrich uses (see
 //! [`crate::enrich::run_llm_subprocess`]), which decides for itself how to
 //! convert (pick a tool, or read it directly). This module owns the payload
 //! type, the transient upload storage helpers, the status-list query for the
@@ -401,6 +402,36 @@ pub async fn execute_document_convert(
     result
 }
 
+/// The deterministic command-line converter that handles a given extension.
+/// `pandoc` reads the office/markup formats; `pdftotext` (poppler) reads PDF.
+enum DeterministicTool {
+    Pandoc,
+    PdfToText,
+}
+
+/// The deterministic converter for `ext`, or `None` when no tool fits and the
+/// agentic (LLM) fallback must run. Single source of truth for "which formats
+/// take the fast, offline route" — both [`try_deterministic_convert`] and
+/// [`has_deterministic_converter`] read it, so the routing decision and the
+/// command dispatch can never drift apart.
+fn deterministic_tool_for(ext: &str) -> Option<DeterministicTool> {
+    match ext {
+        // pandoc reads these natively and emits GitHub-flavored Markdown.
+        "docx" | "odt" | "rtf" | "html" | "htm" | "epub" | "fb2" => Some(DeterministicTool::Pandoc),
+        // pandoc cannot read PDF; poppler's pdftotext extracts the text layer.
+        "pdf" => Some(DeterministicTool::PdfToText),
+        _ => None,
+    }
+}
+
+/// Whether a deterministic converter handles `ext`. Formats without one take the
+/// agentic (LLM) fallback route instead. Public so the upload boundary and tests
+/// can reason about which route a newly-accepted format will follow without
+/// spawning a tool.
+pub fn has_deterministic_converter(ext: &str) -> bool {
+    deterministic_tool_for(ext).is_some()
+}
+
 /// Try to convert `input_file` to markdown at `output_path` with a deterministic
 /// command-line tool, chosen by extension. Returns `Some(markdown)` on success,
 /// or `None` when the format is not handled, the tool is absent, it exits
@@ -414,9 +445,8 @@ pub(crate) async fn try_deterministic_convert(
     ext: &str,
     output_path: &Path,
 ) -> Option<String> {
-    let mut cmd = match ext {
-        // pandoc reads these natively and emits GitHub-flavored Markdown.
-        "docx" | "odt" | "rtf" | "html" | "htm" | "epub" | "fb2" => {
+    let mut cmd = match deterministic_tool_for(ext)? {
+        DeterministicTool::Pandoc => {
             let mut c = tokio::process::Command::new("pandoc");
             c.arg(input_file)
                 .arg("-t")
@@ -426,13 +456,11 @@ pub(crate) async fn try_deterministic_convert(
                 .arg(output_path);
             c
         }
-        // pandoc cannot read PDF; poppler's pdftotext extracts the text layer.
-        "pdf" => {
+        DeterministicTool::PdfToText => {
             let mut c = tokio::process::Command::new("pdftotext");
             c.arg("-layout").arg(input_file).arg(output_path);
             c
         }
-        _ => return None,
     };
 
     match cmd.status().await {
@@ -729,5 +757,115 @@ mod tests {
             .await
             .is_none());
         assert!(!output.exists());
+    }
+
+    #[test]
+    fn routes_formats_between_deterministic_and_agentic() {
+        // Formats a real tool handles take the fast, offline route. This covers
+        // the newly-accepted office/markup formats (odt/rtf/html/epub/…) that the
+        // upload boundary used to reject before the allow-list was dropped.
+        for ext in ["docx", "odt", "rtf", "html", "htm", "epub", "fb2", "pdf"] {
+            assert!(
+                has_deterministic_converter(ext),
+                "{ext} should take the deterministic route"
+            );
+        }
+        // Everything else — images, spreadsheets, presentations, unknown/binary
+        // junk — has no deterministic tool and falls back to the agentic
+        // (enricher/LLM) converter, which returns a reviewable markdown task.
+        for ext in ["png", "jpg", "xlsx", "pptx", "csv", "bin", "", "exe"] {
+            assert!(
+                !has_deterministic_converter(ext),
+                "{ext} should take the agentic fallback route"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn convert_in_dir_uses_agentic_fallback_for_new_nonconvertible_format() {
+        let dir = tempfile::tempdir().unwrap();
+        // A `.pptx` is a format the upload boundary now accepts but no
+        // deterministic tool here reads, so the agentic fallback (FakeConverter)
+        // must run and produce the reviewable markdown.
+        let upload = Upload {
+            filename: "deck.pptx".to_string(),
+            content_type:
+                "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+                    .to_string(),
+            bytes: b"raw slide bytes".to_vec(),
+        };
+        let converter = FakeConverter {
+            markdown: "# Deck\n\nSlide one.\n".to_string(),
+        };
+        let md = convert_in_dir(
+            dir.path(),
+            &upload,
+            "deck.md",
+            &EnrichConfig::for_test(crate::enrich::LlmProvider::Claude {
+                path: "claude".into(),
+                model: None,
+            }),
+            &converter,
+        )
+        .await
+        .unwrap();
+        assert_eq!(md, "# Deck\n\nSlide one.\n");
+    }
+
+    /// End-to-end deterministic route for a newly-accepted format (`.html`): when
+    /// `pandoc` is present the converter is never consulted, proving the fast
+    /// route is taken. Skipped when `pandoc` is absent (it lives in the
+    /// enrich-worker image but not every test host), so the suite never depends
+    /// on an external tool being installed.
+    #[tokio::test]
+    async fn convert_in_dir_uses_deterministic_route_for_new_html_format() {
+        if tokio::process::Command::new("pandoc")
+            .arg("--version")
+            .output()
+            .await
+            .map(|o| !o.status.success())
+            .unwrap_or(true)
+        {
+            eprintln!("skipping: pandoc not installed");
+            return;
+        }
+
+        struct PanickingConverter;
+        #[async_trait::async_trait]
+        impl DocumentConverter for PanickingConverter {
+            async fn convert(
+                &self,
+                _input_file: &Path,
+                _work_dir: &Path,
+                _output_path: &Path,
+                _config: &EnrichConfig,
+            ) -> Result<()> {
+                panic!("the agentic converter must not run for a deterministic format");
+            }
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let upload = Upload {
+            filename: "page.html".to_string(),
+            content_type: "text/html".to_string(),
+            bytes: b"<h1>Titel</h1><p>Inhoud.</p>".to_vec(),
+        };
+        let md = convert_in_dir(
+            dir.path(),
+            &upload,
+            "page.md",
+            &EnrichConfig::for_test(crate::enrich::LlmProvider::Claude {
+                path: "claude".into(),
+                model: None,
+            }),
+            &PanickingConverter,
+        )
+        .await
+        .unwrap();
+        // pandoc turns the <h1> into an ATX heading.
+        assert!(
+            md.contains("Titel"),
+            "expected converted markdown, got: {md}"
+        );
     }
 }

--- a/packages/pipeline/src/document_convert.rs
+++ b/packages/pipeline/src/document_convert.rs
@@ -425,9 +425,9 @@ fn deterministic_tool_for(ext: &str) -> Option<DeterministicTool> {
 }
 
 /// Whether a deterministic converter handles `ext`. Formats without one take the
-/// agentic (LLM) fallback route instead. Public so the upload boundary and tests
-/// can reason about which route a newly-accepted format will follow without
-/// spawning a tool.
+/// agentic (LLM) fallback route instead. Public so tests (and any future caller)
+/// can reason about which route a given format will follow without spawning a
+/// tool.
 pub fn has_deterministic_converter(ext: &str) -> bool {
     deterministic_tool_for(ext).is_some()
 }


### PR DESCRIPTION
## Wat

De werkdocument-upload accepteert nu **elk bestandsformaat**. De extensie-/type-filter die op pdf/doc/docx (plus markdown pass-through) gate'de en 415 gaf voor de rest, vervalt.

## Waarom

De conversiepijplijn kon al breder dan de gate toeliet:

- **Deterministisch** via `pandoc` (docx/odt/rtf/html/htm/epub/fb2) en `pdftotext` (pdf) — snel, offline, en het houdt de untrusted bytes weg bij de Bash-LLM.
- **Agentische fallback** voor al het overige: het document gaat als taak naar de enricher en komt als reviewbaar markdown terug.

De filter was dus strenger dan de pijplijn aankan. De gebruiker hoeft niet meer na te denken over "mag dit formaat wel".

## Wijzigingen

- **editor-api**: `read_upload_multipart` neemt nu een optionele allow-list. De werkdocument-upload geeft `None` (elk formaat); de enige overgebleven sanity-guard is de bestaande leeg-bestand-check. De wet-upload houdt zijn allow-list — alleen tekstdragende documenten voeden de conversie-naar-wet-keten. De gate is uitgesplitst naar een pure `check_upload_format` zodat hij zonder multipart-harnas testbaar is.
- **pipeline**: de deterministische route-keuze is samengetrokken tot één bron van waarheid (`deterministic_tool_for`), met een publieke `has_deterministic_converter`, zodat de routing-beslissing en de command-dispatch niet uit elkaar kunnen lopen.
- **frontend**: het `accept`-filter op de bestandskiezer vervalt en de "Document uploaden…"-menu-labels noemen geen formaat-lijst meer.

Markdown blijft pass-through (geen dubbele conversie). Deterministisch-converteerbare formaten volgen de snelle route; al het overige loopt via de enricher-taak en komt als markdown terug ter beoordeling — de bestaande conversiejob-status-UI dekt die "duurt langer / staat ter beoordeling"-flow al, dus er is geen nieuwe UX nodig.

## UX / max-filesize

Bewust géén harde max-filesize toegevoegd (buiten scope): de bestaande grootte-/leeg-checks blijven leidend. Het prompt-injection-model (deterministisch-eerst om untrusted bytes weg te houden bij de LLM) blijft ongewijzigd.

## Tests

- **pipeline** (`document_convert`): routing-test die de nieuw-geaccepteerde office/markup-formaten (odt/rtf/html/epub/…) naar de deterministische route stuurt en beeld/spreadsheet/onbekend naar de agentische fallback; een `convert_in_dir`-test die een nieuw niet-deterministisch formaat (`.pptx`) via de agentische converter laat lopen; en een end-to-end deterministische html-conversie (overgeslagen wanneer `pandoc` ontbreekt).
- **editor-api**: `check_upload_format` accepteert elk formaat wanneer ongegate en houdt de allow-list overeind voor de wet-upload.
- Frontend `LibraryView`- en `useTrajectDocuments`-suites blijven groen.