### PR TITLE
refactor(editor): bundel traject-credentials in één service

### DIFF
--- a/packages/editor-api/src/corpus_handlers.rs
+++ b/packages/editor-api/src/corpus_handlers.rs
@@ -25,7 +25,7 @@ use regelrecht_corpus::timing;
 use regelrecht_corpus::CorpusError;
 
 use crate::accounts::AccountRecord;
-use crate::github_oauth;
+use crate::credentials::{self, TrajectCredentials};
 use crate::state::{AppState, CorpusState};
 use crate::traject_corpus::{ScenarioListEntry, TrajectCorpus, TrajectCorpusError};
 use crate::trajects::resolve_traject_ref;
@@ -304,10 +304,10 @@ fn law_read_error(
 }
 
 /// Resolve the per-request read token for a traject's writable-own
-/// backend (see [`github_oauth::user_read_token_for_backend`] for the
-/// decision table). The result — including the deferred 428 — is stored
-/// on the [`TrajectScope`] and only surfaced by reads that actually
-/// target the writable-own source.
+/// backend (see [`TrajectCredentials::for_read`] for the decision table).
+/// The result — including the deferred 428 — is stored on the
+/// [`TrajectScope`] and only surfaced by reads that actually target the
+/// writable-own source.
 async fn resolve_own_read_token(
     state: &AppState,
     account_id: Uuid,
@@ -324,9 +324,11 @@ async fn resolve_own_read_token(
         return Ok(None);
     }
     // Lock only long enough for the two synchronous capability probes
-    // inside `user_read_token_for_backend`; no I/O under this guard.
+    // inside `for_read`; no I/O under this guard.
     let backend = entry.backend.lock().await;
-    github_oauth::user_read_token_for_backend(state, account_id, headers, &**backend).await
+    TrajectCredentials::new(state, account_id, headers)
+        .for_read(&**backend, entry.writable)
+        .await
 }
 
 /// Read a law's YAML within a scope. 502 for a backend failure, 404 for a
