### PR TITLE
feat(dev): relaties tussen sub-componenten zichtbaar in de architectuurverkenner

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -614,10 +614,13 @@ arch-explore:
     cd packages/arch-extract/ui && npm install && npm run build
     cd packages && cargo run --release --quiet -p regelrecht-arch-extract -- serve
 
-# Run the arch-extract tests (schema validation of the generated model + the
-# prose-sidecar drift logic). Part of `just check`.
+# Run the arch-extract tests: the Rust side (schema validation of the generated
+# model + the prose-sidecar drift logic) and the explorer UI's vitest suite
+# (edge-lifting / aggregation logic). Part of `just check`.
 arch-test:
     cd packages && {{ci_flags}} cargo test -p regelrecht-arch-extract
+    npm --prefix packages/arch-extract/ui install
+    npm --prefix packages/arch-extract/ui test
 
 # --- Architecture prose sidecar ---
 # Per-node "wat/waarom" narrative lives beside the model in

--- a/packages/arch-extract/README.md
+++ b/packages/arch-extract/README.md
@@ -66,6 +66,37 @@ cargo run -p regelrecht-arch-extract -- serve      # terminal 1 (API on :7180)
 npm --prefix packages/arch-extract/ui run dev        # terminal 2 (UI on :7181)
 ```
 
+### Relations in the explorer (rolled-up edges)
+
+The model holds ~1500 relations over ~2400 nodes, but only a handful of nodes
+are on screen at once (the explorer expands lazily). So the explorer **rolls
+every relation up to the detail level currently on screen** — no relation is
+ever silently dropped:
+
+- **Edge-lifting.** Each end of a relation is lifted to its nearest *visible*
+  ancestor, and relations between the same lifted pair, of the same kind, are
+  aggregated into **one line with a count**. The line's colour still encodes the
+  kind (`depends-on` / `impl` / `uses`); its thickness scales logarithmically
+  with the count. Expanding one side refines the line — its endpoint slides from
+  crate to module to type.
+- **The number on a line** is how many underlying relations it represents.
+  Lines with a count greater than one carry a small **clickable badge**: click
+  it to reveal the underlying relations. The line then splits into its exact
+  sub-lines and the canvas eases to the involved nodes. To avoid opening
+  hundreds of nodes at once, a very wide roll-up (more than ~25 underlying
+  pairs) opens only one level per click; click again to keep refining.
+- **Internal relations become a counter, not a line.** When *both* ends of a
+  relation roll up to the *same* visible node, there is nothing to draw between —
+  it is an internal relation of that subtree. It shows as a small ↺ counter on
+  the node instead of a self-loop. (A relation whose lifted ends are in a
+  containment relation — one contains the other — is nesting, not a relation,
+  and is drawn as neither a line nor a counter.)
+- **Filters.** The toolbar has a toggle per relation kind (`depends-on` /
+  `impl` / `uses`), all on by default and persisted in localStorage. A disabled
+  kind is excluded from the lines, the weights and the counters; the toolbar
+  shows how many relations are currently visible of the total. (`calls` is not
+  offered — the model deliberately never produces that kind.)
+
 ### Known limitations
 
 - **Accessibility.** The explorer is an internal-only developer tool. Its Vue
@@ -372,3 +403,13 @@ now resolve (and that no edge points outside the workspace — the "no false edg
 guard), and confirms generation is deterministic — so a malformed model or a lost
 edge fails CI. The edge-resolution logic itself (path/`use` resolution, the
 drop-don't-guess rules) is unit-tested in `src/syn_pass.rs`.
+
+The explorer UI has its own unit tests (`ui/`, `vitest`): the edge-lifting and
+aggregation logic in `useArchGraph.js` is a pure function of
+`(model, expanded, enabledKinds)`, so `ui/src/composables/useArchGraph.test.js`
+covers lifting to the nearest visible ancestor, internal relations becoming a
+counter, containment pairs being skipped, aggregation weight/pairs, refinement
+on expand, a disabled kind counting nowhere, and the reveal policy (including the
+one-level fallback above the limit) without a DOM. `just arch-test` runs both the
+Rust tests and `npm --prefix packages/arch-extract/ui test`, so `just check`
+gates them together.

--- a/packages/arch-extract/ui/package-lock.json
+++ b/packages/arch-extract/ui/package-lock.json
@@ -16,7 +16,8 @@
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "^6.0.7",
-        "vite": "^8.0.16"
+        "vite": "^8.0.16",
+        "vitest": "^3.2.4"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -66,37 +67,482 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "version": "2.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-2.0.0-alpha.3.tgz",
+      "integrity": "sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g==",
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
+        "@emnapi/wasi-threads": "2.0.1",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "version": "2.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-2.0.0-alpha.3.tgz",
+      "integrity": "sha512-hFPAhMUjJD9BSyCANEISPOogeXC9Zo9ZQl7L6vKnaVsMkCtzznaW/naYypeyl0Gv5rYfWYsZbpixTMpjDJzQeA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-2.0.1.tgz",
+      "integrity": "sha512-9DsSk+o5NBX0CCJT8s0EROGSGxjR/tKu6aBTaVyq+SjAEQH4XcdcRxPBRzsBLizTTJ49MJjF+jgu3qnO9GLQcQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -106,22 +552,25 @@
       "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
-      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.0.tgz",
+      "integrity": "sha512-kDoONqMa+VnZ4vvvu/ZUurpJ4gkZU57e7g69qpNgWhYcZFPUHZM2CEMKm+cG6ufDVALbjMvfmMjFVqaK7uEMnA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@tybys/wasm-util": "^0.10.3"
       },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
+      },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
       },
       "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
+        "@emnapi/core": "^2.0.0-alpha.3",
+        "@emnapi/runtime": "^2.0.0-alpha.3"
       }
     },
     "node_modules/@oxc-project/types": {
@@ -357,6 +806,40 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
@@ -398,6 +881,356 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.3.tgz",
+      "integrity": "sha512-c0wdcekXtQvvn5Tsrk/+op/gUArrbWaFduBnTLP2l1cKLSQs4diMWjJw3m6A0DdzT8dAAX95KpkJ3qynCePbmw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.3.tgz",
+      "integrity": "sha512-3YjElDdWN+qXAFbJ/CzPV+0wspLqh54k/I6GfdYtEJRqg7buSgc1yPM3B+93j1M4neobtkATHZTmxK2AMVGfnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.3.tgz",
+      "integrity": "sha512-Pch2pFNOxxz1hTjypIdPyRTR6riiwRl84+VcN9djS680fw+Co1nAJINrdpqp7KV0NvyuU8ilZXZCjd7ykJl1GQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.3.tgz",
+      "integrity": "sha512-LEuncFUHFiF8t4yZVZvvZA1wk0pjAscRnsrn1EfTEmN4HXotBi2YtcnLRyaK6UbuczW7xZS5ES+81Rdz8Z0T6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.3.tgz",
+      "integrity": "sha512-zvBUvsQUpOWALdDsk6qbS8bXf2VxmPisuudNDrY7x0p0jBdsoZl8HsHczIOgkQiZldmcacMKtBzpoGVNeIe2bQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.3.tgz",
+      "integrity": "sha512-C2KmNrcSem/AMg984H/dev+si0lieQGdXdR/lYGJnuumXnFb9Y7QdiI62obFdLlxRYLBv4P0eUVIDbD4c1vVvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.3.tgz",
+      "integrity": "sha512-ggXnsTAEzNQx74XpunRsiZ9aBZDsI7XIa0hm2nzR9f4WzH5/f/d73ZSDaC5ejJ8YLY4NW+V3wr0tjOaeCq8hqA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.3.tgz",
+      "integrity": "sha512-2vng+FlzNUhKZxtej3IUqJgbZoQk2M/dwQM20+ULV0R/E/8tr9/P6uEf2iiGIk4HL0zMKh5Jry7mUHdUOvyGgA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.3.tgz",
+      "integrity": "sha512-LLLFZKt4/Nraf9rxDkhiU8QVgLF4WmCkfr0L4fj0fPfIZFBib0DeiFk1hhaYKd03LFAFJcxHslhDFlNJLylf5Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.3.tgz",
+      "integrity": "sha512-WJkdQCvS9sWNOUBJZfQRKpZGFBztRzcowI+nndmflKgU4XY+3a420FgTOSKTsVqJbnzSxeT4vaJalpOaPo2YCQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.3.tgz",
+      "integrity": "sha512-PwHXCCS2n64/1Ot6rP1YEYA02MGYBcQlr8CSZZyrUG2O7NH6NklYmvr9v3Jy+5e/eDeNchc/ukmKJi9LuflMIQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.3.tgz",
+      "integrity": "sha512-vUjxINQu3RC8NZS3ykk1gN65gIz8pAopOq2HXuZhiIxHdx7TFvDG+jgrdSgInu1Eza4/Rfi2VzZgyIgEH4WOaw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.3.tgz",
+      "integrity": "sha512-wzko4aJ13+0G3kGnviCg5gnXFKd40izKsrf2uOw12US4XqprkDrmwOpeW14aSNa37V8bfPcz5Fkob6LZ3BAPmA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.3.tgz",
+      "integrity": "sha512-8120ue0JUMSwy11stlwnfdX3pPd+WZYGCDBwEHWtIHi6pOpZmsEF5QKB7a/UN+XFdqvobxz98kv8RTqikyCEBw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.3.tgz",
+      "integrity": "sha512-XLFHnR3tXMjbOCh2vtVJHmxt+995uJsTERQyseFDRA0xxMxyTZPLa3OIUlyFaO4mF/Lu0FjmWHCuPXJT1n/IOg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.3.tgz",
+      "integrity": "sha512-se6yXvNGMIl0f+RQzyh7XAmia8/9kplQx424wnG2w0C1oi6XgO6Y8otKhdXFHbHs88Ihavzmvh1NWjuovE76BQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.3.tgz",
+      "integrity": "sha512-gNoxRefktVIiGflpONuxWWXZAzIQG++z9qHO3xKwk4WdDMuQja3JHGfE1u0i3PfPDyvhypdk+WrgIJqLhGG7sg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.3.tgz",
+      "integrity": "sha512-V4KtWtQfAFMU7+9/A/VDps/VI8CHd3cYz0L8sgJzz8qK7eY7wI4ruFD82UYIYvW9Z4DtlTfhQcsl4XyPHW5uSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.3.tgz",
+      "integrity": "sha512-LBx9LYXvj2CBkMkjLdNAWLwH0MLMin7do2VcVo9kVPibGLkY0BQQut2fv7NVqkXqZ/CrAu9LqDHVV1xHCMpCPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.3.tgz",
+      "integrity": "sha512-ABVf3Q0RCu7NcyCCOZQI0pJ3GuSdfSl8EXcy88QtdceIMIoCUdfhsJChZ64L9zVM2aJHjde1Bhn5uqSRcX9ySA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.3.tgz",
+      "integrity": "sha512-+2Cy/ldweGBLlPIKsQLF8U5N44a0KDdbrk1rAjHOM9M2K+kGdIVjHLmmrZIcx+9Ny3ke/1JomCsDI1ocb11+sg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.3.tgz",
+      "integrity": "sha512-dtZvzc8BedpSaFNy75x6uiWwAGTH+aZHDtdrqP6qk+WcLJrfti6sGje1ZJ9UxyzDLF23d/mV+PaMwuC0hL7UVA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.3.tgz",
+      "integrity": "sha512-Rj8Ra4noo+aYy7sKBggCx0407mws34kAb1ySyWuq5DAtFBQdkSwnsjCgPrhPe9cvgBKZIukpE+CVHvORCS93kQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.3.tgz",
+      "integrity": "sha512-vp7N084ew/odXn2gi/mzm9mUkQu9l6AiN6dt4IeUM2Uvm9o+cVmP+YkqbMOteLbiGgqBBlJZjIMYVCfOOIVbVQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.3.tgz",
+      "integrity": "sha512-MOG/3gTOn4Fwf574RVOaY61I5o6P90legkFADiTyn1hyjNydT+cerU2rLUwPdZkKKyJ+iT+K9p7WXK4LM1Ka6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
@@ -408,6 +1241,31 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/web-bluetooth": {
       "version": "0.0.20",
@@ -430,6 +1288,94 @@
       "peerDependencies": {
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vue-flow/background": {
@@ -668,6 +1614,53 @@
         }
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -779,6 +1772,34 @@
         "node": ">=12"
       }
     },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -801,11 +1822,70 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -839,6 +1919,13 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lightningcss": {
       "version": "1.33.0",
@@ -1101,6 +2188,13 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -1109,6 +2203,13 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.16",
@@ -1126,6 +2227,23 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/picocolors": {
@@ -1148,9 +2266,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.23",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
-      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
+      "version": "8.5.24",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.24.tgz",
+      "integrity": "sha512-8RyVklq0owXUTa4xlpzu4l9AaVKIdQvAcOHZWaMh98HgySsUtxRVf/chRe3dsSLqb6i40BzGRzEUddRaI+9TSw==",
       "funding": [
         {
           "type": "opencollective",
@@ -1209,6 +2327,58 @@
         "@rolldown/binding-win32-x64-msvc": "1.1.5"
       }
     },
+    "node_modules/rollup": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.3.tgz",
+      "integrity": "sha512-Gu0c0iH9FzgX1L1t7ByIbbS3Vmdz+6KHm/EsqmmC71gUQ82yvZRkTK6XzrFObSka91WUVdynqp6nsfilzr5k6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.3",
+        "@rollup/rollup-android-arm64": "4.62.3",
+        "@rollup/rollup-darwin-arm64": "4.62.3",
+        "@rollup/rollup-darwin-x64": "4.62.3",
+        "@rollup/rollup-freebsd-arm64": "4.62.3",
+        "@rollup/rollup-freebsd-x64": "4.62.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.3",
+        "@rollup/rollup-linux-arm64-musl": "4.62.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.3",
+        "@rollup/rollup-linux-loong64-musl": "4.62.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.3",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.3",
+        "@rollup/rollup-linux-x64-gnu": "4.62.3",
+        "@rollup/rollup-linux-x64-musl": "4.62.3",
+        "@rollup/rollup-openbsd-x64": "4.62.3",
+        "@rollup/rollup-openharmony-arm64": "4.62.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.3",
+        "@rollup/rollup-win32-x64-gnu": "4.62.3",
+        "@rollup/rollup-win32-x64-msvc": "4.62.3",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1217,6 +2387,47 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
@@ -1233,6 +2444,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tslib": {
@@ -1321,6 +2562,289 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vue": {
       "version": "3.5.40",
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.40.tgz",
@@ -1340,6 +2864,23 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     }
   }

--- a/packages/arch-extract/ui/package.json
+++ b/packages/arch-extract/ui/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@vue-flow/background": "^1.3.2",
@@ -18,6 +19,7 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^6.0.7",
-    "vite": "^8.0.16"
+    "vite": "^8.0.16",
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/arch-extract/ui/src/components/ArchEdge.vue
+++ b/packages/arch-extract/ui/src/components/ArchEdge.vue
@@ -1,0 +1,71 @@
+<script setup>
+/**
+ * ArchEdge — a rolled-up relationship line with a clickable count badge.
+ *
+ * The line itself is a plain `<BaseEdge>` on a bezier path, identical in shape
+ * to Vue Flow's built-in `default` edge, so the visuals match the pre-lifting
+ * edges. When the edge aggregates more than one underlying relation
+ * (`weight > 1`) it also renders a small badge in the `<EdgeLabelRenderer>`
+ * layer showing the count; clicking the badge reveals the underlying relations.
+ *
+ * Only the badge is a click target. Vue Flow's invisible 20px interaction path
+ * under every edge keeps `pointer-events: none` (see styles.css) so it cannot
+ * steal clicks from the node expand toggles it crosses (regression from #982);
+ * the label layer as a whole is click-through and only the badge re-enables
+ * pointer events.
+ */
+import { computed, inject } from 'vue';
+import { BaseEdge, EdgeLabelRenderer, getBezierPath } from '@vue-flow/core';
+
+const props = defineProps({
+  id: { type: String, required: true },
+  sourceX: { type: Number, required: true },
+  sourceY: { type: Number, required: true },
+  targetX: { type: Number, required: true },
+  targetY: { type: Number, required: true },
+  sourcePosition: { type: String, default: undefined },
+  targetPosition: { type: String, default: undefined },
+  data: { type: Object, default: () => ({}) },
+  markerEnd: { type: String, default: undefined },
+  style: { type: Object, default: () => ({}) },
+});
+
+const revealEdge = inject('revealEdge', null);
+
+const path = computed(() =>
+  getBezierPath({
+    sourceX: props.sourceX,
+    sourceY: props.sourceY,
+    sourcePosition: props.sourcePosition,
+    targetX: props.targetX,
+    targetY: props.targetY,
+    targetPosition: props.targetPosition,
+  }),
+);
+
+const weight = computed(() => props.data?.weight ?? 1);
+const labelStyle = computed(() => ({
+  transform: `translate(-50%, -50%) translate(${path.value[1]}px, ${path.value[2]}px)`,
+}));
+
+function onReveal(event) {
+  event.stopPropagation();
+  revealEdge?.(props.data);
+}
+</script>
+
+<template>
+  <BaseEdge :id="id" :path="path[0]" :marker-end="markerEnd" :style="style" />
+  <EdgeLabelRenderer v-if="weight > 1">
+    <button
+      type="button"
+      class="arch-edge__badge nodrag nopan"
+      :class="`arch-edge__badge--${data.kind}`"
+      :style="labelStyle"
+      :title="`${weight} onderliggende relaties — klik om te ontvouwen`"
+      @click="onReveal"
+    >
+      {{ weight }}
+    </button>
+  </EdgeLabelRenderer>
+</template>

--- a/packages/arch-extract/ui/src/components/ArchExplorer.vue
+++ b/packages/arch-extract/ui/src/components/ArchExplorer.vue
@@ -1,6 +1,6 @@
 <script setup>
-import { computed, markRaw, provide, ref, watch } from 'vue';
-import { VueFlow } from '@vue-flow/core';
+import { computed, markRaw, nextTick, provide, ref, watch } from 'vue';
+import { VueFlow, useVueFlow } from '@vue-flow/core';
 import { Background } from '@vue-flow/background';
 import { Controls } from '@vue-flow/controls';
 import { MiniMap } from '@vue-flow/minimap';
@@ -10,6 +10,7 @@ import '@vue-flow/controls/dist/style.css';
 import '@vue-flow/minimap/dist/style.css';
 
 import ArchNode from './ArchNode.vue';
+import ArchEdge from './ArchEdge.vue';
 import DetailPanel from './DetailPanel.vue';
 import { useArchGraph } from '../composables/useArchGraph.js';
 import { useColorScheme } from '../composables/useColorScheme.js';
@@ -20,8 +21,24 @@ const props = defineProps({
 });
 
 const nodeTypes = markRaw({ arch: ArchNode });
+const edgeTypes = markRaw({ arch: ArchEdge });
 
-const { model, nodes, edges, setModel, toggle, expandSubtree, collapseAll } = useArchGraph();
+const {
+  model,
+  nodes,
+  edges,
+  stats,
+  setModel,
+  toggle,
+  expandSubtree,
+  collapseAll,
+  revealEdge,
+  toggleKind,
+  kindEnabled,
+  FILTERABLE_KINDS,
+} = useArchGraph();
+
+const { fitView } = useVueFlow();
 
 watch(
   () => props.model,
@@ -51,6 +68,15 @@ provide('toggleExpand', toggle);
 provide('expandSubtree', expandSubtree);
 provide('selectNode', selectNode);
 
+// Clicking a rolled-up line's badge reveals its underlying relations, then the
+// canvas eases to the involved nodes. Same injection pattern as above.
+provide('revealEdge', (data) => {
+  const fitIds = revealEdge(data);
+  nextTick(() => {
+    fitView({ nodes: fitIds, duration: 500, padding: 0.3 });
+  });
+});
+
 // --- Theme ----------------------------------------------------------------
 const { colorScheme, cycleColorScheme } = useColorScheme();
 const themeLabel = computed(
@@ -67,21 +93,34 @@ function miniMapNodeColor(node) {
 }
 
 const nodeCount = computed(() => (model.value ? model.value.nodes.length : 0));
-const edgeCount = computed(() => (model.value ? model.value.edges.length : 0));
+
+// Which CSS legend swatch class an edge kind maps to.
+const KIND_SWATCH = { 'depends-on': 'lg-depends', impl: 'lg-impl', uses: 'lg-uses' };
 </script>
 
 <template>
   <div class="arch-explorer">
     <header class="arch-toolbar">
       <strong class="arch-toolbar__title">Architectuurverkenner</strong>
-      <span class="arch-toolbar__stat">{{ nodeCount }} nodes · {{ edgeCount }} edges</span>
+      <span class="arch-toolbar__stat">
+        {{ nodeCount }} nodes · {{ stats.visible }}/{{ stats.total }} relaties zichtbaar
+      </span>
 
       <div class="arch-toolbar__spacer"></div>
 
-      <div class="arch-legend" aria-hidden="true">
-        <span class="arch-legend__item"><i class="lg lg-depends"></i>depends-on</span>
-        <span class="arch-legend__item"><i class="lg lg-impl"></i>impl</span>
-        <span class="arch-legend__item"><i class="lg lg-uses"></i>uses</span>
+      <div class="arch-filters" role="group" aria-label="Relatiesoorten filteren">
+        <button
+          v-for="kind in FILTERABLE_KINDS"
+          :key="kind"
+          type="button"
+          class="arch-filter"
+          :class="{ 'arch-filter--off': !kindEnabled(kind) }"
+          :aria-pressed="kindEnabled(kind)"
+          :title="kindEnabled(kind) ? `${kind} verbergen` : `${kind} tonen`"
+          @click="toggleKind(kind)"
+        >
+          <i class="lg" :class="KIND_SWATCH[kind]"></i>{{ kind }}
+        </button>
       </div>
 
       <button type="button" class="arch-btn" @click="collapseAll">Alles inklappen</button>
@@ -95,6 +134,7 @@ const edgeCount = computed(() => (model.value ? model.value.edges.length : 0));
         :nodes="nodes"
         :edges="edges"
         :node-types="nodeTypes"
+        :edge-types="edgeTypes"
         :nodes-connectable="false"
         :min-zoom="0.05"
         :max-zoom="4"

--- a/packages/arch-extract/ui/src/components/ArchNode.vue
+++ b/packages/arch-extract/ui/src/components/ArchNode.vue
@@ -30,10 +30,18 @@ function onExpandAll(event) {
 </script>
 
 <template>
-  <!-- Handles are hidden via CSS (edges are not user-connectable) but must
-       exist for relationship edges to attach to. -->
-  <Handle type="target" :position="Position.Left" />
-  <Handle type="source" :position="Position.Right" />
+  <!-- Eight handles (source + target on each side), hidden via CSS. Edges are
+       not user-connectable; the handles exist so buildFlow can attach a
+       relationship line to whichever side faces the other endpoint, keeping
+       lines from always running left-to-right. -->
+  <Handle id="source-top" type="source" :position="Position.Top" />
+  <Handle id="target-top" type="target" :position="Position.Top" />
+  <Handle id="source-right" type="source" :position="Position.Right" />
+  <Handle id="target-right" type="target" :position="Position.Right" />
+  <Handle id="source-bottom" type="source" :position="Position.Bottom" />
+  <Handle id="target-bottom" type="target" :position="Position.Bottom" />
+  <Handle id="source-left" type="source" :position="Position.Left" />
+  <Handle id="target-left" type="target" :position="Position.Left" />
 
   <div class="arch-node__header" @click="onSelect">
     <button
@@ -49,6 +57,11 @@ function onExpandAll(event) {
 
     <span class="arch-node__kind">{{ kindLabel }}</span>
     <span class="arch-node__name" :title="node.name">{{ node.name }}</span>
+    <span
+      v-if="data.internalCount > 0"
+      class="arch-node__internal"
+      :title="`${data.internalCount} interne relatie(s) tussen onderliggende onderdelen`"
+    >↺ {{ data.internalCount }}</span>
     <span v-if="data.expandable" class="arch-node__count">{{ data.childCount }}</span>
   </div>
 </template>

--- a/packages/arch-extract/ui/src/composables/useArchGraph.js
+++ b/packages/arch-extract/ui/src/composables/useArchGraph.js
@@ -13,9 +13,19 @@
  * positions relative to their parent, and each expanded parent is grown to a
  * padded grid that contains its (recursively laid out) children. Collapsed and
  * leaf nodes get a fixed header-sized box.
+ *
+ * Relationships are **edge-lifted**: every edge in the model is always
+ * accounted for, rolled up to whatever detail level is currently on screen.
+ * Each endpoint is lifted to its nearest *visible* ancestor; edges that lift to
+ * the same node become an internal counter on that node instead of a line;
+ * edges whose lifted ends are in an ancestor/descendant relation are containment
+ * and drawn as nesting, not a line; the rest are aggregated per
+ * `kind|from->to` into one weighted line. Expanding a node refines the lines
+ * that touched it. See packages/arch-extract/README.md.
  */
 import { computed, ref, shallowRef } from 'vue';
 import { MarkerType } from '@vue-flow/core';
+import { useEdgeFilters } from './useEdgeFilters.js';
 
 // --- Layout constants -------------------------------------------------------
 const NODE_W = 220; // width of a collapsed / leaf node
@@ -23,9 +33,18 @@ const HEADER_H = 46; // height of a node's own header strip
 const PAD = 20; // inner padding around a parent's children
 const GAP = 18; // gap between sibling children
 const MAX_COLS = 5; // cap the grid width so deep crates don't sprawl sideways
-const ROOT_GAP_X = 80;
-const ROOT_GAP_Y = 80;
-const ROOT_ROW_MAX_W = 1800; // wrap the crate row past this width
+
+// Layered root layout (see layoutRoots). Roots become topological layers on the
+// aggregated `depends-on` graph so dependencies overwhelmingly flow one way.
+const ROOT_LAYER_GAP_X = 140; // horizontal gap between dependency layers
+const ROOT_COL_GAP_X = 70; // gap between wrapped sub-columns inside one layer
+const ROOT_GAP_Y = 80; // vertical gap between stacked roots
+const ROOT_MAX_PER_COL = 4; // wrap a layer into a new sub-column past this many
+
+// Above this many underlying pairs, revealing a rolled-up line opens only one
+// level instead of every ancestor chain, so one click never opens hundreds of
+// nodes. Repeated clicks refine step by step. (Acceptance criterion 7.)
+export const REVEAL_LIMIT = 25;
 
 // Sort order for children: coarse kinds first, then alphabetically. Keeps a
 // crate's modules above its loose fns, types above their methods, etc. The
@@ -47,13 +66,27 @@ const KIND_RANK = {
 };
 
 // Per-edge-kind styling. Visually distinct so `depends-on` / `impl` / `uses`
-// are told apart at a glance (acceptance criterion).
+// are told apart at a glance (acceptance criterion). `strokeWidth` is the
+// *base* dikte per soort; a rolled-up line scales up logarithmically from it
+// (see scaledStrokeWidth) so the colour coding stays intact.
 const EDGE_STYLE = {
   'depends-on': { stroke: '#6366f1', strokeWidth: 2.5 },
   impl: { stroke: '#10b981', strokeWidth: 2, strokeDasharray: '7 4' },
   uses: { stroke: '#94a3b8', strokeWidth: 1.5, strokeDasharray: '2 4' },
   calls: { stroke: '#f59e0b', strokeWidth: 1.5 },
 };
+
+export { EDGE_STYLE };
+
+/**
+ * Log-scale a rolled-up line's width off the per-kind base. weight 1 → base
+ * (so a single relation keeps its kind's dikte); heavier lines grow toward a
+ * ~9px cap. (Acceptance criterion 4.)
+ */
+function scaledStrokeWidth(base, weight) {
+  const w = base + Math.log2(Math.max(1, weight)) * 1.2;
+  return Math.min(9, Math.max(1.5, Math.round(w * 10) / 10));
+}
 
 function sortChildren(byId) {
   return (a, b) => {
@@ -67,11 +100,103 @@ function sortChildren(byId) {
 }
 
 /**
- * Build the Vue Flow `nodes` + `edges` for the current `expanded` set.
- * Pure function of (model, expanded) so it is trivial to recompute on toggle.
+ * Order the crate/app roots into topological layers on the aggregated
+ * `depends-on` relations, so dependencies overwhelmingly point one way instead
+ * of sitting in an alphabetical row. This is a structural port of
+ * `frontend/src/composables/useLawGraph.js` → `applyLayeredLayout()`
+ * (Kahn-style layering with `dependents`/`dependencies`/`incomingCount` and
+ * column wrapping); the explorer is a standalone npm project that cannot import
+ * from `frontend/`, so the algorithm is reproduced here. Keep the two in step.
+ *
+ * Unlike the law graph it is size-aware: layer columns are spaced by the actual
+ * node widths/heights (roots vary wildly once expanded) rather than a fixed
+ * pitch, so expanded crates do not overlap.
+ *
+ * Writes absolute positions into `pos` for every root id.
  */
-function buildFlow(model, expanded) {
+function layoutRoots(roots, rootDepends, sizes, pos) {
+  const rootSet = new Set(roots);
+  const dependents = new Map(); // id → ids that depend on it
+  const dependencies = new Map(); // id → ids it depends on
+  const incomingCount = new Map();
+  for (const id of roots) {
+    dependents.set(id, new Set());
+    dependencies.set(id, new Set());
+    incomingCount.set(id, 0);
+  }
+
+  for (const { from, to } of rootDepends) {
+    if (from === to || !rootSet.has(from) || !rootSet.has(to)) continue;
+    // `from depends-on to`: `to` gains a dependent, `from` gains a dependency.
+    if (!dependents.get(to).has(from)) {
+      dependents.get(to).add(from);
+      dependencies.get(from).add(to);
+      incomingCount.set(from, incomingCount.get(from) + 1);
+    }
+  }
+
+  const layers = [];
+  const processed = new Set();
+  let currentLayer = roots.filter((id) => incomingCount.get(id) === 0);
+
+  while (currentLayer.length > 0) {
+    layers.push(currentLayer);
+    for (const id of currentLayer) processed.add(id);
+    const next = new Set();
+    for (const id of currentLayer) {
+      for (const dependent of dependents.get(id) || []) {
+        if (processed.has(dependent)) continue;
+        let allDepsDone = true;
+        for (const dep of dependencies.get(dependent) || []) {
+          if (!processed.has(dep)) {
+            allDepsDone = false;
+            break;
+          }
+        }
+        if (allDepsDone) next.add(dependent);
+      }
+    }
+    currentLayer = [...next];
+  }
+  // Any root left over (a dependency cycle) goes in a final layer so nothing
+  // is dropped.
+  const leftover = roots.filter((id) => !processed.has(id));
+  if (leftover.length > 0) layers.push(leftover);
+
+  // Place each layer as one or more stacked sub-columns, spaced by real sizes.
+  let layerX = 0;
+  for (const layer of layers) {
+    let colX = layerX;
+    let layerRight = layerX;
+    for (let start = 0; start < layer.length; start += ROOT_MAX_PER_COL) {
+      const chunk = layer.slice(start, start + ROOT_MAX_PER_COL);
+      let colW = 0;
+      let y = 0;
+      for (const id of chunk) {
+        const s = sizes.get(id) || { w: NODE_W, h: HEADER_H };
+        pos.set(id, { x: colX, y });
+        colW = Math.max(colW, s.w);
+        y += s.h + ROOT_GAP_Y;
+      }
+      colX += colW + ROOT_COL_GAP_X;
+      layerRight = colX;
+    }
+    layerX = layerRight + ROOT_LAYER_GAP_X;
+  }
+}
+
+/**
+ * Build the Vue Flow `nodes` + `edges` for the current `expanded` set and the
+ * currently-enabled edge kinds.
+ *
+ * Pure function of (model, expanded, enabledKinds) so the whole lifting /
+ * aggregation pipeline is testable without a DOM. `enabledKinds` is a Set of
+ * edge kinds to include; anything not in it is filtered out *before*
+ * aggregation, so weights and counters never include a disabled kind.
+ */
+function buildFlow(model, expanded, enabledKinds) {
   const byId = new Map(model.nodes.map((n) => [n.id, n]));
+  const parentOf = (id) => byId.get(id)?.parent;
 
   const childrenMap = new Map();
   for (const n of model.nodes) {
@@ -144,28 +269,34 @@ function buildFlow(model, expanded) {
 
   roots.forEach(layout);
 
-  // Place crate roots in a wrapping row.
-  let rx = 0;
-  let ry = 0;
-  let rowMaxH = 0;
-  for (const id of roots) {
-    const { w, h } = sizes.get(id);
-    if (rx > 0 && rx + w > ROOT_ROW_MAX_W) {
-      rx = 0;
-      ry += rowMaxH + ROOT_GAP_Y;
-      rowMaxH = 0;
-    }
-    pos.set(id, { x: rx, y: ry });
-    rx += w + ROOT_GAP_X;
-    rowMaxH = Math.max(rowMaxH, h);
+  // Root positions: topological layers on the aggregated `depends-on` graph.
+  // Aggregate to the root level regardless of the kind filter so the layout is
+  // stable as filters toggle.
+  const rootOf = (id) => {
+    let cur = id;
+    while (cur && byId.get(cur)?.parent) cur = byId.get(cur).parent;
+    return cur;
+  };
+  const rootDepends = [];
+  for (const e of model.edges) {
+    if (e.kind !== 'depends-on') continue;
+    const rf = rootOf(e.from);
+    const rt = rootOf(e.to);
+    if (rf && rt && rf !== rt) rootDepends.push({ from: rf, to: rt });
   }
+  layoutRoots(roots, rootDepends, sizes, pos);
 
   // Emit Vue Flow nodes in pre-order (parent before child, as Vue Flow expects).
+  // Accumulate absolute positions so edge-lifting can pick a handle side from
+  // the two visible endpoints' centres.
   const flowNodes = [];
-  const emit = (id, depth) => {
+  const absCenter = new Map(); // id -> { x, y } absolute centre
+  const emit = (id, depth, parentAbs) => {
     const n = byId.get(id);
     const size = sizes.get(id);
     const p = pos.get(id) || { x: 0, y: 0 };
+    const abs = { x: parentAbs.x + p.x, y: parentAbs.y + p.y };
+    absCenter.set(id, { x: abs.x + size.w / 2, y: abs.y + size.h / 2 });
     const exp = expanded.has(id);
     const expandable = isExpandable(id);
     flowNodes.push({
@@ -179,6 +310,8 @@ function buildFlow(model, expanded) {
         expandable,
         expanded: exp,
         childCount: (childrenMap.get(id) || []).length,
+        // Set below, once edges are lifted: relations that roll up to this node.
+        internalCount: 0,
       },
       class: [
         'arch-node',
@@ -194,56 +327,179 @@ function buildFlow(model, expanded) {
       // deeper nodes still stack above their own container.
       zIndex: depth + 1,
     });
-    for (const k of visibleChildren(id)) emit(k, depth + 1);
+    for (const k of visibleChildren(id)) emit(k, depth + 1, abs);
   };
-  roots.forEach((id) => emit(id, 0));
+  roots.forEach((id) => emit(id, 0, { x: 0, y: 0 }));
 
-  // Edges between currently-visible nodes only.
   const visibleIds = new Set(flowNodes.map((n) => n.id));
-  const flowEdges = [];
+
+  // Lift an id to its nearest visible ancestor. Roots are always visible, so
+  // the walk always terminates; returns undefined only for an id not in the
+  // tree at all (a dangling edge endpoint).
+  const lift = (id) => {
+    let cur = id;
+    while (cur && !visibleIds.has(cur)) cur = parentOf(cur);
+    return cur;
+  };
+  // Is `anc` a (strict) ancestor of `desc`?
+  const isAncestor = (anc, desc) => {
+    let cur = parentOf(desc);
+    while (cur) {
+      if (cur === anc) return true;
+      cur = parentOf(cur);
+    }
+    return false;
+  };
+
+  // --- Edge lifting + aggregation ------------------------------------------
+  const aggregates = new Map(); // `${kind}|${from}->${to}` -> aggregate
+  const internal = new Map(); // nodeId -> internal relation count
+  let totalRelations = 0;
+  let visibleRelations = 0;
+
   for (const e of model.edges) {
-    if (!visibleIds.has(e.from) || !visibleIds.has(e.to)) continue;
-    const style = EDGE_STYLE[e.kind] || EDGE_STYLE.uses;
+    if (!enabledKinds.has(e.kind)) continue;
+    const from = lift(e.from);
+    const to = lift(e.to);
+    if (!from || !to) continue; // dangling endpoint, nothing to draw
+    totalRelations += 1;
+
+    if (from === to) {
+      // Both ends roll up to the same visible node: an internal relation. It
+      // becomes a counter on that node, not a line. (Criterion 2.)
+      internal.set(from, (internal.get(from) || 0) + 1);
+      visibleRelations += 1;
+      continue;
+    }
+    if (isAncestor(from, to) || isAncestor(to, from)) {
+      // One lifted end contains the other: that is containment (nesting), not a
+      // relation. No line, and it is not "visible" as a relation. (Criterion 3.)
+      continue;
+    }
+
+    const key = `${e.kind}|${from}->${to}`;
+    let agg = aggregates.get(key);
+    if (!agg) {
+      agg = { kind: e.kind, from, to, weight: 0, pairs: [] };
+      aggregates.set(key, agg);
+    }
+    agg.weight += 1;
+    agg.pairs.push({ from: e.from, to: e.to });
+    visibleRelations += 1;
+  }
+
+  // Publish internal counters onto their nodes.
+  for (const n of flowNodes) {
+    const c = internal.get(n.id);
+    if (c) n.data.internalCount = c;
+  }
+
+  // Choose a handle side per aggregated edge from the two centres' dominant
+  // axis, so lines leave/enter on the facing sides instead of always L→R.
+  const pickHandles = (a, b) => {
+    const dx = b.x - a.x;
+    const dy = b.y - a.y;
+    if (Math.abs(dx) >= Math.abs(dy)) {
+      return dx >= 0 ? ['source-right', 'target-left'] : ['source-left', 'target-right'];
+    }
+    return dy >= 0 ? ['source-bottom', 'target-top'] : ['source-top', 'target-bottom'];
+  };
+
+  const flowEdges = [];
+  for (const agg of aggregates.values()) {
+    const base = EDGE_STYLE[agg.kind] || EDGE_STYLE.uses;
+    const strokeWidth = scaledStrokeWidth(base.strokeWidth, agg.weight);
+    const ca = absCenter.get(agg.from) || { x: 0, y: 0 };
+    const cb = absCenter.get(agg.to) || { x: 0, y: 0 };
+    const [sourceHandle, targetHandle] = pickHandles(ca, cb);
     flowEdges.push({
-      id: `${e.kind}:${e.from}->${e.to}`,
-      source: e.from,
-      target: e.to,
-      class: `edge-${e.kind}`,
-      data: { kind: e.kind },
-      type: 'default',
-      style,
-      markerEnd: { type: MarkerType.ArrowClosed, color: style.stroke, width: 16, height: 16 },
-      // Below every node (which start at 1). Edges used to sit at 2000, which
-      // drew the lines over the node boxes and — worse — put Vue Flow's
-      // invisible 20px-wide `.vue-flow__edge-interaction` hit path on top of
-      // the expand toggles, swallowing the click on most nodes.
+      id: `${agg.kind}|${agg.from}->${agg.to}`,
+      source: agg.from,
+      target: agg.to,
+      sourceHandle,
+      targetHandle,
+      class: `edge-${agg.kind}`,
+      type: 'arch',
+      data: {
+        kind: agg.kind,
+        weight: agg.weight,
+        from: agg.from,
+        to: agg.to,
+        pairs: agg.pairs,
+      },
+      style: { ...base, strokeWidth },
+      markerEnd: { type: MarkerType.ArrowClosed, color: base.stroke, width: 16, height: 16 },
+      // Below every node (which start at 1). Keeps Vue Flow's invisible 20px
+      // interaction path from stealing clicks off the node toggles.
       zIndex: 0,
     });
   }
 
-  return { nodes: flowNodes, edges: flowEdges, childrenMap };
+  return {
+    nodes: flowNodes,
+    edges: flowEdges,
+    childrenMap,
+    stats: { visible: visibleRelations, total: totalRelations },
+  };
+}
+
+export { buildFlow };
+
+/**
+ * Compute the next `expanded` set when a rolled-up line's badge is clicked.
+ *
+ * Pure so the reveal policy is unit-testable. Below `limit` underlying pairs it
+ * fully reveals — expands every ancestor of every underlying endpoint, so the
+ * line splits into its exact sub-lines. At or above the limit it opens only one
+ * level (expands the two currently-lifted endpoints), so a single click never
+ * opens hundreds of nodes; repeated clicks refine step by step. (Criteria 6, 7.)
+ */
+export function computeReveal({ parentOf, childrenMap, expanded, data, limit = REVEAL_LIMIT }) {
+  const next = new Set(expanded);
+  const addAncestors = (id) => {
+    let cur = parentOf.get(id);
+    while (cur) {
+      next.add(cur);
+      cur = parentOf.get(cur);
+    }
+  };
+
+  if (data.pairs.length > limit) {
+    if (childrenMap.has(data.from)) next.add(data.from);
+    if (childrenMap.has(data.to)) next.add(data.to);
+  } else {
+    for (const { from, to } of data.pairs) {
+      addAncestors(from);
+      addAncestors(to);
+    }
+  }
+  return next;
 }
 
 export function useArchGraph() {
   const model = shallowRef(null);
   const expanded = ref(new Set());
+  const { enabledKinds, toggleKind, kindEnabled, FILTERABLE_KINDS } = useEdgeFilters();
 
-  // Cache childrenMap for subtree expansion without rebuilding the whole map.
+  // Cache maps for subtree expansion / reveal without rebuilding them.
   let childrenMap = new Map();
+  let parentOf = new Map();
 
   const built = computed(() => {
-    if (!model.value) return { nodes: [], edges: [] };
-    const result = buildFlow(model.value, expanded.value);
+    if (!model.value) return { nodes: [], edges: [], stats: { visible: 0, total: 0 } };
+    const result = buildFlow(model.value, expanded.value, enabledKinds.value);
     childrenMap = result.childrenMap;
     return result;
   });
 
   const nodes = computed(() => built.value.nodes);
   const edges = computed(() => built.value.edges);
+  const stats = computed(() => built.value.stats);
 
   function setModel(m) {
     model.value = m;
     expanded.value = new Set(); // start collapsed at crate level
+    parentOf = new Map(m.nodes.map((n) => [n.id, n.parent || null]));
   }
 
   function toggle(id) {
@@ -270,5 +526,29 @@ export function useArchGraph() {
     expanded.value = new Set();
   }
 
-  return { model, nodes, edges, expanded, setModel, toggle, expandSubtree, collapseAll };
+  /**
+   * Reveal a rolled-up line. Returns the ids the caller should `fitView` to
+   * (the two lifted endpoints, which contain the newly-split lines).
+   */
+  function revealEdge(data) {
+    expanded.value = computeReveal({ parentOf, childrenMap, expanded: expanded.value, data });
+    return [data.from, data.to];
+  }
+
+  return {
+    model,
+    nodes,
+    edges,
+    stats,
+    expanded,
+    enabledKinds,
+    toggleKind,
+    kindEnabled,
+    FILTERABLE_KINDS,
+    setModel,
+    toggle,
+    expandSubtree,
+    collapseAll,
+    revealEdge,
+  };
 }

--- a/packages/arch-extract/ui/src/composables/useArchGraph.test.js
+++ b/packages/arch-extract/ui/src/composables/useArchGraph.test.js
@@ -1,0 +1,203 @@
+import { describe, it, expect } from 'vitest';
+import { buildFlow, computeReveal, REVEAL_LIMIT } from './useArchGraph.js';
+
+// A small synthetic model that exercises every lifting case. Three crates; one
+// (`a`) has a two-level inner tree so lifting has somewhere to travel to.
+//
+//   crate:a
+//     mod:a::m1  → type T1, type T2
+//     mod:a::m2  → type U1
+//   crate:b      → type V1
+//   crate:c      → type W1
+function makeModel() {
+  const node = (id, kind, level, parent) => ({
+    id,
+    kind,
+    level,
+    lang: 'rust',
+    name: id.split('::').pop(),
+    path: 'x',
+    ...(parent ? { parent } : {}),
+  });
+  return {
+    schemaVersion: '1',
+    nodes: [
+      node('crate:a', 'crate', 'container'),
+      node('crate:b', 'crate', 'container'),
+      node('crate:c', 'crate', 'container'),
+      node('mod:a::m1', 'module', 'component', 'crate:a'),
+      node('mod:a::m2', 'module', 'component', 'crate:a'),
+      node('type:a::m1::T1', 'struct', 'code', 'mod:a::m1'),
+      node('type:a::m1::T2', 'struct', 'code', 'mod:a::m1'),
+      node('type:a::m2::U1', 'struct', 'code', 'mod:a::m2'),
+      node('type:b::V1', 'struct', 'code', 'crate:b'),
+      node('type:c::W1', 'struct', 'code', 'crate:c'),
+    ],
+    edges: [
+      { from: 'type:a::m1::T1', to: 'type:b::V1', kind: 'uses' }, // E1 cross-crate
+      { from: 'type:a::m1::T2', to: 'type:b::V1', kind: 'uses' }, // E2 cross-crate (aggregates with E1)
+      { from: 'type:a::m1::T1', to: 'type:a::m2::U1', kind: 'uses' }, // E3 crate-internal / cross-module
+      { from: 'type:a::m1::T1', to: 'type:c::W1', kind: 'impl' }, // E4 cross-crate impl
+      { from: 'type:a::m1::T1', to: 'crate:a', kind: 'uses' }, // E5 points at own ancestor
+      { from: 'crate:a', to: 'crate:b', kind: 'depends-on' }, // E6 root depends-on
+      { from: 'crate:a', to: 'crate:c', kind: 'depends-on' }, // E7 root depends-on
+    ],
+  };
+}
+
+const ALL_KINDS = new Set(['depends-on', 'impl', 'uses']);
+
+function parentMap(model) {
+  return new Map(model.nodes.map((n) => [n.id, n.parent || null]));
+}
+
+/** Find the single aggregated edge with the given kind/from/to, or undefined. */
+function findEdge(edges, kind, from, to) {
+  return edges.find((e) => e.data.kind === kind && e.data.from === from && e.data.to === to);
+}
+
+describe('buildFlow edge lifting', () => {
+  it('lifts every endpoint to its nearest visible ancestor (all collapsed → crate level)', () => {
+    const model = makeModel();
+    const { edges } = buildFlow(model, new Set(), ALL_KINDS);
+
+    // Cross-crate uses lifts to crate:a → crate:b.
+    expect(findEdge(edges, 'uses', 'crate:a', 'crate:b')).toBeTruthy();
+    // Cross-crate impl lifts to crate:a → crate:c.
+    expect(findEdge(edges, 'impl', 'crate:a', 'crate:c')).toBeTruthy();
+    // No edge ever references a node below the crate level while collapsed.
+    for (const e of edges) {
+      expect(e.data.from.startsWith('crate:')).toBe(true);
+      expect(e.data.to.startsWith('crate:')).toBe(true);
+    }
+  });
+
+  it('aggregates same-kind relations between the same lifted pair into one weighted line', () => {
+    const model = makeModel();
+    const { edges } = buildFlow(model, new Set(), ALL_KINDS);
+
+    const usesAB = findEdge(edges, 'uses', 'crate:a', 'crate:b');
+    expect(usesAB.data.weight).toBe(2);
+    // Both underlying pairs are retained for the reveal step.
+    const pairs = usesAB.data.pairs.map((p) => `${p.from}->${p.to}`).sort();
+    expect(pairs).toEqual(['type:a::m1::T1->type:b::V1', 'type:a::m1::T2->type:b::V1']);
+    // A weight-2 line draws thicker than its per-kind base (1.5 for `uses`),
+    // and stays within the ~1.5–9px band.
+    expect(usesAB.style.strokeWidth).toBeGreaterThan(1.5);
+    expect(usesAB.style.strokeWidth).toBeLessThanOrEqual(9);
+  });
+
+  it('turns a relation whose ends roll up to the same node into an internal counter, not a line', () => {
+    const model = makeModel();
+    const { nodes, edges } = buildFlow(model, new Set(), ALL_KINDS);
+
+    // E3 (T1→U1) and E5 (T1→crate:a) both roll up to crate:a while collapsed.
+    const crateA = nodes.find((n) => n.id === 'crate:a');
+    expect(crateA.data.internalCount).toBe(2);
+    // No self-line on crate:a.
+    expect(edges.some((e) => e.data.from === 'crate:a' && e.data.to === 'crate:a')).toBe(false);
+  });
+
+  it('skips ancestor/descendant pairs as containment (no line)', () => {
+    const model = makeModel();
+    // Expand crate:a but not its modules: T1 lifts to mod:a::m1, crate:a stays
+    // crate:a → crate:a is an ancestor of mod:a::m1, so E5 is containment.
+    const { edges } = buildFlow(model, new Set(['crate:a']), ALL_KINDS);
+    expect(findEdge(edges, 'uses', 'crate:a', 'mod:a::m1')).toBeFalsy();
+    expect(findEdge(edges, 'uses', 'mod:a::m1', 'crate:a')).toBeFalsy();
+  });
+
+  it('refines a rolled-up relation when one side is expanded', () => {
+    const model = makeModel();
+    const collapsed = buildFlow(model, new Set(), ALL_KINDS);
+    // Collapsed: E3 is internal to crate:a (a counter, no line).
+    expect(findEdge(collapsed.edges, 'uses', 'mod:a::m1', 'mod:a::m2')).toBeFalsy();
+
+    const expanded = buildFlow(model, new Set(['crate:a']), ALL_KINDS);
+    // Expanding crate:a splits it: E3 now runs module→module as a real line…
+    expect(findEdge(expanded.edges, 'uses', 'mod:a::m1', 'mod:a::m2')).toBeTruthy();
+    // …and the cross-crate uses now leaves from the module, not the crate.
+    expect(findEdge(expanded.edges, 'uses', 'mod:a::m1', 'crate:b')).toBeTruthy();
+    expect(findEdge(expanded.edges, 'uses', 'crate:a', 'crate:b')).toBeFalsy();
+  });
+
+  it('excludes a disabled kind from lines, weights and the internal counter', () => {
+    const model = makeModel();
+    const { nodes, edges } = buildFlow(model, new Set(), new Set(['depends-on', 'impl']));
+
+    // No `uses` line survives.
+    expect(edges.some((e) => e.data.kind === 'uses')).toBe(false);
+    // The two `uses` relations that were internal to crate:a no longer count.
+    const crateA = nodes.find((n) => n.id === 'crate:a');
+    expect(crateA.data.internalCount).toBe(0);
+    // impl + depends-on lines remain.
+    expect(findEdge(edges, 'impl', 'crate:a', 'crate:c')).toBeTruthy();
+    expect(findEdge(edges, 'depends-on', 'crate:a', 'crate:b')).toBeTruthy();
+  });
+
+  it('reports visible/total relation stats over the enabled kinds', () => {
+    const model = makeModel();
+    const all = buildFlow(model, new Set(), ALL_KINDS);
+    // 7 edges, all enabled, all placeable → total 7. Every one is either a line
+    // or an internal counter while collapsed (no containment yet), so visible 7.
+    expect(all.stats.total).toBe(7);
+    expect(all.stats.visible).toBe(7);
+
+    // Expanding crate:a makes E5 (T1→crate:a) containment: still counted in
+    // total, but no longer visible as a relation.
+    const expanded = buildFlow(model, new Set(['crate:a']), ALL_KINDS);
+    expect(expanded.stats.total).toBe(7);
+    expect(expanded.stats.visible).toBe(6);
+  });
+});
+
+describe('computeReveal', () => {
+  it('expands every ancestor chain of the underlying endpoints below the limit', () => {
+    const model = makeModel();
+    const { edges, childrenMap } = buildFlow(model, new Set(), ALL_KINDS);
+    const usesAB = findEdge(edges, 'uses', 'crate:a', 'crate:b');
+
+    const next = computeReveal({
+      parentOf: parentMap(model),
+      childrenMap,
+      expanded: new Set(),
+      data: usesAB.data,
+    });
+
+    // Ancestors of T1/T2 (mod:a::m1, crate:a) and of V1 (crate:b) are opened.
+    expect(next.has('crate:a')).toBe(true);
+    expect(next.has('mod:a::m1')).toBe(true);
+    expect(next.has('crate:b')).toBe(true);
+    // Nothing unrelated is opened.
+    expect(next.has('mod:a::m2')).toBe(false);
+
+    // After revealing, the rolled-up line splits into exact per-pair lines.
+    const revealed = buildFlow(model, next, ALL_KINDS);
+    expect(findEdge(revealed.edges, 'uses', 'type:a::m1::T1', 'type:b::V1')).toBeTruthy();
+    expect(findEdge(revealed.edges, 'uses', 'type:a::m1::T2', 'type:b::V1')).toBeTruthy();
+    expect(findEdge(revealed.edges, 'uses', 'crate:a', 'crate:b')).toBeFalsy();
+  });
+
+  it('opens only one level when the underlying pair count exceeds the limit', () => {
+    const model = makeModel();
+    const { childrenMap } = buildFlow(model, new Set(), ALL_KINDS);
+    // Synthesize a heavy rolled-up edge with more than REVEAL_LIMIT pairs.
+    const pairs = Array.from({ length: REVEAL_LIMIT + 5 }, () => ({
+      from: 'type:a::m1::T1',
+      to: 'type:b::V1',
+    }));
+    const data = { kind: 'uses', from: 'crate:a', to: 'crate:b', weight: pairs.length, pairs };
+
+    const next = computeReveal({
+      parentOf: parentMap(model),
+      childrenMap,
+      expanded: new Set(),
+      data,
+    });
+
+    // Only the two lifted endpoints open (one level), not the deep chains.
+    expect(next.has('crate:a')).toBe(true);
+    expect(next.has('crate:b')).toBe(true);
+    expect(next.has('mod:a::m1')).toBe(false);
+  });
+});

--- a/packages/arch-extract/ui/src/composables/useEdgeFilters.js
+++ b/packages/arch-extract/ui/src/composables/useEdgeFilters.js
@@ -1,0 +1,66 @@
+/**
+ * useEdgeFilters — per-edge-kind visibility toggles for the architecture
+ * explorer.
+ *
+ * The model only produces three relationship kinds (`depends-on`, `impl`,
+ * `uses`); `calls` is deliberately never emitted, so it is not offered as a
+ * toggle. All three start enabled and the choice is persisted in localStorage
+ * so it survives a refresh.
+ *
+ * The read/write-with-try/catch shape and the module-level singleton follow
+ * `useColorScheme.js` in this same directory — the explorer is a standalone npm
+ * project with no shared package, so the pattern is reproduced rather than
+ * imported. Keep the two in step.
+ */
+import { ref } from 'vue';
+
+// Order is the display order of the toggles in the toolbar.
+export const FILTERABLE_KINDS = ['depends-on', 'impl', 'uses'];
+
+const STORAGE_KEY = 'arch-explorer-edge-kinds';
+
+function read() {
+  try {
+    const raw = window.localStorage?.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const arr = JSON.parse(raw);
+    if (!Array.isArray(arr)) return null;
+    // Drop anything that is no longer a known kind (defensive against an old
+    // persisted value after the kind set changes).
+    return arr.filter((k) => FILTERABLE_KINDS.includes(k));
+  } catch {
+    return null;
+  }
+}
+
+function write(kinds) {
+  try {
+    window.localStorage?.setItem(STORAGE_KEY, JSON.stringify(kinds));
+  } catch {
+    // Ignore storage errors (private mode, quota); the filters just reset to
+    // "all on" on the next load.
+  }
+}
+
+// Module-level singleton so every caller shares one enabled-set ref. `read()`
+// may legitimately return an empty array (user turned everything off), so we
+// only fall back to "all on" when there is no stored value at all (null).
+const stored = typeof window !== 'undefined' ? read() : null;
+const enabled = ref(new Set(stored ?? FILTERABLE_KINDS));
+
+export function useEdgeFilters() {
+  function toggleKind(kind) {
+    if (!FILTERABLE_KINDS.includes(kind)) return;
+    const next = new Set(enabled.value);
+    if (next.has(kind)) next.delete(kind);
+    else next.add(kind);
+    enabled.value = next;
+    write([...next]);
+  }
+
+  function kindEnabled(kind) {
+    return enabled.value.has(kind);
+  }
+
+  return { enabledKinds: enabled, toggleKind, kindEnabled, FILTERABLE_KINDS };
+}

--- a/packages/arch-extract/ui/src/styles.css
+++ b/packages/arch-extract/ui/src/styles.css
@@ -429,8 +429,11 @@ body,
 }
 
 /* The edge label layer is click-through as a whole; only the badge inside it
-   accepts clicks, so nothing over a node steals the node's toggle clicks. */
-.vue-flow__edgelabel-renderer {
+   accepts clicks, so nothing over a node steals the node's toggle clicks.
+   `EdgeLabelRenderer` teleports into `.vue-flow__edge-labels` (Vue Flow already
+   defaults it to `pointer-events: none`; pinned here so the #982 safety net does
+   not silently depend on the vendored default). */
+.vue-flow__edge-labels {
   pointer-events: none;
 }
 .arch-edge__badge {

--- a/packages/arch-extract/ui/src/styles.css
+++ b/packages/arch-extract/ui/src/styles.css
@@ -156,22 +156,40 @@ body,
   border-color: var(--accent);
 }
 
-.arch-legend {
+/* Edge-kind filter toggles (replace the old passive legend). Each toggle keeps
+   the legend swatch and dims to "off" when its kind is filtered out. */
+.arch-filters {
   display: flex;
-  gap: 12px;
-  font-size: 12px;
-  color: var(--text-muted);
+  gap: 6px;
 }
-.arch-legend__item {
+.arch-filter {
   display: flex;
   align-items: center;
-  gap: 5px;
+  gap: 6px;
+  font: inherit;
+  font-size: 12px;
+  padding: 4px 9px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface-2);
+  color: var(--text);
+  cursor: pointer;
 }
-.arch-legend .lg {
+.arch-filter:hover {
+  border-color: var(--accent);
+}
+.arch-filter--off {
+  opacity: 0.45;
+  background: transparent;
+  color: var(--text-muted);
+  text-decoration: line-through;
+}
+.arch-filter .lg {
   width: 18px;
   height: 0;
   border-top-width: 2px;
   border-top-style: solid;
+  flex: 0 0 auto;
 }
 .lg-depends {
   border-top-color: #6366f1;
@@ -292,6 +310,23 @@ body,
   padding: 0 7px;
   flex: 0 0 auto;
 }
+/* Internal-relation counter: relations whose both ends roll up to this node.
+   Shown as a teller on the node instead of a line (criterion 2). */
+.arch-node__internal {
+  margin-left: auto;
+  font-size: 10px;
+  color: #fff;
+  background: var(--accent);
+  border-radius: 999px;
+  padding: 1px 7px;
+  white-space: nowrap;
+  flex: 0 0 auto;
+}
+/* When the child-count badge is present it takes the right-most slot, so the
+   internal counter sits just before it rather than grabbing the auto margin. */
+.arch-node__internal + .arch-node__count {
+  margin-left: 6px;
+}
 
 /* Kind accents: a coloured left edge + matching badge. */
 .arch-node.kind-crate {
@@ -383,11 +418,48 @@ body,
 }
 
 /* Vue Flow lays an invisible 20px-wide stroke over every edge to make it easy
-   to hover/click. Nothing here reacts to an edge click, so that hit path only
-   steals clicks from the node controls underneath it. Belt and braces next to
-   the edge z-index: a wide stroke would still cover a node it crosses. */
-.vue-flow__edge-interaction {
+   to hover/click. The line itself is not a click target — only the count badge
+   is (see below) — so that hit path only steals clicks from the node controls
+   underneath it. Keeping it `pointer-events: none` is the #982 fix; the new
+   badge layer re-enables pointer events on the badge alone. Belt and braces
+   next to the edge z-index: a wide stroke would still cover a node it crosses. */
+.vue-flow__edge-interaction,
+.vue-flow__edge-path {
   pointer-events: none;
+}
+
+/* The edge label layer is click-through as a whole; only the badge inside it
+   accepts clicks, so nothing over a node steals the node's toggle clicks. */
+.vue-flow__edgelabel-renderer {
+  pointer-events: none;
+}
+.arch-edge__badge {
+  position: absolute;
+  pointer-events: auto;
+  font: inherit;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1;
+  min-width: 20px;
+  padding: 3px 6px;
+  border: 1px solid var(--surface);
+  border-radius: 999px;
+  color: #fff;
+  background: var(--text-muted);
+  cursor: pointer;
+  box-shadow: var(--shadow);
+}
+.arch-edge__badge:hover {
+  filter: brightness(1.12);
+}
+.arch-edge__badge--depends-on {
+  background: #6366f1;
+}
+.arch-edge__badge--impl {
+  background: #10b981;
+}
+.arch-edge__badge--uses {
+  background: #64748b;
 }
 
 .vue-flow__minimap {


### PR DESCRIPTION
## Wat & waarom

De lokale architectuurverkenner (`just arch-explore`, `packages/arch-extract`)
liet alleen relaties zien waarvan **beide** uiteinden toevallig zichtbaar waren.
Op het beginscherm overleefden zo maar ~15 van de ~1500 relaties uit het model,
en het uitklappen van een crate toonde geen enkele lijn tussen sub-componenten:
een relatie naar een type in een nog ingeklapte crate verdween volledig.

Deze PR maakt **elke relatie uit het model altijd zichtbaar**, opgerold naar het
detailniveau dat op dat moment op het scherm staat (*edge-lifting*), met één klik
door te stoten naar de echte sub-componenten. Het is puur een presentatielaag in
de Vue-UI; de Rust-extractor, het modelschema en de prose-sidecar veranderen niet.

## Wat er verandert

- **Edge-lifting & aggregatie.** Elk uiteinde wordt opgetild naar de
  dichtstbijzijnde *zichtbare* voorouder. Relaties tussen hetzelfde opgetilde
  paar, van dezelfde soort, worden één lijn met een gewicht; `strokeWidth`
  schaalt logaritmisch (~1,5-9 px) op de basisdikte per soort, zodat de
  kleurcodering per soort intact blijft. Filteren gebeurt vóór het aggregeren.
- **Interne teller i.p.v. lijn.** Tillen beide uiteinden naar dezelfde node, dan
  is er geen lijn maar een teller op die node. Een voorouder/afstammeling-paar is
  containment (nesting) en levert lijn noch teller op.
- **Onthullen.** Een opgerolde lijn (gewicht > 1) krijgt een klein, klikbaar
  badge met het aantal. Klikken ontvouwt de onderliggende voorouderketens en de
  lijn splitst zich in exacte lijnen; het canvas beweegt via `fitView` naar de
  betrokken nodes. Boven ~25 onderliggende paren wordt één niveau per klik
  opengeklapt, zodat één klik nooit honderden nodes opent.
- **Klikdoel is het badge, niet de lijn.** Het onzichtbare 20px
  interaction-path onder elke edge blijft `pointer-events: none`; alleen het
  badge zelf krijgt `pointer-events: auto`. Zo blijven de uitklap-driehoekjes hun
  kliks houden (regressie uit de vorige fix): op het beginscherm accepteren nog
  steeds alle 14 driehoekjes een klik.
- **Filters.** De passieve legenda is nu een set klikbare toggles per soort
  (`depends-on` / `impl` / `uses`), alle drie standaard aan, bewaard in
  localStorage (patroon van `useColorScheme.js`). Een uitgezette soort telt niet
  mee in de gewichten en niet in de teller. De toolbar toont hoeveel relaties
  zichtbaar zijn van het totaal.
- **Leesbaarheid.** `ArchNode` heeft nu acht CSS-verborgen handles (source +
  target op elke zijde); `buildFlow` kiest per edge de zijde op basis van de
  dominante as tussen de twee middelpunten. De crate-roots staan in topologische
  lagen op de geaggregeerde `depends-on`-relaties in plaats van alfabetisch.

## Bewuste duplicatie

Het gelaagde root-layout-algoritme is een structurele port van
`applyLayeredLayout()` uit `frontend/src/composables/useLawGraph.js` (Kahn-achtige
laagopbouw). De verkenner-UI is bewust **geen** onderdeel van de root
npm-workspace en kan niets uit `frontend/` importeren, dus het algoritme is
gereproduceerd met een comment die naar de bron verwijst - net zoals
`useColorScheme.js` dat al doet.

## Tests & verificatie

- Nieuwe **vitest**-suite op de pure lifting-logica
  (`ui/src/composables/useArchGraph.test.js`, 9 tests): lifting naar de
  dichtstbijzijnde zichtbare voorouder, interne teller, containment-overslaan,
  aggregatie-gewicht + onderliggende paren, verfijning bij uitklappen, uitgezette
  soort telt nergens mee, en onthullen incl. de limiet-terugval.
- `arch-test` draait de vitest-suite nu naast `cargo test -p
  regelrecht-arch-extract`, zodat `just check` de poort blijft. `just arch-test`
  is groen.
- **In de browser nagelopen** tegen het echte model (2407 nodes, 1537 relaties):
  - Beginscherm: **45** relatielijnen i.p.v. ~15; toolbar toont
    `1537/1537 relaties zichtbaar`.
  - `uses` uitzetten: lijnen 45 -> 28, teller `58/58`, keuze overleeft een
    refresh (localStorage `["depends-on","impl"]`).
  - Alle **14/14** uitklap-driehoekjes accepteren nog een klik.
  - Het badge met gewicht 44 (`editor-api` -> `corpus`, `uses`) ontvouwt correct
    en het canvas beweegt naar beide crates.
- **Steekproef op waarheid**: de opgerolde `editor-api` -> `corpus` `uses`-lijn
  bevat o.a. `editor_user_from_session -> corpus::backend::EditorUser` en
  `enforce_if_match -> corpus::backend::RepoBackend`; beide kloppen tegen de
  broncode (`use regelrecht_corpus::backend::{EditorUser, ..., RepoBackend, ...}`
  in `packages/editor-api/src/corpus_handlers.rs`).

> Noot: screenshots (beginscherm vóór/na en een opgerolde lijn vóór/na
> onthullen) zijn lokaal gemaakt en visueel gecontroleerd, maar konden vanuit
> deze headless omgeving niet als afbeelding in de PR-body worden geüpload.

## Buiten scope

Extractiedekking (macro's, glob-imports, re-exports, `calls`), toegankelijkheid
van het canvas, een focus/dim-modus en een relatielijst in het detailpaneel -
ongewijzigd, zoals afgesproken.
