### PR TITLE
fix(dev): uitklappen in de architectuurverkenner werkte niet

### DIFF
--- a/packages/arch-extract/ui/src/composables/useArchGraph.js
+++ b/packages/arch-extract/ui/src/composables/useArchGraph.js
@@ -190,7 +190,9 @@ function buildFlow(model, expanded) {
         .filter(Boolean)
         .join(' '),
       style: { width: `${size.w}px`, height: `${size.h}px` },
-      zIndex: depth,
+      // depth + 1 so every node outranks the edge layer (zIndex 0 below);
+      // deeper nodes still stack above their own container.
+      zIndex: depth + 1,
     });
     for (const k of visibleChildren(id)) emit(k, depth + 1);
   };
@@ -211,7 +213,11 @@ function buildFlow(model, expanded) {
       type: 'default',
       style,
       markerEnd: { type: MarkerType.ArrowClosed, color: style.stroke, width: 16, height: 16 },
-      zIndex: 2000,
+      // Below every node (which start at 1). Edges used to sit at 2000, which
+      // drew the lines over the node boxes and — worse — put Vue Flow's
+      // invisible 20px-wide `.vue-flow__edge-interaction` hit path on top of
+      // the expand toggles, swallowing the click on most nodes.
+      zIndex: 0,
     });
   }
 

--- a/packages/arch-extract/ui/src/styles.css
+++ b/packages/arch-extract/ui/src/styles.css
@@ -243,7 +243,15 @@ body,
   background: transparent;
   color: var(--text-muted);
   cursor: pointer;
-  padding: 2px 4px;
+  /* 24x24 hit target: the canvas opens at fit-view zoom (~0.4 on the crate
+     level), so a snug button shrinks to a handful of screen pixels. */
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  padding: 0;
   border-radius: 4px;
   line-height: 1;
 }
@@ -371,6 +379,14 @@ body,
 /* Handles exist for edge attachment but are not user-facing (no connecting). */
 .vue-flow__handle {
   opacity: 0;
+  pointer-events: none;
+}
+
+/* Vue Flow lays an invisible 20px-wide stroke over every edge to make it easy
+   to hover/click. Nothing here reacts to an edge click, so that hit path only
+   steals clicks from the node controls underneath it. Belt and braces next to
+   the edge z-index: a wide stroke would still cover a node it crosses. */
+.vue-flow__edge-interaction {
   pointer-events: none;
 }
 


### PR DESCRIPTION
## Wat was er kapot

In de architectuurverkenner (`just arch-explore`) gebeurde er niets als je op een uitklap-driehoekje klikte. Op het beginscherm waren **10 van de 14 driehoekjes onbereikbaar** — alleen `admin`, `github`, `frontend` en `frontend-lawmaking` lagen vrij.

## Oorzaak

`useArchGraph.js` zette edges op `zIndex: 2000`, terwijl nodes `zIndex: depth` kregen (0 en hoger). Alle lijnen lagen dus boven alle blokjes.

Vue Flow legt onder elke edge een onzichtbare `<path class="vue-flow__edge-interaction">` met `stroke-width="20"` en `pointer-events: visibleStroke`, zodat een edge makkelijk te hoveren en te klikken is. Door die z-index lag die band van 20 px over de driehoekjes heen en ving hij de klik af. Playwright weigerde de klik met zoveel woorden:

```
<path class="vue-flow__edge-interaction" stroke-width="20" stroke-opacity="0" …>
  from <svg class="vue-flow__edges"> subtree intercepts pointer events
```

Dat verklaarde ook waarom de lijnen slecht leesbaar waren: ze werden over de node-blokjes heen getekend.

## Wijzigingen

| Wat | Van | Naar |
|---|---|---|
| `zIndex` op edges | 2000 | 0 |
| `zIndex` op nodes | `depth` | `depth + 1` |
| `.vue-flow__edge-interaction` | `pointer-events: visibleStroke` | `none` |
| Klikdoel driehoekje | 14 × 16 px | 24 × 24 px |

De `pointer-events`-regel staat naast de z-index-fix omdat een 20 px brede stroke ook een node bedekt die hij kruist. Niets in deze UI reageert op een edge-klik (`:nodes-connectable="false"`, geen edge-handlers), dus die hit-path kan alleen maar klikken stelen.

Het grotere klikdoel is nodig omdat de canvas opent op fit-view-zoom (~0,41 op crate-niveau); daardoor kwam het knopje op ~6 × 7 schermpixels uit.

De editor lost dit al goed op — `useLawGraph.js` houdt zijn edges op `zIndex: 1`–`2`. Dat patroon is bij het nabouwen van de verkenner net omgedraaid.

## Verificatie

In de browser gemeten via `document.elementFromPoint` op het midden van elk driehoekje:

| | Voor | Na |
|---|---:|---:|
| Driehoekjes afgevangen door een edge (crate-niveau) | 10 / 14 | **0 / 14** |
| Idem op moduleniveau, engine uitgeklapt | — | **0 / 18** |
| Klikdoel op scherm bij startzoom | 5,8 × 6,6 px | 20,3 × 20,3 px |

Uitklappen werkt drie niveaus diep: crate → module → type, 14 → 36 → 48 nodes. Een echte Playwright-muisklik op het `engine`-driehoekje liep eerst in een timeout en slaagt nu.

`just arch-test` groen (11 tests). De wijziging raakt alleen `ui/`; de rest van `just check` dekt Rust-paden die niet aangeraakt zijn.

## Extra CSS

Conform de CLAUDE.md-regel over aanvullende CSS — dit zijn geen design-system-componenten maar de eigen stylesheet van dit interne dev-tool:

- `.vue-flow__edge-interaction { pointer-events: none }` — Vue Flow-override, zie hierboven
- `.arch-node__toggle` van `padding: 2px 4px` naar een vaste `24px` × `24px` flex-box, om het klikdoel op fit-view-zoom bruikbaar te houden

## Nog open

Dat de verkenner de graph-tooling van de editor heeft nagebouwd in plaats van gedeeld (inclusief een tweede `useColorScheme` naast die in `packages/frontend-shared`) is hier niet aangepakt — dat wordt een apart ticket.