@@ -378,7 +380,8 @@ async fn require_traject_scope(
     // `ReadScope` re-resolves the token and raises the 428 at the call
     // sites that actually need the writable-own source (including the
     // traject-library gate in `require_traject_index`).
-    let scan_token = github_oauth::user_read_token(state, account.id, headers)
+    let scan_token = TrajectCredentials::new(state, account.id, headers)
+        .read_scan_candidate()
         .await
         .unwrap_or(None);
     let traject = require_traject_corpus_from_ref_with_scan_token(
@@ -1656,6 +1659,9 @@ async fn require_editor_user(session: &Session) -> Result<EditorUser, (StatusCod
 /// `persist` call, so we don't need to flag the backend here.
 struct EditorWriteTarget {
     relative_path: PathBuf,
+    /// Whether the write-target source is writable at rest — see
+    /// [`TrajectLawWrite::write_source_writable`].
+    writable: bool,
     backend: tokio::sync::OwnedMutexGuard<Box<dyn RepoBackend>>,
 }
 
@@ -1816,6 +1822,12 @@ struct TrajectLawWrite {
     /// source and its writes are routed to the traject's writable-own
     /// backend (see `write_target_for_source`).
     write_source_id: String,
+    /// Whether the write-target source is writable at rest (has its own
+    /// service token / is a natively writable local dir), captured at
+    /// backend registration. Fed to [`TrajectCredentials::for_write`] as the
+    /// explicit "has own write credential" capability instead of a runtime
+    /// `is_writable()` probe.
+    write_source_writable: bool,
     backend: tokio::sync::OwnedMutexGuard<Box<dyn RepoBackend>>,
 }
 
@@ -1823,7 +1835,6 @@ struct TrajectLawWrite {
 /// the looked-up law (for its `relative_path`), the write-target source
 /// id, and an owned guard over the traject's writable backend.
 async fn resolve_traject_law_write(
-    state: &AppState,
     traject: &Arc<TrajectCorpus>,
     law_id: &str,
 ) -> Result<TrajectLawWrite, (StatusCode, String)> {
@@ -1842,42 +1853,16 @@ async fn resolve_traject_law_write(
     // serialises here, so contention (a second save waiting out the
     // first's GitHub round-trips) shows up as a fat `lock` phase.
     let backend = timing::measure("lock", entry.backend.clone().lock_owned()).await;
-    require_traject_backend_writable(state, entry.writable, &**backend).await?;
+    // The writability gate + the per-user token are resolved together by
+    // `TrajectCredentials::for_write` at the handler's write site, so they
+    // can't drift apart; this resolver just carries the write-target
+    // capability along.
     Ok(TrajectLawWrite {
         law,
         write_source_id: write_target_source_id,
+        write_source_writable: entry.writable,
         backend,
     })
-}
-
-/// The single writability gate for traject writes.
-///
-/// A backend that is writable at rest (configured service token, or a
-/// natively writable local dir) always passes. A backend that is
-/// read-only at rest still passes when this deployment routes writes
-/// through the acting user's own GitHub token AND the backend honors
-/// `WriteContext::token_override` — the deployed federation config for a
-/// user-created traject repo has no service token on purpose, and 403-ing
-/// there would break every write in the user-token mode (the pr952
-/// promote bug). The subsequent `user_write_token_for_backend` call then
-/// applies the token-precedence rule: a configured service token goes
-/// first (the write proceeds without an override), and only on token-less
-/// backends is the linked-token requirement enforced (428 when
-/// absent/expired). `persist` itself still refuses
-/// (`CorpusError::ReadOnly` → 403) if a write somehow reaches it with no
-/// token at all.
-async fn require_traject_backend_writable(
-    state: &AppState,
-    writable_at_rest: bool,
-    backend: &dyn RepoBackend,
-) -> Result<(), (StatusCode, String)> {
-    if writable_at_rest {
-        return Ok(());
-    }
-    if backend.supports_token_override() && github_oauth::user_token_write_mode(state).await? {
-        return Ok(());
-    }
-    Err((StatusCode::FORBIDDEN, "Source is read-only".to_string()))
 }
 
 /// Source-relative path of a law's scenario file.
@@ -2067,15 +2052,15 @@ async fn read_traject_scenario_cached(
 /// the law/scenario writes use), so notes land in the same traject
 /// branch/PR as the rest of the edits in the session.
 async fn resolve_traject_annotation_target(
-    state: &AppState,
     traject: &Arc<TrajectCorpus>,
     law_id: &str,
 ) -> Result<EditorWriteTarget, (StatusCode, String)> {
-    let write = resolve_traject_law_write(state, traject, law_id).await?;
+    let write = resolve_traject_law_write(traject, law_id).await?;
     Ok(EditorWriteTarget {
         relative_path: PathBuf::from("annotations")
             .join(law_id)
             .join("annotations.yaml"),
+        writable: write.write_source_writable,
         backend: write.backend,
     })
 }
@@ -2122,34 +2107,30 @@ pub async fn save_scenario(
     let author = Some(require_editor_user(&session).await?);
 
     let traject = require_traject_corpus_from_ref(&state, &session, &traject_ref).await?;
-    let write = resolve_traject_law_write(&state, &traject, &law_id).await?;
-    // Resolved-backend-aware: a local writable-own backend ignores the
-    // override, so enforcement must not 428 a save that never reaches GitHub.
-    let token_override =
-        github_oauth::user_write_token_for_backend(&state, account.id, &headers, &**write.backend)
-            .await?;
+    let write = resolve_traject_law_write(&traject, &law_id).await?;
+    // One credential resolution for the whole write: the writability gate
+    // (403) plus the per-user token (428) plus the precondition read token,
+    // resolved together so they can't drift. A local writable-own backend
+    // ignores the override, so this never 428s a save that never reaches
+    // GitHub.
+    let auth = TrajectCredentials::new(&state, account.id, &headers)
+        .for_write(&**write.backend, write.write_source_writable)
+        .await?;
     let relative_path = scenario_relative_path(&write.law, &filename)?;
 
     // Optimistic concurrency, same semantics as documents. Only read the
     // current content when the client actually sent a precondition — a
     // header-less save stays a single write, no extra backend read. The
-    // precondition read uses the read-token mechanism (a token-less
-    // writable-own backend reads with the user's token), so it compares
-    // against the same bytes the GET served.
+    // precondition read uses the same token the write authenticates with
+    // (a token-less writable-own backend reads with the user's token), so
+    // it compares against the same bytes the GET served.
     if let Some(if_match) = extract_if_match(&headers) {
-        let read_token = github_oauth::user_read_token_for_backend(
-            &state,
-            account.id,
-            &headers,
-            &**write.backend,
-        )
-        .await?;
         let current = current_content_for_write(
             &traject,
             &write,
             &relative_path,
             "scenario",
-            read_token.as_deref(),
+            auth.read_token(),
         )
         .await?;
         check_if_match(current.as_deref(), Some(&if_match), "Scenario")?;
@@ -2163,11 +2144,10 @@ pub async fn save_scenario(
 
     let outcome = write
         .backend
-        .persist(&WriteContext {
-            message: format!("Update scenario {} for {}", filename, law_id),
+        .persist(&auth.into_write_context(
+            format!("Update scenario {} for {}", filename, law_id),
             author,
-            token_override,
-        })
+        ))
         .await
         .map_err(corpus_write_error("scenario"))?;
 
@@ -2338,29 +2318,29 @@ pub async fn save_annotations(
         }));
     }
     let new_notes = public_notes;
-    let target = resolve_traject_annotation_target(&state, &traject, &law_id).await?;
+    let target = resolve_traject_annotation_target(&traject, &law_id).await?;
     let EditorWriteTarget {
         relative_path,
+        writable,
         backend,
     } = target;
-    // Checked here — after the all-personal early return and against the
+    // Resolved here — after the all-personal early return and against the
     // resolved backend — so enforcement only fires for notes that actually
     // commit to GitHub: personal notes go to the database, and a local
-    // writable-own backend never uses a token at all.
-    let token_override =
-        github_oauth::user_write_token_for_backend(&state, account.id, &headers, &**backend)
-            .await?;
+    // writable-own backend never uses a token at all. One resolution covers
+    // the write override and the append-base read below.
+    let auth = TrajectCredentials::new(&state, account.id, &headers)
+        .for_write(&**backend, writable)
+        .await?;
 
     // Read the current sidecar from the traject backend (the branch this
     // traject's PR is built on — read-your-writes within the traject).
-    // Absent file = first notes for this law. Uses the read-token
-    // mechanism: on a token-less writable-own backend this read would
-    // otherwise 404 on a private repo and silently drop the existing
-    // notes from the append base.
-    let read_token =
-        github_oauth::user_read_token_for_backend(&state, account.id, &headers, &**backend).await?;
+    // Absent file = first notes for this law. Uses the write's token: on a
+    // token-less writable-own backend this read would otherwise 404 on a
+    // private repo and silently drop the existing notes from the append
+    // base.
     let base_text: Option<String> = backend
-        .read_file_with_token(&relative_path, read_token.as_deref())
+        .read_file_with_token(&relative_path, auth.read_token())
         .await
         .map_err(corpus_write_error("annotations"))?;
 
@@ -2470,11 +2450,7 @@ pub async fn save_annotations(
         .map_err(corpus_write_error("annotations"))?;
 
     let outcome = backend
-        .persist(&WriteContext {
-            message: format!("Notities bijgewerkt voor {}", law_id),
-            author,
-            token_override,
-        })
+        .persist(&auth.into_write_context(format!("Notities bijgewerkt voor {}", law_id), author))
         .await
         .map_err(corpus_write_error("annotations"))?;
 
@@ -2561,10 +2537,10 @@ pub async fn save_law(
     // corpus so we can mirror the saved body into its read-your-writes
     // overlay after `persist` succeeds.
     let traject = require_traject_corpus_from_ref(&state, &session, &traject_ref).await?;
-    let write = resolve_traject_law_write(&state, &traject, &law_id).await?;
-    let token_override =
-        github_oauth::user_write_token_for_backend(&state, account.id, &headers, &**write.backend)
-            .await?;
+    let write = resolve_traject_law_write(&traject, &law_id).await?;
+    let auth = TrajectCredentials::new(&state, account.id, &headers)
+        .for_write(&**write.backend, write.write_source_writable)
+        .await?;
     let relative_path = PathBuf::from(&write.law.relative_path);
 
     // Optimistic concurrency, same semantics as the document PUT: a
@@ -2574,21 +2550,9 @@ pub async fn save_law(
     // mutex (acquired by `resolve_traject_law_write` above), so a
     // concurrent save cannot slip between the check and the write.
     if let Some(if_match) = extract_if_match(&headers) {
-        let read_token = github_oauth::user_read_token_for_backend(
-            &state,
-            account.id,
-            &headers,
-            &**write.backend,
-        )
-        .await?;
-        let current = current_content_for_write(
-            &traject,
-            &write,
-            &relative_path,
-            "law",
-            read_token.as_deref(),
-        )
-        .await?;
+        let current =
+            current_content_for_write(&traject, &write, &relative_path, "law", auth.read_token())
+                .await?;
         check_if_match(current.as_deref(), Some(&if_match), "Wet")?;
     }
 
@@ -2600,11 +2564,7 @@ pub async fn save_law(
             .map_err(corpus_write_error("law"))?;
         write
             .backend
-            .persist(&WriteContext {
-                message: format!("Update law {}", law_id),
-                author,
-                token_override,
-            })
+            .persist(&auth.into_write_context(format!("Update law {}", law_id), author))
             .await
             .map_err(corpus_write_error("law"))?
     };
@@ -2648,10 +2608,10 @@ pub async fn delete_scenario(
     let author = Some(require_editor_user(&session).await?);
 
     let traject = require_traject_corpus_from_ref(&state, &session, &traject_ref).await?;
-    let write = resolve_traject_law_write(&state, &traject, &law_id).await?;
-    let token_override =
-        github_oauth::user_write_token_for_backend(&state, account.id, &headers, &**write.backend)
-            .await?;
+    let write = resolve_traject_law_write(&traject, &law_id).await?;
+    let auth = TrajectCredentials::new(&state, account.id, &headers)
+        .for_write(&**write.backend, write.write_source_writable)
+        .await?;
     let relative_path = scenario_relative_path(&write.law, &filename)?;
 
     write
@@ -2662,11 +2622,10 @@ pub async fn delete_scenario(
 
     let outcome = write
         .backend
-        .persist(&WriteContext {
-            message: format!("Delete scenario {} for {}", filename, law_id),
+        .persist(&auth.into_write_context(
+            format!("Delete scenario {} for {}", filename, law_id),
             author,
-            token_override,
-        })
+        ))
         .await
         .map_err(corpus_write_error("scenario"))?;
 
@@ -2924,7 +2883,7 @@ fn traject_documents_base(traject_ref: &str) -> PathBuf {
 async fn resolve_traject_documents_writer(
     state: &AppState,
     traject: &Arc<TrajectCorpus>,
-) -> Result<tokio::sync::OwnedMutexGuard<Box<dyn RepoBackend>>, (StatusCode, String)> {
+) -> Result<DocumentsWriter, (StatusCode, String)> {
     let entry = traject
         .corpus
         .backends
@@ -2933,9 +2892,25 @@ async fn resolve_traject_documents_writer(
             StatusCode::SERVICE_UNAVAILABLE,
             "Writable backend not initialised".to_string(),
         ))?;
+    let writable = entry.writable;
     let backend = entry.backend.clone().lock_owned().await;
-    require_traject_backend_writable(state, entry.writable, &**backend).await?;
-    Ok(backend)
+    // The writability gate runs here so the read-only callers of this
+    // resolver (the document listing/GET) keep their 403; write callers
+    // additionally go through `TrajectCredentials::for_write`, which
+    // re-asserts the gate together with the token so the two are never
+    // applied out of order.
+    credentials::assert_writable(state, &**backend, writable).await?;
+    Ok(DocumentsWriter { backend, writable })
+}
+
+/// The traject's writable-own backend for the document endpoints, plus its
+/// writable-at-rest capability — the input
+/// [`TrajectCredentials::for_read`]/[`TrajectCredentials::for_write`] need to
+/// pick the token source.
+struct DocumentsWriter {
+    backend: tokio::sync::OwnedMutexGuard<Box<dyn RepoBackend>>,
+    /// See [`TrajectLawWrite::write_source_writable`].
+    writable: bool,
 }
 
 /// Read the `If-Match` header value, trimmed. `None` when absent or empty.
@@ -3039,15 +3014,17 @@ pub async fn list_traject_documents(
     headers: axum::http::HeaderMap,
 ) -> Result<Json<TrajectDocumentList>, (StatusCode, String)> {
     let traject = require_traject_corpus_from_ref(&state, &session, &traject_ref).await?;
-    let backend = resolve_traject_documents_writer(&state, &traject).await?;
+    let writer = resolve_traject_documents_writer(&state, &traject).await?;
     // Documents live exclusively on the writable-own source, so this read
     // rides the per-request user token when that source has no service
     // token — and fails loud (428, the GitHub connect-flow) instead of
     // returning a silently empty list when the user hasn't linked GitHub.
-    let read_token =
-        github_oauth::user_read_token_for_backend(&state, account.id, &headers, &**backend).await?;
+    let read_token = TrajectCredentials::new(&state, account.id, &headers)
+        .for_read(&**writer.backend, writer.writable)
+        .await?;
     let base = traject_documents_base(&traject_ref);
-    let entries = backend
+    let entries = writer
+        .backend
         .list_files_recursive_with_token(&base, None, read_token.as_deref())
         .await
         .map_err(|e| {
@@ -3296,15 +3273,17 @@ pub async fn upload_traject_document(
     // the derivation hand back a name that already exists, and the worker's
     // unconditional write would silently overwrite that document. Fail the
     // upload instead.
-    let backend = resolve_traject_documents_writer(&state, &traject).await?;
+    let writer = resolve_traject_documents_writer(&state, &traject).await?;
     // Same read-token routing as `list_traject_documents`: without it a
     // token-less writable-own repo lists empty and the collision check is
     // blind.
-    let read_token =
-        github_oauth::user_read_token_for_backend(&state, account.id, &headers, &**backend).await?;
+    let read_token = TrajectCredentials::new(&state, account.id, &headers)
+        .for_read(&**writer.backend, writer.writable)
+        .await?;
 
     let base = traject_documents_base(&traject_ref);
-    let mut existing: Vec<String> = backend
+    let mut existing: Vec<String> = writer
+        .backend
         .list_files_recursive_with_token(&base, None, read_token.as_deref())
         .await
         .map_err(|e| upload_internal_error("list documents for collision check", e))?
@@ -3314,7 +3293,7 @@ pub async fn upload_traject_document(
     // Release the writable-backend lock before the DB work below — the backend
     // is only needed for the listing, and holding its mutex through the
     // transaction would serialize every writable-document op on this traject.
-    drop(backend);
+    drop(writer);
     // Also avoid colliding with conversions that are enqueued but haven't
     // committed their `.md` yet, and with failed ones that still show a row under
     // that name — otherwise two same-named uploads both derive e.g. `report.md`,
@@ -3357,24 +3336,20 @@ pub async fn upload_traject_document(
             )
         })?;
         let author = Some(require_editor_user(&session).await?);
-        let backend = resolve_traject_documents_writer(&state, &traject).await?;
-        let token_override =
-            github_oauth::user_write_token_for_backend(&state, account.id, &headers, &**backend)
-                .await?;
+        let writer = resolve_traject_documents_writer(&state, &traject).await?;
+        let auth = TrajectCredentials::new(&state, account.id, &headers)
+            .for_write(&**writer.backend, writer.writable)
+            .await?;
         let relative_path = traject_documents_base(&traject_ref).join(&target_path);
         write_markdown_passthrough(
-            &**backend,
+            &**writer.backend,
             &relative_path,
             &markdown,
-            WriteContext {
-                message: format!("Add document {target_path}"),
-                author,
-                token_override,
-            },
+            auth.into_write_context(format!("Add document {target_path}"), author),
         )
         .await
         .map_err(corpus_write_error("document"))?;
-        drop(backend);
+        drop(writer);
         // The `.md` already exists on the branch; the job-based path answers 202
         // (async), so this synchronous write answers 201 Created.
         return Ok((
@@ -3595,14 +3570,17 @@ pub async fn create_traject_law(
         .join(format!("{}.yaml", meta.valid_from));
 
     // The writable-own backend (same routing as documents: the law does not
-    // exist yet, so there is no per-law source to route from).
-    let backend = resolve_traject_documents_writer(&state, &traject).await?;
-    let read_token =
-        github_oauth::user_read_token_for_backend(&state, account.id, &headers, &**backend).await?;
+    // exist yet, so there is no per-law source to route from). One credential
+    // resolution: the write override plus the read token for the exists-check.
+    let writer = resolve_traject_documents_writer(&state, &traject).await?;
+    let auth = TrajectCredentials::new(&state, account.id, &headers)
+        .for_write(&**writer.backend, writer.writable)
+        .await?;
     // Belt-and-braces against an index blind spot (e.g. a file committed on
     // the branch after the current snapshot was built).
-    if backend
-        .read_file_with_token(&relative_path, read_token.as_deref())
+    if writer
+        .backend
+        .read_file_with_token(&relative_path, auth.read_token())
         .await
         .map_err(corpus_write_error("law"))?
         .is_some()
@@ -3613,23 +3591,21 @@ pub async fn create_traject_law(
                 .to_string(),
         ));
     }
-    let token_override =
-        github_oauth::user_write_token_for_backend(&state, account.id, &headers, &**backend)
-            .await?;
 
-    backend
+    writer
+        .backend
         .write_file(&relative_path, &body)
         .await
         .map_err(corpus_write_error("law"))?;
-    let outcome = backend
-        .persist(&WriteContext {
-            message: format!("Nieuwe wet {} uit documentconversie", law_id),
+    let outcome = writer
+        .backend
+        .persist(&auth.into_write_context(
+            format!("Nieuwe wet {} uit documentconversie", law_id),
             author,
-            token_override,
-        })
+        ))
         .await
         .map_err(corpus_write_error("law"))?;
-    drop(backend);
+    drop(writer);
 
     let new_etag = document_etag(&body);
 
@@ -3722,12 +3698,14 @@ pub async fn promote_corpus_law(
     // Schrijfpad: de writable-own backend van het traject (zelfde routing als
     // documents/create: per-wet routing bestaat nog niet, want de wet zit nog
     // niet in de traject-repo).
-    let backend = resolve_traject_documents_writer(&state, &traject).await?;
-    // Leestoken voor de bestaat-al-checks hieronder: zonder service-token
-    // leest een privé traject-repo anders overal 404 en zou de promote
-    // bestaande traject-edits stilletjes overschrijven.
-    let read_token =
-        github_oauth::user_read_token_for_backend(&state, account.id, &headers, &**backend).await?;
+    let writer = resolve_traject_documents_writer(&state, &traject).await?;
+    // Eén credential-resolutie: het schrijf-override én het leestoken voor de
+    // bestaat-al-checks hieronder. Zonder service-token leest een privé
+    // traject-repo anders overal 404 en zou de promote bestaande traject-edits
+    // stilletjes overschrijven.
+    let auth = TrajectCredentials::new(&state, account.id, &headers)
+        .for_write(&**writer.backend, writer.writable)
+        .await?;
 
     // Geen dubbele/overschreven bestanden, per bestandssoort:
     // - Wet-versie-YAML al op het doelpad (bijv. via een eerdere save_law op
@@ -3741,8 +3719,9 @@ pub async fn promote_corpus_law(
     //   source_priority 0) en de rest van de wet-map wordt gewoon gekopieerd.
     let mut to_write: Vec<&PromoteFile> = Vec::with_capacity(files.len());
     for file in &files {
-        let exists = backend
-            .read_file_with_token(&file.relative_path, read_token.as_deref())
+        let exists = writer
+            .backend
+            .read_file_with_token(&file.relative_path, auth.read_token())
             .await
             .map_err(corpus_write_error("law"))?
             .is_some();
@@ -3767,25 +3746,22 @@ pub async fn promote_corpus_law(
         );
     }
 
-    let token_override =
-        github_oauth::user_write_token_for_backend(&state, account.id, &headers, &**backend)
-            .await?;
-
     for file in &to_write {
-        backend
+        writer
+            .backend
             .write_file(&file.relative_path, &file.content)
             .await
             .map_err(corpus_write_error("law"))?;
     }
-    let outcome = backend
-        .persist(&WriteContext {
-            message: format!("Voeg wet {} toe uit het centrale corpus", law_id),
+    let outcome = writer
+        .backend
+        .persist(&auth.into_write_context(
+            format!("Voeg wet {} toe uit het centrale corpus", law_id),
             author,
-            token_override,
-        })
+        ))
         .await
         .map_err(corpus_write_error("law"))?;
-    drop(backend);
+    drop(writer);
 
     // Read-your-writes + index-verversing, zoals create_traject_law: de
     // nieuwste versie in de overlay, de wet in de changed-lijst, en een
@@ -3996,14 +3972,16 @@ pub async fn get_traject_document(
     use axum::response::IntoResponse;
     validate_document_path(&doc_path)?;
     let traject = require_traject_corpus_from_ref(&state, &session, &traject_ref).await?;
-    let backend = resolve_traject_documents_writer(&state, &traject).await?;
+    let writer = resolve_traject_documents_writer(&state, &traject).await?;
     // Same read-token routing as the listing: user token on a token-less
     // writable-own source, 428 instead of a misleading 404 when the user
     // hasn't linked GitHub.
-    let read_token =
-        github_oauth::user_read_token_for_backend(&state, account.id, &headers, &**backend).await?;
+    let read_token = TrajectCredentials::new(&state, account.id, &headers)
+        .for_read(&**writer.backend, writer.writable)
+        .await?;
     let relative_path = traject_documents_base(&traject_ref).join(&doc_path);
-    let content = backend
+    let content = writer
+        .backend
         .read_file_with_token(&relative_path, read_token.as_deref())
         .await
         .map_err(corpus_write_error("document"))?
@@ -4067,25 +4045,24 @@ pub async fn save_traject_document(
     }
 
     let traject = require_traject_corpus_from_ref(&state, &session, &traject_ref).await?;
-    let backend = resolve_traject_documents_writer(&state, &traject).await?;
-    let token_override =
-        github_oauth::user_write_token_for_backend(&state, account.id, &headers, &**backend)
-            .await?;
-    let read_token =
-        github_oauth::user_read_token_for_backend(&state, account.id, &headers, &**backend).await?;
+    let writer = resolve_traject_documents_writer(&state, &traject).await?;
+    let auth = TrajectCredentials::new(&state, account.id, &headers)
+        .for_write(&**writer.backend, writer.writable)
+        .await?;
     let relative_path = traject_documents_base(&traject_ref).join(&doc_path);
 
     let if_match = extract_if_match(&headers);
     let existed_before = enforce_if_match(
-        &**backend,
+        &**writer.backend,
         &relative_path,
         if_match.as_deref(),
-        read_token.as_deref(),
+        auth.read_token(),
     )
     .await?
     .is_some();
 
-    backend
+    writer
+        .backend
         .write_file(&relative_path, &body)
         .await
         .map_err(corpus_write_error("document"))?;
@@ -4095,12 +4072,9 @@ pub async fn save_traject_document(
     } else {
         format!("Add document {doc_path}")
     };
-    let outcome = backend
-        .persist(&WriteContext {
-            message,
-            author,
-            token_override,
-        })
+    let outcome = writer
+        .backend
+        .persist(&auth.into_write_context(message, author))
         .await
         .map_err(corpus_write_error("document"))?;
 
@@ -4142,20 +4116,18 @@ pub async fn delete_traject_document(
     let author = Some(require_editor_user(&session).await?);
 
     let traject = require_traject_corpus_from_ref(&state, &session, &traject_ref).await?;
-    let backend = resolve_traject_documents_writer(&state, &traject).await?;
-    let token_override =
-        github_oauth::user_write_token_for_backend(&state, account.id, &headers, &**backend)
-            .await?;
-    let read_token =
-        github_oauth::user_read_token_for_backend(&state, account.id, &headers, &**backend).await?;
+    let writer = resolve_traject_documents_writer(&state, &traject).await?;
+    let auth = TrajectCredentials::new(&state, account.id, &headers)
+        .for_write(&**writer.backend, writer.writable)
+        .await?;
     let relative_path = traject_documents_base(&traject_ref).join(&doc_path);
 
     let if_match = extract_if_match(&headers);
     let existed = enforce_if_match(
-        &**backend,
+        &**writer.backend,
         &relative_path,
         if_match.as_deref(),
-        read_token.as_deref(),
+        auth.read_token(),
     )
     .await?
     .is_some();
@@ -4163,17 +4135,15 @@ pub async fn delete_traject_document(
         return Err((StatusCode::NOT_FOUND, "Document niet gevonden".to_string()));
     }
 
-    backend
+    writer
+        .backend
         .delete_file(&relative_path)
         .await
         .map_err(corpus_write_error("document"))?;
 
-    let outcome = backend
-        .persist(&WriteContext {
-            message: format!("Delete document {doc_path}"),
-            author,
-            token_override,
-        })
+    let outcome = writer
+        .backend
+        .persist(&auth.into_write_context(format!("Delete document {doc_path}"), author))
         .await
         .map_err(corpus_write_error("document"))?;
 

--- a/packages/editor-api/src/credentials.rs
+++ b/packages/editor-api/src/credentials.rs
@@ -1,0 +1,719 @@
+//! One credential service for traject reads and writes.
+//!
+//! Every editor-api handler that touches a traject backend has to answer the
+//! same question — *which* token authenticates this request, and what happens
+//! when there is none* — and used to answer it by hand: a write-token
+//! resolution, a separate read-token resolution, a loose writability gate, and
+//! a `WriteContext { token_override: … }` built literally at the persist site.
+//! Four steps, each independently forgettable: a new call-site that skipped one
+//! still compiled and silently fell back to the service token (the bug class
+//! behind the pr952 promote regression).
+//!
+//! [`TrajectCredentials`] folds those steps into two entry points —
+//! [`TrajectCredentials::for_read`] and [`TrajectCredentials::for_write`] — plus
+//! the two backend-less variants the index scan and the create-traject
+//! preflight need. The write path returns a [`WriteAuthorization`], the **only**
+//! way an editor handler puts a `token_override` into a [`WriteContext`]: the
+//! writability gate (403) and the per-user token are resolved together, so they
+//! can no longer drift apart.
+//!
+//! ## What the decision depends on
+//!
+//! * **writable-at-rest** — whether the target backend has its own write
+//!   credential (a configured `CORPUS_AUTH_*` service token on the GitHub API
+//!   backend, or a natively writable local dir). This is the
+//!   [`writable`](crate::state::BackendEntry::writable) flag captured once at
+//!   backend registration, **not** a runtime `RepoBackend::is_writable()` probe:
+//!   the old code used `is_writable()` as a stand-in for "has a service token",
+//!   overloading a method whose meaning could shift under it. Passing the
+//!   registration-time capability in explicitly keeps the credential decision
+//!   decoupled from what `is_writable()` happens to mean.
+//! * **override-capability** — [`RepoBackend::supports_token_override`]: only a
+//!   backend that authenticates each persist against GitHub can route a write
+//!   through the acting user's own token. A local/clone backend that ignores the
+//!   override must never be handed a per-user token (or demanded one).
+//! * **requiredness** — whether this deployment routes writes through the acting
+//!   user's own GitHub token (the `GITHUB_USER_TOKEN_REQUIRED` env var **or** the
+//!   `github.user_oauth` feature flag). See [`write_requires_user_token`] and the
+//!   deliberately-more-tolerant [`user_token_write_mode`].
+//! * **the link state** — whether the caller has a valid / expired / absent
+//!   sealed GitHub-token cookie riding on this request.
+//!
+//! ## Precedence, in one place
+//!
+//! A configured service token always wins: a backend that is writable at rest
+//! keeps reading and writing with its own token, byte-identical to the
+//! pre-user-token flow, even for a linked user. Rerouting working service-token
+//! traffic through a personal token would 403 every member GitHub refuses on
+//! that repo (no direct push access, or an org's OAuth-App access
+//! restrictions). Only a token-less, override-capable backend — the traject
+//! writable-own repo on a user-chosen repo, which has no service token *by
+//! design* (fail-closed against shipping the central token to a user-picked
+//! repo) — falls through to the user's own token, or the 428 connect-flow when
+//! they haven't linked one.
+
+use axum::http::{HeaderMap, StatusCode};
+use uuid::Uuid;
+
+use regelrecht_corpus::auth::{token_env_name, CredentialResolver, TokenContext, TokenDecision};
+use regelrecht_corpus::backend::{EditorUser, RepoBackend, WriteContext};
+
+use crate::github_oauth::{self, GithubOAuth};
+use crate::state::AppState;
+
+/// Whether traject writes must carry the acting user's own GitHub token.
+///
+/// Two switches, OR-ed:
+/// * the `GITHUB_USER_TOKEN_REQUIRED` env var — static, deployment-wide
+///   override;
+/// * the `github.user_oauth` feature flag — the same toggle that shows the
+///   GitHub-koppeling UI, so switching the feature on in the Functies menu
+///   also switches enforcement on. Linking is never offered-but-inert.
+///
+/// A flag-read failure propagates as 500: on a token-less backend the
+/// requiredness decision determines whether a write may proceed at all,
+/// and that must not be guessed when the flag store is unreadable. (In
+/// practice the session store shares the same database, so requests
+/// rarely get this far with a broken pool.)
+///
+/// `pub`: the `/auth/github/status` handler reports this to the frontend as
+/// `required` so the UI can nudge the user to link before their first write.
+pub async fn write_requires_user_token(
+    state: &AppState,
+    oauth: &GithubOAuth,
+) -> Result<bool, (StatusCode, String)> {
+    if oauth.require_user_token {
+        return Ok(true);
+    }
+    // Without a database there is no flag store either (the toggle PUT 503s),
+    // so the env var is the only switch — e.g. OIDC-off local dev.
+    let Some(pool) = &state.pool else {
+        return Ok(false);
+    };
+    crate::feature_flags::flag_enabled(pool, crate::feature_flags::GITHUB_USER_OAUTH)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, "failed to read github.user_oauth feature flag");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Kon de feature-flags niet lezen; probeer het opnieuw.".to_string(),
+            )
+        })
+}
+
+/// [`write_requires_user_token`], tolerating an unconfigured OAuth
+/// integration: `false` when `github_oauth` is absent (the pre-spike
+/// service-token world).
+///
+/// The fail-mode difference from [`write_requires_user_token`] is
+/// **deliberate**, not an oversight to unify away: the writability gate
+/// ([`assert_writable`]) must not 500 a write merely because the OAuth
+/// integration isn't configured — a deployment can run the whole
+/// service-token flow with no `github_oauth` block at all, and its writes to a
+/// writable-at-rest backend must keep working. So the gate consults this
+/// tolerant variant; the token resolvers, which only run once an OAuth config
+/// is known present, consult the strict one.
+async fn user_token_write_mode(state: &AppState) -> Result<bool, (StatusCode, String)> {
+    match state.config.github_oauth.as_ref() {
+        Some(oauth) => write_requires_user_token(state, oauth).await,
+        None => Ok(false),
+    }
+}
+
+/// The single writability gate for traject writes.
+///
+/// A backend that is writable at rest (configured service token, or a
+/// natively writable local dir) always passes. A backend that is
+/// read-only at rest still passes when this deployment routes writes
+/// through the acting user's own GitHub token AND the backend honors
+/// `WriteContext::token_override` — the deployed federation config for a
+/// user-created traject repo has no service token on purpose, and 403-ing
+/// there would break every write in the user-token mode (the pr952
+/// promote bug). [`TrajectCredentials::for_write`] runs this before
+/// resolving the token, so the two can't be applied out of order.
+/// `persist` itself still refuses (`CorpusError::ReadOnly` → 403) if a
+/// write somehow reaches it with no token at all.
+pub(crate) async fn assert_writable(
+    state: &AppState,
+    backend: &dyn RepoBackend,
+    writable_at_rest: bool,
+) -> Result<(), (StatusCode, String)> {
+    if writable_at_rest {
+        return Ok(());
+    }
+    if backend.supports_token_override() && user_token_write_mode(state).await? {
+        return Ok(());
+    }
+    Err((StatusCode::FORBIDDEN, "Source is read-only".to_string()))
+}
+
+/// A resolved write authorization for a single traject write.
+///
+/// The **only** way an editor handler puts a `token_override` into a
+/// [`WriteContext`]: [`TrajectCredentials::for_write`] produced it, having
+/// already run the writability gate and applied the token-precedence rule, so a
+/// handler can neither skip the gate nor forget the override. The same resolved
+/// token also serves the write path's optimistic-concurrency precondition read
+/// ([`WriteAuthorization::read_token`]) — one credential resolution per write
+/// instead of a separate write-token and read-token lookup that could disagree.
+#[must_use = "a resolved WriteAuthorization must be turned into a WriteContext (or its read token used) — dropping it silently discards the per-user token"]
+pub struct WriteAuthorization {
+    token_override: Option<String>,
+}
+
+/// Redacts the token — a `WriteAuthorization` carries a live credential and is
+/// one `{:?}` away from a log line, so a derived `Debug` would leak it. Reports
+/// only *whether* an override is present.
+impl std::fmt::Debug for WriteAuthorization {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WriteAuthorization")
+            .field(
+                "token_override",
+                &self.token_override.as_ref().map(|_| "***"),
+            )
+            .finish()
+    }
+}
+
+impl WriteAuthorization {
+    /// The token to authenticate a **precondition read** on the same write
+    /// target with (the `If-Match` check that must see the same bytes the
+    /// write will land on). Identical to the write's `token_override` — same
+    /// backend, same precedence — so the read and the write can't authenticate
+    /// as different identities.
+    pub fn read_token(&self) -> Option<&str> {
+        self.token_override.as_deref()
+    }
+
+    /// Consume the authorization into the [`WriteContext`] handed to
+    /// `RepoBackend::persist`. Takes ownership so the token can't be reused
+    /// past the single write it authorizes.
+    pub fn into_write_context(self, message: String, author: Option<EditorUser>) -> WriteContext {
+        WriteContext {
+            message,
+            author,
+            token_override: self.token_override,
+        }
+    }
+}
+
+/// Per-request credential service for a traject.
+///
+/// Constructed from the request's identity (editor account + headers, the
+/// latter carrying the sealed GitHub-token cookie) and answers "which token"
+/// for every read/write against a traject backend. Cheap to build — it just
+/// borrows the request context — so handlers construct one per request.
+pub struct TrajectCredentials<'a> {
+    state: &'a AppState,
+    account_id: Uuid,
+    headers: &'a HeaderMap,
+}
+
+impl<'a> TrajectCredentials<'a> {
+    /// Build the service for one request.
+    pub fn new(state: &'a AppState, account_id: Uuid, headers: &'a HeaderMap) -> Self {
+        Self {
+            state,
+            account_id,
+            headers,
+        }
+    }
+
+    /// Resolve the per-user GitHub credential for a **read** on `backend`.
+    ///
+    /// * backend ignores token overrides (local source, clone-based git) →
+    ///   `Ok(None)`;
+    /// * backend is writable at rest (has a service token) → `Ok(None)` (read
+    ///   uses it, as before) — even in the user-token write mode. Rerouting
+    ///   working service-token traffic through personal tokens would break
+    ///   members without direct repo access;
+    /// * backend is token-less and override-capable (the traject writable-own
+    ///   Contents-API backend on a user-chosen repo) → the user's own token,
+    ///   or the 428 connect-flow when this deployment requires a user token and
+    ///   the caller hasn't linked one. Without the user-token mode enabled this
+    ///   stays `Ok(None)` — the pre-existing behaviour.
+    pub async fn for_read(
+        &self,
+        backend: &dyn RepoBackend,
+        writable_at_rest: bool,
+    ) -> Result<Option<String>, (StatusCode, String)> {
+        if !backend.supports_token_override() || writable_at_rest {
+            return Ok(None);
+        }
+        self.user_read_token().await
+    }
+
+    /// Resolve a [`WriteAuthorization`] for a write on `backend`: the
+    /// writability gate ([`assert_writable`]) followed by the per-user token,
+    /// applying the same precedence as [`Self::for_read`].
+    ///
+    /// The gate and the token are resolved together on purpose — see
+    /// [`WriteAuthorization`].
+    pub async fn for_write(
+        &self,
+        backend: &dyn RepoBackend,
+        writable_at_rest: bool,
+    ) -> Result<WriteAuthorization, (StatusCode, String)> {
+        assert_writable(self.state, backend, writable_at_rest).await?;
+        let token_override = if !backend.supports_token_override() || writable_at_rest {
+            // Local/clone backend (ignores the override) or a backend with its
+            // own service token: the write uses the backend's configured token
+            // and stamps the commit with the session identity — the pre-user-
+            // token flow. Routing writes on a service-token repo through the
+            // user's personal token instead would 403 every member GitHub
+            // refuses on that repo.
+            None
+        } else {
+            self.user_write_token().await?
+        };
+        Ok(WriteAuthorization { token_override })
+    }
+
+    /// The read-path candidate token **without** a backend to scope it to.
+    ///
+    /// Exists for the traject **index scan**, which resolves a candidate token
+    /// ahead of `build_traject_corpus` so the enumeration of a token-less
+    /// writable-own repo can authenticate as the acting user. Because there is
+    /// no backend to scope the decision to, callers must treat the result as a
+    /// *candidate*: apply it only where a server-side token is absent (the
+    /// corpus-side `ScanTokenOverride` enforces that) and defer the `Err` (428
+    /// connect-flow) until a traject-scoped read actually needs the
+    /// writable-own source.
+    pub async fn read_scan_candidate(&self) -> Result<Option<String>, (StatusCode, String)> {
+        self.user_read_token().await
+    }
+
+    /// The write-path user token **without** a backend to scope it to.
+    ///
+    /// `Ok(None)` when this deployment does not require a user token; the
+    /// linked token when it does and the caller has one; `Err((428, …))` when
+    /// it does and the caller hasn't (or it expired). Used by
+    /// [`Self::for_new_repo_preflight`] and exercised directly by the
+    /// requiredness tests.
+    ///
+    /// Callers that have a resolved backend must prefer [`Self::for_write`],
+    /// which applies the service-token-first precedence; a bare caller is
+    /// responsible for that precedence itself (the create-traject preflight
+    /// resolves the configured token first — see
+    /// [`Self::for_new_repo_preflight`]).
+    pub async fn user_write_token(&self) -> Result<Option<String>, (StatusCode, String)> {
+        self.user_token_when_required(
+            "Je GitHub-koppeling is verlopen. Koppel je account opnieuw om op te slaan.",
+            "Koppel je GitHub-account om in dit traject op te slaan. \
+             De wijziging wordt met jouw eigen GitHub-toegang weggeschreven.",
+        )
+        .await
+    }
+
+    /// The read-path analogue of [`Self::user_write_token`] (same requiredness
+    /// gate and 428 semantics, read-flavoured messages).
+    async fn user_read_token(&self) -> Result<Option<String>, (StatusCode, String)> {
+        self.user_token_when_required(
+            "Je GitHub-koppeling is verlopen. Koppel je account opnieuw om de \
+             inhoud van dit traject te kunnen lezen.",
+            "Koppel je GitHub-account om de inhoud van dit traject te kunnen \
+             lezen. De traject-repo wordt met jouw eigen GitHub-toegang gelezen.",
+        )
+        .await
+    }
+
+    /// Resolve the token for a **create-traject preflight** on a user-supplied
+    /// repo, following the same precedence as the write path.
+    ///
+    /// A configured per-repo service token goes first — the eventual writes on
+    /// this repo run over that token too, so preflighting with the user's
+    /// personal token would validate an access path the traject will never use.
+    /// The lookup is **strict** ([`TokenContext::strict`]): `auth_ref` derives
+    /// from user-supplied repo coords, so an unknown ref must NOT fall back to
+    /// the legacy shared `CORPUS_GIT_TOKEN` (that would ship the central token
+    /// to a user-picked repo — a token-exfiltration vector).
+    ///
+    /// Only for a token-less ref does the acting user's OWN GitHub token come
+    /// into play: the preflight then validates *their* push access to the
+    /// chosen repo. Outcomes:
+    /// * configured service token → it;
+    /// * no service token, user-token required + linked → the user's token;
+    /// * no service token, required + unlinked/expired → 428 (connect-flow);
+    /// * no service token, not required → 503 with the `token_env_name` hint so
+    ///   the operator knows which env var to set.
+    pub async fn for_new_repo_preflight(
+        &self,
+        auth_ref: &str,
+    ) -> Result<String, (StatusCode, String)> {
+        let auth_file = {
+            let corpus = self.state.corpus.read().await;
+            corpus.auth_file.clone()
+        };
+        let service_token = CredentialResolver::new(auth_file.as_deref())
+            .resolve(TokenContext::strict(auth_ref))
+            .map(TokenDecision::into_token)
+            .map_err(|e| {
+                tracing::error!(error = %e, "auth lookup failed for new traject repo");
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "auth lookup failed".to_string(),
+                )
+            })?;
+        match service_token {
+            Some(service_token) => Ok(service_token),
+            None => self.user_write_token().await?.ok_or_else(|| {
+                let env_name = token_env_name(auth_ref);
+                tracing::warn!(
+                    auth_ref = %auth_ref,
+                    env_name = %env_name,
+                    "no token configured for user-supplied repo"
+                );
+                (
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    format!(
+                        "deze repo is nog niet door je beheerder geconfigureerd \
+                             (verwacht env var {env_name})"
+                    ),
+                )
+            }),
+        }
+    }
+
+    /// Shared core of the read/write token resolvers: the requiredness gate,
+    /// the sealed-cookie resolution, and the 428 semantics — parameterised only
+    /// in the user-facing messages so the read path can say "lezen" where the
+    /// write path says "opslaan".
+    ///
+    /// **428 is reserved editor-wide for this flow.** `apiAuthGuard.js`
+    /// redirects every same-origin `/api/*` response with status 428 into the
+    /// GitHub connect flow, keyed on nothing but the status code — an endpoint
+    /// that returns 428 for any other reason would silently hijack its callers
+    /// into the koppel-flow. Pick a different status for other preconditions.
+    async fn user_token_when_required(
+        &self,
+        expired_msg: &str,
+        missing_msg: &str,
+    ) -> Result<Option<String>, (StatusCode, String)> {
+        let Some(oauth) = self.state.config.github_oauth.as_ref() else {
+            return Ok(None);
+        };
+
+        // The override is gated *entirely* on the requiredness decision. With
+        // it off (the default), every request keeps using the backend's
+        // configured token — byte-identical to pre-spike behaviour, and
+        // crucially this holds even for users who HAVE linked GitHub. That
+        // matters for the operator-managed central repo: routing a linked
+        // user's write there through their personal token would 403 if they
+        // lack direct push access, silently breaking saves that worked before.
+        // So linking is inert until this deployment opts into the "editor is
+        // not in the middle" mode via the feature flag or the env var.
+        if !write_requires_user_token(self.state, oauth).await? {
+            return Ok(None);
+        }
+
+        // From here the user-token mode is on AND the caller established that
+        // no configured service token applies (`for_read`/`for_write` return
+        // early on writable-at-rest backends): the only outcomes are the user's
+        // own token or a 428. `github_oauth::open_link` folds every cookie
+        // failure mode (absent, tampered, wrong key, foreign account) into
+        // `None` = not linked, which fails closed into the 428 below.
+        match github_oauth::open_link(oauth, self.headers, self.account_id) {
+            Some(link) if !link.expired => {
+                tracing::debug!(
+                    github_login = %link.github_login,
+                    "authorizing traject access as the linked GitHub user"
+                );
+                Ok(Some(link.access_token))
+            }
+            Some(_expired) => Err((StatusCode::PRECONDITION_REQUIRED, expired_msg.to_string())),
+            None => Err((StatusCode::PRECONDITION_REQUIRED, missing_msg.to_string())),
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    use async_trait::async_trait;
+    use regelrecht_corpus::backend::{FileEntry, PersistOutcome};
+    use regelrecht_corpus::error::Result as CorpusResult;
+    use std::path::Path;
+    use tokio::sync::{Mutex, RwLock};
+
+    use crate::config::AppConfig;
+    use crate::github_oauth::{seal_token_cookie_for_tests, GithubOAuth};
+    use crate::state::{AppState, CorpusState};
+    use crate::traject_corpus::TrajectCorpusCache;
+
+    /// Minimal backend whose two credential-relevant capabilities are
+    /// configurable, so the decision table can vary `supports_token_override`
+    /// independently. Every data method is unreachable in these tests — the
+    /// service never touches the wire, only the capability probes.
+    struct CapBackend {
+        supports_override: bool,
+    }
+
+    #[async_trait]
+    impl RepoBackend for CapBackend {
+        async fn read_file(&self, _relative_path: &Path) -> CorpusResult<Option<String>> {
+            unreachable!("credential tests never read")
+        }
+        async fn write_file(&self, _relative_path: &Path, _content: &str) -> CorpusResult<()> {
+            unreachable!("credential tests never write")
+        }
+        async fn delete_file(&self, _relative_path: &Path) -> CorpusResult<()> {
+            unreachable!("credential tests never delete")
+        }
+        async fn list_files(
+            &self,
+            _dir: &Path,
+            _extension: Option<&str>,
+        ) -> CorpusResult<Vec<FileEntry>> {
+            unreachable!("credential tests never list")
+        }
+        async fn persist(&self, _ctx: &WriteContext) -> CorpusResult<PersistOutcome> {
+            unreachable!("credential tests never persist")
+        }
+        async fn ensure_ready(&mut self) -> CorpusResult<()> {
+            Ok(())
+        }
+        fn supports_token_override(&self) -> bool {
+            self.supports_override
+        }
+        fn is_writable(&self) -> bool {
+            // Deliberately the *opposite* of what a writable-at-rest backend
+            // would report, to prove the credential decision never consults
+            // this method (it takes `writable_at_rest` explicitly instead).
+            !self.supports_override
+        }
+    }
+
+    /// AppState with an OAuth config whose `require_user_token` is set from
+    /// `required`, and no database (so requiredness is driven purely by the env
+    /// switch — no feature-flag DB hit needed for the decision table).
+    fn state_with(required: bool, oauth_configured: bool) -> AppState {
+        let github_oauth = oauth_configured.then(|| GithubOAuth::for_tests(required));
+        AppState {
+            corpus: Arc::new(RwLock::new(CorpusState::empty())),
+            oidc_client: None,
+            end_session_url: None,
+            config: Arc::new(AppConfig {
+                oidc: None,
+                base_url: None,
+                github_oauth,
+                task_enrich_provider: "claude".to_string(),
+            }),
+            http_client: reqwest::Client::new(),
+            pool: None,
+            pipeline_api_url: None,
+            harvest_admin_url: None,
+            reload_lock: Arc::new(Mutex::new(())),
+            trajects: Arc::new(TrajectCorpusCache::new()),
+        }
+    }
+
+    /// Headers carrying a valid sealed token cookie for `account_id`.
+    fn linked_headers(state: &AppState, account_id: Uuid) -> HeaderMap {
+        let oauth = state.config.github_oauth.as_ref().unwrap();
+        let cookie = seal_token_cookie_for_tests(oauth, account_id, "gho_test_token");
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            axum::http::header::COOKIE,
+            axum::http::HeaderValue::from_str(&cookie).unwrap(),
+        );
+        headers
+    }
+
+    fn overridable() -> CapBackend {
+        CapBackend {
+            supports_override: true,
+        }
+    }
+    fn non_overridable() -> CapBackend {
+        CapBackend {
+            supports_override: false,
+        }
+    }
+
+    // --- Reads -------------------------------------------------------------
+
+    #[tokio::test]
+    async fn read_writable_at_rest_uses_service_token() {
+        // Service token present (writable at rest) → no override, ever, even
+        // with the user-token mode on and a linked cookie.
+        let state = state_with(true, true);
+        let account = Uuid::new_v4();
+        let headers = linked_headers(&state, account);
+        let creds = TrajectCredentials::new(&state, account, &headers);
+        let token = creds.for_read(&overridable(), true).await.unwrap();
+        assert_eq!(token, None);
+    }
+
+    #[tokio::test]
+    async fn read_non_overridable_backend_uses_no_token() {
+        // A local/clone backend ignores overrides → no user token demanded even
+        // token-less and required.
+        let state = state_with(true, true);
+        let account = Uuid::new_v4();
+        let headers = HeaderMap::new();
+        let creds = TrajectCredentials::new(&state, account, &headers);
+        let token = creds.for_read(&non_overridable(), false).await.unwrap();
+        assert_eq!(token, None);
+    }
+
+    #[tokio::test]
+    async fn read_tokenless_not_required_stays_none() {
+        // Token-less, override-capable, but the deployment does not require a
+        // user token → pre-spike behaviour, no override, no 428.
+        let state = state_with(false, true);
+        let account = Uuid::new_v4();
+        let headers = HeaderMap::new();
+        let creds = TrajectCredentials::new(&state, account, &headers);
+        let token = creds.for_read(&overridable(), false).await.unwrap();
+        assert_eq!(token, None);
+    }
+
+    #[tokio::test]
+    async fn read_tokenless_required_linked_uses_user_token() {
+        let state = state_with(true, true);
+        let account = Uuid::new_v4();
+        let headers = linked_headers(&state, account);
+        let creds = TrajectCredentials::new(&state, account, &headers);
+        let token = creds.for_read(&overridable(), false).await.unwrap();
+        assert_eq!(token.as_deref(), Some("gho_test_token"));
+    }
+
+    #[tokio::test]
+    async fn read_tokenless_required_unlinked_is_428() {
+        let state = state_with(true, true);
+        let account = Uuid::new_v4();
+        let headers = HeaderMap::new();
+        let creds = TrajectCredentials::new(&state, account, &headers);
+        let err = creds.for_read(&overridable(), false).await.unwrap_err();
+        assert_eq!(err.0, StatusCode::PRECONDITION_REQUIRED);
+    }
+
+    #[tokio::test]
+    async fn read_without_oauth_config_stays_none() {
+        // No `github_oauth` block at all → the whole user-token flow is inert.
+        let state = state_with(false, false);
+        let account = Uuid::new_v4();
+        let headers = HeaderMap::new();
+        let creds = TrajectCredentials::new(&state, account, &headers);
+        let token = creds.for_read(&overridable(), false).await.unwrap();
+        assert_eq!(token, None);
+    }
+
+    // --- Writes ------------------------------------------------------------
+
+    #[tokio::test]
+    async fn write_writable_at_rest_uses_service_token() {
+        let state = state_with(true, true);
+        let account = Uuid::new_v4();
+        let headers = linked_headers(&state, account);
+        let creds = TrajectCredentials::new(&state, account, &headers);
+        let auth = creds.for_write(&overridable(), true).await.unwrap();
+        assert_eq!(auth.read_token(), None);
+        let ctx = auth.into_write_context("msg".to_string(), None);
+        assert_eq!(ctx.token_override, None);
+    }
+
+    #[tokio::test]
+    async fn write_tokenless_not_required_is_403() {
+        // Token-less, override-capable, but not in user-token mode: there is no
+        // credential to write with → the writability gate 403s (pre-spike:
+        // such a backend was simply read-only).
+        let state = state_with(false, true);
+        let account = Uuid::new_v4();
+        let headers = HeaderMap::new();
+        let creds = TrajectCredentials::new(&state, account, &headers);
+        let err = creds.for_write(&overridable(), false).await.unwrap_err();
+        assert_eq!(err.0, StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn write_non_overridable_read_only_is_403() {
+        // A read-only-at-rest, non-override backend can never be written.
+        let state = state_with(true, true);
+        let account = Uuid::new_v4();
+        let headers = HeaderMap::new();
+        let creds = TrajectCredentials::new(&state, account, &headers);
+        let err = creds
+            .for_write(&non_overridable(), false)
+            .await
+            .unwrap_err();
+        assert_eq!(err.0, StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn write_tokenless_required_linked_uses_user_token() {
+        let state = state_with(true, true);
+        let account = Uuid::new_v4();
+        let headers = linked_headers(&state, account);
+        let creds = TrajectCredentials::new(&state, account, &headers);
+        let auth = creds.for_write(&overridable(), false).await.unwrap();
+        // The precondition read and the write authenticate as the same user.
+        assert_eq!(auth.read_token(), Some("gho_test_token"));
+        let ctx = auth.into_write_context("msg".to_string(), None);
+        assert_eq!(ctx.token_override.as_deref(), Some("gho_test_token"));
+    }
+
+    #[tokio::test]
+    async fn write_tokenless_required_unlinked_is_428() {
+        let state = state_with(true, true);
+        let account = Uuid::new_v4();
+        let headers = HeaderMap::new();
+        let creds = TrajectCredentials::new(&state, account, &headers);
+        let err = creds.for_write(&overridable(), false).await.unwrap_err();
+        assert_eq!(err.0, StatusCode::PRECONDITION_REQUIRED);
+    }
+
+    // --- Backend-less variants --------------------------------------------
+
+    #[tokio::test]
+    async fn scan_candidate_swallows_nothing_but_maps_link_state() {
+        // Required + unlinked → 428 (the caller swallows it for seed-only
+        // browsing; here we assert the raw decision).
+        let state = state_with(true, true);
+        let account = Uuid::new_v4();
+        let headers = HeaderMap::new();
+        let creds = TrajectCredentials::new(&state, account, &headers);
+        let err = creds.read_scan_candidate().await.unwrap_err();
+        assert_eq!(err.0, StatusCode::PRECONDITION_REQUIRED);
+
+        // Not required → None.
+        let state = state_with(false, true);
+        let headers = HeaderMap::new();
+        let creds = TrajectCredentials::new(&state, account, &headers);
+        assert_eq!(creds.read_scan_candidate().await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn preflight_no_service_token_required_unlinked_is_428() {
+        // No CORPUS_AUTH_* env for this ref, user-token required, unlinked →
+        // 428, not the 503 "not configured".
+        let state = state_with(true, true);
+        let account = Uuid::new_v4();
+        let headers = HeaderMap::new();
+        let creds = TrajectCredentials::new(&state, account, &headers);
+        let err = creds
+            .for_new_repo_preflight("example-unconfigured-ref")
+            .await
+            .unwrap_err();
+        assert_eq!(err.0, StatusCode::PRECONDITION_REQUIRED);
+    }
+
+    #[tokio::test]
+    async fn preflight_no_service_token_not_required_is_503() {
+        // No service token and the deployment does not require a user token →
+        // 503 with the env-var hint (nothing to preflight with).
+        let state = state_with(false, true);
+        let account = Uuid::new_v4();
+        let headers = HeaderMap::new();
+        let creds = TrajectCredentials::new(&state, account, &headers);
+        let err = creds
+            .for_new_repo_preflight("example-unconfigured-ref")
+            .await
+            .unwrap_err();
+        assert_eq!(err.0, StatusCode::SERVICE_UNAVAILABLE);
+        assert!(err.1.contains("CORPUS_AUTH_EXAMPLE_UNCONFIGURED_REF_TOKEN"));
+    }
+}

--- a/packages/editor-api/src/feature_flags.rs
+++ b/packages/editor-api/src/feature_flags.rs
@@ -10,7 +10,7 @@ use serde::Deserialize;
 use crate::state::AppState;
 
 /// Key of the GitHub user-OAuth flag (PR #887). Shared with the write path
-/// (`github_oauth::write_requires_user_token`), which reads this flag to
+/// (`credentials::write_requires_user_token`), which reads this flag to
 /// decide whether traject writes must carry the acting user's own token.
 pub const GITHUB_USER_OAUTH: &str = "github.user_oauth";
 
@@ -36,7 +36,7 @@ static DEFAULTS: LazyLock<HashMap<String, bool>> = LazyLock::new(|| {
         // GitHub user-OAuth (spike, PR #887). One switch, two effects: it
         // shows the "Koppel GitHub-account" affordance in the account menu
         // AND makes traject writes require the acting user's own GitHub token
-        // (`github_oauth::write_requires_user_token`) — linking is never
+        // (`credentials::write_requires_user_token`) — linking is never
         // offered-but-inert. Default off so the spike stays invisible until
         // opted in. Same allow-list rule: without this key the toggle PUT
         // 400s and the frontend silently reverts it, so the toggle would

--- a/packages/editor-api/src/github_oauth.rs
+++ b/packages/editor-api/src/github_oauth.rs
@@ -85,9 +85,9 @@ pub struct GithubOAuth {
     /// middle" mode). This is one of TWO switches: the `github.user_oauth`
     /// feature flag enforces the same thing at runtime, so enabling the
     /// GitHub-koppeling UI also enables enforcement — linking is never
-    /// offered-but-inert. See [`write_requires_user_token`] for the combined
-    /// decision; this env var remains as a deployment-wide override that wins
-    /// regardless of the flag.
+    /// offered-but-inert. See [`crate::credentials::write_requires_user_token`]
+    /// for the combined decision; this env var remains as a deployment-wide
+    /// override that wins regardless of the flag.
     ///
     /// * required off (both switches): writes **always** use the backend's
     ///   configured token — byte-identical to pre-spike behaviour for every
@@ -95,7 +95,8 @@ pub struct GithubOAuth {
     ///   central repo can't start 403-ing because their personal token lacks
     ///   access.
     /// * required on (either switch): a configured service token still takes
-    ///   precedence per backend (see [`user_write_token_for_backend`]); only
+    ///   precedence per backend (see
+    ///   [`crate::credentials::TrajectCredentials::for_write`]); only
     ///   writes to token-less, override-capable backends must carry the
     ///   acting user's token, and a save there with no linked (or an
     ///   expired) token is refused with 428.

--- a/packages/editor-api/src/github_oauth.rs
+++ b/packages/editor-api/src/github_oauth.rs
@@ -54,8 +54,6 @@ use subtle::ConstantTimeEq;
 use tower_sessions::Session;
 use uuid::Uuid;
 
-use regelrecht_corpus::backend::RepoBackend;
-
 use crate::accounts::AccountRecord;
 use crate::crypto::TokenCipher;
 use crate::state::AppState;
@@ -387,6 +385,35 @@ fn open_token_cookie(
         return None;
     }
     Some(payload)
+}
+
+/// The sealed per-user GitHub link, opened for one request. The cookie
+/// internals (encryption, account binding, the `expired` computation) stay
+/// private to this module; [`crate::credentials`] consumes this narrow view to
+/// apply the requiredness / 428 policy.
+pub(crate) struct OpenedLink {
+    /// The GitHub access token to authenticate as the linked user.
+    pub access_token: String,
+    /// Whether the provider-reported expiry has passed.
+    pub expired: bool,
+    /// GitHub login (handle) — for the authorizing-as log line only.
+    pub github_login: String,
+}
+
+/// Open the sealed per-user token cookie for `account_id`, exposing only what
+/// the credential policy needs. `None` on *any* cookie failure (absent,
+/// undecodable, tampered, wrong-key, foreign-account) — all of which mean "not
+/// linked" and fail closed into the 428 connect-flow at the policy layer.
+pub(crate) fn open_link(
+    oauth: &GithubOAuth,
+    headers: &HeaderMap,
+    account_id: Uuid,
+) -> Option<OpenedLink> {
+    open_token_cookie(oauth, headers, account_id).map(|cookie| OpenedLink {
+        expired: cookie.expired(),
+        github_login: cookie.github_login,
+        access_token: cookie.access_token,
+    })
 }
 
 /// Extract a cookie value from the request's `Cookie` header(s).
@@ -807,7 +834,7 @@ pub async fn status(
     };
     // Effective requiredness (env var OR feature flag), so the frontend's
     // `required` mirrors what the write path will actually enforce.
-    let required = write_requires_user_token(&state, oauth)
+    let required = crate::credentials::write_requires_user_token(&state, oauth)
         .await
         .map_err(|(code, _)| code)?;
     Ok(Json(match open_token_cookie(oauth, &headers, account.id) {
@@ -856,256 +883,6 @@ pub async fn disconnect(
     let mut response = StatusCode::NO_CONTENT.into_response();
     append_set_cookie(&mut response, &clear_token_cookie_header(secure));
     Ok(response)
-}
-
-// --- Write-path helper -----------------------------------------------------
-
-/// Whether traject writes must carry the acting user's own GitHub token.
-///
-/// Two switches, OR-ed:
-/// * the `GITHUB_USER_TOKEN_REQUIRED` env var — static, deployment-wide
-///   override;
-/// * the `github.user_oauth` feature flag — the same toggle that shows the
-///   GitHub-koppeling UI, so switching the feature on in the Functies menu
-///   also switches enforcement on. Linking is never offered-but-inert.
-///
-/// A flag-read failure propagates as 500: on a token-less backend the
-/// requiredness decision determines whether a write may proceed at all,
-/// and that must not be guessed when the flag store is unreadable. (In
-/// practice the session store shares the same database, so requests
-/// rarely get this far with a broken pool.)
-pub async fn write_requires_user_token(
-    state: &AppState,
-    oauth: &GithubOAuth,
-) -> Result<bool, (StatusCode, String)> {
-    if oauth.require_user_token {
-        return Ok(true);
-    }
-    // Without a database there is no flag store either (the toggle PUT 503s),
-    // so the env var is the only switch — e.g. OIDC-off local dev.
-    let Some(pool) = &state.pool else {
-        return Ok(false);
-    };
-    crate::feature_flags::flag_enabled(pool, crate::feature_flags::GITHUB_USER_OAUTH)
-        .await
-        .map_err(|e| {
-            tracing::error!(error = %e, "failed to read github.user_oauth feature flag");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "Kon de feature-flags niet lezen; probeer het opnieuw.".to_string(),
-            )
-        })
-}
-
-/// [`write_requires_user_token`], tolerating an unconfigured OAuth
-/// integration: `false` when `github_oauth` is absent (the pre-spike
-/// service-token world).
-///
-/// Used by the traject write resolvers to decide whether a backend that is
-/// read-only **at rest** (no configured service token) may still be
-/// written through: in user-token mode the acting user's own GitHub token
-/// authenticates the commit (`WriteContext::token_override`), so "no
-/// service token" must not 403 the write up-front — the deployed
-/// federation config for a user-created traject repo intentionally has no
-/// `CORPUS_AUTH_*` token for that repo (fail-closed against shipping the
-/// central token to a user-chosen repo).
-pub async fn user_token_write_mode(state: &AppState) -> Result<bool, (StatusCode, String)> {
-    match state.config.github_oauth.as_ref() {
-        Some(oauth) => write_requires_user_token(state, oauth).await,
-        None => Ok(false),
-    }
-}
-
-/// Resolve the per-user GitHub credential to attach to an editor write, read
-/// from the sealed token cookie riding on this request.
-///
-/// * `Ok(None)` — no override; the write uses the backend's configured token
-///   (pre-spike behaviour, or the user simply hasn't linked GitHub and this
-///   deployment doesn't require it).
-/// * `Ok(Some(token))` — use the acting user's own token for this write.
-/// * `Err((428, msg))` — this deployment requires a user token but the user
-///   hasn't linked one (or it expired); the frontend bounces this straight
-///   into the GitHub connect flow (`apiAuthGuard.js`).
-///
-/// **428 is reserved editor-wide for this flow.** `apiAuthGuard.js` redirects
-/// every same-origin `/api/*` response with status 428 into the GitHub
-/// connect flow, keyed on nothing but the status code — an endpoint that
-/// returns 428 for any other reason would silently hijack its callers into
-/// the koppel-flow. Pick a different status for other preconditions.
-///
-/// Precedence contract: a configured service token goes first; the
-/// user-token requirement (incl. the 428 connect-flow) applies only to
-/// token-less write targets. Write handlers should therefore prefer
-/// [`user_write_token_for_backend`], which encodes that rule (and skips
-/// enforcement for backends that ignore the override). Callers of this
-/// bare function must apply the same precedence themselves — resolve the
-/// configured token first and only demand the user token when there is
-/// none (see the create-traject preflight in `trajects.rs`).
-pub async fn user_write_token(
-    state: &AppState,
-    account_id: Uuid,
-    headers: &HeaderMap,
-) -> Result<Option<String>, (StatusCode, String)> {
-    user_token_when_required(
-        state,
-        account_id,
-        headers,
-        "Je GitHub-koppeling is verlopen. Koppel je account opnieuw om op te slaan.",
-        "Koppel je GitHub-account om in dit traject op te slaan. \
-         De wijziging wordt met jouw eigen GitHub-toegang weggeschreven.",
-    )
-    .await
-}
-
-/// Shared core of [`user_write_token`] and [`user_read_token_for_backend`]:
-/// the requiredness gate, the cookie resolution, and the 428 semantics —
-/// parameterised only in the user-facing messages so the read path can say
-/// "lezen" where the write path says "opslaan".
-async fn user_token_when_required(
-    state: &AppState,
-    account_id: Uuid,
-    headers: &HeaderMap,
-    expired_msg: &str,
-    missing_msg: &str,
-) -> Result<Option<String>, (StatusCode, String)> {
-    let Some(oauth) = state.config.github_oauth.as_ref() else {
-        return Ok(None);
-    };
-
-    // The override is gated *entirely* on the requiredness decision. With it
-    // off (the default), every write keeps using the backend's configured
-    // token — byte-identical to pre-spike behaviour, and crucially this holds
-    // even for users who HAVE linked GitHub. That matters for the
-    // operator-managed central repo: routing a linked user's write there
-    // through their personal token would 403 if they lack direct push access,
-    // silently breaking saves that worked before. So linking is inert for
-    // writes until this deployment opts into the "editor is not in the
-    // middle" mode via the feature flag or the env var.
-    if !write_requires_user_token(state, oauth).await? {
-        return Ok(None);
-    }
-
-    // From here the user-token mode is on AND the caller established that
-    // no configured service token applies (the `_for_backend` wrappers
-    // return early on `is_writable` backends): the only outcomes are the
-    // user's own token or a 428. `open_token_cookie` folds every failure
-    // mode (absent, tampered, wrong key, foreign account) into `None` =
-    // not linked, which fails closed into the 428 below.
-    match open_token_cookie(oauth, headers, account_id) {
-        Some(link) if !link.expired() => {
-            tracing::debug!(
-                github_login = %link.github_login,
-                "authorizing traject access as the linked GitHub user"
-            );
-            Ok(Some(link.access_token))
-        }
-        Some(_expired) => Err((StatusCode::PRECONDITION_REQUIRED, expired_msg.to_string())),
-        None => Err((StatusCode::PRECONDITION_REQUIRED, missing_msg.to_string())),
-    }
-}
-
-/// [`user_write_token`], scoped to the backend the write actually goes to.
-///
-/// Enforcement only makes sense for a backend whose `persist` honors
-/// `WriteContext::token_override` (the GitHub Contents-API backend). A
-/// writable-own source can also be `SourceType::Local` — the supported
-/// preview/local-stack configuration — whose backend never touches GitHub or
-/// any token at all. Demanding a linked GitHub account there would 428 every
-/// save with a requirement linking can never satisfy. So: resolve the write
-/// target first, then call this with the resolved backend.
-///
-/// Mirrors [`user_read_token_for_backend`]: a backend with its own
-/// configured (service) token keeps writing with it — `Ok(None)`, so
-/// `persist` uses the backend token and stamps the commit with the
-/// session identity, exactly the pre-user-token flow. The user-token
-/// requirement (and its 428 connect-flow) applies only to token-less,
-/// override-capable backends. Routing writes on a service-token repo
-/// through the user's personal token instead would 403 for every member
-/// whose token GitHub refuses on that repo (no direct push access, or an
-/// org's OAuth App access restrictions blocking the editor app).
-pub async fn user_write_token_for_backend(
-    state: &AppState,
-    account_id: Uuid,
-    headers: &HeaderMap,
-    backend: &dyn RepoBackend,
-) -> Result<Option<String>, (StatusCode, String)> {
-    if !backend.supports_token_override() {
-        return Ok(None);
-    }
-    // `is_writable` on the Contents-API backend means "has a configured
-    // rest token" — the one backend kind that reaches this point. A
-    // configured service token takes precedence over the user token.
-    if backend.is_writable() {
-        return Ok(None);
-    }
-    user_write_token(state, account_id, headers).await
-}
-
-/// The read-path analogue of [`user_write_token_for_backend`]: resolve the
-/// per-user GitHub credential for a **read** on `backend`.
-///
-/// Same precedence rule as the write path: a backend that has its own
-/// configured (service) token keeps using it — `Ok(None)`, behaviour
-/// unchanged — even in the user-token write mode. Rerouting working
-/// service-token traffic through personal tokens would break members
-/// without direct repo access (or whose token GitHub blocks via OAuth App
-/// access restrictions).
-///
-/// So the outcomes are:
-///
-/// * backend ignores token overrides (local source, clone-based git) →
-///   `Ok(None)`;
-/// * backend has a service token → `Ok(None)` (read uses it, as before);
-/// * backend is token-less and override-capable (the traject writable-own
-///   Contents-API backend on a user-chosen repo) → the user's own token,
-///   or the same 428 connect-flow the write path uses when the user hasn't
-///   linked GitHub. Without the user-token mode enabled this stays
-///   `Ok(None)` — the pre-existing (silently degrading) behaviour, exactly
-///   like writes stay on the service-token path there.
-pub async fn user_read_token_for_backend(
-    state: &AppState,
-    account_id: Uuid,
-    headers: &HeaderMap,
-    backend: &dyn RepoBackend,
-) -> Result<Option<String>, (StatusCode, String)> {
-    if !backend.supports_token_override() {
-        return Ok(None);
-    }
-    // `is_writable` on the Contents-API backend means "has a configured
-    // rest token" — the one backend kind that reaches this point.
-    if backend.is_writable() {
-        return Ok(None);
-    }
-    user_read_token(state, account_id, headers).await
-}
-
-/// [`user_read_token_for_backend`] without the backend probes: the raw
-/// requiredness gate + cookie resolution with the read-path messages.
-///
-/// Exists for the one caller that needs the token *before* any backend
-/// exists — the traject **index scan**, which resolves a candidate token
-/// ahead of `build_traject_corpus` so the enumeration of a token-less
-/// writable-own repo can authenticate as the acting user. Because there is
-/// no backend to scope the decision to, callers must treat the result as a
-/// *candidate*: apply it only where a server-side token is absent (the
-/// corpus-side [`regelrecht_corpus::ScanTokenOverride`] enforces that) and
-/// defer the `Err` (428 connect-flow) until a traject-scoped read actually
-/// needs the writable-own source.
-pub async fn user_read_token(
-    state: &AppState,
-    account_id: Uuid,
-    headers: &HeaderMap,
-) -> Result<Option<String>, (StatusCode, String)> {
-    user_token_when_required(
-        state,
-        account_id,
-        headers,
-        "Je GitHub-koppeling is verlopen. Koppel je account opnieuw om de \
-         inhoud van dit traject te kunnen lezen.",
-        "Koppel je GitHub-account om de inhoud van dit traject te kunnen \
-         lezen. De traject-repo wordt met jouw eigen GitHub-toegang gelezen.",
-    )
-    .await
 }
 
 // --- GitHub HTTP calls -----------------------------------------------------

--- a/packages/editor-api/src/lib.rs
+++ b/packages/editor-api/src/lib.rs
@@ -8,6 +8,7 @@
 pub mod accounts;
 pub mod config;
 pub mod corpus_handlers;
+pub mod credentials;
 pub mod crypto;
 pub mod feature_flags;
 pub mod github_oauth;

--- a/packages/editor-api/src/main.rs
+++ b/packages/editor-api/src/main.rs
@@ -19,6 +19,7 @@ use tower_sessions_sqlx_store::PostgresStore;
 mod accounts;
 mod config;
 mod corpus_handlers;
+mod credentials;
 mod crypto;
 mod favorites;
 mod feature_flags;

--- a/packages/editor-api/src/trajects.rs
+++ b/packages/editor-api/src/trajects.rs
@@ -853,60 +853,23 @@ async fn resolve_writable_target(
                 ));
             }
 
-            // Resolve the token to preflight the repo with, following the
-            // same precedence rule as the write path
-            // (`user_write_token_for_backend`): a configured per-repo
-            // service token goes first — the eventual writes on this repo
-            // run over that token too, so preflighting with the user's
-            // personal token would validate an access path the traject
-            // will never use. The strict context (`TokenContext::strict`)
-            // is deliberate: `auth_ref` derives from user-supplied repo
-            // coords, so an unknown ref must NOT fall back to
-            // `CORPUS_GIT_TOKEN` (that would ship the central token to a
-            // user-picked repo, a token-exfiltration vector).
-            //
-            // Only for a token-less ref does the acting user's OWN GitHub
-            // token come into play (user-OAuth spike): the preflight then
-            // validates *their* push access to the chosen repo — the
-            // entitlement check GitHub gives us for free, so the editor
-            // never needs an all-access credential to police repo choice
-            // (the gap that #885 tracks). `user_write_token` returns 428
-            // when a linked token is required but absent.
-            let auth_file = {
-                let corpus = state.corpus.read().await;
-                corpus.auth_file.clone()
-            };
-            let service_token =
-                regelrecht_corpus::auth::CredentialResolver::new(auth_file.as_deref())
-                    .resolve(regelrecht_corpus::auth::TokenContext::strict(&auth_ref))
-                    .map(regelrecht_corpus::auth::TokenDecision::into_token)
-                    .map_err(|e| {
-                        tracing::error!(error = %e, "auth lookup failed for new traject repo");
-                        (
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            "auth lookup failed".to_string(),
-                        )
-                    })?;
-            let token = match service_token {
-                Some(service_token) => service_token,
-                None => crate::github_oauth::user_write_token(state, account_id, headers)
-                    .await?
-                    .ok_or_else(|| {
-                        let env_name = regelrecht_corpus::auth::token_env_name(&auth_ref);
-                        tracing::warn!(
-                            auth_ref = %auth_ref,
-                            env_name = %env_name,
-                            "no token configured for user-supplied repo"
-                        );
-                        (
-                            StatusCode::SERVICE_UNAVAILABLE,
-                            format!(
-                                "deze repo is nog niet door je beheerder geconfigureerd \
-                             (verwacht env var {env_name})"
-                            ),
-                        )
-                    })?,
-            };
+            // Resolve the token to preflight the repo with through the one
+            // credential service, following the same precedence rule as the
+            // write path: a configured per-repo service token goes first — the
+            // eventual writes on this repo run over that token too, so
+            // preflighting with the user's personal token would validate an
+            // access path the traject will never use. Only for a token-less
+            // ref does the acting user's OWN GitHub token come into play
+            // (user-OAuth spike): the preflight then validates *their* push
+            // access to the chosen repo — the entitlement check GitHub gives us
+            // for free, so the editor never needs an all-access credential to
+            // police repo choice (the gap that #885 tracks). The service uses a
+            // strict lookup for `auth_ref` (derived from user-supplied repo
+            // coords), so an unknown ref never falls back to the legacy shared
+            // token, and returns 428 when a linked token is required but absent.
+            let token = crate::credentials::TrajectCredentials::new(state, account_id, headers)
+                .for_new_repo_preflight(&auth_ref)
+                .await?;
 
             // Build the shared GitHub client for the pre-flight. A build
             // failure is an infrastructure problem, not a caller error → 503.

--- a/packages/editor-api/tests/traject_reads_test.rs
+++ b/packages/editor-api/tests/traject_reads_test.rs
@@ -1015,13 +1015,12 @@ async fn feature_flag_row_drives_user_token_requirement() {
     let account_id = Uuid::new_v4();
 
     // Flag row absent (default off): pre-spike behaviour, no override demanded.
-    let token = regelrecht_editor_api::github_oauth::user_write_token(
-        &state,
-        account_id,
-        &HeaderMap::new(),
-    )
-    .await
-    .expect("without the flag no user token may be demanded");
+    let headers = HeaderMap::new();
+    let token =
+        regelrecht_editor_api::credentials::TrajectCredentials::new(&state, account_id, &headers)
+            .user_write_token()
+            .await
+            .expect("without the flag no user token may be demanded");
     assert_eq!(token, None);
 
     // Flip the DB row — the same write the "Functies" toggle PUT performs.
@@ -1035,12 +1034,11 @@ async fn feature_flag_row_drives_user_token_requirement() {
     .expect("flag upsert must succeed");
 
     // Flag on + no linked token cookie → 428 on the GitHub-capable write path.
-    let err = regelrecht_editor_api::github_oauth::user_write_token(
-        &state,
-        account_id,
-        &HeaderMap::new(),
-    )
-    .await
-    .expect_err("flag on without a linked token must refuse the write");
+    let headers = HeaderMap::new();
+    let err =
+        regelrecht_editor_api::credentials::TrajectCredentials::new(&state, account_id, &headers)
+            .user_write_token()
+            .await
+            .expect_err("flag on without a linked token must refuse the write");
     assert_eq!(err.0, StatusCode::PRECONDITION_REQUIRED);
 }


### PR DESCRIPTION
## Wat

Introduceert één credential-service (`TrajectCredentials`) in `editor-api` die
per request beantwoordt: *welk token authenticeert deze traject-lees/-schrijf,
en wat als het er niet is*. Voorheen deed elke handler dat met de hand — een
write-token-resolutie, een losse read-token-resolutie, een aparte
schrijfbaarheids-gate en een `WriteContext { token_override }` die ter plekke
werd opgebouwd.

## Waarom

Die vier stappen waren elk los te vergeten. Een nieuwe call-site die er één
oversloeg compileerde gewoon en viel stil terug op het gedeelde service-token
in plaats van het persoonlijke token van de gebruiker — precies de foutklasse
achter een eerdere promote-regressie. Door de beslissing op één plek te
concentreren kan dat niet meer per ongeluk.

## Hoe

- **`for_read(backend, writable_at_rest)`** en **`for_write(backend,
  writable_at_rest)`** als enige ingangen, plus twee backend-loze varianten
  voor de index-scan (`read_scan_candidate`) en de traject-aanmaak-preflight
  (`for_new_repo_preflight`).
- **`for_write`** levert een `WriteAuthorization` — de enige manier waarop een
  handler een `token_override` in een `WriteContext` krijgt. De
  schrijfbaarheids-gate (403) en het per-user token (428 wanneer vereist maar
  niet gekoppeld/verlopen) worden in één resolutie bepaald, zodat ze niet meer
  uiteen kunnen lopen. Datzelfde token bedient meteen de
  optimistic-concurrency-precondition-lees, dus één credential-resolutie per
  write in plaats van een aparte write- en read-lookup die konden verschillen.
- De beslissing "eigen service-token vs. persoonlijk token" leunt **niet langer
  op `RepoBackend::is_writable()`** als proxy voor "heeft service-token", maar op
  de expliciete *writable-at-rest*-capability die bij backend-registratie is
  vastgelegd — losgekoppeld van wat `is_writable()` toevallig betekent.
- De writability-gate (`require_traject_backend_writable`), de per-request
  read-token-resolutie en de user-OAuth/428-helpers zijn in de service
  opgegaan; de ~15 call-sites in `corpus_handlers.rs` zijn herbedraad. De
  aanmaak-preflight loopt via dezelfde service (strikte lookup via de
  corpus-`CredentialResolver`, met behoud van de 428/503-semantiek en de
  env-var-hint).
- Het bewuste verschil tussen de twee requiredness-varianten (de gate mag niet
  500'en op een ontbrekende OAuth-config) is gedocumenteerd, niet verloren.

## Tests

- Nieuwe beslistabel-tests op de service dekken de matrix `{writable-at-rest,
  service-token, override-capability, requiredness, gekoppeld/afwezig,
  read|write}` → `{tokenbron, HTTP-fout}`.
- Bestaande unit- en integratietests van `editor-api` blijven groen
  (o.a. de service-token-voorrang, de user-token-writes/-reads en de
  promote-flow); gedrag ongewijzigd. `cargo fmt`, `clippy -Dwarnings` en
  `cargo check` schoon.
